### PR TITLE
security(release): isolate Apple signing credentials

### DIFF
--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -162,13 +162,15 @@ jobs:
             fi
           fi
 
-          echo "identity=$actual" >> "$GITHUB_OUTPUT"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "tag_exists=$tag_exists" >> "$GITHUB_OUTPUT"
-          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
-          echo "target=$target" >> "$GITHUB_OUTPUT"
-          echo "dry_run=$dry_run" >> "$GITHUB_OUTPUT"
-          echo "should_release=$should_release" >> "$GITHUB_OUTPUT"
+          {
+            echo "identity=$actual"
+            echo "tag=$tag"
+            echo "tag_exists=$tag_exists"
+            echo "source_sha=$source_sha"
+            echo "target=$target"
+            echo "dry_run=$dry_run"
+            echo "should_release=$should_release"
+          } >> "$GITHUB_OUTPUT"
 
   android:
     name: Android / Play internal
@@ -321,8 +323,8 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-  ios:
-    name: iOS / TestFlight
+  ios-build:
+    name: iOS / credential-free unsigned archive
     needs: prepare
     if: >-
       needs.prepare.outputs.should_release == 'true' &&
@@ -331,7 +333,6 @@ jobs:
       needs.prepare.outputs.target == 'all')
     runs-on: macos-26
     timeout-minutes: 120
-    environment: zuuli-app-stores
     permissions:
       contents: read
       id-token: write
@@ -339,11 +340,10 @@ jobs:
     defaults:
       run:
         working-directory: wallet/zuuli
+    outputs:
+      artifact_sha256: ${{ steps.unsigned.outputs.artifact_sha256 }}
+      payload_sha256: ${{ steps.unsigned.outputs.payload_sha256 }}
     env:
-      APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
-      ASC_KEY_ID: ${{ vars.ASC_KEY_ID }}
-      ASC_ISSUER_ID: ${{ vars.ASC_ISSUER_ID }}
-      ZUULI_CONFIRM_UPLOAD: ${{ needs.prepare.outputs.dry_run == 'false' && needs.prepare.outputs.identity || '' }}
       ZUULI_RELEASE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -374,157 +374,429 @@ jobs:
         with:
           shared-key: zuuli-release-ios-device-v2-rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-ios18-aarch64-device
           save: "false"
