### PR TITLE
feat(zuuli): AI personalities (custom system messages)

### DIFF
--- a/wallet/zuuli/src/features/ai/PersonalityManager.tsx
+++ b/wallet/zuuli/src/features/ai/PersonalityManager.tsx
@@ -1,0 +1,391 @@
+import { useState } from "react";
+import { Loader2, Pencil, Plus, Trash2, UserRound, Users } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { EmptyState } from "@/components/common/EmptyState";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { ai } from "@/lib/api/free2z";
+import type { Personality } from "@/lib/api/types";
+
+const NAME_MAX = 200;
+const MESSAGE_MAX = 4000;
+
+interface PersonalityManagerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  personalities: Personality[];
+  ownUsername?: string;
+  isAuthed: boolean;
+  /** Called after a successful create/update/delete so the caller can refresh. */
+  onChanged: (next: {
+    created?: Personality;
+    updated?: Personality;
+    deletedId?: string;
+  }) => void;
+}
+
+type View = { kind: "list" } | { kind: "edit"; personality: Personality | null };
+
+/**
+ * Full CRUD over `/api/ai/personalities/`: list your own + public
+ * personalities, create/edit yours (display name + system message + public
+ * toggle), delete yours. Read-only for personalities you don't own.
+ */
+export function PersonalityManager({
+  open,
+  onOpenChange,
+  personalities,
+  ownUsername,
+  isAuthed,
+  onChanged,
+}: PersonalityManagerProps) {
+  const [view, setView] = useState<View>({ kind: "list" });
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  // Armed by a first click on the trash icon; a second click on "Confirm"
+  // actually deletes. Avoids a blocking `window.confirm()`, which freezes
+  // the page (and is untheme-able) — an inline step keeps it in-app.
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+
+  function close(next: boolean) {
+    if (!next) {
+      setView({ kind: "list" });
+      setConfirmingId(null);
+    }
+    onOpenChange(next);
+  }
+
+  async function handleDelete(p: Personality) {
+    setConfirmingId(null);
+    setDeletingId(p.id);
+    try {
+      await ai.personalities.delete(p.id);
+      onChanged({ deletedId: p.id });
+      toast.success("Personality deleted");
+    } catch {
+      toast.error("Couldn't delete that personality.");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  const mine = personalities.filter((p) => p.creator === ownUsername);
+  const others = personalities.filter((p) => p.creator !== ownUsername);
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto">
+        {view.kind === "list" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Personalities</DialogTitle>
+              <DialogDescription>
+                A personality is a custom system message that primes the AI —
+                pick one in chat to change how every model in this thread
+                answers.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4">
+              {!isAuthed ? (
+                <p className="rounded-lg border border-border bg-secondary/40 px-3 py-2 text-xs text-muted-foreground">
+                  Sign in with Zcash to create your own personalities. You can
+                  still use public ones below.
+                </p>
+              ) : (
+                <Button
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => setView({ kind: "edit", personality: null })}
+                >
+                  <Plus className="h-4 w-4" aria-hidden />
+                  New personality
+                </Button>
+              )}
+
+              {mine.length > 0 ? (
+                <Section title="Mine" icon={UserRound}>
+                  {mine.map((p) => (
+                    <PersonalityRow
+                      key={p.id}
+                      personality={p}
+                      editable
+                      deleting={deletingId === p.id}
+                      confirming={confirmingId === p.id}
+                      onEdit={() => setView({ kind: "edit", personality: p })}
+                      onRequestDelete={() => setConfirmingId(p.id)}
+                      onCancelDelete={() => setConfirmingId(null)}
+                      onConfirmDelete={() => void handleDelete(p)}
+                    />
+                  ))}
+                </Section>
+              ) : null}
+
+              <Section title="Public" icon={Users}>
+                {others.length === 0 ? (
+                  <p className="px-1 text-xs text-muted-foreground">
+                    No public personalities yet.
+                  </p>
+                ) : (
+                  others.map((p) => (
+                    <PersonalityRow key={p.id} personality={p} editable={false} />
+                  ))
+                )}
+              </Section>
+
+              {personalities.length === 0 ? (
+                <EmptyState
+                  icon={UserRound}
+                  title="No personalities yet"
+                  description="Create one to give the AI a custom voice and instructions."
+                />
+              ) : null}
+            </div>
+          </>
+        ) : (
+          <PersonalityForm
+            personality={view.personality}
+            onCancel={() => setView({ kind: "list" })}
+            onSaved={(saved, wasCreate) => {
+              onChanged(wasCreate ? { created: saved } : { updated: saved });
+              setView({ kind: "list" });
+            }}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Section({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon: typeof UserRound;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <Icon className="h-3.5 w-3.5" aria-hidden />
+        {title}
+      </div>
+      <div className="space-y-1.5">{children}</div>
+    </div>
+  );
+}
+
+function PersonalityRow({
+  personality,
+  editable,
+  deleting,
+  confirming,
+  onEdit,
+  onRequestDelete,
+  onCancelDelete,
+  onConfirmDelete,
+}: {
+  personality: Personality;
+  editable: boolean;
+  deleting?: boolean;
+  confirming?: boolean;
+  onEdit?: () => void;
+  onRequestDelete?: () => void;
+  onCancelDelete?: () => void;
+  onConfirmDelete?: () => void;
+}) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-border bg-card/50 px-3 py-2.5">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-medium">{personality.display_name}</span>
+          {personality.is_public ? (
+            <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+              public
+            </Badge>
+          ) : null}
+        </div>
+        {confirming ? (
+          <p className="mt-0.5 text-xs text-destructive">
+            Delete this personality? This can&rsquo;t be undone.
+          </p>
+        ) : (
+          <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+            {personality.system_message}
+          </p>
+        )}
+      </div>
+      {editable ? (
+        confirming ? (
+          <div className="flex shrink-0 gap-1.5">
+            <Button variant="outline" size="sm" onClick={onCancelDelete}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={onConfirmDelete}
+              disabled={deleting}
+            >
+              {deleting ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                "Delete"
+              )}
+            </Button>
+          </div>
+        ) : (
+          <div className="flex shrink-0 gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-muted-foreground"
+              aria-label={`Edit ${personality.display_name}`}
+              onClick={onEdit}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-destructive"
+              aria-label={`Delete ${personality.display_name}`}
+              onClick={onRequestDelete}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+function PersonalityForm({
+  personality,
+  onCancel,
+  onSaved,
+}: {
+  personality: Personality | null;
+  onCancel: () => void;
+  onSaved: (saved: Personality, wasCreate: boolean) => void;
+}) {
+  const [displayName, setDisplayName] = useState(personality?.display_name ?? "");
+  const [systemMessage, setSystemMessage] = useState(
+    personality?.system_message ?? "",
+  );
+  const [isPublic, setIsPublic] = useState(personality?.is_public ?? false);
+  const [saving, setSaving] = useState(false);
+
+  const canSave =
+    displayName.trim().length > 0 && systemMessage.trim().length > 0 && !saving;
+
+  async function save() {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const input = {
+        display_name: displayName.trim(),
+        system_message: systemMessage.trim(),
+        is_public: isPublic,
+      };
+      const saved = personality
+        ? await ai.personalities.update(personality.id, input)
+        : await ai.personalities.create(input);
+      toast.success(personality ? "Personality updated" : "Personality created");
+      onSaved(saved, !personality);
+    } catch {
+      toast.error("Couldn't save that personality. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {personality ? "Edit personality" : "New personality"}
+        </DialogTitle>
+        <DialogDescription>
+          The system message is sent to the model before every reply in a
+          conversation using this personality.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="personality-name">Name</Label>
+          <Input
+            id="personality-name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value.slice(0, NAME_MAX))}
+            placeholder="e.g. Patient Zcash tutor"
+            maxLength={NAME_MAX}
+            autoFocus
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="personality-message">System message</Label>
+          <Textarea
+            id="personality-message"
+            value={systemMessage}
+            onChange={(e) =>
+              setSystemMessage(e.target.value.slice(0, MESSAGE_MAX))
+            }
+            placeholder="You are..."
+            className="min-h-[140px] resize-y"
+          />
+          <p className="text-xs tabular-nums text-muted-foreground">
+            {systemMessage.length} / {MESSAGE_MAX}
+          </p>
+        </div>
+
+        <div className="flex items-center justify-between rounded-lg border border-border bg-card/50 px-3 py-2.5">
+          <div>
+            <Label htmlFor="personality-public">Public</Label>
+            <p className="text-xs text-muted-foreground">
+              Anyone can discover and use this personality (they can't edit or
+              delete it).
+            </p>
+          </div>
+          <Switch
+            id="personality-public"
+            checked={isPublic}
+            onCheckedChange={setIsPublic}
+          />
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel} disabled={saving}>
+          Cancel
+        </Button>
+        <Button onClick={() => void save()} disabled={!canSave}>
+          {saving ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Saving
+            </>
+          ) : (
+            "Save"
+          )}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/wallet/zuuli/src/features/ai/PersonalityPicker.tsx
+++ b/wallet/zuuli/src/features/ai/PersonalityPicker.tsx
@@ -1,0 +1,163 @@
+import { Check, ChevronsUpDown, Settings2, UserRound, Users } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { Personality } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+
+interface PersonalityPickerProps {
+  personalities: Personality[];
+  value: Personality | null;
+  onChange: (personality: Personality | null) => void;
+  onManage: () => void;
+  ownUsername?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Lets the user prime the AI with a custom system message. "Default" (no
+ * personality) falls back to the selected model's own system message —
+ * exactly what the backend does when a conversation's `personality` is null.
+ */
+export function PersonalityPicker({
+  personalities,
+  value,
+  onChange,
+  onManage,
+  ownUsername,
+  disabled,
+}: PersonalityPickerProps) {
+  const mine = personalities.filter((p) => p.creator === ownUsername);
+  const others = personalities.filter((p) => p.creator !== ownUsername);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className="h-10 min-w-0 max-w-full justify-start gap-2.5 pr-2"
+          disabled={disabled}
+          aria-label="Select AI personality"
+        >
+          <UserRound className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          <span className="min-w-0 flex-1 truncate text-left font-medium">
+            {value?.display_name ?? "Default persona"}
+          </span>
+          <ChevronsUpDown className="ml-auto text-muted-foreground" aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[min(22rem,90vw)]">
+        <DropdownMenuItem
+          onSelect={() => onChange(null)}
+          className="items-start gap-2.5 py-2"
+        >
+          <div className="min-w-0 flex-1">
+            <div className="font-medium">Default persona</div>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Use the selected model's built-in system message.
+            </p>
+          </div>
+          {value === null ? (
+            <Check className="mt-1 h-4 w-4 shrink-0 text-primary" aria-hidden />
+          ) : null}
+        </DropdownMenuItem>
+
+        {mine.length > 0 ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="flex items-center gap-1.5">
+              <UserRound className="h-3.5 w-3.5" aria-hidden />
+              Mine
+            </DropdownMenuLabel>
+            {mine.map((p) => (
+              <PersonalityItem
+                key={p.id}
+                personality={p}
+                selected={p.id === value?.id}
+                onSelect={() => onChange(p)}
+              />
+            ))}
+          </>
+        ) : null}
+
+        {others.length > 0 ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="flex items-center gap-1.5">
+              <Users className="h-3.5 w-3.5" aria-hidden />
+              Public
+            </DropdownMenuLabel>
+            {others.map((p) => (
+              <PersonalityItem
+                key={p.id}
+                personality={p}
+                selected={p.id === value?.id}
+                onSelect={() => onChange(p)}
+              />
+            ))}
+          </>
+        ) : null}
+
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onManage} className="gap-2.5">
+          <Settings2 className="h-4 w-4 text-muted-foreground" aria-hidden />
+          Manage personalities…
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function PersonalityItem({
+  personality,
+  selected,
+  onSelect,
+}: {
+  personality: Personality;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <DropdownMenuItem onSelect={onSelect} className="items-start gap-2.5 py-2">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-medium">{personality.display_name}</span>
+          {personality.is_public ? (
+            <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+              public
+            </Badge>
+          ) : null}
+        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <p className="mt-0.5 line-clamp-1 text-left text-xs text-muted-foreground">
+              {personality.system_message}
+            </p>
+          </TooltipTrigger>
+          <TooltipContent
+            side="bottom"
+            align="start"
+            className={cn("max-w-xs text-left")}
+          >
+            {personality.system_message}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      {selected ? (
+        <Check className="mt-1 h-4 w-4 shrink-0 text-primary" aria-hidden />
+      ) : null}
+    </DropdownMenuItem>
+  );
+}

--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUp,
   Coins,
   Cpu,
+  RotateCcw,
   ShieldCheck,
   Sparkles,
   Square,
@@ -18,11 +19,13 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { Markdown } from "@/components/common/Markdown";
 import { ai } from "@/lib/api/free2z";
-import type { AIModel, PromptResponse } from "@/lib/api/types";
+import type { AIModel, Personality } from "@/lib/api/types";
 import { formatTuzis, initials } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { useSession } from "@/store/session";
 import { ModelPicker } from "./ModelPicker";
+import { PersonalityManager } from "./PersonalityManager";
+import { PersonalityPicker } from "./PersonalityPicker";
 import { pricePerMessage, providerMeta } from "./providers";
 
 interface ChatMessage {
@@ -36,10 +39,19 @@ interface ChatMessage {
   /** Generation was stopped by the user. */
   aborted?: boolean;
   modelName?: string;
+  personalityName?: string;
   tuzisCharged?: number;
   inputTokens?: number;
   outputTokens?: number;
 }
+
+/**
+ * The real conversation endpoint (see `ai.conversations` below) enforces a
+ * 100-2Z minimum balance before it will start a turn — a reserve requirement
+ * the old flat `/api/openai/prompt` endpoint didn't have. Mirrored here so
+ * the composer disables itself before the backend would reject the call.
+ */
+const MIN_TUZIS_TO_CHAT = 100;
 
 const EXAMPLE_PROMPTS = [
   "Explain zero-knowledge proofs like I'm five.",
@@ -52,15 +64,10 @@ let idCounter = 0;
 const nextId = () => `m-${Date.now()}-${idCounter++}`;
 
 /**
- * Wraps ai.prompt so an AbortController rejects the pending call even in mock
- * mode (where the mock resolver ignores the signal).
+ * Races a promise against an AbortController so cancellation works even in
+ * mock mode (whose fixtures ignore the signal they're handed).
  */
-function promptWithAbort(args: {
-  model: AIModel;
-  prompt: string;
-  signal: AbortSignal;
-}): Promise<PromptResponse> {
-  const { signal } = args;
+function withAbort<T>(run: () => Promise<T>, signal: AbortSignal): Promise<T> {
   return new Promise((resolve, reject) => {
     if (signal.aborted) {
       reject(new DOMException("Aborted", "AbortError"));
@@ -68,8 +75,7 @@ function promptWithAbort(args: {
     }
     const onAbort = () => reject(new DOMException("Aborted", "AbortError"));
     signal.addEventListener("abort", onAbort, { once: true });
-    ai
-      .prompt(args)
+    run()
       .then(resolve, reject)
       .finally(() => signal.removeEventListener("abort", onAbort));
   });
@@ -81,15 +87,25 @@ function isAbortError(err: unknown): boolean {
     : (err as { name?: string })?.name === "AbortError";
 }
 
+/** Key identifying which (model, personality) pair a live conversation belongs to. */
+function conversationKey(model: AIModel, personality: Personality | null): string {
+  return `${model.id}:${personality?.id ?? "default"}`;
+}
+
 export default function AiFeature() {
   const user = useSession((s) => s.user);
   const tuzis = useSession((s) => s.tuzis);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
+  const refreshSession = useSession((s) => s.refresh);
 
   const [models, setModels] = useState<AIModel[]>([]);
   const [loadingModels, setLoadingModels] = useState(true);
   const [modelsError, setModelsError] = useState(false);
   const [selected, setSelected] = useState<AIModel | null>(null);
+
+  const [personalities, setPersonalities] = useState<Personality[]>([]);
+  const [personality, setPersonality] = useState<Personality | null>(null);
+  const [managerOpen, setManagerOpen] = useState(false);
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
@@ -97,14 +113,17 @@ export default function AiFeature() {
   const [sessionCost, setSessionCost] = useState(0);
 
   const abortRef = useRef<AbortController | null>(null);
+  // Which live backend conversation (if any) the next turn continues — pinned
+  // to a single (model, personality) pair for its lifetime.
+  const conversationRef = useRef<{ id: string; key: string } | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  const lowBalance = tuzis <= 0;
+  const lowBalance = tuzis < MIN_TUZIS_TO_CHAT;
   const canSend =
     !!selected && !isSending && !lowBalance && input.trim().length > 0;
 
-  // Load models once; default to the first GA model.
+  // Load models + personalities once; default to the first GA model.
   useEffect(() => {
     let active = true;
     ai
@@ -117,6 +136,12 @@ export default function AiFeature() {
       })
       .catch(() => active && setModelsError(true))
       .finally(() => active && setLoadingModels(false));
+    ai.personalities
+      .list()
+      .then((list) => active && setPersonalities(list))
+      .catch(() => {
+        /* personalities are optional — chat still works with the default persona */
+      });
     return () => {
       active = false;
     };
@@ -130,12 +155,19 @@ export default function AiFeature() {
   // Abort any in-flight request on unmount.
   useEffect(() => () => abortRef.current?.abort(), []);
 
+  const startNewChat = useCallback(() => {
+    conversationRef.current = null;
+    setMessages([]);
+    setSessionCost(0);
+  }, []);
+
   const send = useCallback(
     async (text: string) => {
       const prompt = text.trim();
-      if (!prompt || !selected || isSending || tuzis <= 0) return;
+      if (!prompt || !selected || isSending || tuzis < MIN_TUZIS_TO_CHAT) return;
 
       const model = selected;
+      const pers = personality;
       const placeholderId = nextId();
       setMessages((prev) => [
         ...prev,
@@ -146,6 +178,7 @@ export default function AiFeature() {
           content: "",
           pending: true,
           modelName: model.display_name,
+          personalityName: pers?.display_name,
         },
       ]);
       setInput("");
@@ -155,11 +188,44 @@ export default function AiFeature() {
       abortRef.current = controller;
 
       try {
-        const res = await promptWithAbort({
-          model,
-          prompt,
-          signal: controller.signal,
-        });
+        // A conversation is pinned to one (model, personality) pair for its
+        // lifetime — start a new one whenever that pair changes.
+        const key = conversationKey(model, pers);
+        if (!conversationRef.current || conversationRef.current.key !== key) {
+          const convo = await ai.conversations.create({
+            displayName: prompt.slice(0, 60) || "New chat",
+            model,
+            personality: pers,
+          });
+          conversationRef.current = { id: convo.id, key };
+        }
+
+        const beforeTuzis = useSession.getState().tuzis;
+        const res = await withAbort(
+          () =>
+            ai.conversations.sendMessage({
+              conversationId: conversationRef.current!.id,
+              userInput: prompt,
+              model,
+              personality: pers,
+              signal: controller.signal,
+            }),
+          controller.signal,
+        );
+
+        let tuzisCharged = res.tuzis_charged;
+        if (tuzisCharged != null) {
+          // Mock mode (and any endpoint that returns it directly): apply
+          // optimistically.
+          adjustTuzis(-tuzisCharged);
+        } else {
+          // The real conversation endpoint doesn't return a per-message cost
+          // breakdown, so sync the authoritative balance from the account
+          // and derive the exact charge from the delta.
+          await refreshSession();
+          tuzisCharged = Math.max(0, beforeTuzis - useSession.getState().tuzis);
+        }
+
         setMessages((prev) =>
           prev.map((m) =>
             m.id === placeholderId
@@ -168,16 +234,16 @@ export default function AiFeature() {
                   pending: false,
                   content: res.response,
                   modelName: res.model ?? model.display_name,
-                  tuzisCharged: res.tuzis_charged,
+                  personalityName: res.personality ?? pers?.display_name,
+                  tuzisCharged,
                   inputTokens: res.input_tokens,
                   outputTokens: res.output_tokens,
                 }
               : m,
           ),
         );
-        if (res.tuzis_charged) {
-          adjustTuzis(-res.tuzis_charged);
-          setSessionCost((c) => c + (res.tuzis_charged ?? 0));
+        if (tuzisCharged) {
+          setSessionCost((c) => c + (tuzisCharged ?? 0));
         }
       } catch (err) {
         const aborted = isAbortError(err);
@@ -202,7 +268,7 @@ export default function AiFeature() {
         setIsSending(false);
       }
     },
-    [selected, isSending, tuzis, adjustTuzis],
+    [selected, personality, isSending, tuzis, adjustTuzis, refreshSession],
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -236,7 +302,7 @@ export default function AiFeature() {
             </div>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {loadingModels ? (
               <Skeleton className="h-10 w-52" />
             ) : modelsError ? (
@@ -251,6 +317,26 @@ export default function AiFeature() {
                 disabled={isSending}
               />
             )}
+            <PersonalityPicker
+              personalities={personalities}
+              value={personality}
+              onChange={setPersonality}
+              onManage={() => setManagerOpen(true)}
+              ownUsername={user?.username}
+              disabled={isSending}
+            />
+            {messages.length > 0 ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10 shrink-0 text-muted-foreground"
+                aria-label="Start a new chat"
+                onClick={startNewChat}
+                disabled={isSending}
+              >
+                <RotateCcw className="h-4 w-4" />
+              </Button>
+            ) : null}
           </div>
 
           {/* Cost meters */}
@@ -274,7 +360,8 @@ export default function AiFeature() {
           <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm">
             <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" aria-hidden />
             <span className="text-foreground">
-              You&rsquo;re out of 2Zs. Top up to keep chatting.
+              You need at least {formatTuzis(MIN_TUZIS_TO_CHAT)} to start
+              chatting. Top up to continue.
             </span>
             <Button asChild size="sm" className="ml-auto">
               <Link to="/buy">Buy 2Zs</Link>
@@ -357,7 +444,9 @@ export default function AiFeature() {
             </span>
             {selected ? (
               <span className="tabular-nums">
-                {selected.display_name} · ~{pricePerMessage(selected)}
+                {selected.display_name}
+                {personality ? ` · ${personality.display_name}` : ""} · ~
+                {pricePerMessage(selected)}
               </span>
             ) : (
               <span />
@@ -365,6 +454,32 @@ export default function AiFeature() {
           </div>
         </div>
       </div>
+
+      <PersonalityManager
+        open={managerOpen}
+        onOpenChange={setManagerOpen}
+        personalities={personalities}
+        ownUsername={user?.username}
+        isAuthed={!!user}
+        onChanged={(change) => {
+          if (change.created) {
+            setPersonalities((prev) => [...prev, change.created!]);
+            setPersonality(change.created);
+          } else if (change.updated) {
+            setPersonalities((prev) =>
+              prev.map((p) => (p.id === change.updated!.id ? change.updated! : p)),
+            );
+            setPersonality((cur) =>
+              cur?.id === change.updated!.id ? change.updated! : cur,
+            );
+          } else if (change.deletedId) {
+            setPersonalities((prev) =>
+              prev.filter((p) => p.id !== change.deletedId),
+            );
+            setPersonality((cur) => (cur?.id === change.deletedId ? null : cur));
+          }
+        }}
+      />
     </div>
   );
 }
@@ -430,6 +545,14 @@ function MessageRow({
           <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 px-1 text-[11px] tabular-nums text-muted-foreground">
             {message.modelName ? (
               <span className="text-foreground/70">{message.modelName}</span>
+            ) : null}
+            {message.personalityName ? (
+              <>
+                <span aria-hidden>·</span>
+                <span className="text-foreground/70">
+                  as {message.personalityName}
+                </span>
+              </>
             ) : null}
             {message.tuzisCharged != null ? (
               <>

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -13,19 +13,25 @@ import {
   mockAiReply,
   mockArticleFeed,
   mockArticles,
+  mockConversationReply,
+  mockCreatePersonality,
   mockCreatorDetail,
   mockCreators,
+  mockDeletePersonality,
   mockKycIdentityDocuments,
   mockKycProfile,
   mockKycTaxForm,
   mockLivestreams,
   mockModels,
+  mockPersonalities,
   mockSearchCreators,
   mockSearchPages,
   mockTransactions,
+  mockUpdatePersonality,
   mockUser,
 } from "./mock-data";
 import type {
+  AIConversation,
   AIModel,
   Article,
   ArticleFeedPage,
@@ -44,6 +50,8 @@ import type {
   LoginResult,
   OtpStatus,
   Paginated,
+  Personality,
+  PersonalityInput,
   PricingQuote,
   PricingSnapshot,
   ProfileUpdateInput,
@@ -440,6 +448,34 @@ export const profile = {
 };
 
 // ─── AI ─────────────────────────────────────────────────────────────────────
+
+/** Raw shape of PromptResponseSerializer (`__all__` on the PromptResponse model). */
+interface RawConversationPromptResponse {
+  id: string;
+  user_input: string;
+  response: string;
+  created_at?: string;
+  ai_model?: { display_name?: string } | null;
+  personality?: { display_name?: string } | null;
+}
+
+function normalizeConversationReply(
+  raw: RawConversationPromptResponse,
+  fallbackModelName: string,
+): PromptResponse {
+  return {
+    id: raw.id,
+    prompt: raw.user_input,
+    response: raw.response,
+    model: raw.ai_model?.display_name ?? fallbackModelName,
+    personality: raw.personality?.display_name,
+    created_at: raw.created_at,
+    // The backend doesn't return per-message token/cost breakdown on this
+    // endpoint — callers sync the real charge from the account balance
+    // (`auth.me().tuzis`) instead of guessing it here.
+  };
+}
+
 export const ai = {
   async models(): Promise<AIModel[]> {
     if (useMock()) {
@@ -484,6 +520,131 @@ export const ai = {
       created_at: new Date().toISOString(),
       tuzis_charged: 1,
     };
+  },
+
+  /**
+   * Custom system messages a user can create, edit, share (`is_public`) and
+   * select to prime the AI. Full CRUD over `/api/ai/personalities/`
+   * (DRF ModelViewSet, `IsAuthenticatedOrReadOnly`): GET lists your own plus
+   * public personalities; POST/PATCH/DELETE only ever touch your own.
+   */
+  personalities: {
+    async list(): Promise<Personality[]> {
+      if (useMock()) {
+        await delay();
+        return [...mockPersonalities];
+      }
+      const page = await request<Paginated<Personality>>(
+        "/api/ai/personalities/",
+        { query: { page_size: 100 }, anonymous: true },
+      );
+      return page.results ?? [];
+    },
+
+    async create(input: PersonalityInput): Promise<Personality> {
+      if (useMock()) {
+        await delay();
+        return mockCreatePersonality(input);
+      }
+      return request<Personality>("/api/ai/personalities/", {
+        method: "POST",
+        body: input,
+      });
+    },
+
+    async update(
+      id: string,
+      input: Partial<PersonalityInput>,
+    ): Promise<Personality> {
+      if (useMock()) {
+        await delay();
+        return mockUpdatePersonality(id, input);
+      }
+      return request<Personality>(`/api/ai/personalities/${id}/`, {
+        method: "PATCH",
+        body: input,
+      });
+    },
+
+    async delete(id: string): Promise<void> {
+      if (useMock()) {
+        await delay();
+        mockDeletePersonality(id);
+        return;
+      }
+      await request<void>(`/api/ai/personalities/${id}/`, {
+        method: "DELETE",
+      });
+    },
+  },
+
+  /**
+   * Stateful chat threads (`/api/ai/conversations/`). This is the path that
+   * actually applies a personality's `system_message` to the model: the
+   * flat `ai.prompt()` above (`/api/openai/prompt`) is a fixed legacy
+   * endpoint that ignores both the model and any personality. A
+   * conversation pins one `ai_model` + optional `personality` for its
+   * lifetime; the backend replays every prior turn as history, so real
+   * multi-turn memory is a side benefit of wiring this up.
+   */
+  conversations: {
+    async create(args: {
+      displayName: string;
+      model: AIModel;
+      personality?: Personality | null;
+    }): Promise<AIConversation> {
+      if (useMock()) {
+        await delay(200);
+        return {
+          id: `conv-mock-${Date.now()}`,
+          display_name: args.displayName,
+          ai_model: args.model.id,
+          personality: args.personality?.id ?? null,
+          model_name: args.model.display_name,
+        };
+      }
+      const body: Record<string, unknown> = {
+        display_name: args.displayName,
+        ai_model: args.model.id,
+      };
+      if (args.personality) body.personality = args.personality.id;
+      return request<AIConversation>("/api/ai/conversations/", {
+        method: "POST",
+        body,
+      });
+    },
+
+    /**
+     * Post a turn to an existing conversation. Streams over a websocket on
+     * the backend, but this also resolves synchronously with the full
+     * reply, so callers that don't need live word-by-word streaming (e.g.
+     * this PR's chat UI) can just await it.
+     */
+    async sendMessage(args: {
+      conversationId: string;
+      userInput: string;
+      model: AIModel;
+      personality?: Personality | null;
+      signal?: AbortSignal;
+    }): Promise<PromptResponse> {
+      if (useMock()) {
+        await delay(700);
+        return mockConversationReply(
+          args.userInput,
+          args.model.display_name,
+          args.personality ?? null,
+        );
+      }
+      const raw = await request<RawConversationPromptResponse>(
+        `/api/ai/conversations/${args.conversationId}/promptresponses/`,
+        {
+          method: "POST",
+          body: { user_input: args.userInput },
+          signal: args.signal,
+        },
+      );
+      return normalizeConversationReply(raw, args.model.display_name);
+    },
   },
 };
 

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -12,6 +12,8 @@ import type {
   KycIdentityDocuments,
   KycProfile,
   Livestream,
+  Personality,
+  PersonalityInput,
   PromptResponse,
   SimpleCreator,
   TuziTransaction,
@@ -254,6 +256,68 @@ export const mockModels: AIModel[] = [
     provider: "local",
   },
 ];
+
+// Mutated in place by the CRUD helpers below so create/edit/delete persist
+// across the mock session, mirroring how `mockUser` is updated by `Object.assign`.
+export const mockPersonalities: Personality[] = [
+  {
+    id: "pers-default-helpful",
+    display_name: "Default assistant",
+    system_message: "You are a helpful, privacy-respecting assistant.",
+    is_public: true,
+    creator: null,
+  },
+  {
+    id: "pers-zk-tutor",
+    display_name: "ZK Tutor",
+    system_message:
+      "You are a patient cryptography tutor who explains zero-knowledge proofs, " +
+      "Zcash shielded transactions and Halo2 circuits with concrete analogies " +
+      "before diving into the math. Keep answers concise unless asked to go deeper.",
+    is_public: true,
+    creator: null,
+  },
+  {
+    id: "pers-first-mate",
+    display_name: "Salty First Mate",
+    system_message:
+      "You are a gruff but good-hearted ship's first mate. Answer every " +
+      "question helpfully and accurately, but narrate it like you're on the " +
+      "deck of a privacy-loving pirate ship. Light on the nautical slang — " +
+      "don't overdo it.",
+    is_public: false,
+    creator: mockUser.username,
+  },
+];
+
+let mockPersonalityIdCounter = 0;
+
+export function mockCreatePersonality(input: PersonalityInput): Personality {
+  const personality: Personality = {
+    id: `pers-mock-${Date.now()}-${mockPersonalityIdCounter++}`,
+    display_name: input.display_name,
+    system_message: input.system_message,
+    is_public: input.is_public,
+    creator: mockUser.username,
+  };
+  mockPersonalities.push(personality);
+  return personality;
+}
+
+export function mockUpdatePersonality(
+  id: string,
+  input: Partial<PersonalityInput>,
+): Personality {
+  const existing = mockPersonalities.find((p) => p.id === id);
+  if (!existing) throw new Error("Personality not found");
+  Object.assign(existing, input);
+  return existing;
+}
+
+export function mockDeletePersonality(id: string): void {
+  const idx = mockPersonalities.findIndex((p) => p.id === id);
+  if (idx !== -1) mockPersonalities.splice(idx, 1);
+}
 
 export const mockLivestreams: Livestream[] = [
   {
@@ -548,6 +612,42 @@ export function mockAiReply(prompt: string, modelName: string): PromptResponse {
     prompt,
     response,
     model: modelName,
+    created_at: new Date().toISOString(),
+    input_tokens: Math.ceil(prompt.length / 4),
+    output_tokens: Math.ceil(response.length / 4),
+    tuzis_charged: 4,
+  };
+}
+
+/**
+ * Mock reply for the stateful conversation flow (`ai.conversations.sendMessage`).
+ * Unlike `mockAiReply`, this echoes the active personality's `system_message`
+ * back so it's obvious offline that the personality is what's priming the model.
+ */
+export function mockConversationReply(
+  prompt: string,
+  modelName: string,
+  personality: Personality | null,
+): PromptResponse {
+  const primer = personality
+    ? `*(${modelName}, primed as “${personality.display_name}”)*\n\n` +
+      `_System prompt: "${personality.system_message.slice(0, 160)}${
+        personality.system_message.length > 160 ? "…" : ""
+      }"_\n\n`
+    : `*(${modelName}, default persona — via the free2z API, the provider never sees you)*\n\n`;
+  const response =
+    primer +
+    `You asked: "${prompt.slice(0, 140)}${prompt.length > 140 ? "…" : ""}"\n\n` +
+    `Here's a reply in character. In the live app this streams from the model you ` +
+    `picked, with the personality's system message steering every turn of this ` +
+    `conversation, and you're charged the exact upstream cost plus margin, rounded ` +
+    `up to whole 2Zs.`;
+  return {
+    id: `pr-${Math.abs(hashString(prompt + (personality?.id ?? "")))}`,
+    prompt,
+    response,
+    model: modelName,
+    personality: personality?.display_name,
     created_at: new Date().toISOString(),
     input_tokens: Math.ceil(prompt.length / 4),
     output_tokens: Math.ceil(response.length / 4),

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -121,6 +121,8 @@ export interface PromptResponse {
   prompt: string;
   response: string;
   model?: string;
+  /** Display name of the personality that primed this reply, if any. */
+  personality?: string;
   created_at?: string;
   /** 2Zs charged for this exchange (cost-plus, rounded up). */
   tuzis_charged?: number;
@@ -128,13 +130,46 @@ export interface PromptResponse {
   output_tokens?: number;
 }
 
+/**
+ * A custom system message a user can create, edit and select to prime the AI
+ * (`/api/ai/personalities/`, DRF ModelViewSet). Anyone can read public
+ * personalities (plus their own private ones); only the creator can edit or
+ * delete theirs. `creator` is omitted/undefined for built-in, creator-less
+ * public personalities.
+ */
+export interface Personality {
+  id: string;
+  display_name: string;
+  system_message: string;
+  is_public: boolean;
+  /** Username of the creator; absent for built-in personalities. */
+  creator?: string | null;
+}
+
+/** Body for creating/editing a personality — everything but the server-set fields. */
+export interface PersonalityInput {
+  display_name: string;
+  system_message: string;
+  is_public: boolean;
+}
+
+/**
+ * A stateful chat thread (`/api/ai/conversations/`). Pairs one `ai_model`
+ * with an optional `personality` for the lifetime of the thread — the
+ * backend replays `prompt_response_set` as history on every turn, so
+ * switching model or personality starts a new conversation.
+ */
 export interface AIConversation {
   id: string;
-  title?: string;
-  model?: string;
+  display_name: string;
+  ai_model: string;
+  personality?: string | null;
+  model_name?: string;
+  is_public?: boolean;
+  is_subscriber_only?: boolean;
   created_at?: string;
   updated_at?: string;
-  is_public?: boolean;
+  tags?: string[];
   promptresponses?: PromptResponse[];
 }
 


### PR DESCRIPTION
## What

Lets ZUULI users create, edit, delete and select custom AI "personalities"
(a display name + `system_message` + `is_public` toggle) in AI Studio, and
actually applies the selected personality's system message to the model.

## Endpoints

- `GET/POST /api/ai/personalities/`, `PATCH/DELETE /api/ai/personalities/{id}/`
  — full CRUD over the existing `AIPersonalityViewSet`
  (`IsAuthenticatedOrReadOnly`). GET returns your own + public personalities;
  write ops only ever touch your own. Wired additively in `src/lib/api/free2z.ts`
  under `ai.personalities`, with `Personality` / `PersonalityInput` types in
  `src/lib/api/types.ts`.

## How the system message reaches the model

The chat previously called the flat `POST /api/openai/prompt` endpoint. I
checked the actual backend implementation (`tuzi/py/dj/apps/openai/views.py`,
`PromptView`) and confirmed it's a fixed legacy view: it hardcodes
`gpt-3.5-turbo-instruct`, ignores the `model` field the client already sends,
and has no concept of a system message or personality at all — there is no
way to make it honor a personality.

The only path that actually applies `personality.system_message` is the
stateful conversation flow:

1. `POST /api/ai/conversations/` with `{ ai_model, personality }` — pins one
   model + optional personality for the thread's lifetime.
2. `POST /api/ai/conversations/{conversation_id}/promptresponses/` with
   `{ user_input }` — the backend's `Conversation.next_response()` builds
   the message list with `{"role": "system", "content": personality.system_message}`
   (falling back to `ai_model.system_message` when there's no personality),
   replays every prior turn in the conversation as history, and returns the
   full reply synchronously (it also streams over a websocket, which this PR
   doesn't wire up — the synchronous response is enough for the existing UI).

`src/features/ai/index.tsx` now uses this flow instead of the flat prompt
endpoint. This is a strict upgrade, not just a personality carrier: the old
flow never sent conversation history to the model at all (every message was
answered in isolation), so real multi-turn memory is a side effect of
switching to it. A conversation is pinned to one (model, personality) pair;
changing either transparently starts a new backend conversation (existing
transcript stays visible, but the model's own memory resets for that pair).

**Limitation surfaced by this switch:** the real conversation endpoint
(`PromptResponseViewSet.create`) enforces a 100-2Z minimum balance that the
old flat endpoint didn't have, and it doesn't return a per-message cost
breakdown. I updated the composer's low-balance gate to match (100 2Z, was
"any balance > 0"), and the displayed charge is now derived from the delta
in the account's real balance (`auth.me().tuzis`, via a `session.refresh()`)
rather than guessed client-side — more accurate than the flat endpoint's
hardcoded `1` before it.

## UI

- `src/features/ai/PersonalityPicker.tsx` — dropdown next to the model
  picker (mirrors `ModelPicker.tsx`): "Default persona" (maps to
  `personality: null`), your own personalities under "Mine", others under
  "Public", plus a "Manage personalities…" entry.
- `src/features/ai/PersonalityManager.tsx` — dialog with full CRUD: list
  (mine + public), create/edit (name, system message, public toggle),
  delete your own (inline two-step confirm, not `window.confirm()` — a
  blocking native dialog freezes the render thread, which I hit directly
  while testing with CDP-driven automation and don't want in a themed
  Tauri/browser app either).
- A "new chat" reset button appears once a thread has messages.
- Assistant messages show which model + personality answered and the real
  2Z charge.

## Mock support

`src/lib/api/mock-data.ts` adds three sample personalities (a public
default, a public "ZK Tutor", and a private "Salty First Mate" owned by the
mock user) with in-memory CRUD helpers, plus `mockConversationReply()`,
which echoes the active personality's `system_message` back in the reply
so the effect is visible with `VITE_MOCK=1` and no backend.

## Verification

- `npm run typecheck` and `npm run build` both pass.
- Manually exercised in the browser with `VITE_MOCK=1 npm run dev`:
  created a personality ("Haiku Bot"), selected it, sent two chat turns
  under two different personalities in the same thread (each correctly
  started its own conversation and echoed its own system message), watched
  the 2Z balance update per turn, and deleted a personality via the fixed
  inline confirm flow. Screenshots taken throughout confirm the picker,
  manager dialog, and chat integration all work end-to-end in mock mode.

`ai.models` / `ai.prompt` are untouched — all additions are additive within
the `ai` object and `types.ts`.