### PR TITLE
feat(zuuli): KYC / creator revenue-share application flow

### DIFF
--- a/wallet/zuuli/src/App.tsx
+++ b/wallet/zuuli/src/App.tsx
@@ -17,6 +17,7 @@ import AuthFeature from "@/features/auth";
 import SearchFeature from "@/features/search";
 import CreatorFeature from "@/features/creator";
 import ProfileFeature from "@/features/profile";
+import KycFeature from "@/features/kyc";
 
 export default function App() {
   const bootstrapSession = useSession((s) => s.bootstrap);
@@ -40,6 +41,7 @@ export default function App() {
             <Route path="/search/*" element={<SearchFeature />} />
             <Route path="/creator/:username/*" element={<CreatorFeature />} />
             <Route path="/profile" element={<ProfileFeature />} />
+            <Route path="/kyc/*" element={<KycFeature />} />
             <Route path="/wallet/*" element={<WalletFeature />} />
             <Route path="/ai/*" element={<AiFeature />} />
             <Route path="/live/*" element={<LiveFeature />} />

--- a/wallet/zuuli/src/components/layout/TopBar.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.tsx
@@ -5,6 +5,7 @@ import {
   Plus,
   Wallet as WalletIcon,
   LogOut,
+  ShieldCheck,
   User,
   UserCog,
   Search,
@@ -129,6 +130,9 @@ export function TopBar() {
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => navigate("/buy")}>
               <Coins /> Buy 2Zs
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => navigate("/kyc")}>
+              <ShieldCheck /> Apply for revenue share
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={() => logout()}>

--- a/wallet/zuuli/src/features/kyc/Stepper.tsx
+++ b/wallet/zuuli/src/features/kyc/Stepper.tsx
@@ -1,0 +1,40 @@
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const STEP_LABELS = ["Basic info", "Identity documents", "Tax form", "Review"];
+
+export function Stepper({ step }: { step: number }) {
+  return (
+    <ol className="mb-6 flex items-center gap-2">
+      {STEP_LABELS.map((label, i) => {
+        const done = i < step;
+        const active = i === step;
+        return (
+          <li key={label} className="flex flex-1 items-center gap-2 last:flex-none">
+            <div
+              className={cn(
+                "grid h-7 w-7 shrink-0 place-items-center rounded-full border text-xs font-semibold",
+                done && "border-primary bg-primary text-primary-foreground",
+                active && !done && "border-primary bg-primary/15 text-primary",
+                !active && !done && "border-border bg-transparent text-muted-foreground",
+              )}
+            >
+              {done ? <Check className="h-3.5 w-3.5" aria-hidden /> : i + 1}
+            </div>
+            <span
+              className={cn(
+                "hidden text-xs font-medium sm:inline",
+                active ? "text-foreground" : "text-muted-foreground",
+              )}
+            >
+              {label}
+            </span>
+            {i < STEP_LABELS.length - 1 ? (
+              <div className={cn("h-px flex-1", done ? "bg-primary" : "bg-border")} />
+            ) : null}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/wallet/zuuli/src/features/kyc/UploadSlot.tsx
+++ b/wallet/zuuli/src/features/kyc/UploadSlot.tsx
@@ -1,0 +1,102 @@
+import { useRef } from "react";
+import { FileCheck2, Loader2, Trash2, Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * One file-upload slot shared by the identity-documents and tax-form steps.
+ * Shows a dashed dropzone-style button when empty, or a "view / remove" row
+ * once a file is on file (the KYC endpoints return a plain URL per slot).
+ */
+export function UploadSlot({
+  label,
+  description,
+  required,
+  url,
+  accept,
+  uploading,
+  onSelect,
+  onDelete,
+}: {
+  label: string;
+  description?: string;
+  required?: boolean;
+  url?: string | null;
+  accept?: string;
+  uploading: boolean;
+  onSelect: (file: File) => void;
+  onDelete: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between">
+        <span className="text-sm font-medium">
+          {label}
+          {required ? (
+            <span className="ml-1 text-primary">*</span>
+          ) : (
+            <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+              (optional)
+            </span>
+          )}
+        </span>
+      </div>
+      {description ? (
+        <p className="text-xs text-muted-foreground">{description}</p>
+      ) : null}
+
+      {url ? (
+        <div className="flex items-center justify-between rounded-lg border border-border bg-secondary/40 px-3 py-2.5">
+          <a
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-2 text-sm text-primary hover:underline"
+          >
+            <FileCheck2 className="h-4 w-4" aria-hidden />
+            View uploaded file
+          </a>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={onDelete}
+            aria-label={`Remove ${label}`}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          disabled={uploading}
+          onClick={() => inputRef.current?.click()}
+          className={cn(
+            "min-tap flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-card/30 px-3 py-3 text-sm text-muted-foreground transition-colors hover:bg-secondary/40 disabled:cursor-not-allowed disabled:opacity-60",
+          )}
+        >
+          {uploading ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          ) : (
+            <Upload className="h-4 w-4" aria-hidden />
+          )}
+          {uploading ? "Uploading…" : "Choose file to upload"}
+        </button>
+      )}
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) onSelect(file);
+          e.target.value = "";
+        }}
+      />
+    </div>
+  );
+}

--- a/wallet/zuuli/src/features/kyc/index.tsx
+++ b/wallet/zuuli/src/features/kyc/index.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { CheckCircle2, Clock, Lock, XCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { EmptyState } from "@/components/common/EmptyState";
+import { PageHeader } from "@/components/common/PageHeader";
+import { Skeleton } from "@/components/ui/skeleton";
+import { kyc } from "@/lib/api/free2z";
+import { useSession } from "@/store/session";
+import type { KycIdentityDocuments, KycProfile } from "@/lib/api/types";
+import { Stepper } from "./Stepper";
+import { BasicInfoStep } from "./steps/BasicInfoStep";
+import { IdentityDocumentsStep } from "./steps/IdentityDocumentsStep";
+import { TaxFormStep } from "./steps/TaxFormStep";
+import { ReviewStep } from "./steps/ReviewStep";
+
+/**
+ * KYC / creator revenue-share APPLICATION flow — `dj.apps.kyc`
+ * (/api/kyc/*, see src/lib/api/free2z.ts `kyc` for the confirmed contract).
+ *
+ * This is the application only: it walks a creator through identity
+ * verification and a signed tax form, then submits for review
+ * (application_status NEW → PENDING). There is no payout / cash-out surface
+ * yet on the backend — APPROVED here only means "verified", not "can be
+ * paid out."
+ */
+export default function KycFeature() {
+  const user = useSession((s) => s.user);
+
+  if (!user) {
+    return (
+      <div className="animate-slide-up">
+        <PageHeader title="Apply for revenue share" />
+        <EmptyState
+          icon={Lock}
+          title="Sign in to apply"
+          description="Sign in with Zcash to start your creator revenue-share application."
+          action={
+            <Button asChild>
+              <Link to="/login">Sign in with Zcash</Link>
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  return <KycApplication key={user.username} />;
+}
+
+function KycApplication() {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [profile, setProfile] = useState<KycProfile | null>(null);
+  const [docs, setDocs] = useState<KycIdentityDocuments>({});
+  const [taxFormUrl, setTaxFormUrl] = useState<string | null>(null);
+  const [signature, setSignature] = useState<string | null>(null);
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [p, d, t, s] = await Promise.all([
+          kyc.getProfile(),
+          kyc.getIdentityDocuments(),
+          kyc.getTaxFormFile(),
+          kyc.getTaxFormSignature(),
+        ]);
+        if (cancelled) return;
+        setProfile(p);
+        setDocs(d);
+        setTaxFormUrl(t.file);
+        setSignature(s.tax_form_signature);
+      } catch {
+        if (!cancelled) setLoadError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="animate-slide-up space-y-4">
+        <PageHeader title="Apply for revenue share" />
+        <Skeleton className="h-52 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  if (loadError || !profile) {
+    return (
+      <div className="animate-slide-up">
+        <PageHeader title="Apply for revenue share" />
+        <EmptyState
+          title="Couldn't load your application"
+          description="Something went wrong reaching the KYC service. Please try again shortly."
+        />
+      </div>
+    );
+  }
+
+  if (profile.application_status === "REJECTED") {
+    return (
+      <div className="animate-slide-up">
+        <PageHeader title="Revenue share" />
+        <EmptyState
+          icon={XCircle}
+          title="Not eligible at this time"
+          description="Your application wasn't approved for the revenue-share program."
+        />
+      </div>
+    );
+  }
+
+  if (profile.application_status === "PENDING") {
+    return (
+      <div className="mx-auto max-w-2xl animate-slide-up">
+        <PageHeader title="Revenue share" />
+        <Card className="flex items-center gap-3 rounded-xl border-border/60 bg-card/60 p-5">
+          <Clock className="h-5 w-5 shrink-0 text-primary" aria-hidden />
+          <div>
+            <div className="font-medium">Your application is under review</div>
+            <p className="text-sm text-muted-foreground">
+              We'll let you know as soon as a reviewer makes a decision.
+            </p>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (profile.application_status === "APPROVED") {
+    return (
+      <div className="mx-auto max-w-2xl animate-slide-up">
+        <PageHeader title="Revenue share" />
+        <Card className="space-y-3 rounded-xl border-border/60 bg-card/60 p-5">
+          <div className="flex items-center gap-3">
+            <CheckCircle2
+              className="h-5 w-5 shrink-0 text-emerald-400"
+              aria-hidden
+            />
+            <div className="font-medium">
+              You're approved for the revenue-share program
+            </div>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Payout / cash-out isn't live yet — this only confirms your
+            creator verification is on file.
+          </p>
+          <Button
+            variant="outline"
+            onClick={async () => {
+              await kyc.submit(); // APPROVED → NEW, re-opening the wizard.
+              setProfile({ ...profile, application_status: "NEW" });
+              setStep(0);
+            }}
+          >
+            Revise application
+          </Button>
+        </Card>
+      </div>
+    );
+  }
+
+  // NEW — walk the wizard.
+  return (
+    <div className="mx-auto max-w-2xl animate-slide-up">
+      <PageHeader
+        title="Apply for revenue share"
+        description="Verify your identity and complete a tax form to become an eligible revenue-share creator. This is the application step only — payouts aren't live yet."
+      />
+      <Stepper step={step} />
+      {step === 0 ? (
+        <BasicInfoStep
+          profile={profile}
+          onNext={(p) => {
+            setProfile(p);
+            setStep(1);
+          }}
+        />
+      ) : null}
+      {step === 1 ? (
+        <IdentityDocumentsStep
+          docs={docs}
+          onNext={(d) => {
+            setDocs(d);
+            setStep(2);
+          }}
+          onBack={() => setStep(0)}
+        />
+      ) : null}
+      {step === 2 ? (
+        <TaxFormStep
+          profile={profile}
+          fileUrl={taxFormUrl}
+          signature={signature}
+          onNext={(url, sig) => {
+            setTaxFormUrl(url);
+            setSignature(sig);
+            setStep(3);
+          }}
+          onBack={() => setStep(1)}
+        />
+      ) : null}
+      {step === 3 ? (
+        <ReviewStep
+          profile={profile}
+          docs={docs}
+          taxFormUrl={taxFormUrl}
+          signature={signature}
+          onBack={() => setStep(2)}
+          onSubmitted={() =>
+            setProfile({ ...profile, application_status: "PENDING" })
+          }
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/wallet/zuuli/src/features/kyc/steps/BasicInfoStep.tsx
+++ b/wallet/zuuli/src/features/kyc/steps/BasicInfoStep.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { kyc } from "@/lib/api/free2z";
+import type { KycProfile } from "@/lib/api/types";
+
+/** Step 1 — POST /api/kyc/user-profile: tax residency + filer type. */
+export function BasicInfoStep({
+  profile,
+  onNext,
+}: {
+  profile: KycProfile;
+  onNext: (profile: KycProfile) => void;
+}) {
+  const [isUs, setIsUs] = useState<boolean | null>(profile.is_us);
+  const [isIndividual, setIsIndividual] = useState<boolean | null>(
+    profile.is_individual,
+  );
+  const [saving, setSaving] = useState(false);
+
+  const canContinue = isUs !== null && isIndividual !== null && !saving;
+
+  async function handleContinue() {
+    if (isUs === null || isIndividual === null) return;
+    setSaving(true);
+    try {
+      const updated = await kyc.saveProfile({
+        is_us: isUs,
+        is_individual: isIndividual,
+      });
+      onNext(updated);
+    } catch {
+      toast.error("Couldn't save your info. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card className="rounded-xl border-border/60 bg-card/60 p-5">
+      <CardHeader className="p-0 pb-4">
+        <CardTitle className="text-lg">Basic information</CardTitle>
+        <CardDescription>
+          This determines which tax form you'll complete next.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6 p-0">
+        <ToggleGroup
+          label="Are you a US taxpayer?"
+          value={isUs}
+          onChange={setIsUs}
+          options={[
+            { value: true, label: "US" },
+            { value: false, label: "Non-US" },
+          ]}
+        />
+        <ToggleGroup
+          label="Are you an individual or an entity?"
+          value={isIndividual}
+          onChange={setIsIndividual}
+          options={[
+            { value: true, label: "Individual" },
+            { value: false, label: "Entity" },
+          ]}
+        />
+      </CardContent>
+      <div className="mt-6 flex justify-end">
+        <Button onClick={handleContinue} disabled={!canContinue}>
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : null}
+          Continue
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function ToggleGroup({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: boolean | null;
+  onChange: (v: boolean) => void;
+  options: { value: boolean; label: string }[];
+}) {
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium">{label}</p>
+      <div className="grid grid-cols-2 gap-2">
+        {options.map((opt) => (
+          <button
+            key={String(opt.value)}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              "min-tap rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors",
+              value === opt.value
+                ? "border-primary bg-primary/15 text-primary"
+                : "border-border bg-transparent text-muted-foreground hover:bg-secondary hover:text-foreground",
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/wallet/zuuli/src/features/kyc/steps/IdentityDocumentsStep.tsx
+++ b/wallet/zuuli/src/features/kyc/steps/IdentityDocumentsStep.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { kyc } from "@/lib/api/free2z";
+import type { KycIdentityDocType, KycIdentityDocuments } from "@/lib/api/types";
+import { UploadSlot } from "../UploadSlot";
+
+const SLOTS: {
+  type: KycIdentityDocType;
+  label: string;
+  description: string;
+  required: boolean;
+}[] = [
+  {
+    type: "id_front",
+    label: "Government-issued ID (front)",
+    description: "Passport, driver's license, or national ID — front side.",
+    required: true,
+  },
+  {
+    type: "id_back",
+    label: "Government-issued ID (back)",
+    description: "The back side, if your ID has one.",
+    required: false,
+  },
+  {
+    type: "additional_document",
+    label: "Proof of address",
+    description: "A recent utility bill or bank statement.",
+    required: false,
+  },
+  {
+    type: "live_photo",
+    label: "Live photo",
+    description: "A current photo of yourself, for identity verification.",
+    required: true,
+  },
+];
+
+/**
+ * Step 2 — /api/kyc/identity-documents. Each slot's file field name IS the
+ * doc type (`id_front`, `id_back`, `additional_document`, `live_photo`); the
+ * GET response returns `{ <doctype>_url }` per uploaded slot.
+ */
+export function IdentityDocumentsStep({
+  docs,
+  onNext,
+  onBack,
+}: {
+  docs: KycIdentityDocuments;
+  onNext: (docs: KycIdentityDocuments) => void;
+  onBack: () => void;
+}) {
+  const [current, setCurrent] = useState<KycIdentityDocuments>(docs);
+  const [uploading, setUploading] = useState<
+    Partial<Record<KycIdentityDocType, boolean>>
+  >({});
+
+  async function handleSelect(type: KycIdentityDocType, file: File) {
+    setUploading((u) => ({ ...u, [type]: true }));
+    try {
+      const updated = await kyc.uploadIdentityDocument(type, file);
+      setCurrent(updated);
+    } catch {
+      toast.error("Couldn't upload that file. Please try again.");
+    } finally {
+      setUploading((u) => ({ ...u, [type]: false }));
+    }
+  }
+
+  async function handleDelete(type: KycIdentityDocType) {
+    try {
+      await kyc.deleteIdentityDocument(type);
+      setCurrent((c) => {
+        const next = { ...c };
+        delete next[`${type}_url`];
+        return next;
+      });
+    } catch {
+      toast.error("Couldn't remove that file. Please try again.");
+    }
+  }
+
+  const canContinue = Boolean(current.id_front_url && current.live_photo_url);
+
+  return (
+    <Card className="space-y-5 rounded-xl border-border/60 bg-card/60 p-5">
+      <CardHeader className="p-0 pb-1">
+        <CardTitle className="text-lg">Identity documents</CardTitle>
+        <CardDescription>
+          Upload the files below so we can verify who you are.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 p-0">
+        {SLOTS.map((slot) => (
+          <UploadSlot
+            key={slot.type}
+            label={slot.label}
+            description={slot.description}
+            required={slot.required}
+            url={current[`${slot.type}_url`]}
+            uploading={Boolean(uploading[slot.type])}
+            onSelect={(file) => handleSelect(slot.type, file)}
+            onDelete={() => handleDelete(slot.type)}
+          />
+        ))}
+      </CardContent>
+      <div className="flex justify-between pt-2">
+        <Button variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        <Button onClick={() => onNext(current)} disabled={!canContinue}>
+          Continue
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/wallet/zuuli/src/features/kyc/steps/ReviewStep.tsx
+++ b/wallet/zuuli/src/features/kyc/steps/ReviewStep.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import { CheckCircle2, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { kyc } from "@/lib/api/free2z";
+import type { KycIdentityDocuments, KycProfile } from "@/lib/api/types";
+
+/** Step 4 — POST /api/kyc/change-status (no body): NEW → PENDING. */
+export function ReviewStep({
+  profile,
+  docs,
+  taxFormUrl,
+  signature,
+  onBack,
+  onSubmitted,
+}: {
+  profile: KycProfile;
+  docs: KycIdentityDocuments;
+  taxFormUrl: string | null;
+  signature: string | null;
+  onBack: () => void;
+  onSubmitted: () => void;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    try {
+      await kyc.submit();
+      toast.success("Application submitted for review");
+      onSubmitted();
+    } catch {
+      toast.error("Couldn't submit your application. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const rows: { label: string; value: string; ok: boolean }[] = [
+    {
+      label: "Tax residency",
+      value: profile.is_us ? "United States" : "Outside the United States",
+      ok: profile.is_us !== null,
+    },
+    {
+      label: "Filer type",
+      value: profile.is_individual ? "Individual" : "Entity",
+      ok: profile.is_individual !== null,
+    },
+    {
+      label: "Government ID",
+      value: docs.id_front_url ? "Uploaded" : "Missing",
+      ok: Boolean(docs.id_front_url),
+    },
+    {
+      label: "Live photo",
+      value: docs.live_photo_url ? "Uploaded" : "Missing",
+      ok: Boolean(docs.live_photo_url),
+    },
+    {
+      label: "Tax form",
+      value: taxFormUrl ? "Uploaded" : "Missing",
+      ok: Boolean(taxFormUrl),
+    },
+    {
+      label: "E-signature",
+      value: signature || "Missing",
+      ok: Boolean(signature),
+    },
+  ];
+  const canSubmit = rows.every((r) => r.ok) && !submitting;
+
+  return (
+    <Card className="space-y-5 rounded-xl border-border/60 bg-card/60 p-5">
+      <CardHeader className="p-0 pb-1">
+        <CardTitle className="text-lg">Review & submit</CardTitle>
+        <CardDescription>
+          Confirm everything below, then submit for review. We'll let you know
+          once a reviewer has made a decision — this only submits your
+          application, it does not enable payouts.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-0 p-0">
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            className="flex items-center justify-between border-b border-border/40 py-2 text-sm last:border-0"
+          >
+            <span className="text-muted-foreground">{row.label}</span>
+            <span
+              className={row.ok ? "font-medium" : "font-medium text-destructive"}
+            >
+              {row.value}
+            </span>
+          </div>
+        ))}
+      </CardContent>
+      <div className="flex justify-between pt-2">
+        <Button variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        <Button onClick={handleSubmit} disabled={!canSubmit}>
+          {submitting ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          ) : (
+            <CheckCircle2 className="h-4 w-4" aria-hidden />
+          )}
+          Submit application
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/wallet/zuuli/src/features/kyc/steps/TaxFormStep.tsx
+++ b/wallet/zuuli/src/features/kyc/steps/TaxFormStep.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { kyc } from "@/lib/api/free2z";
+import type { KycProfile, KycTaxFormKind } from "@/lib/api/types";
+import { UploadSlot } from "../UploadSlot";
+
+/** Which IRS form applies, mirroring ts/react/free2z's KYCTaxForm.tsx. */
+function taxFormFor(profile: KycProfile): {
+  kind: KycTaxFormKind;
+  description: string;
+  url: string;
+} {
+  if (profile.is_us) {
+    return {
+      kind: "W-9",
+      description: profile.is_individual
+        ? "for US individuals"
+        : "for US entities",
+      url: "https://www.irs.gov/pub/irs-pdf/fw9.pdf",
+    };
+  }
+  return profile.is_individual
+    ? {
+        kind: "W-8BEN",
+        description: "for non-US individuals",
+        url: "https://www.irs.gov/pub/irs-pdf/fw8ben.pdf",
+      }
+    : {
+        kind: "W-8BEN-E",
+        description: "for non-US entities",
+        url: "https://www.irs.gov/pub/irs-pdf/fw8bene.pdf",
+      };
+}
+
+/**
+ * Step 3 — upload the filled-out tax form (POST /api/kyc/upload-tax-form,
+ * multipart field `file`) then e-sign it (POST /api/kyc/tax-form-signature,
+ * body `{ tax_form_signature }`).
+ */
+export function TaxFormStep({
+  profile,
+  fileUrl,
+  signature,
+  onNext,
+  onBack,
+}: {
+  profile: KycProfile;
+  fileUrl: string | null;
+  signature: string | null;
+  onNext: (fileUrl: string | null, signature: string | null) => void;
+  onBack: () => void;
+}) {
+  const [file, setFile] = useState(fileUrl);
+  const [sig, setSig] = useState(signature ?? "");
+  const [checked, setChecked] = useState(Boolean(signature));
+  const [uploading, setUploading] = useState(false);
+  const [signing, setSigning] = useState(false);
+
+  const form = taxFormFor(profile);
+
+  async function handleSelect(f: File) {
+    setUploading(true);
+    try {
+      const res = await kyc.uploadTaxForm(f);
+      setFile(res.file_url);
+    } catch {
+      toast.error("Couldn't upload the form. Please try again.");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleDelete() {
+    try {
+      await kyc.deleteTaxForm();
+      setFile(null);
+    } catch {
+      toast.error("Couldn't remove the form. Please try again.");
+    }
+  }
+
+  async function handleContinue() {
+    const trimmed = sig.trim();
+    if (!file || !trimmed || !checked || signing) return;
+    setSigning(true);
+    try {
+      await kyc.signTaxForm(trimmed);
+      onNext(file, trimmed);
+    } catch {
+      toast.error("Couldn't save your signature. Please try again.");
+    } finally {
+      setSigning(false);
+    }
+  }
+
+  const canContinue = Boolean(file) && sig.trim().length > 0 && checked && !signing;
+
+  return (
+    <Card className="space-y-5 rounded-xl border-border/60 bg-card/60 p-5">
+      <CardHeader className="p-0 pb-1">
+        <CardTitle className="text-lg">Tax form — {form.kind}</CardTitle>
+        <CardDescription>
+          Download, fill out, and upload the {form.kind} form ({form.description}
+          ). No wet signature needed — you'll e-sign below.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 p-0">
+        <a
+          href={form.url}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-block text-sm text-primary underline-offset-4 hover:underline"
+        >
+          Download the {form.kind} form (IRS.gov)
+        </a>
+        <UploadSlot
+          label={`${form.kind} form (PDF)`}
+          required
+          accept="application/pdf"
+          url={file}
+          uploading={uploading}
+          onSelect={handleSelect}
+          onDelete={handleDelete}
+        />
+        <div className="space-y-2 border-t border-border/60 pt-4">
+          <Label htmlFor="kyc-signature">
+            Type your full legal name to e-sign
+          </Label>
+          <Input
+            id="kyc-signature"
+            value={sig}
+            onChange={(e) => setSig(e.target.value)}
+            placeholder="Full legal name"
+            disabled={!file}
+          />
+          <label className="flex items-start gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={checked}
+              onChange={(e) => setChecked(e.target.checked)}
+              disabled={!file}
+              className="mt-0.5 h-3.5 w-3.5 rounded border-border"
+            />
+            I understand that typing my name above acts as my legal signature
+            on the uploaded tax form.
+          </label>
+        </div>
+      </CardContent>
+      <div className="flex justify-between pt-2">
+        <Button variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        <Button onClick={handleContinue} disabled={!canContinue}>
+          {signing ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : null}
+          Continue
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/wallet/zuuli/src/features/profile/index.tsx
+++ b/wallet/zuuli/src/features/profile/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { BadgeCheck, Loader2, Lock, Save } from "lucide-react";
+import { BadgeCheck, Loader2, Lock, Save, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 import {
   Avatar,
@@ -103,6 +103,24 @@ function ProfileForm({ user }: { user: AuthUser }) {
           </Button>
         }
       />
+
+      <Card className="mb-6 flex flex-col items-start justify-between gap-3 rounded-xl border-border/60 bg-card/60 p-5 sm:flex-row sm:items-center">
+        <div className="flex items-start gap-3">
+          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-full bg-primary/15 text-primary">
+            <ShieldCheck className="h-5 w-5" aria-hidden />
+          </div>
+          <div>
+            <div className="font-medium">Creator revenue share</div>
+            <p className="text-sm text-muted-foreground">
+              Verify your identity and complete a tax form to apply for the
+              creator revenue-share program.
+            </p>
+          </div>
+        </div>
+        <Button asChild variant="outline" className="shrink-0">
+          <Link to="/kyc">Apply for revenue share</Link>
+        </Button>
+      </Card>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         {/* Form */}

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -15,6 +15,9 @@ import {
   mockArticles,
   mockCreatorDetail,
   mockCreators,
+  mockKycIdentityDocuments,
+  mockKycProfile,
+  mockKycTaxForm,
   mockLivestreams,
   mockModels,
   mockSearchCreators,
@@ -30,6 +33,13 @@ import type {
   AuthUser,
   CreatorDetail,
   DyteJoinTicket,
+  KycIdentityDocType,
+  KycIdentityDocuments,
+  KycProfile,
+  KycProfileInput,
+  KycTaxFormFile,
+  KycTaxFormSignature,
+  KycTaxFormUploadResult,
   Livestream,
   LoginResult,
   OtpStatus,
@@ -932,5 +942,161 @@ export const pricing = {
       anonymous: true,
       signal,
     });
+  },
+};
+
+// ─── KYC / creator revenue-share application ─────────────────────────────────
+// `dj.apps.kyc` (tuzi/py/dj/apps/kyc), mounted at /api/kyc/. This is the
+// APPLICATION flow only — an applicant supplies basic tax-residency info,
+// identity documents, and an e-signed tax form, then advances
+// application_status from NEW to PENDING for review. There is no payout /
+// cash-out surface yet (that backend doesn't exist); APPROVED only unlocks
+// whatever the platform wires up later.
+//
+// The generated OpenAPI schema (tuzi/py/dj/free2z/openapi/f2z.yaml) documents
+// every /api/kyc/* operation with only a bare 200/204 and no request/response
+// body — so every shape below is confirmed instead against the working
+// reference client already talking to this backend:
+// ts/react/free2z/src/components/KYC{BasicInfoStep,TaxFormStep,TaxForm,
+// ElectronicSignature,Identity,LivePhotoCapture,Page}.tsx and
+// RevenueShareLink.tsx.
+export const kyc = {
+  /** GET /api/kyc/user-profile → `{ is_us, is_individual, application_status }`. */
+  async getProfile(): Promise<KycProfile> {
+    if (useMock()) {
+      await delay(150);
+      return { ...mockKycProfile };
+    }
+    return request<KycProfile>("/api/kyc/user-profile");
+  },
+
+  /** POST /api/kyc/user-profile — the "basic info" step (tax residency / entity type). */
+  async saveProfile(input: KycProfileInput): Promise<KycProfile> {
+    if (useMock()) {
+      await delay(300);
+      Object.assign(mockKycProfile, input);
+      return { ...mockKycProfile };
+    }
+    return request<KycProfile>("/api/kyc/user-profile", {
+      method: "POST",
+      body: input,
+    });
+  },
+
+  /** GET /api/kyc/identity-documents → `{ id_front_url, id_back_url, additional_document_url, live_photo_url }`. */
+  async getIdentityDocuments(): Promise<KycIdentityDocuments> {
+    if (useMock()) {
+      await delay(150);
+      return { ...mockKycIdentityDocuments };
+    }
+    return request<KycIdentityDocuments>("/api/kyc/identity-documents");
+  },
+
+  /**
+   * POST /api/kyc/identity-documents (multipart) — the file field name IS the
+   * doc type (`id_front` / `id_back` / `additional_document` / `live_photo`).
+   * Refetches the full set afterward since the endpoint doesn't echo it back.
+   */
+  async uploadIdentityDocument(
+    docType: KycIdentityDocType,
+    file: File,
+  ): Promise<KycIdentityDocuments> {
+    if (useMock()) {
+      await delay(500);
+      mockKycIdentityDocuments[`${docType}_url`] = URL.createObjectURL(file);
+      return { ...mockKycIdentityDocuments };
+    }
+    const form = new FormData();
+    form.append(docType, file);
+    await request("/api/kyc/identity-documents", {
+      method: "POST",
+      body: form,
+    });
+    return kyc.getIdentityDocuments();
+  },
+
+  /** DELETE /api/kyc/identity-documents — body `{ doc_type }`. */
+  async deleteIdentityDocument(docType: KycIdentityDocType): Promise<void> {
+    if (useMock()) {
+      await delay(200);
+      delete mockKycIdentityDocuments[`${docType}_url`];
+      return;
+    }
+    await request("/api/kyc/identity-documents", {
+      method: "DELETE",
+      body: { doc_type: docType },
+    });
+  },
+
+  /** GET /api/kyc/get-tax-form-file → `{ file }` (null until one is uploaded). */
+  async getTaxFormFile(): Promise<KycTaxFormFile> {
+    if (useMock()) {
+      await delay(150);
+      return { file: mockKycTaxForm.file_url };
+    }
+    return request<KycTaxFormFile>("/api/kyc/get-tax-form-file");
+  },
+
+  /** POST /api/kyc/upload-tax-form (multipart, field `file`) → `{ file_url }`. */
+  async uploadTaxForm(file: File): Promise<KycTaxFormUploadResult> {
+    if (useMock()) {
+      await delay(500);
+      const url = URL.createObjectURL(file);
+      mockKycTaxForm.file_url = url;
+      return { file_url: url };
+    }
+    const form = new FormData();
+    form.append("file", file);
+    return request<KycTaxFormUploadResult>("/api/kyc/upload-tax-form", {
+      method: "POST",
+      body: form,
+    });
+  },
+
+  /** DELETE /api/kyc/delete-tax-form — no body. */
+  async deleteTaxForm(): Promise<void> {
+    if (useMock()) {
+      await delay(200);
+      mockKycTaxForm.file_url = null;
+      return;
+    }
+    await request("/api/kyc/delete-tax-form", { method: "DELETE" });
+  },
+
+  /** GET /api/kyc/tax-form-signature → `{ tax_form_signature }`. */
+  async getTaxFormSignature(): Promise<KycTaxFormSignature> {
+    if (useMock()) {
+      await delay(150);
+      return { tax_form_signature: mockKycTaxForm.tax_form_signature };
+    }
+    return request<KycTaxFormSignature>("/api/kyc/tax-form-signature");
+  },
+
+  /** POST /api/kyc/tax-form-signature — body `{ tax_form_signature }` (the typed full legal name). */
+  async signTaxForm(signature: string): Promise<void> {
+    if (useMock()) {
+      await delay(300);
+      mockKycTaxForm.tax_form_signature = signature;
+      return;
+    }
+    await request("/api/kyc/tax-form-signature", {
+      method: "POST",
+      body: { tax_form_signature: signature },
+    });
+  },
+
+  /**
+   * POST /api/kyc/change-status — no body; the backend advances the workflow
+   * itself (NEW → PENDING on submit; APPROVED → NEW if a creator reopens their
+   * application to revise + resubmit — mirrors RevenueShareLink.tsx).
+   */
+  async submit(): Promise<void> {
+    if (useMock()) {
+      await delay(400);
+      mockKycProfile.application_status =
+        mockKycProfile.application_status === "APPROVED" ? "NEW" : "PENDING";
+      return;
+    }
+    await request("/api/kyc/change-status", { method: "POST" });
   },
 };

--- a/wallet/zuuli/src/lib/api/http.ts
+++ b/wallet/zuuli/src/lib/api/http.ts
@@ -117,7 +117,12 @@ export async function request<T>(
     Accept: "application/json",
     ...opts.headers,
   };
-  if (opts.body !== undefined && !headers["Content-Type"]) {
+  // Multipart bodies (file uploads, e.g. KYC docs) must NOT get a manual
+  // Content-Type — the browser/native fetch sets `multipart/form-data;
+  // boundary=...` itself. Only JSON bodies get the default header.
+  const isFormData =
+    typeof FormData !== "undefined" && opts.body instanceof FormData;
+  if (opts.body !== undefined && !isFormData && !headers["Content-Type"]) {
     headers["Content-Type"] = "application/json";
   }
   const token = getToken();
@@ -129,7 +134,12 @@ export async function request<T>(
   const res = await doFetch(buildUrl(path, opts.query), {
     method: opts.method ?? "GET",
     headers,
-    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    body:
+      opts.body === undefined
+        ? undefined
+        : isFormData
+          ? (opts.body as FormData)
+          : JSON.stringify(opts.body),
     signal: opts.signal,
     cache: opts.cache,
   });

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -9,6 +9,8 @@ import type {
   ArticleFeedParams,
   AuthUser,
   CreatorDetail,
+  KycIdentityDocuments,
+  KycProfile,
   Livestream,
   PromptResponse,
   SimpleCreator,
@@ -605,3 +607,26 @@ export function mockCreatorDetail(username: string): CreatorDetail {
     p2paddr: `u1mock${uname}zcashaddressplaceholderxxxxxxxxxxxxxxxxxxxxxxxx`,
   };
 }
+
+// ── KYC / creator revenue-share application (mock) ──────────────────────────
+// Mirrors mockUser above: a plain object mutated in place (never reassigned)
+// so edits made while walking the KYC flow in mock mode persist for the rest
+// of the session, exactly like a real profile/status would.
+
+export const mockKycProfile: KycProfile = {
+  is_us: null,
+  is_individual: null,
+  application_status: "NEW",
+};
+
+/** Uploaded identity-document slots (`{ <doctype>_url }`), mock mode. */
+export const mockKycIdentityDocuments: KycIdentityDocuments = {};
+
+/** Uploaded tax-form file + e-signature, mock mode. */
+export const mockKycTaxForm: {
+  file_url: string | null;
+  tax_form_signature: string | null;
+} = {
+  file_url: null,
+  tax_form_signature: null,
+};

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -283,3 +283,65 @@ export interface PricingQuote {
   stale: boolean;
   bootstrap: boolean;
 }
+
+// ── KYC / creator revenue-share application ─────────────────────────────────
+// Backend: `dj.apps.kyc` (tuzi/py/dj/apps/kyc, mounted at /api/kyc/ per
+// tuzi/py/dj/free2z/settings.py + tuzi/py/dj/free2z/openapi/f2z.yaml). The
+// generated OpenAPI schema for this app carries no request/response bodies
+// (every operation documents only `200`/`204` with no schema), so these
+// shapes are instead confirmed against the working reference client at
+// ts/react/free2z/src/components/KYC*.tsx (KYCBasicInfoStep, KYCTaxFormStep,
+// KYCTaxForm, KYCElectronicSignature, KYCIdentity, KYCLivePhotoCapture,
+// KYCPage) and ts/react/free2z/src/components/RevenueShareLink.tsx, which
+// talk to this same live backend.
+
+/**
+ * Workflow status returned by `application_status` on the KYC profile.
+ * NEW → PENDING (via change-status) → APPROVED (reviewer decision), or
+ * REJECTED. An APPROVED creator can revise + resubmit, which POSTs
+ * change-status again to flip APPROVED back to NEW.
+ */
+export type KycApplicationStatus = "NEW" | "PENDING" | "APPROVED" | "REJECTED";
+
+/** GET/POST /api/kyc/user-profile. */
+export interface KycProfile {
+  is_us: boolean | null;
+  is_individual: boolean | null;
+  application_status: KycApplicationStatus;
+}
+
+/** Fields the applicant sets in the "basic info" step — POST /api/kyc/user-profile. */
+export interface KycProfileInput {
+  is_us: boolean;
+  is_individual: boolean;
+}
+
+/** Which US tax form applies, derived from `is_us` + `is_individual`. */
+export type KycTaxFormKind = "W-9" | "W-8BEN" | "W-8BEN-E";
+
+/** The four identity-document upload slots /api/kyc/identity-documents accepts. */
+export type KycIdentityDocType =
+  | "id_front"
+  | "id_back"
+  | "additional_document"
+  | "live_photo";
+
+/** GET /api/kyc/identity-documents → `{ <doctype>_url }` per uploaded slot. */
+export type KycIdentityDocuments = Partial<
+  Record<`${KycIdentityDocType}_url`, string | null>
+>;
+
+/** GET /api/kyc/get-tax-form-file → `{ file }` (null until a form is uploaded). */
+export interface KycTaxFormFile {
+  file: string | null;
+}
+
+/** POST /api/kyc/upload-tax-form (multipart, field `file`) response. */
+export interface KycTaxFormUploadResult {
+  file_url: string;
+}
+
+/** GET/POST /api/kyc/tax-form-signature. */
+export interface KycTaxFormSignature {
+  tax_form_signature: string | null;
+}


### PR DESCRIPTION
## Summary

Adds a KYC / creator revenue-share **APPLICATION** flow to ZUULI (`wallet/zuuli`) — identity verification + a signed tax form, gated behind sign-in, with a status-aware entry point. This is the application step only: there is no payout / cash-out backend yet, so an APPROVED status here only confirms verification is on file.

### Backend contract (confirmed, not guessed)

`dj.apps.kyc` is wired into `INSTALLED_APPS` (`tuzi/py/dj/free2z/settings.py`) and its routes are registered in `tuzi/py/dj/free2z/openapi/f2z.yaml` under `/api/kyc/*` — **but the app's source (`py/dj/apps/kyc`) is not present anywhere in this repo's history, on any branch, or on GitHub's `main`**, and the generated OpenAPI schema documents every `/api/kyc/*` operation with only a bare `200`/`204` and no request/response body. So exact field names could not come from Django source or the schema.

Instead, every shape below is confirmed against the **working reference client already talking to this live backend**: `ts/react/free2z/src/components/KYC{BasicInfoStep,TaxFormStep,TaxForm,ElectronicSignature,Identity,LivePhotoCapture,Page}.tsx` and `RevenueShareLink.tsx`.

| Endpoint | Method | Fields used |
|---|---|---|
| `/api/kyc/user-profile` | GET/POST | `is_us`, `is_individual`, `application_status` (`NEW`\|`PENDING`\|`APPROVED`\|`REJECTED`) |
| `/api/kyc/identity-documents` | GET/POST(multipart)/DELETE | field name **is** the doc type: `id_front`, `id_back`, `additional_document`, `live_photo`; GET returns `{ <doctype>_url }`; DELETE body `{ doc_type }` |
| `/api/kyc/upload-tax-form` | POST (multipart, field `file`) | response `{ file_url }` |
| `/api/kyc/get-tax-form-file` | GET | `{ file }` |
| `/api/kyc/delete-tax-form` | DELETE | no body |
| `/api/kyc/tax-form-signature` | GET/POST | `{ tax_form_signature }` |
| `/api/kyc/change-status` | POST | no body — backend advances the workflow itself (NEW→PENDING on submit; APPROVED→NEW to revise+resubmit) |

### Implementation

- `src/lib/api/types.ts` — new `Kyc*` types (additive block at the end).
- `src/lib/api/free2z.ts` — new `export const kyc = {...}` (additive block at the end): `getProfile`/`saveProfile`, `getIdentityDocuments`/`uploadIdentityDocument`/`deleteIdentityDocument`, `getTaxFormFile`/`uploadTaxForm`/`deleteTaxForm`, `getTaxFormSignature`/`signTaxForm`, `submit`. Every function branches mock vs. real like the rest of the file.
- `src/lib/api/http.ts` — small additive fix: `request()` now detects a `FormData` body and skips JSON-stringifying / the `Content-Type: application/json` header (needed for the multipart doc/tax-form uploads; nothing else changed).
- `src/lib/api/mock-data.ts` — `mockKycProfile`, `mockKycIdentityDocuments`, `mockKycTaxForm`, mutated in place like `mockUser` so mock-mode edits persist through the session.
- `src/features/kyc/` — new feature: `index.tsx` (status gate: sign-in wall → REJECTED/PENDING/APPROVED views → the 4-step wizard), `Stepper.tsx`, `UploadSlot.tsx`, and `steps/{BasicInfoStep,IdentityDocumentsStep,TaxFormStep,ReviewStep}.tsx`.
- `src/App.tsx` — new route `/kyc/*` → `KycFeature`.
- Entry points: a "Creator revenue share" CTA card on `/profile`, and an "Apply for revenue share" item in the account dropdown menu (`TopBar.tsx`).

### Verification

- `npm run typecheck` — pass.
- `npm run build` — pass.
- `VITE_MOCK=1 npm run dev`, walked the entire flow in a real browser: sign in (mock) → `/kyc` sign-in gate → Basic info (US/Individual toggles, saved via mock `saveProfile`) → Identity documents (uploaded `id_front` + `live_photo` via real file inputs, upload/view/delete UI works) → Tax form (form correctly resolves to W-9 for US+Individual, uploaded a PDF, typed + checked e-signature) → Review (accurate summary) → Submit → `application_status` flips to `PENDING` and the read-only "under review" view renders. Entry points (Profile CTA, account-menu item) confirmed to link to `/kyc`.
- **Real uploads against the live backend could not be exercised** (no backend available offline, and the backend app source isn't in this repo to run locally) — only the mock-mode multipart path was verified; the real path is exercised via the shared `request()` FormData branch and matches the reference client's usage 1:1.

Note: this PR ships the **application** flow only. The revenue-share **payout/cash-out** backend does not exist yet (greenfield) — nothing here implies or enables payouts; `APPROVED` explicitly says so in the UI copy.