### PR TITLE
release: advance ZUULI to 0.1.0+4

### DIFF
--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -1,8 +1,8 @@
 # Releasing ZUULI
 
 ZUULI ships from one reviewed commit under one immutable identity. The current
-identity is `0.1.0+3`: marketing version `0.1.0`, Apple build `3`, Android
-`versionCode` `3`, and package/bundle identifier `cash.free2z.zuuli`.
+identity is `0.1.0+4`: marketing version `0.1.0`, Apple build `4`, Android
+`versionCode` `4`, and package/bundle identifier `cash.free2z.zuuli`.
 
 `release.json` is the source of truth. `npm run release:verify` fails if the npm,
 Cargo, Tauri, generated Xcode, or generated Gradle representation disagrees.
@@ -198,7 +198,7 @@ must both be confirmed:
 
 ```bash
 export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
-export ZUULI_CONFIRM_UPLOAD=0.1.0+3
+export ZUULI_CONFIRM_UPLOAD=0.1.0+4
 scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
 ```
@@ -263,9 +263,11 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    TestFlight and Play internal. Adding `release.json` for the first time is a
    no-upload baseline, so merging the release infrastructure itself is safe.
    Build `0.1.0+1` established the first Play internal release, and `0.1.0+2`
-   confirmed repeatable Play delivery. Both iOS attempts stopped before upload;
-   `0.1.0+3` is the first automatic mobile store run with Tauri's protected
-   manual-signing contract and fail-closed IPA verification.
+   confirmed repeatable Play delivery. Build `0.1.0+3` also reached Play
+   internal, while its iOS job stopped before upload in Tauri's PKCS#12 import
+   path. Build `0.1.0+4` is the first automatic mobile store run with the
+   verified signing keychain reuse workaround, fail-closed IPA verification,
+   and corrected shared Rust caches.
 4. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
    attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
    protected release** with the exact full SHA, identity, missing target, and

--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -3,7 +3,7 @@
   "schemaVersion": 1,
   "applicationId": "cash.free2z.zuuli",
   "version": "0.1.0",
-  "build": 3,
+  "build": 4,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "3").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "4").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "3"
+        CFBundleVersion: "4"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -28,14 +28,14 @@
     "targets": "all",
     "icon": ["icons/icon.png"],
     "iOS": {
-      "bundleVersion": "3",
+      "bundleVersion": "4",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 3
+      "versionCode": 4
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

- advance the synchronized ZUULI identity from 0.1.0+3 to 0.1.0+4
- preserve marketing version 0.1.0 and application ID cash.free2z.zuuli
- synchronize Tauri, generated Xcode/plist, and generated Gradle build numbers
- correct the operator runbook with the Build 3 Play success / pre-upload iOS failure and Build 4 recovery context

## Verification

- npm run release:verify
- npm run typecheck
- npm test (19/19)
- npm run build
- npm audit --audit-level=high (zero high/critical; seven moderate)
- Prettier, plutil, and git diff checks
- exact-head Claude adversarial review: APPROVE

## Release safety

Exact reviewed head: cac614a8b275e1f1078f006319f4471ff5b49aa8.

The corrected v2 Rust caches were first seeded by trusted main packaging run 31252049015, which completed successfully. This PR will restore only and is being monitored for correctness and timing.

Merging this PR is store-mutating. Do not merge until every automated check is green on this exact head; founder/admin review bypass remains a deliberate post-CI action.

Closes #286