### PR TITLE
perf(zuuli): optimize dependencies in the dev profile so tauri dev sync isn't 100x slow

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/Cargo.toml
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.toml
@@ -62,3 +62,40 @@ security-framework = { version = "3", features = ["OSX_10_15"] }
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }
 tauri-build = "2"
+
+# ---------------------------------------------------------------------------
+# Build profiles. DO NOT DELETE — see the identical blocks in
+# wallet/zuuli/src-tauri/Cargo.toml and wallet/zuuallet/src-tauri/Cargo.toml.
+#
+# This crate is its own workspace root, so these profiles apply when it is built
+# or tested standalone (`cargo test -p tauri-plugin-zcash` from this directory).
+# When it is consumed as a path dep by zuuli/zuuallet, THEIR profiles win — which
+# is why the same block is duplicated there.
+#
+# Why: at Cargo's default `opt-level = 0`, the whole Zcash crypto stack
+# (sapling-crypto, orchard, halo2_proofs, bls12_381, pasta_curves, group/ff,
+# incrementalmerkletree / shardtree, blake2b_simd, zcash_note_encryption) runs
+# unoptimized. Trial decryption, Pedersen hashing and shardtree inserts are then
+# 20-100x slower than release and chain sync crawls. Standard Zashi /
+# zcash-devtool pattern: optimize dependencies, keep our own crates cheap to
+# rebuild.
+# ---------------------------------------------------------------------------
+
+[profile.dev]
+# Our own crate: unoptimized so incremental rebuilds stay quick and debugging
+# (breakpoints, variable inspection) behaves.
+opt-level = 0
+
+[profile.dev.package."*"]
+# Every dependency — crucially the Zcash crypto stack — gets fully optimized.
+# Deps are compiled once and cached, so this costs a single cold build.
+opt-level = 3
+
+[profile.dev.build-override]
+# Build scripts and proc macros also run at opt-level 0 by default; several
+# Zcash deps do real work in build.rs. Cheap win on cold builds.
+opt-level = 3
+
+[profile.release]
+lto = "thin"
+codegen-units = 1

--- a/wallet/zuuallet/src-tauri/Cargo.toml
+++ b/wallet/zuuallet/src-tauri/Cargo.toml
@@ -17,3 +17,44 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-zcash = { path = "../../plugins/tauri-plugin-zcash" }
+
+# ---------------------------------------------------------------------------
+# Build profiles. DO NOT DELETE — this is load-bearing for `tauri dev` usability.
+#
+# This package is its own workspace root (there is no `[workspace]` above it and
+# no repo-root Cargo.toml), so `[profile.*]` declared here IS honored for the
+# whole dependency graph — including the `tauri-plugin-zcash` path dep and the
+# librustzcash path deps in `z/zcash/librustzcash`.
+#
+# Why: `npm run tauri dev` builds the *dev* profile. At the Cargo default of
+# `opt-level = 0`, the entire Zcash crypto stack (sapling-crypto, orchard,
+# halo2_proofs, bls12_381, pasta_curves, group/ff, incrementalmerkletree /
+# shardtree, blake2b_simd, zcash_note_encryption) runs unoptimized. Trial
+# decryption, Pedersen hashing and shardtree inserts are then 20-100x slower
+# than release, and chain sync crawls — minutes to advance a couple of blocks.
+#
+# The fix is the standard Zashi / zcash-devtool pattern: optimize dependencies,
+# leave our own crates at opt-level 0 so edit-rebuild stays fast.
+# ---------------------------------------------------------------------------
+
+[profile.dev]
+# Our own crates: unoptimized so incremental rebuilds stay quick and debugging
+# (breakpoints, variable inspection) behaves.
+opt-level = 0
+
+[profile.dev.package."*"]
+# Every dependency — crucially the Zcash crypto stack — gets fully optimized.
+# Deps are compiled once and cached, so this costs a single cold build and buys
+# back orders of magnitude on sync speed in `tauri dev`.
+opt-level = 3
+
+[profile.dev.build-override]
+# Build scripts and proc macros also run at opt-level 0 by default; several
+# Zcash deps do real work in build.rs. Cheap win on cold builds.
+opt-level = 3
+
+[profile.release]
+# Release already implies opt-level = 3; these squeeze out the rest for shipped
+# binaries at the cost of slower link times.
+lto = "thin"
+codegen-units = 1

--- a/wallet/zuuli/src-tauri/Cargo.toml
+++ b/wallet/zuuli/src-tauri/Cargo.toml
@@ -26,3 +26,44 @@ tauri-plugin-zcash = { path = "../../plugins/tauri-plugin-zcash" }
 # (RFC 8252) — binds 127.0.0.1, serves a single request, then shuts down. Kept
 # out of the shared tauri-plugin-zcash crate since it's ZUULI-specific.
 tiny_http = "0.12"
