### PR TITLE
fix(zuuli): bootstrap internal TestFlight group

### DIFF
--- a/.github/workflows/zuuli-testflight-bootstrap.yml
+++ b/.github/workflows/zuuli-testflight-bootstrap.yml
@@ -1,0 +1,134 @@
+name: ZUULI / TestFlight protected bootstrap
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Exact full commit SHA that established the release identity
+        required: true
+        type: string
+      identity:
+        description: Exact version+build to publish internally
+        required: true
+        default: 0.1.0+10
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zuuli-mobile-store
+  cancel-in-progress: false
+
+jobs:
+  bootstrap:
+    name: Create internal group and publish exact build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    environment: zuuli-app-stores
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    env:
+      ASC_KEY_ID: ${{ vars.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ vars.ASC_ISSUER_ID }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+      - name: Verify immutable release identity
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          CONFIRMED_IDENTITY: ${{ inputs.identity }}
+        run: |
+          set -euo pipefail
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "source SHA must be a full lowercase 40-character commit SHA" >&2
+            exit 1
+          }
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
+          identity_sha=$(git log -1 --format=%H "$SOURCE_SHA" -- release.json)
+          [[ "$identity_sha" == "$SOURCE_SHA" ]] || {
+            echo "source SHA must be the commit that established this release identity" >&2
+            exit 1
+          }
+          release_json=$(git show "${SOURCE_SHA}:wallet/zuuli/release.json")
+          jq -e '
+            (.schemaVersion == 1 or .schemaVersion == 2) and
+            .applicationId == "cash.free2z.zuuli" and
+            .iosUsesNonExemptEncryption == false and
+            (.version | type == "string") and
+            (.build | type == "number" and floor == . and . >= 1)
+          ' <<<"$release_json" >/dev/null
+          actual_identity=$(jq -r '.version + "+" + (.build | tostring)' <<<"$release_json")
+          [[ "$actual_identity" == "$CONFIRMED_IDENTITY" ]] || {
+            echo "confirmed identity does not match the immutable source" >&2
+            exit 1
+          }
+          current_release_json=$(git show refs/remotes/origin/main:wallet/zuuli/release.json)
+          current_identity=$(jq -er '.version + "+" + (.build | tostring)' <<<"$current_release_json")
+          [[ "$current_identity" == "$CONFIRMED_IDENTITY" ]] || {
+            echo "confirmed identity is no longer current on origin/main" >&2
+            exit 1
+          }
+      - name: Verify bootstrap state machine offline
+        run: node --test scripts/asc-testflight.node-test.mjs
+      - name: Materialize ephemeral ASC credential
+        env:
+          ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
+          : "${ASC_KEY_ID:?ASC_KEY_ID is not configured}"
+          : "${ASC_ISSUER_ID:?ASC_ISSUER_ID is not configured}"
+          secret_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-asc-bootstrap.XXXXXX")
+          echo "ZUULI_ASC_BOOTSTRAP_SECRET_DIR=$secret_dir" >> "$GITHUB_ENV"
+          chmod 700 "$secret_dir"
+          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$secret_dir/AuthKey.p8"
+          chmod 600 "$secret_dir/AuthKey.p8"
+          test -s "$secret_dir/AuthKey.p8"
+          echo "ASC_KEY_PATH=$secret_dir/AuthKey.p8" >> "$GITHUB_ENV"
+      - name: Bootstrap exact internal TestFlight state
+        env:
+          CONFIRMED_IDENTITY: ${{ inputs.identity }}
+        run: |
+          set -euo pipefail
+          version=${CONFIRMED_IDENTITY%+*}
+          build=${CONFIRMED_IDENTITY##*+}
+          evidence_dir="$RUNNER_TEMP/zuuli-testflight-bootstrap-evidence"
+          mkdir -p "$evidence_dir"
+          echo "ZUULI_TESTFLIGHT_BOOTSTRAP_EVIDENCE_DIR=$evidence_dir" >> "$GITHUB_ENV"
+          node scripts/asc-testflight.mjs \
+            --bootstrap \
+            "--version=$version" \
+            "--build=$build" \
+            --timeout-seconds=1800 \
+            --poll-seconds=30 \
+            "--output=$evidence_dir/testflight-bootstrap.json"
+      - name: Destroy ephemeral ASC credential
+        if: always()
+        run: |
+          set -u
+          cleanup_failed=0
+          if [[ -n "${ZUULI_ASC_BOOTSTRAP_SECRET_DIR:-}" && -d "$ZUULI_ASC_BOOTSTRAP_SECRET_DIR" ]]; then
+            find "$ZUULI_ASC_BOOTSTRAP_SECRET_DIR" -type f -exec rm -f -- {} + || cleanup_failed=1
+            rmdir "$ZUULI_ASC_BOOTSTRAP_SECRET_DIR" || cleanup_failed=1
+          fi
+          if [[ -n "${ZUULI_ASC_BOOTSTRAP_SECRET_DIR:-}" && -e "$ZUULI_ASC_BOOTSTRAP_SECRET_DIR" ]]; then
+            cleanup_failed=1
+          fi
+          exit "$cleanup_failed"
+      - name: Upload sanitized bootstrap evidence
+        if: success()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: zuuli-testflight-bootstrap-${{ inputs.identity }}-${{ inputs.source_sha }}
+          path: ${{ env.ZUULI_TESTFLIGHT_BOOTSTRAP_EVIDENCE_DIR }}/testflight-bootstrap.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -71,7 +71,7 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-play-testers.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
                 zuuli=true
                 ;;
             esac

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -80,11 +80,13 @@ repeat bootstrap work or substitute unrelated credentials.
    it signs.
 4. Maintain exactly one internal TestFlight group named `ZUULI Internal Testers`.
    The name and internal-only requirement are fixed in
-   `scripts/asc-testflight.mjs`; the release refuses a missing, duplicate, or
-   external group. Group membership remains an owner-managed App Store Connect
-   concern. Automation never reads or logs tester resources or email addresses.
-   The exempt-encryption declaration described below is embedded in each package;
-   do not answer the same question differently in App Store Connect.
+   `scripts/asc-testflight.mjs`; ordinary release and read-only recovery refuse
+   a missing, duplicate, or external group. The protected bootstrap transaction
+   below is the only automation allowed to create it. Group membership remains
+   an owner-managed App Store Connect concern. Automation never reads or logs
+   tester resources or email addresses. The exempt-encryption declaration
+   described below is embedded in each package; do not answer the same question
+   differently in App Store Connect.
 
 ### Google Play (Corpora)
 
@@ -381,11 +383,43 @@ tester resources.
 
 The recovery succeeds only if the exact build is processed, export compliance
 is resolved as the packaged `false` declaration, and the group relationship is
-visible on a fresh read. If it reports `processed` but not internally available,
-the owner must add that historical build to `ZUULI Internal Testers` in App Store
-Connect and rerun the read-only proof. Future uploads have no such manual gap:
-the protected release performs the idempotent relationship transaction and
-readback itself.
+visible on a fresh read. If it reports `INTERNAL_GROUP_MISSING` for the current
+release identity, use the protected bootstrap transaction below. Future uploads
+then have no setup gap: the protected release performs the idempotent
+relationship transaction and readback itself.
+
+### Protected TestFlight group bootstrap
+
+The one-time **ZUULI / TestFlight protected bootstrap** workflow is a narrowly
+scoped write transaction for the current release identity. It requires the
+exact identity-establishing commit to remain on `main`, requires that identity
+to still equal `origin/main`'s current `release.json`, and runs the complete
+offline mock suite before loading the protected ASC credential. It creates
+`ZUULI Internal Testers` only after a fresh lookup proves the name absent, with
+`isInternalGroup=true` and `hasAccessToAllBuilds=false`; a duplicate or external
+group fails closed. A run makes at most one create request; an ambiguous response
+switches permanently to bounded readback polling instead of risking a duplicate.
+It then relates only the exact processed build and requires
+fresh group and build-relationship readback. An ambiguous create or relationship
+response is accepted only when that readback proves the requested state landed.
+The workflow never requests tester membership or identities and emits only the
+sanitized state evidence.
+
+For Build 10, after the bootstrap workflow is merged and its required gate is
+green, dispatch it once and then repeat the read-only proof:
+
+```bash
+gh workflow run zuuli-testflight-bootstrap.yml --repo free2z/zuu --ref main \
+  -f source_sha=6359bbe8ddbb23a5024383b1ce780a00b76c5e3f \
+  -f identity=0.1.0+10
+gh workflow run zuuli-testflight-recovery.yml --repo free2z/zuu --ref main \
+  -f source_sha=6359bbe8ddbb23a5024383b1ce780a00b76c5e3f \
+  -f identity=0.1.0+10
+```
+
+The create contract follows Apple's [Create a Beta Group](https://developer.apple.com/documentation/appstoreconnectapi/post-v1-betagroups)
+API and its required app relationship. Do not use this workflow for a superseded
+identity; read-only recovery may still inspect historical builds.
 
 Store build numbers are append-only. Signed packages are not bit-reproducible:
 timestamps and signatures can change on a rebuild, while neither store permits a

--- a/wallet/zuuli/scripts/asc-testflight.mjs
+++ b/wallet/zuuli/scripts/asc-testflight.mjs
@@ -451,6 +451,30 @@ export function createAscApiClient({
       });
     },
 
