### PR TITLE
fix(ios): enforce protected manual signing

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -59,6 +59,8 @@ jobs:
         run: npm run release:verify
       - name: Exercise generated iOS normalization
         run: node scripts/normalize-generated-ios-project.mjs --self-test
+      - name: Exercise iOS IPA fail-closed verification
+        run: bash scripts/verify-ios-ipa.sh --self-test
       - name: Exercise immutable manifest generation
         run: |
           mkdir release-artifacts
@@ -179,6 +181,8 @@ jobs:
           targets: aarch64-apple-ios-sim
       - run: npm ci
       - run: npm run release:verify
+      - name: Exercise Darwin signing-tool contracts
+        run: bash scripts/verify-ios-ipa.sh --self-test-darwin
       - name: Exercise Xcode release formatting normalization
         run: |
           build=$(jq -r .build release.json)

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -389,11 +389,11 @@ jobs:
           keychain="$files/release.keychain-db"
           keychain_password=$(openssl rand -hex 24)
           security create-keychain -p "$keychain_password" "$keychain"
+          echo "ZUULI_PREFLIGHT_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
           security set-keychain-settings -lut 21600 "$keychain"
           security unlock-keychain -p "$keychain_password" "$keychain"
           security import "$files/distribution.p12" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain" >/dev/null
