### PR TITLE
feat(zuuli): instant + accurate "Watch live" via creator is_live payload

### DIFF
--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
@@ -118,16 +118,10 @@ function CreatorProfile({ creator }: { creator: CreatorDetail }) {
     [creator.bio],
   );
   // "Watch live" must only appear when this creator is ACTUALLY live right now.
-  // `CreatorDetail` carries no live flag (only the internal `can_stream`
-  // eligibility), so we probe the dedicated live-status endpoint for this one
-  // creator (one request for the profile being viewed, not an N+1). Absent /
-  // failed probes resolve to `live: false`, so the affordance stays hidden
-  // unless there's a confirmed live stream.
-  const { data: liveStatus } = useAsync(
-    () => live.status(creator.username),
-    [creator.username],
-  );
-  const isLive = liveStatus?.live ?? false;
+  // Gate it on the server-computed `is_live` from the creator payload so the
+  // button renders instantly with NO probe on mount. See `useLiveGate` for the
+  // graceful fallback (older backend) and the light poll that keeps it accurate.
+  const isLive = useLiveGate(creator.username, creator.is_live);
 
   return (
     <div className="animate-slide-up pb-6">
@@ -276,6 +270,63 @@ function CreatorProfile({ creator }: { creator: CreatorDetail }) {
       </div>
     </div>
   );
+}
+
+/**
+ * Resolve whether a creator is live, fast AND accurate:
+ *
+ *  1. **Instant** — seed state from `payloadIsLive` (the server-computed
+ *     `is_live` on the creator payload), so the very first render gates
+ *     "Watch live" correctly with NO network request on mount.
+ *  2. **Graceful fallback** — if the payload omits the field (`undefined`,
+ *     e.g. an older backend mid-deploy), probe the cheap `live.status`
+ *     endpoint once on mount so nothing breaks during the deploy window.
+ *  3. **Accurate over time** — a creator can go live/offline while the profile
+ *     is open, so poll the same light `live.status` endpoint on a 30s interval
+ *     and correct the button. We never refetch the heavy creator profile here.
+ *
+ * The interval and in-flight guard are torn down on unmount / username change,
+ * so navigating away leaves no lingering timers or requests.
+ */
+const LIVE_POLL_MS = 30_000;
+
+function useLiveGate(
+  username: string,
+  payloadIsLive: boolean | undefined,
+): boolean {
+  // Initialise from the payload so the first paint is already correct.
+  const [isLive, setIsLive] = useState<boolean>(payloadIsLive ?? false);
+  // Track whether THIS mount has ever had a definitive answer, so an initial
+  // `undefined` payload triggers the fallback probe immediately.
+  const hasPayload = payloadIsLive !== undefined;
+
+  useEffect(() => {
+    // Reset to the payload value whenever we switch creators (or the payload
+    // arrives) — keeps the instant gate correct without waiting on a probe.
+    setIsLive(payloadIsLive ?? false);
+
+    let alive = true;
+    const probe = async () => {
+      try {
+        const s = await live.status(username);
+        if (alive) setIsLive(s.live);
+      } catch {
+        // Keep the last known value on a failed probe rather than flicker.
+      }
+    };
+
+    // Fallback: only probe on mount when the payload couldn't tell us.
+    if (!hasPayload) void probe();
+
+    // Light poll keeps the button accurate while the profile stays mounted.
+    const timer = setInterval(probe, LIVE_POLL_MS);
+    return () => {
+      alive = false;
+      clearInterval(timer);
+    };
+  }, [username, payloadIsLive, hasPayload]);
+
+  return isLive;
 }
 
 // ─── Subscribe ────────────────────────────────────────────────────────────────

