### PR TITLE
fix(zuuli): fence stale auth and persist wallet backup

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/build.rs
+++ b/wallet/plugins/tauri-plugin-zcash/build.rs
@@ -4,6 +4,8 @@ const COMMANDS: &[&str] = &[
     "get_wallet_status",
     "retry_wallet_cleanup",
     "get_seed_phrase",
+    "get_backup_seed_phrase",
+    "confirm_wallet_backup",
     "get_viewing_key",
     "get_spending_key",
     "list_wallets",

--- a/wallet/plugins/tauri-plugin-zcash/permissions/autogenerated/commands/confirm_wallet_backup.toml
+++ b/wallet/plugins/tauri-plugin-zcash/permissions/autogenerated/commands/confirm_wallet_backup.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-confirm-wallet-backup"
+description = "Enables the confirm_wallet_backup command without any pre-configured scope."
+commands.allow = ["confirm_wallet_backup"]
+
+[[permission]]
+identifier = "deny-confirm-wallet-backup"
+description = "Denies the confirm_wallet_backup command without any pre-configured scope."
+commands.deny = ["confirm_wallet_backup"]

--- a/wallet/plugins/tauri-plugin-zcash/permissions/autogenerated/commands/get_backup_seed_phrase.toml
+++ b/wallet/plugins/tauri-plugin-zcash/permissions/autogenerated/commands/get_backup_seed_phrase.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-backup-seed-phrase"
+description = "Enables the get_backup_seed_phrase command without any pre-configured scope."
+commands.allow = ["get_backup_seed_phrase"]
+
+[[permission]]
+identifier = "deny-get-backup-seed-phrase"
+description = "Denies the get_backup_seed_phrase command without any pre-configured scope."
+commands.deny = ["get_backup_seed_phrase"]

--- a/wallet/plugins/tauri-plugin-zcash/permissions/autogenerated/reference.md
+++ b/wallet/plugins/tauri-plugin-zcash/permissions/autogenerated/reference.md
@@ -9,6 +9,8 @@ Default permissions for the Zcash wallet plugin
 - `allow-get-wallet-status`
 - `allow-retry-wallet-cleanup`
 - `allow-get-seed-phrase`
+- `allow-get-backup-seed-phrase`
+- `allow-confirm-wallet-backup`
 - `allow-get-viewing-key`
 - `allow-get-spending-key`
 - `allow-list-wallets`
@@ -44,6 +46,32 @@ Default permissions for the Zcash wallet plugin
 <th>Description</th>
 </tr>
 
+
+<tr>
+<td>
+
+`zcash:allow-confirm-wallet-backup`
+
+</td>
+<td>
+
+Enables the confirm_wallet_backup command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`zcash:deny-confirm-wallet-backup`
+
+</td>
+<td>
+
+Denies the confirm_wallet_backup command without any pre-configured scope.
+
+</td>
+</tr>
 
 <tr>
 <td>
@@ -223,6 +251,32 @@ Enables the get_account_balance command without any pre-configured scope.
 <td>
 
 Denies the get_account_balance command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`zcash:allow-get-backup-seed-phrase`
+
+</td>
+<td>
+
+Enables the get_backup_seed_phrase command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`zcash:deny-get-backup-seed-phrase`
+
+</td>
+<td>
+
+Denies the get_backup_seed_phrase command without any pre-configured scope.
 
 </td>
 </tr>

--- a/wallet/plugins/tauri-plugin-zcash/permissions/default.toml
+++ b/wallet/plugins/tauri-plugin-zcash/permissions/default.toml
@@ -6,6 +6,8 @@ permissions = [
     "allow-get-wallet-status",
     "allow-retry-wallet-cleanup",
     "allow-get-seed-phrase",
+    "allow-get-backup-seed-phrase",
+    "allow-confirm-wallet-backup",
     "allow-get-viewing-key",
     "allow-get-spending-key",
     "allow-list-wallets",

--- a/wallet/plugins/tauri-plugin-zcash/permissions/schemas/schema.json
+++ b/wallet/plugins/tauri-plugin-zcash/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the confirm_wallet_backup command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-confirm-wallet-backup",
+          "markdownDescription": "Enables the confirm_wallet_backup command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the confirm_wallet_backup command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-confirm-wallet-backup",
+          "markdownDescription": "Denies the confirm_wallet_backup command without any pre-configured scope."
+        },
+        {
           "description": "Enables the create_account command without any pre-configured scope.",
           "type": "string",
           "const": "allow-create-account",
@@ -377,6 +389,18 @@
           "type": "string",
           "const": "deny-get-account-balance",
           "markdownDescription": "Denies the get_account_balance command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_backup_seed_phrase command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-backup-seed-phrase",
+          "markdownDescription": "Enables the get_backup_seed_phrase command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_backup_seed_phrase command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-backup-seed-phrase",
+          "markdownDescription": "Denies the get_backup_seed_phrase command without any pre-configured scope."
         },
         {
           "description": "Enables the get_pending_send command without any pre-configured scope.",
@@ -679,10 +703,10 @@
           "markdownDescription": "Denies the validate_address command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the Zcash wallet plugin\n#### This default permission set includes:\n\n- `allow-create-wallet`\n- `allow-restore-wallet`\n- `allow-get-wallet-status`\n- `allow-retry-wallet-cleanup`\n- `allow-get-seed-phrase`\n- `allow-get-viewing-key`\n- `allow-get-spending-key`\n- `allow-list-wallets`\n- `allow-switch-wallet`\n- `allow-rename-wallet`\n- `allow-delete-wallet`\n- `allow-create-account`\n- `allow-list-accounts`\n- `allow-get-account-balance`\n- `allow-get-unified-address`\n- `allow-start-sync`\n- `allow-stop-sync`\n- `allow-get-sync-status`\n- `allow-ensure-sapling-params`\n- `allow-propose-send`\n- `allow-propose-send-all`\n- `allow-execute-send`\n- `allow-get-pending-send`\n- `allow-retry-pending-send`\n- `allow-discard-unrecoverable-send`\n- `allow-get-transaction-history`\n- `allow-set-lightwalletd-url`\n- `allow-parse-payment-uri`\n- `allow-unlock-wallet`\n- `allow-validate-address`\n- `allow-sign-challenge`",
+          "description": "Default permissions for the Zcash wallet plugin\n#### This default permission set includes:\n\n- `allow-create-wallet`\n- `allow-restore-wallet`\n- `allow-get-wallet-status`\n- `allow-retry-wallet-cleanup`\n- `allow-get-seed-phrase`\n- `allow-get-backup-seed-phrase`\n- `allow-confirm-wallet-backup`\n- `allow-get-viewing-key`\n- `allow-get-spending-key`\n- `allow-list-wallets`\n- `allow-switch-wallet`\n- `allow-rename-wallet`\n- `allow-delete-wallet`\n- `allow-create-account`\n- `allow-list-accounts`\n- `allow-get-account-balance`\n- `allow-get-unified-address`\n- `allow-start-sync`\n- `allow-stop-sync`\n- `allow-get-sync-status`\n- `allow-ensure-sapling-params`\n- `allow-propose-send`\n- `allow-propose-send-all`\n- `allow-execute-send`\n- `allow-get-pending-send`\n- `allow-retry-pending-send`\n- `allow-discard-unrecoverable-send`\n- `allow-get-transaction-history`\n- `allow-set-lightwalletd-url`\n- `allow-parse-payment-uri`\n- `allow-unlock-wallet`\n- `allow-validate-address`\n- `allow-sign-challenge`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the Zcash wallet plugin\n#### This default permission set includes:\n\n- `allow-create-wallet`\n- `allow-restore-wallet`\n- `allow-get-wallet-status`\n- `allow-retry-wallet-cleanup`\n- `allow-get-seed-phrase`\n- `allow-get-viewing-key`\n- `allow-get-spending-key`\n- `allow-list-wallets`\n- `allow-switch-wallet`\n- `allow-rename-wallet`\n- `allow-delete-wallet`\n- `allow-create-account`\n- `allow-list-accounts`\n- `allow-get-account-balance`\n- `allow-get-unified-address`\n- `allow-start-sync`\n- `allow-stop-sync`\n- `allow-get-sync-status`\n- `allow-ensure-sapling-params`\n- `allow-propose-send`\n- `allow-propose-send-all`\n- `allow-execute-send`\n- `allow-get-pending-send`\n- `allow-retry-pending-send`\n- `allow-discard-unrecoverable-send`\n- `allow-get-transaction-history`\n- `allow-set-lightwalletd-url`\n- `allow-parse-payment-uri`\n- `allow-unlock-wallet`\n- `allow-validate-address`\n- `allow-sign-challenge`"
+          "markdownDescription": "Default permissions for the Zcash wallet plugin\n#### This default permission set includes:\n\n- `allow-create-wallet`\n- `allow-restore-wallet`\n- `allow-get-wallet-status`\n- `allow-retry-wallet-cleanup`\n- `allow-get-seed-phrase`\n- `allow-get-backup-seed-phrase`\n- `allow-confirm-wallet-backup`\n- `allow-get-viewing-key`\n- `allow-get-spending-key`\n- `allow-list-wallets`\n- `allow-switch-wallet`\n- `allow-rename-wallet`\n- `allow-delete-wallet`\n- `allow-create-account`\n- `allow-list-accounts`\n- `allow-get-account-balance`\n- `allow-get-unified-address`\n- `allow-start-sync`\n- `allow-stop-sync`\n- `allow-get-sync-status`\n- `allow-ensure-sapling-params`\n- `allow-propose-send`\n- `allow-propose-send-all`\n- `allow-execute-send`\n- `allow-get-pending-send`\n- `allow-retry-pending-send`\n- `allow-discard-unrecoverable-send`\n- `allow-get-transaction-history`\n- `allow-set-lightwalletd-url`\n- `allow-parse-payment-uri`\n- `allow-unlock-wallet`\n- `allow-validate-address`\n- `allow-sign-challenge`"
         }
       ]
     }

--- a/wallet/plugins/tauri-plugin-zcash/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/commands.rs
@@ -283,6 +283,16 @@ async fn ensure_active_seed_loaded(
     Ok(())
 }
 
