### PR TITLE
fix(zuuli): keep iOS Rust archive out of app bundle

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -230,6 +230,17 @@ jobs:
         # A device archive has the same Rust target as TestFlight. It remains
         # unsigned and this job receives no Apple credentials.
         run: ./node_modules/.bin/tauri ios build --ci --no-sign --target aarch64 -- --locked
+      - name: Verify unsigned iOS bundle structure
+        run: |
+          apps=()
+          while IFS= read -r -d '' app; do apps+=("$app"); done < <(
+            find src-tauri/gen/apple/build -type d -name 'ZUULI.app' -print0
+          )
+          [[ ${#apps[@]} -eq 1 ]] || {
+            echo "expected exactly one unsigned iOS app, found ${#apps[@]}" >&2
+            exit 1
+          }
+          scripts/verify-ios-ipa.sh --verify-app-structure "${apps[0]}"
       - name: Verify post-build iOS project reproducibility
         run: |
           node scripts/normalize-generated-ios-project.mjs

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -1,8 +1,8 @@
 # Releasing ZUULI
 
 ZUULI ships from one reviewed commit under one immutable identity. The current
-identity is `0.1.0+5`: marketing version `0.1.0`, Apple build `5`, Android
-`versionCode` `5`, and package/bundle identifier `cash.free2z.zuuli`.
+identity is `0.1.0+6`: marketing version `0.1.0`, Apple build `6`, Android
+`versionCode` `6`, and package/bundle identifier `cash.free2z.zuuli`.
 
 `release.json` is the source of truth. `npm run release:verify` fails if the npm,
 Cargo, Tauri, generated Xcode, or generated Gradle representation disagrees.
@@ -198,7 +198,7 @@ must both be confirmed:
 
 ```bash
 export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
-export ZUULI_CONFIRM_UPLOAD=0.1.0+5
+export ZUULI_CONFIRM_UPLOAD=0.1.0+6
 scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
 ```
@@ -268,8 +268,12 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    path. Build `0.1.0+4` proved the verified signing-keychain workaround by
    signing and exporting the iOS IPA, and it reached Play internal. Its iOS job
    stopped before verification/upload on a generated-plist ordering diff.
-   Build `0.1.0+5` is the canonical-plist retry; it retains fail-closed IPA
-   verification and the corrected shared Rust caches.
+   Build `0.1.0+5` reached Play internal. Its iOS IPA signed, exported, and
+   passed the local profile/signature verification, but Apple validation
+   rejected the standalone `ZUULI.app/libapp.a` with error 90171 before upload.
+   Build `0.1.0+6` keeps the Rust archive as a link-only input, removes it from
+   Copy Bundle Resources, and makes both the generated-project contract and IPA
+   verifier reject a future static-archive regression before Apple validation.
 4. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
    attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
    protected release** with the exact full SHA, identity, missing target, and

--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -3,7 +3,7 @@
   "schemaVersion": 1,
   "applicationId": "cash.free2z.zuuli",
   "version": "0.1.0",
-  "build": 5,
+  "build": 6,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -188,6 +188,31 @@ if (!pbxproj.includes('CODE_SIGN_IDENTITY = "Apple Distribution";'))
   );
 if (!pbxproj.includes('PROVISIONING_PROFILE_SPECIFIER = "ZUULI App Store CI";'))
   failures.push("generated Xcode release provisioning profile is not pinned");
+expect(
+  "XcodeGen link-only Rust archive dependency count",
+  occurrenceCount(project, "- framework: libapp.a\n        embed: false"),
+  1,
+);
+expect(
+  "XcodeGen Rust archive source-tree count",
+  occurrenceCount(project, "\n      - path: Externals\n"),
+  0,
+);
+expect(
+  "generated Xcode Rust archive framework-phase count",
+  occurrenceCount(pbxproj, "libapp.a in Frameworks"),
+  2,
+);
+expect(
+  "generated Xcode Rust archive resource-phase count",
+  occurrenceCount(pbxproj, "libapp.a in Resources"),
+  0,
+);
+expect(
+  "generated Xcode Rust archive file-reference count",
+  occurrenceCount(pbxproj, "/* libapp.a */ = {isa = PBXFileReference;"),
+  1,
+);
 for (const [label, contents] of [
   ["generated Xcode project", pbxproj],
   ["generated iOS plist", plist],

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -77,6 +77,7 @@ const androidToolchain = read("scripts/android-toolchain-env.sh");
 const gemLock = read("Gemfile.lock");
 const mobileRelease = read("scripts/mobile-release.sh");
 const releaseWorkflow = read("../../.github/workflows/zuuli-release.yml");
+const packagingWorkflow = read("../../.github/workflows/zuuli-packaging.yml");
 
 expect("package.json version", packageJson.version, release.version);
 expect("package-lock.json version", packageLock.version, release.version);
@@ -190,12 +191,17 @@ if (!pbxproj.includes('PROVISIONING_PROFILE_SPECIFIER = "ZUULI App Store CI";'))
   failures.push("generated Xcode release provisioning profile is not pinned");
 expect(
   "XcodeGen link-only Rust archive dependency count",
-  occurrenceCount(project, "- framework: libapp.a\n        embed: false"),
+  (
+    project.match(
+      /^[ \t]*-[ \t]+framework:[ \t]+libapp\.a[ \t]*\n[ \t]+embed:[ \t]+false[ \t]*$/gm,
+    ) ?? []
+  ).length,
   1,
 );
 expect(
   "XcodeGen Rust archive source-tree count",
-  occurrenceCount(project, "\n      - path: Externals\n"),
+  (project.match(/^[ \t]*-[ \t]+path:[ \t]+Externals[ \t]*$/gm) ?? [])
+    .length,
   0,
 );
 expect(
@@ -207,6 +213,11 @@ expect(
   "generated Xcode Rust archive resource-phase count",
   occurrenceCount(pbxproj, "libapp.a in Resources"),
   0,
+);
+expect(
+  "generated Xcode Rust archive total build-phase label count",
+  occurrenceCount(pbxproj, "libapp.a in "),
+  2,
 );
 expect(
   "generated Xcode Rust archive file-reference count",
@@ -511,6 +522,26 @@ if (
 ) {
   failures.push(
     "iOS release must prepare signing keys, build, normalize, inspect the IPA, then validate and upload with Apple",
+  );
+}
+const unsignedIosBuild = packagingWorkflow.indexOf(
+  "./node_modules/.bin/tauri ios build --ci --no-sign",
+);
+const unsignedIosInspection = packagingWorkflow.indexOf(
+  'scripts/verify-ios-ipa.sh --verify-app-structure "${apps[0]}"',
+);
+const unsignedIosCollection = packagingWorkflow.indexOf(
+  "- name: Collect unsigned package",
+);
+if (
+  unsignedIosBuild === -1 ||
+  unsignedIosInspection === -1 ||
+  unsignedIosCollection === -1 ||
+  unsignedIosBuild > unsignedIosInspection ||
+  unsignedIosInspection > unsignedIosCollection
+) {
+  failures.push(
+    "unsigned iOS packaging must build, inspect the app structure, then collect the artifact",
   );
 }
 for (const target of [

--- a/wallet/zuuli/scripts/verify-ios-ipa.sh
+++ b/wallet/zuuli/scripts/verify-ios-ipa.sh
@@ -28,13 +28,19 @@ is_allowed_bundle_binary() {
 }
 
 verify_app_structure() {
-  local app=$1 bundle_file relative file_kind main_kind
+  local app=$1 bundle_entry bundle_file relative file_kind main_kind
   [[ -d "$app" && ! -L "$app" ]] || fail "app bundle is not a regular directory"
   [[ -f "$app/ZUULI" && ! -L "$app/ZUULI" ]] ||
     fail "app bundle main executable is not a regular file"
   main_kind=$(/usr/bin/file -b "$app/ZUULI") ||
     fail "unable to inspect app bundle main executable"
   [[ "$main_kind" == *Mach-O* ]] || fail "app bundle main executable is not Mach-O"
+  while IFS= read -r -d '' bundle_entry; do
+    relative=${bundle_entry#"$app/"}
+    if [[ -L "$bundle_entry" || (! -d "$bundle_entry" && ! -f "$bundle_entry") ]]; then
+      fail "app bundle contains a non-regular entry: $relative"
+    fi
+  done < <(find "$app" -mindepth 1 -print0)
   while IFS= read -r -d '' bundle_file; do
     relative=${bundle_file#"$app/"}
     if [[ "$relative" == *.a ]]; then
@@ -110,6 +116,13 @@ self_test() (
   rm "$fixture_app/assets/archive-data"
   "$script_path" --verify-app-structure "$fixture_app" ||
     fail "clean app-structure self-test unexpectedly failed"
+
+  ln -s ZUULI "$fixture_app/linked-binary"
+  if output=$("$script_path" --verify-app-structure "$fixture_app" 2>&1); then
+    fail "symlink self-test unexpectedly passed"
+  fi
+  grep -Fq 'app bundle contains a non-regular entry: linked-binary' <<<"$output" ||
+    fail "symlink self-test failed for the wrong reason: $output"
 )
 
 darwin_self_test() (

--- a/wallet/zuuli/scripts/verify-ios-ipa.sh
+++ b/wallet/zuuli/scripts/verify-ios-ipa.sh
@@ -29,6 +29,26 @@ self_test() (
   fi
   grep -Fq 'archive does not contain exactly one embedded.mobileprovision' <<<"$output" ||
     fail "missing-profile self-test failed for the wrong reason: $output"
+
+  printf 'fixture\n' > "$fixture_dir/root/Payload/ZUULI.app/embedded.mobileprovision"
+  printf 'fixture\n' > "$fixture_dir/root/Payload/ZUULI.app/libapp.a"
+  fixture_ipa="$fixture_dir/static-archive.ipa"
+  (cd "$fixture_dir/root" && zip -qry "$fixture_ipa" Payload)
+  if output=$("$script_path" "$fixture_ipa" "$fixture_dir/expected.mobileprovision" F9AV5HKF6N cash.free2z.zuuli 2>&1); then
+    fail "static-archive self-test unexpectedly passed"
+  fi
+  grep -Fq 'app bundle contains a forbidden static archive' <<<"$output" ||
+    fail "static-archive self-test failed for the wrong reason: $output"
+
+  rm "$fixture_dir/root/Payload/ZUULI.app/libapp.a"
+  printf '\317\372\355\376\014\000\000\001' > "$fixture_dir/root/Payload/ZUULI.app/Sidecar"
+  fixture_ipa="$fixture_dir/root-binary.ipa"
+  (cd "$fixture_dir/root" && zip -qry "$fixture_ipa" Payload)
+  if output=$("$script_path" "$fixture_ipa" "$fixture_dir/expected.mobileprovision" F9AV5HKF6N cash.free2z.zuuli 2>&1); then
+    fail "root-binary self-test unexpectedly passed"
+  fi
+  grep -Fq 'app bundle contains a forbidden root binary' <<<"$output" ||
+    fail "root-binary self-test failed for the wrong reason: $output"
 )
 
 darwin_self_test() (
@@ -95,6 +115,20 @@ done < <(
 [[ ${#app_roots[@]} -eq 1 ]] ||
   fail "archive must contain exactly one top-level Payload app, found ${#app_roots[@]}"
 app_root=${app_roots[0]}
+app_prefix="$app_root/"
+forbidden_static_archive=$(awk -v prefix="$app_prefix" '
+  index($0, prefix) == 1 && $0 ~ /\.a$/ { print; exit }
+' <<<"$archive_listing")
+[[ -z "$forbidden_static_archive" ]] ||
+  fail "app bundle contains a forbidden static archive: $forbidden_static_archive"
+forbidden_root_library=$(awk -v prefix="$app_prefix" '
+  index($0, prefix) == 1 {
+    relative = substr($0, length(prefix) + 1)
+    if (relative !~ /\// && relative ~ /\.(dylib|so)$/) { print; exit }
+  }
+' <<<"$archive_listing")
+[[ -z "$forbidden_root_library" ]] ||
+  fail "app bundle contains a forbidden root binary: $forbidden_root_library"
 embedded_archive_path="$app_root/embedded.mobileprovision"
 embedded_count=$(grep -Fxc "$embedded_archive_path" <<<"$archive_listing" || true)
 [[ "$embedded_count" -eq 1 ]] ||
@@ -108,6 +142,13 @@ embedded_profile="$app/embedded.mobileprovision"
 [[ -d "$app" && ! -L "$app" ]] || fail "app bundle is not a regular directory"
 [[ -f "$embedded_profile" && ! -L "$embedded_profile" ]] ||
   fail "embedded provisioning profile is not a regular file"
+while IFS= read -r -d '' root_file; do
+  [[ "$(basename -- "$root_file")" == ZUULI ]] && continue
+  file_kind=$(/usr/bin/file -b "$root_file") || fail "unable to inspect app root file"
+  if [[ "$file_kind" == *Mach-O* || "$file_kind" == *"ar archive"* ]]; then
+    fail "app bundle contains a forbidden root binary: $(basename -- "$root_file")"
+  fi
+done < <(find "$app" -maxdepth 1 -type f -print0)
 cmp -s "$expected_profile" "$embedded_profile" ||
   fail "embedded provisioning profile differs from the protected input"
 

--- a/wallet/zuuli/scripts/verify-ios-ipa.sh
+++ b/wallet/zuuli/scripts/verify-ios-ipa.sh
@@ -15,12 +15,49 @@ cleanup_directory() {
   find "$directory" -depth -delete 2>/dev/null || true
 }
 
+is_allowed_bundle_binary() {
+  local relative=$1
+  case "$relative" in
+    ZUULI | Frameworks/*.framework/* | Frameworks/*.dylib | Frameworks/*.so | \
+      PlugIns/*.appex/* | Extensions/*.appex/* | Watch/*.app/* | AppClips/*.app/* | \
+      XPCServices/*.xpc/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+verify_app_structure() {
+  local app=$1 bundle_file relative file_kind main_kind
+  [[ -d "$app" && ! -L "$app" ]] || fail "app bundle is not a regular directory"
+  [[ -f "$app/ZUULI" && ! -L "$app/ZUULI" ]] ||
+    fail "app bundle main executable is not a regular file"
+  main_kind=$(/usr/bin/file -b "$app/ZUULI") ||
+    fail "unable to inspect app bundle main executable"
+  [[ "$main_kind" == *Mach-O* ]] || fail "app bundle main executable is not Mach-O"
+  while IFS= read -r -d '' bundle_file; do
+    relative=${bundle_file#"$app/"}
+    if [[ "$relative" == *.a ]]; then
+      fail "app bundle contains a forbidden static archive: $relative"
+    fi
+    file_kind=$(/usr/bin/file -b "$bundle_file") ||
+      fail "unable to inspect app bundle file: $relative"
+    if [[ "$file_kind" == *"ar archive"* ]]; then
+      fail "app bundle contains a forbidden static archive binary: $relative"
+    fi
+    if [[ "$file_kind" == *Mach-O* ]] && ! is_allowed_bundle_binary "$relative"; then
+      fail "app bundle contains a forbidden standalone binary: $relative"
+    fi
+  done < <(find "$app" -type f -print0)
+}
+
 self_test() (
-  local fixture_dir fixture_ipa output
+  local fixture_app fixture_dir fixture_ipa output
   fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-ipa-self-test.XXXXXX")
   trap 'cleanup_directory "$fixture_dir"' EXIT
-  mkdir -p "$fixture_dir/root/Payload/ZUULI.app"
-  printf 'fixture\n' > "$fixture_dir/root/Payload/ZUULI.app/ZUULI"
+  fixture_app="$fixture_dir/root/Payload/ZUULI.app"
+  mkdir -p "$fixture_app"
+  printf '\317\372\355\376\014\000\000\001' > "$fixture_app/ZUULI"
   printf 'fixture\n' > "$fixture_dir/expected.mobileprovision"
   fixture_ipa="$fixture_dir/missing-profile.ipa"
   (cd "$fixture_dir/root" && zip -qry "$fixture_ipa" Payload)
@@ -30,8 +67,8 @@ self_test() (
   grep -Fq 'archive does not contain exactly one embedded.mobileprovision' <<<"$output" ||
     fail "missing-profile self-test failed for the wrong reason: $output"
 
-  printf 'fixture\n' > "$fixture_dir/root/Payload/ZUULI.app/embedded.mobileprovision"
-  printf 'fixture\n' > "$fixture_dir/root/Payload/ZUULI.app/libapp.a"
+  printf 'fixture\n' > "$fixture_app/embedded.mobileprovision"
+  printf 'fixture\n' > "$fixture_app/libapp.a"
   fixture_ipa="$fixture_dir/static-archive.ipa"
   (cd "$fixture_dir/root" && zip -qry "$fixture_ipa" Payload)
   if output=$("$script_path" "$fixture_ipa" "$fixture_dir/expected.mobileprovision" F9AV5HKF6N cash.free2z.zuuli 2>&1); then
@@ -40,15 +77,39 @@ self_test() (
   grep -Fq 'app bundle contains a forbidden static archive' <<<"$output" ||
     fail "static-archive self-test failed for the wrong reason: $output"
 
-  rm "$fixture_dir/root/Payload/ZUULI.app/libapp.a"
-  printf '\317\372\355\376\014\000\000\001' > "$fixture_dir/root/Payload/ZUULI.app/Sidecar"
+  rm "$fixture_app/libapp.a"
+  printf '\317\372\355\376\014\000\000\001' > "$fixture_app/Sidecar"
   fixture_ipa="$fixture_dir/root-binary.ipa"
   (cd "$fixture_dir/root" && zip -qry "$fixture_ipa" Payload)
   if output=$("$script_path" "$fixture_ipa" "$fixture_dir/expected.mobileprovision" F9AV5HKF6N cash.free2z.zuuli 2>&1); then
     fail "root-binary self-test unexpectedly passed"
   fi
-  grep -Fq 'app bundle contains a forbidden root binary' <<<"$output" ||
+  grep -Fq 'app bundle contains a forbidden standalone binary: Sidecar' <<<"$output" ||
     fail "root-binary self-test failed for the wrong reason: $output"
+
+  mkdir "$fixture_app/assets"
+  mv "$fixture_app/Sidecar" "$fixture_app/assets/Sidecar"
+  fixture_ipa="$fixture_dir/nested-binary.ipa"
+  (cd "$fixture_dir/root" && zip -qry "$fixture_ipa" Payload)
+  if output=$("$script_path" "$fixture_ipa" "$fixture_dir/expected.mobileprovision" F9AV5HKF6N cash.free2z.zuuli 2>&1); then
+    fail "nested-binary self-test unexpectedly passed"
+  fi
+  grep -Fq 'app bundle contains a forbidden standalone binary: assets/Sidecar' <<<"$output" ||
+    fail "nested-binary self-test failed for the wrong reason: $output"
+
+  rm "$fixture_app/assets/Sidecar"
+  printf '!<arch>\n' > "$fixture_app/assets/archive-data"
+  fixture_ipa="$fixture_dir/renamed-static-archive.ipa"
+  (cd "$fixture_dir/root" && zip -qry "$fixture_ipa" Payload)
+  if output=$("$script_path" "$fixture_ipa" "$fixture_dir/expected.mobileprovision" F9AV5HKF6N cash.free2z.zuuli 2>&1); then
+    fail "renamed-static-archive self-test unexpectedly passed"
+  fi
+  grep -Fq 'app bundle contains a forbidden static archive binary: assets/archive-data' <<<"$output" ||
+    fail "renamed-static-archive self-test failed for the wrong reason: $output"
+
+  rm "$fixture_app/assets/archive-data"
+  "$script_path" --verify-app-structure "$fixture_app" ||
+    fail "clean app-structure self-test unexpectedly failed"
 )
 
 darwin_self_test() (
@@ -80,6 +141,12 @@ fi
 if [[ "${1:-}" == --self-test-darwin ]]; then
   [[ $# -eq 1 ]] || fail "--self-test-darwin takes no additional arguments"
   darwin_self_test
+  exit 0
+fi
+
+if [[ "${1:-}" == --verify-app-structure ]]; then
+  [[ $# -eq 2 ]] || fail "--verify-app-structure requires exactly one app path"
+  verify_app_structure "$2"
   exit 0
 fi
 
@@ -115,20 +182,6 @@ done < <(
 [[ ${#app_roots[@]} -eq 1 ]] ||
   fail "archive must contain exactly one top-level Payload app, found ${#app_roots[@]}"
 app_root=${app_roots[0]}
-app_prefix="$app_root/"
-forbidden_static_archive=$(awk -v prefix="$app_prefix" '
-  index($0, prefix) == 1 && $0 ~ /\.a$/ { print; exit }
-' <<<"$archive_listing")
-[[ -z "$forbidden_static_archive" ]] ||
-  fail "app bundle contains a forbidden static archive: $forbidden_static_archive"
-forbidden_root_library=$(awk -v prefix="$app_prefix" '
-  index($0, prefix) == 1 {
-    relative = substr($0, length(prefix) + 1)
-    if (relative !~ /\// && relative ~ /\.(dylib|so)$/) { print; exit }
-  }
-' <<<"$archive_listing")
-[[ -z "$forbidden_root_library" ]] ||
-  fail "app bundle contains a forbidden root binary: $forbidden_root_library"
 embedded_archive_path="$app_root/embedded.mobileprovision"
 embedded_count=$(grep -Fxc "$embedded_archive_path" <<<"$archive_listing" || true)
 [[ "$embedded_count" -eq 1 ]] ||
@@ -139,16 +192,9 @@ trap 'cleanup_directory "$inspect_dir"' EXIT
 /usr/bin/unzip -q "$ipa" -d "$inspect_dir"
 app="$inspect_dir/$app_root"
 embedded_profile="$app/embedded.mobileprovision"
-[[ -d "$app" && ! -L "$app" ]] || fail "app bundle is not a regular directory"
+verify_app_structure "$app"
 [[ -f "$embedded_profile" && ! -L "$embedded_profile" ]] ||
   fail "embedded provisioning profile is not a regular file"
-while IFS= read -r -d '' root_file; do
-  [[ "$(basename -- "$root_file")" == ZUULI ]] && continue
-  file_kind=$(/usr/bin/file -b "$root_file") || fail "unable to inspect app root file"
-  if [[ "$file_kind" == *Mach-O* || "$file_kind" == *"ar archive"* ]]; then
-    fail "app bundle contains a forbidden root binary: $(basename -- "$root_file")"
-  fi
-done < <(find "$app" -maxdepth 1 -type f -print0)
 cmp -s "$expected_profile" "$embedded_profile" ||
   fail "embedded provisioning profile differs from the protected input"
 

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "5").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "6").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -68,7 +68,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "5"
+        CFBundleVersion: "6"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -39,7 +39,6 @@ targets:
     sources:
       - path: Sources
       - path: Assets.xcassets
-      - path: Externals
       - path: zuuli_iOS
       - path: assets
         buildPhase: resources

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		D4F951D673376126CE43FFAC /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 53135BE9E6C5277EB10DCCAB /* main.mm */; };
 		EF1033B3BCF4333F214CD239 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF50730DDEE9C016587C33C8 /* UIKit.framework */; };
 		FAC5E5B9C30B29BDDAF05E1E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 00273035D6BF322ED673A7A7 /* LaunchScreen.storyboard */; };
-		FEB4633D9B5302D8A1E7DE89 /* libapp.a in Resources */ = {isa = PBXBuildFile; fileRef = 895018E8D7EB83F50A3788B2 /* libapp.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,7 +31,6 @@
 		759DD8A882A530239EF1E304 /* zuuli_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = zuuli_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		77F42168F58D14ADCE84DD98 /* bindings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bindings.h; sourceTree = "<group>"; };
 		79A6AC0BBBECBC836243B2A2 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
-		895018E8D7EB83F50A3788B2 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
 		8E2241BC3BAC928AEA585784 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
 		9B15EF6F08F4C43D51A325CA /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		A0DC69B5F5D0C4B020198D94 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -81,14 +79,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		14892246B7815CA438A147EC /* Externals */ = {
-			isa = PBXGroup;
-			children = (
-				99EBA03AB175C293A205632C /* arm64 */,
-			);
-			path = Externals;
-			sourceTree = "<group>";
-		};
 		3C5E39E543F32DA41F2C6963 /* src */ = {
 			isa = PBXGroup;
 			children = (
@@ -98,14 +88,6 @@
 			);
 			name = src;
 			path = ../../src;
-			sourceTree = "<group>";
-		};
-		570D646A14CDC4502E15C81E /* release */ = {
-			isa = PBXGroup;
-			children = (
-				895018E8D7EB83F50A3788B2 /* libapp.a */,
-			);
-			path = release;
 			sourceTree = "<group>";
 		};
 		651D4A879A200EBC89CC2D3D /* bindings */ = {
@@ -122,14 +104,6 @@
 				D7C323E050A672F07EC2508F /* zuuli */,
 			);
 			path = Sources;
-			sourceTree = "<group>";
-		};
-		99EBA03AB175C293A205632C /* arm64 */ = {
-			isa = PBXGroup;
-			children = (
-				570D646A14CDC4502E15C81E /* release */,
-			);
-			path = arm64;
 			sourceTree = "<group>";
 		};
 		A2ADBE166F291E3DA7EA1D86 /* Frameworks */ = {
@@ -162,20 +136,12 @@
 				6BAF0CAD6D6AB94CAB16251E /* assets */,
 				A0DC69B5F5D0C4B020198D94 /* Assets.xcassets */,
 				00273035D6BF322ED673A7A7 /* LaunchScreen.storyboard */,
-				14892246B7815CA438A147EC /* Externals */,
 				797F2FB502FD39B9A9FDD95D /* Sources */,
 				3C5E39E543F32DA41F2C6963 /* src */,
 				00DEF184AA79D7159DC00C8B /* zuuli_iOS */,
 				A2ADBE166F291E3DA7EA1D86 /* Frameworks */,
 				0EDEDC95DA795B7BF5E0D308 /* Products */,
 			);
-			sourceTree = "<group>";
-		};
-		"TEMP_3DB7166F-B106-41A0-A2C4-27870FF810F3" /* x86_64 */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = x86_64;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -242,7 +208,6 @@
 				87F0E2CFE7042521EF298841 /* Assets.xcassets in Resources */,
 				FAC5E5B9C30B29BDDAF05E1E /* LaunchScreen.storyboard in Resources */,
 				61596CE92793FA64110C7451 /* assets in Resources */,
-				FEB4633D9B5302D8A1E7DE89 /* libapp.a in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -28,14 +28,14 @@
     "targets": "all",
     "icon": ["icons/icon.png"],
     "iOS": {
-      "bundleVersion": "5",
+      "bundleVersion": "6",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 5
+      "versionCode": 6
     }
   },
   "plugins": {


### PR DESCRIPTION
Closes #290.

## Outcome

- removes `Externals` from XcodeGen target sources so `libapp.a` remains a link-only dependency and is no longer copied into `ZUULI.app`
- regenerates the checked-in Xcode project while retaining the Rust prebuild outputs and library search paths
- advances the coordinated store identity to `0.1.0+6` because Android build 5 reached Play internal before iOS build 5 stopped at Apple validation 90171
- strengthens the release contract against resource/copy-phase and XcodeGen source-tree regressions
- shares one fail-closed app-structure checker between signed IPA verification and the PR-built unsigned device app
- rejects named/renamed static archives, standalone root/nested Mach-O files, symlinks, and special entries while allowing valid embedded framework/extension/watch/app-clip/XPC binary locations

## Local verification

- `npm ci`
- `npm run release:verify`
- `npm test` (19/19)
- `npm run typecheck`
- `npm run build`
- `node scripts/normalize-generated-ios-project.mjs --self-test`
- `node scripts/verify-ci-cache-policy.mjs`
- `scripts/verify-ios-ipa.sh --self-test`
- `scripts/verify-ios-ipa.sh --self-test-darwin`
- XcodeGen 2.45.4 regeneration is byte-stable
- exact clean `npm run tauri -- ios build --ci --no-sign --archive-only -- --locked`
- exact build-6 archive: correct bundle ID/build, arm64 Mach-O main executable, zero `.a` files anywhere, zero forbidden sidecar binaries, generated files normalized back to a clean tree
- macOS Bash 3 workflow snippet and real unsigned app structural check
- independent exact-head Claude adversarial review: `VERDICT: APPROVED` with no findings after macOS and Ubuntu probes
