### PR TITLE
feat(zuuli): real livestream A/V via Cloudflare RealtimeKit

### DIFF
--- a/wallet/zuuli/package-lock.json
+++ b/wallet/zuuli/package-lock.json
@@ -8,6 +8,9 @@
       "name": "zuuli",
       "version": "0.1.0",
       "dependencies": {
+        "@cloudflare/realtimekit": "1.5.1",
+        "@cloudflare/realtimekit-react": "1.5.1",
+        "@cloudflare/realtimekit-react-ui": "1.2.0",
         "@radix-ui/react-avatar": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
@@ -51,6 +54,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -293,6 +297,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -339,6 +352,49 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cloudflare/realtimekit": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/realtimekit/-/realtimekit-1.5.1.tgz",
+      "integrity": "sha512-3ymELEXoT2MbWlqnUrx3+XFm51oScby5WfrWaB8mqoQzlihAPrh+qGa9ag2Q1t4yL8vtMMI+jaJpHJgPSD6O1g==",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.7.0",
+        "bowser": "^2.11.0",
+        "sdp-transform": "^2.14.1",
+        "uuid": "^8.3.2",
+        "worker-timers": "7.0.60"
+      }
+    },
+    "node_modules/@cloudflare/realtimekit-react": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/realtimekit-react/-/realtimekit-react-1.5.1.tgz",
+      "integrity": "sha512-BqR1EWD92971wbmculNeotjRcJYUf6scDOet919e519QsCwJPG/PnXZGrX7BDyiVlVW7anHwzUl2exa8FuU+HQ==",
+      "dependencies": {
+        "@cloudflare/realtimekit": "1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.6"
+      }
+    },
+    "node_modules/@cloudflare/realtimekit-react-ui": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/realtimekit-react-ui/-/realtimekit-react-ui-1.2.0.tgz",
+      "integrity": "sha512-aJoVPxpEboibpyQWgy+zgHbppQK4DlNDxwJkWu2f8gIWFFhr4QWLg7ovVvxfUhi8ONuTAzHao7ktAlg2Gr4onQ==",
+      "dependencies": {
+        "@cloudflare/realtimekit-ui": "1.2.0"
+      }
+    },
+    "node_modules/@cloudflare/realtimekit-ui": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/realtimekit-ui/-/realtimekit-ui-1.2.0.tgz",
+      "integrity": "sha512-/0cutQJgDXsVy8iuBMgq+9xu8lYjNH0yEkZrabTQCkysyuc61lN2gXjwE2rfQgmSS3tZQjz3r0MVl430sidNPQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4",
+        "hark": "^1.2.3",
+        "hls.js": "^1.5.17",
+        "lodash-es": "^4.17.21",
+        "resize-observer-polyfill": "^1.5.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -825,6 +881,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -846,6 +903,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -855,12 +913,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -871,6 +931,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -884,6 +945,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -893,6 +955,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -901,6 +964,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@protobuf-ts/runtime": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz",
+      "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.2",
@@ -2418,12 +2487,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2434,7 +2505,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -2477,12 +2548,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2496,6 +2569,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/aria-hidden": {
@@ -2574,6 +2648,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2582,10 +2657,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2632,6 +2714,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2712,6 +2795,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2736,6 +2820,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2779,6 +2864,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2795,6 +2881,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -2807,6 +2894,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2871,12 +2959,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -2890,6 +2980,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2979,6 +3070,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2995,6 +3087,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3003,10 +3096,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-unique-numbers": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.13.tgz",
+      "integrity": "sha512-7OnTFAVPefgw2eBJ1xj2PGGR9FwYzSUso9decayHgCDX4sJkHLdcsYTytTg+tYv+wKF3U8gJuSBz2jJpQV4u/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3016,6 +3123,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3042,6 +3150,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3056,6 +3165,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3084,6 +3194,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -3092,10 +3203,20 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/hark": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hark/-/hark-1.2.3.tgz",
+      "integrity": "sha512-u68vz9SCa38ESiFJSDjqK8XbXqWzyot7Cj6Y2b6jk2NJ+II3MY2dIrLMg/kjtIAun4Y1DHF/20hfx4rq1G5GMg==",
+      "license": "MIT",
+      "dependencies": {
+        "wildemitter": "^1.2.0"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3144,6 +3265,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -3188,6 +3315,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -3200,6 +3328,7 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -3225,6 +3354,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3234,6 +3364,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3256,6 +3387,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3277,6 +3409,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -3318,6 +3451,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -3330,6 +3464,13 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -3657,6 +3798,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4229,6 +4371,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -4248,6 +4391,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -4259,6 +4403,7 @@
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4287,6 +4432,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4296,6 +4442,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4305,6 +4452,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4339,18 +4487,21 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4363,6 +4514,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4372,6 +4524,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4381,6 +4534,7 @@
       "version": "8.5.19",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
       "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4409,6 +4563,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -4426,6 +4581,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4451,6 +4607,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4493,6 +4650,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4518,6 +4676,7 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
       "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -4531,6 +4690,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/property-information": {
@@ -4556,6 +4716,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4739,6 +4900,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -4748,6 +4910,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -4822,10 +4985,17 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4847,6 +5017,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -4902,6 +5073,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4930,6 +5102,15 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4954,6 +5135,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -5005,6 +5187,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -5027,6 +5210,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5049,6 +5233,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -5095,6 +5280,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -5104,6 +5290,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -5116,6 +5303,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -5132,6 +5320,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -5149,6 +5338,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5161,6 +5351,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -5193,6 +5384,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -5380,7 +5572,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -5514,6 +5717,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/wildemitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/wildemitter/-/wildemitter-1.2.1.tgz",
+      "integrity": "sha512-UMmSUoIQSir+XbBpTxOTS53uJ8s/lVhADCkEbhfRjUGFDPme/XGOb0sBWLx5sTz7Wx/2+TlAw1eK9O5lw5PiEw=="
+    },
+    "node_modules/worker-timers": {
+      "version": "7.0.60",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-7.0.60.tgz",
+      "integrity": "sha512-kom5j7+JQU0uuJAqAeFvxPpKlp21BH09YLMU/JLKA+0Zs3WTGk7WSBFYjdR3G+kjXr6qWD7zIcenv3oXaWBJzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6",
+        "tslib": "^2.4.1",
+        "worker-timers-broker": "^6.0.80",
+        "worker-timers-worker": "^7.0.46"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-6.1.8.tgz",
+      "integrity": "sha512-FUCJu9jlK3A8WqLTKXM9E6kAmI/dR1vAJ8dHYLMisLNB/n3GuaFIjJ7pn16ZcD1zCOf7P6H62lWIEBi+yz/zQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.5",
+        "fast-unique-numbers": "^8.0.13",
+        "tslib": "^2.6.2",
+        "worker-timers-worker": "^7.0.71"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "7.0.71",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-7.0.71.tgz",
+      "integrity": "sha512-ks/5YKwZsto1c2vmljroppOKCivB/ma97g9y77MAAz2TBBjPPgpoOiS1qYQKIgvGTr2QYPT3XhJWIB6Rj2MVPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.5",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/yallist": {

--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -12,6 +12,9 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@cloudflare/realtimekit": "1.5.1",
+    "@cloudflare/realtimekit-react": "1.5.1",
+    "@cloudflare/realtimekit-react-ui": "1.2.0",
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -14,7 +14,6 @@ import {
   Coins,
   Sparkles,
   LogOut,
-  Send,
   ShieldCheck,
   KeyRound,
 } from "lucide-react";
@@ -40,8 +39,8 @@ import { useAsync } from "@/hooks/useAsync";
 import { useSession } from "@/store/session";
 import { formatTuzis, timeAgo, initials } from "@/lib/format";
 import type { DyteJoinTicket, Livestream, StreamKind } from "@/lib/api/types";
-import { cn } from "@/lib/utils";
 import { KIND_META, gradientFor } from "./lib";
+import { Stage } from "./Stage";
 
 interface JustStarted {
   ticket: DyteJoinTicket;
@@ -49,15 +48,6 @@ interface JustStarted {
   title: string;
   price_tuzis: number;
 }
-
-const FAUX_PARTICIPANTS = [
-  "Ava R.",
-  "Marco",
-  "Sol K.",
-  "Nadia",
-  "Ren",
-  "Ivo P.",
-];
 
 export function Room() {
   const { username = "" } = useParams();
@@ -191,9 +181,9 @@ export function Room() {
               </div>
             ) : null}
 
-            {/* Stage center: either the "off-air" identity or the connected state */}
+            {/* Stage center: either the "off-air" identity or the real meeting */}
             {ticket ? (
-              <ConnectedStage ticket={ticket} />
+              <Stage ticket={ticket} />
             ) : (
               <div className="absolute inset-0 grid place-items-center">
                 <div className="flex flex-col items-center gap-3 text-center">
@@ -238,29 +228,28 @@ export function Room() {
           </div>
         </div>
 
-        {/* Right column: join gate OR chat sidebar */}
+        {/* Right column: join gate OR connection details (the real meeting's
+            own chat + participant panels live inside the Stage itself). */}
         <div className="space-y-4">
           {ticket ? (
-            <>
-              {ticket.as === "host" ? (
-                <HostControls
-                  stream={stream}
-                  onEnd={() => {
-                    toast.success("Stream ended");
-                    navigate("/live");
-                  }}
-                />
-              ) : (
-                <ConnectedDetails
-                  ticket={ticket}
-                  onLeave={() => {
-                    toast("You left the stream");
-                    navigate("/live");
-                  }}
-                />
-              )}
-              <ChatSidebar creatorName={creatorName} />
-            </>
+            ticket.as === "host" ? (
+              <HostControls
+                stream={stream}
+                onEnd={() => {
+                  toast.success("Stream ended");
+                  navigate("/live");
+                }}
+              />
+            ) : (
+              <ConnectedDetails
+                ticket={ticket}
+                stream={stream}
+                onLeave={() => {
+                  toast("You left the stream");
+                  navigate("/live");
+                }}
+              />
+            )
           ) : (
             <JoinPanel
               stream={stream}
@@ -288,25 +277,6 @@ function BackLink() {
       <ArrowLeft className="h-4 w-4" aria-hidden />
       All livestreams
     </Link>
-  );
-}
-
-function ConnectedStage({ ticket }: { ticket: DyteJoinTicket }) {
-  return (
-    <div className="absolute inset-0 grid place-items-center px-6 animate-fade-in">
-      <div className="flex flex-col items-center gap-3 text-center">
-        <div className="grid h-14 w-14 place-items-center rounded-full bg-emerald-500/20 ring-2 ring-emerald-400/40">
-          <ShieldCheck className="h-7 w-7 text-emerald-300" aria-hidden />
-        </div>
-        <div className="text-lg font-semibold text-white">
-          {ticket.as === "host" ? "You're on air" : "You're connected"}
-        </div>
-        <p className="max-w-xs text-xs text-white/70">
-          Live video is powered by Dyte; this build shows the join/entitlement
-          flow end-to-end.
-        </p>
-      </div>
-    </div>
   );
 }
 
@@ -539,8 +509,8 @@ function JoinPanel({
         ) : null}
 
         <p className="text-center text-[11px] leading-relaxed text-muted-foreground">
-          Live video is powered by Dyte; this build shows the join/entitlement
-          flow end-to-end.
+          Live video is powered by Cloudflare RealtimeKit — mic, camera, and
+          chat all run in the room once you join.
         </p>
       </div>
     </div>
@@ -549,9 +519,11 @@ function JoinPanel({
 
 function ConnectedDetails({
   ticket,
+  stream,
   onLeave,
 }: {
   ticket: DyteJoinTicket;
+  stream: Livestream;
   onLeave: () => void;
 }) {
   return (
@@ -585,7 +557,7 @@ function ConnectedDetails({
         </div>
       </dl>
       <Separator className="my-3" />
-      <ParticipantStrip />
+      <ParticipantStrip count={stream.participants + 1} />
       <Button
         variant="outline"
         className="mt-4 w-full gap-2"
@@ -629,7 +601,7 @@ function HostControls({
         . Manage your broadcast below.
       </p>
       <Separator className="my-3" />
-      <ParticipantStrip />
+      <ParticipantStrip count={stream.participants + 1} />
       <Button variant="destructive" className="mt-4 w-full gap-2" onClick={onEnd}>
         <Radio className="h-4 w-4" aria-hidden />
         End stream
@@ -638,82 +610,23 @@ function HostControls({
   );
 }
 
-function ParticipantStrip() {
+// The real participant roster, active-speaker highlighting, and chat all
+// live inside the mounted `<Stage>` (RealtimeKit's own meeting UI) — this
+// strip is just a lightweight, always-real count for the ZUULI chrome
+// around it.
+function ParticipantStrip({ count }: { count: number }) {
   return (
     <div>
       <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
         In the room
       </div>
-      <div className="flex items-center gap-2">
-        <div className="flex -space-x-2">
-          {FAUX_PARTICIPANTS.slice(0, 5).map((name) => (
-            <Avatar
-              key={name}
-              className="h-7 w-7 border-2 border-card"
-              title={name}
-            >
-              <AvatarFallback className="text-[10px]">
-                {initials(name)}
-              </AvatarFallback>
-            </Avatar>
-          ))}
-        </div>
-        <span className="text-xs text-muted-foreground">+ many more</span>
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Users className="h-3.5 w-3.5" aria-hidden />
+        <span className="tabular-nums font-medium text-foreground">
+          {count.toLocaleString()}
+        </span>
+        {count === 1 ? "person watching" : "people watching"}
       </div>
-    </div>
-  );
-}
-
-function ChatSidebar({ creatorName }: { creatorName: string }) {
-  return (
-    <div className="flex h-72 flex-col rounded-xl border border-border bg-card shadow-sm">
-      <div className="border-b border-border px-4 py-3 text-sm font-semibold">
-        Live chat
-      </div>
-      <div className="flex-1 space-y-3 overflow-hidden px-4 py-3 text-xs">
-        <ChatLine who={creatorName} accent>
-          Welcome in — glad you made it.
-        </ChatLine>
-        <ChatLine who="Ava R.">this is going to be good</ChatLine>
-        <ChatLine who="Marco">2Zs well spent, worth it</ChatLine>
-        <ChatLine who="Sol K.">gm from the shielded pool</ChatLine>
-      </div>
-      <div className="border-t border-border p-3">
-        <div className="flex items-center gap-2">
-          <Input
-            placeholder="Chat is a placeholder in this build"
-            disabled
-            aria-label="Send a chat message"
-          />
-          <Button size="icon" variant="secondary" disabled aria-label="Send">
-            <Send className="h-4 w-4" aria-hidden />
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ChatLine({
-  who,
-  accent,
-  children,
-}: {
-  who: string;
-  accent?: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="leading-snug">
-      <span
-        className={cn(
-          "font-semibold",
-          accent ? "text-primary" : "text-foreground",
-        )}
-      >
-        {who}
-      </span>{" "}
-      <span className="text-muted-foreground">{children}</span>
     </div>
   );
 }

--- a/wallet/zuuli/src/features/live/Stage.tsx
+++ b/wallet/zuuli/src/features/live/Stage.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from "react";
+import { AlertCircle, Loader2 } from "lucide-react";
+import {
+  RealtimeKitProvider,
+  useRealtimeKitClient,
+} from "@cloudflare/realtimekit-react";
+import { RtkMeeting } from "@cloudflare/realtimekit-react-ui";
+import { Button } from "@/components/ui/button";
+import type { DyteJoinTicket } from "@/lib/api/types";
+
+type StageStatus = "connecting" | "connected" | "failed" | "ended";
+
+/**
+ * Mounts the real Cloudflare RealtimeKit meeting for a join ticket returned by
+ * `live.start` / `live.join`. Mirrors the web app's reference implementation
+ * (`tuzi/ts/svelte/free2z`'s `rtk-manager.ts` + `<rtk-meeting>`): the auth
+ * token goes straight into `RealtimeKitClient.init`, and the full
+ * `mode="fill"` meeting UI — self + participant tiles, mic/cam/leave
+ * controls, and chat — is rendered as-is. No custom media plumbing needed;
+ * RealtimeKit owns the whole stage.
+ */
+export function Stage({ ticket }: { ticket: DyteJoinTicket }) {
+  const [meeting, initMeeting] = useRealtimeKitClient();
+  const [status, setStatus] = useState<StageStatus>("connecting");
+  const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus("connecting");
+    setError(null);
+
+    initMeeting({
+      authToken: ticket.authToken,
+      defaults: {
+        // Hosts publish immediately; viewers join with mic/cam off.
+        audio: ticket.as === "host",
+        video: ticket.as === "host",
+      },
+    })
+      .then((client) => {
+        if (cancelled || client) return;
+        // A falsy resolution (no thrown error) still means we never got a
+        // connected client — surface it rather than rendering a blank stage.
+        setError("Failed to connect to meeting.");
+        setStatus("failed");
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        console.error("Failed to initialize RealtimeKit meeting:", err);
+        const e = err as { message?: string; name?: string };
+        const message =
+          e.name === "NotAllowedError" ||
+          e.message?.includes("Permission denied")
+            ? "Microphone or camera permission denied. Please allow access in your browser/app settings and try again."
+            : e.message || "Failed to connect to meeting.";
+        setError(message);
+        setStatus("failed");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ticket.authToken, ticket.as, attempt, initMeeting]);
+
+  useEffect(() => {
+    if (!meeting) return;
+
+    const onJoined = () => setStatus("connected");
+    const onLeft = ({ state }: { state: string }) => {
+      if (state === "ended") {
+        setStatus("ended");
+      } else if (state === "failed") {
+        setError("Connection to the meeting failed.");
+        setStatus("failed");
+      }
+    };
+
+    meeting.self.on("roomJoined", onJoined);
+    meeting.self.on("roomLeft", onLeft);
+
+    return () => {
+      meeting.self.off("roomJoined", onJoined);
+      meeting.self.off("roomLeft", onLeft);
+    };
+  }, [meeting]);
+
+  if (error) {
+    return (
+      <div className="absolute inset-0 grid place-items-center px-6">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <div className="grid h-14 w-14 place-items-center rounded-full bg-red-500/20 ring-2 ring-red-400/40">
+            <AlertCircle className="h-7 w-7 text-red-300" aria-hidden />
+          </div>
+          <p className="max-w-xs text-sm text-white/80">{error}</p>
+          <Button
+            size="sm"
+            variant="outline"
+            className="mt-1 border-white/20 bg-white/5 text-white hover:bg-white/10"
+            onClick={() => setAttempt((n) => n + 1)}
+          >
+            Try again
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "ended") {
+    return (
+      <div className="absolute inset-0 grid place-items-center px-6">
+        <p className="text-sm text-white/80">The stream has ended.</p>
+      </div>
+    );
+  }
+
+  if (!meeting) {
+    return (
+      <div className="absolute inset-0 grid place-items-center">
+        <div className="flex flex-col items-center gap-3 text-white/80">
+          <Loader2 className="h-8 w-8 animate-spin" aria-hidden />
+          <span className="text-sm">Connecting to stream…</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <RealtimeKitProvider value={meeting}>
+      <div className="absolute inset-0">
+        <RtkMeeting
+          meeting={meeting}
+          mode="fill"
+          showSetupScreen={false}
+          leaveOnUnmount
+          className="h-full w-full"
+        />
+      </div>
+    </RealtimeKitProvider>
+  );
+}


### PR DESCRIPTION
## Summary

ZUULI's livestreaming backend (Cloudflare RealtimeKit, formerly Dyte) was already fully real — `api.live.start`/`api.live.join` in `src/lib/api/free2z.ts` hit `POST /api/dyte/{username}/{type}` and return a real join ticket (`DyteJoinTicket = { authToken, meetingId, roomName?, as }`). The only gap was the media layer: `Room.tsx` rendered a placeholder ("you're connected" card, `FAUX_PARTICIPANTS`, a disabled chat input) with no video SDK in `package.json`.

This PR mounts the real meeting.

## What changed

- **SDK added** to `wallet/zuuli/package.json`, pinned to the exact versions the reference Svelte web app (`tuzi/ts/svelte/free2z`) resolves to in its lockfile:
  - `@cloudflare/realtimekit@1.5.1` (core client)
  - `@cloudflare/realtimekit-react@1.5.1` (`useRealtimeKitClient`/`RealtimeKitProvider` hooks — the React equivalent of the web app's manual `RealtimeKitClient.init`)
  - `@cloudflare/realtimekit-react-ui@1.2.0` (React wrapper around `@cloudflare/realtimekit-ui@1.2.0`, exposing `<RtkMeeting>` — the React equivalent of the web app's `<rtk-meeting>` web component)
- **New `src/features/live/Stage.tsx`**: given a `DyteJoinTicket`, calls `useRealtimeKitClient()` + `initMeeting({ authToken, defaults: { audio/video: as === "host" } })`, tracks `roomJoined`/`roomLeft` events (mirroring the web app's `rtk-manager.ts`), and renders `<RtkMeeting mode="fill" showSetupScreen={false} leaveOnUnmount />` once connected — real self + participant tiles, mic/cam/leave controls, and chat, all built into RealtimeKit's UI kit (same as the web app, which doesn't build a custom chat component either). Shows a connecting spinner and a graceful "Try again" error state on init failure (verified live against the real Cloudflare backend — see below).
- **`src/features/live/Room.tsx`**: mounts `<Stage ticket={ticket}/>` in place of the old placeholder card, removes `FAUX_PARTICIPANTS` and the disabled `ChatSidebar`/`ChatLine` (superseded by Stage's real chat), and switches the sidebar's "in the room" strip to a real `stream.participants` count instead of fake avatars. Broadcaster (`can_stream`-gated start) vs viewer (public/subscriber/PPV/private join) entitlement flow, loading/error states, and leave/end behavior are all preserved unchanged.
- No changes to `src/lib/api/free2z.ts` / `types.ts` — the live API contract was already correct.

Custom element registration: React's `@cloudflare/realtimekit-react-ui` self-registers the underlying web components on import (unlike the web app, which explicitly calls the lazy `defineCustomElements()` loader) — confirmed via the package's ESM entry, so no extra bootstrap code is needed.

## Verified

- `npm install` resolves cleanly (318 packages added).
- `npm run typecheck` (`tsc --noEmit`) passes clean.
- `npm run build` succeeds (the RealtimeKit UI kit chunk is the main size warning, expected for a full meeting UI).
- **Live-drove it in a real browser** (`npm run dev` with mock mode) against a real stream listing, clicked "Join free", and watched `Stage` make a genuine network call to Cloudflare's RealtimeKit backend — which correctly rejected the mock ticket's fake token (`Invalid auth token provided... You get the participant token from the Add Participant API`). The graceful "Failed to connect to meeting." + "Try again" UI rendered exactly as designed, with the surrounding ZUULI chrome (Connected badge, Meeting ID, Room, Role, live participant count, Leave button) all intact and no React crash. "Leave" correctly navigates back with a toast.

**What could not be verified**: actual audio/video capture and a real join between two participants — that needs a live meeting created against a real free2z backend plus camera/mic hardware, neither of which is available headless. The error-path test above does confirm the SDK is genuinely wired to Cloudflare's RealtimeKit service (not stubbed), so the only remaining unknown is the happy-path media rendering itself.

## Test plan

- [x] `npm install && npm run typecheck && npm run build`
- [x] Manually drove `/live/:username` in a browser, exercised join → real RealtimeKit init → graceful failure/retry → leave
- [ ] Real end-to-end join with a live meeting + camera (needs a live backend + hardware, not available in this environment)