+fn ensure_challenge_signing_allowed(
+    manifest: &crate::wallet::manifest::WalletManifest,
+) -> Result<()> {
+    if manifest.active_backup_required() {
+        Err(Error::BackupRequired)
+    } else {
+        Ok(())
+    }
+}
+
 #[command]
 pub(crate) async fn create_wallet<R: Runtime>(
     app: AppHandle<R>,
@@ -330,10 +340,11 @@ pub(crate) async fn create_wallet<R: Runtime>(
 
     // Allocate an identity, but keep it out of the durable manifest until its
     // database and native seed custody have both committed.
-    let wallet_entry = crate::wallet::manifest::WalletManifest::prepare_wallet(
+    let mut wallet_entry = crate::wallet::manifest::WalletManifest::prepare_wallet(
         wallet_name,
         Some(tip_height),
     );
+    crate::wallet::manifest::WalletManifest::require_backup(&mut wallet_entry);
     let cleanup_authorization =
         crate::wallet::cleanup::schedule_staged_wallet_rollback(
             &zcash.state.data_dir,
@@ -482,6 +493,7 @@ pub(crate) async fn create_wallet<R: Runtime>(
     retry_staged_wallet_cleanup(&zcash.state, "wallet rollback cancellation deferred").await;
 
     Ok(WalletCreated {
+        wallet_id: wallet_entry.id.clone(),
         seed_phrase: mnemonic.phrase().to_string(),
         birthday_height: tip_height,
     })
@@ -750,6 +762,7 @@ pub(crate) async fn get_wallet_status<R: Runtime>(app: AppHandle<R>) -> Result<W
     let manifest = zcash.state.manifest.lock().await;
     let active_wallet_id = manifest.active_wallet_id.clone();
     let active_wallet_name = manifest.get_active().map(|w| w.name.clone());
+    let backup_required = manifest.active_backup_required();
     let wallet_count = manifest.wallets.len() as u32;
     drop(manifest);
     let cleanup = zcash.state.cleanup_status.lock().await.clone();
@@ -778,6 +791,7 @@ pub(crate) async fn get_wallet_status<R: Runtime>(app: AppHandle<R>) -> Result<W
         active_wallet_id,
         active_wallet_name,
         wallet_count,
+        backup_required,
         cleanup,
         legacy_app_data: zcash.legacy_app_data.clone(),
     })
@@ -811,6 +825,47 @@ pub(crate) async fn get_seed_phrase<R: Runtime>(app: AppHandle<R>) -> Result<Str
         .get_seed_phrase(&transition_guard, &wallet_id)
         .await
         .map(|phrase| phrase.to_string())
+}
+
+/// Retrieve the recovery phrase only for the exact active wallet whose backup
+/// acknowledgement is still pending. The transition lock binds the manifest
+/// check and custody read so a concurrent wallet switch cannot disclose a
+/// different wallet's phrase to a stale backup screen.
+#[command]
+pub(crate) async fn get_backup_seed_phrase<R: Runtime>(
+    app: AppHandle<R>,
+    args: ConfirmWalletBackupArgs,
+) -> Result<String> {
+    let zcash = app.zcash();
+    let transition_guard = zcash.state.lock_wallet_transition().await;
+    {
+        let manifest = zcash.state.manifest.lock().await;
+        if !manifest.is_exact_active_backup_pending(&args.wallet_id) {
+            return Err(Error::BackupRequired);
+        }
+    }
+    zcash
+        .state
+        .get_seed_phrase(&transition_guard, &args.wallet_id)
+        .await
+        .map(|phrase| phrase.to_string())
+}
+
+#[command]
+pub(crate) async fn confirm_wallet_backup<R: Runtime>(
+    app: AppHandle<R>,
+    args: ConfirmWalletBackupArgs,
+) -> Result<()> {
+    let zcash = app.zcash();
+    let _transition_guard = zcash.state.lock_wallet_transition().await;
+    let mut manifest = zcash.state.manifest.lock().await;
+    match manifest.confirm_backup(&zcash.state.data_dir, &args.wallet_id) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(Error::Other(
+            "backup confirmation does not match the active wallet".into(),
+        )),
+        Err(error) => Err(Error::Io(error)),
+    }
 }
 
 #[command]
@@ -1374,7 +1429,25 @@ mod deletion_tests {
             db_filename: format!("wallet_{id}.sqlite"),
             birthday_height: Some(1),
             created_at: "2026-08-06T00:00:00Z".to_string(),
+            backup_required: false,
         }
+    }
+
+    #[test]
+    fn challenge_signing_fails_closed_until_backup_is_confirmed() {
+        let mut required = wallet("new-wallet");
+        required.backup_required = true;
+        let mut manifest = WalletManifest {
+            wallets: vec![required.clone()],
+            active_wallet_id: Some(required.id.clone()),
+        };
+
+        assert!(matches!(
+            ensure_challenge_signing_allowed(&manifest),
+            Err(Error::BackupRequired)
+        ));
+        manifest.wallets[0].backup_required = false;
+        assert!(ensure_challenge_signing_allowed(&manifest).is_ok());
     }
 
     // These tests prove authorization ordering, not custody cryptography. A
