### PR TITLE
fix(zuuli): persist exempt iOS encryption status

### DIFF
--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -1,12 +1,19 @@
 # Releasing ZUULI
 
 ZUULI ships from one reviewed commit under one immutable identity. The current
-identity is `0.1.0+6`: marketing version `0.1.0`, Apple build `6`, Android
-`versionCode` `6`, and package/bundle identifier `cash.free2z.zuuli`.
+identity is `0.1.0+7`: marketing version `0.1.0`, Apple build `7`, Android
+`versionCode` `7`, and package/bundle identifier `cash.free2z.zuuli`.
 
-`release.json` is the source of truth. `npm run release:verify` fails if the npm,
-Cargo, Tauri, generated Xcode, or generated Gradle representation disagrees.
-Never fix a release mismatch with Tauri's `--ignore-version-mismatches` switch.
+`release.json` schema v2 is the source of truth. It must remain valid UTF-8 and
+byte-canonical pretty-printed JSON; the verifier uses fatal UTF-8 decoding and
+compares the original bytes with the canonical serialization, rejecting invalid
+bytes plus duplicate or escaped property names before their last-value-wins
+semantics can hide ambiguity. `npm run
+release:verify` fails if the npm, Cargo, Tauri, generated Xcode, or generated
+Gradle representation disagrees. Never fix a release mismatch with Tauri's
+`--ignore-version-mismatches` switch. The same contract pins
+`iosUsesNonExemptEncryption` to `false`; verification requires both the source
+and generated iOS plists to carry the matching Boolean.
 
 The train pins Node `24.18.0`, Rust `1.88.0`, Java `21.0.12`, Xcode `26.6`,
 Android SDK/build tools `36`/`36.0.0`, Android NDK `27.0.12077973`, Gradle
@@ -62,8 +69,10 @@ repeat bootstrap work or substitute unrelated credentials.
    Distribution certificate, and profile `ZUULI App Store CI`. CI verifies the
    profile's team, application identifier, UUID, and certificate linkage before
    it signs.
-4. Add internal TestFlight testers and complete the export-compliance/beta
-   metadata prompts after Apple processes the first upload.
+4. Add internal TestFlight testers and complete the beta metadata after Apple
+   processes the first upload. The exempt-encryption declaration described below
+   is embedded in each package; do not answer the same question differently in
+   App Store Connect.
 
 ### Google Play (Corpora)
 
@@ -117,7 +126,9 @@ Primary references:
 Credentials are paths or environment values; never paste a private key, service
 account document, seed phrase, or password into a command line. Disable shell
 tracing (`set +x`) before loading them. The scripts reject symlink credential
-paths, a partial Android signing setup, and dirty source trees.
+paths, a partial Android signing setup, and dirty source trees. Python 3 is a
+release prerequisite: the standard-library plist verifier preserves duplicate
+evidence that Apple's semantic plist tools discard.
 
 Apple variables:
 
@@ -143,10 +154,15 @@ signing key that Tauri updates in a validated generated-project shape, then
 restores the
 committed Automatic-debug project byte-for-byte after the build. The resulting
 IPA is unpacked and its exact embedded profile, distribution signature,
