### PR TITLE
ci(rust): fix clippy warnings and enable -D warnings

### DIFF
--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -23,6 +23,7 @@ on:
       - '.gitmodules'
       - 'scripts/check-rust-fmt.sh'
       - 'scripts/check-rust-deny.sh'
+      - 'scripts/check-rust-clippy.sh'
       - 'wallet/deny.toml'
       - '.github/workflows/zuuallet.yml'
   push:
@@ -34,6 +35,7 @@ on:
       - '.gitmodules'
       - 'scripts/check-rust-fmt.sh'
       - 'scripts/check-rust-deny.sh'
+      - 'scripts/check-rust-clippy.sh'
       - 'wallet/deny.toml'
       - '.github/workflows/zuuallet.yml'
   workflow_dispatch:
@@ -109,6 +111,69 @@ jobs:
 
       - name: Check advisories, licences and sources
         run: scripts/check-rust-deny.sh
+
+  # ---------------------------------------------------------------------------
+  # Lints, for the same reason as `fmt` and `deny`: the required `gate` in
+  # zuuli.yml does not select wallet/zuuallet/**, so without this a
+  # Zuuallet-only pull request could land code that fails `clippy -D warnings`
+  # — and then fail the next unrelated ZUULI pull request on files it never
+  # touched. Same script, so the two workflows cannot disagree about what
+  # "lint-clean" means.
+  #
+  # This one compiles (clippy is a rustc driver), so unlike `fmt` it needs the
+  # submodule, the Tauri system libraries and a cache.
+  # ---------------------------------------------------------------------------
+  clippy:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libxdo-dev \
+            libdbus-1-dev \
+            libssl-dev \
+            build-essential curl wget file pkg-config
+
+      - name: Resolve the pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          set -euo pipefail
+          version=$(scripts/check-rust-toolchain.sh --print-channel)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # clippy is absent from the minimal profile this action installs.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
+          components: clippy
+
+      # Separate key from the `rust` job: clippy writes different artifacts into
+      # the same target directory names, so a shared cache would have the two
+      # jobs evicting each other's work on every run.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            wallet/plugins/tauri-plugin-zcash
+            wallet/zuuli/src-tauri
+            wallet/zuuallet/src-tauri
+          key: zuuallet-clippy
+
+      - name: Lint every Rust crate under wallet/ at -D warnings
+        run: scripts/check-rust-clippy.sh
 
   # ---------------------------------------------------------------------------
   # Frontend: TypeScript typecheck + production bundle.

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -71,7 +71,7 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*)
                 zuuli=true
                 ;;
             esac
@@ -201,6 +201,72 @@ jobs:
       - name: Check advisories, licences and sources
         run: scripts/check-rust-deny.sh
 
+  # Lints, at `-D warnings`, for every crate under wallet/. Unlike rust_fmt and
+  # rust_deny this one genuinely compiles — clippy is a rustc driver and needs
+  # the whole dependency graph — so it carries the submodule, the Tauri system
+  # libraries and a cache of its own. It is still cheaper than rust_plugin and
+  # rust_app because it only checks: no codegen, no linking.
+  #
+  # Its cache is separate from theirs on purpose. Clippy writes different
+  # artifacts into the same target directory names, so sharing a key would make
+  # the two kinds of job evict each other's work on every run.
+  #
+  # Like rust_fmt it covers wallet/zuuallet/src-tauri, which this workflow's
+  # change filter does not select on its own; the matching job in zuuallet.yml
+  # covers a Zuuallet-only pull request.
+  rust_clippy:
+    name: Rust / lints
+    needs: changes
+    if: needs.changes.outputs.zuuli == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libxdo-dev \
+            libdbus-1-dev \
+            libssl-dev \
+            build-essential curl wget file pkg-config
+
+      - name: Resolve the pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          set -euo pipefail
+          version=$(scripts/check-rust-toolchain.sh --print-channel)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # clippy is not in the minimal profile this action installs, and its lint
+      # set differs between compiler versions — the pinned toolchain is what
+      # makes the verdict reproducible, so the check refuses to run on any other.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            wallet/plugins/tauri-plugin-zcash
+            wallet/zuuli/src-tauri
+            wallet/zuuallet/src-tauri
+          key: zuuli-clippy
+
+      - name: Lint every Rust crate under wallet/ at -D warnings
+        run: scripts/check-rust-clippy.sh
+
   rust_plugin:
     name: Rust / shared plugin
     needs: changes
@@ -307,7 +373,7 @@ jobs:
   # change detector and every applicable full-stack job succeeded; legitimate
   # non-ZUULI skips continue to report success instead of remaining pending.
   gate:
-    needs: [changes, frontend, rust_fmt, rust_deny, rust_plugin, rust_app]
+    needs: [changes, frontend, rust_fmt, rust_deny, rust_clippy, rust_plugin, rust_app]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -319,6 +385,7 @@ jobs:
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           RUST_FMT_RESULT: ${{ needs.rust_fmt.result }}
           RUST_DENY_RESULT: ${{ needs.rust_deny.result }}
+          RUST_CLIPPY_RESULT: ${{ needs.rust_clippy.result }}
           RUST_PLUGIN_RESULT: ${{ needs.rust_plugin.result }}
           RUST_APP_RESULT: ${{ needs.rust_app.result }}
         run: |
@@ -329,7 +396,7 @@ jobs:
 
           # Every job in `needs:` above must appear here as well; a job that is
           # awaited but not inspected makes the gate decorative for that job.
