### PR TITLE
fix(zuuli): unify route-backed search

### DIFF
--- a/wallet/zuuli/src/components/layout/TopBar.test.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.test.tsx
@@ -6,13 +6,19 @@ import { useWallet } from "@/store/wallet";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TopBar } from "./TopBar";
 
-function renderTopBar({ pushed = false } = {}) {
+function renderTopBar({
+  pushed = false,
+  route = pushed ? "/wallet/fund" : "/",
+}: {
+  pushed?: boolean;
+  route?: string;
+} = {}) {
   vi.stubGlobal("window", {
     history: { state: { idx: pushed ? 1 : 0 } },
   });
 
   return renderToStaticMarkup(
-    <MemoryRouter initialEntries={[pushed ? "/wallet/fund" : "/"]}>
+    <MemoryRouter initialEntries={[route]}>
       <TooltipProvider>
         <TopBar />
       </TooltipProvider>
@@ -44,5 +50,14 @@ describe("TopBar account chrome", () => {
     expect(markup).not.toContain('href="/wallet"');
     expect(markup).toContain('aria-label="Search"');
     expect(markup.includes('aria-label="Go back"')).toBe(pushed);
+  });
+
+  it("yields all search chrome to the route while /search is active", () => {
+    const markup = renderTopBar({ pushed: true, route: "/search?q=zcash" });
+
+    expect(markup).not.toContain('role="search"');
+    expect(markup).not.toContain('aria-label="Search"');
+    expect(markup).toContain('aria-label="Go back"');
+    expect(markup).toContain('aria-label="Log in"');
   });
 });

--- a/wallet/zuuli/src/components/layout/TopBar.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.tsx
@@ -34,6 +34,11 @@ import {
 import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
 import { formatTuzis, formatZecTrim, initials } from "@/lib/format";
+import {
+  isSearchRoute,
+  searchHref,
+  SEARCH_INPUT_LABEL,
+} from "@/lib/search-route";
 
 const ICON_CONTROL_LABELS = {
   account: "Account menu",
@@ -48,6 +53,7 @@ export function TopBar() {
   const navigate = useNavigate();
   const location = useLocation();
   const [q, setQ] = useState("");
+  const searchOwnsChrome = isSearchRoute(location.pathname);
 
   // This is an app, not a browser — surface a persistent back affordance so
   // fans can retreat from any screen. React Router stamps a monotonic `idx`
@@ -86,44 +92,47 @@ export function TopBar() {
       ) : null}
 
       {/* Global search */}
-      <form
-        role="search"
-        onSubmit={(e) => {
-          e.preventDefault();
-          const term = q.trim();
-          navigate(term ? `/search?q=${encodeURIComponent(term)}` : "/search");
-        }}
-        className="relative hidden max-w-sm flex-1 sm:block"
-      >
-        <Search
-          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-          aria-hidden
-        />
-        <input
-          type="search"
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          placeholder="Search creators and pages…"
-          aria-label="Search creators and pages"
-          className="h-9 w-full rounded-full border border-border bg-card/60 pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-ring"
-        />
-      </form>
+      {!searchOwnsChrome ? (
+        <form
+          role="search"
+          onSubmit={(e) => {
+            e.preventDefault();
+            navigate(searchHref(q));
+          }}
+          className="relative hidden max-w-sm flex-1 sm:block"
+        >
+          <Search
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <input
+            type="search"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search creators and pages…"
+            aria-label={SEARCH_INPUT_LABEL}
+            className="h-9 w-full rounded-full border border-border bg-card/60 pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        </form>
+      ) : null}
 
       {/* Search icon (mobile) */}
-      <Tooltip>
-        <TooltipTrigger asChild aria-describedby={undefined}>
-          <Link
-            to="/search"
-            className="min-tap grid place-items-center rounded-full text-muted-foreground transition-colors hover:text-foreground sm:hidden"
-            aria-label={ICON_CONTROL_LABELS.search}
-          >
-            <Search className="h-5 w-5" aria-hidden />
-          </Link>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {ICON_CONTROL_LABELS.search}
-        </TooltipContent>
-      </Tooltip>
+      {!searchOwnsChrome ? (
+        <Tooltip>
+          <TooltipTrigger asChild aria-describedby={undefined}>
+            <Link
+              to="/search"
+              className="min-tap grid place-items-center rounded-full text-muted-foreground transition-colors hover:text-foreground sm:hidden"
+              aria-label={ICON_CONTROL_LABELS.search}
+            >
+              <Search className="h-5 w-5" aria-hidden />
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {ICON_CONTROL_LABELS.search}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
 
       <div className="flex-1" />
 

--- a/wallet/zuuli/src/features/articles/pages/Feed.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Feed.tsx
@@ -107,11 +107,15 @@ export function Feed() {
               aria-hidden
             />
             <Input
-              type="search"
+              type="text"
+              role="searchbox"
+              inputMode="search"
+              enterKeyHint="search"
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Search articles by meaning…"
               aria-label="Search articles"
+              data-custom-search-clear
               className="pl-9 pr-12"
             />
             {searchInput ? (

--- a/wallet/zuuli/src/features/search/index.tsx
+++ b/wallet/zuuli/src/features/search/index.tsx
@@ -30,6 +30,7 @@ import {
   type KeyedRemoteData,
 } from "@/lib/remote-data";
 import type { Article, SimpleCreator } from "@/lib/api/types";
+import { SEARCH_INPUT_LABEL, withSearchQuery } from "@/lib/search-route";
 
 const DEBOUNCE_MS = 300;
 
@@ -44,8 +45,7 @@ function excerpt(text: string, max = 160): string {
 
 export default function SearchFeature() {
   const [params, setParams] = useSearchParams();
-  const initial = params.get("q") ?? "";
-  const [query, setQuery] = useState(initial);
+  const query = params.get("q") ?? "";
   const debounced = useDebounced(query, DEBOUNCE_MS);
   const inputRef = useRef<HTMLInputElement>(null);
   const searchKey = debounced.trim();
@@ -81,14 +81,9 @@ export default function SearchFeature() {
     inputRef.current?.focus();
   }, []);
 
-  // Keep ?q= in the URL in sync with the debounced query (shareable results).
-  useEffect(() => {
-    const q = debounced.trim();
-    setParams(q ? { q } : {}, { replace: true });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debounced]);
-
-  const hasQuery = searchKey.length > 0;
+  // The route, not the debounce timer, owns visible empty-vs-results state.
+  // Clearing `?q=` must clear the screen in the same render.
+  const hasQuery = query.trim().length > 0;
   const creatorCount = creators?.length ?? 0;
   const pageCount = pages?.length ?? 0;
 
@@ -115,18 +110,29 @@ export default function SearchFeature() {
         />
         <Input
           ref={inputRef}
-          type="search"
+          type="text"
+          role="searchbox"
+          inputMode="search"
+          enterKeyHint="search"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => {
+            const value = e.target.value;
+            setParams((current) => withSearchQuery(current, value), {
+              replace: true,
+            });
+          }}
           placeholder="Search creators and pages…"
-          aria-label="Search creators and pages"
+          aria-label={SEARCH_INPUT_LABEL}
+          data-custom-search-clear
           className="h-12 pl-10 pr-14 text-base"
         />
         {query ? (
           <button
             type="button"
             onClick={() => {
-              setQuery("");
+              setParams((current) => withSearchQuery(current, ""), {
+                replace: true,
+              });
               inputRef.current?.focus();
             }}
             aria-label="Clear search"

--- a/wallet/zuuli/src/lib/search-route.test.ts
+++ b/wallet/zuuli/src/lib/search-route.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSearchRoute,
+  searchHref,
+  withSearchQuery,
+} from "./search-route";
+
+describe("route-backed search contract", () => {
+  it("recognizes only the Search route and its mounted descendants", () => {
+    expect(isSearchRoute("/search")).toBe(true);
+    expect(isSearchRoute("/search/results")).toBe(true);
+    expect(isSearchRoute("/searching")).toBe(false);
+    expect(isSearchRoute("/articles/search")).toBe(false);
+  });
+
+  it("builds a canonical TopBar destination without losing Unicode", () => {
+    expect(searchHref("  shielded payments  ")).toBe(
+      "/search?q=shielded%20payments",
+    );
+    expect(searchHref("élodie")).toBe("/search?q=%C3%A9lodie");
+    expect(searchHref("   ")).toBe("/search");
+  });
+
+  it("changes only q so route-owned filters survive typing and clear", () => {
+    const initial = new URLSearchParams("tab=pages&q=old&sort=newest");
+    expect(withSearchQuery(initial, "new phrase").toString()).toBe(
+      "tab=pages&q=new+phrase&sort=newest",
+    );
+    expect(withSearchQuery(initial, "").toString()).toBe(
+      "tab=pages&sort=newest",
+    );
+    expect(initial.toString()).toBe("tab=pages&q=old&sort=newest");
+  });
+});

--- a/wallet/zuuli/src/lib/search-route.ts
+++ b/wallet/zuuli/src/lib/search-route.ts
@@ -1,0 +1,28 @@
+export const SEARCH_INPUT_LABEL = "Search creators and pages";
+
+/** Search owns the chrome for every route mounted below `/search/*`. */
+export function isSearchRoute(pathname: string): boolean {
+  return pathname === "/search" || pathname.startsWith("/search/");
+}
+
+/** TopBar submissions enter the canonical Search route with a trimmed query. */
+export function searchHref(query: string): string {
+  const canonical = query.trim();
+  return canonical
+    ? `/search?q=${encodeURIComponent(canonical)}`
+    : "/search";
+}
+
+/**
+ * Update only Search's owned query parameter. Keeping unrelated parameters
+ * makes this safe for future result filters and direct/bookmarked URLs.
+ */
+export function withSearchQuery(
+  current: URLSearchParams,
+  query: string,
+): URLSearchParams {
+  const next = new URLSearchParams(current);
+  if (query) next.set("q", query);
+  else next.delete("q");
+  return next;
+}

--- a/wallet/zuuli/tests/search.pw.ts
+++ b/wallet/zuuli/tests/search.pw.ts
@@ -1,0 +1,143 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const SEARCH_NAME = "Search creators and pages";
+const VIEWPORTS = [
+  { name: "phone", width: 320, height: 568 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+] as const;
+
+async function enterSearch(page: Page, width: number) {
+  await page.goto("/");
+  const topBar = page.locator("[data-app-top-bar]");
+
+  if (width < 640) {
+    await topBar.getByRole("link", { name: "Search", exact: true }).click();
+  } else {
+    const globalSearch = topBar.getByRole("searchbox", { name: SEARCH_NAME });
+    await globalSearch.fill("alpha route");
+    await globalSearch.press("Enter");
+  }
+
+  await expect(page).toHaveURL(
+    width < 640 ? /\/search$/ : /\/search\?q=alpha(?:\+|%20)route$/,
+  );
+}
+
+async function expectSingleRouteSearch(page: Page) {
+  const input = page.getByRole("searchbox", { name: SEARCH_NAME });
+  const topBar = page.locator("[data-app-top-bar]");
+
+  await expect(input).toHaveCount(1);
+  await expect(input).toBeVisible();
+  await expect(
+    topBar.getByRole("searchbox", { name: SEARCH_NAME }),
+  ).toHaveCount(0);
+  await expect(topBar.getByLabel("Search", { exact: true })).toHaveCount(0);
+  await expect(input).toHaveAttribute("data-custom-search-clear", "true");
+  await expect(input).toHaveAttribute("type", "text");
+  await expect(input).toHaveAttribute("inputmode", "search");
+  return input;
+}
+
+for (const viewport of VIEWPORTS) {
+  test(
+    `${viewport.name} Search has one route-backed interaction`,
+    async ({ page }) => {
+      await page.setViewportSize(viewport);
+      await enterSearch(page, viewport.width);
+
+      const input = await expectSingleRouteSearch(page);
+      await expect(input).toBeFocused();
+
+      if (viewport.width < 640) {
+        await input.fill("alpha route");
+        await expect(page).toHaveURL(/\/search\?q=alpha(?:\+|%20)route$/);
+      } else {
+        await expect(input).toHaveValue("alpha route");
+      }
+
+      await input.fill("beta history");
+      await expect(page).toHaveURL(/\/search\?q=beta(?:\+|%20)history$/);
+
+      await page.goBack();
+      await expect(page).toHaveURL(/\/$/);
+      await page.goForward();
+      await expect(page).toHaveURL(/\/search\?q=beta(?:\+|%20)history$/);
+      await expect(await expectSingleRouteSearch(page)).toHaveValue(
+        "beta history",
+      );
+
+      const clear = page.getByRole("button", { name: "Clear search" });
+      await expect(clear).toHaveCount(1);
+      const clearBox = await clear.boundingBox();
+      expect(clearBox).not.toBeNull();
+      expect(clearBox!.width).toBeGreaterThanOrEqual(44);
+      expect(clearBox!.height).toBeGreaterThanOrEqual(44);
+
+      const clearPresentation = await input.evaluate((element) => {
+        const inputRect = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+        return {
+          inputRight: inputRect.right,
+          editableRight:
+            inputRect.right -
+            Number.parseFloat(style.paddingRight) -
+            Number.parseFloat(style.borderRightWidth),
+          documentClientWidth: document.documentElement.clientWidth,
+          documentScrollWidth: document.documentElement.scrollWidth,
+        };
+      });
+      expect(clearBox!.x).toBeGreaterThanOrEqual(
+        clearPresentation.editableRight - 0.5,
+      );
+      expect(clearBox!.x + clearBox!.width).toBeLessThanOrEqual(
+        clearPresentation.inputRight + 0.5,
+      );
+      expect(clearPresentation.documentScrollWidth).toBeLessThanOrEqual(
+        clearPresentation.documentClientWidth,
+      );
+
+      await input.focus();
+      await page.keyboard.press("Tab");
+      await expect(clear).toBeFocused();
+      await page.keyboard.press("Enter");
+      await expect(page).toHaveURL(/\/search$/);
+      await expect(input).toHaveValue("");
+      await expect(input).toBeFocused();
+      await expect(clear).toHaveCount(0);
+      await expect(page.getByText("Search all of free2z")).toBeVisible();
+
+      await page.goBack();
+      await expect(page).toHaveURL(/\/$/);
+      await page.goForward();
+      await expect(page).toHaveURL(/\/search$/);
+      await expect(await expectSingleRouteSearch(page)).toHaveValue("");
+
+      await page.goto("/search?tab=pages&q=direct%20query");
+      const directInput = await expectSingleRouteSearch(page);
+      await expect(directInput).toHaveValue("direct query");
+      await page.getByRole("button", { name: "Clear search" }).click();
+      await expect(page).toHaveURL(/\/search\?tab=pages$/);
+      await expect(directInput).toHaveValue("");
+
+      // Articles uses the same explicit-clear compound-input contract. A text
+      // input with search keyboard hints cannot acquire Chromium/WebKit's
+      // anonymous native cancel beside the accessible ZUULI action.
+      await page.goto("/articles");
+      const articleSearch = page.getByRole("searchbox", {
+        name: "Search articles",
+      });
+      await articleSearch.fill("shielded publishing");
+      await expect(articleSearch).toHaveAttribute("type", "text");
+      await expect(articleSearch).toHaveAttribute("inputmode", "search");
+      await expect(articleSearch).toHaveAttribute(
+        "data-custom-search-clear",
+        "true",
+      );
+      await expect(
+        page.getByRole("button", { name: "Clear search" }),
+      ).toHaveCount(1);
+    },
+  );
+}


### PR DESCRIPTION
Closes #254.

Cross-links #387 and #395. Store-media recapture remains downstream of this product fix.

## Product change

- Makes the `/search` `q` parameter the authoritative value for the visible query.
- Hides TopBar search chrome while `/search` owns the interaction, leaving one usable searchbox on phone, tablet, and desktop.
- Keeps TopBar submit, direct `?q=`, typing, clear, browser Back, and Forward synchronized without manufacturing malformed history entries.
- Preserves unrelated route parameters when changing or clearing `q`.
- Retains mobile search-keyboard hints while using semantic text searchboxes for fields with custom clear buttons, so Chromium/WebKit cannot inject a second anonymous native cancel action.
- Keeps one keyboard-accessible 44px custom clear action with reserved editable padding on Search and Articles.

## Verification

- `npm test` — 350 Vitest, 8 Node boundary contracts, 69/69 Playwright.
- New `tests/search.pw.ts` — 320x568 phone, 768x1024 tablet, and 1280x800 desktop; mobile entry focus, TopBar/direct query, clear, Back/Forward, preserved params, one-clear semantics, 44px geometry, content reservation, and horizontal containment.
- Existing 320/360 touch-target, 320/360/390/414 viewport, navigation, and scroll-restoration matrices pass.
- `npm run typecheck` — pass.
- `npm run build` — pass.
- `node scripts/check-zuuli-linux-image.mjs --self-test` — 25 negative cases plus libxdo runtime cases pass; promoted digest unchanged.
- `scripts/check-rust-toolchain.sh` and `git diff --check` — pass.

## Adversarial review

> The changes typecheck successfully and the targeted unit tests pass. The route-backed search behavior preserves query parameters and avoids duplicate search controls without introducing an identified correctness issue.

No native/API contract changed. Do not merge until the exact-head required gate and all package targets are green.