### PR TITLE
feat(zuuli): link a Zcash key to your account (Linked identities)

### DIFF
--- a/wallet/zuuli/src/features/auth/useZcashAssociate.ts
+++ b/wallet/zuuli/src/features/auth/useZcashAssociate.ts
@@ -1,0 +1,73 @@
+// Link a Zcash key to the CURRENTLY SIGNED-IN account.
+//
+// A sibling of `useZcashLogin.ts`: both run the exact same
+// challenge → sign → verify stepper (`useZcashChallengeFlow`), so the crypto
+// is never duplicated. The only differences are:
+//   - the final verify call attaches the session's knox token (NOT anonymous)
+//     via `auth.zcashAssociate`, so the backend links the address to this
+//     account instead of logging in/creating a new one;
+//   - on success we update the signed-in user in place (no navigation — the
+//     caller stays on the profile page and shows the linked identity).
+//
+// The backend (`POST /api/auth/zcash/login/` with a knox token attached)
+// returns 409 for either conflict: the address is already linked to another
+// account, or this account already has a linked Zcash identity —
+// `auth.zcashAssociate` turns both into a single friendly message that lands
+// on the "verify" step, same as any other server-side failure.
+
+import { toast } from "sonner";
+import { auth } from "@/lib/api/free2z";
+import { useSession } from "@/store/session";
+import {
+  useZcashChallengeFlow,
+  type StepMeta,
+  type StepKey,
+  type ZcashChallengeFlowState,
+} from "./useZcashChallengeFlow";
+
+export const LINK_STEP_META: Record<StepKey, StepMeta> = {
+  prepare: {
+    key: "prepare",
+    title: "Preparing your identity",
+    detail: "Locating the Zcash key that will represent you. No key ever leaves this device.",
+  },
+  challenge: {
+    key: "challenge",
+    title: "Requesting a challenge",
+    detail: "Asking free2z for a one-time, timestamped nonce to sign — bound to this session, so it can't be replayed.",
+  },
+  sign: {
+    key: "sign",
+    title: "Signing with your key",
+    detail: "Producing a ZIP-304 signature over the challenge to prove you control the address.",
+  },
+  verify: {
+    key: "verify",
+    title: "Linking to your account",
+    detail: "free2z checks the signature and links this Zcash identity to your signed-in account.",
+  },
+};
+
+export type ZcashAssociateState = ZcashChallengeFlowState;
+
+export function useZcashAssociate(): ZcashAssociateState {
+  const setUser = useSession((s) => s.setUser);
+
+  return useZcashChallengeFlow({
+    verify: (signed) =>
+      auth.zcashAssociate({
+        address: signed.address,
+        challenge: signed.challenge,
+        signature: signed.signature,
+        pubkey: signed.pubkey,
+      }),
+    verifyErrorMessage:
+      "free2z couldn't link that Zcash key. Please try again.",
+    onVerified: (user) => setUser(user),
+    afterSuccess: () => {
+      toast.success("Zcash key linked", {
+        description: "This Zcash identity is now linked to your account.",
+      });
+    },
+  });
+}

