### PR TITLE
fix(zuuli): restore existing Zcash identities

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/README.md
+++ b/wallet/plugins/tauri-plugin-zcash/README.md
@@ -57,7 +57,7 @@ All commands are invoked from TypeScript as `invoke("plugin:zcash|command_name",
 | Command | Args | Returns | Description |
 |---------|------|---------|-------------|
 | `create_wallet` | `CreateWalletArgs { mnemonicWordCount?, name? }` | `WalletCreated` | Generate new wallet with BIP-39 mnemonic, fetch birthday from chain tip |
-| `restore_wallet` | `RestoreWalletArgs { seedPhrase, birthdayHeight?, name? }` | `{ success: true }` | Restore wallet from existing seed phrase |
+| `restore_wallet` | `RestoreWalletArgs { seedPhrase, birthdayHeight?, name? }` | `WalletRestored { success, walletId }` | Restore a wallet and return the exact atomically published manifest identity |
 | `get_wallet_status` | — | `WalletStatus` | Check if wallet is initialized, has seed, synced height, active wallet info |
 | `retry_wallet_cleanup` | — | `WalletCleanupStatus` | Explicitly retry pending orphan cleanup and return diagnostics |
 | `get_seed_phrase` | — | `String` | Authenticate and retrieve the seed from platform-native custody |

--- a/wallet/plugins/tauri-plugin-zcash/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/commands.rs
@@ -522,16 +522,27 @@ pub(crate) async fn create_wallet<R: Runtime>(
 pub(crate) async fn restore_wallet<R: Runtime>(
     app: AppHandle<R>,
     args: RestoreWalletArgs,
-) -> Result<serde_json::Value> {
+) -> Result<WalletRestored> {
+    let RestoreWalletArgs {
+        seed_phrase,
+        birthday_height,
+        name,
+    } = args;
+    // Wrap renderer-supplied recovery material before the first await so a
+    // contended transition lock never leaves it in an ordinary String for the
+    // duration of the wait.
+    let seed_phrase = Zeroizing::new(seed_phrase);
     let zcash = app.zcash();
     let transition_guard = Arc::clone(&zcash.state.wallet_transition)
         .lock_owned()
         .await;
     let _send_guard = Arc::clone(&zcash.state.send_operation).lock_owned().await;
-    let mnemonic = keys::parse_mnemonic(&args.seed_phrase)?;
+    // Error text is deliberately generic (see `parse_mnemonic`) and must never
+    // echo a phrase word.
+    let mnemonic = keys::parse_mnemonic(seed_phrase.as_str())?;
     let seed = keys::mnemonic_to_seed(&mnemonic);
-    let birthday_height = args.birthday_height.unwrap_or(419200); // sapling activation
-    let wallet_name = args.name.unwrap_or_else(|| "Restored".to_string());
+    let birthday_height = birthday_height.unwrap_or(419200); // sapling activation
+    let wallet_name = name.unwrap_or_else(|| "Restored".to_string());
 
     // Stop any running sync and retain an identity-bound recovery obligation
     // until the restored wallet context has committed.
@@ -571,7 +582,9 @@ pub(crate) async fn restore_wallet<R: Runtime>(
         .map_err(|e| Error::DatabaseError(format!("failed to create birthday: {}", format_birthday_error(e))))?;
 
     // Allocate an identity, but keep it out of the durable manifest until its
-    // database and native seed custody have both committed.
+    // database and native seed custody have both committed. Unlike a newly
+    // generated key, restored custody is already backed up, so the prepared
+    // entry intentionally retains `backup_required = false`.
     let wallet_entry = crate::wallet::manifest::WalletManifest::prepare_wallet(
         wallet_name,
         Some(birthday_height),
@@ -730,7 +743,10 @@ pub(crate) async fn restore_wallet<R: Runtime>(
     )
     .await;
 
-    Ok(serde_json::json!({ "success": true }))
+    Ok(WalletRestored {
+        success: true,
+        wallet_id: wallet_entry.id.clone(),
+    })
     }
     .await;
 

--- a/wallet/plugins/tauri-plugin-zcash/src/models.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/models.rs
@@ -8,6 +8,18 @@ pub struct WalletCreated {
     pub birthday_height: u64,
 }
 
+/// Result of atomically restoring and publishing a wallet.
+///
+/// `wallet_id` identifies the exact manifest entry committed by the native
+/// transition. Callers must bind any follow-up identity operation to this ID
+/// rather than re-reading whichever wallet happens to be active later.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WalletRestored {
+    pub success: bool,
+    pub wallet_id: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WalletStatus {
@@ -66,6 +78,35 @@ impl From<crate::app_data_migration::MigrationOutcome> for LegacyAppDataStatus {
 #[cfg(test)]
 mod legacy_app_data_tests {
     use super::*;
+
+    #[test]
+    fn restored_wallet_result_binds_the_exact_manifest_identity() {
+        let value = serde_json::to_value(WalletRestored {
+            success: true,
+            wallet_id: "wallet-restored-123".to_owned(),
+        })
+        .expect("serialize restore result");
+
+        assert_eq!(value["success"], true);
+        assert_eq!(value["walletId"], "wallet-restored-123");
+        assert_eq!(value.as_object().expect("object").len(), 2);
+    }
+
+    #[test]
+    fn restore_arguments_redact_recovery_material_from_debug_output() {
+        let private_input = "private recovery material";
+        let debug = format!(
+            "{:?}",
+            RestoreWalletArgs {
+                seed_phrase: private_input.to_owned(),
+                birthday_height: Some(2_600_000),
+                name: Some("Recovered identity".to_owned()),
+            }
+        );
+
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains(private_input));
+    }
 
     #[test]
     fn preserved_conflict_serializes_as_structured_import_pending_status() {
@@ -187,12 +228,23 @@ pub struct CreateWalletArgs {
     pub name: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RestoreWalletArgs {
     pub seed_phrase: String,
     pub birthday_height: Option<u64>,
     pub name: Option<String>,
+}
+
+impl std::fmt::Debug for RestoreWalletArgs {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RestoreWalletArgs")
+            .field("seed_phrase", &"[REDACTED]")
+            .field("birthday_height", &self.birthday_height)
+            .field("name", &self.name)
+            .finish()
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/keys.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/keys.rs
@@ -29,7 +29,12 @@ pub fn generate_mnemonic(word_count: u32) -> Result<Mnemonic> {
 
 /// Parse an existing mnemonic phrase.
 pub fn parse_mnemonic(phrase: &str) -> Result<Mnemonic> {
-    Mnemonic::from_phrase(phrase).map_err(|e| Error::InvalidMnemonic(e.to_string()))
+    // Parser diagnostics can contain an invalid input word. Recovery material
+    // must never be copied into logs, IPC errors, toast text, or telemetry, so
+    // expose only a content-free validation result.
+    Mnemonic::from_phrase(phrase).map_err(|_| {
+        Error::InvalidMnemonic("recovery phrase is not a valid supported BIP39 mnemonic".to_owned())
+    })
 }
 
 /// Derive a seed from a mnemonic.
@@ -293,6 +298,29 @@ fn hex_encode(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
     use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
+
+    #[test]
+    fn parses_a_supported_bip39_recovery_phrase() {
+        let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let mnemonic = parse_mnemonic(phrase).expect("known BIP39 recovery phrase");
+
+        assert_eq!(mnemonic.phrase(), phrase);
+    }
+
+    #[test]
+    fn invalid_mnemonic_error_never_echoes_recovery_input() {
+        let private_input = "not-a-bip39-word private-recovery-material";
+        let error = parse_mnemonic(private_input).expect_err("phrase must be invalid");
+        let message = error.to_string();
+
+        assert_eq!(
+            message,
+            "invalid mnemonic: recovery phrase is not a valid supported BIP39 mnemonic"
+        );
+        for word in private_input.split_whitespace() {
+            assert!(!message.contains(word));
+        }
+    }
 
     /// Sign a fixed challenge with a fixed seed, then INDEPENDENTLY recover the
     /// signing pubkey from the recoverable signature + reconstructed digest and

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/manifest.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/manifest.rs
@@ -539,6 +539,7 @@ mod replacement_tests {
         };
         let entry = WalletManifest::prepare_wallet("Staged".into(), Some(42));
 
+        assert!(!entry.backup_required);
         assert!(manifest.wallets.is_empty());
         assert!(manifest.active_wallet_id.is_none());
         assert!(!WalletManifest::manifest_path(&data_dir).exists());

--- a/wallet/zuuallet/src/lib/tauri.ts
+++ b/wallet/zuuallet/src/lib/tauri.ts
@@ -30,7 +30,7 @@ export async function restoreWallet(
   seedPhrase: string,
   birthdayHeight?: number,
   name?: string,
-): Promise<{ success: boolean }> {
+): Promise<{ success: boolean; walletId: string }> {
   return invoke("plugin:zcash|restore_wallet", {
     args: { seedPhrase, birthdayHeight, name },
   });

--- a/wallet/zuuli/scripts/auth-session-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/auth-session-boundary.node-test.mjs
@@ -38,3 +38,37 @@ test("uncommitted profile probes use a private explicit token header", () => {
   assert.match(requestBody, /opts\.authToken \?\? getToken\(\)/);
   assert.match(requestBody, /headers\["Authorization"\] = `Token \$\{token\}`/);
 });
+
+test("recovery phrases cannot enter browser persistence, URLs, logs, or toasts", () => {
+  const flow = readFileSync(
+    new URL("../src/features/auth/useZcashChallengeFlow.ts", import.meta.url),
+    "utf8",
+  );
+  const form = readFileSync(
+    new URL("../src/features/auth/RestoreIdentity.tsx", import.meta.url),
+    "utf8",
+  );
+  const restoreFlow = between(
+    flow,
+    "  const restoreIdentity = useCallback",
+    "  const createIdentity = useCallback",
+  );
+
+  for (const source of [restoreFlow, form]) {
+    assert.doesNotMatch(source, /localStorage\s*\./);
+    assert.doesNotMatch(source, /sessionStorage\s*\./);
+    assert.doesNotMatch(source, /URLSearchParams|location\.(?:href|search|hash)/);
+    assert.doesNotMatch(source, /console\.(?:debug|info|log|warn|error)\s*\(/);
+    assert.doesNotMatch(source, /toast\s*\./);
+  }
+
+  assert.match(
+    restoreFlow,
+    /const restoration = wallet\.restoreWallet\([\s\S]*?seedPhrase = "";[\s\S]*?const restored = await restoration;/,
+  );
+  assert.match(
+    restoreFlow,
+    /clearPhrase\(\);[\s\S]*?await useWallet\.getState\(\)\.bootstrap\(\);[\s\S]*?if \(!isCurrent\(\)\) return;[\s\S]*?await runCrypto/,
+  );
+  assert.doesNotMatch(form, /await onRestore\(/);
+});

--- a/wallet/zuuli/src/features/auth/RestoreIdentity.tsx
+++ b/wallet/zuuli/src/features/auth/RestoreIdentity.tsx
@@ -1,0 +1,207 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
+import { ArrowLeft, Eye, EyeOff, Loader2, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+const SUPPORTED_WORD_COUNTS = new Set([12, 15, 18, 21, 24]);
+
+interface RestoreIdentityProps {
+  restoring: boolean;
+  error: string | null;
+  onCancel: () => void;
+  onRestore: (
+    seedPhrase: string,
+    birthdayHeight: number | undefined,
+    clearPhrase: () => void,
+  ) => Promise<void>;
+}
+
+export function RestoreIdentity({
+  restoring,
+  error,
+  onCancel,
+  onRestore,
+}: RestoreIdentityProps) {
+  const recoveryId = useId();
+  const birthdayId = useId();
+  const phraseRef = useRef("");
+  const [seedPhrase, setSeedPhrase] = useState("");
+  const [birthday, setBirthday] = useState("");
+  const [revealed, setRevealed] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const normalizedPhrase = useMemo(
+    () => seedPhrase.trim().replace(/\s+/g, " "),
+    [seedPhrase],
+  );
+  const wordCount = normalizedPhrase ? normalizedPhrase.split(" ").length : 0;
+  const supportedWordCount = SUPPORTED_WORD_COUNTS.has(wordCount);
+
+  useEffect(() => {
+    return () => {
+      // The phrase is renderer-only and must not survive a method switch,
+      // close, route change, or completed restore.
+      phraseRef.current = "";
+    };
+  }, []);
+
+  const clearPhrase = () => {
+    phraseRef.current = "";
+    setSeedPhrase("");
+    setRevealed(false);
+  };
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    setLocalError(null);
+    if (!normalizedPhrase) {
+      setLocalError("Enter your recovery phrase.");
+      return;
+    }
+
+    const birthdayHeight = birthday ? Number(birthday) : undefined;
+    if (
+      birthdayHeight !== undefined &&
+      (!Number.isSafeInteger(birthdayHeight) || birthdayHeight < 0)
+    ) {
+      setLocalError("Enter a valid birthday height.");
+      return;
+    }
+
+    // Do not keep an async form-frame alive with another reference to the
+    // phrase. The flow owns the native promise and reports status through its
+    // phase/error state.
+    void onRestore(normalizedPhrase, birthdayHeight, clearPhrase);
+  };
+
+  return (
+    <form
+      className="animate-slide-up space-y-4"
+      data-auth-restore
+      onSubmit={submit}
+    >
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="min-tap h-11 w-11 shrink-0"
+          onClick={() => {
+            clearPhrase();
+            onCancel();
+          }}
+          disabled={restoring}
+          aria-label="Back to identity choices"
+        >
+          <ArrowLeft aria-hidden />
+        </Button>
+        <div className="min-w-0">
+          <h2 className="font-semibold">Use existing identity</h2>
+          <p className="text-xs text-muted-foreground">
+            Restore locally with your recovery phrase.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <Label htmlFor={recoveryId}>Recovery phrase</Label>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="min-tap shrink-0 text-muted-foreground"
+            onClick={() => setRevealed((value) => !value)}
+            disabled={restoring || !seedPhrase}
+            aria-pressed={revealed}
+          >
+            {revealed ? <EyeOff aria-hidden /> : <Eye aria-hidden />}
+            {revealed ? "Hide" : "Show"}
+          </Button>
+        </div>
+        <Textarea
+          id={recoveryId}
+          value={seedPhrase}
+          onChange={(event) => {
+            phraseRef.current = event.target.value;
+            setSeedPhrase(event.target.value);
+          }}
+          placeholder="Words separated by spaces"
+          spellCheck={false}
+          autoComplete="off"
+          autoCapitalize="none"
+          autoCorrect="off"
+          disabled={restoring}
+          aria-describedby={`${recoveryId}-hint`}
+          className={cn(
+            "min-h-20 resize-none font-mono",
+            !revealed && seedPhrase && "[-webkit-text-security:disc] [text-security:disc]",
+          )}
+        />
+        <div
+          id={`${recoveryId}-hint`}
+          className="flex min-w-0 items-start justify-between gap-3 text-xs text-muted-foreground"
+        >
+          <span className="min-w-0">Never sent to free2z.</span>
+          <span
+            className={cn(
+              "shrink-0 tabular-nums",
+              wordCount && supportedWordCount && "text-emerald-400",
+            )}
+          >
+            {wordCount || 0} words
+          </span>
+        </div>
+        {wordCount > 0 && !supportedWordCount && (
+          <p className="text-xs text-amber-300">
+            Supported phrases usually have 12, 15, 18, 21, or 24 words. Native
+            validation makes the final check.
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor={birthdayId}>
+          Birthday height <span className="text-muted-foreground">(optional)</span>
+        </Label>
+        <Input
+          id={birthdayId}
+          value={birthday}
+          onChange={(event) => setBirthday(event.target.value.replace(/[^\d]/g, ""))}
+          inputMode="numeric"
+          placeholder="Faster wallet scan"
+          className="min-tap tabular-nums"
+          disabled={restoring}
+        />
+      </div>
+
+      {(localError || error) && (
+        <p role="alert" className="text-sm text-destructive">
+          {localError ?? error}
+        </p>
+      )}
+
+      <Button type="submit" size="lg" className="w-full" disabled={restoring}>
+        {restoring ? (
+          <Loader2 className="animate-spin" aria-hidden />
+        ) : (
+          <RotateCcw aria-hidden />
+        )}
+        {restoring ? "Restoring identity…" : "Restore and continue"}
+      </Button>
+
+      <p className="text-center text-xs text-muted-foreground">
+        External wallet signing isn’t supported yet.
+      </p>
+    </form>
+  );
+}

--- a/wallet/zuuli/src/features/auth/ZcashLoginFlow.tsx
+++ b/wallet/zuuli/src/features/auth/ZcashLoginFlow.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { truncateAddress } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { SeedReveal } from "./SeedReveal";
+import { RestoreIdentity } from "./RestoreIdentity";
 import type { LoginDestination } from "@/lib/auth/login-destination";
 import {
   STEP_META,
@@ -71,6 +72,9 @@ export function ZcashLoginFlow({
     seedPhrase,
     error,
     start,
+    showRestoreIdentity,
+    cancelRestoreIdentity,
+    restoreIdentity,
     createIdentity,
     revealSeedBackup,
     confirmSeedSaved,
@@ -80,6 +84,7 @@ export function ZcashLoginFlow({
   useEffect(() => {
     const busy =
       phase === "running" ||
+      phase === "restoring" ||
       phase === "creating" ||
       phase === "loadingSeed" ||
       phase === "confirmingBackup" ||
@@ -153,34 +158,69 @@ export function ZcashLoginFlow({
     );
   }
 
-  // ── No wallet yet — offer to mint an identity ─────────────────────────────
+  if (phase === "restoreIdentity" || phase === "restoring") {
+    return (
+      <RestoreIdentity
+        restoring={phase === "restoring"}
+        error={error}
+        onCancel={cancelRestoreIdentity}
+        onRestore={(...args) => {
+          onBusyChange?.(true);
+          return restoreIdentity(...args).finally(() => onBusyChange?.(false));
+        }}
+      />
+    );
+  }
+
+  // ── No wallet yet — separate recovery from new identity creation ─────────
   if (phase === "needsWallet" || phase === "creating") {
     const creating = phase === "creating";
     return (
-      <div className="animate-slide-up space-y-5">
-        <div className="rounded-lg border border-border bg-background/40 p-4">
+      <div className="animate-slide-up space-y-4">
+        <div className="rounded-lg border border-border bg-background/40 p-3">
           <p className="text-sm font-medium">No Zcash identity on this device</p>
           <p className="mt-1 text-sm text-muted-foreground">
-            Create one now. We generate a Zcash key that becomes your DID — your
-            login, owned entirely by you.
+            Restore the key already linked to your account.
           </p>
         </div>
         <Button
-          size="xl"
+          size="lg"
           className="w-full"
-          onClick={() => {
-            onBusyChange?.(true);
-            void createIdentity();
-          }}
+          onClick={showRestoreIdentity}
           disabled={creating}
         >
-          {creating ? (
-            <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
-          ) : (
-            <Sparkles className="h-5 w-5" aria-hidden />
-          )}
-          {creating ? "Creating your identity…" : "Create a Zcash identity"}
+          <Fingerprint className="h-5 w-5" aria-hidden />
+          Use existing identity
         </Button>
+
+        <div className="flex items-center gap-3" aria-hidden>
+          <span className="h-px flex-1 bg-border" />
+          <span className="text-xs uppercase tracking-wider text-muted-foreground">or</span>
+          <span className="h-px flex-1 bg-border" />
+        </div>
+
+        <div className="space-y-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
+          <p className="text-sm text-amber-100">
+            A new key creates a distinct identity and may open a different account.
+          </p>
+          <Button
+            size="lg"
+            variant="outline"
+            className="w-full"
+            onClick={() => {
+              onBusyChange?.(true);
+              void createIdentity();
+            }}
+            disabled={creating}
+          >
+            {creating ? (
+              <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+            ) : (
+              <Sparkles className="h-5 w-5" aria-hidden />
+            )}
+            {creating ? "Creating identity…" : "Create new identity"}
+          </Button>
+        </div>
       </div>
     );
   }
@@ -276,7 +316,10 @@ export function ZcashLoginFlow({
 
       {phase === "error" && (
         <div className="space-y-3 animate-fade-in">
-          <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+          >
             <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
             <span>{error ?? "The login could not be completed."}</span>
           </div>

--- a/wallet/zuuli/src/features/auth/auth-density.test.tsx
+++ b/wallet/zuuli/src/features/auth/auth-density.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthChooser, SelectedAuthMethod } from "./index";
+import { RestoreIdentity } from "./RestoreIdentity";
 
 function render(ui: React.ReactNode): string {
   return renderToStaticMarkup(
@@ -65,5 +66,34 @@ describe("selected auth methods", () => {
     expect(markup).toContain("<h1>Password</h1>");
     expect(markup).toContain('for="f2z-username"');
     expect(markup).toContain('for="f2z-password"');
+  });
+});
+
+describe("existing Zcash identity recovery", () => {
+  it("keeps recovery local, masked, accessible, and explicit about signer support", () => {
+    const markup = render(
+      <RestoreIdentity
+        restoring={false}
+        error={null}
+        onCancel={vi.fn()}
+        onRestore={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("data-auth-restore");
+    expect(markup).toContain("Use existing identity");
+    expect(markup).toContain("Never sent to free2z");
+    expect(markup).toContain("External wallet signing isn’t supported yet");
+    expect(markup).toContain('aria-label="Back to identity choices"');
+    expect(markup).toContain('autoComplete="off"');
+    expect(markup).toContain('autoCapitalize="none"');
+    expect(markup).toContain('autoCorrect="off"');
+    expect(markup).toContain('spellcheck="false"');
+    expect(markup).toContain("Restore and continue");
+    expect(markup).not.toContain("Create new identity");
+
+    for (const [control] of markup.matchAll(/<(?:button|input|textarea)[^>]+>/g)) {
+      expect(control).toMatch(/(?:min-tap|h-11|min-h-20)/);
+    }
   });
 });

--- a/wallet/zuuli/src/features/auth/useZcashChallengeFlow.ts
+++ b/wallet/zuuli/src/features/auth/useZcashChallengeFlow.ts
@@ -21,6 +21,7 @@ import type { SignedChallenge } from "@/lib/wallet/types";
 import { auth } from "@/lib/api/free2z";
 import type { AuthUser } from "@/lib/api/types";
 import { useAttemptLease, type IsCurrentAttempt } from "@/hooks/useAttemptLease";
+import { useWallet } from "@/store/wallet";
 
 export type StepKey = "prepare" | "challenge" | "sign" | "verify";
 export type StepStatus = "pending" | "active" | "done" | "error";
@@ -28,7 +29,9 @@ export type StepStatus = "pending" | "active" | "done" | "error";
 export type Phase =
   | "idle" // nothing started yet
   | "running" // walking the crypto steps
-  | "needsWallet" // no wallet on device — offer to create one
+  | "needsWallet" // no wallet on device — choose restore or create
+  | "restoreIdentity" // entering an existing recovery phrase
+  | "restoring" // native restore is atomically publishing that identity
   | "creating" // minting a fresh identity
   | "backupRequired" // durable backup gate resumed from native custody
   | "loadingSeed" // authenticating native custody for an explicit reveal
@@ -79,6 +82,13 @@ export interface ZcashChallengeFlowState {
   /** Convenience: 0-based index of the currently active/next step. */
   activeIndex: number;
   start: () => void;
+  showRestoreIdentity: () => void;
+  cancelRestoreIdentity: () => void;
+  restoreIdentity: (
+    seedPhrase: string,
+    birthdayHeight: number | undefined,
+    clearPhrase: () => void,
+  ) => Promise<void>;
   createIdentity: () => Promise<void>;
   revealSeedBackup: () => Promise<void>;
   confirmSeedSaved: () => Promise<void>;
@@ -157,11 +167,28 @@ export function useZcashChallengeFlow(
   }, []);
 
   // The crypto half of the flow: challenge → sign → verify → done.
-  const runCrypto = useCallback(async (isCurrent: IsCurrentAttempt) => {
+  const runCrypto = useCallback(async (
+    isCurrent: IsCurrentAttempt,
+    expectedWalletId?: string,
+  ) => {
     // Track which step is in flight so a failure lands on the right row and
     // gets the right friendly message.
     let stage: StepKey = "prepare";
     try {
+      if (expectedWalletId) {
+        const status = await wallet.getWalletStatus();
+        if (!isCurrent()) return;
+        if (
+          !status.initialized ||
+          status.activeWalletId !== expectedWalletId ||
+          status.backupRequired
+        ) {
+          throw new Error(
+            "The selected Zcash identity is no longer active. Try again.",
+          );
+        }
+      }
+
       // The identity is the wallet's transparent P2PKH t-address — the one
       // the plugin signs with and the one free2z verifies via zcashd
       // `verifymessage`. The server challenge MUST be requested for THIS
@@ -171,6 +198,24 @@ export function useZcashChallengeFlow(
       // misses and fails as "challenge does not match".
       const addr = await wallet.getLoginAddress(0);
       if (!isCurrent()) return;
+
+      // Restore returns the exact manifest identity committed by native code.
+      // Recheck after deriving the address, immediately before the first
+      // network operation, so a concurrent wallet switch cannot substitute a
+      // different local identity into the original login attempt.
+      if (expectedWalletId) {
+        const status = await wallet.getWalletStatus();
+        if (!isCurrent()) return;
+        if (
+          !status.initialized ||
+          status.activeWalletId !== expectedWalletId ||
+          status.backupRequired
+        ) {
+          throw new Error(
+            "The selected Zcash identity is no longer active. Try again.",
+          );
+        }
+      }
       setAddress(addr);
 
       // 2 — Ask the SERVER for the challenge to sign. The one-time,
@@ -193,6 +238,11 @@ export function useZcashChallengeFlow(
       if (!isCurrent()) return;
       const signed = await wallet.signChallenge(challenge);
       if (!isCurrent()) return;
+      if (signed.address !== addr || signed.challenge !== challenge) {
+        throw new Error(
+          "The active Zcash identity changed before signing. No login was sent.",
+        );
+      }
       setStep("sign", "done");
 
       // 4 — Verify with free2z (login or associate — see `config.verify`).
@@ -239,6 +289,9 @@ export function useZcashChallengeFlow(
         setPhase("needsWallet");
         return;
       }
+      if (!status.activeWalletId) {
+        throw new Error("The active Zcash identity is unavailable.");
+      }
       if (status.backupRequired) {
         runningRef.current = false;
         setBackupWalletId(status.activeWalletId);
@@ -246,7 +299,7 @@ export function useZcashChallengeFlow(
         return;
       }
       setStep("prepare", "done");
-      await runCrypto(isCurrent);
+      await runCrypto(isCurrent, status.activeWalletId);
     } catch (e) {
       if (!isCurrent()) return;
       setStep("prepare", "error");
@@ -259,6 +312,76 @@ export function useZcashChallengeFlow(
   const start = useCallback(() => {
     void prepareAndRun();
   }, [prepareAndRun]);
+
+  const showRestoreIdentity = useCallback(() => {
+    attempt.invalidate();
+    runningRef.current = false;
+    setError(null);
+    setPhase("restoreIdentity");
+  }, [attempt]);
+
+  const cancelRestoreIdentity = useCallback(() => {
+    attempt.invalidate();
+    runningRef.current = false;
+    setError(null);
+    setPhase("needsWallet");
+  }, [attempt]);
+
+  const restoreIdentity = useCallback(async (
+    seedPhrase: string,
+    birthdayHeight: number | undefined,
+    clearPhrase: () => void,
+  ) => {
+    if (runningRef.current) return;
+    const isCurrent = attempt.begin();
+    runningRef.current = true;
+    setError(null);
+    setPhase("restoring");
+    try {
+      const restoration = wallet.restoreWallet(
+        seedPhrase,
+        birthdayHeight,
+        "Recovered identity",
+      );
+      // Drop this flow-local binding before waiting on native I/O. JavaScript
+      // strings cannot be zeroized, and the IPC argument object may retain its
+      // immutable copy until serialization; the renderer guarantee is no
+      // persistence, logging, toast, URL, or network transport, plus clearing
+      // the editable state immediately after native custody succeeds.
+      seedPhrase = "";
+      const restored = await restoration;
+      if (!isCurrent()) {
+        clearPhrase();
+        return;
+      }
+      if (!restored.success || !restored.walletId) {
+        throw new Error("The recovery phrase could not be restored.");
+      }
+      // Clear the editable renderer state immediately after successful native
+      // custody, before any identity/network continuation.
+      clearPhrase();
+      // The app-level bootstrap may already have cached `initialized: false`.
+      // Publish the restored wallet to the shared renderer store before login
+      // continues so Wallet does not show onboarding until the next reload.
+      await useWallet.getState().bootstrap();
+      if (!isCurrent()) return;
+      setPhase("running");
+      setStep("prepare", "done");
+      await runCrypto(isCurrent, restored.walletId);
+    } catch {
+      if (!isCurrent()) return;
+      // Native mnemonic diagnostics are intentionally content-free. Keep the
+      // renderer message fixed as a second defense against phrase leakage,
+      // while acknowledging that words, birthday, network, or native custody
+      // can each prevent restoration.
+      setError(
+        "Couldn't restore this identity. Check the recovery words, birthday, and connection, then try again.",
+      );
+      setPhase("restoreIdentity");
+    } finally {
+      if (isCurrent()) runningRef.current = false;
+    }
+  }, [attempt, runCrypto, setStep]);
 
   const createIdentity = useCallback(async () => {
     if (runningRef.current) return;
@@ -295,7 +418,7 @@ export function useZcashChallengeFlow(
       }
       if (!status.backupRequired) {
         setStep("prepare", "done");
-        await runCrypto(isCurrent);
+        await runCrypto(isCurrent, status.activeWalletId);
         return;
       }
       const phrase = await wallet.getBackupSeedPhrase(status.activeWalletId);
@@ -325,7 +448,7 @@ export function useZcashChallengeFlow(
       setSeedPhrase(null);
       setPhase("running");
       setStep("prepare", "done");
-      await runCrypto(isCurrent);
+      await runCrypto(isCurrent, backupWalletId);
     } catch (e) {
       if (!isCurrent()) return;
       setError(errMessage(e));
@@ -367,6 +490,9 @@ export function useZcashChallengeFlow(
     error,
     activeIndex,
     start,
+    showRestoreIdentity,
+    cancelRestoreIdentity,
+    restoreIdentity,
     createIdentity,
     revealSeedBackup,
     confirmSeedSaved,

--- a/wallet/zuuli/src/lib/wallet/bridge.ts
+++ b/wallet/zuuli/src/lib/wallet/bridge.ts
@@ -20,6 +20,7 @@ import type {
   SyncStatus,
   TransactionEntry,
   WalletCreated,
+  WalletRestored,
   WalletCleanupStatus,
   WalletStatus,
 } from "./types";
@@ -37,12 +38,18 @@ export const wallet = {
     return invoke("create_wallet", { args: { mnemonicWordCount, name } });
   },
 
-  async restoreWallet(
+  restoreWallet(
     seedPhrase: string,
     birthdayHeight?: number,
     name?: string,
-  ): Promise<{ success: boolean }> {
-    if (useMock()) return mockWallet.restoreWallet();
+  ): Promise<WalletRestored> {
+    if (useMock()) {
+      try {
+        return Promise.resolve(mockWallet.restoreWallet(seedPhrase));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
     return invoke("restore_wallet", { args: { seedPhrase, birthdayHeight, name } });
   },
 

--- a/wallet/zuuli/src/lib/wallet/mock.test.ts
+++ b/wallet/zuuli/src/lib/wallet/mock.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { mockWallet } from "./mock";
 
+const RECOVERY_PHRASE =
+  "wisdom shadow orchard zebra pledge notice frost violet render " +
+  "summer harvest mirror canyon velvet ranch fossil pupil sunset " +
+  "quantum ledger prosper anchor beyond zephyr";
+
 describe("mockWallet.parsePaymentUri", () => {
   it("preserves an exact eight-decimal URI amount", () => {
     expect(mockWallet.parsePaymentUri("zcash:u1test?amount=1.00000001").amount).toBe(
@@ -16,4 +21,30 @@ describe("mockWallet.parsePaymentUri", () => {
       ).toThrow("Invalid ZEC amount");
     },
   );
+});
+
+describe("mockWallet.restoreWallet", () => {
+  it("returns the exact published wallet identity without a backup obligation", async () => {
+    expect(await mockWallet.restoreWallet(RECOVERY_PHRASE)).toEqual({
+      success: true,
+      walletId: "mock-wallet-0",
+    });
+    expect(mockWallet.getWalletStatus()).toMatchObject({
+      activeWalletId: "mock-wallet-0",
+      backupRequired: false,
+      initialized: true,
+    });
+  });
+
+  it("rejects invalid recovery input without echoing it", () => {
+    const privateInput = "private invalid recovery material";
+    expect(() => mockWallet.restoreWallet(privateInput)).toThrow(
+      "Recovery phrase is not a valid supported BIP39 mnemonic.",
+    );
+    try {
+      mockWallet.restoreWallet(privateInput);
+    } catch (error) {
+      expect(String(error)).not.toContain(privateInput);
+    }
+  });
 });

--- a/wallet/zuuli/src/lib/wallet/mock.ts
+++ b/wallet/zuuli/src/lib/wallet/mock.ts
@@ -12,6 +12,7 @@ import type {
   SyncStatus,
   TransactionEntry,
   WalletCreated,
+  WalletRestored,
   WalletStatus,
 } from "./types";
 import { parseZecToZatoshis } from "../format";
@@ -38,10 +39,24 @@ const MOCK_WALLET_SCENARIO_KEY = "zuuli.mock.wallet-scenario";
 const MOCK_CREATED_WALLET_KEY = "zuuli.mock.created-wallet";
 const MOCK_BACKUP_REQUIRED_KEY = "zuuli.mock.backup-required";
 const MOCK_WALLET_ID = "mock-wallet-0";
-function mockWalletScenario(): "empty" | "sign-error" | null {
+function mockWalletScenario():
+  | "empty"
+  | "sign-error"
+  | "identity-switch"
+  | "wallet-switch"
+  | "slow-restore"
+  | "slow-restore-error"
+  | null {
   try {
     const value = globalThis.localStorage?.getItem(MOCK_WALLET_SCENARIO_KEY);
-    return value === "empty" || value === "sign-error" ? value : null;
+    return value === "empty" ||
+      value === "sign-error" ||
+      value === "identity-switch" ||
+      value === "wallet-switch" ||
+      value === "slow-restore" ||
+      value === "slow-restore-error"
+      ? value
+      : null;
   } catch {
     return null;
   }
@@ -87,14 +102,27 @@ let proposalCounter = 1;
 export const mockWallet = {
   getWalletStatus(): WalletStatus {
     const persistedCreated = globalThis.localStorage?.getItem(MOCK_CREATED_WALLET_KEY) === "1";
+    const scenario = mockWalletScenario();
+    const needsRestore = [
+      "empty",
+      "identity-switch",
+      "wallet-switch",
+      "slow-restore",
+      "slow-restore-error",
+    ].includes(scenario ?? "");
     const initialized =
-      mockWalletScenario() === "empty" && !persistedCreated ? false : created || persistedCreated;
+      needsRestore && !persistedCreated ? false : created || persistedCreated;
     return {
       initialized,
       hasSeed: initialized,
       syncedHeight: synced,
       chainTip: tip,
-      activeWalletId: initialized ? MOCK_WALLET_ID : null,
+      activeWalletId:
+        initialized && scenario === "wallet-switch"
+          ? "mock-wallet-switched-after-restore"
+          : initialized
+            ? MOCK_WALLET_ID
+            : null,
       activeWalletName: "Main",
       walletCount: 1,
       backupRequired:
@@ -129,10 +157,28 @@ export const mockWallet = {
     globalThis.localStorage?.setItem(MOCK_BACKUP_REQUIRED_KEY, MOCK_WALLET_ID);
     return { walletId: MOCK_WALLET_ID, seedPhrase: MOCK_SEED, birthdayHeight: tip - 100 };
   },
-  restoreWallet() {
-    created = true;
-    globalThis.localStorage?.removeItem(MOCK_BACKUP_REQUIRED_KEY);
-    return { success: true };
+  restoreWallet(seedPhrase: string): WalletRestored | Promise<WalletRestored> {
+    if (mockWalletScenario() === "slow-restore-error") {
+      return new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error("Recovery phrase is not a valid supported BIP39 mnemonic.")),
+          250,
+        ),
+      );
+    }
+    if (seedPhrase.trim().replace(/\s+/g, " ") !== MOCK_SEED) {
+      throw new Error("Recovery phrase is not a valid supported BIP39 mnemonic.");
+    }
+    const publish = (): WalletRestored => {
+      created = true;
+      globalThis.localStorage?.setItem(MOCK_CREATED_WALLET_KEY, "1");
+      globalThis.localStorage?.removeItem(MOCK_BACKUP_REQUIRED_KEY);
+      return { success: true, walletId: MOCK_WALLET_ID };
+    };
+    if (mockWalletScenario() === "slow-restore") {
+      return new Promise((resolve) => setTimeout(() => resolve(publish()), 750));
+    }
+    return publish();
   },
   getSeedPhrase(): string {
     return MOCK_SEED;
@@ -253,6 +299,16 @@ export const mockWallet = {
     }
     if (mockWalletScenario() === "sign-error") {
       throw new Error("The mock wallet could not sign this challenge.");
+    }
+    if (
+      mockWalletScenario() === "identity-switch" &&
+      challenge !== "ZUULI-Login:identity-probe"
+    ) {
+      return {
+        address: `${MOCK_UA}-different-identity`,
+        challenge,
+        signature: "must-not-reach-backend",
+      };
     }
     // A believable-looking signature. Real signing happens in the Rust plugin
     // (ZIP-304); this keeps the browser demo flowing.

--- a/wallet/zuuli/src/lib/wallet/types.ts
+++ b/wallet/zuuli/src/lib/wallet/types.ts
@@ -8,6 +8,12 @@ export interface WalletCreated {
   birthdayHeight: number;
 }
 
+export interface WalletRestored {
+  success: boolean;
+  /** Exact native manifest identity atomically published by restore. */
+  walletId: string;
+}
+
 export interface WalletStatus {
   initialized: boolean;
   hasSeed: boolean;

--- a/wallet/zuuli/tests/auth-density.pw.ts
+++ b/wallet/zuuli/tests/auth-density.pw.ts
@@ -5,14 +5,27 @@ const PHONE_VIEWPORTS = [
   { label: "iPhone SE", width: 375, height: 667 },
 ] as const;
 
+const RECOVERY_PHRASE =
+  "wisdom shadow orchard zebra pledge notice frost violet render " +
+  "summer harvest mirror canyon velvet ranch fossil pupil sunset " +
+  "quantum ledger prosper anchor beyond zephyr";
+
 async function openLogin(
   page: Page,
   viewport: (typeof PHONE_VIEWPORTS)[number],
-  walletScenario?: "empty" | "sign-error",
+  walletScenario?:
+    | "empty"
+    | "sign-error"
+    | "identity-switch"
+    | "wallet-switch"
+    | "slow-restore"
+    | "slow-restore-error",
 ) {
   await page.setViewportSize(viewport);
   await page.addInitScript((scenario) => {
     localStorage.removeItem("zuuli.knox.token");
+    localStorage.removeItem("zuuli.mock.created-wallet");
+    localStorage.removeItem("zuuli.mock.backup-required");
     if (scenario) localStorage.setItem("zuuli.mock.wallet-scenario", scenario);
     else localStorage.removeItem("zuuli.mock.wallet-scenario");
   }, walletScenario);
@@ -168,7 +181,17 @@ for (const viewport of PHONE_VIEWPORTS) {
     await page.getByRole("button", { name: "Zcash", exact: true }).click();
     await page.getByRole("button", { name: "Continue", exact: true }).click();
     await expect(page.getByText("No Zcash identity on this device")).toBeVisible();
-    await page.getByRole("button", { name: "Create a Zcash identity" }).click();
+    await expectReachable(
+      scroller,
+      page.getByRole("button", { name: "Use existing identity" }),
+    );
+    await expect(
+      page.getByText("A new key creates a distinct identity and may open a different account."),
+    ).toBeVisible();
+    const createIdentity = page.getByRole("button", { name: "Create new identity" });
+    await expectReachable(scroller, createIdentity);
+    await expectAuthGeometry(page, false);
+    await createIdentity.click();
 
     await expect(page.getByText("This recovery phrase is your identity.")).toBeVisible();
     const reveal = page.getByRole("button", { name: "Reveal recovery phrase" });
@@ -181,4 +204,158 @@ for (const viewport of PHONE_VIEWPORTS) {
     await expect(page.getByText(/Anyone who sees them controls your account/)).toBeVisible();
     await expectAuthGeometry(page, false);
   });
+
+  test(`existing identity recovery is private and reachable on ${viewport.label}`, async ({
+    page,
+  }) => {
+    await openLogin(page, viewport, "empty");
+    const scroller = page.locator("[data-route-frame] [data-route-scroll]");
+    const privateInput = Array.from({ length: 12 }, (_, index) => `private${index}`).join(
+      " ",
+    );
+    const consoleText: string[] = [];
+    page.on("console", (message) => consoleText.push(message.text()));
+
+    await page.getByRole("button", { name: "Zcash", exact: true }).click();
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+    await page.getByRole("button", { name: "Use existing identity" }).click();
+
+    const phrase = page.getByLabel("Recovery phrase");
+    await expect(phrase).toBeVisible();
+    await expect(page.getByText("External wallet signing isn’t supported yet.")).toBeVisible();
+    await phrase.fill(privateInput);
+    expect(
+      await phrase.evaluate(
+        (element) => getComputedStyle(element).webkitTextSecurity,
+      ),
+    ).toBe("disc");
+    await expectReachable(
+      scroller,
+      page.getByRole("button", { name: "Restore and continue" }),
+    );
+    await page.getByRole("button", { name: "Restore and continue" }).click();
+
+    const error = page.getByRole("alert");
+    await expect(error).toHaveText(
+      "Couldn't restore this identity. Check the recovery words, birthday, and connection, then try again.",
+    );
+    await expect(error).not.toContainText(privateInput);
+    await expect(phrase).toHaveValue(privateInput);
+    expect(page.url()).not.toContain("private0");
+    expect(consoleText.join("\n")).not.toContain("private0");
+    expect(
+      await page.evaluate((secret) =>
+        Object.values(localStorage).some((value) => value.includes(secret)),
+      "private0"),
+    ).toBe(false);
+    await expectAuthGeometry(page, false);
+
+    await page.getByRole("button", { name: "Choose another login method" }).click();
+    await expect(page.locator("textarea")).toHaveCount(0);
+    await page.getByRole("button", { name: "Zcash", exact: true }).click();
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+    await page.getByRole("button", { name: "Use existing identity" }).click();
+    await expect(page.getByLabel("Recovery phrase")).toHaveValue("");
+    await expectAuthGeometry(page, false);
+  });
+
+  test(`restored identity resumes the original funding login on ${viewport.label}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(viewport);
+    await page.addInitScript(() => {
+      localStorage.removeItem("zuuli.knox.token");
+      localStorage.removeItem("zuuli.mock.created-wallet");
+      localStorage.removeItem("zuuli.mock.backup-required");
+      localStorage.setItem("zuuli.mock.wallet-scenario", "empty");
+    });
+    const consoleText: string[] = [];
+    page.on("console", (message) => consoleText.push(message.text()));
+    await page.goto("/wallet/fund");
+    await page.getByRole("button", { name: "Log in to buy" }).click();
+    await page.getByRole("button", { name: "Zcash", exact: true }).click();
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+    await page.getByRole("button", { name: "Use existing identity" }).click();
+    await page.getByLabel("Recovery phrase").fill(RECOVERY_PHRASE);
+    await page.getByRole("button", { name: "Restore and continue" }).click();
+
+    await expect(page.locator("textarea")).toHaveCount(0);
+    await expect(page).toHaveURL(/\/wallet\/fund$/, { timeout: 10_000 });
+    expect(await page.evaluate(() => localStorage.getItem("zuuli.knox.token"))).toBe(
+      "mock-knox-token-zcash",
+    );
+    expect(await page.evaluate(() => localStorage.getItem("zuuli.mock.backup-required"))).toBeNull();
+    expect(
+      await page.evaluate((secret) =>
+        Object.values(localStorage).some((value) => value.includes(secret)),
+      "wisdom shadow"),
+    ).toBe(false);
+    expect(consoleText.join("\n")).not.toContain("wisdom shadow");
+
+    // Use the rendered production navigation so this proves the successful
+    // restore refreshed the already-cached `initialized: false` wallet store
+    // without a reload while preserving React Router's real history state.
+    await page.getByRole("link", { name: "Zcash wallet", exact: true }).click();
+    await expect(page).toHaveURL(/\/wallet$/);
+    await expect(page.getByText("Set up your Zcash wallet")).toHaveCount(0);
+    await expect(page.getByText("Spendable balance")).toBeVisible();
+  });
 }
