### PR TITLE
feat(zuuli): global back nav + creator detail cleanup

### DIFF
--- a/wallet/zuuli/src/components/layout/TopBar.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
+  ArrowLeft,
   Coins,
   Plus,
   Wallet as WalletIcon,
@@ -33,10 +34,35 @@ export function TopBar() {
   const { user, tuzis, logout } = useSession();
   const balance = useWallet((s) => s.balance);
   const navigate = useNavigate();
+  const location = useLocation();
   const [q, setQ] = useState("");
+
+  // This is an app, not a browser — surface a persistent back affordance so
+  // fans can retreat from any screen. React Router stamps a monotonic `idx`
+  // onto `window.history.state` for every in-app entry, so `idx > 0` means
+  // there is a real prior in-app screen to return to (a fresh load / deep
+  // link starts at 0). Reading it during render keyed on `location` keeps it
+  // reactive. Hidden on the root/home route, where "back" is meaningless, so
+  // it never dead-ends the user out of the app.
+  const historyIdx =
+    (window.history.state?.idx as number | undefined) ?? 0;
+  const canGoBack = historyIdx > 0 && location.pathname !== "/";
 
   return (
     <header className="sticky top-0 z-30 flex h-14 items-center gap-3 border-b border-border bg-background/80 px-4 backdrop-blur">
+      {/* Global back — available on every screen inside the shell */}
+      {canGoBack ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => navigate(-1)}
+          aria-label="Go back"
+          className="min-tap h-9 w-9 shrink-0"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+      ) : null}
+
       {/* Global search */}
       <form
         role="search"

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -29,7 +29,6 @@ import {
   AvatarFallback,
   AvatarImage,
 } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -45,7 +44,7 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
 import { Markdown } from "@/components/common/Markdown";
-import { discover, tuzi } from "@/lib/api/free2z";
+import { discover, live, tuzi } from "@/lib/api/free2z";
 import { formatTuzis, initials, timeAgo } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { parseBioFrontmatter, type SocialLink } from "@/lib/utils/bio";
@@ -118,6 +117,17 @@ function CreatorProfile({ creator }: { creator: CreatorDetail }) {
     () => parseBioFrontmatter(creator.bio),
     [creator.bio],
   );
+  // "Watch live" must only appear when this creator is ACTUALLY live right now.
+  // `CreatorDetail` carries no live flag (only the internal `can_stream`
+  // eligibility), so we probe the dedicated live-status endpoint for this one
+  // creator (one request for the profile being viewed, not an N+1). Absent /
+  // failed probes resolve to `live: false`, so the affordance stays hidden
+  // unless there's a confirmed live stream.
+  const { data: liveStatus } = useAsync(
+    () => live.status(creator.username),
+    [creator.username],
+  );
+  const isLive = liveStatus?.live ?? false;
 
   return (
     <div className="animate-slide-up pb-6">
@@ -181,16 +191,17 @@ function CreatorProfile({ creator }: { creator: CreatorDetail }) {
                 </span>{" "}
                 score
               </span>
-              {creator.can_stream ? (
-                <Badge variant="live">Can stream</Badge>
-              ) : null}
+              {/* `can_stream` is an INTERNAL streaming-eligibility flag we track
+                  server-side — it is deliberately NOT surfaced to fans. Whether
+                  a creator is *currently* live is a separate signal, handled by
+                  the live-status probe on the "Watch live" action below. */}
             </div>
           </div>
         </div>
 
         {/* Actions */}
         <div className="flex shrink-0 flex-wrap items-center gap-2 pb-1">
-          {creator.can_stream ? (
+          {isLive ? (
             <Button asChild variant="outline">
               <Link
                 to={`/live/${creator.username}`}


### PR DESCRIPTION
## Two ZUULI UX fixes

### Task 1 — Global back navigation (it's an app, not a browser)
Adds a persistent **back button** to the shared `TopBar`, so it's available on every screen inside the app shell (both the desktop sidebar layout and the mobile bottom-nav layout share this top bar).

- Uses react-router `useNavigate()(-1)`.
- **Visibility:** shown only when `window.history.state?.idx > 0` (React Router stamps a monotonic `idx` on each in-app history entry — `0` means a fresh load / deep link with no in-app previous screen) **and** the current route is not the root/home (`/`). This means it never dead-ends the user out of the app and never appears where "back" is meaningless. Read during render keyed on `useLocation()`, so it stays reactive across navigations.
- Ghost icon `Button` with a lucide `ArrowLeft`, `aria-label="Go back"`, `min-tap`, keyboard-focusable, placed as the first header child so it doesn't overlap the search/composer or balance chips.

### Task 2 — Creator detail cleanup (`features/creator/index.tsx`)
- **Removed the "Can stream" badge.** `can_stream` is an *internal* streaming-eligibility flag and must not be surfaced to fans. Replaced with an explanatory code comment.
- **Gated "Watch live" on real live status.** It previously showed whenever `can_stream` was true (wrong — eligibility ≠ currently live). `CreatorDetail` carries **no** live flag, so we probe the existing `live.status(username)` endpoint (`GET /api/dyte/{username}/live-status`) — one request for the single profile being viewed (not an N+1), resolving to `live: false` on absent/failed probes — and show "Watch live" only when `live === true`.

**Backend note:** No new backend field is required — the live-status signal already exists in the contract (`live.status`). If the team later wants to avoid even this one probe on the creator page, adding an `is_live` boolean to the `CreatorDetail` payload would let the client gate synchronously; not needed for this PR.

## Verification
- `npm install && npm run typecheck && npm run build` — all clean.
- Drove `VITE_MOCK=1` in a browser:
  - Back button **hidden** on root/home; **appears** after in-app navigation (Livestreams); clicking it returns to home where it hides again.
  - Creator **f2z** (not live in mock): no "Can stream" badge, no "Watch live" button (only Tip / Subscribe).
  - Creator **zooko** (live in mock): "Watch live" button appears; still no "Can stream" badge.

## Files changed
- `wallet/zuuli/src/components/layout/TopBar.tsx`
- `wallet/zuuli/src/features/creator/index.tsx`