### PR TITLE
fix(zuuli): accept empty Play testers resource

### DIFF
--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -162,7 +162,14 @@ come from a code allowlist, never a provider URL or response. If a primary audit
 failure is followed by failure to delete its temporary Play edit, evidence also
 sets `temporaryEditCleanupFailed: true` while retaining the primary stage. The
 workflow then fails after credential cleanup; an artifact is not a successful
-audit verdict. Dispatch only after the source has merged:
+audit verdict.
+
+The Publisher API does not expose Play Console email-list membership. An exact
+empty `Testers` resource therefore means zero API-visible Google Groups, not
+zero internal testers; the audit preserves the owner-declared email-list mode
+and never reads or changes tester identities.
+
+Dispatch only after the source has merged:
 
 ```bash
 source_sha=$(git rev-parse origin/main)

--- a/wallet/zuuli/scripts/store-state-audit.mjs
+++ b/wallet/zuuli/scripts/store-state-audit.mjs
@@ -121,6 +121,22 @@ export function parsePlayImages(payload, stage = "unknown") {
   return payload.images;
 }
 
+export function parsePlayTesterGroupCount(payload) {
+  const stage = "testers";
+  const prototype = payload && typeof payload === "object" ? Object.getPrototypeOf(payload) : undefined;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload) || prototype !== Object.prototype) fail("INVALID_RESPONSE", "Play testers response is malformed", { stage });
+  if (Object.hasOwn(payload, "error") || Object.hasOwn(payload, "errors")) fail("INVALID_RESPONSE", "Play testers response contains an error payload", { stage });
+  const keys = Reflect.ownKeys(payload);
+  if (!Object.hasOwn(payload, "googleGroups")) {
+    if (keys.length !== 0) fail("INVALID_RESPONSE", "Play testers response omitted googleGroups alongside unknown members", { stage });
+    return 0;
+  }
+  if (keys.length !== 1 || keys[0] !== "googleGroups") fail("INVALID_RESPONSE", "Play testers response contains unknown members", { stage });
+  if (!Array.isArray(payload.googleGroups)) fail("INVALID_RESPONSE", "Play testers response has a non-array googleGroups member", { stage });
+  for (const group of payload.googleGroups) if (typeof group !== "string") fail("INVALID_RESPONSE", "Play testers response contains malformed group configuration", { stage });
+  return payload.googleGroups.length;
+}
+
 const SAFE_PROVIDER_FAILURE_MESSAGES = Object.freeze({
   AMBIGUOUS_REMOTE_STATE: "provider returned ambiguous duplicate state",
   API_ERROR: "provider API request failed",
@@ -334,9 +350,7 @@ export async function auditPlayStore({ credentials, expected, fetchImpl = global
     let groupCount = null;
     try {
       const testers = await request("GET", `${editBase}/testers/${PLAY_TRACK}`, undefined, false, "testers");
-      if (!Array.isArray(testers?.googleGroups)) fail("INVALID_RESPONSE", "Play testers response has no googleGroups array", { stage: "testers" });
-      for (const group of testers.googleGroups) if (typeof group !== "string") fail("INVALID_RESPONSE", "Play testers response contains malformed group configuration", { stage: "testers" });
-      groupCount = testers.googleGroups.length;
+      groupCount = parsePlayTesterGroupCount(testers);
       testerMode = groupCount === 0 ? "no_api_visible_google_groups" : "publisher_api_google_groups";
     } catch (error) {
       if (!(error instanceof StoreAuditError) || error.code !== "API_ERROR" || !new Set([403, 404]).has(error.status)) throw error;

--- a/wallet/zuuli/scripts/store-state-audit.node-test.mjs
+++ b/wallet/zuuli/scripts/store-state-audit.node-test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { generateKeyPairSync } from "node:crypto";
 import test from "node:test";
-import { auditAppleStore, auditPlayStore, main, parsePlayImages, StoreAuditError } from "./store-state-audit.mjs";
+import { auditAppleStore, auditPlayStore, main, parsePlayImages, parsePlayTesterGroupCount, StoreAuditError } from "./store-state-audit.mjs";
 
 const expected = {
   release: { version: "0.1.0", build: 10 },
@@ -98,7 +98,7 @@ test("Apple audit rejects duplicate locale/display-type screenshot sets", async 
   await assert.rejects(() => auditAppleStore({ credentials: appleCredentials, expected, fetchImpl, nowSeconds: () => 1_800_000_000 }), (error) => error instanceof StoreAuditError && error.code === "AMBIGUOUS_REMOTE_STATE");
 });
 
-function playMock({ groups = [], invalidListings = false, invalidDetails = false, invalidTrack = false, invalidTesters = false, editId = "audit-edit", listingFailures = 0, deleteFailures = 0, testerStatus = 200, listingTitle = "ZUULI", releaseNotes = "release notes", missingBrandType, duplicateBrandType, imagePayload } = {}) {
+function playMock({ groups = [], testersPayload, invalidListings = false, invalidDetails = false, invalidTrack = false, invalidTesters = false, editId = "audit-edit", listingFailures = 0, deleteFailures = 0, testerStatus = 200, listingTitle = "ZUULI", releaseNotes = "release notes", missingBrandType, duplicateBrandType, imagePayload } = {}) {
   const calls = [];
   let remainingListingFailures = listingFailures;
   let remainingDeleteFailures = deleteFailures;
@@ -119,7 +119,7 @@ function playMock({ groups = [], invalidListings = false, invalidDetails = false
       }
       if (url.pathname.endsWith("/details")) return invalidDetails ? json([]) : json({ defaultLanguage: "en-US", contactEmail: "help@example.com", contactWebsite: "https://example.com/" });
       if (url.pathname.endsWith("/tracks/internal")) return invalidTrack ? json({}) : json({ track: "internal", releases: [{ versionCodes: ["10"], releaseNotes: [{ language: "en-US", text: releaseNotes }] }] });
-      if (url.pathname.endsWith("/testers/internal")) return invalidTesters ? json({}) : testerStatus === 200 ? json({ googleGroups: groups }) : json({ error: { status: "PERMISSION_DENIED" } }, testerStatus);
+      if (url.pathname.endsWith("/testers/internal")) return testersPayload !== undefined ? json(testersPayload) : invalidTesters ? json({ googleGroups: null }) : testerStatus === 200 ? json({ googleGroups: groups }) : json({ error: { status: "PERMISSION_DENIED" } }, testerStatus);
       if (url.pathname.includes("/listings/en-US/")) {
         if (imagePayload !== undefined) return json(imagePayload);
         const imageType = url.pathname.split("/").at(-1);
@@ -152,6 +152,47 @@ test("Play group configuration is flagged without logging group addresses", asyn
   assert.equal(evidence.testerEligibility.publisherApiObservation, "publisher_api_google_groups");
   assert.equal(evidence.testerEligibility.consistentWithOwnerMode, false);
   assert.equal(JSON.stringify(evidence).includes(marker), false);
+});
+
+test("Play treats the live empty Testers resource as zero API-visible Google Groups", async () => {
+  const mock = playMock({ testersPayload: {} });
+  const evidence = await auditPlayStore({ credentials: playCredentials, expected, fetchImpl: mock.fetch, nowSeconds: () => 1_800_000_000 });
+  assert.equal(evidence.testerEligibility.publisherApiObservation, "no_api_visible_google_groups");
+  assert.equal(evidence.testerEligibility.publisherApiGroupCount, 0);
+  assert.equal(evidence.testerEligibility.consistentWithOwnerMode, true);
+  assert.equal(evidence.testerEligibility.emailListIdentitiesReadable, false);
+  assert.equal(mock.calls.at(-1).method, "DELETE");
+});
+
+test("Play Testers parser accepts only exact empty or one-array-member resources", () => {
+  const marker = "Bearer hostile-token attacker@example.invalid";
+  assert.equal(parsePlayTesterGroupCount({}), 0);
+  assert.equal(parsePlayTesterGroupCount({ googleGroups: [] }), 0);
+  const parsed = parsePlayTesterGroupCount({ googleGroups: [marker] });
+  assert.equal(parsed, 1);
+  assert.equal(JSON.stringify(parsed).includes(marker), false);
+  for (const payload of [
+    null,
+    [],
+    "",
+    Object.create(null),
+    new Date("2026-08-19T00:00:00Z"),
+    { foo: marker },
+    { googleGroups: [], foo: marker },
+    { googleGroups: null },
+    { googleGroups: {} },
+    { googleGroups: [marker, 7] },
+    { error: { message: marker } },
+    { errors: [{ message: marker }] },
+  ]) {
+    assert.throws(
+      () => parsePlayTesterGroupCount(payload),
+      (error) => {
+        const errorState = JSON.stringify({ code: error?.code, message: error?.message, stage: error?.stage, status: error?.status });
+        return error instanceof StoreAuditError && error.code === "INVALID_RESPONSE" && error.stage === "testers" && !errorState.includes(marker);
+      },
+    );
+  }
 });
 
 test("Play completeness rejects stale listing copy", async () => {


### PR DESCRIPTION
## Summary

- accept the successful empty Google Play `Testers` resource `{}` as zero API-visible Google Groups
- continue to accept exactly one `googleGroups: string[]` member while never retaining or emitting its values
- reject null, array, primitive, non-plain, unknown-member, mixed-member, explicit-null/non-array, malformed-member, and error-envelope responses
- preserve owner-declared console email-list mode and document that Publisher API cannot inspect email-list membership

## Live and primary evidence

- Protected exact-main Play audit [32272464539](https://github.com/free2z/zuu/actions/runs/32272464539) passed listings, details, internal track, and all five image stages, then failed safely at `testers`; credential and temporary-edit cleanup succeeded, artifact `9372699287` remained sanitized, and no provider state was published.
- Sanitized structural finding: the successful `Testers` resource omitted the repeated `googleGroups` field, producing the exact empty representation `{}`. No raw group/tester identity was logged or retained.
- Google documents `edits.testers.get` returning `Testers`, whose only field is repeated `googleGroups[]`, and explicitly says this resource does not support console email lists: https://developers.google.com/android-publisher/api-ref/rest/v3/edits.testers/get and https://developers.google.com/android-publisher/api-ref/rest/v3/edits.testers

## Verification

- `npm ci`
- `npm run test:store-listing` (37/37)
- `npm run release:verify`
- `npm run store:validate`
- `actionlint .github/workflows/zuuli-store-audit.yml`
- `npm run typecheck`
- `npm run build`
- `npm test` (258 Vitest, 7 auth/safe-area contracts, 33 Playwright)
- `npm audit --audit-level=high` (no high/critical; existing moderate findings only)
- `node scripts/verify-ci-cache-policy.mjs`
- `gitleaks git --log-opts="origin/main..HEAD"`
- `git diff --check`

## Adversarial review

The parser accepts only an ordinary zero-key object or an ordinary one-key object whose sole member is a string array. Symbols, unknown siblings, error envelopes, mixed hostile values, and non-plain objects fail at the fixed `testers` stage with a static sanitized message. Even valid Google Group strings are reduced immediately to a count and never enter evidence. Email-list state remains owner-declared and uninspectable through this API. Request bounds are unchanged: OAuth, one temporary edit insert, bounded GETs, and best-effort DELETE only; no PUT, PATCH, edit commit, tester update, or publication.

Closes #424. Part of #387 and #296.