### PR TITLE
docs(zuuli): ground product status in production evidence

### DIFF
--- a/wallet/zuuli/CLAUDE.md
+++ b/wallet/zuuli/CLAUDE.md
@@ -1,9 +1,9 @@
 # ZUULI — Agent instructions
 
-**ZUULI, by 2Z Inc**, is the flagship Zcash-native app: a cutting-edge Zcash
-wallet fused with the free2z platform — AI (multi-provider, metered in 2Zs),
-livestreaming (broadcast / subscriber / PPV / private), articles, and a 2Z
-credit economy — with **Login with Zcash** (no password, no email, no KYC).
+**ZUULI, by 2Z Inc**, is the flagship Zcash-native app: a native Zcash wallet
+combined with free2z AI, livestreaming, articles, profile/KYC, and 2Z-credit
+surfaces. Implemented UI or source wiring is not itself production evidence;
+the per-surface status and release blockers live in [`STATUS.md`](STATUS.md).
 
 It is distinct from **`../zuuallet`**, the whitelabel *reference* wallet. Both
 apps share the Zcash engine in `../plugins/tauri-plugin-zcash` (the "guts").
@@ -21,8 +21,9 @@ cd wallet/zuuli
 npm install
 npm run typecheck          # tsc --noEmit
 npm run build              # tsc && vite build
-npm run dev                # vite dev server on :1423 (browser = mock mode)
-npm run tauri dev          # full desktop app (real wallet)
+VITE_MOCK=1 npm run dev    # browser fixtures on :1423 (UI/demo only)
+npm run dev                # real staging API on :1423; no native wallet
+npm run tauri dev          # native wallet + staging API by default
 npm run tauri -- ios dev   # iOS simulator/device through Xcode
 npm run tauri -- ios build # unsigned/signing-configured iOS archive as applicable
 npm run tauri -- android dev
@@ -75,19 +76,26 @@ never merge two identity directories or add an insecure mobile import path.
 - @tauri-apps/api 2 (IPC), Tauri v2 backend
 - react-markdown (articles + AI), qrcode.react, sonner (toasts), lucide-react
 
-## Two runtime modes — the key architectural idea
+## Runtime selection — two independent boundaries
 
-Every data path has a real implementation AND a mock fallback, chosen at
-runtime by `src/lib/platform.ts`:
+The API and wallet contracts have real implementations plus fixture fallbacks,
+but a plain browser is **not** itself the mock-mode switch:
 
-- **Tauri desktop/mobile** (`isTauri()`): the wallet bridge calls the real
-  `tauri-plugin-zcash` commands (librustzcash); the API layer hits the real
-  free2z backend.
-- **Plain browser / `VITE_MOCK=1`**: realistic fixtures (`src/lib/api/mock-data.ts`,
-  `src/lib/wallet/mock.ts`) so the whole UI runs, demos, and screenshots with
-  no backend and no chain sync.
+- **`VITE_MOCK=1`:** normal API and wallet calls select fixtures from
+  `src/lib/api/mock-data.ts` and `src/lib/wallet/mock.ts`. This is UI/demo
+  evidence only, not a network-isolation guarantee: a native profile can retain
+  one-shot OAuth recovery state from an earlier real run. Use a fresh plain
+  browser profile plus network controls when an offline proof is required.
+- **Without `VITE_MOCK=1`:** API calls are real. Development uses the Vite proxy
+  and defaults to staging. Production builds default to `free2z.cash`; packaged
+  Tauri uses the registered native HTTP plugin, while a non-Tauri browser build
+  uses `window.fetch` and remains subject to browser-origin policy.
+- **Tauri is required for a real wallet:** the wallet bridge invokes
+  `tauri-plugin-zcash`. A plain browser without `VITE_MOCK=1` can exercise API
+  surfaces, but it cannot exercise the wallet and is not a whole-app run.
 
-This is why `npm run dev` in a browser shows a fully working app.
+Never describe a browser fixture, compile, package, upload, or store-listing
+result as proof of a product operation.
 
 ## Architecture / conventions
 
@@ -121,10 +129,13 @@ This is why `npm run dev` in a browser shows a fully working app.
 
 ## Backend follow-ups (see repo STATUS / the free2z backend)
 
