### PR TITLE
CI: make the required ZUULI gate full-stack

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       zuuli: ${{ steps.filter.outputs.zuuli }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Diff locally instead of relying on the pull-request files API.
           fetch-depth: 0
@@ -80,9 +80,9 @@ jobs:
       run:
         working-directory: wallet/zuuli
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: npm
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Fetch only the in-source dependency required by the app/plugin graph.
       - name: Fetch librustzcash submodule
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Fetch librustzcash submodule
         run: git submodule update --init z/zcash/librustzcash

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -1,54 +1,61 @@
 name: wallet/zuuli
 
-# CI gate for the ZUULI app (wallet/zuuli) — a Vite + React 18 + TS 5 frontend.
-#
-# Nothing else in the repo covered wallet/zuuli/** before this workflow, so
-# ZUULI changes could merge with zero automated QA. As we move to autonomous,
-# human-review-free merging, ZUULI needs a required CI gate.
-#
-# Modeled on tuzi's CI (.github/workflows/ci.yml): the workflow triggers on
-# EVERY pull_request (and merge_group), NOT on a workflow-level `paths:` filter.
-# That is deliberate — a required status check must report on every PR, and a
-# workflow gated by `on.<event>.paths` simply does not run when a PR misses the
-# paths, which leaves a required check "pending" forever and blocks unrelated
-# PRs. Instead, the `changes` job path-filters via git diff and the real `build`
-# job skips when a PR does not touch ZUULI. The `gate` job then aggregates the
-# results with always() so branch protection can require a single stable check
-# ("gate") that passes when the real jobs succeed OR are legitimately skipped,
-# and fails only on a genuine failure/cancel.
+# Stable, full-stack required check for ZUULI. The workflow runs for every PR
+# and merge-group event so branch protection always receives `gate`; expensive
+# jobs skip only after the checked-out diff proves that no release-impacting
+# ZUULI surface changed.
 
 on:
   pull_request:
   merge_group:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
-  group: zuuli-${{ github.event.pull_request.number || github.ref }}
+  # PR updates supersede older runs; post-merge/manual runs use run_id and are
+  # never cancelled merely because another main build started.
+  group: zuuli-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
   cancel-in-progress: true
 
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
 jobs:
-  # Path filter so non-ZUULI PRs skip the build job (but the workflow — and
-  # therefore the `gate` job — still runs, so the required check always reports).
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       zuuli: ${{ steps.filter.outputs.zuuli }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          # The filter diffs against the event base locally instead of calling
-          # the pull-request files API, so the base commit must be present.
+          # Diff locally instead of relying on the pull-request files API.
           fetch-depth: 0
-      - name: Detect changed areas
+
+      - name: Detect release-impacting ZUULI changes
         id: filter
         shell: bash
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
         run: |
           set -euo pipefail
 
-          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] || ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
-            echo "::warning::Base commit is unavailable; running all checks."
+          # Manual runs, first pushes, and incomplete event payloads fail open
+          # into the full test suite, never into an unverified skip.
+          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+             ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+            echo "::notice::No usable base commit; running the full ZUULI gate."
+            echo "zuuli=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! changed_files=$(git diff --name-only --no-renames "$BASE_SHA" "$GITHUB_SHA"); then
+            echo "::warning::Diff failed; running the full ZUULI gate."
             echo "zuuli=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -56,17 +63,15 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|.github/workflows/zuuli.yml) zuuli=true ;;
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml)
+                zuuli=true
+                ;;
             esac
-          done < <(git diff --name-only --no-renames "$BASE_SHA" "$GITHUB_SHA")
+          done <<< "$changed_files"
 
           echo "zuuli=$zuuli" >> "$GITHUB_OUTPUT"
 
-  # Real quality checks: typecheck (tsc --noEmit) + production build
-  # (tsc && vite build). No lint or unit-test scripts are configured in
-  # wallet/zuuli/package.json yet, so there is nothing to run for those — add a
-  # step here once `lint`/`test` scripts exist.
-  build:
+  frontend:
     needs: changes
     if: needs.changes.outputs.zuuli == 'true'
     runs-on: ubuntu-latest
