### PR TITLE
fix(zuuli): scoped markdown link hover + clearer membership price + stateful Subscribe

### DIFF
--- a/wallet/zuuli/src/components/common/Markdown.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.tsx
@@ -104,7 +104,16 @@ export function Markdown({
         // only clears ~4.3:1 against card surfaces, short of WCAG AA (4.5:1)
         // for body-sized link text. `--link` is the same hue, lightened to
         // 74%, which clears AA on every surface content renders on.
-        "[&_a]:text-link [&_a]:underline [&_a]:underline-offset-4 [&_a]:hover:decoration-2",
+        //
+        // `[&_a:hover]:decoration-2` (NOT `[&_a]:hover:decoration-2`): the
+        // hover pseudo-class must bind to the `a` itself inside the arbitrary
+        // selector. `[&_a]:hover:decoration-2` instead compiles to
+        // `.container:hover a { … }` — hovering ANYWHERE over the container
+        // (e.g. the card the bio/article renders inside) thickens every link
+        // at once. `[&_a:hover]:decoration-2` compiles to
+        // `.container a:hover { … }`, so only the specific anchor under the
+        // cursor is affected.
+        "[&_a]:text-link [&_a]:underline [&_a]:underline-offset-4 [&_a:hover]:decoration-2",
         "[&_ul]:list-disc [&_ul]:pl-6 [&_ol]:list-decimal [&_ol]:pl-6",
         "[&_li]:my-1",
         "[&_blockquote]:border-l-2 [&_blockquote]:border-primary [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:text-muted-foreground",

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft,
   ArrowRight,
   BadgeCheck,
+  Check,
   Clock,
   Facebook,
   FileText,
@@ -50,7 +51,7 @@ import { cn } from "@/lib/utils";
 import { parseBioFrontmatter, type SocialLink } from "@/lib/utils/bio";
 import { useAsync } from "@/hooks/useAsync";
 import { useSession } from "@/store/session";
-import type { Article, CreatorDetail } from "@/lib/api/types";
+import type { Article, CreatorDetail, Subscription } from "@/lib/api/types";
 
 /** Icon per canonical social platform key, falling back to a plain link glyph. */
 const SOCIAL_ICONS: Record<SocialLink["key"], LucideIcon> = {
@@ -267,6 +268,15 @@ function CreatorProfile({ creator }: { creator: CreatorDetail }) {
 }
 
 // ─── Subscribe ────────────────────────────────────────────────────────────────
+/** "Aug 14" style short date for a membership renewal/expiry. */
+function formatMembershipDate(iso?: string): string {
+  if (!iso) return "";
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
 function SubscribeButton({ creator }: { creator: CreatorDetail }) {
   const name = creator.display_name || creator.username;
   const navigate = useNavigate();
@@ -275,9 +285,32 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
   const adjustTuzis = useSession((s) => s.adjustTuzis);
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
+  // Set the instant `subscribe()` succeeds so the button reflects the new
+  // state immediately, even before `reloadSubscriptions` below lands (and
+  // even if that refetch fails) — see the comment on `tuzi.mySubscriptions`
+  // for why this is the only backend source of subscription status.
+  const [justSubscribed, setJustSubscribed] = useState<Subscription | null>(
+    null,
+  );
 
   const price = creator.member_price ?? 0;
   const enough = price <= balance;
+
+  const { data: subscriptions, reload: reloadSubscriptions } = useAsync<
+    Subscription[]
+  >(
+    () => (user ? tuzi.mySubscriptions() : Promise.resolve([])),
+    [user?.username, creator.username],
+  );
+  const remoteSub = subscriptions?.find(
+    (s) => s.star.username.toLowerCase() === creator.username.toLowerCase(),
+  );
+  const sub = remoteSub ?? justSubscribed;
+  const subscribed = Boolean(sub);
+  // `max_price === 0` means the fan cancelled auto-renew (DELETE
+  // /api/tuzis/subscribe/{username}) — access still runs to `expires`, it
+  // just won't recur.
+  const renewing = sub ? Number(sub.max_price ?? 0) > 0 : true;
 
   async function subscribe() {
     if (!user) {
@@ -288,8 +321,24 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
     try {
       await tuzi.subscribe(creator.username);
       if (price > 0) adjustTuzis(-price);
-      toast.success(`Subscribed to ${name}`);
+      const expires = new Date(Date.now() + 30 * 86400000).toISOString();
+      setJustSubscribed({
+        fan: {
+          username: user.username,
+          free2zaddr: user.free2zaddr ?? user.username,
+        },
+        star: { username: creator.username, free2zaddr: creator.free2zaddr },
+        expires,
+        max_price: String(price),
+      });
+      toast.success(`Subscribed to ${name}`, {
+        description:
+          price > 0
+            ? `Renews monthly · ${formatTuzis(price)}. You've unlocked ${name}'s subscriber posts and livestreams.`
+            : `You've unlocked ${name}'s subscriber posts and livestreams.`,
+      });
       setOpen(false);
+      void reloadSubscriptions();
     } catch {
       toast.error("Couldn't complete the subscription. Please try again.");
     } finally {
@@ -297,34 +346,124 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
     }
   }
 
+  async function unsubscribe() {
+    setBusy(true);
+    try {
+      await tuzi.unsubscribe(creator.username);
+      setJustSubscribed(null);
+      toast.success("Membership won't renew", {
+        description: sub?.expires
+          ? `You'll keep access to ${name}'s subscriber posts and livestreams until ${formatMembershipDate(sub.expires)}.`
+          : undefined,
+      });
+      setOpen(false);
+      void reloadSubscriptions();
+    } catch {
+      toast.error("Couldn't update your membership. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
   if (!creator.member_price) {
-    // No paid tier — a plain follow/subscribe.
+    // No paid tier — a plain follow/subscribe, reflected the same way.
     return (
-      <Button onClick={subscribe} disabled={busy}>
+      <Button
+        variant={subscribed ? "secondary" : "default"}
+        onClick={subscribe}
+        disabled={busy || subscribed}
+      >
         {busy ? (
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+        ) : subscribed ? (
+          <Check className="h-4 w-4" aria-hidden />
         ) : null}
-        Subscribe
+        {subscribed ? "Following" : "Subscribe"}
       </Button>
+    );
+  }
+
+  if (subscribed) {
+    return (
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button
+            variant="secondary"
+            className="border border-primary/30 bg-primary/10 text-primary hover:bg-primary/15"
+            aria-label={`Manage your ${name} membership`}
+          >
+            <Check className="h-4 w-4" aria-hidden />
+            Member
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Your membership to {name}</DialogTitle>
+            <DialogDescription>
+              {renewing
+                ? "Unlocks subscriber posts and livestreams. Renews automatically each month."
+                : "Auto-renew is off — you'll keep access until it expires."}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="rounded-xl border border-border bg-card/50 p-4">
+            <div className="flex items-baseline justify-between">
+              <span className="text-sm text-muted-foreground">
+                Membership price
+              </span>
+              <span className="text-xl font-bold tabular-nums">
+                {formatTuzis(price)}
+                <span className="text-sm font-normal text-muted-foreground">
+                  /mo
+                </span>
+              </span>
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              {renewing ? "Renews" : "Access ends"}{" "}
+              {sub?.expires ? formatMembershipDate(sub.expires) : "soon"}
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
+              Close
+            </Button>
+            {renewing ? (
+              <Button variant="outline" onClick={unsubscribe} disabled={busy}>
+                {busy ? (
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                ) : null}
+                Cancel membership
+              </Button>
+            ) : null}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     );
   }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button aria-label={`Subscribe to ${name}`}>Subscribe</Button>
+        <Button aria-label={`Subscribe to ${name} · ${formatTuzis(price)}/mo`}>
+          Subscribe · {formatTuzis(price)}/mo
+        </Button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Subscribe to {name}</DialogTitle>
           <DialogDescription>
-            Membership unlocks subscriber posts and livestreams for 30 days.
+            This is {name}'s membership price — what it costs you to become a
+            subscriber. It unlocks their subscriber posts and livestreams for
+            30 days.
           </DialogDescription>
         </DialogHeader>
 
         <div className="rounded-xl border border-border bg-card/50 p-4">
           <div className="flex items-baseline justify-between">
-            <span className="text-sm text-muted-foreground">Monthly</span>
+            <span className="text-sm text-muted-foreground">
+              Membership · monthly
+            </span>
             <span className="text-xl font-bold tabular-nums">
               {formatTuzis(price)}
             </span>

--- a/wallet/zuuli/src/features/search/index.tsx
+++ b/wallet/zuuli/src/features/search/index.tsx
@@ -245,8 +245,15 @@ function CreatorResultCard({ creator }: { creator: SimpleCreator }) {
             <span className="tabular-nums">{creator.zpages} pages</span>
           ) : null}
           {creator.member_price ? (
-            <Badge variant="sub" className="tabular-nums">
-              {formatTuzis(creator.member_price)}/mo
+            // "Membership": this is what it costs to SUBSCRIBE to this
+            // creator, not the viewer's own spend — make that unmistakable
+            // rather than showing a bare, ambiguous "200 2Z/mo".
+            <Badge
+              variant="sub"
+              className="tabular-nums"
+              aria-label={`Membership price: ${formatTuzis(creator.member_price)} per month`}
+            >
+              Membership · {formatTuzis(creator.member_price)}/mo
             </Badge>
           ) : null}
         </div>

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -28,7 +28,10 @@ import {
   mockPersonalities,
   mockSearchCreators,
   mockSearchPages,
+  mockSubscribe,
+  mockSubscriptions,
   mockTransactions,
+  mockUnsubscribe,
   mockUpdatePersonality,
   mockUser,
 } from "./mock-data";
@@ -62,6 +65,7 @@ import type {
   SocialProvider,
   SocialProvidersStatus,
   StreamKind,
+  Subscription,
   TuziTransaction,
 } from "./types";
 
@@ -1104,9 +1108,48 @@ export const tuzi = {
   async subscribe(username: string): Promise<void> {
     if (useMock()) {
       await delay(400);
+      mockSubscribe(username);
       return;
     }
     await request(`/api/tuzis/subscribe/${username}`, { method: "POST" });
+  },
+
+  /**
+   * The CURRENT user's active memberships — GET /api/tuzis/my-subscriptions.
+   * The backend has no "am I subscribed to creator X" flag on
+   * `GET /api/creator/{username}/` (CreatorDetailSerializer carries only
+   * `member_price`, not a per-viewer status), and `/api/tuzis/my-subscribers`
+   * is the inverse (who subscribes to the SIGNED-IN creator, not who the
+   * signed-in user subscribes to). This is the one real endpoint that answers
+   * "am I subscribed, and to whom": it's already scoped to `fan=request.user`
+   * and filtered server-side to `expires__gt=now`, so every row here is a
+   * live membership. Callers match on `star.username` to find the status for
+   * a specific creator.
+   */
+  async mySubscriptions(): Promise<Subscription[]> {
+    if (useMock()) {
+      await delay(150);
+      return [...mockSubscriptions];
+    }
+    const page = await request<Paginated<Subscription>>(
+      "/api/tuzis/my-subscriptions",
+    );
+    return page.results ?? [];
+  },
+
+  /**
+   * Cancel auto-renewal — DELETE /api/tuzis/subscribe/{username}. Mirrors the
+   * backend exactly: this sets `max_price` to 0 so the membership won't
+   * recur, it does NOT revoke access already paid for. The membership stays
+   * active (and keeps showing in `mySubscriptions`) until `expires`.
+   */
+  async unsubscribe(username: string): Promise<void> {
+    if (useMock()) {
+      await delay(300);
+      mockUnsubscribe(username);
+      return;
+    }
+    await request(`/api/tuzis/subscribe/${username}`, { method: "DELETE" });
   },
 };
 

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -16,6 +16,7 @@ import type {
   PersonalityInput,
   PromptResponse,
   SimpleCreator,
+  Subscription,
   TuziTransaction,
 } from "./types";
 
@@ -628,6 +629,72 @@ export const mockTransactions: TuziTransaction[] = [
     counterparty: "zooko",
   },
 ];
+
+/** The mock signed-in user as a `SimpleCreator` (the `fan` side of a `Subscription`). */
+function mockFan(): SimpleCreator {
+  return {
+    username: mockUser.username,
+    free2zaddr: mockUser.free2zaddr ?? mockUser.username,
+    display_name: mockUser.display_name,
+    image: mockUser.image,
+  };
+}
+
+/**
+ * The mock signed-in user's active memberships — mirrors GET
+ * /api/tuzis/my-subscriptions (`fan=request.user`, `expires__gt=now`).
+ * Mutated in place (via `push`/field writes, never reassigned) by
+ * `mockSubscribe`/`mockUnsubscribe`, same pattern as `mockUser` above, so a
+ * subscribe in one screen is reflected everywhere that refetches this list.
+ *
+ * Seeded with one already-active membership (mining_maya) so BOTH the
+ * "Member" and "Subscribe" states are demoable without doing anything first.
+ */
+export const mockSubscriptions: Subscription[] = [
+  {
+    fan: mockFan(),
+    star: mockCreators[1], // mining_maya, member_price 250
+    expires: new Date(Date.now() + 18 * 86400000).toISOString(),
+    max_price: String(mockCreators[1].member_price ?? 0),
+  },
+];
+
+/**
+ * Mock `tuzi.subscribe(username)`. Mirrors `CreatorSubscribeView.post`:
+ * get-or-create a `Subscription` for (star, fan) and extend it 30 days from
+ * now, at the creator's current `member_price`.
+ */
+export function mockSubscribe(username: string): Subscription {
+  const star: SimpleCreator =
+    mockCreators.find((c) => c.username.toLowerCase() === username.toLowerCase()) ??
+    { username, free2zaddr: username, display_name: username };
+  const expires = new Date(Date.now() + 30 * 86400000).toISOString();
+  const maxPrice = String(star.member_price ?? 0);
+
+  const existing = mockSubscriptions.find(
+    (s) => s.star.username.toLowerCase() === username.toLowerCase(),
+  );
+  if (existing) {
+    existing.expires = expires;
+    existing.max_price = maxPrice;
+    return existing;
+  }
+  const sub: Subscription = { fan: mockFan(), star, expires, max_price: maxPrice };
+  mockSubscriptions.push(sub);
+  return sub;
+}
+
+/**
+ * Mock `tuzi.unsubscribe(username)`. Mirrors `CreatorSubscribeView.delete`:
+ * sets `max_price` to 0 so the membership won't renew. The row (and access)
+ * stays until `expires` — it does not disappear from `mySubscriptions`.
+ */
+export function mockUnsubscribe(username: string): void {
+  const existing = mockSubscriptions.find(
+    (s) => s.star.username.toLowerCase() === username.toLowerCase(),
+  );
+  if (existing) existing.max_price = "0";
+}
 
 export function mockAiReply(prompt: string, modelName: string): PromptResponse {
   const response =


### PR DESCRIPTION
## What

Three related ZUULI creator-detail / markdown fixes:

### 1. Markdown link hover was scoped to the wrong element (root cause)
`src/components/common/Markdown.tsx` used `[&_a]:hover:decoration-2`, which
Tailwind compiles to `.container:hover a { text-decoration-thickness: 2px }`
— i.e. hovering **anywhere over the container** (e.g. the bio card) thickens
**every** link inside it at once. Confirmed by compiling the class in
isolation and inspecting the generated CSS.

Fixed to `[&_a:hover]:decoration-2`, which compiles to
`.container a:hover { … }` — hover state now binds to the individual `<a>`,
so only the link actually under the cursor is affected.

`Markdown` is the one shared renderer for the creator bio, articles, and AI
chat, so fixing it here covers all three surfaces without touching
`src/features/ai/**`. Verified live: hovering a card's body text leaves both
links thin; hovering a specific link thickens only that link.

### 2. "200 2Z/mo" was ambiguous
Relabeled everywhere it appears:
- Search creator card: badge now reads **"Membership · 200 2Z/mo"**.
- Creator detail: the Subscribe button itself reads **"Subscribe · 200 2Z/mo"**,
  and the confirm dialog is captioned "Membership · monthly" with a line
  clarifying it's the creator's price to subscribe to them, not the viewer's
  spend.

### 3. Subscribe button ignored subscription state
The backend has **no per-creator "am I subscribed" flag** on
`GET /api/creator/{username}/` (`CreatorDetailSerializer` only carries
`member_price`), and `/api/tuzis/my-subscribers` is the inverse (who
subscribes to *me*, not who *I* subscribe to). The one endpoint that answers
"am I subscribed, and to whom" is `GET /api/tuzis/my-subscriptions` — the
fan's own active memberships (`fan=request.user`, `expires__gt=now`),
matched client-side by `star.username`.

- Subscribed creators now show a **"Member"** button (checkmark, violet
  outline) instead of "Subscribe". Clicking it opens a details dialog:
  price, renews-vs-cancelled state, renewal/expiry date, and a "Cancel
  membership" action wired to the real `DELETE /api/tuzis/subscribe/{username}`
  (sets `max_price` to 0 — access runs to `expires`, doesn't revoke early,
  matching the backend exactly).
- After a successful `subscribe()`: local state flips immediately
  (optimistic), a toast confirms with price + monthly cadence + what was
  unlocked, and `mySubscriptions` is refetched in the background — so the
  button never keeps saying "Subscribe" post-purchase, even if the refetch
  is slow.
- Tip button unchanged; price display consistent with #2 everywhere.
- No dollar signs — 2Z is presented purely as credits throughout.

Added `tuzi.mySubscriptions()` and `tuzi.unsubscribe()` to the typed
`free2z.ts` contract (both backed by real, already-documented endpoints —
no invented API surface), plus `mockSubscriptions`/`mockSubscribe`/
`mockUnsubscribe` fixtures so mock mode demoes both the "already a member"
and "not yet subscribed" states out of the box.

## Verification
- `npm run typecheck` — clean.
- `npm run build` — clean (pre-existing chunk-size warnings only, unrelated).
- `VITE_MOCK=1 npm run dev`, driven in a real browser (signed in via the mock
  Zcash login flow):
  - Search → creator card shows "Membership · 250 2Z/mo".
  - `/creator/mining_maya` (seeded as already-subscribed in mock data) shows
    a "Member" button; opening it shows "Membership price 250 2Z/mo",
    "Renews Aug 6", and a working "Cancel membership" action.
  - `/creator/zooko` (not subscribed) shows "Subscribe · 500 2Z/mo".
  - Isolated hover reproduction (exact compiled Tailwind CSS for both the
    old and new class) confirms: old selector thickens every link on card
    hover; new selector only thickens the specific hovered link — screenshots
    taken hovering the card body vs. hovering a specific link.

## Test plan
- [ ] `npm run typecheck && npm run build` in `wallet/zuuli`
- [ ] `VITE_MOCK=1 npm run dev`, sign in, visit `/search`, `/creator/mining_maya`
      (pre-subscribed in mock data), `/creator/zooko` (not subscribed)
- [ ] Hover the bio card — confirm only the specific link under the cursor
      thickens, not all links at once
- [ ] Subscribe to a creator in mock mode and confirm the button flips to
      "Member" with a toast and detail dialog