### PR TITLE
fix(ios): normalize release generator drift

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -57,6 +57,8 @@ jobs:
       - run: npm ci
       - name: Verify one release identity
         run: npm run release:verify
+      - name: Exercise generated iOS normalization
+        run: node scripts/normalize-generated-ios-project.mjs --self-test
       - name: Exercise immutable manifest generation
         run: |
           mkdir release-artifacts
@@ -177,6 +179,12 @@ jobs:
           targets: aarch64-apple-ios-sim
       - run: npm ci
       - run: npm run release:verify
+      - name: Exercise Xcode release formatting normalization
+        run: |
+          build=$(jq -r .build release.json)
+          (cd src-tauri/gen/apple && xcrun agvtool new-version -all "$build")
+          node scripts/normalize-generated-ios-project.mjs
+          git diff --exit-code
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
       - name: Build without signing

--- a/wallet/zuuli/scripts/mobile-release.sh
+++ b/wallet/zuuli/scripts/mobile-release.sh
@@ -109,6 +109,7 @@ if [[ "$platform" == ios ]]; then
       --export-method app-store-connect \
       -- \
       --locked
+  node scripts/normalize-generated-ios-project.mjs
   git diff --exit-code
 
   ipa=$(find_one './src-tauri/gen/apple/build/arm64/*.ipa')

--- a/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
+++ b/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function occurrenceCount(contents, value) {
+  return contents.split(value).length - 1;
+}
+
+function normalizeBuildSetting(contents, name, value, expectedCount) {
+  const canonical = `${name} = ${value};`;
+  const generated = `${name} = "${value}";`;
+  const count =
+    occurrenceCount(contents, canonical) + occurrenceCount(contents, generated);
+  if (count !== expectedCount) {
+    throw new Error(
+      `refusing to normalize ${name}: expected ${expectedCount} known values, found ${count}`,
+    );
+  }
+  return contents.replaceAll(generated, canonical);
+}
+
+function normalizeProject(contents) {
+  let normalized = normalizeBuildSetting(
+    contents,
+    "DEVELOPMENT_TEAM",
+    "F9AV5HKF6N",
+    2,
+  );
+  normalized = normalizeBuildSetting(normalized, "PRODUCT_NAME", "ZUULI", 2);
+  return normalized;
+}
+
+function normalizePlist(contents, label) {
+  if (!contents.trimEnd().endsWith("</plist>")) {
+    throw new Error(
+      `refusing to normalize ${label}: plist terminator is missing`,
+    );
+  }
+  return contents.endsWith("\n") ? contents : `${contents}\n`;
+}
+
+function selfTest() {
+  const generatedProject = [
+    'DEVELOPMENT_TEAM = "F9AV5HKF6N";',
+    'PRODUCT_NAME = "ZUULI";',
+    'DEVELOPMENT_TEAM = "F9AV5HKF6N";',
+    'PRODUCT_NAME = "ZUULI";',
+  ].join("\n");
+  const expectedProject = generatedProject
+    .replaceAll(' = "', " = ")
+    .replaceAll('";', ";");
+  if (normalizeProject(generatedProject) !== expectedProject) {
+    throw new Error("iOS project normalization self-test failed");
+  }
+  if (
+    normalizePlist("<plist><dict/></plist>", "fixture") !==
+    "<plist><dict/></plist>\n"
+  ) {
+    throw new Error("iOS plist normalization self-test failed");
+  }
+  try {
+    normalizeProject('DEVELOPMENT_TEAM = "F9AV5HKF6N";');
+  } catch {
+    return;
+  }
+  throw new Error("iOS project normalization accepted an unexpected shape");
+}
+
+if (process.argv.includes("--self-test")) {
+  selfTest();
+  process.exit(0);
+}
+
+const projectPath = resolve(
+  appDir,
+  "src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj",
+);
+const plistPaths = [
+  "src-tauri/gen/apple/zuuli_iOS/Info.plist",
+  "src-tauri/gen/apple/zuuli_iOS/zuuli_iOS.entitlements",
+].map((path) => resolve(appDir, path));
+
+const project = readFileSync(projectPath, "utf8");
+const normalizedProject = normalizeProject(project);
+if (normalizedProject !== project) {
+  writeFileSync(projectPath, normalizedProject);
+}
+
+for (const plistPath of plistPaths) {
+  const plist = readFileSync(plistPath, "utf8");
+  const normalizedPlist = normalizePlist(plist, plistPath);
+  if (normalizedPlist !== plist) {
+    writeFileSync(plistPath, normalizedPlist);
+  }
+}

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -28,6 +28,10 @@ function capture(pattern, text, label) {
   return match[1];
 }
 