+
+test("an asynchronous invalid restore releases the method fence only after failure", async ({
+  page,
+}) => {
+  await openLogin(page, PHONE_VIEWPORTS[0], "slow-restore-error");
+  await page.getByRole("button", { name: "Zcash", exact: true }).click();
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
+  await page.getByLabel("Recovery phrase").fill("private invalid recovery material");
+  await page.getByRole("button", { name: "Restore and continue" }).click();
+
+  const switchMethod = page.getByRole("button", {
+    name: "Choose another login method",
+  });
+  await expect(page.getByRole("button", { name: "Restoring identity…" })).toBeVisible();
+  await expect(switchMethod).toBeDisabled();
+  await expect(page.getByRole("alert")).toHaveText(
+    "Couldn't restore this identity. Check the recovery words, birthday, and connection, then try again.",
+  );
+  await expect(switchMethod).toBeEnabled();
+  await switchMethod.click();
+  await expect(page.locator("textarea")).toHaveCount(0);
+  expect(await page.evaluate(() => localStorage.getItem("zuuli.knox.token"))).toBeNull();
+});
+
+test("a changed signer cannot verify the restored identity", async ({ page }) => {
+  await openLogin(page, PHONE_VIEWPORTS[0], "identity-switch");
+  await page.getByRole("button", { name: "Zcash", exact: true }).click();
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
+  await page.getByLabel("Recovery phrase").fill(RECOVERY_PHRASE);
+  await page.getByRole("button", { name: "Restore and continue" }).click();
+
+  await expect(page.getByRole("alert")).toContainText(
+    "The active Zcash identity changed before signing. No login was sent.",
+  );
+  expect(await page.evaluate(() => localStorage.getItem("zuuli.knox.token"))).toBeNull();
+  await expect(page).toHaveURL(/\/login$/);
+  await expectAuthGeometry(page, false);
+});
+
+test("a switched active wallet cannot replace the exact restored wallet", async ({
+  page,
+}) => {
+  await openLogin(page, PHONE_VIEWPORTS[0], "wallet-switch");
+  await page.getByRole("button", { name: "Zcash", exact: true }).click();
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
+  await page.getByLabel("Recovery phrase").fill(RECOVERY_PHRASE);
+  await page.getByRole("button", { name: "Restore and continue" }).click();
+
+  await expect(page.getByRole("alert")).toContainText(
+    "The selected Zcash identity is no longer active. Try again.",
+  );
+  expect(await page.evaluate(() => localStorage.getItem("zuuli.knox.token"))).toBeNull();
+  await expect(page).toHaveURL(/\/login$/);
+  await expectAuthGeometry(page, false);
+});

