### PR TITLE
ci(zuuallet): remove live apt from required Rust build

### DIFF
--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -205,34 +205,42 @@ jobs:
   rust:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/free2z/zuuli-linux-ci@sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
     env:
       # Shared target dir so the app build and the standalone plugin build reuse
       # the same compiled librustzcash artifacts instead of building it twice.
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
     steps:
+      - name: Verify pinned Linux build image
+        working-directory: /
+        run: |
+          set -euo pipefail
+          /usr/local/bin/verify-zuuli-linux-image
+          test -n "$BASH_VERSION"
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Configure exact Git workspace trust
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       # Only fetch the one submodule the build needs — the rest of z/ is huge
       # (zebra, zcashd, zodl, ...) and irrelevant to compiling Zuuallet.
       - name: Fetch librustzcash submodule
         run: git submodule update --init z/zcash/librustzcash
 
-      - name: Install Tauri system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev \
-            libxdo-dev \
-            libdbus-1-dev \
-            libssl-dev \
-            build-essential curl wget file pkg-config
-
-      - uses: dtolnay/rust-toolchain@stable
+      # `uses:` cannot take an expression; scripts/check-rust-toolchain.sh holds
+      # this version-branch ref to wallet/rust-toolchain.toml.
+      - uses: dtolnay/rust-toolchain@1.97.1
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/zuuli-linux-image.yml
+++ b/.github/workflows/zuuli-linux-image.yml
@@ -9,6 +9,7 @@ on:
       - .github/workflows/zuuli-linux-image.yml
       - docs/ZUULI-LINUX-BUILD-IMAGE.md
       - scripts/check-zuuli-linux-image.mjs
+      - .github/workflows/zuuallet.yml
   push:
     branches: [main]
     paths:
@@ -16,6 +17,7 @@ on:
       - .github/workflows/zuuli-linux-image.yml
       - docs/ZUULI-LINUX-BUILD-IMAGE.md
       - scripts/check-zuuli-linux-image.mjs
+      - .github/workflows/zuuallet.yml
   schedule:
     - cron: "23 9 * * 3"
   workflow_dispatch:

--- a/docs/ZUULI-LINUX-BUILD-IMAGE.md
+++ b/docs/ZUULI-LINUX-BUILD-IMAGE.md
@@ -33,11 +33,18 @@ the main-branch image workflow, and a GitHub-hosted runner.
 
 ## Phase B: digest-pinned consumers
 
-Exactly five Linux consumers use the promoted digest: the required lint,
+Exactly six Linux consumers use the promoted digest: the required lint,
 standalone plugin, and ZUULI backend jobs; the Linux packaging smoke matrix
-entry; and the protected Linux release job. macOS, Android, iOS, lightweight
-format/supply-chain jobs, and all store-upload jobs remain on their native
-runners.
+entry; the protected Linux release job; and Zuuallet's required locked Rust
+build/test job. Zuuallet's lightweight jobs and separately scoped upstream
+canary remain outside this focused consumer set. macOS, Android, iOS,
+lightweight format/supply-chain jobs, and all store-upload jobs remain on their
+native runners.
+
+The image-policy workflow also runs its validator and negative suite whenever
+the Zuuallet workflow changes. This is merge-time policy coverage, not a claim
+that PR-authored workflow code is an immutable pre-execution sandbox; the
+reviewed digest and inventory-first runtime check remain the execution boundary.
 
 GHCR keeps the package private. Each consumer therefore grants only
 `packages: read` and supplies `github.actor` plus `secrets.GITHUB_TOKEN` as
@@ -50,7 +57,7 @@ comes exclusively from the pinned toolchain action and
 `wallet/rust-toolchain.toml`.
 
 `scripts/check-zuuli-linux-image.mjs` enforces the consumed lock state, exactly
-five identical digest references, pull-time credentials, packages-read scope,
+six identical digest references, pull-time credentials, packages-read scope,
 the inventory-first contract, explicit Bash, and absence of live apt commands.
 Its negative tests reject mutable tags, digest skew, missing credentials,
 reordered inventory, missing or broad Git ownership trust, and policy paths

--- a/scripts/check-zuuli-linux-image.mjs
+++ b/scripts/check-zuuli-linux-image.mjs
@@ -22,14 +22,24 @@ const consumerWorkflows = [
   ".github/workflows/zuuli.yml",
   ".github/workflows/zuuli-packaging.yml",
   ".github/workflows/zuuli-release.yml",
+  ".github/workflows/zuuallet.yml",
 ];
 const imageRepository = "ghcr.io/free2z/zuuli-linux-ci";
 const lockedImageDigest = "sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1";
 const lockedImage = `${imageRepository}@${lockedImageDigest}`;