@@ -75,41 +80,152 @@ jobs:
       run:
         working-directory: wallet/zuuli
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: wallet/zuuli/package-lock.json
 
-      - name: Install dependencies
+      - name: Install locked dependencies
         run: npm ci
 
-      - name: Typecheck (tsc --noEmit)
+      # The current lockfile has moderate advisories but no high/critical ones.
+      # Dependency upgrades belong in focused PRs; this gate prevents severity
+      # from regressing while making the existing baseline explicit.
+      - name: Audit dependencies (high and critical)
+        run: |
+          for attempt in 1 2 3; do
+            npm audit --audit-level=high && exit 0
+            [ "$attempt" -eq 3 ] && exit 1
+            sleep $((attempt * 5))
+          done
+
+      - name: Typecheck
         run: npm run typecheck
 
-      - name: Build (tsc && vite build)
+      - name: Build production frontend
         run: npm run build
 
-  # Single required status check for branch protection / a future merge queue.
-  # The `build` job above skips via the `changes` path filter, which would leave
-  # its status "pending" forever if required directly. This aggregator runs
-  # always() and passes when every needed job is success or skipped, failing
-  # only on a real failure/cancel — so a skipped check can't be gamed.
+  rust_plugin:
+    name: Rust / shared plugin
+    needs: changes
+    if: needs.changes.outputs.zuuli == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      # Fetch only the in-source dependency required by the app/plugin graph.
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libxdo-dev \
+            libssl-dev \
+            build-essential curl wget file pkg-config
+
+      # Keep CI explicit as well as repository-pinned so runner state cannot
+      # silently select a newer compiler.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: wallet/plugins/tauri-plugin-zcash
+          key: zuuli-plugin
+
+      - name: Build and test shared Zcash plugin
+        run: cargo test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
+
+  # The app and standalone plugin have independent lockfiles and resolve some
+  # crates differently. Run them in parallel so a cold gate takes the slower
+  # job's time instead of compiling both graphs serially.
+  rust_app:
+    name: Rust / ZUULI backend
+    needs: changes
+    if: needs.changes.outputs.zuuli == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libxdo-dev \
+            libssl-dev \
+            build-essential curl wget file pkg-config
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: wallet/zuuli/src-tauri
+          key: zuuli-app
+
+      - name: Build ZUULI Tauri backend
+        run: cargo build --locked --manifest-path wallet/zuuli/src-tauri/Cargo.toml
+
+      - name: Test ZUULI Tauri backend
+        run: cargo test --locked --manifest-path wallet/zuuli/src-tauri/Cargo.toml
+
+  # Branch protection requires this stable context. It succeeds only when the
+  # change detector and every applicable full-stack job succeeded; legitimate
+  # non-ZUULI skips continue to report success instead of remaining pending.
   gate:
-    needs: [changes, build]
+    needs: [changes, frontend, rust_plugin, rust_app]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Verify required jobs succeeded (or were legitimately skipped)
+      - name: Verify required jobs succeeded or legitimately skipped
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          ZUULI_CHANGED: ${{ needs.changes.outputs.zuuli }}
+          FRONTEND_RESULT: ${{ needs.frontend.result }}
+          RUST_PLUGIN_RESULT: ${{ needs.rust_plugin.result }}
+          RUST_APP_RESULT: ${{ needs.rust_app.result }}
         run: |
-          results="${{ needs.changes.result }} ${{ needs.build.result }}"
-          echo "Job results: $results"
-          for r in $results; do
-            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
-              echo "A required job did not pass: $r"; exit 1
-            fi
+          set -euo pipefail
+          [ "$CHANGES_RESULT" = "success" ] || {
+            echo "Change detection did not pass: $CHANGES_RESULT"; exit 1;
+          }
+
+          results="$FRONTEND_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"
+          echo "ZUULI changed: $ZUULI_CHANGED; job results: $results"
+          case "$ZUULI_CHANGED" in
+            true) expected=success ;;
+            false) expected=skipped ;;
+            *) echo "Invalid or missing change-detector output: $ZUULI_CHANGED"; exit 1 ;;
+          esac
+
+          for result in $results; do
+            [ "$result" = "$expected" ] || {
+              echo "Expected every applicable job to be $expected, got: $result"; exit 1;
+            }
           done