-- `plugin:zcash|sign_challenge` powers Login with Zcash on desktop (ZIP-304).
-- Real endpoints for Zcash login (`/api/auth/zcash/login/`) and pay-with-ZEC
-  top-ups live in the free2z backend (`tuzi/py`). The client contract already
-  targets them; mock mode stands in until they ship.
+- `plugin:zcash|sign_challenge` powers the current transparent-address Zcash
+  Signed Message login. Do not call it ZIP-304; that shielded design is a
+  separate future upgrade.
+- The client targets the Zcash login endpoints, but the production
+  challenge/signature/session round trip still needs recorded native evidence.
+- Production pricing/quote endpoints exist for ZEC top-ups; wallet spend,
+  settlement, and 2Z credit do not. Track that boundary in #155.
 
 ## Social OAuth callbacks
 

--- a/wallet/zuuli/README.md
+++ b/wallet/zuuli/README.md
@@ -6,56 +6,66 @@
 
 *Your Z. Your keys. Your universe.*
 
-A Zcash-native app for desktop and mobile: a cutting-edge wallet fused with the
-free2z platform — AI, livestreaming, articles, and a credit economy — all
-metered in **2Zs**, all shielded by default.
+A Zcash-native app for desktop and mobile: a wallet fused with the free2z
+platform's AI, livestreaming, articles, and **2Z** credit economy.
 
 </div>
 
 ---
 
-## What ZUULI does
+## What ZUULI includes
 
-- 🔑 **Login with Zcash** — your key is your identity. No password, no email, no
-  KYC, no third party. Sign a challenge (ZIP-304), your address becomes a W3C
-  DID. Associate an existing free2z account if you have one.
-- 🪙 **A real Zcash wallet, right here** — create/restore, sync, send, receive,
-  history. Powered by `librustzcash` via `tauri-plugin-zcash` (the same engine
-  as the `zuuallet` reference wallet).
-- 🤖 **AI from every provider, anonymously** — OpenAI, Anthropic, xAI, Kimi, and
-  open-source models on our hardware. You go through the free2z API, so the
-  provider never sees *you*. Priced cost-plus, rounded up to whole 2Zs.
-- 📡 **Livestreaming** — start a broadcast, subscriber-only, PPV, or private
-  stream. Discover what's live. Join a PPV stream by spending 2Zs.
-- ✍️ **Articles** — read a feed, or author your own with a live markdown editor.
-- 💸 **The 2Z economy** — buy 2Zs with a card *or* with ZEC from your in-app
-  wallet. Donate 2Zs or ZEC to creators without ever leaving the app.
+- **Zcash-key sign-in integration** — the native wallet can sign a free2z
+  challenge with its transparent login key, without an email or password.
+- **A native Zcash wallet** — create/restore, sync, send, receive, and history
+  surfaces backed by `librustzcash` through `tauri-plugin-zcash` (the same
+  engine as the `zuuallet` reference wallet).
+- **AI Studio** — model and personality selection through free2z's metered
+  conversation API, with the authoritative 2Z balance refreshed after a turn.
+- **Livestreaming surfaces** — public discovery and RealtimeKit room UI, with
+  authenticated broadcast, subscriber, PPV, and private-stream contracts.
+- **Articles surfaces** — public feed/reader plus authenticated authoring,
+  comments, and tips.
+- **The 2Z economy** — 2Z balances, creator tips, memberships, Activity, and
+  top-up surfaces. Card checkout and ZEC settlement are still incomplete.
+
+These are implemented surfaces, not a claim that every production path has
+passed. The source-and-runtime evidence, release blockers, and issue links live
+in [STATUS.md](STATUS.md). Mock-mode flows are demo evidence only.
 
 ## The 2Z (Tuzi)
 
-`1 Tuzi = 1 US cent`. Everything metered — an AI prompt, a PPV seat — is charged
-at our upstream cost plus a thin margin, **rounded up** to the nearest 2Z. If a
-prompt costs us `$0.0323478`, you pay `4 2Z`.
+ZUULI represents free2z platform credits as integer 2Z (Tuzis). Production
+pricing and quote endpoints provide the authoritative current card/ZEC quote;
+individual charging and settlement paths remain subject to the evidence and
+gaps in [STATUS.md](STATUS.md).
 
 ## Run it
 
 ```bash
 npm install
-npm run dev          # browser, mock mode — the whole app, no backend needed
-npm run tauri dev    # the real desktop app with a live Zcash wallet
+VITE_MOCK=1 npm run dev  # browser fixtures for UI exploration/screenshots
+npm run dev              # real staging API through Vite; no native wallet
+npm run tauri dev        # native wallet + staging API by default
 npm run tauri -- ios dev
 npm run tauri -- android dev
 ```
 
