### PR TITLE
fix(zuuli): resolve article image URLs against the media host

### DIFF
--- a/wallet/zuuli/src/components/common/Markdown.test.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.test.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { Markdown, type MarkdownVariant } from "./Markdown";
 
 /**
@@ -53,5 +53,117 @@ describe("Markdown images", () => {
     expect(markup).toContain('rel="noopener noreferrer"');
     expect(markup).toContain("alt text");
     expectNoErrorFallback(markup);
+  });
+
+  it("leaves a relative src alone when the media base is same-origin (dev proxy)", () => {
+    // `MEDIA_BASE` is "" in dev / `tauri dev`, where the Vite proxy already
+    // forwards `/uploadz` from the app's own origin. Absolutizing must be a
+    // no-op there, not a mangled "undefined/uploadz/..." or a doubled slash.
+    const markup = render(
+      "![](/uploadz/public/palmar/elg03269-1.webp)",
+      "article",
+    );
+
+    expect(markup).toContain('src="/uploadz/public/palmar/elg03269-1.webp"');
+  });
+});
+
+/**
+ * free2z stores article bodies with ORIGIN-RELATIVE upload paths, e.g.
+ * `![](/uploadz/public/palmar/elg03269-1.webp)`. Those only resolve when the
+ * document itself is served from free2z. A production `tauri build` has no Vite
+ * proxy and runs on the `tauri://localhost` origin, so the path would resolve
+ * against the app's own bundled `dist/` and 404. The article `img` renderer
+ * absolutizes it via `mediaUrl()`.
+ *
+ * `MEDIA_BASE` is captured at module-eval time (and is "" under vitest, which
+ * runs with `import.meta.env.DEV`), so these cases need a re-imported module
+ * graph with `@/lib/env` mocked to a remote host. `vi.stubEnv` does NOT work
+ * here — it never reaches `import.meta.env` in this setup.
+ */
+describe("Markdown article images against a remote media host", () => {
+  const MEDIA = "https://media.example";
+  let renderArticle: (source: string) => string;
+
+  beforeAll(async () => {
+    vi.doMock("@/lib/env", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>("@/lib/env");
+      return { ...actual, MEDIA_BASE: MEDIA };
+    });
+    vi.resetModules();
+    const mod = await import("./Markdown");
+    renderArticle = (source) =>
+      renderToStaticMarkup(
+        <MemoryRouter>
+          <mod.Markdown variant="article">{source}</mod.Markdown>
+        </MemoryRouter>,
+      );
+  });
+
+  afterAll(() => {
+    vi.doUnmock("@/lib/env");
+    vi.resetModules();
+  });
+
+  it("absolutizes a relative /uploadz src against the media host", () => {
+    const markup = renderArticle("![](/uploadz/public/palmar/elg03269-1.webp)");
+
+    expect(markup).toContain(
+      `src="${MEDIA}/uploadz/public/palmar/elg03269-1.webp"`,
+    );
+    // Exactly one slash between host and path — no `https://media.example//…`.
+    expect(markup).not.toContain(`${MEDIA}//uploadz`);
+  });
+
+  it("absolutizes a path with no leading slash", () => {
+    const markup = renderArticle("![](uploadz/public/x.webp)");
+
+    expect(markup).toContain(`src="${MEDIA}/uploadz/public/x.webp"`);
+  });
+
+  it("leaves an already-absolute https src untouched", () => {
+    const markup = renderArticle("![alt text](https://example.com/y.png)");
+
+    expect(markup).toContain('src="https://example.com/y.png"');
+    expect(markup).not.toContain(MEDIA);
+  });
+
+  it("leaves a protocol-relative src untouched", () => {
+    // `//cdn.example/z.png` is already absolute w.r.t. the scheme; prefixing it
+    // would produce `https://media.example//cdn.example/z.png`.
+    const markup = renderArticle("![](//cdn.example/z.png)");
+
+    expect(markup).toContain('src="//cdn.example/z.png"');
+    expect(markup).not.toContain(MEDIA);
+  });
+
+  it("does not corrupt a data: URI into a media-host path", () => {
+    // react-markdown's `defaultUrlTransform` blocks non-http(s) protocols, so a
+    // `data:` image arrives here already emptied. Whatever it becomes, it must
+    // never turn into `https://media.example/data:image/...` — and an empty
+    // `src=""` (which browsers resolve to the current document URL) must not
+    // survive either.
+    const markup = renderArticle("![dot](data:image/png;base64,iVBORw0KGgo=)");
+
+    expect(markup).toContain("<img");
+    expect(markup).not.toContain(`${MEDIA}/data:`);
+    expect(markup).not.toContain(`${MEDIA}/image/png`);
+    expect(markup).not.toContain('src=""');
+  });
+
+  it("still degrades a relative comment image to a plain link", () => {
+    // Privacy guard: absolutizing article images must NOT make untrusted
+    // comment images auto-load. A relative comment src stays a link.
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <Markdown variant="comment">
+          {"![shot](/uploadz/public/tracker.webp)"}
+        </Markdown>
+      </MemoryRouter>,
+    );
+
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain('href="/uploadz/public/tracker.webp"');
+    expect(markup).toContain("shot");
   });
 });

