### PR TITLE
test(zuuli): pin test runner locale

### DIFF
--- a/wallet/zuuli/playwright.config.ts
+++ b/wallet/zuuli/playwright.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
     browserName: "chromium",
     channel: process.env.CI ? "chrome" : undefined,
     colorScheme: "dark",
+    locale: "en-US",
+    timezoneId: "UTC",
     trace: "retain-on-failure",
   },
   webServer: {

--- a/wallet/zuuli/vite.config.ts
+++ b/wallet/zuuli/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
 
@@ -14,6 +14,15 @@ const apiTarget = process.env.VITE_F2Z_PROXY || "https://stage.free2z.cash";
 // reference wallet (1421). Tauri drives this via beforeDevCommand.
 export default defineConfig(async () => ({
   plugins: [react()],
+  test: {
+    // Workers must not inherit a contributor's locale or timezone. LC_ALL is
+    // pinned with LANG because it takes precedence on POSIX systems.
+    env: {
+      LANG: "en_US.UTF-8",
+      LC_ALL: "en_US.UTF-8",
+      TZ: "UTC",
+    },
+  },
   // `mathjax-full` (pulled in by rehype-mathjax for offline SVG math in the
   // Markdown renderer) reads its version via `eval('require')(...)` UNLESS a
   // global `PACKAGE_VERSION` is defined — see mathjax-full/js/components/


### PR DESCRIPTION
## Summary

- pin Vitest worker locale and timezone to en-US/UTC, including `LC_ALL` so it cannot override `LANG` on POSIX hosts
- pin Playwright browser contexts to en-US/UTC
- keep production locale-aware formatting and the existing `4,210` assertions unchanged

## Validation

- reproduced before the fix: the focused TopBar test passed under `en_US` and failed under `de_DE` (`4.210` vs `4,210`)
- focused Vitest and Playwright assertions pass under both `en_US`/`America/New_York` and `de_DE`/`Europe/Berlin`
- full frontend workflow surface under an outer `de_DE`/`Europe/Berlin` environment with Node 24.19.0:
  - 430 Vitest tests passed, 5 skipped
  - 77 Node tests passed
  - 98 Playwright tests passed
  - typecheck and production build passed
  - cache, icon, store, TestFlight, and high/critical audit gates passed
- action-pin and Rust-toolchain policy checks passed

Closes #449
