### PR TITLE
fix(zuuli): pin AI chat input to bottom + no auth probe when logged out

### DIFF
--- a/wallet/zuuli/src/components/layout/AppShell.tsx
+++ b/wallet/zuuli/src/components/layout/AppShell.tsx
@@ -1,19 +1,34 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { Sidebar, MobileTabBar } from "./Sidebar";
 import { TopBar } from "./TopBar";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 export function AppShell() {
+  const location = useLocation();
+  // The AI chat needs a bounded-height panel with its own internal scroll
+  // region (message list) and a footer pinned to the true bottom — Radix's
+  // ScrollArea wraps children in a `display: table` div that sizes to
+  // content, so a `h-full` flex column nested inside it can never resolve a
+  // real height. Give that route a plain, height-bound `main` instead of the
+  // page-scrolling ScrollArea every other route uses.
+  const isFullBleed = location.pathname.startsWith("/ai");
+
   return (
     <div className="flex h-screen overflow-hidden bg-background">
       <Sidebar />
       <div className="flex min-w-0 flex-1 flex-col">
         <TopBar />
-        <ScrollArea className="flex-1">
-          <main className="mx-auto w-full max-w-6xl px-4 pb-24 pt-6 md:px-8 md:pb-10">
+        {isFullBleed ? (
+          <main className="min-h-0 flex-1 overflow-hidden">
             <Outlet />
           </main>
-        </ScrollArea>
+        ) : (
+          <ScrollArea className="flex-1">
+            <main className="mx-auto w-full max-w-6xl px-4 pb-24 pt-6 md:px-8 md:pb-10">
+              <Outlet />
+            </main>
+          </ScrollArea>
+        )}
       </div>
       <MobileTabBar />
     </div>

--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -286,9 +286,9 @@ export default function AiFeature() {
   const localModel = models.find((m) => m.provider === "local");
 
   return (
-    <div className="flex flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       {/* ── Header rail ─────────────────────────────────────────────── */}
-      <div className="sticky top-0 z-20 -mx-4 border-b border-border/60 bg-background/85 px-4 py-3 backdrop-blur md:-mx-8 md:px-8">
+      <div className="shrink-0 border-b border-border/60 bg-background/85 px-4 py-3 backdrop-blur md:px-8">
         <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
           <div className="flex min-w-0 items-center gap-3">
             <div className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
@@ -371,7 +371,7 @@ export default function AiFeature() {
       </div>
 
       {/* ── Thread ──────────────────────────────────────────────────── */}
-      <div className="flex-1 py-6">
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8">
         {messages.length === 0 ? (
           <EmptyHero
             selected={selected}
@@ -394,7 +394,7 @@ export default function AiFeature() {
       </div>
 
       {/* ── Composer ────────────────────────────────────────────────── */}
-      <div className="sticky bottom-0 z-20 -mx-4 border-t border-border/60 bg-background/85 px-4 pb-3 pt-3 backdrop-blur md:-mx-8 md:px-8">
+      <div className="shrink-0 border-t border-border/60 bg-background/85 px-4 pb-3 pt-3 backdrop-blur md:px-8">
         <div className="mx-auto max-w-3xl">
           <div className="relative rounded-xl border border-border bg-card/60 shadow-sm focus-within:border-primary/60 focus-within:shadow-glow">
             <Textarea

--- a/wallet/zuuli/src/store/session.ts
+++ b/wallet/zuuli/src/store/session.ts
@@ -1,7 +1,17 @@
 import { create } from "zustand";
 import { auth } from "@/lib/api/free2z";
-import { isAuthed, setToken } from "@/lib/api/http";
+import { ApiError, isAuthed, setToken } from "@/lib/api/http";
 import type { AuthUser } from "@/lib/api/types";
+
+/**
+ * `GET /api/auth/user/` 403s (some deployments 401) for anonymous requests —
+ * that's an expected "you're logged out" response, not a real failure, so we
+ * never want it surfacing as an uncaught console error. Anything else (a
+ * network blip, a 5xx) is transient and shouldn't nuke a valid session.
+ */
+function isSessionExpired(err: unknown): boolean {
+  return err instanceof ApiError && (err.status === 401 || err.status === 403);
+}
 
 interface SessionState {
   user: AuthUser | null;
@@ -23,6 +33,8 @@ export const useSession = create<SessionState>((set, get) => ({
   tuzis: 0,
 
   async bootstrap() {
+    // No knox token → we're logged out; resolve without ever hitting
+    // `/api/auth/user/` (it 403s for anonymous requests).
     if (!isAuthed()) {
       set({ loading: false });
       return;
@@ -30,8 +42,8 @@ export const useSession = create<SessionState>((set, get) => ({
     try {
       const user = await auth.me();
       set({ user, tuzis: user.tuzis ?? 0, loading: false });
-    } catch {
-      setToken(null);
+    } catch (err) {
+      if (isSessionExpired(err)) setToken(null);
       set({ user: null, loading: false });
     }
   },
@@ -41,11 +53,18 @@ export const useSession = create<SessionState>((set, get) => ({
   },
 
   async refresh() {
+    // Same guard as `bootstrap` — logged-out callers must never probe
+    // `/api/auth/user/` (see `isSessionExpired` above).
+    if (!isAuthed()) return;
     try {
       const user = await auth.me();
       set({ user, tuzis: user.tuzis ?? 0 });
-    } catch {
-      /* ignore */
+    } catch (err) {
+      if (isSessionExpired(err)) {
+        setToken(null);
+        set({ user: null, tuzis: 0 });
+      }
+      /* otherwise a transient/network error — keep the current session */
     }
   },
 


### PR DESCRIPTION
## Summary

Two focused ZUULI fixes, no unrelated churn:

**1. AI chat composer wasn't pinned to the bottom.**
`wallet/zuuli/src/features/ai/index.tsx` relied on `sticky bottom-0` inside the AppShell's Radix `ScrollArea`. Radix's `ScrollAreaViewport` wraps its children in a `display: table` div (confirmed in `node_modules/@radix-ui/react-scroll-area`) that sizes to content, not to the available viewport — so a `flex-1` message list nested inside it can never resolve a real height, and with a short conversation the composer just floats below the content with empty space beneath it, instead of sitting at the true bottom of the panel.

Fix:
- `wallet/zuuli/src/components/layout/AppShell.tsx`: the `/ai` route now gets a plain, height-bound `<main className="min-h-0 flex-1 overflow-hidden">` instead of the page-scrolling `ScrollArea` every other route uses (which is untouched).
- `wallet/zuuli/src/features/ai/index.tsx`: `AiFeature` is now a `flex h-full min-h-0 flex-col` — header/model-picker/balance-warning are `shrink-0` at the top, the message list is the `flex-1 min-h-0 overflow-y-auto` scrollable middle (auto-scrolls to the newest message, unchanged), and the composer is a `shrink-0` footer that's always visible, in normal flow at the true bottom of the column. The "Enter to send · Shift+Enter" hint and send button are untouched.

**2. `/api/auth/user/` was probed while logged out, spamming 403s.**
`GET /api/auth/user/` 403s for anonymous requests. `useSession.bootstrap()` already guarded the call with `isAuthed()`, but `useSession.refresh()` (called from the AI composer's send flow) didn't — and neither treated a 401/403 response as "you're logged out," so a stale/invalid token would throw uncaught rather than clearing.

Fix in `wallet/zuuli/src/store/session.ts`:
- `refresh()` now bails out before calling `auth.me()` when there's no knox token (same guard `bootstrap()` already had).
- Both `bootstrap()` and `refresh()` now recognize a 401/403 `ApiError` specifically as "session expired" — clearing the token and resolving to logged-out state — while other errors (network blips, 5xx) leave the current session alone instead of nuking it.
- `auth.me()` itself, and the login/associate/social/profile flows that call it right after minting a token, are untouched.

## Verification

- `cd wallet/zuuli && npm install && npm run typecheck && npm run build` — all green.
- Ran `VITE_MOCK=1 npm run dev` and drove the app in a real browser:
  - Logged out: composer sits flush at the bottom of the panel in the "Pick a model" empty state, no orphan whitespace below it.
  - Logged in (mock user, 4,210 2Z) and sent 5 chat turns: header stays fixed at top, composer stays pinned at the bottom throughout, message list scrolls independently and auto-scrolls to the newest reply.
  - Console/network: no auth-related errors during the whole session (checked via chrome devtools).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Manual verification in `VITE_MOCK=1 npm run dev` (empty state + multi-turn conversation, logged out + logged in)