### PR TITLE
fix(zuuli): respect mobile safe areas

### DIFF
--- a/wallet/zuuli/index.html
+++ b/wallet/zuuli/index.html
@@ -2,7 +2,10 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <meta name="color-scheme" content="dark" />
     <title>ZUULI</title>
   </head>

--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs",
     "test:play-testers": "node --test scripts/play-tester-groups.node-test.mjs",
     "typecheck": "tsc --noEmit",
     "release:verify": "node scripts/release-identity.mjs",

--- a/wallet/zuuli/scripts/safe-area-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/safe-area-contract.node-test.mjs
@@ -14,7 +14,12 @@ const topBar = source("../src/components/layout/TopBar.tsx");
 const sidebar = source("../src/components/layout/Sidebar.tsx");
 const auth = source("../src/features/auth/index.tsx");
 const ai = source("../src/features/ai/index.tsx");
+const reader = source("../src/features/articles/pages/Reader.tsx");
 const root = source("../src/main.tsx");
+const androidManifest = source(
+  "../src-tauri/gen/android/app/src/main/AndroidManifest.xml",
+);
+const androidGradle = source("../src-tauri/gen/android/app/build.gradle.kts");
 const androidActivity = source(
   "../src-tauri/gen/android/app/src/main/java/cash/free2z/zuuli/MainActivity.kt",
 );
