### PR TITLE
Fix stale ZUULI livestream presence

### DIFF
--- a/wallet/zuuli/src/features/live/Discovery.tsx
+++ b/wallet/zuuli/src/features/live/Discovery.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Radio } from "lucide-react";
 import { PageHeader } from "@/components/common/PageHeader";
 import { EmptyState } from "@/components/common/EmptyState";
@@ -19,8 +19,13 @@ const FILTERS: { value: Filter; label: string }[] = [
 ];
 
 export function Discovery() {
-  const { data, loading } = useAsync(() => live.listPublic(), []);
+  const { data, loading, reload } = useAsync(() => live.listPublic(), []);
   const [filter, setFilter] = useState<Filter>("all");
+
+  useEffect(() => {
+    const interval = window.setInterval(reload, 15_000);
+    return () => window.clearInterval(interval);
+  }, [reload]);
 
   const streams = useMemo(() => {
     const all = data ?? [];

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -370,22 +370,51 @@ export const live = {
     const page = await request<Paginated<RawDyteMeeting>>("/api/dyte/public/", {
       query: { page_size: 48 },
       anonymous: true,
+      cache: "no-store",
     });
-    return (page.results ?? []).map(mapLivestream);
+    const meetings = page.results ?? [];
+    const streams = meetings.map(mapLivestream);
+
+    // `live_now` is maintained by provider webhooks and can remain true when
+    // an end event is delayed or lost. Reconcile every listing with the live
+    // provider session so stale meetings never appear as currently live.
+    const statuses = await Promise.all(
+      streams.map((stream) => live.status(stream.username, stream.kind)),
+    );
+    return streams
+      .map((stream, index) => ({
+        ...stream,
+        live: statuses[index].live,
+        participants: statuses[index].participants,
+      }))
+      .filter((stream) => stream.live);
   },
 
-  async status(username: string): Promise<{ live: boolean; participants: number }> {
+  async status(
+    username: string,
+    kind?: StreamKind,
+  ): Promise<{ live: boolean; participants: number }> {
     if (useMock()) {
       await delay(120);
       const s = mockLivestreams.find((l) => l.username === username);
       return { live: s?.live ?? false, participants: s?.participants ?? 0 };
     }
     try {
-      const s = await request<Record<string, { participants?: number }>>(
+      const s = await request<
+        Record<string, { meeting_type?: string; participants?: number }>
+      >(
         `/api/dyte/${username}/live-status`,
-        { anonymous: true },
+        { anonymous: true, cache: "no-store" },
       );
-      const entries = Object.values(s || {});
+      const expectedType = kind ? TYPE_FROM_KIND[kind] : undefined;
+      const entries = Object.entries(s || {})
+        .filter(
+          ([key, entry]) =>
+            !expectedType ||
+            key === expectedType ||
+            entry.meeting_type === expectedType,
+        )
+        .map(([, entry]) => entry);
       const participants = entries.reduce((n, e) => n + (e.participants ?? 0), 0);
       return { live: entries.length > 0, participants };
     } catch {

--- a/wallet/zuuli/src/lib/api/http.ts
+++ b/wallet/zuuli/src/lib/api/http.ts
@@ -78,6 +78,7 @@ interface RequestOpts {
   body?: unknown;
   query?: Record<string, string | number | boolean | undefined>;
   headers?: Record<string, string>;
+  cache?: RequestCache;
   /** Skip the auth header even if a token exists. */
   anonymous?: boolean;
   signal?: AbortSignal;
@@ -121,6 +122,7 @@ export async function request<T>(
     headers,
     body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
     signal: opts.signal,
+    cache: opts.cache,
   });
 
   const text = await res.text();


### PR DESCRIPTION
## Summary
- reconcile public livestream listings with active provider sessions
- prevent stale webhook-maintained `live_now` flags from inflating the live count
- refresh discovery every 15 seconds and bypass GET caching for presence reads

## Verification
- `npm run typecheck`
- `npm run build`

This keeps the existing API contract and filters status by stream kind.