### PR TITLE
Fix: avoid infinite loading state

### DIFF
--- a/ts/react/free2z/src/components/StoryTimeDisplay.tsx
+++ b/ts/react/free2z/src/components/StoryTimeDisplay.tsx
@@ -21,15 +21,16 @@ export default function StoryTimeDisplay() {
         ).then((res) => {
             // console.log(res)
             setStory(res.data)
-            setLoading(false)
         }).catch((res) => {
-            setLoading(false)
             setSnackbarState({
                 message: JSON.stringify(res.data),
                 open: true,
                 duration: undefined,
                 severity: "error",
             })
+        })
+        .finally(() => {
+            setLoading(false)
         })
     }
 

--- a/ts/react/free2z/src/components/StoryTimeEdit.tsx
+++ b/ts/react/free2z/src/components/StoryTimeEdit.tsx
@@ -46,7 +46,6 @@ export default function StoryTimeEdit() {
         ).then((res) => {
             // console.log(res)
             setStory(res.data)
-            setLoading(false)
         }).catch((res) => {
             console.error("ERROR", res)
             setSnackbarState({
@@ -55,6 +54,8 @@ export default function StoryTimeEdit() {
                 duration: undefined,
                 severity: "error",
             })
+        }).finally(() => {
+            setLoading(false)
         })
     }
 


### PR DESCRIPTION
## Description

Avoid infinite loading state on "/storytime/edit/:creator/:slug" when story is not found

## Issues
Closes #117 