### PR TITLE
fix(wallet): preserve seed on rejected deletion

### DIFF
--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -117,6 +117,11 @@ jobs:
       - name: Build Tauri backend (plugin + librustzcash path deps)
         run: cargo build --locked --manifest-path wallet/zuuallet/src-tauri/Cargo.toml
 
+      - name: Test wallet plugin
+        run: >-
+          cargo test --locked
+          --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
+
   # ---------------------------------------------------------------------------
   # Canary: rebuild against the LATEST librustzcash main + refreshed crates.
   # Runs weekly (and on manual dispatch) so upstream breakage shows up as an

--- a/wallet/plugins/tauri-plugin-zcash/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/commands.rs
@@ -21,12 +21,72 @@ fn format_birthday_error(e: BirthdayError) -> String {
     }
 }
 
+struct CommittedWalletDeletion {
+    wallet_id: String,
+    db_filename: String,
+    was_active: bool,
+    cleanup_authorized: bool,
+}
+
+/// Validate and remove a wallet from the manifest/DB deletion path.
+///
+/// Returning this token proves the manifest replacement became visible; its
+/// cleanup flag separately proves crash durability before seed destruction.
+/// Rejected or durability-uncertain deletions cannot erase recovery data.
+fn commit_wallet_deletion(
+    manifest: &mut crate::wallet::manifest::WalletManifest,
+    data_dir: &std::path::Path,
+    wallet_id: &str,
+) -> Result<CommittedWalletDeletion> {
+    let was_active = manifest.active_wallet_id.as_deref() == Some(wallet_id);
+    let durable = manifest
+        .delete_wallet_durable(data_dir, wallet_id)
+        .map_err(|e| match e {
+            crate::wallet::manifest::DeleteWalletError::LastWallet => {
+                Error::Other("cannot delete the last wallet".into())
+            }
+            crate::wallet::manifest::DeleteWalletError::NotFound => {
+                Error::Other("wallet not found".into())
+            }
+            crate::wallet::manifest::DeleteWalletError::Persistence(e) => {
+                Error::DatabaseError(format!("failed to persist wallet deletion: {e}"))
+            }
+        })?;
+
+    Ok(CommittedWalletDeletion {
+        wallet_id: durable.entry.id,
+        db_filename: durable.entry.db_filename,
+        was_active,
+        cleanup_authorized: durable.cleanup_authorized,
+    })
+}
+
+async fn cleanup_committed_wallet(
+    data_dir: std::path::PathBuf,
+    wallet_id: String,
+    db_filename: String,
+) {
+    match tokio::task::spawn_blocking(move || {
+        crate::wallet::manifest::cleanup_wallet_database_files(&data_dir, &db_filename);
+        keychain::delete_seed_phrase(&data_dir, &wallet_id)
+    })
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::warn!("wallet deleted but secure seed cleanup failed: {e}"),
+        Err(e) => tracing::warn!("wallet deleted but seed cleanup task failed: {e}"),
+    }
+}
+
 #[command]
 pub(crate) async fn create_wallet<R: Runtime>(
     app: AppHandle<R>,
     args: CreateWalletArgs,
 ) -> Result<WalletCreated> {
     let zcash = app.zcash();
+    let transition_guard = Arc::clone(&zcash.state.wallet_transition)
+        .lock_owned()
+        .await;
     let word_count = args.mnemonic_word_count.unwrap_or(24);
     let wallet_name = args.name.unwrap_or_else(|| "Default".to_string());
 
@@ -99,6 +159,7 @@ pub(crate) async fn create_wallet<R: Runtime>(
     let db_arc = Arc::clone(&zcash.state.db);
     let app2 = app.clone();
     tokio::spawn(async move {
+        let _transition_guard = transition_guard;
         *db_arc.lock().await = Some(db);
         tracing::info!("write db ready for new wallet");
         // Auto-start sync once write db is available
@@ -118,6 +179,9 @@ pub(crate) async fn restore_wallet<R: Runtime>(
     args: RestoreWalletArgs,
 ) -> Result<serde_json::Value> {
     let zcash = app.zcash();
+    let transition_guard = Arc::clone(&zcash.state.wallet_transition)
+        .lock_owned()
+        .await;
     let mnemonic = keys::parse_mnemonic(&args.seed_phrase)?;
     let seed = keys::mnemonic_to_seed(&mnemonic);
     let birthday_height = args.birthday_height.unwrap_or(419200); // sapling activation
@@ -197,6 +261,7 @@ pub(crate) async fn restore_wallet<R: Runtime>(
     let db_arc = Arc::clone(&zcash.state.db);
     let app2 = app.clone();
     tokio::spawn(async move {
+        let _transition_guard = transition_guard;
         *db_arc.lock().await = Some(db);
         tracing::info!("write db ready for restored wallet");
         // Auto-start sync once write db is available
@@ -265,6 +330,7 @@ pub(crate) async fn unlock_wallet<R: Runtime>(
     args: UnlockWalletArgs,
 ) -> Result<()> {
     let zcash = app.zcash();
+    let _transition_guard = zcash.state.wallet_transition.lock().await;
 
     // Parse and validate the mnemonic
     let mnemonic = keys::parse_mnemonic(&args.seed_phrase)?;
@@ -431,6 +497,9 @@ pub(crate) async fn switch_wallet<R: Runtime>(
     args: SwitchWalletArgs,
 ) -> Result<()> {
     let zcash = app.zcash();
+    let transition_guard = Arc::clone(&zcash.state.wallet_transition)
+        .lock_owned()
+        .await;
 
     // Signal sync to stop (non-blocking — don't wait for the batch to finish)
     *zcash.state.syncing.write().await = false;
@@ -482,6 +551,7 @@ pub(crate) async fn switch_wallet<R: Runtime>(
     // Swap write db in background — waits for aborted sync to release the lock
     let db_arc = Arc::clone(&zcash.state.db);
     tokio::spawn(async move {
+        let _transition_guard = transition_guard;
         *db_arc.lock().await = Some(new_db);
         tracing::info!("write db swapped for switched wallet");
     });
@@ -508,55 +578,266 @@ pub(crate) async fn delete_wallet<R: Runtime>(
     args: DeleteWalletArgs,
 ) -> Result<()> {
     let zcash = app.zcash();
-    let was_active = {
+    let transition_guard = Arc::clone(&zcash.state.wallet_transition)
+        .lock_owned()
+        .await;
+
+    let deleting_active = {
         let manifest = zcash.state.manifest.lock().await;
         manifest.active_wallet_id.as_deref() == Some(&args.wallet_id)
     };
-
-    // Delete from keychain + encrypted file
-    let data_dir = zcash.state.data_dir.clone();
-    let wid = args.wallet_id.clone();
-    let _ = tokio::task::spawn_blocking(move || {
-        keychain::delete_seed_phrase(&data_dir, &wid)
-    }).await;
-
-    // Delete from manifest (also deletes DB file)
-    let deleted = {
-        let mut manifest = zcash.state.manifest.lock().await;
-        manifest.delete_wallet(&zcash.state.data_dir, &args.wallet_id)
-    };
-
-    if deleted.is_none() {
-        return Err(Error::Other("cannot delete the last wallet".into()));
+    if deleting_active {
+        *zcash.state.syncing.write().await = false;
+        if let Some(handle) = zcash.state.sync_handle.lock().await.take() {
+            handle.abort();
+        }
+        *zcash.state.pending_proposal.lock().await = None;
     }
 
-    // If we deleted the active wallet, switch to the new active
-    if was_active {
-        let new_active = {
-            let manifest = zcash.state.manifest.lock().await;
-            manifest.get_active().cloned()
-        };
-
-        if let Some(entry) = new_active {
+    // Prepare the replacement wallet before committing an active-wallet
+    // deletion. Once the deletion is durable, no later failure may turn the
+    // command into an ambiguous error that invites a destructive retry.
+    let (deletion, prepared_active) = {
+        let mut manifest = zcash.state.manifest.lock().await;
+        let prepared = if manifest.active_wallet_id.as_deref() == Some(&args.wallet_id) {
+            let deletion_pos = manifest
+                .validate_wallet_deletion(&args.wallet_id)
+                .map_err(|e| match e {
+                    crate::wallet::manifest::DeleteWalletError::LastWallet => {
+                        Error::Other("cannot delete the last wallet".into())
+                    }
+                    crate::wallet::manifest::DeleteWalletError::NotFound => {
+                        Error::Other("wallet not found".into())
+                    }
+                    crate::wallet::manifest::DeleteWalletError::Persistence(e) => {
+                        Error::DatabaseError(e)
+                    }
+                })?;
+            let entry = manifest
+                .wallets
+                .iter()
+                .enumerate()
+                .find(|(index, _)| *index != deletion_pos)
+                .map(|(_, entry)| entry)
+                .ok_or_else(|| Error::Other("wallet manifest has no replacement wallet".into()))?
+                .clone();
             let db_path = zcash.state.data_dir.join(&entry.db_filename);
             let db = storage::init_wallet_db(&db_path, zcash.state.network)?;
             let read_db = storage::open_read_db(&db_path, zcash.state.network)?;
-            *zcash.state.db.lock().await = Some(db);
-            *zcash.state.read_db.lock().await = Some(read_db);
+            Some((entry, db, read_db))
+        } else {
+            None
+        };
+        let deletion =
+            commit_wallet_deletion(&mut manifest, &zcash.state.data_dir, &args.wallet_id)?;
+        (deletion, prepared)
+    };
 
+    // If we deleted the active wallet, switch to the new active
+    if deletion.was_active {
+        if let Some((entry, db, read_db)) = prepared_active {
             let data_dir = zcash.state.data_dir.clone();
             let wid = entry.id.clone();
             let seed = match tokio::task::spawn_blocking(move || {
                 keychain::get_seed_phrase(&data_dir, &wid)
-            }).await {
-                Ok(Ok(phrase)) => keys::parse_mnemonic(&phrase).ok().map(|m| keys::mnemonic_to_seed(&m)),
+            })
+            .await
+            {
+                Ok(Ok(phrase)) => keys::parse_mnemonic(&phrase)
+                    .ok()
+                    .map(|m| keys::mnemonic_to_seed(&m)),
                 _ => None,
             };
+            *zcash.state.read_db.lock().await = Some(read_db);
             *zcash.state.seed.lock().await = seed;
+            zcash
+                .state
+                .last_known_chain_tip
+                .store(0, std::sync::atomic::Ordering::Relaxed);
+
+            let db_arc = Arc::clone(&zcash.state.db);
+            let cleanup_authorized = deletion.cleanup_authorized;
+            let cleanup_data_dir = zcash.state.data_dir.clone();
+            let cleanup_wallet_id = deletion.wallet_id;
+            let cleanup_db_filename = deletion.db_filename;
+            tokio::spawn(async move {
+                let _transition_guard = transition_guard;
+                *db_arc.lock().await = Some(db);
+                if cleanup_authorized {
+                    cleanup_committed_wallet(
+                        cleanup_data_dir,
+                        cleanup_wallet_id,
+                        cleanup_db_filename,
+                    )
+                    .await;
+                }
+            });
+            return Ok(());
         }
     }
 
+    // Previously the seed was deleted before the manifest check, so rejecting
+    // deletion of the last wallet destroyed its recovery data. Cleanup now
+    // requires a confirmed-durable manifest replacement and happens only after
+    // active DB handles have been swapped. It is best-effort because returning
+    // an error after commit would invite an ambiguous destructive retry.
+    if deletion.cleanup_authorized {
+        cleanup_committed_wallet(
+            zcash.state.data_dir.clone(),
+            deletion.wallet_id,
+            deletion.db_filename,
+        )
+        .await;
+    }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod deletion_tests {
+    use super::*;
+    use crate::wallet::manifest::{WalletEntry, WalletManifest};
+
+    fn wallet(id: &str) -> WalletEntry {
+        WalletEntry {
+            id: id.to_string(),
+            name: id.to_string(),
+            db_filename: format!("wallet_{id}.sqlite"),
+            birthday_height: Some(1),
+            created_at: "2026-08-06T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn last_wallet_rejection_never_authorizes_seed_cleanup() {
+        let data_dir =
+            std::env::temp_dir().join(format!("zuuli-delete-command-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&data_dir).expect("create test data dir");
+
+        let wallet = wallet(&format!("only-{}", uuid::Uuid::new_v4()));
+        let db_path = data_dir.join(&wallet.db_filename);
+        std::fs::write(&db_path, b"wallet database").expect("write test database");
+        keychain::store_seed_phrase(&data_dir, &wallet.id, "actual test seed")
+            .expect("store encrypted seed");
+
+        let mut manifest = WalletManifest {
+            wallets: vec![wallet.clone()],
+            active_wallet_id: Some(wallet.id.clone()),
+        };
+        manifest.save(&data_dir);
+        let manifest_before = std::fs::read(data_dir.join("wallets.json"))
+            .expect("read manifest before deletion attempt");
+
+        let deletion = commit_wallet_deletion(&mut manifest, &data_dir, &wallet.id);
+        assert!(deletion.is_err(), "last wallet deletion must be rejected");
+
+        // Seed cleanup requires the token returned by commit_wallet_deletion;
+        // the rejected operation produced no token and cannot reach that phase.
+        assert_eq!(manifest.wallets.len(), 1);
+        assert_eq!(manifest.active_wallet_id, Some(wallet.id.clone()));
+        assert!(db_path.exists(), "wallet database must not be deleted");
+        assert_eq!(
+            keychain::get_seed_phrase(&data_dir, &wallet.id).expect("seed must remain readable"),
+            "actual test seed"
+        );
+        assert_eq!(
+            std::fs::read(data_dir.join("wallets.json")).expect("read manifest after attempt"),
+            manifest_before,
+            "manifest file must not change"
+        );
+
+        std::fs::remove_dir_all(data_dir).expect("remove test data dir");
+    }
+
+    #[test]
+    fn persistence_failure_never_authorizes_seed_cleanup_and_rolls_back() {
+        let data_dir =
+            std::env::temp_dir().join(format!("zuuli-delete-persistence-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&data_dir).expect("create test data dir");
+
+        let first = wallet(&format!("first-{}", uuid::Uuid::new_v4()));
+        let second = wallet(&format!("second-{}", uuid::Uuid::new_v4()));
+        let first_db = data_dir.join(&first.db_filename);
+        std::fs::write(&first_db, b"wallet database").expect("write test database");
+        keychain::store_seed_phrase(&data_dir, &first.id, "actual test seed")
+            .expect("store encrypted seed");
+
+        // Force atomic manifest replacement to fail deterministically.
+        std::fs::create_dir(data_dir.join("wallets.json")).expect("create manifest-path blocker");
+        let mut manifest = WalletManifest {
+            wallets: vec![first.clone(), second],
+            active_wallet_id: Some(first.id.clone()),
+        };
+
+        let deletion = commit_wallet_deletion(&mut manifest, &data_dir, &first.id);
+        assert!(
+            deletion.is_err(),
+            "persistence failure must reject deletion"
+        );
+        assert_eq!(
+            manifest.wallets.len(),
+            2,
+            "in-memory removal must roll back"
+        );
+        assert_eq!(manifest.active_wallet_id, Some(first.id.clone()));
+        assert!(first_db.exists(), "wallet database must not be deleted");
+        assert_eq!(
+            keychain::get_seed_phrase(&data_dir, &first.id).expect("seed must remain readable"),
+            "actual test seed"
+        );
+
+        std::fs::remove_dir_all(data_dir).expect("remove test data dir");
+    }
+
+    #[test]
+    fn successful_commit_is_durable_before_seed_cleanup_is_authorized() {
+        let data_dir =
+            std::env::temp_dir().join(format!("zuuli-delete-success-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&data_dir).expect("create test data dir");
+
+        let first = wallet(&format!("first-{}", uuid::Uuid::new_v4()));
+        let second = wallet(&format!("second-{}", uuid::Uuid::new_v4()));
+        let first_db = data_dir.join(&first.db_filename);
+        let first_wal = data_dir.join(format!("{}-wal", first.db_filename));
+        let first_shm = data_dir.join(format!("{}-shm", first.db_filename));
+        std::fs::write(&first_db, b"wallet database").expect("write test database");
+        std::fs::write(&first_wal, b"wallet WAL").expect("write test WAL");
+        std::fs::write(&first_shm, b"wallet SHM").expect("write test SHM");
+        keychain::store_seed_phrase(&data_dir, &first.id, "actual test seed")
+            .expect("store encrypted seed");
+
+        let mut manifest = WalletManifest {
+            wallets: vec![first.clone(), second.clone()],
+            active_wallet_id: Some(first.id.clone()),
+        };
+        manifest.save(&data_dir);
+
+        let deletion = commit_wallet_deletion(&mut manifest, &data_dir, &first.id)
+            .expect("deletion should commit");
+        assert!(deletion.was_active);
+        assert!(deletion.cleanup_authorized);
+        assert_eq!(manifest.active_wallet_id, Some(second.id.clone()));
+        assert!(!first_db.exists(), "database cleanup follows manifest commit");
+        assert!(!first_wal.exists(), "WAL cleanup follows manifest commit");
+        assert!(!first_shm.exists(), "SHM cleanup follows manifest commit");
+        assert_eq!(
+            keychain::get_seed_phrase(&data_dir, &first.id)
+                .expect("seed remains until the commit token is consumed"),
+            "actual test seed"
+        );
+
+        let persisted = WalletManifest::load(&data_dir);
+        assert_eq!(persisted.wallets.len(), 1);
+        assert_eq!(persisted.active_wallet_id, Some(second.id));
+
+        keychain::delete_seed_phrase(&data_dir, &deletion.wallet_id)
+            .expect("consume cleanup authorization");
+        assert!(
+            keychain::get_seed_phrase(&data_dir, &deletion.wallet_id).is_err(),
+            "authorized cleanup removes the real encrypted seed"
+        );
+        std::fs::remove_dir_all(data_dir).expect("remove test data dir");
+    }
 }
 
 // --- Existing commands ---

--- a/wallet/plugins/tauri-plugin-zcash/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/commands.rs
@@ -22,10 +22,13 @@ fn format_birthday_error(e: BirthdayError) -> String {
 }
 
 struct CommittedWalletDeletion {
+    was_active: bool,
+    cleanup: Option<AuthorizedWalletCleanup>,
+}
+
+struct AuthorizedWalletCleanup {
     wallet_id: String,
     db_filename: String,
-    was_active: bool,
-    cleanup_authorized: bool,
 }
 
 /// Validate and remove a wallet from the manifest/DB deletion path.
@@ -54,21 +57,28 @@ fn commit_wallet_deletion(
         })?;
 
     Ok(CommittedWalletDeletion {
-        wallet_id: durable.entry.id,
-        db_filename: durable.entry.db_filename,
         was_active,
-        cleanup_authorized: durable.cleanup_authorized,
+        cleanup: durable.cleanup_authorized.then_some(AuthorizedWalletCleanup {
+            wallet_id: durable.entry.id,
+            db_filename: durable.entry.db_filename,
+        }),
     })
+}
+
+fn cleanup_committed_wallet_blocking(
+    data_dir: &std::path::Path,
+    cleanup: AuthorizedWalletCleanup,
+) -> Result<()> {
+    crate::wallet::manifest::cleanup_wallet_database_files(data_dir, &cleanup.db_filename);
+    keychain::delete_seed_phrase(data_dir, &cleanup.wallet_id)
 }
 
 async fn cleanup_committed_wallet(
     data_dir: std::path::PathBuf,
-    wallet_id: String,
-    db_filename: String,
+    cleanup: AuthorizedWalletCleanup,
 ) {
     match tokio::task::spawn_blocking(move || {
-        crate::wallet::manifest::cleanup_wallet_database_files(&data_dir, &db_filename);
-        keychain::delete_seed_phrase(&data_dir, &wallet_id)
+        cleanup_committed_wallet_blocking(&data_dir, cleanup)
     })
     .await
     {
@@ -656,20 +666,13 @@ pub(crate) async fn delete_wallet<R: Runtime>(
                 .store(0, std::sync::atomic::Ordering::Relaxed);
 
             let db_arc = Arc::clone(&zcash.state.db);
-            let cleanup_authorized = deletion.cleanup_authorized;
+            let cleanup = deletion.cleanup;
             let cleanup_data_dir = zcash.state.data_dir.clone();
-            let cleanup_wallet_id = deletion.wallet_id;
-            let cleanup_db_filename = deletion.db_filename;
             tokio::spawn(async move {
                 let _transition_guard = transition_guard;
                 *db_arc.lock().await = Some(db);
-                if cleanup_authorized {
-                    cleanup_committed_wallet(
-                        cleanup_data_dir,
-                        cleanup_wallet_id,
-                        cleanup_db_filename,
-                    )
-                    .await;
+                if let Some(cleanup) = cleanup {
+                    cleanup_committed_wallet(cleanup_data_dir, cleanup).await;
                 }
             });
             return Ok(());
@@ -681,13 +684,8 @@ pub(crate) async fn delete_wallet<R: Runtime>(
     // requires a confirmed-durable manifest replacement and happens only after
     // active DB handles have been swapped. It is best-effort because returning
     // an error after commit would invite an ambiguous destructive retry.
-    if deletion.cleanup_authorized {
-        cleanup_committed_wallet(
-            zcash.state.data_dir.clone(),
-            deletion.wallet_id,
-            deletion.db_filename,
-        )
-        .await;
+    if let Some(cleanup) = deletion.cleanup {
+        cleanup_committed_wallet(zcash.state.data_dir.clone(), cleanup).await;
     }
 
     Ok(())
@@ -815,11 +813,11 @@ mod deletion_tests {
         let deletion = commit_wallet_deletion(&mut manifest, &data_dir, &first.id)
             .expect("deletion should commit");
         assert!(deletion.was_active);
-        assert!(deletion.cleanup_authorized);
+        assert!(deletion.cleanup.is_some());
         assert_eq!(manifest.active_wallet_id, Some(second.id.clone()));
-        assert!(!first_db.exists(), "database cleanup follows manifest commit");
-        assert!(!first_wal.exists(), "WAL cleanup follows manifest commit");
-        assert!(!first_shm.exists(), "SHM cleanup follows manifest commit");
+        assert!(first_db.exists(), "commit must not consume database cleanup");
+        assert!(first_wal.exists(), "commit must not consume WAL cleanup");
+        assert!(first_shm.exists(), "commit must not consume SHM cleanup");
         assert_eq!(
             keychain::get_seed_phrase(&data_dir, &first.id)
                 .expect("seed remains until the commit token is consumed"),
@@ -830,10 +828,15 @@ mod deletion_tests {
         assert_eq!(persisted.wallets.len(), 1);
         assert_eq!(persisted.active_wallet_id, Some(second.id));
 
-        keychain::delete_seed_phrase(&data_dir, &deletion.wallet_id)
+        let cleanup = deletion.cleanup.expect("cleanup token");
+        let deleted_wallet_id = cleanup.wallet_id.clone();
+        cleanup_committed_wallet_blocking(&data_dir, cleanup)
             .expect("consume cleanup authorization");
+        assert!(!first_db.exists(), "token consumption removes database");
+        assert!(!first_wal.exists(), "token consumption removes WAL");
+        assert!(!first_shm.exists(), "token consumption removes SHM");
         assert!(
-            keychain::get_seed_phrase(&data_dir, &deletion.wallet_id).is_err(),
+            keychain::get_seed_phrase(&data_dir, &deleted_wallet_id).is_err(),
             "authorized cleanup removes the real encrypted seed"
         );
         std::fs::remove_dir_all(data_dir).expect("remove test data dir");

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/keychain.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/keychain.rs
@@ -101,9 +101,9 @@ pub fn get_seed_phrase(data_dir: &Path, wallet_id: &str) -> Result<String> {
 /// Delete a seed phrase from all storage locations.
 pub fn delete_seed_phrase(data_dir: &Path, wallet_id: &str) -> Result<()> {
     let _ = os_keychain::delete(wallet_id);
-    let _ = encrypted_file::delete(data_dir, wallet_id);
+    let encrypted_result = encrypted_file::delete(data_dir, wallet_id);
     let _ = legacy_keyring::delete(wallet_id);
-    Ok(())
+    encrypted_result.map_err(|e| Error::KeyError(format!("failed to delete encrypted seed: {e}")))
 }
 
 // ---------------------------------------------------------------------------

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/manifest.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/manifest.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -14,6 +15,18 @@ pub struct WalletEntry {
 pub struct WalletManifest {
     pub wallets: Vec<WalletEntry>,
     pub active_wallet_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DeleteWalletError {
+    LastWallet,
+    NotFound,
+    Persistence(String),
+}
+
+pub(crate) struct DurableDeletion {
+    pub(crate) entry: WalletEntry,
+    pub(crate) cleanup_authorized: bool,
 }
 
 impl WalletManifest {
@@ -41,14 +54,8 @@ impl WalletManifest {
 
     /// Save manifest to disk.
     pub fn save(&self, data_dir: &Path) {
-        let path = Self::manifest_path(data_dir);
-        match serde_json::to_string_pretty(self) {
-            Ok(json) => {
-                if let Err(e) = std::fs::write(&path, json) {
-                    tracing::error!("failed to write wallets.json: {e}");
-                }
-            }
-            Err(e) => tracing::error!("failed to serialize wallets.json: {e}"),
+        if let Err(e) = self.save_atomic(data_dir) {
+            tracing::error!("failed to save wallets.json atomically: {e}");
         }
     }
 
@@ -139,12 +146,18 @@ impl WalletManifest {
         }
     }
 
-    /// Delete a wallet. Returns the entry if removed.
-    pub fn delete_wallet(&mut self, data_dir: &Path, wallet_id: &str) -> Option<WalletEntry> {
-        if self.wallets.len() <= 1 {
-            return None; // Can't delete the last wallet
-        }
-        let pos = self.wallets.iter().position(|w| w.id == wallet_id)?;
+    /// Durably remove a wallet from the manifest, then clean up its DB file.
+    ///
+    /// If manifest persistence fails, the in-memory mutation is rolled back and
+    /// the DB remains in place. External state such as a keychain seed must not
+    /// be deleted unless the returned cleanup authorization is true.
+    pub(crate) fn delete_wallet_durable(
+        &mut self,
+        data_dir: &Path,
+        wallet_id: &str,
+    ) -> Result<DurableDeletion, DeleteWalletError> {
+        let pos = self.validate_wallet_deletion(wallet_id)?;
+        let previous_active = self.active_wallet_id.clone();
         let entry = self.wallets.remove(pos);
 
         // If we deleted the active wallet, switch to the first remaining
@@ -152,14 +165,102 @@ impl WalletManifest {
             self.active_wallet_id = self.wallets.first().map(|w| w.id.clone());
         }
 
-        // Delete the DB file
-        let db_path = data_dir.join(&entry.db_filename);
-        if db_path.exists() {
-            let _ = std::fs::remove_file(&db_path);
+        let cleanup_authorized = match self.save_atomic(data_dir) {
+            Ok(cleanup_authorized) => cleanup_authorized,
+            Err(e) => {
+                self.wallets.insert(pos, entry);
+                self.active_wallet_id = previous_active;
+                return Err(DeleteWalletError::Persistence(e.to_string()));
+            }
+        };
+
+        // A confirmed-durable manifest no longer references this wallet. DB
+        // cleanup is best-effort; a leftover DB is recoverable orphaned data,
+        // not a wallet whose seed was erased while its manifest entry survived.
+        if cleanup_authorized {
+            cleanup_wallet_database_files(data_dir, &entry.db_filename);
+        } else {
+            tracing::warn!(
+                "wallet manifest replacement was visible but not confirmed durable; preserving database and seed"
+            );
         }
 
-        self.save(data_dir);
-        Some(entry)
+        Ok(DurableDeletion {
+            entry,
+            cleanup_authorized,
+        })
+    }
+
+    /// Validate deletion without changing the manifest or filesystem.
+    ///
+    /// Callers that also delete external state, such as a keychain seed, must
+    /// call this before performing any irreversible cleanup.
+    pub(crate) fn validate_wallet_deletion(
+        &self,
+        wallet_id: &str,
+    ) -> Result<usize, DeleteWalletError> {
+        let pos = self
+            .wallets
+            .iter()
+            .position(|w| w.id == wallet_id)
+            .ok_or(DeleteWalletError::NotFound)?;
+
+        if self.wallets.len() <= 1 {
+            return Err(DeleteWalletError::LastWallet);
+        }
+
+        Ok(pos)
+    }
+
+    fn save_atomic(&self, data_dir: &Path) -> std::io::Result<bool> {
+        let path = Self::manifest_path(data_dir);
+        let temp_path = data_dir.join(format!(".wallets-{}.tmp", uuid::Uuid::new_v4()));
+        let json = serde_json::to_vec_pretty(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        let result = (|| {
+            let mut temp = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)?;
+            temp.write_all(&json)?;
+            temp.sync_all()?;
+            std::fs::rename(&temp_path, &path)?;
+            #[cfg(windows)]
+            if let Err(e) = std::fs::File::open(&path).and_then(|file| file.sync_all()) {
+                tracing::warn!(
+                    "wallet manifest replaced but file durability could not be confirmed: {e}"
+                );
+                return Ok(false);
+            }
+            #[cfg(unix)]
+            if let Err(e) = std::fs::File::open(data_dir).and_then(|dir| dir.sync_all()) {
+                tracing::warn!(
+                    "wallet manifest replaced but directory durability could not be confirmed: {e}"
+                );
+                return Ok(false);
+            }
+            Ok(true)
+        })();
+
+        if result.is_err() {
+            let _ = std::fs::remove_file(temp_path);
+        }
+        result
+    }
+}
+
+pub(crate) fn cleanup_wallet_database_files(data_dir: &Path, filename: &str) {
+    for db_path in [
+        data_dir.join(filename),
+        data_dir.join(format!("{filename}-wal")),
+        data_dir.join(format!("{filename}-shm")),
+    ] {
+        if db_path.exists() {
+            if let Err(e) = std::fs::remove_file(&db_path) {
+                tracing::warn!("wallet removed but database cleanup failed: {e}");
+            }
+        }
     }
 }
 

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/manifest.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/manifest.rs
@@ -37,6 +37,10 @@ impl WalletManifest {
     /// Load manifest from disk, or create empty if none exists.
     pub fn load(data_dir: &Path) -> Self {
         let path = Self::manifest_path(data_dir);
+        #[cfg(windows)]
+        if let Err(e) = recover_manifest_backup(&path, &manifest_backup_path(data_dir)) {
+            tracing::error!("failed to recover wallet manifest backup: {e}");
+        }
         if path.exists() {
             match std::fs::read_to_string(&path) {
                 Ok(contents) => match serde_json::from_str(&contents) {
@@ -146,7 +150,7 @@ impl WalletManifest {
         }
     }
 
-    /// Durably remove a wallet from the manifest, then clean up its DB file.
+    /// Durably remove a wallet from the manifest and return cleanup authority.
     ///
     /// If manifest persistence fails, the in-memory mutation is rolled back and
     /// the DB remains in place. External state such as a keychain seed must not
@@ -174,12 +178,7 @@ impl WalletManifest {
             }
         };
 
-        // A confirmed-durable manifest no longer references this wallet. DB
-        // cleanup is best-effort; a leftover DB is recoverable orphaned data,
-        // not a wallet whose seed was erased while its manifest entry survived.
-        if cleanup_authorized {
-            cleanup_wallet_database_files(data_dir, &entry.db_filename);
-        } else {
+        if !cleanup_authorized {
             tracing::warn!(
                 "wallet manifest replacement was visible but not confirmed durable; preserving database and seed"
             );
@@ -225,9 +224,20 @@ impl WalletManifest {
                 .open(&temp_path)?;
             temp.write_all(&json)?;
             temp.sync_all()?;
+            #[cfg(not(windows))]
             std::fs::rename(&temp_path, &path)?;
             #[cfg(windows)]
-            if let Err(e) = std::fs::File::open(&path).and_then(|file| file.sync_all()) {
+            replace_manifest_with_backup(
+                &temp_path,
+                &path,
+                &manifest_backup_path(data_dir),
+            )?;
+            #[cfg(windows)]
+            if let Err(e) = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .and_then(|file| file.sync_all())
+            {
                 tracing::warn!(
                     "wallet manifest replaced but file durability could not be confirmed: {e}"
                 );
@@ -250,6 +260,57 @@ impl WalletManifest {
     }
 }
 
+#[cfg(any(windows, test))]
+fn manifest_backup_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("wallets.json.backup")
+}
+
+/// Restore the last complete manifest after interruption between the two
+/// Windows replacement renames. If the new manifest is present, it wins.
+#[cfg(any(windows, test))]
+fn recover_manifest_backup(path: &Path, backup: &Path) -> std::io::Result<()> {
+    if !path.exists() && backup.exists() {
+        std::fs::rename(backup, path)?;
+        tracing::warn!("recovered wallet manifest from interrupted replacement");
+    }
+    Ok(())
+}
+
+/// Windows cannot portably rename over an existing destination. Preserve the
+/// old manifest, install the synced temp file, and restore the backup if the
+/// second rename fails. This is compiled in tests on every host so the recovery
+/// protocol does not rely on an untested `cfg(windows)` branch.
+#[cfg(any(windows, test))]
+fn replace_manifest_with_backup(
+    temp: &Path,
+    path: &Path,
+    backup: &Path,
+) -> std::io::Result<()> {
+    recover_manifest_backup(path, backup)?;
+    if backup.exists() {
+        std::fs::remove_file(backup)?;
+    }
+
+    let had_manifest = path.exists();
+    if had_manifest {
+        std::fs::rename(path, backup)?;
+    }
+
+    if let Err(e) = std::fs::rename(temp, path) {
+        if had_manifest {
+            let _ = std::fs::rename(backup, path);
+        }
+        return Err(e);
+    }
+
+    if had_manifest {
+        if let Err(e) = std::fs::remove_file(backup) {
+            tracing::warn!("wallet manifest replaced but backup cleanup failed: {e}");
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn cleanup_wallet_database_files(data_dir: &Path, filename: &str) {
     for db_path in [
         data_dir.join(filename),
@@ -261,6 +322,85 @@ pub(crate) fn cleanup_wallet_database_files(data_dir: &Path, filename: &str) {
                 tracing::warn!("wallet removed but database cleanup failed: {e}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod replacement_tests {
+    use super::*;
+
+    fn test_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "zuuli-manifest-{label}-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).expect("create test directory");
+        dir
+    }
+
+    #[test]
+    fn backup_replacement_installs_new_manifest_and_removes_backup() {
+        let data_dir = test_dir("replace");
+        let path = WalletManifest::manifest_path(&data_dir);
+        let backup = manifest_backup_path(&data_dir);
+        let temp = data_dir.join("wallets.tmp");
+        std::fs::write(&path, b"old manifest").expect("write old manifest");
+        std::fs::write(&backup, b"stale backup").expect("write stale backup");
+        std::fs::write(&temp, b"new manifest").expect("write new manifest");
+
+        replace_manifest_with_backup(&temp, &path, &backup).expect("replace manifest");
+
+        assert_eq!(std::fs::read(&path).expect("read manifest"), b"new manifest");
+        assert!(!temp.exists());
+        assert!(!backup.exists());
+        std::fs::remove_dir_all(data_dir).expect("remove test directory");
+    }
+
+    #[test]
+    fn failed_install_restores_previous_manifest() {
+        let data_dir = test_dir("rollback");
+        let path = WalletManifest::manifest_path(&data_dir);
+        let backup = manifest_backup_path(&data_dir);
+        let missing_temp = data_dir.join("missing.tmp");
+        std::fs::write(&path, b"old manifest").expect("write old manifest");
+
+        assert!(replace_manifest_with_backup(&missing_temp, &path, &backup).is_err());
+
+        assert_eq!(std::fs::read(&path).expect("read manifest"), b"old manifest");
+        assert!(!backup.exists());
+        std::fs::remove_dir_all(data_dir).expect("remove test directory");
+    }
+
+    #[test]
+    fn backup_replacement_installs_first_manifest() {
+        let data_dir = test_dir("first");
+        let path = WalletManifest::manifest_path(&data_dir);
+        let backup = manifest_backup_path(&data_dir);
+        let temp = data_dir.join("wallets.tmp");
+        std::fs::write(&temp, b"first manifest").expect("write new manifest");
+
+        replace_manifest_with_backup(&temp, &path, &backup).expect("install manifest");
+
+        assert_eq!(std::fs::read(&path).expect("read manifest"), b"first manifest");
+        assert!(!backup.exists());
+        std::fs::remove_dir_all(data_dir).expect("remove test directory");
+    }
+
+    #[test]
+    fn interrupted_replacement_recovers_complete_backup() {
+        let data_dir = test_dir("recover");
+        let path = WalletManifest::manifest_path(&data_dir);
+        let backup = manifest_backup_path(&data_dir);
+        std::fs::write(&backup, b"complete old manifest").expect("write backup");
+
+        recover_manifest_backup(&path, &backup).expect("recover manifest");
+
+        assert_eq!(
+            std::fs::read(&path).expect("read recovered manifest"),
+            b"complete old manifest"
+        );
+        assert!(!backup.exists());
+        std::fs::remove_dir_all(data_dir).expect("remove test directory");
     }
 }
 

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
@@ -42,6 +42,8 @@ pub struct WalletState {
     /// Zuuli polls `get_sync_status`, so the error MUST live here — not only in
     /// the emitted event — for the UI to see it.
     pub last_sync_error: Arc<RwLock<Option<String>>>,
+    /// Serializes create/restore/switch/delete through the final write-DB swap.
+    pub wallet_transition: Arc<Mutex<()>>,
     pub manifest: Arc<Mutex<manifest::WalletManifest>>,
     pub prover: Arc<Mutex<Option<zcash_proofs::prover::LocalTxProver>>>,
     pub pending_proposal: Arc<Mutex<Option<(u32, WalletProposal)>>>,
@@ -115,6 +117,7 @@ impl WalletState {
             syncing: Arc::new(RwLock::new(false)),
             last_known_chain_tip: Arc::new(AtomicU64::new(0)),
             last_sync_error: Arc::new(RwLock::new(None)),
+            wallet_transition: Arc::new(Mutex::new(())),
             manifest: Arc::new(Mutex::new(manifest)),
             prover: Arc::new(Mutex::new(None)),
             pending_proposal: Arc::new(Mutex::new(None)),


### PR DESCRIPTION
## Summary

- reject last-wallet and unknown-wallet deletion before any seed or database cleanup
- atomically persist manifest changes, roll back pre-replacement failures, and withhold destructive cleanup when durability cannot be confirmed
- use an explicit Windows backup/install/restore protocol with load-time recovery; compile and test that protocol on every host
- return an explicit cleanup capability from durable deletion; manifest commit never unlinks SQLite, WAL, or SHM files
- serialize create/restore/unlock/switch/delete transitions through the final background write-DB swap
- stop active sync before deletion and consume DB/seed cleanup authority only after old active handles are replaced
- surface encrypted-seed deletion failures without returning an ambiguous error after commit
- run the complete wallet plugin test suite in the Zuuallet CI gate

## Regression coverage

The tests use the real debug encrypted-seed implementation and verify:

- rejecting deletion of the sole wallet preserves manifest bytes, DB, and readable seed
- forced manifest persistence failure restores in-memory state and preserves DB and readable seed
- successful manifest commit leaves DB/WAL/SHM and seed untouched until the cleanup token is explicitly consumed
- token consumption removes DB/WAL/SHM and the real encrypted seed
- Windows-style backup replacement installs over an existing manifest and removes stale backup state
- first-manifest installation works
- failed installation restores the previous complete manifest
- interrupted replacement recovers the complete backup

## Verification

- `cargo check --locked --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml`
- `cargo test --locked --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml` — 8 passed, 0 failed
- workflow YAML parse
- `git diff --check`
- rebased onto `origin/main` at `191557d`

## Adversarial review

Claude CLI reviewed deletion ordering, persistence failure behavior, transition locking, cross-platform replacement, DB cleanup ordering, and test validity across multiple passes. Root review then identified two correctness defects that the earlier Claude disposition missed:

1. Windows manifest replacement still depended on rename-over-existing.
2. Manifest commit still attempted DB/WAL/SHM cleanup before active DB handles were replaced.

Both are corrected in follow-up commit `b56725e`:

- Windows now uses backup → install → restore-on-failure plus load-time recovery, through helpers compiled and tested on every host.
- `delete_wallet_durable` performs no database cleanup. It returns authority that production consumes only after the active write-DB replacement, or immediately for a proven inactive wallet.
- The success test proves DB/WAL/SHM and seed remain after commit and disappear only when the cleanup token is consumed.

The targeted final Claude re-review verified these two facts and returned `BLOCKING NO`.

## Follow-up

Native platform seed custody and fail-closed migration are tracked separately in #229 so this deletion-integrity fix can land independently.
