### PR TITLE
feat(zuuli): link article bylines to creator + socials block

### DIFF
--- a/wallet/zuuli/src/features/articles/components/ArticleCard.tsx
+++ b/wallet/zuuli/src/features/articles/components/ArticleCard.tsx
@@ -61,7 +61,7 @@ export function ArticleCard({
         </div>
 
         {/* Body */}
-        <div className="flex flex-1 flex-col gap-2 p-5">
+        <div className="flex flex-1 flex-col gap-2 p-5 pb-3">
           <h3 className="text-lg font-semibold leading-snug tracking-tight text-foreground transition-colors group-hover:text-primary">
             {article.title}
           </h3>
@@ -70,24 +70,29 @@ export function ArticleCard({
               {article.subtitle}
             </p>
           ) : null}
+        </div>
+      </Link>
 
-          <div className="mt-auto flex items-center gap-3 pt-3">
-            <Avatar className="h-8 w-8">
-              {author.image ? (
-                <AvatarImage src={author.image} alt={name} />
-              ) : null}
-              <AvatarFallback className="text-xs">
-                {initials(name)}
-              </AvatarFallback>
-            </Avatar>
-            <div className="min-w-0 flex-1">
-              <div className="truncate text-sm font-medium text-foreground">
-                {name}
-              </div>
-              <div className="text-xs text-muted-foreground">
-                {article.published_at ? timeAgo(article.published_at) : ""}
-              </div>
-            </div>
+      {/* Byline — links to the creator, separate from the article link so the
+          two targets don't nest inside one another. */}
+      <Link
+        to={`/creator/${author.username}`}
+        aria-label={`View ${name}’s profile`}
+        className="mt-auto flex items-center gap-3 px-5 pb-5 focus:outline-none"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Avatar className="h-8 w-8">
+          {author.image ? (
+            <AvatarImage src={author.image} alt={name} />
+          ) : null}
+          <AvatarFallback className="text-xs">{initials(name)}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-foreground transition-colors hover:text-primary hover:underline">
+            {name}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {article.published_at ? timeAgo(article.published_at) : ""}
           </div>
         </div>
       </Link>

--- a/wallet/zuuli/src/features/articles/pages/Reader.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Reader.tsx
@@ -103,14 +103,25 @@ export function Reader() {
           ) : null}
 
           <div className="flex items-center gap-3 pt-2">
-            <Avatar>
-              {author.image ? (
-                <AvatarImage src={author.image} alt={name} />
-              ) : null}
-              <AvatarFallback>{initials(name)}</AvatarFallback>
-            </Avatar>
+            <Link
+              to={`/creator/${author.username}`}
+              aria-label={`View ${name}’s profile`}
+              className="shrink-0"
+            >
+              <Avatar>
+                {author.image ? (
+                  <AvatarImage src={author.image} alt={name} />
+                ) : null}
+                <AvatarFallback>{initials(name)}</AvatarFallback>
+              </Avatar>
+            </Link>
             <div className="text-sm">
-              <div className="font-medium text-foreground">{name}</div>
+              <Link
+                to={`/creator/${author.username}`}
+                className="font-medium text-foreground transition-colors hover:text-primary hover:underline"
+              >
+                {name}
+              </Link>
               <div className="flex items-center gap-2 text-muted-foreground">
                 {article.published_at ? (
                   <span>{formatPublished(article.published_at)}</span>

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -1,17 +1,28 @@
-import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useMemo, useState } from "react";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
   ArrowRight,
   BadgeCheck,
   Clock,
+  Facebook,
   FileText,
+  Github,
+  Globe,
   Heart,
+  Instagram,
+  Link2,
+  Linkedin,
   Loader2,
   Radio,
+  Send,
+  Twitter,
   UserX,
+  Youtube,
+  Zap,
 } from "lucide-react";
 import { toast } from "sonner";
+import type { LucideIcon } from "lucide-react";
 import {
   Avatar,
   AvatarFallback,
@@ -36,9 +47,25 @@ import { Markdown } from "@/components/common/Markdown";
 import { discover, tuzi } from "@/lib/api/free2z";
 import { formatTuzis, initials, timeAgo } from "@/lib/format";
 import { cn } from "@/lib/utils";
+import { parseBioFrontmatter, type SocialLink } from "@/lib/utils/bio";
 import { useAsync } from "@/hooks/useAsync";
 import { useSession } from "@/store/session";
 import type { Article, CreatorDetail } from "@/lib/api/types";
+
+/** Icon per canonical social platform key, falling back to a plain link glyph. */
+const SOCIAL_ICONS: Record<SocialLink["key"], LucideIcon> = {
+  twitter: Twitter,
+  github: Github,
+  instagram: Instagram,
+  youtube: Youtube,
+  facebook: Facebook,
+  linkedin: Linkedin,
+  reddit: Link2,
+  telegram: Send,
+  mastodon: Link2,
+  nostr: Zap,
+  website: Globe,
+};
 
 /** Deterministic violet→fuchsia banner gradient from the username. */
 function bannerGradient(seed: string): string {
@@ -85,6 +112,10 @@ function CreatorProfile({ creator }: { creator: CreatorDetail }) {
   const { data: pages, loading: pagesLoading } = useAsync<Article[]>(
     () => discover.creatorPages(creator.username),
     [creator.username],
+  );
+  const { body: bio, socials } = useMemo(
+    () => parseBioFrontmatter(creator.bio),
+    [creator.bio],
   );
 
   return (
@@ -175,11 +206,34 @@ function CreatorProfile({ creator }: { creator: CreatorDetail }) {
       </div>
 
       {/* Bio */}
-      {creator.bio ? (
+      {bio ? (
         <div className="mt-8 md:px-4">
           <div className="rounded-xl border border-border/60 bg-card/40 p-5">
-            <Markdown>{creator.bio}</Markdown>
+            <Markdown>{bio}</Markdown>
           </div>
+        </div>
+      ) : null}
+
+      {/* Links / socials — parsed from a frontmatter block at the top of the
+          bio (e.g. `---\nsocials:\n  twitter: handle\n---`). */}
+      {socials.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2 md:px-4">
+          {socials.map((social) => {
+            const Icon = SOCIAL_ICONS[social.key];
+            return (
+              <a
+                key={social.key}
+                href={social.url}
+                target="_blank"
+                rel="noreferrer noopener"
+                aria-label={`${name} on ${social.label}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-card/40 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
+              >
+                <Icon className="h-3.5 w-3.5" aria-hidden />
+                {social.display}
+              </a>
+            );
+          })}
         </div>
       ) : null}
 
@@ -486,7 +540,31 @@ function PageCardSkeleton() {
   );
 }
 
+/**
+ * Context-aware back link: reaching a creator profile from an article byline
+ * (or anywhere else in the app) should return to where the visitor came from,
+ * not dump them on /search. `location.key === "default"` only for the very
+ * first entry in the history stack (a direct link / fresh load), so that's
+ * the one case with nowhere real to go back to.
+ */
 function BackLink() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const hasHistory = location.key !== "default";
+
+  if (hasHistory) {
+    return (
+      <button
+        type="button"
+        onClick={() => navigate(-1)}
+        className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden />
+        Back
+      </button>
+    );
+  }
+
   return (
     <Link
       to="/search"

--- a/wallet/zuuli/src/features/home/CreatorsRow.tsx
+++ b/wallet/zuuli/src/features/home/CreatorsRow.tsx
@@ -5,12 +5,16 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
 import { initials } from "@/lib/format";
 import { discover } from "@/lib/api/free2z";
+import { parseBioFrontmatter } from "@/lib/utils/bio";
 import { useAsync } from "@/hooks/useAsync";
 import type { SimpleCreator } from "@/lib/api/types";
 import { SectionHeader, gradientFor } from "./parts";
 
 function CreatorCard({ creator }: { creator: SimpleCreator }) {
   const name = creator.display_name || creator.username;
+  // Bios may lead with a socials frontmatter block (see lib/utils/bio) — never
+  // show that raw in a plain-text snippet.
+  const { body: bio } = parseBioFrontmatter(creator.bio);
   return (
     <Link
       to={`/creator/${creator.username}`}
@@ -38,9 +42,9 @@ function CreatorCard({ creator }: { creator: SimpleCreator }) {
             />
           ) : null}
         </div>
-        {creator.bio ? (
+        {bio ? (
           <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-            {creator.bio}
+            {bio}
           </p>
         ) : null}
         <span className="mt-3 inline-flex items-center gap-1.5 rounded-full border border-primary/40 bg-primary/10 px-4 py-1.5 text-xs font-semibold text-primary transition-colors group-hover:bg-primary group-hover:text-primary-foreground">

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -51,11 +51,16 @@ const creator = (
 });
 
 export const mockCreators: SimpleCreator[] = [
-  creator("zooko", "Zooko", "Founder-ish energy. Shielded by default.", {
-    is_verified: true,
-    zpages: 12,
-    member_price: 500,
-  }),
+  creator(
+    "zooko",
+    "Zooko",
+    "---\nsocials:\n  twitter: zooko\n  github: zooko\n  website: electriccoin.co\n---\n\nFounder-ish energy. Shielded by default.",
+    {
+      is_verified: true,
+      zpages: 12,
+      member_price: 500,
+    },
+  ),
   creator("mining_maya", "Maya ⛏️", "Halo2 circuits & late-night proofs.", {
     is_verified: true,
     zpages: 7,

--- a/wallet/zuuli/src/lib/utils/bio.ts
+++ b/wallet/zuuli/src/lib/utils/bio.ts
@@ -1,0 +1,347 @@
+// Bio frontmatter parsing.
+//
+// Creator bios (`CreatorDetail.bio` / `AuthUser.bio`, backed by the server's
+// `description` field) may begin with a small YAML-ish frontmatter block that
+// declares social links, e.g.
+//
+//   ---
+//   socials:
+//     twitter: _skyl
+//     github: someuser
+//   ---
+//
+//   ...markdown body...
+//
+// This is a straight TypeScript port of the svelte web client's parser
+// (`ts/svelte/free2z/src/lib/utils/bio.js`, added for issue #566) so both
+// clients render the same social row from the same bio text. It is a
+// dependency-free, pure helper: it strips the leading frontmatter block off
+// the body and returns the recognized social links in a stable order. A bio
+// with no frontmatter is returned unchanged.
+
+/** Canonical platform key (twitter, github, ...). */
+export type SocialKey =
+  | "twitter"
+  | "github"
+  | "instagram"
+  | "youtube"
+  | "facebook"
+  | "linkedin"
+  | "reddit"
+  | "telegram"
+  | "mastodon"
+  | "nostr"
+  | "website";
+
+export interface SocialLink {
+  /** Canonical platform key (twitter, github, ...). */
+  key: SocialKey;
+  /** Human-readable platform name (X, GitHub, ...). */
+  label: string;
+  /** Raw handle/url as written in the frontmatter. */
+  value: string;
+  /** Resolved, safe https href. */
+  url: string;
+  /** Short text to show next to the icon. */
+  display: string;
+}
+
+export interface ParsedBio {
+  /** Markdown body with frontmatter removed. */
+  body: string;
+  /** Recognized social links, ordered. */
+  socials: SocialLink[];
+}
+
+/** Aliases that normalize to a canonical platform key. */
+const ALIASES: Record<string, SocialKey> = {
+  x: "twitter",
+  url: "website",
+  web: "website",
+  site: "website",
+  homepage: "website",
+  gh: "github",
+  ig: "instagram",
+  yt: "youtube",
+  fb: "facebook",
+  tg: "telegram",
+  telegramme: "telegram",
+};
+
+function isUrl(v: string): boolean {
+  return /^https?:\/\//i.test(v);
+}
+
+function stripHandle(v: string): string {
+  return v
+    .replace(/^@/, "")
+    .replace(/^https?:\/\/[^/]+\//i, "")
+    .replace(/\/+$/, "");
+}
+
+/** Build an https href for a plain-handle platform. */
+function handleUrl(v: string, prefix: string): string {
+  return isUrl(v) ? v : prefix + stripHandle(v);
+}
+
+function websiteUrl(v: string): string {
+  if (isUrl(v)) return v;
+  return "https://" + v.replace(/^\/+/, "");
+}
+
+function nostrUrl(v: string): string {
+  if (isUrl(v)) return v;
+  return "https://njump.me/" + v.replace(/^nostr:/i, "").replace(/^@/, "");
+}
+
+function mastodonUrl(v: string): string {
+  if (isUrl(v)) return v;
+  // user@instance or @user@instance -> https://instance/@user
+  const m = v.match(/^@?([^@\s]+)@([^@\s/]+)$/);
+  if (m) return `https://${m[2]}/@${m[1]}`;
+  return "https://" + v.replace(/^@/, "");
+}
+
+function redditUrl(v: string): string {
+  if (isUrl(v)) return v;
+  return "https://reddit.com/u/" + v.replace(/^\/?(u\/|user\/|@)/i, "");
+}
+
+function linkedinUrl(v: string): string {
+  if (isUrl(v)) return v;
+  return "https://linkedin.com/in/" + stripHandle(v);
+}
+
+function youtubeUrl(v: string): string {
+  if (isUrl(v)) return v;
+  const h = v.replace(/^@/, "");
+  return "https://youtube.com/@" + h;
+}
+
+function truncateMiddle(v: string): string {
+  if (v.length <= 16) return v;
+  return v.slice(0, 8) + "…" + v.slice(-6);
+}
+
+interface SocialConfig {
+  label: string;
+  url: (v: string) => string;
+  display: (v: string) => string;
+}
+
+/** Canonical platform config. Order here is the render order. */
+const SOCIAL_CONFIG: Record<SocialKey, SocialConfig> = {
+  twitter: {
+    label: "X",
+    url: (v) => handleUrl(v, "https://x.com/"),
+    display: (v) => (isUrl(v) ? stripHandle(v) : "@" + stripHandle(v)),
+  },
+  github: {
+    label: "GitHub",
+    url: (v) => handleUrl(v, "https://github.com/"),
+    display: (v) => stripHandle(v),
+  },
+  instagram: {
+    label: "Instagram",
+    url: (v) => handleUrl(v, "https://instagram.com/"),
+    display: (v) => (isUrl(v) ? stripHandle(v) : "@" + stripHandle(v)),
+  },
+  youtube: {
+    label: "YouTube",
+    url: youtubeUrl,
+    display: (v) => (isUrl(v) ? stripHandle(v) : "@" + v.replace(/^@/, "")),
+  },
+  facebook: {
+    label: "Facebook",
+    url: (v) => handleUrl(v, "https://facebook.com/"),
+    display: (v) => stripHandle(v),
+  },
+  linkedin: {
+    label: "LinkedIn",
+    url: linkedinUrl,
+    display: (v) => stripHandle(v),
+  },
+  reddit: {
+    label: "Reddit",
+    url: redditUrl,
+    display: (v) => "u/" + v.replace(/^\/?(u\/|user\/|@)/i, ""),
+  },
+  telegram: {
+    label: "Telegram",
+    url: (v) => handleUrl(v, "https://t.me/"),
+    display: (v) => (isUrl(v) ? stripHandle(v) : "@" + stripHandle(v)),
+  },
+  mastodon: {
+    label: "Mastodon",
+    url: mastodonUrl,
+    display: (v) => (isUrl(v) ? v.replace(/^https?:\/\//i, "") : v),
+  },
+  nostr: {
+    label: "Nostr",
+    url: nostrUrl,
+    display: (v) => truncateMiddle(v.replace(/^nostr:/i, "").replace(/^@/, "")),
+  },
+  website: {
+    label: "Website",
+    url: websiteUrl,
+    display: (v) => v.replace(/^https?:\/\//i, "").replace(/\/+$/, ""),
+  },
+};
+
+const RENDER_ORDER = Object.keys(SOCIAL_CONFIG) as SocialKey[];
+
+function canonicalKey(key: string): SocialKey {
+  const lower = key.toLowerCase();
+  return ALIASES[lower] ?? (lower as SocialKey);
+}
+
+function stripQuotes(v: string): string {
+  const t = v.trim();
+  if (
+    (t.startsWith('"') && t.endsWith('"')) ||
+    (t.startsWith("'") && t.endsWith("'"))
+  ) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+/** Split a leading frontmatter block off the raw description. Supports both
+ * fenced (`---` ... `---`) and a bare leading `socials:` block. */
+function splitFrontmatter(raw: string): {
+  frontmatter: string | null;
+  body: string;
+} {
+  const text = raw.replace(/^\uFEFF/, "");
+
+  // Fenced frontmatter must be the very first thing in the string.
+  const fence = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/.exec(text);
+  if (fence) {
+    return {
+      frontmatter: fence[1],
+      body: text.slice(fence[0].length).replace(/^\s*\r?\n/, ""),
+    };
+  }
+
+  // Bare leading `socials:` block: the `socials:` line plus the indented
+  // lines beneath it, terminated by a blank line or a dedented line.
+  const lines = text.split(/\r?\n/);
+  let i = 0;
+  while (i < lines.length && lines[i].trim() === "") i++;
+  if (i < lines.length && /^socials\s*:/i.test(lines[i])) {
+    const start = i;
+    i++;
+    while (i < lines.length) {
+      const line = lines[i];
+      if (line.trim() === "") break;
+      if (/^\s+\S/.test(line)) {
+        i++;
+        continue;
+      }
+      break;
+    }
+    const frontmatter = lines.slice(start, i).join("\n");
+    // drop a single trailing blank separator line
+    if (i < lines.length && lines[i].trim() === "") i++;
+    return { frontmatter, body: lines.slice(i).join("\n") };
+  }
+
+  return { frontmatter: null, body: raw };
+}
+
+/** Parse an inline flow map like `{ twitter: a, github: b }`. */
+function parseInlineMap(value: string, out: Record<string, string>): void {
+  const inner = value.replace(/^\{/, "").replace(/\}$/, "");
+  for (const pair of inner.split(",")) {
+    const m = pair.match(/^\s*([A-Za-z0-9_.-]+)\s*:\s*(.*)$/);
+    if (m) {
+      const val = stripQuotes(m[2]);
+      if (val) out[m[1].toLowerCase()] = val;
+    }
+  }
+}
+
+/** Extract a flat `{ key: value }` map of socials from a frontmatter block. */
+function extractSocialsMap(text: string): Record<string, string> {
+  const lines = text.split(/\r?\n/);
+  const found: Record<string, string> = {};
+  let inSocials = false;
+  let socialsIndent = -1;
+
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    const indent = (line.match(/^(\s*)/)?.[1] ?? "").length;
+    const kv = line.match(/^\s*([A-Za-z0-9_.-]+)\s*:\s*(.*)$/);
+    if (!kv) continue;
+
+    const key = kv[1].toLowerCase();
+    const value = stripQuotes(kv[2]);
+
+    if (inSocials) {
+      if (indent > socialsIndent) {
+        if (value) found[key] = value;
+        continue;
+      }
+      inSocials = false; // dedented: reconsider this line at top level
+    }
+
+    if (key === "socials") {
+      if (value) {
+        parseInlineMap(value, found);
+      } else {
+        inSocials = true;
+        socialsIndent = indent;
+      }
+      continue;
+    }
+
+    // Also accept top-level social keys written without nesting.
+    if (value && SOCIAL_CONFIG[canonicalKey(key)]) {
+      found[key] = value;
+    }
+  }
+
+  return found;
+}
+
+/** Turn a raw socials map into ordered, resolved SocialLink objects. */
+function buildSocialLinks(map: Record<string, string>): SocialLink[] {
+  const links: SocialLink[] = [];
+  const seen = new Set<SocialKey>();
+
+  for (const rawKey of Object.keys(map)) {
+    const key = canonicalKey(rawKey);
+    const config = SOCIAL_CONFIG[key];
+    const value = (map[rawKey] || "").trim();
+    if (!config || !value || seen.has(key)) continue;
+    seen.add(key);
+    links.push({
+      key,
+      label: config.label,
+      value,
+      url: config.url(value),
+      display: config.display(value),
+    });
+  }
+
+  links.sort((a, b) => RENDER_ORDER.indexOf(a.key) - RENDER_ORDER.indexOf(b.key));
+  return links;
+}
+
+/**
+ * Parse a creator bio: strip any leading frontmatter block from the body and
+ * return the recognized social links. Defensive: input without frontmatter is
+ * returned unchanged with an empty socials list.
+ */
+export function parseBioFrontmatter(
+  description: string | null | undefined,
+): ParsedBio {
+  const raw = typeof description === "string" ? description : "";
+  if (!raw.trim()) return { body: raw, socials: [] };
+
+  const { frontmatter, body } = splitFrontmatter(raw);
+  if (frontmatter === null) return { body: raw, socials: [] };
+
+  const socials = buildSocialLinks(extractSocialsMap(frontmatter));
+  return { body, socials };
+}


### PR DESCRIPTION
## Summary
- Article bylines now link to the creator: `ArticleCard` (feed cards) and `Reader` (article detail) render the author name/avatar as `Link to={/creator/{username}}` instead of static text.
- Added a bio-frontmatter parser (`wallet/zuuli/src/lib/utils/bio.ts`), a TypeScript port of the svelte web client's `parseBioFrontmatter` (`ts/svelte/free2z/src/lib/utils/bio.js`, issue #566). It strips a leading `---\nsocials:\n  twitter: handle\n---` (or bare `socials:`) block from a bio and returns ordered, resolved social links (twitter/x, github, instagram, youtube, facebook, linkedin, reddit, telegram, mastodon, nostr, website), with alias/URL/display handling matching the original 1:1.
- `features/creator/index.tsx` (creator detail) now renders the parsed bio body (frontmatter stripped) plus a small pill-style links/socials row underneath it, with a lucide icon per platform.
- `features/home/CreatorsRow.tsx`'s bio snippet is updated to use the same parser so a creator's frontmatter never leaks into the plain-text preview on the home page — this was a real regression risk once any bio can carry a socials block.
- `BackLink` in the creator view is now context-aware: if there's history to go back to (`location.key !== "default"`, i.e. reached via a click from an article, the feed, home, etc.) it calls `navigate(-1)` and reads "Back"; on a fresh/direct visit it falls back to the previous `/search` link. This means clicking an author byline no longer strands the reader on `/search` when they hit back.
- Added a mock bio with a real socials block to the "zooko" fixture (`lib/api/mock-data.ts`) so the feature is exercisable end-to-end in `VITE_MOCK=1` dev mode.

## Verification
- `cd wallet/zuuli && npm install && npm run typecheck` — passes.
- `npm run build` (`tsc && vite build`) — passes (pre-existing >500kB chunk-size warning only, unrelated).
- `VITE_MOCK=1 npm run dev`, driven via Chrome automation:
  - `/articles` feed → clicked "Zooko" byline on a card → landed on `/creator/zooko`.
  - `/articles/mock-article-100` (Reader) → clicked the "Zooko" byline → landed on `/creator/zooko` with the parsed bio ("Founder-ish energy. Shielded by default.") and a socials row (X @zooko, GitHub zooko, electriccoin.co) rendered — no raw frontmatter visible.
  - Clicked "Back" on the creator page → returned to the article reader (not `/search`).
  - Direct nav to `/creator/zooko` (fresh load, no history) → BackLink correctly shows "Search" fallback.
  - Home page "Creators to watch" row → Zooko's bio snippet shows the clean bio text, confirming no frontmatter leak there either.

## Test plan
- [x] Typecheck clean
- [x] Build clean
- [x] Manual click-through in mock mode (feed → creator, reader → creator, back button both paths, home row bio)