### PR TITLE
security(ci): pin every GitHub Action to an immutable revision

### DIFF
--- a/.github/workflows/docs-about-free2z.yml
+++ b/.github/workflows/docs-about-free2z.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/ts-react-free2z.yml
+++ b/.github/workflows/ts-react-free2z.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/.github/workflows/ts-svelte-free2z.yml
+++ b/.github/workflows/ts-svelte-free2z.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 

--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Resolve the pinned Rust toolchain
         id: rust_toolchain
@@ -74,7 +74,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       # rustfmt is absent from the minimal profile this action installs.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
           components: rustfmt
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Fetch librustzcash submodule
         run: git submodule update --init z/zcash/librustzcash
@@ -105,7 +105,7 @@ jobs:
           version=$(scripts/check-rust-toolchain.sh --print-channel)
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
 
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Fetch librustzcash submodule
         run: git submodule update --init z/zcash/librustzcash
@@ -156,7 +156,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       # clippy is absent from the minimal profile this action installs.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
           components: clippy
@@ -164,7 +164,7 @@ jobs:
       # Separate key from the `rust` job: clippy writes different artifacts into
       # the same target directory names, so a shared cache would have the two
       # jobs evicting each other's work on every run.
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: |
             wallet/plugins/tauri-plugin-zcash
@@ -182,9 +182,9 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: npm
@@ -227,7 +227,7 @@ jobs:
           set -euo pipefail
           /usr/local/bin/verify-zuuli-linux-image
           test -n "$BASH_VERSION"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
       - name: Configure exact Git workspace trust
@@ -239,10 +239,10 @@ jobs:
         run: git submodule update --init z/zcash/librustzcash
 
       # `uses:` cannot take an expression; scripts/check-rust-toolchain.sh holds
-      # this version-branch ref to wallet/rust-toolchain.toml.
-      - uses: dtolnay/rust-toolchain@1.97.1
+      # this commit-pinned version action to wallet/rust-toolchain.toml.
+      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: wallet/zuuallet/src-tauri -> ${{ github.workspace }}/target
 
@@ -273,17 +273,17 @@ jobs:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Fetch librustzcash submodule
         run: git submodule update --init z/zcash/librustzcash
 
-      # `uses:` cannot take an expression, so this version-branch ref restates
-      # wallet/rust-toolchain.toml; scripts/check-rust-toolchain.sh holds it to
-      # the source of truth.
-      - uses: dtolnay/rust-toolchain@1.97.1
+      # `uses:` cannot take an expression, so this commit-pinned version action
+      # restates wallet/rust-toolchain.toml; scripts/check-rust-toolchain.sh
+      # holds it to the source of truth.
+      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: wallet/plugins/tauri-plugin-zcash
 
@@ -302,7 +302,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Fetch + bump librustzcash to latest main
         run: |
