### PR TITLE
fix(zuuli): authenticate before paid balance checks

### DIFF
--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
   AlertTriangle,
   ArrowUp,
@@ -20,6 +20,9 @@ import { Markdown } from "@/components/common/Markdown";
 import { useRouteScroll } from "@/hooks/useRouteScroll";
 import { ai } from "@/lib/api/free2z";
 import { ApiError } from "@/lib/api/http";
+import { paidActionGate } from "@/lib/auth/paid-action";
+import { preservePaidIntent } from "@/lib/auth/paid-intent";
+import { usePaidIntent } from "@/hooks/usePaidIntent";
 import type { AIModel, Personality } from "@/lib/api/types";
 import { formatTuzis, initials } from "@/lib/format";
 import { useSession } from "@/store/session";
@@ -88,13 +91,18 @@ function isAbortError(err: unknown): boolean {
 }
 
 /** Key identifying which (model, personality) pair a live conversation belongs to. */
-function conversationKey(model: AIModel, personality: Personality | null): string {
+function conversationKey(
+  model: AIModel,
+  personality: Personality | null,
+): string {
   return `${model.id}:${personality?.id ?? "default"}`;
 }
 
 export default function AiFeature() {
   const { registerViewport } = useRouteScroll();
+  const navigate = useNavigate();
   const user = useSession((s) => s.user);
+  const sessionLoading = useSession((s) => s.loading);
   const tuzis = useSession((s) => s.tuzis);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
   const refreshSession = useSession((s) => s.refresh);
@@ -108,6 +116,8 @@ export default function AiFeature() {
   const [personality, setPersonality] = useState<Personality | null>(null);
   const [managerOpen, setManagerOpen] = useState(false);
 
+  const restoredIntent = usePaidIntent("/ai", "ai");
+  const restoredIntentHandled = useRef(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [isSending, setIsSending] = useState(false);
@@ -120,17 +130,32 @@ export default function AiFeature() {
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  const lowBalance = tuzis < MIN_TUZIS_TO_CHAT;
+  useEffect(() => {
+    if (restoredIntent?.kind !== "ai" || restoredIntentHandled.current) return;
+    restoredIntentHandled.current = true;
+    setInput(restoredIntent.draft);
+  }, [restoredIntent]);
+
+  const gate = paidActionGate({
+    sessionLoading,
+    user,
+    balance: tuzis,
+    cost: MIN_TUZIS_TO_CHAT,
+  });
+  const lowBalance = gate === "low-balance";
   const canSend =
-    !!selected && !isSending && !lowBalance && input.trim().length > 0;
+    !!selected &&
+    !isSending &&
+    gate !== "loading" &&
+    !lowBalance &&
+    input.trim().length > 0;
 
   // Load models + personalities once; default to the highest-`order` GA
   // model (the API already returns them sorted by `-order`, so this is the
   // first GA entry — the one most likely to actually work).
   useEffect(() => {
     let active = true;
-    ai
-      .models()
+    ai.models()
       .then((list) => {
         if (!active) return;
         const sorted = [...list].sort((a, b) => b.order - a.order);
@@ -189,7 +214,13 @@ export default function AiFeature() {
   const send = useCallback(
     async (text: string) => {
       const prompt = text.trim();
-      if (!prompt || !selected || isSending || tuzis < MIN_TUZIS_TO_CHAT) return;
+      if (!prompt || !selected || isSending || gate === "loading") return;
+      if (!useSession.getState().user || gate === "sign-in") {
+        const returnTo = preservePaidIntent("/ai", { kind: "ai", draft: text });
+        navigate("/login", { state: { returnTo } });
+        return;
+      }
+      if (gate === "low-balance") return;
 
       const model = selected;
       const pers = personality;
@@ -300,7 +331,16 @@ export default function AiFeature() {
         setIsSending(false);
       }
     },
-    [selected, personality, isSending, tuzis, adjustTuzis, refreshSession],
+    [
+      selected,
+      personality,
+      isSending,
+      gate,
+      navigate,
+      tuzis,
+      adjustTuzis,
+      refreshSession,
+    ],
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -380,7 +420,10 @@ export default function AiFeature() {
                 className="flex shrink-0 items-center gap-1.5 rounded-full border border-primary/25 bg-primary/[0.06] px-2.5 py-1.5"
                 title="Spent this session"
               >
-                <Coins className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />
+                <Coins
+                  className="h-3.5 w-3.5 shrink-0 text-primary"
+                  aria-hidden
+                />
                 <span className="hidden text-[11px] text-muted-foreground sm:inline">
                   This session
                 </span>
@@ -392,9 +435,33 @@ export default function AiFeature() {
           </div>
         </div>
 
-        {lowBalance ? (
+        {gate === "sign-in" ? (
+          <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-primary/30 bg-primary/10 px-3 py-2 text-sm">
+            <ShieldCheck
+              className="h-4 w-4 shrink-0 text-primary"
+              aria-hidden
+            />
+            <span className="text-foreground">Sign in to use AI.</span>
+            <Button
+              size="sm"
+              className="ml-auto"
+              onClick={() => {
+                const returnTo = preservePaidIntent("/ai", {
+                  kind: "ai",
+                  draft: input,
+                });
+                navigate("/login", { state: { returnTo } });
+              }}
+            >
+              Sign in
+            </Button>
+          </div>
+        ) : lowBalance ? (
           <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm">
-            <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" aria-hidden />
+            <AlertTriangle
+              className="h-4 w-4 shrink-0 text-destructive"
+              aria-hidden
+            />
             <span className="text-foreground">
               You need at least {formatTuzis(MIN_TUZIS_TO_CHAT)} to start
               chatting. Top up to continue.
@@ -416,7 +483,9 @@ export default function AiFeature() {
           <EmptyHero
             selected={selected}
             localModel={localModel}
-            onSelectLocal={localModel ? () => setSelected(localModel) : undefined}
+            onSelectLocal={
+              localModel ? () => setSelected(localModel) : undefined
+            }
             onPrefill={prefill}
           />
         ) : (
@@ -442,13 +511,15 @@ export default function AiFeature() {
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
-              disabled={lowBalance}
+              disabled={gate === "loading" || lowBalance}
               rows={1}
               aria-label="Message"
               placeholder={
-                lowBalance
-                  ? "Buy 2Zs to start chatting…"
-                  : `Message ${selected?.display_name ?? "the model"}…`
+                gate === "loading"
+                  ? "Checking your account…"
+                  : lowBalance
+                    ? "Buy 2Zs to start chatting…"
+                    : `Message ${selected?.display_name ?? "the model"}…`
               }
               className="max-h-[40vh] min-h-[52px] resize-none overflow-y-auto border-0 bg-transparent py-3.5 pl-4 pr-14 text-[15px] focus-visible:ring-0 focus-visible:ring-offset-0"
             />
@@ -470,7 +541,11 @@ export default function AiFeature() {
                   size="icon"
                   onClick={() => void send(input)}
                   disabled={!canSend}
-                  aria-label="Send message"
+                  aria-label={
+                    gate === "sign-in"
+                      ? "Sign in to send message"
+                      : "Send message"
+                  }
                   className="h-11 w-11"
                 >
                   <ArrowUp className="h-4 w-4" />
@@ -507,7 +582,9 @@ export default function AiFeature() {
             setPersonality(change.created);
           } else if (change.updated) {
             setPersonalities((prev) =>
-              prev.map((p) => (p.id === change.updated!.id ? change.updated! : p)),
+              prev.map((p) =>
+                p.id === change.updated!.id ? change.updated! : p,
+              ),
             );
             setPersonality((cur) =>
               cur?.id === change.updated!.id ? change.updated! : cur,
@@ -516,7 +593,9 @@ export default function AiFeature() {
             setPersonalities((prev) =>
               prev.filter((p) => p.id !== change.deletedId),
             );
-            setPersonality((cur) => (cur?.id === change.deletedId ? null : cur));
+            setPersonality((cur) =>
+              cur?.id === change.deletedId ? null : cur,
+            );
           }
         }}
       />
@@ -535,7 +614,9 @@ function MessageRow({
     return (
       <div className="flex animate-slide-up justify-end gap-3">
         <div className="max-w-[85%] rounded-2xl rounded-tr-sm border border-primary/30 bg-primary/15 px-4 py-2.5 text-[15px] leading-relaxed text-foreground">
-          <span className="whitespace-pre-wrap break-words">{message.content}</span>
+          <span className="whitespace-pre-wrap break-words">
+            {message.content}
+          </span>
         </div>
         <Avatar className="h-8 w-8 border border-border">
           <AvatarFallback className="bg-primary/20 text-xs text-primary">
@@ -663,14 +744,20 @@ function EmptyHero({
               <span className="min-w-0 break-words font-semibold">
                 {localModel.display_name}
               </span>
-              <Badge variant="default" className="gap-1 px-1.5 py-0 text-[10px]">
+              <Badge
+                variant="default"
+                className="gap-1 px-1.5 py-0 text-[10px]"
+              >
                 <ShieldCheck className="h-3 w-3" aria-hidden />
                 private
               </Badge>
             </div>
             <p className="mt-0.5 text-xs text-muted-foreground">
               Open-source, run on 2Z hardware — nothing leaves our walls. From{" "}
-              <span className="tabular-nums">{pricePerMessage(localModel)}</span>.
+              <span className="tabular-nums">
+                {pricePerMessage(localModel)}
+              </span>
+              .
             </p>
           </div>
           {onSelectLocal ? (

--- a/wallet/zuuli/src/features/articles/components/TipDialog.tsx
+++ b/wallet/zuuli/src/features/articles/components/TipDialog.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { ArrowRight, Heart, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -24,25 +24,65 @@ import {
 import { cn } from "@/lib/utils";
 import { useSession } from "@/store/session";
 import type { SimpleCreator } from "@/lib/api/types";
+import { paidActionGate } from "@/lib/auth/paid-action";
+import { preservePaidIntent } from "@/lib/auth/paid-intent";
+import { usePaidIntent } from "@/hooks/usePaidIntent";
 
 const PRESETS = [50, 100, 250, 500];
 
 export function TipDialog({ author }: { author: SimpleCreator }) {
   const name = author.display_name || author.username;
   const navigate = useNavigate();
+  const location = useLocation();
+  const user = useSession((s) => s.user);
+  const sessionLoading = useSession((s) => s.loading);
   const tuzis = useSession((s) => s.tuzis);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
+  const restored = usePaidIntent(location.pathname, "article-tip");
+  const restoredTip =
+    restored?.kind === "article-tip" && restored.subject === author.username
+      ? restored
+      : null;
+  const restoredHandled = useRef(false);
   const [open, setOpen] = useState(false);
   const [amount, setAmount] = useState("100");
   const [sending, setSending] = useState(false);
 
-  const amountResult = validateTuzis(amount, { minimum: 1, maximum: MAX_TUZIS });
+  useEffect(() => {
+    if (!restoredTip || restoredHandled.current) return;
+    restoredHandled.current = true;
+    setAmount(restoredTip.amount);
+    setOpen(true);
+  }, [restoredTip]);
+
+  const amountResult = validateTuzis(amount, {
+    minimum: 1,
+    maximum: MAX_TUZIS,
+  });
   const parsedAmount = amountResult.value;
   const validAmount = amountResult.error === null;
-  const enough = parsedAmount !== null && parsedAmount <= tuzis;
-  const canSend = validAmount && enough && !sending;
+  const gate = paidActionGate({
+    sessionLoading,
+    user,
+    balance: tuzis,
+    cost: validAmount ? parsedAmount : null,
+  });
+  const canSend = validAmount && gate === "ready" && !sending;
+
+  function signIn() {
+    const returnTo = preservePaidIntent(location.pathname, {
+      kind: "article-tip",
+      subject: author.username,
+      amount,
+    });
+    navigate("/login", { state: { returnTo } });
+  }
 
   async function send() {
+    if (!useSession.getState().user || gate === "sign-in") {
+      signIn();
+      return;
+    }
     if (!canSend || parsedAmount === null) return;
     setSending(true);
     try {
@@ -103,13 +143,23 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
               className="tabular-nums"
-              aria-describedby="tip-amount-error tip-balance"
+              aria-describedby={
+                user ? "tip-amount-error tip-balance" : "tip-amount-error"
+              }
               aria-invalid={amount.length > 0 && !validAmount}
             />
-            <p id="tip-balance" className="text-xs text-muted-foreground tabular-nums">
-              Balance: {formatTuzis(tuzis)}
-            </p>
-            <p id="tip-amount-error" className="min-h-[1rem] text-xs text-destructive">
+            {user ? (
+              <p
+                id="tip-balance"
+                className="text-xs text-muted-foreground tabular-nums"
+              >
+                Balance: {formatTuzis(tuzis)}
+              </p>
+            ) : null}
+            <p
+              id="tip-amount-error"
+              className="min-h-[1rem] text-xs text-destructive"
+            >
               {amountResult.error === "tooLarge"
                 ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per tip.`
                 : amount.length > 0 && amountResult.error !== null
@@ -127,7 +177,14 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
           >
             Cancel
           </Button>
-          {validAmount && !enough ? (
+          {gate === "loading" ? (
+            <Button disabled>
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Checking account
+            </Button>
+          ) : gate === "sign-in" ? (
+            <Button onClick={signIn}>Sign in to tip</Button>
+          ) : validAmount && gate === "low-balance" ? (
             <Button
               variant="outline"
               onClick={() => {
@@ -146,7 +203,10 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
                   Sending
                 </>
               ) : (
-                <>Send {parsedAmount !== null ? formatTuzis(parsedAmount) : "2Zs"}</>
+                <>
+                  Send{" "}
+                  {parsedAmount !== null ? formatTuzis(parsedAmount) : "2Zs"}
+                </>
               )}
             </Button>
           )}

--- a/wallet/zuuli/src/features/auth/index.tsx
+++ b/wallet/zuuli/src/features/auth/index.tsx
@@ -5,7 +5,7 @@
 // prominent choice — passwordless, no email, no KYC. Email/username + password
 // (with 2FA when enabled) and, soon, X / Google follow below as alternatives.
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import {
   ArrowLeft,
@@ -16,12 +16,7 @@ import {
 } from "lucide-react";
 import { Wordmark } from "@/components/brand/Logo";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Tooltip,
   TooltipContent,
@@ -38,6 +33,8 @@ import {
   loginDestinationFromState,
   type LoginDestination,
 } from "@/lib/auth/login-destination";
+import { discardPaidIntent } from "@/lib/auth/paid-intent";
+import { useSession } from "@/store/session";
 
 export type AuthMethod = "chooser" | "zcash" | "password";
 
@@ -47,10 +44,37 @@ export default function AuthFeature() {
   const loginDestination = loginDestinationFromState(location.state);
   const bootstrap = useWallet((s) => s.bootstrap);
   const [method, setMethod] = useState<AuthMethod>("chooser");
+  const abandonedIntentTimer = useRef<number | null>(null);
 
   useEffect(() => {
     void bootstrap();
   }, [bootstrap]);
+
+  useEffect(() => {
+    const clearAbandonedFullPageLogin = () => {
+      if (!useSession.getState().user) discardPaidIntent();
+    };
+
+    // sessionStorage survives reloads and same-tab full-page departures. A
+    // pagehide listener closes that privacy boundary; social auth uses the
+    // app's popup/native-loopback transport, so its login page stays mounted.
+    window.addEventListener("pagehide", clearAbandonedFullPageLogin);
+
+    // React StrictMode replays effects in development. Cancel the first
+    // cleanup on the replayed setup, but clear after a real SPA departure when
+    // no login flow committed a user. This prevents one guest's private draft
+    // from being restored into a later account in the same tab.
+    if (abandonedIntentTimer.current !== null) {
+      window.clearTimeout(abandonedIntentTimer.current);
+      abandonedIntentTimer.current = null;
+    }
+    return () => {
+      window.removeEventListener("pagehide", clearAbandonedFullPageLogin);
+      abandonedIntentTimer.current = window.setTimeout(() => {
+        if (!useSession.getState().user) discardPaidIntent();
+      }, 0);
+    };
+  }, []);
 
   return (
     <div
@@ -130,10 +154,7 @@ export function AuthChooser({
 
         {/* Configured providers are additional methods. The empty state adds
             no decision and no translation surface, so it stays invisible. */}
-        <SocialButtons
-          emptyState={null}
-          loginDestination={loginDestination}
-        />
+        <SocialButtons emptyState={null} loginDestination={loginDestination} />
 
         <div className="flex min-h-11 items-center justify-between">
           <ZShieldInfo>

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -24,11 +24,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import type { LucideIcon } from "lucide-react";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -62,8 +58,11 @@ import {
   type KeyedRemoteData,
 } from "@/lib/remote-data";
 import { useAsync } from "@/hooks/useAsync";
+import { usePaidIntent } from "@/hooks/usePaidIntent";
 import { useSession } from "@/store/session";
 import type { Article, CreatorDetail, Subscription } from "@/lib/api/types";
+import { paidActionGate } from "@/lib/auth/paid-action";
+import { preservePaidIntent, type PaidIntent } from "@/lib/auth/paid-intent";
 
 /** Icon per canonical social platform key, falling back to a plain link glyph. */
 const SOCIAL_ICONS: Record<SocialLink["key"], LucideIcon> = {
@@ -155,6 +154,7 @@ export default function CreatorFeature() {
 
   return (
     <CreatorProfile
+      key={creator.username}
       creator={creator}
       refreshError={error}
       refresh={reload}
@@ -175,6 +175,11 @@ function CreatorProfile({
   refreshing: boolean;
 }) {
   const name = creator.display_name || creator.username;
+  const location = useLocation();
+  const restoredPaidIntent = usePaidIntent(location.pathname, [
+    "creator-subscription",
+    "creator-tip",
+  ]);
   const {
     data: pagesData,
     loading: pagesLoading,
@@ -292,8 +297,8 @@ function CreatorProfile({
               </Link>
             </Button>
           ) : null}
-          <TipButton creator={creator} />
-          <SubscribeButton creator={creator} />
+          <TipButton creator={creator} restored={restoredPaidIntent} />
+          <SubscribeButton creator={creator} restored={restoredPaidIntent} />
         </div>
       </div>
 
@@ -443,10 +448,18 @@ function formatMembershipDate(iso?: string): string {
   });
 }
 
-function SubscribeButton({ creator }: { creator: CreatorDetail }) {
+function SubscribeButton({
+  creator,
+  restored,
+}: {
+  creator: CreatorDetail;
+  restored: PaidIntent | null;
+}) {
   const name = creator.display_name || creator.username;
   const navigate = useNavigate();
+  const location = useLocation();
   const user = useSession((s) => s.user);
+  const sessionLoading = useSession((s) => s.loading);
   const balance = useSession((s) => s.tuzis);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
   const [open, setOpen] = useState(false);
@@ -470,8 +483,30 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
   // from the UI immediately and keep it dropped across the refetch.
   const [unfollowed, setUnfollowed] = useState(false);
 
+  useEffect(() => {
+    if (
+      restored?.kind === "creator-subscription" &&
+      restored.subject === creator.username
+    ) {
+      setOpen(true);
+    }
+  }, [creator.username, restored]);
+
   const price = creator.member_price ?? 0;
-  const enough = price <= balance;
+  const gate = paidActionGate({
+    sessionLoading,
+    user,
+    balance,
+    cost: price,
+  });
+
+  function signInToSubscribe() {
+    const returnTo = preservePaidIntent(location.pathname, {
+      kind: "creator-subscription",
+      subject: creator.username,
+    });
+    navigate("/login", { state: { returnTo } });
+  }
 
   const { data: subscriptions, reload: reloadSubscriptions } = useAsync<
     Subscription[]
@@ -496,10 +531,12 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
   // renewal at the current price — so they share one runner and differ only in
   // the copy and whether the dialog stays open to show the flipped state.
   async function runSubscribe(mode: "subscribe" | "resume") {
-    if (!user) {
-      navigate("/login");
+    const currentUser = useSession.getState().user;
+    if (!currentUser || gate === "sign-in") {
+      signInToSubscribe();
       return;
     }
+    if (gate !== "ready") return;
     setBusy(true);
     try {
       await tuzi.subscribe(creator.username);
@@ -511,8 +548,8 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
       if (mode === "resume") setRenewOverride(true);
       setJustSubscribed({
         fan: {
-          username: user.username,
-          free2zaddr: user.free2zaddr ?? user.username,
+          username: currentUser.username,
+          free2zaddr: currentUser.free2zaddr ?? currentUser.username,
         },
         star: { username: creator.username, free2zaddr: creator.free2zaddr },
         expires,
@@ -554,6 +591,10 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
   // stops. The dialog stays open so it re-renders into the "Resume renewal"
   // state.
   async function cancelRenewal() {
+    if (!useSession.getState().user) {
+      signInToSubscribe();
+      return;
+    }
     setBusy(true);
     try {
       await tuzi.unsubscribe(creator.username);
@@ -574,6 +615,10 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
 
   // Free follow: undo the follow entirely.
   async function unfollow() {
+    if (!useSession.getState().user) {
+      signInToSubscribe();
+      return;
+    }
     setBusy(true);
     try {
       await tuzi.unsubscribe(creator.username);
@@ -594,10 +639,8 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
       <Button
         variant={subscribed ? "secondary" : "default"}
         onClick={subscribed ? unfollow : subscribe}
-        disabled={busy}
-        aria-label={
-          subscribed ? `Unfollow ${name}` : `Follow ${name}`
-        }
+        disabled={busy || gate === "loading"}
+        aria-label={subscribed ? `Unfollow ${name}` : `Follow ${name}`}
       >
         {busy ? (
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
@@ -651,10 +694,21 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
           </div>
 
           <DialogFooter>
-            <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
+            <Button
+              variant="ghost"
+              onClick={() => setOpen(false)}
+              disabled={busy}
+            >
               Close
             </Button>
-            {renewing ? (
+            {gate === "loading" ? (
+              <Button disabled>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Checking account
+              </Button>
+            ) : gate === "sign-in" ? (
+              <Button onClick={signInToSubscribe}>Sign in to manage</Button>
+            ) : renewing ? (
               <Button
                 variant="outline"
                 onClick={cancelRenewal}
@@ -666,7 +720,7 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
                 ) : null}
                 Cancel membership
               </Button>
-            ) : enough ? (
+            ) : gate === "ready" ? (
               <Button
                 onClick={resumeRenewal}
                 disabled={busy}
@@ -707,8 +761,8 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
           <DialogTitle>Subscribe to {name}</DialogTitle>
           <DialogDescription>
             This is {name}'s membership price — what it costs you to become a
-            subscriber. It unlocks their subscriber posts and livestreams for
-            30 days.
+            subscriber. It unlocks their subscriber posts and livestreams for 30
+            days.
           </DialogDescription>
         </DialogHeader>
 
@@ -721,16 +775,29 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
               {formatTuzis(price)}
             </span>
           </div>
-          <p className="mt-2 text-xs text-muted-foreground tabular-nums">
-            Your balance: {formatTuzis(balance)}
-          </p>
+          {user ? (
+            <p className="mt-2 text-xs text-muted-foreground tabular-nums">
+              Your balance: {formatTuzis(balance)}
+            </p>
+          ) : null}
         </div>
 
         <DialogFooter>
-          <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
+          <Button
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={busy}
+          >
             Cancel
           </Button>
-          {enough ? (
+          {gate === "loading" ? (
+            <Button disabled>
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Checking account
+            </Button>
+          ) : gate === "sign-in" ? (
+            <Button onClick={signInToSubscribe}>Sign in to subscribe</Button>
+          ) : gate === "ready" ? (
             <Button onClick={subscribe} disabled={busy}>
               {busy ? (
                 <>
@@ -762,22 +829,62 @@ function SubscribeButton({ creator }: { creator: CreatorDetail }) {
 // ─── Tip ──────────────────────────────────────────────────────────────────────
 const TIP_PRESETS = [50, 100, 250, 500];
 
-function TipButton({ creator }: { creator: CreatorDetail }) {
+function TipButton({
+  creator,
+  restored,
+}: {
+  creator: CreatorDetail;
+  restored: PaidIntent | null;
+}) {
   const name = creator.display_name || creator.username;
   const navigate = useNavigate();
+  const location = useLocation();
+  const user = useSession((s) => s.user);
+  const sessionLoading = useSession((s) => s.loading);
   const balance = useSession((s) => s.tuzis);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
+  const restoredTip =
+    restored?.kind === "creator-tip" && restored.subject === creator.username
+      ? restored
+      : null;
   const [open, setOpen] = useState(false);
   const [amount, setAmount] = useState("100");
   const [busy, setBusy] = useState(false);
 
-  const amountResult = validateTuzis(amount, { minimum: 1, maximum: MAX_TUZIS });
+  useEffect(() => {
+    if (!restoredTip) return;
+    setAmount(restoredTip.amount);
+    setOpen(true);
+  }, [restoredTip]);
+
+  const amountResult = validateTuzis(amount, {
+    minimum: 1,
+    maximum: MAX_TUZIS,
+  });
   const parsedAmount = amountResult.value;
   const validAmount = amountResult.error === null;
-  const enough = parsedAmount !== null && parsedAmount <= balance;
-  const canSend = validAmount && enough && !busy;
+  const gate = paidActionGate({
+    sessionLoading,
+    user,
+    balance,
+    cost: validAmount ? parsedAmount : null,
+  });
+  const canSend = validAmount && gate === "ready" && !busy;
+
+  function signInToTip() {
+    const returnTo = preservePaidIntent(location.pathname, {
+      kind: "creator-tip",
+      subject: creator.username,
+      amount,
+    });
+    navigate("/login", { state: { returnTo } });
+  }
 
   async function send() {
+    if (!useSession.getState().user || gate === "sign-in") {
+      signInToTip();
+      return;
+    }
     if (!canSend || parsedAmount === null) return;
     setBusy(true);
     try {
@@ -837,13 +944,25 @@ function TipButton({ creator }: { creator: CreatorDetail }) {
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
               className="tabular-nums"
-              aria-describedby="creator-tip-error creator-tip-balance"
+              aria-describedby={
+                user
+                  ? "creator-tip-error creator-tip-balance"
+                  : "creator-tip-error"
+              }
               aria-invalid={amount.length > 0 && !validAmount}
             />
-            <p id="creator-tip-balance" className="text-xs text-muted-foreground tabular-nums">
-              Balance: {formatTuzis(balance)}
-            </p>
-            <p id="creator-tip-error" className="min-h-[1rem] text-xs text-destructive">
+            {user ? (
+              <p
+                id="creator-tip-balance"
+                className="text-xs text-muted-foreground tabular-nums"
+              >
+                Balance: {formatTuzis(balance)}
+              </p>
+            ) : null}
+            <p
+              id="creator-tip-error"
+              className="min-h-[1rem] text-xs text-destructive"
+            >
               {amountResult.error === "tooLarge"
                 ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per tip.`
                 : amount.length > 0 && amountResult.error !== null
@@ -854,10 +973,21 @@ function TipButton({ creator }: { creator: CreatorDetail }) {
         </div>
 
         <DialogFooter>
-          <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
+          <Button
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={busy}
+          >
             Cancel
           </Button>
-          {validAmount && !enough ? (
+          {gate === "loading" ? (
+            <Button disabled>
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Checking account
+            </Button>
+          ) : gate === "sign-in" ? (
+            <Button onClick={signInToTip}>Sign in to tip</Button>
+          ) : validAmount && gate === "low-balance" ? (
             <Button
               variant="outline"
               onClick={() => {
@@ -876,7 +1006,10 @@ function TipButton({ creator }: { creator: CreatorDetail }) {
                   Sending
                 </>
               ) : (
-                <>Send {parsedAmount !== null ? formatTuzis(parsedAmount) : "2Zs"}</>
+                <>
+                  Send{" "}
+                  {parsedAmount !== null ? formatTuzis(parsedAmount) : "2Zs"}
+                </>
               )}
             </Button>
           )}

--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -1,10 +1,5 @@
-import { useMemo, useRef, useState } from "react";
-import {
-  Link,
-  useLocation,
-  useNavigate,
-  useParams,
-} from "react-router-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
   Users,
@@ -37,7 +32,10 @@ import { EmptyState } from "@/components/common/EmptyState";
 import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { auth, live, tuzi } from "@/lib/api/free2z";
 import { ApiError } from "@/lib/api/http";
+import { paidActionGate } from "@/lib/auth/paid-action";
+import { preservePaidIntent } from "@/lib/auth/paid-intent";
 import { useAsync } from "@/hooks/useAsync";
+import { usePaidIntent } from "@/hooks/usePaidIntent";
 import { useSession } from "@/store/session";
 import { formatTuzis, timeAgo, initials } from "@/lib/format";
 import type { DyteJoinTicket, Livestream, StreamKind } from "@/lib/api/types";
@@ -331,7 +329,14 @@ function JoinPanel({
   tuzis: number;
   onJoined: (ticket: DyteJoinTicket) => void;
 }) {
+  const navigate = useNavigate();
+  const location = useLocation();
   const kind = KIND_META[stream.kind] ?? KIND_META.broadcast;
+  const restored = usePaidIntent(location.pathname, "live-entry");
+  const restoredEntry =
+    restored?.kind === "live-entry" && restored.subject === stream.username
+      ? restored
+      : null;
   const [busy, setBusy] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [membershipConfirmOpen, setMembershipConfirmOpen] = useState(false);
@@ -343,6 +348,7 @@ function JoinPanel({
   // Keep this key through any ambiguous failure. A retry then asks the backend
   // to replay the same purchase instead of buying another month.
   const membershipAttemptKey = useRef<string | null>(null);
+  const restoredEntryHandled = useRef(false);
 
   const user = useSession((state) => state.user);
   const sessionLoading = useSession((state) => state.loading);
@@ -354,14 +360,17 @@ function JoinPanel({
     reload: reloadMemberships,
   } = useAsync(
     () =>
-      user
-        ? tuzi.subscriptionStatus(stream.username)
-        : Promise.resolve(null),
+      user ? tuzi.subscriptionStatus(stream.username) : Promise.resolve(null),
     [user?.username, stream.username],
   );
 
   const price = stream.price_tuzis;
-  const affordable = tuzis >= price;
+  const ppvGate = paidActionGate({
+    sessionLoading,
+    user,
+    balance: tuzis,
+    cost: price,
+  });
   const membershipPrice =
     membershipPriceOverride !== null
       ? membershipPriceOverride.price
@@ -372,7 +381,41 @@ function JoinPanel({
     hasMembershipPrice && tuzis >= (membershipPrice ?? 0);
   const membership = membershipStatus?.active ? membershipStatus : null;
 
-  async function runExclusive<T>(operation: () => Promise<T>): Promise<T | null> {
+  function signInForEntry(mode: "ppv" | "subscriber") {
+    const returnTo = preservePaidIntent(location.pathname, {
+      kind: "live-entry",
+      subject: stream.username,
+      mode,
+    });
+    navigate("/login", { state: { returnTo } });
+  }
+
+  useEffect(() => {
+    if (!restoredEntry || restoredEntryHandled.current || !user) return;
+    if (restoredEntry.mode === "ppv") {
+      if (ppvGate === "loading") return;
+      restoredEntryHandled.current = true;
+      if (ppvGate === "ready") setConfirmOpen(true);
+      return;
+    }
+    if (membershipLoading) return;
+    restoredEntryHandled.current = true;
+    if (!membershipError && !membership && membershipAffordable) {
+      setMembershipConfirmOpen(true);
+    }
+  }, [
+    restoredEntry,
+    user,
+    ppvGate,
+    membershipLoading,
+    membershipError,
+    membership,
+    membershipAffordable,
+  ]);
+
+  async function runExclusive<T>(
+    operation: () => Promise<T>,
+  ): Promise<T | null> {
     // React state updates are not synchronous. The ref closes the double-click
     // window before the disabled button can render.
     return runSingleFlight(operationInFlight, async () => {
@@ -407,6 +450,11 @@ function JoinPanel({
 
   async function confirmPpv() {
     setConfirmOpen(false);
+    if (!useSession.getState().user) {
+      signInForEntry("ppv");
+      return;
+    }
+    if (ppvGate !== "ready") return;
     const ok = await doJoin();
     if (ok) {
       // onJoined has already debited the balance; celebrate the entry.
@@ -417,7 +465,10 @@ function JoinPanel({
   }
 
   async function confirmMembership() {
-    if (!user) return;
+    if (!useSession.getState().user) {
+      signInForEntry("subscriber");
+      return;
+    }
     const alreadyActive = membership !== null;
     if (
       !alreadyActive &&
@@ -574,11 +625,13 @@ function JoinPanel({
                 Checking membership
               </Button>
             ) : !user ? (
-              <Button asChild className="w-full gap-2" size="lg">
-                <Link to="/login">
-                  <KeyRound className="h-4 w-4" aria-hidden />
-                  Log in to subscribe
-                </Link>
+              <Button
+                className="w-full gap-2"
+                size="lg"
+                onClick={() => signInForEntry("subscriber")}
+              >
+                <KeyRound className="h-4 w-4" aria-hidden />
+                Log in to subscribe
               </Button>
             ) : membershipError ? (
               <div className="space-y-2">
@@ -684,7 +737,9 @@ function JoinPanel({
                     </span>
                   </div>
                   <div className="flex items-center justify-between gap-3">
-                    <span className="text-muted-foreground">Current balance</span>
+                    <span className="text-muted-foreground">
+                      Current balance
+                    </span>
                     <span className="font-medium tabular-nums">
                       {formatTuzis(tuzis)}
                     </span>
@@ -693,9 +748,7 @@ function JoinPanel({
                   <div className="flex items-center justify-between gap-3">
                     <span className="text-muted-foreground">Balance after</span>
                     <span className="font-semibold tabular-nums">
-                      {formatTuzis(
-                        Math.max(0, tuzis - (membershipPrice ?? 0)),
-                      )}
+                      {formatTuzis(Math.max(0, tuzis - (membershipPrice ?? 0)))}
                     </span>
                   </div>
                 </div>
@@ -737,7 +790,21 @@ function JoinPanel({
                 {formatTuzis(price)}
               </span>
             </div>
-            {affordable ? (
+            {ppvGate === "loading" ? (
+              <Button className="w-full gap-2" size="lg" disabled>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Checking account
+              </Button>
+            ) : ppvGate === "sign-in" ? (
+              <Button
+                className="w-full gap-2"
+                size="lg"
+                onClick={() => signInForEntry("ppv")}
+              >
+                <KeyRound className="h-4 w-4" aria-hidden />
+                Sign in to join
+              </Button>
+            ) : ppvGate === "ready" ? (
               <Button
                 className="w-full gap-2"
                 size="lg"
@@ -789,10 +856,7 @@ function JoinPanel({
                   </span>
                 </div>
                 <DialogFooter>
-                  <Button
-                    variant="ghost"
-                    onClick={() => setConfirmOpen(false)}
-                  >
+                  <Button variant="ghost" onClick={() => setConfirmOpen(false)}>
                     Cancel
                   </Button>
                   <Button className="gap-2" onClick={confirmPpv}>
@@ -891,11 +955,7 @@ function ConnectedDetails({
       </dl>
       <Separator className="my-3" />
       <ParticipantStrip count={stream.participants + 1} />
-      <Button
-        variant="outline"
-        className="mt-4 w-full gap-2"
-        onClick={onLeave}
-      >
+      <Button variant="outline" className="mt-4 w-full gap-2" onClick={onLeave}>
         <LogOut className="h-4 w-4" aria-hidden />
         Leave
       </Button>
@@ -930,12 +990,16 @@ function HostControls({
       </div>
       <p className="mt-3 text-xs text-muted-foreground">
         You're hosting as{" "}
-        <span className="font-medium text-foreground">@{stream.username}</span>
-        . Manage your broadcast below.
+        <span className="font-medium text-foreground">@{stream.username}</span>.
+        Manage your broadcast below.
       </p>
       <Separator className="my-3" />
       <ParticipantStrip count={stream.participants + 1} />
-      <Button variant="destructive" className="mt-4 w-full gap-2" onClick={onEnd}>
+      <Button
+        variant="destructive"
+        className="mt-4 w-full gap-2"
+        onClick={onEnd}
+      >
         <Radio className="h-4 w-4" aria-hidden />
         End stream
       </Button>

--- a/wallet/zuuli/src/features/wallet/funding-route.test.ts
+++ b/wallet/zuuli/src/features/wallet/funding-route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { isWalletFundingPath } from ".";
+import { fundingTabForPath } from "./funding";
 
 describe("Wallet funding route", () => {
   it.each(["/wallet/fund", "/wallet/fund/card"])(
@@ -8,6 +9,16 @@ describe("Wallet funding route", () => {
       expect(isWalletFundingPath(pathname)).toBe(true);
     },
   );
+
+  it.each([
+    ["/wallet/fund", "buy"],
+    ["/wallet/fund/send", "send"],
+    ["/wallet/fund/send/", "send"],
+    ["/wallet/fund/activity", "activity"],
+    ["/wallet/fund/activity/", "activity"],
+  ] as const)("selects the addressable funding tab for %s", (pathname, tab) => {
+    expect(fundingTabForPath(pathname)).toBe(tab);
+  });
 
   it.each(["/wallet", "/wallet/funding", "/wallet/fundraiser", "/wallet/fund-me"])(
     "does not bypass wallet setup for a prefix lookalike: %s",

--- a/wallet/zuuli/src/features/wallet/funding/ActivityTab.tsx
+++ b/wallet/zuuli/src/features/wallet/funding/ActivityTab.tsx
@@ -1,6 +1,8 @@
-import { Receipt, TrendingUp, TrendingDown } from "lucide-react";
+import { LogIn, Receipt, TrendingUp, TrendingDown } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
 import { SectionLoadError } from "@/components/common/SectionLoadError";
@@ -9,17 +11,24 @@ import { tuzi } from "@/lib/api/free2z";
 import type { TuziTransaction } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import { formatTuzis, timeAgo } from "@/lib/format";
+import { useSession } from "@/store/session";
 import { kindMeta, kindIconClass } from "./lib";
 
 export function ActivityTab() {
+  const navigate = useNavigate();
+  const user = useSession((state) => state.user);
+  const sessionLoading = useSession((state) => state.loading);
   const {
     data: txns,
     loading,
     error,
     reload,
-  } = useAsync<TuziTransaction[]>(() => tuzi.transactions(), []);
+  } = useAsync<TuziTransaction[]>(
+    () => (user ? tuzi.transactions() : Promise.resolve([])),
+    [user?.username],
+  );
 
-  if (loading && txns === null && !error) {
+  if (sessionLoading || (user && loading && txns === null && !error)) {
     return (
       <div className="space-y-3">
         <div className="grid gap-3 sm:grid-cols-2">
@@ -33,11 +42,33 @@ export function ActivityTab() {
     );
   }
 
+  if (!user) {
+    return (
+      <EmptyState
+        icon={Receipt}
+        title="Sign in to view activity"
+        description="Card purchase history belongs to your account."
+        action={
+          <Button
+            onClick={() =>
+              navigate("/login", {
+                state: { returnTo: "/wallet/fund/activity" },
+              })
+            }
+          >
+            <LogIn className="h-4 w-4" aria-hidden />
+            Sign in
+          </Button>
+        }
+      />
+    );
+  }
+
   if (error && txns === null) {
     return (
       <SectionLoadError
-        title="Couldn't load 2Z activity"
-        description="Your 2Z activity is temporarily unavailable."
+        title="Couldn't load purchase history"
+        description="Your card purchase history is temporarily unavailable."
         retry={reload}
         retrying={loading}
       />
@@ -51,8 +82,8 @@ export function ActivityTab() {
       <div className="space-y-3">
         {error ? (
           <SectionLoadError
-            title="Couldn't refresh 2Z activity"
-            description="Showing the last 2Z activity loaded on this device."
+            title="Couldn't refresh purchase history"
+            description="Showing the last card purchase history loaded on this device."
             retry={reload}
             retrying={loading}
             stale
@@ -60,8 +91,8 @@ export function ActivityTab() {
         ) : null}
         <EmptyState
           icon={Receipt}
-          title="No activity yet"
-          description="Your 2Z purchases, tips and charges will show up here."
+          title="No card purchases yet"
+          description="Your available card purchase history will show up here."
         />
       </div>
     );
@@ -78,8 +109,8 @@ export function ActivityTab() {
     <div className="space-y-4">
       {error ? (
         <SectionLoadError
-          title="Couldn't refresh 2Z activity"
-          description="Showing the last 2Z activity loaded on this device."
+          title="Couldn't refresh purchase history"
+          description="Showing the last card purchase history loaded on this device."
           retry={reload}
           retrying={loading}
           stale
@@ -113,13 +144,9 @@ export function ActivityTab() {
             const Icon = meta.icon;
             const credit = t.tuzis_credited > 0;
             const label =
-              t.counterparty ??
-              (t.kind === "buy" ? "Added 2Zs" : meta.label);
+              t.counterparty ?? (t.kind === "buy" ? "Added 2Zs" : meta.label);
             return (
-              <div
-                key={t.id}
-                className="flex items-center gap-3 px-4 py-3.5"
-              >
+              <div key={t.id} className="flex items-center gap-3 px-4 py-3.5">
                 <div
                   className={cn(
                     "grid h-10 w-10 shrink-0 place-items-center rounded-full",

--- a/wallet/zuuli/src/features/wallet/funding/BuyTab.tsx
+++ b/wallet/zuuli/src/features/wallet/funding/BuyTab.tsx
@@ -87,7 +87,10 @@ export function BuyTab() {
   // The custom field wins whenever it has input, keeping one source of
   // truth for "amount". Everything downstream reads `amount`.
   const hasCustomAmount = custom.length > 0;
-  const customAmount = validateTuzis(custom, { minimum: 1, maximum: MAX_TUZIS });
+  const customAmount = validateTuzis(custom, {
+    minimum: 1,
+    maximum: MAX_TUZIS,
+  });
   const customTuzis = customAmount.value;
   const amount = hasCustomAmount ? customTuzis : selected;
   const valid = !hasCustomAmount || customAmount.error === null;
@@ -99,7 +102,7 @@ export function BuyTab() {
   // `zec_amount`. A cancel flag keeps only the latest request's result, and a
   // 503 / fetch error surfaces as an "unavailable" state (no fabricated number).
   useEffect(() => {
-    if (!zecDemoEnabled || !valid || amount === null) {
+    if (!user || !zecDemoEnabled || !valid || amount === null) {
       setQuoteState({ status: "idle" });
       return;
     }
@@ -121,7 +124,7 @@ export function BuyTab() {
       ctrl.abort();
       clearTimeout(t);
     };
-  }, [amount, valid, zecDemoEnabled]);
+  }, [amount, user, valid, zecDemoEnabled]);
 
   const quote = quoteState.status === "ready" ? quoteState.quote : null;
   const zatoshisNeeded = quote ? zatoshisFromQuote(quote) : null;
@@ -135,7 +138,7 @@ export function BuyTab() {
 
   async function payWithCard() {
     if (!valid || amount === null) return;
-    const authenticated = user !== null;
+    const authenticated = useSession.getState().user !== null;
     if (authenticated) setCardLoading(true);
     try {
       const result = await startCardCheckout({
@@ -163,6 +166,10 @@ export function BuyTab() {
   }
 
   async function payWithZec() {
+    if (!useSession.getState().user) {
+      navigate("/login", { state: { returnTo: "/wallet/fund" } });
+      return;
+    }
     if (
       !zecDemoEnabled ||
       !valid ||
@@ -186,9 +193,9 @@ export function BuyTab() {
   }
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[1.5fr_1fr]">
+    <div className="grid min-w-0 grid-cols-1 gap-6 lg:grid-cols-[1.5fr_1fr]">
       {/* Packs + custom */}
-      <div className="space-y-5">
+      <div className="min-w-0 space-y-5">
         <div>
           <h2 className="text-sm font-semibold">Choose an amount</h2>
           <p className="text-sm text-muted-foreground">
@@ -270,7 +277,7 @@ export function BuyTab() {
       </div>
 
       {/* Checkout panel */}
-      <Card className="h-fit lg:sticky lg:top-4">
+      <Card className="h-fit min-w-0 lg:sticky lg:top-4">
         <CardHeader className="pb-4">
           <CardTitle className="flex items-baseline justify-between">
             <span>You pay</span>
@@ -314,18 +321,28 @@ export function BuyTab() {
             variant="zec"
             className="w-full"
             disabled={
-              !zecDemoEnabled ||
+              sessionLoading ||
+              (user !== null && !zecDemoEnabled) ||
               !valid ||
-              !validQuote ||
-              !enoughZec ||
-              quoteLoading
+              (user !== null && (!validQuote || !enoughZec || quoteLoading))
             }
-            onClick={() => setZecConfirm(true)}
+            onClick={() => {
+              if (!user) void payWithZec();
+              else setZecConfirm(true);
+            }}
           >
-            <Wallet className="h-4 w-4" />
-            {zecDemoEnabled ? "Demo: Pay with ZEC" : "Pay with ZEC unavailable"}
+            {!user ? (
+              <LogIn className="h-4 w-4" />
+            ) : (
+              <Wallet className="h-4 w-4" />
+            )}
+            {!user
+              ? "Log in to pay with ZEC"
+              : zecDemoEnabled
+                ? "Demo: Pay with ZEC"
+                : "Pay with ZEC unavailable"}
           </Button>
-          {zecDemoEnabled ? (
+          {user && zecDemoEnabled ? (
             <>
               <div className="space-y-1 text-xs">
                 <div className="flex items-center justify-between text-muted-foreground">
@@ -363,16 +380,16 @@ export function BuyTab() {
                 )}
               </div>
               <p className="text-xs text-muted-foreground">
-                Demo only: this changes a local mock 2Z balance. It does not send
-                ZEC or create a real purchase.
+                Demo only: this changes a local mock 2Z balance. It does not
+                send ZEC or create a real purchase.
               </p>
             </>
-          ) : (
+          ) : user ? (
             <p className="text-xs text-muted-foreground">
               ZEC top-ups are not available yet. No ZEC will be sent and no 2Z
               balance will change. Pay with card for now.
             </p>
-          )}
+          ) : null}
         </CardContent>
       </Card>
 
@@ -412,7 +429,8 @@ export function BuyTab() {
             />
           </div>
           <p className="text-xs text-muted-foreground">
-            Demo only: no transaction is proposed, signed, broadcast, or settled.
+            Demo only: no transaction is proposed, signed, broadcast, or
+            settled.
           </p>
           <DialogFooter>
             <Button

--- a/wallet/zuuli/src/features/wallet/funding/SendTab.tsx
+++ b/wallet/zuuli/src/features/wallet/funding/SendTab.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type KeyboardEvent,
 } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   AlertCircle,
   ArrowRight,
@@ -40,10 +41,14 @@ import {
   formatTuzis,
   initials,
   MAX_TUZIS,
+  parseTuzis,
   tuziInputMaxLength,
   validateTuzis,
 } from "@/lib/format";
 import { TIP_PRESETS } from "./lib";
+import { paidActionGate } from "@/lib/auth/paid-action";
+import { preservePaidIntent } from "@/lib/auth/paid-intent";
+import { usePaidIntent } from "@/hooks/usePaidIntent";
 import {
   classifyTransferFailure,
   clearPendingDonation,
@@ -76,15 +81,19 @@ function useDebounced<T>(value: T, delay: number): T {
 }
 
 export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
+  const navigate = useNavigate();
   const user = useSession((s) => s.user);
+  const sessionLoading = useSession((s) => s.loading);
   const tuzis = useSession((s) => s.tuzis);
   const setTuzis = useSession((s) => s.setTuzis);
   const setUser = useSession((s) => s.setUser);
   const refreshSession = useSession((s) => s.refresh);
-  const [recipientState, dispatch] = useReducer(
-    recipientReducer,
-    initialRecipientState,
-  );
+  const restored = usePaidIntent("/wallet/fund/send", "send");
+  const restoredSend = restored?.kind === "send" ? restored : null;
+  const restoredHandled = useRef(false);
+  const [recipientState, dispatch] = useReducer(recipientReducer, {
+    ...initialRecipientState,
+  });
   const [selectedAmount, setSelectedAmount] = useState<number>(TIP_PRESETS[1]);
   const [custom, setCustom] = useState("");
   const [sending, setSending] = useState(false);
@@ -96,6 +105,23 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
     result: DonationResult;
   } | null>(null);
   const resultsId = useId();
+
+  useEffect(() => {
+    if (!restoredSend || restoredHandled.current) return;
+    restoredHandled.current = true;
+    dispatch({ type: "queryChanged", query: restoredSend.query });
+    const restoredAmount = parseTuzis(restoredSend.amount);
+    if (
+      restoredAmount !== null &&
+      TIP_PRESETS.some((preset) => preset === restoredAmount)
+    ) {
+      setSelectedAmount(restoredAmount);
+      setCustom("");
+    } else {
+      setCustom(restoredSend.amount);
+    }
+  }, [restoredSend]);
+
   const debouncedQuery = useDebounced(
     recipientState.query.trim(),
     SEARCH_DEBOUNCE_MS,
@@ -128,8 +154,8 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
       .then((creators) => {
         if (!alive) return;
         const candidates = ownUsername
-          ? creators.filter((creator) =>
-              !sameUsername(creator.username, ownUsername),
+          ? creators.filter(
+              (creator) => !sameUsername(creator.username, ownUsername),
             )
           : creators;
         dispatch({ type: "searchSucceeded", generation, results: candidates });
@@ -152,10 +178,19 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
   ]);
 
   const hasCustomAmount = custom.length > 0;
-  const customAmount = validateTuzis(custom, { minimum: 1, maximum: MAX_TUZIS });
+  const customAmount = validateTuzis(custom, {
+    minimum: 1,
+    maximum: MAX_TUZIS,
+  });
   const amount = hasCustomAmount ? customAmount.value : selectedAmount;
   const validAmount = !hasCustomAmount || customAmount.error === null;
   const enough = amount !== null && amount <= tuzis;
+  const gate = paidActionGate({
+    sessionLoading,
+    user,
+    balance: tuzis,
+    cost: validAmount ? amount : null,
+  });
   const block = transferBlock({
     selected: recipientState.selected,
     query: recipientState.query,
@@ -168,23 +203,23 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
   const pendingDonation = loadPendingDonation();
   const pendingMatchesCurrent = Boolean(
     pendingDonation &&
-      recipientState.selected &&
-      ownUsername &&
-      amount !== null &&
-      validAmount &&
-      pendingDonationMatches(pendingDonation, {
-        senderUsername: ownUsername,
-        recipient: recipientState.selected,
-        amount,
-      }),
+    recipientState.selected &&
+    ownUsername &&
+    amount !== null &&
+    validAmount &&
+    pendingDonationMatches(pendingDonation, {
+      senderUsername: ownUsername,
+      recipient: recipientState.selected,
+      amount,
+    }),
   );
   const canReview =
     block === null || (block === "balance" && pendingMatchesCurrent);
   const reviewHasPersistedAttempt = Boolean(
     recipientState.review &&
-      pendingDonation &&
-      recipientState.review.idempotencyKey === pendingDonation.idempotencyKey &&
-      pendingDonationMatches(pendingDonation, recipientState.review),
+    pendingDonation &&
+    recipientState.review.idempotencyKey === pendingDonation.idempotencyKey &&
+    pendingDonationMatches(pendingDonation, recipientState.review),
   );
   const reviewIsCurrent = reviewMatchesTransfer({
     review: recipientState.review,
@@ -277,7 +312,20 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
     next();
   }
 
+  function signInToSend() {
+    const returnTo = preservePaidIntent("/wallet/fund/send", {
+      kind: "send",
+      query: recipientState.query,
+      amount: custom || String(selectedAmount),
+    });
+    navigate("/login", { state: { returnTo } });
+  }
+
   function beginReview() {
+    if (gate === "sign-in") {
+      signInToSend();
+      return;
+    }
     if (!canReview || amount === null || !ownUsername) return;
     const selected = recipientState.selected;
     if (!selected) return;
@@ -293,7 +341,8 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
     }
     let idempotencyKey: string;
     try {
-      idempotencyKey = pending?.idempotencyKey ?? createDonationIdempotencyKey();
+      idempotencyKey =
+        pending?.idempotencyKey ?? createDonationIdempotencyKey();
     } catch {
       setTransferFailure("security");
       return;
@@ -309,11 +358,12 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
 
   async function send() {
     const review = recipientState.review;
-    if (
-      sendingRef.current ||
-      !review ||
-      !reviewIsCurrent
-    ) {
+    if (!useSession.getState().user) {
+      dispatch({ type: "clearReview" });
+      signInToSend();
+      return;
+    }
+    if (sendingRef.current || !review || !reviewIsCurrent) {
       dispatch({ type: "clearReview" });
       return;
     }
@@ -397,7 +447,9 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
               role="combobox"
               aria-label="Search for a 2Z recipient"
               aria-autocomplete="list"
-              aria-expanded={showingResults && recipientState.results.length > 0}
+              aria-expanded={
+                showingResults && recipientState.results.length > 0
+              }
               aria-controls={
                 showingResults && recipientState.results.length > 0
                   ? resultsId
@@ -595,21 +647,26 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
               {validAmount && amount !== null ? formatTuzis(amount) : "—"}
             </div>
           </div>
-          <div className="flex items-center justify-between border-t border-border pt-3 text-sm">
-            <span className="text-muted-foreground">Balance after</span>
-            <span
-              className={cn(
-                "tabular-nums",
-                validAmount && !enough && "text-destructive",
-              )}
-            >
-              {formatTuzis(
-                Math.max(0, tuzis - (validAmount && amount !== null ? amount : 0)),
-              )}
-            </span>
-          </div>
+          {user ? (
+            <div className="flex items-center justify-between border-t border-border pt-3 text-sm">
+              <span className="text-muted-foreground">Balance after</span>
+              <span
+                className={cn(
+                  "tabular-nums",
+                  validAmount && !enough && "text-destructive",
+                )}
+              >
+                {formatTuzis(
+                  Math.max(
+                    0,
+                    tuzis - (validAmount && amount !== null ? amount : 0),
+                  ),
+                )}
+              </span>
+            </div>
+          ) : null}
 
-          {transferFailure ? (
+          {transferFailure && (user || transferFailure !== "balance") ? (
             <div
               role="alert"
               className="flex gap-2 rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
@@ -644,6 +701,16 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
                 Start another transfer
               </Button>
             </div>
+          ) : gate === "loading" ? (
+            <Button className="w-full" disabled>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Checking account
+            </Button>
+          ) : gate === "sign-in" ? (
+            <Button className="w-full" onClick={signInToSend}>
+              Sign in to send 2Z
+              <ArrowRight className="h-4 w-4" />
+            </Button>
           ) : block === "balance" && !pendingMatchesCurrent ? (
             <Button variant="outline" className="w-full" onClick={onNeedBuy}>
               Not enough 2Z — buy more

--- a/wallet/zuuli/src/features/wallet/funding/index.tsx
+++ b/wallet/zuuli/src/features/wallet/funding/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Coins, Gift, Receipt } from "lucide-react";
 import { PageHeader } from "@/components/common/PageHeader";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -6,11 +6,35 @@ import { BalanceHero } from "./BalanceHero";
 import { BuyTab } from "./BuyTab";
 import { SendTab } from "./SendTab";
 import { ActivityTab } from "./ActivityTab";
+import { useSession } from "@/store/session";
 
 type TabKey = "buy" | "send" | "activity";
 
+export function fundingTabForPath(pathname: string): TabKey {
+  const canonicalPath =
+    pathname.endsWith("/") && pathname !== "/"
+      ? pathname.slice(0, -1)
+      : pathname;
+  if (canonicalPath === "/wallet/fund/send") return "send";
+  if (canonicalPath === "/wallet/fund/activity") return "activity";
+  return "buy";
+}
+
 export default function FundingFeature() {
-  const [tab, setTab] = useState<TabKey>("buy");
+  const location = useLocation();
+  const navigate = useNavigate();
+  const user = useSession((state) => state.user);
+  const tab = fundingTabForPath(location.pathname);
+
+  function selectTab(next: TabKey) {
+    const destination =
+      next === "send"
+        ? "/wallet/fund/send"
+        : next === "activity"
+          ? "/wallet/fund/activity"
+          : "/wallet/fund";
+    if (location.pathname !== destination) navigate(destination);
+  }
 
   return (
     <div className="animate-fade-in space-y-6">
@@ -19,9 +43,9 @@ export default function FundingFeature() {
         description="Buy or send 2Zs and review activity."
       />
 
-      <BalanceHero />
+      {user ? <BalanceHero /> : null}
 
-      <Tabs value={tab} onValueChange={(v) => setTab(v as TabKey)}>
+      <Tabs value={tab} onValueChange={(v) => selectTab(v as TabKey)}>
         <TabsList className="grid w-full grid-cols-3 sm:inline-flex sm:w-auto">
           <TabsTrigger value="buy" className="gap-1.5">
             <Coins className="h-4 w-4" />
@@ -41,10 +65,10 @@ export default function FundingFeature() {
           <BuyTab />
         </TabsContent>
         <TabsContent value="send">
-          <SendTab onNeedBuy={() => setTab("buy")} />
+          <SendTab onNeedBuy={() => selectTab("buy")} />
         </TabsContent>
         <TabsContent value="activity">
-          <ActivityTab />
+          <ActivityTab key={user?.username ?? "guest"} />
         </TabsContent>
       </Tabs>
     </div>

--- a/wallet/zuuli/src/hooks/usePaidIntent.ts
+++ b/wallet/zuuli/src/hooks/usePaidIntent.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from "react";
+import { consumePaidIntent, type PaidIntent } from "@/lib/auth/paid-intent";
+import { safeLoginDestination } from "@/lib/auth/login-destination";
+import { useSession } from "@/store/session";
+
+/**
+ * Consume a paid-action draft once after commit. The ref survives React
+ * StrictMode's development effect replay, while the session-storage record is
+ * still destroyed before validation and can never be consumed on a later
+ * mount.
+ */
+export function usePaidIntent(
+  returnTo: unknown,
+  expectedKinds: PaidIntent["kind"] | readonly PaidIntent["kind"][],
+): PaidIntent | null {
+  const user = useSession((state) => state.user);
+  const sessionLoading = useSession((state) => state.loading);
+  const destination = safeLoginDestination(returnTo);
+  const kinds = Array.isArray(expectedKinds)
+    ? expectedKinds.join(",")
+    : expectedKinds;
+  const consumeKey = `${destination}\u0000${kinds}`;
+  const consumedKey = useRef<string | null>(null);
+  const [result, setResult] = useState<{
+    key: string;
+    intent: PaidIntent | null;
+  }>({ key: "", intent: null });
+
+  useEffect(() => {
+    // A guest returning with browser Back must not restore private input. The
+    // login route owns abandonment cleanup; only a completed, bootstrapped
+    // session is allowed to consume the one-shot record.
+    if (sessionLoading || !user) return;
+    if (consumedKey.current === consumeKey) return;
+    consumedKey.current = consumeKey;
+    setResult({
+      key: consumeKey,
+      intent: consumePaidIntent(destination, expectedKinds),
+    });
+  }, [consumeKey, destination, expectedKinds, sessionLoading, user]);
+
+  return result.key === consumeKey ? result.intent : null;
+}

--- a/wallet/zuuli/src/lib/auth/login-destination.test.ts
+++ b/wallet/zuuli/src/lib/auth/login-destination.test.ts
@@ -3,6 +3,7 @@ import {
   consumePendingSocialLoginDestination,
   loginDestinationFromState,
   rememberPendingSocialLoginDestination,
+  safeLoginDestination,
 } from "./login-destination";
 
 class MemoryStorage {
@@ -22,15 +23,31 @@ class MemoryStorage {
 }
 
 describe("post-login destination", () => {
-  it("accepts the exact Wallet funding route", () => {
-    expect(loginDestinationFromState({ returnTo: "/wallet/fund" })).toBe(
-      "/wallet/fund",
-    );
+  it.each([
+    "/ai",
+    "/wallet/fund",
+    "/wallet/fund/activity",
+    "/wallet/fund/send",
+    "/articles/post-1",
+    "/articles/-private_notes",
+    "/creator/alice",
+    "/creator/@alice+news",
+    `/creator/${"a".repeat(150)}`,
+    "/creator/%C3%A9lodie",
+    "/creator/%C3%A9lodie+news",
+    "/live/%F0%90%90%80@news",
+    "/live/alice",
+    "/live/_alice",
+  ] as const)("accepts the exact paid destination %s", (returnTo) => {
+    expect(loginDestinationFromState({ returnTo })).toBe(returnTo);
   });
 
   it("normalizes the legacy exact Buy route for in-flight logins", () => {
     expect(loginDestinationFromState({ returnTo: "/buy" })).toBe(
       "/wallet/fund",
+    );
+    expect(loginDestinationFromState({ returnTo: "/buy/send" })).toBe(
+      "/wallet/fund/send",
     );
   });
 
@@ -40,6 +57,14 @@ describe("post-login destination", () => {
     {},
     { returnTo: "/" },
     { returnTo: "/buy/" },
+    { returnTo: "/articles/a/b" },
+    { returnTo: "/articles/privacy~today" },
+    { returnTo: "/creator/alice?admin=1" },
+    { returnTo: "/creator/élodie" },
+    { returnTo: "/creator/%C3%A9lodie%2Bnews" },
+    { returnTo: "/live/%F0%90%90%80%40news" },
+    { returnTo: `/creator/${"a".repeat(151)}` },
+    { returnTo: "/live/%61lice" },
     { returnTo: "https://evil.example/wallet/fund" },
     { returnTo: "//evil.example/wallet/fund" },
     { returnTo: "/wallet/fund?next=https://evil.example" },
@@ -69,6 +94,24 @@ describe("post-login destination", () => {
     expect(consumePendingSocialLoginDestination(storage)).toBe("/wallet/fund");
     expect(consumePendingSocialLoginDestination(storage)).toBe("/");
   });
+
+  it("uses the same allowlist for direct and persisted redirect input", () => {
+    expect(safeLoginDestination("/articles/-privacy_today")).toBe(
+      "/articles/-privacy_today",
+    );
+    expect(safeLoginDestination("//evil.example/articles/privacy")).toBe("/");
+  });
+
+  it.each([
+    ["/articles/privacy/", "/articles/privacy"],
+    ["/creator/alice/", "/creator/alice"],
+    ["/live/alice/", "/live/alice"],
+  ] as const)(
+    "canonicalizes the valid trailing-slash route %s",
+    (input, expected) => {
+      expect(safeLoginDestination(input)).toBe(expected);
+    },
+  );
 
   it("migrates a pending legacy Buy destination once", () => {
     const storage = new MemoryStorage();

--- a/wallet/zuuli/src/lib/auth/login-destination.ts
+++ b/wallet/zuuli/src/lib/auth/login-destination.ts
@@ -1,4 +1,12 @@
-export type LoginDestination = "/" | "/wallet/fund";
+export type LoginDestination =
+  | "/"
+  | "/ai"
+  | "/wallet/fund"
+  | "/wallet/fund/activity"
+  | "/wallet/fund/send"
+  | `/articles/${string}`
+  | `/creator/${string}`
+  | `/live/${string}`;
 
 export const DEFAULT_LOGIN_DESTINATION: LoginDestination = "/";
 
@@ -7,21 +15,74 @@ const PENDING_SOCIAL_LOGIN_DESTINATION =
 
 type DestinationStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
-/**
- * Resolve history state through a deliberately tiny allowlist. This must never
- * become a generic internal-URL redirect: login currently needs only Wallet's
- * exact funding route.
- */
+// Redirect input crosses history and storage boundaries. Match each dynamic
+// segment to its backend schema, while accepting only canonical percent
+// encoding for non-ASCII usernames. ASCII escapes such as `%61` stay rejected
+// so one identity cannot have ambiguous redirect spellings.
+const USERNAME = /^[\p{L}\p{N}_.@+-]+$/u;
+const ARTICLE_VANITY = /^[-A-Za-z0-9_]+$/;
+
+function decodedCanonicalSegment(segment: string): string | null {
+  if (!segment.includes("%")) {
+    return /^[\x00-\x7F]*$/.test(segment) ? segment : null;
+  }
+  try {
+    const decoded = decodeURIComponent(segment);
+    if (/^[\x00-\x7F]*$/.test(decoded)) return null;
+    // Browser pathnames encode Unicode while retaining these valid username
+    // punctuation characters when they were written literally. Keep that one
+    // spelling canonical; accepting `%2B`/`%40` as well would give one route
+    // two persisted redirect spellings.
+    const canonical = encodeURIComponent(decoded)
+      .replace(/%2B/g, "+")
+      .replace(/%40/g, "@");
+    return canonical === segment ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
+function dynamicPaidDestination(value: string): LoginDestination | null {
+  // React Router accepts one trailing slash on these leaf routes. Collapse it
+  // to the canonical spelling before validation and persistence so a valid
+  // paid flow returns to the same resource instead of falling back home.
+  const canonicalValue = value.endsWith("/") ? value.slice(0, -1) : value;
+  const match = /^\/(articles|creator|live)\/([^/]+)$/.exec(canonicalValue);
+  if (!match) return null;
+  const [, route, encodedSegment] = match;
+  const segment = decodedCanonicalSegment(encodedSegment);
+  if (!segment) return null;
+  const length = [...segment].length;
+  const valid =
+    route === "articles"
+      ? length <= 128 && ARTICLE_VANITY.test(segment)
+      : length <= 150 && USERNAME.test(segment);
+  return valid ? (canonicalValue as LoginDestination) : null;
+}
+
+export function safeLoginDestination(value: unknown): LoginDestination {
+  if (value === "/buy") return "/wallet/fund";
+  if (value === "/buy/send") return "/wallet/fund/send";
+  if (
+    value === "/ai" ||
+    value === "/wallet/fund" ||
+    value === "/wallet/fund/activity" ||
+    value === "/wallet/fund/send"
+  ) {
+    return value;
+  }
+  return typeof value === "string"
+    ? (dynamicPaidDestination(value) ?? DEFAULT_LOGIN_DESTINATION)
+    : DEFAULT_LOGIN_DESTINATION;
+}
+
+/** Resolve history state through the paid-route allowlist. */
 export function loginDestinationFromState(state: unknown): LoginDestination {
   try {
     if (typeof state !== "object" || state === null) {
       return DEFAULT_LOGIN_DESTINATION;
     }
-
-    const returnTo = (state as { returnTo?: unknown }).returnTo;
-    if (returnTo === "/wallet/fund" || returnTo === "/buy") {
-      return "/wallet/fund";
-    }
+    return safeLoginDestination((state as { returnTo?: unknown }).returnTo);
   } catch {
     // Treat proxies/getters like any other malformed navigation state.
   }
@@ -47,7 +108,7 @@ export function rememberPendingSocialLoginDestination(
 ): void {
   if (!storage) return;
   try {
-    if (destination === "/wallet/fund") {
+    if (destination !== DEFAULT_LOGIN_DESTINATION) {
       storage.setItem(PENDING_SOCIAL_LOGIN_DESTINATION, destination);
     } else {
       storage.removeItem(PENDING_SOCIAL_LOGIN_DESTINATION);
@@ -68,7 +129,7 @@ export function consumePendingSocialLoginDestination(
   } catch {
     return DEFAULT_LOGIN_DESTINATION;
   }
-  return loginDestinationFromState({ returnTo: stored });
+  return safeLoginDestination(stored);
 }
 
 export function clearPendingSocialLoginDestination(

--- a/wallet/zuuli/src/lib/auth/paid-action.test.ts
+++ b/wallet/zuuli/src/lib/auth/paid-action.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AuthUser } from "@/lib/api/types";
+import { paidActionGate, runPaidAction } from "./paid-action";
+
+const user = { username: "alice", tuzis: 5 } as AuthUser;
+
+describe("paidActionGate", () => {
+  it("resolves session and authentication before diagnosing balance", () => {
+    expect(
+      paidActionGate({
+        sessionLoading: true,
+        user: null,
+        balance: 0,
+        cost: 10,
+      }),
+    ).toBe("loading");
+    expect(
+      paidActionGate({
+        sessionLoading: false,
+        user: null,
+        balance: 0,
+        cost: 10,
+      }),
+    ).toBe("sign-in");
+    expect(
+      paidActionGate({ sessionLoading: false, user, balance: 5, cost: 10 }),
+    ).toBe("low-balance");
+    expect(
+      paidActionGate({ sessionLoading: false, user, balance: 10, cost: 10 }),
+    ).toBe("ready");
+  });
+
+  it("never invokes a protected action for loading, signed-out, or low-balance state", async () => {
+    const action = vi.fn().mockResolvedValue("called");
+    for (const state of [
+      { sessionLoading: true, user: null, balance: 0, cost: 1 },
+      { sessionLoading: false, user: null, balance: 1_000, cost: 1 },
+      { sessionLoading: false, user, balance: 0, cost: 1 },
+    ]) {
+      await runPaidAction(state, action);
+    }
+    expect(action).not.toHaveBeenCalled();
+    await expect(
+      runPaidAction(
+        { sessionLoading: false, user, balance: 5, cost: 1 },
+        action,
+      ),
+    ).resolves.toEqual({ gate: "ready", result: "called" });
+    expect(action).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    "AI conversation",
+    "article tip",
+    "creator tip",
+    "creator subscription",
+    "2Z send",
+    "card checkout",
+    "paid livestream entry",
+  ])("keeps the %s API boundary closed for a guest", async () => {
+    const protectedApi = vi.fn().mockResolvedValue(undefined);
+    const outcome = await runPaidAction(
+      { sessionLoading: false, user: null, balance: 0, cost: 100 },
+      protectedApi,
+    );
+    expect(outcome.gate).toBe("sign-in");
+    expect(protectedApi).not.toHaveBeenCalled();
+  });
+});

--- a/wallet/zuuli/src/lib/auth/paid-action.ts
+++ b/wallet/zuuli/src/lib/auth/paid-action.ts
@@ -1,0 +1,36 @@
+import type { AuthUser } from "@/lib/api/types";
+
+export type PaidActionGate = "loading" | "sign-in" | "low-balance" | "ready";
+
+/**
+ * The shared ordering for every action that can spend 2Z.
+ *
+ * Anonymous `tuzis` is deliberately initialized to zero, so balance must not
+ * be interpreted until the session has resolved and an account exists.
+ */
+export function paidActionGate({
+  sessionLoading,
+  user,
+  balance,
+  cost,
+}: {
+  sessionLoading: boolean;
+  user: AuthUser | null;
+  balance: number;
+  cost: number | null;
+}): PaidActionGate {
+  if (sessionLoading) return "loading";
+  if (!user) return "sign-in";
+  if (cost !== null && cost > balance) return "low-balance";
+  return "ready";
+}
+
+/** Testable money-boundary runner: blocked states never invoke the API task. */
+export async function runPaidAction<T>(
+  state: Parameters<typeof paidActionGate>[0],
+  action: () => Promise<T>,
+): Promise<{ gate: PaidActionGate; result?: T }> {
+  const gate = paidActionGate(state);
+  if (gate !== "ready") return { gate };
+  return { gate, result: await action() };
+}

--- a/wallet/zuuli/src/lib/auth/paid-intent.test.ts
+++ b/wallet/zuuli/src/lib/auth/paid-intent.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  consumePaidIntent,
+  discardPaidIntent,
+  discardPaidIntentForAccountTransition,
+  preservePaidIntent,
+} from "./paid-intent";
+
+class MemoryStorage {
+  value: string | null = null;
+  getItem() {
+    return this.value;
+  }
+  setItem(_key: string, value: string) {
+    this.value = value;
+  }
+  removeItem() {
+    this.value = null;
+  }
+}
+
+describe("paid login intent", () => {
+  it("round-trips a bounded draft only to its exact safe destination", () => {
+    const storage = new MemoryStorage();
+    preservePaidIntent(
+      "/ai",
+      { kind: "ai", draft: "unfinished thought" },
+      storage,
+      100,
+    );
+    expect(consumePaidIntent("/ai", "ai", storage, 200)).toEqual({
+      kind: "ai",
+      draft: "unfinished thought",
+    });
+    expect(consumePaidIntent("/ai", "ai", storage, 200)).toBeNull();
+  });
+
+  it.each([
+    ["/ai", { kind: "ai", draft: "draft" }],
+    [
+      "/articles/post",
+      { kind: "article-tip", subject: "alice", amount: "250" },
+    ],
+    ["/creator/alice", { kind: "creator-tip", subject: "alice", amount: "50" }],
+    ["/creator/alice", { kind: "creator-subscription", subject: "alice" }],
+    ["/wallet/fund/send", { kind: "send", query: "alice", amount: "500" }],
+    ["/live/alice", { kind: "live-entry", subject: "alice", mode: "ppv" }],
+  ] as const)("preserves the %s paid intent across login", (path, intent) => {
+    const storage = new MemoryStorage();
+    preservePaidIntent(path, intent, storage, 100);
+    expect(consumePaidIntent(path, intent.kind, storage, 200)).toEqual(intent);
+  });
+
+  it("destructively rejects wrong-route, wrong-kind, expired, and malformed records", () => {
+    const storage = new MemoryStorage();
+    const record = JSON.stringify({
+      returnTo: "/ai",
+      createdAt: 100,
+      intent: { kind: "ai", draft: "secret" },
+    });
+
+    storage.value = record;
+    expect(consumePaidIntent("/wallet/fund", "ai", storage, 200)).toBeNull();
+    expect(storage.value).toBeNull();
+
+    storage.value = record;
+    expect(consumePaidIntent("/ai", "creator-tip", storage, 200)).toBeNull();
+    expect(storage.value).toBeNull();
+
+    storage.value = record;
+    expect(consumePaidIntent("/ai", "ai", storage, 31 * 60 * 1000)).toBeNull();
+    expect(storage.value).toBeNull();
+
+    storage.value = "not-json";
+    expect(consumePaidIntent("/ai", "ai", storage, 200)).toBeNull();
+    expect(storage.value).toBeNull();
+  });
+
+  it("clears a prior draft when its replacement is unsafe or invalid", () => {
+    const storage = new MemoryStorage();
+    const prior = JSON.stringify({ private: "draft" });
+
+    storage.value = prior;
+    preservePaidIntent(
+      "https://evil.test",
+      { kind: "ai", draft: "secret" },
+      storage,
+      100,
+    );
+    expect(storage.value).toBeNull();
+
+    storage.value = prior;
+    preservePaidIntent("/", { kind: "ai", draft: "secret" }, storage, 100);
+    expect(storage.value).toBeNull();
+
+    storage.value = prior;
+    preservePaidIntent("/ai", { kind: "ai", draft: 42 } as never, storage, 100);
+    expect(storage.value).toBeNull();
+  });
+
+  it("clears a private draft when its login attempt is abandoned", () => {
+    const storage = new MemoryStorage();
+    preservePaidIntent(
+      "/ai",
+      { kind: "ai", draft: "belongs to the guest" },
+      storage,
+      100,
+    );
+
+    discardPaidIntent(storage);
+
+    expect(storage.value).toBeNull();
+  });
+
+  it("retains a first-login draft but destroys it on logout or account switch", () => {
+    const storage = new MemoryStorage();
+    const draft = JSON.stringify({ private: "draft" });
+
+    storage.value = draft;
+    discardPaidIntentForAccountTransition(null, "alice", storage);
+    expect(storage.value).toBe(draft);
+
+    discardPaidIntentForAccountTransition("alice", "alice", storage);
+    expect(storage.value).toBe(draft);
+
+    discardPaidIntentForAccountTransition("alice", "bob", storage);
+    expect(storage.value).toBeNull();
+
+    storage.value = draft;
+    discardPaidIntentForAccountTransition("alice", null, storage);
+    expect(storage.value).toBeNull();
+  });
+
+  it("preserves paid actions for a full-length backend username", () => {
+    const storage = new MemoryStorage();
+    const username = "a".repeat(150);
+    const intent = {
+      kind: "creator-tip",
+      subject: username,
+      amount: "50",
+    } as const;
+
+    preservePaidIntent(`/creator/${username}`, intent, storage, 100);
+
+    expect(
+      consumePaidIntent(`/creator/${username}`, "creator-tip", storage, 200),
+    ).toEqual(intent);
+  });
+
+  it("counts a full-length Unicode username by code point", () => {
+    const storage = new MemoryStorage();
+    const username = "\u{10400}".repeat(150);
+    const returnTo = `/creator/${encodeURIComponent(username)}`;
+    const intent = {
+      kind: "creator-tip",
+      subject: username,
+      amount: "50",
+    } as const;
+
+    preservePaidIntent(returnTo, intent, storage, 100);
+
+    expect(consumePaidIntent(returnTo, "creator-tip", storage, 200)).toEqual(
+      intent,
+    );
+  });
+
+  it("lets the creator page consume either of its owned intent kinds once", () => {
+    const storage = new MemoryStorage();
+    preservePaidIntent(
+      "/creator/alice",
+      { kind: "creator-tip", subject: "alice", amount: "50" },
+      storage,
+      100,
+    );
+    expect(
+      consumePaidIntent(
+        "/creator/alice",
+        ["creator-subscription", "creator-tip"],
+        storage,
+        200,
+      ),
+    ).toEqual({ kind: "creator-tip", subject: "alice", amount: "50" });
+    expect(storage.value).toBeNull();
+  });
+
+  it("fails closed when the record cannot be removed", () => {
+    const storage = new MemoryStorage();
+    storage.value = JSON.stringify({
+      returnTo: "/ai",
+      createdAt: 100,
+      intent: { kind: "ai", draft: "secret" },
+    });
+    storage.removeItem = () => {
+      throw new Error("blocked");
+    };
+
+    expect(consumePaidIntent("/ai", "ai", storage, 200)).toBeNull();
+    expect(storage.value).toContain("secret");
+  });
+});

--- a/wallet/zuuli/src/lib/auth/paid-intent.ts
+++ b/wallet/zuuli/src/lib/auth/paid-intent.ts
@@ -1,0 +1,162 @@
+import {
+  safeLoginDestination,
+  type LoginDestination,
+} from "./login-destination";
+
+const STORAGE_KEY = "zuuli.auth.pending-paid-intent";
+const MAX_AGE_MS = 30 * 60 * 1000;
+const MAX_DRAFT = 8_000;
+const MAX_FIELD = 128;
+const MAX_USERNAME = 150;
+
+type IntentStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export type PaidIntent =
+  | { kind: "ai"; draft: string }
+  | { kind: "article-tip"; subject: string; amount: string }
+  | { kind: "creator-tip"; subject: string; amount: string }
+  | { kind: "creator-subscription"; subject: string }
+  | { kind: "send"; query: string; amount: string }
+  | { kind: "live-entry"; subject: string; mode: "ppv" | "subscriber" };
+
+interface StoredPaidIntent {
+  returnTo: LoginDestination;
+  createdAt: number;
+  intent: PaidIntent;
+}
+
+function sessionIntentStorage(): IntentStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function shortString(value: unknown, maximum = MAX_FIELD): value is string {
+  return typeof value === "string" && value.length <= maximum;
+}
+
+function usernameString(value: unknown): value is string {
+  return typeof value === "string" && [...value].length <= MAX_USERNAME;
+}
+
+function validIntent(value: unknown): value is PaidIntent {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  switch (record.kind) {
+    case "ai":
+      return shortString(record.draft, MAX_DRAFT);
+    case "article-tip":
+    case "creator-tip":
+      return usernameString(record.subject) && shortString(record.amount, 32);
+    case "creator-subscription":
+      return usernameString(record.subject);
+    case "send":
+      return usernameString(record.query) && shortString(record.amount, 32);
+    case "live-entry":
+      return (
+        usernameString(record.subject) &&
+        (record.mode === "ppv" || record.mode === "subscriber")
+      );
+    default:
+      return false;
+  }
+}
+
+/**
+ * Save only a bounded UI draft in session storage. It survives the in-app
+ * login route but not a durable browser/device restart, which is intentional
+ * for potentially private AI prompts.
+ */
+export function preservePaidIntent(
+  returnToValue: unknown,
+  intent: PaidIntent,
+  storage: IntentStorage | null = sessionIntentStorage(),
+  now = Date.now(),
+): LoginDestination {
+  const returnTo = safeLoginDestination(returnToValue);
+  if (!storage) return returnTo;
+  try {
+    // One intent owns this slot. Clear it first so an invalid replacement or a
+    // failed write cannot leave a private draft available for a later visit.
+    storage.removeItem(STORAGE_KEY);
+    if (returnTo !== "/" && validIntent(intent)) {
+      storage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ returnTo, createdAt: now, intent }),
+      );
+    }
+  } catch {
+    // Storage failure may lose convenience, but must never block sign-in.
+  }
+  return returnTo;
+}
+
+/** Drop any draft when its login attempt is abandoned. */
+export function discardPaidIntent(
+  storage: Pick<IntentStorage, "removeItem"> | null = sessionIntentStorage(),
+): void {
+  try {
+    storage?.removeItem(STORAGE_KEY);
+  } catch {
+    // A blocked storage implementation is already inaccessible to the app.
+  }
+}
+
+/**
+ * A first login may consume the guest's draft, but no draft may cross a
+ * logout or an already-established account switch.
+ */
+export function discardPaidIntentForAccountTransition(
+  previousUsername: string | null,
+  nextUsername: string | null,
+  storage: Pick<IntentStorage, "removeItem"> | null = sessionIntentStorage(),
+): void {
+  if (
+    nextUsername === null ||
+    (previousUsername !== null && previousUsername !== nextUsername)
+  ) {
+    discardPaidIntent(storage);
+  }
+}
+
+/** Read once, validate again, and bind the draft to the exact returned route. */
+export function consumePaidIntent(
+  returnToValue: unknown,
+  expectedKinds: PaidIntent["kind"] | readonly PaidIntent["kind"][],
+  storage: IntentStorage | null = sessionIntentStorage(),
+  now = Date.now(),
+): PaidIntent | null {
+  if (!storage) return null;
+  let raw: string | null;
+  try {
+    raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    // Consumption is destructive even when the record is expired, malformed,
+    // routed elsewhere, or the wrong kind. Private drafts must not replay on a
+    // later visit. If removal fails, fail closed rather than return a value we
+    // cannot prove was consumed.
+    storage.removeItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw) as Partial<StoredPaidIntent>;
+    const acceptedKinds = Array.isArray(expectedKinds)
+      ? expectedKinds
+      : [expectedKinds];
+    if (
+      safeLoginDestination(parsed.returnTo) !==
+        safeLoginDestination(returnToValue) ||
+      safeLoginDestination(parsed.returnTo) === "/" ||
+      typeof parsed.createdAt !== "number" ||
+      now - parsed.createdAt < 0 ||
+      now - parsed.createdAt > MAX_AGE_MS ||
+      !validIntent(parsed.intent) ||
+      !acceptedKinds.includes(parsed.intent.kind)
+    ) {
+      return null;
+    }
+    return parsed.intent;
+  } catch {
+    return null;
+  }
+}

--- a/wallet/zuuli/src/store/session.ts
+++ b/wallet/zuuli/src/store/session.ts
@@ -1,6 +1,10 @@
 import { create } from "zustand";
 import { auth } from "@/lib/api/free2z";
 import { ApiError, isAuthed, setToken } from "@/lib/api/http";
+import {
+  discardPaidIntent,
+  discardPaidIntentForAccountTransition,
+} from "@/lib/auth/paid-intent";
 import type { AuthUser } from "@/lib/api/types";
 
 /**
@@ -38,6 +42,7 @@ export const useSession = create<SessionState>((set, get) => ({
     // No knox token → we're logged out; resolve without ever hitting
     // `/api/auth/user/` (it 403s for anonymous requests).
     if (!isAuthed()) {
+      discardPaidIntent();
       set({ loading: false });
       return;
     }
@@ -45,12 +50,19 @@ export const useSession = create<SessionState>((set, get) => ({
       const user = await auth.me();
       set({ user, tuzis: user.tuzis ?? 0, loading: false });
     } catch (err) {
-      if (isSessionExpired(err)) setToken(null);
+      if (isSessionExpired(err)) {
+        setToken(null);
+        discardPaidIntent();
+      }
       set({ user: null, loading: false });
     }
   },
 
   setUser(user) {
+    discardPaidIntentForAccountTransition(
+      get().user?.username ?? null,
+      user?.username ?? null,
+    );
     set({ user, tuzis: user?.tuzis ?? 0, loading: false });
   },
 
@@ -64,6 +76,7 @@ export const useSession = create<SessionState>((set, get) => ({
     } catch (err) {
       if (isSessionExpired(err)) {
         setToken(null);
+        discardPaidIntent();
         set({ user: null, tuzis: 0 });
       }
       /* otherwise a transient/network error — keep the current session */
@@ -71,6 +84,9 @@ export const useSession = create<SessionState>((set, get) => ({
   },
 
   async logout() {
+    // Clear private pending input before awaiting a network logout. Even if
+    // that request fails, the draft must not survive for another account.
+    discardPaidIntent();
     await auth.logout();
     set({ user: null, tuzis: 0 });
   },

--- a/wallet/zuuli/tests/paid-actions.pw.ts
+++ b/wallet/zuuli/tests/paid-actions.pw.ts
@@ -1,0 +1,366 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const PHONE = { width: 320, height: 568 };
+
+async function setSession(page: Page, signedIn: boolean) {
+  await page.addInitScript((authenticated) => {
+    const key = "zuuli.knox.token";
+    if (authenticated) localStorage.setItem(key, "mock-knox-token");
+    else localStorage.removeItem(key);
+    sessionStorage.removeItem("zuuli.auth.pending-paid-intent");
+  }, signedIn);
+}
+
+async function openRoute(page: Page, path: string, signedIn = false) {
+  await page.setViewportSize(PHONE);
+  await setSession(page, signedIn);
+  await page.goto(path);
+  await page.locator("[data-app-frame]").waitFor();
+  if (signedIn) {
+    await expect(
+      page.getByRole("button", { name: "Account menu" }),
+    ).toBeVisible();
+  } else {
+    await expect(
+      page.getByRole("button", { name: "Log in", exact: true }),
+    ).toBeVisible();
+  }
+}
+
+async function expectNoAnonymousBalanceDiagnosis(page: Page) {
+  await expect(
+    page.getByText(/^(?:Your |Current )?Balance(?: after)?:/i),
+  ).toHaveCount(0);
+  await expect(page.getByText(/Not enough (?:2Z|2Zs)/i)).toHaveCount(0);
+  await expect(page.getByText(/You have .* need/i)).toHaveCount(0);
+  await expect(page.getByRole("link", { name: /Buy more 2Z/i })).toHaveCount(0);
+}
+
+async function expectLoginReturn(page: Page, returnTo: string) {
+  await expect(page).toHaveURL(/\/login$/);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const state = window.history.state as {
+          usr?: { returnTo?: unknown };
+        } | null;
+        return state?.usr?.returnTo ?? null;
+      }),
+    )
+    .toBe(returnTo);
+}
+
+async function storedIntent(page: Page) {
+  return page.evaluate(() => {
+    const raw = sessionStorage.getItem("zuuli.auth.pending-paid-intent");
+    return raw ? JSON.parse(raw) : null;
+  });
+}
+
+test("funding authenticates before balances, quotes, or either top-up method", async ({
+  page,
+}) => {
+  await openRoute(page, "/wallet/fund");
+
+  await expect(page.getByText("2Z balance", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("ZEC in wallet", { exact: true })).toHaveCount(0);
+  await expect(
+    page.getByText("Mock wallet spendable", { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Log in to buy" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Log in to pay with ZEC" }),
+  ).toBeVisible();
+  await expectNoAnonymousBalanceDiagnosis(page);
+
+  await page.getByRole("button", { name: "Log in to buy" }).click();
+  await expectLoginReturn(page, "/wallet/fund");
+
+  await openRoute(page, "/wallet/fund");
+  await page.getByRole("tab", { name: "Activity" }).click();
+  await expect(page).toHaveURL(/\/wallet\/fund\/activity$/);
+  await expect(page.getByText("Sign in to view activity")).toBeVisible();
+  await expect(
+    page.getByText("Card purchase history belongs to your account."),
+  ).toBeVisible();
+  await expect(page.getByText(/tips|charges/i)).toHaveCount(0);
+  await expect(page.getByText("Total bought")).toHaveCount(0);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await expectLoginReturn(page, "/wallet/fund/activity");
+});
+
+test("send restores its bounded draft only after login and never diagnoses a guest balance", async ({
+  page,
+}) => {
+  await openRoute(page, "/wallet/fund/send");
+
+  await page
+    .getByRole("combobox", { name: "Search for a 2Z recipient" })
+    .fill("maya");
+  await page.getByLabel("Custom tip amount in 2Z").fill("5000");
+  await expectNoAnonymousBalanceDiagnosis(page);
+  await page.getByRole("button", { name: "Sign in to send 2Z" }).click();
+
+  await expectLoginReturn(page, "/wallet/fund/send");
+  await expect
+    .poll(() => storedIntent(page))
+    .toMatchObject({
+      returnTo: "/wallet/fund/send",
+      intent: { kind: "send", query: "maya", amount: "5000" },
+    });
+});
+
+test("send keeps malformed restored money text invalid instead of coercing it to a preset", async ({
+  page,
+}) => {
+  await page.setViewportSize(PHONE);
+  await page.addInitScript(() => {
+    localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+    sessionStorage.setItem(
+      "zuuli.auth.pending-paid-intent",
+      JSON.stringify({
+        returnTo: "/wallet/fund/send",
+        createdAt: Date.now(),
+        intent: { kind: "send", query: "maya", amount: "0100" },
+      }),
+    );
+  });
+  await page.goto("/wallet/fund/send");
+  await page.locator("[data-app-frame]").waitFor();
+
+  await expect(page.getByLabel("Custom tip amount in 2Z")).toHaveValue("0100");
+  await expect(
+    page.getByText(
+      "Enter a positive whole 2Z amount; commas may separate thousands.",
+    ),
+  ).toBeVisible();
+});
+
+test("AI preserves its draft while authenticating before the paid conversation APIs", async ({
+  page,
+}) => {
+  await openRoute(page, "/ai");
+
+  const draft = "Explain shielded payments simply";
+  await page.getByRole("textbox", { name: "Message" }).fill(draft);
+  await expect(
+    page.getByText("Sign in to use AI.", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Buy 2Zs" })).toHaveCount(0);
+  await expectNoAnonymousBalanceDiagnosis(page);
+  await page.getByRole("button", { name: "Sign in to send message" }).click();
+
+  await expectLoginReturn(page, "/ai");
+  await expect
+    .poll(() => storedIntent(page))
+    .toMatchObject({
+      returnTo: "/ai",
+      intent: { kind: "ai", draft },
+    });
+});
+
+test("abandoning login destroys the guest's private paid intent", async ({
+  page,
+}) => {
+  await openRoute(page, "/ai");
+  await page.getByRole("textbox", { name: "Message" }).fill("private draft");
+  await page.getByRole("button", { name: "Sign in to send message" }).click();
+  await expectLoginReturn(page, "/ai");
+  await expect.poll(() => storedIntent(page)).not.toBeNull();
+
+  await page.getByRole("link", { name: "Continue as guest" }).click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect.poll(() => storedIntent(page)).toBeNull();
+});
+
+test("reloading login destroys the guest's private paid intent", async ({
+  page,
+}) => {
+  await openRoute(page, "/ai");
+  await page.getByRole("textbox", { name: "Message" }).fill("private draft");
+  await page.getByRole("button", { name: "Sign in to send message" }).click();
+  await expectLoginReturn(page, "/ai");
+  await expect.poll(() => storedIntent(page)).not.toBeNull();
+
+  await page.reload();
+  await expect(page).toHaveURL(/\/login$/);
+  await expect.poll(() => storedIntent(page)).toBeNull();
+});
+
+test("browser Back cannot restore a private paid intent while signed out", async ({
+  page,
+}) => {
+  await openRoute(page, "/ai");
+  await page.getByRole("textbox", { name: "Message" }).fill("private draft");
+  await page.getByRole("button", { name: "Sign in to send message" }).click();
+  await expectLoginReturn(page, "/ai");
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/ai$/);
+  await expect(page.getByRole("textbox", { name: "Message" })).toHaveValue("");
+  await expect.poll(() => storedIntent(page)).toBeNull();
+});
+
+test("funding tabs and browser history stay synchronized with the send URL", async ({
+  page,
+}) => {
+  await openRoute(page, "/wallet/fund");
+  await page.getByRole("tab", { name: "Send & Tip" }).click();
+  await expect(page).toHaveURL(/\/wallet\/fund\/send$/);
+  await expect(page.getByRole("tab", { name: "Send & Tip" })).toHaveAttribute(
+    "data-state",
+    "active",
+  );
+
+  await page.getByRole("tab", { name: "Buy" }).click();
+  await expect(page).toHaveURL(/\/wallet\/fund$/);
+  await expect(page.getByRole("tab", { name: "Buy" })).toHaveAttribute(
+    "data-state",
+    "active",
+  );
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/wallet\/fund\/send$/);
+  await expect(page.getByRole("tab", { name: "Send & Tip" })).toHaveAttribute(
+    "data-state",
+    "active",
+  );
+
+  await page.goto("/wallet/fund/send/");
+  await expect(page.getByRole("tab", { name: "Send & Tip" })).toHaveAttribute(
+    "data-state",
+    "active",
+  );
+});
+
+test("article and creator tips authenticate before balance or top-up diagnosis", async ({
+  page,
+}) => {
+  await openRoute(page, "/articles/why-shielded-by-default");
+  await page.getByRole("button", { name: "Tip Zooko" }).click();
+  await page.getByLabel("Amount (2Z)").fill("5000");
+  await expectNoAnonymousBalanceDiagnosis(page);
+  await page.getByRole("button", { name: "Sign in to tip" }).click();
+  await expectLoginReturn(page, "/articles/why-shielded-by-default");
+  await expect
+    .poll(() => storedIntent(page))
+    .toMatchObject({
+      returnTo: "/articles/why-shielded-by-default",
+      intent: { kind: "article-tip", subject: "zooko", amount: "5000" },
+    });
+
+  await openRoute(page, "/creator/zooko");
+  await page.getByRole("button", { name: "Tip Zooko" }).click();
+  await page.getByLabel("Amount (2Z)").fill("5000");
+  await expectNoAnonymousBalanceDiagnosis(page);
+  await page.getByRole("button", { name: "Sign in to tip" }).click();
+  await expectLoginReturn(page, "/creator/zooko");
+  await expect
+    .poll(() => storedIntent(page))
+    .toMatchObject({
+      returnTo: "/creator/zooko",
+      intent: { kind: "creator-tip", subject: "zooko", amount: "5000" },
+    });
+});
+
+test("creator membership authenticates before showing balance-dependent outcomes", async ({
+  page,
+}) => {
+  await openRoute(page, "/creator/zooko");
+  await page.getByRole("button", { name: /Subscribe to Zooko/ }).click();
+
+  await expectNoAnonymousBalanceDiagnosis(page);
+  await page.getByRole("button", { name: "Sign in to subscribe" }).click();
+  await expectLoginReturn(page, "/creator/zooko");
+  await expect
+    .poll(() => storedIntent(page))
+    .toMatchObject({
+      returnTo: "/creator/zooko",
+      intent: { kind: "creator-subscription", subject: "zooko" },
+    });
+});
+
+for (const restored of [
+  {
+    intent: { kind: "creator-tip", subject: "zooko", amount: "250" },
+    dialog: "Tip Zooko",
+  },
+  {
+    intent: { kind: "creator-subscription", subject: "zooko" },
+    dialog: "Subscribe to Zooko",
+  },
+] as const) {
+  test(`creator page resumes its ${restored.intent.kind} after login`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(PHONE);
+    await page.addInitScript((intent) => {
+      localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+      sessionStorage.setItem(
+        "zuuli.auth.pending-paid-intent",
+        JSON.stringify({
+          returnTo: "/creator/zooko",
+          createdAt: Date.now(),
+          intent,
+        }),
+      );
+    }, restored.intent);
+    await page.goto("/creator/zooko");
+
+    await expect(
+      page.getByRole("dialog", { name: restored.dialog }),
+    ).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          sessionStorage.getItem("zuuli.auth.pending-paid-intent"),
+        ),
+      )
+      .toBeNull();
+  });
+}
+
+for (const stream of [
+  { path: "/live/mining_maya", mode: "ppv" },
+  { path: "/live/zooko", mode: "subscriber" },
+] as const) {
+  test(`${stream.mode} livestream authenticates before membership or balance diagnosis`, async ({
+    page,
+  }) => {
+    await openRoute(page, stream.path);
+    await expectNoAnonymousBalanceDiagnosis(page);
+
+    const label =
+      stream.mode === "ppv" ? "Sign in to join" : "Log in to subscribe";
+    await page.getByRole("button", { name: label }).click();
+    await expectLoginReturn(page, stream.path);
+    await expect
+      .poll(() => storedIntent(page))
+      .toMatchObject({
+        returnTo: stream.path,
+        intent: {
+          kind: "live-entry",
+          subject: stream.path.split("/").at(-1),
+          mode: stream.mode,
+        },
+      });
+  });
+}
+
+test("low-balance top-up diagnosis appears only after authentication", async ({
+  page,
+}) => {
+  await openRoute(page, "/articles/why-shielded-by-default", true);
+  await page.getByRole("button", { name: "Tip Zooko" }).click();
+  await page.getByLabel("Amount (2Z)").fill("5000");
+
+  await expect(
+    page.getByRole("button", { name: "Not enough 2Z — buy more" }),
+  ).toBeVisible();
+  await expect(page.getByText(/Balance: 4,210 2Z/)).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Sign in to tip" }),
+  ).toHaveCount(0);
+});


### PR DESCRIPTION
Closes #269

## Outcome

- gate every protected paid surface on a resolved authenticated session before reading affordability or offering a top-up diagnosis: AI, article/creator tips, creator subscriptions, card/ZEC funding, 2Z send, Activity, and paid/subscriber livestream entry
- preserve one bounded, one-shot paid intent and exact allowlisted return route through login; destroy private drafts on invalid/expired/wrong-route reads, abandonment, reload, Back, logout/session expiry, or account switch
- make Wallet funding Send and Activity canonical addressable routes while retaining the existing `/wallet/fund` checkout/login destination used by #400 and the pending native-return work in #406
- show only truthful card-purchase Activity copy and never expose an invented anonymous 2Z/ZEC balance or guest low-balance diagnosis
- make the mobile funding grid explicitly shrinkable so the signed-out card-purchase surface fits the 288 px content area at a 320 px Linux/Chrome viewport

The browser evidence uses the existing explicit mock runtime to prove UI routing/API-boundary behavior; it is not represented as production checkout or custody proof, consistent with the release/status doctrine.

## Compatibility

#406 can retain `/wallet/fund` as its canonical checkout return. This branch does not depend on or copy any unmerged #406 source; its nested `/wallet/fund/send` and `/wallet/fund/activity` routes preserve the same Wallet shell and current #400 login-return behavior.

## Verification

- `npm test` — 346 Vitest + 8 static Node contracts + 66 Playwright cases, all green
- `npx playwright test tests/paid-actions.pw.ts` — 15/15 at 320×568, including every listed guest/authenticated paid boundary, intent abandonment/reload/Back, canonical funding history, and malformed-money restoration
- clean Linux `mcr.microsoft.com/playwright:v1.62.1-noble` proof of the previously failing `signed out routes fit at 320px` viewport case — 1/1 green after the funding-grid fix
- `npm run typecheck` — green
- `npm run build` — green (only the existing chunk-size advisories)
- `cargo +1.97.1 build --locked --manifest-path wallet/zuuli/src-tauri/Cargo.toml` — green on the unchanged native dependency graph
- `git diff --check` and focused Prettier checks — green

## Adversarial review

Successive review findings were fixed before publication:

- made paid-intent consumption destructive for malformed/expired/wrong-route records and cleared invalid replacements
- aligned dynamic route bounds with the backend, canonicalized trailing slashes, rejected raw non-ASCII route spellings, and accepted only canonical UTF-8 percent encoding
- made Activity and Send independently addressable so login and browser history return to the requested funding surface
- preserved canonical Unicode usernames containing literal allowed `+`/`@`, counted the 150-character username limit by Unicode code point, and prevented malformed money text such as `0100` from coercing to preset `100`
- corrected the deterministic hosted Linux 320 px `/wallet/fund` overflow without weakening the viewport assertion

Final mandatory review on exact head `abfba7cd27495f2564917d4f39511cf0a474d0cf`:

> No actionable correctness regressions were identified in the changes relative to the specified merge base.
