### PR TITLE
docs(zuuli): derive release identity from source

### DIFF
--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -1,8 +1,17 @@
 # Releasing ZUULI
 
-ZUULI ships from one reviewed commit under one immutable identity. The current
-identity is `0.1.0+8`: marketing version `0.1.0`, Apple build `8`, Android
-`versionCode` `8`, and package/bundle identifier `cash.free2z.zuuli`.
+ZUULI ships from one reviewed commit under one immutable identity. Do not copy a
+"current" version or build number from this runbook: read and verify the
+canonical identity from the release source every time:
+
+```bash
+npm run release:verify
+jq -er '.version + "+" + (.build | tostring)' release.json
+```
+
+The verifier prints the identity only after proving that the marketing version,
+Apple build, Android `versionCode`, application identifier, and every other
+generated representation agree.
 
 `release.json` schema v2 is the source of truth. It must remain valid UTF-8 and
 byte-canonical pretty-printed JSON; the verifier uses fatal UTF-8 decoding and
@@ -217,7 +226,7 @@ AAB, releases use the exact audited command:
 
 ```bash
 export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
-export ZUULI_CONFIRM_UPLOAD="$(jq -r '.version + "+" + (.build | tostring)' release.json)"
+export ZUULI_CONFIRM_UPLOAD="$(jq -er '.version + "+" + (.build | tostring)' release.json)"
 scripts/mobile-release.sh android --upload
 ```
 
@@ -227,7 +236,7 @@ must both be confirmed:
 
 ```bash
 export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
-export ZUULI_CONFIRM_UPLOAD=0.1.0+8
+export ZUULI_CONFIRM_UPLOAD="$(jq -er '.version + "+" + (.build | tostring)' release.json)"
 scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
 ```
@@ -291,28 +300,30 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    did not decrease, builds/signs both mobile artifacts, and uploads them to
    TestFlight and Play internal. Adding `release.json` for the first time is a
    no-upload baseline, so merging the release infrastructure itself is safe.
-   Build `0.1.0+1` established the first Play internal release, and `0.1.0+2`
-   confirmed repeatable Play delivery. Build `0.1.0+3` also reached Play
-   internal, while its iOS job stopped before upload in Tauri's PKCS#12 import
-   path. Build `0.1.0+4` proved the verified signing-keychain workaround by
-   signing and exporting the iOS IPA, and it reached Play internal. Its iOS job
-   stopped before verification/upload on a generated-plist ordering diff.
-   Build `0.1.0+5` reached Play internal. Its iOS IPA signed, exported, and
-   passed the local profile/signature verification, but Apple validation
-   rejected the standalone `ZUULI.app/libapp.a` with error 90171 before upload.
-   Build `0.1.0+6` keeps the Rust archive as a link-only input, removes it from
-   Copy Bundle Resources, and makes both the generated-project contract and IPA
-   verifier reject a future static-archive regression before Apple validation.
-   It uploaded and processed successfully; App Store Connect initially marked it
-   `MISSING_EXPORT_COMPLIANCE`, then moved it to `IN_BETA_TESTING` after the
-   build-specific `usesNonExemptEncryption=false` answer. Build `0.1.0+7`
-   persists that answer in the canonical and packaged iOS plists and makes the
-   release contract, normalizer, and IPA inspection fail closed on drift. Its
-   iOS upload succeeded, but its Android job failed before packaging an AAB
-   because the plugin's app-data migration did not compile for the 32-bit
-   armv7/i686 ABIs. Build `0.1.0+8` carries that Android compile fix along with
-   the article image-rendering and media-host URL corrections; post-merge
-   packaging on `main` is green for all four Android ABIs.
+   Do not infer the current identity or latest store state from a prose build
+   narrative. The selected immutable milestones below explain prior release
+   fixes; omission of a later build does not mean it does not exist. For a new
+   release, read `release.json`, inspect that identity's exact protected run,
+   and confirm both stores directly.
+
+   | Identity | Durable protected-run evidence | Historical result |
+   |---|---|---|
+   | `0.1.0+2` | [run 31245152190](https://github.com/free2z/zuu/actions/runs/31245152190) | Play internal succeeded; iOS exposed the PKCS#12 import failure. |
+   | `0.1.0+3` | [run 31248731230](https://github.com/free2z/zuu/actions/runs/31248731230) | Play internal succeeded; iOS again stopped before upload. |
+   | `0.1.0+4` | [run 31253299730](https://github.com/free2z/zuu/actions/runs/31253299730) | Play internal succeeded; iOS signing/export passed, then generated-plist ordering failed. |
+   | `0.1.0+5` | [run 31254971614](https://github.com/free2z/zuu/actions/runs/31254971614) | Play internal succeeded; Apple rejected a bundled static archive with error 90171. |
+   | `0.1.0+6` | [run 31257912883](https://github.com/free2z/zuu/actions/runs/31257912883) | Both protected jobs succeeded after the static archive became link-only; App Store Connect required the build-specific exempt-encryption answer before beta testing. |
+   | `0.1.0+7` | [run 31270095364](https://github.com/free2z/zuu/actions/runs/31270095364) | iOS upload succeeded with the declaration packaged; Android exposed the 32-bit app-data-migration compile error. |
+   | `0.1.0+8` | [run 31293265075](https://github.com/free2z/zuu/actions/runs/31293265075) | Android/Play internal and iOS/TestFlight jobs both succeeded after the cross-ABI fix. |
+   | `0.1.0+9` | [run 31301302280](https://github.com/free2z/zuu/actions/runs/31301302280) | Android/Play internal and iOS/TestFlight jobs both succeeded. |
+   | `0.1.0+10` | [run 31323759501](https://github.com/free2z/zuu/actions/runs/31323759501) | Android/Play internal and iOS/TestFlight jobs both succeeded. |
+
+   Packaging is a separate credential-free signal. Query the
+   [scheduled packaging runs](https://github.com/free2z/zuu/actions/workflows/zuuli-packaging.yml?query=event%3Aschedule)
+   for the release commit instead of calling a fixed run "latest"; for example,
+   [run 32006817573](https://github.com/free2z/zuu/actions/runs/32006817573)
+   is the cache-free, all-target success recorded for the commit audited by
+   issue #389.
 4. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
    attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
    protected release** with the exact full SHA, identity, missing target, and


### PR DESCRIPTION
Closes #389

## Summary

- remove the volatile “current version” claim from the release runbook and require release identity to be derived fail-closed from `release.json`
- derive both iOS and Android upload confirmations with `jq -er` instead of copying a literal build number
- replace the current-seeming prose history with explicitly historical, immutable protected-run evidence through `0.1.0+10`
- point cache-free packaging evidence at the scheduled-run query rather than calling one permanent run “latest”

## Verification

- `npm run release:verify` → `0.1.0+10`
- `jq -er '.version + "+" + (.build | tostring)' release.json` → `0.1.0+10`
- both `ZUULI_CONFIRM_UPLOAD` examples are derived with `jq -er`; no literal upload confirmation remains
- all relative Markdown links resolve locally
- every cited Actions run still resolves; the milestone table deliberately records partial failures as historical evidence and labels itself non-current
- `git diff --check` passes
- exact one-file diff: `wallet/zuuli/docs/releasing.md`

## Adversarial review

The runbook never claims that its milestone list is complete or current, and no release decision depends on prose. The verifier remains authoritative and fail-closed. No release identity, source, workflow, signing path, or upload behavior changes in this PR.
