### PR TITLE
fix(zuuli): render article images instead of raw markdown (react-markdown `img: undefined` override)

### DIFF
--- a/wallet/zuuli/src/components/common/Markdown.test.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.test.tsx
@@ -1,0 +1,57 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { Markdown, type MarkdownVariant } from "./Markdown";
+
+/**
+ * `MarkdownLink` calls `useNavigate()`, so every render needs a router in
+ * context (the comment variant routes images through it).
+ */
+function render(source: string, variant: MarkdownVariant): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Markdown variant={variant}>{source}</Markdown>
+    </MemoryRouter>,
+  );
+}
+
+const IMAGE = "![alt text](https://example.com/y.png)";
+
+/**
+ * The ErrorBoundary fallback is the raw source in a `whitespace-pre-wrap` div.
+ * (Under `renderToStaticMarkup` an error boundary does not catch at all — the
+ * throw propagates and fails the test outright — so this asserts the fallback
+ * is absent in the client-render case too, without weakening the check.)
+ */
+function expectNoErrorFallback(markup: string) {
+  expect(markup).not.toContain("whitespace-pre-wrap");
+  expect(markup).not.toContain("![alt text]");
+}
+
+describe("Markdown images", () => {
+  it("renders a real <img> for the trusted article variant", () => {
+    // Regression: the `components` map used to carry `img: undefined` for the
+    // article variant. react-markdown resolves overrides by KEY PRESENCE, so
+    // the element type became `undefined`, React threw "Element type is
+    // invalid", the ErrorBoundary caught it, and every article containing an
+    // image rendered as raw markdown source. See issue #319.
+    const markup = render(IMAGE, "article");
+
+    expect(markup).toContain("<img");
+    expect(markup).toContain('src="https://example.com/y.png"');
+    expect(markup).toContain('alt="alt text"');
+    expectNoErrorFallback(markup);
+  });
+
+  it("degrades an image to a plain link for the untrusted comment variant", () => {
+    // Privacy: an untrusted comment must never auto-load a remote image, which
+    // would beacon the reader's IP to an attacker-chosen host on render.
+    const markup = render(IMAGE, "comment");
+
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain('href="https://example.com/y.png"');
+    expect(markup).toContain('rel="noopener noreferrer"');
+    expect(markup).toContain("alt text");
+    expectNoErrorFallback(markup);
+  });
+});

--- a/wallet/zuuli/src/components/common/Markdown.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.tsx
@@ -307,6 +307,24 @@ function SafeEmbed({ url, variant }: { url: string; variant: MarkdownVariant }) 
   return <MarkdownLink href={url}>{url}</MarkdownLink>;
 }
 
+/**
+ * `img` renderer for the UNTRUSTED "comment" variant: a remote image is
+ * degraded to a plain external link so it never auto-loads and beacons the
+ * reader's IP to an attacker-chosen host on render. Deliberate privacy
+ * behavior — see `MarkdownVariant`; do not "fix" it into a real <img>.
+ *
+ * Hoisted to module scope (like `MarkdownLink` / `CodeBlock`) so it is a stable
+ * component identity instead of a fresh function on every render.
+ */
+function CommentImageLink({ src, alt }: { src?: string | Blob; alt?: string }) {
+  const href = typeof src === "string" ? src : "#";
+  return (
+    <MarkdownLink href={href}>
+      {alt || (typeof src === "string" ? src : "image")}
+    </MarkdownLink>
+  );
+}
+
 // ── Math DoS guard (defense-in-depth) ───────────────────────────────────────
 // A comment body of `$$` + `{`×400 + … + `}`×400 + `$$` makes rehype-mathjax
 // recurse until it throws `RangeError: Maximum call stack size exceeded`
