### PR TITLE
fix(zuuli): secure mobile OAuth callbacks

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Test frontend contracts
+        run: npm run test
+
       - name: Build production frontend
         run: npm run build
 

--- a/docs/release/ZUULI-MOBILE-OAUTH.md
+++ b/docs/release/ZUULI-MOBILE-OAUTH.md
@@ -1,0 +1,83 @@
+# ZUULI mobile OAuth verification
+
+ZUULI uses the system browser for social OAuth on every native platform.
+Desktop captures the return on an ephemeral, nonce-bearing
+`http://127.0.0.1` listener. iOS and Android register exactly:
+
+```text
+cash.free2z.zuuli://oauth/callback
+```
+
+The app callback is a private-use URI following RFC 8252. Google no longer
+supports arbitrary private-scheme provider callbacks and X requires exact
+production HTTPS callbacks, so providers return first to the environment's
+exact Free2Z relay (production is
+`https://free2z.cash/api/auth/social/mobile/callback`). The relay atomically
+consumes a provider-only state, binds the code to a distinct app completion
+state, and redirects only to the compile-time URI above. It never accepts a
+destination from a request. Claimed HTTPS Universal Links / Android App Links
+remain the store-grade upgrade tracked in #242; they require the Apple Team ID
+and final Android signing-certificate fingerprints.
+
+The Free2Z capability contract is the release assertion, while
+`/api/auth/social/providers/` controls which sign-in buttons render. Safe
+defaults keep the capability false and the relay unset. Provider credentials do
+not by themselves enable the path: mobile `/start` fails closed while the relay
+is unset. Mobile accepts only X and Google after an operator completes the
+backend rollout checklist; their authorization URLs must contain PKCE S256.
+GitHub OAuth Apps do not offer PKCE and therefore remain desktop/web-only.
+
+The companion backend suppresses nginx logging for the exact relay and redacts
+the query from gunicorn/daphne records. Before enabling a provider, verify that
+load-balancer/CDN access logs also omit or redact query strings for
+`/api/auth/social/mobile/callback`; OAuth codes and states must not be retained
+at the edge.
+
+## Automated contract
+
+- Rust tests validate exact scheme + host + path, duplicate parameters,
+  malformed callbacks, session binding, ten-minute expiry, crash-safe
+  armed-to-received persistence, and the generated Tauri configuration.
+- Claim, resume, timeout, and cancellation are scoped to the random completion
+  state, so a stale cold-start waiter cannot consume or clear a newer flow.
+- TypeScript tests validate the provider authorization host/path allowlist,
+  exact redirect/state binding, app-generated PKCE S256, and one-way Knox token
+  binding. Only the challenge leaves the app before callback; an app that
+  intercepts the private-use URI cannot redeem the code without the verifier.
+- The tuzi companion change #903 exposes the one-destination HTTPS relay,
+  consumes provider callbacks exactly once, binds the returned code, accepts
+  only the canonical app URI for PKCE providers, and preserves the exact
+  desktop loopback shape. It does not enable a capability or provider.
+
+## Signed-device smoke test
+
+Run this against a non-production Free2Z environment with one Google or X OAuth
+client configured for that environment's exact HTTPS relay. Never register the
+private app URI with the provider, or put client secrets in the app/repository.
+
+1. Install a signed ZUULI build on one iOS 18+ device and one Android 10+
+   device. Confirm the package/bundle ID is `cash.free2z.zuuli`.
+2. With ZUULI signed out, tap the configured provider. Confirm Safari/Chrome,
+   not an embedded webview, opens the provider's HTTPS authorization page.
+3. Approve. Confirm the OS returns to ZUULI and exactly one Free2Z session is
+   created. Deliver the same callback URL again; confirm it is rejected and no
+   second exchange occurs.
+4. Start again, background ZUULI, then approve. Confirm the warm-start callback
+   finishes.
+5. Start again, force-quit ZUULI while the browser is open, then approve.
+   Confirm the callback cold-starts ZUULI and the persisted pending flow
+   finishes once.
+6. Start an account-link flow, change or clear the Knox session before approval,
+   then approve. Confirm the callback is rejected as a changed session and no
+   identity is linked to either account.
+7. Cancel at the provider. Confirm ZUULI reports cancellation and clears the
+   pending flow. Start another flow immediately and confirm it succeeds.
+8. Change the callback's state, host, path, duplicate `state`, duplicate `code`,
+   add a fragment, and replay an expired callback. Confirm every variant fails
+   closed without calling the code-exchange endpoint.
+9. Repeat a normal login on macOS/Linux and confirm desktop still uses only an
+   ephemeral `127.0.0.1` listener with a 32-hex-character path nonce.
+
+Record device/OS versions, signing identity fingerprints, provider, backend
+environment, app commit, backend commit, and screen recording in the release
+candidate issue. Do not paste codes, states, tokens, or provider secrets.

--- a/wallet/zuuli/CLAUDE.md
+++ b/wallet/zuuli/CLAUDE.md
@@ -107,3 +107,17 @@ This is why `npm run dev` in a browser shows a fully working app.
 - Real endpoints for Zcash login (`/api/auth/zcash/login/`) and pay-with-ZEC
   top-ups live in the free2z backend (`tuzi/py`). The client contract already
   targets them; mock mode stands in until they ship.
+
+## Social OAuth callbacks
+
+- Desktop uses an ephemeral RFC 8252 `http://127.0.0.1` listener with a random
+  path nonce. iOS/Android use exactly
+  `cash.free2z.zuuli://oauth/callback` through `tauri-plugin-deep-link`.
+- Never widen the mobile scheme/host/path, accept a callback without matching
+  local + backend state, or weaken PKCE S256 for a mobile provider. GitHub is
+  intentionally desktop/web-only until its provider path is PKCE-capable.
+- Pending mobile state is crash-safe and bound to login-vs-associate plus the
+  initiating Knox session digest. Every native claim/resume/cancel operation is
+  also scoped to its random completion state; never reintroduce an unscoped
+  cleanup that can delete a newer flow. See `docs/release/ZUULI-MOBILE-OAUTH.md`
+  for signed-device verification and the claimed-HTTPS upgrade gate.

--- a/wallet/zuuli/package-lock.json
+++ b/wallet/zuuli/package-lock.json
@@ -22,6 +22,7 @@
         "@radix-ui/react-tabs": "^1.1.1",
         "@radix-ui/react-tooltip": "^1.1.3",
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-deep-link": "^2.4.9",
         "@tauri-apps/plugin-http": "^2.5.9",
         "@tauri-apps/plugin-opener": "^2",
         "class-variance-authority": "^0.7.0",
@@ -54,7 +55,8 @@
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.6.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^3.2.7"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2525,6 +2527,14 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tauri-apps/plugin-deep-link": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-deep-link/-/plugin-deep-link-2.4.9.tgz",
+      "integrity": "sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-http": {
       "version": "2.5.9",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-http/-/plugin-http-2.5.9.tgz",
@@ -2588,6 +2598,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -2617,6 +2637,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2743,6 +2769,114 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.9.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
@@ -2799,6 +2933,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -2942,6 +3085,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2996,6 +3148,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -3034,6 +3202,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3731,6 +3908,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
@@ -3866,6 +4052,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -3974,6 +4166,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -4912,6 +5122,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4929,6 +5145,15 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-table": {
@@ -6626,6 +6851,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7661,6 +7901,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/sonner": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
@@ -7713,6 +7959,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -7726,6 +7984,24 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -7873,6 +8149,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -7919,6 +8207,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8470,6 +8785,28 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -8494,6 +8831,90 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -8571,6 +8992,22 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wicked-good-xpath": {

--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "tauri": "tauri"
   },
@@ -26,6 +27,7 @@
     "@radix-ui/react-tabs": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-http": "^2.5.9",
     "@tauri-apps/plugin-opener": "^2",
     "class-variance-authority": "^0.7.0",
@@ -43,10 +45,10 @@
     "remark-directive": "^3.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
-    "unist-util-visit": "^5.0.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
+    "unist-util-visit": "^5.0.0",
     "zustand": "^5.0.0"
   },
   "devDependencies": {
@@ -58,6 +60,7 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.6.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^3.2.7"
   }
 }

