### PR TITLE
fix(rust): update h2 across wallet lockfiles

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/Cargo.lock
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.lock
@@ -1848,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/wallet/zuuallet/src-tauri/Cargo.lock
+++ b/wallet/zuuallet/src-tauri/Cargo.lock
@@ -1862,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/wallet/zuuli/src-tauri/Cargo.lock
+++ b/wallet/zuuli/src-tauri/Cargo.lock
@@ -2066,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Closes #398.

## Summary

- update `h2` to patched `0.4.16` in all three wallet lockfiles
- retain a single `h2` copy in each graph
- preserve the repo-wide `rusqlite 0.37.0` / `libsqlite3-sys 0.35.0` singletons
- limit the lockfile diff to `h2` version and checksum only (6 additions, 6 deletions)

## Verification

- `scripts/check-rust-toolchain.sh` and `scripts/check-rust-toolchain.sh --self-test`
- `scripts/check-rust-fmt.sh`
- `scripts/check-rust-deny.sh advisories` (RUSTSEC-2026-0258 clear in all three graphs; only existing `spin 0.9.8` yanked/stale-ignore warnings)
- `scripts/check-rust-clippy.sh`
- pinned `cargo +1.97.1 metadata --locked` for all three manifests
- pinned `cargo +1.97.1 tree --locked -i h2`, `-i rusqlite`, and `-i libsqlite3-sys` for all three manifests
- `cargo +1.97.1 test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml` (94 passed)
- `cargo +1.97.1 build --locked --manifest-path wallet/zuuli/src-tauri/Cargo.toml`
- `cargo +1.97.1 test --locked --manifest-path wallet/zuuli/src-tauri/Cargo.toml` (12 passed)
- `cargo +1.97.1 build --locked --manifest-path wallet/zuuallet/src-tauri/Cargo.toml`

## Clean Linux proofs

All builds used Ubuntu 24.04 amd64, the CI Tauri system packages, pinned Rust 1.97.1, an initially empty Cargo registry/target, and `--locked`:

- shared plugin: passed
- ZUULI backend: passed
- Zuuallet backend: passed in a separate fresh container

Tauri regenerated platform schema files during the writable builds; those generated changes were restored exactly and are not part of this PR.
