### PR TITLE
chore(zuuli): present 2Z as platform credits, not convertible currency

### DIFF
--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -19,7 +19,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Markdown } from "@/components/common/Markdown";
 import { ai } from "@/lib/api/free2z";
 import type { AIModel, PromptResponse } from "@/lib/api/types";
-import { formatTuzis, formatUsd, initials, tuzisToUsd } from "@/lib/format";
+import { formatTuzis, initials } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { useSession } from "@/store/session";
 import { ModelPicker } from "./ModelPicker";
@@ -259,14 +259,12 @@ export default function AiFeature() {
               icon={Coins}
               label="This session"
               value={formatTuzis(sessionCost)}
-              sub={formatUsd(tuzisToUsd(sessionCost))}
               accent="text-primary"
             />
             <Meter
               icon={Wallet}
               label="Balance"
               value={formatTuzis(tuzis)}
-              sub={formatUsd(tuzisToUsd(tuzis))}
               accent={lowBalance ? "text-destructive" : "text-foreground"}
             />
           </div>
@@ -375,13 +373,11 @@ function Meter({
   icon: Icon,
   label,
   value,
-  sub,
   accent,
 }: {
   icon: typeof Coins;
   label: string;
   value: string;
-  sub: string;
   accent: string;
 }) {
   return (
@@ -393,7 +389,6 @@ function Meter({
       <div className={cn("text-sm font-semibold tabular-nums", accent)}>
         {value}
       </div>
-      <div className="text-[10px] tabular-nums text-muted-foreground">{sub}</div>
     </div>
   );
 }

--- a/wallet/zuuli/src/features/articles/components/TipDialog.tsx
+++ b/wallet/zuuli/src/features/articles/components/TipDialog.tsx
@@ -61,7 +61,7 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
         <DialogHeader>
           <DialogTitle>Tip {name}</DialogTitle>
           <DialogDescription>
-            Send 2Zs straight to the author. 1 2Z = 1 cent.
+            Send 2Zs straight to the author, from your platform credit balance.
           </DialogDescription>
         </DialogHeader>
 

--- a/wallet/zuuli/src/features/buy/ActivityTab.tsx
+++ b/wallet/zuuli/src/features/buy/ActivityTab.tsx
@@ -7,7 +7,7 @@ import { EmptyState } from "@/components/common/EmptyState";
 import { tuzi } from "@/lib/api/free2z";
 import type { TuziTransaction } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
-import { formatTuzis, formatUsd, timeAgo, tuzisToUsd } from "@/lib/format";
+import { formatTuzis, timeAgo } from "@/lib/format";
 import { kindMeta, kindIconClass } from "./lib";
 
 export function ActivityTab() {
@@ -122,9 +122,6 @@ export function ActivityTab() {
                   >
                     {credit ? "+" : "−"}
                     {formatTuzis(Math.abs(t.tuzis_credited))}
-                  </div>
-                  <div className="text-xs tabular-nums text-muted-foreground">
-                    {formatUsd(tuzisToUsd(Math.abs(t.tuzis_credited)))}
                   </div>
                 </div>
               </div>

--- a/wallet/zuuli/src/features/buy/BalanceHero.tsx
+++ b/wallet/zuuli/src/features/buy/BalanceHero.tsx
@@ -4,11 +4,13 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
-import { formatUsd, formatZecTrim, tuzisToUsd } from "@/lib/format";
+import { formatZecTrim } from "@/lib/format";
 
 /**
- * The "two balances, one app" hero: 2Z credit balance front and centre with
- * its USD value, and the on-chain ZEC spendable alongside.
+ * The "two balances, one app" hero: 2Z platform-credit balance front and
+ * centre, and the on-chain ZEC spendable alongside. The 2Z balance is shown
+ * in 2Z units only — it's a spendable credit, not a cash value, so we never
+ * print a "$X" equivalent next to it.
  */
 export function BalanceHero() {
   const tuzis = useSession((s) => s.tuzis);
@@ -34,8 +36,8 @@ export function BalanceHero() {
             </span>
             <span className="text-lg font-semibold text-primary">2Z</span>
           </div>
-          <div className="text-sm text-muted-foreground tabular-nums">
-            {formatUsd(tuzisToUsd(tuzis))} in spendable credit
+          <div className="text-sm text-muted-foreground">
+            Spendable platform credit
           </div>
         </div>
 

--- a/wallet/zuuli/src/features/buy/BuyTab.tsx
+++ b/wallet/zuuli/src/features/buy/BuyTab.tsx
@@ -321,7 +321,7 @@ export function BuyTab() {
           </DialogHeader>
           <div className="space-y-3 rounded-lg border border-border bg-secondary/40 p-4 text-sm">
             <Row label="You receive" value={formatTuzis(amount)} strong />
-            <Row label="USD value" value={formatUsd(usd)} />
+            <Row label="Price" value={formatUsd(usd)} />
             <Separator />
             <Row
               label={

--- a/wallet/zuuli/src/features/buy/SendTab.tsx
+++ b/wallet/zuuli/src/features/buy/SendTab.tsx
@@ -17,7 +17,7 @@ import { discover, tuzi } from "@/lib/api/free2z";
 import type { SimpleCreator } from "@/lib/api/types";
 import { useSession } from "@/store/session";
 import { cn } from "@/lib/utils";
-import { formatTuzis, formatUsd, initials, tuzisToUsd } from "@/lib/format";
+import { formatTuzis, initials } from "@/lib/format";
 import { MAX_TUZIS, TIP_PRESETS, parseTuzis } from "./lib";
 
 export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
@@ -162,9 +162,7 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
               aria-label="Custom tip amount in 2Z"
             />
             <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm font-medium tabular-nums text-muted-foreground">
-              {custom.trim() && parseTuzis(custom) > 0
-                ? formatUsd(tuzisToUsd(parseTuzis(custom)))
-                : "2Z"}
+              2Z
             </span>
           </div>
         </div>
@@ -189,11 +187,6 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
               <div className="text-xl font-bold tabular-nums">
                 {validAmount ? formatTuzis(amount) : "—"}
               </div>
-              {validAmount && (
-                <div className="text-xs tabular-nums text-muted-foreground">
-                  {formatUsd(tuzisToUsd(amount))}
-                </div>
-              )}
             </div>
           </div>
           <div className="flex items-center justify-between border-t border-border pt-3 text-sm">

--- a/wallet/zuuli/src/features/buy/lib.ts
+++ b/wallet/zuuli/src/features/buy/lib.ts
@@ -1,8 +1,10 @@
-// Shared constants + helpers for the 2Z economy feature.
+// Shared constants + helpers for the 2Z platform-credit feature.
 //
-// 2Z ("Tuzi") = 1 US cent. Buying credits the session balance; spending
-// (tips/donations) debits it. The "pay with ZEC" cost is fetched live from the
-// backend pricing service (pricing.quote) — there is no client-side rate.
+// 2Z ("Tuzi") is a prepaid platform credit, not a currency — it has a
+// purchase price but no cash-out or exchange value. Buying credits the
+// session balance; spending (tips/donations) debits it. The "pay with ZEC"
+// cost is fetched live from the backend pricing service (pricing.quote) —
+// there is no client-side rate.
 
 import { TUZIS_PER_USD } from "@/lib/format";
 import type { TuziTransaction } from "@/lib/api/types";

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -355,7 +355,7 @@ function TipButton({ creator }: { creator: CreatorDetail }) {
         <DialogHeader>
           <DialogTitle>Tip {name}</DialogTitle>
           <DialogDescription>
-            Send 2Zs straight to the creator. 1 2Z = 1 cent.
+            Send 2Zs straight to the creator, from your platform credit balance.
           </DialogDescription>
         </DialogHeader>
 

--- a/wallet/zuuli/src/lib/format.ts
+++ b/wallet/zuuli/src/lib/format.ts
@@ -1,17 +1,24 @@
 // ─────────────────────────────────────────────────────────────────────────
 // Money & units for ZUULI.
 //
-// Two currencies live here:
-//   • ZEC — the on-chain asset. Amounts are zatoshis (1 ZEC = 1e8 zatoshis).
-//   • 2Z  ("Tuzi") — free2z platform credits. 1 Tuzi = 1 US cent ($0.01).
+// ZEC is the on-chain asset here (amounts are zatoshis, 1 ZEC = 1e8 zatoshis).
 //
-// The 2Z model is cost-plus: whatever an upstream service costs us in USD,
-// we round *up* to a whole number of 2Zs. Example from the spec:
+// 2Z ("Tuzi") is a free2z **platform credit** — not a currency, token, or
+// investment. It has a *purchase price* (you buy it for a fiat/ZEC amount,
+// same as any other prepaid credit) but no cash-out, redemption, or exchange
+// value: 2Z only ever spends on platform features (AI, tips, PPV,
+// subscriptions). `TUZIS_PER_USD` below is an internal cost-plus accounting
+// constant used to price purchases and meter AI usage — it is not a
+// user-facing exchange rate and must never be displayed as one (no "1 2Z =
+// $X" / "worth $X" next to a balance).
+//
+// The 2Z pricing model is cost-plus: whatever an upstream service costs us
+// in USD, we round *up* to a whole number of 2Zs. Example from the spec:
 //   a prompt that costs us $0.0323478  →  ceil(3.23478¢)  →  4 2Zs.
 // ─────────────────────────────────────────────────────────────────────────
 
 export const ZATOSHIS_PER_ZEC = 100_000_000;
-export const TUZIS_PER_USD = 100; // 1 Tuzi === 1 cent
+export const TUZIS_PER_USD = 100; // internal cost-plus accounting constant, not a displayed exchange rate
 
 /** Format zatoshis as a plain ZEC string (8dp). */
 export function formatZec(zatoshis: number): string {
@@ -40,7 +47,12 @@ export function usdToTuzis(usd: number): number {
   return Math.max(0, Math.ceil(usd * TUZIS_PER_USD));
 }
 
-/** Convert 2Zs back to a USD number (exact, for display). */
+/**
+ * Convert a 2Z amount to a USD number, exact. Use ONLY to show the fiat
+ * *purchase price* of a 2Z pack/top-up (e.g. "2,000 2Z for $20") — never
+ * to show the "value" of an existing balance or a spend, which would imply
+ * 2Z is redeemable for cash.
+ */
 export function tuzisToUsd(tuzis: number): number {
   return tuzis / TUZIS_PER_USD;
 }
@@ -50,7 +62,7 @@ export function formatTuzis(tuzis: number): string {
   return `${Math.round(tuzis).toLocaleString()} 2Z`;
 }
 
-/** USD display for a 2Z balance/price. */
+/** USD display for a 2Z purchase price. Do not use for balances or spends. */
 export function formatUsd(usd: number): string {
   return usd.toLocaleString(undefined, {
     style: "currency",


### PR DESCRIPTION
## Why (legal/compliance rationale)

2Z (Tuzi) is a free2z platform credit — you buy it and spend it on features
(AI messages, tips/donations, PPV, subscriptions). Several places in the
ZUULI UI showed a `$` figure next to a 2Z **balance** or **spend**, or stated
the internal `1 2Z = 1 cent` conversion outright. Read together, that framing
risks implying 2Z is a currency/token with a fixed, redeemable cash value —
which it is not. This PR is a copy-only reframing to a "platform credit"
model: no cash-out, no redemption, no exchange rate shown to users.

## What changed

| File | Before → After |
|---|---|
| `features/buy/BalanceHero.tsx` | `"$19.87 in spendable credit"` under the 2Z balance → `"Spendable platform credit"` (no $ figure) |
| `features/ai/index.tsx` | "This session" and "Balance" cost meters had a `$X` sub-line under the 2Z figure → removed; `Meter` component's `sub` prop dropped |
| `features/buy/ActivityTab.tsx` | Every activity row (buys, tips, AI spend, PPV, subs) showed a `$X` line under the 2Z amount → removed (2Z units only) |
| `features/buy/SendTab.tsx` | Tip amount input suffix and the "Review tip" summary converted the tip to `$X` → removed; input suffix is now a static `2Z` unit label |
| `features/creator/index.tsx`, `features/articles/components/TipDialog.tsx` | Tip dialog subtitle said `"Send 2Zs straight to the creator/author. 1 2Z = 1 cent."` → `"…from your platform credit balance."` (drops the explicit exchange-rate statement) |
| `features/buy/BuyTab.tsx` | ZEC-purchase confirm dialog row labeled `"USD value"` → relabeled `"Price"` (still the purchase price, less "this is what your 2Z is worth" framing) |
| `lib/format.ts`, `features/buy/lib.ts` | Header comments reframed 2Z as a "platform credit" with a purchase price but no cash-out/redemption/exchange value; `TUZIS_PER_USD` and `tuzisToUsd`/`formatUsd` doc comments now say explicitly these exist for **purchase-price** display only, never for showing balance/spend "value" |

## Intentionally kept (legitimate — these are purchase prices, not redemption values)

- `features/buy/BuyTab.tsx` — the whole buy flow: pack prices ("2,000 2Z for
  $20"), the custom-amount USD preview, "You pay $X" checkout panel, and the
  ZEC quote. Buying 2Z for a fiat/ZEC price is a normal product purchase, not
  a claim that 2Z is convertible back to cash.
- `features/ai/ModelPicker.tsx` — the model-info tooltip's per-1K-token USD
  cost + markup multiplier. This discloses the upstream wholesale cost basis
  behind cost-plus billing; it isn't tied to the value of a user's own 2Z
  balance.
- `features/ai/providers.tsx` `pricePerMessage()` — already 2Z-unit only, no
  `$` shown.
- The word "2Z"/"Tuzi" as the credit's name, "metered in 2Zs" taglines,
  2Z balances/costs shown in 2Z units — all unchanged.
- `src/lib/api/free2z.ts` and the router were not touched, per the working
  agreement that other agents own those files.

## Ambiguous / flagged for a second look

- `features/ai/ModelPicker.tsx`'s USD-denominated per-token pricing tooltip
  (input/output $/1K, markup ×) — kept as legitimate cost-structure
  transparency, but it's the one place still showing raw USD figures inside
  the AI feature. Worth a compliance sanity-check if the bar is "no USD
  figures anywhere near the 2Z feature," though it does not reference the
  user's balance or imply redeemability.

## Verification

- `npm run typecheck` (`tsc --noEmit`) — clean.
- `npm run build` (`tsc && vite build`) — clean (pre-existing chunk-size
  warning only, unrelated to this change).
- Read every changed line in context before and after editing; no
  functional/behavioral changes — purchase flow, spend flow, and balance
  state management are untouched, only displayed copy/labels.