### PR TITLE
chore: gitignore agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ bazel-*
 node_modules
 private/
 .vscode/
+# Isolated agent worktrees created by the Claude Code harness (see AGENTS.md).
+# Only the worktrees dir is ignored: the rest of .claude/ (settings.json,
+# agents/, commands/) stays trackable.
+.claude/worktrees/
 *.log
 target/
 # Checksum-verified cargo-deny binary fetched by scripts/check-rust-deny.sh.


### PR DESCRIPTION
## Problem

The Claude Code harness creates isolated agent worktrees under `.claude/worktrees/`. That path was not gitignored, so `git status` on the primary checkout reported `?? .claude/` for as long as any agent was running.

That matters more than the one-line diff suggests. Repo doctrine in `CLAUDE.md` / `AGENTS.md` is emphatic that the primary checkout stays clean — "Never, ever, do we have a dirty local `main`." A permanently-untracked entry trains us to skim past `git status`, which is precisely the signal that doctrine relies on to catch a genuinely dirty tree. Noise in the tripwire defeats the tripwire.

## The change

One rule, deliberately narrow:

```gitignore
# Isolated agent worktrees created by the Claude Code harness (see AGENTS.md).
# Only the worktrees dir is ignored: the rest of .claude/ (settings.json,
# agents/, commands/) stays trackable.
.claude/worktrees/
```

Placed next to `.vscode/` in the root `.gitignore`, grouping it with the other local tool/editor state, and carrying an explanatory comment in the same style as the existing `.cargo-deny/` entry.

**Not** `.claude/` wholesale. That directory is a legitimate home for committed Claude Code configuration — `settings.json`, `agents/`, `commands/` — and blanket-ignoring it would silently make those files untrackable the day someone tries to add one. The pattern is anchored (it contains a slash, so it resolves relative to the repo root) and directory-only.

## Verification

`git check-ignore -v` attributes the ignore to the new rule, for both the directory and files nested inside it:

```
$ git check-ignore -v .claude/worktrees
.gitignore:9:.claude/worktrees/	.claude/worktrees

$ git check-ignore -v .claude/worktrees/agent-fake/src/file.rs
.gitignore:9:.claude/worktrees/	.claude/worktrees/agent-fake/src/file.rs
```

Sibling config paths are explicitly **not** caught (exit 1, no match):

```
$ git check-ignore -v .claude/settings.json .claude/agents/foo.md .claude/commands/bar.md
exit=1
```

With an agent worktree present, `.claude` no longer appears in status:

```
$ git status --porcelain | grep '\.claude'
grep exit=1   # no match
```

## No tracked file was affected

`git ls-files .claude/` returns empty both before and after — nothing under `.claude/` is currently tracked, so this rule cannot un-track anything. Confirmed repo-wide as well:

```
$ git ls-files -i -c --exclude-standard   # tracked-but-ignored files
(empty)
```

Diff is `.gitignore` only, 1 file changed, 4 insertions.

https://claude.ai/code/session_016hGD65qzFQS9CgtEd8Pyej