-const expectedConsumerCount = 5;
+const expectedConsumerCount = 6;
+const requiredConsumerJobs = new Set([
+  ".github/workflows/zuuli.yml:rust_clippy",
+  ".github/workflows/zuuli.yml:rust_plugin",
+  ".github/workflows/zuuli.yml:rust_app",
+  ".github/workflows/zuuli-packaging.yml:desktop",
+  ".github/workflows/zuuli-release.yml:linux",
+  ".github/workflows/zuuallet.yml:rust",
+]);
 const phaseATriggerPaths = [
   ".github/containers/zuuli-linux",
   ".github/workflows/zuuli-linux-image.yml",
+  ".github/workflows/zuuallet.yml",
   "docs/ZUULI-LINUX-BUILD-IMAGE.md",
   "scripts/check-zuuli-linux-image.mjs",
 ];
@@ -163,6 +173,33 @@ function validateConsumerJob(job, failures) {
   while (previousStep >= 0 && !lines[previousStep].startsWith(`${stepIndent}- `)) previousStep -= 1;
   if (previousStep < 0 || !lines[previousStep].trim().startsWith("- uses: actions/checkout@")) {
     failures.push(`${job.name}: exact-workspace trust must immediately follow checkout`);
+  }
+
+  for (const [label, value] of [
+    ["packages-read permission", "packages: read"],
+    ["pull-time username", "username: ${{ github.actor }}"],
+    ["pull-time credential", "password: ${{ secrets.GITHUB_TOKEN }}"],
+    ["explicit Bash default", "shell: bash"],
+    ["inventory invocation", "/usr/local/bin/verify-zuuli-linux-image"],
+  ]) {
+    if (countOccurrences(job.contents, value) !== 1) {
+      failures.push(`${job.name}: require exactly one ${label}`);
+    }
+  }
+
+  if (job.name === ".github/workflows/zuuallet.yml:rust") {
+    for (const expected of [
+      "persist-credentials: false",
+      "dtolnay/rust-toolchain@1.97.1",
+      "Swatinem/rust-cache@v2",
+      "cargo build --locked --manifest-path wallet/zuuallet/src-tauri/Cargo.toml",
+      "cargo test --locked",
+      "--manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml",
+    ]) {
+      if (countOccurrences(job.contents, expected) !== 1) {
+        failures.push(`${job.name}: locked build/test contract is missing ${expected}`);
+      }
+    }
   }
 }
 
