### PR TITLE
feat(release): add immutable ZUULI store train

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -1,0 +1,297 @@
+name: ZUULI / packaging smoke
+
+on:
+  pull_request:
+    paths:
+      - wallet/zuuli/**
+      - wallet/plugins/**
+      - wallet/rust-toolchain.toml
+      - z/zcash/librustzcash
+      - .gitmodules
+      - .github/workflows/zuuli-packaging.yml
+      - .github/workflows/zuuli-release.yml
+  push:
+    branches: [main]
+    paths:
+      - wallet/zuuli/**
+      - wallet/plugins/**
+      - wallet/rust-toolchain.toml
+      - z/zcash/librustzcash
+      - .gitmodules
+      - .github/workflows/zuuli-packaging.yml
+      - .github/workflows/zuuli-release.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zuuli-package-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+  ZUULI_NODE_VERSION: "24.18.0"
+  ZUULI_RUST_VERSION: "1.88.0"
+  ZUULI_JAVA_VERSION: "21.0.12"
+  ZUULI_XCODE_VERSION: "26.6"
+  ZUULI_ANDROID_NDK_VERSION: "27.0.12077973"
+
+jobs:
+  contract:
+    name: Release identity
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+          cache: npm
+          cache-dependency-path: wallet/zuuli/package-lock.json
+      - run: npm ci
+      - name: Verify one release identity
+        run: npm run release:verify
+      - name: Exercise immutable manifest generation
+        run: |
+          mkdir release-artifacts
+          cp release.json release-artifacts/identity.json
+          npm run release:manifest -- \
+            --artifacts=release-artifacts \
+            --checksums=release-artifacts/CHECKSUMS.sha256 \
+            --output=release-artifacts/provenance.json
+
+  android:
+    name: Android / unsigned AAB
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Fetch librustzcash
+        run: git submodule update --init z/zcash/librustzcash
+        working-directory: .
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+          cache: npm
+          cache-dependency-path: wallet/zuuli/package-lock.json
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "21.0.12"
+          cache: gradle
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+        with:
+          toolchain: 1.88.0
+          targets: aarch64-linux-android
+      - name: Install exact Android SDK components
+        run: |
+          java -version 2>&1 | grep -F '21.0.12'
+          set +e
+          yes 2>/dev/null | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
+            'platforms;android-36' \
+            'build-tools;36.0.0' \
+            'ndk;27.0.12077973' >/dev/null
+          sdk_status=${PIPESTATUS[1]}
+          set -e
+          [[ "$sdk_status" -eq 0 ]] || { echo "sdkmanager failed ($sdk_status)" >&2; exit 1; }
+          source scripts/android-toolchain-env.sh
+          for name in NDK_HOME ANDROID_NDK_HOME \
+            CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER \
+            CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER \
+            CARGO_TARGET_I686_LINUX_ANDROID_LINKER \
+            CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER \
+            CC_aarch64_linux_android CC_armv7_linux_androideabi \
+            CC_i686_linux_android CC_x86_64_linux_android \
+            CXX_aarch64_linux_android CXX_armv7_linux_androideabi \
+            CXX_i686_linux_android CXX_x86_64_linux_android; do
+            echo "$name=${!name}" >> "$GITHUB_ENV"
+          done
+      - run: npm ci
+      - run: npm run release:verify
+      - name: Verify Rust compiler
+        run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
+      - name: Build unsigned arm64 release bundle
+        run: ./node_modules/.bin/tauri android build --ci --aab --target aarch64 -- --locked
+      - name: Collect package
+        run: |
+          mkdir release-artifacts
+          aab=$(find src-tauri/gen/android/app/build/outputs/bundle -type f -name '*.aab' -print -quit)
+          test -n "$aab"
+          cp "$aab" release-artifacts/ZUULI-android-unsigned.aab
+      - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          syft-version: v1.50.0
+          path: wallet/zuuli
+          config: wallet/zuuli/syft.yaml
+          format: cyclonedx-json
+          output-file: wallet/zuuli/release-artifacts/ZUULI-android.sbom.cdx.json
+          upload-artifact: false
+      - name: Record checksums and provenance
+        run: |
+          jq -e '(.components // []) | length >= 50' release-artifacts/ZUULI-android.sbom.cdx.json
+          npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: zuuli-android-unsigned-${{ github.sha }}
+          path: wallet/zuuli/release-artifacts
+          if-no-files-found: error
+          retention-days: 14
+
+  ios:
+    name: iOS / unsigned simulator app
+    runs-on: macos-26
+    timeout-minutes: 90
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Fetch librustzcash
+        run: git submodule update --init z/zcash/librustzcash
+        working-directory: .
+      - name: Select and verify Xcode
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_26.6.app
+          xcodebuild -version | grep -Fx 'Xcode 26.6'
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+          cache: npm
+          cache-dependency-path: wallet/zuuli/package-lock.json
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+        with:
+          toolchain: 1.88.0
+          targets: aarch64-apple-ios-sim
+      - run: npm ci
+      - run: npm run release:verify
+      - name: Verify Rust compiler
+        run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
+      - name: Build without signing
+        run: ./node_modules/.bin/tauri ios build --ci --no-sign --target aarch64-sim -- --locked
+      - name: Collect simulator package
+        run: |
+          mkdir release-artifacts
+          app=$(find src-tauri/gen/apple/build -type d -name '*.app' -print -quit)
+          test -n "$app"
+          ditto -c -k --keepParent "$app" release-artifacts/ZUULI-ios-simulator-unsigned.zip
+      - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          syft-version: v1.50.0
+          path: wallet/zuuli
+          config: wallet/zuuli/syft.yaml
+          format: cyclonedx-json
+          output-file: wallet/zuuli/release-artifacts/ZUULI-ios.sbom.cdx.json
+          upload-artifact: false
+      - name: Record checksums and provenance
+        run: |
+          jq -e '(.components // []) | length >= 50' release-artifacts/ZUULI-ios.sbom.cdx.json
+          npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: zuuli-ios-simulator-unsigned-${{ github.sha }}
+          path: wallet/zuuli/release-artifacts
+          if-no-files-found: error
+          retention-days: 14
+
+  desktop:
+    name: Desktop / ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux packages
+            os: ubuntu-24.04
+            bundles: appimage,deb,rpm
+          - name: macOS universal app
+            os: macos-26
+            bundles: app,dmg
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Fetch librustzcash
+        run: git submodule update --init z/zcash/librustzcash
+        working-directory: .
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+          cache: npm
+          cache-dependency-path: wallet/zuuli/package-lock.json
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+        with:
+          toolchain: 1.88.0
+      - name: Install macOS universal Rust targets
+        if: runner.os == 'macOS'
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+      - name: Install Linux package dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev libxdo-dev libdbus-1-dev \
+            libssl-dev build-essential file pkg-config rpm
+      - name: Select and verify Xcode
+        if: runner.os == 'macOS'
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_26.6.app
+          xcodebuild -version | grep -Fx 'Xcode 26.6'
+      - run: npm ci
+      - run: npm run release:verify
+      - name: Verify Rust compiler
+        run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
+      - name: Build packages
+        run: |
+          if [[ "${{ runner.os }}" == macOS ]]; then
+            ./node_modules/.bin/tauri build --target universal-apple-darwin --bundles '${{ matrix.bundles }}' -- --locked
+          else
+            ./node_modules/.bin/tauri build --bundles '${{ matrix.bundles }}' -- --locked
+          fi
+      - name: Collect packages
+        run: |
+          mkdir release-artifacts
+          find src-tauri/target -path '*/release/bundle/*' -type f \
+            \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' \) \
+            -exec cp {} release-artifacts/ \;
+          if [[ "${{ runner.os }}" == macOS ]]; then
+            app=$(find src-tauri/target -path '*/release/bundle/macos/*.app' -type d -print -quit)
+            test -n "$app"
+            ditto -c -k --keepParent "$app" release-artifacts/ZUULI-macos-universal-unsigned.zip
+          fi
+          test -n "$(find release-artifacts -type f -print -quit)"
+      - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          syft-version: v1.50.0
+          path: wallet/zuuli
+          config: wallet/zuuli/syft.yaml
+          format: cyclonedx-json
+          output-file: wallet/zuuli/release-artifacts/ZUULI-desktop.sbom.cdx.json
+          upload-artifact: false
+      - name: Record checksums and provenance
+        run: |
+          jq -e '(.components // []) | length >= 50' release-artifacts/ZUULI-desktop.sbom.cdx.json
+          npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: zuuli-${{ runner.os }}-unsigned-${{ github.sha }}
+          path: wallet/zuuli/release-artifacts
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -1,0 +1,574 @@
+name: ZUULI / protected release
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Full 40-character commit SHA to release
+        required: true
+        type: string
+      identity:
+        description: Confirm version+build from release.json (for example 0.1.0+1)
+        required: true
+        type: string
+      target:
+        description: Artifact set to build
+        required: true
+        default: mobile
+        type: choice
+        options: [mobile, ios, android, desktop, all]
+      dry_run:
+        description: Build, sign, and validate without uploading to either store
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zuuli-release-${{ inputs.identity }}
+  cancel-in-progress: false
+
+env:
+  CI: true
+  ZUULI_NODE_VERSION: "24.18.0"
+  ZUULI_RUST_VERSION: "1.88.0"
+  ZUULI_JAVA_VERSION: "21.0.12"
+  ZUULI_XCODE_VERSION: "26.6"
+  ZUULI_ANDROID_NDK_VERSION: "27.0.12077973"
+
+jobs:
+  prepare:
+    name: Pin immutable source
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      identity: ${{ steps.identity.outputs.identity }}
+      tag: ${{ steps.identity.outputs.tag }}
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+          cache: npm
+          cache-dependency-path: wallet/zuuli/package-lock.json
+      - run: npm ci
+      - name: Verify source, identity, and release tag
+        id: identity
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          CONFIRMED_IDENTITY: ${{ inputs.identity }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          git fetch origin \
+            '+refs/heads/main:refs/remotes/origin/main' \
+            '+refs/tags/*:refs/tags/*'
+          args=("--source-sha=$SOURCE_SHA" --require-main)
+          [[ "$DRY_RUN" == true ]] || args+=(--require-tag)
+          metadata=$(node scripts/release-identity.mjs "${args[@]}")
+          actual=$(jq -r .identity <<<"$metadata")
+          [[ "$actual" == "$CONFIRMED_IDENTITY" ]] || {
+            echo "confirmed identity $CONFIRMED_IDENTITY does not match source identity $actual" >&2
+            exit 1
+          }
+          tag=$(jq -r .tag <<<"$metadata")
+          if [[ "$DRY_RUN" == false && "$GITHUB_REF" != "refs/tags/$tag" ]]; then
+            echo "real uploads must dispatch the workflow from the matching release tag" >&2
+            exit 1
+          fi
+          echo "identity=$actual" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  android:
+    name: Android / Play internal
+    needs: prepare
+    if: inputs.target == 'mobile' || inputs.target == 'android' || inputs.target == 'all'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    environment: zuuli-app-stores
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    env:
+      ZUULI_CONFIRM_UPLOAD: ${{ inputs.dry_run == false && needs.prepare.outputs.identity || '' }}
+      BUNDLE_FROZEN: "true"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - name: Fetch origin/main for ancestry check
+        run: git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+        working-directory: .
+      - name: Fetch librustzcash
+        run: git submodule update --init z/zcash/librustzcash
+        working-directory: .
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+          cache: npm
+          cache-dependency-path: wallet/zuuli/package-lock.json
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "21.0.12"
+          cache: gradle
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+        with:
+          toolchain: 1.88.0
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+      - name: Install exact Android SDK components
+        run: |
+          java -version 2>&1 | grep -F '21.0.12'
+          set +e
+          yes 2>/dev/null | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
+            'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.0.12077973' >/dev/null
+          sdk_status=${PIPESTATUS[1]}
+          set -e
+          [[ "$sdk_status" -eq 0 ]] || { echo "sdkmanager failed ($sdk_status)" >&2; exit 1; }
+          source scripts/android-toolchain-env.sh
+          for name in NDK_HOME ANDROID_NDK_HOME \
+            CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER \
+            CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER \
+            CARGO_TARGET_I686_LINUX_ANDROID_LINKER \
+            CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER \
+            CC_aarch64_linux_android CC_armv7_linux_androideabi \
+            CC_i686_linux_android CC_x86_64_linux_android \
+            CXX_aarch64_linux_android CXX_armv7_linux_androideabi \
+            CXX_i686_linux_android CXX_x86_64_linux_android; do
+            echo "$name=${!name}" >> "$GITHUB_ENV"
+          done
+      - run: npm ci
+      - name: Verify Rust compiler
+        run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
+        with:
+          ruby-version: "3.4.10"
+          bundler-cache: true
+          working-directory: wallet/zuuli
+      - name: Materialize ephemeral signing files
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          SERVICE_ACCOUNT_BASE64: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          : "${KEYSTORE_BASE64:?ANDROID_KEYSTORE_BASE64 is not configured}"
+          if [[ "$DRY_RUN" == false ]]; then
+            : "${SERVICE_ACCOUNT_BASE64:?PLAY_SERVICE_ACCOUNT_JSON_BASE64 is not configured}"
+          fi
+          files=$(mktemp -d "$RUNNER_TEMP/zuuli-android.XXXXXX")
+          chmod 700 "$files"
+          printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$files/upload.jks"
+          test -s "$files/upload.jks"
+          echo "ANDROID_KEYSTORE_PATH=$files/upload.jks" >> "$GITHUB_ENV"
+          if [[ "$DRY_RUN" == false ]]; then
+            printf '%s' "$SERVICE_ACCOUNT_BASE64" | base64 --decode > "$files/play-service-account.json"
+            test -s "$files/play-service-account.json"
+            echo "PLAY_SERVICE_ACCOUNT_JSON=$files/play-service-account.json" >> "$GITHUB_ENV"
+          fi
+          echo "ZUULI_SECRET_DIR=$files" >> "$GITHUB_ENV"
+      - name: Build, verify, and optionally upload
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [[ "$DRY_RUN" == false ]]; then
+            scripts/mobile-release.sh android --upload
+          else
+            scripts/mobile-release.sh android
+          fi
+      - name: Destroy ephemeral signing files
+        if: always()
+        run: |
+          if [[ -n "${ZUULI_SECRET_DIR:-}" && -d "$ZUULI_SECRET_DIR" ]]; then
+            find "$ZUULI_SECRET_DIR" -type f -exec rm -f -- {} +
+            rmdir "$ZUULI_SECRET_DIR"
+          fi
+      - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          syft-version: v1.50.0
+          path: wallet/zuuli
+          config: wallet/zuuli/syft.yaml
+          format: cyclonedx-json
+          output-file: wallet/zuuli/release-artifacts/ZUULI-android.sbom.cdx.json
+          upload-artifact: false
+      - name: Record checksums and provenance
+        run: |
+          jq -e '(.components // []) | length >= 50' release-artifacts/ZUULI-android.sbom.cdx.json
+          npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
+      - uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: wallet/zuuli/release-artifacts/*
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: zuuli-android-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}
+          path: wallet/zuuli/release-artifacts
+          if-no-files-found: error
+          retention-days: 90
+
+  ios:
+    name: iOS / TestFlight
+    needs: prepare
+    if: inputs.target == 'mobile' || inputs.target == 'ios' || inputs.target == 'all'
+    runs-on: macos-26
+    timeout-minutes: 120
+    environment: zuuli-app-stores
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    env:
+      APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+      ASC_KEY_ID: ${{ vars.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ vars.ASC_ISSUER_ID }}
+      ZUULI_CONFIRM_UPLOAD: ${{ inputs.dry_run == false && needs.prepare.outputs.identity || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - name: Fetch origin/main for ancestry check
+        run: git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+        working-directory: .
+      - name: Fetch librustzcash
+        run: git submodule update --init z/zcash/librustzcash
+        working-directory: .
+      - name: Select and verify Xcode
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_26.6.app
+          xcodebuild -version | grep -Fx 'Xcode 26.6'
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+          cache: npm
+          cache-dependency-path: wallet/zuuli/package-lock.json
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+        with:
+          toolchain: 1.88.0
+          targets: aarch64-apple-ios
+      - run: npm ci
+      - name: Verify Rust compiler
+        run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
+      - name: Materialize ephemeral Apple credentials
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          : "${CERTIFICATE_BASE64:?APPLE_DISTRIBUTION_CERTIFICATE_BASE64 is not configured}"
+          : "${CERTIFICATE_PASSWORD:?APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD is not configured}"
+          : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
+          : "${APPLE_TEAM_ID:?APPLE_TEAM_ID is not configured}"
+          : "${ASC_KEY_ID:?ASC_KEY_ID is not configured}"
+          : "${ASC_ISSUER_ID:?ASC_ISSUER_ID is not configured}"
+          files=$(mktemp -d "$RUNNER_TEMP/zuuli-apple.XXXXXX")
+          chmod 700 "$files"
+          printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$files/distribution.p12"
+          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$files/AuthKey.p8"
+          test -s "$files/distribution.p12"
+          test -s "$files/AuthKey.p8"
+          keychain="$files/release.keychain-db"
+          keychain_password=$(openssl rand -hex 24)
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$files/distribution.p12" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain" login.keychain-db
+          echo "ASC_KEY_PATH=$files/AuthKey.p8" >> "$GITHUB_ENV"
+          echo "ZUULI_SECRET_DIR=$files" >> "$GITHUB_ENV"
+          echo "ZUULI_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+      - name: Build, validate, and optionally upload
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [[ "$DRY_RUN" == false ]]; then
+            scripts/mobile-release.sh ios --upload
+          else
+            scripts/mobile-release.sh ios
+          fi
+      - name: Destroy ephemeral Apple credentials
+        if: always()
+        run: |
+          security delete-keychain "$ZUULI_KEYCHAIN" 2>/dev/null || true
+          if [[ -n "${ZUULI_SECRET_DIR:-}" && -d "$ZUULI_SECRET_DIR" ]]; then
+            find "$ZUULI_SECRET_DIR" -type f -exec rm -f -- {} +
+            rmdir "$ZUULI_SECRET_DIR"
+          fi
+      - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          syft-version: v1.50.0
+          path: wallet/zuuli
+          config: wallet/zuuli/syft.yaml
+          format: cyclonedx-json
+          output-file: wallet/zuuli/release-artifacts/ZUULI-ios.sbom.cdx.json
+          upload-artifact: false
+      - name: Record checksums and provenance
+        run: |
+          jq -e '(.components // []) | length >= 50' release-artifacts/ZUULI-ios.sbom.cdx.json
+          npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
+      - uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: wallet/zuuli/release-artifacts/*
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: zuuli-ios-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}
+          path: wallet/zuuli/release-artifacts
+          if-no-files-found: error
+          retention-days: 90
+
+  linux:
+    name: Linux release packages
+    needs: prepare
+    if: inputs.target == 'desktop' || inputs.target == 'all'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - name: Fetch librustzcash
+        run: git submodule update --init z/zcash/librustzcash
+        working-directory: .
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          {
+            node-version: "24.18.0",
+            cache: npm,
+            cache-dependency-path: wallet/zuuli/package-lock.json,
+          }
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+        with: { toolchain: 1.88.0 }
+      - name: Install package dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
+            librsvg2-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libxdo-dev libdbus-1-dev \
+            libssl-dev build-essential file pkg-config rpm
+      - run: npm ci
+      - run: npm run release:verify
+      - name: Verify Rust compiler
+        run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
+      - run: ./node_modules/.bin/tauri build --bundles appimage,deb,rpm -- --locked
+      - name: Collect packages
+        run: |
+          mkdir release-artifacts
+          find src-tauri/target -path '*/release/bundle/*' -type f \
+            \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \) -exec cp {} release-artifacts/ \;
+          test -n "$(find release-artifacts -type f -print -quit)"
+      - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          {
+            syft-version: v1.50.0,
+            path: wallet/zuuli,
+            config: wallet/zuuli/syft.yaml,
+            format: cyclonedx-json,
+            output-file: wallet/zuuli/release-artifacts/ZUULI-linux.sbom.cdx.json,
+            upload-artifact: false,
+          }
+      - name: Record checksums and provenance
+        run: |
+          jq -e '(.components // []) | length >= 50' release-artifacts/ZUULI-linux.sbom.cdx.json
+          npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
+      - uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with: { subject-path: "wallet/zuuli/release-artifacts/*" }
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          {
+            name: "zuuli-linux-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}",
+            path: wallet/zuuli/release-artifacts,
+            if-no-files-found: error,
+            retention-days: 90,
+          }
+
+  macos:
+    name: macOS universal signed and notarized
+    needs: prepare
+    if: inputs.target == 'desktop' || inputs.target == 'all'
+    runs-on: macos-26
+    timeout-minutes: 120
+    environment: zuuli-app-stores
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    env:
+      APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_DEVELOPER_ID_IDENTITY }}
+      APPLE_API_ISSUER: ${{ vars.ASC_ISSUER_ID }}
+      APPLE_API_KEY: ${{ vars.ASC_KEY_ID }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - name: Fetch librustzcash
+        run: git submodule update --init z/zcash/librustzcash
+        working-directory: .
+      - name: Select and verify Xcode
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_26.6.app
+          xcodebuild -version | grep -Fx 'Xcode 26.6'
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          {
+            node-version: "24.18.0",
+            cache: npm,
+            cache-dependency-path: wallet/zuuli/package-lock.json,
+          }
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+        with:
+          {
+            toolchain: 1.88.0,
+            targets: "aarch64-apple-darwin,x86_64-apple-darwin",
+          }
+      - run: npm ci
+      - run: npm run release:verify
+      - name: Verify Rust compiler
+        run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
+      - name: Build signed/notarized universal packages
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          : "${APPLE_SIGNING_IDENTITY:?APPLE_DEVELOPER_ID_IDENTITY is not configured}"
+          : "${APPLE_CERTIFICATE:?APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 is not configured}"
+          : "${APPLE_CERTIFICATE_PASSWORD:?APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD is not configured}"
+          : "${APPLE_API_ISSUER:?ASC_ISSUER_ID is not configured}"
+          : "${APPLE_API_KEY:?ASC_KEY_ID is not configured}"
+          : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
+          key_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-notary.XXXXXX")
+          chmod 700 "$key_dir"
+          cleanup() {
+            find "$key_dir" -type f -exec rm -f -- {} +
+            rmdir "$key_dir"
+          }
+          trap cleanup EXIT
+          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$key_dir/AuthKey.p8"
+          export APPLE_API_KEY_PATH="$key_dir/AuthKey.p8"
+          ./node_modules/.bin/tauri build --target universal-apple-darwin --bundles app,dmg -- --locked
+      - name: Collect packages
+        run: |
+          mkdir release-artifacts
+          find src-tauri/target -path '*/release/bundle/*' -type f -name '*.dmg' -exec cp {} release-artifacts/ \;
+          app=$(find src-tauri/target -path '*/release/bundle/macos/*.app' -type d -print -quit)
+          test -n "$app"
+          ditto -c -k --keepParent "$app" release-artifacts/ZUULI-macos-universal.zip
+      - name: Verify Developer ID signature and notarization
+        run: |
+          set -euo pipefail
+          apps=()
+          while IFS= read -r -d '' path; do apps+=("$path"); done < <(find src-tauri/target -path '*/release/bundle/macos/*.app' -type d -print0)
+          [[ "${#apps[@]}" -eq 1 ]] || { echo "expected one macOS app, found ${#apps[@]}" >&2; exit 1; }
+          codesign --verify --deep --strict --verbose=2 "${apps[0]}"
+          codesign -dvv "${apps[0]}" 2>&1 | grep -F 'Authority=Developer ID Application'
+          xcrun stapler validate "${apps[0]}"
+          spctl -a -vvv -t exec "${apps[0]}"
+          dmgs=()
+          while IFS= read -r -d '' path; do dmgs+=("$path"); done < <(find release-artifacts -type f -name '*.dmg' -print0)
+          [[ "${#dmgs[@]}" -eq 1 ]] || { echo "expected one DMG, found ${#dmgs[@]}" >&2; exit 1; }
+          codesign --verify --verbose=2 "${dmgs[0]}"
+      - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          {
+            syft-version: v1.50.0,
+            path: wallet/zuuli,
+            config: wallet/zuuli/syft.yaml,
+            format: cyclonedx-json,
+            output-file: wallet/zuuli/release-artifacts/ZUULI-macos.sbom.cdx.json,
+            upload-artifact: false,
+          }
+      - name: Record checksums and provenance
+        run: |
+          jq -e '(.components // []) | length >= 50' release-artifacts/ZUULI-macos.sbom.cdx.json
+          npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
+      - uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with: { subject-path: "wallet/zuuli/release-artifacts/*" }
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          {
+            name: "zuuli-macos-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}",
+            path: wallet/zuuli/release-artifacts,
+            if-no-files-found: error,
+            retention-days: 90,
+          }
+
+  release-index:
+    name: Immutable GitHub release index
+    needs: [prepare, android, ios, linux, macos]
+    if: >-
+      always() && !cancelled() &&
+      needs.prepare.result == 'success' &&
+      (needs.android.result == 'success' || needs.android.result == 'skipped') &&
+      (needs.ios.result == 'success' || needs.ios.result == 'skipped') &&
+      (needs.linux.result == 'success' || needs.linux.result == 'skipped') &&
+      (needs.macos.result == 'success' || needs.macos.result == 'skipped')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: zuuli-*-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}
+          path: release-downloads
+      - name: Publish idempotent draft release
+        if: inputs.dry_run == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: wallet/zuuli/scripts/publish-github-release.sh '${{ needs.prepare.outputs.tag }}' '${{ needs.prepare.outputs.identity }}' release-downloads
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: zuuli-release-index-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}
+          path: release-downloads
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -1,6 +1,10 @@
 name: ZUULI / protected release
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - wallet/zuuli/release.json
   workflow_dispatch:
     inputs:
       source_sha:
@@ -27,7 +31,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: zuuli-release-${{ inputs.identity }}
+  # All protected store transactions share one lane, including different build
+  # identities. GitHub reruns failed jobs without replaying successful jobs.
+  group: zuuli-mobile-store
   cancel-in-progress: false
 
 env:
@@ -46,13 +52,18 @@ jobs:
     outputs:
       identity: ${{ steps.identity.outputs.identity }}
       tag: ${{ steps.identity.outputs.tag }}
+      tag_exists: ${{ steps.identity.outputs.tag_exists }}
+      source_sha: ${{ steps.identity.outputs.source_sha }}
+      target: ${{ steps.identity.outputs.target }}
+      dry_run: ${{ steps.identity.outputs.dry_run }}
+      should_release: ${{ steps.identity.outputs.should_release }}
     defaults:
       run:
         working-directory: wallet/zuuli
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.source_sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || inputs.source_sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
@@ -62,37 +73,108 @@ jobs:
           cache: npm
           cache-dependency-path: wallet/zuuli/package-lock.json
       - run: npm ci
-      - name: Verify source, identity, and release tag
+      - name: Verify exact source and release identity
         id: identity
         env:
-          SOURCE_SHA: ${{ inputs.source_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          EVENT_SHA: ${{ github.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          INPUT_SOURCE_SHA: ${{ inputs.source_sha }}
           CONFIRMED_IDENTITY: ${{ inputs.identity }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_TARGET: ${{ inputs.target }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
           git fetch origin \
             '+refs/heads/main:refs/remotes/origin/main' \
             '+refs/tags/*:refs/tags/*'
-          args=("--source-sha=$SOURCE_SHA" --require-main)
-          [[ "$DRY_RUN" == true ]] || args+=(--require-tag)
-          metadata=$(node scripts/release-identity.mjs "${args[@]}")
-          actual=$(jq -r .identity <<<"$metadata")
-          [[ "$actual" == "$CONFIRMED_IDENTITY" ]] || {
-            echo "confirmed identity $CONFIRMED_IDENTITY does not match source identity $actual" >&2
+
+          if [[ "$EVENT_NAME" == push ]]; then
+            [[ "$EVENT_REF" == refs/heads/main ]] || {
+              echo "automatic store releases only accept main pushes" >&2
+              exit 1
+            }
+            source_sha=$EVENT_SHA
+            target=mobile
+            dry_run=false
+          else
+            source_sha=$INPUT_SOURCE_SHA
+            target=$INPUT_TARGET
+            dry_run=$INPUT_DRY_RUN
+          fi
+
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "source SHA must be a full lowercase 40-character commit SHA" >&2
             exit 1
           }
-          tag=$(jq -r .tag <<<"$metadata")
-          if [[ "$DRY_RUN" == false && "$GITHUB_REF" != "refs/tags/$tag" ]]; then
-            echo "real uploads must dispatch the workflow from the matching release tag" >&2
-            exit 1
+          args=("--source-sha=$source_sha" --require-main)
+          metadata=$(node scripts/release-identity.mjs "${args[@]}")
+          actual=$(jq -r .identity <<<"$metadata")
+
+          should_release=true
+          if [[ "$EVENT_NAME" == push ]]; then
+            if git cat-file -e "$BEFORE_SHA:wallet/zuuli/release.json" 2>/dev/null; then
+              node scripts/release-identity.mjs \
+                "--source-sha=$source_sha" \
+                "--require-newer-than=$BEFORE_SHA" \
+                --require-main >/dev/null
+            else
+              # Adding release.json establishes the baseline but must not turn
+              # an infrastructure merge into an unreviewed first store upload.
+              should_release=false
+            fi
+          else
+            [[ "$actual" == "$CONFIRMED_IDENTITY" ]] || {
+              echo "confirmed identity $CONFIRMED_IDENTITY does not match source identity $actual" >&2
+              exit 1
+            }
+            identity_sha=$(git log -1 --format=%H "$source_sha" -- ':(top)wallet/zuuli/release.json')
+            [[ "$identity_sha" == "$source_sha" ]] || {
+              echo "manual release source must be the exact commit that established this identity ($identity_sha)" >&2
+              exit 1
+            }
+            parent_sha=$(git rev-parse "$source_sha^1")
+            if git cat-file -e "$parent_sha:wallet/zuuli/release.json" 2>/dev/null; then
+              node scripts/release-identity.mjs \
+                "--source-sha=$source_sha" \
+                "--require-newer-than=$parent_sha" \
+                --require-main >/dev/null
+            fi
+            tip_identity=$(git show refs/remotes/origin/main:wallet/zuuli/release.json |
+              jq -r '.version + "+" + (.build | tostring)')
+            [[ "$actual" == "$tip_identity" ]] || {
+              echo "manual recovery identity $actual is stale; current main identity is $tip_identity" >&2
+              exit 1
+            }
           fi
+
+          tag=$(jq -r .tag <<<"$metadata")
+          tag_exists=false
+          if [[ "$(git cat-file -t "refs/tags/$tag" 2>/dev/null || true)" == tag ]]; then
+            tagged=$(git rev-list -n 1 "refs/tags/$tag")
+            remote_tagged=$(git ls-remote --tags origin "refs/tags/$tag^{}" | awk '{print $1}')
+            if [[ "$tagged" == "$source_sha" && "$remote_tagged" == "$source_sha" ]]; then
+              tag_exists=true
+            fi
+          fi
+
           echo "identity=$actual" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "tag_exists=$tag_exists" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$dry_run" >> "$GITHUB_OUTPUT"
+          echo "should_release=$should_release" >> "$GITHUB_OUTPUT"
 
   android:
     name: Android / Play internal
     needs: prepare
-    if: inputs.target == 'mobile' || inputs.target == 'android' || inputs.target == 'all'
+    if: >-
+      needs.prepare.outputs.should_release == 'true' &&
+      (needs.prepare.outputs.target == 'mobile' ||
+      needs.prepare.outputs.target == 'android' ||
+      needs.prepare.outputs.target == 'all')
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     environment: zuuli-app-stores
@@ -104,12 +186,14 @@ jobs:
       run:
         working-directory: wallet/zuuli
     env:
-      ZUULI_CONFIRM_UPLOAD: ${{ inputs.dry_run == false && needs.prepare.outputs.identity || '' }}
+      ZUULI_CONFIRM_UPLOAD: ${{ needs.prepare.outputs.dry_run == 'false' && needs.prepare.outputs.identity || '' }}
+      ZUULI_RELEASE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+      ANDROID_UPLOAD_CERT_SHA256: ${{ vars.ANDROID_UPLOAD_CERT_SHA256 }}
       BUNDLE_FROZEN: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.source_sha }}
+          ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
@@ -166,7 +250,7 @@ jobs:
         env:
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           SERVICE_ACCOUNT_BASE64: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
         run: |
           set -euo pipefail
           : "${KEYSTORE_BASE64:?ANDROID_KEYSTORE_BASE64 is not configured}"
@@ -189,7 +273,7 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
         run: |
           set -euo pipefail
           if [[ "$DRY_RUN" == false ]]; then
@@ -221,7 +305,7 @@ jobs:
           subject-path: wallet/zuuli/release-artifacts/*
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: zuuli-android-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}
+          name: zuuli-android-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
           path: wallet/zuuli/release-artifacts
           if-no-files-found: error
           retention-days: 90
@@ -229,7 +313,11 @@ jobs:
   ios:
     name: iOS / TestFlight
     needs: prepare
-    if: inputs.target == 'mobile' || inputs.target == 'ios' || inputs.target == 'all'
+    if: >-
+      needs.prepare.outputs.should_release == 'true' &&
+      (needs.prepare.outputs.target == 'mobile' ||
+      needs.prepare.outputs.target == 'ios' ||
+      needs.prepare.outputs.target == 'all')
     runs-on: macos-26
     timeout-minutes: 120
     environment: zuuli-app-stores
@@ -244,11 +332,12 @@ jobs:
       APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
       ASC_KEY_ID: ${{ vars.ASC_KEY_ID }}
       ASC_ISSUER_ID: ${{ vars.ASC_ISSUER_ID }}
-      ZUULI_CONFIRM_UPLOAD: ${{ inputs.dry_run == false && needs.prepare.outputs.identity || '' }}
+      ZUULI_CONFIRM_UPLOAD: ${{ needs.prepare.outputs.dry_run == 'false' && needs.prepare.outputs.identity || '' }}
+      ZUULI_RELEASE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.source_sha }}
+          ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
@@ -279,11 +368,13 @@ jobs:
           CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
           ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
         run: |
           set -euo pipefail
           : "${CERTIFICATE_BASE64:?APPLE_DISTRIBUTION_CERTIFICATE_BASE64 is not configured}"
           : "${CERTIFICATE_PASSWORD:?APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD is not configured}"
           : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
+          : "${PROVISIONING_PROFILE_BASE64:?APPLE_PROVISIONING_PROFILE_BASE64 is not configured}"
           : "${APPLE_TEAM_ID:?APPLE_TEAM_ID is not configured}"
           : "${ASC_KEY_ID:?ASC_KEY_ID is not configured}"
           : "${ASC_ISSUER_ID:?ASC_ISSUER_ID is not configured}"
@@ -291,8 +382,10 @@ jobs:
           chmod 700 "$files"
           printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$files/distribution.p12"
           printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$files/AuthKey.p8"
+          printf '%s' "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$files/zuuli.mobileprovision"
           test -s "$files/distribution.p12"
           test -s "$files/AuthKey.p8"
+          test -s "$files/zuuli.mobileprovision"
           keychain="$files/release.keychain-db"
           keychain_password=$(openssl rand -hex 24)
           security create-keychain -p "$keychain_password" "$keychain"
@@ -300,13 +393,44 @@ jobs:
           security unlock-keychain -p "$keychain_password" "$keychain"
           security import "$files/distribution.p12" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain" >/dev/null
-          security list-keychains -d user -s "$keychain" login.keychain-db
+          security list-keychains -d user -s "$keychain"
+          identity_count=$(security find-identity -v -p codesigning "$keychain" | grep -c 'Apple Distribution: Corpora Inc' || true)
+          [[ "$identity_count" -eq 1 ]] || {
+            echo "expected exactly one dedicated Corpora Apple Distribution identity" >&2
+            exit 1
+          }
+          identity_sha=$(security find-identity -v -p codesigning "$keychain" | awk '/Apple Distribution: Corpora Inc/ {print $2; exit}')
+          [[ "$identity_sha" =~ ^[0-9A-F]{40}$ ]] || {
+            echo "dedicated Corpora Apple Distribution identity was not imported" >&2
+            exit 1
+          }
+
+          security cms -D -i "$files/zuuli.mobileprovision" > "$files/profile.plist"
+          profile_uuid=$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$files/profile.plist")
+          profile_name=$(/usr/libexec/PlistBuddy -c 'Print :Name' "$files/profile.plist")
+          profile_team=$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$files/profile.plist")
+          profile_app=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$files/profile.plist")
+          [[ "$profile_uuid" == e5ead62c-83ec-4e54-abb6-4770833b5e0d ]]
+          [[ "$profile_name" == 'ZUULI App Store CI' ]]
+          [[ "$profile_team" == F9AV5HKF6N ]]
+          [[ "$profile_app" == F9AV5HKF6N.cash.free2z.zuuli ]]
+          plutil -extract DeveloperCertificates.0 raw -o - "$files/profile.plist" |
+            base64 --decode > "$files/profile-certificate.der"
+          profile_sha=$(openssl x509 -inform DER -in "$files/profile-certificate.der" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')
+          [[ "$profile_sha" == "$identity_sha" ]] || {
+            echo "provisioning profile is not linked to the imported distribution certificate" >&2
+            exit 1
+          }
+          profile_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$profile_dir"
+          cp "$files/zuuli.mobileprovision" "$profile_dir/$profile_uuid.mobileprovision"
           echo "ASC_KEY_PATH=$files/AuthKey.p8" >> "$GITHUB_ENV"
           echo "ZUULI_SECRET_DIR=$files" >> "$GITHUB_ENV"
           echo "ZUULI_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+          echo "ZUULI_PROFILE_PATH=$profile_dir/$profile_uuid.mobileprovision" >> "$GITHUB_ENV"
       - name: Build, validate, and optionally upload
         env:
-          DRY_RUN: ${{ inputs.dry_run }}
+          DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
         run: |
           set -euo pipefail
           if [[ "$DRY_RUN" == false ]]; then
@@ -318,6 +442,7 @@ jobs:
         if: always()
         run: |
           security delete-keychain "$ZUULI_KEYCHAIN" 2>/dev/null || true
+          rm -f -- "${ZUULI_PROFILE_PATH:-}"
           if [[ -n "${ZUULI_SECRET_DIR:-}" && -d "$ZUULI_SECRET_DIR" ]]; then
             find "$ZUULI_SECRET_DIR" -type f -exec rm -f -- {} +
             rmdir "$ZUULI_SECRET_DIR"
@@ -339,7 +464,7 @@ jobs:
           subject-path: wallet/zuuli/release-artifacts/*
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: zuuli-ios-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}
+          name: zuuli-ios-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
           path: wallet/zuuli/release-artifacts
           if-no-files-found: error
           retention-days: 90
@@ -347,7 +472,10 @@ jobs:
   linux:
     name: Linux release packages
     needs: prepare
-    if: inputs.target == 'desktop' || inputs.target == 'all'
+    if: >-
+      needs.prepare.outputs.should_release == 'true' &&
+      (needs.prepare.outputs.target == 'desktop' ||
+      needs.prepare.outputs.target == 'all')
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     permissions:
@@ -360,10 +488,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.source_sha }}
+          ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
+      - name: Fetch origin/main for release verification
+        run: git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+        working-directory: .
       - name: Fetch librustzcash
         run: git submodule update --init z/zcash/librustzcash
         working-directory: .
@@ -383,10 +514,14 @@ jobs:
             librsvg2-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libxdo-dev libdbus-1-dev \
             libssl-dev build-essential file pkg-config rpm
       - run: npm ci
-      - run: npm run release:verify
+      - name: Reverify exact release source
+        env:
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+        run: node scripts/release-identity.mjs "--source-sha=$SOURCE_SHA" --require-main
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
       - run: ./node_modules/.bin/tauri build --bundles appimage,deb,rpm -- --locked
+      - run: git diff --exit-code
       - name: Collect packages
         run: |
           mkdir release-artifacts
@@ -412,7 +547,7 @@ jobs:
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           {
-            name: "zuuli-linux-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}",
+            name: "zuuli-linux-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}",
             path: wallet/zuuli/release-artifacts,
             if-no-files-found: error,
             retention-days: 90,
@@ -421,7 +556,10 @@ jobs:
   macos:
     name: macOS universal signed and notarized
     needs: prepare
-    if: inputs.target == 'desktop' || inputs.target == 'all'
+    if: >-
+      needs.prepare.outputs.should_release == 'true' &&
+      (needs.prepare.outputs.target == 'desktop' ||
+      needs.prepare.outputs.target == 'all')
     runs-on: macos-26
     timeout-minutes: 120
     environment: zuuli-app-stores
@@ -436,13 +574,17 @@ jobs:
       APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_DEVELOPER_ID_IDENTITY }}
       APPLE_API_ISSUER: ${{ vars.ASC_ISSUER_ID }}
       APPLE_API_KEY: ${{ vars.ASC_KEY_ID }}
+      ZUULI_RELEASE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.source_sha }}
+          ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
+      - name: Fetch origin/main for release verification
+        run: git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+        working-directory: .
       - name: Fetch librustzcash
         run: git submodule update --init z/zcash/librustzcash
         working-directory: .
@@ -464,32 +606,57 @@ jobs:
             targets: "aarch64-apple-darwin,x86_64-apple-darwin",
           }
       - run: npm ci
-      - run: npm run release:verify
+      - name: Reverify exact release source
+        run: node scripts/release-identity.mjs "--source-sha=$ZUULI_RELEASE_SOURCE_SHA" --require-main
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
-      - name: Build signed/notarized universal packages
+      - name: Build unsigned universal packages without Apple credentials
+        if: needs.prepare.outputs.dry_run == 'true'
+        run: |
+          set -euo pipefail
+          unset APPLE_SIGNING_IDENTITY APPLE_API_ISSUER APPLE_API_KEY APPLE_API_KEY_PATH
+          ./node_modules/.bin/tauri build --target universal-apple-darwin --bundles app,dmg -- --locked
+          git diff --exit-code
+      - name: Build signed and notarized universal packages
+        if: needs.prepare.outputs.dry_run == 'false'
         env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
           ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
         run: |
           set -euo pipefail
           : "${APPLE_SIGNING_IDENTITY:?APPLE_DEVELOPER_ID_IDENTITY is not configured}"
-          : "${APPLE_CERTIFICATE:?APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 is not configured}"
-          : "${APPLE_CERTIFICATE_PASSWORD:?APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD is not configured}"
+          : "${CERTIFICATE_BASE64:?APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 is not configured}"
+          : "${CERTIFICATE_PASSWORD:?APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD is not configured}"
           : "${APPLE_API_ISSUER:?ASC_ISSUER_ID is not configured}"
           : "${APPLE_API_KEY:?ASC_KEY_ID is not configured}"
           : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
-          key_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-notary.XXXXXX")
-          chmod 700 "$key_dir"
+          files=$(mktemp -d "$RUNNER_TEMP/zuuli-notary.XXXXXX")
+          chmod 700 "$files"
+          keychain="$files/notary.keychain-db"
+          keychain_password=$(openssl rand -hex 24)
           cleanup() {
-            find "$key_dir" -type f -exec rm -f -- {} +
-            rmdir "$key_dir"
+            security delete-keychain "$keychain" 2>/dev/null || true
+            find "$files" -type f -exec rm -f -- {} +
+            rmdir "$files"
           }
           trap cleanup EXIT
-          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$key_dir/AuthKey.p8"
-          export APPLE_API_KEY_PATH="$key_dir/AuthKey.p8"
+          printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$files/developer-id.p12"
+          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$files/AuthKey.p8"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$files/developer-id.p12" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain"
+          identity_count=$(security find-identity -v -p codesigning "$keychain" | grep -Fc "$APPLE_SIGNING_IDENTITY" || true)
+          [[ "$identity_count" -eq 1 ]] || {
+            echo "expected exactly one configured Developer ID identity" >&2
+            exit 1
+          }
+          export APPLE_API_KEY_PATH="$files/AuthKey.p8"
           ./node_modules/.bin/tauri build --target universal-apple-darwin --bundles app,dmg -- --locked
+          git diff --exit-code
       - name: Collect packages
         run: |
           mkdir release-artifacts
@@ -498,13 +665,17 @@ jobs:
           test -n "$app"
           ditto -c -k --keepParent "$app" release-artifacts/ZUULI-macos-universal.zip
       - name: Verify Developer ID signature and notarization
+        if: needs.prepare.outputs.dry_run == 'false'
         run: |
           set -euo pipefail
           apps=()
           while IFS= read -r -d '' path; do apps+=("$path"); done < <(find src-tauri/target -path '*/release/bundle/macos/*.app' -type d -print0)
           [[ "${#apps[@]}" -eq 1 ]] || { echo "expected one macOS app, found ${#apps[@]}" >&2; exit 1; }
           codesign --verify --deep --strict --verbose=2 "${apps[0]}"
-          codesign -dvv "${apps[0]}" 2>&1 | grep -F 'Authority=Developer ID Application'
+          signature=$(codesign -dvv "${apps[0]}" 2>&1)
+          grep -F 'Authority=Developer ID Application: Corpora Inc (F9AV5HKF6N)' <<<"$signature"
+          grep -F 'TeamIdentifier=F9AV5HKF6N' <<<"$signature"
+          unset signature
           xcrun stapler validate "${apps[0]}"
           spctl -a -vvv -t exec "${apps[0]}"
           dmgs=()
@@ -530,7 +701,7 @@ jobs:
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           {
-            name: "zuuli-macos-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}",
+            name: "zuuli-macos-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}",
             path: wallet/zuuli/release-artifacts,
             if-no-files-found: error,
             retention-days: 90,
@@ -542,6 +713,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       needs.prepare.result == 'success' &&
+      needs.prepare.outputs.should_release == 'true' &&
       (needs.android.result == 'success' || needs.android.result == 'skipped') &&
       (needs.ios.result == 'success' || needs.ios.result == 'skipped') &&
       (needs.linux.result == 'success' || needs.linux.result == 'skipped') &&
@@ -553,22 +725,24 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.source_sha }}
+          ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          pattern: zuuli-*-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}
+          pattern: zuuli-*-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
           path: release-downloads
       - name: Publish idempotent draft release
-        if: inputs.dry_run == false
+        if: needs.prepare.outputs.dry_run == 'false' && needs.prepare.outputs.tag_exists == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: wallet/zuuli/scripts/publish-github-release.sh '${{ needs.prepare.outputs.tag }}' '${{ needs.prepare.outputs.identity }}' release-downloads
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}
+        run: wallet/zuuli/scripts/publish-github-release.sh "$RELEASE_TAG" "$RELEASE_IDENTITY" release-downloads
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: zuuli-release-index-${{ needs.prepare.outputs.identity }}-${{ inputs.source_sha }}
+          name: zuuli-release-index-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
           path: release-downloads
           if-no-files-found: error
           retention-days: 90

--- a/wallet/zuuli/.gitignore
+++ b/wallet/zuuli/.gitignore
@@ -2,6 +2,9 @@ node_modules
 dist
 dist-ssr
 .vite
+release-artifacts
+vendor/
+.bundle/
 *.local
 .DS_Store
 

--- a/wallet/zuuli/CLAUDE.md
+++ b/wallet/zuuli/CLAUDE.md
@@ -27,6 +27,7 @@ npm run tauri -- ios dev   # iOS simulator/device through Xcode
 npm run tauri -- ios build # unsigned/signing-configured iOS archive as applicable
 npm run tauri -- android dev
 npm run tauri -- android build # Android APK/AAB
+npm run release:verify         # cross-platform version/build/identity contract
 ```
 
 The web dev server runs on **1423** so it never collides with zuuallet (1421).
@@ -40,6 +41,11 @@ target is 18.0; Android uses min API 29 and target/compile API 36. Keep
 versions aligned. Keep iOS privacy strings in `src-tauri/Info.ios.plist` as the
 regeneration source of truth. Never commit signing certificates, provisioning
 profiles, API keys, keystores, or local SDK paths.
+
+Signed releases follow [`docs/releasing.md`](docs/releasing.md). PR packaging
+never receives store credentials; upload jobs use the protected
+`zuuli-app-stores` environment and require an immutable release tag and source
+SHA.
 
 `cash.free2z.zuuli` replaces the unreleased `com.2zinc.zuuli` identifier.
 The Zcash plugin migrates reachable legacy application data before wallet state

--- a/wallet/zuuli/Gemfile
+++ b/wallet/zuuli/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane", "2.237.0"

--- a/wallet/zuuli/Gemfile.lock
+++ b/wallet/zuuli/Gemfile.lock
@@ -1,0 +1,346 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.8)
+    abbrev (0.1.2)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    artifactory (3.0.17)
+    atomos (0.1.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1278.0)
+    aws-sdk-core (3.254.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.130.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.229.0)
+      aws-sdk-core (~> 3, >= 3.254.1)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    babosa (1.0.4)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    claide (1.1.0)
+    colored (1.2)
+    colored2 (3.1.2)
+    commander (4.6.0)
+      highline (~> 2.0.0)
+    csv (3.3.6)
+    declarative (0.0.20)
+    digest-crc (0.7.0)
+      rake (>= 12.0.0, < 14.0.0)
+    domain_name (0.6.20240107)
+    dotenv (2.8.1)
+    emoji_regex (3.2.3)
+    excon (1.7.0)
+      logger
+    faraday (1.10.6)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-cookie_jar (0.0.8)
+      faraday (>= 0.8.0)
+      http-cookie (>= 1.0.0)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.1)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (1.0.2)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.4)
+    faraday_middleware (1.2.1)
+      faraday (~> 1.0)
+    fastimage (2.4.1)
+    fastlane (2.237.0)
+      CFPropertyList (>= 2.3, < 5.0.0)
+      abbrev (~> 0.1)
+      addressable (>= 2.9.0, < 3.0.0)
+      artifactory (~> 3.0)
+      aws-sdk-s3 (~> 1.197)
+      babosa (>= 1.0.3, < 2.0.0)
+      base64 (~> 0.2)
+      benchmark (>= 0.1.0)
+      bundler (>= 2.4.0, < 5.0.0)
+      colored (~> 1.2)
+      commander (~> 4.6)
+      csv (~> 3.3)
+      dotenv (>= 2.1.1, < 3.0.0)
+      emoji_regex (>= 0.1, < 4.0)
+      excon (>= 0.71.0, < 2.0.0)
+      faraday (~> 1.0)
+      faraday-cookie_jar (~> 0.0.6)
+      faraday_middleware (~> 1.0)
+      fastimage (>= 2.1.0, < 3.0.0)
+      fastlane-sirp (>= 1.1.0)
+      gh_inspector (>= 1.1.2, < 2.0.0)
+      google-apis-androidpublisher_v3 (~> 0.3)
+      google-apis-playcustomapp_v1 (~> 0.1)
+      google-cloud-env (>= 1.6.0, < 2.3.0)
+      google-cloud-storage (~> 1.31)
+      highline (~> 2.0)
+      http-cookie (~> 1.0.5)
+      json (< 3.0.0)
+      jwt (>= 2.10.3, < 4)
+      logger (>= 1.6, < 2.0)
+      mini_magick (>= 4.9.4, < 5.0.0)
+      multi_json (~> 1.12)
+      multipart-post (>= 2.0.0, < 3.0.0)
+      mutex_m (~> 0.3)
+      naturally (~> 2.2)
+      nkf (~> 0.2)
+      optparse (>= 0.1.1, < 1.0.0)
+      ostruct (>= 0.1.0)
+      plist (>= 3.1.0, < 4.0.0)
+      rubyzip (>= 2.0.0, < 3.0.0)
+      security (= 0.1.5)
+      simctl (~> 1.6.3)
+      terminal-notifier (>= 2.0.0, < 3.0.0)
+      terminal-table (~> 3)
+      tty-screen (>= 0.6.3, < 1.0.0)
+      tty-spinner (>= 0.8.0, < 1.0.0)
+      word_wrap (~> 1.0.0)
+      xcodeproj (>= 1.13.0, < 2.0.0)
+      xcpretty (~> 0.4.1)
+      xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
+    fastlane-sirp (1.1.0)
+    gh_inspector (1.1.3)
+    google-apis-androidpublisher_v3 (0.106.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-core (0.18.0)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (~> 1.9)
+      httpclient (>= 2.8.3, < 3.a)
+      mini_mime (~> 1.0)
+      mutex_m
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.a)
+    google-apis-iamcredentials_v1 (0.28.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-playcustomapp_v1 (0.18.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-apis-storage_v1 (0.65.0)
+      google-apis-core (>= 0.15.0, < 2.a)
+    google-cloud-core (1.9.0)
+      google-cloud-env (>= 1.0, < 3.a)
+      google-cloud-errors (~> 1.0)
+    google-cloud-env (2.2.2)
+      base64 (~> 0.2)
+      faraday (>= 1.0, < 3.a)
+    google-cloud-errors (1.7.0)
+    google-cloud-storage (1.62.0)
+      addressable (~> 2.8)
+      digest-crc (~> 0.4)
+      google-apis-core (>= 0.18, < 2)
+      google-apis-iamcredentials_v1 (~> 0.18)
+      google-apis-storage_v1 (>= 0.42)
+      google-cloud-core (~> 1.6)
+      googleauth (~> 1.9)
+      mini_mime (~> 1.0)
+    google-logging-utils (0.2.0)
+    googleauth (1.17.3)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.2)
+      google-logging-utils (~> 0.1)
+      jwt (>= 1.4, < 4.0)
+      os (>= 0.9, < 2.0)
+      pstore (~> 0.1)
+      signet (>= 0.16, < 2.a)
+    highline (2.0.3)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
+    httpclient (2.9.0)
+      mutex_m
+    jmespath (1.6.2)
+    json (2.21.2)
+    jwt (3.2.0)
+      base64
+    logger (1.7.0)
+    mini_magick (4.13.2)
+    mini_mime (1.1.5)
+    multi_json (1.21.1)
+    multipart-post (2.4.1)
+    mutex_m (0.3.0)
+    nanaimo (0.4.0)
+    naturally (2.3.0)
+    nkf (0.3.0)
+    optparse (0.8.1)
+    os (1.1.4)
+    ostruct (0.6.3)
+    plist (3.7.2)
+    pstore (0.2.1)
+    public_suffix (7.0.5)
+    rake (13.4.2)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.8.0)
+    rexml (3.4.4)
+    rouge (3.28.0)
+    ruby2_keywords (0.0.5)
+    rubyzip (2.4.1)
+    security (0.1.5)
+    signet (0.22.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 4.0)
+    simctl (1.6.10)
+      CFPropertyList
+      naturally
+    terminal-notifier (2.0.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    trailblazer-option (0.1.2)
+    tty-cursor (0.7.1)
+    tty-screen (0.8.2)
+    tty-spinner (0.9.3)
+      tty-cursor (~> 0.7)
+    uber (0.1.0)
+    unicode-display_width (2.6.0)
+    word_wrap (1.0.0)
+    xcodeproj (1.28.1)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      base64
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.4.0)
+      nkf
+      rexml (>= 3.3.6, < 4.0)
+    xcpretty (0.4.1)
+      rouge (~> 3.28.0)
+    xcpretty-travis-formatter (1.0.1)
+      xcpretty (~> 0.2, >= 0.0.7)
+
+PLATFORMS
+  arm64-darwin-25
+  ruby
+  x86_64-darwin-25
+  x86_64-linux
+
+DEPENDENCIES
+  fastlane (= 2.237.0)
+
+CHECKSUMS
+  CFPropertyList (3.0.8) sha256=2c99d0d980536d3d7ab252f7bd59ac8be50fbdd1ff487c98c949bb66bb114261
+  abbrev (0.1.2) sha256=ad1b4eaaaed4cb722d5684d63949e4bde1d34f2a95e20db93aecfe7cbac74242
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
+  atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
+  aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
+  aws-partitions (1.1278.0) sha256=be1e99e905b0800b60c3b6b70806361f98b2311b14f1c13b91c3eae70cafbb26
+  aws-sdk-core (3.254.1) sha256=518089e32134c3478cd4ec63d07fb966546a45e9e4cbf5f80d2cf16d5699d29b
+  aws-sdk-kms (1.130.0) sha256=a2e83662ca31b77a2a19c9aa2f40a98165a67270c18c718fe1c70d0cbd7cd749
+  aws-sdk-s3 (1.229.0) sha256=7dd11a111875b3505d2ec0a0a383a6aab6c1badb3d4e94e7fbb958a24451f596
+  aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
+  babosa (1.0.4) sha256=18dea450f595462ed7cb80595abd76b2e535db8c91b350f6c4b3d73986c5bc99
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  claide (1.1.0) sha256=6d3c5c089dde904d96aa30e73306d0d4bd444b1accb9b3125ce14a3c0183f82e
+  colored (1.2) sha256=9d82b47ac589ce7f6cab64b1f194a2009e9fd00c326a5357321f44afab2c1d2c
+  colored2 (3.1.2) sha256=b13c2bd7eeae2cf7356a62501d398e72fde78780bd26aec6a979578293c28b4a
+  commander (4.6.0) sha256=7d1ddc3fccae60cc906b4131b916107e2ef0108858f485fdda30610c0f2913d9
+  csv (3.3.6) sha256=aba61e7e507a66f03d45cb1f3c4b6359861c3504038b422962875dce099e4456
+  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
+  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
+  domain_name (0.6.20240107) sha256=5f693b2215708476517479bf2b3802e49068ad82167bcd2286f899536a17d933
+  dotenv (2.8.1) sha256=c5944793349ae03c432e1780a2ca929d60b88c7d14d52d630db0508c3a8a17d8
+  emoji_regex (3.2.3) sha256=ecd8be856b7691406c6bf3bb3a5e55d6ed683ffab98b4aa531bb90e1ddcc564b
+  excon (1.7.0) sha256=b8deec2bf978123b7e4b13a103ffec61557c6feaba34706dbc1ce4a94dec33e0
+  faraday (1.10.6) sha256=7ff4802a6b312876a2241b3e641ce0d5045e168dd871b422c35b505e5261ad4d
+  faraday-cookie_jar (0.0.8) sha256=0140605823f8cc63c7028fccee486aaed8e54835c360cffc1f7c8c07c4299dbb
+  faraday-em_http (1.0.0) sha256=7a3d4c7079789121054f57e08cd4ef7e40ad1549b63101f38c7093a9d6c59689
+  faraday-em_synchrony (1.0.1) sha256=bf3ce45dcf543088d319ab051f80985ea6d294930635b7a0b966563179f81750
+  faraday-excon (1.1.0) sha256=b055c842376734d7f74350fe8611542ae2000c5387348d9ba9708109d6e40940
+  faraday-httpclient (1.0.1) sha256=4c8ff1f0973ff835be8d043ef16aaf54f47f25b7578f6d916deee8399a04d33b
+  faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
+  faraday-net_http (1.0.2) sha256=63992efea42c925a20818cf3c0830947948541fdcf345842755510d266e4c682
+  faraday-net_http_persistent (1.2.0) sha256=0b0cbc8f03dab943c3e1cc58d8b7beb142d9df068b39c718cd83e39260348335
+  faraday-patron (1.0.0) sha256=dc2cd7b340bb3cc8e36bcb9e6e7eff43d134b6d526d5f3429c7a7680ddd38fa7
+  faraday-rack (1.0.0) sha256=ef60ec969a2bb95b8dbf24400155aee64a00fc8ba6c6a4d3968562bcc92328c0
+  faraday-retry (1.0.4) sha256=dc659233777fabf96c69c2ffe56c0a5d2c102af90321a42cc6c90157bcd716aa
+  faraday_middleware (1.2.1) sha256=d45b78c8ee864c4783fbc276f845243d4a7918a67301c052647bacabec0529e9
+  fastimage (2.4.1) sha256=c64bebd46b6fd8943ab70c1e6e85ff728f970f2e48f92ecd249b6bc3a540ad20
+  fastlane (2.237.0) sha256=bb1e867bc070fb328741b5e6e7606d5ba596941a9ecca0478f60ef22d1009db9
+  fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
+  gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
+  google-apis-androidpublisher_v3 (0.106.0) sha256=b90b5312b70f8f731def88f24a2b8fb791fe1b979a7c2c14a905cb6cae19cf3f
+  google-apis-core (0.18.0) sha256=96b057816feeeab448139ed5b5c78eab7fc2a9d8958f0fbc8217dedffad054ee
+  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
+  google-apis-playcustomapp_v1 (0.18.0) sha256=44b277b9dee4a59ac5e9d98be1485edc5e382d2f9d73c79ae8908a455786a254
+  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
+  google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
+  google-cloud-env (2.2.2) sha256=94bed40e05a67e9468ce1cb38389fba9a90aa8fc62fc9e173204c1dca59e21e7
+  google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
+  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
+  google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
+  googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
+  highline (2.0.3) sha256=2ddd5c127d4692721486f91737307236fe005352d12a4202e26c48614f719479
+  http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
+  httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
+  jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
+  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
+  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  nanaimo (0.4.0) sha256=faf069551bab17f15169c1f74a1c73c220657e71b6e900919897a10d991d0723
+  naturally (2.3.0) sha256=459923cf76c2e6613048301742363200c3c7e4904c324097d54a67401e179e01
+  nkf (0.3.0) sha256=357a8dbeba38b727b75930f665146546076a394a1c243faf634ff176e3588895
+  optparse (0.8.1) sha256=42bea10d53907ccff4f080a69991441d611fbf8733b60ed1ce9ee365ce03bd1a
+  os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
+  plist (3.7.2) sha256=d37a4527cc1116064393df4b40e1dbbc94c65fa9ca2eec52edf9a13616718a42
+  pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
+  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (3.28.0) sha256=0d6de482c7624000d92697772ab14e48dca35629f8ddf3f4b21c99183fd70e20
+  ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
+  rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
+  security (0.1.5) sha256=3a977a0eca7706e804c96db0dd9619e0a94969fe3aac9680fcfc2bf9b8a833b7
+  signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
+  simctl (1.6.10) sha256=b99077f4d13ad81eace9f86bf5ba4df1b0b893a4d1b368bd3ed59b5b27f9236b
+  terminal-notifier (2.0.0) sha256=7a0d2b2212ab9835c07f4b2e22a94cff64149dba1eed203c04835f7991078cea
+  terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
+  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
+  tty-cursor (0.7.1) sha256=79534185e6a777888d88628b14b6a1fdf5154a603f285f80b1753e1908e0bf48
+  tty-screen (0.8.2) sha256=c090652115beae764336c28802d633f204fb84da93c6a968aa5d8e319e819b50
+  tty-spinner (0.9.3) sha256=0e036f047b4ffb61f2aa45f5a770ec00b4d04130531558a94bfc5b192b570542
+  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
+  word_wrap (1.0.0) sha256=f556d4224c812e371000f12a6ee8102e0daa724a314c3f246afaad76d82accc7
+  xcodeproj (1.28.1) sha256=6f12670f00739d9817ca27ac89d6ef01cc86050e22a0bc08a3131487e5b5cddc
+  xcpretty (0.4.1) sha256=b14c50e721f6589ee3d6f5353e2c2cfcd8541fa1ea16d6c602807dd7327f3892
+  xcpretty-travis-formatter (1.0.1) sha256=aacc332f17cb7b2cba222994e2adc74223db88724fe76341483ad3098e232f93
+
+BUNDLED WITH
+  4.0.3

--- a/wallet/zuuli/README.md
+++ b/wallet/zuuli/README.md
@@ -56,6 +56,8 @@ The committed native projects live under `src-tauri/gen/apple` and
 `cash.free2z.zuuli`, targets iOS 18+, and supports Android API 29+ while
 compiling against API 36. Mobile builds require the corresponding Xcode or
 Android SDK/NDK toolchain; signing credentials stay outside the repository.
+The immutable package train, protected store upload, credential contract, and
+physical-device checklist live in [the release runbook](docs/releasing.md).
 This identifier replaces the unreleased development identifier
 `com.2zinc.zuuli`. Existing development data is handled by the fail-closed
 [identifier migration](docs/app-data-identifier-migration.md); never treat an

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -44,10 +44,19 @@ consoles. This is intentionally outside CI.
    for future updates. Play App Signing protects the app-signing key; CI holds
    only the replaceable upload key.
 3. Create a dedicated Google Cloud service account, enable the Android Publisher
-   API, and grant that principal release permission to ZUULI only.
+   API, and grant that principal release permission to ZUULI only. The dedicated
+   principal is
+   `corpan-play-verifier@corpora1.iam.gserviceaccount.com`; the release script
+   rejects a different service-account document.
 4. Google requires the first signed AAB to establish the package/signature in
    Play Console. Upload the locally produced AAB to the internal-testing release
    once; after that, the protected workflow performs uploads through the API.
+
+The Play app record already exists for `cash.free2z.zuuli`, and the dedicated
+principal has been granted ZUULI admin access. Fastlane's Play JSON-key
+validation succeeds for this account. The first AAB is still a separate manual
+package/signature bootstrap; do not weaken the account check or upload a debug
+key.
 
 Primary references:
 
@@ -87,7 +96,18 @@ ANDROID_KEY_PASSWORD
 PLAY_SERVICE_ACCOUNT_JSON   path to the JSON file; upload only
 ```
 
-From a clean, tagged worktree with locked dependencies installed:
+Keep both credential files outside the repository with owner-only permissions.
+After installing the locked bundle below, verify the Play hook through its path;
+the command does not print or copy the document:
+
+```bash
+chmod 600 "$PLAY_SERVICE_ACCOUNT_JSON"
+FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane run \
+  validate_play_store_json_key json_key:"$PLAY_SERVICE_ACCOUNT_JSON"
+```
+
+From a clean worktree at a commit on `origin/main`, with locked dependencies
+installed:
 
 ```bash
 npm ci
@@ -95,6 +115,24 @@ npm ci
 npm run release:verify
 scripts/mobile-release.sh ios
 scripts/mobile-release.sh android
+```
+
+The first Android bootstrap is intentionally two steps. Produce the signed AAB
+without granting the local process upload authority:
+
+```bash
+scripts/mobile-release.sh android
+```
+
+Then, as the founder, upload
+`release-artifacts/ZUULI-<VERSION>+<BUILD>-android.aab` once through Play Console
+to the internal track. Do not use the `z/hhanh00/zwallet/docker/*.jks` samples:
+ZUULI needs its own backed-up upload key. After Google accepts that first
+AAB, tagged releases use the exact audited command:
+
+```bash
+export ZUULI_CONFIRM_UPLOAD="$(jq -r '.version + "+" + (.build | tostring)' release.json)"
+scripts/mobile-release.sh android --upload
 ```
 
 These commands sign and validate without uploading. To make the irreversible
@@ -137,6 +175,18 @@ ANDROID_KEY_PASSWORD
 PLAY_SERVICE_ACCOUNT_JSON_BASE64
 APPLE_DEVELOPER_ID_CERTIFICATE_BASE64
 APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD
+```
+
+Create the protected environment before installing credentials. Feed the Play
+JSON through standard input so neither the JSON nor its base64 encoding appears
+in shell history or process arguments:
+
+```bash
+gh api --method PUT repos/free2z/zuu/environments/zuuli-app-stores \
+  --input - <<<'{"wait_timer":0,"prevent_self_review":false}' >/dev/null
+base64 < "$PLAY_SERVICE_ACCOUNT_JSON" | tr -d '\n' | \
+  gh secret set PLAY_SERVICE_ACCOUNT_JSON_BASE64 \
+    --repo free2z/zuu --env zuuli-app-stores
 ```
 
 The final two are needed only for direct-download macOS signing/notarization.
@@ -190,3 +240,12 @@ Any seed-recovery, signing, wallet-consistency, store-validation, or ambiguous
 broadcast failure stops promotion. Disable the workflow environment or remove
 tester availability while investigating; never reuse that build identity for a
 fix.
+
+## Release records for cryptography
+
+ZUULI contains cryptography. Store export-compliance checkboxes are declarations,
+not an export classification. This does not block internal TestFlight or Play
+testing. Before public production distribution, Corpora should retain a concise
+export-classification memo covering the applicable EAR, encryption, and
+mass-market analysis. Record the conclusion and supporting facts without
+asserting a specific ECCN in this runbook.

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -1,0 +1,192 @@
+# Releasing ZUULI
+
+ZUULI ships from one reviewed commit under one immutable identity. The current
+identity is `0.1.0+1`: marketing version `0.1.0`, Apple build `1`, Android
+`versionCode` `1`, and package/bundle identifier `cash.free2z.zuuli`.
+
+`release.json` is the source of truth. `npm run release:verify` fails if the npm,
+Cargo, Tauri, generated Xcode, or generated Gradle representation disagrees.
+Never fix a release mismatch with Tauri's `--ignore-version-mismatches` switch.
+
+The train pins Node `24.18.0`, Rust `1.88.0`, Java `21.0.12`, Xcode `26.6`,
+Android SDK/build tools `36`/`36.0.0`, Android NDK `27.0.12077973`, Gradle
+`8.14.3` with its distribution checksum, Fastlane `2.237.0` through a
+checksum-bearing Bundler `4.0.3` lockfile, and Syft `1.50.0`. Action dependencies
+are commit-SHA pinned. Upgrade these together in a reviewed dependency PR.
+
+## One-time owner bootstrap
+
+Apple and Google require the owner to create a new app record in their web
+consoles. This is intentionally outside CI.
+
+### App Store Connect (Corpora Inc)
+
+1. In Certificates, Identifiers & Profiles, register the explicit App ID
+   `cash.free2z.zuuli` under team `F9AV5HKF6N` and enable only the capabilities
+   present in the committed entitlements.
+2. In App Store Connect **Apps**, create `ZUULI` with that bundle ID. Record the
+   SKU privately. App Store Connect API keys cannot create app records.
+3. Create an App Store Connect API key with the Admin role so Xcode automatic
+   provisioning can manage certificates and profiles. Save the `.p8`
+   exactly once and record its key ID and issuer ID.
+4. Create/download an App Store Connect distribution profile if automatic
+   provisioning is not used. The protected CI lane uses Xcode automatic
+   provisioning authenticated by the API key.
+5. Add internal TestFlight testers and complete the export-compliance/beta
+   metadata prompts after Apple processes the first upload.
+
+### Google Play (Corpora)
+
+1. In Play Console **All apps → Create app**, create `ZUULI` for
+   `cash.free2z.zuuli`, accept Play App Signing, and finish the mandatory app,
+   policy, data-safety, and tester setup pages.
+2. Generate a dedicated upload key, back it up offline, and retain the same key
+   for future updates. Play App Signing protects the app-signing key; CI holds
+   only the replaceable upload key.
+3. Create a dedicated Google Cloud service account, enable the Android Publisher
+   API, and grant that principal release permission to ZUULI only.
+4. Google requires the first signed AAB to establish the package/signature in
+   Play Console. Upload the locally produced AAB to the internal-testing release
+   once; after that, the protected workflow performs uploads through the API.
+
+Primary references:
+
+- Apple: https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/
+- Apple distribution: https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases
+- Android signing: https://developer.android.com/studio/publish/app-signing
+- Google Publisher tracks: https://developers.google.com/android-publisher/tracks
+- Tauri iOS/App Store: https://v2.tauri.app/distribute/app-store/
+- Tauri Google Play: https://v2.tauri.app/distribute/google-play/
+
+## Local signed dry run
+
+Credentials are paths or environment values; never paste a private key, service
+account document, seed phrase, or password into a command line. Disable shell
+tracing (`set +x`) before loading them. The scripts reject symlink credential
+paths, a partial Android signing setup, and dirty source trees.
+
+Apple variables:
+
+```text
+APPLE_TEAM_ID
+ASC_KEY_ID
+ASC_ISSUER_ID
+ASC_KEY_PATH                 path to the .p8 file
+```
+
+The Apple Distribution identity must already be present in the login Keychain.
+Xcode may obtain the matching provisioning profile with the API key.
+
+Android variables:
+
+```text
+ANDROID_KEYSTORE_PATH        path to the upload-key JKS
+ANDROID_KEYSTORE_PASSWORD
+ANDROID_KEY_ALIAS
+ANDROID_KEY_PASSWORD
+PLAY_SERVICE_ACCOUNT_JSON   path to the JSON file; upload only
+```
+
+From a clean, tagged worktree with locked dependencies installed:
+
+```bash
+npm ci
+/opt/homebrew/opt/ruby/bin/bundle install # Android upload tooling on this Mac
+npm run release:verify
+scripts/mobile-release.sh ios
+scripts/mobile-release.sh android
+```
+
+These commands sign and validate without uploading. To make the irreversible
+store call, the release tag must point at `HEAD` and the exact identity must be
+confirmed:
+
+```bash
+export ZUULI_CONFIRM_UPLOAD=0.1.0+1
+scripts/mobile-release.sh ios --upload
+scripts/mobile-release.sh android --upload
+```
+
+## Protected GitHub release
+
+Create a GitHub environment named `zuuli-app-stores` and restrict deployments to
+protected release tags. In founder mode the owner can dispatch it directly and
+can admin-merge after every automated gate is green; add a required environment
+approver when another operator is consistently available. Ordinary PR workflows
+have read-only permissions and never reference this environment or its secrets.
+
+Environment variables:
+
+```text
+APPLE_TEAM_ID
+ASC_KEY_ID
+ASC_ISSUER_ID
+APPLE_DEVELOPER_ID_IDENTITY
+```
+
+Environment secrets:
+
+```text
+ASC_KEY_BASE64
+APPLE_DISTRIBUTION_CERTIFICATE_BASE64
+APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD
+ANDROID_KEYSTORE_BASE64
+ANDROID_KEYSTORE_PASSWORD
+ANDROID_KEY_ALIAS
+ANDROID_KEY_PASSWORD
+PLAY_SERVICE_ACCOUNT_JSON_BASE64
+APPLE_DEVELOPER_ID_CERTIFICATE_BASE64
+APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD
+```
+
+The final two are needed only for direct-download macOS signing/notarization.
+Base64 values are decoded only into mode-0700 runner-temporary directories and
+destroyed even when a job fails. GitHub never exports store secrets into a PR.
+
+1. Merge only with the required `gate` and `ZUULI / packaging smoke` green.
+2. From a clean version worktree run
+   `npm run release:bump -- --version=<VERSION> --build=<BUILD>`, review every
+   generated change, run `npm run release:verify`, and merge the version PR.
+3. Create an annotated (preferably signed) tag on that exact remote commit as
+   `git tag -s zuuli-v<VERSION>+<BUILD> <SHA>` and push it. Signed uploads refuse
+   a lightweight, missing, mismatched, or non-`origin/main` tag.
+4. Dispatch **ZUULI / protected release** with the full 40-character commit SHA,
+   exact identity, desired target, and `dry_run=true`.
+5. Inspect the signed package, SBOM, checksum manifest, GitHub attestation, and
+   App Store validation. Then select the release tag in the workflow's **Use
+   workflow from** control and dispatch the same SHA/identity with
+   `dry_run=false`. The tag selection is mandatory and lets environment branch
+   policy protect the credential-bearing run.
+6. Wait for App Store processing; assign the build to internal TestFlight.
+   Confirm the Play internal release is available to the tester list.
+
+Store build numbers are append-only. Signed packages are not bit-reproducible:
+timestamps and signatures can change on a rebuild, while neither store permits a
+different package to replace an uploaded version/build. Never change source under
+an existing identity. After a partial failure, inspect both stores and the draft
+GitHub release, then rerun only the missing target; an existing release asset is
+accepted only when its checksum matches and is never overwritten. If an upload is
+ambiguous or a different artifact is required, increment `build`, merge, tag, and
+dispatch again.
+
+## Kick-the-tires gate
+
+Before widening either tester cohort:
+
+- install TestFlight on a physical iPhone/iPad and Play internal on API 29 and a
+  current Android device;
+- create a new 24-word wallet, back it up offline, and prove restore in an
+  isolated profile;
+- migrate the legacy development wallet and compare its expected address;
+- sync to tip, receive a tiny amount, restart during sync, send a tiny amount,
+  and confirm the durable-send recovery UI after forced interruption;
+- exercise Free2Z login/deep-link return, article playback, AI, and live media;
+- verify denial paths for camera/microphone, offline startup, app upgrade with
+  wallet data intact, and delete/reinstall behavior;
+- record device/OS/build, checksums, transactions, failures, and stop/go decision
+  on issue #238 without recording secrets or seed words.
+
+Any seed-recovery, signing, wallet-consistency, store-validation, or ambiguous
+broadcast failure stops promotion. Disable the workflow environment or remove
+tester availability while investigating; never reuse that build identity for a
+fix.

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -16,23 +16,20 @@ are commit-SHA pinned. Upgrade these together in a reviewed dependency PR.
 
 ## One-time owner bootstrap
 
-Apple and Google require the owner to create a new app record in their web
-consoles. This is intentionally outside CI.
+The owner has created both store records and the dedicated automation
+principals. Their current state is recorded here so a fresh operator does not
+repeat bootstrap work or substitute unrelated credentials.
 
 ### App Store Connect (Corpora Inc)
 
-1. In Certificates, Identifiers & Profiles, register the explicit App ID
-   `cash.free2z.zuuli` under team `F9AV5HKF6N` and enable only the capabilities
-   present in the committed entitlements.
-2. In App Store Connect **Apps**, create `ZUULI` with that bundle ID. Record the
-   SKU privately. App Store Connect API keys cannot create app records.
-3. Create an App Store Connect API key with the Admin role so Xcode automatic
-   provisioning can manage certificates and profiles. Save the `.p8`
-   exactly once and record its key ID and issuer ID.
-4. Create/download an App Store Connect distribution profile if automatic
-   provisioning is not used. The protected CI lane uses Xcode automatic
-   provisioning authenticated by the API key.
-5. Add internal TestFlight testers and complete the export-compliance/beta
+1. The explicit App ID `cash.free2z.zuuli` exists under team `F9AV5HKF6N`.
+2. App Store Connect app `6799322201` is `ZUULI`, bundle
+   `cash.free2z.zuuli`, SKU `zuuli-ios`, with `en-US` localization.
+3. The protected environment contains the Admin ASC key, dedicated ZUULI Apple
+   Distribution certificate, and profile `ZUULI App Store CI`. CI verifies the
+   profile's team, application identifier, UUID, and certificate linkage before
+   it signs.
+4. Add internal TestFlight testers and complete the export-compliance/beta
    metadata prompts after Apple processes the first upload.
 
 ### Google Play (Corpora)
@@ -48,15 +45,16 @@ consoles. This is intentionally outside CI.
    principal is
    `corpan-play-verifier@corpora1.iam.gserviceaccount.com`; the release script
    rejects a different service-account document.
-4. Google requires the first signed AAB to establish the package/signature in
-   Play Console. Upload the locally produced AAB to the internal-testing release
-   once; after that, the protected workflow performs uploads through the API.
+4. Let the protected workflow attempt the first signed AAB through the Publisher
+   API. If Google returns its package-initialization blocker, upload that exact
+   signed AAB to the internal-testing release once in Play Console; subsequent
+   protected uploads use the API.
 
 The Play app record already exists for `cash.free2z.zuuli`, and the dedicated
 principal has been granted ZUULI admin access. Fastlane's Play JSON-key
-validation succeeds for this account. The first AAB is still a separate manual
-package/signature bootstrap; do not weaken the account check or upload a debug
-key.
+validation succeeds for this account. The first API upload has not run yet.
+Attempt it automatically before falling back to the console bootstrap; do not
+weaken the account check or upload a debug key.
 
 Primary references:
 
@@ -93,6 +91,7 @@ ANDROID_KEYSTORE_PATH        path to the upload-key JKS
 ANDROID_KEYSTORE_PASSWORD
 ANDROID_KEY_ALIAS
 ANDROID_KEY_PASSWORD
+ANDROID_UPLOAD_CERT_SHA256   uppercase colon-delimited SHA-256 certificate fingerprint
 PLAY_SERVICE_ACCOUNT_JSON   path to the JSON file; upload only
 ```
 
@@ -117,29 +116,32 @@ scripts/mobile-release.sh ios
 scripts/mobile-release.sh android
 ```
 
-The first Android bootstrap is intentionally two steps. Produce the signed AAB
-without granting the local process upload authority:
+If and only if the Publisher API returns its first-package initialization
+blocker, produce the signed AAB locally without granting that process upload
+authority:
 
 ```bash
 scripts/mobile-release.sh android
 ```
 
-Then, as the founder, upload
+Then upload
 `release-artifacts/ZUULI-<VERSION>+<BUILD>-android.aab` once through Play Console
 to the internal track. Do not use the `z/hhanh00/zwallet/docker/*.jks` samples:
 ZUULI needs its own backed-up upload key. After Google accepts that first
-AAB, tagged releases use the exact audited command:
+AAB, releases use the exact audited command:
 
 ```bash
+export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
 export ZUULI_CONFIRM_UPLOAD="$(jq -r '.version + "+" + (.build | tostring)' release.json)"
 scripts/mobile-release.sh android --upload
 ```
 
 These commands sign and validate without uploading. To make the irreversible
-store call, the release tag must point at `HEAD` and the exact identity must be
-confirmed:
+store call locally, the exact full `origin/main` source SHA and release identity
+must both be confirmed:
 
 ```bash
+export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
 export ZUULI_CONFIRM_UPLOAD=0.1.0+1
 scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
@@ -147,11 +149,11 @@ scripts/mobile-release.sh android --upload
 
 ## Protected GitHub release
 
-Create a GitHub environment named `zuuli-app-stores` and restrict deployments to
-protected release tags. In founder mode the owner can dispatch it directly and
-can admin-merge after every automated gate is green; add a required environment
-approver when another operator is consistently available. Ordinary PR workflows
-have read-only permissions and never reference this environment or its secrets.
+The GitHub environment `zuuli-app-stores` holds the dedicated mobile signing and
+store credentials. In founder mode it has no required reviewer or wait timer;
+add a required environment approver when another operator is consistently
+available. Ordinary PR workflows have read-only permissions and never reference
+this environment or its secrets.
 
 Environment variables:
 
@@ -159,6 +161,7 @@ Environment variables:
 APPLE_TEAM_ID
 ASC_KEY_ID
 ASC_ISSUER_ID
+ANDROID_UPLOAD_CERT_SHA256
 APPLE_DEVELOPER_ID_IDENTITY
 ```
 
@@ -168,6 +171,7 @@ Environment secrets:
 ASC_KEY_BASE64
 APPLE_DISTRIBUTION_CERTIFICATE_BASE64
 APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD
+APPLE_PROVISIONING_PROFILE_BASE64
 ANDROID_KEYSTORE_BASE64
 ANDROID_KEYSTORE_PASSWORD
 ANDROID_KEY_ALIAS
@@ -197,27 +201,43 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
 2. From a clean version worktree run
    `npm run release:bump -- --version=<VERSION> --build=<BUILD>`, review every
    generated change, run `npm run release:verify`, and merge the version PR.
-3. Create an annotated (preferably signed) tag on that exact remote commit as
-   `git tag -s zuuli-v<VERSION>+<BUILD> <SHA>` and push it. Signed uploads refuse
-   a lightweight, missing, mismatched, or non-`origin/main` tag.
-4. Dispatch **ZUULI / protected release** with the full 40-character commit SHA,
-   exact identity, desired target, and `dry_run=true`.
-5. Inspect the signed package, SBOM, checksum manifest, GitHub attestation, and
-   App Store validation. Then select the release tag in the workflow's **Use
-   workflow from** control and dispatch the same SHA/identity with
-   `dry_run=false`. The tag selection is mandatory and lets environment branch
-   policy protect the credential-bearing run.
+3. A push to `main` that changes an existing `release.json` automatically pins
+   the exact pushed SHA, proves that `build` strictly increased and `version`
+   did not decrease, builds/signs both mobile artifacts, and uploads them to
+   TestFlight and Play internal. Adding `release.json` for the first time is a
+   no-upload baseline, so merging the release infrastructure itself is safe.
+   After that baseline and the wallet-conflict fix are on `main`, make a
+   dedicated `0.1.0+2` bump PR; merging that PR is the first automatic mobile
+   store run.
+4. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
+   attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
+   protected release** with the exact full SHA, identity, missing target, and
+   the appropriate `dry_run` value. A real manual recovery requires the same
+   exact-SHA and identity confirmations as automatic release: the SHA must be
+   the commit that introduced that identity, and it must be monotonic relative
+   to its first parent. It must also match the current `origin/main` release
+   identity, so a superseded build cannot be recovered after a newer release.
+   The initial `release.json` baseline is the only no-previous-identity
+   exception. Desktop `dry_run=true` packaging does not load signing credentials
+   or contact Apple's notarization service.
+5. Optionally create an annotated (preferably signed) tag on that exact remote
+   commit as `zuuli-v<VERSION>+<BUILD>`. If the matching tag exists before a
+   manual recovery run, the workflow also maintains an idempotent draft GitHub
+   release. Store upload authority does not depend on a tag.
 6. Wait for App Store processing; assign the build to internal TestFlight.
    Confirm the Play internal release is available to the tester list.
 
 Store build numbers are append-only. Signed packages are not bit-reproducible:
 timestamps and signatures can change on a rebuild, while neither store permits a
 different package to replace an uploaded version/build. Never change source under
-an existing identity. After a partial failure, inspect both stores and the draft
-GitHub release, then rerun only the missing target; an existing release asset is
-accepted only when its checksum matches and is never overwritten. If an upload is
-ambiguous or a different artifact is required, increment `build`, merge, tag, and
-dispatch again.
+an existing identity. Every protected store transaction shares one concurrency
+lane across all identities, and GitHub's **rerun failed jobs** preserves
+already-successful platform jobs. After a partial failure, inspect both stores
+and the draft GitHub release, then
+rerun only the missing target; an existing release asset is accepted only when
+its checksum matches and is never overwritten. If an upload is ambiguous or a
+different artifact is required, increment `build`, merge, and let the exact new
+source run automatically.
 
 ## Kick-the-tires gate
 

--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
+    "release:verify": "node scripts/release-identity.mjs",
+    "release:bump": "node scripts/release-bump.mjs",
+    "release:manifest": "node scripts/release-manifest.mjs",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./release.schema.json",
+  "schemaVersion": 1,
+  "applicationId": "cash.free2z.zuuli",
+  "version": "0.1.0",
+  "build": 1,
+  "minimums": {
+    "ios": "18.0",
+    "android": 29
+  }
+}

--- a/wallet/zuuli/release.schema.json
+++ b/wallet/zuuli/release.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://free2z.com/schemas/zuuli-release-v1.json",
+  "title": "ZUULI release identity",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "applicationId",
+    "version",
+    "build",
+    "minimums"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schemaVersion": { "const": 1 },
+    "applicationId": { "const": "cash.free2z.zuuli" },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+    },
+    "build": { "type": "integer", "minimum": 1, "maximum": 2100000000 },
+    "minimums": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ios", "android"],
+      "properties": {
+        "ios": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+$" },
+        "android": { "type": "integer", "minimum": 29 }
+      }
+    }
+  }
+}

--- a/wallet/zuuli/scripts/android-toolchain-env.sh
+++ b/wallet/zuuli/scripts/android-toolchain-env.sh
@@ -1,0 +1,35 @@
+# Source this file from Bash before every Android build. Tauri supplies these
+# values too, but explicit exports prevent a developer's stale cargo linker
+# environment from silently selecting a different NDK or API level.
+case "$(uname -s)" in
+  Darwin) zuuli_ndk_host=darwin-x86_64 ;;
+  Linux) zuuli_ndk_host=linux-x86_64 ;;
+  *) echo "unsupported Android build host: $(uname -s)" >&2; return 1 ;;
+esac
+
+: "${ANDROID_HOME:?ANDROID_HOME must point at the Android SDK}"
+export NDK_HOME="$ANDROID_HOME/ndk/27.0.12077973"
+export ANDROID_NDK_HOME="$NDK_HOME"
+zuuli_ndk_bin="$NDK_HOME/toolchains/llvm/prebuilt/$zuuli_ndk_host/bin"
+
+export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$zuuli_ndk_bin/aarch64-linux-android29-clang"
+export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$zuuli_ndk_bin/armv7a-linux-androideabi29-clang"
+export CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$zuuli_ndk_bin/i686-linux-android29-clang"
+export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$zuuli_ndk_bin/x86_64-linux-android29-clang"
+export CC_aarch64_linux_android="$CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER"
+export CC_armv7_linux_androideabi="$CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER"
+export CC_i686_linux_android="$CARGO_TARGET_I686_LINUX_ANDROID_LINKER"
+export CC_x86_64_linux_android="$CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER"
+export CXX_aarch64_linux_android="${CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER}++"
+export CXX_armv7_linux_androideabi="${CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER}++"
+export CXX_i686_linux_android="${CARGO_TARGET_I686_LINUX_ANDROID_LINKER}++"
+export CXX_x86_64_linux_android="${CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER}++"
+
+for zuuli_compiler in \
+  "$CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER" \
+  "$CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER" \
+  "$CARGO_TARGET_I686_LINUX_ANDROID_LINKER" \
+  "$CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER"; do
+  [[ -x "$zuuli_compiler" ]] || { echo "missing pinned NDK compiler: $zuuli_compiler" >&2; return 1; }
+done
+unset zuuli_compiler zuuli_ndk_bin zuuli_ndk_host

--- a/wallet/zuuli/scripts/mobile-release.sh
+++ b/wallet/zuuli/scripts/mobile-release.sh
@@ -128,6 +128,21 @@ else
   require_value ANDROID_KEY_ALIAS
   require_value ANDROID_KEY_PASSWORD
 
+  if [[ "$mode" == --upload ]]; then
+    PLAY_SERVICE_ACCOUNT_JSON=$(canonical_secret_file PLAY_SERVICE_ACCOUNT_JSON)
+    export PLAY_SERVICE_ACCOUNT_JSON
+    if ! jq -e '
+      .type == "service_account" and
+      .project_id == "corpora1" and
+      .client_email == "corpan-play-verifier@corpora1.iam.gserviceaccount.com" and
+      (.private_key_id | type == "string" and length > 0) and
+      (.private_key | type == "string" and startswith("-----BEGIN PRIVATE KEY-----"))
+    ' "$PLAY_SERVICE_ACCOUNT_JSON" >/dev/null; then
+      echo "PLAY_SERVICE_ACCOUNT_JSON is not the dedicated Corpora ZUULI release account" >&2
+      exit 66
+    fi
+  fi
+
   ./node_modules/.bin/tauri android build --ci --aab -- --locked
   aab=$(find_one './src-tauri/gen/android/app/build/outputs/bundle/universalRelease/*.aab')
   # Android upload-key certificates are intentionally self-signed, which makes
@@ -142,7 +157,6 @@ else
   cp "$aab" "release-artifacts/ZUULI-${identity}-android.aab"
 
   if [[ "$mode" == --upload ]]; then
-    PLAY_SERVICE_ACCOUNT_JSON=$(canonical_secret_file PLAY_SERVICE_ACCOUNT_JSON)
     FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane supply \
       --package_name "$application_id" \
       --aab "$aab" \

--- a/wallet/zuuli/scripts/mobile-release.sh
+++ b/wallet/zuuli/scripts/mobile-release.sh
@@ -17,13 +17,20 @@ mode=${2:-}
 [[ "$platform" == ios || "$platform" == android ]] || usage
 [[ -z "$mode" || "$mode" == --upload ]] || usage
 
-identity_json=$(node scripts/release-identity.mjs --require-main)
+identity_args=(--require-main)
+if [[ -n "${ZUULI_RELEASE_SOURCE_SHA:-}" ]]; then
+  identity_args+=("--source-sha=$ZUULI_RELEASE_SOURCE_SHA")
+fi
+identity_json=$(node scripts/release-identity.mjs "${identity_args[@]}")
 identity=$(jq -r .identity <<<"$identity_json")
 build=$(jq -r .build <<<"$identity_json")
 application_id=$(jq -r .applicationId <<<"$identity_json")
 
 if [[ "$mode" == --upload ]]; then
-  node scripts/release-identity.mjs --require-tag >/dev/null
+  if [[ ! "${ZUULI_RELEASE_SOURCE_SHA:-}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "refusing store upload: ZUULI_RELEASE_SOURCE_SHA must be the exact full source SHA" >&2
+    exit 65
+  fi
   if [[ "${ZUULI_CONFIRM_UPLOAD:-}" != "$identity" ]]; then
     echo "refusing store upload: set ZUULI_CONFIRM_UPLOAD=$identity" >&2
     exit 65
@@ -102,6 +109,7 @@ if [[ "$platform" == ios ]]; then
       --export-method app-store-connect \
       -- \
       --locked
+  git diff --exit-code
 
   ipa=$(find_one './src-tauri/gen/apple/build/arm64/*.ipa')
   ipa_abs="$app_dir/${ipa#./}"
@@ -127,6 +135,20 @@ else
   require_value ANDROID_KEYSTORE_PASSWORD
   require_value ANDROID_KEY_ALIAS
   require_value ANDROID_KEY_PASSWORD
+  require_value ANDROID_UPLOAD_CERT_SHA256
+  if [[ ! "$ANDROID_UPLOAD_CERT_SHA256" =~ ^([0-9A-F]{2}:){31}[0-9A-F]{2}$ ]]; then
+    echo "ANDROID_UPLOAD_CERT_SHA256 must be an uppercase colon-delimited SHA-256 fingerprint" >&2
+    exit 66
+  fi
+  actual_upload_fingerprint=$(keytool -list -v \
+    -keystore "$ANDROID_KEYSTORE_PATH" \
+    -storepass:env ANDROID_KEYSTORE_PASSWORD \
+    -alias "$ANDROID_KEY_ALIAS" | awk -F'SHA256: ' '/SHA256: / {print $2; exit}')
+  if [[ "$actual_upload_fingerprint" != "$ANDROID_UPLOAD_CERT_SHA256" ]]; then
+    echo "Android upload certificate fingerprint does not match the protected release identity" >&2
+    exit 66
+  fi
+  unset actual_upload_fingerprint
 
   if [[ "$mode" == --upload ]]; then
     PLAY_SERVICE_ACCOUNT_JSON=$(canonical_secret_file PLAY_SERVICE_ACCOUNT_JSON)
@@ -144,6 +166,8 @@ else
   fi
 
   ./node_modules/.bin/tauri android build --ci --aab -- --locked
+  node scripts/normalize-generated-android-manifest.mjs
+  git diff --exit-code
   aab=$(find_one './src-tauri/gen/android/app/build/outputs/bundle/universalRelease/*.aab')
   # Android upload-key certificates are intentionally self-signed, which makes
   # jarsigner --strict return 4 even when the archive signature is valid.

--- a/wallet/zuuli/scripts/mobile-release.sh
+++ b/wallet/zuuli/scripts/mobile-release.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+app_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
+cd "$app_dir"
+
+usage() {
+  echo "usage: scripts/mobile-release.sh <ios|android> [--upload]" >&2
+  exit 64
+}
+
+platform=${1:-}
+mode=${2:-}
+[[ $# -le 2 ]] || usage
+[[ "$platform" == ios || "$platform" == android ]] || usage
+[[ -z "$mode" || "$mode" == --upload ]] || usage
+
+identity_json=$(node scripts/release-identity.mjs --require-main)
+identity=$(jq -r .identity <<<"$identity_json")
+build=$(jq -r .build <<<"$identity_json")
+application_id=$(jq -r .applicationId <<<"$identity_json")
+
+if [[ "$mode" == --upload ]]; then
+  node scripts/release-identity.mjs --require-tag >/dev/null
+  if [[ "${ZUULI_CONFIRM_UPLOAD:-}" != "$identity" ]]; then
+    echo "refusing store upload: set ZUULI_CONFIRM_UPLOAD=$identity" >&2
+    exit 65
+  fi
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "refusing release from a dirty worktree" >&2
+  exit 65
+fi
+
+require_value() {
+  local name=$1
+  if [[ -z "${!name:-}" ]]; then
+    echo "missing required environment variable: $name" >&2
+    exit 66
+  fi
+}
+
+require_secret_file() {
+  local name=$1
+  require_value "$name"
+  local path=${!name}
+  if [[ ! -f "$path" || -L "$path" ]]; then
+    echo "$name must name a regular, non-symlink file" >&2
+    exit 66
+  fi
+}
+
+canonical_secret_file() {
+  local name=$1 path parent
+  require_secret_file "$name"
+  path=${!name}
+  parent=$(CDPATH= cd -P -- "$(dirname -- "$path")" && pwd)
+  printf '%s/%s\n' "$parent" "$(basename -- "$path")"
+}
+
+find_one() {
+  local pattern=$1
+  local -a matches=()
+  while IFS= read -r -d '' path; do matches+=("$path"); done < <(find . -type f -path "$pattern" -print0)
+  if [[ ${#matches[@]} -ne 1 ]]; then
+    echo "expected exactly one artifact matching $pattern, found ${#matches[@]}" >&2
+    exit 70
+  fi
+  printf '%s\n' "${matches[0]}"
+}
+
+mkdir -p release-artifacts
+
+if [[ "$platform" == ios ]]; then
+  require_value APPLE_TEAM_ID
+  if [[ "$APPLE_TEAM_ID" != "F9AV5HKF6N" ]]; then
+    echo "APPLE_TEAM_ID must be the configured Corpora team F9AV5HKF6N" >&2
+    exit 66
+  fi
+  require_value ASC_KEY_ID
+  require_value ASC_ISSUER_ID
+  ASC_KEY_PATH=$(canonical_secret_file ASC_KEY_PATH)
+
+  key_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-asc.XXXXXX")
+  cleanup_apple_key() {
+    rm -f "$key_dir"/private_keys/AuthKey_*.p8
+    rmdir "$key_dir/private_keys" "$key_dir" 2>/dev/null || true
+  }
+  trap cleanup_apple_key EXIT
+  mkdir "$key_dir/private_keys"
+  cp "$ASC_KEY_PATH" "$key_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+
+  APPLE_TEAM_ID="$APPLE_TEAM_ID" \
+    APPLE_API_ISSUER="$ASC_ISSUER_ID" \
+    APPLE_API_KEY="$ASC_KEY_ID" \
+    APPLE_API_KEY_PATH="$key_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8" \
+    ./node_modules/.bin/tauri ios build \
+      --ci \
+      --export-method app-store-connect \
+      -- \
+      --locked
+
+  ipa=$(find_one './src-tauri/gen/apple/build/arm64/*.ipa')
+  ipa_abs="$app_dir/${ipa#./}"
+  (
+    cd "$key_dir"
+    xcrun altool --validate-app --type ios --file "$ipa_abs" \
+      --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+  )
+  cp "$ipa" "release-artifacts/ZUULI-${identity}-ios.ipa"
+
+  if [[ "$mode" == --upload ]]; then
+    (
+      cd "$key_dir"
+      xcrun altool --upload-app --type ios --file "$ipa_abs" \
+        --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+    )
+  fi
+else
+  # shellcheck source=android-toolchain-env.sh
+  source "$script_dir/android-toolchain-env.sh"
+  ANDROID_KEYSTORE_PATH=$(canonical_secret_file ANDROID_KEYSTORE_PATH)
+  export ANDROID_KEYSTORE_PATH
+  require_value ANDROID_KEYSTORE_PASSWORD
+  require_value ANDROID_KEY_ALIAS
+  require_value ANDROID_KEY_PASSWORD
+
+  ./node_modules/.bin/tauri android build --ci --aab -- --locked
+  aab=$(find_one './src-tauri/gen/android/app/build/outputs/bundle/universalRelease/*.aab')
+  # Android upload-key certificates are intentionally self-signed, which makes
+  # jarsigner --strict return 4 even when the archive signature is valid.
+  if ! signature_report=$(jarsigner -verify -certs "$aab" 2>&1) ||
+    ! grep -Fq "jar verified." <<<"$signature_report" ||
+    grep -Fqi "unsigned" <<<"$signature_report"; then
+    echo "Android bundle signature verification failed" >&2
+    exit 70
+  fi
+  unset signature_report
+  cp "$aab" "release-artifacts/ZUULI-${identity}-android.aab"
+
+  if [[ "$mode" == --upload ]]; then
+    PLAY_SERVICE_ACCOUNT_JSON=$(canonical_secret_file PLAY_SERVICE_ACCOUNT_JSON)
+    FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane supply \
+      --package_name "$application_id" \
+      --aab "$aab" \
+      --json_key "$PLAY_SERVICE_ACCOUNT_JSON" \
+      --track internal \
+      --release_status completed \
+      --skip_upload_apk true \
+      --skip_upload_metadata true \
+      --skip_upload_images true \
+      --skip_upload_screenshots true
+  fi
+fi
+
+echo "ZUULI $identity $platform release validation completed ($([[ "$mode" == --upload ]] && echo uploaded || echo dry-run))."

--- a/wallet/zuuli/scripts/normalize-generated-android-manifest.mjs
+++ b/wallet/zuuli/scripts/normalize-generated-android-manifest.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const manifestPath = resolve(
+  appDir,
+  "src-tauri/gen/android/app/src/main/AndroidManifest.xml",
+);
+const manifest = readFileSync(manifestPath, "utf8");
+
+if (!manifest.includes("DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE.")) {
+  throw new Error(
+    "refusing to normalize an Android manifest without Tauri's deep-link marker",
+  );
+}
+
+const normalized = manifest.replace(/^[\t ]+$/gm, "");
+if (normalized !== manifest) writeFileSync(manifestPath, normalized);

--- a/wallet/zuuli/scripts/publish-github-release.sh
+++ b/wallet/zuuli/scripts/publish-github-release.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: scripts/publish-github-release.sh <tag> <identity> <artifact-root>" >&2
+  exit 64
+fi
+
+tag=$1
+identity=$2
+artifact_root=$3
+[[ -d "$artifact_root" ]] || { echo "artifact root does not exist: $artifact_root" >&2; exit 66; }
+
+if ! gh release view "$tag" >/dev/null 2>&1; then
+  gh release create "$tag" --verify-tag --draft \
+    --title "ZUULI $identity" \
+    --notes "Immutable ZUULI $identity release candidate. Store promotion evidence is attached; keep draft until physical-device verification passes."
+elif [[ "$(gh release view "$tag" --json isDraft --jq .isDraft)" != true ]]; then
+  echo "release $tag is already published; refusing to mutate it" >&2
+  exit 73
+fi
+
+package_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-github-release.XXXXXX")
+for directory in "$artifact_root"/*; do
+  [[ -d "$directory" ]] || continue
+  name=$(basename "$directory")
+  archive="$package_dir/$name.tar.gz"
+  tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner \
+    -cf - -C "$directory" . | gzip -n > "$archive"
+
+  comparison_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-release-compare.XXXXXX")
+  if gh release download "$tag" --pattern "$name.tar.gz" --dir "$comparison_dir" >/dev/null 2>&1; then
+    existing="$comparison_dir/$name.tar.gz"
+    if [[ "$(shasum -a 256 "$existing" | cut -d ' ' -f 1)" != "$(shasum -a 256 "$archive" | cut -d ' ' -f 1)" ]]; then
+      echo "release asset collision for $name.tar.gz; refusing overwrite" >&2
+      exit 73
+    fi
+    echo "$name.tar.gz already exists with the same checksum; keeping it"
+  else
+    gh release upload "$tag" "$archive"
+  fi
+done

--- a/wallet/zuuli/scripts/release-bump.mjs
+++ b/wallet/zuuli/scripts/release-bump.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const argument = (name) =>
+  process.argv.find((item) => item.startsWith(`--${name}=`))?.split("=", 2)[1];
+const version = argument("version");
+const buildText = argument("build");
+const build = Number(buildText);
+
+if (!version || !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)) {
+  throw new Error("--version must be a strict major.minor.patch value");
+}
+if (
+  !buildText ||
+  !/^\d+$/.test(buildText) ||
+  !Number.isSafeInteger(build) ||
+  build < 1 ||
+  build > 2_100_000_000
+) {
+  throw new Error("--build must be an integer from 1 through 2100000000");
+}
+if (
+  execFileSync("git", ["status", "--porcelain"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim()
+) {
+  throw new Error("release bump requires a clean worktree");
+}
+
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const replacements = new Map();
+const replaceOne = (path, pattern, replacement, label) => {
+  const before = replacements.get(path) ?? read(path);
+  const matches = before.match(
+    new RegExp(
+      pattern.source,
+      `${pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`}`,
+    ),
+  );
+  if (!matches || matches.length !== 1)
+    throw new Error(
+      `${label}: expected exactly one match, got ${matches?.length ?? 0}`,
+    );
+  replacements.set(path, before.replace(pattern, replacement));
+};
+const replaceJsonVersion = (path) => {
+  const value = JSON.parse(read(path));
+  value.version = version;
+  if (path === "package-lock.json") value.packages[""].version = version;
+  replacements.set(path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const release = JSON.parse(read("release.json"));
+release.version = version;
+release.build = build;
+replacements.set("release.json", `${JSON.stringify(release, null, 2)}\n`);
+replaceJsonVersion("package.json");
+replaceJsonVersion("package-lock.json");
+
+replaceOne(
+  "src-tauri/Cargo.toml",
+  /^version\s*=\s*"[^"]+"/m,
+  `version = "${version}"`,
+  "Cargo.toml version",
+);
+replaceOne(
+  "src-tauri/Cargo.lock",
+  /(\[\[package\]\]\nname = "zuuli"\nversion = ")[^"]+("\n)/m,
+  `$1${version}$2`,
+  "Cargo.lock zuuli version",
+);
+
+replaceOne(
+  "src-tauri/tauri.conf.json",
+  /("version":\s*")[^"]+(")/,
+  `$1${version}$2`,
+  "Tauri marketing version",
+);
+replaceOne(
+  "src-tauri/tauri.conf.json",
+  /("bundleVersion":\s*")[^"]+(")/,
+  `$1${build}$2`,
+  "Tauri iOS build",
+);
+replaceOne(
+  "src-tauri/tauri.conf.json",
+  /("versionCode":\s*)\d+/,
+  `$1${build}`,
+  "Tauri Android build",
+);
+
+replaceOne(
+  "src-tauri/gen/apple/project.yml",
+  /(CFBundleShortVersionString:\s*)[^\s]+/,
+  `$1${version}`,
+  "XcodeGen marketing version",
+);
+replaceOne(
+  "src-tauri/gen/apple/project.yml",
+  /(CFBundleVersion:\s*)"?[^"\s]+"?/,
+  `$1"${build}"`,
+  "XcodeGen build",
+);
+replaceOne(
+  "src-tauri/gen/apple/zuuli_iOS/Info.plist",
+  /(<key>CFBundleShortVersionString<\/key>\s*<string>)[^<]+(<\/string>)/,
+  `$1${version}$2`,
+  "generated iOS marketing version",
+);
+replaceOne(
+  "src-tauri/gen/apple/zuuli_iOS/Info.plist",
+  /(<key>CFBundleVersion<\/key>\s*<string>)[^<]+(<\/string>)/,
+  `$1${build}$2`,
+  "generated iOS build",
+);
+replaceOne(
+  "src-tauri/gen/android/app/build.gradle.kts",
+  /(tauri\.android\.versionCode",\s*")[^"]+("\))/,
+  `$1${build}$2`,
+  "Android fallback build",
+);
+replaceOne(
+  "src-tauri/gen/android/app/build.gradle.kts",
+  /(tauri\.android\.versionName",\s*")[^"]+("\))/,
+  `$1${version}$2`,
+  "Android fallback version",
+);
+
+for (const [path, contents] of replacements) {
+  const absolute = resolve(root, path);
+  const temporary = `${absolute}.release-bump.tmp`;
+  writeFileSync(temporary, contents, { mode: statSync(absolute).mode });
+  renameSync(temporary, absolute);
+}
+
+console.log(`updated ZUULI release identity to ${version}+${build}`);
+console.log("review the diff and run npm run release:verify before committing");

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -63,6 +63,9 @@ const gradleWrapper = read(
   "src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties",
 );
 const gradleProperties = read("src-tauri/gen/android/gradle.properties");
+const androidManifest = read(
+  "src-tauri/gen/android/app/src/main/AndroidManifest.xml",
+);
 const androidToolchain = read("scripts/android-toolchain-env.sh");
 const gemLock = read("Gemfile.lock");
 
@@ -174,6 +177,8 @@ if (!pbxproj.includes('CODE_SIGN_IDENTITY = "Apple Distribution";'))
   failures.push(
     "generated Xcode release signing identity is not Apple Distribution",
   );
+if (!pbxproj.includes('PROVISIONING_PROFILE_SPECIFIER = "ZUULI App Store CI";'))
+  failures.push("generated Xcode release provisioning profile is not pinned");
 for (const privacyKey of [
   "NSCameraUsageDescription",
   "NSFaceIDUsageDescription",
@@ -221,6 +226,18 @@ expect(
   capture(/applicationId\s*=\s*"([^"]+)"/, gradle, "Android applicationId"),
   release.applicationId,
 );
+if (/^[\t ]+$/m.test(androidManifest))
+  failures.push("generated Android manifest contains whitespace-only lines");
+for (const callbackElement of [
+  `<data android:scheme="${callbackScheme}" />`,
+  '<data android:host="oauth" />',
+  '<data android:path="/callback" />',
+]) {
+  if (!androidManifest.includes(callbackElement))
+    failures.push(
+      `generated Android OAuth callback is missing ${callbackElement}`,
+    );
+}
 expect(
   "Android fallback version name",
   capture(
@@ -382,15 +399,86 @@ if (process.argv.includes("--require-tag")) {
 const sourceArg = process.argv.find((arg) => arg.startsWith("--source-sha="));
 if (sourceArg) {
   const required = sourceArg.slice("--source-sha=".length);
-  const head = execFileSync("git", ["rev-parse", "HEAD"], {
-    cwd: root,
-    encoding: "utf8",
-  }).trim();
   if (!/^[0-9a-f]{40}$/.test(required))
     failures.push(
       "--source-sha must be a full lowercase 40-character commit SHA",
     );
-  expect("checked-out source SHA", head, required);
+  else {
+    const head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    expect("checked-out source SHA", head, required);
+  }
+}
+
+const newerArg = process.argv.find((arg) =>
+  arg.startsWith("--require-newer-than="),
+);
+if (newerArg) {
+  const previousSha = newerArg.slice("--require-newer-than=".length);
+  if (!/^[0-9a-f]{40}$/.test(previousSha)) {
+    failures.push(
+      "--require-newer-than must be a full lowercase 40-character commit SHA",
+    );
+  } else {
+    try {
+      const head = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: root,
+        encoding: "utf8",
+      }).trim();
+      execFileSync("git", ["merge-base", "--is-ancestor", previousSha, head], {
+        cwd: root,
+        stdio: "ignore",
+      });
+      const previous = JSON.parse(
+        execFileSync(
+          "git",
+          ["show", `${previousSha}:wallet/zuuli/release.json`],
+          { cwd: root, encoding: "utf8" },
+        ),
+      );
+      if (
+        previous.schemaVersion !== 1 ||
+        previous.applicationId !== release.applicationId
+      ) {
+        failures.push(
+          "previous release identity has an incompatible schema or application ID",
+        );
+      }
+      if (!Number.isSafeInteger(previous.build) || previous.build < 1) {
+        failures.push("previous release build is not a positive safe integer");
+      } else if (release.build <= previous.build) {
+        failures.push(
+          `release build must increase: ${release.build} is not greater than ${previous.build}`,
+        );
+      }
+      const semverCore = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+      const previousVersion = semverCore.exec(previous.version ?? "");
+      const currentVersion = semverCore.exec(release.version ?? "");
+      if (!previousVersion) {
+        failures.push("previous release version is not strict SemVer core");
+      } else if (currentVersion) {
+        const previousParts = previousVersion.slice(1).map(Number);
+        const currentParts = currentVersion.slice(1).map(Number);
+        const versionOrder = currentParts.findIndex(
+          (part, index) => part !== previousParts[index],
+        );
+        if (
+          versionOrder !== -1 &&
+          currentParts[versionOrder] < previousParts[versionOrder]
+        ) {
+          failures.push(
+            `release version must not decrease: ${release.version} is older than ${previous.version}`,
+          );
+        }
+      }
+    } catch {
+      failures.push(
+        "previous release source is missing, malformed, or not an ancestor of HEAD",
+      );
+    }
+  }
 }
 
 if (failures.length) {

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (path) => readFileSync(resolve(root, path), "utf8");
+const json = (path) => JSON.parse(read(path));
+const release = json("release.json");
+const failures = [];
+
+function expect(label, actual, expected) {
+  if (`${actual}` !== `${expected}`) {
+    failures.push(
+      `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function capture(pattern, text, label) {
+  const match = text.match(pattern);
+  if (!match) {
+    failures.push(`${label}: value not found`);
+    return undefined;
+  }
+  return match[1];
+}
+
+expect("release schema version", release.schemaVersion, 1);
+expect("release application ID", release.applicationId, "cash.free2z.zuuli");
+expect("release minimum iOS", release.minimums?.ios, "18.0");
+expect("release minimum Android", release.minimums?.android, 29);
+
+if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(release.version)) {
+  failures.push(
+    `release.json version is not strict SemVer core: ${release.version}`,
+  );
+}
+if (
+  !Number.isSafeInteger(release.build) ||
+  release.build < 1 ||
+  release.build > 2_100_000_000
+) {
+  failures.push(
+    `release.json build must be an integer from 1 through 2100000000: ${release.build}`,
+  );
+}
+
+const packageJson = json("package.json");
+const packageLock = json("package-lock.json");
+const tauri = json("src-tauri/tauri.conf.json");
+const cargo = read("src-tauri/Cargo.toml");
+const cargoLock = read("src-tauri/Cargo.lock");
+const project = read("src-tauri/gen/apple/project.yml");
+const plist = read("src-tauri/gen/apple/zuuli_iOS/Info.plist");
+const plistSource = read("src-tauri/Info.ios.plist");
+const pbxproj = read("src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj");
+const rustToolchain = read("../rust-toolchain.toml");
+const gradle = read("src-tauri/gen/android/app/build.gradle.kts");
+const gradleWrapper = read(
+  "src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties",
+);
+const gradleProperties = read("src-tauri/gen/android/gradle.properties");
+const androidToolchain = read("scripts/android-toolchain-env.sh");
+const gemLock = read("Gemfile.lock");
+
+expect("package.json version", packageJson.version, release.version);
+expect("package-lock.json version", packageLock.version, release.version);
+expect(
+  "package-lock.json root version",
+  packageLock.packages?.[""]?.version,
+  release.version,
+);
+expect(
+  "Cargo.toml package version",
+  capture(/^version\s*=\s*"([^"]+)"/m, cargo, "Cargo.toml package version"),
+  release.version,
+);
+expect(
+  "Cargo.lock zuuli package version",
+  capture(
+    /\[\[package\]\]\nname = "zuuli"\nversion = "([^"]+)"/m,
+    cargoLock,
+    "Cargo.lock zuuli package version",
+  ),
+  release.version,
+);
+expect("tauri.conf.json version", tauri.version, release.version);
+expect("tauri.conf.json identifier", tauri.identifier, release.applicationId);
+expect(
+  "tauri iOS bundleVersion",
+  tauri.bundle?.iOS?.bundleVersion,
+  release.build,
+);
+expect("tauri Apple team", tauri.bundle?.iOS?.developmentTeam, "F9AV5HKF6N");
+expect(
+  "tauri Android versionCode",
+  tauri.bundle?.android?.versionCode,
+  release.build,
+);
+expect(
+  "tauri iOS minimum",
+  tauri.bundle?.iOS?.minimumSystemVersion,
+  release.minimums.ios,
+);
+expect(
+  "tauri Android minimum",
+  tauri.bundle?.android?.minSdkVersion,
+  release.minimums.android,
+);
+
+expect(
+  "XcodeGen bundle identifier",
+  capture(
+    /PRODUCT_BUNDLE_IDENTIFIER:\s*([^\s]+)/,
+    project,
+    "XcodeGen bundle identifier",
+  ),
+  release.applicationId,
+);
+expect(
+  "XcodeGen marketing version",
+  capture(
+    /CFBundleShortVersionString:\s*([^\s]+)/,
+    project,
+    "XcodeGen marketing version",
+  ),
+  release.version,
+);
+expect(
+  "XcodeGen build",
+  capture(/CFBundleVersion:\s*"?([^"\s]+)"?/, project, "XcodeGen build"),
+  release.build,
+);
+expect(
+  "XcodeGen Apple team",
+  capture(/DEVELOPMENT_TEAM:\s*([^\s]+)/, project, "XcodeGen Apple team"),
+  "F9AV5HKF6N",
+);
+expect(
+  "generated iOS marketing version",
+  capture(
+    /<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/,
+    plist,
+    "generated iOS marketing version",
+  ),
+  release.version,
+);
+expect(
+  "generated iOS build",
+  capture(
+    /<key>CFBundleVersion<\/key>\s*<string>([^<]+)<\/string>/,
+    plist,
+    "generated iOS build",
+  ),
+  release.build,
+);
+expect(
+  "generated iOS bundle identifier",
+  capture(
+    /PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);/,
+    pbxproj,
+    "generated iOS bundle identifier",
+  ),
+  release.applicationId,
+);
+if (!pbxproj.includes('CODE_SIGN_IDENTITY = "Apple Development";'))
+  failures.push(
+    "generated Xcode debug signing identity is not Apple Development",
+  );
+if (!pbxproj.includes('CODE_SIGN_IDENTITY = "Apple Distribution";'))
+  failures.push(
+    "generated Xcode release signing identity is not Apple Distribution",
+  );
+for (const privacyKey of [
+  "NSCameraUsageDescription",
+  "NSFaceIDUsageDescription",
+  "NSMicrophoneUsageDescription",
+]) {
+  const sourceValue = capture(
+    new RegExp(`<key>${privacyKey}<\\/key>\\s*<string>([^<]+)<\\/string>`),
+    plistSource,
+    `iOS source ${privacyKey}`,
+  );
+  const generatedValue = capture(
+    new RegExp(`<key>${privacyKey}<\\/key>\\s*<string>([^<]+)<\\/string>`),
+    plist,
+    `generated iOS ${privacyKey}`,
+  );
+  if (sourceValue !== undefined && generatedValue !== undefined)
+    expect(`generated iOS ${privacyKey}`, generatedValue, sourceValue);
+}
+
+expect(
+  "Android namespace",
+  capture(/namespace\s*=\s*"([^"]+)"/, gradle, "Android namespace"),
+  release.applicationId,
+);
+expect(
+  "Android applicationId",
+  capture(/applicationId\s*=\s*"([^"]+)"/, gradle, "Android applicationId"),
+  release.applicationId,
+);
+expect(
+  "Android fallback version name",
+  capture(
+    /tauri\.android\.versionName",\s*"([^"]+)"/,
+    gradle,
+    "Android fallback version name",
+  ),
+  release.version,
+);
+expect(
+  "Android fallback version code",
+  capture(
+    /tauri\.android\.versionCode",\s*"([^"]+)"/,
+    gradle,
+    "Android fallback version code",
+  ),
+  release.build,
+);
+expect(
+  "Android compile SDK",
+  capture(/compileSdk\s*=\s*(\d+)/, gradle, "Android compile SDK"),
+  36,
+);
+expect(
+  "Android target SDK",
+  capture(/targetSdk\s*=\s*(\d+)/, gradle, "Android target SDK"),
+  36,
+);
+expect(
+  "Android NDK",
+  capture(/ndkVersion\s*=\s*"([^"]+)"/, gradle, "Android NDK"),
+  "27.0.12077973",
+);
+expect(
+  "Gradle wrapper",
+  capture(/gradle-([0-9.]+)-bin\.zip/, gradleWrapper, "Gradle wrapper"),
+  "8.14.3",
+);
+expect(
+  "Gradle wrapper checksum",
+  capture(
+    /^distributionSha256Sum=([0-9a-f]{64})$/m,
+    gradleWrapper,
+    "Gradle wrapper checksum",
+  ),
+  "bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531",
+);
+expect(
+  "Gradle daemon isolation",
+  capture(
+    /^org\.gradle\.daemon=(\S+)$/m,
+    gradleProperties,
+    "Gradle daemon isolation",
+  ),
+  "false",
+);
+expect(
+  "Fastlane lock",
+  capture(/^    fastlane \(([^)]+)\)$/m, gemLock, "Fastlane lock"),
+  "2.237.0",
+);
+expect(
+  "Bundler lock",
+  capture(
+    /^  ([0-9.]+)$/m,
+    gemLock.split("BUNDLED WITH")[1] ?? "",
+    "Bundler lock",
+  ),
+  "4.0.3",
+);
+expect(
+  "Android toolchain NDK",
+  capture(
+    /export NDK_HOME="\$ANDROID_HOME\/ndk\/([0-9.]+)"/,
+    androidToolchain,
+    "Android toolchain NDK",
+  ),
+  "27.0.12077973",
+);
+expect(
+  "Rust toolchain",
+  capture(/channel\s*=\s*"([^"]+)"/, rustToolchain, "Rust toolchain"),
+  "1.88.0",
+);
+for (const target of [
+  "aarch64-linux-android",
+  "armv7a-linux-androideabi",
+  "i686-linux-android",
+  "x86_64-linux-android",
+]) {
+  if (!androidToolchain.includes(`${target}29-clang`))
+    failures.push(`Android toolchain does not pin ${target} to API 29`);
+}
+
+const identity = `${release.version}+${release.build}`;
+const tag = `zuuli-v${identity}`;
+if (process.env.ZUULI_NODE_VERSION)
+  expect("Node runtime", process.versions.node, process.env.ZUULI_NODE_VERSION);
+if (process.argv.includes("--require-main")) {
+  try {
+    const head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    execFileSync(
+      "git",
+      ["merge-base", "--is-ancestor", head, "refs/remotes/origin/main"],
+      { cwd: root, stdio: "ignore" },
+    );
+  } catch {
+    failures.push("checked-out source is not a commit on origin/main");
+  }
+}
+if (process.argv.includes("--require-tag")) {
+  let head;
+  let tagged;
+  let remoteTagged;
+  try {
+    head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    tagged = execFileSync("git", ["rev-list", "-n", "1", `refs/tags/${tag}`], {
+      cwd: root,
+      encoding: "utf8",
+    }).trim();
+    const tagType = execFileSync(
+      "git",
+      ["cat-file", "-t", `refs/tags/${tag}`],
+      {
+        cwd: root,
+        encoding: "utf8",
+      },
+    ).trim();
+    if (tagType !== "tag")
+      failures.push(
+        `release tag must be annotated, got Git object type ${tagType}`,
+      );
+    remoteTagged = execFileSync(
+      "git",
+      ["ls-remote", "--tags", "origin", `refs/tags/${tag}^{}`],
+      { cwd: root, encoding: "utf8" },
+    )
+      .trim()
+      .split(/\s+/)[0];
+    if (!remoteTagged)
+      failures.push(`required release tag is not published on origin: ${tag}`);
+  } catch {
+    failures.push(`required immutable release tag is missing: ${tag}`);
+  }
+  if (head && tagged && head !== tagged)
+    failures.push(`${tag} points to ${tagged}, not checked-out ${head}`);
+  if (tagged && remoteTagged && tagged !== remoteTagged)
+    failures.push(
+      `${tag} resolves to ${tagged} locally but ${remoteTagged} on origin`,
+    );
+}
+
+const sourceArg = process.argv.find((arg) => arg.startsWith("--source-sha="));
+if (sourceArg) {
+  const required = sourceArg.slice("--source-sha=".length);
+  const head = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+  if (!/^[0-9a-f]{40}$/.test(required))
+    failures.push(
+      "--source-sha must be a full lowercase 40-character commit SHA",
+    );
+  expect("checked-out source SHA", head, required);
+}
+
+if (failures.length) {
+  console.error(
+    "ZUULI release identity is inconsistent:\n- " + failures.join("\n- "),
+  );
+  process.exit(1);
+}
+
+console.log(
+  JSON.stringify({
+    applicationId: release.applicationId,
+    version: release.version,
+    build: release.build,
+    identity,
+    tag,
+  }),
+);

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -192,6 +192,24 @@ for (const privacyKey of [
   if (sourceValue !== undefined && generatedValue !== undefined)
     expect(`generated iOS ${privacyKey}`, generatedValue, sourceValue);
 }
+const callbackScheme = "cash.free2z.zuuli";
+if (
+  !new RegExp(
+    `CFBundleURLSchemes:\\s*\\n\\s*-\\s*${callbackScheme.replaceAll(".", "\\.")}`,
+  ).test(project)
+)
+  failures.push("XcodeGen OAuth callback URL scheme is missing");
+for (const [label, contents] of [
+  ["iOS source", plistSource],
+  ["generated iOS", plist],
+]) {
+  if (
+    !new RegExp(
+      `<key>CFBundleURLSchemes<\\/key>\\s*<array>\\s*<string>${callbackScheme.replaceAll(".", "\\.")}<\\/string>`,
+    ).test(contents)
+  )
+    failures.push(`${label} OAuth callback URL scheme is missing`);
+}
 
 expect(
   "Android namespace",

--- a/wallet/zuuli/scripts/release-manifest.mjs
+++ b/wallet/zuuli/scripts/release-manifest.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const release = JSON.parse(readFileSync(resolve(root, "release.json"), "utf8"));
+const option = (name, fallback) => {
+  const prefix = `--${name}=`;
+  const value = process.argv.find((arg) => arg.startsWith(prefix));
+  return value ? value.slice(prefix.length) : fallback;
+};
+const artifactsRoot = resolve(
+  process.cwd(),
+  option("artifacts", "release-artifacts"),
+);
+const output = resolve(
+  process.cwd(),
+  option("output", "release-manifest.json"),
+);
+const checksumsOutput = resolve(
+  process.cwd(),
+  option("checksums", "CHECKSUMS.sha256"),
+);
+
+function filesUnder(path) {
+  const files = [];
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    const absolute = resolve(path, entry.name);
+    if (entry.isSymbolicLink())
+      throw new Error(`release artifact must not be a symlink: ${absolute}`);
+    if (entry.isDirectory()) files.push(...filesUnder(absolute));
+    else if (entry.isFile()) files.push(absolute);
+  }
+  return files;
+}
+
+function sha256(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+const git = (...args) =>
+  execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+const sourceSha = git("rev-parse", "HEAD");
+const sourceTree = git("rev-parse", "HEAD^{tree}");
+const artifacts = filesUnder(artifactsRoot)
+  .filter((path) => ![output, checksumsOutput].includes(resolve(path)))
+  .sort()
+  .map((path) => ({
+    path: relative(artifactsRoot, path),
+    bytes: statSync(path).size,
+    sha256: sha256(path),
+  }));
+
+if (artifacts.length === 0)
+  throw new Error(`no artifacts found under ${artifactsRoot}`);
+writeFileSync(
+  checksumsOutput,
+  `${artifacts.map((artifact) => `${artifact.sha256}  ${artifact.path}`).join("\n")}\n`,
+  { flag: "wx", mode: 0o644 },
+);
+artifacts.push({
+  path: relative(artifactsRoot, checksumsOutput),
+  bytes: statSync(checksumsOutput).size,
+  sha256: sha256(checksumsOutput),
+});
+
+const manifest = {
+  schemaVersion: 1,
+  applicationId: release.applicationId,
+  version: release.version,
+  build: release.build,
+  identity: `${release.version}+${release.build}`,
+  source: {
+    repository:
+      process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY
+        ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}`
+        : git("remote", "get-url", "origin"),
+    commit: sourceSha,
+    tree: sourceTree,
+    ref: process.env.GITHUB_REF || null,
+  },
+  builder: {
+    githubRun: process.env.GITHUB_RUN_ID
+      ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : null,
+    runner:
+      process.env.ImageOS && process.env.ImageVersion
+        ? `${process.env.ImageOS}@${process.env.ImageVersion}`
+        : process.env.RUNNER_OS && process.env.RUNNER_ARCH
+          ? `${process.env.RUNNER_OS}/${process.env.RUNNER_ARCH}`
+          : process.platform,
+    rust: process.env.ZUULI_RUST_VERSION || null,
+    node: process.env.ZUULI_NODE_VERSION || process.version,
+    java: process.env.ZUULI_JAVA_VERSION || null,
+    xcode: process.env.ZUULI_XCODE_VERSION || null,
+    androidNdk: process.env.ZUULI_ANDROID_NDK_VERSION || null,
+  },
+  artifacts,
+};
+
+writeFileSync(output, `${JSON.stringify(manifest, null, 2)}\n`, {
+  flag: "wx",
+  mode: 0o644,
+});
+for (const artifact of artifacts)
+  console.log(`${artifact.sha256}  ${artifact.path}`);
+console.log(
+  `wrote ${basename(output)} for ${artifacts.length} immutable artifact(s)`,
+);

--- a/wallet/zuuli/src-tauri/Info.ios.plist
+++ b/wallet/zuuli/src-tauri/Info.ios.plist
@@ -8,5 +8,16 @@
   <string>ZUULI uses Face ID to unlock your wallet seed for recovery and spending.</string>
   <key>NSMicrophoneUsageDescription</key>
   <string>ZUULI uses the microphone when you broadcast or join a live stream.</string>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleURLName</key>
+      <string>cash.free2z.zuuli</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>cash.free2z.zuuli</string>
+      </array>
+    </dict>
+  </array>
 </dict>
 </plist>

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -15,6 +15,7 @@ val tauriProperties = Properties().apply {
 
 android {
     compileSdk = 36
+    ndkVersion = "27.0.12077973"
     namespace = "cash.free2z.zuuli"
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
@@ -23,6 +24,35 @@ android {
         targetSdk = 36
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
+    }
+    val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }
+    val releaseStorePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")?.takeIf { it.isNotBlank() }
+    val releaseKeyAlias = System.getenv("ANDROID_KEY_ALIAS")?.takeIf { it.isNotBlank() }
+    val releaseKeyPassword = System.getenv("ANDROID_KEY_PASSWORD")?.takeIf { it.isNotBlank() }
+    val releaseSigningValues = listOf(
+        releaseStoreFile,
+        releaseStorePassword,
+        releaseKeyAlias,
+        releaseKeyPassword,
+    )
+    if (releaseSigningValues.any { it != null } && releaseSigningValues.any { it == null }) {
+        throw GradleException(
+            "Android release signing is partially configured; set all four ANDROID_KEYSTORE_* variables"
+        )
+    }
+    signingConfigs {
+        if (releaseSigningValues.all { it != null }) {
+            create("releaseFromEnvironment") {
+                val absoluteStoreFile = file(requireNotNull(releaseStoreFile))
+                require(absoluteStoreFile.isAbsolute) {
+                    "ANDROID_KEYSTORE_PATH must be absolute"
+                }
+                storeFile = absoluteStoreFile
+                storePassword = requireNotNull(releaseStorePassword)
+                keyAlias = requireNotNull(releaseKeyAlias)
+                keyPassword = requireNotNull(releaseKeyPassword)
+            }
+        }
     }
     buildTypes {
         getByName("debug") {
@@ -38,6 +68,9 @@ android {
             }
         }
         getByName("release") {
+            if (releaseSigningValues.all { it != null }) {
+                signingConfig = signingConfigs.getByName("releaseFromEnvironment")
+            }
             isMinifyEnabled = true
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }

--- a/wallet/zuuli/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/wallet/zuuli/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,9 @@
                 <data android:scheme="cash.free2z.zuuli" />
                 <data android:host="oauth" />
                 <data android:path="/callback" />
+
+
+
             </intent-filter>
             <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
         </activity>

--- a/wallet/zuuli/src-tauri/gen/android/gradle.properties
+++ b/wallet/zuuli/src-tauri/gen/android/gradle.properties
@@ -7,6 +7,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# Release builds must not inherit toolchain state from a long-lived local daemon.
+org.gradle.daemon=false
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/wallet/zuuli/src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties
+++ b/wallet/zuuli/src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 #Tue May 10 19:22:52 CST 2022
 distributionBase=GRADLE_USER_HOME
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionSha256Sum=bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -47,6 +47,10 @@ targets:
       path: zuuli_iOS/Info.plist
       properties:
         CFBundleDisplayName: ZUULI
+        CFBundleURLTypes:
+          - CFBundleURLName: cash.free2z.zuuli
+            CFBundleURLSchemes:
+              - cash.free2z.zuuli
         LSRequiresIPhoneOS: true
         NSCameraUsageDescription: ZUULI uses the camera when you broadcast or join a live video stream.
         NSMicrophoneUsageDescription: ZUULI uses the microphone when you broadcast or join a live stream.

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -12,6 +12,13 @@ settingGroups:
     base:
       PRODUCT_NAME: ZUULI
       PRODUCT_BUNDLE_IDENTIFIER: cash.free2z.zuuli
+      DEVELOPMENT_TEAM: F9AV5HKF6N
+      CODE_SIGN_STYLE: Automatic
+    configs:
+      debug:
+        CODE_SIGN_IDENTITY: Apple Development
+      release:
+        CODE_SIGN_IDENTITY: Apple Distribution
 targetTemplates:
   app:
     type: application
@@ -43,6 +50,7 @@ targets:
         LSRequiresIPhoneOS: true
         NSCameraUsageDescription: ZUULI uses the camera when you broadcast or join a live video stream.
         NSMicrophoneUsageDescription: ZUULI uses the microphone when you broadcast or join a live stream.
+        NSFaceIDUsageDescription: ZUULI uses Face ID to unlock your wallet seed for recovery and spending.
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:
@@ -55,7 +63,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "0.1.0"
+        CFBundleVersion: "1"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -19,6 +19,8 @@ settingGroups:
         CODE_SIGN_IDENTITY: Apple Development
       release:
         CODE_SIGN_IDENTITY: Apple Distribution
+        CODE_SIGN_STYLE: Manual
+        PROVISIONING_PROFILE_SPECIFIER: ZUULI App Store CI
 targetTemplates:
   app:
     type: application

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj
@@ -184,6 +184,10 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					14A815A563040980E02B9C15 = {
+						DevelopmentTeam = F9AV5HKF6N;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 9615D6B1237F0F96C5530CF8 /* Build configuration list for PBXProject "zuuli" */;
@@ -326,7 +330,9 @@
 				);
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = zuuli_iOS/zuuli_iOS.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = F9AV5HKF6N;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -341,7 +347,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = cash.free2z.zuuli;
-				PRODUCT_NAME = "ZUULI";
+				PRODUCT_NAME = ZUULI;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;
@@ -357,7 +363,9 @@
 				);
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = zuuli_iOS/zuuli_iOS.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = F9AV5HKF6N;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -372,7 +380,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = cash.free2z.zuuli;
-				PRODUCT_NAME = "ZUULI";
+				PRODUCT_NAME = ZUULI;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		D4F951D673376126CE43FFAC /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53135BE9E6C5277EB10DCCAB /* main.mm */; };
 		EF1033B3BCF4333F214CD239 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF50730DDEE9C016587C33C8 /* UIKit.framework */; };
 		FAC5E5B9C30B29BDDAF05E1E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 00273035D6BF322ED673A7A7 /* LaunchScreen.storyboard */; };
