### PR TITLE
fix(zuuli): contain creator tablet layout

### DIFF
--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -204,7 +204,10 @@ function CreatorProfile({
   const isLive = useLiveGate(creator.username, creator.is_live);
 
   return (
-    <div className="animate-slide-up pb-6">
+    <div
+      className="creator-profile animate-slide-up pb-6"
+      data-creator-profile
+    >
       <BackLink />
 
       {refreshError ? (
@@ -220,7 +223,7 @@ function CreatorProfile({
 
       {/* Banner */}
       <div
-        className="relative mt-4 h-40 w-full overflow-hidden rounded-xl border border-border md:h-56"
+        className="creator-profile-banner relative mt-4 h-40 w-full overflow-hidden rounded-xl border border-border"
         style={
           creator.banner
             ? undefined
@@ -238,8 +241,11 @@ function CreatorProfile({
       </div>
 
       {/* Header */}
-      <div className="relative -mt-12 flex flex-col gap-4 px-1 sm:flex-row sm:items-end sm:justify-between md:px-4">
-        <div className="flex items-end gap-4">
+      <div
+        className="creator-profile-header relative -mt-12 flex flex-col gap-4 px-1"
+        data-creator-profile-header
+      >
+        <div className="flex min-w-0 items-end gap-4" data-creator-identity>
           <Avatar className="h-24 w-24 border-4 border-background shadow-md">
             {creator.image ? (
               <AvatarImage src={creator.image} alt={name} />
@@ -250,7 +256,7 @@ function CreatorProfile({
           </Avatar>
           <div className="min-w-0 pb-1">
             <div className="flex items-center gap-2">
-              <h1 className="truncate text-2xl font-bold tracking-tight md:text-3xl">
+              <h1 className="creator-profile-name truncate text-2xl font-bold tracking-tight">
                 {name}
               </h1>
               {creator.is_verified ? (
@@ -285,7 +291,10 @@ function CreatorProfile({
         </div>
 
         {/* Actions */}
-        <div className="flex shrink-0 flex-wrap items-center gap-2 pb-1">
+        <div
+          className="creator-profile-actions flex min-w-0 flex-wrap items-center gap-2 pb-1"
+          data-creator-actions
+        >
           {isLive ? (
             <Button asChild variant="outline">
               <Link
@@ -304,7 +313,7 @@ function CreatorProfile({
 
       {/* Bio */}
       {bio ? (
-        <div className="mt-8 md:px-4">
+        <div className="creator-profile-inset mt-8">
           <div className="rounded-xl border border-border/60 bg-card/40 p-5">
             <Markdown>{bio}</Markdown>
           </div>
@@ -314,7 +323,7 @@ function CreatorProfile({
       {/* Links / socials — parsed from a frontmatter block at the top of the
           bio (e.g. `---\nsocials:\n  twitter: handle\n---`). */}
       {socials.length > 0 ? (
-        <div className="mt-4 flex flex-wrap gap-2 md:px-4">
+        <div className="creator-profile-inset mt-4 flex flex-wrap gap-2">
           {socials.map((social) => {
             const Icon = SOCIAL_ICONS[social.key];
             return (
@@ -335,7 +344,7 @@ function CreatorProfile({
       ) : null}
 
       {/* Pages */}
-      <div className="mt-10 md:px-4">
+      <div className="creator-profile-inset mt-10" data-creator-pages>
         <h2 className="mb-4 text-lg font-semibold tracking-tight">
           Pages by {name}
         </h2>
@@ -358,7 +367,7 @@ function CreatorProfile({
           />
         ) : null}
         {pagesLoading && pages === null ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="creator-pages-grid grid grid-cols-1 gap-4">
             {Array.from({ length: 3 }).map((_, i) => (
               <PageCardSkeleton key={i} />
             ))}
@@ -370,7 +379,7 @@ function CreatorProfile({
             description={`${name} hasn't published any pages yet.`}
           />
         ) : pages ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="creator-pages-grid grid grid-cols-1 gap-4">
             {pages.map((p) => (
               <PageCard key={String(p.id)} article={p} />
             ))}

--- a/wallet/zuuli/src/index.css
+++ b/wallet/zuuli/src/index.css
@@ -161,6 +161,58 @@
     padding-bottom: calc(var(--mobile-tab-bar-height) + 1.5rem);
   }
 
+  /* Creator profiles live beside a persistent 15rem sidebar on desktop. Their
+     usable width can therefore be much narrower than the browser window (for
+     example, 560px in an 800px window). Keep profile breakpoints tied to the
+     route content itself so window-level media queries cannot force the
+     identity and actions into a row that does not fit. */
+  .creator-profile {
+    container-name: creator-profile;
+    container-type: inline-size;
+  }
+
+  @container creator-profile (min-width: 24rem) {
+    .creator-pages-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @container creator-profile (min-width: 36rem) {
+    .creator-profile-inset,
+    .creator-profile-header {
+      padding-right: 1rem;
+      padding-left: 1rem;
+    }
+  }
+
+  @container creator-profile (min-width: 40rem) {
+    .creator-profile-banner {
+      height: 14rem;
+    }
+
+    .creator-profile-name {
+      font-size: 1.875rem;
+      line-height: 2.25rem;
+    }
+  }
+
+  @container creator-profile (min-width: 42rem) {
+    .creator-pages-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  /* The widest mock header needs 676px before its profile inset. Waiting for
+     720px leaves that content 688px and prevents a one-pixel breakpoint from
+     recreating horizontal scroll at neighboring tablet widths. */
+  @container creator-profile (min-width: 45rem) {
+    .creator-profile-header {
+      flex-direction: row;
+      align-items: flex-end;
+      justify-content: space-between;
+    }
+  }
+
   .app-full-bleed-inset {
     padding-bottom: var(--mobile-tab-bar-height);
   }

--- a/wallet/zuuli/tests/creator-responsive.pw.ts
+++ b/wallet/zuuli/tests/creator-responsive.pw.ts
@@ -1,0 +1,247 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const PROFILE_WIDTHS = [320, 390, 767, 768, 799, 800, 801, 900, 1023, 1024] as const;
+
+type Box = {
+  clientWidth: number;
+  height: number;
+  left: number;
+  right: number;
+  scrollWidth: number;
+  top: number;
+};
+
+type CreatorLayout = {
+  actions: Box;
+  actionTargets: Array<Box & { name: string }>;
+  content: Box;
+  grid: Box;
+  gridCards: Box[];
+  gridColumns: number;
+  handle: Box;
+  header: Box;
+  headerDirection: string;
+  identity: Box;
+  name: Box;
+  profile: Box;
+  route: Box;
+};
+
+async function openCreator(page: Page, username = "zooko") {
+  await page.goto(`/creator/${username}`);
+  await page.locator("[data-creator-profile]").waitFor();
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  await expect(page.locator(".creator-pages-grid")).toBeVisible();
+}
+
+async function creatorLayout(page: Page): Promise<CreatorLayout> {
+  return page.evaluate(() => {
+    function required(selector: string): HTMLElement {
+      const element = document.querySelector<HTMLElement>(selector);
+      if (!element) throw new Error(`Missing creator layout element: ${selector}`);
+      return element;
+    }
+
+    function box(element: HTMLElement): Box {
+      const rect = element.getBoundingClientRect();
+      return {
+        clientWidth: element.clientWidth,
+        height: rect.height,
+        left: rect.left,
+        right: rect.right,
+        scrollWidth: element.scrollWidth,
+        top: rect.top,
+      };
+    }
+
+    const route = required("[data-scroll-area-viewport]");
+    const content = required("main.app-scroll-content");
+    const profile = required("[data-creator-profile]");
+    const header = required("[data-creator-profile-header]");
+    const identity = required("[data-creator-identity]");
+    const actions = required("[data-creator-actions]");
+    const grid = required(".creator-pages-grid");
+    const name = required("[data-creator-identity] h1");
+    const handle = [...identity.querySelectorAll<HTMLElement>("div")].find(
+      (element) => element.textContent?.trim() === "@zooko",
+    );
+    if (!handle) throw new Error("Creator handle is missing");
+
+    const actionTargets = [...actions.querySelectorAll<HTMLElement>("a, button")].map(
+      (element) => ({
+        ...box(element),
+        name: element.getAttribute("aria-label") ?? element.innerText.trim(),
+      }),
+    );
+
+    return {
+      actions: box(actions),
+      actionTargets,
+      content: box(content),
+      grid: box(grid),
+      gridCards: [...grid.children].map((element) => box(element as HTMLElement)),
+      gridColumns: getComputedStyle(grid).gridTemplateColumns.split(" ").length,
+      handle: box(handle),
+      header: box(header),
+      headerDirection: getComputedStyle(header).flexDirection,
+      identity: box(identity),
+      name: box(name),
+      profile: box(profile),
+      route: box(route),
+    };
+  });
+}
+
+function expectNoHorizontalOverflow(layout: CreatorLayout, width: number) {
+  const expectedRouteWidth = width >= 768 ? width - 240 : width;
+  const expectedProfileWidth = expectedRouteWidth - (width >= 768 ? 64 : 32);
+  const tolerance = 1;
+
+  expect(layout.route.clientWidth, "Radix route viewport must reflect the sidebar").toBe(
+    expectedRouteWidth,
+  );
+  expect(layout.content.clientWidth, "route content must use the Radix viewport").toBe(
+    expectedRouteWidth,
+  );
+  expect(layout.profile.clientWidth, "profile width must come from route content").toBe(
+    expectedProfileWidth,
+  );
+
+  for (const [name, element] of Object.entries({
+    route: layout.route,
+    content: layout.content,
+    profile: layout.profile,
+    header: layout.header,
+    identity: layout.identity,
+    actions: layout.actions,
+    grid: layout.grid,
+  })) {
+    expect(
+      element.scrollWidth,
+      `${name} must not acquire horizontal overflow at ${width}px`,
+    ).toBeLessThanOrEqual(element.clientWidth + tolerance);
+    expect(element.left, `${name} must stay inside the route's left edge`).toBeGreaterThanOrEqual(
+      layout.route.left - tolerance,
+    );
+    expect(element.right, `${name} must stay inside the route's right edge`).toBeLessThanOrEqual(
+      layout.route.right + tolerance,
+    );
+  }
+
+  expect(layout.name.clientWidth, "creator name must remain readable").toBeGreaterThan(0);
+  expect(layout.name.right, "creator name must stay inside its identity row").toBeLessThanOrEqual(
+    layout.identity.right + tolerance,
+  );
+  expect(layout.handle.right, "creator handle must stay inside its identity row").toBeLessThanOrEqual(
+    layout.identity.right + tolerance,
+  );
+
+  expect(layout.actionTargets.map(({ name }) => name)).toEqual([
+    "Watch Zooko live",
+    "Tip Zooko",
+    "Subscribe to Zooko · 500 2Z/mo",
+  ]);
+  for (const target of layout.actionTargets) {
+    expect(target.height, `${target.name} must keep its 44px touch height`).toBeGreaterThanOrEqual(
+      44,
+    );
+    expect(
+      target.clientWidth,
+      `${target.name} must keep its 44px touch width`,
+    ).toBeGreaterThanOrEqual(44);
+    expect(target.left, `${target.name} must stay inside the actions row`).toBeGreaterThanOrEqual(
+      layout.actions.left - tolerance,
+    );
+    expect(target.right, `${target.name} must stay inside the actions row`).toBeLessThanOrEqual(
+      layout.actions.right + tolerance,
+    );
+  }
+
+  const expectedColumns = layout.profile.clientWidth >= 672 ? 3 : layout.profile.clientWidth >= 384 ? 2 : 1;
+  expect(layout.gridColumns, "page grid columns must follow profile width").toBe(
+    expectedColumns,
+  );
+  expect(layout.gridCards.length, "published pages must remain visible").toBeGreaterThan(0);
+  for (const card of layout.gridCards) {
+    expect(card.left, "page cards must stay inside the grid").toBeGreaterThanOrEqual(
+      layout.grid.left - tolerance,
+    );
+    expect(card.right, "page cards must stay inside the grid").toBeLessThanOrEqual(
+      layout.grid.right + tolerance,
+    );
+  }
+
+  expect(layout.headerDirection, "header breakpoint must follow profile width").toBe(
+    layout.profile.clientWidth >= 720 ? "row" : "column",
+  );
+}
+
+test("creator profile follows its Radix route viewport from phones through sidebar tablets", async ({
+  page,
+}) => {
+  for (const width of PROFILE_WIDTHS) {
+    await page.setViewportSize({ width, height: 1280 });
+    await openCreator(page);
+    expectNoHorizontalOverflow(await creatorLayout(page), width);
+  }
+});
+
+test("tablet creator actions remain usable and preserve anonymous tip intent", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 800, height: 1280 });
+  await openCreator(page);
+
+  const tip = page.getByRole("button", { name: "Tip Zooko" });
+  await tip.focus();
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("dialog", { name: "Tip Zooko" })).toBeVisible();
+  await page.getByLabel("Amount (2Z)").fill("5000");
+  await expect(page.getByText(/^(?:Your |Current )?Balance(?: after)?:/i)).toHaveCount(0);
+  await page.getByRole("button", { name: "Sign in to tip" }).click();
+  await expect(page).toHaveURL(/\/login$/);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const raw = sessionStorage.getItem("zuuli.auth.pending-paid-intent");
+        return raw ? JSON.parse(raw) : null;
+      }),
+    )
+    .toMatchObject({
+      returnTo: "/creator/zooko",
+      intent: { amount: "5000", kind: "creator-tip", subject: "zooko" },
+    });
+});
+
+test("free follow keeps a 44px target and preserves its sign-in return", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 800, height: 1280 });
+  await openCreator(page, "f2z");
+
+  const follow = page.getByRole("button", { name: "Follow Free2Z" });
+  const followBox = await follow.boundingBox();
+  const routeBox = await page.locator("[data-scroll-area-viewport]").boundingBox();
+  expect(followBox).not.toBeNull();
+  expect(routeBox).not.toBeNull();
+  expect(followBox!.width).toBeGreaterThanOrEqual(44);
+  expect(followBox!.height).toBeGreaterThanOrEqual(44);
+  expect(followBox!.x).toBeGreaterThanOrEqual(routeBox!.x - 1);
+  expect(followBox!.x + followBox!.width).toBeLessThanOrEqual(
+    routeBox!.x + routeBox!.width + 1,
+  );
+
+  await follow.click();
+  await expect(page).toHaveURL(/\/login$/);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const raw = sessionStorage.getItem("zuuli.auth.pending-paid-intent");
+        return raw ? JSON.parse(raw) : null;
+      }),
+    )
+    .toMatchObject({
+      returnTo: "/creator/f2z",
+      intent: { kind: "creator-subscription", subject: "f2z" },
+    });
+});


### PR DESCRIPTION
## Summary

- make the creator profile a named inline-size container so its header, typography, insets, banner, and published-page grid respond to the actual route width left by the persistent sidebar
- keep the full live creator action set stacked until the profile itself has enough room, while retaining wrapping and 44px action targets
- add real-Chromium regressions for 320, 390, 767/768, 799/800/801, 900, and 1023/1024 CSS widths, including keyboard Tip and pointer Follow interactions
- semantically rebase onto `17803a5` so #437's unified route-backed Search contract remains intact

## Exact 800×1280 evidence

Current main before the fix:

- Radix route viewport: `clientWidth 560 / scrollWidth 695`
- route content: `560 / 695`
- creator profile: `496 / 663`
- action group extended from `x=531.8` to `x=935.4`, beyond the `x=240..800` route viewport

This branch:

- Radix route viewport: `560 / 560`
- route content: `560 / 560`
- creator profile: `496 / 496`
- creator header: `496 / 496`
- action group: `488 / 488`; Watch, Tip, and Subscribe targets are each 44px high and stay inside the route

The browser contract also asserts the creator identity and every published-page card remain inside the actual Radix viewport, and that grid/header column changes follow the measured profile width rather than `window.innerWidth`.

## Exact-head verification (`7a50d37`)

- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm test` — 350 Vitest, 8 Node contract tests, 72/72 Playwright passed in 2.9m
- `git diff --check origin/main...HEAD`
- clean committed `codex review --base origin/main` — coherent/scoped; no correctness finding

The pre-rebase head also passed the required ZUULI gate. This exact rebased head must pass a fresh gate and every packaging target before merge.

Closes #432.
Related: #387, #395.
