### PR TITLE
ci(rust): add cargo-deny for advisories and licences

### DIFF
--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -22,6 +22,8 @@ on:
       - 'z/zcash/librustzcash'
       - '.gitmodules'
       - 'scripts/check-rust-fmt.sh'
+      - 'scripts/check-rust-deny.sh'
+      - 'wallet/deny.toml'
       - '.github/workflows/zuuallet.yml'
   push:
     branches: [main]
@@ -31,6 +33,8 @@ on:
       - 'z/zcash/librustzcash'
       - '.gitmodules'
       - 'scripts/check-rust-fmt.sh'
+      - 'scripts/check-rust-deny.sh'
+      - 'wallet/deny.toml'
       - '.github/workflows/zuuallet.yml'
   workflow_dispatch:
   schedule:
@@ -75,6 +79,36 @@ jobs:
 
       - name: Check formatting of every Rust crate under wallet/
         run: scripts/check-rust-fmt.sh
+
+  # ---------------------------------------------------------------------------
+  # Supply chain, for the same reason as `fmt`: the required `gate` in zuuli.yml
+  # does not select wallet/zuuallet/**, so without this a Zuuallet-only change
+  # to Cargo.toml or Cargo.lock could pull in an advisory or an incompatible
+  # licence that nothing checks.
+  # ---------------------------------------------------------------------------
+  deny:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - name: Resolve the pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          set -euo pipefail
+          version=$(scripts/check-rust-toolchain.sh --print-channel)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
+
+      - name: Check advisories, licences and sources
+        run: scripts/check-rust-deny.sh
 
   # ---------------------------------------------------------------------------
   # Frontend: TypeScript typecheck + production bundle.

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -71,7 +71,7 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|scripts/check-rust-fmt.sh|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*)
                 zuuli=true
                 ;;
             esac
@@ -161,6 +161,45 @@ jobs:
 
       - name: Check formatting of every Rust crate under wallet/
         run: scripts/check-rust-fmt.sh
+
+  # Supply chain: RustSec advisories, licences, and crate sources for all three
+  # wallet lockfiles. Like rust_fmt this compiles nothing — cargo-deny works
+  # from `cargo metadata` and the lockfiles — but unlike rust_fmt it does need
+  # the dependency graph resolved, so the librustzcash submodule is fetched.
+  # Still a couple of minutes rather than 45.
+  rust_deny:
+    name: Rust / supply chain
+    needs: changes
+    if: needs.changes.outputs.zuuli == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      # cargo-deny resolves the whole graph, and the wallet crates reach the
+      # Zcash crates by path into this submodule.
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - name: Resolve the pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          set -euo pipefail
+          version=$(scripts/check-rust-toolchain.sh --print-channel)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # cargo-deny shells out to `cargo metadata`, so a toolchain is required
+      # even though nothing is compiled.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
+
+      # The script fetches a checksum-verified cargo-deny release binary itself;
+      # the version and digests are pinned in the script. Deliberately not a
+      # third-party installer action — the tool that polices our supply chain
+      # should not arrive through an unpinned one.
+      - name: Check advisories, licences and sources
+        run: scripts/check-rust-deny.sh
 
   rust_plugin:
     name: Rust / shared plugin
@@ -268,7 +307,7 @@ jobs:
   # change detector and every applicable full-stack job succeeded; legitimate
   # non-ZUULI skips continue to report success instead of remaining pending.
   gate:
-    needs: [changes, frontend, rust_fmt, rust_plugin, rust_app]
+    needs: [changes, frontend, rust_fmt, rust_deny, rust_plugin, rust_app]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -279,6 +318,7 @@ jobs:
           ZUULI_CHANGED: ${{ needs.changes.outputs.zuuli }}
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           RUST_FMT_RESULT: ${{ needs.rust_fmt.result }}
+          RUST_DENY_RESULT: ${{ needs.rust_deny.result }}
           RUST_PLUGIN_RESULT: ${{ needs.rust_plugin.result }}
           RUST_APP_RESULT: ${{ needs.rust_app.result }}
         run: |
@@ -289,7 +329,7 @@ jobs:
 
           # Every job in `needs:` above must appear here as well; a job that is
           # awaited but not inspected makes the gate decorative for that job.
-          results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"
+          results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_DENY_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"
           echo "ZUULI changed: $ZUULI_CHANGED; job results: $results"
           case "$ZUULI_CHANGED" in
             true) expected=success ;;

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ private/
 .vscode/
 *.log
 target/
+# Checksum-verified cargo-deny binary fetched by scripts/check-rust-deny.sh.
+.cargo-deny/
 *.pyc
 __pycache__
 wallet/zuuli/dist/