+		FEB4633D9B5302D8A1E7DE89 /* libapp.a in Resources */ = {isa = PBXBuildFile; fileRef = 895018E8D7EB83F50A3788B2 /* libapp.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		759DD8A882A530239EF1E304 /* zuuli_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = zuuli_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		77F42168F58D14ADCE84DD98 /* bindings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bindings.h; sourceTree = "<group>"; };
 		79A6AC0BBBECBC836243B2A2 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		895018E8D7EB83F50A3788B2 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
 		8E2241BC3BAC928AEA585784 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
 		9B15EF6F08F4C43D51A325CA /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		A0DC69B5F5D0C4B020198D94 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -82,6 +84,7 @@
 		14892246B7815CA438A147EC /* Externals */ = {
 			isa = PBXGroup;
 			children = (
+				99EBA03AB175C293A205632C /* arm64 */,
 			);
 			path = Externals;
 			sourceTree = "<group>";
@@ -95,6 +98,14 @@
 			);
 			name = src;
 			path = ../../src;
+			sourceTree = "<group>";
+		};
+		570D646A14CDC4502E15C81E /* release */ = {
+			isa = PBXGroup;
+			children = (
+				895018E8D7EB83F50A3788B2 /* libapp.a */,
+			);
+			path = release;
 			sourceTree = "<group>";
 		};
 		651D4A879A200EBC89CC2D3D /* bindings */ = {
@@ -111,6 +122,14 @@
 				D7C323E050A672F07EC2508F /* zuuli */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		99EBA03AB175C293A205632C /* arm64 */ = {
+			isa = PBXGroup;
+			children = (
+				570D646A14CDC4502E15C81E /* release */,
+			);
+			path = arm64;
 			sourceTree = "<group>";
 		};
 		A2ADBE166F291E3DA7EA1D86 /* Frameworks */ = {
@@ -152,6 +171,13 @@
 			);
 			sourceTree = "<group>";
 		};
