### PR TITLE
fix(zuuli): default AI to top model (gpt-4o) + surface real backend error detail

### DIFF
--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { Markdown } from "@/components/common/Markdown";
 import { ai } from "@/lib/api/free2z";
+import { ApiError } from "@/lib/api/http";
 import type { AIModel, Personality } from "@/lib/api/types";
 import { formatTuzis, initials } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -123,14 +124,16 @@ export default function AiFeature() {
   const canSend =
     !!selected && !isSending && !lowBalance && input.trim().length > 0;
 
-  // Load models + personalities once; default to the first GA model.
+  // Load models + personalities once; default to the highest-`order` GA
+  // model (the API already returns them sorted by `-order`, so this is the
+  // first GA entry — the one most likely to actually work).
   useEffect(() => {
     let active = true;
     ai
       .models()
       .then((list) => {
         if (!active) return;
-        const sorted = [...list].sort((a, b) => a.order - b.order);
+        const sorted = [...list].sort((a, b) => b.order - a.order);
         setModels(sorted);
         setSelected(sorted.find((m) => m.is_ga) ?? sorted[0] ?? null);
       })
@@ -247,6 +250,15 @@ export default function AiFeature() {
         }
       } catch (err) {
         const aborted = isAbortError(err);
+        const genericMessage =
+          "Sorry — the model could not be reached. Please try again.";
+        const detail =
+          err instanceof ApiError &&
+          err.body &&
+          typeof (err.body as { detail?: unknown }).detail === "string"
+            ? (err.body as { detail: string }).detail
+            : undefined;
+        const errorMessage = detail ?? genericMessage;
         setMessages((prev) =>
           prev.map((m) =>
             m.id === placeholderId
@@ -255,14 +267,12 @@ export default function AiFeature() {
                   pending: false,
                   aborted,
                   error: !aborted,
-                  content: aborted
-                    ? "_Generation stopped._"
-                    : "Sorry — the model could not be reached. Please try again.",
+                  content: aborted ? "_Generation stopped._" : errorMessage,
                 }
               : m,
           ),
         );
-        if (!aborted) toast.error("The model could not be reached.");
+        if (!aborted) toast.error(detail ?? "The model could not be reached.");
       } finally {
         abortRef.current = null;
         setIsSending(false);

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -203,7 +203,10 @@ export const mockModels: AIModel[] = [
     system_message: "You are a helpful assistant.",
     max_tokens: 4096,
     is_ga: true,
-    order: 7,
+    // Highest `order` of the catalog, mirroring stage (gpt-4o = 200 there):
+    // it's the one GA model with a verified id + API key, so it must win
+    // the default-model pick (see features/ai/index.tsx).
+    order: 200,
     input_price: "0.0000025",
     output_price: "0.00001",
     markup: "1.15",


### PR DESCRIPTION
## Summary

- **Default model was wrong-way-round.** `features/ai/index.tsx` sorted the models list *ascending* by `order` and took the first GA hit — i.e. it picked the **lowest**-order model. The `/api/ai/models/` API already returns the catalog sorted by `-order` (highest first, meaning highest = most trusted/working). On stage this meant the picker defaulted to an unverified `gpt-5.6-*` id instead of `gpt-4o`, the one GA model with a valid id + API key that actually works. Fixed by sorting descending (`b.order - a.order`) so the top-of-list pick tracks whatever the backend ranks highest — no hardcoded `"gpt-4o"`.
- **Chat errors hid the real reason.** The `send` catch block always showed a hardcoded "Sorry — the model could not be reached." bubble + toast, regardless of cause. The backend now returns a 503 with a specific `detail` (e.g. `"This model isn't enabled yet."` or `"This model isn't available right now (…). Try another model."`). Now extracts `err.body.detail` when `err instanceof ApiError` and shows that string in both the assistant error bubble and the toast, falling back to the generic message only when no detail is present. Abort handling (`"_Generation stopped._"`) is unchanged.
- Also bumped `gpt-4o`'s `order` in the mock fixtures (`src/lib/api/mock-data.ts`) to `200`, mirroring stage, since the mock's placeholder order values (1–12, assigned in array order) didn't share that convention and would otherwise default the mock UI to a different "top" model (Llama).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `VITE_MOCK=1 npm run dev`, logged in and confirmed the AI Studio header/model picker now defaults to **GPT-4o** (previously defaulted to whichever GA model had the lowest `order`)
- [x] Verified the error-detail extraction logic in isolation (same expression as the shipped code) against representative backend error shapes: 503 with `detail` → surfaces backend text in bubble + toast; ApiError with no body/detail and non-`ApiError` failures → fall back to the generic message; abort path unaffected