-In a plain browser ZUULI runs in **mock mode** with realistic data so you can
-explore every screen. Inside a Tauri shell it drives the real wallet engine
-and the real free2z API.
+Mock selection is explicit: set `VITE_MOCK=1` to use normal API and wallet
+fixtures. It does not erase persisted native OAuth recovery state or guarantee
+network isolation; use a fresh plain-browser profile plus network controls for
+an offline proof. Without the flag, the API layer is real-first. Development
+defaults to `stage.free2z.cash`; production bundles default to `free2z.cash`.
+The real wallet bridge requires a Tauri shell, so a plain real-first browser run
+is not an end-to-end wallet run.
 
 Card checkout permits `https://checkout.stripe.com` by default. If Stripe
 Custom Domains is enabled for the account, add its exact DNS name at build time
 with `VITE_STRIPE_CHECKOUT_HOSTS=pay.example.com` (comma-separated for more than
 one). Do not include a scheme, path, port, userinfo, suffix wildcard, or a domain
-that is not configured in Stripe.
+that is not configured in Stripe. This is an outbound-URL safety policy, not
+evidence that native checkout and settlement work end to end; see
+[STATUS.md](STATUS.md).
 
 The committed native projects live under `src-tauri/gen/apple` and
 `src-tauri/gen/android`. ZUULI uses application identifier

--- a/wallet/zuuli/STATUS.md
+++ b/wallet/zuuli/STATUS.md
@@ -1,102 +1,108 @@
-# ZUULI — build status
+# ZUULI product status
 
-**ZUULI by 2Z Inc** — a Zcash-native desktop app (Tauri v2 + React 18 + TS +
-Vite + Tailwind + shadcn/ui). Built as the flagship atop the shared Zcash engine
-(`../plugins/tauri-plugin-zcash`, aka the "zuuallet guts") and the free2z API
-(`tuzi/f2z.yaml`).
+This is a release-readiness record, not a feature catalogue. A browser fixture,
+compiled code path, successful package build, or store upload does **not** prove
+that a product operation works. In this document, **production-observed** means
+the non-mock path was actually exercised against `https://free2z.cash` or read
+back from the named store. Authenticated, money-moving, wallet, KYC, and media
+operations are not called working without recorded evidence from that path.
 
-This file is an honest accounting of what is **real & working**, what is
-**scaffolded behind a real interface**, and what needs **backend/infra** to go
-fully live.
+Last re-derived from `origin/main` at
+`1f752c743473f41c3b745160d3bb662cf5467e52` on 2026-08-19. Before a release,
+update the evidence and disposition for every non-ready row; do not carry this
+commit or date forward mechanically.
 
-## Verified working (built, typechecks, runs, exercised in-browser)
+## Evidence boundaries
 
-Full app: `tsc --noEmit` clean, `vite build` green. Every screen runs in
-**mock mode** (`npm run dev` in a browser) with realistic data, and the flows
-below were click-tested end-to-end:
+- `VITE_MOCK=1` selects normal API/wallet fixtures for UI/demo work. It is useful
+  for layout, deterministic screenshots, and component development, but it is
+  never backend, payment, media, authentication, or wallet evidence. It is not
+  a network-isolation guarantee for a native profile with persisted OAuth
+  recovery state; offline proof needs a fresh plain-browser profile plus network
+  controls.
+- A development run uses the Vite proxy and defaults to
+  `https://stage.free2z.cash`, not production. A production bundle defaults to
+  `https://free2z.cash`; packaged Tauri calls use the registered native HTTP
+  plugin. See [`vite.config.ts`](vite.config.ts), [`src/lib/env.ts`](src/lib/env.ts),
+  [`src/lib/api/http.ts`](src/lib/api/http.ts), and
+  [`src-tauri/src/lib.rs`](src-tauri/src/lib.rs).
+- **Wired, not runtime-proven** means source reaches a real API or native
+  command, but this repository has no successful production operation recorded
+  for it.
+- **Known broken/incomplete** means a visible path has a confirmed contract,
+  safety, settlement, deployment, or product gap. It blocks calling that path
+  ready.
 
-- **Login with Zcash** — challenge → sign (wallet) → verify → session, with a
-  live animated stepper. No password, no email. Lands you logged in.
-- **AI Studio** — multi-provider model picker (Anthropic / OpenAI / xAI / Kimi /
-  on-our-hardware Llama), markdown chat, and **live 2Z metering**: each answer is
-  charged (cost-plus, rounded up) and the balance decrements in real time.
-- **Livestreams + PPV** — discovery grid, Go-Live dialog, and the marquee flow:
-  join a PPV stream → confirm the 2Z price → balance debited → connected room
-  (meeting details, participants, live chat).
-- **Wallet** — shielded balance, sync bar, unified-address QR + copy, send
-  (live address validation → fee-confirm → execute), receive, history,
-  create/restore onboarding with seed-phrase backup.
-- **2Z economy** — buy packs (card via Stripe **and** pay-with-ZEC from the
-  in-app wallet), send/tip creators, transaction activity.
-- **Articles** — feed, reader with tip-the-author, and a live-preview markdown
-  composer.
+## Source-and-runtime-backed matrix
 