+		"TEMP_3DB7166F-B106-41A0-A2C4-27870FF810F3" /* x86_64 */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = x86_64;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -186,7 +212,6 @@
 				TargetAttributes = {
 					14A815A563040980E02B9C15 = {
 						DevelopmentTeam = F9AV5HKF6N;
-						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -217,6 +242,7 @@
 				87F0E2CFE7042521EF298841 /* Assets.xcassets in Resources */,
 				FAC5E5B9C30B29BDDAF05E1E /* LaunchScreen.storyboard in Resources */,
 				61596CE92793FA64110C7451 /* assets in Resources */,
+				FEB4633D9B5302D8A1E7DE89 /* libapp.a in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -364,7 +390,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = zuuli_iOS/zuuli_iOS.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = F9AV5HKF6N;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
@@ -381,6 +407,7 @@
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = cash.free2z.zuuli;
 				PRODUCT_NAME = ZUULI;
+				PROVISIONING_PROFILE_SPECIFIER = "ZUULI App Store CI";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.1.0</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -28,11 +28,14 @@
     "targets": "all",
     "icon": ["icons/icon.png"],
     "iOS": {
+      "bundleVersion": "1",
+      "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
-      "minSdkVersion": 29
+      "minSdkVersion": 29,
+      "versionCode": 1
     }
   },
   "plugins": {

--- a/wallet/zuuli/syft.yaml
+++ b/wallet/zuuli/syft.yaml
@@ -1,0 +1,9 @@
+exclude:
+  - "**/node_modules/**"
+  - "**/target/**"
+  - "**/dist/**"
+  - "**/release-artifacts/**"
+
+file:
+  metadata:
+    selection: "none"


### PR DESCRIPTION
Refs #238

## Outcome

Adds a founder-operated, immutable release train for ZUULI `cash.free2z.zuuli` across iOS/TestFlight, Android/Play internal, signed+notarized universal macOS, and Linux AppImage/deb/rpm.

- one checked release identity (`release.json`) propagated through npm, Cargo, Tauri, Xcode, and Gradle
- protected signed release workflow pinned to a full SHA on `origin/main`, with annotated remote-tag and explicit identity/upload confirmation gates
- ephemeral App Store Connect, Apple certificate, Android upload-key, and Play service-account materialization
- unsigned PR packaging smoke for Android, iOS simulator, macOS, and Linux
- locked Node/Rust/Java/Xcode/SDK/NDK/Gradle/Fastlane/Syft versions and SHA-pinned Actions
- source SBOM, checksums, provenance, GitHub attestations, retained artifacts, and non-overwriting draft GitHub release publication
- founder runbook covering one-time Corpora console setup, protected environment variables/secrets, dry runs, promotion, rollback, and physical-device acceptance

## Verified locally

- `npm run release:verify`, typecheck, and production frontend build under Node 24
- same-identity `release:bump` is clean/idempotent
- real arm64 Android AAB build with NDK 27.0.12077973 and API-29 linkers
- Android Gradle release-signing validation with an ephemeral self-signed JKS
- Android signature predicate rejects unsigned and accepts a valid upload-key-signed bundle
- real arm64 iOS simulator app build under Xcode 26.6
- XcodeGen regeneration is byte-stable and preserves Apple Development/Distribution identities and privacy keys
- Syft 1.50.0 source scan using the committed config: 1,196 components
- immutable manifest generation and overwrite refusal
- Actionlint 1.7.12, Prettier, `bash -n`, and `git diff --check`
- main/tag refusal guards fail closed on this unmerged, untagged branch

## Adversarial review

Claude Code 2.1.223 / Opus reviewed the complete `origin/main...HEAD` patch after the fixes, independently rechecked signing, credential isolation, tag/source immutability, provenance, privacy metadata, exact toolchains, notarization, SBOMs, permissions, and non-overwrite behavior, and returned:

`VERDICT: APPROVE`

No blocker or high-severity finding remains.

## Bootstrap still requiring the owner

This PR deliberately does not create external app records or upload builds. After merge:

1. create the ZUULI app records in the existing Corpora App Store Connect and Play Console spaces;
2. add the documented credentials to the protected `zuuli-app-stores` environment;
3. perform signed dry-run dispatches;
4. upload the first Android AAB manually once to establish the Play package/signature, then run the protected real-upload dispatch;
5. install and exercise TestFlight on physical iOS and Play internal on API 29 plus current Android, recording the acceptance result on #238.

The final two physical-device acceptance boxes on #238 therefore remain open.