+function occurrenceCount(contents, value) {
+  return contents.split(value).length - 1;
+}
+
 expect("release schema version", release.schemaVersion, 1);
 expect("release application ID", release.applicationId, "cash.free2z.zuuli");
 expect("release minimum iOS", release.minimums?.ios, "18.0");
@@ -57,6 +61,9 @@ const project = read("src-tauri/gen/apple/project.yml");
 const plist = read("src-tauri/gen/apple/zuuli_iOS/Info.plist");
 const plistSource = read("src-tauri/Info.ios.plist");
 const pbxproj = read("src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj");
+const entitlements = read(
+  "src-tauri/gen/apple/zuuli_iOS/zuuli_iOS.entitlements",
+);
 const rustToolchain = read("../rust-toolchain.toml");
 const gradle = read("src-tauri/gen/android/app/build.gradle.kts");
 const gradleWrapper = read(
@@ -179,6 +186,34 @@ if (!pbxproj.includes('CODE_SIGN_IDENTITY = "Apple Distribution";'))
   );
 if (!pbxproj.includes('PROVISIONING_PROFILE_SPECIFIER = "ZUULI App Store CI";'))
   failures.push("generated Xcode release provisioning profile is not pinned");
+for (const [label, contents] of [
+  ["generated Xcode project", pbxproj],
+  ["generated iOS plist", plist],
+  ["generated iOS entitlements", entitlements],
+]) {
+  if (!contents.endsWith("\n"))
+    failures.push(`${label} has no terminal newline`);
+}
+expect(
+  "generated Xcode canonical team setting count",
+  occurrenceCount(pbxproj, "DEVELOPMENT_TEAM = F9AV5HKF6N;"),
+  2,
+);
+expect(
+  "generated Xcode quoted team setting count",
+  occurrenceCount(pbxproj, 'DEVELOPMENT_TEAM = "F9AV5HKF6N";'),
+  0,
+);
+expect(
+  "generated Xcode canonical product name count",
+  occurrenceCount(pbxproj, "PRODUCT_NAME = ZUULI;"),
+  2,
+);
+expect(
+  "generated Xcode quoted product name count",
+  occurrenceCount(pbxproj, 'PRODUCT_NAME = "ZUULI";'),
+  0,
+);
 for (const privacyKey of [
   "NSCameraUsageDescription",
   "NSFaceIDUsageDescription",


### PR DESCRIPTION
Closes #274

The first signed iOS release built and exported `ZUULI.ipa`, but deterministic `agvtool` formatting drift tripped the broad clean-tree guard before `altool` validation or upload.

This fix:
- normalizes only the two exact known quoted Xcode build settings and terminal plist newlines;
- refuses unexpected Xcode project shapes;
- preserves the broad `git diff --exit-code` gate before Apple validation/upload;
- adds checked-in canonical-form guards and both synthetic and real-macOS `agvtool` regression coverage.

Verification:
- `npm run release:verify`
- `node scripts/normalize-generated-ios-project.mjs --self-test`
- real `xcrun agvtool new-version -all 1` reproduction followed by normalization and byte-clean generated paths
- `npm run typecheck`
- `npm run build`
- `bash -n scripts/mobile-release.sh`
- Prettier 3.6.2
- actionlint 1.7.12 (official archive checksum verified)
- `git diff --check`

Adversarial review: Claude Code 2.1.226, Sonnet/high effort, APPROVE with no blocking correctness, security, CI, portability, or release-integrity findings.
