### PR TITLE
fix(zuuli): verify internal TestFlight delivery

### DIFF
--- a/.github/workflows/zuuli-testflight-recovery.yml
+++ b/.github/workflows/zuuli-testflight-recovery.yml
@@ -1,0 +1,130 @@
+name: ZUULI / TestFlight read-only recovery
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Exact full commit SHA that established the release identity
+        required: true
+        type: string
+      identity:
+        description: Exact version+build to inspect (for example 0.1.0+10)
+        required: true
+        default: 0.1.0+10
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize protected store reads with releases so an observation cannot race
+  # the relationship write/readback for another build.
+  group: zuuli-mobile-store
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    name: Verify exact build and internal group
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    environment: zuuli-app-stores
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    env:
+      ASC_KEY_ID: ${{ vars.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ vars.ASC_ISSUER_ID }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+      - name: Verify immutable release identity
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          CONFIRMED_IDENTITY: ${{ inputs.identity }}
+        run: |
+          set -euo pipefail
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "source SHA must be a full lowercase 40-character commit SHA" >&2
+            exit 1
+          }
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
+          identity_sha=$(git log -1 --format=%H "$SOURCE_SHA" -- release.json)
+          [[ "$identity_sha" == "$SOURCE_SHA" ]] || {
+            echo "source SHA must be the commit that established this release identity" >&2
+            exit 1
+          }
+          release_json=$(git show "${SOURCE_SHA}:wallet/zuuli/release.json")
+          jq -e '
+            (.schemaVersion == 1 or .schemaVersion == 2) and
+            .applicationId == "cash.free2z.zuuli" and
+            .iosUsesNonExemptEncryption == false and
+            (.version | type == "string") and
+            (.build | type == "number" and floor == . and . >= 1)
+          ' <<<"$release_json" >/dev/null
+          actual_identity=$(jq -r '.version + "+" + (.build | tostring)' <<<"$release_json")
+          [[ "$actual_identity" == "$CONFIRMED_IDENTITY" ]] || {
+            echo "confirmed identity does not match the immutable source" >&2
+            exit 1
+          }
+      - name: Verify read-only state machine offline
+        run: node --test scripts/asc-testflight.node-test.mjs
+      - name: Materialize ephemeral ASC credential
+        env:
+          ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
+          : "${ASC_KEY_ID:?ASC_KEY_ID is not configured}"
+          : "${ASC_ISSUER_ID:?ASC_ISSUER_ID is not configured}"
+          secret_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-asc-recovery.XXXXXX")
+          chmod 700 "$secret_dir"
+          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$secret_dir/AuthKey.p8"
+          chmod 600 "$secret_dir/AuthKey.p8"
+          test -s "$secret_dir/AuthKey.p8"
+          echo "ZUULI_ASC_RECOVERY_SECRET_DIR=$secret_dir" >> "$GITHUB_ENV"
+          echo "ASC_KEY_PATH=$secret_dir/AuthKey.p8" >> "$GITHUB_ENV"
+      - name: Observe exact TestFlight state without mutation
+        env:
+          CONFIRMED_IDENTITY: ${{ inputs.identity }}
+        run: |
+          set -euo pipefail
+          version=${CONFIRMED_IDENTITY%+*}
+          build=${CONFIRMED_IDENTITY##*+}
+          evidence_dir="$RUNNER_TEMP/zuuli-testflight-evidence"
+          mkdir -p "$evidence_dir"
+          echo "ZUULI_TESTFLIGHT_EVIDENCE_DIR=$evidence_dir" >> "$GITHUB_ENV"
+          node scripts/asc-testflight.mjs \
+            --read-only \
+            "--version=$version" \
+            "--build=$build" \
+            --timeout-seconds=1800 \
+            --poll-seconds=30 \
+            "--output=$evidence_dir/testflight-state.json"
+      - name: Destroy ephemeral ASC credential
+        if: always()
+        run: |
+          set -u
+          cleanup_failed=0
+          if [[ -n "${ZUULI_ASC_RECOVERY_SECRET_DIR:-}" && -d "$ZUULI_ASC_RECOVERY_SECRET_DIR" ]]; then
+            find "$ZUULI_ASC_RECOVERY_SECRET_DIR" -type f -exec rm -f -- {} + || cleanup_failed=1
+            rmdir "$ZUULI_ASC_RECOVERY_SECRET_DIR" || cleanup_failed=1
+          fi
+          if [[ -n "${ZUULI_ASC_RECOVERY_SECRET_DIR:-}" && -e "$ZUULI_ASC_RECOVERY_SECRET_DIR" ]]; then
+            cleanup_failed=1
+          fi
+          exit "$cleanup_failed"
+      - name: Upload sanitized recovery evidence
+        if: success()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: zuuli-testflight-${{ inputs.identity }}-${{ inputs.source_sha }}
+          path: ${{ env.ZUULI_TESTFLIGHT_EVIDENCE_DIR }}/testflight-state.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -71,7 +71,7 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
                 zuuli=true
                 ;;
             esac
@@ -109,6 +109,9 @@ jobs:
 
       - name: Test protected Play tester transaction
         run: npm run test:play-testers
+
+      - name: Test App Store Connect state machine
+        run: npm run test:asc-testflight
 
       # The current lockfile has moderate advisories but no high/critical ones.
       # Dependency upgrades belong in focused PRs; this gate prevents severity

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -78,10 +78,13 @@ repeat bootstrap work or substitute unrelated credentials.
    Distribution certificate, and profile `ZUULI App Store CI`. CI verifies the
    profile's team, application identifier, UUID, and certificate linkage before
    it signs.
-4. Add internal TestFlight testers and complete the beta metadata after Apple
-   processes the first upload. The exempt-encryption declaration described below
-   is embedded in each package; do not answer the same question differently in
-   App Store Connect.
+4. Maintain exactly one internal TestFlight group named `ZUULI Internal Testers`.
+   The name and internal-only requirement are fixed in
+   `scripts/asc-testflight.mjs`; the release refuses a missing, duplicate, or
+   external group. Group membership remains an owner-managed App Store Connect
+   concern. Automation never reads or logs tester resources or email addresses.
+   The exempt-encryption declaration described below is embedded in each package;
+   do not answer the same question differently in App Store Connect.
 
 ### Google Play (Corpora)
 
@@ -125,6 +128,9 @@ Primary references:
 
 - Apple: https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/
 - Apple distribution: https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases
+- Apple exact-build query: https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds
+- Apple internal-state values: https://developer.apple.com/documentation/appstoreconnectapi/internalbetastate
+- Apple group relationship: https://developer.apple.com/documentation/appstoreconnectapi/post-v1-betagroups-_id_-relationships-builds
 - Android signing: https://developer.android.com/studio/publish/app-signing
 - Google Publisher tracks: https://developers.google.com/android-publisher/tracks
 - Tauri iOS/App Store: https://v2.tauri.app/distribute/app-store/
@@ -241,6 +247,19 @@ scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
 ```
 
+The iOS upload command does not stop at Transporter acceptance. After `altool`
+accepts the IPA, it polls the exact app `6799322201`, bundle
+`cash.free2z.zuuli`, marketing version, iOS platform, and build number for at
+most 45 minutes. It records `uploaded`, `processed`, and
+`internal_group_available` as distinct transitions; invalid binaries,
+processing exceptions, missing or contradictory export compliance, expired
+builds, unknown states, duplicate exact identities, and bounded timeouts fail
+with sanitized diagnostics. Once valid, it idempotently adds the build to
+`ZUULI Internal Testers` only when absent and reads the group's build
+relationship back before the protected job can succeed. The resulting
+`ZUULI-<VERSION>+<BUILD>-testflight.json` is sanitized release evidence and
+contains no tester resources.
+
 ## Protected GitHub release
 
 The GitHub environment `zuuli-app-stores` holds the dedicated mobile signing and
@@ -314,9 +333,9 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    | `0.1.0+5` | [run 31254971614](https://github.com/free2z/zuu/actions/runs/31254971614) | Play internal succeeded; Apple rejected a bundled static archive with error 90171. |
    | `0.1.0+6` | [run 31257912883](https://github.com/free2z/zuu/actions/runs/31257912883) | Both protected jobs succeeded after the static archive became link-only; App Store Connect required the build-specific exempt-encryption answer before beta testing. |
    | `0.1.0+7` | [run 31270095364](https://github.com/free2z/zuu/actions/runs/31270095364) | iOS upload succeeded with the declaration packaged; Android exposed the 32-bit app-data-migration compile error. |
-   | `0.1.0+8` | [run 31293265075](https://github.com/free2z/zuu/actions/runs/31293265075) | Android/Play internal and iOS/TestFlight jobs both succeeded after the cross-ABI fix. |
-   | `0.1.0+9` | [run 31301302280](https://github.com/free2z/zuu/actions/runs/31301302280) | Android/Play internal and iOS/TestFlight jobs both succeeded. |
-   | `0.1.0+10` | [run 31323759501](https://github.com/free2z/zuu/actions/runs/31323759501) | Android/Play internal and iOS/TestFlight jobs both succeeded. |
+   | `0.1.0+8` | [run 31293265075](https://github.com/free2z/zuu/actions/runs/31293265075) | Play internal succeeded and Apple accepted the iOS upload after the cross-ABI fix; the historical workflow did not prove TestFlight group availability. |
+   | `0.1.0+9` | [run 31301302280](https://github.com/free2z/zuu/actions/runs/31301302280) | Play internal succeeded and Apple accepted the iOS upload; the historical workflow did not prove TestFlight group availability. |
+   | `0.1.0+10` | [run 31323759501](https://github.com/free2z/zuu/actions/runs/31323759501) | Play internal succeeded and Apple accepted the iOS upload; use the protected read-only recovery below for current processing/group evidence. |
 
    Packaging is a separate credential-free signal. Query the
    [scheduled packaging runs](https://github.com/free2z/zuu/actions/workflows/zuuli-packaging.yml?query=event%3Aschedule)
@@ -333,14 +352,40 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    to its first parent. It must also match the current `origin/main` release
    identity, so a superseded build cannot be recovered after a newer release.
    The initial `release.json` baseline is the only no-previous-identity
-   exception. Desktop `dry_run=true` packaging does not load signing credentials
-   or contact Apple's notarization service.
+   exception. This current-main restriction applies to a protected release that
+   can rebuild or upload. The read-only TestFlight observation below
+   intentionally accepts an exact identity-establishing SHA that remains on
+   `main`, including a superseded build, because it cannot change App Store
+   Connect. Desktop `dry_run=true` packaging does not load signing credentials or
+   contact Apple's notarization service.
 5. Optionally create an annotated (preferably signed) tag on that exact remote
    commit as `zuuli-v<VERSION>+<BUILD>`. If the matching tag exists before a
    manual recovery run, the workflow also maintains an idempotent draft GitHub
    release. Store upload authority does not depend on a tag.
-6. Wait for App Store processing; assign the build to internal TestFlight.
-   Confirm the Play internal release is available to the tester list.
+6. Require the iOS job's sanitized state evidence to show all three Booleans:
+   `uploaded`, `processed`, and `availableToInternalTesters`. A successful upload
+   alone is not TestFlight delivery. Confirm the Play internal release is
+   available to the tester list.
+
+### Read-only TestFlight recovery
+
+To inspect an already-uploaded build without rebuilding, re-uploading, or
+changing App Store Connect, dispatch **ZUULI / TestFlight read-only recovery**
+from `main`. For Build 10 use source
+`6359bbe8ddbb23a5024383b1ce780a00b76c5e3f` and identity `0.1.0+10`. The workflow
+requires that exact commit to be on `main` and to be the commit that established
+the identity. It uses the protected ASC key only to read the fixed app, exact
+build, TestFlight build detail, internal groups, and the configured group's
+build relationship. The workflow has no ensure/upload option and never requests
+tester resources.
+
+The recovery succeeds only if the exact build is processed, export compliance
+is resolved as the packaged `false` declaration, and the group relationship is
+visible on a fresh read. If it reports `processed` but not internally available,
+the owner must add that historical build to `ZUULI Internal Testers` in App Store
+Connect and rerun the read-only proof. Future uploads have no such manual gap:
+the protected release performs the idempotent relationship transaction and
+readback itself.
 
 Store build numbers are append-only. Signed packages are not bit-reproducible:
 timestamps and signatures can change on a rebuild, while neither store permits a

--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs && playwright test",
     "test:viewport": "playwright test tests/viewport.pw.ts",
     "test:play-testers": "node --test scripts/play-tester-groups.node-test.mjs",
+    "test:asc-testflight": "node --test scripts/asc-testflight.node-test.mjs",
     "typecheck": "tsc --noEmit",
     "icons:generate": "node scripts/brand-assets.mjs",
     "icons:check": "node scripts/brand-assets.mjs --check",

--- a/wallet/zuuli/scripts/asc-testflight.mjs
+++ b/wallet/zuuli/scripts/asc-testflight.mjs
@@ -1,0 +1,901 @@
+#!/usr/bin/env node
+
+import { createPrivateKey, sign } from "node:crypto";
+import { chmod, lstat, readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+export const ASC_API_ROOT = "https://api.appstoreconnect.apple.com";
+export const ASC_APP_ID = "6799322201";
+export const ASC_BUNDLE_ID = "cash.free2z.zuuli";
+export const ASC_INTERNAL_GROUP = "ZUULI Internal Testers";
+export const DEFAULT_TIMEOUT_SECONDS = 45 * 60;
+export const DEFAULT_POLL_SECONDS = 30;
+export const MAX_TIMEOUT_SECONDS = 60 * 60;
+export const MAX_PAGES = 5;
+export const REQUEST_TIMEOUT_MS = 30_000;
+
+const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const BUILD_PATTERN = /^(0|[1-9]\d*)$/;
+const KEY_ID_PATTERN = /^[A-Z0-9]{10}$/;
+const ISSUER_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const PROCESSING_STATES = new Set(["PROCESSING", "FAILED", "INVALID", "VALID"]);
+const INTERNAL_STATES = new Set([
+  "PROCESSING",
+  "PROCESSING_EXCEPTION",
+  "MISSING_EXPORT_COMPLIANCE",
+  "READY_FOR_BETA_TESTING",
+  "IN_BETA_TESTING",
+  "EXPIRED",
+  "IN_EXPORT_COMPLIANCE_REVIEW",
+]);
+
+export class AscStateError extends Error {
+  constructor(code, stage, message, { retryable = false } = {}) {
+    super(message);
+    this.name = "AscStateError";
+    this.code = code;
+    this.stage = stage;
+    this.retryable = retryable;
+  }
+}
+
+function base64url(value) {
+  return Buffer.from(value).toString("base64url");
+}
+
+export function validateIdentity(version, build) {
+  const versionString = String(version ?? "");
+  const buildString = String(build ?? "");
+  if (!VERSION_PATTERN.test(versionString)) {
+    throw new AscStateError(
+      "INVALID_IDENTITY",
+      "not_observed",
+      "marketing version must be a canonical three-component numeric version",
+    );
+  }
+  if (!BUILD_PATTERN.test(buildString)) {
+    throw new AscStateError(
+      "INVALID_IDENTITY",
+      "not_observed",
+      "build number must be a canonical nonnegative integer",
+    );
+  }
+  return { version: versionString, build: buildString };
+}
+
+export function validateJwtInputs({ keyId, issuerId, privateKey }) {
+  if (!KEY_ID_PATTERN.test(keyId ?? "")) {
+    throw new AscStateError(
+      "INVALID_CREDENTIAL_CONFIGURATION",
+      "not_observed",
+      "ASC key ID must be ten uppercase alphanumeric characters",
+    );
+  }
+  if (!ISSUER_ID_PATTERN.test(issuerId ?? "")) {
+    throw new AscStateError(
+      "INVALID_CREDENTIAL_CONFIGURATION",
+      "not_observed",
+      "ASC issuer ID must be a UUID",
+    );
+  }
+  try {
+    const parsed = createPrivateKey(privateKey);
+    if (parsed.asymmetricKeyType !== "ec" || parsed.asymmetricKeyDetails?.namedCurve !== "prime256v1") {
+      throw new Error("not a P-256 key");
+    }
+    return parsed;
+  } catch {
+    throw new AscStateError(
+      "INVALID_CREDENTIAL_CONFIGURATION",
+      "not_observed",
+      "ASC private key is not a valid P-256 key",
+    );
+  }
+}
+
+export function createAscToken({ keyId, issuerId, privateKey, nowSeconds }) {
+  const parsedKey = validateJwtInputs({ keyId, issuerId, privateKey });
+  if (!Number.isInteger(nowSeconds) || nowSeconds < 1) {
+    throw new AscStateError(
+      "INVALID_CLOCK",
+      "not_observed",
+      "JWT clock must be a positive integer",
+    );
+  }
+  const header = base64url(JSON.stringify({ alg: "ES256", kid: keyId, typ: "JWT" }));
+  const claims = base64url(
+    JSON.stringify({
+      iss: issuerId,
+      iat: nowSeconds,
+      exp: nowSeconds + 15 * 60,
+      aud: "appstoreconnect-v1",
+    }),
+  );
+  const signingInput = `${header}.${claims}`;
+  const signature = sign("sha256", Buffer.from(signingInput), {
+    key: parsedKey,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${signature.toString("base64url")}`;
+}
+
+function safeAppleError(payload) {
+  const first = Array.isArray(payload?.errors) ? payload.errors[0] : undefined;
+  const code =
+    typeof first?.code === "string"
+      ? first.code.replace(/[^A-Z0-9_.-]/gi, "").slice(0, 80)
+      : "UNKNOWN";
+  const title =
+    typeof first?.title === "string"
+      ? first.title.replace(/[^\w .,:;()/-]/g, "").slice(0, 160)
+      : "request rejected";
+  return `${code}: ${title}`;
+}
+
+async function parseResponse(response, operation, allowEmpty = false) {
+  const text = await response.text();
+  if (!response.ok) {
+    let payload;
+    try {
+      payload = text ? JSON.parse(text) : undefined;
+    } catch {
+      payload = undefined;
+    }
+    throw new AscStateError(
+      "ASC_API_ERROR",
+      "not_observed",
+      `${operation} failed with HTTP ${response.status} (${safeAppleError(payload)})`,
+      { retryable: response.status === 429 || response.status >= 500 },
+    );
+  }
+  if (!text) {
+    if (allowEmpty) return undefined;
+    throw new AscStateError(
+      "ASC_INVALID_RESPONSE",
+      "not_observed",
+      `${operation} returned an empty response`,
+    );
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new AscStateError(
+      "ASC_INVALID_RESPONSE",
+      "not_observed",
+      `${operation} returned invalid JSON`,
+    );
+  }
+}
+
+function assertResource(resource, expectedType, operation) {
+  if (
+    !resource ||
+    resource.type !== expectedType ||
+    typeof resource.id !== "string" ||
+    resource.id.length < 1 ||
+    !resource.attributes ||
+    typeof resource.attributes !== "object"
+  ) {
+    throw new AscStateError(
+      "ASC_INVALID_RESPONSE",
+      "not_observed",
+      `${operation} returned a malformed ${expectedType} resource`,
+    );
+  }
+  return resource;
+}
+
+function resourceKey(resource) {
+  return `${resource.type}:${resource.id}`;
+}
+
+function relationshipIds(resource, name, expectedType, many) {
+  const data = resource.relationships?.[name]?.data;
+  if (many) {
+    if (!Array.isArray(data)) {
+      throw new AscStateError(
+        "ASC_INVALID_RESPONSE",
+        "not_observed",
+        `build response is missing the ${name} relationship`,
+      );
+    }
+    for (const item of data) {
+      if (item?.type !== expectedType || typeof item.id !== "string") {
+        throw new AscStateError(
+          "ASC_INVALID_RESPONSE",
+          "not_observed",
+          `build response has a malformed ${name} relationship`,
+        );
+      }
+    }
+    return data.map(({ id }) => id);
+  }
+  if (data?.type !== expectedType || typeof data.id !== "string") {
+    throw new AscStateError(
+      "ASC_INVALID_RESPONSE",
+      "not_observed",
+      `build response is missing the ${name} relationship`,
+    );
+  }
+  return [data.id];
+}
+
+function checkedNextUrl(next) {
+  if (!next) return undefined;
+  let parsed;
+  try {
+    parsed = new URL(next);
+  } catch {
+    throw new AscStateError(
+      "ASC_INVALID_RESPONSE",
+      "not_observed",
+      "App Store Connect pagination returned an invalid next link",
+    );
+  }
+  if (parsed.origin !== ASC_API_ROOT || !parsed.pathname.startsWith("/v1/")) {
+    throw new AscStateError(
+      "ASC_INVALID_RESPONSE",
+      "not_observed",
+      "App Store Connect pagination escaped the API origin",
+    );
+  }
+  return parsed;
+}
+
+export function createAscApiClient({
+  keyId,
+  issuerId,
+  privateKey,
+  fetchImpl = globalThis.fetch,
+  nowSeconds = () => Math.floor(Date.now() / 1000),
+}) {
+  validateJwtInputs({ keyId, issuerId, privateKey });
+
+  async function request(method, pathOrUrl, { body, allowEmpty = false } = {}) {
+    const url = pathOrUrl instanceof URL ? pathOrUrl : new URL(pathOrUrl, ASC_API_ROOT);
+    if (url.origin !== ASC_API_ROOT || !url.pathname.startsWith("/v1/")) {
+      throw new AscStateError(
+        "ASC_INVALID_REQUEST",
+        "not_observed",
+        "refusing an App Store Connect request outside the fixed API origin",
+      );
+    }
+    const token = createAscToken({
+      keyId,
+      issuerId,
+      privateKey,
+      nowSeconds: nowSeconds(),
+    });
+    const controller = new AbortController();
+    const requestTimer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetchImpl(url, {
+        method,
+        signal: controller.signal,
+        headers: {
+          authorization: `Bearer ${token}`,
+          ...(body === undefined
+            ? { accept: "application/json" }
+            : { accept: "application/json", "content-type": "application/json" }),
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      });
+      return await parseResponse(
+        response,
+        `${method} App Store Connect request`,
+        allowEmpty,
+      );
+    } catch (error) {
+      if (error instanceof AscStateError) throw error;
+      throw new AscStateError(
+        "ASC_NETWORK_ERROR",
+        "not_observed",
+        `${method} App Store Connect request failed before a response`,
+        { retryable: true },
+      );
+    } finally {
+      clearTimeout(requestTimer);
+    }
+  }
+
+  async function paged(path) {
+    const resources = [];
+    let next = new URL(path, ASC_API_ROOT);
+    for (let page = 0; next; page += 1) {
+      if (page >= MAX_PAGES) {
+        throw new AscStateError(
+          "ASC_PAGINATION_LIMIT",
+          "not_observed",
+          `App Store Connect response exceeded ${MAX_PAGES} pages`,
+        );
+      }
+      const payload = await request("GET", next);
+      if (!Array.isArray(payload?.data)) {
+        throw new AscStateError(
+          "ASC_INVALID_RESPONSE",
+          "not_observed",
+          "App Store Connect list response has no data array",
+        );
+      }
+      resources.push(...payload.data);
+      next = checkedNextUrl(payload.links?.next);
+    }
+    return resources;
+  }
+
+  return {
+    async readApp() {
+      const params = new URLSearchParams({ "fields[apps]": "name,bundleId,sku" });
+      const payload = await request("GET", `/v1/apps/${ASC_APP_ID}?${params}`);
+      return assertResource(payload?.data, "apps", "app lookup");
+    },
+
+    async listBuildCandidates(version, build) {
+      const params = new URLSearchParams({
+        "filter[app]": ASC_APP_ID,
+        "filter[version]": build,
+        "filter[preReleaseVersion.version]": version,
+        "filter[preReleaseVersion.platform]": "IOS",
+        include: "preReleaseVersion,buildBetaDetail,betaGroups",
+        "fields[builds]": [
+          "version",
+          "uploadedDate",
+          "expired",
+          "processingState",
+          "usesNonExemptEncryption",
+          "preReleaseVersion",
+          "buildBetaDetail",
+          "betaGroups",
+        ].join(","),
+        "fields[preReleaseVersions]": "version,platform",
+        "fields[buildBetaDetails]": "internalBuildState",
+        "fields[betaGroups]": "name,isInternalGroup,hasAccessToAllBuilds",
+        limit: "200",
+      });
+      const payload = await request("GET", `/v1/builds?${params}`);
+      if (!Array.isArray(payload?.data)) {
+        throw new AscStateError(
+          "ASC_INVALID_RESPONSE",
+          "not_observed",
+          "exact build lookup returned malformed relationship data",
+        );
+      }
+      // JSON:API permits `included` to be absent when an exact build has not
+      // appeared yet. That is the normal upload-processing polling state, not
+      // a malformed response. Once data exists, both requested relationships
+      // must still resolve through included resources below.
+      const includedResources = payload.included ?? [];
+      if (!Array.isArray(includedResources)) {
+        throw new AscStateError(
+          "ASC_INVALID_RESPONSE",
+          "not_observed",
+          "exact build lookup returned malformed included resources",
+        );
+      }
+      const included = new Map(
+        includedResources.map((item) => [resourceKey(item), item]),
+      );
+      return payload.data.map((item) => {
+        const buildResource = assertResource(item, "builds", "exact build lookup");
+        const [preReleaseId] = relationshipIds(
+          buildResource,
+          "preReleaseVersion",
+          "preReleaseVersions",
+          false,
+        );
+        const betaGroupIds = relationshipIds(buildResource, "betaGroups", "betaGroups", true);
+        const preRelease = assertResource(
+          included.get(`preReleaseVersions:${preReleaseId}`),
+          "preReleaseVersions",
+          "exact build lookup",
+        );
+        const processingState = buildResource.attributes.processingState;
+        const betaDetailLink = buildResource.relationships?.buildBetaDetail?.data;
+        let internalBuildState = null;
+        if (betaDetailLink !== null && betaDetailLink !== undefined) {
+          if (
+            betaDetailLink.type !== "buildBetaDetails" ||
+            typeof betaDetailLink.id !== "string"
+          ) {
+            throw new AscStateError(
+              "ASC_INVALID_RESPONSE",
+              "not_observed",
+              "exact build lookup returned a malformed buildBetaDetail relationship",
+            );
+          }
+          const betaDetail = included.get(`buildBetaDetails:${betaDetailLink.id}`);
+          if (betaDetail) {
+            internalBuildState = assertResource(
+              betaDetail,
+              "buildBetaDetails",
+              "exact build lookup",
+            ).attributes.internalBuildState;
+          } else if (processingState === "VALID") {
+            throw new AscStateError(
+              "ASC_INVALID_RESPONSE",
+              "not_observed",
+              "exact build lookup omitted build beta detail for a non-processing build",
+            );
+          }
+        } else if (processingState === "VALID") {
+          throw new AscStateError(
+            "ASC_INVALID_RESPONSE",
+            "not_observed",
+            "exact build lookup omitted build beta detail for a non-processing build",
+          );
+        }
+        return {
+          id: buildResource.id,
+          version: buildResource.attributes.version,
+          processingState,
+          usesNonExemptEncryption: buildResource.attributes.usesNonExemptEncryption,
+          expired: buildResource.attributes.expired,
+          uploadedDate: buildResource.attributes.uploadedDate,
+          marketingVersion: preRelease.attributes.version,
+          platform: preRelease.attributes.platform,
+          internalBuildState,
+          betaGroupIds,
+        };
+      });
+    },
+
+    async listBetaGroups() {
+      const params = new URLSearchParams({
+        "fields[betaGroups]": "name,isInternalGroup,hasAccessToAllBuilds",
+        limit: "200",
+      });
+      const resources = await paged(`/v1/apps/${ASC_APP_ID}/betaGroups?${params}`);
+      return resources.map((item) => {
+        const resource = assertResource(item, "betaGroups", "beta group lookup");
+        return { id: resource.id, ...resource.attributes };
+      });
+    },
+
+    async listGroupBuildIds(groupId) {
+      const params = new URLSearchParams({ "fields[builds]": "version", limit: "200" });
+      const resources = await paged(
+        `/v1/betaGroups/${encodeURIComponent(groupId)}/builds?${params}`,
+      );
+      return resources.map((item) => assertResource(item, "builds", "beta group build lookup").id);
+    },
+
+    async addBuildToGroup(groupId, buildId) {
+      await request("POST", `/v1/betaGroups/${encodeURIComponent(groupId)}/relationships/builds`, {
+        body: { data: [{ type: "builds", id: buildId }] },
+        allowEmpty: true,
+      });
+    },
+  };
+}
+
+export function selectExactBuild(candidates, version, build) {
+  if (!Array.isArray(candidates)) {
+    throw new AscStateError(
+      "ASC_INVALID_RESPONSE",
+      "not_observed",
+      "build lookup did not return an array",
+    );
+  }
+  const matches = candidates.filter(
+    (candidate) =>
+      candidate?.version === build &&
+      candidate?.marketingVersion === version &&
+      candidate?.platform === "IOS",
+  );
+  if (matches.length > 1) {
+    throw new AscStateError(
+      "AMBIGUOUS_EXACT_BUILD",
+      "uploaded",
+      `App Store Connect returned ${matches.length} builds for the exact version and build identity`,
+    );
+  }
+  return matches[0];
+}
+
+export function classifyBuild(build) {
+  if (!PROCESSING_STATES.has(build.processingState)) {
+    throw new AscStateError(
+      "UNKNOWN_PROCESSING_STATE",
+      "uploaded",
+      "App Store Connect returned an unknown build processing state",
+    );
+  }
+  if (build.processingState === "FAILED") {
+    throw new AscStateError(
+      "PROCESSING_FAILED",
+      "uploaded",
+      "Apple failed while processing the exact uploaded build; " +
+        "inspect App Store Connect for the binary diagnostic",
+    );
+  }
+  if (build.processingState === "INVALID") {
+    throw new AscStateError(
+      "INVALID_BINARY",
+      "uploaded",
+      "Apple marked the exact uploaded build invalid; inspect App Store Connect for the binary diagnostic",
+    );
+  }
+  if (build.processingState === "PROCESSING" && build.internalBuildState === null) {
+    return "uploaded";
+  }
+  if (!INTERNAL_STATES.has(build.internalBuildState)) {
+    throw new AscStateError(
+      "UNKNOWN_INTERNAL_STATE",
+      build.processingState === "VALID" ? "processed" : "uploaded",
+      "App Store Connect returned an unknown internal TestFlight state",
+    );
+  }
+  if (build.internalBuildState === "PROCESSING_EXCEPTION") {
+    throw new AscStateError(
+      "PROCESSING_FAILED",
+      "uploaded",
+      "Apple failed while processing the exact uploaded build; " +
+        "inspect App Store Connect for the binary diagnostic",
+    );
+  }
+  if (build.internalBuildState === "MISSING_EXPORT_COMPLIANCE") {
+    throw new AscStateError(
+      "MISSING_EXPORT_COMPLIANCE",
+      "processed",
+      "the exact build requires an export-compliance answer before internal testing",
+    );
+  }
+  if (build.internalBuildState === "EXPIRED" || build.expired === true) {
+    throw new AscStateError(
+      "BUILD_EXPIRED",
+      "processed",
+      "the exact build is expired and cannot be made available to internal testers",
+    );
+  }
+  if (build.processingState !== "VALID") return "uploaded";
+  if (build.usesNonExemptEncryption !== false) {
+    throw new AscStateError(
+      build.usesNonExemptEncryption === true
+        ? "UNEXPECTED_NONEXEMPT_ENCRYPTION"
+        : "MISSING_EXPORT_COMPLIANCE",
+      "processed",
+      build.usesNonExemptEncryption === true
+        ? "the exact build unexpectedly declares nonexempt encryption"
+        : "the exact build has no resolved export-compliance value",
+    );
+  }
+  if (
+    build.internalBuildState === "PROCESSING" ||
+    build.internalBuildState === "IN_EXPORT_COMPLIANCE_REVIEW"
+  ) {
+    return "uploaded";
+  }
+  return "processed";
+}
+
+export function selectInternalGroup(groups) {
+  const named = groups.filter((group) => group?.name === ASC_INTERNAL_GROUP);
+  if (named.length === 0) {
+    throw new AscStateError(
+      "INTERNAL_GROUP_MISSING",
+      "processed",
+      `the configured internal group ${JSON.stringify(ASC_INTERNAL_GROUP)} does not exist`,
+    );
+  }
+  if (named.length > 1) {
+    throw new AscStateError(
+      "INTERNAL_GROUP_AMBIGUOUS",
+      "processed",
+      `App Store Connect returned ${named.length} groups with the configured name`,
+    );
+  }
+  if (named[0].isInternalGroup !== true) {
+    throw new AscStateError(
+      "INTERNAL_GROUP_WRONG_TYPE",
+      "processed",
+      "the configured TestFlight group is not an internal group",
+    );
+  }
+  return named[0];
+}
+
+function evidenceFor({ version, build, exactBuild, group, mode, nowMs }) {
+  return {
+    schemaVersion: 1,
+    application: { id: ASC_APP_ID, bundleId: ASC_BUNDLE_ID },
+    identity: { version, build },
+    mode,
+    state: {
+      uploaded: true,
+      processed: true,
+      availableToInternalTesters: true,
+    },
+    build: {
+      id: exactBuild.id,
+      processingState: exactBuild.processingState,
+      internalBuildState: exactBuild.internalBuildState,
+      usesNonExemptEncryption: exactBuild.usesNonExemptEncryption,
+    },
+    group: {
+      id: group.id,
+      name: ASC_INTERNAL_GROUP,
+      isInternalGroup: true,
+      hasAccessToAllBuilds: group.hasAccessToAllBuilds === true,
+      exactBuildRelationshipVerified: true,
+    },
+    observedAt: new Date(nowMs).toISOString(),
+  };
+}
+
+export async function convergeTestFlightState({
+  api,
+  version,
+  build,
+  mode,
+  uploadConfirmed = false,
+  timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+  pollSeconds = DEFAULT_POLL_SECONDS,
+  nowMs = () => Date.now(),
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  onTransition = () => {},
+}) {
+  ({ version, build } = validateIdentity(version, build));
+  if (mode !== "ensure" && mode !== "read-only") {
+    throw new AscStateError(
+      "INVALID_MODE",
+      "not_observed",
+      "mode must be ensure or read-only",
+    );
+  }
+  if (
+    !Number.isInteger(timeoutSeconds) ||
+    timeoutSeconds < 0 ||
+    timeoutSeconds > MAX_TIMEOUT_SECONDS ||
+    !Number.isInteger(pollSeconds) ||
+    pollSeconds < 1 ||
+    pollSeconds > 300
+  ) {
+    throw new AscStateError(
+      "INVALID_POLL_BOUNDS",
+      "not_observed",
+      "timeout and poll intervals are outside the bounded policy",
+    );
+  }
+
+  const startedAt = nowMs();
+  const deadline = startedAt + timeoutSeconds * 1000;
+  let lastStage = uploadConfirmed ? "uploaded" : "not_observed";
+  let transitionedStage;
+  async function callAtStage(stage, operation) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (error instanceof AscStateError && error.stage === "not_observed") {
+        throw new AscStateError(error.code, stage, error.message, {
+          retryable: error.retryable,
+        });
+      }
+      throw error;
+    }
+  }
+  async function waitForNextPoll(stage) {
+    const current = nowMs();
+    if (current >= deadline) {
+      throw new AscStateError(
+        "STATE_TIMEOUT",
+        stage,
+        `bounded TestFlight observation timed out at ${stage}`,
+      );
+    }
+    await sleep(Math.min(pollSeconds * 1000, deadline - current));
+  }
+
+  let app;
+  while (!app) {
+    try {
+      app = await callAtStage(lastStage, () => api.readApp());
+    } catch (error) {
+      if (!(error instanceof AscStateError) || !error.retryable) throw error;
+      await waitForNextPoll(lastStage);
+    }
+  }
+  if (app.id !== ASC_APP_ID || app.attributes.bundleId !== ASC_BUNDLE_ID) {
+    throw new AscStateError(
+      "APP_IDENTITY_MISMATCH",
+      "not_observed",
+      "the configured App Store Connect app does not match the ZUULI bundle",
+    );
+  }
+
+  while (true) {
+    try {
+      const candidates = await callAtStage(lastStage, () =>
+        api.listBuildCandidates(version, build),
+      );
+      const exactBuild = selectExactBuild(candidates, version, build);
+      if (exactBuild) {
+        const stage = classifyBuild(exactBuild);
+        if (stage !== transitionedStage) {
+          onTransition({ stage, version, build });
+          transitionedStage = stage;
+        }
+        lastStage = stage;
+        if (stage === "processed") {
+          const groups = await callAtStage("processed", () => api.listBetaGroups());
+          const group = selectInternalGroup(groups);
+          let groupBuildIds = await callAtStage("processed", () =>
+            api.listGroupBuildIds(group.id),
+          );
+          if (!groupBuildIds.includes(exactBuild.id) && mode === "ensure") {
+            let mutationError;
+            try {
+              await callAtStage("processed", () =>
+                api.addBuildToGroup(group.id, exactBuild.id),
+              );
+            } catch (error) {
+              mutationError = error;
+            }
+            groupBuildIds = await callAtStage("processed", () =>
+              api.listGroupBuildIds(group.id),
+            );
+            if (!groupBuildIds.includes(exactBuild.id) && mutationError) throw mutationError;
+          }
+          if (groupBuildIds.includes(exactBuild.id)) {
+            onTransition({ stage: "internal_group_available", version, build });
+            return evidenceFor({ version, build, exactBuild, group, mode, nowMs: nowMs() });
+          }
+          if (mode === "read-only") {
+            throw new AscStateError(
+              "INTERNAL_GROUP_NOT_AVAILABLE",
+              "processed",
+              "the exact processed build is not related to the configured internal group",
+            );
+          }
+          throw new AscStateError(
+            "INTERNAL_GROUP_READBACK_FAILED",
+            "processed",
+            "App Store Connect did not return the exact build from the group after assignment",
+            { retryable: true },
+          );
+        }
+      } else if (uploadConfirmed && transitionedStage !== "uploaded") {
+        onTransition({ stage: "uploaded", version, build });
+        transitionedStage = "uploaded";
+      }
+    } catch (error) {
+      if (!(error instanceof AscStateError) || !error.retryable) throw error;
+    }
+
+    await waitForNextPoll(lastStage);
+  }
+}
+
+function parseIntegerFlag(name, value, fallback) {
+  if (value === undefined) return fallback;
+  if (!/^(0|[1-9]\d*)$/.test(value)) {
+    throw new AscStateError(
+      "INVALID_ARGUMENT",
+      "not_observed",
+      `${name} must be a canonical nonnegative integer`,
+    );
+  }
+  return Number(value);
+}
+
+export function parseCliArgs(argv) {
+  const values = new Map();
+  let mode;
+  for (const arg of argv) {
+    if (arg === "--ensure") {
+      if (mode) throw new AscStateError("INVALID_ARGUMENT", "not_observed", "choose exactly one mode");
+      mode = "ensure";
+      continue;
+    }
+    if (arg === "--read-only") {
+      if (mode) throw new AscStateError("INVALID_ARGUMENT", "not_observed", "choose exactly one mode");
+      mode = "read-only";
+      continue;
+    }
+    const match = /^--([a-z-]+)=(.*)$/.exec(arg);
+    if (!match || values.has(match[1])) {
+      throw new AscStateError("INVALID_ARGUMENT", "not_observed", "invalid or duplicate command argument");
+    }
+    values.set(match[1], match[2]);
+  }
+  const allowed = new Set(["version", "build", "timeout-seconds", "poll-seconds", "output"]);
+  for (const key of values.keys()) {
+    if (!allowed.has(key)) {
+      throw new AscStateError("INVALID_ARGUMENT", "not_observed", "unknown command argument");
+    }
+  }
+  if (!mode || !values.has("version") || !values.has("build")) {
+    throw new AscStateError(
+      "INVALID_ARGUMENT",
+      "not_observed",
+      "usage: asc-testflight.mjs <--ensure|--read-only> --version=X.Y.Z " +
+        "--build=N [--timeout-seconds=N] [--poll-seconds=N] [--output=PATH]",
+    );
+  }
+  return {
+    ...validateIdentity(values.get("version"), values.get("build")),
+    mode,
+    timeoutSeconds: parseIntegerFlag(
+      "timeout-seconds",
+      values.get("timeout-seconds"),
+      DEFAULT_TIMEOUT_SECONDS,
+    ),
+    pollSeconds: parseIntegerFlag(
+      "poll-seconds",
+      values.get("poll-seconds"),
+      DEFAULT_POLL_SECONDS,
+    ),
+    output: values.get("output"),
+  };
+}
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2));
+  const keyId = process.env.ASC_KEY_ID;
+  const issuerId = process.env.ASC_ISSUER_ID;
+  const keyPath = process.env.ASC_KEY_PATH;
+  if (!keyPath) {
+    throw new AscStateError(
+      "INVALID_CREDENTIAL_CONFIGURATION",
+      "not_observed",
+      "ASC_KEY_PATH is required",
+    );
+  }
+  let privateKey;
+  try {
+    const keyMetadata = await lstat(keyPath);
+    if (!keyMetadata.isFile() || keyMetadata.isSymbolicLink()) throw new Error("unsafe key path");
+    privateKey = await readFile(keyPath, "utf8");
+  } catch {
+    throw new AscStateError(
+      "INVALID_CREDENTIAL_CONFIGURATION",
+      "not_observed",
+      "ASC private key could not be read",
+    );
+  }
+  const api = createAscApiClient({ keyId, issuerId, privateKey });
+  const evidence = await convergeTestFlightState({
+    api,
+    ...args,
+    uploadConfirmed: args.mode === "ensure",
+    onTransition(event) {
+      process.stdout.write(`${JSON.stringify({ event: "testflight_state", ...event })}\n`);
+    },
+  });
+  const serialized = `${JSON.stringify(evidence, null, 2)}\n`;
+  if (args.output) {
+    try {
+      const outputMetadata = await lstat(args.output);
+      if (!outputMetadata.isFile() || outputMetadata.isSymbolicLink()) {
+        throw new Error("unsafe output path");
+      }
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        throw new AscStateError(
+          "INVALID_OUTPUT_PATH",
+          "internal_group_available",
+          "evidence output must be a regular, non-symlink file path",
+        );
+      }
+    }
+    await writeFile(args.output, serialized, { encoding: "utf8", mode: 0o600 });
+    await chmod(args.output, 0o600);
+  }
+  process.stdout.write(`${JSON.stringify({ event: "testflight_evidence", ...evidence })}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    const safe =
+      error instanceof AscStateError
+        ? error
+        : new AscStateError(
+            "UNEXPECTED_FAILURE",
+            "not_observed",
+            "unexpected TestFlight state-machine failure",
+          );
+    process.stderr.write(
+      `TestFlight state failed [${safe.code}] at ${safe.stage}: ${safe.message}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/wallet/zuuli/scripts/asc-testflight.node-test.mjs
+++ b/wallet/zuuli/scripts/asc-testflight.node-test.mjs
@@ -1,0 +1,826 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync, verify } from "node:crypto";
+import test from "node:test";
+
+import {
+  ASC_API_ROOT,
+  ASC_APP_ID,
+  ASC_BUNDLE_ID,
+  ASC_INTERNAL_GROUP,
+  AscStateError,
+  classifyBuild,
+  convergeTestFlightState,
+  createAscApiClient,
+  createAscToken,
+  parseCliArgs,
+  selectExactBuild,
+  selectInternalGroup,
+} from "./asc-testflight.mjs";
+
+const KEY_ID = "AB12CD34EF";
+const ISSUER_ID = "12345678-1234-1234-1234-123456789abc";
+const VERSION = "0.1.0";
+const BUILD = "10";
+
+function keyPair() {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  return {
+    privateKey: privateKey.export({ type: "pkcs8", format: "pem" }),
+    publicKey,
+  };
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function queuedFetch(responses) {
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url: String(url), options });
+    assert.ok(responses.length > 0, `unexpected request: ${options.method} ${url}`);
+    const next = responses.shift();
+    return typeof next === "function" ? next(url, options) : next;
+  };
+  return { calls, fetchImpl, remaining: responses };
+}
+
+function candidate(overrides = {}) {
+  return {
+    id: "build-10",
+    version: BUILD,
+    marketingVersion: VERSION,
+    platform: "IOS",
+    processingState: "VALID",
+    usesNonExemptEncryption: false,
+    expired: false,
+    uploadedDate: "2026-08-10T12:00:00Z",
+    internalBuildState: "READY_FOR_BETA_TESTING",
+    betaGroupIds: [],
+    ...overrides,
+  };
+}
+
+function group(overrides = {}) {
+  return {
+    id: "group-internal",
+    name: ASC_INTERNAL_GROUP,
+    isInternalGroup: true,
+    hasAccessToAllBuilds: false,
+    ...overrides,
+  };
+}
+
+function fakeApi({
+  builds,
+  groups = [group()],
+  groupBuilds = [],
+  addError,
+  addLands = true,
+} = {}) {
+  const calls = [];
+  let buildResponses = Array.isArray(builds?.[0]) ? [...builds] : [builds ?? [candidate()]];
+  let relationships = [...groupBuilds];
+  return {
+    calls,
+    api: {
+      async readApp() {
+        calls.push(["readApp"]);
+        return {
+          type: "apps",
+          id: ASC_APP_ID,
+          attributes: { bundleId: ASC_BUNDLE_ID, name: "ZUULI", sku: "zuuli-ios" },
+        };
+      },
+      async listBuildCandidates(version, buildNumber) {
+        calls.push(["listBuildCandidates", version, buildNumber]);
+        return buildResponses.length > 1 ? buildResponses.shift() : buildResponses[0];
+      },
+      async listBetaGroups() {
+        calls.push(["listBetaGroups"]);
+        return groups;
+      },
+      async listGroupBuildIds(groupId) {
+        calls.push(["listGroupBuildIds", groupId]);
+        return [...relationships];
+      },
+      async addBuildToGroup(groupId, buildId) {
+        calls.push(["addBuildToGroup", groupId, buildId]);
+        if (addLands) relationships.push(buildId);
+        if (addError) throw addError;
+      },
+    },
+  };
+}
+
+test("creates a 15-minute ES256 App Store Connect JWT", () => {
+  const { privateKey, publicKey } = keyPair();
+  const now = 1_786_196_000;
+  const jwt = createAscToken({
+    keyId: KEY_ID,
+    issuerId: ISSUER_ID,
+    privateKey,
+    nowSeconds: now,
+  });
+  const [headerPart, claimsPart, signaturePart] = jwt.split(".");
+  assert.deepEqual(JSON.parse(Buffer.from(headerPart, "base64url")), {
+    alg: "ES256",
+    kid: KEY_ID,
+    typ: "JWT",
+  });
+  assert.deepEqual(JSON.parse(Buffer.from(claimsPart, "base64url")), {
+    iss: ISSUER_ID,
+    iat: now,
+    exp: now + 900,
+    aud: "appstoreconnect-v1",
+  });
+  assert.equal(Buffer.from(signaturePart, "base64url").length, 64);
+  assert.equal(
+    verify(
+      "sha256",
+      Buffer.from(`${headerPart}.${claimsPart}`),
+      { key: publicKey, dsaEncoding: "ieee-p1363" },
+      Buffer.from(signaturePart, "base64url"),
+    ),
+    true,
+  );
+});
+
+test("rejects malformed credential material without echoing it", () => {
+  const secretFragment = "VERY-SECRET-KEY-FRAGMENT";
+  assert.throws(
+    () =>
+      createAscToken({
+        keyId: KEY_ID,
+        issuerId: ISSUER_ID,
+        privateKey: secretFragment,
+        nowSeconds: 1,
+      }),
+    (error) =>
+      error.code === "INVALID_CREDENTIAL_CONFIGURATION" &&
+      !error.message.includes(secretFragment),
+  );
+  const { privateKey } = keyPair();
+  assert.throws(() =>
+    createAscToken({ keyId: "bad", issuerId: ISSUER_ID, privateKey, nowSeconds: 1 }),
+  );
+  assert.throws(() =>
+    createAscToken({ keyId: KEY_ID, issuerId: "bad", privateKey, nowSeconds: 1 }),
+  );
+});
+
+test("constructs exact app/build/group API requests without tester fields", async () => {
+  const { privateKey } = keyPair();
+  const mock = queuedFetch([
+    jsonResponse({
+      data: {
+        type: "apps",
+        id: ASC_APP_ID,
+        attributes: { bundleId: ASC_BUNDLE_ID, name: "ZUULI", sku: "zuuli-ios" },
+      },
+    }),
+    jsonResponse({
+      data: [
+        {
+          type: "builds",
+          id: "build-10",
+          attributes: {
+            version: BUILD,
+            uploadedDate: "2026-08-10T12:00:00Z",
+            expired: false,
+            processingState: "VALID",
+            usesNonExemptEncryption: false,
+          },
+          relationships: {
+            preReleaseVersion: { data: { type: "preReleaseVersions", id: "pre-1" } },
+            buildBetaDetail: { data: { type: "buildBetaDetails", id: "detail-1" } },
+            betaGroups: { data: [{ type: "betaGroups", id: "group-internal" }] },
+          },
+        },
+      ],
+      included: [
+        {
+          type: "preReleaseVersions",
+          id: "pre-1",
+          attributes: { version: VERSION, platform: "IOS" },
+        },
+        {
+          type: "buildBetaDetails",
+          id: "detail-1",
+          attributes: { internalBuildState: "IN_BETA_TESTING" },
+        },
+        {
+          type: "betaGroups",
+          id: "group-internal",
+          attributes: {
+            name: ASC_INTERNAL_GROUP,
+            isInternalGroup: true,
+            hasAccessToAllBuilds: false,
+          },
+        },
+      ],
+    }),
+    jsonResponse({
+      data: [
+        {
+          type: "betaGroups",
+          id: "group-internal",
+          attributes: {
+            name: ASC_INTERNAL_GROUP,
+            isInternalGroup: true,
+            hasAccessToAllBuilds: false,
+          },
+        },
+      ],
+      links: {},
+    }),
+    jsonResponse({
+      data: [{ type: "builds", id: "build-10", attributes: { version: BUILD } }],
+      links: {},
+    }),
+    new Response(null, { status: 204 }),
+  ]);
+  const api = createAscApiClient({
+    keyId: KEY_ID,
+    issuerId: ISSUER_ID,
+    privateKey,
+    fetchImpl: mock.fetchImpl,
+    nowSeconds: () => 1_786_196_000,
+  });
+
+  const app = await api.readApp();
+  const builds = await api.listBuildCandidates(VERSION, BUILD);
+  const groups = await api.listBetaGroups();
+  const buildIds = await api.listGroupBuildIds("group-internal");
+  await api.addBuildToGroup("group-internal", "build-10");
+  assert.equal(app.attributes.bundleId, ASC_BUNDLE_ID);
+  assert.deepEqual(builds, [
+    candidate({
+      internalBuildState: "IN_BETA_TESTING",
+      betaGroupIds: ["group-internal"],
+    }),
+  ]);
+  assert.deepEqual(groups, [group()]);
+  assert.deepEqual(buildIds, ["build-10"]);
+  assert.equal(mock.remaining.length, 0);
+  const buildUrl = new URL(mock.calls[1].url);
+  assert.equal(buildUrl.origin, ASC_API_ROOT);
+  assert.equal(buildUrl.searchParams.get("filter[app]"), ASC_APP_ID);
+  assert.equal(buildUrl.searchParams.get("filter[version]"), BUILD);
+  assert.equal(buildUrl.searchParams.get("filter[preReleaseVersion.version]"), VERSION);
+  assert.equal(buildUrl.searchParams.get("filter[preReleaseVersion.platform]"), "IOS");
+  assert.equal(buildUrl.searchParams.toString().includes("betaTesters"), false);
+  for (const call of mock.calls) {
+    assert.match(call.options.headers.authorization, /^Bearer [^.]+\.[^.]+\.[^.]+$/);
+    assert.equal(call.options.signal instanceof AbortSignal, true);
+    assert.equal(JSON.stringify(call).includes("email"), false);
+  }
+  assert.equal(mock.calls[4].options.method, "POST");
+  assert.deepEqual(JSON.parse(mock.calls[4].options.body), {
+    data: [{ type: "builds", id: "build-10" }],
+  });
+});
+
+test("accepts an empty exact-build document while Apple has not exposed the upload", async () => {
+  const { privateKey } = keyPair();
+  const mock = queuedFetch([jsonResponse({ data: [] })]);
+  const api = createAscApiClient({
+    keyId: KEY_ID,
+    issuerId: ISSUER_ID,
+    privateKey,
+    fetchImpl: mock.fetchImpl,
+    nowSeconds: () => 1,
+  });
+  assert.deepEqual(await api.listBuildCandidates(VERSION, BUILD), []);
+});
+
+test("accepts a processing exact build before Apple materializes beta detail", async () => {
+  const { privateKey } = keyPair();
+  const processingBuild = {
+    type: "builds",
+    id: "build-10",
+    attributes: {
+      version: BUILD,
+      uploadedDate: "2026-08-10T12:00:00Z",
+      expired: false,
+      processingState: "PROCESSING",
+      usesNonExemptEncryption: null,
+    },
+    relationships: {
+      preReleaseVersion: { data: { type: "preReleaseVersions", id: "pre-1" } },
+      buildBetaDetail: { data: null },
+      betaGroups: { data: [] },
+    },
+  };
+  const preRelease = {
+    type: "preReleaseVersions",
+    id: "pre-1",
+    attributes: { version: VERSION, platform: "IOS" },
+  };
+  const { fetchImpl } = queuedFetch([
+    jsonResponse({ data: [processingBuild], included: [preRelease] }),
+    jsonResponse({
+      data: [
+        {
+          ...processingBuild,
+          relationships: {
+            ...processingBuild.relationships,
+            buildBetaDetail: {
+              data: { type: "buildBetaDetails", id: "detail-not-materialized" },
+            },
+          },
+        },
+      ],
+      included: [preRelease],
+    }),
+    jsonResponse({
+      data: [
+        {
+          ...processingBuild,
+          attributes: { ...processingBuild.attributes, processingState: "FAILED" },
+        },
+      ],
+      included: [preRelease],
+    }),
+    jsonResponse({
+      data: [
+        {
+          ...processingBuild,
+          attributes: { ...processingBuild.attributes, processingState: "INVALID" },
+          relationships: {
+            preReleaseVersion: processingBuild.relationships.preReleaseVersion,
+            betaGroups: { data: [] },
+          },
+        },
+      ],
+      included: [preRelease],
+    }),
+    jsonResponse({
+      data: [{ ...processingBuild, attributes: { ...processingBuild.attributes, processingState: "VALID" } }],
+      included: [preRelease],
+    }),
+  ]);
+  const api = createAscApiClient({
+    keyId: KEY_ID,
+    issuerId: ISSUER_ID,
+    privateKey,
+    fetchImpl,
+    nowSeconds: () => 1,
+  });
+  const [build] = await api.listBuildCandidates(VERSION, BUILD);
+  assert.equal(build.internalBuildState, null);
+  assert.equal(classifyBuild(build), "uploaded");
+  const [linkedBuild] = await api.listBuildCandidates(VERSION, BUILD);
+  assert.equal(linkedBuild.internalBuildState, null);
+  assert.equal(classifyBuild(linkedBuild), "uploaded");
+  const [failedBuild] = await api.listBuildCandidates(VERSION, BUILD);
+  assert.equal(failedBuild.internalBuildState, null);
+  assert.throws(
+    () => classifyBuild(failedBuild),
+    (error) => error.code === "PROCESSING_FAILED",
+  );
+  const [invalidBuild] = await api.listBuildCandidates(VERSION, BUILD);
+  assert.equal(invalidBuild.internalBuildState, null);
+  assert.throws(
+    () => classifyBuild(invalidBuild),
+    (error) => error.code === "INVALID_BINARY",
+  );
+  await assert.rejects(
+    api.listBuildCandidates(VERSION, BUILD),
+    (error) =>
+      error.code === "ASC_INVALID_RESPONSE" &&
+      error.message.includes("non-processing build"),
+  );
+});
+
+test("sanitizes App Store Connect errors and never returns response detail", async () => {
+  const { privateKey } = keyPair();
+  const secret = "tester@example.invalid secret-token";
+  const mock = queuedFetch([
+    jsonResponse(
+      {
+        errors: [
+          {
+            status: "403",
+            code: "FORBIDDEN_ERROR",
+            title: "The request is forbidden",
+            detail: secret,
+          },
+        ],
+      },
+      403,
+    ),
+  ]);
+  const api = createAscApiClient({
+    keyId: KEY_ID,
+    issuerId: ISSUER_ID,
+    privateKey,
+    fetchImpl: mock.fetchImpl,
+    nowSeconds: () => 1,
+  });
+  await assert.rejects(
+    api.readApp(),
+    (error) =>
+      error.code === "ASC_API_ERROR" &&
+      error.message.includes("FORBIDDEN_ERROR") &&
+      !error.message.includes(secret) &&
+      !error.message.includes("tester@example"),
+  );
+});
+
+test("rejects pagination that escapes Apple or exceeds the fixed page bound", async () => {
+  const { privateKey } = keyPair();
+  const escaped = queuedFetch([
+    jsonResponse({ data: [], links: { next: "https://example.invalid/v1/groups?page=2" } }),
+  ]);
+  const escapedApi = createAscApiClient({
+    keyId: KEY_ID,
+    issuerId: ISSUER_ID,
+    privateKey,
+    fetchImpl: escaped.fetchImpl,
+    nowSeconds: () => 1,
+  });
+  await assert.rejects(escapedApi.listBetaGroups(), /escaped the API origin/);
+
+  const pages = Array.from({ length: 5 }, (_, index) =>
+    jsonResponse({
+      data: [],
+      links: { next: `${ASC_API_ROOT}/v1/apps/${ASC_APP_ID}/betaGroups?page=${index + 2}` },
+    }),
+  );
+  const tooMany = queuedFetch(pages);
+  const tooManyApi = createAscApiClient({
+    keyId: KEY_ID,
+    issuerId: ISSUER_ID,
+    privateKey,
+    fetchImpl: tooMany.fetchImpl,
+    nowSeconds: () => 1,
+  });
+  await assert.rejects(tooManyApi.listBetaGroups(), /exceeded 5 pages/);
+});
+
+test("selects only the exact iOS marketing/build identity and rejects duplicates", () => {
+  assert.equal(selectExactBuild([candidate()], VERSION, BUILD).id, "build-10");
+  assert.equal(selectExactBuild([candidate({ platform: "TV_OS" })], VERSION, BUILD), undefined);
+  assert.throws(
+    () => selectExactBuild([candidate(), candidate({ id: "duplicate" })], VERSION, BUILD),
+    (error) => error.code === "AMBIGUOUS_EXACT_BUILD" && error.stage === "uploaded",
+  );
+});
+
+test("classifies processing, compliance, invalid, failure, and expired states", () => {
+  assert.equal(
+    classifyBuild(candidate({ processingState: "PROCESSING", internalBuildState: "PROCESSING" })),
+    "uploaded",
+  );
+  assert.equal(classifyBuild(candidate()), "processed");
+  assert.equal(
+    classifyBuild(candidate({ internalBuildState: "IN_EXPORT_COMPLIANCE_REVIEW" })),
+    "uploaded",
+  );
+  const cases = [
+    [candidate({ processingState: "FAILED", internalBuildState: null }), "PROCESSING_FAILED"],
+    [candidate({ processingState: "INVALID", internalBuildState: null }), "INVALID_BINARY"],
+    [candidate({ internalBuildState: "PROCESSING_EXCEPTION" }), "PROCESSING_FAILED"],
+    [candidate({ internalBuildState: "MISSING_EXPORT_COMPLIANCE" }), "MISSING_EXPORT_COMPLIANCE"],
+    [candidate({ usesNonExemptEncryption: undefined }), "MISSING_EXPORT_COMPLIANCE"],
+    [candidate({ usesNonExemptEncryption: true }), "UNEXPECTED_NONEXEMPT_ENCRYPTION"],
+    [candidate({ internalBuildState: "EXPIRED" }), "BUILD_EXPIRED"],
+    [candidate({ expired: true }), "BUILD_EXPIRED"],
+    [candidate({ processingState: "NEW_STATE" }), "UNKNOWN_PROCESSING_STATE"],
+    [candidate({ internalBuildState: "NEW_STATE" }), "UNKNOWN_INTERNAL_STATE"],
+  ];
+  for (const [build, code] of cases) {
+    assert.throws(() => classifyBuild(build), (error) => error.code === code);
+  }
+});
+
+test("requires one explicitly named internal group", () => {
+  assert.deepEqual(selectInternalGroup([group()]), group());
+  assert.throws(() => selectInternalGroup([]), (error) => error.code === "INTERNAL_GROUP_MISSING");
+  assert.throws(
+    () => selectInternalGroup([group(), group({ id: "duplicate" })]),
+    (error) => error.code === "INTERNAL_GROUP_AMBIGUOUS",
+  );
+  assert.throws(
+    () => selectInternalGroup([group({ isInternalGroup: false })]),
+    (error) => error.code === "INTERNAL_GROUP_WRONG_TYPE",
+  );
+});
+
+test("read-only mode verifies an existing relationship without mutating", async () => {
+  const fixture = fakeApi({
+    builds: [candidate({ internalBuildState: "IN_BETA_TESTING" })],
+    groupBuilds: ["build-10"],
+  });
+  const transitions = [];
+  const result = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "read-only",
+    timeoutSeconds: 0,
+    pollSeconds: 1,
+    nowMs: () => 1_786_196_000_000,
+    onTransition: (event) => transitions.push(event.stage),
+  });
+  assert.deepEqual(result.state, {
+    uploaded: true,
+    processed: true,
+    availableToInternalTesters: true,
+  });
+  assert.equal(result.mode, "read-only");
+  assert.equal(result.group.name, ASC_INTERNAL_GROUP);
+  assert.deepEqual(transitions, ["processed", "internal_group_available"]);
+  assert.equal(fixture.calls.some(([operation]) => operation === "addBuildToGroup"), false);
+  assert.equal(JSON.stringify(result).includes("email"), false);
+});
+
+test("refuses an App Store Connect app whose bundle identity does not match", async () => {
+  const fixture = fakeApi();
+  fixture.api.readApp = async () => ({
+    type: "apps",
+    id: ASC_APP_ID,
+    attributes: { bundleId: "invalid.example.bundle" },
+  });
+  await assert.rejects(
+    convergeTestFlightState({
+      api: fixture.api,
+      version: VERSION,
+      build: BUILD,
+      mode: "read-only",
+      timeoutSeconds: 0,
+      pollSeconds: 1,
+    }),
+    (error) => error.code === "APP_IDENTITY_MISMATCH" && error.stage === "not_observed",
+  );
+});
+
+test("ensure mode adds once, reads back, and is idempotent on a rerun", async () => {
+  const fixture = fakeApi({ groupBuilds: [] });
+  const first = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "ensure",
+    timeoutSeconds: 0,
+    pollSeconds: 1,
+    nowMs: () => 1_786_196_000_000,
+  });
+  const second = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "ensure",
+    timeoutSeconds: 0,
+    pollSeconds: 1,
+    nowMs: () => 1_786_196_001_000,
+  });
+  assert.equal(first.group.exactBuildRelationshipVerified, true);
+  assert.equal(second.group.exactBuildRelationshipVerified, true);
+  assert.equal(
+    fixture.calls.filter(([operation]) => operation === "addBuildToGroup").length,
+    1,
+  );
+});
+
+test("waits for eventual relationship readback without repeating the assignment", async () => {
+  const fixture = fakeApi({ groupBuilds: [] });
+  const readRelationship = fixture.api.listGroupBuildIds;
+  let relationshipReads = 0;
+  fixture.api.listGroupBuildIds = async (...args) => {
+    relationshipReads += 1;
+    const ids = await readRelationship(...args);
+    return relationshipReads === 2 ? [] : ids;
+  };
+  let current = 1_000;
+  const result = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "ensure",
+    timeoutSeconds: 10,
+    pollSeconds: 2,
+    nowMs: () => current,
+    sleep: async (milliseconds) => {
+      current += milliseconds;
+    },
+  });
+  assert.equal(result.state.availableToInternalTesters, true);
+  assert.equal(relationshipReads, 3);
+  assert.equal(
+    fixture.calls.filter(([operation]) => operation === "addBuildToGroup").length,
+    1,
+  );
+});
+
+test("an ambiguous POST failure succeeds only when relationship readback proves it landed", async () => {
+  const fixture = fakeApi({
+    groupBuilds: [],
+    addError: new AscStateError("ASC_NETWORK_ERROR", "not_observed", "synthetic failure"),
+  });
+  const result = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "ensure",
+    timeoutSeconds: 0,
+    pollSeconds: 1,
+    nowMs: () => 1_786_196_000_000,
+  });
+  assert.equal(result.state.availableToInternalTesters, true);
+});
+
+test("an assignment failure that did not land is reported at the processed stage", async () => {
+  const fixture = fakeApi({
+    groupBuilds: [],
+    addLands: false,
+    addError: new AscStateError("ASC_API_ERROR", "not_observed", "sanitized failure"),
+  });
+  await assert.rejects(
+    convergeTestFlightState({
+      api: fixture.api,
+      version: VERSION,
+      build: BUILD,
+      mode: "ensure",
+      timeoutSeconds: 0,
+      pollSeconds: 1,
+      nowMs: () => 1_786_196_000_000,
+    }),
+    (error) =>
+      error.code === "ASC_API_ERROR" &&
+      error.stage === "processed" &&
+      error.message === "sanitized failure",
+  );
+});
+
+test("read-only mode reports processed-but-unavailable without mutation", async () => {
+  const fixture = fakeApi({ groupBuilds: [] });
+  await assert.rejects(
+    convergeTestFlightState({
+      api: fixture.api,
+      version: VERSION,
+      build: BUILD,
+      mode: "read-only",
+      timeoutSeconds: 0,
+      pollSeconds: 1,
+      nowMs: () => 1_786_196_000_000,
+    }),
+    (error) => error.code === "INTERNAL_GROUP_NOT_AVAILABLE" && error.stage === "processed",
+  );
+  assert.equal(fixture.calls.some(([operation]) => operation === "addBuildToGroup"), false);
+});
+
+test("polls through upload and processing with a fixed deadline", async () => {
+  const fixture = fakeApi({
+    builds: [
+      [],
+      [candidate({ processingState: "PROCESSING", internalBuildState: "PROCESSING" })],
+      [candidate({ internalBuildState: "IN_BETA_TESTING" })],
+    ],
+    groupBuilds: ["build-10"],
+  });
+  let current = 1_000;
+  const sleeps = [];
+  const transitions = [];
+  const result = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "ensure",
+    uploadConfirmed: true,
+    timeoutSeconds: 10,
+    pollSeconds: 2,
+    nowMs: () => current,
+    sleep: async (milliseconds) => {
+      sleeps.push(milliseconds);
+      current += milliseconds;
+    },
+    onTransition: ({ stage }) => transitions.push(stage),
+  });
+  assert.equal(result.state.availableToInternalTesters, true);
+  assert.deepEqual(sleeps, [2_000, 2_000]);
+  assert.deepEqual(transitions, ["uploaded", "processed", "internal_group_available"]);
+});
+
+test("retries sanitized transient API failures within the same fixed deadline", async () => {
+  const fixture = fakeApi({ groupBuilds: ["build-10"] });
+  const original = fixture.api.listBuildCandidates;
+  let attempts = 0;
+  fixture.api.listBuildCandidates = async (...args) => {
+    attempts += 1;
+    if (attempts === 1) {
+      throw new AscStateError(
+        "ASC_NETWORK_ERROR",
+        "not_observed",
+        "synthetic transient failure",
+        { retryable: true },
+      );
+    }
+    return original(...args);
+  };
+  let current = 1_000;
+  const result = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "read-only",
+    timeoutSeconds: 10,
+    pollSeconds: 2,
+    nowMs: () => current,
+    sleep: async (milliseconds) => {
+      current += milliseconds;
+    },
+  });
+  assert.equal(result.state.availableToInternalTesters, true);
+  assert.equal(attempts, 2);
+  assert.equal(current, 3_000);
+});
+
+test("retries the fixed app identity lookup within the same deadline", async () => {
+  const fixture = fakeApi({ groupBuilds: ["build-10"] });
+  const readApp = fixture.api.readApp;
+  let attempts = 0;
+  fixture.api.readApp = async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      throw new AscStateError(
+        "ASC_NETWORK_ERROR",
+        "not_observed",
+        "synthetic transient failure",
+        { retryable: true },
+      );
+    }
+    return readApp();
+  };
+  let current = 1_000;
+  const result = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "read-only",
+    timeoutSeconds: 10,
+    pollSeconds: 2,
+    nowMs: () => current,
+    sleep: async (milliseconds) => {
+      current += milliseconds;
+    },
+  });
+  assert.equal(result.state.availableToInternalTesters, true);
+  assert.equal(attempts, 2);
+  assert.equal(current, 3_000);
+});
+
+test("bounded timeout reports the last proven stage", async () => {
+  const fixture = fakeApi({ builds: [[]] });
+  let current = 100;
+  await assert.rejects(
+    convergeTestFlightState({
+      api: fixture.api,
+      version: VERSION,
+      build: BUILD,
+      mode: "ensure",
+      uploadConfirmed: true,
+      timeoutSeconds: 3,
+      pollSeconds: 2,
+      nowMs: () => current,
+      sleep: async (milliseconds) => {
+        current += milliseconds;
+      },
+    }),
+    (error) => error.code === "STATE_TIMEOUT" && error.stage === "uploaded",
+  );
+  assert.equal(current, 3_100);
+});
+
+test("validates bounded CLI arguments and explicit mode", () => {
+  assert.deepEqual(
+    parseCliArgs([
+      "--read-only",
+      `--version=${VERSION}`,
+      `--build=${BUILD}`,
+      "--timeout-seconds=120",
+      "--poll-seconds=5",
+      "--output=/tmp/evidence.json",
+    ]),
+    {
+      version: VERSION,
+      build: BUILD,
+      mode: "read-only",
+      timeoutSeconds: 120,
+      pollSeconds: 5,
+      output: "/tmp/evidence.json",
+    },
+  );
+  for (const args of [
+    [],
+    ["--ensure", "--read-only", `--version=${VERSION}`, `--build=${BUILD}`],
+    ["--ensure", `--version=${VERSION}`, `--build=${BUILD}`, "--poll-seconds=-1"],
+    ["--ensure", `--version=${VERSION}`, `--build=${BUILD}`, "--unknown=x"],
+  ]) {
+    assert.throws(() => parseCliArgs(args));
+  }
+});

