### PR TITLE
release: advance ZUULI to 0.1.0+2

### DIFF
--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -1,8 +1,8 @@
 # Releasing ZUULI
 
 ZUULI ships from one reviewed commit under one immutable identity. The current
-identity is `0.1.0+1`: marketing version `0.1.0`, Apple build `1`, Android
-`versionCode` `1`, and package/bundle identifier `cash.free2z.zuuli`.
+identity is `0.1.0+2`: marketing version `0.1.0`, Apple build `2`, Android
+`versionCode` `2`, and package/bundle identifier `cash.free2z.zuuli`.
 
 `release.json` is the source of truth. `npm run release:verify` fails if the npm,
 Cargo, Tauri, generated Xcode, or generated Gradle representation disagrees.
@@ -52,9 +52,10 @@ repeat bootstrap work or substitute unrelated credentials.
 
 The Play app record already exists for `cash.free2z.zuuli`, and the dedicated
 principal has been granted ZUULI admin access. Fastlane's Play JSON-key
-validation succeeds for this account. The first API upload has not run yet.
-Attempt it automatically before falling back to the console bootstrap; do not
-weaken the account check or upload a debug key.
+validation succeeds for this account. Build `0.1.0+1` completed the first API
+upload to the internal track; subsequent protected releases use the same
+dedicated principal and upload key. Do not weaken the account check or upload a
+debug key.
 
 Primary references:
 
@@ -142,7 +143,7 @@ must both be confirmed:
 
 ```bash
 export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
-export ZUULI_CONFIRM_UPLOAD=0.1.0+1
+export ZUULI_CONFIRM_UPLOAD=0.1.0+2
 scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
 ```
@@ -206,9 +207,9 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    did not decrease, builds/signs both mobile artifacts, and uploads them to
    TestFlight and Play internal. Adding `release.json` for the first time is a
    no-upload baseline, so merging the release infrastructure itself is safe.
-   After that baseline and the wallet-conflict fix are on `main`, make a
-   dedicated `0.1.0+2` bump PR; merging that PR is the first automatic mobile
-   store run.
+   Build `0.1.0+1` established the first Play internal release. Its iOS build
+   stopped before Apple validation or upload, so `0.1.0+2` is the first
+   automatic mobile store run with the corrected iOS release path.
 4. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
    attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
    protected release** with the exact full SHA, identity, missing target, and

--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -3,7 +3,7 @@
   "schemaVersion": 1,
   "applicationId": "cash.free2z.zuuli",
   "version": "0.1.0",
-  "build": 1,
+  "build": 2,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "2").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "1"
+        CFBundleVersion: "2"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -28,14 +28,14 @@
     "targets": "all",
     "icon": ["icons/icon.png"],
     "iOS": {
-      "bundleVersion": "1",
+      "bundleVersion": "2",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 1
+      "versionCode": 2
     }
   },
   "plugins": {


### PR DESCRIPTION
Closes #276

Advances the immutable ZUULI store identity from `0.1.0+1` to `0.1.0+2` with marketing version and application ID unchanged.

> [!CAUTION]
> Merging this PR changes `wallet/zuuli/release.json` on `main` and automatically signs/uploads both mobile targets to TestFlight and Play internal. Do not merge until every gate is green and the release is intentionally authorized.

Scope:
- canonical `npm run release:bump -- --version=0.1.0 --build=2` output only;
- directly corresponding release-runbook identity, Play bootstrap result, recovery example, and build-2 rationale;
- no app, dependency, lockfile, workflow, signing, or store-principal changes.

Verification:
- `npm ci`
- `npm audit --audit-level=high` (zero high/critical; seven pre-existing moderate)
- `npm run release:verify`
- monotonic `release-identity.mjs --require-newer-than=<build-1-sha>`
- `npm run typecheck`
- `npm test` (19/19)
- `npm run build`
- iOS and Android generated-normalizer self-tests
- Prettier and `git diff --check`

Adversarial review: Claude Code 2.1.226, Sonnet/high effort, re-run on exact amended commit `520d818`: **APPROVE**, no blockers.