--- a/wallet/zuuli/src/features/search/index.tsx
+++ b/wallet/zuuli/src/features/search/index.tsx
@@ -5,6 +5,7 @@ import {
   BookOpen,
   Clock,
   FileText,
+  Radio,
   Search as SearchIcon,
   Users,
   X,
@@ -235,6 +236,18 @@ function CreatorResultCard({ creator }: { creator: SimpleCreator }) {
               className="h-4 w-4 shrink-0 text-primary"
               aria-label="Verified"
             />
+          ) : null}
+          {/* Server-computed live flag on the creator list payload — renders
+              only when the creator is actually broadcasting right now. Absent
+              on older backends (`undefined`), so the badge just doesn't show. */}
+          {creator.is_live ? (
+            <span
+              className="inline-flex shrink-0 items-center gap-1 rounded-full bg-[#f43f5e]/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#f43f5e]"
+              aria-label="Live now"
+            >
+              <Radio className="h-3 w-3" aria-hidden />
+              Live
+            </span>
           ) : null}
         </div>
         <div className="truncate text-xs text-muted-foreground">

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -99,6 +99,8 @@ interface RawCreator {
   can_stream?: boolean;
   total?: string | number | null;
   zpages?: number;
+  /** Server-computed "is this creator live right now" (Dyte room state). */
+  is_live?: boolean;
 }
 interface RawZPage {
   free2zaddr: string;
@@ -144,6 +146,9 @@ function mapCreator(c: RawCreator): SimpleCreator {
     is_verified: c.is_verified ?? false,
     zpages: typeof c.zpages === "number" ? c.zpages : undefined,
     member_price: parsePrice(c.member_price),
+    // Pass through as-is: `undefined` (field absent) is meaningful — it lets
+    // consumers distinguish "backend doesn't report live state" from "not live".
+    is_live: c.is_live,
   };
 }
 
@@ -161,6 +166,10 @@ function mapCreatorDetail(c: RawCreator): CreatorDetail {
       ) ?? null,
     is_verified: c.is_verified ?? false,
     can_stream: c.can_stream ?? false,