--- a/wallet/zuuli/tests/auth-lifecycle.pw.ts
+++ b/wallet/zuuli/tests/auth-lifecycle.pw.ts
@@ -1,8 +1,15 @@
 import { expect, test, type Page } from "@playwright/test";
 
 const TOKEN_KEY = "zuuli.knox.token";
+const RECOVERY_PHRASE =
+  "wisdom shadow orchard zebra pledge notice frost violet render " +
+  "summer harvest mirror canyon velvet ranch fossil pupil sunset " +
+  "quantum ledger prosper anchor beyond zephyr";
 
-async function openLogin(page: Page, walletScenario?: "empty" | "sign-error") {
+async function openLogin(
+  page: Page,
+  walletScenario?: "empty" | "sign-error" | "slow-restore",
+) {
   await page.setViewportSize({ width: 320, height: 568 });
   await page.addInitScript((scenario) => {
     localStorage.removeItem("zuuli.knox.token");
@@ -83,6 +90,30 @@ test("an unmounted Zcash retry cannot revive the failed attempt", async ({ page 
   await expectNoInvisibleLogin(page);
 });
 
+test("an unmounted recovery cannot continue into challenge verification", async ({
+  page,
+}) => {
+  await openLogin(page, "slow-restore");
+  await page.getByRole("button", { name: "Zcash", exact: true }).click();
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
+  await page.getByLabel("Recovery phrase").fill(RECOVERY_PHRASE);
+  await page.getByRole("button", { name: "Restore and continue" }).click();
+  await expect(page.getByRole("button", { name: "Restoring identity…" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Choose another login method" }),
+  ).toBeDisabled();
+
+  await unmountLoginWithoutReload(page);
+  await expect(page.locator("textarea")).toHaveCount(0);
+  await expectNoInvisibleLogin(page);
+  expect(
+    await page.evaluate((secret) =>
+      Object.values(localStorage).some((value) => value.includes(secret)),
+    "wisdom shadow"),
+  ).toBe(false);
+});
+
 test("new identity backup resumes after method switch and process-style reload", async ({
   page,
 }) => {
@@ -90,7 +121,10 @@ test("new identity backup resumes after method switch and process-style reload",
   await page.getByRole("button", { name: "Zcash", exact: true }).click();
   await page.getByRole("button", { name: "Continue", exact: true }).click();
   await expect(page.getByText("No Zcash identity on this device")).toBeVisible();
-  await page.getByRole("button", { name: "Create a Zcash identity" }).click();
+  await expect(
+    page.getByText("A new key creates a distinct identity and may open a different account."),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Create new identity" }).click();
   await expect(page.getByText("This recovery phrase is your identity.")).toBeVisible();
 
   await page.getByRole("button", { name: "Choose another login method" }).click();


### PR DESCRIPTION
## Summary

- clearly separates **Use existing identity** from **Create new identity** when Zcash login finds no local wallet, including a warning that creation produces a distinct account identity
- restores an existing identity locally from a masked BIP39 recovery phrase; external wallet signing is explicitly identified as unsupported rather than implied
- returns the exact restored wallet ID from the native atomic transition, then rechecks active wallet, derived address, signed address, and exact challenge before backend verification
- keeps recovery material out of URLs, storage, logs, toasts, network calls, and raw errors; masks it, disables OS spelling/autocorrect affordances, clears editable renderer state on success/reset/switch/unmount, and zeroizes the native copy before the first await
- refreshes the shared wallet store after native publication so the restored wallet is immediately usable without a reload
- preserves the durable backup ceremony for newly created identities while restored/legacy identities remain backup-complete
- fences restore, challenge, signing, verification, session publication, success delay, toast, and navigation against stale/unmounted attempts

## Verification

- `cargo +1.97.1 test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml` — 102 passed
- `cargo +1.97.1 clippy --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml -- -D warnings`
- `cargo +1.97.1 build --locked --manifest-path wallet/zuuli/src-tauri/Cargo.toml`
- `npm test` in `wallet/zuuli` — 292 Vitest + 8 Node contract + 51 Playwright passed
- `npx playwright test tests/auth-density.pw.ts tests/auth-lifecycle.pw.ts` — 21 passed
- `npm run typecheck` and `npm run build` in `wallet/zuuli`
- Zuuallet `npm ci` + `npm run build`
- Rust toolchain/fmt/full-clippy repository checks passed on the native diff

Browser coverage includes 320x568 and iPhone SE restore UI, sync and async invalid recovery, phrase non-retention, restore-unmount fencing, wallet-switch and signer-address rejection, original `/wallet/fund` return, and real rendered Wallet-link SPA navigation to `/wallet` proving both #427 history-state compatibility and a current restored Zustand snapshot without reload.

## Adversarial review

Adversarial passes found and this branch fixed:

- native recovery-phrase lifetime across async boundaries; Rust now wraps it in `Zeroizing` before the first await
- renderer privacy affordances and claims; editable state is cleared immediately after native custody, Safari/iOS autocorrect is disabled, and documentation explicitly acknowledges immutable JS/IPC strings cannot be zeroized
- synchronous rejection releasing the method-switch fence incorrectly
- a restored native wallet leaving the renderer wallet store at cached `initialized: false`
- a phrase-specific error incorrectly masking birthday, connection, database, or custody failures

The final mandatory `codex review --base origin/main` on exact head `dc996b9060df1a0ebd6581d4009472fa5599da6c` found no remaining issue. It independently passed TypeScript/targeted tests and all 102 Rust plugin tests; its sandbox could not bind the Playwright port, while the exact full 51-case Playwright suite passed immediately beforehand outside that sandbox.

Follow-up #246 remains open for the separate profile recovery drill and release-policy work; this PR accepts the native-supported 12/15/18/21/24-word BIP39 restore lengths and does not claim that follow-up complete.

Closes #268
