### PR TITLE
fix(zuuli): reject malformed money inputs

### DIFF
--- a/wallet/zuuli/src/features/articles/components/Comments/CommentForm.tsx
+++ b/wallet/zuuli/src/features/articles/components/Comments/CommentForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ArrowRight, Eye, EyeOff, Loader2, LogIn, Send } from "lucide-react";
 import { toast } from "sonner";
@@ -7,10 +7,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Markdown } from "@/components/common/Markdown";
-import { formatTuzis } from "@/lib/format";
+import {
+  formatTuzis,
+  MAX_COMMENT_TUZIS,
+  tuziInputMaxLength,
+} from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { useSession } from "@/store/session";
 import type { Comment, CommentInput } from "@/lib/api/types";
+import { commentWeightState } from "./comment-weight";
 
 const HEADLINE_MAX = 100;
 const CONTENT_MAX = 1000;
@@ -40,9 +45,11 @@ export function CommentForm({
 
   const [headline, setHeadline] = useState("");
   const [content, setContent] = useState("");
-  const [tuzis, setTuzis] = useState(1);
+  const [tuziInput, setTuziInput] = useState("1");
   const [preview, setPreview] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const weightInputId = useId();
+  const weightErrorId = `${weightInputId}-error`;
 
   // Login gate — comments cost 2Zs, which requires an account.
   if (!user) {
@@ -65,12 +72,14 @@ export function CommentForm({
 
   const headlineOk = headline.trim().length > 0 && headline.length <= HEADLINE_MAX;
   const contentOk = content.trim().length > 0 && content.length <= CONTENT_MAX;
-  const weightOk = tuzis >= 1;
-  const enough = tuzis <= balance;
+  const weight = commentWeightState(tuziInput, balance);
+  const tuzis = weight.value;
+  const weightOk = weight.error === null;
+  const enough = weightOk && !weight.needsTopUp;
   const canPost = headlineOk && contentOk && weightOk && enough && !submitting;
 
   async function post() {
-    if (!canPost) return;
+    if (!canPost || tuzis === null) return;
     setSubmitting(true);
     try {
       const created = await submit({
@@ -83,7 +92,7 @@ export function CommentForm({
       toast.success(`Posted — ${formatTuzis(tuzis)} weight`);
       setHeadline("");
       setContent("");
-      setTuzis(1);
+      setTuziInput("1");
       setPreview(false);
       onPosted(created);
     } catch {
@@ -147,20 +156,29 @@ export function CommentForm({
 
       <div className="flex flex-wrap items-center gap-2">
         <div className="flex items-center gap-1.5">
-          <Label htmlFor="comment-weight" className="text-xs text-muted-foreground">
+          <Label htmlFor={weightInputId} className="text-xs text-muted-foreground">
             Weight
           </Label>
           <Input
-            id="comment-weight"
-            type="number"
-            min={1}
+            id={weightInputId}
+            type="text"
             inputMode="numeric"
-            value={tuzis}
-            onChange={(e) => setTuzis(Math.max(1, Number(e.target.value) || 1))}
+            maxLength={tuziInputMaxLength(MAX_COMMENT_TUZIS)}
+            value={tuziInput}
+            onChange={(e) => setTuziInput(e.target.value)}
             className="h-9 w-20 tabular-nums"
             aria-label="2Z weight to spend on this comment"
+            aria-describedby={weightErrorId}
+            aria-invalid={!weightOk}
           />
           <span className="text-xs text-muted-foreground">2Z</span>
+          <span id={weightErrorId} className="text-xs text-destructive">
+            {weight.error === "tooLarge"
+              ? `Max ${MAX_COMMENT_TUZIS.toLocaleString()} 2Z`
+              : !weightOk
+                ? "Positive whole 2Z only"
+                : null}
+          </span>
         </div>
 
         <Button
@@ -189,7 +207,7 @@ export function CommentForm({
               Cancel
             </Button>
           ) : null}
-          {!enough ? (
+          {weight.needsTopUp ? (
             <Button
               type="button"
               variant="outline"

--- a/wallet/zuuli/src/features/articles/components/Comments/comment-weight.test.ts
+++ b/wallet/zuuli/src/features/articles/components/Comments/comment-weight.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { MAX_COMMENT_TUZIS } from "@/lib/format";
+import { commentWeightState } from "./comment-weight";
+
+describe("commentWeightState", () => {
+  it("offers a top-up only for a valid positive weight above the balance", () => {
+    expect(commentWeightState("11", 10)).toEqual({
+      value: 11,
+      error: null,
+      needsTopUp: true,
+    });
+    expect(commentWeightState("10", 10).needsTopUp).toBe(false);
+  });
+
+  it.each(["", "-1", "1.5", "1e3", "junk"])(
+    "keeps malformed weight %s in validation instead of the top-up path",
+    (raw) => {
+      const state = commentWeightState(raw, 0);
+      expect(state.error).not.toBeNull();
+      expect(state.needsTopUp).toBe(false);
+    },
+  );
+
+  it("enforces the backend signed-32-bit maximum", () => {
+    expect(commentWeightState(String(MAX_COMMENT_TUZIS), MAX_COMMENT_TUZIS)).toEqual({
+      value: MAX_COMMENT_TUZIS,
+      error: null,
+      needsTopUp: false,
+    });
+    expect(commentWeightState(String(MAX_COMMENT_TUZIS + 1), Number.MAX_SAFE_INTEGER)).toEqual({
+      value: MAX_COMMENT_TUZIS + 1,
+      error: "tooLarge",
+      needsTopUp: false,
+    });
+  });
+});

--- a/wallet/zuuli/src/features/articles/components/Comments/comment-weight.ts
+++ b/wallet/zuuli/src/features/articles/components/Comments/comment-weight.ts
@@ -1,0 +1,24 @@
+import {
+  MAX_COMMENT_TUZIS,
+  validateTuzis,
+  type TuziInputError,
+} from "@/lib/format";
+
+export interface CommentWeightState {
+  value: number | null;
+  error: TuziInputError | null;
+  needsTopUp: boolean;
+}
+
+/** Keep malformed/over-limit weights distinct from valid unaffordable ones. */
+export function commentWeightState(raw: string, balance: number): CommentWeightState {
+  const parsed = validateTuzis(raw, {
+    minimum: 1,
+    maximum: MAX_COMMENT_TUZIS,
+  });
+  return {
+    ...parsed,
+    needsTopUp:
+      parsed.error === null && parsed.value !== null && parsed.value > balance,
+  };
+}

--- a/wallet/zuuli/src/features/articles/components/TipDialog.tsx
+++ b/wallet/zuuli/src/features/articles/components/TipDialog.tsx
@@ -15,7 +15,12 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { tuzi } from "@/lib/api/free2z";
-import { formatTuzis } from "@/lib/format";
+import {
+  formatTuzis,
+  MAX_TUZIS,
+  tuziInputMaxLength,
+  validateTuzis,
+} from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { useSession } from "@/store/session";
 import type { SimpleCreator } from "@/lib/api/types";
@@ -28,19 +33,22 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
   const tuzis = useSession((s) => s.tuzis);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
   const [open, setOpen] = useState(false);
-  const [amount, setAmount] = useState(100);
+  const [amount, setAmount] = useState("100");
   const [sending, setSending] = useState(false);
 
-  const enough = amount <= tuzis;
-  const canSend = amount > 0 && enough && !sending;
+  const amountResult = validateTuzis(amount, { minimum: 1, maximum: MAX_TUZIS });
+  const parsedAmount = amountResult.value;
+  const validAmount = amountResult.error === null;
+  const enough = parsedAmount !== null && parsedAmount <= tuzis;
+  const canSend = validAmount && enough && !sending;
 
   async function send() {
-    if (!canSend) return;
+    if (!canSend || parsedAmount === null) return;
     setSending(true);
     try {
-      await tuzi.donate(author.username, amount);
-      adjustTuzis(-amount);
-      toast.success(`Sent ${formatTuzis(amount)} to ${name}`);
+      await tuzi.donate(author.username, parsedAmount);
+      adjustTuzis(-parsedAmount);
+      toast.success(`Sent ${formatTuzis(parsedAmount)} to ${name}`);
       setOpen(false);
     } catch {
       toast.error("Could not send your tip. Please try again.");
@@ -71,11 +79,11 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
               <button
                 key={preset}
                 type="button"
-                onClick={() => setAmount(preset)}
-                aria-pressed={amount === preset}
+                onClick={() => setAmount(String(preset))}
+                aria-pressed={parsedAmount === preset}
                 className={cn(
                   "rounded-lg border px-3 py-2 text-sm font-medium tabular-nums transition-colors",
-                  amount === preset
+                  parsedAmount === preset
                     ? "border-primary bg-primary/15 text-primary"
                     : "border-border bg-transparent text-muted-foreground hover:bg-secondary",
                 )}
@@ -89,15 +97,24 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
             <Label htmlFor="tip-amount">Amount (2Z)</Label>
             <Input
               id="tip-amount"
-              type="number"
-              min={1}
+              type="text"
               inputMode="numeric"
+              maxLength={tuziInputMaxLength(MAX_TUZIS)}
               value={amount}
-              onChange={(e) => setAmount(Math.max(0, Number(e.target.value)))}
+              onChange={(e) => setAmount(e.target.value)}
               className="tabular-nums"
+              aria-describedby="tip-amount-error tip-balance"
+              aria-invalid={amount.length > 0 && !validAmount}
             />
-            <p className="text-xs text-muted-foreground tabular-nums">
+            <p id="tip-balance" className="text-xs text-muted-foreground tabular-nums">
               Balance: {formatTuzis(tuzis)}
+            </p>
+            <p id="tip-amount-error" className="min-h-[1rem] text-xs text-destructive">
+              {amountResult.error === "tooLarge"
+                ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per tip.`
+                : amount.length > 0 && amountResult.error !== null
+                  ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                  : null}
             </p>
           </div>
         </div>
@@ -110,7 +127,7 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
           >
             Cancel
           </Button>
-          {amount > 0 && !enough ? (
+          {validAmount && !enough ? (
             <Button
               variant="outline"
               onClick={() => {
@@ -129,7 +146,7 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
                   Sending
                 </>
               ) : (
-                <>Send {formatTuzis(amount)}</>
+                <>Send {parsedAmount !== null ? formatTuzis(parsedAmount) : "2Zs"}</>
               )}
             </Button>
           )}

--- a/wallet/zuuli/src/features/buy/BuyTab.tsx
+++ b/wallet/zuuli/src/features/buy/BuyTab.tsx
@@ -27,13 +27,15 @@ import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
 import { cn } from "@/lib/utils";
 import {
-  ZATOSHIS_PER_ZEC,
   formatTuzis,
   formatUsd,
   formatZecTrim,
+  MAX_TUZIS,
+  tuziInputMaxLength,
   tuzisToUsd,
+  validateTuzis,
 } from "@/lib/format";
-import { BUY_PACKS, MAX_TUZIS, parseTuzis } from "./lib";
+import { BUY_PACKS, zatoshisFromQuote } from "./lib";
 import type { PricingQuote } from "@/lib/api/types";
 import { isTauri, useMock } from "@/lib/platform";
 import {
@@ -76,20 +78,22 @@ export function BuyTab() {
   const [zecLoading, setZecLoading] = useState(false);
   const [quoteState, setQuoteState] = useState<QuoteState>({ status: "idle" });
 
-  // The custom field wins when it holds a valid amount, keeping one source of
+  // The custom field wins whenever it has input, keeping one source of
   // truth for "amount". Everything downstream reads `amount`.
-  const customTuzis = parseTuzis(custom);
-  const amount = custom.trim() ? customTuzis : selected;
-  const valid = amount > 0 && amount <= MAX_TUZIS;
+  const hasCustomAmount = custom.length > 0;
+  const customAmount = validateTuzis(custom, { minimum: 1, maximum: MAX_TUZIS });
+  const customTuzis = customAmount.value;
+  const amount = hasCustomAmount ? customTuzis : selected;
+  const valid = !hasCustomAmount || customAmount.error === null;
 
-  const usd = tuzisToUsd(amount);
+  const usd = tuzisToUsd(amount ?? 0);
 
   // Live ZEC cost from the backend pricing service, debounced on the amount.
   // We NEVER recompute ZEC on the client — the backend returns the exact
   // `zec_amount`. A cancel flag keeps only the latest request's result, and a
   // 503 / fetch error surfaces as an "unavailable" state (no fabricated number).
   useEffect(() => {
-    if (!zecDemoEnabled || !valid) {
+    if (!zecDemoEnabled || !valid || amount === null) {
       setQuoteState({ status: "idle" });
       return;
     }
@@ -114,16 +118,17 @@ export function BuyTab() {
   }, [amount, valid, zecDemoEnabled]);
 
   const quote = quoteState.status === "ready" ? quoteState.quote : null;
-  const zatoshisNeeded = quote
-    ? Math.round(Number(quote.zec_amount) * ZATOSHIS_PER_ZEC)
-    : 0;
-  const enoughZec = !!quote && spendable >= zatoshisNeeded;
+  const zatoshisNeeded = quote ? zatoshisFromQuote(quote) : null;
+  const validQuote = quote !== null && zatoshisNeeded !== null;
+  const enoughZec = validQuote && spendable >= zatoshisNeeded;
   const isEstimate = !!quote && (quote.stale || quote.bootstrap);
   const quoteLoading = quoteState.status === "loading";
-  const quoteUnavailable = quoteState.status === "error";
+  const quoteUnavailable =
+    quoteState.status === "error" ||
+    (quoteState.status === "ready" && zatoshisNeeded === null);
 
   async function payWithCard() {
-    if (!valid) return;
+    if (!valid || amount === null) return;
     setCardLoading(true);
     try {
       const { url } = await tuzi.buyCheckout(amount);
@@ -139,7 +144,16 @@ export function BuyTab() {
   }
 
   async function payWithZec() {
-    if (!zecDemoEnabled || !valid || !quote || !enoughZec) return;
+    if (
+      !zecDemoEnabled ||
+      !valid ||
+      amount === null ||
+      !quote ||
+      !validQuote ||
+      !enoughZec
+    ) {
+      return;
+    }
     setZecLoading(true);
     try {
       await settleZecTopUpDemo(zecDemoRuntime, amount, adjustTuzis);
@@ -165,7 +179,7 @@ export function BuyTab() {
 
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {BUY_PACKS.map((pack) => {
-            const active = !custom.trim() && selected === pack;
+            const active = !hasCustomAmount && selected === pack;
             return (
               <button
                 key={pack}
@@ -207,25 +221,32 @@ export function BuyTab() {
               id="custom-tuzis"
               inputMode="numeric"
               placeholder="e.g. 3,000"
+              maxLength={tuziInputMaxLength(MAX_TUZIS)}
               value={custom}
               onChange={(e) => setCustom(e.target.value)}
               className="pr-24 tabular-nums"
-              aria-describedby="custom-tuzis-usd"
+              aria-describedby="custom-tuzis-usd custom-tuzis-error"
+              aria-invalid={hasCustomAmount && !valid}
             />
             <span
               id="custom-tuzis-usd"
               className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm font-medium tabular-nums text-muted-foreground"
             >
-              {custom.trim() && customTuzis > 0
+              {hasCustomAmount && customTuzis !== null && customTuzis > 0
                 ? formatUsd(tuzisToUsd(customTuzis))
                 : "2Z"}
             </span>
           </div>
-          {custom.trim() && customTuzis > MAX_TUZIS && (
-            <p className="text-xs text-destructive">
-              Max {MAX_TUZIS.toLocaleString()} 2Z per purchase.
-            </p>
-          )}
+          <div
+            id="custom-tuzis-error"
+            className="min-h-[1rem] text-xs text-destructive"
+          >
+            {hasCustomAmount && customAmount.error === "tooLarge"
+              ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per purchase.`
+              : hasCustomAmount && customAmount.error !== null
+                ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                : null}
+          </div>
         </div>
       </div>
 
@@ -239,7 +260,7 @@ export function BuyTab() {
             </span>
           </CardTitle>
           <CardDescription className="tabular-nums">
-            for {valid ? formatTuzis(amount) : "—"}
+            for {valid && amount !== null ? formatTuzis(amount) : "—"}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -274,7 +295,7 @@ export function BuyTab() {
             disabled={
               !zecDemoEnabled ||
               !valid ||
-              !quote ||
+              !validQuote ||
               !enoughZec ||
               quoteLoading
             }
@@ -298,7 +319,7 @@ export function BuyTab() {
                       ? "—"
                       : quoteLoading
                         ? "…"
-                        : quote
+                        : validQuote && quote
                           ? `${quote.zec_amount} ZEC`
                           : "—"}
                   </span>
@@ -314,7 +335,7 @@ export function BuyTab() {
                     Demo pricing unavailable — try again.
                   </p>
                 )}
-                {valid && quote && !enoughZec && (
+                {valid && validQuote && !enoughZec && (
                   <p className="pt-1 text-destructive">
                     Not enough mock ZEC for this demo.
                   </p>
@@ -347,7 +368,11 @@ export function BuyTab() {
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3 rounded-lg border border-border bg-secondary/40 p-4 text-sm">
-            <Row label="You receive" value={formatTuzis(amount)} strong />
+            <Row
+              label="You receive"
+              value={amount !== null ? formatTuzis(amount) : "—"}
+              strong
+            />
             <Row label="Price" value={formatUsd(usd)} />
             <Separator />
             <Row

--- a/wallet/zuuli/src/features/buy/SendTab.tsx
+++ b/wallet/zuuli/src/features/buy/SendTab.tsx
@@ -17,8 +17,14 @@ import { discover, tuzi } from "@/lib/api/free2z";
 import type { SimpleCreator } from "@/lib/api/types";
 import { useSession } from "@/store/session";
 import { cn } from "@/lib/utils";
-import { formatTuzis, initials } from "@/lib/format";
-import { MAX_TUZIS, TIP_PRESETS, parseTuzis } from "./lib";
+import {
+  formatTuzis,
+  initials,
+  MAX_TUZIS,
+  tuziInputMaxLength,
+  validateTuzis,
+} from "@/lib/format";
+import { TIP_PRESETS } from "./lib";
 
 export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
   const tuzis = useSession((s) => s.tuzis);
@@ -41,14 +47,16 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
     };
   }, []);
 
-  const amount = custom.trim() ? parseTuzis(custom) : selected;
+  const hasCustomAmount = custom.length > 0;
+  const customAmount = validateTuzis(custom, { minimum: 1, maximum: MAX_TUZIS });
+  const amount = hasCustomAmount ? customAmount.value : selected;
   const recipient = username.trim();
-  const validAmount = amount > 0 && amount <= MAX_TUZIS;
-  const enough = amount <= tuzis;
+  const validAmount = !hasCustomAmount || customAmount.error === null;
+  const enough = amount !== null && amount <= tuzis;
   const canSend = validAmount && recipient.length > 0 && enough && !sending;
 
   async function send() {
-    if (!canSend) return;
+    if (!canSend || amount === null) return;
     setSending(true);
     try {
       await tuzi.donate(recipient, amount);
@@ -127,7 +135,7 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
           <Label>Amount</Label>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
             {TIP_PRESETS.map((preset) => {
-              const active = !custom.trim() && selected === preset;
+              const active = !hasCustomAmount && selected === preset;
               return (
                 <button
                   key={preset}
@@ -156,14 +164,24 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
             <Input
               inputMode="numeric"
               placeholder="Custom amount"
+              maxLength={tuziInputMaxLength(MAX_TUZIS)}
               value={custom}
               onChange={(e) => setCustom(e.target.value)}
               className="pr-24 tabular-nums"
               aria-label="Custom tip amount in 2Z"
+              aria-describedby="custom-tip-error"
+              aria-invalid={hasCustomAmount && !validAmount}
             />
             <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm font-medium tabular-nums text-muted-foreground">
               2Z
             </span>
+          </div>
+          <div id="custom-tip-error" className="min-h-[1rem] text-xs text-destructive">
+            {hasCustomAmount && customAmount.error === "tooLarge"
+                ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per tip.`
+                : hasCustomAmount && customAmount.error !== null
+                  ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                  : null}
           </div>
         </div>
       </div>
@@ -185,7 +203,7 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
             <span className="text-sm text-muted-foreground">Amount</span>
             <div className="text-right">
               <div className="text-xl font-bold tabular-nums">
-                {validAmount ? formatTuzis(amount) : "—"}
+                {validAmount && amount !== null ? formatTuzis(amount) : "—"}
               </div>
             </div>
           </div>
@@ -197,7 +215,9 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
                 validAmount && !enough && "text-destructive",
               )}
             >
-              {formatTuzis(Math.max(0, tuzis - (validAmount ? amount : 0)))}
+              {formatTuzis(
+                Math.max(0, tuzis - (validAmount && amount !== null ? amount : 0)),
+              )}
             </span>
           </div>
 

--- a/wallet/zuuli/src/features/buy/lib.test.ts
+++ b/wallet/zuuli/src/features/buy/lib.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { zatoshisFromQuote } from "./lib";
+
+describe("zatoshisFromQuote", () => {
+  it("preserves the backend's exact quoted zatoshi amount", () => {
+    expect(zatoshisFromQuote({ zec_amount: "1.00000001" })).toBe(100_000_001);
+  });
+
+  it.each(["1.000000001", "1e3", "NaN", "90071992.54740992"])(
+    "rejects unusable quote amount %s",
+    (zec_amount) => {
+      expect(zatoshisFromQuote({ zec_amount })).toBeNull();
+    },
+  );
+});

--- a/wallet/zuuli/src/features/buy/lib.ts
+++ b/wallet/zuuli/src/features/buy/lib.ts
@@ -6,8 +6,8 @@
 // cost is fetched live from the backend pricing service (pricing.quote) —
 // there is no client-side rate.
 
-import { TUZIS_PER_USD } from "@/lib/format";
-import type { TuziTransaction } from "@/lib/api/types";
+import { parseZecToZatoshis, TUZIS_PER_USD } from "@/lib/format";
+import type { PricingQuote, TuziTransaction } from "@/lib/api/types";
 import {
   CreditCard,
   Gift,
@@ -25,13 +25,10 @@ export const BUY_PACKS = [500, 2_000, 5_000, 10_000] as const;
 /** Preset tip amounts, in 2Z. */
 export const TIP_PRESETS = [100, 500, 1_000, 2_500] as const;
 
-/** Parse a possibly-messy numeric string into a non-negative whole 2Z amount. */
-export function parseTuzis(raw: string): number {
-  const n = Math.floor(Number(raw.replace(/[^0-9.]/g, "")));
-  return Number.isFinite(n) && n > 0 ? n : 0;
+/** Validate the backend's exact ZEC quote before balance checks or confirmation. */
+export function zatoshisFromQuote(quote: Pick<PricingQuote, "zec_amount">): number | null {
+  return parseZecToZatoshis(quote.zec_amount);
 }
-
-export const MAX_TUZIS = 1_000_000; // sane cap for a single purchase / tip
 
 // ── Transaction presentation ────────────────────────────────────────────────
 

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -45,7 +45,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
 import { Markdown } from "@/components/common/Markdown";
 import { discover, live, tuzi } from "@/lib/api/free2z";
-import { formatTuzis, initials, timeAgo } from "@/lib/format";
+import {
+  formatTuzis,
+  initials,
+  MAX_TUZIS,
+  timeAgo,
+  tuziInputMaxLength,
+  validateTuzis,
+} from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { parseBioFrontmatter, type SocialLink } from "@/lib/utils/bio";
 import { useAsync } from "@/hooks/useAsync";
@@ -664,19 +671,22 @@ function TipButton({ creator }: { creator: CreatorDetail }) {
   const balance = useSession((s) => s.tuzis);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
   const [open, setOpen] = useState(false);
-  const [amount, setAmount] = useState(100);
+  const [amount, setAmount] = useState("100");
   const [busy, setBusy] = useState(false);
 
-  const enough = amount <= balance;
-  const canSend = amount > 0 && enough && !busy;
+  const amountResult = validateTuzis(amount, { minimum: 1, maximum: MAX_TUZIS });
+  const parsedAmount = amountResult.value;
+  const validAmount = amountResult.error === null;
+  const enough = parsedAmount !== null && parsedAmount <= balance;
+  const canSend = validAmount && enough && !busy;
 
   async function send() {
-    if (!canSend) return;
+    if (!canSend || parsedAmount === null) return;
     setBusy(true);
     try {
-      await tuzi.donate(creator.username, amount);
-      adjustTuzis(-amount);
-      toast.success(`Sent ${formatTuzis(amount)} to ${name}`);
+      await tuzi.donate(creator.username, parsedAmount);
+      adjustTuzis(-parsedAmount);
+      toast.success(`Sent ${formatTuzis(parsedAmount)} to ${name}`);
       setOpen(false);
     } catch {
       toast.error("Could not send your tip. Please try again.");
@@ -707,11 +717,11 @@ function TipButton({ creator }: { creator: CreatorDetail }) {
               <button
                 key={preset}
                 type="button"
-                onClick={() => setAmount(preset)}
-                aria-pressed={amount === preset}
+                onClick={() => setAmount(String(preset))}
+                aria-pressed={parsedAmount === preset}
                 className={cn(
                   "rounded-lg border px-3 py-2 text-sm font-medium tabular-nums transition-colors",
-                  amount === preset
+                  parsedAmount === preset
                     ? "border-primary bg-primary/15 text-primary"
                     : "border-border bg-transparent text-muted-foreground hover:bg-secondary",
                 )}
@@ -724,15 +734,24 @@ function TipButton({ creator }: { creator: CreatorDetail }) {
             <Label htmlFor="creator-tip-amount">Amount (2Z)</Label>
             <Input
               id="creator-tip-amount"
-              type="number"
-              min={1}
+              type="text"
               inputMode="numeric"
+              maxLength={tuziInputMaxLength(MAX_TUZIS)}
               value={amount}
-              onChange={(e) => setAmount(Math.max(0, Number(e.target.value)))}
+              onChange={(e) => setAmount(e.target.value)}
               className="tabular-nums"
+              aria-describedby="creator-tip-error creator-tip-balance"
+              aria-invalid={amount.length > 0 && !validAmount}
             />
-            <p className="text-xs text-muted-foreground tabular-nums">
+            <p id="creator-tip-balance" className="text-xs text-muted-foreground tabular-nums">
               Balance: {formatTuzis(balance)}
+            </p>
+            <p id="creator-tip-error" className="min-h-[1rem] text-xs text-destructive">
+              {amountResult.error === "tooLarge"
+                ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per tip.`
+                : amount.length > 0 && amountResult.error !== null
+                  ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                  : null}
             </p>
           </div>
         </div>
@@ -741,7 +760,7 @@ function TipButton({ creator }: { creator: CreatorDetail }) {
           <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
             Cancel
           </Button>
-          {amount > 0 && !enough ? (
+          {validAmount && !enough ? (
             <Button
               variant="outline"
               onClick={() => {
@@ -760,7 +779,7 @@ function TipButton({ creator }: { creator: CreatorDetail }) {
                   Sending
                 </>
               ) : (
-                <>Send {formatTuzis(amount)}</>
+                <>Send {parsedAmount !== null ? formatTuzis(parsedAmount) : "2Zs"}</>
               )}
             </Button>
           )}

--- a/wallet/zuuli/src/features/live/GoLiveDialog.tsx
+++ b/wallet/zuuli/src/features/live/GoLiveDialog.tsx
@@ -17,7 +17,12 @@ import { Label } from "@/components/ui/label";
 import { live } from "@/lib/api/free2z";
 import { ApiError } from "@/lib/api/http";
 import { useSession } from "@/store/session";
-import { formatTuzis } from "@/lib/format";
+import {
+  formatTuzis,
+  MAX_PPV_PRICE_TUZIS,
+  tuziInputMaxLength,
+  validateTuzis,
+} from "@/lib/format";
 import type { StreamKind } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import { KIND_META, KIND_ORDER } from "./lib";
@@ -31,14 +36,19 @@ export function GoLiveDialog() {
   const [price, setPrice] = useState("100");
   const [starting, setStarting] = useState(false);
 
-  const priceNum = Math.max(0, Math.round(Number(price) || 0));
+  const priceResult = validateTuzis(price, {
+    minimum: 1,
+    maximum: MAX_PPV_PRICE_TUZIS,
+  });
+  const priceNum = priceResult.value;
+  const validPrice = priceResult.error === null;
   const canStart =
     title.trim().length > 0 &&
     !starting &&
-    (kind !== "ppv" || priceNum > 0);
+    (kind !== "ppv" || validPrice);
 
   async function handleStart() {
-    if (!canStart) return;
+    if (!canStart || (kind === "ppv" && priceNum === null)) return;
     setStarting(true);
     try {
       const ticket = await live.start(kind);
@@ -55,7 +65,7 @@ export function GoLiveDialog() {
             ticket,
             kind,
             title: title.trim(),
-            price_tuzis: priceNum,
+            price_tuzis: kind === "ppv" ? priceNum : 0,
           },
         },
       });
@@ -164,19 +174,28 @@ export function GoLiveDialog() {
               <Label htmlFor="go-live-price">Join price (2Z)</Label>
               <Input
                 id="go-live-price"
-                type="number"
+                type="text"
                 inputMode="numeric"
-                min={1}
+                maxLength={tuziInputMaxLength(MAX_PPV_PRICE_TUZIS)}
                 value={price}
                 onChange={(e) => setPrice(e.target.value)}
                 className="tabular-nums"
+                aria-describedby="go-live-price-error go-live-price-summary"
+                aria-invalid={!validPrice}
               />
-              <p className="text-xs text-muted-foreground">
+              <p id="go-live-price-summary" className="text-xs text-muted-foreground">
                 Viewers spend{" "}
                 <span className="font-medium text-amber-400 tabular-nums">
-                  {formatTuzis(priceNum)}
+                  {priceNum !== null && priceNum > 0 ? formatTuzis(priceNum) : "—"}
                 </span>{" "}
                 to join.
+              </p>
+              <p id="go-live-price-error" className="min-h-[1rem] text-xs text-destructive">
+                {priceResult.error === "tooLarge"
+                  ? `Max ${MAX_PPV_PRICE_TUZIS.toLocaleString()} 2Z for PPV.`
+                  : !validPrice
+                    ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                    : null}
               </p>
             </div>
           ) : null}

--- a/wallet/zuuli/src/features/profile/index.tsx
+++ b/wallet/zuuli/src/features/profile/index.tsx
@@ -15,7 +15,12 @@ import { Label } from "@/components/ui/label";
 import { PageHeader } from "@/components/common/PageHeader";
 import { Textarea } from "@/components/ui/textarea";
 import { profile } from "@/lib/api/free2z";
-import { initials } from "@/lib/format";
+import {
+  initials,
+  MAX_MEMBER_PRICE_TUZIS,
+  tuziInputMaxLength,
+  validateTuzis,
+} from "@/lib/format";
 import { useSession } from "@/store/session";
 import type { AuthUser } from "@/lib/api/types";
 import { LinkedAccounts } from "./LinkedAccounts";
@@ -61,18 +66,23 @@ function ProfileForm({ user }: { user: AuthUser }) {
   const [saving, setSaving] = useState(false);
 
   const trimmedName = displayName.trim();
-  const canSave = trimmedName.length > 0 && !saving;
+  const memberPriceResult = validateTuzis(memberPrice, {
+    minimum: 0,
+    maximum: MAX_MEMBER_PRICE_TUZIS,
+  });
+  const parsedMemberPrice = memberPriceResult.value;
+  const memberPriceValid = memberPrice === "" || memberPriceResult.error === null;
+  const canSave = trimmedName.length > 0 && memberPriceValid && !saving;
 
   async function save() {
-    if (!canSave) return;
+    if (!canSave || (memberPrice !== "" && parsedMemberPrice === null)) return;
     setSaving(true);
     try {
-      const price = memberPrice.trim();
       const updated = await profile.update({
         display_name: trimmedName,
         bio: bio.trim(),
         p2paddr: p2paddr.trim(),
-        member_price: price === "" ? null : Math.max(0, Math.round(Number(price))),
+        member_price: memberPrice === "" ? null : parsedMemberPrice,
       });
       setUser(updated);
       toast.success("Profile updated");
@@ -169,14 +179,26 @@ function ProfileForm({ user }: { user: AuthUser }) {
             </Label>
             <Input
               id="profile-member-price"
-              type="number"
-              min={0}
+              type="text"
               inputMode="numeric"
+              maxLength={tuziInputMaxLength(MAX_MEMBER_PRICE_TUZIS)}
               value={memberPrice}
               onChange={(e) => setMemberPrice(e.target.value)}
               placeholder="Leave blank for no paid membership tier"
               className="tabular-nums"
+              aria-describedby="profile-member-price-error"
+              aria-invalid={!memberPriceValid}
             />
+            <p
+              id="profile-member-price-error"
+              className="min-h-[1rem] text-xs text-destructive"
+            >
+              {memberPriceResult.error === "tooLarge"
+                ? `Max ${MAX_MEMBER_PRICE_TUZIS.toLocaleString()} 2Z per membership.`
+                : !memberPriceValid
+                  ? "Enter a non-negative whole 2Z amount; commas may separate thousands."
+                  : null}
+            </p>
           </div>
 
           <div className="space-y-2">

--- a/wallet/zuuli/src/features/wallet/Send.tsx
+++ b/wallet/zuuli/src/features/wallet/Send.tsx
@@ -23,11 +23,14 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Separator } from "@/components/ui/separator";
 import {
-  ZATOSHIS_PER_ZEC,
+  formatZec,
   formatZecDisplay,
+  MAX_ZEC_INPUT_LENGTH,
+  parseZecToZatoshis,
   truncateAddress,
 } from "@/lib/format";
 import { wallet } from "@/lib/wallet/bridge";
+import { assertExactSendProposal } from "@/lib/wallet/amounts";
 import type {
   AddressValidation,
   ExecuteSendResult,
@@ -66,12 +69,6 @@ function clampToBytes(value: string, maxBytes: number): string {
   return out;
 }
 
-function toZatoshis(zec: string): number | null {
-  const n = Number(zec);
-  if (!Number.isFinite(n) || n <= 0) return null;
-  return Math.round(n * ZATOSHIS_PER_ZEC);
-}
-
 function errorMessage(error: unknown, fallback: string): string {
   if (error instanceof Error) return error.message;
   if (typeof error === "string" && error.trim()) return error;
@@ -101,7 +98,8 @@ export function Send() {
   const debounceRef = useRef<number | null>(null);
 
   const canReceiveMemo = validation?.valid ? validation.canReceiveMemo : true;
-  const zatoshis = toZatoshis(amount);
+  const zatoshis = parseZecToZatoshis(amount);
+  const invalidAmount = amount.length > 0 && zatoshis === null;
   const spendable = balance?.spendable ?? 0;
   // Largest amount that still leaves room for the network fee.
   const maxSpendable = Math.max(0, spendable - FEE_RESERVE);
@@ -131,8 +129,7 @@ export function Send() {
     try {
       const req = await wallet.parsePaymentUri(uri);
       setTo(req.address);
-      if (req.amount !== null)
-        setAmount((req.amount / ZATOSHIS_PER_ZEC).toString());
+      if (req.amount !== null) setAmount(formatZec(req.amount));
       if (req.memo !== null) setMemo(clampToBytes(req.memo, MEMO_MAX_BYTES));
       toast.success("Payment request loaded");
     } catch {
@@ -204,6 +201,7 @@ export function Send() {
         zatoshis,
         canReceiveMemo && memo ? memo : undefined,
       );
+      assertExactSendProposal(zatoshis, p);
       setProposal(p);
       setDialogOpen(true);
     } catch (e) {
@@ -378,9 +376,7 @@ export function Send() {
                   type="button"
                   disabled={hasUnknownBroadcast}
                   className="text-xs text-muted-foreground hover:text-foreground"
-                  onClick={() =>
-                    setAmount((maxSpendable / ZATOSHIS_PER_ZEC).toString())
-                  }
+                  onClick={() => setAmount(formatZec(maxSpendable))}
                 >
                   Max: {formatZecDisplay(maxSpendable)}
                 </button>
@@ -393,22 +389,27 @@ export function Send() {
                 onChange={(e) => setAmount(e.target.value)}
                 placeholder="0.00"
                 inputMode="decimal"
-                type="number"
+                maxLength={MAX_ZEC_INPUT_LENGTH}
+                type="text"
                 disabled={hasUnknownBroadcast}
-                min="0"
-                step="0.00000001"
                 className={cn(
                   "pr-14 tabular-nums",
-                  overBalance && "border-destructive",
+                  (invalidAmount || overBalance) && "border-destructive",
                 )}
-                aria-invalid={overBalance || undefined}
+                aria-describedby="amount-error"
+                aria-invalid={invalidAmount || overBalance || undefined}
               />
               <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center">
                 <ZecTag className="text-xs" />
               </div>
             </div>
-            <div className="min-h-[1.25rem] text-xs">
-              {overBalance ? (
+            <div id="amount-error" className="min-h-[1.25rem] text-xs">
+              {invalidAmount ? (
+                <span className="flex items-center gap-1.5 text-destructive">
+                  <AlertCircle className="h-3.5 w-3.5" />
+                  Enter a positive ZEC amount with no more than 8 decimal places
+                </span>
+              ) : overBalance ? (
                 <span className="flex items-center gap-1.5 text-destructive">
                   <AlertCircle className="h-3.5 w-3.5" />
                   Amount plus network fee exceeds spendable balance

--- a/wallet/zuuli/src/lib/format.test.ts
+++ b/wallet/zuuli/src/lib/format.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatZec,
+  MAX_COMMENT_TUZIS,
+  MAX_MEMBER_PRICE_TUZIS,
+  MAX_PPV_PRICE_TUZIS,
+  MAX_TUZIS,
+  MAX_ZEC_INPUT_LENGTH,
+  parseTuzis,
+  parseZecToZatoshis,
+  tuziInputMaxLength,
+  validateTuzis,
+} from "./format";
+
+describe("parseTuzis", () => {
+  it.each([
+    ["0", 0],
+    ["1", 1],
+    ["999", 999],
+    ["1,000", 1_000],
+    ["1000000", 1_000_000],
+    ["9,007,199,254,740,991", Number.MAX_SAFE_INTEGER],
+  ])("parses exact whole 2Z input %s", (raw, expected) => {
+    expect(parseTuzis(raw)).toBe(expected);
+  });
+
+  it.each([
+    "",
+    " 1",
+    "1 ",
+    "-100",
+    "+100",
+    "1.9",
+    "1e3",
+    "1.2.3",
+    "100 2Z",
+    "1_000",
+    "1 000",
+    "1,00",
+    "1,0000",
+    "0,001",
+    "01",
+    "NaN",
+    "Infinity",
+    "9,007,199,254,740,992",
+    "9".repeat(10_000),
+  ])("rejects malformed or unsafe 2Z input %s", (raw) => {
+    expect(parseTuzis(raw)).toBeNull();
+  });
+});
+
+describe("parseZecToZatoshis", () => {
+  it.each([
+    ["0.00000001", 1],
+    ["0.1", 10_000_000],
+    ["1", 100_000_000],
+    ["1.00000000", 100_000_000],
+    ["90071992.54740991", Number.MAX_SAFE_INTEGER],
+  ])("parses exact ZEC input %s", (raw, expected) => {
+    expect(parseZecToZatoshis(raw)).toBe(expected);
+  });
+
+  it.each([
+    "",
+    "0",
+    "0.00000000",
+    " 1",
+    "1 ",
+    "-1",
+    "+1",
+    ".1",
+    "1.",
+    "1.000000001",
+    "1e3",
+    "1.2.3",
+    "1 ZEC",
+    "1,000",
+    "NaN",
+    "Infinity",
+    "90071992.54740992",
+    `${"9".repeat(10_000)}.1`,
+  ])("rejects malformed, non-positive, imprecise, or unsafe ZEC input %s", (raw) => {
+    expect(parseZecToZatoshis(raw)).toBeNull();
+  });
+});
+
+describe("whole-2Z form limits", () => {
+  it.each([
+    ["purchase/tip", MAX_TUZIS],
+    ["member price", MAX_MEMBER_PRICE_TUZIS],
+    ["comment", MAX_COMMENT_TUZIS],
+    ["whole PPV price", MAX_PPV_PRICE_TUZIS],
+  ])("enforces the %s maximum", (_label, maximum) => {
+    expect(validateTuzis(String(maximum), { minimum: 1, maximum })).toEqual({
+      value: maximum,
+      error: null,
+    });
+    expect(validateTuzis(String(maximum + 1), { minimum: 1, maximum })).toEqual({
+      value: maximum + 1,
+      error: "tooLarge",
+    });
+  });
+
+  it("distinguishes malformed and below-minimum input", () => {
+    expect(validateTuzis("1e3", { minimum: 1, maximum: MAX_TUZIS }).error).toBe(
+      "invalid",
+    );
+    expect(validateTuzis("0", { minimum: 1, maximum: MAX_TUZIS }).error).toBe(
+      "tooSmall",
+    );
+  });
+
+  it("provides raw input lengths for canonical comma grouping", () => {
+    expect(tuziInputMaxLength(MAX_MEMBER_PRICE_TUZIS)).toBe("999,999".length);
+    expect(tuziInputMaxLength(MAX_TUZIS)).toBe("1,000,000".length);
+    expect(tuziInputMaxLength(MAX_COMMENT_TUZIS)).toBe("2,147,483,647".length);
+    expect(tuziInputMaxLength(MAX_PPV_PRICE_TUZIS)).toBe("9,999".length);
+    expect(MAX_ZEC_INPUT_LENGTH).toBe("90071992.54740991".length);
+  });
+});
+
+describe("formatZec", () => {
+  it("preserves exact minimum, negative, and maximum-safe zatoshi values", () => {
+    expect(formatZec(1)).toBe("0.00000001");
+    expect(formatZec(-1)).toBe("-0.00000001");
+    expect(formatZec(Number.MAX_SAFE_INTEGER)).toBe("90071992.54740991");
+  });
+
+  it("rejects values that cannot represent an exact zatoshi amount", () => {
+    expect(() => formatZec(1.5)).toThrow(RangeError);
+    expect(() => formatZec(Number.POSITIVE_INFINITY)).toThrow(RangeError);
+  });
+});

--- a/wallet/zuuli/src/lib/format.ts
+++ b/wallet/zuuli/src/lib/format.ts
@@ -20,15 +20,103 @@
 export const ZATOSHIS_PER_ZEC = 100_000_000;
 export const TUZIS_PER_USD = 100; // internal cost-plus accounting constant, not a displayed exchange rate
 
+/** Product/API bounds for user-entered whole-2Z amounts. */
+export const MAX_TUZIS = 1_000_000;
+export const MAX_MEMBER_PRICE_TUZIS = 999_999;
+export const MAX_COMMENT_TUZIS = 2_147_483_647;
+// free2z CreatorMeeting.price_per_minute is Decimal(6, 2), capped at 9999.99.
+// ZUULI's PPV input is whole 2Z, so 9,999 is the largest representable value.
+export const MAX_PPV_PRICE_TUZIS = 9_999;
+
+export const MAX_ZEC_INPUT_LENGTH = "90071992.54740991".length;
+
+const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const MAX_SAFE_INTEGER_DIGITS = String(Number.MAX_SAFE_INTEGER).length;
+
+export type TuziInputError = "invalid" | "tooSmall" | "tooLarge";
+
+export interface TuziInputResult {
+  value: number | null;
+  error: TuziInputError | null;
+}
+
+/** Maximum raw length for an integer that may contain canonical ASCII commas. */
+export function tuziInputMaxLength(maximum: number): number {
+  const digits = String(maximum).length;
+  return digits + Math.floor((digits - 1) / 3);
+}
+
+/**
+ * Parse an exact, non-negative whole-2Z amount.
+ *
+ * ASCII commas are the only supported grouping separator, and when present
+ * they must delimit groups of three digits. Returning `null` (instead of a
+ * fallback number) keeps malformed input from being silently changed before
+ * it is displayed or submitted.
+ */
+export function parseTuzis(raw: string): number | null {
+  if (!/^(?:0|[1-9]\d*|[1-9]\d{0,2}(?:,\d{3})+)$/.test(raw)) return null;
+
+  const normalized = raw.replace(/,/g, "");
+  // Bound work before BigInt construction, even when called outside an input
+  // with maxLength (for example, from pasted/programmatic values).
+  if (normalized.length > MAX_SAFE_INTEGER_DIGITS) return null;
+
+  const value = BigInt(normalized);
+  if (value > MAX_SAFE_INTEGER_BIGINT) return null;
+  return Number(value);
+}
+
+/** Parse a whole-2Z input and retain why a syntactically valid value failed. */
+export function validateTuzis(
+  raw: string,
+  { minimum, maximum }: { minimum: number; maximum: number },
+): TuziInputResult {
+  const value = parseTuzis(raw);
+  if (value === null) return { value: null, error: "invalid" };
+  if (value < minimum) return { value, error: "tooSmall" };
+  if (value > maximum) return { value, error: "tooLarge" };
+  return { value, error: null };
+}
+
+/**
+ * Parse a positive ZEC amount to an exact integer number of zatoshis.
+ *
+ * ZEC input deliberately supports no grouping separators and at most eight
+ * decimal places. Integer arithmetic avoids the rounding that comes from
+ * multiplying a JavaScript floating-point value by 1e8.
+ */
+export function parseZecToZatoshis(raw: string): number | null {
+  const match = /^(\d+)(?:\.(\d{1,8}))?$/.exec(raw);
+  if (!match) return null;
+
+  const fraction = (match[2] ?? "").padEnd(8, "0");
+  const normalized = `${match[1]}${fraction}`.replace(/^0+/, "") || "0";
+  // Number.MAX_SAFE_INTEGER is 16 digits; reject longer zatoshi values before
+  // asking BigInt to allocate for an untrusted string.
+  if (normalized.length > MAX_SAFE_INTEGER_DIGITS) return null;
+
+  const value = BigInt(normalized);
+  if (value <= 0n || value > MAX_SAFE_INTEGER_BIGINT) return null;
+  return Number(value);
+}
+
 /** Format zatoshis as a plain ZEC string (8dp). */
 export function formatZec(zatoshis: number): string {
-  return (zatoshis / ZATOSHIS_PER_ZEC).toFixed(8);
+  if (!Number.isSafeInteger(zatoshis)) {
+    throw new RangeError("Zatoshi amount must be a safe integer");
+  }
+
+  const sign = zatoshis < 0 ? "-" : "";
+  const absolute = BigInt(Math.abs(zatoshis));
+  const whole = absolute / BigInt(ZATOSHIS_PER_ZEC);
+  const fraction = absolute % BigInt(ZATOSHIS_PER_ZEC);
+  return `${sign}${whole}.${fraction.toString().padStart(8, "0")}`;
 }
 
 /** Format zatoshis as ZEC, trimming trailing zeros but keeping >= 2 dp. */
 export function formatZecTrim(zatoshis: number): string {
-  const zec = zatoshis / ZATOSHIS_PER_ZEC;
-  const s = zec.toFixed(8).replace(/0+$/, "").replace(/\.$/, ".0");
+  const s = formatZec(zatoshis).replace(/0+$/, "").replace(/\.$/, ".0");
   const [w, d = ""] = s.split(".");
   return `${w}.${d.padEnd(2, "0")}`;
 }

--- a/wallet/zuuli/src/lib/wallet/amounts.test.ts
+++ b/wallet/zuuli/src/lib/wallet/amounts.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { assertExactSendProposal } from "./amounts";
+
+describe("assertExactSendProposal", () => {
+  const exact = { proposalId: 1, amount: 100_000_001, fee: 10_000, total: 100_010_001 };
+
+  it("accepts a safe proposal whose amount and total are exact", () => {
+    expect(() => assertExactSendProposal(exact.amount, exact)).not.toThrow();
+  });
+
+  it("rejects a wallet proposal that changes the entered amount", () => {
+    expect(() => assertExactSendProposal(exact.amount - 1, exact)).toThrow(
+      "changed the payment amount",
+    );
+  });
+
+  it("rejects inconsistent or non-integer proposal totals", () => {
+    expect(() =>
+      assertExactSendProposal(exact.amount, { ...exact, total: exact.total + 1 }),
+    ).toThrow("invalid payment totals");
+    expect(() =>
+      assertExactSendProposal(exact.amount, { ...exact, fee: 0.5, total: exact.amount + 0.5 }),
+    ).toThrow("invalid payment totals");
+  });
+});

--- a/wallet/zuuli/src/lib/wallet/amounts.ts
+++ b/wallet/zuuli/src/lib/wallet/amounts.ts
@@ -1,0 +1,20 @@
+import type { SendProposal } from "./types";
+
+/** Reject a proposal that changes the requested amount or carries lossy totals. */
+export function assertExactSendProposal(
+  expectedAmount: number,
+  proposal: SendProposal,
+): void {
+  if (proposal.amount !== expectedAmount) {
+    throw new Error("Wallet proposal changed the payment amount");
+  }
+  if (
+    !Number.isSafeInteger(proposal.amount) ||
+    !Number.isSafeInteger(proposal.fee) ||
+    proposal.fee < 0 ||
+    !Number.isSafeInteger(proposal.total) ||
+    proposal.total !== proposal.amount + proposal.fee
+  ) {
+    throw new Error("Wallet proposal returned invalid payment totals");
+  }
+}

--- a/wallet/zuuli/src/lib/wallet/mock.test.ts
+++ b/wallet/zuuli/src/lib/wallet/mock.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { mockWallet } from "./mock";
+
+describe("mockWallet.parsePaymentUri", () => {
+  it("preserves an exact eight-decimal URI amount", () => {
+    expect(mockWallet.parsePaymentUri("zcash:u1test?amount=1.00000001").amount).toBe(
+      100_000_001,
+    );
+  });
+
+  it.each(["1.000000001", "1e3", "-1", "Infinity"])(
+    "rejects malformed URI amount %s instead of rounding it",
+    (amount) => {
+      expect(() =>
+        mockWallet.parsePaymentUri(`zcash:u1test?amount=${encodeURIComponent(amount)}`),
+      ).toThrow("Invalid ZEC amount");
+    },
+  );
+});

--- a/wallet/zuuli/src/lib/wallet/mock.ts
+++ b/wallet/zuuli/src/lib/wallet/mock.ts
@@ -14,6 +14,7 @@ import type {
   WalletCreated,
   WalletStatus,
 } from "./types";
+import { parseZecToZatoshis } from "../format";
 
 const MOCK_UA =
   "u1l8xunezsvpntq2snz67h6md2eq09u09vv3xh6z8kqvxg7pdvz4qc9x2u84kqmpc0mz0kmvexz";
@@ -163,11 +164,14 @@ export const mockWallet = {
   parsePaymentUri(uri: string): PaymentRequest {
     const [addr, qs = ""] = uri.replace(/^zcash:/, "").split("?");
     const params = new URLSearchParams(qs);
+    const rawAmount = params.get("amount");
+    const amount = rawAmount === null ? null : parseZecToZatoshis(rawAmount);
+    if (rawAmount !== null && amount === null) {
+      throw new Error("Invalid ZEC amount in payment URI");
+    }
     return {
       address: addr,
-      amount: params.get("amount")
-        ? Math.round(Number(params.get("amount")) * 1e8)
-        : null,
+      amount,
       memo: params.get("memo"),
       label: params.get("label"),
     };


### PR DESCRIPTION
## Summary

- add exact, unit-aware 2Z and ZEC parsers with strict comma grouping, bounded pre-BigInt work, safe-integer bounds, and integer zatoshi conversion
- enforce authoritative per-form maxima for purchases/tips, memberships, comments, and whole-2Z PPV input with inline validation and bounded input lengths
- reject malformed money input across purchases, tips, comments, memberships, PPV pricing, wallet sends, quotes, and mock payment URIs
- preserve exact ZEC amounts through input, demo quote review, and wallet submission, including proposal amount/total consistency guards
- preserve #299's production ZEC-top-up disable gate and clearly labeled mock-only demo path

## Verification

- `git diff --check origin/main...HEAD`
- `npm run typecheck`
- `npm test` (101 tests passed)
- `npm run build`

Closes #260