### PR TITLE
docs(e2ee): Phase 0 architecture, threat model, and decision records

### DIFF
--- a/docs/e2ee/ARCHITECTURE.md
+++ b/docs/e2ee/ARCHITECTURE.md
@@ -1,0 +1,977 @@
+# free2z E2EE — Architecture
+
+**Status:** Phase 0 design. Nothing described here is implemented.
+**Refs:** [#305](https://github.com/free2z/zuu/issues/305) (epic and decisions),
+[#131](https://github.com/free2z/zuu/issues/131),
+[#132](https://github.com/free2z/zuu/issues/132),
+[#133](https://github.com/free2z/zuu/issues/133),
+[#134](https://github.com/free2z/zuu/issues/134).
+**Companion:** [`THREAT-MODEL.md`](./THREAT-MODEL.md),
+[`decisions/`](./decisions/).
+
+This document is written to be read by a third-party security auditor. Where
+something is undecided, it is listed in [§13 Open questions](#13-open-questions)
+rather than answered by invention. Where a property does not hold, it is stated
+as not holding. Constants, labels and wire encodings marked *proposed* are
+placeholders to be fixed in the Phase 1 specification; they are written down so
+the structure can be reviewed, not so they can be implemented as-is.
+
+---
+
+## 1. Where we are today
+
+Verified against the tree at the time of writing, so the starting point is a
+fact rather than a memory:
+
+- `ts/react/free2z/src/lib/p2pe2e/` is **642 lines** across
+  `webrtcmanager.ts` (151), `peerconnectionmanager.ts` (256),
+  `websocketmanager.ts` (160) and `datachannelmanager.ts` (75). Grepping it for
+  `encrypt|crypto|subtle|fingerprint|sodium|nacl` returns **nothing**. There is
+  no application-layer cryptography in the p2pe2e client at all.
+- `py/dj/apps/efm/consumers.py` is a 210-line Django Channels
+  `SignalingConsumer`. It authenticates a participant with an HS256 JWT signed
+  by `settings.SECRET_KEY`, tracks presence in the Django cache, and in
+  `handle_signaling_message` relays `offer` / `answer` / `ice_candidate`
+  messages verbatim from one participant's channel to another's.
+
+The consequence is exactly what [#133](https://github.com/free2z/zuu/issues/133)
+says: today's confidentiality is *only* WebRTC's DTLS transport encryption, and
+the certificate fingerprints that key it travel through the server inside the
+SDP. The server can hand participant A an offer pointing at a machine it
+controls, and MITM the session undetectably. **We are not hardening an E2EE
+system; we are building one for the first time.** There is no wire format to
+preserve, so we are architecturally unconstrained.
+
+## 2. Goals and non-goals
+
+### 2.1 Goals
+
+1. **The server cannot read message content.** Non-negotiable. No server-side
+   key escrow, no server-held plaintext, no server-mediated key agreement that
+   the server could substitute into.
+2. **The server destroys ciphertext on acknowledged delivery.** The relay may
+   buffer ciphertext for an offline recipient and must delete it once delivery
+   is acknowledged. It is a buffer, not an archive. (Relaxed from the original
+   "must be online" requirement, which made the product unusable.)
+3. **Forward secrecy and post-compromise security** at group scale, not just
+   for 1:1.
+4. **The server cannot lie about who you are talking to.** Key changes are
+   publicly auditable; a server that equivocates leaves non-repudiable evidence.
+5. **A credible, written metadata story** — not just AEAD over the body.
+6. **P2P is an optimization, never a security dependency.** It may fail, be
+   blocked, or be attacked without weakening confidentiality or authenticity.
+7. **Support cryptographic "apps"**, with FROST/DKG
+   ([#132](https://github.com/free2z/zuu/issues/132),
+   [#134](https://github.com/free2z/zuu/issues/134)) as the first one.
+8. **Hybrid post-quantum confidentiality from day one**, not retrofitted.
+9. **Federated by construction** — anyone can run a relay, and clients treat
+   relays as untrusted, replaceable infrastructure.
+
+### 2.2 Non-goals
+
+- **Anonymity against a global passive adversary.** We improve metadata privacy
+  substantially and state the limit plainly. We are not building Tor, and we do
+  not ship an anonymity network. Users who need network-layer anonymity should
+  run the client over one.
+- **Cryptographic deniability of conversational messages.** See §5.6 — MLS
+  application messages are signed by the sender's leaf key, so we do not get
+  deniability and we do not claim it.
+- **Post-quantum *authentication*.** X-Wing gives hybrid PQ confidentiality
+  (a KEM). Signatures remain Ed25519. See §5.5.
+- **Defending a compromised endpoint.** Malware with the user's privileges on
+  the user's device reads plaintext. No messenger defends against this and
+  neither do we.
+- **Compatibility with the current prototype's wire format.** There isn't one.
+- **Shipping code from Phase 0.**
+
+## 3. The stack
+
+| Layer | Choice | Standard |
+|---|---|---|
+| 0. Client integrity | ZUULI native (strong) / web WASM (stated-weaker) | [ADR 0001](./decisions/0001-platform-priority.md) |
+| 1. Identity + directory | Seed-derived identity; key-transparency log with cross-relay witness cosigning | CONIKS / SEEMless / Parakeet lineage |
+| 2. Session crypto | **MLS**, hybrid PQ (X-Wing) from day one | [RFC 9420](https://datatracker.ietf.org/doc/html/rfc9420), [RFC 9750](https://datatracker.ietf.org/doc/rfc9750/), [draft-ietf-mls-extensions](https://www.ietf.org/archive/id/draft-ietf-mls-extensions-04.html) |
+| 3. Delivery | SMP-style opaque pairwise unidirectional queues, delete-on-ack, federated | [SimpleX SMP](https://simplex.chat/docs/simplex.html) design, clean-room implementation |
+| 3b. Fallback delivery | Nostr relays, optional, retention consciously accepted | [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) is advisory only |
+| 4. P2P | WebRTC, DTLS fingerprints authenticated **inside** the MLS group | [RFC 8827](https://datatracker.ietf.org/doc/html/rfc8827) |
+| App | FROST/DKG on the MLS exporter, [#134](https://github.com/free2z/zuu/issues/134) payload structure, CertEq echo broadcast | [FROST](https://eprint.iacr.org/2020/852.pdf), [bip-frost-dkg](https://github.com/BlockstreamResearch/bip-frost-dkg) |
+
+Each layer is independently replaceable. The security of layer 2 does not depend
+on layers 3 or 4 being honest, which is what lets us push ciphertext through
+relays we do not trust as a censorship-resistance measure.
+
+```
+   ┌──────────────────────────────────────────────────────────────┐
+   │ App: chat UI · FROST/DKG ceremony · future apps              │
+   ├──────────────────────────────────────────────────────────────┤
+   │ Application framing: hash-linked DAG, retention class,       │
+   │ receipts, gap requests            (§7, transport-independent)│
+   ├──────────────────────────────────────────────────────────────┤
+   │ MLS (RFC 9420): FS, PCS, epochs, membership, exporter  (§5)  │
+   ├───────────────────────────┬──────────────────────────────────┤
+   │ Delivery service (§6)     │ P2P (§10)                        │
+   │ opaque queues, del-on-ack │ WebRTC, fingerprints from MLS    │
+   ├───────────────────────────┴──────────────────────────────────┤
+   │ Identity + key transparency directory (§4, §9)               │
+   └──────────────────────────────────────────────────────────────┘
+```
+
+### 3.1 MLS implementation choice
+
+**Recommended: [OpenMLS](https://github.com/openmls/openmls)** (Rust,
+permissively licensed, interop-tested against other MLS stacks), with the
+X-Wing hybrid ciphersuite built on Cryspen's
+[libcrux](https://cryspen.com/post/pq-openmls/) formally verified ML-KEM/X25519.
+One Rust crypto core, compiled natively for ZUULI and to WASM for the web
+client — no second implementation, therefore no implementation-divergence class
+of bug ([ADR 0001](./decisions/0001-platform-priority.md)).
+
+Alternatives considered: **mls-rs** (AWS) — good WASM story and conformance
+validation, but per #305 no published third-party security audit;
+**ts-mls** — would mean a second implementation, rejected on divergence grounds;
+**Marmot MDK** — audited by Least Authority and the closest existing system, but
+tightly coupled to Nostr transport, which conflicts with delete-on-ack (§6.7).
+We should study MDK closely and reuse its lessons without adopting its transport
+coupling.
+
+> **Open question (§13-A):** OpenMLS's third-party audit status must be
+> established in writing before release. Do not treat "widely used" as audited.
+
+## 4. Identity and the key hierarchy
+
+### 4.1 Principles
+
+- **Domain separation everywhere.** Every derivation is a keyed hash with a
+  distinct, versioned label. No key is ever used for two purposes.
+- **Never reuse Zcash spending or viewing keys as messaging keys.**
+  Non-negotiable ([ADR 0006](./decisions/0006-zcash-coupling.md)). Different
+  curves (Jubjub/Pallas vs. X25519/Ed25519) and, more fundamentally, key
+  separation is bedrock. We derive a *distinct* messaging seed from the master
+  seed and generate messaging keys from that.
+- **Identity is restorable from the mnemonic; device keys are not.** Identity
+  keys are seed-derived so that restoring the wallet restores the identity.
+  Device keys are generated by the device's CSPRNG, never leave the device, and
+  are *not* derivable from the seed — so seed compromise does not retroactively
+  yield every device's MLS state.
+- **Non-repudiation and deniable-style authentication never share a key.**
+  Per [#305 §3.3](https://github.com/free2z/zuu/issues/305), ceremony payloads
+  are deliberately signed and attributable; conversational authentication is a
+  different key context. (This buys blast-radius separation and clean
+  semantics; it does not buy deniability — see §5.6.)
+
+### 4.2 Derivation (proposed)
+
+Written in ZIP 32's idiom — BLAKE2b-512 with a 16-byte personalization,
+`(I_L, I_R) = (key, chain code)`, hardened indices only — because ZUULI already
+implements that shape and auditors already know it.
+See [ZIP 32](https://zips.z.cash/zip-0032).
+
+```
+S                     = BIP-39 seed (the wallet mnemonic the user already backs up)
+
+MSK  = (msk, cc_msk)  = BLAKE2b-512(personal = "Free2zMsg_MSTRv1", S)
+                        ── one-way. S is not recoverable from MSK.
+                        ── rooted in its own personalization, so this tree
+                           cannot collide with the Sapling ("ZcashIP32Sapling")
+                           or Orchard key trees even at identical indices.
+
+CKDh(node, i)         = BLAKE2b-512(personal = "Free2zMsg_CKDv1_",
+                                    cc_node || 0x11 || I2LEOSP32(i))
+                        ── hardened only; there is no non-hardened variant and
+                           no extended public key at any level of this tree.
+
+account_node          = CKDh(CKDh(CKDh(MSK, 32'), 133'), account')
+                           purpose' = 32'   (ZIP 32 idiom)
+                           coin'    = 133'  (SLIP-44 Zcash)
+```
+
+From `account_node`, every leaf is an HKDF-SHA256 expansion under a distinct
+versioned label (`HKDF-Expand(PRK = ik_account, info = label, L)`):
+
+| Key | Label | Type | Lifetime |
+|---|---|---|---|
+| `IdentitySigningKey` (ISK) | `free2z/msg/v1/identity-sig` | Ed25519 | Long-term. Signs device credentials and directory entries. **Never signs message content.** |
+| `CeremonySigningKey` (CSK) | `free2z/msg/v1/ceremony-sig` | Ed25519 | Long-term. Signs **only** FROST/DKG payloads (§11). Deliberately non-repudiable. |
+| `DirectoryAuthKey` | `free2z/msg/v1/directory-auth` | Ed25519 | Long-term. Authenticates directory updates and self-audit queries. |
+| `BackupWrapKey` | `free2z/msg/v1/backup-wrap` | 32 B | Long-term. Wraps local encrypted history so it survives reinstall on the same seed. |
+
+Per-device, generated on-device from the OS CSPRNG, never seed-derived, never
+exported:
+
+| Key | Type | Notes |
+|---|---|---|
+| `DeviceSignatureKey` (DSK) | Ed25519 | The MLS leaf `signature_key` (RFC 9420 §7.2). |
+| `DeviceInitKey` / KeyPackage keys | X-Wing hybrid (X25519 + ML-KEM-768) | HPKE init key and leaf `encryption_key`. |
+| `QueueKey_{q}` | Ed25519, one per queue | Authorizes send or receive on one relay queue (§6.2). |
+
+A **device credential** binds the two levels:
+
+```
+DeviceCredential = {
+  type:        "free2z/device-credential/v1",
+  identity_pk: ISK.public,
+  handle:      "@alice",
+  device_pk:   DSK.public,
+  device_kem_pk: DeviceInitKey.public,
+  not_before, not_after,
+  signature:   Sign(ISK, canonical(everything above))
+}
+```
+
+This is carried as the MLS `Credential` in the member's `LeafNode`, so **every
+MLS peer validates the identity→device binding as part of ordinary MLS
+processing.** Revocation is an explicit signed `DeviceRevocation` published to
+the key-transparency log and mirrored by an MLS `Remove` proposal in every group
+the device is in.
+
+> Adding a device to an account is a wiretap. Device registration and revocation
+> are designed now ([ADR 0002](./decisions/0002-multi-device.md)) and shipped
+> later, and when they ship they are security-critical: every registration must
+> be surfaced to every other device of the account and to the key-transparency
+> log, so it cannot happen silently.
+
+### 4.3 What is derived from what — summary
+
+```
+mnemonic ──► S ──► Sapling / Orchard trees            (wallet; never touched here)
+              └──► MSK ──► account_node ──► ISK, CSK, DirectoryAuthKey, BackupWrapKey
+                                              │
+                                              └─ signs ─► DeviceCredential
+                                                             ▲
+                     OS CSPRNG ──► DSK, DeviceInitKey, QueueKeys (per device)
+                                                             │
+                                                MLS LeafNode ┘
+                                                      │
+                                     MLS key schedule ▼ (RFC 9420 §8)
+                        epoch_secret ──► encryption_secret, sender_data_secret,
+                                          exporter_secret, epoch_authenticator, …
+                                                      │
+                                MLS-Exporter(label, ctx, L) ──► §5.4 app secrets
+```
+
+## 5. Session cryptography — MLS
+
+One MLS group per conversation or room, 1:1 included. MLS
+([RFC 9420](https://datatracker.ietf.org/doc/html/rfc9420)) is chosen because it
+is the only IETF-standard construction that gives forward secrecy **and**
+post-compromise security at group scale with O(log N) rekeying, has multiple
+interop-tested implementations, and — decisively for us — has a standardized
+exporter for handing application protocols epoch-bound key material (§5.4).
+
+### 5.1 Membership and epochs
+
+Membership changes (Add / Remove / Update) are Proposals committed into a new
+epoch. Every member independently validates the Commit against the
+`GroupContext`, so the delivery service cannot add or remove a member. The
+server relays Commits; it cannot author them.
+
+**Forward secrecy:** a member added in epoch *n* cannot derive keys for epoch
+*n−1*. A member who joins on Tuesday cannot read Monday's traffic through the
+protocol. This is correct and occasionally infuriating, and the product must say
+so plainly rather than paper over it; history transfer to a *new device of an
+existing member* is a separate, explicitly-designed mechanism (§13-D), not an
+accident of the crypto.
+
+**Post-compromise security:** a member who Updates their leaf key heals the
+group's secrets against an adversary who previously extracted that member's
+state, provided the adversary is passive after the Update. Clients issue an
+Update on a schedule and on every app foreground.
+
+### 5.2 Ciphersuite
+
+Baseline hybrid post-quantum from day one: X25519 + ML-KEM-768 via
+**X-Wing** ([draft-connolly-cfrg-xwing-kem](https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/)),
+AES-128-GCM (or ChaCha20-Poly1305 where AES is not hardware-accelerated),
+SHA-256, Ed25519 signatures.
+
+We adopt hybrid PQ now rather than retrofitting, because harvest-now-decrypt-
+later is a live threat against long-lived conversations and because retrofitting
+a ciphersuite across a federation is far harder than starting with one.
+
+> **Open question (§13-B):** the MLS PQ ciphersuite codepoint registration is
+> still in flight. We must pin an exact ciphersuite identifier and a migration
+> path before Phase 2, and be prepared for the registered value to differ from
+> whatever OpenMLS ships today.
+
+### 5.3 Framing
+
+All application payloads travel as MLS `PrivateMessage` (RFC 9420 §6.3), which
+encrypts the content, the sender's leaf index and the content type under the
+epoch's `encryption_secret` and `sender_data_secret`. The relay sees an opaque
+blob and a queue address, nothing more.
+
+### 5.4 Exporter-derived application secrets
+
+Per RFC 9420 §8.5,
+`MLS-Exporter(Label, Context, Length)` yields forward-secret, epoch-bound key
+material bound to the group state. The Safe Extension API in
+[draft-ietf-mls-extensions](https://www.ietf.org/archive/id/draft-ietf-mls-extensions-04.html)
+is the mechanism we intend to use for component-scoped exports as it stabilizes.
+
+| Consumer | Label | Context | Use |
+|---|---|---|---|
+| FROST/DKG (§11) | `free2z/frost/v1` | `ceremony_id` | Session domain separator, transcript binding, outer AEAD for part-2 shares |
+| WebRTC binding (§10) | `free2z/webrtc/v1` | `session_id` | Binds DTLS fingerprints to the group |
+| Queue rotation (§6.2) | `free2z/queue/v1` | `peer_leaf_index` | Derives the next queue addresses without a round trip |
+| Local history wrap | `free2z/history/v1` | `conversation_id` | At-rest key for retained plaintext |
+
+Because these are exporter outputs, they inherit the group's forward secrecy and
+are automatically bound to the exact membership of the epoch — which is
+precisely the "confidential, authenticated, replay-bound channel between an
+agreed participant list" that
+[#132](https://github.com/free2z/zuu/issues/132) requires, obtained from a
+standard instead of invented.
+
+### 5.5 What hybrid PQ does and does not buy
+
+- **Does:** confidentiality against an adversary that records ciphertext today
+  and gains a cryptographically relevant quantum computer later. The KEM is
+  hybrid, so it is no weaker than X25519 alone even if ML-KEM is broken
+  classically.
+- **Does not:** post-quantum *authentication*. MLS signatures are Ed25519, our
+  identity, device and ceremony signatures are Ed25519, and the KT log is signed
+  with Ed25519. An adversary with a quantum computer *at the time of the attack*
+  could forge them. This is an accepted, stated limitation; migrating signatures
+  (e.g. to ML-DSA) is future work and is listed in §13-C.
+
+### 5.6 Deniability — stated, not claimed
+
+MLS `PrivateMessage` carries a signature by the sender's leaf key over the
+framed content. **Therefore MLS as specified does not provide cryptographic
+deniability for conversational messages, and we do not claim it.** A recipient
+who preserves the ciphertext, the epoch secrets and the sender's leaf credential
+holds attributable evidence.
+
+What we *do* provide is strict key-context separation
+([#305 §3.3](https://github.com/free2z/zuu/issues/305)): `CeremonySigningKey`
+signs ceremony payloads and nothing else; `DeviceSignatureKey` signs MLS framing
+and nothing else; `IdentitySigningKey` signs credentials and directory entries
+and nothing else. A FROST transcript can never be replayed as chat evidence and
+vice versa. See also
+[Real-World Deniability in Messaging](https://petsymposium.org/popets/2025/popets-2025-0018.pdf)
+for why the practical value of deniability is contested; our position is to be
+honest about not having it rather than to imply it.
+
+## 6. Delivery service
+
+The delivery service is a **separate, small, efficient Rust process**, not a
+Django app ([ADR 0005](./decisions/0005-federation.md)). Concurrent WebSocket
+connections, not bandwidth, are the cost driver, and the Django Channels stack
+is dramatically less efficient per connection than a Rust service.
+
+Its design follows SimpleX's SMP: pairwise, unidirectional, opaque queues with
+no user identifiers anywhere. We adopt the *protocol design*; the implementation
+is clean-room.
+
+> **Action item (§13-E):** verify SimpleX's server licensing **before** anyone
+> reads their server source. Parts of that project are copyleft and we need a
+> clean-room posture.
+
+### 6.1 What the relay is
+
+A relay accepts ciphertext against a queue address, holds it until the reader of
+that queue acknowledges it, then deletes it. It has no accounts, no user
+identifiers, no contact lists, no group state, and no ability to enumerate who
+talks to whom by asking itself. It is a buffer, not an archive.
+
+Steady-state stored ciphertext at 1,000 DAU is on the order of **4 MB** — only
+what is currently undelivered. That is the entire point of delete-on-ack, and it
+is also the economic precondition for the federation
+([ADR 0005](./decisions/0005-federation.md)).
+
+### 6.2 Queues
+
+For every ordered pair (sender device → recipient device) there is a
+unidirectional queue with **two distinct addresses**:
+
+```
+QueueSendAddr  — presented by the sender; authorizes APPEND only
+QueueRecvAddr  — presented by the recipient; authorizes READ, ACK and DELETE
+```
+
+Each address is an opaque random identifier bound to an Ed25519 `QueueKey` at
+creation. Every relay command is signed with the relevant queue key. The relay
+verifies the signature against the key registered for that address and learns
+nothing else — no account, no handle, no identity key.
+
+The two addresses are unlinkable to each other at the relay, so a relay
+observing traffic on a send address cannot trivially identify the corresponding
+receive address, and therefore cannot trivially pair correspondents. It can
+still attempt timing correlation; see [`THREAT-MODEL.md`](./THREAT-MODEL.md).
+
+Queue addresses are established **inside** the MLS group — a member advertises
+its `QueueSendAddr` set to peers in an authenticated application message, never
+via the server. Addresses rotate on a schedule using the
+`free2z/queue/v1` exporter so a long-lived relationship does not present a
+long-lived identifier.
+
+**Fan-out (D2):** a message to a recipient with *d* registered devices is sent
+to *d* queues, one per device, as *d* independently encrypted MLS messages
+(each device is its own MLS leaf). Group messages to a group with *m* member
+devices go to *m* queues. The relay never learns that *d* queues belong to one
+person.
+
+### 6.3 What "delivered" means
+
+Four distinct states, deliberately separated. Conflating them is how
+delete-on-ack loses messages.
+
+| State | Who observes it | Meaning |
+|---|---|---|
+| `accepted` | sender ↔ relay | The relay returned OK for an APPEND to queue *q*. Says nothing about the recipient. |
+| `queue-delivered` | reader ↔ relay | The reader of *q* has **durably written the ciphertext to local storage** and then sent a signed ACK for that queue index. The relay deletes the ciphertext at this instant. |
+| `device-delivered` | end-to-end | The recipient device emitted an authenticated `DeliveryReceipt` **inside the MLS group**, referencing the message by `msg_id`. |
+| `delivered` (the D2 definition) | sender, application layer | A `device-delivered` receipt has been received from **every device in the recipient's device set as of the epoch in which the message was sent**. |
+
+Three properties follow, and each is deliberate:
+
+1. **The relay implements only `queue-delivered`.** Its deletion rule is
+   per-queue and unconditional: ACK arrives → delete. It has no cross-queue
+   state, because cross-queue state would mean knowing the device set, which
+   would mean knowing the recipient. There is no "all devices delivered" concept
+   on the server, by design.
+2. **A device MUST NOT ACK before its durable write completes.** ACK-on-read
+   plus a crash equals permanent loss, because the relay has already deleted the
+   only copy. This is a MUST in the client, and it is the single most
+   safety-critical rule in the delivery layer.
+3. **`delivered` is computed by the sender end-to-end**, from receipts that are
+   themselves MLS application messages. The relay cannot forge, suppress
+   undetectably (§7), or observe it.
+
+Undelivered ciphertext has a **TTL ceiling** (proposed: 30 days) after which the
+relay drops it and the sender learns only from the continued absence of a
+receipt. Quota and TTL are relay policy and are published in the relay's
+capability document so clients can choose.
+
+### 6.4 Delete-on-ack and lost acknowledgements
+
+[#131](https://github.com/free2z/zuu/issues/131) makes the point precisely: a
+dropped connection tells you nothing about what arrived. Delete-on-ack sharpens
+it — a lost ACK now means a permanently lost message, because the relay's copy
+is gone or was never taken.
+
+This is why §7's hash-linked DAG is not optional. It is the mechanism that turns
+"a message vanished" from an undetectable event into a detected gap with a
+defined repair path.
+
+### 6.5 Padding
+
+Ciphertext is padded to fixed-size buckets before it reaches the relay
+(proposed: 1 KiB / 4 KiB / 16 KiB / 64 KiB, then chunked into 64 KiB units).
+The relay **rejects** non-conforming sizes, so a client cannot leak length by
+being sloppy and a malicious client cannot use length as a covert channel to a
+colluding relay. Real text is ~100 bytes; the padding dominates, which is the
+intent.
+
+> **Open question (§13-F):** bucket sizes need a traffic study. The values above
+> are placeholders chosen for arithmetic convenience, not measurement.
+
+### 6.6 Delivery receipts
+
+Receipt timing is a **published deanonymization vector** against sealed sender
+([No safety in numbers](https://arxiv.org/pdf/2305.09799)) — sealed-sender group
+membership has been recovered from receipt patterns alone. Our position:
+
+- Receipts are **on by default, batched and jittered** (proposed: flushed on a
+  randomized interval rather than immediately on arrival).
+- Receipts are **disableable per conversation**, and the UI states the trade-off
+  (disabling costs you the ability to know a message landed, which under
+  delete-on-ack matters more than in a retaining messenger).
+- **Read receipts are separate from delivery receipts** and default off.
+
+### 6.7 Nostr as fallback transport
+
+Nostr relays are useful as a redundant, censorship-resistant path, and MLS's
+security does not depend on the relay being honest, so pushing ciphertext
+through relays we do not control costs no confidentiality.
+
+But Nostr relays are **retain-by-default**. NIP-40 expiration is advisory; a
+relay is free to ignore it, and we cannot verify deletion on infrastructure we
+do not run. **Therefore Nostr cannot satisfy goal 2 and is not our primary
+transport.** It is an opt-in fallback, per conversation, and the UI must state
+that choosing it means accepting that ciphertext may be retained indefinitely by
+third parties. Delete-on-ack is a property of relay software we specify.
+
+## 7. Application framing — hash-linked causal ordering
+
+Per [#131](https://github.com/free2z/zuu/issues/131) and
+[#134](https://github.com/free2z/zuu/issues/134)'s structural approach, every
+application payload carries hashes of its predecessors. This single choice makes
+ordering and gap detection **transport-independent**: it works identically
+whether a message arrived over the relay, over WebRTC, or over Nostr, so the
+transports can interleave freely without a sequencing authority.
+
+```
+AppMessage = {
+  type:            "chat" | "receipt" | "gap_request" | "gap_response"
+                 | "ceremony" | "queue_advert" | "webrtc_offer" | ...,
+  msg_id:          BLAKE2b-256("free2z/msg/v1/msgid" || canonical(rest)),
+  parents:         [msg_id, ...],   // every message this sender had delivered
+                                    // and not yet referenced, at send time
+  epoch:           uint64,          // MLS epoch
+  sent_at:         uint64,          // sender-claimed; ADVISORY ONLY, never
+                                    // used for ordering or security decisions
+  retention_class: CHAT | CEREMONY, // §8
+  body:            opaque
+}
+```
+
+Wrapped in an MLS `PrivateMessage`, so it is confidential and authenticated by
+the sender's leaf key without any additional signature for `CHAT` payloads.
+`CEREMONY` payloads carry their own signature *in addition* (§11) — that is
+deliberate belt-and-braces, not redundancy.
+
+- **Causal ordering:** the DAG's partial order. For display, a deterministic
+  total order breaks ties by `(epoch, sender_leaf_index, msg_id)`. Wall-clock
+  timestamps are never used to order, because a clock is an attacker-controlled
+  input.
+- **Gap detection:** a receiver that sees a `parents` hash it does not hold
+  knows, with certainty and without any server assistance, that it is missing a
+  message. It emits `gap_request{hashes}` to the sender over any available
+  transport.
+- **Repair:** the sender re-encrypts the original plaintext under the *current*
+  epoch and replies `gap_response`. It does not replay old ciphertext, so repair
+  does not undermine forward secrecy. This requires the sender to hold a
+  bounded-window plaintext outbox, which interacts with retention (§8.4).
+- **What hash links do NOT detect: tail truncation.** If a relay drops the last
+  *k* messages from a sender and no later message arrives, there is no dangling
+  parent to notice. Detecting suppression of the tail requires liveness signals
+  — periodic authenticated heartbeats carrying the sender's current DAG head —
+  and even then, an adversary that partitions a peer entirely is
+  indistinguishable from that peer being offline. Stated in
+  [`THREAT-MODEL.md`](./THREAT-MODEL.md); no protocol fixes this.
+
+## 8. Retention (D3)
+
+[ADR 0003](./decisions/0003-history-retention.md). This governs **client-side**
+retention only. In every mode, the server holds nothing after acknowledged
+delivery — that is goal 2 and it is not adjustable per conversation.
+
+### 8.1 Retention is group state, not a preference
+
+Retention is carried as a `GroupContext` extension (RFC 9420 §12.4), so it is
+part of the authenticated group state that every member validates on every
+Commit. **The server cannot tamper with it, cannot observe it, and cannot
+suppress a change to it undetectably.**
+
+```
+retention_policy_extension = {
+  mode:        EPHEMERAL | RETAINED,
+  ttl_seconds: uint32,      // EPHEMERAL only; time-to-live after local receipt
+  set_in_epoch: uint64,
+}
+```
+
+The extension is listed in `required_capabilities`, so a client that does not
+understand it cannot join the group at all. That is the correct failure mode: a
+client that would silently ignore an ephemeral setting must be excluded rather
+than tolerated.
+
+### 8.2 Changing it — negotiated, and what "agreed" actually means
+
+Changing retention is a two-phase application-layer negotiation followed by an
+MLS Commit:
+
+1. A member sends `RetentionChangeProposal{new_policy}` as an application
+   message.
+2. Every other member's client responds `RetentionChangeAck{accept | reject}`.
+3. Only on unanimous accept does the proposer issue a Commit carrying a
+   `GroupContextExtensions` proposal with the new policy.
+
+**Honest limit.** MLS cannot *enforce* unanimity — any member may commit a
+`GroupContextExtensions` proposal unilaterally, and MLS will accept it. What the
+protocol guarantees is that such a change is **authenticated, attributable and
+visible**: every member sees exactly who changed the policy and in which epoch,
+and can leave. So the property we deliver is **"no silent change,"** not "no
+unilateral change." The UI must present an out-of-band policy change as a
+prominent, attributed security event, not a toast.
+
+### 8.3 Mid-conversation changes apply forward only
+
+**A retention change takes effect from the epoch in which its Commit lands, and
+applies only to messages received in that epoch or later.** Messages already
+stored are governed by the policy that was in force when they were received.
+
+Rationale, both directions:
+
+- **RETAINED → EPHEMERAL cannot be retroactive**, because retroactive deletion
+  is unenforceable. A member may have been offline, may have exported, may have
+  screenshotted. Claiming retroactive deletion would be claiming a property we
+  cannot deliver.
+- **EPHEMERAL → RETAINED cannot be retroactive**, because the data is already
+  gone. There is nothing to retain.
+
+Separately, and clearly labeled as a **request, not a guarantee**, a member may
+send `PurgeRequest{before_epoch}`. Conforming clients delete local history
+before that epoch and reply `PurgeAck`. The UI must say "asked N participants to
+delete; M confirmed," never "deleted."
+
+### 8.4 Ephemeral mode is best-effort, and the UI must say so
+
+A recipient can always screenshot, photograph the screen, or run a modified
+client. Ephemeral mode defends against *casual* persistence and device seizure
+after the TTL. It does not defend against a determined counterparty, and any UI
+copy implying otherwise is a defect.
+
+Ephemeral mode also shortens the plaintext outbox window used for gap repair
+(§7), which means some gaps become unrecoverable. That is surfaced to the user
+as an explicit "this message could not be recovered" marker rather than a silent
+hole.
+
+### 8.5 Ceremony transcripts are exempt
+
+Messages with `retention_class = CEREMONY` are **always retained**, regardless of
+the conversation's retention policy. A DKG transcript is evidence: it is what
+lets a participant later prove the ceremony ran correctly and who said what.
+Clients MUST NOT delete them under any retention setting, and the UI MUST state
+this before the ceremony begins, so consent is informed. Transcripts are stored
+under the `free2z/history/v1` local wrap key like everything else.
+
+## 9. Identity directory, key transparency, and federation
+
+### 9.1 The problem this solves
+
+[#133](https://github.com/free2z/zuu/issues/133): the server today decides who
+you are connected to. Any directory that maps `@handle → identity key` and is
+trusted blindly reintroduces exactly that MITM, one level up. Encrypting
+perfectly to the wrong key is not security.
+
+### 9.2 The directory
+
+A CONIKS / SEEMless / Parakeet-lineage **append-only log** of
+`(handle → IdentitySigningKey.public, epoch, DeviceCredential set)`, with:
+
+- **Inclusion proofs** for a queried handle, so a lookup is verifiable.
+- **Privacy-preserving lookups** (SEEMless/Parakeet-style) so a lookup does not
+  reveal the rest of the directory and unqueried entries stay private.
+- **Consistency proofs** between successive epoch roots
+  ([RFC 6962](https://datatracker.ietf.org/doc/html/rfc6962)-style), so a client
+  can verify the log is append-only across every root it has ever seen.
+- **Self-audit:** every client monitors its own handle each epoch and raises a
+  loud, non-dismissible alarm on any key change it did not initiate. This is
+  what makes an attempted MITM *detectable by the victim*, which is the whole
+  point.
+- **Manual safety-number verification** remains available and is the strongest
+  check; ZUULI additionally offers verification over a shielded Zcash memo
+  between two users who already know each other's payment address — an
+  authenticated, private, *remote* out-of-band channel, which is genuinely
+  unusual (see [ADR 0006](./decisions/0006-zcash-coupling.md)).
+
+### 9.3 Anti-equivocation without a blockchain
+
+The residual attack on any KT log is **equivocation**: showing different
+directories to different users. The fix is Certificate Transparency's, not a
+chain's:
+
+- **Cross-relay witness cosigning.** Each relay in the federation observes and
+  signs the KT log root for each epoch. A client accepts a root only if it
+  carries at least *t* cosignatures from its own configured witness set. Two
+  conflicting signed roots for the same epoch are **non-repudiable
+  cryptographic evidence of misbehavior**, publishable by anyone.
+- **Client gossip.** Clients cross-check roots with each other over the
+  messaging channel itself — CONIKS's original design, and free because we
+  already have an authenticated channel.
+
+The property strengthens as the federation grows, so the multi-relay design we
+want for censorship resistance ([ADR 0005](./decisions/0005-federation.md))
+delivers anti-equivocation as a side effect.
+
+**No blockchain in the critical path** ([ADR 0006](./decisions/0006-zcash-coupling.md)).
+On-chain checkpointing buys nothing that witness cosigning does not, and costs a
+hard dependency plus exposure to ZEC price volatility. For the record: at
+[ZIP 317](https://zips.z.cash/zip-0317)'s 10,000-zatoshi minimum shielded fee and
+ZEC ≈ $517 (Aug 2026), a checkpoint costs ~$0.052 — cheap, but cheap is not the
+argument. It may exist later as an opt-in highest-assurance tier.
+
+### 9.4 Relay trust model
+
+Clients treat relays as **untrusted, replaceable infrastructure.**
+
+| A relay CAN | A relay CANNOT |
+|---|---|
+| Refuse service, drop, delay or reorder ciphertext | Read message content |
+| Count messages and observe bucketed sizes | Forge or modify a message (MLS auth fails) |
+| Observe connection times and source IPs | Add or remove a group member |
+| Attempt timing correlation between queues | Learn the handle or identity key behind a queue |
+| Retain ciphertext despite claiming not to (unverifiable) | Undetectably suppress a message in the *middle* of a DAG (§7) |
+| Suppress the *tail* of a conversation (§7) | Equivocate on the KT log without leaving evidence (§9.3) |
+
+The relay is open source and trivially self-hostable **from the first release**,
+not as a later "community edition." A community operator should be able to run
+one sustainably on a ~$5/month VPS; that is achievable precisely because
+delete-on-ack means there is no archive and pairwise queues mean there is no
+public firehose. (~95% of Nostr relays cannot cover their costs, and retain-
+everything-serve-a-firehose is why.)
+
+Redundancy: a device may publish queue addresses on *k* relays and senders send
+to all *k*; duplicates are deduplicated client-side by `msg_id`. Egress
+multiplies by *k*; at *k*=3 this is still trivial. Choosing *k*'s default is
+§13-G.
+
+## 10. P2P (WebRTC) — an optimization, not a dependency
+
+Keep WebRTC, invert the trust. Today the signaling server relays SDP containing
+DTLS certificate fingerprints, and the client trusts them — which is the MITM in
+[#133](https://github.com/free2z/zuu/issues/133).
+
+**New rule: DTLS certificate fingerprints are exchanged and authenticated inside
+the MLS group, never trusted from the signaling server.**
+
+1. Each peer generates its DTLS certificate and computes the fingerprint.
+2. Each peer sends `webrtc_offer{fingerprint, sdp_digest, session_id}` as an
+   MLS application message — confidential and authenticated to the group.
+3. SDP may still be relayed by the server for connectivity, but the receiving
+   client **verifies that the fingerprint in the received SDP exactly matches
+   the one it received inside the MLS group**, and refuses the connection
+   otherwise.
+4. The session is additionally bound to the group by
+   `MLS-Exporter("free2z/webrtc/v1", session_id, 32)`.
+
+A substituted fingerprint now fails authentication rather than going unnoticed.
+This makes #133's attack **impossible rather than merely detectable**, and it
+demotes P2P to what it should be: a latency and bandwidth optimization that may
+fail freely without compromising anything. Application framing (§7) is identical
+over P2P and relay, so the two interleave without special cases.
+
+WebRTC still leaks the peer's IP address through ICE candidates. Clients default
+to relay-only ICE (TURN) for contacts not explicitly trusted, and the UI states
+what enabling direct connections reveals.
+
+## 11. FROST/DKG — the first application
+
+Runs **inside** an MLS group whose membership is exactly the participant list,
+using an exporter-derived, epoch-bound secret — while keeping
+[#134](https://github.com/free2z/zuu/issues/134)'s signed, session-hash-bound
+payload structure as the application payload.
+
+This is deliberate belt-and-braces, and the reasoning matters: MLS provides the
+channel, forward secrecy, post-compromise security and ordering; #134's
+structure keeps the ceremony **verifiable even if the channel is broken**, which
+was the entire point of that proposal. The data structure must remain secure
+over "any networking, even unreliable or insecure networking."
+
+### 11.1 Payload structure (from #134, retained)
+
+Including the follow-up refinement in #134's comments: **every signed message
+carries the signing participant's public key (`participant_id`) and an explicit
+message `type`.** A key signing itself costs nothing and makes ordering and
+verification obvious to implement.
+
+```
+session = {
+  type: "frost/dkg/session/v1",
+  participants: [SigningKey, ...],   // CeremonySigningKey publics, ordered
+  threshold, max_signers,
+  nonce: <32 random bytes>,          // distinguishes runs with same participants
+  time,                              // advisory
+}
+session_hash = H(canonical(session))
+
+part1 = {
+  type: "frost/dkg/part1/v1",
+  participant_id: <signer's CeremonySigningKey public>,
+  session: session_hash,             // identical on every message; anti-replay
+  commitment: <FROST round-1 commitment>,
+  encryption: <fresh X25519 public key>,   // MUST be fresh per session
+  signature: Sign(CSK, canonical(rest)),
+}
+part1_id = H(all part1 messages, in session participant order)
+
+part2 = {
+  type: "frost/dkg/part2/v1",
+  participant_id, part1: part1_id,
+  shares: [ box(FROST.part2(participants[i]),
+                nonce = part1_id,             // deterministic ⇒ unique per pair
+                receiver = participants[i].encryption,
+                sender   = self.encryption) , ... ],  // session participant order
+  signature: Sign(CSK, canonical(whole message including shares)),
+}
+
+part3 = {
+  type: "frost/dkg/part3/v1",
+  participant_id,
+  part2: H(all part2 messages, in session participant order),
+  shared_public_key: <the FROST group public key>,
+  signature: Sign(CSK, canonical(rest)),
+}
+```
+
+Signatures use `CeremonySigningKey` — a key context that signs ceremony payloads
+and nothing else (§4.2, §5.6). Using `part1_id` as the box nonce is
+deterministic *and* unique per (session, pair), which is stronger than random
+for this purpose because it removes any chance of nonce reuse across a retry.
+
+The MLS exporter secret `MLS-Exporter("free2z/frost/v1", ceremony_id, 32)` is
+mixed into the transcript domain separator and used as an outer AEAD context, so
+a ceremony transcript from one group can never be replayed into another even if
+the participant list and nonce were somehow identical.
+
+### 11.2 Mandatory destruction of the per-session encryption key
+
+#134 requires that each participant **delete their per-session encryption
+private key once they have received the part-2 messages.** An attacker who later
+obtains that key can decrypt the shares sent to that participant, and an
+attacker who obtains enough of them can reconstruct a threshold and forge
+signatures. This is a forward-secrecy requirement, and it must be **enforced and
+tested, not left to convention**:
+
+- The key lives in a `Zeroizing` wrapper in the Rust core and is owned by the
+  ceremony state machine.
+- The Part2 → Part3 transition destroys it as part of the transition, not as a
+  best-effort cleanup afterwards.
+- A test asserts that after the transition, an attempt to decrypt any part-2
+  ciphertext fails — i.e. the destruction is observable, not merely intended.
+- **Honest limit:** in the WASM/browser client we cannot guarantee zeroization.
+  The JavaScript engine's GC may have copied the buffer, and we cannot control
+  the heap. This is one of several reasons ceremonies are a ZUULI-first feature
+  ([ADR 0001](./decisions/0001-platform-priority.md)).
+
+### 11.3 Participant-list agreement needs a real echo broadcast
+
+#134's first step — the initiator announces the participant list — requires
+genuine *agreement*, not just delivery. Pedersen-style DKG without agreement on
+the broadcast is vulnerable to a participant **biasing the resulting key by
+adaptively complaining after seeing shares**. This is a known, live concern in
+the exact FROST implementation we would use:
+[ZcashFoundation/frost#577 — "Lack of agreement despite broadcast"](https://github.com/ZcashFoundation/frost/issues/577).
+
+We therefore implement an echo broadcast — Goldwasser–Lindell style, or
+concretely the `CertEq` construction from
+[BlockstreamResearch/bip-frost-dkg](https://github.com/BlockstreamResearch/bip-frost-dkg):
+
+1. Every participant signs `session_hash` with its `CeremonySigningKey`.
+2. Signatures are echoed to all participants and collected into a certificate.
+3. A participant outputs success **only** when it holds a certificate containing
+   a valid signature from **every** participant in the list.
+
+A participant that never obtains a complete certificate does not proceed and
+does not output a key. See also the
+[ZF Pedersen DKG DoS remediation](https://zfnd.org/pedersen-dkg-vulnerability-in-frost-distributed-key-generation-successfully-remediated/).
+
+### 11.4 Meeting #132's requirements
+
+| #132 requirement | How it is met |
+|---|---|
+| Part 1 from every participant to every other (reliable broadcast) | MLS application messages fanned out to per-device queues, plus §7's hash-linked DAG for gap detection and explicit re-request. This is *eventual delivery with retry*, **not** Byzantine reliable broadcast — see the caveat below. |
+| Part 2 to each participant confidentially, hidden from server and other participants | #134's per-recipient `box()` to fresh per-session X25519 keys, inside MLS. Two independent layers; either alone suffices for confidentiality against the relay. |
+| An agreed participant list before key generation | §11.3 CertEq echo broadcast. |
+| Progress on receiving all part-*n* without knowing others have | The state machine advances on local completeness, exactly as #132 specifies. |
+
+**Caveat, stated plainly:** our transport gives eventual delivery with retry, not
+Byzantine reliable broadcast. A relay can delay or partition arbitrarily. What
+CertEq supplies is the *agreement* property that a lossy broadcast lacks — a
+partitioned participant fails to complete rather than completing on a divergent
+view. Liveness is not guaranteed against an adversarial relay; **safety is.**
+
+### 11.5 Transcript retention
+
+Every ceremony message carries `retention_class = CEREMONY` and is retained
+regardless of the conversation's retention policy (§8.5).
+
+## 12. Disposition of prior review feedback
+
+| Issue | Point | Disposition |
+|---|---|---|
+| [#131](https://github.com/free2z/zuu/issues/131) | Networks are unreliable; connections drop without telling you what arrived | **Addressed** — §7 hash-linked DAG, explicit acks, §6.4 |
+| #131 | N² P2P connections make failure probability quadratic | **Addressed** — §10 demotes P2P to an optimization; the relay is the default path, and its connection count is linear |
+| #131 | Timestamps cannot order messages | **Addressed** — §7, `sent_at` is advisory only and never used for ordering |
+| #131 | "For FROST, a centralized server with sequence numbers is much simpler" | **Consciously declined in that form.** We keep a server-mediated default path (agreeing with the reliability argument) but reject server-assigned sequence numbers as the ordering authority, because that hands the server censorship and reordering power. The DAG gives the same replay-on-reconnect ergonomics without trusting the sequencer. |
+| [#132](https://github.com/free2z/zuu/issues/132) | Reliable broadcast, confidential per-recipient delivery, agreed participant list, local-completeness progression | **Addressed** — §11.4, with the honest caveat that we provide eventual delivery, not Byzantine reliable broadcast |
+| [#133](https://github.com/free2z/zuu/issues/133) | The server can MITM the WebRTC handshake | **Addressed** — §10 (fingerprints authenticated in-band) and §9 (key transparency for the identity keys themselves) |
+| #133 | Minimize manual checking; prefer many participants checking the same thing | **Addressed** — §9.2 self-audit and gossip mean everyone checks the same log roots automatically; manual safety numbers are a backstop, not the primary mechanism |
+| [#134](https://github.com/free2z/zuu/issues/134) | Signed, session-hash-bound, self-securing payload structure | **Adopted essentially verbatim** — §11.1 |
+| #134 | Deterministic `part1_id` as box nonce | **Adopted** — §11.1 |
+| #134 | Per-session encryption key MUST be deleted after part 2 | **Adopted and made testable** — §11.2 |
+| #134 (comment) | Include `participant_id` and a message `type` in every signed message | **Adopted** — §11.1 |
+| #134 | Participant-list agreement | **Strengthened** — §11.3 requires a real echo broadcast (CertEq); announcement alone is insufficient |
+
+## 13. Open questions
+
+Genuinely undecided. Listed rather than invented.
+
+- **A. OpenMLS audit status.** Must be established in writing before release.
+  "Widely used" is not "audited." If no adequate audit exists, budget one; per
+  #305's economics, audit dominates the cost of this system and infrastructure
+  is a rounding error.
+- **B. PQ ciphersuite codepoint.** The MLS PQ ciphersuite registration is in
+  flight. Pin an exact identifier and a migration path before Phase 2.
+- **C. Post-quantum signatures.** X-Wing covers the KEM only. Migrating identity,
+  device, ceremony and KT-log signatures (e.g. to ML-DSA) is unscheduled. What
+  is the trigger condition?
+- **D. History transfer to a new device.** MLS forward secrecy means a newly
+  added device cannot decrypt past epochs. Under `RETAINED`, do we transfer
+  local history device-to-device (requiring a secure pairing channel), and what
+  does that do to the forward-secrecy claim? Unresolved.
+- **E. SimpleX licensing.** Verify the server licence **before** anyone reads
+  their source; adopt the SMP protocol design with a clean-room implementation.
+- **F. Padding bucket sizes.** Need a traffic study; current values are
+  placeholders.
+- **G. Relay redundancy factor *k*.** Default value, and whether it is per
+  conversation or global.
+- **H. Push notifications.** APNs/FCM are the standard way to avoid a persistent
+  connection per mobile client — which is our dominant cost driver — but they
+  leak notification timing to Apple/Google and the push token is an identifier.
+  SimpleX uses a separate optional queue address. **We need a deliberate
+  position and do not have one.**
+- **I. Anonymous credentials for quota.** The zkgroup/KVAC-style design for
+  "prove you paid for capacity without revealing who you are"
+  ([ADR 0006](./decisions/0006-zcash-coupling.md), optional tier) is unspecified.
+- **J. Retention unanimity.** §8.2 delivers "no silent change," not "no
+  unilateral change." Is that acceptable, or do we want an application-layer
+  policy that treats a non-unanimous change as grounds for automatic exit?
+- **K. Handle rename and transfer.** How the KT log represents a handle changing
+  owner without creating a MITM window.
+- **L. Encrypted media attachments.** Out of scope for the first release, but the
+  storage decision (zero-egress object storage) should be made before we build,
+  not after — retrofitting off S3-style egress pricing is painful.
+- **M. Group scale limits.** MLS is O(log N) for rekey but the delivery fan-out
+  is O(members × devices). At what size do we need a different fan-out strategy?
+
+## 14. References
+
+**Standards**
+[RFC 9420 — MLS Protocol](https://datatracker.ietf.org/doc/html/rfc9420) ·
+[RFC 9750 — MLS Architecture](https://datatracker.ietf.org/doc/rfc9750/) ·
+[draft-ietf-mls-extensions — Safe Extension API](https://www.ietf.org/archive/id/draft-ietf-mls-extensions-04.html) ·
+[draft-connolly-cfrg-xwing-kem](https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/) ·
+[RFC 9180 — HPKE](https://datatracker.ietf.org/doc/html/rfc9180) ·
+[RFC 6962 — Certificate Transparency](https://datatracker.ietf.org/doc/html/rfc6962) ·
+[RFC 8827 — WebRTC Security Architecture](https://datatracker.ietf.org/doc/html/rfc8827) ·
+[ZIP 32](https://zips.z.cash/zip-0032) ·
+[ZIP 316](https://zips.z.cash/zip-0316) ·
+[ZIP 317](https://zips.z.cash/zip-0317) ·
+[ZIP 302](https://zips.z.cash/zip-0302) ·
+[ZIP 231](https://zips.z.cash/zip-0231)
+
+**Systems**
+[Marmot / White Noise](https://github.com/marmot-protocol/marmot) ·
+[Least Authority audit — Marmot MDK](https://leastauthority.com/blog/audit-of-white-noise-marmot-development-kit-mdk/) ·
+[SimpleX / SMP](https://simplex.chat/docs/simplex.html) ·
+[Signal Private Group System (KVAC)](https://signal.org/blog/pdfs/signal_private_group_system.pdf) ·
+[Signal Double Ratchet](https://signal.org/docs/specifications/doubleratchet/) ·
+[Signal SPQR](https://signal.org/blog/spqr/)
+
+**Key transparency**
+[CONIKS](https://eprint.iacr.org/2014/1004.pdf) ·
+[Parakeet](https://eprint.iacr.org/2023/081.pdf) ·
+[WhatsApp Key Transparency](https://engineering.fb.com/2023/04/13/security/whatsapp-key-transparency/)
+
+**FROST / DKG**
+[FROST paper](https://eprint.iacr.org/2020/852.pdf) ·
+[bip-frost-dkg (CertEq)](https://github.com/BlockstreamResearch/bip-frost-dkg) ·
+[ZF FROST book — DKG](https://frost.zfnd.org/tutorial/dkg.html) ·
+[ZcashFoundation/frost#577](https://github.com/ZcashFoundation/frost/issues/577) ·
+[ZF Pedersen DKG remediation](https://zfnd.org/pedersen-dkg-vulnerability-in-frost-distributed-key-generation-successfully-remediated/)
+
+**Implementations**
+[OpenMLS](https://github.com/openmls/openmls) ·
+[PQ OpenMLS / libcrux](https://cryspen.com/post/pq-openmls/) ·
+[mls-rs](https://github.com/awslabs/mls-rs) ·
+[ts-mls](https://github.com/LukaJCB/ts-mls)
+
+**Limits and attacks**
+[No safety in numbers — sealed-sender traffic analysis](https://arxiv.org/pdf/2305.09799) ·
+[Improving Signal's Sealed Sender](https://www.cs.umd.edu/~kaptchuk/publications/ndss21.pdf) ·
+[WAIT — Binary-Equivalent Transparency](https://arxiv.org/pdf/2104.06136) ·
+[Trustworthy JavaScript for the Open Web](https://hacks.mozilla.org/2026/05/trustworthy-javascript-for-the-open-web/) ·
+[Real-World Deniability in Messaging](https://petsymposium.org/popets/2025/popets-2025-0018.pdf)

--- a/docs/e2ee/README.md
+++ b/docs/e2ee/README.md
@@ -1,0 +1,57 @@
+# free2z E2EE — Phase 0 design documentation
+
+This directory holds the Phase 0 deliverable of
+[issue #305](https://github.com/free2z/zuu/issues/305) — the design of free2z's
+end-to-end encrypted messaging system. **No code ships from Phase 0.** These are
+specifications and decision records written before implementation so that the
+architecture is chosen deliberately and can be reviewed by a third party.
+
+## Contents
+
+| Document | What it is |
+|---|---|
+| [`ARCHITECTURE.md`](./ARCHITECTURE.md) | The design. Layers, key hierarchy and derivation, delivery-service semantics, retention model, metadata model, federation and relay trust, FROST/DKG application design, open questions. |
+| [`THREAT-MODEL.md`](./THREAT-MODEL.md) | Adversaries, what each can do, and for each one the defense — or a plain statement that there is none. Includes the known, accepted limits. |
+| [`decisions/`](./decisions/) | One ADR per owner decision, `0001`–`0006`. |
+
+## The six binding decisions
+
+Recorded by the owner on 2026-08-08 in
+[#305](https://github.com/free2z/zuu/issues/305). They are inputs to this
+design, not conclusions of it. An implementation PR that contradicts one of
+these should be rejected, or should first change the decision on the record.
+
+| ADR | Decision |
+|---|---|
+| [0001](./decisions/0001-platform-priority.md) | **Platform** — ZUULI-first; the web client speaks the same protocol via WASM with an explicitly weaker, UI-stated trust model. |
+| [0002](./decisions/0002-multi-device.md) | **Multi-device** — design the protocol, queues and key hierarchy for per-device fan-out from day one; ship single-device in the UI. |
+| [0003](./decisions/0003-history-retention.md) | **History** — per-conversation retention, negotiated and authenticated inside the MLS group. FROST transcripts exempt and always retained. |
+| [0004](./decisions/0004-metadata-ambition.md) | **Metadata** — key-transparency directory for `@handle` discovery, then sealed sender over opaque pairwise unidirectional queues. |
+| [0005](./decisions/0005-federation.md) | **Federation** — full multi-relay. The relay is a separate small Rust service, open source and self-hostable from the first release. |
+| [0006](./decisions/0006-zcash-coupling.md) | **Zcash** — client-side cryptography only. Seed-derived messaging identity; no blockchain in the critical path. |
+
+## Prior art in this repo
+
+These four issues are the best prior analysis we have, contributed by a
+cryptographer, and the design is written to honor them rather than replace them.
+
+- [#131](https://github.com/free2z/zuu/issues/131) — the network is unreliable;
+  ordering and gap detection must be transport-independent.
+- [#132](https://github.com/free2z/zuu/issues/132) — FROST/DKG needs reliable
+  broadcast *plus* confidential per-recipient delivery *plus* an agreed
+  participant list.
+- [#133](https://github.com/free2z/zuu/issues/133) — the server can MITM the
+  WebRTC handshake today; key transparency plus in-band fingerprint
+  authentication is the fix.
+- [#134](https://github.com/free2z/zuu/issues/134) — the signed,
+  session-hash-bound ceremony payload structure, and the mandatory destruction
+  of per-session encryption keys after part 2.
+
+Where each of those is addressed is tabulated in
+[`ARCHITECTURE.md` §12](./ARCHITECTURE.md#12-disposition-of-prior-review-feedback).
+
+## Status
+
+Phase 0 documentation. Nothing here is implemented. The phasing plan lives in
+[#305 §8](https://github.com/free2z/zuu/issues/305); child issues are filed
+against it.

--- a/docs/e2ee/THREAT-MODEL.md
+++ b/docs/e2ee/THREAT-MODEL.md
@@ -1,0 +1,451 @@
+# free2z E2EE — Threat model
+
+**Status:** Phase 0 design. Nothing described here is implemented.
+**Companion:** [`ARCHITECTURE.md`](./ARCHITECTURE.md),
+[`decisions/`](./decisions/). **Refs:**
+[#305](https://github.com/free2z/zuu/issues/305).
+
+This document names the adversaries and, for each, states the defense — or
+states plainly that there is none. It is written for a third-party auditor, so
+the failures are as prominent as the successes. **Every security property
+claimed here is one the design in `ARCHITECTURE.md` actually delivers.** Where a
+property does not hold, it is listed as not holding rather than softened.
+
+---
+
+## 1. Assets
+
+| Asset | Why it matters |
+|---|---|
+| Message plaintext | The obvious one. |
+| Long-term identity keys (`ISK`, `CSK`) | Compromise means impersonation, and for `CSK`, forged ceremony transcripts. Seed-derived, so seed compromise implies these. |
+| Per-device MLS state (leaf key, epoch secrets) | Compromise means reading current traffic until PCS heals. |
+| FROST secret shares and the per-session encryption key | Enough shares reach threshold and forge spending authority over real funds. |
+| Social graph (who talks to whom) | Often more sensitive than content. |
+| Conversation existence and timing | Traffic analysis input. |
+| Group membership | Signal-sealed-sender research shows this is recoverable from receipt patterns if you are careless. |
+| Handle → identity key mapping | If the server can lie about it, all of the above is moot. |
+| Retained local history | Device seizure surface. |
+
+## 2. Trust assumptions
+
+We assume, without which nothing works:
+
+- The user's device is not compromised at the time of key generation.
+- The mnemonic is backed up by the user and not disclosed.
+- The cryptographic primitives hold: X25519, ML-KEM-768, Ed25519, SHA-256,
+  BLAKE2b, AES-GCM / ChaCha20-Poly1305 — with the quantum caveat in §3.8.
+- The Rust crypto core, once audited, is a correct implementation.
+- For ZUULI: the OS, the code-signing chain, and the update channel are honest.
+- For the web client: **we assume much more, and that is the point of §3.6.**
+
+We do **not** assume the free2z server is honest, the relay is honest, the
+network is honest, or that other participants are honest.
+
+## 3. Adversaries
+
+### 3.1 Malicious or compromised free2z server
+
+**Capability.** Runs the application server, the key-transparency directory, and
+the first relay. Serves the web client's JavaScript. Sees every connection, every
+queue operation, every directory lookup, and every source IP. Can modify any
+data it stores or relays.
+
+**Defended.**
+
+- **Cannot read message content.** All payloads are MLS `PrivateMessage`; the
+  server holds no key material and participates in no key agreement. This is
+  goal 1 and it holds unconditionally for the ZUULI client.
+- **Cannot forge or modify messages.** MLS authenticates every message with the
+  sender's leaf key, bound to a device credential signed by the sender's
+  identity key. Modification fails authentication at the recipient.
+- **Cannot add or remove group members.** Membership changes are MLS Commits
+  validated independently by every member against the `GroupContext`. The server
+  relays Commits; it cannot author them.
+- **Cannot MITM the WebRTC handshake** — the attack in
+  [#133](https://github.com/free2z/zuu/issues/133). DTLS fingerprints are
+  exchanged inside the MLS group and the client refuses any SDP whose
+  fingerprint does not match
+  ([`ARCHITECTURE.md` §10](./ARCHITECTURE.md#10-p2p-webrtc--an-optimization-not-a-dependency)).
+  A substituted fingerprint fails authentication rather than going unnoticed.
+- **Cannot substitute an identity key undetectably.** The KT directory is an
+  append-only log with inclusion and consistency proofs; every client self-audits
+  its own handle every epoch and alarms on any key change it did not initiate.
+  An attempted substitution is visible **to the victim**.
+- **Cannot equivocate on the directory without leaving evidence.** Cross-relay
+  witness cosigning plus client gossip means two conflicting signed roots for one
+  epoch are non-repudiable, publishable proof of misbehavior
+  ([`ARCHITECTURE.md` §9.3](./ARCHITECTURE.md#93-anti-equivocation-without-a-blockchain)).
+- **Cannot tamper with the retention policy.** It is a `GroupContext` extension,
+  authenticated inside MLS.
+- **Cannot silently drop a message in the middle of a conversation.** Hash-linked
+  parents produce a detectable gap.
+- **Cannot retain ciphertext it has deleted.** For its *own* relay we control the
+  code; see the honest limit below.
+
+**Not defended.**
+
+- **Denial of service.** The server can refuse to serve, drop every message, or
+  delete a user's account. There is no defense within the protocol. The mitigation
+  is structural, not cryptographic: federation
+  ([ADR 0005](./decisions/0005-federation.md)) means a user can move to another
+  relay, and the KT log's witnesses are not all ours.
+- **Retention despite claiming deletion.** Delete-on-ack is a property of relay
+  *software*, and no client can verify that a remote process actually called
+  `unlink`. We can make it auditable (open source, reproducible builds,
+  self-hosting) but not verifiable. **Anyone who needs a verifiable guarantee
+  must run their own relay.** Stated plainly, and it is why self-hosting from the
+  first release is a decision rather than a nicety.
+- **Tail truncation.** Dropping the last *k* messages from a sender, when no later
+  message arrives to dangle a parent hash, is not detectable by the hash-link
+  mechanism. Heartbeats carrying the sender's DAG head narrow the window; a full
+  partition remains indistinguishable from the peer being offline.
+- **Directory lookup metadata.** See §4.1.
+- **Serving malicious JavaScript to the web client.** See §3.6. This is the big
+  one, and it is not fixable at the protocol layer.
+
+### 3.2 Network observer
+
+**Capability.** Passive or active on-path: the user's ISP, a national backbone,
+a hostile Wi-Fi, a CDN in the path. Sees TLS-wrapped traffic to the relay and,
+if direct P2P is used, the peer's IP.
+
+**Defended.**
+
+- Content is encrypted twice over (MLS inside TLS). A network observer learns
+  nothing about content that the relay does not already learn — which is nothing.
+- Message sizes are padded to fixed buckets before leaving the client, so length
+  does not leak content
+  ([`ARCHITECTURE.md` §6.5](./ARCHITECTURE.md#65-padding)).
+- Active tampering with the transport causes MLS authentication failures, not
+  silent corruption.
+- Queue identifiers are opaque and rotate, so a long-lived relationship does not
+  present a long-lived on-wire identifier.
+
+**Not defended.**
+
+- **The user is using free2z, and when.** Connection timing, volume and cadence
+  are visible. We do not ship an anonymity network; a user who needs to hide
+  *that they are using the system* must run the client over Tor or a VPN. This
+  is a stated non-goal.
+- **Coarse activity correlation.** An observer with vantage on both endpoints can
+  correlate send and receive timing. See §3.7.
+- **Peer IP address on direct P2P.** ICE candidates reveal it. Clients default to
+  relay-only ICE for contacts not explicitly trusted, and the UI states what
+  enabling direct connections reveals — but if the user enables it, the IP is
+  exposed to the peer and to anyone observing.
+
+### 3.3 Compromised relay operator (third-party or ours)
+
+**Capability.** Full control of a relay: reads its storage, logs everything,
+drops, delays, reorders, replays, and lies about deletion. May be a relay the
+user chose, or ours.
+
+**Defended.**
+
+- Reads only opaque ciphertext against opaque queue addresses. No accounts, no
+  handles, no identity keys, no group state, no contact lists.
+- Cannot forge messages (MLS authentication) or modify them undetectably.
+- Cannot enumerate group membership by asking itself, because it has no notion of
+  a group — only independent unidirectional queues.
+- Cannot link a queue to a person: queue addresses are established inside the MLS
+  group, never through the server, and send/receive addresses for the same queue
+  are distinct and unlinkable at the relay.
+- Replay is rejected: MLS generation counters and the message DAG make a replayed
+  ciphertext a duplicate `msg_id` at worst.
+- Cannot single-handedly equivocate on the KT log — a client requires *t*
+  witness cosignatures from its own configured set.
+
+**Not defended.**
+
+- **Traffic correlation between queues it hosts.** A relay that hosts both ends of
+  a conversation sees an append on one queue closely followed by a fetch on
+  another and can guess they are paired. Padding and jitter raise the cost; they
+  do not eliminate it. Using different relays for send and receive directions
+  helps and is supported, but is a user choice we cannot enforce.
+- **Delivery-receipt timing.** See §4.2 — this is the strongest practical attack
+  available to a relay operator.
+- **Denial of service and censorship.** Same as §3.1. Federation is the answer:
+  clients treat relays as replaceable, and a device may publish queue addresses
+  on *k* relays.
+- **Claimed deletion.** Same limit as §3.1: unverifiable from outside.
+- **Source IP.** The relay sees it unless the client uses Tor or a VPN.
+
+### 3.4 Compromised participant (a legitimate member turned adversary)
+
+**Capability.** A real member of the group with valid keys. Sees all plaintext
+addressed to the group by construction.
+
+**Defended.**
+
+- **Cannot read history from before they joined.** MLS forward secrecy: a member
+  added in epoch *n* cannot derive epoch *n−1* keys.
+- **Cannot read after removal.** A Remove commits a new epoch with fresh secrets.
+- **Cannot impersonate another member.** Every message is signed by the sender's
+  leaf key under a device credential chained to that member's identity key.
+- **Cannot bias a FROST/DKG result by adaptively complaining after seeing
+  shares.** This is the concrete attack behind
+  [ZcashFoundation/frost#577](https://github.com/ZcashFoundation/frost/issues/577);
+  the CertEq echo broadcast
+  ([`ARCHITECTURE.md` §11.3](./ARCHITECTURE.md#113-participant-list-agreement-needs-a-real-echo-broadcast))
+  is the defense. A participant that cannot obtain a complete certificate does
+  not output a key.
+- **Cannot deny having sent a ceremony message.** Ceremony payloads are signed
+  with `CeremonySigningKey` and bound to `session_hash`. Non-repudiation is the
+  intended property here.
+- **Cannot change retention silently.** A policy change is authenticated and
+  attributable inside MLS.
+
+**Not defended.**
+
+- **Leaking plaintext they legitimately received.** Screenshots, copy-paste,
+  forwarding, a modified client that ignores the TTL. No E2EE system defends
+  against an authorized reader; ephemeral mode is explicitly best-effort
+  ([`ARCHITECTURE.md` §8.4](./ARCHITECTURE.md#84-ephemeral-mode-is-best-effort-and-the-ui-must-say-so)),
+  and the UI must not imply otherwise.
+- **Refusing to participate.** A ceremony participant can stall a DKG
+  indefinitely. Availability is not a property we provide against a member who
+  will not play; the failure is safe (no key is output) rather than silent.
+- **Adding their own device to their own account** and thereby retaining a copy
+  outside the conversation's retention policy.
+- **A member unilaterally committing a retention change.** MLS permits it; we
+  make it visible and attributable, not impossible
+  ([`ARCHITECTURE.md` §8.2](./ARCHITECTURE.md#82-changing-it--negotiated-and-what-agreed-actually-means)).
+
+### 3.5 Compromised device
+
+**Capability.** Malware or a forensic tool with the user's privileges on the
+user's machine, or physical access to an unlocked device.
+
+**Defended.**
+
+- **Past traffic is partially protected.** MLS forward secrecy means epoch
+  secrets already deleted cannot be recovered — subject to the retention setting,
+  since retained local plaintext is right there on disk.
+- **Future traffic heals, eventually.** Post-compromise security: once the
+  compromised member issues an Update and the adversary is passive thereafter, the
+  group's secrets recover.
+- **Local storage is encrypted at rest** under a key wrapped by `BackupWrapKey`
+  and the OS keystore where available.
+- **The FROST per-session encryption key is destroyed after part 2**
+  ([`ARCHITECTURE.md` §11.2](./ARCHITECTURE.md#112-mandatory-destruction-of-the-per-session-encryption-key)),
+  enforced in the state machine and asserted by test — so a device compromised
+  after the ceremony does not yield the shares that were sent to it.
+- **Device revocation exists**: a signed `DeviceRevocation` in the KT log plus an
+  MLS `Remove` in every group.
+
+**Not defended.**
+
+- **Anything at all, while the compromise is active.** The adversary reads
+  plaintext as the user reads it, exfiltrates keys, and sends as the user. This is
+  total and unavoidable; no messenger defends against it, and we should never
+  imply we do.
+- **The seed.** If the mnemonic is on the compromised device, the adversary gains
+  `ISK`, `CSK` and the ability to enroll new devices — i.e. a permanent wiretap
+  that survives revocation of the compromised device, until the user rotates
+  identity. Identity rotation is a KT event and is loud, but the window is real.
+- **Retained history**, in `RETAINED` mode, in full.
+- **Zeroization in the browser.** In WASM we cannot guarantee that key material
+  is erased from memory: the JS engine's GC may have copied the buffer and we do
+  not control the heap. This is one reason ceremonies are ZUULI-first.
+
+### 3.6 A coerced server serving targeted JavaScript to web clients
+
+**This is the most important entry in this document.**
+
+**Capability.** A legal order, an insider, or an attacker with deployment access
+causes the free2z server to serve modified JavaScript/WASM **to one targeted
+user** while serving honest code to everyone else. The modified bundle
+exfiltrates keys or plaintext.
+
+**Defense: there is none.**
+
+Not "weak," not "mitigated" — **none**. This is a fundamental property of
+browser-delivered E2EE, not a bug in our code. The user fetches the program that
+performs the encryption from the same party the encryption is meant to protect
+against, on every page load, and has no way to know what they received. Subresource
+integrity, CSP and code review do not help, because the attacker controls the
+document that declares them. It leaves no trace on the client.
+
+**What we actually do about it:**
+
+1. **ZUULI is the trust anchor** ([ADR 0001](./decisions/0001-platform-priority.md)).
+   A signed native binary with a Rust crypto core is fetched once, from a signed
+   update channel, and can be verified out of band. Strong claims are made there.
+2. **The web UI must state its weaker guarantee in the interface**, not merely in
+   documentation. A user making a decision about a sensitive conversation in a
+   browser must be told, in the product, that the browser client's guarantee
+   depends on the server being honest at page-load time.
+3. **High-value operations are ZUULI-only.** FROST/DKG ceremonies, which create
+   spending authority over real funds, are not offered in the browser.
+4. **Web code transparency is a research track, never a release blocker.**
+   See [WAIT](https://arxiv.org/pdf/2104.06136) and
+   [Trustworthy JavaScript for the Open Web](https://hacks.mozilla.org/2026/05/trustworthy-javascript-for-the-open-web/).
+   Binary-equivalent transparency for web bundles would reduce this to
+   "detectable after the fact," which is a real improvement and still not a fix.
+
+Any marketing copy that describes the web client's guarantee as equivalent to
+ZUULI's is false. This is a hard constraint on the product, not a documentation
+preference.
+
+### 3.7 Global passive adversary — explicitly out of scope
+
+**Capability.** Observes traffic at enough vantage points to correlate senders
+and recipients by timing and volume across the whole network.
+
+**Defense: none, and this is a stated non-goal.**
+
+Padding and receipt jitter raise the cost of correlation but do not defeat an
+adversary with global vantage. Defeating one requires mixnet-grade cover traffic
+and latency budgets that are incompatible with an interactive messenger. We are
+not building Tor. We say so here rather than implying otherwise by silence.
+
+### 3.8 Future quantum adversary
+
+**Capability.** Records ciphertext today; obtains a cryptographically relevant
+quantum computer later ("harvest now, decrypt later"). Or, in the further future,
+possesses one at the time of attack.
+
+**Defended.**
+
+- **Confidentiality against harvest-now-decrypt-later.** The MLS ciphersuite is
+  hybrid X25519 + ML-KEM-768 (X-Wing) **from day one**, not retrofitted. Recorded
+  ciphertext is not decryptable by a future quantum adversary unless *both*
+  components fall.
+
+**Not defended.**
+
+- **Authentication.** Every signature in the system — MLS leaf signatures, device
+  credentials, ceremony payloads, KT log roots and witness cosignatures — is
+  Ed25519. An adversary with a quantum computer *at the time of the attack* could
+  forge them and impersonate any party. Migrating signatures (e.g. to ML-DSA) is
+  unscheduled future work
+  ([`ARCHITECTURE.md` §13-C](./ARCHITECTURE.md#13-open-questions)). This is an
+  accepted, stated limitation, not an oversight.
+
+### 3.9 Malicious directory witness
+
+**Capability.** Operates one of the relays whose cosignature clients rely on for
+KT anti-equivocation; may refuse to sign, sign a false root, or collude with the
+directory operator.
+
+**Defended.** A client requires *t* cosignatures from **its own configured**
+witness set, so a single malicious witness cannot validate a forged root. A
+witness that signs a root conflicting with another root it signed produces
+non-repudiable evidence against itself.
+
+**Not defended.** Collusion of the directory operator with *t* witnesses defeats
+the scheme entirely. The property is only as strong as the independence of the
+witness set, and independence is a social fact we cannot verify
+cryptographically. Clients should default to a witness set that is not all
+free2z-operated, and the UI should make the configured set inspectable.
+
+### 3.10 Lost or stolen device (no active malware)
+
+**Defended.** Local storage is encrypted at rest; ephemeral conversations have
+already discarded plaintext past their TTL; the device can be revoked via the KT
+log and Removed from every group, after which it decrypts nothing new.
+
+**Not defended.** Anything the device holds at seizure time in `RETAINED` mode,
+if the attacker also has the unlock credential. Revocation is not retroactive.
+
+## 4. Known limits, stated up front
+
+These are not open questions. They are decided trade-offs we accept, and each
+must appear in user-facing documentation, not only here.
+
+### 4.1 Directory lookup reveals interest in a handle
+
+Resolving `@alice` to an identity key tells the directory operator that someone
+is interested in `@alice` at that moment. This is an **unavoidable consequence of
+free2z being a public creator platform** where handles are the discovery
+mechanism — you cannot look someone up by name without revealing that you looked.
+
+The limit is bounded: it applies at **connection time**, not to ongoing
+communication. Once the conversation exists, traffic flows over opaque pairwise
+queues and the directory is not consulted again
+([ADR 0004](./decisions/0004-metadata-ambition.md)). Privacy-preserving lookup
+proofs (SEEMless/Parakeet-style) prevent the *rest* of the directory leaking, and
+future work could add private information retrieval, but the fact of the lookup
+remains. We document this honestly rather than paper over it.
+
+### 4.2 Delivery-receipt timing is a published deanonymization vector
+
+Sealed sender is not a defense against traffic analysis of receipt patterns.
+Researchers have recovered **sealed-sender group membership from receipt timing
+alone** ([No safety in numbers](https://arxiv.org/pdf/2305.09799);
+see also [Improving Signal's Sealed Sender](https://www.cs.umd.edu/~kaptchuk/publications/ndss21.pdf)).
+
+Our position: receipts are batched and jittered by default, disableable per
+conversation, with read receipts separate and off by default. **This raises the
+cost of the attack; it does not eliminate it.** A relay that hosts both ends and
+observes receipt cadence over time retains a real statistical advantage. Users
+with a strong anonymity requirement should disable delivery receipts and accept
+the resulting loss of certainty about delivery — which, under delete-on-ack,
+costs more than it would in a retaining messenger.
+
+### 4.3 Ephemeral mode is best-effort
+
+A recipient can screenshot, photograph the screen, or run a modified client that
+ignores the TTL. Ephemeral mode defends against casual persistence and against
+device seizure after the TTL has elapsed. It does not defend against a determined
+counterparty, and **any UI copy implying that it does is a defect.**
+
+### 4.4 Tail truncation is not detectable by hash links
+
+Hash-linked parents detect gaps in the *middle* of a message DAG with certainty.
+They do not detect suppression of the *most recent* messages, because there is no
+later message to dangle a reference. Heartbeats narrow the window; a total
+partition remains indistinguishable from the peer being offline.
+
+### 4.5 Server-side deletion is auditable, not verifiable
+
+No client can prove a remote process deleted anything. Open source, reproducible
+builds and self-hosting make the claim auditable; only running your own relay
+makes it verifiable.
+
+### 4.6 No deniability for conversational messages
+
+MLS signs application messages with the sender's leaf key, so a recipient who
+retains the ciphertext, the epoch secrets and the sender's credential holds
+attributable evidence. **We do not claim deniability.** Key-context separation
+([`ARCHITECTURE.md` §5.6](./ARCHITECTURE.md#56-deniability--stated-not-claimed))
+gives clean semantics and blast-radius containment, not deniability.
+
+### 4.7 Push notifications are an unresolved metadata leak
+
+Mobile push (APNs/FCM) is the standard way to avoid holding a persistent
+connection per client, which is our dominant cost driver. It also gives Apple and
+Google notification timing, and the push token is a stable identifier. **We do
+not yet have a position**
+([`ARCHITECTURE.md` §13-H](./ARCHITECTURE.md#13-open-questions)). Until we do,
+this is an unquantified leak and must not be described as solved.
+
+### 4.8 Nostr fallback means accepting retention
+
+Nostr relays retain by default and NIP-40 expiration is advisory. Choosing the
+Nostr fallback transport trades the delete-on-ack property for reach and
+censorship resistance. It is per conversation, opt-in, and the UI must state that
+ciphertext may be retained indefinitely by third parties.
+
+## 5. Summary: what we claim, precisely
+
+| Property | ZUULI (native) | Web (WASM) |
+|---|---|---|
+| Server cannot read content | **Yes**, unconditionally | **Only if the served bundle is honest** (§3.6) |
+| Server cannot forge messages | **Yes** | Same caveat |
+| Server cannot MITM the identity | **Yes** — KT + self-audit + witnesses | Same caveat |
+| Server cannot MITM WebRTC | **Yes** — in-band fingerprints | Same caveat |
+| Forward secrecy | **Yes** — MLS epochs | Yes, same caveat |
+| Post-compromise security | **Yes** — MLS Updates | Yes, same caveat |
+| PQ confidentiality (harvest-now) | **Yes** — X-Wing hybrid | Yes, same caveat |
+| PQ authentication | **No** (§3.8) | No |
+| Relay learns no social graph | **Yes**, modulo timing (§3.3, §4.2) | Same |
+| Server retains nothing after ack | **Auditable, not verifiable** (§4.5) | Same |
+| Ephemeral messages truly disappear | **No** — best-effort (§4.3) | No |
+| Deniability | **No** (§4.6) | No |
+| Anonymity vs. global passive adversary | **No** (§3.7) | No |
+| Defense against endpoint compromise | **No** (§3.5) | No |
+| Defense against targeted malicious code delivery | **Yes** — signed binary, verifiable out of band | **No** (§3.6) |
+
+The last row is the whole reason ZUULI is the trust anchor.

--- a/docs/e2ee/decisions/0001-platform-priority.md
+++ b/docs/e2ee/decisions/0001-platform-priority.md
@@ -1,0 +1,59 @@
+# ADR 0001 — Platform priority: ZUULI-first, web is an explicitly lesser client
+
+**Status:** Accepted (owner, 2026-08-08) · **Refs:** [#305](https://github.com/free2z/zuu/issues/305) §3.5, §7.1
+
+## Context
+
+A web app's E2EE is only as good as the JavaScript the server just sent you. A
+compromised or coerced free2z server can serve modified code to **one targeted
+user**, exfiltrate their keys, and leave no trace on the client. This is a
+well-documented, fundamental limitation of browser-delivered E2EE — the user
+fetches the program that performs the encryption from the party the encryption is
+meant to protect against, on every page load. Subresource integrity and CSP do
+not help, because the attacker controls the document that declares them.
+
+ZUULI is a signed native binary with a Rust crypto core: fetched once, from a
+signed update channel, verifiable out of band.
+
+## Decision
+
+**Full guarantees live in ZUULI.** The web client speaks the same protocol, but
+its trust model is weaker and this is stated **in the interface**, not merely in
+documentation.
+
+The crypto core is **Rust, built once**: used natively by ZUULI and compiled to
+WASM for the web client. There is no second implementation.
+
+## Consequences
+
+- One codebase for all cryptography eliminates the implementation-divergence
+  class of bug outright. This also settles the MLS library choice toward a Rust
+  engine (OpenMLS) over a TypeScript one (ts-mls).
+- The web UI **must** carry a visible statement of its weaker guarantee. Marketing
+  or UI copy describing the web client's guarantee as equivalent to ZUULI's is
+  false and is a defect.
+- High-value operations that create spending authority — FROST/DKG ceremonies —
+  are **ZUULI-only**. They are not offered in the browser.
+- WASM cannot guarantee memory zeroization (the JS engine's GC may copy buffers;
+  we do not control the heap), which independently disqualifies the browser for
+  ceremony key handling.
+- Web code transparency is a **research track, never a release blocker**. See
+  [WAIT](https://arxiv.org/pdf/2104.06136) and
+  [Trustworthy JavaScript for the Open Web](https://hacks.mozilla.org/2026/05/trustworthy-javascript-for-the-open-web/).
+  At best it converts the attack from undetectable to detectable-after-the-fact,
+  which is a real improvement and still not a fix.
+
+## Alternatives rejected
+
+- **Web-first parity.** Rejected: it would require either claiming a guarantee we
+  cannot deliver, or holding ZUULI back to the browser's trust model. Both are
+  worse than being honest about the difference.
+- **Ship only ZUULI.** Rejected: free2z is a web platform and the reach matters.
+  A weaker-but-stated guarantee reaching many people is worth more than a
+  stronger guarantee reaching none, provided the statement is truthful and
+  prominent.
+- **Block release on web code transparency.** Rejected: the technology is not
+  deployable today and making it a blocker means shipping nothing.
+- **Two independent implementations (Rust + TypeScript).** Rejected: divergence
+  between two crypto implementations is a reliable source of exploitable bugs,
+  and it doubles the audit surface.

--- a/docs/e2ee/decisions/0002-multi-device.md
+++ b/docs/e2ee/decisions/0002-multi-device.md
@@ -1,0 +1,61 @@
+# ADR 0002 — Multi-device: design for it, ship single-device
+
+**Status:** Accepted (owner, 2026-08-08) · **Refs:** [#305](https://github.com/free2z/zuu/issues/305) §3.1, §7.2
+
+## Context
+
+Delete-on-acknowledged-delivery and multi-device pull directly against each
+other. If the relay destroys ciphertext when device 1 acknowledges it, device 2
+never receives it. Every serious messenger resolves this by fanning out to
+**per-device queues**, so "delivered" means "delivered to every registered device
+of the recipient."
+
+Retrofitting that later is expensive: it changes the definition of delivered, the
+queue model, and the key hierarchy simultaneously — the three things that are
+hardest to change once a federation is running.
+
+## Decision
+
+**The protocol, queue model and key hierarchy assume per-device fan-out from day
+one. The first release exposes a single device in the UI.**
+
+## Consequences
+
+- **"Delivered" is defined once, correctly, from the start.** Four separate
+  states — `accepted`, `queue-delivered`, `device-delivered`, `delivered` — where
+  `delivered` means a receipt from *every* device in the recipient's device set as
+  of the epoch the message was sent. See
+  [`../ARCHITECTURE.md` §6.3](../ARCHITECTURE.md#63-what-delivered-means).
+- **The relay implements only `queue-delivered`**, per-queue and unconditionally:
+  ACK arrives → delete. It holds no cross-queue state, because cross-queue state
+  would mean knowing the device set, which would mean knowing the recipient.
+- **Identity keys and device keys are separate levels of the hierarchy from the
+  first commit.** Identity keys are seed-derived and restorable; device keys are
+  generated on-device, never leave it, and are *not* seed-derivable. A
+  `DeviceCredential` signed by the identity key binds the two and is carried as
+  the MLS `Credential`, so every peer validates the binding during ordinary MLS
+  processing.
+- **A device MUST NOT acknowledge to the relay before its durable local write
+  completes.** ACK-on-read plus a crash equals permanent message loss, because the
+  relay has already deleted the only copy. This is the single most safety-critical
+  rule in the delivery layer.
+- Fan-out multiplies relay storage and egress by the device count. At our sizing
+  this is negligible; the assumption is baked into the cost model.
+- **Device registration and revocation are designed now and shipped later — and
+  when they ship they are security-critical.** A rogue device added to an account
+  is a wiretap. Every registration must be surfaced to every other device of the
+  account and published to the key-transparency log, so it cannot happen silently.
+- History transfer to a *newly added* device is an unresolved question
+  ([`../ARCHITECTURE.md` §13-D](../ARCHITECTURE.md#13-open-questions)): MLS forward
+  secrecy means a new device cannot decrypt past epochs by design.
+
+## Alternatives rejected
+
+- **Ship multi-device in v1.** Rejected: device registration is a wiretap-shaped
+  feature and deserves its own design and review cycle, not a rushed one.
+- **Accept single-device permanently.** Rejected: users have more than one device,
+  and retrofitting fan-out into a live federation is far harder than designing
+  for it.
+- **Server-side "delivered to all devices" tracking.** Rejected: it would require
+  the relay to know the device set, i.e. to know the recipient, which destroys the
+  metadata property that the whole queue design exists to provide.

--- a/docs/e2ee/decisions/0003-history-retention.md
+++ b/docs/e2ee/decisions/0003-history-retention.md
@@ -1,0 +1,64 @@
+# ADR 0003 — History: per-conversation retention, negotiated inside the group
+
+**Status:** Accepted (owner, 2026-08-08) · **Refs:** [#305](https://github.com/free2z/zuu/issues/305) §7.3
+
+## Context
+
+"Delete on delivery" is a server property. Whether the *client* keeps a local,
+locally-encrypted copy is a separate and much more product-shaped question, and
+the three plausible answers (never keep, always keep, let users choose) make
+materially different products. Per-conversation choice is the most demanding of
+the three and therefore needs the most careful specification.
+
+## Decision
+
+**Users choose retention per conversation or room.** This governs **client-side**
+retention only — the server holds nothing after acknowledged delivery in every
+case, and that is not adjustable.
+
+Retention is a **negotiated, shared property of the conversation**, authenticated
+inside the MLS group, not a local preference.
+
+## Consequences
+
+- Retention lives in a `GroupContext` extension (RFC 9420 §12.4), so every member
+  validates it on every Commit and **the server cannot tamper with it, observe it,
+  or suppress a change to it undetectably.** It is listed in
+  `required_capabilities`, so a client that would silently ignore an ephemeral
+  setting cannot join at all.
+- **Changes apply forward only**, from the epoch in which the Commit lands.
+  Retroactive deletion is unenforceable (members may be offline, may have
+  exported, may have screenshotted) and retroactive retention is impossible (the
+  data is gone). A separate, explicitly labeled `PurgeRequest{before_epoch}` asks
+  members to delete older history; the UI must say "asked N, M confirmed," never
+  "deleted." See
+  [`../ARCHITECTURE.md` §8.3](../ARCHITECTURE.md#83-mid-conversation-changes-apply-forward-only).
+- **"Agreed" means "no silent change," not "no unilateral change."** A two-phase
+  propose/ack negotiation precedes the Commit, but MLS cannot *enforce* unanimity —
+  any member may commit a `GroupContextExtensions` proposal. What the protocol
+  guarantees is that such a change is authenticated, attributable and visible. The
+  UI must present an out-of-band change as a prominent, attributed security event.
+- **Ephemeral mode is best-effort and the UI must not overclaim.** A recipient can
+  screenshot, photograph the screen, or run a modified client. Copy implying
+  otherwise is a defect.
+- Ephemeral mode shortens the plaintext outbox window used to repair detected gaps
+  ([`../ARCHITECTURE.md` §7](../ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering)),
+  so some gaps become unrecoverable. That is surfaced explicitly rather than left
+  as a silent hole.
+- **FROST ceremony transcripts are exempt and always retained.** A DKG transcript
+  is evidence: it is what lets a participant later prove the ceremony ran
+  correctly and who said what. Messages carry `retention_class = CEREMONY`, clients
+  MUST NOT delete them under any retention setting, and the UI MUST state this
+  before the ceremony begins so consent is informed.
+
+## Alternatives rejected
+
+- **No client history at all.** Rejected: it produces a product most people will
+  not use, and it does not actually stop a determined counterparty from keeping a
+  copy.
+- **Always keep history.** Rejected: it forecloses the ephemeral use case, which
+  is one of the reasons people reach for a private messenger.
+- **Retention as a local per-user preference.** Rejected: a "disappearing"
+  conversation where the other side silently keeps everything is a
+  misrepresentation. Making it shared group state means the setting is at least
+  honest about what both sides are doing.

--- a/docs/e2ee/decisions/0004-metadata-ambition.md
+++ b/docs/e2ee/decisions/0004-metadata-ambition.md
@@ -1,0 +1,64 @@
+# ADR 0004 — Metadata: sealed sender over opaque pairwise queues
+
+**Status:** Accepted (owner, 2026-08-08) · **Refs:** [#305](https://github.com/free2z/zuu/issues/305) §3.6, §7.4
+
+## Context
+
+Encrypting content is the easy half. A system that hides message bodies but
+exposes who talks to whom, how often, and when has not delivered much to a user
+whose risk comes from association rather than content. The available ambition
+levels are: hide content only; additionally hide the sender (sealed sender);
+additionally hide the social graph (SimpleX-style, no user identifiers anywhere).
+Each step costs real performance and complexity.
+
+free2z is also a **public creator platform** where `@handle` is the discovery
+mechanism, which constrains what is achievable at connection time.
+
+## Decision
+
+**A key-transparency directory resolves `@handle` → identity key for discovery.
+After connection, traffic flows over pairwise, unidirectional, opaque queues, so
+ongoing communication does not expose the social graph.**
+
+## Consequences
+
+- The relay has **no accounts, no handles, no identity keys, no contact lists and
+  no group state.** It sees opaque queue addresses and opaque ciphertext. Each
+  queue has **two distinct addresses** — one authorizing append, one authorizing
+  read/ack/delete — that are unlinkable at the relay, so it cannot trivially pair
+  correspondents.
+- Queue addresses are established **inside the MLS group**, never via the server,
+  and rotate on a schedule using an MLS exporter, so a long-lived relationship
+  does not present a long-lived identifier.
+- **Accepted limit: the directory lookup reveals interest in a handle at
+  connection time.** This is an unavoidable consequence of handle-based discovery
+  on a public platform — you cannot look someone up by name without revealing that
+  you looked. The limit is bounded to *connection time*; the directory is not
+  consulted again for ongoing traffic. It is documented honestly in
+  [`../THREAT-MODEL.md` §4.1](../THREAT-MODEL.md#41-directory-lookup-reveals-interest-in-a-handle)
+  rather than papered over.
+- **Fixed-size padding buckets are mandatory**, enforced by the relay rejecting
+  non-conforming sizes — so a sloppy client cannot leak length and a malicious one
+  cannot use length as a covert channel to a colluding relay.
+- **Delivery-receipt policy is a deliberate decision, not an accident.** Receipt
+  timing is a *published* deanonymization vector against sealed sender — group
+  membership has been recovered from receipt patterns alone
+  ([No safety in numbers](https://arxiv.org/pdf/2305.09799)). Receipts are batched
+  and jittered by default, disableable per conversation; read receipts are
+  separate and default off. **This raises the cost of the attack; it does not
+  eliminate it**, and we say so.
+- Push notifications remain an **unresolved** metadata leak
+  ([`../ARCHITECTURE.md` §13-H](../ARCHITECTURE.md#13-open-questions)) and must not
+  be described as solved until we take a position.
+
+## Alternatives rejected
+
+- **Hide content only.** Rejected: insufficient for any credible claim of being
+  world-class, and the social graph is frequently the more sensitive asset.
+- **Full SimpleX-style no-identifiers-anywhere, including discovery.** Rejected as
+  incompatible with free2z's product: handle-based discovery is the point of a
+  creator platform. We take the SimpleX queue model for everything *after*
+  connection, which is where it matters most and costs least.
+- **Private information retrieval for directory lookups.** Not rejected — deferred.
+  It would genuinely close the §4.1 limit, and remains future work rather than a
+  v1 requirement.

--- a/docs/e2ee/decisions/0005-federation.md
+++ b/docs/e2ee/decisions/0005-federation.md
@@ -1,0 +1,69 @@
+# ADR 0005 — Federation: full multi-relay from day one
+
+**Status:** Accepted (owner, 2026-08-08) · **Refs:** [#305](https://github.com/free2z/zuu/issues/305) §7.5 and the economics comment
+
+## Context
+
+A single-operator relay is a single point of censorship, coercion and failure,
+and it makes every privacy claim conditional on one company's continued good
+behavior. Federation is also much cheaper to decide now than to retrofit — it
+touches addressing, trust configuration and the key-transparency design at once.
+
+The counter-argument is economic: decentralized networks re-centralize because
+running a node is expensive, so only well-funded operators persist. Roughly **95%
+of Nostr relays cannot cover their operating costs**, and the reason is
+instructive — they retain every event forever and serve a public firehose.
+
+## Decision
+
+**Full multi-relay.** free2z runs the first relay. The protocol and relay
+software are built for anyone to run one, and clients treat relays as
+**untrusted, replaceable infrastructure**.
+
+## Consequences
+
+- The relay is a **separate, small, efficient Rust service**, not a Django app.
+  Bandwidth is not the constraint; **concurrent WebSocket connections are**, and
+  the existing Django Channels stack is dramatically less efficient per connection
+  than a Rust service.
+- **Open source and trivially self-hostable from the first release**, not as a
+  later "community edition." This matters beyond ideology: server-side deletion is
+  auditable but not verifiable from outside
+  ([`../THREAT-MODEL.md` §4.5](../THREAT-MODEL.md#45-server-side-deletion-is-auditable-not-verifiable)),
+  so **anyone who needs a verifiable guarantee must be able to run their own
+  relay.**
+- **Our economics invert Nostr's.** Delete-on-ack means no archive; pairwise
+  opaque queues mean no firehose. Steady-state stored ciphertext is ~4 MB per
+  1,000 DAU. A community operator can sustainably run a relay on a ~$5/month VPS.
+  **The delete-on-ack requirement is not only a privacy property — it is the
+  economic precondition for the federation.**
+- **Cross-relay witness cosigning of key-transparency log roots provides
+  anti-equivocation**, which is why no blockchain is needed
+  ([ADR 0006](./0006-zcash-coupling.md)). The property strengthens as the
+  federation grows — but it is only as strong as the *independence* of the witness
+  set, which is a social fact we cannot verify cryptographically. Clients should
+  default to a witness set that is not all free2z-operated.
+- A device may publish queue addresses on *k* relays; senders send to all *k* and
+  clients deduplicate by `msg_id`. Egress multiplies by *k*; at *k*=3 this is still
+  trivially inside one commodity host's included bandwidth. The default *k* is an
+  open question.
+- **Nostr is a fallback transport, not the primary one.** Nostr relays retain by
+  default and NIP-40 expiration is advisory, so they cannot deliver delete-on-ack.
+  Opt-in per conversation, with the retention trade-off stated in the UI.
+- If encrypted attachments ship, **zero-egress object storage (R2 or equivalent)
+  is the design, not an optimization** — 1M DAU at 2 MB/day is ~60 TB/month, about
+  $5,400 on S3-style egress and $0 on R2. Infrastructure is anyway a rounding
+  error next to **engineering time and third-party security audit**, which
+  dominate the budget. Plan around the audit.
+
+## Alternatives rejected
+
+- **free2z as the only relay.** Rejected: single point of censorship and coercion,
+  and it makes every privacy claim conditional on us.
+- **Adopt Nostr's relay network as the primary transport.** Rejected: retain-by-
+  default is architecturally incompatible with requirement 2 (destroy ciphertext
+  on delivery), and we cannot verify deletion on infrastructure we do not run.
+- **Relay inside the Django monolith.** Rejected on connection efficiency, which
+  is the actual cost driver.
+- **Relay as a later community edition.** Rejected: self-hosting is what converts
+  "trust us" into "verify it yourself," so it cannot be deferred.

--- a/docs/e2ee/decisions/0006-zcash-coupling.md
+++ b/docs/e2ee/decisions/0006-zcash-coupling.md
@@ -1,0 +1,71 @@
+# ADR 0006 — Zcash coupling: client-side cryptography only, no chain in the critical path
+
+**Status:** Accepted (owner, 2026-08-08) · **Refs:** [#305](https://github.com/free2z/zuu/issues/305) §5, §7.6
+
+## Context
+
+ZUULI ships a Zcash wallet, which offers four things no other messenger has:
+seed-derived identity, an immutable public broadcast medium for key-transparency
+checkpoints, an authenticated remote out-of-band verification channel (shielded
+memos), and anonymous paid anti-abuse. The question is how much belongs in the
+critical path, given that a chain dependency brings availability coupling and
+exposure to ZEC price volatility.
+
+## Decision
+
+**Client-side cryptography only.**
+
+- **In:** messaging identity derived from the wallet seed via **hardened,
+  ZIP-32-style derivation on a dedicated messaging-only branch**. Pure client-side
+  key derivation; no chain involved.
+- **In (optional, later):** prepaid quota credentials purchased with shielded ZEC
+  and redeemed via blind-issued/KVAC tokens — anti-spam without identity.
+- **Out of the critical path:** on-chain anchoring of key-transparency
+  checkpoints.
+
+**Hard constraint: never reuse Sapling/Orchard spending or viewing keys as
+messaging keys.** Different curves (Jubjub/Pallas vs. X25519/Ed25519) and, more
+fundamentally, key separation is non-negotiable. Derive a distinct messaging seed
+from the master seed, then generate messaging keys from that.
+
+## Consequences
+
+- Restoring the wallet mnemonic restores the messaging identity. There is no
+  separate identity backup to lose.
+- The messaging tree is rooted at its own BLAKE2b personalization and uses only
+  hardened derivation with no extended public key at any level, so it **cannot
+  collide with the Sapling or Orchard key trees even at identical indices**, and
+  the seed is not recoverable from any messaging key. See
+  [`../ARCHITECTURE.md` §4.2](../ARCHITECTURE.md#42-derivation-proposed).
+- Cross-protocol key reuse is exactly what an auditor will (correctly) fail us on,
+  so the domain-separation table is part of the specification, not an
+  implementation detail.
+- **No chain dependency means no availability coupling and no ZEC price exposure
+  in the messaging path.** Cross-relay witness cosigning
+  ([ADR 0005](./0005-federation.md)) provides the same anti-equivocation property
+  for free, and it is the Certificate Transparency model rather than a novel one.
+  For the record: at [ZIP 317](https://zips.z.cash/zip-0317)'s 10,000-zatoshi
+  minimum shielded fee and ZEC ≈ $517 (Aug 2026), a checkpoint costs ~$0.052 —
+  cheap, but cheap was never the argument.
+- **Shielded-memo verification is retained as a genuinely unusual capability.**
+  Two users who already know each other's payment address have an authenticated,
+  private, *remote* out-of-band channel for confirming identity keys — safety
+  numbers without an in-person QR scan. ZUULI-only; a complement to key
+  transparency, not a replacement.
+- Anchoring may exist later as an **opt-in highest-assurance tier**, never a
+  requirement. The KVAC/blind-credential design for paid quota is unspecified
+  ([`../ARCHITECTURE.md` §13-I](../ARCHITECTURE.md#13-open-questions)).
+
+## Alternatives rejected
+
+- **Reuse Sapling/Orchard keys as messaging keys.** Rejected outright: wrong
+  curves, and a bedrock violation of key separation.
+- **On-chain KT checkpoints in the critical path.** Rejected: buys nothing that
+  witness cosigning does not, and adds a hard external dependency plus price
+  exposure.
+- **No Zcash coupling at all.** Rejected: seed-derived identity is a cheap
+  usability win with no downside once domain separation is done correctly, and the
+  shielded-memo verification channel is a genuine differentiator.
+- **Requiring payment for messaging.** Rejected: marginal cost per user for text
+  is ~$0.002–0.02/month, so pricing should be set by spam resistance and relay
+  sustainability, not cost recovery.


### PR DESCRIPTION
Phase 0 deliverable for #305: the committed design documentation for free2z's
end-to-end encrypted messaging system.

**This is documentation only. No application code, no protocol implementation,
no changes outside `docs/e2ee/`.** Nine new markdown files, 1,873 insertions,
zero deletions.

## What's here

| File | Contents |
|---|---|
| `docs/e2ee/ARCHITECTURE.md` | The design document. |
| `docs/e2ee/THREAT-MODEL.md` | Adversaries, defenses, and the honest gaps. |
| `docs/e2ee/decisions/0001`–`0006` | One ADR per owner decision. |
| `docs/e2ee/README.md` | Index. |

### `ARCHITECTURE.md`

Goals and non-goals; the five-layer stack (client integrity → identity + key
transparency → MLS session crypto → delivery → opportunistic P2P); the key
hierarchy and derivation with an explicit domain-separation table; delivery
service semantics; hash-linked causal ordering; the retention model; the
metadata model and its limits; federation and the relay trust model; the
FROST/DKG application design; a disposition table for #131/#132/#133/#134; and
thirteen open questions left explicitly open rather than invented.

Points worth reviewer attention:

- **Key hierarchy.** Identity keys are seed-derived (restorable from the
  mnemonic) via a hardened ZIP-32-style tree rooted at its own BLAKE2b
  personalization, so it cannot collide with the Sapling or Orchard trees.
  Device keys are generated on-device, never leave it, and are **not**
  seed-derivable, so seed compromise does not retroactively yield every device's
  MLS state. A signed `DeviceCredential` binds the two and rides as the MLS
  `Credential`, so every peer validates the binding during ordinary MLS
  processing.
- **"Delivered" is four states, not one** — `accepted`, `queue-delivered`,
  `device-delivered`, `delivered` (D2's "every registered device"). The relay
  implements only `queue-delivered`, per-queue and unconditionally, because
  cross-queue state would mean knowing the device set. A device MUST NOT ACK
  before its durable local write completes; ACK-on-read plus a crash is
  permanent message loss under delete-on-ack.
- **Retention change semantics are specified**: forward-only from the epoch the
  Commit lands, with a separate, explicitly-labeled `PurgeRequest` that is a
  request and not a guarantee. And the honest version of "negotiated": MLS
  cannot enforce unanimity, so what we deliver is **"no silent change," not "no
  unilateral change."**
- **Hash links detect gaps, not tail truncation.** Stated, with the reason.

### `THREAT-MODEL.md`

Ten adversaries — malicious/compromised free2z server, network observer,
compromised relay operator, compromised participant, compromised device, coerced
server serving targeted JavaScript, global passive adversary, future quantum
adversary, malicious directory witness, lost/stolen device — each with its
defense or a plain statement that there is none.

The targeted-JavaScript entry says **"Defense: there is none"** and explains why
it is unfixable at the protocol layer, which is the entire justification for D1.

Eight known limits are stated up front rather than buried: directory lookup
reveals interest in a handle at connection time; delivery-receipt timing is a
published deanonymization vector against sealed sender; ephemeral mode is
best-effort; tail truncation is undetectable; server-side deletion is auditable
but not verifiable; **no deniability** (MLS signs application messages, so we do
not claim it); push notifications are an unresolved leak; Nostr fallback means
accepting retention.

Also stated: hybrid PQ (X-Wing) gives confidentiality against harvest-now-
decrypt-later, **but authentication remains Ed25519 and is not post-quantum.**

## The six decisions designed to

| ADR | Decision |
|---|---|
| 0001 Platform | ZUULI-first; the web client speaks the same protocol via WASM from the same Rust core, with an explicitly weaker trust model stated in the UI. |
| 0002 Multi-device | Design the protocol, queue model and key hierarchy for per-device fan-out from day one; ship single-device in the UI. |
| 0003 History | Per-conversation retention, negotiated and authenticated inside the MLS group; FROST transcripts exempt and always retained. |
| 0004 Metadata | Key-transparency directory for `@handle` discovery, then sealed sender over opaque pairwise unidirectional queues. |
| 0005 Federation | Full multi-relay; the relay is a separate small Rust service, open source and self-hostable from the first release. |
| 0006 Zcash | Client-side cryptography only; seed-derived messaging identity; no blockchain in the critical path; never reuse Sapling/Orchard keys. |

Each ADR states context, decision, consequences, and alternatives rejected.

## Prior art honored

- **#131** — hash-linked messages give transport-independent causal ordering and
  gap detection; wall-clock timestamps are advisory and never order anything.
  #131's suggestion of server-assigned sequence numbers is **consciously
  declined** with the reason stated (it hands the server reordering and
  censorship power).
- **#132** — reliable broadcast plus confidential per-recipient delivery plus an
  agreed participant list, with the honest caveat that we provide eventual
  delivery with retry, **not** Byzantine reliable broadcast: safety holds against
  an adversarial relay, liveness does not.
- **#133** — key transparency for identity, and DTLS fingerprints authenticated
  inside the MLS group, which makes the server-MITM impossible rather than merely
  detectable.
- **#134** — the signed, session-hash-bound payload structure retained
  essentially verbatim, including the follow-up comment's `participant_id` and
  message `type` fields; the mandatory deletion of the per-session encryption key
  after part 2 made enforceable and testable rather than conventional; and the
  participant-list agreement step upgraded to a real echo broadcast per
  BlockstreamResearch/bip-frost-dkg `CertEq` and ZcashFoundation/frost#577.

## Verified against the tree

- `ts/react/free2z/src/lib/p2pe2e/` is 642 lines across four files; grepping for
  `encrypt|crypto|subtle|fingerprint|sodium|nacl` returns nothing. No
  application-layer cryptography exists.
- `py/dj/apps/efm/consumers.py` is a 210-line Django Channels
  `SignalingConsumer` that relays `offer`/`answer`/`ice_candidate` verbatim.

So #133's MITM is real today, and there is no wire format to preserve.

Refs #305

https://claude.ai/code/session_016hGD65qzFQS9CgtEd8Pyej
