### PR TITLE
fix(zuuli): surface swallowed Zcash sync errors + lightwalletd fallback

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/src/models.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/models.rs
@@ -54,6 +54,13 @@ pub struct SyncStatus {
     pub synced_height: u64,
     pub chain_tip: u64,
     pub progress_percent: f32,
+    /// Most recent sync error surfaced to the UI, or `None` when the last pass
+    /// succeeded. This is **additive/optional**: consumers that predate the
+    /// field (e.g. zuuallet) simply ignore it, so adding it does not break them.
+    /// Serializes to `lastError` (camelCase); `#[serde(default)]` keeps
+    /// deserialization tolerant of payloads that omit it.
+    #[serde(default)]
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
@@ -37,6 +37,11 @@ pub struct WalletState {
     pub sync_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     pub syncing: Arc<RwLock<bool>>,
     pub last_known_chain_tip: Arc<AtomicU64>,
+    /// Most recent sync error, shared between the background sync task (writer)
+    /// and the `get_sync_status` command (reader). `None` once a pass succeeds.
+    /// Zuuli polls `get_sync_status`, so the error MUST live here — not only in
+    /// the emitted event — for the UI to see it.
+    pub last_sync_error: Arc<RwLock<Option<String>>>,
     pub manifest: Arc<Mutex<manifest::WalletManifest>>,
     pub prover: Arc<Mutex<Option<zcash_proofs::prover::LocalTxProver>>>,
     pub pending_proposal: Arc<Mutex<Option<(u32, WalletProposal)>>>,
@@ -109,6 +114,7 @@ impl WalletState {
             sync_handle: Mutex::new(None),
             syncing: Arc::new(RwLock::new(false)),
             last_known_chain_tip: Arc::new(AtomicU64::new(0)),
+            last_sync_error: Arc::new(RwLock::new(None)),
             manifest: Arc::new(Mutex::new(manifest)),
             prover: Arc::new(Mutex::new(None)),
             pending_proposal: Arc::new(Mutex::new(None)),

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs
@@ -22,6 +22,24 @@ use crate::wallet::WalletState;
 /// Interval between sync re-checks after catching up (30 seconds).
 const SYNC_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// Known-good MAINNET lightwalletd endpoints used as an ordered fallback list
+/// when the configured endpoint repeatedly fails to stream blocks. All are
+/// `*.zec.rocks`, so they satisfy the app CSP (`connect-src https://*.zec.rocks`)
+/// and match the regional endpoints already offered in the wallet Settings UI —
+/// no invented / unreachable hosts. The configured endpoint is always tried
+/// first; these only extend the rotation.
+const FALLBACK_LIGHTWALLETD_URLS: &[&str] = &[
+    "https://zec.rocks:443",
+    "https://na.zec.rocks:443",
+    "https://eu.zec.rocks:443",
+    "https://ap.zec.rocks:443",
+];
+
+/// Rotate to the next lightwalletd endpoint after this many consecutive scan
+/// failures on the current one. Conservative on purpose: we only switch after
+/// repeated failures so a single transient blip never causes endpoint churn.
+const MAX_CONSECUTIVE_FAILURES: u32 = 3;
+
 /// Start the background sync task.
 pub async fn start_sync<R: Runtime>(
     app: AppHandle<R>,
@@ -44,6 +62,7 @@ pub async fn start_sync<R: Runtime>(
     let read_db = Arc::clone(&state.read_db);
     let network = state.network;
     let last_known_chain_tip = Arc::clone(&state.last_known_chain_tip);
+    let last_sync_error = Arc::clone(&state.last_sync_error);
 
     let handle = tokio::spawn(sync_task(
         app,
@@ -53,6 +72,7 @@ pub async fn start_sync<R: Runtime>(
         read_db,
         network,
         last_known_chain_tip,
+        last_sync_error,
     ));
 
     *state.sync_handle.lock().await = Some(handle);
@@ -130,20 +150,40 @@ async fn sync_task<R: Runtime>(
     read_db: Arc<Mutex<Option<WalletDatabase>>>,
     network: Network,
     last_known_chain_tip: Arc<AtomicU64>,
+    last_sync_error: Arc<RwLock<Option<String>>>,
 ) {
     tracing::info!("sync started with endpoint: {}", lightwalletd_url);
+
+    // Ordered endpoint rotation: the configured endpoint first, then any
+    // known-good fallbacks not already equal to it. On repeated scan failures we
+    // cycle through this list (see `MAX_CONSECUTIVE_FAILURES`) so one endpoint
+    // being unreachable, or accepting the connection but refusing to stream
+    // compact blocks / subtree roots, can no longer wedge sync at 0.0% forever.
+    let mut endpoints: Vec<String> = vec![lightwalletd_url.clone()];
+    for &fb in FALLBACK_LIGHTWALLETD_URLS {
+        if !endpoints.iter().any(|e| e == fb) {
+            endpoints.push(fb.to_string());
+        }
+    }
+    let mut endpoint_idx = 0usize;
+    let mut consecutive_failures = 0u32;
 
     // Connect to lightwalletd
     let mut client = match connect_to_lightwalletd(&lightwalletd_url).await {
         Ok(c) => c,
         Err(e) => {
+            let msg = format!("Can't reach the Zcash network: {e}");
             tracing::error!("failed to connect to lightwalletd: {e}");
+            // Surface the failure instead of dying silently — store it so the
+            // polled `get_sync_status` returns it, and emit for event listeners.
+            *last_sync_error.write().await = Some(msg.clone());
             *syncing.write().await = false;
             let _ = app.emit("zcash://sync-progress", &SyncStatus {
                 syncing: false,
                 synced_height: 0,
                 chain_tip: 0,
                 progress_percent: 0.0,
+                last_error: Some(msg),
             });
             return;
         }
@@ -200,6 +240,7 @@ async fn sync_task<R: Runtime>(
                     synced_height,
                     chain_tip,
                     progress_percent: progress,
+                    last_error: None,
                 });
                 return;
             }
@@ -225,6 +266,11 @@ async fn sync_task<R: Runtime>(
 
             match result {
                 Ok(()) => {
+                    // A pass committed cleanly: reset the failure counter and clear
+                    // any previously surfaced error so the UI leaves the error state.
+                    consecutive_failures = 0;
+                    *last_sync_error.write().await = None;
+
                     // Check progress using block_max_scanned (actual scanned height)
                     let synced_height = read_scanned_height(&read_db, birthday_height).await;
 
@@ -241,6 +287,7 @@ async fn sync_task<R: Runtime>(
                         synced_height,
                         chain_tip: effective_tip,
                         progress_percent: progress,
+                        last_error: None,
                     };
                     let _ = app.emit("zcash://sync-progress", &status);
 
@@ -261,23 +308,81 @@ async fn sync_task<R: Runtime>(
                     }
                 }
                 Err(e) => {
-                    tracing::error!("sync error: {e:?}");
+                    // The error that used to be swallowed here (logged, then a
+                    // silent 30s retry) is the reason a wedged endpoint shows an
+                    // eternal "Syncing 0.0%". Surface it and, after repeated
+                    // failures, rotate to a fallback endpoint to try to recover.
+                    consecutive_failures += 1;
+                    let err_msg = format!("{e:?}");
+                    tracing::error!(
+                        "sync error (attempt {consecutive_failures}): {err_msg}"
+                    );
+
+                    let mut surfaced = format!("Sync trouble — retrying. ({err_msg})");
+                    if consecutive_failures >= MAX_CONSECUTIVE_FAILURES
+                        && endpoints.len() > 1
+                    {
+                        endpoint_idx = (endpoint_idx + 1) % endpoints.len();
+                        let next = endpoints[endpoint_idx].clone();
+                        tracing::warn!(
+                            "rotating lightwalletd endpoint after {consecutive_failures} consecutive failures -> {next}"
+                        );
+                        match connect_to_lightwalletd(&next).await {
+                            Ok(c) => {
+                                client = c;
+                                surfaced = format!("Sync trouble — retrying via {next}");
+                            }
+                            Err(ce) => {
+                                tracing::error!(
+                                    "failed to connect to fallback endpoint {next}: {ce}"
+                                );
+                                surfaced = format!(
+                                    "Can't reach the Zcash network — retrying via {next}"
+                                );
+                            }
+                        }
+                        // Give the new endpoint a fresh streak before rotating again.
+                        consecutive_failures = 0;
+                    }
+
+                    // Store for the polled `get_sync_status`, and emit for
+                    // event listeners. Keep progress fields as-is (still `true`
+                    // syncing — we WILL retry) so the UI shows an error banner
+                    // without losing the caught-up/height context.
+                    *last_sync_error.write().await = Some(surfaced.clone());
+                    let synced_height =
+                        read_scanned_height(&read_db, birthday_height).await;
+                    let progress =
+                        calc_progress(synced_height, chain_tip, birthday_height);
+                    let _ = app.emit("zcash://sync-progress", &SyncStatus {
+                        syncing: true,
+                        synced_height,
+                        chain_tip,
+                        progress_percent: progress,
+                        last_error: Some(surfaced),
+                    });
+
                     // On sync error, break inner loop to retry after sleep
                     break;
                 }
             }
         }
 
-        // Emit "idle" status (synced, but still watching for new blocks)
+        // Emit "idle" status. NOTE: the inner loop breaks here on BOTH a clean
+        // catch-up AND an error, so carry whatever error is currently stored
+        // (the error arm may have just set it) rather than clearing it — a
+        // successful pass is the only thing that clears `last_sync_error`.
         let synced_height = read_scanned_height(&read_db, birthday_height).await;
         let effective_tip = chain_tip.max(synced_height);
         last_known_chain_tip.store(effective_tip, Ordering::Relaxed);
         let progress = calc_progress(synced_height, effective_tip, birthday_height);
+        let last_error = last_sync_error.read().await.clone();
         let _ = app.emit("zcash://sync-progress", &SyncStatus {
             syncing: true,
             synced_height,
             chain_tip: effective_tip,
             progress_percent: progress,
+            last_error,
         });
 
         // Sleep before re-checking for new blocks, with cancellation support
@@ -300,11 +405,13 @@ async fn sync_task<R: Runtime>(
 
     *syncing.write().await = false;
 
+    let last_error = last_sync_error.read().await.clone();
     let _ = app.emit("zcash://sync-progress", &SyncStatus {
         syncing: false,
         synced_height,
         chain_tip,
         progress_percent: progress,
+        last_error,
     });
 }
 
@@ -494,6 +601,7 @@ pub async fn get_sync_status(state: &WalletState) -> Result<SyncStatus> {
             synced_height: 0,
             chain_tip: 0,
             progress_percent: 0.0,
+            last_error: state.last_sync_error.read().await.clone(),
         });
     }
 
@@ -518,5 +626,6 @@ pub async fn get_sync_status(state: &WalletState) -> Result<SyncStatus> {
         synced_height,
         chain_tip,
         progress_percent: progress,
+        last_error: state.last_sync_error.read().await.clone(),
     })
 }

--- a/wallet/zuuli/src/features/wallet/components.tsx
+++ b/wallet/zuuli/src/features/wallet/components.tsx
@@ -1,7 +1,7 @@
 // Composite wallet UI pieces: sync bar, address card, transaction row.
 import { QRCodeSVG } from "qrcode.react";
 import { Link } from "react-router-dom";
-import { ArrowDownLeft, ArrowUpRight, Loader2 } from "lucide-react";
+import { AlertTriangle, ArrowDownLeft, ArrowUpRight, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
@@ -20,12 +20,22 @@ import { CopyButton } from "./shared";
  * just quietly reflects state: "Syncing… N%" while catching up, "Synced" once
  * at the chain tip. The engine keeps reporting `syncing: true` even when caught
  * up (it watches for new blocks), so "caught up" is judged by height.
+ *
+ * When the engine surfaces a `lastError` (e.g. lightwalletd unreachable, or a
+ * scan pass that keeps failing), we show a distinct "Sync trouble — retrying"
+ * state instead of an eternal, silent "Syncing 0.0%". The engine keeps retrying
+ * on its own (and rotates lightwalletd endpoints), so this is informational, not
+ * a dead end; it clears automatically on the next successful pass.
  */
 export function SyncBar({ sync }: { sync: SyncStatus | null }) {
   const pct = sync ? Math.min(100, Math.max(0, sync.progressPercent)) : 0;
   const connecting = sync === null || sync.chainTip === 0;
   const caughtUp =
     sync !== null && sync.chainTip > 0 && sync.syncedHeight >= sync.chainTip;
+  // Only treat an error as active while not caught up — a successful pass clears
+  // `lastError` on the backend, but guard here too so a stale value never sticks.
+  const errorMsg = !caughtUp ? (sync?.lastError ?? null) : null;
+  const hasError = errorMsg !== null && errorMsg !== "";
 
   return (
     <Card className="rounded-xl p-4" role="status" aria-live="polite">
@@ -34,6 +44,11 @@ export function SyncBar({ sync }: { sync: SyncStatus | null }) {
           <>
             <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
             <span>Synced</span>
+          </>
+        ) : hasError ? (
+          <>
+            <AlertTriangle className="h-3.5 w-3.5 text-amber-400" aria-hidden />
+            <span className="text-amber-400">Sync trouble — retrying</span>
           </>
         ) : connecting ? (
           <>
@@ -51,17 +66,28 @@ export function SyncBar({ sync }: { sync: SyncStatus | null }) {
         )}
       </div>
 
-      <p className="mt-0.5 truncate text-xs tabular-nums text-muted-foreground">
-        {sync && !connecting
-          ? `${formatHeight(sync.syncedHeight)} / ${formatHeight(sync.chainTip)}`
-          : "Waiting for chain tip…"}
+      <p
+        className={cn(
+          "mt-0.5 truncate text-xs tabular-nums text-muted-foreground",
+          hasError && "text-amber-400/80",
+        )}
+        title={hasError ? errorMsg : undefined}
+      >
+        {hasError
+          ? errorMsg
+          : sync && !connecting
+            ? `${formatHeight(sync.syncedHeight)} / ${formatHeight(sync.chainTip)}`
+            : "Waiting for chain tip…"}
       </p>
 
       {!caughtUp ? (
         <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-muted">
           <div
-            className="h-full rounded-full bg-primary transition-[width] duration-500 ease-out"
-            style={{ width: `${pct}%` }}
+            className={cn(
+              "h-full rounded-full transition-[width] duration-500 ease-out",
+              hasError ? "bg-amber-400" : "bg-primary",
+            )}
+            style={{ width: `${hasError ? Math.max(pct, 4) : pct}%` }}
             role="progressbar"
             aria-valuenow={Math.round(pct)}
             aria-valuemin={0}

--- a/wallet/zuuli/src/lib/wallet/types.ts
+++ b/wallet/zuuli/src/lib/wallet/types.ts
@@ -44,6 +44,13 @@ export interface SyncStatus {
   syncedHeight: number;
   chainTip: number;
   progressPercent: number;
+  /**
+   * Most recent sync error, or `null`/absent when the last pass succeeded. The
+   * engine used to swallow scan errors and spin silently at "0.0%"; this field
+   * surfaces them so the UI can show a "Sync trouble — retrying" state instead.
+   * Optional so it stays backward-compatible with payloads that omit it.
+   */
+  lastError?: string | null;
 }
 
 export interface TransactionEntry {


### PR DESCRIPTION
## Root cause
ZUULI's wallet could sit on a permanent, silent **"Syncing 0.0%"**. In `wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs`, every `zcash_client_backend::sync::run` pass that errored was **swallowed** at the loop's error arm: `tracing::error!(...)`, break, sleep 30s, retry forever. Nothing reached `SyncStatus`/the UI. When the configured lightwalletd endpoint (`https://zec.rocks:443`) connects but fails to stream compact blocks / subtree roots, no block is ever committed, `block_max_scanned()` stays `None`, and the displayed scanned height is the birthday floor — so progress is stuck at 0.0% with no signal to the user.

The progress **math** (`calc_progress`, birthday-relative) is correct and is **unchanged**.

## What changed
**Observability (the core fix)**
- Additive `SyncStatus.last_error: Option<String>` (`#[serde(default)]`, camelCase `lastError`). Additive on purpose so **zuuallet**, which shares this plugin, simply ignores it and is unaffected.
- The error is stored in a shared `WalletState.last_sync_error`, because ZUULI reads status by **polling `get_sync_status`** (not the event listener) — so the command now returns it, in addition to emitting on `zcash://sync-progress`. Cleared to `None` on any successful pass.
- ZUULI `SyncBar` (`wallet/zuuli/src/features/wallet/components.tsx`) renders a distinct **"Sync trouble — retrying"** state (amber, with the message) instead of the silent "Syncing 0.0%". Normal connecting / syncing / caught-up states are intact.

**lightwalletd endpoint fallback (may itself clear the stall)**
- Ordered rotation: the configured endpoint first, then known-good **`*.zec.rocks`** fallbacks (`na` / `eu` / `ap`) — already referenced in zuuallet Settings and allowed by both apps' CSP (`connect-src https://*.zec.rocks`). (The regional zec.rocks hosts are used deliberately instead of other providers so the choice stays within CSP and uses hosts already trusted in-repo.)
- After **3 consecutive** scan failures, rotate to the next endpoint, reconnect via `connect_to_lightwalletd`, and reflect the switch in `last_error` ("retrying via <host>"). Conservative: only rotates after repeated failures, cycles the list, never hammers.

## zuuallet compatibility
No zuuallet files changed. Its TS `SyncStatus` doesn't declare `lastError`; the extra JSON field is ignored structurally. The Rust field is additive.

## Verification
- **Rust:** `cargo check --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml` — passed locally (clean, exit 0) against the pinned librustzcash submodule. The authoritative clean-Linux build is `zuuallet.yml` CI, which runs here because plugin paths changed.
- **TS:** `cd wallet/zuuli && npm run typecheck && npm run build` — both pass (only pre-existing chunk-size / dynamic-import warnings).

### Honest caveat
This PR makes the failure **visible** and adds **recovery** (endpoint rotation). It **cannot** be proven against a live wedged sync — reproducing that needs the affected user's actual chain/network state and logs. It does not, by itself, prove the underlying stall is resolved; it ensures the stall is no longer silent and gives the engine a self-recovery path.