### PR TITLE
fix(zuuli): TipDialog balance guard + 2Z decrement

### DIFF
--- a/wallet/zuuli/src/features/articles/components/TipDialog.tsx
+++ b/wallet/zuuli/src/features/articles/components/TipDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { Heart, Loader2 } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, Heart, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,24 +17,29 @@ import { Label } from "@/components/ui/label";
 import { tuzi } from "@/lib/api/free2z";
 import { formatTuzis } from "@/lib/format";
 import { cn } from "@/lib/utils";
+import { useSession } from "@/store/session";
 import type { SimpleCreator } from "@/lib/api/types";
 
 const PRESETS = [50, 100, 250, 500];
 
 export function TipDialog({ author }: { author: SimpleCreator }) {
   const name = author.display_name || author.username;
+  const navigate = useNavigate();
+  const tuzis = useSession((s) => s.tuzis);
+  const adjustTuzis = useSession((s) => s.adjustTuzis);
   const [open, setOpen] = useState(false);
   const [amount, setAmount] = useState(100);
   const [sending, setSending] = useState(false);
 
+  const enough = amount <= tuzis;
+  const canSend = amount > 0 && enough && !sending;
+
   async function send() {
-    if (amount <= 0) {
-      toast.error("Enter an amount greater than zero.");
-      return;
-    }
+    if (!canSend) return;
     setSending(true);
     try {
       await tuzi.donate(author.username, amount);
+      adjustTuzis(-amount);
       toast.success(`Sent ${formatTuzis(amount)} to ${name}`);
       setOpen(false);
     } catch {
@@ -90,6 +96,9 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
               onChange={(e) => setAmount(Math.max(0, Number(e.target.value)))}
               className="tabular-nums"
             />
+            <p className="text-xs text-muted-foreground tabular-nums">
+              Balance: {formatTuzis(tuzis)}
+            </p>
           </div>
         </div>
 
@@ -101,16 +110,29 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
           >
             Cancel
           </Button>
-          <Button onClick={send} disabled={sending}>
-            {sending ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                Sending
-              </>
-            ) : (
-              <>Send {formatTuzis(amount)}</>
-            )}
-          </Button>
+          {amount > 0 && !enough ? (
+            <Button
+              variant="outline"
+              onClick={() => {
+                setOpen(false);
+                navigate("/buy");
+              }}
+            >
+              Not enough 2Z — buy more
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Button>
+          ) : (
+            <Button onClick={send} disabled={!canSend}>
+              {sending ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  Sending
+                </>
+              ) : (
+                <>Send {formatTuzis(amount)}</>
+              )}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
Closes #170.

`articles/TipDialog` now mirrors the `buy/SendTab` pattern:

- Reads `tuzis` from the session store and computes `enough = amount <= tuzis`.
- Blocks overspend: when `amount > tuzis` the Send button is replaced by a "Not enough 2Z — buy more" action that closes the dialog and navigates to `/buy` (same UX as SendTab's `onNeedBuy`).
- The Send button is gated by `canSend` (amount > 0, enough, not sending).
- On successful `tuzi.donate`, calls `adjustTuzis(-amount)` so the top-bar 2Z chip and all balance-reading surfaces update immediately, without waiting for an `auth.me()` refresh.
- Shows the current balance under the amount input.

typecheck (`tsc --noEmit`) and build (`tsc && vite build`) both pass.