### PR TITLE
ci(zuuli): narrow the packaging path filter to consumed crates

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - wallet/zuuli/**
-      - wallet/plugins/**
+      - wallet/plugins/tauri-plugin-zcash/**
       - wallet/rust-toolchain.toml
       - z/zcash/librustzcash
       - .gitmodules
@@ -16,7 +16,7 @@ on:
     branches: [main]
     paths:
       - wallet/zuuli/**
-      - wallet/plugins/**
+      - wallet/plugins/tauri-plugin-zcash/**
       - wallet/rust-toolchain.toml
       - z/zcash/librustzcash
       - .gitmodules


### PR DESCRIPTION
Half 1 of #348. **This PR changes `zuuli-packaging.yml` only. `zuuli.yml`'s `case` list is deliberately untouched** — the analysis and recommendation for it are below, for the owner to decide.

## What changed

`.github/workflows/zuuli-packaging.yml`, both `paths:` filters (lines 7 and 19):

```diff
       - wallet/zuuli/**
-      - wallet/plugins/**
+      - wallet/plugins/tauri-plugin-zcash/**
       - wallet/rust-toolchain.toml
```

Two lines. Nothing else in the file, and no other file, is modified.

## ZUULI's verified path dependencies

`wallet/zuuli/src-tauri/Cargo.toml` has **exactly one** path dependency under `wallet/plugins/`:

```toml
tauri-plugin-zcash = { path = "../../plugins/tauri-plugin-zcash" }
```

Everything else there is a crates.io dep (`tauri`, `tauri-plugin-opener`, `tauri-plugin-deep-link`, `tauri-plugin-http`, `serde`, `serde_json`, `tiny_http`, `url`, `getrandom`).

**Transitive check** — the same one #345 did: `wallet/plugins/tauri-plugin-zcash/Cargo.toml`'s own path deps (8 of them: `zcash_client_backend`, `zcash_client_sqlite`, `zcash_primitives`, `zcash_proofs`, `zcash_keys`, `zcash_protocol`, `zcash_address`, `zip321`) all point into `../../../z/zcash/librustzcash`, which this filter already lists separately as `z/zcash/librustzcash`. So the narrowed glob is a **complete cover** of the real dependency graph — no transitive input loses coverage.

**Occurrence check** — `wallet/plugins/**` appeared exactly twice in the file, lines 7 and 19, one in `pull_request.paths` and one in `push.paths`, both expressing the same "packaging builds the crates ZUULI consumes" intent. No third occurrence, and no occurrence with a different meaning. (The file's other `wallet/plugins` references — rust-cache `workspaces`, `--manifest-path` — were already specific to `tauri-plugin-zcash`.)

Verified: the file still parses as YAML and both filter lists round-trip as intended.

## `scripts/check-rust-*.sh` and `wallet/deny.toml` — not added, and that is correct

They are **not** in the packaging filter today, and they should stay out: `zuuli-packaging.yml` never invokes `check-rust-fmt.sh`, `check-rust-deny.sh`, or `check-rust-clippy.sh`, and never reads `wallet/deny.toml`. Those are lint/supply-chain gates that live in `zuuli.yml` (which does list all four). Adding them here would trigger a ~90-minute packaging matrix for a policy file packaging does not consume.

**Separate gap worth noting, deliberately not fixed here.** The packaging workflow *does* depend on five scripts, none of which are in its filter:

- `scripts/verify-ios-ipa.sh` (`--self-test`, `--self-test-darwin`, `--verify-app-structure`)
- `scripts/normalize-generated-ios-project.mjs` (`--self-test`, plus pre/post-build reproducibility)
- `scripts/verify-ci-cache-policy.mjs`
- `scripts/check-rust-toolchain.sh`
- `scripts/android-toolchain-env.sh`

A PR editing only one of those does not run packaging, so its self-tests are unexercised. That is pre-existing and orthogonal to #348's "narrow the breadth" question — widening a filter is the opposite change and deserves its own issue rather than riding along in a two-line narrowing PR.

---

# Half 2 — `zuuli.yml`'s `case` list: analysis and recommendation (NOT changed)

The `changes` job's glob list at line 74 is untouched, byte for byte, as are the `gate` job's `needs:` and its inline `results=` string.

**Recommendation: leave `wallet/plugins/*` broad. Do not narrow it.** I found a reason stronger than the general fail-safe argument in the issue.

**The decisive fact.** `zuuli.yml`'s `rust_fmt`, `rust_deny`, and `rust_clippy` jobs do not lint ZUULI's crates — they lint *every crate under `wallet/`*, and they **discover** crates rather than listing them. All three scripts do a `find . -name Cargo.toml` under `wallet/`, and all three say so in their headers:

- `check-rust-fmt.sh`: "Crates are discovered rather than listed. A new crate under wallet/ is gated"
- `check-rust-clippy.sh`: "Crates are discovered rather than listed. A new crate under wallet/ is gated"
- `check-rust-deny.sh`: "Crates are discovered rather than listed, so a new crate under wallet/ is gated from its first commit"

So when a second plugin crate lands under `wallet/plugins/`, these three jobs are **the only thing in CI that formats, lints, and supply-chain-audits it** — and `wallet/plugins/*` is precisely what causes them to run. Narrowing the `case` list to `wallet/plugins/tauri-plugin-zcash/*` would mean a PR touching the new crate skips the very jobs responsible for gating it. The crate would be gated "from its first commit" by the scripts' own design, and then silently ungated by the trigger filter. That is not over-inclusion being trimmed; that is a hole.

Note this is exactly the asymmetry that makes half 1 and half 2 different calls. `zuuli-packaging.yml` *builds the ZUULI app* — a crate ZUULI does not consume genuinely contributes nothing to a packaging run, so narrowing loses no coverage. `zuuli.yml` *lints everything under `wallet/`* — so the same glob that looks over-broad is load-bearing.

**Supporting arguments, in the issue's own terms:**

1. **The asymmetry.** Over-inclusive costs one wasted build (frontend ~15 min, Rust jobs up to 45 min). Under-inclusive lets a real regression merge ungated: when `changes` reports `false`, `gate` *expects* every job to be `skipped` and reports success. A missed path is an invisible pass, not a visible failure.
2. **The author already reasoned this way.** The `changes` job fails open to `zuuli=true` on a non-40-hex base SHA, on a base commit absent from the clone, and on a failed `git diff` — three separate fail-open branches, each with a comment saying so ("never into an unverified skip"). Narrowing the glob would contradict the safety posture the rest of the job is built around.
3. **Cost is bounded and one-time-ish.** The wasted work is one extra ZUULI run per PR touching a hypothetical unconsumed plugin crate. The packaging matrix — the genuinely expensive ~90-minute one — is already excluded by this PR.

**If the owner prefers to narrow anyway**, the safe form is to list consumed crates explicitly rather than glob (`wallet/plugins/tauri-plugin-zcash/*|wallet/plugins/<next-crate>/*`), and pair it with a comment on the `case` line stating that any new crate under `wallet/` must be added there or it goes unlinted. A bare narrowing without that note will be re-broken the first time someone adds a crate.

**Suggested resolution of #348:** merge this PR for half 1; record "leave `zuuli.yml` broad, by design" as the half-2 decision with the discovery-script rationale above; then close. Per the issue's framing, it stays open until the gate question is decided.

## Acceptance criteria (#348)

- [x] A decision recorded for each of the two workflows, with rationale — packaging narrowed here; `zuuli.yml` analysed above with a recommendation to leave it broad.
- [x] Narrowing verified against ZUULI's actual path dependencies in `wallet/zuuli/src-tauri/Cargo.toml`, including the transitive check into `z/zcash/librustzcash`.
- [x] The `gate` job's `needs:` and inline `results` logic left byte-identical — `zuuli.yml` is not in this diff at all.
- [ ] A PR touching a consumed crate still triggers the ZUULI jobs — **demonstrated by this PR itself**: it edits `.github/workflows/zuuli-packaging.yml`, which is both an entry in packaging's own filter and an entry in `zuuli.yml`'s `case` list. So the required `gate` and the full packaging matrix both run here, exercising the edited file. Check the run before merging.

Refs #348

https://claude.ai/code/session_016hGD65qzFQS9CgtEd8Pyej
