### PR TITLE
fix(zuuli): simplify mobile login choices

### DIFF
--- a/wallet/zuuli/src/components/common/SocialButtons.tsx
+++ b/wallet/zuuli/src/components/common/SocialButtons.tsx
@@ -106,14 +106,14 @@ export function SocialButtons({
         onLinked?.(provider);
       } else {
         toast.success("Welcome to ZUULI", {
-          description: `Signed in with ${name}.`,
+          description: `Logged in with ${name}.`,
         });
         clearPendingSocialLoginDestination();
         navigate(loginDestination, { replace: true });
       }
     } catch (e) {
       if (!associate) clearPendingSocialLoginDestination();
-      toast.error(associate ? "Couldn't link that account" : "Couldn't sign in", {
+      toast.error(associate ? "Couldn't link that account" : "Couldn't log in", {
         description: e instanceof Error ? e.message : "Please try again.",
       });
     } finally {

--- a/wallet/zuuli/src/features/ai/PersonalityManager.tsx
+++ b/wallet/zuuli/src/features/ai/PersonalityManager.tsx
@@ -100,7 +100,7 @@ export function PersonalityManager({
             <div className="space-y-4">
               {!isAuthed ? (
                 <p className="rounded-lg border border-border bg-secondary/40 px-3 py-2 text-xs text-muted-foreground">
-                  Sign in with Zcash to create your own personalities. You can
+                  Log in to create your own personalities. You can
                   still use public ones below.
                 </p>
               ) : (

--- a/wallet/zuuli/src/features/articles/pages/Author.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Author.tsx
@@ -72,12 +72,12 @@ export function Author() {
         <PageHeader title="Write an article" />
         <EmptyState
           icon={Lock}
-          title="Sign in with Zcash to publish"
-          description="Authoring is free — sign a challenge with your wallet, no password or email required."
+          title="Log in to publish"
+          description="Authoring is free. Choose your login method to continue."
           action={
             <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
               <Button asChild>
-                <Link to="/login">Sign in with Zcash</Link>
+                <Link to="/login">Log in</Link>
               </Button>
               <Button asChild variant="outline">
                 <Link to="/articles">Back to articles</Link>

--- a/wallet/zuuli/src/features/auth/BrandPanel.tsx
+++ b/wallet/zuuli/src/features/auth/BrandPanel.tsx
@@ -46,7 +46,7 @@ export function BrandPanel() {
       <div className="relative max-w-md space-y-10">
         <div className="space-y-3">
           <h1 className="text-balance text-4xl font-bold leading-[1.1] tracking-tight xl:text-5xl">
-            Sign in your way — including with{" "}
+            Log in your way — including with{" "}
             <span className="zuuli-gradient-text">just your key</span>.
           </h1>
           <p className="text-lg text-muted-foreground">{APP_TAGLINE}</p>
@@ -54,20 +54,20 @@ export function BrandPanel() {
 
         <div className="space-y-4">
           <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            Why Continue with Zcash
+            Why Zcash
           </p>
           <ul className="space-y-5">
-          {VALUES.map(({ icon: Icon, title, body }) => (
-            <li key={title} className="flex gap-3.5">
-              <span className="mt-0.5 grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
-                <Icon className="h-5 w-5" aria-hidden />
-              </span>
-              <div className="space-y-0.5">
-                <p className="font-semibold">{title}</p>
-                <p className="text-sm text-muted-foreground">{body}</p>
-              </div>
-            </li>
-          ))}
+            {VALUES.map(({ icon: Icon, title, body }) => (
+              <li key={title} className="flex gap-3.5">
+                <span className="mt-0.5 grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
+                  <Icon className="h-5 w-5" aria-hidden />
+                </span>
+                <div className="space-y-0.5">
+                  <p className="font-semibold">{title}</p>
+                  <p className="text-sm text-muted-foreground">{body}</p>
+                </div>
+              </li>
+            ))}
           </ul>
         </div>
       </div>

--- a/wallet/zuuli/src/features/auth/ClassicLoginForm.tsx
+++ b/wallet/zuuli/src/features/auth/ClassicLoginForm.tsx
@@ -5,7 +5,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import { ArrowLeft, Link2, Loader2, LogIn, ShieldCheck } from "lucide-react";
+import { ArrowLeft, Loader2, LogIn, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -16,8 +16,10 @@ import type { LoginDestination } from "@/lib/auth/login-destination";
 
 export function ClassicLoginForm({
   loginDestination = "/",
+  onBusyChange,
 }: {
   loginDestination?: LoginDestination;
+  onBusyChange?: (busy: boolean) => void;
 }) {
   const navigate = useNavigate();
   const setUser = useSession((s) => s.setUser);
@@ -32,7 +34,7 @@ export function ClassicLoginForm({
   function land(user: AuthUser) {
     setUser(user);
     toast.success("Welcome back", {
-      description: `Signed in as ${user.username}.`,
+      description: `Logged in as ${user.username}.`,
     });
     navigate(loginDestination, { replace: true });
   }
@@ -41,6 +43,7 @@ export function ClassicLoginForm({
     e.preventDefault();
     if (!username || !password || submitting) return;
     setSubmitting(true);
+    onBusyChange?.(true);
     setError(null);
     try {
       const result = await auth.login(username.trim(), password);
@@ -55,6 +58,7 @@ export function ClassicLoginForm({
       );
     } finally {
       setSubmitting(false);
+      onBusyChange?.(false);
     }
   }
 
@@ -64,6 +68,7 @@ export function ClassicLoginForm({
         username={username.trim()}
         password={password}
         onVerified={land}
+        onBusyChange={onBusyChange}
         onBack={() => {
           setNeedsOtp(false);
           setError(null);
@@ -116,14 +121,8 @@ export function ClassicLoginForm({
         ) : (
           <LogIn className="h-4 w-4" aria-hidden />
         )}
-        {submitting ? "Signing in…" : "Sign in"}
+        {submitting ? "Logging in…" : "Log in"}
       </Button>
-
-      <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <Link2 className="h-3.5 w-3.5 shrink-0" aria-hidden />
-        You can link this account to your Zcash identity later for keys-only
-        sign-in.
-      </p>
     </form>
   );
 }
@@ -135,11 +134,13 @@ function OtpStep({
   password,
   onVerified,
   onBack,
+  onBusyChange,
 }: {
   username: string;
   password: string;
   onVerified: (user: AuthUser) => void;
   onBack: () => void;
+  onBusyChange?: (busy: boolean) => void;
 }) {
   const [code, setCode] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -149,6 +150,7 @@ function OtpStep({
     e.preventDefault();
     if (code.length !== 6 || submitting) return;
     setSubmitting(true);
+    onBusyChange?.(true);
     setError(null);
     try {
       const user = await auth.completeOtp(username, password, code);
@@ -158,6 +160,7 @@ function OtpStep({
       setCode("");
     } finally {
       setSubmitting(false);
+      onBusyChange?.(false);
     }
   }
 
@@ -170,7 +173,7 @@ function OtpStep({
         <div className="space-y-0.5">
           <p className="text-sm font-medium">Two-factor authentication</p>
           <p className="text-sm text-muted-foreground">
-            Enter the 6-digit code from your authenticator app to finish signing
+            Enter the 6-digit code from your authenticator app to finish logging
             in as{" "}
             <span className="font-medium text-foreground">{username}</span>.
           </p>
@@ -210,7 +213,7 @@ function OtpStep({
         ) : (
           <ShieldCheck className="h-4 w-4" aria-hidden />
         )}
-        {submitting ? "Verifying…" : "Verify and sign in"}
+        {submitting ? "Verifying…" : "Verify and log in"}
       </Button>
 
       <Button

--- a/wallet/zuuli/src/features/auth/SeedReveal.tsx
+++ b/wallet/zuuli/src/features/auth/SeedReveal.tsx
@@ -62,17 +62,17 @@ export function SeedReveal({ seedPhrase, onConfirm }: SeedRevealProps) {
         </ol>
 
         {!revealed && (
-          <button
-            type="button"
-            onClick={() => setRevealed(true)}
-            className="absolute inset-0 grid place-items-center rounded-lg bg-background/40 backdrop-blur-[2px] transition-colors hover:bg-background/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-            aria-label="Reveal recovery phrase"
-          >
-            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 text-sm font-medium shadow-glow">
+          <div className="absolute inset-0 grid place-items-center rounded-lg bg-background/40 backdrop-blur-[2px]">
+            <button
+              type="button"
+              onClick={() => setRevealed(true)}
+              className="min-tap inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 text-sm font-medium shadow-glow transition-colors hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              aria-label="Reveal recovery phrase"
+            >
               <Eye className="h-4 w-4" aria-hidden />
               Tap to reveal
-            </span>
-          </button>
+            </button>
+          </div>
         )}
       </div>
 

--- a/wallet/zuuli/src/features/auth/ZShieldInfo.tsx
+++ b/wallet/zuuli/src/features/auth/ZShieldInfo.tsx
@@ -21,7 +21,7 @@ const POINTS = [
   {
     icon: KeyRound,
     title: "You prove control by signing",
-    body: "To sign in you sign a fresh, one-time challenge with your key using ZIP-304. The signature proves you hold the key without ever revealing it.",
+    body: "To log in you sign a fresh, one-time challenge with your key using ZIP-304. The signature proves you hold the key without ever revealing it.",
   },
   {
     icon: ShieldCheck,

--- a/wallet/zuuli/src/features/auth/ZcashLoginFlow.tsx
+++ b/wallet/zuuli/src/features/auth/ZcashLoginFlow.tsx
@@ -6,13 +6,13 @@
 
 import {
   AlertCircle,
-  ArrowRight,
   Check,
   Fingerprint,
   Loader2,
   RotateCw,
   Sparkles,
 } from "lucide-react";
+import { useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { truncateAddress } from "@/lib/format";
@@ -57,8 +57,10 @@ function StepIcon({ status }: { status: StepStatus }) {
 
 export function ZcashLoginFlow({
   loginDestination = "/",
+  onBusyChange,
 }: {
   loginDestination?: LoginDestination;
+  onBusyChange?: (busy: boolean) => void;
 }) {
   const flow = useZcashLogin(loginDestination);
   const {
@@ -73,29 +75,33 @@ export function ZcashLoginFlow({
     retry,
   } = flow;
 
+  useEffect(() => {
+    const busy = phase === "running" || phase === "creating" || phase === "success";
+    onBusyChange?.(busy);
+  }, [onBusyChange, phase]);
+
   // ── Initial call-to-action ────────────────────────────────────────────────
   if (phase === "idle") {
     return (
-      <div className="space-y-5">
-        <div className="flex items-start gap-3 rounded-lg border border-border bg-background/40 p-4">
-          <span className="mt-0.5 grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
-            <Fingerprint className="h-5 w-5" aria-hidden />
+      <div className="space-y-4">
+        <div className="flex items-center gap-3 rounded-lg border border-border bg-background/40 p-3">
+          <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-primary/15 text-primary">
+            <Fingerprint aria-hidden />
           </span>
           <p className="text-sm text-muted-foreground">
-            Sign a one-time challenge with your Zcash key to prove it is yours.
-            No password, no email, no third party — the key never leaves this
-            device.
+            Your key signs a one-time challenge and never leaves this device.
           </p>
         </div>
         <Button
-          size="xl"
+          size="lg"
           className="w-full"
-          onClick={start}
-          aria-label="Login with Zcash"
+          onClick={() => {
+            onBusyChange?.(true);
+            start();
+          }}
         >
           <Sparkles className="h-5 w-5" aria-hidden />
-          Login with Zcash
-          <ArrowRight className="h-5 w-5" aria-hidden />
+          Continue
         </Button>
       </div>
     );
@@ -116,7 +122,10 @@ export function ZcashLoginFlow({
         <Button
           size="xl"
           className="w-full"
-          onClick={() => void createIdentity()}
+          onClick={() => {
+            onBusyChange?.(true);
+            void createIdentity();
+          }}
           disabled={creating}
         >
           {creating ? (
@@ -132,7 +141,15 @@ export function ZcashLoginFlow({
 
   // ── Freshly created — back up the recovery phrase before continuing ───────
   if (phase === "seedReveal" && seedPhrase) {
-    return <SeedReveal seedPhrase={seedPhrase} onConfirm={confirmSeedSaved} />;
+    return (
+      <SeedReveal
+        seedPhrase={seedPhrase}
+        onConfirm={() => {
+          onBusyChange?.(true);
+          confirmSeedSaved();
+        }}
+      />
+    );
   }
 
   // ── Success terminal ──────────────────────────────────────────────────────
@@ -145,7 +162,7 @@ export function ZcashLoginFlow({
         <div>
           <p className="text-lg font-semibold">Identity verified</p>
           <p className="text-sm text-muted-foreground">
-            Signing you in to ZUULI…
+            Logging you in to ZUULI…
           </p>
         </div>
       </div>
@@ -215,7 +232,13 @@ export function ZcashLoginFlow({
             <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
             <span>{error ?? "The login could not be completed."}</span>
           </div>
-          <Button className="w-full" onClick={retry}>
+          <Button
+            className="w-full"
+            onClick={() => {
+              onBusyChange?.(true);
+              retry();
+            }}
+          >
             <RotateCw className="h-4 w-4" aria-hidden />
             Try again
           </Button>

--- a/wallet/zuuli/src/features/auth/auth-density.test.tsx
+++ b/wallet/zuuli/src/features/auth/auth-density.test.tsx
@@ -1,0 +1,69 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { AuthChooser, SelectedAuthMethod } from "./index";
+
+function render(ui: React.ReactNode): string {
+  return renderToStaticMarkup(
+    <TooltipProvider>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </TooltipProvider>,
+  );
+}
+
+describe("compact auth chooser", () => {
+  it("shows only neutral, concise decisions before identity is known", () => {
+    const markup = render(<AuthChooser onSelect={vi.fn()} />);
+
+    expect(markup).toContain("<h1>Log in</h1>");
+    expect(markup).toContain(">Zcash</button>");
+    expect(markup).toContain(">Password</button>");
+    expect(markup).toContain("How it works");
+    expect(markup).toContain('aria-label="Continue as guest"');
+    expect(markup).not.toContain("Welcome back");
+    expect(markup).not.toContain("Continue with Zcash");
+    expect(markup).not.toContain("Email or username");
+    expect(markup).not.toContain("More sign-in options coming soon");
+  });
+
+  it("keeps each chooser control at the 44px minimum tap target", () => {
+    const markup = render(<AuthChooser onSelect={vi.fn()} />);
+    const methodButtons = [...markup.matchAll(/<button[^>]+>/g)].slice(0, 2);
+    expect(methodButtons).toHaveLength(2);
+    for (const [button] of methodButtons) {
+      expect(button).toContain("h-11");
+      expect(button).toContain("min-tap");
+    }
+
+    const controls = [...markup.matchAll(/<(?:button|a)[^>]+>/g)];
+    expect(controls).toHaveLength(4);
+    for (const [control] of controls) expect(control).toContain("min-tap");
+  });
+});
+
+describe("selected auth methods", () => {
+  it("does not repeat Zcash in the selected method CTA", () => {
+    const markup = render(
+      <SelectedAuthMethod method="zcash" onBack={vi.fn()} />,
+    );
+
+    expect(markup).toContain("<h1>Zcash</h1>");
+    expect(markup).toContain(">Continue</button>");
+    expect(markup).not.toContain("Login with Zcash");
+    expect(markup).not.toContain("Continue with Zcash");
+    expect(markup).toContain("never leaves this device");
+  });
+
+  it("gives the icon-only method back control a name and minimum target", () => {
+    const markup = render(
+      <SelectedAuthMethod method="password" onBack={vi.fn()} />,
+    );
+
+    expect(markup).toContain('aria-label="Choose another login method"');
+    expect(markup).toMatch(/class="[^"]*min-tap[^"]*h-11 w-11/);
+    expect(markup).toContain("<h1>Password</h1>");
+    expect(markup).toContain('for="f2z-username"');
+    expect(markup).toContain('for="f2z-password"');
+  });
+});

--- a/wallet/zuuli/src/features/auth/index.tsx
+++ b/wallet/zuuli/src/features/auth/index.tsx
@@ -7,32 +7,44 @@
 
 import { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { ArrowLeft, ArrowUpRight, HelpCircle, ShieldCheck } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  HelpCircle,
+  KeyRound,
+  ShieldCheck,
+} from "lucide-react";
 import { Wordmark } from "@/components/brand/Logo";
 import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useWallet } from "@/store/wallet";
 import { SocialButtons } from "@/components/common/SocialButtons";
 import { BrandPanel } from "./BrandPanel";
 import { ClassicLoginForm } from "./ClassicLoginForm";
 import { ZcashLoginFlow } from "./ZcashLoginFlow";
 import { ZShieldInfo } from "./ZShieldInfo";
-import { loginDestinationFromState } from "@/lib/auth/login-destination";
+import {
+  loginDestinationFromState,
+  type LoginDestination,
+} from "@/lib/auth/login-destination";
 
-type Method = "chooser" | "zcash";
+export type AuthMethod = "chooser" | "zcash" | "password";
 
 export default function AuthFeature() {
   const location = useLocation();
   const loginDestination = loginDestinationFromState(location.state);
   const bootstrap = useWallet((s) => s.bootstrap);
-  const [method, setMethod] = useState<Method>("chooser");
+  const [method, setMethod] = useState<AuthMethod>("chooser");
 
   useEffect(() => {
     void bootstrap();
@@ -45,110 +57,161 @@ export default function AuthFeature() {
     >
       <BrandPanel />
 
-      <main className="app-auth-content relative flex min-h-full flex-col items-center justify-start p-6 sm:p-10">
+      <main className="app-auth-content relative flex min-h-full flex-col items-center justify-start p-4 sm:p-10">
         {/* Auto block margins center the stack only when it fits. Unlike
             justify-center, they collapse to zero when the stack is taller
             than the bounded scroller, so its top can always be reached. */}
         <div className="app-auth-stack my-auto flex w-full max-w-md flex-col">
           {/* Compact wordmark for small screens where the brand panel is hidden */}
-          <div className="mb-8 lg:hidden">
+          <div className="mb-4 lg:hidden">
             <Wordmark />
           </div>
 
           <div className="w-full animate-slide-up">
-            <Card className="border-border/80 bg-card/70 shadow-glow backdrop-blur">
-              <CardHeader className="space-y-1">
-                <CardTitle className="text-2xl">Sign in to ZUULI</CardTitle>
-                <CardDescription>
-                  {method === "zcash"
-                    ? "Prove control of your Zcash key to sign in — no password."
-                    : "Welcome back. Choose how you'd like to continue."}
-                </CardDescription>
-              </CardHeader>
-
-              <CardContent className="space-y-6">
-                {method === "zcash" ? (
-                  <div className="space-y-5">
-                    <button
-                      type="button"
-                      onClick={() => setMethod("chooser")}
-                      className="min-tap inline-flex items-center gap-1.5 rounded-md text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      aria-label="Back to all sign-in options"
-                    >
-                      <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
-                      All sign-in options
-                    </button>
-                    <ZcashLoginFlow loginDestination={loginDestination} />
-                  </div>
-                ) : (
-                  <>
-                    {/* Primary method — Login with Zcash (default, passwordless) */}
-                    <div className="space-y-2">
-                      <Button
-                        type="button"
-                        size="lg"
-                        className="w-full justify-center text-sm font-semibold"
-                        onClick={() => setMethod("zcash")}
-                      >
-                        <ShieldCheck className="h-4 w-4" aria-hidden />
-                        Continue with Zcash
-                      </Button>
-                      <p className="text-center text-xs text-muted-foreground">
-                        Passwordless — prove control of your Zcash key. No email,
-                        no KYC.
-                      </p>
-                    </div>
-
-                    <div className="flex items-center gap-3">
-                      <Separator className="flex-1" />
-                      <span className="text-xs uppercase tracking-wider text-muted-foreground">
-                        or use a password
-                      </span>
-                      <Separator className="flex-1" />
-                    </div>
-
-                    {/* Alternative — email/username + password (with 2FA) */}
-                    <ClassicLoginForm loginDestination={loginDestination} />
-
-                    {/* X / Google / GitHub — renders only for providers the
-                        backend reports as configured (none, today) */}
-                    <SocialButtons loginDestination={loginDestination} />
-
-                    <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
-                      <ZShieldInfo>
-                        <button
-                          type="button"
-                          className="min-tap inline-flex items-center gap-1.5 rounded-md text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                          aria-label="How Login with Zcash works"
-                        >
-                          <HelpCircle className="h-3.5 w-3.5" aria-hidden />
-                          How Zcash login works
-                        </button>
-                      </ZShieldInfo>
-
-                      <Button
-                        asChild
-                        variant="link"
-                        size="sm"
-                        className="text-muted-foreground"
-                      >
-                        <Link to="/" aria-label="Explore ZUULI as a guest">
-                          Continue as guest
-                          <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
-                        </Link>
-                      </Button>
-                    </div>
-                  </>
-                )}
-              </CardContent>
-            </Card>
-
-            <p className="mt-6 text-center text-xs text-muted-foreground lg:hidden">
-              © {new Date().getFullYear()} 2Z Inc
-            </p>
+            {method === "chooser" ? (
+              <AuthChooser
+                loginDestination={loginDestination}
+                onSelect={setMethod}
+              />
+            ) : (
+              <SelectedAuthMethod
+                loginDestination={loginDestination}
+                method={method}
+                onBack={() => setMethod("chooser")}
+              />
+            )}
           </div>
         </div>
       </main>
     </div>
+  );
+}
+
+export function AuthChooser({
+  loginDestination = "/",
+  onSelect,
+}: {
+  loginDestination?: LoginDestination;
+  onSelect: (method: Exclude<AuthMethod, "chooser">) => void;
+}) {
+  return (
+    <Card
+      className="border-border/80 bg-card/70 shadow-glow backdrop-blur"
+      data-auth-chooser
+    >
+      <CardHeader className="p-5 pb-4">
+        <CardTitle className="text-2xl">
+          <h1>Log in</h1>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 p-5 pt-0">
+        <Button
+          type="button"
+          size="lg"
+          className="w-full justify-center"
+          onClick={() => onSelect("zcash")}
+        >
+          <ShieldCheck aria-hidden />
+          Zcash
+        </Button>
+        <Button
+          type="button"
+          size="lg"
+          variant="outline"
+          className="w-full justify-center"
+          onClick={() => onSelect("password")}
+        >
+          <KeyRound aria-hidden />
+          Password
+        </Button>
+
+        {/* Configured providers are additional methods. The empty state adds
+            no decision and no translation surface, so it stays invisible. */}
+        <SocialButtons
+          emptyState={null}
+          loginDestination={loginDestination}
+        />
+
+        <div className="flex min-h-11 items-center justify-between">
+          <ZShieldInfo>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="min-tap text-muted-foreground"
+            >
+              <HelpCircle aria-hidden />
+              How it works
+            </Button>
+          </ZShieldInfo>
+
+          <Button
+            asChild
+            variant="ghost"
+            size="sm"
+            className="min-tap text-muted-foreground"
+          >
+            <Link to="/" aria-label="Continue as guest">
+              Guest
+              <ArrowUpRight aria-hidden />
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function SelectedAuthMethod({
+  loginDestination = "/",
+  method,
+  onBack,
+}: {
+  loginDestination?: LoginDestination;
+  method: Exclude<AuthMethod, "chooser">;
+  onBack: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const title = method === "zcash" ? "Zcash" : "Password";
+  return (
+    <Card
+      className="border-border/80 bg-card/70 shadow-glow backdrop-blur"
+      data-auth-selected={method}
+    >
+      <CardHeader className="flex-row items-center gap-3 space-y-0 p-5 pb-4">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="min-tap h-11 w-11 shrink-0"
+              onClick={onBack}
+              disabled={busy}
+              aria-label="Choose another login method"
+            >
+              <ArrowLeft aria-hidden />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Choose another method</TooltipContent>
+        </Tooltip>
+        <CardTitle className="text-xl">
+          <h1>{title}</h1>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-5 pt-0">
+        {method === "zcash" ? (
+          <ZcashLoginFlow
+            loginDestination={loginDestination}
+            onBusyChange={setBusy}
+          />
+        ) : (
+          <ClassicLoginForm
+            loginDestination={loginDestination}
+            onBusyChange={setBusy}
+          />
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/wallet/zuuli/src/features/auth/useZcashLogin.ts
+++ b/wallet/zuuli/src/features/auth/useZcashLogin.ts
@@ -69,7 +69,7 @@ export function useZcashLogin(
     onVerified: (user) => setUser(user),
     afterSuccess: async () => {
       toast.success("Welcome to ZUULI", {
-        description: "Signed in with your Zcash key.",
+        description: "Logged in with your Zcash key.",
       });
       await new Promise((r) => setTimeout(r, 700));
       navigate(loginDestination, { replace: true });

--- a/wallet/zuuli/src/features/kyc/index.tsx
+++ b/wallet/zuuli/src/features/kyc/index.tsx
@@ -34,11 +34,11 @@ export default function KycFeature() {
         <PageHeader title="Apply for revenue share" />
         <EmptyState
           icon={Lock}
-          title="Sign in to apply"
-          description="Sign in with Zcash to start your creator revenue-share application."
+          title="Log in to apply"
+          description="Log in to start your creator revenue-share application."
           action={
             <Button asChild>
-              <Link to="/login">Sign in with Zcash</Link>
+              <Link to="/login">Log in</Link>
             </Button>
           }
         />

--- a/wallet/zuuli/src/features/live/GoLiveDialog.tsx
+++ b/wallet/zuuli/src/features/live/GoLiveDialog.tsx
@@ -76,8 +76,8 @@ export function GoLiveDialog() {
       // ("Authentication credentials were not provided.").
       if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
         setOpen(false);
-        toast.error("Sign in to go live", {
-          description: "Your session ended — please sign in again.",
+        toast.error("Log in to go live", {
+          description: "Your session ended — please log in again.",
         });
         navigate("/login");
         return;
@@ -91,7 +91,7 @@ export function GoLiveDialog() {
   }
 
   // Going live requires an account. When signed out, don't offer a broadcast
-  // action that can only fail — route the user to sign in instead.
+  // action that can only fail — route the user to log in instead.
   if (!user) {
     return (
       <Button
@@ -101,7 +101,7 @@ export function GoLiveDialog() {
         onClick={() => navigate("/login")}
       >
         <LogIn className="h-4 w-4" aria-hidden />
-        Authenticate to go live
+        Log in to go live
       </Button>
     );
   }

--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -552,7 +552,7 @@ function JoinPanel({
               <Button asChild className="w-full gap-2" size="lg">
                 <Link to="/login">
                   <KeyRound className="h-4 w-4" aria-hidden />
-                  Sign in to subscribe
+                  Log in to subscribe
                 </Link>
               </Button>
             ) : membershipError ? (

--- a/wallet/zuuli/src/features/profile/index.tsx
+++ b/wallet/zuuli/src/features/profile/index.tsx
@@ -38,11 +38,11 @@ export default function ProfileFeature() {
         <PageHeader title="Edit profile" />
         <EmptyState
           icon={Lock}
-          title="Sign in with Zcash to edit your profile"
-          description="Sign a challenge with your wallet — no password or email required."
+          title="Log in to edit your profile"
+          description="Choose your login method to continue."
           action={
             <Button asChild>
-              <Link to="/login">Sign in with Zcash</Link>
+              <Link to="/login">Log in</Link>
             </Button>
           }
         />

--- a/wallet/zuuli/src/features/wallet/funding/BuyTab.tsx
+++ b/wallet/zuuli/src/features/wallet/funding/BuyTab.tsx
@@ -296,7 +296,7 @@ export function BuyTab() {
             ) : (
               <CreditCard className="h-4 w-4" />
             )}
-            {user ? "Pay with card" : "Sign in to buy"}
+            {user ? "Pay with card" : "Log in to buy"}
           </Button>
           <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <ShieldCheck className="h-3.5 w-3.5 text-emerald-400" />

--- a/wallet/zuuli/src/features/wallet/funding/SendTab.tsx
+++ b/wallet/zuuli/src/features/wallet/funding/SendTab.tsx
@@ -213,7 +213,7 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
       : undefined;
 
   const recipientHelp = useMemo(() => {
-    if (!ownUsername) return "Sign in before sending 2Z.";
+    if (!ownUsername) return "Log in before sending 2Z.";
     if (exactSelfQuery) return "You can't send 2Z to your own account.";
     if (recipientState.searchStatus === "error") {
       return "Creator search failed. Check your connection and try again.";

--- a/wallet/zuuli/src/features/wallet/funding/card-checkout.test.ts
+++ b/wallet/zuuli/src/features/wallet/funding/card-checkout.test.ts
@@ -97,7 +97,7 @@ describe("card checkout failure guidance", () => {
     "sends an HTTP %i session failure back to sign-in",
     (status) => {
       expect(cardCheckoutFeedback(new ApiError(status, "auth"))).toMatchObject({
-        title: "Sign in again",
+        title: "Log in again",
         signIn: true,
       });
     },

--- a/wallet/zuuli/src/features/wallet/funding/card-checkout.ts
+++ b/wallet/zuuli/src/features/wallet/funding/card-checkout.ts
@@ -70,8 +70,8 @@ export function cardCheckoutFeedback(error: unknown): CardCheckoutFeedback {
     (error.status === 401 || error.status === 403)
   ) {
     return {
-      title: "Sign in again",
-      description: "Your session expired. Sign in, then retry your purchase.",
+      title: "Log in again",
+      description: "Your session expired. Log in, then retry your purchase.",
       signIn: true,
     };
   }

--- a/wallet/zuuli/src/features/wallet/funding/send-recipient.ts
+++ b/wallet/zuuli/src/features/wallet/funding/send-recipient.ts
@@ -483,7 +483,7 @@ export function transferFailureIsAmbiguous(failure: TransferFailure): boolean {
 }
 
 export const TRANSFER_FAILURE_MESSAGES: Record<TransferFailure, string> = {
-  auth: "Your session expired. Sign in again before sending 2Z.",
+  auth: "Your session expired. Log in again before sending 2Z.",
   balance: "Your 2Z balance changed and is no longer enough for this tip.",
   "not-found":
     "That creator is no longer available. Search again before sending.",

--- a/wallet/zuuli/src/lib/wallet/mock.ts
+++ b/wallet/zuuli/src/lib/wallet/mock.ts
@@ -29,6 +29,21 @@ let tip = 2_612_004;
 let synced = 2_612_004;
 let syncing = false;
 
+/**
+ * Browser-only scenarios for exercising states that otherwise require a
+ * freshly installed device or a native wallet failure. Kept behind the mock
+ * wallet boundary so production/native behavior cannot observe them.
+ */
+const MOCK_WALLET_SCENARIO_KEY = "zuuli.mock.wallet-scenario";
+function mockWalletScenario(): "empty" | "sign-error" | null {
+  try {
+    const value = globalThis.localStorage?.getItem(MOCK_WALLET_SCENARIO_KEY);
+    return value === "empty" || value === "sign-error" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 const balance: AccountBalance = {
   accountIndex: 0,
   totalShielded: 137_400_000, // 1.374 ZEC
@@ -68,9 +83,10 @@ let proposalCounter = 1;
 
 export const mockWallet = {
   getWalletStatus(): WalletStatus {
+    const initialized = mockWalletScenario() === "empty" ? false : created;
     return {
-      initialized: created,
-      hasSeed: created,
+      initialized,
+      hasSeed: initialized,
       syncedHeight: synced,
       chainTip: tip,
       activeWalletId: "mock-wallet-0",
@@ -206,6 +222,9 @@ export const mockWallet = {
   },
   discardUnrecoverableSend() {},
   signChallenge(challenge: string): SignedChallenge {
+    if (mockWalletScenario() === "sign-error") {
+      throw new Error("The mock wallet could not sign this challenge.");
+    }
     // A believable-looking signature. Real signing happens in the Rust plugin
     // (ZIP-304); this keeps the browser demo flowing.
     const sig = btoa(`${MOCK_UA}:${challenge}`).replace(/=+$/, "");

--- a/wallet/zuuli/tests/auth-density.pw.ts
+++ b/wallet/zuuli/tests/auth-density.pw.ts
@@ -1,0 +1,184 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const PHONE_VIEWPORTS = [
+  { label: "320x568", width: 320, height: 568 },
+  { label: "iPhone SE", width: 375, height: 667 },
+] as const;
+
+async function openLogin(
+  page: Page,
+  viewport: (typeof PHONE_VIEWPORTS)[number],
+  walletScenario?: "empty" | "sign-error",
+) {
+  await page.setViewportSize(viewport);
+  await page.addInitScript((scenario) => {
+    localStorage.removeItem("zuuli.knox.token");
+    if (scenario) localStorage.setItem("zuuli.mock.wallet-scenario", scenario);
+    else localStorage.removeItem("zuuli.mock.wallet-scenario");
+  }, walletScenario);
+  await page.goto("/login");
+  await page.addStyleTag({
+    content: `:root {
+      --safe-area-top: 20px !important;
+      --safe-area-bottom: 16px !important;
+    }`,
+  });
+  await expect(page.locator("[data-route-frame] [data-route-scroll]")).toBeVisible();
+}
+
+async function expectAuthGeometry(page: Page, noVerticalScroll: boolean) {
+  const metrics = await page
+    .locator("[data-route-frame] [data-route-scroll]")
+    .evaluate((scroller) => {
+      const boundary = scroller.getBoundingClientRect();
+      const outside = [...scroller.querySelectorAll<HTMLElement>("*")]
+        .filter((element) => {
+          const rect = element.getBoundingClientRect();
+          const style = getComputedStyle(element);
+          return (
+            rect.width > 0 &&
+            rect.height > 0 &&
+            style.display !== "none" &&
+            style.visibility !== "hidden" &&
+            !element.closest("[hidden], [inert], [aria-hidden='true']") &&
+            !element.closest("svg") &&
+            (rect.left < boundary.left - 1 || rect.right > boundary.right + 1)
+          );
+        })
+        .map((element) => element.getAttribute("aria-label") ?? element.innerText.slice(0, 50));
+
+      return {
+        clientHeight: scroller.clientHeight,
+        clientWidth: scroller.clientWidth,
+        outside,
+        rootClientHeight: document.documentElement.clientHeight,
+        rootClientWidth: document.documentElement.clientWidth,
+        rootScrollHeight: document.documentElement.scrollHeight,
+        rootScrollWidth: document.documentElement.scrollWidth,
+        scrollHeight: scroller.scrollHeight,
+        scrollWidth: scroller.scrollWidth,
+      };
+    });
+
+  expect(metrics.rootScrollWidth).toBeLessThanOrEqual(metrics.rootClientWidth);
+  expect(metrics.rootScrollHeight).toBeLessThanOrEqual(metrics.rootClientHeight);
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+  expect(metrics.outside).toEqual([]);
+  if (noVerticalScroll) {
+    expect(metrics.scrollHeight).toBeLessThanOrEqual(metrics.clientHeight + 1);
+  }
+}
+
+async function expectReachable(scroller: Locator, target: Locator) {
+  await target.scrollIntoViewIfNeeded();
+  await expect(target).toBeVisible();
+  const [boundary, control] = await Promise.all([
+    scroller.boundingBox(),
+    target.boundingBox(),
+  ]);
+  expect(boundary).not.toBeNull();
+  expect(control).not.toBeNull();
+  const visibleTop = Math.max(control!.y, boundary!.y);
+  const visibleBottom = Math.min(
+    control!.y + control!.height,
+    boundary!.y + boundary!.height,
+  );
+  expect(visibleBottom - visibleTop).toBeGreaterThanOrEqual(
+    Math.min(44, control!.height),
+  );
+}
+
+for (const viewport of PHONE_VIEWPORTS) {
+  test(`chooser, password, OTP and error stay compact and reachable on ${viewport.label}`, async ({
+    page,
+  }) => {
+    await openLogin(page, viewport);
+    const scroller = page.locator("[data-route-frame] [data-route-scroll]");
+
+    await expect(page.getByRole("heading", { name: "Log in" })).toBeVisible();
+    await expect(page.getByText("Welcome back", { exact: false })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Zcash", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Password", exact: true })).toBeVisible();
+    await expectAuthGeometry(page, true);
+
+    await page.getByRole("button", { name: "Zcash", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Zcash" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Continue", exact: true })).toBeVisible();
+    await expect(
+      page.locator("[data-auth-selected]").getByText(/Login with Zcash|Continue with Zcash/),
+    ).toHaveCount(0);
+    await expectAuthGeometry(page, true);
+
+    const back = page.getByRole("button", { name: "Choose another login method" });
+    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+    await page.keyboard.press("Tab");
+    await expect(back).toBeFocused();
+    expect(await back.evaluate((element) => getComputedStyle(element).boxShadow)).not.toBe("none");
+    await back.hover();
+    await expect(page.getByRole("tooltip", { name: "Choose another method" })).toBeVisible();
+    await back.click();
+
+    await page.getByRole("button", { name: "Password", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Password" })).toBeVisible();
+    await expectAuthGeometry(page, true);
+    const passwordBack = page.getByRole("button", {
+      name: "Choose another login method",
+    });
+    await page.getByLabel("Email or username").fill("otp-user");
+    await page.getByLabel("Password").fill("mock-password");
+    await page
+      .locator("[data-auth-selected='password']")
+      .getByRole("button", { name: "Log in", exact: true })
+      .click();
+    await expect(passwordBack).toBeDisabled();
+
+    await expect(page.getByText("Two-factor authentication")).toBeVisible();
+    await expect(passwordBack).toBeEnabled();
+    await expectAuthGeometry(page, false);
+    await page.getByLabel("Authentication code").fill("000000");
+    await page.getByRole("button", { name: "Verify and log in" }).click();
+    await expect(passwordBack).toBeDisabled();
+    const error = page.getByRole("alert");
+    await expect(error).toContainText("code didn't match");
+    await expect(passwordBack).toBeEnabled();
+    await expectReachable(scroller, error);
+    await expectReachable(scroller, page.getByRole("button", { name: "Use a different account" }));
+    await expectAuthGeometry(page, false);
+  });
+
+  test(`Zcash error remains reachable on ${viewport.label}`, async ({ page }) => {
+    await openLogin(page, viewport, "sign-error");
+    const scroller = page.locator("[data-route-frame] [data-route-scroll]");
+    await page.getByRole("button", { name: "Zcash", exact: true }).click();
+    const back = page.getByRole("button", {
+      name: "Choose another login method",
+    });
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+    await expect(back).toBeDisabled();
+    const retry = page.getByRole("button", { name: "Try again" });
+    await expect(retry).toBeVisible();
+    await expect(back).toBeEnabled();
+    await expectReachable(scroller, retry);
+    await expectAuthGeometry(page, false);
+  });
+
+  test(`seed safety remains reachable on ${viewport.label}`, async ({ page }) => {
+    await openLogin(page, viewport, "empty");
+    const scroller = page.locator("[data-route-frame] [data-route-scroll]");
+    await page.getByRole("button", { name: "Zcash", exact: true }).click();
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+    await expect(page.getByText("No Zcash identity on this device")).toBeVisible();
+    await page.getByRole("button", { name: "Create a Zcash identity" }).click();
+
+    await expect(page.getByText("This recovery phrase is your identity.")).toBeVisible();
+    const reveal = page.getByRole("button", { name: "Reveal recovery phrase" });
+    await expectReachable(scroller, reveal);
+    await reveal.click();
+    const acknowledgement = page.getByRole("checkbox");
+    await expectReachable(scroller, acknowledgement);
+    await acknowledgement.check();
+    await expectReachable(scroller, page.getByRole("button", { name: "I saved it — continue" }));
+    await expect(page.getByText(/Anyone who sees them controls your account/)).toBeVisible();
+    await expectAuthGeometry(page, false);
+  });
+}

--- a/wallet/zuuli/tests/touch-targets.pw.ts
+++ b/wallet/zuuli/tests/touch-targets.pw.ts
@@ -293,7 +293,9 @@ for (const signedIn of [false, true]) {
       await page.keyboard.press("Escape");
 
       await page.goto("/login");
-      await page.getByRole("button", { name: "Continue with Zcash" }).click();
+      await page.getByRole("button", { name: "Zcash", exact: true }).click();
+      await expect(page.getByRole("heading", { name: "Zcash" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Continue" })).toBeVisible();
       routeFailures.push(
         ...(await auditTouchTargets(page)).failures.map(
           (failure) => `/login?method=zcash: ${failure}`,

--- a/wallet/zuuli/tests/viewport.pw.ts
+++ b/wallet/zuuli/tests/viewport.pw.ts
@@ -326,14 +326,18 @@ test("signed-out card checkout returns to Wallet funding after login at 320px", 
   await page.goto("/wallet/fund");
   await page.locator("[data-app-frame]").waitFor();
 
-  await page.getByRole("button", { name: "Sign in to buy" }).click();
+  await page.getByRole("button", { name: "Log in to buy" }).click();
   await expect(page).toHaveURL(/\/login$/);
-  await expect(page.getByText("Sign in to ZUULI", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Log in" })).toBeVisible();
   expect((await auditHorizontalLayout(page)).failures).toEqual([]);
 
+  await page.getByRole("button", { name: "Password" }).click();
   await page.getByLabel("Email or username").fill("checkout-return");
   await page.getByLabel("Password").fill("mock-password");
-  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await page
+    .locator("[data-auth-selected='password']")
+    .getByRole("button", { name: "Log in", exact: true })
+    .click();
 
   await expect(page).toHaveURL(/\/wallet\/fund$/);
   await expect(page.getByRole("button", { name: "Pay with card" })).toBeVisible();


### PR DESCRIPTION
Closes #392
Closes #328

## Summary

- replace the dense pre-identity form with a neutral, compact chooser (`Zcash`, `Password`, configured social methods, `Guest`)
- reduce repeated authentication copy across entry points while retaining detailed Zcash documentation in the opt-in help dialog
- preserve the #400 login destination contract, including the canonical `/wallet/fund` checkout return
- keep recovery phrase, password, OTP, signing-error, and empty-wallet states reachable inside the bounded auth scroller
- prevent switching methods while password, OTP, or Zcash authentication can still establish a session

## Mobile evidence

The real-browser matrix covers 320×568 and 375×667 (iPhone SE) with simulated top/bottom safe areas. It verifies:

- chooser, Zcash, and password states do not scroll when their content fits
- root and bounded auth scroller have no horizontal overflow
- password, OTP error, Zcash signing error, and recovery phrase actions remain scroll-reachable
- icon-only back control has a 44px target, keyboard focus indication, accessible name, and tooltip
- method switching is disabled during password, OTP, and Zcash authentication work
- the signed-out card flow returns to `/wallet/fund` after password login

## Verification

- `npm test` — 258 Vitest, 5 safe-area contracts, 26 Playwright cases passed
- `npm run typecheck`
- `npm run build`
- `git diff --check origin/main...HEAD`

## Adversarial review

The first exact-commit review found a P2 method-switch race: an in-flight password or OTP request could complete after its form was unmounted. The fix propagates busy state from classic, OTP, and Zcash operations and disables the selected-method back control until each operation reaches a safe terminal state; the browser regression asserts all three paths.

The final review of the amended exact commit reported: “The authentication flow refactor preserves login behavior and destination handling while improving method selection and busy-state protection. Typechecking, unit tests, and the production build pass; no actionable regressions were identified.”