--- a/wallet/zuuli/src/features/auth/useZcashChallengeFlow.ts
+++ b/wallet/zuuli/src/features/auth/useZcashChallengeFlow.ts
@@ -1,0 +1,285 @@
+// The shared Login-with-Zcash state machine.
+//
+// Drives the challenge/response flow end-to-end:
+//   prepare identity → request challenge → sign (ZIP-304) → verify → done.
+//
+// The wallet key never leaves the device: free2z issues a one-time challenge
+// for the wallet's address, the wallet signs that exact challenge, and only
+// the { address, challenge, signature } triple is sent back. What differs
+// between CALLERS is only the final network call and what happens after it
+// succeeds:
+//   - `useZcashLogin` — POSTs anonymously; the backend logs in (or creates)
+//     the account for that address and mints a session.
+//   - `useZcashAssociate` — POSTs WITH the current session's knox token
+//     attached (not anonymous); the backend links the address to the
+//     signed-in account instead.
+// Both reuse this exact stepper so the crypto is never duplicated.
+
+import { useCallback, useRef, useState } from "react";
+import { wallet } from "@/lib/wallet/bridge";
+import type { SignedChallenge } from "@/lib/wallet/types";
+import { auth } from "@/lib/api/free2z";
+import type { AuthUser } from "@/lib/api/types";
+
+export type StepKey = "prepare" | "challenge" | "sign" | "verify";
+export type StepStatus = "pending" | "active" | "done" | "error";
+
+export type Phase =
+  | "idle" // nothing started yet
+  | "running" // walking the crypto steps
+  | "needsWallet" // no wallet on device — offer to create one
+  | "creating" // minting a fresh identity
+  | "seedReveal" // showing the recovery phrase for backup
+  | "success"
+  | "error";
+
+export const STEP_ORDER: StepKey[] = [
+  "prepare",
+  "challenge",
+  "sign",
+  "verify",
+];
+
+export interface StepMeta {
+  key: StepKey;
+  title: string;
+  /** One-line explainer of what is happening cryptographically. */
+  detail: string;
+}
+
+type Steps = Record<StepKey, StepStatus>;
+
+const freshSteps = (): Steps => ({
+  prepare: "pending",
+  challenge: "pending",
+  sign: "pending",
+  verify: "pending",
+});
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function errMessage(e: unknown): string {
+  if (e instanceof Error && e.message) return e.message;
+  if (typeof e === "string" && e) return e;
+  return "Something went wrong. Please try again.";
+}
+
+export interface ZcashChallengeFlowState {
+  phase: Phase;
+  steps: Steps;
+  /** The unified address in play (full, for truncation at the call site). */
+  address: string | null;
+  /** The recovery phrase, present ONLY during the seedReveal phase. */
+  seedPhrase: string | null;
+  error: string | null;
+  /** Convenience: 0-based index of the currently active/next step. */
+  activeIndex: number;
+  start: () => void;
+  createIdentity: () => Promise<void>;
+  confirmSeedSaved: () => void;
+  retry: () => void;
+  reset: () => void;
+}
+
+export interface ChallengeFlowConfig {
+  /**
+   * The final network call once the wallet has signed the server's
+   * challenge — either `auth.zcashLogin` (anonymous) or `auth.zcashAssociate`
+   * (authenticated, attaches the current knox token).
+   */
+  verify: (signed: SignedChallenge) => Promise<AuthUser>;
+  /** Friendly message shown when `verify` throws (a non-conflict error). */
+  verifyErrorMessage: string;
+  /** Called once `verify` resolves, so the caller can update its own state. */
+  onVerified: (user: AuthUser, address: string) => void;
+  /** Run after the phase flips to "success" (e.g. toast + navigate). */
+  afterSuccess?: (user: AuthUser, address: string) => void | Promise<void>;
+}
+
+// A friendly, step-aware message for the user. We NEVER surface the raw
+// backend string (e.g. "Challenge is missing, expired or does not match") —
+// it leaks server internals and doesn't tell the user what to do. Local
+// wallet/key errors ("prepare"/"sign") carry actionable messages we author,
+// so we keep those; server errors ("challenge"/"verify") get a clean, generic
+// message. The raw error is always logged for debugging.
+function friendlyError(
+  stage: StepKey,
+  e: unknown,
+  verifyErrorMessage: string,
+): string {
+  console.error(`Zcash challenge flow failed at "${stage}":`, e);
+  switch (stage) {
+    case "prepare":
+    case "sign":
+      return errMessage(e);
+    case "challenge":
+      return "Couldn't reach free2z to start the Zcash challenge. Check your connection and try again.";
+    case "verify":
+      // `verify` errors (e.g. a 409 conflict) already carry a caller-authored,
+      // user-safe message (see auth.zcashAssociate) — surface it as-is.
+      return errMessage(e) || verifyErrorMessage;
+  }
+}
+
+export function useZcashChallengeFlow(
+  config: ChallengeFlowConfig,
+): ZcashChallengeFlowState {
+  const { verify, verifyErrorMessage, onVerified, afterSuccess } = config;
+
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [steps, setSteps] = useState<Steps>(freshSteps);
+  const [address, setAddress] = useState<string | null>(null);
+  const [seedPhrase, setSeedPhrase] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Guards against overlapping runs (e.g. an impatient double-click).
+  const runningRef = useRef(false);
+
+  const setStep = useCallback((key: StepKey, status: StepStatus) => {
+    setSteps((prev) => ({ ...prev, [key]: status }));
+  }, []);
+
+  // The crypto half of the flow: challenge → sign → verify → done.
+  const runCrypto = useCallback(async () => {
+    // Track which step is in flight so a failure lands on the right row and
+    // gets the right friendly message.
+    let stage: StepKey = "prepare";
+    try {
+      // The identity is the wallet's transparent P2PKH t-address — the one
+      // the plugin signs with and the one free2z verifies via zcashd
+      // `verifymessage`. The server challenge MUST be requested for THIS
+      // exact address: the backend keys the one-time nonce by address, so if
+      // we asked for the challenge under a different address (e.g. the
+      // unified u1… address) than the t1… address we sign with, the lookup
+      // misses and fails as "challenge does not match".
+      const addr = await wallet.getLoginAddress(0);
+      setAddress(addr);
+
+      // 2 — Ask the SERVER for the challenge to sign. The one-time,
+      //     timestamped nonce must come from free2z so it can record/expire
+      //     it and reject replays — a client-minted string would carry no
+      //     such binding.
+      stage = "challenge";
+      setStep("challenge", "active");
+      await wait(450);
+      const { challenge } = await auth.zcashChallenge(addr);
+      setStep("challenge", "done");
+
+      // 3 — Sign the server's exact challenge with the wallet key. Send it
+      //     promptly: server nonces expire.
+      stage = "sign";
+      setStep("sign", "active");
+      await wait(500);
+      const signed = await wallet.signChallenge(challenge);
+      setStep("sign", "done");
+
+      // 4 — Verify with free2z (login or associate — see `config.verify`).
+      stage = "verify";
+      setStep("verify", "active");
+      await wait(400);
+      const user = await verify(signed);
+      setStep("verify", "done");
+
+      // 5 — Land the result and let the caller react.
+      onVerified(user, signed.address);
+      setPhase("success");
+      if (afterSuccess) await afterSuccess(user, signed.address);
+    } catch (e) {
+      setStep(stage, "error");
+      setError(friendlyError(stage, e, verifyErrorMessage));
+      setPhase("error");
+    } finally {
+      runningRef.current = false;
+    }
+  }, [afterSuccess, onVerified, setStep, verify, verifyErrorMessage]);
+
+  // Step 1 — ensure a wallet exists, then either pause for creation or run.
+  const prepareAndRun = useCallback(async () => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    setError(null);
+    setSteps(freshSteps());
+    setPhase("running");
+    setStep("prepare", "active");
+    try {
+      await wait(400);
+      const status = await wallet.getWalletStatus();
+      if (!status.initialized) {
+        // Pause the machine and hand control to the create-identity path.
+        runningRef.current = false;
+        setPhase("needsWallet");
+        return;
+      }
+      setStep("prepare", "done");
+      await runCrypto();
+    } catch (e) {
+      setStep("prepare", "error");
+      setError(errMessage(e));
+      setPhase("error");
+      runningRef.current = false;
+    }
+  }, [runCrypto, setStep]);
+
+  const start = useCallback(() => {
+    void prepareAndRun();
+  }, [prepareAndRun]);
+
+  const createIdentity = useCallback(async () => {
+    setPhase("creating");
+    setError(null);
+    try {
+      const { seedPhrase: phrase } = await wallet.createWallet();
+      setSeedPhrase(phrase);
+      setPhase("seedReveal");
+    } catch (e) {
+      setError(errMessage(e));
+      setPhase("error");
+    }
+  }, []);
+
+  const confirmSeedSaved = useCallback(() => {
+    // Drop the phrase from memory the moment backup is confirmed.
+    setSeedPhrase(null);
+    if (runningRef.current) return;
+    runningRef.current = true;
+    setPhase("running");
+    setStep("prepare", "done");
+    void runCrypto();
+  }, [runCrypto, setStep]);
+
+  const retry = useCallback(() => {
+    void prepareAndRun();
+  }, [prepareAndRun]);
+
+  const reset = useCallback(() => {
+    runningRef.current = false;
+    setPhase("idle");
+    setSteps(freshSteps());
+    setAddress(null);
+    setSeedPhrase(null);
+    setError(null);
+  }, []);
+
+  const activeIndex = (() => {
+    const idx = STEP_ORDER.findIndex(
+      (k) => steps[k] === "active" || steps[k] === "error",
+    );
+    if (idx >= 0) return idx;
+    const done = STEP_ORDER.filter((k) => steps[k] === "done").length;
+    return Math.min(done, STEP_ORDER.length - 1);
+  })();
+
+  return {
+    phase,
+    steps,
+    address,
+    seedPhrase,
+    error,
+    activeIndex,
+    start,
+    createIdentity,
+    confirmSeedSaved,
+    retry,
+    reset,
+  };
+}