@@ -1876,6 +1949,13 @@ pub(crate) async fn sign_challenge<R: Runtime>(
 
     if !zcash.state.is_initialized().await {
         return Err(Error::WalletNotInitialized);
+    }
+
+    // Fail closed before loading seed custody or producing any signature. The
+    // exact active wallet remains stable under the transition lock.
+    {
+        let manifest = zcash.state.manifest.lock().await;
+        ensure_challenge_signing_allowed(&manifest)?;
     }
 
     ensure_active_seed_loaded(&zcash.state, &transition_guard).await?;

--- a/wallet/plugins/tauri-plugin-zcash/src/error.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     #[error("wallet already initialized")]
     WalletAlreadyInitialized,
 
+    #[error("recovery phrase backup must be confirmed before signing")]
+    BackupRequired,
+
     #[error("invalid mnemonic: {0}")]
     InvalidMnemonic(String),
 

--- a/wallet/plugins/tauri-plugin-zcash/src/lib.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/lib.rs
@@ -46,6 +46,8 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::get_wallet_status,
             commands::retry_wallet_cleanup,
             commands::get_seed_phrase,
+            commands::get_backup_seed_phrase,
+            commands::confirm_wallet_backup,
             commands::get_viewing_key,
             commands::get_spending_key,
             commands::list_wallets,

--- a/wallet/plugins/tauri-plugin-zcash/src/models.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/models.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WalletCreated {
+    pub wallet_id: String,
     pub seed_phrase: String,
     pub birthday_height: u64,
 }
@@ -17,6 +18,7 @@ pub struct WalletStatus {
     pub active_wallet_id: Option<String>,
     pub active_wallet_name: Option<String>,
     pub wallet_count: u32,
+    pub backup_required: bool,
     /// Durable orphan cleanup state. This is additive so older frontends can
     /// ignore it while operators still receive startup diagnostics.
     #[serde(default)]
@@ -191,6 +193,12 @@ pub struct RestoreWalletArgs {
     pub seed_phrase: String,
     pub birthday_height: Option<u64>,
     pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmWalletBackupArgs {
+    pub wallet_id: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/cleanup.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/cleanup.rs
@@ -76,6 +76,8 @@ struct CleanupOperation {
     wallet_name: Option<String>,
     #[serde(default)]
     birthday_height: Option<u64>,
+    #[serde(default)]
+    backup_required: bool,
     reason: CleanupReason,
     /// Deletions are not executable until both the manifest and this flag are
     /// durably committed. Rollbacks are executable whenever the exact wallet
@@ -188,6 +190,7 @@ fn schedule(
         db_filename: entry.db_filename.clone(),
         wallet_name: Some(entry.name.clone()),
         birthday_height: entry.birthday_height,
+        backup_required: entry.backup_required,
         reason,
         transition_confirmed: false,
         preserve_custody_if_manifest_missing: false,
@@ -386,6 +389,7 @@ pub(crate) fn recover_published_wallets(
             db_filename: operation.db_filename.clone(),
             birthday_height: operation.birthday_height,
             created_at: operation.generation.clone(),
+            backup_required: operation.backup_required,
         };
         match manifest.commit_wallet(data_dir, entry) {
             Ok(true) => diagnostics.push(format!(
@@ -992,6 +996,7 @@ mod tests {
             db_filename: format!("wallet_{id}.sqlite"),
             birthday_height: Some(1),
             created_at: "2026-08-06T00:00:00Z".into(),
+            backup_required: false,
         }
     }
 
@@ -1211,7 +1216,8 @@ mod tests {
     #[test]
     fn startup_restores_a_published_wallet_before_cancelling_rollback() {
         let dir = TestDir::new("published-recovery");
-        let entry = wallet();
+        let mut entry = wallet();
+        entry.backup_required = true;
         let authorization = schedule_staged_wallet_rollback(&dir.0, &entry).unwrap();
         protect_staged_wallet_custody(&dir.0, &authorization).unwrap();
         let mut manifest = empty_manifest();
@@ -1220,6 +1226,7 @@ mod tests {
         assert_eq!(manifest.wallets.len(), 1);
         assert_eq!(manifest.wallets[0].id, entry.id);
         assert_eq!(manifest.wallets[0].created_at, entry.created_at);
+        assert!(manifest.wallets[0].backup_required);
         assert!(
             diagnostics
                 .iter()

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/manifest.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/manifest.rs
@@ -9,6 +9,11 @@ pub struct WalletEntry {
     pub db_filename: String,
     pub birthday_height: Option<u64>,
     pub created_at: String,
+    /// A freshly generated identity cannot sign a login challenge until the
+    /// user has explicitly completed the recovery-phrase backup ceremony.
+    /// Legacy manifests and restored wallets predate/do not need this gate.
+    #[serde(default)]
+    pub backup_required: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -155,6 +160,7 @@ impl WalletManifest {
             db_filename: "wallet.sqlite".to_string(),
             birthday_height: None,
             created_at: chrono_now(),
+            backup_required: false,
         };
 
         self.wallets.push(entry);
@@ -179,6 +185,18 @@ impl WalletManifest {
             .and_then(|id| self.wallets.iter().find(|w| &w.id == id))
     }
 
+    pub(crate) fn active_backup_required(&self) -> bool {
+        self.get_active()
+            .is_some_and(|wallet| wallet.backup_required)
+    }
+
+    pub(crate) fn is_exact_active_backup_pending(&self, wallet_id: &str) -> bool {
+        self.active_wallet_id.as_deref() == Some(wallet_id)
+            && self
+                .get_active()
+                .is_some_and(|wallet| wallet.backup_required)
+    }
+
     /// Allocate a wallet identity without making it visible or durable.
     ///
     /// Callers initialize the database and commit native seed custody before
@@ -194,7 +212,49 @@ impl WalletManifest {
             db_filename,
             birthday_height,
             created_at: chrono_now(),
+            backup_required: false,
         }
+    }
+
+    /// Mark a newly generated wallet's recovery phrase as requiring backup
+    /// before the entry is ever published in the durable manifest.
+    pub(crate) fn require_backup(entry: &mut WalletEntry) {
+        entry.backup_required = true;
+    }
+
+    /// Atomically clear the backup gate for the exact active wallet.
+    ///
+    /// The wallet ID binding prevents a stale seed screen from acknowledging a
+    /// different identity after a switch. Persistence failure restores memory
+    /// so runtime and restart state cannot disagree.
+    pub(crate) fn confirm_backup(
+        &mut self,
+        data_dir: &Path,
+        wallet_id: &str,
+    ) -> std::io::Result<bool> {
+        if self.active_wallet_id.as_deref() != Some(wallet_id) {
+            return Ok(false);
+        }
+        let Some(wallet) = self
+            .wallets
+            .iter_mut()
+            .find(|wallet| wallet.id == wallet_id)
+        else {
+            return Ok(false);
+        };
+        if !wallet.backup_required {
+            return Ok(true);
+        }
+        wallet.backup_required = false;
+        if let Err(error) = self.save_atomic(data_dir) {
+            self.wallets
+                .iter_mut()
+                .find(|wallet| wallet.id == wallet_id)
+                .expect("active wallet remains present")
+                .backup_required = true;
+            return Err(error);
+        }
+        Ok(true)
     }
 
     /// Durably add a fully initialized wallet and set it active.
@@ -499,6 +559,100 @@ mod replacement_tests {
     }
 
     #[test]
+    fn new_wallet_backup_gate_is_published_and_cleared_durably() {
+        let data_dir = test_dir("backup-gate");
+        let mut manifest = WalletManifest {
+            wallets: Vec::new(),
+            active_wallet_id: None,
+        };
+        let mut entry = WalletManifest::prepare_wallet("New identity".into(), Some(42));
+        WalletManifest::require_backup(&mut entry);
+        let wallet_id = entry.id.clone();
+
+        manifest.commit_wallet(&data_dir, entry).unwrap();
+        assert!(manifest.active_backup_required());
+        assert!(
+            WalletManifest::load(&data_dir)
+                .expect("reload required backup")
+                .active_backup_required()
+        );
+
+        assert!(manifest.confirm_backup(&data_dir, &wallet_id).unwrap());
+        assert!(!manifest.active_backup_required());
+        assert!(
+            !WalletManifest::load(&data_dir)
+                .expect("reload confirmed backup")
+                .active_backup_required()
+        );
+        std::fs::remove_dir_all(data_dir).expect("remove test directory");
+    }
+
+    #[test]
+    fn backup_confirmation_binds_active_wallet_and_rolls_back_on_write_failure() {
+        let data_dir = test_dir("backup-confirm-rollback");
+        let mut active = WalletManifest::prepare_wallet("Active".into(), Some(1));
+        WalletManifest::require_backup(&mut active);
+        let other = WalletManifest::prepare_wallet("Other".into(), Some(2));
+        let mut manifest = WalletManifest {
+            wallets: vec![active.clone(), other.clone()],
+            active_wallet_id: Some(active.id.clone()),
+        };
+        manifest.save_atomic(&data_dir).unwrap();
+        assert!(manifest.is_exact_active_backup_pending(&active.id));
+
+        assert!(manifest.set_active(&data_dir, &other.id).unwrap());
+        assert!(
+            !manifest.is_exact_active_backup_pending(&active.id),
+            "a switched-away seed screen cannot retrieve the prior wallet phrase"
+        );
+        assert!(
+            !manifest.confirm_backup(&data_dir, &active.id).unwrap(),
+            "a seed screen from the prior wallet cannot confirm after a switch"
+        );
+        assert!(
+            manifest
+                .wallets
+                .iter()
+                .find(|wallet| wallet.id == active.id)
+                .unwrap()
+                .backup_required
+        );
+        assert!(manifest.set_active(&data_dir, &active.id).unwrap());
+
+        std::fs::remove_file(data_dir.join("wallets.json")).unwrap();
+        std::fs::create_dir(data_dir.join("wallets.json")).unwrap();
+        assert!(manifest.confirm_backup(&data_dir, &active.id).is_err());
+        assert!(
+            manifest.active_backup_required(),
+            "failed persistence must restore the in-memory gate"
+        );
+        std::fs::remove_dir_all(data_dir).expect("remove test directory");
+    }
+
+    #[test]
+    fn legacy_manifest_without_backup_field_defaults_to_complete() {
+        let data_dir = test_dir("legacy-backup-default");
+        std::fs::write(
+            data_dir.join("wallets.json"),
+            r#"{
+              "wallets": [{
+                "id": "legacy",
+                "name": "Legacy",
+                "db_filename": "wallet.sqlite",
+                "birthday_height": null,
+                "created_at": "2025-01-01T00:00:00Z"
+              }],
+              "active_wallet_id": "legacy"
+            }"#,
+        )
+        .unwrap();
+
+        let manifest = WalletManifest::load(&data_dir).expect("load legacy manifest");
+        assert!(!manifest.active_backup_required());
+        std::fs::remove_dir_all(data_dir).expect("remove test directory");
+    }
+
+    #[test]
     fn active_wallet_persistence_failure_rolls_back_memory() {
         let parent = test_dir("activate-rollback");
         let invalid_data_dir = parent.join("not-a-directory");
@@ -621,6 +775,7 @@ mod replacement_tests {
                 db_filename: "../../outside.sqlite".into(),
                 birthday_height: None,
                 created_at: chrono_now(),
+                backup_required: false,
             }],
             active_wallet_id: Some(id),
         };

--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs && playwright test",
+    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs scripts/auth-session-boundary.node-test.mjs && playwright test",
     "test:viewport": "playwright test tests/viewport.pw.ts",
     "test:asc-testflight": "node --test scripts/asc-testflight.node-test.mjs",
     "test:store-listing": "node --test scripts/store-contract.node-test.mjs scripts/store-state-audit.node-test.mjs",

--- a/wallet/zuuli/scripts/auth-session-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/auth-session-boundary.node-test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function between(source, start, end) {
+  const from = source.indexOf(start);
+  const to = source.indexOf(end, from + start.length);
+  assert.ok(from >= 0, `missing source marker: ${start}`);
+  assert.ok(to > from, `missing source marker: ${end}`);
+  return source.slice(from, to);
+}
+
+test("awaited raw login helpers cannot publish the global token", () => {
+  const api = readFileSync(new URL("../src/lib/api/free2z.ts", import.meta.url), "utf8");
+  const transport = readFileSync(new URL("../src/lib/api/http.ts", import.meta.url), "utf8");
+  const rawHelpers = [
+    between(api, "  async login(", "  /** Whether the currently-authenticated"),
+    between(api, "  async completeOtp(", "  async me("),
+    between(api, "  async zcashLogin(", "  /** Ask the backend"),
+    between(api, "  async completeSocialOAuth(", "};\n\n// ─── Profile"),
+    between(transport, "export async function basicLogin(", "function safeJson("),
+  ];
+
+  for (const helper of rawHelpers) {
+    assert.doesNotMatch(helper, /\bsetToken\s*\(/);
+    assert.doesNotMatch(helper, /localStorage\s*\./);
+  }
+});
+
+test("uncommitted profile probes use a private explicit token header", () => {
+  const transport = readFileSync(new URL("../src/lib/api/http.ts", import.meta.url), "utf8");
+  const requestBody = between(
+    transport,
+    "export async function request<T>(",
+    "/** Knox login:",
+  );
+
+  assert.match(requestBody, /opts\.authToken \?\? getToken\(\)/);
+  assert.match(requestBody, /headers\["Authorization"\] = `Token \$\{token\}`/);
+});

--- a/wallet/zuuli/src/App.tsx
+++ b/wallet/zuuli/src/App.tsx
@@ -16,6 +16,8 @@ import { NotFound } from "@/components/common/NotFound";
 import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
 import { auth } from "@/lib/api/free2z";
+import { setToken } from "@/lib/api/http";
+import { useAttemptLease } from "@/hooks/useAttemptLease";
 import { recoverMobileOAuth } from "@/lib/oauth/transport";
 import {
   clearPendingSocialLoginDestination,
@@ -63,6 +65,7 @@ function MobileOAuthRecovery() {
   const setUser = useSession((state) => state.setUser);
   const sessionLoading = useSession((state) => state.loading);
   const started = useRef(false);
+  const attempt = useAttemptLease();
 
   useEffect(() => {
     // The pending record is bound to the Knox session that initiated it.
@@ -72,11 +75,18 @@ function MobileOAuthRecovery() {
     // state is one-shot too, but this guard avoids two backend exchanges.
     if (started.current) return;
     started.current = true;
+    const isCurrent = attempt.begin();
     void recoverMobileOAuth()
       .then(async (capture) => {
-        if (!capture) return;
-        const user = await auth.completeSocialOAuth(capture);
-        setUser(user);
+        if (!isCurrent() || !capture) return;
+        const result = await auth.completeSocialOAuth(capture);
+        if (!isCurrent()) return;
+        if (result.status === "authenticated") {
+          setToken(result.session.token);
+          setUser(result.session.user);
+        } else {
+          setUser(result.user);
+        }
         toast.success(capture.associate ? "Account linked" : "Welcome to ZUULI", {
           description: `Finished ${capture.provider} sign-in after returning to the app.`,
         });
@@ -87,12 +97,13 @@ function MobileOAuthRecovery() {
         }
       })
       .catch((error) => {
+        if (!isCurrent()) return;
         clearPendingSocialLoginDestination();
         toast.error("Couldn't finish sign-in", {
           description: error instanceof Error ? error.message : "Please try again.",
         });
       });
-  }, [navigate, sessionLoading, setUser]);
+  }, [attempt, navigate, sessionLoading, setUser]);
 
   return null;
 }

--- a/wallet/zuuli/src/components/common/SocialButtons.tsx
+++ b/wallet/zuuli/src/components/common/SocialButtons.tsx
@@ -23,7 +23,9 @@ import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useSocialProviders } from "@/hooks/useSocialProviders";
 import { auth } from "@/lib/api/free2z";
+import { setToken } from "@/lib/api/http";
 import { useSession } from "@/store/session";
+import { useAttemptLease } from "@/hooks/useAttemptLease";
 import type { SocialProvider } from "@/lib/api/types";
 import {
   clearPendingSocialLoginDestination,
@@ -85,6 +87,7 @@ export function SocialButtons({
   const navigate = useNavigate();
   const setUser = useSession((s) => s.setUser);
   const [pending, setPending] = useState<SocialProvider | null>(null);
+  const attempt = useAttemptLease();
 
   const providers = configured.filter((p) => !alreadyLinked?.includes(p));
 
@@ -93,18 +96,24 @@ export function SocialButtons({
 
   async function handleClick(provider: SocialProvider) {
     if (pending) return;
+    const isCurrent = attempt.begin();
     setPending(provider);
     if (!associate) rememberPendingSocialLoginDestination(loginDestination);
     try {
-      const user = await auth.socialLogin(provider, { associate });
-      setUser(user);
+      const result = await auth.socialLogin(provider, { associate });
+      if (!isCurrent()) return;
       const name = PROVIDER_NAME[provider];
       if (associate) {
+        if (result.status !== "associated") throw new Error("Unexpected login result");
+        setUser(result.user);
         toast.success(`${name} linked`, {
           description: `This ${name} identity is now linked to your account.`,
         });
         onLinked?.(provider);
       } else {
+        if (result.status !== "authenticated") throw new Error("Unexpected link result");
+        setToken(result.session.token);
+        setUser(result.session.user);
         toast.success("Welcome to ZUULI", {
           description: `Logged in with ${name}.`,
         });
@@ -112,12 +121,13 @@ export function SocialButtons({
         navigate(loginDestination, { replace: true });
       }
     } catch (e) {
+      if (!isCurrent()) return;
       if (!associate) clearPendingSocialLoginDestination();
       toast.error(associate ? "Couldn't link that account" : "Couldn't log in", {
         description: e instanceof Error ? e.message : "Please try again.",
       });
     } finally {
-      setPending(null);
+      if (isCurrent()) setPending(null);
     }
   }
 

--- a/wallet/zuuli/src/features/auth/ClassicLoginForm.tsx
+++ b/wallet/zuuli/src/features/auth/ClassicLoginForm.tsx
@@ -10,9 +10,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { auth } from "@/lib/api/free2z";
-import type { AuthUser } from "@/lib/api/types";
+import { setToken } from "@/lib/api/http";
+import type { AuthenticatedSession } from "@/lib/api/types";
 import { useSession } from "@/store/session";
 import type { LoginDestination } from "@/lib/auth/login-destination";
+import { useAttemptLease, type IsCurrentAttempt } from "@/hooks/useAttemptLease";
 
 export function ClassicLoginForm({
   loginDestination = "/",
@@ -30,11 +32,14 @@ export function ClassicLoginForm({
   // When 2FA is required, we advance to the code step; the password stays in
   // component memory only long enough to complete the second factor.
   const [needsOtp, setNeedsOtp] = useState(false);
+  const attempt = useAttemptLease();
 
-  function land(user: AuthUser) {
-    setUser(user);
+  function land(session: AuthenticatedSession, isCurrent: IsCurrentAttempt) {
+    if (!isCurrent()) return;
+    setToken(session.token);
+    setUser(session.user);
     toast.success("Welcome back", {
-      description: `Logged in as ${user.username}.`,
+      description: `Logged in as ${session.user.username}.`,
     });
     navigate(loginDestination, { replace: true });
   }
@@ -43,22 +48,27 @@ export function ClassicLoginForm({
     e.preventDefault();
     if (!username || !password || submitting) return;
     setSubmitting(true);
+    const isCurrent = attempt.begin();
     onBusyChange?.(true);
     setError(null);
     try {
       const result = await auth.login(username.trim(), password);
+      if (!isCurrent()) return;
       if (result.status === "otp_required") {
         setNeedsOtp(true);
       } else {
-        land(result.user);
+        land(result.session, isCurrent);
       }
     } catch (err) {
+      if (!isCurrent()) return;
       setError(
         err instanceof Error ? err.message : "Sign-in failed. Check your details.",
       );
     } finally {
-      setSubmitting(false);
-      onBusyChange?.(false);
+      if (isCurrent()) {
+        setSubmitting(false);
+        onBusyChange?.(false);
+      }
     }
   }
 
@@ -68,8 +78,10 @@ export function ClassicLoginForm({
         username={username.trim()}
         password={password}
         onVerified={land}
+        beginAttempt={attempt.begin}
         onBusyChange={onBusyChange}
         onBack={() => {
+          attempt.invalidate();
           setNeedsOtp(false);
           setError(null);
         }}
@@ -133,12 +145,14 @@ function OtpStep({
   username,
   password,
   onVerified,
+  beginAttempt,
   onBack,
   onBusyChange,
 }: {
   username: string;
   password: string;
-  onVerified: (user: AuthUser) => void;
+  onVerified: (session: AuthenticatedSession, isCurrent: IsCurrentAttempt) => void;
+  beginAttempt: () => IsCurrentAttempt;
   onBack: () => void;
   onBusyChange?: (busy: boolean) => void;
 }) {
@@ -150,17 +164,22 @@ function OtpStep({
     e.preventDefault();
     if (code.length !== 6 || submitting) return;
     setSubmitting(true);
+    const isCurrent = beginAttempt();
     onBusyChange?.(true);
     setError(null);
     try {
-      const user = await auth.completeOtp(username, password, code);
-      onVerified(user);
+      const session = await auth.completeOtp(username, password, code);
+      if (!isCurrent()) return;
+      onVerified(session, isCurrent);
     } catch (err) {
+      if (!isCurrent()) return;
       setError(err instanceof Error ? err.message : "Verification failed.");
       setCode("");
     } finally {
-      setSubmitting(false);
-      onBusyChange?.(false);
+      if (isCurrent()) {
+        setSubmitting(false);
+        onBusyChange?.(false);
+      }
     }
   }
 

--- a/wallet/zuuli/src/features/auth/SeedReveal.tsx
+++ b/wallet/zuuli/src/features/auth/SeedReveal.tsx
@@ -13,10 +13,17 @@ import { cn } from "@/lib/utils";
 
 interface SeedRevealProps {
   seedPhrase: string;
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<void>;
+  confirming?: boolean;
+  error?: string | null;
 }
 
-export function SeedReveal({ seedPhrase, onConfirm }: SeedRevealProps) {
+export function SeedReveal({
+  seedPhrase,
+  onConfirm,
+  confirming = false,
+  error,
+}: SeedRevealProps) {
   const [revealed, setRevealed] = useState(false);
   const [acknowledged, setAcknowledged] = useState(false);
   const words = seedPhrase.trim().split(/\s+/);
@@ -96,12 +103,18 @@ export function SeedReveal({ seedPhrase, onConfirm }: SeedRevealProps) {
 
       <Separator />
 
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
       <label className="min-h-11 flex cursor-pointer items-start gap-3 text-sm">
         <input
           type="checkbox"
           checked={acknowledged}
           onChange={(e) => setAcknowledged(e.target.checked)}
-          disabled={!revealed}
+          disabled={!revealed || confirming}
           className="mt-0.5 h-4 w-4 accent-[hsl(var(--primary))] disabled:opacity-40"
         />
         <span className={cn(!revealed && "text-muted-foreground")}>
@@ -114,11 +127,11 @@ export function SeedReveal({ seedPhrase, onConfirm }: SeedRevealProps) {
         type="button"
         size="lg"
         className="w-full"
-        disabled={!acknowledged}
-        onClick={onConfirm}
+        disabled={!acknowledged || confirming}
+        onClick={() => void onConfirm()}
       >
         <Check className="h-4 w-4" aria-hidden />
-        I saved it — continue
+        {confirming ? "Saving confirmation…" : "I saved it — continue"}
       </Button>
     </div>
   );

--- a/wallet/zuuli/src/features/auth/ZcashLoginFlow.tsx
+++ b/wallet/zuuli/src/features/auth/ZcashLoginFlow.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   RotateCw,
   Sparkles,
+  ShieldAlert,
 } from "lucide-react";
 import { useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -71,12 +72,18 @@ export function ZcashLoginFlow({
     error,
     start,
     createIdentity,
+    revealSeedBackup,
     confirmSeedSaved,
     retry,
   } = flow;
 
   useEffect(() => {
-    const busy = phase === "running" || phase === "creating" || phase === "success";
+    const busy =
+      phase === "running" ||
+      phase === "creating" ||
+      phase === "loadingSeed" ||
+      phase === "confirmingBackup" ||
+      phase === "success";
     onBusyChange?.(busy);
   }, [onBusyChange, phase]);
 
@@ -102,6 +109,45 @@ export function ZcashLoginFlow({
         >
           <Sparkles className="h-5 w-5" aria-hidden />
           Continue
+        </Button>
+      </div>
+    );
+  }
+
+  if (phase === "backupRequired" || phase === "loadingSeed") {
+    const loading = phase === "loadingSeed";
+    return (
+      <div className="animate-slide-up space-y-5">
+        <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+          <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-amber-400" aria-hidden />
+          <div className="space-y-1 text-sm">
+            <p className="font-semibold text-amber-300">Back up your recovery phrase</p>
+            <p className="text-amber-200/80">
+              This identity was created, but its required backup was not confirmed.
+              Finish that step before logging in.
+            </p>
+          </div>
+        </div>
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        <Button
+          size="lg"
+          className="w-full"
+          disabled={loading}
+          onClick={() => {
+            onBusyChange?.(true);
+            void revealSeedBackup();
+          }}
+        >
+          {loading ? (
+            <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+          ) : (
+            <Fingerprint className="h-5 w-5" aria-hidden />
+          )}
+          {loading ? "Opening secure backup…" : "Reveal recovery phrase"}
         </Button>
       </div>
     );
@@ -140,13 +186,15 @@ export function ZcashLoginFlow({
   }
 
   // ── Freshly created — back up the recovery phrase before continuing ───────
-  if (phase === "seedReveal" && seedPhrase) {
+  if ((phase === "seedReveal" || phase === "confirmingBackup") && seedPhrase) {
     return (
       <SeedReveal
         seedPhrase={seedPhrase}
+        confirming={phase === "confirmingBackup"}
+        error={error}
         onConfirm={() => {
           onBusyChange?.(true);
-          confirmSeedSaved();
+          return confirmSeedSaved();
         }}
       />
     );

--- a/wallet/zuuli/src/features/auth/useZcashAssociate.ts
+++ b/wallet/zuuli/src/features/auth/useZcashAssociate.ts
@@ -54,17 +54,19 @@ export function useZcashAssociate(): ZcashAssociateState {
   const setUser = useSession((s) => s.setUser);
 
   return useZcashChallengeFlow({
-    verify: (signed) =>
-      auth.zcashAssociate({
+    verify: async (signed) => ({
+      user: await auth.zcashAssociate({
         address: signed.address,
         challenge: signed.challenge,
         signature: signed.signature,
         pubkey: signed.pubkey,
       }),
+    }),
     verifyErrorMessage:
       "free2z couldn't link that Zcash key. Please try again.",
-    onVerified: (user) => setUser(user),
-    afterSuccess: () => {
+    onVerified: ({ user }) => setUser(user),
+    afterSuccess: (_result, _address, isCurrent) => {
+      if (!isCurrent()) return;
       toast.success("Zcash key linked", {
         description: "This Zcash identity is now linked to your account.",
       });

--- a/wallet/zuuli/src/features/auth/useZcashChallengeFlow.ts
+++ b/wallet/zuuli/src/features/auth/useZcashChallengeFlow.ts
@@ -20,6 +20,7 @@ import { wallet } from "@/lib/wallet/bridge";
 import type { SignedChallenge } from "@/lib/wallet/types";
 import { auth } from "@/lib/api/free2z";
 import type { AuthUser } from "@/lib/api/types";
+import { useAttemptLease, type IsCurrentAttempt } from "@/hooks/useAttemptLease";
 
 export type StepKey = "prepare" | "challenge" | "sign" | "verify";
 export type StepStatus = "pending" | "active" | "done" | "error";
@@ -29,7 +30,10 @@ export type Phase =
   | "running" // walking the crypto steps
   | "needsWallet" // no wallet on device — offer to create one
   | "creating" // minting a fresh identity
+  | "backupRequired" // durable backup gate resumed from native custody
+  | "loadingSeed" // authenticating native custody for an explicit reveal
   | "seedReveal" // showing the recovery phrase for backup
+  | "confirmingBackup" // durably clearing the native backup gate
   | "success"
   | "error";
 
@@ -76,7 +80,8 @@ export interface ZcashChallengeFlowState {
   activeIndex: number;
   start: () => void;
   createIdentity: () => Promise<void>;
-  confirmSeedSaved: () => void;
+  revealSeedBackup: () => Promise<void>;
+  confirmSeedSaved: () => Promise<void>;
   retry: () => void;
   reset: () => void;
 }
@@ -87,13 +92,23 @@ export interface ChallengeFlowConfig {
    * challenge — either `auth.zcashLogin` (anonymous) or `auth.zcashAssociate`
    * (authenticated, attaches the current knox token).
    */
-  verify: (signed: SignedChallenge) => Promise<AuthUser>;
+  verify: (signed: SignedChallenge) => Promise<ChallengeVerification>;
   /** Friendly message shown when `verify` throws (a non-conflict error). */
   verifyErrorMessage: string;
   /** Called once `verify` resolves, so the caller can update its own state. */
-  onVerified: (user: AuthUser, address: string) => void;
+  onVerified: (result: ChallengeVerification, address: string) => void;
   /** Run after the phase flips to "success" (e.g. toast + navigate). */
-  afterSuccess?: (user: AuthUser, address: string) => void | Promise<void>;
+  afterSuccess?: (
+    result: ChallengeVerification,
+    address: string,
+    isCurrent: IsCurrentAttempt,
+  ) => void | Promise<void>;
+}
+
+export interface ChallengeVerification {
+  user: AuthUser;
+  /** Present only for login. Association never replaces the current token. */
+  token?: string;
 }
 
 // A friendly, step-aware message for the user. We NEVER surface the raw
@@ -130,17 +145,19 @@ export function useZcashChallengeFlow(
   const [steps, setSteps] = useState<Steps>(freshSteps);
   const [address, setAddress] = useState<string | null>(null);
   const [seedPhrase, setSeedPhrase] = useState<string | null>(null);
+  const [backupWalletId, setBackupWalletId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // Guards against overlapping runs (e.g. an impatient double-click).
   const runningRef = useRef(false);
+  const attempt = useAttemptLease();
 
   const setStep = useCallback((key: StepKey, status: StepStatus) => {
     setSteps((prev) => ({ ...prev, [key]: status }));
   }, []);
 
   // The crypto half of the flow: challenge → sign → verify → done.
-  const runCrypto = useCallback(async () => {
+  const runCrypto = useCallback(async (isCurrent: IsCurrentAttempt) => {
     // Track which step is in flight so a failure lands on the right row and
     // gets the right friendly message.
     let stage: StepKey = "prepare";
@@ -153,6 +170,7 @@ export function useZcashChallengeFlow(
       // unified u1… address) than the t1… address we sign with, the lookup
       // misses and fails as "challenge does not match".
       const addr = await wallet.getLoginAddress(0);
+      if (!isCurrent()) return;
       setAddress(addr);
 
       // 2 — Ask the SERVER for the challenge to sign. The one-time,
@@ -162,7 +180,9 @@ export function useZcashChallengeFlow(
       stage = "challenge";
       setStep("challenge", "active");
       await wait(450);
+      if (!isCurrent()) return;
       const { challenge } = await auth.zcashChallenge(addr);
+      if (!isCurrent()) return;
       setStep("challenge", "done");
 
       // 3 — Sign the server's exact challenge with the wallet key. Send it
@@ -170,32 +190,39 @@ export function useZcashChallengeFlow(
       stage = "sign";
       setStep("sign", "active");
       await wait(500);
+      if (!isCurrent()) return;
       const signed = await wallet.signChallenge(challenge);
+      if (!isCurrent()) return;
       setStep("sign", "done");
 
       // 4 — Verify with free2z (login or associate — see `config.verify`).
       stage = "verify";
       setStep("verify", "active");
       await wait(400);
-      const user = await verify(signed);
+      if (!isCurrent()) return;
+      const result = await verify(signed);
+      if (!isCurrent()) return;
       setStep("verify", "done");
 
       // 5 — Land the result and let the caller react.
-      onVerified(user, signed.address);
+      onVerified(result, signed.address);
+      if (!isCurrent()) return;
       setPhase("success");
-      if (afterSuccess) await afterSuccess(user, signed.address);
+      if (afterSuccess) await afterSuccess(result, signed.address, isCurrent);
     } catch (e) {
+      if (!isCurrent()) return;
       setStep(stage, "error");
       setError(friendlyError(stage, e, verifyErrorMessage));
       setPhase("error");
     } finally {
-      runningRef.current = false;
+      if (isCurrent()) runningRef.current = false;
     }
   }, [afterSuccess, onVerified, setStep, verify, verifyErrorMessage]);
 
   // Step 1 — ensure a wallet exists, then either pause for creation or run.
   const prepareAndRun = useCallback(async () => {
     if (runningRef.current) return;
+    const isCurrent = attempt.begin();
     runningRef.current = true;
     setError(null);
     setSteps(freshSteps());
@@ -203,62 +230,125 @@ export function useZcashChallengeFlow(
     setStep("prepare", "active");
     try {
       await wait(400);
+      if (!isCurrent()) return;
       const status = await wallet.getWalletStatus();
+      if (!isCurrent()) return;
       if (!status.initialized) {
         // Pause the machine and hand control to the create-identity path.
         runningRef.current = false;
         setPhase("needsWallet");
         return;
       }
+      if (status.backupRequired) {
+        runningRef.current = false;
+        setBackupWalletId(status.activeWalletId);
+        setPhase("backupRequired");
+        return;
+      }
       setStep("prepare", "done");
-      await runCrypto();
+      await runCrypto(isCurrent);
     } catch (e) {
+      if (!isCurrent()) return;
       setStep("prepare", "error");
       setError(errMessage(e));
       setPhase("error");
       runningRef.current = false;
     }
-  }, [runCrypto, setStep]);
+  }, [attempt, runCrypto, setStep]);
 
   const start = useCallback(() => {
     void prepareAndRun();
   }, [prepareAndRun]);
 
   const createIdentity = useCallback(async () => {
+    if (runningRef.current) return;
+    const isCurrent = attempt.begin();
+    runningRef.current = true;
     setPhase("creating");
     setError(null);
     try {
-      const { seedPhrase: phrase } = await wallet.createWallet();
+      const { walletId, seedPhrase: phrase } = await wallet.createWallet();
+      if (!isCurrent()) return;
+      setBackupWalletId(walletId);
       setSeedPhrase(phrase);
       setPhase("seedReveal");
     } catch (e) {
+      if (!isCurrent()) return;
       setError(errMessage(e));
       setPhase("error");
+    } finally {
+      if (isCurrent()) runningRef.current = false;
     }
-  }, []);
+  }, [attempt]);
 
-  const confirmSeedSaved = useCallback(() => {
-    // Drop the phrase from memory the moment backup is confirmed.
-    setSeedPhrase(null);
+  const revealSeedBackup = useCallback(async () => {
     if (runningRef.current) return;
+    const isCurrent = attempt.begin();
     runningRef.current = true;
-    setPhase("running");
-    setStep("prepare", "done");
-    void runCrypto();
-  }, [runCrypto, setStep]);
+    setError(null);
+    setPhase("loadingSeed");
+    try {
+      const status = await wallet.getWalletStatus();
+      if (!isCurrent()) return;
+      if (!status.initialized || !status.activeWalletId) {
+        throw new Error("The Zcash identity is no longer available.");
+      }
+      if (!status.backupRequired) {
+        setStep("prepare", "done");
+        await runCrypto(isCurrent);
+        return;
+      }
+      const phrase = await wallet.getBackupSeedPhrase(status.activeWalletId);
+      if (!isCurrent()) return;
+      setBackupWalletId(status.activeWalletId);
+      setSeedPhrase(phrase);
+      setPhase("seedReveal");
+    } catch (e) {
+      if (!isCurrent()) return;
+      setError(errMessage(e));
+      setPhase("backupRequired");
+    } finally {
+      if (isCurrent()) runningRef.current = false;
+    }
+  }, [attempt, runCrypto, setStep]);
+
+  const confirmSeedSaved = useCallback(async () => {
+    if (runningRef.current || !backupWalletId) return;
+    const isCurrent = attempt.begin();
+    runningRef.current = true;
+    setError(null);
+    setPhase("confirmingBackup");
+    try {
+      await wallet.confirmWalletBackup(backupWalletId);
+      if (!isCurrent()) return;
+      // Drop the phrase from memory only after the durable acknowledgement.
+      setSeedPhrase(null);
+      setPhase("running");
+      setStep("prepare", "done");
+      await runCrypto(isCurrent);
+    } catch (e) {
+      if (!isCurrent()) return;
+      setError(errMessage(e));
+      setPhase("seedReveal");
+    } finally {
+      if (isCurrent()) runningRef.current = false;
+    }
+  }, [attempt, backupWalletId, runCrypto, setStep]);
 
   const retry = useCallback(() => {
     void prepareAndRun();
   }, [prepareAndRun]);
 
   const reset = useCallback(() => {
+    attempt.invalidate();
     runningRef.current = false;
     setPhase("idle");
     setSteps(freshSteps());
     setAddress(null);
     setSeedPhrase(null);
+    setBackupWalletId(null);
     setError(null);
-  }, []);
+  }, [attempt]);
 
   const activeIndex = (() => {
     const idx = STEP_ORDER.findIndex(
@@ -278,6 +368,7 @@ export function useZcashChallengeFlow(
     activeIndex,
     start,
     createIdentity,
+    revealSeedBackup,
     confirmSeedSaved,
     retry,
     reset,

--- a/wallet/zuuli/src/features/auth/useZcashLogin.ts
+++ b/wallet/zuuli/src/features/auth/useZcashLogin.ts
@@ -10,6 +10,7 @@
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { auth } from "@/lib/api/free2z";
+import { setToken } from "@/lib/api/http";
 import { useSession } from "@/store/session";
 import type { LoginDestination } from "@/lib/auth/login-destination";
 import {
@@ -66,12 +67,18 @@ export function useZcashLogin(
       }),
     verifyErrorMessage:
       "free2z couldn't verify your Zcash signature. Please try again.",
-    onVerified: (user) => setUser(user),
-    afterSuccess: async () => {
+    onVerified: (session) => {
+      if (!session.token) throw new Error("Zcash login returned no session token");
+      setToken(session.token);
+      setUser(session.user);
+    },
+    afterSuccess: async (_session, _address, isCurrent) => {
+      if (!isCurrent()) return;
       toast.success("Welcome to ZUULI", {
         description: "Logged in with your Zcash key.",
       });
       await new Promise((r) => setTimeout(r, 700));
+      if (!isCurrent()) return;
       navigate(loginDestination, { replace: true });
     },
   });

--- a/wallet/zuuli/src/features/profile/LinkedAccounts.tsx
+++ b/wallet/zuuli/src/features/profile/LinkedAccounts.tsx
@@ -18,6 +18,7 @@ import {
   Github,
   Loader2,
   RotateCw,
+  ShieldAlert,
   ShieldCheck,
   Sparkles,
 } from "lucide-react";
@@ -79,6 +80,7 @@ function ZcashLinkDialogBody({ onDone }: { onDone: () => void }) {
     error,
     start,
     createIdentity,
+    revealSeedBackup,
     confirmSeedSaved,
     retry,
   } = flow;
@@ -117,8 +119,46 @@ function ZcashLinkDialogBody({ onDone }: { onDone: () => void }) {
     );
   }
 
-  if (phase === "seedReveal" && seedPhrase) {
-    return <SeedReveal seedPhrase={seedPhrase} onConfirm={confirmSeedSaved} />;
+  if (phase === "backupRequired" || phase === "loadingSeed") {
+    const loading = phase === "loadingSeed";
+    return (
+      <div className="animate-slide-up space-y-5">
+        <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+          <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-amber-400" aria-hidden />
+          <div className="space-y-1 text-sm">
+            <p className="font-semibold text-amber-300">Back up your recovery phrase</p>
+            <p className="text-amber-200/80">
+              Finish the required backup before linking this identity.
+            </p>
+          </div>
+        </div>
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        <Button
+          size="lg"
+          className="w-full"
+          disabled={loading}
+          onClick={() => void revealSeedBackup()}
+        >
+          {loading && <Loader2 className="h-5 w-5 animate-spin" aria-hidden />}
+          {loading ? "Opening secure backup…" : "Reveal recovery phrase"}
+        </Button>
+      </div>
+    );
+  }
+
+  if ((phase === "seedReveal" || phase === "confirmingBackup") && seedPhrase) {
+    return (
+      <SeedReveal
+        seedPhrase={seedPhrase}
+        confirming={phase === "confirmingBackup"}
+        error={error}
+        onConfirm={confirmSeedSaved}
+      />
+    );
   }
 
   if (phase === "success") {

--- a/wallet/zuuli/src/hooks/useAttemptLease.ts
+++ b/wallet/zuuli/src/hooks/useAttemptLease.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+export type IsCurrentAttempt = () => boolean;
+
+/**
+ * Component-owned generation fence for async authentication work.
+ *
+ * Native invokes and OAuth handoffs cannot always be cancelled once
+ * dispatched, so every awaited continuation must prove that its component and
+ * generation are still current before publishing UI or session state.
+ */
+export function useAttemptLease() {
+  const generation = useRef(0);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      generation.current += 1;
+    };
+  }, []);
+
+  const begin = useCallback((): IsCurrentAttempt => {
+    const attempt = ++generation.current;
+    return () => mounted.current && generation.current === attempt;
+  }, []);
+
+  const invalidate = useCallback(() => {
+    generation.current += 1;
+  }, []);
+
+  return useMemo(() => ({ begin, invalidate }), [begin, invalidate]);
+}

--- a/wallet/zuuli/src/index.css
+++ b/wallet/zuuli/src/index.css
@@ -166,7 +166,14 @@
   }
 
   .app-auth-content {
-    padding-bottom: calc(var(--mobile-tab-bar-height) + 1.5rem);
+    padding-bottom: 0;
+  }
+
+  /* End padding on an overflowing flex scroller is not consistently included
+     in its scroll range. Put the mobile-nav clearance on the content stack so
+     the final seed-backup action can always scroll fully above the fixed bar. */
+  .app-auth-stack {
+    padding-bottom: calc(var(--mobile-tab-bar-height) + 1.25rem);
   }
 
   .app-reader-content {
@@ -181,7 +188,7 @@
 
   @media (min-width: 768px) {
     .app-scroll-content,
-    .app-auth-content {
+    .app-auth-stack {
       padding-bottom: max(2.5rem, var(--safe-area-bottom));
     }
 

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -76,6 +76,7 @@ import type {
   KycTaxFormUploadResult,
   Livestream,
   LoginResult,
+  AuthenticatedSession,
   OtpStatus,
   Paginated,
   Personality,
@@ -86,6 +87,7 @@ import type {
   PromptResponse,
   SimpleCreator,
   SocialProvider,
+  SocialAuthResult,
   SocialProvidersStatus,
   StreamKind,
   SubscribeResult,
@@ -466,10 +468,11 @@ export const auth = {
    * Login with Zcash).
    *
    * Real flow:
-   *   1. `basicLogin` → Knox Basic-auth login (`/api/token/login/`) mints a token.
+   *   1. `basicLogin` → Knox Basic-auth login (`/api/token/login/`) mints a token
+   *      without storing it.
    *   2. `otpStatus()` (authenticated with that token) reports whether the
    *      account has TOTP 2FA enabled.
-   *   3. If 2FA is ON we DROP the token and return `otp_required`, so an
+   *   3. If 2FA is ON we WITHHOLD the token and return `otp_required`, so an
    *      abandoned code prompt never leaves a live session behind; the caller
    *      finishes via `completeOtp`. If 2FA is OFF, the login is complete.
    *
@@ -481,25 +484,29 @@ export const auth = {
     if (useMock()) {
       await delay();
       if (mockOtpEnabled(username)) return { status: "otp_required", username };
-      setToken("mock-knox-token");
-      return { status: "complete", user: { ...mockUser, username } };
+      return {
+        status: "complete",
+        session: { token: "mock-knox-token", user: { ...mockUser, username } },
+      };
     }
-    await basicLogin(username, password); // sets the Knox token
-    const { enabled } = await auth.otpStatus();
+    const token = await basicLogin(username, password);
+    const { enabled } = await auth.otpStatus(token);
     if (enabled) {
-      setToken(null); // don't persist a session behind an unfinished 2FA prompt
       return { status: "otp_required", username };
     }
-    return { status: "complete", user: await auth.me() };
+    return {
+      status: "complete",
+      session: { token, user: await auth.me(token) },
+    };
   },
 
   /** Whether the currently-authenticated account has TOTP 2FA enabled. */
-  async otpStatus(): Promise<OtpStatus> {
+  async otpStatus(authToken?: string): Promise<OtpStatus> {
     if (useMock()) {
       await delay(120);
       return { enabled: false };
     }
-    return request<OtpStatus>("/api/otp/status/");
+    return request<OtpStatus>("/api/otp/status/", { authToken });
   },
 
   /**
@@ -512,14 +519,16 @@ export const auth = {
     username: string,
     password: string,
     code: string,
-  ): Promise<AuthUser> {
+  ): Promise<AuthenticatedSession> {
     if (useMock()) {
       await delay();
       if (code !== MOCK_OTP_CODE) {
         throw new Error("That code didn't match. (Mock mode expects 123456.)");
       }
-      setToken("mock-knox-token");
-      return { ...mockUser, username };
+      return {
+        token: "mock-knox-token",
+        user: { ...mockUser, username },
+      };
     }
     try {
       await request("/api/otp/login/", {
@@ -535,11 +544,11 @@ export const auth = {
       }
       throw e;
     }
-    await basicLogin(username, password); // establish the real session token
-    return auth.me();
+    const token = await basicLogin(username, password);
+    return { token, user: await auth.me(token) };
   },
 
-  async me(): Promise<AuthUser> {
+  async me(authToken?: string): Promise<AuthUser> {
     if (useMock()) {
       await delay(120);
       return { ...mockUser };
@@ -556,7 +565,7 @@ export const auth = {
       tuzis?: string;
       avatar_image?: RawImage | null;
       banner_image?: RawImage | null;
-    }>("/api/auth/user/", { cache: "no-store" });
+    }>("/api/auth/user/", { cache: "no-store", authToken });
     return {
       username: u.username,
       email: u.email,
@@ -597,20 +606,21 @@ export const auth = {
     challenge: string;
     signature: string;
     pubkey?: string;
-  }): Promise<AuthUser> {
+  }): Promise<AuthenticatedSession> {
     if (useMock()) {
       await delay(400);
-      setToken("mock-knox-token-zcash");
-      return { ...mockUser, zcashLinked: true };
+      return {
+        token: "mock-knox-token-zcash",
+        user: { ...mockUser, zcashLinked: true },
+      };
     }
     const tok = await request<{ token: string }>("/api/auth/zcash/login/", {
       method: "POST",
       body: params,
       anonymous: true,
     });
-    setToken(tok.token);
-    const me = await auth.me();
-    return { ...me, zcashLinked: true };
+    const me = await auth.me(tok.token);
+    return { token: tok.token, user: { ...me, zcashLinked: true } };
   },
 
   /** Ask the backend for a login challenge to sign. */
@@ -718,7 +728,8 @@ export const auth = {
    * Social login / link with a provider (X / Google / GitHub). Runs the
    * OAuth authorization-code round trip over the desktop loopback transport,
    * the mobile free2z-HTTPS-to-app relay, or a web popup fallback
-   * (`../oauth/transport.ts`) — callers see only the resolved `AuthUser`.
+   * (`../oauth/transport.ts`) — callers receive an uncommitted result and own
+   * the final current-attempt session publication.
    *
    * Dual-mode, mirroring `zcashLogin`/`zcashAssociate`:
    *   - `associate: false` (default) — POSTs anonymously; the backend logs
@@ -736,7 +747,7 @@ export const auth = {
   async socialLogin(
     provider: SocialProvider,
     opts: { associate?: boolean } = {},
-  ): Promise<AuthUser> {
+  ): Promise<SocialAuthResult> {
     if (useMock()) {
       throw new Error(
         "Social login isn't available in mock mode — no provider is configured yet.",
@@ -754,7 +765,7 @@ export const auth = {
    * transport. Public so App startup can finish a crash-recovered cold-start
    * callback through exactly the same backend path as the live button flow.
    */
-  async completeSocialOAuth(capture: OAuthCapture): Promise<AuthUser> {
+  async completeSocialOAuth(capture: OAuthCapture): Promise<SocialAuthResult> {
     const { provider, associate, code, state, redirectUri, codeVerifier } = capture;
     await assertMobileOAuthSession(capture);
     const body = {
@@ -788,8 +799,11 @@ export const auth = {
       }
       const me = await auth.me();
       return {
-        ...me,
-        social_identities: { ...me.social_identities, [provider]: true },
+        status: "associated",
+        user: {
+          ...me,
+          social_identities: { ...me.social_identities, [provider]: true },
+        },
       };
     }
 
@@ -802,12 +816,17 @@ export const auth = {
       }
       throw error;
     });
-    setToken(tok.token);
     await finishMobileOAuth(state).catch(() => undefined);
-    const me = await auth.me();
+    const me = await auth.me(tok.token);
     return {
-      ...me,
-      social_identities: { ...me.social_identities, [provider]: true },
+      status: "authenticated",
+      session: {
+        token: tok.token,
+        user: {
+          ...me,
+          social_identities: { ...me.social_identities, [provider]: true },
+        },
+      },
     };
   },
 };

--- a/wallet/zuuli/src/lib/api/http.ts
+++ b/wallet/zuuli/src/lib/api/http.ts
@@ -110,6 +110,8 @@ interface RequestOpts {
   cache?: RequestCache;
   /** Skip the auth header even if a token exists. */
   anonymous?: boolean;
+  /** Authenticate this request without publishing a process-wide session. */
+  authToken?: string;
   signal?: AbortSignal;
 }
 
@@ -145,7 +147,7 @@ export async function request<T>(
   if (opts.body !== undefined && !isFormData && !headers["Content-Type"]) {
     headers["Content-Type"] = "application/json";
   }
-  const token = getToken();
+  const token = opts.authToken ?? getToken();
   if (token && !opts.anonymous && !headers["Authorization"]) {
     headers["Authorization"] = `Token ${token}`;
   }
@@ -173,7 +175,7 @@ export async function request<T>(
   return data as T;
 }
 
-/** Knox login: HTTP Basic auth against /api/token/login/ → { token, expiry }. */
+/** Knox login: mint a token without publishing a process-wide session. */
 export async function basicLogin(
   username: string,
   password: string,
@@ -183,7 +185,6 @@ export async function basicLogin(
     "/api/token/login/",
     { method: "POST", anonymous: true, headers: { Authorization: `Basic ${basic}` } },
   );
-  setToken(res.token);
   return res.token;
 }
 

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -114,6 +114,10 @@ export const SOCIAL_PROVIDERS: SocialProvider[] = ["x", "google", "github"];
  */
 export type SocialProvidersStatus = Partial<Record<SocialProvider, boolean>>;
 
+export type SocialAuthResult =
+  | { status: "authenticated"; session: AuthenticatedSession }
+  | { status: "associated"; user: AuthUser };
+
 /**
  * Editable fields for the signed-in user's own profile —
  * PATCH /api/auth/user/ (CreatorProfileUpdateSerializer). Avatar/banner
@@ -148,8 +152,13 @@ export interface OtpStatus {
  * the caller must finish via `auth.completeOtp`.
  */
 export type LoginResult =
-  | { status: "complete"; user: AuthUser }
+  | { status: "complete"; session: AuthenticatedSession }
   | { status: "otp_required"; username: string };
+
+export interface AuthenticatedSession {
+  token: string;
+  user: AuthUser;
+}
 
 // ── AI ────────────────────────────────────────────────────────────────────
 export interface AIModel {

--- a/wallet/zuuli/src/lib/wallet/bridge.ts
+++ b/wallet/zuuli/src/lib/wallet/bridge.ts
@@ -61,6 +61,16 @@ export const wallet = {
     return invoke("get_seed_phrase");
   },
 
+  async getBackupSeedPhrase(walletId: string): Promise<string> {
+    if (useMock()) return mockWallet.getBackupSeedPhrase(walletId);
+    return invoke("get_backup_seed_phrase", { args: { walletId } });
+  },
+
+  async confirmWalletBackup(walletId: string): Promise<void> {
+    if (useMock()) return mockWallet.confirmWalletBackup(walletId);
+    return invoke("confirm_wallet_backup", { args: { walletId } });
+  },
+
   async listAccounts(): Promise<AccountInfo[]> {
     if (useMock()) return mockWallet.listAccounts();
     return invoke("list_accounts");

--- a/wallet/zuuli/src/lib/wallet/mock.ts
+++ b/wallet/zuuli/src/lib/wallet/mock.ts
@@ -35,6 +35,9 @@ let syncing = false;
  * wallet boundary so production/native behavior cannot observe them.
  */
 const MOCK_WALLET_SCENARIO_KEY = "zuuli.mock.wallet-scenario";
+const MOCK_CREATED_WALLET_KEY = "zuuli.mock.created-wallet";
+const MOCK_BACKUP_REQUIRED_KEY = "zuuli.mock.backup-required";
+const MOCK_WALLET_ID = "mock-wallet-0";
 function mockWalletScenario(): "empty" | "sign-error" | null {
   try {
     const value = globalThis.localStorage?.getItem(MOCK_WALLET_SCENARIO_KEY);
@@ -83,15 +86,20 @@ let proposalCounter = 1;
 
 export const mockWallet = {
   getWalletStatus(): WalletStatus {
-    const initialized = mockWalletScenario() === "empty" ? false : created;
+    const persistedCreated = globalThis.localStorage?.getItem(MOCK_CREATED_WALLET_KEY) === "1";
+    const initialized =
+      mockWalletScenario() === "empty" && !persistedCreated ? false : created || persistedCreated;
     return {
       initialized,
       hasSeed: initialized,
       syncedHeight: synced,
       chainTip: tip,
-      activeWalletId: "mock-wallet-0",
+      activeWalletId: initialized ? MOCK_WALLET_ID : null,
       activeWalletName: "Main",
       walletCount: 1,
+      backupRequired:
+        initialized &&
+        globalThis.localStorage?.getItem(MOCK_BACKUP_REQUIRED_KEY) === MOCK_WALLET_ID,
       cleanup: {
         pendingOperations: 0,
         blockedOperations: 0,
@@ -117,14 +125,32 @@ export const mockWallet = {
   },
   createWallet(): WalletCreated {
     created = true;
-    return { seedPhrase: MOCK_SEED, birthdayHeight: tip - 100 };
+    globalThis.localStorage?.setItem(MOCK_CREATED_WALLET_KEY, "1");
+    globalThis.localStorage?.setItem(MOCK_BACKUP_REQUIRED_KEY, MOCK_WALLET_ID);
+    return { walletId: MOCK_WALLET_ID, seedPhrase: MOCK_SEED, birthdayHeight: tip - 100 };
   },
   restoreWallet() {
     created = true;
+    globalThis.localStorage?.removeItem(MOCK_BACKUP_REQUIRED_KEY);
     return { success: true };
   },
   getSeedPhrase(): string {
     return MOCK_SEED;
+  },
+  getBackupSeedPhrase(walletId: string): string {
+    if (
+      walletId !== MOCK_WALLET_ID ||
+      globalThis.localStorage?.getItem(MOCK_BACKUP_REQUIRED_KEY) !== walletId
+    ) {
+      throw new Error("backup phrase request does not match the active pending wallet");
+    }
+    return MOCK_SEED;
+  },
+  confirmWalletBackup(walletId: string): void {
+    if (walletId !== MOCK_WALLET_ID) {
+      throw new Error("backup confirmation does not match the active wallet");
+    }
+    globalThis.localStorage?.removeItem(MOCK_BACKUP_REQUIRED_KEY);
   },
   listAccounts(): AccountInfo[] {
     return [{ accountIndex: 0, name: "Main", unifiedAddress: MOCK_UA }];
@@ -222,6 +248,9 @@ export const mockWallet = {
   },
   discardUnrecoverableSend() {},
   signChallenge(challenge: string): SignedChallenge {
+    if (globalThis.localStorage?.getItem(MOCK_BACKUP_REQUIRED_KEY)) {
+      throw new Error("Recovery phrase backup must be confirmed before signing.");
+    }
     if (mockWalletScenario() === "sign-error") {
       throw new Error("The mock wallet could not sign this challenge.");
     }

--- a/wallet/zuuli/src/lib/wallet/types.ts
+++ b/wallet/zuuli/src/lib/wallet/types.ts
@@ -3,6 +3,7 @@
 // camelCase on both sides.
 
 export interface WalletCreated {
+  walletId: string;
   seedPhrase: string;
   birthdayHeight: number;
 }
@@ -15,6 +16,7 @@ export interface WalletStatus {
   activeWalletId: string | null;
   activeWalletName: string | null;
   walletCount: number;
+  backupRequired: boolean;
   cleanup: WalletCleanupStatus;
   legacyAppData: LegacyAppDataStatus;
 }

--- a/wallet/zuuli/tests/auth-lifecycle.pw.ts
+++ b/wallet/zuuli/tests/auth-lifecycle.pw.ts
@@ -1,0 +1,139 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const TOKEN_KEY = "zuuli.knox.token";
+
+async function openLogin(page: Page, walletScenario?: "empty" | "sign-error") {
+  await page.setViewportSize({ width: 320, height: 568 });
+  await page.addInitScript((scenario) => {
+    localStorage.removeItem("zuuli.knox.token");
+    if (scenario) localStorage.setItem("zuuli.mock.wallet-scenario", scenario);
+    else localStorage.removeItem("zuuli.mock.wallet-scenario");
+  }, walletScenario);
+  await page.goto("/login");
+}
+
+async function unmountLoginWithoutReload(page: Page) {
+  await page.evaluate(() => {
+    history.pushState({}, "", "/articles");
+    dispatchEvent(new PopStateEvent("popstate"));
+  });
+  await expect(page).toHaveURL(/\/articles$/);
+}
+
+async function expectNoInvisibleLogin(page: Page) {
+  await page.waitForTimeout(2_500);
+  expect(await page.evaluate((key) => localStorage.getItem(key), TOKEN_KEY)).toBeNull();
+  await expect(page).toHaveURL(/\/articles$/);
+  await expect(page.getByText(/Welcome (?:back|to ZUULI)/)).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Account menu" })).toHaveCount(0);
+}
+
+test("unmounted password and OTP attempts cannot publish a session", async ({ page }) => {
+  await openLogin(page);
+  await page.getByRole("button", { name: "Password", exact: true }).click();
+  await page.getByLabel("Email or username").fill("plain-user");
+  await page.getByLabel("Password").fill("password");
+  await page
+    .locator("[data-auth-selected='password']")
+    .getByRole("button", { name: "Log in", exact: true })
+    .click();
+  await unmountLoginWithoutReload(page);
+  await expectNoInvisibleLogin(page);
+
+  await page.goto("/login");
+  await page.getByRole("button", { name: "Password", exact: true }).click();
+  await page.getByLabel("Email or username").fill("otp-user");
+  await page.getByLabel("Password").fill("password");
+  await page
+    .locator("[data-auth-selected='password']")
+    .getByRole("button", { name: "Log in", exact: true })
+    .click();
+  await expect(page.getByText("Two-factor authentication")).toBeVisible();
+  await page.getByLabel("Authentication code").fill("123456");
+  await page.getByRole("button", { name: "Verify and log in" }).click();
+  await unmountLoginWithoutReload(page);
+  await expectNoInvisibleLogin(page);
+});
+
+for (const stage of ["prepare", "challenge", "sign", "verify"] as const) {
+  test(`unmounted Zcash ${stage} attempt cannot publish a session`, async ({ page }) => {
+    await openLogin(page);
+    await page.getByRole("button", { name: "Zcash", exact: true }).click();
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+
+    const titles = {
+      prepare: "Preparing your identity",
+      challenge: "Requesting a challenge",
+      sign: "Signing with your key",
+      verify: "Verifying",
+    } as const;
+    const step = page.locator("li", { hasText: titles[stage] });
+    await expect(step.getByText("working", { exact: true })).toBeVisible();
+    await unmountLoginWithoutReload(page);
+    await expectNoInvisibleLogin(page);
+  });
+}
+
+test("an unmounted Zcash retry cannot revive the failed attempt", async ({ page }) => {
+  await openLogin(page, "sign-error");
+  await page.getByRole("button", { name: "Zcash", exact: true }).click();
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await page.getByRole("button", { name: "Try again" }).click();
+  await unmountLoginWithoutReload(page);
+  await expectNoInvisibleLogin(page);
+});
+
+test("new identity backup resumes after method switch and process-style reload", async ({
+  page,
+}) => {
+  await openLogin(page, "empty");
+  await page.getByRole("button", { name: "Zcash", exact: true }).click();
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect(page.getByText("No Zcash identity on this device")).toBeVisible();
+  await page.getByRole("button", { name: "Create a Zcash identity" }).click();
+  await expect(page.getByText("This recovery phrase is your identity.")).toBeVisible();
+
+  await page.getByRole("button", { name: "Choose another login method" }).click();
+  await expect(page.getByText("wisdom", { exact: true })).toHaveCount(0);
+  expect(
+    await page.evaluate(() => localStorage.getItem("zuuli.mock.backup-required")),
+  ).toBe("mock-wallet-0");
+  await page.getByRole("button", { name: "Password", exact: true }).click();
+  await page.getByRole("button", { name: "Choose another login method" }).click();
+  await page.getByRole("button", { name: "Zcash", exact: true }).click();
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect(page.getByText("Back up your recovery phrase")).toBeVisible();
+  await page.getByRole("button", { name: "Reveal recovery phrase" }).click();
+  await page.getByRole("button", { name: "Reveal recovery phrase" }).click();
+  await expect(page.getByText("wisdom", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Choose another login method" }).click();
+  await expect(page.getByText("wisdom", { exact: true })).toHaveCount(0);
+  expect(
+    await page.evaluate(() => localStorage.getItem("zuuli.mock.backup-required")),
+  ).toBe("mock-wallet-0");
+
+  await page.reload();
+  await page.getByRole("button", { name: "Zcash", exact: true }).click();
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await expect(page.getByText("Back up your recovery phrase")).toBeVisible();
+  await page.getByRole("button", { name: "Reveal recovery phrase" }).click();
+  await page.getByRole("button", { name: "Reveal recovery phrase" }).click();
+  await page.getByRole("checkbox").check();
+  const confirm = page.getByRole("button", { name: "I saved it — continue" });
+  await page.locator("[data-route-scroll]").evaluate((scroller) => {
+    scroller.scrollTop = scroller.scrollHeight;
+  });
+  const [confirmBox, navBox] = await Promise.all([
+    confirm.boundingBox(),
+    page.locator("[data-app-bottom-nav]").boundingBox(),
+  ]);
+  expect(confirmBox).not.toBeNull();
+  expect(navBox).not.toBeNull();
+  expect(confirmBox!.y + confirmBox!.height).toBeLessThanOrEqual(navBox!.y);
+  await confirm.click();
+
+  await expect(page).toHaveURL(/\/$/, { timeout: 8_000 });
+  expect(await page.evaluate((key) => localStorage.getItem(key), TOKEN_KEY)).toBe(
+    "mock-knox-token-zcash",
+  );
+});


### PR DESCRIPTION
Closes #267.

## What changed

- make raw password, OTP, Zcash, and social login helpers return uncommitted `{ token, user }` results; component-owned generation leases now fence every awaited continuation before token/session, toast, UI, or navigation publication
- lock method switching during non-cancellable auth work and preserve the existing `/wallet/fund` login destination behavior
- persist `backup_required` in the existing atomic wallet manifest for newly generated identities, including interrupted-publication recovery; legacy and restored wallets default to complete without a migration
- bind backup phrase retrieval and confirmation to the exact active wallet under the transition lock, roll memory back on persistence failure, and fail challenge signing closed until backup confirmation is durable
- resume the phrase ceremony after method switching, close/unmount, or reload while clearing revealed words from renderer state on unmount
- register both new native commands through the handler, plugin build list, default capability, and generated permission schema

## Regression proof

- 320×568 browser tests unmount password, OTP, and each Zcash prepare/challenge/sign/verify stage before resolution and assert no token, session chrome, toast, or navigation appears
- the backup browser test switches methods after phrase reveal, proves the words leave the DOM while the durable exact wallet flag remains, reloads, resumes, confirms, then completes login
- the native manifest test switches away from the displayed wallet and rejects both phrase eligibility and stale confirmation; it then proves an atomic-write failure restores `backup_required`
- a source contract fails if any raw login helper reintroduces `setToken`/localStorage mutation and verifies uncommitted profile probes use only a private explicit-token header

## Verification

- `npm test` — 258 Vitest + 7 Node contract + 33 Playwright tests passed
- `npm run typecheck`
- `npm run build`
- `cargo +1.97.1 test --locked` in `wallet/plugins/tauri-plugin-zcash` — 98 passed
- `cargo +1.97.1 clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.97.1 build --locked && cargo +1.97.1 test --locked` in `wallet/zuuli/src-tauri` — build plus 12 tests passed
- `scripts/check-rust-toolchain.sh`
- `scripts/check-rust-fmt.sh`
- `scripts/check-rust-clippy.sh` — all three wallet crates passed on pinned Rust 1.97.1
- `git diff --check`

## Adversarial review

The first clean review found that the two new Tauri commands were in the invoke handler but missing from the plugin build/default permission surface. That would have passed browser tests while failing native invocation. The final head includes and regenerates all three registration layers; follow-up native build, plugin tests, and clippy are green. No significant finding remains on the exact rebased head.
