### PR TITLE
fix(zuuli): derive release identity in the store contract test

### DIFF
--- a/wallet/zuuli/scripts/store-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/store-contract.node-test.mjs
@@ -202,12 +202,18 @@ test("application and contact identities cannot drift", async (t) => {
 test("release identity is canonical, returned, and cannot drift", async (t) => {
   const root = await fixture();
   t.after(() => rm(root, { recursive: true, force: true }));
-  const valid = await validateStoreContract({ root });
-  assert.deepEqual(valid.release, { version: "0.1.0", build: 10 });
   const releasePath = resolve(root, "release.json");
   const release = JSON.parse(await readFile(releasePath, "utf8"));
-  release.applicationId = "example.invalid";
-  await writeJson(releasePath, release);
+  const valid = await validateStoreContract({ root });
+  assert.deepEqual(valid.release, { version: release.version, build: release.build });
+  // The identity is read, never assumed: an identity this repository has never
+  // shipped must come back verbatim, so a hardcoded constant cannot pass.
+  const rolled = { ...release, version: "9.9.9", build: release.build + 1000 };
+  await writeJson(releasePath, rolled);
+  assert.deepEqual((await validateStoreContract({ root })).release, { version: "9.9.9", build: release.build + 1000 });
+  await writeJson(releasePath, { ...release, version: "0.1" });
+  await rejectsCode(() => validateStoreContract({ root }), "IDENTITY_MISMATCH");
+  await writeJson(releasePath, { ...release, applicationId: "example.invalid" });
   await rejectsCode(() => validateStoreContract({ root }), "IDENTITY_MISMATCH");
 });
 


### PR DESCRIPTION
## Releasing ZUULI is currently impossible; this unblocks it

`wallet/zuuli/scripts/store-contract.node-test.mjs` asserted the release
identity returned by `validateStoreContract` against a **hardcoded literal**:

```js
assert.deepEqual(valid.release, { version: "0.1.0", build: 10 });
```

Its `fixture()` copies the **real** `release.json` into a temp root, so the
literal froze whatever the identity happened to be the day the file was added
(#417, 2026-08-19 — after the last bump, #364/build 10, which is why nobody hit
it until now). Every future build bump fails the `frontend` gate on it.

**This is a prerequisite for #460** (`0.1.0+10` → `0.1.0+11`), which currently
fails CI on exactly this assertion, and it unblocks all releases after it.

## Proof

All runs are `npm run test:store-listing` from `wallet/zuuli/`.

**1. Unmodified `main`, build 10 — passes** (the literal happens to match):

```
1..55
# tests 55
# pass 55
# fail 0
```

**2. Unmodified `main` + the #460 bump applied locally (`npm run release:bump -- --version=0.1.0 --build=11`) — FAILS:**

```
not ok 28 - release identity is canonical, returned, and cannot drift
  location: '.../scripts/store-contract.node-test.mjs:202:1'
  error: |-
    Expected values to be strictly deep-equal:
    + actual - expected

      {
    +   build: 11,
    -   build: 10,
        version: '0.1.0'
      }
  code: 'ERR_ASSERTION'
...
# tests 55
# pass 54
# fail 1
```

That one assertion is the *only* thing a bump breaks — 54/55 still pass.

**3. This fix + build 11 — passes:**

```
1..55
# tests 55
# pass 55
# fail 0
```

**4. This fix, bump reverted, back at build 10 — still passes:**

```
1..55
# tests 55
# pass 55
# fail 0
```

**5. The fixed test is not vacuous.** Deriving the expectation from the same
file the implementation reads could make the check hollow, so I mutation-tested
it: hardcoding `store-contract.mjs:390` back to `release: { version: "0.1.0",
build: 10 }` makes the new test fail:

```
not ok 28 - release identity is canonical, returned, and cannot drift
# pass 28
# fail 1
```

(implementation restored immediately; not part of this diff)

Also green from `wallet/zuuli/`: `npm run typecheck`, `npm run build`,
`npm run test` (vitest + node tests + 98 Playwright tests), `npm run store:validate`,
`npm run release:verify`, `npm run test:asc-testflight` (30 pass).

## The change

The whole diff is one test:

- The expectation now comes from the fixture's own `release.json` — proves
  **returned**.
- Added a positive step that rolls the fixture to an identity the repo has
  never shipped (`9.9.9+1010`) and requires it back verbatim. This is what keeps
  the derived assertion honest: a constant-returning implementation fails.
- Added a non-SemVer version (`"0.1"`) → `IDENTITY_MISMATCH`, backing the
  **canonical** half of the test's name.
- The existing `applicationId` drift rejection is **unchanged** — the part with
  teeth stays exactly as it was.

## Second literal: `store-state-audit.node-test.mjs:7` — left alone, deliberately

`release: { version: "0.1.0", build: 10 }` there is part of a **synthetic
`expected` fixture** the test constructs and injects as the `expected` argument
of `auditAppleStore`/`auditPlayStore` (and via a stubbed `validate:` in the
`main` tests). It is never compared against the real `release.json` — it sits
next to `sha256: "a".repeat(64)` and `https://example.com/` placeholders, and
its version is used to assert the mock's `filter[versionString]` query. A bump
cannot break it. Hardcoding is correct and idiomatic here.

## Sweep for the same trap

Checked every store/release contract suite:

| Location | Verdict |
| --- | --- |
| `store-contract.node-test.mjs:206` | **The bug** — fixed here. |
| `store-state-audit.node-test.mjs:7,57` | Synthetic fixture + mock query assertion. Safe. |
| `asc-testflight.node-test.mjs:22-23` (`VERSION`/`BUILD`) | Synthetic constants driving mocked ASC responses; never read from `release.json`. Safe. |
| `store-screenshot-contract.node-test.mjs` / `.mjs` | Pins Playwright `1.62.1` and a container digest — an intentional immutable capture contract, unrelated to release identity. Safe. |
| `store-contract.mjs:274`, `release-identity.mjs`, `release-manifest.mjs`, `store-state-audit.mjs` | All read `release.json` and validate *shape* (SemVer regex, `build >= 1`), never a specific value. Correct as-is. |

Empirically confirmed too: with the build-11 bump applied, exactly one
assertion in the whole `test:store-listing` suite failed.

## On a shared helper (considered, not done)

Deriving identity through one shared helper was considered. There is now exactly
**one** place that needs the real identity, so a helper would be indirection for
a single caller — noting the option rather than gold-plating. The real guard is
the mutation step above: if anyone reintroduces a constant, that assertion fails.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