-          security list-keychains -d user -s "$keychain"
           identity_count=$(security find-identity -v -p codesigning "$keychain" | grep -c 'Apple Distribution: Corpora Inc' || true)
           [[ "$identity_count" -eq 1 ]] || {
             echo "expected exactly one dedicated Corpora Apple Distribution identity" >&2
@@ -414,10 +414,18 @@ jobs:
           [[ "$profile_name" == 'ZUULI App Store CI' ]]
           [[ "$profile_team" == F9AV5HKF6N ]]
           [[ "$profile_app" == F9AV5HKF6N.cash.free2z.zuuli ]]
-          plutil -extract DeveloperCertificates.0 raw -o - "$files/profile.plist" |
-            base64 --decode > "$files/profile-certificate.der"
-          profile_sha=$(openssl x509 -inform DER -in "$files/profile-certificate.der" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')
-          [[ "$profile_sha" == "$identity_sha" ]] || {
+          profile_authorizes_identity=false
+          certificate_index=0
+          while certificate_base64=$(plutil -extract "DeveloperCertificates.$certificate_index" raw -o - "$files/profile.plist" 2>/dev/null); do
+            printf '%s' "$certificate_base64" | base64 --decode > "$files/profile-certificate.der"
+            profile_sha=$(openssl x509 -inform DER -in "$files/profile-certificate.der" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')
+            if [[ "$profile_sha" == "$identity_sha" ]]; then
+              profile_authorizes_identity=true
+              break
+            fi
+            certificate_index=$((certificate_index + 1))
+          done
+          [[ "$profile_authorizes_identity" == true ]] || {
             echo "provisioning profile is not linked to the imported distribution certificate" >&2
             exit 1
           }
@@ -426,11 +434,14 @@ jobs:
           cp "$files/zuuli.mobileprovision" "$profile_dir/$profile_uuid.mobileprovision"
           echo "ASC_KEY_PATH=$files/AuthKey.p8" >> "$GITHUB_ENV"
           echo "ZUULI_SECRET_DIR=$files" >> "$GITHUB_ENV"
-          echo "ZUULI_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
           echo "ZUULI_PROFILE_PATH=$profile_dir/$profile_uuid.mobileprovision" >> "$GITHUB_ENV"
+          security delete-keychain "$keychain"
       - name: Build, validate, and optionally upload
         env:
           DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
+          IOS_CERTIFICATE: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          IOS_MOBILE_PROVISION: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
         run: |
           set -euo pipefail
           if [[ "$DRY_RUN" == false ]]; then
@@ -441,7 +452,7 @@ jobs:
       - name: Destroy ephemeral Apple credentials
         if: always()
         run: |
-          security delete-keychain "$ZUULI_KEYCHAIN" 2>/dev/null || true
+          security delete-keychain "${ZUULI_PREFLIGHT_KEYCHAIN:-}" 2>/dev/null || true
           rm -f -- "${ZUULI_PROFILE_PATH:-}"
           if [[ -n "${ZUULI_SECRET_DIR:-}" && -d "$ZUULI_SECRET_DIR" ]]; then
             find "$ZUULI_SECRET_DIR" -type f -exec rm -f -- {} +

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -80,10 +80,18 @@ APPLE_TEAM_ID
 ASC_KEY_ID
 ASC_ISSUER_ID
 ASC_KEY_PATH                 path to the .p8 file
+IOS_CERTIFICATE              base64-encoded Apple Distribution .p12
+IOS_CERTIFICATE_PASSWORD     password for IOS_CERTIFICATE
+IOS_MOBILE_PROVISION         base64-encoded ZUULI App Store CI profile
 ```
 
-The Apple Distribution identity must already be present in the login Keychain.
-Xcode may obtain the matching provisioning profile with the API key.
+The protected release validates that the certificate, profile, team, and App ID
+are linked before Tauri receives the three manual-signing variables. The
+release script first prepares every signing key that Tauri 2.11.4 updates in a
+validated generated-project shape, then restores the committed Automatic-debug
+project byte-for-byte after the build. The resulting IPA is unpacked and its
+exact embedded profile, distribution signature, certificate linkage, and signed
+entitlements are verified before Apple validation or upload.
 
 Android variables:
 

--- a/wallet/zuuli/scripts/mobile-release.sh
+++ b/wallet/zuuli/scripts/mobile-release.sh
@@ -89,18 +89,25 @@ if [[ "$platform" == ios ]]; then
   fi
   require_value ASC_KEY_ID
   require_value ASC_ISSUER_ID
+  require_value IOS_CERTIFICATE
+  require_value IOS_CERTIFICATE_PASSWORD
+  require_value IOS_MOBILE_PROVISION
   ASC_KEY_PATH=$(canonical_secret_file ASC_KEY_PATH)
 
   key_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-asc.XXXXXX")
   cleanup_apple_key() {
-    rm -f "$key_dir"/private_keys/AuthKey_*.p8
+    find "$key_dir" -type f -exec rm -f -- {} + 2>/dev/null || true
     rmdir "$key_dir/private_keys" "$key_dir" 2>/dev/null || true
   }
   trap cleanup_apple_key EXIT
   mkdir "$key_dir/private_keys"
   cp "$ASC_KEY_PATH" "$key_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8"
 
-  APPLE_TEAM_ID="$APPLE_TEAM_ID" \
+  node scripts/normalize-generated-ios-project.mjs --prepare-manual-signing
+  IOS_CERTIFICATE="$IOS_CERTIFICATE" \
+    IOS_CERTIFICATE_PASSWORD="$IOS_CERTIFICATE_PASSWORD" \
+    IOS_MOBILE_PROVISION="$IOS_MOBILE_PROVISION" \
+    APPLE_TEAM_ID="$APPLE_TEAM_ID" \
     APPLE_API_ISSUER="$ASC_ISSUER_ID" \
     APPLE_API_KEY="$ASC_KEY_ID" \
     APPLE_API_KEY_PATH="$key_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8" \
@@ -114,6 +121,12 @@ if [[ "$platform" == ios ]]; then
 
   ipa=$(find_one './src-tauri/gen/apple/build/arm64/*.ipa')
   ipa_abs="$app_dir/${ipa#./}"
+  printf '%s' "$IOS_MOBILE_PROVISION" | base64 --decode > "$key_dir/expected.mobileprovision"
+  scripts/verify-ios-ipa.sh \
+    "$ipa_abs" \
+    "$key_dir/expected.mobileprovision" \
+    "$APPLE_TEAM_ID" \
+    "$application_id"
   (
     cd "$key_dir"
     xcrun altool --validate-app --type ios --file "$ipa_abs" \

--- a/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
+++ b/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
@@ -5,6 +5,11 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const appDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const teamId = "F9AV5HKF6N";
+const profileUuid = "e5ead62c-83ec-4e54-abb6-4770833b5e0d";
+const profileName = "ZUULI App Store CI";
+const distributionIdentity = `Apple Distribution: Corpora Inc (${teamId})`;
+const appBundleSetting = "PRODUCT_BUNDLE_IDENTIFIER = cash.free2z.zuuli;";
 
 function occurrenceCount(contents, value) {
   return contents.split(value).length - 1;
@@ -23,6 +28,151 @@ function normalizeBuildSetting(contents, name, value, expectedCount) {
   return contents.replaceAll(generated, canonical);
 }
 
+function settingLine(key, value) {
+  return `\t\t\t\t${key} = ${value};`;
+}
+
+function settingIndex(lines, key) {
+  const prefix = `${key} = `;
+  const matches = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].trimStart().startsWith(prefix)) matches.push(index);
+  }
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one ${key} setting, found ${matches.length}`,
+    );
+  }
+  return matches[0];
+}
+
+function replaceSetting(lines, key, expectedValue, replacementValue) {
+  const index = settingIndex(lines, key);
+  const expected = settingLine(key, expectedValue);
+  if (lines[index] !== expected) {
+    throw new Error(
+      `refusing to normalize ${key}: expected ${JSON.stringify(expected)}, found ${JSON.stringify(lines[index])}`,
+    );
+  }
+  if (replacementValue === null) lines.splice(index, 1);
+  else lines[index] = settingLine(key, replacementValue);
+}
+
+function insertSettingAfter(lines, afterKey, key, value) {
+  if (lines.some((line) => line.trimStart().startsWith(`${key} = `))) {
+    throw new Error(`refusing to prepare duplicate ${key} setting`);
+  }
+  lines.splice(settingIndex(lines, afterKey) + 1, 0, settingLine(key, value));
+}
+
+function transformAppConfigurations(contents, transform) {
+  const configurationPattern =
+    /(\t\t[0-9A-F]+ \/\* (debug|release) \*\/ = \{\n\t\t\tisa = XCBuildConfiguration;\n\t\t\tbuildSettings = \{\n)([\s\S]*?)(\n\t\t\t\};\n\t\t\tname = (debug|release);\n\t\t\};)/g;
+  let appConfigurationCount = 0;
+  const transformed = contents.replace(
+    configurationPattern,
+    (block, prefix, headerName, body, suffix, footerName) => {
+      if (headerName !== footerName) {
+        throw new Error(
+          `Xcode configuration name mismatch: ${headerName} != ${footerName}`,
+        );
+      }
+      if (!body.includes(appBundleSetting)) return block;
+      appConfigurationCount += 1;
+      return `${prefix}${transform(body, headerName)}${suffix}`;
+    },
+  );
+  if (appConfigurationCount !== 2) {
+    throw new Error(
+      `expected two ZUULI app build configurations, found ${appConfigurationCount}`,
+    );
+  }
+  return transformed;
+}
+
+function normalizeAppSigning(body, configuration) {
+  const lines = body.split("\n");
+  const sdkIdentity = '"CODE_SIGN_IDENTITY[sdk=iphoneos*]"';
+  const sdkTeam = '"DEVELOPMENT_TEAM[sdk=iphoneos*]"';
+  const sdkProfile = '"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]"';
+  const hasPreparedSigning = lines.some((line) =>
+    line.trimStart().startsWith(`${sdkIdentity} = `),
+  );
+
+  if (hasPreparedSigning) {
+    replaceSetting(
+      lines,
+      "CODE_SIGN_IDENTITY",
+      `"${distributionIdentity}"`,
+      configuration === "debug"
+        ? '"Apple Development"'
+        : '"Apple Distribution"',
+    );
+    replaceSetting(lines, sdkIdentity, `"${distributionIdentity}"`, null);
+    replaceSetting(
+      lines,
+      "CODE_SIGN_STYLE",
+      "Manual",
+      configuration === "debug" ? "Automatic" : "Manual",
+    );
+    replaceSetting(lines, "DEVELOPMENT_TEAM", teamId, teamId);
+    replaceSetting(lines, sdkTeam, `"${teamId}"`, null);
+    replaceSetting(
+      lines,
+      "PROVISIONING_PROFILE_SPECIFIER",
+      `"${profileUuid}"`,
+      configuration === "debug" ? null : `"${profileName}"`,
+    );
+    replaceSetting(lines, sdkProfile, `"${profileUuid}"`, null);
+  }
+
+  return lines.join("\n");
+}
+
+function prepareAppSigning(body, configuration) {
+  const lines = body.split("\n");
+  const identity =
+    configuration === "debug" ? '"Apple Development"' : '"Apple Distribution"';
+  const profile = configuration === "debug" ? '""' : `"${profileName}"`;
+  replaceSetting(lines, "CODE_SIGN_IDENTITY", identity, identity);
+  replaceSetting(
+    lines,
+    "CODE_SIGN_STYLE",
+    configuration === "debug" ? "Automatic" : "Manual",
+    configuration === "debug" ? "Automatic" : "Manual",
+  );
+  replaceSetting(lines, "DEVELOPMENT_TEAM", teamId, teamId);
+  insertSettingAfter(
+    lines,
+    "CODE_SIGN_IDENTITY",
+    '"CODE_SIGN_IDENTITY[sdk=iphoneos*]"',
+    identity,
+  );
+  insertSettingAfter(
+    lines,
+    "DEVELOPMENT_TEAM",
+    '"DEVELOPMENT_TEAM[sdk=iphoneos*]"',
+    teamId,
+  );
+  if (configuration === "debug") {
+    insertSettingAfter(
+      lines,
+      "PRODUCT_NAME",
+      "PROVISIONING_PROFILE_SPECIFIER",
+      profile,
+    );
+  } else {
+    replaceSetting(lines, "PROVISIONING_PROFILE_SPECIFIER", profile, profile);
+  }
+  insertSettingAfter(
+    lines,
+    "PROVISIONING_PROFILE_SPECIFIER",
+    '"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]"',
+    profile,
+  );
+  return lines.join("\n");
+}
+
 function normalizeProject(contents) {
   let normalized = normalizeBuildSetting(
     contents,
@@ -31,7 +181,14 @@ function normalizeProject(contents) {
     2,
   );
   normalized = normalizeBuildSetting(normalized, "PRODUCT_NAME", "ZUULI", 2);
-  return normalized;
+  return transformAppConfigurations(normalized, normalizeAppSigning);
+}
+
+function prepareManualSigningProject(contents) {
+  return transformAppConfigurations(
+    normalizeProject(contents),
+    prepareAppSigning,
+  );
 }
 
 function normalizePlist(contents, label) {
@@ -53,8 +210,20 @@ function selfTest() {
   const expectedProject = generatedProject
     .replaceAll(' = "', " = ")
     .replaceAll('";', ";");
-  if (normalizeProject(generatedProject) !== expectedProject) {
-    throw new Error("iOS project normalization self-test failed");
+  let normalizedFixture = normalizeBuildSetting(
+    generatedProject,
+    "DEVELOPMENT_TEAM",
+    teamId,
+    2,
+  );
+  normalizedFixture = normalizeBuildSetting(
+    normalizedFixture,
+    "PRODUCT_NAME",
+    "ZUULI",
+    2,
+  );
+  if (normalizedFixture !== expectedProject) {
+    throw new Error("iOS basic project normalization self-test failed");
   }
   if (
     normalizePlist("<plist><dict/></plist>", "fixture") !==
@@ -62,12 +231,100 @@ function selfTest() {
   ) {
     throw new Error("iOS plist normalization self-test failed");
   }
+  let rejectedUnexpectedShape = false;
   try {
     normalizeProject('DEVELOPMENT_TEAM = "F9AV5HKF6N";');
   } catch {
-    return;
+    rejectedUnexpectedShape = true;
   }
-  throw new Error("iOS project normalization accepted an unexpected shape");
+  if (!rejectedUnexpectedShape) {
+    throw new Error("iOS project normalization accepted an unexpected shape");
+  }
+  const projectPath = resolve(
+    appDir,
+    "src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj",
+  );
+  const canonical = readFileSync(projectPath, "utf8");
+  if (normalizeProject(canonical) !== canonical) {
+    throw new Error("committed iOS project is not canonical");
+  }
+  const prepared = prepareManualSigningProject(canonical);
+  if (prepared === canonical) {
+    throw new Error("manual-signing preparation did not add guarded settings");
+  }
+  let tauriGenerated = normalizeBuildSetting(
+    prepared,
+    "DEVELOPMENT_TEAM",
+    teamId,
+    2,
+  );
+  tauriGenerated = normalizeBuildSetting(
+    tauriGenerated,
+    "PRODUCT_NAME",
+    "ZUULI",
+    2,
+  );
+  tauriGenerated = transformAppConfigurations(
+    tauriGenerated,
+    (body, configuration) => {
+      const lines = body.split("\n");
+      const canonicalIdentity =
+        configuration === "debug"
+          ? '"Apple Development"'
+          : '"Apple Distribution"';
+      const canonicalProfile =
+        configuration === "debug" ? '""' : `"${profileName}"`;
+      replaceSetting(
+        lines,
+        "CODE_SIGN_IDENTITY",
+        canonicalIdentity,
+        `"${distributionIdentity}"`,
+      );
+      replaceSetting(
+        lines,
+        '"CODE_SIGN_IDENTITY[sdk=iphoneos*]"',
+        canonicalIdentity,
+        `"${distributionIdentity}"`,
+      );
+      replaceSetting(
+        lines,
+        "CODE_SIGN_STYLE",
+        configuration === "debug" ? "Automatic" : "Manual",
+        "Manual",
+      );
+      replaceSetting(lines, "DEVELOPMENT_TEAM", teamId, `"${teamId}"`);
+      replaceSetting(
+        lines,
+        '"DEVELOPMENT_TEAM[sdk=iphoneos*]"',
+        teamId,
+        `"${teamId}"`,
+      );
+      replaceSetting(
+        lines,
+        "PROVISIONING_PROFILE_SPECIFIER",
+        canonicalProfile,
+        `"${profileUuid}"`,
+      );
+      replaceSetting(
+        lines,
+        '"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]"',
+        canonicalProfile,
+        `"${profileUuid}"`,
+      );
+      return lines.join("\n");
+    },
+  );
+  tauriGenerated = tauriGenerated
+    .replaceAll(
+      `DEVELOPMENT_TEAM = ${teamId};`,
+      `DEVELOPMENT_TEAM = "${teamId}";`,
+    )
+    .replaceAll("PRODUCT_NAME = ZUULI;", 'PRODUCT_NAME = "ZUULI";');
+  if (normalizeProject(tauriGenerated) !== canonical) {
+    throw new Error(
+      "manual-signing project did not normalize to canonical bytes",
+    );
+  }
 }
 
 if (process.argv.includes("--self-test")) {
@@ -85,7 +342,9 @@ const plistPaths = [
 ].map((path) => resolve(appDir, path));
 
 const project = readFileSync(projectPath, "utf8");
-const normalizedProject = normalizeProject(project);
+const normalizedProject = process.argv.includes("--prepare-manual-signing")
+  ? prepareManualSigningProject(project)
+  : normalizeProject(project);
 if (normalizedProject !== project) {
   writeFileSync(projectPath, normalizedProject);
 }

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -75,6 +75,8 @@ const androidManifest = read(
 );
 const androidToolchain = read("scripts/android-toolchain-env.sh");
 const gemLock = read("Gemfile.lock");
+const mobileRelease = read("scripts/mobile-release.sh");
+const releaseWorkflow = read("../../.github/workflows/zuuli-release.yml");
 
 expect("package.json version", packageJson.version, release.version);
 expect("package-lock.json version", packageLock.version, release.version);
@@ -357,6 +359,48 @@ expect(
   capture(/channel\s*=\s*"([^"]+)"/, rustToolchain, "Rust toolchain"),
   "1.88.0",
 );
+for (const wiring of [
+  "IOS_CERTIFICATE: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}",
+  "IOS_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}",
+  "IOS_MOBILE_PROVISION: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}",
+]) {
+  if (!releaseWorkflow.includes(wiring))
+    failures.push(`protected iOS manual-signing wiring is missing: ${wiring}`);
+}
+const ipaVerification = mobileRelease.indexOf(
+  "\n  scripts/verify-ios-ipa.sh \\\n",
+);
+const appleValidation = mobileRelease.indexOf(
+  "\n    xcrun altool --validate-app",
+);
+const appleUpload = mobileRelease.indexOf("\n      xcrun altool --upload-app");
+const signingPreparation = mobileRelease.indexOf(
+  "node scripts/normalize-generated-ios-project.mjs --prepare-manual-signing",
+);
+const tauriIosBuild = mobileRelease.indexOf(
+  "./node_modules/.bin/tauri ios build",
+);
+const signingNormalization = mobileRelease.indexOf(
+  "\n  node scripts/normalize-generated-ios-project.mjs\n",
+  tauriIosBuild,
+);
+if (
+  signingPreparation === -1 ||
+  tauriIosBuild === -1 ||
+  signingNormalization === -1 ||
+  ipaVerification === -1 ||
+  appleValidation === -1 ||
+  appleUpload === -1 ||
+  signingPreparation > tauriIosBuild ||
+  tauriIosBuild > signingNormalization ||
+  signingNormalization > ipaVerification ||
+  ipaVerification > appleValidation ||
+  ipaVerification > appleUpload
+) {
+  failures.push(
+    "iOS release must prepare signing keys, build, normalize, inspect the IPA, then validate and upload with Apple",
+  );
+}
 for (const target of [
   "aarch64-linux-android",
   "armv7a-linux-androideabi",

--- a/wallet/zuuli/scripts/verify-ios-ipa.sh
+++ b/wallet/zuuli/scripts/verify-ios-ipa.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+script_path=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")
+
+fail() {
+  echo "iOS IPA verification failed: $*" >&2
+  exit 70
+}
+
+cleanup_directory() {
+  local directory=$1
+  [[ -d "$directory" ]] || return 0
+  find "$directory" -depth -delete 2>/dev/null || true
+}
+
+self_test() (
+  local fixture_dir fixture_ipa output
+  fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-ipa-self-test.XXXXXX")
+  trap 'cleanup_directory "$fixture_dir"' EXIT
+  mkdir -p "$fixture_dir/root/Payload/ZUULI.app"
+  printf 'fixture\n' > "$fixture_dir/root/Payload/ZUULI.app/ZUULI"
+  printf 'fixture\n' > "$fixture_dir/expected.mobileprovision"
+  fixture_ipa="$fixture_dir/missing-profile.ipa"
+  (cd "$fixture_dir/root" && zip -qry "$fixture_ipa" Payload)
+  if output=$("$script_path" "$fixture_ipa" "$fixture_dir/expected.mobileprovision" F9AV5HKF6N cash.free2z.zuuli 2>&1); then
+    fail "missing-profile self-test unexpectedly passed"
+  fi
+  grep -Fq 'archive does not contain exactly one embedded.mobileprovision' <<<"$output" ||
+    fail "missing-profile self-test failed for the wrong reason: $output"
+)
+
+darwin_self_test() (
+  local fixture_dir certificate_prefix entitlements extracted_team
+  [[ "$(uname -s)" == Darwin ]] || fail "--self-test-darwin requires macOS"
+  fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-ipa-darwin-self-test.XXXXXX")
+  trap 'cleanup_directory "$fixture_dir"' EXIT
+
+  certificate_prefix="$fixture_dir/system-certificate-"
+  codesign -d --extract-certificates="$certificate_prefix" /usr/bin/ssh 2>/dev/null ||
+    fail "Darwin self-test could not extract certificates"
+  [[ -f "${certificate_prefix}0" ]] ||
+    fail "Darwin self-test did not extract the signing leaf certificate"
+
+  entitlements="$fixture_dir/entitlements.plist"
+  plutil -create xml1 "$entitlements"
+  plutil -insert 'com\.apple\.developer\.team-identifier' -string F9AV5HKF6N "$entitlements"
+  extracted_team=$(plutil -extract 'com\.apple\.developer\.team-identifier' raw -o - "$entitlements")
+  [[ "$extracted_team" == F9AV5HKF6N ]] ||
+    fail "Darwin self-test could not extract the dotted entitlement key"
+)
+
+if [[ "${1:-}" == --self-test ]]; then
+  [[ $# -eq 1 ]] || fail "--self-test takes no additional arguments"
+  self_test
+  exit 0
+fi
+
+if [[ "${1:-}" == --self-test-darwin ]]; then
+  [[ $# -eq 1 ]] || fail "--self-test-darwin takes no additional arguments"
+  darwin_self_test
+  exit 0
+fi
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: scripts/verify-ios-ipa.sh <ipa> <expected.mobileprovision> <team-id> <application-id>" >&2
+  exit 64
+fi
+
+ipa=$1
+expected_profile=$2
+team_id=$3
+application_id=$4
+
+[[ -f "$ipa" && ! -L "$ipa" ]] || fail "IPA must be a regular, non-symlink file"
+[[ -f "$expected_profile" && ! -L "$expected_profile" ]] ||
+  fail "expected provisioning profile must be a regular, non-symlink file"
+[[ "$team_id" == F9AV5HKF6N ]] || fail "unexpected Apple team $team_id"
+[[ "$application_id" == cash.free2z.zuuli ]] ||
+  fail "unexpected application identifier $application_id"
+
+archive_listing=$(/usr/bin/unzip -Z1 "$ipa") || fail "IPA is not a readable zip archive"
+if grep -Eq '(^/|(^|/)\.\.(/|$))' <<<"$archive_listing"; then
+  fail "IPA contains an unsafe archive path"
+fi
+
+app_roots=()
+while IFS= read -r path; do
+  [[ -n "$path" ]] && app_roots+=("$path")
+done < <(
+  awk -F/ '$1 == "Payload" && $2 ~ /\.app$/ { print $1 "/" $2 }' <<<"$archive_listing" |
+    sort -u
+)
+[[ ${#app_roots[@]} -eq 1 ]] ||
+  fail "archive must contain exactly one top-level Payload app, found ${#app_roots[@]}"
+app_root=${app_roots[0]}
+embedded_archive_path="$app_root/embedded.mobileprovision"
+embedded_count=$(grep -Fxc "$embedded_archive_path" <<<"$archive_listing" || true)
+[[ "$embedded_count" -eq 1 ]] ||
+  fail "archive does not contain exactly one embedded.mobileprovision"
+
+inspect_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-ipa-inspect.XXXXXX")
+trap 'cleanup_directory "$inspect_dir"' EXIT
+/usr/bin/unzip -q "$ipa" -d "$inspect_dir"
+app="$inspect_dir/$app_root"
+embedded_profile="$app/embedded.mobileprovision"
+[[ -d "$app" && ! -L "$app" ]] || fail "app bundle is not a regular directory"
+[[ -f "$embedded_profile" && ! -L "$embedded_profile" ]] ||
+  fail "embedded provisioning profile is not a regular file"
+cmp -s "$expected_profile" "$embedded_profile" ||
+  fail "embedded provisioning profile differs from the protected input"
+
+profile_plist="$inspect_dir/profile.plist"
+security cms -D -i "$embedded_profile" > "$profile_plist" ||
+  fail "embedded provisioning profile is not a valid CMS document"
+profile_uuid=$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$profile_plist")
+profile_name=$(/usr/libexec/PlistBuddy -c 'Print :Name' "$profile_plist")
+profile_team=$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$profile_plist")
+profile_app=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$profile_plist")
+[[ "$profile_uuid" == e5ead62c-83ec-4e54-abb6-4770833b5e0d ]] ||
+  fail "embedded profile UUID is not the protected ZUULI profile"
+[[ "$profile_name" == 'ZUULI App Store CI' ]] ||
+  fail "embedded profile name is not ZUULI App Store CI"
+[[ "$profile_team" == "$team_id" ]] || fail "embedded profile team mismatch"
+[[ "$profile_app" == "$team_id.$application_id" ]] ||
+  fail "embedded profile application identifier mismatch"
+
+codesign --verify --deep --strict --verbose=2 "$app" ||
+  fail "app bundle signature is invalid"
+signature=$(codesign -dvvv "$app" 2>&1) || fail "app signature metadata is unreadable"
+grep -Fxq "Identifier=$application_id" <<<"$signature" ||
+  fail "signed bundle identifier mismatch"
+grep -Fxq "Authority=Apple Distribution: Corpora Inc ($team_id)" <<<"$signature" ||
+  fail "app is not signed by the dedicated Corpora distribution certificate"
+grep -Fxq "TeamIdentifier=$team_id" <<<"$signature" ||
+  fail "signed team identifier mismatch"
+
+certificate_prefix="$inspect_dir/signing-certificate-"
+codesign -d --extract-certificates="$certificate_prefix" "$app" 2>/dev/null ||
+  fail "unable to extract the app signing certificate"
+[[ -f "${certificate_prefix}0" ]] || fail "app signing certificate is missing"
+signer_sha=$(openssl x509 -inform DER -in "${certificate_prefix}0" -noout -fingerprint -sha1 |
+  cut -d= -f2 | tr -d ':')
+profile_authorizes_signer=false
+certificate_index=0
+while certificate_base64=$(plutil -extract "DeveloperCertificates.$certificate_index" raw -o - "$profile_plist" 2>/dev/null); do
+  printf '%s' "$certificate_base64" | base64 --decode > "$inspect_dir/profile-certificate.der"
+  profile_sha=$(openssl x509 -inform DER -in "$inspect_dir/profile-certificate.der" -noout -fingerprint -sha1 |
+    cut -d= -f2 | tr -d ':')
+  if [[ "$signer_sha" == "$profile_sha" ]]; then
+    profile_authorizes_signer=true
+    break
+  fi
+  certificate_index=$((certificate_index + 1))
+done
+[[ "$profile_authorizes_signer" == true ]] ||
+  fail "app signer is not authorized by the embedded provisioning profile"
+
+signed_entitlements="$inspect_dir/signed-entitlements.plist"
+codesign -d --entitlements "$signed_entitlements" --xml "$app" 2>/dev/null ||
+  fail "unable to extract signed entitlements"
+signed_app=$(plutil -extract application-identifier raw -o - "$signed_entitlements")
+signed_team=$(plutil -extract 'com\.apple\.developer\.team-identifier' raw -o - "$signed_entitlements")
+signed_entitlements_json=$(plutil -convert json -o - "$signed_entitlements") ||
+  fail "signed entitlements are not a readable plist"
+[[ "$signed_app" == "$team_id.$application_id" ]] ||
+  fail "signed application entitlement mismatch"
+[[ "$signed_team" == "$team_id" ]] || fail "signed team entitlement mismatch"
+jq -e '
+  type == "object" and
+  ((has("get-task-allow") | not) or .["get-task-allow"] == false)
+' <<<"$signed_entitlements_json" >/dev/null ||
+  fail "distribution app enables or has an invalid get-task-allow entitlement"
+
+echo "verified exact embedded profile and Corpora distribution signature in $(basename -- "$ipa")"


### PR DESCRIPTION
Closes #280.

## What failed

The protected certificate and provisioning profile were validated, but the Tauri iOS build did not receive its documented manual-signing environment variables. With App Store Connect API credentials present, Tauri archived without signing, temporarily signed the executable with its self-signed `Apple Distribution: Tauri (unset)` certificate, and exported an IPA with no `embedded.mobileprovision`. Apple correctly rejected it with 90174 before upload.

## Fix

- pass the protected `IOS_CERTIFICATE`, `IOS_CERTIFICATE_PASSWORD`, and `IOS_MOBILE_PROVISION` values only to the iOS build step and explicitly into Tauri
- keep the preflight certificate keychain isolated from the user search list and delete it before Tauri imports the sole searchable signing identity
- pre-create every signing key Tauri 2.11.4 updates in both app build configurations, avoiding its missing-key raw-line insertion path
- accept only the exact expected Corpora/team/profile mutation and restore the committed Automatic-debug Xcode project byte-for-byte after build
- unpack the IPA and fail closed unless it embeds the exact protected profile, has the expected distribution signature/team/identifier/entitlements, and its signer matches any certificate authorized by that pinned profile
- enforce prepare -> build -> normalize -> inspect -> Apple validate/upload ordering in the release identity contract
- exercise the negative verifier path on Linux and real `codesign`/`plutil` invocation contracts on macOS CI

## Verification

- `npm run release:verify`
- `npm run typecheck`
- `npm test` (19/19)
- `npm run build`
- `npm audit --audit-level=high` (zero high/critical; seven moderate)
- Prettier
- actionlint on both changed workflows
- Bash syntax and ShellCheck
- iOS normalizer source-faithful prepare/mutate/byte-identical restore self-test
- IPA missing-profile fail-closed self-test
- macOS Darwin signing-tool contract self-test
- Claude adversarial review: APPROVE

No store upload is performed by this PR.