### PR TITLE
feat(zuuli): simplify persistent chrome copy

### DIFF
--- a/wallet/zuuli/src/components/layout/Sidebar.tsx
+++ b/wallet/zuuli/src/components/layout/Sidebar.tsx
@@ -76,14 +76,6 @@ export function Sidebar() {
           );
         })}
       </nav>
-      <div
-        className="shrink-0 px-5 py-4 text-[11px] leading-relaxed text-muted-foreground"
-        data-sidebar-footer
-      >
-        Shielded by default.
-        <br />
-        Powered by free2z.
-      </div>
     </aside>
   );
 }

--- a/wallet/zuuli/src/components/layout/TopBar.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.tsx
@@ -35,6 +35,13 @@ import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
 import { formatTuzis, formatZecTrim, initials } from "@/lib/format";
 
+const ICON_CONTROL_LABELS = {
+  account: "Account menu",
+  back: "Go back",
+  login: "Log in",
+  search: "Search",
+} as const;
+
 export function TopBar() {
   const { user, tuzis, logout } = useSession();
   const balance = useWallet((s) => s.balance);
@@ -60,15 +67,22 @@ export function TopBar() {
     >
       {/* Global back — available on every screen inside the shell */}
       {canGoBack ? (
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => navigate(-1)}
-          aria-label="Go back"
-          className="min-tap h-9 w-9 shrink-0"
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild aria-describedby={undefined}>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => navigate(-1)}
+              aria-label={ICON_CONTROL_LABELS.back}
+              className="min-tap h-9 w-9 shrink-0"
+            >
+              <ArrowLeft className="h-5 w-5" aria-hidden />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {ICON_CONTROL_LABELS.back}
+          </TooltipContent>
+        </Tooltip>
       ) : null}
 
       {/* Global search */}
