### PR TITLE
docs: require safe post-merge worktree cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,11 @@ exact cycle:
    branch, then prune stale worktree and remote-tracking metadata. First verify
    that the PR merged into this repository's `main`, that its merge commit is
    on `origin/main`, and that the checked-out and local branch match the PR's
-   head name and commit. Audit branch and worktree reflogs, then inspect
-   tracked, untracked, and ignored files in both the worktree and every
-   initialized submodule; preserve anything needed before deleting its last
-   ref or reflog. Never use force removal to override dirty or unmerged work.
+   head name and commit. Confirm the worker and its background processes have
+   stopped. Audit branch and worktree reflogs, then inspect tracked, untracked,
+   and ignored files and reflogs in every initialized submodule; preserve
+   anything needed before deleting its last ref or reflog. Never use force
+   removal to override dirty or unmerged work.
    Delete the remote branch only with a lease bound to the verified head
    commit. Build-heavy merged worktrees (`target/`, `node_modules/`, etc.) must
    not be left behind.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,12 +36,15 @@ exact cycle:
    ahead of the remote.
 6. After the merge is confirmed, promptly remove the worker worktree and local
    branch, then prune stale worktree and remote-tracking metadata. First verify
-   that the checked-out and local branch match the merged PR's head name and
-   commit, then inspect tracked, untracked, and ignored files in both the
-   worktree and every initialized submodule. Preserve anything needed; never
-   use force removal to override dirty or unmerged work. Delete the remote
-   branch only with a lease bound to that verified commit. Build-heavy merged
-   worktrees (`target/`, `node_modules/`, etc.) must not be left behind.
+   that the PR merged into this repository's `main`, that its merge commit is
+   on `origin/main`, and that the checked-out and local branch match the PR's
+   head name and commit. Audit branch and worktree reflogs, then inspect
+   tracked, untracked, and ignored files in both the worktree and every
+   initialized submodule; preserve anything needed before deleting its last
+   ref or reflog. Never use force removal to override dirty or unmerged work.
+   Delete the remote branch only with a lease bound to the verified head
+   commit. Build-heavy merged worktrees (`target/`, `node_modules/`, etc.) must
+   not be left behind.
 
 **Why this is absolute:** an un-pushed commit on local `main` is not saved —
 `git reset --hard origin/main` or a fresh re-clone silently destroys it, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,11 +36,12 @@ exact cycle:
    ahead of the remote.
 6. After the merge is confirmed, promptly remove the worker worktree and local
    branch, then prune stale worktree and remote-tracking metadata. First verify
-   that local `HEAD` equals the merged PR's head commit and inspect tracked,
-   untracked, and ignored files in both the worktree and every initialized
-   submodule. Preserve anything needed; never use force removal to override
-   dirty or unmerged work. Build-heavy merged worktrees (`target/`,
-   `node_modules/`, etc.) must not be left behind.
+   that the checked-out and local branch match the merged PR's head name and
+   commit, then inspect tracked, untracked, and ignored files in both the
+   worktree and every initialized submodule. Preserve anything needed; never
+   use force removal to override dirty or unmerged work. Delete the remote
+   branch only with a lease bound to that verified commit. Build-heavy merged
+   worktrees (`target/`, `node_modules/`, etc.) must not be left behind.
 
 **Why this is absolute:** an un-pushed commit on local `main` is not saved —
 `git reset --hard origin/main` or a fresh re-clone silently destroys it, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,13 @@ exact cycle:
 5. Local `main` is updated **only** by `git pull --ff-only origin main` in the
    primary working tree. It must ALWAYS equal `origin/main` and must NEVER be
    ahead of the remote.
