### PR TITLE
fix(wallet): restore sync after aborted transitions

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/commands.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use tauri::{command, AppHandle, Runtime};
 
@@ -19,6 +20,143 @@ fn format_birthday_error(e: BirthdayError) -> String {
     match e {
         BirthdayError::HeightInvalid(e) => format!("invalid height: {e}"),
         BirthdayError::Decode(e) => format!("decode error: {e}"),
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PreviousSyncContext {
+    wallet_id: Option<String>,
+    was_syncing: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SyncRecoveryObligation {
+    previous: PreviousSyncContext,
+    armed: bool,
+}
+
+impl SyncRecoveryObligation {
+    fn new(previous: PreviousSyncContext) -> Self {
+        Self {
+            armed: previous.was_syncing,
+            previous,
+        }
+    }
+
+    fn commit(&mut self) {
+        self.armed = false;
+    }
+
+    fn should_restart(&self, active_wallet_id: Option<&str>, shutting_down: bool) -> bool {
+        self.armed
+            && self
+                .previous
+                .should_restart(active_wallet_id, shutting_down)
+    }
+}
+
+impl PreviousSyncContext {
+    fn should_restart(&self, active_wallet_id: Option<&str>, shutting_down: bool) -> bool {
+        self.was_syncing
+            && !shutting_down
+            && self
+                .wallet_id
+                .as_deref()
+                .is_some_and(|wallet_id| Some(wallet_id) == active_wallet_id)
+    }
+}
+
+/// Owns the obligation to restore a sync task stopped for an uncommitted wallet
+/// transition. Normal errors restore synchronously through `restore_now`; Drop
+/// covers cancellation, timeout, and panic-unwind boundaries by scheduling the
+/// same identity-checked recovery after the transition lock is released.
+struct StoppedSyncRecovery<R: Runtime> {
+    app: AppHandle<R>,
+    obligation: SyncRecoveryObligation,
+}
+
+impl<R: Runtime> StoppedSyncRecovery<R> {
+    async fn stop(app: AppHandle<R>) -> Self {
+        let state = &app.zcash().state;
+        let previous = PreviousSyncContext {
+            wallet_id: state.active_wallet_id().await,
+            was_syncing: *state.syncing.read().await,
+        };
+        // Construct the guard before the first cancellation point involved in
+        // stopping the task. If this future is dropped while joining, Drop will
+        // still restore the exact context that was active at entry.
+        let recovery = Self {
+            app,
+            obligation: SyncRecoveryObligation::new(previous),
+        };
+        crate::wallet::sync::stop_sync(&recovery.app.zcash().state)
+            .await
+            .expect("stopping sync is infallible");
+        recovery
+    }
+
+    fn commit(&mut self) {
+        self.obligation.commit();
+    }
+
+    async fn restore_now(&mut self) {
+        if !self.obligation.armed {
+            return;
+        }
+        restart_previous_sync(&self.app, &self.obligation).await;
+        self.obligation.commit();
+    }
+}
+
+impl<R: Runtime> Drop for StoppedSyncRecovery<R> {
+    fn drop(&mut self) {
+        if !self.obligation.armed
+            || self
+                .app
+                .zcash()
+                .state
+                .shutting_down
+                .load(Ordering::Acquire)
+        {
+            return;
+        }
+        let app = self.app.clone();
+        let obligation = self.obligation.clone();
+        // The command's owned transition guard is declared before this recovery
+        // guard, so it drops immediately after us. Reacquiring it here makes the
+        // cancelled transition and its recovery one serialized identity unit.
+        tauri::async_runtime::spawn(async move {
+            let transition = Arc::clone(&app.zcash().state.wallet_transition)
+                .lock_owned()
+                .await;
+            restart_previous_sync(&app, &obligation).await;
+            drop(transition);
+        });
+    }
+}
+
+async fn restart_previous_sync<R: Runtime>(
+    app: &AppHandle<R>,
+    obligation: &SyncRecoveryObligation,
+) {
+    let state = &app.zcash().state;
+    let shutting_down = state.shutting_down.load(Ordering::Acquire);
+    let active_wallet_id = state.active_wallet_id().await;
+    if !obligation.should_restart(active_wallet_id.as_deref(), shutting_down) {
+        if obligation.previous.was_syncing && !shutting_down {
+            tracing::warn!(
+                expected_wallet_id = ?obligation.previous.wallet_id,
+                active_wallet_id = ?active_wallet_id,
+                "not restoring sync because the wallet context changed"
+            );
+        }
+        return;
+    }
+    if let Err(error) = crate::wallet::sync::start_sync(app.clone(), state).await {
+        tracing::error!(
+            wallet_id = ?obligation.previous.wallet_id,
+            "failed to restore sync after aborted wallet transition: {error}"
+        );
     }
 }
 
@@ -163,14 +301,11 @@ pub(crate) async fn create_wallet<R: Runtime>(
     let word_count = args.mnemonic_word_count.unwrap_or(24);
     let wallet_name = args.name.unwrap_or_else(|| "Default".to_string());
 
-    // Stop any running sync and wait until it has released the old write DB.
-    // The transition lock prevents another wallet operation from interleaving.
-    *zcash.state.syncing.write().await = false;
-    if let Some(h) = zcash.state.sync_handle.lock().await.take() {
-        h.abort();
-        let _ = h.await;
-    }
+    // Stop any running sync and retain an identity-bound recovery obligation
+    // until the new wallet context has committed.
+    let mut sync_recovery = StoppedSyncRecovery::stop(app.clone()).await;
 
+    let result = async {
     let mnemonic = keys::generate_mnemonic(word_count)?;
     let seed = keys::mnemonic_to_seed(&mnemonic);
 
@@ -275,6 +410,14 @@ pub(crate) async fn create_wallet<R: Runtime>(
         )));
     }
 
+    // Acquire every live context slot before publication. Once the manifest
+    // commit returns successfully, installing the matching in-memory context
+    // contains no cancellation point.
+    let mut db_guard = zcash.state.db.lock().await;
+    let mut read_db_guard = zcash.state.read_db.lock().await;
+    let mut seed_guard = zcash.state.seed.lock().await;
+    let mut pending_proposal_guard = zcash.state.pending_proposal.lock().await;
+    let mut pending_broadcast_guard = zcash.state.pending_broadcast.lock().await;
     let manifest_commit = {
         let mut manifest = zcash.state.manifest.lock().await;
         manifest.commit_wallet(&zcash.state.data_dir, wallet_entry.clone())
@@ -289,6 +432,11 @@ pub(crate) async fn create_wallet<R: Runtime>(
             false
         }
         Err(error) => {
+            drop(pending_broadcast_guard);
+            drop(pending_proposal_guard);
+            drop(seed_guard);
+            drop(read_db_guard);
+            drop(db_guard);
             drop(read_db);
             drop(db);
             if let Err(cleanup_error) =
@@ -320,29 +468,45 @@ pub(crate) async fn create_wallet<R: Runtime>(
         }
     }
 
-    *zcash.state.pending_proposal.lock().await = None;
-    *zcash.state.pending_broadcast.lock().await =
+    *pending_proposal_guard = None;
+    *pending_broadcast_guard =
         send::load_pending_broadcast(&zcash.state.data_dir, &wallet_entry.id);
-    // The exact generation is now active. Cancel its rollback tombstone before
-    // installing the live context; a cancellation failure is safe because
-    // every future retry recognizes and preserves this manifest generation.
+    *db_guard = Some(db);
+    *read_db_guard = Some(read_db);
+    *seed_guard = Some(seed);
+    sync_recovery.commit();
+    drop(pending_broadcast_guard);
+    drop(pending_proposal_guard);
+    drop(seed_guard);
+    drop(read_db_guard);
+    drop(db_guard);
+
+    // The exact generation is now active. A cancellation failure is safe
+    // because every future retry recognizes and preserves this manifest
+    // generation.
     retry_staged_wallet_cleanup(&zcash.state, "wallet rollback cancellation deferred").await;
-
-    // Complete the entire context swap before releasing the transition lock or
-    // returning. A caller must never observe the new manifest/read DB/seed while
-    // mutations still target the previous wallet's write DB.
-    *zcash.state.db.lock().await = Some(db);
-    *zcash.state.read_db.lock().await = Some(read_db);
-    *zcash.state.seed.lock().await = Some(seed);
-    drop(transition_guard);
-
-    // Auto-start sync only after the new context is fully installed.
-    let _ = crate::wallet::sync::start_sync(app.clone(), &zcash.state).await;
 
     Ok(WalletCreated {
         seed_phrase: mnemonic.phrase().to_string(),
         birthday_height: tip_height,
     })
+    }
+    .await;
+
+    match result {
+        Ok(created) => {
+            sync_recovery.commit();
+            drop(transition_guard);
+            // Auto-start sync only after the new context is fully installed.
+            let _ = crate::wallet::sync::start_sync(app.clone(), &zcash.state).await;
+            Ok(created)
+        }
+        Err(error) => {
+            sync_recovery.restore_now().await;
+            drop(transition_guard);
+            Err(error)
+        }
+    }
 }
 
 #[command]
@@ -360,13 +524,11 @@ pub(crate) async fn restore_wallet<R: Runtime>(
     let birthday_height = args.birthday_height.unwrap_or(419200); // sapling activation
     let wallet_name = args.name.unwrap_or_else(|| "Restored".to_string());
 
-    // Stop any running sync and wait until it has released the old write DB.
-    *zcash.state.syncing.write().await = false;
-    if let Some(h) = zcash.state.sync_handle.lock().await.take() {
-        h.abort();
-        let _ = h.await;
-    }
+    // Stop any running sync and retain an identity-bound recovery obligation
+    // until the restored wallet context has committed.
+    let mut sync_recovery = StoppedSyncRecovery::stop(app.clone()).await;
 
+    let result = async {
     // Connect to lightwalletd
     let url = zcash.state.lightwalletd_url.read().await.clone();
     let mut client = connect_to_lightwalletd(&url).await?;
@@ -481,6 +643,11 @@ pub(crate) async fn restore_wallet<R: Runtime>(
         )));
     }
 
