### PR TITLE
release(zuuli): internal build 0.1.0+10

### DIFF
--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.zuuli",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 9,
+  "build": 10,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "9").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "10").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "9"
+        CFBundleVersion: "10"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -28,14 +28,14 @@
     "targets": "all",
     "icon": ["icons/icon.png"],
     "iOS": {
-      "bundleVersion": "9",
+      "bundleVersion": "10",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 9
+      "versionCode": 10
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary
- bump the canonical ZUULI internal release identity from `0.1.0+9` to `0.1.0+10`
- synchronize Android `versionCode`, iOS `CURRENT_PROJECT_VERSION`/Info.plist, and Tauri bundle version
- package the merged safe-area, resolved-recipient donation, and membership purchase-safety train for internal device testing

## Verification
- `npm run release:bump -- --version=0.1.0 --build=10`
- `npm run release:verify`
- `git diff --check`

After exact-head gates pass, admin squash merge will trigger the protected Android Play internal and iOS TestFlight release workflow.