### PR TITLE
fix(ios): canonicalize URL plist ordering for build 5

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -230,6 +230,14 @@ jobs:
         # A device archive has the same Rust target as TestFlight. It remains
         # unsigned and this job receives no Apple credentials.
         run: ./node_modules/.bin/tauri ios build --ci --no-sign --target aarch64 -- --locked
+      - name: Verify post-build iOS project reproducibility
+        run: |
+          node scripts/normalize-generated-ios-project.mjs
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git status --short
+            git diff
+            exit 1
+          fi
       - name: Collect unsigned package
         run: |
           mkdir release-artifacts

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -1,8 +1,8 @@
 # Releasing ZUULI
 
 ZUULI ships from one reviewed commit under one immutable identity. The current
-identity is `0.1.0+4`: marketing version `0.1.0`, Apple build `4`, Android
-`versionCode` `4`, and package/bundle identifier `cash.free2z.zuuli`.
+identity is `0.1.0+5`: marketing version `0.1.0`, Apple build `5`, Android
+`versionCode` `5`, and package/bundle identifier `cash.free2z.zuuli`.
 
 `release.json` is the source of truth. `npm run release:verify` fails if the npm,
 Cargo, Tauri, generated Xcode, or generated Gradle representation disagrees.
@@ -198,7 +198,7 @@ must both be confirmed:
 
 ```bash
 export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
-export ZUULI_CONFIRM_UPLOAD=0.1.0+4
+export ZUULI_CONFIRM_UPLOAD=0.1.0+5
 scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
 ```
@@ -265,9 +265,11 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    Build `0.1.0+1` established the first Play internal release, and `0.1.0+2`
    confirmed repeatable Play delivery. Build `0.1.0+3` also reached Play
    internal, while its iOS job stopped before upload in Tauri's PKCS#12 import
-   path. Build `0.1.0+4` is the first automatic mobile store run with the
-   verified signing keychain reuse workaround, fail-closed IPA verification,
-   and corrected shared Rust caches.
+   path. Build `0.1.0+4` proved the verified signing-keychain workaround by
+   signing and exporting the iOS IPA, and it reached Play internal. Its iOS job
+   stopped before verification/upload on a generated-plist ordering diff.
+   Build `0.1.0+5` is the canonical-plist retry; it retains fail-closed IPA
+   verification and the corrected shared Rust caches.
 4. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
    attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
    protected release** with the exact full SHA, identity, missing target, and

--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -3,7 +3,7 @@
   "schemaVersion": 1,
   "applicationId": "cash.free2z.zuuli",
   "version": "0.1.0",
-  "build": 4,
+  "build": 5,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
+++ b/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
@@ -10,6 +10,32 @@ const profileUuid = "e5ead62c-83ec-4e54-abb6-4770833b5e0d";
 const profileName = "ZUULI App Store CI";
 const distributionIdentity = `Apple Distribution: Corpora Inc (${teamId})`;
 const appBundleSetting = "PRODUCT_BUNDLE_IDENTIFIER = cash.free2z.zuuli;";
