### PR TITLE
ci(zuuallet): narrow the plugins path filter to tauri-plugin-zcash

### DIFF
--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -18,7 +18,7 @@ on:
   pull_request:
     paths:
       - 'wallet/zuuallet/**'
-      - 'wallet/plugins/**'
+      - 'wallet/plugins/tauri-plugin-zcash/**'
       - 'z/zcash/librustzcash'
       - '.gitmodules'
       - '.github/workflows/zuuallet.yml'
@@ -26,7 +26,7 @@ on:
     branches: [main]
     paths:
       - 'wallet/zuuallet/**'
-      - 'wallet/plugins/**'
+      - 'wallet/plugins/tauri-plugin-zcash/**'
       - 'z/zcash/librustzcash'
       - '.gitmodules'
       - '.github/workflows/zuuallet.yml'


### PR DESCRIPTION
## Why

`.github/workflows/zuuallet.yml` filtered on `wallet/plugins/**` in both its
`pull_request` and `push` triggers. That is correct *only by accident*: the
directory currently holds exactly one crate, `tauri-plugin-zcash`, and that is
the one zuuallet actually consumes.

The moment a second crate lands under `wallet/plugins/`, every PR touching it
would fire zuuallet's full Rust gate — a ~45-minute job spanning
`ubuntu-latest` plus the `custody-platforms` macOS/Windows matrix — for a crate
zuuallet never builds against. That is a standing tax that only gets noticed
later as "CI got slow," by which time the cause is non-obvious. Two lines now,
free forever.

## What I verified

- **Exactly two occurrences.** `wallet/plugins/**` appeared only at lines 21
  and 29, both `paths:` filters, both the same "zuuallet consumes this plugin"
  case. The workflow's other four `wallet/plugins` references were already
  specific to `tauri-plugin-zcash` (`--manifest-path`, rust-cache `workspaces`).
- **Zuuallet's real path dependencies.** `wallet/zuuallet/src-tauri/Cargo.toml`
  has exactly one path dep under `wallet/plugins/`:
  `tauri-plugin-zcash = { path = "../../plugins/tauri-plugin-zcash" }`.
  The plugin's own path deps all point into `z/zcash/librustzcash`, which the
  filter already covers via its `z/zcash/librustzcash` entry. So the narrowed
  glob is a complete cover of the actual dependency graph — no transitive input
  loses coverage.
- **`zuuli.yml` is untouched.** The required `gate` check derives from
  `zuuli.yml`'s `changes` job, which uses a separate shell `case` glob list
  (`wallet/zuuli/*|wallet/plugins/*|...`) evaluated against a local `git diff` —
  a different mechanism entirely from GitHub's `on.paths`. This change cannot
  affect it. (`zuuli-packaging.yml` likewise keeps its own `wallet/plugins/**`
  filter; both are ZUULI's to decide and out of scope here.)
- **YAML parses**, and the two filter lists round-trip as intended.

## Acceptance criteria

- [x] Both `paths:` occurrences narrowed to `wallet/plugins/tauri-plugin-zcash/**`.
- [x] A PR touching only `wallet/plugins/tauri-plugin-zcash/**` still matches the
      filter, so the zuuallet Rust job still triggers.
- [x] A PR touching an unrelated path under `wallet/plugins/` no longer matches.

Note: this PR itself changes only `.github/workflows/zuuallet.yml`, which is its
own filter entry — so zuuallet's jobs do run here, exercising the edited file.

Closes #339

https://claude.ai/code/session_016hGD65qzFQS9CgtEd8Pyej