### PR TITLE
fix(zuuli): restore scroll by history entry

### DIFF
--- a/wallet/zuuli/src/components/layout/AppShell.tsx
+++ b/wallet/zuuli/src/components/layout/AppShell.tsx
@@ -4,6 +4,8 @@ import { TopBar } from "./TopBar";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { TriangleAlert } from "lucide-react";
 import { useWallet } from "@/store/wallet";
+import { useRouteScroll } from "@/hooks/useRouteScroll";
+import { RouteScrollProvider } from "./route-scroll";
 
 function LegacyWalletNotice() {
   const legacy = useWallet((state) => state.status?.legacyAppData);
@@ -29,8 +31,9 @@ function LegacyWalletNotice() {
   );
 }
 
-export function AppShell() {
+function AppShellContent() {
   const location = useLocation();
+  const { registerViewport } = useRouteScroll();
   // AI and login each own a bounded internal scroll region while the header
   // and mobile tabs stay pinned. Keep those routes in a plain, height-bound
   // main instead of nesting their scroll owners inside the generic page
@@ -49,7 +52,11 @@ export function AppShell() {
             <Outlet />
           </main>
         ) : (
-          <ScrollArea className="min-h-0 min-w-0 max-w-full flex-1" data-route-scroll>
+          <ScrollArea
+            className="min-h-0 min-w-0 max-w-full flex-1"
+            data-route-scroll
+            viewportRef={registerViewport}
+          >
             <main className="app-scroll-content mx-auto w-full min-w-0 max-w-6xl px-4 pt-6 md:px-8">
               <Outlet />
             </main>
@@ -58,5 +65,13 @@ export function AppShell() {
       </div>
       <MobileTabBar />
     </div>
+  );
+}
+
+export function AppShell() {
+  return (
+    <RouteScrollProvider>
+      <AppShellContent />
+    </RouteScrollProvider>
   );
 }

--- a/wallet/zuuli/src/components/layout/Sidebar.tsx
+++ b/wallet/zuuli/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { Wordmark } from "@/components/brand/Logo";
 import {
@@ -19,6 +19,7 @@ import {
   NAVIGATION_GROUP_ORDER,
   type NavigationRoute,
 } from "./navigation";
+import { useRouteScroll } from "@/hooks/useRouteScroll";
 
 const desktopLinkClass = ({ isActive }: { isActive: boolean }) =>
   cn(
@@ -27,6 +28,46 @@ const desktopLinkClass = ({ isActive }: { isActive: boolean }) =>
       ? "bg-primary/15 text-primary"
       : "text-muted-foreground hover:bg-secondary hover:text-foreground",
   );
+
+function useActiveRouteRetap(item: NavigationRoute) {
+  const location = useLocation();
+  const { scrollToTop } = useRouteScroll();
+
+  return (event: MouseEvent<HTMLAnchorElement>) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      !isNavigationRouteActive(item, location.pathname) ||
+      location.pathname !== item.to
+    ) {
+      return;
+    }
+    event.preventDefault();
+    scrollToTop();
+  };
+}
+
+function DesktopRoute({ item }: { item: NavigationRoute }) {
+  const onClick = useActiveRouteRetap(item);
+  const Icon = item.icon;
+
+  return (
+    <NavLink
+      to={item.to}
+      end={item.end}
+      aria-label={item.accessibleLabel}
+      className={desktopLinkClass}
+      onClick={onClick}
+    >
+      <Icon className="h-[18px] w-[18px]" aria-hidden />
+      <span aria-hidden>{item.label}</span>
+    </NavLink>
+  );
+}
 
 export function Sidebar() {
   const signedIn = useSession((state) => Boolean(state.user));
@@ -59,17 +100,8 @@ export function Sidebar() {
                 {NAVIGATION_GROUP_LABELS[group]}
               </h2>
               <div className="flex flex-col gap-1">
-                {groupRoutes.map(({ to, label, accessibleLabel, icon: Icon, end }) => (
-                  <NavLink
-                    key={to}
-                    to={to}
-                    end={end}
-                    aria-label={accessibleLabel}
-                    className={desktopLinkClass}
-                  >
-                    <Icon className="h-[18px] w-[18px]" aria-hidden />
-                    <span aria-hidden>{label}</span>
-                  </NavLink>
+                {groupRoutes.map((item) => (
+                  <DesktopRoute key={item.to} item={item} />
                 ))}
               </div>
             </section>
@@ -81,6 +113,7 @@ export function Sidebar() {
 }
 
 function MobileRoute({ item }: { item: NavigationRoute }) {
+  const onClick = useActiveRouteRetap(item);
   const visibleLabel =
     item.mobile.area === "primary" ? item.mobile.label : item.label;
 
@@ -90,6 +123,7 @@ function MobileRoute({ item }: { item: NavigationRoute }) {
       end={item.end}
       aria-label={item.accessibleLabel}
       data-navigation-id={item.id}
+      onClick={onClick}
       className={({ isActive }) =>
         cn(
           "min-tap flex min-w-0 flex-col items-center justify-center gap-1 text-[10px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
@@ -98,9 +132,45 @@ function MobileRoute({ item }: { item: NavigationRoute }) {
       }
     >
       <item.icon className="h-5 w-5" aria-hidden />
-      <span className="max-w-full whitespace-nowrap px-0.5 leading-none" aria-hidden>
+      <span
+        className="max-w-full whitespace-nowrap px-0.5 leading-none"
+        aria-hidden
+      >
         {visibleLabel}
       </span>
+    </NavLink>
+  );
+}
+
+function MobileMoreRoute({
+  item,
+  onSelect,
+}: {
+  item: NavigationRoute;
+  onSelect: () => void;
+}) {
+  const onRetap = useActiveRouteRetap(item);
+
+  return (
+    <NavLink
+      to={item.to}
+      end={item.end}
+      aria-label={item.accessibleLabel}
+      onClick={(event) => {
+        onRetap(event);
+        onSelect();
+      }}
+      className={({ isActive }) =>
+        cn(
+          "min-tap flex min-w-0 items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          isActive
+            ? "bg-primary/15 text-primary"
+            : "text-foreground hover:bg-secondary",
+        )
+      }
+    >
+      <item.icon className="h-5 w-5 shrink-0" aria-hidden />
+      <span className="min-w-0">{item.label}</span>
     </NavLink>
   );
 }
@@ -142,8 +212,13 @@ export function MobileTabBar() {
                 )}
               >
                 <Icon className="h-5 w-5" aria-hidden />
-                <span className="whitespace-nowrap px-0.5 leading-none" aria-hidden>
-                  {item.mobile.area === "primary" ? item.mobile.label : item.label}
+                <span
+                  className="whitespace-nowrap px-0.5 leading-none"
+                  aria-hidden
+                >
+                  {item.mobile.area === "primary"
+                    ? item.mobile.label
+                    : item.label}
                 </span>
               </button>
             </DialogTrigger>
@@ -160,24 +235,11 @@ export function MobileTabBar() {
               </div>
               <nav className="mt-2 grid gap-1" aria-label="More navigation">
                 {moreItems.map((moreItem) => (
-                  <NavLink
+                  <MobileMoreRoute
                     key={moreItem.id}
-                    to={moreItem.to}
-                    end={moreItem.end}
-                    aria-label={moreItem.accessibleLabel}
-                    onClick={() => setMoreOpen(false)}
-                    className={({ isActive }) =>
-                      cn(
-                        "min-tap flex min-w-0 items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                        isActive
-                          ? "bg-primary/15 text-primary"
-                          : "text-foreground hover:bg-secondary",
-                      )
-                    }
-                  >
-                    <moreItem.icon className="h-5 w-5 shrink-0" aria-hidden />
-                    <span className="min-w-0">{moreItem.label}</span>
-                  </NavLink>
+                    item={moreItem}
+                    onSelect={() => setMoreOpen(false)}
+                  />
                 ))}
               </nav>
             </DialogContent>

--- a/wallet/zuuli/src/components/layout/route-scroll.test.ts
+++ b/wallet/zuuli/src/components/layout/route-scroll.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  browserHistoryEntryKey,
+  normalizedInitialHistoryState,
+  ScrollPositionStore,
+} from "./route-scroll";
+
+describe("ScrollPositionStore", () => {
+  it("keeps distinct history-entry offsets and refreshes restored entries", () => {
+    const positions = new ScrollPositionStore(3);
+    positions.remember("a", 120);
+    positions.remember("b", 340);
+    positions.remember("c", 560);
+
+    expect(positions.recall("a")).toBe(120);
+    positions.remember("d", 780);
+
+    expect(positions.recall("b")).toBeUndefined();
+    expect(positions.recall("c")).toBe(560);
+    expect(positions.recall("d")).toBe(780);
+    expect(positions.size).toBe(3);
+    expect(positions.has("a")).toBe(true);
+    expect(positions.has("b")).toBe(false);
+  });
+
+  it("bounds hostile offsets and never grows past its limit", () => {
+    const positions = new ScrollPositionStore(2);
+    positions.remember("negative", -20);
+    positions.remember("infinite", Number.POSITIVE_INFINITY);
+    positions.remember("huge", Number.MAX_VALUE);
+
+    expect(positions.recall("negative")).toBeUndefined();
+    expect(positions.recall("infinite")).toBe(0);
+    expect(positions.recall("huge")).toBe(Number.MAX_SAFE_INTEGER);
+    expect(positions.size).toBe(2);
+  });
+});
+
+describe("browserHistoryEntryKey", () => {
+  it("accepts the exact non-empty React Router history key", () => {
+    expect(browserHistoryEntryKey({ usr: null, key: "entry-2", idx: 2 })).toBe(
+      "entry-2",
+    );
+  });
+
+  it.each([null, undefined, [], {}, { key: "" }, { key: 2 }])(
+    "fails closed for malformed history state %#",
+    (state) => {
+      expect(browserHistoryEntryKey(state)).toBeNull();
+    },
+  );
+});
+
+describe("normalizedInitialHistoryState", () => {
+  it("adds BrowserRouter's default key only to its exact initial state", () => {
+    expect(normalizedInitialHistoryState({ idx: 0 }, "default")).toEqual({
+      idx: 0,
+      key: "default",
+    });
+  });
+
+  it.each([
+    [{ idx: 0 }, "unexpected"],
+    [{ idx: 1 }, "default"],
+    [{ idx: 0, usr: null }, "default"],
+    [{ idx: 0, hostile: true }, "default"],
+    [null, "default"],
+  ])("rejects malformed or non-initial state %#", (state, locationKey) => {
+    expect(normalizedInitialHistoryState(state, locationKey)).toBeNull();
+  });
+});

--- a/wallet/zuuli/src/components/layout/route-scroll.tsx
+++ b/wallet/zuuli/src/components/layout/route-scroll.tsx
@@ -1,0 +1,339 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useLocation, useNavigationType } from "react-router-dom";
+import {
+  RouteScrollContextProvider,
+  type RouteScrollContextValue,
+} from "@/hooks/useRouteScroll";
+
+export const MAX_SAVED_SCROLL_ENTRIES = 64;
+export const MAX_PENDING_RESTORE_MS = 30_000;
+
+/** A small insertion-ordered history-entry cache with finite numeric offsets. */
+export class ScrollPositionStore {
+  readonly #limit: number;
+  readonly #offsets = new Map<string, number>();
+
+  constructor(limit = MAX_SAVED_SCROLL_ENTRIES) {
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new Error("Scroll position limit must be a positive integer");
+    }
+    this.#limit = limit;
+  }
+
+  remember(key: string, offset: number) {
+    if (!key) return;
+    const finiteOffset = Number.isFinite(offset)
+      ? Math.min(Math.max(0, offset), Number.MAX_SAFE_INTEGER)
+      : 0;
+    this.#offsets.delete(key);
+    this.#offsets.set(key, finiteOffset);
+    while (this.#offsets.size > this.#limit) {
+      const oldest = this.#offsets.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.#offsets.delete(oldest);
+    }
+  }
+
+  recall(key: string) {
+    const offset = this.#offsets.get(key);
+    if (offset === undefined) return undefined;
+    // A restored entry becomes the newest one without changing its value.
+    this.#offsets.delete(key);
+    this.#offsets.set(key, offset);
+    return offset;
+  }
+
+  has(key: string) {
+    return this.#offsets.has(key);
+  }
+
+  get size() {
+    return this.#offsets.size;
+  }
+}
+
+type CurrentEntry = {
+  key: string;
+  navigationType: ReturnType<typeof useNavigationType>;
+};
+
+function positionForEntry(store: ScrollPositionStore, entry: CurrentEntry) {
+  // Initial loads are reported as POP, but have no saved entry and therefore
+  // deliberately start at the top. Router hashes are retained in the URL but
+  // do not invoke native window scrolling: in-page Markdown anchors own their
+  // explicit scrollIntoView behavior, while cross-entry/deep-link navigation
+  // follows the same top/POP contract as every other route.
+  return entry.navigationType === "POP" ? (store.recall(entry.key) ?? 0) : 0;
+}
+
+export function browserHistoryEntryKey(state: unknown) {
+  if (state === null || typeof state !== "object" || Array.isArray(state)) {
+    return null;
+  }
+  const key = Reflect.get(state, "key");
+  return typeof key === "string" && key.length > 0 ? key : null;
+}
+
+export function normalizedInitialHistoryState(
+  state: unknown,
+  locationKey: string,
+) {
+  // BrowserRouter's initial entry is the one deliberate exception to its
+  // normal { usr, key, idx } state: it starts as { idx: 0 } while exposing the
+  // location key "default". Normalize only that exact known shape. Unknown
+  // history state remains untrusted and scroll recording stays fail-closed.
+  if (
+    locationKey !== "default" ||
+    state === null ||
+    typeof state !== "object" ||
+    Array.isArray(state) ||
+    Object.keys(state).length !== 1 ||
+    Reflect.get(state, "idx") !== 0
+  ) {
+    return null;
+  }
+  return { idx: 0, key: locationKey };
+}
+
+export function RouteScrollProvider({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  const storeRef = useRef(new ScrollPositionStore());
+  const registeredViewportRef = useRef<HTMLDivElement | null>(null);
+  const registeredViewportCleanupRef = useRef<(() => void) | null>(null);
+  const recordingEntryKeyRef = useRef(location.key);
+  const lastRecordedOffsetRef = useRef<{ key: string; offset: number } | null>(
+    null,
+  );
+  const pendingRestoreCleanupRef = useRef<(() => void) | null>(null);
+  const [viewport, setViewport] = useState<HTMLDivElement | null>(null);
+  const currentEntryRef = useRef<CurrentEntry>({
+    key: location.key,
+    navigationType,
+  });
+  currentEntryRef.current = { key: location.key, navigationType };
+
+  const applyEntryPosition = useCallback(
+    (node: HTMLDivElement, entry: CurrentEntry) => {
+      pendingRestoreCleanupRef.current?.();
+      pendingRestoreCleanupRef.current = null;
+
+      const target = positionForEntry(storeRef.current, entry);
+      const apply = () => {
+        node.scrollTop = target;
+        lastRecordedOffsetRef.current = {
+          key: entry.key,
+          offset: node.scrollTop,
+        };
+      };
+      apply();
+
+      // A POP can remount an async route while it still contains only a short
+      // loading skeleton. It can also accept the target immediately and then
+      // let browser scroll anchoring move it when late route content appears.
+      // Keep the entry's real target through that bounded content-ready window,
+      // unless the user starts interacting.
+      if (entry.navigationType === "POP" && target > 0) {
+        let animationFrame: number | null = null;
+        const reapplyBeforePaint = () => {
+          apply();
+          if (animationFrame !== null)
+            window.cancelAnimationFrame(animationFrame);
+          // Scroll anchoring is resolved during layout. Reassert immediately
+          // before paint as well as in the mutation microtask.
+          animationFrame = window.requestAnimationFrame(() => {
+            animationFrame = null;
+            apply();
+          });
+        };
+        let resizeObserver: ResizeObserver | null = new ResizeObserver(() => {
+          reapplyBeforePaint();
+        });
+        let observedContentBoxes = new Set<Element>();
+        const observeContentBoxes = () => {
+          const nextContentBoxes = new Set<Element>([node]);
+          for (const child of node.children) {
+            if (child instanceof Element) nextContentBoxes.add(child);
+          }
+          for (const observed of observedContentBoxes) {
+            if (!nextContentBoxes.has(observed))
+              resizeObserver?.unobserve(observed);
+          }
+          for (const contentBox of nextContentBoxes) {
+            if (!observedContentBoxes.has(contentBox)) {
+              resizeObserver?.observe(contentBox, { box: "border-box" });
+            }
+          }
+          observedContentBoxes = nextContentBoxes;
+        };
+        let mutationObserver: MutationObserver | null = new MutationObserver(
+          () => {
+            observeContentBoxes();
+            reapplyBeforePaint();
+          },
+        );
+        const cancelForUser = () => cleanup();
+        const timeout = window.setTimeout(
+          () => cleanup(),
+          MAX_PENDING_RESTORE_MS,
+        );
+        const cleanup = () => {
+          mutationObserver?.disconnect();
+          mutationObserver = null;
+          resizeObserver?.disconnect();
+          resizeObserver = null;
+          observedContentBoxes.clear();
+          if (animationFrame !== null) {
+            window.cancelAnimationFrame(animationFrame);
+            animationFrame = null;
+          }
+          window.clearTimeout(timeout);
+          window.removeEventListener("pointerdown", cancelForUser, true);
+          window.removeEventListener("touchstart", cancelForUser, true);
+          window.removeEventListener("wheel", cancelForUser, true);
+          window.removeEventListener("keydown", cancelForUser, true);
+          if (pendingRestoreCleanupRef.current === cleanup) {
+            pendingRestoreCleanupRef.current = null;
+          }
+        };
+        observeContentBoxes();
+        mutationObserver.observe(node, { childList: true, subtree: true });
+        // Do not end on a short quiet period: real route requests can remain
+        // quiet for seconds before replacing their loading skeleton. The hard
+        // deadline keeps the cost bounded, while callbacks run only for real
+        // DOM or box-size changes (there is no polling).
+        // Capture at the window boundary so touching a Radix scrollbar (which
+        // is a viewport sibling) also yields immediately to the user.
+        window.addEventListener("pointerdown", cancelForUser, {
+          capture: true,
+          passive: true,
+        });
+        window.addEventListener("touchstart", cancelForUser, {
+          capture: true,
+          passive: true,
+        });
+        window.addEventListener("wheel", cancelForUser, {
+          capture: true,
+          passive: true,
+        });
+        window.addEventListener("keydown", cancelForUser, true);
+        pendingRestoreCleanupRef.current = cleanup;
+      }
+    },
+    [],
+  );
+
+  const registerViewport = useCallback(
+    (node: HTMLDivElement | null) => {
+      registeredViewportCleanupRef.current?.();
+      registeredViewportCleanupRef.current = null;
+      if (!node) {
+        pendingRestoreCleanupRef.current?.();
+        pendingRestoreCleanupRef.current = null;
+      }
+      registeredViewportRef.current = node;
+      setViewport((current) => (current === node ? current : node));
+      // Callback refs run during the commit. Applying here covers a newly
+      // mounted generic/full-bleed owner before the browser can paint it.
+      if (node) {
+        recordingEntryKeyRef.current = currentEntryRef.current.key;
+        const recordActualOffset = () => {
+          const key = recordingEntryKeyRef.current;
+          // React Router installs the destination history state before React
+          // commits its new route. During that boundary, browser anchoring can
+          // emit clamp events from the departing DOM. Accept scroll events only
+          // while the browser and installed React entry identities agree. This
+          // freezes the last delivered current-entry offset symmetrically for
+          // PUSH, REPLACE, back, and forward without relying on listener order.
+          if (browserHistoryEntryKey(window.history.state) !== key) return;
+          const offset = node.scrollTop;
+          lastRecordedOffsetRef.current = { key, offset };
+          storeRef.current.remember(key, offset);
+        };
+        node.addEventListener("scroll", recordActualOffset, { passive: true });
+        registeredViewportCleanupRef.current = () => {
+          node.removeEventListener("scroll", recordActualOffset);
+        };
+        applyEntryPosition(node, currentEntryRef.current);
+      }
+    },
+    [applyEntryPosition],
+  );
+
+  useLayoutEffect(() => {
+    if (browserHistoryEntryKey(window.history.state) !== null) return;
+    const normalized = normalizedInitialHistoryState(
+      window.history.state,
+      location.key,
+    );
+    if (normalized) window.history.replaceState(normalized, "");
+  }, [location.key]);
+
+  useLayoutEffect(() => {
+    const node = registeredViewportRef.current;
+    const entry = { key: location.key, navigationType };
+    if (node) {
+      // Switch the scroll event's history-entry identity only after the old
+      // layout cleanup has persisted its final offset. Programmatic resets
+      // are then harmlessly recorded against the new entry, never the old one.
+      recordingEntryKeyRef.current = entry.key;
+      applyEntryPosition(node, entry);
+    }
+    return () => {
+      pendingRestoreCleanupRef.current?.();
+      pendingRestoreCleanupRef.current = null;
+      // Capture the element itself. Across the generic/full-bleed boundary its
+      // ref is detached during mutation before this layout cleanup runs, but
+      // the detached element still carries the route's actual final offset.
+      if (node) {
+        const last = lastRecordedOffsetRef.current;
+        if (last?.key === entry.key) {
+          storeRef.current.remember(entry.key, last.offset);
+        } else if (!storeRef.current.has(entry.key)) {
+          // A replacement viewport may attach before this old owner's layout
+          // cleanup. Never overwrite a live scroll-event value with a detached
+          // element whose content has already been clamped by the mutation.
+          storeRef.current.remember(entry.key, node.scrollTop);
+        }
+      }
+    };
+  }, [applyEntryPosition, location.key, navigationType]);
+
+  useLayoutEffect(() => {
+    const previous = window.history.scrollRestoration;
+    window.history.scrollRestoration = "manual";
+    return () => {
+      window.history.scrollRestoration = previous;
+    };
+  }, []);
+
+  const scrollToTop = useCallback(() => {
+    pendingRestoreCleanupRef.current?.();
+    pendingRestoreCleanupRef.current = null;
+    const node = registeredViewportRef.current;
+    if (node) node.scrollTop = 0;
+    lastRecordedOffsetRef.current = {
+      key: currentEntryRef.current.key,
+      offset: 0,
+    };
+    storeRef.current.remember(currentEntryRef.current.key, 0);
+  }, []);
+
+  const value = useMemo<RouteScrollContextValue>(
+    () => ({ registerViewport, scrollToTop, viewport }),
+    [registerViewport, scrollToTop, viewport],
+  );
+
+  return (
+    <RouteScrollContextProvider value={value}>
+      {children}
+    </RouteScrollContextProvider>
+  );
+}

--- a/wallet/zuuli/src/components/ui/scroll-area.tsx
+++ b/wallet/zuuli/src/components/ui/scroll-area.tsx
@@ -2,10 +2,17 @@ import * as React from "react";
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 import { cn } from "@/lib/utils";
 
+type ScrollAreaViewport = React.ElementRef<typeof ScrollAreaPrimitive.Viewport>;
+type ScrollAreaProps = React.ComponentPropsWithoutRef<
+  typeof ScrollAreaPrimitive.Root
+> & {
+  viewportRef?: React.Ref<ScrollAreaViewport>;
+};
+
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+  ScrollAreaProps
+>(({ className, children, viewportRef, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
     className={cn("relative min-w-0 max-w-full overflow-hidden", className)}
@@ -13,6 +20,7 @@ const ScrollArea = React.forwardRef<
   >
     {/* Radix's max-content table wrapper must not widen a vertical page scroller. */}
     <ScrollAreaPrimitive.Viewport
+      ref={viewportRef}
       className="h-full w-full min-w-0 max-w-full rounded-[inherit] [&>div]:!block [&>div]:w-full [&>div]:min-w-0 [&>div]:max-w-full"
       data-scroll-area-viewport
     >
@@ -44,4 +52,4 @@ const ScrollBar = React.forwardRef<
 ));
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
 
-export { ScrollArea, ScrollBar };
+export { ScrollArea, ScrollBar, type ScrollAreaViewport };

--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { Markdown } from "@/components/common/Markdown";
+import { useRouteScroll } from "@/hooks/useRouteScroll";
 import { ai } from "@/lib/api/free2z";
 import { ApiError } from "@/lib/api/http";
 import type { AIModel, Personality } from "@/lib/api/types";
@@ -92,6 +93,7 @@ function conversationKey(model: AIModel, personality: Personality | null): strin
 }
 
 export default function AiFeature() {
+  const { registerViewport } = useRouteScroll();
   const user = useSession((s) => s.user);
   const tuzis = useSession((s) => s.tuzis);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
@@ -171,6 +173,7 @@ export default function AiFeature() {
 
   // Keep the latest message in view.
   useEffect(() => {
+    if (messages.length === 0) return;
     bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [messages]);
 
@@ -404,7 +407,11 @@ export default function AiFeature() {
       </div>
 
       {/* ── Thread ──────────────────────────────────────────────────── */}
-      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-4 py-6 md:px-8">
+      <div
+        ref={registerViewport}
+        className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-4 py-6 md:px-8"
+        data-route-scroll
+      >
         {messages.length === 0 ? (
           <EmptyHero
             selected={selected}

--- a/wallet/zuuli/src/features/articles/components/ArticleCard.tsx
+++ b/wallet/zuuli/src/features/articles/components/ArticleCard.tsx
@@ -25,6 +25,7 @@ export function ArticleCard({
 
   return (
     <Card
+      data-article-card
       className={cn(
         "group flex flex-col overflow-hidden rounded-xl border-border/60 bg-card/60 transition-colors hover:border-primary/40",
         className,

--- a/wallet/zuuli/src/features/articles/pages/Feed.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Feed.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { Loader2, Newspaper, PenLine, Search, Sparkles, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/common/EmptyState";
 import { PageHeader } from "@/components/common/PageHeader";
+import { useRouteScroll } from "@/hooks/useRouteScroll";
 import { cn } from "@/lib/utils";
 import type { ArticleSort } from "@/lib/api/types";
 import { ArticleCard, ArticleCardSkeleton } from "../components/ArticleCard";
@@ -18,6 +19,7 @@ const SORTS: { value: ArticleSort; label: string }[] = [
 ];
 
 export function Feed() {
+  const { viewport } = useRouteScroll();
   const [sort, setSort] = useState<ArticleSort>("popular");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [searchInput, setSearchInput] = useState("");
@@ -54,19 +56,18 @@ export function Feed() {
     );
 
   // Infinite scroll: fire loadMore when the sentinel scrolls into view.
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const [sentinel, setSentinel] = useState<HTMLDivElement | null>(null);
   useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el) return;
+    if (!sentinel || !viewport) return;
     const io = new IntersectionObserver(
       (entries) => {
         if (entries.some((e) => e.isIntersecting)) loadMore();
       },
-      { rootMargin: "600px 0px" },
+      { root: viewport, rootMargin: "600px 0px" },
     );
-    io.observe(el);
+    io.observe(sentinel);
     return () => io.disconnect();
-  }, [loadMore]);
+  }, [loadMore, sentinel, viewport]);
 
   const hasFilters = selectedTags.length > 0 || search.length > 0;
   const showTagBar = knownTags.length > 0;
@@ -255,7 +256,13 @@ export function Feed() {
           {grid}
 
           {/* Infinite-scroll sentinel + loading / end states */}
-          <div ref={sentinelRef} aria-hidden className="h-px w-full" />
+          <div
+            ref={setSentinel}
+            aria-hidden
+            className="h-px w-full"
+            data-article-feed-sentinel
+            data-observer-root-ready={viewport ? "true" : "false"}
+          />
           {loadingMore ? (
             <div className="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {Array.from({ length: 3 }).map((_, i) => (

--- a/wallet/zuuli/src/features/auth/index.tsx
+++ b/wallet/zuuli/src/features/auth/index.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useWallet } from "@/store/wallet";
 import { SocialButtons } from "@/components/common/SocialButtons";
+import { useRouteScroll } from "@/hooks/useRouteScroll";
 import { BrandPanel } from "./BrandPanel";
 import { ClassicLoginForm } from "./ClassicLoginForm";
 import { ZcashLoginFlow } from "./ZcashLoginFlow";
@@ -42,6 +43,7 @@ export type AuthMethod = "chooser" | "zcash" | "password";
 
 export default function AuthFeature() {
   const location = useLocation();
+  const { registerViewport } = useRouteScroll();
   const loginDestination = loginDestinationFromState(location.state);
   const bootstrap = useWallet((s) => s.bootstrap);
   const [method, setMethod] = useState<AuthMethod>("chooser");
@@ -52,6 +54,7 @@ export default function AuthFeature() {
 
   return (
     <div
+      ref={registerViewport}
       className="grid h-full min-h-0 w-full grid-cols-1 overflow-y-auto bg-background lg:grid-cols-2"
       data-route-scroll
     >

--- a/wallet/zuuli/src/hooks/useRouteScroll.tsx
+++ b/wallet/zuuli/src/hooks/useRouteScroll.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export type RouteScrollContextValue = {
+  registerViewport: (node: HTMLDivElement | null) => void;
+  scrollToTop: () => void;
+  viewport: HTMLDivElement | null;
+};
+
+const RouteScrollContext = createContext<RouteScrollContextValue | null>(null);
+
+export function RouteScrollContextProvider({
+  children,
+  value,
+}: {
+  children: ReactNode;
+  value: RouteScrollContextValue;
+}) {
+  return (
+    <RouteScrollContext.Provider value={value}>
+      {children}
+    </RouteScrollContext.Provider>
+  );
+}
+
+export function useRouteScroll() {
+  const value = useContext(RouteScrollContext);
+  if (!value)
+    throw new Error("useRouteScroll must be used inside RouteScrollProvider");
+  return value;
+}

--- a/wallet/zuuli/tests/scroll-restoration.pw.ts
+++ b/wallet/zuuli/tests/scroll-restoration.pw.ts
@@ -1,0 +1,378 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+async function setSession(page: Page, signedIn: boolean) {
+  await page.addInitScript((authenticated) => {
+    const key = "zuuli.knox.token";
+    if (authenticated) localStorage.setItem(key, "mock-knox-token");
+    else localStorage.removeItem(key);
+  }, signedIn);
+}
+
+function genericViewport(page: Page) {
+  return page.locator("[data-scroll-area-viewport]");
+}
+
+async function setOffset(scroller: Locator, requested: number) {
+  const offset = await scroller.evaluate(
+    (element, target) =>
+      new Promise<number>((resolve) => {
+        element.scrollTop = Math.min(
+          target,
+          Math.max(0, element.scrollHeight - element.clientHeight),
+        );
+        requestAnimationFrame(() => resolve(element.scrollTop));
+      }),
+    requested,
+  );
+  expect(offset).toBeGreaterThan(100);
+  return offset;
+}
+
+async function expectOffset(scroller: Locator, expected: number) {
+  await expect
+    .poll(() => scroller.evaluate((element) => element.scrollTop))
+    .toBeCloseTo(expected, 0);
+}
+
+test("fresh Articles uses the Radix viewport and loads only page 1 at the top", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 568 });
+  await setSession(page, false);
+  await page.addInitScript(() => {
+    const NativeIntersectionObserver = window.IntersectionObserver;
+    const roots: boolean[] = [];
+    const RecordingIntersectionObserver = function (
+      callback: IntersectionObserverCallback,
+      options?: IntersectionObserverInit,
+    ) {
+      roots.push(
+        options?.root instanceof HTMLElement &&
+          options.root.hasAttribute("data-scroll-area-viewport"),
+      );
+      return new NativeIntersectionObserver(callback, options);
+    } as unknown as typeof IntersectionObserver;
+    RecordingIntersectionObserver.prototype =
+      NativeIntersectionObserver.prototype;
+    window.IntersectionObserver = RecordingIntersectionObserver;
+    (
+      window as Window & { __zuuliArticleObserverRoots?: boolean[] }
+    ).__zuuliArticleObserverRoots = roots;
+  });
+
+  await page.goto("/articles");
+  const scroller = genericViewport(page);
+  await expect(scroller).toBeVisible();
+  await expect(page.locator("[data-article-card]")).toHaveCount(24);
+  await expectOffset(scroller, 0);
+  await expect(page.locator("[data-article-feed-sentinel]")).toHaveAttribute(
+    "data-observer-root-ready",
+    "true",
+  );
+
+  await expect(page.locator("[data-article-card]")).toHaveCount(24);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as Window & { __zuuliArticleObserverRoots?: boolean[] })
+            .__zuuliArticleObserverRoots,
+      ),
+    )
+    .toEqual([true]);
+  await page.waitForTimeout(900);
+  await expect(page.locator("[data-article-card]")).toHaveCount(24);
+  await expect(page.locator("[data-article-feed-sentinel]")).toHaveCount(1);
+});
+
+test("PUSH resets before paint and POP restores distinct history entries", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1024, height: 640 });
+  await setSession(page, false);
+  await page.goto("/");
+  await page.waitForTimeout(900);
+
+  const scroller = genericViewport(page);
+  const homeOffset = await setOffset(scroller, 720);
+  await page.evaluate(() => {
+    const originalPushState = history.pushState.bind(history);
+    const offsets: number[] = [];
+    history.pushState = function (...args) {
+      originalPushState(...args);
+      requestAnimationFrame(() => {
+        offsets.push(
+          document.querySelector<HTMLElement>("[data-scroll-area-viewport]")
+            ?.scrollTop ?? -1,
+        );
+      });
+    };
+    (
+      window as Window & { __zuuliFirstPaintOffsets?: number[] }
+    ).__zuuliFirstPaintOffsets = offsets;
+  });
+
+  await page
+    .getByRole("navigation", { name: "App navigation" })
+    .getByRole("link", { name: "Articles" })
+    .click();
+  await expect(page).toHaveURL(/\/articles$/);
+  await expect(page.locator("[data-article-card]")).toHaveCount(24);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as Window & { __zuuliFirstPaintOffsets?: number[] })
+            .__zuuliFirstPaintOffsets?.[0],
+      ),
+    )
+    .toBe(0);
+  await expectOffset(scroller, 0);
+
+  await setOffset(scroller, 980);
+  // The asynchronously populated tag bar can trigger browser scroll anchoring
+  // after the first cards arrive. Snapshot the entry's settled, actual offset
+  // immediately before leaving; that is the value POP must restore.
+  await page.waitForTimeout(150);
+  const articlesOffset = await scroller.evaluate(
+    (element) => element.scrollTop,
+  );
+  expect(articlesOffset).toBeGreaterThan(100);
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await expectOffset(scroller, homeOffset);
+
+  await page.goForward();
+  await expect(page).toHaveURL(/\/articles$/);
+  await expect(page.locator("[data-article-card]")).toHaveCount(24);
+  await expectOffset(scroller, articlesOffset);
+
+  await page
+    .locator("[data-app-top-bar]")
+    .getByRole("button", { name: "Go back" })
+    .click();
+  await expect(page).toHaveURL(/\/$/);
+  await expectOffset(scroller, homeOffset);
+
+  await page.goForward();
+  await expect(page).toHaveURL(/\/articles$/);
+  await expect(page.locator("[data-article-card]")).toHaveCount(24);
+  await expectOffset(scroller, articlesOffset);
+
+  // Stay pending beyond the former short deadline, then change only a content
+  // box size (no child-list mutation). ResizeObserver must reassert the saved
+  // entry before paint.
+  await page.waitForTimeout(3_100);
+  const resizeContent = async (kind: "padding" | "content") =>
+    scroller.evaluate(
+      (element, { target, resizeKind }) => {
+        element.scrollTop = target + 120;
+        const content = element.firstElementChild;
+        if (!(content instanceof HTMLElement))
+          throw new Error("missing scroll content");
+        if (resizeKind === "padding") {
+          content.style.paddingBottom = "1px";
+        } else {
+          content.style.minHeight = `${content.getBoundingClientRect().height + 1}px`;
+        }
+      },
+      { target: articlesOffset, resizeKind: kind },
+    );
+  await resizeContent("padding");
+  await expectOffset(scroller, articlesOffset);
+  await resizeContent("content");
+  await expectOffset(scroller, articlesOffset);
+
+  // The bounded async-content retry must yield to real input outside the
+  // viewport, not only events dispatched inside it. Use a real pointer action
+  // over pinned chrome, then move to the user's new offset. A later DOM
+  // mutation must not snap that position back to the restored target.
+  const topBarBox = await page.locator("[data-app-top-bar]").boundingBox();
+  expect(topBarBox).not.toBeNull();
+  const topBarPoint = {
+    x: topBarBox!.x + topBarBox!.width / 2,
+    y: topBarBox!.y + topBarBox!.height / 2,
+  };
+  let currentArticlesOffset = articlesOffset;
+  const assertInputWins = async (
+    interact: () => Promise<void>,
+    markerName: string,
+  ) => {
+    await interact();
+    currentArticlesOffset = await setOffset(
+      scroller,
+      currentArticlesOffset + 60,
+    );
+    await scroller.evaluate((element, marker) => {
+      const node = document.createElement("span");
+      node.hidden = true;
+      node.dataset.postRestoreMutation = marker;
+      element.append(node);
+    }, markerName);
+    await page.waitForTimeout(100);
+    await expectOffset(scroller, currentArticlesOffset);
+  };
+  const rearmPendingRestore = async () => {
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+    await expectOffset(scroller, homeOffset);
+    await page.goForward();
+    await expect(page).toHaveURL(/\/articles$/);
+    await expect(page.locator("[data-article-card]")).toHaveCount(24);
+    await expectOffset(scroller, currentArticlesOffset);
+  };
+
+  await assertInputWins(async () => {
+    await page.mouse.move(topBarPoint.x, topBarPoint.y);
+    await page.mouse.down();
+    await page.mouse.up();
+  }, "pointer");
+
+  await rearmPendingRestore();
+  await assertInputWins(async () => {
+    await page.mouse.move(topBarPoint.x, topBarPoint.y);
+    await page.mouse.wheel(0, 100);
+  }, "wheel");
+
+  await rearmPendingRestore();
+  await assertInputWins(async () => {
+    await page.keyboard.press("PageDown");
+  }, "keyboard");
+});
+
+test("generic and full-bleed owners hand off without leaking offsets", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1024, height: 640 });
+  await setSession(page, false);
+  await page.goto("/");
+  await page.waitForTimeout(900);
+
+  const generic = genericViewport(page);
+  const homeOffset = await setOffset(generic, 680);
+  await page
+    .getByRole("navigation", { name: "App navigation" })
+    .getByRole("link", { name: "Artificial intelligence" })
+    .click();
+  await expect(page).toHaveURL(/\/ai$/);
+  await expect(generic).toHaveCount(0);
+  const fullBleed = page.locator("main[data-route-frame] [data-route-scroll]");
+  await expect(fullBleed).toBeVisible();
+  await expectOffset(fullBleed, 0);
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(genericViewport(page)).toBeVisible();
+  await expectOffset(genericViewport(page), homeOffset);
+
+  await page.goForward();
+  await expect(page).toHaveURL(/\/ai$/);
+  await expectOffset(fullBleed, 0);
+  await page
+    .getByRole("navigation", { name: "App navigation" })
+    .getByRole("link", { name: "Articles" })
+    .click();
+  await expect(page).toHaveURL(/\/articles$/);
+  await expectOffset(genericViewport(page), 0);
+});
+
+test("active desktop tabs return to top by pointer and keyboard without navigation", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1024, height: 640 });
+  await setSession(page, false);
+  await page.goto("/");
+  await page.waitForTimeout(900);
+
+  const scroller = genericViewport(page);
+  const home = page
+    .getByRole("navigation", { name: "App navigation" })
+    .getByRole("link", { name: "Home", exact: true });
+  const historyLength = await page.evaluate(() => history.length);
+
+  await setOffset(scroller, 620);
+  await home.click();
+  await expectOffset(scroller, 0);
+  expect(await page.evaluate(() => history.length)).toBe(historyLength);
+
+  await setOffset(scroller, 540);
+  await home.focus();
+  await page.keyboard.press("Enter");
+  await expectOffset(scroller, 0);
+  await expect(home).toBeFocused();
+  expect(await page.evaluate(() => history.length)).toBe(historyLength);
+});
+
+test("a prefix-active tab still navigates from a child route to its destination", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1024, height: 640 });
+  await setSession(page, false);
+
+  await page.goto("/articles/nested-route-review");
+  const articles = page
+    .getByRole("navigation", { name: "App navigation" })
+    .getByRole("link", { name: "Articles" });
+  await expect(articles).toHaveAttribute("aria-current", "page");
+  await articles.click();
+  await expect(page).toHaveURL(/\/articles$/);
+  await expectOffset(genericViewport(page), 0);
+
+  await page.goto("/wallet/send");
+
+  const wallet = page
+    .getByRole("navigation", { name: "App navigation" })
+    .getByRole("link", { name: "Zcash wallet" });
+  await expect(wallet).toHaveAttribute("aria-current", "page");
+  await wallet.click();
+  await expect(page).toHaveURL(/\/wallet$/);
+  await expectOffset(genericViewport(page), 0);
+});
+
+test.describe("touch scroll restoration", () => {
+  test.use({ hasTouch: true });
+
+  test("the active mobile tab tops on first touch at 320x568 without overflow", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await setSession(page, false);
+    await page.goto("/");
+    await page.waitForTimeout(900);
+
+    const scroller = genericViewport(page);
+    await setOffset(scroller, 520);
+    const home = page
+      .getByRole("navigation", { name: "Primary navigation" })
+      .locator('[data-navigation-id="home"]');
+    await home.tap();
+    await expectOffset(scroller, 0);
+
+    const geometry = await page
+      .locator("[data-app-frame]")
+      .evaluate((frame) => ({
+        clientWidth: frame.clientWidth,
+        scrollWidth: frame.scrollWidth,
+        viewportClientWidth: document.documentElement.clientWidth,
+        viewportScrollWidth: document.documentElement.scrollWidth,
+      }));
+    expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth);
+    expect(geometry.viewportScrollWidth).toBeLessThanOrEqual(
+      geometry.viewportClientWidth,
+    );
+  });
+});
+
+test("fresh deep links and hashes deliberately start the custom owner at top", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 568 });
+  await setSession(page, true);
+  await page.goto("/profile#profile-p2paddr");
+  await expect(
+    page.getByRole("heading", { name: "Edit profile" }),
+  ).toBeVisible();
+  await expectOffset(genericViewport(page), 0);
+  await page.waitForTimeout(500);
+  await expectOffset(genericViewport(page), 0);
+});