+
+# ---------------------------------------------------------------------------
+# Build profiles. DO NOT DELETE — this is load-bearing for `tauri dev` usability.
+#
+# This package is its own workspace root (there is no `[workspace]` above it and
+# no repo-root Cargo.toml), so `[profile.*]` declared here IS honored for the
+# whole dependency graph — including the `tauri-plugin-zcash` path dep and the
+# librustzcash path deps in `z/zcash/librustzcash`.
+#
+# Why: `npm run tauri dev` builds the *dev* profile. At the Cargo default of
+# `opt-level = 0`, the entire Zcash crypto stack (sapling-crypto, orchard,
+# halo2_proofs, bls12_381, pasta_curves, group/ff, incrementalmerkletree /
+# shardtree, blake2b_simd, zcash_note_encryption) runs unoptimized. Trial
+# decryption, Pedersen hashing and shardtree inserts are then 20-100x slower
+# than release, and chain sync crawls — minutes to advance a couple of blocks.
+#
+# The fix is the standard Zashi / zcash-devtool pattern: optimize dependencies,
+# leave our own crates at opt-level 0 so edit-rebuild stays fast.
+# ---------------------------------------------------------------------------
+
+[profile.dev]
+# Our own crates: unoptimized so incremental rebuilds stay quick and debugging
+# (breakpoints, variable inspection) behaves.
+opt-level = 0
+
+[profile.dev.package."*"]
+# Every dependency — crucially the Zcash crypto stack — gets fully optimized.
+# Deps are compiled once and cached, so this costs a single cold build and buys
+# back orders of magnitude on sync speed in `tauri dev`.
+opt-level = 3
+
+[profile.dev.build-override]
+# Build scripts and proc macros also run at opt-level 0 by default; several
+# Zcash deps do real work in build.rs. Cheap win on cold builds.
+opt-level = 3
+
+[profile.release]
+# Release already implies opt-level = 3; these squeeze out the rest for shipped
+# binaries at the cost of slower link times.
+lto = "thin"
+codegen-units = 1


### PR DESCRIPTION
## Diagnosis

There were **no `[profile.*]` sections anywhere in the repo** and no `.cargo/config.toml`. `npm run tauri dev` builds `target/debug/zuuli`, i.e. the **dev** profile, which defaults to `opt-level = 0` for *everything* in the graph.

That means the entire Zcash crypto stack was running unoptimized:

`sapling-crypto`, `orchard`, `halo2_proofs`, `bls12_381`, `pasta_curves`, `group`/`ff`, `incrementalmerkletree`/`shardtree`, `blake2b_simd`, `zcash_note_encryption`.

These are exactly the crates that dominate sync: trial decryption of every output, Pedersen hashing, and shardtree inserts. Unoptimized field/curve arithmetic is routinely **20-100x** slower than `opt-level = 3` — constant-time bigint code compiles to enormous unoptimized IR with no inlining. This is the primary reason dev sync was taking **minutes to advance two blocks**.

## Fix

The standard Zashi / zcash-devtool pattern — optimize *dependencies*, leave *our* crates cheap to rebuild:

```toml
[profile.dev]
opt-level = 0            # our crates: fast incremental rebuilds, sane debugging

[profile.dev.package."*"]
opt-level = 3            # every dependency, incl. the Zcash crypto stack

[profile.dev.build-override]
opt-level = 3            # build scripts / proc macros

[profile.release]
lto = "thin"
codegen-units = 1
```

Applied to **all three workspace roots**, each with a prominent DO-NOT-DELETE comment explaining why:

- `wallet/zuuli/src-tauri/Cargo.toml`
- `wallet/zuuallet/src-tauri/Cargo.toml`
- `wallet/plugins/tauri-plugin-zcash/Cargo.toml` (only applies when built/tested standalone; when consumed as a path dep the app's profile wins — hence the duplication)

## Why it lands where it does

`[profile.*]` is only honored in the workspace root / top-level package being built. Verified each `src-tauri` **is** its own workspace root — none of the three manifests declares or joins a `[workspace]`, and there is no repo-root `Cargo.toml`:

```
$ cargo metadata --manifest-path wallet/zuuli/src-tauri/Cargo.toml --no-deps
"workspace_root": ".../wallet/zuuli/src-tauri"
```

So the profile applies to the whole graph, including the `tauri-plugin-zcash` path dep and the `z/zcash/librustzcash` path deps (they are plain dependencies, not workspace members, so they match `package."*"`).

## Evidence the profile is actually honored

`cargo build -v --manifest-path wallet/zuuli/src-tauri/Cargo.toml` (submodule checked out):

- **0** occurrences of `profiles for the non root package will be ignored` (or any profile warning).
- **0** occurrences of `-C opt-level=0` in any rustc invocation.
- Dependency lib crates compiled with `-C opt-level=3`, e.g. `--crate-name memchr ... -C opt-level=3`, and build scripts likewise (`build_script_build ... -C opt-level=3`).

## Expected impact

- Dev sync speedup of roughly **1-2 orders of magnitude** on the decrypt/hash/shardtree hot path — `tauri dev` becomes usable for real chain sync instead of a demo of the UI.
- Cost: a **one-time** cold dependency build (deps are compiled once and cached; edit-rebuild of our own code is unchanged since we stay at `opt-level = 0`).
- CI: `zuuallet.yml` / `zuuli.yml` use `Swatinem/rust-cache@v2`, so the extra cost is a single cache-key-miss build, not per-run.
