### PR TITLE
fix(ios): reuse verified signing keychain

### DIFF
--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -380,23 +380,49 @@ jobs:
           : "${ASC_ISSUER_ID:?ASC_ISSUER_ID is not configured}"
           files=$(mktemp -d "$RUNNER_TEMP/zuuli-apple.XXXXXX")
           chmod 700 "$files"
+          files=$(CDPATH= cd -P -- "$files" && pwd)
+          echo "ZUULI_SECRET_DIR=$files" >> "$GITHUB_ENV"
           printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$files/distribution.p12"
           printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$files/AuthKey.p8"
           printf '%s' "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$files/zuuli.mobileprovision"
           test -s "$files/distribution.p12"
           test -s "$files/AuthKey.p8"
           test -s "$files/zuuli.mobileprovision"
+          original_keychains="$files/original-user-keychains.txt"
+          security list-keychains -d user |
+            sed -E 's/^[[:space:]]*"//; s/"[[:space:]]*$//' > "$original_keychains"
+          [[ -s "$original_keychains" ]] || {
+            echo "user keychain search list is unexpectedly empty" >&2
+            exit 1
+          }
           keychain="$files/release.keychain-db"
           keychain_password=$(openssl rand -hex 24)
-          security create-keychain -p "$keychain_password" "$keychain"
           echo "ZUULI_PREFLIGHT_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+          echo "ZUULI_ORIGINAL_KEYCHAIN_LIST=$original_keychains" >> "$GITHUB_ENV"
+          security create-keychain -p "$keychain_password" "$keychain"
           security set-keychain-settings -lut 21600 "$keychain"
           security unlock-keychain -p "$keychain_password" "$keychain"
-          security import "$files/distribution.p12" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
+          security import "$files/distribution.p12" -P "$CERTIFICATE_PASSWORD" \
+            -t cert -f pkcs12 \
+            -T /usr/bin/codesign -T /usr/bin/xcodebuild \
+            -k "$keychain"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain" >/dev/null
-          identity_count=$(security find-identity -v -p codesigning "$keychain" | grep -c 'Apple Distribution: Corpora Inc' || true)
+          keychains=("$keychain")
+          while IFS= read -r existing_keychain; do
+            [[ -z "$existing_keychain" ]] || keychains+=("$existing_keychain")
+          done < "$original_keychains"
+          security list-keychains -d user -s "${keychains[@]}"
+          identity_count=$(security find-identity -v -p codesigning "$keychain" | grep -Fc 'Apple Distribution: Corpora Inc (F9AV5HKF6N)' || true)
           [[ "$identity_count" -eq 1 ]] || {
             echo "expected exactly one dedicated Corpora Apple Distribution identity" >&2
+            exit 1
+          }
+          searchable_distribution_count=$(security find-identity -v -p codesigning |
+            grep -Fc 'Apple Distribution:' || true)
+          searchable_identity_count=$(security find-identity -v -p codesigning |
+            grep -Fc 'Apple Distribution: Corpora Inc (F9AV5HKF6N)' || true)
+          [[ "$searchable_distribution_count" -eq 1 && "$searchable_identity_count" -eq 1 ]] || {
+            echo "user keychain search list does not resolve the unique Corpora distribution identity" >&2
             exit 1
           }
           identity_sha=$(security find-identity -v -p codesigning "$keychain" | awk '/Apple Distribution: Corpora Inc/ {print $2; exit}')
@@ -429,18 +455,15 @@ jobs:
             echo "provisioning profile is not linked to the imported distribution certificate" >&2
             exit 1
           }
+          rm -f -- "$files/distribution.p12" "$files/profile-certificate.der"
           profile_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
           mkdir -p "$profile_dir"
           cp "$files/zuuli.mobileprovision" "$profile_dir/$profile_uuid.mobileprovision"
           echo "ASC_KEY_PATH=$files/AuthKey.p8" >> "$GITHUB_ENV"
-          echo "ZUULI_SECRET_DIR=$files" >> "$GITHUB_ENV"
           echo "ZUULI_PROFILE_PATH=$profile_dir/$profile_uuid.mobileprovision" >> "$GITHUB_ENV"
-          security delete-keychain "$keychain"
       - name: Build, validate, and optionally upload
         env:
           DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
-          IOS_CERTIFICATE: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
-          IOS_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
           IOS_MOBILE_PROVISION: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
         run: |
           set -euo pipefail
@@ -452,12 +475,42 @@ jobs:
       - name: Destroy ephemeral Apple credentials
         if: always()
         run: |
