### PR TITLE
ci(zuuli): cache release dependencies safely

### DIFF
--- a/.github/actions/zuuli-rust-cache/action.yml
+++ b/.github/actions/zuuli-rust-cache/action.yml
@@ -1,0 +1,33 @@
+name: ZUULI Rust dependency cache
+description: Restore or save credential-free Cargo dependency artifacts for one exact release target surface.
+
+inputs:
+  shared-key:
+    description: Stable cache family shared by packaging and the matching release job.
+    required: true
+  target-key:
+    description: Explicit native toolchain and target discriminator.
+    required: true
+  save:
+    description: Whether this credential-free job may publish a cache entry.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Security default: callers only restore unless they explicitly opt into
+    # saving. Protected release jobs therefore cannot publish target contents
+    # after signing credentials have existed on their runner.
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      with:
+        workspaces: wallet/zuuli/src-tauri -> target
+        shared-key: ${{ inputs.shared-key }}
+        key: ${{ inputs.target-key }}
+        add-job-id-key: "false"
+        cache-bin: "false"
+        cache-targets: "true"
+        cache-workspace-crates: "false"
+        cache-all-crates: "false"
+        cache-on-failure: "false"
+        save-if: ${{ inputs.save }}

--- a/.github/actions/zuuli-rust-cache/action.yml
+++ b/.github/actions/zuuli-rust-cache/action.yml
@@ -3,10 +3,7 @@ description: Restore or save credential-free Cargo dependency artifacts for one 
 
 inputs:
   shared-key:
-    description: Stable cache family shared by packaging and the matching release job.
-    required: true
-  target-key:
-    description: Explicit native toolchain and target discriminator.
+    description: Full cache family including the explicit native toolchain and target discriminator.
     required: true
   save:
     description: Whether this credential-free job may publish a cache entry.
@@ -23,8 +20,6 @@ runs:
       with:
         workspaces: wallet/zuuli/src-tauri -> target
         shared-key: ${{ inputs.shared-key }}
-        key: ${{ inputs.target-key }}
-        add-job-id-key: "false"
         cache-bin: "false"
         cache-targets: "true"
         cache-workspace-crates: "false"

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -9,12 +9,17 @@ on:
     - cron: "41 8 * * *"
   workflow_dispatch:
 
-# This workflow never checks out or executes PR code. Its only authority is to
-# delete cache entries under the exact closed PR merge ref.
+# This workflow never checks out or executes PR code. `actions: write` is the
+# minimum GitHub permission that can delete caches; the implementation narrows
+# its use to entries under API-verified closed PR merge refs.
 permissions:
   actions: write
   contents: none
   pull-requests: read
+
+concurrency:
+  group: ci-closed-pr-cache-cleanup
+  cancel-in-progress: false
 
 jobs:
   closed-pr:
@@ -35,9 +40,13 @@ jobs:
             exit 1
           }
           pr_ref="refs/pull/$PR_NUMBER/merge"
