### PR TITLE
ci(rust): single source of truth for the toolchain pin, with drift check

### DIFF
--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Fetch librustzcash submodule
         run: git submodule update --init z/zcash/librustzcash
 
+      # `uses:` cannot take an expression, so this version-branch ref restates
+      # wallet/rust-toolchain.toml; scripts/check-rust-toolchain.sh holds it to
+      # the source of truth.
       - uses: dtolnay/rust-toolchain@1.88.0
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -46,6 +46,9 @@ concurrency:
 env:
   CI: true
   ZUULI_NODE_VERSION: "24.18.0"
+  # Restates wallet/rust-toolchain.toml because GitHub cannot compute a
+  # workflow-level `env:` from a file. scripts/check-rust-toolchain.sh fails
+  # the pull request if this ever stops matching the source of truth.
   ZUULI_RUST_VERSION: "1.88.0"
   ZUULI_JAVA_VERSION: "21.0.12"
   ZUULI_XCODE_VERSION: "26.6"
@@ -110,9 +113,14 @@ jobs:
           distribution: temurin
           java-version: "21.0.12"
           cache: gradle
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+      # dtolnay/rust-toolchain's version branches hardcode the compiler in
+      # action.yml, so this commit is itself the version pin and the trailing
+      # comment is its only readable record. Bumping the toolchain means moving
+      # the SHA to the new version branch and updating the comment with it;
+      # scripts/check-rust-toolchain.sh fails the pull request otherwise.
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ env.ZUULI_RUST_VERSION }}
           targets: ${{ github.event_name == 'pull_request' && 'aarch64-linux-android' || 'aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android' }}
       - name: Install exact Android SDK components
         run: |
@@ -204,9 +212,9 @@ jobs:
           node-version: "24.18.0"
           cache: npm
           cache-dependency-path: wallet/zuuli/package-lock.json
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ env.ZUULI_RUST_VERSION }}
           targets: aarch64-apple-ios
       - name: Restore credential-free iOS Rust dependencies
         if: github.event_name != 'schedule' && github.event.inputs.cold_rust_cache != 'true'
@@ -303,9 +311,9 @@ jobs:
           node-version: "24.18.0"
           cache: npm
           cache-dependency-path: wallet/zuuli/package-lock.json
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ env.ZUULI_RUST_VERSION }}
       - name: Install macOS universal Rust targets
         if: runner.os == 'macOS'
         run: rustup target add aarch64-apple-darwin x86_64-apple-darwin

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -39,6 +39,9 @@ concurrency:
 env:
   CI: true
   ZUULI_NODE_VERSION: "24.18.0"
+  # Restates wallet/rust-toolchain.toml because GitHub cannot compute a
+  # workflow-level `env:` from a file. scripts/check-rust-toolchain.sh fails
+  # the pull request if this ever stops matching the source of truth.
   ZUULI_RUST_VERSION: "1.88.0"
   ZUULI_JAVA_VERSION: "21.0.12"
   ZUULI_XCODE_VERSION: "26.6"
@@ -210,9 +213,14 @@ jobs:
         with:
           distribution: temurin
           java-version: "21.0.12"
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+      # dtolnay/rust-toolchain's version branches hardcode the compiler in
+      # action.yml, so this commit is itself the version pin and the trailing
+      # comment is its only readable record. Bumping the toolchain means moving
+      # the SHA to the new version branch and updating the comment with it;
+      # scripts/check-rust-toolchain.sh fails the pull request otherwise.
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ env.ZUULI_RUST_VERSION }}
           targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
       - name: Install exact Android SDK components
         run: |
@@ -357,9 +365,9 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24.18.0"
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ env.ZUULI_RUST_VERSION }}
           targets: aarch64-apple-ios
       - name: Restore reviewed iOS Rust dependencies
         uses: ./.github/actions/zuuli-rust-cache
@@ -573,8 +581,8 @@ jobs:
           {
             node-version: "24.18.0",
           }
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
-        with: { toolchain: 1.88.0 }
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
+        with: { toolchain: "${{ env.ZUULI_RUST_VERSION }}" }
       - name: Install package dependencies
         run: |
           sudo apt-get update
@@ -670,10 +678,10 @@ jobs:
           {
             node-version: "24.18.0",
           }
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
         with:
           {
-            toolchain: 1.88.0,
+            toolchain: "${{ env.ZUULI_RUST_VERSION }}",
             targets: "aarch64-apple-darwin,x86_64-apple-darwin",
           }
       - name: Restore reviewed macOS Rust dependencies

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -37,6 +37,14 @@ jobs:
           # Diff locally instead of relying on the pull-request files API.
           fetch-depth: 0
 