-          results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_DENY_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"
+          results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_DENY_RESULT $RUST_CLIPPY_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"
           echo "ZUULI changed: $ZUULI_CHANGED; job results: $results"
           case "$ZUULI_CHANGED" in
             true) expected=success ;;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,17 @@ integrate, and move it forward alongside everything else.
   agrees with `wallet/rust-toolchain.toml`. The `wallet/zuuli` gate runs it on
   every pull request, so a half-finished bump fails in review instead of in a
   protected store release. See below.
+- **`scripts/check-rust-fmt.sh`**, **`scripts/check-rust-clippy.sh`** and
+  **`scripts/check-rust-deny.sh`** hold every Rust crate under `wallet/` to
+  rustfmt, `clippy -D warnings`, and the `wallet/deny.toml` supply-chain policy.
+  All three **discover** crates by finding `Cargo.toml` under `wallet/` rather
+  than listing them, so a new crate is gated from its first commit. All three
+  run on the pinned toolchain and refuse to render a verdict on any other —
+  rustfmt's output and clippy's lint set both move between compiler versions,
+  and a check that ran on whatever was installed would report version skew as a
+  code defect. Each has a mirrored job in `zuuallet.yml`, because the required
+  `gate` lives in `zuuli.yml` and its change detector does not select
+  `wallet/zuuallet/**`.
 
 ## The Rust toolchain pin
 
@@ -187,6 +198,11 @@ all**. Every remaining restatement is verified against the file by
 A bump that touches the source of truth and nothing else **cannot merge** — the
 gate fails. That is the point: the version is one edit plus a mechanical
 follow-through, not an eleven-place archaeology exercise.
+
+A bump is also the one moment new clippy lints can appear, since
+`scripts/check-rust-clippy.sh` judges only on the pinned compiler. Expect the
+bump's own pull request to carry the fixes for whatever the new lint set found —
+that is where they belong, not leaking into the next unrelated change.
 
 ### Cadence
 

