### PR TITLE
fix(zuuli): resolve relative article links against real routes

### DIFF
--- a/wallet/zuuli/src/components/common/Markdown.test.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.test.tsx
@@ -69,6 +69,38 @@ describe("Markdown links", () => {
     expect(markup).toContain('href="/articles/guide"');
     expect(markup).toContain(">the guide</a>");
   });
+
+  // free2z article bodies are authored on free2z.cash, where relative hrefs
+  // mean free2z routes — which mostly don't exist in ZUULI (#337). These must
+  // resolve to something real instead of dead-ending in `NotFound`.
+
+  it("keeps a genuine ZUULI app route routed as-is", () => {
+    const markup = render("[wallet](/wallet/send)", "article");
+
+    expect(markup).toContain('href="/wallet/send"');
+  });
+
+  it("maps a free2z {username}/{slug} content link onto the in-app article route", () => {
+    const markup = render("[post](/palmar/7th-meetup-zcash-club-queretaro)", "article");
+
+    expect(markup).toContain('href="/articles/7th-meetup-zcash-club-queretaro"');
+  });
+
+  it("maps a free2z {username} link onto the in-app creator route", () => {
+    const markup = render("[palmar](/palmar)", "article");
+
+    expect(markup).toContain('href="/creator/palmar"');
+  });
+
+  it("routes an /uploadz link as out-of-app media instead of the SPA router", () => {
+    const markup = render(
+      "[report](/uploadz/public/x/report.pdf)",
+      "article",
+    );
+
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain('rel="noopener noreferrer"');
+  });
 });
 
 /**

--- a/wallet/zuuli/src/components/common/Markdown.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.tsx
@@ -21,6 +21,7 @@ import rehypeSlug from "rehype-slug";
 
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { isTauri } from "@/lib/platform";
+import { mediaUrl } from "@/lib/api/http";
 import { cn } from "@/lib/utils";
 
 import remarkOembed from "@/lib/markdown/remark-oembed";
@@ -81,6 +82,59 @@ async function openExternal(url: string) {
 }
 
 /**
+ * Path segments ZUULI itself routes (`src/App.tsx`). A relative href whose
+ * first segment matches one of these is a genuine in-app path and must keep
+ * navigating through the router exactly as before. `""` covers `/` (index).
+ */
+const APP_ROUTE_SEGMENTS = new Set([
+  "",
+  "login",
+  "search",
+  "creator",
+  "profile",
+  "kyc",
+  "wallet",
+  "ai",
+  "live",
+  "articles",
+  "buy",
+]);
+
+/**
+ * Article bodies are authored on free2z.cash, where relative hrefs mean
+ * free2z routes — which mostly don't exist in ZUULI (issue #337). Classify a
+ * non-anchor, non-external href so `MarkdownLink` can send it somewhere that
+ * actually resolves instead of dead-ending in `NotFound`:
+ *
+ *   • `/uploadz/…`        — an upload; absolutize against the media host and
+ *                            open it out-of-app, same as `mediaUrl()` does
+ *                            for images.
+ *   • a genuine app route  — unchanged, still routed in-app.
+ *   • `/{username}/{slug}`— a zpage; ZUULI's article route is slug-only
+ *                            (`/articles/:slug`, `src/features/articles`),
+ *                            so map onto that and keep navigation native.
+ *   • `/{username}`       — a creator profile; map onto `/creator/:username`.
+ */
+function classifyInternalHref(
+  href: string,
+): { kind: "app"; to: string } | { kind: "media"; url: string } {
+  const path = href.split(/[?#]/)[0] ?? "";
+  const segments = path.replace(/^\/+/, "").split("/").filter(Boolean);
+  const first = segments[0] ?? "";
+
+  if (first === "uploadz") {
+    return { kind: "media", url: mediaUrl(href) ?? href };
+  }
+  if (APP_ROUTE_SEGMENTS.has(first)) {
+    return { kind: "app", to: href };
+  }
+  if (segments.length >= 2) {
+    return { kind: "app", to: `/articles/${segments[1]}` };
+  }
+  return { kind: "app", to: `/creator/${segments[0]}` };
+}
+
+/**
  * Markdown anchor. Article/AI content is remote/untrusted: external links open
  * outside the app (OS browser on desktop, new tab in the browser build) and
  * always carry `rel="noopener noreferrer"`; internal links use the router so
@@ -136,17 +190,42 @@ function MarkdownLink({
     );
   }
 
+  if (href) {
+    const target = classifyInternalHref(href);
+    if (target.kind === "media") {
+      return (
+        <a
+          {...rest}
+          data-touch-target-exempt="inline-text"
+          href={target.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => {
+            e.preventDefault();
+            void openExternal(target.url);
+          }}
+        >
+          {children}
+        </a>
+      );
+    }
+    return (
+      <a
+        {...rest}
+        data-touch-target-exempt="inline-text"
+        href={target.to}
+        onClick={(e) => {
+          e.preventDefault();
+          navigate(target.to);
+        }}
+      >
+        {children}
+      </a>
+    );
+  }
+
   return (
-    <a
-      {...rest}
-      data-touch-target-exempt="inline-text"
-      href={href ?? "#"}
-      onClick={(e) => {
-        if (!href) return;
-        e.preventDefault();
-        navigate(href);
-      }}
-    >
+    <a {...rest} data-touch-target-exempt="inline-text" href="#">
       {children}
     </a>
   );


### PR DESCRIPTION
## Summary

Article bodies are authored on free2z.cash, where relative hrefs mean
free2z routes — which mostly don't exist in ZUULI. `MarkdownLink`
classified any href starting with `/` as an in-app path and handed it
straight to the router, dead-ending in `NotFound`.

Classifies relative hrefs before routing:

- `/uploadz/…` — absolutizes against the media host, opens out-of-app
  (same as `mediaUrl()` already does for images).
- Genuine ZUULI routes (`/wallet`, `/articles`, `/creator`, `/kyc`, …) —
  unchanged, still routed in-app.
- `/{username}/{slug}` — maps onto the slug-only `/articles/:slug`
  route.
- `/{username}` — maps onto `/creator/:username`.

## Testing

- `npm run typecheck` — clean
- `npm run test -- src/components/common/Markdown.test.tsx` — 14/14
  pass (4 new cases covering the mapping above)
- Full suite: 422 pass, 1 pre-existing unrelated failure
  (`TopBar.signed-in.test.tsx`, locale number formatting — reproduces
  on `main` before this change too)
- Manually verified in a running dev server (`VITE_MOCK=1`): typed all
  four link shapes into the article editor's live preview, confirmed
  rendered hrefs, clicked through — lands on `/articles/:slug` inside
  the router instead of the app-level `NotFound`, no console errors

## Note for reviewer

`APP_ROUTE_SEGMENTS` is a manual allowlist mirroring `src/App.tsx`'s
top-level routes. A future new top-level route needs to be added here
too, or it'll be misclassified as a creator username.

Fixes #337