### PR TITLE
docs: trunk-based dev + review governance doctrine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,22 @@
 # Working in `zuu` — the contribution doctrine
 
+## eXtreme, Lean, Trunk-based development on steroids
+
+We ship a massive amount of work **in parallel, autonomously, with agents** — not
+by fiddling with a local worktree. The ONLY loop is:
+
+1. A human (or agent) names something that needs to change.
+2. **Subagents** do the work in **isolated worktrees** → **issues/PRs** →
+   automated **QA gate + adversarial review** → **squash-merge to `main` on the
+   remote**.
+3. Local `main` is **fast-forwarded from the remote** — the changes arrive
+   already reviewed, gated, and merged. Then repeat.
+
+**Never, ever, do we have a dirty local `main`.** Uncommitted changes sitting on
+the primary checkout is a process failure, not a deliverable. Nobody hands the
+human stray local edits to "review" — the whole point is that the PR pipeline
+already proved the change is good **before** it reaches local `main`.
+
 ## IRON RULE — local `main` is read-only
 
 **LOCAL `main` NEVER CHANGES EXCEPT BY FAST-FORWARD PULL FROM THE REMOTE.**
@@ -37,6 +54,19 @@ stability.**
 
 - **Parallel agents:** see [docs/PARALLEL-AGENTS.md](docs/PARALLEL-AGENTS.md)
   for how multiple agents collaborate through issues/worktrees/PRs.
+
+## Review governance — required, but never a bottleneck
+
+Branch protection **requires 1 approving review** on `main` — this is real
+governance, and **colleagues are always subject to it**; no one merges unreviewed.
+The reviewer, though, is almost always an **agent acting on the owner's behalf**,
+watching PRs and approving the instant CI is green so nobody is ever blocked.
+Skylar is the owner/CEO/CTO and moves at the speed of light: when no
+colleague-agent reviewer is around, the owner **overrides via admin** and keeps
+going (`enforce_admins=false`; `gh pr merge --squash --admin` **after** the CI
+`gate` is confirmed green). The admin path bypasses the *human* check, never the
+*QA* check — CI must be verified green first. In ~99.999% of cases the "human
+review" is simply an agent standing in for the owner, not a person.
 
 ## The prime directive: stay on the bleeding edge, and contribute the fixes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,19 @@
 Read **[AGENTS.md](./AGENTS.md)** first — it is the contribution doctrine for
 this repo:
 
+## eXtreme, Lean, Trunk-based development on steroids
+
+We ship a massive amount of work **in parallel, autonomously, with agents** — not
+by fiddling with a local worktree. The ONLY loop is: (1) something is named that
+needs changing → (2) **subagents** do it in **isolated worktrees** → issues/PRs →
+automated **QA gate + adversarial review** → **squash-merge to `main` on the
+remote** → (3) local `main` is **fast-forwarded from the remote** (already
+reviewed, gated, merged) → repeat.
+
+**Never, ever, do we have a dirty local `main`.** Leaving uncommitted changes on
+the primary checkout for a human to hand-review defeats the whole model — the
+pipeline proves the change is good **before** it reaches local `main`.
+
 ## IRON RULE — local `main` is read-only
 
 **LOCAL `main` NEVER CHANGES EXCEPT BY FAST-FORWARD PULL FROM THE REMOTE.**
@@ -36,6 +49,18 @@ that only ever moves forward, and every change carries a reviewable PR trail.
   transiently → resume `main` once merged**.
 - Moving the **whole ecosystem forward** takes priority over Zuuallet's own
   short-term stability.
+
+## Review governance — required, but never a bottleneck
+
+Branch protection **requires 1 approving review** on `main` — real governance,
+and **colleagues are always subject to it**; no one merges unreviewed. The
+reviewer is almost always an **agent acting on the owner's behalf**, watching PRs
+and approving the instant CI is green so nobody is blocked. Skylar (owner/CEO/CTO)
+moves at the speed of light and, when no reviewer-agent is around, **overrides via
+admin** (`enforce_admins=false`; `gh pr merge --squash --admin` **after** the CI
+`gate` is confirmed green — admin bypasses the *human* check, never the *QA*
+check). In ~99.999% of cases the "human review" is an agent standing in for the
+owner, not a person.
 
 Per-project specifics:
 


### PR DESCRIPTION
Adds two doctrine sections to both root `AGENTS.md` and `CLAUDE.md`, matching each file's existing prose style. All existing content (including the IRON RULE) is preserved.

## Section 1 — "eXtreme, Lean, Trunk-based development on steroids" (near the top)
- We ship massive parallel, autonomous work via agents — not by fiddling with a local worktree.
- The only loop: name a change → subagents work in isolated worktrees → issues/PRs → automated QA gate + adversarial review → squash-merge to `main` on the remote → local `main` fast-forwards from the remote → repeat.
- We never just have a dirty local `main`; the pipeline proves the change is good BEFORE it reaches local `main`.

## Section 2 — "Review governance — required, but never a bottleneck"
- Branch protection requires 1 approving review on `main`; colleagues are always governed — no one merges unreviewed.
- The reviewer is almost always an agent approving on the owner's behalf, the instant CI is green.
- The owner (Skylar, CEO/CTO) overrides via admin when no reviewer-agent is around (`enforce_admins=false`; `gh pr merge --squash --admin` only after the CI `gate` is green — admin bypasses the human check, never the QA check).
- In ~99.999% of cases the "human review" is an agent standing in for the owner.