### PR TITLE
Fix not found pages

### DIFF
--- a/ts/react/free2z/src/App.tsx
+++ b/ts/react/free2z/src/App.tsx
@@ -378,7 +378,7 @@ function App() {
                                             <>
                                                 <SimpleNav />
                                                 <NormalPage>
-                                                    <PageDetail />
+                                                    <RootSplitter />
                                                 </NormalPage>
                                             </>
                                         }

--- a/ts/react/free2z/src/components/Converse.tsx
+++ b/ts/react/free2z/src/components/Converse.tsx
@@ -1,44 +1,45 @@
 import { useParams } from "react-router-dom";
 import { CommentData } from "./DisplayThreadedComments";
-import { useEffect, useState } from "react";
+import { lazy, useEffect, useState } from "react";
 import axios from "axios";
 import { Grid } from "@mui/material";
 import DisplayThreadedComment from "./DisplayThreadedComment";
-
+const Global404 = lazy(() => import('../Global404'))
 
 export default function Converse() {
-    const params = useParams()
-    const parent = params.commentUUID
-
-    const [comment, setComment] = useState({} as CommentData)
+    const params = useParams();
+    const parent = params.commentUUID;
+    const [isLoading, setLoading] = useState(true)
+    const [comment, setComment] = useState<CommentData>({} as CommentData);
 
     useEffect(() => {
         axios.get(`/api/comments/${parent}/`).then(res => {
-            // console.log("COMMENT", res)
             setComment(res.data)
+        }).catch(() => {
+            // prevent error when comment is not found
+        }).finally(() => {
+            setLoading(false);
         })
     }, [parent])
 
-    if (!comment.uuid) {
-        return null
-    }
-
-    return (
-        <Grid
-            textAlign="left"
-            alignItems="center"
-            justifyContent="center"
-            width="100%"
-            style={{
-                overflowWrap: "break-word",
-                overflowX: "auto",
-                padding: "0.33em",
-            }}
-        >
-            <DisplayThreadedComment
-                comment={comment}
-                top={true}
-            />
-        </Grid>
-    )
+    if (isLoading) return null
+    if (!comment.uuid) return <Global404 />
+        return (
+            <Grid
+                textAlign="left"
+                alignItems="center"
+                justifyContent="center"
+                width="100%"
+                style={{
+                    overflowWrap: "break-word",
+                    overflowX: "auto",
+                    padding: "0.33em",
+                }}
+            >
+                <DisplayThreadedComment
+                    comment={comment}
+                    top={true}
+                />
+            </Grid>
+        )
 }


### PR DESCRIPTION
## Description
Render 404 component when pages are not found,

## Changes applied

-  **Handle error in Converse page: ** avoid error when converse comment is not found, render 404. 
-  **Render 404 when ZPage is not found: ** instead of render directly the `<PageDetail/>` it would render through the `<RootSpliter/>`

Let me know what you think about these changes @skyl, 

## Further improvements

There are also pages that does not render the 404 page when an item is not found, instead they only render a snackbar.  Should this be left like this?
- Sample => https://free2z.com/storytime/:creator/:slug

## Issues 
Closes #93 