### PR TITLE
feat(zuuli): edit your own profile

### DIFF
--- a/wallet/zuuli/src/App.tsx
+++ b/wallet/zuuli/src/App.tsx
@@ -16,6 +16,7 @@ import BuyFeature from "@/features/buy";
 import AuthFeature from "@/features/auth";
 import SearchFeature from "@/features/search";
 import CreatorFeature from "@/features/creator";
+import ProfileFeature from "@/features/profile";
 
 export default function App() {
   const bootstrapSession = useSession((s) => s.bootstrap);
@@ -38,6 +39,7 @@ export default function App() {
             <Route index element={<HomeFeature />} />
             <Route path="/search/*" element={<SearchFeature />} />
             <Route path="/creator/:username/*" element={<CreatorFeature />} />
+            <Route path="/profile" element={<ProfileFeature />} />
             <Route path="/wallet/*" element={<WalletFeature />} />
             <Route path="/ai/*" element={<AiFeature />} />
             <Route path="/live/*" element={<LiveFeature />} />

--- a/wallet/zuuli/src/components/layout/TopBar.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.tsx
@@ -6,6 +6,7 @@ import {
   Wallet as WalletIcon,
   LogOut,
   User,
+  UserCog,
   Search,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -120,6 +121,9 @@ export function TopBar() {
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => navigate("/profile")}>
+              <UserCog /> Edit profile
+            </DropdownMenuItem>
             <DropdownMenuItem onClick={() => navigate("/wallet")}>
               <WalletIcon /> Wallet
             </DropdownMenuItem>

--- a/wallet/zuuli/src/features/profile/index.tsx
+++ b/wallet/zuuli/src/features/profile/index.tsx
@@ -1,0 +1,220 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { BadgeCheck, Loader2, Lock, Save } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { EmptyState } from "@/components/common/EmptyState";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { PageHeader } from "@/components/common/PageHeader";
+import { Textarea } from "@/components/ui/textarea";
+import { profile } from "@/lib/api/free2z";
+import { initials } from "@/lib/format";
+import { useSession } from "@/store/session";
+import type { AuthUser } from "@/lib/api/types";
+
+const BIO_MAX = 1024;
+const NAME_MAX = 128;
+const ADDR_MAX = 255;
+
+export default function ProfileFeature() {
+  const user = useSession((s) => s.user);
+
+  if (!user) {
+    return (
+      <div className="animate-slide-up">
+        <PageHeader title="Edit profile" />
+        <EmptyState
+          icon={Lock}
+          title="Sign in with Zcash to edit your profile"
+          description="Sign a challenge with your wallet — no password or email required."
+          action={
+            <Button asChild>
+              <Link to="/login">Sign in with Zcash</Link>
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  return <ProfileForm key={user.username} user={user} />;
+}
+
+function ProfileForm({ user }: { user: AuthUser }) {
+  const setUser = useSession((s) => s.setUser);
+  const name = user.display_name || user.username;
+
+  const [displayName, setDisplayName] = useState(name);
+  const [bio, setBio] = useState(user.bio ?? "");
+  const [p2paddr, setP2paddr] = useState(user.p2paddr ?? "");
+  const [memberPrice, setMemberPrice] = useState(
+    user.member_price != null ? String(user.member_price) : "",
+  );
+  const [saving, setSaving] = useState(false);
+
+  const trimmedName = displayName.trim();
+  const canSave = trimmedName.length > 0 && !saving;
+
+  async function save() {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const price = memberPrice.trim();
+      const updated = await profile.update({
+        display_name: trimmedName,
+        bio: bio.trim(),
+        p2paddr: p2paddr.trim(),
+        member_price: price === "" ? null : Math.max(0, Math.round(Number(price))),
+      });
+      setUser(updated);
+      toast.success("Profile updated");
+    } catch {
+      toast.error("Couldn't save your profile. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="animate-slide-up">
+      <PageHeader
+        title="Edit profile"
+        description="This is what other creators and fans see on your public page."
+        actions={
+          <Button onClick={save} disabled={!canSave}>
+            {saving ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Saving
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4" aria-hidden />
+                Save changes
+              </>
+            )}
+          </Button>
+        }
+      />
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        {/* Form */}
+        <Card className="space-y-5 rounded-xl border-border/60 bg-card/60 p-5">
+          <div className="space-y-2">
+            <Label htmlFor="profile-username">Username</Label>
+            <Input id="profile-username" value={user.username} disabled />
+            <p className="text-xs text-muted-foreground">
+              @{user.username} · usernames can't be changed here yet.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="profile-display-name">Display name</Label>
+            <Input
+              id="profile-display-name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value.slice(0, NAME_MAX))}
+              placeholder="How you want to appear to fans"
+              maxLength={NAME_MAX}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="profile-bio">Bio</Label>
+            <Textarea
+              id="profile-bio"
+              value={bio}
+              onChange={(e) => setBio(e.target.value.slice(0, BIO_MAX))}
+              placeholder="Tell people what you're building, streaming or writing about."
+              className="min-h-[140px] resize-y"
+            />
+            <p className="text-xs tabular-nums text-muted-foreground">
+              {bio.length} / {BIO_MAX}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="profile-member-price">
+              Membership price (2Z / 30 days)
+            </Label>
+            <Input
+              id="profile-member-price"
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={memberPrice}
+              onChange={(e) => setMemberPrice(e.target.value)}
+              placeholder="Leave blank for no paid membership tier"
+              className="tabular-nums"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="profile-p2paddr">
+              Zcash address for tips{" "}
+              <span className="font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <Input
+              id="profile-p2paddr"
+              value={p2paddr}
+              onChange={(e) => setP2paddr(e.target.value.slice(0, ADDR_MAX))}
+              placeholder="Defaults to your account address if left blank"
+              className="font-mono text-xs"
+            />
+          </div>
+        </Card>
+
+        {/* Preview */}
+        <div className="space-y-3 lg:sticky lg:top-6 lg:self-start">
+          <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Preview
+          </div>
+          <Card className="rounded-xl border-border/60 bg-card/40 p-5">
+            <div className="flex items-center gap-3">
+              <Avatar className="h-14 w-14 border border-border">
+                {user.image ? <AvatarImage src={user.image} alt={name} /> : null}
+                <AvatarFallback className="bg-primary/15 text-lg text-primary">
+                  {initials(trimmedName || user.username)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5">
+                  <span className="truncate font-semibold">
+                    {trimmedName || user.username}
+                  </span>
+                  {user.is_verified ? (
+                    <BadgeCheck
+                      className="h-4 w-4 shrink-0 text-primary"
+                      aria-label="Verified creator"
+                    />
+                  ) : null}
+                </div>
+                <div className="truncate text-xs text-muted-foreground">
+                  @{user.username}
+                </div>
+              </div>
+            </div>
+            {bio ? (
+              <p className="mt-4 whitespace-pre-wrap text-sm text-muted-foreground">
+                {bio}
+              </p>
+            ) : null}
+          </Card>
+          <p className="px-1 text-xs text-muted-foreground">
+            Avatar and banner image uploads are coming soon — for now they can
+            be set from the classic free2z site.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -36,6 +36,7 @@ import type {
   Paginated,
   PricingQuote,
   PricingSnapshot,
+  ProfileUpdateInput,
   PromptResponse,
   SimpleCreator,
   StreamKind,
@@ -296,15 +297,20 @@ export const auth = {
   async me(): Promise<AuthUser> {
     if (useMock()) {
       await delay(120);
-      return mockUser;
+      return { ...mockUser };
     }
     const u = await request<{
       username: string;
       email?: string;
       full_name?: string;
-      p2paddr?: string;
+      description?: string | null;
+      p2paddr?: string | null;
+      member_price?: string | null;
+      can_stream?: boolean;
+      is_verified?: boolean;
       tuzis?: string;
       avatar_image?: RawImage | null;
+      banner_image?: RawImage | null;
     }>("/api/auth/user/");
     return {
       username: u.username,
@@ -312,6 +318,15 @@ export const auth = {
       free2zaddr: u.username,
       display_name: u.full_name || u.username,
       image: mediaUrl(u.avatar_image?.thumbnail || u.avatar_image?.url) ?? null,
+      banner:
+        mediaUrl(
+          u.banner_image?.banner || u.banner_image?.card || u.banner_image?.url,
+        ) ?? null,
+      bio: u.description ?? null,
+      p2paddr: u.p2paddr ?? null,
+      member_price: parsePrice(u.member_price),
+      can_stream: u.can_stream ?? false,
+      is_verified: u.is_verified ?? false,
       tuzis: u.tuzis ? Math.floor(Number(u.tuzis)) : 0,
     };
   },
@@ -364,6 +379,53 @@ export const auth = {
       body: { address },
       anonymous: true,
     });
+  },
+};
+
+// ─── Profile (self-edit) ─────────────────────────────────────────────────────
+export const profile = {
+  /**
+   * Update the signed-in user's own profile — PATCH /api/auth/user/, backed by
+   * `CustomUserDetailsView` → `CreatorProfileUpdateSerializer`
+   * (tuzi/py/dj/apps/g12f/{views,serializers}/creator.py). Writable fields used
+   * here: `full_name` (display name), `description` (bio, markdown ≤1024
+   * chars), `p2paddr` (Zcash tip address), `member_price` (2Z / 30 days, `null`
+   * clears the paid tier).
+   *
+   * Avatar/banner aren't wired yet: the backend takes a `GenericFile` primary
+   * key, not a raw image — a creator must first `POST /uploads/single-public`
+   * (multipart) and then reference the returned id here as `avatar_image` /
+   * `banner_image` (this is what the Svelte web app's settings page does). A
+   * follow-up once ZUULI has a general upload flow.
+   *
+   * Returns the refreshed `AuthUser` (a plain refetch via `auth.me()`, since
+   * the PATCH response shape doesn't carry the same mapped fields).
+   */
+  async update(input: ProfileUpdateInput): Promise<AuthUser> {
+    if (useMock()) {
+      await delay(400);
+      Object.assign(mockUser, {
+        ...(input.display_name !== undefined
+          ? { display_name: input.display_name }
+          : {}),
+        ...(input.bio !== undefined ? { bio: input.bio } : {}),
+        ...(input.p2paddr !== undefined ? { p2paddr: input.p2paddr } : {}),
+        ...(input.member_price !== undefined
+          ? { member_price: input.member_price }
+          : {}),
+      });
+      return { ...mockUser };
+    }
+    const body: Record<string, unknown> = {};
+    if (input.display_name !== undefined) body.full_name = input.display_name;
+    if (input.bio !== undefined) body.description = input.bio;
+    if (input.p2paddr !== undefined) body.p2paddr = input.p2paddr;
+    if (input.member_price !== undefined) {
+      body.member_price =
+        input.member_price === null ? null : String(input.member_price);
+    }
+    await request("/api/auth/user/", { method: "PATCH", body });
+    return auth.me();
   },
 };
 

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -15,6 +15,9 @@ import type {
   TuziTransaction,
 } from "./types";
 
+// Mutated in place (via `Object.assign`, never reassigned — an ES module
+// import binding can't be reassigned from outside) so a saved profile edit
+// (`profile.update`) persists across the mock session and reflects in `auth.me()`.
 export const mockUser: AuthUser = {
   id: 1,
   username: "skyl",
@@ -22,6 +25,12 @@ export const mockUser: AuthUser = {
   free2zaddr: "skyl",
   display_name: "Skylar",
   image: null,
+  banner: null,
+  bio: "Building on Zcash. Shielded by default.",
+  p2paddr: "",
+  member_price: null,
+  can_stream: false,
+  is_verified: false,
   tuzis: 4210,
   zcashLinked: true,
 };

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -48,10 +48,36 @@ export interface AuthUser {
   free2zaddr?: string;
   display_name?: string;
   image?: string | null;
+  /** Own-profile enrichment from GET /api/auth/user/ (owner-only fields). */
+  banner?: string | null;
+  bio?: string | null; // `description` (markdown, ≤1024 chars)
+  /** Zcash address for direct tips (falls back to the account address server-side). */
+  p2paddr?: string | null;
+  /** 2Z price for 30 days of membership (null = no paid tier). */
+  member_price?: number | null;
+  can_stream?: boolean;
+  is_verified?: boolean;
   /** 2Z (Tuzi) credit balance. */
   tuzis: number;
   /** True when this session authenticated via a Zcash address (no password). */
   zcashLinked?: boolean;
+}
+
+/**
+ * Editable fields for the signed-in user's own profile —
+ * PATCH /api/auth/user/ (CreatorProfileUpdateSerializer). Avatar/banner
+ * uploads aren't included yet: the backend takes a `GenericFile` PK from a
+ * separate upload endpoint, not a raw image, so that's a follow-up.
+ */
+export interface ProfileUpdateInput {
+  /** → `full_name`, ≤128 chars. */
+  display_name?: string;
+  /** → `description`, markdown, ≤1024 chars. */
+  bio?: string;
+  /** → `p2paddr`, ≤255 chars. Empty string clears it. */
+  p2paddr?: string;
+  /** → `member_price`. `null` clears the paid tier. */
+  member_price?: number | null;
 }
 
 /** Knox token returned by /api/token/login/. */


### PR DESCRIPTION
## What

Lets a ZUULI user (who logs in with Zcash and gets an auto-generated username like `z56db8a529782dbea`) edit their own profile: display name, bio, membership price, and Zcash tip address.

## Backend endpoint + fields

`PATCH /api/auth/user/` — `CustomUserDetailsView` → `CreatorProfileUpdateSerializer` (`tuzi/py/dj/apps/g12f/{views,serializers}/creator.py`). This is the real, already-working self-edit endpoint (confirmed against the Django source, since `f2z.yaml`'s documented `UserDetails` schema under-describes it — `get_serializer_class` swaps in a richer serializer per HTTP method that drf-spectacular doesn't fully capture). The Svelte web app's `[username]/dashboard/settings/+page.svelte` calls the same endpoint with the same fields.

Fields written by this PR:
- `full_name` → display name
- `description` → bio (markdown, ≤1024 chars)
- `p2paddr` → Zcash address for direct tips (optional — the backend falls back to the account address when blank)
- `member_price` → 2Z price for a 30-day membership (blank/null clears the paid tier)

`GET /api/auth/user/` (same endpoint) is extended in `auth.me()` to read back `description`/`banner_image`/`p2paddr`/`member_price`/`can_stream`/`is_verified` alongside the existing fields, so the edit form can prefill from the session.

**Out of scope, by design:** avatar/banner image upload. The backend's `avatar_image`/`banner_image` fields are `PrimaryKeyRelatedField`s pointing at a `GenericFile` — a creator must first `POST /uploads/single-public` (multipart) and then PATCH with the returned id, which is what the Svelte settings page does. ZUULI has no general upload flow yet, so this PR sticks to the text fields and leaves image upload as a follow-up (noted in a code comment on `profile.update`).

## Where it lives

- `src/lib/api/free2z.ts` — new `profile.update(input)`; `auth.me()` mapping extended.
- `src/lib/api/types.ts` — `AuthUser` gains `bio`, `banner`, `p2paddr`, `member_price`, `can_stream`, `is_verified`; new `ProfileUpdateInput`.
- `src/lib/api/mock-data.ts` — `mockUser` gains the new fields; `profile.update`'s mock branch mutates it in place (`Object.assign`, not reassignment — it's an ES module import binding) so edits persist for the mock session.
- `src/features/profile/index.tsx` — new feature: sign-in gate (mirrors `features/articles/pages/Author.tsx`'s pattern) + a form with a live preview card, toasts via `sonner`.
- `src/App.tsx` — routed at `/profile`.
- `src/components/layout/TopBar.tsx` — "Edit profile" entry in the account dropdown.

## Verification

- `npm run typecheck` — pass.
- `npm run build` — pass (pre-existing >500kB chunk-size warning, unrelated).
- Exercised in the real app: `VITE_MOCK=1 npm run dev`, logged in via the mock Zcash flow, opened the account menu → **Edit profile**, confirmed the sign-in gate when logged out, prefilled fields when logged in, edited display name + membership price, saved — got a "Profile updated" toast, the live preview updated, and the account-menu avatar/name updated immediately everywhere (confirms the session store refresh works, not just local component state).

## Testing checklist

- [ ] Confirm against a real backend that `PATCH /api/auth/user/` accepts these fields from a non-superuser creator account (spec-verified via Django source + the working Svelte implementation, but not hit against a live server from this PR).
- [ ] Follow-up: wire avatar/banner upload once ZUULI has a general file-upload flow.