### PR TITLE
Improve zpage rendering

### DIFF
--- a/ts/react/free2z/src/components/CodeCopyButton.tsx
+++ b/ts/react/free2z/src/components/CodeCopyButton.tsx
@@ -29,23 +29,26 @@ export default function CodeCopyButton(props: CodeCopyProps) {
 
     return (
         <IconButton
-            // variant="contained"
             size="small"
             color="primary"
             onClick={handleCopyClick}
             sx={{
                 position: 'absolute',
-                top: '3px',
-                right: '-4px',
+                top: '20px',
+                right: '20px',
                 zIndex: (theme: Theme) => theme.zIndex.mobileStepper - 1,
                 borderColor: copySuccess ? 'success.main' : undefined,
                 color: copySuccess ? 'success.main' : undefined,
             }}
         >
             {copySuccess ?
-                <Check fontSize="small" />
+                <Check fontSize="small" style={{
+                    color: 'green'
+                }} />
                 :
-                <ContentCopy fontSize="small" />
+                <ContentCopy fontSize="small" style={{
+                    color: 'whitesmoke'
+                }}/>
             }
         </IconButton>
     )

--- a/ts/react/free2z/src/components/CodeCopyButton.tsx
+++ b/ts/react/free2z/src/components/CodeCopyButton.tsx
@@ -34,8 +34,8 @@ export default function CodeCopyButton(props: CodeCopyProps) {
             onClick={handleCopyClick}
             sx={{
                 position: 'absolute',
-                top: '20px',
-                right: '20px',
+                top: '10px',
+                right: '10px',
                 zIndex: (theme: Theme) => theme.zIndex.mobileStepper - 1,
                 borderColor: copySuccess ? 'success.main' : undefined,
                 color: copySuccess ? 'success.main' : undefined,
@@ -43,7 +43,7 @@ export default function CodeCopyButton(props: CodeCopyProps) {
         >
             {copySuccess ?
                 <Check fontSize="small" style={{
-                    color: 'green'
+                    color: '#00ff04'
                 }} />
                 :
                 <ContentCopy fontSize="small" style={{

--- a/ts/react/free2z/src/components/MTypography.tsx
+++ b/ts/react/free2z/src/components/MTypography.tsx
@@ -11,9 +11,9 @@ const CustomTypography = styled(Typography)(({ theme, variant,fontStyle }) => ({
   }),
   ...(fontStyle === "italic" && {
     fontStyle: "italic",
-    fontSize: "1.32rem",    
+    fontSize: "1.2rem",    
     fontFamily: "serif",
-    fontWeight: 400,
+    fontWeight: 300,
   }),
 }));
 

--- a/ts/react/free2z/src/components/MTypography.tsx
+++ b/ts/react/free2z/src/components/MTypography.tsx
@@ -1,14 +1,34 @@
-import { Typography } from "@mui/material"
+import { styled, Typography } from "@mui/material";
 
-export default function (variant: string) {
-    return function MTypography(props: any) {
-        return (
-            <Typography
-                component="div"
-                style={{ margin: "0.75em 0" }}
-                variant={variant}
-                {...props}
-            />
-        )
-    }
+const CustomTypography = styled(Typography)(({ theme, variant,fontStyle }) => ({  
+  ...(variant === "body1" && {
+    fontSize: "1.13rem",
+    lineHeight: 1.48,
+    fontWeight: 400,
+    letterSpacing: "0.01em",
+    marginBottom: "1.2em",
+    marginTop: "1.2em",
+  }),
+  ...(fontStyle === "italic" && {
+    fontStyle: "italic",
+    fontSize: "1.32rem",    
+    fontFamily: "serif",
+    fontWeight: 400,
+  }),
+}));
+
+export default function (
+  variant: string,
+  fontStyle: 'italic' | 'normal' = 'normal'
+) {
+  return function MTypography(props: any) {
+    return (
+      <CustomTypography
+      fontStyle={fontStyle}
+        component={fontStyle === 'italic' ? 'span' : 'p'}
+        variant={variant}
+        {...props}
+      />
+    );
+  };
 }

--- a/ts/react/free2z/src/components/MathMarkdown.css
+++ b/ts/react/free2z/src/components/MathMarkdown.css
@@ -9,15 +9,15 @@
 pre[class*="language-"],
 code[class*="language-"] {
     color: #d4d4d4;
-    font-size: 18px;
-    font-weight: 500;
+    font-size: 0.95rem;
+    font-weight: 400;
     text-shadow: none;
-    font-family: Menlo, Monaco, Consolas, "Andale Mono", "Ubuntu Mono", "Courier New", monospace;
+    font-family:  Menlo, Consolas, Monaco, "Andale Mono", "Ubuntu Mono", "Courier New", monospace;
     direction: ltr;
     text-align: left;
-    white-space: pre;
+    white-space: pre-wrap;
     word-spacing: normal;
-    word-break: normal;
+    word-break: break-word;
     line-height: 1.5;
     -moz-tab-size: 4;
     -o-tab-size: 4;
@@ -33,7 +33,7 @@ code[class*="language-"]::selection,
 pre[class*="language-"] *::selection,
 code[class*="language-"] *::selection {
     text-shadow: none;
-    background: #264F78;
+    background: #267844;
 }
 
 @media print {
@@ -46,16 +46,15 @@ code[class*="language-"] *::selection {
 
 pre[class*="language-"] {
     padding: 1em;
-    margin: 0.5em 0;
     overflow: auto;
-    background: #1e1e1e;
+    background: #000000;
 }
 
 :not(pre)>code[class*="language-"] {
     padding: .1em .3em;
     border-radius: .3em;
     color: #db4c69;
-    background: #1e1e1e;
+    background: #000000;
 }
 
 /*********************************************************

--- a/ts/react/free2z/src/components/MathMarkdown.tsx
+++ b/ts/react/free2z/src/components/MathMarkdown.tsx
@@ -150,6 +150,44 @@ const Heading = ({ level, ...props }: { id?: string, level: 1 | 2 | 3 | 4 | 5 | 
     )
 }
 
+// Custom styling forinline code
+const InlineCode = styled('code')(
+    ({ theme }) => ({
+        backgroundColor: theme.palette.mode === "dark" ? "#262625" : "#f5f5f5",
+        padding: "3px 8px",
+        borderRadius: "6px",
+        fontFamily: "monospace",
+        fontSize: "0.90rem !important",
+
+
+    }),
+)
+// Custom styling for block code
+const BlockCode = styled('code')(
+    () => ({
+        backgroundColor:"#000000",
+        position: "relative",
+        paddingLeft: "0.3rem",
+        paddingRight: "0.3rem",
+        paddingTop: "0.2rem",
+        paddingBottom: "0.2rem",
+        fontFamily: "monospace",
+        whiteSpace: "pre-wrap !important",
+        wordBreak: "break-word",
+        fontSize: "0.875rem !important",
+
+    }),
+)
+
+const Pre = styled('pre')(
+    () => ({
+        backgroundColor: '#000000 !important',
+        borderRadius: "4px",
+        maxHeight: "650px !important",
+        padding: "1rem !important",
+    }),
+)
+
 // Helper function to adjust scroll position
 const scrollToElement = (element: HTMLElement, offset = 0) => {
     const top = element.getBoundingClientRect().top + window.scrollY + offset;
@@ -262,10 +300,10 @@ function MemoMarkdown(props: MathMarkdownProps) {
                     if (className?.startsWith('language-')) {
                         return (
                             <Box component="div" display="flex" flexDirection="column" position="relative">
-                                <CodeCopyButton code={extractTextFromChildren(children)} />
-                                <pre className={className} {...props}>
+                                <CodeCopyButton code={extractTextFromChildren(children)} /> 
+                                <Pre className={className} {...props}>
                                     {children}
-                                </pre>
+                                </Pre>
                             </Box>
                         )
                     } else {
@@ -372,18 +410,24 @@ function MemoMarkdown(props: MathMarkdownProps) {
                     if (qrCodeMatch && qrCodeAddr) {
                         return <QRAddress addr={qrCodeAddr} size={256} />;
                     }
-
-                    // Fallback to rendering as a code block
+                    if(className?.startsWith('language-')){
+                        return (
+                            <BlockCode className={className} {...props}>
+                                {children}
+                            </BlockCode>
+                        );
+                    }
                     return (
-                        <code className={className} {...props}>
+                        <InlineCode className={className} {...props}>
                             {children}
-                        </code>
+                        </InlineCode>
                     );
                 },
             }}
         />, [props.content, darkMode])
     return memoized
 }
+
 
 export default function MathMarkdown(props: MathMarkdownProps) {
     const headingRef = useRef<any>({})

--- a/ts/react/free2z/src/components/MathMarkdown.tsx
+++ b/ts/react/free2z/src/components/MathMarkdown.tsx
@@ -320,6 +320,7 @@ function MemoMarkdown(props: MathMarkdownProps) {
                 h4: (props) => <Heading {...props} level={4} />,
                 h5: (props) => <Heading {...props} level={5} />,
                 h6: (props) => <Heading {...props} level={6} />,
+                em: MTypography("body1", "italic"),
                 table: (props) => (
                     <TableWrapper>
                         <Table {...(props as TableProps)} />

--- a/ts/react/free2z/src/components/MathMarkdown.tsx
+++ b/ts/react/free2z/src/components/MathMarkdown.tsx
@@ -156,7 +156,6 @@ const InlineCode = styled('code')(
         backgroundColor: theme.palette.mode === "dark" ? "#262625" : "#f5f5f5",
         padding: "3px 8px",
         borderRadius: "6px",
-        fontFamily: "monospace",
         fontSize: "0.90rem !important",
 
 
@@ -165,26 +164,19 @@ const InlineCode = styled('code')(
 // Custom styling for block code
 const BlockCode = styled('code')(
     () => ({
-        backgroundColor:"#000000",
+        backgroundColor:"#000000 !important",
         position: "relative",
-        paddingLeft: "0.3rem",
-        paddingRight: "0.3rem",
-        paddingTop: "0.2rem",
-        paddingBottom: "0.2rem",
-        fontFamily: "monospace",
-        whiteSpace: "pre-wrap !important",
-        wordBreak: "break-word",
-        fontSize: "0.875rem !important",
+        padding:'0.5rem !important',    
 
     }),
 )
 
 const Pre = styled('pre')(
     () => ({
-        backgroundColor: '#000000 !important',
         borderRadius: "4px",
+        margin: '0 !important',
         maxHeight: "650px !important",
-        padding: "1rem !important",
+        padding: "0.5rem ",
     }),
 )
 


### PR DESCRIPTION
## Description
Improve markdown typography rendering, was made using parts of Spotify design system. 

## This pull request includes the following changes:
- Improve inline code rendering
- Improve block code rendering
- Improve italics rendering
-  Subtract line height 
- Add space between paragraphs

## Showcase
Right images: new version
Left images: old version

![image](https://github.com/user-attachments/assets/e8d5634a-5c8b-463a-906f-d58945be9236)

![image](https://github.com/user-attachments/assets/663544b3-785c-4a87-b97e-b4cb0cd38792)

![image](https://github.com/user-attachments/assets/e04fd696-b744-4304-b2fd-0ced330ad0d1)


I think there is still some changes that could be made. For example with the height of this card
![image](https://github.com/user-attachments/assets/9be98193-68d0-4faf-b353-3bab3d936e68)

@skyl do you have any other improvements in mind?


## Issues 
#92