### PR TITLE
docs: trunk IRON RULE — local main only fast-forwards from remote

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,29 @@
 # Working in `zuu` — the contribution doctrine
 
+## IRON RULE — local `main` is read-only
+
+**LOCAL `main` NEVER CHANGES EXCEPT BY FAST-FORWARD PULL FROM THE REMOTE.**
+No agent — and no human — ever commits or merges to local `main`. Not once, not
+for a "trivial" one-liner. Every change, without exception, flows through this
+exact cycle:
+
+1. `git fetch origin`, then create a **worktree branched from `origin/main`**
+   (never from local `main`):
+   `git worktree add -b <type>/<slug> <path> origin/main`.
+2. Make the changes in the worktree; verify.
+3. Push the branch to `origin` and open a **PR** against `main`.
+4. **Squash-merge the PR onto the REMOTE** `origin/main` (`gh pr merge --squash`,
+   honoring the repo's merge queue / required checks).
+5. Local `main` is updated **only** by `git pull --ff-only origin main` in the
+   primary working tree. It must ALWAYS equal `origin/main` and must NEVER be
+   ahead of the remote.
+
+**Why this is absolute:** an un-pushed commit on local `main` is not saved —
+`git reset --hard origin/main` or a fresh re-clone silently destroys it, and
+nothing is durable until it lands on `origin`. Keeping local `main` a pure
+fast-forward mirror of the remote means the human always sits on a clean `main`
+that only ever moves forward, and every change carries a reviewable PR trail.
+
 `zuu` is a **synthetic monorepo**. The `z/` directory vendors Zcash-ecosystem
 repos as git submodules (`z/{github-org}/{repo}`) so we can depend on them **in
 source** — build, test, and integrate against real upstream code rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,30 @@
 Read **[AGENTS.md](./AGENTS.md)** first — it is the contribution doctrine for
 this repo:
 
+## IRON RULE — local `main` is read-only
+
+**LOCAL `main` NEVER CHANGES EXCEPT BY FAST-FORWARD PULL FROM THE REMOTE.**
+No agent — and no human — ever commits or merges to local `main`. Not once, not
+for a "trivial" one-liner. Every change, without exception, flows through this
+exact cycle:
+
+1. `git fetch origin`, then create a **worktree branched from `origin/main`**
+   (never from local `main`):
+   `git worktree add -b <type>/<slug> <path> origin/main`.
+2. Make the changes in the worktree; verify.
+3. Push the branch to `origin` and open a **PR** against `main`.
+4. **Squash-merge the PR onto the REMOTE** `origin/main` (`gh pr merge --squash`,
+   honoring the repo's merge queue / required checks).
+5. Local `main` is updated **only** by `git pull --ff-only origin main` in the
+   primary working tree. It must ALWAYS equal `origin/main` and must NEVER be
+   ahead of the remote.
+
+**Why this is absolute:** an un-pushed commit on local `main` is not saved —
+`git reset --hard origin/main` or a fresh re-clone silently destroys it, and
+nothing is durable until it lands on `origin`. Keeping local `main` a pure
+fast-forward mirror of the remote means the human always sits on a clean `main`
+that only ever moves forward, and every change carries a reviewable PR trail.
+
 - `zuu` is a **synthetic monorepo**; `z/` vendors Zcash-ecosystem repos as
   submodules so we depend on them **in source**.
 - We **stay on upstream HEAD** and **contribute fixes** rather than pinning to

--- a/docs/PARALLEL-AGENTS.md
+++ b/docs/PARALLEL-AGENTS.md
@@ -2,6 +2,32 @@
 
 How multiple Claude agents work on `zuu` concurrently without creating a clusterfuck on the local branch. Read this together with [AGENTS.md](../AGENTS.md).
 
+## IRON RULE — local `main` is read-only
+
+This is the one rule that makes everything below work. If you read nothing else, read this.
+
+**LOCAL `main` NEVER CHANGES EXCEPT BY FAST-FORWARD PULL FROM THE REMOTE.**
+No agent — and no human — ever commits or merges to local `main`. Not once, not
+for a "trivial" one-liner. Every change, without exception, flows through this
+exact cycle:
+
+1. `git fetch origin`, then create a **worktree branched from `origin/main`**
+   (never from local `main`):
+   `git worktree add -b <type>/<slug> <path> origin/main`.
+2. Make the changes in the worktree; verify.
+3. Push the branch to `origin` and open a **PR** against `main`.
+4. **Squash-merge the PR onto the REMOTE** `origin/main` (`gh pr merge --squash`,
+   honoring the repo's merge queue / required checks).
+5. Local `main` is updated **only** by `git pull --ff-only origin main` in the
+   primary working tree. It must ALWAYS equal `origin/main` and must NEVER be
+   ahead of the remote.
+
+**Why this is absolute:** an un-pushed commit on local `main` is not saved —
+`git reset --hard origin/main` or a fresh re-clone silently destroys it, and
+nothing is durable until it lands on `origin`. Keeping local `main` a pure
+fast-forward mirror of the remote means the human always sits on a clean `main`
+that only ever moves forward, and every change carries a reviewable PR trail.
+
 ## Roles
 - **Orchestrator** (the human + their lead agent) stays on `main`, always. Local `main` only ever fast-forwards to `origin/main` — never committed to, never left dirty. The orchestrator creates issues and dispatches subagents; it does not edit the working tree of `main`.
 - **Worker subagents** do all code changes, each in its **own git worktree** (via the Agent tool's `isolation: "worktree"`), so N agents build in parallel with zero working-tree collisions.

--- a/wallet/zuuli/CLAUDE.md
+++ b/wallet/zuuli/CLAUDE.md
@@ -8,6 +8,12 @@ credit economy — with **Login with Zcash** (no password, no email, no KYC).
 It is distinct from **`../zuuallet`**, the whitelabel *reference* wallet. Both
 apps share the Zcash engine in `../plugins/tauri-plugin-zcash` (the "guts").
 
+> **IRON RULE (trunk workflow):** local `main` is read-only — it only ever
+> fast-forwards from `origin/main`. Never commit or merge to local `main`; every
+> change goes through a worktree branched off `origin/main` → PR → squash-merge
+> on the remote. Full rule: [`../../AGENTS.md`](../../AGENTS.md) and
+> [`../../docs/PARALLEL-AGENTS.md`](../../docs/PARALLEL-AGENTS.md).
+
 ## Build / check commands
 
 ```bash


### PR DESCRIPTION
Adds an explicit, impossible-to-miss **IRON RULE** to the agent-facing docs: local `main` is read-only and changes ONLY by fast-forward pull from `origin/main`. No agent or human commits/merges to local `main`; every change goes through a worktree branched off `origin/main` → PR → squash-merge on the remote → `git pull --ff-only`.

Files changed:
- `CLAUDE.md` — IRON RULE section right after the intro
- `AGENTS.md` — IRON RULE as the first, boldest rule
- `docs/PARALLEL-AGENTS.md` — IRON RULE as the centerpiece
- `wallet/zuuli/CLAUDE.md` — short pointer to the repo-root doctrine

Rationale documented in-line: un-pushed local-main commits get silently destroyed by `git reset --hard origin/main` / re-clones; nothing is durable until it's on origin; the human sits on a clean `main` that only fast-forwards.