@@ -96,13 +110,20 @@ export function TopBar() {
       </form>
 
       {/* Search icon (mobile) */}
-      <Link
-        to="/search"
-        className="min-tap grid place-items-center rounded-full text-muted-foreground transition-colors hover:text-foreground sm:hidden"
-        aria-label="Search"
-      >
-        <Search className="h-5 w-5" />
-      </Link>
+      <Tooltip>
+        <TooltipTrigger asChild aria-describedby={undefined}>
+          <Link
+            to="/search"
+            className="min-tap grid place-items-center rounded-full text-muted-foreground transition-colors hover:text-foreground sm:hidden"
+            aria-label={ICON_CONTROL_LABELS.search}
+          >
+            <Search className="h-5 w-5" aria-hidden />
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {ICON_CONTROL_LABELS.search}
+        </TooltipContent>
+      </Tooltip>
 
       <div className="flex-1" />
 
@@ -138,19 +159,26 @@ export function TopBar() {
 
       {user ? (
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              className="min-tap rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              aria-label="Account menu"
-            >
-              <Avatar className="h-9 w-9 border border-border">
-                {user.image ? <AvatarImage src={user.image} /> : null}
-                <AvatarFallback className="bg-primary/20 text-primary">
-                  {initials(user.display_name || user.username)}
-                </AvatarFallback>
-              </Avatar>
-            </button>
-          </DropdownMenuTrigger>
+          <Tooltip>
+            <TooltipTrigger asChild aria-describedby={undefined}>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className="min-tap rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  aria-label={ICON_CONTROL_LABELS.account}
+                >
+                  <Avatar className="h-9 w-9 border border-border">
+                    {user.image ? <AvatarImage src={user.image} /> : null}
+                    <AvatarFallback className="bg-primary/20 text-primary">
+                      {initials(user.display_name || user.username)}
+                    </AvatarFallback>
+                  </Avatar>
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {ICON_CONTROL_LABELS.account}
+            </TooltipContent>
+          </Tooltip>
           <DropdownMenuContent align="end" className="w-56">
             <DropdownMenuLabel>
               <div className="font-medium text-foreground">
@@ -172,7 +200,7 @@ export function TopBar() {
               <Coins /> Buy 2Zs
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => navigate("/kyc")}>
-              <ShieldCheck /> Apply for revenue share
+              <ShieldCheck /> Revenue share
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={() => logout()}>
@@ -182,18 +210,20 @@ export function TopBar() {
         </DropdownMenu>
       ) : (
         <Tooltip>
-          <TooltipTrigger asChild>
+          <TooltipTrigger asChild aria-describedby={undefined}>
             <Button
               variant="ghost"
               size="icon"
               className="min-tap shrink-0 rounded-full"
               onClick={() => navigate("/login")}
-              aria-label="Log in"
+              aria-label={ICON_CONTROL_LABELS.login}
             >
               <LogIn className="h-5 w-5" aria-hidden />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">Log in</TooltipContent>
+          <TooltipContent side="bottom">
+            {ICON_CONTROL_LABELS.login}
+          </TooltipContent>
         </Tooltip>
       )}
     </header>

--- a/wallet/zuuli/src/components/layout/navigation.test.ts
+++ b/wallet/zuuli/src/components/layout/navigation.test.ts
@@ -34,6 +34,9 @@ describe("app navigation information architecture", () => {
       "profile",
       "revenue-share",
     ]);
+    const revenueShare = NAVIGATION.find((item) => item.id === "revenue-share");
+    expect(revenueShare?.label).toBe("Revenue share");
+    expect(revenueShare?.accessibleLabel).toBe("Revenue share");
   });
 
   it("drives grouped desktop routes from the same config", () => {

--- a/wallet/zuuli/src/components/layout/navigation.ts
+++ b/wallet/zuuli/src/components/layout/navigation.ts
@@ -125,7 +125,7 @@ export const NAVIGATION: readonly NavigationItem[] = [
     kind: "route",
     to: "/kyc",
     label: "Revenue share",
-    accessibleLabel: "Apply for revenue share",
+    accessibleLabel: "Revenue share",
     icon: ShieldCheck,
     auth: "signed-in",
     desktop: { group: "account", order: 1 },

--- a/wallet/zuuli/src/features/kyc/index.tsx
+++ b/wallet/zuuli/src/features/kyc/index.tsx
@@ -31,7 +31,7 @@ export default function KycFeature() {
   if (!user) {
     return (
       <div className="animate-slide-up">
-        <PageHeader title="Apply for revenue share" />
+        <PageHeader title="Revenue share" />
         <EmptyState
           icon={Lock}
           title="Log in to apply"
@@ -87,7 +87,7 @@ function KycApplication() {
   if (loading) {
     return (
       <div className="animate-slide-up space-y-4">
-        <PageHeader title="Apply for revenue share" />
+        <PageHeader title="Revenue share" />
         <Skeleton className="h-52 w-full rounded-xl" />
       </div>
     );
@@ -96,7 +96,7 @@ function KycApplication() {
   if (loadError || !profile) {
     return (
       <div className="animate-slide-up">
-        <PageHeader title="Apply for revenue share" />
+        <PageHeader title="Revenue share" />
         <EmptyState
           title="Couldn't load your application"
           description="Something went wrong reaching the KYC service. Please try again shortly."
@@ -172,7 +172,7 @@ function KycApplication() {
   return (
     <div className="mx-auto max-w-2xl animate-slide-up">
       <PageHeader
-        title="Apply for revenue share"
+        title="Revenue share"
         description="Verify your identity and complete a tax form to become an eligible revenue-share creator. This is the application step only — payouts aren't live yet."
       />
       <Stepper step={step} />

--- a/wallet/zuuli/tests/navigation.pw.ts
+++ b/wallet/zuuli/tests/navigation.pw.ts
@@ -3,6 +3,7 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
 const WIDTHS = [320, 360] as const;
 const PRIMARY_IDS = ["home", "live", "ai", "wallet", "more"] as const;
 const PRIMARY_LABELS = ["Home", "Live", "AI", "Wallet", "More"] as const;
+const GERMAN_PRIMARY_LABELS = ["Start", "Live", "KI", "Wallet", "Mehr"] as const;
 
 async function setSession(page: Page, signedIn: boolean) {
   await page.addInitScript((authenticated) => {
@@ -18,7 +19,10 @@ async function primaryNavigation(page: Page) {
   return navigation;
 }
 
-async function expectFiveItemGeometry(navigation: Locator) {
+async function expectFiveItemGeometry(
+  navigation: Locator,
+  expectedLabels: readonly string[] = PRIMARY_LABELS,
+) {
   const controls = navigation.locator("[data-navigation-id]");
   await expect(controls).toHaveCount(5);
   expect(await controls.evaluateAll((items) => items.map((item) => item.dataset.navigationId))).toEqual(
@@ -69,7 +73,7 @@ async function expectFiveItemGeometry(navigation: Locator) {
   const visibleLabels = await controls.evaluateAll((items) =>
     items.map((item) => item.querySelector("span")?.textContent?.trim()),
   );
-  expect(visibleLabels).toEqual(PRIMARY_LABELS);
+  expect(visibleLabels).toEqual(expectedLabels);
 }
 
 for (const signedIn of [false, true]) {
@@ -127,7 +131,7 @@ for (const signedIn of [false, true]) {
       const moreNavigation = dialog.getByRole("navigation", { name: "More navigation" });
       const rows = moreNavigation.getByRole("link");
       const expectedNames = signedIn
-        ? ["Articles", "Edit profile", "Apply for revenue share"]
+        ? ["Articles", "Edit profile", "Revenue share"]
         : ["Articles", "Log in"];
       await expect(rows).toHaveCount(expectedNames.length);
       for (const name of expectedNames) {
@@ -181,6 +185,152 @@ test("long localized accessible names do not change the 320px bar", async ({ pag
     await expect(navigation.getByLabel(name, { exact: true })).toBeVisible();
   }
   await expectFiveItemGeometry(navigation);
+});
+
+test("German proxy copy fits the signed-in chrome and Revenue share destination at 320px", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 760 });
+  await setSession(page, true);
+  await page.goto("/kyc");
+
+  const navigation = await primaryNavigation(page);
+  await navigation.locator("[data-navigation-id]").evaluateAll((items, labels) => {
+    items.forEach((item, index) => {
+      const label = item.querySelector<HTMLElement>("span");
+      if (label) label.textContent = labels[index];
+    });
+  }, GERMAN_PRIMARY_LABELS);
+  await expectFiveItemGeometry(navigation, GERMAN_PRIMARY_LABELS);
+
+  const heading = page.getByRole("heading", { name: "Revenue share" });
+  await expect(heading).toBeVisible();
+  const headingGeometry = await heading.evaluate((element) => {
+    element.textContent = "Umsatzbeteiligung für Kreative";
+    const rect = element.getBoundingClientRect();
+    return {
+      left: rect.left,
+      right: rect.right,
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+      viewportWidth: document.documentElement.clientWidth,
+    };
+  });
+  expect(headingGeometry.left).toBeGreaterThanOrEqual(0);
+  expect(headingGeometry.right).toBeLessThanOrEqual(headingGeometry.viewportWidth);
+  expect(headingGeometry.scrollWidth).toBeLessThanOrEqual(headingGeometry.clientWidth);
+
+  await navigation.locator('[data-navigation-id="more"]').click();
+  const dialog = page.getByRole("dialog", { name: "More" });
+  const rows = dialog.getByRole("navigation", { name: "More navigation" }).getByRole("link");
+  await rows.evaluateAll((items, labels) => {
+    items.forEach((item, index) => {
+      const label = item.querySelector<HTMLElement>("span");
+      if (label) label.textContent = labels[index];
+    });
+  }, ["Artikel", "Profil bearbeiten", "Umsatzbeteiligung"]);
+  const germanGeometry = await dialog.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const rows = [...element.querySelectorAll<HTMLElement>("nav a")];
+    return {
+      left: rect.left,
+      right: rect.right,
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+      viewportWidth: document.documentElement.clientWidth,
+      rows: rows.map((row) => {
+        const rowRect = row.getBoundingClientRect();
+        return { left: rowRect.left, right: rowRect.right };
+      }),
+    };
+  });
+  expect(germanGeometry.left).toBeGreaterThanOrEqual(0);
+  expect(germanGeometry.right).toBeLessThanOrEqual(germanGeometry.viewportWidth);
+  expect(germanGeometry.scrollWidth).toBeLessThanOrEqual(germanGeometry.clientWidth);
+  expect(
+    germanGeometry.rows.every(
+      ({ left, right }) => left >= germanGeometry.left && right <= germanGeometry.right,
+    ),
+  ).toBe(true);
+});
+
+test("conventional icon-only TopBar controls expose pointer tooltips", async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 760 });
+  await setSession(page, false);
+  await page.goto("/");
+
+  const topBar = page.locator("[data-app-top-bar]");
+  for (const name of ["Search", "Log in"]) {
+    await topBar
+      .getByRole(name === "Search" ? "link" : "button", {
+        name,
+        exact: true,
+      })
+      .hover();
+    await expect(page.getByRole("tooltip", { name })).toBeVisible();
+    await expect(topBar.getByLabel(name, { exact: true })).toHaveAccessibleName(name);
+    await expect(topBar.getByLabel(name, { exact: true })).not.toHaveAttribute(
+      "aria-describedby",
+    );
+    await page.reload();
+  }
+
+  const navigation = await primaryNavigation(page);
+  await navigation.locator('[data-navigation-id="more"]').click();
+  await page.getByRole("dialog", { name: "More" }).getByRole("link", { name: "Articles" }).click();
+  const back = topBar.getByRole("button", { name: "Go back" });
+  await back.hover();
+  await expect(page.getByRole("tooltip", { name: "Go back" })).toBeVisible();
+  await expect(back).toHaveAccessibleName("Go back");
+  await expect(back).not.toHaveAttribute("aria-describedby");
+
+  await setSession(page, true);
+  await page.reload();
+  const account = topBar.getByRole("button", { name: "Account menu" });
+  await account.hover();
+  await expect(page.getByRole("tooltip", { name: "Account menu" })).toBeVisible();
+  await expect(account).toHaveAccessibleName("Account menu");
+  await expect(account).not.toHaveAttribute("aria-describedby");
+  await account.click();
+  await expect(page.getByRole("menuitem", { name: "Revenue share" })).toBeVisible();
+  await expect(page.getByRole("tooltip", { name: "Account menu" })).toBeHidden();
+
+  await page.keyboard.press("Escape");
+  await page.reload();
+  for (let index = 0; index < 6 && !(await account.evaluate((element) => element === document.activeElement)); index += 1) {
+    await page.keyboard.press("Tab");
+  }
+  await expect(account).toBeFocused();
+  expect(await account.evaluate((element) => element.matches(":focus-visible"))).toBe(true);
+  expect(
+    await account.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return style.boxShadow !== "none" || style.outlineStyle !== "none";
+    }),
+  ).toBe(true);
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("menuitem", { name: "Revenue share" })).toBeVisible();
+  await expect(page.getByRole("tooltip", { name: "Account menu" })).toBeHidden();
+});
+
+test.describe("touch icon controls", () => {
+  test.use({ hasTouch: true });
+
+  test("search, back, and account menu act on the first touch", async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 760 });
+    await setSession(page, true);
+    await page.goto("/");
+
+    const topBar = page.locator("[data-app-top-bar]");
+    await topBar.getByRole("button", { name: "Account menu" }).tap();
+    await expect(page.getByRole("menuitem", { name: "Revenue share" })).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    await topBar.getByRole("link", { name: "Search", exact: true }).tap();
+    await expect(page).toHaveURL(/\/search$/);
+    await topBar.getByRole("button", { name: "Go back" }).tap();
+    await expect(page).toHaveURL(/\/$/);
+  });
 });
 
 test("More sheet keeps controls inside native horizontal safe areas", async ({ page }) => {
@@ -239,9 +389,8 @@ test("grouped desktop navigation stays reachable in a short landscape viewport",
 
   const navigation = page.getByRole("navigation", { name: "App navigation" });
   const revenueShare = navigation.getByRole("link", {
-    name: "Apply for revenue share",
+    name: "Revenue share",
   });
-  const footer = page.locator("[data-sidebar-footer]");
   const metrics = await navigation.evaluate((element) => ({
     clientHeight: element.clientHeight,
     overflowY: getComputedStyle(element).overflowY,
@@ -252,5 +401,5 @@ test("grouped desktop navigation stays reachable in a short landscape viewport",
   expect(metrics.scrollHeight).toBeGreaterThanOrEqual(metrics.clientHeight);
   await revenueShare.scrollIntoViewIfNeeded();
   await expect(revenueShare).toBeVisible();
-  await expect(footer).toBeVisible();
+  await expect(page.locator("[data-sidebar-footer]")).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary

- remove the decorative desktop footer copy from persistent navigation
- standardize persistent navigation, account chrome, and every KYC destination heading on **Revenue share**
- keep **Apply for revenue share** on the explicit profile action, and preserve all money, seed, KYC-step, save, submit, and confirmation labels
- add pointer/focus tooltips to conventional icon-only back, mobile-search, account, and login controls while keeping one authoritative accessible name
- add 320px German proxy, tooltip-composition, keyboard, touch-first-activation, focus-visible, and overflow regressions

## UI/UX ruling and literal budget

The five-item mobile bar remains visibly labeled: Home, Live, AI, Wallet, More. No unfamiliar action was mechanically iconified.

The issue's rough inventory moves from about **781 to 778 user-facing literal sites**:

- two decorative footer literals are deleted
- the duplicate `Log in` icon-control literal is consolidated with the other shared icon-control names
- tooltip text reuses those names, so it adds no new translation concept

The German proxy uses `Start / Live / KI / Wallet / Mehr`, `Umsatzbeteiligung für Kreative`, and the localized More rows at 320px. The primary bar, destination heading, and sheet remain inside their boxes with no horizontal scroll.

## Verification

Exact head `e9b1ada97f1572529cbd0013c725c210e9338745` on base `1b900be7fa7e35f9435897608930dc5d187125ce`:

- `CI=1 npx playwright test tests/navigation.pw.ts --grep 'German proxy' --repeat-each=10` — 10/10 pass with two workers
- `npm test` — 274 Vitest, 7 boundary contracts, 36 Playwright; all pass
- `npm run typecheck`
- `npm run build`
- `npm run test:store-listing` — 37/37
- `npm run store:validate`
- `npm run icons:check`
- `npm run release:verify`
- `node scripts/verify-ci-cache-policy.mjs`
- `scripts/check-rust-toolchain.sh`
- `npm audit --audit-level=high` — no high/critical; existing moderate findings only
- `gitleaks git --log-opts='origin/main..HEAD'`
- `git diff --check origin/main...HEAD`

Hosted exact-head evidence:

- wallet gate run **32278590766** — frontend, formatting, supply chain, lints, shared plugin, backend, and aggregate gate all green
- packaging run **32278590402** — release identity, unsigned Android AAB, unsigned iOS target app, Linux packages, and macOS universal app all green

The post-#423 rebase preserves the intended app patch and does not modify its remote-data/loading files or the store audit contracts.

The first hosted run exposed a test-only locator defect: after replacing the heading text with the German proxy, a second evaluation re-resolved the live locator by its obsolete accessible name. The regression now mutates and measures the same resolved element atomically; the localization geometry assertion remains intact and passed a 10-repeat CI-mode soak before this exact head was pushed.

## Adversarial review

The nested Radix `TooltipTrigger -> DropdownMenuTrigger` account control was exercised by pointer, keyboard, and touch. The menu opens on first activation, tooltip closes rather than overlapping the menu, keyboard focus remains visibly styled, and the trigger keeps the single accessible name `Account menu` without a duplicate `aria-describedby`. Back and search navigate on the first touch. Existing explicit financial, recovery, compliance, and application-action copy remains intact.

Closes #323.