--- a/wallet/zuuli/src-tauri/Cargo.lock
+++ b/wallet/zuuli/src-tauri/Cargo.lock
@@ -793,6 +793,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1241,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2126,6 +2155,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2359,7 +2394,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -3445,6 +3480,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4329,6 +4374,16 @@ dependencies = [
  "smallvec",
  "time",
  "uuid",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -5345,6 +5400,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry 0.5.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-fs"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5647,6 +5723,15 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -6639,6 +6724,17 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
@@ -7604,14 +7700,17 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 name = "zuuli"
 version = "0.1.0"
 dependencies = [
+ "getrandom 0.3.4",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-http",
  "tauri-plugin-opener",
  "tauri-plugin-zcash",
  "tiny_http",
+ "url",
 ]
 
 [[package]]

--- a/wallet/zuuli/src-tauri/Cargo.toml
+++ b/wallet/zuuli/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-deep-link = "2.4.9"
 # Native HTTP client used by the frontend (@tauri-apps/plugin-http) to reach the
 # free2z backend without browser CORS — powers Login with Zcash and every API call.
 tauri-plugin-http = "2"
@@ -26,6 +27,8 @@ tauri-plugin-zcash = { path = "../../plugins/tauri-plugin-zcash" }
 # (RFC 8252) — binds 127.0.0.1, serves a single request, then shuts down. Kept
 # out of the shared tauri-plugin-zcash crate since it's ZUULI-specific.
 tiny_http = "0.12"
+url = "2"
+getrandom = "0.3"
 
 # ---------------------------------------------------------------------------
 # Build profiles. DO NOT DELETE — this is load-bearing for `tauri dev` usability.

--- a/wallet/zuuli/src-tauri/capabilities/mobile.json
+++ b/wallet/zuuli/src-tauri/capabilities/mobile.json
@@ -6,6 +6,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "deep-link:default",
     "opener:default",
     "zcash:default",
     {

--- a/wallet/zuuli/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/wallet/zuuli/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,18 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
+            <intent-filter >
+                <action android:name="android.intent.action.VIEW" />
+                <!-- ChromeOS ARC++ uses a different action for deep links -->
+                <action android:name="org.chromium.arc.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="cash.free2z.zuuli" />
+                <data android:host="oauth" />
+                <data android:path="/callback" />
+            </intent-filter>
+            <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
         </activity>
 
         <provider

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -46,5 +46,18 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSFaceIDUsageDescription</key>
+	<string>ZUULI uses Face ID to unlock your wallet seed for recovery and spending.</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>cash.free2z.zuuli</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>cash.free2z.zuuli</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/wallet/zuuli/src-tauri/src/lib.rs
+++ b/wallet/zuuli/src-tauri/src/lib.rs
@@ -4,6 +4,10 @@ mod oauth;
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        // RFC 8252 private-use redirect for iOS/Android social OAuth. The
+        // plugin registers only cash.free2z.zuuli://oauth/callback; oauth.rs
+        // independently validates the full URL, state and calling session.
+        .plugin(tauri_plugin_deep_link::init())
         // Native HTTP client the frontend uses (@tauri-apps/plugin-http) to call
         // the free2z API without browser CORS — required for Login with Zcash.
         .plugin(tauri_plugin_http::init())
@@ -16,9 +20,18 @@ pub fn run() {
         // until invoked; the frontend only calls these commands once the
         // backend reports a provider is configured.
         .manage(oauth::OauthLoopbackState::default())
+        .manage(oauth::OauthMobileState::default())
         .invoke_handler(tauri::generate_handler![
             oauth::oauth_loopback_start,
             oauth::oauth_loopback_wait,
+            oauth::oauth_loopback_cancel,
+            oauth::oauth_callback_transport,
+            oauth::oauth_mobile_arm,
+            oauth::oauth_mobile_pending,
+            oauth::oauth_mobile_claim,
+            oauth::oauth_mobile_resume,
+            oauth::oauth_mobile_finish,
+            oauth::oauth_mobile_cancel,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/wallet/zuuli/src-tauri/src/oauth.rs
+++ b/wallet/zuuli/src-tauri/src/oauth.rs
@@ -1,44 +1,48 @@
-//! Desktop OAuth transport for social login (X / Google / GitHub) — the
-//! RFC 8252 "loopback redirect" pattern. This module is ZUULI-specific (not
-//! part of the shared `tauri-plugin-zcash` crate) and owns exactly one thing:
-//! a local, single-use `127.0.0.1` HTTP listener that captures the
-//! authorization-code redirect from the system browser.
+//! OAuth callback transports for ZUULI social login.
 //!
-//! Everything else — asking the free2z backend which providers are
-//! configured, building `authorize_url`, opening the system browser, and
-//! POSTing the captured `{code, state}` back — is orchestrated by the
-//! frontend (`src/lib/oauth/transport.ts` / `src/lib/api/free2z.ts`). This
-//! keeps the Rust side dumb and small: bind loopback-only, accept ONE
-//! request, reply with a static page, and shut down.
+//! Desktop uses RFC 8252 loopback on an ephemeral `127.0.0.1` port. iOS and
+//! Android use the reverse-domain private-use redirect
+//! `cash.free2z.zuuli://oauth/callback`. The mobile redirect is deliberately
+//! exact: the OS registration, the Tauri deep-link configuration, this Rust
+//! parser, the TypeScript authorization response validator, and free2z's
+//! server-side allowlist all name the same scheme, host and path.
 //!
-//! Two commands, not one, because the frontend needs the bound PORT before it
-//! can ask the backend to build `authorize_url` (its `redirect_uri` bakes the
-//! port in), but must not block on that call — the actual wait for the
-//! provider's redirect only starts after the system browser has been opened:
-//!
-//!   1. [`oauth_loopback_start`] binds `127.0.0.1:0`, mints a random one-time
-//!      path nonce, and returns `{ port, redirect_path }` immediately.
-//!   2. [`oauth_loopback_wait`] blocks (up to a 5-minute timeout) for the ONE
-//!      inbound `GET /<nonce>?code=...&state=...`, replies with a minimal
-//!      "you can close this tab" page, and returns `{ code, state }`.
-//!
-//! The listener is bound to loopback only, serves exactly one request, and is
-//! dropped immediately after — nothing keeps listening once the round trip is
-//! done.
+//! On mobile the app owns the PKCE verifier; only its S256 challenge leaves the
+//! sandbox. Providers return to a fixed free2z HTTPS relay, which consumes a
+//! separate provider-facing state before redirecting to this private-use URI.
+//! The local completion state is additionally bound to provider,
+//! login-vs-associate mode, and the Knox session that initiated an association.
+//! Pending state is crash-safe so a cold-start callback can finish, and
+//! transitions to `received` before returning a code to the webview.
 
-use std::collections::HashMap;
-use std::hash::{BuildHasher, Hasher};
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use serde::Serialize;
-use tauri::State;
-use tiny_http::{Header, Response, Server};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager, Runtime, State};
+use tiny_http::{Header, Method, Response, Server, StatusCode};
+use url::Url;
 
-/// Holds the bound-but-not-yet-consumed loopback listener between the two
-/// commands below. `Default` gives us `None` with no `Server` required.
+pub const MOBILE_REDIRECT_URI: &str = "cash.free2z.zuuli://oauth/callback";
+const MOBILE_SCHEME: &str = "cash.free2z.zuuli";
+const MOBILE_HOST: &str = "oauth";
+const MOBILE_PATH: &str = "/callback";
+const OAUTH_TTL: Duration = Duration::from_secs(10 * 60);
+const LOOPBACK_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const MAX_CALLBACK_URL_BYTES: usize = 8 * 1024;
+const MAX_CODE_BYTES: usize = 4 * 1024;
+const MAX_STATE_BYTES: usize = 512;
+const PENDING_VERSION: u8 = 1;
+
 #[derive(Default)]
 pub struct OauthLoopbackState(Mutex<Option<(Server, String)>>);
+
+/// Serializes every read/transition/write of the crash-safe mobile record.
+#[derive(Default)]
+pub struct OauthMobileState(Mutex<()>);
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -48,9 +52,100 @@ pub struct LoopbackStart {
 }
 
 #[derive(Serialize)]
-pub struct LoopbackResult {
+pub struct OauthCapture {
     code: String,
     state: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MobileArmArgs {
+    provider: String,
+    state: String,
+    associate: bool,
+    session_binding: String,
+    code_verifier: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MobileClaimSessionArgs {
+    session_binding: String,
+    expected_state: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MobileClaimArgs {
+    callback_url: String,
+    session_binding: String,
+    expected_state: String,
+}
+
+#[derive(Deserialize)]
+pub struct MobileFinishArgs {
+    state: String,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PendingMobileOauth {
+    version: u8,
+    provider: String,
+    state: String,
+    redirect_uri: String,
+    associate: bool,
+    session_binding: String,
+    code_verifier: String,
+    created_at_unix_ms: u64,
+    phase: PendingPhase,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum PendingPhase {
+    Armed,
+    Received { code: String },
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MobilePendingSummary {
+    provider: String,
+    associate: bool,
+    phase: &'static str,
+    state: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MobileCapture {
+    provider: String,
+    associate: bool,
+    code: String,
+    state: String,
+    redirect_uri: String,
+    code_verifier: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case", tag = "status")]
+pub enum MobileClaimResult {
+    Ignored,
+    Captured { capture: MobileCapture },
+    Rejected { message: String },
+    Cancelled { message: String },
+}
+
+enum ParsedCallback {
+    Code { code: String, state: String },
+    Error { state: String },
+}
+
+enum PendingAction {
+    Keep(MobileClaimResult),
+    Save(MobileClaimResult),
+    Remove(MobileClaimResult),
 }
 
 const SUCCESS_HTML: &str = r#"<!doctype html><html><head><meta charset="utf-8"><title>ZUULI</title></head>
@@ -63,170 +158,800 @@ const INCOMPLETE_HTML: &str = r#"<!doctype html><html><head><meta charset="utf-8
 <div><h2>Sign-in didn't complete</h2><p style="color:#999">Return to ZUULI and try again.</p></div>
 </body></html>"#;
 
-/// A zero-dependency source of randomness for the one-time path nonce.
-/// `std::collections::hash_map::RandomState` seeds its SipHash keys from the
-/// OS RNG (the same entropy `HashMap` relies on to resist hash-flooding), so
-/// hashing a counter with a fresh `RandomState` yields OS-derived bits without
-/// pulling in a `rand` crate. The nonce only needs to resist another local
-/// process guessing the path during the few-minute window the listener is
-/// open — not survive a cryptographic attacker — so this is a good fit.
-fn random_hex(bytes: usize) -> String {
-    let mut out = String::with_capacity(bytes * 2);
-    let mut counter: u64 = 0;
-    while out.len() < bytes * 2 {
-        let mut hasher = std::collections::hash_map::RandomState::new().build_hasher();
-        hasher.write_u64(counter);
-        hasher.write_u64(Instant::now().elapsed().as_nanos() as u64);
-        out.push_str(&format!("{:016x}", hasher.finish()));
-        counter = counter.wrapping_add(1);
-    }
-    out.truncate(bytes * 2);
-    out
+fn random_hex(bytes: usize) -> Result<String, String> {
+    let mut random = vec![0_u8; bytes];
+    getrandom::fill(&mut random).map_err(|e| format!("OS randomness unavailable: {e}"))?;
+    Ok(random.iter().map(|byte| format!("{byte:02x}")).collect())
 }
 
-/// Percent-decode a query-string value (`application/x-www-form-urlencoded`
-/// style: `+` is a space). Hand-rolled to avoid a dependency for something
-/// this small; OAuth `code`/`state` values are short opaque tokens.
-fn percent_decode(s: &str) -> String {
-    let bytes = s.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'%' if i + 2 < bytes.len() => {
-                if let Ok(byte) = u8::from_str_radix(
-                    std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or(""),
-                    16,
-                ) {
-                    out.push(byte);
-                    i += 3;
-                    continue;
-                }
-                out.push(bytes[i]);
-                i += 1;
-            }
-            b'+' => {
-                out.push(b' ');
-                i += 1;
-            }
-            b => {
-                out.push(b);
-                i += 1;
-            }
-        }
+fn single_query(url: &Url, name: &str) -> Result<Option<String>, String> {
+    let values = url
+        .query_pairs()
+        .filter(|(key, _)| key == name)
+        .map(|(_, value)| value.into_owned())
+        .collect::<Vec<_>>();
+    match values.as_slice() {
+        [] => Ok(None),
+        [value] => Ok(Some(value.clone())),
+        _ => Err(format!("OAuth callback repeated `{name}`")),
     }
-    String::from_utf8_lossy(&out).into_owned()
 }
 
-/// Parse the query string off a raw request target (`/<nonce>?a=b&c=d`).
-fn parse_query(target: &str) -> HashMap<String, String> {
-    let mut map = HashMap::new();
-    if let Some((_, q)) = target.split_once('?') {
-        for pair in q.split('&') {
-            if let Some((k, v)) = pair.split_once('=') {
-                map.insert(percent_decode(k), percent_decode(v));
-            } else if !pair.is_empty() {
-                map.insert(percent_decode(pair), String::new());
-            }
-        }
+fn parse_callback(url: &Url) -> Result<ParsedCallback, String> {
+    let state = single_query(url, "state")?
+        .filter(|value| !value.is_empty() && value.len() <= MAX_STATE_BYTES)
+        .ok_or_else(|| "OAuth callback is missing a valid `state`".to_string())?;
+    let code = single_query(url, "code")?;
+    let error = single_query(url, "error")?;
+    if code.is_some() == error.is_some() {
+        return Err("OAuth callback must contain exactly one of `code` or `error`".to_string());
     }
-    map
+    if let Some(code) = code {
+        if code.is_empty() || code.len() > MAX_CODE_BYTES {
+            return Err("OAuth callback contains an invalid authorization code".to_string());
+        }
+        Ok(ParsedCallback::Code { code, state })
+    } else {
+        Ok(ParsedCallback::Error { state })
+    }
 }
 
 fn html_response(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
-    let header = Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..])
-        .expect("static header is valid ASCII");
-    Response::from_string(body).with_header(header)
+    let headers = [
+        ("Content-Type", "text/html; charset=utf-8"),
+        ("Cache-Control", "no-store"),
+        (
+            "Content-Security-Policy",
+            "default-src 'none'; style-src 'unsafe-inline'",
+        ),
+        ("X-Content-Type-Options", "nosniff"),
+    ];
+    headers
+        .into_iter()
+        .fold(Response::from_string(body), |response, (name, value)| {
+            response.with_header(
+                Header::from_bytes(name.as_bytes(), value.as_bytes())
+                    .expect("static OAuth response header is valid ASCII"),
+            )
+        })
 }
 
-/// Bind an ephemeral loopback listener and return its port + a random
-/// one-time path nonce the caller must include in `redirect_uri`.
+fn valid_mobile_provider(provider: &str) -> bool {
+    matches!(provider, "x" | "google")
+}
+
+fn valid_state(state: &str) -> bool {
+    (16..=MAX_STATE_BYTES).contains(&state.len())
+        && state
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() && byte != b'"' && byte != b'\\')
+}
+
+fn valid_session_binding(binding: &str, associate: bool) -> bool {
+    if !associate {
+        return binding == "login:none";
+    }
+    binding
+        .strip_prefix("associate:")
+        .is_some_and(|digest| digest.len() == 64 && digest.bytes().all(|b| b.is_ascii_hexdigit()))
+}
+
+fn valid_pkce_verifier(verifier: &str) -> bool {
+    verifier.len() == 43
+        && verifier
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+fn now_unix_ms() -> Result<u64, String> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| "system clock is before the Unix epoch".to_string())?
+        .as_millis();
+    u64::try_from(millis).map_err(|_| "system clock value is out of range".to_string())
+}
+
+fn is_expired(pending: &PendingMobileOauth, now_ms: u64) -> bool {
+    now_ms.saturating_sub(pending.created_at_unix_ms)
+        >= u64::try_from(OAUTH_TTL.as_millis()).expect("OAuth TTL fits u64")
+}
+
+fn pending_path<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
+    app.path()
+        .app_data_dir()
+        .map(|dir| dir.join("oauth").join("pending-v1.json"))
+        .map_err(|e| format!("cannot resolve OAuth state directory: {e}"))
+}
+
+fn load_pending(path: &Path) -> Result<Option<PendingMobileOauth>, String> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("cannot read OAuth pending state: {error}")),
+    };
+    if file
+        .metadata()
+        .map_err(|e| format!("cannot inspect OAuth pending state: {e}"))?
+        .len()
+        > 16 * 1024
+    {
+        return Err("OAuth pending state is unexpectedly large".to_string());
+    }
+    let pending: PendingMobileOauth = serde_json::from_reader(BufReader::new(file))
+        .map_err(|_| "OAuth pending state is corrupt".to_string())?;
+    if pending.version != PENDING_VERSION
+        || !valid_mobile_provider(&pending.provider)
+        || !valid_state(&pending.state)
+        || pending.redirect_uri != MOBILE_REDIRECT_URI
+        || !valid_session_binding(&pending.session_binding, pending.associate)
+        || !valid_pkce_verifier(&pending.code_verifier)
+    {
+        return Err("OAuth pending state failed validation".to_string());
+    }
+    Ok(Some(pending))
+}
+
+fn save_pending(path: &Path, pending: &PendingMobileOauth) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "OAuth pending state path has no parent".to_string())?;
+    fs::create_dir_all(parent).map_err(|e| format!("cannot create OAuth state directory: {e}"))?;
+    let temp = path.with_extension(format!("tmp-{}", std::process::id()));
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&temp)
+        .map_err(|e| format!("cannot create OAuth pending state: {e}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&temp, fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("cannot secure OAuth pending state: {e}"))?;
+    }
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer(&mut writer, pending)
+        .map_err(|e| format!("cannot encode OAuth pending state: {e}"))?;
+    writer
+        .flush()
+        .map_err(|e| format!("cannot flush OAuth pending state: {e}"))?;
+    writer
+        .get_ref()
+        .sync_all()
+        .map_err(|e| format!("cannot persist OAuth pending state: {e}"))?;
+    drop(writer);
+
+    #[cfg(not(windows))]
+    {
+        // POSIX rename-over-existing is atomic. This is the crash-safety
+        // guarantee for iOS, Android, macOS and Linux.
+        if let Err(error) = fs::rename(&temp, path) {
+            let _ = fs::remove_file(&temp);
+            return Err(format!("cannot install OAuth pending state: {error}"));
+        }
+        Ok(())
+    }
+    #[cfg(windows)]
+    {
+        // Windows rename cannot overwrite. The mobile commands are unreachable
+        // there, but keep the persistence helper correct for its unit tests and
+        // for any future transport reuse.
+        let backup = path.with_extension("backup");
+        let _ = fs::remove_file(&backup);
+        let had_existing = path.exists();
+        if had_existing {
+            fs::rename(path, &backup)
+                .map_err(|e| format!("cannot stage old OAuth pending state: {e}"))?;
+        }
+        if let Err(error) = fs::rename(&temp, path) {
+            if had_existing {
+                let _ = fs::rename(&backup, path);
+            }
+            let _ = fs::remove_file(&temp);
+            return Err(format!("cannot install OAuth pending state: {error}"));
+        }
+        if had_existing {
+            let _ = fs::remove_file(backup);
+        }
+        Ok(())
+    }
+}
+
+fn remove_pending(path: &Path) -> Result<(), String> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("cannot clear OAuth pending state: {error}")),
+    }
+}
+
+fn pending_matches_state(pending: &PendingMobileOauth, expected_state: &str) -> bool {
+    pending.state == expected_state
+}
+
+fn capture_from_pending(pending: &PendingMobileOauth, code: String) -> MobileCapture {
+    MobileCapture {
+        provider: pending.provider.clone(),
+        associate: pending.associate,
+        code,
+        state: pending.state.clone(),
+        redirect_uri: pending.redirect_uri.clone(),
+        code_verifier: pending.code_verifier.clone(),
+    }
+}
+
+fn validate_mobile_target(url: &Url) -> bool {
+    url.scheme() == MOBILE_SCHEME
+        && url.host_str() == Some(MOBILE_HOST)
+        && url.path() == MOBILE_PATH
+        && url.port().is_none()
+        && url.username().is_empty()
+        && url.password().is_none()
+        && url.fragment().is_none()
+}
+
+fn evaluate_mobile_claim(
+    pending: &mut PendingMobileOauth,
+    callback_url: &str,
+    session_binding: &str,
+) -> PendingAction {
+    if pending.session_binding != session_binding {
+        return PendingAction::Remove(MobileClaimResult::Rejected {
+            message: "The account session changed while sign-in was open. Start again.".to_string(),
+        });
+    }
+    if matches!(pending.phase, PendingPhase::Received { .. })
+        || callback_url.len() > MAX_CALLBACK_URL_BYTES
+    {
+        return PendingAction::Keep(MobileClaimResult::Ignored);
+    }
+    let url = match Url::parse(callback_url) {
+        Ok(url) if validate_mobile_target(&url) => url,
+        _ => return PendingAction::Keep(MobileClaimResult::Ignored),
+    };
+    let parsed = match parse_callback(&url) {
+        Ok(parsed) => parsed,
+        Err(message) => {
+            if single_query(&url, "state").ok().flatten().as_deref() == Some(&pending.state) {
+                return PendingAction::Remove(MobileClaimResult::Rejected { message });
+            }
+            return PendingAction::Keep(MobileClaimResult::Ignored);
+        }
+    };
+    let callback_state = match &parsed {
+        ParsedCallback::Code { state, .. } | ParsedCallback::Error { state } => state,
+    };
+    if callback_state != &pending.state {
+        return PendingAction::Keep(MobileClaimResult::Ignored);
+    }
+    match parsed {
+        ParsedCallback::Error { .. } => PendingAction::Remove(MobileClaimResult::Cancelled {
+            message: "Sign-in was cancelled.".to_string(),
+        }),
+        ParsedCallback::Code { code, .. } => {
+            let capture = capture_from_pending(pending, code.clone());
+            pending.phase = PendingPhase::Received { code };
+            PendingAction::Save(MobileClaimResult::Captured { capture })
+        }
+    }
+}
+
+/// Desktop vs mobile selection without user-agent sniffing.
+#[tauri::command]
+pub fn oauth_callback_transport() -> &'static str {
+    if cfg!(mobile) {
+        "mobile"
+    } else {
+        "desktop"
+    }
+}
+
 #[tauri::command]
 pub async fn oauth_loopback_start(
     state: State<'_, OauthLoopbackState>,
 ) -> Result<LoopbackStart, String> {
-    let nonce = random_hex(16);
+    if cfg!(mobile) {
+        return Err("desktop OAuth loopback is unavailable on mobile".to_string());
+    }
+    let nonce = random_hex(16)?;
     let server = tauri::async_runtime::spawn_blocking(|| {
-        // 127.0.0.1 only (never 0.0.0.0) — this must not be reachable off the
-        // machine. Port 0 asks the OS for any free ephemeral port.
         Server::http("127.0.0.1:0").map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| e.to_string())??;
-
-    let port = match server.server_addr().to_ip() {
-        Some(addr) => addr.port(),
-        None => return Err("loopback listener bound to a non-IP address".to_string()),
-    };
-
-    let mut guard = state
+    let port = server
+        .server_addr()
+        .to_ip()
+        .map(|addr| addr.port())
+        .ok_or_else(|| "loopback listener bound to a non-IP address".to_string())?;
+    *state
         .0
         .lock()
-        .map_err(|_| "oauth loopback state lock poisoned".to_string())?;
-    *guard = Some((server, nonce.clone()));
-
+        .map_err(|_| "OAuth loopback state lock poisoned".to_string())? =
+        Some((server, nonce.clone()));
     Ok(LoopbackStart {
         port,
         redirect_path: nonce,
     })
 }
 
-/// Wait (up to 5 minutes) for the single provider redirect to
-/// `http://127.0.0.1:<port>/<redirect_path>?code=...&state=...`, reply with a
-/// static "you can close this tab" page, and return the captured values. The
-/// listener is consumed and dropped (closed) by this call either way.
 #[tauri::command]
 pub async fn oauth_loopback_wait(
     state: State<'_, OauthLoopbackState>,
-) -> Result<LoopbackResult, String> {
+    expected_state: String,
+) -> Result<OauthCapture, String> {
+    if !valid_state(&expected_state) {
+        return Err("free2z returned an invalid OAuth state".to_string());
+    }
     let (server, nonce) = state
         .0
         .lock()
-        .map_err(|_| "oauth loopback state lock poisoned".to_string())?
+        .map_err(|_| "OAuth loopback state lock poisoned".to_string())?
         .take()
-        .ok_or_else(|| {
-            "no loopback listener is active — call oauth_loopback_start first".to_string()
-        })?;
+        .ok_or_else(|| "no OAuth loopback listener is active".to_string())?;
 
     tauri::async_runtime::spawn_blocking(move || {
-        let deadline = Instant::now() + Duration::from_secs(5 * 60);
-        let expected_prefix = format!("/{nonce}");
+        let deadline = Instant::now() + LOOPBACK_TIMEOUT;
+        let expected_path = format!("/{nonce}");
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return Err("timed out waiting for the OAuth redirect".to_string());
             }
             let request = match server.recv_timeout(remaining) {
-                Ok(Some(req)) => req,
-                Ok(None) => continue, // recv_timeout's own tick elapsed; recheck our deadline
-                Err(e) => return Err(format!("loopback listener error: {e}")),
+                Ok(Some(request)) => request,
+                Ok(None) => continue,
+                Err(error) => return Err(format!("OAuth loopback listener error: {error}")),
             };
-
-            let target = request.url().to_string();
-            if !target.starts_with(&expected_prefix) {
-                // Not our nonce path (stray probe, favicon request, etc.) —
-                // answer politely and keep waiting for the real redirect.
-                let _ = request.respond(Response::from_string("Not found").with_status_code(
-                    tiny_http::StatusCode(404),
-                ));
+            if request.method() != &Method::Get {
+                let _ = request.respond(
+                    Response::from_string("Method not allowed").with_status_code(StatusCode(405)),
+                );
                 continue;
             }
-
-            let params = parse_query(&target);
-            let code = params.get("code").cloned();
-            let oauth_state = params.get("state").cloned();
-            let _ = request.respond(html_response(if code.is_some() && oauth_state.is_some() {
-                SUCCESS_HTML
-            } else {
-                INCOMPLETE_HTML
-            }));
-
-            return match (code, oauth_state) {
-                (Some(code), Some(state)) => Ok(LoopbackResult { code, state }),
-                _ => Err("the provider redirect was missing `code` or `state`".to_string()),
+            let target = request.url();
+            if target.len() > MAX_CALLBACK_URL_BYTES {
+                let _ = request.respond(
+                    Response::from_string("Request too large").with_status_code(StatusCode(414)),
+                );
+                continue;
+            }
+            let url = match Url::parse(&format!("http://127.0.0.1{target}")) {
+                Ok(url) if url.path() == expected_path && url.fragment().is_none() => url,
+                _ => {
+                    let _ = request.respond(
+                        Response::from_string("Not found").with_status_code(StatusCode(404)),
+                    );
+                    continue;
+                }
             };
+            let parsed = match parse_callback(&url) {
+                Ok(parsed) => parsed,
+                Err(_) => {
+                    let _ = request.respond(html_response(INCOMPLETE_HTML));
+                    continue;
+                }
+            };
+            match parsed {
+                ParsedCallback::Code { code, state } if state == expected_state => {
+                    let _ = request.respond(html_response(SUCCESS_HTML));
+                    return Ok(OauthCapture { code, state });
+                }
+                ParsedCallback::Error { state } if state == expected_state => {
+                    let _ = request.respond(html_response(INCOMPLETE_HTML));
+                    return Err("Sign-in was cancelled.".to_string());
+                }
+                _ => {
+                    // A local process that did not know the backend-minted
+                    // state cannot consume the listener. Keep waiting.
+                    let _ = request.respond(html_response(INCOMPLETE_HTML));
+                }
+            }
         }
     })
     .await
     .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub fn oauth_loopback_cancel(state: State<'_, OauthLoopbackState>) -> Result<(), String> {
+    state
+        .0
+        .lock()
+        .map_err(|_| "OAuth loopback state lock poisoned".to_string())?
+        .take();
+    Ok(())
+}
+
+#[tauri::command]
+pub fn oauth_mobile_arm<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, OauthMobileState>,
+    args: MobileArmArgs,
+) -> Result<(), String> {
+    if !cfg!(mobile) {
+        return Err("mobile OAuth callback is unavailable on desktop".to_string());
+    }
+    if !valid_mobile_provider(&args.provider)
+        || !valid_state(&args.state)
+        || !valid_session_binding(&args.session_binding, args.associate)
+        || !valid_pkce_verifier(&args.code_verifier)
+    {
+        return Err("invalid mobile OAuth pending state".to_string());
+    }
+    let _guard = state
+        .0
+        .lock()
+        .map_err(|_| "OAuth mobile state lock poisoned".to_string())?;
+    save_pending(
+        &pending_path(&app)?,
+        &PendingMobileOauth {
+            version: PENDING_VERSION,
+            provider: args.provider,
+            state: args.state,
+            redirect_uri: MOBILE_REDIRECT_URI.to_string(),
+            associate: args.associate,
+            session_binding: args.session_binding,
+            code_verifier: args.code_verifier,
+            created_at_unix_ms: now_unix_ms()?,
+            phase: PendingPhase::Armed,
+        },
+    )
+}
+
+fn load_fresh_pending(path: &Path) -> Result<Option<PendingMobileOauth>, String> {
+    match load_pending(path) {
+        Ok(Some(pending)) if is_expired(&pending, now_unix_ms()?) => {
+            remove_pending(path)?;
+            Ok(None)
+        }
+        Ok(value) => Ok(value),
+        Err(error) => {
+            // Corrupt or invalid state is never recoverable and must not keep
+            // surprising every app launch.
+            let _ = remove_pending(path);
+            Err(error)
+        }
+    }
+}
+
+#[tauri::command]
+pub fn oauth_mobile_pending<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, OauthMobileState>,
+) -> Result<Option<MobilePendingSummary>, String> {
+    if !cfg!(mobile) {
+        return Ok(None);
+    }
+    let _guard = state
+        .0
+        .lock()
+        .map_err(|_| "OAuth mobile state lock poisoned".to_string())?;
+    Ok(
+        load_fresh_pending(&pending_path(&app)?)?.map(|pending| MobilePendingSummary {
+            provider: pending.provider,
+            associate: pending.associate,
+            state: pending.state,
+            phase: match pending.phase {
+                PendingPhase::Armed => "armed",
+                PendingPhase::Received { .. } => "received",
+            },
+        }),
+    )
+}
+
+#[tauri::command]
+pub fn oauth_mobile_claim<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, OauthMobileState>,
+    args: MobileClaimArgs,
+) -> Result<MobileClaimResult, String> {
+    if !cfg!(mobile) {
+        return Err("mobile OAuth callback is unavailable on desktop".to_string());
+    }
+    if !valid_state(&args.expected_state) {
+        return Err("invalid expected mobile OAuth state".to_string());
+    }
+    let _guard = state
+        .0
+        .lock()
+        .map_err(|_| "OAuth mobile state lock poisoned".to_string())?;
+    let path = pending_path(&app)?;
+    let Some(mut pending) = load_fresh_pending(&path)? else {
+        return Ok(MobileClaimResult::Ignored);
+    };
+    if !pending_matches_state(&pending, &args.expected_state) {
+        return Ok(MobileClaimResult::Ignored);
+    }
+    match evaluate_mobile_claim(&mut pending, &args.callback_url, &args.session_binding) {
+        PendingAction::Keep(result) => Ok(result),
+        PendingAction::Save(result) => {
+            save_pending(&path, &pending)?;
+            Ok(result)
+        }
+        PendingAction::Remove(result) => {
+            remove_pending(&path)?;
+            Ok(result)
+        }
+    }
+}
+
+#[tauri::command]
+pub fn oauth_mobile_resume<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, OauthMobileState>,
+    args: MobileClaimSessionArgs,
+) -> Result<MobileClaimResult, String> {
+    if !cfg!(mobile) {
+        return Ok(MobileClaimResult::Ignored);
+    }
+    let _guard = state
+        .0
+        .lock()
+        .map_err(|_| "OAuth mobile state lock poisoned".to_string())?;
+    let path = pending_path(&app)?;
+    let Some(pending) = load_fresh_pending(&path)? else {
+        return Ok(MobileClaimResult::Ignored);
+    };
+    if !pending_matches_state(&pending, &args.expected_state) {
+        return Ok(MobileClaimResult::Ignored);
+    }
+    if pending.session_binding != args.session_binding {
+        remove_pending(&path)?;
+        return Ok(MobileClaimResult::Rejected {
+            message: "The account session changed while sign-in was open. Start again.".to_string(),
+        });
+    }
+    match &pending.phase {
+        PendingPhase::Armed => Ok(MobileClaimResult::Ignored),
+        PendingPhase::Received { code } => Ok(MobileClaimResult::Captured {
+            capture: capture_from_pending(&pending, code.clone()),
+        }),
+    }
+}
+
+#[tauri::command]
+pub fn oauth_mobile_finish<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, OauthMobileState>,
+    args: MobileFinishArgs,
+) -> Result<(), String> {
+    if !cfg!(mobile) {
+        return Err("mobile OAuth callback is unavailable on desktop".to_string());
+    }
+    let _guard = state
+        .0
+        .lock()
+        .map_err(|_| "OAuth mobile state lock poisoned".to_string())?;
+    let path = pending_path(&app)?;
+    if let Some(pending) = load_pending(&path)? {
+        if pending.state != args.state || !matches!(pending.phase, PendingPhase::Received { .. }) {
+            return Err("OAuth completion does not match the pending callback".to_string());
+        }
+    }
+    remove_pending(&path)
+}
+
+#[tauri::command]
+pub fn oauth_mobile_cancel<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, OauthMobileState>,
+    args: MobileFinishArgs,
+) -> Result<(), String> {
+    if !cfg!(mobile) {
+        return Err("mobile OAuth callback is unavailable on desktop".to_string());
+    }
+    let _guard = state
+        .0
+        .lock()
+        .map_err(|_| "OAuth mobile state lock poisoned".to_string())?;
+    let path = pending_path(&app)?;
+    if load_pending(&path)?.is_some_and(|pending| pending_matches_state(&pending, &args.state)) {
+        remove_pending(&path)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pending() -> PendingMobileOauth {
+        PendingMobileOauth {
+            version: PENDING_VERSION,
+            provider: "google".to_string(),
+            state: "abcdefghijklmnopqrstuvwxyz012345".to_string(),
+            redirect_uri: MOBILE_REDIRECT_URI.to_string(),
+            associate: false,
+            session_binding: "login:none".to_string(),
+            code_verifier: "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG".to_string(),
+            created_at_unix_ms: 1_000,
+            phase: PendingPhase::Armed,
+        }
+    }
+
+    #[test]
+    fn mobile_target_is_exact() {
+        assert!(validate_mobile_target(
+            &Url::parse(MOBILE_REDIRECT_URI).unwrap()
+        ));
+        for bad in [
+            "cash.free2z.zuuli://evil/callback",
+            "cash.free2z.zuuli://oauth/callback/extra",
+            "cash.free2z.zuuli://oauth:99/callback",
+            "cash.free2z.zuuli://oauth/callback#code=x",
+            "other://oauth/callback",
+        ] {
+            assert!(!validate_mobile_target(&Url::parse(bad).unwrap()), "{bad}");
+        }
+    }
+
+    #[test]
+    fn callback_requires_single_code_or_error_and_single_state() {
+        let state = &pending().state;
+        let good = Url::parse(&format!("{MOBILE_REDIRECT_URI}?code=abc&state={state}")).unwrap();
+        assert!(matches!(
+            parse_callback(&good),
+            Ok(ParsedCallback::Code { .. })
+        ));
+        for bad in [
+            format!("{MOBILE_REDIRECT_URI}?code=a&code=b&state={state}"),
+            format!("{MOBILE_REDIRECT_URI}?code=a&state={state}&state={state}"),
+            format!("{MOBILE_REDIRECT_URI}?code=a&error=denied&state={state}"),
+            format!("{MOBILE_REDIRECT_URI}?state={state}"),
+        ] {
+            assert!(parse_callback(&Url::parse(&bad).unwrap()).is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn session_binding_is_mode_specific() {
+        assert!(valid_session_binding("login:none", false));
+        assert!(!valid_session_binding("login:none", true));
+        assert!(valid_session_binding(
+            &format!("associate:{}", "a".repeat(64)),
+            true
+        ));
+        assert!(!valid_session_binding(
+            &format!("associate:{}", "g".repeat(64)),
+            true
+        ));
+    }
+
+    #[test]
+    fn mobile_provider_and_pending_generation_are_strict() {
+        assert!(valid_mobile_provider("google"));
+        assert!(valid_mobile_provider("x"));
+        assert!(!valid_mobile_provider("github"));
+
+        let value = pending();
+        assert!(pending_matches_state(&value, &value.state));
+        assert!(!pending_matches_state(
+            &value,
+            "new-flow-state-abcdefghijklmnopqrstuvwxyz",
+        ));
+    }
+
+    #[test]
+    fn expiry_is_bounded_to_backend_ttl() {
+        let value = pending();
+        assert!(!is_expired(&value, 600_999));
+        assert!(is_expired(&value, 601_000));
+    }
+
+    #[test]
+    fn pending_round_trip_preserves_received_transition() {
+        let dir = std::env::temp_dir().join(format!("zuuli-oauth-test-{}", random_hex(8).unwrap()));
+        let path = dir.join("pending.json");
+        let mut value = pending();
+        save_pending(&path, &value).unwrap();
+        assert!(matches!(
+            load_pending(&path).unwrap().unwrap().phase,
+            PendingPhase::Armed
+        ));
+        value.phase = PendingPhase::Received {
+            code: "one-shot-code".to_string(),
+        };
+        save_pending(&path, &value).unwrap();
+        let loaded = load_pending(&path).unwrap().unwrap();
+        assert!(
+            matches!(loaded.phase, PendingPhase::Received { ref code } if code == "one-shot-code")
+        );
+        remove_pending(&path).unwrap();
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn mobile_claim_is_one_shot_and_session_bound() {
+        let mut value = pending();
+        let callback = format!("{MOBILE_REDIRECT_URI}?code=one-shot&state={}", value.state);
+        assert!(matches!(
+            evaluate_mobile_claim(&mut value, &callback, "login:none"),
+            PendingAction::Save(MobileClaimResult::Captured { .. })
+        ));
+        assert!(matches!(value.phase, PendingPhase::Received { .. }));
+        assert!(matches!(
+            evaluate_mobile_claim(&mut value, &callback, "login:none"),
+            PendingAction::Keep(MobileClaimResult::Ignored)
+        ));
+
+        let mut changed_session = pending();
+        assert!(matches!(
+            evaluate_mobile_claim(
+                &mut changed_session,
+                &callback,
+                &format!("associate:{}", "a".repeat(64)),
+            ),
+            PendingAction::Remove(MobileClaimResult::Rejected { .. })
+        ));
+    }
+
+    #[test]
+    fn spoofed_state_is_ignored_but_matching_malformed_callback_fails_closed() {
+        let mut value = pending();
+        let spoof = format!("{MOBILE_REDIRECT_URI}?code=evil&state={}x", value.state);
+        assert!(matches!(
+            evaluate_mobile_claim(&mut value, &spoof, "login:none"),
+            PendingAction::Keep(MobileClaimResult::Ignored)
+        ));
+        let malformed = format!("{MOBILE_REDIRECT_URI}?code=a&code=b&state={}", value.state);
+        assert!(matches!(
+            evaluate_mobile_claim(&mut value, &malformed, "login:none"),
+            PendingAction::Remove(MobileClaimResult::Rejected { .. })
+        ));
+    }
+
+    #[test]
+    fn matching_provider_error_cancels_and_consumes() {
+        let mut value = pending();
+        let callback = format!(
+            "{MOBILE_REDIRECT_URI}?error=access_denied&state={}",
+            value.state
+        );
+        assert!(matches!(
+            evaluate_mobile_claim(&mut value, &callback, "login:none"),
+            PendingAction::Remove(MobileClaimResult::Cancelled { .. })
+        ));
+    }
+
+    #[test]
+    fn generated_config_names_only_canonical_mobile_redirect() {
+        let config: serde_json::Value =
+            serde_json::from_str(include_str!("../tauri.conf.json")).unwrap();
+        let mobile = &config["plugins"]["deep-link"]["mobile"];
+        assert_eq!(mobile.as_array().unwrap().len(), 1);
+        assert_eq!(mobile[0]["scheme"][0], MOBILE_SCHEME);
+        assert_eq!(mobile[0]["host"], MOBILE_HOST);
+        assert_eq!(mobile[0]["path"][0], MOBILE_PATH);
+        assert_eq!(mobile[0]["appLink"], false);
+    }
+
+    #[test]
+    fn generated_android_manifest_registers_exact_mobile_redirect() {
+        let manifest = include_str!("../gen/android/app/src/main/AndroidManifest.xml");
+        assert_eq!(
+            manifest
+                .matches("android:scheme=\"cash.free2z.zuuli\"")
+                .count(),
+            1
+        );
+        assert_eq!(manifest.matches("android:host=\"oauth\"").count(), 1);
+        assert_eq!(manifest.matches("android:path=\"/callback\"").count(), 1);
+        assert_eq!(
+            manifest
+                .matches("android.intent.category.BROWSABLE")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn generated_ios_plist_registers_mobile_scheme() {
+        let plist = include_str!("../gen/apple/zuuli_iOS/Info.plist");
+        assert_eq!(plist.matches("<key>CFBundleURLTypes</key>").count(), 1);
+        assert_eq!(
+            plist.matches("<string>cash.free2z.zuuli</string>").count(),
+            2
+        );
+    }
 }

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -34,5 +34,17 @@
     "android": {
       "minSdkVersion": 29
     }
+  },
+  "plugins": {
+    "deep-link": {
+      "mobile": [
+        {
+          "scheme": ["cash.free2z.zuuli"],
+          "host": "oauth",
+          "path": ["/callback"],
+          "appLink": false
+        }
+      ]
+    }
   }
 }

--- a/wallet/zuuli/src/App.tsx
+++ b/wallet/zuuli/src/App.tsx
@@ -1,12 +1,15 @@
-import { lazy, Suspense, useEffect } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { lazy, Suspense, useEffect, useRef } from "react";
+import { BrowserRouter, Routes, Route, useNavigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { AppShell } from "@/components/layout/AppShell";
 import { NotFound } from "@/components/common/NotFound";
 import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
+import { auth } from "@/lib/api/free2z";
+import { recoverMobileOAuth } from "@/lib/oauth/transport";
 
 import AuthFeature from "@/features/auth";
 
@@ -37,6 +40,41 @@ function RouteFallback() {
   );
 }
 
+/** Finish a mobile OAuth callback that cold-started or resumed the app. */
+function MobileOAuthRecovery() {
+  const navigate = useNavigate();
+  const setUser = useSession((state) => state.setUser);
+  const sessionLoading = useSession((state) => state.loading);
+  const started = useRef(false);
+
+  useEffect(() => {
+    // The pending record is bound to the Knox session that initiated it.
+    // Wait until bootstrap has validated/cleared that token before recovery.
+    if (sessionLoading) return;
+    // React StrictMode deliberately reruns effects in development. The native
+    // state is one-shot too, but this guard avoids two backend exchanges.
+    if (started.current) return;
+    started.current = true;
+    void recoverMobileOAuth()
+      .then(async (capture) => {
+        if (!capture) return;
+        const user = await auth.completeSocialOAuth(capture);
+        setUser(user);
+        toast.success(capture.associate ? "Account linked" : "Welcome to ZUULI", {
+          description: `Finished ${capture.provider} sign-in after returning to the app.`,
+        });
+        if (!capture.associate) navigate("/", { replace: true });
+      })
+      .catch((error) => {
+        toast.error("Couldn't finish sign-in", {
+          description: error instanceof Error ? error.message : "Please try again.",
+        });
+      });
+  }, [navigate, sessionLoading, setUser]);
+
+  return null;
+}
+
 export default function App() {
   const bootstrapSession = useSession((s) => s.bootstrap);
   const bootstrapWallet = useWallet((s) => s.bootstrap);
@@ -49,6 +87,7 @@ export default function App() {
   return (
     <TooltipProvider delayDuration={200}>
       <BrowserRouter>
+        <MobileOAuthRecovery />
         <Routes>
           {/* Full-screen auth, outside the app shell — kept eager so /login is instant */}
           <Route path="/login" element={<AuthFeature />} />

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -8,7 +8,14 @@
 import { useMock } from "../platform";
 import { MOCK_OTP } from "../env";
 import { usdToTuzis } from "../format";
-import { captureOAuthCode } from "../oauth/transport";
+import {
+  assertMobileOAuthSession,
+  cancelMobileOAuth,
+  captureOAuthCode,
+  finishMobileOAuth,
+  type OAuthCapture,
+} from "../oauth/transport";
+import type { OAuthStartResponse } from "../oauth/protocol";
 import { ApiError, basicLogin, mediaUrl, request, setToken } from "./http";
 import {
   mockAiReply,
@@ -491,10 +498,10 @@ export const auth = {
   },
 
   /**
-   * Ask the backend to build the provider's `authorize_url` (it constructs
-   * the PKCE challenge and validates `redirectUri` against its allowlist,
-   * which includes `http://127.0.0.1:*` / `http://localhost:*` for the
-   * desktop loopback transport) — GET /api/auth/social/{provider}/start.
+   * Ask the backend to build the provider's `authorize_url`. Desktop uses its
+   * backend-generated PKCE pair and exact `127.0.0.1:<ephemeral>/<nonce>`
+   * callback. Mobile sends only its app-generated S256 challenge; providers
+   * return to free2z's fixed HTTPS relay before the exact private app URI.
    * 503s if the provider isn't configured; callers should already have
    * gated the entry point on `socialProviders()`, so that should only ever
    * fire on a race with the backend config changing mid-session.
@@ -502,18 +509,22 @@ export const auth = {
   async socialStart(
     provider: SocialProvider,
     redirectUri: string,
-  ): Promise<{ authorize_url: string; state: string }> {
-    return request<{ authorize_url: string; state: string }>(
+    codeChallenge?: string,
+  ): Promise<OAuthStartResponse> {
+    return request<OAuthStartResponse>(
       `/api/auth/social/${provider}/start`,
-      { query: { redirect_uri: redirectUri }, anonymous: true },
+      {
+        query: { redirect_uri: redirectUri, code_challenge: codeChallenge },
+        anonymous: true,
+      },
     );
   },
 
   /**
    * Social login / link with a provider (X / Google / GitHub). Runs the
-   * OAuth authorization-code round trip over the desktop loopback transport
-   * (Tauri) or a web popup fallback (`../oauth/transport.ts`) — the caller
-   * never sees which transport ran, only the resolved `AuthUser`.
+   * OAuth authorization-code round trip over the desktop loopback transport,
+   * the mobile free2z-HTTPS-to-app relay, or a web popup fallback
+   * (`../oauth/transport.ts`) — callers see only the resolved `AuthUser`.
    *
    * Dual-mode, mirroring `zcashLogin`/`zcashAssociate`:
    *   - `associate: false` (default) — POSTs anonymously; the backend logs
@@ -537,12 +548,29 @@ export const auth = {
         "Social login isn't available in mock mode — no provider is configured yet.",
       );
     }
-    const { code, state, redirectUri } = await captureOAuthCode((redirect) =>
-      auth.socialStart(provider, redirect).then((r) => r.authorize_url),
+    const associate = opts.associate === true;
+    const capture = await captureOAuthCode(provider, associate, (redirect, challenge) =>
+      auth.socialStart(provider, redirect, challenge),
     );
-    const body = { code, state, redirect_uri: redirectUri };
+    return auth.completeSocialOAuth(capture);
+  },
 
-    if (opts.associate) {
+  /**
+   * Exchange a callback already validated and one-shot claimed by the native
+   * transport. Public so App startup can finish a crash-recovered cold-start
+   * callback through exactly the same backend path as the live button flow.
+   */
+  async completeSocialOAuth(capture: OAuthCapture): Promise<AuthUser> {
+    const { provider, associate, code, state, redirectUri, codeVerifier } = capture;
+    await assertMobileOAuthSession(capture);
+    const body = {
+      code,
+      state,
+      redirect_uri: redirectUri,
+      ...(codeVerifier ? { code_verifier: codeVerifier } : {}),
+    };
+
+    if (associate) {
       try {
         // Deliberately NOT `anonymous: true` — the point is that the request
         // carries `Authorization: Token <knox token>`.
@@ -550,7 +578,13 @@ export const auth = {
           method: "POST",
           body,
         });
+        // The backend mutation already succeeded. Local scratch-file cleanup
+        // must not turn a completed link into a user-visible auth failure.
+        await finishMobileOAuth(state).catch(() => undefined);
       } catch (e) {
+        if (e instanceof ApiError && e.status >= 400 && e.status < 500) {
+          await cancelMobileOAuth(state).catch(() => undefined);
+        }
         if (e instanceof ApiError && e.status === 409) {
           throw new Error(
             "That account is already linked — either to a different free2z account, or this account already has a linked identity for this provider. Unlink it there first, or use a different account.",
@@ -568,8 +602,14 @@ export const auth = {
     const tok = await request<{ token: string }>(
       `/api/auth/social/${provider}/`,
       { method: "POST", body, anonymous: true },
-    );
+    ).catch(async (error) => {
+      if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+        await cancelMobileOAuth(state).catch(() => undefined);
+      }
+      throw error;
+    });
     setToken(tok.token);
+    await finishMobileOAuth(state).catch(() => undefined);
     const me = await auth.me();
     return {
       ...me,

--- a/wallet/zuuli/src/lib/oauth/protocol.test.ts
+++ b/wallet/zuuli/src/lib/oauth/protocol.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import type { SocialProvider } from "../api/types";
+import {
+  MOBILE_REDIRECT_URI,
+  buildSessionBinding,
+  canResumeMobileOAuth,
+  generatePkcePair,
+  validateAuthorizationStart,
+} from "./protocol";
+
+const STATE = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+const AUTHORIZATION_STATE = "ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210zyxwvut";
+const CHALLENGE = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+const PROVIDER_REDIRECT_URI = "https://free2z.cash/api/auth/social/mobile/callback";
+
+function start(
+  provider: SocialProvider = "google",
+  redirectUri = MOBILE_REDIRECT_URI,
+) {
+  const endpoint = {
+    x: "https://twitter.com/i/oauth2/authorize",
+    google: "https://accounts.google.com/o/oauth2/v2/auth",
+    github: "https://github.com/login/oauth/authorize",
+  }[provider];
+  const url = new URL(endpoint);
+  url.searchParams.set("response_type", "code");
+  const mobile = redirectUri === MOBILE_REDIRECT_URI;
+  url.searchParams.set("state", mobile ? AUTHORIZATION_STATE : STATE);
+  url.searchParams.set("redirect_uri", mobile ? PROVIDER_REDIRECT_URI : redirectUri);
+  if (provider !== "github") {
+    url.searchParams.set("code_challenge", CHALLENGE);
+    url.searchParams.set("code_challenge_method", "S256");
+  }
+  return {
+    authorize_url: url.toString(),
+    state: STATE,
+    ...(mobile
+      ? {
+          authorization_state: AUTHORIZATION_STATE,
+          provider_redirect_uri: PROVIDER_REDIRECT_URI,
+        }
+      : {}),
+  };
+}
+
+describe("validateAuthorizationStart", () => {
+  it("accepts the exact Google endpoint, callback, state and S256 challenge", () => {
+    expect(
+      validateAuthorizationStart("google", start(), MOBILE_REDIRECT_URI, true),
+    ).toContain("accounts.google.com");
+  });
+
+  it.each([
+    ["wrong host", (url: URL) => (url.hostname = "evil.example")],
+    ["wrong path", (url: URL) => (url.pathname = "/not-oauth")],
+    ["wrong callback", (url: URL) => url.searchParams.set("redirect_uri", "evil://callback")],
+    ["wrong state", (url: URL) => url.searchParams.set("state", `${AUTHORIZATION_STATE}x`)],
+    ["missing PKCE", (url: URL) => url.searchParams.delete("code_challenge")],
+    ["downgraded PKCE", (url: URL) => url.searchParams.set("code_challenge_method", "plain")],
+  ])("rejects %s", (_name, mutate) => {
+    const value = start();
+    const url = new URL(value.authorize_url);
+    mutate(url);
+    value.authorize_url = url.toString();
+    expect(() =>
+      validateAuthorizationStart("google", value, MOBILE_REDIRECT_URI, true),
+    ).toThrow();
+  });
+
+  it("rejects duplicate security parameters", () => {
+    const value = start();
+    value.authorize_url += `&state=${AUTHORIZATION_STATE}`;
+    expect(() =>
+      validateAuthorizationStart("google", value, MOBILE_REDIRECT_URI, true),
+    ).toThrow(/repeated/);
+  });
+
+  it("keeps non-PKCE GitHub off mobile while preserving desktop", () => {
+    expect(() =>
+      validateAuthorizationStart("github", start("github"), MOBILE_REDIRECT_URI, true),
+    ).toThrow(/PKCE-capable/);
+    const desktop = "http://127.0.0.1:49152/0123456789abcdef0123456789abcdef";
+    expect(() => validateAuthorizationStart("github", start("github", desktop), desktop, false))
+      .not.toThrow();
+  });
+
+  it.each([
+    "http://free2z.cash/api/auth/social/mobile/callback",
+    "https://evil.example/api/auth/social/mobile/callback",
+    "https://api.free2z.cash/api/auth/social/mobile/callback",
+    "https://free2z.cash/api/auth/social/mobile/callback?next=evil",
+    "https://free2z.cash/other",
+  ])("rejects unsafe provider relay %s", (relay) => {
+    const value = start();
+    value.provider_redirect_uri = relay;
+    expect(() =>
+      validateAuthorizationStart("google", value, MOBILE_REDIRECT_URI, true),
+    ).toThrow(/relay/);
+  });
+});
+
+describe("buildSessionBinding", () => {
+  it("binds anonymous login to an empty session", async () => {
+    await expect(buildSessionBinding(false, null)).resolves.toBe("login:none");
+    await expect(buildSessionBinding(false, "existing-token")).rejects.toThrow(/Sign out/);
+  });
+
+  it("binds association to a one-way digest of the current token", async () => {
+    const binding = await buildSessionBinding(true, "secret-token");
+    expect(binding).toMatch(/^associate:[0-9a-f]{64}$/);
+    expect(binding).not.toContain("secret-token");
+    await expect(buildSessionBinding(true, null)).rejects.toThrow(/expired/);
+  });
+});
+
+describe("canResumeMobileOAuth", () => {
+  it("only resumes a login while signed out", () => {
+    expect(canResumeMobileOAuth(false, null)).toBe(true);
+    expect(canResumeMobileOAuth(false, "new-session")).toBe(false);
+  });
+
+  it("only resumes account association while signed in", () => {
+    expect(canResumeMobileOAuth(true, "existing-session")).toBe(true);
+    expect(canResumeMobileOAuth(true, null)).toBe(false);
+  });
+});
+
+describe("generatePkcePair", () => {
+  it("creates fresh RFC 7636 base64url verifier/challenge pairs", async () => {
+    const first = await generatePkcePair();
+    const second = await generatePkcePair();
+    expect(first.verifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(first.challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(second.verifier).not.toBe(first.verifier);
+    expect(() =>
+      validateAuthorizationStart(
+        "google",
+        start(),
+        MOBILE_REDIRECT_URI,
+        true,
+        `${CHALLENGE}x`,
+      ),
+    ).toThrow(/changed the app's PKCE challenge/);
+  });
+});

--- a/wallet/zuuli/src/lib/oauth/protocol.ts
+++ b/wallet/zuuli/src/lib/oauth/protocol.ts
@@ -1,0 +1,190 @@
+import type { SocialProvider } from "../api/types";
+
+export const MOBILE_REDIRECT_URI = "cash.free2z.zuuli://oauth/callback";
+const MOBILE_RELAY_HOSTS = new Set([
+  "free2z.cash",
+  "new.free2z.cash",
+  "stage.free2z.cash",
+  "test.free2z.cash",
+]);
+
+export interface OAuthStartResponse {
+  authorize_url: string;
+  state: string;
+  authorization_state?: string;
+  provider_redirect_uri?: string;
+}
+
+export interface PkcePair {
+  verifier: string;
+  challenge: string;
+}
+
+const PROVIDER_AUTHORIZATION_ENDPOINT: Record<
+  SocialProvider,
+  { host: string; path: string }
+> = {
+  x: { host: "twitter.com", path: "/i/oauth2/authorize" },
+  google: { host: "accounts.google.com", path: "/o/oauth2/v2/auth" },
+  github: { host: "github.com", path: "/login/oauth/authorize" },
+};
+
+function oneQuery(url: URL, name: string): string | null {
+  const values = url.searchParams.getAll(name);
+  if (values.length > 1) {
+    throw new Error(`The authorization URL repeated \`${name}\`.`);
+  }
+  return values[0] ?? null;
+}
+
+function validState(state: string): boolean {
+  return (
+    state.length >= 16 &&
+    state.length <= 512 &&
+    [...state].every((char) => {
+      const code = char.charCodeAt(0);
+      return code >= 0x21 && code <= 0x7e && char !== '"' && char !== "\\";
+    })
+  );
+}
+
+function validateMobileProviderRedirect(value: string | undefined): string {
+  if (!value) throw new Error("free2z did not return its mobile OAuth relay URI.");
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("free2z returned an invalid mobile OAuth relay URI.");
+  }
+  if (
+    url.protocol !== "https:" ||
+    !MOBILE_RELAY_HOSTS.has(url.hostname) ||
+    url.pathname !== "/api/auth/social/mobile/callback" ||
+    url.username ||
+    url.password ||
+    url.port ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("free2z returned a mobile OAuth relay outside its allowlist.");
+  }
+  return url.toString();
+}
+
+/**
+ * Treat the backend's authorization URL as untrusted structured input. This
+ * prevents a compromised/misconfigured API response from turning the system
+ * browser opener into an arbitrary-URL launcher or swapping callback state.
+ */
+export function validateAuthorizationStart(
+  provider: SocialProvider,
+  start: OAuthStartResponse,
+  redirectUri: string,
+  mobile: boolean,
+  expectedCodeChallenge?: string,
+): string {
+  if (!validState(start.state)) {
+    throw new Error("free2z returned an invalid OAuth state.");
+  }
+  const authorizationState = mobile ? start.authorization_state : start.state;
+  if (
+    !authorizationState ||
+    !validState(authorizationState) ||
+    (mobile && authorizationState === start.state)
+  ) {
+    throw new Error("free2z returned an invalid provider-facing OAuth state.");
+  }
+  let url: URL;
+  try {
+    url = new URL(start.authorize_url);
+  } catch {
+    throw new Error("free2z returned an invalid authorization URL.");
+  }
+  const endpoint = PROVIDER_AUTHORIZATION_ENDPOINT[provider];
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== endpoint.host ||
+    url.pathname !== endpoint.path ||
+    url.username ||
+    url.password ||
+    url.port ||
+    url.hash
+  ) {
+    throw new Error("free2z returned an authorization URL outside the provider allowlist.");
+  }
+  if (oneQuery(url, "response_type") !== "code") {
+    throw new Error("The provider authorization response type is not \`code\`.");
+  }
+  if (oneQuery(url, "state") !== authorizationState) {
+    throw new Error("The provider authorization URL does not match its OAuth state.");
+  }
+  const providerRedirect = mobile
+    ? validateMobileProviderRedirect(start.provider_redirect_uri)
+    : redirectUri;
+  if (oneQuery(url, "redirect_uri") !== providerRedirect) {
+    throw new Error("The provider authorization URL changed the callback URI.");
+  }
+
+  // Native apps are public OAuth clients. X and Google support RFC 7636 S256;
+  // GitHub OAuth Apps currently do not, so GitHub stays desktop/web-only rather
+  // than shipping a weaker mobile exception.
+  if (mobile && provider === "github") {
+    throw new Error("GitHub sign-in on mobile is waiting for a PKCE-capable provider configuration.");
+  }
+  if (provider !== "github") {
+    const challenge = oneQuery(url, "code_challenge");
+    if (
+      oneQuery(url, "code_challenge_method") !== "S256" ||
+      !challenge ||
+      !/^[A-Za-z0-9_-]{43}$/.test(challenge)
+    ) {
+      throw new Error("The provider authorization URL is missing PKCE S256.");
+    }
+    if (expectedCodeChallenge && challenge !== expectedCodeChallenge) {
+      throw new Error("The provider authorization URL changed the app's PKCE challenge.");
+    }
+  }
+  return url.toString();
+}
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** Generate the verifier inside the app; only its S256 challenge leaves it. */
+export async function generatePkcePair(): Promise<PkcePair> {
+  const random = crypto.getRandomValues(new Uint8Array(32));
+  const verifier = base64Url(random);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return { verifier, challenge: base64Url(new Uint8Array(digest)) };
+}
+
+export async function buildSessionBinding(
+  associate: boolean,
+  token: string | null,
+): Promise<string> {
+  if (!associate) {
+    if (token) {
+      throw new Error("Sign out before starting a different social login.");
+    }
+    return "login:none";
+  }
+  if (!token) {
+    throw new Error("Your session expired before account linking started.");
+  }
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+  const hex = [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `associate:${hex}`;
+}
+
+/** Whether the current auth mode can still complete the pending OAuth flow. */
+export function canResumeMobileOAuth(
+  associate: boolean,
+  token: string | null,
+): boolean {
+  return associate ? token !== null : token === null;
+}

--- a/wallet/zuuli/src/lib/oauth/transport.ts
+++ b/wallet/zuuli/src/lib/oauth/transport.ts
@@ -1,136 +1,396 @@
-// Desktop/web transport for the OAuth authorization-code round trip that
-// backs social login (X / Google / GitHub). This module owns ONLY how the
-// `{code, state}` pair gets captured after the user approves in the system
-// browser (or a popup) — it knows nothing about free2z, tokens, or accounts.
-// See `auth.socialProviders` / `auth.socialLogin` in `../api/free2z.ts` for
-// the orchestration that calls this.
-//
-// One flow, two transports, chosen by `isTauri()`:
-//
-//   - Desktop (Tauri): the RFC 8252 "loopback redirect" pattern. A Rust
-//     command (`wallet/zuuli/src-tauri/src/oauth.rs`) binds an ephemeral
-//     `127.0.0.1` listener and hands back its port + a random one-time path
-//     nonce; we build `redirect_uri = http://127.0.0.1:<port>/<nonce>`, open
-//     the system browser at `authorize_url` via `@tauri-apps/plugin-opener`,
-//     then await the Rust command that blocks until the provider's single
-//     redirect lands, parses `code`/`state`, and serves a static "you can
-//     close this tab" page.
-//   - Web (plain browser / `npm run dev`): a popup window, with
-//     `redirect_uri = window.location.origin`. We poll the popup's location
-//     (readable once it navigates back same-origin) for the `code`/`state`
-//     query params the backend's redirect carries.
-//
-// Neither transport is ever exercised with real credentials today — the
-// backend reports every provider as unconfigured (`socialProviders()` returns
-// all-false), so nothing calls into this module in practice yet.
+// OAuth authorization-code callback transports. Desktop keeps RFC 8252
+// loopback; iOS/Android use the canonical private-use callback registered by
+// tauri-plugin-deep-link; plain web uses a same-origin popup.
 
+import { getToken } from "../api/http";
+import type { SocialProvider } from "../api/types";
 import { isTauri } from "../platform";
+import {
+  MOBILE_REDIRECT_URI,
+  buildSessionBinding,
+  canResumeMobileOAuth,
+  generatePkcePair,
+  validateAuthorizationStart,
+  type OAuthStartResponse,
+} from "./protocol";
 
 export interface OAuthCapture {
+  provider: SocialProvider;
+  associate: boolean;
   code: string;
   state: string;
   redirectUri: string;
+  codeVerifier?: string;
 }
 
 interface LoopbackStart {
   port: number;
   redirectPath: string;
 }
+
 interface LoopbackResult {
   code: string;
   state: string;
 }
 
-async function invokeLoopback<T>(cmd: string): Promise<T> {
-  const { invoke } = await import("@tauri-apps/api/core");
-  return invoke<T>(cmd);
+interface MobilePendingSummary {
+  provider: SocialProvider;
+  associate: boolean;
+  phase: "armed" | "received";
+  state: string;
 }
 
-/** Milliseconds between polls of the web popup's location. */
+type MobileClaimResult =
+  | { status: "ignored" }
+  | { status: "captured"; capture: OAuthCapture }
+  | { status: "rejected" | "cancelled"; message: string };
+
+async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  const { invoke: tauriInvoke } = await import("@tauri-apps/api/core");
+  return tauriInvoke<T>(cmd, args);
+}
+
 const POPUP_POLL_MS = 350;
-/** Popup window features (roughly matches other providers' OAuth popups). */
+const OAUTH_TIMEOUT_MS = 10 * 60 * 1_000;
 const POPUP_FEATURES = "width=480,height=680,noopener=no,noreferrer=no";
 
+let transportKind: Promise<"desktop" | "mobile"> | null = null;
+async function nativeTransport(): Promise<"desktop" | "mobile"> {
+  transportKind ??= invoke<"desktop" | "mobile">("oauth_callback_transport").catch(
+    (error) => {
+      transportKind = null;
+      throw error;
+    },
+  );
+  return transportKind;
+}
+
 async function runDesktopLoopback(
-  buildAuthorizeUrl: (redirectUri: string) => Promise<string>,
+  provider: SocialProvider,
+  associate: boolean,
+  buildStart: (redirectUri: string) => Promise<OAuthStartResponse>,
 ): Promise<OAuthCapture> {
-  const start = await invokeLoopback<LoopbackStart>("oauth_loopback_start");
-  const redirectUri = `http://127.0.0.1:${start.port}/${start.redirectPath}`;
+  const loopback = await invoke<LoopbackStart>("oauth_loopback_start");
+  const redirectUri = `http://127.0.0.1:${loopback.port}/${loopback.redirectPath}`;
+  try {
+    const start = await buildStart(redirectUri);
+    const authorizeUrl = validateAuthorizationStart(provider, start, redirectUri, false);
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(authorizeUrl);
+    const result = await invoke<LoopbackResult>("oauth_loopback_wait", {
+      expectedState: start.state,
+    });
+    return { provider, associate, code: result.code, state: result.state, redirectUri };
+  } catch (error) {
+    await invoke<void>("oauth_loopback_cancel").catch(() => undefined);
+    throw error;
+  }
+}
 
-  const authorizeUrl = await buildAuthorizeUrl(redirectUri);
+function settleMobileResult(
+  result: MobileClaimResult,
+  resolve: (capture: OAuthCapture) => void,
+  reject: (error: Error) => void,
+): boolean {
+  if (result.status === "captured") {
+    resolve(result.capture);
+    return true;
+  }
+  if (result.status === "rejected" || result.status === "cancelled") {
+    reject(new Error(result.message));
+    return true;
+  }
+  return false;
+}
 
-  // The system browser, not an in-app webview — the whole point of the
-  // loopback pattern is that the user authenticates in their normal browser
-  // (existing sessions, password manager, 2FA), never inside the app.
-  const { openUrl } = await import("@tauri-apps/plugin-opener");
-  await openUrl(authorizeUrl);
+async function waitForMobileCallback(
+  associate: boolean,
+  expectedState: string,
+  signal?: AbortSignal,
+): Promise<OAuthCapture> {
+  const { getCurrent, onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
+  let finished = false;
+  let unlisten: (() => void) | undefined;
+  let timer: number | undefined;
 
-  const result = await invokeLoopback<LoopbackResult>("oauth_loopback_wait");
-  return { code: result.code, state: result.state, redirectUri };
+  const promise = new Promise<OAuthCapture>((resolve, reject) => {
+    const finishResolve = (capture: OAuthCapture) => {
+      if (finished) return;
+      finished = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+      unlisten?.();
+      signal?.removeEventListener("abort", abort);
+      resolve(capture);
+    };
+    const finishReject = (error: Error) => {
+      if (finished) return;
+      finished = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+      unlisten?.();
+      signal?.removeEventListener("abort", abort);
+      reject(error);
+    };
+    const abort = () => finishReject(new Error("Sign-in was cancelled."));
+    if (signal?.aborted) {
+      abort();
+      return;
+    }
+    signal?.addEventListener("abort", abort, { once: true });
+    const processUrls = async (urls: string[]) => {
+      for (const callbackUrl of urls) {
+        if (finished) return;
+        try {
+          // Re-read the session at delivery time. Using only the binding from
+          // start would let a sign-out/account switch while Safari/Chrome is
+          // open associate the returning identity with the wrong account.
+          const currentBinding = await buildSessionBinding(associate, getToken());
+          const result = await invoke<MobileClaimResult>("oauth_mobile_claim", {
+            args: { callbackUrl, sessionBinding: currentBinding, expectedState },
+          });
+          if (settleMobileResult(result, finishResolve, finishReject)) return;
+        } catch (error) {
+          await invoke<void>("oauth_mobile_cancel", {
+            args: { state: expectedState },
+          }).catch(() => undefined);
+          finishReject(error instanceof Error ? error : new Error(String(error)));
+          return;
+        }
+      }
+    };
+
+    void onOpenUrl((urls) => void processUrls(urls))
+      .then((stop) => {
+        unlisten = stop;
+        return getCurrent();
+      })
+      .then((urls) => {
+        if (urls) void processUrls(urls);
+      })
+      .catch((error) =>
+        finishReject(error instanceof Error ? error : new Error(String(error))),
+      );
+
+    timer = window.setTimeout(() => {
+      void invoke<void>("oauth_mobile_cancel", { args: { state: expectedState } }).finally(() =>
+        finishReject(new Error("Timed out waiting for the OAuth redirect.")),
+      );
+    }, OAUTH_TIMEOUT_MS);
+  });
+  return promise;
+}
+
+async function runMobileDeepLink(
+  provider: SocialProvider,
+  associate: boolean,
+  buildStart: (
+    redirectUri: string,
+    codeChallenge?: string,
+  ) => Promise<OAuthStartResponse>,
+): Promise<OAuthCapture> {
+  const sessionBinding = await buildSessionBinding(associate, getToken());
+  const pkce = await generatePkcePair();
+  const start = await buildStart(MOBILE_REDIRECT_URI, pkce.challenge);
+  const authorizeUrl = validateAuthorizationStart(
+    provider,
+    start,
+    MOBILE_REDIRECT_URI,
+    true,
+    pkce.challenge,
+  );
+  await invoke<void>("oauth_mobile_arm", {
+    args: {
+      provider,
+      state: start.state,
+      associate,
+      sessionBinding,
+      codeVerifier: pkce.verifier,
+    },
+  });
+  recoveryController?.abort();
+  recoveryController = null;
+  const controller = new AbortController();
+  const callback = waitForMobileCallback(associate, start.state, controller.signal);
+  // Observe listener/setup failures immediately; the original promise is
+  // still awaited below so the caller receives the same rejection.
+  void callback.catch(() => undefined);
+  try {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(authorizeUrl);
+    return await callback;
+  } catch (error) {
+    controller.abort();
+    await invoke<void>("oauth_mobile_cancel", {
+      args: { state: start.state },
+    }).catch(() => undefined);
+    await callback.catch(() => undefined);
+    throw error;
+  }
 }
 
 function runWebPopup(
-  authorizeUrl: string,
+  provider: SocialProvider,
+  associate: boolean,
+  start: OAuthStartResponse,
   redirectUri: string,
 ): Promise<OAuthCapture> {
+  const authorizeUrl = validateAuthorizationStart(provider, start, redirectUri, false);
   return new Promise((resolve, reject) => {
     const popup = window.open(authorizeUrl, "zuuli-oauth", POPUP_FEATURES);
     if (!popup) {
-      reject(
-        new Error(
-          "The sign-in popup was blocked. Allow popups for this site and try again.",
-        ),
-      );
+      reject(new Error("The sign-in popup was blocked. Allow popups and try again."));
       return;
     }
-
-    const stop = () => window.clearInterval(timer);
-
-    const timer = window.setInterval(() => {
+    const expected = new URL(redirectUri);
+    const deadline = window.setTimeout(() => {
+      window.clearInterval(poll);
+      popup.close();
+      reject(new Error("Timed out waiting for the OAuth redirect."));
+    }, OAUTH_TIMEOUT_MS);
+    const finish = () => {
+      window.clearTimeout(deadline);
+      window.clearInterval(poll);
+      popup.close();
+    };
+    const poll = window.setInterval(() => {
       if (popup.closed) {
-        stop();
+        finish();
         reject(new Error("Sign-in was cancelled."));
         return;
       }
-      // Reading `.location.href` throws while the popup is still on the
-      // provider's cross-origin page — that's expected, just keep polling
-      // until it navigates back to our own origin (the redirect_uri).
-      let href: string;
+      let url: URL;
       try {
-        href = popup.location.href;
+        url = new URL(popup.location.href);
       } catch {
         return;
       }
-      if (!href || !href.startsWith(redirectUri)) return;
-
-      stop();
-      const url = new URL(href);
-      const code = url.searchParams.get("code");
-      const state = url.searchParams.get("state");
-      popup.close();
-      if (code && state) {
-        resolve({ code, state, redirectUri });
+      if (
+        url.origin !== expected.origin ||
+        url.pathname !== expected.pathname ||
+        url.username ||
+        url.password ||
+        url.hash
+      ) {
+        return;
+      }
+      const states = url.searchParams.getAll("state");
+      const codes = url.searchParams.getAll("code");
+      const errors = url.searchParams.getAll("error");
+      if (states.length !== 1 || states[0] !== start.state) {
+        finish();
+        reject(new Error("The provider callback did not match this sign-in attempt."));
+      } else if (codes.length === 1 && errors.length === 0 && codes[0]) {
+        finish();
+        resolve({ provider, associate, code: codes[0], state: states[0], redirectUri });
+      } else if (errors.length === 1 && codes.length === 0) {
+        finish();
+        reject(new Error("Sign-in was cancelled."));
       } else {
-        reject(
-          new Error("The provider redirect was missing `code` or `state`."),
-        );
+        finish();
+        reject(new Error("The provider callback was malformed."));
       }
     }, POPUP_POLL_MS);
   });
 }
 
-/**
- * Run the OAuth authorization-code round trip end to end and resolve with
- * the captured `{code, state, redirectUri}`. `buildAuthorizeUrl` is called
- * with the transport's `redirect_uri` and must return the provider's
- * `authorize_url` (i.e. it should call `auth.socialStart`).
- */
 export async function captureOAuthCode(
-  buildAuthorizeUrl: (redirectUri: string) => Promise<string>,
+  provider: SocialProvider,
+  associate: boolean,
+  buildStart: (
+    redirectUri: string,
+    codeChallenge?: string,
+  ) => Promise<OAuthStartResponse>,
 ): Promise<OAuthCapture> {
-  if (isTauri()) return runDesktopLoopback(buildAuthorizeUrl);
-
+  if (isTauri()) {
+    return (await nativeTransport()) === "mobile"
+      ? runMobileDeepLink(provider, associate, buildStart)
+      : runDesktopLoopback(provider, associate, buildStart);
+  }
   const redirectUri = window.location.origin;
-  const authorizeUrl = await buildAuthorizeUrl(redirectUri);
-  return runWebPopup(authorizeUrl, redirectUri);
+  const start = await buildStart(redirectUri);
+  return runWebPopup(provider, associate, start, redirectUri);
+}
+
+let recovery: Promise<OAuthCapture | null> | null = null;
+let recoveryController: AbortController | null = null;
+
+/** Recover a received cold-start callback (or claim getCurrent()) once. */
+export function recoverMobileOAuth(): Promise<OAuthCapture | null> {
+  recovery ??= (async () => {
+    if (!isTauri() || (await nativeTransport()) !== "mobile") return null;
+    const pending = await invoke<MobilePendingSummary | null>("oauth_mobile_pending");
+    if (!pending) return null;
+    const token = getToken();
+    if (!canResumeMobileOAuth(pending.associate, token)) {
+      // Session bootstrap may have signed in, signed out, or invalidated a
+      // token while the app was away. Consume the now-impossible flow instead
+      // of throwing on every cold start until its TTL expires.
+      await invoke<void>("oauth_mobile_cancel", {
+        args: { state: pending.state },
+      }).catch(() => undefined);
+      return null;
+    }
+    const sessionBinding = await buildSessionBinding(pending.associate, token);
+    const result = await invoke<MobileClaimResult>("oauth_mobile_resume", {
+      args: { sessionBinding, expectedState: pending.state },
+    });
+    if (result.status === "ignored" && pending.phase === "armed") {
+      // The app may have been reopened manually while the system browser is
+      // still active. Keep a warm-start listener alive; getCurrent() inside
+      // the waiter also closes the cold-start race.
+      const controller = new AbortController();
+      recoveryController = controller;
+      try {
+        return await waitForMobileCallback(
+          pending.associate,
+          pending.state,
+          controller.signal,
+        );
+      } catch (error) {
+        if (controller.signal.aborted) return null;
+        throw error;
+      } finally {
+        if (recoveryController === controller) recoveryController = null;
+      }
+    }
+    if (result.status === "captured") return result.capture;
+    if (result.status === "rejected" || result.status === "cancelled") {
+      throw new Error(result.message);
+    }
+    return null;
+  })();
+  return recovery;
+}
+
+export async function finishMobileOAuth(state: string): Promise<void> {
+  if (!isTauri() || (await nativeTransport()) !== "mobile") return;
+  await invoke<void>("oauth_mobile_finish", { args: { state } });
+}
+
+/** Revalidate the initiating session immediately before backend exchange. */
+export async function assertMobileOAuthSession(capture: OAuthCapture): Promise<void> {
+  if (!isTauri() || (await nativeTransport()) !== "mobile") return;
+  const sessionBinding = await buildSessionBinding(capture.associate, getToken());
+  const result = await invoke<MobileClaimResult>("oauth_mobile_resume", {
+    args: { sessionBinding, expectedState: capture.state },
+  });
+  if (
+    result.status !== "captured" ||
+    result.capture.state !== capture.state ||
+    result.capture.provider !== capture.provider ||
+    result.capture.associate !== capture.associate
+  ) {
+    await invoke<void>("oauth_mobile_cancel", {
+      args: { state: capture.state },
+    }).catch(() => undefined);
+    throw new Error(
+      result.status === "rejected" || result.status === "cancelled"
+        ? result.message
+        : "The mobile sign-in session no longer matches this callback.",
+    );
+  }
+}
+
+export async function cancelMobileOAuth(state: string): Promise<void> {
+  if (!isTauri() || (await nativeTransport()) !== "mobile") return;
+  await invoke<void>("oauth_mobile_cancel", { args: { state } });
 }


### PR DESCRIPTION
Closes #231

Depends on free2z/tuzi#904. Merge and deploy the backend first.

ZUULI now uses the system browser on every native platform: an ephemeral nonce-bearing 127.0.0.1 callback on macOS/Linux, and the exact cash.free2z.zuuli://oauth/callback deep link on iOS/Android. The mobile app owns the PKCE verifier while Free2Z relays the provider response through a fixed HTTPS callback with distinct provider and app states.

Security and resilience:
- exact scheme, host, path, provider endpoint, relay host, state, and PKCE S256 validation
- crash-safe 0600 pending state with ten-minute expiry and armed-to-received one-shot transition
- session binding for login versus account association
- cold/warm start recovery gated on Knox bootstrap
- every claim, resume, timeout, finish, and cancellation scoped to its random completion state, so stale listeners cannot damage a newer flow
- GitHub remains desktop/web-only until its mobile provider path supports PKCE
- native callback registrations are checked from Rust tests
- capability remains fail closed until backend/operator rollout

Verification:
- 12 Rust tests passed on pinned Rust 1.88.0
- 17 Vitest protocol tests passed
- TypeScript and production Vite build passed
- npm audit has no high or critical advisories
- final Android aarch64 build produced a universal debug APK
- final iOS arm64 simulator build produced ZUULI.app
- Claude adversarial review found and drove concurrency/bootstrap hardening; focused final result BLOCKING: NO

The existing full-stack workflow runs frontend typecheck/tests/build, the standalone Zcash plugin suite, the ZUULI Rust suite, locked dependency builds, and a stable gate context.

Follow-up #242 tracks claimed HTTPS Universal Links and Android App Links once the Apple Team ID and final Android signing fingerprints are available.