### PR TITLE
release: advance ZUULI to 0.1.0+3

### DIFF
--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -1,8 +1,8 @@
 # Releasing ZUULI
 
 ZUULI ships from one reviewed commit under one immutable identity. The current
-identity is `0.1.0+2`: marketing version `0.1.0`, Apple build `2`, Android
-`versionCode` `2`, and package/bundle identifier `cash.free2z.zuuli`.
+identity is `0.1.0+3`: marketing version `0.1.0`, Apple build `3`, Android
+`versionCode` `3`, and package/bundle identifier `cash.free2z.zuuli`.
 
 `release.json` is the source of truth. `npm run release:verify` fails if the npm,
 Cargo, Tauri, generated Xcode, or generated Gradle representation disagrees.
@@ -53,9 +53,9 @@ repeat bootstrap work or substitute unrelated credentials.
 The Play app record already exists for `cash.free2z.zuuli`, and the dedicated
 principal has been granted ZUULI admin access. Fastlane's Play JSON-key
 validation succeeds for this account. Build `0.1.0+1` completed the first API
-upload to the internal track; subsequent protected releases use the same
-dedicated principal and upload key. Do not weaken the account check or upload a
-debug key.
+upload to the internal track, and `0.1.0+2` confirmed the repeatable protected
+path. Subsequent protected releases use the same dedicated principal and upload
+key. Do not weaken the account check or upload a debug key.
 
 Primary references:
 
@@ -151,7 +151,7 @@ must both be confirmed:
 
 ```bash
 export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
-export ZUULI_CONFIRM_UPLOAD=0.1.0+2
+export ZUULI_CONFIRM_UPLOAD=0.1.0+3
 scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
 ```
@@ -215,9 +215,10 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    did not decrease, builds/signs both mobile artifacts, and uploads them to
    TestFlight and Play internal. Adding `release.json` for the first time is a
    no-upload baseline, so merging the release infrastructure itself is safe.
-   Build `0.1.0+1` established the first Play internal release. Its iOS build
-   stopped before Apple validation or upload, so `0.1.0+2` is the first
-   automatic mobile store run with the corrected iOS release path.
+   Build `0.1.0+1` established the first Play internal release, and `0.1.0+2`
+   confirmed repeatable Play delivery. Both iOS attempts stopped before upload;
+   `0.1.0+3` is the first automatic mobile store run with Tauri's protected
+   manual-signing contract and fail-closed IPA verification.
 4. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
    attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
    protected release** with the exact full SHA, identity, missing target, and

--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -3,7 +3,7 @@
   "schemaVersion": 1,
   "applicationId": "cash.free2z.zuuli",
   "version": "0.1.0",
-  "build": 2,
+  "build": 3,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "2").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "3").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "2"
+        CFBundleVersion: "3"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -28,14 +28,14 @@
     "targets": "all",
     "icon": ["icons/icon.png"],
     "iOS": {
-      "bundleVersion": "2",
+      "bundleVersion": "3",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 2
+      "versionCode": 3
     }
   },
   "plugins": {


### PR DESCRIPTION
Closes #282.

## Release identity

Advances the immutable ZUULI store identity from `0.1.0+2` to `0.1.0+3` while preserving marketing version `0.1.0` and application ID `cash.free2z.zuuli`. Build 3 is the first identity whose parent contains the complete Tauri manual-signing and fail-closed IPA verification repair from #281.

The repository release tool updated every build representation together:

- `release.json` build
- Tauri iOS `bundleVersion`
- Tauri Android `versionCode`
- XcodeGen and generated Info.plist `CFBundleVersion`
- generated Gradle fallback `versionCode`
- release operator documentation and local upload confirmation

## Store history

- Builds 1 and 2 reached Play internal successfully.
- Neither prior iOS attempt uploaded to App Store Connect.
- Build 3 is unused on both stores and will trigger the protected release after merge.

## Verification

- `npm run release:verify` => exact `0.1.0+3`
- `npm run typecheck`
- `npm test` (19/19)
- `npm run build`
- `npm audit --audit-level=high` (zero high/critical; seven moderate)
- Prettier on supported changed formats
- `plutil -lint` on generated Info.plist
- `git diff --check`
- exact-head Claude adversarial review: APPROVE

Merging this PR is intentionally store-mutating: the protected workflow will sign and upload Build 3 to TestFlight and Play internal. Do not merge until every PR check is green.