--- a/wallet/zuuli/src/components/common/Markdown.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.tsx
@@ -3,6 +3,7 @@ import {
   useState,
   isValidElement,
   type AnchorHTMLAttributes,
+  type ImgHTMLAttributes,
   type ReactNode,
 } from "react";
 import ReactMarkdown from "react-markdown";
@@ -19,6 +20,7 @@ import rehypePrism from "rehype-prism-plus";
 import rehypeSlug from "rehype-slug";
 
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { mediaUrl } from "@/lib/api/http";
 import { isTauri } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 
@@ -325,6 +327,33 @@ function CommentImageLink({ src, alt }: { src?: string | Blob; alt?: string }) {
   );
 }
 
+/**
+ * `img` renderer for the trusted "article" variant: a real, auto-loading
+ * `<img>` whose `src` is resolved against the media host.
+ *
+ * free2z authors embed uploads as ORIGIN-RELATIVE paths — a real body reads
+ * `![](/uploadz/public/palmar/elg03269-1.webp)`. That only resolves by accident
+ * in `npm run dev` / `tauri dev`, where the Vite proxy forwards `/uploadz` to
+ * the backend from the same origin. A production `tauri build` has no proxy and
+ * the webview origin is `tauri://localhost`, so the same path resolves against
+ * the app's own bundled `dist/` (which contains only `index.html` + `assets/`)
+ * and 404s — every in-body image is broken. `mediaUrl()` absolutizes it against
+ * `MEDIA_BASE`, and leaves already-absolute `https:` / `data:` /
+ * protocol-relative sources untouched.
+ *
+ * `node` is destructured out because react-markdown passes the hast node to
+ * every override and it must not reach the DOM element.
+ */
+function ArticleImage({
+  node: _node,
+  src,
+  alt,
+  ...rest
+}: ImgHTMLAttributes<HTMLImageElement> & { node?: unknown }) {
+  const resolved = typeof src === "string" ? mediaUrl(src) : undefined;
+  return <img {...rest} src={resolved} alt={alt ?? ""} />;
+}
+
 // ── Math DoS guard (defense-in-depth) ───────────────────────────────────────
 // A comment body of `$$` + `{`×400 + … + `}`×400 + `$$` makes rehype-mathjax
 // recurse until it throws `RangeError: Maximum call stack size exceeded`