@@ -326,9 +326,9 @@ jobs:
             libssl-dev \
             build-essential curl wget file pkg-config
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: wallet/zuuallet/src-tauri
 

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -251,7 +251,7 @@ jobs:
       - run: npm ci
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
-      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "3.4.10"
           working-directory: wallet/zuuli

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -32,10 +32,18 @@ jobs:
     outputs:
       zuuli: ${{ steps.filter.outputs.zuuli }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Diff locally instead of relying on the pull-request files API.
           fetch-depth: 0
+
+      # This runs before change detection on every event. A workflow cannot
+      # replace its own judge with a mutable external action and then skip the
+      # full application suite as an allegedly unrelated change.
+      - name: Verify every external action has an immutable revision
+        run: |
+          node scripts/check-github-actions-pins.mjs --self-test
+          node scripts/check-github-actions-pins.mjs
 
       # Runs on every event, including changes this job would otherwise skip,
       # because a toolchain pin can drift from any workflow or manifest. The
@@ -71,7 +79,7 @@ jobs:
           zuuli=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-store-audit.yml|.github/workflows/zuuli-store-publish.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-github-actions-pins.mjs|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-store-audit.yml|.github/workflows/zuuli-store-publish.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
                 zuuli=true
                 ;;
             esac
@@ -90,9 +98,9 @@ jobs:
       run:
         working-directory: wallet/zuuli
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm
@@ -157,7 +165,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve the pinned Rust toolchain
         id: rust_toolchain
@@ -169,7 +177,7 @@ jobs:
       # rustfmt is not in the minimal profile this action installs, and its
       # output differs between compiler versions — the pinned toolchain is what
       # makes the verdict reproducible, so the check refuses to run on any other.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
           components: rustfmt
@@ -189,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # cargo-deny resolves the whole graph, and the wallet crates reach the
       # Zcash crates by path into this submodule.
@@ -205,7 +213,7 @@ jobs:
 
       # cargo-deny shells out to `cargo metadata`, so a toolchain is required
       # even though nothing is compiled.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
 
@@ -253,7 +261,7 @@ jobs:
           set -euo pipefail
           /usr/local/bin/verify-zuuli-linux-image
           test -n "$BASH_VERSION"
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Configure exact Git workspace trust
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
@@ -270,12 +278,12 @@ jobs:
       # clippy is not in the minimal profile this action installs, and its lint
       # set differs between compiler versions — the pinned toolchain is what
       # makes the verdict reproducible, so the check refuses to run on any other.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: |
             wallet/plugins/tauri-plugin-zcash
@@ -310,7 +318,7 @@ jobs:
           set -euo pipefail
           /usr/local/bin/verify-zuuli-linux-image
           test -n "$BASH_VERSION"
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Configure exact Git workspace trust
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
@@ -328,11 +336,11 @@ jobs:
           version=$(scripts/check-rust-toolchain.sh --print-channel)
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: wallet/plugins/tauri-plugin-zcash
           key: zuuli-plugin
@@ -367,7 +375,7 @@ jobs:
           set -euo pipefail
           /usr/local/bin/verify-zuuli-linux-image
           test -n "$BASH_VERSION"
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Configure exact Git workspace trust
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
@@ -381,11 +389,11 @@ jobs:
           version=$(scripts/check-rust-toolchain.sh --print-channel)
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: wallet/zuuli/src-tauri
           key: zuuli-app

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,8 +199,8 @@ read a TOML file at the moment they need the value:
 |---|---|
 | `rust-version` in the three `Cargo.toml` manifests | Cargo needs a literal, and it is the **two-component MSRV floor** (`X.Y`) of the three-component channel (`X.Y.Z`) — deliberately a different form, compared as such |
 | `ZUULI_RUST_VERSION` in `zuuli-packaging.yml` and `zuuli-release.yml` | A workflow-level `env:` cannot be computed from a file, and the release jobs verify the installed compiler with `rustc --version \| grep -F "rustc $ZUULI_RUST_VERSION "` |
-| `dtolnay/rust-toolchain@<sha> # <version>` in the packaging/release workflows | The action's **version branches hardcode the compiler in `action.yml` and do not declare a `toolchain` input at all** — a commit-pinned ref *is* the version pin, and the trailing comment is its only readable record |
-| `dtolnay/rust-toolchain@<version>` in `zuuallet.yml` | `uses:` cannot contain an expression |
+| `dtolnay/rust-toolchain@<sha> # <version>` in packaging/release and target-native Zuuallet jobs | The action's **version branches hardcode the compiler in `action.yml` and do not declare a `toolchain` input at all** — a commit-pinned ref *is* the version pin, and the trailing comment is its only readable record |
+| `dtolnay/rust-toolchain@<sha> # stable` in source-derived gate/Zuuallet jobs | `uses:` cannot contain an expression, so the generic action implementation is commit-pinned while its `toolchain:` input still reads the version from `wallet/rust-toolchain.toml`; the upstream canary deliberately omits that input so only its compiler selection follows `stable` |
 | MSRV/`cargo +<version>` lines in the wallet READMEs, the plugin `CLAUDE.md`, and `wallet/zuuli/docs/releasing.md` | Prose |
 
 The `wallet/zuuli` gate reads the channel out of the file (`--print-channel`) and
@@ -215,7 +215,7 @@ all**. Every remaining restatement is verified against the file by
    not followed, with file and line.
 3. Update exactly what it names — including moving each commit-pinned
    `dtolnay/rust-toolchain` SHA to the new version branch **and** its `# <version>`
-   comment.
+   comment, plus the checker’s re-derived generic/version expected commits.
 4. Re-run until it passes. `scripts/check-rust-toolchain.sh --self-test` proves
    the check can still fail; CI runs both.
 

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -1,0 +1,470 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FULL_COMMIT_SHA = /^[0-9a-f]{40}$/;
+const EXTERNAL_USES = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[^@\s]+)?@([^@\s]+)$/;
+
+function yamlFilesBelow(directory) {
+  if (!fs.existsSync(directory)) return [];
+
+  const files = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const candidate = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...yamlFilesBelow(candidate));
+    } else if (/\.ya?ml$/i.test(entry.name)) {
+      files.push(candidate);
+    }
+  }
+  return files;
+}
+
+function usesFromLine(line) {
+  // Keep the policy deliberately smaller than a YAML parser: GitHub's usual
+  // block-mapping form is supported below, while alternate key spellings and
+  // inline collections that could hide `uses` fail closed. This also covers
+  // valid constructs such as `steps: [{ uses: ... }]` and nested flow jobs.
+  let keySearchLine = line;
+  keySearchLine = keySearchLine.replace(
+    /"(?:\\.|[^"])*"|'(?:''|[^'])*'/g,
+    (quoted) => {
+      let decoded;
+      if (quoted[0] === '"') {
+        try {
+          decoded = JSON.parse(quoted);
+        } catch {
+          return quoted;
+        }
+      } else {
+        decoded = quoted.slice(1, -1).replaceAll("''", "'");
+      }
+      // Preserve a decoded `uses` key for policy detection, but mask every
+      // other quoted scalar so text such as "documentation uses: ..." cannot
+      // be mistaken for a workflow key.
+      return decoded === "uses" ? "uses" : '""';
+    },
+  );
+  keySearchLine = keySearchLine.replace(/^\s*#.*$|\s+#.*$/, "");
+
+  // Explicit keys and continued quoted keys can construct the literal key
+  // `uses` across multiple source lines. The checker intentionally supports a
+  // constrained, reviewable YAML spelling instead of trying to reimplement a
+  // complete YAML resolver.
+  if (/^\s*(?:-\s*)?\?\s*/.test(keySearchLine)) {
+    return {
+      error: "explicit YAML mapping keys are unsupported; put `uses:` on its own line",
+    };
+  }
+  if (/^\s*(?:-\s*)?"(?:\\.|[^"])*\\\s*$/.test(line)) {
+    return {
+      error: "continued quoted YAML scalars are unsupported because they can construct `uses`",
+    };
+  }
+  if (/[\[,{]\s*(?:"(?:\\.|[^"])*"|'(?:''|[^'])*')\s*:/.test(keySearchLine)) {
+    return {
+      error: "quoted keys in inline YAML mappings are unsupported because they can encode `uses`",
+    };
+  }
+
+  const match = line.match(/^\s*(?:-\s*)?uses\s*:\s*(.*?)\s*$/);
+  let scalar;
+  if (match) {
+    scalar = match[1];
+  } else {
+    const quotedKey = line.match(
+      /^\s*(?:-\s*)?((?:"(?:\\.|[^"])*")|(?:'(?:''|[^'])*'))\s*:\s*(.*?)\s*$/,
+    );
+    if (quotedKey) {
+      let key;
+      if (quotedKey[1][0] === '"') {
+        try {
+          key = JSON.parse(quotedKey[1]);
+        } catch {
+          return { error: "quoted YAML mapping key cannot be decoded safely" };
+        }
+      } else {
+        key = quotedKey[1].slice(1, -1).replaceAll("''", "'");
+      }
+      if (key !== "uses") return null;
+      scalar = quotedKey[2];
+    }
+  }
+
+  if (!match && scalar === undefined) {
+    if (
+      /(?:^|[\s[,{?])\*[^\s:[\]{},]+\s*:/.test(keySearchLine) ||
+      /^\s*(?:-\s*)?\?\s*\*[^\s:[\]{},]+\s*$/.test(keySearchLine)
+    ) {
+      return {
+        error:
+          "YAML aliases are unsupported as mapping keys because they can resolve to `uses`",
+      };
+    }
+    if (
+      /\buses\s*:/.test(keySearchLine) ||
+      /^\s*(?:-\s*)?\??\s*(?:(?:&|!)[^\s]+\s+)*uses\s*$/.test(keySearchLine)
+    ) {
+      return {
+        error:
+          "decorated, inline, or explicit `uses` mappings are unsupported; put `uses:` on its own line",
+      };
+    }
+    return null;
+  }
+
+  if (!scalar) return { error: "empty `uses:` value" };
+
+  if (scalar[0] === '"' || scalar[0] === "'") {
+    const quote = scalar[0];
+    const closing = scalar.indexOf(quote, 1);
+    if (closing < 0) return { error: "unterminated quoted `uses:` value" };
+
+    const trailing = scalar.slice(closing + 1).trim();
+    if (trailing && !trailing.startsWith("#")) {
+      return { error: "unexpected content after quoted `uses:` value" };
+    }
+    return {
+      provenance: trailing.startsWith("#") ? trailing.slice(1).trim() : "",
+      ref: scalar.slice(1, closing),
+    };
+  }
+
+  const comment = scalar.search(/\s+#/);
+  const ref = (comment < 0 ? scalar : scalar.slice(0, comment)).trim();
+  const provenance = comment < 0 ? "" : scalar.slice(comment).replace(/^\s+#/, "").trim();
+  return ref ? { provenance, ref } : { error: "empty `uses:` value" };
+}
+
+function localTarget(repoRoot, reference) {
+  const relative = reference.slice(2);
+  const candidate = path.resolve(repoRoot, relative);
+  const relativeCandidate = path.relative(repoRoot, candidate);
+  if (relativeCandidate.startsWith("..") || path.isAbsolute(relativeCandidate)) {
+    return { error: `local action escapes the repository: ${reference}` };
+  }
+  if (!fs.existsSync(candidate)) {
+    return { error: `local action or workflow does not exist: ${reference}` };
+  }
+  const canonical = fs.realpathSync(candidate);
+  const relativeCanonical = path.relative(repoRoot, canonical);
+  if (relativeCanonical.startsWith("..") || path.isAbsolute(relativeCanonical)) {
+    return { error: `local action resolves outside the repository: ${reference}` };
+  }
+  if (fs.statSync(candidate).isFile()) return { file: candidate };
+
+  const actionFiles = ["action.yml", "action.yaml"]
+    .map((name) => path.join(candidate, name))
+    .filter((file) => fs.existsSync(file));
+  if (actionFiles.length !== 1) {
+    return {
+      error: `local action directory must contain exactly one action.yml or action.yaml: ${reference}`,
+    };
+  }
+  return { file: actionFiles[0] };
+}
+
+function scanRepository(repoRoot) {
+  repoRoot = fs.realpathSync(repoRoot);
+  const queued = [
+    ...yamlFilesBelow(path.join(repoRoot, ".github", "workflows")),
+    ...yamlFilesBelow(path.join(repoRoot, ".github", "actions")),
+  ];
+  const seen = new Set();
+  const failures = [];
+  let externalReferences = 0;
+
+  while (queued.length) {
+    const file = queued.shift();
+    const canonical = fs.realpathSync(file);
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+
+    const relativeFile = path.relative(repoRoot, file);
+    const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+    for (const [index, line] of lines.entries()) {
+      const parsed = usesFromLine(line);
+      if (!parsed) continue;
+      const location = `${relativeFile}:${index + 1}`;
+      if (parsed.error) {
+        failures.push(`${location}: ${parsed.error}`);
+        continue;
+      }
+
+      const reference = parsed.ref;
+      if (reference.startsWith("./")) {
+        const target = localTarget(repoRoot, reference);
+        if (target.error) failures.push(`${location}: ${target.error}`);
+        else queued.push(target.file);
+        continue;
+      }
+
+      externalReferences += 1;
+      const external = reference.match(EXTERNAL_USES);
+      if (!external) {
+        failures.push(`${location}: invalid external \`uses:\` reference: ${reference}`);
+      } else if (!FULL_COMMIT_SHA.test(external[1])) {
+        failures.push(
+          `${location}: external \`uses:\` reference must end in a full lowercase 40-character commit SHA: ${reference}`,
+        );
+      } else if (!parsed.provenance) {
+        failures.push(
+          `${location}: commit-pinned external \`uses:\` reference needs a nonempty trailing version/provenance comment: ${reference}`,
+        );
+      }
+    }
+  }
+
+  return {
+    externalReferences,
+    failures,
+    scannedFiles: seen.size,
+  };
+}
+
+function writeFixture(root, relative, contents) {
+  const destination = path.join(root, relative);
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, contents);
+}
+
+function runSelfTest() {
+  const fullSha = "0123456789abcdef0123456789abcdef01234567";
+  const cases = [
+    {
+      name: "valid pinned, quoted, reusable, and nested-local references",
+      valid: true,
+      files: {
+        ".github/workflows/gate.yml": `steps:\n  - uses: ./.github/actions/outer\n  - uses: owner/action@${fullSha} # v1.2.3\n  - uses: "owner/repo/.github/workflows/reuse.yml@${fullSha}" # v4\n`,
+        ".github/actions/outer/action.yml":
+          "runs:\n  using: composite\n  steps:\n    - uses: ./.github/actions/inner\n",
+        ".github/actions/inner/action.yaml": `runs:\n  using: composite\n  steps:\n    - uses: 'owner/nested@${fullSha}' # v2\n`,
+      },
+    },
+    {
+      name: "tag",
+      needle: "owner/action@v1",
+      files: { ".github/workflows/gate.yml": "steps:\n  - uses: owner/action@v1\n" },
+    },
+    {
+      name: "branch",
+      needle: "owner/action@main",
+      files: { ".github/workflows/gate.yml": "steps:\n  - uses: owner/action@main\n" },
+    },
+    {
+      name: "short SHA",
+      needle: "owner/action@0123456",
+      files: { ".github/workflows/gate.yml": "steps:\n  - uses: owner/action@0123456\n" },
+    },
+    {
+      name: "commit pin without readable provenance",
+      needle: "version/provenance comment",
+      files: { ".github/workflows/gate.yml": `steps:\n  - uses: owner/action@${fullSha}\n` },
+    },
+    {
+      name: "mutable reusable workflow",
+      needle: "owner/repo/.github/workflows/reuse.yml@release",
+      files: {
+        ".github/workflows/gate.yml":
+          "jobs:\n  call:\n    uses: owner/repo/.github/workflows/reuse.yml@release\n",
+      },
+    },
+    {
+      name: "quoted mutable reference",
+      needle: "owner/action@v2",
+      files: { ".github/workflows/gate.yml": 'steps:\n  - uses: "owner/action@v2" # mutable\n' },
+    },
+    {
+      name: "quoted uses key cannot hide a mutable reference",
+      needle: "owner/action@v4",
+      files: {
+        ".github/workflows/gate.yml": 'steps:\n  - "uses": owner/action@v4\n  - \'uses\': owner/other@main\n',
+      },
+    },
+    {
+      name: "escaped quoted uses key cannot hide a mutable reference",
+      needle: "owner/action@main",
+      files: {
+        ".github/workflows/gate.yml": 'steps:\n  - "\\u0075ses": owner/action@main\n',
+      },
+    },
+    {
+      name: "nested local action is scanned",
+      needle: "owner/nested@nightly",
+      files: {
+        ".github/workflows/gate.yml": "steps:\n  - uses: ./.github/actions/nested\n",
+        ".github/actions/nested/action.yml":
+          "runs:\n  using: composite\n  steps:\n    - uses: owner/nested@nightly\n",
+      },
+    },
+    {
+      name: "missing local action fails closed",
+      needle: "does not exist",
+      files: { ".github/workflows/gate.yml": "steps:\n  - uses: ./.github/actions/missing\n" },
+    },
+    {
+      name: "expression reference fails closed",
+      needle: "invalid external",
+      files: { ".github/workflows/gate.yml": "steps:\n  - uses: owner/action@${{ inputs.ref }}\n" },
+    },
+    {
+      name: "flow-style step reference fails closed",
+      needle: "decorated, inline, or explicit",
+      files: {
+        ".github/workflows/gate.yml": `steps:\n  - { uses: owner/action@${fullSha}, name: hidden }\n`,
+      },
+    },
+    {
+      name: "inline steps sequence cannot hide a mutable reference",
+      needle: "decorated, inline, or explicit",
+      files: {
+        ".github/workflows/gate.yml": "steps: [{ uses: owner/action@v1 }]\n",
+      },
+    },
+    {
+      name: "nested inline jobs cannot hide a mutable reusable workflow",
+      needle: "decorated, inline, or explicit",
+      files: {
+        ".github/workflows/gate.yml":
+          "jobs: { call: { uses: owner/repo/.github/workflows/reuse.yml@main } }\n",
+      },
+    },
+    {
+      name: "quoted inline key cannot hide a mutable reference",
+      needle: "decorated, inline, or explicit",
+      files: {
+        ".github/workflows/gate.yml": 'steps: [{ "\\u0075ses": owner/action@v2 }]\n',
+      },
+    },
+    {
+      name: "explicit mapping key cannot hide a mutable reference",
+      needle: "explicit YAML mapping keys",
+      files: {
+        ".github/workflows/gate.yml": "steps:\n  - ? uses\n    : owner/action@v3\n",
+      },
+    },
+    {
+      name: "anchored step cannot hide a mutable reference",
+      needle: "decorated, inline, or explicit",
+      files: {
+        ".github/workflows/gate.yml": "steps:\n  - &shared uses: owner/action@main\n",
+      },
+    },
+    {
+      name: "tagged step cannot hide a mutable reference",
+      needle: "decorated, inline, or explicit",
+      files: {
+        ".github/workflows/gate.yml": "steps:\n  - !!str uses: owner/action@main\n",
+      },
+    },
+    {
+      name: "explicit anchored key cannot hide a mutable reference",
+      needle: "explicit YAML mapping keys",
+      files: {
+        ".github/workflows/gate.yml": "steps:\n  - ? &action-key uses\n    : owner/action@v3\n",
+      },
+    },
+    {
+      name: "alias-resolved key cannot hide a mutable reference",
+      needle: "aliases are unsupported as mapping keys",
+      files: {
+        ".github/workflows/gate.yml":
+          "env:\n  ACTION_KEY: &action-key uses\nsteps:\n  - *action-key: owner/action@main\n",
+      },
+    },
+    {
+      name: "explicit alias key cannot hide a mutable reference",
+      needle: "explicit YAML mapping keys",
+      files: {
+        ".github/workflows/gate.yml":
+          "env:\n  ACTION_KEY: &action-key uses\nsteps:\n  - ? *action-key\n    : owner/action@v1\n",
+      },
+    },
+    {
+      name: "continued quoted key cannot hide a mutable reference",
+      needle: "continued quoted YAML scalars",
+      files: {
+        ".github/workflows/gate.yml":
+          'steps:\n  - "us\\\n      es": owner/action@main\n',
+      },
+    },
+    {
+      name: "explicit continued key cannot hide a mutable reference",
+      needle: "explicit YAML mapping keys",
+      files: {
+        ".github/workflows/gate.yml":
+          'steps:\n  - ? "us\\\n        es"\n    : owner/action@main\n',
+      },
+    },
+    {
+      name: "YAML-only escape in quoted flow key cannot hide a mutable reference",
+      needle: "quoted keys in inline YAML mappings",
+      files: {
+        ".github/workflows/gate.yml": 'steps: [{ "u\\x73es": owner/action@main }]\n',
+      },
+    },
+    {
+      name: "comments and quoted documentation are not workflow keys",
+      valid: true,
+      files: {
+        ".github/workflows/gate.yml":
+          'name: "documentation uses: examples"\n# uses: owner/action@main\nenv:\n  NOTE: "uses: is documentation" # uses: owner/action@v1\n',
+      },
+    },
+  ];
+
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "zuu-action-pins-"));
+  try {
+    for (const testCase of cases) {
+      const fixture = path.join(temporaryRoot, testCase.name.replaceAll(/[^a-z0-9]+/gi, "-"));
+      for (const [relative, contents] of Object.entries(testCase.files)) {
+        writeFixture(fixture, relative, contents);
+      }
+      const result = scanRepository(fixture);
+      if (testCase.valid) {
+        if (result.failures.length) {
+          throw new Error(`${testCase.name}: expected success, got ${result.failures.join("; ")}`);
+        }
+      } else if (
+        result.failures.length === 0 ||
+        !result.failures.some((failure) => failure.includes(testCase.needle))
+      ) {
+        throw new Error(
+          `${testCase.name}: expected failure containing ${JSON.stringify(testCase.needle)}, got ${result.failures.join("; ")}`,
+        );
+      }
+      console.log(`self-test: ${testCase.name}: passed`);
+    }
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+  console.log(`self-test: ${cases.length} action pin policy case(s) passed.`);
+}
+
+const args = process.argv.slice(2);
+if (args.length > 1 || (args.length === 1 && args[0] !== "--self-test")) {
+  console.error("usage: scripts/check-github-actions-pins.mjs [--self-test]");
+  process.exit(2);
+}
+
+if (args[0] === "--self-test") {
+  runSelfTest();
+} else {
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.resolve(scriptDirectory, "..");
+  const result = scanRepository(repoRoot);
+  if (result.failures.length) {
+    console.error("GitHub Actions immutable-reference policy failed:");
+    for (const failure of result.failures) console.error(`- ${failure}`);
+    console.error(
+      `${result.failures.length} failure(s); scanned ${result.scannedFiles} workflow/action file(s) and ${result.externalReferences} external reference(s).`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `Every external GitHub Action and reusable workflow is pinned to a full 40-character commit SHA with readable provenance (${result.externalReferences} reference(s), ${result.scannedFiles} file(s)).`,
+  );
+}

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -66,6 +66,14 @@ ACCEPTED_EXPRESSIONS=(
   'steps.rust_toolchain.outputs.version'
 )
 
+# These are implementation identities, not alternate version decisions. The
+# generic branch commit accepts the source-derived `toolchain:` input; the
+# version-branch commit hardcodes exactly PINNED_ACTION_CHANNEL. Re-derive both
+# from dtolnay/rust-toolchain's authoritative refs during a toolchain bump.
+GENERIC_ACTION_SHA=4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+PINNED_ACTION_CHANNEL=1.97.1
+PINNED_ACTION_SHA=032958afbdc797a9164d3bc0b56325c1308924a5
+
 errors=0
 
 fail() {
@@ -110,10 +118,59 @@ read_channel() {
   printf '%s\n' "$channel"
 }
 
+# Print `line-number<TAB>value` for toolchain inputs that are structurally
+# nested under this exact action step's `with:` mapping. Comments, sibling
+# steps, and values at the wrong indentation cannot satisfy the contract.
+step_toolchain_inputs() {
+  local file=$1 uses_line=$2
+  awk -v target="$uses_line" '
+    function indentation(line, copy) {
+      copy = line
+      sub(/[^ ].*$/, "", copy)
+      return length(copy)
+    }
+    NR == target {
+      uses_indent = indentation($0)
+      copy = $0
+      sub(/^[ ]*/, "", copy)
+      step_indent = uses_indent
+      if (copy !~ /^-[ ]+/) step_indent -= 2
+      next
+    }
+    NR > target {
+      if ($0 ~ /^[ ]*$/ || $0 ~ /^[ ]*#/) next
+      current_indent = indentation($0)
+      if (current_indent <= step_indent) exit
+
+      if (!in_with) {
+        if (current_indent == step_indent + 2 && $0 ~ /^[ ]*with:[ ]*$/) {
+          in_with = 1
+          with_indent = current_indent
+        }
+        next
+      }
+
+      if (current_indent <= with_indent) {
+        in_with = 0
+        next
+      }
+      if (current_indent == with_indent + 2 && $0 ~ /^[ ]*toolchain:[ ]*/) {
+        value = $0
+        sub(/^[ ]*toolchain:[ ]*/, "", value)
+        print NR "\t" value
+      }
+    }
+  ' "$file"
+}
+
 check_workflows() {
   local root=$1 channel=$2
-  local file rel lineno text ref comment window value expression
+  local file rel lineno text ref comment value expression job binding binding_count input_lineno
   local refs=0 inputs=0 floating=0
+
+  if [[ $PINNED_ACTION_CHANNEL != "$channel" ]]; then
+    fail "dtolnay/rust-toolchain expected-commit map is for $PINNED_ACTION_CHANNEL, expected $channel"
+  fi
 
   local files=()
   shopt -s nullglob
@@ -139,22 +196,65 @@ check_workflows() {
         comment=$(trim "${text#*#}")
         comment=${comment%%[[:space:]]*}
       fi
-      window=$(awk -v start="$lineno" '
-        NR > start {
-          if ($0 ~ /^[[:space:]]*-[[:space:]]/ || NR > start + 10) exit
-          print
-        }' "$file")
+      job=$(awk -v end="$lineno" '
+        NR >= end { exit }
+        /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+          value=$0
+          sub(/^  /, "", value)
+          sub(/:[[:space:]]*$/, "", value)
+          job=value
+        }
+        END { print job }
+      ' "$file")
 
       if [[ $ref =~ ^[0-9a-f]{40}$ ]]; then
-        # dtolnay/rust-toolchain's version branches hardcode the toolchain in
-        # action.yml and do not even declare a `toolchain` input, so a
-        # commit-pinned ref decides the compiler on its own and any
-        # `toolchain:` beside it is inert. The trailing comment is the only
-        # human- and machine-readable record of what the SHA installs.
+        # A commit from a version branch hardcodes that compiler and is marked
+        # with the canonical channel. A commit from the generic stable branch
+        # pins the action implementation while `toolchain:` remains the
+        # compiler input; the one canary with no input deliberately follows
+        # rustup's stable channel. The comment distinguishes those two upstream
+        # action shapes without making the action ref mutable again.
         if [[ -z $comment ]]; then
-          fail "$rel:$lineno pins dtolnay/rust-toolchain by commit with no '# <version>' comment; the SHA alone selects the compiler"
+          fail "$rel:$lineno pins dtolnay/rust-toolchain by commit with no '# <version-or-channel>' comment"
+        elif [[ $comment == stable ]]; then
+          if [[ $ref != "$GENERIC_ACTION_SHA" ]]; then
+            fail "$rel:$lineno labels dtolnay/rust-toolchain@$ref as stable, expected verified generic commit $GENERIC_ACTION_SHA"
+          fi
+          binding=$(step_toolchain_inputs "$file" "$lineno")
+          binding_count=$(awk 'NF { count++ } END { print count + 0 }' <<<"$binding")
+          if (( binding_count == 0 )); then
+            if [[ $rel == .github/workflows/zuuallet.yml && $job == upstream-canary ]]; then
+              floating=$((floating + 1))
+            else
+              fail "$rel:$lineno ($job) pins the generic stable action without a source-derived toolchain input; only zuuallet/upstream-canary may follow stable"
+            fi
+          elif (( binding_count != 1 )); then
+            fail "$rel:$lineno ($job) must have exactly one toolchain input in its own with: mapping, found $binding_count"
+          else
+            input_lineno=${binding%%$'\t'*}
+            value=${binding#*$'\t'}
+            inputs=$((inputs + 1))
+            if [[ $value == '"'* ]]; then
+              value=${value#\"}
+              value=${value%%\"*}
+            fi
+            if [[ $value == '${{'* ]]; then
+              expression=${value#*\{\{}
+              expression=${expression%%\}\}*}
+              expression=$(trim "$expression")
+              if ! contains "$expression" "${ACCEPTED_EXPRESSIONS[@]}"; then
+                fail "$rel:$input_lineno resolves the toolchain from \${{ $expression }}, which cannot be traced back to $TOOLCHAIN_FILE"
+              fi
+            else
+              value=${value%%[[:space:]]*}
+              [[ $value == "$channel" ]] ||
+                fail "$rel:$input_lineno sets toolchain: $value, expected $channel"
+            fi
+          fi
         elif [[ $comment != "$channel" ]]; then
-          fail "$rel:$lineno pins dtolnay/rust-toolchain by commit commented '# $comment', expected '# $channel'"
+          fail "$rel:$lineno pins dtolnay/rust-toolchain by commit commented '# $comment', expected '# stable' or '# $channel'"
+        elif [[ $ref != "$PINNED_ACTION_SHA" ]]; then
+          fail "$rel:$lineno labels dtolnay/rust-toolchain@$ref as $channel, expected verified version-branch commit $PINNED_ACTION_SHA"
         fi
       elif [[ $ref =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
         [[ $ref == "$channel" ]] ||
@@ -163,7 +263,9 @@ check_workflows() {
         # A moving ref is only a pin when the step also passes `toolchain:`.
         # Without one the job deliberately floats (the zuuallet canary does);
         # that is reported, not failed.
-        if ! grep -qE '(^|[[:space:],{])toolchain:' <<<"$window"; then
+        binding=$(step_toolchain_inputs "$file" "$lineno")
+        binding_count=$(awk 'NF { count++ } END { print count + 0 }' <<<"$binding")
+        if (( binding_count == 0 )); then
           floating=$((floating + 1))
         fi
       else
@@ -171,8 +273,12 @@ check_workflows() {
       fi
     done < <(grep -nE 'uses:[[:space:]]*dtolnay/rust-toolchain@' "$file" || true)
 
-    # 2. Explicit `toolchain:` inputs, in both block and flow mapping style.
+    # 2. Other explicit `toolchain:` inputs, in both block and flow mapping
+    #    style. The generic-action inputs were already structurally bound above;
+    #    this inventory also checks the inert but documented release inputs.
     while IFS=: read -r lineno text; do
+      value=$(trim "$text")
+      [[ $value == \#* ]] && continue
       inputs=$((inputs + 1))
       value=$(trim "${text#*toolchain:}")
       if [[ $value == '"'* ]]; then
@@ -221,9 +327,11 @@ check_workflows() {
     fail "no dtolnay/rust-toolchain steps matched; this check has gone blind"
   (( inputs > 0 )) ||
     fail "no 'toolchain:' inputs matched; this check has gone blind"
+  (( floating == 1 )) ||
+    fail "expected exactly one stable-following Rust compiler selection at zuuallet/upstream-canary, found $floating"
 
   if (( floating > 0 )); then
-    printf 'note: %d rust-toolchain step(s) intentionally float on a moving ref (upstream canaries).\n' \
+    printf 'note: %d Rust compiler selection(s) intentionally follow the stable channel (upstream canaries).\n' \
       "$floating"
   fi
 }
@@ -296,7 +404,12 @@ run_checks() {
 SELF_TEST_MUTATIONS=(
   $'a commit-pinned action loses its version comment\t.github/workflows/zuuli-packaging.yml\ts| # %CHANNEL%||'
   $'a workflow declares a stale ZUULI_RUST_VERSION\t.github/workflows/zuuli-packaging.yml\ts|ZUULI_RUST_VERSION: "%CHANNEL%"|ZUULI_RUST_VERSION: "%BOGUS%"|'
-  $'a version-branch action ref drifts\t.github/workflows/zuuallet.yml\ts|rust-toolchain@%CHANNEL%|rust-toolchain@%BOGUS%|'
+  $'a generic action revision loses stable provenance\t.github/workflows/zuuallet.yml\ts|# stable|# beta|'
+  $'a generic action SHA disagrees with its stable label\t.github/workflows/zuuallet.yml\ts|%GENERIC_ACTION_SHA% # stable|%PINNED_ACTION_SHA% # stable|'
+  $'a version action SHA disagrees with its channel label\t.github/workflows/zuuallet.yml\ts|%PINNED_ACTION_SHA% # %CHANNEL%|%GENERIC_ACTION_SHA% # %CHANNEL%|'
+  $'a required job cannot borrow another step toolchain input\t.github/workflows/zuuli.yml\t/^  rust_fmt:/,/^  rust_deny:/ s|toolchain: \${{ steps.rust_toolchain.outputs.version }}|compiler: \${{ steps.rust_toolchain.outputs.version }}|'
+  $'a commented-out toolchain input is not real\t.github/workflows/zuuli.yml\t/^  rust_fmt:/,/^  rust_deny:/ s|          toolchain: \${{ steps.rust_toolchain.outputs.version }}|          # toolchain: \${{ steps.rust_toolchain.outputs.version }}|'
+  $'a wrongly indented toolchain input is not step-bound\t.github/workflows/zuuli.yml\t/^  rust_fmt:/,/^  rust_deny:/ s|          toolchain: \${{ steps.rust_toolchain.outputs.version }}|        toolchain: \${{ steps.rust_toolchain.outputs.version }}|'
   $'the required gate stops reading the source of truth\t.github/workflows/zuuli.yml\ts|steps.rust_toolchain.outputs.version|steps.somewhere_else.outputs.version|'
   $'a crate manifest MSRV drifts\twallet/zuuli/src-tauri/Cargo.toml\ts|rust-version = "%MSRV%"|rust-version = "%BOGUS_MSRV%"|'
   $'documentation still names the old version\twallet/plugins/tauri-plugin-zcash/README.md\ts|MSRV\\*\\*: %MSRV%|MSRV**: %BOGUS_MSRV%|'
@@ -367,6 +480,8 @@ self_test() {
     index=$((index + 1))
     IFS=$'\t' read -r description rel script <<<"$mutation"
     script=${script//%CHANNEL%/$channel}
+    script=${script//%GENERIC_ACTION_SHA%/$GENERIC_ACTION_SHA}
+    script=${script//%PINNED_ACTION_SHA%/$PINNED_ACTION_SHA}
     script=${script//%MSRV%/$msrv}
     script=${script//%BOGUS_MSRV%/$bogus_msrv}
     script=${script//%BOGUS%/$bogus}

--- a/scripts/check-zuuli-linux-image.mjs
+++ b/scripts/check-zuuli-linux-image.mjs
@@ -64,6 +64,12 @@ const pinnedActions = [
   "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0",
   "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2",
 ];
+const pinnedZuualletToolchain =
+  "dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1";
+const pinnedGenericToolchain =
+  "dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable";
+const pinnedRustCache =
+  "Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2";
 const requiredPackages = [
   "bash",
   "build-essential",
@@ -199,8 +205,8 @@ function validateConsumerJob(job, failures) {
   if (job.name === ".github/workflows/zuuallet.yml:rust") {
     for (const expected of [
       "persist-credentials: false",
-      "dtolnay/rust-toolchain@1.97.1",
-      "Swatinem/rust-cache@v2",
+      pinnedZuualletToolchain,
+      pinnedRustCache,
       "cargo build --locked --manifest-path wallet/zuuallet/src-tauri/Cargo.toml",
       "cargo test --locked",
       "--manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml",
@@ -631,10 +637,10 @@ function runSelfTest() {
         name: "Zuuallet required build floats its Rust toolchain",
         path: consumerWorkflows[3],
         mutate: (value) => value.replace(
-          "dtolnay/rust-toolchain@1.97.1",
-          "dtolnay/rust-toolchain@stable",
+          pinnedZuualletToolchain,
+          pinnedGenericToolchain,
         ),
-        expected: "dtolnay/rust-toolchain@1.97.1",
+        expected: pinnedZuualletToolchain,
       },
       {
         name: "missing pull-time credential",
@@ -685,8 +691,8 @@ function runSelfTest() {
         name: "Git ownership trust moved before checkout",
         path: consumerWorkflows[0],
         mutate: (value) => value.replace(
-          '      - uses: actions/checkout@v7\n      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"',
-          '      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"\n      - uses: actions/checkout@v7',
+          `      - uses: ${pinnedActions[0]}\n      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"`,
+          `      - name: Configure exact Git workspace trust\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"\n      - uses: ${pinnedActions[0]}`,
         ),
         expected: "must immediately follow checkout",
       },


### PR DESCRIPTION
## Summary

- Replaces all 40 mutable external `uses:` references with authoritative 40-character commits and readable version/provenance comments; the repository now inventories 110/110 external references as immutable.
- Adds a dependency-free recursive policy checker for workflows, reusable workflows, and nested local actions, wired before change detection on every required-gate event.
- Preserves source-derived Rust toolchains while binding each generic action to its exact `with.toolchain` mapping and verified upstream action commit.
- Completes the existing `ruby/setup-ruby` pin provenance as `v1.321.0`; this is a one-line semantic overlap for the release-workflow work tracked separately.

## Evidence

- Fail-first on base `5491fef`: 40 of 110 external references were mutable; the prior Rust checker still passed.
- `node scripts/check-github-actions-pins.mjs --self-test`: 26/26 policy cases pass.
- `node scripts/check-github-actions-pins.mjs`: 110 references across 14 files, all immutable with nonempty provenance.
- `scripts/check-rust-toolchain.sh --self-test`: 12/12 drift cases caught, including borrowed sibling, commented, wrong-indent, wrong-expression, exact action-SHA, and label drift.
- `scripts/check-rust-toolchain.sh`: canonical `1.97.1`/MSRV `1.97` contract passes.
- `node scripts/check-zuuli-linux-image.mjs --self-test`: consumer contracts use exact immutable action identities; 25 negative cases plus runtime regressions pass.
- Changed-workflow `actionlint`, scoped `shellcheck`, `bash -n`, `node --check`, `git diff --check`, and clean-tree checks pass.
- Independent exact-head review of `3c6557d` against `5491fef`: `No significant findings.`

## External owner gate — issue remains open

Addresses #373, but does not close it. Repository settings still read `allowed_actions=all` and `sha_pinning_required=false`. Enabling SHA enforcement, selecting the reviewed allowlist, and reading both settings back are owner-controlled post-merge acceptance steps. This PR deliberately does not mutate repository or organization policy.
