### PR TITLE
ci(rust): enforce cargo fmt

### DIFF
--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -21,6 +21,7 @@ on:
       - 'wallet/plugins/tauri-plugin-zcash/**'
       - 'z/zcash/librustzcash'
       - '.gitmodules'
+      - 'scripts/check-rust-fmt.sh'
       - '.github/workflows/zuuallet.yml'
   push:
     branches: [main]
@@ -29,6 +30,7 @@ on:
       - 'wallet/plugins/tauri-plugin-zcash/**'
       - 'z/zcash/librustzcash'
       - '.gitmodules'
+      - 'scripts/check-rust-fmt.sh'
       - '.github/workflows/zuuallet.yml'
   workflow_dispatch:
   schedule:
@@ -44,6 +46,36 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Formatting. The required `gate` lives in zuuli.yml and its change detector
+  # does not select wallet/zuuallet/**, so a Zuuallet-only pull request would
+  # otherwise be able to land unformatted code — and then fail the next
+  # unrelated ZUULI pull request on files it never touched. Same script, so the
+  # two workflows cannot disagree about what "formatted" means.
+  # ---------------------------------------------------------------------------
+  fmt:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve the pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          set -euo pipefail
+          version=$(scripts/check-rust-toolchain.sh --print-channel)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # rustfmt is absent from the minimal profile this action installs.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
+          components: rustfmt
+
+      - name: Check formatting of every Rust crate under wallet/
+        run: scripts/check-rust-fmt.sh
+
   # ---------------------------------------------------------------------------
   # Frontend: TypeScript typecheck + production bundle.
   # ---------------------------------------------------------------------------

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -71,7 +71,7 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|scripts/check-rust-fmt.sh|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*)
                 zuuli=true
                 ;;
             esac
@@ -124,6 +124,43 @@ jobs:
 
       - name: Build production frontend
         run: npm run build
+
+  # Formatting is its own job rather than a step on rust_plugin/rust_app, which
+  # are 45-minute builds. `cargo fmt` reads manifests with
+  # `cargo metadata --no-deps`, so it resolves no dependency graph and compiles
+  # nothing: no submodule fetch, no Tauri system packages, no Cargo cache. The
+  # verdict lands in about a minute instead of behind a cold Zcash build, and a
+  # formatting failure no longer costs a full rebuild to re-check.
+  #
+  # It covers every crate under wallet/, including wallet/zuuallet/src-tauri,
+  # which this workflow's change filter does not select on its own; a
+  # Zuuallet-only pull request is covered by the matching job in zuuallet.yml.
+  rust_fmt:
+    name: Rust / formatting
+    needs: changes
+    if: needs.changes.outputs.zuuli == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve the pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          set -euo pipefail
+          version=$(scripts/check-rust-toolchain.sh --print-channel)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # rustfmt is not in the minimal profile this action installs, and its
+      # output differs between compiler versions — the pinned toolchain is what
+      # makes the verdict reproducible, so the check refuses to run on any other.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
+          components: rustfmt
+
+      - name: Check formatting of every Rust crate under wallet/
+        run: scripts/check-rust-fmt.sh
 
   rust_plugin:
     name: Rust / shared plugin
@@ -231,7 +268,7 @@ jobs:
   # change detector and every applicable full-stack job succeeded; legitimate
   # non-ZUULI skips continue to report success instead of remaining pending.
   gate:
-    needs: [changes, frontend, rust_plugin, rust_app]
+    needs: [changes, frontend, rust_fmt, rust_plugin, rust_app]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -241,6 +278,7 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           ZUULI_CHANGED: ${{ needs.changes.outputs.zuuli }}
           FRONTEND_RESULT: ${{ needs.frontend.result }}
+          RUST_FMT_RESULT: ${{ needs.rust_fmt.result }}
           RUST_PLUGIN_RESULT: ${{ needs.rust_plugin.result }}
           RUST_APP_RESULT: ${{ needs.rust_app.result }}
         run: |
@@ -249,7 +287,9 @@ jobs:
             echo "Change detection did not pass: $CHANGES_RESULT"; exit 1;
           }
 
-          results="$FRONTEND_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"
+          # Every job in `needs:` above must appear here as well; a job that is
+          # awaited but not inspected makes the gate decorative for that job.
+          results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"
           echo "ZUULI changed: $ZUULI_CHANGED; job results: $results"
           case "$ZUULI_CHANGED" in
             true) expected=success ;;