--- a/scripts/check-rust-deny.sh
+++ b/scripts/check-rust-deny.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Run cargo-deny's supply-chain checks over every Rust crate under wallet/.
+#
+# The three wallet crates have independent lockfiles that resolve the Zcash and
+# Tauri graphs differently, so each is checked separately — against one shared
+# policy, wallet/deny.toml, so they cannot drift into disagreeing about what is
+# acceptable. Crates are discovered rather than listed, so a new crate under
+# wallet/ is gated from its first commit.
+#
+# cargo-deny is fetched as a checksum-verified release binary rather than built
+# from source or installed by a third-party action. A tool whose job is to
+# police the supply chain should not itself arrive from an unverified one: the
+# version and the per-platform SHA-256 below are the whole trust decision, and
+# they are in the repository where they can be reviewed and bumped deliberately.
+#
+# Unlike scripts/check-rust-fmt.sh this needs the dependency graph resolved, so
+# z/zcash/librustzcash must be checked out — the wallet crates reach the Zcash
+# crates through path dependencies into it.
+#
+# Usage:
+#   scripts/check-rust-deny.sh                  advisories, bans, licences, sources
+#   scripts/check-rust-deny.sh advisories       one check only (any cargo-deny check)
+#   scripts/check-rust-deny.sh --print-version  print the pinned cargo-deny version
+
+set -euo pipefail
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+RUST_ROOT=$REPO_ROOT/wallet
+CONFIG=$RUST_ROOT/deny.toml
+
+# Bumping: change the version, then replace all four digests with the contents
+# of the matching .sha256 files from the release. Never bump the version alone.
+CARGO_DENY_VERSION=0.20.2
+CARGO_DENY_SHA256_x86_64_unknown_linux_musl=9f12ed4c49936e09b48bf862b595cde2fe64fcbd9d74dfacac6131ca824c8d5f
+CARGO_DENY_SHA256_aarch64_unknown_linux_musl=995c82be0defc7a025cae49a2aa2644ce8245c9a3318fc4103907c6a285e8c7d
+CARGO_DENY_SHA256_x86_64_apple_darwin=248da7f581724e470071990c088ffc55c811981715f4cbdb258621fb79f8b7a6
+CARGO_DENY_SHA256_aarch64_apple_darwin=fe67d82a10d8597a3549364cb733a3f9cc1bfff9031b7ae46384a9f2a72090c3
+
+if [[ ${1-} == --print-version ]]; then
+  printf '%s\n' "$CARGO_DENY_VERSION"
+  exit 0
+fi
+
+if [[ ${1-} == -h || ${1-} == --help ]]; then
+  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+  exit 0
+fi
+
+check=${1-all}
+
+if [[ ! -f $CONFIG ]]; then
+  printf 'wallet/deny.toml is missing; it is the supply-chain policy this check enforces.\n' >&2
+  exit 1
+fi
+
+host_target() {
+  local os arch
+  os=$(uname -s)
+  arch=$(uname -m)
+  case "$os/$arch" in
+    Linux/x86_64) printf 'x86_64-unknown-linux-musl' ;;
+    Linux/aarch64 | Linux/arm64) printf 'aarch64-unknown-linux-musl' ;;
+    Darwin/x86_64) printf 'x86_64-apple-darwin' ;;
+    Darwin/arm64) printf 'aarch64-apple-darwin' ;;
+    *) return 1 ;;
+  esac
+}
+
+expected_sha() {
+  local var="CARGO_DENY_SHA256_${1//-/_}"
+  printf '%s' "${!var-}"
+}
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+# Install into the repository rather than the user's PATH so a stale global
+# cargo-deny cannot silently decide the verdict, and so the version in use is
+# always the pinned one.
+install_cargo_deny() {
+  local target sha dest tmp url archive actual
+  target=$(host_target) || {
+    printf 'no pinned cargo-deny binary for %s/%s; install cargo-deny %s manually and re-run.\n' \
+      "$(uname -s)" "$(uname -m)" "$CARGO_DENY_VERSION" >&2
+    exit 1
+  }
+  sha=$(expected_sha "$target")
+  if [[ -z $sha ]]; then
+    printf 'no SHA-256 pinned for %s; refusing to run an unverified cargo-deny.\n' "$target" >&2
+    exit 1
+  fi
+
+  dest=$REPO_ROOT/.cargo-deny/$CARGO_DENY_VERSION/cargo-deny
+  if [[ -x $dest ]]; then
+    printf '%s' "$dest"
+    return
+  fi
+
+  url="https://github.com/EmbarkStudios/cargo-deny/releases/download/$CARGO_DENY_VERSION/cargo-deny-$CARGO_DENY_VERSION-$target.tar.gz"
+  tmp=$(mktemp -d)
+  archive=$tmp/cargo-deny.tar.gz
+  printf 'Fetching cargo-deny %s for %s\n' "$CARGO_DENY_VERSION" "$target" >&2
+  curl --fail --silent --show-error --location --retry 3 --output "$archive" "$url"
+
+  # Lower-cased with tr rather than ${var,,} so this still runs on the bash 3.2
+  # that ships with macOS, where developers verify before pushing.
+  actual=$(sha256_of "$archive" | tr 'A-F' 'a-f')
+  sha=$(printf '%s' "$sha" | tr 'A-F' 'a-f')
+  if [[ $actual != "$sha" ]]; then
+    printf 'cargo-deny download failed verification.\n  expected %s\n  actual   %s\n' \
+      "$sha" "$actual" >&2
+    rm -rf "$tmp"
+    exit 1
+  fi
+
+  tar -xzf "$archive" -C "$tmp"
+  mkdir -p "$(dirname "$dest")"
+  mv "$tmp/cargo-deny-$CARGO_DENY_VERSION-$target/cargo-deny" "$dest"
+  chmod +x "$dest"
+  rm -rf "$tmp"
+  printf '%s' "$dest"
+}
+
+CARGO_DENY=$(install_cargo_deny)
+
+cd "$RUST_ROOT"
+
+manifests=()
+while IFS= read -r manifest; do
+  manifests+=("${manifest#./}")
+done < <(
+  find . -name Cargo.toml \
+    -not -path './target/*' \
+    -not -path '*/target/*' \
+    -not -path '*/node_modules/*' |
+    LC_ALL=C sort
+)
+
+if [[ ${#manifests[@]} -eq 0 ]]; then
+  printf 'no Cargo manifests found under wallet/; this check has gone blind.\n' >&2
+  exit 1
+fi
+
+failed=()
+for manifest in "${manifests[@]}"; do
+  crate=$(dirname "$manifest")
+  printf '\n==> cargo-deny check %s -- wallet/%s\n' "$check" "$crate"
+  # One shared policy across three lockfiles means some ignore entries apply to
+  # a different lockfile than the one being checked; cargo-deny reports those as
+  # `advisory-not-detected` warnings. They are expected and are not failures.
+  # --locked: judge the lockfile CI actually builds. Without it cargo-deny may
+  # regenerate the graph and clear an advisory that the committed Cargo.lock
+  # still carries.
+  if "$CARGO_DENY" --manifest-path "$manifest" --config "$CONFIG" --locked check "$check"; then
+    continue
+  fi
+  failed+=("wallet/$crate")
+done
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+  printf '\n%d crate(s) failed the supply-chain policy: %s\n' "${#failed[@]}" "${failed[*]}" >&2
+  printf 'Fix the dependency, or add a specific, reasoned entry to wallet/deny.toml.\n' >&2
+  printf 'Do not broaden a category to make this pass.\n' >&2
+  exit 1
+fi
+
+printf '\nAll %d Rust crate(s) under wallet/ satisfy wallet/deny.toml.\n' "${#manifests[@]}"

--- a/wallet/deny.toml
+++ b/wallet/deny.toml
@@ -1,0 +1,193 @@
+# Supply-chain policy for every Rust crate under wallet/.
+#
+# One config for all three crates (wallet/plugins/tauri-plugin-zcash,
+# wallet/zuuli/src-tauri, wallet/zuuallet/src-tauri) so they cannot drift into
+# disagreeing about what is acceptable. `scripts/check-rust-deny.sh` runs
+# cargo-deny against each lockfile with `--config wallet/deny.toml`.
+#
+# HOW TO READ THE `ignore` LIST BELOW
+#
+# This repository had no supply-chain check at all until #340, so the list is
+# the *measured* backlog on the day the gate landed — not a wish list and not a
+# way to make the build quiet. Every entry names a specific advisory, the
+# version that fixes it, and why we are not on that version yet. Nothing is
+# ignored by category, by severity, or by wildcard.
+#
+# The value is in what is NOT listed: any advisory that appears from here on
+# fails CI, because it will not be in this file. Deleting an entry is the
+# expected outcome of remediation, and the gate proves the deletion is real.
+#
+# Remediation is tracked in the follow-up issue linked from #340. Do not add an
+# entry here without a reason string that would satisfy someone auditing this
+# wallet.
+
+[graph]
+# Evaluate every target, not just the host. CI runs on Linux, releases build on
+# macOS, Windows and mobile, and the GTK and objc2 halves of the graph carry
+# different advisories — a host-only view would report a different verdict on
+# each runner.
+all-features = false
+
+# =============================================================================
+# Advisories — the security half of this gate.
+# =============================================================================
+[advisories]
+db-urls = ["https://github.com/rustsec/advisory-db"]
+
+# Yanking is registry state, not repository state: a crate can be yanked
+# upstream between two runs of CI with no commit of ours in between, which would
+# turn an unrelated pull request red for reasons its author cannot act on. It is
+# reported on every run and triaged deliberately instead.
+# Currently reported: spin 0.9.8 (via flume -> zcash_client_backend, and via
+# lazy_static -> bellman/orchard/tao).
+yanked = "warn"
+
+ignore = [
+  # ---------------------------------------------------------------------------
+  # Vulnerabilities. Each of these is transitive; none is a crate we depend on
+  # directly, and none has a fix reachable from the current lockfile without a
+  # semver-major bump in an intermediate crate. Fixing them is the follow-up
+  # issue, deliberately not this one: bumping them touches the lockfile that
+  # every release build is pinned to, and that belongs in a PR whose diff is
+  # the bump rather than in the PR that installs the check.
+  # ---------------------------------------------------------------------------
+
+  # aws-lc-sys 0.37.1; reached via rustls 0.23 -> aws-lc-rs -> aws-lc-sys, which
+  # tonic's TLS stack pulls in. Fixed in 0.38.0/0.39.0, which is a semver-major
+  # bump for a 0.x crate: `cargo update` cannot reach it, aws-lc-rs must widen
+  # its requirement first.
+  { id = "RUSTSEC-2026-0044", reason = "aws-lc-sys 0.37.1: X.509 name-constraint bypass; needs aws-lc-sys >= 0.39.0, a semver-major bump held by aws-lc-rs 1.15.4" },
+  { id = "RUSTSEC-2026-0045", reason = "aws-lc-sys 0.37.1: AES-CCM tag-verification timing side channel; needs >= 0.38.0, same semver-major bump" },
+  { id = "RUSTSEC-2026-0046", reason = "aws-lc-sys 0.37.1: PKCS7_verify chain-validation bypass; needs >= 0.38.0, same semver-major bump. We do not call PKCS7_verify" },
+  { id = "RUSTSEC-2026-0047", reason = "aws-lc-sys 0.37.1: PKCS7_verify signature-validation bypass; needs >= 0.38.0, same semver-major bump. We do not call PKCS7_verify" },
+  { id = "RUSTSEC-2026-0048", reason = "aws-lc-sys 0.37.1: CRL distribution-point scope logic error; needs >= 0.39.0, same semver-major bump. We do not consume CRLs" },
+
+  # rustls-webpki. Two versions are in the graph: 0.101.7 behind rustls 0.21
+  # (an old transitive TLS stack) and 0.103.9 behind rustls 0.23. The 0.101 line
+  # has no fixed release at all — the fix starts at 0.103.12 — so clearing these
+  # means getting every consumer off rustls 0.21, not a version bump.
+  { id = "RUSTSEC-2026-0049", reason = "rustls-webpki 0.103.9: CRL authority matching; fixed in 0.103.10. Reachable by `cargo update -p rustls-webpki`, deferred to the lockfile-bump PR" },
+  { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 and 0.103.9: URI name constraints incorrectly accepted; fixed in 0.103.12. No fix exists on the 0.101 line" },
+  { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101.7 and 0.103.9: wildcard name constraints incorrectly accepted; fixed in 0.103.12. No fix exists on the 0.101 line" },
+  { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 and 0.103.9: reachable panic parsing a CRL; fixed in 0.103.13. No fix exists on the 0.101 line. We do not parse CRLs" },
+
+  # Remaining transitive vulnerabilities.
+  { id = "RUSTSEC-2026-0009", reason = "time 0.3.37: stack exhaustion parsing untrusted input; fixed in 0.3.47. Semver-compatible, deferred to the lockfile-bump PR" },
+  { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.38.4: quadratic duplicate-attribute scan; fixed in 0.41.0, a semver-major bump owned by the Tauri bundler chain. Build-time XML only" },
+  { id = "RUSTSEC-2026-0195", reason = "quick-xml 0.38.4: unbounded namespace allocation; fixed in 0.41.0, same semver-major bump. Build-time XML only" },
+  { id = "RUSTSEC-2026-0204", reason = "crossbeam-epoch 0.9.18: invalid pointer deref in a Debug impl; fixed in 0.9.20. Semver-compatible, deferred to the lockfile-bump PR" },
+
+  # Unsound.
+  { id = "RUSTSEC-2026-0097", reason = "rand 0.8.5: unsound with a custom logger calling rand::rng(); fixed in 0.8.6. Semver-compatible, deferred to the lockfile-bump PR" },
+
+  # ---------------------------------------------------------------------------
+  # Unmaintained. None of these has a fixed version to move to — the advisory is
+  # that the crate is no longer developed. Clearing them means the *dependent*
+  # migrates, which is upstream work in Tauri and in the proc-macro ecosystem.
+  # They are listed one by one anyway: `unmaintained = "warn"` would also hide
+  # the next unmaintained crate to appear, and that is the signal worth keeping.
+  # ---------------------------------------------------------------------------
+
+  # gtk-rs GTK3 bindings, all reached through tauri -> gtk 0.18. Tauri v2 still
+  # targets GTK3 on Linux; the migration is upstream's.
+  { id = "RUSTSEC-2024-0411", reason = "gdkwayland-sys 0.18.2: GTK3 bindings unmaintained; required by tauri v2 on Linux, no successor to move to" },
+  { id = "RUSTSEC-2024-0412", reason = "gdk 0.18.2: GTK3 bindings unmaintained; required by tauri v2 on Linux" },
+  { id = "RUSTSEC-2024-0413", reason = "atk 0.18.2: GTK3 bindings unmaintained; required by tauri v2 on Linux" },
+  { id = "RUSTSEC-2024-0414", reason = "gdkx11-sys 0.18.2: GTK3 bindings unmaintained; required by tauri v2 on Linux" },
+  { id = "RUSTSEC-2024-0415", reason = "gtk 0.18.2: GTK3 bindings unmaintained; required by tauri v2 on Linux" },
+  { id = "RUSTSEC-2024-0416", reason = "atk-sys 0.18.2: GTK3 bindings unmaintained; required by tauri v2 on Linux" },
+  { id = "RUSTSEC-2024-0417", reason = "gdkx11 0.18.2: GTK3 bindings unmaintained; required by tauri v2 on Linux" },
+  { id = "RUSTSEC-2024-0418", reason = "gdk-sys 0.18.2: GTK3 bindings unmaintained; required by tauri v2 on Linux" },
+  { id = "RUSTSEC-2024-0419", reason = "gtk3-macros 0.18.2: GTK3 bindings unmaintained; required by tauri v2 on Linux" },
+  { id = "RUSTSEC-2024-0420", reason = "gtk-sys 0.18.2: GTK3 bindings unmaintained; required by tauri v2 on Linux" },
+
+  # Build-time only: proc macros and Unicode tables used by proc-macro crates.
+  # None of this ships in a release binary.
+  { id = "RUSTSEC-2024-0370", reason = "proc-macro-error 1.0.4: unmaintained; build-time proc-macro dependency, no code in the shipped binary" },
+  { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 2.0.1: unmaintained; build-time proc-macro dependency, no code in the shipped binary" },
+  { id = "RUSTSEC-2025-0057", reason = "fxhash 0.2.1: unmaintained; transitive through the Tauri/servo CSS stack" },
+  { id = "RUSTSEC-2025-0075", reason = "unic-char-range 0.9.0: unmaintained; build-time Unicode tables" },
+  { id = "RUSTSEC-2025-0080", reason = "unic-common 0.9.0: unmaintained; build-time Unicode tables" },
+  { id = "RUSTSEC-2025-0081", reason = "unic-char-property 0.9.0: unmaintained; build-time Unicode tables" },
+  { id = "RUSTSEC-2025-0098", reason = "unic-ucd-version 0.9.0: unmaintained; build-time Unicode tables" },
+  { id = "RUSTSEC-2025-0100", reason = "unic-ucd-ident 0.9.0: unmaintained; build-time Unicode tables" },
+]
+
+# =============================================================================
+# Licences.
+#
+# This wallet is shipped as a binary, so a copyleft dependency is a licensing
+# decision about the whole product, not about one file. The allow list below is
+# permissive-only; every non-permissive licence in the graph is either an
+# explicitly reasoned entry or a per-crate exception, so adding a new copyleft
+# dependency fails CI rather than arriving silently.
+# =============================================================================
+[licenses]
+# The three wallet crates carry no `license` field because none of them is
+# published; they are marked `publish = false` and skipped here. Third-party
+# crates are never skipped by this setting.
+private = { ignore = true }
+
+allow = [
+  # The Rust ecosystem's default dual licence, and the overwhelming majority of
+  # this graph.
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception", # rustix, linux-raw-sys, wasi, wit-bindgen
+
+  # Permissive, no reciprocity, no advertising clause.
+  "0BSD",         # adler2
+  "MIT-0",        # constant_time_eq, dunce
+  "BSD-2-Clause", # arrayref, zerocopy
+  "BSD-3-Clause", # subtle, brotli, num_enum
+  "ISC",          # ring, rustls, untrusted, minreq
+  "Unlicense",    # memchr, aho-corasick, byteorder, walkdir
+  "Zlib",         # the objc2 family, bytemuck, miniz_oxide, tinyvec
+
+  # Public-domain dedications. No patent grant, which is why they are called out
+  # rather than lumped in above; accepted because the crates are small and
+  # widely used, including secp256k1 which we rely on for transparent-address
+  # key derivation.
+  "CC0-1.0",              # secp256k1, secp256k1-sys, constant_time_eq, dunce, bounded-vec
+  "Unicode-3.0",          # the ICU4X family and unicode-ident
+  "CDLA-Permissive-2.0",  # webpki-roots 1.x (the Mozilla CA bundle as data)
+
+  # Weak, file-scoped copyleft. Obligations attach to modified MPL files, not to
+  # the binary that links them; we vendor none of these and modify none of them.
+  # Reached through the Tauri/servo CSS stack (cssparser, cssparser-macros,
+  # dtoa-short, selectors) and through webpki-roots 0.25 and option-ext.
+  "MPL-2.0",
+]
+
+# Per-crate escapes, so an unusual licence is accepted for exactly the crate it
+# was reasoned about and for no other.
+exceptions = [
+  # aws-lc-sys is "ISC AND (Apache-2.0 OR ISC) AND OpenSSL": the OpenSSL term is
+  # conjunctive, so it cannot be satisfied any other way. The original OpenSSL
+  # licence is permissive but carries an advertising clause and is GPL-
+  # incompatible, so it is accepted here only for this crate rather than added
+  # to the allow list.
+  { name = "aws-lc-sys", allow = ["OpenSSL"] },
+]
+
+# =============================================================================
+# Bans. No crate is banned outright yet; this section exists to silence the
+# duplicate-version report, which is endemic to a graph this size (windows-sys
+# appears 5 times, getrandom 4, thiserror as both 1.x and 2.x) and is a
+# build-size concern rather than a supply-chain one. Left at "warn" it prints
+# roughly sixty warnings per crate and buries the advisory and licence output
+# this gate exists for.
+# =============================================================================
+[bans]
+multiple-versions = "allow"
+
+# =============================================================================
+# Sources. Every crate in all three lockfiles resolves to crates.io today; the
+# in-source Zcash dependencies are path dependencies into z/, not git ones. This
+# makes that a rule instead of a coincidence, so a `git = "..."` dependency on a
+# personal fork cannot be introduced without amending this file.
+# =============================================================================
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/wallet/plugins/tauri-plugin-zcash/Cargo.toml
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.toml
@@ -3,6 +3,9 @@ name = "tauri-plugin-zcash"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.88"
+# Never goes to a registry: the wallet crates are consumed by path only. This is
+# also what lets wallet/deny.toml skip them under `licenses.private.ignore`.
+publish = false
 description = "Tauri plugin for Zcash wallet operations"
 links = "tauri-plugin-zcash"
 

--- a/wallet/zuuallet/src-tauri/Cargo.toml
+++ b/wallet/zuuallet/src-tauri/Cargo.toml
@@ -3,6 +3,9 @@ name = "zuuallet"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.88"
+# Never goes to a registry: the wallet crates are consumed by path only. This is
+# also what lets wallet/deny.toml skip them under `licenses.private.ignore`.
+publish = false
 
 [lib]
 name = "zuuallet_lib"

--- a/wallet/zuuli/src-tauri/Cargo.toml
+++ b/wallet/zuuli/src-tauri/Cargo.toml
@@ -3,6 +3,9 @@ name = "zuuli"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.88"
+# Never goes to a registry: the wallet crates are consumed by path only. This is
+# also what lets wallet/deny.toml skip them under `licenses.private.ignore`.
+publish = false
 description = "ZUULI by 2Z Inc — Zcash-native wallet, AI, livestreaming and articles."
 
 [lib]


### PR DESCRIPTION
Second of two PRs for #340, on top of #349 (`cargo fmt`). This one is the
supply-chain half — the part of #340 with actual security value.

Until now this repository had no mechanical path from a RustSec advisory to our
attention. `scripts/check-rust-deny.sh` runs cargo-deny's **advisories,
licences, bans and sources** checks over all three wallet lockfiles against one
committed policy, `wallet/deny.toml`.

## The backlog is large, and it is not swept away

**36 findings** exist today. Every one is an individually commented `ignore`
entry that names the advisory, the version that fixes it, and why we are not on
that version. Nothing is ignored by category, by severity, or by wildcard —
`unmaintained = "warn"` would have made this file three lines long and would
also have hidden the *next* unmaintained crate to appear.

A gate that is green because everything is exempted is worthless. This one is
green because today's state is written down; **anything new fails**, because it
will not be in the file. Entries are deleted one at a time as remediation lands,
and the gate proves each deletion is real.

### Vulnerabilities (13)

| Advisory | Crate | Fixed in | Reachable by `cargo update`? |
| --- | --- | --- | --- |
| RUSTSEC-2026-0044 | aws-lc-sys 0.37.1 — X.509 name-constraint bypass | 0.39.0 | No — semver-major for a 0.x crate; aws-lc-rs 1.15.4 must widen first |
| RUSTSEC-2026-0045 | aws-lc-sys 0.37.1 — AES-CCM timing side channel | 0.38.0 | No — same |
| RUSTSEC-2026-0046 | aws-lc-sys 0.37.1 — PKCS7_verify chain bypass | 0.38.0 | No — same |
| RUSTSEC-2026-0047 | aws-lc-sys 0.37.1 — PKCS7_verify signature bypass | 0.38.0 | No — same |
| RUSTSEC-2026-0048 | aws-lc-sys 0.37.1 — CRL distribution-point logic error | 0.39.0 | No — same |
| RUSTSEC-2026-0049 | rustls-webpki 0.103.9 — CRL authority matching | 0.103.10 | **Yes** |
| RUSTSEC-2026-0098 | rustls-webpki 0.101.7 **and** 0.103.9 — URI name constraints | 0.103.12 | Partly — no fix exists on the 0.101 line |
| RUSTSEC-2026-0099 | rustls-webpki 0.101.7 **and** 0.103.9 — wildcard name constraints | 0.103.12 | Partly — same |
| RUSTSEC-2026-0104 | rustls-webpki 0.101.7 **and** 0.103.9 — reachable panic parsing a CRL | 0.103.13 | Partly — same |
| RUSTSEC-2026-0009 | time 0.3.37 — stack exhaustion | 0.3.47 | **Yes** |
| RUSTSEC-2026-0194 | quick-xml 0.38.4 — quadratic duplicate-attribute scan | 0.41.0 | No — semver-major, owned by the Tauri bundler chain |
| RUSTSEC-2026-0195 | quick-xml 0.38.4 — unbounded namespace allocation | 0.41.0 | No — same |
| RUSTSEC-2026-0204 | crossbeam-epoch 0.9.18 — invalid pointer deref in a Debug impl | 0.9.20 | **Yes** |

All 13 are transitive; none is a direct dependency. The two TLS clusters are the
ones that matter: `aws-lc-sys` and `rustls-webpki` sit under the tonic/rustls
stack the wallet uses to reach lightwalletd. Note that `rustls-webpki 0.101.7`
has **no** fixed release at all — the fix line starts at 0.103.12 — so clearing
it means getting every consumer off rustls 0.21, not bumping a version.

### Unsound (1)

| Advisory | Crate | Fixed in |
| --- | --- | --- |
| RUSTSEC-2026-0097 | rand 0.8.5 — unsound with a custom logger calling `rand::rng()` | 0.8.6 (semver-compatible) |

### Unmaintained (18)

None of these has a fixed version; the advisory *is* that the crate is no longer
developed, so clearing them means the dependent migrates.

- **gtk-rs GTK3 bindings (10)** — RUSTSEC-2024-0411 … -0420: `gdk`, `gdk-sys`,
  `gdkwayland-sys`, `gdkx11`, `gdkx11-sys`, `gtk`, `gtk-sys`, `gtk3-macros`,
  `atk`, `atk-sys`. All via `tauri` v2, which still targets GTK3 on Linux.
  Upstream's migration, not ours.
- **Build-time proc-macro / Unicode (8)** — RUSTSEC-2024-0370
  (`proc-macro-error`), RUSTSEC-2026-0173 (`proc-macro-error2`),
  RUSTSEC-2025-0057 (`fxhash`), RUSTSEC-2025-0075/-0080/-0081/-0098/-0100 (the
  `unic-*` family). None of this ships in a release binary.

### Yanked (1)

`spin 0.9.8`, via `flume` → `zcash_client_backend` and via `lazy_static` →
`bellman`/`orchard`/`tao`. Reported on every run, but `yanked = "warn"` rather
than deny: yanking is *registry* state, not repository state. A crate can be
yanked upstream between two CI runs with no commit of ours in between, which
would turn an unrelated PR red for a reason its author cannot act on.

### Follow-up

Remediation is filed as #351 rather than done here. Bumping
these touches the lockfiles that every release build is pinned to; that belongs
in a PR whose diff *is* the bump, not in the PR that installs the check. The
follow-up carries the fixable/not-fixable split from the table above so it is
actionable rather than aspirational.

## Licences

Permissive-only allow list, every entry annotated with the crates that brought
it. The interesting decisions:

- **MPL-2.0 — allowed, with the reasoning written down.** Weak, file-scoped
  copyleft: obligations attach to modified MPL files, not to a binary that links
  them, and we neither vendor nor modify any of them. Reached via the
  Tauri/servo CSS stack (`cssparser`, `selectors`, `dtoa-short`) and via
  `webpki-roots` 0.25 / `option-ext`.
- **OpenSSL — a per-crate exception, not an allowance.** `aws-lc-sys` is
  `ISC AND (Apache-2.0 OR ISC) AND OpenSSL`; the OpenSSL term is *conjunctive*,
  so it cannot be satisfied any other way. The original OpenSSL licence is
  permissive but carries an advertising clause and is GPL-incompatible, so it is
  accepted for that one crate and nothing else.
- **CC0-1.0 / Unicode-3.0 / CDLA-Permissive-2.0 — called out separately** rather
  than lumped in with MIT/Apache, because the public-domain dedications carry no
  patent grant. `secp256k1` is the one that matters — we use it for
  transparent-address key derivation.

Given the repo's clean-room posture, the point is that a *new* copyleft
dependency now fails CI instead of arriving quietly. There is no GPL/AGPL/LGPL
in the graph today: `r-efi` shows up under `LGPL-2.1-or-later` in a licence
listing but is `MIT OR Apache-2.0 OR LGPL-2.1-or-later`, so it resolves
permissively and needs no exception.

The three wallet crates gain `publish = false` — none of them is published, and
it is what lets `licenses.private.ignore` skip them rather than fail them for
having no `license` field. That setting never applies to third-party crates.

## Sources

Restricted to crates.io. All three lockfiles already resolve there exclusively
(the in-source Zcash deps are *path* deps into `z/`, not git deps), so this
turns a property that happens to be true into one that stays true: a
`git = "https://github.com/someone/fork"` dependency now fails the gate.

## cargo-deny is itself pinned and verified

The script fetches a cargo-deny release binary and checks its SHA-256 against a
digest committed here, per platform, before running it. Deliberately not a
third-party installer action: a tool whose job is policing the supply chain
should not arrive through an unverified one. Bumping it means replacing the
version *and* all four digests.

## CI wiring

Mirrors #349 exactly.

- New `rust_deny` job in zuuli.yml rather than steps on the 45-minute builds.
  cargo-deny compiles nothing, but unlike `cargo fmt` it does need the graph
  resolved, so the job fetches `z/zcash/librustzcash` and installs the pinned
  toolchain (cargo-deny shells out to `cargo metadata`). Minutes, not 45.
- **`gate` updated in both places** — `needs:` *and* the inline `results=`
  string:
  ```yaml
  needs: [changes, frontend, rust_fmt, rust_deny, rust_plugin, rust_app]
  ```
  ```bash
  results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_DENY_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"
  ```
  Updating only `needs:` would make `gate` wait for `rust_deny` and then ignore
  it. Reasoning about the failure path, since a green run cannot show it: `gate`
  runs `if: always()`, so a failed `rust_deny` does not cancel it; with
  `zuuli == true` the script sets `expected=success` and the loop over
  `$results` — which now contains `$RUST_DENY_RESULT` — hits `failure` and exits
  1. Verified mechanically that the `needs:` set and the set of jobs actually
  inspected by `results=` are equal.
- `rust_deny` carries the same `if: needs.changes.outputs.zuuli == 'true'` as
  its siblings, so under `zuuli == false` it reports `skipped` with them and the
  gate's expected-skip branch stays consistent.
- `wallet/deny.toml` and `scripts/check-rust-deny.sh` joined the change
  detector's `case` filter, so editing the policy re-runs the check.
- zuuallet.yml gets the same job: zuuli.yml's detector does not select
  `wallet/zuuallet/**`, so without it a Zuuallet-only change to `Cargo.toml` or
  `Cargo.lock` could pull in an advisory that nothing checks.

## Proven to fail, not just to pass

Advisories — comment out one `ignore` entry:

```
$ scripts/check-rust-deny.sh advisories
==> cargo-deny check advisories -- wallet/plugins/tauri-plugin-zcash
error[vulnerability]: AWS-LC X.509 Name Constraints Bypass via Wildcard/Unicode CN
advisories FAILED
...
2 crate(s) failed the supply-chain policy
```

Licences — drop `MPL-2.0` from the allow list:

```
$ scripts/check-rust-deny.sh licenses
licenses FAILED   (all three crates)
3 crate(s) failed the supply-chain policy: wallet/plugins/tauri-plugin-zcash wallet/zuuallet/src-tauri wallet/zuuli/src-tauri
```

Both were reverted; the committed state is:

```
$ scripts/check-rust-deny.sh
==> cargo-deny check all -- wallet/plugins/tauri-plugin-zcash
advisories ok, bans ok, licenses ok, sources ok
==> cargo-deny check all -- wallet/zuuallet/src-tauri
advisories ok, bans ok, licenses ok, sources ok
==> cargo-deny check all -- wallet/zuuli/src-tauri
advisories ok, bans ok, licenses ok, sources ok
All 3 Rust crate(s) under wallet/ satisfy wallet/deny.toml.
```

## Known cosmetic wart

One shared policy across three lockfiles means some `ignore` entries apply to a
lockfile other than the one being checked, and cargo-deny reports those as
`advisory-not-detected` warnings. They are warnings, not failures, and the
alternative — three drifting copies of the policy — is worse. Called out in the
script so nobody mistakes them for a problem.

## Also configured

`[bans] multiple-versions = "allow"`. Duplicate versions are endemic to a graph
this size — `windows-sys` appears five times, `getrandom` four, `thiserror` as
both 1.x and 2.x — and at `"warn"` they print roughly sixty lines per crate,
burying the advisory and licence output this gate exists for. Duplication is a
build-size concern, not a supply-chain one. The section is there so that banning
a specific crate later is a one-line change.

`--locked` is passed to cargo-deny so it judges the lockfile CI actually builds,
rather than silently regenerating the graph and clearing an advisory the
committed `Cargo.lock` still carries.

Closes #340. Follow-up: #351.
