### PR TITLE
fix(zuuli): require consent for remote article media

### DIFF
--- a/wallet/zuuli/index.html
+++ b/wallet/zuuli/index.html
@@ -2,6 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
+    <meta name="referrer" content="no-referrer" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"

--- a/wallet/zuuli/src/components/common/Markdown.test.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.test.tsx
@@ -29,29 +29,21 @@ function expectNoErrorFallback(markup: string) {
 }
 
 describe("Markdown images", () => {
-  it("renders a real <img> for the trusted article variant", () => {
-    // Regression: the `components` map used to carry `img: undefined` for the
-    // article variant. react-markdown resolves overrides by KEY PRESENCE, so
-    // the element type became `undefined`, React threw "Element type is
-    // invalid", the ErrorBoundary caught it, and every article containing an
-    // image rendered as raw markdown source. See issue #319.
+  it("holds an article image behind destination-specific consent", () => {
     const markup = render(IMAGE, "article");
 
-    expect(markup).toContain("<img");
-    expect(markup).toContain('src="https://example.com/y.png"');
-    expect(markup).toContain('alt="alt text"');
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain('data-remote-media-host="example.com"');
+    expect(markup).toContain('aria-label="Load image from example.com"');
     expectNoErrorFallback(markup);
   });
 
-  it("degrades an image to a plain link for the untrusted comment variant", () => {
-    // Privacy: an untrusted comment must never auto-load a remote image, which
-    // would beacon the reader's IP to an attacker-chosen host on render.
+  it("uses the same one-item consent boundary for comments", () => {
     const markup = render(IMAGE, "comment");
 
     expect(markup).not.toContain("<img");
-    expect(markup).toContain('href="https://example.com/y.png"');
-    expect(markup).toContain('rel="noopener noreferrer"');
-    expect(markup).toContain("alt text");
+    expect(markup).toContain('data-remote-media-host="example.com"');
+    expect(markup).toContain('aria-label="Load image from example.com"');
     expectNoErrorFallback(markup);
   });
 
@@ -64,7 +56,8 @@ describe("Markdown images", () => {
       "article",
     );
 
-    expect(markup).toContain('src="/uploadz/public/palmar/elg03269-1.webp"');
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain('data-remote-media-host="zuuli.invalid"');
   });
 });
 
@@ -83,8 +76,8 @@ describe("Markdown links", () => {
  * `![](/uploadz/public/palmar/elg03269-1.webp)`. Those only resolve when the
  * document itself is served from free2z. A production `tauri build` has no Vite
  * proxy and runs on the `tauri://localhost` origin, so the path would resolve
- * against the app's own bundled `dist/` and 404. The article `img` renderer
- * absolutizes it via `mediaUrl()`.
+ * against the app's own bundled `dist/` and 404. The consent policy resolves
+ * it via `mediaUrl()` but withholds a media DOM source until the reader clicks.
  *
  * `MEDIA_BASE` is captured at module-eval time (and is "" under vitest, which
  * runs with `import.meta.env.DEV`), so these cases need a re-imported module
@@ -115,55 +108,42 @@ describe("Markdown article images against a remote media host", () => {
     vi.resetModules();
   });
 
-  it("absolutizes a relative /uploadz src against the media host", () => {
+  it("discloses the media host for a relative /uploadz src", () => {
     const markup = renderArticle("![](/uploadz/public/palmar/elg03269-1.webp)");
 
-    expect(markup).toContain(
-      `src="${MEDIA}/uploadz/public/palmar/elg03269-1.webp"`,
-    );
-    // Exactly one slash between host and path — no `https://media.example//…`.
-    expect(markup).not.toContain(`${MEDIA}//uploadz`);
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain('data-remote-media-host="media.example"');
   });
 
-  it("absolutizes a path with no leading slash", () => {
+  it("discloses the media host for a path with no leading slash", () => {
     const markup = renderArticle("![](uploadz/public/x.webp)");
 
-    expect(markup).toContain(`src="${MEDIA}/uploadz/public/x.webp"`);
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain('data-remote-media-host="media.example"');
   });
 
-  it("leaves an already-absolute https src untouched", () => {
+  it("names an already-absolute https destination", () => {
     const markup = renderArticle("![alt text](https://example.com/y.png)");
 
-    expect(markup).toContain('src="https://example.com/y.png"');
-    expect(markup).not.toContain(MEDIA);
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain('data-remote-media-host="example.com"');
   });
 
-  it("leaves a protocol-relative src untouched", () => {
-    // `//cdn.example/z.png` is already absolute w.r.t. the scheme; prefixing it
-    // would produce `https://media.example//cdn.example/z.png`.
+  it("normalizes and names a protocol-relative destination", () => {
     const markup = renderArticle("![](//cdn.example/z.png)");
 
-    expect(markup).toContain('src="//cdn.example/z.png"');
-    expect(markup).not.toContain(MEDIA);
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain('data-remote-media-host="cdn.example"');
   });
 
-  it("does not corrupt a data: URI into a media-host path", () => {
-    // react-markdown's `defaultUrlTransform` blocks non-http(s) protocols, so a
-    // `data:` image arrives here already emptied. Whatever it becomes, it must
-    // never turn into `https://media.example/data:image/...` — and an empty
-    // `src=""` (which browsers resolve to the current document URL) must not
-    // survive either.
+  it("fails closed for a data URI", () => {
     const markup = renderArticle("![dot](data:image/png;base64,iVBORw0KGgo=)");
 
-    expect(markup).toContain("<img");
-    expect(markup).not.toContain(`${MEDIA}/data:`);
-    expect(markup).not.toContain(`${MEDIA}/image/png`);
-    expect(markup).not.toContain('src=""');
+    expect(markup).not.toContain("<img");
+    expect(markup).toContain("data-remote-media-blocked");
   });
 
-  it("still degrades a relative comment image to a plain link", () => {
-    // Privacy guard: absolutizing article images must NOT make untrusted
-    // comment images auto-load. A relative comment src stays a link.
+  it("uses the same remote host consent for a relative comment image", () => {
     const markup = renderToStaticMarkup(
       <MemoryRouter>
         <Markdown variant="comment">
@@ -173,7 +153,6 @@ describe("Markdown article images against a remote media host", () => {
     );
 
     expect(markup).not.toContain("<img");
-    expect(markup).toContain('href="/uploadz/public/tracker.webp"');
-    expect(markup).toContain("shot");
+    expect(markup).toContain('data-remote-media-host="zuuli.invalid"');
   });
 });

--- a/wallet/zuuli/src/components/common/Markdown.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.tsx
@@ -20,7 +20,6 @@ import rehypePrism from "rehype-prism-plus";
 import rehypeSlug from "rehype-slug";
 
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { mediaUrl } from "@/lib/api/http";
 import { isTauri } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 
@@ -28,23 +27,26 @@ import remarkOembed from "@/lib/markdown/remark-oembed";
 import remarkQrCodePlugin from "@/lib/markdown/remark-qrcode";
 import Mermaid from "@/components/common/Mermaid";
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
+import {
+  RemoteImage,
+  RemoteMedia,
+  resolveRemoteMediaSource,
+} from "@/components/common/RemoteMedia";
 
 import "./markdown.css";
 
 /**
  * Rendering variants:
- *   • "article"  — trusted, creator/AI long-form content. Full rich pipeline:
- *                  auto-loading images, native video/audio embeds, QR codes,
- *                  mermaid diagrams.
+ *   • "article"  — creator/AI long-form content. Full rich pipeline, but every
+ *                  network image/audio/video/provider embed is held behind
+ *                  one-item destination consent.
  *   • "comment"  — UNTRUSTED, user-supplied comment bodies. Hardened: remote
- *                  images and media embeds degrade to plain external LINKS (no
- *                  silent network beacons that deanonymize readers by IP), and
+ *                  images and media embeds use the same one-item consent
+ *                  boundary (no silent network beacons by IP), and
  *                  `::qrcode` / mermaid are shown as text/code rather than a
  *                  scannable QR or rendered diagram (phishing + perf). This is
  *                  the primary render-layer privacy fix; see also the CSP note
- *                  in `src-tauri/tauri.conf.json` (intentionally NOT tightened
- *                  for images because trusted article markdown legitimately
- *                  hotlinks arbitrary hosts).
+ *                  in `src-tauri/tauri.conf.json`.
  */
 export type MarkdownVariant = "article" | "comment";
 
@@ -219,13 +221,17 @@ function CodeBlock({
  */
 function youTubeId(url: URL): string | null {
   const host = url.hostname.replace(/^www\./, "");
-  if (host === "youtu.be") return url.pathname.slice(1) || null;
-  if (host === "youtube.com" || host === "youtube-nocookie.com") {
-    if (url.pathname.startsWith("/embed/"))
-      return url.pathname.split("/")[2] || null;
-    return url.searchParams.get("v");
-  }
-  return null;
+  const candidate =
+    host === "youtu.be"
+      ? url.pathname.slice(1)
+      : host === "youtube.com" || host === "youtube-nocookie.com"
+        ? url.pathname.startsWith("/embed/")
+          ? url.pathname.split("/")[2] || null
+          : url.searchParams.get("v")
+        : null;
+  return candidate && /^[A-Za-z0-9_-]{1,64}$/.test(candidate)
+    ? candidate
+    : null;
 }
 
 /** Extract a numeric Vimeo id (exact-host match only). */
@@ -245,119 +251,117 @@ function vimeoId(url: URL): string | null {
  *   • .mp3/... → native <audio controls>
  *   • anything else → a plain external link.
  *
- * In the "comment" (untrusted) variant, NOTHING auto-loads: every embed
- * degrades to a plain external link. Native <video>/<audio> from an arbitrary
- * attacker host would silently beacon every reader's IP on render, and even the
- * fixed YouTube/Vimeo iframes ping third parties — neither is acceptable for
- * anonymous, unmoderated comment content in a wallet.
+ * Every recognized media target uses the shared one-item consent boundary.
+ * Unknown targets remain external links and do not issue an in-app request.
  */
-function SafeEmbed({ url, variant }: { url: string; variant: MarkdownVariant }) {
-  // Untrusted comments never auto-load remote media — always a link.
-  if (variant === "comment") {
-    return <MarkdownLink href={url}>{url}</MarkdownLink>;
-  }
-
-  let parsed: URL | null = null;
-  try {
-    parsed = new URL(url);
-  } catch {
-    parsed = null;
-  }
+function SafeEmbed({ url }: { url: string }) {
+  const authoredTarget = resolveRemoteMediaSource(url);
+  const parsed = authoredTarget ? new URL(authoredTarget.url) : null;
 
   // Only https targets get rich embeds; everything else degrades to a link.
   if (parsed && parsed.protocol === "https:") {
     const yt = youTubeId(parsed);
     if (yt) {
       return (
-        <div className="my-4 aspect-video w-full overflow-hidden rounded-lg border border-border">
-          <iframe
-            className="h-full w-full"
-            src={`https://www.youtube-nocookie.com/embed/${yt}`}
-            title="YouTube video"
-            loading="lazy"
-            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-          />
-        </div>
+        <RemoteMedia
+          source={`https://www.youtube-nocookie.com/embed/${yt}`}
+          kind="video"
+          className="my-4 aspect-video w-full overflow-hidden"
+        >
+          {({ url: consentedUrl }) => (
+            <iframe
+              className="h-full w-full"
+              src={consentedUrl}
+              title="YouTube video"
+              referrerPolicy="no-referrer"
+              allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          )}
+        </RemoteMedia>
       );
     }
 
     const vm = vimeoId(parsed);
     if (vm) {
       return (
-        <div className="my-4 aspect-video w-full overflow-hidden rounded-lg border border-border">
-          <iframe
-            className="h-full w-full"
-            src={`https://player.vimeo.com/video/${vm}`}
-            title="Vimeo video"
-            loading="lazy"
-            allow="autoplay; fullscreen; picture-in-picture"
-            allowFullScreen
-          />
-        </div>
+        <RemoteMedia
+          source={`https://player.vimeo.com/video/${vm}`}
+          kind="video"
+          className="my-4 aspect-video w-full overflow-hidden"
+        >
+          {({ url: consentedUrl }) => (
+            <iframe
+              className="h-full w-full"
+              src={consentedUrl}
+              title="Vimeo video"
+              referrerPolicy="no-referrer"
+              allow="autoplay; fullscreen; picture-in-picture"
+              allowFullScreen
+            />
+          )}
+        </RemoteMedia>
       );
     }
 
     if (/\.(mp4|webm|ogv|mov)$/i.test(parsed.pathname)) {
       return (
-        <video controls className="my-4 w-full rounded-lg border border-border">
-          <source src={url} />
-        </video>
+        <RemoteMedia
+          source={parsed.href}
+          kind="video"
+          className="my-4 w-full"
+        >
+          {({ url: consentedUrl }) => (
+            <video
+              controls
+              preload="metadata"
+              className="w-full rounded-lg border border-border"
+              src={consentedUrl}
+            />
+          )}
+        </RemoteMedia>
       );
     }
 
     if (/\.(mp3|ogg|wav|m4a|flac)$/i.test(parsed.pathname)) {
-      return <audio controls className="my-4 w-full" src={url} />;
+      return (
+        <RemoteMedia
+          source={parsed.href}
+          kind="audio"
+          className="my-4 w-full"
+        >
+          {({ url: consentedUrl }) => (
+            <audio
+              controls
+              preload="metadata"
+              className="w-full"
+              src={consentedUrl}
+            />
+          )}
+        </RemoteMedia>
+      );
     }
   }
 
   // Fallback: a plain external link (reuses out-of-app open handling).
-  return <MarkdownLink href={url}>{url}</MarkdownLink>;
-}
-
-/**
- * `img` renderer for the UNTRUSTED "comment" variant: a remote image is
- * degraded to a plain external link so it never auto-loads and beacons the
- * reader's IP to an attacker-chosen host on render. Deliberate privacy
- * behavior — see `MarkdownVariant`; do not "fix" it into a real <img>.
- *
- * Hoisted to module scope (like `MarkdownLink` / `CodeBlock`) so it is a stable
- * component identity instead of a fresh function on every render.
- */
-function CommentImageLink({ src, alt }: { src?: string | Blob; alt?: string }) {
-  const href = typeof src === "string" ? src : "#";
   return (
-    <MarkdownLink href={href}>
-      {alt || (typeof src === "string" ? src : "image")}
+    <MarkdownLink href={authoredTarget?.url ?? url}>
+      {authoredTarget?.url ?? url}
     </MarkdownLink>
   );
 }
 
-/**
- * `img` renderer for the trusted "article" variant: a real, auto-loading
- * `<img>` whose `src` is resolved against the media host.
- *
- * free2z authors embed uploads as ORIGIN-RELATIVE paths — a real body reads
- * `![](/uploadz/public/palmar/elg03269-1.webp)`. That only resolves by accident
- * in `npm run dev` / `tauri dev`, where the Vite proxy forwards `/uploadz` to
- * the backend from the same origin. A production `tauri build` has no proxy and
- * the webview origin is `tauri://localhost`, so the same path resolves against
- * the app's own bundled `dist/` (which contains only `index.html` + `assets/`)
- * and 404s — every in-body image is broken. `mediaUrl()` absolutizes it against
- * `MEDIA_BASE`, and leaves already-absolute `https:` / `data:` /
- * protocol-relative sources untouched.
- *
- * `node` is destructured out because react-markdown passes the hast node to
- * every override and it must not reach the DOM element.
- */
-function ArticleImage({
+/** Shared article/comment image consent renderer. */
+function MarkdownRemoteImage({
   node: _node,
   src,
   alt,
   ...rest
 }: ImgHTMLAttributes<HTMLImageElement> & { node?: unknown }) {
-  const resolved = typeof src === "string" ? mediaUrl(src) : undefined;
-  return <img {...rest} src={resolved} alt={alt ?? ""} />;
+  if (typeof src !== "string") {
+    return <span data-remote-media-blocked>Media blocked</span>;
+  }
+  return <RemoteImage {...rest} src={src} alt={alt ?? ""} />;
 }
 
 // ── Math DoS guard (defense-in-depth) ───────────────────────────────────────
@@ -468,13 +472,9 @@ export function Markdown({
         components={{
           a: MarkdownLink,
           pre: CodeBlock,
-          // Images. BOTH variants must map to a REAL component:
-          //   • article — <ArticleImage>: a real <img>, src absolutized against
-          //     the media host so origin-relative `/uploadz/…` bodies load in a
-          //     production build (where there is no Vite proxy).
-          //   • comment — <CommentImageLink>: degrades to a plain external link
-          //     so untrusted images never auto-load and beacon the reader's IP
-          //     to an attacker-chosen host.
+          // Both variants use the exact same one-item consent boundary. The
+          // source is resolved against the media host, but no <img> exists
+          // until the reader chooses this exact destination.
           //
           // NEVER write `img: cond ? X : undefined` (nor any other
           // conditionally-`undefined` entry in this map). react-markdown@9
@@ -491,7 +491,7 @@ export function Markdown({
           // image renders as raw markdown source (issue #319). If a variant
           // ever needs the plain intrinsic tag, omit the key entirely via a
           // spread — do not set it to `undefined`.
-          img: isComment ? CommentImageLink : ArticleImage,
+          img: MarkdownRemoteImage,
           table: ({ node, ...props }) => (
             <div className="overflow-x-auto">
               <table {...props} />
@@ -539,7 +539,7 @@ export function Markdown({
                 node?.properties?.["dataEmbedUrl"]?.toString() ||
                 node?.properties?.["data-embed-url"]?.toString() ||
                 "";
-              if (url) return <SafeEmbed url={url} variant={variant} />;
+              if (url) return <SafeEmbed url={url} />;
             }
 
             return (

--- a/wallet/zuuli/src/components/common/RemoteMedia.tsx
+++ b/wallet/zuuli/src/components/common/RemoteMedia.tsx
@@ -1,0 +1,146 @@
+import {
+  useMemo,
+  useState,
+  type ImgHTMLAttributes,
+  type ReactNode,
+} from "react";
+import { EyeOff } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { MEDIA_BASE } from "@/lib/env";
+import { mediaUrl } from "@/lib/api/http";
+import {
+  normalizeRemoteMediaTarget,
+  type RemoteMediaTarget,
+} from "@/lib/media/remote-media-policy";
+import { cn } from "@/lib/utils";
+
+export type RemoteMediaKind = "image" | "audio" | "video";
+
+function documentBase(): string {
+  if (MEDIA_BASE) return `${MEDIA_BASE}/`;
+  if (typeof window !== "undefined") return window.location.href;
+  // SSR/static-markup tests need a syntactically valid base. Production
+  // builds always have MEDIA_BASE; this value is never used for a request.
+  return "https://zuuli.invalid/";
+}
+
+/** Resolve a backend-relative or authored media source without requesting it. */
+export function resolveRemoteMediaSource(
+  source: string,
+): RemoteMediaTarget | null {
+  const resolved = mediaUrl(source);
+  if (!resolved) return null;
+  // Production MEDIA_BASE is HTTPS. Make protocol-relative authored media
+  // deterministic in the HTTP Vite harness too instead of ever consenting an
+  // insecure third-party request merely because the test document is HTTP.
+  const candidate = resolved.startsWith("//") ? `https:${resolved}` : resolved;
+  return normalizeRemoteMediaTarget(candidate, documentBase());
+}
+
+/**
+ * One-item consent boundary for creator-selected network media.
+ *
+ * Consent is bound to this component instance AND the exact canonical URL.
+ * Changing `source` can therefore never reuse consent from the previous item,
+ * even for a single render. Nothing is persisted in storage or shared through
+ * context.
+ */
+export function RemoteMedia({
+  source,
+  kind,
+  className,
+  children,
+}: {
+  source: string;
+  kind: RemoteMediaKind;
+  className?: string;
+  children: (target: RemoteMediaTarget) => ReactNode;
+}) {
+  const target = useMemo(() => resolveRemoteMediaSource(source), [source]);
+  const [consentedUrl, setConsentedUrl] = useState<string | null>(null);
+
+  if (!target) {
+    return (
+      <span
+        data-remote-media-blocked
+        className={cn(
+          "flex min-h-24 w-full min-w-0 items-center justify-center rounded-lg border border-border bg-muted/40 px-3 py-4 text-center text-sm text-muted-foreground",
+          className,
+        )}
+        role="status"
+      >
+        Media blocked
+      </span>
+    );
+  }
+
+  if (consentedUrl === target.url) {
+    return (
+      <span
+        data-remote-media-loaded
+        data-remote-media-host={target.hostname}
+        className={cn("block min-w-0", className)}
+      >
+        {children(target)}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      data-remote-media-consent
+      data-remote-media-host={target.hostname}
+      className={cn(
+        "flex min-h-24 w-full min-w-0 flex-col items-center justify-center gap-2 overflow-hidden rounded-lg border border-border bg-muted/40 px-3 py-4 text-center",
+        className,
+      )}
+      role="group"
+      aria-label={`Remote ${kind} from ${target.hostname}`}
+    >
+      <EyeOff className="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+      <span className="min-w-0 max-w-full break-all text-xs text-muted-foreground">
+        {target.hostname}
+      </span>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="min-tap h-12 min-h-12 max-w-full"
+        aria-label={`Load ${kind} from ${target.hostname}`}
+        onClick={(event) => {
+          // Some article cards use the loaded image as a navigation link. Keep
+          // this first consent click scoped to media, never route navigation.
+          event.preventDefault();
+          event.stopPropagation();
+          setConsentedUrl(target.url);
+        }}
+      >
+        Load {kind}
+      </Button>
+    </span>
+  );
+}
+
+export function RemoteImage({
+  src,
+  containerClassName,
+  alt = "",
+  ...imageProps
+}: {
+  src: string;
+  containerClassName?: string;
+} & Omit<ImgHTMLAttributes<HTMLImageElement>, "src" | "referrerPolicy">) {
+  return (
+    <RemoteMedia source={src} kind="image" className={containerClassName}>
+      {({ url }) => (
+        <img
+          {...imageProps}
+          src={url}
+          alt={alt}
+          referrerPolicy="no-referrer"
+        />
+      )}
+    </RemoteMedia>
+  );
+}

--- a/wallet/zuuli/src/features/articles/components/ArticleCard.tsx
+++ b/wallet/zuuli/src/features/articles/components/ArticleCard.tsx
@@ -8,6 +8,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { RemoteMedia } from "@/components/common/RemoteMedia";
 import { initials, timeAgo } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { Article } from "@/lib/api/types";
@@ -31,36 +32,52 @@ export function ArticleCard({
         className,
       )}
     >
+      {/* Cover consent cannot live inside the article link: the first click
+          must load only this media item, never navigate as a side effect. */}
+      <div
+        className="relative aspect-[16/9] w-full overflow-hidden"
+        style={
+          article.image
+            ? undefined
+            : { backgroundImage: coverGradient(article.title) }
+        }
+      >
+        {article.image ? (
+          <RemoteMedia
+            source={article.image}
+            kind="image"
+            className="h-full min-h-0 rounded-none border-0 p-0"
+          >
+            {({ url }) => (
+              <Link
+                to={articleHref(article)}
+                aria-label={`Read “${article.title}”`}
+                className="block h-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <img
+                  src={url}
+                  alt=""
+                  referrerPolicy="no-referrer"
+                  className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                />
+              </Link>
+            )}
+          </RemoteMedia>
+        ) : (
+          <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
+        )}
+        {article.category ? (
+          <Badge className="pointer-events-none absolute left-3 top-3 backdrop-blur-sm">
+            {article.category}
+          </Badge>
+        ) : null}
+      </div>
+
       <Link
         to={articleHref(article)}
         aria-label={`Read “${article.title}”`}
         className="flex flex-1 flex-col focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        {/* Cover */}
-        <div
-          className="relative aspect-[16/9] w-full overflow-hidden"
-          style={
-            article.image
-              ? undefined
-              : { backgroundImage: coverGradient(article.title) }
-          }
-        >
-          {article.image ? (
-            <img
-              src={article.image}
-              alt=""
-              className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-            />
-          ) : (
-            <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
-          )}
-          {article.category ? (
-            <Badge className="absolute left-3 top-3 backdrop-blur-sm">
-              {article.category}
-            </Badge>
-          ) : null}
-        </div>
-
         {/* Body */}
         <div className="flex flex-1 flex-col gap-2 p-5 pb-3">
           <h3 className="text-lg font-semibold leading-snug tracking-tight text-foreground transition-colors group-hover:text-primary">

--- a/wallet/zuuli/src/features/articles/pages/Reader.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Reader.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
 import { Markdown } from "@/components/common/Markdown";
+import { RemoteImage } from "@/components/common/RemoteMedia";
 import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { useAsync } from "@/hooks/useAsync";
 import { articles } from "@/lib/api/free2z";
@@ -170,10 +171,11 @@ export function Reader() {
           }
         >
           {article.image ? (
-            <img
+            <RemoteImage
               src={article.image}
               alt=""
               className="h-full w-full object-cover"
+              containerClassName="h-full min-h-0 rounded-none border-0 p-0"
             />
           ) : null}
         </div>

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -40,6 +40,7 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/common/EmptyState";
 import { Markdown } from "@/components/common/Markdown";
+import { RemoteMedia } from "@/components/common/RemoteMedia";
 import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { discover, live, tuzi } from "@/lib/api/free2z";
 import {
@@ -1031,25 +1032,40 @@ function TipButton({
 // ─── Page card ────────────────────────────────────────────────────────────────
 function PageCard({ article }: { article: Article }) {
   return (
-    <Link
-      to={`/articles/${article.slug ?? article.id}`}
-      aria-label={`Read “${article.title}”`}
-      className="group flex flex-col overflow-hidden rounded-xl border border-border/60 bg-card/60 transition-colors hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    >
+    <div className="group flex flex-col overflow-hidden rounded-xl border border-border/60 bg-card/60 transition-colors hover:border-primary/40">
       <div className="aspect-[16/9] w-full overflow-hidden bg-secondary">
         {article.image ? (
-          <img
-            src={article.image}
-            alt=""
-            className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-          />
+          <RemoteMedia
+            source={article.image}
+            kind="image"
+            className="h-full min-h-0 rounded-none border-0 p-0"
+          >
+            {({ url }) => (
+              <Link
+                to={`/articles/${article.slug ?? article.id}`}
+                aria-label={`Read “${article.title}”`}
+                className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <img
+                  src={url}
+                  alt=""
+                  referrerPolicy="no-referrer"
+                  className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                />
+              </Link>
+            )}
+          </RemoteMedia>
         ) : (
           <div className="grid h-full w-full place-items-center text-muted-foreground">
             <FileText className="h-6 w-6" aria-hidden />
           </div>
         )}
       </div>
-      <div className="flex flex-1 flex-col gap-2 p-4">
+      <Link
+        to={`/articles/${article.slug ?? article.id}`}
+        aria-label={`Read “${article.title}”`}
+        className="flex flex-1 flex-col gap-2 rounded-md p-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
         <h3 className="line-clamp-2 font-semibold leading-snug group-hover:text-primary">
           {article.title}
         </h3>
@@ -1069,8 +1085,8 @@ function PageCard({ article }: { article: Article }) {
             <span>{timeAgo(article.published_at)}</span>
           ) : null}
         </div>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 }
 

--- a/wallet/zuuli/src/features/search/index.tsx
+++ b/wallet/zuuli/src/features/search/index.tsx
@@ -22,6 +22,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/common/EmptyState";
 import { PageHeader } from "@/components/common/PageHeader";
 import { SectionLoadError } from "@/components/common/SectionLoadError";
+import { RemoteMedia } from "@/components/common/RemoteMedia";
 import { useAsync } from "@/hooks/useAsync";
 import { discover } from "@/lib/api/free2z";
 import { formatTuzis, initials, timeAgo } from "@/lib/format";
@@ -136,7 +137,7 @@ export default function SearchFeature() {
               inputRef.current?.focus();
             }}
             aria-label="Clear search"
-            className="min-tap absolute right-1.5 top-1/2 grid -translate-y-1/2 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="min-tap absolute right-1.5 top-1/2 grid h-12 w-12 min-h-12 min-w-12 -translate-y-1/2 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <X className="h-4 w-4" aria-hidden />
           </button>
@@ -334,25 +335,40 @@ function PageResultRow({ article }: { article: Article }) {
   const name = author.display_name || author.username;
   const body = article.subtitle || excerpt(article.content);
   return (
-    <Link
-      to={`/articles/${article.slug ?? article.id}`}
-      aria-label={`Read “${article.title}”`}
-      className="group flex w-full min-w-0 gap-4 rounded-xl border border-border bg-card/60 p-4 transition-colors hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    >
-      <div className="hidden h-16 w-24 shrink-0 overflow-hidden rounded-lg bg-secondary sm:block">
+    <div className="group flex w-full min-w-0 gap-4 rounded-xl border border-border bg-card/60 p-4 transition-colors hover:border-primary/40">
+      <div className="hidden h-28 w-32 shrink-0 overflow-hidden rounded-lg bg-secondary sm:block">
         {article.image ? (
-          <img
-            src={article.image}
-            alt=""
-            className="h-full w-full object-cover"
-          />
+          <RemoteMedia
+            source={article.image}
+            kind="image"
+            className="h-full min-h-0 rounded-none border-0 px-2 py-1"
+          >
+            {({ url }) => (
+              <Link
+                to={`/articles/${article.slug ?? article.id}`}
+                aria-label={`Read “${article.title}”`}
+                className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <img
+                  src={url}
+                  alt=""
+                  referrerPolicy="no-referrer"
+                  className="h-full w-full object-cover"
+                />
+              </Link>
+            )}
+          </RemoteMedia>
         ) : (
           <div className="grid h-full w-full place-items-center text-muted-foreground">
             <FileText className="h-5 w-5" aria-hidden />
           </div>
         )}
       </div>
-      <div className="min-w-0 flex-1">
+      <Link
+        to={`/articles/${article.slug ?? article.id}`}
+        aria-label={`Read “${article.title}”`}
+        className="min-w-0 flex-1 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
         <div className="flex items-start justify-between gap-3">
           <h3 className="min-w-0 truncate font-semibold leading-snug group-hover:text-primary">
             {article.title}
@@ -380,8 +396,8 @@ function PageResultRow({ article }: { article: Article }) {
             </>
           ) : null}
         </div>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 }
 

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -460,6 +460,40 @@ const featuredArticles: Article[] = [
     reading_minutes: 5,
     tags: ["zcash", "identity", "auth"],
   },
+  {
+    // Reserved fixture for the remote-media privacy contract. The `.test`
+    // destinations are intercepted only by Playwright; keeping this article
+    // old prevents it from displacing normal mock content in the feed.
+    id: 4,
+    slug: "remote-media-consent-audit",
+    free2zaddr: "remote-media-consent-audit",
+    title: "Remote Media Consent Audit",
+    subtitle: "Deterministic privacy fixtures for article media.",
+    content: [
+      "# Remote Media Consent Audit",
+      "",
+      "![Inline tracker](https://inline.media.test/pixel.png)",
+      "",
+      "![Protocol-relative tracker](//protocol.media.test/pixel.png)",
+      "",
+      "![Encoded tracker](https://%65ncoded.media.test/%70ixel.png)",
+      "",
+      "::embed[https://video.media.test/clip.webm]",
+      "",
+      "::embed[https://audio.media.test/clip.ogg]",
+      "",
+      "::embed[https://youtu.be/PrivacyAudit01]",
+      "",
+      "::embed[https://vimeo.com/123456789]",
+    ].join("\n"),
+    image: "https://cover.media.test/redirect",
+    category: "Privacy",
+    author: mockCreators[0],
+    votes: 0,
+    published_at: "2020-01-01T00:00:00.000Z",
+    reading_minutes: 1,
+    tags: ["privacy", "test"],
+  },
 ];
 
 // A broader synthetic corpus so mock mode can demo infinite scroll, tag
@@ -998,6 +1032,16 @@ function seedComment(
     "Great piece. Worth noting Halo2 drops the trusted setup entirely — might be worth a follow-up article.",
     23,
     45,
+  );
+
+  seedComment(
+    featuredArticles[3].free2zaddr!,
+    mockCreators[1],
+    null,
+    "Remote comment media audit",
+    "![Comment tracker](https://comment.media.test/pixel.png)\n\n::embed[https://comment-video.media.test/clip.webm]",
+    1,
+    5,
   );
 })();
 

--- a/wallet/zuuli/src/lib/media/remote-media-policy.test.ts
+++ b/wallet/zuuli/src/lib/media/remote-media-policy.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRemoteMediaTarget } from "./remote-media-policy";
+
+const BASE = "https://media.free2z.test/root/";
+
+describe("remote media URL policy", () => {
+  it.each([
+    ["https://EXAMPLE.com./image.png", "https://example.com/image.png", "example.com"],
+    ["//CDN.example/path.png", "https://cdn.example/path.png", "cdn.example"],
+    ["/uploadz/a.png", "https://media.free2z.test/uploadz/a.png", "media.free2z.test"],
+    ["clip.mp3", "https://media.free2z.test/root/clip.mp3", "media.free2z.test"],
+    ["https://%65xample.com/%70ixel.png", "https://example.com/%70ixel.png", "example.com"],
+  ])("normalizes %s without a request", (source, url, hostname) => {
+    expect(normalizeRemoteMediaTarget(source, BASE)).toEqual({ url, hostname });
+  });
+
+  it.each([
+    "",
+    "   ",
+    "data:image/png;base64,AAAA",
+    "blob:https://example.com/id",
+    "javascript:alert(1)",
+    "file:///etc/passwd",
+    "http://tracker.example/pixel.png",
+    "http://127.0.0.1:8080/video.mp4",
+    "https://user@example.com/x.png",
+    "https://user:pass@example.com/x.png",
+    "https://exa\nmple.com/x.png",
+    "https://[not-an-ipv6]/x.png",
+  ])("fails closed for %j", (source) => {
+    expect(normalizeRemoteMediaTarget(source, BASE)).toBeNull();
+  });
+
+  it("allows only the exact same-origin loopback HTTP development proxy", () => {
+    expect(
+      normalizeRemoteMediaTarget(
+        "/uploadz/dev.png",
+        "http://127.0.0.1:1432/articles/example",
+      ),
+    ).toEqual({
+      url: "http://127.0.0.1:1432/uploadz/dev.png",
+      hostname: "127.0.0.1",
+    });
+    expect(
+      normalizeRemoteMediaTarget(
+        "http://127.0.0.1:1423/uploadz/wrong-port.png",
+        "http://127.0.0.1:1432/",
+      ),
+    ).toBeNull();
+  });
+
+  it("never double-decodes an encoded absolute URL into another origin", () => {
+    const target = normalizeRemoteMediaTarget(
+      "https%3A%2F%2Ftracker.example%2Fpixel.png",
+      BASE,
+    );
+
+    expect(target?.hostname).toBe("media.free2z.test");
+    expect(target?.url).not.toContain("tracker.example/");
+  });
+
+  it("fails closed across a deterministic control-character fuzz matrix", () => {
+    for (let code = 0; code <= 0x7f; code += 1) {
+      const char = String.fromCharCode(code);
+      const target = normalizeRemoteMediaTarget(
+        `https://example.com/a${char}b.png`,
+        BASE,
+      );
+      if (code <= 0x1f || code === 0x7f) {
+        expect(target, `code point ${code}`).toBeNull();
+      } else {
+        expect(target?.hostname, `code point ${code}`).toBe("example.com");
+      }
+    }
+  });
+});

--- a/wallet/zuuli/src/lib/media/remote-media-policy.ts
+++ b/wallet/zuuli/src/lib/media/remote-media-policy.ts
@@ -1,0 +1,67 @@
+export interface RemoteMediaTarget {
+  /** Canonical browser destination. This is the only value handed to media DOM. */
+  url: string;
+  /** Normalized network hostname shown before consent. */
+  hostname: string;
+}
+
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f]/;
+
+function isLoopback(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]"
+  );
+}
+
+/**
+ * Resolve an untrusted media source without fetching it.
+ *
+ * The parser deliberately performs exactly one WHATWG URL parse. In
+ * particular, percent-encoded absolute URLs are not decoded a second time:
+ * `%68%74...` remains a path on the supplied base instead of becoming an
+ * attacker-controlled origin. Credentials and non-network schemes fail
+ * closed, while protocol-relative and ordinary relative upload paths resolve
+ * against the explicit application/media base.
+ */
+export function normalizeRemoteMediaTarget(
+  source: string,
+  base: string,
+): RemoteMediaTarget | null {
+  if (!source || CONTROL_CHARACTER.test(source)) return null;
+
+  const candidate = source.trim();
+  if (!candidate) return null;
+
+  let parsed: URL;
+  let parsedBase: URL;
+  try {
+    parsedBase = new URL(base);
+    parsed = new URL(candidate, parsedBase);
+  } catch {
+    return null;
+  }
+
+  // Packaged ZUULI intentionally permits only HTTPS network media in CSP. The
+  // sole HTTP exception is the exact same-origin loopback Vite dev proxy; it
+  // cannot authorize an authored external HTTP destination or packaged app.
+  const allowedDevHttp =
+    parsed.protocol === "http:" &&
+    parsed.origin === parsedBase.origin &&
+    isLoopback(parsed.hostname);
+  if (parsed.protocol !== "https:" && !allowedDevHttp) return null;
+  if (!parsed.hostname || parsed.username || parsed.password) return null;
+
+  // DNS ignores a terminal root dot. Remove it from both the request and the
+  // disclosure so equivalent spellings cannot make the destination look
+  // different. URL already lower-cases and IDNA-normalizes the hostname.
+  const hostname = parsed.hostname.endsWith(".")
+    ? parsed.hostname.slice(0, -1)
+    : parsed.hostname;
+  if (!hostname) return null;
+  parsed.hostname = hostname;
+
+  return { url: parsed.href, hostname };
+}

--- a/wallet/zuuli/tests/remote-media-consent.pw.ts
+++ b/wallet/zuuli/tests/remote-media-consent.pw.ts
@@ -1,0 +1,376 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const ARTICLE = "/articles/remote-media-consent-audit";
+const OBSERVED_HOSTS = new Set([
+  "cover.media.test",
+  "redirect-target.media.test",
+  "inline.media.test",
+  "protocol.media.test",
+  "encoded.media.test",
+  "video.media.test",
+  "audio.media.test",
+  "www.youtube-nocookie.com",
+  "player.vimeo.com",
+  "comment.media.test",
+  "comment-video.media.test",
+]);
+
+interface ObservedRequest {
+  url: string;
+  hostname: string;
+  referer?: string;
+}
+
+async function observeRemoteMedia(page: Page): Promise<ObservedRequest[]> {
+  const observed: ObservedRequest[] = [];
+  page.on("request", (request) => {
+    const target = new URL(request.url());
+    if (!OBSERVED_HOSTS.has(target.hostname)) return;
+    observed.push({
+      url: target.href,
+      hostname: target.hostname,
+      referer: request.headers().referer,
+    });
+  });
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const target = new URL(request.url());
+    if (!OBSERVED_HOSTS.has(target.hostname)) {
+      await route.continue();
+      return;
+    }
+
+    if (
+      target.hostname === "cover.media.test" &&
+      target.pathname === "/redirect"
+    ) {
+      await route.fulfill({
+        status: 302,
+        headers: {
+          location: "https://redirect-target.media.test/final.svg",
+          "cache-control": "no-store",
+        },
+      });
+      return;
+    }
+
+    if (
+      target.hostname === "www.youtube-nocookie.com" ||
+      target.hostname === "player.vimeo.com"
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><title>consented provider fixture</title>",
+      });
+      return;
+    }
+
+    const isAudio = target.pathname.endsWith(".ogg");
+    const isVideo = target.pathname.endsWith(".webm");
+    await route.fulfill({
+      status: 200,
+      contentType: isAudio
+        ? "audio/ogg"
+        : isVideo
+          ? "video/webm"
+          : "image/svg+xml",
+      body:
+        isAudio || isVideo
+          ? ""
+          : '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="18"/>',
+    });
+  });
+  return observed;
+}
+
+function requestsTo(observed: ObservedRequest[], hostname: string) {
+  return observed.filter((request) => request.hostname === hostname);
+}
+
+const MEDIA_CASES = [
+  {
+    name: "cover redirect",
+    buttonName: "Load image from cover.media.test",
+    hostname: "cover.media.test",
+    expectedUrls: [
+      "https://cover.media.test/redirect",
+      "https://redirect-target.media.test/final.svg",
+    ],
+    element: "img",
+  },
+  {
+    name: "inline image",
+    buttonName: "Load image from inline.media.test",
+    hostname: "inline.media.test",
+    expectedUrls: ["https://inline.media.test/pixel.png"],
+    element: "img",
+  },
+  {
+    name: "protocol-relative image",
+    buttonName: "Load image from protocol.media.test",
+    hostname: "protocol.media.test",
+    expectedUrls: ["https://protocol.media.test/pixel.png"],
+    element: "img",
+  },
+  {
+    name: "encoded image",
+    buttonName: "Load image from encoded.media.test",
+    hostname: "encoded.media.test",
+    expectedUrls: ["https://encoded.media.test/%70ixel.png"],
+    element: "img",
+  },
+  {
+    name: "YouTube embed",
+    buttonName: "Load video from www.youtube-nocookie.com",
+    hostname: "www.youtube-nocookie.com",
+    expectedUrls: ["https://www.youtube-nocookie.com/embed/PrivacyAudit01"],
+    element: "iframe",
+  },
+  {
+    name: "Vimeo embed",
+    buttonName: "Load video from player.vimeo.com",
+    hostname: "player.vimeo.com",
+    expectedUrls: ["https://player.vimeo.com/video/123456789"],
+    element: "iframe",
+  },
+  {
+    name: "direct video",
+    buttonName: "Load video from video.media.test",
+    hostname: "video.media.test",
+    expectedUrls: ["https://video.media.test/clip.webm"],
+    element: "video",
+  },
+  {
+    name: "direct audio",
+    buttonName: "Load audio from audio.media.test",
+    hostname: "audio.media.test",
+    expectedUrls: ["https://audio.media.test/clip.ogg"],
+    element: "audio",
+  },
+  {
+    name: "comment image",
+    buttonName: "Load image from comment.media.test",
+    hostname: "comment.media.test",
+    expectedUrls: ["https://comment.media.test/pixel.png"],
+    element: "img",
+  },
+  {
+    name: "comment video",
+    buttonName: "Load video from comment-video.media.test",
+    hostname: "comment-video.media.test",
+    expectedUrls: ["https://comment-video.media.test/clip.webm"],
+    element: "video",
+  },
+] as const;
+
+test("all article and comment media start inert and consent stays item-scoped", async ({
+  page,
+}) => {
+  const observed = await observeRemoteMedia(page);
+  await page.goto(ARTICLE);
+  await expect(page.getByRole("heading", { name: "Comments" })).toBeVisible();
+
+  for (const { hostname } of MEDIA_CASES) {
+    await expect(
+      page.locator(`[data-remote-media-host="${hostname}"]`).first(),
+    ).toBeVisible();
+  }
+
+  await page.waitForTimeout(300);
+  expect(observed).toEqual([]);
+  const prematureMedia = await page.evaluate(
+    (hosts) => {
+      const attributes = ["src", "poster"];
+      return Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "img[src], iframe[src], audio[src], video[src], source[src], [poster]",
+        ),
+      )
+        .flatMap((element) =>
+          attributes.map((attribute) => element.getAttribute(attribute)),
+        )
+        .filter((value): value is string => Boolean(value))
+        .filter((value) => {
+          try {
+            return hosts.includes(
+              new URL(value, window.location.href).hostname,
+            );
+          } catch {
+            return false;
+          }
+        });
+    },
+    [...OBSERVED_HOSTS],
+  );
+  expect(prematureMedia).toEqual([]);
+
+  await page
+    .getByRole("button", { name: "Load image from inline.media.test" })
+    .click();
+  await expect
+    .poll(() => requestsTo(observed, "inline.media.test").length)
+    .toBe(1);
+  expect(observed).toHaveLength(1);
+  expect(observed[0].url).toBe("https://inline.media.test/pixel.png");
+  expect(observed[0].referer).toBeUndefined();
+
+  // Consent for one image must not authorize any sibling media.
+  for (const { hostname } of MEDIA_CASES) {
+    if (hostname === "inline.media.test") continue;
+    expect(requestsTo(observed, hostname), hostname).toEqual([]);
+  }
+
+  // No consent is remembered across an unmount/remount of the same article.
+  await page.goto("/articles");
+  observed.length = 0;
+  await page.goto(ARTICLE);
+  await expect(page.getByRole("heading", { name: "Comments" })).toBeVisible();
+  await page.waitForTimeout(300);
+  expect(observed).toEqual([]);
+});
+
+for (const media of MEDIA_CASES) {
+  test(`${media.name} requests only its exact destination after consent`, async ({
+    page,
+  }) => {
+    // Every media assertion gets its own page/document lifecycle. This keeps
+    // iframe and native-media resource scheduling from earlier consented items
+    // from influencing whether Chromium starts the request under CI load.
+    const observed = await observeRemoteMedia(page);
+    await page.goto(ARTICLE);
+    await expect(page.getByRole("heading", { name: "Comments" })).toBeVisible();
+
+    const placeholder = page
+      .locator(
+        `[data-remote-media-consent][data-remote-media-host="${media.hostname}"]`,
+      )
+      .first();
+    await expect(placeholder).toBeVisible();
+    await expect(
+      placeholder.locator(
+        "img[src], iframe[src], audio[src], video[src], source[src], [poster]",
+      ),
+    ).toHaveCount(0);
+    await page.waitForTimeout(100);
+    expect(observed).toEqual([]);
+
+    await page.getByRole("button", { name: media.buttonName }).first().click();
+    const terminalUrl = media.expectedUrls.at(-1)!;
+    await expect
+      .poll(
+        () => observed.filter((request) => request.url === terminalUrl).length,
+        { message: terminalUrl },
+      )
+      .toBeGreaterThan(0);
+
+    expect(observed.map((request) => request.url)).toEqual(
+      expect.arrayContaining([...media.expectedUrls]),
+    );
+    expect(
+      observed.every(
+        (request) =>
+          media.expectedUrls.includes(
+            request.url as (typeof media.expectedUrls)[number],
+          ) && request.referer === undefined,
+      ),
+    ).toBe(true);
+
+    const loaded = page
+      .locator(
+        `[data-remote-media-loaded][data-remote-media-host="${media.hostname}"]`,
+      )
+      .first();
+    await expect(loaded.locator(media.element)).toHaveAttribute(
+      "src",
+      media.expectedUrls[0],
+    );
+    if (media.element === "img" || media.element === "iframe") {
+      await expect(loaded.locator(media.element)).toHaveAttribute(
+        "referrerpolicy",
+        "no-referrer",
+      );
+    }
+  });
+}
+
+test("320px placeholders stay contained, named, and tappable", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 568 });
+  const observed = await observeRemoteMedia(page);
+  await page.goto(ARTICLE);
+  await expect(page.getByRole("heading", { name: "Comments" })).toBeVisible();
+  await expect(
+    page.getByRole("button", {
+      name: "Load video from comment-video.media.test",
+    }),
+  ).toBeVisible();
+
+  const routeViewport = page.locator("[data-scroll-area-viewport]");
+  await expect(routeViewport).toHaveCount(1);
+
+  const geometry = await routeViewport.evaluate((viewport) => {
+    const bounds = viewport.getBoundingClientRect();
+    const controls = Array.from(
+      viewport.querySelectorAll<HTMLElement>(
+        "[data-remote-media-consent] button",
+      ),
+    ).map((button) => {
+      const rect = button.getBoundingClientRect();
+      return {
+        width: rect.width,
+        height: rect.height,
+        left: rect.left,
+        right: rect.right,
+      };
+    });
+    return {
+      clientWidth: viewport.clientWidth,
+      scrollWidth: viewport.scrollWidth,
+      left: bounds.left,
+      right: bounds.right,
+      controls,
+    };
+  });
+
+  expect(geometry.scrollWidth).toBe(geometry.clientWidth);
+  expect(geometry.controls.length).toBeGreaterThanOrEqual(10);
+  for (const control of geometry.controls) {
+    expect(control.height).toBeGreaterThanOrEqual(44);
+    expect(control.width).toBeGreaterThanOrEqual(44);
+    expect(control.left).toBeGreaterThanOrEqual(geometry.left);
+    expect(control.right).toBeLessThanOrEqual(geometry.right);
+  }
+  expect(observed).toEqual([]);
+});
+
+test("a card consent click loads only its cover and never navigates", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 800, height: 1280 });
+  const observed = await observeRemoteMedia(page);
+  await page.goto("/search?q=Remote%20Media%20Consent%20Audit");
+
+  const result = page
+    .getByRole("link", { name: "Read “Remote Media Consent Audit”" })
+    .last();
+  await expect(result).toBeVisible();
+  const before = page.url();
+  await page
+    .getByRole("button", { name: "Load image from cover.media.test" })
+    .click();
+
+  await expect
+    .poll(() => requestsTo(observed, "redirect-target.media.test").length)
+    .toBe(1);
+  expect(page.url()).toBe(before);
+  await expect(result).toBeVisible();
+  expect(
+    observed.every(
+      (request) =>
+        request.hostname === "cover.media.test" ||
+        request.hostname === "redirect-target.media.test",
+    ),
+  ).toBe(true);
+});


### PR DESCRIPTION
Closes #374.

Related product-quality audit: #395. Related store/readiness audit: #387. Preserves and hardens the unified Search interaction delivered for #254.

## Product/security contract

- route every creator-controlled article/comment image, cover, direct audio/video, YouTube, and Vimeo render through one shared consent component
- keep remote URLs out of `src`/`poster`/iframe DOM until the user clicks that exact item; consent is component-local and is discarded on unmount or target change
- normalize once with the URL parser, require HTTPS (with only the exact same-origin loopback Vite development exception), reject credentials/control characters/unsupported schemes, and name the normalized destination hostname in the placeholder
- apply `Referrer-Policy: no-referrer` document-wide plus element-level `referrerPolicy` defenses
- separate card media activation from article navigation, with a 48px non-submitting control that stops parent navigation
- retain the merged #375 isolated Mermaid worker and package/Vite contracts

There is no existing proven metadata-stripping media proxy in ZUULI/Tuzi, so this PR does not invent one. Redirect destinations can still learn the client IP only after the explicit per-item click; the browser regression observes both the initial URL and redirect target.

## Regression proof

Added deterministic parser negatives/fuzzing and real Chromium request observation for article and comment media. The browser contract proves:

- zero matching network requests before consent
- zero third-party URL-bearing `src`/`poster` attributes before consent
- exactly the selected item loads after click, including redirect, protocol-relative, and encoded cases
- no `Referer` header is sent
- sibling media remains blocked and consent resets after unmount/remount
- cover consent cannot submit or navigate its parent card
- 320x568 placeholders remain named, within the Radix route viewport, and at least 44px

## Exact-head verification

Rebased once onto the reviewed #375 merge `16f31d32c9f4bc8735974f42e38a4c0b6eee747b`. Exact head: `8c6e89c1b93f5bacf5042477b521f75e731a47a2`.

Using the packaging-pinned Node `v24.18.0`:

- `npm test`: 378/378 Vitest, 13/13 Node contract tests, 89/89 Playwright (3.0m), no retry
- exact fresh-document media suite in `mcr.microsoft.com/playwright:v1.62.1-noble` on Linux/amd64, Node v24.18.1, two workers and zero retries after a clean `npm ci`: 13/13 (32.4s)
- combined remote-media and Search suite repeated three times with two workers and zero retries after physical 48px hardening: 48/48
- `npm run typecheck`: pass
- `npm run build`: pass (3,226 modules; existing large-chunk warnings only)
- `npm run release:verify`: pass (`0.1.0+10`)
- `npm audit --audit-level=high`: pass; five pre-existing moderate advisories reported
- `git diff --check origin/main...HEAD`: pass
- mandatory clean-head `codex review --base origin/main`: “The changes typecheck, build successfully, and the existing plus newly added tests pass without revealing correctness issues.”

Fresh hosted runs on that exact head are fully green: required wallet gate [32330302315](https://github.com/free2z/zuu/actions/runs/32330302315) (including frontend, backend, format, lint, supply-chain, and shared-plugin jobs) and packaging [32330302299](https://github.com/free2z/zuu/actions/runs/32330302299) (Android unsigned AAB, iOS unsigned target app, Linux packages, macOS universal app, and release identity).

The first hosted frontend run exposed a timing-dependent test that clicked every media item before observing them. The second hosted run proved two platform distinctions: Linux Chrome can decline unsupported `.mp4` before requesting it, while `loading="lazy"` may defer a newly consented Vimeo iframe. After those corrections, the third hosted run still proved that an accumulated page with many already-loaded media resources could deterministically defer Vimeo under full-suite load. The final regression therefore keeps one all-items inert/sibling-isolation test, but gives every destination-specific request assertion a fresh page/document lifecycle. Each case independently proves zero request and zero media URL before click, then the exact browser-native request and no-referrer behavior after click. It uses open-codec WebM/Ogg fixtures, no synthetic fetch, and no skipped or weakened request assertion.

Two concurrent full runs also measured real fractional touch defects: the existing Search clear control at `43.9999847px`, and the new consent control at `43.9998779px`. Both actual controls (not the assertions) now have an explicit 48px box. One earlier exploratory 30-case Linux/amd64 run with two x86 Chrome workers under ARM QEMU was excluded after unrelated page/fixture readiness repeatedly exceeded its timeouts; its container was stopped and removed. The fresh exact two-worker Linux result above supersedes it. No URL, request, DOM, no-referrer, or touch-size assertion was skipped or weakened.