--- a/scripts/check-rust-clippy.sh
+++ b/scripts/check-rust-clippy.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Hold every Rust crate under wallet/ to `cargo clippy -D warnings`.
+#
+# Clippy's lint set is not stable across compiler versions: lints are added,
+# promoted between groups, and taught new patterns with every release, so the
+# same source can be clean on one toolchain and warn on the next. A check that
+# ran on whatever compiler happened to be installed would report that version
+# skew as if it were a code defect. So, exactly like scripts/check-rust-fmt.sh,
+# this renders a verdict only on the toolchain named by
+# wallet/rust-toolchain.toml — it runs cargo from the directory holding that
+# file so rustup selects the pin, and refuses to continue if a different
+# compiler answers. Bumping the pin is therefore the one moment new lints can
+# appear, and they appear in the bump's own pull request.
+#
+# Crates are discovered rather than listed. A new crate under wallet/ is gated
+# from its first commit, which is the cheapest moment and never gets cheaper.
+#
+# Unlike scripts/check-rust-fmt.sh this genuinely compiles: clippy is a rustc
+# driver and needs the whole dependency graph, so z/zcash/librustzcash must be
+# checked out — the wallet crates reach the Zcash crates by path into it — and
+# the Tauri system libraries must be installed. Budget it alongside the real
+# builds, not alongside the formatting check.
+#
+# --all-targets so tests, benches and examples are linted too. Test code that
+# nobody lints is where the next warning backlog comes from.
+#
+# Usage:
+#   scripts/check-rust-clippy.sh          fail on any clippy warning
+#   scripts/check-rust-clippy.sh --fix    apply clippy's machine-applicable fixes
+#
+# After --fix, read every edit before committing it and run
+# scripts/check-rust-fmt.sh --fix: clippy's rewrites are usually right, but
+# "usually" is not a standard wallet code is held to, and its suggestions do not
+# re-indent the code they restructure.
+
+set -euo pipefail
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+# The directory holding rust-toolchain.toml. Cargo is invoked from here so
+# rustup's toolchain selection — which keys off the working directory, not the
+# --manifest-path — lands on the pinned channel.
+RUST_ROOT=$REPO_ROOT/wallet
+TOOLCHAIN_FILE=$RUST_ROOT/rust-toolchain.toml
+SUBMODULE=$REPO_ROOT/z/zcash/librustzcash
+
+mode=check
+case "${1-}" in
+  "") ;;
+  --fix) mode=fix ;;
+  -h | --help)
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+    exit 0
+    ;;
+  *)
+    printf 'unknown argument: %s\n' "$1" >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -f $TOOLCHAIN_FILE ]]; then
+  printf 'wallet/rust-toolchain.toml is missing; it decides which clippy this check trusts.\n' >&2
+  exit 1
+fi
+
+channel=$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' "$TOOLCHAIN_FILE")
+if [[ ! $channel =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  printf 'channel in wallet/rust-toolchain.toml must be a three-component version, got "%s".\n' \
+    "$channel" >&2
+  exit 1
+fi
+
+if [[ ! -f $SUBMODULE/Cargo.toml ]]; then
+  printf 'z/zcash/librustzcash is not checked out; clippy resolves and compiles the whole graph.\n' >&2
+  printf 'Run: git submodule update --init z/zcash/librustzcash\n' >&2
+  exit 1
+fi
+
+cd "$RUST_ROOT"
+
+installed=$(rustc --version)
+if [[ $installed != "rustc $channel "* ]]; then
+  printf 'refusing to judge lints: wallet/rust-toolchain.toml pins %s but `rustc --version` says "%s".\n' \
+    "$channel" "$installed" >&2
+  printf "clippy's lint set differs between compiler versions, so this run could only produce a misleading verdict.\n" >&2
+  exit 1
+fi
+
+# Tracked, buildable crates only: target/ holds vendored and generated
+# manifests, node_modules/ holds npm packages that ship Rust sources.
+manifests=()
+while IFS= read -r manifest; do
+  manifests+=("${manifest#./}")
+done < <(
+  find . -name Cargo.toml \
+    -not -path './target/*' \
+    -not -path '*/target/*' \
+    -not -path '*/node_modules/*' |
+    LC_ALL=C sort
+)
+
+if [[ ${#manifests[@]} -eq 0 ]]; then
+  printf 'no Cargo manifests found under wallet/; this check has gone blind.\n' >&2
+  exit 1
+fi
+
+failed=()
+for manifest in "${manifests[@]}"; do
+  crate=$(dirname "$manifest")
+  if [[ $mode == fix ]]; then
+    printf '\n==> applying clippy fixes to wallet/%s\n' "$crate"
+    # --allow-dirty/--allow-staged: this is run deliberately, mid-change, by
+    # someone who will read the diff. Refusing on a dirty tree only pushes them
+    # to stash and lose that context.
+    cargo clippy --fix --locked --all-targets --allow-dirty --allow-staged \
+      --manifest-path "$manifest"
+    continue
+  fi
+
+  printf '\n==> cargo clippy -- wallet/%s\n' "$crate"
+  # --locked: lint the lockfile CI actually builds, so a resolution that only
+  # happens locally cannot change the verdict.
+  if cargo clippy --locked --all-targets --manifest-path "$manifest" -- -D warnings; then
+    continue
+  fi
+  failed+=("wallet/$crate")
+done
+
+if [[ $mode == fix ]]; then
+  printf '\nRan clippy --fix over %d crate(s) with the pinned %s toolchain.\n' \
+    "${#manifests[@]}" "$channel"
+  printf 'Read every edit, then run scripts/check-rust-fmt.sh --fix.\n'
+  exit 0
+fi
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+  printf '\n%d crate(s) have clippy warnings: %s\n' "${#failed[@]}" "${failed[*]}" >&2
+  printf 'Fix the code, or add a narrow #[allow(clippy::lint)] with a comment saying why.\n' >&2
+  printf 'Do not blanket-allow at crate level, and do not raise the bar for the next reader.\n' >&2
+  exit 1
+fi
+
+printf '\nAll %d Rust crate(s) under wallet/ are clippy-clean (clippy from %s).\n' \
+  "${#manifests[@]}" "$channel"

--- a/wallet/plugins/tauri-plugin-zcash/src/app_data_migration.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/app_data_migration.rs
@@ -399,8 +399,16 @@ fn remove_empty_directory_unchanged(
     // where the operand is already u32 (via core's reflexive
     // `impl<T> From<T> for T`), so it can neither truncate nor sign-extend and
     // the file-type test keeps its exact meaning on every target.
-    let file_type = u32::from(stat.st_mode) & u32::from(libc::S_IFMT);
-    if file_type != u32::from(libc::S_IFDIR) {
+    //
+    // Which is exactly why `clippy::useless_conversion` has to be silenced
+    // here: clippy sees one target at a time, and on that target at least one
+    // of these three conversions *is* the reflexive identity and looks like
+    // dead weight. It is load-bearing on the targets clippy is not looking at.
+    // Scoped to this one statement, never crate-wide.
+    #[allow(clippy::useless_conversion)]
+    let is_directory =
+        (u32::from(stat.st_mode) & u32::from(libc::S_IFMT)) == u32::from(libc::S_IFDIR);
+    if !is_directory {
         return Err(RemoveEmptyDirectoryError::InvalidState(
             "canonical app-data directory changed filesystem type during migration".to_owned(),
         ));

--- a/wallet/plugins/tauri-plugin-zcash/src/app_data_migration.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/app_data_migration.rs
@@ -405,6 +405,18 @@ fn remove_empty_directory_unchanged(
             "canonical app-data directory changed filesystem type during migration".to_owned(),
         ));
     }
+    // Platform width skew again — same reason as the `st_mode` note above, so
+    // do NOT let `clippy::unnecessary_cast` talk you into deleting either cast.
+    // `dev_t` and `ino_t` are not one type across the targets this `cfg(unix)`
+    // function compiles for: on Apple `st_dev` is `i32` and `st_ino` is `u64`,
+    // on Linux/Android both are `u64`, and other unices narrow them further.
+    // Whichever host clippy runs on, exactly one of these two casts looks
+    // redundant *there* and is load-bearing somewhere else — removing it turns
+    // a portable widening into a compile error on the other target. `as u64` is
+    // safe here for the same reason the comparison is meaningful: both fields
+    // are non-negative kernel identifiers, so widening preserves the value and
+    // the identity test keeps its exact meaning on every target.
+    #[allow(clippy::unnecessary_cast)]
     let actual = DirectoryIdentity {
         first: stat.st_dev as u64,
         second: stat.st_ino as u64,

--- a/wallet/plugins/tauri-plugin-zcash/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/commands.rs
@@ -451,16 +451,16 @@ pub(crate) async fn create_wallet<R: Runtime>(
             )));
         }
     };
-    if manifest_commit_durable {
-        if let Err(error) = crate::wallet::cleanup::confirm_staged_wallet_commit(
+    if manifest_commit_durable
+        && let Err(error) = crate::wallet::cleanup::confirm_staged_wallet_commit(
             &zcash.state.data_dir,
             &cleanup_authorization,
-        ) {
-            tracing::warn!(
-                wallet_id = wallet_entry.id,
-                "wallet committed but rollback tombstone finalization failed; startup will resolve it: {error}"
-            );
-        }
+        )
+    {
+        tracing::warn!(
+            wallet_id = wallet_entry.id,
+            "wallet committed but rollback tombstone finalization failed; startup will resolve it: {error}"
+        );
     }
 
     *pending_proposal_guard = None;
@@ -687,16 +687,16 @@ pub(crate) async fn restore_wallet<R: Runtime>(
             )));
         }
     };