+6. After the merge is confirmed, promptly remove the worker worktree and local
+   branch, then prune stale worktree and remote-tracking metadata. First verify
+   that local `HEAD` equals the merged PR's head commit and inspect tracked,
+   untracked, and ignored files in both the worktree and every initialized
+   submodule. Preserve anything needed; never use force removal to override
+   dirty or unmerged work. Build-heavy merged worktrees (`target/`,
+   `node_modules/`, etc.) must not be left behind.
 
 **Why this is absolute:** an un-pushed commit on local `main` is not saved —
 `git reset --hard origin/main` or a fresh re-clone silently destroys it, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ exact cycle:
    primary working tree. It must ALWAYS equal `origin/main` and must NEVER be
    ahead of the remote.
 6. After the merge is confirmed, promptly remove the worker worktree and local
-   branch, then prune stale worktree and remote-tracking metadata. First verify
+   branch, then prune its remote-tracking metadata. First verify
    that the PR merged into this repository's `main`, that its merge commit is
    on `origin/main`, and that the checked-out and local branch match the PR's
    head name and commit. Confirm the worker and its background processes have
@@ -44,8 +44,9 @@ exact cycle:
    anything needed before deleting its last ref or reflog. Never use force
    removal to override dirty or unmerged work.
    Delete the remote branch only with a lease bound to the verified head
-   commit. Build-heavy merged worktrees (`target/`, `node_modules/`, etc.) must
-   not be left behind.
+   commit. Treat global worktree pruning as a separate audited operation; never
+   let it remove metadata for an unavailable worktree. Build-heavy merged
+   worktrees (`target/`, `node_modules/`, etc.) must not be left behind.
 
 **Why this is absolute:** an un-pushed commit on local `main` is not saved —
 `git reset --hard origin/main` or a fresh re-clone silently destroys it, and

--- a/docs/PARALLEL-AGENTS.md
+++ b/docs/PARALLEL-AGENTS.md
@@ -41,11 +41,19 @@ that only ever moves forward, and every change carries a reviewable PR trail.
 6. **Partition file surfaces** across concurrent tasks so parallel PRs don't collide. Sequence dependent work; land shared/foundational changes first.
 7. **Clean up immediately after merge.** Before removal, verify all of these:
 
-   - Record the PR's `headRefName` as `B` and `headRefOid` as `H`. Require
-     GitHub to report the PR merged, `git branch --show-current` to equal `B`,
-     and both `git rev-parse HEAD` and `git rev-parse refs/heads/$B` to equal
-     `H`. A clean worktree alone does not detect the wrong branch, unpushed or
-     post-PR commits, and squash-merging breaks normal ancestry checks.
+   - Record the PR's `headRefName` as `B`, `headRefOid` as `H`, and merge-commit
+     OID as `M`. Require GitHub to report that the PR merged into `main` in the
+     repository configured as `origin`. Fetch `origin`, then require `M` to be
+     an ancestor of `origin/main`, `git branch --show-current` to equal `B`, and
+     both `git rev-parse HEAD` and `git rev-parse "refs/heads/$B"` to equal
+     `H`. A clean worktree alone does not detect the wrong PR or branch,
+     unpushed or post-PR commits, and squash-merging breaks normal ancestry
+     checks.
+   - Inspect both `git reflog show HEAD` and
+     `git reflog show "refs/heads/$B"`. Before removing either recovery log,
+     preserve every commit worth keeping on a ref pushed to a durable remote;
+     if any reflog entry's disposition is uncertain, stop and ask the owner.
+     Never rely on these reflogs remaining available after cleanup.
    - `git status --short --untracked-files=all --ignore-submodules=none` is
      empty, then inspect the same command with `--ignored=matching`. These
      explicit options prevent user configuration from hiding files without
@@ -60,10 +68,10 @@ that only ever moves forward, and every change carries a reviewable PR trail.
      files or per-worktree Git metadata inside submodules.
 
    Then remove the worktree and atomically delete its local branch with
