### PR TITLE
feat(zuuli): threaded comments on zpages + Reader overflow fix

### DIFF
--- a/wallet/zuuli/src/features/articles/components/Comments/CommentCard.tsx
+++ b/wallet/zuuli/src/features/articles/components/Comments/CommentCard.tsx
@@ -1,0 +1,173 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { ChevronDown, ChevronUp, MessageSquare, Reply } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Markdown } from "@/components/common/Markdown";
+import { comments as commentsApi } from "@/lib/api/free2z";
+import { formatTuzis, initials, timeAgo } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { useSession } from "@/store/session";
+import type { Comment, CommentInput } from "@/lib/api/types";
+import { CommentForm } from "./CommentForm";
+
+interface CommentCardProps {
+  comment: Comment;
+  /** Called after a reply is posted so the thread can refetch its children. */
+  onReplied: (reply: Comment) => void;
+}
+
+export function CommentCard({ comment, onReplied }: CommentCardProps) {
+  const adjustTuzis = useSession((s) => s.adjustTuzis);
+  const [replying, setReplying] = useState(false);
+  const [score, setScore] = useState(comment.tuzis);
+  const [voted, setVoted] = useState<"up" | "down" | null>(null);
+  const [voting, setVoting] = useState(false);
+
+  const name = comment.author.username;
+
+  async function vote(dir: "up" | "down") {
+    if (voting || voted === dir) return;
+    setVoting(true);
+    // Optimistic: reflect the new score + spend 1 2Z immediately.
+    const prevScore = score;
+    const prevVoted = voted;
+    setScore((s) => s + (dir === "up" ? 1 : -1));
+    setVoted(dir);
+    adjustTuzis(-1);
+    try {
+      await commentsApi.vote(comment.uuid, dir);
+    } catch {
+      setScore(prevScore);
+      setVoted(prevVoted);
+      adjustTuzis(1);
+      toast.error("Could not record your vote.");
+    } finally {
+      setVoting(false);
+    }
+  }
+
+  async function submitReply(body: CommentInput) {
+    return commentsApi.createReply(comment.uuid, body);
+  }
+
+  return (
+    <div className="min-w-0 rounded-xl border border-border bg-card/60 p-4">
+      <div className="flex items-start gap-3">
+        {/* Vote rail */}
+        <div className="flex shrink-0 flex-col items-center gap-0.5">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 min-tap"
+            aria-label="Upvote comment"
+            aria-pressed={voted === "up"}
+            disabled={voting}
+            onClick={() => vote("up")}
+          >
+            <ChevronUp
+              className={cn("h-4 w-4", voted === "up" && "text-primary")}
+              aria-hidden
+            />
+          </Button>
+          <span className="text-xs font-semibold tabular-nums text-muted-foreground">
+            {score}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 min-tap"
+            aria-label="Downvote comment"
+            aria-pressed={voted === "down"}
+            disabled={voting}
+            onClick={() => vote("down")}
+          >
+            <ChevronDown
+              className={cn("h-4 w-4", voted === "down" && "text-primary")}
+              aria-hidden
+            />
+          </Button>
+        </div>
+
+        {/* Body */}
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+            <Link
+              to={`/creator/${name}`}
+              className="flex items-center gap-2 font-medium text-foreground transition-colors hover:text-primary"
+            >
+              <Avatar className="h-6 w-6">
+                {comment.author.avatar_image ? (
+                  <AvatarImage src={comment.author.avatar_image} alt={name} />
+                ) : null}
+                <AvatarFallback className="text-[10px]">
+                  {initials(name)}
+                </AvatarFallback>
+              </Avatar>
+              {name}
+            </Link>
+            <span className="text-muted-foreground" aria-hidden>
+              ·
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {timeAgo(comment.created_at)}
+            </span>
+            <span
+              className="ml-auto inline-flex items-center gap-1 text-xs tabular-nums text-muted-foreground"
+              title={`${formatTuzis(comment.tuzis)} weight`}
+            >
+              {formatTuzis(comment.tuzis)}
+            </span>
+          </div>
+
+          <h4 className="break-words text-base font-semibold leading-snug">
+            {comment.headline}
+          </h4>
+
+          <div className="min-w-0 max-w-full overflow-x-auto break-words text-sm text-muted-foreground">
+            <Markdown>{comment.content}</Markdown>
+          </div>
+
+          <div className="flex items-center gap-2 pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 px-2 text-muted-foreground"
+              onClick={() => setReplying((r) => !r)}
+              aria-expanded={replying}
+            >
+              <Reply className="h-4 w-4" aria-hidden />
+              Reply
+            </Button>
+            {comment.num_children > 0 ? (
+              <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                <MessageSquare className="h-3.5 w-3.5" aria-hidden />
+                {comment.num_children}
+              </span>
+            ) : null}
+          </div>
+
+          {replying ? (
+            <div className="pt-2">
+              <CommentForm
+                compact
+                autoFocus
+                submit={submitReply}
+                onCancel={() => setReplying(false)}
+                onPosted={(reply) => {
+                  setReplying(false);
+                  onReplied(reply);
+                }}
+              />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/wallet/zuuli/src/features/articles/components/Comments/CommentForm.tsx
+++ b/wallet/zuuli/src/features/articles/components/Comments/CommentForm.tsx
@@ -1,0 +1,219 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, Eye, EyeOff, Loader2, LogIn, Send } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Markdown } from "@/components/common/Markdown";
+import { formatTuzis } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { useSession } from "@/store/session";
+import type { Comment, CommentInput } from "@/lib/api/types";
+
+const HEADLINE_MAX = 100;
+const CONTENT_MAX = 1000;
+
+interface CommentFormProps {
+  /** Performs the POST (root create vs. reply create is decided by the caller). */
+  submit: (body: CommentInput) => Promise<Comment>;
+  /** Called with the freshly-created comment after a successful post. */
+  onPosted: (comment: Comment) => void;
+  /** Reply forms render a cancel affordance and start focused. */
+  onCancel?: () => void;
+  compact?: boolean;
+  autoFocus?: boolean;
+}
+
+export function CommentForm({
+  submit,
+  onPosted,
+  onCancel,
+  compact,
+  autoFocus,
+}: CommentFormProps) {
+  const navigate = useNavigate();
+  const user = useSession((s) => s.user);
+  const balance = useSession((s) => s.tuzis);
+  const adjustTuzis = useSession((s) => s.adjustTuzis);
+
+  const [headline, setHeadline] = useState("");
+  const [content, setContent] = useState("");
+  const [tuzis, setTuzis] = useState(1);
+  const [preview, setPreview] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Login gate — comments cost 2Zs, which requires an account.
+  if (!user) {
+    return (
+      <div className="rounded-xl border border-dashed border-border bg-card/30 px-4 py-6 text-center">
+        <p className="text-sm text-muted-foreground">
+          Log in to join the conversation — comments are titled and cost 2Zs.
+        </p>
+        <Button
+          className="mt-3"
+          variant="outline"
+          onClick={() => navigate("/login")}
+        >
+          <LogIn className="h-4 w-4" aria-hidden />
+          Log in to comment
+        </Button>
+      </div>
+    );
+  }
+
+  const headlineOk = headline.trim().length > 0 && headline.length <= HEADLINE_MAX;
+  const contentOk = content.trim().length > 0 && content.length <= CONTENT_MAX;
+  const weightOk = tuzis >= 1;
+  const enough = tuzis <= balance;
+  const canPost = headlineOk && contentOk && weightOk && enough && !submitting;
+
+  async function post() {
+    if (!canPost) return;
+    setSubmitting(true);
+    try {
+      const created = await submit({
+        headline: headline.trim(),
+        content: content.trim(),
+        tuzis,
+      });
+      // Posting spends the weight from the local balance, like the tip flow.
+      adjustTuzis(-tuzis);
+      toast.success(`Posted — ${formatTuzis(tuzis)} weight`);
+      setHeadline("");
+      setContent("");
+      setTuzis(1);
+      setPreview(false);
+      onPosted(created);
+    } catch {
+      toast.error("Could not post your comment. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={cn("space-y-3", compact && "space-y-2")}>
+      <div className="space-y-1.5">
+        <Label htmlFor="comment-headline" className="sr-only">
+          Headline
+        </Label>
+        <Input
+          id="comment-headline"
+          placeholder="Headline"
+          value={headline}
+          maxLength={HEADLINE_MAX + 1}
+          autoFocus={autoFocus}
+          onChange={(e) => setHeadline(e.target.value)}
+          aria-invalid={headline.length > HEADLINE_MAX}
+        />
+      </div>
+
+      {preview ? (
+        <div className="min-h-[6rem] w-full min-w-0 overflow-x-auto rounded-md border border-border bg-background/50 px-3 py-2">
+          {content.trim() ? (
+            <Markdown>{content}</Markdown>
+          ) : (
+            <p className="text-sm text-muted-foreground">Nothing to preview yet.</p>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-1">
+          <Label htmlFor="comment-body" className="sr-only">
+            Comment
+          </Label>
+          <Textarea
+            id="comment-body"
+            placeholder="Share your thoughts… (markdown supported)"
+            value={content}
+            maxLength={CONTENT_MAX + 1}
+            rows={compact ? 3 : 4}
+            onChange={(e) => setContent(e.target.value)}
+            aria-invalid={content.length > CONTENT_MAX}
+          />
+          <p
+            className={cn(
+              "text-right text-xs tabular-nums text-muted-foreground",
+              content.length > CONTENT_MAX && "text-destructive",
+            )}
+          >
+            {content.length}/{CONTENT_MAX}
+          </p>
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-1.5">
+          <Label htmlFor="comment-weight" className="text-xs text-muted-foreground">
+            Weight
+          </Label>
+          <Input
+            id="comment-weight"
+            type="number"
+            min={1}
+            inputMode="numeric"
+            value={tuzis}
+            onChange={(e) => setTuzis(Math.max(1, Number(e.target.value) || 1))}
+            className="h-9 w-20 tabular-nums"
+            aria-label="2Z weight to spend on this comment"
+          />
+          <span className="text-xs text-muted-foreground">2Z</span>
+        </div>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setPreview((p) => !p)}
+        >
+          {preview ? (
+            <EyeOff className="h-4 w-4" aria-hidden />
+          ) : (
+            <Eye className="h-4 w-4" aria-hidden />
+          )}
+          {preview ? "Edit" : "Preview"}
+        </Button>
+
+        <div className="ml-auto flex items-center gap-2">
+          {onCancel ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onCancel}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+          ) : null}
+          {!enough ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => navigate("/buy")}
+            >
+              Not enough 2Z
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Button>
+          ) : (
+            <Button type="button" size="sm" onClick={post} disabled={!canPost}>
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  Posting
+                </>
+              ) : (
+                <>
+                  <Send className="h-4 w-4" aria-hidden />
+                  Post
+                </>
+              )}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/wallet/zuuli/src/features/articles/components/Comments/CommentThread.tsx
+++ b/wallet/zuuli/src/features/articles/components/Comments/CommentThread.tsx
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { comments as commentsApi } from "@/lib/api/free2z";
+import type { Comment, CommentContentType } from "@/lib/api/types";
+import { CommentCard } from "./CommentCard";
+
+/** How deep to keep indenting before flattening, so deep threads never push
+ *  content off-screen on a phone. */
+const MAX_INDENT_DEPTH = 4;
+
+interface CommentThreadProps {
+  comment: Comment;
+  contentType: CommentContentType;
+  depth?: number;
+}
+
+/** One comment plus its (recursively threaded) replies. */
+export function CommentThread({ comment, contentType, depth = 0 }: CommentThreadProps) {
+  // Bumped whenever a reply is posted under this comment, to refetch children.
+  const [reload, setReload] = useState(0);
+
+  return (
+    <div className="min-w-0 space-y-3">
+      <CommentCard
+        comment={comment}
+        onReplied={() => setReload((n) => n + 1)}
+      />
+      <CommentReplies
+        parentUuid={comment.uuid}
+        contentType={contentType}
+        reload={reload}
+        depth={depth + 1}
+      />
+    </div>
+  );
+}
+
+interface CommentRepliesProps {
+  parentUuid: string;
+  contentType: CommentContentType;
+  reload: number;
+  depth: number;
+}
+
+function CommentReplies({
+  parentUuid,
+  contentType,
+  reload,
+  depth,
+}: CommentRepliesProps) {
+  const [replies, setReplies] = useState<Comment[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const acc: Comment[] = [];
+      let page: number | null = 1;
+      while (page) {
+        const res = await commentsApi.listReplies(parentUuid, { page });
+        acc.push(...res.items);
+        page = res.next;
+      }
+      setReplies(acc);
+    } catch {
+      // A failed reply fetch shouldn't tear down the whole thread; leave the
+      // existing replies in place.
+    } finally {
+      setLoading(false);
+    }
+  }, [parentUuid]);
+
+  useEffect(() => {
+    void load();
+  }, [load, reload]);
+
+  if (!replies.length) {
+    return loading ? (
+      <div className="pl-3">
+        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" aria-hidden />
+      </div>
+    ) : null;
+  }
+
+  // The thread tree: indent replies with a left border, but stop indenting past
+  // a max depth so long chains never cause horizontal overflow on mobile.
+  const indent = depth <= MAX_INDENT_DEPTH;
+
+  return (
+    <div
+      className={
+        indent
+          ? "space-y-3 border-l border-border pl-3 sm:pl-4"
+          : "space-y-3"
+      }
+    >
+      {replies.map((reply) => (
+        <CommentThread
+          key={reply.uuid}
+          comment={reply}
+          contentType={contentType}
+          depth={depth}
+        />
+      ))}
+    </div>
+  );
+}

--- a/wallet/zuuli/src/features/articles/components/Comments/index.tsx
+++ b/wallet/zuuli/src/features/articles/components/Comments/index.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useState } from "react";
+import { MessagesSquare } from "lucide-react";
+import { EmptyState } from "@/components/common/EmptyState";
+import { Skeleton } from "@/components/ui/skeleton";
+import { comments as commentsApi } from "@/lib/api/free2z";
+import type { Comment, CommentContentType, CommentInput } from "@/lib/api/types";
+import { CommentForm } from "./CommentForm";
+import { CommentThread } from "./CommentThread";
+
+interface CommentsSectionProps {
+  /** The content object's uuid — for a zpage this is `article.free2zaddr`. */
+  uuid: string;
+  contentType?: CommentContentType;
+}
+
+type Status = "loading" | "ready" | "error";
+
+/**
+ * Threaded comments for a content object (a zpage in the Reader). Fetches the
+ * top-level comments (following DRF pagination), renders a titled compose form
+ * (login-gated), and a recursive thread tree. Newly-posted roots appear at the
+ * top of the list without a full refetch.
+ */
+export function CommentsSection({
+  uuid,
+  contentType = "zpage",
+}: CommentsSectionProps) {
+  const [roots, setRoots] = useState<Comment[]>([]);
+  const [count, setCount] = useState(0);
+  const [status, setStatus] = useState<Status>("loading");
+
+  const load = useCallback(async () => {
+    setStatus("loading");
+    try {
+      const acc: Comment[] = [];
+      let page: number | null = 1;
+      let total = 0;
+      while (page) {
+        const res = await commentsApi.list(contentType, uuid, {
+          rootsOnly: true,
+          page,
+        });
+        acc.push(...res.items);
+        total = res.count;
+        page = res.next;
+      }
+      setRoots(acc);
+      setCount(total);
+      setStatus("ready");
+    } catch {
+      setStatus("error");
+    }
+  }, [contentType, uuid]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function submitRoot(body: CommentInput) {
+    return commentsApi.create(contentType, uuid, body);
+  }
+
+  return (
+    <section aria-labelledby="comments-heading" className="mt-14 min-w-0">
+      <div className="mb-5 flex items-center gap-2">
+        <MessagesSquare className="h-5 w-5 text-muted-foreground" aria-hidden />
+        <h2 id="comments-heading" className="text-xl font-bold tracking-tight">
+          Comments
+          {status === "ready" && count > 0 ? (
+            <span className="ml-2 text-base font-normal tabular-nums text-muted-foreground">
+              {count}
+            </span>
+          ) : null}
+        </h2>
+      </div>
+
+      <div className="mb-8 rounded-xl border border-border bg-card/40 p-4">
+        <CommentForm
+          submit={submitRoot}
+          onPosted={(created) => {
+            setRoots((prev) => [created, ...prev]);
+            setCount((c) => c + 1);
+          }}
+        />
+      </div>
+
+      {status === "loading" ? (
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="rounded-xl border border-border bg-card/60 p-4">
+              <div className="flex gap-3">
+                <Skeleton className="h-7 w-7 rounded-md" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-3 w-full" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : status === "error" ? (
+        <EmptyState
+          icon={MessagesSquare}
+          title="Couldn’t load comments"
+          description="Something went wrong fetching the discussion. Try again later."
+        />
+      ) : roots.length === 0 ? (
+        <EmptyState
+          icon={MessagesSquare}
+          title="No comments yet"
+          description="Be the first to weigh in — comments are titled and backed by 2Zs."
+        />
+      ) : (
+        <div className="space-y-4">
+          {roots.map((root) => (
+            <CommentThread
+              key={root.uuid}
+              comment={root}
+              contentType={contentType}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/wallet/zuuli/src/features/articles/pages/Reader.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Reader.tsx
@@ -16,6 +16,7 @@ import { articles } from "@/lib/api/free2z";
 import { initials } from "@/lib/format";
 import type { Article } from "@/lib/api/types";
 import { TipDialog } from "../components/TipDialog";
+import { CommentsSection } from "../components/Comments";
 import { coverGradient, formatPublished } from "../lib";
 
 type Status = "loading" | "ready" | "missing";
@@ -89,17 +90,19 @@ export function Reader() {
   const name = author.display_name || author.username;
 
   return (
-    <article className="animate-slide-up pb-28">
-      <div className="mx-auto max-w-3xl">
+    <article className="animate-slide-up w-full min-w-0 overflow-x-clip pb-28">
+      <div className="mx-auto w-full min-w-0 max-w-3xl">
         <BackLink />
 
-        <header className="mt-6 space-y-4">
+        <header className="mt-6 min-w-0 space-y-4">
           {article.category ? <Badge>{article.category}</Badge> : null}
-          <h1 className="text-3xl font-bold leading-tight tracking-tight md:text-4xl">
+          <h1 className="break-words text-3xl font-bold leading-tight tracking-tight md:text-4xl">
             {article.title}
           </h1>
           {article.subtitle ? (
-            <p className="text-lg text-muted-foreground">{article.subtitle}</p>
+            <p className="break-words text-lg text-muted-foreground">
+              {article.subtitle}
+            </p>
           ) : null}
 
           <div className="flex items-center gap-3 pt-2">
@@ -158,9 +161,13 @@ export function Reader() {
           ) : null}
         </div>
 
-        <div className="mt-10">
+        <div className="mt-10 min-w-0 max-w-full break-words">
           <Markdown>{article.content}</Markdown>
         </div>
+
+        {article.free2zaddr ? (
+          <CommentsSection uuid={article.free2zaddr} contentType="zpage" />
+        ) : null}
       </div>
 
       {/* Sticky action bar */}

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -16,6 +16,11 @@ import {
   mockArticles,
   mockAssociateZcash,
   mockConversationReply,
+  mockCommentCreate,
+  mockCommentReplies,
+  mockCommentReplyCreate,
+  mockCommentVote,
+  mockComments,
   mockCreatePersonality,
   mockCreatorDetail,
   mockCreators,
@@ -42,6 +47,10 @@ import type {
   ArticleFeedPage,
   ArticleFeedParams,
   AuthUser,
+  Comment,
+  CommentContentType,
+  CommentInput,
+  CommentVote,
   CreatorDetail,
   DyteJoinTicket,
   KycIdentityDocType,
@@ -906,6 +915,160 @@ export const articles = {
       },
     });
     return mapArticle(z);
+  },
+};
+
+// ─── Comments (threaded, on zpages) ──────────────────────────────────────────
+
+/** Raw wire shape of a comment (CommentListSerializer). */
+interface RawComment {
+  uuid: string;
+  author: { username: string; avatar_image?: RawImage | null };
+  parent: string | null;
+  headline: string;
+  content: string;
+  tuzis: number | string;
+  created_at: string;
+  updated_at: string;
+  tags?: string[];
+  num_children?: number;
+  content_url?: string | null;
+}
+
+function mapComment(c: RawComment): Comment {
+  return {
+    uuid: c.uuid,
+    author: {
+      username: c.author.username,
+      avatar_image:
+        mediaUrl(
+          c.author.avatar_image?.thumbnail || c.author.avatar_image?.url,
+        ) ?? null,
+    },
+    parent: c.parent ?? null,
+    headline: c.headline,
+    content: c.content,
+    tuzis: Math.round(Number(c.tuzis)) || 0,
+    created_at: c.created_at,
+    updated_at: c.updated_at,
+    tags: c.tags ?? [],
+    num_children: c.num_children ?? 0,
+    content_url: c.content_url ?? null,
+  };
+}
+
+/** One page of comments — `next` is the next page number (or null at the end). */
+export interface CommentPage {
+  items: Comment[];
+  next: number | null;
+  count: number;
+}
+
+export const comments = {
+  /**
+   * Top-level comments on a content object — GET
+   * /api/comments/{type}/{uuid}/?parent__isnull=True. `uuid` is the zpage's
+   * `free2zaddr` (a canonical UUID). DRF PageNumber pagination.
+   *
+   * NB: the backend's zpage list/create view 404s unless the target zpage has a
+   * truthy vanity slug OR is addressed by its `free2zaddr` — always pass
+   * `article.free2zaddr` here, never the vanity slug.
+   */
+  async list(
+    type: CommentContentType,
+    uuid: string,
+    opts: { rootsOnly?: boolean; page?: number } = {},
+  ): Promise<CommentPage> {
+    const page = opts.page ?? 1;
+    if (useMock()) {
+      await delay(180);
+      return mockComments(uuid, { rootsOnly: opts.rootsOnly ?? true, page });
+    }
+    const res = await request<Paginated<RawComment>>(
+      `/api/comments/${type}/${encodeURIComponent(uuid)}/`,
+      {
+        query: {
+          page,
+          ...(opts.rootsOnly ? { parent__isnull: "True" } : {}),
+        },
+        anonymous: true,
+      },
+    );
+    return {
+      items: (res.results ?? []).map(mapComment),
+      next: res.next ? page + 1 : null,
+      count: res.count ?? 0,
+    };
+  },
+
+  /** Replies to a parent comment — GET /api/comments/{uuid}/replies/. */
+  async listReplies(
+    parentUuid: string,
+    opts: { page?: number } = {},
+  ): Promise<CommentPage> {
+    const page = opts.page ?? 1;
+    if (useMock()) {
+      await delay(150);
+      return mockCommentReplies(parentUuid, { page });
+    }
+    const res = await request<Paginated<RawComment>>(
+      `/api/comments/${encodeURIComponent(parentUuid)}/replies/`,
+      { query: { page }, anonymous: true },
+    );
+    return {
+      items: (res.results ?? []).map(mapComment),
+      next: res.next ? page + 1 : null,
+      count: res.count ?? 0,
+    };
+  },
+
+  /**
+   * Create a top-level comment — POST /api/comments/{type}/{uuid}/. Requires
+   * Knox auth and costs `tuzis` (≥1), deducted from the author's balance.
+   */
+  async create(
+    type: CommentContentType,
+    uuid: string,
+    body: CommentInput,
+  ): Promise<Comment> {
+    if (useMock()) {
+      await delay(300);
+      return mockCommentCreate(uuid, body);
+    }
+    const c = await request<RawComment>(
+      `/api/comments/${type}/${encodeURIComponent(uuid)}/`,
+      { method: "POST", body: { ...body, parent: null } },
+    );
+    return mapComment(c);
+  },
+
+  /**
+   * Reply to a comment — POST /api/comments/{uuid}/replies/. Inherits the
+   * parent's content object. Requires auth and costs `tuzis`.
+   */
+  async createReply(parentUuid: string, body: CommentInput): Promise<Comment> {
+    if (useMock()) {
+      await delay(300);
+      return mockCommentReplyCreate(parentUuid, body);
+    }
+    const c = await request<RawComment>(
+      `/api/comments/${encodeURIComponent(parentUuid)}/replies/`,
+      { method: "POST", body },
+    );
+    return mapComment(c);
+  },
+
+  /** Vote on a comment — POST /api/comments/{uuid}/vote/ (costs 1 2Z). */
+  async vote(uuid: string, dir: CommentVote): Promise<void> {
+    if (useMock()) {
+      await delay(150);
+      mockCommentVote(uuid, dir);
+      return;
+    }
+    await request(`/api/comments/${encodeURIComponent(uuid)}/vote/`, {
+      method: "POST",
+      body: { vote: dir },
+    });
   },
 };
 

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -8,6 +8,9 @@ import type {
   ArticleFeedPage,
   ArticleFeedParams,
   AuthUser,
+  Comment,
+  CommentInput,
+  CommentVote,
   CreatorDetail,
   KycIdentityDocuments,
   KycProfile,
@@ -830,3 +833,158 @@ export const mockKycTaxForm: {
   file_url: null,
   tax_form_signature: null,
 };
+
+// ── Comments (threaded, mock) ───────────────────────────────────────────────
+// A small in-memory thread store so the Reader's comments section is fully
+// demoable offline (VITE_MOCK=1): a couple of titled roots on the first
+// featured zpage, one with a nested reply chain, realistic 2Z weights. Mutated
+// in place (posts/votes persist for the session), mirroring the real backend.
+
+interface MockCommentPage {
+  items: Comment[];
+  next: number | null;
+  count: number;
+}
+
+/** content uuid (zpage free2zaddr) each comment lives on, by comment uuid. */
+const mockCommentContent = new Map<string, string>();
+/** Flat store of every mock comment (roots + replies). */
+const mockCommentStore: Comment[] = [];
+
+function mockAuthor(c: SimpleCreator): Comment["author"] {
+  return { username: c.username, avatar_image: c.image ?? null };
+}
+
+function seedComment(
+  contentUuid: string,
+  author: SimpleCreator,
+  parent: string | null,
+  headline: string,
+  content: string,
+  tuzis: number,
+  minutesAgo: number,
+): Comment {
+  const uuid = `mock-comment-${mockCommentStore.length + 1}`;
+  const ts = new Date(Date.now() - minutesAgo * 60000).toISOString();
+  const comment: Comment = {
+    uuid,
+    author: mockAuthor(author),
+    parent,
+    headline,
+    content,
+    tuzis,
+    created_at: ts,
+    updated_at: ts,
+    tags: [],
+    num_children: 0,
+    content_url: null,
+  };
+  mockCommentStore.push(comment);
+  mockCommentContent.set(uuid, contentUuid);
+  if (parent) {
+    const p = mockCommentStore.find((x) => x.uuid === parent);
+    if (p) p.num_children += 1;
+  }
+  return comment;
+}
+
+// Seed a lively thread on the first featured zpage ("zooko").
+(() => {
+  const content = featuredArticles[0].free2zaddr!;
+  const root1 = seedComment(
+    content,
+    mockCreators[3],
+    null,
+    "This reframed privacy for me",
+    "The **asymmetry** point is the whole game. Transparency for the powerful, privacy for everyone else — shielded-by-default finally flips it.",
+    42,
+    180,
+  );
+  const reply1 = seedComment(
+    content,
+    mockCreators[0],
+    root1.uuid,
+    "Exactly the intent",
+    "That inversion was the design goal from day one. The default is what most people actually get.",
+    18,
+    120,
+  );
+  seedComment(
+    content,
+    mockCreators[4],
+    reply1.uuid,
+    "And it compounds",
+    "Once the shielded pool is the norm, the anonymity set grows for *everyone* — privacy as a public good, literally.",
+    7,
+    64,
+  );
+  seedComment(
+    content,
+    mockCreators[1],
+    null,
+    "Small nit on the trusted setup",
+    "Great piece. Worth noting Halo2 drops the trusted setup entirely — might be worth a follow-up article.",
+    23,
+    45,
+  );
+})();
+
+export function mockComments(
+  contentUuid: string,
+  opts: { rootsOnly: boolean; page: number },
+): MockCommentPage {
+  const items = mockCommentStore
+    .filter(
+      (c) =>
+        mockCommentContent.get(c.uuid) === contentUuid &&
+        (opts.rootsOnly ? c.parent === null : true),
+    )
+    .sort((a, b) => b.tuzis - a.tuzis || b.created_at.localeCompare(a.created_at));
+  return { items, next: null, count: items.length };
+}
+
+export function mockCommentReplies(
+  parentUuid: string,
+  _opts: { page: number },
+): MockCommentPage {
+  const items = mockCommentStore
+    .filter((c) => c.parent === parentUuid)
+    .sort((a, b) => b.tuzis - a.tuzis || b.created_at.localeCompare(a.created_at));
+  return { items, next: null, count: items.length };
+}
+
+export function mockCommentCreate(
+  contentUuid: string,
+  body: CommentInput,
+): Comment {
+  return seedComment(
+    contentUuid,
+    mockUser as unknown as SimpleCreator,
+    null,
+    body.headline,
+    body.content,
+    body.tuzis,
+    0,
+  );
+}
+
+export function mockCommentReplyCreate(
+  parentUuid: string,
+  body: CommentInput,
+): Comment {
+  const content = mockCommentContent.get(parentUuid) ?? "";
+  return seedComment(
+    content,
+    mockUser as unknown as SimpleCreator,
+    parentUuid,
+    body.headline,
+    body.content,
+    body.tuzis,
+    0,
+  );
+}
+
+export function mockCommentVote(uuid: string, dir: CommentVote): void {
+  const c = mockCommentStore.find((x) => x.uuid === uuid);
+  if (c) c.tuzis = Math.max(0, c.tuzis + (dir === "up" ? 1 : -1));
+}

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -226,6 +226,54 @@ export interface Article {
   tags?: string[];
 }
 
+// ── Comments (threaded, on zpages / AI conversations) ───────────────────────
+// Backend: `/api/comments/` (confirmed against tuzi f2z.yaml). Comments are
+// TITLED (`headline` required, ≤100 chars) and cost `tuzis` to post (≥1, spent
+// from the author's balance; also the vote weight/score). Threading is a
+// self-FK `parent` (to_field uuid): roots via `?parent__isnull=True`, replies
+// via `/api/comments/{parent}/replies/`. Nesting is unbounded.
+
+/** The content object a thread of comments hangs off of. */
+export type CommentContentType = "zpage" | "ai_conversation";
+
+/** Author of a comment (CommentListSerializer.author). */
+export interface CommentAuthor {
+  username: string;
+  /** Avatar URL (mapped from `avatar_image.thumbnail`/`url`), if any. */
+  avatar_image?: string | null;
+}
+
+/** One comment — shape from `CommentListSerializer`. */
+export interface Comment {
+  uuid: string;
+  author: CommentAuthor;
+  /** Parent comment uuid (self-FK), or `null` for a top-level comment. */
+  parent: string | null;
+  /** Required title, ≤100 chars. */
+  headline: string;
+  /** Markdown body, ≤1000 chars. */
+  content: string;
+  /** Weight spent to post (≥1); doubles as the vote score. */
+  tuzis: number;
+  created_at: string;
+  updated_at: string;
+  tags?: string[];
+  /** Number of direct replies. */
+  num_children: number;
+  /** Link back to the content object the comment lives on, if any. */
+  content_url?: string | null;
+}
+
+/** Body for creating a comment / reply (POST). */
+export interface CommentInput {
+  headline: string;
+  content: string;
+  tuzis: number;
+}
+
+/** Vote direction — POST /api/comments/{uuid}/vote/ (costs 1 2Z). */
+export type CommentVote = "up" | "down";
+
 /**
  * How the article feed is ranked (`?homeSort=` on /api/zpage/):
  * - `popular` — recency-decayed "fresh" ranking (the ZUULI default).


### PR DESCRIPTION
## What

Adds **threaded comments** to the ZUULI article Reader and fixes the reported **zpage horizontal-overflow/wrapping** on mobile.

### Comments
- **`lib/api/free2z.ts`** — new `comments` API object wired to `/api/comments/` (confirmed against tuzi `f2z.yaml`): `list(type,uuid,{rootsOnly,page})`, `listReplies(uuid,{page})`, `create(type,uuid,body)`, `createReply(parentUuid,body)`, `vote(uuid,dir)`. Uses the existing `request<T>()` helper + Knox `Authorization: Token`, with the standard `useMock()` fallback for every method. Roots are addressed by the zpage's **`free2zaddr`** (canonical UUID), per the backend's vanity-slug gotcha. Adds a `RawComment` → `Comment` mapper (parses `tuzis`, maps avatar via `mediaUrl`).
- **`lib/api/types.ts`** — `Comment`, `CommentAuthor`, `CommentInput`, `CommentContentType`, `CommentVote`. `headline` required (≤100), `content` (≤1000), `tuzis` ≥1 (weight = score).
- **`lib/api/mock-data.ts`** — in-memory thread store seeded on the first featured zpage: 2 titled roots, one with a 2-level nested reply chain, realistic 2Z weights. Posts/votes persist for the mock session.
- **`features/articles/components/Comments/*`** (new) — recursive thread tree with shadcn primitives:
  - `index.tsx` (`CommentsSection`) — fetches roots following DRF pagination, count header, skeleton + empty + error states, root compose form; new roots prepend without a refetch.
  - `CommentThread.tsx` — one comment + its replies, recursive with left-border indent (indent caps past depth 4 so deep chains never overflow on mobile).
  - `CommentCard.tsx` — avatar/headline/relative-time, up/down vote rail (optimistic, costs 1 2Z), Markdown body, collapsible reply.
  - `CommentForm.tsx` — **login-gated** (routes to `/login`), titled compose (headline + markdown body + 2Z weight), preview toggle, balance-aware "Not enough 2Z → buy" state. Posting optimistically debits the local 2Z balance via `useSession` (same pattern as the tip flow).

### Reader overflow fix
- `Reader.tsx`: mount `CommentsSection` at the bottom keyed off `article.free2zaddr` (type `zpage`), and harden the page container against page-level horizontal scroll: `w-full min-w-0 overflow-x-clip` article, `min-w-0` header/content, `break-words` on title/subtitle and the markdown wrapper.

## Verified (VITE_MOCK=1, browser)
- `npm install && npm run typecheck && npm run build` — all clean.
- Reader renders the mocked thread: 2 roots + nested `zooko` reply + deeper `halo_hana` reply, correctly indented.
- Reply/compose form is **login-gated** when logged out; with a mock session the titled form enables.
- Posting a root comment appears at the **top** of the tree ("Comments 2" → "3") and the 2Z balance drops (4210 → 4209) — optimistic debit confirmed.
- **No page-level horizontal scroll at 360px**: with the article constrained to a 360px box, worst descendant overflow = 0 and `article.scrollWidth === 360`, even after injecting a 240-char unbreakable token into a headline (`break-words` holds).

## Scope
Only touched owned files: `free2z.ts`, `types.ts`, `mock-data.ts`, `Reader.tsx`, and new `Comments/*`. Imports (does not edit) the shared `Markdown` component for comment bodies.