### PR TITLE
fix(zuuli): accept empty Play image responses

### DIFF
--- a/.github/workflows/zuuli-store-audit.yml
+++ b/.github/workflows/zuuli-store-audit.yml
@@ -34,9 +34,6 @@ jobs:
     defaults:
       run:
         working-directory: wallet/zuuli
-    env:
-      ASC_KEY_ID: ${{ vars.ASC_KEY_ID }}
-      ASC_ISSUER_ID: ${{ vars.ASC_ISSUER_ID }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -75,15 +72,23 @@ jobs:
         if: inputs.provider == 'apple' || inputs.provider == 'both'
         env:
           ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
+          ASC_KEY_ID: ${{ vars.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ vars.ASC_ISSUER_ID }}
         run: |
           set -euo pipefail
           : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
           : "${ASC_KEY_ID:?ASC_KEY_ID is not configured}"
           : "${ASC_ISSUER_ID:?ASC_ISSUER_ID is not configured}"
+          echo "::add-mask::$ASC_KEY_ID"
+          echo "::add-mask::$ASC_ISSUER_ID"
           printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$ZUULI_STORE_AUDIT_SECRET_DIR/AuthKey.p8"
           chmod 600 "$ZUULI_STORE_AUDIT_SECRET_DIR/AuthKey.p8"
           test -s "$ZUULI_STORE_AUDIT_SECRET_DIR/AuthKey.p8"
-          echo "ASC_KEY_PATH=$ZUULI_STORE_AUDIT_SECRET_DIR/AuthKey.p8" >> "$GITHUB_ENV"
+          {
+            echo "ASC_KEY_PATH=$ZUULI_STORE_AUDIT_SECRET_DIR/AuthKey.p8"
+            echo "ASC_KEY_ID=$ASC_KEY_ID"
+            echo "ASC_ISSUER_ID=$ASC_ISSUER_ID"
+          } >> "$GITHUB_ENV"
       - name: Materialize ephemeral Play credential
         if: inputs.provider == 'play' || inputs.provider == 'both'
         env:
@@ -96,18 +101,30 @@ jobs:
           test -s "$ZUULI_STORE_AUDIT_SECRET_DIR/play-service-account.json"
           echo "PLAY_SERVICE_ACCOUNT_JSON=$ZUULI_STORE_AUDIT_SECRET_DIR/play-service-account.json" >> "$GITHUB_ENV"
       - name: Audit canonical locales, media, and Play tester mode
+        id: audit
+        continue-on-error: true
         env:
           PROVIDER: ${{ inputs.provider }}
         run: |
           set -euo pipefail
           evidence_dir="$RUNNER_TEMP/zuuli-store-audit-evidence"
           mkdir -p "$evidence_dir"
-          echo "ZUULI_STORE_AUDIT_EVIDENCE_DIR=$evidence_dir" >> "$GITHUB_ENV"
+          set +e
           node scripts/store-state-audit.mjs \
             "--provider=$PROVIDER" \
             "--output=$evidence_dir/store-state.json"
+          audit_status=$?
+          set -e
+          if [[ -s "$evidence_dir/store-state.json" ]]; then
+            echo "evidence_present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "evidence_present=false" >> "$GITHUB_OUTPUT"
+          fi
+          exit "$audit_status"
       - name: Destroy ephemeral store credentials
+        id: cleanup
         if: always()
+        continue-on-error: true
         run: |
           set -u
           cleanup_failed=0
@@ -120,10 +137,32 @@ jobs:
           fi
           exit "$cleanup_failed"
       - name: Upload sanitized store-state evidence
-        if: success()
+        if: always() && steps.audit.outputs.evidence_present == 'true'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: zuuli-store-state-${{ inputs.provider }}-${{ inputs.source_sha }}
-          path: ${{ env.ZUULI_STORE_AUDIT_EVIDENCE_DIR }}/store-state.json
+          path: ${{ runner.temp }}/zuuli-store-audit-evidence/store-state.json
           if-no-files-found: error
           retention-days: 90
+      - name: Enforce audit and cleanup verdict
+        if: always()
+        env:
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
+          CLEANUP_OUTCOME: ${{ steps.cleanup.outcome }}
+          EVIDENCE_PRESENT: ${{ steps.audit.outputs.evidence_present }}
+        run: |
+          set -uo pipefail
+          verdict_failed=0
+          if [[ "$EVIDENCE_PRESENT" != true ]]; then
+            echo "::error::sanitized store audit evidence was not produced"
+            verdict_failed=1
+          fi
+          if [[ "$CLEANUP_OUTCOME" != success ]]; then
+            echo "::error::ephemeral store credential cleanup did not succeed"
+            verdict_failed=1
+          fi
+          if [[ "$AUDIT_OUTCOME" != success ]]; then
+            echo "::error::one or more requested store provider audits failed"
+            verdict_failed=1
+          fi
+          exit "$verdict_failed"

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -155,8 +155,10 @@ App Store Connect and Play state with an exact current `main` source SHA. Apple
 requests are GET-only. Google requires an ephemeral edit to read listings and
 images; the audit always deletes it and never sends PUT or commit. Its evidence
 contains locale/media counts and status booleans only—never remote copy, image
-URLs, Google Group addresses, or tester identities. Dispatch only after the
-source has merged:
+URLs, Google Group addresses, or tester identities. A provider failure still
+uploads this sanitized evidence when available, then the workflow fails after
+credential cleanup; an artifact is not a successful audit verdict. Dispatch
+only after the source has merged:
 
 ```bash
 source_sha=$(git rev-parse origin/main)

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -758,8 +758,17 @@ for (const auditContract of [
   "test \"$(git rev-parse refs/remotes/origin/main)\" = \"$SOURCE_SHA\"",
   "npm run test:store-listing",
   "node scripts/store-state-audit.mjs",
+  "id: audit\n        continue-on-error: true",
+  "id: cleanup\n        if: always()\n        continue-on-error: true",
+  "steps.audit.outputs.evidence_present == 'true'",
+  "steps.audit.outcome",
+  "steps.cleanup.outcome",
+  "::add-mask::$ASC_KEY_ID",
   "Destroy ephemeral store credentials",
   "Upload sanitized store-state evidence",
+  "Enforce audit and cleanup verdict",
+  "ephemeral store credential cleanup did not succeed",
+  "one or more requested store provider audits failed",
 ]) {
   if (!storeAuditWorkflow.includes(auditContract))
     failures.push(`store audit workflow is missing: ${auditContract}`);
@@ -767,6 +776,21 @@ for (const auditContract of [
 for (const forbiddenAuditContract of ["edits:commit", "updateTesters", "betaTesters"])
   if (storeAuditWorkflow.includes(forbiddenAuditContract))
     failures.push(`store audit workflow has a forbidden contract: ${forbiddenAuditContract}`);
+if (storeAuditWorkflow.includes("    env:\n      ASC_KEY_ID: ${{ vars.ASC_KEY_ID }}"))
+  failures.push("store audit workflow must not expose ASC identifiers in every Play-only step");
+const storeAuditExecution = storeAuditWorkflow.indexOf("      - name: Audit canonical locales, media, and Play tester mode");
+const storeAuditCleanup = storeAuditWorkflow.indexOf("      - name: Destroy ephemeral store credentials");
+const storeAuditEvidence = storeAuditWorkflow.indexOf("      - name: Upload sanitized store-state evidence");
+const storeAuditVerdict = storeAuditWorkflow.indexOf("      - name: Enforce audit and cleanup verdict");
+if (
+  storeAuditExecution === -1 ||
+  storeAuditCleanup === -1 ||
+  storeAuditEvidence === -1 ||
+  storeAuditVerdict === -1 ||
+  storeAuditExecution > storeAuditCleanup ||
+  storeAuditCleanup > storeAuditEvidence ||
+  storeAuditEvidence > storeAuditVerdict
+) failures.push("store audit must execute, clean credentials, upload sanitized evidence, then enforce its verdict");
 for (const publishContract of [
   "name: ZUULI / Store listing publication gate",
   "environment: zuuli-app-stores",

--- a/wallet/zuuli/scripts/store-state-audit.mjs
+++ b/wallet/zuuli/scripts/store-state-audit.mjs
@@ -87,6 +87,38 @@ function fieldsMatch(actual, expected, mapping) {
   return Object.entries(mapping).every(([remoteKey, expectedKey]) => actual?.[remoteKey] === expected?.[expectedKey]);
 }
 
+export function parsePlayImages(payload) {
+  const prototype = payload && typeof payload === "object" ? Object.getPrototypeOf(payload) : undefined;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload) || prototype !== Object.prototype) fail("INVALID_RESPONSE", "Play images response is malformed");
+  if (Object.hasOwn(payload, "error") || Object.hasOwn(payload, "errors")) fail("INVALID_RESPONSE", "Play images response contains an error payload");
+  if (!Object.hasOwn(payload, "images")) {
+    if (Reflect.ownKeys(payload).length !== 0) fail("INVALID_RESPONSE", "Play images response omitted images alongside unknown members");
+    return [];
+  }
+  if (!Array.isArray(payload.images)) fail("INVALID_RESPONSE", "Play images response has a non-array images member");
+  return payload.images;
+}
+
+const SAFE_PROVIDER_FAILURE_MESSAGES = Object.freeze({
+  AMBIGUOUS_REMOTE_STATE: "provider returned ambiguous duplicate state",
+  API_ERROR: "provider API request failed",
+  IDENTITY_MISMATCH: "provider application identity did not match ZUULI",
+  INVALID_CREDENTIALS: "provider audit credential was invalid",
+  INVALID_REQUEST: "provider request escaped the fixed audit scope",
+  INVALID_RESPONSE: "provider API returned an invalid response",
+  INVALID_SOURCE: "canonical store source was invalid",
+  MISSING_CREDENTIALS: "provider audit credential was not configured",
+  NETWORK_ERROR: "provider request failed before receiving a response",
+  PAGINATION_LIMIT: "provider audit exceeded its page limit",
+  TRANSACTION_TIMEOUT: "provider audit exceeded its transaction deadline",
+});
+
+function sanitizedProviderFailure(provider, error) {
+  if (!(error instanceof StoreAuditError)) return { provider, code: "STORE_AUDIT_FAILED", message: "provider audit failed unexpectedly" };
+  const message = SAFE_PROVIDER_FAILURE_MESSAGES[error.code];
+  return message ? { provider, code: error.code, message } : { provider, code: "STORE_AUDIT_FAILED", message: "provider audit failed unexpectedly" };
+}
+
 export async function auditAppleStore({ credentials, expected, fetchImpl = globalThis.fetch, nowSeconds = () => Math.floor(Date.now() / 1000) }) {
   async function get(pathOrUrl) {
     const url = pathOrUrl instanceof URL ? pathOrUrl : new URL(pathOrUrl, ASC_ROOT);
@@ -266,10 +298,10 @@ export async function auditPlayStore({ credentials, expected, fetchImpl = global
     for (const locale of expectedLocales) {
       for (const imageType of imageTypes) {
         const payload = await request("GET", `${editBase}/listings/${encodeURIComponent(locale)}/${encodeURIComponent(imageType)}`);
-        if (!Array.isArray(payload?.images)) fail("INVALID_RESPONSE", "Play images response has no images array");
-        for (const image of payload.images) if (typeof image?.id !== "string") fail("INVALID_RESPONSE", "Play images response contains malformed media");
+        const images = parsePlayImages(payload);
+        for (const image of images) if (typeof image?.id !== "string") fail("INVALID_RESPONSE", "Play images response contains malformed media");
         const expectedDigest = brandDigestByType.get(imageType);
-        imageState.push({ locale, imageType, count: payload.images.length, contentMatched: expectedDigest === undefined ? null : payload.images.length === 1 && payload.images[0].sha256 === expectedDigest });
+        imageState.push({ locale, imageType, count: images.length, contentMatched: expectedDigest === undefined ? null : images.length === 1 && images[0].sha256 === expectedDigest });
       }
     }
     let testerMode = "publisher_api_unavailable";
@@ -328,28 +360,45 @@ export function parseAuditArgs(argv) {
   return result;
 }
 
-export async function main(argv = process.argv.slice(2), env = process.env) {
+export async function main(argv = process.argv.slice(2), env = process.env, dependencies = {}) {
+  const validate = dependencies.validate ?? validateStoreContract;
+  const read = dependencies.read ?? readFile;
+  const write = dependencies.write ?? writeFile;
+  const auditApple = dependencies.auditApple ?? auditAppleStore;
+  const auditPlay = dependencies.auditPlay ?? auditPlayStore;
   const args = parseAuditArgs(argv);
-  const expected = await validateStoreContract();
-  const evidence = { schemaVersion: 1, contractPhase: expected.phase, publicationReady: expected.publicationReady, sourceIdentity: { ...expected.application, release: expected.release }, providers: [] };
+  const expected = await validate();
+  const evidence = { schemaVersion: 1, contractPhase: expected.phase, publicationReady: expected.publicationReady, sourceIdentity: { ...expected.application, release: expected.release }, providers: [], providerFailures: [] };
   if (args.provider === "apple" || args.provider === "both") {
-    if (!env.ASC_KEY_PATH || !env.ASC_KEY_ID || !env.ASC_ISSUER_ID) fail("MISSING_CREDENTIALS", "ASC audit credential is not configured");
-    evidence.providers.push(await auditAppleStore({ credentials: { keyId: env.ASC_KEY_ID, issuerId: env.ASC_ISSUER_ID, privateKey: await readFile(env.ASC_KEY_PATH, "utf8") }, expected }));
+    try {
+      if (!env.ASC_KEY_PATH || !env.ASC_KEY_ID || !env.ASC_ISSUER_ID) fail("MISSING_CREDENTIALS", "ASC audit credential is not configured");
+      evidence.providers.push(await auditApple({ credentials: { keyId: env.ASC_KEY_ID, issuerId: env.ASC_ISSUER_ID, privateKey: await read(env.ASC_KEY_PATH, "utf8") }, expected }));
+    } catch (error) {
+      evidence.providerFailures.push(sanitizedProviderFailure("apple", error));
+    }
   }
   if (args.provider === "play" || args.provider === "both") {
-    if (!env.PLAY_SERVICE_ACCOUNT_JSON) fail("MISSING_CREDENTIALS", "Play audit credential is not configured");
-    let credentials;
-    try { credentials = JSON.parse(await readFile(env.PLAY_SERVICE_ACCOUNT_JSON, "utf8")); } catch { fail("INVALID_CREDENTIALS", "Play credential document is invalid JSON"); }
-    evidence.providers.push(await auditPlayStore({ credentials, expected }));
+    try {
+      if (!env.PLAY_SERVICE_ACCOUNT_JSON) fail("MISSING_CREDENTIALS", "Play audit credential is not configured");
+      let credentials;
+      try { credentials = JSON.parse(await read(env.PLAY_SERVICE_ACCOUNT_JSON, "utf8")); } catch { fail("INVALID_CREDENTIALS", "Play credential document is invalid JSON"); }
+      evidence.providers.push(await auditPlay({ credentials, expected }));
+    } catch (error) {
+      evidence.providerFailures.push(sanitizedProviderFailure("play", error));
+    }
   }
   const outputPath = resolve(args.output);
-  await writeFile(outputPath, `${JSON.stringify(evidence, null, 2)}\n`, { mode: 0o600 });
-  process.stdout.write(`${JSON.stringify({ auditedProviders: evidence.providers.map(({ provider }) => provider), complete: evidence.providers.every(({ complete }) => complete) })}\n`);
+  await write(outputPath, `${JSON.stringify(evidence, null, 2)}\n`, { mode: 0o600 });
+  process.stdout.write(`${JSON.stringify({ auditedProviders: evidence.providers.map(({ provider }) => provider), failedProviders: evidence.providerFailures.map(({ provider }) => provider), complete: evidence.providerFailures.length === 0 && evidence.providers.every(({ complete }) => complete) })}\n`);
+  if (evidence.providerFailures.length > 0) {
+    const summary = evidence.providerFailures.map(({ provider, code, message }) => `${provider} ${code}: ${message}`).join("; ");
+    fail("PROVIDER_AUDIT_FAILED", `${summary}; sanitized evidence written`);
+  }
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   main().catch((error) => {
-    process.stderr.write(`${error instanceof StoreAuditError ? error.code : "STORE_AUDIT_FAILED"}: ${error.message}\n`);
+    process.stderr.write(error instanceof StoreAuditError ? `${error.code}: ${error.message}\n` : "STORE_AUDIT_FAILED: store audit failed unexpectedly\n");
     process.exitCode = 1;
   });
 }

--- a/wallet/zuuli/scripts/store-state-audit.node-test.mjs
+++ b/wallet/zuuli/scripts/store-state-audit.node-test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { generateKeyPairSync } from "node:crypto";
 import test from "node:test";
-import { auditAppleStore, auditPlayStore, StoreAuditError } from "./store-state-audit.mjs";
+import { auditAppleStore, auditPlayStore, main, parsePlayImages, StoreAuditError } from "./store-state-audit.mjs";
 
 const expected = {
   release: { version: "0.1.0", build: 10 },
@@ -98,7 +98,7 @@ test("Apple audit rejects duplicate locale/display-type screenshot sets", async 
   await assert.rejects(() => auditAppleStore({ credentials: appleCredentials, expected, fetchImpl, nowSeconds: () => 1_800_000_000 }), (error) => error instanceof StoreAuditError && error.code === "AMBIGUOUS_REMOTE_STATE");
 });
 
-function playMock({ groups = [], invalidListings = false, editId = "audit-edit", listingFailures = 0, deleteFailures = 0, testerStatus = 200, listingTitle = "ZUULI", releaseNotes = "release notes", missingBrandType, duplicateBrandType } = {}) {
+function playMock({ groups = [], invalidListings = false, editId = "audit-edit", listingFailures = 0, deleteFailures = 0, testerStatus = 200, listingTitle = "ZUULI", releaseNotes = "release notes", missingBrandType, duplicateBrandType, imagePayload } = {}) {
   const calls = [];
   let remainingListingFailures = listingFailures;
   let remainingDeleteFailures = deleteFailures;
@@ -121,6 +121,7 @@ function playMock({ groups = [], invalidListings = false, editId = "audit-edit",
       if (url.pathname.endsWith("/tracks/internal")) return json({ track: "internal", releases: [{ versionCodes: ["10"], releaseNotes: [{ language: "en-US", text: releaseNotes }] }] });
       if (url.pathname.endsWith("/testers/internal")) return testerStatus === 200 ? json({ googleGroups: groups }) : json({ error: { status: "PERMISSION_DENIED" } }, testerStatus);
       if (url.pathname.includes("/listings/en-US/")) {
+        if (imagePayload !== undefined) return json(imagePayload);
         const imageType = url.pathname.split("/").at(-1);
         const count = imageType === missingBrandType ? 0 : imageType === duplicateBrandType ? 2 : new Set(["phoneScreenshots", "sevenInchScreenshots", "tenInchScreenshots"]).has(imageType) ? 4 : 1;
         return json({ images: Array.from({ length: count }, (_, index) => ({ id: `${imageType}-${index}`, sha256: "a".repeat(64) })) });
@@ -176,6 +177,34 @@ test("Play completeness requires hash-matched icon and feature media", async () 
   assert.equal(feature.count, 0);
   assert.equal(feature.contentMatched, false);
   assert.equal(evidence.complete, false);
+});
+
+test("Play treats the live empty image-list object as exactly zero images", async () => {
+  const mock = playMock({ imagePayload: {} });
+  const evidence = await auditPlayStore({ credentials: playCredentials, expected, fetchImpl: mock.fetch, nowSeconds: () => 1_800_000_000 });
+  assert.equal(evidence.imageState.length, 5);
+  assert.equal(evidence.imageState.every(({ count }) => count === 0), true);
+  assert.equal(evidence.imageState.find(({ imageType }) => imageType === "icon").contentMatched, false);
+  assert.equal(evidence.complete, false);
+  assert.equal(mock.calls.at(-1).method, "DELETE");
+});
+
+test("Play accepts only an exact plain empty object when images is absent", () => {
+  assert.deepEqual(parsePlayImages({}), []);
+  for (const payload of [{ foo: "bar" }, Object.create(null), new Date("2026-08-19T00:00:00Z")]) {
+    assert.throws(() => parsePlayImages(payload), (error) => error instanceof StoreAuditError && error.code === "INVALID_RESPONSE");
+  }
+});
+
+test("Play rejects malformed, explicit-null, non-array, and error image payloads", async () => {
+  for (const imagePayload of [null, [], "", { foo: "bar" }, { images: null }, { images: {} }, { error: { status: "FAILED_PRECONDITION" } }, { errors: [{ code: "FAILED_PRECONDITION" }] }]) {
+    const mock = playMock({ imagePayload });
+    await assert.rejects(
+      () => auditPlayStore({ credentials: playCredentials, expected, fetchImpl: mock.fetch, nowSeconds: () => 1_800_000_000 }),
+      (error) => error instanceof StoreAuditError && error.code === "INVALID_RESPONSE",
+    );
+    assert.equal(mock.calls.at(-1).method, "DELETE");
+  }
 });
 
 test("Play singleton brand media rejects duplicate remote assets", async () => {
@@ -239,4 +268,66 @@ test("Play cleanup reports when the single transaction deadline is exhausted", a
   );
   assert.equal(calls.filter(({ method, pathname }) => method === "POST" && pathname.endsWith("/edits")).length, 1);
   assert.equal(calls.some(({ method }) => method === "DELETE"), false);
+});
+
+test("combined audit writes sanitized successful-provider and failure evidence before rejecting", async () => {
+  let written;
+  await assert.rejects(
+    () => main(
+      ["--provider=both", "--output=store-state.json"],
+      { ASC_KEY_PATH: "apple-key", ASC_KEY_ID: "ABCDEFGHIJ", ASC_ISSUER_ID: "11111111-2222-3333-4444-555555555555", PLAY_SERVICE_ACCOUNT_JSON: "play-key" },
+      {
+        validate: async () => ({ ...expected, phase: "foundation", publicationReady: false }),
+        read: async (path) => path === "play-key" ? JSON.stringify(playCredentials) : appleCredentials.privateKey,
+        write: async (_path, contents, options) => { written = { contents, options }; },
+        auditApple: async () => ({ provider: "apple", readOnly: true, complete: false }),
+        auditPlay: async () => { throw new StoreAuditError("INVALID_RESPONSE", "Play images response has a non-array images member"); },
+      },
+    ),
+    (error) => error instanceof StoreAuditError && error.code === "PROVIDER_AUDIT_FAILED" && error.message.includes("play INVALID_RESPONSE"),
+  );
+  assert.equal(written.options.mode, 0o600);
+  const evidence = JSON.parse(written.contents);
+  assert.deepEqual(evidence.providers, [{ provider: "apple", readOnly: true, complete: false }]);
+  assert.deepEqual(evidence.providerFailures, [{ provider: "play", code: "INVALID_RESPONSE", message: "provider API returned an invalid response" }]);
+});
+
+test("provider failures never copy hostile remote strings into evidence or the verdict", async () => {
+  const marker = "attacker+locale@example.invalid Bearer hostile-token locale-SECRET";
+  let written;
+  await assert.rejects(
+    () => main(
+      ["--provider=play", "--output=store-state.json"],
+      { PLAY_SERVICE_ACCOUNT_JSON: "play-key" },
+      {
+        validate: async () => ({ ...expected, phase: "foundation", publicationReady: false }),
+        read: async () => JSON.stringify(playCredentials),
+        write: async (_path, contents) => { written = contents; },
+        auditPlay: async () => { throw new StoreAuditError("INVALID_RESPONSE", `duplicate remote locale ${marker}`); },
+      },
+    ),
+    (error) => error instanceof StoreAuditError && error.code === "PROVIDER_AUDIT_FAILED" && !error.message.includes(marker),
+  );
+  assert.equal(written.includes(marker), false);
+  assert.deepEqual(JSON.parse(written).providerFailures, [{ provider: "play", code: "INVALID_RESPONSE", message: "provider API returned an invalid response" }]);
+});
+
+test("unexpected provider failures remain generic", async () => {
+  const marker = "private credential marker";
+  let written;
+  await assert.rejects(
+    () => main(
+      ["--provider=play", "--output=store-state.json"],
+      { PLAY_SERVICE_ACCOUNT_JSON: "play-key" },
+      {
+        validate: async () => ({ ...expected, phase: "foundation", publicationReady: false }),
+        read: async () => JSON.stringify(playCredentials),
+        write: async (_path, contents) => { written = contents; },
+        auditPlay: async () => { throw new Error(marker); },
+      },
+    ),
+    (error) => error instanceof StoreAuditError && error.code === "PROVIDER_AUDIT_FAILED" && !error.message.includes(marker),
+  );
+  assert.equal(written.includes(marker), false);
+  assert.deepEqual(JSON.parse(written).providerFailures, [{ provider: "play", code: "STORE_AUDIT_FAILED", message: "provider audit failed unexpectedly" }]);
 });


### PR DESCRIPTION
## Summary

- accept Google Play `edits.images.list` live empty response `{}` as exactly zero images while rejecting null, non-array, malformed, and error payloads
- retain sanitized successful-provider and provider-failure evidence when a combined protected audit fails, then preserve a nonzero workflow verdict
- keep temporary-edit cleanup and ephemeral-credential cleanup outcomes explicit and ordered before evidence upload/final verdict
- remove ASC identifiers from Play-only step environments and mask them immediately when Apple credentials are selected
- document that a failure artifact is evidence, not a successful audit verdict

## Live evidence

- Combined protected audit [32264471568](https://github.com/free2z/zuu/actions/runs/32264471568) failed on the empty Play image response; credential cleanup succeeded; no artifact or store mutation.
- Apple-only protected audit [32264572536](https://github.com/free2z/zuu/actions/runs/32264572536), artifact `9369645452`, completed read-only with `complete: false` and no listing-publication inference.
- Google documents that `edits.images.list` may return an empty response: https://developers.google.com/android-publisher/api-ref/rest/v3/edits.images/list

## Verification

- `npm ci`
- `npm run test:store-listing` (31/31)
- `npm run release:verify`
- `npm run store:validate`
- `node scripts/verify-ci-cache-policy.mjs`
- `npm run typecheck`
- `npm run build`
- `npm test` (258 Vitest, 7 auth/safe-area contract, 33 Playwright)
- `actionlint .github/workflows/zuuli-store-audit.yml`
- `npm audit --audit-level=high` (no high/critical findings; existing moderate findings only)
- `gitleaks git --log-opts="origin/main..HEAD"`
- `git diff --check`

## Adversarial review

The audit still performs only OAuth, one Play edit insertion, bounded GET reads, and bounded best-effort DELETE. It contains no PUT, PATCH, edit commit, listing write, or tester mutation. An audit failure and credential-cleanup failure are independently reported; artifact upload cannot turn either into success. Unexpected errors are reduced to a generic sanitized provider failure and cannot copy their message into evidence.

Closes #419. Part of #387.