### PR TITLE
ci(zuuli): consume immutable Linux build image

### DIFF
--- a/.github/containers/zuuli-linux/image.lock
+++ b/.github/containers/zuuli-linux/image.lock
@@ -1,6 +1,6 @@
 schema_version=1
-phase=bootstrap
+phase=consumed
 repository=ghcr.io/free2z/zuuli-linux-ci
 base_digest=sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316
-image_digest=UNPUBLISHED
+image_digest=sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1
 source_sha256=13eb98f352e0e3d1198f30abe333d289f504ae5cacef01cb83b21c1f7e030056

--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -291,18 +291,38 @@ jobs:
           - name: Linux packages
             os: ubuntu-24.04
             bundles: appimage,deb,rpm
+            container: ghcr.io/free2z/zuuli-linux-ci@sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1
           - name: macOS universal app
             os: macos-26
             bundles: app,dmg
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ${{ matrix.container }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     defaults:
       run:
         working-directory: wallet/zuuli
+        shell: bash
     steps:
+      - name: Verify pinned Linux build image
+        if: runner.os == 'Linux'
+        working-directory: /
+        run: |
+          set -euo pipefail
+          /usr/local/bin/verify-zuuli-linux-image
+          test -n "$BASH_VERSION"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Configure exact Git workspace trust
+        if: runner.os == 'Linux'
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Fetch librustzcash
         run: git submodule update --init z/zcash/librustzcash
         working-directory: .
@@ -317,14 +337,6 @@ jobs:
       - name: Install macOS universal Rust targets
         if: runner.os == 'macOS'
         run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
-      - name: Install Linux package dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev \
-            libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev libxdo-dev libdbus-1-dev \
-            libssl-dev build-essential file pkg-config rpm
       - name: Select and verify Xcode
         if: runner.os == 'macOS'
         run: |
@@ -353,6 +365,9 @@ jobs:
           else
             ./node_modules/.bin/tauri build --bundles '${{ matrix.bundles }}' -- --locked
           fi
+      - name: Verify generated projects remain clean
+        run: git diff --exit-code
+        working-directory: .
       - name: Collect packages
         run: |
           mkdir release-artifacts
@@ -364,7 +379,13 @@ jobs:
             test -n "$app"
             ditto -c -k --keepParent "$app" release-artifacts/ZUULI-macos-universal-unsigned.zip
           fi
-          test -n "$(find release-artifacts -type f -print -quit)"
+          if [[ "${{ runner.os }}" == Linux ]]; then
+            for extension in AppImage deb rpm; do
+              test -n "$(find release-artifacts -type f -name "*.$extension" -size +0c -print -quit)"
+            done
+          else
+            test -n "$(find release-artifacts -type f -print -quit)"
+          fi
       - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
           syft-version: v1.50.0

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -558,18 +558,33 @@ jobs:
     timeout-minutes: 120
     permissions:
       contents: read
+      packages: read
       id-token: write
       attestations: write
+    container:
+      image: ghcr.io/free2z/zuuli-linux-ci@sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     defaults:
       run:
         working-directory: wallet/zuuli
+        shell: bash
     steps:
+      - name: Verify pinned Linux build image
+        working-directory: /
+        run: |
+          set -euo pipefail
+          /usr/local/bin/verify-zuuli-linux-image
+          test -n "$BASH_VERSION"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
+      - name: Configure exact Git workspace trust
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Fetch origin/main for release verification
         run: git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
         working-directory: .
@@ -583,12 +598,6 @@ jobs:
           }
       - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with: { toolchain: "${{ env.ZUULI_RUST_VERSION }}" }
-      - name: Install package dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
-            librsvg2-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libxdo-dev libdbus-1-dev \
-            libssl-dev build-essential file pkg-config rpm
       - name: Restore reviewed Linux Rust dependencies
         uses: ./.github/actions/zuuli-rust-cache
         with:
@@ -608,7 +617,9 @@ jobs:
           mkdir release-artifacts
           find src-tauri/target -path '*/release/bundle/*' -type f \
             \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \) -exec cp {} release-artifacts/ \;
