### PR TITLE
fix(zuuli): confirm live memberships before purchase

### DIFF
--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   Link,
   useLocation,
@@ -34,12 +34,18 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { EmptyState } from "@/components/common/EmptyState";
-import { live, tuzi } from "@/lib/api/free2z";
+import { auth, discover, live, tuzi } from "@/lib/api/free2z";
 import { useAsync } from "@/hooks/useAsync";
 import { useSession } from "@/store/session";
 import { formatTuzis, timeAgo, initials } from "@/lib/format";
 import type { DyteJoinTicket, Livestream, StreamKind } from "@/lib/api/types";
 import { KIND_META, gradientFor } from "./lib";
+import {
+  activeMembershipFor,
+  enterSubscriberStream,
+  newMembershipIdempotencyKey,
+  runSingleFlight,
+} from "./membership";
 import { Stage } from "./Stage";
 
 interface JustStarted {
@@ -280,6 +286,16 @@ function BackLink() {
   );
 }
 
+function formatMembershipExpiry(expires?: string): string {
+  if (!expires) return "";
+  const date = new Date(expires);
+  if (Number.isNaN(date.getTime())) return "";
+  return ` until ${date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  })}`;
+}
+
 function JoinPanel({
   stream,
   tuzis,
@@ -292,19 +308,67 @@ function JoinPanel({
   const kind = KIND_META[stream.kind] ?? KIND_META.broadcast;
   const [busy, setBusy] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [membershipConfirmOpen, setMembershipConfirmOpen] = useState(false);
+  const [membershipPriceOverride, setMembershipPriceOverride] = useState<{
+    price: number | null;
+  } | null>(null);
   const [secret, setSecret] = useState("");
+  const operationInFlight = useRef(false);
+  // Keep this key through any ambiguous failure. A retry then asks the backend
+  // to replay the same purchase instead of buying another month.
+  const membershipAttemptKey = useRef<string | null>(null);
+
+  const user = useSession((state) => state.user);
+  const sessionLoading = useSession((state) => state.loading);
+  const setUser = useSession((state) => state.setUser);
+  const {
+    data: subscriptions,
+    loading: membershipLoading,
+    error: membershipError,
+    reload: reloadMemberships,
+  } = useAsync(
+    () => (user ? tuzi.mySubscriptions() : Promise.resolve([])),
+    [user?.username, stream.username],
+  );
 
   const price = stream.price_tuzis;
   const affordable = tuzis >= price;
+  const membershipPrice =
+    membershipPriceOverride !== null
+      ? membershipPriceOverride.price
+      : stream.creator.member_price;
+  const hasMembershipPrice =
+    Number.isSafeInteger(membershipPrice) && (membershipPrice ?? 0) > 0;
+  const membershipAffordable =
+    hasMembershipPrice && tuzis >= (membershipPrice ?? 0);
+  const membership = activeMembershipFor(
+    subscriptions ?? [],
+    stream.username,
+  );
+
+  async function runExclusive<T>(operation: () => Promise<T>): Promise<T | null> {
+    // React state updates are not synchronous. The ref closes the double-click
+    // window before the disabled button can render.
+    return runSingleFlight(operationInFlight, async () => {
+      setBusy(true);
+      try {
+        return await operation();
+      } finally {
+        setBusy(false);
+      }
+    });
+  }
 
   async function doJoin(
     action?: () => Promise<void>,
     joinSecret?: string,
   ): Promise<boolean> {
-    setBusy(true);
     try {
-      if (action) await action();
-      const ticket = await live.join(stream.username, stream.kind, joinSecret);
+      const ticket = await runExclusive(async () => {
+        if (action) await action();
+        return live.join(stream.username, stream.kind, joinSecret);
+      });
+      if (!ticket) return false;
       onJoined(ticket);
       return true;
     } catch (e) {
@@ -312,8 +376,6 @@ function JoinPanel({
         description: e instanceof Error ? e.message : "Please try again.",
       });
       return false;
-    } finally {
-      setBusy(false);
     }
   }
 
@@ -324,6 +386,73 @@ function JoinPanel({
       // onJoined has already debited the balance; celebrate the entry.
       toast.success("You're in", {
         description: `Enjoy the stream — ${formatTuzis(price)} spent.`,
+      });
+    }
+  }
+
+  async function confirmMembership() {
+    if (
+      !user ||
+      typeof membershipPrice !== "number" ||
+      !Number.isSafeInteger(membershipPrice) ||
+      membershipPrice <= 0
+    ) {
+      return;
+    }
+    const confirmedPrice = membershipPrice;
+    setMembershipConfirmOpen(false);
+    membershipAttemptKey.current ??= newMembershipIdempotencyKey(
+      stream.username,
+    );
+
+    try {
+      const result = await runExclusive(() =>
+        enterSubscriberStream({
+          username: stream.username,
+          idempotencyKey: membershipAttemptKey.current!,
+          confirmedPrice,
+          loadMemberships: () => tuzi.mySubscriptions(),
+          loadCurrentPrice: async () => {
+            const creator = await discover.creator(stream.username);
+            const currentPrice =
+              Number.isSafeInteger(creator.member_price) &&
+              (creator.member_price ?? 0) > 0
+                ? creator.member_price!
+                : null;
+            setMembershipPriceOverride({ price: currentPrice });
+            return currentPrice;
+          },
+          subscribe: (username, idempotencyKey) =>
+            tuzi.subscribe(username, idempotencyKey),
+          reconcileBalance: async () => {
+            const authoritative = await auth.me();
+            // Preserve session-only identity observations that GET /auth/user
+            // does not expose while replacing all authoritative account data.
+            setUser({ ...useSession.getState().user, ...authoritative });
+          },
+          join: () => live.join(stream.username, stream.kind),
+        }),
+      );
+      if (!result) return;
+
+      membershipAttemptKey.current = null;
+      onJoined(result.ticket);
+      const renews = Number(result.membership.max_price ?? 0) > 0;
+      toast.success("You're in", {
+        description:
+          result.purchase?.charged === true
+            ? `${formatTuzis(confirmedPrice)} paid. Auto-renew is ${renews ? "on" : "off"}.`
+            : result.purchase !== null || result.recoveredAmbiguousPurchase
+              ? "Your membership and balance were verified before joining."
+              : "Your active membership was verified. No membership purchase was made.",
+      });
+    } catch (error) {
+      // The key intentionally survives: if the POST committed but its response
+      // was lost, retrying reconciles/replays instead of charging again.
+      reloadMemberships();
+      toast.error("Could not confirm membership", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
       });
     }
   }
@@ -365,30 +494,192 @@ function JoinPanel({
         {stream.kind === "subscriber" ? (
           <>
             <p className="text-xs text-muted-foreground">
-              This stream is for subscribers. Subscribe to{" "}
+              This stream is for members of{" "}
               <span className="font-medium text-foreground">
                 @{stream.username}
-              </span>{" "}
-              to watch.
+              </span>
+              . Active members join without another purchase.
             </p>
-            <Button
-              className="w-full gap-2"
-              size="lg"
-              variant="secondary"
-              disabled={busy}
-              onClick={() =>
-                doJoin(async () => {
-                  await tuzi.subscribe(stream.username);
-                })
-              }
-            >
-              {busy ? (
+
+            <div className="space-y-2 rounded-lg border border-border bg-background/50 px-3 py-3 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Creator</span>
+                <span className="font-medium">
+                  {stream.creator.display_name ?? `@${stream.username}`}
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Membership</span>
+                <span className="font-semibold tabular-nums">
+                  {hasMembershipPrice
+                    ? `${formatTuzis(membershipPrice!)}/30 days`
+                    : "Unavailable"}
+                </span>
+              </div>
+              {user ? (
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-muted-foreground">Current balance</span>
+                  <span className="font-medium tabular-nums">
+                    {formatTuzis(tuzis)}
+                  </span>
+                </div>
+              ) : null}
+            </div>
+
+            {sessionLoading || (user && membershipLoading) ? (
+              <Button className="w-full gap-2" size="lg" disabled>
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-              ) : (
+                Checking membership
+              </Button>
+            ) : !user ? (
+              <Button asChild className="w-full gap-2" size="lg">
+                <Link to="/login">
+                  <KeyRound className="h-4 w-4" aria-hidden />
+                  Sign in to subscribe
+                </Link>
+              </Button>
+            ) : membershipError ? (
+              <div className="space-y-2">
+                <p className="text-center text-xs text-destructive">
+                  We couldn't safely verify your current membership.
+                </p>
+                <Button
+                  className="w-full"
+                  size="lg"
+                  variant="outline"
+                  disabled={busy}
+                  onClick={reloadMemberships}
+                >
+                  Retry membership check
+                </Button>
+              </div>
+            ) : membership ? (
+              <div className="space-y-2">
+                <p className="text-xs text-muted-foreground">
+                  {Number(membership.max_price ?? 0) > 0
+                    ? `Membership active${formatMembershipExpiry(membership.expires)} and set to renew.`
+                    : `Membership active${formatMembershipExpiry(membership.expires)}. Auto-renew is off.`}
+                </p>
+                <Button
+                  className="w-full gap-2"
+                  size="lg"
+                  variant="secondary"
+                  disabled={busy}
+                  onClick={() => doJoin()}
+                >
+                  {busy ? (
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  ) : (
+                    <ShieldCheck className="h-4 w-4" aria-hidden />
+                  )}
+                  Join as a member
+                </Button>
+              </div>
+            ) : !hasMembershipPrice ? (
+              <div className="space-y-2">
+                <Button className="w-full" size="lg" disabled>
+                  Membership unavailable
+                </Button>
+                <Button asChild variant="outline" className="w-full">
+                  <Link to={`/creator/${stream.username}`}>
+                    View creator profile
+                  </Link>
+                </Button>
+              </div>
+            ) : !membershipAffordable ? (
+              <div className="space-y-2">
+                <Button className="w-full" size="lg" disabled>
+                  Not enough 2Zs
+                </Button>
+                <Button asChild variant="outline" className="w-full gap-2">
+                  <Link to="/buy">
+                    <Coins className="h-4 w-4" aria-hidden />
+                    Buy more 2Zs
+                  </Link>
+                </Button>
+                <p className="text-center text-xs text-muted-foreground tabular-nums">
+                  You have {formatTuzis(tuzis)} · need{" "}
+                  {formatTuzis(membershipPrice!)}
+                </p>
+              </div>
+            ) : (
+              <Button
+                className="w-full gap-2"
+                size="lg"
+                variant="secondary"
+                disabled={busy}
+                onClick={() => setMembershipConfirmOpen(true)}
+              >
                 <Sparkles className="h-4 w-4" aria-hidden />
-              )}
-              Subscribe to watch
-            </Button>
+                Review membership
+              </Button>
+            )}
+
+            <Dialog
+              open={membershipConfirmOpen}
+              onOpenChange={(open) => {
+                if (!busy) setMembershipConfirmOpen(open);
+              }}
+            >
+              <DialogContent className="max-w-sm">
+                <DialogHeader>
+                  <DialogTitle>
+                    Join {stream.creator.display_name ?? `@${stream.username}`}
+                  </DialogTitle>
+                  <DialogDescription>
+                    This purchase unlocks subscriber posts and livestreams for
+                    30 days. New memberships renew automatically, capped at the
+                    membership price below; if you previously turned renewal
+                    off, this purchase leaves it off. You can manage renewal
+                    without losing time already purchased.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-3 rounded-lg border border-border bg-background/50 px-4 py-3 text-sm">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-muted-foreground">Monthly price</span>
+                    <span className="font-semibold tabular-nums">
+                      {formatTuzis(membershipPrice ?? 0)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-muted-foreground">Current balance</span>
+                    <span className="font-medium tabular-nums">
+                      {formatTuzis(tuzis)}
+                    </span>
+                  </div>
+                  <Separator />
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-muted-foreground">Balance after</span>
+                    <span className="font-semibold tabular-nums">
+                      {formatTuzis(
+                        Math.max(0, tuzis - (membershipPrice ?? 0)),
+                      )}
+                    </span>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button
+                    variant="ghost"
+                    onClick={() => setMembershipConfirmOpen(false)}
+                    disabled={busy}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    className="gap-2"
+                    onClick={confirmMembership}
+                    disabled={busy || !membershipAffordable}
+                  >
+                    {busy ? (
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                    ) : (
+                      <ShieldCheck className="h-4 w-4" aria-hidden />
+                    )}
+                    Confirm · {formatTuzis(membershipPrice ?? 0)}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
           </>
         ) : null}
 

--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -414,6 +414,7 @@ function JoinPanel({
           username: stream.username,
           idempotencyKey: membershipAttemptKey.current!,
           confirmedPrice,
+          authorization: alreadyActive ? "join-only" : "purchase-approved",
           loadMembership: () => tuzi.subscriptionStatus(stream.username),
           subscribe: (username, idempotencyKey, expectedPrice) =>
             tuzi.subscribeConfirmed(username, idempotencyKey, expectedPrice),

--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -34,15 +34,16 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { EmptyState } from "@/components/common/EmptyState";
-import { auth, discover, live, tuzi } from "@/lib/api/free2z";
+import { auth, live, tuzi } from "@/lib/api/free2z";
+import { ApiError } from "@/lib/api/http";
 import { useAsync } from "@/hooks/useAsync";
 import { useSession } from "@/store/session";
 import { formatTuzis, timeAgo, initials } from "@/lib/format";
 import type { DyteJoinTicket, Livestream, StreamKind } from "@/lib/api/types";
 import { KIND_META, gradientFor } from "./lib";
 import {
-  activeMembershipFor,
   enterSubscriberStream,
+  MembershipPriceChangedError,
   newMembershipIdempotencyKey,
   runSingleFlight,
 } from "./membership";
@@ -322,12 +323,15 @@ function JoinPanel({
   const sessionLoading = useSession((state) => state.loading);
   const setUser = useSession((state) => state.setUser);
   const {
-    data: subscriptions,
+    data: membershipStatus,
     loading: membershipLoading,
     error: membershipError,
     reload: reloadMemberships,
   } = useAsync(
-    () => (user ? tuzi.mySubscriptions() : Promise.resolve([])),
+    () =>
+      user
+        ? tuzi.subscriptionStatus(stream.username)
+        : Promise.resolve(null),
     [user?.username, stream.username],
   );
 
@@ -341,10 +345,7 @@ function JoinPanel({
     Number.isSafeInteger(membershipPrice) && (membershipPrice ?? 0) > 0;
   const membershipAffordable =
     hasMembershipPrice && tuzis >= (membershipPrice ?? 0);
-  const membership = activeMembershipFor(
-    subscriptions ?? [],
-    stream.username,
-  );
+  const membership = membershipStatus?.active ? membershipStatus : null;
 
   async function runExclusive<T>(operation: () => Promise<T>): Promise<T | null> {
     // React state updates are not synchronous. The ref closes the double-click
@@ -391,19 +392,21 @@ function JoinPanel({
   }
 
   async function confirmMembership() {
+    if (!user) return;
+    const alreadyActive = membership !== null;
     if (
-      !user ||
-      typeof membershipPrice !== "number" ||
-      !Number.isSafeInteger(membershipPrice) ||
-      membershipPrice <= 0
+      !alreadyActive &&
+      (typeof membershipPrice !== "number" ||
+        !Number.isSafeInteger(membershipPrice) ||
+        membershipPrice <= 0)
     ) {
       return;
     }
-    const confirmedPrice = membershipPrice;
+    const confirmedPrice = alreadyActive
+      ? Number(membership.current_price ?? 0)
+      : membershipPrice!;
     setMembershipConfirmOpen(false);
-    membershipAttemptKey.current ??= newMembershipIdempotencyKey(
-      stream.username,
-    );
+    membershipAttemptKey.current ??= newMembershipIdempotencyKey();
 
     try {
       const result = await runExclusive(() =>
@@ -411,19 +414,9 @@ function JoinPanel({
           username: stream.username,
           idempotencyKey: membershipAttemptKey.current!,
           confirmedPrice,
-          loadMemberships: () => tuzi.mySubscriptions(),
-          loadCurrentPrice: async () => {
-            const creator = await discover.creator(stream.username);
-            const currentPrice =
-              Number.isSafeInteger(creator.member_price) &&
-              (creator.member_price ?? 0) > 0
-                ? creator.member_price!
-                : null;
-            setMembershipPriceOverride({ price: currentPrice });
-            return currentPrice;
-          },
-          subscribe: (username, idempotencyKey) =>
-            tuzi.subscribe(username, idempotencyKey),
+          loadMembership: () => tuzi.subscriptionStatus(stream.username),
+          subscribe: (username, idempotencyKey, expectedPrice) =>
+            tuzi.subscribeConfirmed(username, idempotencyKey, expectedPrice),
           reconcileBalance: async () => {
             const authoritative = await auth.me();
             // Preserve session-only identity observations that GET /auth/user
@@ -450,9 +443,32 @@ function JoinPanel({
       // The key intentionally survives: if the POST committed but its response
       // was lost, retrying reconciles/replays instead of charging again.
       reloadMemberships();
+      let displayError = error;
+      if (
+        error instanceof ApiError &&
+        error.body &&
+        typeof error.body === "object"
+      ) {
+        const body = error.body as Record<string, unknown>;
+        if (body.code === "price_changed") {
+          const rawPrice = body.current_price;
+          const currentPrice =
+            typeof rawPrice === "string" &&
+            Number.isSafeInteger(Number(rawPrice))
+              ? Number(rawPrice)
+              : null;
+          setMembershipPriceOverride({ price: currentPrice });
+          displayError = new MembershipPriceChangedError(
+            confirmedPrice,
+            currentPrice,
+          );
+        }
+      }
       toast.error("Could not confirm membership", {
         description:
-          error instanceof Error ? error.message : "Please try again.",
+          displayError instanceof Error
+            ? displayError.message
+            : "Please try again.",
       });
     }
   }
@@ -557,15 +573,15 @@ function JoinPanel({
               <div className="space-y-2">
                 <p className="text-xs text-muted-foreground">
                   {Number(membership.max_price ?? 0) > 0
-                    ? `Membership active${formatMembershipExpiry(membership.expires)} and set to renew.`
-                    : `Membership active${formatMembershipExpiry(membership.expires)}. Auto-renew is off.`}
+                    ? `Membership active${formatMembershipExpiry(membership.expires ?? undefined)} and set to renew.`
+                    : `Membership active${formatMembershipExpiry(membership.expires ?? undefined)}. Auto-renew is off.`}
                 </p>
                 <Button
                   className="w-full gap-2"
                   size="lg"
                   variant="secondary"
                   disabled={busy}
-                  onClick={() => doJoin()}
+                  onClick={confirmMembership}
                 >
                   {busy ? (
                     <Loader2 className="h-4 w-4 animate-spin" aria-hidden />

--- a/wallet/zuuli/src/features/live/membership.test.ts
+++ b/wallet/zuuli/src/features/live/membership.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  DyteJoinTicket,
+  Subscription,
+} from "@/lib/api/types";
+import {
+  activeMembershipFor,
+  enterSubscriberStream,
+  MembershipReconciliationError,
+  runSingleFlight,
+} from "./membership";
+
+const ticket: DyteJoinTicket = {
+  authToken: "ticket",
+  meetingId: "meeting",
+  as: "participant",
+};
+
+function membership(
+  expires: string,
+  maxPrice = "500",
+): Subscription {
+  return {
+    fan: { username: "viewer", free2zaddr: "viewer" },
+    star: { username: "Creator", free2zaddr: "creator" },
+    expires,
+    max_price: maxPrice,
+  };
+}
+
+describe("activeMembershipFor", () => {
+  it("matches the server-filtered active list case-insensitively", () => {
+    const active = membership("2026-08-08T12:00:01Z");
+
+    expect(activeMembershipFor([active], "creator")).toBe(active);
+    expect(activeMembershipFor([active], "someone-else")).toBeNull();
+  });
+
+  it("treats an active cancelled membership as entitled", () => {
+    const cancelled = membership("2026-09-01T00:00:00Z", "0");
+    expect(activeMembershipFor([cancelled], "creator")).toBe(cancelled);
+  });
+});
+
+describe("enterSubscriberStream", () => {
+  function deps(loadMemberships: () => Promise<Subscription[]>) {
+    return {
+      username: "creator",
+      idempotencyKey: "stable-attempt-key",
+      confirmedPrice: 500,
+      loadMemberships,
+      loadCurrentPrice: vi.fn().mockResolvedValue(500),
+      subscribe: vi.fn().mockResolvedValue({
+        charged: true,
+        expires: "2026-09-07T12:00:00Z",
+      }),
+      reconcileBalance: vi.fn().mockResolvedValue(undefined),
+      join: vi.fn().mockResolvedValue(ticket),
+    };
+  }
+
+  it("joins an active member directly without purchasing or refreshing balance", async () => {
+    const active = membership("2099-01-01T00:00:00Z", "0");
+    const runtime = deps(vi.fn().mockResolvedValue([active]));
+
+    const result = await enterSubscriberStream(runtime);
+
+    expect(result.purchase).toBeNull();
+    expect(runtime.subscribe).not.toHaveBeenCalled();
+    expect(runtime.reconcileBalance).not.toHaveBeenCalled();
+    expect(runtime.join).toHaveBeenCalledOnce();
+  });
+
+  it("purchases after an expired membership drops from the active endpoint and joins only after reconciliation", async () => {
+    const active = membership("2099-01-01T00:00:00Z");
+    const events: string[] = [];
+    const load = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        events.push("preflight");
+        return [];
+      })
+      .mockImplementationOnce(async () => {
+        events.push("membership reconciled");
+        return [active];
+      });
+    const runtime = deps(load);
+    runtime.subscribe.mockImplementation(async (_username, key) => {
+      events.push(`subscribe:${key}`);
+      return { charged: true, expires: active.expires! };
+    });
+    runtime.reconcileBalance.mockImplementation(async () => {
+      events.push("balance reconciled");
+    });
+    runtime.join.mockImplementation(async () => {
+      events.push("join");
+      return ticket;
+    });
+
+    await enterSubscriberStream(runtime);
+
+    expect(runtime.subscribe).toHaveBeenCalledWith(
+      "creator",
+      "stable-attempt-key",
+    );
+    expect(events.indexOf("join")).toBeGreaterThan(
+      events.indexOf("membership reconciled"),
+    );
+    expect(events.indexOf("join")).toBeGreaterThan(
+      events.indexOf("balance reconciled"),
+    );
+  });
+
+  it("does not join or invent local state after insufficient funds", async () => {
+    const runtime = deps(vi.fn().mockResolvedValue([]));
+    runtime.subscribe.mockRejectedValue(new Error("Insufficient funds"));
+
+    await expect(enterSubscriberStream(runtime)).rejects.toThrow(
+      "Insufficient funds",
+    );
+    expect(runtime.reconcileBalance).toHaveBeenCalledOnce();
+    expect(runtime.join).not.toHaveBeenCalled();
+  });
+
+  it("requires a new confirmation when the authoritative price changed", async () => {
+    const runtime = deps(vi.fn().mockResolvedValue([]));
+    runtime.loadCurrentPrice.mockResolvedValue(750);
+
+    await expect(enterSubscriberStream(runtime)).rejects.toThrow(
+      "price changed from 500 2Z to 750 2Z",
+    );
+    expect(runtime.subscribe).not.toHaveBeenCalled();
+    expect(runtime.reconcileBalance).not.toHaveBeenCalled();
+    expect(runtime.join).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a successful POST cannot be confirmed", async () => {
+    const runtime = deps(vi.fn().mockResolvedValue([]));
+
+    await expect(enterSubscriberStream(runtime)).rejects.toBeInstanceOf(
+      MembershipReconciliationError,
+    );
+    expect(runtime.join).not.toHaveBeenCalled();
+  });
+
+  it("recovers an ambiguous response when authoritative reads prove the purchase", async () => {
+    const active = membership("2099-01-01T00:00:00Z");
+    const runtime = deps(
+      vi.fn().mockResolvedValueOnce([]).mockResolvedValueOnce([active]),
+    );
+    runtime.subscribe.mockRejectedValue(new Error("response lost"));
+
+    const result = await enterSubscriberStream(runtime);
+
+    expect(result.recoveredAmbiguousPurchase).toBe(true);
+    expect(runtime.join).toHaveBeenCalledOnce();
+  });
+
+  it("a retry after reconciliation failure sees membership and never POSTs twice", async () => {
+    const active = membership("2099-01-01T00:00:00Z");
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error("read failed"))
+      .mockResolvedValueOnce([active]);
+    const runtime = deps(load);
+
+    await expect(enterSubscriberStream(runtime)).rejects.toBeInstanceOf(
+      MembershipReconciliationError,
+    );
+    await expect(enterSubscriberStream(runtime)).resolves.toMatchObject({
+      purchase: null,
+    });
+
+    expect(runtime.subscribe).toHaveBeenCalledOnce();
+    expect(runtime.join).toHaveBeenCalledOnce();
+  });
+});
+
+describe("runSingleFlight", () => {
+  it("drops a double-click while the first operation is pending, then unlocks", async () => {
+    const lock = { current: false };
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const operation = vi.fn().mockImplementation(() => pending);
+
+    const first = runSingleFlight(lock, operation);
+    const second = runSingleFlight(lock, operation);
+
+    await expect(second).resolves.toBeNull();
+    expect(operation).toHaveBeenCalledOnce();
+    release();
+    await expect(first).resolves.toBeUndefined();
+
+    await runSingleFlight(lock, operation);
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/wallet/zuuli/src/features/live/membership.test.ts
+++ b/wallet/zuuli/src/features/live/membership.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 import type {
   DyteJoinTicket,
   Subscription,
+  SubscriptionStatus,
 } from "@/lib/api/types";
 import {
   activeMembershipFor,
   enterSubscriberStream,
   MembershipReconciliationError,
+  newMembershipIdempotencyKey,
   runSingleFlight,
 } from "./membership";
 
@@ -28,6 +30,16 @@ function membership(
   };
 }
 
+function status(active: boolean, maxPrice = "500"): SubscriptionStatus {
+  return {
+    username: "Creator",
+    active,
+    expires: active ? "2099-01-01T00:00:00Z" : null,
+    max_price: active ? maxPrice : null,
+    current_price: "500",
+  };
+}
+
 describe("activeMembershipFor", () => {
   it("matches the server-filtered active list case-insensitively", () => {
     const active = membership("2026-08-08T12:00:01Z");
@@ -43,51 +55,58 @@ describe("activeMembershipFor", () => {
 });
 
 describe("enterSubscriberStream", () => {
-  function deps(loadMemberships: () => Promise<Subscription[]>) {
+  function deps(loadMembership: () => Promise<SubscriptionStatus>) {
     return {
       username: "creator",
       idempotencyKey: "stable-attempt-key",
       confirmedPrice: 500,
-      loadMemberships,
-      loadCurrentPrice: vi.fn().mockResolvedValue(500),
+      loadMembership,
       subscribe: vi.fn().mockResolvedValue({
+        balance: "500.000",
         charged: true,
+        replayed: false,
         expires: "2026-09-07T12:00:00Z",
+        subscription: membership("2026-09-07T12:00:00Z"),
       }),
       reconcileBalance: vi.fn().mockResolvedValue(undefined),
       join: vi.fn().mockResolvedValue(ticket),
     };
   }
 
-  it("joins an active member directly without purchasing or refreshing balance", async () => {
-    const active = membership("2099-01-01T00:00:00Z", "0");
-    const runtime = deps(vi.fn().mockResolvedValue([active]));
+  it("joins an active member without purchasing, after reconciling balance", async () => {
+    const runtime = deps(vi.fn().mockResolvedValue(status(true, "0")));
 
     const result = await enterSubscriberStream(runtime);
 
     expect(result.purchase).toBeNull();
     expect(runtime.subscribe).not.toHaveBeenCalled();
-    expect(runtime.reconcileBalance).not.toHaveBeenCalled();
+    expect(runtime.reconcileBalance).toHaveBeenCalledOnce();
     expect(runtime.join).toHaveBeenCalledOnce();
   });
 
   it("purchases after an expired membership drops from the active endpoint and joins only after reconciliation", async () => {
-    const active = membership("2099-01-01T00:00:00Z");
+    const active = status(true);
     const events: string[] = [];
     const load = vi
       .fn()
       .mockImplementationOnce(async () => {
         events.push("preflight");
-        return [];
+        return status(false);
       })
       .mockImplementationOnce(async () => {
         events.push("membership reconciled");
-        return [active];
+        return active;
       });
     const runtime = deps(load);
     runtime.subscribe.mockImplementation(async (_username, key) => {
       events.push(`subscribe:${key}`);
-      return { charged: true, expires: active.expires! };
+      return {
+        balance: "500.000",
+        charged: true,
+        replayed: false,
+        expires: active.expires!,
+        subscription: membership(active.expires!),
+      };
     });
     runtime.reconcileBalance.mockImplementation(async () => {
       events.push("balance reconciled");
@@ -102,6 +121,7 @@ describe("enterSubscriberStream", () => {
     expect(runtime.subscribe).toHaveBeenCalledWith(
       "creator",
       "stable-attempt-key",
+      500,
     );
     expect(events.indexOf("join")).toBeGreaterThan(
       events.indexOf("membership reconciled"),
@@ -112,7 +132,7 @@ describe("enterSubscriberStream", () => {
   });
 
   it("does not join or invent local state after insufficient funds", async () => {
-    const runtime = deps(vi.fn().mockResolvedValue([]));
+    const runtime = deps(vi.fn().mockResolvedValue(status(false)));
     runtime.subscribe.mockRejectedValue(new Error("Insufficient funds"));
 
     await expect(enterSubscriberStream(runtime)).rejects.toThrow(
@@ -122,20 +142,8 @@ describe("enterSubscriberStream", () => {
     expect(runtime.join).not.toHaveBeenCalled();
   });
 
-  it("requires a new confirmation when the authoritative price changed", async () => {
-    const runtime = deps(vi.fn().mockResolvedValue([]));
-    runtime.loadCurrentPrice.mockResolvedValue(750);
-
-    await expect(enterSubscriberStream(runtime)).rejects.toThrow(
-      "price changed from 500 2Z to 750 2Z",
-    );
-    expect(runtime.subscribe).not.toHaveBeenCalled();
-    expect(runtime.reconcileBalance).not.toHaveBeenCalled();
-    expect(runtime.join).not.toHaveBeenCalled();
-  });
-
   it("fails closed when a successful POST cannot be confirmed", async () => {
-    const runtime = deps(vi.fn().mockResolvedValue([]));
+    const runtime = deps(vi.fn().mockResolvedValue(status(false)));
 
     await expect(enterSubscriberStream(runtime)).rejects.toBeInstanceOf(
       MembershipReconciliationError,
@@ -144,9 +152,9 @@ describe("enterSubscriberStream", () => {
   });
 
   it("recovers an ambiguous response when authoritative reads prove the purchase", async () => {
-    const active = membership("2099-01-01T00:00:00Z");
+    const active = status(true);
     const runtime = deps(
-      vi.fn().mockResolvedValueOnce([]).mockResolvedValueOnce([active]),
+      vi.fn().mockResolvedValueOnce(status(false)).mockResolvedValueOnce(active),
     );
     runtime.subscribe.mockRejectedValue(new Error("response lost"));
 
@@ -157,12 +165,12 @@ describe("enterSubscriberStream", () => {
   });
 
   it("a retry after reconciliation failure sees membership and never POSTs twice", async () => {
-    const active = membership("2099-01-01T00:00:00Z");
+    const active = status(true);
     const load = vi
       .fn()
-      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(status(false))
       .mockRejectedValueOnce(new Error("read failed"))
-      .mockResolvedValueOnce([active]);
+      .mockResolvedValueOnce(active);
     const runtime = deps(load);
 
     await expect(enterSubscriberStream(runtime)).rejects.toBeInstanceOf(
@@ -173,6 +181,24 @@ describe("enterSubscriberStream", () => {
     });
 
     expect(runtime.subscribe).toHaveBeenCalledOnce();
+    expect(runtime.reconcileBalance).toHaveBeenCalledTimes(2);
+    expect(runtime.join).toHaveBeenCalledOnce();
+  });
+
+  it("does not join an active retry until its balance reconciliation succeeds", async () => {
+    const runtime = deps(vi.fn().mockResolvedValue(status(true)));
+    runtime.reconcileBalance.mockRejectedValueOnce(new Error("balance failed"));
+
+    await expect(enterSubscriberStream(runtime)).rejects.toBeInstanceOf(
+      MembershipReconciliationError,
+    );
+    expect(runtime.subscribe).not.toHaveBeenCalled();
+    expect(runtime.join).not.toHaveBeenCalled();
+
+    await expect(enterSubscriberStream(runtime)).resolves.toMatchObject({
+      purchase: null,
+    });
+    expect(runtime.reconcileBalance).toHaveBeenCalledTimes(2);
     expect(runtime.join).toHaveBeenCalledOnce();
   });
 });
@@ -196,5 +222,13 @@ describe("runSingleFlight", () => {
 
     await runSingleFlight(lock, operation);
     expect(operation).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("newMembershipIdempotencyKey", () => {
+  it("creates a backend-valid UUIDv4", () => {
+    expect(newMembershipIdempotencyKey()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
   });
 });

--- a/wallet/zuuli/src/features/live/membership.test.ts
+++ b/wallet/zuuli/src/features/live/membership.test.ts
@@ -60,6 +60,7 @@ describe("enterSubscriberStream", () => {
       username: "creator",
       idempotencyKey: "stable-attempt-key",
       confirmedPrice: 500,
+      authorization: "purchase-approved" as "join-only" | "purchase-approved",
       loadMembership,
       subscribe: vi.fn().mockResolvedValue({
         balance: "500.000",
@@ -75,6 +76,7 @@ describe("enterSubscriberStream", () => {
 
   it("joins an active member without purchasing, after reconciling balance", async () => {
     const runtime = deps(vi.fn().mockResolvedValue(status(true, "0")));
+    runtime.authorization = "join-only";
 
     const result = await enterSubscriberStream(runtime);
 
@@ -82,6 +84,19 @@ describe("enterSubscriberStream", () => {
     expect(runtime.subscribe).not.toHaveBeenCalled();
     expect(runtime.reconcileBalance).toHaveBeenCalledOnce();
     expect(runtime.join).toHaveBeenCalledOnce();
+  });
+
+  it("never promotes a stale active-member join click into a purchase", async () => {
+    const runtime = deps(vi.fn().mockResolvedValue(status(false)));
+    runtime.authorization = "join-only";
+
+    await expect(enterSubscriberStream(runtime)).rejects.toThrow(
+      "Review the current membership price before purchasing",
+    );
+
+    expect(runtime.subscribe).not.toHaveBeenCalled();
+    expect(runtime.reconcileBalance).not.toHaveBeenCalled();
+    expect(runtime.join).not.toHaveBeenCalled();
   });
 
   it("purchases after an expired membership drops from the active endpoint and joins only after reconciliation", async () => {

--- a/wallet/zuuli/src/features/live/membership.ts
+++ b/wallet/zuuli/src/features/live/membership.ts
@@ -50,6 +50,12 @@ export interface EnterSubscriberStreamDeps {
   username: string;
   idempotencyKey: string;
   confirmedPrice: number;
+  /**
+   * The exact money authority granted by the UI that launched this attempt.
+   * A join-only click must never be promoted into a purchase when entitlement
+   * expires between render and the authoritative preflight.
+   */
+  authorization: "join-only" | "purchase-approved";
   loadMembership: () => Promise<SubscriptionStatus>;
   subscribe: (
     username: string,
@@ -117,6 +123,12 @@ export async function enterSubscriberStream(
       purchase: null,
       recoveredAmbiguousPurchase: false,
     };
+  }
+
+  if (deps.authorization === "join-only") {
+    throw new MembershipReconciliationError(
+      "Your membership expired before entry. Review the current membership price before purchasing.",
+    );
   }
 
   let purchase: SubscribeResult | null = null;

--- a/wallet/zuuli/src/features/live/membership.ts
+++ b/wallet/zuuli/src/features/live/membership.ts
@@ -2,6 +2,7 @@ import type {
   DyteJoinTicket,
   SubscribeResult,
   Subscription,
+  SubscriptionStatus,
 } from "@/lib/api/types";
 
 /**
@@ -49,11 +50,11 @@ export interface EnterSubscriberStreamDeps {
   username: string;
   idempotencyKey: string;
   confirmedPrice: number;
-  loadMemberships: () => Promise<Subscription[]>;
-  loadCurrentPrice: () => Promise<number | null>;
+  loadMembership: () => Promise<SubscriptionStatus>;
   subscribe: (
     username: string,
     idempotencyKey: string,
+    expectedPrice: number,
   ) => Promise<SubscribeResult>;
   reconcileBalance: () => Promise<void>;
   join: () => Promise<DyteJoinTicket>;
@@ -61,7 +62,7 @@ export interface EnterSubscriberStreamDeps {
 
 export interface SubscriberEntryResult {
   ticket: DyteJoinTicket;
-  membership: Subscription;
+  membership: SubscriptionStatus;
   /** Null when the viewer was already entitled and no purchase was attempted. */
   purchase: SubscribeResult | null;
   /** True when a failed/ambiguous POST was proven successful by the read-back. */
@@ -85,7 +86,7 @@ export async function runSingleFlight<T>(
 /**
  * Cross the subscriber-room money boundary safely.
  *
- * Every attempt first checks the authoritative active-membership endpoint, so
+ * Every attempt first checks the target-specific membership endpoint, so
  * an existing member (including one with auto-renew disabled) is never POSTed
  * merely for entering a room. A new purchase is joined only after BOTH the
  * membership and account balance have been read back from the backend.
@@ -97,30 +98,35 @@ export async function runSingleFlight<T>(
 export async function enterSubscriberStream(
   deps: EnterSubscriberStreamDeps,
 ): Promise<SubscriberEntryResult> {
-  const before = await deps.loadMemberships();
-  const existing = activeMembershipFor(before, deps.username);
-  if (existing) {
+  const before = await deps.loadMembership();
+  if (before.active) {
+    try {
+      // This is deliberately required even for an already-active membership.
+      // A prior POST may have committed while its response/reconciliation was
+      // lost; joining directly here would leave the displayed balance stale.
+      await deps.reconcileBalance();
+    } catch (error) {
+      throw new MembershipReconciliationError(
+        "Your account balance could not be reconciled. The stream was not joined.",
+        error,
+      );
+    }
     return {
       ticket: await deps.join(),
-      membership: existing,
+      membership: before,
       purchase: null,
       recoveredAmbiguousPurchase: false,
     };
   }
 
-  // The public live listing may be a few seconds old. Re-read the creator
-  // immediately before the money POST and force a new confirmation if the
-  // displayed terms changed. (The backend endpoint does not yet accept a
-  // client price cap, so this is the strongest available client boundary.)
-  const currentPrice = await deps.loadCurrentPrice();
-  if (currentPrice !== deps.confirmedPrice) {
-    throw new MembershipPriceChangedError(deps.confirmedPrice, currentPrice);
-  }
-
   let purchase: SubscribeResult | null = null;
   let purchaseError: unknown = null;
   try {
-    purchase = await deps.subscribe(deps.username, deps.idempotencyKey);
+    purchase = await deps.subscribe(
+      deps.username,
+      deps.idempotencyKey,
+      deps.confirmedPrice,
+    );
   } catch (error) {
     // A transport failure is ambiguous: the backend may have committed before
     // the response disappeared. Read back both facts before deciding whether
@@ -128,10 +134,10 @@ export async function enterSubscriberStream(
     purchaseError = error;
   }
 
-  let after: Subscription[];
+  let after: SubscriptionStatus;
   try {
     [after] = await Promise.all([
-      deps.loadMemberships(),
+      deps.loadMembership(),
       deps.reconcileBalance(),
     ]);
   } catch (error) {
@@ -141,8 +147,7 @@ export async function enterSubscriberStream(
     );
   }
 
-  const membership = activeMembershipFor(after, deps.username);
-  if (!membership) {
+  if (!after.active) {
     if (purchaseError instanceof Error) throw purchaseError;
     throw new MembershipReconciliationError(
       "The backend did not confirm an active membership. The stream was not joined.",
@@ -151,16 +156,27 @@ export async function enterSubscriberStream(
 
   return {
     ticket: await deps.join(),
-    membership,
+    membership: after,
     purchase,
     recoveredAmbiguousPurchase: purchaseError !== null,
   };
 }
 
 /** A cryptographically random, per-confirmation retry key for the money POST. */
-export function newMembershipIdempotencyKey(username: string): string {
+export function newMembershipIdempotencyKey(): string {
   const random = crypto.getRandomValues(new Uint8Array(16));
-  const nonce = Array.from(random, (byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
-  return `zuuli-live:${username.toLowerCase()}:${nonce}`;
+  // RFC 4122 UUIDv4 bits; the username belongs in the backend request
+  // fingerprint, not in this opaque retry key.
+  random[6] = (random[6]! & 0x0f) | 0x40;
+  random[8] = (random[8]! & 0x3f) | 0x80;
+  const hex = Array.from(random, (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
 }

--- a/wallet/zuuli/src/features/live/membership.ts
+++ b/wallet/zuuli/src/features/live/membership.ts
@@ -1,0 +1,166 @@
+import type {
+  DyteJoinTicket,
+  SubscribeResult,
+  Subscription,
+} from "@/lib/api/types";
+
+/**
+ * The endpoint already filters with `expires__gt=server_now`. Presence in that
+ * list is the entitlement fact; re-checking its timestamp against a possibly
+ * skewed device clock could misclassify a real member and recharge them.
+ */
+export function activeMembershipFor(
+  subscriptions: Subscription[],
+  username: string,
+): Subscription | null {
+  return (
+    subscriptions.find(
+      (subscription) =>
+        subscription.star.username.toLowerCase() === username.toLowerCase(),
+    ) ?? null
+  );
+}
+
+export class MembershipReconciliationError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "MembershipReconciliationError";
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export class MembershipPriceChangedError extends Error {
+  readonly currentPrice: number | null;
+
+  constructor(confirmedPrice: number, currentPrice: number | null) {
+    super(
+      currentPrice === null
+        ? "This creator no longer offers a paid membership. Review the updated details before continuing."
+        : `The membership price changed from ${confirmedPrice.toLocaleString()} 2Z to ${currentPrice.toLocaleString()} 2Z. Review the updated price before confirming.`,
+    );
+    this.name = "MembershipPriceChangedError";
+    this.currentPrice = currentPrice;
+  }
+}
+
+export interface EnterSubscriberStreamDeps {
+  username: string;
+  idempotencyKey: string;
+  confirmedPrice: number;
+  loadMemberships: () => Promise<Subscription[]>;
+  loadCurrentPrice: () => Promise<number | null>;
+  subscribe: (
+    username: string,
+    idempotencyKey: string,
+  ) => Promise<SubscribeResult>;
+  reconcileBalance: () => Promise<void>;
+  join: () => Promise<DyteJoinTicket>;
+}
+
+export interface SubscriberEntryResult {
+  ticket: DyteJoinTicket;
+  membership: Subscription;
+  /** Null when the viewer was already entitled and no purchase was attempted. */
+  purchase: SubscribeResult | null;
+  /** True when a failed/ambiguous POST was proven successful by the read-back. */
+  recoveredAmbiguousPurchase: boolean;
+}
+
+/** Close the synchronous gap before React can render a disabled button. */
+export async function runSingleFlight<T>(
+  lock: { current: boolean },
+  operation: () => Promise<T>,
+): Promise<T | null> {
+  if (lock.current) return null;
+  lock.current = true;
+  try {
+    return await operation();
+  } finally {
+    lock.current = false;
+  }
+}
+
+/**
+ * Cross the subscriber-room money boundary safely.
+ *
+ * Every attempt first checks the authoritative active-membership endpoint, so
+ * an existing member (including one with auto-renew disabled) is never POSTed
+ * merely for entering a room. A new purchase is joined only after BOTH the
+ * membership and account balance have been read back from the backend.
+ *
+ * The caller owns a stable idempotency key and must reuse it when retrying an
+ * ambiguous attempt. The backend then replays the first result instead of
+ * extending another month.
+ */
+export async function enterSubscriberStream(
+  deps: EnterSubscriberStreamDeps,
+): Promise<SubscriberEntryResult> {
+  const before = await deps.loadMemberships();
+  const existing = activeMembershipFor(before, deps.username);
+  if (existing) {
+    return {
+      ticket: await deps.join(),
+      membership: existing,
+      purchase: null,
+      recoveredAmbiguousPurchase: false,
+    };
+  }
+
+  // The public live listing may be a few seconds old. Re-read the creator
+  // immediately before the money POST and force a new confirmation if the
+  // displayed terms changed. (The backend endpoint does not yet accept a
+  // client price cap, so this is the strongest available client boundary.)
+  const currentPrice = await deps.loadCurrentPrice();
+  if (currentPrice !== deps.confirmedPrice) {
+    throw new MembershipPriceChangedError(deps.confirmedPrice, currentPrice);
+  }
+
+  let purchase: SubscribeResult | null = null;
+  let purchaseError: unknown = null;
+  try {
+    purchase = await deps.subscribe(deps.username, deps.idempotencyKey);
+  } catch (error) {
+    // A transport failure is ambiguous: the backend may have committed before
+    // the response disappeared. Read back both facts before deciding whether
+    // entry is safe, and keep the same idempotency key for any later retry.
+    purchaseError = error;
+  }
+
+  let after: Subscription[];
+  try {
+    [after] = await Promise.all([
+      deps.loadMemberships(),
+      deps.reconcileBalance(),
+    ]);
+  } catch (error) {
+    throw new MembershipReconciliationError(
+      "The membership result could not be verified. No balance was debited optimistically; retry to reconcile it safely.",
+      purchaseError ?? error,
+    );
+  }
+
+  const membership = activeMembershipFor(after, deps.username);
+  if (!membership) {
+    if (purchaseError instanceof Error) throw purchaseError;
+    throw new MembershipReconciliationError(
+      "The backend did not confirm an active membership. The stream was not joined.",
+    );
+  }
+
+  return {
+    ticket: await deps.join(),
+    membership,
+    purchase,
+    recoveredAmbiguousPurchase: purchaseError !== null,
+  };
+}
+
+/** A cryptographically random, per-confirmation retry key for the money POST. */
+export function newMembershipIdempotencyKey(username: string): string {
+  const random = crypto.getRandomValues(new Uint8Array(16));
+  const nonce = Array.from(random, (byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `zuuli-live:${username.toLowerCase()}:${nonce}`;
+}

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -83,6 +83,7 @@ import type {
   StreamKind,
   SubscribeResult,
   Subscription,
+  SubscriptionStatus,
   TuziTransaction,
 } from "./types";
 
@@ -142,6 +143,185 @@ function parsePrice(v: string | null | undefined): number | null {
   if (v === null || v === undefined || v === "") return null;
   const n = Number(v);
   return Number.isFinite(n) ? Math.round(n) : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseDecimalString(value: unknown, field: string): string {
+  if (typeof value !== "string" || !/^\d+(?:\.\d+)?$/.test(value)) {
+    throw new Error(`Malformed membership response: ${field}.`);
+  }
+  return value;
+}
+
+function parseNullableString(value: unknown, field: string): string | null {
+  if (value === null) return null;
+  if (typeof value !== "string") {
+    throw new Error(`Malformed membership response: ${field}.`);
+  }
+  return value;
+}
+
+function parseSubscription(value: unknown): Subscription {
+  if (!isRecord(value) || !isRecord(value.fan) || !isRecord(value.star)) {
+    throw new Error("Malformed membership response: subscription.");
+  }
+  const fanUsername = value.fan.username;
+  const starUsername = value.star.username;
+  if (typeof fanUsername !== "string" || typeof starUsername !== "string") {
+    throw new Error("Malformed membership response: subscriber identity.");
+  }
+  const expires = value.expires;
+  const maxPrice = value.max_price;
+  if (expires !== undefined && typeof expires !== "string") {
+    throw new Error("Malformed membership response: expires.");
+  }
+  if (maxPrice !== undefined && typeof maxPrice !== "string") {
+    throw new Error("Malformed membership response: max_price.");
+  }
+  return {
+    fan: {
+      ...(value.fan as unknown as SimpleCreator),
+      username: fanUsername,
+      free2zaddr:
+        typeof value.fan.p2paddr === "string" && value.fan.p2paddr
+          ? value.fan.p2paddr
+          : fanUsername,
+    },
+    star: {
+      ...(value.star as unknown as SimpleCreator),
+      username: starUsername,
+      free2zaddr:
+        typeof value.star.p2paddr === "string" && value.star.p2paddr
+          ? value.star.p2paddr
+          : starUsername,
+    },
+    expires,
+    max_price: maxPrice,
+  };
+}
+
+/** Runtime validator used before trusting any paginated entitlement data. */
+export function parseSubscriptionPage(
+  value: unknown,
+): Paginated<Subscription> {
+  if (!isRecord(value) || !Array.isArray(value.results)) {
+    throw new Error("Malformed membership pagination response.");
+  }
+  if (!Number.isSafeInteger(value.count) || Number(value.count) < 0) {
+    throw new Error("Malformed membership pagination count.");
+  }
+  const next = value.next;
+  const previous = value.previous;
+  if (next !== null && typeof next !== "string") {
+    throw new Error("Malformed membership pagination next link.");
+  }
+  if (previous !== null && typeof previous !== "string") {
+    throw new Error("Malformed membership pagination previous link.");
+  }
+  return {
+    count: Number(value.count),
+    next,
+    previous,
+    results: value.results.map(parseSubscription),
+  };
+}
+
+/**
+ * Collect a validated management-list snapshot. Money decisions use the
+ * target-specific status endpoint instead, so offset pagination can never
+ * authorize a purchase.
+ */
+export async function collectSubscriptionPages(
+  loadPage: (page: number, pageSize: number) => Promise<unknown>,
+): Promise<Subscription[]> {
+  const endpoint = "/api/tuzis/my-subscriptions";
+  const pageSize = 48;
+  const subscriptions: Subscription[] = [];
+  const seenPages = new Set<number>();
+  const seenMemberships = new Set<string>();
+  let expectedCount: number | null = null;
+  let pageNumber = 1;
+
+  for (;;) {
+    if (seenPages.has(pageNumber)) {
+      throw new Error("Membership pagination repeated a page.");
+    }
+    seenPages.add(pageNumber);
+
+    const page = parseSubscriptionPage(await loadPage(pageNumber, pageSize));
+    if (pageNumber === 1) expectedCount = page.count;
+    if (page.count !== expectedCount) {
+      throw new Error("Membership pagination changed during the read.");
+    }
+    for (const subscription of page.results) {
+      const identity = subscription.star.username.toLowerCase();
+      if (seenMemberships.has(identity)) {
+        throw new Error("Membership pagination returned a duplicate row.");
+      }
+      seenMemberships.add(identity);
+      subscriptions.push(subscription);
+    }
+    if (!page.next) {
+      if (subscriptions.length !== expectedCount) {
+        throw new Error("Membership pagination returned an incomplete snapshot.");
+      }
+      return subscriptions;
+    }
+
+    const nextUrl = new URL(page.next, "http://localhost");
+    if (nextUrl.pathname !== endpoint) {
+      throw new Error("Membership pagination left its endpoint.");
+    }
+    const nextPage = Number(nextUrl.searchParams.get("page"));
+    if (!Number.isSafeInteger(nextPage) || nextPage <= pageNumber) {
+      throw new Error("Membership pagination returned an invalid next page.");
+    }
+    pageNumber = nextPage;
+  }
+}
+
+export function parseSubscriptionStatus(value: unknown): SubscriptionStatus {
+  if (
+    !isRecord(value) ||
+    typeof value.username !== "string" ||
+    typeof value.active !== "boolean"
+  ) {
+    throw new Error("Malformed membership status response.");
+  }
+  return {
+    username: value.username,
+    active: value.active,
+    expires: parseNullableString(value.expires, "expires"),
+    max_price:
+      value.max_price === null
+        ? null
+        : parseDecimalString(value.max_price, "max_price"),
+    current_price:
+      value.current_price === null
+        ? null
+        : parseDecimalString(value.current_price, "current_price"),
+  };
+}
+
+export function parseSubscribeResult(value: unknown): SubscribeResult {
+  if (
+    !isRecord(value) ||
+    typeof value.charged !== "boolean" ||
+    typeof value.replayed !== "boolean" ||
+    typeof value.expires !== "string"
+  ) {
+    throw new Error("Malformed confirmed membership response.");
+  }
+  return {
+    balance: parseDecimalString(value.balance, "balance"),
+    charged: value.charged,
+    replayed: value.replayed,
+    expires: value.expires,
+    subscription: parseSubscription(value.subscription),
+  };
 }
 
 function mapCreator(c: RawCreator): SimpleCreator {
@@ -1321,17 +1501,81 @@ export const tuzi = {
   async subscribe(
     username: string,
     idempotencyKey?: string,
-  ): Promise<SubscribeResult> {
+  ): Promise<void> {
     if (useMock()) {
       await delay(400);
-      return mockSubscribe(username, idempotencyKey);
+      const creator = mockCreators.find(
+        (candidate) =>
+          candidate.username.toLowerCase() === username.toLowerCase(),
+      );
+      mockSubscribe(
+        username,
+        idempotencyKey ?? crypto.randomUUID(),
+        creator?.member_price ?? 0,
+      );
+      return;
     }
-    return request<SubscribeResult>(`/api/tuzis/subscribe/${username}`, {
+    await request(`/api/tuzis/subscribe/${username}`, {
       method: "POST",
       headers: idempotencyKey
         ? { "Idempotency-Key": idempotencyKey }
         : undefined,
     });
+  },
+
+  async subscribeConfirmed(
+    username: string,
+    idempotencyKey: string,
+    expectedPrice: number,
+  ): Promise<SubscribeResult> {
+    if (useMock()) {
+      await delay(400);
+      return mockSubscribe(username, idempotencyKey, expectedPrice);
+    }
+    const response = await request<unknown>(
+      `/api/tuzis/subscribe-confirmed/${username}`,
+      {
+        method: "POST",
+        headers: { "Idempotency-Key": idempotencyKey },
+        body: { expected_price: expectedPrice },
+      },
+    );
+    return parseSubscribeResult(response);
+  },
+
+  /** Target-specific entitlement fact; safe for purchase decisions. */
+  async subscriptionStatus(username: string): Promise<SubscriptionStatus> {
+    if (useMock()) {
+      await delay(150);
+      const subscription = mockSubscriptions.find(
+        (candidate) =>
+          candidate.star.username.toLowerCase() === username.toLowerCase(),
+      );
+      const creator = mockCreators.find(
+        (candidate) =>
+          candidate.username.toLowerCase() === username.toLowerCase(),
+      );
+      const expires = subscription?.expires ?? null;
+      return {
+        username: creator?.username ?? username,
+        active: Boolean(expires && Date.parse(expires) > Date.now()),
+        expires,
+        max_price: subscription?.max_price ?? null,
+        current_price:
+          creator?.member_price === null || creator?.member_price === undefined
+            ? null
+            : String(creator.member_price),
+      };
+    }
+    const response = await request<unknown>(
+      `/api/tuzis/subscription-status/${username}`,
+      { cache: "no-store" },
+    );
+    const parsed = parseSubscriptionStatus(response);
+    if (parsed.username.toLowerCase() !== username.toLowerCase()) {
+      throw new Error("Membership status referred to a different creator.");
+    }
+    return parsed;
   },
 
   /**
@@ -1359,32 +1603,12 @@ export const tuzi = {
     // the money path extend them another month. Walk every page and fail the
     // whole read on malformed pagination; callers must not purchase from an
     // incomplete entitlement view.
-    const endpoint = "/api/tuzis/my-subscriptions";
-    const pageSize = 48;
-    const subscriptions: Subscription[] = [];
-    const seenPages = new Set<number>();
-    let pageNumber = 1;
-
-    for (;;) {
-      if (seenPages.has(pageNumber)) {
-        throw new Error("Membership pagination repeated a page.");
-      }
-      seenPages.add(pageNumber);
-
-      const page = await request<Paginated<Subscription>>(endpoint, {
-        query: { page: pageNumber, page_size: pageSize },
+    return collectSubscriptionPages((page, pageSize) =>
+      request<unknown>("/api/tuzis/my-subscriptions", {
+        query: { page, page_size: pageSize },
         cache: "no-store",
-      });
-      subscriptions.push(...(page.results ?? []));
-      if (!page.next) return subscriptions;
-
-      const nextUrl = new URL(page.next, "http://localhost");
-      const nextPage = Number(nextUrl.searchParams.get("page"));
-      if (!Number.isSafeInteger(nextPage) || nextPage < 1) {
-        throw new Error("Membership pagination returned an invalid next page.");
-      }
-      pageNumber = nextPage;
-    }
+      }),
+    );
   },
 
   /**

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -81,6 +81,7 @@ import type {
   SocialProvider,
   SocialProvidersStatus,
   StreamKind,
+  SubscribeResult,
   Subscription,
   TuziTransaction,
 } from "./types";
@@ -362,7 +363,7 @@ export const auth = {
       tuzis?: string;
       avatar_image?: RawImage | null;
       banner_image?: RawImage | null;
-    }>("/api/auth/user/");
+    }>("/api/auth/user/", { cache: "no-store" });
     return {
       username: u.username,
       email: u.email,
@@ -1317,13 +1318,20 @@ export const tuzi = {
     });
   },
 
-  async subscribe(username: string): Promise<void> {
+  async subscribe(
+    username: string,
+    idempotencyKey?: string,
+  ): Promise<SubscribeResult> {
     if (useMock()) {
       await delay(400);
-      mockSubscribe(username);
-      return;
+      return mockSubscribe(username, idempotencyKey);
     }
-    await request(`/api/tuzis/subscribe/${username}`, { method: "POST" });
+    return request<SubscribeResult>(`/api/tuzis/subscribe/${username}`, {
+      method: "POST",
+      headers: idempotencyKey
+        ? { "Idempotency-Key": idempotencyKey }
+        : undefined,
+    });
   },
 
   /**
@@ -1341,12 +1349,42 @@ export const tuzi = {
   async mySubscriptions(): Promise<Subscription[]> {
     if (useMock()) {
       await delay(150);
-      return [...mockSubscriptions];
+      return mockSubscriptions.filter(
+        (subscription) =>
+          !subscription.expires || Date.parse(subscription.expires) > Date.now(),
+      );
     }
-    const page = await request<Paginated<Subscription>>(
-      "/api/tuzis/my-subscriptions",
-    );
-    return page.results ?? [];
+    // This endpoint is paginated (12 rows by default). Looking at only the
+    // first page can misclassify a real active member as a nonmember and make
+    // the money path extend them another month. Walk every page and fail the
+    // whole read on malformed pagination; callers must not purchase from an
+    // incomplete entitlement view.
+    const endpoint = "/api/tuzis/my-subscriptions";
+    const pageSize = 48;
+    const subscriptions: Subscription[] = [];
+    const seenPages = new Set<number>();
+    let pageNumber = 1;
+
+    for (;;) {
+      if (seenPages.has(pageNumber)) {
+        throw new Error("Membership pagination repeated a page.");
+      }
+      seenPages.add(pageNumber);
+
+      const page = await request<Paginated<Subscription>>(endpoint, {
+        query: { page: pageNumber, page_size: pageSize },
+        cache: "no-store",
+      });
+      subscriptions.push(...(page.results ?? []));
+      if (!page.next) return subscriptions;
+
+      const nextUrl = new URL(page.next, "http://localhost");
+      const nextPage = Number(nextUrl.searchParams.get("page"));
+      if (!Number.isSafeInteger(nextPage) || nextPage < 1) {
+        throw new Error("Membership pagination returned an invalid next page.");
+      }
+      pageNumber = nextPage;
+    }
   },
 
   /**
@@ -1407,7 +1445,7 @@ export const discover = {
     }
     const c = await request<RawCreator>(
       `/api/creator/${encodeURIComponent(username)}/`,
-      { anonymous: true },
+      { anonymous: true, cache: "no-store" },
     );
     return mapCreatorDetail(c);
   },

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -673,18 +673,25 @@ export const mockSubscriptions: Subscription[] = [
  * get-or-create a `Subscription` for (star, fan) and extend it 30 days from
  * now, at the creator's current `member_price`.
  */
-const mockSubscriptionAttempts = new Map<string, SubscribeResult>();
+const mockSubscriptionAttempts = new Map<
+  string,
+  { username: string; expectedPrice: number; result: SubscribeResult }
+>();
 
 export function mockSubscribe(
   username: string,
-  idempotencyKey?: string,
+  idempotencyKey: string,
+  expectedPrice: number,
 ): SubscribeResult {
-  const attemptKey = idempotencyKey
-    ? `${username.toLowerCase()}:${idempotencyKey}`
-    : null;
-  if (attemptKey) {
-    const replay = mockSubscriptionAttempts.get(attemptKey);
-    if (replay) return replay;
+  const replay = mockSubscriptionAttempts.get(idempotencyKey);
+  if (replay) {
+    if (
+      replay.username !== username.toLowerCase() ||
+      replay.expectedPrice !== expectedPrice
+    ) {
+      throw new Error("This idempotency key was used for different terms.");
+    }
+    return { ...replay.result, replayed: true };
   }
 
   const star: SimpleCreator =
@@ -692,6 +699,7 @@ export function mockSubscribe(
     { username, free2zaddr: username, display_name: username };
   const price = star.member_price ?? 0;
   if (price <= 0) throw new Error("Creator did not set member price");
+  if (price !== expectedPrice) throw new Error("Membership price changed");
   if (mockUser.tuzis < price) throw new Error("Insufficient funds");
 
   const now = Date.now();
@@ -718,9 +726,25 @@ export function mockSubscribe(
     const sub: Subscription = { fan: mockFan(), star, expires, max_price: maxPrice };
     mockSubscriptions.push(sub);
   }
+  const subscription =
+    existing ??
+    mockSubscriptions.find(
+      (candidate) =>
+        candidate.star.username.toLowerCase() === username.toLowerCase(),
+    )!;
   mockUser.tuzis -= price;
-  const result = { charged: true, expires };
-  if (attemptKey) mockSubscriptionAttempts.set(attemptKey, result);
+  const result: SubscribeResult = {
+    balance: String(mockUser.tuzis),
+    charged: true,
+    replayed: false,
+    expires,
+    subscription,
+  };
+  mockSubscriptionAttempts.set(idempotencyKey, {
+    username: username.toLowerCase(),
+    expectedPrice,
+    result,
+  });
   return result;
 }
 

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -19,6 +19,7 @@ import type {
   PersonalityInput,
   PromptResponse,
   SimpleCreator,
+  SubscribeResult,
   Subscription,
   TuziTransaction,
 } from "./types";
@@ -672,24 +673,55 @@ export const mockSubscriptions: Subscription[] = [
  * get-or-create a `Subscription` for (star, fan) and extend it 30 days from
  * now, at the creator's current `member_price`.
  */
-export function mockSubscribe(username: string): Subscription {
+const mockSubscriptionAttempts = new Map<string, SubscribeResult>();
+
+export function mockSubscribe(
+  username: string,
+  idempotencyKey?: string,
+): SubscribeResult {
+  const attemptKey = idempotencyKey
+    ? `${username.toLowerCase()}:${idempotencyKey}`
+    : null;
+  if (attemptKey) {
+    const replay = mockSubscriptionAttempts.get(attemptKey);
+    if (replay) return replay;
+  }
+
   const star: SimpleCreator =
     mockCreators.find((c) => c.username.toLowerCase() === username.toLowerCase()) ??
     { username, free2zaddr: username, display_name: username };
-  const expires = new Date(Date.now() + 30 * 86400000).toISOString();
-  const maxPrice = String(star.member_price ?? 0);
+  const price = star.member_price ?? 0;
+  if (price <= 0) throw new Error("Creator did not set member price");
+  if (mockUser.tuzis < price) throw new Error("Insufficient funds");
+
+  const now = Date.now();
+  const thirtyDays = 30 * 86400000;
+  const maxPrice = String(price);
 
   const existing = mockSubscriptions.find(
     (s) => s.star.username.toLowerCase() === username.toLowerCase(),
   );
+  let expires: string;
   if (existing) {
+    const previousExpiry = Date.parse(existing.expires ?? "");
+    expires = new Date(
+      Math.max(
+        Number.isFinite(previousExpiry) ? previousExpiry + thirtyDays : 0,
+        now + thirtyDays,
+      ),
+    ).toISOString();
     existing.expires = expires;
-    existing.max_price = maxPrice;
-    return existing;
+    // Backend POST extends an existing row but does not silently re-enable a
+    // max_price that the fan previously set to zero.
+  } else {
+    expires = new Date(now + thirtyDays).toISOString();
+    const sub: Subscription = { fan: mockFan(), star, expires, max_price: maxPrice };
+    mockSubscriptions.push(sub);
   }
-  const sub: Subscription = { fan: mockFan(), star, expires, max_price: maxPrice };
-  mockSubscriptions.push(sub);
-  return sub;
+  mockUser.tuzis -= price;
+  const result = { charged: true, expires };
+  if (attemptKey) mockSubscriptionAttempts.set(attemptKey, result);
+  return result;
 }
 
 /**

--- a/wallet/zuuli/src/lib/api/subscription-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/subscription-contract.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  collectSubscriptionPages,
+  parseSubscribeResult,
+  parseSubscriptionPage,
+  parseSubscriptionStatus,
+} from "./free2z";
+
+function rawSubscription(username: string) {
+  return {
+    fan: { username: "viewer" },
+    star: { username },
+    expires: "2099-01-01T00:00:00Z",
+    max_price: "10",
+  };
+}
+
+function page(
+  count: number,
+  results: unknown[],
+  next: string | null = null,
+) {
+  return { count, next, previous: null, results };
+}
+
+describe("membership pagination contract", () => {
+  it("rejects missing or non-array results instead of failing open", () => {
+    expect(() =>
+      parseSubscriptionPage({ count: 1, next: null, previous: null }),
+    ).toThrow("Malformed membership pagination response");
+    expect(() =>
+      parseSubscriptionPage({
+        count: 1,
+        next: null,
+        previous: null,
+        results: {},
+      }),
+    ).toThrow("Malformed membership pagination response");
+  });
+
+  it("collects a complete validated multi-page snapshot", async () => {
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce(
+        page(2, [rawSubscription("one")], "/api/tuzis/my-subscriptions?page=2"),
+      )
+      .mockResolvedValueOnce(page(2, [rawSubscription("two")]));
+
+    await expect(collectSubscriptionPages(load)).resolves.toHaveLength(2);
+    expect(load).toHaveBeenNthCalledWith(1, 1, 48);
+    expect(load).toHaveBeenNthCalledWith(2, 2, 48);
+  });
+
+  it("rejects count drift and duplicates caused by a mutable offset list", async () => {
+    const drift = vi
+      .fn()
+      .mockResolvedValueOnce(
+        page(2, [rawSubscription("one")], "/api/tuzis/my-subscriptions?page=2"),
+      )
+      .mockResolvedValueOnce(page(3, [rawSubscription("two")]));
+    await expect(collectSubscriptionPages(drift)).rejects.toThrow(
+      "changed during the read",
+    );
+
+    const duplicate = vi
+      .fn()
+      .mockResolvedValueOnce(
+        page(2, [rawSubscription("one")], "/api/tuzis/my-subscriptions?page=2"),
+      )
+      .mockResolvedValueOnce(page(2, [rawSubscription("one")]));
+    await expect(collectSubscriptionPages(duplicate)).rejects.toThrow(
+      "duplicate row",
+    );
+  });
+
+  it("rejects incomplete and off-endpoint pagination", async () => {
+    await expect(
+      collectSubscriptionPages(
+        vi.fn().mockResolvedValue(page(2, [rawSubscription("one")])),
+      ),
+    ).rejects.toThrow("incomplete snapshot");
+
+    await expect(
+      collectSubscriptionPages(
+        vi
+          .fn()
+          .mockResolvedValue(
+            page(2, [rawSubscription("one")], "/api/other?page=2"),
+          ),
+      ),
+    ).rejects.toThrow("left its endpoint");
+  });
+});
+
+describe("target membership money contract", () => {
+  it("rejects malformed status rather than treating it as nonmember", () => {
+    expect(() => parseSubscriptionStatus({ active: false })).toThrow(
+      "Malformed membership status response",
+    );
+    expect(() =>
+      parseSubscriptionStatus({
+        username: "creator",
+        active: false,
+        expires: null,
+        max_price: null,
+      }),
+    ).toThrow("current_price");
+  });
+
+  it("requires the authoritative balance and full subscription result", () => {
+    expect(() =>
+      parseSubscribeResult({
+        charged: true,
+        replayed: false,
+        expires: "2099-01-01T00:00:00Z",
+        subscription: rawSubscription("creator"),
+      }),
+    ).toThrow("balance");
+  });
+});

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -364,6 +364,14 @@ export interface Subscription {
   max_price?: string;
 }
 
+/** POST /api/tuzis/subscribe/{username} authoritative money result. */
+export interface SubscribeResult {
+  /** False when the backend safely swallowed an idempotent/debounced retry. */
+  charged: boolean;
+  /** Authoritative membership expiry after the request. */
+  expires: string;
+}
+
 export interface TuziTransaction {
   id: number;
   amount: number; // cents paid

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -364,12 +364,26 @@ export interface Subscription {
   max_price?: string;
 }
 
-/** POST /api/tuzis/subscribe/{username} authoritative money result. */
+/** GET /api/tuzis/subscription-status/{username} entitlement fact. */
+export interface SubscriptionStatus {
+  username: string;
+  active: boolean;
+  expires: string | null;
+  max_price: string | null;
+  current_price: string | null;
+}
+
+/** POST /api/tuzis/subscribe-confirmed/{username} authoritative result. */
 export interface SubscribeResult {
   /** False when the backend safely swallowed an idempotent/debounced retry. */
   charged: boolean;
+  /** True when the backend replayed the response for this exact retry key. */
+  replayed: boolean;
+  /** Authoritative post-operation account balance. */
+  balance: string;
   /** Authoritative membership expiry after the request. */
   expires: string;
+  subscription: Subscription;
 }
 
 export interface TuziTransaction {


### PR DESCRIPTION
## Summary

- replace subscriber-room one-click purchase with explicit creator, 30-day price, renewal, current-balance, and balance-after review
- authorize purchase only from that exact dialog; an active-member click is permanently join-only and cannot become a purchase if entitlement expires during preflight
- use a target-specific, server-timed membership-status endpoint for money decisions; separately validate every management-list page and reject malformed, duplicated, drifting, or incomplete pagination
- call the new backend-first `subscribe-confirmed` route with a required UUIDv4 `Idempotency-Key` and atomically enforced `expected_price`
- reconcile both authoritative target entitlement and `auth.me()` balance before requesting a subscriber-room ticket
- retain the same key across ambiguous failures so a retry replays rather than extending another month

## Safety properties

- canceling the dialog performs no money request
- only `purchase-approved` mode may reach the subscription POST; `join-only` expiry fails before reconcile, POST, or join and requires fresh price review
- a transaction-locked backend price mismatch returns the new current price without a debit
- a successful or ambiguous POST never joins until target entitlement and account balance both reconcile
- an already-active retry also requires balance reconciliation before join
- a synchronous single-flight guard closes the React double-click window
- malformed or unavailable entitlement data fails closed
- older backends lack the explicit routes and therefore fail without a legacy side effect

## Backend dependency and rollout

Depends on free2z/tuzi#975 at exact green head `25e14e1f4325fedc076026e1ca7e904e715f6ef1`. That PR adds the target-status and atomic confirmed-subscription contracts. Merge and deploy the backend before merging/releasing this client. This PR intentionally does not change the tuzi submodule pointer because #303 shares the same coordinated backend-first rollout.

## Verification

- `npm run typecheck`
- `npm test` — 121 tests passed
- focused membership/API contract suite — 18 tests passed
- `npm run build`
- `npm run release:verify -- --version 0.1.0 --build-number 7` — `0.1.0+7`
- `git diff --check`
- ZUU app gate green on exact head `3f3e759e92d4ce1e98086e33c2f6357b5e6ddf59`; packaging smoke jobs are tracked separately
- independent exact-head technical APPROVE: https://github.com/free2z/zuu/pull/304#pullrequestreview-4890110182

## Adversarial review

The original review found an atomic-price TOCTOU, a stale-balance retry path, and fail-open/mutable pagination; all were repaired with the upstream contracts and authoritative reconciliation. A second review found a stale-active consent race where a join click could fall through to purchase after expiry; explicit join-only authority now blocks that transition and has a zero-POST/zero-join regression test. The repaired exact head has an independent technical APPROVE. GitHub records it as COMMENTED because all agents authenticate as the PR-author account; formal governance still requires a different identity or the documented admin path.

Closes #263