### PR TITLE
fix(zuuli): require resolved 2Z recipients

### DIFF
--- a/wallet/zuuli/src/features/buy/SendTab.tsx
+++ b/wallet/zuuli/src/features/buy/SendTab.tsx
@@ -1,5 +1,20 @@
-import { useEffect, useState } from "react";
-import { Gift, Loader2, Search, ArrowRight } from "lucide-react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import {
+  AlertCircle,
+  ArrowRight,
+  CheckCircle2,
+  Gift,
+  Loader2,
+  Search,
+} from "lucide-react";
 import { toast } from "sonner";
 import {
   Card,
@@ -12,8 +27,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Skeleton } from "@/components/ui/skeleton";
 import { discover, tuzi } from "@/lib/api/free2z";
+import {
+  authoritativeBalanceFromErrorBody,
+  type DonationResult,
+} from "@/lib/api/donation";
+import { setToken } from "@/lib/api/http";
 import type { SimpleCreator } from "@/lib/api/types";
 import { useSession } from "@/store/session";
 import { cn } from "@/lib/utils";
@@ -25,50 +44,332 @@ import {
   validateTuzis,
 } from "@/lib/format";
 import { TIP_PRESETS } from "./lib";
+import {
+  classifyTransferFailure,
+  clearPendingDonation,
+  createDonationIdempotencyKey,
+  initialRecipientState,
+  loadPendingDonation,
+  pendingDonationMatches,
+  persistPendingDonation,
+  recipientKeyAction,
+  recipientReducer,
+  reviewMatchesTransfer,
+  sameUsername,
+  shouldSearchRecipients,
+  transferBlock,
+  transferFailureIsAmbiguous,
+  TRANSFER_FAILURE_MESSAGES,
+  type TransferFailure,
+  type TransferReview,
+} from "./send-recipient";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+function useDebounced<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebounced(value), delay);
+    return () => window.clearTimeout(timer);
+  }, [value, delay]);
+  return debounced;
+}
 
 export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
+  const user = useSession((s) => s.user);
   const tuzis = useSession((s) => s.tuzis);
-  const adjustTuzis = useSession((s) => s.adjustTuzis);
-
-  const [creators, setCreators] = useState<SimpleCreator[] | null>(null);
-  const [username, setUsername] = useState("");
-  const [selected, setSelected] = useState<number>(TIP_PRESETS[1]);
+  const setTuzis = useSession((s) => s.setTuzis);
+  const setUser = useSession((s) => s.setUser);
+  const refreshSession = useSession((s) => s.refresh);
+  const [recipientState, dispatch] = useReducer(
+    recipientReducer,
+    initialRecipientState,
+  );
+  const [selectedAmount, setSelectedAmount] = useState<number>(TIP_PRESETS[1]);
   const [custom, setCustom] = useState("");
   const [sending, setSending] = useState(false);
+  const sendingRef = useRef(false);
+  const [transferFailure, setTransferFailure] =
+    useState<TransferFailure | null>(null);
+  const [completedTransfer, setCompletedTransfer] = useState<{
+    review: TransferReview;
+    result: DonationResult;
+  } | null>(null);
+  const resultsId = useId();
+  const debouncedQuery = useDebounced(
+    recipientState.query.trim(),
+    SEARCH_DEBOUNCE_MS,
+  );
+  const currentQuery = recipientState.query.trim();
+  const debouncedQueryIsCurrent = debouncedQuery === currentQuery;
+
+  const ownUsername = user?.username;
+  const exactSelfQuery = Boolean(
+    ownUsername && currentQuery && sameUsername(currentQuery, ownUsername),
+  );
 
   useEffect(() => {
+    if (
+      !shouldSearchRecipients({
+        currentQuery,
+        debouncedQuery,
+        selected: recipientState.selected,
+        isSelf: exactSelfQuery,
+      })
+    ) {
+      return;
+    }
+
+    const generation = recipientState.generation;
     let alive = true;
+    dispatch({ type: "searchStarted", generation });
     discover
-      .creators()
-      .then((c) => alive && setCreators(c))
-      .catch(() => alive && setCreators([]));
+      .searchCreators(debouncedQuery)
+      .then((creators) => {
+        if (!alive) return;
+        const candidates = ownUsername
+          ? creators.filter((creator) =>
+              !sameUsername(creator.username, ownUsername),
+            )
+          : creators;
+        dispatch({ type: "searchSucceeded", generation, results: candidates });
+      })
+      .catch(() => {
+        if (alive) dispatch({ type: "searchFailed", generation });
+      });
+
     return () => {
       alive = false;
     };
-  }, []);
+  }, [
+    debouncedQuery,
+    debouncedQueryIsCurrent,
+    currentQuery,
+    exactSelfQuery,
+    ownUsername,
+    recipientState.generation,
+    recipientState.selected,
+  ]);
 
   const hasCustomAmount = custom.length > 0;
   const customAmount = validateTuzis(custom, { minimum: 1, maximum: MAX_TUZIS });
-  const amount = hasCustomAmount ? customAmount.value : selected;
-  const recipient = username.trim();
+  const amount = hasCustomAmount ? customAmount.value : selectedAmount;
   const validAmount = !hasCustomAmount || customAmount.error === null;
   const enough = amount !== null && amount <= tuzis;