--- a/scripts/check-rust-fmt.sh
+++ b/scripts/check-rust-fmt.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Prove every Rust crate under wallet/ is formatted the way the pinned rustfmt
+# formats it.
+#
+# rustfmt's output is *not* stable across compiler versions: the same file
+# formatted by 1.88.0 and by a newer stable can differ, and a check that runs on
+# whatever compiler happens to be installed reports version skew as if it were a
+# formatting mistake. So this script renders a verdict only on the toolchain
+# named by wallet/rust-toolchain.toml — it runs cargo from the directory that
+# holds that file, so rustup selects the pin, and it refuses to continue if the
+# compiler that answers is a different one.
+#
+# Crates are discovered rather than listed. A new crate under wallet/ is gated
+# from its first commit, which is the cheapest moment and never gets cheaper.
+#
+# `cargo fmt` reads the manifest with `cargo metadata --no-deps`, which does not
+# resolve the dependency graph, so this runs without the z/ submodules checked
+# out and without compiling anything.
+#
+# Usage:
+#   scripts/check-rust-fmt.sh          fail on any unformatted file
+#   scripts/check-rust-fmt.sh --fix    rewrite the offending files in place
+
+set -euo pipefail
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+# The directory holding rust-toolchain.toml. Cargo is invoked from here so
+# rustup's toolchain selection — which keys off the working directory, not the
+# --manifest-path — lands on the pinned channel.
+RUST_ROOT=$REPO_ROOT/wallet
+TOOLCHAIN_FILE=$RUST_ROOT/rust-toolchain.toml
+
+mode=check
+case "${1-}" in
+  "") ;;
+  --fix) mode=fix ;;
+  -h | --help)
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+    exit 0
+    ;;
+  *)
+    printf 'unknown argument: %s\n' "$1" >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -f $TOOLCHAIN_FILE ]]; then
+  printf 'wallet/rust-toolchain.toml is missing; it decides which rustfmt this check trusts.\n' >&2
+  exit 1
+fi
+
+channel=$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' "$TOOLCHAIN_FILE")
+if [[ ! $channel =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  printf 'channel in wallet/rust-toolchain.toml must be a three-component version, got "%s".\n' \
+    "$channel" >&2
+  exit 1
+fi
+
+cd "$RUST_ROOT"
+
+installed=$(rustc --version)
+if [[ $installed != "rustc $channel "* ]]; then
+  printf 'refusing to judge formatting: wallet/rust-toolchain.toml pins %s but `rustc --version` says "%s".\n' \
+    "$channel" "$installed" >&2
+  printf 'rustfmt output differs between compiler versions, so this run could only produce a misleading verdict.\n' >&2
+  exit 1
+fi
+
+# Tracked, buildable crates only: target/ holds vendored and generated
+# manifests, node_modules/ holds npm packages that ship Rust sources.
+manifests=()
+while IFS= read -r manifest; do
+  manifests+=("${manifest#./}")
+done < <(
+  find . -name Cargo.toml \
+    -not -path './target/*' \
+    -not -path '*/target/*' \
+    -not -path '*/node_modules/*' |
+    LC_ALL=C sort
+)
+
+if [[ ${#manifests[@]} -eq 0 ]]; then
+  printf 'no Cargo manifests found under wallet/; this check has gone blind.\n' >&2
+  exit 1
+fi
+
+failed=()
+for manifest in "${manifests[@]}"; do
+  crate=$(dirname "$manifest")
+  if [[ $mode == fix ]]; then
+    printf '==> formatting wallet/%s\n' "$crate"
+    cargo fmt --all --manifest-path "$manifest"
+    continue
+  fi
+
+  printf '==> checking wallet/%s\n' "$crate"
+  if cargo fmt --all --check --manifest-path "$manifest"; then
+    continue
+  fi
+  failed+=("wallet/$crate")
+done
+
+if [[ $mode == fix ]]; then
+  printf 'Formatted %d crate(s) with rustfmt from the pinned %s toolchain.\n' \
+    "${#manifests[@]}" "$channel"
+  exit 0
+fi
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+  printf '\n%d crate(s) are not formatted: %s\n' "${#failed[@]}" "${failed[*]}" >&2
+  printf 'Run `scripts/check-rust-fmt.sh --fix` and commit the result; do not hand-edit.\n' >&2
+  exit 1
+fi
+
+printf 'All %d Rust crate(s) under wallet/ are formatted (rustfmt from %s).\n' \
+  "${#manifests[@]}" "$channel"

--- a/wallet/plugins/tauri-plugin-zcash/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/commands.rs
@@ -1,14 +1,16 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use tauri::{command, AppHandle, Runtime};
+use tauri::{AppHandle, Runtime, command};
 
 use secrecy::ExposeSecret;
-use zeroize::Zeroizing;
-use zcash_client_backend::data_api::{Account, AccountBirthday, BirthdayError, WalletRead, WalletWrite};
 use zcash_client_backend::data_api::wallet::ConfirmationsPolicy;
+use zcash_client_backend::data_api::{
+    Account, AccountBirthday, BirthdayError, WalletRead, WalletWrite,
+};
 use zcash_client_backend::proto::service::BlockId;
 use zcash_keys::keys::UnifiedAddressRequest;
+use zeroize::Zeroizing;
 
 use crate::error::Error;
 use crate::models::*;
@@ -189,9 +191,7 @@ fn commit_wallet_deletion(
             }
         })?;
 
-    Ok(CommittedWalletDeletion {
-        was_active,
-    })
+    Ok(CommittedWalletDeletion { was_active })
 }
 
 pub(crate) async fn run_wallet_cleanup_retry(
@@ -209,9 +209,7 @@ pub(crate) async fn run_wallet_cleanup_retry(
         Ok(Ok(report)) => WalletCleanupStatus::from(report),
         Ok(Err(error)) => {
             tracing::error!("wallet cleanup retry could not update its journal: {error}");
-            WalletCleanupStatus::from(crate::wallet::cleanup::CleanupReport::journal_error(
-                error,
-            ))
+            WalletCleanupStatus::from(crate::wallet::cleanup::CleanupReport::journal_error(error))
         }
         Err(error) => {
             tracing::error!("wallet cleanup retry task failed: {error}");
@@ -231,11 +229,8 @@ pub(crate) async fn run_wallet_cleanup_retry(
 pub(crate) async fn resume_wallet_cleanup_after_setup<R: Runtime>(app: AppHandle<R>) {
     let zcash = app.zcash();
     let _transition_guard = zcash.state.lock_wallet_transition().await;
-    let status = run_wallet_cleanup_retry(
-        &zcash.state,
-        crate::wallet::cleanup::RetryMode::Runtime,
-    )
-    .await;
+    let status =
+        run_wallet_cleanup_retry(&zcash.state, crate::wallet::cleanup::RetryMode::Runtime).await;
     if status.pending_operations > 0 || status.blocked_operations > 0 {
         tracing::warn!(
             pending = status.pending_operations,
@@ -746,9 +741,7 @@ pub(crate) async fn restore_wallet<R: Runtime>(
 }
 
 #[command]
-pub(crate) async fn get_wallet_status<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<WalletStatus> {
+pub(crate) async fn get_wallet_status<R: Runtime>(app: AppHandle<R>) -> Result<WalletStatus> {
     let zcash = app.zcash();
     let _transition_guard = zcash.state.lock_wallet_transition().await;
     let initialized = zcash.state.is_initialized().await;
@@ -764,7 +757,11 @@ pub(crate) async fn get_wallet_status<R: Runtime>(
     let (synced_height, chain_tip) = if initialized {
         let db_guard = zcash.state.read_db.lock().await;
         if let Some(db) = db_guard.as_ref() {
-            let height = db.chain_height().ok().flatten().map(|h| u64::from(u32::from(h)));
+            let height = db
+                .chain_height()
+                .ok()
+                .flatten()
+                .map(|h| u64::from(u32::from(h)));
             (height, None)
         } else {
             (None, None)
@@ -797,20 +794,17 @@ pub(crate) async fn retry_wallet_cleanup<R: Runtime>(
     let _transition_guard = Arc::clone(&zcash.state.wallet_transition)
         .lock_owned()
         .await;
-    Ok(run_wallet_cleanup_retry(
-        &zcash.state,
-        crate::wallet::cleanup::RetryMode::Runtime,
-    )
-    .await)
+    Ok(run_wallet_cleanup_retry(&zcash.state, crate::wallet::cleanup::RetryMode::Runtime).await)
 }
 
 #[command]
-pub(crate) async fn get_seed_phrase<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<String> {
+pub(crate) async fn get_seed_phrase<R: Runtime>(app: AppHandle<R>) -> Result<String> {
     let zcash = app.zcash();
     let transition_guard = zcash.state.lock_wallet_transition().await;
-    let wallet_id = zcash.state.active_wallet_id().await
+    let wallet_id = zcash
+        .state
+        .active_wallet_id()
+        .await
         .ok_or(Error::WalletNotInitialized)?;
     zcash
         .state
@@ -859,14 +853,19 @@ pub(crate) async fn unlock_wallet<R: Runtime>(
 
     let db_guard = zcash.state.read_db.lock().await;
     let db = db_guard.as_ref().ok_or(Error::WalletNotInitialized)?;
-    let account_ids = db.get_account_ids()
+    let account_ids = db
+        .get_account_ids()
         .map_err(|e| Error::DatabaseError(format!("{e}")))?;
-    let account_id = account_ids.first().copied()
+    let account_id = account_ids
+        .first()
+        .copied()
         .ok_or(Error::AddressError("no accounts in wallet".into()))?;
-    let account = db.get_account(account_id)
+    let account = db
+        .get_account(account_id)
         .map_err(|e| Error::DatabaseError(format!("{e}")))?
         .ok_or(Error::AddressError("account not found".into()))?;
-    let stored_ufvk = account.ufvk()
+    let stored_ufvk = account
+        .ufvk()
         .ok_or(Error::KeyError("wallet has no viewing key".into()))?;
     drop(db_guard);
 
@@ -876,13 +875,11 @@ pub(crate) async fn unlock_wallet<R: Runtime>(
     if derived_encoded != stored_encoded {
         let derived_prefix = &derived_encoded[..derived_encoded.len().min(20)];
         let stored_prefix = &stored_encoded[..stored_encoded.len().min(20)];
-        return Err(Error::KeyError(
-            format!(
-                "seed phrase does not match this wallet. \
+        return Err(Error::KeyError(format!(
+            "seed phrase does not match this wallet. \
                  Derived UFVK starts with: {derived_prefix}... \
                  Stored UFVK starts with: {stored_prefix}..."
-            ),
-        ));
+        )));
     }
 
     // Store in platform-native custody only.
@@ -928,7 +925,8 @@ pub(crate) async fn get_viewing_key<R: Runtime>(
         .map_err(|e| Error::DatabaseError(format!("failed to get account: {e}")))?
         .ok_or(Error::AddressError("account not found".into()))?;
 
-    let ufvk = account.ufvk()
+    let ufvk = account
+        .ufvk()
         .ok_or(Error::KeyError("no unified full viewing key".into()))?;
 
     Ok(ufvk.encode(&zcash.state.network))
@@ -946,39 +944,47 @@ pub(crate) async fn get_spending_key<R: Runtime>(
 
     // Now try to use the seed
     let seed_guard = zcash.state.seed.lock().await;
-    let seed = seed_guard.as_ref()
-        .ok_or(Error::KeyError("seed not available — re-enter your recovery phrase in Settings".into()))?;
+    let seed = seed_guard.as_ref().ok_or(Error::KeyError(
+        "seed not available — re-enter your recovery phrase in Settings".into(),
+    ))?;
 
     // Verify we can derive a spending key (proves spending authority)
-    let _usk = keys::derive_usk(seed.expose_secret(), &zcash.state.network, args.account_index)?;
+    let _usk = keys::derive_usk(
+        seed.expose_secret(),
+        &zcash.state.network,
+        args.account_index,
+    )?;
 
     // Return status — we intentionally don't expose raw spending key bytes.
     // The seed phrase IS the spending authority. Anyone with the seed can spend.
     Ok(SpendingKeyStatus {
         account_index: args.account_index,
         available: true,
-        message: "Spending authority verified. Your seed phrase grants full spending access.".into(),
+        message: "Spending authority verified. Your seed phrase grants full spending access."
+            .into(),
     })
 }
 
 // --- Multi-wallet commands ---
 
 #[command]
-pub(crate) async fn list_wallets<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<Vec<WalletInfo>> {
+pub(crate) async fn list_wallets<R: Runtime>(app: AppHandle<R>) -> Result<Vec<WalletInfo>> {
     let zcash = app.zcash();
     let _transition_guard = zcash.state.lock_wallet_transition().await;
     let manifest = zcash.state.manifest.lock().await;
     let active_id = manifest.active_wallet_id.clone();
 
-    Ok(manifest.wallets.iter().map(|w| WalletInfo {
-        id: w.id.clone(),
-        name: w.name.clone(),
-        is_active: active_id.as_deref() == Some(&w.id),
-        birthday_height: w.birthday_height,
-        created_at: w.created_at.clone(),
-    }).collect())
+    Ok(manifest
+        .wallets
+        .iter()
+        .map(|w| WalletInfo {
+            id: w.id.clone(),
+            name: w.name.clone(),
+            is_active: active_id.as_deref() == Some(&w.id),
+            birthday_height: w.birthday_height,
+            created_at: w.created_at.clone(),
+        })
+        .collect())
 }
 
 #[command]
@@ -1004,11 +1010,8 @@ pub(crate) async fn switch_wallet<R: Runtime>(
             .cloned()
             .ok_or_else(|| Error::Other("wallet not found".into()))?
     };
-    let (new_db, new_read_db) = open_wallet_context(
-        &zcash.state.data_dir,
-        &wallet_entry,
-        zcash.state.network,
-    )?;
+    let (new_db, new_read_db) =
+        open_wallet_context(&zcash.state.data_dir, &wallet_entry, zcash.state.network)?;
 
     // Stop and join sync so it cannot retain or mutate the previous write DB
     // while the new context is installed. Until the manifest commits, every
@@ -1016,59 +1019,62 @@ pub(crate) async fn switch_wallet<R: Runtime>(
     let mut sync_recovery = StoppedSyncRecovery::stop(app.clone()).await;
 
     let result = async {
-    // Hold every context slot while committing the active selection. There is
-    // no await between the durable manifest mutation and the in-memory swap.
-    let mut db_guard = zcash.state.db.lock().await;
-    let mut read_db_guard = zcash.state.read_db.lock().await;
-    let mut seed_guard = zcash.state.seed.lock().await;
-    let mut pending_proposal_guard = zcash.state.pending_proposal.lock().await;
-    let mut pending_broadcast_guard = zcash.state.pending_broadcast.lock().await;
-    let activation = {
-        let mut manifest = zcash.state.manifest.lock().await;
-        manifest.set_active(&zcash.state.data_dir, &args.wallet_id)
-    };
-    let activated = match activation {
-        Ok(activated) => activated,
-        Err(error) => {
+        // Hold every context slot while committing the active selection. There is
+        // no await between the durable manifest mutation and the in-memory swap.
+        let mut db_guard = zcash.state.db.lock().await;
+        let mut read_db_guard = zcash.state.read_db.lock().await;
+        let mut seed_guard = zcash.state.seed.lock().await;
+        let mut pending_proposal_guard = zcash.state.pending_proposal.lock().await;
+        let mut pending_broadcast_guard = zcash.state.pending_broadcast.lock().await;
+        let activation = {
+            let mut manifest = zcash.state.manifest.lock().await;
+            manifest.set_active(&zcash.state.data_dir, &args.wallet_id)
+        };
+        let activated = match activation {
+            Ok(activated) => activated,
+            Err(error) => {
+                drop(pending_broadcast_guard);
+                drop(pending_proposal_guard);
+                drop(seed_guard);
+                drop(read_db_guard);
+                drop(db_guard);
+                return Err(Error::DatabaseError(format!(
+                    "failed to persist active wallet: {error}"
+                )));
+            }
+        };
+        if !activated {
             drop(pending_broadcast_guard);
             drop(pending_proposal_guard);
             drop(seed_guard);
             drop(read_db_guard);
             drop(db_guard);
-            return Err(Error::DatabaseError(format!(
-                "failed to persist active wallet: {error}"
-            )));
+            return Err(Error::Other("wallet not found".into()));
         }
-    };
-    if !activated {
-        drop(pending_broadcast_guard);
-        drop(pending_proposal_guard);
-        drop(seed_guard);
-        drop(read_db_guard);
-        drop(db_guard);
-        return Err(Error::Other("wallet not found".into()));
-    }
-    *db_guard = Some(new_db);
+        *db_guard = Some(new_db);
         *read_db_guard = Some(new_read_db);
         *seed_guard = None;
         // From here forward the manifest and all live context slots refer to
         // the target. Cancellation must not restart the predecessor.
         sync_recovery.commit();
         drop(seed_guard);
-    drop(read_db_guard);
-    drop(db_guard);
+        drop(read_db_guard);
+        drop(db_guard);
 
-    // Only committed transitions invalidate the previous wallet's proposal.
-    *pending_proposal_guard = None;
-    *pending_broadcast_guard =
-        send::load_pending_broadcast(&zcash.state.data_dir, &wallet_entry.id);
-    drop(pending_broadcast_guard);
-    drop(pending_proposal_guard);
+        // Only committed transitions invalidate the previous wallet's proposal.
+        *pending_proposal_guard = None;
+        *pending_broadcast_guard =
+            send::load_pending_broadcast(&zcash.state.data_dir, &wallet_entry.id);
+        drop(pending_broadcast_guard);
+        drop(pending_proposal_guard);
 
-    // Reset chain tip cache
-    zcash.state.last_known_chain_tip.store(0, std::sync::atomic::Ordering::Relaxed);
+        // Reset chain tip cache
+        zcash
+            .state
+            .last_known_chain_tip
+            .store(0, std::sync::atomic::Ordering::Relaxed);
 
-    Ok(())
+        Ok(())
     }
     .await;
 
@@ -1122,153 +1128,156 @@ pub(crate) async fn delete_wallet<R: Runtime>(
     };
 
     let result = async {
-    // Prepare the replacement wallet before committing an active-wallet
-    // deletion. Once the deletion is durable, no later failure may turn the
-    // command into an ambiguous error that invites a destructive retry.
-    let (
-        deletion,
-        prepared_active,
-        mut db_guard,
-        mut read_db_guard,
-        mut seed_guard,
-        mut pending_proposal_guard,
-        mut pending_broadcast_guard,
-    ) = {
-        let mut manifest = zcash.state.manifest.lock().await;
-        let prepared = if manifest.active_wallet_id.as_deref() == Some(&args.wallet_id) {
-            let deletion_pos = manifest
-                .validate_wallet_deletion(&args.wallet_id)
-                .map_err(|e| match e {
-                    crate::wallet::manifest::DeleteWalletError::LastWallet => {
-                        Error::Other("cannot delete the last wallet".into())
-                    }
-                    crate::wallet::manifest::DeleteWalletError::NotFound => {
-                        Error::Other("wallet not found".into())
-                    }
-                    crate::wallet::manifest::DeleteWalletError::Persistence(e) => {
-                        Error::DatabaseError(e)
-                    }
-                })?;
-            let entry = manifest
-                .wallets
-                .iter()
-                .enumerate()
-                .find(|(index, _)| *index != deletion_pos)
-                .map(|(_, entry)| entry)
-                .ok_or_else(|| Error::Other("wallet manifest has no replacement wallet".into()))?
-                .clone();
-            let db_path = zcash.state.data_dir.join(&entry.db_filename);
-            let db = storage::init_wallet_db(&db_path, zcash.state.network)?;
-            let read_db = storage::open_read_db(&db_path, zcash.state.network)?;
-            Some((entry, db, read_db))
-        } else {
-            None
-        };
-        let db_guard = if prepared.is_some() {
-            Some(zcash.state.db.lock().await)
-        } else {
-            None
-        };
-        let read_db_guard = if prepared.is_some() {
-            Some(zcash.state.read_db.lock().await)
-        } else {
-            None
-        };
-        let seed_guard = if prepared.is_some() {
-            Some(zcash.state.seed.lock().await)
-        } else {
-            None
-        };
-        let pending_proposal_guard = if prepared.is_some() {
-            Some(zcash.state.pending_proposal.lock().await)
-        } else {
-            None
-        };
-        let pending_broadcast_guard = if prepared.is_some() {
-            Some(zcash.state.pending_broadcast.lock().await)
-        } else {
-            None
-        };
-        let deletion =
-            commit_wallet_deletion(&mut manifest, &zcash.state.data_dir, &args.wallet_id)?;
-        (
+        // Prepare the replacement wallet before committing an active-wallet
+        // deletion. Once the deletion is durable, no later failure may turn the
+        // command into an ambiguous error that invites a destructive retry.
+        let (
             deletion,
-            prepared,
-            db_guard,
-            read_db_guard,
-            seed_guard,
-            pending_proposal_guard,
-            pending_broadcast_guard,
-        )
-    };
-
-    // If we deleted the active wallet, switch to the new active
-    if deletion.was_active {
-        if let Some((entry, db, read_db)) = prepared_active {
-            **db_guard.as_mut().expect("active deletion holds the write context") = Some(db);
-            **read_db_guard
-                .as_mut()
-                .expect("active deletion holds the read context") = Some(read_db);
-            // Do not prompt while finalizing a destructive transition. The next
-            // explicit spend/reveal action authenticates against native custody.
-            **seed_guard
-                .as_mut()
-                .expect("active deletion holds the seed context") = None;
-            **pending_proposal_guard
-                .as_mut()
-                .expect("active deletion holds the proposal context") = None;
-            **pending_broadcast_guard
-                .as_mut()
-                .expect("active deletion holds the broadcast context") =
-                send::load_pending_broadcast(&zcash.state.data_dir, &entry.id);
-            zcash
-                .state
-                .last_known_chain_tip
-                .store(0, std::sync::atomic::Ordering::Relaxed);
-            if let Some(recovery) = sync_recovery.as_mut() {
-                recovery.commit();
-            }
-            drop(pending_broadcast_guard.take());
-            drop(pending_proposal_guard.take());
-            drop(seed_guard.take());
-            drop(read_db_guard.take());
-            drop(db_guard.take());
-
-            let status = run_wallet_cleanup_retry(
-                &zcash.state,
-                crate::wallet::cleanup::RetryMode::Runtime,
+            prepared_active,
+            mut db_guard,
+            mut read_db_guard,
+            mut seed_guard,
+            mut pending_proposal_guard,
+            mut pending_broadcast_guard,
+        ) = {
+            let mut manifest = zcash.state.manifest.lock().await;
+            let prepared = if manifest.active_wallet_id.as_deref() == Some(&args.wallet_id) {
+                let deletion_pos =
+                    manifest
+                        .validate_wallet_deletion(&args.wallet_id)
+                        .map_err(|e| match e {
+                            crate::wallet::manifest::DeleteWalletError::LastWallet => {
+                                Error::Other("cannot delete the last wallet".into())
+                            }
+                            crate::wallet::manifest::DeleteWalletError::NotFound => {
+                                Error::Other("wallet not found".into())
+                            }
+                            crate::wallet::manifest::DeleteWalletError::Persistence(e) => {
+                                Error::DatabaseError(e)
+                            }
+                        })?;
+                let entry = manifest
+                    .wallets
+                    .iter()
+                    .enumerate()
+                    .find(|(index, _)| *index != deletion_pos)
+                    .map(|(_, entry)| entry)
+                    .ok_or_else(|| {
+                        Error::Other("wallet manifest has no replacement wallet".into())
+                    })?
+                    .clone();
+                let db_path = zcash.state.data_dir.join(&entry.db_filename);
+                let db = storage::init_wallet_db(&db_path, zcash.state.network)?;
+                let read_db = storage::open_read_db(&db_path, zcash.state.network)?;
+                Some((entry, db, read_db))
+            } else {
+                None
+            };
+            let db_guard = if prepared.is_some() {
+                Some(zcash.state.db.lock().await)
+            } else {
+                None
+            };
+            let read_db_guard = if prepared.is_some() {
+                Some(zcash.state.read_db.lock().await)
+            } else {
+                None
+            };
+            let seed_guard = if prepared.is_some() {
+                Some(zcash.state.seed.lock().await)
+            } else {
+                None
+            };
+            let pending_proposal_guard = if prepared.is_some() {
+                Some(zcash.state.pending_proposal.lock().await)
+            } else {
+                None
+            };
+            let pending_broadcast_guard = if prepared.is_some() {
+                Some(zcash.state.pending_broadcast.lock().await)
+            } else {
+                None
+            };
+            let deletion =
+                commit_wallet_deletion(&mut manifest, &zcash.state.data_dir, &args.wallet_id)?;
+            (
+                deletion,
+                prepared,
+                db_guard,
+                read_db_guard,
+                seed_guard,
+                pending_proposal_guard,
+                pending_broadcast_guard,
             )
-            .await;
-            if status.pending_operations > 0 {
-                tracing::warn!(
-                    pending = status.pending_operations,
-                    diagnostics = ?status.diagnostics,
-                    "wallet deletion committed; cleanup remains durably scheduled"
-                );
+        };
+
+        // If we deleted the active wallet, switch to the new active
+        if deletion.was_active {
+            if let Some((entry, db, read_db)) = prepared_active {
+                **db_guard
+                    .as_mut()
+                    .expect("active deletion holds the write context") = Some(db);
+                **read_db_guard
+                    .as_mut()
+                    .expect("active deletion holds the read context") = Some(read_db);
+                // Do not prompt while finalizing a destructive transition. The next
+                // explicit spend/reveal action authenticates against native custody.
+                **seed_guard
+                    .as_mut()
+                    .expect("active deletion holds the seed context") = None;
+                **pending_proposal_guard
+                    .as_mut()
+                    .expect("active deletion holds the proposal context") = None;
+                **pending_broadcast_guard
+                    .as_mut()
+                    .expect("active deletion holds the broadcast context") =
+                    send::load_pending_broadcast(&zcash.state.data_dir, &entry.id);
+                zcash
+                    .state
+                    .last_known_chain_tip
+                    .store(0, std::sync::atomic::Ordering::Relaxed);
+                if let Some(recovery) = sync_recovery.as_mut() {
+                    recovery.commit();
+                }
+                drop(pending_broadcast_guard.take());
+                drop(pending_proposal_guard.take());
+                drop(seed_guard.take());
+                drop(read_db_guard.take());
+                drop(db_guard.take());
+
+                let status = run_wallet_cleanup_retry(
+                    &zcash.state,
+                    crate::wallet::cleanup::RetryMode::Runtime,
+                )
+                .await;
+                if status.pending_operations > 0 {
+                    tracing::warn!(
+                        pending = status.pending_operations,
+                        diagnostics = ?status.diagnostics,
+                        "wallet deletion committed; cleanup remains durably scheduled"
+                    );
+                }
+                return Ok(());
             }
-            return Ok(());
         }
-    }
 
-    // Previously the seed was deleted before the manifest check, so rejecting
-    // deletion of the last wallet destroyed its recovery data. Cleanup now
-    // requires a confirmed-durable manifest replacement and happens only after
-    // active DB handles have been swapped. It is best-effort because returning
-    // an error after commit would invite an ambiguous destructive retry.
-    let status = run_wallet_cleanup_retry(
-        &zcash.state,
-        crate::wallet::cleanup::RetryMode::Runtime,
-    )
-    .await;
-    if status.pending_operations > 0 {
-        tracing::warn!(
-            pending = status.pending_operations,
-            diagnostics = ?status.diagnostics,
-            "wallet deletion committed; cleanup remains durably scheduled"
-        );
-    }
+        // Previously the seed was deleted before the manifest check, so rejecting
+        // deletion of the last wallet destroyed its recovery data. Cleanup now
+        // requires a confirmed-durable manifest replacement and happens only after
+        // active DB handles have been swapped. It is best-effort because returning
+        // an error after commit would invite an ambiguous destructive retry.
+        let status =
+            run_wallet_cleanup_retry(&zcash.state, crate::wallet::cleanup::RetryMode::Runtime)
+                .await;
+        if status.pending_operations > 0 {
+            tracing::warn!(
+                pending = status.pending_operations,
+                diagnostics = ?status.diagnostics,
+                "wallet deletion committed; cleanup remains durably scheduled"
+            );
+        }
 
-    Ok(())
+        Ok(())
     }
     .await;
 
@@ -1342,12 +1351,9 @@ mod sync_recovery_tests {
         });
 
         assert!(
-            tokio::time::timeout(
-                std::time::Duration::from_millis(25),
-                &mut completed_rx,
-            )
-            .await
-            .is_err(),
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut completed_rx,)
+                .await
+                .is_err(),
             "drop recovery must not pass the live transition"
         );
         drop(transition_guard);
@@ -1483,7 +1489,10 @@ mod deletion_tests {
             .expect("deletion should commit");
         assert!(deletion.was_active);
         assert_eq!(manifest.active_wallet_id, Some(second.id.clone()));
-        assert!(first_db.exists(), "commit must not consume database cleanup");
+        assert!(
+            first_db.exists(),
+            "commit must not consume database cleanup"
+        );
         assert!(first_wal.exists(), "commit must not consume WAL cleanup");
         assert!(first_shm.exists(), "commit must not consume SHM cleanup");
         assert!(seed_sentinel(&data_dir, &first.id).exists());
@@ -1516,14 +1525,19 @@ mod deletion_tests {
         // preparation fail before the active selection can be committed.
         std::fs::create_dir(data_dir.join(&target.db_filename))
             .expect("create invalid target database path");
-        assert!(open_wallet_context(
-            &data_dir,
-            &target,
-            zcash_protocol::consensus::Network::MainNetwork,
-        )
-        .is_err());
+        assert!(
+            open_wallet_context(
+                &data_dir,
+                &target,
+                zcash_protocol::consensus::Network::MainNetwork,
+            )
+            .is_err()
+        );
 
-        assert_eq!(manifest.active_wallet_id.as_deref(), Some(active.id.as_str()));
+        assert_eq!(
+            manifest.active_wallet_id.as_deref(),
+            Some(active.id.as_str())
+        );
         let persisted = WalletManifest::load(&data_dir).expect("load active manifest");
         assert_eq!(
             persisted.active_wallet_id.as_deref(),
@@ -1569,18 +1583,14 @@ mod deletion_tests {
 // --- Existing commands ---
 
 #[command]
-pub(crate) async fn create_account<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<AccountInfo> {
+pub(crate) async fn create_account<R: Runtime>(app: AppHandle<R>) -> Result<AccountInfo> {
     let zcash = app.zcash();
     let _transition_guard = zcash.state.lock_wallet_transition().await;
     crate::wallet::accounts::create_account(&zcash.state).await
 }
 
 #[command]
-pub(crate) async fn list_accounts<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<Vec<AccountInfo>> {
+pub(crate) async fn list_accounts<R: Runtime>(app: AppHandle<R>) -> Result<Vec<AccountInfo>> {
     let zcash = app.zcash();
     let _transition_guard = zcash.state.lock_wallet_transition().await;
     crate::wallet::accounts::list_accounts(&zcash.state).await
@@ -1695,27 +1705,21 @@ pub(crate) async fn get_unified_address<R: Runtime>(
 }
 
 #[command]
-pub(crate) async fn start_sync<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<()> {
+pub(crate) async fn start_sync<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     let zcash = app.zcash();
     let _transition_guard = zcash.state.lock_wallet_transition().await;
     crate::wallet::sync::start_sync(app.clone(), &zcash.state).await
 }
 
 #[command]
-pub(crate) async fn stop_sync<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<()> {
+pub(crate) async fn stop_sync<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     let zcash = app.zcash();
     let _transition_guard = zcash.state.lock_wallet_transition().await;
     crate::wallet::sync::stop_sync(&zcash.state).await
 }
 
 #[command]
-pub(crate) async fn get_sync_status<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<SyncStatus> {
+pub(crate) async fn get_sync_status<R: Runtime>(app: AppHandle<R>) -> Result<SyncStatus> {
     let zcash = app.zcash();
     crate::wallet::sync::get_sync_status(&zcash.state).await
 }
@@ -1735,13 +1739,8 @@ pub(crate) async fn propose_send<R: Runtime>(
 ) -> Result<SendProposal> {
     let zcash = app.zcash();
     let _transition_guard = zcash.state.lock_wallet_transition().await;
-    crate::wallet::send::propose_send(
-        &zcash.state,
-        &args.to,
-        args.amount,
-        args.memo.as_deref(),
-    )
-    .await
+    crate::wallet::send::propose_send(&zcash.state, &args.to, args.amount, args.memo.as_deref())
+        .await
 }
 
 #[command]
@@ -1751,12 +1750,7 @@ pub(crate) async fn propose_send_all<R: Runtime>(
 ) -> Result<SendProposal> {
     let zcash = app.zcash();
     let _transition_guard = zcash.state.lock_wallet_transition().await;
-    crate::wallet::send::propose_send_all(
-        &zcash.state,
-        &args.to,
-        args.memo.as_deref(),
-    )
-    .await
+    crate::wallet::send::propose_send_all(&zcash.state, &args.to, args.memo.as_deref()).await
 }
 
 #[command]
@@ -1780,9 +1774,7 @@ pub(crate) async fn get_pending_send<R: Runtime>(
 }
 
 #[command]
-pub(crate) async fn retry_pending_send<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<ExecuteSendResult> {
+pub(crate) async fn retry_pending_send<R: Runtime>(app: AppHandle<R>) -> Result<ExecuteSendResult> {
     let zcash = app.zcash();
     let _transition_guard = zcash.state.lock_wallet_transition().await;
     crate::wallet::send::retry_pending_send(&zcash.state).await
@@ -1897,11 +1889,7 @@ pub(crate) async fn sign_challenge<R: Runtime>(
         "seed not available — re-enter your recovery phrase in Settings".into(),
     ))?;
 
-    let signed = keys::sign_challenge(
-        seed.expose_secret(),
-        args.account_index,
-        &args.challenge,
-    )?;
+    let signed = keys::sign_challenge(seed.expose_secret(), args.account_index, &args.challenge)?;
     drop(seed_guard);
 
     Ok(SignedChallenge {

--- a/wallet/plugins/tauri-plugin-zcash/src/error.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/error.rs
@@ -1,4 +1,4 @@
-use serde::{ser::Serializer, Serialize};
+use serde::{Serialize, ser::Serializer};
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/wallet/plugins/tauri-plugin-zcash/src/lib.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/lib.rs
@@ -1,6 +1,6 @@
 use tauri::{
-    plugin::{Builder, TauriPlugin},
     Manager, Runtime,
+    plugin::{Builder, TauriPlugin},
 };
 
 pub use models::*;

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/accounts.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/accounts.rs
@@ -24,9 +24,7 @@ pub async fn create_account(state: &WalletState) -> Result<AccountInfo> {
         .ok_or(Error::Other("seed not available in session".into()))?;
 
     let mut db_guard = state.db.lock().await;
-    let db = db_guard
-        .as_mut()
-        .ok_or(Error::WalletNotInitialized)?;
+    let db = db_guard.as_mut().ok_or(Error::WalletNotInitialized)?;
 
     // We need a birthday for the new account - use the existing wallet birthday
     let _birthday_height = db
@@ -63,8 +61,15 @@ pub async fn create_account(state: &WalletState) -> Result<AccountInfo> {
         .map_err(|e| Error::NetworkError(format!("failed to get tree state: {e}")))?
         .into_inner();
 
-    let birthday = zcash_client_backend::data_api::AccountBirthday::from_treestate(tree_state, None)
-        .map_err(|e| Error::DatabaseError(format!("failed to create birthday: {}", format_birthday_error(e))))?;
+    let birthday = zcash_client_backend::data_api::AccountBirthday::from_treestate(
+        tree_state, None,
+    )
+    .map_err(|e| {
+        Error::DatabaseError(format!(
+            "failed to create birthday: {}",
+            format_birthday_error(e)
+        ))
+    })?;
 
     let seed_guard = state.seed.lock().await;
     let seed = seed_guard
@@ -72,9 +77,7 @@ pub async fn create_account(state: &WalletState) -> Result<AccountInfo> {
         .ok_or(Error::Other("seed not available in session".into()))?;
 
     let mut db_guard = state.db.lock().await;
-    let db = db_guard
-        .as_mut()
-        .ok_or(Error::WalletNotInitialized)?;
+    let db = db_guard.as_mut().ok_or(Error::WalletNotInitialized)?;
 
     let account_count = db
         .get_account_ids()
@@ -107,9 +110,7 @@ pub async fn list_accounts(state: &WalletState) -> Result<Vec<AccountInfo>> {
     }
 
     let db_guard = state.read_db.lock().await;
-    let db = db_guard
-        .as_ref()
-        .ok_or(Error::WalletNotInitialized)?;
+    let db = db_guard.as_ref().ok_or(Error::WalletNotInitialized)?;
 
     let account_ids = db
         .get_account_ids()
@@ -121,7 +122,9 @@ pub async fn list_accounts(state: &WalletState) -> Result<Vec<AccountInfo>> {
             .get_account(*account_id)
             .map_err(|e| Error::DatabaseError(format!("{e}")))?;
 
-        let name = account.as_ref().and_then(|a| a.name().map(|n| n.to_string()));
+        let name = account
+            .as_ref()
+            .and_then(|a| a.name().map(|n| n.to_string()));
 
         let ua_request = UnifiedAddressRequest::AllAvailableKeys;
         let addr = db

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/cache.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/cache.rs
@@ -79,7 +79,10 @@ impl BlockCache for MemBlockCache {
         })
     }
 
-    async fn read(&self, range: &ScanRange) -> Result<Vec<CompactBlock>, <Self as BlockSource>::Error> {
+    async fn read(
+        &self,
+        range: &ScanRange,
+    ) -> Result<Vec<CompactBlock>, <Self as BlockSource>::Error> {
         let inner = self.0.read().unwrap();
         Ok(inner
             .range(range.block_range().start..range.block_range().end)
@@ -87,7 +90,10 @@ impl BlockCache for MemBlockCache {
             .collect())
     }
 
-    async fn insert(&self, compact_blocks: Vec<CompactBlock>) -> Result<(), <Self as BlockSource>::Error> {
+    async fn insert(
+        &self,
+        compact_blocks: Vec<CompactBlock>,
+    ) -> Result<(), <Self as BlockSource>::Error> {
         let mut inner = self.0.write().unwrap();
         for block in compact_blocks {
             let height = block.height();

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/cleanup.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/cleanup.rs
@@ -365,7 +365,10 @@ pub(crate) fn recover_published_wallets(
         .filter(|operation| {
             operation.reason == CleanupReason::StagedWalletRollback
                 && operation.preserve_custody_if_manifest_missing
-                && matches!(manifest_binding(manifest, operation), ManifestBinding::Absent)
+                && matches!(
+                    manifest_binding(manifest, operation),
+                    ManifestBinding::Absent
+                )
         })
         .cloned()
         .collect();
@@ -704,11 +707,10 @@ fn execute_stage(
             remove_regular_file(&data_dir.join(format!("{}-journal", operation.db_filename)))
                 .map_err(|e| e.to_string())
         }
-        CleanupStage::PendingSendJournal => super::send::clear_pending_broadcast(
-            data_dir,
-            &operation.wallet_id,
-        )
-        .map_err(|e| e.to_string()),
+        CleanupStage::PendingSendJournal => {
+            super::send::clear_pending_broadcast(data_dir, &operation.wallet_id)
+                .map_err(|e| e.to_string())
+        }
         CleanupStage::LegacyFileCustody => seed_store
             .delete_legacy_file_record(&operation.wallet_id)
             .map_err(|e| e.to_string()),
@@ -1124,16 +1126,12 @@ mod tests {
         assert_eq!(report.pending_stages, 3);
 
         let mut deferred = Vec::new();
-        let report = retry_pending_with(
-            &dir.0,
-            &empty_manifest(),
-            RetryMode::Runtime,
-            |_, stage| {
+        let report =
+            retry_pending_with(&dir.0, &empty_manifest(), RetryMode::Runtime, |_, stage| {
                 deferred.push(stage);
                 Ok(())
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
         assert_eq!(
             deferred,
             vec![
@@ -1193,16 +1191,12 @@ mod tests {
         protect_staged_wallet_custody(&dir.0, &authorization).unwrap();
 
         let mut executed = Vec::new();
-        let report = retry_pending_with(
-            &dir.0,
-            &empty_manifest(),
-            RetryMode::Startup,
-            |_, stage| {
+        let report =
+            retry_pending_with(&dir.0, &empty_manifest(), RetryMode::Startup, |_, stage| {
                 executed.push(stage);
                 Ok(())
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
         assert!(executed.is_empty());
         assert_eq!(report.pending_operations, 1);
         assert_eq!(report.blocked_operations, 1);
@@ -1248,16 +1242,12 @@ mod tests {
         rearm_staged_wallet_custody_cleanup(&dir.0, &authorization).unwrap();
 
         let mut executed = Vec::new();
-        let report = retry_pending_with(
-            &dir.0,
-            &empty_manifest(),
-            RetryMode::Runtime,
-            |_, stage| {
+        let report =
+            retry_pending_with(&dir.0, &empty_manifest(), RetryMode::Runtime, |_, stage| {
                 executed.push(stage);
                 Ok(())
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
         assert_eq!(executed, ALL_STAGES);
         assert_eq!(report.pending_operations, 0);
     }

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/client.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/client.rs
@@ -1,5 +1,5 @@
-use zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
 use tonic::transport::Channel;
+use zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
 
 use crate::error::{Error, Result};
 

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/history.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/history.rs
@@ -84,74 +84,73 @@ pub async fn get_transaction_history(
         .map_err(|e| Error::DatabaseError(format!("failed to prepare history query: {e}")))?;
 
     let rows = stmt
-        .query_map(
-            rusqlite::params![account_uuid, limit, offset],
-            |row| {
-                let txid_blob: Vec<u8> = row.get(0)?;
-                let mined_height: Option<u64> = row.get(1)?;
-                let block_time: Option<i64> = row.get(2)?;
-                let balance_delta: Option<i64> = row.get(3)?;
-                let sent_note_count: i64 = row.get(4)?;
-                let _received_note_count: i64 = row.get(5)?;
-                let memo_blob: Option<Vec<u8>> = row.get(6)?;
+        .query_map(rusqlite::params![account_uuid, limit, offset], |row| {
+            let txid_blob: Vec<u8> = row.get(0)?;
+            let mined_height: Option<u64> = row.get(1)?;
+            let block_time: Option<i64> = row.get(2)?;
+            let balance_delta: Option<i64> = row.get(3)?;
+            let sent_note_count: i64 = row.get(4)?;
+            let _received_note_count: i64 = row.get(5)?;
+            let memo_blob: Option<Vec<u8>> = row.get(6)?;
 
-                // Reverse txid bytes for display (Zcash convention)
-                let mut txid_reversed = txid_blob;
-                txid_reversed.reverse();
-                let txid_hex = txid_reversed
+            // Reverse txid bytes for display (Zcash convention)
+            let mut txid_reversed = txid_blob;
+            txid_reversed.reverse();
+            let txid_hex = txid_reversed
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<String>();
+
+            // Decode memo per ZIP 302:
+            // - First byte 0x00..0xF4: UTF-8 text (trailing nulls are padding)
+            // - First byte 0xF5: arbitrary binary (not displayable)
+            // - First byte 0xF6: empty memo (already filtered in SQL)
+            // - First byte 0xF7..0xFF: future/unknown format
+            // Embedded null bytes (used by some wallets as field separators)
+            // are replaced with newlines for display.
+            let memo = memo_blob.and_then(|bytes| {
+                if bytes.is_empty() {
+                    return None;
+                }
+                // ZIP 302: only first byte 0x00..0xF4 indicates a text memo
+                if bytes[0] > 0xF4 {
+                    return None;
+                }
+                // Strip trailing null padding
+                let end = bytes
                     .iter()
-                    .map(|b| format!("{b:02x}"))
-                    .collect::<String>();
+                    .rposition(|&b| b != 0)
+                    .map(|i| i + 1)
+                    .unwrap_or(0);
+                if end == 0 {
+                    return None;
+                }
+                // Decode as UTF-8, then replace embedded null bytes with newlines
+                // (some wallets like YWallet use \x00 as a field separator between
+                // the reply-to address and message text)
+                String::from_utf8(bytes[..end].to_vec())
+                    .ok()
+                    .map(|s| s.replace('\0', "\n"))
+                    .filter(|s| !s.is_empty())
+            });
 
-                // Decode memo per ZIP 302:
-                // - First byte 0x00..0xF4: UTF-8 text (trailing nulls are padding)
-                // - First byte 0xF5: arbitrary binary (not displayable)
-                // - First byte 0xF6: empty memo (already filtered in SQL)
-                // - First byte 0xF7..0xFF: future/unknown format
-                // Embedded null bytes (used by some wallets as field separators)
-                // are replaced with newlines for display.
-                let memo = memo_blob.and_then(|bytes| {
-                    if bytes.is_empty() {
-                        return None;
-                    }
-                    // ZIP 302: only first byte 0x00..0xF4 indicates a text memo
-                    if bytes[0] > 0xF4 {
-                        return None;
-                    }
-                    // Strip trailing null padding
-                    let end = bytes.iter().rposition(|&b| b != 0).map(|i| i + 1).unwrap_or(0);
-                    if end == 0 {
-                        return None;
-                    }
-                    // Decode as UTF-8, then replace embedded null bytes with newlines
-                    // (some wallets like YWallet use \x00 as a field separator between
-                    // the reply-to address and message text)
-                    String::from_utf8(bytes[..end].to_vec())
-                        .ok()
-                        .map(|s| s.replace('\0', "\n"))
-                        .filter(|s| !s.is_empty())
-                });
+            let delta = balance_delta.unwrap_or(0);
+            let incoming = sent_note_count == 0 && delta > 0;
 
-                let delta = balance_delta.unwrap_or(0);
-                let incoming = sent_note_count == 0 && delta > 0;
-
-                Ok(TransactionEntry {
-                    txid: txid_hex,
-                    block_height: mined_height,
-                    timestamp: block_time,
-                    value: delta,
-                    memo,
-                    incoming,
-                })
-            },
-        )
+            Ok(TransactionEntry {
+                txid: txid_hex,
+                block_height: mined_height,
+                timestamp: block_time,
+                value: delta,
+                memo,
+                incoming,
+            })
+        })
         .map_err(|e| Error::DatabaseError(format!("failed to query history: {e}")))?;
 
     let mut entries = Vec::new();
     for row in rows {
-        entries.push(
-            row.map_err(|e| Error::DatabaseError(format!("failed to read row: {e}")))?,
-        );
+        entries.push(row.map_err(|e| Error::DatabaseError(format!("failed to read row: {e}")))?);
     }
 
     Ok(entries)

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/keys.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/keys.rs
@@ -18,17 +18,18 @@ pub fn generate_mnemonic(word_count: u32) -> Result<Mnemonic> {
         18 => Count::Words18,
         21 => Count::Words21,
         24 => Count::Words24,
-        _ => return Err(Error::InvalidMnemonic(
-            format!("unsupported word count: {word_count}; use 12, 15, 18, 21, or 24"),
-        )),
+        _ => {
+            return Err(Error::InvalidMnemonic(format!(
+                "unsupported word count: {word_count}; use 12, 15, 18, 21, or 24"
+            )));
+        }
     };
     Ok(Mnemonic::generate(count))
 }
 
 /// Parse an existing mnemonic phrase.
 pub fn parse_mnemonic(phrase: &str) -> Result<Mnemonic> {
-    Mnemonic::from_phrase(phrase)
-        .map_err(|e| Error::InvalidMnemonic(e.to_string()))
+    Mnemonic::from_phrase(phrase).map_err(|e| Error::InvalidMnemonic(e.to_string()))
 }
 
 /// Derive a seed from a mnemonic.
@@ -332,8 +333,8 @@ mod tests {
             (31..=34).contains(&header),
             "header {header} out of compressed range 31..=34"
         );
-        let recovery_id = RecoveryId::from_i32(((header - 27) & 0x03) as i32)
-            .expect("valid recovery id");
+        let recovery_id =
+            RecoveryId::from_i32(((header - 27) & 0x03) as i32).expect("valid recovery id");
         let compressed_flag = (header - 27) & 0x04 != 0;
         assert!(compressed_flag, "header must mark a compressed pubkey");
 
@@ -370,7 +371,10 @@ mod tests {
 
         // Determinism: signing again yields the identical signature.
         let again = sign_challenge(&seed, 0, challenge).expect("signing must succeed");
-        assert_eq!(again.signature, signed.signature, "signing must be deterministic");
+        assert_eq!(
+            again.signature, signed.signature,
+            "signing must be deterministic"
+        );
         assert_eq!(again.address, signed.address);
         assert_eq!(again.pubkey, signed.pubkey);
     }

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
@@ -1,7 +1,7 @@
 pub mod accounts;
 pub mod cache;
-pub mod client;
 pub mod cleanup;
+pub mod client;
 pub mod history;
 pub mod keychain;
 pub mod keys;
@@ -10,14 +10,14 @@ pub mod send;
 pub mod storage;
 pub mod sync;
 
+use secrecy::SecretVec;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64};
-use secrecy::SecretVec;
 use tokio::sync::{Mutex, MutexGuard, RwLock};
-use zeroize::Zeroizing;
 use zcash_client_backend::data_api::{Account, WalletRead};
 use zcash_protocol::consensus::Network;
+use zeroize::Zeroizing;
 
 /// Type alias for a cached transaction proposal.
 pub type WalletProposal = zcash_client_backend::proposal::Proposal<
@@ -26,8 +26,12 @@ pub type WalletProposal = zcash_client_backend::proposal::Proposal<
 >;
 
 /// Type alias for our concrete WalletDb.
-pub type WalletDatabase =
-    zcash_client_sqlite::WalletDb<rusqlite::Connection, Network, zcash_client_sqlite::util::SystemClock, rand::rngs::OsRng>;
+pub type WalletDatabase = zcash_client_sqlite::WalletDb<
+    rusqlite::Connection,
+    Network,
+    zcash_client_sqlite::util::SystemClock,
+    rand::rngs::OsRng,
+>;
 
 /// Proof that an identity-sensitive operation owns the wallet transition.
 /// Custody retrieval requires this token so a future caller cannot accidentally
@@ -108,9 +112,9 @@ impl WalletState {
                 }
                 Err(error) => {
                     tracing::error!("wallet cleanup startup retry failed: {error}");
-                    crate::models::WalletCleanupStatus::from(
-                        cleanup::CleanupReport::journal_error(error),
-                    )
+                    crate::models::WalletCleanupStatus::from(cleanup::CleanupReport::journal_error(
+                        error,
+                    ))
                 }
             },
             Err(error) => {
@@ -162,9 +166,7 @@ impl WalletState {
             // restart; commands load it lazily after an explicit user action.
             seed: Arc::new(Mutex::new(None)),
             seed_store,
-            lightwalletd_url: RwLock::new(
-                "https://zec.rocks:443".to_string(),
-            ),
+            lightwalletd_url: RwLock::new("https://zec.rocks:443".to_string()),
             sync_supervisor: Arc::new(sync::SyncTaskSupervisor::default()),
             syncing: Arc::new(RwLock::new(false)),
             last_known_chain_tip: Arc::new(AtomicU64::new(0)),
@@ -212,7 +214,9 @@ impl WalletState {
         let phrase = Zeroizing::new(phrase.to_owned());
         tokio::task::spawn_blocking(move || store.store_seed_phrase(&wallet_id, phrase.as_str()))
             .await
-            .map_err(|error| crate::error::Error::KeyError(format!("secure-storage task panicked: {error}")))?
+            .map_err(|error| {
+                crate::error::Error::KeyError(format!("secure-storage task panicked: {error}"))
+            })?
     }
 
     /// Retrieve and, when necessary, migrate a seed only after proving that its
@@ -241,12 +245,20 @@ impl WalletState {
                         .map_err(|error| crate::error::Error::DatabaseError(error.to_string()))?
                         .first()
                         .copied()
-                        .ok_or_else(|| crate::error::Error::KeyError("wallet has no account to validate seed migration".into()))?;
+                        .ok_or_else(|| {
+                            crate::error::Error::KeyError(
+                                "wallet has no account to validate seed migration".into(),
+                            )
+                        })?;
                     Some(
                         db.get_account(account_id)
                             .map_err(|error| crate::error::Error::DatabaseError(error.to_string()))?
                             .and_then(|account| account.ufvk().cloned())
-                            .ok_or_else(|| crate::error::Error::KeyError("wallet has no viewing key to validate seed migration".into()))?
+                            .ok_or_else(|| {
+                                crate::error::Error::KeyError(
+                                    "wallet has no viewing key to validate seed migration".into(),
+                                )
+                            })?
                             .encode(&self.network),
                     )
                 }
@@ -262,13 +274,10 @@ impl WalletState {
                 store.get_seed_phrase_validated(&wallet_id, |phrase| {
                     let mnemonic = keys::parse_mnemonic(phrase)?;
                     let seed = keys::mnemonic_to_seed(&mnemonic);
-                    let derived = keys::derive_usk(
-                        secrecy::ExposeSecret::expose_secret(&seed),
-                        &network,
-                        0,
-                    )?
-                    .to_unified_full_viewing_key()
-                    .encode(&network);
+                    let derived =
+                        keys::derive_usk(secrecy::ExposeSecret::expose_secret(&seed), &network, 0)?
+                            .to_unified_full_viewing_key()
+                            .encode(&network);
                     if derived == expected_ufvk {
                         Ok(())
                     } else {
@@ -286,7 +295,9 @@ impl WalletState {
             }
         })
         .await
-        .map_err(|error| crate::error::Error::KeyError(format!("secure-storage task panicked: {error}")))?
+        .map_err(|error| {
+            crate::error::Error::KeyError(format!("secure-storage task panicked: {error}"))
+        })?
     }
 
     pub async fn delete_seed_phrase(&self, wallet_id: &str) -> crate::Result<()> {
@@ -294,6 +305,8 @@ impl WalletState {
         let wallet_id = wallet_id.to_owned();
         tokio::task::spawn_blocking(move || store.delete_seed_phrase(&wallet_id))
             .await
-            .map_err(|error| crate::error::Error::KeyError(format!("secure-storage task panicked: {error}")))?
+            .map_err(|error| {
+                crate::error::Error::KeyError(format!("secure-storage task panicked: {error}"))
+            })?
     }
 }

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
@@ -8,15 +8,14 @@ use std::{
 };
 
 use secrecy::ExposeSecret;
+use zcash_client_backend::data_api::WalletRead;
 use zcash_client_backend::data_api::wallet::{
-    create_proposed_transactions,
+    ConfirmationsPolicy, SpendingKeys, create_proposed_transactions,
     input_selection::{GreedyInputSelector, SpendPolicy},
     propose_transfer,
-    ConfirmationsPolicy, SpendingKeys,
 };
-use zcash_client_backend::data_api::WalletRead;
-use zcash_client_backend::fees::zip317::SingleOutputChangeStrategy;
 use zcash_client_backend::fees::DustOutputPolicy;
+use zcash_client_backend::fees::zip317::SingleOutputChangeStrategy;
 use zcash_client_backend::proto::service::{RawTransaction, TxFilter};
 use zcash_client_backend::wallet::OvkPolicy;
 use zcash_keys::address::Address;
@@ -31,9 +30,9 @@ use crate::models::{
     AddressValidation, BroadcastStatus, ExecuteSendResult, PendingSendStatus, SaplingParamsStatus,
     SendProposal,
 };
+use crate::wallet::WalletState;
 use crate::wallet::client::connect_to_lightwalletd;
 use crate::wallet::keys;
-use crate::wallet::WalletState;
 
 /// A transaction that has already been created in the wallet database.
 /// Retrying this record always rebroadcasts `raw_transaction`; it never signs
@@ -56,8 +55,7 @@ pub struct PendingBroadcast {
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const RPC_TIMEOUT: Duration = Duration::from_secs(30);
-const INTERRUPTED_CREATION_RECOVERY_ERROR: &str =
-    "Transaction creation was interrupted; automatic rebroadcast is unavailable. Inspect wallet history before creating another payment.";
+const INTERRUPTED_CREATION_RECOVERY_ERROR: &str = "Transaction creation was interrupted; automatic rebroadcast is unavailable. Inspect wallet history before creating another payment.";
 // A consensus-valid transaction is far smaller than this even after JSON's
 // integer-array expansion. Bound both allocation and streaming reads so a
 // local malformed journal cannot exhaust process memory during startup.
@@ -120,9 +118,8 @@ fn validate_windows_file_handle(file: &File, label: &str) -> Result<()> {
     let mut information = BY_HANDLE_FILE_INFORMATION::default();
     // SAFETY: the handle is owned by `file` for the duration of this call and
     // `information` points to a correctly-sized writable Win32 structure.
-    let succeeded = unsafe {
-        GetFileInformationByHandle(file.as_raw_handle().cast(), &mut information)
-    };
+    let succeeded =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle().cast(), &mut information) };
     if succeeded == 0 {
         return Err(Error::DatabaseError(format!(
             "pending send {label} link metadata could not be read: {}",
@@ -210,9 +207,7 @@ fn read_recovery_file(path: &Path, label: &str) -> Result<Option<Vec<u8>>> {
     file.take(MAX_PENDING_JOURNAL_BYTES + 1)
         .read_to_end(&mut bytes)
         .map_err(|error| {
-            Error::DatabaseError(format!(
-                "pending send {label} could not be read: {error}"
-            ))
+            Error::DatabaseError(format!("pending send {label} could not be read: {error}"))
         })?;
     if bytes.len() as u64 > MAX_PENDING_JOURNAL_BYTES {
         return Err(Error::DatabaseError(format!(
@@ -231,9 +226,9 @@ impl Drop for TemporaryJournal {
         match std::fs::remove_file(&self.path) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => tracing::warn!(
-                "failed to clean exact pending send temporary file: {error}"
-            ),
+            Err(error) => {
+                tracing::warn!("failed to clean exact pending send temporary file: {error}")
+            }
         }
     }
 }
@@ -279,10 +274,7 @@ fn sync_recovery_directory(data_dir: &Path) -> Result<()> {
         })
 }
 
-pub(crate) fn load_pending_broadcast(
-    data_dir: &Path,
-    wallet_id: &str,
-) -> Option<PendingBroadcast> {
+pub(crate) fn load_pending_broadcast(data_dir: &Path, wallet_id: &str) -> Option<PendingBroadcast> {
     let corrupt = |message: String| PendingBroadcast {
         wallet_id: wallet_id.to_string(),
         proposal_id: 0,
@@ -371,10 +363,14 @@ fn persist_pending_broadcast(data_dir: &Path, record: &PendingBroadcast) -> Resu
     }
     let (mut file, temporary) = create_unique_journal(data_dir, &record.wallet_id)?;
     file.write_all(&bytes).map_err(|error| {
-        Error::DatabaseError(format!("failed to write pending send recovery state: {error}"))
+        Error::DatabaseError(format!(
+            "failed to write pending send recovery state: {error}"
+        ))
     })?;
     file.sync_all().map_err(|error| {
-        Error::DatabaseError(format!("failed to sync pending send recovery state: {error}"))
+        Error::DatabaseError(format!(
+            "failed to sync pending send recovery state: {error}"
+        ))
     })?;
     drop(file);
     #[cfg(windows)]
@@ -414,7 +410,9 @@ fn persist_pending_broadcast(data_dir: &Path, record: &PendingBroadcast) -> Resu
     }
     #[cfg(not(windows))]
     std::fs::rename(&temporary.path, &path).map_err(|error| {
-        Error::DatabaseError(format!("failed to commit pending send recovery state: {error}"))
+        Error::DatabaseError(format!(
+            "failed to commit pending send recovery state: {error}"
+        ))
     })?;
     // On Unix, fsync the directory as well as the file. Without this, a crash
     // after lightwalletd accepts the transaction can lose the directory entry
@@ -701,7 +699,9 @@ pub async fn ensure_sapling_params(state: &WalletState) -> Result<SaplingParamsS
             return Ok(prover);
         }
         zcash_proofs::download_sapling_parameters(Some(300)).map_err(|error| {
-            Error::SendError(format!("failed to download Sapling proving parameters: {error}"))
+            Error::SendError(format!(
+                "failed to download Sapling proving parameters: {error}"
+            ))
         })?;
         LocalTxProver::with_default_location().ok_or_else(|| {
             Error::SendError("Sapling proving parameters were not found after download".into())
@@ -735,26 +735,20 @@ pub async fn propose_send(
     let (recipient, _) = parse_recipient(&state.network, to)?;
 
     // Build the payment request
-    let zatoshis = Zatoshis::from_u64(amount)
-        .map_err(|_| Error::SendError("invalid amount".into()))?;
+    let zatoshis =
+        Zatoshis::from_u64(amount).map_err(|_| Error::SendError("invalid amount".into()))?;
 
     let memo_bytes = match memo {
-        Some(m) => Some(MemoBytes::from(
-            Memo::from_str(m)
-                .map_err(|e| Error::SendError(format!("invalid memo: {e}")))?
-        )),
+        Some(m) => {
+            Some(MemoBytes::from(Memo::from_str(m).map_err(|e| {
+                Error::SendError(format!("invalid memo: {e}"))
+            })?))
+        }
         None => None,
     };
 
-    let payment = zip321::Payment::new(
-        recipient,
-        Some(zatoshis),
-        memo_bytes,
-        None,
-        None,
-        vec![],
-    )
-    .map_err(|e| Error::SendError(format!("failed to create payment: {e:?}")))?;
+    let payment = zip321::Payment::new(recipient, Some(zatoshis), memo_bytes, None, None, vec![])
+        .map_err(|e| Error::SendError(format!("failed to create payment: {e:?}")))?;
 
     let request = zip321::TransactionRequest::new(vec![payment])
         .map_err(|e| Error::SendError(format!("failed to create transaction request: {e:?}")))?;
@@ -781,18 +775,19 @@ pub async fn propose_send(
 
     let policy = ConfirmationsPolicy::default();
 
-    let proposal = propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(
-        db,
-        &state.network,
-        account_id,
-        &input_selector,
-        &change_strategy,
-        request,
-        policy,
-        &SpendPolicy::default(),
-        None,
-    )
-    .map_err(|e| Error::SendError(format!("failed to propose transfer: {e:?}")));
+    let proposal =
+        propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(
+            db,
+            &state.network,
+            account_id,
+            &input_selector,
+            &change_strategy,
+            request,
+            policy,
+            &SpendPolicy::default(),
+            None,
+        )
+        .map_err(|e| Error::SendError(format!("failed to propose transfer: {e:?}")));
 
     drop(db_guard);
 
@@ -892,10 +887,11 @@ pub async fn propose_send_all(
     let (recipient, _) = parse_recipient(&state.network, to)?;
 
     let memo_bytes = match memo {
-        Some(m) => Some(MemoBytes::from(
-            Memo::from_str(m)
-                .map_err(|e| Error::SendError(format!("invalid memo: {e}")))?
-        )),
+        Some(m) => {
+            Some(MemoBytes::from(Memo::from_str(m).map_err(|e| {
+                Error::SendError(format!("invalid memo: {e}"))
+            })?))
+        }
         None => None,
     };
 
@@ -903,8 +899,8 @@ pub async fn propose_send_all(
     let mut amount = spendable - 10000;
 
     for _ in 0..3 {
-        let zatoshis = Zatoshis::from_u64(amount)
-            .map_err(|_| Error::SendError("invalid amount".into()))?;
+        let zatoshis =
+            Zatoshis::from_u64(amount).map_err(|_| Error::SendError("invalid amount".into()))?;
 
         let payment = zip321::Payment::new(
             recipient.clone(),
@@ -916,8 +912,9 @@ pub async fn propose_send_all(
         )
         .map_err(|e| Error::SendError(format!("failed to create payment: {e:?}")))?;
 
-        let request = zip321::TransactionRequest::new(vec![payment])
-            .map_err(|e| Error::SendError(format!("failed to create transaction request: {e:?}")))?;
+        let request = zip321::TransactionRequest::new(vec![payment]).map_err(|e| {
+            Error::SendError(format!("failed to create transaction request: {e:?}"))
+        })?;
 
         let mut db_guard = state.db.lock().await;
         let db = db_guard.as_mut().ok_or(Error::WalletNotInitialized)?;
@@ -940,17 +937,18 @@ pub async fn propose_send_all(
 
         let policy = ConfirmationsPolicy::default();
 
-        let result = propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(
-            db,
-            &state.network,
-            account_id,
-            &input_selector,
-            &change_strategy,
-            request,
-            policy,
-            &SpendPolicy::default(),
-            None,
-        );
+        let result =
+            propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(
+                db,
+                &state.network,
+                account_id,
+                &input_selector,
+                &change_strategy,
+                request,
+                policy,
+                &SpendPolicy::default(),
+                None,
+            );
 
         drop(db_guard);
 
@@ -989,7 +987,8 @@ pub async fn propose_send_all(
                 amount = spendable - actual_fee;
             }
             Err(zcash_client_backend::data_api::error::Error::InsufficientFunds {
-                required, ..
+                required,
+                ..
             }) => {
                 let required_u64 = u64::from(required);
                 let computed_fee = required_u64.saturating_sub(amount);
@@ -997,9 +996,7 @@ pub async fn propose_send_all(
                     amount = spendable - computed_fee;
                     continue;
                 }
-                return Err(Error::SendError(
-                    "insufficient funds to cover fee".into(),
-                ));
+                return Err(Error::SendError("insufficient funds to cover fee".into()));
             }
             Err(e) => {
                 return Err(Error::SendError(format!(
@@ -1009,14 +1006,13 @@ pub async fn propose_send_all(
         }
     }
 
-    Err(Error::SendError("could not converge on send-all amount after retries".into()))
+    Err(Error::SendError(
+        "could not converge on send-all amount after retries".into(),
+    ))
 }
 
 /// Execute a previously-proposed send transaction.
-pub async fn execute_send(
-    state: &WalletState,
-    proposal_id: u32,
-) -> Result<ExecuteSendResult> {
+pub async fn execute_send(state: &WalletState, proposal_id: u32) -> Result<ExecuteSendResult> {
     let _send_operation = state.send_operation.lock().await;
     if !state.is_initialized().await {
         return Err(Error::WalletNotInitialized);
@@ -1062,20 +1058,22 @@ pub async fn execute_send(
     // serialization succeed. A rejected creation can therefore be retried;
     // it never advances into the broadcast state.
     let mut prop_guard = state.pending_proposal.lock().await;
-    let (stored_id, proposal) = prop_guard
-        .as_ref()
-        .ok_or(Error::SendError("no pending proposal — call propose_send first".into()))?;
+    let (stored_id, proposal) = prop_guard.as_ref().ok_or(Error::SendError(
+        "no pending proposal — call propose_send first".into(),
+    ))?;
 
     if *stored_id != proposal_id {
-        return Err(Error::SendError("proposal_id mismatch — stale proposal".into()));
+        return Err(Error::SendError(
+            "proposal_id mismatch — stale proposal".into(),
+        ));
     }
 
     // Derive USK from seed
     let usk = {
         let seed_guard = state.seed.lock().await;
-        let seed = seed_guard
-            .as_ref()
-            .ok_or(Error::Other("seed not available - please restart the wallet".into()))?;
+        let seed = seed_guard.as_ref().ok_or(Error::Other(
+            "seed not available - please restart the wallet".into(),
+        ))?;
         keys::derive_usk(seed.expose_secret(), &state.network, 0)?
     };
 
@@ -1108,7 +1106,14 @@ pub async fn execute_send(
 
     let mut transaction_created = false;
     let created = (|| -> Result<PendingBroadcast> {
-        let txids = create_proposed_transactions::<_, _, std::convert::Infallible, _, std::convert::Infallible, _>(
+        let txids = create_proposed_transactions::<
+            _,
+            _,
+            std::convert::Infallible,
+            _,
+            std::convert::Infallible,
+            _,
+        >(
             db,
             &state.network,
             prover,
@@ -1207,9 +1212,9 @@ pub async fn retry_pending_send(state: &WalletState) -> Result<ExecuteSendResult
         .await
         .ok_or(Error::WalletNotInitialized)?;
     let mut pending = state.pending_broadcast.lock().await;
-    let record = pending.as_mut().ok_or_else(|| {
-        Error::SendError("there is no pending transaction to rebroadcast".into())
-    })?;
+    let record = pending
+        .as_mut()
+        .ok_or_else(|| Error::SendError("there is no pending transaction to rebroadcast".into()))?;
     if record.wallet_id != wallet_id {
         return Err(Error::SendError(
             "pending transaction belongs to a different wallet".into(),
@@ -1245,9 +1250,9 @@ pub async fn discard_unrecoverable_send(
         .await
         .ok_or(Error::WalletNotInitialized)?;
     let mut pending = state.pending_broadcast.lock().await;
-    let record = pending.as_ref().ok_or_else(|| {
-        Error::SendError("there is no unrecoverable pending transaction".into())
-    })?;
+    let record = pending
+        .as_ref()
+        .ok_or_else(|| Error::SendError("there is no unrecoverable pending transaction".into()))?;
     if record.wallet_id != wallet_id || record.proposal_id != proposal_id {
         return Err(Error::SendError(
             "pending transaction does not match the active wallet".into(),
@@ -1297,15 +1302,21 @@ async fn local_pending_state(
     let db = db_guard.as_ref().ok_or(Error::WalletNotInitialized)?;
     if db
         .get_tx_height(txid)
-        .map_err(|error| Error::DatabaseError(format!("failed to read transaction height: {error}")))?
+        .map_err(|error| {
+            Error::DatabaseError(format!("failed to read transaction height: {error}"))
+        })?
         .is_some()
     {
         return Ok(LocalPendingState::Mined);
     }
     let transaction = db
         .get_transaction(txid)
-        .map_err(|error| Error::DatabaseError(format!("failed to read pending transaction: {error}")))?
-        .ok_or_else(|| Error::SendError("pending transaction is missing from the wallet database".into()));
+        .map_err(|error| {
+            Error::DatabaseError(format!("failed to read pending transaction: {error}"))
+        })?
+        .ok_or_else(|| {
+            Error::SendError("pending transaction is missing from the wallet database".into())
+        });
     let transaction = match transaction {
         Ok(transaction) => transaction,
         Err(error) => {
@@ -1329,13 +1340,17 @@ async fn local_pending_state(
     }
     let fully_scanned = db
         .block_fully_scanned()
-        .map_err(|error| Error::DatabaseError(format!("failed to read wallet scan height: {error}")))?
+        .map_err(|error| {
+            Error::DatabaseError(format!("failed to read wallet scan height: {error}"))
+        })?
         .map(|metadata| metadata.block_height());
-    Ok(if fully_scanned.is_some_and(|height| height >= expiry_height) {
-        LocalPendingState::Expired
-    } else {
-        LocalPendingState::Pending
-    })
+    Ok(
+        if fully_scanned.is_some_and(|height| height >= expiry_height) {
+            LocalPendingState::Expired
+        } else {
+            LocalPendingState::Pending
+        },
+    )
 }
 
 fn apply_broadcast_result(
@@ -1409,33 +1424,34 @@ async fn broadcast_record(
     }
 
     let url = state.lightwalletd_url.read().await.clone();
-    let mut client = match tokio::time::timeout(CONNECT_TIMEOUT, connect_to_lightwalletd(&url)).await {
-        Ok(Ok(client)) => client,
-        Ok(Err(error)) => {
-            tracing::warn!("pending send could not connect to lightwalletd: {error}");
-            return Ok(apply_broadcast_result(
-                state,
-                record,
-                classify_broadcast_response(
-                    record.txid.clone(),
-                    record.had_ambiguous_attempt,
-                    None,
-                ),
-            ));
-        }
-        Err(_) => {
-            tracing::warn!("pending send lightwalletd connection timed out");
-            return Ok(apply_broadcast_result(
-                state,
-                record,
-                classify_broadcast_response(
-                    record.txid.clone(),
-                    record.had_ambiguous_attempt,
-                    None,
-                ),
-            ));
-        }
-    };
+    let mut client =
+        match tokio::time::timeout(CONNECT_TIMEOUT, connect_to_lightwalletd(&url)).await {
+            Ok(Ok(client)) => client,
+            Ok(Err(error)) => {
+                tracing::warn!("pending send could not connect to lightwalletd: {error}");
+                return Ok(apply_broadcast_result(
+                    state,
+                    record,
+                    classify_broadcast_response(
+                        record.txid.clone(),
+                        record.had_ambiguous_attempt,
+                        None,
+                    ),
+                ));
+            }
+            Err(_) => {
+                tracing::warn!("pending send lightwalletd connection timed out");
+                return Ok(apply_broadcast_result(
+                    state,
+                    record,
+                    classify_broadcast_response(
+                        record.txid.clone(),
+                        record.had_ambiguous_attempt,
+                        None,
+                    ),
+                ));
+            }
+        };
 
     if record.attempts > 0 {
         let lookup = tokio::time::timeout(
@@ -1475,9 +1491,9 @@ async fn broadcast_record(
                 code = ?status.code(),
                 "pending send txid lookup failed; rebroadcasting identical bytes"
             ),
-            Err(_) => tracing::warn!(
-                "pending send txid lookup timed out; rebroadcasting identical bytes"
-            ),
+            Err(_) => {
+                tracing::warn!("pending send txid lookup timed out; rebroadcasting identical bytes")
+            }
         }
     }
 
@@ -1494,11 +1510,7 @@ async fn broadcast_record(
         return Ok(apply_broadcast_result(
             state,
             record,
-            classify_broadcast_response(
-                record.txid.clone(),
-                record.had_ambiguous_attempt,
-                None,
-            ),
+            classify_broadcast_response(record.txid.clone(), record.had_ambiguous_attempt, None),
         ));
     }
 
@@ -1540,11 +1552,7 @@ async fn broadcast_record(
     Ok(apply_broadcast_result(
         state,
         record,
-        classify_broadcast_response(
-            record.txid.clone(),
-            record.had_ambiguous_attempt,
-            response,
-        ),
+        classify_broadcast_response(record.txid.clone(), record.had_ambiguous_attempt, response),
     ))
 }
 
@@ -1578,7 +1586,11 @@ mod tests {
             Ok(_) => panic!("missing prover must fail closed"),
             Err(error) => error,
         };
-        assert!(error.to_string().contains("proving parameters are not ready"));
+        assert!(
+            error
+                .to_string()
+                .contains("proving parameters are not ready")
+        );
     }
 
     #[test]
@@ -1599,9 +1611,12 @@ mod tests {
     fn tex_is_rejected_until_ordered_batch_recovery_exists() {
         let validation = validate_recipient_address(&Network::MainNetwork, MAINNET_TEX);
         assert!(!validation.valid);
-        assert!(validation.error.as_deref().is_some_and(|message| {
-            message.contains("ordered multi-transaction recovery")
-        }));
+        assert!(
+            validation
+                .error
+                .as_deref()
+                .is_some_and(|message| { message.contains("ordered multi-transaction recovery") })
+        );
     }
 
     #[test]
@@ -1617,8 +1632,7 @@ mod tests {
 
     #[test]
     fn broadcast_success_is_explicit() {
-        let result =
-            classify_broadcast_response("txid".into(), false, Some((0, String::new())));
+        let result = classify_broadcast_response("txid".into(), false, Some((0, String::new())));
         assert_eq!(result.status, BroadcastStatus::Accepted);
         assert_eq!(result.txid, "txid");
         assert_eq!(result.message, None);
@@ -1647,10 +1661,12 @@ mod tests {
         let result = classify_broadcast_response(record.txid.clone(), true, None);
         assert_eq!(result.status, BroadcastStatus::Unknown);
         assert_eq!(record.raw_transaction, original_bytes);
-        assert!(result
-            .message
-            .as_deref()
-            .is_some_and(|message| message.contains("exact transaction")));
+        assert!(
+            result
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("exact transaction"))
+        );
     }
 
     #[test]
@@ -1744,17 +1760,15 @@ mod tests {
 
     #[test]
     fn pending_broadcast_survives_state_reconstruction() {
-        let directory = std::env::temp_dir().join(format!(
-            "zuuli-pending-send-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let directory =
+            std::env::temp_dir().join(format!("zuuli-pending-send-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&directory).expect("create test directory");
         let mut record = pending(BroadcastStatus::Unknown);
         record.attempts = 1;
         persist_pending_broadcast(&directory, &record).expect("persist recovery state");
 
-        let loaded = load_pending_broadcast(&directory, &record.wallet_id)
-            .expect("load recovery state");
+        let loaded =
+            load_pending_broadcast(&directory, &record.wallet_id).expect("load recovery state");
         assert_eq!(loaded.status, BroadcastStatus::Unknown);
         assert_eq!(loaded.attempts, 1);
         assert_eq!(loaded.raw_transaction, record.raw_transaction);
@@ -1806,7 +1820,10 @@ mod tests {
         let record = pending(BroadcastStatus::Unknown);
         persist_pending_broadcast(&directory, &record)
             .expect("unique create-new temporary must bypass stale name");
-        assert_eq!(std::fs::read(&victim).expect("read victim"), b"must not change");
+        assert_eq!(
+            std::fs::read(&victim).expect("read victim"),
+            b"must not change"
+        );
         assert!(
             std::fs::symlink_metadata(&stale)
                 .expect("stale link remains untouched")
@@ -1829,7 +1846,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn linked_stable_and_backup_paths_fail_closed_without_touching_targets() {
-        use std::os::unix::fs::{symlink, PermissionsExt};
+        use std::os::unix::fs::{PermissionsExt, symlink};
 
         let directory = std::env::temp_dir().join(format!(
             "zuuli-pending-send-linked-path-test-{}",
@@ -1841,8 +1858,7 @@ mod tests {
         std::fs::set_permissions(&victim, std::fs::Permissions::from_mode(0o600))
             .expect("secure victim permissions");
         let record = pending(BroadcastStatus::Unknown);
-        let stable = pending_broadcast_path(&directory, &record.wallet_id)
-            .expect("journal path");
+        let stable = pending_broadcast_path(&directory, &record.wallet_id).expect("journal path");
         symlink(&victim, &stable).expect("create stable symlink");
 
         let loaded = load_pending_broadcast(&directory, &record.wallet_id)
@@ -1850,13 +1866,19 @@ mod tests {
         assert!(loaded.recovery_error.is_some());
         assert!(persist_pending_broadcast(&directory, &record).is_err());
         assert!(clear_pending_broadcast(&directory, &record.wallet_id).is_err());
-        assert_eq!(std::fs::read(&victim).expect("read victim"), b"must not change");
+        assert_eq!(
+            std::fs::read(&victim).expect("read victim"),
+            b"must not change"
+        );
         std::fs::remove_file(&stable).expect("remove stable symlink");
 
         let backup = stable.with_extension("json.bak");
         symlink(&victim, &backup).expect("create backup symlink");
         assert!(persist_pending_broadcast(&directory, &record).is_err());
-        assert_eq!(std::fs::read(&victim).expect("read victim"), b"must not change");
+        assert_eq!(
+            std::fs::read(&victim).expect("read victim"),
+            b"must not change"
+        );
         std::fs::remove_file(backup).expect("remove backup symlink");
         std::fs::remove_file(victim).expect("remove victim");
         std::fs::remove_dir(directory).expect("remove test directory");
@@ -1877,8 +1899,7 @@ mod tests {
         std::fs::set_permissions(&victim, std::fs::Permissions::from_mode(0o600))
             .expect("secure victim permissions");
         let record = pending(BroadcastStatus::Unknown);
-        let stable = pending_broadcast_path(&directory, &record.wallet_id)
-            .expect("journal path");
+        let stable = pending_broadcast_path(&directory, &record.wallet_id).expect("journal path");
         std::fs::hard_link(&victim, &stable).expect("create stable hardlink");
 
         let loaded = load_pending_broadcast(&directory, &record.wallet_id)
@@ -1886,7 +1907,10 @@ mod tests {
         assert!(loaded.recovery_error.is_some());
         assert!(persist_pending_broadcast(&directory, &record).is_err());
         assert!(clear_pending_broadcast(&directory, &record.wallet_id).is_err());
-        assert_eq!(std::fs::read(&victim).expect("read victim"), b"must not change");
+        assert_eq!(
+            std::fs::read(&victim).expect("read victim"),
+            b"must not change"
+        );
 
         std::fs::remove_file(stable).expect("remove hardlink");
         std::fs::remove_file(victim).expect("remove victim");
@@ -1901,8 +1925,7 @@ mod tests {
         ));
         std::fs::create_dir_all(&directory).expect("create test directory");
         let wallet_id = "wallet_test";
-        let stable = pending_broadcast_path(&directory, wallet_id)
-            .expect("journal path");
+        let stable = pending_broadcast_path(&directory, wallet_id).expect("journal path");
         let file = OpenOptions::new()
             .write(true)
             .create_new(true)

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs
@@ -352,10 +352,7 @@ pub async fn start_sync<R: Runtime>(app: AppHandle<R>, state: &WalletState) -> R
 /// scan the entire chain from Sapling, and the sync loop's `synced >= tip` check
 /// never fires so it spins forever (issue #180). Everything below the birthday is
 /// not the wallet's to scan, so we floor the scanned height at the birthday.
-async fn read_scanned_height(
-    read_db: &Mutex<Option<WalletDatabase>>,
-    birthday_height: u64,
-) -> u64 {
+async fn read_scanned_height(read_db: &Mutex<Option<WalletDatabase>>, birthday_height: u64) -> u64 {
     let db_guard = read_db.lock().await;
     let scanned = if let Some(db) = db_guard.as_ref() {
         db.block_max_scanned()
@@ -592,8 +589,10 @@ async fn refresh_subtree_roots(
     let (next_sapling, next_orchard, next_ironwood) =
         next_subtree_indices(read_db).await.unwrap_or((0, 0, 0));
 
-    let sapling_roots = fetch_subtree_roots(client, ShieldedProtocol::Sapling, next_sapling).await?;
-    let orchard_roots = fetch_subtree_roots(client, ShieldedProtocol::Orchard, next_orchard).await?;
+    let sapling_roots =
+        fetch_subtree_roots(client, ShieldedProtocol::Sapling, next_sapling).await?;
+    let orchard_roots =
+        fetch_subtree_roots(client, ShieldedProtocol::Orchard, next_orchard).await?;
     // Ironwood note commitments are Orchard-shaped, so the same hash type is
     // used. Servers predating Ironwood activation simply stream nothing; an
     // outright error means the server does not know the pool, which is not fatal.
@@ -985,13 +984,16 @@ async fn sync_task<R: Runtime>(
             // polled `get_sync_status` returns it, and emit for event listeners.
             *last_sync_error.write().await = Some(msg.clone());
             *syncing.write().await = false;
-            let _ = app.emit("zcash://sync-progress", &SyncStatus {
-                syncing: false,
-                synced_height: 0,
-                chain_tip: 0,
-                progress_percent: 0.0,
-                last_error: Some(msg),
-            });
+            let _ = app.emit(
+                "zcash://sync-progress",
+                &SyncStatus {
+                    syncing: false,
+                    synced_height: 0,
+                    chain_tip: 0,
+                    progress_percent: 0.0,
+                    last_error: Some(msg),
+                },
+            );
             return;
         }
     };
@@ -1035,13 +1037,16 @@ async fn sync_task<R: Runtime>(
                 let synced_height = read_scanned_height(&read_db, birthday_height).await;
                 let progress = calc_progress(synced_height, chain_tip, birthday_height);
                 *syncing.write().await = false;
-                let _ = app.emit("zcash://sync-progress", &SyncStatus {
-                    syncing: false,
-                    synced_height,
-                    chain_tip,
-                    progress_percent: progress,
-                    last_error: None,
-                });
+                let _ = app.emit(
+                    "zcash://sync-progress",
+                    &SyncStatus {
+                        syncing: false,
+                        synced_height,
+                        chain_tip,
+                        progress_percent: progress,
+                        last_error: None,
+                    },
+                );
                 return;
             }
             Ok(PassOutcome::Completed { scanned_blocks }) => {
@@ -1080,9 +1085,7 @@ async fn sync_task<R: Runtime>(
                             surfaced = format!("Sync trouble — retrying via {next}");
                         }
                         Err(ce) => {
-                            tracing::error!(
-                                "failed to connect to fallback endpoint {next}: {ce}"
-                            );
+                            tracing::error!("failed to connect to fallback endpoint {next}: {ce}");
                             surfaced =
                                 format!("Can't reach the Zcash network — retrying via {next}");
                         }
@@ -1100,13 +1103,16 @@ async fn sync_task<R: Runtime>(
                 let birthday_height = birthday_opt.unwrap_or(chain_tip);
                 let synced_height = read_scanned_height(&read_db, birthday_height).await;
                 let progress = calc_progress(synced_height, chain_tip, birthday_height);
-                let _ = app.emit("zcash://sync-progress", &SyncStatus {
-                    syncing: true,
-                    synced_height,
-                    chain_tip,
-                    progress_percent: progress,
-                    last_error: Some(surfaced),
-                });
+                let _ = app.emit(
+                    "zcash://sync-progress",
+                    &SyncStatus {
+                        syncing: true,
+                        synced_height,
+                        chain_tip,
+                        progress_percent: progress,
+                        last_error: Some(surfaced),
+                    },
+                );
 
                 0
             }
@@ -1123,13 +1129,16 @@ async fn sync_task<R: Runtime>(
         last_known_chain_tip.store(effective_tip, Ordering::Relaxed);
         let progress = calc_progress(synced_height, effective_tip, birthday_height);
         let last_error = last_sync_error.read().await.clone();
-        let _ = app.emit("zcash://sync-progress", &SyncStatus {
-            syncing: true,
-            synced_height,
-            chain_tip: effective_tip,
-            progress_percent: progress,
-            last_error,
-        });
+        let _ = app.emit(
+            "zcash://sync-progress",
+            &SyncStatus {
+                syncing: true,
+                synced_height,
+                chain_tip: effective_tip,
+                progress_percent: progress,
+                last_error,
+            },
+        );
 
         // Adaptive backoff: snap to the minimum while we still have work to do,
         // back off toward 30s once caught up.
@@ -1154,13 +1163,16 @@ async fn sync_task<R: Runtime>(
     *syncing.write().await = false;
 
     let last_error = last_sync_error.read().await.clone();
-    let _ = app.emit("zcash://sync-progress", &SyncStatus {
-        syncing: false,
-        synced_height,
-        chain_tip,
-        progress_percent: progress,
-        last_error,
-    });
+    let _ = app.emit(
+        "zcash://sync-progress",
+        &SyncStatus {
+            syncing: false,
+            synced_height,
+            chain_tip,
+            progress_percent: progress,
+            last_error,
+        },
+    );
 }
 
 /// Outcome of one full "catch up to the chain tip" pass.
@@ -1295,13 +1307,16 @@ async fn run_pass<R: Runtime>(
         let effective_tip = chain_tip_u64.max(synced_height);
         last_known_chain_tip.store(effective_tip, Ordering::Relaxed);
         let progress = calc_progress(synced_height, effective_tip, birthday_height);
-        let _ = app.emit("zcash://sync-progress", &SyncStatus {
-            syncing: true,
-            synced_height,
-            chain_tip: effective_tip,
-            progress_percent: progress,
-            last_error: None,
-        });
+        let _ = app.emit(
+            "zcash://sync-progress",
+            &SyncStatus {
+                syncing: true,
+                synced_height,
+                chain_tip: effective_tip,
+                progress_percent: progress,
+                last_error: None,
+            },
+        );
         tracing::info!("sync progress: {progress:.1}% ({synced_height}/{effective_tip})");
 
         // Retrieve memos for anything we just detected. This early-returns when
@@ -1531,10 +1546,7 @@ mod supervisor_tests {
     }
 
     impl LiveTask {
-        fn new(
-            live: Arc<AtomicUsize>,
-            dropped: tokio::sync::oneshot::Sender<()>,
-        ) -> Self {
+        fn new(live: Arc<AtomicUsize>, dropped: tokio::sync::oneshot::Sender<()>) -> Self {
             live.fetch_add(1, AtomicOrdering::SeqCst);
             Self {
                 live,
@@ -1612,7 +1624,10 @@ mod supervisor_tests {
         tokio::task::yield_now().await;
         stop.abort();
         assert!(stop.await.expect_err("stop is cancelled").is_cancelled());
-        assert!(matches!(lifecycle_guard.phase, SyncTaskPhase::Running { .. }));
+        assert!(matches!(
+            lifecycle_guard.phase,
+            SyncTaskPhase::Running { .. }
+        ));
         drop(lifecycle_guard);
 
         assert!(*syncing.read().await);
@@ -1678,12 +1693,14 @@ mod supervisor_tests {
         });
         first_dropped_rx.await.expect("old handle is aborted");
         stop.abort();
-        assert!(stop.await.expect_err("stop caller is cancelled").is_cancelled());
+        assert!(
+            stop.await
+                .expect_err("stop caller is cancelled")
+                .is_cancelled()
+        );
 
-        let (replacement_started_tx, mut replacement_started_rx) =
-            tokio::sync::oneshot::channel();
-        let (replacement_dropped_tx, replacement_dropped_rx) =
-            tokio::sync::oneshot::channel();
+        let (replacement_started_tx, mut replacement_started_rx) = tokio::sync::oneshot::channel();
+        let (replacement_dropped_tx, replacement_dropped_rx) = tokio::sync::oneshot::channel();
         let recovery_supervisor = Arc::clone(&supervisor);
         let recovery_flag = Arc::clone(&syncing);
         let recovery_starts = Arc::clone(&starts);
@@ -1712,13 +1729,19 @@ mod supervisor_tests {
             "replacement cannot start before the old handle finalizes"
         );
         assert_eq!(live.load(AtomicOrdering::SeqCst), 0);
-        assert!(*syncing_guard, "stale flag is still held at the test barrier");
+        assert!(
+            *syncing_guard,
+            "stale flag is still held at the test barrier"
+        );
         drop(syncing_guard);
 
         replacement_started_rx
             .await
             .expect("replacement starts after old handle joins");
-        assert_eq!(recovery.await.expect("recovery task joins"), SyncStart::Started);
+        assert_eq!(
+            recovery.await.expect("recovery task joins"),
+            SyncStart::Started
+        );
         assert_phase(&supervisor, "running").await;
         assert!(*syncing.read().await);
         assert_eq!(starts.load(AtomicOrdering::SeqCst), 2);


### PR DESCRIPTION
First of two PRs for #340. This one is `cargo fmt` only; `cargo deny` follows
once this is merged, so a supply-chain policy file does not have to be reviewed
underneath a mechanical reformat.

## Read this as two commits

1. **`style(plugin): apply cargo fmt to tauri-plugin-zcash`** — machine output,
   nothing hand-edited. Skip it. Re-run the formatter if you want to verify it.
2. **`ci(rust): enforce cargo fmt`** — the actual change. Review this one.

## Measured state

`cargo fmt --check` was run against all three crates on the pinned 1.88.0
toolchain before touching anything:

| Crate | Unformatted files | Hunks |
| --- | --- | --- |
| `wallet/plugins/tauri-plugin-zcash` | 12 | 126 |
| `wallet/zuuli/src-tauri` | 0 | 0 |
| `wallet/zuuallet/src-tauri` | 0 | 0 |

Correcting the figure this work was scoped against: it is **12 files, 126 diff
hunks** — `cargo fmt --check` prints one `Diff in <path>:<line>` header per
hunk, not per file. The reformat is 704 insertions / 655 deletions across 12
files, almost all of it edition-2024 import ordering
(`{Serialize, ser::Serializer}`) and wrapping long signatures.

## The check

`scripts/check-rust-fmt.sh` checks every Rust crate under `wallet/`, and both
Rust workflows call it so they cannot disagree about what "formatted" means.

Two deliberate properties:

- **Crates are discovered, not listed.** A new crate under `wallet/` is gated
  from its first commit — one of the acceptance criteria on #340, and the only
  moment when strict gating is free.
- **It refuses to run on the wrong compiler.** rustfmt's output is not stable
  across rustc versions, so the script reads the channel from
  `wallet/rust-toolchain.toml`, runs cargo from that directory (rustup selects
  on working directory, not `--manifest-path`), and hard-fails if
  `rustc --version` disagrees. Without that, a contributor on a newer stable
  gets version skew reported as a formatting mistake.

Proven to fail, not just to pass:

```
$ printf 'pub fn _fmt_canary(  ) ->  u8 { 1 }\n' >> wallet/zuuli/src-tauri/src/lib.rs
$ scripts/check-rust-fmt.sh; echo "EXIT=$?"
...
1 crate(s) are not formatted: wallet/zuuli/src-tauri
Run `scripts/check-rust-fmt.sh --fix` and commit the result; do not hand-edit.
EXIT=1
```

## CI wiring — the part worth checking

**A new job, not a step on the existing builds.** `rust_plugin` and `rust_app`
are 45-minute jobs. `cargo fmt` reads manifests with
`cargo metadata --no-deps`, which resolves no dependency graph and compiles
nothing, so `rust_fmt` needs no submodule fetch, no Tauri system packages and
no Cargo cache. (Verified empirically: `cargo fmt --check` produces correct
output in a tree where `z/zcash/librustzcash` is not initialised.) It reports in
about a minute instead of behind a cold Zcash build.

**The `gate` job was updated in both places.** Adding a job to `needs:` alone
makes `gate` *wait* for it and then ignore it — decorative. So both changed:

```yaml
needs: [changes, frontend, rust_fmt, rust_plugin, rust_app]
```
```bash
results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"
```

Reasoning about the failure path, since a green run cannot demonstrate it:
`gate` runs `if: always()`, so a failed `rust_fmt` does not cancel it. With
`zuuli == true` the script sets `expected=success`, and the loop over
`$results` — which now contains `$RUST_FMT_RESULT` — hits `failure`, prints
`Expected every applicable job to be success, got: failure` and exits 1. If I
had updated only `needs:`, `results` would not contain the value and the loop
would pass over a red job. A comment now sits above `results=` saying every
entry in `needs:` must appear there too.

**Skip semantics preserved.** `rust_fmt` carries the same
`if: needs.changes.outputs.zuuli == 'true'` as its siblings, so when
`zuuli == false` it reports `skipped` alongside them and the gate's
`expected=skipped` branch stays internally consistent.

**Change filter.** `scripts/check-rust-fmt.sh` was added to the `changes` job's
shell `case` list; otherwise editing the check would not re-run it.

**Zuuallet coverage.** zuuli.yml's detector does not select
`wallet/zuuallet/**`, so the required gate skips on a Zuuallet-only PR. Without
a matching job in zuuallet.yml, such a PR could land unformatted code that then
fails the *next* unrelated ZUULI PR on files it never touched. zuuallet.yml
therefore gets the same job — pinned via the same
`steps.rust_toolchain.outputs.version` expression rather than that workflow's
`@stable`, because `@stable` rustfmt would disagree with 1.88.0 rustfmt.

`components: rustfmt` is explicit on both new jobs: `dtolnay/rust-toolchain`
installs the minimal profile, which does not include it.

`scripts/check-rust-toolchain.sh` and its `--self-test` still pass — the two new
`@stable` refs both pass an accepted `toolchain:` expression, so they are pins
and not floats, and the floating-ref count is unchanged at 2 (the zuuallet
canaries).

## Clippy — measured, not enabled

Per #340's sequencing, clippy is measured here and left off. Numbers are posted
as a comment on #340 with a follow-up issue, so the decision to turn it on is
made on evidence rather than on a guess. No clippy gate and no warning fixes are
in this PR.

## Verification

- `cargo test --locked --all-targets` on `wallet/plugins/tauri-plugin-zcash`
- `cargo build --locked` and `cargo test --locked` on `wallet/zuuli/src-tauri`
- `cargo build --locked` on `wallet/zuuallet/src-tauri`
- `scripts/check-rust-fmt.sh` passes; the canary above proves it can fail
- `scripts/check-rust-toolchain.sh --self-test` passes

Refs #340
