### PR TITLE
fix(zuuli): address truncation keeps trailing digits

### DIFF
--- a/wallet/zuuli/src/components/ui/dialog.tsx
+++ b/wallet/zuuli/src/components/ui/dialog.tsx
@@ -32,7 +32,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-slide-up sm:rounded-xl",
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-dialog-in sm:rounded-xl",
         className,
       )}
       {...props}

--- a/wallet/zuuli/src/features/auth/ZcashLoginFlow.tsx
+++ b/wallet/zuuli/src/features/auth/ZcashLoginFlow.tsx
@@ -156,7 +156,7 @@ export function ZcashLoginFlow() {
             Signing as
           </span>
           <code className="font-mono text-xs text-foreground" title={address}>
-            {truncateAddress(address, 10)}
+            {truncateAddress(address)}
           </code>
         </div>
       )}

--- a/wallet/zuuli/src/features/wallet/History.tsx
+++ b/wallet/zuuli/src/features/wallet/History.tsx
@@ -112,7 +112,7 @@ function HistoryRow({ tx }: { tx: TransactionEntry }) {
 
         <div className="flex items-center gap-1.5">
           <span className="font-mono text-xs text-muted-foreground/70">
-            {truncateAddress(tx.txid, 10)}
+            {truncateAddress(tx.txid)}
           </span>
           <CopyButton
             value={tx.txid}

--- a/wallet/zuuli/src/features/wallet/Send.tsx
+++ b/wallet/zuuli/src/features/wallet/Send.tsx
@@ -180,7 +180,7 @@ export function Send() {
       const txid = await wallet.executeSend(proposal.proposalId);
       setDialogOpen(false);
       toast.success("Transaction sent", {
-        description: `txid ${truncateAddress(txid, 8)}`,
+        description: `txid ${truncateAddress(txid)}`,
       });
       await refreshBalance();
       navigate("/wallet/history");
@@ -355,8 +355,8 @@ export function Send() {
           {proposal ? (
             <div className="space-y-3 rounded-lg border border-border bg-background/40 p-4 text-sm">
               <Row label="To">
-                <span className="font-mono text-xs">
-                  {truncateAddress(to.trim(), 12)}
+                <span className="break-all font-mono text-xs">
+                  {truncateAddress(to.trim())}
                 </span>
               </Row>
               <Row label="Amount">

--- a/wallet/zuuli/src/features/wallet/components.tsx
+++ b/wallet/zuuli/src/features/wallet/components.tsx
@@ -98,8 +98,8 @@ export function AddressCard({
         <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           Your unified address
         </div>
-        <div className="truncate font-mono text-sm text-foreground">
-          {truncateAddress(address, 14)}
+        <div className="break-all font-mono text-sm text-foreground">
+          {truncateAddress(address)}
         </div>
         <div className="pt-1">
           <CopyButton
@@ -151,8 +151,8 @@ export function TxRow({ tx }: { tx: TransactionEntry }) {
             {tx.memo}
           </p>
         ) : (
-          <p className="truncate font-mono text-xs text-muted-foreground/70">
-            {truncateAddress(tx.txid, 10)}
+          <p className="break-all font-mono text-xs text-muted-foreground/70">
+            {truncateAddress(tx.txid)}
           </p>
         )}
       </div>

--- a/wallet/zuuli/src/lib/format.ts
+++ b/wallet/zuuli/src/lib/format.ts
@@ -60,9 +60,24 @@ export function formatUsd(usd: number): string {
   });
 }
 
-export function truncateAddress(address: string, chars = 8): string {
-  if (address.length <= chars * 2 + 3) return address;
-  return `${address.slice(0, chars)}…${address.slice(-chars)}`;
+/**
+ * Shorten a long value (Zcash address, txid) for display while keeping the
+ * security-relevant *trailing* characters visible — those are what a human
+ * checks when verifying an address.
+ *
+ * Renders the first `head` and last `tail` characters joined by a single
+ * middle ellipsis (e.g. `u1st8hhxjv…q7x9gge4kd`). It never emits more than one
+ * ellipsis and always preserves the last `tail` characters. Only the rendered
+ * string is shortened — the full value is untouched, so callers keep it intact
+ * for copying/QR.
+ *
+ * NOTE: render the result WITHOUT a CSS `truncate`/`text-ellipsis` class. That
+ * clips the already-shortened string and clobbers the trailing digits with a
+ * second ellipsis. Use `break-all` if wrapping is a concern.
+ */
+export function truncateAddress(value: string, head = 8, tail = 10): string {
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
 }
 
 export function formatDate(timestamp: number | null): string {

--- a/wallet/zuuli/tailwind.config.cjs
+++ b/wallet/zuuli/tailwind.config.cjs
@@ -77,6 +77,14 @@ module.exports = {
           from: { opacity: "0", transform: "translateY(10px)" },
           to: { opacity: "1", transform: "translateY(0)" },
         },
+        // Dialog/modal entrance. Keeps the `-translate-x/y-1/2` centering baked
+        // into the transform so the content never jumps off-center mid-anim
+        // (a plain translateY keyframe overrides the centering and makes the
+        // panel jerk in from the lower-right before snapping to center).
+        "dialog-in": {
+          from: { opacity: "0", transform: "translate(-50%, -48%) scale(0.97)" },
+          to: { opacity: "1", transform: "translate(-50%, -50%) scale(1)" },
+        },
         "pulse-live": {
           "0%, 100%": { opacity: "1" },
           "50%": { opacity: "0.4" },
@@ -90,6 +98,7 @@ module.exports = {
         "accordion-up": "accordion-up 0.2s ease-out",
         "fade-in": "fade-in 0.3s ease-out",
         "slide-up": "slide-up 0.35s cubic-bezier(0.16, 1, 0.3, 1)",
+        "dialog-in": "dialog-in 0.2s cubic-bezier(0.16, 1, 0.3, 1)",
         "pulse-live": "pulse-live 1.4s ease-in-out infinite",
       },
       boxShadow: {


### PR DESCRIPTION
Closes #181.

## Address truncation (#181)
`truncateAddress` now shows the first ~8 and last ~10 characters with a single middle ellipsis (`u1st8hhxjv…q7x9gge4kd`), always preserving the security-relevant trailing digits. Signature is now `truncateAddress(value, head=8, tail=10)`.

The visible double-ellipsis (`u1st8hhxjvar77…gge…`) came from a CSS `truncate` class clipping the already-JS-shortened string; removed it (using `break-all` where wrapping matters) at the Receive unified-address card and the tx-id row. Full address stays intact for copy/QR. Applied consistently across all display sites: Receive AddressCard, tx history (History + components), Send review, Send toast, and the Zcash login stepper.

## Bonus: 'How Zcash login works' dialog animation
The dialog jerked in from the lower-right: the shadcn `DialogContent` is centered with `-translate-x/y-1/2` but used `animate-slide-up`, whose `translateY` keyframe overrode the centering transform mid-animation, so the panel started with its top-left corner at screen center and snapped back on completion. Added a `dialog-in` keyframe that bakes `translate(-50%,-50%)` into the animation so it rises smoothly in place.

Verified: `npm run typecheck` and `npm run build` both clean.