### PR TITLE
fix(zuuli): accessible link contrast in zpage/article content

### DIFF
--- a/wallet/zuuli/src/components/common/Markdown.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.tsx
@@ -100,7 +100,11 @@ export function Markdown({
         "[&_h2]:mt-6 [&_h2]:text-xl [&_h2]:font-semibold",
         "[&_h3]:mt-4 [&_h3]:text-lg [&_h3]:font-semibold",
         "[&_p]:leading-relaxed",
-        "[&_a]:text-primary [&_a]:underline [&_a]:underline-offset-4",
+        // `text-link` (not `text-primary`): the brand violet at 65% lightness
+        // only clears ~4.3:1 against card surfaces, short of WCAG AA (4.5:1)
+        // for body-sized link text. `--link` is the same hue, lightened to
+        // 74%, which clears AA on every surface content renders on.
+        "[&_a]:text-link [&_a]:underline [&_a]:underline-offset-4 [&_a]:hover:decoration-2",
         "[&_ul]:list-disc [&_ul]:pl-6 [&_ol]:list-decimal [&_ol]:pl-6",
         "[&_li]:my-1",
         "[&_blockquote]:border-l-2 [&_blockquote]:border-primary [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:text-muted-foreground",

--- a/wallet/zuuli/src/index.css
+++ b/wallet/zuuli/src/index.css
@@ -13,6 +13,11 @@
     --popover-foreground: 0 0% 98%;
     --primary: 271 91% 65%;
     --primary-foreground: 0 0% 100%;
+    /* Lighter than --primary: used for hyperlinks in rendered content
+       (articles/zpages/AI chat) so they clear WCAG AA (4.5:1) against the
+       near-black background and card surfaces while staying in the same
+       violet hue as the brand accent. */
+    --link: 271 91% 74%;
     --secondary: 240 4% 20%;
     --secondary-foreground: 0 0% 98%;
     --muted: 240 4% 18%;
@@ -36,6 +41,7 @@
     --popover-foreground: 0 0% 98%;
     --primary: 271 91% 65%;
     --primary-foreground: 0 0% 100%;
+    --link: 271 91% 74%;
     --secondary: 240 5% 18%;
     --secondary-foreground: 0 0% 98%;
     --muted: 240 5% 16%;

--- a/wallet/zuuli/tailwind.config.cjs
+++ b/wallet/zuuli/tailwind.config.cjs
@@ -19,6 +19,10 @@ module.exports = {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
         },
+        // Lighter violet used for hyperlinks in rendered content (see
+        // src/index.css) so link text meets WCAG AA contrast on dark
+        // backgrounds without changing the app-wide --primary accent.
+        link: "hsl(var(--link))",
         secondary: {
           DEFAULT: "hsl(var(--secondary))",
           foreground: "hsl(var(--secondary-foreground))",


### PR DESCRIPTION
## Problem

Hyperlinks inside rendered markdown content (articles, zpage/creator bio, AI chat — all routed through the single shared `Markdown` component) used `--primary` (`hsl(271 91% 65%)`, `#a855f7`-ish).

Against the page background (`--background: hsl(240 8% 8%)`) that's ~4.69:1 — barely passes AA. But links in this app frequently render on `bg-card` (`hsl(240 6% 12%)`) — e.g. the AI chat assistant bubble, the creator bio card, the article-composer preview card — where the same color only reaches **~4.25:1**, short of WCAG AA's 4.5:1 for body-sized text.

## Fix

Added a dedicated `--link` CSS variable: same hue/saturation as the brand violet (271, 91%), lightness raised from 65% to 74%. Wired it through `tailwind.config.cjs` as a `link` color token, and switched the shared `Markdown` component's anchor styling from `text-primary` to `text-link`. `--primary` itself (buttons, rings, badges, focus states) is untouched — this only affects link color in rendered content.

Also added `hover:decoration-2` (thicker underline on hover) for a bit of extra affordance without touching color/contrast.

## Before / after

| | color | vs page bg (`hsl(240 8% 8%)`) | vs card bg (`hsl(240 6% 12%)`) |
|---|---|---|---|
| **Before** (`--primary`, L65%) | `#a855f7`-ish | 4.69:1 | **4.25:1 (fails AA)** |
| **After** (`--link`, L74%) | `#bf80f9`-ish | **6.80:1** | **6.16:1** |

Both comfortably clear WCAG AA (4.5:1) for normal text on every surface the shared `Markdown` component renders on (page background and card surfaces alike).

## Files changed

- `wallet/zuuli/src/index.css` — add `--link: 271 91% 74%` to both `:root` and `.dark`
- `wallet/zuuli/tailwind.config.cjs` — expose `link: hsl(var(--link))` as a Tailwind color token
- `wallet/zuuli/src/components/common/Markdown.tsx` — anchor style: `text-primary` → `text-link`, plus `hover:decoration-2`

Since `Markdown` is the single shared renderer for articles (`Reader.tsx`), creator bio, article-composer preview (`Author.tsx`), and AI chat, this fix applies consistently across all content surfaces from one change.

## Verification

- `npm run typecheck` — clean
- `npm run build` — succeeds; confirmed compiled CSS contains `.text-link{color:hsl(var(--link))}`
- Contrast ratios computed via the standard WCAG relative-luminance formula (sRGB → linearized → relative luminance → `(L1+0.05)/(L2+0.05)`), converting the HSL tokens to RGB first.