### PR TITLE
perf(zuuli): code-split feature routes off the login critical path

### DIFF
--- a/wallet/zuuli/src/App.tsx
+++ b/wallet/zuuli/src/App.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Loader2 } from "lucide-react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { AppShell } from "@/components/layout/AppShell";
@@ -7,17 +8,34 @@ import { NotFound } from "@/components/common/NotFound";
 import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
 
-import HomeFeature from "@/features/home";
-import WalletFeature from "@/features/wallet";
-import AiFeature from "@/features/ai";
-import LiveFeature from "@/features/live";
-import ArticlesFeature from "@/features/articles";
-import BuyFeature from "@/features/buy";
 import AuthFeature from "@/features/auth";
-import SearchFeature from "@/features/search";
-import CreatorFeature from "@/features/creator";
-import ProfileFeature from "@/features/profile";
-import KycFeature from "@/features/kyc";
+
+// Feature routes are code-split so the heavy markdown/math/prism graph they
+// transitively pull in (rehype-mathjax, rehype-prism-plus) never lands in the
+// login/critical-path entry chunk. The login screen (AuthFeature), the AppShell
+// layout, and the router stay eager so /login renders instantly.
+const HomeFeature = lazy(() => import("@/features/home"));
+const WalletFeature = lazy(() => import("@/features/wallet"));
+const AiFeature = lazy(() => import("@/features/ai"));
+const LiveFeature = lazy(() => import("@/features/live"));
+const ArticlesFeature = lazy(() => import("@/features/articles"));
+const BuyFeature = lazy(() => import("@/features/buy"));
+const SearchFeature = lazy(() => import("@/features/search"));
+const CreatorFeature = lazy(() => import("@/features/creator"));
+const ProfileFeature = lazy(() => import("@/features/profile"));
+const KycFeature = lazy(() => import("@/features/kyc"));
+
+function RouteFallback() {
+  return (
+    <div
+      className="flex min-h-[40vh] w-full items-center justify-center"
+      role="status"
+      aria-label="Loading"
+    >
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" aria-hidden />
+    </div>
+  );
+}
 
 export default function App() {
   const bootstrapSession = useSession((s) => s.bootstrap);
@@ -32,21 +50,92 @@ export default function App() {
     <TooltipProvider delayDuration={200}>
       <BrowserRouter>
         <Routes>
-          {/* Full-screen auth, outside the app shell */}
+          {/* Full-screen auth, outside the app shell — kept eager so /login is instant */}
           <Route path="/login" element={<AuthFeature />} />
 
-          {/* Everything else lives inside the shell */}
+          {/* Everything else lives inside the shell. A single Suspense boundary
+              per route keeps the AppShell mounted while the lazy chunk loads. */}
           <Route element={<AppShell />}>
-            <Route index element={<HomeFeature />} />
-            <Route path="/search/*" element={<SearchFeature />} />
-            <Route path="/creator/:username/*" element={<CreatorFeature />} />
-            <Route path="/profile" element={<ProfileFeature />} />
-            <Route path="/kyc/*" element={<KycFeature />} />
-            <Route path="/wallet/*" element={<WalletFeature />} />
-            <Route path="/ai/*" element={<AiFeature />} />
-            <Route path="/live/*" element={<LiveFeature />} />
-            <Route path="/articles/*" element={<ArticlesFeature />} />
-            <Route path="/buy/*" element={<BuyFeature />} />
+            <Route
+              index
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <HomeFeature />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/search/*"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <SearchFeature />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/creator/:username/*"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <CreatorFeature />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/profile"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <ProfileFeature />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/kyc/*"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <KycFeature />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/wallet/*"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <WalletFeature />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/ai/*"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <AiFeature />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/live/*"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <LiveFeature />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/articles/*"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <ArticlesFeature />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/buy/*"
+              element={
+                <Suspense fallback={<RouteFallback />}>
+                  <BuyFeature />
+                </Suspense>
+              }
+            />
 
             {/* Catch-all: unknown paths render a NotFound inside the shell */}
             <Route path="*" element={<NotFound />} />


### PR DESCRIPTION
## Problem (confirmed HIGH startup-perf regression)

`wallet/zuuli/src/App.tsx` statically imported all ~11 feature routes. Every feature transitively imports `src/components/common/Markdown.tsx`, which top-level imports `rehype-mathjax/svg` (mathjax-full, ~623 kB gzip) and `rehype-prism-plus` (refractor, ~219 kB gzip). Result: a single entry chunk of **5,675 kB raw / 1,729 kB gzip** — MathJax+Prism (~842 kB gzip, ~49% of the compressed startup payload) were downloaded and parsed before the `/login` screen, which renders zero markdown.

## Fix

- Convert the feature-route imports in `App.tsx` to `React.lazy(() => import(...))` (each feature default-exports).
- Wrap each lazy route in a `<Suspense>` boundary with a lightweight `Loader2` spinner fallback (consistent with existing app loading UI). The AppShell stays mounted while chunks load.
- **Eager (entry chunk):** `AuthFeature` (login), `AppShell` layout, the router. `/login` renders instantly.
- Routing behavior unchanged — same paths, guards, redirects.

## Results (`npm run build`)

| | entry chunk raw | entry chunk gzip |
|---|---|---|
| **before** | 5,675 kB | **1,728.81 kB** |
| **after**  | 432 kB | **137.15 kB** |

Entry-chunk gzip drops by **~1,592 kB** (login critical path). MathJax + Prism now live only in a lazily-loaded `Markdown-*.js` chunk:

- `grep -l MathJax dist/assets/*.js` -> matches only `Markdown-*.js`, **not** the entry chunk.
- `grep refractor` on the entry chunk -> no match.

## Verification

- `npm run typecheck` + `npm run build` both green.
- Drove `VITE_MOCK=1 npm run dev` in a browser: booted to `/login`, logged in (mock Zcash ZIP-304), then navigated to an article (markdown renders) and AI Studio (renders) — lazy chunks load, no console errors, no broken routes, AppShell/balance chips intact.

## Scope

Route-level code-splitting only. Does **not** touch `Markdown.tsx`, `Comments/*`, `features/creator/**`, `features/ai/**`, `lib/api/**`, `package.json`, or `src-tauri/**` (owned by parallel agents).