### PR TITLE
Improve homepage links accessibility

### DIFF
--- a/ts/react/free2z/src/components/CreatorCarousel.tsx
+++ b/ts/react/free2z/src/components/CreatorCarousel.tsx
@@ -1,7 +1,7 @@
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Swiper as SwiperClass } from 'swiper';
 import SwiperCore, { Autoplay, Navigation } from 'swiper';
-import { Card, CardContent, CardMedia, Typography } from '@mui/material';
+import {  CardActionArea, CardContent, CardMedia, Typography } from '@mui/material';
 
 // Import Swiper styles
 import 'swiper/css';
@@ -10,7 +10,6 @@ import { PublicCreator } from '../CreatorDetail';
 import axios from 'axios';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import SwiperLoadingAnimation from './SwiperLoadingAnimation';
-import { useTransitionNavigate } from '../hooks/useTransitionNavigate';
 import { HOME_CAROUSEL_BREAKPOINTS } from './HomeCarouselConstants';
 import HoverCard from './common/HoverCard';
 
@@ -36,7 +35,6 @@ export default function CreatorCarousel(props: CreatorCarouselProps) {
     const [hasMore, setHasMore] = useState(true);
     const [page, setPage] = useState(1);
     const lastElement = useRef<HTMLDivElement | null>(null);
-    const navigate = useTransitionNavigate()
     const [sortChanged, setSortChanged] = useState(false)
     const swiperRef = useRef<SwiperClass | null>(null);
 
@@ -131,18 +129,19 @@ export default function CreatorCarousel(props: CreatorCarouselProps) {
                         <div
                             ref={index === creators.length - 1 ? lastElement : null}
                         >
-                            <HoverCard
-                                onClick={() => {
-                                    navigate(`/${creator.username}`)
-                                }}
-                            >
-                                <CardMedia
+                            <HoverCard>
+                            {/* Add CardActionArea to allow the Card to function as an `<a>` tag */}
+                            <CardActionArea href={creator.username}>
+                                {/* Replace `CardMedia` with an `img` HTML tag. `CardMedia` does not have all the accessibility features that `img` provides */}
+                                <img
+                                    src={creator.banner_image?.thumbnail}
+                                    alt={creator.full_name || creator.username}
                                     style={{
-                                        // height: '80%',
-                                        minHeight: 180,
+                                    minHeight: 180,
+                                    maxHeight: 180,
+                                    objectFit: "cover",
+                                    width: "100%",
                                     }}
-                                    image={creator.banner_image?.thumbnail}
-                                    title={creator.full_name || creator.username}
                                 />
                                 <div
                                     style={{
@@ -190,6 +189,7 @@ export default function CreatorCarousel(props: CreatorCarouselProps) {
                                         {truncate(creator.full_name || creator.username, 33)}
                                     </Typography>
                                 </CardContent>
+                                </CardActionArea >
                             </HoverCard>
                         </div>
                     </SwiperSlide>

--- a/ts/react/free2z/src/components/zPageCarousel.tsx
+++ b/ts/react/free2z/src/components/zPageCarousel.tsx
@@ -1,7 +1,7 @@
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Swiper as SwiperClass } from 'swiper';
 import SwiperCore, { Autoplay, Navigation } from 'swiper';
-import { Avatar, Card, CardContent, CardMedia, Typography } from '@mui/material';
+import { Avatar,  CardActionArea, CardContent, Typography } from '@mui/material';
 
 // Import Swiper styles
 import 'swiper/css';
@@ -10,7 +10,6 @@ import axios from 'axios';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { PageInterface } from './PageRenderer';
 import SwiperLoadingAnimation from './SwiperLoadingAnimation';
-import { useTransitionNavigate } from '../hooks/useTransitionNavigate';
 import { HOME_CAROUSEL_BREAKPOINTS } from './HomeCarouselConstants';
 import HoverCard from './common/HoverCard';
 
@@ -28,7 +27,6 @@ export default function ZPageCarousel(props: ZPageCarouselProps) {
     const [page, setPage] = useState(1);
     const lastElement = useRef<HTMLDivElement | null>(null);
     const swiperRef = useRef<SwiperClass | null>(null);
-    const navigate = useTransitionNavigate()
 
     const fetchData = useCallback(async (triggeredByObserver = false) => {
         if (fetching || !hasMore || (!triggeredByObserver && page !== 1)) return;
@@ -120,18 +118,19 @@ export default function ZPageCarousel(props: ZPageCarouselProps) {
                             ref={index === zpages.length - 1 ? lastElement : null}
                         >
 
-                            <HoverCard
-                                onClick={() => {
-                                    navigate(zpage.get_url);
-                                }}
-                            >
-
-                                <CardMedia
+                            <HoverCard>   
+                            {/* Add CardActionArea to allow the Card to function as an `<a>` tag */}
+                            <CardActionArea href={zpage.get_url}>
+                                {/* Replace `CardMedia` with an `img` HTML tag. `CardMedia` does not have all the accessibility features that `img` provides */}
+                                <img
+                                    src={zpage.featured_image?.thumbnail}
+                                    alt={zpage.title}
                                     style={{
-                                        minHeight: 180,
+                                    minHeight: 180,
+                                    maxHeight: 180,
+                                    objectFit: "cover",
+                                    width: "100%",
                                     }}
-                                    image={zpage.featured_image?.thumbnail}
-                                    title={zpage.title}
                                 />
                                 <CardContent
                                     style={{
@@ -204,6 +203,7 @@ export default function ZPageCarousel(props: ZPageCarouselProps) {
                                         {zpage.content}
                                     </Typography>
                                 </CardContent>
+                            </CardActionArea>
                             </HoverCard>
                         </div>
                     </SwiperSlide>


### PR DESCRIPTION
 ## Description
Improve accessibility in homepage cards (`CreatorCard` & `ZPageCard`), This allows users to "open in new tab" the links and also enables to interact with the images trough the native right click menu 

## This pull request includes the following changes:
* Replaced `CardMedia` with an `img`HTML tag to enhance accessibility.
* Ensured the `CardActionArea` functions as an `<a>` tag for better navigation.
* Quit the `navigateTo` action from the `HoverCard`

## Samples

**Before** 
![Before](https://github.com/user-attachments/assets/ce46afd9-f4f3-4bd7-bcd5-53ae30d590cd)

**After**
![After](https://github.com/user-attachments/assets/03b186e6-54a5-4be9-adde-7c7c26e12d31)


## Issue
Closes #63 