### PR TITLE
fix(zuuli): pin librustzcash pre-Ironwood so Zcash wallet sync works on deployed lightwalletd

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/Cargo.lock
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.lock
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6529,7 +6529,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
+version = "0.21.1"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -6841,7 +6841,7 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/wallet/zuuallet/src-tauri/Cargo.lock
+++ b/wallet/zuuallet/src-tauri/Cargo.lock
@@ -6848,7 +6848,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6898,7 +6898,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
+version = "0.21.1"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -7210,7 +7210,7 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/wallet/zuuli/src-tauri/Cargo.lock
+++ b/wallet/zuuli/src-tauri/Cargo.lock
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7088,7 +7088,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
+version = "0.21.1"
 dependencies = [
  "bip32",
  "bitflags 2.13.1",
@@ -7400,7 +7400,7 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "nom",


### PR DESCRIPTION
## Symptom
ZUULI Zcash wallet sync is wedged at **0.0%** (birthday height). The newly-shipped sync-error surfacing shows the real cause on every `zcash_client_backend::sync::run` pass:

```
Sync trouble — retrying. (Server(Status { code: Unknown, message: "unrecognized shielded protocol", metadata: {...nginx/1.24.0 (Ubuntu)...} }))
```

## Root cause — client-too-new (bleeding-edge break)
`librustzcash` HEAD (`30bbc899`) introduced a new shielded pool, **Ironwood** (`ShieldedProtocol::Ironwood`, wire value **2**). In commit **`576e378c5` "Fetch Ironwood subtree roots during sync"** (2026-07-10), `sync::run()` now unconditionally calls, as its **first** step:

```
run() -> update_subtree_roots() -> download_subtree_roots(client, ShieldedProtocol::Ironwood)  // GetSubtreeRoots{ shieldedProtocol: 2 }
```

and propagates the result with `?`. Every deployed mainnet lightwalletd (the default `https://zec.rocks:443` and all `*.zec.rocks` fallbacks) only recognizes `sapling=0` / `orchard=1`, so a `GetSubtreeRoots` for protocol `2` returns **"unrecognized shielded protocol"**. Because this is the first gRPC call in `run()`, the pass fails **before committing any block** → sync never advances past the birthday height → stuck at 0.0% forever. Ironwood has no mainnet activation yet, so **no** currently-deployed server supports it — switching endpoints cannot help.

This is not our bug and not a server outage: upstream HEAD simply outpaced the deployable lightwalletd fleet.

## Fix — transient submodule pin (per monorepo doctrine)
Pin `z/zcash/librustzcash` to **`b253bb6c`** — the parent of `576e378c5`, i.e. the newest upstream commit whose sync loop does **not** request Ironwood subtree roots.

- The plugin has **zero** Ironwood API usage, so nothing is lost functionally.
- `cargo check` on `tauri-plugin-zcash` passes cleanly at this pin.
- Cargo.lock: `zcash_client_backend 0.24.0-rc.1 → 0.23.0`, `zcash_client_sqlite 0.22.0-rc.1 → 0.21.1`, `zip321 0.9.0-rc.1 → 0.8.0`.

**Revert (return to upstream HEAD) once** the lightwalletd fleet ships Ironwood support, **or** upstream makes the Ironwood subtree fetch tolerant of servers that don't recognize the protocol.

## Verification
- `cargo check --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml` — clean at the pin.
- Live sync against lightwalletd was **not** reproduced in this environment; the diagnosis is from the vendored code + protobuf enum + gRPC call path. High confidence given the error string maps 1:1 to the unconditional Ironwood `GetSubtreeRoots` at the head of `run()`.