-          echo "All required jobs passed or were skipped."
+          echo "The full-stack gate is internally consistent and passed."

--- a/wallet/plugins/tauri-plugin-zcash/CLAUDE.md
+++ b/wallet/plugins/tauri-plugin-zcash/CLAUDE.md
@@ -13,7 +13,7 @@ cargo build --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
 cd wallet/zuuli && npm run tauri dev
 ```
 
-Rust edition 2024, MSRV 1.85.1. All librustzcash deps are path deps at `z/zcash/librustzcash`.
+Rust edition 2024, MSRV 1.88. All librustzcash deps are path deps at `z/zcash/librustzcash`.
 
 ## Type aliases
 

--- a/wallet/plugins/tauri-plugin-zcash/Cargo.toml
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tauri-plugin-zcash"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.1"
+rust-version = "1.88"
 description = "Tauri plugin for Zcash wallet operations"
 links = "tauri-plugin-zcash"
 

--- a/wallet/plugins/tauri-plugin-zcash/README.md
+++ b/wallet/plugins/tauri-plugin-zcash/README.md
@@ -114,7 +114,7 @@ cd wallet/zuuli && npm run tauri build
 ```
 
 - **Rust edition**: 2024
-- **MSRV**: 1.85.1
+- **MSRV**: 1.88
 - **librustzcash**: path deps at `z/zcash/librustzcash` (forked)
 
 ## Known gotchas

--- a/wallet/rust-toolchain.toml
+++ b/wallet/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.88.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]

--- a/wallet/zuuallet/README.md
+++ b/wallet/zuuallet/README.md
@@ -6,7 +6,7 @@ A privacy-first desktop wallet for Zcash, built with Tauri v2, React, and librus
 
 ### Prerequisites
 
