### PR TITLE
ci(zuuli): automate additive Play tester groups

### DIFF
--- a/.github/workflows/zuuli-play-testers.yml
+++ b/.github/workflows/zuuli-play-testers.yml
@@ -1,0 +1,55 @@
+name: ZUULI / Play tester groups
+
+on:
+  workflow_dispatch:
+    inputs:
+      google_group:
+        description: Private Google Group to add to ZUULI internal testing
+        required: true
+        default: zuuli-internal-testers-free2z@googlegroups.com
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize edits with signed releases; Play permits only one active edit.
+  group: zuuli-mobile-store
+  cancel-in-progress: false
+
+jobs:
+  configure:
+    name: Add and verify internal tester group
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: zuuli-app-stores
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+      - name: Verify Play tester transaction offline
+        run: node --test wallet/zuuli/scripts/play-tester-groups.node-test.mjs
+      - name: Add group and verify committed Play state
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
+          ZUULI_PLAY_TESTER_GROUP: ${{ inputs.google_group }}
+        run: |
+          set -euo pipefail
+          : "${PLAY_SERVICE_ACCOUNT_JSON_BASE64:?PLAY_SERVICE_ACCOUNT_JSON_BASE64 is not configured}"
+          secret_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-play-testers.XXXXXX")
+          chmod 700 "$secret_dir"
+          cleanup() {
+            find "$secret_dir" -type f -exec rm -f -- {} +
+            rmdir "$secret_dir"
+          }
+          trap cleanup EXIT
+          printf '%s' "$PLAY_SERVICE_ACCOUNT_JSON_BASE64" |
+            base64 --decode > "$secret_dir/play-service-account.json"
+          chmod 600 "$secret_dir/play-service-account.json"
+          test -s "$secret_dir/play-service-account.json"
+          PLAY_SERVICE_ACCOUNT_JSON="$secret_dir/play-service-account.json" \
+            node wallet/zuuli/scripts/play-tester-groups.mjs

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -63,7 +63,7 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*)
                 zuuli=true
                 ;;
             esac
@@ -93,6 +93,9 @@ jobs:
 
       - name: Verify release cache security policy
         run: node scripts/verify-ci-cache-policy.mjs
+
+      - name: Test protected Play tester transaction
+        run: npm run test:play-testers
 
       # The current lockfile has moderate advisories but no high/critical ones.
       # Dependency upgrades belong in focused PRs; this gate prevents severity

--- a/wallet/zuuli/CLAUDE.md
+++ b/wallet/zuuli/CLAUDE.md
@@ -29,6 +29,7 @@ npm run tauri -- android dev
 npm run tauri -- android build # Android APK/AAB
 npm run release:verify         # cross-platform version/build/identity contract
 node scripts/verify-ci-cache-policy.mjs # release-cache trust boundaries