+    // Preserve `undefined` (older backend) vs `false` (confirmed offline) so
+    // the creator screen can fall back to a live-status probe only when the
+    // payload genuinely can't tell it.
+    is_live: c.is_live,
     member_price: parsePrice(c.member_price),
     zpages: typeof c.zpages === "number" ? c.zpages : 0,
     total: c.total != null ? Math.round(Number(c.total)) || 0 : 0,

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -92,21 +92,26 @@ export const mockCreators: SimpleCreator[] = [
       is_verified: true,
       zpages: 12,
       member_price: 500,
+      // Live now (subscriber stream, see mockLivestreams) — demos is_live:true.
+      is_live: true,
     },
   ),
   creator("mining_maya", "Maya ⛏️", "Halo2 circuits & late-night proofs.", {
     is_verified: true,
     zpages: 7,
     member_price: 250,
+    is_live: true, // PPV stream live now.
   }),
   creator("f2z", "Free2Z", "The zero-knowledge creator platform.", {
     is_verified: true,
     zpages: 24,
     member_price: null,
+    is_live: false, // Offline — demos is_live:false (button hidden).
   }),
   creator("nine", "Nine", "Privacy maximalist. Streams from the void.", {
     zpages: 5,
     member_price: 100,
+    is_live: true, // Broadcast live now.
   }),
   creator("halo_hana", "Hana", "Recursive proofs & zk-SNARK explainers.", {
     zpages: 9,
@@ -793,10 +798,21 @@ export function mockCreatorDetail(username: string): CreatorDetail {
     (a) => a.author.username.toLowerCase() === uname.toLowerCase(),
   ).length;
   const seed = Math.abs(hashString(uname));
+  // Known mock creators report a concrete `is_live` (derived from
+  // mockLivestreams, the same source the live.status poll reads, so the payload
+  // gate and the poll agree). An UNKNOWN username returns `undefined` on
+  // purpose — it stands in for a backend that predates the field, so the
+  // creator screen's graceful fallback (probe live.status on mount) is demoable.
+  const isLive = base
+    ? mockLivestreams.some(
+        (l) => l.live && l.username.toLowerCase() === uname.toLowerCase(),
+      )
+    : undefined;
   return {
     username: uname,
     free2zaddr: uname,
     display_name: base?.display_name || uname,
+    is_live: isLive,
     bio:
       base?.bio ??
       "A creator on ZUULI, publishing on Zcash and privacy. Follow along.",

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -14,6 +14,13 @@ export interface SimpleCreator {
   zpages?: number;
   /** 2Z price for 30 days of membership (null = no paid tier). */
   member_price?: number | null;
+  /**
+   * Whether this creator is broadcasting a livestream RIGHT NOW — computed
+   * server-side from the Dyte live-room state and returned on the creator
+   * list/search payload. `undefined` when talking to a backend that predates
+   * the field (callers fall back to the live-status probe). See `CreatorDetail.is_live`.
+   */
+  is_live?: boolean;
 }
 
 /**
@@ -31,6 +38,15 @@ export interface CreatorDetail {
   banner?: string | null; // banner_image
   is_verified: boolean;
   can_stream: boolean;
+  /**
+   * Whether this creator is broadcasting a livestream RIGHT NOW — computed
+   * server-side from the Dyte live-room state, so the "Watch live" affordance
+   * can render instantly from the payload with no per-profile probe on mount.
+   * `undefined` when the field isn't present (older backend during a deploy
+   * window); callers fall back to the `live.status()` probe in that case, and
+   * a light background poll keeps it accurate while the profile stays open.
+   */
+  is_live?: boolean;
   /** 2Z price for 30 days of membership / livestream access (null = free). */
   member_price?: number | null;
   /** Count of published zpages. */


### PR DESCRIPTION
## What

Makes ZUULI's **"Watch live"** affordance instant and accurate by reading the new
server-computed `is_live` boolean off the creator payload instead of firing a
per-profile `live.status` probe on mount.

## Why

`GET /api/creator/<username>/` (and the list/search creator objects) is gaining an
`is_live` flag computed server-side from the Dyte live-room state. Gating on it lets
the button render synchronously from the payload — no extra request, no spinner —
while staying robust across the backend deploy window.

## Behavior — fast AND accurate

New `useLiveGate(username, payloadIsLive)` hook on the creator screen:

1. **Fast (instant):** state is seeded from `creator.is_live`, so the first paint
   gates "Watch live" correctly with **no network probe on mount**.
2. **Graceful fallback:** if `is_live` is `undefined` (older backend mid-deploy),
   it probes the cheap `live.status` endpoint once on mount so nothing breaks.
3. **Accurate over time:** a light 30s background poll of `live.status` corrects the
   button if the creator goes live/offline while the profile is open. The interval
   (and any in-flight guard) is torn down on unmount — no leaks. The heavy creator
   profile is never refetched on the interval.

## Files

- `lib/api/types.ts` — `is_live?: boolean` on `CreatorDetail` + `SimpleCreator`.
- `lib/api/free2z.ts` — pass `is_live` through the creator detail + list/search
  mappers, preserving `undefined` (unknown) vs `false` (confirmed offline).
- `features/creator/index.tsx` — `useLiveGate` (gate + fallback + poll).
- `features/search/index.tsx` — small red **LIVE** badge on creator cards when the
  list payload reports `is_live` (hidden on older backends that omit it).
- `lib/api/mock-data.ts` — seed `is_live` on mock creators (zooko/maya/nine live,
  f2z offline); unknown usernames return `undefined` so the fallback is demoable.

## Verification (VITE_MOCK=1, driven in a browser)

Instrumented the app's real free2z module instance and drove SPA transitions:

- **Payload present (is_live:true):** "Watch live" renders on first paint;
  **live-status probes on mount = 0** (synchronous gate).
- **Payload absent (is_live undefined, simulated older backend):** mount **falls
  back to a `live.status` probe** (fires under React 18 StrictMode; button appears
  once it resolves).
- **Poll lifecycle:** a 30_000ms interval is registered on mount and **fully cleared
  on unmount** (0 active intervals after navigating away — no leak).
- **Payload states render correctly:** zooko/maya (live) show "Watch live" + a LIVE
  badge on the maya search card; f2z (offline) shows only Tip/Subscribe.
- No `/dyte` live-status **HTTP** requests occur in mock mode (all in-memory).

`npm run typecheck` and `npm run build` are clean.