+      # Runs on every event, including changes this job would otherwise skip,
+      # because a toolchain pin can drift from any workflow or manifest. The
+      # self-test proves the check can still fail before its verdict is trusted.
+      - name: Verify the Rust toolchain pin has not drifted
+        run: |
+          scripts/check-rust-toolchain.sh --self-test
+          scripts/check-rust-toolchain.sh
+
       - name: Detect release-impacting ZUULI changes
         id: filter
         shell: bash
@@ -146,10 +154,18 @@ jobs:
             build-essential curl wget file pkg-config
 
       # Keep CI explicit as well as repository-pinned so runner state cannot
-      # silently select a newer compiler.
+      # silently select a newer compiler. The version is read from
+      # wallet/rust-toolchain.toml rather than restated here.
+      - name: Resolve the pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          set -euo pipefail
+          version=$(scripts/check-rust-toolchain.sh --print-channel)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -189,9 +205,16 @@ jobs:
             libssl-dev \
             build-essential curl wget file pkg-config
 
+      - name: Resolve the pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          set -euo pipefail
+          version=$(scripts/check-rust-toolchain.sh --print-channel)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.88.0
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,58 @@ integrate, and move it forward alongside everything else.
 - The workflow's **weekly `upstream-canary`** job rebuilds against the *latest*
   librustzcash `main` + refreshed crates, so upstream drift surfaces as an early
   warning **before** we bump the submodule in a PR.