+    async createInternalGroup() {
+      const payload = await request("POST", "/v1/betaGroups", {
+        body: {
+          data: {
+            type: "betaGroups",
+            attributes: {
+              name: ASC_INTERNAL_GROUP,
+              isInternalGroup: true,
+              hasAccessToAllBuilds: false,
+            },
+            relationships: {
+              app: { data: { type: "apps", id: ASC_APP_ID } },
+            },
+          },
+        },
+      });
+      const resource = assertResource(
+        payload?.data,
+        "betaGroups",
+        "internal beta group creation",
+      );
+      return { id: resource.id, ...resource.attributes };
+    },
+
     async listGroupBuildIds(groupId) {
       const params = new URLSearchParams({ "fields[builds]": "version", limit: "200" });
       const resources = await paged(
@@ -635,11 +659,11 @@ export async function convergeTestFlightState({
   onTransition = () => {},
 }) {
   ({ version, build } = validateIdentity(version, build));
-  if (mode !== "ensure" && mode !== "read-only") {
+  if (mode !== "ensure" && mode !== "read-only" && mode !== "bootstrap") {
     throw new AscStateError(
       "INVALID_MODE",
       "not_observed",
-      "mode must be ensure or read-only",
+      "mode must be ensure, read-only, or bootstrap",
     );
   }
   if (
@@ -702,6 +726,7 @@ export async function convergeTestFlightState({
     );
   }
 
+  let groupCreationAttempted = false;
   while (true) {
     try {
       const candidates = await callAtStage(lastStage, () =>
@@ -716,12 +741,49 @@ export async function convergeTestFlightState({
         }
         lastStage = stage;
         if (stage === "processed") {
-          const groups = await callAtStage("processed", () => api.listBetaGroups());
-          const group = selectInternalGroup(groups);
+          let groups = await callAtStage("processed", () => api.listBetaGroups());
+          let group;
+          try {
+            group = selectInternalGroup(groups);
+          } catch (error) {
+            if (error.code !== "INTERNAL_GROUP_MISSING" || mode !== "bootstrap") {
+              throw error;
+            }
+            if (!groupCreationAttempted) {
+              groupCreationAttempted = true;
+              try {
+                await callAtStage("processed", () => api.createInternalGroup());
+              } catch (createError) {
+                if (
+                  !(createError instanceof AscStateError) ||
+                  (!createError.retryable && createError.code !== "ASC_INVALID_RESPONSE")
+                ) {
+                  throw createError;
+                }
+              }
+            }
+            groups = await callAtStage("processed", () => api.listBetaGroups());
+            try {
+              group = selectInternalGroup(groups);
+            } catch (readbackError) {
+              if (readbackError.code !== "INTERNAL_GROUP_MISSING") {
+                throw readbackError;
+              }
+              throw new AscStateError(
+                "INTERNAL_GROUP_CREATE_PENDING",
+                "processed",
+                "App Store Connect has not returned the internal group after the one allowed creation attempt",
+                { retryable: true },
+              );
+            }
+          }
           let groupBuildIds = await callAtStage("processed", () =>
             api.listGroupBuildIds(group.id),
           );
-          if (!groupBuildIds.includes(exactBuild.id) && mode === "ensure") {
+          if (
+            !groupBuildIds.includes(exactBuild.id) &&
+            (mode === "ensure" || mode === "bootstrap")
+          ) {
             let mutationError;
             try {
               await callAtStage("processed", () =>
@@ -791,6 +853,11 @@ export function parseCliArgs(argv) {
       mode = "read-only";
       continue;
     }
+    if (arg === "--bootstrap") {
+      if (mode) throw new AscStateError("INVALID_ARGUMENT", "not_observed", "choose exactly one mode");
+      mode = "bootstrap";
+      continue;
+    }
     const match = /^--([a-z-]+)=(.*)$/.exec(arg);
     if (!match || values.has(match[1])) {
       throw new AscStateError("INVALID_ARGUMENT", "not_observed", "invalid or duplicate command argument");
@@ -807,7 +874,7 @@ export function parseCliArgs(argv) {
     throw new AscStateError(
       "INVALID_ARGUMENT",
       "not_observed",
-      "usage: asc-testflight.mjs <--ensure|--read-only> --version=X.Y.Z " +
+      "usage: asc-testflight.mjs <--ensure|--read-only|--bootstrap> --version=X.Y.Z " +
         "--build=N [--timeout-seconds=N] [--poll-seconds=N] [--output=PATH]",
     );
   }

--- a/wallet/zuuli/scripts/asc-testflight.node-test.mjs
+++ b/wallet/zuuli/scripts/asc-testflight.node-test.mjs
@@ -78,11 +78,17 @@ function fakeApi({
   builds,
   groups = [group()],
   groupBuilds = [],
+  createError,
+  createLands = true,
+  createVisibleAfterGroupReads = 0,
   addError,
   addLands = true,
 } = {}) {
   const calls = [];
   let buildResponses = Array.isArray(builds?.[0]) ? [...builds] : [builds ?? [candidate()]];
+  let groupResources = [...groups];
+  let pendingCreatedGroup;
+  let groupReadsAfterCreate = 0;
   let relationships = [...groupBuilds];
   return {
     calls,
@@ -101,7 +107,25 @@ function fakeApi({
       },
       async listBetaGroups() {
         calls.push(["listBetaGroups"]);
-        return groups;
+        if (pendingCreatedGroup) {
+          if (groupReadsAfterCreate >= createVisibleAfterGroupReads) {
+            groupResources.push(pendingCreatedGroup);
+            pendingCreatedGroup = undefined;
+          } else {
+            groupReadsAfterCreate += 1;
+          }
+        }
+        return [...groupResources];
+      },
+      async createInternalGroup() {
+        calls.push(["createInternalGroup"]);
+        const created = group();
+        if (createLands) {
+          if (createVisibleAfterGroupReads === 0) groupResources.push(created);
+          else pendingCreatedGroup = created;
+        }
+        if (createError) throw createError;
+        return created;
       },
       async listGroupBuildIds(groupId) {
         calls.push(["listGroupBuildIds", groupId]);
@@ -237,6 +261,20 @@ test("constructs exact app/build/group API requests without tester fields", asyn
       ],
       links: {},
     }),
+    jsonResponse(
+      {
+        data: {
+          type: "betaGroups",
+          id: "group-internal",
+          attributes: {
+            name: ASC_INTERNAL_GROUP,
+            isInternalGroup: true,
+            hasAccessToAllBuilds: false,
+          },
+        },
+      },
+      201,
+    ),
     jsonResponse({
       data: [{ type: "builds", id: "build-10", attributes: { version: BUILD } }],
       links: {},
@@ -254,6 +292,7 @@ test("constructs exact app/build/group API requests without tester fields", asyn
   const app = await api.readApp();
   const builds = await api.listBuildCandidates(VERSION, BUILD);
   const groups = await api.listBetaGroups();
+  const createdGroup = await api.createInternalGroup();
   const buildIds = await api.listGroupBuildIds("group-internal");
   await api.addBuildToGroup("group-internal", "build-10");
   assert.equal(app.attributes.bundleId, ASC_BUNDLE_ID);
@@ -264,6 +303,7 @@ test("constructs exact app/build/group API requests without tester fields", asyn
     }),
   ]);
   assert.deepEqual(groups, [group()]);
+  assert.deepEqual(createdGroup, group());
   assert.deepEqual(buildIds, ["build-10"]);
   assert.equal(mock.remaining.length, 0);
   const buildUrl = new URL(mock.calls[1].url);
@@ -278,8 +318,22 @@ test("constructs exact app/build/group API requests without tester fields", asyn
     assert.equal(call.options.signal instanceof AbortSignal, true);
     assert.equal(JSON.stringify(call).includes("email"), false);
   }
-  assert.equal(mock.calls[4].options.method, "POST");
-  assert.deepEqual(JSON.parse(mock.calls[4].options.body), {
+  assert.equal(mock.calls[3].options.method, "POST");
+  assert.deepEqual(JSON.parse(mock.calls[3].options.body), {
+    data: {
+      type: "betaGroups",
+      attributes: {
+        name: ASC_INTERNAL_GROUP,
+        isInternalGroup: true,
+        hasAccessToAllBuilds: false,
+      },
+      relationships: {
+        app: { data: { type: "apps", id: ASC_APP_ID } },
+      },
+    },
+  });
+  assert.equal(mock.calls[5].options.method, "POST");
+  assert.deepEqual(JSON.parse(mock.calls[5].options.body), {
     data: [{ type: "builds", id: "build-10" }],
   });
 });
@@ -587,6 +641,237 @@ test("ensure mode adds once, reads back, and is idempotent on a rerun", async ()
   );
 });
 
+test("bootstrap mode creates the internal group once and converges idempotently", async () => {
+  const fixture = fakeApi({ groups: [], groupBuilds: [] });
+  const first = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "bootstrap",
+    timeoutSeconds: 0,
+    pollSeconds: 1,
+    nowMs: () => 1_786_196_000_000,
+  });
+  const second = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "bootstrap",
+    timeoutSeconds: 0,
+    pollSeconds: 1,
+    nowMs: () => 1_786_196_001_000,
+  });
+  assert.equal(first.mode, "bootstrap");
+  assert.equal(first.group.exactBuildRelationshipVerified, true);
+  assert.equal(second.group.exactBuildRelationshipVerified, true);
+  assert.equal(
+    fixture.calls.filter(([operation]) => operation === "createInternalGroup").length,
+    1,
+  );
+  assert.equal(
+    fixture.calls.filter(([operation]) => operation === "addBuildToGroup").length,
+    1,
+  );
+});
+
+test("bootstrap accepts an ambiguous create only after fresh group readback", async () => {
+  const fixture = fakeApi({
+    groups: [],
+    groupBuilds: ["build-10"],
+    createError: new AscStateError(
+      "ASC_NETWORK_ERROR",
+      "not_observed",
+      "synthetic ambiguous create",
+      { retryable: true },
+    ),
+  });
+  const result = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "bootstrap",
+    timeoutSeconds: 0,
+    pollSeconds: 1,
+    nowMs: () => 1_786_196_000_000,
+  });
+  assert.equal(result.state.availableToInternalTesters, true);
+  assert.equal(
+    fixture.calls.filter(([operation]) => operation === "createInternalGroup").length,
+    1,
+  );
+});
+
+test("bootstrap polls delayed ambiguous-create readback without a second POST", async () => {
+  const fixture = fakeApi({
+    groups: [],
+    groupBuilds: ["build-10"],
+    createVisibleAfterGroupReads: 2,
+    createError: new AscStateError(
+      "ASC_NETWORK_ERROR",
+      "not_observed",
+      "synthetic ambiguous create",
+      { retryable: true },
+    ),
+  });
+  let current = 0;
+  const result = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "bootstrap",
+    timeoutSeconds: 5,
+    pollSeconds: 1,
+    nowMs: () => current,
+    sleep: async (milliseconds) => {
+      current += milliseconds;
+    },
+  });
+  assert.equal(result.state.availableToInternalTesters, true);
+  assert.equal(
+    fixture.calls.filter(([operation]) => operation === "createInternalGroup").length,
+    1,
+  );
+  assert.equal(
+    fixture.calls.filter(([operation]) => operation === "listBetaGroups").length,
+    4,
+  );
+});
+
+test("bootstrap treats a malformed success response as ambiguous and trusts only readback", async () => {
+  const fixture = fakeApi({
+    groups: [],
+    groupBuilds: ["build-10"],
+    createVisibleAfterGroupReads: 1,
+    createError: new AscStateError(
+      "ASC_INVALID_RESPONSE",
+      "not_observed",
+      "synthetic malformed creation response",
+    ),
+  });
+  let current = 0;
+  const result = await convergeTestFlightState({
+    api: fixture.api,
+    version: VERSION,
+    build: BUILD,
+    mode: "bootstrap",
+    timeoutSeconds: 3,
+    pollSeconds: 1,
+    nowMs: () => current,
+    sleep: async (milliseconds) => {
+      current += milliseconds;
+    },
+  });
+  assert.equal(result.state.availableToInternalTesters, true);
+  assert.equal(
+    fixture.calls.filter(([operation]) => operation === "createInternalGroup").length,
+    1,
+  );
+});
+
+test("bootstrap times out after one ambiguous create when the group never appears", async () => {
+  const fixture = fakeApi({
+    groups: [],
+    createLands: false,
+    createError: new AscStateError(
+      "ASC_NETWORK_ERROR",
+      "not_observed",
+      "synthetic ambiguous create",
+      { retryable: true },
+    ),
+  });
+  let current = 0;
+  await assert.rejects(
+    convergeTestFlightState({
+      api: fixture.api,
+      version: VERSION,
+      build: BUILD,
+      mode: "bootstrap",
+      timeoutSeconds: 2,
+      pollSeconds: 1,
+      nowMs: () => current,
+      sleep: async (milliseconds) => {
+        current += milliseconds;
+      },
+    }),
+    (error) => error.code === "STATE_TIMEOUT" && error.stage === "processed",
+  );
+  assert.equal(
+    fixture.calls.filter(([operation]) => operation === "createInternalGroup").length,
+    1,
+  );
+});
+
+test("bootstrap fails closed when group creation does not land", async () => {
+  const fixture = fakeApi({
+    groups: [],
+    createLands: false,
+    createError: new AscStateError("ASC_API_ERROR", "not_observed", "sanitized create failure"),
+  });
+  await assert.rejects(
+    convergeTestFlightState({
+      api: fixture.api,
+      version: VERSION,
+      build: BUILD,
+      mode: "bootstrap",
+      timeoutSeconds: 0,
+      pollSeconds: 1,
+      nowMs: () => 1_786_196_000_000,
+    }),
+    (error) =>
+      error.code === "ASC_API_ERROR" &&
+      error.stage === "processed" &&
+      error.message === "sanitized create failure",
+  );
+  assert.equal(fixture.calls.some(([operation]) => operation === "addBuildToGroup"), false);
+});
+
+test("bootstrap never creates around a duplicate or external named group", async () => {
+  for (const [groups, code] of [
+    [[group({ isInternalGroup: false })], "INTERNAL_GROUP_WRONG_TYPE"],
+    [[group(), group({ id: "duplicate" })], "INTERNAL_GROUP_AMBIGUOUS"],
+  ]) {
+    const fixture = fakeApi({ groups });
+    await assert.rejects(
+      convergeTestFlightState({
+        api: fixture.api,
+        version: VERSION,
+        build: BUILD,
+        mode: "bootstrap",
+        timeoutSeconds: 0,
+        pollSeconds: 1,
+        nowMs: () => 1_786_196_000_000,
+      }),
+      (error) => error.code === code,
+    );
+    assert.equal(
+      fixture.calls.some(([operation]) => operation === "createInternalGroup"),
+      false,
+    );
+  }
+});
+
+test("ensure and read-only modes never create a missing group", async () => {
+  for (const mode of ["ensure", "read-only"]) {
+    const fixture = fakeApi({ groups: [] });
+    await assert.rejects(
+      convergeTestFlightState({
+        api: fixture.api,
+        version: VERSION,
+        build: BUILD,
+        mode,
+        timeoutSeconds: 0,
+        pollSeconds: 1,
+        nowMs: () => 1_786_196_000_000,
+      }),
+      (error) => error.code === "INTERNAL_GROUP_MISSING" && error.stage === "processed",
+    );
+    assert.equal(
+      fixture.calls.some(([operation]) => operation === "createInternalGroup"),
+      false,
+    );
+  }
+});
+
 test("waits for eventual relationship readback without repeating the assignment", async () => {
   const fixture = fakeApi({ groupBuilds: [] });
   const readRelationship = fixture.api.listGroupBuildIds;
@@ -815,9 +1100,14 @@ test("validates bounded CLI arguments and explicit mode", () => {
       output: "/tmp/evidence.json",
     },
   );
+  assert.equal(
+    parseCliArgs(["--bootstrap", `--version=${VERSION}`, `--build=${BUILD}`]).mode,
+    "bootstrap",
+  );
   for (const args of [
     [],
     ["--ensure", "--read-only", `--version=${VERSION}`, `--build=${BUILD}`],
+    ["--bootstrap", "--read-only", `--version=${VERSION}`, `--build=${BUILD}`],
     ["--ensure", `--version=${VERSION}`, `--build=${BUILD}`, "--poll-seconds=-1"],
     ["--ensure", `--version=${VERSION}`, `--build=${BUILD}`, "--unknown=x"],
   ]) {

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -202,6 +202,9 @@ const releaseWorkflow = read("../../.github/workflows/zuuli-release.yml");
 const testFlightRecoveryWorkflow = read(
   "../../.github/workflows/zuuli-testflight-recovery.yml",
 );
+const testFlightBootstrapWorkflow = read(
+  "../../.github/workflows/zuuli-testflight-bootstrap.yml",
+);
 const packagingWorkflow = read("../../.github/workflows/zuuli-packaging.yml");
 
 expect("package.json version", packageJson.version, release.version);
@@ -696,6 +699,12 @@ for (const contract of [
   '"INVALID_BINARY"',
   '"AMBIGUOUS_EXACT_BUILD"',
   'availableToInternalTesters: true',
+  'async createInternalGroup()',
+  'let groupCreationAttempted = false',
+  '"POST", "/v1/betaGroups"',
+  'isInternalGroup: true',
+  'hasAccessToAllBuilds: false',
+  'app: { data: { type: "apps", id: ASC_APP_ID } }',
   '/relationships/builds',
 ]) {
   if (!ascTestFlight.includes(contract))
@@ -713,10 +722,34 @@ for (const recoveryContract of [
   if (!testFlightRecoveryWorkflow.includes(recoveryContract))
     failures.push(`TestFlight recovery workflow is missing: ${recoveryContract}`);
 }
-if (testFlightRecoveryWorkflow.includes("--ensure"))
+if (
+  testFlightRecoveryWorkflow.includes("--ensure") ||
+  testFlightRecoveryWorkflow.includes("--bootstrap")
+)
   failures.push("TestFlight recovery workflow must remain read-only");
 if (!gateWorkflow.includes(".github/workflows/zuuli-testflight-recovery.yml"))
   failures.push("ZUULI gate must select TestFlight recovery workflow changes");
+for (const bootstrapContract of [
+  "name: ZUULI / TestFlight protected bootstrap",
+  "environment: zuuli-app-stores",
+  "--bootstrap",
+  "source SHA must be the commit that established this release identity",
+  "confirmed identity is no longer current on origin/main",
+  "node --test scripts/asc-testflight.node-test.mjs",
+  "Destroy ephemeral ASC credential",
+  "Upload sanitized bootstrap evidence",
+]) {
+  if (!testFlightBootstrapWorkflow.includes(bootstrapContract))
+    failures.push(`TestFlight bootstrap workflow is missing: ${bootstrapContract}`);
+}
+for (const forbiddenBootstrapContract of ["--ensure", "--read-only", "betaTesters"]) {
+  if (testFlightBootstrapWorkflow.includes(forbiddenBootstrapContract))
+    failures.push(
+      `TestFlight bootstrap workflow has a forbidden contract: ${forbiddenBootstrapContract}`,
+    );
+}
+if (!gateWorkflow.includes(".github/workflows/zuuli-testflight-bootstrap.yml"))
+  failures.push("ZUULI gate must select TestFlight bootstrap workflow changes");
 const unsignedIosBuild = packagingWorkflow.indexOf(
   "./node_modules/.bin/tauri ios build --ci --no-sign",
 );


### PR DESCRIPTION
Closes #414.

## Outcome

Adds one narrowly protected, idempotent App Store Connect bootstrap transaction for the current ZUULI release identity. It creates the exact `ZUULI Internal Testers` beta group only when a fresh lookup proves it absent, relates the exact processed build, and requires fresh readback before success.

## Safety contract

- dispatch is `main`-only, uses the protected `zuuli-app-stores` environment, and accepts only the exact identity-establishing SHA plus current `origin/main` release identity
- the create request is fixed to app `6799322201`, bundle `cash.free2z.zuuli`, `isInternalGroup=true`, and `hasAccessToAllBuilds=false`
- duplicate or external same-name groups fail closed
- a process issues at most one beta-group create POST; ambiguous/invalid success responses switch permanently to bounded readback polling, preventing duplicate creation
- the exact processed Build is related only after compliance/state validation; success requires fresh relationship readback
- neither the script nor workflow requests tester resources, memberships, or email addresses
- credentials exist only in a mode-0700 runner-temp directory, are removed on every exit path, and only sanitized state evidence is uploaded
- ordinary release `--ensure` and recovery `--read-only` cannot create a group

## Verification

Semantically rebased onto `origin/main` `74ab9f84241303269903ca1e5b8c8724f4d45aed`; `git range-diff` proves the #414 patch is unchanged.

- `npm ci`
- `npm run test:asc-testflight` — 30/30
- `npm run release:verify`
- `npm run typecheck`
- `npm run build`
- `npm run test:play-testers` — 10/10
- `npm run icons:check`
- `npm test` — Vitest 258/258, safe-area 5/5, Playwright 26/26 on the rebased #415 UI
- `node scripts/verify-ci-cache-policy.mjs`
- `scripts/check-rust-toolchain.sh --self-test`
- `scripts/check-rust-toolchain.sh`
- `actionlint` on bootstrap, recovery, and required-gate workflows
- `git diff --check`

Offline adversarial mocks cover exact request shape, no tester fields, absent/existing/duplicate/external groups, current modes that cannot create, successful rerun idempotence, definite creation failure, ambiguous create with immediate and delayed visibility, malformed success response, a never-visible create timing out after exactly one POST, relationship ambiguity, and sanitized failures.

No production App Store Connect mutation has occurred in this PR. After merge and required-gate success, the owner-authorized sequence is:

```bash
gh workflow run zuuli-testflight-bootstrap.yml --repo free2z/zuu --ref main \
  -f source_sha=6359bbe8ddbb23a5024383b1ce780a00b76c5e3f \
  -f identity=0.1.0+10
gh workflow run zuuli-testflight-recovery.yml --repo free2z/zuu --ref main \
  -f source_sha=6359bbe8ddbb23a5024383b1ce780a00b76c5e3f \
  -f identity=0.1.0+10
```