-          security delete-keychain "${ZUULI_PREFLIGHT_KEYCHAIN:-}" 2>/dev/null || true
-          rm -f -- "${ZUULI_PROFILE_PATH:-}"
-          if [[ -n "${ZUULI_SECRET_DIR:-}" && -d "$ZUULI_SECRET_DIR" ]]; then
-            find "$ZUULI_SECRET_DIR" -type f -exec rm -f -- {} +
-            rmdir "$ZUULI_SECRET_DIR"
+          set -u
+          cleanup_failed=0
+          if [[ -n "${ZUULI_ORIGINAL_KEYCHAIN_LIST:-}" && -s "$ZUULI_ORIGINAL_KEYCHAIN_LIST" ]]; then
+            original_keychains=()
+            while IFS= read -r existing_keychain; do
+              [[ -z "$existing_keychain" ]] || original_keychains+=("$existing_keychain")
+            done < "$ZUULI_ORIGINAL_KEYCHAIN_LIST"
+            if [[ ${#original_keychains[@]} -gt 0 ]]; then
+              security list-keychains -d user -s "${original_keychains[@]}" || cleanup_failed=1
+            else
+              echo "recorded user keychain search list is empty" >&2
+              cleanup_failed=1
+            fi
+          elif [[ -n "${ZUULI_PREFLIGHT_KEYCHAIN:-}" ]]; then
+            echo "cannot restore the original user keychain search list" >&2
+            cleanup_failed=1
           fi
+          if [[ -n "${ZUULI_PREFLIGHT_KEYCHAIN:-}" && -e "$ZUULI_PREFLIGHT_KEYCHAIN" ]]; then
+            security delete-keychain "$ZUULI_PREFLIGHT_KEYCHAIN" || cleanup_failed=1
+          fi
+          if [[ -n "${ZUULI_PROFILE_PATH:-}" ]]; then
+            rm -f -- "$ZUULI_PROFILE_PATH" || cleanup_failed=1
+          fi
+          if [[ -n "${ZUULI_SECRET_DIR:-}" && -d "$ZUULI_SECRET_DIR" ]]; then
+            find "$ZUULI_SECRET_DIR" -type f -exec rm -f -- {} + || cleanup_failed=1
+            rmdir "$ZUULI_SECRET_DIR" || cleanup_failed=1
+          fi
+          [[ -z "${ZUULI_PREFLIGHT_KEYCHAIN:-}" || ! -e "$ZUULI_PREFLIGHT_KEYCHAIN" ]] || cleanup_failed=1
+          [[ -z "${ZUULI_PROFILE_PATH:-}" || ! -e "$ZUULI_PROFILE_PATH" ]] || cleanup_failed=1
+          [[ -z "${ZUULI_SECRET_DIR:-}" || ! -e "$ZUULI_SECRET_DIR" ]] || cleanup_failed=1
+          if [[ -n "${ZUULI_PREFLIGHT_KEYCHAIN:-}" ]] &&
+            security list-keychains -d user | grep -Fq "$ZUULI_PREFLIGHT_KEYCHAIN"; then
+            echo "ephemeral release keychain remains in the user search list" >&2
+            cleanup_failed=1
+          fi
+          exit "$cleanup_failed"
       - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
           syft-version: v1.50.0

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -80,18 +80,32 @@ APPLE_TEAM_ID
 ASC_KEY_ID
 ASC_ISSUER_ID
 ASC_KEY_PATH                 path to the .p8 file
-IOS_CERTIFICATE              base64-encoded Apple Distribution .p12
-IOS_CERTIFICATE_PASSWORD     password for IOS_CERTIFICATE
+ZUULI_PREFLIGHT_KEYCHAIN     path to an unlocked, ephemeral signing keychain
 IOS_MOBILE_PROVISION         base64-encoded ZUULI App Store CI profile
 ```
 
 The protected release validates that the certificate, profile, team, and App ID
-are linked before Tauri receives the three manual-signing variables. The
-release script first prepares every signing key that Tauri 2.11.4 updates in a
-validated generated-project shape, then restores the committed Automatic-debug
-project byte-for-byte after the build. The resulting IPA is unpacked and its
-exact embedded profile, distribution signature, certificate linkage, and signed
-entitlements are verified before Apple validation or upload.
+are linked, removes the decoded PKCS#12 file, and keeps the unlocked ephemeral
+keychain in the user search list through Tauri and Xcode export. The import ACL
+trusts only `codesign` and `xcodebuild`. Tauri receives only the provisioning
+profile—not the distribution P12 and not the ASC API credentials—so Xcode signs
+the archive directly and neither Tauri 2.11.4 PKCS#12-import path can run. This
+avoids the path that could not read this dedicated P12 on macOS 26. The release
+script rejects certificate variables and Tauri-facing `APPLE_API_*` variables,
+proves the dedicated identity is still present and discoverable, prepares every
+signing key that Tauri updates in a validated generated-project shape, then
+restores the
+committed Automatic-debug project byte-for-byte after the build. The resulting
+IPA is unpacked and its exact embedded profile, distribution signature,
+certificate linkage, and signed entitlements are verified before Apple
+validation or upload. The workflow then restores the original keychain search
+list and fails if the keychain, installed profile, or credential directory
+survives cleanup.
+
+The implicit-format import regression is reported upstream as
+[`tauri-apps/tauri#15843`](https://github.com/tauri-apps/tauri/issues/15843).
+Remove this workaround only after the fixed Tauri release is upgraded here and
+the protected path has proved the replacement import and cleanup behavior.
 
 Android variables:
 

--- a/wallet/zuuli/scripts/mobile-release.sh
+++ b/wallet/zuuli/scripts/mobile-release.sh
@@ -89,9 +89,43 @@ if [[ "$platform" == ios ]]; then
   fi
   require_value ASC_KEY_ID
   require_value ASC_ISSUER_ID
-  require_value IOS_CERTIFICATE
-  require_value IOS_CERTIFICATE_PASSWORD
   require_value IOS_MOBILE_PROVISION
+  signing_keychain=$(canonical_secret_file ZUULI_PREFLIGHT_KEYCHAIN)
+  if [[ -n "${IOS_CERTIFICATE+x}" || -n "${IOS_CERTIFICATE_PASSWORD+x}" ]]; then
+    echo "refusing duplicate iOS certificate import: use the verified ephemeral keychain" >&2
+    exit 66
+  fi
+  if [[ -n "${APPLE_API_KEY+x}" || -n "${APPLE_API_ISSUER+x}" || -n "${APPLE_API_KEY_PATH+x}" ]]; then
+    echo "refusing Tauri skip-signing path: App Store credentials are reserved for altool" >&2
+    exit 66
+  fi
+  if [[ $(security find-identity -v -p codesigning "$signing_keychain" |
+    grep -Fc 'Apple Distribution: Corpora Inc (F9AV5HKF6N)' || true) -ne 1 ]]; then
+    echo "verified ephemeral keychain does not contain exactly one Corpora distribution identity" >&2
+    exit 66
+  fi
+  searchable_distribution_count=$(security find-identity -v -p codesigning |
+    grep -Fc 'Apple Distribution:' || true)
+  searchable_identity_count=$(security find-identity -v -p codesigning |
+    grep -Fc 'Apple Distribution: Corpora Inc (F9AV5HKF6N)' || true)
+  if [[ "$searchable_distribution_count" -ne 1 || "$searchable_identity_count" -ne 1 ]]; then
+    echo "user keychain search list does not resolve the unique Corpora distribution identity" >&2
+    exit 66
+  fi
+  keychain_is_searchable=false
+  while IFS= read -r listed_keychain; do
+    [[ -f "$listed_keychain" && ! -L "$listed_keychain" ]] || continue
+    listed_parent=$(CDPATH= cd -P -- "$(dirname -- "$listed_keychain")" && pwd)
+    if [[ "$listed_parent/$(basename -- "$listed_keychain")" == "$signing_keychain" ]]; then
+      keychain_is_searchable=true
+      break
+    fi
+  done < <(security list-keychains -d user |
+    sed -E 's/^[[:space:]]*"//; s/"[[:space:]]*$//')
+  if [[ "$keychain_is_searchable" != true ]]; then
+    echo "verified ephemeral keychain is missing from the user search list" >&2
+    exit 66
+  fi
   ASC_KEY_PATH=$(canonical_secret_file ASC_KEY_PATH)
 
   key_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-asc.XXXXXX")
@@ -104,13 +138,8 @@ if [[ "$platform" == ios ]]; then
   cp "$ASC_KEY_PATH" "$key_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8"
 
   node scripts/normalize-generated-ios-project.mjs --prepare-manual-signing
-  IOS_CERTIFICATE="$IOS_CERTIFICATE" \
-    IOS_CERTIFICATE_PASSWORD="$IOS_CERTIFICATE_PASSWORD" \
-    IOS_MOBILE_PROVISION="$IOS_MOBILE_PROVISION" \
+  IOS_MOBILE_PROVISION="$IOS_MOBILE_PROVISION" \
     APPLE_TEAM_ID="$APPLE_TEAM_ID" \
-    APPLE_API_ISSUER="$ASC_ISSUER_ID" \
-    APPLE_API_KEY="$ASC_KEY_ID" \
-    APPLE_API_KEY_PATH="$key_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8" \
     ./node_modules/.bin/tauri ios build \
       --ci \
       --export-method app-store-connect \

--- a/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
+++ b/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
@@ -103,12 +103,21 @@ function normalizeAppSigning(body, configuration) {
     replaceSetting(
       lines,
       "CODE_SIGN_IDENTITY",
-      `"${distributionIdentity}"`,
+      configuration === "debug"
+        ? '"Apple Development"'
+        : `"${distributionIdentity}"`,
       configuration === "debug"
         ? '"Apple Development"'
         : '"Apple Distribution"',
     );
-    replaceSetting(lines, sdkIdentity, `"${distributionIdentity}"`, null);
+    replaceSetting(
+      lines,
+      sdkIdentity,
+      configuration === "debug"
+        ? '"Apple Development"'
+        : `"${distributionIdentity}"`,
+      null,
+    );
     replaceSetting(
       lines,
       "CODE_SIGN_STYLE",
@@ -116,7 +125,7 @@ function normalizeAppSigning(body, configuration) {
       configuration === "debug" ? "Automatic" : "Manual",
     );
     replaceSetting(lines, "DEVELOPMENT_TEAM", teamId, teamId);
-    replaceSetting(lines, sdkTeam, `"${teamId}"`, null);
+    replaceSetting(lines, sdkTeam, teamId, null);
     replaceSetting(
       lines,
       "PROVISIONING_PROFILE_SPECIFIER",
@@ -131,10 +140,14 @@ function normalizeAppSigning(body, configuration) {
 
 function prepareAppSigning(body, configuration) {
   const lines = body.split("\n");
-  const identity =
+  const canonicalIdentity =
     configuration === "debug" ? '"Apple Development"' : '"Apple Distribution"';
+  const identity =
+    configuration === "debug"
+      ? '"Apple Development"'
+      : `"${distributionIdentity}"`;
   const profile = configuration === "debug" ? '""' : `"${profileName}"`;
-  replaceSetting(lines, "CODE_SIGN_IDENTITY", identity, identity);
+  replaceSetting(lines, "CODE_SIGN_IDENTITY", canonicalIdentity, identity);
   replaceSetting(
     lines,
     "CODE_SIGN_STYLE",
@@ -268,24 +281,8 @@ function selfTest() {
     tauriGenerated,
     (body, configuration) => {
       const lines = body.split("\n");
-      const canonicalIdentity =
-        configuration === "debug"
-          ? '"Apple Development"'
-          : '"Apple Distribution"';
       const canonicalProfile =
         configuration === "debug" ? '""' : `"${profileName}"`;
-      replaceSetting(
-        lines,
-        "CODE_SIGN_IDENTITY",
-        canonicalIdentity,
-        `"${distributionIdentity}"`,
-      );
-      replaceSetting(
-        lines,
-        '"CODE_SIGN_IDENTITY[sdk=iphoneos*]"',
-        canonicalIdentity,
-        `"${distributionIdentity}"`,
-      );
       replaceSetting(
         lines,
         "CODE_SIGN_STYLE",
@@ -293,12 +290,6 @@ function selfTest() {
         "Manual",
       );
       replaceSetting(lines, "DEVELOPMENT_TEAM", teamId, `"${teamId}"`);
-      replaceSetting(
-        lines,
-        '"DEVELOPMENT_TEAM[sdk=iphoneos*]"',
-        teamId,
-        `"${teamId}"`,
-      );
       replaceSetting(
         lines,
         "PROVISIONING_PROFILE_SPECIFIER",

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -360,12 +360,99 @@ expect(
   "1.88.0",
 );
 for (const wiring of [
-  "IOS_CERTIFICATE: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}",
-  "IOS_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}",
   "IOS_MOBILE_PROVISION: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}",
+  "ZUULI_PREFLIGHT_KEYCHAIN=$keychain",
+  'security list-keychains -d user -s "${keychains[@]}"',
+  'security delete-keychain "$ZUULI_PREFLIGHT_KEYCHAIN"',
+  "-t cert -f pkcs12",
+  "-T /usr/bin/codesign -T /usr/bin/xcodebuild",
 ]) {
   if (!releaseWorkflow.includes(wiring))
-    failures.push(`protected iOS manual-signing wiring is missing: ${wiring}`);
+    failures.push(`protected iOS signing-keychain wiring is missing: ${wiring}`);
+}
+expect(
+  "protected build certificate secret exposure count",
+  occurrenceCount(
+    releaseWorkflow,
+    "IOS_CERTIFICATE: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}",
+  ),
+  0,
+);
+expect(
+  "protected build certificate password secret exposure count",
+  occurrenceCount(
+    releaseWorkflow,
+    "IOS_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}",
+  ),
+  0,
+);
+expect(
+  "protected certificate materialization count",
+  occurrenceCount(
+    releaseWorkflow,
+    "CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}",
+  ),
+  1,
+);
+expect(
+  "protected certificate password materialization count",
+  occurrenceCount(
+    releaseWorkflow,
+    "CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}",
+  ),
+  1,
+);
+expect(
+  "protected provisioning-profile build exposure count",
+  occurrenceCount(
+    releaseWorkflow,
+    "IOS_MOBILE_PROVISION: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}",
+  ),
+  1,
+);
+const explicitCertificateImport = releaseWorkflow.indexOf(
+  'security import "$files/distribution.p12" -P "$CERTIFICATE_PASSWORD"',
+);
+const decodedCertificateRemoval = releaseWorkflow.indexOf(
+  'rm -f -- "$files/distribution.p12" "$files/profile-certificate.der"',
+);
+const protectedIosBuild = releaseWorkflow.indexOf(
+  "      - name: Build, validate, and optionally upload",
+);
+const protectedIosCleanup = releaseWorkflow.indexOf(
+  "      - name: Destroy ephemeral Apple credentials",
+);
+if (
+  explicitCertificateImport === -1 ||
+  decodedCertificateRemoval === -1 ||
+  protectedIosBuild === -1 ||
+  protectedIosCleanup === -1 ||
+  explicitCertificateImport > decodedCertificateRemoval ||
+  decodedCertificateRemoval > protectedIosBuild ||
+  protectedIosBuild > protectedIosCleanup
+) {
+  failures.push(
+    "protected iOS release must explicitly import, remove the decoded P12, build from the keychain, then clean up",
+  );
+}
+for (const guard of [
+  "refusing duplicate iOS certificate import",
+  "refusing Tauri skip-signing path",
+  "verified ephemeral keychain is missing from the user search list",
+  "user keychain search list does not resolve the unique Corpora distribution identity",
+]) {
+  if (!mobileRelease.includes(guard))
+    failures.push(`iOS release keychain guard is missing: ${guard}`);
+}
+for (const forbiddenTauriCredential of [
+  'APPLE_API_ISSUER="$ASC_ISSUER_ID"',
+  'APPLE_API_KEY="$ASC_KEY_ID"',
+  'APPLE_API_KEY_PATH="$key_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8"',
+]) {
+  if (mobileRelease.includes(forbiddenTauriCredential))
+    failures.push(
+      `Tauri must not receive App Store credentials that enable its skip-signing path: ${forbiddenTauriCredential}`,
+    );
 }
 const ipaVerification = mobileRelease.indexOf(
   "\n  scripts/verify-ios-ipa.sh \\\n",


### PR DESCRIPTION
Closes #284

## Outcome

Fixes the protected iOS release failure on macOS 26 without weakening signing verification. The workflow imports and validates the dedicated Corpora distribution identity once, keeps that ephemeral keychain available to Xcode, and removes every Tauri path that would re-import a PKCS#12.

## Design

- Explicitly imports the protected P12 with deterministic PKCS#12 type/format and ACLs limited to `codesign`/`xcodebuild`.
- Validates exact identity, profile UUID/name/team/App ID, certificate linkage, and uniqueness across the full user keychain search list.
- Passes Tauri only `IOS_MOBILE_PROVISION`; rejects both `IOS_CERTIFICATE*` and `APPLE_API_*`, so neither Tauri implicit-import/skip-signing path is reachable.
- Pins the full Corpora distribution certificate name in the prepared runtime Xcode project, preserves the canonical committed project byte-for-byte afterward, and retains the fail-closed IPA verifier before Apple validation/upload.
- Restores the original user keychain search list and verifies removal of the keychain, installed profile, and credential directory on every job outcome.
- Documents upstream `tauri-apps/tauri#15843`.

## Verification

- `bash -n wallet/zuuli/scripts/mobile-release.sh` under macOS Bash 3.2.57
- extracted cleanup step syntax + empty-materialization execution under Bash 3.2.57
- `node wallet/zuuli/scripts/normalize-generated-ios-project.mjs --self-test`
- `npm run release:verify`
- `npm test` (19/19)
- `npm run typecheck`
- `npm run build`
- YAML parse + `git diff --check`
- exact-head Claude adversarial review: **APPROVE** after one request-changes round; verified against Tauri CLI 2.11.4 source

## Upstream

- https://github.com/tauri-apps/tauri/issues/15843

Do not merge until the full required matrix is green.