+      - name: Prove Apple credentials are absent before dependency code
+        run: scripts/assert-no-apple-credentials.sh
       - run: npm ci
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
-      - name: Materialize ephemeral Apple credentials
+      - name: Reverify exact release source
+        run: node scripts/release-identity.mjs "--source-sha=$ZUULI_RELEASE_SOURCE_SHA" --require-main
+      - name: Build source-bound unsigned archive
+        id: unsigned
+        env:
+          RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}
+          RELEASE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          node scripts/normalize-generated-ios-project.mjs --prepare-manual-signing
+          ./node_modules/.bin/tauri ios build --ci --no-sign --archive-only -- --locked
+          node scripts/normalize-generated-ios-project.mjs
+          git diff --exit-code
+          archives=(src-tauri/gen/apple/build/arm64/*.xcarchive)
+          [[ ${#archives[@]} -eq 1 && -d "${archives[0]}" ]]
+          mkdir unsigned-ios
+          ditto -c -k --sequesterRsrc --keepParent "${archives[0]}" unsigned-ios/ZUULI.xcarchive.zip
+          cat > unsigned-ios/ExportOptions.plist <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+            <key>destination</key><string>export</string>
+            <key>manageAppVersionAndBuildNumber</key><false/>
+            <key>method</key><string>app-store-connect</string>
+            <key>signingCertificate</key><string>Apple Distribution</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>stripSwiftSymbols</key><true/>
+            <key>teamID</key><string>F9AV5HKF6N</string>
+            <key>provisioningProfiles</key><dict>
+              <key>cash.free2z.zuuli</key><string>ZUULI App Store CI</string>
+            </dict>
+          </dict></plist>
+          PLIST
+          version=${RELEASE_IDENTITY%+*}
+          build=${RELEASE_IDENTITY#*+}
+          jq -n --arg identity "$RELEASE_IDENTITY" --arg sourceSha "$RELEASE_SOURCE_SHA" \
+            --arg version "$version" --arg build "$build" \
+            '{schemaVersion:1,identity:$identity,sourceSha:$sourceSha,version:$version,build:$build,kind:"ios-unsigned-xcarchive"}' \
+            > unsigned-ios/source-record.json
+          (cd unsigned-ios && shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256)
+          artifact_sha256=$(shasum -a 256 unsigned-ios/ZUULI.xcarchive.zip | awk '{print $1}')
+          payload_sha256=$(shasum -a 256 unsigned-ios/CHECKSUMS.sha256 | awk '{print $1}')
+          echo "artifact_sha256=$artifact_sha256" >> "$GITHUB_OUTPUT"
+          echo "payload_sha256=$payload_sha256" >> "$GITHUB_OUTPUT"
+      - name: Prove Apple credentials remained absent through the build
+        run: scripts/assert-no-apple-credentials.sh
+      - uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: wallet/zuuli/unsigned-ios/*
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: internal-zuuli-ios-unsigned-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: wallet/zuuli/unsigned-ios
+          if-no-files-found: error
+          retention-days: 1
+
+  ios-sign:
+    name: iOS / system export and signing
+    needs: [prepare, ios-build]
+    if: >-
+      needs.prepare.outputs.should_release == 'true' &&
+      needs.ios-build.result == 'success'
+    runs-on: macos-26
+    timeout-minutes: 30
+    environment: zuuli-app-stores
+    permissions:
+      contents: read
+      attestations: read
+    outputs:
+      artifact_sha256: ${{ steps.sign.outputs.artifact_sha256 }}
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: internal-zuuli-ios-unsigned-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: unsigned-ios
+      - name: Verify source-bound artifact
+        env:
+          EXPECTED_ARCHIVE_SHA256: ${{ needs.ios-build.outputs.artifact_sha256 }}
+          EXPECTED_PAYLOAD_SHA256: ${{ needs.ios-build.outputs.payload_sha256 }}
+          EXPECTED_IDENTITY: ${{ needs.prepare.outputs.identity }}
+          EXPECTED_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_ARCHIVE_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$EXPECTED_PAYLOAD_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          expected_members=$(printf '%s\n' \
+            ./CHECKSUMS.sha256 ./ExportOptions.plist ./ZUULI.xcarchive.zip ./source-record.json | LC_ALL=C sort)
+          actual_members=$(cd unsigned-ios && find . -mindepth 1 -print | LC_ALL=C sort)
+          [[ "$actual_members" == "$expected_members" ]]
+          for member in CHECKSUMS.sha256 ExportOptions.plist ZUULI.xcarchive.zip source-record.json; do
+            [[ -f "unsigned-ios/$member" && ! -L "unsigned-ios/$member" ]]
+          done
+          test "$(shasum -a 256 unsigned-ios/CHECKSUMS.sha256 | awk '{print $1}')" = "$EXPECTED_PAYLOAD_SHA256"
+          (cd unsigned-ios && shasum -a 256 -c CHECKSUMS.sha256)
+          test "$(shasum -a 256 unsigned-ios/ZUULI.xcarchive.zip | awk '{print $1}')" = "$EXPECTED_ARCHIVE_SHA256"
+          jq -e --arg identity "$EXPECTED_IDENTITY" --arg source "$EXPECTED_SOURCE_SHA" \
+            '.schemaVersion == 1 and .kind == "ios-unsigned-xcarchive" and .identity == $identity and .sourceSha == $source' \
+            unsigned-ios/source-record.json
+          # The attested canonical manifest and its build-job output bind every
+          # unsigned payload member, including ExportOptions.plist.
+          gh attestation verify unsigned-ios/CHECKSUMS.sha256 --repo "$GITHUB_REPOSITORY"
+          mkdir archive-root
+          ditto -x -k unsigned-ios/ZUULI.xcarchive.zip archive-root
+          archives=(archive-root/*.xcarchive)
+          [[ ${#archives[@]} -eq 1 && -d "${archives[0]}" ]]
+          echo "ZUULI_UNSIGNED_ARCHIVE=${archives[0]}" >> "$GITHUB_ENV"
+      - name: Materialize, export, and destroy ephemeral iOS signing credential
+        id: sign
         env:
           CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
-          ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
           PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+          RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}
+          RELEASE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          UNSIGNED_ARCHIVE_SHA256: ${{ needs.ios-build.outputs.artifact_sha256 }}
         run: |
           set -euo pipefail
+          umask 077
           : "${CERTIFICATE_BASE64:?APPLE_DISTRIBUTION_CERTIFICATE_BASE64 is not configured}"
           : "${CERTIFICATE_PASSWORD:?APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD is not configured}"
-          : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
           : "${PROVISIONING_PROFILE_BASE64:?APPLE_PROVISIONING_PROFILE_BASE64 is not configured}"
-          : "${APPLE_TEAM_ID:?APPLE_TEAM_ID is not configured}"
-          : "${ASC_KEY_ID:?ASC_KEY_ID is not configured}"
-          : "${ASC_ISSUER_ID:?ASC_ISSUER_ID is not configured}"
-          files=$(mktemp -d "$RUNNER_TEMP/zuuli-apple.XXXXXX")
-          chmod 700 "$files"
-          files=$(CDPATH= cd -P -- "$files" && pwd)
-          echo "ZUULI_SECRET_DIR=$files" >> "$GITHUB_ENV"
-          printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$files/distribution.p12"
-          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$files/AuthKey.p8"
-          printf '%s' "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$files/zuuli.mobileprovision"
-          test -s "$files/distribution.p12"
-          test -s "$files/AuthKey.p8"
-          test -s "$files/zuuli.mobileprovision"
-          original_keychains="$files/original-user-keychains.txt"
-          security list-keychains -d user |
-            sed -E 's/^[[:space:]]*"//; s/"[[:space:]]*$//' > "$original_keychains"
-          [[ -s "$original_keychains" ]] || {
-            echo "user keychain search list is unexpectedly empty" >&2
-            exit 1
+          secret_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-ios-sign.XXXXXX")
+          keychain="$secret_dir/release.keychain-db"
+          original_keychains_file="$secret_dir/original-keychains.txt"
+          cleanup_failed="$RUNNER_TEMP/zuuli-ios-sign-cleanup-failed"
+          profile_path=""
+          rm -f -- "$cleanup_failed"
+          security list-keychains -d user | sed -E 's/^[[:space:]]*"([^"]+)"[[:space:]]*$/\1/' > "$original_keychains_file"
+          test -s "$original_keychains_file"
+          cleanup() {
+            set +e
+            cleanup_status=0
+            if [[ -n "$profile_path" ]] && ! rm -f -- "$profile_path"; then cleanup_status=1; fi
+            original_keychains=()
+            while IFS= read -r original_keychain; do
+              [[ -z "$original_keychain" ]] || original_keychains+=("$original_keychain")
+            done < "$original_keychains_file"
+            [[ ${#original_keychains[@]} -gt 0 ]] || cleanup_status=1
+            [[ ${#original_keychains[@]} -eq 0 ]] || security list-keychains -d user -s "${original_keychains[@]}" || cleanup_status=1
+            [[ ! -e "$keychain" ]] || security delete-keychain "$keychain" || cleanup_status=1
+            find "$secret_dir" -depth -delete || cleanup_status=1
+            [[ "$cleanup_status" -eq 0 ]] || : > "$cleanup_failed"
+            return 0
           }
-          keychain="$files/release.keychain-db"
-          keychain_password=$(openssl rand -hex 24)
-          echo "ZUULI_PREFLIGHT_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
-          echo "ZUULI_ORIGINAL_KEYCHAIN_LIST=$original_keychains" >> "$GITHUB_ENV"
-          security create-keychain -p "$keychain_password" "$keychain"
-          security set-keychain-settings -lut 21600 "$keychain"
-          security unlock-keychain -p "$keychain_password" "$keychain"
-          security import "$files/distribution.p12" -P "$CERTIFICATE_PASSWORD" \
-            -t cert -f pkcs12 \
-            -T /usr/bin/codesign -T /usr/bin/xcodebuild \
-            -k "$keychain"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain" >/dev/null
-          keychains=("$keychain")
-          while IFS= read -r existing_keychain; do
-            [[ -z "$existing_keychain" ]] || keychains+=("$existing_keychain")
-          done < "$original_keychains"
-          security list-keychains -d user -s "${keychains[@]}"
-          identity_count=$(security find-identity -v -p codesigning "$keychain" | grep -Fc 'Apple Distribution: Corpora Inc (F9AV5HKF6N)' || true)
-          [[ "$identity_count" -eq 1 ]] || {
-            echo "expected exactly one dedicated Corpora Apple Distribution identity" >&2
-            exit 1
-          }
-          searchable_distribution_count=$(security find-identity -v -p codesigning |
-            grep -Fc 'Apple Distribution:' || true)
-          searchable_identity_count=$(security find-identity -v -p codesigning |
-            grep -Fc 'Apple Distribution: Corpora Inc (F9AV5HKF6N)' || true)
-          [[ "$searchable_distribution_count" -eq 1 && "$searchable_identity_count" -eq 1 ]] || {
-            echo "user keychain search list does not resolve the unique Corpora distribution identity" >&2
-            exit 1
-          }
-          identity_sha=$(security find-identity -v -p codesigning "$keychain" | awk '/Apple Distribution: Corpora Inc/ {print $2; exit}')
-          [[ "$identity_sha" =~ ^[0-9A-F]{40}$ ]] || {
-            echo "dedicated Corpora Apple Distribution identity was not imported" >&2
-            exit 1
-          }
-
-          security cms -D -i "$files/zuuli.mobileprovision" > "$files/profile.plist"
-          profile_uuid=$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$files/profile.plist")
-          profile_name=$(/usr/libexec/PlistBuddy -c 'Print :Name' "$files/profile.plist")
-          profile_team=$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$files/profile.plist")
-          profile_app=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$files/profile.plist")
+          trap cleanup EXIT
+          printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$secret_dir/distribution.p12"
+          printf '%s' "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$secret_dir/zuuli.mobileprovision"
+          test -s "$secret_dir/distribution.p12"
+          test -s "$secret_dir/zuuli.mobileprovision"
+          security cms -D -i "$secret_dir/zuuli.mobileprovision" > "$secret_dir/profile.plist"
+          profile_uuid=$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$secret_dir/profile.plist")
+          profile_name=$(/usr/libexec/PlistBuddy -c 'Print :Name' "$secret_dir/profile.plist")
+          profile_team=$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$secret_dir/profile.plist")
+          profile_app=$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$secret_dir/profile.plist")
           [[ "$profile_uuid" == e5ead62c-83ec-4e54-abb6-4770833b5e0d ]]
           [[ "$profile_name" == 'ZUULI App Store CI' ]]
           [[ "$profile_team" == F9AV5HKF6N ]]
           [[ "$profile_app" == F9AV5HKF6N.cash.free2z.zuuli ]]
+          keychain_password=$(openssl rand -hex 24)
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 1800 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$secret_dir/distribution.p12" -P "$CERTIFICATE_PASSWORD" -t cert -f pkcs12 \
+            -T /usr/bin/codesign -T /usr/bin/xcodebuild -k "$keychain"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain"
+          identity_sha=$(security find-identity -v -p codesigning "$keychain" | awk '/Apple Distribution: Corpora Inc/ {print $2; exit}')
+          [[ "$identity_sha" =~ ^[0-9A-F]{40}$ ]]
           profile_authorizes_identity=false
           certificate_index=0
-          while certificate_base64=$(plutil -extract "DeveloperCertificates.$certificate_index" raw -o - "$files/profile.plist" 2>/dev/null); do
-            printf '%s' "$certificate_base64" | base64 --decode > "$files/profile-certificate.der"
-            profile_sha=$(openssl x509 -inform DER -in "$files/profile-certificate.der" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')
-            if [[ "$profile_sha" == "$identity_sha" ]]; then
-              profile_authorizes_identity=true
-              break
-            fi
+          while certificate_base64=$(plutil -extract "DeveloperCertificates.$certificate_index" raw -o - "$secret_dir/profile.plist" 2>/dev/null); do
+            printf '%s' "$certificate_base64" | base64 --decode > "$secret_dir/profile-certificate.der"
+            profile_sha=$(openssl x509 -inform DER -in "$secret_dir/profile-certificate.der" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')
+            [[ "$profile_sha" != "$identity_sha" ]] || profile_authorizes_identity=true
             certificate_index=$((certificate_index + 1))
           done
-          [[ "$profile_authorizes_identity" == true ]] || {
-            echo "provisioning profile is not linked to the imported distribution certificate" >&2
-            exit 1
-          }
-          rm -f -- "$files/distribution.p12" "$files/profile-certificate.der"
+          [[ "$profile_authorizes_identity" == true ]]
           profile_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
           mkdir -p "$profile_dir"
-          cp "$files/zuuli.mobileprovision" "$profile_dir/$profile_uuid.mobileprovision"
-          echo "ASC_KEY_PATH=$files/AuthKey.p8" >> "$GITHUB_ENV"
-          echo "ZUULI_PROFILE_PATH=$profile_dir/$profile_uuid.mobileprovision" >> "$GITHUB_ENV"
-      - name: Build, validate, and optionally upload
-        env:
-          DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
-          IOS_MOBILE_PROVISION: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
-        run: |
-          set -euo pipefail
-          if [[ "$DRY_RUN" == false ]]; then
-            scripts/mobile-release.sh ios --upload
-          else
-            scripts/mobile-release.sh ios
-          fi
-      - name: Destroy ephemeral Apple credentials
+          profile_candidate="$profile_dir/$profile_uuid.mobileprovision"
+          [[ ! -e "$profile_candidate" ]]
+          profile_path="$profile_candidate"
+          cp "$secret_dir/zuuli.mobileprovision" "$profile_path"
+          mkdir signed-export signed-ios
+          xcodebuild -exportArchive \
+            -archivePath "$ZUULI_UNSIGNED_ARCHIVE" \
+            -exportPath signed-export \
+            -exportOptionsPlist unsigned-ios/ExportOptions.plist
+          ipas=(signed-export/*.ipa)
+          [[ ${#ipas[@]} -eq 1 && -f "${ipas[0]}" ]]
+          archive_listing=$(/usr/bin/unzip -Z1 "${ipas[0]}")
+          embedded=$(awk -F/ '$1 == "Payload" && $2 ~ /\.app$/ && $3 == "embedded.mobileprovision" {print; exit}' <<<"$archive_listing")
+          [[ -n "$embedded" ]]
+          /usr/bin/unzip -p "${ipas[0]}" "$embedded" > "$secret_dir/embedded.mobileprovision"
+          cmp -s "$secret_dir/zuuli.mobileprovision" "$secret_dir/embedded.mobileprovision"
+          cp "${ipas[0]}" "signed-ios/ZUULI-${RELEASE_IDENTITY}-ios.ipa"
+          ipa_sha256=$(shasum -a 256 "signed-ios/ZUULI-${RELEASE_IDENTITY}-ios.ipa" | awk '{print $1}')
+          profile_sha256=$(shasum -a 256 "$secret_dir/zuuli.mobileprovision" | awk '{print $1}')
+          jq -n --arg identity "$RELEASE_IDENTITY" --arg sourceSha "$RELEASE_SOURCE_SHA" \
+            --arg unsignedArchiveSha256 "$UNSIGNED_ARCHIVE_SHA256" --arg ipaSha256 "$ipa_sha256" \
+            --arg profileSha256 "$profile_sha256" --arg signerSha1 "$identity_sha" \
+            '{schemaVersion:1,identity:$identity,sourceSha:$sourceSha,kind:"ios-signed-ipa",unsignedArchiveSha256:$unsignedArchiveSha256,ipaSha256:$ipaSha256,profileSha256:$profileSha256,signerSha1:$signerSha1}' \
+            > signed-ios/signing-record.json
+          (cd signed-ios && shasum -a 256 ./* > CHECKSUMS.sha256)
+          artifact_sha256=$(shasum -a 256 "signed-ios/ZUULI-${RELEASE_IDENTITY}-ios.ipa" | awk '{print $1}')
+          echo "artifact_sha256=$artifact_sha256" >> "$GITHUB_OUTPUT"
+      - name: Destroy ephemeral iOS signing credential
         if: always()
         run: |
-          set -u
-          cleanup_failed=0
-          if [[ -n "${ZUULI_ORIGINAL_KEYCHAIN_LIST:-}" && -s "$ZUULI_ORIGINAL_KEYCHAIN_LIST" ]]; then
-            original_keychains=()
-            while IFS= read -r existing_keychain; do
-              [[ -z "$existing_keychain" ]] || original_keychains+=("$existing_keychain")
-            done < "$ZUULI_ORIGINAL_KEYCHAIN_LIST"
-            if [[ ${#original_keychains[@]} -gt 0 ]]; then
-              security list-keychains -d user -s "${original_keychains[@]}" || cleanup_failed=1
-            else
-              echo "recorded user keychain search list is empty" >&2
-              cleanup_failed=1
-            fi
-          elif [[ -n "${ZUULI_PREFLIGHT_KEYCHAIN:-}" ]]; then
-            echo "cannot restore the original user keychain search list" >&2
-            cleanup_failed=1
+          set -euo pipefail
+          if find "$RUNNER_TEMP" -maxdepth 1 -name 'zuuli-ios-sign.*' -print -quit | grep -q .; then
+            echo "ephemeral iOS signing directory survived cleanup" >&2
+            exit 1
           fi
-          if [[ -n "${ZUULI_PREFLIGHT_KEYCHAIN:-}" && -e "$ZUULI_PREFLIGHT_KEYCHAIN" ]]; then
-            security delete-keychain "$ZUULI_PREFLIGHT_KEYCHAIN" || cleanup_failed=1
+          if security list-keychains -d user | grep -Fq 'zuuli-ios-sign.'; then
+            echo "ephemeral iOS signing keychain survived cleanup" >&2
+            exit 1
           fi
-          if [[ -n "${ZUULI_PROFILE_PATH:-}" ]]; then
-            rm -f -- "$ZUULI_PROFILE_PATH" || cleanup_failed=1
+          if [[ -e "$HOME/Library/MobileDevice/Provisioning Profiles/e5ead62c-83ec-4e54-abb6-4770833b5e0d.mobileprovision" ]]; then
+            echo "ephemeral iOS provisioning profile survived cleanup" >&2
+            exit 1
           fi
-          if [[ -n "${ZUULI_SECRET_DIR:-}" && -d "$ZUULI_SECRET_DIR" ]]; then
-            find "$ZUULI_SECRET_DIR" -type f -exec rm -f -- {} + || cleanup_failed=1
-            rmdir "$ZUULI_SECRET_DIR" || cleanup_failed=1
+          if [[ -e "$RUNNER_TEMP/zuuli-ios-sign-cleanup-failed" ]]; then
+            echo "iOS signing credential cleanup or keychain restoration failed" >&2
+            exit 1
           fi
-          [[ -z "${ZUULI_PREFLIGHT_KEYCHAIN:-}" || ! -e "$ZUULI_PREFLIGHT_KEYCHAIN" ]] || cleanup_failed=1
-          [[ -z "${ZUULI_PROFILE_PATH:-}" || ! -e "$ZUULI_PROFILE_PATH" ]] || cleanup_failed=1
-          [[ -z "${ZUULI_SECRET_DIR:-}" || ! -e "$ZUULI_SECRET_DIR" ]] || cleanup_failed=1
-          if [[ -n "${ZUULI_PREFLIGHT_KEYCHAIN:-}" ]] &&
-            security list-keychains -d user | grep -Fq "$ZUULI_PREFLIGHT_KEYCHAIN"; then
-            echo "ephemeral release keychain remains in the user search list" >&2
-            cleanup_failed=1
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: internal-zuuli-ios-signed-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: signed-ios
+          if-no-files-found: error
+          retention-days: 1
+
+  ios-verify:
+    name: iOS / credential-free signed artifact verification
+    needs: [prepare, ios-sign]
+    if: needs.ios-sign.result == 'success'
+    runs-on: macos-26
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    outputs:
+      artifact_sha256: ${{ steps.verify.outputs.artifact_sha256 }}
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+          persist-credentials: false
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: internal-zuuli-ios-signed-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: wallet/zuuli/signed-ios
+      - name: Verify signed IPA and prepare upload payload
+        id: verify
+        env:
+          EXPECTED_IDENTITY: ${{ needs.prepare.outputs.identity }}
+          EXPECTED_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          EXPECTED_IPA_SHA256: ${{ needs.ios-sign.outputs.artifact_sha256 }}
+        run: |
+          set -euo pipefail
+          (cd signed-ios && shasum -a 256 -c CHECKSUMS.sha256)
+          jq -e --arg identity "$EXPECTED_IDENTITY" --arg source "$EXPECTED_SOURCE_SHA" --arg sha "$EXPECTED_IPA_SHA256" \
+            '.schemaVersion == 1 and .kind == "ios-signed-ipa" and .identity == $identity and .sourceSha == $source and .ipaSha256 == $sha' \
+            signed-ios/signing-record.json
+          ipa="signed-ios/ZUULI-${EXPECTED_IDENTITY}-ios.ipa"
+          profile_sha=$(jq -er .profileSha256 signed-ios/signing-record.json)
+          scripts/verify-ios-ipa.sh --expected-profile-sha256 "$profile_sha" "$ipa" F9AV5HKF6N cash.free2z.zuuli
+          mkdir verified-ios
+          cp "$ipa" signed-ios/signing-record.json scripts/asc-testflight.mjs verified-ios/
+          (cd verified-ios && shasum -a 256 ./* > CHECKSUMS.sha256)
+          artifact_sha256=$(shasum -a 256 "$ipa" | awk '{print $1}')
+          echo "artifact_sha256=$artifact_sha256" >> "$GITHUB_OUTPUT"
+      - uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: wallet/zuuli/verified-ios/*
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: internal-zuuli-ios-verified-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: wallet/zuuli/verified-ios
+          if-no-files-found: error
+          retention-days: 1
+
+  ios-upload:
+    name: iOS / App Store validation and TestFlight
+    needs: [prepare, ios-verify]
+    if: needs.ios-verify.result == 'success'
+    runs-on: macos-26
+    timeout-minutes: 60
+    environment: zuuli-app-stores
+    permissions:
+      contents: read
+      attestations: read
+    outputs:
+      payload_sha256: ${{ steps.upload.outputs.payload_sha256 }}
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: internal-zuuli-ios-verified-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: verified-ios
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+      - name: Verify source-bound artifact
+        env:
+          EXPECTED_IPA_SHA256: ${{ needs.ios-verify.outputs.artifact_sha256 }}
+          EXPECTED_IDENTITY: ${{ needs.prepare.outputs.identity }}
+          EXPECTED_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          (cd verified-ios && shasum -a 256 -c CHECKSUMS.sha256)
+          ipa="verified-ios/ZUULI-${EXPECTED_IDENTITY}-ios.ipa"
+          expected_members=$(printf '%s\n' \
+            ./CHECKSUMS.sha256 "./ZUULI-${EXPECTED_IDENTITY}-ios.ipa" \
+            ./asc-testflight.mjs ./signing-record.json | LC_ALL=C sort)
+          actual_members=$(cd verified-ios && find . -mindepth 1 -print | LC_ALL=C sort)
+          [[ "$actual_members" == "$expected_members" ]]
+          for member in CHECKSUMS.sha256 "ZUULI-${EXPECTED_IDENTITY}-ios.ipa" asc-testflight.mjs signing-record.json; do
+            [[ -f "verified-ios/$member" && ! -L "verified-ios/$member" ]]
+          done
+          test "$(shasum -a 256 "$ipa" | awk '{print $1}')" = "$EXPECTED_IPA_SHA256"
+          jq -e --arg identity "$EXPECTED_IDENTITY" --arg source "$EXPECTED_SOURCE_SHA" \
+            '.identity == $identity and .sourceSha == $source' verified-ios/signing-record.json
+          gh attestation verify "$ipa" --repo "$GITHUB_REPOSITORY"
+          gh attestation verify verified-ios/asc-testflight.mjs --repo "$GITHUB_REPOSITORY"
+      - name: Materialize, upload, reconcile, and destroy ephemeral ASC credential
+        id: upload
+        env:
+          ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
+          ASC_KEY_ID: ${{ vars.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ vars.ASC_ISSUER_ID }}
+          DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
+          RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}
+        run: |
+          set -euo pipefail
+          umask 077
+          : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
+          : "${ASC_KEY_ID:?ASC_KEY_ID is not configured}"
+          : "${ASC_ISSUER_ID:?ASC_ISSUER_ID is not configured}"
+          secret_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-ios-asc.XXXXXX")
+          cleanup() { find "$secret_dir" -depth -delete 2>/dev/null || true; }
+          trap cleanup EXIT
+          mkdir "$secret_dir/private_keys"
+          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$secret_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+          test -s "$secret_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+          ipa="$GITHUB_WORKSPACE/verified-ios/ZUULI-${RELEASE_IDENTITY}-ios.ipa"
+          (cd "$secret_dir" && xcrun altool --validate-app --type ios --file "$ipa" --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID")
+          mkdir uploaded-ios
+          cp verified-ios/* uploaded-ios/
+          if [[ "$DRY_RUN" == false ]]; then
+            (cd "$secret_dir" && xcrun altool --upload-app --type ios --file "$ipa" --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID")
+            version=${RELEASE_IDENTITY%+*}
+            build=${RELEASE_IDENTITY#*+}
+            ASC_KEY_PATH="$secret_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8" \
+              node verified-ios/asc-testflight.mjs --ensure "--version=$version" "--build=$build" \
+                --output=uploaded-ios/testflight.json
           fi
-          exit "$cleanup_failed"
+          find uploaded-ios -name CHECKSUMS.sha256 -delete
+          (cd uploaded-ios && shasum -a 256 ./* > CHECKSUMS.sha256)
+          payload_sha256=$(shasum -a 256 uploaded-ios/CHECKSUMS.sha256 | awk '{print $1}')
+          echo "payload_sha256=$payload_sha256" >> "$GITHUB_OUTPUT"
+      - name: Destroy ephemeral ASC credential
+        if: always()
+        run: |
+          set -euo pipefail
+          if find "$RUNNER_TEMP" -maxdepth 1 -name 'zuuli-ios-asc.*' -print -quit | grep -q .; then
+            echo "ephemeral ASC credential directory survived cleanup" >&2
+            exit 1
+          fi
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: internal-zuuli-ios-uploaded-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: uploaded-ios
+          if-no-files-found: error
+          retention-days: 1
+
+  ios-finalize:
+    name: iOS / credential-free shipped-artifact provenance
+    needs: [prepare, ios-upload]
+    if: needs.ios-upload.result == 'success'
+    runs-on: macos-26
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: internal-zuuli-ios-uploaded-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: wallet/zuuli/uploaded-ios
+      - name: Verify uploaded payload and collect shipped artifact
+        env:
+          EXPECTED_PAYLOAD_SHA256: ${{ needs.ios-upload.outputs.payload_sha256 }}
+          EXPECTED_IDENTITY: ${{ needs.prepare.outputs.identity }}
+        run: |
+          set -euo pipefail
+          test "$(shasum -a 256 uploaded-ios/CHECKSUMS.sha256 | awk '{print $1}')" = "$EXPECTED_PAYLOAD_SHA256"
+          (cd uploaded-ios && shasum -a 256 -c CHECKSUMS.sha256)
+          mkdir release-artifacts
+          cp "uploaded-ios/ZUULI-${EXPECTED_IDENTITY}-ios.ipa" uploaded-ios/signing-record.json release-artifacts/
+          [[ ! -f uploaded-ios/testflight.json ]] || cp uploaded-ios/testflight.json release-artifacts/
       - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
           syft-version: v1.50.0
@@ -536,7 +808,7 @@ jobs:
       - name: Record checksums and provenance
         run: |
           jq -e '(.components // []) | length >= 50' release-artifacts/ZUULI-ios.sbom.cdx.json
-          npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
+          node scripts/release-manifest.mjs --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
       - uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
         with:
           subject-path: wallet/zuuli/release-artifacts/*
@@ -645,8 +917,8 @@ jobs:
             retention-days: 90,
           }
 
-  macos:
-    name: macOS universal signed and notarized
+  macos-build:
+    name: macOS / credential-free unsigned packages
     needs: prepare
     if: >-
       needs.prepare.outputs.should_release == 'true' &&
@@ -654,7 +926,6 @@ jobs:
       needs.prepare.outputs.target == 'all')
     runs-on: macos-26
     timeout-minutes: 120
-    environment: zuuli-app-stores
     permissions:
       contents: read
       id-token: write
@@ -662,10 +933,10 @@ jobs:
     defaults:
       run:
         working-directory: wallet/zuuli
+    outputs:
+      artifact_sha256: ${{ steps.unsigned.outputs.artifact_sha256 }}
+      payload_sha256: ${{ steps.unsigned.outputs.payload_sha256 }}
     env:
-      APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_DEVELOPER_ID_IDENTITY }}
-      APPLE_API_ISSUER: ${{ vars.ASC_ISSUER_ID }}
-      APPLE_API_KEY: ${{ vars.ASC_KEY_ID }}
       ZUULI_RELEASE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -700,83 +971,404 @@ jobs:
         with:
           shared-key: zuuli-release-macos-universal-v2-rust-${{ env.ZUULI_RUST_VERSION }}-xcode-${{ env.ZUULI_XCODE_VERSION }}-macos-arm64-x86_64
           save: "false"
+      - name: Prove Apple credentials are absent before dependency code
+        run: scripts/assert-no-apple-credentials.sh
       - run: npm ci
       - name: Reverify exact release source
         run: node scripts/release-identity.mjs "--source-sha=$ZUULI_RELEASE_SOURCE_SHA" --require-main
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "
-      - name: Build unsigned universal packages without Apple credentials
-        if: needs.prepare.outputs.dry_run == 'true'
+      - name: Build source-bound unsigned universal packages
+        id: unsigned
+        env:
+          RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}
+          RELEASE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
         run: |
           set -euo pipefail
           unset APPLE_SIGNING_IDENTITY APPLE_API_ISSUER APPLE_API_KEY APPLE_API_KEY_PATH
-          ./node_modules/.bin/tauri build --target universal-apple-darwin --bundles app,dmg -- --locked
+          ./node_modules/.bin/tauri build --target universal-apple-darwin --bundles app,dmg --no-sign -- --locked
           git diff --exit-code
-      - name: Build signed and notarized universal packages
-        if: needs.prepare.outputs.dry_run == 'false'
+          apps=(src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app)
+          dmgs=(src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg)
+          [[ ${#apps[@]} -eq 1 && -d "${apps[0]}" ]]
+          [[ ${#dmgs[@]} -eq 1 && -f "${dmgs[0]}" ]]
+          mkdir unsigned-macos
+          ditto -c -k --sequesterRsrc --keepParent "${apps[0]}" unsigned-macos/ZUULI.app.zip
+          cp "${dmgs[0]}" unsigned-macos/ZUULI-layout.dmg
+          jq -n --arg identity "$RELEASE_IDENTITY" --arg sourceSha "$RELEASE_SOURCE_SHA" \
+            '{schemaVersion:1,identity:$identity,sourceSha:$sourceSha,kind:"macos-unsigned-app-and-layout"}' \
+            > unsigned-macos/source-record.json
+          (cd unsigned-macos && shasum -a 256 ZUULI.app.zip ZUULI-layout.dmg source-record.json > CHECKSUMS.sha256)
+          artifact_sha256=$(shasum -a 256 unsigned-macos/ZUULI.app.zip | awk '{print $1}')
+          payload_sha256=$(shasum -a 256 unsigned-macos/CHECKSUMS.sha256 | awk '{print $1}')
+          echo "artifact_sha256=$artifact_sha256" >> "$GITHUB_OUTPUT"
+          echo "payload_sha256=$payload_sha256" >> "$GITHUB_OUTPUT"
+      - name: Prove Apple credentials remained absent through the build
+        run: scripts/assert-no-apple-credentials.sh
+      - uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: wallet/zuuli/unsigned-macos/*
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: internal-zuuli-macos-unsigned-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: wallet/zuuli/unsigned-macos
+          if-no-files-found: error
+          retention-days: 1
+
+  macos-sign:
+    name: macOS / system signing and notarization
+    needs: [prepare, macos-build]
+    if: >-
+      needs.prepare.outputs.should_release == 'true' &&
+      needs.macos-build.result == 'success'
+    runs-on: macos-26
+    timeout-minutes: 90
+    environment: zuuli-app-stores
+    permissions:
+      contents: read
+      attestations: read
+    outputs:
+      artifact_sha256: ${{ steps.package.outputs.artifact_sha256 }}
+    env:
+      APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_DEVELOPER_ID_IDENTITY }}
+      ASC_KEY_ID: ${{ vars.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ vars.ASC_ISSUER_ID }}
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: internal-zuuli-macos-unsigned-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: unsigned-macos
+      - name: Verify source-bound artifact
+        env:
+          EXPECTED_APP_SHA256: ${{ needs.macos-build.outputs.artifact_sha256 }}
+          EXPECTED_PAYLOAD_SHA256: ${{ needs.macos-build.outputs.payload_sha256 }}
+          EXPECTED_IDENTITY: ${{ needs.prepare.outputs.identity }}
+          EXPECTED_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_APP_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$EXPECTED_PAYLOAD_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          expected_members=$(printf '%s\n' \
+            ./CHECKSUMS.sha256 ./ZUULI-layout.dmg ./ZUULI.app.zip ./source-record.json | LC_ALL=C sort)
+          actual_members=$(cd unsigned-macos && find . -mindepth 1 -print | LC_ALL=C sort)
+          [[ "$actual_members" == "$expected_members" ]]
+          for member in CHECKSUMS.sha256 ZUULI-layout.dmg ZUULI.app.zip source-record.json; do
+            [[ -f "unsigned-macos/$member" && ! -L "unsigned-macos/$member" ]]
+          done
+          test "$(shasum -a 256 unsigned-macos/CHECKSUMS.sha256 | awk '{print $1}')" = "$EXPECTED_PAYLOAD_SHA256"
+          (cd unsigned-macos && shasum -a 256 -c CHECKSUMS.sha256)
+          test "$(shasum -a 256 unsigned-macos/ZUULI.app.zip | awk '{print $1}')" = "$EXPECTED_APP_SHA256"
+          jq -e --arg identity "$EXPECTED_IDENTITY" --arg source "$EXPECTED_SOURCE_SHA" \
+            '.schemaVersion == 1 and .kind == "macos-unsigned-app-and-layout" and .identity == $identity and .sourceSha == $source' \
+            unsigned-macos/source-record.json
+          # The attested canonical manifest and its build-job output bind both
+          # the app archive and the creator-controlled shipping layout DMG.
+          gh attestation verify unsigned-macos/CHECKSUMS.sha256 --repo "$GITHUB_REPOSITORY"
+          mkdir signing-work
+          ditto -x -k unsigned-macos/ZUULI.app.zip signing-work
+          apps=(signing-work/*.app)
+          [[ ${#apps[@]} -eq 1 && -d "${apps[0]}" ]]
+          echo "ZUULI_SIGNED_APP=${apps[0]}" >> "$GITHUB_ENV"
+      - name: Materialize, sign app, and destroy ephemeral Developer ID credential
         env:
           CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
-          ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
         run: |
           set -euo pipefail
+          umask 077
           : "${APPLE_SIGNING_IDENTITY:?APPLE_DEVELOPER_ID_IDENTITY is not configured}"
           : "${CERTIFICATE_BASE64:?APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 is not configured}"
           : "${CERTIFICATE_PASSWORD:?APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD is not configured}"
-          : "${APPLE_API_ISSUER:?ASC_ISSUER_ID is not configured}"
-          : "${APPLE_API_KEY:?ASC_KEY_ID is not configured}"
-          : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
-          files=$(mktemp -d "$RUNNER_TEMP/zuuli-notary.XXXXXX")
-          chmod 700 "$files"
-          keychain="$files/notary.keychain-db"
+          secret_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-macos-app-sign.XXXXXX")
+          keychain="$secret_dir/signing.keychain-db"
+          original_keychains_file="$secret_dir/original-keychains.txt"
+          cleanup_failed="$RUNNER_TEMP/zuuli-macos-app-sign-cleanup-failed"
           keychain_password=$(openssl rand -hex 24)
+          rm -f -- "$cleanup_failed"
+          security list-keychains -d user | sed -E 's/^[[:space:]]*"([^"]+)"[[:space:]]*$/\1/' > "$original_keychains_file"
+          test -s "$original_keychains_file"
           cleanup() {
-            security delete-keychain "$keychain" 2>/dev/null || true
-            find "$files" -type f -exec rm -f -- {} +
-            rmdir "$files"
+            set +e
+            cleanup_status=0
+            original_keychains=()
+            while IFS= read -r original_keychain; do
+              [[ -z "$original_keychain" ]] || original_keychains+=("$original_keychain")
+            done < "$original_keychains_file"
+            [[ ${#original_keychains[@]} -gt 0 ]] || cleanup_status=1
+            [[ ${#original_keychains[@]} -eq 0 ]] || security list-keychains -d user -s "${original_keychains[@]}" || cleanup_status=1
+            [[ ! -e "$keychain" ]] || security delete-keychain "$keychain" || cleanup_status=1
+            find "$secret_dir" -depth -delete || cleanup_status=1
+            [[ "$cleanup_status" -eq 0 ]] || : > "$cleanup_failed"
+            return 0
           }
           trap cleanup EXIT
-          printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$files/developer-id.p12"
-          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$files/AuthKey.p8"
+          printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$secret_dir/developer-id.p12"
           security create-keychain -p "$keychain_password" "$keychain"
-          security set-keychain-settings -lut 21600 "$keychain"
+          security set-keychain-settings -lut 1800 "$keychain"
           security unlock-keychain -p "$keychain_password" "$keychain"
-          security import "$files/developer-id.p12" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
+          security import "$secret_dir/developer-id.p12" -P "$CERTIFICATE_PASSWORD" -t cert -f pkcs12 \
+            -T /usr/bin/codesign -k "$keychain"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain" >/dev/null
           security list-keychains -d user -s "$keychain"
           identity_count=$(security find-identity -v -p codesigning "$keychain" | grep -Fc "$APPLE_SIGNING_IDENTITY" || true)
-          [[ "$identity_count" -eq 1 ]] || {
-            echo "expected exactly one configured Developer ID identity" >&2
-            exit 1
-          }
-          export APPLE_API_KEY_PATH="$files/AuthKey.p8"
-          ./node_modules/.bin/tauri build --target universal-apple-darwin --bundles app,dmg -- --locked
-          git diff --exit-code
-      - name: Collect packages
-        run: |
-          mkdir release-artifacts
-          find src-tauri/target -path '*/release/bundle/*' -type f -name '*.dmg' -exec cp {} release-artifacts/ \;
-          app=$(find src-tauri/target -path '*/release/bundle/macos/*.app' -type d -print -quit)
-          test -n "$app"
-          ditto -c -k --keepParent "$app" release-artifacts/ZUULI-macos-universal.zip
-      - name: Verify Developer ID signature and notarization
-        if: needs.prepare.outputs.dry_run == 'false'
+          [[ "$identity_count" -eq 1 ]]
+          codesign --force --deep --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$ZUULI_SIGNED_APP"
+          codesign --verify --deep --strict --verbose=2 "$ZUULI_SIGNED_APP"
+      - name: Destroy ephemeral app-signing credential
+        if: always()
         run: |
           set -euo pipefail
-          apps=()
-          while IFS= read -r -d '' path; do apps+=("$path"); done < <(find src-tauri/target -path '*/release/bundle/macos/*.app' -type d -print0)
-          [[ "${#apps[@]}" -eq 1 ]] || { echo "expected one macOS app, found ${#apps[@]}" >&2; exit 1; }
+          if find "$RUNNER_TEMP" -maxdepth 1 -name 'zuuli-macos-app-sign.*' -print -quit | grep -q .; then
+            echo "ephemeral app-signing directory survived cleanup" >&2
+            exit 1
+          fi
+          if security list-keychains -d user | grep -Fq 'zuuli-macos-app-sign.'; then
+            echo "ephemeral app-signing keychain survived cleanup" >&2
+            exit 1
+          fi
+          if [[ -e "$RUNNER_TEMP/zuuli-macos-app-sign-cleanup-failed" ]]; then
+            echo "app-signing credential cleanup or keychain restoration failed" >&2
+            exit 1
+          fi
+      - name: Materialize, notarize app, and destroy ephemeral ASC credential
+        env:
+          ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
+          : "${ASC_KEY_ID:?ASC_KEY_ID is not configured}"
+          : "${ASC_ISSUER_ID:?ASC_ISSUER_ID is not configured}"
+          secret_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-macos-app-notary.XXXXXX")
+          cleanup() { find "$secret_dir" -depth -delete 2>/dev/null || true; }
+          trap cleanup EXIT
+          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$secret_dir/AuthKey.p8"
+          ditto -c -k --keepParent "$ZUULI_SIGNED_APP" "$secret_dir/ZUULI.app.zip"
+          xcrun notarytool submit "$secret_dir/ZUULI.app.zip" --wait \
+            --key "$secret_dir/AuthKey.p8" --key-id "$ASC_KEY_ID" --issuer "$ASC_ISSUER_ID"
+          xcrun stapler staple "$ZUULI_SIGNED_APP"
+          xcrun stapler validate "$ZUULI_SIGNED_APP"
+      - name: Destroy ephemeral app-notarization credential
+        if: always()
+        run: |
+          set -euo pipefail
+          if find "$RUNNER_TEMP" -maxdepth 1 -name 'zuuli-macos-app-notary.*' -print -quit | grep -q .; then
+            echo "ephemeral app-notarization directory survived cleanup" >&2
+            exit 1
+          fi
+      - name: Materialize, create and sign DMG, and destroy ephemeral Developer ID credential
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}
+        run: |
+          set -euo pipefail
+          umask 077
+          : "${APPLE_SIGNING_IDENTITY:?APPLE_DEVELOPER_ID_IDENTITY is not configured}"
+          : "${CERTIFICATE_BASE64:?APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 is not configured}"
+          : "${CERTIFICATE_PASSWORD:?APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD is not configured}"
+          secret_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-macos-dmg-sign.XXXXXX")
+          keychain="$secret_dir/signing.keychain-db"
+          original_keychains_file="$secret_dir/original-keychains.txt"
+          cleanup_failed="$RUNNER_TEMP/zuuli-macos-dmg-sign-cleanup-failed"
+          mountpoint="$secret_dir/mount"
+          mounted=false
+          rm -f -- "$cleanup_failed"
+          security list-keychains -d user | sed -E 's/^[[:space:]]*"([^"]+)"[[:space:]]*$/\1/' > "$original_keychains_file"
+          test -s "$original_keychains_file"
+          cleanup() {
+            set +e
+            cleanup_status=0
+            if [[ "$mounted" == true ]] && ! hdiutil detach "$mountpoint" -force >/dev/null; then cleanup_status=1; fi
+            original_keychains=()
+            while IFS= read -r original_keychain; do
+              [[ -z "$original_keychain" ]] || original_keychains+=("$original_keychain")
+            done < "$original_keychains_file"
+            [[ ${#original_keychains[@]} -gt 0 ]] || cleanup_status=1
+            [[ ${#original_keychains[@]} -eq 0 ]] || security list-keychains -d user -s "${original_keychains[@]}" || cleanup_status=1
+            [[ ! -e "$keychain" ]] || security delete-keychain "$keychain" || cleanup_status=1
+            find "$secret_dir" -depth -delete || cleanup_status=1
+            [[ "$cleanup_status" -eq 0 ]] || : > "$cleanup_failed"
+            return 0
+          }
+          trap cleanup EXIT
+          printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$secret_dir/developer-id.p12"
+          keychain_password=$(openssl rand -hex 24)
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 1800 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$secret_dir/developer-id.p12" -P "$CERTIFICATE_PASSWORD" -t cert -f pkcs12 \
+            -T /usr/bin/codesign -k "$keychain"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain"
+          [[ $(security find-identity -v -p codesigning "$keychain" | grep -Fc "$APPLE_SIGNING_IDENTITY" || true) -eq 1 ]]
+          hdiutil convert unsigned-macos/ZUULI-layout.dmg -format UDRW -o "$secret_dir/rewritable.dmg" >/dev/null
+          image_bytes=$(stat -f %z "$secret_dir/rewritable.dmg")
+          image_megabytes=$(( (image_bytes + 1048575) / 1048576 + 64 ))
+          hdiutil resize -size "${image_megabytes}m" "$secret_dir/rewritable.dmg" >/dev/null
+          mkdir "$mountpoint"
+          hdiutil attach "$secret_dir/rewritable.dmg" -readwrite -nobrowse -mountpoint "$mountpoint" >/dev/null
+          mounted=true
+          [[ -d "$mountpoint/ZUULI.app" && ! -L "$mountpoint/ZUULI.app" ]]
+          find "$mountpoint/ZUULI.app" -depth -delete
+          ditto "$ZUULI_SIGNED_APP" "$mountpoint/ZUULI.app"
+          hdiutil detach "$mountpoint" >/dev/null
+          mounted=false
+          mkdir signed-macos
+          hdiutil convert "$secret_dir/rewritable.dmg" -format UDZO -imagekey zlib-level=9 \
+            -o "signed-macos/ZUULI-${RELEASE_IDENTITY}-macos.dmg" >/dev/null
+          codesign --force --timestamp --sign "$APPLE_SIGNING_IDENTITY" "signed-macos/ZUULI-${RELEASE_IDENTITY}-macos.dmg"
+          codesign --verify --verbose=2 "signed-macos/ZUULI-${RELEASE_IDENTITY}-macos.dmg"
+      - name: Destroy ephemeral DMG-signing credential
+        if: always()
+        run: |
+          set -euo pipefail
+          if find "$RUNNER_TEMP" -maxdepth 1 -name 'zuuli-macos-dmg-sign.*' -print -quit | grep -q .; then
+            echo "ephemeral DMG-signing directory survived cleanup" >&2
+            exit 1
+          fi
+          if security list-keychains -d user | grep -Fq 'zuuli-macos-dmg-sign.'; then
+            echo "ephemeral DMG-signing keychain survived cleanup" >&2
+            exit 1
+          fi
+          if hdiutil info | grep -Fq 'zuuli-macos-dmg-sign.'; then
+            echo "ephemeral DMG-signing image remained mounted after cleanup" >&2
+            exit 1
+          fi
+          if [[ -e "$RUNNER_TEMP/zuuli-macos-dmg-sign-cleanup-failed" ]]; then
+            echo "DMG-signing credential cleanup or keychain restoration failed" >&2
+            exit 1
+          fi
+      - name: Materialize, notarize DMG, and destroy ephemeral ASC credential
+        id: package
+        env:
+          ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}
+          RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}
+          RELEASE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          UNSIGNED_APP_SHA256: ${{ needs.macos-build.outputs.artifact_sha256 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          : "${ASC_KEY_BASE64:?ASC_KEY_BASE64 is not configured}"
+          : "${ASC_KEY_ID:?ASC_KEY_ID is not configured}"
+          : "${ASC_ISSUER_ID:?ASC_ISSUER_ID is not configured}"
+          secret_dir=$(mktemp -d "$RUNNER_TEMP/zuuli-macos-dmg-notary.XXXXXX")
+          cleanup() { find "$secret_dir" -depth -delete 2>/dev/null || true; }
+          trap cleanup EXIT
+          printf '%s' "$ASC_KEY_BASE64" | base64 --decode > "$secret_dir/AuthKey.p8"
+          dmg="signed-macos/ZUULI-${RELEASE_IDENTITY}-macos.dmg"
+          xcrun notarytool submit "$dmg" --wait \
+            --key "$secret_dir/AuthKey.p8" --key-id "$ASC_KEY_ID" --issuer "$ASC_ISSUER_ID"
+          xcrun stapler staple "$dmg"
+          xcrun stapler validate "$dmg"
+          ditto -c -k --sequesterRsrc --keepParent "$ZUULI_SIGNED_APP" \
+            "signed-macos/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip"
+          app_sha256=$(shasum -a 256 "signed-macos/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" | awk '{print $1}')
+          dmg_sha256=$(shasum -a 256 "$dmg" | awk '{print $1}')
+          jq -n --arg identity "$RELEASE_IDENTITY" --arg sourceSha "$RELEASE_SOURCE_SHA" \
+            --arg unsignedAppSha256 "$UNSIGNED_APP_SHA256" --arg appSha256 "$app_sha256" --arg dmgSha256 "$dmg_sha256" \
+            '{schemaVersion:1,identity:$identity,sourceSha:$sourceSha,kind:"macos-signed-notarized",unsignedAppSha256:$unsignedAppSha256,appSha256:$appSha256,dmgSha256:$dmgSha256}' \
+            > signed-macos/signing-record.json
+          (cd signed-macos && shasum -a 256 ./* > CHECKSUMS.sha256)
+          artifact_sha256=$(shasum -a 256 signed-macos/CHECKSUMS.sha256 | awk '{print $1}')
+          echo "artifact_sha256=$artifact_sha256" >> "$GITHUB_OUTPUT"
+      - name: Destroy ephemeral DMG-notarization credential
+        if: always()
+        run: |
+          set -euo pipefail
+          if find "$RUNNER_TEMP" -maxdepth 1 -name 'zuuli-macos-dmg-notary.*' -print -quit | grep -q .; then
+            echo "ephemeral DMG-notarization directory survived cleanup" >&2
+            exit 1
+          fi
+      - name: Destroy all ephemeral Apple credentials
+        if: always()
+        run: |
+          set -euo pipefail
+          if find "$RUNNER_TEMP" -maxdepth 1 \( -name 'zuuli-macos-*-sign.*' -o -name 'zuuli-macos-*-notary.*' \) -print -quit | grep -q .; then
+            echo "ephemeral macOS Apple credential directory survived cleanup" >&2
+            exit 1
+          fi
+          if security list-keychains -d user | grep -Fq 'zuuli-macos-'; then
+            echo "ephemeral macOS Apple keychain survived cleanup" >&2
+            exit 1
+          fi
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: internal-zuuli-macos-signed-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: signed-macos
+          if-no-files-found: error
+          retention-days: 1
+
+  macos-finalize:
+    name: macOS / credential-free shipped-artifact provenance
+    needs: [prepare, macos-sign]
+    if: needs.macos-sign.result == 'success'
+    runs-on: macos-26
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    defaults:
+      run:
+        working-directory: wallet/zuuli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24.18.0"
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: internal-zuuli-macos-signed-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          path: wallet/zuuli/signed-macos
+      - name: Verify source-bound signed packages
+        env:
+          EXPECTED_PAYLOAD_SHA256: ${{ needs.macos-sign.outputs.artifact_sha256 }}
+          EXPECTED_IDENTITY: ${{ needs.prepare.outputs.identity }}
+          EXPECTED_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          test "$(shasum -a 256 signed-macos/CHECKSUMS.sha256 | awk '{print $1}')" = "$EXPECTED_PAYLOAD_SHA256"
+          (cd signed-macos && shasum -a 256 -c CHECKSUMS.sha256)
+          jq -e --arg identity "$EXPECTED_IDENTITY" --arg source "$EXPECTED_SOURCE_SHA" \
+            '.schemaVersion == 1 and .kind == "macos-signed-notarized" and .identity == $identity and .sourceSha == $source' \
+            signed-macos/signing-record.json
+          inspect=$(mktemp -d "$RUNNER_TEMP/zuuli-macos-verify.XXXXXX")
+          trap 'find "$inspect" -depth -delete' EXIT
+          ditto -x -k "signed-macos/ZUULI-${EXPECTED_IDENTITY}-macos-universal.zip" "$inspect"
+          apps=("$inspect"/*.app)
+          [[ ${#apps[@]} -eq 1 && -d "${apps[0]}" ]]
           codesign --verify --deep --strict --verbose=2 "${apps[0]}"
           signature=$(codesign -dvv "${apps[0]}" 2>&1)
           grep -F 'Authority=Developer ID Application: Corpora Inc (F9AV5HKF6N)' <<<"$signature"
           grep -F 'TeamIdentifier=F9AV5HKF6N' <<<"$signature"
-          unset signature
           xcrun stapler validate "${apps[0]}"
           spctl -a -vvv -t exec "${apps[0]}"
-          dmgs=()
-          while IFS= read -r -d '' path; do dmgs+=("$path"); done < <(find release-artifacts -type f -name '*.dmg' -print0)
-          [[ "${#dmgs[@]}" -eq 1 ]] || { echo "expected one DMG, found ${#dmgs[@]}" >&2; exit 1; }
-          codesign --verify --verbose=2 "${dmgs[0]}"
+          dmg="signed-macos/ZUULI-${EXPECTED_IDENTITY}-macos.dmg"
+          codesign --verify --verbose=2 "$dmg"
+          xcrun stapler validate "$dmg"
+          mountpoint="$inspect/dmg"
+          mkdir "$mountpoint"
+          mounted=false
+          cleanup_dmg() {
+            [[ "$mounted" != true ]] || hdiutil detach "$mountpoint" -force >/dev/null
+          }
+          trap 'cleanup_dmg; find "$inspect" -depth -delete' EXIT
+          hdiutil attach "$dmg" -readonly -nobrowse -mountpoint "$mountpoint" >/dev/null
+          mounted=true
+          [[ -d "$mountpoint/ZUULI.app" && ! -L "$mountpoint/ZUULI.app" ]]
+          [[ -L "$mountpoint/Applications" && "$(readlink "$mountpoint/Applications")" == /Applications ]]
+          codesign --verify --deep --strict --verbose=2 "$mountpoint/ZUULI.app"
+          xcrun stapler validate "$mountpoint/ZUULI.app"
+          hdiutil detach "$mountpoint" >/dev/null
+          mounted=false
+          mkdir release-artifacts
+          cp "$dmg" "signed-macos/ZUULI-${EXPECTED_IDENTITY}-macos-universal.zip" \
+            signed-macos/signing-record.json release-artifacts/
       - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
           {
@@ -790,7 +1382,7 @@ jobs:
       - name: Record checksums and provenance
         run: |
           jq -e '(.components // []) | length >= 50' release-artifacts/ZUULI-macos.sbom.cdx.json
-          npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
+          node scripts/release-manifest.mjs --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
       - uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
         with: { subject-path: "wallet/zuuli/release-artifacts/*" }
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -804,15 +1396,15 @@ jobs:
 
   release-index:
     name: Immutable GitHub release index
-    needs: [prepare, android, ios, linux, macos]
+    needs: [prepare, android, ios-finalize, linux, macos-finalize]
     if: >-
       always() && !cancelled() &&
       needs.prepare.result == 'success' &&
       needs.prepare.outputs.should_release == 'true' &&
       (needs.android.result == 'success' || needs.android.result == 'skipped') &&
-      (needs.ios.result == 'success' || needs.ios.result == 'skipped') &&
+      (needs.ios-finalize.result == 'success' || needs.ios-finalize.result == 'skipped') &&
       (needs.linux.result == 'success' || needs.linux.result == 'skipped') &&
-      (needs.macos.result == 'success' || needs.macos.result == 'skipped')
+      (needs.macos-finalize.result == 'success' || needs.macos-finalize.result == 'skipped')
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -74,10 +74,15 @@ repeat bootstrap work or substitute unrelated credentials.
 1. The explicit App ID `cash.free2z.zuuli` exists under team `F9AV5HKF6N`.
 2. App Store Connect app `6799322201` is `ZUULI`, bundle
    `cash.free2z.zuuli`, SKU `zuuli-ios`, with `en-US` localization.
-3. The protected environment contains the Admin ASC key, dedicated ZUULI Apple
-   Distribution certificate, and profile `ZUULI App Store CI`. CI verifies the
-   profile's team, application identifier, UUID, and certificate linkage before
-   it signs.
+3. The protected environment currently contains an Admin ASC key, dedicated
+   ZUULI Apple Distribution certificate, and profile `ZUULI App Store CI`. CI
+   verifies the profile's team, application identifier, UUID, and certificate
+   linkage before it signs. Admin is not accepted as the final least-privilege
+   state: an owner must replace it with the minimum App Store Connect role that
+   passes upload, build-status reconciliation, and internal-group assignment,
+   then record that protected-run evidence. Repository tests cannot prove the
+   external role, so Apple publication and issue closure remain blocked until
+   that owner-side evidence exists.
 4. Maintain exactly one internal TestFlight group named `ZUULI Internal Testers`.
    The name and internal-only requirement are fixed in
    `scripts/asc-testflight.mjs`; ordinary release and read-only recovery refuse
@@ -193,7 +198,7 @@ later reviewed screenshot/publication phase must add mocked provider writes and
 fresh readback before that stop can be replaced. Never dispatch it as evidence
 of publication while `publicationReady` is false.
 
-## Local signed dry run
+## Local release dry run
 
 Credentials are paths or environment values; never paste a private key, service
 account document, seed phrase, or password into a command line. Disable shell
@@ -202,39 +207,36 @@ paths, a partial Android signing setup, and dirty source trees. Python 3 is a
 release prerequisite: the standard-library plist verifier preserves duplicate
 evidence that Apple's semantic plist tools discard.
 
-Apple variables:
+Apple signing is intentionally not available through a combined local build
+script. The protected workflow first runs every source/dependency-controlled
+step in jobs that cannot access the protected environment: iOS produces a
+`--no-sign --archive-only` archive and macOS produces a `--no-sign` universal
+app plus the Tauri-created DMG layout. Those source-bound artifacts carry
+checksums and attestations before entering a signing job.
 
-```text
-APPLE_TEAM_ID
-ASC_KEY_ID
-ASC_ISSUER_ID
-ASC_KEY_PATH                 path to the .p8 file
-ZUULI_PREFLIGHT_KEYCHAIN     path to an unlocked, ephemeral signing keychain
-IOS_MOBILE_PROVISION         base64-encoded ZUULI App Store CI profile
-```
+The signing jobs do not check out source and never run npm, Cargo, Tauri,
+CocoaPods, an Xcode build/archive action, or a project build hook. iOS uses only
+`xcodebuild -exportArchive`; macOS uses `codesign`, `hdiutil`, `notarytool`, and
+`stapler`, replacing the app inside the reviewed unsigned DMG so the Tauri
+layout is preserved. Distribution and App Store Connect credentials are
+materialized as separate classes immediately before their operation and are
+unconditionally destroyed before artifact upload. Separate credential-free
+jobs then verify the shipped packages, generate SBOM/checksum/provenance files,
+and attest the result.
 
-The protected release validates that the certificate, profile, team, and App ID
-are linked, removes the decoded PKCS#12 file, and keeps the unlocked ephemeral
-keychain in the user search list through Tauri and Xcode export. The import ACL
-trusts only `codesign` and `xcodebuild`. Tauri receives only the provisioning
-profile—not the distribution P12 and not the ASC API credentials—so Xcode signs
-the archive directly and neither Tauri 2.11.4 PKCS#12-import path can run. This
-avoids the path that could not read this dedicated P12 on macOS 26. The release
-script rejects certificate variables and Tauri-facing `APPLE_API_*` variables,
-proves the dedicated identity is still present and discoverable, prepares every
-signing key that Tauri updates in a validated generated-project shape, then
-restores the
-committed Automatic-debug project byte-for-byte after the build. The resulting
-IPA is unpacked and its exact embedded profile, distribution signature,
-certificate linkage, signed entitlements, and packaged encryption declaration
-are verified before Apple validation or upload. The plist verifier rejects
+The iOS generated project is still prepared in its validated manual-signing
+shape before the unsigned archive and restored to the committed
+Automatic-debug shape byte-for-byte afterward. The signed IPA is unpacked and
+its exact protected-profile digest, distribution signature, certificate
+linkage, signed entitlements, and packaged encryption declaration are verified
+before Apple validation or upload. The plist verifier rejects
 duplicate root keys before semantic decoding: it walks XML dictionary entries
 directly and, for binary plists, inspects the raw object table and dictionary key
 references. This matters because `plutil` and ordinary plist decoders collapse
 duplicate keys and can disagree about which value wins. Both same-value and
 conflicting duplicates are invalid; no binary duplicate ambiguity is accepted.
-The workflow then restores the original keychain search list and fails if the
-keychain, installed profile, or credential directory survives cleanup.
+Each credential operation uses a dedicated temporary keychain/directory and
+fails if any keychain, installed profile, or credential directory survives.
 
 The implicit-format import regression is reported upstream as
 [`tauri-apps/tauri#15843`](https://github.com/tauri-apps/tauri/issues/15843).
@@ -269,7 +271,6 @@ installed:
 npm ci
 /opt/homebrew/opt/ruby/bin/bundle install # Android upload tooling on this Mac
 npm run release:verify
-scripts/mobile-release.sh ios
 scripts/mobile-release.sh android
 ```
 
@@ -300,11 +301,10 @@ must both be confirmed:
 ```bash
 export ZUULI_RELEASE_SOURCE_SHA="$(git rev-parse HEAD)"
 export ZUULI_CONFIRM_UPLOAD="$(jq -er '.version + "+" + (.build | tostring)' release.json)"
-scripts/mobile-release.sh ios --upload
 scripts/mobile-release.sh android --upload
 ```
 
-The iOS upload command does not stop at Transporter acceptance. After `altool`
+The protected iOS upload job does not stop at Transporter acceptance. After `altool`
 accepts the IPA, it polls the exact app `6799322201`, bundle
 `cash.free2z.zuuli`, marketing version, iOS platform, and build number for at
 most 45 minutes. It records `uploaded`, `processed`, and
@@ -364,8 +364,22 @@ base64 < "$PLAY_SERVICE_ACCOUNT_JSON" | tr -d '\n' | \
 ```
 
 The final two are needed only for direct-download macOS signing/notarization.
-Base64 values are decoded only into mode-0700 runner-temporary directories and
-destroyed even when a job fails. GitHub never exports store secrets into a PR.
+Base64 values are decoded only inside the system-tool credential jobs into
+mode-0700 runner-temporary directories and destroyed even when a job fails.
+Dependency-controlled build jobs neither reference the protected environment
+nor contain secret expressions. GitHub never exports store secrets into a PR.
+`scripts/apple-credential-boundary.mjs` parses the workflow as YAML nodes,
+rejects aliases, anchors, tagged/explicit/duplicate keys, and permits only the
+named secret set for each credential job. The three Apple credential jobs are
+also sealed by reviewed whole-job digests: changing a step, action input, shell,
+or command requires reviewing the complete credential execution program and
+updating its digest. The workflow root is a closed authority envelope: its
+trigger, permissions, serialization, inherited environment, and exact job set
+are bound, and reusable-workflow jobs or inherited secret forwarding are
+forbidden. Their downloaded payloads must contain exactly the
+canonical manifested members before any credential is materialized; the
+separately attested TestFlight reconciliation helper is the sole project script
+allowed to execute in a credential-bearing job.
 
 1. Re-derive [`../STATUS.md`](../STATUS.md) from the candidate source and current
    production/native evidence. Every visible **known broken/incomplete** path
@@ -420,8 +434,10 @@ destroyed even when a job fails. GitHub never exports store secrets into a PR.
    can rebuild or upload. The read-only TestFlight observation below
    intentionally accepts an exact identity-establishing SHA that remains on
    `main`, including a superseded build, because it cannot change App Store
-   Connect. Desktop `dry_run=true` packaging does not load signing credentials or
-   contact Apple's notarization service.
+   Connect. Desktop `dry_run=true` still signs and notarizes the macOS packages,
+   because notarization is part of shipped-artifact validation; it suppresses
+   publication of the draft GitHub release, not Apple credential use or contact
+   with Apple's notarization service.
 6. Optionally create an annotated (preferably signed) tag on that exact remote
    commit as `zuuli-v<VERSION>+<BUILD>`. If the matching tag exists before a
    manual recovery run, the workflow also maintains an idempotent draft GitHub

--- a/wallet/zuuli/package-lock.json
+++ b/wallet/zuuli/package-lock.json
@@ -61,7 +61,8 @@
         "tailwindcss": "^3.4.0",
         "typescript": "^5.6.0",
         "vite": "^6.0.0",
-        "vitest": "^3.2.7"
+        "vitest": "^3.2.7",
+        "yaml": "2.9.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -9389,6 +9390,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zustand": {
       "version": "5.0.14",

--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -8,9 +8,10 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs scripts/auth-session-boundary.node-test.mjs scripts/mermaid-security.node-test.mjs scripts/send-review-boundary.node-test.mjs && playwright test",
+    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs scripts/auth-session-boundary.node-test.mjs scripts/mermaid-security.node-test.mjs scripts/send-review-boundary.node-test.mjs scripts/apple-credential-boundary.node-test.mjs && node scripts/apple-credential-boundary.mjs && playwright test",
     "test:mermaid-security": "node scripts/check-mermaid-security.mjs && node --test scripts/mermaid-security.node-test.mjs && playwright test tests/mermaid-security.pw.ts",
     "test:send-review": "node --test scripts/send-review-boundary.node-test.mjs && playwright test tests/send-review.pw.ts",
+    "test:apple-credential-boundary": "node --test scripts/apple-credential-boundary.node-test.mjs && node scripts/apple-credential-boundary.mjs",
     "test:viewport": "playwright test tests/viewport.pw.ts",
     "test:asc-testflight": "node --test scripts/asc-testflight.node-test.mjs",
     "test:store-listing": "node --test scripts/store-contract.node-test.mjs scripts/store-state-audit.node-test.mjs",
@@ -77,6 +78,7 @@
     "tailwindcss": "^3.4.0",
     "typescript": "^5.6.0",
     "vite": "^6.0.0",
-    "vitest": "^3.2.7"
+    "vitest": "^3.2.7",
+    "yaml": "2.9.0"
   }
 }

--- a/wallet/zuuli/scripts/apple-credential-boundary.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.mjs
@@ -1,0 +1,471 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { isAlias, isMap, isScalar, isSeq, parseDocument } from "yaml";
+
+const BUILD_JOBS = ["ios-build", "macos-build"];
+const CREDENTIAL_JOBS = ["ios-sign", "ios-upload", "macos-sign"];
+const FINALIZE_JOBS = ["ios-verify", "ios-finalize", "macos-finalize"];
+const RELEASE_JOBS = [
+  "prepare",
+  "android",
+  "ios-build",
+  "ios-sign",
+  "ios-verify",
+  "ios-upload",
+  "ios-finalize",
+  "linux",
+  "macos-build",
+  "macos-sign",
+  "macos-finalize",
+  "release-index",
+];
+const ROOT_KEYS = ["name", "on", "permissions", "concurrency", "env", "jobs"];
+const ALLOWED_JOB_SECRETS = new Map([
+  ["android", new Set([
+    "ANDROID_KEYSTORE_BASE64",
+    "PLAY_SERVICE_ACCOUNT_JSON_BASE64",
+    "ANDROID_KEYSTORE_PASSWORD",
+    "ANDROID_KEY_ALIAS",
+    "ANDROID_KEY_PASSWORD",
+  ])],
+  ["ios-sign", new Set([
+    "APPLE_DISTRIBUTION_CERTIFICATE_BASE64",
+    "APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD",
+    "APPLE_PROVISIONING_PROFILE_BASE64",
+  ])],
+  ["ios-upload", new Set(["ASC_KEY_BASE64"])],
+  ["macos-sign", new Set([
+    "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64",
+    "APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD",
+    "ASC_KEY_BASE64",
+  ])],
+]);
+
+// Each protected job is an exact reviewed execution program. These hashes are
+// deliberately opaque tripwires: any step, action input, interpreter, shell,
+// job-level default, or command change requires a visible policy update. The
+// semantic checks below explain the major boundaries, while the digest closes
+// all unenumerated execution paths. Update only after reviewing the full job.
+const CREDENTIAL_JOB_SHA256 = new Map([
+  ["ios-sign", "b2143be25eeb91c95c1f5f9b5feb70410fd791ca46ae7fce1e0561f713dbfe29"],
+  ["ios-upload", "d2372e34e07fbf31f64b950484a2168c78bcf35261e1858efd26f477f88c963c"],
+  ["macos-sign", "e177d4b9121dae642dd922bb252220bff43b64dff15981ce36bcd06e65ae0df4"],
+]);
+
+// These four inherited/root controls sit outside the protected job nodes but
+// can change when or how they execute. Bind their exact reviewed YAML source so
+// triggers, global permissions, serialization, and inherited environment
+// cannot drift around the credential-job program seals.
+const ROOT_AUTHORITY_SHA256 = new Map([
+  ["on", "c58b4535da1019427311bdfdc1bcc62d083a9458e4d9746f1e8ee0e841b23ebe"],
+  ["permissions", "248e857abefa9bcd48e29bf205c0ba2260ad4c167937fe37b5506afec6569d6c"],
+  ["concurrency", "9e63d742d3a1d8bf26f2f8d8b77427f2bac2d28142d17eecaa75fafc7f95f4f5"],
+  ["env", "d905f9175e5d70ba3b4459bae14bc895f75b97bfb48b91ff764c2d9c382386ca"],
+]);
+
+function requireText(failures, label, source, needle) {
+  if (!source.includes(needle)) failures.push(`${label} is missing ${JSON.stringify(needle)}`);
+}
+
+function rejectText(failures, label, source, needle) {
+  if (source.includes(needle)) failures.push(`${label} contains forbidden ${JSON.stringify(needle)}`);
+}
+
+function secretExpressions(source) {
+  return [...source.matchAll(/\$\{\{[\s\S]*?\}\}/g)]
+    .filter((match) => /\bsecrets\b/i.test(match[0]));
+}
+
+function scalarKey(pair) {
+  return isScalar(pair?.key) && typeof pair.key.value === "string" ? pair.key.value : null;
+}
+
+function pairFor(map, key) {
+  return isMap(map) ? map.items.find((pair) => scalarKey(pair) === key) : undefined;
+}
+
+function sourceForNode(workflow, node) {
+  return node?.range ? workflow.slice(node.range[0], node.range[2]) : "";
+}
+
+function sha256(source) {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+function inspectYamlNode(node, failures, path = "workflow") {
+  if (!node) return;
+  if (node.anchor) failures.push(`${path} contains forbidden YAML anchor ${JSON.stringify(node.anchor)}`);
+  if (isAlias(node)) {
+    failures.push(`${path} contains forbidden YAML alias ${JSON.stringify(node.source)}`);
+    return;
+  }
+  if (isMap(node)) {
+    for (const [index, pair] of node.items.entries()) {
+      const token = node.srcToken?.items?.[index];
+      if (token?.explicitKey) failures.push(`${path} contains forbidden explicit YAML mapping key`);
+      if (!isScalar(pair.key) || typeof pair.key.value !== "string") {
+        failures.push(`${path} contains a non-string or complex YAML mapping key`);
+      } else if (pair.key.tag) {
+        failures.push(`${path}.${pair.key.value} contains forbidden tagged YAML mapping key`);
+      }
+      inspectYamlNode(pair.key, failures, `${path}.<key>`);
+      inspectYamlNode(pair.value, failures, `${path}.${scalarKey(pair) ?? "<complex>"}`);
+    }
+  } else if (isSeq(node)) {
+    node.items.forEach((item, index) => inspectYamlNode(item, failures, `${path}[${index}]`));
+  }
+}
+
+function parseWorkflow(workflow, failures) {
+  let document;
+  try {
+    document = parseDocument(workflow, {
+      keepSourceTokens: true,
+      prettyErrors: false,
+      strict: true,
+      uniqueKeys: true,
+    });
+  } catch (error) {
+    failures.push(`workflow YAML parser threw: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+  for (const error of document.errors) failures.push(`workflow YAML is invalid: ${error.message}`);
+  for (const warning of document.warnings) failures.push(`workflow YAML warning is forbidden: ${warning.message}`);
+  if (document.errors.length > 0 || document.warnings.length > 0) return null;
+  inspectYamlNode(document.contents, failures);
+  if (!isMap(document.contents)) {
+    failures.push("workflow root must be a YAML mapping");
+    return null;
+  }
+  const jobs = pairFor(document.contents, "jobs")?.value;
+  if (!isMap(jobs)) {
+    failures.push("workflow jobs must be a YAML mapping");
+    return null;
+  }
+  return { document, jobs };
+}
+
+export function credentialJobDigests(workflow) {
+  const failures = [];
+  const parsed = parseWorkflow(workflow, failures);
+  if (!parsed || failures.length > 0) throw new Error(failures.join("\n"));
+  return new Map(CREDENTIAL_JOBS.map((name) => {
+    const node = pairFor(parsed.jobs, name)?.value;
+    if (!node) throw new Error(`workflow is missing credential job ${name}`);
+    return [name, sha256(sourceForNode(workflow, node))];
+  }));
+}
+
+export function releaseAuthorityDigests(workflow) {
+  const failures = [];
+  const parsed = parseWorkflow(workflow, failures);
+  if (!parsed || failures.length > 0) throw new Error(failures.join("\n"));
+  return new Map([...ROOT_AUTHORITY_SHA256.keys()].map((name) => {
+    const node = pairFor(parsed.document.contents, name)?.value;
+    if (!node) throw new Error(`workflow is missing root authority ${name}`);
+    return [name, sha256(sourceForNode(workflow, node))];
+  }));
+}
+
+/**
+ * Enforce the source-level Apple release authority boundary.
+ *
+ * Build jobs may execute repository and dependency code, so they must have no
+ * protected environment or secret expressions. Credential jobs may use only
+ * already-built, checksum-verified artifacts and Apple/system release tools;
+ * they may not check out or build repository code. Finalization happens after
+ * credentials are destroyed in separate credential-free jobs.
+ */
+export function verifyAppleCredentialBoundary(
+  workflow,
+  {
+    credentialJobDigests = CREDENTIAL_JOB_SHA256,
+    rootAuthorityDigests = ROOT_AUTHORITY_SHA256,
+  } = {},
+) {
+  const failures = [];
+  const parsed = parseWorkflow(workflow, failures);
+  if (!parsed) return failures;
+  const jobNodes = new Map();
+  const jobs = new Map();
+  for (const pair of parsed.jobs.items) {
+    const name = scalarKey(pair);
+    if (name && pair.value) {
+      jobNodes.set(name, pair.value);
+      jobs.set(name, sourceForNode(workflow, pair.value));
+    }
+  }
+
+  const rootNames = parsed.document.contents.items.map((pair) => scalarKey(pair));
+  if (
+    rootNames.length !== ROOT_KEYS.length ||
+    ROOT_KEYS.some((name) => !rootNames.includes(name))
+  ) {
+    failures.push(`workflow root keys must be exactly ${ROOT_KEYS.join(", ")}`);
+  }
+  const workflowName = pairFor(parsed.document.contents, "name")?.value;
+  if (!isScalar(workflowName) || workflowName.value !== "ZUULI / protected release") {
+    failures.push("workflow name must be exactly ZUULI / protected release");
+  }
+  for (const [name, expectedDigest] of rootAuthorityDigests) {
+    const node = pairFor(parsed.document.contents, name)?.value;
+    const actualDigest = node ? sha256(sourceForNode(workflow, node)) : null;
+    if (actualDigest !== expectedDigest) {
+      failures.push(
+        `workflow root ${name} authority changed: expected ${expectedDigest}, got ${actualDigest ?? "missing"}`,
+      );
+    }
+  }
+
+  const actualJobNames = [...jobs.keys()];
+  if (
+    actualJobNames.length !== RELEASE_JOBS.length ||
+    RELEASE_JOBS.some((name) => !jobs.has(name))
+  ) {
+    failures.push(`workflow jobs must be exactly ${RELEASE_JOBS.join(", ")}`);
+  }
+  for (const [name, node] of jobNodes) {
+    if (pairFor(node, "uses")) failures.push(`${name} contains forbidden reusable-workflow uses`);
+    if (pairFor(node, "secrets")) failures.push(`${name} contains forbidden job-level secrets forwarding`);
+  }
+
+  for (const name of [...BUILD_JOBS, ...CREDENTIAL_JOBS, ...FINALIZE_JOBS]) {
+    if (!jobs.has(name)) failures.push(`workflow is missing required job ${name}`);
+  }
+  if (failures.length > 0) return failures;
+
+  // Preserve the immutable Linux image consumer contract without making the
+  // token available to any job step: exactly this container pull field may
+  // reference it, once.
+  const linuxContainer = pairFor(jobNodes.get("linux"), "container")?.value;
+  const linuxCredentials = pairFor(linuxContainer, "credentials")?.value;
+  const linuxPassword = pairFor(linuxCredentials, "password")?.value;
+  const linuxPasswordValue = isScalar(linuxPassword) ? linuxPassword.value : null;
+  if (linuxPasswordValue !== "${{ secrets.GITHUB_TOKEN }}") {
+    failures.push("linux container pull password must be exactly secrets.GITHUB_TOKEN");
+  }
+  let linuxPullCredentialOccurrences = 0;
+  for (const expression of secretExpressions(workflow)) {
+    const job = [...jobNodes].find(([, node]) =>
+      node.range && expression.index >= node.range[0] && expression.index < node.range[2]
+    )?.[0];
+    const body = expression[0].slice(3, -2).trim();
+    const exact = body.match(/^secrets\.([A-Z0-9_]+)$/);
+    const isLinuxPullCredential =
+      job === "linux" &&
+      exact?.[1] === "GITHUB_TOKEN" &&
+      linuxPassword?.range &&
+      expression.index >= linuxPassword.range[0] &&
+      expression.index < linuxPassword.range[2];
+    if (isLinuxPullCredential) linuxPullCredentialOccurrences += 1;
+    const allowed =
+      isLinuxPullCredential ||
+      (job && exact && ALLOWED_JOB_SECRETS.get(job)?.has(exact[1]));
+    if (!allowed) {
+      failures.push(
+        `${job ?? "workflow"} contains unauthorized secrets-context expression ${JSON.stringify(expression[0])}`,
+      );
+    }
+  }
+  if (linuxPullCredentialOccurrences !== 1) {
+    failures.push(
+      `linux container pull credential must occur exactly once, found ${linuxPullCredentialOccurrences}`,
+    );
+  }
+  for (const name of BUILD_JOBS) {
+    const source = jobs.get(name);
+    if (pairFor(jobNodes.get(name), "environment")) failures.push(`${name} contains forbidden protected environment`);
+    requireText(failures, name, source, "actions/checkout@");
+    requireText(failures, name, source, "--no-sign");
+    requireText(failures, name, source, "actions/attest-build-provenance@");
+    requireText(failures, name, source, "actions/upload-artifact@");
+    const canary = "scripts/assert-no-apple-credentials.sh";
+    const firstCanary = source.indexOf(canary);
+    const dependencyInstall = source.indexOf("npm ci");
+    const unsignedBuild = source.indexOf("--no-sign");
+    const lastCanary = source.lastIndexOf(canary);
+    if (!(firstCanary >= 0 && firstCanary < dependencyInstall)) {
+      failures.push(`${name} must run the Apple credential canary before dependency install`);
+    }
+    if (!(unsignedBuild >= 0 && unsignedBuild < lastCanary)) {
+      failures.push(`${name} must run the Apple credential canary after the unsigned build`);
+    }
+  }
+
+  for (const name of CREDENTIAL_JOBS) {
+    const source = jobs.get(name);
+    const environment = pairFor(jobNodes.get(name), "environment")?.value;
+    if (!isScalar(environment) || environment.value !== "zuuli-app-stores") {
+      failures.push(`${name} must use exactly the protected zuuli-app-stores environment`);
+    }
+    const expectedDigest = credentialJobDigests.get(name);
+    const actualDigest = sha256(source);
+    if (!expectedDigest || actualDigest !== expectedDigest) {
+      failures.push(
+        `${name} credential execution program changed: expected ${expectedDigest ?? "no digest"}, got ${actualDigest}`,
+      );
+    }
+    requireText(failures, name, source, "actions/download-artifact@");
+    rejectText(failures, name, source, "actions/checkout@");
+    for (const forbidden of [
+      "npm ci",
+      "npm install",
+      "cargo ",
+      "./node_modules/",
+      "tauri ",
+      "pod install",
+      "xcodebuild archive",
+      "xcodebuild build",
+      "node scripts/",
+      "scripts/",
+      "uses: ./.github/actions/",
+      "actions/cache@",
+    ]) {
+      rejectText(failures, name, source, forbidden);
+    }
+    const firstSecret = secretExpressions(source)[0]?.index ?? -1;
+    const download = source.indexOf("actions/download-artifact@");
+    const verification = source.indexOf("Verify source-bound artifact");
+    if (!(download >= 0 && download < verification && verification < firstSecret)) {
+      failures.push(`${name} must verify its downloaded artifact before any secrets-context expression`);
+    }
+    const expressions = secretExpressions(source);
+    const lastExpression = expressions.at(-1);
+    const lastSecret = lastExpression ? lastExpression.index : -1;
+    const lastDestroy = Math.max(
+      source.lastIndexOf("Destroy ephemeral"),
+      source.lastIndexOf("Destroy all ephemeral"),
+    );
+    const upload = source.lastIndexOf("actions/upload-artifact@");
+    if (!(lastSecret < lastDestroy && lastDestroy < upload)) {
+      failures.push(`${name} must destroy every credential class before artifact upload`);
+    }
+    requireText(failures, name, source, "if: always()");
+  }
+
+  for (const name of FINALIZE_JOBS) {
+    const source = jobs.get(name);
+    if (pairFor(jobNodes.get(name), "environment")) failures.push(`${name} contains forbidden protected environment`);
+    requireText(failures, name, source, "actions/download-artifact@");
+    requireText(failures, name, source, "actions/attest-build-provenance@");
+    requireText(failures, name, source, "actions/upload-artifact@");
+  }
+
+  rejectText(
+    failures,
+    "iOS signer",
+    jobs.get("ios-sign"),
+    "ASC_KEY_BASE64: ${{ secrets.ASC_KEY_BASE64 }}",
+  );
+  rejectText(
+    failures,
+    "iOS uploader",
+    jobs.get("ios-upload"),
+    "APPLE_DISTRIBUTION_CERTIFICATE_BASE64",
+  );
+  requireText(failures, "iOS signer", jobs.get("ios-sign"), "xcodebuild -exportArchive");
+  requireText(
+    failures,
+    "iOS unsigned builder",
+    jobs.get("ios-build"),
+    "ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256",
+  );
+  requireText(failures, "iOS signer", jobs.get("ios-sign"), "EXPECTED_PAYLOAD_SHA256");
+  requireText(
+    failures,
+    "iOS signer",
+    jobs.get("ios-sign"),
+    'test "$(shasum -a 256 unsigned-ios/CHECKSUMS.sha256',
+  );
+  requireText(
+    failures,
+    "iOS signer",
+    jobs.get("ios-sign"),
+    "(cd unsigned-ios && shasum -a 256 -c CHECKSUMS.sha256)",
+  );
+  requireText(
+    failures,
+    "iOS signer",
+    jobs.get("ios-sign"),
+    "gh attestation verify unsigned-ios/CHECKSUMS.sha256",
+  );
+  requireText(failures, "iOS signer", jobs.get("ios-sign"), "original-keychains.txt");
+  requireText(failures, "iOS signer", jobs.get("ios-sign"), "cleanup-failed");
+  requireText(
+    failures,
+    "iOS signer",
+    jobs.get("ios-sign"),
+    'if [[ -n "$profile_path" ]] && ! rm -f -- "$profile_path"',
+  );
+  requireText(
+    failures,
+    "iOS signer",
+    jobs.get("ios-sign"),
+    'if [[ -e "$HOME/Library/MobileDevice/Provisioning Profiles/e5ead62c-83ec-4e54-abb6-4770833b5e0d.mobileprovision" ]]',
+  );
+  requireText(
+    failures,
+    "iOS uploader",
+    jobs.get("ios-upload"),
+    "gh attestation verify verified-ios/asc-testflight.mjs",
+  );
+  requireText(failures, "macOS signer", jobs.get("macos-sign"), "codesign");
+  requireText(failures, "macOS signer", jobs.get("macos-sign"), "xcrun notarytool submit");
+  requireText(
+    failures,
+    "macOS unsigned builder",
+    jobs.get("macos-build"),
+    "ZUULI.app.zip ZUULI-layout.dmg source-record.json > CHECKSUMS.sha256",
+  );
+  requireText(failures, "macOS signer", jobs.get("macos-sign"), "EXPECTED_PAYLOAD_SHA256");
+  requireText(
+    failures,
+    "macOS signer",
+    jobs.get("macos-sign"),
+    'test "$(shasum -a 256 unsigned-macos/CHECKSUMS.sha256',
+  );
+  requireText(
+    failures,
+    "macOS signer",
+    jobs.get("macos-sign"),
+    "(cd unsigned-macos && shasum -a 256 -c CHECKSUMS.sha256)",
+  );
+  requireText(
+    failures,
+    "macOS signer",
+    jobs.get("macos-sign"),
+    "gh attestation verify unsigned-macos/CHECKSUMS.sha256",
+  );
+  requireText(failures, "macOS signer", jobs.get("macos-sign"), "original-keychains.txt");
+  requireText(failures, "macOS signer", jobs.get("macos-sign"), "cleanup-failed");
+  requireText(
+    failures,
+    "macOS signer",
+    jobs.get("macos-sign"),
+    'if [[ "$mounted" == true ]] && ! hdiutil detach "$mountpoint" -force',
+  );
+  requireText(
+    failures,
+    "macOS signer",
+    jobs.get("macos-sign"),
+    "if hdiutil info | grep -Fq 'zuuli-macos-dmg-sign.'",
+  );
+
+  return failures;
+}
+
+async function main() {
+  const workflowUrl = new URL("../../../.github/workflows/zuuli-release.yml", import.meta.url);
+  const failures = verifyAppleCredentialBoundary(await readFile(workflowUrl, "utf8"));
+  if (failures.length > 0) {
+    console.error("Apple credential boundary verification failed:");
+    for (const failure of failures) console.error(`- ${failure}`);
+    process.exit(1);
+  }
+  console.log("Apple release build, credential, and finalization boundaries verified.");
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) await main();

--- a/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
@@ -1,0 +1,628 @@
+import assert from "node:assert/strict";
+import { lstat, mkdtemp, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { parseDocument } from "yaml";
+
+import {
+  credentialJobDigests,
+  releaseAuthorityDigests,
+  verifyAppleCredentialBoundary,
+} from "./apple-credential-boundary.mjs";
+
+const buildJob = (name, command) => {
+  const checksumMembers = name === "ios-build"
+    ? "ZUULI.xcarchive.zip ExportOptions.plist source-record.json"
+    : "ZUULI.app.zip ZUULI-layout.dmg source-record.json";
+  return `  ${name}:
+    steps:
+      - uses: actions/checkout@sha
+      - run: scripts/assert-no-apple-credentials.sh
+      - run: npm ci
+      - run: |
+          ${command} --no-sign
+          shasum -a 256 ${checksumMembers} > CHECKSUMS.sha256
+      - run: scripts/assert-no-apple-credentials.sh
+      - uses: actions/attest-build-provenance@sha
+      - uses: actions/upload-artifact@sha
+`;
+};
+
+const credentialJob = (name, command, secret) => {
+  const selectedSecret = secret ?? (name === "ios-sign"
+    ? "APPLE_DISTRIBUTION_CERTIFICATE_BASE64"
+    : "APPLE_DEVELOPER_ID_CERTIFICATE_BASE64");
+  const trustMarker = name === "ios-upload"
+    ? "          gh attestation verify verified-ios/asc-testflight.mjs --repo repo"
+    : name === "ios-sign"
+      ? "          EXPECTED_PAYLOAD_SHA256=fixture\n          test \"$(shasum -a 256 unsigned-ios/CHECKSUMS.sha256 | awk '{print $1}')\" = \"$EXPECTED_PAYLOAD_SHA256\"\n          (cd unsigned-ios && shasum -a 256 -c CHECKSUMS.sha256)\n          gh attestation verify unsigned-ios/CHECKSUMS.sha256 --repo repo"
+      : name === "macos-sign"
+        ? "          EXPECTED_PAYLOAD_SHA256=fixture\n          test \"$(shasum -a 256 unsigned-macos/CHECKSUMS.sha256 | awk '{print $1}')\" = \"$EXPECTED_PAYLOAD_SHA256\"\n          (cd unsigned-macos && shasum -a 256 -c CHECKSUMS.sha256)\n          gh attestation verify unsigned-macos/CHECKSUMS.sha256 --repo repo"
+        : "          echo verified";
+  const cleanupMarkers = name === "ios-sign" || name === "macos-sign"
+    ? name === "ios-sign"
+      ? "          echo original-keychains.txt cleanup-failed\n          if [[ -n \"$profile_path\" ]] && ! rm -f -- \"$profile_path\"; then echo cleanup; fi\n          if [[ -e \"$HOME/Library/MobileDevice/Provisioning Profiles/e5ead62c-83ec-4e54-abb6-4770833b5e0d.mobileprovision\" ]]; then echo survived; fi"
+      : "          echo original-keychains.txt cleanup-failed\n          if [[ \"$mounted\" == true ]] && ! hdiutil detach \"$mountpoint\" -force; then echo cleanup; fi\n          if hdiutil info | grep -Fq 'zuuli-macos-dmg-sign.'; then echo mounted; fi"
+    : "          echo cleanup";
+  return `  ${name}:
+    environment: zuuli-app-stores
+    steps:
+      - uses: actions/download-artifact@sha
+      - name: Verify source-bound artifact
+        run: |
+          shasum -a 256 -c artifact.sha256
+${trustMarker}
+      - name: Materialize
+        env:
+          VALUE: \${{ secrets.${selectedSecret} }}
+        run: echo materialized
+      - name: Operate
+        run: ${command}
+      - name: Destroy ephemeral credential
+        if: always()
+        run: |
+          echo destroyed
+${cleanupMarkers}
+      - uses: actions/upload-artifact@sha
+`;
+};
+
+const finalizeJob = (name) => `  ${name}:
+    steps:
+      - uses: actions/download-artifact@sha
+      - uses: actions/attest-build-provenance@sha
+      - uses: actions/upload-artifact@sha
+`;
+
+const validWorkflow = `name: ZUULI / protected release
+on:
+  push:
+    branches: [main]
+    paths: [wallet/zuuli/release.json]
+  workflow_dispatch: {}
+permissions:
+  contents: read
+concurrency:
+  group: zuuli-mobile-store
+  cancel-in-progress: false
+env:
+  CI: true
+  ZUULI_NODE_VERSION: "24.18.0"
+  ZUULI_RUST_VERSION: "1.97.1"
+  ZUULI_JAVA_VERSION: "21.0.12"
+  ZUULI_XCODE_VERSION: "26.6"
+  ZUULI_ANDROID_NDK_VERSION: "27.0.12077973"
+jobs:
+  prepare:
+    steps: []
+  android:
+    env:
+      KEYSTORE: \${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+${buildJob("ios-build", "tauri ios build --archive-only")}
+${credentialJob("ios-sign", "xcodebuild -exportArchive")}
+${finalizeJob("ios-verify")}
+${credentialJob("ios-upload", "xcrun altool --upload-app", "ASC_KEY_BASE64")}
+${finalizeJob("ios-finalize")}
+${buildJob("macos-build", "tauri build")}
+${credentialJob("macos-sign", "codesign app && xcrun notarytool submit app")}
+${finalizeJob("macos-finalize")}
+  linux:
+    container:
+      credentials:
+        password: \${{ secrets.GITHUB_TOKEN }}
+  release-index:
+    steps: []
+`;
+
+const credentialEscapeWorkflow = `name: Credential escape fixture
+on:
+  workflow_call:
+jobs:
+  escape:
+    runs-on: macos-15
+    environment: zuuli-app-stores
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Run project hook with inherited Apple authority
+        env:
+          ASC_KEY_BASE64: \${{ secrets.ASC_KEY_BASE64 }}
+        run: wallet/zuuli/scripts/project-hook.sh
+`;
+
+const fixtureCredentialJobDigests = credentialJobDigests(validWorkflow);
+const fixtureRootAuthorityDigests = releaseAuthorityDigests(validWorkflow);
+const verifyFixture = (source) => verifyAppleCredentialBoundary(source, {
+  credentialJobDigests: fixtureCredentialJobDigests,
+  rootAuthorityDigests: fixtureRootAuthorityDigests,
+});
+
+test("accepts separated source, credential, and finalization jobs", () => {
+  assert.deepEqual(verifyFixture(validWorkflow), []);
+});
+
+test("rejects the actionlint-valid two-file reusable-workflow escape", () => {
+  const caller = validWorkflow.replace(
+    "  release-index:\n",
+    "  credential-escape:\n    uses: ./.github/workflows/credential-escape.yml\n    secrets: inherit\n  release-index:\n",
+  );
+  assert.equal(parseDocument(caller).errors.length, 0);
+  assert.equal(parseDocument(credentialEscapeWorkflow).errors.length, 0);
+  assert.match(credentialEscapeWorkflow, /environment: zuuli-app-stores/);
+  assert.match(credentialEscapeWorkflow, /wallet\/zuuli\/scripts\/project-hook\.sh/);
+  const failures = verifyFixture(caller);
+  assert.ok(failures.some((failure) => failure.includes("workflow jobs must be exactly")), failures.join("\n"));
+  assert.ok(
+    failures.some((failure) => failure.includes("credential-escape contains forbidden reusable-workflow uses")),
+    failures.join("\n"),
+  );
+  assert.ok(
+    failures.some((failure) => failure.includes("credential-escape contains forbidden job-level secrets forwarding")),
+    failures.join("\n"),
+  );
+});
+
+for (const [name, mutate, expected] of [
+  [
+    "rejects a protected build environment",
+    (source) => source.replace("  ios-build:\n", "  ios-build:\n    environment: zuuli-app-stores\n"),
+    "ios-build contains forbidden protected environment",
+  ],
+  [
+    "rejects a secret in dependency-controlled build",
+    (source) => source.replace(
+      "  ios-build:\n",
+      "  ios-build:\n    env:\n      LEAK: ${{ secrets.ASC_KEY_BASE64 }}\n",
+    ),
+    "ios-build contains unauthorized secrets-context expression",
+  ],
+  [
+    "rejects a build without a pre-install credential canary",
+    (source) => source.replace(
+      "      - run: scripts/assert-no-apple-credentials.sh\n      - run: npm ci",
+      "      - run: npm ci",
+    ),
+    "ios-build must run the Apple credential canary before dependency install",
+  ],
+  [
+    "rejects a build without a post-build credential canary",
+    (source) => source.replace(
+      "          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256\n      - run: scripts/assert-no-apple-credentials.sh",
+      "          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256",
+    ),
+    "ios-build must run the Apple credential canary after the unsigned build",
+  ],
+  [
+    "rejects source checkout in a signer",
+    (source) => source.replace(
+      "      - uses: actions/download-artifact@sha\n",
+      "      - uses: actions/checkout@sha\n      - uses: actions/download-artifact@sha\n",
+    ),
+    "ios-sign contains forbidden \"actions/checkout@\"",
+  ],
+  [
+    "rejects a Tauri rebuild in a signer",
+    (source) => source.replace("run: xcodebuild -exportArchive", "run: tauri ios build && xcodebuild -exportArchive"),
+    "ios-sign contains forbidden \"tauri \"",
+  ],
+  [
+    "rejects secrets before artifact verification",
+    (source) => source.replace("      - uses: actions/download-artifact@sha\n", ""),
+    "must verify its downloaded artifact before any secrets-context expression",
+  ],
+  [
+    "rejects finalization before cleanup",
+    (source) => source.replace(
+      "      - name: Destroy ephemeral credential\n",
+      "      - name: Leave ephemeral credential in place\n",
+    ),
+    "must destroy every credential class before artifact upload",
+  ],
+  [
+    "rejects a later credential class after the last cleanup",
+    (source) => source.replace(
+      "\n  ios-verify:",
+      "\n      - env:\n          LATE_SECRET: ${{ secrets.LATE_SECRET }}\n        run: echo late\n\n  ios-verify:",
+    ),
+    "must destroy every credential class before artifact upload",
+  ],
+  [
+    "rejects a secret in credential-free signed-artifact verification",
+    (source) => source.replace(
+      "  ios-verify:\n",
+      "  ios-verify:\n    env:\n      LEAK: ${{ secrets.ASC_KEY_BASE64 }}\n",
+    ),
+    "ios-verify contains unauthorized secrets-context expression",
+  ],
+  [
+    "rejects an uploader that does not provenance-verify its reconciliation helper",
+    (source) => source.replace(
+      "          gh attestation verify verified-ios/asc-testflight.mjs --repo repo\n",
+      "",
+    ),
+    "iOS uploader is missing \"gh attestation verify verified-ios/asc-testflight.mjs\"",
+  ],
+  [
+    "rejects an iOS signer without keychain restoration evidence",
+    (source) => source.replace("          echo original-keychains.txt cleanup-failed\n", ""),
+    "iOS signer is missing \"original-keychains.txt\"",
+  ],
+  [
+    "rejects a macOS signer without keychain restoration evidence",
+    (source) => source.replaceAll("          echo original-keychains.txt cleanup-failed\n", ""),
+    "macOS signer is missing \"original-keychains.txt\"",
+  ],
+  [
+    "rejects a workflow-global secret context",
+    (source) => source.replace("  CI: true\n", "  CI: true\n  LEAK: ${{ secrets.GLOBAL }}\n"),
+    "workflow root env authority changed",
+  ],
+  [
+    "rejects bracket secret syntax in an unsigned build",
+    (source) => source.replace(
+      "  ios-build:\n",
+      "  ios-build:\n    env:\n      LEAK: ${{ secrets['APPLE_SECRET'] }}\n",
+    ),
+    "ios-build contains unauthorized secrets-context expression",
+  ],
+  [
+    "rejects function-wrapped secret context in finalization",
+    (source) => source.replace(
+      "  ios-finalize:\n",
+      "  ios-finalize:\n    env:\n      LEAK: ${{ toJSON(secrets) }}\n",
+    ),
+    "ios-finalize contains unauthorized secrets-context expression",
+  ],
+  [
+    "rejects YAML aliases that can obscure credential inheritance",
+    (source) => source.replace("jobs:\n", "x-secret: &apple_secret ${{ secrets.VALUE }}\njobs:\n"),
+    "contains forbidden YAML anchor",
+  ],
+  [
+    "rejects an Apple secret smuggled into the Android credential job",
+    (source) => source.replace(
+      "      KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n",
+      "      KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n      APPLE_LEAK: ${{ secrets.ASC_KEY_BASE64 }}\n",
+    ),
+    "android contains unauthorized secrets-context expression \"${{ secrets.ASC_KEY_BASE64 }}\"",
+  ],
+  [
+    "rejects a flow anchor in Android aliased into the unsigned iOS build",
+    (source) => source
+      .replace(
+        "      KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n",
+        "      KEYSTORE: &apple ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n",
+      )
+      .replace("  ios-build:\n", "  ios-build:\n    env: { APPLE_LEAK: *apple }\n"),
+    "contains forbidden YAML alias",
+  ],
+  ...[
+    ["numeric", "1"],
+    ["dotted", "apple.key"],
+    ["leading-hyphen", "-apple"],
+  ].map(([label, anchor]) => [
+    `rejects an actionlint-valid ${label} anchor and alias`,
+    (source) => source
+      .replace(
+        "      KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n",
+        `      KEYSTORE: &${anchor} \${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n`,
+      )
+      .replace("  ios-build:\n", `  ios-build:\n    env: { APPLE_LEAK: *${anchor} }\n`),
+    "contains forbidden YAML",
+  ]),
+  [
+    "rejects an explicit protected-environment mapping key",
+    (source) => source.replace(
+      "  ios-build:\n",
+      "  ios-build:\n    ? environment\n    : zuuli-app-stores\n",
+    ),
+    "contains forbidden explicit YAML mapping key",
+  ],
+  [
+    "rejects a tagged protected-environment mapping key",
+    (source) => source.replace(
+      "  ios-build:\n",
+      "  ios-build:\n    !!str environment: zuuli-app-stores\n",
+    ),
+    "environment contains forbidden tagged YAML mapping key",
+  ],
+  [
+    "rejects duplicate YAML mapping keys",
+    (source) => source.replace(
+      "  ios-build:\n",
+      "  ios-build:\n    environment: first\n    environment: second\n",
+    ),
+    "workflow YAML is invalid: Map keys must be unique",
+  ],
+  [
+    "does not mistake quoted hash and pipe text for a block scalar",
+    (source) => source
+      .replace(
+        "      KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n",
+        "      KEYSTORE: &apple ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n",
+      )
+      .replace(
+        "      - run: npm ci\n",
+        "      - name: \"install: | # not a block\"\n        env: { APPLE_LEAK: *apple }\n        run: npm ci\n",
+      ),
+    "contains forbidden YAML",
+  ],
+  [
+    "rejects job-level reusable workflow execution and secret forwarding",
+    (source) => source.replace(
+      "  linux:\n    container:\n      credentials:\n        password: ${{ secrets.GITHUB_TOKEN }}\n",
+      "  linux:\n    uses: ./.github/workflows/credential-escape.yml\n    secrets: inherit\n",
+    ),
+    "linux contains forbidden reusable-workflow uses",
+  ],
+  [
+    "rejects the Linux pull token in an npm step",
+    (source) => source.replace(
+      "        password: ${{ secrets.GITHUB_TOKEN }}\n",
+      "        password: ${{ secrets.GITHUB_TOKEN }}\n    steps:\n      - run: npm ci\n        env:\n          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n",
+    ),
+    "linux contains unauthorized secrets-context expression",
+  ],
+  [
+    "rejects moving the Linux pull token out of container credentials",
+    (source) => source.replace(
+      "    container:\n      credentials:\n        password: ${{ secrets.GITHUB_TOKEN }}\n",
+      "    steps:\n      - run: npm ci\n        env:\n          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n",
+    ),
+    "linux container pull password must be exactly secrets.GITHUB_TOKEN",
+  ],
+  [
+    "rejects a top-level shell wrapper inherited by credential steps",
+    (source) => source.replace(
+      "permissions:\n",
+      "defaults:\n  run:\n    shell: bash -c 'env > /tmp/apple-step-environment; exec bash \"$1\"' -- {0}\npermissions:\n",
+    ),
+    "workflow root keys must be exactly",
+  ],
+  [
+    "rejects inherited top-level environment drift",
+    (source) => source.replace("  CI: true\n", "  CI: true\n  BASH_ENV: /tmp/project-hook\n"),
+    "workflow root env authority changed",
+  ],
+  [
+    "rejects release trigger drift",
+    (source) => source.replace("    branches: [main]\n", "    branches: [main, attacker]\n"),
+    "workflow root on authority changed",
+  ],
+  [
+    "rejects global permission drift",
+    (source) => source.replace("  contents: read\n", "  contents: write\n"),
+    "workflow root permissions authority changed",
+  ],
+  [
+    "rejects release concurrency drift",
+    (source) => source.replace("  cancel-in-progress: false\n", "  cancel-in-progress: true\n"),
+    "workflow root concurrency authority changed",
+  ],
+  [
+    "rejects a single-quoted protected environment key on an unsigned build",
+    (source) => source.replace("  ios-build:\n", "  ios-build:\n    'environment': zuuli-app-stores\n"),
+    "ios-build contains forbidden protected environment",
+  ],
+  [
+    "rejects a double-quoted protected environment key on an unsigned build",
+    (source) => source.replace(
+      "  ios-build:\n",
+      "  ios-build:\n    \"environment\": zuuli-app-stores\n",
+    ),
+    "ios-build contains forbidden protected environment",
+  ],
+  [
+    "rejects a mapping protected environment on finalization",
+    (source) => source.replace(
+      "  macos-finalize:\n",
+      "  macos-finalize:\n    environment:\n      name: zuuli-app-stores\n",
+    ),
+    "macos-finalize contains forbidden protected environment",
+  ],
+  [
+    "rejects an unsigned iOS manifest that omits ExportOptions",
+    (source) => source.replace("ZUULI.xcarchive.zip ExportOptions.plist source-record.json", "ZUULI.xcarchive.zip source-record.json"),
+    "iOS unsigned builder is missing \"ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256\"",
+  ],
+  [
+    "rejects an unsigned macOS manifest that omits the shipping layout",
+    (source) => source.replace("ZUULI.app.zip ZUULI-layout.dmg source-record.json", "ZUULI.app.zip source-record.json"),
+    "macOS unsigned builder is missing \"ZUULI.app.zip ZUULI-layout.dmg source-record.json > CHECKSUMS.sha256\"",
+  ],
+  [
+    "rejects an iOS signer that does not bind the attested checksum manifest",
+    (source) => source.replace(
+      "          test \"$(shasum -a 256 unsigned-ios/CHECKSUMS.sha256 | awk '{print $1}')\" = \"$EXPECTED_PAYLOAD_SHA256\"\n",
+      "",
+    ),
+    "iOS signer is missing \"test \\\"$(shasum -a 256 unsigned-ios/CHECKSUMS.sha256\"",
+  ],
+  [
+    "rejects a macOS signer that does not attest the checksum manifest",
+    (source) => source.replace("          gh attestation verify unsigned-macos/CHECKSUMS.sha256 --repo repo\n", ""),
+    "macOS signer is missing \"gh attestation verify unsigned-macos/CHECKSUMS.sha256\"",
+  ],
+  [
+    "rejects an iOS signer without provisioning-profile absence readback",
+    (source) => source.replace(
+      "          if [[ -e \"$HOME/Library/MobileDevice/Provisioning Profiles/e5ead62c-83ec-4e54-abb6-4770833b5e0d.mobileprovision\" ]]; then echo survived; fi\n",
+      "",
+    ),
+    "iOS signer is missing \"if [[ -e \\\"$HOME/Library/MobileDevice/Provisioning Profiles/e5ead62c-83ec-4e54-abb6-4770833b5e0d.mobileprovision\\\" ]]\"",
+  ],
+  [
+    "rejects a macOS signer without mounted-image readback",
+    (source) => source.replace("          if hdiutil info | grep -Fq 'zuuli-macos-dmg-sign.'; then echo mounted; fi\n", ""),
+    "macOS signer is missing \"if hdiutil info | grep -Fq 'zuuli-macos-dmg-sign.'\"",
+  ],
+  [
+    "rejects an iOS signer that ignores provisioning-profile removal failure",
+    (source) => source.replace(
+      "          if [[ -n \"$profile_path\" ]] && ! rm -f -- \"$profile_path\"; then echo cleanup; fi\n",
+      "",
+    ),
+    "iOS signer is missing \"if [[ -n \\\"$profile_path\\\" ]] && ! rm -f -- \\\"$profile_path\\\"\"",
+  ],
+  [
+    "rejects a macOS signer that ignores forced-detach failure",
+    (source) => source.replace(
+      "          if [[ \"$mounted\" == true ]] && ! hdiutil detach \"$mountpoint\" -force; then echo cleanup; fi\n",
+      "",
+    ),
+    "macOS signer is missing \"if [[ \\\"$mounted\\\" == true ]] && ! hdiutil detach \\\"$mountpoint\\\" -force\"",
+  ],
+  ...["bash", "sh", "python3", "ruby", "node"].map((interpreter) => [
+    `rejects ${interpreter} execution added to the iOS credential job`,
+    (source) => source.replace(
+      "run: xcodebuild -exportArchive",
+      `run: xcodebuild -exportArchive && ${interpreter} unsigned-ios/post-sign.sh`,
+    ),
+    "ios-sign credential execution program changed",
+  ]),
+  [
+    "rejects an extra builder file followed by credential-job execution",
+    (source) => source
+      .replace(
+        "          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256",
+        "          touch post-sign.sh\n          shasum -a 256 ZUULI.xcarchive.zip ExportOptions.plist source-record.json > CHECKSUMS.sha256",
+      )
+      .replace(
+        "run: xcodebuild -exportArchive",
+        "run: xcodebuild -exportArchive && bash unsigned-ios/post-sign.sh",
+      ),
+    "ios-sign credential execution program changed",
+  ],
+  [
+    "rejects a credential-job shell override",
+    (source) => source.replace(
+      "      - name: Operate\n        run: xcodebuild -exportArchive",
+      "      - name: Operate\n        shell: python\n        run: xcodebuild -exportArchive",
+    ),
+    "ios-sign credential execution program changed",
+  ],
+  [
+    "rejects credential-job action input drift",
+    (source) => source.replace(
+      "      - uses: actions/download-artifact@sha\n",
+      "      - uses: actions/download-artifact@sha\n        with: { path: attacker-controlled }\n",
+    ),
+    "ios-sign credential execution program changed",
+  ],
+  [
+    "rejects credential-job defaults that replace the reviewed shell",
+    (source) => source.replace(
+      "  ios-sign:\n",
+      "  ios-sign:\n    defaults: { run: { shell: python } }\n",
+    ),
+    "ios-sign credential execution program changed",
+  ],
+]) {
+  test(name, () => {
+    const failures = verifyFixture(mutate(validWorkflow));
+    assert.ok(failures.some((failure) => failure.includes(expected)), failures.join("\n"));
+  });
+}
+
+function shasum(directory, args) {
+  return spawnSync("shasum", ["-a", "256", ...args], {
+    cwd: directory,
+    encoding: "utf8",
+  });
+}
+
+function verifyCanonicalPayload(directory, expectedManifestDigest) {
+  const manifest = shasum(directory, ["CHECKSUMS.sha256"]);
+  if (manifest.status !== 0) return false;
+  if (manifest.stdout.trim().split(/\s+/)[0] !== expectedManifestDigest) return false;
+  return shasum(directory, ["-c", "CHECKSUMS.sha256"]).status === 0;
+}
+
+async function hasExactMembers(directory, expected) {
+  const entries = await readdir(directory, { recursive: true });
+  if (JSON.stringify(entries.sort()) !== JSON.stringify([...expected].sort())) return false;
+  const stats = await Promise.all(entries.map((entry) => lstat(join(directory, entry))));
+  return stats.every((stat) => stat.isFile() && !stat.isSymbolicLink());
+}
+
+async function createPayload(files) {
+  const directory = await mkdtemp(join(tmpdir(), "zuuli-apple-payload-test."));
+  for (const [name, contents] of Object.entries(files)) {
+    await writeFile(join(directory, name), contents);
+  }
+  const members = Object.keys(files);
+  const checksums = shasum(directory, members);
+  assert.equal(checksums.status, 0, checksums.stderr);
+  await writeFile(join(directory, "CHECKSUMS.sha256"), checksums.stdout);
+  const manifest = shasum(directory, ["CHECKSUMS.sha256"]);
+  assert.equal(manifest.status, 0, manifest.stderr);
+  return { directory, digest: manifest.stdout.trim().split(/\s+/)[0] };
+}
+
+test("canonical payload digest rejects tampered ExportOptions and checksum manifest", async (context) => {
+  const payload = await createPayload({
+    "ZUULI.xcarchive.zip": "archive",
+    "ExportOptions.plist": "reviewed export options",
+    "source-record.json": "source",
+  });
+  context.after(() => rm(payload.directory, { recursive: true, force: true }));
+  assert.equal(verifyCanonicalPayload(payload.directory, payload.digest), true);
+  await writeFile(join(payload.directory, "ExportOptions.plist"), "tampered export options");
+  assert.equal(verifyCanonicalPayload(payload.directory, payload.digest), false);
+  const regenerated = shasum(payload.directory, [
+    "ZUULI.xcarchive.zip",
+    "ExportOptions.plist",
+    "source-record.json",
+  ]);
+  await writeFile(join(payload.directory, "CHECKSUMS.sha256"), regenerated.stdout);
+  assert.equal(verifyCanonicalPayload(payload.directory, payload.digest), false);
+});
+
+test("canonical payload digest rejects a tampered macOS shipping layout", async (context) => {
+  const payload = await createPayload({
+    "ZUULI.app.zip": "app",
+    "ZUULI-layout.dmg": "reviewed layout",
+    "source-record.json": "source",
+  });
+  context.after(() => rm(payload.directory, { recursive: true, force: true }));
+  assert.equal(verifyCanonicalPayload(payload.directory, payload.digest), true);
+  await writeFile(join(payload.directory, "ZUULI-layout.dmg"), "tampered layout");
+  assert.equal(verifyCanonicalPayload(payload.directory, payload.digest), false);
+});
+
+test("canonical member inventory rejects an unmanifested post-sign script", async (context) => {
+  const payload = await createPayload({
+    "ZUULI.xcarchive.zip": "archive",
+    "ExportOptions.plist": "reviewed export options",
+    "source-record.json": "source",
+  });
+  context.after(() => rm(payload.directory, { recursive: true, force: true }));
+  const expected = [
+    "CHECKSUMS.sha256",
+    "ExportOptions.plist",
+    "ZUULI.xcarchive.zip",
+    "source-record.json",
+  ];
+  assert.equal(await hasExactMembers(payload.directory, expected), true);
+  await writeFile(join(payload.directory, "post-sign.sh"), "echo exfiltrate");
+  assert.equal(await hasExactMembers(payload.directory, expected), false);
+});
+
+test("canonical member inventory rejects a symlink in place of an expected file", async (context) => {
+  const payload = await createPayload({
+    "ZUULI.xcarchive.zip": "archive",
+    "ExportOptions.plist": "reviewed export options",
+    "source-record.json": "source",
+  });
+  context.after(() => rm(payload.directory, { recursive: true, force: true }));
+  const expected = [
+    "CHECKSUMS.sha256",
+    "ExportOptions.plist",
+    "ZUULI.xcarchive.zip",
+    "source-record.json",
+  ];
+  await rm(join(payload.directory, "ExportOptions.plist"));
+  await symlink("source-record.json", join(payload.directory, "ExportOptions.plist"));
+  assert.equal(await hasExactMembers(payload.directory, expected), false);
+});

--- a/wallet/zuuli/scripts/assert-no-apple-credentials.sh
+++ b/wallet/zuuli/scripts/assert-no-apple-credentials.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This canary runs immediately before dependency installation and again after
+# the unsigned Apple build. The workflow boundary checker separately proves
+# that no protected environment or secret expression exists in either job.
+credential_variables=(
+  APPLE_API_ISSUER
+  APPLE_API_KEY
+  APPLE_API_KEY_PATH
+  ASC_ISSUER_ID
+  ASC_KEY_BASE64
+  ASC_KEY_ID
+  CERTIFICATE_BASE64
+  CERTIFICATE_PASSWORD
+  IOS_CERTIFICATE
+  IOS_CERTIFICATE_PASSWORD
+  IOS_MOBILE_PROVISION
+  PROVISIONING_PROFILE_BASE64
+  ZUULI_PREFLIGHT_KEYCHAIN
+)
+
+for variable in "${credential_variables[@]}"; do
+  if [[ -n "${!variable-}" ]]; then
+    echo "Apple credential canary found forbidden variable: $variable" >&2
+    exit 1
+  fi
+done
+
+runner_temp=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+for pattern in \
+  'zuuli-ios-sign.*' \
+  'zuuli-ios-upload.*' \
+  'zuuli-macos-app-sign.*' \
+  'zuuli-macos-app-notary.*' \
+  'zuuli-macos-dmg-sign.*' \
+  'zuuli-macos-dmg-notary.*'; do
+  if find "$runner_temp" -maxdepth 1 -name "$pattern" -print -quit | grep -q .; then
+    echo "Apple credential canary found forbidden temporary material: $pattern" >&2
+    exit 1
+  fi
+done
+
+if [[ -d "${HOME}/Library/MobileDevice/Provisioning Profiles" ]] &&
+  find "${HOME}/Library/MobileDevice/Provisioning Profiles" -maxdepth 1 \
+    -name 'e5ead62c-83ec-4e54-abb6-4770833b5e0d.mobileprovision' -print -quit | grep -q .; then
+  echo "Apple credential canary found the ZUULI provisioning profile" >&2
+  exit 1
+fi
+
+if command -v security >/dev/null 2>&1; then
+  identities=$(security find-identity -v -p codesigning 2>/dev/null || true)
+  if grep -Fq 'F9AV5HKF6N' <<<"$identities"; then
+    echo "Apple credential canary found a Corpora signing identity" >&2
+    exit 1
+  fi
+fi
+
+echo "Apple credential canary: no ZUULI signing or store-upload authority is present."

--- a/wallet/zuuli/scripts/mobile-release.sh
+++ b/wallet/zuuli/scripts/mobile-release.sh
@@ -2,19 +2,19 @@
 set -euo pipefail
 umask 077
 
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-app_dir=$(CDPATH= cd -- "$script_dir/.." && pwd)
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+app_dir=$(CDPATH='' cd -- "$script_dir/.." && pwd)
 cd "$app_dir"
 
 usage() {
-  echo "usage: scripts/mobile-release.sh <ios|android> [--upload]" >&2
+  echo "usage: scripts/mobile-release.sh android [--upload]" >&2
   exit 64
 }
 
 platform=${1:-}
 mode=${2:-}
 [[ $# -le 2 ]] || usage
-[[ "$platform" == ios || "$platform" == android ]] || usage
+[[ "$platform" == android ]] || usage
 [[ -z "$mode" || "$mode" == --upload ]] || usage
 
 identity_args=(--require-main)
@@ -23,8 +23,6 @@ if [[ -n "${ZUULI_RELEASE_SOURCE_SHA:-}" ]]; then
 fi
 identity_json=$(node scripts/release-identity.mjs "${identity_args[@]}")
 identity=$(jq -r .identity <<<"$identity_json")
-version=$(jq -r .version <<<"$identity_json")
-build=$(jq -r .build <<<"$identity_json")
 application_id=$(jq -r .applicationId <<<"$identity_json")
 
 if [[ "$mode" == --upload ]]; then
@@ -65,7 +63,7 @@ canonical_secret_file() {
   local name=$1 path parent
   require_secret_file "$name"
   path=${!name}
-  parent=$(CDPATH= cd -P -- "$(dirname -- "$path")" && pwd)
+  parent=$(CDPATH='' cd -P -- "$(dirname -- "$path")" && pwd)
   printf '%s/%s\n' "$parent" "$(basename -- "$path")"
 }
 
@@ -82,169 +80,69 @@ find_one() {
 
 mkdir -p release-artifacts
 
-if [[ "$platform" == ios ]]; then
-  require_value APPLE_TEAM_ID
-  if [[ "$APPLE_TEAM_ID" != "F9AV5HKF6N" ]]; then
-    echo "APPLE_TEAM_ID must be the configured Corpora team F9AV5HKF6N" >&2
-    exit 66
-  fi
-  require_value ASC_KEY_ID
-  require_value ASC_ISSUER_ID
-  require_value IOS_MOBILE_PROVISION
-  signing_keychain=$(canonical_secret_file ZUULI_PREFLIGHT_KEYCHAIN)
-  if [[ -n "${IOS_CERTIFICATE+x}" || -n "${IOS_CERTIFICATE_PASSWORD+x}" ]]; then
-    echo "refusing duplicate iOS certificate import: use the verified ephemeral keychain" >&2
-    exit 66
-  fi
-  if [[ -n "${APPLE_API_KEY+x}" || -n "${APPLE_API_ISSUER+x}" || -n "${APPLE_API_KEY_PATH+x}" ]]; then
-    echo "refusing Tauri skip-signing path: App Store credentials are reserved for altool" >&2
-    exit 66
-  fi
-  if [[ $(security find-identity -v -p codesigning "$signing_keychain" |
-    grep -Fc 'Apple Distribution: Corpora Inc (F9AV5HKF6N)' || true) -ne 1 ]]; then
-    echo "verified ephemeral keychain does not contain exactly one Corpora distribution identity" >&2
-    exit 66
-  fi
-  searchable_distribution_count=$(security find-identity -v -p codesigning |
-    grep -Fc 'Apple Distribution:' || true)
-  searchable_identity_count=$(security find-identity -v -p codesigning |
-    grep -Fc 'Apple Distribution: Corpora Inc (F9AV5HKF6N)' || true)
-  if [[ "$searchable_distribution_count" -ne 1 || "$searchable_identity_count" -ne 1 ]]; then
-    echo "user keychain search list does not resolve the unique Corpora distribution identity" >&2
-    exit 66
-  fi
-  keychain_is_searchable=false
-  while IFS= read -r listed_keychain; do
-    [[ -f "$listed_keychain" && ! -L "$listed_keychain" ]] || continue
-    listed_parent=$(CDPATH= cd -P -- "$(dirname -- "$listed_keychain")" && pwd)
-    if [[ "$listed_parent/$(basename -- "$listed_keychain")" == "$signing_keychain" ]]; then
-      keychain_is_searchable=true
-      break
-    fi
-  done < <(security list-keychains -d user |
-    sed -E 's/^[[:space:]]*"//; s/"[[:space:]]*$//')
-  if [[ "$keychain_is_searchable" != true ]]; then
-    echo "verified ephemeral keychain is missing from the user search list" >&2
-    exit 66
-  fi
-  ASC_KEY_PATH=$(canonical_secret_file ASC_KEY_PATH)
+# shellcheck source=android-toolchain-env.sh
+source "$script_dir/android-toolchain-env.sh"
+ANDROID_KEYSTORE_PATH=$(canonical_secret_file ANDROID_KEYSTORE_PATH)
+export ANDROID_KEYSTORE_PATH
+require_value ANDROID_KEYSTORE_PASSWORD
+require_value ANDROID_KEY_ALIAS
+require_value ANDROID_KEY_PASSWORD
+require_value ANDROID_UPLOAD_CERT_SHA256
+if [[ ! "$ANDROID_UPLOAD_CERT_SHA256" =~ ^([0-9A-F]{2}:){31}[0-9A-F]{2}$ ]]; then
+  echo "ANDROID_UPLOAD_CERT_SHA256 must be an uppercase colon-delimited SHA-256 fingerprint" >&2
+  exit 66
+fi
+actual_upload_fingerprint=$(keytool -list -v \
+  -keystore "$ANDROID_KEYSTORE_PATH" \
+  -storepass:env ANDROID_KEYSTORE_PASSWORD \
+  -alias "$ANDROID_KEY_ALIAS" | awk -F'SHA256: ' '/SHA256: / {print $2; exit}')
+if [[ "$actual_upload_fingerprint" != "$ANDROID_UPLOAD_CERT_SHA256" ]]; then
+  echo "Android upload certificate fingerprint does not match the protected release identity" >&2
+  exit 66
+fi
+unset actual_upload_fingerprint
 
-  key_dir=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-asc.XXXXXX")
-  cleanup_apple_key() {
-    find "$key_dir" -type f -exec rm -f -- {} + 2>/dev/null || true
-    rmdir "$key_dir/private_keys" "$key_dir" 2>/dev/null || true
-  }
-  trap cleanup_apple_key EXIT
-  mkdir "$key_dir/private_keys"
-  cp "$ASC_KEY_PATH" "$key_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8"
-
-  node scripts/normalize-generated-ios-project.mjs --prepare-manual-signing
-  IOS_MOBILE_PROVISION="$IOS_MOBILE_PROVISION" \
-    APPLE_TEAM_ID="$APPLE_TEAM_ID" \
-    ./node_modules/.bin/tauri ios build \
-      --ci \
-      --export-method app-store-connect \
-      -- \
-      --locked
-  node scripts/normalize-generated-ios-project.mjs
-  git diff --exit-code
-
-  ipa=$(find_one './src-tauri/gen/apple/build/arm64/*.ipa')
-  ipa_abs="$app_dir/${ipa#./}"
-  printf '%s' "$IOS_MOBILE_PROVISION" | base64 --decode > "$key_dir/expected.mobileprovision"
-  scripts/verify-ios-ipa.sh \
-    "$ipa_abs" \
-    "$key_dir/expected.mobileprovision" \
-    "$APPLE_TEAM_ID" \
-    "$application_id"
-  (
-    cd "$key_dir"
-    xcrun altool --validate-app --type ios --file "$ipa_abs" \
-      --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
-  )
-  cp "$ipa" "release-artifacts/ZUULI-${identity}-ios.ipa"
-
-  if [[ "$mode" == --upload ]]; then
-    (
-      cd "$key_dir"
-      xcrun altool --upload-app --type ios --file "$ipa_abs" \
-        --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
-    )
-    node scripts/asc-testflight.mjs \
-      --ensure \
-      "--version=$version" \
-      "--build=$build" \
-      "--output=release-artifacts/ZUULI-${identity}-testflight.json"
-  fi
-else
-  # shellcheck source=android-toolchain-env.sh
-  source "$script_dir/android-toolchain-env.sh"
-  ANDROID_KEYSTORE_PATH=$(canonical_secret_file ANDROID_KEYSTORE_PATH)
-  export ANDROID_KEYSTORE_PATH
-  require_value ANDROID_KEYSTORE_PASSWORD
-  require_value ANDROID_KEY_ALIAS
-  require_value ANDROID_KEY_PASSWORD
-  require_value ANDROID_UPLOAD_CERT_SHA256
-  if [[ ! "$ANDROID_UPLOAD_CERT_SHA256" =~ ^([0-9A-F]{2}:){31}[0-9A-F]{2}$ ]]; then
-    echo "ANDROID_UPLOAD_CERT_SHA256 must be an uppercase colon-delimited SHA-256 fingerprint" >&2
+if [[ "$mode" == --upload ]]; then
+  PLAY_SERVICE_ACCOUNT_JSON=$(canonical_secret_file PLAY_SERVICE_ACCOUNT_JSON)
+  export PLAY_SERVICE_ACCOUNT_JSON
+  if ! jq -e '
+    .type == "service_account" and
+    .project_id == "corpora1" and
+    .client_email == "corpan-play-verifier@corpora1.iam.gserviceaccount.com" and
+    (.private_key_id | type == "string" and length > 0) and
+    (.private_key | type == "string" and startswith("-----BEGIN PRIVATE KEY-----"))
+  ' "$PLAY_SERVICE_ACCOUNT_JSON" >/dev/null; then
+    echo "PLAY_SERVICE_ACCOUNT_JSON is not the dedicated Corpora ZUULI release account" >&2
     exit 66
-  fi
-  actual_upload_fingerprint=$(keytool -list -v \
-    -keystore "$ANDROID_KEYSTORE_PATH" \
-    -storepass:env ANDROID_KEYSTORE_PASSWORD \
-    -alias "$ANDROID_KEY_ALIAS" | awk -F'SHA256: ' '/SHA256: / {print $2; exit}')
-  if [[ "$actual_upload_fingerprint" != "$ANDROID_UPLOAD_CERT_SHA256" ]]; then
-    echo "Android upload certificate fingerprint does not match the protected release identity" >&2
-    exit 66
-  fi
-  unset actual_upload_fingerprint
-
-  if [[ "$mode" == --upload ]]; then
-    PLAY_SERVICE_ACCOUNT_JSON=$(canonical_secret_file PLAY_SERVICE_ACCOUNT_JSON)
-    export PLAY_SERVICE_ACCOUNT_JSON
-    if ! jq -e '
-      .type == "service_account" and
-      .project_id == "corpora1" and
-      .client_email == "corpan-play-verifier@corpora1.iam.gserviceaccount.com" and
-      (.private_key_id | type == "string" and length > 0) and
-      (.private_key | type == "string" and startswith("-----BEGIN PRIVATE KEY-----"))
-    ' "$PLAY_SERVICE_ACCOUNT_JSON" >/dev/null; then
-      echo "PLAY_SERVICE_ACCOUNT_JSON is not the dedicated Corpora ZUULI release account" >&2
-      exit 66
-    fi
-  fi
-
-  ./node_modules/.bin/tauri android build --ci --aab -- --locked
-  node scripts/normalize-generated-android-manifest.mjs
-  git diff --exit-code
-  aab=$(find_one './src-tauri/gen/android/app/build/outputs/bundle/universalRelease/*.aab')
-  # Android upload-key certificates are intentionally self-signed, which makes
-  # jarsigner --strict return 4 even when the archive signature is valid.
-  if ! signature_report=$(jarsigner -verify -certs "$aab" 2>&1) ||
-    ! grep -Fq "jar verified." <<<"$signature_report" ||
-    grep -Fqi "unsigned" <<<"$signature_report"; then
-    echo "Android bundle signature verification failed" >&2
-    exit 70
-  fi
-  unset signature_report
-  cp "$aab" "release-artifacts/ZUULI-${identity}-android.aab"
-
-  if [[ "$mode" == --upload ]]; then
-    FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane supply \
-      --package_name "$application_id" \
-      --aab "$aab" \
-      --json_key "$PLAY_SERVICE_ACCOUNT_JSON" \
-      --track internal \
-      --release_status completed \
-      --skip_upload_apk true \
-      --skip_upload_metadata true \
-      --skip_upload_images true \
-      --skip_upload_screenshots true
   fi
 fi
 
-if [[ "$platform" == ios && "$mode" == --upload ]]; then
-  echo "ZUULI $identity iOS is processed and available to the configured internal TestFlight group."
-else
-  echo "ZUULI $identity $platform release validation completed ($([[ "$mode" == --upload ]] && echo uploaded || echo dry-run))."
+./node_modules/.bin/tauri android build --ci --aab -- --locked
+node scripts/normalize-generated-android-manifest.mjs
+git diff --exit-code
+aab=$(find_one './src-tauri/gen/android/app/build/outputs/bundle/universalRelease/*.aab')
+# Android upload-key certificates are intentionally self-signed, which makes
+# jarsigner --strict return 4 even when the archive signature is valid.
+if ! signature_report=$(jarsigner -verify -certs "$aab" 2>&1) ||
+  ! grep -Fq "jar verified." <<<"$signature_report" ||
+  grep -Fqi "unsigned" <<<"$signature_report"; then
+  echo "Android bundle signature verification failed" >&2
+  exit 70
 fi
+unset signature_report
+cp "$aab" "release-artifacts/ZUULI-${identity}-android.aab"
+
+if [[ "$mode" == --upload ]]; then
+  FASTLANE_SKIP_UPDATE_CHECK=1 bundle exec fastlane supply \
+    --package_name "$application_id" \
+    --aab "$aab" \
+    --json_key "$PLAY_SERVICE_ACCOUNT_JSON" \
+    --track internal \
+    --release_status completed \
+    --skip_upload_apk true \
+    --skip_upload_metadata true \
+    --skip_upload_images true \
+    --skip_upload_screenshots true
+fi
+
+echo "ZUULI $identity Android release validation completed ($([[ "$mode" == --upload ]] && echo uploaded || echo dry-run))."

--- a/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
+++ b/wallet/zuuli/scripts/normalize-generated-ios-project.mjs
@@ -88,6 +88,18 @@ function replaceSetting(lines, key, expectedValue, replacementValue) {
   else lines[index] = settingLine(key, replacementValue);
 }
 
+function replaceKnownSetting(lines, key, expectedValues, replacementValue) {
+  const index = settingIndex(lines, key);
+  const expected = expectedValues.map((value) => settingLine(key, value));
+  if (!expected.includes(lines[index])) {
+    throw new Error(
+      `refusing to normalize ${key}: expected one of ${JSON.stringify(expected)}, found ${JSON.stringify(lines[index])}`,
+    );
+  }
+  if (replacementValue === null) lines.splice(index, 1);
+  else lines[index] = settingLine(key, replacementValue);
+}
+
 function insertSettingAfter(lines, afterKey, key, value) {
   if (lines.some((line) => line.trimStart().startsWith(`${key} = `))) {
     throw new Error(`refusing to prepare duplicate ${key} setting`);
@@ -148,21 +160,28 @@ function normalizeAppSigning(body, configuration) {
         : `"${distributionIdentity}"`,
       null,
     );
-    replaceSetting(
+    replaceKnownSetting(
       lines,
       "CODE_SIGN_STYLE",
-      "Manual",
+      configuration === "debug" ? ["Automatic", "Manual"] : ["Manual"],
       configuration === "debug" ? "Automatic" : "Manual",
     );
     replaceSetting(lines, "DEVELOPMENT_TEAM", teamId, teamId);
     replaceSetting(lines, sdkTeam, teamId, null);
-    replaceSetting(
+    const preparedProfile =
+      configuration === "debug" ? '""' : `"${profileName}"`;
+    replaceKnownSetting(
       lines,
       "PROVISIONING_PROFILE_SPECIFIER",
-      `"${profileUuid}"`,
+      [preparedProfile, `"${profileUuid}"`],
       configuration === "debug" ? null : `"${profileName}"`,
     );
-    replaceSetting(lines, sdkProfile, `"${profileUuid}"`, null);
+    replaceKnownSetting(
+      lines,
+      sdkProfile,
+      [preparedProfile, `"${profileUuid}"`],
+      null,
+    );
   }
 
   return lines.join("\n");
@@ -369,6 +388,11 @@ function selfTest() {
   const prepared = prepareManualSigningProject(canonical);
   if (prepared === canonical) {
     throw new Error("manual-signing preparation did not add guarded settings");
+  }
+  if (normalizeProject(prepared) !== canonical) {
+    throw new Error(
+      "unsigned manual-signing project did not normalize to canonical bytes",
+    );
   }
   let tauriGenerated = normalizeBuildSetting(
     prepared,

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -6,6 +6,8 @@ import { dirname, resolve } from "node:path";
 import { TextDecoder } from "node:util";
 import { fileURLToPath } from "node:url";
 
+import { verifyAppleCredentialBoundary } from "./apple-credential-boundary.mjs";
+
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const read = (path) => readFileSync(resolve(root, path), "utf8");
 const json = (path) => JSON.parse(read(path));
@@ -557,139 +559,25 @@ expect(
   // truth fails here too. scripts/check-rust-toolchain.sh holds it in step.
   "1.97.1",
 );
-for (const wiring of [
-  "IOS_MOBILE_PROVISION: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}",
-  "ZUULI_PREFLIGHT_KEYCHAIN=$keychain",
-  'security list-keychains -d user -s "${keychains[@]}"',
-  'security delete-keychain "$ZUULI_PREFLIGHT_KEYCHAIN"',
-  "-t cert -f pkcs12",
-  "-T /usr/bin/codesign -T /usr/bin/xcodebuild",
-]) {
-  if (!releaseWorkflow.includes(wiring))
-    failures.push(`protected iOS signing-keychain wiring is missing: ${wiring}`);
-}
-expect(
-  "protected build certificate secret exposure count",
-  occurrenceCount(
-    releaseWorkflow,
-    "IOS_CERTIFICATE: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}",
-  ),
-  0,
-);
-expect(
-  "protected build certificate password secret exposure count",
-  occurrenceCount(
-    releaseWorkflow,
-    "IOS_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}",
-  ),
-  0,
-);
-expect(
-  "protected certificate materialization count",
-  occurrenceCount(
-    releaseWorkflow,
-    "CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}",
-  ),
-  1,
-);
-expect(
-  "protected certificate password materialization count",
-  occurrenceCount(
-    releaseWorkflow,
-    "CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}",
-  ),
-  1,
-);
-expect(
-  "protected provisioning-profile build exposure count",
-  occurrenceCount(
-    releaseWorkflow,
-    "IOS_MOBILE_PROVISION: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}",
-  ),
-  1,
-);
-const explicitCertificateImport = releaseWorkflow.indexOf(
-  'security import "$files/distribution.p12" -P "$CERTIFICATE_PASSWORD"',
-);
-const decodedCertificateRemoval = releaseWorkflow.indexOf(
-  'rm -f -- "$files/distribution.p12" "$files/profile-certificate.der"',
-);
-const protectedIosBuild = releaseWorkflow.indexOf(
-  "      - name: Build, validate, and optionally upload",
-);
-const protectedIosCleanup = releaseWorkflow.indexOf(
-  "      - name: Destroy ephemeral Apple credentials",
-);
-if (
-  explicitCertificateImport === -1 ||
-  decodedCertificateRemoval === -1 ||
-  protectedIosBuild === -1 ||
-  protectedIosCleanup === -1 ||
-  explicitCertificateImport > decodedCertificateRemoval ||
-  decodedCertificateRemoval > protectedIosBuild ||
-  protectedIosBuild > protectedIosCleanup
-) {
-  failures.push(
-    "protected iOS release must explicitly import, remove the decoded P12, build from the keychain, then clean up",
-  );
-}
-for (const guard of [
-  "refusing duplicate iOS certificate import",
-  "refusing Tauri skip-signing path",
-  "verified ephemeral keychain is missing from the user search list",
-  "user keychain search list does not resolve the unique Corpora distribution identity",
-]) {
-  if (!mobileRelease.includes(guard))
-    failures.push(`iOS release keychain guard is missing: ${guard}`);
-}
-for (const forbiddenTauriCredential of [
-  'APPLE_API_ISSUER="$ASC_ISSUER_ID"',
-  'APPLE_API_KEY="$ASC_KEY_ID"',
-  'APPLE_API_KEY_PATH="$key_dir/private_keys/AuthKey_${ASC_KEY_ID}.p8"',
-]) {
-  if (mobileRelease.includes(forbiddenTauriCredential))
-    failures.push(
-      `Tauri must not receive App Store credentials that enable its skip-signing path: ${forbiddenTauriCredential}`,
-    );
-}
-const ipaVerification = mobileRelease.indexOf(
-  "\n  scripts/verify-ios-ipa.sh \\\n",
-);
-const appleValidation = mobileRelease.indexOf(
-  "\n    xcrun altool --validate-app",
-);
-const appleUpload = mobileRelease.indexOf("\n      xcrun altool --upload-app");
-const testFlightConvergence = mobileRelease.indexOf(
-  "\n    node scripts/asc-testflight.mjs \\",
-);
-const signingPreparation = mobileRelease.indexOf(
+for (const boundaryFailure of verifyAppleCredentialBoundary(releaseWorkflow))
+  failures.push(`Apple credential boundary: ${boundaryFailure}`);
+if (mobileRelease.includes("tauri ios build") || mobileRelease.includes("platform == ios"))
+  failures.push("mobile-release.sh must not recombine iOS credentials with dependency-controlled builds");
+for (const preservedContract of [
   "node scripts/normalize-generated-ios-project.mjs --prepare-manual-signing",
-);
-const tauriIosBuild = mobileRelease.indexOf(
-  "./node_modules/.bin/tauri ios build",
-);
-const signingNormalization = mobileRelease.indexOf(
-  "\n  node scripts/normalize-generated-ios-project.mjs\n",
-  tauriIosBuild,
-);
-if (
-  signingPreparation === -1 ||
-  tauriIosBuild === -1 ||
-  signingNormalization === -1 ||
-  ipaVerification === -1 ||
-  appleValidation === -1 ||
-  appleUpload === -1 ||
-  testFlightConvergence === -1 ||
-  signingPreparation > tauriIosBuild ||
-  tauriIosBuild > signingNormalization ||
-  signingNormalization > ipaVerification ||
-  ipaVerification > appleValidation ||
-  ipaVerification > appleUpload ||
-  appleUpload > testFlightConvergence
-) {
-  failures.push(
-    "iOS release must prepare signing keys, build, normalize, inspect the IPA, validate, upload, then prove internal TestFlight availability",
-  );
+  "./node_modules/.bin/tauri ios build --ci --no-sign --archive-only -- --locked",
+  "node scripts/normalize-generated-ios-project.mjs",
+  "xcodebuild -exportArchive",
+  "scripts/verify-ios-ipa.sh --expected-profile-sha256",
+  "xcrun altool --validate-app",
+  "xcrun altool --upload-app",
+  "node verified-ios/asc-testflight.mjs --ensure",
+  "xcrun notarytool submit",
+  "xcrun stapler validate",
+  "node scripts/release-manifest.mjs",
+]) {
+  if (!releaseWorkflow.includes(preservedContract))
+    failures.push(`protected Apple release contract is missing: ${preservedContract}`);
 }
 for (const contract of [
   'export const ASC_APP_ID = "6799322201"',

--- a/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
+++ b/wallet/zuuli/scripts/verify-ci-cache-policy.mjs
@@ -153,10 +153,10 @@ requireCount("protected release npm auto-cache", release, "cache: npm", 1);
 const prepareJob = job(release, "prepare", "android");
 requireCount("credential-free prepare npm auto-cache", prepareJob, "cache: npm", 1);
 for (const [name, nextName] of [
-  ["android", "ios"],
-  ["ios", "linux"],
-  ["linux", "macos"],
-  ["macos", "release-index"],
+  ["android", "ios-build"],
+  ["ios-build", "ios-sign"],
+  ["linux", "macos-build"],
+  ["macos-build", "macos-sign"],
 ]) {
   const protectedJob = job(release, name, nextName);
   requireCount(`${name} cache caller`, protectedJob, localAction, 1);
@@ -171,6 +171,25 @@ for (const [name, nextName] of [
     "gh cache",
   ]) {
     rejectText(`${name} protected job`, protectedJob, writer);
+  }
+}
+for (const [name, nextName] of [
+  ["ios-sign", "ios-verify"],
+  ["ios-upload", "ios-finalize"],
+  ["macos-sign", "macos-finalize"],
+]) {
+  const credentialJob = job(release, name, nextName);
+  rejectText(`${name} credential-bearing job`, credentialJob, localAction);
+  for (const writer of [
+    "Swatinem/rust-cache@",
+    "actions/cache@",
+    "actions/cache/save@",
+    "cache: npm",
+    "cache: gradle",
+    "bundler-cache: true",
+    "gh cache",
+  ]) {
+    rejectText(`${name} credential-bearing job`, credentialJob, writer);
   }
 }
 

--- a/wallet/zuuli/scripts/verify-ios-ipa.sh
+++ b/wallet/zuuli/scripts/verify-ios-ipa.sh
@@ -81,6 +81,11 @@ self_test() (
   printf '\317\372\355\376\014\000\000\001' > "$fixture_app/ZUULI"
   printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>' '<plist version="1.0"><dict><key>ITSAppUsesNonExemptEncryption</key><false/></dict></plist>' > "$fixture_app/Info.plist"
   printf 'fixture\n' > "$fixture_dir/expected.mobileprovision"
+  if output=$("$script_path" --expected-profile-sha256 not-a-hash "$fixture_dir/missing.ipa" F9AV5HKF6N cash.free2z.zuuli 2>&1); then
+    fail "malformed profile-digest self-test unexpectedly passed"
+  fi
+  grep -Fq 'expected provisioning-profile SHA-256 is malformed' <<<"$output" ||
+    fail "malformed profile-digest self-test failed for the wrong reason: $output"
   fixture_ipa="$fixture_dir/missing-profile.ipa"
   (cd "$fixture_dir/root" && zip -qry "$fixture_ipa" Payload)
   if output=$("$script_path" "$fixture_ipa" "$fixture_dir/expected.mobileprovision" F9AV5HKF6N cash.free2z.zuuli 2>&1); then
@@ -250,19 +255,31 @@ if [[ "${1:-}" == --verify-app-structure ]]; then
   exit 0
 fi
 
-if [[ $# -ne 4 ]]; then
-  echo "usage: scripts/verify-ios-ipa.sh <ipa> <expected.mobileprovision> <team-id> <application-id>" >&2
+expected_profile=""
+expected_profile_sha256=""
+if [[ "${1:-}" == --expected-profile-sha256 ]]; then
+  [[ $# -eq 5 ]] || fail "--expected-profile-sha256 requires a hash, IPA, team ID, and application ID"
+  expected_profile_sha256=$2
+  ipa=$3
+  team_id=$4
+  application_id=$5
+  [[ "$expected_profile_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+    fail "expected provisioning-profile SHA-256 is malformed"
+elif [[ $# -eq 4 ]]; then
+  ipa=$1
+  expected_profile=$2
+  team_id=$3
+  application_id=$4
+else
+  echo "usage: scripts/verify-ios-ipa.sh [--expected-profile-sha256 <sha256>] <ipa> <expected.mobileprovision|team-id> <team-id|application-id> [application-id]" >&2
   exit 64
 fi
 
-ipa=$1
-expected_profile=$2
-team_id=$3
-application_id=$4
-
 [[ -f "$ipa" && ! -L "$ipa" ]] || fail "IPA must be a regular, non-symlink file"
-[[ -f "$expected_profile" && ! -L "$expected_profile" ]] ||
-  fail "expected provisioning profile must be a regular, non-symlink file"
+if [[ -n "$expected_profile" ]]; then
+  [[ -f "$expected_profile" && ! -L "$expected_profile" ]] ||
+    fail "expected provisioning profile must be a regular, non-symlink file"
+fi
 [[ "$team_id" == F9AV5HKF6N ]] || fail "unexpected Apple team $team_id"
 [[ "$application_id" == cash.free2z.zuuli ]] ||
   fail "unexpected application identifier $application_id"
@@ -295,8 +312,14 @@ embedded_profile="$app/embedded.mobileprovision"
 verify_app_structure "$app"
 [[ -f "$embedded_profile" && ! -L "$embedded_profile" ]] ||
   fail "embedded provisioning profile is not a regular file"
-cmp -s "$expected_profile" "$embedded_profile" ||
-  fail "embedded provisioning profile differs from the protected input"
+if [[ -n "$expected_profile" ]]; then
+  cmp -s "$expected_profile" "$embedded_profile" ||
+    fail "embedded provisioning profile differs from the protected input"
+else
+  embedded_profile_sha256=$(shasum -a 256 "$embedded_profile" | awk '{print $1}')
+  [[ "$embedded_profile_sha256" == "$expected_profile_sha256" ]] ||
+    fail "embedded provisioning profile differs from the protected-input digest"
+fi
 
 profile_plist="$inspect_dir/profile.plist"
 security cms -D -i "$embedded_profile" > "$profile_plist" ||


### PR DESCRIPTION
Closes #371.

## Outcome

Apple release builds now produce source-bound unsigned artifacts without Apple authority. Separate protected jobs accept only the exact verified payload, materialize one credential class immediately before its system signing/export/notary/upload operation, and unconditionally destroy it before credential-free finalization and provenance.

## Security boundary

- iOS/macOS builders run checkout, npm/Cargo/Tauri/Xcode build phases with credential canaries before dependency install and after the unsigned build.
- Signer/upload jobs have no checkout, npm, Cargo, Tauri, project build, local action, or cache execution.
- A pinned real-YAML AST checker fails closed on aliases/anchors, explicit/tagged/duplicate keys, secret-expression variants, unknown jobs, reusable workflows, inherited secrets/defaults, and drift in the exact trigger/permission/concurrency/environment envelope.
- The three credential-bearing programs are sealed by exact reviewed job digests.
- Canonical checksum manifests and attestations bind all unsigned payload members, including ExportOptions and macOS layout; exact member and non-symlink checks reject extra project hooks.
- The attested TestFlight reconciliation helper is the sole narrow project-script exception.
- The Linux image pull token remains exactly one `secrets.GITHUB_TOKEN` reference at `linux.container.credentials.password`; it cannot reach a job step.
- Android's combined build/sign boundary remains separately tracked by #293.

## Local verification

- Credential-free unsigned iOS archive build: green; archive unsigned; generated Xcode/project files restored byte-identical.
- Credential-free universal macOS app+DMG build: green for arm64+x86_64; app unsigned.
- Pinned Rust 1.97.1 fmt/clippy/tests/build: green (Zuuli 12 tests; Zcash plugin 105 tests; docs green; existing upstream future-incompat warning only).
- Exact Node 24.18.0 `npm test`: 380 Vitest + 77 Node boundary + 94 Playwright, all green; full 320-414 px matrix green.
- Apple boundary suite: 60/60, including every reviewed YAML/inheritance/program/payload/Linux-token bypass.
- `npm run typecheck`, `npm run build`, release identity, actionlint, 131 action-pin references + self-tests, Rust toolchain + self-tests, cache policy, immutable Linux image policy, high-severity npm audit threshold, and `git diff --check`: green.
- Independent final exact-head review of `bcd4be9d1f5a51375db8a8bfef2d45c40e2f38c6`: **No significant findings.**

## External acceptance blockers

This PR does not claim owner-side credential-policy proof or a live store release. Before issue closure or Apple publication:

- the owner must replace/prove the current ASC Admin credential with the minimum role/scope that supports the required upload, and
- the protected credential environments must complete a reviewed dry run on the merged source.

No protected workflow was dispatched, and no credentials, environments, or repository policies were accessed or mutated in this work.
