### PR TITLE
fix(zuuli): enforce mobile touch targets

### DIFF
--- a/wallet/zuuli/src/components/common/Markdown.test.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.test.tsx
@@ -68,6 +68,16 @@ describe("Markdown images", () => {
   });
 });
 
+describe("Markdown links", () => {
+  it("marks genuine inline prose links for the narrow touch-target exemption", () => {
+    const markup = render("Read [the guide](/articles/guide).", "article");
+
+    expect(markup).toContain('data-touch-target-exempt="inline-text"');
+    expect(markup).toContain('href="/articles/guide"');
+    expect(markup).toContain(">the guide</a>");
+  });
+});
+
 /**
  * free2z stores article bodies with ORIGIN-RELATIVE upload paths, e.g.
  * `![](/uploadz/public/palmar/elg03269-1.webp)`. Those only resolve when the

--- a/wallet/zuuli/src/components/common/Markdown.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.tsx
@@ -85,6 +85,9 @@ async function openExternal(url: string) {
  * the running SPA is never blown away. In-page `#` anchors (footnotes, heading
  * slugs) smooth-scroll to their target instead of routing — router navigation
  * to a hash never scrolls, which is the "footnotes don't scroll" bug.
+ * These are the one deliberate 44px touch-target exemption: prose links must
+ * stay inline so a paragraph remains readable. The browser audit rejects the
+ * marker anywhere outside inline, text-only `.zuuli-markdown` anchors.
  */
 function MarkdownLink({
   href,
@@ -98,6 +101,7 @@ function MarkdownLink({
     return (
       <a
         {...rest}
+        data-touch-target-exempt="inline-text"
         href={href}
         onClick={(e) => {
           e.preventDefault();
@@ -116,6 +120,7 @@ function MarkdownLink({
     return (
       <a
         {...rest}
+        data-touch-target-exempt="inline-text"
         href={href}
         target="_blank"
         rel="noopener noreferrer"
@@ -132,6 +137,7 @@ function MarkdownLink({
   return (
     <a
       {...rest}
+      data-touch-target-exempt="inline-text"
       href={href ?? "#"}
       onClick={(e) => {
         if (!href) return;
@@ -169,7 +175,7 @@ function CopyButton({ getText }: { getText: () => string }) {
         setCopied(true);
         window.setTimeout(() => setCopied(false), 1500);
       }}
-      className="absolute right-2 top-2 z-10 inline-flex min-h-8 min-w-8 items-center justify-center rounded-md border border-border bg-card/80 p-1.5 text-muted-foreground opacity-0 backdrop-blur transition hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+      className="min-tap absolute right-2 top-2 z-10 inline-flex items-center justify-center rounded-md border border-border bg-card/80 p-1.5 text-muted-foreground opacity-0 backdrop-blur transition hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
     >
       {copied ? (
         <Check className="h-4 w-4 text-primary" />

--- a/wallet/zuuli/src/components/layout/Sidebar.tsx
+++ b/wallet/zuuli/src/components/layout/Sidebar.tsx
@@ -12,13 +12,13 @@ import { Wordmark } from "@/components/brand/Logo";
 import { cn } from "@/lib/utils";
 
 const NAV = [
-  { to: "/", label: "Discover", icon: Home, end: true },
-  { to: "/search", label: "Search", icon: Search },
-  { to: "/live", label: "Livestreams", icon: Radio },
-  { to: "/ai", label: "AI", icon: Sparkles },
-  { to: "/articles", label: "Articles", icon: BookOpen },
-  { to: "/wallet", label: "Wallet", icon: Wallet },
-  { to: "/buy", label: "Buy & Send 2Z", icon: Coins },
+  { to: "/", label: "Discover", mobileLabel: "Home", icon: Home, end: true },
+  { to: "/search", label: "Search", mobileLabel: "Search", icon: Search },
+  { to: "/live", label: "Livestreams", mobileLabel: "Live", icon: Radio },
+  { to: "/ai", label: "AI", mobileLabel: "AI", icon: Sparkles },
+  { to: "/articles", label: "Articles", mobileLabel: "Read", icon: BookOpen },
+  { to: "/wallet", label: "Wallet", mobileLabel: "Wallet", icon: Wallet },
+  { to: "/buy", label: "Buy & Send 2Z", mobileLabel: "Buy", icon: Coins },
 ];
 
 export function Sidebar() {
@@ -35,7 +35,7 @@ export function Sidebar() {
             end={end}
             className={({ isActive }) =>
               cn(
-                "min-tap flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors",
+                "min-tap flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 isActive
                   ? "bg-primary/15 text-primary"
                   : "text-muted-foreground hover:bg-secondary hover:text-foreground",
@@ -58,25 +58,31 @@ export function Sidebar() {
 
 /** Bottom tab bar for narrow / mobile widths. */
 export function MobileTabBar() {
+  // Equal zero-minimum tracks prevent a long translated/desktop label from
+  // stealing width from neighboring targets. Compact visible labels keep all
+  // seven real hit boxes above 44px at a 320px viewport.
   return (
     <nav
-      className="app-bottom-nav fixed inset-x-0 bottom-0 z-40 flex border-t border-border bg-card/95 backdrop-blur md:hidden"
+      className="app-bottom-nav fixed inset-x-0 bottom-0 z-40 grid grid-cols-7 border-t border-border bg-card/95 backdrop-blur md:hidden"
       data-app-bottom-nav
     >
-      {NAV.map(({ to, label, icon: Icon, end }) => (
+      {NAV.map(({ to, label, mobileLabel, icon: Icon, end }) => (
         <NavLink
           key={to}
           to={to}
           end={end}
+          aria-label={label}
           className={({ isActive }) =>
             cn(
-              "flex flex-1 flex-col items-center justify-center gap-1 text-[10px]",
+              "min-tap flex min-w-0 flex-col items-center justify-center gap-1 text-[10px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
               isActive ? "text-primary" : "text-muted-foreground",
             )
           }
         >
-          <Icon className="h-5 w-5" />
-          {label.split(" ")[0]}
+          <Icon className="h-5 w-5" aria-hidden />
+          <span className="max-w-full truncate px-0.5" aria-hidden>
+            {mobileLabel}
+          </span>
         </NavLink>
       ))}
     </nav>

--- a/wallet/zuuli/src/components/ui/button.tsx
+++ b/wallet/zuuli/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "min-tap inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -21,11 +21,11 @@ const buttonVariants = cva(
         zec: "bg-[#f4b728] text-[#1a1206] shadow hover:bg-[#f4b728]/90 font-semibold",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3 text-xs",
+        default: "h-11 px-4 py-2",
+        sm: "h-11 rounded-md px-3 text-xs",
         lg: "h-11 rounded-md px-6",
         xl: "h-12 rounded-lg px-8 text-base",
-        icon: "h-10 w-10",
+        icon: "h-11 w-11",
       },
     },
     defaultVariants: {

--- a/wallet/zuuli/src/components/ui/input.tsx
+++ b/wallet/zuuli/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background/60 px-3 py-2 text-sm ring-offset-background transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-11 min-h-11 w-full rounded-md border border-input bg-background/60 px-3 py-2 text-sm ring-offset-background transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/wallet/zuuli/src/components/ui/tabs.tsx
+++ b/wallet/zuuli/src/components/ui/tabs.tsx
@@ -11,7 +11,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-lg bg-muted/60 p-1 text-muted-foreground",
+      "inline-flex h-auto min-h-11 items-center justify-center rounded-lg bg-muted/60 p-1 text-muted-foreground",
       className,
     )}
     {...props}
@@ -26,7 +26,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "min-tap inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className,
     )}
     {...props}

--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -453,7 +453,7 @@ export default function AiFeature() {
                   variant="outline"
                   onClick={() => abortRef.current?.abort()}
                   aria-label="Stop generating"
-                  className="h-9 w-9"
+                  className="h-11 w-11"
                 >
                   <Square className="h-3.5 w-3.5 fill-current" />
                 </Button>
@@ -464,7 +464,7 @@ export default function AiFeature() {
                   onClick={() => void send(input)}
                   disabled={!canSend}
                   aria-label="Send message"
-                  className="h-9 w-9"
+                  className="h-11 w-11"
                 >
                   <ArrowUp className="h-4 w-4" />
                 </Button>
@@ -686,7 +686,7 @@ function EmptyHero({
             key={prompt}
             type="button"
             onClick={() => onPrefill(prompt)}
-            className="rounded-full border border-border bg-card/60 px-3.5 py-1.5 text-xs text-foreground/80 transition-colors hover:border-primary/50 hover:bg-secondary hover:text-foreground"
+            className="min-tap rounded-full border border-border bg-card/60 px-3.5 py-1.5 text-xs text-foreground/80 transition-colors hover:border-primary/50 hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {prompt}
           </button>

--- a/wallet/zuuli/src/features/articles/components/Comments/CommentCard.tsx
+++ b/wallet/zuuli/src/features/articles/components/Comments/CommentCard.tsx
@@ -125,7 +125,7 @@ export function CommentCard({ comment, numChildren, onReplied }: CommentCardProp
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
             <Link
               to={`/creator/${name}`}
-              className="flex items-center gap-2 font-medium text-foreground transition-colors hover:text-primary"
+              className="min-tap flex items-center gap-2 rounded-md font-medium text-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <Avatar className="h-6 w-6">
                 {comment.author.avatar_image ? (

--- a/wallet/zuuli/src/features/articles/components/TipDialog.tsx
+++ b/wallet/zuuli/src/features/articles/components/TipDialog.tsx
@@ -82,7 +82,7 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
                 onClick={() => setAmount(String(preset))}
                 aria-pressed={parsedAmount === preset}
                 className={cn(
-                  "rounded-lg border px-3 py-2 text-sm font-medium tabular-nums transition-colors",
+                  "min-tap rounded-lg border px-3 py-2 text-sm font-medium tabular-nums transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   parsedAmount === preset
                     ? "border-primary bg-primary/15 text-primary"
                     : "border-border bg-transparent text-muted-foreground hover:bg-secondary",

--- a/wallet/zuuli/src/features/articles/pages/Feed.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Feed.tsx
@@ -111,14 +111,14 @@ export function Feed() {
               onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Search articles by meaning…"
               aria-label="Search articles"
-              className="pl-9 pr-9"
+              className="pl-9 pr-12"
             />
             {searchInput ? (
               <button
                 type="button"
                 onClick={() => setSearchInput("")}
                 aria-label="Clear search"
-                className="absolute right-2 top-1/2 grid h-6 w-6 -translate-y-1/2 place-items-center rounded-md text-muted-foreground hover:text-foreground"
+                className="min-tap absolute right-0 top-1/2 grid -translate-y-1/2 place-items-center rounded-md text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 <X className="h-4 w-4" aria-hidden />
               </button>
@@ -143,7 +143,7 @@ export function Feed() {
               aria-selected={sort === s.value}
               onClick={() => setSort(s.value)}
               className={cn(
-                "rounded-full px-3 py-1 text-sm font-medium transition-colors",
+                "min-tap rounded-full px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 sort === s.value
                   ? "bg-primary/15 text-primary"
                   : "text-muted-foreground hover:text-foreground",
@@ -167,7 +167,7 @@ export function Feed() {
                 aria-pressed={on}
                 onClick={() => toggleTag(tag)}
                 className={cn(
-                  "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                  "min-tap rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   on
                     ? "border-primary bg-primary/15 text-primary"
                     : "border-border bg-transparent text-muted-foreground hover:bg-secondary hover:text-foreground",
@@ -181,7 +181,7 @@ export function Feed() {
             <button
               type="button"
               onClick={() => setSelectedTags([])}
-              className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+              className="min-tap inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <X className="h-3 w-3" aria-hidden />
               Clear tags

--- a/wallet/zuuli/src/features/articles/pages/Reader.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Reader.tsx
@@ -94,7 +94,7 @@ export function Reader() {
             <Link
               to={`/creator/${author.username}`}
               aria-label={`View ${name}’s profile`}
-              className="shrink-0"
+              className="min-tap inline-flex shrink-0 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <Avatar>
                 {author.image ? (
@@ -106,7 +106,7 @@ export function Reader() {
             <div className="text-sm">
               <Link
                 to={`/creator/${author.username}`}
-                className="font-medium text-foreground transition-colors hover:text-primary hover:underline"
+                className="min-tap inline-flex items-center rounded-md font-medium text-foreground transition-colors hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {name}
               </Link>
@@ -170,7 +170,7 @@ function BackLink() {
   return (
     <Link
       to="/articles"
-      className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      className="min-tap inline-flex items-center gap-2 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <ArrowLeft className="h-4 w-4" aria-hidden />
       All articles

--- a/wallet/zuuli/src/features/auth/SeedReveal.tsx
+++ b/wallet/zuuli/src/features/auth/SeedReveal.tsx
@@ -65,7 +65,7 @@ export function SeedReveal({ seedPhrase, onConfirm }: SeedRevealProps) {
           <button
             type="button"
             onClick={() => setRevealed(true)}
-            className="absolute inset-0 grid place-items-center rounded-lg bg-background/40 backdrop-blur-[2px] transition-colors hover:bg-background/25"
+            className="absolute inset-0 grid place-items-center rounded-lg bg-background/40 backdrop-blur-[2px] transition-colors hover:bg-background/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
             aria-label="Reveal recovery phrase"
           >
             <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 text-sm font-medium shadow-glow">
@@ -96,7 +96,7 @@ export function SeedReveal({ seedPhrase, onConfirm }: SeedRevealProps) {
 
       <Separator />
 
-      <label className="flex cursor-pointer items-start gap-3 text-sm">
+      <label className="min-h-11 flex cursor-pointer items-start gap-3 text-sm">
         <input
           type="checkbox"
           checked={acknowledged}

--- a/wallet/zuuli/src/features/auth/index.tsx
+++ b/wallet/zuuli/src/features/auth/index.tsx
@@ -72,7 +72,7 @@ export default function AuthFeature() {
                     <button
                       type="button"
                       onClick={() => setMethod("chooser")}
-                      className="inline-flex items-center gap-1.5 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground"
+                      className="min-tap inline-flex items-center gap-1.5 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       aria-label="Back to all sign-in options"
                     >
                       <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
@@ -114,11 +114,11 @@ export default function AuthFeature() {
                         backend reports as configured (none, today) */}
                     <SocialButtons loginDestination={loginDestination} />
 
-                    <div className="flex items-center justify-between">
+                    <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
                       <ZShieldInfo>
                         <button
                           type="button"
-                          className="inline-flex items-center gap-1.5 rounded-md text-xs text-muted-foreground transition-colors hover:text-foreground"
+                          className="min-tap inline-flex items-center gap-1.5 rounded-md text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                           aria-label="How Login with Zcash works"
                         >
                           <HelpCircle className="h-3.5 w-3.5" aria-hidden />

--- a/wallet/zuuli/src/features/buy/BuyTab.tsx
+++ b/wallet/zuuli/src/features/buy/BuyTab.tsx
@@ -210,7 +210,7 @@ export function BuyTab() {
                 aria-pressed={active}
                 aria-label={`Buy ${formatTuzis(pack)} for ${formatUsd(tuzisToUsd(pack))}`}
                 className={cn(
-                  "group relative flex flex-col items-start gap-1 rounded-xl border p-4 text-left transition-all",
+                  "min-tap group relative flex flex-col items-start gap-1 rounded-xl border p-4 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   active
                     ? "border-primary bg-primary/10 shadow-glow"
                     : "border-border bg-card hover:border-primary/40 hover:bg-primary/5",

--- a/wallet/zuuli/src/features/buy/SendTab.tsx
+++ b/wallet/zuuli/src/features/buy/SendTab.tsx
@@ -434,7 +434,7 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
                     aria-selected={index === recipientState.highlightedIndex}
                     onClick={() => chooseRecipient(creator)}
                     className={cn(
-                      "flex min-h-11 w-full items-center gap-3 border-b border-border px-3 py-2 text-left last:border-b-0",
+                      "flex min-h-11 w-full items-center gap-3 border-b border-border px-3 py-2 text-left last:border-b-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
                       index === recipientState.highlightedIndex
                         ? "bg-primary/10"
                         : "hover:bg-secondary",
@@ -519,7 +519,7 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
                   aria-pressed={active}
                   disabled={sending || flowLocked}
                   className={cn(
-                    "min-h-11 rounded-xl border p-3 text-center transition-all disabled:opacity-50",
+                    "min-tap rounded-xl border p-3 text-center transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50",
                     active
                       ? "border-primary bg-primary/10 shadow-glow"
                       : "border-border hover:border-primary/40 hover:bg-primary/5",

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -240,7 +240,7 @@ function CreatorProfile({ creator }: { creator: CreatorDetail }) {
                 target="_blank"
                 rel="noreferrer noopener"
                 aria-label={`${name} on ${social.label}`}
-                className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-card/40 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
+                className="min-tap inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-card/40 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 <Icon className="h-3.5 w-3.5" aria-hidden />
                 {social.display}
@@ -720,7 +720,7 @@ function TipButton({ creator }: { creator: CreatorDetail }) {
                 onClick={() => setAmount(String(preset))}
                 aria-pressed={parsedAmount === preset}
                 className={cn(
-                  "rounded-lg border px-3 py-2 text-sm font-medium tabular-nums transition-colors",
+                  "min-tap rounded-lg border px-3 py-2 text-sm font-medium tabular-nums transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   parsedAmount === preset
                     ? "border-primary bg-primary/15 text-primary"
                     : "border-border bg-transparent text-muted-foreground hover:bg-secondary",
@@ -864,7 +864,7 @@ function BackLink() {
       <button
         type="button"
         onClick={() => navigate(-1)}
-        className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        className="min-tap inline-flex items-center gap-2 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <ArrowLeft className="h-4 w-4" aria-hidden />
         Back
@@ -875,7 +875,7 @@ function BackLink() {
   return (
     <Link
       to="/search"
-      className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      className="min-tap inline-flex items-center gap-2 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <ArrowLeft className="h-4 w-4" aria-hidden />
       Search

--- a/wallet/zuuli/src/features/home/parts.tsx
+++ b/wallet/zuuli/src/features/home/parts.tsx
@@ -45,7 +45,7 @@ export function SectionHeader({
       {to ? (
         <Link
           to={to}
-          className="group inline-flex shrink-0 items-center gap-1 rounded-md text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="min-tap group inline-flex shrink-0 items-center gap-1 rounded-md text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label={`${linkLabel}: ${title}`}
         >
           {linkLabel}

--- a/wallet/zuuli/src/features/kyc/UploadSlot.tsx
+++ b/wallet/zuuli/src/features/kyc/UploadSlot.tsx
@@ -53,7 +53,7 @@ export function UploadSlot({
             href={url}
             target="_blank"
             rel="noreferrer"
-            className="flex items-center gap-2 text-sm text-primary hover:underline"
+            className="min-tap flex items-center gap-2 rounded-md text-sm text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <FileCheck2 className="h-4 w-4" aria-hidden />
             View uploaded file

--- a/wallet/zuuli/src/features/kyc/steps/TaxFormStep.tsx
+++ b/wallet/zuuli/src/features/kyc/steps/TaxFormStep.tsx
@@ -120,7 +120,7 @@ export function TaxFormStep({
           href={form.url}
           target="_blank"
           rel="noreferrer"
-          className="inline-block text-sm text-primary underline-offset-4 hover:underline"
+          className="min-tap inline-flex items-center rounded-md text-sm text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           Download the {form.kind} form (IRS.gov)
         </a>
@@ -144,7 +144,7 @@ export function TaxFormStep({
             placeholder="Full legal name"
             disabled={!file}
           />
-          <label className="flex items-start gap-2 text-xs text-muted-foreground">
+          <label className="min-h-11 flex items-start gap-2 text-xs text-muted-foreground">
             <input
               type="checkbox"
               checked={checked}

--- a/wallet/zuuli/src/features/live/GoLiveDialog.tsx
+++ b/wallet/zuuli/src/features/live/GoLiveDialog.tsx
@@ -141,7 +141,7 @@ export function GoLiveDialog() {
                     aria-checked={active}
                     onClick={() => setKind(k)}
                     className={cn(
-                      "flex flex-col items-start gap-0.5 rounded-lg border px-3 py-2 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      "min-tap flex flex-col items-start gap-0.5 rounded-lg border px-3 py-2 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                       active
                         ? "border-primary/60 bg-primary/10 shadow-glow"
                         : "border-border bg-background/40 hover:border-primary/30",

--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -279,7 +279,7 @@ function BackLink() {
   return (
     <Link
       to="/live"
-      className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      className="min-tap inline-flex items-center gap-1.5 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <ArrowLeft className="h-4 w-4" aria-hidden />
       All livestreams

--- a/wallet/zuuli/src/features/search/index.tsx
+++ b/wallet/zuuli/src/features/search/index.tsx
@@ -118,7 +118,7 @@ export default function SearchFeature() {
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search creators and pages…"
           aria-label="Search creators and pages"
-          className="h-12 pl-10 pr-10 text-base"
+          className="h-12 pl-10 pr-14 text-base"
         />
         {query ? (
           <button
@@ -128,7 +128,7 @@ export default function SearchFeature() {
               inputRef.current?.focus();
             }}
             aria-label="Clear search"
-            className="min-tap absolute right-1.5 top-1/2 grid -translate-y-1/2 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
+            className="min-tap absolute right-1.5 top-1/2 grid -translate-y-1/2 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <X className="h-4 w-4" aria-hidden />
           </button>

--- a/wallet/zuuli/src/features/wallet/Onboarding.tsx
+++ b/wallet/zuuli/src/features/wallet/Onboarding.tsx
@@ -95,7 +95,7 @@ function CreatePane({
                 type="button"
                 onClick={() => setWordCount(n)}
                 className={cn(
-                  "rounded-lg border px-4 py-3 text-sm font-medium transition-colors",
+                  "min-tap rounded-lg border px-4 py-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   wordCount === n
                     ? "border-primary bg-primary/10 text-foreground"
                     : "border-border text-muted-foreground hover:bg-secondary",
@@ -179,7 +179,7 @@ function RestorePane({ onRestored }: { onRestored: () => void }) {
             <button
               type="button"
               onClick={() => setReveal((r) => !r)}
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              className="min-tap inline-flex items-center gap-1 rounded-md text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               aria-pressed={reveal}
             >
               {reveal ? (
@@ -322,7 +322,7 @@ function SeedReveal({
               <button
                 type="button"
                 onClick={() => setReveal(true)}
-                className="absolute inset-0 grid place-items-center rounded-lg bg-background/20 text-sm font-medium backdrop-blur-[2px]"
+                className="absolute inset-0 grid place-items-center rounded-lg bg-background/20 text-sm font-medium backdrop-blur-[2px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
               >
                 <span className="flex items-center gap-2 rounded-full bg-secondary px-4 py-2 shadow">
                   <Eye className="h-4 w-4" />
@@ -344,7 +344,7 @@ function SeedReveal({
             ) : null}
           </div>
 
-          <label className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-border p-3 text-sm">
+          <label className="min-h-11 flex cursor-pointer items-start gap-2.5 rounded-lg border border-border p-3 text-sm">
             <input
               type="checkbox"
               checked={confirmed}

--- a/wallet/zuuli/src/features/wallet/Send.tsx
+++ b/wallet/zuuli/src/features/wallet/Send.tsx
@@ -375,7 +375,7 @@ export function Send() {
                 <button
                   type="button"
                   disabled={hasUnknownBroadcast}
-                  className="text-xs text-muted-foreground hover:text-foreground"
+                  className="min-tap inline-flex items-center justify-center rounded-md text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   onClick={() => setAmount(formatZec(maxSpendable))}
                 >
                   Max: {formatZecDisplay(maxSpendable)}

--- a/wallet/zuuli/src/features/wallet/index.tsx
+++ b/wallet/zuuli/src/features/wallet/index.tsx
@@ -46,7 +46,7 @@ function WalletNav() {
           end={end}
           className={({ isActive }) =>
             cn(
-              "inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "min-tap inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               isActive
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground",
@@ -100,7 +100,7 @@ function CleanupNotice() {
           </p>
           {cleanup.diagnostics.length > 0 && cleanup.pendingOperations > 0 && (
             <details className="mt-2 text-xs text-muted-foreground">
-              <summary className="cursor-pointer">Technical details</summary>
+              <summary className="min-tap inline-flex cursor-pointer items-center">Technical details</summary>
               <ul className="mt-1 list-disc space-y-1 pl-5">
                 {cleanup.diagnostics.map((diagnostic) => (
                   <li key={diagnostic}>{diagnostic}</li>

--- a/wallet/zuuli/src/main.tsx
+++ b/wallet/zuuli/src/main.tsx
@@ -43,6 +43,8 @@ function RootFallback() {
         type="button"
         onClick={() => window.location.reload()}
         style={{
+          minWidth: "44px",
+          minHeight: "44px",
           padding: "0.5rem 1rem",
           borderRadius: "0.75rem",
           border: "1px solid #3f3f46",

--- a/wallet/zuuli/tests/touch-targets.pw.ts
+++ b/wallet/zuuli/tests/touch-targets.pw.ts
@@ -1,0 +1,294 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TOUCH_WIDTHS = [320, 360] as const;
+const ROUTES = [
+  "/",
+  "/search",
+  "/search?q=zcash",
+  "/creator/skyl",
+  "/profile",
+  "/kyc",
+  "/wallet",
+  "/wallet/send",
+  "/wallet/receive",
+  "/wallet/history",
+  "/ai",
+  "/live",
+  "/live/nine",
+  "/articles",
+  "/articles/new",
+  "/articles/why-shielded-by-default",
+  "/buy",
+  "/does-not-exist",
+  "/login",
+] as const;
+
+type TouchAudit = {
+  failures: string[];
+  exemptions: string[];
+  targets: number;
+};
+
+async function setSession(page: Page, signedIn: boolean) {
+  await page.addInitScript((authenticated) => {
+    const key = "zuuli.knox.token";
+    if (authenticated) localStorage.setItem(key, "mock-knox-token");
+    else localStorage.removeItem(key);
+  }, signedIn);
+}
+
+async function expectEditableTextClearsButton(page: Page, inputName: string) {
+  const input = page.getByRole("searchbox", { name: inputName });
+  const clear = page.getByRole("button", { name: "Clear search" });
+  const [inputBox, clearBox, inset] = await Promise.all([
+    input.boundingBox(),
+    clear.boundingBox(),
+    input.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return Number.parseFloat(style.paddingRight) + Number.parseFloat(style.borderRightWidth);
+    }),
+  ]);
+
+  expect(inputBox, `${inputName} must have measurable input geometry`).not.toBeNull();
+  expect(clearBox, `${inputName} must have a measurable clear target`).not.toBeNull();
+  const editableRight = inputBox!.x + inputBox!.width - inset;
+  expect(
+    clearBox!.x,
+    `${inputName} editable content must end before its clear target`,
+  ).toBeGreaterThanOrEqual(editableRight - 0.5);
+}
+
+async function auditTouchTargets(page: Page): Promise<TouchAudit> {
+  return page.evaluate(() => {
+    const selector = [
+      "a[href]",
+      "button",
+      "input:not([type='hidden'])",
+      "textarea",
+      "select",
+      "summary",
+      "[role='button']",
+      "[role='link']",
+      "[role='tab']",
+    ].join(",");
+    const minimum = 44;
+    const tolerance = 0.5;
+    const failures: string[] = [];
+    const exemptions: string[] = [];
+
+    function label(element: HTMLElement): string {
+      const text = (
+        element.getAttribute("aria-label") ??
+        element.innerText ??
+        element.getAttribute("placeholder") ??
+        element.getAttribute("title") ??
+        element.textContent ??
+        ""
+      )
+        .trim()
+        .replace(/\s+/g, " ")
+        .slice(0, 70);
+      return `${element.tagName.toLowerCase()}${text ? ` “${text}”` : ""}`;
+    }
+
+    function accessibleName(element: HTMLElement): string {
+      const labelledBy = element.getAttribute("aria-labelledby");
+      const labelledText = labelledBy
+        ?.split(/\s+/)
+        .map((id) => document.getElementById(id)?.textContent ?? "")
+        .join(" ");
+      const controlLabels =
+        element instanceof HTMLInputElement ||
+        element instanceof HTMLTextAreaElement ||
+        element instanceof HTMLSelectElement
+          ? [...element.labels].map((item) => item.textContent ?? "").join(" ")
+          : "";
+      return (
+        [
+          element.getAttribute("aria-label"),
+          labelledText,
+          controlLabels,
+          element.innerText,
+          element.getAttribute("title"),
+        ].find((candidate) => candidate?.trim()) ?? ""
+      ).trim();
+    }
+
+    function isRendered(element: HTMLElement): boolean {
+      const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      return (
+        rect.width > 0 &&
+        rect.height > 0 &&
+        style.display !== "none" &&
+        style.visibility !== "hidden" &&
+        !element.closest("[hidden], [inert], [aria-hidden='true']") &&
+        !element.classList.contains("sr-only")
+      );
+    }
+
+    function effectiveRect(element: HTMLElement): DOMRect {
+      if (element instanceof HTMLInputElement && ["checkbox", "radio"].includes(element.type)) {
+        const wrappingLabel = element.closest("label");
+        const explicitLabel = element.id
+          ? document.querySelector<HTMLLabelElement>(`label[for=${CSS.escape(element.id)}]`)
+          : null;
+        return (wrappingLabel ?? explicitLabel)?.getBoundingClientRect() ?? element.getBoundingClientRect();
+      }
+      return element.getBoundingClientRect();
+    }
+
+    const targets = [...document.querySelectorAll<HTMLElement>(selector)].filter(
+      (element, index, all) => all.indexOf(element) === index && isRendered(element),
+    );
+    const auditedTargets: Array<{ element: HTMLElement; rect: DOMRect }> = [];
+
+    for (const element of targets) {
+      if (!accessibleName(element)) {
+        failures.push(`${label(element)} has no accessible name`);
+      }
+
+      const exemption = element.dataset.touchTargetExempt;
+      if (exemption) {
+        const style = getComputedStyle(element);
+        const validInlineText =
+          exemption === "inline-text" &&
+          element.tagName === "A" &&
+          style.display === "inline" &&
+          element.closest(".zuuli-markdown") !== null &&
+          element.textContent?.trim() !== "" &&
+          element.querySelector("img, svg, video, audio") === null;
+        if (!validInlineText) {
+          failures.push(`${label(element)} has invalid touch-target exemption “${exemption}”`);
+        } else {
+          exemptions.push(label(element));
+        }
+        continue;
+      }
+
+      // The contract measures the real layout box. ZUULI deliberately does
+      // not use pseudo-elements to expand hit areas beyond those boxes.
+      const rect = effectiveRect(element);
+      auditedTargets.push({ element, rect });
+      if (rect.width < minimum - tolerance || rect.height < minimum - tolerance) {
+        failures.push(
+          `${label(element)} is ${rect.width.toFixed(1)}×${rect.height.toFixed(1)}px`,
+        );
+      }
+    }
+
+    for (let index = 0; index < auditedTargets.length; index += 1) {
+      const first = auditedTargets[index];
+      for (let otherIndex = index + 1; otherIndex < auditedTargets.length; otherIndex += 1) {
+        const second = auditedTargets[otherIndex];
+        if (
+          !first.element.classList.contains("min-tap") ||
+          !second.element.classList.contains("min-tap") ||
+          first.element.parentElement !== second.element.parentElement ||
+          first.element.contains(second.element) ||
+          second.element.contains(first.element) ||
+          [first.element, second.element].some((element) =>
+            ["absolute", "fixed"].includes(getComputedStyle(element).position),
+          )
+        ) {
+          // This assertion targets adjacent controls whose actual box was
+          // expanded by `min-tap`. Nested controls and absolutely positioned
+          // controls such as an input's clear button are deliberate compound
+          // widgets rather than adjacent siblings.
+          continue;
+        }
+        const overlapWidth =
+          Math.min(first.rect.right, second.rect.right) -
+          Math.max(first.rect.left, second.rect.left);
+        const overlapHeight =
+          Math.min(first.rect.bottom, second.rect.bottom) -
+          Math.max(first.rect.top, second.rect.top);
+        if (overlapWidth > tolerance && overlapHeight > tolerance) {
+          failures.push(
+            `${label(first.element)} overlaps ${label(second.element)} by ${overlapWidth.toFixed(1)}×${overlapHeight.toFixed(1)}px`,
+          );
+        }
+      }
+    }
+
+    return {
+      failures: [...new Set(failures)].slice(0, 50),
+      exemptions: [...new Set(exemptions)],
+      targets: targets.length,
+    };
+  });
+}
+
+for (const signedIn of [false, true]) {
+  for (const width of TOUCH_WIDTHS) {
+    test(`${signedIn ? "signed in" : "signed out"} touch targets fit at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 760 });
+      await setSession(page, signedIn);
+      const routeFailures: string[] = [];
+
+      for (const route of ROUTES) {
+        await page.goto(route);
+        await page.locator("[data-app-frame]").waitFor();
+        await page.waitForTimeout(500);
+
+        const audit = await auditTouchTargets(page);
+        expect(audit.targets, `${route} must expose audited controls`).toBeGreaterThan(0);
+        routeFailures.push(...audit.failures.map((failure) => `${route}: ${failure}`));
+      }
+
+      await page.goto("/buy");
+      for (const tab of ["Send & Tip", "Activity"]) {
+        await page.getByRole("tab", { name: tab }).click();
+        routeFailures.push(
+          ...(await auditTouchTargets(page)).failures.map(
+            (failure) => `/buy?tab=${tab.toLowerCase().replaceAll(" ", "-")}: ${failure}`,
+          ),
+        );
+      }
+
+      await page.goto("/articles");
+      await page
+        .getByRole("searchbox", { name: "Search articles" })
+        .fill("a long semantic article query that reaches the trailing control");
+      await expectEditableTextClearsButton(page, "Search articles");
+      routeFailures.push(
+        ...(await auditTouchTargets(page)).failures.map(
+          (failure) => `/articles?search=long: ${failure}`,
+        ),
+      );
+
+      await page.goto("/search?q=zcash");
+      await page
+        .getByRole("searchbox", { name: "Search creators and pages" })
+        .fill("a long creator and page query that reaches the trailing control");
+      await expectEditableTextClearsButton(page, "Search creators and pages");
+      await page.getByRole("tab", { name: /Pages/ }).click();
+      routeFailures.push(
+        ...(await auditTouchTargets(page)).failures.map(
+          (failure) => `/search?q=zcash&tab=pages: ${failure}`,
+        ),
+      );
+
+      if (signedIn) {
+        await page.goto("/");
+        await page.getByRole("button", { name: "Account menu" }).click();
+        routeFailures.push(
+          ...(await auditTouchTargets(page)).failures.map(
+            (failure) => `/?menu=account: ${failure}`,
+          ),
+        );
+      }
+
+      await page.goto("/login");
+      await page.getByRole("button", { name: "Continue with Zcash" }).click();
+      routeFailures.push(
+        ...(await auditTouchTargets(page)).failures.map(
+          (failure) => `/login?method=zcash: ${failure}`,
+        ),
+      );
+      expect(routeFailures, "mobile routes have undersized touch targets").toEqual([]);
+    });
+  }
+}


### PR DESCRIPTION
Closes #394

## Summary

- enforce the existing 44×44 CSS-pixel mobile target contract in shared buttons, inputs, tabs, and the explicitly audited wallet, article, live, AI, auth, buy, creator, home, KYC, search, navigation, and fallback controls
- retain compact visual treatment while using real layout boxes, preserving accessible names and adding focus-visible treatment to direct native controls
- allocate the seven mobile destinations with equal zero-minimum grid tracks and compact contained labels, retaining full accessible names so Linux font metrics and future long labels cannot shrink or paint across neighboring targets
- keep prose links inline through one narrowly validated data-touch-target-exempt="inline-text" marker accepted only for text-only inline anchors inside rendered ZUULI Markdown
- add a real-browser matrix at 320 and 360 CSS px in signed-out and mock signed-in states across 19 routes plus Buy tabs, Search Pages, the account menu, and the Zcash auth chooser
- reject undersized or unnamed controls and adjacent sibling min-tap boxes that overlap; the existing viewport matrix independently rejects descendant and page overflow

## Verification

Final head: 62d43f8ccdfe0940c2e875afc6f67178ed794a18
Base verified: ab61ac958e72451db648009b12545fcad4618ad7

- npm test: 19 Vitest files / 240 tests, 5 safe-area Node tests, and 13 Playwright cases passed
  - touch matrix: signed out and signed in at 320 and 360, all 4 passed
  - viewport matrix: signed out and signed in at 320, 360, 390, and 414 plus checkout return, all 9 passed
- isolated Ubuntu 24.04 Playwright 1.62.1 container: all four signed-out/in 320/360 touch cases passed
- npm run typecheck: passed
- npm run build: passed (existing chunk-size advisory only)
- git diff --check: passed
- worktree clean; no TopBar diff from main, and the merged #401 signed-in header passes the 320/360 target contract

## Hosted Linux finding and disposition

The first hosted run measured Search, AI, Articles, Wallet, and Buy bottom-nav anchors at 43.2×55px on Linux at 320px because intrinsic label widths distorted flex allocation. The fix does not change the 44px assertion or its tolerance: the bar now uses seven equal grid tracks, every target has min-w-0 and min-tap, compact visual labels are contained within their track, and each link retains its full aria-label. The final isolated Linux matrix passes the same four 320/360 auth cases.

## Adversarial review

- found and fixed a 40px TabsList container around 44px triggers by making the container at least 44px and content-sized
- found and fixed a test gap where non-overlap was documented but not asserted; adjacent expanded min-tap siblings are now measured and rejected on intersection
- found and fixed Linux intrinsic-label width coupling in the flex bottom bar; equal grid allocation and contained labels preserve target width and prevent localized text overlap
- absolute controls embedded in compound fields are excluded only from the sibling-overlap check; they remain subject to the 44×44 size, accessible-name, and viewport-overflow contracts
- found and fixed trailing clear-button overlap with editable text by reserving each 44px target plus its inset; long-query browser geometry now asserts the editable content edge ends before the control at 320/360 in both auth states
- no remaining findings


