### PR TITLE
chore(rust): bump toolchain 1.88.0 -> 1.97.1

### DIFF
--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -208,7 +208,7 @@ jobs:
       # `uses:` cannot take an expression, so this version-branch ref restates
       # wallet/rust-toolchain.toml; scripts/check-rust-toolchain.sh holds it to
       # the source of truth.
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: dtolnay/rust-toolchain@1.97.1
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -49,7 +49,7 @@ env:
   # Restates wallet/rust-toolchain.toml because GitHub cannot compute a
   # workflow-level `env:` from a file. scripts/check-rust-toolchain.sh fails
   # the pull request if this ever stops matching the source of truth.
-  ZUULI_RUST_VERSION: "1.88.0"
+  ZUULI_RUST_VERSION: "1.97.1"
   ZUULI_JAVA_VERSION: "21.0.12"
   ZUULI_XCODE_VERSION: "26.6"
   ZUULI_ANDROID_NDK_VERSION: "27.0.12077973"
@@ -118,7 +118,7 @@ jobs:
       # comment is its only readable record. Bumping the toolchain means moving
       # the SHA to the new version branch and updating the comment with it;
       # scripts/check-rust-toolchain.sh fails the pull request otherwise.
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
+      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with:
           toolchain: ${{ env.ZUULI_RUST_VERSION }}
           targets: ${{ github.event_name == 'pull_request' && 'aarch64-linux-android' || 'aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android' }}
@@ -212,7 +212,7 @@ jobs:
           node-version: "24.18.0"
           cache: npm
           cache-dependency-path: wallet/zuuli/package-lock.json
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
+      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with:
           toolchain: ${{ env.ZUULI_RUST_VERSION }}
           targets: aarch64-apple-ios
@@ -311,7 +311,7 @@ jobs:
           node-version: "24.18.0"
           cache: npm
           cache-dependency-path: wallet/zuuli/package-lock.json
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
+      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with:
           toolchain: ${{ env.ZUULI_RUST_VERSION }}
       - name: Install macOS universal Rust targets

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -42,7 +42,7 @@ env:
   # Restates wallet/rust-toolchain.toml because GitHub cannot compute a
   # workflow-level `env:` from a file. scripts/check-rust-toolchain.sh fails
   # the pull request if this ever stops matching the source of truth.
-  ZUULI_RUST_VERSION: "1.88.0"
+  ZUULI_RUST_VERSION: "1.97.1"
   ZUULI_JAVA_VERSION: "21.0.12"
   ZUULI_XCODE_VERSION: "26.6"
   ZUULI_ANDROID_NDK_VERSION: "27.0.12077973"
@@ -218,7 +218,7 @@ jobs:
       # comment is its only readable record. Bumping the toolchain means moving
       # the SHA to the new version branch and updating the comment with it;
       # scripts/check-rust-toolchain.sh fails the pull request otherwise.
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
+      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with:
           toolchain: ${{ env.ZUULI_RUST_VERSION }}
           targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
@@ -365,7 +365,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24.18.0"
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
+      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with:
           toolchain: ${{ env.ZUULI_RUST_VERSION }}
           targets: aarch64-apple-ios
@@ -581,7 +581,7 @@ jobs:
           {
             node-version: "24.18.0",
           }
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
+      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with: { toolchain: "${{ env.ZUULI_RUST_VERSION }}" }
       - name: Install package dependencies
         run: |
@@ -678,7 +678,7 @@ jobs:
           {
             node-version: "24.18.0",
           }
