### PR TITLE
release(zuuli): prepare internal build 0.1.0+11

### DIFF
--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.zuuli",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 10,
+  "build": 11,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "10").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "11").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "10"
+        CFBundleVersion: "11"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -34,14 +34,14 @@
       "icons/icon.ico"
     ],
     "iOS": {
-      "bundleVersion": "10",
+      "bundleVersion": "11",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 10
+      "versionCode": 11
     }
   },
   "plugins": {


### PR DESCRIPTION
## Merging this PR performs a real store upload

A push to `main` that changes `wallet/zuuli/release.json` triggers
**ZUULI / protected release** (`.github/workflows/zuuli-release.yml`). On the
push path the workflow hard-codes `target=mobile` and `dry_run=false`
(lines 102-103), so squash-merging this **uploads signed builds to TestFlight
and Google Play internal test**. There is no dry run in between. Merge only
when you intend to ship `0.1.0+11` to testers.

Build 10 shipped on 2026-08-09. 46 commits have landed on `main` since,
including the full UI restyle (#457), and none of them have reached a tester.

## What changed

Produced entirely by the repo's own tool — nothing was hand-edited:

```
npm run release:bump -- --version=0.1.0 --build=11
```

(The script requires both `--version=` and `--build=` in `--name=value` form
and refuses to run on a dirty worktree.)

```
 wallet/zuuli/release.json                               | 2 +-
 wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts | 2 +-
 wallet/zuuli/src-tauri/gen/apple/project.yml            | 2 +-
 wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist   | 2 +-
 wallet/zuuli/src-tauri/tauri.conf.json                  | 4 ++--
 5 files changed, 6 insertions(+), 6 deletions(-)
```

Every changed line is the integer `10` becoming `11`:

- `release.json` — `"build": 11`
- `tauri.conf.json` — iOS `bundleVersion: "11"`, Android `versionCode: 11`
- `gen/apple/project.yml` — XcodeGen `CFBundleVersion: "11"`
- `gen/apple/zuuli_iOS/Info.plist` — `CFBundleVersion` `11`
- `gen/android/app/build.gradle.kts` — `tauri.android.versionCode` fallback `"11"`

Marketing version stays `0.1.0`, so `package.json`, `package-lock.json`,
`Cargo.toml`, and `Cargo.lock` are byte-identical and absent from the diff.
No behaviour, UI, or dependency change. `11` is the next free integer, which
satisfies both Play's strictly-increasing `versionCode` and App Store Connect's
unique-build-per-version rule.

## Verification (real output)

`npm run release:verify` on the pinned Node `24.18.0`, exit 0:

```
> zuuli@0.1.0 release:verify
> node scripts/release-identity.mjs

{"applicationId":"cash.free2z.zuuli","version":"0.1.0","build":11,"identity":"0.1.0+11","tag":"zuuli-v0.1.0+11"}
```

`node scripts/apple-credential-boundary.mjs`, exit 0:

```
Apple release build, credential, and finalization boundaries verified.
```

`node --test scripts/apple-credential-boundary.node-test.mjs`: 60 pass, 0 fail.

No signing material, keystore, profile, or credential of any kind is in the
diff — it is six integer literals.

`scripts/assert-no-apple-credentials.sh` is a **runner-environment canary**, not
a diff scanner: it asserts the *current machine* holds no ZUULI signing
authority. Run on the developer Mac it exits 1 with "found a Corpora signing
identity", because that Mac legitimately has a team `F9AV5HKF6N` codesigning
identity in its login keychain. Every other condition passes there (no
forbidden env var, no `zuuli-ios-sign.*`/`zuuli-macos-*` temp material, and the
ZUULI provisioning profile is absent). It says nothing about this PR's content;
it is meaningful only inside the credential-free CI jobs, where it will run.

Candidate-commit gates on `960ff6b`, per `docs/releasing.md` step 2:
`wallet/zuuli` (run 32557873199) and `ZUULI / packaging smoke`
(run 32557873181) both **success**.

## Context for whoever merges

1. **This is the first execution of the restructured credential path.** #443
   ("security(release): isolate Apple signing credentials", 2026-08-20) split
   iOS into credential-free build → sign → verify → upload → finalize, and the
   release workflow **has not run since**. Expect to watch this run closely; the
   rewritten Apple credential jobs are unexercised in production. Nothing here
   attempts to "fix" the workflow.
2. **The last three release runs (2026-08-19, pre-restructure) failed in the
   macOS desktop signing job.** That job is not on the push path — a push forces
   `target=mobile` — so it should not affect this release. Noted only so a
   reader of the run history is not misled.

## One thing that needs your call before merge

`docs/releasing.md` step 1 says to re-derive `wallet/zuuli/STATUS.md` from the
candidate source before promotion, and "do not start promotion with a stale
commit/date". `STATUS.md` currently reads:

> Last re-derived from `origin/main` at `1f752c74...` on 2026-08-19.

That is **21 commits behind** the candidate `960ff6b`. Re-deriving it requires
production/native evidence this PR cannot manufacture, so it is deliberately
untouched here rather than mechanically date-stamped. For an internal
TestFlight/Play-internal build this may well be an acceptable known gap — but
it is a documented pre-promotion step that has not been satisfied, and it is
your decision, not mine.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