+- **`scripts/check-rust-toolchain.sh`** proves every Rust toolchain pin still
+  agrees with `wallet/rust-toolchain.toml`. The `wallet/zuuli` gate runs it on
+  every pull request, so a half-finished bump fails in review instead of in a
+  protected store release. See below.
+
+## The Rust toolchain pin
+
+### One source of truth
+
+**`wallet/rust-toolchain.toml` decides the version. Nothing else does.**
+
+Everything else in the repo restates it, because the surrounding tools cannot
+read a TOML file at the moment they need the value:
+
+| Restatement | Why it cannot just read the file |
+|---|---|
+| `rust-version` in the three `Cargo.toml` manifests | Cargo needs a literal, and it is the **two-component MSRV floor** (`X.Y`) of the three-component channel (`X.Y.Z`) — deliberately a different form, compared as such |
+| `ZUULI_RUST_VERSION` in `zuuli-packaging.yml` and `zuuli-release.yml` | A workflow-level `env:` cannot be computed from a file, and the release jobs verify the installed compiler with `rustc --version \| grep -F "rustc $ZUULI_RUST_VERSION "` |
+| `dtolnay/rust-toolchain@<sha> # <version>` in the packaging/release workflows | The action's **version branches hardcode the compiler in `action.yml` and do not declare a `toolchain` input at all** — a commit-pinned ref *is* the version pin, and the trailing comment is its only readable record |
+| `dtolnay/rust-toolchain@<version>` in `zuuallet.yml` | `uses:` cannot contain an expression |
+| MSRV/`cargo +<version>` lines in the wallet READMEs, the plugin `CLAUDE.md`, and `wallet/zuuli/docs/releasing.md` | Prose |
+
+The `wallet/zuuli` gate reads the channel out of the file (`--print-channel`) and
+feeds it to the toolchain action, so the required CI jobs hold **no literal at
+all**. Every remaining restatement is verified against the file by
+`scripts/check-rust-toolchain.sh`.
+
+### How to bump
+
+1. Change `channel` in `wallet/rust-toolchain.toml`. **That is the only decision.**
+2. Run `scripts/check-rust-toolchain.sh`. It names every restatement that has
+   not followed, with file and line.
+3. Update exactly what it names — including moving each commit-pinned
+   `dtolnay/rust-toolchain` SHA to the new version branch **and** its `# <version>`
+   comment.
+4. Re-run until it passes. `scripts/check-rust-toolchain.sh --self-test` proves
+   the check can still fail; CI runs both.
+
+A bump that touches the source of truth and nothing else **cannot merge** — the
+gate fails. That is the point: the version is one edit plus a mechanical
+follow-through, not an eleven-place archaeology exercise.
+
+### Cadence — proposed, not yet adopted
+
+The pin is currently `1.88.0`, released June 2025 and roughly fourteen months
+old at the time of writing. Nothing here changes it; the bump is a separate,
+owner-gated decision because it moves every mobile and desktop release target at
+once. **Proposal for the owner to accept or reject:** track **stable minus one
+or two releases**, reviewed **quarterly**, with a named owner, so the pin is
+current enough for modern crates' MSRVs without chasing stable into surprises.
+Recorded here so the next person inherits a decision to make rather than a
+literal to be afraid of.
 
 ## Verifying before you push
 

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+# Prove every Rust toolchain pin in this repository still agrees with the one
+# place the version is actually decided: wallet/rust-toolchain.toml.
+#
+# Everything else — workflow inputs, the commit-pinned dtolnay/rust-toolchain
+# refs, ZUULI_RUST_VERSION, each crate's `rust-version`, and the prose that
+# quotes them — is a restatement. Restatements rot. This script fails the pull
+# request when one of them stops matching, instead of letting a half-finished
+# bump surface in a protected release build.
+#
+# Usage:
+#   scripts/check-rust-toolchain.sh                  verify every pin agrees
+#   scripts/check-rust-toolchain.sh --print-channel  print the pinned channel (X.Y.Z)
+#   scripts/check-rust-toolchain.sh --print-msrv     print the MSRV floor (X.Y)
+#   scripts/check-rust-toolchain.sh --self-test      prove the check still fails on drift
+
+set -euo pipefail
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+# The single source of truth.
+TOOLCHAIN_FILE=wallet/rust-toolchain.toml
+
+# Crate manifests. These carry the two-component MSRV form (1.88) of the
+# three-component channel (1.88.0) — Cargo's `rust-version` is a floor, not an
+# exact toolchain, so the forms are deliberately different and compared as such.
+MANIFESTS=(
+  wallet/zuuli/src-tauri/Cargo.toml
+  wallet/zuuallet/src-tauri/Cargo.toml
+  wallet/plugins/tauri-plugin-zcash/Cargo.toml
+)
+
+# Workflows whose jobs verify the installed compiler with
+# `rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "`. GitHub cannot
+# compute a workflow-level `env:` from a file, so this one value is restated
+# per workflow and held to the source of truth here instead.
+RUST_VERSION_ENV_WORKFLOWS=(
+  .github/workflows/zuuli-packaging.yml
+  .github/workflows/zuuli-release.yml
+)
+
+# Prose restatements. Each entry is `path` + TAB + a line the file must still
+# contain, with %CHANNEL% / %MSRV% substituted. Documentation is checked by
+# exact expected text rather than by pattern so the failure message tells the
+# next person precisely what to write.
+DOC_PINS=(
+  $'wallet/zuuallet/README.md\t- [Rust](https://rustup.rs/) %MSRV%+ (edition 2024)'
+  $'wallet/plugins/tauri-plugin-zcash/README.md\tcargo +%CHANNEL% check --locked'
+  $'wallet/plugins/tauri-plugin-zcash/README.md\tcargo +%CHANNEL% test --locked'
+  $'wallet/plugins/tauri-plugin-zcash/README.md\t- **MSRV**: %MSRV%'
+  $'wallet/plugins/tauri-plugin-zcash/CLAUDE.md\tRust edition 2024, MSRV %MSRV%.'
+  $'wallet/zuuli/docs/releasing.md\tRust `%CHANNEL%`'
+  $'AGENTS.md\tThe pin is currently `%CHANNEL%`'
+)
+
+# `toolchain:` may be an expression instead of a literal, but only one that
+# leads back to the source of truth. Anything else is opaque to this check and
+# is therefore rejected rather than quietly trusted.
+ACCEPTED_EXPRESSIONS=(
+  'env.ZUULI_RUST_VERSION'
+  'steps.rust_toolchain.outputs.version'
+)
+
+errors=0
+
+fail() {
+  printf 'drift: %s\n' "$*" >&2
+  errors=$((errors + 1))
+}
+
+trim() {
+  local s=$1
+  s=${s#"${s%%[![:space:]]*}"}
+  s=${s%"${s##*[![:space:]]}"}
+  printf '%s' "$s"
+}
+
+contains() {
+  local needle=$1 item
+  shift
+  for item in "$@"; do
+    [[ $item == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# Turn a version into a literal for use inside an extended regular expression.
+quote_re() {
+  printf '%s' "${1//./\\.}"
+}
+
+read_channel() {
+  local root=$1 channel
+  if [[ ! -f "$root/$TOOLCHAIN_FILE" ]]; then
+    printf '%s is missing; it is the single source of truth for the Rust toolchain.\n' \
+      "$TOOLCHAIN_FILE" >&2
+    return 1
+  fi
+  channel=$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' "$root/$TOOLCHAIN_FILE")
+  if [[ ! $channel =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    printf 'channel in %s must be a three-component version, got "%s".\n' \
+      "$TOOLCHAIN_FILE" "$channel" >&2
+    return 1
+  fi
+  printf '%s\n' "$channel"
+}
+
+check_workflows() {
+  local root=$1 channel=$2
+  local file rel lineno text ref comment window value expression
+  local refs=0 inputs=0 floating=0
+
+  local files=()
+  shopt -s nullglob
+  files=("$root"/.github/workflows/*.yml)
+  shopt -u nullglob
+
+  if [[ ${#files[@]} -eq 0 ]]; then
+    fail "no workflows found under .github/workflows; this check has gone blind"
+    return
+  fi
+
+  for file in "${files[@]}"; do
+    rel=${file#"$root"/}
+
+    # 1. How each job selects the action, which on the version branches *is*
+    #    the version selection.
+    while IFS=: read -r lineno text; do
+      refs=$((refs + 1))
+      ref=${text#*dtolnay/rust-toolchain@}
+      ref=${ref%%[[:space:]]*}
+      comment=""
+      if [[ $text == *"#"* ]]; then
+        comment=$(trim "${text#*#}")
+        comment=${comment%%[[:space:]]*}
+      fi
+      window=$(awk -v start="$lineno" '
+        NR > start {
+          if ($0 ~ /^[[:space:]]*-[[:space:]]/ || NR > start + 10) exit
+          print
+        }' "$file")
+
+      if [[ $ref =~ ^[0-9a-f]{40}$ ]]; then
+        # dtolnay/rust-toolchain's version branches hardcode the toolchain in
+        # action.yml and do not even declare a `toolchain` input, so a
+        # commit-pinned ref decides the compiler on its own and any
+        # `toolchain:` beside it is inert. The trailing comment is the only
+        # human- and machine-readable record of what the SHA installs.
+        if [[ -z $comment ]]; then
+          fail "$rel:$lineno pins dtolnay/rust-toolchain by commit with no '# <version>' comment; the SHA alone selects the compiler"
+        elif [[ $comment != "$channel" ]]; then
+          fail "$rel:$lineno pins dtolnay/rust-toolchain by commit commented '# $comment', expected '# $channel'"
+        fi
+      elif [[ $ref =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+        [[ $ref == "$channel" ]] ||
+          fail "$rel:$lineno uses dtolnay/rust-toolchain@$ref, expected @$channel"
+      elif [[ $ref =~ ^(stable|beta|nightly|master|main)$ ]]; then
+        # A moving ref is only a pin when the step also passes `toolchain:`.
+        # Without one the job deliberately floats (the zuuallet canary does);
+        # that is reported, not failed.
+        if ! grep -qE '(^|[[:space:],{])toolchain:' <<<"$window"; then
+          floating=$((floating + 1))
+        fi
+      else
+        fail "$rel:$lineno uses an unrecognized dtolnay/rust-toolchain ref '@$ref'"
+      fi
+    done < <(grep -nE 'uses:[[:space:]]*dtolnay/rust-toolchain@' "$file" || true)
+
+    # 2. Explicit `toolchain:` inputs, in both block and flow mapping style.
+    while IFS=: read -r lineno text; do
+      inputs=$((inputs + 1))
+      value=$(trim "${text#*toolchain:}")
+      if [[ $value == '"'* ]]; then
+        value=${value#\"}
+        value=${value%%\"*}
+      fi
+      if [[ $value == '${{'* ]]; then
+        expression=${value#*\{\{}
+        expression=${expression%%\}\}*}
+        expression=$(trim "$expression")
+        if ! contains "$expression" "${ACCEPTED_EXPRESSIONS[@]}"; then
+          fail "$rel:$lineno resolves the toolchain from \${{ $expression }}, which cannot be traced back to $TOOLCHAIN_FILE"
+        fi
+      else
+        value=${value%%[[:space:]]*}
+        value=${value%,}
+        value=${value%\}}
+        value=${value%,}
+        [[ $value == "$channel" ]] ||
+          fail "$rel:$lineno sets toolchain: $value, expected $channel"
+      fi
+    done < <(grep -nE '(^|[[:space:],{])toolchain:[[:space:]]' "$file" || true)
+
+    # 3. The verified release environment variable.
+    while IFS=: read -r lineno text; do
+      value=$(trim "${text#*ZUULI_RUST_VERSION:}")
+      value=${value#\"}
+      value=${value%\"}
+      [[ $value == "$channel" ]] ||
+        fail "$rel:$lineno declares ZUULI_RUST_VERSION: $value, expected $channel"
+    done < <(grep -nE '^[[:space:]]*ZUULI_RUST_VERSION:' "$file" || true)
+  done
+
+  # The release jobs grep the installed compiler against this variable. If a
+  # workflow stops declaring it, the safety net is gone and the check must say so.
+  for rel in "${RUST_VERSION_ENV_WORKFLOWS[@]}"; do
+    if [[ ! -f "$root/$rel" ]]; then
+      fail "$rel is missing"
+      continue
+    fi
+    grep -qE "^[[:space:]]*ZUULI_RUST_VERSION:[[:space:]]*\"$(quote_re "$channel")\"[[:space:]]*$" "$root/$rel" ||
+      fail "$rel does not declare ZUULI_RUST_VERSION: \"$channel\""
+  done
+
+  (( refs > 0 )) ||
+    fail "no dtolnay/rust-toolchain steps matched; this check has gone blind"
+  (( inputs > 0 )) ||
+    fail "no 'toolchain:' inputs matched; this check has gone blind"
+
+  if (( floating > 0 )); then
+    printf 'note: %d rust-toolchain step(s) intentionally float on a moving ref (upstream canaries).\n' \
+      "$floating"
+  fi
+}
+
+check_manifests() {
+  local root=$1 channel=$2 msrv=$3
+  local rel line value
+
+  for rel in "${MANIFESTS[@]}"; do
+    if [[ ! -f "$root/$rel" ]]; then
+      fail "$rel is missing"
+      continue
+    fi
+    line=$(grep -E '^[[:space:]]*rust-version[[:space:]]*=' "$root/$rel" || true)
+    if [[ -z $line ]]; then
+      fail "$rel does not declare rust-version"
+      continue
+    fi
+    value=$(sed -nE 's/^[[:space:]]*rust-version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' <<<"$line")
+    [[ $value == "$msrv" ]] ||
+      fail "$rel declares rust-version = \"$value\", expected \"$msrv\" (the MSRV form of channel $channel)"
+  done
+}
+
+check_docs() {
+  local root=$1 channel=$2 msrv=$3
+  local entry rel needle
+
+  for entry in "${DOC_PINS[@]}"; do
+    rel=${entry%%$'\t'*}
+    needle=${entry#*$'\t'}
+    needle=${needle//%CHANNEL%/$channel}
+    needle=${needle//%MSRV%/$msrv}
+    if [[ ! -f "$root/$rel" ]]; then
+      fail "$rel is missing"
+      continue
+    fi
+    grep -qF -- "$needle" "$root/$rel" ||
+      fail "$rel no longer says: $needle"
+  done
+}
+
+run_checks() {
+  local root=$1 channel msrv
+
+  errors=0
+  channel=$(read_channel "$root") || return 1
+  msrv=${channel%.*}
+
+  check_workflows "$root" "$channel"
+  check_manifests "$root" "$channel" "$msrv"
+  check_docs "$root" "$channel" "$msrv"
+
+  if (( errors > 0 )); then
+    printf '%d pin(s) disagree with %s (channel %s, MSRV %s).\n' \
+      "$errors" "$TOOLCHAIN_FILE" "$channel" "$msrv" >&2
+    return 1
+  fi
+
+  printf 'Every Rust toolchain pin agrees with %s: channel %s, MSRV %s.\n' \
+    "$TOOLCHAIN_FILE" "$channel" "$msrv"
+}
+
+# --- self-test ---------------------------------------------------------------
+#
+# Copies the files this check reads into a scratch tree, confirms the untouched
+# copy passes, then breaks one pin at a time and confirms each break is caught.
+# A check that cannot be shown to fail is not a check.
+
+SELF_TEST_MUTATIONS=(
+  $'a commit-pinned action loses its version comment\t.github/workflows/zuuli-packaging.yml\ts| # %CHANNEL%||'
+  $'a workflow declares a stale ZUULI_RUST_VERSION\t.github/workflows/zuuli-packaging.yml\ts|ZUULI_RUST_VERSION: "%CHANNEL%"|ZUULI_RUST_VERSION: "%BOGUS%"|'
+  $'a version-branch action ref drifts\t.github/workflows/zuuallet.yml\ts|rust-toolchain@%CHANNEL%|rust-toolchain@%BOGUS%|'
+  $'the required gate stops reading the source of truth\t.github/workflows/zuuli.yml\ts|steps.rust_toolchain.outputs.version|steps.somewhere_else.outputs.version|'
+  $'a crate manifest MSRV drifts\twallet/zuuli/src-tauri/Cargo.toml\ts|rust-version = "%MSRV%"|rust-version = "%BOGUS_MSRV%"|'
+  $'documentation still names the old version\twallet/plugins/tauri-plugin-zcash/README.md\ts|MSRV\\*\\*: %MSRV%|MSRV**: %BOGUS_MSRV%|'
+  $'only the source of truth is bumped and nothing follows\twallet/rust-toolchain.toml\ts|channel = "%CHANNEL%"|channel = "%BOGUS%"|'
+)
+
+staged_paths() {
+  local entry file
+  printf '%s\n' "$TOOLCHAIN_FILE"
+  printf '%s\n' "${MANIFESTS[@]}"
+  for entry in "${DOC_PINS[@]}"; do
+    printf '%s\n' "${entry%%$'\t'*}"
+  done
+  shopt -s nullglob
+  for file in "$REPO_ROOT"/.github/workflows/*.yml; do
+    printf '.github/workflows/%s\n' "$(basename "$file")"
+  done
+  shopt -u nullglob
+}
+
+stage_tree() {
+  local dest=$1 rel
+  while IFS= read -r rel; do
+    [[ -e "$dest/$rel" ]] && continue
+    mkdir -p "$dest/$(dirname "$rel")"
+    cp "$REPO_ROOT/$rel" "$dest/$rel"
+  done < <(staged_paths)
+}
+
+apply_sed() {
+  local file=$1 script=$2 scratch
+  scratch=$(mktemp)
+  sed "$script" "$file" >"$scratch"
+  cat "$scratch" >"$file"
+  rm -f "$scratch"
+}
+
+SELF_TEST_SCRATCH=
+
+cleanup_self_test() {
+  [[ -n $SELF_TEST_SCRATCH ]] && rm -rf "$SELF_TEST_SCRATCH"
+  return 0
+}
+
+self_test() {
+  local scratch channel msrv bogus bogus_msrv
+  local mutation description rel script staged before after
+  local failures=0
+
+  SELF_TEST_SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/rust-toolchain-check.XXXXXX")
+  scratch=$SELF_TEST_SCRATCH
+  trap cleanup_self_test EXIT
+
+  stage_tree "$scratch/baseline"
+  if ! run_checks "$scratch/baseline" >/dev/null; then
+    printf 'self-test FAILED: the unmodified tree must pass the drift check.\n' >&2
+    return 1
+  fi
+  printf 'self-test: the unmodified tree passes.\n'
+
+  channel=$(read_channel "$scratch/baseline")
+  msrv=${channel%.*}
+  bogus=9.99.9
+  bogus_msrv=9.99
+
+  local index=0
+  for mutation in "${SELF_TEST_MUTATIONS[@]}"; do
+    index=$((index + 1))
+    IFS=$'\t' read -r description rel script <<<"$mutation"
+    script=${script//%CHANNEL%/$channel}
+    script=${script//%MSRV%/$msrv}
+    script=${script//%BOGUS_MSRV%/$bogus_msrv}
+    script=${script//%BOGUS%/$bogus}
+
+    staged="$scratch/mutation-$index"
+    stage_tree "$staged"
+    before=$(cat "$staged/$rel")
+    apply_sed "$staged/$rel" "$script"
+    after=$(cat "$staged/$rel")
+
+    if [[ $before == "$after" ]]; then
+      printf 'self-test FAILED: mutation %d (%s) changed nothing; the case no longer applies.\n' \
+        "$index" "$description" >&2
+      failures=$((failures + 1))
+      continue
+    fi
+
+    if run_checks "$staged" >/dev/null 2>&1; then
+      printf 'self-test FAILED: drift went undetected when %s.\n' "$description" >&2
+      failures=$((failures + 1))
+      continue
+    fi
+    printf 'self-test: caught drift when %s.\n' "$description"
+  done
+
+  if (( failures > 0 )); then
+    printf '%d self-test case(s) failed.\n' "$failures" >&2
+    return 1
+  fi
+  printf 'self-test: %d drift case(s) caught.\n' "${#SELF_TEST_MUTATIONS[@]}"
+}
+
+usage() {
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+}
+
+main() {
+  case "${1-}" in
+    "")
+      run_checks "$REPO_ROOT"
+      ;;
+    --print-channel)
+      read_channel "$REPO_ROOT"
+      ;;
+    --print-msrv)
+      local channel
+      channel=$(read_channel "$REPO_ROOT")
+      printf '%s\n' "${channel%.*}"
+      ;;
+    --self-test)
+      self_test
+      ;;
+    -h | --help)
+      usage
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage >&2
+      return 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/wallet/rust-toolchain.toml
+++ b/wallet/rust-toolchain.toml
@@ -1,3 +1,12 @@
+# The single source of truth for the Rust toolchain this repository builds with.
+#
+# Every other pin — CI workflow inputs, the commit-pinned dtolnay/rust-toolchain
+# refs, ZUULI_RUST_VERSION, each crate's `rust-version`, and the documentation
+# that quotes them — restates the `channel` below and is verified against it by
+# `scripts/check-rust-toolchain.sh`, which runs on every pull request.
+#
+# Bumping: change `channel` here, then run `scripts/check-rust-toolchain.sh` and
+# fix everything it names. See "The Rust toolchain pin" in the root AGENTS.md.
 [toolchain]
 channel = "1.88.0"
 profile = "minimal"


### PR DESCRIPTION
## The version is UNCHANGED at `1.88.0`

Nothing in this PR moves the Rust toolchain. Every `1.88.0` / `1.88` in the tree
still says `1.88.0` / `1.88`. This is purely the deduplication half of #338 —
one source of truth plus a check that fails on drift. **The bump stays open**;
it is an owner-gated decision that moves every mobile and desktop release target
at once.

## What changed

`wallet/rust-toolchain.toml` is now the only place the version is decided, and
its `channel` grew a header saying so.

**The required `wallet/zuuli` gate now holds no literal at all.** Its two Rust
jobs read the channel out of the file and feed it to the toolchain action:

```yaml
- name: Resolve the pinned Rust toolchain
  id: rust_toolchain
  run: |
    version=$(scripts/check-rust-toolchain.sh --print-channel)
    echo "version=$version" >> "$GITHUB_OUTPUT"

- uses: dtolnay/rust-toolchain@stable
  with:
    toolchain: ${{ steps.rust_toolchain.outputs.version }}
```

The seven `toolchain: 1.88.0` literals in `zuuli-packaging.yml` and
`zuuli-release.yml` became `${{ env.ZUULI_RUST_VERSION }}`, which those workflows
already declare and already verify at runtime.

Counting honestly, rather than claiming a number that sounds better than it is:

| | before | after |
|---|---|---|
| version literals in the required `zuuli.yml` gate | 2 | **0** — it reads the file |
| `toolchain:` literals in packaging + release | 7 | **0** |
| `ZUULI_RUST_VERSION` declarations | 2 | 2 (see below) |
| version-branch action refs (`uses:` cannot take an expression) | 1 | 1 |
| commit-pinned SHAs that silently *are* the version | 7, unlabelled | 7, each labelled `# 1.88.0` |
| **restatements verified against a source of truth** | **0 of them** | **all of them** |

The point is not the count. Before this PR, twelve version literals and seven
invisible SHA pins agreed only by luck and by whoever last edited them. Now
nothing restates the version without CI proving it still matches.

## A finding worth reading: the SHA *is* the pin

`zuuli-packaging.yml` and `zuuli-release.yml` pin
`dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b`. That commit is
the tip of the action's `1.88.0` branch, and on the version branches the action

- **hardcodes** `toolchain: 1.88.0` in `action.yml`, and
- **does not declare a `toolchain` input at all**.

So the commit-pinned SHA selects the compiler entirely on its own, and the
`toolchain:` sitting beside it has been inert (and emitting "Unexpected input(s)"
warnings) all along. It was effectively a *twelfth*, undocumented pin — the one
place a bumper would be most likely to miss, in the two workflows where missing
it costs the most.

That is now recorded where it can be checked:

```yaml
- uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
```

The `# <version>` comment is the only human- and machine-readable record of what
the SHA installs, and the drift check requires it to match the source of truth.
The inert input was kept (pointed at the verified env var) rather than deleted,
because deleting it is a behavioural claim about workflows that cannot be
exercised from a PR; it costs nothing to leave, and the comment now carries the
truth.

## What the check covers

`scripts/check-rust-toolchain.sh` parses `channel` from
`wallet/rust-toolchain.toml` and asserts:

| Pin | Rule |
|---|---|
| `rust-version` in the 3 crate manifests | equals the **two-component MSRV floor** (`1.88`) of the three-component channel (`1.88.0`) — compared as the different forms they are, not forced equal |
| `ZUULI_RUST_VERSION` in packaging + release | equals the channel, and is still declared in both (the release jobs' `rustc --version \| grep -F` safety net depends on it) |
| every `dtolnay/rust-toolchain@<sha>` | carries a `# <version>` comment equal to the channel |
| every `dtolnay/rust-toolchain@<version>` | equals the channel |
| every `toolchain:` input | equals the channel, or is one of two expressions that provably lead back to the file — anything else is rejected rather than trusted |
| MSRV / `cargo +<version>` prose in 2 READMEs, the plugin `CLAUDE.md`, `wallet/zuuli/docs/releasing.md`, and `AGENTS.md` | says exactly what it should |

Plus blindness guards: if the patterns ever stop matching any
`dtolnay/rust-toolchain` step or any `toolchain:` input, the check fails rather
than passing vacuously. The two deliberately-floating `@stable` steps in
`zuuallet.yml` (the reference-wallet build and the upstream canary) are reported,
not failed.

## Demonstration: fails on drift, passes on the tree as merged

Passing, unmodified:

```
$ scripts/check-rust-toolchain.sh
note: 2 rust-toolchain step(s) intentionally float on a moving ref (upstream canaries).
Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.88.0, MSRV 1.88.
$ echo $?
0
```

Failing, after changing **one** literal
(`ZUULI_RUST_VERSION: "1.88.0"` → `"1.90.0"` in `zuuli-packaging.yml`):

```
$ scripts/check-rust-toolchain.sh
drift: .github/workflows/zuuli-packaging.yml:52 declares ZUULI_RUST_VERSION: 1.90.0, expected 1.88.0
drift: .github/workflows/zuuli-packaging.yml does not declare ZUULI_RUST_VERSION: "1.88.0"
2 pin(s) disagree with wallet/rust-toolchain.toml (channel 1.88.0, MSRV 1.88).
$ echo $?
1
```

Failing, after bumping **only** the source of truth to `1.89.0` — this is the
one-line-bump case, and the check turns it into a worklist:

```
drift: .github/workflows/zuuallet.yml:145 uses dtolnay/rust-toolchain@1.88.0, expected @1.89.0
drift: .github/workflows/zuuli-packaging.yml:121 pins dtolnay/rust-toolchain by commit commented '# 1.88.0', expected '# 1.89.0'
drift: .github/workflows/zuuli-packaging.yml:215 pins dtolnay/rust-toolchain by commit commented '# 1.88.0', expected '# 1.89.0'
drift: .github/workflows/zuuli-packaging.yml:314 pins dtolnay/rust-toolchain by commit commented '# 1.88.0', expected '# 1.89.0'
drift: .github/workflows/zuuli-packaging.yml:52 declares ZUULI_RUST_VERSION: 1.88.0, expected 1.89.0
drift: .github/workflows/zuuli-release.yml:221 pins dtolnay/rust-toolchain by commit commented '# 1.88.0', expected '# 1.89.0'
drift: .github/workflows/zuuli-release.yml:368 pins dtolnay/rust-toolchain by commit commented '# 1.88.0', expected '# 1.89.0'
drift: .github/workflows/zuuli-release.yml:584 pins dtolnay/rust-toolchain by commit commented '# 1.88.0', expected '# 1.89.0'
drift: .github/workflows/zuuli-release.yml:681 pins dtolnay/rust-toolchain by commit commented '# 1.88.0', expected '# 1.89.0'
drift: .github/workflows/zuuli-release.yml:45 declares ZUULI_RUST_VERSION: 1.88.0, expected 1.89.0
drift: wallet/zuuli/src-tauri/Cargo.toml declares rust-version = "1.88", expected "1.89" (the MSRV form of channel 1.89.0)
drift: wallet/zuuallet/src-tauri/Cargo.toml declares rust-version = "1.88", expected "1.89" (the MSRV form of channel 1.89.0)
drift: wallet/plugins/tauri-plugin-zcash/Cargo.toml declares rust-version = "1.88", expected "1.89" (the MSRV form of channel 1.89.0)
drift: wallet/zuuallet/README.md no longer says: - [Rust](https://rustup.rs/) 1.89+ (edition 2024)
drift: wallet/plugins/tauri-plugin-zcash/README.md no longer says: cargo +1.89.0 check --locked
...
21 pin(s) disagree with wallet/rust-toolchain.toml (channel 1.89.0, MSRV 1.89).
```

(Both mutations were reverted; the branch is the passing tree.)

### The check is itself checked

`--self-test` stages the files into a scratch tree, confirms the untouched copy
passes, then breaks one pin at a time and confirms each break is caught. A check
nobody has seen fail is not a check. CI runs it before trusting the verdict:

```
$ scripts/check-rust-toolchain.sh --self-test
self-test: the unmodified tree passes.
self-test: caught drift when a commit-pinned action loses its version comment.
self-test: caught drift when a workflow declares a stale ZUULI_RUST_VERSION.
self-test: caught drift when a version-branch action ref drifts.
self-test: caught drift when the required gate stops reading the source of truth.
self-test: caught drift when a crate manifest MSRV drifts.
self-test: caught drift when documentation still names the old version.
self-test: caught drift when only the source of truth is bumped and nothing follows.
self-test: 7 drift case(s) caught.
```

Each case also asserts its own mutation actually changed the file, so a future
refactor cannot silently turn a case into a no-op.

## Wiring, and what was deliberately left alone

The check runs as a step in `zuuli.yml`'s `changes` job — the only job that runs
on **every** event. `changes` is already in `gate`'s `needs`, so drift fails the
required check without touching `gate`'s `needs:` or its `results` logic, and
without touching the `changes` path filters. All three were left byte-identical
on purpose: a toolchain pin can drift from a workflow the filters intentionally
skip, so the check had to live somewhere unconditional.

Also unchanged: the two floating `@stable` steps in `zuuallet.yml` (pinning the
reference wallet or the canary is a separate call), and the release workflows'
`rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "` verification, which is
kept as the last line of defence.

`ZUULI_RUST_VERSION` is still declared twice. GitHub cannot compute a
workflow-level `env:` from a file, and both workflows' Rust cache keys interpolate
it before any job step runs, so sourcing it once would mean restructuring every
job onto a new `needs:` dependency — real risk to the release path for no gain
now that the two declarations are held to the source of truth by CI. The
rationale is recorded in a comment beside each declaration.

## Policy

`AGENTS.md` gains a "The Rust toolchain pin" section: where the version lives, a
table of every restatement and *why* it cannot read the file, the bump procedure
(change one line, run the check, fix exactly what it names), and — proposed, not
enacted — a cadence of **stable minus one or two releases, reviewed quarterly,
with a named owner**, noting the current pin is ~14 months old. The current-pin
sentence is itself covered by the drift check, so it cannot rot.

## Verification

- `scripts/check-rust-toolchain.sh` and `--self-test` pass on this branch.
- All 8 workflows parse (`yaml.safe_load`); `gate.needs` is unchanged.
- Every rewritten `toolchain:` value parses to the intended expression, including
  the two flow-mapping styles in `zuuli-release.yml`.
- `wallet/zuuli/scripts/verify-ci-cache-policy.mjs` still passes.
- Script is bash 3.2 compatible (verified on `/bin/bash` 3.2.57) and committed `0755`.

Refs #338 — the version bump itself remains open there.