@@ -417,13 +435,21 @@ export function Markdown({
           pre: CodeBlock,
           // Untrusted comments: remote images become plain external links so
           // they never auto-load and beacon the reader's IP to an attacker.
-          img: isComment
-            ? ({ src, alt }) => (
-                <MarkdownLink href={typeof src === "string" ? src : "#"}>
-                  {alt || (typeof src === "string" ? src : "image")}
-                </MarkdownLink>
-              )
-            : undefined,
+          //
+          // SPREAD the key in — NEVER write `img: isComment ? X : undefined`.
+          // react-markdown@9 resolves overrides through
+          // hast-util-to-jsx-runtime, which tests for KEY PRESENCE, not value:
+          //
+          //   return own.call(state.components, name)
+          //     ? state.components[name] : name
+          //
+          // So a present-but-`undefined` `img` key makes the element type
+          // literally `undefined` instead of falling back to the intrinsic
+          // `<img>` tag; React throws "Element type is invalid", the
+          // ErrorBoundary below catches it, and EVERY article containing an
+          // image renders as raw markdown source (issue #319). The same
+          // footgun applies to any future conditional entry in this map.
+          ...(isComment ? { img: CommentImageLink } : {}),
           table: ({ node, ...props }) => (
             <div className="overflow-x-auto">
               <table {...props} />


### PR DESCRIPTION
Fixes #319

## The bug

Every ZUULI article whose body contains an image rendered as **raw markdown
source** instead of the article.

`wallet/zuuli/src/components/common/Markdown.tsx` passed this to
`<ReactMarkdown>`:

```tsx
img: isComment ? ({ src, alt }) => (…) : undefined,
```

For `variant="article"` that puts the key `img` on the `components` object with
the value `undefined`. react-markdown@9 resolves component overrides through
`hast-util-to-jsx-runtime`, which tests for **key presence**, not value
(`hast-util-to-jsx-runtime/lib/index.js:711`):

```js
return own.call(state.components, name) ? state.components[name] : name
```

`own.call(components, 'img')` is `true`, so the element type resolved to
`undefined` rather than falling back to the intrinsic `'img'` tag. React threw
`Element type is invalid … got: undefined`, the per-body `ErrorBoundary` caught
it, and the reader degraded to the plain-source fallback.

Real-world repro: <https://free2z.cash/palmar/7th-meetup-zcash-club-queretaro>
(body opens with `![](/uploadz/public/palmar/elg03269-1.webp)`).

## The fix

Only put the key on the object when it has a real value:

```tsx
...(isComment ? { img: CommentImageLink } : {}),
```

The comment-variant renderer is hoisted to a named top-level
`CommentImageLink` (consistent with `MarkdownLink` / `CodeBlock` in the same
file) so it's a stable component identity instead of a fresh arrow on every
render.

A rationale comment at the call site spells out **why the key must be absent
rather than `undefined`** — this is a non-obvious footgun that would otherwise
be reintroduced by the next conditional entry in this map.

**Privacy behavior is unchanged.** The `comment` variant still degrades
untrusted remote images to plain external links so they never auto-load and
beacon the reader's IP — that was a deliberate security fix and the new test
locks it in.

I grepped the ZUULI codebase for other `components={{ … }}` / `<ReactMarkdown`
maps: `Markdown.tsx` is the only one, and after this change it contains no
remaining `cond ? X : undefined` entries.

## Regression test

New `wallet/zuuli/src/components/common/Markdown.test.tsx`, following the
existing vitest + `renderToStaticMarkup` convention already used by
`ArticleScore.test.tsx` (no jsdom/testing-library in this repo):

- `variant="article"` on `![alt text](https://example.com/y.png)` renders a real
  `<img>` with the right `src`/`alt`, and the ErrorBoundary fallback is **not**
  shown.
- `variant="comment"` on the same source renders **no** `<img>` — just an
  external link with `rel="noopener noreferrer"`.

Verified the test genuinely catches the bug: on the pre-fix code the article
case fails with `Element type is invalid … got: undefined`; both pass after.

## Verification (run in `wallet/zuuli`)

| command | result |
| --- | --- |
| `npm install` | ok, `package-lock.json` unchanged |
| `npm run typecheck` | pass, no output |
| `npm test` | **9 files / 103 tests passed** (was 8 / 101) |
| `npm run build` | pass, `✓ built in 14.51s` |

These are exactly the frontend steps the required `gate` check runs
(`.github/workflows/zuuli.yml:112-118`).

## Out of scope (still open)

The follow-up noted at the bottom of #319 is **not** addressed here: article
bodies use origin-relative upload paths (`/uploadz/public/…`), which resolve
against the app/Tauri origin rather than `free2z.cash`, so such images will 404
on desktop even now that the crash is gone. That deserves its own issue and an
article-variant `img` renderer that resolves relative `src` against the free2z
API base. Externally-hosted images in articles work with this PR alone.
