### PR TITLE
fix(zuuli): secure card checkout launch

### DIFF
--- a/wallet/zuuli/README.md
+++ b/wallet/zuuli/README.md
@@ -51,6 +51,12 @@ In a plain browser ZUULI runs in **mock mode** with realistic data so you can
 explore every screen. Inside a Tauri shell it drives the real wallet engine
 and the real free2z API.
 
+Card checkout permits `https://checkout.stripe.com` by default. If Stripe
+Custom Domains is enabled for the account, add its exact DNS name at build time
+with `VITE_STRIPE_CHECKOUT_HOSTS=pay.example.com` (comma-separated for more than
+one). Do not include a scheme, path, port, userinfo, suffix wildcard, or a domain
+that is not configured in Stripe.
+
 The committed native projects live under `src-tauri/gen/apple` and
 `src-tauri/gen/android`. ZUULI uses application identifier
 `cash.free2z.zuuli`, targets iOS 18+, and supports Android API 29+ while

--- a/wallet/zuuli/src/App.tsx
+++ b/wallet/zuuli/src/App.tsx
@@ -10,6 +10,10 @@ import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
 import { auth } from "@/lib/api/free2z";
 import { recoverMobileOAuth } from "@/lib/oauth/transport";
+import {
+  clearPendingSocialLoginDestination,
+  consumePendingSocialLoginDestination,
+} from "@/lib/auth/login-destination";
 
 import AuthFeature from "@/features/auth";
 