-certificate linkage, and signed entitlements are verified before Apple
-validation or upload. The workflow then restores the original keychain search
-list and fails if the keychain, installed profile, or credential directory
-survives cleanup.
+certificate linkage, signed entitlements, and packaged encryption declaration
+are verified before Apple validation or upload. The plist verifier rejects
+duplicate root keys before semantic decoding: it walks XML dictionary entries
+directly and, for binary plists, inspects the raw object table and dictionary key
+references. This matters because `plutil` and ordinary plist decoders collapse
+duplicate keys and can disagree about which value wins. Both same-value and
+conflicting duplicates are invalid; no binary duplicate ambiguity is accepted.
+The workflow then restores the original keychain search list and fails if the
+keychain, installed profile, or credential directory survives cleanup.
 
 The implicit-format import regression is reported upstream as
 [`tauri-apps/tauri#15843`](https://github.com/tauri-apps/tauri/issues/15843).
@@ -211,7 +227,7 @@ must both be confirmed:
 
 ```bash
 export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
-export ZUULI_CONFIRM_UPLOAD=0.1.0+6
+export ZUULI_CONFIRM_UPLOAD=0.1.0+7
 scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
 ```
@@ -287,6 +303,11 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    Build `0.1.0+6` keeps the Rust archive as a link-only input, removes it from
    Copy Bundle Resources, and makes both the generated-project contract and IPA
    verifier reject a future static-archive regression before Apple validation.
+   It uploaded and processed successfully; App Store Connect initially marked it
+   `MISSING_EXPORT_COMPLIANCE`, then moved it to `IN_BETA_TESTING` after the
+   build-specific `usesNonExemptEncryption=false` answer. Build `0.1.0+7`
+   persists that answer in the canonical and packaged iOS plists and makes the
+   release contract, normalizer, and IPA inspection fail closed on drift.
 4. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
    attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
    protected release** with the exact full SHA, identity, missing target, and
@@ -341,9 +362,25 @@ fix.
 
 ## Release records for cryptography
 
-ZUULI contains cryptography. Store export-compliance checkboxes are declarations,
-not an export classification. This does not block internal TestFlight or Play
-testing. Before public production distribution, Corpora should retain a concise
+ZUULI contains cryptography; `ITSAppUsesNonExemptEncryption=false` means the app
+uses only encryption exempt from Apple's documentation requirement, not that the
+app uses no cryptography. The recorded basis for the current App Store answer is
+that ZUULI's non-OS cryptography uses published, non-proprietary algorithms and
+is limited to its Zcash wallet and financial-transaction functionality. Build 6
+proved this answer through App Store Connect, and Build 7 makes it package data.
+
+Apple directs apps that use no encryption *or only exempt encryption* to set the
+Boolean to `NO`; omitting the key causes the export-compliance questions to recur
+for each upload. Apple also says the developer remains responsible for the
+classification and may have separate reporting obligations. See Apple's
+[`ITSAppUsesNonExemptEncryption` property-list reference](https://developer.apple.com/documentation/bundleresources/information-property-list/itsappusesnonexemptencryption),
+[`Overview of export compliance`](https://developer.apple.com/help/app-store-connect/manage-app-information/overview-of-export-compliance),
+and [`Complying with Encryption Export Regulations`](https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations).
+
+Re-evaluate this declaration before shipping any proprietary or non-standard
+cryptography, or any material change to how encryption is used. Store
+export-compliance checkboxes are declarations, not an export classification.
+Before public production distribution, Corpora should retain a concise
 export-classification memo covering the applicable EAR, encryption, and
 mass-market analysis. Record the conclusion and supporting facts without
 asserting a specific ECCN in this runbook.

--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -1,9 +1,10 @@
 {
   "$schema": "./release.schema.json",
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "applicationId": "cash.free2z.zuuli",
+  "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 6,
+  "build": 7,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/release.schema.json
+++ b/wallet/zuuli/release.schema.json
@@ -1,20 +1,22 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://free2z.com/schemas/zuuli-release-v1.json",
+  "$id": "https://free2z.com/schemas/zuuli-release-v2.json",
   "title": "ZUULI release identity",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "schemaVersion",
     "applicationId",
+    "iosUsesNonExemptEncryption",
     "version",
     "build",
     "minimums"
   ],
   "properties": {
     "$schema": { "type": "string" },
-    "schemaVersion": { "const": 1 },
+    "schemaVersion": { "const": 2 },
     "applicationId": { "const": "cash.free2z.zuuli" },
+    "iosUsesNonExemptEncryption": { "const": false },
     "version": {
       "type": "string",
       "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"

--- a/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
+++ b/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
@@ -10,6 +10,10 @@ const profileUuid = "e5ead62c-83ec-4e54-abb6-4770833b5e0d";
 const profileName = "ZUULI App Store CI";
 const distributionIdentity = `Apple Distribution: Corpora Inc (${teamId})`;
 const appBundleSetting = "PRODUCT_BUNDLE_IDENTIFIER = cash.free2z.zuuli;";
+const exemptEncryptionDeclaration = [
+  "\t<key>ITSAppUsesNonExemptEncryption</key>",
+  "\t<false/>",
+].join("\n");
 const canonicalUrlType = [
   "\t<key>CFBundleURLTypes</key>",
   "\t<array>",
@@ -241,6 +245,19 @@ function normalizePlist(contents, label) {
 
 function normalizeInfoPlist(contents, label) {
   const normalized = normalizePlist(contents, label);
+  const encryptionKeyCount = occurrenceCount(
+    normalized,
+    "<key>ITSAppUsesNonExemptEncryption</key>",
+  );
+  const exemptDeclarationCount = occurrenceCount(
+    normalized,
+    exemptEncryptionDeclaration,
+  );
+  if (encryptionKeyCount !== 1 || exemptDeclarationCount !== 1) {
+    throw new Error(
+      `refusing to normalize ${label}: expected exactly one canonical exempt-encryption declaration, found ${encryptionKeyCount} keys and ${exemptDeclarationCount} false declarations`,
+    );
+  }
   const canonicalCount = occurrenceCount(normalized, canonicalUrlType);
   const reversedCount = occurrenceCount(normalized, reversedUrlType);
   if (canonicalCount + reversedCount !== 1) {
@@ -282,8 +299,8 @@ function selfTest() {
   ) {
     throw new Error("iOS plist normalization self-test failed");
   }
-  const canonicalFixture = `<plist><dict>\n${canonicalUrlType}\n</dict></plist>`;
-  const reversedFixture = `<plist><dict>\n${reversedUrlType}\n</dict></plist>`;
+  const canonicalFixture = `<plist><dict>\n${canonicalUrlType}\n${exemptEncryptionDeclaration}\n</dict></plist>`;
+  const reversedFixture = `<plist><dict>\n${reversedUrlType}\n${exemptEncryptionDeclaration}\n</dict></plist>`;
   if (
     normalizeInfoPlist(canonicalFixture, "canonical fixture") !==
       `${canonicalFixture}\n` ||
@@ -294,12 +311,33 @@ function selfTest() {
   }
   let rejectedUnknownUrlShape = false;
   try {
-    normalizeInfoPlist("<plist><dict/></plist>", "unknown fixture");
-  } catch {
-    rejectedUnknownUrlShape = true;
+    normalizeInfoPlist(
+      `<plist><dict>\n${exemptEncryptionDeclaration}\n</dict></plist>`,
+      "unknown fixture",
+    );
+  } catch (error) {
+    rejectedUnknownUrlShape =
+      error instanceof Error &&
+      error.message.includes("expected exactly one known ZUULI URL type");
   }
   if (!rejectedUnknownUrlShape) {
     throw new Error("iOS URL type normalization accepted an unknown shape");
+  }
+  let rejectedNonExemptEncryption = false;
+  try {
+    normalizeInfoPlist(
+      canonicalFixture.replace("\t<false/>", "\t<true/>"),
+      "non-exempt encryption fixture",
+    );
+  } catch (error) {
+    rejectedNonExemptEncryption =
+      error instanceof Error &&
+      error.message.includes(
+        "expected exactly one canonical exempt-encryption declaration",
+      );
+  }
+  if (!rejectedNonExemptEncryption) {
+    throw new Error("iOS plist normalization accepted non-exempt encryption");
   }
   const infoPlistPath = resolve(
     appDir,

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -3,13 +3,129 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { TextDecoder } from "node:util";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const read = (path) => readFileSync(resolve(root, path), "utf8");
 const json = (path) => JSON.parse(read(path));
-const release = json("release.json");
 const failures = [];
+const releaseBytes = readFileSync(resolve(root, "release.json"));
+
+function releaseEncryptionKeyCount(contents) {
+  return (
+    contents.match(/"iosUsesNonExemptEncryption"\s*:/g) ?? []
+  ).length;
+}
+
+function validateReleaseEncryptionKeyCount(contents, label, target) {
+  const count = releaseEncryptionKeyCount(contents);
+  if (count !== 1)
+    target.push(
+      `${label} must contain exactly one raw iosUsesNonExemptEncryption key, found ${count}`,
+    );
+}
+
+function parseCanonicalRelease(bytes, label, target) {
+  let contents;
+  try {
+    contents = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    target.push(`${label} must contain valid UTF-8`);
+    return undefined;
+  }
+  validateReleaseEncryptionKeyCount(contents, label, target);
+  let parsed;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    target.push(`${label} must contain valid JSON`);
+    return undefined;
+  }
+  if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+    target.push(`${label} root must be a JSON object`);
+    return undefined;
+  }
+  const canonicalBytes = Buffer.from(`${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+  if (!bytes.equals(canonicalBytes))
+    target.push(
+      `${label} bytes must be canonical UTF-8 JSON without duplicate or escaped property names`,
+    );
+  return parsed;
+}
+
+for (const [label, fixture, expectedRawFailures] of [
+  [
+    "same-value literal duplicate",
+    '{\n  "iosUsesNonExemptEncryption": false,\n  "iosUsesNonExemptEncryption": false\n}\n',
+    1,
+  ],
+  [
+    "conflicting literal duplicate",
+    '{\n  "iosUsesNonExemptEncryption": true,\n  "iosUsesNonExemptEncryption": false\n}\n',
+    1,
+  ],
+  [
+    "same-value escaped duplicate",
+    `${String.raw`{
+  "iosUsesNonExemptEncryption": false,
+  "iosUsesNonExemptEncrypt\u0069on": false
+}`}\n`,
+    0,
+  ],
+  [
+    "conflicting escaped duplicate",
+    `${String.raw`{
+  "iosUsesNonExemptEncryption": true,
+  "iosUsesNonExemptEncrypt\u0069on": false
+}`}\n`,
+    0,
+  ],
+]) {
+  const fixtureFailures = [];
+  const parsedFixture = parseCanonicalRelease(
+    Buffer.from(fixture, "utf8"),
+    label,
+    fixtureFailures,
+  );
+  const canonicalFailures = fixtureFailures.filter((failure) =>
+    failure.includes("bytes must be canonical UTF-8 JSON"),
+  );
+  const rawFailures = fixtureFailures.filter((failure) =>
+    failure.includes("must contain exactly one raw"),
+  );
+  if (
+    canonicalFailures.length !== 1 ||
+    rawFailures.length !== expectedRawFailures ||
+    parsedFixture.iosUsesNonExemptEncryption !== false
+  )
+    throw new Error(`release duplicate-key detector self-test failed: ${label}`);
+}
+
+const invalidUtf8Fixture = Buffer.concat([
+  Buffer.from('{\n  "iosUsesNonExemptEncryption": false,\n  "$schema": "', "utf8"),
+  Buffer.from([0xff]),
+  Buffer.from('"\n}\n', "utf8"),
+]);
+const invalidUtf8Failures = [];
+if (
+  parseCanonicalRelease(
+    invalidUtf8Fixture,
+    "invalid UTF-8 fixture",
+    invalidUtf8Failures,
+  ) !== undefined ||
+  invalidUtf8Failures.length !== 1 ||
+  invalidUtf8Failures[0] !== "invalid UTF-8 fixture must contain valid UTF-8"
+)
+  throw new Error("release invalid-UTF-8 detector self-test failed");
+
+const release = parseCanonicalRelease(releaseBytes, "release.json", failures);
+if (release === undefined) {
+  console.error(
+    "ZUULI release identity is inconsistent:\n- " + failures.join("\n- "),
+  );
+  process.exit(1);
+}
 
 function expect(label, actual, expected) {
   if (`${actual}` !== `${expected}`) {
@@ -32,8 +148,12 @@ function occurrenceCount(contents, value) {
   return contents.split(value).length - 1;
 }
 
-expect("release schema version", release.schemaVersion, 1);
+expect("release schema version", release.schemaVersion, 2);
 expect("release application ID", release.applicationId, "cash.free2z.zuuli");
+if (release.iosUsesNonExemptEncryption !== false)
+  failures.push(
+    "release iOS non-exempt encryption declaration must be Boolean false",
+  );
 expect("release minimum iOS", release.minimums?.ios, "18.0");
 expect("release minimum Android", release.minimums?.android, 29);
 
@@ -146,6 +266,17 @@ expect(
   "XcodeGen build",
   capture(/CFBundleVersion:\s*"?([^"\s]+)"?/, project, "XcodeGen build"),
   release.build,
+);
+expect(
+  "XcodeGen iOS non-exempt encryption key count",
+  (project.match(/^\s*ITSAppUsesNonExemptEncryption:/gm) ?? []).length,
+  1,
+);
+expect(
+  "XcodeGen iOS non-exempt encryption declaration count",
+  (project.match(/^\s*ITSAppUsesNonExemptEncryption:\s*false\s*$/gm) ?? [])
+    .length,
+  1,
 );
 expect(
   "XcodeGen Apple team",
@@ -269,6 +400,25 @@ for (const privacyKey of [
   );
   if (sourceValue !== undefined && generatedValue !== undefined)
     expect(`generated iOS ${privacyKey}`, generatedValue, sourceValue);
+}
+for (const [label, contents] of [
+  ["iOS source", plistSource],
+  ["generated iOS", plist],
+]) {
+  expect(
+    `${label} ITSAppUsesNonExemptEncryption key count`,
+    occurrenceCount(contents, "<key>ITSAppUsesNonExemptEncryption</key>"),
+    1,
+  );
+  expect(
+    `${label} ITSAppUsesNonExemptEncryption`,
+    capture(
+      /<key>ITSAppUsesNonExemptEncryption<\/key>\s*<(true|false)\s*\/>/,
+      contents,
+      `${label} ITSAppUsesNonExemptEncryption`,
+    ),
+    release.iosUsesNonExemptEncryption,
+  );
 }
 const callbackScheme = "cash.free2z.zuuli";
 if (
@@ -661,7 +811,7 @@ if (newerArg) {
         ),
       );
       if (
-        previous.schemaVersion !== 1 ||
+        ![1, 2].includes(previous.schemaVersion) ||
         previous.applicationId !== release.applicationId
       ) {
         failures.push(

--- a/wallet/zuuli/scripts/verify-ios-info-plist.py
+++ b/wallet/zuuli/scripts/verify-ios-info-plist.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Fail-closed verification for the packaged ZUULI Info.plist."""
+
+from __future__ import annotations
+
+from collections import Counter
+import plistlib
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ElementTree
+
+
+TARGET_KEY = "ITSAppUsesNonExemptEncryption"
+
+
+class VerificationError(Exception):
+    pass
+
+
+def _sized_count(data: bytes, position: int, short_count: int) -> tuple[int, int]:
+    if short_count < 0xF:
+        return short_count, position
+    if position >= len(data):
+        raise VerificationError("binary Info.plist has a truncated count")
+    marker = data[position]
+    if marker >> 4 != 0x1:
+        raise VerificationError("binary Info.plist uses an invalid count object")
+    byte_count = 1 << (marker & 0xF)
+    end = position + 1 + byte_count
+    if end > len(data):
+        raise VerificationError("binary Info.plist has a truncated count object")
+    return int.from_bytes(data[position + 1 : end], "big"), end
+
+
+def _binary_layout(data: bytes) -> tuple[list[int], int, int, int]:
+    if len(data) < 40 or not data.startswith(b"bplist00"):
+        raise VerificationError("Info.plist is not a supported binary plist")
+    trailer = data[-32:]
+    offset_size = trailer[6]
+    reference_size = trailer[7]
+    object_count = int.from_bytes(trailer[8:16], "big")
+    root_reference = int.from_bytes(trailer[16:24], "big")
+    offset_table = int.from_bytes(trailer[24:32], "big")
+    if (
+        offset_size < 1
+        or reference_size < 1
+        or object_count < 1
+        or root_reference >= object_count
+        or offset_table < 8
+        or offset_table + object_count * offset_size > len(data) - 32
+    ):
+        raise VerificationError("binary Info.plist trailer is invalid")
+    offsets = [
+        int.from_bytes(
+            data[
+                offset_table + index * offset_size :
+                offset_table + (index + 1) * offset_size
+            ],
+            "big",
+        )
+        for index in range(object_count)
+    ]
+    if any(offset < 8 or offset >= offset_table for offset in offsets):
+        raise VerificationError("binary Info.plist object offset is invalid")
+    return offsets, root_reference, reference_size, offset_table
+
+
+def _binary_string(
+    data: bytes, offsets: list[int], reference: int, object_table_end: int
+) -> str:
+    if reference >= len(offsets):
+        raise VerificationError("binary Info.plist key reference is invalid")
+    position = offsets[reference]
+    marker = data[position]
+    kind = marker >> 4
+    count, payload = _sized_count(data, position + 1, marker & 0xF)
+    if kind == 0x5:
+        end = payload + count
+        encoding = "ascii"
+    elif kind == 0x6:
+        end = payload + count * 2
+        encoding = "utf-16-be"
+    else:
+        raise VerificationError("binary Info.plist dictionary key is not a string")
+    if end > object_table_end:
+        raise VerificationError("binary Info.plist string is truncated")
+    try:
+        return data[payload:end].decode(encoding)
+    except UnicodeDecodeError as error:
+        raise VerificationError("binary Info.plist key is not decodable") from error
+
+
+def _binary_root_keys(data: bytes) -> tuple[list[str], int, int]:
+    offsets, root_reference, reference_size, offset_table = _binary_layout(data)
+    position = offsets[root_reference]
+    marker = data[position]
+    if marker >> 4 != 0xD:
+        raise VerificationError("binary Info.plist root is not a dictionary")
+    count, references = _sized_count(data, position + 1, marker & 0xF)
+    references_end = references + count * reference_size * 2
+    if references_end > offset_table:
+        raise VerificationError("binary Info.plist dictionary is truncated")
+    key_references = [
+        int.from_bytes(
+            data[
+                references + index * reference_size :
+                references + (index + 1) * reference_size
+            ],
+            "big",
+        )
+        for index in range(count)
+    ]
+    return (
+        [
+            _binary_string(data, offsets, reference, offset_table)
+            for reference in key_references
+        ],
+        references,
+        reference_size,
+    )
+
+
+def _xml_root_keys(data: bytes) -> list[str]:
+    try:
+        root = ElementTree.fromstring(data)
+    except ElementTree.ParseError as error:
+        raise VerificationError("XML Info.plist is malformed") from error
+    if root.tag != "plist" or len(root) != 1 or root[0].tag != "dict":
+        raise VerificationError("XML Info.plist root is not a dictionary")
+    entries = list(root[0])
+    if len(entries) % 2:
+        raise VerificationError("XML Info.plist dictionary has an unmatched key")
+    keys = []
+    for index in range(0, len(entries), 2):
+        if entries[index].tag != "key":
+            raise VerificationError("XML Info.plist dictionary key is malformed")
+        keys.append(entries[index].text or "")
+    return keys
+
+
+def verify_bytes(data: bytes) -> None:
+    if data.startswith(b"bplist00"):
+        keys, _, _ = _binary_root_keys(data)
+    elif data.lstrip().startswith((b"<?xml", b"<plist")):
+        keys = _xml_root_keys(data)
+    else:
+        raise VerificationError("Info.plist must use XML or binary plist format")
+
+    duplicates = sorted(key for key, count in Counter(keys).items() if count > 1)
+    if duplicates:
+        raise VerificationError(
+            "Info.plist root dictionary contains duplicate keys: "
+            + ", ".join(duplicates)
+        )
+    target_count = keys.count(TARGET_KEY)
+    if target_count != 1:
+        raise VerificationError(
+            f"Info.plist must contain exactly one raw {TARGET_KEY} key, found {target_count}"
+        )
+
+    try:
+        parsed = plistlib.loads(data)
+    except (plistlib.InvalidFileException, ValueError) as error:
+        raise VerificationError("Info.plist cannot be decoded semantically") from error
+    if not isinstance(parsed, dict):
+        raise VerificationError("Info.plist root is not a decoded dictionary")
+    value = parsed.get(TARGET_KEY)
+    if type(value) is not bool:
+        raise VerificationError(f"Info.plist {TARGET_KEY} must be a Boolean")
+    if value is not False:
+        raise VerificationError(f"Info.plist must declare {TARGET_KEY}=false")
+
+
+def _duplicate_binary_fixture(first_value: bool, second_value: bool) -> bytes:
+    data = bytearray(
+        plistlib.dumps(
+            {TARGET_KEY: first_value, "ZUULIDuplicateFixture": second_value},
+            fmt=plistlib.FMT_BINARY,
+            sort_keys=False,
+        )
+    )
+    keys, references, reference_size = _binary_root_keys(bytes(data))
+    if keys != [TARGET_KEY, "ZUULIDuplicateFixture"]:
+        raise AssertionError("binary duplicate fixture has unexpected key order")
+    first = data[references : references + reference_size]
+    data[references + reference_size : references + reference_size * 2] = first
+    return bytes(data)
+
+
+def _expect_rejected(data: bytes, reason: str, label: str) -> None:
+    try:
+        verify_bytes(data)
+    except VerificationError as error:
+        if reason not in str(error):
+            raise AssertionError(f"{label} failed for the wrong reason: {error}") from error
+    else:
+        raise AssertionError(f"{label} unexpectedly passed")
+
+
+def self_test() -> None:
+    valid = {TARGET_KEY: False, "CFBundleIdentifier": "cash.free2z.zuuli"}
+    verify_bytes(plistlib.dumps(valid, fmt=plistlib.FMT_XML, sort_keys=False))
+    verify_bytes(plistlib.dumps(valid, fmt=plistlib.FMT_BINARY, sort_keys=False))
+
+    same_xml = (
+        b'<plist version="1.0"><dict><key>'
+        + TARGET_KEY.encode()
+        + b"</key><false/><key>"
+        + TARGET_KEY.encode()
+        + b"</key><false/></dict></plist>"
+    )
+    conflicting_xml = same_xml.replace(b"<false/>", b"<true/>", 1)
+    _expect_rejected(same_xml, "duplicate keys", "same-value XML duplicate")
+    _expect_rejected(conflicting_xml, "duplicate keys", "conflicting XML duplicate")
+
+    same_binary = _duplicate_binary_fixture(False, False)
+    conflicting_binary = _duplicate_binary_fixture(True, False)
+    if plistlib.loads(conflicting_binary).get(TARGET_KEY) is not False:
+        raise AssertionError("binary conflict fixture does not demonstrate last-value masking")
+    _expect_rejected(same_binary, "duplicate keys", "same-value binary duplicate")
+    _expect_rejected(
+        conflicting_binary, "duplicate keys", "conflicting binary duplicate"
+    )
+
+
+def main() -> int:
+    if sys.argv[1:] == ["--self-test"]:
+        self_test()
+        return 0
+    if len(sys.argv) != 2:
+        print("usage: verify-ios-info-plist.py <Info.plist>", file=sys.stderr)
+        return 64
+    try:
+        verify_bytes(Path(sys.argv[1]).read_bytes())
+    except (OSError, VerificationError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/wallet/zuuli/scripts/verify-ios-ipa.sh
+++ b/wallet/zuuli/scripts/verify-ios-ipa.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 umask 077
 
-script_path=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")
+script_directory=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+script_path="$script_directory/$(basename -- "$0")"
+plist_verifier="$script_directory/verify-ios-info-plist.py"
 
 fail() {
   echo "iOS IPA verification failed: $*" >&2
@@ -27,6 +29,16 @@ is_allowed_bundle_binary() {
   return 1
 }
 
+verify_export_compliance() {
+  local app=$1 info_plist output
+  info_plist="$app/Info.plist"
+  [[ -f "$info_plist" && ! -L "$info_plist" ]] ||
+    fail "app bundle Info.plist is not a regular file"
+  command -v python3 >/dev/null 2>&1 ||
+    fail "python3 is required for duplicate-safe app bundle plist verification"
+  output=$(python3 "$plist_verifier" "$info_plist" 2>&1) || fail "$output"
+}
+
 verify_app_structure() {
   local app=$1 bundle_entry bundle_file relative file_kind main_kind
   [[ -d "$app" && ! -L "$app" ]] || fail "app bundle is not a regular directory"
@@ -35,6 +47,7 @@ verify_app_structure() {
   main_kind=$(/usr/bin/file -b "$app/ZUULI") ||
     fail "unable to inspect app bundle main executable"
   [[ "$main_kind" == *Mach-O* ]] || fail "app bundle main executable is not Mach-O"
+  verify_export_compliance "$app"
   while IFS= read -r -d '' bundle_entry; do
     relative=${bundle_entry#"$app/"}
     if [[ -L "$bundle_entry" || (! -d "$bundle_entry" && ! -f "$bundle_entry") ]]; then
@@ -59,11 +72,14 @@ verify_app_structure() {
 
 self_test() (
   local fixture_app fixture_dir fixture_ipa output
+  python3 "$plist_verifier" --self-test ||
+    fail "Info.plist duplicate-policy self-test failed"
   fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-ipa-self-test.XXXXXX")
   trap 'cleanup_directory "$fixture_dir"' EXIT
   fixture_app="$fixture_dir/root/Payload/ZUULI.app"
   mkdir -p "$fixture_app"
   printf '\317\372\355\376\014\000\000\001' > "$fixture_app/ZUULI"
+  printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>' '<plist version="1.0"><dict><key>ITSAppUsesNonExemptEncryption</key><false/></dict></plist>' > "$fixture_app/Info.plist"
   printf 'fixture\n' > "$fixture_dir/expected.mobileprovision"
   fixture_ipa="$fixture_dir/missing-profile.ipa"
   (cd "$fixture_dir/root" && zip -qry "$fixture_ipa" Payload)
@@ -123,10 +139,52 @@ self_test() (
   fi
   grep -Fq 'app bundle contains a non-regular entry: linked-binary' <<<"$output" ||
     fail "symlink self-test failed for the wrong reason: $output"
+
+  rm "$fixture_app/linked-binary" "$fixture_app/Info.plist"
+  if output=$("$script_path" --verify-app-structure "$fixture_app" 2>&1); then
+    fail "missing export-compliance declaration self-test unexpectedly passed"
+  fi
+  grep -Fq 'app bundle Info.plist is not a regular file' <<<"$output" ||
+    fail "missing export-compliance declaration self-test failed for the wrong reason: $output"
+
+  printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>' '<plist version="1.0"><dict/></plist>' > "$fixture_app/Info.plist"
+  if output=$("$script_path" --verify-app-structure "$fixture_app" 2>&1); then
+    fail "missing export-compliance key self-test unexpectedly passed"
+  fi
+  grep -Fq 'Info.plist must contain exactly one raw ITSAppUsesNonExemptEncryption key, found 0' <<<"$output" ||
+    fail "missing export-compliance key self-test failed for the wrong reason: $output"
+
+  printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>' '<plist version="1.0"><dict><key>ITSAppUsesNonExemptEncryption</key><string>false</string></dict></plist>' > "$fixture_app/Info.plist"
+  if output=$("$script_path" --verify-app-structure "$fixture_app" 2>&1); then
+    fail "string export-compliance declaration self-test unexpectedly passed"
+  fi
+  grep -Fq 'Info.plist ITSAppUsesNonExemptEncryption must be a Boolean' <<<"$output" ||
+    fail "string export-compliance declaration self-test failed for the wrong reason: $output"
+
+  printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>' '<plist version="1.0"><dict><key>ITSAppUsesNonExemptEncryption</key><true/></dict></plist>' > "$fixture_app/Info.plist"
+  if output=$("$script_path" --verify-app-structure "$fixture_app" 2>&1); then
+    fail "non-exempt encryption declaration self-test unexpectedly passed"
+  fi
+  grep -Fq 'Info.plist must declare ITSAppUsesNonExemptEncryption=false' <<<"$output" ||
+    fail "non-exempt encryption declaration self-test failed for the wrong reason: $output"
+
+  printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>' '<plist version="1.0"><dict><key>ITSAppUsesNonExemptEncryption</key><false/><key>ITSAppUsesNonExemptEncryption</key><false/></dict></plist>' > "$fixture_app/Info.plist"
+  if output=$("$script_path" --verify-app-structure "$fixture_app" 2>&1); then
+    fail "same-value duplicate export-compliance declaration unexpectedly passed"
+  fi
+  grep -Fq 'Info.plist root dictionary contains duplicate keys: ITSAppUsesNonExemptEncryption' <<<"$output" ||
+    fail "same-value duplicate export-compliance declaration failed for the wrong reason: $output"
+
+  printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>' '<plist version="1.0"><dict><key>ITSAppUsesNonExemptEncryption</key><true/><key>ITSAppUsesNonExemptEncryption</key><false/></dict></plist>' > "$fixture_app/Info.plist"
+  if output=$("$script_path" --verify-app-structure "$fixture_app" 2>&1); then
+    fail "conflicting duplicate export-compliance declaration unexpectedly passed"
+  fi
+  grep -Fq 'Info.plist root dictionary contains duplicate keys: ITSAppUsesNonExemptEncryption' <<<"$output" ||
+    fail "conflicting duplicate export-compliance declaration failed for the wrong reason: $output"
 )
 
 darwin_self_test() (
-  local fixture_dir certificate_prefix entitlements extracted_team
+  local fixture_dir fixture_app certificate_prefix entitlements extracted_team output
   [[ "$(uname -s)" == Darwin ]] || fail "--self-test-darwin requires macOS"
   fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-ipa-darwin-self-test.XXXXXX")
   trap 'cleanup_directory "$fixture_dir"' EXIT
@@ -143,6 +201,35 @@ darwin_self_test() (
   extracted_team=$(plutil -extract 'com\.apple\.developer\.team-identifier' raw -o - "$entitlements")
   [[ "$extracted_team" == F9AV5HKF6N ]] ||
     fail "Darwin self-test could not extract the dotted entitlement key"
+
+  fixture_app="$fixture_dir/ZUULI.app"
+  mkdir "$fixture_app"
+  printf '\317\372\355\376\014\000\000\001' > "$fixture_app/ZUULI"
+  plutil -create xml1 "$fixture_app/Info.plist"
+  plutil -insert ITSAppUsesNonExemptEncryption -bool NO "$fixture_app/Info.plist"
+  "$script_path" --verify-app-structure "$fixture_app" ||
+    fail "Darwin Boolean export-compliance fixture unexpectedly failed"
+  plutil -convert binary1 "$fixture_app/Info.plist"
+  "$script_path" --verify-app-structure "$fixture_app" ||
+    fail "Darwin binary-plist export-compliance fixture unexpectedly failed"
+  plutil -replace ITSAppUsesNonExemptEncryption -string false "$fixture_app/Info.plist"
+  if output=$("$script_path" --verify-app-structure "$fixture_app" 2>&1); then
+    fail "Darwin string export-compliance fixture unexpectedly passed"
+  fi
+  grep -Fq 'Info.plist ITSAppUsesNonExemptEncryption must be a Boolean' <<<"$output" ||
+    fail "Darwin string export-compliance fixture failed for the wrong reason: $output"
+  plutil -replace ITSAppUsesNonExemptEncryption -bool YES "$fixture_app/Info.plist"
+  if output=$("$script_path" --verify-app-structure "$fixture_app" 2>&1); then
+    fail "Darwin non-exempt encryption fixture unexpectedly passed"
+  fi
+  grep -Fq 'Info.plist must declare ITSAppUsesNonExemptEncryption=false' <<<"$output" ||
+    fail "Darwin non-exempt encryption fixture failed for the wrong reason: $output"
+  plutil -remove ITSAppUsesNonExemptEncryption "$fixture_app/Info.plist"
+  if output=$("$script_path" --verify-app-structure "$fixture_app" 2>&1); then
+    fail "Darwin missing export-compliance key fixture unexpectedly passed"
+  fi
+  grep -Fq 'Info.plist must contain exactly one raw ITSAppUsesNonExemptEncryption key, found 0' <<<"$output" ||
+    fail "Darwin missing export-compliance key fixture failed for the wrong reason: $output"
 )
 
 if [[ "${1:-}" == --self-test ]]; then

--- a/wallet/zuuli/src-tauri/Info.ios.plist
+++ b/wallet/zuuli/src-tauri/Info.ios.plist
@@ -19,5 +19,7 @@
       </array>
     </dict>
   </array>
+  <key>ITSAppUsesNonExemptEncryption</key>
+  <false/>
 </dict>
 </plist>

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "6").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "7").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -52,6 +52,7 @@ targets:
           - CFBundleURLName: cash.free2z.zuuli
             CFBundleURLSchemes:
               - cash.free2z.zuuli
+        ITSAppUsesNonExemptEncryption: false
         LSRequiresIPhoneOS: true
         NSCameraUsageDescription: ZUULI uses the camera when you broadcast or join a live video stream.
         NSMicrophoneUsageDescription: ZUULI uses the microphone when you broadcast or join a live stream.
@@ -68,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "6"
+        CFBundleVersion: "7"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
@@ -59,5 +59,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -28,14 +28,14 @@
     "targets": "all",
     "icon": ["icons/icon.png"],
     "iOS": {
-      "bundleVersion": "6",
+      "bundleVersion": "7",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 6
+      "versionCode": 7
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

- persist `ITSAppUsesNonExemptEncryption=false` in ZUULI's canonical iOS plist, committed generated plist, and XcodeGen input
- evolve the release identity contract to schema v2 and fail closed on missing, duplicate, string, or `true` declarations
- inspect the packaged `Info.plist` in both unsigned-app and signed-IPA verification, including XML/binary and macOS/Linux reader tests
- document the exempt-encryption rationale and official Apple guidance
- advance the coordinated append-only mobile identity from `0.1.0+6` to `0.1.0+7`

## Verification

Exact reviewed head: `586ee26642fbc9dae61ce9fce97ce28b0d9ec585`, based on `dd65b72124a4b86963975fb221ee95e19fdf31ea`.

- `npm ci`
- `npm run release:verify` → `0.1.0+7`
- `node scripts/normalize-generated-ios-project.mjs --self-test`
- `bash scripts/verify-ios-ipa.sh --self-test`
- `bash scripts/verify-ios-ipa.sh --self-test-darwin`
- `plutil -lint` and type-strict Boolean extraction for both source/generated plists
- XcodeGen regeneration returns generated iOS files to identical hashes
- `agvtool new-version -all 7` plus normalization returns the tracked project/plists to identical hashes
- `npm run typecheck`
- `npm run build`
- `npm test -- --reporter=dot` → 3 files, 25 tests passed
- `git diff --check origin/main...HEAD`

Independent Claude CLI adversarial review ran read-only against the exact head after the final rebase. It mutation-tested declarations at every layer, schema-v1 predecessor compatibility and build monotonicity, macOS/Linux plist readers, XML/binary fixtures, both package paths, and rebase fidelity. Final verdict: **APPROVED — no blocking or non-blocking findings**.

No files from #273's application-data migration or #299's ZEC top-up surfaces are touched.

Closes #292
