### PR TITLE
docs(e2ee): correct unlinkability claim, supersede retention model, decouple witness

### DIFF
--- a/docs/e2ee/ARCHITECTURE.md
+++ b/docs/e2ee/ARCHITECTURE.md
@@ -64,8 +64,9 @@ preserve, so we are architecturally unconstrained.
    ([#132](https://github.com/free2z/zuu/issues/132),
    [#134](https://github.com/free2z/zuu/issues/134)) as the first one.
 8. **Hybrid post-quantum confidentiality from day one**, not retrofitted.
-9. **Federated by construction** — anyone can run a relay, and clients treat
-   relays as untrusted, replaceable infrastructure.
+9. **Federated by construction** — anyone can run a relay, and separately anyone
+   can run a witness (§9.3); clients treat both as untrusted, replaceable
+   infrastructure.
 
 ### 2.2 Non-goals
 
@@ -89,7 +90,7 @@ preserve, so we are architecturally unconstrained.
 | Layer | Choice | Standard |
 |---|---|---|
 | 0. Client integrity | ZUULI native (strong) / web WASM (stated-weaker) | [ADR 0001](./decisions/0001-platform-priority.md) |
-| 1. Identity + directory | Seed-derived identity; key-transparency log with cross-relay witness cosigning | CONIKS / SEEMless / Parakeet lineage |
+| 1. Identity + directory | Seed-derived identity; key-transparency log with independent witness cosigning (§9.3) | CONIKS / SEEMless / Parakeet lineage |
 | 2. Session crypto | **MLS**, hybrid PQ (X-Wing) from day one | [RFC 9420](https://datatracker.ietf.org/doc/html/rfc9420), [RFC 9750](https://datatracker.ietf.org/doc/rfc9750/), [draft-ietf-mls-extensions](https://www.ietf.org/archive/id/draft-ietf-mls-extensions-04.html) |
 | 3. Delivery | SMP-style opaque pairwise unidirectional queues, delete-on-ack, federated | [SimpleX SMP](https://simplex.chat/docs/simplex.html) design, clean-room implementation |
 | 3b. Fallback delivery | Nostr relays, optional, retention consciously accepted | [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) is advisory only |
@@ -134,8 +135,24 @@ tightly coupled to Nostr transport, which conflicts with delete-on-ack (§6.7).
 We should study MDK closely and reuse its lessons without adopting its transport
 coupling.
 
-> **Open question (§13-A):** OpenMLS's third-party audit status must be
-> established in writing before release. Do not treat "widely used" as audited.
+**Audit status — established, and it is why the version floor exists.** OpenMLS
+received an independent security assessment by SRLabs, sponsored by the Sovereign
+Tech Agency, published
+[2026-05-27](https://blog.openmls.tech/posts/2026-05-27-independent-audit/).
+Eight findings, one of them **High severity — "improper authentication of
+MACs."** The High finding and all but one of the rest are fixed in **0.8.1** (and
+0.7.3 on the previous line).
+
+**Floor: `openmls >= 0.8.1`.** Any earlier version contains a High-severity
+authentication defect and MUST NOT be shipped. One Low-severity finding was still
+open at publication; **review its status before release** rather than assuming the
+audit closed everything. Note also that the version floor interacts with the
+crypto provider: `openmls_rust_crypto` does not implement X-Wing, so the PQ
+ciphersuite (§5.2) requires the libcrux provider.
+
+This closes §13-A. It does not remove the case for our own review — an audit of
+the library is not an audit of how we use it — but it does mean "widely used" has
+been replaced by a published assessment with a named auditor and a fixed version.
 
 ## 4. Identity and the key hierarchy
 
@@ -394,10 +411,31 @@ creation. Every relay command is signed with the relevant queue key. The relay
 verifies the signature against the key registered for that address and learns
 nothing else — no account, no handle, no identity key.
 
-The two addresses are unlinkable to each other at the relay, so a relay
-observing traffic on a send address cannot trivially identify the corresponding
-receive address, and therefore cannot trivially pair correspondents. It can
-still attempt timing correlation; see [`THREAT-MODEL.md`](./THREAT-MODEL.md).
+**The two addresses are not unlinkable at the relay, and we do not claim they
+are.** An APPEND to `QueueSendAddr` has to be delivered into the message list
+read from `QueueRecvAddr`, so the relay necessarily holds that mapping — it is
+what makes delivery work. An operator who dumps the queue table pairs the two
+ends of every queue it hosts, directly and without any traffic analysis.
+SimpleX's SMP does not achieve this property either.
+
+What the split does buy is real, and it is capability separation rather than
+unlinkability:
+
+- **A sender cannot read, ACK or delete.** The append capability is strictly
+  weaker than the read capability and there is no way to escalate one into the
+  other. A sender learns nothing about what is queued or whether it was taken.
+- **A compromised sender-side key cannot drain the queue.** Whoever holds a
+  `QueueSendAddr` and its key — including someone who seizes the sending device
+  — can write, but cannot recover a single undelivered message.
+- **An observer of the relay's front door cannot pair addresses from traffic
+  alone.** The two addresses are unrelated on the wire, so an attacker who sees
+  connections and commands but not the relay's internal state is reduced to
+  timing correlation.
+
+Only the third of these survives against a relay operator with database access,
+and against that adversary it fails completely. See
+[`THREAT-MODEL.md` §3.3](./THREAT-MODEL.md#33-compromised-relay-operator-third-party-or-ours)
+and [§4.9](./THREAT-MODEL.md#49-the-relay-knows-which-queue-addresses-are-paired).
 
 Queue addresses are established **inside** the MLS group — a member advertises
 its `QueueSendAddr` set to peers in an authenticated application message, never
@@ -543,89 +581,120 @@ deliberate belt-and-braces, not redundancy.
 
 ## 8. Retention (D3)
 
-[ADR 0003](./decisions/0003-history-retention.md). This governs **client-side**
-retention only. In every mode, the server holds nothing after acknowledged
-delivery — that is goal 2 and it is not adjustable per conversation.
+[ADR 0007](./decisions/0007-retention-per-user.md), which supersedes
+[ADR 0003](./decisions/0003-history-retention.md). This section governs
+**client-side** retention only.
 
-### 8.1 Retention is group state, not a preference
+**The one retention property that is a security claim** is the server-side one,
+and it is unchanged: in every mode, the relay holds nothing after acknowledged
+delivery. That is goal 2, it is not adjustable per conversation, and it is
+remotely auditable rather than verifiable
+([`THREAT-MODEL.md` §4.5](./THREAT-MODEL.md#45-server-side-deletion-is-auditable-not-verifiable)).
+Everything else in §8 is local policy and courtesy signalling, and is labeled as
+such.
 
-Retention is carried as a `GroupContext` extension (RFC 9420 §12.4), so it is
-part of the authenticated group state that every member validates on every
-Commit. **The server cannot tamper with it, cannot observe it, and cannot
-suppress a change to it undetectably.**
+### 8.1 Retention is a per-user local choice
+
+**Each user decides how long their own device keeps its own copy.** One
+participant keeps five minutes; another keeps forever. Both are legitimate, and
+neither constrains the other. There is no shared retention state, no group-wide
+setting, and nothing in the protocol that makes one member's preference bind
+another member's disk.
+
+An earlier revision of this document specified the opposite: retention as a
+`GroupContext` retention extension (RFC 9420 §12.4), listed in
+`required_capabilities`, changed by a two-phase `RetentionChangeProposal` /
+`RetentionChangeAck` unanimity negotiation. **That design was withdrawn because
+it does not deliver the property it appears to deliver.** Once a recipient
+legitimately holds plaintext, nothing in the protocol constrains what their
+device does with it — a modified client advertises whatever capabilities it
+likes, joins the group, honors nothing, and retains everything. The machinery
+bought group-state complexity and a join-time exclusion rule in exchange for a
+guarantee that a recompiled binary defeats. It is client-trust theater and it is
+gone.
+
+### 8.2 The ephemeral hint is a courtesy signal, not a control
+
+A conversation may carry an **ephemeral hint**: a requested mode and TTL, sent as
+an MLS application message.
 
 ```
-retention_policy_extension = {
-  mode:        EPHEMERAL | RETAINED,
-  ttl_seconds: uint32,      // EPHEMERAL only; time-to-live after local receipt
-  set_in_epoch: uint64,
+ephemeral_hint = {
+  mode:        EPHEMERAL | RETAINED,   // requested, not imposed
+  ttl_seconds: uint32,                 // EPHEMERAL only; from local receipt
+  sent_in_epoch: uint64,
 }
 ```
 
-The extension is listed in `required_capabilities`, so a client that does not
-understand it cannot join the group at all. That is the correct failure mode: a
-client that would silently ignore an ephemeral setting must be excluded rather
-than tolerated.
+Because it travels inside MLS it is confidential, **authenticated and
+attributable**: nobody can forge "Azhr asked for this to be ephemeral," and every
+member sees who asked and in which epoch. That much is real cryptography.
 
-### 8.2 Changing it — negotiated, and what "agreed" actually means
+What it is not is enforcement. Conforming clients honor a hint by default and
+expire local plaintext at the requested TTL. **A non-conforming client simply
+ignores it, and no mechanism exists — or can exist — to detect that.** The hint
+is a courtesy feature in exactly the class of Signal's and WhatsApp's
+disappearing messages: it defends against casual persistence, against a message
+lingering on a screen, and against device seizure after the TTL, on devices whose
+owners are not adversaries. Those are worth having, and none of them is a defense
+against the counterparty.
 
-Changing retention is a two-phase application-layer negotiation followed by an
-MLS Commit:
+**Therefore the hint MUST NOT appear in any security claims table** — not here,
+and not in
+[`THREAT-MODEL.md` §5](./THREAT-MODEL.md#5-summary-what-we-claim-precisely).
+UI copy that implies a hint is enforced against a determined counterparty is a
+defect.
 
-1. A member sends `RetentionChangeProposal{new_policy}` as an application
-   message.
-2. Every other member's client responds `RetentionChangeAck{accept | reject}`.
-3. Only on unanimous accept does the proposer issue a Commit carrying a
-   `GroupContextExtensions` proposal with the new policy.
+**The knock-on, stated plainly.** Dropping the retention extension also drops
+`required_capabilities`, and with it the only join-time mechanism that excluded a
+client which would silently ignore an ephemeral setting. **Nothing replaces it.**
+Any client that speaks MLS and our application framing can join a conversation,
+and whether it honors hints is unobservable from outside. We accept this because
+the exclusion never worked — a client that lies about its capabilities passed the
+check anyway — but the change is a real reduction in what the group can assert
+about who is in it, and it should be read as one.
 
-**Honest limit.** MLS cannot *enforce* unanimity — any member may commit a
-`GroupContextExtensions` proposal unilaterally, and MLS will accept it. What the
-protocol guarantees is that such a change is **authenticated, attributable and
-visible**: every member sees exactly who changed the policy and in which epoch,
-and can leave. So the property we deliver is **"no silent change,"** not "no
-unilateral change." The UI must present an out-of-band policy change as a
-prominent, attributed security event, not a toast.
+### 8.3 Purge requests, and why nothing here is retroactive
 
-### 8.3 Mid-conversation changes apply forward only
+Clearly labeled a **request, not a guarantee**, a member may send
+`PurgeRequest{before_epoch}`. Conforming clients delete local history before that
+epoch and reply `PurgeAck`. The UI must say "asked N participants to delete; M
+confirmed," never "deleted."
 
-**A retention change takes effect from the epoch in which its Commit lands, and
-applies only to messages received in that epoch or later.** Messages already
-stored are governed by the policy that was in force when they were received.
+`PurgeRequest` survives the change to §8.1 **unchanged**, because it was always
+correctly labeled: it never claimed to compel anyone, so nothing about it was
+theater.
 
-Rationale, both directions:
+A purge is a request precisely because deletion cannot reach backwards, and the
+same asymmetry governs everything else in this section. A user changing their own
+local setting, and a hint arriving mid-conversation, both apply **forward only**:
 
-- **RETAINED → EPHEMERAL cannot be retroactive**, because retroactive deletion
-  is unenforceable. A member may have been offline, may have exported, may have
-  screenshotted. Claiming retroactive deletion would be claiming a property we
-  cannot deliver.
-- **EPHEMERAL → RETAINED cannot be retroactive**, because the data is already
+- **Retaining → ephemeral cannot be retroactive**, because retroactive deletion
+  is unenforceable across other people's devices. A member may have been offline,
+  may have exported, may have screenshotted.
+- **Ephemeral → retaining cannot be retroactive**, because the data is already
   gone. There is nothing to retain.
 
-Separately, and clearly labeled as a **request, not a guarantee**, a member may
-send `PurgeRequest{before_epoch}`. Conforming clients delete local history
-before that epoch and reply `PurgeAck`. The UI must say "asked N participants to
-delete; M confirmed," never "deleted."
+### 8.4 Short local retention and gap repair
 
-### 8.4 Ephemeral mode is best-effort, and the UI must say so
-
-A recipient can always screenshot, photograph the screen, or run a modified
-client. Ephemeral mode defends against *casual* persistence and device seizure
-after the TTL. It does not defend against a determined counterparty, and any UI
-copy implying otherwise is a defect.
-
-Ephemeral mode also shortens the plaintext outbox window used for gap repair
-(§7), which means some gaps become unrecoverable. That is surfaced to the user
+A short local TTL shortens the plaintext outbox window used for gap repair (§7),
+which means some detected gaps become unrecoverable. That is surfaced to the user
 as an explicit "this message could not be recovered" marker rather than a silent
-hole.
+hole. Because retention is now per user, this trade-off is made by the person who
+chose the short TTL and lands on their own conversation view.
 
-### 8.5 Ceremony transcripts are exempt
+### 8.5 Ceremony transcripts are retained by default
 
-Messages with `retention_class = CEREMONY` are **always retained**, regardless of
-the conversation's retention policy. A DKG transcript is evidence: it is what
-lets a participant later prove the ceremony ran correctly and who said what.
-Clients MUST NOT delete them under any retention setting, and the UI MUST state
-this before the ceremony begins, so consent is informed. Transcripts are stored
-under the `free2z/history/v1` local wrap key like everything else.
+Messages with `retention_class = CEREMONY` are **retained by default**, and the
+reason is not protocol compulsion — it is that the participant wants the
+evidence. A DKG transcript is what lets them later prove the ceremony ran
+correctly and who said what. Discarding it is discarding your own proof.
+
+Under the per-user model this needs no exemption machinery: a default plus a
+clear explanation before the ceremony begins, so consent is informed. A
+participant who deletes their own transcript anyway has only reduced what they
+themselves can later demonstrate. Transcripts are stored under the
+`free2z/history/v1` local wrap key like everything else.
 
 ## 9. Identity directory, key transparency, and federation
 
@@ -663,18 +732,43 @@ The residual attack on any KT log is **equivocation**: showing different
 directories to different users. The fix is Certificate Transparency's, not a
 chain's:
 
-- **Cross-relay witness cosigning.** Each relay in the federation observes and
-  signs the KT log root for each epoch. A client accepts a root only if it
-  carries at least *t* cosignatures from its own configured witness set. Two
-  conflicting signed roots for the same epoch are **non-repudiable
-  cryptographic evidence of misbehavior**, publishable by anyone.
+- **Witness cosigning.** A witness observes the KT log root for each epoch and
+  signs what it saw. A client accepts a root only if it carries at least *t*
+  cosignatures from its own configured witness set. Two conflicting signed roots
+  for the same epoch are **non-repudiable cryptographic evidence of
+  misbehavior**, publishable by anyone.
 - **Client gossip.** Clients cross-check roots with each other over the
   messaging channel itself — CONIKS's original design, and free because we
   already have an authenticated channel.
 
-The property strengthens as the federation grows, so the multi-relay design we
-want for censorship resistance ([ADR 0005](./decisions/0005-federation.md))
-delivers anti-equivocation as a side effect.
+**Witness and relay are separate roles.** An operator MAY run both, and we
+expect some will, but the protocol does not couple them and neither should the
+volunteer ask. A witness:
+
+- needs **no inbound port** — it polls the log over outbound HTTPS,
+- needs **no TLS certificate, no domain and no public IP**, for the same reason,
+- needs **no database** — its entire state is the last root it signed, a few
+  hundred bytes in a file,
+- needs no ciphertext, no queue storage, no uptime commitment beyond "checks in
+  often enough," and holds nothing whose loss or seizure harms a user.
+
+A relay, by contrast, is a public network service with storage, an inbound
+listener, TLS termination and a durability obligation. Requiring a witness to
+also be a relay would multiply the cost, the operational risk and the legal
+exposure of volunteering, for no gain in the property being bought — and the
+number of independent witnesses is precisely what makes that property real.
+
+The property strengthens as the *witness set* grows, independently of the number
+of relays, which is why recruiting witnesses is a cheaper path to
+anti-equivocation than recruiting relay operators. The multi-relay design we
+want for censorship resistance ([ADR 0005](./decisions/0005-federation.md)) is
+complementary: both become genuinely meaningful at the same moment, when the
+operators are independent of us.
+
+> **Stated plainly:** witnesses we operate are not independent witnesses. Until
+> there are at least two run by parties outside free2z, *t* is effectively 0 and
+> client gossip is the only anti-equivocation that exists. The UI must say so
+> rather than display a reassuring witness count.
 
 **No blockchain in the critical path** ([ADR 0006](./decisions/0006-zcash-coupling.md)).
 On-chain checkpointing buys nothing that witness cosigning does not, and costs a
@@ -865,8 +959,8 @@ view. Liveness is not guaranteed against an adversarial relay; **safety is.**
 
 ### 11.5 Transcript retention
 
-Every ceremony message carries `retention_class = CEREMONY` and is retained
-regardless of the conversation's retention policy (§8.5).
+Every ceremony message carries `retention_class = CEREMONY` and is retained by
+default, because the participant wants the evidence (§8.5).
 
 ## 12. Disposition of prior review feedback
 
@@ -889,19 +983,21 @@ regardless of the conversation's retention policy (§8.5).
 
 Genuinely undecided. Listed rather than invented.
 
-- **A. OpenMLS audit status.** Must be established in writing before release.
-  "Widely used" is not "audited." If no adequate audit exists, budget one; per
-  #305's economics, audit dominates the cost of this system and infrastructure
-  is a rounding error.
+**Letters are stable identifiers.** A question that gets answered is moved to
+§13.1 and its letter is retired rather than reused, so a citation to "§13-F"
+means the same thing a year from now. The gaps in the list below are therefore
+deliberate.
+
 - **B. PQ ciphersuite codepoint.** The MLS PQ ciphersuite registration is in
   flight. Pin an exact identifier and a migration path before Phase 2.
 - **C. Post-quantum signatures.** X-Wing covers the KEM only. Migrating identity,
   device, ceremony and KT-log signatures (e.g. to ML-DSA) is unscheduled. What
   is the trigger condition?
 - **D. History transfer to a new device.** MLS forward secrecy means a newly
-  added device cannot decrypt past epochs. Under `RETAINED`, do we transfer
-  local history device-to-device (requiring a secure pairing channel), and what
-  does that do to the forward-secrecy claim? Unresolved.
+  added device cannot decrypt past epochs. Where the user has chosen to retain
+  local history (§8.1), do we transfer it device-to-device (requiring a secure
+  pairing channel), and what does that do to the forward-secrecy claim?
+  Unresolved.
 - **E. SimpleX licensing.** Verify the server licence **before** anyone reads
   their source; adopt the SMP protocol design with a clean-room implementation.
 - **F. Padding bucket sizes.** Need a traffic study; current values are
@@ -916,9 +1012,6 @@ Genuinely undecided. Listed rather than invented.
 - **I. Anonymous credentials for quota.** The zkgroup/KVAC-style design for
   "prove you paid for capacity without revealing who you are"
   ([ADR 0006](./decisions/0006-zcash-coupling.md), optional tier) is unspecified.
-- **J. Retention unanimity.** §8.2 delivers "no silent change," not "no
-  unilateral change." Is that acceptable, or do we want an application-layer
-  policy that treats a non-unanimous change as grounds for automatic exit?
 - **K. Handle rename and transfer.** How the KT log represents a handle changing
   owner without creating a MITM window.
 - **L. Encrypted media attachments.** Out of scope for the first release, but the
@@ -926,6 +1019,26 @@ Genuinely undecided. Listed rather than invented.
   not after — retrofitting off S3-style egress pricing is painful.
 - **M. Group scale limits.** MLS is O(log N) for rekey but the delivery fan-out
   is O(members × devices). At what size do we need a different fan-out strategy?
+
+### 13.1 Closed
+
+Kept here rather than deleted, so that a reader who arrives via an old citation
+finds the answer instead of a hole.
+
+- **A. OpenMLS audit status — closed 2026-08-08.** An independent assessment by
+  SRLabs, sponsored by the Sovereign Tech Agency, was published
+  [2026-05-27](https://blog.openmls.tech/posts/2026-05-27-independent-audit/):
+  eight findings, one High ("improper authentication of MACs"), fixed in 0.8.1
+  and 0.7.3. **We adopt the floor `openmls >= 0.8.1`.** One Low-severity finding
+  was still open at publication and must be re-checked before release. See §3.1.
+  This closes the question of whether the library has been audited; it does not
+  close the question of auditing *our* use of it, which per #305's economics
+  remains the dominant cost of the system.
+- **J. Retention unanimity — closed 2026-08-08, by removing the premise.** The
+  negotiated-unanimity retention model was withdrawn (§8.1). With retention a
+  per-user local choice there is no group policy to change unanimously or
+  otherwise, so the question of what to do about a non-unanimous change no longer
+  has a subject. See [ADR 0007](./decisions/0007-retention-per-user.md).
 
 ## 14. References
 

--- a/docs/e2ee/README.md
+++ b/docs/e2ee/README.md
@@ -12,23 +12,25 @@ architecture is chosen deliberately and can be reviewed by a third party.
 |---|---|
 | [`ARCHITECTURE.md`](./ARCHITECTURE.md) | The design. Layers, key hierarchy and derivation, delivery-service semantics, retention model, metadata model, federation and relay trust, FROST/DKG application design, open questions. |
 | [`THREAT-MODEL.md`](./THREAT-MODEL.md) | Adversaries, what each can do, and for each one the defense — or a plain statement that there is none. Includes the known, accepted limits. |
-| [`decisions/`](./decisions/) | One ADR per owner decision, `0001`–`0006`. |
+| [`decisions/`](./decisions/) | One ADR per owner decision, `0001`–`0007`. |
 
-## The six binding decisions
+## The binding decisions
 
 Recorded by the owner on 2026-08-08 in
 [#305](https://github.com/free2z/zuu/issues/305). They are inputs to this
 design, not conclusions of it. An implementation PR that contradicts one of
-these should be rejected, or should first change the decision on the record.
+these should be rejected, or should first change the decision on the record —
+which is what ADR 0007 does to ADR 0003.
 
 | ADR | Decision |
 |---|---|
 | [0001](./decisions/0001-platform-priority.md) | **Platform** — ZUULI-first; the web client speaks the same protocol via WASM with an explicitly weaker, UI-stated trust model. |
 | [0002](./decisions/0002-multi-device.md) | **Multi-device** — design the protocol, queues and key hierarchy for per-device fan-out from day one; ship single-device in the UI. |
-| [0003](./decisions/0003-history-retention.md) | **History** — per-conversation retention, negotiated and authenticated inside the MLS group. FROST transcripts exempt and always retained. |
+| ~~[0003](./decisions/0003-history-retention.md)~~ | **History** — per-conversation retention negotiated inside the MLS group. **Superseded by 0007**; do not implement. |
 | [0004](./decisions/0004-metadata-ambition.md) | **Metadata** — key-transparency directory for `@handle` discovery, then sealed sender over opaque pairwise unidirectional queues. |
 | [0005](./decisions/0005-federation.md) | **Federation** — full multi-relay. The relay is a separate small Rust service, open source and self-hostable from the first release. |
 | [0006](./decisions/0006-zcash-coupling.md) | **Zcash** — client-side cryptography only. Seed-derived messaging identity; no blockchain in the critical path. |
+| [0007](./decisions/0007-retention-per-user.md) | **History (supersedes 0003)** — retention is a per-user local choice, plus a non-binding, authenticated ephemeral hint that conforming clients honor. FROST transcripts retained by default because the participant wants the evidence. |
 
 ## Prior art in this repo
 

--- a/docs/e2ee/THREAT-MODEL.md
+++ b/docs/e2ee/THREAT-MODEL.md
@@ -72,12 +72,18 @@ data it stores or relays.
   append-only log with inclusion and consistency proofs; every client self-audits
   its own handle every epoch and alarms on any key change it did not initiate.
   An attempted substitution is visible **to the victim**.
-- **Cannot equivocate on the directory without leaving evidence.** Cross-relay
-  witness cosigning plus client gossip means two conflicting signed roots for one
-  epoch are non-repudiable, publishable proof of misbehavior
+- **Cannot equivocate on the directory without leaving evidence**, once an
+  independent witness set exists. Witness cosigning plus client gossip means two
+  conflicting signed roots for one epoch are non-repudiable, publishable proof of
+  misbehavior. Witnesses free2z operates provide none of this, so until outside
+  operators exist, client gossip is the whole of the defense
   ([`ARCHITECTURE.md` §9.3](./ARCHITECTURE.md#93-anti-equivocation-without-a-blockchain)).
-- **Cannot tamper with the retention policy.** It is a `GroupContext` extension,
-  authenticated inside MLS.
+- **Cannot forge or alter an ephemeral hint.** Hints are MLS application
+  messages, so the server can neither invent one nor change its TTL nor misattribute
+  it. Note carefully what this is *not*: honoring a hint is a client courtesy, not
+  something any party can enforce
+  ([`ARCHITECTURE.md` §8.2](./ARCHITECTURE.md#82-the-ephemeral-hint-is-a-courtesy-signal-not-a-control)),
+  and retention itself is a per-user local choice the server never sees.
 - **Cannot silently drop a message in the middle of a conversation.** Hash-linked
   parents produce a detectable gap.
 - **Cannot retain ciphertext it has deleted.** For its *own* relay we control the
@@ -148,9 +154,14 @@ user chose, or ours.
 - Cannot forge messages (MLS authentication) or modify them undetectably.
 - Cannot enumerate group membership by asking itself, because it has no notion of
   a group — only independent unidirectional queues.
-- Cannot link a queue to a person: queue addresses are established inside the MLS
-  group, never through the server, and send/receive addresses for the same queue
-  are distinct and unlinkable at the relay.
+- Cannot map a queue address to a person from its own records: addresses are
+  established inside the MLS group, never through the server, and carry no
+  handle, account or identity key. The relay learns that address *X* feeds
+  address *Y*; it does not learn who they are.
+- Cannot read, ACK or delete using a send-side credential. `QueueSendAddr`
+  authorizes APPEND only, so a compromised sender-side key — or a seized sending
+  device — cannot drain a single undelivered message out of the queue
+  ([`ARCHITECTURE.md` §6.2](./ARCHITECTURE.md#62-queues)).
 - Replay is rejected: MLS generation counters and the message DAG make a replayed
   ciphertext a duplicate `msg_id` at worst.
 - Cannot single-handedly equivocate on the KT log — a client requires *t*
@@ -158,11 +169,20 @@ user chose, or ours.
 
 **Not defended.**
 
-- **Traffic correlation between queues it hosts.** A relay that hosts both ends of
-  a conversation sees an append on one queue closely followed by a fetch on
-  another and can guess they are paired. Padding and jitter raise the cost; they
-  do not eliminate it. Using different relays for send and receive directions
-  helps and is supported, but is a user choice we cannot enforce.
+- **The send/receive address pair, for every queue it hosts.** Delivery requires
+  it: an APPEND to `QueueSendAddr` must land in the list read from
+  `QueueRecvAddr`, so the mapping is in the relay's database by construction. An
+  operator who dumps that table pairs the two ends of every queue it hosts
+  **directly**, with no traffic analysis at all. The two-address split buys
+  capability separation and resistance to a *front-door* observer; it does not
+  buy unlinkability against the operator, and this document does not claim it
+  does. See §4.9 and
+  [`ARCHITECTURE.md` §6.2](./ARCHITECTURE.md#62-queues).
+- **Traffic correlation across queues.** Even where a relay hosts only one
+  direction, an append on one queue closely followed by a fetch on another is a
+  usable signal. Padding and jitter raise the cost; they do not eliminate it.
+  Using different relays for send and receive directions helps against the
+  point above and is supported, but is a user choice we cannot enforce.
 - **Delivery-receipt timing.** See §4.2 — this is the strongest practical attack
   available to a relay operator.
 - **Denial of service and censorship.** Same as §3.1. Federation is the answer:
@@ -193,24 +213,30 @@ addressed to the group by construction.
 - **Cannot deny having sent a ceremony message.** Ceremony payloads are signed
   with `CeremonySigningKey` and bound to `session_hash`. Non-repudiation is the
   intended property here.
-- **Cannot change retention silently.** A policy change is authenticated and
-  attributable inside MLS.
+- **Cannot forge an ephemeral hint in someone else's name.** Hints are
+  authenticated and attributable inside MLS, so "Azhr asked for this to be
+  ephemeral" cannot be fabricated by another member.
 
 **Not defended.**
 
 - **Leaking plaintext they legitimately received.** Screenshots, copy-paste,
-  forwarding, a modified client that ignores the TTL. No E2EE system defends
-  against an authorized reader; ephemeral mode is explicitly best-effort
-  ([`ARCHITECTURE.md` §8.4](./ARCHITECTURE.md#84-ephemeral-mode-is-best-effort-and-the-ui-must-say-so)),
-  and the UI must not imply otherwise.
+  forwarding, a modified client that ignores an ephemeral hint. No E2EE system
+  defends against an authorized reader, and this is the reason retention is a
+  per-user local choice rather than a negotiated group property
+  ([`ARCHITECTURE.md` §8.1](./ARCHITECTURE.md#81-retention-is-a-per-user-local-choice)):
+  a rule that only conforming clients follow is not a defense against a member
+  who has already decided not to conform.
+- **Keeping their own copy forever.** Every participant chooses their own local
+  retention. A counterparty retaining everything is not a protocol violation and
+  is not detectable; it is the expected case for anyone who wants it.
 - **Refusing to participate.** A ceremony participant can stall a DKG
   indefinitely. Availability is not a property we provide against a member who
   will not play; the failure is safe (no key is output) rather than silent.
-- **Adding their own device to their own account** and thereby retaining a copy
-  outside the conversation's retention policy.
-- **A member unilaterally committing a retention change.** MLS permits it; we
-  make it visible and attributable, not impossible
-  ([`ARCHITECTURE.md` §8.2](./ARCHITECTURE.md#82-changing-it--negotiated-and-what-agreed-actually-means)).
+- **Ignoring an ephemeral hint.** The hint is a courtesy signal
+  ([`ARCHITECTURE.md` §8.2](./ARCHITECTURE.md#82-the-ephemeral-hint-is-a-courtesy-signal-not-a-control));
+  a client that disregards it is indistinguishable from one that honors it, and
+  no join-time capability check excludes it — see the knock-on recorded in that
+  section.
 
 ### 3.5 Compromised device
 
@@ -220,8 +246,8 @@ user's machine, or physical access to an unlocked device.
 **Defended.**
 
 - **Past traffic is partially protected.** MLS forward secrecy means epoch
-  secrets already deleted cannot be recovered — subject to the retention setting,
-  since retained local plaintext is right there on disk.
+  secrets already deleted cannot be recovered — subject to this user's own local
+  retention setting, since retained local plaintext is right there on disk.
 - **Future traffic heals, eventually.** Post-compromise security: once the
   compromised member issues an Update and the adversary is passive thereafter, the
   group's secrets recover.
@@ -244,7 +270,7 @@ user's machine, or physical access to an unlocked device.
   `ISK`, `CSK` and the ability to enroll new devices — i.e. a permanent wiretap
   that survives revocation of the compromised device, until the user rotates
   identity. Identity rotation is a KT event and is loud, but the window is real.
-- **Retained history**, in `RETAINED` mode, in full.
+- **Retained history**, in full, for whatever this user chose to keep.
 - **Zeroization in the browser.** In WASM we cannot guarantee that key material
   is erased from memory: the JS engine's GC may have copied the buffer and we do
   not control the heap. This is one reason ceremonies are ZUULI-first.
@@ -325,9 +351,12 @@ possesses one at the time of attack.
 
 ### 3.9 Malicious directory witness
 
-**Capability.** Operates one of the relays whose cosignature clients rely on for
-KT anti-equivocation; may refuse to sign, sign a false root, or collude with the
-directory operator.
+**Capability.** Operates one of the witnesses whose cosignature clients rely on
+for KT anti-equivocation; may refuse to sign, sign a false root, or collude with
+the directory operator. A witness is a distinct role from a relay
+([`ARCHITECTURE.md` §9.3](./ARCHITECTURE.md#93-anti-equivocation-without-a-blockchain))
+— one operator may run both, but a witness holds no ciphertext and compromising
+one yields no message data.
 
 **Defended.** A client requires *t* cosignatures from **its own configured**
 witness set, so a single malicious witness cannot validate a forged root. A
@@ -342,12 +371,13 @@ free2z-operated, and the UI should make the configured set inspectable.
 
 ### 3.10 Lost or stolen device (no active malware)
 
-**Defended.** Local storage is encrypted at rest; ephemeral conversations have
-already discarded plaintext past their TTL; the device can be revoked via the KT
-log and Removed from every group, after which it decrypts nothing new.
+**Defended.** Local storage is encrypted at rest; conversations this user set to
+expire have already discarded plaintext past their TTL; the device can be revoked
+via the KT log and Removed from every group, after which it decrypts nothing new.
 
-**Not defended.** Anything the device holds at seizure time in `RETAINED` mode,
-if the attacker also has the unlock credential. Revocation is not retroactive.
+**Not defended.** Anything the device still holds at seizure time under this
+user's own retention setting, if the attacker also has the unlock credential.
+Revocation is not retroactive.
 
 ## 4. Known limits, stated up front
 
@@ -384,12 +414,25 @@ with a strong anonymity requirement should disable delivery receipts and accept
 the resulting loss of certainty about delivery — which, under delete-on-ack,
 costs more than it would in a retaining messenger.
 
-### 4.3 Ephemeral mode is best-effort
+### 4.3 Ephemeral hints are a courtesy signal, not a control
 
-A recipient can screenshot, photograph the screen, or run a modified client that
-ignores the TTL. Ephemeral mode defends against casual persistence and against
-device seizure after the TTL has elapsed. It does not defend against a determined
-counterparty, and **any UI copy implying that it does is a defect.**
+Retention is a **per-user local choice**: each participant decides what their own
+device keeps, and nothing in the protocol lets one participant's preference bind
+another's disk
+([`ARCHITECTURE.md` §8.1](./ARCHITECTURE.md#81-retention-is-a-per-user-local-choice)).
+
+A conversation may carry an ephemeral **hint** — authenticated and attributable
+inside MLS, so it cannot be forged or misattributed. Conforming clients honor it.
+A recipient can screenshot, photograph the screen, or run a client that ignores
+the hint entirely, and **that is undetectable.** An earlier revision of these
+documents specified a negotiated group retention policy with a
+`required_capabilities` join check; it was withdrawn, because a modified client
+lies about its capabilities and the check bought nothing.
+
+The hint defends against casual persistence and against device seizure after the
+TTL. It does not defend against a determined counterparty, **it is not a security
+property, and it is deliberately absent from the claims table in §5.** Any UI copy
+implying enforcement is a defect.
 
 ### 4.4 Tail truncation is not detectable by hash links
 
@@ -428,6 +471,29 @@ Nostr fallback transport trades the delete-on-ack property for reach and
 censorship resistance. It is per conversation, opt-in, and the UI must state that
 ciphertext may be retained indefinitely by third parties.
 
+### 4.9 The relay knows which queue addresses are paired
+
+A queue's send address and its receive address are **linked in the relay's own
+database**, because that link is how a message gets from one to the other. A
+relay operator therefore holds a pairing table for every queue it hosts, and can
+read the pseudonymous communication graph over queue addresses off disk without
+any timing analysis.
+
+What limits the damage is what the addresses are *not*: they are opaque, they
+carry no handle or identity key, they are per device pair and per direction, and
+they rotate on the `free2z/queue/v1` exporter schedule, so the graph is over
+short-lived pseudonyms rather than over people. Deanonymizing it requires
+attaching a queue address to a person by some other means — source IP, timing
+against a known event, or correlation with the platform's own logs when free2z
+runs both. Publishing queue addresses on *k* relays, and using different relays
+for the two directions, splits the table so no single operator holds all of it.
+
+The two-address split is still worth having, for the reasons in
+[`ARCHITECTURE.md` §6.2](./ARCHITECTURE.md#62-queues) — a sender that cannot
+read, ACK or delete, and a sender-side key that cannot drain the queue. It is
+simply not unlinkability, and the earlier text in this document that said
+otherwise was wrong.
+
 ## 5. Summary: what we claim, precisely
 
 | Property | ZUULI (native) | Web (WASM) |
@@ -440,12 +506,19 @@ ciphertext may be retained indefinitely by third parties.
 | Post-compromise security | **Yes** — MLS Updates | Yes, same caveat |
 | PQ confidentiality (harvest-now) | **Yes** — X-Wing hybrid | Yes, same caveat |
 | PQ authentication | **No** (§3.8) | No |
-| Relay learns no social graph | **Yes**, modulo timing (§3.3, §4.2) | Same |
+| Relay learns no handles or identity keys | **Yes** (§3.3) | Same |
+| Relay learns no social graph | **No** — it holds the pairing table for its own queues, over opaque rotating addresses (§3.3, §4.9), and receipt timing adds to it (§4.2) | Same |
 | Server retains nothing after ack | **Auditable, not verifiable** (§4.5) | Same |
-| Ephemeral messages truly disappear | **No** — best-effort (§4.3) | No |
 | Deniability | **No** (§4.6) | No |
 | Anonymity vs. global passive adversary | **No** (§3.7) | No |
 | Defense against endpoint compromise | **No** (§3.5) | No |
 | Defense against targeted malicious code delivery | **Yes** — signed binary, verifiable out of band | **No** (§3.6) |
 
 The last row is the whole reason ZUULI is the trust anchor.
+
+**Deliberately absent from this table: ephemeral hints.** A hint is a courtesy
+signal that conforming clients honor and any other client ignores
+([`ARCHITECTURE.md` §8.2](./ARCHITECTURE.md#82-the-ephemeral-hint-is-a-courtesy-signal-not-a-control),
+§4.3). It is not a security property, so it is not listed as one — not even as a
+"No" row, because a reader scanning this table for what the system does should
+not encounter it here at all.

--- a/docs/e2ee/decisions/0003-history-retention.md
+++ b/docs/e2ee/decisions/0003-history-retention.md
@@ -1,6 +1,19 @@
 # ADR 0003 — History: per-conversation retention, negotiated inside the group
 
-**Status:** Accepted (owner, 2026-08-08) · **Refs:** [#305](https://github.com/free2z/zuu/issues/305) §7.3
+**Status:** **SUPERSEDED** by
+[ADR 0007 — per-user local retention, with a non-binding ephemeral hint](./0007-retention-per-user.md)
+(owner, 2026-08-08) · **Refs:** [#305](https://github.com/free2z/zuu/issues/305) §7.3,
+[#342](https://github.com/free2z/zuu/issues/342)
+
+> **Do not implement this ADR.** The negotiated model below — a `GroupContext`
+> retention extension listed in `required_capabilities`, changed by a two-phase
+> unanimity protocol — was withdrawn on owner review because it does not deliver
+> the property it appears to deliver: a modified client advertises whatever
+> capabilities it likes, joins, and retains everything. It is preserved as
+> written — save for one cross-reference repointed at the section that replaced
+> its target — as the record of a decision that was taken and then reversed.
+> **The current design is [ADR 0007](./0007-retention-per-user.md)** and
+> [`../ARCHITECTURE.md` §8](../ARCHITECTURE.md#8-retention-d3).
 
 ## Context
 
@@ -32,7 +45,7 @@ inside the MLS group, not a local preference.
   data is gone). A separate, explicitly labeled `PurgeRequest{before_epoch}` asks
   members to delete older history; the UI must say "asked N, M confirmed," never
   "deleted." See
-  [`../ARCHITECTURE.md` §8.3](../ARCHITECTURE.md#83-mid-conversation-changes-apply-forward-only).
+  [`../ARCHITECTURE.md` §8.3](../ARCHITECTURE.md#83-purge-requests-and-why-nothing-here-is-retroactive).
 - **"Agreed" means "no silent change," not "no unilateral change."** A two-phase
   propose/ack negotiation precedes the Commit, but MLS cannot *enforce* unanimity —
   any member may commit a `GroupContextExtensions` proposal. What the protocol

--- a/docs/e2ee/decisions/0004-metadata-ambition.md
+++ b/docs/e2ee/decisions/0004-metadata-ambition.md
@@ -25,8 +25,12 @@ ongoing communication does not expose the social graph.**
 - The relay has **no accounts, no handles, no identity keys, no contact lists and
   no group state.** It sees opaque queue addresses and opaque ciphertext. Each
   queue has **two distinct addresses** — one authorizing append, one authorizing
-  read/ack/delete — that are unlinkable at the relay, so it cannot trivially pair
-  correspondents.
+  read/ack/delete. That is **capability separation**: a sender can never read,
+  ACK or delete, and a compromised sender-side key cannot drain the queue. It is
+  **not** unlinkability against the relay operator — delivery requires the relay
+  to know which receive address a send address feeds, so the operator holds that
+  pairing table by construction
+  ([`../THREAT-MODEL.md` §4.9](../THREAT-MODEL.md#49-the-relay-knows-which-queue-addresses-are-paired)).
 - Queue addresses are established **inside the MLS group**, never via the server,
   and rotate on a schedule using an MLS exporter, so a long-lived relationship
   does not present a long-lived identifier.

--- a/docs/e2ee/decisions/0005-federation.md
+++ b/docs/e2ee/decisions/0005-federation.md
@@ -37,12 +37,16 @@ software are built for anyone to run one, and clients treat relays as
   1,000 DAU. A community operator can sustainably run a relay on a ~$5/month VPS.
   **The delete-on-ack requirement is not only a privacy property — it is the
   economic precondition for the federation.**
-- **Cross-relay witness cosigning of key-transparency log roots provides
-  anti-equivocation**, which is why no blockchain is needed
-  ([ADR 0006](./0006-zcash-coupling.md)). The property strengthens as the
-  federation grows — but it is only as strong as the *independence* of the witness
-  set, which is a social fact we cannot verify cryptographically. Clients should
-  default to a witness set that is not all free2z-operated.
+- **Witness cosigning of key-transparency log roots provides anti-equivocation**,
+  which is why no blockchain is needed
+  ([ADR 0006](./0006-zcash-coupling.md)). **Witness is a separate role from
+  relay** — an operator may run both, but a witness needs no inbound port, no TLS,
+  no domain and no database, so the two asks are not the same size
+  ([`../ARCHITECTURE.md` §9.3](../ARCHITECTURE.md#93-anti-equivocation-without-a-blockchain)).
+  The property strengthens as the *witness set* grows, independently of the relay
+  count — and it is only as strong as the *independence* of that set, which is a
+  social fact we cannot verify cryptographically. Clients should default to a
+  witness set that is not all free2z-operated.
 - A device may publish queue addresses on *k* relays; senders send to all *k* and
   clients deduplicate by `msg_id`. Egress multiplies by *k*; at *k*=3 this is still
   trivially inside one commodity host's included bandwidth. The default *k* is an

--- a/docs/e2ee/decisions/0006-zcash-coupling.md
+++ b/docs/e2ee/decisions/0006-zcash-coupling.md
@@ -41,7 +41,7 @@ from the master seed, then generate messaging keys from that.
   so the domain-separation table is part of the specification, not an
   implementation detail.
 - **No chain dependency means no availability coupling and no ZEC price exposure
-  in the messaging path.** Cross-relay witness cosigning
+  in the messaging path.** Witness cosigning
   ([ADR 0005](./0005-federation.md)) provides the same anti-equivocation property
   for free, and it is the Certificate Transparency model rather than a novel one.
   For the record: at [ZIP 317](https://zips.z.cash/zip-0317)'s 10,000-zatoshi

--- a/docs/e2ee/decisions/0007-retention-per-user.md
+++ b/docs/e2ee/decisions/0007-retention-per-user.md
@@ -1,0 +1,103 @@
+# ADR 0007 — History: per-user local retention, with a non-binding ephemeral hint
+
+**Status:** Accepted (owner, 2026-08-08) · **Supersedes:**
+[ADR 0003](./0003-history-retention.md) ·
+**Refs:** [#305](https://github.com/free2z/zuu/issues/305) §7.3,
+[#342](https://github.com/free2z/zuu/issues/342)
+
+## Context
+
+[ADR 0003](./0003-history-retention.md) made retention a **negotiated, shared
+property of the conversation**: a `GroupContext` extension (RFC 9420 §12.4)
+listed in `required_capabilities`, changed by a two-phase
+`RetentionChangeProposal` / `RetentionChangeAck` unanimity protocol.
+
+Owner review of the merged Phase 0 docs rejected it, and the objection is
+correct:
+
+> "How could his setting force my device to delete? Isn't that sort of 'trusting
+> the client'? Couldn't I just exfiltrate and backup the messages anyway? In
+> general we want to reject theatrical measures that are easy to get around."
+
+Yes. Once a recipient legitimately holds plaintext, nothing in the protocol
+constrains what their device does with it. The `required_capabilities` check does
+not help, because a modified client advertises whatever capabilities it likes and
+joins anyway — the check filters clients that are *honest about not supporting*
+the extension, which is the population that was never the threat. We were
+spending real complexity, real group state and a join-time exclusion rule to buy a
+property that a recompiled binary defeats.
+
+## Decision
+
+**Retention is a per-user local choice.** Each participant decides how long their
+own device keeps its own copy. One keeps five minutes; another keeps forever. Both
+are legitimate and neither constrains the other.
+
+**A conversation may carry a non-binding ephemeral hint** — a requested mode and
+TTL, sent as an MLS application message so it is confidential, **authenticated and
+attributable**. Nobody can forge "Azhr asked for this to be ephemeral," and every
+member sees who asked and when. Conforming clients honor it by default.
+
+**The hint is a courtesy signal, not a security control**, and it MUST NOT appear
+in any security claims table.
+
+## Consequences
+
+- **Removed:** the `GroupContext` retention extension, its listing in
+  `required_capabilities`, the `RetentionChangeProposal` / `RetentionChangeAck`
+  round trip, and the two-phase unanimity protocol.
+- **The server still holds nothing after acknowledged delivery, in every mode.**
+  This is unchanged, it is the one retention property that is a security claim,
+  and it is not adjustable per conversation. It remains auditable rather than
+  verifiable
+  ([`../THREAT-MODEL.md` §4.5](../THREAT-MODEL.md#45-server-side-deletion-is-auditable-not-verifiable)).
+- **`PurgeRequest{before_epoch}` survives unchanged**, because it was already
+  labeled correctly: a request, not a guarantee. Conforming clients delete local
+  history before that epoch and reply `PurgeAck`; the UI must say "asked N
+  participants to delete; M confirmed," never "deleted." Nothing about it was
+  theater, because it never claimed to compel anyone.
+- **Nothing is retroactive**, in either direction, for the same reasons ADR 0003
+  gave: retroactive deletion is unenforceable across other people's devices, and
+  retroactive retention is impossible because the data is gone.
+- **Ceremony transcripts are retained by default because the participant wants
+  the evidence**, not because the protocol compels it. A DKG transcript is what
+  lets them later prove the ceremony ran correctly and who said what; discarding
+  it discards their own proof. This needs no exemption machinery — a default and
+  a clear explanation before the ceremony begins, so consent is informed.
+- **A short local TTL shortens the plaintext outbox window** used to repair
+  detected gaps
+  ([`../ARCHITECTURE.md` §7](../ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering)),
+  so some gaps become unrecoverable. Surfaced explicitly rather than left as a
+  silent hole. The trade-off is now made by, and lands on, the user who chose the
+  short TTL.
+- **Knock-on, stated plainly: dropping `required_capabilities` removes the
+  join-time exclusion of non-conforming clients, and nothing replaces it.** Any
+  client that speaks MLS and our application framing can join a conversation, and
+  whether it honors hints is unobservable from outside. We accept this because the
+  exclusion never worked against the client we actually cared about, but it is a
+  real reduction in what a group can assert about its own membership and it should
+  be read as one.
+- **The hint is still worth shipping.** It defends against casual persistence,
+  against a message lingering on a screen, and against device seizure after the
+  TTL — the same value Signal and WhatsApp disappearing messages provide. The rule
+  is: the feature ships, and it never appears in the security claims table
+  ([`../THREAT-MODEL.md` §4.3](../THREAT-MODEL.md#43-ephemeral-hints-are-a-courtesy-signal-not-a-control)).
+- Open question §13-J ("retention unanimity") is closed by removal of its premise.
+
+## Alternatives rejected
+
+- **Keeping ADR 0003's negotiated model.** Rejected as client-trust theater, per
+  the reasoning above. The property it appeared to deliver cannot be delivered.
+- **Keeping the `GroupContext` extension as a signal but dropping the unanimity
+  negotiation.** Rejected: it costs group state and a wire-format extension to
+  carry information that an authenticated application message carries equally
+  well, and its presence in `GroupContext` would keep implying enforcement.
+- **No client history at all.** Rejected, as in ADR 0003: it produces a product
+  most people will not use, and it does not stop a determined counterparty from
+  keeping a copy.
+- **Always keep history, with no ephemeral option.** Rejected: it forecloses a
+  legitimate use case, and the courtesy value of hints is real even though the
+  security value is nil.
+- **Detecting non-conforming clients.** Rejected as impossible, not merely
+  expensive. There is no observable difference between a client that deleted its
+  copy and one that did not.


### PR DESCRIPTION
**Documentation only. No code changes.** Corrects false and superseded security
claims in the merged Phase 0 E2EE docs before an auditor, a contributor, or a
user relies on them.

## 1. Queue addresses are not unlinkable at the relay (`ARCHITECTURE.md` §6.2, `THREAT-MODEL.md` §3.3)

Both documents claimed the send and receive addresses of a queue are
"unlinkable at the relay." **This is false.** An `APPEND` to `send_addr` has to
be delivered into `recv_addr`'s message list, so the relay necessarily holds the
mapping — that mapping *is* delivery. A relay operator dumping that table pairs
correspondents directly, with no traffic analysis. SimpleX does not achieve this
property either.

Replaced with what the split actually buys:

- a sender cannot read, ACK or delete;
- a compromised sender-side key cannot drain the queue;
- an observer of the relay's front door cannot pair addresses from traffic alone
  — and this is the only one of the three that fails against the operator.

In `THREAT-MODEL.md` this moves out of §3.3's **cannot** column into **Not
defended**, with a new known limit **§4.9 — The relay knows which queue addresses
are paired**. The §5 claims table's "Relay learns no social graph" row is
corrected from **Yes** to **No**, split from a new "no handles or identity keys"
row that *is* true.

ADR 0004 carried the same false sentence and is corrected too.

## 2. Retention: superseded model replaced (`ARCHITECTURE.md` §8, ADR 0003 → ADR 0007)

The negotiated-unanimity model — a `GroupContext` retention extension in
`required_capabilities`, `RetentionChangeProposal`/`RetentionChangeAck`, two-phase
unanimity — was rejected by the owner on #305 as unenforceable client-trust
theater: a modified client simply lies about its capabilities and retains
everything.

§8 is rewritten to the revised model: **retention is a per-user local choice**,
plus a **non-binding, authenticated ephemeral hint** that conforming clients
honor. Preserved from the old text:

- the server still holds nothing after acknowledged delivery in every mode, and
  it is now labeled as the *only* retention property that is a security claim;
- `PurgeRequest` survives unchanged, because it was already correctly labeled a
  request rather than a guarantee;
- ceremony transcripts are retained by default because the participant wants the
  evidence — no exemption machinery needed.

The hint is a courtesy feature and is **explicitly excluded from every security
claims table**, including a note under `THREAT-MODEL.md` §5 saying so.

**The knock-on is stated honestly:** dropping `required_capabilities` removes the
join-time exclusion of non-conforming clients, and nothing replaces it.

Adds `decisions/0007-retention-per-user.md`; marks 0003 **Superseded** with a
link and a "do not implement" banner, preserved otherwise as the record of a
decision taken and reversed. Open question §13-J is deleted (its premise is gone).

## 3. Witness decoupled from relay (`ARCHITECTURE.md` §9.3)

Was: "each relay in the federation observes and signs the KT log root." Now they
are separate roles that one operator MAY combine. A witness needs **no inbound
port, no TLS certificate, no domain, no public IP and no database** — only
outbound HTTPS and a tiny state file. Coupling the roles makes the volunteer ask
far larger than necessary, and the witness *set* is what makes anti-equivocation
real. ADRs 0005/0006 and `THREAT-MODEL.md` §3.9 updated to match.

## 4. §13-A closed — OpenMLS audit and version floor

OpenMLS received an independent assessment by SRLabs, sponsored by the Sovereign
Tech Agency, [published 2026-05-27](https://blog.openmls.tech/posts/2026-05-27-independent-audit/):
8 findings, one **High** ("improper authentication of MACs"), fixed in 0.8.1 and
0.7.3. Records the floor **`openmls >= 0.8.1`** with that rationale and notes that
the one residual Low-severity finding must be re-checked before release.

§13 gains a **13.1 Closed** subsection so letters stay stable identifiers and old
citations (§13-E, §13-F, §13-G, …) keep resolving; the gaps at A and J are
deliberate and explained.

## Verification

All internal Markdown links and heading anchors across `docs/e2ee/` were
programmatically validated against GitHub's slug rules — 0 broken links, 0
dangling anchors.

Closes #342. Refs #305.

https://claude.ai/code/session_016hGD65qzFQS9CgtEd8Pyej
