### PR TITLE
Remove deprecated shielded protocol API usage

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/Cargo.lock
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.lock
@@ -557,15 +557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,18 +989,6 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "env_home"
@@ -3050,18 +3029,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pczt"
-version = "0.8.0-rc.1"
-dependencies = [
- "document-features",
- "getset",
- "postcard",
- "serde",
- "serde_with",
- "zcash_protocol",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3295,18 +3262,6 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
-]
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "serde",
 ]
 
 [[package]]
@@ -4776,7 +4731,6 @@ dependencies = [
  "chacha20poly1305",
  "keyring",
  "nonempty",
- "pczt",
  "rand 0.8.5",
  "ripemd 0.1.3",
  "rusqlite",

--- a/wallet/plugins/tauri-plugin-zcash/Cargo.toml
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.toml
@@ -55,7 +55,6 @@ zcash_keys = { path = "../../../z/zcash/librustzcash/zcash_keys", features = ["o
 zcash_protocol = { path = "../../../z/zcash/librustzcash/components/zcash_protocol" }
 zcash_address = { path = "../../../z/zcash/librustzcash/components/zcash_address" }
 zip321 = { path = "../../../z/zcash/librustzcash/components/zip321" }
-pczt = { path = "../../../z/zcash/librustzcash/pczt" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "3", features = ["OSX_10_15"] }

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
@@ -16,7 +16,7 @@ use zcash_client_backend::wallet::OvkPolicy;
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::memo::{Memo, MemoBytes};
 use zcash_protocol::value::Zatoshis;
-use zcash_protocol::ShieldedProtocol;
+use zcash_protocol::ShieldedPool;
 
 use crate::error::{Error, Result};
 use crate::models::{SaplingParamsStatus, SendProposal};
@@ -142,7 +142,7 @@ pub async fn propose_send(
     let change_strategy = SingleOutputChangeStrategy::new(
         zcash_primitives::transaction::fees::zip317::FeeRule::standard(),
         None,
-        ShieldedProtocol::Orchard,
+        ShieldedPool::Orchard,
         DustOutputPolicy::default(),
     );
 
@@ -268,7 +268,7 @@ pub async fn propose_send_all(
         let change_strategy = SingleOutputChangeStrategy::new(
             zcash_primitives::transaction::fees::zip317::FeeRule::standard(),
             None,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
         );
 

--- a/wallet/zuuallet/src-tauri/Cargo.lock
+++ b/wallet/zuuallet/src-tauri/Cargo.lock
@@ -690,15 +690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,18 +1131,6 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "endi"
@@ -3306,18 +3285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pczt"
-version = "0.8.0-rc.1"
-dependencies = [
- "document-features",
- "getset",
- "postcard",
- "serde",
- "serde_with",
- "zcash_protocol",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,18 +3543,6 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
-]
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "serde",
 ]
 
 [[package]]
@@ -5079,7 +5034,6 @@ dependencies = [
  "chacha20poly1305",
  "keyring",
  "nonempty",
- "pczt",
  "rand 0.8.5",
  "ripemd 0.1.3",
  "rusqlite",


### PR DESCRIPTION
## Summary

- Replace deprecated `zcash_protocol::ShieldedProtocol` with `ShieldedPool`.
- Remove the plugin's unused direct `pczt` dependency, which caused dead-code warnings in PCZT internals.
- Regenerate the plugin lockfile.

## Verification

- `cargo check --locked --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml`
- Completed successfully with no warnings.

The local `main` checkout remains unchanged.