### PR TITLE
fix(zuuli): server-nonce Zcash login, private-stream secret, real tx kinds

### DIFF
--- a/wallet/zuuli/src/features/auth/useZcashLogin.ts
+++ b/wallet/zuuli/src/features/auth/useZcashLogin.ts
@@ -76,19 +76,6 @@ const freshSteps = (): Steps => ({
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-/** A one-time nonce, from the CSPRNG when available. */
-function makeNonce(): string {
-  const c = globalThis.crypto;
-  if (c && "getRandomValues" in c) {
-    const bytes = new Uint8Array(16);
-    c.getRandomValues(bytes);
-    return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-  }
-  return (
-    Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2)
-  );
-}
-
 function errMessage(e: unknown): string {
   if (e instanceof Error && e.message) return e.message;
   if (typeof e === "string" && e) return e;
@@ -132,15 +119,18 @@ export function useZcashLogin(): ZcashLoginState {
   // The crypto half of the flow: challenge → sign → verify → session.
   const runCrypto = useCallback(async () => {
     try {
-      // 2 — Request a challenge + resolve the address to sign with.
+      // 2 — Resolve the address, then ask the SERVER for the challenge to
+      //     sign. The one-time, timestamped nonce must come from free2z so it
+      //     can record/expire it and reject replays — a client-minted string
+      //     would carry no such binding.
       setStep("challenge", "active");
       await wait(450);
-      const challenge = `zuuli-login:${makeNonce()}:${Date.now()}`;
       const addr = await wallet.getUnifiedAddress(0);
       setAddress(addr);
+      const { challenge } = await auth.zcashChallenge(addr);
       setStep("challenge", "done");
 
-      // 3 — Sign the challenge with the wallet key (ZIP-304).
+      // 3 — Sign the server's exact challenge with the wallet key (ZIP-304).
       setStep("sign", "active");
       await wait(500);
       const signed = await wallet.signChallenge(challenge);

--- a/wallet/zuuli/src/features/buy/ActivityTab.tsx
+++ b/wallet/zuuli/src/features/buy/ActivityTab.tsx
@@ -57,20 +57,24 @@ export function ActivityTab() {
 
   return (
     <div className="space-y-4">
-      {/* Summary chips */}
-      <div className="grid gap-3 sm:grid-cols-2">
+      {/* Summary chips — "Total spent" only appears once there is real spend
+          (the purchases-only Stripe ledger has none, so it isn't shown as a
+          permanent 0). */}
+      <div className={cn("grid gap-3", spent > 0 && "sm:grid-cols-2")}>
         <SummaryChip
           icon={TrendingUp}
           label="Total bought"
           tuzis={bought}
           tone="credit"
         />
-        <SummaryChip
-          icon={TrendingDown}
-          label="Total spent"
-          tuzis={spent}
-          tone="debit"
-        />
+        {spent > 0 ? (
+          <SummaryChip
+            icon={TrendingDown}
+            label="Total spent"
+            tuzis={spent}
+            tone="debit"
+          />
+        ) : null}
       </div>
 
       {/* Rows */}

--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -319,11 +319,14 @@ function JoinPanel({
   const price = stream.price_tuzis;
   const affordable = tuzis >= price;
 
-  async function doJoin(action?: () => Promise<void>): Promise<boolean> {
+  async function doJoin(
+    action?: () => Promise<void>,
+    joinSecret?: string,
+  ): Promise<boolean> {
     setBusy(true);
     try {
       if (action) await action();
-      const ticket = await live.join(stream.username, stream.kind);
+      const ticket = await live.join(stream.username, stream.kind, joinSecret);
       onJoined(ticket);
       return true;
     } catch (e) {
@@ -498,7 +501,7 @@ function JoinPanel({
             onSubmit={(e) => {
               e.preventDefault();
               if (!secret.trim() || busy) return;
-              void doJoin();
+              void doJoin(undefined, secret);
             }}
           >
             <div className="space-y-1.5">

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -518,19 +518,44 @@ export const live = {
   /**
    * Join a stream. For PPV/subscriber streams the backend debits 2Zs / checks
    * entitlement before returning a ticket; a 402 means "buy more 2Zs / subscribe".
+   *
+   * Private streams are gated by a server-issued secret that the viewer must
+   * supply. They join at a DISTINCT endpoint — POST /api/dyte/{username}/private/{secret}
+   * (a UUID path segment) — where the backend 404s a wrong/absent secret; the
+   * plain POST /api/dyte/{username}/private route only lets the creator manage
+   * their room. All other kinds go to POST /api/dyte/{username}/{type}.
    */
-  async join(username: string, kind: StreamKind): Promise<DyteJoinTicket> {
+  async join(
+    username: string,
+    kind: StreamKind,
+    secret?: string,
+  ): Promise<DyteJoinTicket> {
     if (useMock()) {
       await delay(600);
+      if (kind === "private" && !mockSecretUnlocks(secret)) {
+        throw new Error(
+          `That secret didn't unlock the room. (Mock mode expects "${MOCK_ROOM_SECRET}".)`,
+        );
+      }
       return { authToken: "mock-part", meetingId: "mock", roomName: "zuuli-live", as: "participant" };
     }
-    const r = await request<{ meeting_id: string; auth_token: string }>(
-      `/api/dyte/${username}/${TYPE_FROM_KIND[kind]}`,
-      { method: "POST" },
-    );
-    return { authToken: r.auth_token, meetingId: r.meeting_id, as: "participant" };
+    const path =
+      kind === "private"
+        ? `/api/dyte/${username}/private/${encodeURIComponent((secret ?? "").trim())}`
+        : `/api/dyte/${username}/${TYPE_FROM_KIND[kind]}`;
+    // The private-join response omits meeting_id (returns { e2ee, auth_token }).
+    const r = await request<{ meeting_id?: string; auth_token: string }>(path, {
+      method: "POST",
+    });
+    return { authToken: r.auth_token, meetingId: r.meeting_id ?? "", as: "participant" };
   },
 };
+
+/** Mock private-room secret so the private-join gate is demoable offline. */
+const MOCK_ROOM_SECRET = "let-me-in";
+function mockSecretUnlocks(secret?: string): boolean {
+  return (secret ?? "").trim().toLowerCase() === MOCK_ROOM_SECRET;
+}
 
 // ─── Tuzi (2Z) economy ───────────────────────────────────────────────────────
 export const tuzi = {

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -564,10 +564,16 @@ export const tuzi = {
       await delay();
       return mockTransactions;
     }
+    // /api/stripe/transactions/ is the card-purchase ledger: every row is a
+    // BUY that credits 2Zs (tuzis_credited is a PositiveIntegerField, so it is
+    // never a debit). Preserve any kind the payload carries and default to
+    // "buy" for these purchases rather than blanket-overwriting every row.
+    // (The full spend mix — tips/AI/PPV/subscriptions — lives in the /api/events/
+    // ledger; ActivityTab scopes its "Total spent" to whatever spend it sees.)
     const page = await request<Paginated<TuziTransaction>>(
       "/api/stripe/transactions/",
     );
-    return (page.results ?? []).map((t) => ({ ...t, kind: "buy" as const }));
+    return (page.results ?? []).map((t) => ({ ...t, kind: t.kind ?? "buy" }));
   },
 
   /**


### PR DESCRIPTION
Closes #166. Closes #167. Closes #172.

Three ZUULI fixes, one commit each, all wired to the real free2z/tuzi backend contracts.

## #166 — Zcash login signs the SERVER nonce (security, high)
`useZcashLogin.runCrypto` minted its own `zuuli-login:${nonce}:${Date.now()}` challenge and signed that, so the advertised server nonce-binding / replay protection never existed and `auth.zcashChallenge` was dead code. Now it resolves the address, fetches the server challenge via `auth.zcashChallenge(address)` → `POST /api/auth/zcash/challenge/`, signs THAT exact string through the wallet bridge (`signChallenge`), then calls `auth.zcashLogin`. The unused client-nonce helper is removed. Mock mode still completes end-to-end (mock `zcashChallenge` returns a value).

## #167 — private-stream secret reaches the backend gate (security, high)
The "Secret phrase" field only enabled the button; `live.join(username, kind)` never carried it, so any non-empty string unlocked the room client-side. Backend contract (tuzi `apps/dyte`): private rooms join at the distinct route `POST /api/dyte/{username}/private/{secret}` where `secret` is the server-issued UUID and the view `get_object_or_404(CreatorMeeting, meeting_type=PRIVATE, secret=secret)` 404s a wrong/absent secret — the plain `/private` route is creator-only management. `live.join` now takes `secret?`, posts private joins to that gated endpoint (tolerating the meeting_id-less `{ e2ee, auth_token }` response), and `Room.doJoin` forwards the field. Mock accepts/rejects against a known secret so the gate is demoable offline.

## #172 — real tx kinds, honest "Total spent" (data, low-med)
`tuzi.transactions()` force-overwrote every `/api/stripe/transactions/` row to `kind:"buy"`. That endpoint is genuinely purchases-only — `StripeTransaction.tuzis_credited` is a `PositiveIntegerField` and the serializer (`fields='__all__'`) carries no kind — so "Total spent" (derived from `tuzis_credited < 0`) was structurally always 0. Now the mapper preserves/derives kind instead of blanket-overwriting, and ActivityTab renders "Total spent" only when there is real spend, so purchases-only data isn't misrepresented with a permanent 0. Mock keeps its varied kinds (buy/ai/ppv/donate) and shows both chips. (The full spend mix lives in the `/api/events/` ledger — a mixed social+financial notifications feed — left as a follow-up rather than repurposed here.)

## Verification
`npm run typecheck` and `npm run build` both pass.