### PR TITLE
Restore ZUULI session fixes (http/articles, live pricing, auto-sync, stage proxy, method-agnostic login+2FA)

### DIFF
--- a/wallet/zuuli/src-tauri/Cargo.lock
+++ b/wallet/zuuli/src-tauri/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ dependencies = [
  "log",
  "num_cpus",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "rayon",
  "subtle",
 ]
@@ -337,7 +337,7 @@ checksum = "568b6890865156d9043af490d4c4081c385dd68ea10acd6ca15733d511e6b51c"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
- "rand",
+ "rand 0.8.7",
  "sha2 0.10.9",
  "unicode-normalization",
  "zeroize",
@@ -351,7 +351,7 @@ checksum = "143f5327f23168716be068f8e1014ba2ea16a6c91e8777bc8927da7b51e1df1f"
 dependencies = [
  "bs58",
  "hmac 0.13.0-pre.4",
- "rand_core",
+ "rand_core 0.6.4",
  "ripemd 0.2.0-pre.4",
  "secp256k1",
  "sha2 0.11.0-pre.4",
@@ -472,7 +472,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -665,6 +665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,7 +678,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -682,7 +699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -766,8 +783,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -836,6 +872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,7 +942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -991,6 +1036,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dbus"
@@ -1247,6 +1298,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,7 +1430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1499,7 +1559,7 @@ dependencies = [
  "hex",
  "itertools",
  "postcard",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "serdect",
  "thiserror 2.0.18",
@@ -1518,7 +1578,7 @@ dependencies = [
  "document-features",
  "frost-core",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1758,8 +1818,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1877,7 +1940,7 @@ checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "memuse",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1966,7 +2029,7 @@ dependencies = [
  "halo2_proofs",
  "lazy_static",
  "pasta_curves",
- "rand",
+ "rand 0.8.7",
  "sinsemilla",
  "subtle",
  "uint",
@@ -2003,7 +2066,7 @@ dependencies = [
  "indexmap 1.9.3",
  "maybe-rayon",
  "pasta_curves",
- "rand_core",
+ "rand_core 0.6.4",
  "tracing",
 ]
 
@@ -2198,6 +2261,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls 0.23.42",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,9 +2307,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2586,7 +2667,7 @@ dependencies = [
  "bls12_381",
  "ff",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2751,6 +2832,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -3110,6 +3197,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3234,8 +3322,8 @@ dependencies = [
  "memuse",
  "nonempty",
  "pasta_curves",
- "rand",
- "rand_core",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
  "reddsa",
  "serde",
  "sinsemilla",
@@ -3327,7 +3415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3341,7 +3429,7 @@ dependencies = [
  "ff",
  "group",
  "lazy_static",
- "rand",
+ "rand 0.8.7",
  "static_assertions",
  "subtle",
 ]
@@ -3354,18 +3442,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "password-hash",
-]
-
-[[package]]
-name = "pczt"
-version = "0.8.0-rc.1"
-dependencies = [
- "document-features",
- "getset",
- "postcard",
- "serde",
- "serde_with",
- "zcash_protocol",
 ]
 
 [[package]]
@@ -3550,7 +3626,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3722,12 +3798,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.42",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.42",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3765,7 +3913,18 @@ checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3775,7 +3934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3788,13 +3947,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3836,7 +4010,7 @@ dependencies = [
  "hex",
  "jubjub",
  "pasta_curves",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "thiserror 2.0.18",
  "zeroize",
@@ -3848,7 +4022,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b0ac1bc6bb3696d2c6f52cff8fba57238b81da8c0214ee6cd146eb8fde364e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "reddsa",
  "thiserror 1.0.69",
  "zeroize",
@@ -3922,6 +4096,49 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.42",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.9",
+]
 
 [[package]]
 name = "reqwest"
@@ -4067,6 +4284,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4097,6 +4315,12 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4130,8 +4354,8 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "memuse",
- "rand",
- "rand_core",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
  "redjubjub",
  "subtle",
  "tracing",
@@ -4419,6 +4643,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,7 +4734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4509,7 +4745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4520,7 +4756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.11.0-pre.9",
 ]
 
@@ -4755,6 +4991,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4860,7 +5117,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4960,6 +5217,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.3+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-http"
+version = "2.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "data-url",
+ "http",
+ "regex",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "urlpattern",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4992,8 +5297,7 @@ dependencies = [
  "chacha20poly1305",
  "keyring",
  "nonempty",
- "pczt",
- "rand",
+ "rand 0.8.7",
  "ripemd 0.1.3",
  "rusqlite",
  "rustls 0.23.42",
@@ -5916,6 +6220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6178,6 +6492,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6712,7 +7037,7 @@ dependencies = [
  "pasta_curves",
  "percent-encoding",
  "prost",
- "rand_core",
+ "rand_core 0.6.4",
  "rayon",
  "sapling-crypto",
  "secp256k1",
@@ -6754,8 +7079,8 @@ dependencies = [
  "nonempty",
  "orchard",
  "prost",
- "rand",
- "rand_core",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
  "rand_distr",
  "regex",
  "rusqlite",
@@ -6805,7 +7130,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard",
- "rand_core",
+ "rand_core 0.6.4",
  "sapling-crypto",
  "secp256k1",
  "secrecy",
@@ -6825,10 +7150,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "cipher",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -6849,7 +7174,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard",
- "rand_core",
+ "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
  "secp256k1",
@@ -6874,7 +7199,7 @@ dependencies = [
  "jubjub",
  "known-folders",
  "minreq",
- "rand_core",
+ "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
  "tracing",
@@ -7074,6 +7399,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-http",
  "tauri-plugin-opener",
  "tauri-plugin-zcash",
 ]

--- a/wallet/zuuli/src-tauri/Cargo.toml
+++ b/wallet/zuuli/src-tauri/Cargo.toml
@@ -15,6 +15,9 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+# Native HTTP client used by the frontend (@tauri-apps/plugin-http) to reach the
+# free2z backend without browser CORS — powers Login with Zcash and every API call.
+tauri-plugin-http = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Shared Zcash engine (librustzcash under the hood) — the "zuuallet guts".

--- a/wallet/zuuli/src-tauri/capabilities/default.json
+++ b/wallet/zuuli/src-tauri/capabilities/default.json
@@ -8,7 +8,10 @@
     "zcash:default",
     {
       "identifier": "http:default",
-      "allow": [{ "url": "https://free2z.cash/*" }]
+      "allow": [
+        { "url": "https://free2z.cash/*" },
+        { "url": "https://stage.free2z.cash/*" }
+      ]
     }
   ]
 }

--- a/wallet/zuuli/src-tauri/capabilities/default.json
+++ b/wallet/zuuli/src-tauri/capabilities/default.json
@@ -2,5 +2,13 @@
   "identifier": "default",
   "description": "Capability for the main ZUULI window",
   "windows": ["main"],
-  "permissions": ["core:default", "opener:default", "zcash:default"]
+  "permissions": [
+    "core:default",
+    "opener:default",
+    "zcash:default",
+    {
+      "identifier": "http:default",
+      "allow": [{ "url": "https://free2z.cash/*" }]
+    }
+  ]
 }

--- a/wallet/zuuli/src-tauri/src/lib.rs
+++ b/wallet/zuuli/src-tauri/src/lib.rs
@@ -2,6 +2,9 @@
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        // Native HTTP client the frontend uses (@tauri-apps/plugin-http) to call
+        // the free2z API without browser CORS — required for Login with Zcash.
+        .plugin(tauri_plugin_http::init())
         // The shared Zcash engine — same plugin the zuuallet reference wallet
         // uses (librustzcash path dependency). This is what makes ZUULI a real
         // Zcash wallet on the desktop.

--- a/wallet/zuuli/src/features/auth/BrandPanel.tsx
+++ b/wallet/zuuli/src/features/auth/BrandPanel.tsx
@@ -46,13 +46,17 @@ export function BrandPanel() {
       <div className="relative max-w-md space-y-10">
         <div className="space-y-3">
           <h1 className="text-balance text-4xl font-bold leading-[1.1] tracking-tight xl:text-5xl">
-            The <span className="zuuli-gradient-text">future of login</span> has
-            no password.
+            Sign in your way — including with{" "}
+            <span className="zuuli-gradient-text">just your key</span>.
           </h1>
           <p className="text-lg text-muted-foreground">{APP_TAGLINE}</p>
         </div>
 
-        <ul className="space-y-5">
+        <div className="space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Why Continue with Zcash
+          </p>
+          <ul className="space-y-5">
           {VALUES.map(({ icon: Icon, title, body }) => (
             <li key={title} className="flex gap-3.5">
               <span className="mt-0.5 grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
@@ -64,7 +68,8 @@ export function BrandPanel() {
               </div>
             </li>
           ))}
-        </ul>
+          </ul>
+        </div>
       </div>
 
       <p className="relative text-xs text-muted-foreground">

--- a/wallet/zuuli/src/features/auth/ClassicLoginForm.tsx
+++ b/wallet/zuuli/src/features/auth/ClassicLoginForm.tsx
@@ -1,15 +1,16 @@
-// Fallback path — sign in with an existing free2z username + password. Once
-// signed in, the account can be associated with your Zcash identity so future
-// logins are keys-only.
+// Username/password sign-in — a first-class login method, peer to Login with
+// Zcash. When the account has 2FA (TOTP) enabled, the password step hands off
+// to a second, 6-digit code step before the session is considered established.
 
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import { Link2, Loader2, LogIn } from "lucide-react";
+import { ArrowLeft, Link2, Loader2, LogIn, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { auth } from "@/lib/api/free2z";
+import type { AuthUser } from "@/lib/api/types";
 import { useSession } from "@/store/session";
 
 export function ClassicLoginForm() {
@@ -19,6 +20,17 @@ export function ClassicLoginForm() {
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // When 2FA is required, we advance to the code step; the password stays in
+  // component memory only long enough to complete the second factor.
+  const [needsOtp, setNeedsOtp] = useState(false);
+
+  function land(user: AuthUser) {
+    setUser(user);
+    toast.success("Welcome back", {
+      description: `Signed in as ${user.username}.`,
+    });
+    navigate("/");
+  }
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -26,29 +38,45 @@ export function ClassicLoginForm() {
     setSubmitting(true);
     setError(null);
     try {
-      const user = await auth.login(username.trim(), password);
-      setUser(user);
-      toast.success("Welcome back", { description: `Signed in as ${user.username}.` });
-      navigate("/");
+      const result = await auth.login(username.trim(), password);
+      if (result.status === "otp_required") {
+        setNeedsOtp(true);
+      } else {
+        land(result.user);
+      }
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Sign-in failed. Check your details.";
-      setError(message);
+      setError(
+        err instanceof Error ? err.message : "Sign-in failed. Check your details.",
+      );
     } finally {
       setSubmitting(false);
     }
   }
 
+  if (needsOtp) {
+    return (
+      <OtpStep
+        username={username.trim()}
+        password={password}
+        onVerified={land}
+        onBack={() => {
+          setNeedsOtp(false);
+          setError(null);
+        }}
+      />
+    );
+  }
+
   return (
     <form onSubmit={onSubmit} className="animate-slide-up space-y-4">
       <div className="space-y-2">
-        <Label htmlFor="f2z-username">Username</Label>
+        <Label htmlFor="f2z-username">Email or username</Label>
         <Input
           id="f2z-username"
           autoComplete="username"
           value={username}
           onChange={(e) => setUsername(e.target.value)}
-          placeholder="your-handle"
+          placeholder="you@example.com"
           disabled={submitting}
           aria-invalid={!!error}
         />
@@ -75,7 +103,6 @@ export function ClassicLoginForm() {
 
       <Button
         type="submit"
-        variant="secondary"
         className="w-full"
         disabled={!username || !password || submitting}
       >
@@ -92,6 +119,106 @@ export function ClassicLoginForm() {
         You can link this account to your Zcash identity later for keys-only
         sign-in.
       </p>
+    </form>
+  );
+}
+
+// ─── Second factor: 6-digit TOTP code ────────────────────────────────────────
+
+function OtpStep({
+  username,
+  password,
+  onVerified,
+  onBack,
+}: {
+  username: string;
+  password: string;
+  onVerified: (user: AuthUser) => void;
+  onBack: () => void;
+}) {
+  const [code, setCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (code.length !== 6 || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const user = await auth.completeOtp(username, password, code);
+      onVerified(user);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Verification failed.");
+      setCode("");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="animate-slide-up space-y-4">
+      <div className="flex items-start gap-3 rounded-lg border border-border bg-background/40 p-4">
+        <span className="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
+          <ShieldCheck className="h-5 w-5" aria-hidden />
+        </span>
+        <div className="space-y-0.5">
+          <p className="text-sm font-medium">Two-factor authentication</p>
+          <p className="text-sm text-muted-foreground">
+            Enter the 6-digit code from your authenticator app to finish signing
+            in as{" "}
+            <span className="font-medium text-foreground">{username}</span>.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="f2z-otp">Authentication code</Label>
+        <Input
+          id="f2z-otp"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          autoFocus
+          maxLength={6}
+          value={code}
+          onChange={(e) => setCode(e.target.value.replace(/\D/g, "").slice(0, 6))}
+          placeholder="000000"
+          className="text-center text-lg tracking-[0.5em] tabular-nums"
+          disabled={submitting}
+          aria-invalid={!!error}
+        />
+      </div>
+
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={code.length !== 6 || submitting}
+      >
+        {submitting ? (
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+        ) : (
+          <ShieldCheck className="h-4 w-4" aria-hidden />
+        )}
+        {submitting ? "Verifying…" : "Verify and sign in"}
+      </Button>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="w-full text-muted-foreground"
+        onClick={onBack}
+        disabled={submitting}
+      >
+        <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+        Use a different account
+      </Button>
     </form>
   );
 }

--- a/wallet/zuuli/src/features/auth/SocialSoon.tsx
+++ b/wallet/zuuli/src/features/auth/SocialSoon.tsx
@@ -1,0 +1,68 @@
+// X and Google as peer login methods — rendered but clearly not yet available.
+// No desktop OAuth transport exists yet (X is web-cookie-redirect only; Google
+// has no backend), so these are deliberately inert "coming soon" affordances.
+// A tooltip explains why; nothing is wired to any OAuth flow.
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/** Monogram tile standing in for a brand mark (no external brand assets). */
+function Monogram({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      className="grid h-5 w-5 shrink-0 place-items-center rounded bg-muted-foreground/20 text-[11px] font-bold text-muted-foreground"
+      aria-hidden
+    >
+      {children}
+    </span>
+  );
+}
+
+function ComingSoonMethod({
+  label,
+  mark,
+}: {
+  label: string;
+  mark: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {/* Intentionally not a real `disabled` button so the tooltip still
+            fires on hover/focus; `aria-disabled` + no handler keep it inert. */}
+        <button
+          type="button"
+          aria-disabled="true"
+          aria-label={`${label} — coming soon`}
+          onClick={(e) => e.preventDefault()}
+          className="flex w-full cursor-not-allowed items-center justify-center gap-2 rounded-md border border-border bg-transparent px-4 py-2 text-sm font-medium text-muted-foreground opacity-70"
+        >
+          {mark}
+          {label}
+          <span className="ml-1 rounded-full border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider">
+            Soon
+          </span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>Coming soon on desktop</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function SocialSoon() {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <div className="space-y-3">
+        <ComingSoonMethod label="Continue with X" mark={<Monogram>X</Monogram>} />
+        <ComingSoonMethod
+          label="Continue with Google"
+          mark={<Monogram>G</Monogram>}
+        />
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/wallet/zuuli/src/features/auth/index.tsx
+++ b/wallet/zuuli/src/features/auth/index.tsx
@@ -1,15 +1,15 @@
-// ZUULI — Login with Zcash.
+// ZUULI — Login.
 //
 // A standalone, full-viewport auth page (mounted at /login, outside the app
-// shell). Split-screen: a cinematic brand panel on the left and the action
-// panel on the right. The primary path is keys-only Zcash sign-in; classic
-// free2z sign-in and guest browsing are offered as secondary "more ways".
+// shell). Login is just login: the screen offers several methods as peers —
+// email/username + password (with 2FA when enabled), Continue with Zcash, and
+// (soon) X / Google. No single method is the "showpiece"; Zcash is one clearly
+// offered option among equals.
 
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { ArrowUpRight, HelpCircle, ShieldCheck } from "lucide-react";
+import { ArrowLeft, ArrowUpRight, HelpCircle, ShieldCheck } from "lucide-react";
 import { Wordmark } from "@/components/brand/Logo";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -22,12 +22,15 @@ import { Separator } from "@/components/ui/separator";
 import { useWallet } from "@/store/wallet";
 import { BrandPanel } from "./BrandPanel";
 import { ClassicLoginForm } from "./ClassicLoginForm";
+import { SocialSoon } from "./SocialSoon";
 import { ZcashLoginFlow } from "./ZcashLoginFlow";
 import { ZShieldInfo } from "./ZShieldInfo";
 
+type Method = "chooser" | "zcash";
+
 export default function AuthFeature() {
   const bootstrap = useWallet((s) => s.bootstrap);
-  const [showClassic, setShowClassic] = useState(false);
+  const [method, setMethod] = useState<Method>("chooser");
 
   useEffect(() => {
     void bootstrap();
@@ -45,68 +48,85 @@ export default function AuthFeature() {
 
         <div className="w-full max-w-md animate-slide-up">
           <Card className="border-border/80 bg-card/70 shadow-glow backdrop-blur">
-            <CardHeader className="space-y-3">
-              <div className="flex items-center justify-between">
-                <Badge variant="default" className="gap-1.5">
-                  <ShieldCheck className="h-3.5 w-3.5" aria-hidden />
-                  Passwordless
-                </Badge>
-                <ZShieldInfo>
-                  <button
-                    type="button"
-                    className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-                    aria-label="How Login with Zcash works"
-                  >
-                    <HelpCircle className="h-3.5 w-3.5" aria-hidden />
-                    How it works
-                  </button>
-                </ZShieldInfo>
-              </div>
-              <div className="space-y-1">
-                <CardTitle className="text-2xl">Welcome to ZUULI</CardTitle>
-                <CardDescription>
-                  Your Zcash key is your identity. Sign in without a password.
-                </CardDescription>
-              </div>
+            <CardHeader className="space-y-1">
+              <CardTitle className="text-2xl">Sign in to ZUULI</CardTitle>
+              <CardDescription>
+                {method === "zcash"
+                  ? "Prove control of your Zcash key to sign in — no password."
+                  : "Welcome back. Choose how you'd like to continue."}
+              </CardDescription>
             </CardHeader>
 
             <CardContent className="space-y-6">
-              <ZcashLoginFlow />
-
-              <div className="flex items-center gap-3">
-                <Separator className="flex-1" />
-                <span className="text-xs uppercase tracking-wider text-muted-foreground">
-                  more ways
-                </span>
-                <Separator className="flex-1" />
-              </div>
-
-              {showClassic ? (
-                <ClassicLoginForm />
+              {method === "zcash" ? (
+                <div className="space-y-5">
+                  <button
+                    type="button"
+                    onClick={() => setMethod("chooser")}
+                    className="inline-flex items-center gap-1.5 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label="Back to all sign-in options"
+                  >
+                    <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+                    All sign-in options
+                  </button>
+                  <ZcashLoginFlow />
+                </div>
               ) : (
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="w-full"
-                  onClick={() => setShowClassic(true)}
-                >
-                  I already have a free2z account
-                </Button>
-              )}
+                <>
+                  {/* Method 1 — email/username + password (first-class) */}
+                  <ClassicLoginForm />
 
-              <div className="text-center">
-                <Button
-                  asChild
-                  variant="link"
-                  size="sm"
-                  className="text-muted-foreground"
-                >
-                  <Link to="/" aria-label="Explore ZUULI as a guest">
-                    Explore first — continue as guest
-                    <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
-                  </Link>
-                </Button>
-              </div>
+                  <div className="flex items-center gap-3">
+                    <Separator className="flex-1" />
+                    <span className="text-xs uppercase tracking-wider text-muted-foreground">
+                      or continue with
+                    </span>
+                    <Separator className="flex-1" />
+                  </div>
+
+                  {/* Method 2 — Continue with Zcash (a peer option) */}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-full justify-center"
+                    onClick={() => setMethod("zcash")}
+                  >
+                    <ShieldCheck className="h-4 w-4 text-primary" aria-hidden />
+                    Continue with Zcash
+                    <span className="ml-1 rounded-full bg-primary/15 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-primary">
+                      Passwordless
+                    </span>
+                  </Button>
+
+                  {/* Methods 3 & 4 — X / Google, not yet available on desktop */}
+                  <SocialSoon />
+
+                  <div className="flex items-center justify-between">
+                    <ZShieldInfo>
+                      <button
+                        type="button"
+                        className="inline-flex items-center gap-1.5 rounded-md text-xs text-muted-foreground transition-colors hover:text-foreground"
+                        aria-label="How Login with Zcash works"
+                      >
+                        <HelpCircle className="h-3.5 w-3.5" aria-hidden />
+                        How Zcash login works
+                      </button>
+                    </ZShieldInfo>
+
+                    <Button
+                      asChild
+                      variant="link"
+                      size="sm"
+                      className="text-muted-foreground"
+                    >
+                      <Link to="/" aria-label="Explore ZUULI as a guest">
+                        Continue as guest
+                        <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
+                      </Link>
+                    </Button>
+                  </div>
+                </>
+              )}
             </CardContent>
           </Card>
 

--- a/wallet/zuuli/src/features/buy/BuyTab.tsx
+++ b/wallet/zuuli/src/features/buy/BuyTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CreditCard, Check, Loader2, ShieldCheck, Wallet } from "lucide-react";
 import { toast } from "sonner";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -22,17 +22,19 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { tuzi } from "@/lib/api/free2z";
+import { pricing, tuzi } from "@/lib/api/free2z";
 import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
 import { cn } from "@/lib/utils";
 import {
+  ZATOSHIS_PER_ZEC,
   formatTuzis,
   formatUsd,
   formatZecTrim,
   tuzisToUsd,
 } from "@/lib/format";
-import { BUY_PACKS, MAX_TUZIS, parseTuzis, tuzisToZatoshis } from "./lib";
+import { BUY_PACKS, MAX_TUZIS, parseTuzis } from "./lib";
+import type { PricingQuote } from "@/lib/api/types";
 
 /** Open an external URL, falling back to a browser tab outside Tauri. */
 async function open(url: string) {
@@ -43,6 +45,12 @@ async function open(url: string) {
   }
 }
 
+type QuoteState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; quote: PricingQuote }
+  | { status: "error" };
+
 export function BuyTab() {
   const adjustTuzis = useSession((s) => s.adjustTuzis);
   const spendable = useWallet((s) => s.balance?.spendable ?? 0);
@@ -52,6 +60,7 @@ export function BuyTab() {
   const [cardLoading, setCardLoading] = useState(false);
   const [zecConfirm, setZecConfirm] = useState(false);
   const [zecLoading, setZecLoading] = useState(false);
+  const [quoteState, setQuoteState] = useState<QuoteState>({ status: "idle" });
 
   // The custom field wins when it holds a valid amount, keeping one source of
   // truth for "amount". Everything downstream reads `amount`.
@@ -60,8 +69,44 @@ export function BuyTab() {
   const valid = amount > 0 && amount <= MAX_TUZIS;
 
   const usd = tuzisToUsd(amount);
-  const zatoshisNeeded = tuzisToZatoshis(amount);
-  const enoughZec = spendable >= zatoshisNeeded;
+
+  // Live ZEC cost from the backend pricing service, debounced on the amount.
+  // We NEVER recompute ZEC on the client — the backend returns the exact
+  // `zec_amount`. A cancel flag keeps only the latest request's result, and a
+  // 503 / fetch error surfaces as an "unavailable" state (no fabricated number).
+  useEffect(() => {
+    if (!valid) {
+      setQuoteState({ status: "idle" });
+      return;
+    }
+    let cancelled = false;
+    const ctrl = new AbortController();
+    setQuoteState({ status: "loading" });
+    const t = setTimeout(() => {
+      pricing
+        .quote(amount, ctrl.signal)
+        .then((quote) => {
+          if (!cancelled) setQuoteState({ status: "ready", quote });
+        })
+        .catch(() => {
+          if (!cancelled) setQuoteState({ status: "error" });
+        });
+    }, 300);
+    return () => {
+      cancelled = true;
+      ctrl.abort();
+      clearTimeout(t);
+    };
+  }, [amount, valid]);
+
+  const quote = quoteState.status === "ready" ? quoteState.quote : null;
+  const zatoshisNeeded = quote
+    ? Math.round(Number(quote.zec_amount) * ZATOSHIS_PER_ZEC)
+    : 0;
+  const enoughZec = !!quote && spendable >= zatoshisNeeded;
+  const isEstimate = !!quote && (quote.stale || quote.bootstrap);
+  const quoteLoading = quoteState.status === "loading";
+  const quoteUnavailable = quoteState.status === "error";
 
   async function payWithCard() {
     if (!valid) return;
@@ -80,7 +125,7 @@ export function BuyTab() {
   }
 
   async function payWithZec() {
-    if (!valid || !enoughZec) return;
+    if (!valid || !quote || !enoughZec) return;
     setZecLoading(true);
     try {
       // Mock settlement — in production this proposes + broadcasts a shielded
@@ -88,7 +133,7 @@ export function BuyTab() {
       await new Promise((r) => setTimeout(r, 650));
       adjustTuzis(amount);
       toast.success(`Bought ${formatTuzis(amount)} with ZEC`, {
-        description: `${formatZecTrim(zatoshisNeeded)} ZEC debited from your wallet.`,
+        description: `${quote.zec_amount} ZEC debited from your wallet.`,
       });
       setZecConfirm(false);
     } finally {
@@ -215,7 +260,7 @@ export function BuyTab() {
             size="lg"
             variant="zec"
             className="w-full"
-            disabled={!valid || !enoughZec}
+            disabled={!valid || !quote || !enoughZec || quoteLoading}
             onClick={() => setZecConfirm(true)}
           >
             <Wallet className="h-4 w-4" />
@@ -224,13 +269,21 @@ export function BuyTab() {
           <div className="space-y-1 text-xs">
             <div className="flex items-center justify-between text-muted-foreground">
               <span className="flex items-center gap-1">
-                Est. cost
-                <Badge variant="zec" className="px-1.5 py-0 text-[10px]">
-                  estimated
-                </Badge>
+                {isEstimate ? "Est. cost" : "Cost"}
+                {isEstimate && (
+                  <Badge variant="zec" className="px-1.5 py-0 text-[10px]">
+                    estimated
+                  </Badge>
+                )}
               </span>
               <span className="tabular-nums text-zec">
-                {valid ? `${formatZecTrim(zatoshisNeeded)} ZEC` : "—"}
+                {!valid
+                  ? "—"
+                  : quoteLoading
+                    ? "…"
+                    : quote
+                      ? `${quote.zec_amount} ZEC`
+                      : "—"}
               </span>
             </div>
             <div className="flex items-center justify-between text-muted-foreground">
@@ -239,7 +292,12 @@ export function BuyTab() {
                 {formatZecTrim(spendable)} ZEC
               </span>
             </div>
-            {valid && !enoughZec && (
+            {valid && quoteUnavailable && (
+              <p className="pt-1 text-destructive">
+                Live pricing unavailable — try again.
+              </p>
+            )}
+            {valid && quote && !enoughZec && (
               <p className="pt-1 text-destructive">
                 Not enough ZEC — top up your wallet or pay with card.
               </p>
@@ -268,13 +326,15 @@ export function BuyTab() {
             <Row
               label={
                 <span className="flex items-center gap-1.5">
-                  Estimated ZEC
-                  <Badge variant="zec" className="px-1.5 py-0 text-[10px]">
-                    estimated
-                  </Badge>
+                  {isEstimate ? "Estimated ZEC" : "ZEC to send"}
+                  {isEstimate && (
+                    <Badge variant="zec" className="px-1.5 py-0 text-[10px]">
+                      estimated
+                    </Badge>
+                  )}
                 </span>
               }
-              value={`${formatZecTrim(zatoshisNeeded)} ZEC`}
+              value={quote ? `${quote.zec_amount} ZEC` : "—"}
               accent
             />
           </div>

--- a/wallet/zuuli/src/features/buy/lib.ts
+++ b/wallet/zuuli/src/features/buy/lib.ts
@@ -1,14 +1,10 @@
 // Shared constants + helpers for the 2Z economy feature.
 //
 // 2Z ("Tuzi") = 1 US cent. Buying credits the session balance; spending
-// (tips/donations) debits it. The "pay with ZEC" path quotes an *estimated*
-// ZEC amount from a display rate — the real app would fetch a live quote.
+// (tips/donations) debits it. The "pay with ZEC" cost is fetched live from the
+// backend pricing service (pricing.quote) — there is no client-side rate.
 
-import {
-  TUZIS_PER_USD,
-  ZATOSHIS_PER_ZEC,
-  tuzisToUsd,
-} from "@/lib/format";
+import { TUZIS_PER_USD } from "@/lib/format";
 import type { TuziTransaction } from "@/lib/api/types";
 import {
   CreditCard,
@@ -26,23 +22,6 @@ export const BUY_PACKS = [500, 2_000, 5_000, 10_000] as const;
 
 /** Preset tip amounts, in 2Z. */
 export const TIP_PRESETS = [100, 500, 1_000, 2_500] as const;
-
-/**
- * Estimated USD per ZEC used purely for the "pay with ZEC" quote. Treated as a
- * soft quote and always labelled "estimated" in the UI — the production flow
- * would swap this for a live rate from the pricing service.
- */
-export const ZEC_USD_RATE = 42;
-
-/** Convert a USD amount to an estimated zatoshi quote. */
-export function usdToZatoshis(usd: number): number {
-  return Math.round((usd / ZEC_USD_RATE) * ZATOSHIS_PER_ZEC);
-}
-
-/** Convert 2Zs to the estimated zatoshis needed to buy them. */
-export function tuzisToZatoshis(tuzis: number): number {
-  return usdToZatoshis(tuzisToUsd(tuzis));
-}
 
 /** Parse a possibly-messy numeric string into a non-negative whole 2Z amount. */
 export function parseTuzis(raw: string): number {

--- a/wallet/zuuli/src/features/wallet/Overview.tsx
+++ b/wallet/zuuli/src/features/wallet/Overview.tsx
@@ -1,5 +1,5 @@
 // Wallet overview: balance, sync, address, recent activity.
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { ArrowDownToLine, ArrowUpRight, History } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -17,11 +17,11 @@ export function Overview() {
   const balance = useWallet((s) => s.balance);
   const sync = useWallet((s) => s.sync);
   const unifiedAddress = useWallet((s) => s.unifiedAddress);
-  const refreshSync = useWallet((s) => s.refreshSync);
 
-  const [syncBusy, setSyncBusy] = useState(false);
   const [recent, setRecent] = useState<TransactionEntry[] | null>(null);
-  const pollRef = useRef<number | null>(null);
+
+  // Sync runs automatically and is polled by the wallet store, so there is no
+  // manual start/stop here — the SyncBar below is a passive status indicator.
 
   // Load a small recent-activity preview.
   useEffect(() => {
@@ -38,40 +38,6 @@ export function Overview() {
       alive = false;
     };
   }, []);
-
-  // Poll sync status roughly every 1.5s while a sync is in progress.
-  useEffect(() => {
-    const syncing = sync?.syncing ?? false;
-    if (syncing && pollRef.current === null) {
-      pollRef.current = window.setInterval(() => {
-        void refreshSync();
-      }, 1500);
-    }
-    if (!syncing && pollRef.current !== null) {
-      window.clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-    return () => {
-      if (pollRef.current !== null) {
-        window.clearInterval(pollRef.current);
-        pollRef.current = null;
-      }
-    };
-  }, [sync?.syncing, refreshSync]);
-
-  const onToggleSync = useCallback(async () => {
-    setSyncBusy(true);
-    try {
-      if (sync?.syncing) {
-        await wallet.stopSync();
-      } else {
-        await wallet.startSync();
-      }
-      await refreshSync();
-    } finally {
-      setSyncBusy(false);
-    }
-  }, [sync?.syncing, refreshSync]);
 
   const pending = balance
     ? balance.valuePending + balance.changePending
@@ -143,7 +109,7 @@ export function Overview() {
 
         {/* Sync + address column */}
         <div className="space-y-6">
-          <SyncBar sync={sync} busy={syncBusy} onToggle={onToggleSync} />
+          <SyncBar sync={sync} />
           {unifiedAddress ? (
             <AddressCard address={unifiedAddress} compact />
           ) : (

--- a/wallet/zuuli/src/features/wallet/components.tsx
+++ b/wallet/zuuli/src/features/wallet/components.tsx
@@ -1,13 +1,7 @@
 // Composite wallet UI pieces: sync bar, address card, transaction row.
 import { QRCodeSVG } from "qrcode.react";
 import { Link } from "react-router-dom";
-import {
-  ArrowDownLeft,
-  ArrowUpRight,
-  Loader2,
-  Play,
-  Square,
-} from "lucide-react";
+import { ArrowDownLeft, ArrowUpRight, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
@@ -20,88 +14,62 @@ import type { SyncStatus, TransactionEntry } from "@/lib/wallet/types";
 import { cn } from "@/lib/utils";
 import { CopyButton } from "./shared";
 
-/** Sync progress bar with a Start/Stop toggle. */
-export function SyncBar({
-  sync,
-  busy,
-  onToggle,
-}: {
-  sync: SyncStatus | null;
-  busy: boolean;
-  onToggle: () => void;
-}) {
+/**
+ * Passive sync status. Sync runs automatically and continuously (resumed on
+ * launch by the wallet store), so there is no manual start/stop control — this
+ * just quietly reflects state: "Syncing… N%" while catching up, "Synced" once
+ * at the chain tip. The engine keeps reporting `syncing: true` even when caught
+ * up (it watches for new blocks), so "caught up" is judged by height.
+ */
+export function SyncBar({ sync }: { sync: SyncStatus | null }) {
   const pct = sync ? Math.min(100, Math.max(0, sync.progressPercent)) : 0;
-  const syncing = sync?.syncing ?? false;
-  const synced = pct >= 99.995;
+  const connecting = sync === null || sync.chainTip === 0;
+  const caughtUp =
+    sync !== null && sync.chainTip > 0 && sync.syncedHeight >= sync.chainTip;
 
   return (
-    <Card className="rounded-xl p-4">
-      <div className="flex items-center justify-between gap-4">
-        <div className="min-w-0 space-y-0.5">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            {syncing ? (
-              <>
-                <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
-                <span>Syncing blocks</span>
-              </>
-            ) : synced ? (
-              <>
-                <span
-                  className="h-2 w-2 rounded-full bg-emerald-400"
-                  aria-hidden
-                />
-                <span>Up to date</span>
-              </>
-            ) : (
-              <>
-                <span
-                  className="h-2 w-2 rounded-full bg-muted-foreground"
-                  aria-hidden
-                />
-                <span>Sync paused</span>
-              </>
-            )}
-          </div>
-          <p className="truncate text-xs tabular-nums text-muted-foreground">
-            {sync
-              ? `${formatHeight(sync.syncedHeight)} / ${formatHeight(sync.chainTip)} · ${pct.toFixed(1)}%`
-              : "—"}
-          </p>
+    <Card className="rounded-xl p-4" role="status" aria-live="polite">
+      <div className="flex items-center gap-2 text-sm font-medium">
+        {caughtUp ? (
+          <>
+            <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
+            <span>Synced</span>
+          </>
+        ) : connecting ? (
+          <>
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+            <span className="text-muted-foreground">Connecting</span>
+          </>
+        ) : (
+          <>
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
+            <span>Syncing</span>
+            <span className="ml-auto text-xs tabular-nums text-muted-foreground">
+              {pct.toFixed(1)}%
+            </span>
+          </>
+        )}
+      </div>
+
+      <p className="mt-0.5 truncate text-xs tabular-nums text-muted-foreground">
+        {sync && !connecting
+          ? `${formatHeight(sync.syncedHeight)} / ${formatHeight(sync.chainTip)}`
+          : "Waiting for chain tip…"}
+      </p>
+
+      {!caughtUp ? (
+        <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-[width] duration-500 ease-out"
+            style={{ width: `${pct}%` }}
+            role="progressbar"
+            aria-valuenow={Math.round(pct)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label="Chain sync progress"
+          />
         </div>
-
-        <Button
-          type="button"
-          size="sm"
-          variant={syncing ? "outline" : "secondary"}
-          onClick={onToggle}
-          disabled={busy}
-          aria-label={syncing ? "Stop sync" : "Start sync"}
-        >
-          {busy ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : syncing ? (
-            <Square className="h-4 w-4" />
-          ) : (
-            <Play className="h-4 w-4" />
-          )}
-          {syncing ? "Stop" : "Sync"}
-        </Button>
-      </div>
-
-      <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-muted">
-        <div
-          className={cn(
-            "h-full rounded-full transition-[width] duration-500 ease-out",
-            synced ? "bg-emerald-400" : "bg-primary",
-          )}
-          style={{ width: `${pct}%` }}
-          role="progressbar"
-          aria-valuenow={Math.round(pct)}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-label="Chain sync progress"
-        />
-      </div>
+      ) : null}
     </Card>
   );
 }

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -24,6 +24,8 @@ import type {
   DyteJoinTicket,
   Livestream,
   Paginated,
+  PricingQuote,
+  PricingSnapshot,
   PromptResponse,
   SimpleCreator,
   StreamKind,
@@ -520,5 +522,74 @@ export const discover = {
       anonymous: true,
     });
     return (page.results ?? []).map(mapCreator);
+  },
+};
+
+
+// ─── Pricing (live 2Z ↔ ZEC) ──────────────────────────────────────
+// Live price discovery for the "pay with ZEC" buy path. The backend aggregates
+// ZEC/USD across exchanges and computes the exact ZEC to send; the client just
+// displays it and NEVER recomputes ZEC from a hardcoded rate. Both endpoints
+// are public (AllowAny) — hence `anonymous: true`. On no price the backend
+// returns 503; callers must show "unavailable", not a fabricated number.
+
+// A plausible current ZEC/USD used ONLY by mock mode (browser / VITE_MOCK=1) so
+// the buy screen renders offline. Deliberately not the old hardcoded $42; the
+// real number always comes from /api/pricing.
+const MOCK_ZEC_USD = 55;
+const MOCK_SPREAD = 0.1;
+const MOCK_TUZIS_PER_ZEC = MOCK_ZEC_USD * (1 - MOCK_SPREAD) * 100; // 4950
+
+export const pricing = {
+  /** Current pricing snapshot (GET /api/pricing/). Public, no auth. */
+  async current(): Promise<PricingSnapshot> {
+    if (useMock()) {
+      await delay(120);
+      return {
+        zec_usd: MOCK_ZEC_USD.toFixed(2),
+        spread: MOCK_SPREAD.toFixed(2),
+        tuzis_per_zec: MOCK_TUZIS_PER_ZEC.toFixed(4),
+        tuzi_per_usd: 100,
+        usd_per_tuzi: "0.01",
+        num_sources: 4,
+        sources: {
+          kraken: (MOCK_ZEC_USD - 0.12).toFixed(2),
+          coinbase: (MOCK_ZEC_USD + 0.08).toFixed(2),
+          binance: (MOCK_ZEC_USD - 0.05).toFixed(2),
+          gemini: (MOCK_ZEC_USD + 0.11).toFixed(2),
+        },
+        updated_at: new Date().toISOString(),
+        stale: false,
+        bootstrap: false,
+        card: { percent_fee: "0.05", flat_fee_cents: 100 },
+      };
+    }
+    return request<PricingSnapshot>("/api/pricing/", { anonymous: true });
+  },
+
+  /**
+   * Exact ZEC/card amounts to buy `tuzis` 2Z (GET /api/pricing/quote/?tuzis=N).
+   * The backend returns the precise `zec_amount` to send — display it directly.
+   */
+  async quote(tuzis: number, signal?: AbortSignal): Promise<PricingQuote> {
+    if (useMock()) {
+      await delay(180);
+      const zecAmount = Math.ceil((tuzis / MOCK_TUZIS_PER_ZEC) * 1e8) / 1e8;
+      return {
+        tuzis,
+        zec_amount: zecAmount.toFixed(8),
+        card_cents: Math.floor(tuzis * 1.05) + 100,
+        tuzis_per_zec: MOCK_TUZIS_PER_ZEC.toFixed(4),
+        zec_usd: MOCK_ZEC_USD.toFixed(2),
+        updated_at: new Date().toISOString(),
+        stale: false,
+        bootstrap: false,
+      };
+    }
+    return request<PricingQuote>("/api/pricing/quote/", {
+      query: { tuzis },
+      anonymous: true,
+      signal,
+    });
   },
 };

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -6,8 +6,9 @@
 // This module is the CONTRACT every feature imports. Keep the return types stable.
 
 import { useMock } from "../platform";
+import { MOCK_OTP } from "../env";
 import { usdToTuzis } from "../format";
-import { basicLogin, mediaUrl, request, setToken } from "./http";
+import { ApiError, basicLogin, mediaUrl, request, setToken } from "./http";
 import {
   mockAiReply,
   mockArticles,
@@ -23,6 +24,8 @@ import type {
   AuthUser,
   DyteJoinTicket,
   Livestream,
+  LoginResult,
+  OtpStatus,
   Paginated,
   PricingQuote,
   PricingSnapshot,
@@ -159,15 +162,89 @@ function inferProvider(model: string): AIModel["provider"] {
 }
 
 // ─── Auth / session ─────────────────────────────────────────────────────────
+
+/** Mock: which usernames should exercise the 2FA (OTP) step, and the code that clears it. */
+const MOCK_OTP_CODE = "123456";
+function mockOtpEnabled(username: string): boolean {
+  return MOCK_OTP || username.toLowerCase().includes("otp");
+}
+
 export const auth = {
-  /** Classic username/password → Knox token (HTTP Basic auth under the hood). */
-  async login(username: string, password: string): Promise<AuthUser> {
+  /**
+   * Classic username/password sign-in (a first-class login method, peer to
+   * Login with Zcash).
+   *
+   * Real flow:
+   *   1. `basicLogin` → Knox Basic-auth login (`/api/token/login/`) mints a token.
+   *   2. `otpStatus()` (authenticated with that token) reports whether the
+   *      account has TOTP 2FA enabled.
+   *   3. If 2FA is ON we DROP the token and return `otp_required`, so an
+   *      abandoned code prompt never leaves a live session behind; the caller
+   *      finishes via `completeOtp`. If 2FA is OFF, the login is complete.
+   *
+   * (Knox's own login endpoint does not enforce OTP, so the second factor is
+   * gated here on the client — see the follow-up note about a token-upgrading
+   * OTP endpoint on the backend.)
+   */
+  async login(username: string, password: string): Promise<LoginResult> {
     if (useMock()) {
       await delay();
+      if (mockOtpEnabled(username)) return { status: "otp_required", username };
+      setToken("mock-knox-token");
+      return { status: "complete", user: { ...mockUser, username } };
+    }
+    await basicLogin(username, password); // sets the Knox token
+    const { enabled } = await auth.otpStatus();
+    if (enabled) {
+      setToken(null); // don't persist a session behind an unfinished 2FA prompt
+      return { status: "otp_required", username };
+    }
+    return { status: "complete", user: await auth.me() };
+  },
+
+  /** Whether the currently-authenticated account has TOTP 2FA enabled. */
+  async otpStatus(): Promise<OtpStatus> {
+    if (useMock()) {
+      await delay(120);
+      return { enabled: false };
+    }
+    return request<OtpStatus>("/api/otp/status/");
+  },
+
+  /**
+   * Finish a username/password login that requires 2FA. The backend's
+   * `/api/otp/login/` verifies the 6-digit TOTP `code` (it re-checks the
+   * password too); a wrong code throws. On success we mint a fresh Knox token
+   * via Basic-auth login and load the profile.
+   */
+  async completeOtp(
+    username: string,
+    password: string,
+    code: string,
+  ): Promise<AuthUser> {
+    if (useMock()) {
+      await delay();
+      if (code !== MOCK_OTP_CODE) {
+        throw new Error("That code didn't match. (Mock mode expects 123456.)");
+      }
       setToken("mock-knox-token");
       return { ...mockUser, username };
     }
-    await basicLogin(username, password);
+    try {
+      await request("/api/otp/login/", {
+        method: "POST",
+        anonymous: true,
+        body: { username, password, token: code },
+      });
+    } catch (e) {
+      if (e instanceof ApiError && (e.status === 400 || e.status === 401)) {
+        throw new Error(
+          "That code didn't match. Check your authenticator app and try again.",
+        );
+      }
+      throw e;
+    }
+    await basicLogin(username, password); // establish the real session token
     return auth.me();
   },
 

--- a/wallet/zuuli/src/lib/api/http.ts
+++ b/wallet/zuuli/src/lib/api/http.ts
@@ -64,7 +64,16 @@ type FetchLike = typeof fetch;
 let fetchImpl: FetchLike | null = null;
 async function getFetch(): Promise<FetchLike> {
   if (fetchImpl) return fetchImpl;
-  if (isTauri()) {
+  // `tauri dev` is served by the Vite dev server, whose proxy forwards /api and
+  // /uploadz to the backend (same-origin localhost:1423 → backend, no CORS). Use
+  // window.fetch there so that proxy is honored. Only production builds (no dev
+  // server, absolute API_BASE like https://free2z.cash) need tauri-plugin-http
+  // to dodge browser CORS from the webview's own origin.
+  const isDev = Boolean(
+    (import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV,
+  );
+  const useNativeHttp = isTauri() && !isDev;
+  if (useNativeHttp) {
     const mod = await import("@tauri-apps/plugin-http");
     fetchImpl = mod.fetch as unknown as FetchLike;
   } else {

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -139,3 +139,41 @@ export interface Paginated<T> {
   previous: string | null;
   results: T[];
 }
+
+// ── Pricing (live 2Z ↔ ZEC / card) ───────────────────────────────
+// The backend does live ZEC/USD price discovery (tuzi py/dj/apps/pricing) and
+// derives every conversion from "1 2Z = $0.01". Decimal money fields come over
+// the wire as strings; parse them at the point of use, never store a rate.
+
+/** Card processing fees applied to the USD path (PricingSnapshot.card). */
+export interface CardFees {
+  percent_fee: string; // e.g. "0.05" (5%)
+  flat_fee_cents: number;
+}
+
+/** Current live pricing snapshot — GET /api/pricing/. */
+export interface PricingSnapshot {
+  zec_usd: string; // aggregated ZEC/USD spot
+  spread: string; // e.g. "0.10"
+  tuzis_per_zec: string; // 2Z per 1 ZEC after the spread
+  tuzi_per_usd: number; // 100 (2Z == $0.01)
+  usd_per_tuzi: string; // e.g. "0.01"
+  num_sources: number; // exchanges in the average
+  sources: Record<string, string>; // per-exchange ZEC/USD quotes
+  updated_at: string; // ISO datetime
+  stale: boolean; // older than the freshness window
+  bootstrap: boolean; // cold-start estimate — present as an estimate only
+  card: CardFees;
+}
+
+/** Exact amounts to buy N 2Z — GET /api/pricing/quote/?tuzis=N. */
+export interface PricingQuote {
+  tuzis: number;
+  zec_amount: string; // ZEC to send (8dp) — display directly, don't recompute
+  card_cents: number; // USD cents Stripe would charge
+  tuzis_per_zec: string;
+  zec_usd: string;
+  updated_at: string; // ISO datetime
+  stale: boolean;
+  bootstrap: boolean;
+}

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -29,6 +29,20 @@ export interface SessionToken {
   expiry?: string;
 }
 
+/** GET /api/otp/status/ — whether the signed-in account has TOTP 2FA enabled. */
+export interface OtpStatus {
+  enabled: boolean;
+}
+
+/**
+ * Result of a username/password sign-in. Either the session is fully
+ * established, or a second factor (a 6-digit TOTP code) is still required and
+ * the caller must finish via `auth.completeOtp`.
+ */
+export type LoginResult =
+  | { status: "complete"; user: AuthUser }
+  | { status: "otp_required"; username: string };
+
 // ── AI ────────────────────────────────────────────────────────────────────
 export interface AIModel {
   id: string;

--- a/wallet/zuuli/src/lib/env.ts
+++ b/wallet/zuuli/src/lib/env.ts
@@ -12,9 +12,11 @@ function readEnv(key: string, fallback: string): string {
 }
 
 // In dev / `tauri dev` (import.meta.env.DEV), talk to the API via a same-origin
-// relative base so the Vite proxy handles it (no CORS). In a production build
-// use the absolute host (reached through tauri-plugin-http, which isn't subject
-// to browser CORS). Override either with VITE_F2Z_API / VITE_F2Z_MEDIA.
+// relative base so the Vite proxy handles it (no CORS). The proxy target
+// defaults to staging (stage.free2z.cash) during development — see
+// vite.config.ts / VITE_F2Z_PROXY. In a production build use the absolute host
+// below (reached through tauri-plugin-http, which isn't subject to browser
+// CORS). Override either with VITE_F2Z_API / VITE_F2Z_MEDIA.
 const IS_DEV = Boolean(
   (import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV,
 );

--- a/wallet/zuuli/src/lib/env.ts
+++ b/wallet/zuuli/src/lib/env.ts
@@ -35,6 +35,14 @@ export const MEDIA_BASE = readEnv("VITE_F2Z_MEDIA", DEFAULT_API).replace(/\/$/, 
  */
 export const FORCE_MOCK = readEnv("VITE_MOCK", "") === "1";
 
+/**
+ * Mock-only: force the username/password path to require a 2FA (OTP) code so
+ * the code-entry step can be exercised offline (VITE_MOCK_OTP=1). Even without
+ * this flag, any mock username containing "otp" triggers the 2FA step. The mock
+ * accepts the code `123456`.
+ */
+export const MOCK_OTP = readEnv("VITE_MOCK_OTP", "") === "1";
+
 /** Dyte SDK base — used to construct join URLs for livestreams. */
 export const DYTE_BASE = readEnv("VITE_DYTE_BASE", "https://app.dyte.io");
 

--- a/wallet/zuuli/src/lib/wallet/mock.ts
+++ b/wallet/zuuli/src/lib/wallet/mock.ts
@@ -108,8 +108,11 @@ export const mockWallet = {
     };
   },
   startSync() {
+    // Idempotent, like the real engine: resuming an already-caught-up wallet
+    // keeps it synced (it just watches for new blocks) rather than rewinding.
+    // Only rewind for a fresh wallet that has never synced.
     syncing = true;
-    synced = tip - 3200;
+    if (synced >= tip) synced = tip;
   },
   stopSync() {
     syncing = false;

--- a/wallet/zuuli/src/store/wallet.ts
+++ b/wallet/zuuli/src/store/wallet.ts
@@ -16,9 +16,25 @@ interface WalletState {
   bootstrap: () => Promise<void>;
   refreshBalance: () => Promise<void>;
   refreshSync: () => Promise<void>;
+  startSyncPolling: () => void;
+  stopSyncPolling: () => void;
 }
 
-export const useWallet = create<WalletState>((set) => ({
+// Background sync poll — a single self-scheduling timer shared app-wide, so the
+// balance and sync chip update on their own with no user action ("no fanfare").
+// Fast cadence while catching up, relaxed cadence once caught up. Note the
+// engine reports `syncing: true` even at the chain tip (it keeps watching for
+// new blocks), so "caught up" is judged by height, not the syncing flag.
+const POLL_CATCHING_UP_MS = 6_000;
+const POLL_CAUGHT_UP_MS = 30_000;
+let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+function isCaughtUp(sync: SyncStatus | null): boolean {
+  if (!sync) return false;
+  return sync.chainTip > 0 && sync.syncedHeight >= sync.chainTip;
+}
+
+export const useWallet = create<WalletState>((set, get) => ({
   status: null,
   balance: null,
   sync: null,
@@ -36,6 +52,14 @@ export const useWallet = create<WalletState>((set) => ({
           wallet.getSyncStatus(),
         ]);
         set({ balance, unifiedAddress: address, sync });
+        // Resume syncing automatically on every launch. `start_sync` is
+        // idempotent on the backend (a no-op when a sync is already running),
+        // so this is safe to fire-and-forget and tolerant of "already syncing".
+        void wallet.startSync().catch(() => {
+          /* already syncing / db not ready yet — ignore */
+        });
+        // Keep a quiet background poll running so the UI stays live.
+        get().startSyncPolling();
       }
     } catch {
       set({ loading: false });
@@ -57,6 +81,40 @@ export const useWallet = create<WalletState>((set) => ({
       set({ sync });
     } catch {
       /* ignore */
+    }
+  },
+
+  startSyncPolling() {
+    if (pollTimer !== null) return; // already polling — keep the singleton
+
+    const tick = async () => {
+      let caughtUp = false;
+      try {
+        const prev = get().sync;
+        const sync = await wallet.getSyncStatus();
+        set({ sync });
+        caughtUp = isCaughtUp(sync);
+        // When new blocks land, refresh the balance so it updates on its own.
+        if (!prev || sync.syncedHeight !== prev.syncedHeight) {
+          void get().refreshBalance();
+        }
+      } catch {
+        /* transient error — keep polling */
+      }
+      pollTimer = setTimeout(
+        tick,
+        caughtUp ? POLL_CAUGHT_UP_MS : POLL_CATCHING_UP_MS,
+      );
+    };
+
+    // bootstrap already fetched an initial status; schedule the next check.
+    pollTimer = setTimeout(tick, POLL_CATCHING_UP_MS);
+  },
+
+  stopSyncPolling() {
+    if (pollTimer !== null) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
     }
   },
 }));

--- a/wallet/zuuli/vite.config.ts
+++ b/wallet/zuuli/vite.config.ts
@@ -4,9 +4,11 @@ import path from "node:path";
 
 const host = process.env.TAURI_DEV_HOST;
 // Where the dev/`tauri dev` proxy forwards /api and /uploadz. Defaults to
-// production; point it at a local backend to test unshipped endpoints, e.g.
+// staging (stage.free2z.cash tracks latest main) during development; override
+// to point at production or a local backend to test unshipped endpoints, e.g.
+//   VITE_F2Z_PROXY=https://free2z.cash npm run tauri dev
 //   VITE_F2Z_PROXY=http://localhost:8000 npm run tauri dev
-const apiTarget = process.env.VITE_F2Z_PROXY || "https://free2z.cash";
+const apiTarget = process.env.VITE_F2Z_PROXY || "https://stage.free2z.cash";
 
 // ZUULI dev server runs on 1423 so it never collides with the zuuallet
 // reference wallet (1421). Tauri drives this via beforeDevCommand.


### PR DESCRIPTION
Re-lands the ZUULI fixes that were lost when local main was reset to origin/main (they were never pushed). Each was previously verified (typecheck+build). Squash-merging brings them onto remote main so local can fast-forward.

- fix: register tauri-plugin-http + dev transport via Vite proxy — restores article feed & Zcash login reaching the backend
- fix: drive ZEC buy quote off live /api/pricing (no more hardcoded $42)
- feat: auto-resume wallet sync on launch, quiet status (no manual fanfare)
- chore: target stage.free2z.cash for the dev API proxy
- feat: method-agnostic login (password + 2FA/OTP first-class; Zcash a peer; X/Google 'soon')