### PR TITLE
Fix zpages series pagination request

### DIFF
--- a/ts/react/free2z/src/components/EditSelectSeries.tsx
+++ b/ts/react/free2z/src/components/EditSelectSeries.tsx
@@ -254,6 +254,9 @@ const EditSelectSeries: React.FC<Props> = ({ page }) => {
                 onChange={handleSelectSeries}
                 onInputChange={handleInputChange}
                 loading={isLoading}
+                // https://stackoverflow.com/questions/61947941/material-ui-autocomplete-warning-the-value-provided-to-autocomplete-is-invalid
+                freeSolo
+                forcePopupIcon
                 ListboxProps={{
                   sx: { maxHeight: '300px' },
                   onScroll: async(event: React.SyntheticEvent) => {


### PR DESCRIPTION
## Description
The configuration of the zpage series fetch has been updated. Instead of using useQuery, it now utilizes useInfiniteQuery to asynchronously fetch the subsequent pages. In the autocomplete object, when scrolling to the bottom, the system evaluates if there are more pages available. If additional pages exist, it fetches the next page and displays the results in the options.

## This pull request includes the following changes:
- Changes useQuery for useInfinteQuery
- Uses the onScroll prop from the Autocomplete component to detect when the user scrolls to the bottom of the options list.
- Quit warning errors

## Showcase

https://github.com/user-attachments/assets/ee632660-fbba-4fca-ad53-9fdf0dedaf39


## Issues

Closes #104 