-          test -n "$(find release-artifacts -type f -print -quit)"
+          for extension in AppImage deb rpm; do
+            test -n "$(find release-artifacts -type f -name "*.$extension" -size +0c -print -quit)"
+          done
       - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
           {

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -71,7 +71,7 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|z/zcash/librustzcash|.gitmodules|.github/workflows/zuuli.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
                 zuuli=true
                 ;;
             esac
@@ -227,26 +227,30 @@ jobs:
     if: needs.changes.outputs.zuuli == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/free2z/zuuli-linux-ci@sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
     steps:
+      - name: Verify pinned Linux build image
+        working-directory: /
+        run: |
+          set -euo pipefail
+          /usr/local/bin/verify-zuuli-linux-image
+          test -n "$BASH_VERSION"
       - uses: actions/checkout@v7
+      - name: Configure exact Git workspace trust
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Fetch librustzcash submodule
         run: git submodule update --init z/zcash/librustzcash
-
-      - name: Install Tauri system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev \
-            libxdo-dev \
-            libdbus-1-dev \
-            libssl-dev \
-            build-essential curl wget file pkg-config
 
       - name: Resolve the pinned Rust toolchain
         id: rust_toolchain
@@ -280,27 +284,31 @@ jobs:
     if: needs.changes.outputs.zuuli == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/free2z/zuuli-linux-ci@sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
     steps:
+      - name: Verify pinned Linux build image
+        working-directory: /
+        run: |
+          set -euo pipefail
+          /usr/local/bin/verify-zuuli-linux-image
+          test -n "$BASH_VERSION"
       - uses: actions/checkout@v7
+      - name: Configure exact Git workspace trust
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       # Fetch only the in-source dependency required by the app/plugin graph.
       - name: Fetch librustzcash submodule
         run: git submodule update --init z/zcash/librustzcash
-
-      - name: Install Tauri system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev \
-            libxdo-dev \
-            libdbus-1-dev \
-            libssl-dev \
-            build-essential curl wget file pkg-config
 
       # Keep CI explicit as well as repository-pinned so runner state cannot
       # silently select a newer compiler. The version is read from
@@ -333,26 +341,30 @@ jobs:
     if: needs.changes.outputs.zuuli == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/free2z/zuuli-linux-ci@sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
     steps:
+      - name: Verify pinned Linux build image
+        working-directory: /
+        run: |
+          set -euo pipefail
+          /usr/local/bin/verify-zuuli-linux-image
+          test -n "$BASH_VERSION"
       - uses: actions/checkout@v7
+      - name: Configure exact Git workspace trust
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Fetch librustzcash submodule
         run: git submodule update --init z/zcash/librustzcash
-
-      - name: Install Tauri system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev \
-            libxdo-dev \
-            libdbus-1-dev \
-            libssl-dev \
-            build-essential curl wget file pkg-config
 
       - name: Resolve the pinned Rust toolchain
         id: rust_toolchain

--- a/docs/ZUULI-LINUX-BUILD-IMAGE.md
+++ b/docs/ZUULI-LINUX-BUILD-IMAGE.md
@@ -5,10 +5,10 @@ development libraries that are not part of GitHub's Ubuntu runner image. The
 repo-owned `ghcr.io/free2z/zuuli-linux-ci` image turns that mutable apt setup
 into a reviewed, content-addressed OS dependency layer.
 
-This document covers the two-phase bootstrap tracked in #407. The application,
+This document records the two-phase rollout tracked in #407. The application,
 Rust dependency graph and release credentials never belong in this image.
 
-## Phase A: publish, but do not consume
+## Phase A: published and attested
 
 The source lives in `.github/containers/zuuli-linux/`:
 
@@ -16,8 +16,7 @@ The source lives in `.github/containers/zuuli-linux/`:
 - `packages.txt` is the complete reviewed package manifest.
 - `verify-inventory.sh` proves the OS, architecture, native `pkg-config`
   surface, AppImage execution mode and absence of Rust/source/cache state.
-- `image.lock` binds those sources together. `UNPUBLISHED` is intentional until
-  the first post-merge image exists.
+- `image.lock` binds those sources to the promoted registry digest.
 
 `.github/workflows/zuuli-linux-image.yml` validates every pull request and
 performs a real amd64 Docker build plus inventory check. A push to `main`, a
@@ -25,39 +24,37 @@ Wednesday schedule, or a manual run from `main` publishes two convenience tags
 and records the immutable digest. BuildKit attaches an OCI SBOM and maximal
 provenance; GitHub also publishes a registry attestation for that digest.
 
-The ordinary required `wallet/zuuli` workflow still runs on a Phase A pull
-request, but its checked-out diff does not classify this isolated bootstrap
-surface as a release-impacting wallet change. Its fail-closed base/diff checks
-and Rust-toolchain consistency check still run; the existing apt-heavy wallet
-jobs legitimately skip. The dedicated image workflow is the authoritative
-Phase A test. Do not add these bootstrap paths to the full-wallet change filter
-before an immutable image can replace its apt steps.
+The first published image was built from `da58e6567698a173db6cf8bf64c8dcab23f9c5fa`.
+[GitHub attestation 41577363](https://github.com/free2z/zuu/attestations/41577363)
+binds the untagged subject
+`ghcr.io/free2z/zuuli-linux-ci` to digest
+`sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1`,
+the main-branch image workflow, and a GitHub-hosted runner.
 
-## Phase B: pin and consume
+## Phase B: digest-pinned consumers
 
-After Phase A merges and the publish job succeeds:
+Exactly five Linux consumers use the promoted digest: the required lint,
+standalone plugin, and ZUULI backend jobs; the Linux packaging smoke matrix
+entry; and the protected Linux release job. macOS, Android, iOS, lightweight
+format/supply-chain jobs, and all store-upload jobs remain on their native
+runners.
 
-1. Record `ghcr.io/free2z/zuuli-linux-ci@sha256:<digest>` from the job summary.
-2. Verify the registry SBOM and provenance/attestation for that exact digest.
-3. In a separate PR, change `image.lock` from `bootstrap`/`UNPUBLISHED` to the
-   reviewed digest and switch only the Linux consumers named in #407.
-4. Give each consumer `packages: read` and job-level `container.credentials`
-   using `github.actor` and `secrets.GITHUB_TOKEN`; the runner pulls a job
-   container before any login step can run. The OCI source label links the
-   package to this repository, but confirm the new package inherited Actions
-   access because an organization can disable automatic inheritance. Public
-   visibility is optional, not assumed.
-5. Remove their live apt steps, retain the inventory check as their first
-   command, then install and verify the Rust version selected by
-   `wallet/rust-toolchain.toml` exactly as today.
-6. Add a hosted job-container smoke test using the exact digest. It must run
-   checkout and setup actions plus explicit Bash commands before proving clean
-   Rust builds and real AppImage, deb and RPM packages. Never consume
-   `ubuntu-24.04` or another mutable tag.
+GHCR keeps the package private. Each consumer therefore grants only
+`packages: read` and supplies `github.actor` plus `secrets.GITHUB_TOKEN` as
+job-level `container.credentials`; the runner must authenticate before any
+step exists. The image inventory and Bash smoke are the first step, followed by
+checkout, an immediate exact-workspace Git ownership exception, and setup
+actions. This proves the runner-provided JavaScript action runtime works inside
+the minimal image without granting broad `safe.directory` trust. Rust still
+comes exclusively from the pinned toolchain action and
+`wallet/rust-toolchain.toml`.
 
-The first consumer PR must extend `scripts/check-zuuli-linux-image.mjs` so every
-consumer references the one locked digest and a mutable/mismatched reference is
-rejected. Until then, the validator rejects every consumer reference.
+`scripts/check-zuuli-linux-image.mjs` enforces the consumed lock state, exactly
+five identical digest references, pull-time credentials, packages-read scope,
+the inventory-first contract, explicit Bash, and absence of live apt commands.
+Its negative tests reject mutable tags, digest skew, missing credentials,
+reordered inventory, missing or broad Git ownership trust, and policy paths
+that no longer select the full required gate.
 
 ## Rebuild, promotion and rollback
 
@@ -69,9 +66,10 @@ provenance record; they do not move consumers automatically. The
 through a PR that reviews the inventory/security delta and passes all consumer
 smoke tests.
 
-Rollback is a one-line digest change through the same reviewed PR path. Keep
-the previous known-good digest in GHCR until its replacement has completed at
-least two main-branch gates and a packaging canary. GHCR access uses the
+Rollback promotes the previous digest through the same reviewed PR path,
+updating the lock, validator binding, and every consumer together. Keep the
+previous known-good digest in GHCR until its replacement has completed at least
+two main-branch gates and a packaging canary. GHCR access uses the
 workflow-scoped `GITHUB_TOKEN`; no registry password or release credential is
 stored in the image or repository.
 

--- a/scripts/check-zuuli-linux-image.mjs
+++ b/scripts/check-zuuli-linux-image.mjs
@@ -24,6 +24,9 @@ const consumerWorkflows = [
   ".github/workflows/zuuli-release.yml",
 ];
 const imageRepository = "ghcr.io/free2z/zuuli-linux-ci";
+const lockedImageDigest = "sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1";
+const lockedImage = `${imageRepository}@${lockedImageDigest}`;
+const expectedConsumerCount = 5;
 const phaseATriggerPaths = [
   ".github/containers/zuuli-linux",
   ".github/workflows/zuuli-linux-image.yml",
@@ -125,6 +128,44 @@ function shellPatternMatches(pattern, path) {
   return new RegExp(`^${regex}$`).test(path);
 }
 
+function countOccurrences(contents, value) {
+  return contents.split(value).length - 1;
+}
+
+function workflowJobs(contents, workflow) {
+  const starts = [...contents.matchAll(/^  ([a-zA-Z0-9_-]+):\s*$/gm)];
+  return starts.map((match, index) => ({
+    name: `${workflow}:${match[1]}`,
+    contents: contents.slice(match.index, starts[index + 1]?.index ?? contents.length),
+  }));
+}
+
+function validateConsumerJob(job, failures) {
+  const exactTrust = 'git config --global --add safe.directory "$GITHUB_WORKSPACE"';
+  const inventoryFirst = job.contents.match(/steps:\s*\n\s*- name: Verify pinned Linux build image/);
+  if (!inventoryFirst) {
+    failures.push(`${job.name}: image inventory and Bash smoke must be the first step`);
+  }
+  if (countOccurrences(job.contents, "working-directory: /") !== 1) {
+    failures.push(`${job.name}: pre-checkout inventory must run from an existing absolute directory`);
+  }
+  if (countOccurrences(job.contents, "- name: Configure exact Git workspace trust") !== 1 ||
+      countOccurrences(job.contents, exactTrust) !== 1 ||
+      countOccurrences(job.contents, "safe.directory") !== 1) {
+    failures.push(`${job.name}: require one narrow exact-workspace Git ownership trust step`);
+    return;
+  }
+
+  const lines = job.contents.split("\n");
+  const trustIndex = lines.findIndex((line) => line.trim() === "- name: Configure exact Git workspace trust");
+  const stepIndent = lines[trustIndex].match(/^\s*/)[0];
+  let previousStep = trustIndex - 1;
+  while (previousStep >= 0 && !lines[previousStep].startsWith(`${stepIndent}- `)) previousStep -= 1;
+  if (previousStep < 0 || !lines[previousStep].trim().startsWith("- uses: actions/checkout@")) {
+    failures.push(`${job.name}: exact-workspace trust must immediately follow checkout`);
+  }
+}
+
 function validate(root) {
   const failures = [];
   const dockerfile = read(root, `${contextDir}/Dockerfile`);
@@ -136,10 +177,10 @@ function validate(root) {
   const workflow = read(root, workflowPath);
 
   if (lock.get("schema_version") !== "1") failures.push("image.lock: schema_version must be 1");
-  if (lock.get("phase") !== "bootstrap") failures.push("image.lock: Phase A must remain bootstrap");
+  if (lock.get("phase") !== "consumed") failures.push("image.lock: Phase B must be consumed");
   if (lock.get("repository") !== imageRepository) failures.push("image.lock: unexpected repository");
-  if (lock.get("image_digest") !== "UNPUBLISHED") {
-    failures.push("image.lock: Phase A image_digest must be UNPUBLISHED");
+  if (lock.get("image_digest") !== lockedImageDigest) {
+    failures.push("image.lock: image_digest must match the reviewed published digest");
   }
   if (!/^sha256:[0-9a-f]{64}$/.test(lock.get("base_digest") ?? "")) {
     failures.push("image.lock: base_digest must be an immutable sha256 digest");
@@ -241,8 +282,8 @@ function validate(root) {
   } else {
     const gatePatterns = gatePatternMatch[1].split("|").map((pattern) => pattern.trim());
     for (const phaseAPath of phaseASamplePaths) {
-      if (gatePatterns.some((pattern) => shellPatternMatches(pattern, phaseAPath))) {
-        failures.push(`required gate: bootstrap path unexpectedly selects full wallet jobs: ${phaseAPath}`);
+      if (!gatePatterns.some((pattern) => shellPatternMatches(pattern, phaseAPath))) {
+        failures.push(`required gate: consumed-image policy path must select full wallet jobs: ${phaseAPath}`);
       }
     }
   }
@@ -255,11 +296,40 @@ function validate(root) {
       failures.push(`image workflow: bootstrap path is not covered: ${phaseAPath}`);
     }
   }
-  for (const consumer of consumerWorkflows) {
-    const contents = read(root, consumer);
-    if (contents.includes(imageRepository)) {
-      failures.push(`${consumer}: Phase A must not consume the unpublished image`);
+  const workflowContents = consumerWorkflows.map((consumer) => [consumer, read(root, consumer)]);
+  const consumerContents = workflowContents.map(([, contents]) => contents).join("\n");
+  if (countOccurrences(consumerContents, lockedImage) !== expectedConsumerCount) {
+    failures.push(`consumers: expected ${expectedConsumerCount} references to the one locked image digest`);
+  }
+  const imageReferences = [...consumerContents.matchAll(/ghcr\.io\/free2z\/zuuli-linux-ci(?:@sha256:[0-9a-f]+|:[^\s'"}]+)/g)]
+    .map((match) => match[0]);
+  for (const reference of imageReferences) {
+    if (reference !== lockedImage) failures.push(`consumers: mutable or mismatched image reference: ${reference}`);
+  }
+  if (/^\s*(?:- run:\s*)?(?:sudo\s+)?apt(?:-get)?\s/m.test(consumerContents)) {
+    failures.push("consumers: live apt commands are forbidden after digest promotion");
+  }
+  for (const [name, value] of [
+    ["packages: read permissions", "packages: read"],
+    ["pull-time usernames", "username: ${{ github.actor }}"],
+    ["pull-time credentials", "password: ${{ secrets.GITHUB_TOKEN }}"],
+    ["Bash defaults", "shell: bash"],
+    ["inventory invocations", "/usr/local/bin/verify-zuuli-linux-image"],
+  ]) {
+    if (countOccurrences(consumerContents, value) < expectedConsumerCount) {
+      failures.push(`consumers: missing ${name}`);
     }
+  }
+  const consumerJobs = workflowContents
+    .flatMap(([workflow, contents]) => workflowJobs(contents, workflow))
+    .filter((job) => job.contents.includes(lockedImage));
+  if (consumerJobs.length !== expectedConsumerCount) {
+    failures.push(`consumers: expected ${expectedConsumerCount} digest-pinned job blocks`);
+  }
+  for (const job of consumerJobs) validateConsumerJob(job, failures);
+  if (countOccurrences(consumerContents, "for extension in AppImage deb rpm") < 2 ||
+      countOccurrences(consumerContents, "-size +0c") < 2) {
+    failures.push("consumers: packaging and release must require nonempty AppImage, deb, and rpm artifacts");
   }
 
   return failures;
@@ -284,9 +354,9 @@ function runSelfTest() {
 
     const cases = [
       {
-        name: "mutable image reference",
+        name: "mismatched lock digest",
         path: lockPath,
-        mutate: (value) => value.replace("image_digest=UNPUBLISHED", "image_digest=latest"),
+        mutate: (value) => value.replace(lockedImageDigest, `${lockedImageDigest.slice(0, -1)}0`),
         expected: "image_digest",
       },
       {
@@ -302,16 +372,22 @@ function runSelfTest() {
         expected: "missing libwebkit2gtk-4.1-dev",
       },
       {
-        name: "premature consumer",
+        name: "mutable consumer image",
         path: consumerWorkflows[0],
-        mutate: (value) => `${value}\n# ${imageRepository}:latest\n`,
-        expected: "must not consume",
+        mutate: (value) => value.replace(lockedImage, `${imageRepository}:ubuntu-24.04`),
+        expected: "mutable or mismatched",
       },
       {
-        name: "overbroad required-gate pattern",
+        name: "mismatched consumer digest",
         path: consumerWorkflows[0],
-        mutate: (value) => value.replace("scripts/check-rust-clippy.sh|", "scripts/*|"),
-        expected: "bootstrap path unexpectedly selects",
+        mutate: (value) => value.replace(lockedImageDigest, `${lockedImageDigest.slice(0, -1)}0`),
+        expected: "one locked image digest",
+      },
+      {
+        name: "missing required-gate policy path",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace("scripts/check-zuuli-linux-image.mjs|", ""),
+        expected: "policy path must select",
       },
       {
         name: "fail-open required-gate fallback",
@@ -330,6 +406,72 @@ function runSelfTest() {
           "subject-digest: sha256:deadbeef",
         ),
         expected: "subject-digest",
+      },
+      {
+        name: "reintroduced live apt",
+        path: consumerWorkflows[0],
+        mutate: (value) => `${value}\n      - run: apt-get update\n`,
+        expected: "live apt commands",
+      },
+      {
+        name: "missing pull-time credential",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace("password: ${{ secrets.GITHUB_TOKEN }}", "password: missing"),
+        expected: "pull-time credentials",
+      },
+      {
+        name: "inventory is not first",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace("steps:\n      - name: Verify pinned Linux build image", "steps:\n      - run: true\n      - name: Verify pinned Linux build image"),
+        expected: "must be the first step",
+      },
+      {
+        name: "pre-checkout inventory uses a missing workspace",
+        path: consumerWorkflows[1],
+        mutate: (value) => value.replace("working-directory: /", "working-directory: wallet/zuuli"),
+        expected: "pre-checkout inventory",
+      },
+      {
+        name: "wildcard Git ownership trust",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace(
+          'git config --global --add safe.directory "$GITHUB_WORKSPACE"',
+          "git config --global --add safe.directory '*'",
+        ),
+        expected: "narrow exact-workspace Git ownership trust",
+      },
+      {
+        name: "broad Git ownership trust",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace(
+          'git config --global --add safe.directory "$GITHUB_WORKSPACE"',
+          'git config --global --add safe.directory "/__w"',
+        ),
+        expected: "narrow exact-workspace Git ownership trust",
+      },
+      {
+        name: "missing Git ownership trust",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace(
+          '      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"\n',
+          "",
+        ),
+        expected: "narrow exact-workspace Git ownership trust",
+      },
+      {
+        name: "Git ownership trust moved before checkout",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace(
+          '      - uses: actions/checkout@v7\n      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"',
+          '      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"\n      - uses: actions/checkout@v7',
+        ),
+        expected: "must immediately follow checkout",
+      },
+      {
+        name: "missing package format acceptance",
+        path: consumerWorkflows[1],
+        mutate: (value) => value.replace("for extension in AppImage deb rpm", "for extension in AppImage deb"),
+        expected: "nonempty AppImage, deb, and rpm",
       },
     ];
 


### PR DESCRIPTION
Closes #407.

## What changed

- Promote the Phase A image lock to `consumed` at the reviewed digest.
- Run the three apt-using wallet Rust jobs, Linux packaging smoke, and protected Linux release build in authenticated job-level containers.
- Remove live apt only from those five consumers while preserving pinned Rust, credential-free caches, and locked builds.
- Require image inventory/Bash before checkout, then exact-workspace Git trust before any submodule/Git command; wildcard or broad trust is forbidden.
- Require nonempty AppImage, deb, and rpm outputs in both packaging and release workflows.
- Make image-policy changes select the fail-closed full ZUULI gate.
- Extend validation with exact-consumer/digest/auth/order/artifact checks and 17 negative cases.

## Reviewed image

- Digest: `ghcr.io/free2z/zuuli-linux-ci@sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1`
- Provenance: https://github.com/free2z/zuu/attestations/41577363
- Phase A source commit: `da58e6567698a173db6cf8bf64c8dcab23f9c5fa`

The package is private. Hosted jobs authenticate at container pull time with narrowly scoped `packages: read`; successful initialization in all five consumer paths proves repository Actions access. The image contains no Rust toolchain: every consumer installs and verifies Rust 1.97.1 separately.

## Acceptance evidence for exact head

Exact head: `c6952bf0678ab782d0dca22607e518cd1774dad5`.

- First clean wallet run: [32244331651](https://github.com/free2z/zuu/actions/runs/32244331651), all three container Rust jobs and aggregate gate green.
- Second clean unchanged-head wallet run: [32244677485](https://github.com/free2z/zuu/actions/runs/32244677485), all three container Rust jobs and aggregate gate green. Container jobs: lints [96042572172](https://github.com/free2z/zuu/actions/runs/32244677485/job/96042572172), plugin [96042572974](https://github.com/free2z/zuu/actions/runs/32244677485/job/96042572974), backend [96042572261](https://github.com/free2z/zuu/actions/runs/32244677485/job/96042572261).
- Packaging smoke: [32244331658](https://github.com/free2z/zuu/actions/runs/32244331658), including Linux [96041473284](https://github.com/free2z/zuu/actions/runs/32244331658/job/96041473284) and unchanged macOS/iOS/Android jobs, all green. Linux artifact `9362318338` is 119,839,217 bytes and contains nonempty AppImage (89,262,584), deb (15,572,804), and rpm (15,573,596) bundles plus SBOM/checksums/provenance.
- Protected release-path dry run: [32244481921](https://github.com/free2z/zuu/actions/runs/32244481921), Linux job [96042025544](https://github.com/free2z/zuu/actions/runs/32244481921/job/96042025544) green through inventory, exact workspace trust, origin/main source re-verification, pinned Rust 1.97.1, literal `tauri build --bundles appimage,deb,rpm -- --locked`, clean diff, SBOM, provenance, attestation, and upload. Artifact `9362391940` is 119,826,880 bytes and contains AppImage (89,254,392), deb (15,571,624), rpm (15,571,709), and SBOM (1,619,628). The macOS job was rejected before any step solely because this feature branch cannot deploy to protected `zuuli-app-stores`; that expected governance result is not a code failure and no release/store mutation occurred.

No consumer contacted apt at runtime.

## Verification

- `node scripts/check-zuuli-linux-image.mjs --self-test` — pass, including 17 negative mutation cases.
- `shellcheck .github/containers/zuuli-linux/verify-inventory.sh` — pass.
- `actionlint .github/workflows/zuuli.yml .github/workflows/zuuli-packaging.yml` — pass.
- `scripts/check-rust-toolchain.sh --self-test` and `scripts/check-rust-toolchain.sh` — pass at Rust 1.97.1.
- `git diff --check origin/main...HEAD` — pass.
- Local amd64 image inventory/Bash/git/tar/no-Rust smoke — pass.
- Hosted image policy/build/inspect: [32244331650](https://github.com/free2z/zuu/actions/runs/32244331650) — pass.

## Adversarial review

- **Container permissions and credentials:** only `packages: read` plus pull-time actor/`GITHUB_TOKEN`; no registry login or persisted package credential.
- **Git trust:** one exact `$GITHUB_WORKSPACE` trust entry per container consumer, after checkout and before submodule/Git; validator rejects missing, reordered, wildcard, and broad trust.
- **Matrix/runtime behavior:** hosted Linux and macOS packaging jobs prove the matrix container expression, Linux-only bootstrap, checkout/setup actions, Bash, and cache runtime. macOS receives no container.
- **Cache policy:** existing credential-free Rust cache behavior is preserved; hosted cache restore/save/post steps completed inside the minimal image.
- **Release source:** the protected Linux dry run re-fetched and verified the selected origin/main commit before the exact locked release build.
- **Promotion/rollback:** one digest is bound across the consumed lock and all five jobs. Scheduled builds cannot auto-promote; rollback must atomically update lock, validator expectation, and consumers in a reviewed PR.

No unresolved implementation finding remains. This PR does not publish an image, release an app, or mutate either store.
