### PR TITLE
Simplify the anonymous mobile header

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -83,7 +83,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.zuuli == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Retain bounded time for the mandatory viewport suite and production build,
+    # including occasional hosted-runner provisioning delays.
+    timeout-minutes: 35
     defaults:
       run:
         working-directory: wallet/zuuli
@@ -119,8 +121,10 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Install the viewport-test browser
-        run: npx playwright install --with-deps chromium
+      # GitHub's Ubuntu runner image includes stable Google Chrome. Using it in
+      # CI avoids an apt-mirror dependency while preserving real browser tests.
+      - name: Verify the viewport-test browser
+        run: google-chrome --version
 
       - name: Test frontend contracts
         run: npm run test

--- a/wallet/zuuli/playwright.config.ts
+++ b/wallet/zuuli/playwright.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   use: {
     baseURL: `http://127.0.0.1:${port}`,
     browserName: "chromium",
+    channel: process.env.CI ? "chrome" : undefined,
     colorScheme: "dark",
     trace: "retain-on-failure",
   },

--- a/wallet/zuuli/src/components/layout/TopBar.signed-in.test.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.signed-in.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TopBar } from "./TopBar";
+
+vi.mock("@/store/session", () => ({
+  useSession: () => ({
+    user: {
+      username: "skyl",
+      display_name: "Skylar",
+      image: null,
+    },
+    tuzis: 4210,
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock("@/store/wallet", () => ({
+  useWallet: (selector: (state: { balance: null }) => unknown) =>
+    selector({ balance: null }),
+}));
+
+describe("TopBar signed-in account chrome", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps money controls while rendering unknown ZEC as an em dash", () => {
+    vi.stubGlobal("window", { history: { state: { idx: 0 } } });
+
+    const markup = renderToStaticMarkup(
+      <MemoryRouter initialEntries={["/"]}>
+        <TooltipProvider>
+          <TopBar />
+        </TooltipProvider>
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain('href="/wallet"');
+    expect(markup).toContain('aria-label="Open wallet"');
+    expect(markup).toContain(">—</span>");
+    expect(markup).toContain(">ZEC</span>");
+    expect(markup).not.toContain("0.00");
+    expect(markup).toContain('href="/buy"');
+    expect(markup).toContain('aria-label="Buy 2Zs. Balance 4,210 2Z"');
+    expect(markup).toContain('aria-label="Account menu"');
+    expect(markup).not.toContain('aria-label="Log in"');
+  });
+});

--- a/wallet/zuuli/src/components/layout/TopBar.test.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.test.tsx
@@ -1,0 +1,48 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useSession } from "@/store/session";
+import { useWallet } from "@/store/wallet";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TopBar } from "./TopBar";
+
+function renderTopBar({ pushed = false } = {}) {
+  vi.stubGlobal("window", {
+    history: { state: { idx: pushed ? 1 : 0 } },
+  });
+
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={[pushed ? "/buy" : "/"]}>
+      <TooltipProvider>
+        <TopBar />
+      </TooltipProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("TopBar account chrome", () => {
+  beforeEach(() => {
+    useSession.setState({ user: null, tuzis: 0, loading: false });
+    useWallet.setState({ balance: null, loading: false });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    ["root", false],
+    ["pushed route", true],
+  ])("shows no invented anonymous money state on the %s", (_name, pushed) => {
+    const markup = renderTopBar({ pushed });
+
+    expect(markup).toContain('aria-label="Log in"');
+    expect(markup).not.toContain("Login with Zcash");
+    expect(markup).not.toContain("0 2Z");
+    expect(markup).not.toContain("0.00");
+    expect(markup).not.toContain('href="/buy"');
+    expect(markup).not.toContain('href="/wallet"');
+    expect(markup).toContain('aria-label="Search"');
+    expect(markup.includes('aria-label="Go back"')).toBe(pushed);
+  });
+});

--- a/wallet/zuuli/src/components/layout/TopBar.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.tsx
@@ -3,16 +3,21 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   ArrowLeft,
   Coins,
+  LogIn,
   Plus,
   Wallet as WalletIcon,
   LogOut,
   ShieldCheck,
-  User,
   UserCog,
   Search,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   Avatar,
   AvatarFallback,
@@ -50,7 +55,7 @@ export function TopBar() {
 
   return (
     <header
-      className="app-top-bar sticky top-0 z-30 flex shrink-0 items-center gap-3 border-b border-border bg-background/80 px-4 backdrop-blur"
+      className="app-top-bar sticky top-0 z-30 flex shrink-0 items-center gap-2 border-b border-border bg-background/80 px-3 backdrop-blur sm:gap-3 sm:px-4"
       data-app-top-bar
     >
       {/* Global back — available on every screen inside the shell */}
@@ -102,28 +107,34 @@ export function TopBar() {
       <div className="flex-1" />
 
       {/* ZEC wallet chip */}
-      <Link
-        to="/wallet"
-        className="hidden items-center gap-2 rounded-full border border-border bg-card/60 px-3 py-1.5 text-sm transition-colors hover:bg-secondary sm:flex"
-        aria-label="Open wallet"
-      >
-        <WalletIcon className="h-4 w-4 text-[#f4b728]" />
-        <span className="font-medium tabular-nums">
-          {balance ? formatZecTrim(balance.spendable) : "0.00"}
-        </span>
-        <span className="text-xs text-muted-foreground">ZEC</span>
-      </Link>
+      {user ? (
+        <Link
+          to="/wallet"
+          className="hidden items-center gap-2 rounded-full border border-border bg-card/60 px-3 py-1.5 text-sm transition-colors hover:bg-secondary sm:flex"
+          aria-label="Open wallet"
+        >
+          <WalletIcon className="h-4 w-4 text-[#f4b728]" />
+          <span className="font-medium tabular-nums">
+            {balance ? formatZecTrim(balance.spendable) : "—"}
+          </span>
+          <span className="text-xs text-muted-foreground">ZEC</span>
+        </Link>
+      ) : null}
 
       {/* 2Z balance chip */}
-      <Link
-        to="/buy"
-        className="flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1.5 text-sm transition-colors hover:bg-primary/20"
-        aria-label="Buy 2Zs"
-      >
-        <Coins className="h-4 w-4 text-primary" />
-        <span className="font-semibold tabular-nums">{formatTuzis(tuzis)}</span>
-        <Plus className="h-3.5 w-3.5 text-primary" />
-      </Link>
+      {user ? (
+        <Link
+          to="/buy"
+          className="flex min-h-11 min-w-0 items-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 px-2.5 text-sm transition-colors hover:bg-primary/20 sm:gap-2 sm:px-3"
+          aria-label={`Buy 2Zs. Balance ${formatTuzis(tuzis)}`}
+        >
+          <Coins className="h-4 w-4 shrink-0 text-primary" />
+          <span className="whitespace-nowrap font-semibold tabular-nums">
+            {formatTuzis(tuzis)}
+          </span>
+          <Plus className="hidden h-3.5 w-3.5 shrink-0 text-primary min-[360px]:block" />
+        </Link>
+      ) : null}
 
       {user ? (
         <DropdownMenu>
@@ -170,9 +181,20 @@ export function TopBar() {
           </DropdownMenuContent>
         </DropdownMenu>
       ) : (
-        <Button size="sm" onClick={() => navigate("/login")}>
-          <User className="h-4 w-4" /> Login with Zcash
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="min-tap shrink-0 rounded-full"
+              onClick={() => navigate("/login")}
+              aria-label="Log in"
+            >
+              <LogIn className="h-5 w-5" aria-hidden />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Log in</TooltipContent>
+        </Tooltip>
       )}
     </header>
   );

--- a/wallet/zuuli/tests/viewport.pw.ts
+++ b/wallet/zuuli/tests/viewport.pw.ts
@@ -37,6 +37,93 @@ async function setSession(page: Page, signedIn: boolean) {
   }, signedIn);
 }
 
+async function assertMobileHeader(page: Page, signedIn: boolean) {
+  const header = page.locator("[data-app-top-bar]");
+  await expect(header).toBeVisible();
+
+  if (signedIn) {
+    await expect(
+      header.getByRole("button", { name: "Account menu" }),
+    ).toBeVisible();
+    await expect(
+      header.getByRole("link", { name: /Buy 2Zs\. Balance/ }),
+    ).toBeVisible();
+    await expect(
+      header.getByRole("button", { name: "Log in", exact: true }),
+    ).toHaveCount(0);
+  } else {
+    const login = header.getByRole("button", { name: "Log in", exact: true });
+    await expect(login).toBeVisible();
+    await expect(login).toHaveText("");
+    await expect(header.getByRole("link", { name: /Buy 2Zs/ })).toHaveCount(0);
+    await expect(header.getByRole("link", { name: "Open wallet" })).toHaveCount(0);
+    await expect(header).not.toContainText("2Z");
+    await expect(header).not.toContainText("ZEC");
+
+    const loginBox = await login.boundingBox();
+    expect(loginBox, "anonymous Log in target must have a layout box").not.toBeNull();
+    expect(
+      loginBox!.width,
+      "anonymous Log in target must be at least 44px wide",
+    ).toBeGreaterThanOrEqual(44);
+    expect(
+      loginBox!.height,
+      "anonymous Log in target must be at least 44px high",
+    ).toBeGreaterThanOrEqual(44);
+  }
+
+  const metrics = await header.evaluate((element) => {
+    const headerRect = element.getBoundingClientRect();
+    const controls = [...element.querySelectorAll<HTMLElement>("a, button")]
+      .map((control) => {
+        const rect = control.getBoundingClientRect();
+        return {
+          height: rect.height,
+          label:
+            (control.getAttribute("aria-label") ?? control.innerText.trim()) ||
+            control.tagName.toLowerCase(),
+          top: rect.top,
+          bottom: rect.bottom,
+          width: rect.width,
+        };
+      })
+      .filter(({ height }) => height > 0);
+    return {
+      clientWidth: element.clientWidth,
+      height: headerRect.height,
+      scrollWidth: element.scrollWidth,
+      controlCenters: controls.map(({ top, bottom }) => (top + bottom) / 2),
+      undersizedControls: controls
+        .filter(({ height, width }) => height < 44 || width < 44)
+        .map(({ height, label, width }) => `${label}: ${width}x${height}`),
+      controlsInside: controls.every(
+        ({ top, bottom }) =>
+          top >= headerRect.top - 1 && bottom <= headerRect.bottom + 1,
+      ),
+    };
+  });
+
+  expect(
+    metrics.scrollWidth,
+    "mobile header must not scroll horizontally",
+  ).toBeLessThanOrEqual(metrics.clientWidth);
+  expect(metrics.height, "mobile header must retain its 56px chrome row").toBe(
+    56,
+  );
+  expect(
+    metrics.controlsInside,
+    "mobile header controls must stay inside the chrome row",
+  ).toBe(true);
+  expect(
+    metrics.undersizedControls,
+    "mobile header controls must retain 44px touch targets",
+  ).toEqual([]);
+  expect(
+    Math.max(...metrics.controlCenters) - Math.min(...metrics.controlCenters),
+    "mobile header controls must remain on one row",
+  ).toBeLessThanOrEqual(1);
+}
+
 async function auditHorizontalLayout(page: Page): Promise<HorizontalAudit> {
   return page.evaluate(() => {
     const genericContent = document.querySelector<HTMLElement>(
@@ -169,6 +256,28 @@ for (const signedIn of [false, true]) {
     }) => {
       await page.setViewportSize({ width, height: 760 });
       await setSession(page, signedIn);
+
+      if (width === 320) {
+        await page.goto("/");
+        await page.locator("[data-app-frame]").waitFor();
+        await assertMobileHeader(page, signedIn);
+
+        await page
+          .locator("[data-app-top-bar]")
+          .getByRole("link", { name: "Search", exact: true })
+          .click();
+        await expect(page).toHaveURL(/\/search$/);
+        await assertMobileHeader(page, signedIn);
+
+        if (signedIn) {
+          await page.setViewportSize({ width: 640, height: 760 });
+          const wallet = page.getByRole("link", { name: "Open wallet" });
+          await expect(wallet).toBeVisible();
+          await expect(wallet).toContainText("ZEC");
+          await expect(wallet).not.toContainText("0.00");
+          await page.setViewportSize({ width, height: 760 });
+        }
+      }
 
       for (const route of ROUTES) {
         await page.goto(route);


### PR DESCRIPTION
Closes #390

## What changed

- hide anonymous 2Z, ZEC, and buy/top-up chrome instead of inventing zero balances
- replace the method-specific `Login with Zcash` label with a generic icon-only `Log in` control, accessible name, tooltip, and 44 px touch target
- keep authenticated 2Z/account controls, show unknown authenticated ZEC as an em dash, and tighten narrow-screen spacing without shrinking targets
- extend the #397 route viewport matrix with explicit 320 px root and real pushed-route header contracts in signed-out and mock signed-in states
- run the CI viewport suite against the Ubuntu runner's preinstalled stable Google Chrome, fail loudly if it is absent, and retain the bounded 35-minute frontend job without depending on an apt mirror

## 320 px evidence

The browser regression now measures both `/` and an in-app navigation to `/search` (which adds the Back control) in both auth states. It asserts:

- anonymous chrome contains no `2Z`, `ZEC`, wallet link, or buy/top-up link
- the anonymous login control has no visible label, retains the accessible name `Log in`, and measures at least 44×44 px
- every visible header link/button remains at least 44×44 px
- header `scrollWidth <= clientWidth`, all controls remain inside the 56 px chrome row, and their vertical centers remain on one row
- signed-in account and authoritative 2Z controls remain visible; the desktop wallet control remains present; unknown ZEC has dedicated em-dash coverage

## Verification

- focused: `npx vitest run src/components/layout/TopBar.test.tsx src/components/layout/TopBar.signed-in.test.tsx` — 3 passed
- focused: `npx playwright test tests/viewport.pw.ts -g '320px'` — 3 passed, including #400's signed-out checkout return test
- CI browser path: `CI=1 npx playwright test tests/viewport.pw.ts --grep '320px'` — 3 passed against Google Chrome 151
- exact CI browser matrix: `CI=1 npm run test:viewport` — all 9 tests passed against Google Chrome 151
- exact `npm test` — 239 Vitest tests, 5 safe-area contract tests, and 9 Playwright tests passed
- `npm run typecheck` — passed
- `npm run build` — passed (existing chunk-size advisory only)
- `git diff --check origin/main...HEAD` — passed
- `actionlint .github/workflows/zuuli.yml` and Ruby YAML parse — passed

## Rebase and adversarial review

- rebased onto `origin/main` `702b369909ed4f8324774c907c1486584bdfd64f` after #397 and #400 merged
- preserved #397's two-worker, 320/360/390/414, signed-out/signed-in route fit matrix without exemptions
- preserved #400's `/buy` login return and checkout behavior; its 320 px Playwright regression passes on this final tree
- corrected an initial false signed-in SSR proof caused by Zustand's immutable server snapshot by moving that state behind a controlled store mock
- scoped ambiguous Search and account locators to the top bar and added explicit bounds, one-row, overflow, and touch-target checks
- final diff review found no remaining correctness or accessibility issue in scope
- three fresh frontend runners spent 15, 25, and 35 minutes solely in `playwright install --with-deps chromium`; the final run never reached tests or build, while independent Rust/package jobs were simultaneously stuck in apt
- downloading Playwright Chromium without `--with-deps` is not a safe substitute: a pristine Ubuntu 24.04 proof downloaded the browser but failed launch with 20+ missing runtime libraries
- GitHub's official Ubuntu 24.04 image inventory includes Google Chrome and Chromium, and Playwright officially supports the branded `chrome` channel; CI now verifies `google-chrome --version` and uses that channel, eliminating both the browser download and apt install while retaining every assertion
- tradeoff: the runner's stable Chrome updates with the weekly hosted image rather than being Playwright-revision-pinned; this is explicit and fail-loud, and is preferable for this user-facing viewport contract to a large pinned container image