-## Real production integration (no mocks by default)
+| Surface | Real API/backend dependency | Native integration | Automated evidence | Production/native evidence | Current status and linked gaps |
+|---|---|---|---|---|---|
+| Runtime transport | Production bundle → `free2z.cash`; development proxy → staging | `tauri-plugin-http` is registered and selected for packaged non-dev Tauri | The required frontend/Rust gate and four-target package smoke pass on the current tree | Signed-store and unsigned packages exist; no per-surface native HTTP success is recorded here | **Wired, not runtime-proven.** The former claim that packaged HTTP registration was missing was false. |
+| Public Articles, creator listing, search, Live discovery, AI models, and pricing | Public `zpage`, `creator`, `dyte/public`, `ai/models`, `pricing`, and `pricing/quote` endpoints | Shared native HTTP transport in packaged builds | Parser/component tests cover selected article, remote-data, and media contracts | Unfiltered collection/model/pricing production GETs returned HTTP 200 on 2026-08-19; Live returned a valid empty page. Filtered creator/article search was not probed | **Collection reads production-observed; search wired, not runtime-proven.** Signed-native rendering remains unrecorded. Article gaps: [#337](https://github.com/free2z/zuu/issues/337), [#374](https://github.com/free2z/zuu/issues/374), [#250](https://github.com/free2z/zuu/issues/250), [#251](https://github.com/free2z/zuu/issues/251). Search/pagination gaps: [#252](https://github.com/free2z/zuu/issues/252), [#253](https://github.com/free2z/zuu/issues/253). |
+| Username/password and TOTP sign-in | Knox Basic login, OTP status/login, and authenticated user endpoints | Token-backed HTTP; no special native plugin | Session-boundary, login-destination, component, and browser lifecycle tests | Anonymous protected reads returned HTTP 403; no successful production login is recorded | **Wired, not runtime-proven; not release-ready.** Server-side TOTP enforcement: [#369](https://github.com/free2z/zuu/issues/369). Token custody: [#377](https://github.com/free2z/zuu/issues/377). |
+| Login/link with Zcash | `auth/zcash/challenge` and `auth/zcash/login` | The shared plugin supports local recovery-phrase restore and transparent-address Zcash Signed Message signing | Native atomic-restore/signing tests and frontend restore/challenge lifecycle tests exercise local contracts | No production restore → native signature → Knox session round trip is recorded | **Restore is implemented and contract-tested, but the login path is not runtime-proven.** Recovery-phrase restore landed in [#428](https://github.com/free2z/zuu/pull/428); external-wallet signing remains unsupported. Physical recovery ceremony: [#246](https://github.com/free2z/zuu/issues/246). Wallet/login identity choice: [#329](https://github.com/free2z/zuu/issues/329). This is not ZIP-304. |
+| Social login/link | Provider discovery, authorization start, callback exchange, and authenticated user endpoints | Desktop loopback and mobile private-scheme transports exist | OAuth protocol tests cover PKCE, state, session binding, and callback parsing | Generic production discovery returned a `providers` array; the intended mobile discovery endpoint returned HTTP 403 anonymously; no OAuth round trip is recorded | **Known broken/deployment-disabled:** [#403](https://github.com/free2z/zuu/issues/403) and [free2z/tuzi#1260](https://github.com/free2z/tuzi/pull/1260). Current main expects an incompatible object map and does not use the mobile-specific contract. Claimed-HTTPS release proof: [#242](https://github.com/free2z/zuu/issues/242). Association binding: [#380](https://github.com/free2z/zuu/issues/380). |
+| Wallet create/restore/sync/receive/send/history | Lightwalletd and librustzcash through the shared plugin | Real Tauri Zcash plugin is registered | Plugin Rust tests, frontend wallet tests, and backend compilation run in CI | Packages have built, but no signed-device create/restore/sync/receive/send record is checked into this repository | **Wired, not runtime-proven; release stop until kick-the-tires evidence exists.** Send confirmation integrity: [#368](https://github.com/free2z/zuu/issues/368). Preserved-wallet import: [#272](https://github.com/free2z/zuu/issues/272). |
+| AI conversations and billing | Model/personality APIs plus model-bound `ai/conversations/.../promptresponses` metering and authoritative balance refresh | Native HTTP | Component/state tests do not exercise a real metered conversation | Public model discovery returned HTTP 200; no authenticated production prompt and charge is recorded | **Wired, not runtime-proven.** The active UI uses the metered conversation path; the old flat-1-2Z description referred to legacy code. Conversation/model state: [#266](https://github.com/free2z/zuu/issues/266). |
+| Livestream room/media | Public listing plus authenticated start/join and membership endpoints | Cloudflare RealtimeKit provider and meeting UI are mounted; camera/mic are native permissions | Membership reconciliation tests cover selected money-boundary races | Public listing returned HTTP 200 with zero active rooms; no native host/join/camera/mic session is recorded | **Wired, not end-to-end proven.** The former missing-SDK claim was false. Metadata/PPV: [#262](https://github.com/free2z/zuu/issues/262). Private streams: [#264](https://github.com/free2z/zuu/issues/264). Participant counts: [#265](https://github.com/free2z/zuu/issues/265). Purchase integrity: [#336](https://github.com/free2z/zuu/issues/336). |
+| Articles read/write/comments/tips | Public zpage reads; authenticated create/update/comment/donation APIs | Native HTTP; markdown/media render inside the privileged webview | Markdown safety/media and donation idempotency/response tests | Public feed returned HTTP 200; authenticated publishing, commenting, and tipping are not production-proven | **Reads production-observed; writes and charges not runtime-proven.** Remote-content boundaries: [#367](https://github.com/free2z/zuu/issues/367), [#374](https://github.com/free2z/zuu/issues/374). Authoring: [#250](https://github.com/free2z/zuu/issues/250), [#251](https://github.com/free2z/zuu/issues/251). |
+| Creator public profile and self-edit | Public creator detail/zpage reads; authenticated user mutation | Native HTTP | UI and remote-data tests do not prove a production profile read or mutation | The creator collection returned HTTP 200; no creator-detail read, authenticated edit, or media upload is recorded | **Detail and self-edit wired, not runtime-proven.** Avatar/banner upload remains absent. Linked identities are not authoritative across reloads: [#256](https://github.com/free2z/zuu/issues/256). |
+| KYC application | Authenticated KYC profile, document, tax-form, signature, and submit endpoints | Native HTTP and file picker; no live-camera capture flow | UI tests do not exercise the production KYC contract | No production application or signed-device capture/upload is recorded | **Wired, not runtime-proven; incomplete.** “Live photo” is a file upload: [#257](https://github.com/free2z/zuu/issues/257). Tax-form invalidation: [#258](https://github.com/free2z/zuu/issues/258). This is an application flow, not payout/cash-out. |
+| 2Z send/tip/membership | Authenticated donation and subscription APIs | Native HTTP | Donation and membership idempotency/reconciliation contract tests | No production charge is recorded | **Contract-tested, not runtime-proven.** Follow versus paid membership: [#261](https://github.com/free2z/zuu/issues/261). Creator purchase integrity: [#336](https://github.com/free2z/zuu/issues/336). |
+| Buy 2Z with card | Authenticated Stripe Checkout creation, hosted Checkout, signed webhook credit, and a server-controlled return bridge | Native OS opener is used in packaged apps; current main has no complete native return/claim flow | #400 added signed-out gating, exact HTTPS host validation, actionable failures, and opener tests | Anonymous production checkout returned HTTP 403; no signed-in staging/live charge or signed-build return is recorded | **Known broken/incomplete.** Launch is hardened, but client return/claim [#406](https://github.com/free2z/zuu/pull/406), backend return [free2z/tuzi#1265](https://github.com/free2z/tuzi/pull/1265), and money integrity [free2z/tuzi#1253](https://github.com/free2z/tuzi/issues/1253) are not merged/closed. Track the end-to-end path in [#388](https://github.com/free2z/zuu/issues/388) and exact charge/credit integrity in [#399](https://github.com/free2z/zuu/issues/399). |
+| Buy 2Z with ZEC | Public pricing/quote plus wallet spend and backend settlement/credit | Wallet bridge exists; production settlement is intentionally disabled | Quote parsing and explicit browser-only demo-boundary tests | Pricing and an exact 100-2Z quote returned HTTP 200; no spend/settlement exists | **Mock/demo only for settlement; unavailable in release builds:** [#155](https://github.com/free2z/zuu/issues/155). A price quote is not a top-up. |
+| 2Z Activity | Authenticated Stripe purchase ledger | Native HTTP | Parsing/UI tests do not prove a complete ledger | Protected endpoint returned HTTP 403 anonymously; authenticated ledger not exercised | **Known incomplete:** the endpoint is purchases-only and cannot substantiate tips/AI/PPV totals ([#172](https://github.com/free2z/zuu/issues/172)). |
+| Internal distribution and store presentation | GitHub release train, App Store Connect, and Google Play | Signed mobile bundles plus generated platform/store icons | Release identity, icon/store validators, protected state machines, and all-target packaging are gated | TestFlight `0.1.0+10` is processed and available to its internal group; Play build 10 is present on the internal track. No physical-device acceptance is recorded. The latest recorded Apple/Play audits found canonical listing copy and declared screenshot sets unmatched or absent | **Internal delivery exists; publication presentation and device acceptance are incomplete.** Store media: [#387](https://github.com/free2z/zuu/issues/387). Physical installs: [#238](https://github.com/free2z/zuu/issues/238). Play remains owner-selected Console email-list mode: [#296](https://github.com/free2z/zuu/issues/296). |
 
-ZUULI is **real-first**: `src/lib/api/free2z.ts` talks to the live free2z API at
-**`free2z.cash`** and maps the real response shapes into stable internal types.
-Verified against production: articles (zpage), livestreams (dyte), AI models,
-creators all render live data. Mocks only exist behind `VITE_MOCK=1` for offline
-screenshots.
+## Current production and distribution evidence
 
-Transport (`src/lib/api/http.ts`) solves the CORS problem — the free2z backend
-whitelists only a few web origins, not the Tauri webview:
-- **`tauri dev` / `npm run dev`:** a Vite proxy (`/api`, `/uploadz` → free2z.cash)
-  keeps requests same-origin, so the browser/webview never hits CORS. **This is
-  what makes the running app show real data today.**
-- **Packaged `tauri build`:** routes through `@tauri-apps/plugin-http` (native
-  Rust requests, not subject to browser CORS) against the absolute host.
-  *(Rust registration of tauri-plugin-http for the packaged build is the one
-  remaining transport wiring — dev is fully working.)*
+Safe unauthenticated requests on 2026-08-19 returned the following status and
+top-level contracts:
 
-Auth is Knox: classic login uses HTTP Basic against `/api/token/login/`; the
-token rides in `Authorization: Token <key>`; `/api/auth/user/` supplies the 2Z
-balance (`tuzis`).
-
-## Login with Zcash — real, server-verifiable scheme (being implemented)
-
-The identity is the account's **transparent P2PKH t-address**. The wallet signs
-the server's challenge using the standard **Zcash Signed Message** convention
-(same as zcashd `signmessage`): magic-prefixed double-SHA256, recoverable
-secp256k1 sig, base64. The backend verifies with **zcashd `verifymessage`** — no
-new crypto deps, leverages the node the platform already runs. (This replaces the
-earlier symmetric HMAC, which could not be verified server-side — the reason
-login failed.) ZIP-304 (shielded, UFVK-verifiable) is a future upgrade.
-
-- Wallet plugin `sign_challenge` → `{ address, challenge, signature, pubkey }`.
-- Backend `POST /api/auth/zcash/challenge/` + `/api/auth/zcash/login/` in
-  `apps/zauth` (verify → get-or-create Creator → Knox token → `did:zcash:<addr>`).
-  Deploy to prod to go live.
-
-## Still to wire (interfaces in place)
-
-1. **tauri-plugin-http** Rust registration for the *packaged* build (dev works
-   via the Vite proxy).
-2. **Full multi-model AI metering** — `/api/openai/prompt` charges a flat 1 2Z
-   and ignores model choice; per-token metering runs over the
-   `/api/ai/conversations/.../promptresponses/` websocket. Wire it or add a
-   synchronous metered endpoint (we control the backend).
-3. **Stripe checkout URL** — backend must return `session.url` (one-line add, in
-   the backend PR) for the buy-with-card redirect.
-4. **Pay-with-ZEC top-ups** — settle a shielded spend → credit 2Zs.
-5. **Dyte Web SDK** — `live.start/join` already return real `{meeting_id,
-   auth_token}`; drop the SDK into the "connected" room stage for video.
-6. **Web-app parity** — the same zcash-login backs `zuu/ts/react/free2z`.
-
-## Known mock-mode artifacts (not bugs)
-
-- A hard browser reload re-bootstraps the mock session, resetting the 2Z balance
-  to the fixture value. In-app navigation preserves state; the real backend
-  persists.
-- Onboarding (create/restore) only renders against an uninitialized wallet, so
-  it appears on a fresh desktop wallet, not in browser mock mode.
-
-## Run it
-
-```bash
-cd wallet/zuuli
-npm install
-npm run dev          # browser, mock mode — explore everything
-npm run tauri dev    # real desktop wallet + real API
-npm run build        # tsc && vite build (green)
+```text
+GET  /api/zpage/?page_size=1                 200  count,next,previous,results
+GET  /api/creator/?page_size=1               200  count,next,previous,results
+GET  /api/ai/models/?page_size=1             200  count,next,previous,results
+GET  /api/dyte/public/?page_size=1            200  count,next,previous,results
+GET  /api/pricing/                            200  pricing snapshot
+GET  /api/pricing/quote/?tuzis=100            200  exact quote
+GET  /api/auth/social/providers/              200  providers array
+GET  /api/auth/social/mobile/providers/       403  protected response
 ```
+
+Safe anonymous probes of `/api/auth/user/`, `/api/openai/prompt`,
+`/api/kyc/user-profile`, `/api/stripe/transactions/`, and
+`/api/stripe/create-checkout-session/` returned HTTP 403. That proves only the
+anonymous access boundary; it does not prove any authenticated success path.
+
+Distribution evidence is narrower and explicit:
+
+- [Exact-base package run 32294573670](https://github.com/free2z/zuu/actions/runs/32294573670)
+  built Linux AppImage/deb/rpm, a macOS universal app, an unsigned iOS target
+  app, and an unsigned Android AAB successfully.
+- [TestFlight recovery run 32258561016](https://github.com/free2z/zuu/actions/runs/32258561016)
+  read back build `0.1.0+10` as valid, in beta testing, and related to the one
+  internal-only group. It did not read or log tester identities.
+- [Apple listing audit 32264572536](https://github.com/free2z/zuu/actions/runs/32264572536)
+  found no exact version metadata or screenshots and did not report the
+  canonical locale copy as matched.
+- [Play listing audit 32275502006](https://github.com/free2z/zuu/actions/runs/32275502006)
+  found exact build 10, but canonical listing/details/release notes were
+  unmatched and icon, feature graphic, phone, 7-inch, and 10-inch media counts
+  were zero. Its temporary read-only edit was deleted without commit.
+
+These runs prove package/store state, not product operations. No repository
+record yet demonstrates the full physical-device checklist for wallet
+recovery/sync/spend, OAuth, AI charging, Live media, KYC capture, card checkout,
+or ZEC top-up. Do not record secrets, credentials, seed words, tester
+identities, or sensitive identity documents when that evidence is obtained.
+
+## Release rule
+
+The release checklist in [`docs/releasing.md`](docs/releasing.md) must consume
+this matrix. A target cannot be called ready while a visible path for that
+target is **known broken/incomplete**, or while a required money,
+authentication, wallet, KYC, or media operation is merely mock-tested,
+source-wired, packaged, uploaded, or listed. Supply the missing production and
+native evidence, or remove/disable the visible affordance in the release build
+and link the reviewed disposition here.

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -367,11 +367,18 @@ The final two are needed only for direct-download macOS signing/notarization.
 Base64 values are decoded only into mode-0700 runner-temporary directories and
 destroyed even when a job fails. GitHub never exports store secrets into a PR.
 
-1. Merge only with the required `gate` and `ZUULI / packaging smoke` green.
-2. From a clean version worktree run
+1. Re-derive [`../STATUS.md`](../STATUS.md) from the candidate source and current
+   production/native evidence. Every visible **known broken/incomplete** path
+   must either be fixed and evidenced or be removed/disabled for that target
+   with its reviewed disposition linked in the matrix. Mock, compile, package,
+   upload, and listing evidence cannot satisfy an operation that the matrix
+   requires to run. Do not start promotion with a stale commit/date or an
+   undispositioned non-ready row.
+2. Merge only with the required `gate` and `ZUULI / packaging smoke` green.
+3. From a clean version worktree run
    `npm run release:bump -- --version=<VERSION> --build=<BUILD>`, review every
    generated change, run `npm run release:verify`, and merge the version PR.
-3. A push to `main` that changes an existing `release.json` automatically pins
+4. A push to `main` that changes an existing `release.json` automatically pins
    the exact pushed SHA, proves that `build` strictly increased and `version`
    did not decrease, builds/signs both mobile artifacts, and uploads them to
    TestFlight and Play internal. Adding `release.json` for the first time is a
@@ -400,7 +407,7 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    [run 32006817573](https://github.com/free2z/zuu/actions/runs/32006817573)
    is the cache-free, all-target success recorded for the commit audited by
    issue #389.
-4. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
+5. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
    attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
    protected release** with the exact full SHA, identity, missing target, and
    the appropriate `dry_run` value. A real manual recovery requires the same
@@ -415,11 +422,11 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    `main`, including a superseded build, because it cannot change App Store
    Connect. Desktop `dry_run=true` packaging does not load signing credentials or
    contact Apple's notarization service.
-5. Optionally create an annotated (preferably signed) tag on that exact remote
+6. Optionally create an annotated (preferably signed) tag on that exact remote
    commit as `zuuli-v<VERSION>+<BUILD>`. If the matching tag exists before a
    manual recovery run, the workflow also maintains an idempotent draft GitHub
    release. Store upload authority does not depend on a tag.
-6. Require the iOS job's sanitized state evidence to show all three Booleans:
+7. Require the iOS job's sanitized state evidence to show all three Booleans:
    `uploaded`, `processed`, and `availableToInternalTesters`. A successful upload
    alone is not TestFlight delivery. Confirm the Play internal release is
    available to the tester list.


### PR DESCRIPTION
## Outcome

Re-derives ZUULI's product-status documentation from current source, safe production probes, protected store readbacks, and exact-base CI evidence. It removes mock/build/package overclaims and makes the status matrix a mandatory release preflight.

This is the documentation slice of #396. It deliberately does not absorb #406's checkout-return implementation/runbook details.

## What changed

- replaces the prose feature inventory with a source/API/native/test/production-evidence matrix
- distinguishes explicit `VITE_MOCK=1` fixture selection, real-first browser development, packaged Tauri HTTP, and real wallet boundaries
- records that mock selection does not erase persisted native OAuth recovery state or guarantee network isolation
- corrects stale claims about `tauri-plugin-http`, RealtimeKit, AI conversation metering, Zcash signing/restore, and ZEC settlement
- records safe production observations without promoting anonymous 200/403 responses into authenticated-operation proof
- records exact TestFlight, Play internal-track, store-listing, and current-base all-target package evidence without claiming physical-device acceptance
- narrows unprobed filtered search and creator-detail paths to wired/not-runtime-proven
- requires every release to re-derive and disposition `STATUS.md` before promotion
- keeps card checkout, ZEC top-up, Activity, OAuth, wallet, KYC, and Live media gaps explicit and linked

## Evidence re-derived on 2026-08-19

Source base: `1f752c743473f41c3b745160d3bb662cf5467e52`

Safe production probes:

- public zpage/creator collections, AI models, Live discovery, pricing, exact quote, and generic social-provider discovery returned valid HTTP 200 contracts
- mobile social discovery and anonymous protected auth/KYC/Activity/checkout/prompt probes returned HTTP 403; this is recorded only as access-boundary evidence
- filtered search, creator detail, and all authenticated/money/native operations remain unproven unless separately evidenced

Distribution/store evidence:

- exact-base all-target packaging: run 32294573670 (Linux, macOS, iOS, Android, and release identity all green)
- TestFlight `0.1.0+10` processed/internal-group readback: run 32258561016
- Apple listing audit: run 32264572536 (canonical copy/version media incomplete)
- Play listing audit: run 32275502006 (build 10 present; canonical listing/media incomplete; temporary edit deleted without commit)
- physical-device acceptance remains open in #238

## Verification

Exact local worktree after the #428 rebase:

- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npx vitest run` — 292 passed
- Node boundary tests — 8 passed
- `npx playwright test` — 51 passed, including 320px/touch/overflow and recovery lifecycle coverage
- `npm run test:store-listing` — 37 passed
- `npm run store:validate`
- `npm run icons:check`
- `npm run release:verify` — `0.1.0+10`
- `node scripts/verify-ci-cache-policy.mjs`
- `scripts/check-rust-toolchain.sh` — `1.97.1`
- local Markdown-link validation and `git diff --check`
- `npm audit --audit-level=high` — no high/critical findings (7 existing moderate advisories)

Adversarial review history:

- the original review found four truth gaps: release-runbook consumption, unprobed search, unprobed creator detail, and packaged-Tauri transport scope; all were fixed and the repeated old-base review was clean
- post-#428 clean-head review found the mock-mode network-isolation overclaim; docs were narrowed to the actual fixture/native-state boundary
- the repeated review rejected the older package run as exact evidence after the identity-restore rebase; it was replaced only after exact-base run 32294573670 finished green on all targets
- the final clean-head review of `499bb19e65d17ea0c88244928399e965a62c2522` completed with no findings
