### PR TITLE
fix(zuuli): catch-all 404 route

### DIFF
--- a/wallet/zuuli/src/App.tsx
+++ b/wallet/zuuli/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { AppShell } from "@/components/layout/AppShell";
+import { NotFound } from "@/components/common/NotFound";
 import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
 
@@ -38,6 +39,9 @@ export default function App() {
             <Route path="/live/*" element={<LiveFeature />} />
             <Route path="/articles/*" element={<ArticlesFeature />} />
             <Route path="/buy/*" element={<BuyFeature />} />
+
+            {/* Catch-all: unknown paths render a NotFound inside the shell */}
+            <Route path="*" element={<NotFound />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/wallet/zuuli/src/components/common/NotFound.tsx
+++ b/wallet/zuuli/src/components/common/NotFound.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+import { Compass } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/common/EmptyState";
+
+export function NotFound() {
+  return (
+    <div className="animate-slide-up py-8">
+      <EmptyState
+        icon={Compass}
+        title="Page not found"
+        description="This page doesn't exist or has moved. Let's get you back on track."
+        action={
+          <Button asChild>
+            <Link to="/" aria-label="Back to Discover">
+              Back to Discover
+            </Link>
+          </Button>
+        }
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #173.

Unknown paths (typos, stale deep links) matched the `AppShell` parent route but no child `Route`, so `<Outlet/>` rendered nothing — the user saw sidebar/topbar chrome with a blank content area.

## Fix
- Add a catch-all `<Route path="*">` **inside** the `AppShell` route group, rendering a new `NotFound` component.
- `NotFound` (`src/components/common/NotFound.tsx`) uses the existing `<EmptyState>` with a Compass icon and a "Back to Discover" `<Link to="/">` action.
- Semantic tokens only, no emojis in chrome, `animate-slide-up` entrance — per `wallet/zuuli/CLAUDE.md` design rules.
- The full-screen `/login` route stays outside the shell, unchanged. Mock/browser mode unaffected (pure client routing).

## Verification
- `npm run typecheck` passes.
- `npm run build` passes.