-- [Rust](https://rustup.rs/) 1.85.1+ (edition 2024)
+- [Rust](https://rustup.rs/) 1.88+ (edition 2024)
 - [Node.js](https://nodejs.org/) 18+
 - [Tauri CLI](https://tauri.app/start/): `cargo install tauri-cli`
 - Git submodules initialized: `git submodule update --init --recursive` (for `z/zcash/librustzcash`)

--- a/wallet/zuuallet/src-tauri/Cargo.toml
+++ b/wallet/zuuallet/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zuuallet"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.85.1"
+rust-version = "1.88"
 
 [lib]
 name = "zuuallet_lib"

--- a/wallet/zuuli/src-tauri/Cargo.toml
+++ b/wallet/zuuli/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zuuli"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.85.1"
+rust-version = "1.88"
 description = "ZUULI by 2Z Inc — Zcash-native wallet, AI, livestreaming and articles."
 
 [lib]


### PR DESCRIPTION
## Outcome

The stable required `gate` now proves the release-impacting ZUULI stack instead of reporting green after only frontend checks. It always reports for pull requests and merge groups, runs post-merge on `main`, supports manual verification, and safely skips heavy work only when a successful diff proves the change is unrelated.

## What changed

- Detects changes to `wallet/zuuli/**`, `wallet/plugins/**`, `wallet/rust-toolchain.toml`, the `z/zcash/librustzcash` gitlink, `.gitmodules`, and this workflow.
- Fails open into full verification when the comparison SHA or diff is unavailable; the aggregator also verifies the exact change-output/job-result pairing.
- Runs the frontend on Node 24 with locked install, bounded-retry high/critical audit, typecheck, and production build.
- Builds and tests the shared wallet plugin and ZUULI Tauri backend as separate locked Rust 1.88.0 graphs on Ubuntu 24.04 with their real system and submodule dependencies.
- Adds a shared exact wallet toolchain declaration and aligns the three wallet/plugin manifests and documentation with librustzcash's Rust 1.88 floor.
- Uses the current stable majors, `actions/checkout@v7` and `actions/setup-node@v7`, with Node 24; retains `Swatinem/rust-cache@v2` and the existing `dtolnay/rust-toolchain` baseline.
- Keeps the single stable `gate` context expected by branch protection.

Closes #228.

## Verification

- `actionlint` 1.7.12: clean
- `git diff --check`: clean
- Node `v24.17.0`: `npm ci`, `npm audit --audit-level=high`, `npm run typecheck`, and `npm run build`: pass (6 moderate, 0 high/critical)
- Rust `1.88.0`, freshly initialized pinned librustzcash:
  - plugin `cargo test --locked --all-targets`: pass (1 test)
  - ZUULI backend `cargo build --locked`: pass
  - ZUULI backend `cargo test --locked`: pass (test-target compile; currently 0 tests)
- The Rust checks were rerun after rebasing onto `origin/main@191557d` / mobile PR #232.

## Adversarial review 1 — verbatim

```text
# Adversarial review — `chore/228-zuuli-full-stack-gate`

## Verdict: **BLOCK** — 3 blockers, 5 medium, 4 low

The PR preserves the one thing it most easily could have broken: branch protection requires exactly `["gate"]` (verified via API, app_id 15368, `strict: true`), only `zuuli.yml` defines a `gate` job, and the PR adds `name:` to `rust_plugin`/`rust_app` but deliberately not to `gate`. The defects are in what the gate actually *proves*.

---

## Blockers

**1. The change filter fails CLOSED, producing a green `gate` with zero verification.** `zuuli.yml:60-72`. The header comment promises runs "fail open into the full test suite, never into an unverified skip." `set -euo pipefail` does **not** propagate failure out of a process substitution. Confirmed empirically in this repo — `git diff` against an unreachable SHA inside `< <(...)` leaves `zuuli=false` and exits 0, which skips all three heavy jobs and makes `gate` print *"All required jobs passed or were legitimately skipped."*
**Fix:** `if ! changed=$(git diff ...); then echo "zuuli=true" >> "$GITHUB_OUTPUT"; exit 0; fi` then iterate `<<< "$changed"`.

**2. `gate` never reads `needs.changes.outputs.zuuli`.** `zuuli.yml:193-219` inspects only `.result`, so it cannot distinguish a legitimate skip from a filter that emitted empty/wrong. Any `GITHUB_OUTPUT` write failure or future `case`-list typo yields three skips and a green required check. **Fix:** assert the pairing — if `zuuli == 'true'` every job must be `success`; reject any value that isn't literally `true`/`false`.

**3. Rust target-dir caching is completely broken — confirmed against action source.** Both jobs pass an absolute path as the rust-cache target. `Swatinem/rust-cache@v2` `src/config.ts:154-156`:
```js
let [root, target = "target"] = workspace.split("->").map((s) => s.trim());
root = path.resolve(root);
target = path.join(root, target);      // path.join does NOT reset on absolute
```
and `:283` `cachePaths.push(...workspaces.map(ws => ws.target))`. The cached path becomes `/…/wallet/zuuli/src-tauri/home/runner/work/zuu/zuu/target/zuuli-app` — never exists. Cargo writes to the real `CARGO_TARGET_DIR`, which is never saved or restored. **Every run is a cold compile**, and both manifests carry `[profile.dev.package."*"] opt-level = 3`, so halo2/orchard/sapling-crypto/bundled-rusqlite compile fully optimized from scratch on a 4-core runner under a 45-min cap — with `strict: true` forcing a rebase+rerun before each merge. **Fix:** drop `CARGO_TARGET_DIR` and use `workspaces: wallet/zuuli/src-tauri`. (`zuuallet.yml:78-104` has the same bug — pre-existing, but this PR promotes it into the *required* gate.)

## Medium

4. **`npm audit --audit-level=high` makes a required check non-deterministic** (`:95`) — live advisory DB, covers devDependencies, no retry. Verified current state is 6 moderate / 0 high (uuid <11.1.1 via `@cloudflare/realtimekit`), so the comment is accurate today; it's a time bomb. Use `--omit=dev`, `continue-on-error`, or a non-required job.
5. **`wallet/zuuli/rust-toolchain.toml` is untracked** (won't ship without `git add`) **and inert for CI** — rustup resolves from CWD upward, not `--manifest-path`; both Rust jobs run cargo from `$GITHUB_WORKSPACE`. It also doesn't cover the plugin or zuuallet, so #228's "toolchain exact and scoped to this release surface" is only partly met.
6. **`profile = "minimal"` strips clippy/rustfmt**, and `channel = "1.88.0"` diverges from upstream's `channel = "1.88"` + `components = ["clippy","rustfmt"]` (`z/zcash/librustzcash/rust-toolchain.toml`).
7. **`cargo check --all-targets` before `cargo test` doubles the plugin's cold build for zero coverage** — rmeta isn't reusable, and the plugin has no `examples/`/`benches/`/`tests/`; its only test is `src/wallet/keys.rs:291`.
8. **`wallet/zuuallet/src-tauri/Cargo.toml` still says `rust-version = "1.85.1"`** while depending on the now-1.88 plugin. The 1.88 bump itself is correct — `z/zcash/librustzcash/Cargo.toml:26` is `rust-version = "1.88"`.

## Low

9. `cargo test` on the app builds a test profile for zero tests (`lib.rs`/`main.rs`/`oauth.rs`, no `#[test]`).
10. Node 20→22 is unscoped drift; `zuuallet.yml` stays on 20.
11. All actions on mutable refs — limited blast radius under `contents: read`, but a required gate running on fork PRs is where SHA pinning pays.
12. `push`/`workflow_dispatch` concurrency collapses to `zuuli-refs/heads/main` with `cancel-in-progress`, so back-to-back merges cancel post-merge runs.

## Non-blocking — verified correct

Workflow-level `paths:` correctly absent; the always-runs + internal-filter + `always()`-aggregator shape is right. Submodule init of only `z/zcash/librustzcash` is sufficient (every path dep in both manifests points there). Filter globs are `case` patterns so `*` spans `/` — nested lockfiles and the gitlink path are covered. All-zeros `before` matches the regex but is caught by `git cat-file -e` → fails open, correct. `fetch-depth: 0` is cheap (8.44 MiB, 109 commits). `permissions: contents: read` with no escalation. Apt list correct for ubuntu-24.04; `keyring` v3 `linux-native` is linux-keyutils, no extra package needed. `--locked` is safe — `rust-version` isn't recorded in `Cargo.lock`.

**Follow-up issues, out of scope:** `zuuallet.yml` uses `on.pull_request.paths` with no `gate` job, so `wallet/zuuallet/**` has no required check at all; and there's no `clippy`/`fmt --check` anywhere in the gate.

Full writeup with fix snippets and a verification plan: `/Users/skyl/.claude/plans/you-are-the-independent-crispy-fog.md`
```

### Disposition

- Fixed blockers 1–3: captured/checked diff, exact output/result aggregation, and real workspace target caching.
- Kept the high/critical audit as an intentional security boundary and added a bounded three-attempt retry for transient registry/advisory failures.
- Moved the toolchain declaration to `wallet/`, added clippy/rustfmt, and staged it in the commit; CI's explicit `1.88.0` input remains binding.
- Removed the redundant plugin check, aligned Zuuallet's declared MSRV, kept Node 24, and made post-merge/manual concurrency unique. The initially requested Actions v6 baseline was superseded by live release verification and corrected to the current v7 majors in follow-up commit `9f33bd3`.
- Retained app `cargo test` as protection for future tests and test-target compilation. Action SHA pinning and broader Zuuallet modernization remain follow-up work.

## Final adversarial review — verbatim

```text
Nothing was modified. Review of the uncommitted diff vs `origin/main@191557d`:

---

**1. [OK] The git-diff failure path cannot produce a green skip.** `.github/workflows/zuuli.yml` has three fail-open branches, each `echo "zuuli=true" >> "$GITHUB_OUTPUT"; exit 0`: malformed/absent `BASE_SHA`, `git cat-file -e` miss, and `if ! changed_files=$(git diff --name-only --no-renames ...)`. `set -euo pipefail` is active, but both failure-capable commands sit in `if !` conditions so `-e` does not preempt the handler. `zuuli=false` is reachable only after a *successful* diff whose file list matched no case arm. Confirmed sound.

**2. [OK] The gate validates output/result pairing, not just "not failure".** `[ "$CHANGES_RESULT" = "success" ]` guards before the output is read; `expected` is derived from `ZUULI_CHANGED` with a `*)` catch-all that exits 1 on empty/garbage; then every one of `frontend`/`rust_plugin`/`rust_app` must equal `expected` **exactly**. So `skipped` when work was required fails, `success` when it should have skipped fails, and `cancelled`/`failure` fail in both modes. This is a genuine improvement over the old `results` loop, which passed on `skipped` unconditionally.

**3. [OK] Swatinem `workspaces` resolve to the real target dirs.** Neither `wallet/plugins/tauri-plugin-zcash/Cargo.toml` nor `wallet/zuuli/src-tauri/Cargo.toml` declares `[workspace]`; there is no ancestor manifest (no `Cargo.toml`, no `wallet/Cargo.toml`) and no in-repo `.cargo/config.toml`. Each package is therefore its own workspace root with default target dir `<manifest_dir>/target`, matching rust-cache's implicit `-> target`. Note this correctly *diverges* from `.github/workflows/zuuallet.yml:107` (`-> ${{ github.workspace }}/target`) — copying that form would have cached a nonexistent path. Distinct keys `zuuli-plugin` / `zuuli-app` keep the two lockfile graphs separate.

**4. [OK] Trigger/concurrency/stable-context semantics.** No `on.<event>.paths`, so the workflow — and `gate` — reports on every PR and merge_group; the required-check invariant holds. Group falls through `pull_request.number` → `merge_group.head_sha` → `run_id`, so push/`workflow_dispatch` runs get a unique group and `cancel-in-progress: true` can never cancel a main or manual build. `github.event.before` on a first/force push is 40 zeros: it passes `^[0-9a-f]{40}$` but fails `git cat-file -e` → fail-open. No other workflow defines a job named `gate` (zuuallet.yml has `frontend`/`rust`/`upstream-canary`), so the required context is unambiguous. `permissions: contents: read` suffices for checkout plus public submodule fetch.

**5. [OK] Action pins and Node 24.** Verified upstream: `actions/checkout` v6 exists (latest v7.0.1), `actions/setup-node` v6 exists (latest v7.0.0, v6.5.0 current), `Swatinem/rust-cache@v2` current at v2.9.1. Node 24 is supported by setup-node v6. `dtolnay/rust-toolchain@stable` + `toolchain: 1.88.0` is the documented override form and does pin exactly.

**6. [OK] Submodule scope is exactly right and the detector covers it.** Both Rust jobs init only `z/zcash/librustzcash`. That is provably sufficient: the plugin's eight path deps all live under `z/zcash/librustzcash/` (`Cargo.toml:50-57`), the app's only path dep is the plugin (`Cargo.toml:24`), librustzcash has no `[patch]` section and no nested `.gitmodules`. So non-recursive `--init` is complete, and the detector's `z/zcash/librustzcash` arm covers the only submodule that can affect the build.

**7. [MEDIUM] `wallet/rust-toolchain.toml` is inert for every documented invocation.** rustup resolves a toolchain file from the **CWD upward**, never from `--manifest-path`. Every documented command runs from the repo root (`wallet/plugins/tauri-plugin-zcash/CLAUDE.md:13`; the CI `run:` steps), and there is no root or `wallet/` Cargo.toml to change that — so the pin only applies if someone `cd`s into `wallet/` or deeper. Evidence: this checkout's active toolchain is `rustc 1.93.1`, not 1.88.0. *Disposition: non-blocking.* CI's binding pin is the explicit `dtolnay` `toolchain: 1.88.0`; the file is harmless documentation. Follow-up (separate PR): move it to the repo root, or document the `cd wallet` requirement.

**8. [MEDIUM] "Locally green" does not evidence the 1.88.0 claim — but the claim holds under independent check.** Because of finding 7, the local runs used 1.93.1, so they prove nothing about the MSRV. I verified it separately: `cargo +1.88.0 check --locked --all-targets` on the plugin passed resolution and reached compilation with no MSRV rejection, and a scan of both lockfiles (638 and 684 packages; 612/643 present in the local registry cache) found **zero** crates declaring `rust-version > 1.88.0`. `z/zcash/librustzcash/Cargo.toml:26` declares `rust-version = "1.88"`, so 1.88 is the correct floor and the bump from 1.85.1 is justified, not arbitrary. *Disposition: resolved by verification, not blocking.*

**9. [LOW] npm audit retry is shell-correct but couples the gate to an external DB.** Under GitHub's `bash -e {0}`, both `npm audit … && exit 0` and `[ "$attempt" -eq 3 ] && exit 1` are non-final commands in AND-lists, so `-e` does not fire early — the loop behaves as intended. However it cannot distinguish a registry outage from a real advisory: a genuine high finding costs 3 audits plus 15s of sleeps, and a newly-published advisory reddens every ZUULI PR with no lockfile change. *Disposition: accepted* — it matches the stated intent in the inline comment, the cost is bounded, and failing loud is the right bias for a gate.

**10. [LOW] Coverage gaps, all acknowledged or pre-existing.** (a) `wallet/zuuli/src-tauri` contains no `#[test]`/`#[cfg(test)]`, so its `cargo test` step is a test-target compile check and partly redundant with the preceding `cargo build` (shared target dir keeps it incremental). (b) `cargo test --all-targets` excludes doctests. (c) No clippy/rustfmt step despite `rust-toolchain.toml` installing both components, and `wallet/zuuli/package.json` still has only `dev/build/preview/typecheck/tauri` — the old comment documenting that absence was deleted. (d) `timeout-minutes: 45` on a cold librustzcash+Tauri build is untested; zuuallet.yml sets no job timeouts, so there is no precedent. *Disposition: all accepted; watch the first cold run for (d).*

**11. [LOW] Scope note, not a defect.** `wallet/plugins/*` now triggers the ZUULI gate, and the MSRV bump touches `wallet/zuuallet/`, whose workflow still uses checkout@v4 / setup-node@v4 / Node 20 / unpinned `@stable`. The shared plugin will therefore compile at exactly 1.88.0 under `zuuli.yml` and at whatever `stable` is that day under `zuuallet.yml`. *Disposition: acceptable divergence* — zuuallet modernization is separate work — but the 1.88.0 floor is only actually enforced on the ZUULI path.

---

Every item the request flagged for special verification checked out. The two MEDIUM findings are about *evidence quality*, not about a defect in the shipped artifact: the toolchain file is a no-op rather than wrong, and the MSRV claim it was meant to support is independently true.

BLOCKING: NO
VERDICT: APPROVE
```

### Final disposition

- Approved with no blocking findings.
- The shared `wallet/rust-toolchain.toml` applies whenever commands run from `wallet/` or a descendant; CI remains explicitly pinned regardless of working directory. Improving root-invocation ergonomics is follow-up work.
- Correction to finding 8: the validation recorded above explicitly used `cargo +1.88.0`; the full plugin and app build/test commands passed on that exact toolchain. The reviewer's separate dependency/MSRV scan independently corroborates the same result.
- The bounded live audit, current compile-only app test coverage, lack of clippy/fmt in this foundation gate, and Zuuallet workflow modernization are accepted follow-ups rather than hidden blockers.

## Focused Actions v7 compatibility review — verbatim

```text
## Adversarial CI review — `.github/workflows/zuuli.yml` (uncommitted)

Change surface: 5 lines, all `uses:` pins. `actions/checkout@v6→v7` ×4 (L35, L83, L118, L162), `actions/setup-node@v6→v7` ×1 (L85). Nothing else in the diff.

**Tag existence / stability** (verified live, not from memory)
- `actions/checkout`: `v7.0.0` (2026-07-14 era), `v7.0.1`; floating `v7` → `3d3c42e5aac5ba805825da76410c181273ba90b1` == `v7.0.1`. `prerelease=false draft=false`.
- `actions/setup-node`: `v7.0.0`; floating `v7` → `820762786026740c76f36085b0efc47a31fe5020` == `v7.0.0`. `prerelease=false draft=false`.
- v6 is *not* latest for either action; the bump is toward the current stable major.

**(1) checkout@v7 inputs** — fetched `action.yml@v7`. Input key set is identical to `v6`, all 21 keys, no removals (`allow-unsafe-pr-checkout` already existed in v6). `fetch-depth` present, `default: 1`, description unchanged: *"0 indicates all history for all branches and tags."* The workflow supplies only `fetch-depth: 0` (L38). Supported. ✅

**(2) setup-node@v7 inputs** — `node-version`, `cache` (*"Supported values: npm, yarn, pnpm"*), `cache-dependency-path` (*"path to a dependency file… supports wildcards or a list"*) all present and unchanged from v6; input set identical, v7 only *adds* outputs (`cache-primary-key`, `cache-matched-key`). `node-version: '24'`, `cache: npm`, `cache-dependency-path: wallet/zuuli/package-lock.json` all valid. ✅

**(3) Node runtime on ubuntu-latest** — zero delta: `runs.using` is `node24` in **both** v6 and v7 for both actions. The runner requirement is unchanged by this diff, and v6/node24 is already green on this repo (zuuli.yml runs on 2026-08-06, e.g. `31076262572` → changes/build/gate all success). ✅

**(4) Gate semantics** — diff touches no `name:`, `needs:`, `if:`, `outputs:`, `env:`, `concurrency:`, or the `gate` verification script. `gate` still `needs: [changes, frontend, rust_plugin, rust_app]` with `if: always()`; the success/skipped expectation logic (L212–231) is byte-identical. Branch-protection context name `gate` unchanged. ✅

**(5) Blocking issues — none.** Risks examined and cleared:
- checkout v7.0.0's headline behavior change (PR #2454) blocks fork-PR checkout under **`pull_request_target` / `workflow_run`**. This workflow triggers on `pull_request`, `merge_group`, `push`, `workflow_dispatch` only — not in scope. v7.0.0 additionally fired that check even with the default input; fixed in v7.0.1 (PR #2518), and floating `v7` resolves to v7.0.1, so the fix is what you get. Pinning to the v7.0.0 SHA specifically *would* be a hazard.
- setup-node v7.0.0 removed the dummy `NODE_AUTH_TOKEN` export; this job sets no `registry-url` and never reads that var. Unaffected.
- Both majors are ESM/dependency migrations — no user-facing input or output removals.

Non-blocking notes:
- **Unproven by CI yet**: in-flight run `31077718111` is for pushed commit `0aa8fde`, which still carries v6. The v7 pins get their first real execution only after this is committed and pushed.
- Repo now spans `checkout@v3` (ts-react-free2z, docs-about-free2z), `@v4` (zuuallet), `@v7` (zuuli). Out of scope for this diff, but the stale v3 pins are the real exposure.
- Floating major tags are mutable; consistent with existing repo convention (`Swatinem/rust-cache@v2`, `dtolnay/rust-toolchain@stable`), so not a regression.

BLOCKING: NO
VERDICT: APPROVE
```

### Actions v7 disposition

- Updated all four checkout steps to `actions/checkout@v7` and the frontend setup step to `actions/setup-node@v7`; Node remains pinned to `24`.
- `actionlint` 1.7.12 and `git diff --check` passed after the update.
- The focused independent review verified live tags, every supplied input, the Node 24 action runtime on `ubuntu-latest`, and unchanged stable-gate semantics. No blocker was found.