@@ -306,9 +343,6 @@ function validate(root) {
   for (const reference of imageReferences) {
     if (reference !== lockedImage) failures.push(`consumers: mutable or mismatched image reference: ${reference}`);
   }
-  if (/^\s*(?:- run:\s*)?(?:sudo\s+)?apt(?:-get)?\s/m.test(consumerContents)) {
-    failures.push("consumers: live apt commands are forbidden after digest promotion");
-  }
   for (const [name, value] of [
     ["packages: read permissions", "packages: read"],
     ["pull-time usernames", "username: ${{ github.actor }}"],
@@ -326,7 +360,23 @@ function validate(root) {
   if (consumerJobs.length !== expectedConsumerCount) {
     failures.push(`consumers: expected ${expectedConsumerCount} digest-pinned job blocks`);
   }
-  for (const job of consumerJobs) validateConsumerJob(job, failures);
+  const actualConsumerJobs = new Set(consumerJobs.map((job) => job.name));
+  for (const requiredJob of requiredConsumerJobs) {
+    if (!actualConsumerJobs.has(requiredJob)) {
+      failures.push(`consumers: required digest-pinned job is missing: ${requiredJob}`);
+    }
+  }
+  for (const actualJob of actualConsumerJobs) {
+    if (!requiredConsumerJobs.has(actualJob)) {
+      failures.push(`consumers: unreviewed digest-pinned job: ${actualJob}`);
+    }
+  }
+  for (const job of consumerJobs) {
+    validateConsumerJob(job, failures);
+    if (/^\s*(?:- run:\s*)?(?:sudo\s+)?apt(?:-get)?\s/m.test(job.contents)) {
+      failures.push(`${job.name}: live apt commands are forbidden in a digest-pinned consumer`);
+    }
+  }
   if (countOccurrences(consumerContents, "for extension in AppImage deb rpm") < 2 ||
       countOccurrences(consumerContents, "-size +0c") < 2) {
     failures.push("consumers: packaging and release must require nonempty AppImage, deb, and rpm artifacts");
@@ -390,6 +440,12 @@ function runSelfTest() {
         expected: "policy path must select",
       },
       {
+        name: "Zuuallet workflow no longer triggers image policy",
+        path: workflowPath,
+        mutate: (value) => value.replaceAll("      - .github/workflows/zuuallet.yml\n", ""),
+        expected: "bootstrap path is not covered: .github/workflows/zuuallet.yml",
+      },
+      {
         name: "fail-open required-gate fallback",
         path: consumerWorkflows[0],
         mutate: (value) => value.replace(
@@ -410,8 +466,48 @@ function runSelfTest() {
       {
         name: "reintroduced live apt",
         path: consumerWorkflows[0],
-        mutate: (value) => `${value}\n      - run: apt-get update\n`,
+        mutate: (value) => value.replace(
+          '      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"',
+          '      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"\n      - run: apt-get update',
+        ),
         expected: "live apt commands",
+      },
+      {
+        name: "Zuuallet consumer reintroduced live apt",
+        path: consumerWorkflows[3],
+        mutate: (value) => value.replace(
+          '      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"',
+          '      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"\n      - run: sudo apt-get update',
+        ),
+        expected: "live apt commands",
+      },
+      {
+        name: "Zuuallet checkout retains credentials",
+        path: consumerWorkflows[3],
+        mutate: (value) => {
+          const consumerStart = value.indexOf(lockedImage);
+          return value.slice(0, consumerStart) + value.slice(consumerStart)
+            .replace("persist-credentials: false", "persist-credentials: true");
+        },
+        expected: "persist-credentials: false",
+      },
+      {
+        name: "Zuuallet build drops the locked graph",
+        path: consumerWorkflows[3],
+        mutate: (value) => value.replace(
+          "cargo build --locked --manifest-path wallet/zuuallet/src-tauri/Cargo.toml",
+          "cargo build --manifest-path wallet/zuuallet/src-tauri/Cargo.toml",
+        ),
+        expected: "cargo build --locked",
+      },
+      {
+        name: "Zuuallet required build floats its Rust toolchain",
+        path: consumerWorkflows[3],
+        mutate: (value) => value.replace(
+          "dtolnay/rust-toolchain@1.97.1",
+          "dtolnay/rust-toolchain@stable",
+        ),
+        expected: "dtolnay/rust-toolchain@1.97.1",
       },
       {
         name: "missing pull-time credential",


### PR DESCRIPTION
Closes #429.

## Outcome

- moves only the required Zuuallet Rust build/test job onto the attested, digest-pinned Ubuntu 24.04 OS-dependencies image
- removes the live apt update/install step that consumed 23m41s in job 96190358992
- keeps the application and plugin commands locked and pins the Rust action to repository toolchain 1.97.1
- verifies inventory before checkout, grants only contents/packages read, uses pull-time GHCR credentials, and trusts only the exact workspace immediately after checkout
- expands the shared validator to exactly six approved consumers and makes Zuuallet workflow edits trigger image-policy validation

Image: `ghcr.io/free2z/zuuli-linux-ci@sha256:bc66315a17723a6a828a8d3c91733ff2e06f164d18a17de72acf199cc27381d1`  
Attestation: https://github.com/free2z/zuu/attestations/41577363

## Exact reviewed revision

- head: `89aeb3efc1cecbbb1617481f8ad0c8245f7f684a`
- base: `88505ad3517cc4c7783d86c52817dc709bf824c0` (#431)
- semantic `range-diff` against the pre-#431 commit is unchanged; no #431 product/auth/test file is in this PR
- clean-head `codex review --commit 89aeb3e`: no findings

The review cycle resolved policy gaps around workflow-only validation, truthful pre-execution guarantees, and the Rust action pin.

## Local verification

- `node scripts/check-zuuli-linux-image.mjs --self-test` — pass, 22 negative cases
- focused `actionlint` — pass
- Node syntax — pass
- Rust toolchain contract and self-test — pass, 7 drift cases
- `git diff --check` and clean worktree — pass

## Hosted acceptance

All evidence is from exact head `89aeb3e`:

- image policy run 32308324828: validator job 96245827302 and real amd64 build/inventory job 96245876461 passed
- required gate run 32308324825: aggregate gate job 96247248716 passed, including 66 browser cases and all Rust jobs
- Zuuallet run 32308324811: every applicable matrix job passed
- target Rust consumer job 96245827572 passed in 17m52s: private digest pull, inventory-first/Bash runtime, checkout, exact workspace trust, submodule fetch, Rust 1.97.1, cache restore/save, locked build (10m24s), locked plugin tests (6m27s), checkout cleanup, and container stop
- the target consumer has no live apt step; the original 23m42 apt stall is eliminated

No merge is requested until owner review.