-  const canSend = validAmount && recipient.length > 0 && enough && !sending;
+  const block = transferBlock({
+    selected: recipientState.selected,
+    query: recipientState.query,
+    ownUsername,
+    amount,
+    validAmount,
+    balance: tuzis,
+    sending,
+  });
+  const pendingDonation = loadPendingDonation();
+  const pendingMatchesCurrent = Boolean(
+    pendingDonation &&
+      recipientState.selected &&
+      ownUsername &&
+      amount !== null &&
+      validAmount &&
+      pendingDonationMatches(pendingDonation, {
+        senderUsername: ownUsername,
+        recipient: recipientState.selected,
+        amount,
+      }),
+  );
+  const canReview =
+    block === null || (block === "balance" && pendingMatchesCurrent);
+  const reviewHasPersistedAttempt = Boolean(
+    recipientState.review &&
+      pendingDonation &&
+      recipientState.review.idempotencyKey === pendingDonation.idempotencyKey &&
+      pendingDonationMatches(pendingDonation, recipientState.review),
+  );
+  const reviewIsCurrent = reviewMatchesTransfer({
+    review: recipientState.review,
+    selected: recipientState.selected,
+    query: recipientState.query,
+    ownUsername,
+    amount,
+    validAmount,
+    balance: reviewHasPersistedAttempt ? Number.MAX_SAFE_INTEGER : tuzis,
+  });
+  const transferLocked = Boolean(
+    transferFailure && transferFailureIsAmbiguous(transferFailure),
+  );
+  const flowLocked = transferLocked || completedTransfer !== null;
+  const transferCanRetry =
+    transferFailure === "network" || transferFailure === "pending";
+  const showingResults =
+    !recipientState.selected &&
+    (recipientState.searchStatus === "loading" ||
+      recipientState.searchStatus === "ready" ||
+      recipientState.searchStatus === "error");
+
+  const activeResultId =
+    recipientState.highlightedIndex >= 0
+      ? `${resultsId}-option-${recipientState.highlightedIndex}`
+      : undefined;
+
+  const recipientHelp = useMemo(() => {
+    if (!ownUsername) return "Sign in before sending 2Z.";
+    if (exactSelfQuery) return "You can't send 2Z to your own account.";
+    if (recipientState.searchStatus === "error") {
+      return "Creator search failed. Check your connection and try again.";
+    }
+    if (
+      debouncedQuery &&
+      debouncedQueryIsCurrent &&
+      recipientState.searchStatus === "ready" &&
+      recipientState.results.length === 0
+    ) {
+      return `No creator found for “${debouncedQuery}”.`;
+    }
+    if (!recipientState.selected) {
+      return "Search and choose a creator. Typed text alone can never be sent.";
+    }
+    return null;
+  }, [
+    debouncedQuery,
+    debouncedQueryIsCurrent,
+    exactSelfQuery,
+    ownUsername,
+    recipientState.results.length,
+    recipientState.searchStatus,
+    recipientState.selected,
+  ]);
+
+  useEffect(() => {
+    if (recipientState.review && !reviewIsCurrent) {
+      dispatch({ type: "clearReview" });
+    }
+  }, [recipientState.review, reviewIsCurrent]);
+
+  function changeRecipient(query: string) {
+    if (flowLocked) return;
+    setTransferFailure(null);
+    dispatch({ type: "queryChanged", query });
+  }
+
+  function chooseRecipient(creator: SimpleCreator) {
+    if (flowLocked) return;
+    setTransferFailure(null);
+    dispatch({ type: "select", creator });
+  }
+
+  function onRecipientKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    const action = recipientKeyAction(
+      event.key,
+      recipientState.results,
+      recipientState.highlightedIndex,
+    );
+    if (!action || (action.type === "closeResults" && !showingResults)) return;
+    event.preventDefault();
+    if (action.type === "select") setTransferFailure(null);
+    dispatch(action);
+  }
+
+  function changeAmount(next: () => void) {
+    if (flowLocked) return;
+    setTransferFailure(null);
+    dispatch({ type: "clearReview" });
+    next();
+  }
+
+  function beginReview() {
+    if (!canReview || amount === null || !ownUsername) return;
+    const selected = recipientState.selected;
+    if (!selected) return;
+    const pending = loadPendingDonation();
+    const candidate = {
+      senderUsername: ownUsername,
+      recipient: selected,
+      amount,
+    };
+    if (pending && !pendingDonationMatches(pending, candidate)) {
+      setTransferFailure("pending-conflict");
+      return;
+    }
+    let idempotencyKey: string;
+    try {
+      idempotencyKey = pending?.idempotencyKey ?? createDonationIdempotencyKey();
+    } catch {
+      setTransferFailure("security");
+      return;
+    }
+    setTransferFailure(pending ? "pending" : null);
+    dispatch({
+      type: "startReview",
+      amount,
+      senderUsername: ownUsername,
+      idempotencyKey,
+    });
+  }
 
   async function send() {
-    if (!canSend || amount === null) return;
+    const review = recipientState.review;
+    if (
+      sendingRef.current ||
+      !review ||
+      !reviewIsCurrent
+    ) {
+      dispatch({ type: "clearReview" });
+      return;
+    }
+
+    if (!persistPendingDonation(review)) {
+      setTransferFailure("security");
+      dispatch({ type: "clearReview" });
+      return;
+    }
+
+    sendingRef.current = true;
     setSending(true);
+    setTransferFailure(null);
     try {
-      await tuzi.donate(recipient, amount);
-      adjustTuzis(-amount);
-      toast.success(`Sent ${formatTuzis(amount)} to @${recipient}`, {
-        description: "Thanks for supporting the creator.",
-      });
+      const result = await tuzi.donateIdempotent(
+        review.recipient.username,
+        review.amount,
+        review.idempotencyKey,
+      );
+      setTuzis(result.balance);
+      // Keep the keyed record until the user acknowledges this result. If the
+      // app dies between the committed response and visible success, the next
+      // attempt must replay this key rather than create a second charge.
+      setCompletedTransfer({ review, result });
+      toast.success(
+        `${result.replayed ? "Confirmed" : "Sent"} ${formatTuzis(review.amount)} to @${review.recipient.username}`,
+        {
+          description: result.replayed
+            ? "The original transfer was not charged again."
+            : "Thanks for supporting the creator.",
+        },
+      );
       setCustom("");
-      setUsername("");
-    } catch {
-      toast.error("Could not send. Please try again.");
+      dispatch({ type: "reset" });
+    } catch (error) {
+      const failure = classifyTransferFailure(error);
+      setTransferFailure(failure);
+      if (failure === "balance" && error instanceof Error && "body" in error) {
+        const balance = authoritativeBalanceFromErrorBody(
+          (error as { body?: unknown }).body,
+        );
+        if (balance !== null) setTuzis(balance);
+        else void refreshSession();
+      }
+      if (!transferFailureIsAmbiguous(failure)) {
+        clearPendingDonation(review.idempotencyKey);
+        dispatch({ type: "clearReview" });
+      }
+      if (failure === "not-found") dispatch({ type: "reset" });
+      if (failure === "auth") {
+        setToken(null);
+        setUser(null);
+      }
+      toast.error(TRANSFER_FAILURE_MESSAGES[failure]);
     } finally {
+      sendingRef.current = false;
       setSending(false);
     }
   }