@@ -50,14 +55,23 @@ test("cover is enabled only together with four authoritative inset fallbacks", (
 
 test("the document and app are bounded to one dynamic viewport frame", () => {
   assert.match(css, /html,\s*body,\s*#root\s*\{[^}]*overflow: hidden;/s);
-  assert.match(cssRule("app-viewport"), /height: 100dvh;/);
+  for (const className of ["app-viewport", "app-crash-frame"]) {
+    const rule = cssRule(className);
+    const legacyHeight = rule.indexOf("height: 100vh;");
+    const dynamicHeight = rule.indexOf("height: 100dvh;");
+    assert.ok(legacyHeight >= 0, `${className} lacks the legacy fallback`);
+    assert.ok(
+      dynamicHeight > legacyHeight,
+      `${className} must override 100vh with 100dvh in declaration order`,
+    );
+  }
   assert.match(cssRule("app-viewport"), /overflow: hidden;/);
   assert.match(shell, /className="app-viewport flex bg-background"/);
   assert.match(shell, /data-app-frame/);
-  assert.match(root, /height: "100dvh"/);
+  assert.match(root, /className="app-crash-frame"/);
 
   for (const framingSource of [shell, auth, root]) {
-    assert.doesNotMatch(framingSource, /(?:min-h-screen|\bh-screen\b|100vh)/);
+    assert.doesNotMatch(framingSource, /(?:min-h-screen|\bh-screen\b)/);
   }
 });
 
@@ -84,16 +98,28 @@ test("chrome and full-bleed clearance use centralized variables", () => {
   assert.match(ai, /app-full-bleed-inset/);
   assert.match(shell, /app-scroll-content/);
   assert.match(auth, /app-auth-content/);
+  assert.match(reader, /app-reader-content/);
+  assert.match(reader, /app-reader-actions/);
+  assert.doesNotMatch(reader, /fixed[^"\n]*\bbottom-0\b/);
 
-  for (const component of [shell, topBar, sidebar, auth, ai]) {
+  for (const component of [shell, topBar, sidebar, auth, ai, reader]) {
     assert.doesNotMatch(component, /env\(safe-area-inset-/);
   }
 });
 
-test("native edge-to-edge setup precedes WebView creation", () => {
-  const enable = androidActivity.indexOf("enableEdgeToEdge()");
+test("native edge-to-edge, IME resize, and dark-chrome contrast are explicit", () => {
+  const enable = androidActivity.indexOf("enableEdgeToEdge(");
   const create = androidActivity.indexOf("super.onCreate(savedInstanceState)");
+  const controller = androidActivity.indexOf("WindowCompat.getInsetsController");
 
   assert.ok(enable >= 0);
   assert.ok(create > enable);
+  assert.ok(controller > create);
+  assert.match(androidActivity, /statusBarStyle = SystemBarStyle\.dark/);
+  assert.match(androidActivity, /navigationBarStyle = SystemBarStyle\.dark/);
+  assert.match(androidActivity, /Color\.argb\(0x80, 0x0A, 0x0A, 0x0F\)/);
+  assert.match(androidActivity, /isAppearanceLightStatusBars = false/);
+  assert.match(androidActivity, /isAppearanceLightNavigationBars = false/);
+  assert.match(androidManifest, /android:windowSoftInputMode="adjustResize"/);
+  assert.match(androidGradle, /androidx\.core:core-ktx:1\.15\.0/);
 });

--- a/wallet/zuuli/scripts/safe-area-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/safe-area-contract.node-test.mjs
@@ -91,6 +91,21 @@ test("login stays inside pinned chrome with one bounded scroll owner", () => {
   assert.equal(shell.match(/data-route-scroll/g)?.length, 1);
   assert.match(auth, /h-full min-h-0/);
   assert.match(shell, /className="min-h-0 flex-1 overflow-hidden"/);
+
+  const authMain = auth.match(
+    /<main className="([^"]*app-auth-content[^"]*)"/,
+  );
+  assert.ok(authMain, "login must keep the centralized auth inset container");
+  assert.match(authMain[1], /\bjustify-start\b/);
+  assert.doesNotMatch(
+    authMain[1],
+    /\bjustify-center\b/,
+    "centering an overflowing auth column creates unreachable negative overflow",
+  );
+  assert.match(
+    auth,
+    /className="app-auth-stack my-auto flex w-full max-w-md flex-col"/,
+  );
 });
 
 test("chrome and full-bleed clearance use centralized variables", () => {

--- a/wallet/zuuli/scripts/safe-area-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/safe-area-contract.node-test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function source(relativeUrl) {
+  return readFileSync(new URL(relativeUrl, import.meta.url), "utf8");
+}
+
+const html = source("../index.html");
+const css = source("../src/index.css");
+const app = source("../src/App.tsx");
+const shell = source("../src/components/layout/AppShell.tsx");
+const topBar = source("../src/components/layout/TopBar.tsx");
+const sidebar = source("../src/components/layout/Sidebar.tsx");
+const auth = source("../src/features/auth/index.tsx");
+const ai = source("../src/features/ai/index.tsx");
+const root = source("../src/main.tsx");
+const androidActivity = source(
+  "../src-tauri/gen/android/app/src/main/java/cash/free2z/zuuli/MainActivity.kt",
+);
+
+function cssRule(className) {
+  const match = css.match(new RegExp(`\\.${className}\\s*\\{([^}]+)\\}`));
+  assert.ok(match, `missing .${className} CSS rule`);
+  return match[1];
+}
+
+test("cover is enabled only together with four authoritative inset fallbacks", () => {
+  assert.match(html, /viewport-fit=cover/);
+  assert.match(html, /interactive-widget=resizes-content/);
+
+  for (const side of ["top", "right", "bottom", "left"]) {
+    assert.match(
+      css,
+      new RegExp(
+        `--safe-area-${side}: env\\(safe-area-inset-${side}, 0px\\);`,
+      ),
+    );
+  }
+
+  assert.match(cssRule("app-top-bar"), /var\(--safe-area-top\)/);
+  assert.match(cssRule("app-bottom-nav"), /var\(--safe-area-bottom\)/);
+  assert.match(cssRule("app-viewport"), /var\(--safe-area-left\)/);
+  assert.match(cssRule("app-viewport"), /var\(--safe-area-right\)/);
+  assert.match(topBar, /className="app-top-bar /);
+  assert.match(sidebar, /className="app-bottom-nav /);
+  assert.match(topBar, /data-app-top-bar/);
+  assert.match(sidebar, /data-app-bottom-nav/);
+});
+
+test("the document and app are bounded to one dynamic viewport frame", () => {
+  assert.match(css, /html,\s*body,\s*#root\s*\{[^}]*overflow: hidden;/s);
+  assert.match(cssRule("app-viewport"), /height: 100dvh;/);
+  assert.match(cssRule("app-viewport"), /overflow: hidden;/);
+  assert.match(shell, /className="app-viewport flex bg-background"/);
+  assert.match(shell, /data-app-frame/);
+  assert.match(root, /height: "100dvh"/);
+
+  for (const framingSource of [shell, auth, root]) {
+    assert.doesNotMatch(framingSource, /(?:min-h-screen|\bh-screen\b|100vh)/);
+  }
+});
+
+test("login stays inside pinned chrome with one bounded scroll owner", () => {
+  const shellRoute = app.indexOf('<Route element={<AppShell />}>');
+  const loginRoute = app.indexOf(
+    '<Route path="/login" element={<AuthFeature />} />',
+  );
+  const catchAll = app.indexOf('<Route path="*" element={<NotFound />} />');
+
+  assert.ok(shellRoute >= 0);
+  assert.ok(loginRoute > shellRoute);
+  assert.ok(loginRoute < catchAll);
+  assert.match(shell, /location\.pathname === "\/login"/);
+  assert.equal(auth.match(/overflow-y-auto/g)?.length, 1);
+  assert.equal(auth.match(/data-route-scroll/g)?.length, 1);
+  assert.equal(shell.match(/data-route-scroll/g)?.length, 1);
+  assert.match(auth, /h-full min-h-0/);
+  assert.match(shell, /className="min-h-0 flex-1 overflow-hidden"/);
+});
+
+test("chrome and full-bleed clearance use centralized variables", () => {
+  assert.match(sidebar, /app-sidebar/);
+  assert.match(ai, /app-full-bleed-inset/);
+  assert.match(shell, /app-scroll-content/);
+  assert.match(auth, /app-auth-content/);
+
+  for (const component of [shell, topBar, sidebar, auth, ai]) {
+    assert.doesNotMatch(component, /env\(safe-area-inset-/);
+  }
+});
+
+test("native edge-to-edge setup precedes WebView creation", () => {
+  const enable = androidActivity.indexOf("enableEdgeToEdge()");
+  const create = androidActivity.indexOf("super.onCreate(savedInstanceState)");
+
+  assert.ok(enable >= 0);
+  assert.ok(create > enable);
+});

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
     implementation("androidx.webkit:webkit:1.14.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("androidx.activity:activity-ktx:1.10.1")
+    implementation("androidx.core:core-ktx:1.15.0")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.lifecycle:lifecycle-process:2.10.0")
     testImplementation("junit:junit:4.13.2")

--- a/wallet/zuuli/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/wallet/zuuli/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
             android:launchMode="singleTask"
             android:label="@string/main_activity_title"
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/wallet/zuuli/src-tauri/gen/android/app/src/main/java/cash/free2z/zuuli/MainActivity.kt
+++ b/wallet/zuuli/src-tauri/gen/android/app/src/main/java/cash/free2z/zuuli/MainActivity.kt
@@ -1,11 +1,25 @@
 package cash.free2z.zuuli
 
+import android.graphics.Color
 import android.os.Bundle
+import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowCompat
 
 class MainActivity : TauriActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
-    enableEdgeToEdge()
+    enableEdgeToEdge(
+      statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+      // On three-button navigation Android may need an opaque-enough scrim
+      // behind light controls; gesture navigation remains edge-to-edge.
+      navigationBarStyle = SystemBarStyle.dark(Color.argb(0x80, 0x0A, 0x0A, 0x0F)),
+    )
     super.onCreate(savedInstanceState)
+    // ZUULI chrome is fixed-dark regardless of the device theme. Keep the
+    // transparent edge-to-edge system bars legible on light-system devices.
+    WindowCompat.getInsetsController(window, window.decorView).apply {
+      isAppearanceLightStatusBars = false
+      isAppearanceLightNavigationBars = false
+    }
   }
 }

--- a/wallet/zuuli/src/App.tsx
+++ b/wallet/zuuli/src/App.tsx
@@ -16,7 +16,8 @@ import AuthFeature from "@/features/auth";
 // Feature routes are code-split so the heavy markdown/math/prism graph they
 // transitively pull in (rehype-mathjax, rehype-prism-plus) never lands in the
 // login/critical-path entry chunk. The login screen (AuthFeature), the AppShell
-// layout, and the router stay eager so /login renders instantly.
+// layout, and the router stay eager so /login renders instantly inside the
+// same viewport-bound chrome as every other route.
 const HomeFeature = lazy(() => import("@/features/home"));
 const WalletFeature = lazy(() => import("@/features/wallet"));
 const AiFeature = lazy(() => import("@/features/ai"));
@@ -89,12 +90,10 @@ export default function App() {
       <BrowserRouter>
         <MobileOAuthRecovery />
         <Routes>
-          {/* Full-screen auth, outside the app shell — kept eager so /login is instant */}
-          <Route path="/login" element={<AuthFeature />} />
-
-          {/* Everything else lives inside the shell. A single Suspense boundary
+          {/* Every route lives inside the viewport-bound shell. A single Suspense boundary
               per route keeps the AppShell mounted while the lazy chunk loads. */}
           <Route element={<AppShell />}>
+            <Route path="/login" element={<AuthFeature />} />
             <Route
               index
               element={

--- a/wallet/zuuli/src/components/layout/AppShell.tsx
+++ b/wallet/zuuli/src/components/layout/AppShell.tsx
@@ -31,27 +31,28 @@ function LegacyWalletNotice() {
 
 export function AppShell() {
   const location = useLocation();
-  // The AI chat needs a bounded-height panel with its own internal scroll
-  // region (message list) and a footer pinned to the true bottom — Radix's
+  // AI and login each own a bounded internal scroll region while the header
+  // and mobile tabs stay pinned. Radix's
   // ScrollArea wraps children in a `display: table` div that sizes to
   // content, so a `h-full` flex column nested inside it can never resolve a
   // real height. Give that route a plain, height-bound `main` instead of the
   // page-scrolling ScrollArea every other route uses.
-  const isFullBleed = location.pathname.startsWith("/ai");
+  const isFullBleed =
+    location.pathname.startsWith("/ai") || location.pathname === "/login";
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
+    <div className="app-viewport flex bg-background" data-app-frame>
       <Sidebar />
       <div className="flex min-w-0 flex-1 flex-col">
         <TopBar />
         <LegacyWalletNotice />
         {isFullBleed ? (
-          <main className="min-h-0 flex-1 overflow-hidden">
+          <main className="min-h-0 flex-1 overflow-hidden" data-route-frame>
             <Outlet />
           </main>
         ) : (
-          <ScrollArea className="flex-1">
-            <main className="mx-auto w-full max-w-6xl px-4 pb-24 pt-6 md:px-8 md:pb-10">
+          <ScrollArea className="min-h-0 flex-1" data-route-scroll>
+            <main className="app-scroll-content mx-auto w-full max-w-6xl px-4 pt-6 md:px-8">
               <Outlet />
             </main>
           </ScrollArea>

--- a/wallet/zuuli/src/components/layout/Sidebar.tsx
+++ b/wallet/zuuli/src/components/layout/Sidebar.tsx
@@ -23,7 +23,7 @@ const NAV = [
 
 export function Sidebar() {
   return (
-    <aside className="hidden w-60 shrink-0 flex-col border-r border-border bg-card/40 md:flex">
+    <aside className="app-sidebar hidden w-60 shrink-0 flex-col border-r border-border bg-card/40 md:flex">
       <div className="px-5 py-5">
         <Wordmark />
       </div>
@@ -59,7 +59,10 @@ export function Sidebar() {
 /** Bottom tab bar for narrow / mobile widths. */
 export function MobileTabBar() {
   return (
-    <nav className="fixed inset-x-0 bottom-0 z-40 flex h-[calc(3.5rem+env(safe-area-inset-bottom))] border-t border-border bg-card/95 pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden">
+    <nav
+      className="app-bottom-nav fixed inset-x-0 bottom-0 z-40 flex border-t border-border bg-card/95 backdrop-blur md:hidden"
+      data-app-bottom-nav
+    >
       {NAV.map(({ to, label, icon: Icon, end }) => (
         <NavLink
           key={to}

--- a/wallet/zuuli/src/components/layout/TopBar.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.tsx
@@ -49,7 +49,10 @@ export function TopBar() {
   const canGoBack = historyIdx > 0 && location.pathname !== "/";
 
   return (
-    <header className="sticky top-0 z-30 flex h-14 items-center gap-3 border-b border-border bg-background/80 px-4 backdrop-blur">
+    <header
+      className="app-top-bar sticky top-0 z-30 flex shrink-0 items-center gap-3 border-b border-border bg-background/80 px-4 backdrop-blur"
+      data-app-top-bar
+    >
       {/* Global back — available on every screen inside the shell */}
       {canGoBack ? (
         <Button

--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -315,7 +315,7 @@ export default function AiFeature() {
   const localModel = models.find((m) => m.provider === "local");
 
   return (
-    <div className="flex h-full min-h-0 flex-col pb-[calc(3.5rem+env(safe-area-inset-bottom))] md:pb-0">
+    <div className="app-full-bleed-inset flex h-full min-h-0 flex-col">
       {/* ── Header rail ─────────────────────────────────────────────── */}
       <div className="shrink-0 border-b border-border/60 bg-background/85 px-4 py-2.5 backdrop-blur md:px-8">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">

--- a/wallet/zuuli/src/features/articles/pages/Reader.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Reader.tsx
@@ -75,7 +75,7 @@ export function Reader() {
   const name = author.display_name || author.username;
 
   return (
-    <article className="animate-slide-up w-full min-w-0 overflow-x-clip pb-28">
+    <article className="app-reader-content animate-slide-up w-full min-w-0 overflow-x-clip">
       <div className="mx-auto w-full min-w-0 max-w-3xl">
         <BackLink />
 
@@ -156,7 +156,7 @@ export function Reader() {
       </div>
 
       {/* Sticky action bar */}
-      <div className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-background/80 backdrop-blur-md">
+      <div className="app-reader-actions fixed inset-x-0 z-30 border-t border-border bg-background/80 backdrop-blur-md">
         <div className="mx-auto flex max-w-3xl items-center justify-between gap-3 px-4 py-3">
           <ArticleScore score={article.votes ?? 0} />
           <TipDialog author={author} />

--- a/wallet/zuuli/src/features/auth/BrandPanel.tsx
+++ b/wallet/zuuli/src/features/auth/BrandPanel.tsx
@@ -30,7 +30,7 @@ const VALUES = [
 
 export function BrandPanel() {
   return (
-    <aside className="zuuli-hero-glow relative hidden flex-col justify-between overflow-hidden border-r border-border bg-background p-10 lg:flex xl:p-14">
+    <aside className="zuuli-hero-glow relative hidden flex-col justify-between border-r border-border bg-background p-10 lg:flex xl:p-14">
       {/* Ambient glow accents */}
       <div
         className="pointer-events-none absolute -left-24 top-1/3 h-72 w-72 rounded-full bg-primary/20 blur-3xl"

--- a/wallet/zuuli/src/features/auth/index.tsx
+++ b/wallet/zuuli/src/features/auth/index.tsx
@@ -1,7 +1,7 @@
 // ZUULI — Login.
 //
-// A standalone, full-viewport auth page (mounted at /login, outside the app
-// shell). ZUULI is Zcash-native, so Login with Zcash leads as the default,
+// A viewport-bound auth page mounted inside the persistent app shell. ZUULI is
+// Zcash-native, so Login with Zcash leads as the default,
 // prominent choice — passwordless, no email, no KYC. Email/username + password
 // (with 2FA when enabled) and, soon, X / Google follow below as alternatives.
 
@@ -36,10 +36,13 @@ export default function AuthFeature() {
   }, [bootstrap]);
 
   return (
-    <div className="grid min-h-screen w-full grid-cols-1 bg-background lg:grid-cols-2">
+    <div
+      className="grid h-full min-h-0 w-full grid-cols-1 overflow-y-auto bg-background lg:grid-cols-2"
+      data-route-scroll
+    >
       <BrandPanel />
 
-      <main className="relative flex min-h-screen flex-col items-center justify-center overflow-y-auto p-6 sm:p-10">
+      <main className="app-auth-content relative flex min-h-full flex-col items-center justify-center p-6 sm:p-10">
         {/* Compact wordmark for small screens where the brand panel is hidden */}
         <div className="mb-8 lg:hidden">
           <Wordmark />

--- a/wallet/zuuli/src/features/auth/index.tsx
+++ b/wallet/zuuli/src/features/auth/index.tsx
@@ -42,103 +42,108 @@ export default function AuthFeature() {
     >
       <BrandPanel />
 
-      <main className="app-auth-content relative flex min-h-full flex-col items-center justify-center p-6 sm:p-10">
-        {/* Compact wordmark for small screens where the brand panel is hidden */}
-        <div className="mb-8 lg:hidden">
-          <Wordmark />
-        </div>
+      <main className="app-auth-content relative flex min-h-full flex-col items-center justify-start p-6 sm:p-10">
+        {/* Auto block margins center the stack only when it fits. Unlike
+            justify-center, they collapse to zero when the stack is taller
+            than the bounded scroller, so its top can always be reached. */}
+        <div className="app-auth-stack my-auto flex w-full max-w-md flex-col">
+          {/* Compact wordmark for small screens where the brand panel is hidden */}
+          <div className="mb-8 lg:hidden">
+            <Wordmark />
+          </div>
 
-        <div className="w-full max-w-md animate-slide-up">
-          <Card className="border-border/80 bg-card/70 shadow-glow backdrop-blur">
-            <CardHeader className="space-y-1">
-              <CardTitle className="text-2xl">Sign in to ZUULI</CardTitle>
-              <CardDescription>
-                {method === "zcash"
-                  ? "Prove control of your Zcash key to sign in — no password."
-                  : "Welcome back. Choose how you'd like to continue."}
-              </CardDescription>
-            </CardHeader>
+          <div className="w-full animate-slide-up">
+            <Card className="border-border/80 bg-card/70 shadow-glow backdrop-blur">
+              <CardHeader className="space-y-1">
+                <CardTitle className="text-2xl">Sign in to ZUULI</CardTitle>
+                <CardDescription>
+                  {method === "zcash"
+                    ? "Prove control of your Zcash key to sign in — no password."
+                    : "Welcome back. Choose how you'd like to continue."}
+                </CardDescription>
+              </CardHeader>
 
-            <CardContent className="space-y-6">
-              {method === "zcash" ? (
-                <div className="space-y-5">
-                  <button
-                    type="button"
-                    onClick={() => setMethod("chooser")}
-                    className="inline-flex items-center gap-1.5 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground"
-                    aria-label="Back to all sign-in options"
-                  >
-                    <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
-                    All sign-in options
-                  </button>
-                  <ZcashLoginFlow />
-                </div>
-              ) : (
-                <>
-                  {/* Primary method — Login with Zcash (default, passwordless) */}
-                  <div className="space-y-2">
-                    <Button
+              <CardContent className="space-y-6">
+                {method === "zcash" ? (
+                  <div className="space-y-5">
+                    <button
                       type="button"
-                      size="lg"
-                      className="w-full justify-center text-sm font-semibold"
-                      onClick={() => setMethod("zcash")}
+                      onClick={() => setMethod("chooser")}
+                      className="inline-flex items-center gap-1.5 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground"
+                      aria-label="Back to all sign-in options"
                     >
-                      <ShieldCheck className="h-4 w-4" aria-hidden />
-                      Continue with Zcash
-                    </Button>
-                    <p className="text-center text-xs text-muted-foreground">
-                      Passwordless — prove control of your Zcash key. No email,
-                      no KYC.
-                    </p>
+                      <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+                      All sign-in options
+                    </button>
+                    <ZcashLoginFlow />
                   </div>
-
-                  <div className="flex items-center gap-3">
-                    <Separator className="flex-1" />
-                    <span className="text-xs uppercase tracking-wider text-muted-foreground">
-                      or use a password
-                    </span>
-                    <Separator className="flex-1" />
-                  </div>
-
-                  {/* Alternative — email/username + password (with 2FA) */}
-                  <ClassicLoginForm />
-
-                  {/* X / Google / GitHub — renders only for providers the
-                      backend reports as configured (none, today) */}
-                  <SocialButtons />
-
-                  <div className="flex items-center justify-between">
-                    <ZShieldInfo>
-                      <button
+                ) : (
+                  <>
+                    {/* Primary method — Login with Zcash (default, passwordless) */}
+                    <div className="space-y-2">
+                      <Button
                         type="button"
-                        className="inline-flex items-center gap-1.5 rounded-md text-xs text-muted-foreground transition-colors hover:text-foreground"
-                        aria-label="How Login with Zcash works"
+                        size="lg"
+                        className="w-full justify-center text-sm font-semibold"
+                        onClick={() => setMethod("zcash")}
                       >
-                        <HelpCircle className="h-3.5 w-3.5" aria-hidden />
-                        How Zcash login works
-                      </button>
-                    </ZShieldInfo>
+                        <ShieldCheck className="h-4 w-4" aria-hidden />
+                        Continue with Zcash
+                      </Button>
+                      <p className="text-center text-xs text-muted-foreground">
+                        Passwordless — prove control of your Zcash key. No email,
+                        no KYC.
+                      </p>
+                    </div>
 
-                    <Button
-                      asChild
-                      variant="link"
-                      size="sm"
-                      className="text-muted-foreground"
-                    >
-                      <Link to="/" aria-label="Explore ZUULI as a guest">
-                        Continue as guest
-                        <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
-                      </Link>
-                    </Button>
-                  </div>
-                </>
-              )}
-            </CardContent>
-          </Card>
+                    <div className="flex items-center gap-3">
+                      <Separator className="flex-1" />
+                      <span className="text-xs uppercase tracking-wider text-muted-foreground">
+                        or use a password
+                      </span>
+                      <Separator className="flex-1" />
+                    </div>
 
-          <p className="mt-6 text-center text-xs text-muted-foreground lg:hidden">
-            © {new Date().getFullYear()} 2Z Inc
-          </p>
+                    {/* Alternative — email/username + password (with 2FA) */}
+                    <ClassicLoginForm />
+
+                    {/* X / Google / GitHub — renders only for providers the
+                        backend reports as configured (none, today) */}
+                    <SocialButtons />
+
+                    <div className="flex items-center justify-between">
+                      <ZShieldInfo>
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1.5 rounded-md text-xs text-muted-foreground transition-colors hover:text-foreground"
+                          aria-label="How Login with Zcash works"
+                        >
+                          <HelpCircle className="h-3.5 w-3.5" aria-hidden />
+                          How Zcash login works
+                        </button>
+                      </ZShieldInfo>
+
+                      <Button
+                        asChild
+                        variant="link"
+                        size="sm"
+                        className="text-muted-foreground"
+                      >
+                        <Link to="/" aria-label="Explore ZUULI as a guest">
+                          Continue as guest
+                          <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
+                        </Link>
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+
+            <p className="mt-6 text-center text-xs text-muted-foreground lg:hidden">
+              © {new Date().getFullYear()} 2Z Inc
+            </p>
+          </div>
         </div>
       </main>
     </div>

--- a/wallet/zuuli/src/index.css
+++ b/wallet/zuuli/src/index.css
@@ -4,6 +4,19 @@
 
 @layer base {
   :root {
+    /* Native mobile shells render edge-to-edge. Keep every inset derived from
+       the WebView's authoritative safe-area environment instead of device
+       guesses, with zero fallbacks for desktop browsers. */
+    --safe-area-top: env(safe-area-inset-top, 0px);
+    --safe-area-right: env(safe-area-inset-right, 0px);
+    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-area-left: env(safe-area-inset-left, 0px);
+    --top-bar-content-height: 3.5rem;
+    --mobile-tab-content-height: 3.5rem;
+    --mobile-tab-bar-height: calc(
+      var(--mobile-tab-content-height) + var(--safe-area-bottom)
+    );
+
     /* ZUULI runs dark-first. Light tokens exist for completeness. */
     --background: 240 6% 10%;
     --foreground: 0 0% 98%;
@@ -59,7 +72,17 @@
     border-color: hsl(var(--border));
   }
 
+  html,
+  body,
+  #root {
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+  }
+
   body {
+    margin: 0;
+    overscroll-behavior: none;
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
     font-feature-settings: "rlig" 1, "calt" 1;
@@ -84,6 +107,60 @@
 }
 
 @layer utilities {
+  /* One viewport-bound app frame; individual routes opt into exactly one
+     bounded content scroller below the persistent chrome. */
+  .app-viewport {
+    box-sizing: border-box;
+    height: 100dvh;
+    min-height: 0;
+    overflow: hidden;
+    padding-left: var(--safe-area-left);
+    padding-right: var(--safe-area-right);
+  }
+
+  .app-top-bar {
+    box-sizing: border-box;
+    height: calc(var(--top-bar-content-height) + var(--safe-area-top));
+    min-height: calc(var(--top-bar-content-height) + var(--safe-area-top));
+    padding-top: var(--safe-area-top);
+  }
+
+  .app-sidebar {
+    padding-top: var(--safe-area-top);
+    padding-bottom: var(--safe-area-bottom);
+  }
+
+  .app-bottom-nav {
+    box-sizing: border-box;
+    height: var(--mobile-tab-bar-height);
+    padding-right: var(--safe-area-right);
+    padding-bottom: var(--safe-area-bottom);
+    padding-left: var(--safe-area-left);
+  }
+
+  .app-scroll-content {
+    padding-bottom: calc(var(--mobile-tab-bar-height) + 1.5rem);
+  }
+
+  .app-full-bleed-inset {
+    padding-bottom: var(--mobile-tab-bar-height);
+  }
+
+  .app-auth-content {
+    padding-bottom: calc(var(--mobile-tab-bar-height) + 1.5rem);
+  }
+
+  @media (min-width: 768px) {
+    .app-scroll-content,
+    .app-auth-content {
+      padding-bottom: max(2.5rem, var(--safe-area-bottom));
+    }
+
+    .app-full-bleed-inset {
+      padding-bottom: var(--safe-area-bottom);
+    }
+  }
+
   .zuuli-gradient-text {
     background-image: linear-gradient(
       100deg,

--- a/wallet/zuuli/src/index.css
+++ b/wallet/zuuli/src/index.css
@@ -13,6 +13,7 @@
     --safe-area-left: env(safe-area-inset-left, 0px);
     --top-bar-content-height: 3.5rem;
     --mobile-tab-content-height: 3.5rem;
+    --reader-action-content-height: 4rem;
     --mobile-tab-bar-height: calc(
       var(--mobile-tab-content-height) + var(--safe-area-bottom)
     );
@@ -111,11 +112,17 @@
      bounded content scroller below the persistent chrome. */
   .app-viewport {
     box-sizing: border-box;
+    height: 100vh;
     height: 100dvh;
     min-height: 0;
     overflow: hidden;
     padding-left: var(--safe-area-left);
     padding-right: var(--safe-area-right);
+  }
+
+  .app-crash-frame {
+    height: 100vh;
+    height: 100dvh;
   }
 
   .app-top-bar {
@@ -150,6 +157,16 @@
     padding-bottom: calc(var(--mobile-tab-bar-height) + 1.5rem);
   }
 
+  .app-reader-content {
+    padding-bottom: calc(var(--reader-action-content-height) + 1.5rem);
+  }
+
+  .app-reader-actions {
+    bottom: var(--mobile-tab-bar-height);
+    padding-right: var(--safe-area-right);
+    padding-left: var(--safe-area-left);
+  }
+
   @media (min-width: 768px) {
     .app-scroll-content,
     .app-auth-content {
@@ -158,6 +175,10 @@
 
     .app-full-bleed-inset {
       padding-bottom: var(--safe-area-bottom);
+    }
+
+    .app-reader-actions {
+      bottom: var(--safe-area-bottom);
     }
   }
 

--- a/wallet/zuuli/src/main.tsx
+++ b/wallet/zuuli/src/main.tsx
@@ -17,13 +17,16 @@ function RootFallback() {
     <div
       role="alert"
       style={{
-        minHeight: "100vh",
+        boxSizing: "border-box",
+        height: "100dvh",
+        minHeight: 0,
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
         gap: "1rem",
-        padding: "2rem",
+        padding:
+          "calc(2rem + var(--safe-area-top)) calc(2rem + var(--safe-area-right)) calc(2rem + var(--safe-area-bottom)) calc(2rem + var(--safe-area-left))",
         background: "#0a0a0f",
         color: "#e5e5ea",
         fontFamily: "system-ui, sans-serif",

--- a/wallet/zuuli/src/main.tsx
+++ b/wallet/zuuli/src/main.tsx
@@ -15,10 +15,10 @@ import "./index.css";
 function RootFallback() {
   return (
     <div
+      className="app-crash-frame"
       role="alert"
       style={{
         boxSizing: "border-box",
-        height: "100dvh",
         minHeight: 0,
         display: "flex",
         flexDirection: "column",


### PR DESCRIPTION
Refs #331

## What changed
- enables viewport-fit=cover and keyboard-aware viewport resizing together with centralized env(safe-area-inset-*, 0px) variables
- bounds the app with ordered 100vh and 100dvh sizing, locks document scrolling, and keeps route scrolling inside the shell
- protects top chrome, bottom tabs, desktop sidebar, normal pages, AI, articles, login, and crash fallback in portrait and landscape
- moves /login into the persistent shell with one bounded internal scroll owner and overflow-safe centering
- configures Android adjustResize and fixed-light system-bar icons for the always-dark UI
- adds regression coverage for viewport/inset contracts, routing/scroll ownership, auth overflow, and Android edge-to-edge ordering

## Verification
- independent exact-head technical APPROVE
- full exact-head CI and packaging matrix green, including Android AAB and iOS target
- 110 Vitest tests plus 5 safe-area contracts, typecheck, production build, and release verification green
- Pixel 7 Android API 36 emulator: portrait Discover/login, focused email field, gesture navigation, and landscape pass

## Physical follow-up
Keep issue #331 and needs-device open until Skylar validates a signed Android build in portrait and landscape, including the real soft keyboard and available gesture/3-button navigation modes.