### PR TITLE
docs: validate cleanup push destination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,15 @@ exact cycle:
    and ignored files and reflogs in every initialized submodule; preserve
    anything needed before deleting its last ref or reflog. Never use force
    removal to override dirty or unmerged work.
-   Delete the remote branch only with a lease bound to the verified head
-   commit. Treat global worktree pruning as a separate audited operation; never
-   let it remove metadata for an unavailable worktree. Build-heavy merged
-   worktrees (`target/`, `node_modules/`, etc.) must not be left behind.
+   Require exactly one credential-free canonical HTTPS fetch URL and push URL
+   for `origin`, both targeting the PR's base host and repository. From the
+   still-present verified worktree, reject any Git URL-rewrite rule that can
+   match the push URL, then delete the remote branch through that literal URL
+   with a lease bound to the verified head commit. Treat global worktree
+   pruning as a separate audited operation; never let it remove metadata for an
+   unavailable worktree.
+   Build-heavy merged worktrees (`target/`, `node_modules/`, etc.) must not be
+   left behind.
 
 **Why this is absolute:** an un-pushed commit on local `main` is not saved —
 `git reset --hard origin/main` or a fresh re-clone silently destroys it, and

--- a/docs/PARALLEL-AGENTS.md
+++ b/docs/PARALLEL-AGENTS.md
@@ -46,8 +46,17 @@ that only ever moves forward, and every change carries a reviewable PR trail.
      worker; rerun every status check immediately before removal.
    - Record the PR's `headRefName` as `B`, `headRefOid` as `H`, and merge-commit
      OID as `M`. Require GitHub to report that the PR merged into `main` in the
-     repository configured as `origin`. Fetch `origin`, then require `M` to be
-     an ancestor of `origin/main`, `git branch --show-current` to equal `B`, and
+     repository configured as `origin`. Record `git remote get-url --all origin`
+     as `FETCH_URL` and `git remote get-url --push --all origin` as `PUSH_URL`;
+     require exactly one result from each command. After allowing only a
+     terminal `.git`, require both to equal the PR repository's credential-free
+     canonical `https://<host>/<owner>/<repository>` URL exactly—no userinfo,
+     token, port, query, or fragment. Independently run `gh repo view
+     "$FETCH_URL" --json nameWithOwner` and `gh repo view "$PUSH_URL" --json
+     nameWithOwner`; both identities must equal the owner/repository in the PR
+     URL. Multiple URLs, a noncanonical destination, or any mismatch means
+     stop. Fetch the validated `origin`, then require `M` to be an
+     ancestor of `origin/main`, `git branch --show-current` to equal `B`, and
      both `git rev-parse HEAD` and `git rev-parse "refs/heads/$B"` to equal
      `H`. A clean worktree alone does not detect the wrong PR or branch,
      unpushed or post-PR commits, and squash-merging breaks normal ancestry
@@ -71,12 +80,18 @@ that only ever moves forward, and every change carries a reviewable PR trail.
      does not list ignored files or per-worktree Git metadata inside
      submodules, and forced removal deletes their recovery logs.
 
-   Then remove the worktree and atomically delete its local branch with
-   `git update-ref -d "refs/heads/$B" "$H"` (squash merges make `git branch -d`
-   reject it). If the remote branch still exists, delete it only with the
-   verified lease:
-   `git push --force-with-lease="refs/heads/$B:$H" origin ":refs/heads/$B"`.
-   Finish with `git fetch --prune`. Do not run the global
+   While still inside this verified worktree, immediately rerun the URL,
+   name/OID, and status checks. Inspect all scopes reported by `git config
+   --show-origin --get-regexp '^url\..*\.(insteadOf|pushInsteadOf)$'` and stop
+   if any rule's prefix can match `PUSH_URL`; unrelated rewrite rules do not
+   block cleanup. If the remote branch exists, delete it now with the verified
+   lease and literal URL—never the remote name, which may fan out to multiple
+   push URLs:
+   `git push --force-with-lease="refs/heads/$B:$H" "$PUSH_URL" ":refs/heads/$B"`.
+   Only after that succeeds (or the branch is confirmed absent), remove the
+   worktree and atomically delete its local branch with `git update-ref -d
+   "refs/heads/$B" "$H"` (squash merges make `git branch -d` reject it). Finish
+   with `git fetch --prune`. Do not run the global
    `git worktree prune` as routine per-worktree cleanup: it can destroy recovery
    metadata for an unrelated, temporarily unavailable worktree. For genuinely
    stale registrations, first inspect `git worktree prune --dry-run --verbose`,


### PR DESCRIPTION
## Summary

- require exactly one credential-free canonical HTTPS fetch and push URL for cleanup
- validate the URL host and repository against the merged PR and reject matching Git URL rewrites
- perform lease-protected remote deletion through the validated literal URL before removing the verified worktree

Closes #310

## Verification

- `git diff --check origin/main...HEAD`
- verified `gh repo view` accepts the repository's canonical HTTPS URL
- documentation-only change; this repository has no repository-local docs checker

## Codex adversarial review