+npm run test:play-testers  # offline protected Play tester transaction tests
 ```
 
 The web dev server runs on **1423** so it never collides with zuuallet (1421).

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -90,6 +90,19 @@ upload to the internal track, and `0.1.0+2` confirmed the repeatable protected
 path. Subsequent protected releases use the same dedicated principal and upload
 key. Do not weaken the account check or upload a debug key.
 
+Internal tester eligibility is managed additively with the protected
+`ZUULI / Play tester groups` workflow. Its default private group is
+`zuuli-internal-testers-free2z@googlegroups.com`. The workflow shares the
+mobile-store concurrency lane, preserves every existing Google Group, commits
+the requested group through the Android Publisher API, and verifies the result
+through a fresh edit. It accepts only lowercase `@googlegroups.com` addresses;
+Play's API does not support Console email lists. Run the offline transaction
+tests before changing this path:
+
+```bash
+npm run test:play-testers
+```
+
 Primary references:
 
 - Apple: https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/

--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -9,6 +9,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:play-testers": "node --test scripts/play-tester-groups.node-test.mjs",
     "typecheck": "tsc --noEmit",
     "release:verify": "node scripts/release-identity.mjs",
     "release:bump": "node scripts/release-bump.mjs",

--- a/wallet/zuuli/scripts/play-tester-groups.mjs
+++ b/wallet/zuuli/scripts/play-tester-groups.mjs
@@ -257,13 +257,22 @@ export async function configurePlayTesterGroup({
   }
 }
 
+export function summarizeConfigurationResult(result, requestedGoogleGroup) {
+  return {
+    packageName: result.packageName,
+    track: result.track,
+    requestedGoogleGroup,
+    googleGroupCount: result.googleGroups.length,
+  };
+}
+
 export async function main(env = process.env) {
   const keyPath = env.PLAY_SERVICE_ACCOUNT_JSON;
   if (!keyPath) throw new Error("PLAY_SERVICE_ACCOUNT_JSON is required");
   const googleGroup = validateGoogleGroup(env.ZUULI_PLAY_TESTER_GROUP);
   const credentials = parseServiceAccountDocument(await readFile(keyPath, "utf8"));
   const result = await configurePlayTesterGroup({ credentials, googleGroup });
-  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.stdout.write(`${JSON.stringify(summarizeConfigurationResult(result, googleGroup))}\n`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {

--- a/wallet/zuuli/scripts/play-tester-groups.mjs
+++ b/wallet/zuuli/scripts/play-tester-groups.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+
+import { createSign } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const PACKAGE_NAME = "cash.free2z.zuuli";
+export const TRACK = "internal";
+export const EXPECTED_SERVICE_ACCOUNT =
+  "corpan-play-verifier@corpora1.iam.gserviceaccount.com";
+export const ANDROID_PUBLISHER_SCOPE =
+  "https://www.googleapis.com/auth/androidpublisher";
+export const TOKEN_URL = "https://oauth2.googleapis.com/token";
+export const API_ROOT =
+  "https://androidpublisher.googleapis.com/androidpublisher/v3";
+
+const GOOGLE_GROUP_PATTERN =
+  /^[a-z0-9](?:[a-z0-9._+-]{0,62}[a-z0-9])?@googlegroups\.com$/;
+
+function base64url(value) {
+  return Buffer.from(value).toString("base64url");
+}
+
+export function validateGoogleGroup(value) {
+  if (typeof value !== "string" || !GOOGLE_GROUP_PATTERN.test(value)) {
+    throw new Error(
+      "google_group must be a lowercase @googlegroups.com address with a 1-64 character local part",
+    );
+  }
+  return value;
+}
+
+export function mergeGoogleGroups(existing, requested) {
+  validateGoogleGroup(requested);
+  if (existing !== undefined && !Array.isArray(existing)) {
+    throw new Error("Play testers response googleGroups must be an array");
+  }
+  const groups = existing ?? [];
+  for (const group of groups) {
+    if (typeof group !== "string" || group.length < 1) {
+      throw new Error("Play testers response contains an invalid Google Group address");
+    }
+  }
+  return [...new Set([...groups, requested])].sort();
+}
+
+export function createServiceAccountAssertion(credentials, nowSeconds) {
+  if (
+    credentials?.type !== "service_account" ||
+    credentials?.project_id !== "corpora1" ||
+    credentials?.client_email !== EXPECTED_SERVICE_ACCOUNT ||
+    typeof credentials?.private_key_id !== "string" ||
+    credentials.private_key_id.length < 1
+  ) {
+    throw new Error("service-account document is not the dedicated ZUULI Play principal");
+  }
+  if (
+    typeof credentials.private_key !== "string" ||
+    !credentials.private_key.startsWith("-----BEGIN PRIVATE KEY-----")
+  ) {
+    throw new Error("service-account document has no private key");
+  }
+  if (!Number.isInteger(nowSeconds) || nowSeconds < 1) {
+    throw new Error("JWT clock must be a positive integer");
+  }
+
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const claims = base64url(
+    JSON.stringify({
+      iss: credentials.client_email,
+      scope: ANDROID_PUBLISHER_SCOPE,
+      aud: TOKEN_URL,
+      iat: nowSeconds,
+      exp: nowSeconds + 3600,
+    }),
+  );
+  const signingInput = `${header}.${claims}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  return `${signingInput}.${signer.sign(credentials.private_key, "base64url")}`;
+}
+
+export function parseServiceAccountDocument(contents) {
+  try {
+    return JSON.parse(contents);
+  } catch {
+    // GitHub masks the base64 secret, not arbitrary decoded fragments. Never
+    // forward V8's parse error because it can quote part of the private key.
+    throw new Error("service-account document is not valid JSON");
+  }
+}
+
+function safeApiErrorBody(body) {
+  if (!body || typeof body !== "object") return "no structured error body";
+  const message = body.error?.message ?? body.error_description ?? body.error;
+  return typeof message === "string" ? message.slice(0, 500) : "no error message";
+}
+
+async function parseJsonResponse(response, operation, allowEmpty = false) {
+  const text = await response.text();
+  if (!response.ok) {
+    let body;
+    try {
+      body = text ? JSON.parse(text) : undefined;
+    } catch {
+      body = undefined;
+    }
+    throw new Error(
+      `${operation} failed with HTTP ${response.status}: ${safeApiErrorBody(body)}`,
+    );
+  }
+  if (!text) {
+    if (allowEmpty) return undefined;
+    throw new Error(`${operation} returned an empty response`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${operation} returned invalid JSON`);
+  }
+}
+
+export function editUrl(editId, suffix = "") {
+  const packagePart = encodeURIComponent(PACKAGE_NAME);
+  const editPart = editId === undefined ? "" : `/${encodeURIComponent(editId)}`;
+  return `${API_ROOT}/applications/${packagePart}/edits${editPart}${suffix}`;
+}
+
+export async function getAccessToken(credentials, fetchImpl = globalThis.fetch, nowSeconds) {
+  const issuedAt = nowSeconds ?? Math.floor(Date.now() / 1000);
+  const assertion = createServiceAccountAssertion(credentials, issuedAt);
+  const body = new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    assertion,
+  });
+  const response = await fetchImpl(TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  const payload = await parseJsonResponse(response, "OAuth token exchange");
+  if (typeof payload.access_token !== "string" || payload.access_token.length < 1) {
+    throw new Error("OAuth token exchange returned no access token");
+  }
+  return payload.access_token;
+}
+
+function createApiClient(accessToken, fetchImpl) {
+  async function request(method, url, body, allowEmpty = false) {
+    const response = await fetchImpl(url, {
+      method,
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    return parseJsonResponse(response, `${method} ${new URL(url).pathname}`, allowEmpty);
+  }
+
+  return {
+    async insertEdit() {
+      const result = await request("POST", editUrl(), {});
+      if (typeof result.id !== "string" || result.id.length < 1) {
+        throw new Error("Play edit insertion returned no edit ID");
+      }
+      return result.id;
+    },
+    getTesters(editId) {
+      return request(
+        "GET",
+        editUrl(editId, `/testers/${encodeURIComponent(TRACK)}`),
+      );
+    },
+    updateTesters(editId, googleGroups) {
+      return request(
+        "PUT",
+        editUrl(editId, `/testers/${encodeURIComponent(TRACK)}`),
+        { googleGroups },
+      );
+    },
+    commitEdit(editId) {
+      // Tester eligibility does not submit unrelated draft changes for review.
+      // A conflicting live edit fails instead of broadening this transaction.
+      return request("POST", editUrl(editId, ":commit"));
+    },
+    deleteEdit(editId) {
+      return request("DELETE", editUrl(editId), undefined, true);
+    },
+  };
+}
+
+async function deleteUncommittedEdit(api, editId, primaryError) {
+  if (!editId) return;
+  try {
+    await api.deleteEdit(editId);
+  } catch (cleanupError) {
+    if (!primaryError) throw cleanupError;
+    primaryError.message += `; cleanup also failed: ${cleanupError.message}`;
+  }
+}
+
+export async function configurePlayTesterGroup({
+  credentials,
+  googleGroup,
+  fetchImpl = globalThis.fetch,
+  nowSeconds,
+}) {
+  const requested = validateGoogleGroup(googleGroup);
+  const accessToken = await getAccessToken(credentials, fetchImpl, nowSeconds);
+  const api = createApiClient(accessToken, fetchImpl);
+
+  let editId;
+  let expectedGroups;
+  let primaryError;
+  try {
+    editId = await api.insertEdit();
+    const current = await api.getTesters(editId);
+    expectedGroups = mergeGoogleGroups(current.googleGroups, requested);
+    const updated = await api.updateTesters(editId, expectedGroups);
+    if (
+      !updated.googleGroups?.includes(requested) ||
+      JSON.stringify(mergeGoogleGroups(updated.googleGroups, requested)) !==
+        JSON.stringify(expectedGroups)
+    ) {
+      throw new Error("Play tester update response did not preserve the requested group set");
+    }
+    await api.commitEdit(editId);
+    editId = undefined;
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    await deleteUncommittedEdit(api, editId, primaryError);
+  }
+
+  let verificationEditId;
+  let verificationError;
+  try {
+    verificationEditId = await api.insertEdit();
+    const verified = await api.getTesters(verificationEditId);
+    if (!verified.googleGroups?.includes(requested)) {
+      throw new Error("fresh Play edit does not contain the requested tester group");
+    }
+    const groups = mergeGoogleGroups(verified.googleGroups, requested);
+    if (JSON.stringify(groups) !== JSON.stringify(expectedGroups)) {
+      throw new Error("fresh Play edit does not contain the exact committed tester group set");
+    }
+    return { packageName: PACKAGE_NAME, track: TRACK, googleGroups: groups };
+  } catch (error) {
+    verificationError = error;
+    throw error;
+  } finally {
+    await deleteUncommittedEdit(api, verificationEditId, verificationError);
+  }
+}
+
+export async function main(env = process.env) {
+  const keyPath = env.PLAY_SERVICE_ACCOUNT_JSON;
+  if (!keyPath) throw new Error("PLAY_SERVICE_ACCOUNT_JSON is required");
+  const googleGroup = validateGoogleGroup(env.ZUULI_PLAY_TESTER_GROUP);
+  const credentials = parseServiceAccountDocument(await readFile(keyPath, "utf8"));
+  const result = await configurePlayTesterGroup({ credentials, googleGroup });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    process.stderr.write(`Play tester configuration failed: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/wallet/zuuli/scripts/play-tester-groups.node-test.mjs
+++ b/wallet/zuuli/scripts/play-tester-groups.node-test.mjs
@@ -13,6 +13,7 @@ import {
   editUrl,
   mergeGoogleGroups,
   parseServiceAccountDocument,
+  summarizeConfigurationResult,
   validateGoogleGroup,
 } from "./play-tester-groups.mjs";
 
@@ -126,6 +127,24 @@ test("constructs fixed package, edit, tester, and commit URLs", () => {
     `https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}/edits/edit%201/testers/internal`,
   );
   assert.equal(editUrl("edit-1", ":commit").endsWith("/edits/edit-1:commit"), true);
+});
+
+test("summarizes success without disclosing other tester groups", () => {
+  const summary = summarizeConfigurationResult(
+    {
+      packageName: PACKAGE_NAME,
+      track: TRACK,
+      googleGroups: ["private-existing@corpora.example", GROUP],
+    },
+    GROUP,
+  );
+  assert.deepEqual(summary, {
+    packageName: PACKAGE_NAME,
+    track: TRACK,
+    requestedGoogleGroup: GROUP,
+    googleGroupCount: 2,
+  });
+  assert.equal(JSON.stringify(summary).includes("private-existing"), false);
 });
 
 test("preserves existing groups, commits, verifies through a fresh edit, and cleans up", async () => {

--- a/wallet/zuuli/scripts/play-tester-groups.node-test.mjs
+++ b/wallet/zuuli/scripts/play-tester-groups.node-test.mjs
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import { createVerify, generateKeyPairSync } from "node:crypto";
+import test from "node:test";
+
+import {
+  ANDROID_PUBLISHER_SCOPE,
+  EXPECTED_SERVICE_ACCOUNT,
+  PACKAGE_NAME,
+  TOKEN_URL,
+  TRACK,
+  configurePlayTesterGroup,
+  createServiceAccountAssertion,
+  editUrl,
+  mergeGoogleGroups,
+  parseServiceAccountDocument,
+  validateGoogleGroup,
+} from "./play-tester-groups.mjs";
+
+const GROUP = "zuuli-internal-testers-free2z@googlegroups.com";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function queuedFetch(responses) {
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url: String(url), options });
+    assert.ok(responses.length > 0, `unexpected request: ${options.method} ${url}`);
+    const next = responses.shift();
+    return typeof next === "function" ? next(url, options) : next;
+  };
+  return { calls, fetchImpl, remaining: responses };
+}
+
+function testCredentials() {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return {
+    credentials: {
+      type: "service_account",
+      project_id: "corpora1",
+      client_email: EXPECTED_SERVICE_ACCOUNT,
+      private_key_id: "offline-test-key",
+      private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+    },
+    publicKey,
+  };
+}
+
+test("validates only canonical lowercase Google Group addresses", () => {
+  assert.equal(validateGoogleGroup(GROUP), GROUP);
+  for (const invalid of [
+    undefined,
+    "",
+    "Skylar@googlegroups.com",
+    "skylar@gmail.com",
+    "x@evil.googlegroups.com",
+    `.bad@googlegroups.com`,
+    `${"a".repeat(65)}@googlegroups.com`,
+  ]) {
+    assert.throws(() => validateGoogleGroup(invalid));
+  }
+});
+
+test("unions tester groups additively and idempotently", () => {
+  // Play also accepts Workspace-backed Google Groups on custom domains. The
+  // requested group is intentionally strict, while existing groups are opaque
+  // values that must be preserved.
+  const old = "existing-testers@corpora.example";
+  assert.deepEqual(mergeGoogleGroups([old], GROUP), [old, GROUP]);
+  assert.deepEqual(mergeGoogleGroups([GROUP, old, GROUP], GROUP), [old, GROUP]);
+  assert.deepEqual(mergeGoogleGroups(undefined, GROUP), [GROUP]);
+  assert.throws(() => mergeGoogleGroups("not-an-array", GROUP));
+});
+
+test("builds a correctly scoped, one-hour RS256 service-account assertion", () => {
+  const { credentials, publicKey } = testCredentials();
+  const now = 1_786_196_000;
+  const jwt = createServiceAccountAssertion(credentials, now);
+  const [headerPart, claimsPart, signaturePart] = jwt.split(".");
+  assert.deepEqual(JSON.parse(Buffer.from(headerPart, "base64url")), {
+    alg: "RS256",
+    typ: "JWT",
+  });
+  assert.deepEqual(JSON.parse(Buffer.from(claimsPart, "base64url")), {
+    iss: EXPECTED_SERVICE_ACCOUNT,
+    scope: ANDROID_PUBLISHER_SCOPE,
+    aud: TOKEN_URL,
+    iat: now,
+    exp: now + 3600,
+  });
+  const verifier = createVerify("RSA-SHA256");
+  verifier.update(`${headerPart}.${claimsPart}`);
+  verifier.end();
+  assert.equal(verifier.verify(publicKey, signaturePart, "base64url"), true);
+  assert.throws(() =>
+    createServiceAccountAssertion({ ...credentials, client_email: "other@example.com" }, now),
+  );
+  assert.throws(() =>
+    createServiceAccountAssertion({ ...credentials, project_id: "other" }, now),
+  );
+});
+
+test("redacts malformed service-account JSON parse failures", () => {
+  assert.deepEqual(parseServiceAccountDocument('{"type":"service_account"}'), {
+    type: "service_account",
+  });
+  assert.throws(
+    () => parseServiceAccountDocument('{"private_key":"SECRET-FRAGMENT"'),
+    (error) =>
+      error.message === "service-account document is not valid JSON" &&
+      !error.message.includes("SECRET-FRAGMENT"),
+  );
+});
+
+test("constructs fixed package, edit, tester, and commit URLs", () => {
+  assert.equal(
+    editUrl(),
+    `https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}/edits`,
+  );
+  assert.equal(
+    editUrl("edit 1", `/testers/${TRACK}`),
+    `https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}/edits/edit%201/testers/internal`,
+  );
+  assert.equal(editUrl("edit-1", ":commit").endsWith("/edits/edit-1:commit"), true);
+});
+
+test("preserves existing groups, commits, verifies through a fresh edit, and cleans up", async () => {
+  const { credentials } = testCredentials();
+  const old = "existing-testers@googlegroups.com";
+  const mock = queuedFetch([
+    jsonResponse({ access_token: "in-memory-token" }),
+    jsonResponse({ id: "write-edit" }),
+    jsonResponse({ googleGroups: [old] }),
+    jsonResponse({ googleGroups: [old, GROUP] }),
+    jsonResponse({ id: "write-edit", expiryTimeSeconds: "1" }),
+    jsonResponse({ id: "verify-edit" }),
+    jsonResponse({ googleGroups: [GROUP, old] }),
+    new Response(null, { status: 204 }),
+  ]);
+
+  const result = await configurePlayTesterGroup({
+    credentials,
+    googleGroup: GROUP,
+    fetchImpl: mock.fetchImpl,
+    nowSeconds: 1_786_196_000,
+  });
+
+  assert.deepEqual(result, {
+    packageName: PACKAGE_NAME,
+    track: TRACK,
+    googleGroups: [old, GROUP],
+  });
+  assert.equal(mock.remaining.length, 0);
+  assert.equal(mock.calls[0].url, TOKEN_URL);
+  assert.equal(mock.calls[0].options.method, "POST");
+  assert.equal(
+    mock.calls[0].options.headers["content-type"],
+    "application/x-www-form-urlencoded",
+  );
+  assert.equal(
+    mock.calls[0].options.body.get("grant_type"),
+    "urn:ietf:params:oauth:grant-type:jwt-bearer",
+  );
+  assert.equal(mock.calls[0].options.body.get("assertion").split(".").length, 3);
+  assert.deepEqual(
+    mock.calls.slice(1).map(({ url, options }) => [options.method, new URL(url).pathname]),
+    [
+      ["POST", `/androidpublisher/v3/applications/${PACKAGE_NAME}/edits`],
+      ["GET", `/androidpublisher/v3/applications/${PACKAGE_NAME}/edits/write-edit/testers/${TRACK}`],
+      ["PUT", `/androidpublisher/v3/applications/${PACKAGE_NAME}/edits/write-edit/testers/${TRACK}`],
+      ["POST", `/androidpublisher/v3/applications/${PACKAGE_NAME}/edits/write-edit:commit`],
+      ["POST", `/androidpublisher/v3/applications/${PACKAGE_NAME}/edits`],
+      ["GET", `/androidpublisher/v3/applications/${PACKAGE_NAME}/edits/verify-edit/testers/${TRACK}`],
+      ["DELETE", `/androidpublisher/v3/applications/${PACKAGE_NAME}/edits/verify-edit`],
+    ],
+  );
+  assert.deepEqual(JSON.parse(mock.calls[3].options.body), {
+    googleGroups: [old, GROUP],
+  });
+  assert.equal(mock.calls[4].options.body, undefined);
+  for (const call of mock.calls.slice(1)) {
+    assert.equal(call.options.headers.authorization, "Bearer in-memory-token");
+  }
+});
+
+test("rejects a lossy update response and deletes the write edit", async () => {
+  const { credentials } = testCredentials();
+  const old = "existing-testers@googlegroups.com";
+  const mock = queuedFetch([
+    jsonResponse({ access_token: "token" }),
+    jsonResponse({ id: "lossy-edit" }),
+    jsonResponse({ googleGroups: [old] }),
+    jsonResponse({ googleGroups: [GROUP] }),
+    new Response(null, { status: 204 }),
+  ]);
+  await assert.rejects(
+    configurePlayTesterGroup({
+      credentials,
+      googleGroup: GROUP,
+      fetchImpl: mock.fetchImpl,
+      nowSeconds: 1_786_196_000,
+    }),
+    /did not preserve the requested group set/,
+  );
+  assert.equal(mock.calls.at(-1).options.method, "DELETE");
+  assert.equal(mock.calls.at(-1).url, editUrl("lossy-edit"));
+});
+
+test("rejects committed-state drift and deletes the verification edit", async () => {
+  const { credentials } = testCredentials();
+  const old = "existing-testers@googlegroups.com";
+  const mock = queuedFetch([
+    jsonResponse({ access_token: "token" }),
+    jsonResponse({ id: "write-edit" }),
+    jsonResponse({ googleGroups: [old] }),
+    jsonResponse({ googleGroups: [old, GROUP] }),
+    jsonResponse({ id: "write-edit" }),
+    jsonResponse({ id: "verify-edit" }),
+    jsonResponse({ googleGroups: [GROUP] }),
+    new Response(null, { status: 204 }),
+  ]);
+  await assert.rejects(
+    configurePlayTesterGroup({
+      credentials,
+      googleGroup: GROUP,
+      fetchImpl: mock.fetchImpl,
+      nowSeconds: 1_786_196_000,
+    }),
+    /exact committed tester group set/,
+  );
+  assert.equal(mock.calls.at(-1).options.method, "DELETE");
+  assert.equal(mock.calls.at(-1).url, editUrl("verify-edit"));
+});
+
+test("reports API failures and deletes the uncommitted edit", async () => {
+  const { credentials } = testCredentials();
+  const mock = queuedFetch([
+    jsonResponse({ access_token: "token" }),
+    jsonResponse({ id: "failed-edit" }),
+    jsonResponse({ error: { message: "synthetic Play failure" } }, 500),
+    new Response(null, { status: 204 }),
+  ]);
+
+  await assert.rejects(
+    configurePlayTesterGroup({
+      credentials,
+      googleGroup: GROUP,
+      fetchImpl: mock.fetchImpl,
+      nowSeconds: 1_786_196_000,
+    }),
+    /HTTP 500: synthetic Play failure/,
+  );
+  assert.equal(mock.remaining.length, 0);
+  assert.equal(mock.calls.at(-1).options.method, "DELETE");
+  assert.equal(mock.calls.at(-1).url, editUrl("failed-edit"));
+});

--- a/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
+++ b/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
@@ -31,6 +31,7 @@ function requireCount(label, contents, value, expected) {
 const action = readRepo(".github/actions/zuuli-rust-cache/action.yml");
 const packaging = readRepo(".github/workflows/zuuli-packaging.yml");
 const release = readRepo(".github/workflows/zuuli-release.yml");
+const playTesters = readRepo(".github/workflows/zuuli-play-testers.yml");
 const cleanup = readRepo(".github/workflows/cache-cleanup.yml");
 const requiredGate = readRepo(".github/workflows/zuuli.yml");
 const localAction = "uses: ./.github/actions/zuuli-rust-cache";
@@ -126,6 +127,25 @@ for (const writer of [
 ]) {
   rejectText("protected release direct cache writer", release, writer);
 }
+
+requireText("Play testers protected environment", playTesters, "environment: zuuli-app-stores");
+requireText(
+  "Play testers protected secret",
+  playTesters,
+  "PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}",
+);
+for (const writer of [
+  "uses: ./.github/actions/zuuli-rust-cache",
+  "Swatinem/rust-cache@",
+  "actions/cache@",
+  "actions/cache/save@",
+  "cache: npm",
+  "cache: gradle",
+  "bundler-cache: true",
+  "gh cache",
+]) {
+  rejectText("Play testers credential-bearing job", playTesters, writer);
+}
 requireCount("protected release npm auto-cache", release, "cache: npm", 1);
 const prepareJob = job(release, "prepare", "android");
 requireCount("credential-free prepare npm auto-cache", prepareJob, "cache: npm", 1);
@@ -178,6 +198,11 @@ requireText(
   "required gate cache policy trigger",
   requiredGate,
   ".github/workflows/cache-cleanup.yml",
+);
+requireText(
+  "required gate Play testers trigger",
+  requiredGate,
+  ".github/workflows/zuuli-play-testers.yml",
 );
 const frontendGate = job(requiredGate, "frontend", "rust_plugin");
 requireCount(


### PR DESCRIPTION
Closes #294

## Summary
- add a protected, main-only workflow for additive Google Play internal tester groups
- authenticate with the dedicated service account without exposing decoded credentials or tokens
- preserve existing groups, commit atomically, and verify exact state through a fresh Play edit
- enforce credential-bearing cache boundaries and add nine offline transaction/security tests

## Verification
- `npm run test:play-testers` (9/9)
- `node scripts/verify-ci-cache-policy.mjs`
- `npm run test` (19/19)
- `npm run typecheck`
- `npm run build`
- `npm run release:verify`
- workflow YAML parse + `git diff --check`
- Claude adversarial review: APPROVE after two blocking findings were fixed