@@ -76,77 +377,149 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
   return (
     <div className="grid gap-6 lg:grid-cols-[1.5fr_1fr]">
       <div className="space-y-5">
-        {/* Recipient */}
         <div className="space-y-3">
           <Label htmlFor="recipient">Send to</Label>
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Search
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden
+            />
             <Input
               id="recipient"
-              placeholder="username"
-              value={username}
-              onChange={(e) =>
-                setUsername(e.target.value.replace(/^@/, "").trim())
+              type="search"
+              autoComplete="off"
+              maxLength={128}
+              placeholder="Search creators by name or username"
+              value={recipientState.query}
+              onChange={(event) => changeRecipient(event.target.value)}
+              onKeyDown={onRecipientKeyDown}
+              className="h-11 pl-9"
+              role="combobox"
+              aria-label="Search for a 2Z recipient"
+              aria-autocomplete="list"
+              aria-expanded={showingResults && recipientState.results.length > 0}
+              aria-controls={
+                showingResults && recipientState.results.length > 0
+                  ? resultsId
+                  : undefined
               }
-              className="pl-9"
-              aria-label="Recipient username"
+              aria-activedescendant={activeResultId}
+              aria-describedby="recipient-help"
+              aria-invalid={exactSelfQuery}
+              disabled={sending || flowLocked}
             />
+            {recipientState.searchStatus === "loading" ? (
+              <Loader2
+                className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground"
+                aria-label="Searching creators"
+              />
+            ) : null}
           </div>
 
-          <div className="flex flex-wrap gap-2">
-            {creators === null
-              ? Array.from({ length: 4 }).map((_, i) => (
-                  <Skeleton key={i} className="h-10 w-32 rounded-full" />
-                ))
-              : creators.map((c) => {
-                  const active = recipient === c.username;
-                  return (
-                    <button
-                      key={c.username}
-                      type="button"
-                      onClick={() => setUsername(c.username)}
-                      aria-pressed={active}
-                      className={cn(
-                        "flex items-center gap-2 rounded-full border py-1.5 pl-1.5 pr-3 text-sm transition-colors",
-                        active
-                          ? "border-primary bg-primary/10"
-                          : "border-border hover:border-primary/40 hover:bg-primary/5",
-                      )}
-                    >
-                      <Avatar className="h-7 w-7">
-                        {c.image ? (
-                          <AvatarImage src={c.image} alt="" />
-                        ) : null}
-                        <AvatarFallback className="text-[10px]">
-                          {initials(c.display_name ?? c.username)}
-                        </AvatarFallback>
-                      </Avatar>
-                      <span className="font-medium">
-                        {c.display_name ?? c.username}
+          {showingResults && recipientState.results.length > 0 ? (
+            <div
+              id={resultsId}
+              role="listbox"
+              aria-label="Matching creators"
+              className="overflow-hidden rounded-xl border border-border bg-card shadow-lg"
+            >
+              {recipientState.results.map((creator, index) => {
+                const name = creator.display_name || creator.username;
+                return (
+                  <button
+                    id={`${resultsId}-option-${index}`}
+                    key={creator.username}
+                    type="button"
+                    role="option"
+                    aria-selected={index === recipientState.highlightedIndex}
+                    onClick={() => chooseRecipient(creator)}
+                    className={cn(
+                      "flex min-h-11 w-full items-center gap-3 border-b border-border px-3 py-2 text-left last:border-b-0",
+                      index === recipientState.highlightedIndex
+                        ? "bg-primary/10"
+                        : "hover:bg-secondary",
+                    )}
+                  >
+                    <CreatorAvatar creator={creator} className="h-9 w-9" />
+                    <span className="min-w-0">
+                      <span className="block truncate font-medium">{name}</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        @{creator.username}
                       </span>
-                    </button>
-                  );
-                })}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {recipientState.selected ? (
+            <div className="flex items-center gap-3 rounded-xl border border-primary/40 bg-primary/10 p-3">
+              <CreatorAvatar
+                creator={recipientState.selected}
+                className="h-11 w-11"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5 font-medium">
+                  <CheckCircle2 className="h-4 w-4 text-primary" aria-hidden />
+                  <span className="truncate">
+                    {recipientState.selected.display_name ||
+                      recipientState.selected.username}
+                  </span>
+                </div>
+                <div className="truncate text-sm text-muted-foreground">
+                  @{recipientState.selected.username}
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => changeRecipient("")}
+                disabled={sending || flowLocked}
+                aria-label={`Change recipient from @${recipientState.selected.username}`}
+              >
+                Change
+              </Button>
+            </div>
+          ) : null}
+
+          <div
+            id="recipient-help"
+            className={cn(
+              "min-h-[1rem] text-xs text-muted-foreground",
+              (exactSelfQuery || recipientState.searchStatus === "error") &&
+                "text-destructive",
+            )}
+            role={
+              exactSelfQuery || recipientState.searchStatus === "error"
+                ? "alert"
+                : "status"
+            }
+          >
+            {recipientHelp}
           </div>
         </div>
 
-        {/* Amount */}
         <div className="space-y-3">
           <Label>Amount</Label>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
             {TIP_PRESETS.map((preset) => {
-              const active = !hasCustomAmount && selected === preset;
+              const active = !hasCustomAmount && selectedAmount === preset;
               return (
                 <button
                   key={preset}
                   type="button"
-                  onClick={() => {
-                    setSelected(preset);
-                    setCustom("");
-                  }}
+                  onClick={() =>
+                    changeAmount(() => {
+                      setSelectedAmount(preset);
+                      setCustom("");
+                    })
+                  }
                   aria-pressed={active}
+                  disabled={sending || flowLocked}
                   className={cn(
-                    "rounded-xl border p-3 text-center transition-all",
+                    "min-h-11 rounded-xl border p-3 text-center transition-all disabled:opacity-50",
                     active
                       ? "border-primary bg-primary/10 shadow-glow"
                       : "border-border hover:border-primary/40 hover:bg-primary/5",
@@ -166,45 +539,60 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
               placeholder="Custom amount"
               maxLength={tuziInputMaxLength(MAX_TUZIS)}
               value={custom}
-              onChange={(e) => setCustom(e.target.value)}
+              onChange={(event) =>
+                changeAmount(() => setCustom(event.target.value))
+              }
               className="pr-24 tabular-nums"
               aria-label="Custom tip amount in 2Z"
               aria-describedby="custom-tip-error"
               aria-invalid={hasCustomAmount && !validAmount}
+              disabled={sending || flowLocked}
             />
             <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm font-medium tabular-nums text-muted-foreground">
               2Z
             </span>
           </div>
-          <div id="custom-tip-error" className="min-h-[1rem] text-xs text-destructive">
+          <div
+            id="custom-tip-error"
+            className="min-h-[1rem] text-xs text-destructive"
+          >
             {hasCustomAmount && customAmount.error === "tooLarge"
-                ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per tip.`
-                : hasCustomAmount && customAmount.error !== null
-                  ? "Enter a positive whole 2Z amount; commas may separate thousands."
-                  : null}
+              ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per tip.`
+              : hasCustomAmount && customAmount.error !== null
+                ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                : null}
           </div>
         </div>
       </div>
 
-      {/* Summary */}
       <Card className="h-fit lg:sticky lg:top-4">
         <CardHeader className="pb-4">
           <CardTitle>Review tip</CardTitle>
-          <CardDescription>Sent instantly from your 2Z balance.</CardDescription>
+          <CardDescription>
+            You will confirm before anything is sent.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-3">
             <span className="text-sm text-muted-foreground">Recipient</span>
-            <span className="font-medium">
-              {recipient ? `@${recipient}` : "—"}
-            </span>
+            {recipientState.selected ? (
+              <span className="min-w-0 text-right">
+                <span className="block truncate font-medium">
+                  {recipientState.selected.display_name ||
+                    recipientState.selected.username}
+                </span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  @{recipientState.selected.username}
+                </span>
+              </span>
+            ) : (
+              <span className="font-medium">—</span>
+            )}
           </div>
           <div className="flex items-baseline justify-between">
             <span className="text-sm text-muted-foreground">Amount</span>
-            <div className="text-right">
-              <div className="text-xl font-bold tabular-nums">
-                {validAmount && amount !== null ? formatTuzis(amount) : "—"}
-              </div>
+            <div className="text-xl font-bold tabular-nums">
+              {validAmount && amount !== null ? formatTuzis(amount) : "—"}
             </div>
           </div>
           <div className="flex items-center justify-between border-t border-border pt-3 text-sm">
@@ -221,27 +609,113 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
             </span>
           </div>
 
-          {validAmount && !enough ? (
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={onNeedBuy}
+          {transferFailure ? (
+            <div
+              role="alert"
+              className="flex gap-2 rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
             >
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+              <span>{TRANSFER_FAILURE_MESSAGES[transferFailure]}</span>
+            </div>
+          ) : null}
+
+          {completedTransfer ? (
+            <div className="space-y-3 rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-3">
+              <div className="flex items-center gap-2 font-medium text-emerald-400">
+                <CheckCircle2 className="h-4 w-4" aria-hidden />
+                Transfer confirmed
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {formatTuzis(completedTransfer.result.charged)} was sent to @
+                {completedTransfer.review.recipient.username}.
+                {completedTransfer.result.replayed
+                  ? " The stored result was replayed without another charge."
+                  : ""}
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={() => {
+                  clearPendingDonation(completedTransfer.review.idempotencyKey);
+                  setCompletedTransfer(null);
+                }}
+              >
+                Start another transfer
+              </Button>
+            </div>
+          ) : block === "balance" && !pendingMatchesCurrent ? (
+            <Button variant="outline" className="w-full" onClick={onNeedBuy}>
               Not enough 2Z — buy more
               <ArrowRight className="h-4 w-4" />
             </Button>
+          ) : recipientState.review && reviewIsCurrent ? (
+            <div className="space-y-3 rounded-xl border border-primary/40 bg-primary/5 p-3">
+              <p className="text-sm font-medium">Confirm this transfer</p>
+              <p className="text-xs text-muted-foreground">
+                Send {formatTuzis(recipientState.review.amount)} to @
+                {recipientState.review.recipient.username}? This transfer is
+                immediate and cannot be undone.
+              </p>
+              <div
+                className={cn("grid gap-2", !transferLocked && "grid-cols-2")}
+              >
+                {!transferLocked ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => dispatch({ type: "clearReview" })}
+                    disabled={sending}
+                  >
+                    Cancel
+                  </Button>
+                ) : null}
+                <Button
+                  type="button"
+                  onClick={send}
+                  disabled={
+                    sending ||
+                    !reviewIsCurrent ||
+                    (!transferCanRetry && transferLocked)
+                  }
+                >
+                  {sending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Gift className="h-4 w-4" />
+                  )}
+                  {transferCanRetry ? "Retry same transfer" : "Confirm send"}
+                </Button>
+              </div>
+            </div>
           ) : (
-            <Button className="w-full" disabled={!canSend} onClick={send}>
-              {sending ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Gift className="h-4 w-4" />
-              )}
-              Send 2Zs
+            <Button
+              className="w-full"
+              disabled={!canReview}
+              onClick={beginReview}
+            >
+              <Gift className="h-4 w-4" />
+              Review transfer
             </Button>
           )}
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+function CreatorAvatar({
+  creator,
+  className,
+}: {
+  creator: SimpleCreator;
+  className?: string;
+}) {
+  const name = creator.display_name || creator.username;
+  return (
+    <Avatar className={className}>
+      {creator.image ? <AvatarImage src={creator.image} alt="" /> : null}
+      <AvatarFallback className="text-xs">{initials(name)}</AvatarFallback>
+    </Avatar>
   );
 }

--- a/wallet/zuuli/src/features/buy/send-recipient.test.ts
+++ b/wallet/zuuli/src/features/buy/send-recipient.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/api/http";
+import type { SimpleCreator } from "@/lib/api/types";
+import {
+  classifyTransferFailure,
+  clearPendingDonation,
+  createDonationIdempotencyKey,
+  initialRecipientState,
+  nextHighlight,
+  recipientKeyAction,
+  recipientReducer,
+  reviewMatchesTransfer,
+  isDonationIdempotencyKey,
+  loadPendingDonation,
+  pendingDonationMatches,
+  persistPendingDonation,
+  sameUsername,
+  shouldSearchRecipients,
+  transferBlock,
+  transferFailureIsAmbiguous,
+} from "./send-recipient";
+
+const donationKey = "00000000-0000-4000-8000-000000000000";
+
+function memoryStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+  };
+}
+
+const alice: SimpleCreator = {
+  username: "alice",
+  free2zaddr: "alice",
+  display_name: "Alice Example",
+  image: "/alice.png",
+};
+
+const bob: SimpleCreator = {
+  username: "bob",
+  free2zaddr: "bob",
+  display_name: "Bob Example",
+};
+
+describe("recipientReducer", () => {
+  it("never treats arbitrary typed text as a resolved recipient", () => {
+    const state = recipientReducer(initialRecipientState, {
+      type: "queryChanged",
+      query: "typoed-user",
+    });
+
+    expect(state.selected).toBeNull();
+    expect(
+      transferBlock({
+        selected: state.selected,
+        query: state.query,
+        ownUsername: "sender",
+        amount: 100,
+        validAmount: true,
+        balance: 500,
+        sending: false,
+      }),
+    ).toBe("unresolved");
+  });
+
+  it("invalidates selection and confirmation as soon as the text changes", () => {
+    let state = recipientReducer(initialRecipientState, {
+      type: "select",
+      creator: alice,
+    });
+    state = recipientReducer(state, {
+      type: "startReview",
+      amount: 100,
+      senderUsername: "sender",
+      idempotencyKey: donationKey,
+    });
+    expect(state.review?.recipient.username).toBe("alice");
+    expect(state.review?.senderUsername).toBe("sender");
+
+    state = recipientReducer(state, {
+      type: "queryChanged",
+      query: "alicee",
+    });
+    expect(state.selected).toBeNull();
+    expect(state.review).toBeNull();
+  });
+
+  it("ignores stale successes and failures after a newer query", () => {
+    let state = recipientReducer(initialRecipientState, {
+      type: "queryChanged",
+      query: "ali",
+    });
+    const staleGeneration = state.generation;
+    state = recipientReducer(state, {
+      type: "searchStarted",
+      generation: staleGeneration,
+    });
+    state = recipientReducer(state, {
+      type: "queryChanged",
+      query: "bob",
+    });
+
+    state = recipientReducer(state, {
+      type: "searchSucceeded",
+      generation: staleGeneration,
+      results: [alice],
+    });
+    state = recipientReducer(state, {
+      type: "searchFailed",
+      generation: staleGeneration,
+    });
+
+    expect(state.query).toBe("bob");
+    expect(state.results).toEqual([]);
+    expect(state.searchStatus).toBe("idle");
+  });
+
+  it("resolves a canonical recipient from a pointer/mobile selection", () => {
+    const state = recipientReducer(initialRecipientState, {
+      type: "select",
+      creator: alice,
+    });
+    expect(state.query).toBe("alice");
+    expect(state.selected).toEqual(alice);
+  });
+});
+
+describe("keyboard result navigation", () => {
+  it("enters and wraps a result list in both directions", () => {
+    expect(nextHighlight(-1, 2, 1)).toBe(0);
+    expect(nextHighlight(-1, 2, -1)).toBe(1);
+    expect(nextHighlight(0, 2, -1)).toBe(1);
+    expect(nextHighlight(1, 2, 1)).toBe(0);
+    expect(nextHighlight(0, 0, 1)).toBe(-1);
+  });
+
+  it("selects only the highlighted result on Enter and closes on Escape", () => {
+    expect(recipientKeyAction("Enter", [alice, bob], 1)).toEqual({
+      type: "select",
+      creator: bob,
+    });
+    expect(recipientKeyAction("Enter", [alice], -1)).toBeNull();
+    expect(recipientKeyAction("Escape", [alice], 0)).toEqual({
+      type: "closeResults",
+    });
+  });
+});
+
+describe("donation idempotency key", () => {
+  it("creates an RFC 4122 UUIDv4 from secure random bytes", () => {
+    const key = createDonationIdempotencyKey((bytes) => {
+      bytes.fill(0xab);
+      return bytes;
+    });
+    expect(key).toBe("abababab-abab-4bab-abab-abababababab");
+    expect(isDonationIdempotencyKey(key)).toBe(true);
+  });
+
+  it.each(["", "key-123", "00000000-0000-0000-0000-000000000000"])(
+    "rejects non-v4 transfer key %s",
+    (key) => expect(isDonationIdempotencyKey(key)).toBe(false),
+  );
+});
+
+describe("crash-safe pending donation", () => {
+  const review = {
+    recipient: alice,
+    amount: 100,
+    senderUsername: "sender",
+    idempotencyKey: donationKey,
+  };
+
+  it("persists and reloads the exact keyed transfer", () => {
+    const storage = memoryStorage();
+    expect(persistPendingDonation(review, storage)).toBe(true);
+    expect(loadPendingDonation(storage)).toEqual({
+      senderUsername: "sender",
+      amount: 100,
+      idempotencyKey: donationKey,
+      recipient: { username: "alice", free2zaddr: "alice" },
+    });
+    expect(
+      pendingDonationMatches(review, {
+        senderUsername: "SENDER",
+        recipient: { ...alice, username: "ALICE" },
+        amount: 100,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects changed sender, recipient, or amount fingerprints", () => {
+    expect(
+      pendingDonationMatches(review, {
+        senderUsername: "other",
+        recipient: alice,
+        amount: 100,
+      }),
+    ).toBe(false);
+    expect(
+      pendingDonationMatches(review, {
+        senderUsername: "sender",
+        recipient: bob,
+        amount: 100,
+      }),
+    ).toBe(false);
+    expect(
+      pendingDonationMatches(review, {
+        senderUsername: "sender",
+        recipient: alice,
+        amount: 101,
+      }),
+    ).toBe(false);
+  });
+
+  it("clears only the resolved key and leaves a different pending key", () => {
+    const storage = memoryStorage();
+    persistPendingDonation(review, storage);
+    clearPendingDonation("ffffffff-ffff-4fff-bfff-ffffffffffff", storage);
+    expect(loadPendingDonation(storage)?.idempotencyKey).toBe(donationKey);
+    clearPendingDonation(donationKey, storage);
+    expect(loadPendingDonation(storage)).toBeNull();
+  });
+
+  it("fails closed when durable storage cannot be written", () => {
+    const unavailable = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("denied");
+      },
+      removeItem: () => undefined,
+    };
+    expect(persistPendingDonation(review, unavailable)).toBe(false);
+  });
+
+  it("does not overwrite a different pending attempt from another tab", () => {
+    const storage = memoryStorage();
+    expect(persistPendingDonation(review, storage)).toBe(true);
+    expect(
+      persistPendingDonation(
+        {
+          ...review,
+          idempotencyKey: "ffffffff-ffff-4fff-bfff-ffffffffffff",
+        },
+        storage,
+      ),
+    ).toBe(false);
+    expect(loadPendingDonation(storage)?.idempotencyKey).toBe(donationKey);
+  });
+});
+
+describe("debounced search authorization", () => {
+  it("does not start a stale debounced query after the user edits again", () => {
+    expect(
+      shouldSearchRecipients({
+        currentQuery: "bob",
+        debouncedQuery: "alice",
+        selected: null,
+        isSelf: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not search a selected or self recipient", () => {
+    expect(
+      shouldSearchRecipients({
+        currentQuery: "alice",
+        debouncedQuery: "alice",
+        selected: alice,
+        isSelf: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSearchRecipients({
+        currentQuery: "sender",
+        debouncedQuery: "sender",
+        selected: null,
+        isSelf: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("transferBlock", () => {
+  const valid = {
+    selected: alice,
+    query: "alice",
+    ownUsername: "sender",
+    amount: 100,
+    validAmount: true,
+    balance: 500,
+    sending: false,
+  };
+
+  it("requires auth, a current exact selection, a non-self recipient, and balance", () => {
+    expect(transferBlock(valid)).toBeNull();
+    expect(transferBlock({ ...valid, ownUsername: undefined })).toBe("auth");
+    expect(transferBlock({ ...valid, selected: null })).toBe("unresolved");
+    expect(transferBlock({ ...valid, query: "alicee" })).toBe("unresolved");
+    expect(transferBlock({ ...valid, ownUsername: "ALICE" })).toBe("self");
+    expect(transferBlock({ ...valid, amount: 0 })).toBe("amount");
+    expect(transferBlock({ ...valid, amount: 1.5 })).toBe("amount");
+    expect(transferBlock({ ...valid, amount: 501 })).toBe("balance");
+    expect(transferBlock({ ...valid, sending: true })).toBe("sending");
+  });
+
+  it("compares canonical usernames case-insensitively", () => {
+    expect(sameUsername(" Alice ", "aLiCe")).toBe(true);
+    expect(transferBlock({ ...valid, query: "ALICE" })).toBeNull();
+    expect(transferBlock({ ...valid, selected: bob })).toBe("unresolved");
+  });
+});
+
+describe("reviewMatchesTransfer", () => {
+  const review = {
+    recipient: alice,
+    amount: 100,
+    senderUsername: "sender",
+    idempotencyKey: donationKey,
+  };
+  const current = {
+    review,
+    selected: alice,
+    query: "alice",
+    ownUsername: "sender",
+    amount: 100,
+    validAmount: true,
+    balance: 500,
+  };
+
+  it("binds confirmation to the exact sender, recipient, amount, and balance", () => {
+    expect(reviewMatchesTransfer(current)).toBe(true);
+    expect(
+      reviewMatchesTransfer({ ...current, ownUsername: "other-sender" }),
+    ).toBe(false);
+    expect(reviewMatchesTransfer({ ...current, selected: bob })).toBe(false);
+    expect(reviewMatchesTransfer({ ...current, query: "alicee" })).toBe(false);
+    expect(reviewMatchesTransfer({ ...current, amount: 101 })).toBe(false);
+    expect(reviewMatchesTransfer({ ...current, balance: 99 })).toBe(false);
+  });
+});
+
+describe("classifyTransferFailure", () => {
+  it.each([
+    [new ApiError(401, "failure"), "auth"],
+    [new ApiError(403, "failure"), "auth"],
+    [new ApiError(402, "failure"), "balance"],
+    [
+      new ApiError(400, "failure", {
+        error: "Request must contain amount > 1 and < balance",
+      }),
+      "balance",
+    ],
+    [
+      new ApiError(400, "failure", { code: "insufficient_funds" }),
+      "balance",
+    ],
+    [new ApiError(400, "failure", { code: "self_send" }), "self"],
+    [new ApiError(404, "failure", { code: "recipient_not_found" }), "not-found"],
+    [new ApiError(404, "failure"), "unsupported"],
+    [new ApiError(409, "failure", { code: "request_in_progress" }), "pending"],
+    [
+      new ApiError(409, "failure", { code: "idempotency_mismatch" }),
+      "idempotency-conflict",
+    ],
+    [
+      new ApiError(409, "failure", { code: "invalid_idempotency_record" }),
+      "idempotency-conflict",
+    ],
+    [new ApiError(409, "failure"), "idempotency-conflict"],
+    [new ApiError(500, "failure"), "network"],
+  ] as const)("distinguishes transfer failure as %s", (error, expected) => {
+    expect(classifyTransferFailure(error)).toBe(expected);
+  });
+
+  it("treats transport errors as network failures", () => {
+    expect(classifyTransferFailure(new TypeError("Failed to fetch"))).toBe(
+      "network",
+    );
+  });
+
+  it("retains the keyed review only for ambiguous network/in-flight results", () => {
+    expect(transferFailureIsAmbiguous("network")).toBe(true);
+    expect(transferFailureIsAmbiguous("pending")).toBe(true);
+    expect(transferFailureIsAmbiguous("idempotency-conflict")).toBe(true);
+    expect(transferFailureIsAmbiguous("balance")).toBe(false);
+    expect(transferFailureIsAmbiguous("unsupported")).toBe(false);
+  });
+});

--- a/wallet/zuuli/src/features/buy/send-recipient.ts
+++ b/wallet/zuuli/src/features/buy/send-recipient.ts
@@ -1,0 +1,504 @@
+import type { SimpleCreator } from "@/lib/api/types";
+import { ApiError } from "@/lib/api/http";
+import { isDonationIdempotencyKey } from "@/lib/api/donation";
+
+export { isDonationIdempotencyKey } from "@/lib/api/donation";
+
+export type RecipientSearchStatus = "idle" | "loading" | "ready" | "error";
+
+export interface TransferReview {
+  recipient: SimpleCreator;
+  amount: number;
+  senderUsername: string;
+  idempotencyKey: string;
+}
+
+export interface RecipientState {
+  query: string;
+  generation: number;
+  selected: SimpleCreator | null;
+  results: SimpleCreator[];
+  searchStatus: RecipientSearchStatus;
+  highlightedIndex: number;
+  review: TransferReview | null;
+}
+
+export type RecipientAction =
+  | { type: "queryChanged"; query: string }
+  | { type: "searchStarted"; generation: number }
+  | {
+      type: "searchSucceeded";
+      generation: number;
+      results: SimpleCreator[];
+    }
+  | { type: "searchFailed"; generation: number }
+  | { type: "moveHighlight"; delta: -1 | 1 }
+  | { type: "select"; creator: SimpleCreator }
+  | { type: "closeResults" }
+  | {
+      type: "startReview";
+      amount: number;
+      senderUsername: string;
+      idempotencyKey: string;
+    }
+  | { type: "clearReview" }
+  | { type: "reset" };
+
+export const initialRecipientState: RecipientState = {
+  query: "",
+  generation: 0,
+  selected: null,
+  results: [],
+  searchStatus: "idle",
+  highlightedIndex: -1,
+  review: null,
+};
+
+/** Usernames are case-insensitive throughout the free2z API. */
+export function sameUsername(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/** UUIDv4 without relying on newer WebView support for crypto.randomUUID(). */
+export function createDonationIdempotencyKey(
+  fill: (bytes: Uint8Array) => Uint8Array = (bytes) => {
+    const crypto = globalThis.crypto;
+    if (!crypto?.getRandomValues) {
+      throw new Error("Secure randomness is unavailable");
+    }
+    return crypto.getRandomValues(bytes);
+  },
+): string {
+  const bytes = fill(new Uint8Array(16));
+  if (bytes.length !== 16) throw new Error("Invalid secure random result");
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10).join(""),
+  ].join("-");
+}
+
+const PENDING_DONATION_STORAGE_KEY = "zuuli.tuzi.pending-donation.v1";
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export function pendingDonationMatches(
+  pending: TransferReview,
+  candidate: Pick<TransferReview, "senderUsername" | "recipient" | "amount">,
+): boolean {
+  return (
+    sameUsername(pending.senderUsername, candidate.senderUsername) &&
+    sameUsername(pending.recipient.username, candidate.recipient.username) &&
+    pending.amount === candidate.amount
+  );
+}
+
+function defaultStorage(): StorageLike | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function loadPendingDonation(
+  storage: StorageLike | null = defaultStorage(),
+): TransferReview | null {
+  if (!storage) return null;
+  try {
+    const encoded = storage.getItem(PENDING_DONATION_STORAGE_KEY);
+    if (!encoded) return null;
+    const parsed = JSON.parse(encoded) as Partial<TransferReview>;
+    if (
+      typeof parsed.senderUsername !== "string" ||
+      !parsed.senderUsername ||
+      typeof parsed.amount !== "number" ||
+      !Number.isSafeInteger(parsed.amount) ||
+      parsed.amount < 1 ||
+      typeof parsed.idempotencyKey !== "string" ||
+      !isDonationIdempotencyKey(parsed.idempotencyKey) ||
+      !parsed.recipient ||
+      typeof parsed.recipient.username !== "string" ||
+      !parsed.recipient.username ||
+      typeof parsed.recipient.free2zaddr !== "string"
+    ) {
+      return null;
+    }
+    return parsed as TransferReview;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist before sending; failure means the money request must not start. */
+export function persistPendingDonation(
+  review: TransferReview,
+  storage: StorageLike | null = defaultStorage(),
+): boolean {
+  if (!storage || !isDonationIdempotencyKey(review.idempotencyKey)) return false;
+  try {
+    const existing = loadPendingDonation(storage);
+    if (existing && existing.idempotencyKey !== review.idempotencyKey) {
+      return false;
+    }
+    const minimal: TransferReview = {
+      senderUsername: review.senderUsername,
+      amount: review.amount,
+      idempotencyKey: review.idempotencyKey,
+      recipient: {
+        username: review.recipient.username,
+        free2zaddr: review.recipient.free2zaddr,
+      },
+    };
+    storage.setItem(PENDING_DONATION_STORAGE_KEY, JSON.stringify(minimal));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Clear only the exact attempt we resolved; never erase a newer pending key. */
+export function clearPendingDonation(
+  idempotencyKey: string,
+  storage: StorageLike | null = defaultStorage(),
+): void {
+  if (!storage) return;
+  try {
+    const pending = loadPendingDonation(storage);
+    if (pending?.idempotencyKey === idempotencyKey) {
+      storage.removeItem(PENDING_DONATION_STORAGE_KEY);
+    }
+  } catch {
+    // Leaving a resolved key behind is fail-closed: its replay cannot recharge.
+  }
+}
+
+export function nextHighlight(
+  current: number,
+  resultCount: number,
+  delta: -1 | 1,
+): number {
+  if (resultCount === 0) return -1;
+  if (current < 0) return delta === 1 ? 0 : resultCount - 1;
+  return (current + delta + resultCount) % resultCount;
+}
+
+export function recipientKeyAction(
+  key: string,
+  results: SimpleCreator[],
+  highlightedIndex: number,
+): RecipientAction | null {
+  if (key === "ArrowDown" || key === "ArrowUp") {
+    if (results.length === 0) return null;
+    return { type: "moveHighlight", delta: key === "ArrowDown" ? 1 : -1 };
+  }
+  if (key === "Enter") {
+    const creator = results[highlightedIndex];
+    return creator ? { type: "select", creator } : null;
+  }
+  if (key === "Escape") return { type: "closeResults" };
+  return null;
+}
+
+export function shouldSearchRecipients({
+  currentQuery,
+  debouncedQuery,
+  selected,
+  isSelf,
+}: {
+  currentQuery: string;
+  debouncedQuery: string;
+  selected: SimpleCreator | null;
+  isSelf: boolean;
+}): boolean {
+  return Boolean(
+    debouncedQuery && debouncedQuery === currentQuery && !selected && !isSelf,
+  );
+}
+
+/**
+ * Fail-closed recipient state. Every query edit increments `generation`, which
+ * invalidates both a prior selection and any search response still in flight.
+ */
+export function recipientReducer(
+  state: RecipientState,
+  action: RecipientAction,
+): RecipientState {
+  switch (action.type) {
+    case "queryChanged":
+      return {
+        ...state,
+        query: action.query.replace(/^@/, ""),
+        generation: state.generation + 1,
+        selected: null,
+        results: [],
+        searchStatus: "idle",
+        highlightedIndex: -1,
+        review: null,
+      };
+    case "searchStarted":
+      if (action.generation !== state.generation) return state;
+      return {
+        ...state,
+        results: [],
+        searchStatus: "loading",
+        highlightedIndex: -1,
+      };
+    case "searchSucceeded":
+      if (action.generation !== state.generation) return state;
+      return {
+        ...state,
+        results: action.results,
+        searchStatus: "ready",
+        highlightedIndex: action.results.length > 0 ? 0 : -1,
+      };
+    case "searchFailed":
+      if (action.generation !== state.generation) return state;
+      return {
+        ...state,
+        results: [],
+        searchStatus: "error",
+        highlightedIndex: -1,
+      };
+    case "moveHighlight":
+      return {
+        ...state,
+        highlightedIndex: nextHighlight(
+          state.highlightedIndex,
+          state.results.length,
+          action.delta,
+        ),
+      };
+    case "select":
+      return {
+        ...state,
+        query: action.creator.username,
+        generation: state.generation + 1,
+        selected: action.creator,
+        results: [],
+        searchStatus: "idle",
+        highlightedIndex: -1,
+        review: null,
+      };
+    case "closeResults":
+      return {
+        ...state,
+        results: [],
+        searchStatus: "idle",
+        highlightedIndex: -1,
+      };
+    case "startReview":
+      if (
+        !state.selected ||
+        !action.senderUsername ||
+        !isDonationIdempotencyKey(action.idempotencyKey)
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        review: {
+          recipient: state.selected,
+          amount: action.amount,
+          senderUsername: action.senderUsername,
+          idempotencyKey: action.idempotencyKey,
+        },
+      };
+    case "clearReview":
+      return state.review ? { ...state, review: null } : state;
+    case "reset":
+      return {
+        ...initialRecipientState,
+        generation: state.generation + 1,
+      };
+  }
+}
+
+export type TransferBlock =
+  | "auth"
+  | "unresolved"
+  | "self"
+  | "amount"
+  | "balance"
+  | "sending";
+
+export function transferBlock({
+  selected,
+  query,
+  ownUsername,
+  amount,
+  validAmount,
+  balance,
+  sending,
+}: {
+  selected: SimpleCreator | null;
+  query: string;
+  ownUsername?: string;
+  amount: number | null;
+  validAmount: boolean;
+  balance: number;
+  sending: boolean;
+}): TransferBlock | null {
+  if (!ownUsername) return "auth";
+  if (
+    !selected ||
+    !sameUsername(selected.username, query) ||
+    !selected.username.trim()
+  ) {
+    return "unresolved";
+  }
+  if (sameUsername(selected.username, ownUsername)) return "self";
+  if (
+    !validAmount ||
+    amount === null ||
+    !Number.isSafeInteger(amount) ||
+    amount < 1
+  ) {
+    return "amount";
+  }
+  if (amount > balance) return "balance";
+  if (sending) return "sending";
+  return null;
+}
+
+/** Confirmation is authorization for exactly one current transfer snapshot. */
+export function reviewMatchesTransfer({
+  review,
+  selected,
+  query,
+  ownUsername,
+  amount,
+  validAmount,
+  balance,
+}: {
+  review: TransferReview | null;
+  selected: SimpleCreator | null;
+  query: string;
+  ownUsername?: string;
+  amount: number | null;
+  validAmount: boolean;
+  balance: number;
+}): boolean {
+  if (
+    !review ||
+    !selected ||
+    transferBlock({
+      selected,
+      query,
+      ownUsername,
+      amount,
+      validAmount,
+      balance,
+      sending: false,
+    }) !== null ||
+    amount !== review.amount ||
+    !ownUsername ||
+    !sameUsername(review.senderUsername, ownUsername) ||
+    !sameUsername(review.recipient.username, selected.username) ||
+    !isDonationIdempotencyKey(review.idempotencyKey)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export type TransferFailure =
+  | "auth"
+  | "balance"
+  | "not-found"
+  | "self"
+  | "pending"
+  | "pending-conflict"
+  | "idempotency-conflict"
+  | "unsupported"
+  | "rejected"
+  | "security"
+  | "network";
+
+function apiErrorFields(error: ApiError): {
+  code: string;
+  message: string;
+} {
+  if (
+    !error.body ||
+    typeof error.body !== "object" ||
+    Array.isArray(error.body)
+  ) {
+    return { code: "", message: error.message.toLowerCase() };
+  }
+  const body = error.body as Record<string, unknown>;
+  const code = typeof body.code === "string" ? body.code.toLowerCase() : "";
+  const detail =
+    typeof body.error === "string"
+      ? body.error
+      : typeof body.detail === "string"
+        ? body.detail
+        : error.message;
+  return { code, message: detail.toLowerCase() };
+}
+
+export function classifyTransferFailure(error: unknown): TransferFailure {
+  if (error instanceof ApiError) {
+    if (error.status === 401 || error.status === 403) return "auth";
+    const { code, message } = apiErrorFields(error);
+    if (
+      error.status === 402 ||
+      code === "insufficient_funds" ||
+      message.includes("insufficient funds") ||
+      message.includes("amount > 1 and < balance")
+    ) {
+      return "balance";
+    }
+    if (code === "self_send" || message.includes("donate to yourself")) {
+      return "self";
+    }
+    if (error.status === 404) {
+      return code === "recipient_not_found" ? "not-found" : "unsupported";
+    }
+    if (error.status === 409) {
+      return code === "request_in_progress"
+        ? "pending"
+        : "idempotency-conflict";
+    }
+    if (error.status >= 400 && error.status < 500) return "rejected";
+  }
+  return "network";
+}
+
+export function transferFailureIsAmbiguous(failure: TransferFailure): boolean {
+  return (
+    failure === "network" ||
+    failure === "pending" ||
+    failure === "idempotency-conflict"
+  );
+}
+
+export const TRANSFER_FAILURE_MESSAGES: Record<TransferFailure, string> = {
+  auth: "Your session expired. Sign in again before sending 2Z.",
+  balance: "Your 2Z balance changed and is no longer enough for this tip.",
+  "not-found":
+    "That creator is no longer available. Search again before sending.",
+  self: "You can't send 2Z to your own account.",
+  pending:
+    "This transfer is still processing. Wait, then retry the same transfer safely.",
+  "pending-conflict":
+    "A previous transfer is unresolved. Restore its exact recipient and amount before starting another.",
+  "idempotency-conflict":
+    "This transfer ID conflicts with the server record. Nothing new was sent; contact support before trying another transfer.",
+  unsupported:
+    "Secure 2Z transfers are not available on this server yet. Nothing was sent.",
+  rejected: "The server rejected this transfer. Nothing was sent.",
+  security:
+    "A crash-safe transfer ID could not be saved. Nothing was sent.",
+  network:
+    "The transfer result is uncertain. Retry uses the same transfer ID and cannot charge twice.",
+};

--- a/wallet/zuuli/src/lib/api/donation-http.test.ts
+++ b/wallet/zuuli/src/lib/api/donation-http.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./http", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./http")>();
+  return { ...original, request: vi.fn() };
+});
+
+import { tuzi } from "./free2z";
+import { request } from "./http";
+
+const requestMock = vi.mocked(request);
+const donationKey = "00000000-0000-4000-8000-000000000000";
+
+describe("tuzi.donateIdempotent HTTP contract", () => {
+  beforeEach(() => requestMock.mockReset());
+
+  it("uses only the explicit safe route, key header, and reviewed amount", async () => {
+    requestMock.mockResolvedValue({
+      balance: "900.500",
+      charged: "100.000",
+      replayed: false,
+    });
+
+    await expect(
+      tuzi.donateIdempotent("alice/example", 100, donationKey),
+    ).resolves.toEqual({ balance: 900.5, charged: 100, replayed: false });
+
+    expect(requestMock).toHaveBeenCalledOnce();
+    expect(requestMock).toHaveBeenCalledWith(
+      "/api/tuzis/donate-idempotent/alice%2Fexample",
+      {
+        method: "POST",
+        body: { amount: 100 },
+        headers: { "Idempotency-Key": donationKey },
+      },
+    );
+    expect(requestMock.mock.calls[0]?.[0]).not.toBe(
+      "/api/tuzis/donate/alice/example",
+    );
+  });
+
+  it("rejects a response that cannot authoritatively reconcile the charge", async () => {
+    requestMock.mockResolvedValue({
+      balance: "900",
+      charged: "101",
+      replayed: false,
+    });
+    await expect(
+      tuzi.donateIdempotent("alice", 100, donationKey),
+    ).rejects.toThrow("Donation response charge does not match");
+  });
+
+  it("does not contact the server with a malformed idempotency key", async () => {
+    await expect(
+      tuzi.donateIdempotent("alice", 100, "not-a-key"),
+    ).rejects.toThrow("Donation idempotency key is invalid");
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+});

--- a/wallet/zuuli/src/lib/api/donation.test.ts
+++ b/wallet/zuuli/src/lib/api/donation.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  DonationContractError,
+  authoritativeBalanceFromErrorBody,
+  normalizeDonationResult,
+  parseBalanceTuzis,
+  parseWholeTuzis,
+} from "./donation";
+
+describe("idempotent donation wire contract", () => {
+  it.each([
+    [0, 0],
+    [42, 42],
+    ["42", 42],
+    ["42.00", 42],
+    [String(Number.MAX_SAFE_INTEGER), Number.MAX_SAFE_INTEGER],
+  ] as const)("parses exact whole balance %s", (wire, expected) => {
+    expect(parseWholeTuzis(wire)).toBe(expected);
+  });
+
+  it.each([
+    -1,
+    1.2,
+    "-1",
+    "01",
+    "1.2",
+    "1e3",
+    "NaN",
+    String(BigInt(Number.MAX_SAFE_INTEGER) + 1n),
+  ])("rejects unsafe balance %s", (wire) => {
+    expect(parseWholeTuzis(wire)).toBeNull();
+  });
+
+  it.each([
+    [0, 0],
+    [900.5, 900.5],
+    ["900.500", 900.5],
+    ["75.25", 75.25],
+    ["0.001", 0.001],
+  ] as const)("preserves exact Decimal(17,3) balance %s", (wire, expected) => {
+    expect(parseBalanceTuzis(wire)).toBe(expected);
+  });
+
+  it.each([
+    -0.001,
+    "-0.001",
+    "01.000",
+    "1.0001",
+    "1e3",
+    "9007199254741.000",
+  ])("rejects unsafe fractional balance %s", (wire) => {
+    expect(parseBalanceTuzis(wire)).toBeNull();
+  });
+
+  it("normalizes the authoritative first-charge and replay responses", () => {
+    expect(
+      normalizeDonationResult(
+        { balance: "900.500", charged: "100.000", replayed: false },
+        100,
+      ),
+    ).toEqual({ balance: 900.5, charged: 100, replayed: false });
+    expect(
+      normalizeDonationResult(
+        { balance: "900.500", charged: "100.000", replayed: true },
+        100,
+      ),
+    ).toEqual({ balance: 900.5, charged: 100, replayed: true });
+  });
+
+  it.each([
+    900,
+    { balance: "bad", charged: "100", replayed: false },
+    { balance: "900", charged: "101", replayed: false },
+    { balance: "900", charged: "100", replayed: "false" },
+  ])("rejects malformed or mismatched result %#", (response) => {
+    expect(() => normalizeDonationResult(response, 100)).toThrow(
+      DonationContractError,
+    );
+  });
+
+  it("extracts an authoritative balance only from a valid error body", () => {
+    expect(authoritativeBalanceFromErrorBody({ balance: "75.250" })).toBe(
+      75.25,
+    );
+    expect(authoritativeBalanceFromErrorBody({ balance: "75.2501" })).toBeNull();
+    expect(authoritativeBalanceFromErrorBody("75")).toBeNull();
+  });
+});

--- a/wallet/zuuli/src/lib/api/donation.ts
+++ b/wallet/zuuli/src/lib/api/donation.ts
@@ -1,0 +1,90 @@
+export const IDEMPOTENT_DONATION_ROUTE = "/api/tuzis/donate-idempotent";
+
+export interface DonationResult {
+  /** Authoritative whole-2Z balance after the original keyed operation. */
+  balance: number;
+  /** Whole-2Z amount charged by the original keyed operation. */
+  charged: number;
+  /** True when the server replayed the stored result for this key. */
+  replayed: boolean;
+}
+
+export class DonationContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DonationContractError";
+  }
+}
+
+const DONATION_KEY_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+export function isDonationIdempotencyKey(key: string): boolean {
+  return DONATION_KEY_PATTERN.test(key);
+}
+
+/** Parse an exact, non-negative, whole-2Z wire value without rounding. */
+export function parseWholeTuzis(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== "string" || !/^(?:0|[1-9]\d*)(?:\.0+)?$/.test(value)) {
+    return null;
+  }
+  const integer = value.split(".", 1)[0];
+  if (integer.length > String(Number.MAX_SAFE_INTEGER).length) return null;
+  const parsed = BigInt(integer);
+  return parsed <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(parsed) : null;
+}
+
+/**
+ * Parse the backend's Decimal(17,3) balance without rounding away milli-2Z.
+ * Restrict the accepted range to exactly representable integer milli-2Z in
+ * the client's number model; larger values must not silently lose money.
+ */
+export function parseBalanceTuzis(value: unknown): number | null {
+  if (typeof value === "number") {
+    const milliTuzis = value * 1_000;
+    return value >= 0 && Number.isSafeInteger(milliTuzis) ? value : null;
+  }
+  if (typeof value !== "string") return null;
+  const match = /^(0|[1-9]\d*)(?:\.(\d{1,3}))?$/.exec(value);
+  if (!match) return null;
+  const whole = BigInt(match[1]);
+  const fractional = BigInt((match[2] ?? "").padEnd(3, "0") || "0");
+  const milliTuzis = whole * 1_000n + fractional;
+  if (milliTuzis > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+  return Number(milliTuzis) / 1_000;
+}
+
+/**
+ * Validate the idempotent backend response before it can replace local money
+ * state. A charged amount different from the reviewed request is a contract
+ * failure, never something to round or accept optimistically.
+ */
+export function normalizeDonationResult(
+  response: unknown,
+  requestedAmount: number,
+): DonationResult {
+  if (!response || typeof response !== "object" || Array.isArray(response)) {
+    throw new DonationContractError("Donation response must be an object");
+  }
+  const raw = response as Record<string, unknown>;
+  const balance = parseBalanceTuzis(raw.balance);
+  const charged = parseWholeTuzis(raw.charged);
+  if (balance === null) {
+    throw new DonationContractError("Donation response balance is invalid");
+  }
+  if (charged === null || charged !== requestedAmount) {
+    throw new DonationContractError("Donation response charge does not match");
+  }
+  if (typeof raw.replayed !== "boolean") {
+    throw new DonationContractError("Donation replay status is invalid");
+  }
+  return { balance, charged, replayed: raw.replayed };
+}
+
+export function authoritativeBalanceFromErrorBody(body: unknown): number | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  return parseBalanceTuzis((body as Record<string, unknown>).balance);
+}

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -18,6 +18,13 @@ import {
 import type { OAuthStartResponse } from "../oauth/protocol";
 import { ApiError, basicLogin, mediaUrl, request, setToken } from "./http";
 import {
+  DonationContractError,
+  IDEMPOTENT_DONATION_ROUTE,
+  isDonationIdempotencyKey,
+  normalizeDonationResult,
+  type DonationResult,
+} from "./donation";
+import {
   mockAiReply,
   mockArticleFeed,
   mockArticles,
@@ -86,6 +93,11 @@ import type {
 } from "./types";
 
 const delay = (ms = 260) => new Promise((r) => setTimeout(r, ms));
+
+const mockDonationResults = new Map<
+  string,
+  { username: string; amount: number; result: DonationResult }
+>();
 
 // ─── Raw production shapes (only the fields we read) ────────────────────────
 interface RawImage {
@@ -1311,10 +1323,51 @@ export const tuzi = {
       await delay(400);
       return;
     }
-    await request(`/api/tuzis/donate/${username}`, {
+    await request(`/api/tuzis/donate/${encodeURIComponent(username)}`, {
       method: "POST",
       body: { amount: tuzis },
     });
+  },
+
+  async donateIdempotent(
+    username: string,
+    tuzis: number,
+    idempotencyKey: string,
+  ): Promise<DonationResult> {
+    if (!isDonationIdempotencyKey(idempotencyKey)) {
+      throw new DonationContractError("Donation idempotency key is invalid");
+    }
+    if (useMock()) {
+      await delay(400);
+      const prior = mockDonationResults.get(idempotencyKey);
+      if (prior) {
+        if (prior.username !== username || prior.amount !== tuzis) {
+          throw new ApiError(409, "Idempotency key request mismatch", {
+            code: "idempotency_mismatch",
+          });
+        }
+        return { ...prior.result, replayed: true };
+      }
+      if (tuzis > mockUser.tuzis) {
+        throw new ApiError(400, "Insufficient funds", {
+          code: "insufficient_funds",
+          balance: String(mockUser.tuzis),
+        });
+      }
+      mockUser.tuzis -= tuzis;
+      const result = { balance: mockUser.tuzis, charged: tuzis, replayed: false };
+      mockDonationResults.set(idempotencyKey, { username, amount: tuzis, result });
+      return result;
+    }
+    const response = await request(
+      `${IDEMPOTENT_DONATION_ROUTE}/${encodeURIComponent(username)}`,
+      {
+        method: "POST",
+        body: { amount: tuzis },
+        headers: { "Idempotency-Key": idempotencyKey },
+      },
+    );
+    return normalizeDonationResult(response, tuzis);
   },
 
   async subscribe(username: string): Promise<void> {

--- a/wallet/zuuli/src/store/session-balance.test.ts
+++ b/wallet/zuuli/src/store/session-balance.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { AuthUser } from "@/lib/api/types";
+import { useSession } from "./session";
+
+const user: AuthUser = {
+  username: "sender",
+  display_name: "Sender",
+  tuzis: 1_000,
+};
+
+afterEach(() => {
+  useSession.setState({ user: null, tuzis: 0, loading: true });
+});
+
+describe("authoritative session balance", () => {
+  it("replaces both the balance selector and cached user snapshot", () => {
+    useSession.setState({ user, tuzis: user.tuzis, loading: false });
+    useSession.getState().setTuzis(875.5);
+
+    expect(useSession.getState().tuzis).toBe(875.5);
+    expect(useSession.getState().user?.tuzis).toBe(875.5);
+  });
+});

--- a/wallet/zuuli/src/store/session.ts
+++ b/wallet/zuuli/src/store/session.ts
@@ -25,6 +25,8 @@ interface SessionState {
   logout: () => Promise<void>;
   /** Optimistically adjust the local 2Z balance (e.g. after an AI charge). */
   adjustTuzis: (delta: number) => void;
+  /** Replace local money state with a validated authoritative API balance. */
+  setTuzis: (balance: number) => void;
 }
 
 export const useSession = create<SessionState>((set, get) => ({
@@ -75,5 +77,12 @@ export const useSession = create<SessionState>((set, get) => ({
 
   adjustTuzis(delta) {
     set({ tuzis: Math.max(0, get().tuzis + delta) });
+  },
+
+  setTuzis(balance) {
+    set((state) => ({
+      tuzis: balance,
+      user: state.user ? { ...state.user, tuzis: balance } : null,
+    }));
   },
 }));


### PR DESCRIPTION
## Summary
- replace the random creator pill wall with debounced full-corpus creator autocomplete
- require a canonical selected creator and an explicit, sender-bound review step before donation
- fail closed across query edits, stale search responses, session/balance drift, and duplicate submits
- send only through the new server-idempotent donation route with a crash-safe UUIDv4 key reused across ambiguous responses/restarts
- consume Decimal(17,3) authoritative post-donation and 400 insufficient-funds balances without rounding; require the charged amount to match the whole-2Z review exactly
- distinguish self-send, not-found, auth, balance, unsupported-server, rejection, in-flight, idempotency-conflict, security, and network failures
- support combobox arrow/Enter/Escape behavior and 44px pointer/touch targets

## Backend dependency
Depends on free2z/tuzi#975 at upstream head 25e14e1f4325fedc076026e1ca7e904e715f6ef1. This client intentionally uses only POST /api/tuzis/donate-idempotent/{username}; an older backend returns 404 before any side effect and the UI reports it as unsupported. Merge and deploy tuzi#975 before this PR. No zuu submodule pointer is changed because PR #304 shares the upstream contract.

## Verification
- npm test (172 tests)
- npm run typecheck
- npm run build
- node scripts/verify-ci-cache-policy.mjs
- npm run test:play-testers (10 tests)
- npm audit --audit-level=high (passes; existing seven moderate advisories only)
- git diff --check

Closes #259