### PR TITLE
fix(zuuli): disable fabricated ZEC top-up settlement

### DIFF
--- a/wallet/zuuli/src/features/buy/BuyTab.tsx
+++ b/wallet/zuuli/src/features/buy/BuyTab.tsx
@@ -35,6 +35,12 @@ import {
 } from "@/lib/format";
 import { BUY_PACKS, MAX_TUZIS, parseTuzis } from "./lib";
 import type { PricingQuote } from "@/lib/api/types";
+import { isTauri, useMock } from "@/lib/platform";
+import {
+  canRunZecTopUpDemo,
+  settleZecTopUpDemo,
+  type ZecTopUpDemoRuntime,
+} from "./zec-top-up-demo";
 
 /** Open an external URL, falling back to a browser tab outside Tauri. */
 async function open(url: string) {
@@ -54,6 +60,14 @@ type QuoteState =
 export function BuyTab() {
   const adjustTuzis = useSession((s) => s.adjustTuzis);
   const spendable = useWallet((s) => s.balance?.spendable ?? 0);
+  const zecDemoRuntime: ZecTopUpDemoRuntime = {
+    explicitMock: useMock(),
+    development: Boolean(
+      (import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV,
+    ),
+    tauri: isTauri(),
+  };
+  const zecDemoEnabled = canRunZecTopUpDemo(zecDemoRuntime);
 
   const [selected, setSelected] = useState<number>(BUY_PACKS[1]);
   const [custom, setCustom] = useState("");
@@ -75,7 +89,7 @@ export function BuyTab() {
   // `zec_amount`. A cancel flag keeps only the latest request's result, and a
   // 503 / fetch error surfaces as an "unavailable" state (no fabricated number).
   useEffect(() => {
-    if (!valid) {
+    if (!zecDemoEnabled || !valid) {
       setQuoteState({ status: "idle" });
       return;
     }
@@ -97,7 +111,7 @@ export function BuyTab() {
       ctrl.abort();
       clearTimeout(t);
     };
-  }, [amount, valid]);
+  }, [amount, valid, zecDemoEnabled]);
 
   const quote = quoteState.status === "ready" ? quoteState.quote : null;
   const zatoshisNeeded = quote
@@ -125,15 +139,12 @@ export function BuyTab() {
   }
 
   async function payWithZec() {
-    if (!valid || !quote || !enoughZec) return;
+    if (!zecDemoEnabled || !valid || !quote || !enoughZec) return;
     setZecLoading(true);
     try {
-      // Mock settlement — in production this proposes + broadcasts a shielded
-      // spend, then the backend credits the 2Zs on confirmation.
-      await new Promise((r) => setTimeout(r, 650));
-      adjustTuzis(amount);
-      toast.success(`Bought ${formatTuzis(amount)} with ZEC`, {
-        description: `${quote.zec_amount} ZEC debited from your wallet.`,
+      await settleZecTopUpDemo(zecDemoRuntime, amount, adjustTuzis);
+      toast.success(`Demo: added ${formatTuzis(amount)}`, {
+        description: "Local mock balance only. No ZEC was sent.",
       });
       setZecConfirm(false);
     } finally {
@@ -260,63 +271,79 @@ export function BuyTab() {
             size="lg"
             variant="zec"
             className="w-full"
-            disabled={!valid || !quote || !enoughZec || quoteLoading}
+            disabled={
+              !zecDemoEnabled ||
+              !valid ||
+              !quote ||
+              !enoughZec ||
+              quoteLoading
+            }
             onClick={() => setZecConfirm(true)}
           >
             <Wallet className="h-4 w-4" />
-            Pay with ZEC
+            {zecDemoEnabled ? "Demo: Pay with ZEC" : "Pay with ZEC unavailable"}
           </Button>
-          <div className="space-y-1 text-xs">
-            <div className="flex items-center justify-between text-muted-foreground">
-              <span className="flex items-center gap-1">
-                {isEstimate ? "Est. cost" : "Cost"}
-                {isEstimate && (
-                  <Badge variant="zec" className="px-1.5 py-0 text-[10px]">
-                    estimated
-                  </Badge>
+          {zecDemoEnabled ? (
+            <>
+              <div className="space-y-1 text-xs">
+                <div className="flex items-center justify-between text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    {isEstimate ? "Est. demo cost" : "Demo cost"}
+                    <Badge variant="zec" className="px-1.5 py-0 text-[10px]">
+                      demo only
+                    </Badge>
+                  </span>
+                  <span className="tabular-nums text-zec">
+                    {!valid
+                      ? "—"
+                      : quoteLoading
+                        ? "…"
+                        : quote
+                          ? `${quote.zec_amount} ZEC`
+                          : "—"}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-muted-foreground">
+                  <span>Mock wallet spendable</span>
+                  <span className="tabular-nums">
+                    {formatZecTrim(spendable)} ZEC
+                  </span>
+                </div>
+                {valid && quoteUnavailable && (
+                  <p className="pt-1 text-destructive">
+                    Demo pricing unavailable — try again.
+                  </p>
                 )}
-              </span>
-              <span className="tabular-nums text-zec">
-                {!valid
-                  ? "—"
-                  : quoteLoading
-                    ? "…"
-                    : quote
-                      ? `${quote.zec_amount} ZEC`
-                      : "—"}
-              </span>
-            </div>
-            <div className="flex items-center justify-between text-muted-foreground">
-              <span>Wallet spendable</span>
-              <span className="tabular-nums">
-                {formatZecTrim(spendable)} ZEC
-              </span>
-            </div>
-            {valid && quoteUnavailable && (
-              <p className="pt-1 text-destructive">
-                Live pricing unavailable — try again.
+                {valid && quote && !enoughZec && (
+                  <p className="pt-1 text-destructive">
+                    Not enough mock ZEC for this demo.
+                  </p>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Demo only: this changes a local mock 2Z balance. It does not send
+                ZEC or create a real purchase.
               </p>
-            )}
-            {valid && quote && !enoughZec && (
-              <p className="pt-1 text-destructive">
-                Not enough ZEC — top up your wallet or pay with card.
-              </p>
-            )}
-          </div>
-          <p className="text-xs text-muted-foreground">
-            No exchange, no leaving the app. Your wallet is right here — fund 2Zs
-            straight from your shielded balance.
-          </p>
+            </>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              ZEC top-ups are not available yet. No ZEC will be sent and no 2Z
+              balance will change. Pay with card for now.
+            </p>
+          )}
         </CardContent>
       </Card>
 
       {/* ZEC confirm */}
-      <Dialog open={zecConfirm} onOpenChange={(o) => !zecLoading && setZecConfirm(o)}>
+      <Dialog
+        open={zecDemoEnabled && zecConfirm}
+        onOpenChange={(o) => !zecLoading && setZecConfirm(o)}
+      >
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>Confirm ZEC payment</DialogTitle>
+            <DialogTitle>Confirm demo ZEC payment</DialogTitle>
             <DialogDescription>
-              Fund your 2Z balance directly from your shielded wallet.
+              Simulate funding a local mock 2Z balance. No ZEC will be sent.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3 rounded-lg border border-border bg-secondary/40 p-4 text-sm">
@@ -339,8 +366,7 @@ export function BuyTab() {
             />
           </div>
           <p className="text-xs text-muted-foreground">
-            The final ZEC amount is locked from a live quote at signing. This
-            demo settles instantly.
+            Demo only: no transaction is proposed, signed, broadcast, or settled.
           </p>
           <DialogFooter>
             <Button
@@ -352,7 +378,7 @@ export function BuyTab() {
             </Button>
             <Button variant="zec" onClick={payWithZec} disabled={zecLoading}>
               {zecLoading && <Loader2 className="h-4 w-4 animate-spin" />}
-              Confirm &amp; pay
+              Run demo purchase
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/wallet/zuuli/src/features/buy/zec-top-up-demo.test.ts
+++ b/wallet/zuuli/src/features/buy/zec-top-up-demo.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  canRunZecTopUpDemo,
+  settleZecTopUpDemo,
+  type ZecTopUpDemoRuntime,
+} from "./zec-top-up-demo";
+
+const MOCK_BROWSER_DEV: ZecTopUpDemoRuntime = {
+  explicitMock: true,
+  development: true,
+  tauri: false,
+};
+
+describe("ZEC top-up demo boundary", () => {
+  it.each([
+    ["real browser development", { ...MOCK_BROWSER_DEV, explicitMock: false }],
+    ["production browser", { ...MOCK_BROWSER_DEV, development: false }],
+    ["Tauri development", { ...MOCK_BROWSER_DEV, tauri: true }],
+    [
+      "production Tauri",
+      { ...MOCK_BROWSER_DEV, development: false, tauri: true },
+    ],
+  ])("cannot fabricate settlement in %s", async (_name, runtime) => {
+    const adjustTuzis = vi.fn();
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    expect(canRunZecTopUpDemo(runtime)).toBe(false);
+    await expect(
+      settleZecTopUpDemo(runtime, 1_000, adjustTuzis, wait),
+    ).rejects.toThrow(/unavailable/);
+    expect(wait).not.toHaveBeenCalled();
+    expect(adjustTuzis).not.toHaveBeenCalled();
+  });
+
+  it("allows an explicitly mocked browser development demo", async () => {
+    const adjustTuzis = vi.fn();
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    expect(canRunZecTopUpDemo(MOCK_BROWSER_DEV)).toBe(true);
+    await settleZecTopUpDemo(MOCK_BROWSER_DEV, 1_000, adjustTuzis, wait);
+
+    expect(wait).toHaveBeenCalledOnce();
+    expect(adjustTuzis).toHaveBeenCalledOnce();
+    expect(adjustTuzis).toHaveBeenCalledWith(1_000);
+  });
+});

--- a/wallet/zuuli/src/features/buy/zec-top-up-demo.ts
+++ b/wallet/zuuli/src/features/buy/zec-top-up-demo.ts
@@ -1,0 +1,32 @@
+export interface ZecTopUpDemoRuntime {
+  explicitMock: boolean;
+  development: boolean;
+  tauri: boolean;
+}
+
+/**
+ * The local-only ZEC top-up simulation is a browser development aid, never a
+ * payment path. Requiring every condition keeps it out of production bundles'
+ * behavior and out of Tauri even when somebody accidentally sets VITE_MOCK=1.
+ */
+export function canRunZecTopUpDemo(runtime: ZecTopUpDemoRuntime): boolean {
+  return runtime.explicitMock && runtime.development && !runtime.tauri;
+}
+
+export async function settleZecTopUpDemo(
+  runtime: ZecTopUpDemoRuntime,
+  amount: number,
+  adjustTuzis: (delta: number) => void,
+  wait: () => Promise<void> = () =>
+    new Promise((resolve) => setTimeout(resolve, 650)),
+): Promise<void> {
+  if (!canRunZecTopUpDemo(runtime)) {
+    throw new Error("Mock ZEC top-up settlement is unavailable in this runtime.");
+  }
+  if (!Number.isSafeInteger(amount) || amount <= 0) {
+    throw new Error("Mock ZEC top-up amount must be a positive integer.");
+  }
+
+  await wait();
+  adjustTuzis(amount);
+}


### PR DESCRIPTION
## Summary

- disable the unfinished pay-with-ZEC action in every real, production, and Tauri runtime
- stop fetching or presenting simulated ZEC checkout details outside the explicit browser-development demo
- label every surviving mock interaction and success message as local-only, with no ZEC sent
- guard the local `adjustTuzis` simulation behind an explicit mock + development + non-Tauri runtime contract

## Safety boundary

The demo settlement rejects before its timer or balance mutation in real browser development, production browser, Tauri development, and production Tauri. Only a plain browser development session explicitly started with `VITE_MOCK=1` may run it.

## Verification

- `npm test` (24 tests)
- `npm run typecheck`
- `npm run build`
- `git diff --check origin/main...HEAD`

## Remaining work

This is only the immediate truthfulness/safety slice. Full pay-with-ZEC still depends on the backend settlement contract: propose/sign/broadcast a shielded spend, track confirmation idempotently across restart and timeout, reconcile authoritative ZEC and 2Z balances, and credit only after confirmed settlement.

Refs #155