### PR DESCRIPTION
Closes #333

## Summary
- restore the actual registered route scroller by React Router history-entry key on POP while resetting PUSH/REPLACE entries before paint
- expose the typed Radix viewport, register full-bleed AI/login owners, and bind Articles IntersectionObserver to the real viewport with a reactive sentinel
- return already-active exact-root desktop/mobile destinations to top on first pointer, touch, or keyboard activation while nested routes navigate normally to their section root
- bound saved offsets to 64 entries and async POP correction to 30 seconds, observing actual direct content boxes with border-box ResizeObserver and using MutationObserver only to track replacements
- cancel pending correction on route/ref/timeout and window-captured pointer/touch/wheel/key input, so late content cannot override genuine user scrolling

## Local verification
- `npm ci`
- `npm run typecheck`
- `npm run build`
- Vitest: 289/289
- boundary Node tests: 7/7
- Playwright exact full suite, zero retries: 43/43
- POP back/forward/app-back soak, 2 workers, zero retries: 5/5
- focused >3s border-box padding + intrinsic min-height growth and outside-viewport pointer/wheel/key cancellation: 1/1
- `npm run test:store-listing` (37/37)
- `npm run store:validate`
- `npm run icons:check`
- `npm run release:verify`
- `node scripts/verify-ci-cache-policy.mjs`
- `scripts/check-rust-toolchain.sh`
- `npm audit --audit-level=high` (no high/critical findings; existing moderate advisories remain)
- `git diff --check`
- gitleaks exact PR diff: no leaks

## Adversarial review
- clean-head Codex review on exact `011e5dc975dc03d009a66343ed48e74010c9c28f`: no actionable correctness regressions
- prior review findings fixed: nested prefix-active routes now navigate to section roots; feature code imports the documented shared hook layer
- prior review findings fixed: slow data is covered by a hard 30s bound; size-only growth uses explicit border-box ResizeObserver while replacements refresh the direct-box observation set
- verified BrowserRouter initial `{idx: 0}` normalization is exact-shape, idempotent, and unknown state fails closed
- verified native recording freezes on browser/React entry-key mismatch for PUSH, REPLACE, back, and forward
- verified StrictMode replay, route switch, ref detach, timeout, and user input clean observers/listeners
- verified 64-entry eviction, full-bleed handoff, deliberate hash policy, reactive sentinel lifecycle, exact observer root, and page-1-only fresh Articles behavior