-    if manifest_commit_durable {
-        if let Err(error) = crate::wallet::cleanup::confirm_staged_wallet_commit(
+    if manifest_commit_durable
+        && let Err(error) = crate::wallet::cleanup::confirm_staged_wallet_commit(
             &zcash.state.data_dir,
             &cleanup_authorization,
-        ) {
-            tracing::warn!(
-                wallet_id = wallet_entry.id,
-                "restored wallet committed but rollback tombstone finalization failed; startup will resolve it: {error}"
-            );
-        }
+        )
+    {
+        tracing::warn!(
+            wallet_id = wallet_entry.id,
+            "restored wallet committed but rollback tombstone finalization failed; startup will resolve it: {error}"
+        );
     }
 
     *pending_proposal_guard = None;
@@ -1212,53 +1212,51 @@ pub(crate) async fn delete_wallet<R: Runtime>(
         };
 
         // If we deleted the active wallet, switch to the new active
-        if deletion.was_active {
-            if let Some((entry, db, read_db)) = prepared_active {
-                **db_guard
-                    .as_mut()
-                    .expect("active deletion holds the write context") = Some(db);
-                **read_db_guard
-                    .as_mut()
-                    .expect("active deletion holds the read context") = Some(read_db);
-                // Do not prompt while finalizing a destructive transition. The next
-                // explicit spend/reveal action authenticates against native custody.
-                **seed_guard
-                    .as_mut()
-                    .expect("active deletion holds the seed context") = None;
-                **pending_proposal_guard
-                    .as_mut()
-                    .expect("active deletion holds the proposal context") = None;
-                **pending_broadcast_guard
-                    .as_mut()
-                    .expect("active deletion holds the broadcast context") =
-                    send::load_pending_broadcast(&zcash.state.data_dir, &entry.id);
-                zcash
-                    .state
-                    .last_known_chain_tip
-                    .store(0, std::sync::atomic::Ordering::Relaxed);
-                if let Some(recovery) = sync_recovery.as_mut() {
-                    recovery.commit();
-                }
-                drop(pending_broadcast_guard.take());
-                drop(pending_proposal_guard.take());
-                drop(seed_guard.take());
-                drop(read_db_guard.take());
-                drop(db_guard.take());
-
-                let status = run_wallet_cleanup_retry(
-                    &zcash.state,
-                    crate::wallet::cleanup::RetryMode::Runtime,
-                )
-                .await;
-                if status.pending_operations > 0 {
-                    tracing::warn!(
-                        pending = status.pending_operations,
-                        diagnostics = ?status.diagnostics,
-                        "wallet deletion committed; cleanup remains durably scheduled"
-                    );
-                }
-                return Ok(());
+        if deletion.was_active
+            && let Some((entry, db, read_db)) = prepared_active
+        {
+            **db_guard
+                .as_mut()
+                .expect("active deletion holds the write context") = Some(db);
+            **read_db_guard
+                .as_mut()
+                .expect("active deletion holds the read context") = Some(read_db);
+            // Do not prompt while finalizing a destructive transition. The next
+            // explicit spend/reveal action authenticates against native custody.
+            **seed_guard
+                .as_mut()
+                .expect("active deletion holds the seed context") = None;
+            **pending_proposal_guard
+                .as_mut()
+                .expect("active deletion holds the proposal context") = None;
+            **pending_broadcast_guard
+                .as_mut()
+                .expect("active deletion holds the broadcast context") =
+                send::load_pending_broadcast(&zcash.state.data_dir, &entry.id);
+            zcash
+                .state
+                .last_known_chain_tip
+                .store(0, std::sync::atomic::Ordering::Relaxed);
+            if let Some(recovery) = sync_recovery.as_mut() {
+                recovery.commit();
             }
+            drop(pending_broadcast_guard.take());
+            drop(pending_proposal_guard.take());
+            drop(seed_guard.take());
+            drop(read_db_guard.take());
+            drop(db_guard.take());
+
+            let status =
+                run_wallet_cleanup_retry(&zcash.state, crate::wallet::cleanup::RetryMode::Runtime)
+                    .await;
+            if status.pending_operations > 0 {
+                tracing::warn!(
+                    pending = status.pending_operations,
+                    diagnostics = ?status.diagnostics,
+                    "wallet deletion committed; cleanup remains durably scheduled"
+                );
+            }
+            return Ok(());
         }
 
         // Previously the seed was deleted before the manifest check, so rejecting
@@ -1281,10 +1279,10 @@ pub(crate) async fn delete_wallet<R: Runtime>(
     }
     .await;
 
-    if result.is_err() {
-        if let Some(recovery) = sync_recovery.as_mut() {
-            recovery.restore_now().await;
-        }
+    if result.is_err()
+        && let Some(recovery) = sync_recovery.as_mut()
+    {
+        recovery.restore_now().await;
     }
     result
 }
@@ -1628,36 +1626,36 @@ pub(crate) async fn get_account_balance<R: Runtime>(
             .get_account_ids()
             .map_err(|e| Error::DatabaseError(format!("failed to get account ids: {e}")))?;
 
-        if let Some(account_id) = account_ids.get(args.account_index as usize) {
-            if let Some(balance) = summary.account_balances().get(account_id) {
-                let sapling = balance.sapling_balance();
-                let orchard = balance.orchard_balance();
-                // Ironwood is the third shielded pool introduced by NU6.3; after
-                // activation Orchard is spend-only and new shielded value accrues
-                // to Ironwood, so it must be included in every shielded total.
-                let ironwood = balance.ironwood_balance();
+        if let Some(account_id) = account_ids.get(args.account_index as usize)
+            && let Some(balance) = summary.account_balances().get(account_id)
+        {
+            let sapling = balance.sapling_balance();
+            let orchard = balance.orchard_balance();
+            // Ironwood is the third shielded pool introduced by NU6.3; after
+            // activation Orchard is spend-only and new shielded value accrues
+            // to Ironwood, so it must be included in every shielded total.
+            let ironwood = balance.ironwood_balance();
 
-                let total = u64::from(sapling.total())
-                    + u64::from(orchard.total())
-                    + u64::from(ironwood.total());
-                let spendable = u64::from(sapling.spendable_value())
-                    + u64::from(orchard.spendable_value())
-                    + u64::from(ironwood.spendable_value());
-                let change_pending = u64::from(sapling.change_pending_confirmation())
-                    + u64::from(orchard.change_pending_confirmation())
-                    + u64::from(ironwood.change_pending_confirmation());
-                let value_pending = u64::from(sapling.value_pending_spendability())
-                    + u64::from(orchard.value_pending_spendability())
-                    + u64::from(ironwood.value_pending_spendability());
+            let total = u64::from(sapling.total())
+                + u64::from(orchard.total())
+                + u64::from(ironwood.total());
+            let spendable = u64::from(sapling.spendable_value())
+                + u64::from(orchard.spendable_value())
+                + u64::from(ironwood.spendable_value());
+            let change_pending = u64::from(sapling.change_pending_confirmation())
+                + u64::from(orchard.change_pending_confirmation())
+                + u64::from(ironwood.change_pending_confirmation());
+            let value_pending = u64::from(sapling.value_pending_spendability())
+                + u64::from(orchard.value_pending_spendability())
+                + u64::from(ironwood.value_pending_spendability());
 
-                return Ok(AccountBalance {
-                    account_index: args.account_index,
-                    total_shielded: total,
-                    spendable,
-                    change_pending,
-                    value_pending,
-                });
-            }
+            return Ok(AccountBalance {
+                account_index: args.account_index,
+                total_shielded: total,
+                spendable,
+                change_pending,
+                value_pending,
+            });
         }
     }
 
@@ -1848,7 +1846,7 @@ pub(crate) async fn parse_payment_uri<R: Runtime>(
 
     let (_, payment) = payments.iter().next().unwrap();
     let address = payment.recipient_address().encode();
-    let amount = payment.amount().map(|a| u64::from(a));
+    let amount = payment.amount().map(u64::from);
     let memo = payment.memo().map(|m| format!("{:?}", m));
     let label = payment.label().map(|s| s.to_string());
 

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/cache.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/cache.rs
@@ -52,10 +52,10 @@ impl BlockSource for MemBlockCache {
             None => inner.range(..),
         };
         for (i, (_, block)) in iter.enumerate() {
-            if let Some(limit) = limit {
-                if i >= limit {
-                    break;
-                }
+            if let Some(limit) = limit
+                && i >= limit
+            {
+                break;
             }
             with_block(block.clone())?;
         }

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/manifest.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/manifest.rs
@@ -187,14 +187,14 @@ impl WalletManifest {
     pub fn prepare_wallet(name: String, birthday_height: Option<u64>) -> WalletEntry {
         let id = uuid::Uuid::new_v4().to_string();
         let db_filename = format!("wallet_{id}.sqlite");
-        let entry = WalletEntry {
+
+        WalletEntry {
             id: id.clone(),
             name,
             db_filename,
             birthday_height,
             created_at: chrono_now(),
-        };
-        entry
+        }
     }
 
     /// Durably add a fully initialized wallet and set it active.
@@ -421,12 +421,42 @@ fn replace_manifest_with_backup(temp: &Path, path: &Path, backup: &Path) -> std:
         return Err(e);
     }
 
-    if had_manifest {
-        if let Err(e) = std::fs::remove_file(backup) {
-            tracing::warn!("wallet manifest replaced but backup cleanup failed: {e}");
-        }
+    if had_manifest && let Err(e) = std::fs::remove_file(backup) {
+        tracing::warn!("wallet manifest replaced but backup cleanup failed: {e}");
     }
     Ok(())
+}
+
+fn chrono_now() -> String {
+    // ISO 8601 timestamp without pulling in chrono crate
+    let dur = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs();
+    // Convert to UTC components
+    let days = secs / 86400;
+    let time = secs % 86400;
+    let hours = time / 3600;
+    let mins = (time % 3600) / 60;
+    let s = time % 60;
+    // Days since 1970-01-01 to Y-M-D
+    let (y, m, d) = days_to_ymd(days);
+    format!("{y:04}-{m:02}-{d:02}T{hours:02}:{mins:02}:{s:02}Z")
+}
+
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Civil days algorithm
+    let era_days = days + 719468;
+    let era = era_days / 146097;
+    let doe = era_days - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
 }
 
 #[cfg(test)]
@@ -679,36 +709,4 @@ mod replacement_tests {
         assert!(!backup.exists());
         std::fs::remove_dir_all(data_dir).expect("remove test directory");
     }
-}
-
-fn chrono_now() -> String {
-    // ISO 8601 timestamp without pulling in chrono crate
-    let dur = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-    let secs = dur.as_secs();
-    // Convert to UTC components
-    let days = secs / 86400;
-    let time = secs % 86400;
-    let hours = time / 3600;
-    let mins = (time % 3600) / 60;
-    let s = time % 60;
-    // Days since 1970-01-01 to Y-M-D
-    let (y, m, d) = days_to_ymd(days);
-    format!("{y:04}-{m:02}-{d:02}T{hours:02}:{mins:02}:{s:02}Z")
-}
-
-fn days_to_ymd(days: u64) -> (u64, u64, u64) {
-    // Civil days algorithm
-    let era_days = days + 719468;
-    let era = era_days / 146097;
-    let doe = era_days - era * 146097;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    (y, m, d)
 }

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
@@ -669,14 +669,14 @@ fn clean_corrupt_sapling_params() {
         (zcash_proofs::SAPLING_OUTPUT_NAME, EXPECTED_OUTPUT_BYTES),
     ] {
         let path = params_dir.join(name);
-        if let Ok(meta) = std::fs::metadata(&path) {
-            if meta.len() != expected {
-                tracing::warn!(
-                    "removing corrupt {name} ({} bytes, expected {expected})",
-                    meta.len()
-                );
-                let _ = std::fs::remove_file(&path);
-            }
+        if let Ok(meta) = std::fs::metadata(&path)
+            && meta.len() != expected
+        {
+            tracing::warn!(
+                "removing corrupt {name} ({} bytes, expected {expected})",
+                meta.len()
+            );
+            let _ = std::fs::remove_file(&path);
         }
     }
 }
@@ -819,11 +819,11 @@ pub async fn propose_send(
     let result = install_accepted_proposal(&mut *proposal_guard, candidate);
     match result {
         Ok(output) => {
-            if let Some(record) = pending_broadcast.as_ref() {
-                if let Err(error) = clear_pending_broadcast(&state.data_dir, &record.wallet_id) {
-                    *proposal_guard = None;
-                    return Err(error);
-                }
+            if let Some(record) = pending_broadcast.as_ref()
+                && let Err(error) = clear_pending_broadcast(&state.data_dir, &record.wallet_id)
+            {
+                *proposal_guard = None;
+                return Err(error);
             }
             *pending_broadcast = None;
             Ok(output)

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/sync.rs
@@ -647,18 +647,17 @@ async fn refresh_subtree_roots(
 
     // If we handed the backend Ironwood roots and it did not advance its
     // "next Ironwood index", it is using the no-op default impl. Stop fetching.
-    if ironwood_offered {
-        if let Some((_, _, after)) = next_subtree_indices(read_db).await {
-            if after == next_ironwood {
-                tracing::warn!(
-                    "wallet backend accepted {} Ironwood subtree roots without advancing its next \
-                     Ironwood index ({next_ironwood}); it is using the no-op default \
-                     `put_ironwood_subtree_roots`. Disabling Ironwood root fetches for this session.",
-                    ironwood_roots.len(),
-                );
-                state.ironwood_backend_tracks = false;
-            }
-        }
+    if ironwood_offered
+        && let Some((_, _, after)) = next_subtree_indices(read_db).await
+        && after == next_ironwood
+    {
+        tracing::warn!(
+            "wallet backend accepted {} Ironwood subtree roots without advancing its next \
+             Ironwood index ({next_ironwood}); it is using the no-op default \
+             `put_ironwood_subtree_roots`. Disabling Ironwood root fetches for this session.",
+            ironwood_roots.len(),
+        );
+        state.ironwood_backend_tracks = false;
     }
 
     state.last_refresh = Some(Instant::now());
@@ -1562,18 +1561,16 @@ mod supervisor_tests {
         }
     }
 
-    fn counted_task(
+    async fn counted_task(
         starts: Arc<AtomicUsize>,
         live: Arc<AtomicUsize>,
         started: tokio::sync::oneshot::Sender<()>,
         dropped: tokio::sync::oneshot::Sender<()>,
-    ) -> impl Future<Output = ()> + Send + 'static {
-        async move {
-            starts.fetch_add(1, AtomicOrdering::SeqCst);
-            let _live = LiveTask::new(live, dropped);
-            let _ = started.send(());
-            std::future::pending::<()>().await;
-        }
+    ) {
+        starts.fetch_add(1, AtomicOrdering::SeqCst);
+        let _live = LiveTask::new(live, dropped);
+        let _ = started.send(());
+        std::future::pending::<()>().await;
     }
 
     async fn assert_phase(supervisor: &SyncTaskSupervisor, expected: &str) {

--- a/wallet/zuuallet/src-tauri/src/lib.rs
+++ b/wallet/zuuallet/src-tauri/src/lib.rs
@@ -6,3 +6,11 @@ pub fn run() {
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
+
+// TEMPORARY — deliberate clippy violations, to prove the new gate can fail and
+// not merely pass. Reverted in the very next commit on this branch.
+// `clippy::useless_format` + `clippy::let_and_return`.
+pub fn clippy_gate_smoke_test() -> String {
+    let s = format!("{}", "the gate must be able to fail");
+    s
+}

--- a/wallet/zuuallet/src-tauri/src/lib.rs
+++ b/wallet/zuuallet/src-tauri/src/lib.rs
@@ -6,11 +6,3 @@ pub fn run() {
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
-
-// TEMPORARY — deliberate clippy violations, to prove the new gate can fail and
-// not merely pass. Reverted in the very next commit on this branch.
-// `clippy::useless_format` + `clippy::let_and_return`.
-pub fn clippy_gate_smoke_test() -> String {
-    let s = format!("{}", "the gate must be able to fail");
-    s
-}


### PR DESCRIPTION
Closes #354.

## Re-measured first — the backlog is 16, not 8

Issue #354 counted **8** warnings on the old 1.88.0 pin. That count is stale:
#353 moved the pin to **1.97.1**, and a nine-version jump brings a different
lint set. The real backlog, `cargo clippy --locked --all-targets` from `wallet/`
on 1.97.1:

| Crate | Warnings |
| --- | --- |
| `wallet/plugins/tauri-plugin-zcash` | **16** (13 lib + 3 more from the test target) |
| `wallet/zuuli/src-tauri` | **0** |
| `wallet/zuuallet/src-tauri` | **0** |

The `uninlined_format_args` hits the issue listed are gone — that lint no longer
fires on those sites in 1.97.1. What replaced them, and more, is
`collapsible_if`: edition 2024 stabilised let-chains, so clippy now folds
`if cond { if let ... }` into `if cond && let ...`. Nine of the sixteen are that.

## Every warning fixed

| Lint | Location | Fix |
| --- | --- | --- |
| `collapsible_if` | `commands.rs:454`, `commands.rs:690`, `commands.rs:1215`, `commands.rs:1284`, `commands.rs:1631` | folded into let-chains |
| `collapsible_if` | `wallet/cache.rs:55` | folded into a let-chain |
| `collapsible_if` | `wallet/manifest.rs:424` | folded into a let-chain |
| `collapsible_if` | `wallet/send.rs:672`, `wallet/send.rs:822` | folded into let-chains |
| `collapsible_if` | `wallet/sync.rs:650`, `wallet/sync.rs:651` | one three-condition let-chain |
| `unnecessary_cast` | `app_data_migration.rs:410` | **not** removed — narrow `#[allow]`, see below |
| `redundant_closure` | `commands.rs:1851` | `.map(\|a\| u64::from(a))` → `.map(u64::from)` |
| `let_and_return` | `wallet/manifest.rs:197` | `WalletEntry { .. }` returned as the tail expression |
| `items_after_test_module` | `wallet/manifest.rs:433` | `chrono_now` / `days_to_ymd` moved above `mod replacement_tests` |
| `manual_async_fn` | `wallet/sync.rs:1565` (test) | `fn -> impl Future` → `async fn` |

Applied with `cargo clippy --fix`, then `scripts/check-rust-fmt.sh --fix`, then
read line by line. Two places needed a human afterwards, both cosmetic:
rustfmt declines to re-indent the two `create_wallet`/`restore_wallet` bodies
whose let-chain condition is itself multi-line, and the `\`-continued log string
in `sync.rs` kept its old continuation indent (leading whitespace after a
`\`-newline is stripped by the lexer, so the message text is byte-identical).
Both were re-indented by hand and `check-rust-fmt.sh` confirms the result is
rustfmt-stable.

## Behaviour

**No behaviour changed.** Every let-chain preserves short-circuit order and
binding scope; `let_and_return`, `redundant_closure` and `items_after_test_module`
are pure rearrangement. `manual_async_fn` touches test-only helper
`counted_task`: both forms produce a lazy `Send + 'static` future built from
owned arguments, and its `impl Future<Output = ()> + Send + 'static` bound is
still satisfied — the call site's `F: Future<Output = ()> + Send + 'static` bound
proves it at compile time.

### The one lint I refused: `unnecessary_cast` in `app_data_migration.rs`

`cargo clippy --fix` deleted the `as u64` on `stat.st_ino`, and that fix is
**wrong** — it is only correct on the host clippy happened to run on. That
struct literal sits in a `#[cfg(unix)]` function that compiles for macOS, iOS,
Linux and four Android ABIs, and `dev_t`/`ino_t` are not one type across them:
on Apple `st_dev` is `i32` and `st_ino` is `u64`, on Linux/Android both are
`u64`. So on macOS the `st_ino` cast looks redundant and on Linux the `st_dev`
cast does — delete either and you get a compile error on the other target.

Reverted, and pinned in place with a narrow `#[allow(clippy::unnecessary_cast)]`
on the statement plus a comment explaining the target skew, next to the
`st_mode` comment already in the file warning about exactly this hazard. Both
fields are non-negative kernel identifiers, so the widening cannot change the
identity comparison's meaning on any target.

### The same trap, caught by CI: `useless_conversion` three lines above

I ran the whole gate under a clean `ubuntu:24.04` container precisely because of
the above, and it — and then CI — found the mirror image of it. The `st_mode`
file-type test two statements earlier uses `u32::from(...)` on three operands.
On macOS those widen `u16` → `u32` and clippy is silent; on Linux all three are
already `u32`, so `clippy::useless_conversion` fires three times and `-D warnings`
turns them into hard errors. The conversions are exactly as load-bearing as the
file's existing comment says: `mode_t` is `u16` on armv7/i686 Android.

Fixed in **f3d2508** by folding the two statements into one boolean and scoping a
single `#[allow(clippy::useless_conversion)]` to it, with a comment saying why
clippy is wrong here. This is the whole argument for running the gate on the
target CI runs on rather than on a developer's Mac.

Those two are the only `#[allow]`s added. Nothing is allowed at crate level.

## The gate

`scripts/check-rust-clippy.sh`, built to the shape of `check-rust-fmt.sh` and
`check-rust-deny.sh`:

- **discovers** crates by finding `Cargo.toml` under `wallet/` — a new crate is
  gated from its first commit, no list to forget to update (#340's final
  acceptance criterion);
- runs cargo from `wallet/` so `rust-toolchain.toml` selects the pin, and
  **refuses to render a verdict** on any other compiler, because clippy's lint
  set moves between releases and a check on whatever-was-installed reports
  version skew as a code defect;
- `--locked --all-targets -- -D warnings`, so tests are linted too;
- `--fix` mode for the mechanical path, which tells you to read the diff and
  re-run rustfmt afterwards.

Unlike `fmt`/`deny` it genuinely compiles — clippy is a rustc driver — so its
jobs carry the librustzcash submodule, the Tauri system libraries, and a cache
key of their own (clippy and `cargo build` write different artifacts into the
same target-directory names; a shared key would have them evicting each other).

### CI wiring

**`.github/workflows/zuuli.yml`** — new `rust_clippy` job, `zuuli == 'true'`
condition matching its siblings, and all three wiring points updated so the gate
is not decorative:

- `changes` path filter gained `scripts/check-rust-clippy.sh`
- `gate.needs` → `[changes, frontend, rust_fmt, rust_deny, rust_clippy, rust_plugin, rust_app]`
- `gate`'s inline `results=` → `... $RUST_DENY_RESULT $RUST_CLIPPY_RESULT $RUST_PLUGIN_RESULT ...`

**`.github/workflows/zuuallet.yml`** — mirrored `clippy` job and path filters,
for the same reason `fmt` and `deny` are mirrored there: the required `gate`
lives in zuuli.yml and its change detector does not select
`wallet/zuuallet/**`, so a Zuuallet-only PR could otherwise land unlinted code
the gate never sees — and then break the next unrelated ZUULI PR on files it
never touched.

`scripts/check-rust-toolchain.sh --self-test` and the real run both pass; the
new jobs take the channel from `--print-channel` and hold no version literal.

## Verification

- `scripts/check-rust-clippy.sh` — clean on all three crates, macOS 1.97.1.
- **Linux, not just macOS.** Clippy's verdict is target-dependent (see the
  `st_ino` note), so the whole gate was also run under a clean `ubuntu:24.04`
  container on the pinned toolchain. Clean there too.
- `scripts/check-rust-fmt.sh` — clean, so the fixes are rustfmt-stable.
- `cargo build` + `cargo test --locked --all-targets` — pass on all three crates.
- **The gate can fail, not just pass.** Proved in CI: see below.

## Proving the gate fails

Not asserted — done, on the real CI, on this branch:

- **d04bd1c** appended a `pub fn clippy_gate_smoke_test()` to
  `wallet/zuuallet/src-tauri/src/lib.rs` containing `format!("{}", "…")` and a
  `let`-then-return — `useless_format` + `let_and_return`. Deliberately in
  **zuuallet**, not the plugin, so it also proves the script's crate discovery
  reaches a crate nobody named and that the zuuallet mirror job earns its place.
- Both lint jobs went red, in about two minutes:

  ```
  Rust / lints   fail   2m1s
  clippy         fail   2m8s
  ```
  ```
  error: useless use of `format!`
    --> src/lib.rs:14:13
     = help: to override `-D warnings` add `#[allow(clippy::useless_format)]`
  1 crate(s) have clippy warnings: wallet/zuuallet/src-tauri
  ```

- And the required `gate` went red **because of it**, which is the part that is
  easy to get wrong:

  ```
  RUST_CLIPPY_RESULT: failure
  ZUULI changed: true; job results: success success success failure success success
  Expected every applicable job to be success, got: failure
  ```

- **f035006** reverts it. `git diff f3d2508 HEAD` is empty, so the branch head is
  byte-identical to the tree that CI already proved green (all 21 checks pass,
  including `Rust / lints`, `clippy` and `gate`).

## Known limitation, deliberately not fixed here

`#[cfg(windows)]` and macOS-only code — the custody backends — is compiled by
`zuuallet.yml`'s `custody-platforms` matrix, which runs `cargo test`, not clippy.
So the two new jobs lint every crate but only the Linux view of it. Extending
`custody-platforms` to lint is a real follow-up; it is not in this PR because it
would surface an unmeasured second backlog on two more targets, and #354 is
about closing the measured one.