+const canonicalUrlType = [
+  "\t<key>CFBundleURLTypes</key>",
+  "\t<array>",
+  "\t\t<dict>",
+  "\t\t\t<key>CFBundleURLName</key>",
+  "\t\t\t<string>cash.free2z.zuuli</string>",
+  "\t\t\t<key>CFBundleURLSchemes</key>",
+  "\t\t\t<array>",
+  "\t\t\t\t<string>cash.free2z.zuuli</string>",
+  "\t\t\t</array>",
+  "\t\t</dict>",
+  "\t</array>",
+].join("\n");
+const reversedUrlType = [
+  "\t<key>CFBundleURLTypes</key>",
+  "\t<array>",
+  "\t\t<dict>",
+  "\t\t\t<key>CFBundleURLSchemes</key>",
+  "\t\t\t<array>",
+  "\t\t\t\t<string>cash.free2z.zuuli</string>",
+  "\t\t\t</array>",
+  "\t\t\t<key>CFBundleURLName</key>",
+  "\t\t\t<string>cash.free2z.zuuli</string>",
+  "\t\t</dict>",
+  "\t</array>",
+].join("\n");
 
 function occurrenceCount(contents, value) {
   return contents.split(value).length - 1;
@@ -213,6 +239,18 @@ function normalizePlist(contents, label) {
   return contents.endsWith("\n") ? contents : `${contents}\n`;
 }
 
+function normalizeInfoPlist(contents, label) {
+  const normalized = normalizePlist(contents, label);
+  const canonicalCount = occurrenceCount(normalized, canonicalUrlType);
+  const reversedCount = occurrenceCount(normalized, reversedUrlType);
+  if (canonicalCount + reversedCount !== 1) {
+    throw new Error(
+      `refusing to normalize ${label}: expected exactly one known ZUULI URL type, found ${canonicalCount + reversedCount}`,
+    );
+  }
+  return normalized.replace(reversedUrlType, canonicalUrlType);
+}
+
 function selfTest() {
   const generatedProject = [
     'DEVELOPMENT_TEAM = "F9AV5HKF6N";',
@@ -243,6 +281,35 @@ function selfTest() {
     "<plist><dict/></plist>\n"
   ) {
     throw new Error("iOS plist normalization self-test failed");
+  }
+  const canonicalFixture = `<plist><dict>\n${canonicalUrlType}\n</dict></plist>`;
+  const reversedFixture = `<plist><dict>\n${reversedUrlType}\n</dict></plist>`;
+  if (
+    normalizeInfoPlist(canonicalFixture, "canonical fixture") !==
+      `${canonicalFixture}\n` ||
+    normalizeInfoPlist(reversedFixture, "reversed fixture") !==
+      `${canonicalFixture}\n`
+  ) {
+    throw new Error("iOS URL type ordering self-test failed");
+  }
+  let rejectedUnknownUrlShape = false;
+  try {
+    normalizeInfoPlist("<plist><dict/></plist>", "unknown fixture");
+  } catch {
+    rejectedUnknownUrlShape = true;
+  }
+  if (!rejectedUnknownUrlShape) {
+    throw new Error("iOS URL type normalization accepted an unknown shape");
+  }
+  const infoPlistPath = resolve(
+    appDir,
+    "src-tauri/gen/apple/zuuli_iOS/Info.plist",
+  );
+  const committedInfoPlist = readFileSync(infoPlistPath, "utf8");
+  if (
+    normalizeInfoPlist(committedInfoPlist, infoPlistPath) !== committedInfoPlist
+  ) {
+    throw new Error("committed iOS Info.plist is not canonical");
   }
   let rejectedUnexpectedShape = false;
   try {
@@ -327,10 +394,14 @@ const projectPath = resolve(
   appDir,
   "src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj",
 );
-const plistPaths = [
+const infoPlistPath = resolve(
+  appDir,
   "src-tauri/gen/apple/zuuli_iOS/Info.plist",
+);
+const entitlementsPath = resolve(
+  appDir,
   "src-tauri/gen/apple/zuuli_iOS/zuuli_iOS.entitlements",
-].map((path) => resolve(appDir, path));
+);
 
 const project = readFileSync(projectPath, "utf8");
 const normalizedProject = process.argv.includes("--prepare-manual-signing")
@@ -340,10 +411,14 @@ if (normalizedProject !== project) {
   writeFileSync(projectPath, normalizedProject);
 }
 
-for (const plistPath of plistPaths) {
-  const plist = readFileSync(plistPath, "utf8");
-  const normalizedPlist = normalizePlist(plist, plistPath);
-  if (normalizedPlist !== plist) {
-    writeFileSync(plistPath, normalizedPlist);
-  }
+const infoPlist = readFileSync(infoPlistPath, "utf8");
+const normalizedInfoPlist = normalizeInfoPlist(infoPlist, infoPlistPath);
+if (normalizedInfoPlist !== infoPlist) {
+  writeFileSync(infoPlistPath, normalizedInfoPlist);
+}
+
+const entitlements = readFileSync(entitlementsPath, "utf8");
+const normalizedEntitlements = normalizePlist(entitlements, entitlementsPath);
+if (normalizedEntitlements !== entitlements) {
+  writeFileSync(entitlementsPath, normalizedEntitlements);
 }

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "4").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "5").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "4"
+        CFBundleVersion: "5"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
@@ -51,12 +51,12 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleURLName</key>
+			<string>cash.free2z.zuuli</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>cash.free2z.zuuli</string>
 			</array>
-			<key>CFBundleURLName</key>
-			<string>cash.free2z.zuuli</string>
 		</dict>
 	</array>
 </dict>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -28,14 +28,14 @@
     "targets": "all",
     "icon": ["icons/icon.png"],
     "iOS": {
-      "bundleVersion": "4",
+      "bundleVersion": "5",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 4
+      "versionCode": 5
     }
   },
   "plugins": {


### PR DESCRIPTION
Closes #288

## Outcome

Fixes the post-export reproducibility failure that stopped iOS build 4 after successful signing/export. The checked-in generated plist now matches both source inputs and Tauri/Xcode output (`CFBundleURLName` before `CFBundleURLSchemes`).

Android `0.1.0+4` successfully reached Play internal, so this PR atomically advances the next store identity to `0.1.0+5` across `release.json`, Tauri, Xcode, generated plist, and Gradle.

## Guardrails

- The normalizer accepts exactly the two semantically equivalent known URL blocks and emits one canonical byte sequence.
- Missing, duplicate, differently shaped, or differently indented blocks fail closed; unrelated plist bytes are untouched.
- Self-tests prove canonical idempotence, reverse-order convergence, unknown-shape rejection, and committed-file canonicality.
- The credential-free iOS packaging job now normalizes and checks the complete porcelain status after `tauri ios build`, catching tracked and untracked generated drift on every PR.

## Local verification

- `npm run release:verify` → `0.1.0+5`
- normalizer self-test and idempotent unflagged run
- `plutil -lint` for generated/source plist and entitlements
- packaging workflow YAML parse
- Vitest 19/19
- TypeScript typecheck
- Vite production build
- `git diff --check`
- exact-head Claude adversarial review: **APPROVE** at `1f1d74627672d19c526a1f77b66c4acbbc10f701`

## Merge condition

Do not merge until the exact-head wallet gate and every four-platform packaging-smoke job are green. Merging this build-5 identity intentionally triggers the protected mobile release.