### PR TITLE
release(zuuli): prepare store build 0.1.0+8 (DO NOT MERGE without owner go-ahead)

### DIFF
--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -1,8 +1,8 @@
 # Releasing ZUULI
 
 ZUULI ships from one reviewed commit under one immutable identity. The current
-identity is `0.1.0+7`: marketing version `0.1.0`, Apple build `7`, Android
-`versionCode` `7`, and package/bundle identifier `cash.free2z.zuuli`.
+identity is `0.1.0+8`: marketing version `0.1.0`, Apple build `8`, Android
+`versionCode` `8`, and package/bundle identifier `cash.free2z.zuuli`.
 
 `release.json` schema v2 is the source of truth. It must remain valid UTF-8 and
 byte-canonical pretty-printed JSON; the verifier uses fatal UTF-8 decoding and
@@ -227,7 +227,7 @@ must both be confirmed:
 
 ```bash
 export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
-export ZUULI_CONFIRM_UPLOAD=0.1.0+7
+export ZUULI_CONFIRM_UPLOAD=0.1.0+8
 scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
 ```
@@ -307,7 +307,12 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    `MISSING_EXPORT_COMPLIANCE`, then moved it to `IN_BETA_TESTING` after the
    build-specific `usesNonExemptEncryption=false` answer. Build `0.1.0+7`
    persists that answer in the canonical and packaged iOS plists and makes the
-   release contract, normalizer, and IPA inspection fail closed on drift.
+   release contract, normalizer, and IPA inspection fail closed on drift. Its
+   iOS upload succeeded, but its Android job failed before packaging an AAB
+   because the plugin's app-data migration did not compile for the 32-bit
+   armv7/i686 ABIs. Build `0.1.0+8` carries that Android compile fix along with
+   the article image-rendering and media-host URL corrections; post-merge
+   packaging on `main` is green for all four Android ABIs.
 4. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
    attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
    protected release** with the exact full SHA, identity, missing target, and

--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.zuuli",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 7,
+  "build": 8,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "7").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "8").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "7"
+        CFBundleVersion: "8"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -28,14 +28,14 @@
     "targets": "all",
     "icon": ["icons/icon.png"],
     "iOS": {
-      "bundleVersion": "7",
+      "bundleVersion": "8",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 7
+      "versionCode": 8
     }
   },
   "plugins": {


### PR DESCRIPTION
## ⚠️ Merging this PR ships `0.1.0+8` to both stores

A push to `main` that changes `wallet/zuuli/release.json` automatically triggers
the protected **ZUULI / protected release** workflow
(`.github/workflows/zuuli-release.yml`), which builds, signs, and **uploads to
TestFlight and Google Play internal**. Store build numbers are append-only and
uploads are irreversible.

**Do not merge until the owner decides to ship.** This PR is *prepared*, not
shipped — no auto-merge, no admin merge.

## What this changes

Store identity `0.1.0+7` → `0.1.0+8`. Marketing version stays `0.1.0`;
`applicationId` stays `cash.free2z.zuuli`. Produced with
`npm run release:bump -- --version=0.1.0 --build=8` (no native regeneration, no
`--ignore-version-mismatches`).

| File | Change |
| --- | --- |
| `wallet/zuuli/release.json` | `"build": 7` → `8` |
| `wallet/zuuli/src-tauri/tauri.conf.json` | `iOS.bundleVersion "7"` → `"8"`; `android.versionCode 7` → `8` |
| `wallet/zuuli/src-tauri/gen/apple/project.yml` | `CFBundleVersion: "7"` → `"8"` |
| `wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist` | `CFBundleVersion` `7` → `8` |
| `wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts` | `tauri.android.versionCode` fallback `"7"` → `"8"` |
| `wallet/zuuli/docs/releasing.md` | runbook identity, `ZUULI_CONFIRM_UPLOAD`, and the build-history record |

`release.json` stays byte-canonical pretty-printed UTF-8 JSON — the single value
edit only. `iosUsesNonExemptEncryption` remains `false` and both the source
(`src-tauri/Info.ios.plist`) and generated iOS plists keep their matching
`ITSAppUsesNonExemptEncryption` Boolean; neither was touched.

Marketing version is unchanged, so `package.json`, `package-lock.json`,
`Cargo.toml`, `Cargo.lock`, and the Tauri `version` field correctly needed no
edit.

## What the build contains

Everything merged since `0.1.0+7`:

- `3f7845c` — articles containing images no longer render as raw markdown (#319 / #320)
- `6f538a2` — article image URLs resolved against the media host so uploads load in a production build (#334)
- `43b15d9` — 32-bit Android (armv7/i686) compiles again (#335)

## Why this build matters for Android

Build 7's **iOS upload succeeded**, but its **Android job failed** on the 32-bit
compile error that `43b15d9` fixes, so build 7 never produced an AAB. Post-merge
packaging on `main` at `43b15d9` is fully green, including the Android AAB across
all four ABIs — this build is what unblocks Play delivery.

## Verification (real output, run locally from `wallet/zuuli`)

```
$ npm run release:verify
> zuuli@0.1.0 release:verify
> node scripts/release-identity.mjs

{"applicationId":"cash.free2z.zuuli","version":"0.1.0","build":8,"identity":"0.1.0+8","tag":"zuuli-v0.1.0+8"}

$ npm run typecheck
> zuuli@0.1.0 typecheck
> tsc --noEmit
(clean)

$ npm test
 Test Files  9 passed (9)
      Tests  110 passed (110)

$ node scripts/verify-ci-cache-policy.mjs
ZUULI CI cache policy verified: credential-free writers, restore-only releases, and exact closed-PR cleanup.
```
