### PR TITLE
Fix narrow-screen route clipping

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -119,6 +119,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Install the viewport-test browser
+        run: npx playwright install --with-deps chromium
+
       - name: Test frontend contracts
         run: npm run test
 

--- a/wallet/zuuli/.gitignore
+++ b/wallet/zuuli/.gitignore
@@ -2,6 +2,8 @@ node_modules
 dist
 dist-ssr
 .vite
+playwright-report
+test-results
 release-artifacts
 vendor/
 .bundle/

--- a/wallet/zuuli/package-lock.json
+++ b/wallet/zuuli/package-lock.json
@@ -47,6 +47,7 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "1.62.1",
         "@tauri-apps/cli": "^2",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
@@ -1118,6 +1119,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@protobuf-ts/runtime": {
@@ -6903,6 +6919,50 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs",
+    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs && playwright test",
+    "test:viewport": "playwright test tests/viewport.pw.ts",
     "test:play-testers": "node --test scripts/play-tester-groups.node-test.mjs",
     "typecheck": "tsc --noEmit",
     "release:verify": "node scripts/release-identity.mjs",
@@ -56,6 +57,7 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "1.62.1",
     "@tauri-apps/cli": "^2",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",

--- a/wallet/zuuli/playwright.config.ts
+++ b/wallet/zuuli/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "@playwright/test";
+
+const port = 1432;
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/*.pw.ts",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 2,
+  reporter: process.env.CI ? "github" : "list",
+  timeout: 60_000,
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+    browserName: "chromium",
+    colorScheme: "dark",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: `npm run dev -- --host 127.0.0.1 --port ${port}`,
+    env: { ...process.env, VITE_MOCK: "1" },
+    reuseExistingServer: false,
+    stderr: "pipe",
+    stdout: "pipe",
+    timeout: 30_000,
+    url: `http://127.0.0.1:${port}`,
+  },
+});

--- a/wallet/zuuli/src/components/layout/AppShell.tsx
+++ b/wallet/zuuli/src/components/layout/AppShell.tsx
@@ -32,11 +32,9 @@ function LegacyWalletNotice() {
 export function AppShell() {
   const location = useLocation();
   // AI and login each own a bounded internal scroll region while the header
-  // and mobile tabs stay pinned. Radix's
-  // ScrollArea wraps children in a `display: table` div that sizes to
-  // content, so a `h-full` flex column nested inside it can never resolve a
-  // real height. Give that route a plain, height-bound `main` instead of the
-  // page-scrolling ScrollArea every other route uses.
+  // and mobile tabs stay pinned. Keep those routes in a plain, height-bound
+  // main instead of nesting their scroll owners inside the generic page
+  // ScrollArea used by every other route.
   const isFullBleed =
     location.pathname.startsWith("/ai") || location.pathname === "/login";
 
@@ -51,8 +49,8 @@ export function AppShell() {
             <Outlet />
           </main>
         ) : (
-          <ScrollArea className="min-h-0 flex-1" data-route-scroll>
-            <main className="app-scroll-content mx-auto w-full max-w-6xl px-4 pt-6 md:px-8">
+          <ScrollArea className="min-h-0 min-w-0 max-w-full flex-1" data-route-scroll>
+            <main className="app-scroll-content mx-auto w-full min-w-0 max-w-6xl px-4 pt-6 md:px-8">
               <Outlet />
             </main>
           </ScrollArea>

--- a/wallet/zuuli/src/components/ui/scroll-area.tsx
+++ b/wallet/zuuli/src/components/ui/scroll-area.tsx
@@ -8,10 +8,14 @@ const ScrollArea = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
-    className={cn("relative overflow-hidden", className)}
+    className={cn("relative min-w-0 max-w-full overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    {/* Radix's max-content table wrapper must not widen a vertical page scroller. */}
+    <ScrollAreaPrimitive.Viewport
+      className="h-full w-full min-w-0 max-w-full rounded-[inherit] [&>div]:!block [&>div]:w-full [&>div]:min-w-0 [&>div]:max-w-full"
+      data-scroll-area-viewport
+    >
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -652,8 +652,10 @@ function EmptyHero({
             <LocalIcon className="h-5 w-5" aria-hidden />
           </div>
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="font-semibold">{localModel.display_name}</span>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="min-w-0 break-words font-semibold">
+                {localModel.display_name}
+              </span>
               <Badge variant="default" className="gap-1 px-1.5 py-0 text-[10px]">
                 <ShieldCheck className="h-3 w-3" aria-hidden />
                 private

--- a/wallet/zuuli/src/features/articles/pages/Author.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Author.tsx
@@ -75,7 +75,7 @@ export function Author() {
           title="Sign in with Zcash to publish"
           description="Authoring is free — sign a challenge with your wallet, no password or email required."
           action={
-            <div className="flex gap-2">
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
               <Button asChild>
                 <Link to="/login">Sign in with Zcash</Link>
               </Button>

--- a/wallet/zuuli/src/features/buy/BalanceHero.tsx
+++ b/wallet/zuuli/src/features/buy/BalanceHero.tsx
@@ -21,7 +21,7 @@ export function BalanceHero() {
     <Card className="relative overflow-hidden border-primary/20 bg-gradient-to-br from-card via-card to-primary/5">
       <div
         aria-hidden
-        className="pointer-events-none absolute -right-16 -top-16 h-52 w-52 rounded-full bg-primary/20 blur-3xl"
+        className="pointer-events-none absolute right-0 top-0 h-52 w-52 rounded-full bg-primary/20 blur-3xl"
       />
       <div className="relative grid gap-6 p-6 sm:grid-cols-[1.4fr_auto_1fr] sm:items-center sm:p-8">
         {/* 2Z balance */}

--- a/wallet/zuuli/src/features/home/LiveRail.tsx
+++ b/wallet/zuuli/src/features/home/LiveRail.tsx
@@ -120,8 +120,8 @@ export function LiveRail() {
       ) : (
         <div
           className={cn(
-            "-mx-1 flex snap-x snap-mandatory gap-4 overflow-x-auto px-1 pb-2",
-            "sm:mx-0 sm:grid sm:snap-none sm:grid-cols-2 sm:overflow-visible sm:px-0 sm:pb-0 lg:grid-cols-3",
+            "flex snap-x snap-mandatory gap-4 overflow-x-auto px-1 pb-2",
+            "sm:grid sm:snap-none sm:grid-cols-2 sm:overflow-visible sm:px-0 sm:pb-0 lg:grid-cols-3",
           )}
         >
           {streams.map((s) => (

--- a/wallet/zuuli/src/features/live/Discovery.tsx
+++ b/wallet/zuuli/src/features/live/Discovery.tsx
@@ -68,9 +68,9 @@ export function Discovery() {
       />
 
       <Tabs value={filter} onValueChange={(v) => setFilter(v as Filter)}>
-        <TabsList>
+        <TabsList className="grid h-auto w-full grid-cols-2 gap-1 sm:inline-flex sm:w-auto">
           {FILTERS.map((f) => (
-            <TabsTrigger key={f.value} value={f.value}>
+            <TabsTrigger className="min-h-11" key={f.value} value={f.value}>
               {f.label}
             </TabsTrigger>
           ))}

--- a/wallet/zuuli/src/features/profile/LinkedAccounts.tsx
+++ b/wallet/zuuli/src/features/profile/LinkedAccounts.tsx
@@ -246,8 +246,8 @@ interface IdentityRowProps {
 
 function IdentityRow({ icon, label, detail, action }: IdentityRowProps) {
   return (
-    <div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 bg-background/40 p-4">
-      <div className="flex min-w-0 items-center gap-3">
+    <div className="flex flex-col items-stretch gap-3 rounded-lg border border-border/60 bg-background/40 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
         <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
           {icon}
         </span>
@@ -256,7 +256,7 @@ function IdentityRow({ icon, label, detail, action }: IdentityRowProps) {
           <div className="truncate text-xs text-muted-foreground">{detail}</div>
         </div>
       </div>
-      <div className="shrink-0">{action}</div>
+      <div className="shrink-0 [&>*]:w-full sm:[&>*]:w-auto">{action}</div>
     </div>
   );
 }

--- a/wallet/zuuli/src/features/wallet/History.tsx
+++ b/wallet/zuuli/src/features/wallet/History.tsx
@@ -75,7 +75,7 @@ export function History() {
 function HistoryRow({ tx }: { tx: TransactionEntry }) {
   const incoming = tx.incoming;
   return (
-    <div className="flex items-start gap-3 px-3 py-4">
+    <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-3 px-3 py-4 sm:flex sm:gap-3">
       <div
         className={cn(
           "grid h-10 w-10 shrink-0 place-items-center rounded-full",
@@ -123,7 +123,7 @@ function HistoryRow({ tx }: { tx: TransactionEntry }) {
         </div>
       </div>
 
-      <div className="shrink-0 text-right">
+      <div className="col-start-2 mt-1 flex min-w-0 items-baseline justify-between gap-2 text-left sm:mt-0 sm:block sm:shrink-0 sm:text-right">
         <div
           className={cn(
             "text-sm font-semibold tabular-nums",

--- a/wallet/zuuli/src/features/wallet/Overview.tsx
+++ b/wallet/zuuli/src/features/wallet/Overview.tsx
@@ -90,7 +90,7 @@ export function Overview() {
               </div>
             </div>
 
-            <div className="flex flex-wrap gap-2 pt-1">
+            <div className="grid grid-cols-2 gap-2 pt-1 sm:flex sm:flex-wrap">
               <Button asChild variant="zec" size="lg">
                 <Link to="/wallet/send">
                   <ArrowUpRight className="h-4 w-4" />

--- a/wallet/zuuli/src/features/wallet/components.tsx
+++ b/wallet/zuuli/src/features/wallet/components.tsx
@@ -144,7 +144,7 @@ export function AddressCard({
 export function TxRow({ tx }: { tx: TransactionEntry }) {
   const incoming = tx.incoming;
   return (
-    <div className="flex items-center gap-3 rounded-lg px-3 py-3 transition-colors hover:bg-secondary/40">
+    <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 rounded-lg px-3 py-3 transition-colors hover:bg-secondary/40 sm:flex sm:gap-3">
       <div
         className={cn(
           "grid h-9 w-9 shrink-0 place-items-center rounded-full",
@@ -183,7 +183,7 @@ export function TxRow({ tx }: { tx: TransactionEntry }) {
         )}
       </div>
 
-      <div className="shrink-0 text-right">
+      <div className="col-start-2 mt-1 flex min-w-0 items-baseline justify-between gap-2 text-left sm:mt-0 sm:block sm:shrink-0 sm:text-right">
         <div
           className={cn(
             "text-sm font-semibold tabular-nums",

--- a/wallet/zuuli/src/features/wallet/index.tsx
+++ b/wallet/zuuli/src/features/wallet/index.tsx
@@ -36,7 +36,7 @@ const NAV: { to: string; label: string; icon: LucideIcon; end?: boolean }[] = [
 function WalletNav() {
   return (
     <nav
-      className="mb-6 inline-flex items-center gap-1 rounded-lg bg-muted/60 p-1"
+      className="mb-6 grid w-full grid-cols-2 gap-1 rounded-lg bg-muted/60 p-1 sm:inline-flex sm:w-auto sm:items-center"
       aria-label="Wallet sections"
     >
       {NAV.map(({ to, label, icon: Icon, end }) => (
@@ -46,7 +46,7 @@ function WalletNav() {
           end={end}
           className={({ isActive }) =>
             cn(
-              "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               isActive
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground",

--- a/wallet/zuuli/src/features/wallet/shared.tsx
+++ b/wallet/zuuli/src/features/wallet/shared.tsx
@@ -110,14 +110,14 @@ export function AmountDisplay({
   sign?: "+" | "−";
 }) {
   const sizes = {
-    lg: "text-5xl md:text-6xl",
+    lg: "text-2xl min-[360px]:text-3xl sm:text-5xl md:text-6xl",
     md: "text-3xl",
     sm: "text-2xl",
   } as const;
   return (
     <div
       className={cn(
-        "flex items-baseline gap-1.5 font-bold tabular-nums leading-none",
+        "flex min-w-0 items-baseline gap-1.5 font-bold tabular-nums leading-none",
         sizes[size],
       )}
     >

--- a/wallet/zuuli/tests/viewport.pw.ts
+++ b/wallet/zuuli/tests/viewport.pw.ts
@@ -1,0 +1,209 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const WIDTHS = [320, 360, 390, 414] as const;
+const ROUTES = [
+  "/",
+  "/search",
+  "/search?q=zcash",
+  "/creator/skyl",
+  "/profile",
+  "/kyc",
+  "/wallet",
+  "/wallet/send",
+  "/wallet/receive",
+  "/wallet/history",
+  "/ai",
+  "/live",
+  "/live/nine",
+  "/articles",
+  "/articles/new",
+  "/articles/why-shielded-by-default",
+  "/buy",
+  "/does-not-exist",
+  "/login",
+] as const;
+
+type HorizontalAudit = {
+  boundary: { clientWidth: number; scrollWidth: number };
+  content: { clientWidth: number; scrollWidth: number };
+  failures: string[];
+};
+
+async function setSession(page: Page, signedIn: boolean) {
+  await page.addInitScript((authenticated) => {
+    const key = "zuuli.knox.token";
+    if (authenticated) localStorage.setItem(key, "mock-knox-token");
+    else localStorage.removeItem(key);
+  }, signedIn);
+}
+
+async function auditHorizontalLayout(page: Page): Promise<HorizontalAudit> {
+  return page.evaluate(() => {
+    const genericContent = document.querySelector<HTMLElement>(
+      "main.app-scroll-content",
+    );
+    const routeFrame = document.querySelector<HTMLElement>(
+      "main[data-route-frame]",
+    );
+    const content = genericContent ?? routeFrame;
+    if (!content) throw new Error("Route content frame is missing");
+
+    const boundary = genericContent
+      ? genericContent.closest<HTMLElement>("[data-scroll-area-viewport]")
+      : routeFrame;
+    if (!boundary) throw new Error("Route viewport boundary is missing");
+
+    const boundaryRect = boundary.getBoundingClientRect();
+    const tolerance = 1;
+    const failures: string[] = [];
+
+    function label(element: Element): string {
+      const html = element as HTMLElement;
+      const text = (
+        element.getAttribute("aria-label") ??
+        html.innerText ??
+        element.textContent ??
+        ""
+      )
+        .trim()
+        .replace(/\s+/g, " ")
+        .slice(0, 60);
+      const id = element.id ? `#${element.id}` : "";
+      return `${element.tagName.toLowerCase()}${id}${text ? ` “${text}”` : ""}`;
+    }
+
+    function isLocallyScrollable(element: Element): boolean {
+      for (
+        let current = element.parentElement;
+        current && current !== content.parentElement;
+        current = current.parentElement
+      ) {
+        const style = getComputedStyle(current);
+        if (
+          (style.overflowX === "auto" || style.overflowX === "scroll") &&
+          current.scrollWidth > current.clientWidth + tolerance
+        ) {
+          const rect = current.getBoundingClientRect();
+          return (
+            rect.left >= boundaryRect.left - tolerance &&
+            rect.right <= boundaryRect.right + tolerance
+          );
+        }
+        if (current === content) break;
+      }
+      return false;
+    }
+
+    for (const element of [content, ...content.querySelectorAll<HTMLElement>("*")]) {
+      const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      if (
+        rect.width <= 0 ||
+        rect.height <= 0 ||
+        style.display === "none" ||
+        style.visibility === "hidden" ||
+        element.classList.contains("sr-only")
+      ) {
+        continue;
+      }
+      if (element.closest("svg") && element.tagName.toLowerCase() !== "svg") {
+        continue;
+      }
+      if (
+        element.getAttribute("aria-hidden") === "true" ||
+        (style.pointerEvents === "none" && !element.textContent?.trim())
+      ) {
+        continue;
+      }
+
+      const outside =
+        rect.left < boundaryRect.left - tolerance ||
+        rect.right > boundaryRect.right + tolerance;
+      if (outside && !isLocallyScrollable(element)) {
+        failures.push(
+          `${label(element)} bounds ${rect.left.toFixed(1)}..${rect.right.toFixed(1)} outside ${boundaryRect.left.toFixed(1)}..${boundaryRect.right.toFixed(1)}`,
+        );
+      }
+
+      const scrollsHorizontally =
+        element.clientWidth > 0 &&
+        element.scrollWidth > element.clientWidth + tolerance;
+      const isLocalOwner =
+        style.overflowX === "auto" || style.overflowX === "scroll";
+      const deliberatelyEllipsized =
+        style.textOverflow === "ellipsis" ||
+        element.classList.contains("truncate") ||
+        Number.parseInt(style.webkitLineClamp, 10) > 0;
+      const formControl = element.matches("input, textarea, select");
+      if (
+        scrollsHorizontally &&
+        !isLocalOwner &&
+        !isLocallyScrollable(element) &&
+        !deliberatelyEllipsized &&
+        !formControl
+      ) {
+        failures.push(
+          `${label(element)} scrollWidth ${element.scrollWidth} exceeds clientWidth ${element.clientWidth}`,
+        );
+      }
+    }
+
+    return {
+      boundary: {
+        clientWidth: boundary.clientWidth,
+        scrollWidth: boundary.scrollWidth,
+      },
+      content: {
+        clientWidth: content.clientWidth,
+        scrollWidth: content.scrollWidth,
+      },
+      failures: [...new Set(failures)].slice(0, 30),
+    };
+  });
+}
+
+for (const signedIn of [false, true]) {
+  for (const width of WIDTHS) {
+    test(`${signedIn ? "signed in" : "signed out"} routes fit at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 760 });
+      await setSession(page, signedIn);
+
+      for (const route of ROUTES) {
+        await page.goto(route);
+        await page.locator("[data-app-frame]").waitFor();
+        await page.waitForTimeout(500);
+
+        const audit = await auditHorizontalLayout(page);
+        expect(
+          audit.boundary.scrollWidth,
+          `${route} route viewport must not acquire horizontal overflow`,
+        ).toBeLessThanOrEqual(audit.boundary.clientWidth + 1);
+        expect(
+          audit.content.scrollWidth,
+          `${route} route content must not acquire horizontal overflow`,
+        ).toBeLessThanOrEqual(audit.content.clientWidth + 1);
+        expect(audit.failures, `${route} has clipped descendants`).toEqual([]);
+
+        if (route === "/live" && width === 320) {
+          const filterTabs = await page.getByRole("tab").evaluateAll((tabs) =>
+            tabs.map((tab) => {
+              const rect = tab.getBoundingClientRect();
+              return { height: rect.height, top: rect.top };
+            }),
+          );
+          expect(filterTabs, "live filters must retain four touch targets").toHaveLength(4);
+          expect(
+            filterTabs.every(({ height }) => height >= 44),
+            "live filter targets must remain at least 44px high",
+          ).toBe(true);
+          expect(
+            new Set(filterTabs.map(({ top }) => Math.round(top))).size,
+            "live filters must reflow into two rows at 320px",
+          ).toBe(2);
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
Closes #391

## Summary

- constrain the Radix ScrollArea viewport and its generated max-content wrapper to the app shell width
- make each route-level layout exposed by the new invariant responsive at narrow widths (wallet navigation/balances/transactions, profile identities, AI model metadata, article CTAs, buy decoration, and the home live rail)
- add a real Chromium regression matrix covering all 19 routed screens in both signed-out and mock signed-in states at 320, 360, 390, and 414 px
- distinguish deliberate, contained local horizontal scrollers from page/descendant clipping; install Chromium in the existing frontend CI gate

## Evidence

At the reported 320 px viewport before this change:

- route viewport: `clientWidth=320`, `scrollWidth=431`
- route content: `clientWidth=431`, `scrollWidth=431`
- wallet section navigation reached `x=414.859`

After this change:

- route viewport: `clientWidth=320`, `scrollWidth=320`
- route content: `clientWidth=320`, `scrollWidth=320`
- wallet section navigation ends at `x=304`

The automated browser test additionally inspects every visible descendant's bounding box and scroll width, while exempting only contained elements whose computed `overflow-x` is actually scrollable/auto (plus intentional truncation, form-control internals, and non-layout SVG internals).

## Verification after rebase onto `origin/main` at `3dfaffa`

- `npm run test:viewport` — 8/8 Playwright matrix tests passed with the committed two-worker cap
- `npm test` — 197 Vitest tests, 5 safe-area contract tests, and 8 Playwright matrix tests passed
- `npm run typecheck` — passed
- `npm run build` — passed (existing chunk-size warnings only)
- `git diff --check origin/main...HEAD` — passed

The first rebased CI run caught a real Ubuntu/Chromium font-metric miss at
`/live`/320 px: the four filters needed 293 px inside a 288 px content box.
The filters now reflow as a 2×2 mobile grid with 44 px minimum targets and
return to an inline row at `sm`. The viewport test explicitly proves all four
targets, their minimum height, and two-row reflow at 320 px in both auth states.

## Adversarial review

One significant finding was identified and fixed before the final push: Linux
font metrics made the `/live` filter row 5 px wider than its 320 px content
box. The final responsive grid and target-size assertions address it without
hiding overflow or exempting the route. No significant findings remain.

The review specifically challenged the global Radix wrapper override, local-scroller exemptions, auth-state setup, Linux font-metric behavior, CI browser installation, and worker/resource cap. `ScrollArea` has one application use (the generic vertical route scroller), intentional horizontal rails remain ordinary `overflow-x-auto` containers, the test checks the long wallet balance under Chromium in both auth states, and the exact non-CI command completed twice with two workers.

Residual scope: this regression is a Chromium layout contract, not a substitute for signed Android/iOS device QA; it is intentionally limited to catching page-level and descendant horizontal clipping across the routed UI.

RISKIEST LINE: `src/components/ui/scroll-area.tsx`'s generated-wrapper override changes the shared primitive's sizing behavior. Its current single route-scroller use and the complete routed viewport matrix make that blast radius explicit and tested.
