### PR TITLE
fix(free2z): keep the checksum tail when truncating Zcash addresses

### DIFF
--- a/ts/react/free2z/src/components/DonateZcashPanel.tsx
+++ b/ts/react/free2z/src/components/DonateZcashPanel.tsx
@@ -4,6 +4,7 @@ import SimpleZcashAddress from "./SimpleZcashAddress";
 import { SimpleCreator } from "./MySubscribers";
 import { useState } from "react";
 import { TabPanel } from "./TabPanel";
+import { truncateZcashAddress } from "../utils/zcashAddress";
 
 
 type DonateZcashPanelProps = {
@@ -29,8 +30,12 @@ export default function DonateZcashPanel(props: DonateZcashPanelProps) {
                 direction="column" spacing={1}
                 alignItems="center"
             >
-                <Typography variant="caption">
-                    {`${creator.p2paddr.slice(0, 10)}...${creator.p2paddr.slice(-10)}`}
+                <Typography
+                    variant="caption"
+                    title={creator.p2paddr}
+                    sx={{ overflowWrap: "anywhere", wordBreak: "break-all" }}
+                >
+                    {truncateZcashAddress(creator.p2paddr)}
                 </Typography>
                 {!!(addr || creator.p2paddr) &&
                     <SimpleZcashAddress

--- a/ts/react/free2z/src/components/QRAddress.tsx
+++ b/ts/react/free2z/src/components/QRAddress.tsx
@@ -10,6 +10,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import HelpIcon from "@mui/icons-material/Help";
 import QRCode from "react-qr-code";
 import CopyToClipboard from "./CopyToClipboard";
+import { formatZcashAddressForDisplay } from "../utils/zcashAddress";
 
 export interface QRAddressProps {
     addr: string;
@@ -75,8 +76,18 @@ function QRAddress(props: QRAddressProps) {
                 <CopyToClipboard>
                     {({ copy }) => (
                         addr.startsWith("zcash:") ? (
-                            <Link href={addr} onClick={() => handleCopy(copy)}>
-                                {`${addr.slice(0, 15)}...`}
+                            // Showing a tail makes this string longer than the
+                            // head-only version it replaces (measured: 128px ->
+                            // 276px at 16px), which is wider than the ~240px a
+                            // 320px phone leaves inside this dialog. It wraps
+                            // rather than overflowing.
+                            <Link
+                                href={addr}
+                                onClick={() => handleCopy(copy)}
+                                title={addr}
+                                sx={{ overflowWrap: "anywhere", wordBreak: "break-all" }}
+                            >
+                                {formatZcashAddressForDisplay(addr)}
                                 <Button
                                     size="small"
                                     variant="text"
@@ -93,8 +104,9 @@ function QRAddress(props: QRAddressProps) {
                                 color="secondary"
                                 aria-label="copy donation address"
                                 onClick={() => handleCopy(copy)}
+                                title={addr}
                             >
-                                {`${addr.slice(0, 5)}...${addr.slice(-5)}`}
+                                {formatZcashAddressForDisplay(addr, { head: 6, tail: 8 })}
                                 <ContentCopyIcon sx={{ ml: 1 }} />
                             </Button>
                         )

--- a/ts/react/free2z/src/components/SimpleZcashAddress.tsx
+++ b/ts/react/free2z/src/components/SimpleZcashAddress.tsx
@@ -2,6 +2,7 @@ import { Stack, Paper, Button, Link, Typography } from "@mui/material"
 import ContentCopyIcon from "@mui/icons-material/ContentCopy"
 import QRCode from "react-qr-code"
 import CopyToClipboard from "./CopyToClipboard"
+import { formatZcashAddressForDisplay } from "../utils/zcashAddress"
 
 
 export type SimpleZcashAddressProps = {
@@ -35,6 +36,7 @@ export default function SimpleZcashAddress(props: SimpleZcashAddressProps) {
                     addr.startsWith("zcash:") ? (
                         <Link
                             href={addr}
+                            title={addr}
                             onClick={() => {
                                 copy(addr)
                                 // navigate(addr)
@@ -46,8 +48,13 @@ export default function SimpleZcashAddress(props: SimpleZcashAddressProps) {
                                 justifyContent="center"
                                 spacing={0}
                             >
-                                <Typography>
-                                    {addr.slice(0, 15)}...
+                                {/* Wraps rather than overflowing: showing a
+                                    tail makes this ~276px at 16px, wider than
+                                    the ~240px a 320px phone leaves here. */}
+                                <Typography
+                                    sx={{ overflowWrap: "anywhere", wordBreak: "break-all" }}
+                                >
+                                    {formatZcashAddressForDisplay(addr)}
                                 </Typography>
                                 <Button
                                     size="small"
@@ -69,12 +76,13 @@ export default function SimpleZcashAddress(props: SimpleZcashAddressProps) {
                             variant="text"
                             color="secondary"
                             aria-label="copy donation address"
+                            title={addr}
                             onClick={() => {
                                 copy(addr)
                                 // navigate(addr)
                             }}
                         >
-                            {addr.slice(0, 5)}...{addr.slice(addr.length - 5, addr.length)}
+                            {formatZcashAddressForDisplay(addr, { head: 6, tail: 8 })}
                             <ContentCopyIcon />
                         </Button>
                     )

--- a/ts/react/free2z/src/utils/zcashAddress.ts
+++ b/ts/react/free2z/src/utils/zcashAddress.ts
@@ -1,0 +1,76 @@
+/**
+ * Display truncation for Zcash addresses and `zcash:` payment URIs.
+ *
+ * The rule, and the reason this file exists instead of five ad-hoc `slice`
+ * calls: when an address does not fit, truncate the MIDDLE and always keep the
+ * TAIL. Never `addr.slice(0, 15) + "..."`.
+ *
+ * Every Zcash address encoding ends in a checksum over everything before it —
+ * bech32/bech32m for Sapling, Unified and TEX, base58check for transparent. An
+ * attacker producing an address that *looks* like yours grinds a vanity
+ * prefix; that is cheap, and a head-only truncation displays exactly the part
+ * they ground. Matching the trailing characters instead means finding a
+ * different payload whose checksum collides there, which is the part that
+ * cannot be cheaply faked. So a head-only truncation is forgeable and proves
+ * nothing, while the tail is the evidence a user can actually check.
+ *
+ * The tail is therefore never rendered shorter than the head, and the full
+ * value must stay reachable (copy button, title, or an untruncated rendering)
+ * wherever one of these is shown.
+ */
+
+export const ZCASH_ADDRESS_ELLIPSIS = "…";
+
+export interface TruncateZcashAddressOptions {
+    head?: number;
+    tail?: number;
+}
+
+export function truncateZcashAddress(
+    address: string | null | undefined,
+    opts: TruncateZcashAddressOptions = {},
+): string {
+    if (!address) return "";
+    const requestedHead = Math.max(0, Math.trunc(opts.head ?? 10));
+    const requestedTail = Math.max(0, Math.trunc(opts.tail ?? 16));
+
+    // A head-weighted request is SWAPPED, not grown: the smaller budget goes to
+    // the head and the larger to the tail. So `{head: 30, tail: 2}` renders 2
+    // leading and 30 trailing characters — the caller's total width budget is
+    // respected exactly, and the weight lands on the part that cannot be
+    // forged. (Clamping only the head, or only raising the tail, would silently
+    // return a string wider than the caller sized its container for.)
+    const head = Math.min(requestedHead, requestedTail);
+    const tail = Math.max(requestedHead, requestedTail);
+
+    // `{head: 0, tail: 0}` would render a bare ellipsis — the address erased
+    // rather than shortened. Show the real thing instead.
+    if (head + tail === 0) return address;
+
+    // Truncating has to actually save characters, otherwise show the real thing.
+    if (address.length <= head + tail + ZCASH_ADDRESS_ELLIPSIS.length) {
+        return address;
+    }
+    const end = tail === 0 ? "" : address.slice(-tail);
+    return `${address.slice(0, head)}${ZCASH_ADDRESS_ELLIPSIS}${end}`;
+}
+
+/**
+ * What to render for a value that may be a bare address or a `zcash:` payment
+ * URI (`zcash:<addr>?amount=…&memo=…`).
+ *
+ * For a URI the meaningful part is the address, not the query string — keeping
+ * the literal tail of the URI would show `&memo=` and hide the checksum
+ * entirely. So the scheme is preserved, the parameters are dropped, and the
+ * address inside is middle-truncated by the rule above.
+ */
+export function formatZcashAddressForDisplay(
+    value: string | null | undefined,
+    opts: TruncateZcashAddressOptions = {},
+): string {
+    if (!value) return "";
+    if (!value.startsWith("zcash:")) return truncateZcashAddress(value, opts);
+    const withoutScheme = value.slice("zcash:".length);
+    const address = withoutScheme.split("?")[0];
+    return `zcash:${truncateZcashAddress(address, opts)}`;
+}


### PR DESCRIPTION
## Why this matters

The existing code truncates Zcash addresses **head-only** — `addr.slice(0, 15) + "..."`.

Every Zcash address encoding ends in a checksum over everything before it: bech32/bech32m for Sapling, Unified and TEX; base58check for transparent. An attacker producing an address that *looks* like yours grinds a vanity **prefix** — that is cheap, and it is precisely what a head-only truncation puts on screen. Matching the **trailing** characters instead means finding a different payload whose checksum collides there, which is not cheap.

**So the head is the forgeable part and the tail is the evidence.** A head-only truncation is forgeable and useless for verification.

## The fix

New `ts/react/free2z/src/utils/zcashAddress.ts`:

- `truncateZcashAddress(address, { head, tail })` — middle truncation, defaults `head: 10, tail: 16`. A head-weighted request is **swapped** rather than grown, so the tail is never shorter than the head even if a caller explicitly asks for it, and the caller's total width budget is respected exactly. Returns the input unchanged when truncating would not save characters; safe on empty/null/undefined.
- `formatZcashAddressForDisplay(value, opts)` — for `zcash:<addr>?amount=…&memo=…` payment URIs, keeping the literal tail would show the query string and hide the checksum entirely. So the scheme is kept, the parameters dropped, and the address inside middle-truncated.

Five ad-hoc slices now go through the one helper:

| site | was |
| --- | --- |
| `QRAddress.tsx:79` | `` `${addr.slice(0, 15)}...` `` — **head-only** |
| `SimpleZcashAddress.tsx:50` | `{addr.slice(0, 15)}...` — **head-only** |
| `QRAddress.tsx:97` | `` `${addr.slice(0, 5)}...${addr.slice(-5)}` `` |
| `SimpleZcashAddress.tsx:77` | `{addr.slice(0, 5)}...{addr.slice(-5)}` |
| `DonateZcashPanel.tsx:33` | `` `${p2paddr.slice(0, 10)}...${p2paddr.slice(-10)}` `` |

Showing a tail makes the URI string wider than the head-only version it replaces (~276px vs ~128px at 16px, against the ~240px a 320px phone leaves inside these dialogs), so the two URI renderings gain `overflowWrap: "anywhere"` / `wordBreak: "break-all"` and **wrap rather than overflow**. Each site also gains `title={addr}` so the full value stays reachable.

## Confirmed: display-only, never on a payment path

Read every call site — the truncated string is rendered text and nothing else:

- **`QRAddress.tsx`** — QR `value={addr}` (full), `href={addr}` (full), `title={addr}` (full), `handleCopy` does `copy(addr)` (full). Only the link/button *label* is truncated.
- **`SimpleZcashAddress.tsx`** — QR `value={addr}` (full), `href={addr}` (full), `title={addr}` (full), both `onClick` handlers `copy(addr)` (full). Only the `<Typography>` / button label is truncated.
- **`DonateZcashPanel.tsx`** — the truncated value is a bare `<Typography variant="caption">`; the address handed to `<SimpleZcashAddress addr={getURI(addr || creator.p2paddr, …)} />` is built from the **untruncated** `creator.p2paddr`. `title={creator.p2paddr}` carries the full value.

No truncated string is passed to `getURI`, to a QR `value`, to an `href`, or to the clipboard anywhere in the diff.

## Provenance

Ported verbatim from the corresponding change in the private free2z monorepo. All three pre-existing files were verified **byte-identical** to that commit's pre-image before applying (`diff` clean on all three), so the change applies exactly; the diffstat matches the source commit's (`+109 / -8` across the four files).

## Verification

`.github/workflows/ts-react-free2z.yml` is path-filtered to `ts/react/free2z/**`, so this change is genuinely CI-gated. Ran what CI runs:

```
$ cd ts/react/free2z && npm install
added 2428 packages, and audited 2429 packages in 12s

$ CI=false npm run build
EXIT=0
...
Compiled with warnings.
...
The build folder is ready to be deployed.
```

Build **passes**. The warnings are all pre-existing and none are from this change — the only two touching changed files are `DonateZcashPanel.tsx` `'___'/'__' is assigned a value but never used` and `SimpleZcashAddress.tsx` `'Paper' is defined but never used`, both present on `main` and untouched here.

https://claude.ai/code/session_019WPvRxe1tX1MfCw1devnF3