-   `git update-ref -d refs/heads/$B $H` (squash merges make `git branch -d`
+   `git update-ref -d "refs/heads/$B" "$H"` (squash merges make `git branch -d`
    reject it). If the remote branch still exists, delete it only with the
    verified lease:
-   `git push --force-with-lease=refs/heads/$B:$H origin :refs/heads/$B`.
+   `git push --force-with-lease="refs/heads/$B:$H" origin ":refs/heads/$B"`.
    Finish with `git worktree prune` and `git fetch --prune`. Any name/OID
    mismatch or lease rejection means stop and investigate; another commit may
    need preserving. Never run `git submodule deinit` during cleanup: submodule

--- a/docs/PARALLEL-AGENTS.md
+++ b/docs/PARALLEL-AGENTS.md
@@ -41,9 +41,11 @@ that only ever moves forward, and every change carries a reviewable PR trail.
 6. **Partition file surfaces** across concurrent tasks so parallel PRs don't collide. Sequence dependent work; land shared/foundational changes first.
 7. **Clean up immediately after merge.** Before removal, verify all of these:
 
-   - GitHub reports the PR merged and local `HEAD` equals that PR's
-     `headRefOid`. A clean worktree alone does not detect unpushed or post-PR
-     commits, and squash-merging breaks normal ancestry checks.
+   - Record the PR's `headRefName` as `B` and `headRefOid` as `H`. Require
+     GitHub to report the PR merged, `git branch --show-current` to equal `B`,
+     and both `git rev-parse HEAD` and `git rev-parse refs/heads/$B` to equal
+     `H`. A clean worktree alone does not detect the wrong branch, unpushed or
+     post-PR commits, and squash-merging breaks normal ancestry checks.
    - `git status --short --untracked-files=all --ignore-submodules=none` is
      empty, then inspect the same command with `--ignored=matching`. These
      explicit options prevent user configuration from hiding files without
@@ -57,12 +59,14 @@ that only ever moves forward, and every change carries a reviewable PR trail.
      local-only data before removal: superproject status does not list ignored
      files or per-worktree Git metadata inside submodules.
 
-   Then remove the worktree, use `git branch -D` to delete its local branch
-   (squash merges make `-d` reject it), and run `git worktree prune` plus
-   `git fetch --prune`. Delete the exact remote worker branch explicitly, then
-   fetch with pruning again. `-D` and remote deletion are allowed only after
-   the `headRefOid` equality check above. Never run `git submodule deinit`
-   during cleanup: submodule
+   Then remove the worktree and atomically delete its local branch with
+   `git update-ref -d refs/heads/$B $H` (squash merges make `git branch -d`
+   reject it). If the remote branch still exists, delete it only with the
+   verified lease:
+   `git push --force-with-lease=refs/heads/$B:$H origin :refs/heads/$B`.
+   Finish with `git worktree prune` and `git fetch --prune`. Any name/OID
+   mismatch or lease rejection means stop and investigate; another commit may
+   need preserving. Never run `git submodule deinit` during cleanup: submodule
    registrations live in shared repository configuration, so it can disrupt
    other active worktrees. Never leave merged Rust/Tauri worktrees retaining
    `target/`, `node_modules/`, or other reproducible build output. Never use

--- a/docs/PARALLEL-AGENTS.md
+++ b/docs/PARALLEL-AGENTS.md
@@ -41,6 +41,9 @@ that only ever moves forward, and every change carries a reviewable PR trail.
 6. **Partition file surfaces** across concurrent tasks so parallel PRs don't collide. Sequence dependent work; land shared/foundational changes first.
 7. **Clean up immediately after merge.** Before removal, verify all of these:
 
+   - Confirm the worker has exited and no build, watcher, editor, or other
+     process can still write into the worktree. Never clean up an active
+     worker; rerun every status check immediately before removal.
    - Record the PR's `headRefName` as `B`, `headRefOid` as `H`, and merge-commit
      OID as `M`. Require GitHub to report that the PR merged into `main` in the
      repository configured as `origin`. Fetch `origin`, then require `M` to be
@@ -62,10 +65,11 @@ that only ever moves forward, and every change carries a reviewable PR trail.
      `.env.local`, and `release-artifacts/` when present.
    - Within every initialized submodule, recursively run the same tracked,
      untracked, and ignored-file checks. Verify that its checked-out gitlink
-     commit is fetchable from the configured remote; inspect `git stash list`
-     and local refs, and push every commit worth keeping. Relocate any
-     local-only data before removal: superproject status does not list ignored
-     files or per-worktree Git metadata inside submodules.
+     commit is fetchable from the configured remote; inspect `git stash list`,
+     local refs, and `git reflog show --all`, and push every commit worth
+     keeping. Relocate any local-only data before removal: superproject status
+     does not list ignored files or per-worktree Git metadata inside
+     submodules, and forced removal deletes their recovery logs.
 
    Then remove the worktree and atomically delete its local branch with
    `git update-ref -d "refs/heads/$B" "$H"` (squash merges make `git branch -d`

--- a/docs/PARALLEL-AGENTS.md
+++ b/docs/PARALLEL-AGENTS.md
@@ -39,7 +39,42 @@ that only ever moves forward, and every change carries a reviewable PR trail.
 4. **CI is the merge gate.** `.github/workflows/zuuli.yml` (and any other required checks) must be green. Never merge red.
 5. **Rebase onto `origin/main` frequently.** Resolve conflicts in the worktree — never on `main`.
 6. **Partition file surfaces** across concurrent tasks so parallel PRs don't collide. Sequence dependent work; land shared/foundational changes first.
-7. **Clean up on merge.** Delete the branch and worktree after merge. Prune stale local branches routinely (`git fetch --prune`, then delete branches whose upstream is `gone`).
+7. **Clean up immediately after merge.** Before removal, verify all of these:
+
+   - GitHub reports the PR merged and local `HEAD` equals that PR's
+     `headRefOid`. A clean worktree alone does not detect unpushed or post-PR
+     commits, and squash-merging breaks normal ancestry checks.
+   - `git status --short --untracked-files=all --ignore-submodules=none` is
+     empty, then inspect the same command with `--ignored=matching`. These
+     explicit options prevent user configuration from hiding files without
+     expanding every file under large ignored build directories. Delete known
+     reproducible output, but preserve local-only data such as `private/`,
+     `.env.local`, and `release-artifacts/` when present.
+   - Within every initialized submodule, recursively run the same tracked,
+     untracked, and ignored-file checks. Verify that its checked-out gitlink
+     commit is fetchable from the configured remote; inspect `git stash list`
+     and local refs, and push every commit worth keeping. Relocate any
+     local-only data before removal: superproject status does not list ignored
+     files or per-worktree Git metadata inside submodules.
+
+   Then remove the worktree, use `git branch -D` to delete its local branch
+   (squash merges make `-d` reject it), and run `git worktree prune` plus
+   `git fetch --prune`. Delete the exact remote worker branch explicitly, then
+   fetch with pruning again. `-D` and remote deletion are allowed only after
+   the `headRefOid` equality check above. Never run `git submodule deinit`
+   during cleanup: submodule
+   registrations live in shared repository configuration, so it can disrupt
+   other active worktrees. Never leave merged Rust/Tauri worktrees retaining
+   `target/`, `node_modules/`, or other reproducible build output. Never use
+   force removal to override a dirty or unmerged worktree. Git may require
+   `git worktree remove --force` solely because a verified-clean worktree
+   contains initialized submodules; use it only after every safety check above
+   passes.
+
+   If any check fails, keep the worktree and inspect its diffs, files, commits,
+   submodules, and PR state. Commit and push useful work, or get the owner's
+   direction before discarding anything. `git worktree prune` removes stale
+   metadata; it does not make a worktree safe to delete.
 
 ## Branch & PR conventions
 - Prefixes: `feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `deps/`.

--- a/docs/PARALLEL-AGENTS.md
+++ b/docs/PARALLEL-AGENTS.md
@@ -76,9 +76,14 @@ that only ever moves forward, and every change carries a reviewable PR trail.
    reject it). If the remote branch still exists, delete it only with the
    verified lease:
    `git push --force-with-lease="refs/heads/$B:$H" origin ":refs/heads/$B"`.
-   Finish with `git worktree prune` and `git fetch --prune`. Any name/OID
-   mismatch or lease rejection means stop and investigate; another commit may
-   need preserving. Never run `git submodule deinit` during cleanup: submodule
+   Finish with `git fetch --prune`. Do not run the global
+   `git worktree prune` as routine per-worktree cleanup: it can destroy recovery
+   metadata for an unrelated, temporarily unavailable worktree. For genuinely
+   stale registrations, first inspect `git worktree prune --dry-run --verbose`,
+   apply every safety check above to every candidate, and prune only when all
+   candidates are safe. Any name/OID mismatch or lease rejection means stop
+   and investigate; another commit may need preserving. Never run
+   `git submodule deinit` during cleanup: submodule
    registrations live in shared repository configuration, so it can disrupt
    other active worktrees. Never leave merged Rust/Tauri worktrees retaining
    `target/`, `node_modules/`, or other reproducible build output. Never use


### PR DESCRIPTION
## Summary

- require prompt cleanup of merged build-heavy worktrees
- gate destructive cleanup on the exact merged PR head plus tracked, untracked, ignored, submodule, stash, and ref inspection
- preserve local-only data and commits, avoid shared submodule deinitialization, and prune local/remote branch metadata

Closes #308

## Verification

- `git diff --check origin/main...HEAD`
- Documentation-only change; this repository has no repository-local docs checker and `markdownlint` is not installed.

## Codex adversarial review

The `zuu` repository does not contain `./bin/codex-review.sh`. I ran the identical workspace copy from `tuzi/bin/codex-review.sh` while inside this `zuu` worktree, so it reviewed the committed `zuu` diff against `origin/main`.

Last completed review output, verbatim:

```
1. `docs/PARALLEL-AGENTS.md:53-68` — Severity: medium; Confidence: medium. The cleanup checks do not explicitly inspect submodule-local stashes or refs. A developer can stash an upstream fix, restore the submodule to its gitlink so every documented `git status` check is clean, then run `git worktree remove --force`. Because linked worktrees keep submodule repositories under per-worktree Git metadata, removal deletes the stash/local branch along with the worktree. “Every other commit worth keeping is pushed” is not an actionable check and may not alert an agent that stashes must be enumerated. Require explicit inspection of at least `git stash list` and local refs before force-removing. CI does not exercise or validate this cleanup sequence.

2. `docs/PARALLEL-AGENTS.md:59-60` — Severity: low; Confidence: high. The procedure assumes merged remote branches are deleted automatically. `git branch -D` deletes only the local branch, while `git fetch --prune` removes a remote-tracking ref only after the corresponding remote branch has already been deleted. If GitHub’s automatic branch deletion setting is disabled, every merged worker branch remains on GitHub and locally under `origin/*`, so the promised remote-metadata cleanup never occurs. Use `gh pr merge --delete-branch` or explicitly verify/delete the remote branch.

RISKIEST LINE: `docs/PARALLEL-AGENTS.md:67` — `git worktree remove --force` bypasses Git’s final cleanliness safeguard and can irreversibly delete both working files and per-worktree submodule Git data if any preceding manual check is incomplete.
```

Both findings were addressed: the checklist now explicitly inspects submodule stashes/local refs and explicitly deletes the exact remote worker branch after the merged-head safety check.

A final rerun was started after those changes and stopped at the orchestrator's eight-minute cap. Before interruption, it surfaced one additional compatibility concern: `gh pr merge --delete-branch` can attempt local checkout/deletion while `main` is already checked out in the primary worktree. The final diff therefore keeps `gh pr merge --squash` and performs exact remote-branch deletion only after the documented post-merge safety checks. The interrupted rerun produced no final review verdict; this is disclosed rather than silently omitted.

### Follow-up review after branch lease correction

Verbatim output:

```
Blast radius: no production runtime or money/auth path changes. The credible worst case is irreversible loss of unpublished work and hours of recovery.

1. `docs/PARALLEL-AGENTS.md:63` — Severity: MEDIUM; confidence: HIGH. The submodule checklist inspects status, stashes, and current refs, but not submodule reflogs. In this repository, an initialized submodule’s Git directory lives under the worker’s `.git/worktrees/<worker>/modules/...`; forced worktree removal deletes that recovery data. Concrete scenario: an agent develops an upstream Zcash fix, amends or rebases it, and accidentally drops a valuable hunk. The current commit is clean and fetchable, while the pre-amend commit exists only in the submodule’s `HEAD` reflog. Every documented check passes, then `git worktree remove --force` destroys the only reflog/object store containing that commit. The superproject reflog audit cannot recover it. Require reflog inspection within every initialized submodule before removal. [Git documents that forced removal permits deleting worktrees containing submodules](https://git-scm.com/docs/git-worktree.html).

2. `docs/PARALLEL-AGENTS.md:82` — Severity: MEDIUM; confidence: MEDIUM. The cleanliness checks and forced removal are not atomic, and the procedure never establishes that the worker/its background processes have stopped. Concrete scenario: cleanup observes a clean tree; an autonomous worker or delayed build then writes an untracked artifact or unsaved follow-up change; because initialized submodules require `--force`, removal bypasses Git’s final dirty-worktree protection and deletes the new file. The later compare-and-delete of the branch protects committed ref movement only, after the directory is already gone. Require explicit worker quiescence before destructive cleanup.

CI does not validate `docs/PARALLEL-AGENTS.md:44-84`: this docs-only change is classified as non-ZUULI, and no workflow executes the cleanup procedure against a disposable worktree with submodules. Both failures above would remain green.

RISKIEST LINE: `docs/PARALLEL-AGENTS.md:82` — `git worktree remove --force` is the irreversible operation that bypasses Git’s dirty-worktree safeguard and deletes per-worktree submodule recovery data.
```

Both findings were addressed: cleanup now requires worker/background-process quiescence with status checks immediately before removal, and recursively audits initialized submodule reflogs before their metadata can be deleted.

### Final review after those fixes

Verbatim output:

```
- `docs/PARALLEL-AGENTS.md:79` — **High severity, high confidence.** `git worktree prune` operates globally, not only on the verified worktree. Concrete failure: another linked worktree is temporarily unavailable, manually moved, or on an unmounted volume. This cleanup validates worktree B, removes it, then `git worktree prune` immediately deletes the unavailable worktree’s administrative directory. That includes its HEAD reflog, index, and—critically here—initialized submodule repositories under `.git/worktrees/<id>/modules`. When the worktree returns, its submodules point at deleted Git directories; unique local submodule commits and recovery logs may already be gone. I reproduced this with Git 2.49: default `git worktree prune` selected a newly moved worktree immediately and deleted its submodule metadata. `git worktree remove` already removes B’s registration, so this global prune is unnecessary. At minimum, every prune candidate needs its own audit after `git worktree prune --dry-run --verbose`; safest is to omit routine pruning from this per-worktree procedure. CI does not execute or validate these documentation commands.

RISKIEST LINE: `docs/PARALLEL-AGENTS.md:79` — the unscoped `git worktree prune` can destroy recovery metadata and complete submodule object databases belonging to worktrees that were never audited.
```

This finding was addressed: routine per-worktree cleanup no longer runs global worktree pruning. Stale-registration pruning is a separate operation requiring a dry run and the full safety audit for every candidate.