@@ -64,9 +68,14 @@ function MobileOAuthRecovery() {
         toast.success(capture.associate ? "Account linked" : "Welcome to ZUULI", {
           description: `Finished ${capture.provider} sign-in after returning to the app.`,
         });
-        if (!capture.associate) navigate("/", { replace: true });
+        if (!capture.associate) {
+          navigate(consumePendingSocialLoginDestination(), { replace: true });
+        } else {
+          clearPendingSocialLoginDestination();
+        }
       })
       .catch((error) => {
+        clearPendingSocialLoginDestination();
         toast.error("Couldn't finish sign-in", {
           description: error instanceof Error ? error.message : "Please try again.",
         });

--- a/wallet/zuuli/src/components/common/SocialButtons.tsx
+++ b/wallet/zuuli/src/components/common/SocialButtons.tsx
@@ -25,6 +25,11 @@ import { useSocialProviders } from "@/hooks/useSocialProviders";
 import { auth } from "@/lib/api/free2z";
 import { useSession } from "@/store/session";
 import type { SocialProvider } from "@/lib/api/types";
+import {
+  clearPendingSocialLoginDestination,
+  rememberPendingSocialLoginDestination,
+  type LoginDestination,
+} from "@/lib/auth/login-destination";
 
 const PROVIDER_NAME: Record<SocialProvider, string> = {
   x: "X",
@@ -59,6 +64,8 @@ export interface SocialButtonsProps {
   onLinked?: (provider: SocialProvider) => void;
   /** Shown when every configured provider is already linked / none configured. */
   emptyState?: ReactNode;
+  /** Narrowly allowlisted route used only after a fresh login. */
+  loginDestination?: LoginDestination;
 }
 
 const DEFAULT_EMPTY_STATE = (
@@ -72,6 +79,7 @@ export function SocialButtons({
   alreadyLinked,
   onLinked,
   emptyState = DEFAULT_EMPTY_STATE,
+  loginDestination = "/",
 }: SocialButtonsProps) {
   const { providers: configured, loading } = useSocialProviders();
   const navigate = useNavigate();
@@ -86,6 +94,7 @@ export function SocialButtons({
   async function handleClick(provider: SocialProvider) {
     if (pending) return;
     setPending(provider);
+    if (!associate) rememberPendingSocialLoginDestination(loginDestination);
     try {
       const user = await auth.socialLogin(provider, { associate });
       setUser(user);
@@ -99,9 +108,11 @@ export function SocialButtons({
         toast.success("Welcome to ZUULI", {
           description: `Signed in with ${name}.`,
         });
-        navigate("/");
+        clearPendingSocialLoginDestination();
+        navigate(loginDestination, { replace: true });
       }
     } catch (e) {
+      if (!associate) clearPendingSocialLoginDestination();
       toast.error(associate ? "Couldn't link that account" : "Couldn't sign in", {
         description: e instanceof Error ? e.message : "Please try again.",
       });

--- a/wallet/zuuli/src/features/auth/ClassicLoginForm.tsx
+++ b/wallet/zuuli/src/features/auth/ClassicLoginForm.tsx
@@ -12,8 +12,13 @@ import { Label } from "@/components/ui/label";
 import { auth } from "@/lib/api/free2z";
 import type { AuthUser } from "@/lib/api/types";
 import { useSession } from "@/store/session";
+import type { LoginDestination } from "@/lib/auth/login-destination";
 
-export function ClassicLoginForm() {
+export function ClassicLoginForm({
+  loginDestination = "/",
+}: {
+  loginDestination?: LoginDestination;
+}) {
   const navigate = useNavigate();
   const setUser = useSession((s) => s.setUser);
   const [username, setUsername] = useState("");
@@ -29,7 +34,7 @@ export function ClassicLoginForm() {
     toast.success("Welcome back", {
       description: `Signed in as ${user.username}.`,
     });
-    navigate("/");
+    navigate(loginDestination, { replace: true });
   }
 
   async function onSubmit(e: React.FormEvent) {

--- a/wallet/zuuli/src/features/auth/ZcashLoginFlow.tsx
+++ b/wallet/zuuli/src/features/auth/ZcashLoginFlow.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { truncateAddress } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { SeedReveal } from "./SeedReveal";
+import type { LoginDestination } from "@/lib/auth/login-destination";
 import {
   STEP_META,
   STEP_ORDER,
@@ -54,8 +55,12 @@ function StepIcon({ status }: { status: StepStatus }) {
   );
 }
 
-export function ZcashLoginFlow() {
-  const flow = useZcashLogin();
+export function ZcashLoginFlow({
+  loginDestination = "/",
+}: {
+  loginDestination?: LoginDestination;
+}) {
+  const flow = useZcashLogin(loginDestination);
   const {
     phase,
     steps,

--- a/wallet/zuuli/src/features/auth/index.tsx
+++ b/wallet/zuuli/src/features/auth/index.tsx
@@ -6,7 +6,7 @@
 // (with 2FA when enabled) and, soon, X / Google follow below as alternatives.
 
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { ArrowLeft, ArrowUpRight, HelpCircle, ShieldCheck } from "lucide-react";
 import { Wordmark } from "@/components/brand/Logo";
 import { Button } from "@/components/ui/button";
@@ -24,10 +24,13 @@ import { BrandPanel } from "./BrandPanel";
 import { ClassicLoginForm } from "./ClassicLoginForm";
 import { ZcashLoginFlow } from "./ZcashLoginFlow";
 import { ZShieldInfo } from "./ZShieldInfo";
+import { loginDestinationFromState } from "@/lib/auth/login-destination";
 
 type Method = "chooser" | "zcash";
 
 export default function AuthFeature() {
+  const location = useLocation();
+  const loginDestination = loginDestinationFromState(location.state);
   const bootstrap = useWallet((s) => s.bootstrap);
   const [method, setMethod] = useState<Method>("chooser");
 
@@ -75,7 +78,7 @@ export default function AuthFeature() {
                       <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
                       All sign-in options
                     </button>
-                    <ZcashLoginFlow />
+                    <ZcashLoginFlow loginDestination={loginDestination} />
                   </div>
                 ) : (
                   <>
@@ -105,11 +108,11 @@ export default function AuthFeature() {
                     </div>
 
                     {/* Alternative — email/username + password (with 2FA) */}
-                    <ClassicLoginForm />
+                    <ClassicLoginForm loginDestination={loginDestination} />
 
                     {/* X / Google / GitHub — renders only for providers the
                         backend reports as configured (none, today) */}
-                    <SocialButtons />
+                    <SocialButtons loginDestination={loginDestination} />
 
                     <div className="flex items-center justify-between">
                       <ZShieldInfo>

--- a/wallet/zuuli/src/features/auth/useZcashLogin.ts
+++ b/wallet/zuuli/src/features/auth/useZcashLogin.ts
@@ -11,6 +11,7 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { auth } from "@/lib/api/free2z";
 import { useSession } from "@/store/session";
+import type { LoginDestination } from "@/lib/auth/login-destination";
 import {
   STEP_ORDER,
   useZcashChallengeFlow,
@@ -49,7 +50,9 @@ export const STEP_META: Record<StepKey, StepMeta> = {
 
 export type ZcashLoginState = ZcashChallengeFlowState;
 
-export function useZcashLogin(): ZcashLoginState {
+export function useZcashLogin(
+  loginDestination: LoginDestination = "/",
+): ZcashLoginState {
   const navigate = useNavigate();
   const setUser = useSession((s) => s.setUser);
 
@@ -69,7 +72,7 @@ export function useZcashLogin(): ZcashLoginState {
         description: "Signed in with your Zcash key.",
       });
       await new Promise((r) => setTimeout(r, 700));
-      navigate("/");
+      navigate(loginDestination, { replace: true });
     },
   });
 }

--- a/wallet/zuuli/src/features/buy/BuyTab.tsx
+++ b/wallet/zuuli/src/features/buy/BuyTab.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from "react";
-import { CreditCard, Check, Loader2, ShieldCheck, Wallet } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import {
+  CreditCard,
+  Check,
+  Loader2,
+  LogIn,
+  ShieldCheck,
+  Wallet,
+} from "lucide-react";
 import { toast } from "sonner";
-import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   Card,
   CardContent,
@@ -43,15 +50,11 @@ import {
   settleZecTopUpDemo,
   type ZecTopUpDemoRuntime,
 } from "./zec-top-up-demo";
-
-/** Open an external URL, falling back to a browser tab outside Tauri. */
-async function open(url: string) {
-  try {
-    await openUrl(url);
-  } catch {
-    window.open(url, "_blank", "noopener,noreferrer");
-  }
-}
+import {
+  cardCheckoutFeedback,
+  openCardCheckout,
+  startCardCheckout,
+} from "./card-checkout";
 
 type QuoteState =
   | { status: "idle" }
@@ -60,6 +63,9 @@ type QuoteState =
   | { status: "error" };
 
 export function BuyTab() {
+  const navigate = useNavigate();
+  const user = useSession((s) => s.user);
+  const sessionLoading = useSession((s) => s.loading);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
   const spendable = useWallet((s) => s.balance?.spendable ?? 0);
   const zecDemoRuntime: ZecTopUpDemoRuntime = {
@@ -129,17 +135,30 @@ export function BuyTab() {
 
   async function payWithCard() {
     if (!valid || amount === null) return;
-    setCardLoading(true);
+    const authenticated = user !== null;
+    if (authenticated) setCardLoading(true);
     try {
-      const { url } = await tuzi.buyCheckout(amount);
+      const result = await startCardCheckout({
+        authenticated,
+        amount,
+        createCheckout: tuzi.buyCheckout,
+        openCheckout: openCardCheckout,
+      });
+      if (result === "sign-in") {
+        navigate("/login", { state: { returnTo: "/buy" } });
+        return;
+      }
       toast.info("Opening secure checkout…", {
         description: "Complete your purchase with Stripe.",
       });
-      await open(url);
-    } catch {
-      toast.error("Could not start checkout. Please try again.");
+    } catch (error) {
+      const feedback = cardCheckoutFeedback(error);
+      toast.error(feedback.title, { description: feedback.description });
+      if (feedback.signIn) {
+        navigate("/login", { state: { returnTo: "/buy" } });
+      }
     } finally {
-      setCardLoading(false);
+      if (authenticated) setCardLoading(false);
     }
   }
 
@@ -267,15 +286,17 @@ export function BuyTab() {
           <Button
             size="lg"
             className="w-full"
-            disabled={!valid || cardLoading}
+            disabled={!valid || cardLoading || sessionLoading}
             onClick={payWithCard}
           >
             {cardLoading ? (
               <Loader2 className="h-4 w-4 animate-spin" />
+            ) : !user ? (
+              <LogIn className="h-4 w-4" />
             ) : (
               <CreditCard className="h-4 w-4" />
             )}
-            Pay with card
+            {user ? "Pay with card" : "Sign in to buy"}
           </Button>
           <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <ShieldCheck className="h-3.5 w-3.5 text-emerald-400" />

--- a/wallet/zuuli/src/features/buy/card-checkout.test.ts
+++ b/wallet/zuuli/src/features/buy/card-checkout.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/lib/api/http";
+import {
+  CheckoutLinkError,
+  stripeCheckoutHosts,
+  validateStripeCheckoutUrl,
+} from "@/lib/api/checkout";
+import {
+  CheckoutOpenError,
+  cardCheckoutFeedback,
+  startCardCheckout,
+} from "./card-checkout";
+
+describe("card checkout authentication boundary", () => {
+  it("routes a signed-out user to sign-in without calling checkout or opener", async () => {
+    const createCheckout = vi.fn();
+    const openCheckout = vi.fn();
+
+    await expect(
+      startCardCheckout({
+        authenticated: false,
+        amount: 2_000,
+        createCheckout,
+        openCheckout,
+      }),
+    ).resolves.toBe("sign-in");
+    expect(createCheckout).not.toHaveBeenCalled();
+    expect(openCheckout).not.toHaveBeenCalled();
+  });
+
+  it("opens the validated backend URL directly for a signed-in user", async () => {
+    const url = "https://checkout.stripe.com/c/pay/cs_test_123?prefilled=true";
+    const openCheckout = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      startCardCheckout({
+        authenticated: true,
+        amount: 2_000,
+        createCheckout: vi.fn().mockResolvedValue({ url }),
+        openCheckout,
+      }),
+    ).resolves.toBe("opened");
+    expect(openCheckout).toHaveBeenCalledOnce();
+    expect(openCheckout).toHaveBeenCalledWith(url);
+  });
+});
+
+describe("Stripe Checkout URL policy", () => {
+  const customHosts = stripeCheckoutHosts("pay.free2z.cash");
+
+  it.each([
+    "https://checkout.stripe.com/c/pay/cs_test_123?key=value",
+    "https://pay.free2z.cash/session/cs_test_123",
+  ])("accepts an exact configured HTTPS host: %s", (url) => {
+    expect(validateStripeCheckoutUrl(url, customHosts)).toBe(url);
+  });
+
+  it.each([
+    ["suffix", "https://checkout.stripe.com.evil.example/session"],
+    ["userinfo", "https://checkout.stripe.com@evil.example/session"],
+    [
+      "userinfo on allowed host",
+      "https://evil.example@checkout.stripe.com/session",
+    ],
+    ["explicit port", "https://checkout.stripe.com:443/session"],
+    ["non-default port", "https://checkout.stripe.com:8443/session"],
+    ["scheme", "http://checkout.stripe.com/session"],
+    ["protocol-relative", "//checkout.stripe.com/session"],
+    ["fragment", "https://checkout.stripe.com/session#redirect"],
+    ["wildcard-like custom host", "https://sub.pay.free2z.cash/session"],
+    ["parser control character", "https://checkout.stripe.com\t/session"],
+  ])("rejects %s tricks", (_name, url) => {
+    expect(() => validateStripeCheckoutUrl(url, customHosts)).toThrow(
+      CheckoutLinkError,
+    );
+  });
+
+  it.each([undefined, null, "", "not a URL", " https://checkout.stripe.com/"])(
+    "rejects a missing or malformed checkout URL: %s",
+    (url) => {
+      expect(() => validateStripeCheckoutUrl(url, customHosts)).toThrow(
+        CheckoutLinkError,
+      );
+    },
+  );
+
+  it("ignores invalid custom-domain configuration", () => {
+    const hosts = stripeCheckoutHosts(
+      "*.example.com,https://pay.example.com,pay.example.com:443,pay.free2z.cash",
+    );
+    expect([...hosts]).toEqual(["checkout.stripe.com", "pay.free2z.cash"]);
+  });
+});
+
+describe("card checkout failure guidance", () => {
+  it.each([401, 403])(
+    "sends an HTTP %i session failure back to sign-in",
+    (status) => {
+      expect(cardCheckoutFeedback(new ApiError(status, "auth"))).toMatchObject({
+        title: "Sign in again",
+        signIn: true,
+      });
+    },
+  );
+
+  it("distinguishes network, server, hostile-link and opener failures", () => {
+    expect(cardCheckoutFeedback(new TypeError("fetch failed")).title).toBe(
+      "Can't reach checkout",
+    );
+    expect(cardCheckoutFeedback(new ApiError(503, "down")).title).toBe(
+      "Checkout unavailable",
+    );
+    expect(
+      cardCheckoutFeedback(new CheckoutLinkError("untrusted-host")).title,
+    ).toBe("Checkout link blocked");
+    expect(cardCheckoutFeedback(new CheckoutOpenError()).title).toBe(
+      "Couldn't open checkout",
+    );
+  });
+});

--- a/wallet/zuuli/src/features/buy/card-checkout.ts
+++ b/wallet/zuuli/src/features/buy/card-checkout.ts
@@ -1,0 +1,132 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { ApiError } from "@/lib/api/http";
+import { CheckoutLinkError } from "@/lib/api/checkout";
+import { isTauri } from "@/lib/platform";
+
+interface CheckoutSession {
+  url: string;
+}
+
+interface StartCardCheckoutOptions {
+  authenticated: boolean;
+  amount: number;
+  createCheckout: (amount: number) => Promise<CheckoutSession>;
+  openCheckout: (url: string) => Promise<void>;
+}
+
+export type CardCheckoutResult = "sign-in" | "opened";
+
+export class CheckoutOpenError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause?: unknown) {
+    super("The secure checkout page could not be opened.");
+    this.name = "CheckoutOpenError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * Keep the authentication boundary outside the protected request. Returning a
+ * value instead of navigating here makes the no-request behavior easy to prove.
+ */
+export async function startCardCheckout({
+  authenticated,
+  amount,
+  createCheckout,
+  openCheckout,
+}: StartCardCheckoutOptions): Promise<CardCheckoutResult> {
+  if (!authenticated) return "sign-in";
+  const { url } = await createCheckout(amount);
+  try {
+    await openCheckout(url);
+  } catch (cause) {
+    throw new CheckoutOpenError(cause);
+  }
+  return "opened";
+}
+
+/** Open validated Checkout in the OS browser for Tauri, or navigate on web. */
+export async function openCardCheckout(url: string): Promise<void> {
+  if (isTauri()) {
+    await openUrl(url);
+    return;
+  }
+  // A same-tab navigation is not popup-blocked after the awaited API request,
+  // and Stripe returns the web client to the server-controlled currentPath.
+  window.location.assign(url);
+}
+
+export interface CardCheckoutFeedback {
+  title: string;
+  description: string;
+  signIn: boolean;
+}
+
+/** Map technical failure classes to short, distinct recovery instructions. */
+export function cardCheckoutFeedback(error: unknown): CardCheckoutFeedback {
+  if (
+    error instanceof ApiError &&
+    (error.status === 401 || error.status === 403)
+  ) {
+    return {
+      title: "Sign in again",
+      description: "Your session expired. Sign in, then retry your purchase.",
+      signIn: true,
+    };
+  }
+  if (
+    error instanceof ApiError &&
+    (error.status === 400 || error.status === 422)
+  ) {
+    return {
+      title: "Check the amount",
+      description: "Choose a valid amount, then try again.",
+      signIn: false,
+    };
+  }
+  if (error instanceof ApiError && error.status === 429) {
+    return {
+      title: "Too many attempts",
+      description: "Wait a moment before trying checkout again.",
+      signIn: false,
+    };
+  }
+  if (error instanceof ApiError && error.status >= 500) {
+    return {
+      title: "Checkout unavailable",
+      description:
+        "The payment service is temporarily unavailable. Try again shortly.",
+      signIn: false,
+    };
+  }
+  if (error instanceof CheckoutLinkError) {
+    const blocked = error.reason === "untrusted-host";
+    return {
+      title: blocked ? "Checkout link blocked" : "Checkout unavailable",
+      description: blocked
+        ? "The payment link was not an approved Stripe Checkout address."
+        : "The payment service returned an invalid checkout link. Try again shortly.",
+      signIn: false,
+    };
+  }
+  if (error instanceof CheckoutOpenError) {
+    return {
+      title: "Couldn't open checkout",
+      description: "Allow ZUULI to open external links, then try again.",
+      signIn: false,
+    };
+  }
+  if (error instanceof TypeError) {
+    return {
+      title: "Can't reach checkout",
+      description: "Check your connection, then try again.",
+      signIn: false,
+    };
+  }
+  return {
+    title: "Checkout failed",
+    description: "Try again. If this keeps happening, contact support.",
+    signIn: false,
+  };
+}

--- a/wallet/zuuli/src/lib/api/checkout.ts
+++ b/wallet/zuuli/src/lib/api/checkout.ts
@@ -1,0 +1,77 @@
+import { STRIPE_CHECKOUT_CUSTOM_HOSTS } from "../env";
+
+const DEFAULT_STRIPE_CHECKOUT_HOST = "checkout.stripe.com";
+const DNS_NAME =
+  /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export type CheckoutLinkFailure =
+  | "missing"
+  | "malformed"
+  | "insecure"
+  | "credentials"
+  | "port"
+  | "untrusted-host";
+
+export class CheckoutLinkError extends Error {
+  constructor(public readonly reason: CheckoutLinkFailure) {
+    super(`Stripe Checkout URL rejected: ${reason}`);
+    this.name = "CheckoutLinkError";
+  }
+}
+
+/**
+ * Build the exact-host allowlist. Invalid custom entries are ignored instead
+ * of widening trust through a wildcard, URL, path, userinfo or port.
+ */
+export function stripeCheckoutHosts(config: string): ReadonlySet<string> {
+  const hosts = new Set([DEFAULT_STRIPE_CHECKOUT_HOST]);
+  for (const entry of config.split(",")) {
+    const host = entry.trim().toLowerCase();
+    if (DNS_NAME.test(host)) hosts.add(host);
+  }
+  return hosts;
+}
+
+export const ALLOWED_STRIPE_CHECKOUT_HOSTS = stripeCheckoutHosts(
+  STRIPE_CHECKOUT_CUSTOM_HOSTS,
+);
+
+/**
+ * Validate a backend-provided hosted Checkout URL before handing it to the OS.
+ * Matching is an exact normalized hostname comparison; suffixes, credentials,
+ * explicit ports, fragments and non-HTTPS schemes are rejected.
+ */
+export function validateStripeCheckoutUrl(
+  value: unknown,
+  allowedHosts: ReadonlySet<string> = ALLOWED_STRIPE_CHECKOUT_HOSTS,
+): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new CheckoutLinkError("missing");
+  }
+  if (value !== value.trim()) throw new CheckoutLinkError("malformed");
+
+  // Inspect the raw authority as well as URL's parsed fields. URL normalizes
+  // `:443` away, so parsed `url.port` alone cannot enforce the no-port policy.
+  const authority = /^https:\/\/([^/?#]+)/i.exec(value)?.[1];
+  if (!authority) throw new CheckoutLinkError("insecure");
+  if (authority.includes("@")) throw new CheckoutLinkError("credentials");
+  if (authority.includes(":")) throw new CheckoutLinkError("port");
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new CheckoutLinkError("malformed");
+  }
+  if (url.protocol !== "https:") throw new CheckoutLinkError("insecure");
+  if (url.username || url.password) throw new CheckoutLinkError("credentials");
+  if (url.port) throw new CheckoutLinkError("port");
+  if (url.hash) throw new CheckoutLinkError("malformed");
+  if (authority.toLowerCase() !== url.hostname.toLowerCase()) {
+    throw new CheckoutLinkError("malformed");
+  }
+  if (!allowedHosts.has(url.hostname.toLowerCase())) {
+    throw new CheckoutLinkError("untrusted-host");
+  }
+  return value;
+}

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -93,6 +93,7 @@ import type {
   SubscriptionStatus,
   TuziTransaction,
 } from "./types";
+import { validateStripeCheckoutUrl } from "./checkout";
 
 const delay = (ms = 260) => new Promise((r) => setTimeout(r, ms));
 
@@ -1479,24 +1480,24 @@ export const tuzi = {
 
   /**
    * Start a Stripe checkout to buy `tuzis` 2Zs and return the hosted checkout
-   * URL to open. The backend must return the session `url` (a one-line add to
-   * ztripe's create_checkout_session, which today returns only the session id).
+   * URL to open. The returned URL is treated as untrusted input even though the
+   * backend validates it too: only the configured exact Stripe host may leave
+   * the app.
    */
   async buyCheckout(tuzis: number): Promise<{ url: string }> {
     if (useMock()) {
       await delay(400);
-      return { url: `https://checkout.stripe.com/mock?q=${tuzis}` };
+      return {
+        url: validateStripeCheckoutUrl(
+          `https://checkout.stripe.com/mock?q=${tuzis}`,
+        ),
+      };
     }
-    const r = await request<{ id: string; url?: string }>(
+    const r = await request<{ id?: unknown; url?: unknown }>(
       "/api/stripe/create-checkout-session/",
       { method: "POST", body: { quantity: tuzis, currentPath: "/buy" } },
     );
-    if (!r.url) {
-      throw new Error(
-        "Checkout URL unavailable — have the backend return session.url from create_checkout_session.",
-      );
-    }
-    return { url: r.url };
+    return { url: validateStripeCheckoutUrl(r?.url) };
   },
 
   async donate(username: string, tuzis: number): Promise<void> {

--- a/wallet/zuuli/src/lib/auth/login-destination.test.ts
+++ b/wallet/zuuli/src/lib/auth/login-destination.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  consumePendingSocialLoginDestination,
+  loginDestinationFromState,
+  rememberPendingSocialLoginDestination,
+} from "./login-destination";
+
+class MemoryStorage {
+  private readonly entries = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.entries.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.entries.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.entries.delete(key);
+  }
+}
+
+describe("post-login destination", () => {
+  it("accepts only the exact Buy route", () => {
+    expect(loginDestinationFromState({ returnTo: "/buy" })).toBe("/buy");
+  });
+
+  it.each([
+    undefined,
+    null,
+    {},
+    { returnTo: "/" },
+    { returnTo: "https://evil.example/buy" },
+    { returnTo: "//evil.example/buy" },
+    { returnTo: "/buy?next=https://evil.example" },
+    { returnTo: "/buy#checkout" },
+    { returnTo: "%2Fbuy" },
+    { returnTo: "/%62uy" },
+    { returnTo: { pathname: "/buy" } },
+  ])("falls back home for absent, hostile, or encoded state: %j", (state) => {
+    expect(loginDestinationFromState(state)).toBe("/");
+  });
+
+  it("fails closed when hostile state throws during inspection", () => {
+    const state = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("hostile getter");
+        },
+      },
+    );
+    expect(loginDestinationFromState(state)).toBe("/");
+  });
+
+  it("round-trips an allowlisted mobile social-login destination once", () => {
+    const storage = new MemoryStorage();
+    rememberPendingSocialLoginDestination("/buy", storage);
+    expect(consumePendingSocialLoginDestination(storage)).toBe("/buy");
+    expect(consumePendingSocialLoginDestination(storage)).toBe("/");
+  });
+
+  it("does not persist the default destination", () => {
+    const storage = new MemoryStorage();
+    rememberPendingSocialLoginDestination("/buy", storage);
+    rememberPendingSocialLoginDestination("/", storage);
+    expect(consumePendingSocialLoginDestination(storage)).toBe("/");
+  });
+
+  it("revalidates tampered persisted state", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      "zuuli.auth.pending-social-login-destination",
+      "https://evil.example/buy",
+    );
+    expect(consumePendingSocialLoginDestination(storage)).toBe("/");
+  });
+});

--- a/wallet/zuuli/src/lib/auth/login-destination.ts
+++ b/wallet/zuuli/src/lib/auth/login-destination.ts
@@ -1,0 +1,80 @@
+export type LoginDestination = "/" | "/buy";
+
+export const DEFAULT_LOGIN_DESTINATION: LoginDestination = "/";
+
+const PENDING_SOCIAL_LOGIN_DESTINATION =
+  "zuuli.auth.pending-social-login-destination";
+
+type DestinationStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/**
+ * Resolve history state through a deliberately tiny allowlist. This must never
+ * become a generic internal-URL redirect: login currently needs only `/buy`.
+ */
+export function loginDestinationFromState(state: unknown): LoginDestination {
+  try {
+    if (
+      typeof state === "object" &&
+      state !== null &&
+      (state as { returnTo?: unknown }).returnTo === "/buy"
+    ) {
+      return "/buy";
+    }
+  } catch {
+    // Treat proxies/getters like any other malformed navigation state.
+  }
+  return DEFAULT_LOGIN_DESTINATION;
+}
+
+function localDestinationStorage(): DestinationStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Preserve the allowlisted destination if mobile OAuth cold-starts the app.
+ * The value is revalidated when consumed; `/` needs no persistence.
+ */
+export function rememberPendingSocialLoginDestination(
+  destination: LoginDestination,
+  storage: DestinationStorage | null = localDestinationStorage(),
+): void {
+  if (!storage) return;
+  try {
+    if (destination === "/buy") {
+      storage.setItem(PENDING_SOCIAL_LOGIN_DESTINATION, destination);
+    } else {
+      storage.removeItem(PENDING_SOCIAL_LOGIN_DESTINATION);
+    }
+  } catch {
+    // Restricted storage must not prevent login.
+  }
+}
+
+export function consumePendingSocialLoginDestination(
+  storage: DestinationStorage | null = localDestinationStorage(),
+): LoginDestination {
+  if (!storage) return DEFAULT_LOGIN_DESTINATION;
+  let stored: unknown;
+  try {
+    stored = storage.getItem(PENDING_SOCIAL_LOGIN_DESTINATION);
+    storage.removeItem(PENDING_SOCIAL_LOGIN_DESTINATION);
+  } catch {
+    return DEFAULT_LOGIN_DESTINATION;
+  }
+  return loginDestinationFromState({ returnTo: stored });
+}
+
+export function clearPendingSocialLoginDestination(
+  storage: DestinationStorage | null = localDestinationStorage(),
+): void {
+  try {
+    storage?.removeItem(PENDING_SOCIAL_LOGIN_DESTINATION);
+  } catch {
+    // Restricted storage must not prevent login cleanup.
+  }
+}

--- a/wallet/zuuli/src/lib/env.ts
+++ b/wallet/zuuli/src/lib/env.ts
@@ -46,6 +46,16 @@ export const MOCK_OTP = readEnv("VITE_MOCK_OTP", "") === "1";
 /** Dyte SDK base — used to construct join URLs for livestreams. */
 export const DYTE_BASE = readEnv("VITE_DYTE_BASE", "https://app.dyte.io");
 
+/**
+ * Extra exact DNS names that may host Stripe Checkout, separated by commas.
+ * `checkout.stripe.com` is always allowed. Add only a Stripe Custom Domain
+ * configured for this account; schemes, paths, ports and wildcards are invalid.
+ */
+export const STRIPE_CHECKOUT_CUSTOM_HOSTS = readEnv(
+  "VITE_STRIPE_CHECKOUT_HOSTS",
+  "",
+);
+
 export const APP_NAME = "ZUULI";
 export const APP_TAGLINE = "Your Z. Your keys. Your universe.";
 export const COMPANY = "2Z Inc";

--- a/wallet/zuuli/tests/viewport.pw.ts
+++ b/wallet/zuuli/tests/viewport.pw.ts
@@ -207,3 +207,25 @@ for (const signedIn of [false, true]) {
     });
   }
 }
+
+test("signed-out card checkout returns to Buy after login at 320px", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 568 });
+  await setSession(page, false);
+  await page.goto("/buy");
+  await page.locator("[data-app-frame]").waitFor();
+
+  await page.getByRole("button", { name: "Sign in to buy" }).click();
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByText("Sign in to ZUULI", { exact: true })).toBeVisible();
+  expect((await auditHorizontalLayout(page)).failures).toEqual([]);
+
+  await page.getByLabel("Email or username").fill("checkout-return");
+  await page.getByLabel("Password").fill("mock-password");
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+
+  await expect(page).toHaveURL(/\/buy$/);
+  await expect(page.getByRole("button", { name: "Pay with card" })).toBeVisible();
+  expect((await auditHorizontalLayout(page)).failures).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- gate card checkout on the validated ZUULI session, showing a concise Sign in to buy action; successful classic, Zcash, and social login returns to Buy
- accept only the exact internal `/buy` post-login destination and default every absent, external, protocol-relative, query, fragment, encoded, object, throwing, or tampered value to `/`
- preserve that allowlisted destination across mobile social-OAuth cold starts without accepting arbitrary history or persisted state
- validate the backend hosted URL against HTTPS plus an exact hostname allowlist before opening it; `checkout.stripe.com` is always allowed and documented Stripe Custom Domains can be configured explicitly
- open packaged-app checkout through the Tauri OS opener, navigate directly on web, and distinguish authentication, transport, server, malformed/untrusted-link, and opener failures
- preserve the narrow-layout fixes from #397 and add a 320 × 568 Playwright flow covering signed-out Buy → login → authenticated return to Buy

## Verification

- `npx vitest run src/lib/auth/login-destination.test.ts src/features/buy/card-checkout.test.ts` — 39 passed
- `npm test` — 236 Vitest tests, 5 safe-area contract tests, and 9 Playwright viewport tests passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- semantic rebase onto `5943e7ad` (#397); lease-pushed from verified prior PR head `e61159a0`

## Adversarial review

The URL boundary uses exact normalized host equality and rejects suffixes, credentials, explicit ports (including `:443`), fragments, non-HTTPS schemes, whitespace, parser-control input, and malformed authorities. Login state accepts only the literal `/buy`; hostile, encoded, throwing, and tampered values resolve to home. The rebase did not reverse #397 layout changes.

Earlier reviews caught and fixed a browser false-failure from `window.open(..., noopener)` and a dead return contract where login methods ignored `returnTo`.

## Remaining backend/release dependencies

This advances #388 but does not close it and is not end-to-end Stripe completion:

- free2z/tuzi#1258 must provide the validated hosted Checkout URL contract consumed here.
- free2z/tuzi#1257 must provide server-controlled native success/cancel return and authoritative balance refresh.
- free2z/tuzi#1253 must provide authoritative exact-price, verified fulfillment, and exact-credit integrity.

Signed staging and store-build verification remain after those dependencies land.