-          mapfile -t cache_ids < <(
+          cache_output=$(
             gh cache list --ref "$pr_ref" --limit 10000 --json id --jq '.[].id'
           )
+          cache_ids=()
+          if [[ -n "$cache_output" ]]; then
+            mapfile -t cache_ids <<< "$cache_output"
+          fi
           echo "Found ${#cache_ids[@]} cache entries scoped to $pr_ref."
           for cache_id in "${cache_ids[@]}"; do
             [[ "$cache_id" =~ ^[1-9][0-9]*$ ]] || {
@@ -59,6 +68,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          cache_rows=$(
+            gh cache list --limit 10000 --json id,ref --jq \
+              '.[] | select(.ref | startswith("refs/pull/")) | [.id, .ref] | @tsv'
+          )
+          if [[ -z "$cache_rows" ]]; then
+            echo "No pull-request caches found."
+            exit 0
+          fi
           while IFS=$'\t' read -r cache_id cache_ref; do
             [[ "$cache_id" =~ ^[1-9][0-9]*$ ]] || {
               echo "invalid cache ID returned by GitHub" >&2
@@ -69,7 +86,10 @@ jobs:
               exit 1
             fi
             pr_number=${BASH_REMATCH[1]}
-            state=$(gh api "repos/$GH_REPO/pulls/$pr_number" --jq .state)
+            if ! state=$(gh api "repos/$GH_REPO/pulls/$pr_number" --jq .state); then
+              echo "Could not verify PR #$pr_number; retaining its cache." >&2
+              continue
+            fi
             if [[ "$state" == closed ]]; then
               echo "Deleting cache $cache_id for verified-closed PR #$pr_number."
               gh cache delete "$cache_id"
@@ -77,7 +97,4 @@ jobs:
               echo "refusing unknown PR state for #$pr_number: $state" >&2
               exit 1
             fi
-          done < <(
-            gh cache list --limit 10000 --json id,ref --jq \
-              '.[] | select(.ref | startswith("refs/pull/")) | [.id, .ref] | @tsv'
-          )
+          done <<< "$cache_rows"

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,83 @@
+name: CI / closed PR cache cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+  schedule:
+    # Reclaim entries left by PRs closed before this workflow existed or by a
+    # transient failure of the close event.
+    - cron: "41 8 * * *"
+  workflow_dispatch:
+
+# This workflow never checks out or executes PR code. Its only authority is to
+# delete cache entries under the exact closed PR merge ref.
+permissions:
+  actions: write
+  contents: none
+  pull-requests: read
+
+jobs:
+  closed-pr:
+    name: Delete closed PR caches
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Delete only this PR merge-ref caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || {
+            echo "invalid PR number" >&2
+            exit 1
+          }
+          pr_ref="refs/pull/$PR_NUMBER/merge"
+          mapfile -t cache_ids < <(
+            gh cache list --ref "$pr_ref" --limit 10000 --json id --jq '.[].id'
+          )
+          echo "Found ${#cache_ids[@]} cache entries scoped to $pr_ref."
+          for cache_id in "${cache_ids[@]}"; do
+            [[ "$cache_id" =~ ^[1-9][0-9]*$ ]] || {
+              echo "invalid cache ID returned by GitHub" >&2
+              exit 1
+            }
+            gh cache delete "$cache_id"
+          done
+
+  sweep:
+    name: Delete caches for verified-closed PRs
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Delete only caches whose PR is closed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          while IFS=$'\t' read -r cache_id cache_ref; do
+            [[ "$cache_id" =~ ^[1-9][0-9]*$ ]] || {
+              echo "invalid cache ID returned by GitHub" >&2
+              exit 1
+            }
+            if [[ ! "$cache_ref" =~ ^refs/pull/([1-9][0-9]*)/merge$ ]]; then
+              echo "refusing unexpected pull-request cache ref: $cache_ref" >&2
+              exit 1
+            fi
+            pr_number=${BASH_REMATCH[1]}
+            state=$(gh api "repos/$GH_REPO/pulls/$pr_number" --jq .state)
+            if [[ "$state" == closed ]]; then
+              echo "Deleting cache $cache_id for verified-closed PR #$pr_number."
+              gh cache delete "$cache_id"
+            elif [[ "$state" != open ]]; then
+              echo "refusing unknown PR state for #$pr_number: $state" >&2
+              exit 1
+            fi
+          done < <(
+            gh cache list --limit 10000 --json id,ref --jq \
+              '.[] | select(.ref | startswith("refs/pull/")) | [.id, .ref] | @tsv'
+          )

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -18,7 +18,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ci-closed-pr-cache-cleanup
+  group: ci-closed-pr-cache-cleanup-${{ github.event.pull_request.number || 'sweep' }}
   cancel-in-progress: false
 
 jobs:
@@ -82,8 +82,8 @@ jobs:
               exit 1
             }
             if [[ ! "$cache_ref" =~ ^refs/pull/([1-9][0-9]*)/merge$ ]]; then
-              echo "refusing unexpected pull-request cache ref: $cache_ref" >&2
-              exit 1
+              echo "Skipping unexpected pull-request cache ref: $cache_ref" >&2
+              continue
             fi
             pr_number=${BASH_REMATCH[1]}
             if ! state=$(gh api "repos/$GH_REPO/pulls/$pr_number" --jq .state); then

--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -10,6 +10,7 @@ on:
       - .gitmodules
       - .github/workflows/zuuli-packaging.yml
       - .github/workflows/zuuli-release.yml
+      - .github/workflows/cache-cleanup.yml
       - .github/actions/zuuli-rust-cache/**
   push:
     branches: [main]
@@ -21,6 +22,7 @@ on:
       - .gitmodules
       - .github/workflows/zuuli-packaging.yml
       - .github/workflows/zuuli-release.yml
+      - .github/workflows/cache-cleanup.yml
       - .github/actions/zuuli-rust-cache/**
   schedule:
     # A weekly cache-free native build proves that warm dependency artifacts
@@ -139,8 +141,7 @@ jobs:
         if: github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'
         uses: ./.github/actions/zuuli-rust-cache
         with:
-          shared-key: zuuli-release-android-universal-v1
-          target-key: rust-${{ env.ZUULI_RUST_VERSION }}-ndk-${{ env.ZUULI_ANDROID_NDK_VERSION }}-api29-aarch64-armv7-i686-x86_64
+          shared-key: zuuli-release-android-universal-v2-rust-${{ env.ZUULI_RUST_VERSION }}-ndk-${{ env.ZUULI_ANDROID_NDK_VERSION }}-api29-aarch64-armv7-i686-x86_64
           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - run: npm ci
       - run: npm run release:verify
@@ -211,8 +212,7 @@ jobs:
         if: github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'
         uses: ./.github/actions/zuuli-rust-cache
         with:
-          shared-key: zuuli-release-ios-device-v1
-          target-key: rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-ios18-aarch64-device
+          shared-key: zuuli-release-ios-device-v2-rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-ios18-aarch64-device
           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - run: npm ci
       - run: npm run release:verify
@@ -303,12 +303,17 @@ jobs:
         run: |
           sudo xcode-select --switch /Applications/Xcode_26.6.app
           xcodebuild -version | grep -Fx 'Xcode 26.6'
-      - name: Restore credential-free desktop Rust dependencies
-        if: github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'
+      - name: Restore credential-free Linux Rust dependencies
+        if: runner.os == 'Linux' && github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'
         uses: ./.github/actions/zuuli-rust-cache
         with:
-          shared-key: ${{ runner.os == 'macOS' && 'zuuli-release-macos-universal-v1' || 'zuuli-release-linux-v1' }}
-          target-key: ${{ runner.os == 'macOS' && format('rust-{0}-xcode-{1}-macos-arm64-x86_64', env.ZUULI_RUST_VERSION, env.ZUULI_XCODE_VERSION) || format('rust-{0}-ubuntu-24.04-gtk-webkit-4.1', env.ZUULI_RUST_VERSION) }}
+          shared-key: zuuli-release-linux-v2-rust-${{ env.ZUULI_RUST_VERSION }}-ubuntu-24.04-gtk-webkit-4.1
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Restore credential-free macOS Rust dependencies
+        if: runner.os == 'macOS' && github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'
+        uses: ./.github/actions/zuuli-rust-cache
+        with:
+          shared-key: zuuli-release-macos-universal-v2-rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-macos-arm64-x86_64
           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - run: npm ci
       - run: npm run release:verify

--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -10,6 +10,7 @@ on:
       - .gitmodules
       - .github/workflows/zuuli-packaging.yml
       - .github/workflows/zuuli-release.yml
+      - .github/actions/zuuli-rust-cache/**
   push:
     branches: [main]
     paths:
@@ -20,7 +21,18 @@ on:
       - .gitmodules
       - .github/workflows/zuuli-packaging.yml
       - .github/workflows/zuuli-release.yml
+      - .github/actions/zuuli-rust-cache/**
+  schedule:
+    # A weekly cache-free native build proves that warm dependency artifacts
+    # never become the only evidence for a release target.
+    - cron: "23 7 * * 1"
   workflow_dispatch:
+    inputs:
+      cold_rust_cache:
+        description: Skip Rust dependency caches and rebuild every native target cold
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -61,6 +73,8 @@ jobs:
         run: node scripts/normalize-generated-ios-project.mjs --self-test
       - name: Exercise iOS IPA fail-closed verification
         run: bash scripts/verify-ios-ipa.sh --self-test
+      - name: Verify release cache security policy
+        run: node scripts/verify-ci-cache-policy.mjs
       - name: Exercise immutable manifest generation
         run: |
           mkdir release-artifacts
@@ -97,7 +111,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
         with:
           toolchain: 1.88.0
-          targets: aarch64-linux-android
+          targets: ${{ github.event_name == 'pull_request' && 'aarch64-linux-android' || 'aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android' }}
       - name: Install exact Android SDK components
         run: |
           java -version 2>&1 | grep -F '21.0.12'
@@ -121,12 +135,26 @@ jobs:
             CXX_i686_linux_android CXX_x86_64_linux_android; do
             echo "$name=${!name}" >> "$GITHUB_ENV"
           done
+      - name: Restore credential-free Android Rust dependencies
+        if: github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'
+        uses: ./.github/actions/zuuli-rust-cache
+        with:
+          shared-key: zuuli-release-android-universal-v1
+          target-key: rust-1.88.0-ndk-27.0.12077973-api29-aarch64-armv7-i686-x86_64
+          save: "true"
       - run: npm ci
       - run: npm run release:verify
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
-      - name: Build unsigned arm64 release bundle
-        run: ./node_modules/.bin/tauri android build --ci --aab --target aarch64 -- --locked
+      - name: Build unsigned release bundle
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
+            ./node_modules/.bin/tauri android build --ci --aab --target aarch64 -- --locked
+          else
+            # Main and manual/scheduled canaries compile every ABI shipped to
+            # Play so the protected release can restore a complete cache.
+            ./node_modules/.bin/tauri android build --ci --aab -- --locked
+          fi
       - name: Collect package
         run: |
           mkdir release-artifacts
@@ -153,7 +181,7 @@ jobs:
           retention-days: 14
 
   ios:
-    name: iOS / unsigned simulator app
+    name: iOS / unsigned target app
     runs-on: macos-26
     timeout-minutes: 90
     defaults:
@@ -178,7 +206,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
         with:
           toolchain: 1.88.0
-          targets: aarch64-apple-ios-sim
+          targets: aarch64-apple-ios
+      - name: Restore credential-free iOS Rust dependencies
+        if: github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'
+        uses: ./.github/actions/zuuli-rust-cache
+        with:
+          shared-key: zuuli-release-ios-device-v1
+          target-key: rust-1.88.0-xcode-26.6-ios18-aarch64-device
+          save: "true"
       - run: npm ci
       - run: npm run release:verify
       - name: Exercise Darwin signing-tool contracts
@@ -192,13 +227,15 @@ jobs:
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
       - name: Build without signing
-        run: ./node_modules/.bin/tauri ios build --ci --no-sign --target aarch64-sim -- --locked
-      - name: Collect simulator package
+        # A device archive has the same Rust target as TestFlight. It remains
+        # unsigned and this job receives no Apple credentials.
+        run: ./node_modules/.bin/tauri ios build --ci --no-sign --target aarch64 -- --locked
+      - name: Collect unsigned package
         run: |
           mkdir release-artifacts
           app=$(find src-tauri/gen/apple/build -type d -name '*.app' -print -quit)
           test -n "$app"
-          ditto -c -k --keepParent "$app" release-artifacts/ZUULI-ios-simulator-unsigned.zip
+          ditto -c -k --keepParent "$app" release-artifacts/ZUULI-ios-unsigned.zip
       - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
           syft-version: v1.50.0
@@ -213,7 +250,7 @@ jobs:
           npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: zuuli-ios-simulator-unsigned-${{ github.sha }}
+          name: zuuli-ios-unsigned-${{ github.sha }}
           path: wallet/zuuli/release-artifacts
           if-no-files-found: error
           retention-days: 14
@@ -266,6 +303,13 @@ jobs:
         run: |
           sudo xcode-select --switch /Applications/Xcode_26.6.app
           xcodebuild -version | grep -Fx 'Xcode 26.6'
+      - name: Restore credential-free desktop Rust dependencies
+        if: github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'
+        uses: ./.github/actions/zuuli-rust-cache
+        with:
+          shared-key: ${{ runner.os == 'macOS' && 'zuuli-release-macos-universal-v1' || 'zuuli-release-linux-v1' }}
+          target-key: ${{ runner.os == 'macOS' && 'rust-1.88.0-xcode-26.6-macos-arm64-x86_64' || 'rust-1.88.0-ubuntu-24.04-gtk-webkit-4.1' }}
+          save: "true"
       - run: npm ci
       - run: npm run release:verify
       - name: Verify Rust compiler

--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -140,8 +140,8 @@ jobs:
         uses: ./.github/actions/zuuli-rust-cache
         with:
           shared-key: zuuli-release-android-universal-v1
-          target-key: rust-1.88.0-ndk-27.0.12077973-api29-aarch64-armv7-i686-x86_64
-          save: "true"
+          target-key: rust-${{ env.ZUULI_RUST_VERSION }}-ndk-${{ env.ZUULI_ANDROID_NDK_VERSION }}-api29-aarch64-armv7-i686-x86_64
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - run: npm ci
       - run: npm run release:verify
       - name: Verify Rust compiler
@@ -212,8 +212,8 @@ jobs:
         uses: ./.github/actions/zuuli-rust-cache
         with:
           shared-key: zuuli-release-ios-device-v1
-          target-key: rust-1.88.0-xcode-26.6-ios18-aarch64-device
-          save: "true"
+          target-key: rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-ios18-aarch64-device
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - run: npm ci
       - run: npm run release:verify
       - name: Exercise Darwin signing-tool contracts
@@ -308,8 +308,8 @@ jobs:
         uses: ./.github/actions/zuuli-rust-cache
         with:
           shared-key: ${{ runner.os == 'macOS' && 'zuuli-release-macos-universal-v1' || 'zuuli-release-linux-v1' }}
-          target-key: ${{ runner.os == 'macOS' && 'rust-1.88.0-xcode-26.6-macos-arm64-x86_64' || 'rust-1.88.0-ubuntu-24.04-gtk-webkit-4.1' }}
-          save: "true"
+          target-key: ${{ runner.os == 'macOS' && format('rust-{0}-xcode-{1}-macos-arm64-x86_64', env.ZUULI_RUST_VERSION, env.ZUULI_XCODE_VERSION) || format('rust-{0}-ubuntu-24.04-gtk-webkit-4.1', env.ZUULI_RUST_VERSION) }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - run: npm ci
       - run: npm run release:verify
       - name: Verify Rust compiler

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -238,6 +238,12 @@ jobs:
             CXX_i686_linux_android CXX_x86_64_linux_android; do
             echo "$name=${!name}" >> "$GITHUB_ENV"
           done
+      - name: Restore reviewed Android Rust dependencies
+        uses: ./.github/actions/zuuli-rust-cache
+        with:
+          shared-key: zuuli-release-android-universal-v1
+          target-key: rust-1.88.0-ndk-27.0.12077973-api29-aarch64-armv7-i686-x86_64
+          save: "false"
       - run: npm ci
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
@@ -360,6 +366,12 @@ jobs:
         with:
           toolchain: 1.88.0
           targets: aarch64-apple-ios
+      - name: Restore reviewed iOS Rust dependencies
+        uses: ./.github/actions/zuuli-rust-cache
+        with:
+          shared-key: zuuli-release-ios-device-v1
+          target-key: rust-1.88.0-xcode-26.6-ios18-aarch64-device
+          save: "false"
       - run: npm ci
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
@@ -577,6 +589,12 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
             librsvg2-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libxdo-dev libdbus-1-dev \
             libssl-dev build-essential file pkg-config rpm
+      - name: Restore reviewed Linux Rust dependencies
+        uses: ./.github/actions/zuuli-rust-cache
+        with:
+          shared-key: zuuli-release-linux-v1
+          target-key: rust-1.88.0-ubuntu-24.04-gtk-webkit-4.1
+          save: "false"
       - run: npm ci
       - name: Reverify exact release source
         env:
@@ -669,6 +687,12 @@ jobs:
             toolchain: 1.88.0,
             targets: "aarch64-apple-darwin,x86_64-apple-darwin",
           }
+      - name: Restore reviewed macOS Rust dependencies
+        uses: ./.github/actions/zuuli-rust-cache
+        with:
+          shared-key: zuuli-release-macos-universal-v1
+          target-key: rust-1.88.0-xcode-26.6-macos-arm64-x86_64
+          save: "false"
       - run: npm ci
       - name: Reverify exact release source
         run: node scripts/release-identity.mjs "--source-sha=$ZUULI_RELEASE_SOURCE_SHA" --require-main

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -206,13 +206,10 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24.18.0"
-          cache: npm
-          cache-dependency-path: wallet/zuuli/package-lock.json
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
           java-version: "21.0.12"
-          cache: gradle
       - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
         with:
           toolchain: 1.88.0
@@ -242,7 +239,7 @@ jobs:
         uses: ./.github/actions/zuuli-rust-cache
         with:
           shared-key: zuuli-release-android-universal-v1
-          target-key: rust-1.88.0-ndk-27.0.12077973-api29-aarch64-armv7-i686-x86_64
+          target-key: rust-${{ env.ZUULI_RUST_VERSION }}-ndk-${{ env.ZUULI_ANDROID_NDK_VERSION }}-api29-aarch64-armv7-i686-x86_64
           save: "false"
       - run: npm ci
       - name: Verify Rust compiler
@@ -250,8 +247,9 @@ jobs:
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
         with:
           ruby-version: "3.4.10"
-          bundler-cache: true
           working-directory: wallet/zuuli
+      - name: Install locked Android upload tooling
+        run: bundle install --jobs 4 --retry 3
       - name: Materialize ephemeral signing files
         env:
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -360,8 +358,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24.18.0"
-          cache: npm
-          cache-dependency-path: wallet/zuuli/package-lock.json
       - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
         with:
           toolchain: 1.88.0
@@ -370,7 +366,7 @@ jobs:
         uses: ./.github/actions/zuuli-rust-cache
         with:
           shared-key: zuuli-release-ios-device-v1
-          target-key: rust-1.88.0-xcode-26.6-ios18-aarch64-device
+          target-key: rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-ios18-aarch64-device
           save: "false"
       - run: npm ci
       - name: Verify Rust compiler
@@ -578,8 +574,6 @@ jobs:
         with:
           {
             node-version: "24.18.0",
-            cache: npm,
-            cache-dependency-path: wallet/zuuli/package-lock.json,
           }
       - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
         with: { toolchain: 1.88.0 }
@@ -678,8 +672,6 @@ jobs:
         with:
           {
             node-version: "24.18.0",
-            cache: npm,
-            cache-dependency-path: wallet/zuuli/package-lock.json,
           }
       - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
         with:
@@ -691,7 +683,7 @@ jobs:
         uses: ./.github/actions/zuuli-rust-cache
         with:
           shared-key: zuuli-release-macos-universal-v1
-          target-key: rust-1.88.0-xcode-26.6-macos-arm64-x86_64
+          target-key: rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-macos-arm64-x86_64
           save: "false"
       - run: npm ci
       - name: Reverify exact release source

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -238,8 +238,7 @@ jobs:
       - name: Restore reviewed Android Rust dependencies
         uses: ./.github/actions/zuuli-rust-cache
         with:
-          shared-key: zuuli-release-android-universal-v1
-          target-key: rust-${{ env.ZUULI_RUST_VERSION }}-ndk-${{ env.ZUULI_ANDROID_NDK_VERSION }}-api29-aarch64-armv7-i686-x86_64
+          shared-key: zuuli-release-android-universal-v2-rust-${{ env.ZUULI_RUST_VERSION }}-ndk-${{ env.ZUULI_ANDROID_NDK_VERSION }}-api29-aarch64-armv7-i686-x86_64
           save: "false"
       - run: npm ci
       - name: Verify Rust compiler
@@ -365,8 +364,7 @@ jobs:
       - name: Restore reviewed iOS Rust dependencies
         uses: ./.github/actions/zuuli-rust-cache
         with:
-          shared-key: zuuli-release-ios-device-v1
-          target-key: rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-ios18-aarch64-device
+          shared-key: zuuli-release-ios-device-v2-rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-ios18-aarch64-device
           save: "false"
       - run: npm ci
       - name: Verify Rust compiler
@@ -586,8 +584,7 @@ jobs:
       - name: Restore reviewed Linux Rust dependencies
         uses: ./.github/actions/zuuli-rust-cache
         with:
-          shared-key: zuuli-release-linux-v1
-          target-key: rust-1.88.0-ubuntu-24.04-gtk-webkit-4.1
+          shared-key: zuuli-release-linux-v2-rust-${{ env.ZUULI_RUST_VERSION }}-ubuntu-24.04-gtk-webkit-4.1
           save: "false"
       - run: npm ci
       - name: Reverify exact release source
@@ -682,8 +679,7 @@ jobs:
       - name: Restore reviewed macOS Rust dependencies
         uses: ./.github/actions/zuuli-rust-cache
         with:
-          shared-key: zuuli-release-macos-universal-v1
-          target-key: rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-macos-arm64-x86_64
+          shared-key: zuuli-release-macos-universal-v2-rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-macos-arm64-x86_64
           save: "false"
       - run: npm ci
       - name: Reverify exact release source

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -63,7 +63,7 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/actions/zuuli-rust-cache/*)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*)
                 zuuli=true
                 ;;
             esac
@@ -90,6 +90,9 @@ jobs:
 
       - name: Install locked dependencies
         run: npm ci
+
+      - name: Verify release cache security policy
+        run: node scripts/verify-ci-cache-policy.mjs
 
       # The current lockfile has moderate advisories but no high/critical ones.
       # Dependency upgrades belong in focused PRs; this gate prevents severity

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -63,7 +63,7 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/actions/zuuli-rust-cache/*)
                 zuuli=true
                 ;;
             esac

--- a/wallet/zuuli/CLAUDE.md
+++ b/wallet/zuuli/CLAUDE.md
@@ -28,6 +28,7 @@ npm run tauri -- ios build # unsigned/signing-configured iOS archive as applicab
 npm run tauri -- android dev
 npm run tauri -- android build # Android APK/AAB
 npm run release:verify         # cross-platform version/build/identity contract
+node scripts/verify-ci-cache-policy.mjs # release-cache trust boundaries
 ```
 
 The web dev server runs on **1423** so it never collides with zuuallet (1421).
@@ -46,6 +47,14 @@ Signed releases follow [`docs/releasing.md`](docs/releasing.md). PR packaging
 never receives store credentials; upload jobs use the protected
 `zuuli-app-stores` environment and require an immutable release tag and source
 SHA.
+
+Credential-free packaging may save the shared Rust dependency caches. Protected
+release jobs are restore-only: never let a job that has materialized a signing
+key, certificate, profile, or service-account document save a cache. Cached
+paths are limited to Cargo dependency state under `src-tauri/target` and
+`~/.cargo`; never add generated native build trees, packages, frontend output,
+`node_modules`, release artifacts, or runner-temporary paths. The scheduled
+packaging canary deliberately skips Rust caches to retain clean-build evidence.
 
 `cash.free2z.zuuli` replaces the unreleased `com.2zinc.zuuli` identifier.
 The Zcash plugin migrates reachable legacy application data before wallet state

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -14,6 +14,32 @@ Android SDK/build tools `36`/`36.0.0`, Android NDK `27.0.12077973`, Gradle
 checksum-bearing Bundler `4.0.3` lockfile, and Syft `1.50.0`. Action dependencies
 are commit-SHA pinned. Upgrade these together in a reviewed dependency PR.
 
+## Build cache trust boundary
+
+Packaging and protected release share target-specific Rust dependency caches so
+reruns do not rebuild the entire Zcash graph. Cache identity includes the host,
+Rust environment, Cargo manifests/lockfiles, and an explicit Xcode or Android
+NDK/ABI discriminator. Cargo still recompiles changed path dependencies and the
+cache action removes workspace crates and incremental output before saving, so
+the current ZUULI source and final package are always rebuilt.
+
+Only credential-free `ZUULI / packaging smoke` jobs may save these caches.
+Protected release jobs explicitly restore without saving because their runners
+later materialize signing and store credentials. Never cache `node_modules`,
+frontend output, Gradle/Xcode native build trees, packages, `release-artifacts`,
+provisioning profiles, Keychains, keystores, API keys, or runner-temporary
+directories. `node scripts/verify-ci-cache-policy.mjs` enforces this topology.
+
+The scheduled packaging run skips all Rust caches and rebuilds the Android,
+iOS-device, Linux, and macOS release targets cold. Manual operators can dispatch
+the same proof with `cold_rust_cache=true`. Pull-request cache entries are scoped
+by GitHub to that PR merge ref; the cache cleanup workflow runs from trusted base
+code when the PR closes and deletes only entries returned for that exact ref. A
+daily recovery sweep handles missed close events and older entries, but deletes
+an entry only after its ref matches `refs/pull/<number>/merge` and GitHub's pull
+request API confirms that exact PR is closed. Keep at least 30 GiB of repository
+cache capacity while all four release target families are active.
+
 ## One-time owner bootstrap
 
 The owner has created both store records and the dedicated automation

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -20,10 +20,15 @@ Packaging and protected release share target-specific Rust dependency caches so
 reruns do not rebuild the entire Zcash graph. Cache identity includes the host,
 Rust environment, Cargo manifests/lockfiles, and an explicit Xcode or Android
 NDK/ABI discriminator. Cargo still recompiles changed path dependencies and the
-cache action removes workspace crates and incremental output before saving, so
-the current ZUULI source and final package are always rebuilt.
+cache action removes workspace crates and incremental output before saving. The
+current ZUULI crates and final package are therefore rebuilt, while reviewed
+dependency artifacts produced by a credential-free `main` build are reused and
+linked into them. Caches are an optimization, not release evidence or a trust
+substitute; the cache-free canary proves the complete graph from source.
 
-Only credential-free `ZUULI / packaging smoke` jobs may save these caches.
+Only credential-free `ZUULI / packaging smoke` pushes on `main` may save these
+caches. Pull requests and manual runs restore only, preventing large native PR
+entries from evicting the release families.
 Protected release jobs explicitly restore without saving because their runners
 later materialize signing and store credentials. Never cache `node_modules`,
 frontend output, Gradle/Xcode native build trees, packages, `release-artifacts`,
@@ -35,10 +40,13 @@ iOS-device, Linux, and macOS release targets cold. Manual operators can dispatch
 the same proof with `cold_rust_cache=true`. Pull-request cache entries are scoped
 by GitHub to that PR merge ref; the cache cleanup workflow runs from trusted base
 code when the PR closes and deletes only entries returned for that exact ref. A
-daily recovery sweep handles missed close events and older entries, but deletes
+daily recovery sweep handles missed close events and older npm/Gradle entries,
+but deletes
 an entry only after its ref matches `refs/pull/<number>/merge` and GitHub's pull
-request API confirms that exact PR is closed. Keep at least 30 GiB of repository
-cache capacity while all four release target families are active.
+request API confirms that exact PR is closed. Where configurable for the
+repository, keep at least 30 GiB of cache capacity while all four release target
+families are active; otherwise eviction only makes a release build cold and must
+never affect correctness.
 
 ## One-time owner bootstrap
 

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -19,12 +19,14 @@ are commit-SHA pinned. Upgrade these together in a reviewed dependency PR.
 Packaging and protected release share target-specific Rust dependency caches so
 reruns do not rebuild the entire Zcash graph. Cache identity includes the host,
 Rust environment, Cargo manifests/lockfiles, and an explicit Xcode or Android
-NDK/ABI discriminator. Cargo still recompiles changed path dependencies and the
-cache action removes workspace crates and incremental output before saving. The
-current ZUULI crates and final package are therefore rebuilt, while reviewed
-dependency artifacts produced by a credential-free `main` build are reused and
-linked into them. Caches are an optimization, not release evidence or a trust
-substitute; the cache-free canary proves the complete graph from source.
+NDK/ABI discriminator in the action's effective `shared-key`. Cargo validates
+its fingerprints when restored artifacts are used. The action prunes crates in
+the configured `wallet/zuuli/src-tauri` workspace root before saving; path
+dependencies outside that root, including the shared Zcash plugin and vendored
+Zcash crates, may be restored when their fingerprints still match. Every final
+package is freshly produced. Caches are an optimization, not release evidence
+or a trust substitute; the cache-free canary proves the complete graph from
+source.
 
 Only credential-free `ZUULI / packaging smoke` pushes on `main` may save these
 caches. Pull requests and manual runs restore only, preventing large native PR
@@ -41,12 +43,9 @@ the same proof with `cold_rust_cache=true`. Pull-request cache entries are scope
 by GitHub to that PR merge ref; the cache cleanup workflow runs from trusted base
 code when the PR closes and deletes only entries returned for that exact ref. A
 daily recovery sweep handles missed close events and older npm/Gradle entries,
-but deletes
-an entry only after its ref matches `refs/pull/<number>/merge` and GitHub's pull
-request API confirms that exact PR is closed. Where configurable for the
-repository, keep at least 30 GiB of cache capacity while all four release target
-families are active; otherwise eviction only makes a release build cold and must
-never affect correctness.
+but deletes an entry only after its ref matches `refs/pull/<number>/merge` and GitHub's pull
+request API confirms that exact PR is closed. Repository cache eviction may make
+a release build cold, but must never affect correctness.
 
 ## One-time owner bootstrap
 

--- a/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
+++ b/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoDir = resolve(appDir, "../..");
+const readRepo = (path) => readFileSync(resolve(repoDir, path), "utf8");
+const failures = [];
+
+function requireText(label, contents, expected) {
+  if (!contents.includes(expected)) failures.push(`${label}: missing ${expected}`);
+}
+
+function rejectText(label, contents, forbidden) {
+  if (contents.includes(forbidden)) failures.push(`${label}: contains ${forbidden}`);
+}
+
+function count(contents, value) {
+  return contents.split(value).length - 1;
+}
+
+function requireCount(label, contents, value, expected) {
+  const actual = count(contents, value);
+  if (actual !== expected) {
+    failures.push(`${label}: expected ${expected}, found ${actual}`);
+  }
+}
+
+const action = readRepo(".github/actions/zuuli-rust-cache/action.yml");
+const packaging = readRepo(".github/workflows/zuuli-packaging.yml");
+const release = readRepo(".github/workflows/zuuli-release.yml");
+const cleanup = readRepo(".github/workflows/cache-cleanup.yml");
+const localAction = "uses: ./.github/actions/zuuli-rust-cache";
+
+requireText(
+  "cache action",
+  action,
+  "Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6",
+);
+requireText(
+  "cache action",
+  action,
+  "workspaces: wallet/zuuli/src-tauri -> target",
+);
+requireText("cache action", action, 'default: "false"');
+requireText("cache action", action, 'cache-bin: "false"');
+requireText("cache action", action, 'cache-workspace-crates: "false"');
+requireText("cache action", action, 'cache-on-failure: "false"');
+rejectText("cache action", action, "release-artifacts");
+rejectText("cache action", action, "gen/apple/build");
+rejectText("cache action", action, "gen/android");
+rejectText("cache action", action, "node_modules");
+rejectText("cache action", action, "RUNNER_TEMP");
+
+requireCount("packaging cache callers", packaging, localAction, 3);
+requireCount("packaging cache writers", packaging, 'save: "true"', 3);
+requireText("packaging cold canary", packaging, "schedule:");
+requireCount(
+  "packaging cold-cache guards",
+  packaging,
+  "github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'",
+  3,
+);
+
+requireCount("protected release cache callers", release, localAction, 4);
+requireCount("protected release restore-only callers", release, 'save: "false"', 4);
+rejectText("protected release", release, 'save: "true"');
+
+requireText("cache cleanup trigger", cleanup, "pull_request_target:");
+requireText("cache cleanup trigger", cleanup, "types: [closed]");
+requireText("cache cleanup recovery", cleanup, "schedule:");
+requireText("cache cleanup permissions", cleanup, "actions: write");
+requireText("cache cleanup permissions", cleanup, "contents: none");
+requireText("cache cleanup permissions", cleanup, "pull-requests: read");
+requireText("cache cleanup scope", cleanup, 'pr_ref="refs/pull/$PR_NUMBER/merge"');
+requireText("cache cleanup scope", cleanup, 'gh cache list --ref "$pr_ref"');
+requireText("cache cleanup deletion", cleanup, 'gh cache delete "$cache_id"');
+requireText(
+  "cache cleanup closed-state proof",
+  cleanup,
+  'state=$(gh api "repos/$GH_REPO/pulls/$pr_number" --jq .state)',
+);
+requireText("cache cleanup closed-state proof", cleanup, '[[ "$state" == closed ]]');
+requireText(
+  "cache cleanup PR-only sweep",
+  cleanup,
+  "^refs/pull/([1-9][0-9]*)/merge$",
+);
+rejectText("cache cleanup", cleanup, "actions/checkout");
+rejectText("cache cleanup", cleanup, "gh cache delete --all");
+
+if (failures.length > 0) {
+  console.error("ZUULI CI cache policy verification failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "ZUULI CI cache policy verified: credential-free writers, restore-only releases, and exact closed-PR cleanup.",
+);

--- a/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
+++ b/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
@@ -34,6 +34,18 @@ const release = readRepo(".github/workflows/zuuli-release.yml");
 const cleanup = readRepo(".github/workflows/cache-cleanup.yml");
 const localAction = "uses: ./.github/actions/zuuli-rust-cache";
 
+function job(contents, name, nextName) {
+  const startMarker = `\n  ${name}:\n`;
+  const endMarker = `\n  ${nextName}:\n`;
+  const start = contents.indexOf(startMarker);
+  const end = contents.indexOf(endMarker, start + startMarker.length);
+  if (start < 0 || end < 0) {
+    failures.push(`protected release workflow: cannot isolate ${name} job`);
+    return "";
+  }
+  return contents.slice(start, end);
+}
+
 requireText(
   "cache action",
   action,
@@ -48,6 +60,9 @@ requireText("cache action", action, 'default: "false"');
 requireText("cache action", action, 'cache-bin: "false"');
 requireText("cache action", action, 'cache-workspace-crates: "false"');
 requireText("cache action", action, 'cache-on-failure: "false"');
+requireText("cache action", action, "shared-key: ${{ inputs.shared-key }}");
+requireText("cache action", action, "key: ${{ inputs.target-key }}");
+requireText("cache action", action, "save-if: ${{ inputs.save }}");
 rejectText("cache action", action, "release-artifacts");
 rejectText("cache action", action, "gen/apple/build");
 rejectText("cache action", action, "gen/android");
@@ -55,7 +70,13 @@ rejectText("cache action", action, "node_modules");
 rejectText("cache action", action, "RUNNER_TEMP");
 
 requireCount("packaging cache callers", packaging, localAction, 3);
-requireCount("packaging cache writers", packaging, 'save: "true"', 3);
+requireCount(
+  "packaging main-only cache writers",
+  packaging,
+  "save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}",
+  3,
+);
+rejectText("packaging cache callers", packaging, 'save: "true"');
 requireText("packaging cold canary", packaging, "schedule:");
 requireCount(
   "packaging cold-cache guards",
@@ -67,6 +88,26 @@ requireCount(
 requireCount("protected release cache callers", release, localAction, 4);
 requireCount("protected release restore-only callers", release, 'save: "false"', 4);
 rejectText("protected release", release, 'save: "true"');
+for (const [name, nextName] of [
+  ["android", "ios"],
+  ["ios", "linux"],
+  ["macos", "release-index"],
+]) {
+  const protectedJob = job(release, name, nextName);
+  requireCount(`${name} cache caller`, protectedJob, localAction, 1);
+  requireCount(`${name} restore-only cache caller`, protectedJob, 'save: "false"', 1);
+  for (const writer of [
+    "Swatinem/rust-cache@",
+    "actions/cache@",
+    "actions/cache/save@",
+    "cache: npm",
+    "cache: gradle",
+    "bundler-cache: true",
+    "gh cache",
+  ]) {
+    rejectText(`${name} protected job`, protectedJob, writer);
+  }
+}
 
 requireText("cache cleanup trigger", cleanup, "pull_request_target:");
 requireText("cache cleanup trigger", cleanup, "types: [closed]");

--- a/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
+++ b/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
@@ -77,6 +77,14 @@ requireCount(
   3,
 );
 rejectText("packaging cache callers", packaging, 'save: "true"');
+for (const writer of [
+  "Swatinem/rust-cache@",
+  "actions/cache@",
+  "actions/cache/save@",
+  "gh cache",
+]) {
+  rejectText("packaging direct cache writer", packaging, writer);
+}
 requireText("packaging cold canary", packaging, "schedule:");
 requireCount(
   "packaging cold-cache guards",
@@ -91,6 +99,7 @@ rejectText("protected release", release, 'save: "true"');
 for (const [name, nextName] of [
   ["android", "ios"],
   ["ios", "linux"],
+  ["linux", "macos"],
   ["macos", "release-index"],
 ]) {
   const protectedJob = job(release, name, nextName);

--- a/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
+++ b/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
@@ -32,7 +32,14 @@ const action = readRepo(".github/actions/zuuli-rust-cache/action.yml");
 const packaging = readRepo(".github/workflows/zuuli-packaging.yml");
 const release = readRepo(".github/workflows/zuuli-release.yml");
 const cleanup = readRepo(".github/workflows/cache-cleanup.yml");
+const requiredGate = readRepo(".github/workflows/zuuli.yml");
 const localAction = "uses: ./.github/actions/zuuli-rust-cache";
+const cacheFamilies = [
+  "zuuli-release-android-universal-v2-rust-${{ env.ZUULI_RUST_VERSION }}-ndk-${{ env.ZUULI_ANDROID_NDK_VERSION }}-api29-aarch64-armv7-i686-x86_64",
+  "zuuli-release-ios-device-v2-rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-ios18-aarch64-device",
+  "zuuli-release-linux-v2-rust-${{ env.ZUULI_RUST_VERSION }}-ubuntu-24.04-gtk-webkit-4.1",
+  "zuuli-release-macos-universal-v2-rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-macos-arm64-x86_64",
+];
 
 function job(contents, name, nextName) {
   const startMarker = `\n  ${name}:\n`;
@@ -40,7 +47,7 @@ function job(contents, name, nextName) {
   const start = contents.indexOf(startMarker);
   const end = contents.indexOf(endMarker, start + startMarker.length);
   if (start < 0 || end < 0) {
-    failures.push(`protected release workflow: cannot isolate ${name} job`);
+    failures.push(`workflow: cannot isolate ${name} job`);
     return "";
   }
   return contents.slice(start, end);
@@ -61,20 +68,22 @@ requireText("cache action", action, 'cache-bin: "false"');
 requireText("cache action", action, 'cache-workspace-crates: "false"');
 requireText("cache action", action, 'cache-on-failure: "false"');
 requireText("cache action", action, "shared-key: ${{ inputs.shared-key }}");
-requireText("cache action", action, "key: ${{ inputs.target-key }}");
 requireText("cache action", action, "save-if: ${{ inputs.save }}");
+rejectText("cache action", action, "target-key:");
+rejectText("cache action", action, "key: ${{ inputs.target-key }}");
+rejectText("cache action", action, "add-job-id-key:");
 rejectText("cache action", action, "release-artifacts");
 rejectText("cache action", action, "gen/apple/build");
 rejectText("cache action", action, "gen/android");
 rejectText("cache action", action, "node_modules");
 rejectText("cache action", action, "RUNNER_TEMP");
 
-requireCount("packaging cache callers", packaging, localAction, 3);
+requireCount("packaging cache callers", packaging, localAction, 4);
 requireCount(
   "packaging main-only cache writers",
   packaging,
   "save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}",
-  3,
+  4,
 );
 rejectText("packaging cache callers", packaging, 'save: "true"');
 for (const writer of [
@@ -90,12 +99,36 @@ requireCount(
   "packaging cold-cache guards",
   packaging,
   "github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'",
-  3,
+  4,
 );
+requireCount(
+  "packaging cleanup policy trigger",
+  packaging,
+  ".github/workflows/cache-cleanup.yml",
+  2,
+);
+
+for (const family of cacheFamilies) {
+  requireCount("packaging effective cache family", packaging, `shared-key: ${family}`, 1);
+  requireCount("protected release effective cache family", release, `shared-key: ${family}`, 1);
+}
 
 requireCount("protected release cache callers", release, localAction, 4);
 requireCount("protected release restore-only callers", release, 'save: "false"', 4);
 rejectText("protected release", release, 'save: "true"');
+for (const writer of [
+  "Swatinem/rust-cache@",
+  "actions/cache@",
+  "actions/cache/save@",
+  "cache: gradle",
+  "bundler-cache: true",
+  "gh cache",
+]) {
+  rejectText("protected release direct cache writer", release, writer);
+}
+requireCount("protected release npm auto-cache", release, "cache: npm", 1);
+const prepareJob = job(release, "prepare", "android");
+requireCount("credential-free prepare npm auto-cache", prepareJob, "cache: npm", 1);
 for (const [name, nextName] of [
   ["android", "ios"],
   ["ios", "linux"],
@@ -140,6 +173,19 @@ requireText(
 );
 rejectText("cache cleanup", cleanup, "actions/checkout");
 rejectText("cache cleanup", cleanup, "gh cache delete --all");
+
+requireText(
+  "required gate cache policy trigger",
+  requiredGate,
+  ".github/workflows/cache-cleanup.yml",
+);
+const frontendGate = job(requiredGate, "frontend", "rust_plugin");
+requireCount(
+  "required gate cache policy verification",
+  frontendGate,
+  "node scripts/verify-ci-cache-policy.mjs",
+  1,
+);
 
 if (failures.length > 0) {
   console.error("ZUULI CI cache policy verification failed:");


### PR DESCRIPTION
Closes #278

## Summary

- share target-aware Cargo dependency caches between credential-free packaging and protected release jobs
- keep all protected release cache callers explicitly restore-only
- prime exact Android universal, iOS device, Linux, and macOS release targets while retaining a scheduled/manual cold Rust canary
- reclaim only closed-PR merge-ref caches, with an API-confirmed recovery sweep and no PR checkout
- enforce the topology with a repository-local policy verifier and agent/runbook guidance

## Local verification

- `node wallet/zuuli/scripts/verify-ci-cache-policy.mjs`
- `cd wallet/zuuli && npm ci`
- `npm run typecheck`
- `npm run test` (19/19)
- `npm run build`
- `npm run release:verify`
- actionlint v1.7.12 over every changed workflow
- Ruby Psych parse over changed workflows and composite action
- `git diff --check`

Protected release jobs never save caches after signing material has existed on the runner. The reusable action defaults to restore-only and caches only Cargo dependency state; packages, native generated build trees, frontend output, release artifacts, runner temporary files, and credentials are excluded.