### PR TITLE
fix(zcash-plugin): compile app-data migration on 32-bit Android

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/src/app_data_migration.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/app_data_migration.rs
@@ -388,7 +388,19 @@ fn remove_empty_directory_unchanged(
     }
     // SAFETY: fstatat succeeded and initialized the struct.
     let stat = unsafe { stat.assume_init() };
-    if stat.st_mode & libc::S_IFMT != libc::S_IFDIR {
+    // Platform width skew — do NOT "simplify" this back to a bare
+    // `stat.st_mode & libc::S_IFMT != libc::S_IFDIR`. `st_mode` is `c_uint`
+    // (u32) on every Android ABI, but `mode_t` — the type of `S_IFMT`/`S_IFDIR`
+    // — is `u16` on the 32-bit Android ABIs (armv7/x86) and `u32` on 64-bit
+    // Android and Linux. Apple is self-consistent at u16. Mixing the two
+    // directly therefore fails to compile for armv7-linux-androideabi and
+    // i686-linux-android, and only for those targets. `u32::from` is the
+    // portable bridge: it widens u16 losslessly and is the identity conversion
+    // where the operand is already u32 (via core's reflexive
+    // `impl<T> From<T> for T`), so it can neither truncate nor sign-extend and
+    // the file-type test keeps its exact meaning on every target.
+    let file_type = u32::from(stat.st_mode) & u32::from(libc::S_IFMT);
+    if file_type != u32::from(libc::S_IFDIR) {
         return Err(RemoveEmptyDirectoryError::InvalidState(
             "canonical app-data directory changed filesystem type during migration".to_owned(),
         ));
@@ -1165,6 +1177,47 @@ mod tests {
         assert!(fixture.source.exists());
         assert!(fixture.destination.is_dir());
         assert!(fixture.root.join(JOURNAL_FILENAME).is_file());
+    }
+
+    // Pins the `S_IFDIR` file-type guard in `remove_empty_directory_unchanged`.
+    // The empty canonical shell validated during preflight is swapped for a
+    // symlink to a real directory before the removal; `fstatat` is anchored with
+    // AT_SYMLINK_NOFOLLOW, so the mode must read as `S_IFLNK` and fail closed.
+    // A truncating or sign-extending fix to the `st_mode`/`mode_t` width skew
+    // would misclassify this as a directory and unlink the attacker's link.
+    #[cfg(unix)]
+    #[test]
+    fn empty_destination_replaced_by_symlink_fails_closed_on_file_type() {
+        let fixture = Fixture::new("filetype-race");
+        fixture.write_wallet_payload();
+        fs::create_dir(&fixture.destination).expect("create canonical state");
+        let destination = fixture.destination.clone();
+        let decoy = fixture.root.join("decoy-canonical");
+        fs::create_dir(&decoy).expect("create decoy directory");
+        let mut swap_destination_for_symlink = move |step| {
+            if step == MigrationStep::JournalPrepared {
+                fs::remove_dir(&destination).expect("remove preflight destination");
+                std::os::unix::fs::symlink(&decoy, &destination).expect("install symlink");
+            }
+            Ok(())
+        };
+
+        let error = fixture
+            .migrate(&mut swap_destination_for_symlink)
+            .expect_err("reject file-type replacement");
+
+        let MigrationError::InvalidState(reason) = error else {
+            panic!("expected InvalidState, got {error:?}");
+        };
+        assert!(
+            reason.contains("changed filesystem type"),
+            "expected the file-type guard to fire, got {reason}"
+        );
+        assert_eq!(
+            fs::read(fixture.source.join("wallets.json")).expect("read legacy source"),
+            b"manifest"
+        );
+        assert!(fixture.root.join("decoy-canonical").is_dir());
     }
 
     #[test]


### PR DESCRIPTION
## The bug

Android release builds fail to compile. This blocks the ZUULI store release —
build 7's `Android / Play internal` job died on it (run 31270095364).

`wallet/plugins/tauri-plugin-zcash/src/app_data_migration.rs` compared the
`fstatat` file type inline:

```rust
if stat.st_mode & libc::S_IFMT != libc::S_IFDIR {
```

For `armv7-linux-androideabi` and `i686-linux-android` that does not type-check:

```
error[E0277]: no implementation for `u32 & u16`
error[E0308]: mismatched types: expected `u32`, found `u16`
error[E0277]: can't compare `u32` with `u16`
error: could not compile `tauri-plugin-zcash` (lib) due to 4 previous errors
```

## Why only 32-bit Android

`libc` declares `st_mode` as `c_uint` (u32) for **every** Android ABI
(`src/unix/linux_like/android/b32/mod.rs`, `.../b64/{aarch64,x86_64}/mod.rs`),
but `S_IFMT`/`S_IFDIR` are typed `mode_t`, and `mode_t` differs per ABI:

| target | `st_mode` | `mode_t` (`S_IFMT`/`S_IFDIR`) | compiles before this PR |
| --- | --- | --- | --- |
| `armv7-linux-androideabi` | `u32` | **`u16`** (`android/b32/mod.rs:6`) | no |
| `i686-linux-android` | `u32` | **`u16`** (`android/b32/mod.rs:6`) | no |
| `aarch64-linux-android` | `u32` | `u32` (`android/b64/mod.rs:6`) | yes |
| `x86_64-linux-android` | `u32` | `u32` (`android/b64/mod.rs:6`) | yes |
| Linux (glibc) | `u32` | `u32` (`linux/mod.rs:13`) | yes |
| macOS / iOS | `u16` | `u16` (`bsd/apple/mod.rs:17`) | yes |

Android is also the one platform where this code is *dead* — `prepare()`
returns `MobileSandboxScoped` before reaching it — but dead code is still
type-checked, so the build fails anyway.

## The fix

Widen both operands through `u32::from` into a named local:

```rust
let file_type = u32::from(stat.st_mode) & u32::from(libc::S_IFMT);
if file_type != u32::from(libc::S_IFDIR) {
```

No `#[cfg(target_os = "android")]` special-casing — one portable expression for
every target. `u32::from` rather than `as u32` deliberately: this is
security-sensitive code that decides whether a path is a directory before
`unlinkat(AT_REMOVEDIR)`, and `From` is *proven* lossless by the type system.
It widens `u16` losslessly and is the identity conversion where the operand is
already `u32` (core's reflexive `impl<T> From<T> for T`), so it can neither
truncate nor sign-extend. An `as` cast would silently truncate if a type ever
got wider; `From` would refuse to compile. The comparison semantics are
byte-for-byte identical on every target.

A comment above the expression records the width skew so it is not "simplified"
back.

## Test

Added `empty_destination_replaced_by_symlink_fails_closed_on_file_type`
(unix-only). It swaps the preflighted empty canonical directory for a **symlink
to a real directory** at the `JournalPrepared` hook. Because `fstatat` is
anchored with `AT_SYMLINK_NOFOLLOW`, the mode must read `S_IFLNK` and the
migration must fail closed with "changed filesystem type during migration",
leaving the legacy payload untouched. A truncating or sign-extending fix to the
width skew would misclassify the link as a directory and unlink it — this test
catches that.

## Verification

Everything below was actually run on this branch (macOS host, NDK 26.1.10909125,
rustc 1.93.1). No claims by inspection.

| command | result |
| --- | --- |
| `cargo check --locked` (host, aarch64-apple-darwin) | ok, `Finished` in 11m17s |
| `cargo test --locked` (host) | **94 passed; 0 failed** |
| `cargo check --locked --target armv7-linux-androideabi` | **ok**, `Finished` in 6m23s |
| `cargo check --locked --target aarch64-linux-android` | **ok**, `Finished` in 3m10s |
| `cargo check --locked --target i686-linux-android` | **ok**, `Finished` in 3m21s |
| `cargo check --locked --target x86_64-linux-android` | **ok**, `Finished` in 1m53s |
| `cargo check --locked --target aarch64-apple-ios` | **ok** |

Each Android run logged `Compiling tauri-plugin-zcash` and
`` `tauri-plugin-zcash` (lib) generated 27 warnings `` (all pre-existing
`dead_code` on the Android cfg), i.e. the lib really was type-checked for that
target — not skipped.

**Negative control.** Reverting *only* the two changed lines and re-running the
armv7 check reproduces CI exactly, which proves the target check is real and
that this diff is what fixes it:

```
error[E0308]: mismatched types            --> src/app_data_migration.rs:402:36
error[E0277]: no implementation for `u32 & u16`  --> src/app_data_migration.rs:402:34
error[E0308]: mismatched types            --> src/app_data_migration.rs:403:21
error[E0277]: can't compare `u32` with `u16`     --> src/app_data_migration.rs:403:18
error: could not compile `tauri-plugin-zcash` (lib) due to 4 previous errors
```

Linux was not built locally; it is covered by the `gate` job on `ubuntu-latest`,
and `mode_t == st_mode == u32` there makes both conversions the identity.

## Other width-mismatch instances

Searched `wallet/` for `libc::S_*` and `st_*`. Line 391 was the **only**
occurrence of the pattern. The neighbouring `stat.st_dev as u64` /
`stat.st_ino as u64` (now lines 408–409) are left alone on purpose: they are
compared against a `DirectoryIdentity` built from `std`'s
`MetadataExt::{dev,ino}`, which performs the *same* `as u64` cast internally, so
the two sides stay bit-identical on every platform (including macOS, where
`dev_t` is `i32` and both sides sign-extend the same way). Changing one side
would break that agreement.

## Scope

Fix only. No `release.json` bump, no release-workflow edits, no unrelated
changes.

## Why CI never caught this (follow-up, not fixed here)

Two gaps, and they compound:

1. `gate` never compiles for **any** Android target — `Rust / shared plugin`
   (`zuuli.yml`) only builds for the CI host.
2. `zuuli-packaging.yml` *does* build Android on PRs, but **arm64 only**:

   ```yaml
   # .github/workflows/zuuli-packaging.yml:116
   targets: ${{ github.event_name == 'pull_request' && 'aarch64-linux-android'
     || 'aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android' }}
   # :153
   ./node_modules/.bin/tauri android build --ci --aab --target aarch64 -- --locked
   ```

   `aarch64-linux-android` is a 64-bit ABI where `mode_t == st_mode == u32`, so
   it is precisely the one Android ABI that **cannot** see this bug.
   `zuuli-release.yml:216` builds all four ABIs — so the first build that
   compiled `armv7`/`i686` was the protected release job.

**Therefore the green `Android / unsigned AAB` check on this PR is *not*
evidence for this fix** — it only builds arm64, which compiled fine before the
change too. The evidence is the local `armv7-linux-androideabi` and
`i686-linux-android` checks above, plus the negative control.

Filing the CI gap as its own issue; no workflow changes in this PR.