-      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
+      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with:
           {
             toolchain: "${{ env.ZUULI_RUST_VERSION }}",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,16 +188,20 @@ A bump that touches the source of truth and nothing else **cannot merge** — th
 gate fails. That is the point: the version is one edit plus a mechanical
 follow-through, not an eleven-place archaeology exercise.
 
-### Cadence — proposed, not yet adopted
+### Cadence
 
-The pin is currently `1.88.0`, released June 2025 and roughly fourteen months
-old at the time of writing. Nothing here changes it; the bump is a separate,
-owner-gated decision because it moves every mobile and desktop release target at
-once. **Proposal for the owner to accept or reject:** track **stable minus one
-or two releases**, reviewed **quarterly**, with a named owner, so the pin is
-current enough for modern crates' MSRVs without chasing stable into surprises.
-Recorded here so the next person inherits a decision to make rather than a
-literal to be afraid of.
+The pin is currently `1.97.1`, the current stable at the time of writing. It
+moved here from `1.88.0` — a nine-version, fourteen-month jump — because the
+owner wants the release trains building on a modern compiler and the mechanical
+follow-through is now one script instead of an archaeology exercise.
+
+A bump moves every mobile and desktop release target at once, so it stays an
+**owner-gated decision**, reviewed **quarterly**, targeting **stable or stable
+minus one**. The MSRV consequence is deliberate: the three `rust-version` fields
+are defined as the two-component form of the channel, so bumping the channel
+raises them too. None of these crates is published to crates.io, so the MSRV is
+a statement of what we build with, not a compatibility promise to downstream
+consumers.
 
 ## Verifying before you push
 

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -51,6 +51,11 @@ DOC_PINS=(
   $'wallet/plugins/tauri-plugin-zcash/CLAUDE.md\tRust edition 2024, MSRV %MSRV%.'
   $'wallet/zuuli/docs/releasing.md\tRust `%CHANNEL%`'
   $'AGENTS.md\tThe pin is currently `%CHANNEL%`'
+  # Not prose: release-identity.mjs reads rust-toolchain.toml and asserts the
+  # channel equals this literal, so the release train fails closed on a silent
+  # edit to the source of truth. Checked here so a *deliberate* bump does not
+  # have to discover it 18 seconds into the packaging matrix.
+  $'wallet/zuuli/scripts/release-identity.mjs\t  "%CHANNEL%",'
 )
 
 # `toolchain:` may be an expression instead of a literal, but only one that

--- a/wallet/plugins/tauri-plugin-zcash/CLAUDE.md
+++ b/wallet/plugins/tauri-plugin-zcash/CLAUDE.md
@@ -13,7 +13,7 @@ cargo build --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
 cd wallet/zuuli && npm run tauri dev
 ```
 
-Rust edition 2024, MSRV 1.88. All librustzcash deps are path deps at `z/zcash/librustzcash`.
+Rust edition 2024, MSRV 1.97. All librustzcash deps are path deps at `z/zcash/librustzcash`.
 
 ## Type aliases
 

--- a/wallet/plugins/tauri-plugin-zcash/Cargo.toml
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tauri-plugin-zcash"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.97"
 # Never goes to a registry: the wallet crates are consumed by path only. This is
 # also what lets wallet/deny.toml skip them under `licenses.private.ignore`.
 publish = false

--- a/wallet/plugins/tauri-plugin-zcash/README.md
+++ b/wallet/plugins/tauri-plugin-zcash/README.md
@@ -143,10 +143,10 @@ the manifest that actually survived, never by an unsafe same-process guess.
 
 ```bash
 # Check (fast, no linking)
-cargo +1.88.0 check --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
+cargo +1.97.1 check --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
 
 # Run the plugin's wallet/send and lifecycle regression tests
-cargo +1.88.0 test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
+cargo +1.97.1 test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
 
 # Build
 cargo build --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
@@ -156,7 +156,7 @@ cd wallet/zuuli && npm run tauri build
 ```
 
 - **Rust edition**: 2024
-- **MSRV**: 1.88
+- **MSRV**: 1.97
 - **librustzcash**: path deps at `z/zcash/librustzcash` (forked)
 
 ## Known gotchas

--- a/wallet/rust-toolchain.toml
+++ b/wallet/rust-toolchain.toml
@@ -8,6 +8,6 @@
 # Bumping: change `channel` here, then run `scripts/check-rust-toolchain.sh` and
 # fix everything it names. See "The Rust toolchain pin" in the root AGENTS.md.
 [toolchain]
-channel = "1.88.0"
+channel = "1.97.1"
 profile = "minimal"
 components = ["clippy", "rustfmt"]

--- a/wallet/zuuallet/README.md
+++ b/wallet/zuuallet/README.md
@@ -6,7 +6,7 @@ A privacy-first desktop wallet for Zcash, built with Tauri v2, React, and librus
 
 ### Prerequisites
 
-- [Rust](https://rustup.rs/) 1.88+ (edition 2024)
+- [Rust](https://rustup.rs/) 1.97+ (edition 2024)
 - [Node.js](https://nodejs.org/) 18+
 - [Tauri CLI](https://tauri.app/start/): `cargo install tauri-cli`
 - Git submodules initialized: `git submodule update --init --recursive` (for `z/zcash/librustzcash`)

--- a/wallet/zuuallet/src-tauri/Cargo.toml
+++ b/wallet/zuuallet/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zuuallet"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.97"
 # Never goes to a registry: the wallet crates are consumed by path only. This is
 # also what lets wallet/deny.toml skip them under `licenses.private.ignore`.
 publish = false

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -15,7 +15,7 @@ Gradle representation disagrees. Never fix a release mismatch with Tauri's
 `iosUsesNonExemptEncryption` to `false`; verification requires both the source
 and generated iOS plists to carry the matching Boolean.
 
-The train pins Node `24.18.0`, Rust `1.88.0`, Java `21.0.12`, Xcode `26.6`,
+The train pins Node `24.18.0`, Rust `1.97.1`, Java `21.0.12`, Xcode `26.6`,
 Android SDK/build tools `36`/`36.0.0`, Android NDK `27.0.12077973`, Gradle
 `8.14.3` with its distribution checksum, Fastlane `2.237.0` through a
 checksum-bearing Bundler `4.0.3` lockfile, and Syft `1.50.0`. Action dependencies

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -543,7 +543,9 @@ expect(
 expect(
   "Rust toolchain",
   capture(/channel\s*=\s*"([^"]+)"/, rustToolchain, "Rust toolchain"),
-  "1.88.0",
+  // rust-toolchain.toml channel, restated so a silent edit to the source of
+  // truth fails here too. scripts/check-rust-toolchain.sh holds it in step.
+  "1.97.1",
 );
 for (const wiring of [
   "IOS_MOBILE_PROVISION: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}",

--- a/wallet/zuuli/src-tauri/Cargo.toml
+++ b/wallet/zuuli/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zuuli"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.97"
 # Never goes to a registry: the wallet crates are consumed by path only. This is
 # also what lets wallet/deny.toml skip them under `licenses.private.ignore`.
 publish = false


### PR DESCRIPTION
Closes #338.

PR #347 built the machinery — one source of truth plus a drift check. This is the other half of the issue: the bump itself.

## The jump

`1.88.0` (June 2025) → **`1.97.1`** (2026-07-14, `8bab26f4f`) — **nine stable releases, ~14 months**, across the librustzcash graph and Tauri. Verified as current stable against `https://static.rust-lang.org/dist/channel-rust-stable.toml`.

One decision (`channel` in `wallet/rust-toolchain.toml`), then mechanical follow-through. Every file below was **named by `scripts/check-rust-toolchain.sh`**, with line numbers — nothing was found by grepping around.

| File | What moved |
|---|---|
| `wallet/rust-toolchain.toml` | `channel` — **the only decision** |
| `wallet/zuuli/src-tauri/Cargo.toml` | `rust-version` `1.88` → `1.97` |
| `wallet/zuuallet/src-tauri/Cargo.toml` | `rust-version` `1.88` → `1.97` |
| `wallet/plugins/tauri-plugin-zcash/Cargo.toml` | `rust-version` `1.88` → `1.97` |
| `.github/workflows/zuuli-packaging.yml` | `ZUULI_RUST_VERSION` + **3 commit-pinned action SHAs** |
| `.github/workflows/zuuli-release.yml` | `ZUULI_RUST_VERSION` + **4 commit-pinned action SHAs** |
| `.github/workflows/zuuallet.yml` | `dtolnay/rust-toolchain@1.88.0` → `@1.97.1` (version-branch ref) |
| `wallet/zuuallet/README.md` | prerequisite line |
| `wallet/plugins/tauri-plugin-zcash/README.md` | two `cargo +<ver>` lines + MSRV |
| `wallet/plugins/tauri-plugin-zcash/CLAUDE.md` | MSRV prose |
| `wallet/zuuli/docs/releasing.md` | release-train pin |
| `AGENTS.md` | cadence section — proposal → adopted policy |
| `wallet/zuuli/scripts/release-identity.mjs` | a **twelfth** restatement the drift check did not know about — see below |

`scripts/check-rust-toolchain.sh` passes, and `--self-test` still catches all 7 drift cases.

## The SHA swap — the part that silently doesn't work if you skip it

`dtolnay/rust-toolchain`'s **version branches hardcode the compiler and declare no `toolchain` input at all**. The commit-pinned SHA *is* the version pin; the `toolchain:` value beside it is inert and ignored. Updating only the `# 1.88.0` comments would have left CI building on 1.88.0 while every comment claimed 1.97.1 — surfacing first in a protected store release, at the `rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "` step.

So all 7 pinned refs moved:

`2eae45db285e407f22119950686d47e1101e071b` → **`032958afbdc797a9164d3bc0b56325c1308924a5`**

Proof the new SHA installs 1.97.1:

```console
$ gh api "repos/dtolnay/rust-toolchain/contents/action.yml?ref=032958afbdc797a9164d3bc0b56325c1308924a5" \
    -q .content | base64 -d | grep -A2 "^      env:"
      env:
        toolchain: 1.97.1
      shell: bash
```

That SHA is the head of the upstream `1.97.1` branch (`refs/heads/1.97.1`). Its `inputs:` block declares only `targets`, `target`, and `components` — confirming the version branch takes no `toolchain` input, exactly as the doctrine in `AGENTS.md` describes. (`@stable`, used by the required gate, *does* declare `toolchain`, which is why the gate can feed it `--print-channel` and hold no literal.)

CI confirms it end to end. The Android packaging job installed, from the commit-pinned action:

```
1.97.1-x86_64-unknown-linux-gnu installed - rustc 1.97.1 (8bab26f4f 2026-07-14)
rustc 1.97.1 (8bab26f4f 2026-07-14)
```

and GitHub emitted exactly the warning the doctrine predicts, proving the adjacent `toolchain:` value is inert:

```
##[warning]Unexpected input(s) 'toolchain', valid inputs are ['targets', 'target', 'components']
```

## MSRV policy consequence — deliberate, not a side effect

The drift check defines each crate's `rust-version` as the two-component MSRV form of the channel, so bumping the channel necessarily raises all three from `1.88` to `1.97`.

That is the intended policy: **we support what we build with.** None of these crates is published to crates.io, so `rust-version` states our build floor rather than a compatibility promise to downstream consumers. `AGENTS.md` now says so explicitly, alongside the cadence, which this PR turns from a proposal into an adopted policy (**stable or stable-minus-one, reviewed quarterly, owner-gated**) — closing the third acceptance criterion of #338.

## Verification

Built and tested locally on `1.97.1-x86_64-apple-darwin` (`rustc 1.97.1 (8bab26f4f 2026-07-14)`), with `--locked` throughout and `z/zcash/librustzcash` initialised:

- `cargo +1.97.1 test --locked --all-targets` — `wallet/plugins/tauri-plugin-zcash`
- `cargo +1.97.1 build --locked` — `wallet/zuuli/src-tauri`
- `cargo +1.97.1 build --locked` — `wallet/zuuallet/src-tauri`

| Crate | Result |
|---|---|
| `wallet/plugins/tauri-plugin-zcash` | `cargo test --locked --all-targets` — **94 passed, 0 failed** (exit 0) |
| `wallet/zuuli/src-tauri` | `cargo build --locked` — clean in 35m40s; `cargo test --locked` — **12 passed, 0 failed** |
| `wallet/zuuallet/src-tauri` | `cargo build --locked` — clean in 34m15s |

**No source changes were needed.** Nine versions' worth of new and promoted lints — `unsafe_op_in_unsafe_fn`, stricter trait resolution, the usual churn — produced nothing that broke us. `tauri-plugin-zcash` was already edition 2024.

**No `Cargo.lock` changed.** `--locked` held across all three graphs, on cold rebuilds from scratch. Consequently the 32 advisory ignores in `wallet/deny.toml` are untouched and `Rust / supply chain` passes unchanged — nothing from #351 was disturbed.

**`cargo fmt` produced zero changes.** This is the surprising one and worth recording. `scripts/check-rust-fmt.sh` exists precisely because rustfmt's output is not stable across compiler versions, so the expectation going in was a reformat pass. Across nine releases, rustfmt 1.97.1 agrees with rustfmt 1.88.0 on every crate under `wallet/` — verified locally (`RUSTUP_TOOLCHAIN=1.97.1 scripts/check-rust-fmt.sh`) and confirmed green by the `Rust / formatting` job. **There is no reformat commit in this PR because there was nothing to reformat.**

The one thing that did break is below.

## A twelfth restatement the drift check did not know about

The first CI run failed **all five packaging jobs** — including `Release identity`, which finishes in 18 seconds and compiles no Rust:

```
ZUULI release identity is inconsistent:
- Rust toolchain: expected "1.88.0", got "1.97.1"
```

`wallet/zuuli/scripts/release-identity.mjs` reads `wallet/rust-toolchain.toml` and asserts the channel equals a hardcoded literal, so the release train fails closed if the source of truth is edited silently. That is a genuinely useful assertion — its whole job is to disagree with the file — but it was the one restatement `scripts/check-rust-toolchain.sh` had never been taught about. The drift check passed locally, and the bump still broke every installable artifact.

Second commit fixes both halves: the literal moves to `1.97.1`, **and the file joins `DOC_PINS`** so the next bump is named by the drift check like everything else rather than discovered 18 seconds into the packaging matrix. `--self-test` still catches all 7 cases.

This is the acceptance criterion of #338 working as intended, one restatement late.

A local macOS build is not the last word — per `AGENTS.md`, feature unification and platform-gating only show up in a clean Linux build. CI is the real gate.

## Device testing

`wallet/rust-toolchain.toml` is in the path filter of `zuuli-packaging.yml`, so the full packaging matrix runs on this PR and produces installable artifacts:

**All four built green on 1.97.1.** Download from the [`ZUULI / packaging smoke` run](https://github.com/free2z/zuu/actions/runs/31294684142) → **Artifacts** (retained until 2026-08-23):

| Artifact | Job | Time | Size |
|---|---|---|---|
| `zuuli-android-unsigned-7c44a24` | Android / unsigned AAB | 12m30s | 17.1 MB |
| `zuuli-ios-unsigned-7c44a24` | iOS / unsigned target app | 10m14s | 12.5 MB |
| `zuuli-Linux-unsigned-7c44a24` | Desktop / Linux packages | 11m49s | 119.8 MB |
| `zuuli-macOS-unsigned-7c44a24` | Desktop / macOS universal app | 19m3s | 55.7 MB |

Each packaging job runs `rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "` **before** building — those four steps are the running proof that the SHA swap took effect rather than being cosmetic, and all four passed.

## Full CI result

Every check green, including the required `gate`:

- **Gate:** `gate`, `changes`, `Rust / shared plugin` (10m8s), `Rust / ZUULI backend` (12m39s), `Rust / formatting`, `Rust / supply chain`, `frontend`
- **Packaging:** `Release identity`, Android, iOS, Desktop Linux, Desktop macOS — the four installable targets
- **Zuuallet:** `rust` (19m5s), `fmt`, `deny`, `frontend`, `custody / macos-latest`, `custody / windows-latest` (19m15s)

Windows and macOS custody adapters — the platform-specific Keychain and Credential Manager code that only compiles on its native host — both build on 1.97.1.

## Scope

Version bump only, plus the drift-check coverage gap the bump exposed. The `changes` path filters and the `gate` job's `needs:`/`results` logic are untouched, as is `wallet/deny.toml`.

Rebased onto `main` after #349 (`cargo fmt`), #352 (`cargo-deny`), and #344 landed; the `publish = false` addition from #352 is preserved alongside the new `rust-version` in all three manifests.