+    let mut db_guard = zcash.state.db.lock().await;
+    let mut read_db_guard = zcash.state.read_db.lock().await;
+    let mut seed_guard = zcash.state.seed.lock().await;
+    let mut pending_proposal_guard = zcash.state.pending_proposal.lock().await;
+    let mut pending_broadcast_guard = zcash.state.pending_broadcast.lock().await;
     let manifest_commit = {
         let mut manifest = zcash.state.manifest.lock().await;
         manifest.commit_wallet(&zcash.state.data_dir, wallet_entry.clone())
@@ -495,6 +662,11 @@ pub(crate) async fn restore_wallet<R: Runtime>(
             false
         }
         Err(error) => {
+            drop(pending_broadcast_guard);
+            drop(pending_proposal_guard);
+            drop(seed_guard);
+            drop(read_db_guard);
+            drop(db_guard);
             drop(read_db);
             drop(db);
             if let Err(cleanup_error) =
@@ -530,24 +702,42 @@ pub(crate) async fn restore_wallet<R: Runtime>(
         }
     }
 
-    *zcash.state.pending_proposal.lock().await = None;
-    *zcash.state.pending_broadcast.lock().await =
+    *pending_proposal_guard = None;
+    *pending_broadcast_guard =
         send::load_pending_broadcast(&zcash.state.data_dir, &wallet_entry.id);
+    *db_guard = Some(db);
+    *read_db_guard = Some(read_db);
+    *seed_guard = Some(seed);
+    sync_recovery.commit();
+    drop(pending_broadcast_guard);
+    drop(pending_proposal_guard);
+    drop(seed_guard);
+    drop(read_db_guard);
+    drop(db_guard);
+
     retry_staged_wallet_cleanup(
         &zcash.state,
         "restored wallet rollback cancellation deferred",
     )
     .await;
 
-    // Complete the write/read/seed swap before returning; see create_wallet.
-    *zcash.state.db.lock().await = Some(db);
-    *zcash.state.read_db.lock().await = Some(read_db);
-    *zcash.state.seed.lock().await = Some(seed);
-    drop(transition_guard);
-
-    let _ = crate::wallet::sync::start_sync(app.clone(), &zcash.state).await;
-
     Ok(serde_json::json!({ "success": true }))
+    }
+    .await;
+
+    match result {
+        Ok(value) => {
+            sync_recovery.commit();
+            drop(transition_guard);
+            let _ = crate::wallet::sync::start_sync(app.clone(), &zcash.state).await;
+            Ok(value)
+        }
+        Err(error) => {
+            sync_recovery.restore_now().await;
+            drop(transition_guard);
+            Err(error)
+        }
+    }
 }
 
 #[command]
@@ -816,19 +1006,18 @@ pub(crate) async fn switch_wallet<R: Runtime>(
     )?;
 
     // Stop and join sync so it cannot retain or mutate the previous write DB
-    // while the new context is installed.
-    *zcash.state.syncing.write().await = false;
-    let handle = zcash.state.sync_handle.lock().await.take();
-    if let Some(handle) = handle {
-        handle.abort();
-        let _ = handle.await;
-    }
+    // while the new context is installed. Until the manifest commits, every
+    // exit path retains an obligation to restore this exact wallet context.
+    let mut sync_recovery = StoppedSyncRecovery::stop(app.clone()).await;
 
