### PR TITLE
fix(zuuli): distinguish loading errors from empty states

### DIFF
--- a/wallet/zuuli/src/components/common/SectionLoadError.test.tsx
+++ b/wallet/zuuli/src/components/common/SectionLoadError.test.tsx
@@ -1,0 +1,39 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { SectionLoadError } from "./SectionLoadError";
+
+describe("SectionLoadError", () => {
+  it("renders an actionable initial failure instead of empty-state copy", () => {
+    const markup = renderToStaticMarkup(
+      <SectionLoadError
+        title="Couldn't load transactions"
+        description="Transaction history is temporarily unavailable."
+        retry={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("Couldn&#x27;t load transactions");
+    expect(markup).toContain("Retry");
+    expect(markup).toContain("min-tap");
+    expect(markup).toContain("break-words");
+    expect(markup).not.toContain("No transactions");
+  });
+
+  it("announces retained data as stale and disables duplicate retries", () => {
+    const markup = renderToStaticMarkup(
+      <SectionLoadError
+        title="Couldn't refresh transactions"
+        description="Showing the last confirmed history."
+        retry={vi.fn()}
+        retrying
+        stale
+      />,
+    );
+
+    expect(markup).toContain('role="status"');
+    expect(markup).toContain("Showing the last confirmed history.");
+    expect(markup).toContain("Retrying");
+    expect(markup).toContain("disabled");
+  });
+});

--- a/wallet/zuuli/src/components/common/SectionLoadError.tsx
+++ b/wallet/zuuli/src/components/common/SectionLoadError.tsx
@@ -1,0 +1,56 @@
+import { RefreshCw, TriangleAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/** A retryable section failure that never masquerades as successful emptiness. */
+export function SectionLoadError({
+  title,
+  description,
+  retry,
+  retrying = false,
+  stale = false,
+  className,
+}: {
+  title: string;
+  description: string;
+  retry: () => void;
+  retrying?: boolean;
+  stale?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      role={stale ? "status" : "alert"}
+      className={cn(
+        "flex min-w-0 flex-col gap-3 rounded-xl border border-amber-500/35 bg-amber-500/10 p-4 sm:flex-row sm:items-center sm:justify-between",
+        !stale && "py-6",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        <TriangleAlert
+          className="mt-0.5 h-5 w-5 shrink-0 text-amber-400"
+          aria-hidden
+        />
+        <div className="min-w-0 break-words">
+          <p className="font-medium">{title}</p>
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="shrink-0"
+        disabled={retrying}
+        onClick={retry}
+      >
+        <RefreshCw
+          className={cn("h-4 w-4", retrying && "animate-spin")}
+          aria-hidden
+        />
+        {retrying ? "Retrying" : "Retry"}
+      </Button>
+    </div>
+  );
+}

--- a/wallet/zuuli/src/features/articles/pages/Reader.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Reader.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { ArrowLeft, Clock, Newspaper } from "lucide-react";
 import {
@@ -11,48 +10,55 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
 import { Markdown } from "@/components/common/Markdown";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
+import { useAsync } from "@/hooks/useAsync";
 import { articles } from "@/lib/api/free2z";
 import { initials } from "@/lib/format";
+import {
+  currentResourceData,
+  isConfirmedNotFound,
+  type KeyedRemoteData,
+} from "@/lib/remote-data";
 import type { Article } from "@/lib/api/types";
 import { TipDialog } from "../components/TipDialog";
 import { CommentsSection } from "../components/Comments";
 import { ArticleScore } from "../components/ArticleScore";
 import { coverGradient, formatPublished } from "../lib";
 
-type Status = "loading" | "ready" | "missing";
-
 export function Reader() {
   const { slug } = useParams<{ slug: string }>();
-  const [article, setArticle] = useState<Article | null>(null);
-  const [status, setStatus] = useState<Status>("loading");
+  const key = slug ?? "";
+  const { data, loading, error, reload } = useAsync<
+    KeyedRemoteData<string, Article>
+  >(
+    async () => {
+      if (!slug) throw new Error("The article link is missing a slug.");
+      return { key: slug, value: await articles.get(slug) };
+    },
+    [slug],
+  );
+  const article = currentResourceData(data, key);
 
-  useEffect(() => {
-    if (!slug) {
-      setStatus("missing");
-      return;
-    }
-    let alive = true;
-    setStatus("loading");
-    articles
-      .get(slug)
-      .then((a) => {
-        if (!alive) return;
-        setArticle(a);
-        setStatus("ready");
-      })
-      .catch(() => {
-        if (alive) setStatus("missing");
-      });
-    return () => {
-      alive = false;
-    };
-  }, [slug]);
-
-  if (status === "loading") {
+  if (loading && article === null && !error) {
     return <ReaderSkeleton />;
   }
 
-  if (status === "missing" || !article) {
+  if (error && article === null) {
+    if (!isConfirmedNotFound(error)) {
+      return (
+        <div className="animate-slide-up">
+          <BackLink />
+          <SectionLoadError
+            className="mt-6"
+            title="Couldn't load this article"
+            description="The article may still be available. Check your connection and try again."
+            retry={reload}
+            retrying={loading}
+          />
+        </div>
+      );
+    }
+
     return (
       <div className="animate-slide-up">
         <BackLink />
@@ -71,6 +77,21 @@ export function Reader() {
     );
   }
 
+  if (!article) {
+    return (
+      <div className="animate-slide-up">
+        <BackLink />
+        <SectionLoadError
+          className="mt-6"
+          title="Couldn't load this article"
+          description="The server returned no article. Try again."
+          retry={reload}
+          retrying={loading}
+        />
+      </div>
+    );
+  }
+
   const author = article.author;
   const name = author.display_name || author.username;
 
@@ -78,6 +99,17 @@ export function Reader() {
     <article className="app-reader-content animate-slide-up w-full min-w-0 overflow-x-clip">
       <div className="mx-auto w-full min-w-0 max-w-3xl">
         <BackLink />
+
+        {error ? (
+          <SectionLoadError
+            className="mt-6"
+            title="Couldn't refresh this article"
+            description="Showing the last version loaded on this device."
+            retry={reload}
+            retrying={loading}
+            stale
+          />
+        ) : null}
 
         <header className="mt-6 min-w-0 space-y-4">
           {article.category ? <Badge>{article.category}</Badge> : null}

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -44,6 +44,7 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
 import { Markdown } from "@/components/common/Markdown";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { discover, live, tuzi } from "@/lib/api/free2z";
 import {
   formatTuzis,
@@ -55,6 +56,11 @@ import {
 } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { parseBioFrontmatter, type SocialLink } from "@/lib/utils/bio";
+import {
+  currentResourceData,
+  isConfirmedNotFound,
+  type KeyedRemoteData,
+} from "@/lib/remote-data";
 import { useAsync } from "@/hooks/useAsync";
 import { useSession } from "@/store/session";
 import type { Article, CreatorDetail, Subscription } from "@/lib/api/types";
@@ -85,14 +91,35 @@ function bannerGradient(seed: string): string {
 
 export default function CreatorFeature() {
   const { username = "" } = useParams<{ username: string }>();
-  const { data, loading, error } = useAsync<CreatorDetail>(
-    () => discover.creator(username),
+  const { data, loading, error, reload } = useAsync<
+    KeyedRemoteData<string, CreatorDetail>
+  >(
+    async () => ({
+      key: username,
+      value: await discover.creator(username),
+    }),
     [username],
   );
+  const creator = currentResourceData(data, username);
 
-  if (loading) return <CreatorSkeleton />;
+  if (loading && creator === null && !error) return <CreatorSkeleton />;
 
-  if (error || !data) {
+  if (error && creator === null) {
+    if (!isConfirmedNotFound(error)) {
+      return (
+        <div className="animate-slide-up">
+          <BackLink />
+          <SectionLoadError
+            className="mt-6"
+            title="Couldn't load this creator"
+            description="The profile may still be available. Check your connection and try again."
+            retry={reload}
+            retrying={loading}
+          />
+        </div>
+      );
+    }
+
     return (
       <div className="animate-slide-up">
         <BackLink />
@@ -111,15 +138,56 @@ export default function CreatorFeature() {
     );
   }
 
-  return <CreatorProfile creator={data} />;
+  if (!creator) {
+    return (
+      <div className="animate-slide-up">
+        <BackLink />
+        <SectionLoadError
+          className="mt-6"
+          title="Couldn't load this creator"
+          description="The server returned no profile. Try again."
+          retry={reload}
+          retrying={loading}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <CreatorProfile
+      creator={creator}
+      refreshError={error}
+      refresh={reload}
+      refreshing={loading}
+    />
+  );
 }
 
-function CreatorProfile({ creator }: { creator: CreatorDetail }) {
+function CreatorProfile({
+  creator,
+  refreshError,
+  refresh,
+  refreshing,
+}: {
+  creator: CreatorDetail;
+  refreshError: unknown | null;
+  refresh: () => void;
+  refreshing: boolean;
+}) {
   const name = creator.display_name || creator.username;
-  const { data: pages, loading: pagesLoading } = useAsync<Article[]>(
-    () => discover.creatorPages(creator.username),
+  const {
+    data: pagesData,
+    loading: pagesLoading,
+    error: pagesError,
+    reload: reloadPages,
+  } = useAsync<KeyedRemoteData<string, Article[]>>(
+    async () => ({
+      key: creator.username,
+      value: await discover.creatorPages(creator.username),
+    }),
     [creator.username],
   );
+  const pages = currentResourceData(pagesData, creator.username);
   const { body: bio, socials } = useMemo(
     () => parseBioFrontmatter(creator.bio),
     [creator.bio],
@@ -133,6 +201,17 @@ function CreatorProfile({ creator }: { creator: CreatorDetail }) {
   return (
     <div className="animate-slide-up pb-6">
       <BackLink />
+
+      {refreshError ? (
+        <SectionLoadError
+          className="mt-4"
+          title="Couldn't refresh this profile"
+          description="Showing the last version loaded on this device."
+          retry={refresh}
+          retrying={refreshing}
+          stale
+        />
+      ) : null}
 
       {/* Banner */}
       <div
@@ -255,25 +334,43 @@ function CreatorProfile({ creator }: { creator: CreatorDetail }) {
         <h2 className="mb-4 text-lg font-semibold tracking-tight">
           Pages by {name}
         </h2>
-        {pagesLoading ? (
+        {pagesError ? (
+          <SectionLoadError
+            className="mb-4"
+            title={
+              pages === null
+                ? "Couldn't load this creator's pages"
+                : "Couldn't refresh this creator's pages"
+            }
+            description={
+              pages === null
+                ? "The published pages are temporarily unavailable."
+                : "Showing the last pages loaded on this device."
+            }
+            retry={reloadPages}
+            retrying={pagesLoading}
+            stale={pages !== null}
+          />
+        ) : null}
+        {pagesLoading && pages === null ? (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 3 }).map((_, i) => (
               <PageCardSkeleton key={i} />
             ))}
           </div>
-        ) : !pages || pages.length === 0 ? (
+        ) : pagesError && pages === null ? null : pages?.length === 0 ? (
           <EmptyState
             icon={FileText}
             title="No pages yet"
             description={`${name} hasn't published any pages yet.`}
           />
-        ) : (
+        ) : pages ? (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {pages.map((p) => (
               <PageCard key={String(p.id)} article={p} />
             ))}
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/wallet/zuuli/src/features/home/ArticlesGrid.tsx
+++ b/wallet/zuuli/src/features/home/ArticlesGrid.tsx
@@ -3,6 +3,7 @@ import { BookOpen, Clock, ChevronUp } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { initials, timeAgo } from "@/lib/format";
 import { articles } from "@/lib/api/free2z";
 import { useAsync } from "@/hooks/useAsync";
@@ -88,11 +89,12 @@ function ArticleSkeleton() {
 
 export function ArticlesGrid() {
   // Fresh (recency-decayed) — just the first few for the home rail.
-  const { data, loading } = useAsync(
+  const { data, loading, error, reload } = useAsync(
     () => articles.feed({ sort: "popular", pageSize: 3 }),
     [],
   );
   const top = (data?.items ?? []).slice(0, 3);
+  const initialLoading = loading && data === null;
 
   return (
     <div>
@@ -102,13 +104,29 @@ export function ArticlesGrid() {
         subtitle="Long-form writing from the community"
         to="/articles"
       />
-      {loading ? (
+      {error ? (
+        <SectionLoadError
+          className="mb-4"
+          title={
+            data ? "Articles may be out of date" : "Couldn't load articles"
+          }
+          description={
+            data
+              ? "Showing the last confirmed articles. Retry for the latest writing."
+              : "We couldn't reach the article feed."
+          }
+          retry={reload}
+          retrying={loading}
+          stale={data !== null}
+        />
+      ) : null}
+      {initialLoading ? (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (
             <ArticleSkeleton key={i} />
           ))}
         </div>
-      ) : top.length === 0 ? (
+      ) : data === null ? null : top.length === 0 ? (
         <EmptyState
           icon={BookOpen}
           title="No articles yet"

--- a/wallet/zuuli/src/features/home/CreatorsRow.tsx
+++ b/wallet/zuuli/src/features/home/CreatorsRow.tsx
@@ -3,6 +3,7 @@ import { Users, BadgeCheck, ArrowUpRight } from "lucide-react";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { initials } from "@/lib/format";
 import { discover } from "@/lib/api/free2z";
 import { parseBioFrontmatter } from "@/lib/utils/bio";
@@ -71,8 +72,12 @@ function CreatorSkeleton() {
 }
 
 export function CreatorsRow() {
-  const { data, loading } = useAsync(() => discover.creators(), []);
+  const { data, loading, error, reload } = useAsync(
+    () => discover.creators(),
+    [],
+  );
   const creators = data ?? [];
+  const initialLoading = loading && data === null;
 
   return (
     <div>
@@ -81,13 +86,31 @@ export function CreatorsRow() {
         title="Creators to watch"
         subtitle="Voices worth following on ZUULI"
       />
-      {loading ? (
+      {error ? (
+        <SectionLoadError
+          className="mb-4"
+          title={
+            data
+              ? "Creator suggestions may be out of date"
+              : "Couldn't load creators"
+          }
+          description={
+            data
+              ? "Showing the last confirmed suggestions. Retry to refresh them."
+              : "We couldn't reach creator discovery."
+          }
+          retry={reload}
+          retrying={loading}
+          stale={data !== null}
+        />
+      ) : null}
+      {initialLoading ? (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
           {Array.from({ length: 4 }).map((_, i) => (
             <CreatorSkeleton key={i} />
           ))}
         </div>
-      ) : creators.length === 0 ? (
+      ) : data === null ? null : creators.length === 0 ? (
         <EmptyState
           icon={Users}
           title="No creators to show"

--- a/wallet/zuuli/src/features/home/LiveRail.tsx
+++ b/wallet/zuuli/src/features/home/LiveRail.tsx
@@ -3,6 +3,7 @@ import { Radio, Users, RadioTower } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { formatTuzis } from "@/lib/format";
 import { live } from "@/lib/api/free2z";
 import { useAsync } from "@/hooks/useAsync";
@@ -93,8 +94,12 @@ function StreamSkeleton() {
 }
 
 export function LiveRail() {
-  const { data, loading } = useAsync(() => live.listPublic(), []);
+  const { data, loading, error, reload } = useAsync(
+    () => live.listPublic(),
+    [],
+  );
   const streams = (data ?? []).filter((s) => s.live === true);
+  const initialLoading = loading && data === null;
 
   return (
     <div>
@@ -105,13 +110,29 @@ export function LiveRail() {
         to="/live"
         accent="text-[#fb7185]"
       />
-      {loading ? (
+      {error ? (
+        <SectionLoadError
+          className="mb-4"
+          title={
+            data ? "Live status may be out of date" : "Couldn't load live status"
+          }
+          description={
+            data
+              ? "Showing the last confirmed streams. Retry to check who is live now."
+              : "We couldn't confirm whether anyone is live."
+          }
+          retry={reload}
+          retrying={loading}
+          stale={data !== null}
+        />
+      ) : null}
+      {initialLoading ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (
             <StreamSkeleton key={i} />
           ))}
         </div>
-      ) : streams.length === 0 ? (
+      ) : data === null ? null : streams.length === 0 ? (
         <EmptyState
           icon={Radio}
           title="No one is live right now"

--- a/wallet/zuuli/src/features/live/Discovery.tsx
+++ b/wallet/zuuli/src/features/live/Discovery.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Radio } from "lucide-react";
 import { PageHeader } from "@/components/common/PageHeader";
 import { EmptyState } from "@/components/common/EmptyState";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { live } from "@/lib/api/free2z";
 import { useAsync } from "@/hooks/useAsync";
@@ -19,7 +20,10 @@ const FILTERS: { value: Filter; label: string }[] = [
 ];
 
 export function Discovery() {
-  const { data, loading, reload } = useAsync(() => live.listPublic(), []);
+  const { data, loading, error, reload } = useAsync(
+    () => live.listPublic(),
+    [],
+  );
   const [filter, setFilter] = useState<Filter>("all");
 
   // Refresh the listing periodically, but never while the tab is hidden (no
@@ -52,15 +56,18 @@ export function Discovery() {
   }, [data, filter]);
 
   const liveCount = (data ?? []).filter((s) => s.live).length;
+  const initialLoading = loading && data === null;
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Livestreams"
         description={
-          loading
+          initialLoading
             ? "Loading the room…"
-            : liveCount > 0
+            : error && data === null
+              ? "Live status is temporarily unavailable."
+              : liveCount > 0
               ? `${liveCount} creator${liveCount === 1 ? "" : "s"} live right now.`
               : "No one is live yet — be the first to go on air."
         }
@@ -77,13 +84,29 @@ export function Discovery() {
         </TabsList>
       </Tabs>
 
-      {loading ? (
+      {error ? (
+        <SectionLoadError
+          title={
+            data ? "Live status may be out of date" : "Couldn't load livestreams"
+          }
+          description={
+            data
+              ? "Showing the last confirmed listing. Retry to refresh live status."
+              : "We couldn't confirm which creators are live."
+          }
+          retry={reload}
+          retrying={loading}
+          stale={data !== null}
+        />
+      ) : null}
+
+      {initialLoading ? (
         <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {Array.from({ length: 8 }).map((_, i) => (
             <StreamCardSkeleton key={i} />
           ))}
         </div>
-      ) : streams.length === 0 ? (
+      ) : data === null ? null : streams.length === 0 ? (
         <EmptyState
           icon={Radio}
           title="Nothing here yet"

--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -34,6 +34,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { EmptyState } from "@/components/common/EmptyState";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { auth, live, tuzi } from "@/lib/api/free2z";
 import { ApiError } from "@/lib/api/http";
 import { useAsync } from "@/hooks/useAsync";
@@ -72,7 +73,7 @@ export function Room() {
   // fetch entirely — keeping the heavy request off the "Go live" entrance frame
   // so the transition stays smooth. Only a cold visitor (deep link) needs the
   // listing to resolve which stream this is.
-  const { data, loading } = useAsync(
+  const { data, loading, error, reload } = useAsync(
     () => (justStarted ? Promise.resolve<Livestream[]>([]) : live.listPublic()),
     [justStarted],
   );
@@ -110,8 +111,22 @@ export function Room() {
     justStarted?.ticket ?? null,
   );
 
-  if (loading && !stream) {
+  if (loading && !stream && !error) {
     return <RoomSkeleton />;
+  }
+
+  if (error && !stream) {
+    return (
+      <div className="space-y-6">
+        <BackLink />
+        <SectionLoadError
+          title="Couldn't load this stream"
+          description="The stream may still be available. Check your connection and try again."
+          retry={reload}
+          retrying={loading}
+        />
+      </div>
+    );
   }
 
   if (!stream) {
@@ -120,8 +135,8 @@ export function Room() {
         <BackLink />
         <EmptyState
           icon={Radio}
-          title="Stream not found"
-          description={`We couldn't find a stream for @${username}. It may have ended.`}
+          title="Stream unavailable"
+          description={`There is no active public stream listed for @${username}. It may have ended.`}
           action={
             <Button asChild variant="outline">
               <Link to="/live">Browse livestreams</Link>
@@ -139,6 +154,16 @@ export function Room() {
   return (
     <div className="space-y-6 animate-slide-up">
       <BackLink />
+
+      {error ? (
+        <SectionLoadError
+          title="Couldn't refresh this stream"
+          description="Showing the last confirmed stream details."
+          retry={reload}
+          retrying={loading}
+          stale
+        />
+      ) : null}
 
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         <div className="space-y-4">

--- a/wallet/zuuli/src/features/search/index.tsx
+++ b/wallet/zuuli/src/features/search/index.tsx
@@ -21,8 +21,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/common/EmptyState";
 import { PageHeader } from "@/components/common/PageHeader";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
+import { useAsync } from "@/hooks/useAsync";
 import { discover } from "@/lib/api/free2z";
 import { formatTuzis, initials, timeAgo } from "@/lib/format";
+import {
+  currentResourceData,
+  type KeyedRemoteData,
+} from "@/lib/remote-data";
 import type { Article, SimpleCreator } from "@/lib/api/types";
 
 const DEBOUNCE_MS = 300;
@@ -42,10 +48,33 @@ export default function SearchFeature() {
   const [query, setQuery] = useState(initial);
   const debounced = useDebounced(query, DEBOUNCE_MS);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  const [creators, setCreators] = useState<SimpleCreator[] | null>(null);
-  const [pages, setPages] = useState<Article[] | null>(null);
-  const [error, setError] = useState(false);
+  const searchKey = debounced.trim();
+  const {
+    data: creatorData,
+    loading: creatorsLoading,
+    error: creatorsError,
+    reload: reloadCreators,
+  } = useAsync<KeyedRemoteData<string, SimpleCreator[]>>(
+    async () => ({
+      key: searchKey,
+      value: searchKey ? await discover.searchCreators(searchKey) : [],
+    }),
+    [searchKey],
+  );
+  const {
+    data: pageData,
+    loading: pagesLoading,
+    error: pagesError,
+    reload: reloadPages,
+  } = useAsync<KeyedRemoteData<string, Article[]>>(
+    async () => ({
+      key: searchKey,
+      value: searchKey ? await discover.searchPages(searchKey) : [],
+    }),
+    [searchKey],
+  );
+  const creators = currentResourceData(creatorData, searchKey);
+  const pages = currentResourceData(pageData, searchKey);
 
   // Focus the box on mount for a keyboard-first feel.
   useEffect(() => {
@@ -59,43 +88,16 @@ export default function SearchFeature() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debounced]);
 
-  // Fetch both corpora in parallel whenever the debounced query changes.
-  useEffect(() => {
-    const q = debounced.trim();
-    if (!q) {
-      setCreators(null);
-      setPages(null);
-      setError(false);
-      return;
-    }
-    let alive = true;
-    setCreators(null);
-    setPages(null);
-    setError(false);
-    Promise.allSettled([
-      discover.searchCreators(q),
-      discover.searchPages(q),
-    ]).then(([c, p]) => {
-      if (!alive) return;
-      if (c.status === "fulfilled") setCreators(c.value);
-      else setCreators([]);
-      if (p.status === "fulfilled") setPages(p.value);
-      else setPages([]);
-      if (c.status === "rejected" && p.status === "rejected") setError(true);
-    });
-    return () => {
-      alive = false;
-    };
-  }, [debounced]);
-
-  const hasQuery = debounced.trim().length > 0;
-  const loading = hasQuery && (creators === null || pages === null);
+  const hasQuery = searchKey.length > 0;
   const creatorCount = creators?.length ?? 0;
   const pageCount = pages?.length ?? 0;
 
   const defaultTab = useMemo(
-    () => (creatorCount === 0 && pageCount > 0 ? "pages" : "creators"),
-    [creatorCount, pageCount],
+    () =>
+      !creatorsLoading && !pagesLoading && creatorCount === 0 && pageCount > 0
+        ? "pages"
+        : "creators",
+    [creatorCount, creatorsLoading, pageCount, pagesLoading],
   );
 
   return (
@@ -141,61 +143,99 @@ export default function SearchFeature() {
           title="Search all of free2z"
           description="Start typing to find creators by name and pages by meaning — results update as you go."
         />
-      ) : error ? (
-        <EmptyState
-          icon={SearchIcon}
-          title="Search is unavailable"
-          description="Something went wrong reaching search. Try again in a moment."
-        />
       ) : (
         <Tabs defaultValue={defaultTab} key={defaultTab}>
           <TabsList>
             <TabsTrigger value="creators">
               <Users className="mr-1.5 h-4 w-4" aria-hidden />
               Creators
-              <ResultCountBadge n={creatorCount} loading={loading} />
+              <ResultCountBadge
+                n={creatorCount}
+                loading={creatorsLoading && creators === null}
+                available={creators !== null}
+              />
             </TabsTrigger>
             <TabsTrigger value="pages">
               <FileText className="mr-1.5 h-4 w-4" aria-hidden />
               Pages
-              <ResultCountBadge n={pageCount} loading={loading} />
+              <ResultCountBadge
+                n={pageCount}
+                loading={pagesLoading && pages === null}
+                available={pages !== null}
+              />
             </TabsTrigger>
           </TabsList>
 
           <TabsContent value="creators">
-            {creators === null ? (
+            {creatorsError ? (
+              <SectionLoadError
+                className="mb-4"
+                title={
+                  creators === null
+                    ? "Creator search is unavailable"
+                    : "Couldn't refresh creator results"
+                }
+                description={
+                  creators === null
+                    ? "Pages may still be available in the other tab."
+                    : "Showing the last creator results loaded on this device."
+                }
+                retry={reloadCreators}
+                retrying={creatorsLoading}
+                stale={creators !== null}
+              />
+            ) : null}
+            {creatorsLoading && creators === null ? (
               <CreatorGridSkeleton />
-            ) : creators.length === 0 ? (
+            ) : creatorsError && creators === null ? null : creators?.length === 0 ? (
               <EmptyState
                 icon={Users}
                 title="No creators found"
                 description={`No creators match “${debounced.trim()}”. Creators are matched by username and name.`}
               />
-            ) : (
+            ) : creators ? (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 {creators.map((c) => (
                   <CreatorResultCard key={c.username} creator={c} />
                 ))}
               </div>
-            )}
+            ) : null}
           </TabsContent>
 
           <TabsContent value="pages">
-            {pages === null ? (
+            {pagesError ? (
+              <SectionLoadError
+                className="mb-4"
+                title={
+                  pages === null
+                    ? "Page search is unavailable"
+                    : "Couldn't refresh page results"
+                }
+                description={
+                  pages === null
+                    ? "Creators may still be available in the other tab."
+                    : "Showing the last page results loaded on this device."
+                }
+                retry={reloadPages}
+                retrying={pagesLoading}
+                stale={pages !== null}
+              />
+            ) : null}
+            {pagesLoading && pages === null ? (
               <PageListSkeleton />
-            ) : pages.length === 0 ? (
+            ) : pagesError && pages === null ? null : pages?.length === 0 ? (
               <EmptyState
                 icon={BookOpen}
                 title="No pages found"
                 description={`No pages match “${debounced.trim()}”. Try different or broader terms.`}
               />
-            ) : (
+            ) : pages ? (
               <div className="flex flex-col gap-3">
                 {pages.map((p) => (
                   <PageResultRow key={String(p.id)} article={p} />
                 ))}
               </div>
-            )}
+            ) : null}
           </TabsContent>
         </Tabs>
       )}
@@ -203,8 +243,16 @@ export default function SearchFeature() {
   );
 }
 
-function ResultCountBadge({ n, loading }: { n: number; loading: boolean }) {
-  if (loading) return null;
+function ResultCountBadge({
+  n,
+  loading,
+  available,
+}: {
+  n: number;
+  loading: boolean;
+  available: boolean;
+}) {
+  if (loading || !available) return null;
   return (
     <span className="ml-2 rounded-full bg-muted px-1.5 text-[11px] font-semibold tabular-nums text-muted-foreground">
       {n}

--- a/wallet/zuuli/src/features/wallet/History.tsx
+++ b/wallet/zuuli/src/features/wallet/History.tsx
@@ -1,9 +1,14 @@
 // Full transaction history.
-import { useEffect, useState } from "react";
-import { ArrowDownLeft, ArrowUpRight, History as HistoryIcon } from "lucide-react";
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  History as HistoryIcon,
+} from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
+import { useAsync } from "@/hooks/useAsync";
 import {
   formatDate,
   formatZecDisplay,
@@ -15,24 +20,14 @@ import { cn } from "@/lib/utils";
 import { CopyButton } from "./shared";
 
 export function History() {
-  const [txs, setTxs] = useState<TransactionEntry[] | null>(null);
+  const {
+    data: txs,
+    loading,
+    error,
+    reload,
+  } = useAsync<TransactionEntry[]>(() => wallet.getTransactionHistory(0), []);
 
-  useEffect(() => {
-    let alive = true;
-    void wallet
-      .getTransactionHistory(0)
-      .then((res) => {
-        if (alive) setTxs(res);
-      })
-      .catch(() => {
-        if (alive) setTxs([]);
-      });
-    return () => {
-      alive = false;
-    };
-  }, []);
-
-  if (txs === null) {
+  if (loading && txs === null && !error) {
     return (
       <Card className="rounded-xl">
         <CardContent className="divide-y divide-border/60 p-2">
@@ -51,24 +46,59 @@ export function History() {
     );
   }
 
-  if (txs.length === 0) {
+  if (error && txs === null) {
     return (
-      <EmptyState
-        icon={HistoryIcon}
-        title="No transactions yet"
-        description="Send or receive ZEC and every transaction will appear here."
+      <SectionLoadError
+        title="Couldn't load transaction history"
+        description="Your transaction history is temporarily unavailable."
+        retry={reload}
+        retrying={loading}
       />
     );
   }
 
+  if (!txs) return null;
+
+  if (txs.length === 0) {
+    return (
+      <div className="space-y-3">
+        {error ? (
+          <SectionLoadError
+            title="Couldn't refresh transaction history"
+            description="Showing the last transaction history loaded on this device."
+            retry={reload}
+            retrying={loading}
+            stale
+          />
+        ) : null}
+        <EmptyState
+          icon={HistoryIcon}
+          title="No transactions yet"
+          description="Send or receive ZEC and every transaction will appear here."
+        />
+      </div>
+    );
+  }
+
   return (
-    <Card className="rounded-xl">
-      <CardContent className="divide-y divide-border/60 p-2">
-        {txs.map((tx) => (
-          <HistoryRow key={tx.txid} tx={tx} />
-        ))}
-      </CardContent>
-    </Card>
+    <div className="space-y-3">
+      {error ? (
+        <SectionLoadError
+          title="Couldn't refresh transaction history"
+          description="Showing the last transaction history loaded on this device."
+          retry={reload}
+          retrying={loading}
+          stale
+        />
+      ) : null}
+      <Card className="rounded-xl">
+        <CardContent className="divide-y divide-border/60 p-2">
+          {txs.map((tx) => (
+            <HistoryRow key={tx.txid} tx={tx} />
+          ))}
+        </CardContent>
+      </Card>
+    </div>
   );
 }
 

--- a/wallet/zuuli/src/features/wallet/Overview.tsx
+++ b/wallet/zuuli/src/features/wallet/Overview.tsx
@@ -1,11 +1,12 @@
 // Wallet overview: balance, sync, address, recent activity.
-import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { ArrowDownToLine, ArrowUpRight, History } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
+import { useAsync } from "@/hooks/useAsync";
 import { formatZecDisplay, splitZec } from "@/lib/format";
 import { wallet } from "@/lib/wallet/bridge";
 import type { TransactionEntry } from "@/lib/wallet/types";
@@ -18,26 +19,18 @@ export function Overview() {
   const sync = useWallet((s) => s.sync);
   const unifiedAddress = useWallet((s) => s.unifiedAddress);
 
-  const [recent, setRecent] = useState<TransactionEntry[] | null>(null);
+  const {
+    data: recent,
+    loading: recentLoading,
+    error: recentError,
+    reload: reloadRecent,
+  } = useAsync<TransactionEntry[]>(async () => {
+    const transactions = await wallet.getTransactionHistory(0);
+    return transactions.slice(0, 4);
+  }, []);
 
   // Sync runs automatically and is polled by the wallet store, so there is no
   // manual start/stop here — the SyncBar below is a passive status indicator.
-
-  // Load a small recent-activity preview.
-  useEffect(() => {
-    let alive = true;
-    void wallet
-      .getTransactionHistory(0)
-      .then((tx) => {
-        if (alive) setRecent(tx.slice(0, 4));
-      })
-      .catch(() => {
-        if (alive) setRecent([]);
-      });
-    return () => {
-      alive = false;
-    };
-  }, []);
 
   const pending = balance
     ? balance.valuePending + balance.changePending
@@ -127,7 +120,25 @@ export function Overview() {
           {recent && recent.length > 0 ? <ViewAllLink /> : null}
         </CardHeader>
         <CardContent className="pt-0">
-          {recent === null ? (
+          {recentError ? (
+            <SectionLoadError
+              className="mb-3"
+              title={
+                recent === null
+                  ? "Couldn't load recent activity"
+                  : "Couldn't refresh recent activity"
+              }
+              description={
+                recent === null
+                  ? "Your transaction history is temporarily unavailable."
+                  : "Showing the last transaction history loaded on this device."
+              }
+              retry={reloadRecent}
+              retrying={recentLoading}
+              stale={recent !== null}
+            />
+          ) : null}
+          {recentLoading && recent === null ? (
             <div className="space-y-2">
               {[0, 1, 2].map((i) => (
                 <div key={i} className="flex items-center gap-3 px-3 py-3">
@@ -140,19 +151,19 @@ export function Overview() {
                 </div>
               ))}
             </div>
-          ) : recent.length === 0 ? (
+          ) : recentError && recent === null ? null : recent?.length === 0 ? (
             <EmptyState
               icon={History}
               title="No transactions yet"
               description="Once you send or receive ZEC, your activity shows up here."
             />
-          ) : (
+          ) : recent ? (
             <div className="-mx-3 divide-y divide-border/60">
               {recent.map((tx) => (
                 <TxRow key={tx.txid} tx={tx} />
               ))}
             </div>
-          )}
+          ) : null}
         </CardContent>
       </Card>
     </div>

--- a/wallet/zuuli/src/features/wallet/funding/ActivityTab.tsx
+++ b/wallet/zuuli/src/features/wallet/funding/ActivityTab.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
 import { Receipt, TrendingUp, TrendingDown } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
+import { SectionLoadError } from "@/components/common/SectionLoadError";
+import { useAsync } from "@/hooks/useAsync";
 import { tuzi } from "@/lib/api/free2z";
 import type { TuziTransaction } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
@@ -11,20 +12,14 @@ import { formatTuzis, timeAgo } from "@/lib/format";
 import { kindMeta, kindIconClass } from "./lib";
 
 export function ActivityTab() {
-  const [txns, setTxns] = useState<TuziTransaction[] | null>(null);
+  const {
+    data: txns,
+    loading,
+    error,
+    reload,
+  } = useAsync<TuziTransaction[]>(() => tuzi.transactions(), []);
 
-  useEffect(() => {
-    let alive = true;
-    tuzi
-      .transactions()
-      .then((t) => alive && setTxns(t))
-      .catch(() => alive && setTxns([]));
-    return () => {
-      alive = false;
-    };
-  }, []);
-
-  if (txns === null) {
+  if (loading && txns === null && !error) {
     return (
       <div className="space-y-3">
         <div className="grid gap-3 sm:grid-cols-2">
@@ -38,13 +33,37 @@ export function ActivityTab() {
     );
   }
 
+  if (error && txns === null) {
+    return (
+      <SectionLoadError
+        title="Couldn't load 2Z activity"
+        description="Your 2Z activity is temporarily unavailable."
+        retry={reload}
+        retrying={loading}
+      />
+    );
+  }
+
+  if (!txns) return null;
+
   if (txns.length === 0) {
     return (
-      <EmptyState
-        icon={Receipt}
-        title="No activity yet"
-        description="Your 2Z purchases, tips and charges will show up here."
-      />
+      <div className="space-y-3">
+        {error ? (
+          <SectionLoadError
+            title="Couldn't refresh 2Z activity"
+            description="Showing the last 2Z activity loaded on this device."
+            retry={reload}
+            retrying={loading}
+            stale
+          />
+        ) : null}
+        <EmptyState
+          icon={Receipt}
+          title="No activity yet"
+          description="Your 2Z purchases, tips and charges will show up here."
+        />
+      </div>
     );
   }
 
@@ -57,6 +76,15 @@ export function ActivityTab() {
 
   return (
     <div className="space-y-4">
+      {error ? (
+        <SectionLoadError
+          title="Couldn't refresh 2Z activity"
+          description="Showing the last 2Z activity loaded on this device."
+          retry={reload}
+          retrying={loading}
+          stale
+        />
+      ) : null}
       {/* Summary chips — "Total spent" only appears once there is real spend
           (the purchases-only Stripe ledger has none, so it isn't shown as a
           permanent 0). */}

--- a/wallet/zuuli/src/hooks/useAsync.ts
+++ b/wallet/zuuli/src/hooks/useAsync.ts
@@ -1,10 +1,24 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  beginRemoteLoad,
+  initialRemoteData,
+  remoteFailure,
+  remoteSuccess,
+  type RemoteDataState,
+} from "@/lib/remote-data";
 
-interface AsyncState<T> {
-  data: T | null;
-  loading: boolean;
-  error: string | null;
+interface AsyncState<T> extends RemoteDataState<T> {
   reload: () => void;
+}
+
+function sameDependencies(
+  previous: React.DependencyList,
+  current: React.DependencyList,
+): boolean {
+  return (
+    previous.length === current.length &&
+    previous.every((value, index) => Object.is(value, current[index]))
+  );
 }
 
 /**
@@ -15,33 +29,48 @@ export function useAsync<T>(
   loader: () => Promise<T>,
   deps: React.DependencyList = [],
 ): AsyncState<T> {
-  const [data, setData] = useState<T | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [state, setState] = useState<RemoteDataState<T>>(() =>
+    initialRemoteData<T>(),
+  );
   const [nonce, setNonce] = useState(0);
   const idRef = useRef(0);
+  const committedDepsRef = useRef<React.DependencyList>([...deps]);
+
+  // Effects run after render. Hide the prior resource synchronously so a route
+  // or search-key change cannot briefly attribute its data or error (including
+  // an authoritative 404) to the new key.
+  const dependencyChanged = !sameDependencies(committedDepsRef.current, deps);
 
   const reload = useCallback(() => setNonce((n) => n + 1), []);
 
   useEffect(() => {
+    const resourceChanged = !sameDependencies(committedDepsRef.current, deps);
+    committedDepsRef.current = [...deps];
     const id = ++idRef.current;
-    setLoading(true);
-    setError(null);
+    let active = true;
+    setState((current) =>
+      beginRemoteLoad(current, { retainData: !resourceChanged }),
+    );
     loader()
       .then((res) => {
-        if (idRef.current === id) {
-          setData(res);
-          setLoading(false);
+        if (active && idRef.current === id) {
+          setState(remoteSuccess(res));
         }
       })
       .catch((e: unknown) => {
-        if (idRef.current === id) {
-          setError(e instanceof Error ? e.message : String(e));
-          setLoading(false);
+        if (active && idRef.current === id) {
+          setState((current) => remoteFailure(current, e));
         }
       });
+    return () => {
+      active = false;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [...deps, nonce]);
 
-  return { data, loading, error, reload };
+  const visibleState = dependencyChanged
+    ? beginRemoteLoad(state, { retainData: false })
+    : state;
+
+  return { ...visibleState, reload };
 }

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -1147,7 +1147,9 @@ export const articles = {
       const a = mockArticles.find(
         (x) => x.slug === idOrSlug || String(x.id) === String(idOrSlug),
       );
-      if (!a) throw new Error("Article not found");
+      // Mock mode must preserve the same absence contract as production so the
+      // reader can distinguish an authoritative 404 from a transport failure.
+      if (!a) throw new ApiError(404, "Article not found");
       return a;
     }
     const z = await request<RawZPage>(`/api/zpage/${idOrSlug}/`, {

--- a/wallet/zuuli/src/lib/remote-data.test.ts
+++ b/wallet/zuuli/src/lib/remote-data.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "./api/http";
+import {
+  beginRemoteLoad,
+  currentResourceData,
+  initialRemoteData,
+  isConfirmedNotFound,
+  remoteFailure,
+  remoteSuccess,
+  remoteView,
+  type KeyedRemoteData,
+  type RemoteDataState,
+} from "./remote-data";
+
+const listView = <T>(state: RemoteDataState<T[]>) =>
+  remoteView(state, (items) => items.length === 0);
+
+describe("truthful remote-data states", () => {
+  it.each([
+    "Home LiveRail",
+    "Home ArticlesGrid",
+    "Home CreatorsRow",
+    "Live Discovery",
+    "creator pages",
+  ])("keeps %s loading, failure, and confirmed empty distinct", () => {
+    const initial = initialRemoteData<string[]>();
+    expect(listView(initial)).toBe("loading");
+
+    const failed = remoteFailure(initial, new Error("offline"));
+    expect(listView(failed)).toBe("error");
+    expect(failed.data).toBeNull();
+
+    const retrying = beginRemoteLoad(failed);
+    expect(listView(retrying)).toBe("error");
+    expect(retrying.loading).toBe(true);
+    expect(retrying.error).toBe(failed.error);
+
+    const confirmedEmpty = remoteSuccess<string[]>([]);
+    expect(listView(confirmedEmpty)).toBe("empty");
+  });
+
+  it("normalizes non-Error rejections so a failure cannot become falsy", () => {
+    const failed = remoteFailure(initialRemoteData<string[]>(), null);
+    expect(failed.error).toBeInstanceOf(Error);
+    expect(listView(failed)).toBe("error");
+  });
+
+  it("clears another resource's data and error when the dependency key changes", () => {
+    const aliceFailure = remoteFailure(
+      remoteSuccess(["alice result"]),
+      new ApiError(404, "alice not found"),
+    );
+
+    expect(beginRemoteLoad(aliceFailure, { retainData: false })).toEqual({
+      data: null,
+      loading: true,
+      error: null,
+    });
+  });
+
+  it.each([
+    "wallet Overview recent activity",
+    "wallet History",
+    "2Z Activity",
+  ])("retains %s last-known-good data across failure and retry", () => {
+    const successful = remoteSuccess(["confirmed transaction"]);
+    const refreshing = beginRemoteLoad(successful);
+    expect(listView(refreshing)).toBe("refreshing");
+
+    const failed = remoteFailure(refreshing, new Error("timeout"));
+    expect(listView(failed)).toBe("stale-error");
+    expect(failed.data).toEqual(["confirmed transaction"]);
+
+    const retrying = beginRemoteLoad(failed);
+    expect(listView(retrying)).toBe("stale-error");
+    expect(retrying.data).toEqual(["confirmed transaction"]);
+    expect(retrying.loading).toBe(true);
+    expect(retrying.error).toBe(failed.error);
+
+    const confirmedEmpty = remoteSuccess<string[]>([]);
+    expect(listView(confirmedEmpty)).toBe("empty");
+    const emptyRefreshFailure = remoteFailure(
+      beginRemoteLoad(confirmedEmpty),
+      new Error("timeout"),
+    );
+    expect(listView(emptyRefreshFailure)).toBe("stale-error");
+    expect(emptyRefreshFailure.data).toEqual([]);
+  });
+
+  it.each(["Article Reader", "Creator profile"])(
+    "routes only a confirmed 404 to %s not-found",
+    () => {
+      expect(isConfirmedNotFound(new ApiError(404, "Not found"))).toBe(true);
+      expect(isConfirmedNotFound(new ApiError(500, "Server error"))).toBe(
+        false,
+      );
+      expect(isConfirmedNotFound(new TypeError("Network error"))).toBe(false);
+    },
+  );
+
+  it("keeps Search corpora independent and retries only the failed sibling", () => {
+    const creatorSuccess = remoteSuccess(["alice"]);
+    const pageFailure = remoteFailure(
+      initialRemoteData<string[]>(),
+      new Error("page search unavailable"),
+    );
+
+    expect(listView(creatorSuccess)).toBe("ready");
+    expect(listView(pageFailure)).toBe("error");
+
+    const pageRetry = beginRemoteLoad(pageFailure);
+    expect(listView(pageRetry)).toBe("error");
+    expect(pageRetry.loading).toBe(true);
+    expect(pageRetry.error).toBe(pageFailure.error);
+    expect(creatorSuccess.data).toEqual(["alice"]);
+    expect(creatorSuccess.loading).toBe(false);
+    expect(creatorSuccess.error).toBeNull();
+  });
+
+  it("never presents retained data from another resource or search key", () => {
+    const alice: KeyedRemoteData<string, string[]> = {
+      key: "alice",
+      value: ["alice result"],
+    };
+
+    expect(currentResourceData(alice, "alice")).toEqual(["alice result"]);
+    expect(currentResourceData(alice, "bob")).toBeNull();
+  });
+});

--- a/wallet/zuuli/src/lib/remote-data.ts
+++ b/wallet/zuuli/src/lib/remote-data.ts
@@ -1,0 +1,92 @@
+import { ApiError } from "./api/http";
+
+/**
+ * The data from the last confirmed success is deliberately independent from
+ * the current request. A transient refresh failure must not erase trustworthy
+ * financial history (or turn any successful result into an empty state).
+ */
+export interface RemoteDataState<T> {
+  data: T | null;
+  loading: boolean;
+  error: unknown | null;
+}
+
+export type RemoteView =
+  | "loading"
+  | "refreshing"
+  | "error"
+  | "stale-error"
+  | "empty"
+  | "ready";
+
+export function initialRemoteData<T>(): RemoteDataState<T> {
+  return { data: null, loading: true, error: null };
+}
+
+export function beginRemoteLoad<T>(
+  state: RemoteDataState<T>,
+  { retainData = true }: { retainData?: boolean } = {},
+): RemoteDataState<T> {
+  return {
+    data: retainData ? state.data : null,
+    loading: true,
+    // A same-resource retry keeps its failure visible so the retry control can
+    // report progress. A dependency/resource change clears both data and error
+    // because neither may be attributed to the new key.
+    error: retainData ? state.error : null,
+  };
+}
+
+export function remoteSuccess<T>(data: T): RemoteDataState<T> {
+  return { data, loading: false, error: null };
+}
+
+export function remoteFailure<T>(
+  state: RemoteDataState<T>,
+  error: unknown,
+): RemoteDataState<T> {
+  const normalized =
+    error instanceof Error
+      ? error
+      : new Error(
+          typeof error === "string" && error.trim()
+            ? error
+            : "The request failed.",
+        );
+  return { ...state, loading: false, error: normalized };
+}
+
+/** Resolve display truth without conflating a failed request with emptiness. */
+export function remoteView<T>(
+  state: RemoteDataState<T>,
+  isEmpty: (data: T) => boolean,
+): RemoteView {
+  if (state.error !== null) {
+    return state.data === null ? "error" : "stale-error";
+  }
+  if (state.data === null) return "loading";
+  if (state.loading) return "refreshing";
+  return isEmpty(state.data) ? "empty" : "ready";
+}
+
+/** Only an explicit HTTP 404 is authoritative absence. */
+export function isConfirmedNotFound(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 404;
+}
+
+/**
+ * A retained response is safe only for the resource key that produced it.
+ * This prevents a failed search/profile navigation from showing another
+ * query's successful data as if it belonged to the new request.
+ */
+export interface KeyedRemoteData<K, T> {
+  key: K;
+  value: T;
+}
+
+export function currentResourceData<K, T>(
+  data: KeyedRemoteData<K, T> | null,
+  key: K,
+): T | null {
+  return data !== null && Object.is(data.key, key) ? data.value : null;
+}


### PR DESCRIPTION
Closes #255

## Summary

- Introduce a shared remote-data state model and accessible retry surface that distinguishes initial loading, refresh, failure, stale last-known-good data, successful empty results, and confirmed not-found responses.
- Apply truthful independent failure/retry handling across Home, Live discovery/rooms, Search corpora, Reader, Creator/pages, Wallet overview/history, and Wallet funding activity.
- Preserve trusted financial data through refresh failures; never replace unavailable balances or transaction history with fabricated zero/empty states.
- Fence stale async results and synchronously hide prior keyed-resource state when route/search dependencies change.

## Compatibility and integration

- Only confirmed HTTP 404 responses render Reader/Creator not-found copy; transient failures remain retryable.
- Search creators and pages retain independent loading/error/retry state, so one failed corpus does not discard its successful sibling.
- The held `features/buy/ActivityTab.tsx` change was semantically mapped to #332's canonical `features/wallet/funding/ActivityTab.tsx` path.
- #417 store contracts and #418 auth/session lifecycle contracts remain unchanged and pass.
- Final rebase preserves #422/#425 sanitized store-audit changes as base-only files; none appears in this PR diff. Every rebased app commit shares stable patch ID `4a1aec7232023f5ab827fe4ef4183e36451c4df0`.

## Verification

Exact head `a3a85a5b073c05dfb347bb635134552f8dc43331` on base `93f2f69dfd975adaf0d3efc4b1fd14f6d428f647`:

- `npm test` — 274 Vitest, 7 Node boundary contracts, 33 Playwright cases; all pass.
- `npm run typecheck`
- `npm run build`
- `npm run test:store-listing` — 37/37 pass, including #422/#425 protected-audit diagnostics.
- `npm run store:validate`
- `npm run icons:check`
- `npm run release:verify`
- `scripts/check-rust-toolchain.sh`
- `git diff --check origin/main...HEAD`

Prior exact heads completed the required gate and all four package targets successfully. Fresh final-base runs are required for this exact head.

## Adversarial review

The first review identified that retry immediately cleared its error banner, making retry feedback disappear. The implementation now retains the same-resource error while retrying, keeps Retry visible and disabled with progress feedback, and clears error/data only for a true resource-key change.

A second clean review found no blocking regression. The reviewed app patch concluded: “The changes consistently distinguish loading, failure, stale-data, and confirmed-empty states while preventing cross-resource data leakage. Type checking and the full Vitest suite pass.” The final #422/#425 rebases are patch-identical, and all newly based protected-audit tests pass.
