### PR TITLE
fix(zuuli): harden comments + markdown renderer (DoS, IP beacons, QR phishing, comment correctness)

### DIFF
--- a/wallet/zuuli/src/components/common/ErrorBoundary.tsx
+++ b/wallet/zuuli/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,88 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * Rendered instead of `children` once a descendant throws during render.
+   * A function form receives the caught error so callers can degrade
+   * gracefully (e.g. show the raw text of a comment that failed to render).
+   */
+  fallback: ReactNode | ((error: Error) => ReactNode);
+  /**
+   * When any value in this array changes (shallow compare), the boundary
+   * clears its error and retries rendering `children`. Pass the untrusted
+   * content here so a fresh/edited body gets another render attempt instead of
+   * being pinned to the fallback forever.
+   */
+  resetKeys?: unknown[];
+  /** Optional hook for logging/telemetry. Never used to re-throw. */
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+function keysChanged(a: unknown[] | undefined, b: unknown[] | undefined): boolean {
+  if (a === b) return false;
+  if (!a || !b || a.length !== b.length) return true;
+  for (let i = 0; i < a.length; i++) {
+    if (!Object.is(a[i], b[i])) return true;
+  }
+  return false;
+}
+
+/**
+ * Class error boundary — the ONLY React primitive that can stop a render-time
+ * throw from unmounting the whole root. We use it in two places:
+ *
+ *   1. At the app root (`main.tsx`) so a crash in any subtree degrades to a
+ *      small error card instead of a permanent white screen.
+ *   2. Around every markdown body rendered from untrusted/large content
+ *      (`Markdown`), where a malicious comment (e.g. pathologically-nested
+ *      `$$…$$` that overflows the MathJax stack) must degrade to plain text
+ *      rather than take the page down for every viewer.
+ *
+ * React only invokes error boundaries for errors thrown during render /
+ * lifecycle, which is exactly the stored-render-crash DoS class we're closing.
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+    // Dev breadcrumb only; production must never surface a crash to the user.
+    const isDev = Boolean(
+      (import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV,
+    );
+    if (isDev) {
+      // eslint-disable-next-line no-console
+      console.error("ErrorBoundary caught a render error:", error, info);
+    }
+  }
+
+  componentDidUpdate(prev: ErrorBoundaryProps) {
+    if (this.state.error && keysChanged(prev.resetKeys, this.props.resetKeys)) {
+      this.setState({ error: null });
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      const { fallback } = this.props;
+      return typeof fallback === "function"
+        ? fallback(this.state.error)
+        : fallback;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/wallet/zuuli/src/components/common/Markdown.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.tsx
@@ -9,6 +9,7 @@ import ReactMarkdown from "react-markdown";
 import { useNavigate } from "react-router-dom";
 import { Check, Copy } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
+import { visit } from "unist-util-visit";
 
 import remarkDirective from "remark-directive";
 import remarkGfm from "remark-gfm";
@@ -24,8 +25,26 @@ import { cn } from "@/lib/utils";
 import remarkOembed from "@/lib/markdown/remark-oembed";
 import remarkQrCodePlugin from "@/lib/markdown/remark-qrcode";
 import Mermaid from "@/components/common/Mermaid";
+import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 
 import "./markdown.css";
+
+/**
+ * Rendering variants:
+ *   • "article"  — trusted, creator/AI long-form content. Full rich pipeline:
+ *                  auto-loading images, native video/audio embeds, QR codes,
+ *                  mermaid diagrams.
+ *   • "comment"  — UNTRUSTED, user-supplied comment bodies. Hardened: remote
+ *                  images and media embeds degrade to plain external LINKS (no
+ *                  silent network beacons that deanonymize readers by IP), and
+ *                  `::qrcode` / mermaid are shown as text/code rather than a
+ *                  scannable QR or rendered diagram (phishing + perf). This is
+ *                  the primary render-layer privacy fix; see also the CSP note
+ *                  in `src-tauri/tauri.conf.json` (intentionally NOT tightened
+ *                  for images because trusted article markdown legitimately
+ *                  hotlinks arbitrary hosts).
+ */
+export type MarkdownVariant = "article" | "comment";
 
 /**
  * True for links that must leave the app (http/https/mailto/tel and any other
@@ -185,11 +204,15 @@ function CodeBlock({
   );
 }
 
-/** Extract a YouTube video id from the common URL shapes. */
+/**
+ * Extract a YouTube video id from the common URL shapes. Hostnames are matched
+ * EXACTLY (not `endsWith`), so a lookalike like `notyoutube.com` never slips
+ * through the allowlist.
+ */
 function youTubeId(url: URL): string | null {
   const host = url.hostname.replace(/^www\./, "");
   if (host === "youtu.be") return url.pathname.slice(1) || null;
-  if (host.endsWith("youtube.com") || host.endsWith("youtube-nocookie.com")) {
+  if (host === "youtube.com" || host === "youtube-nocookie.com") {
     if (url.pathname.startsWith("/embed/"))
       return url.pathname.split("/")[2] || null;
     return url.searchParams.get("v");
@@ -197,9 +220,10 @@ function youTubeId(url: URL): string | null {
   return null;
 }
 
-/** Extract a numeric Vimeo id. */
+/** Extract a numeric Vimeo id (exact-host match only). */
 function vimeoId(url: URL): string | null {
-  if (!url.hostname.replace(/^www\./, "").endsWith("vimeo.com")) return null;
+  const host = url.hostname.replace(/^www\./, "");
+  if (host !== "vimeo.com" && host !== "player.vimeo.com") return null;
   const m = url.pathname.match(/\/(\d+)/);
   return m ? m[1] : null;
 }
@@ -212,8 +236,19 @@ function vimeoId(url: URL): string | null {
  *   • .mp4/... → native <video controls>
  *   • .mp3/... → native <audio controls>
  *   • anything else → a plain external link.
+ *
+ * In the "comment" (untrusted) variant, NOTHING auto-loads: every embed
+ * degrades to a plain external link. Native <video>/<audio> from an arbitrary
+ * attacker host would silently beacon every reader's IP on render, and even the
+ * fixed YouTube/Vimeo iframes ping third parties — neither is acceptable for
+ * anonymous, unmoderated comment content in a wallet.
  */
-function SafeEmbed({ url }: { url: string }) {
+function SafeEmbed({ url, variant }: { url: string; variant: MarkdownVariant }) {
+  // Untrusted comments never auto-load remote media — always a link.
+  if (variant === "comment") {
+    return <MarkdownLink href={url}>{url}</MarkdownLink>;
+  }
+
   let parsed: URL | null = null;
   try {
     parsed = new URL(url);
@@ -272,11 +307,68 @@ function SafeEmbed({ url }: { url: string }) {
   return <MarkdownLink href={url}>{url}</MarkdownLink>;
 }
 
+// ── Math DoS guard (defense-in-depth) ───────────────────────────────────────
+// A comment body of `$$` + `{`×400 + … + `}`×400 + `$$` makes rehype-mathjax
+// recurse until it throws `RangeError: Maximum call stack size exceeded`
+// SYNCHRONOUSLY inside React render. The <Markdown> ErrorBoundary is the
+// primary fix (degrade to plain text), but we ALSO neutralize the expression
+// before it ever reaches MathJax: any `$$…$$` / `$…$` whose source is absurdly
+// long or brace-nested far past anything real math needs is converted back to a
+// plain code node showing the raw TeX. Legitimate math is nowhere near these
+// caps.
+const MATH_MAX_LEN = 3000;
+const MATH_MAX_BRACE_DEPTH = 30;
+
+function maxBraceDepth(s: string): number {
+  let depth = 0;
+  let max = 0;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === "{") {
+      depth++;
+      if (depth > max) max = depth;
+    } else if (ch === "}" && depth > 0) {
+      depth--;
+    }
+  }
+  return max;
+}
+
 /**
- * Themed markdown renderer used by Articles and AI chat. Styled inline (no
- * tailwind-typography dependency) so it always matches the ZUULI dark theme.
+ * remark plugin (must run AFTER remark-math): defuses pathological math nodes
+ * by turning them into plain `code`/`inlineCode` so rehype-mathjax never sees
+ * them and cannot stack-overflow the render.
  *
- * Feature parity with the free2z web renderer:
+ * @type {import('unified').Plugin<[], import('mdast').Root>}
+ */
+function remarkMathGuard() {
+  return (tree: any) => {
+    visit(tree, (node: any) => {
+      if (node.type !== "math" && node.type !== "inlineMath") return;
+      const value: string = node.value ?? "";
+      if (
+        value.length > MATH_MAX_LEN ||
+        maxBraceDepth(value) > MATH_MAX_BRACE_DEPTH
+      ) {
+        node.type = node.type === "math" ? "code" : "inlineCode";
+        node.lang = null;
+        node.meta = null;
+        // Drop any math-specific hast hints so the default code handler runs.
+        if (node.data) {
+          delete node.data.hName;
+          delete node.data.hProperties;
+        }
+      }
+    });
+  };
+}
+
+/**
+ * Themed markdown renderer used by Articles, AI chat, and comments. Styled
+ * inline (no tailwind-typography dependency) so it always matches the ZUULI
+ * dark theme.
+ *
+ * Feature parity with the free2z web renderer (article variant):
  *   • display math (`$$…$$`) via remark-math + rehype-mathjax/svg (offline SVG),
  *   • syntax highlight + opt-in line numbers via rehype-prism-plus,
  *   • mermaid diagrams (lazy-loaded), `::qrcode[addr]`, safe `::embed[URL]`,
@@ -284,16 +376,25 @@ function SafeEmbed({ url }: { url: string }) {
  *
  * Raw HTML stays ESCAPED (react-markdown's default — no rehype-raw): a wallet
  * must never render untrusted HTML.
+ *
+ * The whole render is wrapped in an ErrorBoundary that degrades to the plain,
+ * escaped source text — so no single body (however malicious) can throw during
+ * render and unmount the surrounding page. Pass `variant="comment"` for
+ * untrusted user content (see `MarkdownVariant`).
  */
 export function Markdown({
   children,
   className,
+  variant = "article",
 }: {
   children: string;
   className?: string;
+  variant?: MarkdownVariant;
 }) {
-  // Memoize on content: mathjax/mermaid/prism are expensive, and AI streaming
-  // re-renders this on every token.
+  const isComment = variant === "comment";
+
+  // Memoize on content + variant: mathjax/mermaid/prism are expensive, and AI
+  // streaming re-renders this on every token.
   const rendered = useMemo(
     () => (
       <ReactMarkdown
@@ -303,6 +404,8 @@ export function Markdown({
           remarkQrCodePlugin,
           remarkGfm,
           [remarkMath, { singleDollarTextMath: false }],
+          // AFTER remark-math so the math nodes already exist to be defused.
+          remarkMathGuard,
         ]}
         rehypePlugins={[
           rehypeMathjaxSvg,
@@ -312,6 +415,15 @@ export function Markdown({
         components={{
           a: MarkdownLink,
           pre: CodeBlock,
+          // Untrusted comments: remote images become plain external links so
+          // they never auto-load and beacon the reader's IP to an attacker.
+          img: isComment
+            ? ({ src, alt }) => (
+                <MarkdownLink href={typeof src === "string" ? src : "#"}>
+                  {alt || (typeof src === "string" ? src : "image")}
+                </MarkdownLink>
+              )
+            : undefined,
           table: ({ node, ...props }) => (
             <div className="overflow-x-auto">
               <table {...props} />
@@ -320,7 +432,11 @@ export function Markdown({
           code({ node, className: codeClass, children: codeChildren, ...rest }) {
             // Directive- and fence-driven custom renderers.
             if (/language-mermaid/.test(codeClass || "")) {
-              return <Mermaid chart={childrenToText(codeChildren)} />;
+              // Comments: don't render arbitrary diagrams (perf + surface) —
+              // fall through to a plain code block showing the source.
+              if (!isComment) {
+                return <Mermaid chart={childrenToText(codeChildren)} />;
+              }
             }
             if (codeClass === "qrcode-display") {
               const addr =
@@ -328,6 +444,16 @@ export function Markdown({
                 node?.properties?.["data-qr-code-addr"]?.toString() ||
                 "";
               if (addr) {
+                // Untrusted comments: never render a scannable QR of an
+                // attacker-chosen string inside wallet chrome (phishing aid) —
+                // show the raw value as text so it's clearly user-supplied.
+                if (isComment) {
+                  return (
+                    <code className="break-all text-xs text-muted-foreground">
+                      {addr}
+                    </code>
+                  );
+                }
                 return (
                   <span className="my-4 flex flex-col items-center gap-2">
                     <span className="rounded-lg bg-white p-3">
@@ -345,7 +471,7 @@ export function Markdown({
                 node?.properties?.["dataEmbedUrl"]?.toString() ||
                 node?.properties?.["data-embed-url"]?.toString() ||
                 "";
-              if (url) return <SafeEmbed url={url} />;
+              if (url) return <SafeEmbed url={url} variant={variant} />;
             }
 
             return (
@@ -359,7 +485,7 @@ export function Markdown({
         {children}
       </ReactMarkdown>
     ),
-    [children],
+    [children, variant, isComment],
   );
 
   return (
@@ -401,7 +527,22 @@ export function Markdown({
         className,
       )}
     >
-      {rendered}
+      {/*
+        Per-body error boundary: a malicious/oversized body (e.g. a MathJax
+        stack overflow that slips past the guard above) degrades to its plain,
+        escaped source text instead of throwing during render and taking the
+        surrounding page down. `resetKeys` retries when the content changes.
+      */}
+      <ErrorBoundary
+        resetKeys={[children, variant]}
+        fallback={
+          <div className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
+            {children}
+          </div>
+        }
+      >
+        {rendered}
+      </ErrorBoundary>
     </div>
   );
 }

--- a/wallet/zuuli/src/features/articles/components/Comments/CommentCard.tsx
+++ b/wallet/zuuli/src/features/articles/components/Comments/CommentCard.tsx
@@ -18,11 +18,19 @@ import { CommentForm } from "./CommentForm";
 
 interface CommentCardProps {
   comment: Comment;
-  /** Called after a reply is posted so the thread can refetch its children. */
+  /**
+   * Live direct-reply count, tracked by the parent thread so a freshly-posted
+   * reply bumps the badge immediately (F5). Falls back to the comment's own
+   * `num_children` when the thread doesn't override it.
+   */
+  numChildren?: number;
+  /** Called after a reply is posted so the thread can show it + bump its count. */
   onReplied: (reply: Comment) => void;
 }
 
-export function CommentCard({ comment, onReplied }: CommentCardProps) {
+export function CommentCard({ comment, numChildren, onReplied }: CommentCardProps) {
+  const user = useSession((s) => s.user);
+  const balance = useSession((s) => s.tuzis);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
   const [replying, setReplying] = useState(false);
   const [score, setScore] = useState(comment.tuzis);
@@ -30,13 +38,23 @@ export function CommentCard({ comment, onReplied }: CommentCardProps) {
   const [voting, setVoting] = useState(false);
 
   const name = comment.author.username;
+  const childCount = numChildren ?? comment.num_children;
+
+  // Voting costs 1 2Z (POST /vote/). It requires an account AND a balance —
+  // gate the rail so logged-out or broke users can't fire a request that
+  // would just 401/402, and can't drive the optimistic balance negative.
+  const canVote = !!user && balance >= 1;
 
   async function vote(dir: "up" | "down") {
-    if (voting || voted === dir) return;
+    if (voting || voted === dir || !canVote) return;
     setVoting(true);
     // Optimistic: reflect the new score + spend 1 2Z immediately.
     const prevScore = score;
     const prevVoted = voted;
+    // Capture the exact pre-debit balance so a failure restores it precisely.
+    // (Blindly refunding +1 would MINT phantom 2Z whenever the debit had been
+    // clamped at 0 — hence restore the delta, not a fixed +1.)
+    const prevBalance = useSession.getState().tuzis;
     setScore((s) => s + (dir === "up" ? 1 : -1));
     setVoted(dir);
     adjustTuzis(-1);
@@ -45,7 +63,7 @@ export function CommentCard({ comment, onReplied }: CommentCardProps) {
     } catch {
       setScore(prevScore);
       setVoted(prevVoted);
-      adjustTuzis(1);
+      adjustTuzis(prevBalance - useSession.getState().tuzis);
       toast.error("Could not record your vote.");
     } finally {
       setVoting(false);
@@ -55,6 +73,12 @@ export function CommentCard({ comment, onReplied }: CommentCardProps) {
   async function submitReply(body: CommentInput) {
     return commentsApi.createReply(comment.uuid, body);
   }
+
+  const voteHint = !user
+    ? "Log in to vote"
+    : balance < 1
+      ? "You need 2Z to vote"
+      : undefined;
 
   return (
     <div className="min-w-0 rounded-xl border border-border bg-card/60 p-4">
@@ -67,7 +91,8 @@ export function CommentCard({ comment, onReplied }: CommentCardProps) {
             className="h-7 w-7 min-tap"
             aria-label="Upvote comment"
             aria-pressed={voted === "up"}
-            disabled={voting}
+            disabled={voting || !canVote}
+            title={voteHint}
             onClick={() => vote("up")}
           >
             <ChevronUp
@@ -84,7 +109,8 @@ export function CommentCard({ comment, onReplied }: CommentCardProps) {
             className="h-7 w-7 min-tap"
             aria-label="Downvote comment"
             aria-pressed={voted === "down"}
-            disabled={voting}
+            disabled={voting || !canVote}
+            title={voteHint}
             onClick={() => vote("down")}
           >
             <ChevronDown
@@ -130,7 +156,10 @@ export function CommentCard({ comment, onReplied }: CommentCardProps) {
           </h4>
 
           <div className="min-w-0 max-w-full overflow-x-auto break-words text-sm text-muted-foreground">
-            <Markdown>{comment.content}</Markdown>
+            {/* Untrusted, unmoderated user content: comment variant degrades
+                remote images/embeds/QRs to links/text and is wrapped in an
+                error boundary so a malicious body can never crash the page. */}
+            <Markdown variant="comment">{comment.content}</Markdown>
           </div>
 
           <div className="flex items-center gap-2 pt-1">
@@ -144,10 +173,10 @@ export function CommentCard({ comment, onReplied }: CommentCardProps) {
               <Reply className="h-4 w-4" aria-hidden />
               Reply
             </Button>
-            {comment.num_children > 0 ? (
+            {childCount > 0 ? (
               <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
                 <MessageSquare className="h-3.5 w-3.5" aria-hidden />
-                {comment.num_children}
+                {childCount}
               </span>
             ) : null}
           </div>

--- a/wallet/zuuli/src/features/articles/components/Comments/CommentForm.tsx
+++ b/wallet/zuuli/src/features/articles/components/Comments/CommentForm.tsx
@@ -113,7 +113,9 @@ export function CommentForm({
       {preview ? (
         <div className="min-h-[6rem] w-full min-w-0 overflow-x-auto rounded-md border border-border bg-background/50 px-3 py-2">
           {content.trim() ? (
-            <Markdown>{content}</Markdown>
+            // Preview with the same hardened variant the posted comment uses,
+            // so what you see is what readers get.
+            <Markdown variant="comment">{content}</Markdown>
           ) : (
             <p className="text-sm text-muted-foreground">Nothing to preview yet.</p>
           )}

--- a/wallet/zuuli/src/features/articles/components/Comments/CommentThread.tsx
+++ b/wallet/zuuli/src/features/articles/components/Comments/CommentThread.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { comments as commentsApi } from "@/lib/api/free2z";
 import type { Comment, CommentContentType } from "@/lib/api/types";
@@ -16,19 +16,32 @@ interface CommentThreadProps {
 
 /** One comment plus its (recursively threaded) replies. */
 export function CommentThread({ comment, contentType, depth = 0 }: CommentThreadProps) {
-  // Bumped whenever a reply is posted under this comment, to refetch children.
-  const [reload, setReload] = useState(0);
+  // Track the direct-child count locally so posting a reply immediately (a)
+  // reveals the reply and (b) updates the count badge (F5) — both without a
+  // full section reload.
+  const [numChildren, setNumChildren] = useState(comment.num_children);
+  // Replies posted from THIS session, appended locally so we never re-pull the
+  // whole reply set just to show a comment we already have in hand (F7).
+  const [extraReplies, setExtraReplies] = useState<Comment[]>([]);
 
   return (
     <div className="min-w-0 space-y-3">
       <CommentCard
         comment={comment}
-        onReplied={() => setReload((n) => n + 1)}
+        numChildren={numChildren}
+        onReplied={(reply) => {
+          setExtraReplies((prev) => [...prev, reply]);
+          setNumChildren((n) => n + 1);
+        }}
       />
       <CommentReplies
         parentUuid={comment.uuid}
         contentType={contentType}
-        reload={reload}
+        // Fetch only when the SERVER says this node has direct children. Leaves
+        // (num_children === 0) make ZERO network requests (F2 — no per-node
+        // waterfall); locally-posted replies come in via `extraReplies`.
+        serverChildCount={comment.num_children}
+        extraReplies={extraReplies}
         depth={depth + 1}
       />
     </div>
@@ -38,41 +51,60 @@ export function CommentThread({ comment, contentType, depth = 0 }: CommentThread
 interface CommentRepliesProps {
   parentUuid: string;
   contentType: CommentContentType;
-  reload: number;
+  serverChildCount: number;
+  extraReplies: Comment[];
   depth: number;
 }
 
 function CommentReplies({
   parentUuid,
   contentType,
-  reload,
+  serverChildCount,
+  extraReplies,
   depth,
 }: CommentRepliesProps) {
-  const [replies, setReplies] = useState<Comment[]>([]);
+  const [fetched, setFetched] = useState<Comment[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      const acc: Comment[] = [];
-      let page: number | null = 1;
-      while (page) {
-        const res = await commentsApi.listReplies(parentUuid, { page });
-        acc.push(...res.items);
-        page = res.next;
-      }
-      setReplies(acc);
-    } catch {
-      // A failed reply fetch shouldn't tear down the whole thread; leave the
-      // existing replies in place.
-    } finally {
-      setLoading(false);
-    }
-  }, [parentUuid]);
-
   useEffect(() => {
-    void load();
-  }, [load, reload]);
+    // F2: skip the /replies/ GET entirely for leaves. Only nodes the server
+    // reports as having children pay for a fetch.
+    if (serverChildCount <= 0) return;
+
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const acc: Comment[] = [];
+        let page: number | null = 1;
+        while (page) {
+          const res = await commentsApi.listReplies(parentUuid, { page });
+          acc.push(...res.items);
+          page = res.next;
+        }
+        if (!cancelled) setFetched(acc);
+      } catch {
+        // A failed reply fetch shouldn't tear down the whole thread; leave the
+        // existing replies in place.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // Intentionally not keyed on `extraReplies`: a new local reply is merged in
+    // below without re-hitting the network (F7).
+  }, [parentUuid, serverChildCount]);
+
+  // Merge server replies with locally-posted ones, deduped by uuid so a reply
+  // that later also arrives from the server can't render twice.
+  const replies = useMemo(() => {
+    if (!extraReplies.length) return fetched;
+    const seen = new Set(fetched.map((r) => r.uuid));
+    return [...fetched, ...extraReplies.filter((r) => !seen.has(r.uuid))];
+  }, [fetched, extraReplies]);
 
   if (!replies.length) {
     return loading ? (

--- a/wallet/zuuli/src/main.tsx
+++ b/wallet/zuuli/src/main.tsx
@@ -1,10 +1,65 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { ErrorBoundary } from "./components/common/ErrorBoundary";
 import "./index.css";
+
+/**
+ * Minimal, dependency-free fallback shown only if the ENTIRE app throws during
+ * render. Styled with plain inline styles (no Tailwind/shadcn) because a crash
+ * here means we can't trust any higher-level component to be mountable. Its job
+ * is purely to keep the webview from going permanently blank and to let the
+ * user recover with a reload — so a stored malicious comment can no longer
+ * white-screen the whole zpage for every viewer.
+ */
+function RootFallback() {
+  return (
+    <div
+      role="alert"
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "1rem",
+        padding: "2rem",
+        background: "#0a0a0f",
+        color: "#e5e5ea",
+        fontFamily: "system-ui, sans-serif",
+        textAlign: "center",
+      }}
+    >
+      <h1 style={{ fontSize: "1.25rem", fontWeight: 600 }}>
+        Something went wrong
+      </h1>
+      <p style={{ maxWidth: "28rem", color: "#a1a1aa" }}>
+        ZUULI hit an unexpected error. Reloading usually fixes it.
+      </p>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        style={{
+          padding: "0.5rem 1rem",
+          borderRadius: "0.75rem",
+          border: "1px solid #3f3f46",
+          background: "#6d28d9",
+          color: "#fff",
+          fontWeight: 600,
+          cursor: "pointer",
+        }}
+      >
+        Reload
+      </button>
+    </div>
+  );
+}
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    {/* Top-level boundary: no subtree can ever unmount the root. */}
+    <ErrorBoundary fallback={<RootFallback />}>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

Hardens the ZUULI threaded comments UI and the shared markdown renderer against confirmed security, privacy, and correctness defects. Scope is limited to `main.tsx`, a new `ErrorBoundary`, `Markdown.tsx`, and the `Comments/*` components. **No CSP / `tauri.conf.json` change** (rationale below).

## Fixes

### 1) 🔴 Stored render-crash DoS — LOAD-BEARING
A comment body of `$$` + `{`×400 + `a` + `}`×400 + `$$` (805 chars, under the 1000 cap) makes `rehype-mathjax` throw `RangeError: Maximum call stack size exceeded` **synchronously in React render**. With no error boundary, React 18 unmounts the whole root → the zpage white-screens permanently for every viewer.
- New reusable class `ErrorBoundary` (`componentDidCatch`, `fallback`, `resetKeys`).
- Root wrap in `main.tsx` (`<ErrorBoundary><App/></ErrorBoundary>`) — no subtree can unmount the root.
- Per-body boundary inside `Markdown` degrading to the **plain, escaped source text**.
- Defense-in-depth: an inline remark math-guard converts absurdly long / brace-nested `$$…$$` to a plain code node (raw TeX) **before** it reaches MathJax.

### 2) 🟠 IP-deanonymization beacons via untrusted comments — privacy
New `Markdown` `variant="comment"` (untrusted) mode: remote images render as plain external **links** (no auto-load), `::embed` media/iframes degrade to links (no silent pings to attacker hosts), heavy mermaid path skipped. Article bodies keep the rich pipeline.

**CSP decision (secondary, deliberately NOT applied):** `img-src`/`media-src` left as `https:`. Article markdown is creator-authored and `mediaUrl()` passes absolute `http(s)` URLs through unchanged, so articles legitimately hotlink arbitrary-host images. Blanket-tightening `img-src` would break real article content. The render-layer variant fix closes the comment vector without that breakage.

### 3) 🟡 `::qrcode` phishing — comment variant renders it as plain text, never a scannable QR of an attacker string inside wallet chrome.

### 4) ⚪ Exact-match embed hostnames — `youTubeId`/`vimeoId` match hostnames exactly (no `notyoutube.com` spoof class). (`remark-oembed.ts` has no host check to change.)

### 5) Comments correctness
- **F2:** skip the `/replies/` GET for leaf nodes (`num_children === 0`); only fetch where the server reports children — kills the per-node request waterfall.
- **F3:** gate voting on `user` AND `balance >= 1` (rail disabled when logged out / broke); restore the **exact** pre-debit balance on failure instead of blindly refunding `+1` (no phantom 2Z from the `adjustTuzis` clamp). `session.ts` clamp untouched.
- **F5:** reply-count badge updates locally when a reply is posted.
- **F7:** locally-posted replies are appended, not re-fetched.

## Verification
`npm run typecheck` + `npm run build` clean. Drove `VITE_MOCK=1` in a browser:
- **(a)** 805-char MathJax payload → degrades to a raw-TeX code block, **page fully survives** (article + comments still rendered); no `RangeError` in console (guard defused it before MathJax; boundary is the backstop).
- **(b)** `![](https://example.com/x.gif)` → renders an `<a>` link, `img` count 0; **Network tab shows zero requests to example.com**. `::embed` (evil.mp4 + YouTube) → links, no `<video>`/`<iframe>`; `::qrcode` → text, no SVG.
- **(c)** leaf comments fire **zero** `/replies/` — only the 2 nodes with children fetched (verified by instrumenting the mock method).
- **(d)** logged-in upvote debits exactly 1 (4,210 → 4,209), score 42 → 43, no phantom mint; logged-out → all vote buttons disabled ("Log in to vote").
- **(e)** articles still render rich markdown (headings, bold, blockquote).