### PR TITLE
fix(zuuli): parse and hint 2Z amounts in the user's own locale

### DIFF
--- a/wallet/zuuli/src/features/articles/components/TipDialog.tsx
+++ b/wallet/zuuli/src/features/articles/components/TipDialog.tsx
@@ -18,6 +18,7 @@ import { tuzi } from "@/lib/api/free2z";
 import {
   formatTuzis,
   MAX_TUZIS,
+  tuziInputExample,
   tuziInputMaxLength,
   validateTuzis,
 } from "@/lib/format";
@@ -163,7 +164,7 @@ export function TipDialog({ author }: { author: SimpleCreator }) {
               {amountResult.error === "tooLarge"
                 ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per tip.`
                 : amount.length > 0 && amountResult.error !== null
-                  ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                  ? `Enter a positive whole 2Z amount, e.g. ${tuziInputExample()}.`
                   : null}
             </p>
           </div>

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -48,6 +48,7 @@ import {
   initials,
   MAX_TUZIS,
   timeAgo,
+  tuziInputExample,
   tuziInputMaxLength,
   validateTuzis,
 } from "@/lib/format";
@@ -976,7 +977,7 @@ function TipButton({
               {amountResult.error === "tooLarge"
                 ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per tip.`
                 : amount.length > 0 && amountResult.error !== null
-                  ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                  ? `Enter a positive whole 2Z amount, e.g. ${tuziInputExample()}.`
                   : null}
             </p>
           </div>

--- a/wallet/zuuli/src/features/live/GoLiveDialog.tsx
+++ b/wallet/zuuli/src/features/live/GoLiveDialog.tsx
@@ -20,6 +20,7 @@ import { useSession } from "@/store/session";
 import {
   formatTuzis,
   MAX_PPV_PRICE_TUZIS,
+  tuziInputExample,
   tuziInputMaxLength,
   validateTuzis,
 } from "@/lib/format";
@@ -194,7 +195,7 @@ export function GoLiveDialog() {
                 {priceResult.error === "tooLarge"
                   ? `Max ${MAX_PPV_PRICE_TUZIS.toLocaleString()} 2Z for PPV.`
                   : !validPrice
-                    ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                    ? `Enter a positive whole 2Z amount, e.g. ${tuziInputExample()}.`
                     : null}
               </p>
             </div>

--- a/wallet/zuuli/src/features/profile/index.tsx
+++ b/wallet/zuuli/src/features/profile/index.tsx
@@ -18,6 +18,7 @@ import { profile } from "@/lib/api/free2z";
 import {
   initials,
   MAX_MEMBER_PRICE_TUZIS,
+  tuziInputExample,
   tuziInputMaxLength,
   validateTuzis,
 } from "@/lib/format";
@@ -196,7 +197,7 @@ function ProfileForm({ user }: { user: AuthUser }) {
               {memberPriceResult.error === "tooLarge"
                 ? `Max ${MAX_MEMBER_PRICE_TUZIS.toLocaleString()} 2Z per membership.`
                 : !memberPriceValid
-                  ? "Enter a non-negative whole 2Z amount; commas may separate thousands."
+                  ? `Enter a non-negative whole 2Z amount, e.g. ${tuziInputExample()}.`
                   : null}
             </p>
           </div>

--- a/wallet/zuuli/src/features/wallet/funding/BuyTab.tsx
+++ b/wallet/zuuli/src/features/wallet/funding/BuyTab.tsx
@@ -38,6 +38,7 @@ import {
   formatUsd,
   formatZecTrim,
   MAX_TUZIS,
+  tuziInputExample,
   tuziInputMaxLength,
   tuzisToUsd,
   validateTuzis,
@@ -246,7 +247,7 @@ export function BuyTab() {
             <Input
               id="custom-tuzis"
               inputMode="numeric"
-              placeholder="e.g. 3,000"
+              placeholder={`e.g. ${tuziInputExample()}`}
               maxLength={tuziInputMaxLength(MAX_TUZIS)}
               value={custom}
               onChange={(e) => setCustom(e.target.value)}
@@ -270,7 +271,7 @@ export function BuyTab() {
             {hasCustomAmount && customAmount.error === "tooLarge"
               ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per purchase.`
               : hasCustomAmount && customAmount.error !== null
-                ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                ? `Enter a positive whole 2Z amount, e.g. ${tuziInputExample()}.`
                 : null}
           </div>
         </div>

--- a/wallet/zuuli/src/features/wallet/funding/SendTab.tsx
+++ b/wallet/zuuli/src/features/wallet/funding/SendTab.tsx
@@ -42,6 +42,7 @@ import {
   initials,
   MAX_TUZIS,
   parseTuzis,
+  tuziInputExample,
   tuziInputMaxLength,
   validateTuzis,
 } from "@/lib/format";
@@ -611,7 +612,7 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
             {hasCustomAmount && customAmount.error === "tooLarge"
               ? `Max ${MAX_TUZIS.toLocaleString()} 2Z per tip.`
               : hasCustomAmount && customAmount.error !== null
-                ? "Enter a positive whole 2Z amount; commas may separate thousands."
+                ? `Enter a positive whole 2Z amount, e.g. ${tuziInputExample()}.`
                 : null}
           </div>
         </div>

--- a/wallet/zuuli/src/lib/format.test.ts
+++ b/wallet/zuuli/src/lib/format.test.ts
@@ -12,7 +12,10 @@ import {
   validateTuzis,
 } from "./format";
 
-describe("parseTuzis", () => {
+// `parseTuzis` is locale-dependent now (#324), so tests asserting on ASCII
+// commas have to pin `locale: "en-US"` instead of relying on the runner's
+// default.
+describe("parseTuzis (en-US)", () => {
   it.each([
     ["0", 0],
     ["1", 1],
@@ -21,7 +24,7 @@ describe("parseTuzis", () => {
     ["1000000", 1_000_000],
     ["9,007,199,254,740,991", Number.MAX_SAFE_INTEGER],
   ])("parses exact whole 2Z input %s", (raw, expected) => {
-    expect(parseTuzis(raw)).toBe(expected);
+    expect(parseTuzis(raw, "en-US")).toBe(expected);
   });
 
   it.each([
@@ -45,7 +48,33 @@ describe("parseTuzis", () => {
     "9,007,199,254,740,992",
     "9".repeat(10_000),
   ])("rejects malformed or unsafe 2Z input %s", (raw) => {
-    expect(parseTuzis(raw)).toBeNull();
+    expect(parseTuzis(raw, "en-US")).toBeNull();
+  });
+});
+
+// #324: any 2Z amount the app displays (`formatTuzis`, i.e. `toLocaleString()`
+// in the runtime locale) must parse back verbatim, whatever locale that is —
+// different grouping separators, non-3-digit grouping, and non-ASCII digits.
+describe("parseTuzis round-trips formatTuzis's toLocaleString() display, per locale", () => {
+  const AMOUNTS = [0, 1, 999, 1_000, 12_345, 1_000_000, 10_00_000];
+
+  it.each([
+    "en-US",
+    "de-DE",
+    "fr-FR",
+    "hi-IN",
+    "ar-SA-u-nu-arab", // Arabic-Indic digits
+  ])("round-trips whole 2Z amounts displayed in %s", (locale) => {
+    for (const amount of AMOUNTS) {
+      const displayed = amount.toLocaleString(locale);
+      expect(parseTuzis(displayed, locale)).toBe(amount);
+    }
+  });
+
+  it("still rejects nonsense once locale glyphs are accounted for", () => {
+    expect(parseTuzis("1.000,00", "de-DE")).toBeNull(); // has a decimal part
+    expect(parseTuzis("abc", "hi-IN")).toBeNull();
+    expect(parseTuzis("", "fr-FR")).toBeNull();
   });
 });
 
@@ -84,38 +113,53 @@ describe("parseZecToZatoshis", () => {
   });
 });
 
-describe("whole-2Z form limits", () => {
+describe("whole-2Z form limits (en-US)", () => {
   it.each([
     ["purchase/tip", MAX_TUZIS],
     ["member price", MAX_MEMBER_PRICE_TUZIS],
     ["comment", MAX_COMMENT_TUZIS],
     ["whole PPV price", MAX_PPV_PRICE_TUZIS],
   ])("enforces the %s maximum", (_label, maximum) => {
-    expect(validateTuzis(String(maximum), { minimum: 1, maximum })).toEqual({
-      value: maximum,
-      error: null,
-    });
-    expect(validateTuzis(String(maximum + 1), { minimum: 1, maximum })).toEqual({
-      value: maximum + 1,
-      error: "tooLarge",
-    });
+    expect(
+      validateTuzis(String(maximum), { minimum: 1, maximum, locale: "en-US" }),
+    ).toEqual({ value: maximum, error: null });
+    expect(
+      validateTuzis(String(maximum + 1), {
+        minimum: 1,
+        maximum,
+        locale: "en-US",
+      }),
+    ).toEqual({ value: maximum + 1, error: "tooLarge" });
   });
 
   it("distinguishes malformed and below-minimum input", () => {
-    expect(validateTuzis("1e3", { minimum: 1, maximum: MAX_TUZIS }).error).toBe(
-      "invalid",
-    );
-    expect(validateTuzis("0", { minimum: 1, maximum: MAX_TUZIS }).error).toBe(
-      "tooSmall",
-    );
+    expect(
+      validateTuzis("1e3", { minimum: 1, maximum: MAX_TUZIS, locale: "en-US" })
+        .error,
+    ).toBe("invalid");
+    expect(
+      validateTuzis("0", { minimum: 1, maximum: MAX_TUZIS, locale: "en-US" })
+        .error,
+    ).toBe("tooSmall");
   });
 
   it("provides raw input lengths for canonical comma grouping", () => {
-    expect(tuziInputMaxLength(MAX_MEMBER_PRICE_TUZIS)).toBe("999,999".length);
-    expect(tuziInputMaxLength(MAX_TUZIS)).toBe("1,000,000".length);
-    expect(tuziInputMaxLength(MAX_COMMENT_TUZIS)).toBe("2,147,483,647".length);
-    expect(tuziInputMaxLength(MAX_PPV_PRICE_TUZIS)).toBe("9,999".length);
+    expect(tuziInputMaxLength(MAX_MEMBER_PRICE_TUZIS, "en-US")).toBe(
+      "999,999".length,
+    );
+    expect(tuziInputMaxLength(MAX_TUZIS, "en-US")).toBe("1,000,000".length);
+    expect(tuziInputMaxLength(MAX_COMMENT_TUZIS, "en-US")).toBe(
+      "2,147,483,647".length,
+    );
+    expect(tuziInputMaxLength(MAX_PPV_PRICE_TUZIS, "en-US")).toBe(
+      "9,999".length,
+    );
     expect(MAX_ZEC_INPUT_LENGTH).toBe("90071992.54740991".length);
+  });
+
+  it("gives the correct raw length for hi-IN's lakh (non-3-digit) grouping", () => {
+    expect(MAX_TUZIS.toLocaleString("hi-IN")).toBe("10,00,000");
+    expect(tuziInputMaxLength(MAX_TUZIS, "hi-IN")).toBe("10,00,000".length);
   });
 });
 

--- a/wallet/zuuli/src/lib/format.ts
+++ b/wallet/zuuli/src/lib/format.ts
@@ -40,39 +40,76 @@ export interface TuziInputResult {
   error: TuziInputError | null;
 }
 
-/** Maximum raw length for an integer that may contain canonical ASCII commas. */
-export function tuziInputMaxLength(maximum: number): number {
-  const digits = String(maximum).length;
-  return digits + Math.floor((digits - 1) / 3);
+/** Digits 0-9 in `locale`'s numbering system, mapped back to ASCII. */
+function localeDigits(locale?: string): Map<string, string> {
+  const fmt = new Intl.NumberFormat(locale, { useGrouping: false });
+  const map = new Map<string, string>();
+  for (let d = 0; d <= 9; d++) map.set(fmt.format(d), String(d));
+  return map;
+}
+
+/** `locale`'s grouping separator glyph, read off a real formatted number instead of hardcoded. */
+function localeGroupSeparator(locale?: string): string {
+  const part = new Intl.NumberFormat(locale)
+    .formatToParts(1234567)
+    .find((p) => p.type === "group");
+  return part?.value ?? ",";
+}
+
+/** Max raw input length for a whole 2Z amount, per `locale`'s own grouping (hi-IN groups in 2s, not just 3s). */
+export function tuziInputMaxLength(maximum: number, locale?: string): number {
+  return maximum.toLocaleString(locale).length;
 }
 
 /**
- * Parse an exact, non-negative whole-2Z amount.
- *
- * ASCII commas are the only supported grouping separator, and when present
- * they must delimit groups of three digits. Returning `null` (instead of a
- * fallback number) keeps malformed input from being silently changed before
- * it is displayed or submitted.
+ * Parse a whole-2Z amount using `locale`'s grouping separator and digits
+ * (default: runtime locale, same as `formatTuzis`). Mirrors display, so
+ * whatever the app shows parses back — see #324. `null` on anything
+ * malformed rather than a best-effort guess.
  */
-export function parseTuzis(raw: string): number | null {
-  if (!/^(?:0|[1-9]\d*|[1-9]\d{0,2}(?:,\d{3})+)$/.test(raw)) return null;
+export function parseTuzis(raw: string, locale?: string): number | null {
+  if (!raw) return null;
 
-  const normalized = raw.replace(/,/g, "");
+  const group = localeGroupSeparator(locale);
+  const digits = localeDigits(locale);
+  const hasGroupSeparator = group !== "" && raw.includes(group);
+  const stripped = hasGroupSeparator ? raw.split(group).join("") : raw;
+
+  let ascii = "";
+  for (const glyph of stripped) {
+    const digit = digits.get(glyph);
+    if (digit === undefined) return null;
+    ascii += digit;
+  }
+  if (!/^(?:0|[1-9]\d*)$/.test(ascii)) return null;
+
   // Bound work before BigInt construction, even when called outside an input
   // with maxLength (for example, from pasted/programmatic values).
-  if (normalized.length > MAX_SAFE_INTEGER_DIGITS) return null;
+  if (ascii.length > MAX_SAFE_INTEGER_DIGITS) return null;
 
-  const value = BigInt(normalized);
+  const value = BigInt(ascii);
   if (value > MAX_SAFE_INTEGER_BIGINT) return null;
-  return Number(value);
+  const num = Number(value);
+
+  // Ungrouped digits are fine as-is. If a separator is present it has to
+  // match the locale's canonical grouping for this value, or malformed
+  // shapes like "1,00" would silently parse as 100.
+  if (hasGroupSeparator && num.toLocaleString(locale) !== raw) return null;
+
+  return num;
+}
+
+/** Example grouped-integer string for input hints, in `locale` (e.g. "3,000", "3.000", "३,०००"). */
+export function tuziInputExample(value = 3000, locale?: string): string {
+  return value.toLocaleString(locale);
 }
 
 /** Parse a whole-2Z input and retain why a syntactically valid value failed. */
 export function validateTuzis(
   raw: string,
-  { minimum, maximum }: { minimum: number; maximum: number },
+  { minimum, maximum, locale }: { minimum: number; maximum: number; locale?: string },
 ): TuziInputResult {
-  const value = parseTuzis(raw);
+  const value = parseTuzis(raw, locale);
   if (value === null) return { value: null, error: "invalid" };
   if (value < minimum) return { value, error: "tooSmall" };
   if (value > maximum) return { value, error: "tooLarge" };
@@ -85,6 +122,10 @@ export function validateTuzis(
  * ZEC input deliberately supports no grouping separators and at most eight
  * decimal places. Integer arithmetic avoids the rounding that comes from
  * multiplying a JavaScript floating-point value by 1e8.
+ *
+ * NOTE: stays ASCII-only and locale-independent on purpose, unlike the 2Z
+ * (Tuzi) parsing above — ZEC is a consensus amount, not a display number.
+ * Don't make this locale-aware too. See #324.
  */
 export function parseZecToZatoshis(raw: string): number | null {
   const match = /^(\d+)(?:\.(\d{1,8}))?$/.exec(raw);
@@ -101,7 +142,12 @@ export function parseZecToZatoshis(raw: string): number | null {
   return Number(value);
 }
 
-/** Format zatoshis as a plain ZEC string (8dp). */
+/**
+ * Format zatoshis as a plain ZEC string (8dp).
+ *
+ * NOTE: same as `parseZecToZatoshis` — hard `.` decimal, Western digits, no
+ * locale grouping, on purpose.
+ */
 export function formatZec(zatoshis: number): string {
   if (!Number.isSafeInteger(zatoshis)) {
     throw new RangeError("Zatoshi amount must be a safe integer");

--- a/wallet/zuuli/tests/paid-actions.pw.ts
+++ b/wallet/zuuli/tests/paid-actions.pw.ts
@@ -131,10 +131,10 @@ test("send keeps malformed restored money text invalid instead of coercing it to
   await page.locator("[data-app-frame]").waitFor();
 
   await expect(page.getByLabel("Custom tip amount in 2Z")).toHaveValue("0100");
+  // The example in the hint is rendered in the browser's own locale, so match
+  // only the locale-independent prefix.
   await expect(
-    page.getByText(
-      "Enter a positive whole 2Z amount; commas may separate thousands.",
-    ),
+    page.getByText(/Enter a positive whole 2Z amount, e\.g\./),
   ).toBeVisible();
 });
 


### PR DESCRIPTION
## Summary

2Z amounts are displayed with locale-aware grouping (`toLocaleString()`)
but parsed with a regex that only accepted ASCII commas in strict
groups of three. Any user whose locale groups numbers differently
(de-DE periods, fr-FR narrow spaces, hi-IN's 3-then-2 grouping,
Arabic-Indic digits, ...) saw the app reject a number it had just
displayed.

- `parseTuzis`, `validateTuzis`, and `tuziInputMaxLength` now derive
  the grouping separator and digit glyphs from `Intl.NumberFormat` for
  the given locale (default: runtime locale, same as `formatTuzis`).
- Grouped input must match the locale's canonical grouping for that
  value exactly, so malformed shapes (`"1,00"`) are still rejected;
  ungrouped digit strings are always accepted.
- Hint copy and placeholders across Buy/Send/Tip/GoLive/Profile/Creator
  now show a locale-formatted example instead of a hardcoded
  `"e.g. 3,000"`.
- `formatZec`/`parseZecToZatoshis` (ZEC, not 2Z) are untouched and now
  carry an explicit comment: they stay ASCII-only by design, since ZEC
  is a consensus amount, not a display number.

## Testing

- `npm run typecheck` — clean
- `npm run test -- src/lib/format.test.ts` — 63/63 pass, including new
  round-trip coverage for `en-US`, `de-DE`, `fr-FR`, `hi-IN`, and an
  Arabic-Indic digit locale
- Full suite: 425 pass, 1 pre-existing unrelated failure (locale
  formatting in `TopBar.signed-in.test.tsx`, reproduces on `main`
  before this change too)
- Manually verified in a running dev server on a pt-BR system locale:
  the custom-amount field placeholder showed `"e.g. 3.000"`, typing
  `3.000` parsed correctly to 3,000 2Z with no error, typing `3.00`
  (wrong grouping) correctly showed the validation error

Fixes #324