The `zuu` repository does not contain `./bin/codex-review.sh`. I ran the identical workspace copy from `tuzi/bin/codex-review.sh` while inside this `zuu` worktree, so it reviewed the committed `zuu` diff against `origin/main`.

First completed review output, verbatim:

```
1. `docs/PARALLEL-AGENTS.md:85` — Severity: Medium; confidence: High. The “literal” URL is still subject to Git’s `url.*.pushInsteadOf` rewriting. Concrete failure: `get-url --push` expands the configured HTTPS origin to a valid GitHub SSH URL, `gh repo view` validates `free2z/zuu`, then `git push "$PUSH_URL"` applies a second rewrite to an internal mirror or fork. If that repository has branch `B` at `H`, the lease succeeds and deletes the wrong branch after the local worktree and branch have already been removed. I reproduced this behavior with `GIT_TRACE`: Git invoked the rewritten host despite receiving a literal URL operand.

2. `docs/PARALLEL-AGENTS.md:52` — Severity: Medium; confidence: High. `nameWithOwner` does not validate the GitHub hostname. Concrete failure: the PR is on `github.com/free2z/zuu`, while `origin` targets a synchronized GitHub Enterprise repository also named `free2z/zuu`. Both identity checks return `free2z/zuu`; the mirrored merge commit and branch satisfy all OID checks; cleanup then deletes the branch on the Enterprise host rather than the PR’s repository.

3. `docs/PARALLEL-AGENTS.md:52` — Severity: Medium; confidence: Medium. The documented command uses `$URL`, but the procedure only defines `FETCH_URL` and `PUSH_URL`; it never binds `URL`. Concrete failure: an agent copies the command literally without `set -u`. With GitHub CLI 2.83.2, `gh repo view "$URL"` with an empty value resolves the current checkout, so both validations can report `free2z/zuu` regardless of the recorded push URL. Cleanup then executes the destructive push against the unvalidated destination.

CI does not validate any of these semantics. `.github/workflows/zuuli.yml` classifies both changed files as non-ZUULI, skips the substantive jobs, and only verifies that they skipped successfully. The cleanup commands, hostname comparison, variable binding, and Git URL-rewrite behavior can all be wrong while CI remains green.

RISKIEST LINE: `docs/PARALLEL-AGENTS.md:85` — it performs the destructive deletion while incorrectly assuming that a validated literal URL is the endpoint Git will actually contact.
```

Those findings were addressed by explicit host validation, binding both named URL variables, and detecting rewrite rules that can redirect the validated push URL.

Review after those fixes, verbatim:

```
1. `docs/PARALLEL-AGENTS.md:49-54,90` — **HIGH severity, high confidence.** Credential-bearing HTTPS URLs are accepted and then exposed. A clone configured as `https://x-access-token:<PAT>@github.com/free2z/zuu.git` passes the host/repository checks; `gh repo view` accepts this syntax. The runbook records the raw URL and passes it to processes as an argument. Shell tracing, agent transcripts, diagnostics, or process inspection can capture the PAT. A leaked write/admin token can mutate repository state and potentially place malicious code into the production deployment path. The current checkout’s URL is credential-free, but the documentation supports HTTPS generally without requiring userinfo or embedded secrets to be absent.

2. `docs/PARALLEL-AGENTS.md:56-59,90` — **HIGH severity, medium confidence.** The URL-rewrite check is not bound to the Git context that performs the destructive push. This repository has `extensions.worktreeConfig=true`; validation naturally occurs in the worker worktree, but line 90 occurs after that worktree is removed and therefore must run from another worktree or Git context. A rewrite configured only in the primary worktree is invisible during validation but applies to the later literal-URL push. Likewise, SSH `HostName`, `ProxyCommand`, `core.sshCommand`, or a concurrent config change can redirect transport without appearing in the checked `url.*` keys. If a mirror contains branch `B` at the same commit `H`, the lease succeeds and deletes the mirror’s branch while leaving the intended GitHub branch intact—after the local branch and recovery reflog have already been removed.

3. `docs/PARALLEL-AGENTS.md:56-59` — **LOW severity, high confidence.** The check rejects every URL rewrite, including rules that cannot match either validated URL. A harmless global rewrite for another host or organization therefore stops every cleanup. Repeated Rust/Tauri worktrees retain `target/` and `node_modules/`; eventually the shared agent disk fills, builds fail, and autonomous work stops until a human diagnoses the unrelated Git setting. This directly conflicts with the instruction that build-heavy merged worktrees must not remain.

CI does not execute this cleanup procedure or validate URL normalization, credential rejection, configuration scope, or the actual deletion destination. All scenarios above remain green.

RISKIEST LINE: `docs/PARALLEL-AGENTS.md:90` — it performs the destructive remote deletion using a raw potentially secret-bearing URL, after switching away from the context whose safety configuration was checked.
```

All findings were addressed: URLs must be credential-free canonical HTTPS endpoints; only rewrite rules capable of matching `PUSH_URL` block cleanup; and the URL/config recheck plus leased deletion now happen inside the still-present verified worktree, before local recovery metadata is removed.