--- a/wallet/zuuli/scripts/mobile-release.sh
+++ b/wallet/zuuli/scripts/mobile-release.sh
@@ -23,6 +23,7 @@ if [[ -n "${ZUULI_RELEASE_SOURCE_SHA:-}" ]]; then
 fi
 identity_json=$(node scripts/release-identity.mjs "${identity_args[@]}")
 identity=$(jq -r .identity <<<"$identity_json")
+version=$(jq -r .version <<<"$identity_json")
 build=$(jq -r .build <<<"$identity_json")
 application_id=$(jq -r .applicationId <<<"$identity_json")
 
@@ -169,6 +170,11 @@ if [[ "$platform" == ios ]]; then
       xcrun altool --upload-app --type ios --file "$ipa_abs" \
         --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
     )
+    node scripts/asc-testflight.mjs \
+      --ensure \
+      "--version=$version" \
+      "--build=$build" \
+      "--output=release-artifacts/ZUULI-${identity}-testflight.json"
   fi
 else
   # shellcheck source=android-toolchain-env.sh
@@ -237,4 +243,8 @@ else
   fi
 fi
 
-echo "ZUULI $identity $platform release validation completed ($([[ "$mode" == --upload ]] && echo uploaded || echo dry-run))."
+if [[ "$platform" == ios && "$mode" == --upload ]]; then
+  echo "ZUULI $identity iOS is processed and available to the configured internal TestFlight group."
+else
+  echo "ZUULI $identity $platform release validation completed ($([[ "$mode" == --upload ]] && echo uploaded || echo dry-run))."
+fi

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -196,7 +196,12 @@ const androidManifest = read(
 const androidToolchain = read("scripts/android-toolchain-env.sh");
 const gemLock = read("Gemfile.lock");
 const mobileRelease = read("scripts/mobile-release.sh");
+const ascTestFlight = read("scripts/asc-testflight.mjs");
+const gateWorkflow = read("../../.github/workflows/zuuli.yml");
 const releaseWorkflow = read("../../.github/workflows/zuuli-release.yml");
+const testFlightRecoveryWorkflow = read(
+  "../../.github/workflows/zuuli-testflight-recovery.yml",
+);
 const packagingWorkflow = read("../../.github/workflows/zuuli-packaging.yml");
 
 expect("package.json version", packageJson.version, release.version);
@@ -649,6 +654,9 @@ const appleValidation = mobileRelease.indexOf(
   "\n    xcrun altool --validate-app",
 );
 const appleUpload = mobileRelease.indexOf("\n      xcrun altool --upload-app");
+const testFlightConvergence = mobileRelease.indexOf(
+  "\n    node scripts/asc-testflight.mjs \\",
+);
 const signingPreparation = mobileRelease.indexOf(
   "node scripts/normalize-generated-ios-project.mjs --prepare-manual-signing",
 );
@@ -666,16 +674,49 @@ if (
   ipaVerification === -1 ||
   appleValidation === -1 ||
   appleUpload === -1 ||
+  testFlightConvergence === -1 ||
   signingPreparation > tauriIosBuild ||
   tauriIosBuild > signingNormalization ||
   signingNormalization > ipaVerification ||
   ipaVerification > appleValidation ||
-  ipaVerification > appleUpload
+  ipaVerification > appleUpload ||
+  appleUpload > testFlightConvergence
 ) {
   failures.push(
-    "iOS release must prepare signing keys, build, normalize, inspect the IPA, then validate and upload with Apple",
+    "iOS release must prepare signing keys, build, normalize, inspect the IPA, validate, upload, then prove internal TestFlight availability",
   );
 }
+for (const contract of [
+  'export const ASC_APP_ID = "6799322201"',
+  'export const ASC_BUNDLE_ID = "cash.free2z.zuuli"',
+  'export const ASC_INTERNAL_GROUP = "ZUULI Internal Testers"',
+  '"filter[preReleaseVersion.version]"',
+  '"filter[preReleaseVersion.platform]"',
+  '"MISSING_EXPORT_COMPLIANCE"',
+  '"INVALID_BINARY"',
+  '"AMBIGUOUS_EXACT_BUILD"',
+  'availableToInternalTesters: true',
+  '/relationships/builds',
+]) {
+  if (!ascTestFlight.includes(contract))
+    failures.push(`App Store Connect state contract is missing: ${contract}`);
+}
+if (ascTestFlight.includes("betaTesters"))
+  failures.push("App Store Connect state machine must never request tester identities");
+for (const recoveryContract of [
+  "name: ZUULI / TestFlight read-only recovery",
+  "environment: zuuli-app-stores",
+  "--read-only",
+  "source SHA must be the commit that established this release identity",
+  "node --test scripts/asc-testflight.node-test.mjs",
+]) {
+  if (!testFlightRecoveryWorkflow.includes(recoveryContract))
+    failures.push(`TestFlight recovery workflow is missing: ${recoveryContract}`);
+}
+if (testFlightRecoveryWorkflow.includes("--ensure"))
+  failures.push("TestFlight recovery workflow must remain read-only");
+if (!gateWorkflow.includes(".github/workflows/zuuli-testflight-recovery.yml"))
+  failures.push("ZUULI gate must select TestFlight recovery workflow changes");
 const unsignedIosBuild = packagingWorkflow.indexOf(
   "./node_modules/.bin/tauri ios build --ci --no-sign",
 );


### PR DESCRIPTION
## Outcome

A green protected iOS release now means more than Transporter acceptance: it resolves the exact ZUULI build, waits for processing and export-compliance resolution, idempotently relates it to the one configured internal group, reads that relationship back, and emits sanitized release evidence.

## What changed

- add a bounded App Store Connect state machine for exact app `6799322201`, bundle `cash.free2z.zuuli`, iOS marketing version, and build number
- distinguish `uploaded`, `processed`, and `internal_group_available`; fail closed on invalid, failed, expired, missing or contradictory compliance, unknown, duplicate, or timed-out states
- configure exactly one internal group, `ZUULI Internal Testers`, and make assignment idempotent with relationship readback after ambiguous POST outcomes
- retry sanitized transient API/network failures within the fixed deadline; bound each request and pagination
- add a protected, main-only, strictly read-only recovery workflow for existing builds, including `0.1.0+10` from `6359bbe8ddbb23a5024383b1ce780a00b76c5e3f`
- keep tester resources, tester identities, raw API details, and credential material out of requests, logs, and artifacts
- extend release verification, required-gate path selection, tests, and the release runbook

The implementation follows official Apple contracts for [build queries](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds), [internal beta states](https://developer.apple.com/documentation/appstoreconnectapi/internalbetastate), [beta-group assignment](https://developer.apple.com/documentation/appstoreconnectapi/post-v1-betagroups-_id_-relationships-builds), [group build readback](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-betagroups-_id_-builds), and [JWTs](https://developer.apple.com/documentation/appstoreconnectapi/generating-tokens-for-api-requests).

## Security and production state

No production App Store Connect request or mutation was made while developing this PR. All API behavior was exercised with local mocks. The protected recovery workflow has no ensure/upload mode and uses the ASC credential only after offline tests and immutable source/identity validation.

The explicit internal group must exist before the next upload. After merge, the protected read-only recovery workflow can attach sanitized Build 10 relationship evidence without rebuilding, re-uploading, or changing App Store Connect. If the historical build is not yet related, the workflow reports the precise owner action and can be rerun after that console-only correction.

## Verification

- `npm run test:asc-testflight` - 22 state/JWT/API/security tests
- `npm run test` - 240 Vitest, 5 safe-area contract, 13 Playwright tests
- `npm run test:play-testers`
- `npm run typecheck`
- `npm run build`
- `npm run release:verify`
- `npm run icons:check`
- `node scripts/verify-ci-cache-policy.mjs`
- `actionlint .github/workflows/zuuli.yml .github/workflows/zuuli-testflight-recovery.yml`
- `git diff --check`
- immutable Build 10 source/identity proof against `6359bbe8ddbb23a5024383b1ce780a00b76c5e3f`

Closes #393