--- a/wallet/zuuli/src/features/auth/useZcashLogin.ts
+++ b/wallet/zuuli/src/features/auth/useZcashLogin.ts
@@ -1,47 +1,28 @@
 // The Login-with-Zcash state machine.
 //
-// Drives the challenge/response flow end-to-end:
-//   prepare identity → request challenge → sign (ZIP-304) → verify → session.
-//
-// The wallet key never leaves the device: free2z issues a one-time challenge
-// for the wallet's address, the wallet signs that exact challenge, and only the
-// { address, challenge, signature } triple is sent back — free2z verifies
-// control of the address (zcashd `verifymessage`) and mints a session. The
-// seed phrase is treated as sensitive — held in state only while the user backs
-// it up, then dropped, and never logged.
+// A thin wrapper over the shared `useZcashChallengeFlow` stepper
+// (challenge → sign → verify — see useZcashChallengeFlow.ts for the crypto),
+// specialized for LOGIN: the final verify call is anonymous (`auth.zcashLogin`),
+// and success lands the session and navigates home. `useZcashAssociate.ts` is
+// the sibling specialization for linking a Zcash key to an already signed-in
+// account — it reuses the exact same stepper instead of duplicating it.
 
-import { useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { auth } from "@/lib/api/free2z";
-import { wallet } from "@/lib/wallet/bridge";
 import { useSession } from "@/store/session";
+import {
+  STEP_ORDER,
+  useZcashChallengeFlow,
+  type Phase,
+  type StepKey,
+  type StepMeta,
+  type StepStatus,
+  type ZcashChallengeFlowState,
+} from "./useZcashChallengeFlow";
 
-export type StepKey = "prepare" | "challenge" | "sign" | "verify";
-export type StepStatus = "pending" | "active" | "done" | "error";
-
-export type Phase =
-  | "idle" // nothing started yet
-  | "running" // walking the crypto steps
-  | "needsWallet" // no wallet on device — offer to create one
-  | "creating" // minting a fresh identity
-  | "seedReveal" // showing the recovery phrase for backup
-  | "success"
-  | "error";
-
-export const STEP_ORDER: StepKey[] = [
-  "prepare",
-  "challenge",
-  "sign",
-  "verify",
-];
-
-export interface StepMeta {
-  key: StepKey;
-  title: string;
-  /** One-line explainer of what is happening cryptographically. */
-  detail: string;
-}
+export type { Phase, StepKey, StepMeta, StepStatus };
+export { STEP_ORDER };
 
 export const STEP_META: Record<StepKey, StepMeta> = {
   prepare: {
@@ -66,227 +47,29 @@ export const STEP_META: Record<StepKey, StepMeta> = {
   },
 };
 
-type Steps = Record<StepKey, StepStatus>;
-
-const freshSteps = (): Steps => ({
-  prepare: "pending",
-  challenge: "pending",
-  sign: "pending",
-  verify: "pending",
-});
-
-const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-function errMessage(e: unknown): string {
-  if (e instanceof Error && e.message) return e.message;
-  if (typeof e === "string" && e) return e;
-  return "Something went wrong. Please try again.";
-}
-
-// A friendly, step-aware message for the user. We NEVER surface the raw backend
-// string (e.g. "Challenge is missing, expired or does not match") — it leaks
-// server internals and doesn't tell the user what to do. Local wallet/key
-// errors ("prepare"/"sign") carry actionable messages we author, so we keep
-// those; server errors ("challenge"/"verify") get a clean, generic message.
-// The raw error is always logged for debugging.
-function friendlyError(stage: StepKey, e: unknown): string {
-  console.error(`Zcash login failed at "${stage}":`, e);
-  switch (stage) {
-    case "prepare":
-    case "sign":
-      return errMessage(e);
-    case "challenge":
-      return "Couldn't start Zcash sign-in with free2z. Check your connection and try again.";
-    case "verify":
-      return "free2z couldn't verify your Zcash signature. Please try again.";
-  }
-}
-
-export interface ZcashLoginState {
-  phase: Phase;
-  steps: Steps;
-  /** The unified address in play (full, for truncation at the call site). */
-  address: string | null;
-  /** The recovery phrase, present ONLY during the seedReveal phase. */
-  seedPhrase: string | null;
-  error: string | null;
-  /** Convenience: 0-based index of the currently active/next step. */
-  activeIndex: number;
-  start: () => void;
-  createIdentity: () => Promise<void>;
-  confirmSeedSaved: () => void;
-  retry: () => void;
-  reset: () => void;
-}
+export type ZcashLoginState = ZcashChallengeFlowState;
 
 export function useZcashLogin(): ZcashLoginState {
   const navigate = useNavigate();
   const setUser = useSession((s) => s.setUser);
 
-  const [phase, setPhase] = useState<Phase>("idle");
-  const [steps, setSteps] = useState<Steps>(freshSteps);
-  const [address, setAddress] = useState<string | null>(null);
-  const [seedPhrase, setSeedPhrase] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  // Guards against overlapping runs (e.g. an impatient double-click).
-  const runningRef = useRef(false);
-
-  const setStep = useCallback((key: StepKey, status: StepStatus) => {
-    setSteps((prev) => ({ ...prev, [key]: status }));
-  }, []);
-
-  // The crypto half of the flow: challenge → sign → verify → session.
-  const runCrypto = useCallback(async () => {
-    // Track which step is in flight so a failure lands on the right row and
-    // gets the right friendly message.
-    let stage: StepKey = "prepare";
-    try {
-      // The login identity is the wallet's transparent P2PKH t-address — the
-      // one the plugin signs with and the one free2z verifies via zcashd
-      // `verifymessage`. The server challenge MUST be requested for THIS exact
-      // address: the backend keys the one-time nonce by address, so if we asked
-      // for the challenge under a different address (e.g. the unified u1…
-      // address) than the t1… address we log in with, the login lookup misses
-      // and fails as "challenge does not match".
-      const addr = await wallet.getLoginAddress(0);
-      setAddress(addr);
-
-      // 2 — Ask the SERVER for the challenge to sign. The one-time, timestamped
-      //     nonce must come from free2z so it can record/expire it and reject
-      //     replays — a client-minted string would carry no such binding.
-      stage = "challenge";
-      setStep("challenge", "active");
-      await wait(450);
-      const { challenge } = await auth.zcashChallenge(addr);
-      setStep("challenge", "done");
-
-      // 3 — Sign the server's exact challenge with the wallet key. Send it
-      //     promptly: server nonces expire.
-      stage = "sign";
-      setStep("sign", "active");
-      await wait(500);
-      const signed = await wallet.signChallenge(challenge);
-      setStep("sign", "done");
-
-      // 4 — Verify with free2z; it mints a session token as a side effect. We
-      //     post the address paired with the signature (identical to `addr`,
-      //     the address the challenge was issued for) and its exact challenge.
-      stage = "verify";
-      setStep("verify", "active");
-      await wait(400);
-      const user = await auth.zcashLogin({
+  return useZcashChallengeFlow({
+    verify: (signed) =>
+      auth.zcashLogin({
         address: signed.address,
         challenge: signed.challenge,
         signature: signed.signature,
         pubkey: signed.pubkey,
-      });
-      setStep("verify", "done");
-
-      // 5 — Land the session and go home.
-      setUser(user);
-      setPhase("success");
+      }),
+    verifyErrorMessage:
+      "free2z couldn't verify your Zcash signature. Please try again.",
+    onVerified: (user) => setUser(user),
+    afterSuccess: async () => {
       toast.success("Welcome to ZUULI", {
         description: "Signed in with your Zcash key.",
       });
-      await wait(700);
+      await new Promise((r) => setTimeout(r, 700));
       navigate("/");
-    } catch (e) {
-      setStep(stage, "error");
-      setError(friendlyError(stage, e));
-      setPhase("error");
-    } finally {
-      runningRef.current = false;
-    }
-  }, [navigate, setStep, setUser]);
-
-  // Step 1 — ensure a wallet exists, then either pause for creation or run.
-  const prepareAndRun = useCallback(async () => {
-    if (runningRef.current) return;
-    runningRef.current = true;
-    setError(null);
-    setSteps(freshSteps());
-    setPhase("running");
-    setStep("prepare", "active");
-    try {
-      await wait(400);
-      const status = await wallet.getWalletStatus();
-      if (!status.initialized) {
-        // Pause the machine and hand control to the create-identity path.
-        runningRef.current = false;
-        setPhase("needsWallet");
-        return;
-      }
-      setStep("prepare", "done");
-      await runCrypto();
-    } catch (e) {
-      setStep("prepare", "error");
-      setError(errMessage(e));
-      setPhase("error");
-      runningRef.current = false;
-    }
-  }, [runCrypto, setStep]);
-
-  const start = useCallback(() => {
-    void prepareAndRun();
-  }, [prepareAndRun]);
-
-  const createIdentity = useCallback(async () => {
-    setPhase("creating");
-    setError(null);
-    try {
-      const { seedPhrase: phrase } = await wallet.createWallet();
-      setSeedPhrase(phrase);
-      setPhase("seedReveal");
-    } catch (e) {
-      setError(errMessage(e));
-      setPhase("error");
-    }
-  }, []);
-
-  const confirmSeedSaved = useCallback(() => {
-    // Drop the phrase from memory the moment backup is confirmed.
-    setSeedPhrase(null);
-    if (runningRef.current) return;
-    runningRef.current = true;
-    setPhase("running");
-    setStep("prepare", "done");
-    void runCrypto();
-  }, [runCrypto, setStep]);
-
-  const retry = useCallback(() => {
-    void prepareAndRun();
-  }, [prepareAndRun]);
-
-  const reset = useCallback(() => {
-    runningRef.current = false;
-    setPhase("idle");
-    setSteps(freshSteps());
-    setAddress(null);
-    setSeedPhrase(null);
-    setError(null);
-  }, []);
-
-  const activeIndex = (() => {
-    const idx = STEP_ORDER.findIndex(
-      (k) => steps[k] === "active" || steps[k] === "error",
-    );
-    if (idx >= 0) return idx;
-    const done = STEP_ORDER.filter((k) => steps[k] === "done").length;
-    return Math.min(done, STEP_ORDER.length - 1);
-  })();
-
-  return {
-    phase,
-    steps,
-    address,
-    seedPhrase,
-    error,
-    activeIndex,
-    start,
-    createIdentity,
-    confirmSeedSaved,
-    retry,
-    reset,
-  };
+    },
+  });
 }

--- a/wallet/zuuli/src/features/profile/LinkedAccounts.tsx
+++ b/wallet/zuuli/src/features/profile/LinkedAccounts.tsx
@@ -1,0 +1,323 @@
+// "Linked identities" — lets a signed-in user associate a Zcash key with
+// their account (independent of whichever method they used to sign in).
+//
+// Runs the SAME challenge → sign → verify stepper as Login with Zcash
+// (`useZcashAssociate`, built on the shared `useZcashChallengeFlow`), but the
+// final call attaches the current session's knox token so free2z links the
+// address instead of logging in. A 409 from the backend (address already
+// linked elsewhere, or this account already has an identity) surfaces as a
+// clear error on the "Linking to your account" step.
+//
+// This card is also the obvious extension point for future social logins
+// (X / Google / GitHub) — see the placeholder rows below.
+
+import { useEffect, useState, type ReactNode } from "react";
+import {
+  AlertCircle,
+  Check,
+  Github,
+  Loader2,
+  RotateCw,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { LINK_STEP_META, useZcashAssociate } from "@/features/auth/useZcashAssociate";
+import { STEP_ORDER, type StepStatus } from "@/features/auth/useZcashChallengeFlow";
+import { SeedReveal } from "@/features/auth/SeedReveal";
+import { truncateAddress } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { AuthUser } from "@/lib/api/types";
+
+function StepIcon({ status }: { status: StepStatus }) {
+  if (status === "done") {
+    return (
+      <span className="grid h-8 w-8 place-items-center rounded-full bg-emerald-500/15 text-emerald-400">
+        <Check className="h-4 w-4" aria-hidden />
+      </span>
+    );
+  }
+  if (status === "active") {
+    return (
+      <span className="grid h-8 w-8 place-items-center rounded-full bg-primary/15 text-primary shadow-glow">
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+      </span>
+    );
+  }
+  if (status === "error") {
+    return (
+      <span className="grid h-8 w-8 place-items-center rounded-full bg-destructive/15 text-destructive">
+        <AlertCircle className="h-4 w-4" aria-hidden />
+      </span>
+    );
+  }
+  return (
+    <span className="grid h-8 w-8 place-items-center rounded-full border border-border bg-background/60 text-muted-foreground">
+      <span className="h-1.5 w-1.5 rounded-full bg-current" />
+    </span>
+  );
+}
+
+/** The link flow's body, swapped by phase — mirrors ZcashLoginFlow but scoped to linking. */
+function ZcashLinkDialogBody({ onDone }: { onDone: () => void }) {
+  const flow = useZcashAssociate();
+  const {
+    phase,
+    steps,
+    address,
+    seedPhrase,
+    error,
+    start,
+    createIdentity,
+    confirmSeedSaved,
+    retry,
+  } = flow;
+
+  // Kick the flow off as soon as the dialog opens — the user already opted
+  // in by clicking "Link Zcash key".
+  useEffect(() => {
+    if (phase === "idle") start();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (phase === "needsWallet" || phase === "creating") {
+    const creating = phase === "creating";
+    return (
+      <div className="animate-slide-up space-y-5">
+        <div className="rounded-lg border border-border bg-background/40 p-4">
+          <p className="text-sm font-medium">No Zcash identity on this device</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Create one now, then it can be linked to your account.
+          </p>
+        </div>
+        <Button
+          size="lg"
+          className="w-full"
+          onClick={() => void createIdentity()}
+          disabled={creating}
+        >
+          {creating ? (
+            <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+          ) : (
+            <Sparkles className="h-5 w-5" aria-hidden />
+          )}
+          {creating ? "Creating your identity…" : "Create a Zcash identity"}
+        </Button>
+      </div>
+    );
+  }
+
+  if (phase === "seedReveal" && seedPhrase) {
+    return <SeedReveal seedPhrase={seedPhrase} onConfirm={confirmSeedSaved} />;
+  }
+
+  if (phase === "success") {
+    return (
+      <div className="animate-fade-in space-y-4 py-6 text-center">
+        <span className="mx-auto grid h-14 w-14 place-items-center rounded-full bg-emerald-500/15 text-emerald-400 shadow-glow">
+          <Check className="h-7 w-7" aria-hidden />
+        </span>
+        <div>
+          <p className="text-lg font-semibold">Zcash key linked</p>
+          {address && (
+            <code
+              className="mt-1 block truncate font-mono text-xs text-muted-foreground"
+              title={address}
+            >
+              {truncateAddress(address)}
+            </code>
+          )}
+        </div>
+        <Button className="w-full" onClick={onDone}>
+          Done
+        </Button>
+      </div>
+    );
+  }
+
+  // idle / running / error — the four-step stepper.
+  return (
+    <div className="animate-slide-up space-y-5">
+      {address && (
+        <div className="flex items-center justify-between rounded-lg border border-border bg-background/40 px-4 py-2.5">
+          <span className="text-xs uppercase tracking-wider text-muted-foreground">
+            Linking
+          </span>
+          <code className="font-mono text-xs text-foreground" title={address}>
+            {truncateAddress(address)}
+          </code>
+        </div>
+      )}
+
+      <ol className="space-y-1" aria-label="Linking progress">
+        {STEP_ORDER.map((key, i) => {
+          const status = steps[key];
+          const meta = LINK_STEP_META[key];
+          const isLast = i === STEP_ORDER.length - 1;
+          return (
+            <li key={key} className="relative flex gap-3 pb-4">
+              {!isLast && (
+                <span
+                  className={cn(
+                    "absolute left-4 top-9 h-[calc(100%-1.5rem)] w-px -translate-x-1/2 transition-colors",
+                    status === "done" ? "bg-emerald-500/40" : "bg-border",
+                  )}
+                  aria-hidden
+                />
+              )}
+              <StepIcon status={status} />
+              <div className="min-w-0 flex-1 pt-1">
+                <p
+                  className={cn(
+                    "text-sm font-medium transition-colors",
+                    status === "pending" && "text-muted-foreground",
+                    status === "error" && "text-destructive",
+                  )}
+                >
+                  {meta.title}
+                </p>
+                {(status === "active" || status === "error") && (
+                  <p className="mt-0.5 text-xs text-muted-foreground animate-fade-in">
+                    {status === "error" ? error : meta.detail}
+                  </p>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      {phase === "error" && (
+        <div className="space-y-3 animate-fade-in">
+          <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+            <span>{error ?? "The link could not be completed."}</span>
+          </div>
+          <Button className="w-full" onClick={retry}>
+            <RotateCw className="h-4 w-4" aria-hidden />
+            Try again
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ZcashLinkDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Link a Zcash key</DialogTitle>
+          <DialogDescription>
+            Sign a one-time challenge with your Zcash key to link it to this
+            account. The key never leaves this device.
+          </DialogDescription>
+        </DialogHeader>
+        {/* Remount on every open so a prior run's state never leaks in. */}
+        {open && <ZcashLinkDialogBody key="link" onDone={() => onOpenChange(false)} />}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface IdentityRowProps {
+  icon: ReactNode;
+  label: string;
+  detail: ReactNode;
+  action: ReactNode;
+}
+
+function IdentityRow({ icon, label, detail, action }: IdentityRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 bg-background/40 p-4">
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
+          {icon}
+        </span>
+        <div className="min-w-0">
+          <div className="font-medium">{label}</div>
+          <div className="truncate text-xs text-muted-foreground">{detail}</div>
+        </div>
+      </div>
+      <div className="shrink-0">{action}</div>
+    </div>
+  );
+}
+
+export function LinkedAccounts({ user }: { user: AuthUser }) {
+  const identity = user.zcash_identity;
+  const did = identity ? `did:zcash:${identity}` : null;
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <Card className="space-y-4 rounded-xl border-border/60 bg-card/60 p-5">
+      <div>
+        <h2 className="font-semibold">Linked identities</h2>
+        <p className="text-sm text-muted-foreground">
+          Associate other keys and accounts with your free2z identity.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <IdentityRow
+          icon={<ShieldCheck className="h-4 w-4" aria-hidden />}
+          label="Zcash"
+          detail={
+            did && identity ? (
+              <code className="font-mono" title={did}>
+                did:zcash:{truncateAddress(identity, 6, 6)}
+              </code>
+            ) : (
+              "Not linked"
+            )
+          }
+          action={
+            identity ? (
+              <Badge variant="success">Linked</Badge>
+            ) : (
+              <Button size="sm" onClick={() => setDialogOpen(true)}>
+                Link Zcash key
+              </Button>
+            )
+          }
+        />
+
+        {/*
+          Extension point: future social identities (X, Google, GitHub, …)
+          render here as additional IdentityRow entries once those OAuth
+          flows exist server-side. Not built yet — see SocialSoon.tsx for the
+          equivalent "coming soon" treatment on the login screen.
+        */}
+        <IdentityRow
+          icon={<Github className="h-4 w-4" aria-hidden />}
+          label="X · Google · GitHub"
+          detail="Coming soon"
+          action={
+            <Badge variant="outline" className="text-muted-foreground">
+              Soon
+            </Badge>
+          }
+        />
+      </div>
+
+      <ZcashLinkDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+    </Card>
+  );
+}

--- a/wallet/zuuli/src/features/profile/index.tsx
+++ b/wallet/zuuli/src/features/profile/index.tsx
@@ -18,6 +18,7 @@ import { profile } from "@/lib/api/free2z";
 import { initials } from "@/lib/format";
 import { useSession } from "@/store/session";
 import type { AuthUser } from "@/lib/api/types";
+import { LinkedAccounts } from "./LinkedAccounts";
 
 const BIO_MAX = 1024;
 const NAME_MAX = 128;
@@ -121,6 +122,10 @@ function ProfileForm({ user }: { user: AuthUser }) {
           <Link to="/kyc">Apply for revenue share</Link>
         </Button>
       </Card>
+
+      <div className="mb-6">
+        <LinkedAccounts user={user} />
+      </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         {/* Form */}

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -13,6 +13,7 @@ import {
   mockAiReply,
   mockArticleFeed,
   mockArticles,
+  mockAssociateZcash,
   mockConversationReply,
   mockCreatePersonality,
   mockCreatorDetail,
@@ -397,6 +398,50 @@ export const auth = {
       body: { address },
       anonymous: true,
     });
+  },
+
+  /**
+   * Link a Zcash key to the CURRENTLY SIGNED-IN account ("Linked identities"
+   * in the profile). This hits the exact same dual-mode endpoint as
+   * `zcashLogin` — `POST /api/auth/zcash/login/` — but WITHOUT
+   * `anonymous: true`, so `request()` attaches the stored knox token. Seeing
+   * that token, the backend associates the verified address with the current
+   * account instead of logging in/creating one (`ZcashLoginView` in
+   * `tuzi/py/dj/apps/zauth/views.py`).
+   *
+   * The backend returns 409 for either conflict case: the address is already
+   * linked to a DIFFERENT account, or this account already has a linked
+   * Zcash identity. We can't (and don't need to) distinguish the two for the
+   * user — both mean "pick a different key, or unlink the existing one
+   * first" — so we surface one clear message for any 409.
+   */
+  async zcashAssociate(params: {
+    address: string;
+    challenge: string;
+    signature: string;
+    pubkey?: string;
+  }): Promise<AuthUser> {
+    if (useMock()) {
+      await delay(400);
+      return mockAssociateZcash(params.address);
+    }
+    try {
+      // Deliberately NOT `anonymous: true` — the point of this call is that
+      // the request carries `Authorization: Token <knox token>`.
+      await request<unknown>("/api/auth/zcash/login/", {
+        method: "POST",
+        body: params,
+      });
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        throw new Error(
+          "That Zcash key is already linked — either to a different free2z account, or this account already has a linked Zcash identity. Unlink it there first, or sign with a different key.",
+        );
+      }
+      throw e;
+    }
+    const me = await auth.me();
+    return { ...me, zcash_identity: params.address };
   },
 };
 

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -37,7 +37,32 @@ export const mockUser: AuthUser = {
   is_verified: false,
   tuzis: 4210,
   zcashLinked: true,
+  // Starts UNLINKED so the profile's "Linked identities" panel is demoable
+  // end-to-end in mock mode: "Link Zcash key" flips this to the signed
+  // address (see `mockAssociateZcash`).
+  zcash_identity: null,
 };
+
+/**
+ * Mock `auth.zcashAssociate()` — links `address` to the mock account, mirroring
+ * the real backend's dual-mode `/api/auth/zcash/login/` (authenticated call =
+ * associate). Mutates `mockUser` in place (never reassigned) so the linked
+ * state persists across the mock session, same pattern as `profile.update`.
+ *
+ * Throws the same friendly conflict message the real 409 path throws
+ * (`auth.zcashAssociate`) if this account is already linked to a DIFFERENT
+ * address — so re-running the flow against a fresh key demoes the conflict
+ * state instead of always silently succeeding.
+ */
+export function mockAssociateZcash(address: string): AuthUser {
+  if (mockUser.zcash_identity && mockUser.zcash_identity !== address) {
+    throw new Error(
+      "That Zcash key is already linked — either to a different free2z account, or this account already has a linked Zcash identity. Unlink it there first, or sign with a different key.",
+    );
+  }
+  Object.assign(mockUser, { zcash_identity: address, zcashLinked: true });
+  return { ...mockUser };
+}
 
 const creator = (
   username: string,

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -61,6 +61,14 @@ export interface AuthUser {
   tuzis: number;
   /** True when this session authenticated via a Zcash address (no password). */
   zcashLinked?: boolean;
+  /**
+   * The Zcash t-address linked to this account for authentication (as a DID,
+   * `did:zcash:<address>`), if any — set locally after a successful
+   * `auth.zcashAssociate()` call. Not yet exposed by GET /api/auth/user/, so
+   * this reflects only what THIS session has observed (a fresh login on
+   * another device won't see it until the backend surfaces it too).
+   */
+  zcash_identity?: string | null;
 }
 
 /**


### PR DESCRIPTION
## What

Adds a **Linked identities** panel to ZUULI's profile so a signed-in user can associate a Zcash key with their current account — separate from whatever method they used to sign in.

## How it works

The Zcash-login endpoint (`POST /api/auth/zcash/login/`) is dual-mode: anonymous → login-or-create by address; authenticated (knox token attached) → associate the verified address with the current account, returning **409** if the address is already linked to another account or this account already has an identity. No backend changes needed — this PR is client-only.

- **Shared crypto, not duplicated.** The challenge → sign → verify stepper is factored out of `useZcashLogin.ts` into a new `useZcashChallengeFlow.ts` hook. `useZcashLogin` is now a thin wrapper (unchanged external behavior/API); `useZcashAssociate.ts` is the new sibling for linking — same stepper, different final call and success handling (no navigation, just updates the signed-in user).
- **`auth.zcashAssociate()`** (`src/lib/api/free2z.ts`) posts to the exact same endpoint/shape as `auth.zcashLogin` but **without** `anonymous: true`, so `request()` attaches the stored knox token and the backend associates instead of logging in. A 409 response is mapped to one clear, user-safe message (can't distinguish/doesn't need to distinguish the two conflict cases for the user).
- **`AuthUser.zcash_identity`** (`src/lib/api/types.ts`) is a new optional field, additive to the contract. It's set locally after a successful associate call — `GET /api/auth/user/` doesn't expose a linked-identity field yet, so this reflects what the current session has observed rather than a persisted server value (documented in the type's doc comment).
- **`LinkedAccounts.tsx`** (new, rendered from `src/features/profile/index.tsx`) shows the linked Zcash identity as `did:zcash:<address>` with a "Linked" badge, or a "Link Zcash key" action that opens a dialog running the associate flow with the same step-by-step UI treatment as the login screen. A second row for X / Google / GitHub is a clearly marked, non-interactive extension point for future social logins — not built here.
- **Mock mode** (`src/lib/api/mock-data.ts`): `mockUser` starts unlinked; `mockAssociateZcash()` flips it to linked (and throws the same conflict message if re-run against a different address), so the whole panel is demoable under `VITE_MOCK=1` with no backend.

## Verification

- `npm run typecheck` — clean.
- `npm run build` — succeeds.
- `VITE_MOCK=1 npm run dev`: logged in via mock Login with Zcash, opened `/profile`, confirmed the panel showed "Zcash / Not linked", clicked "Link Zcash key", watched the stepper ("Preparing your identity" → "Requesting a challenge" → "Signing with your key" → "Linking to your account") complete, saw the success toast, and confirmed the panel now shows `did:zcash:u1l8xu…kmvexz` with a "Linked" badge — persisted across the dialog closing.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Manual click-through in `VITE_MOCK=1` dev server (screenshotted end-to-end: unlinked → link dialog → stepper → success → linked badge)
- [ ] Manual click-through against the real backend (needs a live free2z environment with a signed-in session)