+    let result = async {
     // Hold every context slot while committing the active selection. There is
     // no await between the durable manifest mutation and the in-memory swap.
     let mut db_guard = zcash.state.db.lock().await;
     let mut read_db_guard = zcash.state.read_db.lock().await;
     let mut seed_guard = zcash.state.seed.lock().await;
+    let mut pending_proposal_guard = zcash.state.pending_proposal.lock().await;
+    let mut pending_broadcast_guard = zcash.state.pending_broadcast.lock().await;
     let activation = {
         let mut manifest = zcash.state.manifest.lock().await;
         manifest.set_active(&zcash.state.data_dir, &args.wallet_id)
@@ -836,38 +1025,58 @@ pub(crate) async fn switch_wallet<R: Runtime>(
     let activated = match activation {
         Ok(activated) => activated,
         Err(error) => {
+            drop(pending_broadcast_guard);
+            drop(pending_proposal_guard);
             drop(seed_guard);
             drop(read_db_guard);
             drop(db_guard);
-            let _ = crate::wallet::sync::start_sync(app.clone(), &zcash.state).await;
             return Err(Error::DatabaseError(format!(
                 "failed to persist active wallet: {error}"
             )));
         }
     };
     if !activated {
+        drop(pending_broadcast_guard);
+        drop(pending_proposal_guard);
         drop(seed_guard);
         drop(read_db_guard);
         drop(db_guard);
-        let _ = crate::wallet::sync::start_sync(app.clone(), &zcash.state).await;
         return Err(Error::Other("wallet not found".into()));
     }
     *db_guard = Some(new_db);
-    *read_db_guard = Some(new_read_db);
-    *seed_guard = None;
-    drop(seed_guard);
+        *read_db_guard = Some(new_read_db);
+        *seed_guard = None;
+        // From here forward the manifest and all live context slots refer to
+        // the target. Cancellation must not restart the predecessor.
+        sync_recovery.commit();
+        drop(seed_guard);
     drop(read_db_guard);
     drop(db_guard);
 
     // Only committed transitions invalidate the previous wallet's proposal.
-    *zcash.state.pending_proposal.lock().await = None;
-    *zcash.state.pending_broadcast.lock().await =
+    *pending_proposal_guard = None;
+    *pending_broadcast_guard =
         send::load_pending_broadcast(&zcash.state.data_dir, &wallet_entry.id);
+    drop(pending_broadcast_guard);
+    drop(pending_proposal_guard);
 
     // Reset chain tip cache
     zcash.state.last_known_chain_tip.store(0, std::sync::atomic::Ordering::Relaxed);
 
     Ok(())
+    }
+    .await;
+
+    match result {
+        Ok(()) => {
+            sync_recovery.commit();
+            Ok(())
+        }
+        Err(error) => {
+            sync_recovery.restore_now().await;
+            Err(error)
+        }
+    }
 }
 
 #[command]
@@ -901,19 +1110,25 @@ pub(crate) async fn delete_wallet<R: Runtime>(
         let manifest = zcash.state.manifest.lock().await;
         manifest.active_wallet_id.as_deref() == Some(&args.wallet_id)
     };
-    if deleting_active {
-        *zcash.state.syncing.write().await = false;
-        if let Some(handle) = zcash.state.sync_handle.lock().await.take() {
-            handle.abort();
-            let _ = handle.await;
-        }
-        *zcash.state.pending_proposal.lock().await = None;
-    }
+    let mut sync_recovery = if deleting_active {
+        Some(StoppedSyncRecovery::stop(app.clone()).await)
+    } else {
+        None
+    };
 
+    let result = async {
     // Prepare the replacement wallet before committing an active-wallet
     // deletion. Once the deletion is durable, no later failure may turn the
     // command into an ambiguous error that invites a destructive retry.
-    let (deletion, prepared_active) = {
+    let (
+        deletion,
+        prepared_active,
+        mut db_guard,
+        mut read_db_guard,
+        mut seed_guard,
+        mut pending_proposal_guard,
+        mut pending_broadcast_guard,
+    ) = {
         let mut manifest = zcash.state.manifest.lock().await;
         let prepared = if manifest.active_wallet_id.as_deref() == Some(&args.wallet_id) {
             let deletion_pos = manifest
@@ -944,25 +1159,75 @@ pub(crate) async fn delete_wallet<R: Runtime>(
         } else {
             None
         };
+        let db_guard = if prepared.is_some() {
+            Some(zcash.state.db.lock().await)
+        } else {
+            None
+        };
+        let read_db_guard = if prepared.is_some() {
+            Some(zcash.state.read_db.lock().await)
+        } else {
+            None
+        };
+        let seed_guard = if prepared.is_some() {
+            Some(zcash.state.seed.lock().await)
+        } else {
+            None
+        };
+        let pending_proposal_guard = if prepared.is_some() {
+            Some(zcash.state.pending_proposal.lock().await)
+        } else {
+            None
+        };
+        let pending_broadcast_guard = if prepared.is_some() {
+            Some(zcash.state.pending_broadcast.lock().await)
+        } else {
+            None
+        };
         let deletion =
             commit_wallet_deletion(&mut manifest, &zcash.state.data_dir, &args.wallet_id)?;
-        (deletion, prepared)
+        (
+            deletion,
+            prepared,
+            db_guard,
+            read_db_guard,
+            seed_guard,
+            pending_proposal_guard,
+            pending_broadcast_guard,
+        )
     };
 
     // If we deleted the active wallet, switch to the new active
     if deletion.was_active {
         if let Some((entry, db, read_db)) = prepared_active {
-            *zcash.state.db.lock().await = Some(db);
-            *zcash.state.read_db.lock().await = Some(read_db);
+            **db_guard.as_mut().expect("active deletion holds the write context") = Some(db);
+            **read_db_guard
+                .as_mut()
+                .expect("active deletion holds the read context") = Some(read_db);
             // Do not prompt while finalizing a destructive transition. The next
             // explicit spend/reveal action authenticates against native custody.
-            *zcash.state.seed.lock().await = None;
-            *zcash.state.pending_broadcast.lock().await =
+            **seed_guard
+                .as_mut()
+                .expect("active deletion holds the seed context") = None;
+            **pending_proposal_guard
+                .as_mut()
+                .expect("active deletion holds the proposal context") = None;
+            **pending_broadcast_guard
+                .as_mut()
+                .expect("active deletion holds the broadcast context") =
                 send::load_pending_broadcast(&zcash.state.data_dir, &entry.id);
             zcash
                 .state
                 .last_known_chain_tip
                 .store(0, std::sync::atomic::Ordering::Relaxed);
+            if let Some(recovery) = sync_recovery.as_mut() {
+                recovery.commit();
+            }
+            drop(pending_broadcast_guard.take());
+            drop(pending_proposal_guard.take());
+            drop(seed_guard.take());
+            drop(read_db_guard.take());
+            drop(db_guard.take());
 
             let status = run_wallet_cleanup_retry(
                 &zcash.state,
@@ -999,6 +1264,116 @@ pub(crate) async fn delete_wallet<R: Runtime>(
     }
 
     Ok(())
+    }
+    .await;
+
+    if result.is_err() {
+        if let Some(recovery) = sync_recovery.as_mut() {
+            recovery.restore_now().await;
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod sync_recovery_tests {
+    use super::*;
+
+    const PRECOMMIT_FAILURE_STAGES: &[&str] = &[
+        "create/mnemonic-generation",
+        "create/network-connect",
+        "create/latest-block",
+        "create/tree-state",
+        "create/birthday-decode",
+        "create/rollback-schedule",
+        "create/database-init",
+        "create/account-create",
+        "create/read-database-open",
+        "create/custody-store",
+        "create/custody-protect",
+        "create/live-context-lock-cancellation",
+        "create/manifest-persist",
+        "restore/network-connect",
+        "restore/latest-block",
+        "restore/tree-state",
+        "restore/birthday-decode",
+        "restore/rollback-schedule",
+        "restore/database-init",
+        "restore/account-create",
+        "restore/read-database-open",
+        "restore/custody-store",
+        "restore/custody-protect",
+        "restore/live-context-lock-cancellation",
+        "restore/manifest-persist",
+        "switch/context-lock-cancellation",
+        "switch/manifest-persist",
+        "switch/target-disappeared",
+        "delete/last-wallet-validation",
+        "delete/replacement-database-open",
+        "delete/replacement-read-database-open",
+        "delete/live-context-lock-cancellation",
+        "delete/manifest-persist",
+    ];
+
+    const ABORT_BOUNDARIES: &[&str] = &["error", "cancellation", "timeout", "panic-unwind", "drop"];
+
+    fn active_obligation() -> SyncRecoveryObligation {
+        SyncRecoveryObligation::new(PreviousSyncContext {
+            wallet_id: Some("wallet-before-transition".into()),
+            was_syncing: true,
+        })
+    }
+
+    #[test]
+    fn every_precommit_failure_restores_the_exact_previous_wallet() {
+        for stage in PRECOMMIT_FAILURE_STAGES {
+            let recovery = active_obligation();
+            assert!(
+                recovery.should_restart(Some("wallet-before-transition"), false),
+                "pre-commit failure at {stage} must restore the prior sync"
+            );
+            assert!(
+                !recovery.should_restart(Some("different-wallet"), false),
+                "pre-commit failure at {stage} must not target another wallet"
+            );
+        }
+    }
+
+    #[test]
+    fn every_abort_boundary_retains_the_same_recovery_obligation() {
+        for boundary in ABORT_BOUNDARIES {
+            let recovery = active_obligation();
+            assert!(
+                recovery.should_restart(Some("wallet-before-transition"), false),
+                "{boundary} must retain recovery until commit"
+            );
+        }
+    }
+
+    #[test]
+    fn stopped_or_identityless_context_never_starts_sync() {
+        let stopped = SyncRecoveryObligation::new(PreviousSyncContext {
+            wallet_id: Some("wallet-before-transition".into()),
+            was_syncing: false,
+        });
+        assert!(!stopped.should_restart(Some("wallet-before-transition"), false));
+
+        let identityless = SyncRecoveryObligation::new(PreviousSyncContext {
+            wallet_id: None,
+            was_syncing: true,
+        });
+        assert!(!identityless.should_restart(None, false));
+    }
+
+    #[test]
+    fn commit_and_shutdown_are_irreversible_no_restart_boundaries() {
+        let mut committed = active_obligation();
+        committed.commit();
+        assert!(!committed.should_restart(Some("wallet-before-transition"), false));
+
+        let shutting_down = active_obligation();
+        assert!(!shutting_down.should_restart(Some("wallet-before-transition"), true));
+    }
 }
 
 #[cfg(test)]

--- a/wallet/plugins/tauri-plugin-zcash/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/commands.rs
@@ -1,5 +1,5 @@
+use std::future::Future;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 
 use tauri::{command, AppHandle, Runtime};
 
@@ -110,29 +110,29 @@ impl<R: Runtime> StoppedSyncRecovery<R> {
 
 impl<R: Runtime> Drop for StoppedSyncRecovery<R> {
     fn drop(&mut self) {
-        if !self.obligation.armed
-            || self
-                .app
-                .zcash()
-                .state
-                .shutting_down
-                .load(Ordering::Acquire)
-        {
+        if !self.obligation.armed || self.app.zcash().state.sync_supervisor.is_shutting_down() {
             return;
         }
         let app = self.app.clone();
         let obligation = self.obligation.clone();
+        let transition = Arc::clone(&app.zcash().state.wallet_transition);
         // The command's owned transition guard is declared before this recovery
         // guard, so it drops immediately after us. Reacquiring it here makes the
         // cancelled transition and its recovery one serialized identity unit.
-        tauri::async_runtime::spawn(async move {
-            let transition = Arc::clone(&app.zcash().state.wallet_transition)
-                .lock_owned()
-                .await;
+        spawn_recovery_after_transition(transition, async move {
             restart_previous_sync(&app, &obligation).await;
-            drop(transition);
         });
     }
+}
+
+fn spawn_recovery_after_transition<F>(transition: Arc<tokio::sync::Mutex<()>>, recovery: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    tauri::async_runtime::spawn(async move {
+        let _transition = transition.lock_owned().await;
+        recovery.await;
+    });
 }
 
 async fn restart_previous_sync<R: Runtime>(
@@ -140,7 +140,7 @@ async fn restart_previous_sync<R: Runtime>(
     obligation: &SyncRecoveryObligation,
 ) {
     let state = &app.zcash().state;
-    let shutting_down = state.shutting_down.load(Ordering::Acquire);
+    let shutting_down = state.sync_supervisor.is_shutting_down();
     let active_wallet_id = state.active_wallet_id().await;
     if !obligation.should_restart(active_wallet_id.as_deref(), shutting_down) {
         if obligation.previous.was_syncing && !shutting_down {
@@ -496,9 +496,11 @@ pub(crate) async fn create_wallet<R: Runtime>(
     match result {
         Ok(created) => {
             sync_recovery.commit();
-            drop(transition_guard);
-            // Auto-start sync only after the new context is fully installed.
+            // Keep the transition lock through task registration so another
+            // switch/delete cannot replace the just-installed context between
+            // publication and its automatic sync start.
             let _ = crate::wallet::sync::start_sync(app.clone(), &zcash.state).await;
+            drop(transition_guard);
             Ok(created)
         }
         Err(error) => {
@@ -728,8 +730,11 @@ pub(crate) async fn restore_wallet<R: Runtime>(
     match result {
         Ok(value) => {
             sync_recovery.commit();
-            drop(transition_guard);
+            // Keep the transition lock through task registration so another
+            // switch/delete cannot replace the just-installed context between
+            // publication and its automatic sync start.
             let _ = crate::wallet::sync::start_sync(app.clone(), &zcash.state).await;
+            drop(transition_guard);
             Ok(value)
         }
         Err(error) => {
@@ -1279,75 +1284,11 @@ pub(crate) async fn delete_wallet<R: Runtime>(
 mod sync_recovery_tests {
     use super::*;
 
-    const PRECOMMIT_FAILURE_STAGES: &[&str] = &[
-        "create/mnemonic-generation",
-        "create/network-connect",
-        "create/latest-block",
-        "create/tree-state",
-        "create/birthday-decode",
-        "create/rollback-schedule",
-        "create/database-init",
-        "create/account-create",
-        "create/read-database-open",
-        "create/custody-store",
-        "create/custody-protect",
-        "create/live-context-lock-cancellation",
-        "create/manifest-persist",
-        "restore/network-connect",
-        "restore/latest-block",
-        "restore/tree-state",
-        "restore/birthday-decode",
-        "restore/rollback-schedule",
-        "restore/database-init",
-        "restore/account-create",
-        "restore/read-database-open",
-        "restore/custody-store",
-        "restore/custody-protect",
-        "restore/live-context-lock-cancellation",
-        "restore/manifest-persist",
-        "switch/context-lock-cancellation",
-        "switch/manifest-persist",
-        "switch/target-disappeared",
-        "delete/last-wallet-validation",
-        "delete/replacement-database-open",
-        "delete/replacement-read-database-open",
-        "delete/live-context-lock-cancellation",
-        "delete/manifest-persist",
-    ];
-
-    const ABORT_BOUNDARIES: &[&str] = &["error", "cancellation", "timeout", "panic-unwind", "drop"];
-
     fn active_obligation() -> SyncRecoveryObligation {
         SyncRecoveryObligation::new(PreviousSyncContext {
             wallet_id: Some("wallet-before-transition".into()),
             was_syncing: true,
         })
-    }
-
-    #[test]
-    fn every_precommit_failure_restores_the_exact_previous_wallet() {
-        for stage in PRECOMMIT_FAILURE_STAGES {
-            let recovery = active_obligation();
-            assert!(
-                recovery.should_restart(Some("wallet-before-transition"), false),
-                "pre-commit failure at {stage} must restore the prior sync"
-            );
-            assert!(
-                !recovery.should_restart(Some("different-wallet"), false),
-                "pre-commit failure at {stage} must not target another wallet"
-            );
-        }
-    }
-
-    #[test]
-    fn every_abort_boundary_retains_the_same_recovery_obligation() {
-        for boundary in ABORT_BOUNDARIES {
-            let recovery = active_obligation();
-            assert!(
-                recovery.should_restart(Some("wallet-before-transition"), false),
-                "{boundary} must retain recovery until commit"
-            );
-        }
     }
 
     #[test]
@@ -1373,6 +1314,47 @@ mod sync_recovery_tests {
 
         let shutting_down = active_obligation();
         assert!(!shutting_down.should_restart(Some("wallet-before-transition"), true));
+    }
+
+    struct RecoveryOnDrop {
+        transition: Arc<tokio::sync::Mutex<()>>,
+        completed: Option<tokio::sync::oneshot::Sender<()>>,
+    }
+
+    impl Drop for RecoveryOnDrop {
+        fn drop(&mut self) {
+            let transition = Arc::clone(&self.transition);
+            let completed = self.completed.take().expect("drop runs once");
+            spawn_recovery_after_transition(transition, async move {
+                let _ = completed.send(());
+            });
+        }
+    }
+
+    #[tokio::test]
+    async fn drop_recovery_waits_for_the_transition_lock() {
+        let transition = Arc::new(tokio::sync::Mutex::new(()));
+        let transition_guard = Arc::clone(&transition).lock_owned().await;
+        let (completed_tx, mut completed_rx) = tokio::sync::oneshot::channel();
+        drop(RecoveryOnDrop {
+            transition,
+            completed: Some(completed_tx),
+        });
+
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(25),
+                &mut completed_rx,
+            )
+            .await
+            .is_err(),
+            "drop recovery must not pass the live transition"
+        );
+        drop(transition_guard);
+        tokio::time::timeout(std::time::Duration::from_secs(1), completed_rx)
+            .await
+            .expect("recovery runs after transition release")
+            .expect("recovery completion sender remains live");
     }
 }
 

--- a/wallet/plugins/tauri-plugin-zcash/src/lib.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/lib.rs
@@ -2,6 +2,7 @@ use tauri::{
     plugin::{Builder, TauriPlugin},
     Manager, Runtime,
 };
+use std::sync::atomic::Ordering;
 
 pub use models::*;
 
@@ -94,6 +95,15 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             Ok(())
         })
         .on_event(|app, event| {
+            if matches!(
+                event,
+                tauri::RunEvent::Exit | tauri::RunEvent::ExitRequested { .. }
+            ) {
+                app.zcash()
+                    .state
+                    .shutting_down
+                    .store(true, Ordering::Release);
+            }
             let must_lock = matches!(
                 event,
                 tauri::RunEvent::Exit

--- a/wallet/plugins/tauri-plugin-zcash/src/lib.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/lib.rs
@@ -2,7 +2,6 @@ use tauri::{
     plugin::{Builder, TauriPlugin},
     Manager, Runtime,
 };
-use std::sync::atomic::Ordering;
 
 pub use models::*;
 
@@ -99,10 +98,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                 event,
                 tauri::RunEvent::Exit | tauri::RunEvent::ExitRequested { .. }
             ) {
-                app.zcash()
-                    .state
-                    .shutting_down
-                    .store(true, Ordering::Release);
+                app.zcash().state.sync_supervisor.begin_shutdown();
             }
             let must_lock = matches!(
                 event,

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
@@ -12,7 +12,7 @@ pub mod sync;
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
 use secrecy::SecretVec;
 use tokio::sync::{Mutex, MutexGuard, RwLock};
 use zeroize::Zeroizing;
@@ -48,6 +48,10 @@ pub struct WalletState {
     pub lightwalletd_url: RwLock<String>,
     pub sync_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     pub syncing: Arc<RwLock<bool>>,
+    /// Set synchronously when Tauri begins application shutdown. Transition
+    /// recovery must never launch a replacement background task after this
+    /// boundary.
+    pub shutting_down: Arc<AtomicBool>,
     pub last_known_chain_tip: Arc<AtomicU64>,
     /// Most recent sync error, shared between the background sync task (writer)
     /// and the `get_sync_status` command (reader). `None` once a pass succeeds.
@@ -164,6 +168,7 @@ impl WalletState {
             ),
             sync_handle: Mutex::new(None),
             syncing: Arc::new(RwLock::new(false)),
+            shutting_down: Arc::new(AtomicBool::new(false)),
             last_known_chain_tip: Arc::new(AtomicU64::new(0)),
             last_sync_error: Arc::new(RwLock::new(None)),
             wallet_transition: Arc::new(Mutex::new(())),

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
@@ -12,7 +12,7 @@ pub mod sync;
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
+use std::sync::atomic::{AtomicU32, AtomicU64};
 use secrecy::SecretVec;
 use tokio::sync::{Mutex, MutexGuard, RwLock};
 use zeroize::Zeroizing;
@@ -46,12 +46,11 @@ pub struct WalletState {
     pub seed: Arc<Mutex<Option<SecretVec<u8>>>>,
     pub seed_store: keychain::SeedStore,
     pub lightwalletd_url: RwLock<String>,
-    pub sync_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Owns the background sync handle and serializes start/stop/finalization.
+    /// A stop transfers its handle into a detached join-finalizer before any
+    /// cancellable wait, so a recovery start can never overlap the predecessor.
+    pub sync_supervisor: Arc<sync::SyncTaskSupervisor>,
     pub syncing: Arc<RwLock<bool>>,
-    /// Set synchronously when Tauri begins application shutdown. Transition
-    /// recovery must never launch a replacement background task after this
-    /// boundary.
-    pub shutting_down: Arc<AtomicBool>,
     pub last_known_chain_tip: Arc<AtomicU64>,
     /// Most recent sync error, shared between the background sync task (writer)
     /// and the `get_sync_status` command (reader). `None` once a pass succeeds.
@@ -166,9 +165,8 @@ impl WalletState {
             lightwalletd_url: RwLock::new(
                 "https://zec.rocks:443".to_string(),
             ),
-            sync_handle: Mutex::new(None),
+            sync_supervisor: Arc::new(sync::SyncTaskSupervisor::default()),
             syncing: Arc::new(RwLock::new(false)),
-            shutting_down: Arc::new(AtomicBool::new(false)),
             last_known_chain_tip: Arc::new(AtomicU64::new(0)),
             last_sync_error: Arc::new(RwLock::new(None)),
             wallet_transition: Arc::new(Mutex::new(())),

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs
@@ -123,6 +123,11 @@ pub async fn start_sync<R: Runtime>(
     app: AppHandle<R>,
     state: &WalletState,
 ) -> Result<()> {
+    if state.shutting_down.load(Ordering::Acquire) {
+        return Err(Error::Other(
+            "application is shutting down; refusing to start wallet sync".into(),
+        ));
+    }
     if !state.is_initialized().await {
         return Err(Error::WalletNotInitialized);
     }

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs
@@ -1,9 +1,10 @@
+use std::future::Future;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, Emitter, Runtime};
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, watch};
 use tonic::transport::Channel;
 
 use zcash_client_backend::data_api::chain::{
@@ -118,12 +119,188 @@ const MAX_STALLED_BATCHES: u32 = 5;
 /// Shorthand for the shared write-side wallet database handle.
 type SharedDb = Arc<Mutex<Option<WalletDatabase>>>;
 
+enum SyncTaskPhase {
+    Idle,
+    Running {
+        generation: u64,
+        handle: tokio::task::JoinHandle<()>,
+    },
+    Stopping {
+        generation: u64,
+    },
+}
+
+struct SyncTaskState {
+    phase: SyncTaskPhase,
+    next_generation: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SyncStart {
+    Started,
+    AlreadyRunning,
+    ShuttingDown,
+}
+
+/// Cancellation-safe owner of the background sync task.
+///
+/// `Running -> Stopping` takes and aborts the handle and launches an independent
+/// join-finalizer without awaiting. Callers may then be cancelled freely: the
+/// finalizer remains responsible for reaching `Idle`. Starts wait for `Idle`, so
+/// two generations can never overlap or overwrite one another's handles.
+pub struct SyncTaskSupervisor {
+    state: Mutex<SyncTaskState>,
+    changes: watch::Sender<u64>,
+    /// Synchronous linearization gate shared by task creation and the Tauri
+    /// shutdown event. No task can be spawned after `begin_shutdown` returns.
+    start_gate: std::sync::Mutex<()>,
+    shutting_down: AtomicBool,
+}
+
+impl Default for SyncTaskSupervisor {
+    fn default() -> Self {
+        let (changes, _) = watch::channel(0);
+        Self {
+            state: Mutex::new(SyncTaskState {
+                phase: SyncTaskPhase::Idle,
+                next_generation: 0,
+            }),
+            changes,
+            start_gate: std::sync::Mutex::new(()),
+            shutting_down: AtomicBool::new(false),
+        }
+    }
+}
+
+impl SyncTaskSupervisor {
+    pub fn begin_shutdown(&self) {
+        let _gate = self
+            .start_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.shutting_down.store(true, Ordering::Release);
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutting_down.load(Ordering::Acquire)
+    }
+
+    async fn start<F>(self: &Arc<Self>, syncing: Arc<RwLock<bool>>, task: F) -> SyncStart
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let mut changes = self.changes.subscribe();
+        let mut task = Some(task);
+        loop {
+            let mut state = self.state.lock().await;
+            match state.phase {
+                SyncTaskPhase::Idle => {
+                    // Complete every async acquisition before taking the
+                    // synchronous shutdown gate. Holding the gate across an
+                    // await would make command futures non-Send.
+                    let mut syncing_guard = syncing.write().await;
+                    let gate = self
+                        .start_gate
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    if self.is_shutting_down() {
+                        return SyncStart::ShuttingDown;
+                    }
+                    let generation = state.next_generation;
+                    state.next_generation = state.next_generation.wrapping_add(1);
+                    *syncing_guard = true;
+                    let supervisor = Arc::clone(self);
+                    let syncing_after_task = Arc::clone(&syncing);
+                    let handle = tokio::spawn(async move {
+                        task.take().expect("sync task starts once").await;
+                        supervisor
+                            .finish_running(generation, &syncing_after_task)
+                            .await;
+                    });
+                    state.phase = SyncTaskPhase::Running { generation, handle };
+                    drop(gate);
+                    return SyncStart::Started;
+                }
+                SyncTaskPhase::Running { .. } => return SyncStart::AlreadyRunning,
+                SyncTaskPhase::Stopping { .. } => {
+                    drop(state);
+                    let _ = changes.changed().await;
+                }
+            }
+        }
+    }
+
+    async fn stop(self: &Arc<Self>, syncing: Arc<RwLock<bool>>) {
+        let mut changes = self.changes.subscribe();
+        loop {
+            let mut state = self.state.lock().await;
+            match &state.phase {
+                SyncTaskPhase::Idle => {
+                    *syncing.write().await = false;
+                    return;
+                }
+                SyncTaskPhase::Stopping { .. } => {
+                    drop(state);
+                    let _ = changes.changed().await;
+                }
+                SyncTaskPhase::Running { .. } => {
+                    let SyncTaskPhase::Running { generation, handle } =
+                        std::mem::replace(&mut state.phase, SyncTaskPhase::Idle)
+                    else {
+                        unreachable!("phase was just matched as running");
+                    };
+                    state.phase = SyncTaskPhase::Stopping { generation };
+                    handle.abort();
+                    let supervisor = Arc::clone(self);
+                    let syncing_after_stop = Arc::clone(&syncing);
+                    tokio::spawn(async move {
+                        let _ = handle.await;
+                        supervisor
+                            .finish_stopping(generation, &syncing_after_stop)
+                            .await;
+                    });
+                    drop(state);
+                    let _ = changes.changed().await;
+                }
+            }
+        }
+    }
+
+    async fn finish_running(&self, generation: u64, syncing: &RwLock<bool>) {
+        let mut state = self.state.lock().await;
+        if matches!(
+            state.phase,
+            SyncTaskPhase::Running {
+                generation: current,
+                ..
+            } if current == generation
+        ) {
+            *syncing.write().await = false;
+            state.phase = SyncTaskPhase::Idle;
+            self.changes
+                .send_modify(|change| *change = change.wrapping_add(1));
+        }
+    }
+
+    async fn finish_stopping(&self, generation: u64, syncing: &RwLock<bool>) {
+        let mut state = self.state.lock().await;
+        if matches!(
+            state.phase,
+            SyncTaskPhase::Stopping {
+                generation: current
+            } if current == generation
+        ) {
+            *syncing.write().await = false;
+            state.phase = SyncTaskPhase::Idle;
+            self.changes
+                .send_modify(|change| *change = change.wrapping_add(1));
+        }
+    }
+}
+
 /// Start the background sync task.
-pub async fn start_sync<R: Runtime>(
-    app: AppHandle<R>,
-    state: &WalletState,
-) -> Result<()> {
-    if state.shutting_down.load(Ordering::Acquire) {
+pub async fn start_sync<R: Runtime>(app: AppHandle<R>, state: &WalletState) -> Result<()> {
+    if state.sync_supervisor.is_shutting_down() {
         return Err(Error::Other(
             "application is shutting down; refusing to start wallet sync".into(),
         ));
@@ -131,13 +308,6 @@ pub async fn start_sync<R: Runtime>(
     if !state.is_initialized().await {
         return Err(Error::WalletNotInitialized);
     }
-
-    let mut syncing = state.syncing.write().await;
-    if *syncing {
-        return Ok(()); // Already syncing
-    }
-    *syncing = true;
-    drop(syncing);
 
     let lightwalletd_url = state.lightwalletd_url.read().await.clone();
     let syncing_flag = Arc::clone(&state.syncing);
@@ -147,19 +317,28 @@ pub async fn start_sync<R: Runtime>(
     let last_known_chain_tip = Arc::clone(&state.last_known_chain_tip);
     let last_sync_error = Arc::clone(&state.last_sync_error);
 
-    let handle = tokio::spawn(sync_task(
-        app,
-        lightwalletd_url,
-        syncing_flag,
-        db,
-        read_db,
-        network,
-        last_known_chain_tip,
-        last_sync_error,
-    ));
-
-    *state.sync_handle.lock().await = Some(handle);
-    Ok(())
+    match state
+        .sync_supervisor
+        .start(
+            Arc::clone(&state.syncing),
+            sync_task(
+                app,
+                lightwalletd_url,
+                syncing_flag,
+                db,
+                read_db,
+                network,
+                last_known_chain_tip,
+                last_sync_error,
+            ),
+        )
+        .await
+    {
+        SyncStart::Started | SyncStart::AlreadyRunning => Ok(()),
+        SyncStart::ShuttingDown => Err(Error::Other(
+            "application is shutting down; refusing to start wallet sync".into(),
+        )),
+    }
 }
 
 /// Read the max scanned block height from the read-only DB, floored at the
@@ -1298,17 +1477,7 @@ async fn wait_for_cancel(syncing: &RwLock<bool>) {
 
 /// Stop the background sync task.
 pub async fn stop_sync(state: &WalletState) -> Result<()> {
-    // Signal sync to stop
-    *state.syncing.write().await = false;
-
-    // Abort and wait for the task to fully cancel (releases db mutex)
-    let handle = {
-        state.sync_handle.lock().await.take()
-    };
-    if let Some(h) = handle {
-        h.abort();
-        let _ = h.await; // wait for cancellation to complete
-    }
+    state.sync_supervisor.stop(Arc::clone(&state.syncing)).await;
     Ok(())
 }
 
@@ -1349,4 +1518,302 @@ pub async fn get_sync_status(state: &WalletState) -> Result<SyncStatus> {
         progress_percent: progress,
         last_error: state.last_sync_error.read().await.clone(),
     })
+}
+
+#[cfg(test)]
+mod supervisor_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    struct LiveTask {
+        live: Arc<AtomicUsize>,
+        dropped: Option<tokio::sync::oneshot::Sender<()>>,
+    }
+
+    impl LiveTask {
+        fn new(
+            live: Arc<AtomicUsize>,
+            dropped: tokio::sync::oneshot::Sender<()>,
+        ) -> Self {
+            live.fetch_add(1, AtomicOrdering::SeqCst);
+            Self {
+                live,
+                dropped: Some(dropped),
+            }
+        }
+    }
+
+    impl Drop for LiveTask {
+        fn drop(&mut self) {
+            self.live.fetch_sub(1, AtomicOrdering::SeqCst);
+            let _ = self.dropped.take().expect("task drops once").send(());
+        }
+    }
+
+    fn counted_task(
+        starts: Arc<AtomicUsize>,
+        live: Arc<AtomicUsize>,
+        started: tokio::sync::oneshot::Sender<()>,
+        dropped: tokio::sync::oneshot::Sender<()>,
+    ) -> impl Future<Output = ()> + Send + 'static {
+        async move {
+            starts.fetch_add(1, AtomicOrdering::SeqCst);
+            let _live = LiveTask::new(live, dropped);
+            let _ = started.send(());
+            std::future::pending::<()>().await;
+        }
+    }
+
+    async fn assert_phase(supervisor: &SyncTaskSupervisor, expected: &str) {
+        let state = supervisor.state.lock().await;
+        let actual = match state.phase {
+            SyncTaskPhase::Idle => "idle",
+            SyncTaskPhase::Running { .. } => "running",
+            SyncTaskPhase::Stopping { .. } => "stopping",
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn cancelling_stop_before_handle_transfer_leaves_one_running_task() {
+        let supervisor = Arc::new(SyncTaskSupervisor::default());
+        let syncing = Arc::new(RwLock::new(false));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let live = Arc::new(AtomicUsize::new(0));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
+        assert_eq!(
+            supervisor
+                .start(
+                    Arc::clone(&syncing),
+                    counted_task(
+                        Arc::clone(&starts),
+                        Arc::clone(&live),
+                        started_tx,
+                        dropped_tx,
+                    ),
+                )
+                .await,
+            SyncStart::Started
+        );
+        started_rx.await.expect("first task starts");
+
+        // Hold the single lifecycle lock so stop is cancelled at its first
+        // await, before it can change the flag or take the handle.
+        let lifecycle_guard = supervisor.state.lock().await;
+        let (attempted_tx, attempted_rx) = tokio::sync::oneshot::channel();
+        let stopping_supervisor = Arc::clone(&supervisor);
+        let stopping_flag = Arc::clone(&syncing);
+        let stop = tokio::spawn(async move {
+            let _ = attempted_tx.send(());
+            stopping_supervisor.stop(stopping_flag).await;
+        });
+        attempted_rx.await.expect("stop attempts lifecycle lock");
+        tokio::task::yield_now().await;
+        stop.abort();
+        assert!(stop.await.expect_err("stop is cancelled").is_cancelled());
+        assert!(matches!(lifecycle_guard.phase, SyncTaskPhase::Running { .. }));
+        drop(lifecycle_guard);
+
+        assert!(*syncing.read().await);
+        assert_eq!(live.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(starts.load(AtomicOrdering::SeqCst), 1);
+
+        let (duplicate_started_tx, _duplicate_started_rx) = tokio::sync::oneshot::channel();
+        let (duplicate_dropped_tx, _duplicate_dropped_rx) = tokio::sync::oneshot::channel();
+        assert_eq!(
+            supervisor
+                .start(
+                    Arc::clone(&syncing),
+                    counted_task(
+                        Arc::clone(&starts),
+                        Arc::clone(&live),
+                        duplicate_started_tx,
+                        duplicate_dropped_tx,
+                    ),
+                )
+                .await,
+            SyncStart::AlreadyRunning
+        );
+        assert_eq!(starts.load(AtomicOrdering::SeqCst), 1);
+
+        supervisor.stop(Arc::clone(&syncing)).await;
+        dropped_rx.await.expect("first task is joined after abort");
+        assert_phase(&supervisor, "idle").await;
+        assert!(!*syncing.read().await);
+        assert_eq!(live.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn cancelled_stop_finalizer_blocks_recovery_until_old_handle_is_joined() {
+        let supervisor = Arc::new(SyncTaskSupervisor::default());
+        let syncing = Arc::new(RwLock::new(false));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let live = Arc::new(AtomicUsize::new(0));
+        let (first_started_tx, first_started_rx) = tokio::sync::oneshot::channel();
+        let (first_dropped_tx, first_dropped_rx) = tokio::sync::oneshot::channel();
+        assert_eq!(
+            supervisor
+                .start(
+                    Arc::clone(&syncing),
+                    counted_task(
+                        Arc::clone(&starts),
+                        Arc::clone(&live),
+                        first_started_tx,
+                        first_dropped_tx,
+                    ),
+                )
+                .await,
+            SyncStart::Started
+        );
+        first_started_rx.await.expect("first task starts");
+
+        // Stall only the stop finalizer. Stop has already transferred and
+        // aborted the handle when the task's Drop sentinel fires.
+        let syncing_guard = syncing.write().await;
+        let stopping_supervisor = Arc::clone(&supervisor);
+        let stopping_flag = Arc::clone(&syncing);
+        let stop = tokio::spawn(async move {
+            stopping_supervisor.stop(stopping_flag).await;
+        });
+        first_dropped_rx.await.expect("old handle is aborted");
+        stop.abort();
+        assert!(stop.await.expect_err("stop caller is cancelled").is_cancelled());
+
+        let (replacement_started_tx, mut replacement_started_rx) =
+            tokio::sync::oneshot::channel();
+        let (replacement_dropped_tx, replacement_dropped_rx) =
+            tokio::sync::oneshot::channel();
+        let recovery_supervisor = Arc::clone(&supervisor);
+        let recovery_flag = Arc::clone(&syncing);
+        let recovery_starts = Arc::clone(&starts);
+        let recovery_live = Arc::clone(&live);
+        let recovery = tokio::spawn(async move {
+            recovery_supervisor
+                .start(
+                    recovery_flag,
+                    counted_task(
+                        recovery_starts,
+                        recovery_live,
+                        replacement_started_tx,
+                        replacement_dropped_tx,
+                    ),
+                )
+                .await
+        });
+
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(25),
+                &mut replacement_started_rx,
+            )
+            .await
+            .is_err(),
+            "replacement cannot start before the old handle finalizes"
+        );
+        assert_eq!(live.load(AtomicOrdering::SeqCst), 0);
+        assert!(*syncing_guard, "stale flag is still held at the test barrier");
+        drop(syncing_guard);
+
+        replacement_started_rx
+            .await
+            .expect("replacement starts after old handle joins");
+        assert_eq!(recovery.await.expect("recovery task joins"), SyncStart::Started);
+        assert_phase(&supervisor, "running").await;
+        assert!(*syncing.read().await);
+        assert_eq!(starts.load(AtomicOrdering::SeqCst), 2);
+        assert_eq!(live.load(AtomicOrdering::SeqCst), 1);
+
+        let (duplicate_started_tx, _duplicate_started_rx) = tokio::sync::oneshot::channel();
+        let (duplicate_dropped_tx, _duplicate_dropped_rx) = tokio::sync::oneshot::channel();
+        assert_eq!(
+            supervisor
+                .start(
+                    Arc::clone(&syncing),
+                    counted_task(
+                        Arc::clone(&starts),
+                        Arc::clone(&live),
+                        duplicate_started_tx,
+                        duplicate_dropped_tx,
+                    ),
+                )
+                .await,
+            SyncStart::AlreadyRunning
+        );
+        assert_eq!(starts.load(AtomicOrdering::SeqCst), 2);
+        assert_eq!(live.load(AtomicOrdering::SeqCst), 1);
+
+        supervisor.stop(Arc::clone(&syncing)).await;
+        replacement_dropped_rx
+            .await
+            .expect("replacement is joined during cleanup");
+        assert_phase(&supervisor, "idle").await;
+        assert!(!*syncing.read().await);
+        assert_eq!(live.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn shutdown_while_stopping_prevents_recovery_start() {
+        let supervisor = Arc::new(SyncTaskSupervisor::default());
+        let syncing = Arc::new(RwLock::new(false));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let live = Arc::new(AtomicUsize::new(0));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (dropped_tx, dropped_rx) = tokio::sync::oneshot::channel();
+        assert_eq!(
+            supervisor
+                .start(
+                    Arc::clone(&syncing),
+                    counted_task(
+                        Arc::clone(&starts),
+                        Arc::clone(&live),
+                        started_tx,
+                        dropped_tx,
+                    ),
+                )
+                .await,
+            SyncStart::Started
+        );
+        started_rx.await.expect("task starts");
+
+        let syncing_guard = syncing.write().await;
+        let stopping_supervisor = Arc::clone(&supervisor);
+        let stopping_flag = Arc::clone(&syncing);
+        let stop = tokio::spawn(async move {
+            stopping_supervisor.stop(stopping_flag).await;
+        });
+        dropped_rx.await.expect("task aborts");
+        supervisor.begin_shutdown();
+
+        let (forbidden_started_tx, _forbidden_started_rx) = tokio::sync::oneshot::channel();
+        let (forbidden_dropped_tx, _forbidden_dropped_rx) = tokio::sync::oneshot::channel();
+        let recovery_supervisor = Arc::clone(&supervisor);
+        let recovery_flag = Arc::clone(&syncing);
+        let recovery_starts = Arc::clone(&starts);
+        let recovery_live = Arc::clone(&live);
+        let recovery = tokio::spawn(async move {
+            recovery_supervisor
+                .start(
+                    recovery_flag,
+                    counted_task(
+                        recovery_starts,
+                        recovery_live,
+                        forbidden_started_tx,
+                        forbidden_dropped_tx,
+                    ),
+                )
+                .await
+        });
+        drop(syncing_guard);
+
+        stop.await.expect("stop finalizer completes");
+        assert_eq!(
+            recovery.await.expect("recovery decision completes"),
+            SyncStart::ShuttingDown
+        );
+        assert_phase(&supervisor, "idle").await;
+        assert!(!*syncing.read().await);
+        assert_eq!(starts.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(live.load(AtomicOrdering::SeqCst), 0);
+    }
 }


### PR DESCRIPTION
## Summary

- retain an identity-bound recovery obligation whenever create, restore, switch, or active-delete stops the current wallet sync
- replace the split sync flag/handle lifecycle with one generation-aware `Idle -> Running -> Stopping -> Idle` supervisor
- transfer and abort the old handle and launch an independent join-finalizer before the first cancellable wait, so Drop recovery cannot overlap or overwrite it
- restore the exact prior wallet synchronously on ordinary pre-commit errors and through a transition-lock-serialized Drop path on cancellation, timeout, or unwind
- keep create/restore auto-start registration inside the wallet transition lock and make shutdown a task-creation linearization boundary
- retain cancellation-atomic manifest publication and live DB/read/seed/proposal/broadcast context swaps

## Verification

Exact head: `cc6c2ecc6fe01b267b14d8130640bea5743abae5`, rebased on live `origin/main` `3f7845c5cef48fa9f928f566a29d63896da64539`.

- `CARGO_INCREMENTAL=0 cargo +1.88.0 check --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml`
- `CARGO_INCREMENTAL=0 cargo +1.88.0 test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml` — 93 passed
- scheduler-aware supervisor regressions — 3 passed, exercising real Tokio task handles, abort, task Drop, lifecycle locks, blocked finalization, replacement registration, duplicate rejection, and shutdown
- Drop transition-lock regression plus recovery policy tests — 3 passed
- `CARGO_INCREMENTAL=0 cargo +1.88.0 build --locked --manifest-path wallet/zuuli/src-tauri/Cargo.toml`
- `CARGO_INCREMENTAL=0 cargo +1.88.0 test --locked --manifest-path wallet/zuuli/src-tauri/Cargo.toml` — 12 passed
- `CARGO_INCREMENTAL=0 cargo +1.88.0 build --locked --manifest-path wallet/zuuallet/src-tauri/Cargo.toml`
- `git diff --check`

Repository-wide `cargo fmt --check` remains baseline-red on pre-existing formatting across this crate; no bulk formatting changes are included in this focused repair.

## Safety invariants

- at most one live sync task and one owned handle exist at a time
- a recovery start waits until the aborted predecessor is joined and its matching-generation finalizer reaches `Idle`
- a stale generation cannot clear a replacement task flag or overwrite its handle
- cancellation before handle transfer leaves the original task running; cancellation after transfer cannot orphan finalization
- a previously stopped wallet stays stopped, and recovery requires the same non-empty active wallet ID
- a committed transition can never revive its predecessor
- shutdown and sync task creation share a synchronous gate, making shutdown an irreversible no-start boundary
- Drop recovery reacquires the wallet transition lock before checking identity and starting sync

Closes #241