@@ -433,12 +462,18 @@ export function Markdown({
         components={{
           a: MarkdownLink,
           pre: CodeBlock,
-          // Untrusted comments: remote images become plain external links so
-          // they never auto-load and beacon the reader's IP to an attacker.
+          // Images. BOTH variants must map to a REAL component:
+          //   • article — <ArticleImage>: a real <img>, src absolutized against
+          //     the media host so origin-relative `/uploadz/…` bodies load in a
+          //     production build (where there is no Vite proxy).
+          //   • comment — <CommentImageLink>: degrades to a plain external link
+          //     so untrusted images never auto-load and beacon the reader's IP
+          //     to an attacker-chosen host.
           //
-          // SPREAD the key in — NEVER write `img: isComment ? X : undefined`.
-          // react-markdown@9 resolves overrides through
-          // hast-util-to-jsx-runtime, which tests for KEY PRESENCE, not value:
+          // NEVER write `img: cond ? X : undefined` (nor any other
+          // conditionally-`undefined` entry in this map). react-markdown@9
+          // resolves overrides through hast-util-to-jsx-runtime, which tests
+          // for KEY PRESENCE, not value:
           //
           //   return own.call(state.components, name)
           //     ? state.components[name] : name
@@ -447,9 +482,10 @@ export function Markdown({
           // literally `undefined` instead of falling back to the intrinsic
           // `<img>` tag; React throws "Element type is invalid", the
           // ErrorBoundary below catches it, and EVERY article containing an
-          // image renders as raw markdown source (issue #319). The same
-          // footgun applies to any future conditional entry in this map.
-          ...(isComment ? { img: CommentImageLink } : {}),
+          // image renders as raw markdown source (issue #319). If a variant
+          // ever needs the plain intrinsic tag, omit the key entirely via a
+          // spread — do not set it to `undefined`.
+          img: isComment ? CommentImageLink : ArticleImage,
           table: ({ node, ...props }) => (
             <div className="overflow-x-auto">
               <table {...props} />

--- a/wallet/zuuli/src/lib/api/http.ts
+++ b/wallet/zuuli/src/lib/api/http.ts
@@ -41,10 +41,30 @@ export function isAuthed(): boolean {
   return !!getToken();
 }
 
-/** Prefix a relative `/uploadz/...` media path with the media host. */
+/**
+ * Prefix a relative `/uploadz/...` media path with the media host.
+ *
+ * free2z serves uploads as ORIGIN-RELATIVE paths (`/uploadz/public/…`), which
+ * only resolve correctly when the page itself is served from free2z. ZUULI's
+ * production webview origin is `tauri://localhost` (`http://tauri.localhost` on
+ * Windows/Android), where a relative path resolves against the app's own
+ * bundled assets and 404s — so every such path must be absolutized here.
+ * (In dev `MEDIA_BASE` is "" on purpose: the Vite proxy forwards `/uploadz`,
+ * so the path is already same-origin and is returned unchanged.)
+ *
+ * Anything that is ALREADY absolute is returned untouched — markdown bodies can
+ * legitimately contain `https://` hotlinks, `data:` URIs and protocol-relative
+ * `//host/x.png` sources, and blindly prefixing those would corrupt them into
+ * `https://free2z.cash/data:image/...`.
+ */
 export function mediaUrl(path: string | null | undefined): string | undefined {
   if (!path) return undefined;
-  if (/^https?:\/\//.test(path)) return path;
+  // Protocol-relative (`//host/x.png`) — already absolute w.r.t. the scheme.
+  if (path.startsWith("//")) return path;
+  // Any `scheme:` prefix (https:, data:, blob:, …). A relative path can never
+  // match: `/` is not in the scheme character class, so `uploadz/a:b.png` and
+  // `/uploadz/x.webp` both fall through to the prefixing branch below.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(path)) return path;
   return `${MEDIA_BASE}${path.startsWith("/") ? "" : "/"}${path}`;
 }
 


### PR DESCRIPTION
Follow-up to #319 (the render crash itself was fixed by #320).

## Step 1 — the production failure is real, and here is the evidence

| Check | Result |
| --- | --- |
| Live API body | `curl -s https://free2z.cash/api/zpage/7th-meetup-zcash-club-queretaro/` returns `![](/uploadz/public/palmar/elg03269-1.webp)`, `![](/uploadz/public/palmar/elg03290-anon_VKUtaSZ.webp)`, `![palmar/zcash-address.jpg](/uploadz/public/palmar/zcash-address.jpg)` — all origin-relative. |
| Anything rewriting the body? | No. `mapArticle()` in `src/lib/api/free2z.ts` does `content: z.content ?? …` verbatim; `mediaUrl()` is applied only to `avatar_image` / `featured_image` (lines 151, 169, 171, 200, 371, 373, 993). `Reader.tsx:150` passes `article.content` straight to `<Markdown>`. |
| What does the renderer actually emit? | Probed with a throwaway vitest render: `<img src="/uploadz/public/palmar/elg03269-1.webp" alt=""/>` — the relative path is passed through untouched. |
| `<base>` tag? | None, in `index.html` or built `dist/index.html`. |
| Does `dist/` contain `/uploadz`? | No — `npm run build` produces exactly `dist/index.html` + `dist/assets/`. |
| Asset protocol / custom handler? | None. No `assetProtocol` config, no `convertFileSrc`, nothing in `src-tauri/capabilities/*.json`. |
| Production media base | `MEDIA_BASE` is baked as `https://free2z.cash` in the built bundle — the correct value exists, it was just never applied to the body. |

So in a production `tauri build` (tauri 2.11.5, `frontendDist: ../dist`, webview origin `tauri://localhost`, `http://tauri.localhost` on Windows/Android) `/uploadz/...` resolves against the app's own bundled assets, which do not contain it → 404. The CSP is not the problem (`img-src 'self' data: https:` would happily allow an absolute https URL).

It works in `npm run dev` / `tauri dev` only because `vite.config.ts` proxies `/uploadz` to `VITE_F2Z_PROXY` and `devUrl` is `http://127.0.0.1:1423`, making the path same-origin.

## Step 2 — the fix

**`Markdown.tsx`** — a real `ArticleImage` component for the article variant that runs `src` through `mediaUrl()`:

```tsx
img: isComment ? CommentImageLink : ArticleImage,
```

Both branches are **real components**. The `cond ? X : undefined` footgun from #319 is not reintroduced, and the warning comment is expanded to say so explicitly (including what to do instead: omit the key via a spread, never set it to `undefined`).

**Comment-variant privacy is untouched.** `CommentImageLink` still handles `variant="comment"`, so untrusted comment images still degrade to plain external links and never auto-load. There is a dedicated regression test for a *relative* comment src.

**`http.ts`** — `mediaUrl()` hardened for markdown-sourced input. It previously passed through only `/^https?:\/\//`, so:

- `data:image/png;base64,…` → `https://free2z.cash/data:image/png;…` (corrupted)
- `//cdn.example/z.png` → `https://free2z.cash//cdn.example/z.png` (corrupted)

It now returns anything with a `scheme:` prefix or a leading `//` untouched. Relative paths can never match the scheme regex (`/` is not in the scheme character class), so `/uploadz/x.webp` and `uploadz/x.webp` both still get prefixed. This is a strict improvement for the existing structured-field callers too.

Note: `MEDIA_BASE` is `""` in dev, so the change is a **no-op under the Vite proxy** and only takes effect in production builds.

## Step 3 — tests

`Markdown.test.tsx` extended with 7 cases:

- relative `/uploadz/x.webp` → absolutized against the media base (and no doubled slash)
- path with no leading slash → absolutized
- already-absolute `https://…` → untouched
- protocol-relative `//cdn.example/z.png` → untouched
- `data:` URI → never corrupted into a media-host path, and no `src=""` survives
- relative src with a same-origin media base (dev proxy) → left alone
- **comment variant + relative src → still a plain link, still no `<img>`** (privacy guard)

Follows the existing convention (vitest + `renderToStaticMarkup` in `MemoryRouter`); no jsdom/testing-library introduced.

`MEDIA_BASE` is captured at module-eval time and is `""` under vitest, so the absolutizing cases use `vi.doMock("@/lib/env")` + `vi.resetModules()` + a dynamic re-import. `vi.stubEnv` was tried first and **does not work** — it never reaches `import.meta.env` in this setup; that's documented in the test file so nobody re-tries it.

**Mutation check:** temporarily replacing `mediaUrl(src)` with `src` in `ArticleImage` fails 3 of the new tests. They genuinely bite.

## Verification (real output)

```
$ npm run typecheck    # tsc --noEmit — clean, no output
$ npm test             # Test Files 9 passed (9) / Tests 110 passed (110)
$ npm run build        # ✓ built in 1m 6s
$ npm run test:play-testers   # fail 0 / cancelled 0 / skipped 0
```

## Noted, deliberately out of scope

Relative **links** in article bodies have the same class of problem, but a different fix: `MarkdownLink` treats `/…` as internal and calls `navigate(href)`, so a body link like `/palmar/some-zpage` or `[pdf](/uploadz/foo.pdf)` routes into a nonexistent ZUULI SPA route rather than 404-ing on the media host. That needs a routing decision (open the free2z URL externally? map zpage paths onto `/articles/:slug`?), not a URL prefix, so it is not bundled here. The sample article's own links are all absolute `https://`, so it is not blocking.

Also worth knowing: react-markdown's `defaultUrlTransform` blocks non-`http(s)` protocols, so `data:` images never render in ZUULI at all (they arrive with `src` already emptied). Allowing them would be a separate, security-relevant decision; this PR only guarantees they are not *corrupted*.

Per scope: `release.json` and the release workflows are untouched.
