### PR TITLE
fix(zuuli): harden internal markdown routes

### DIFF
--- a/wallet/zuuli/scripts/safe-area-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/safe-area-contract.node-test.mjs
@@ -9,6 +9,7 @@ function source(relativeUrl) {
 const html = source("../index.html");
 const css = source("../src/index.css");
 const app = source("../src/App.tsx");
+const routes = source("../src/lib/routes.ts");
 const shell = source("../src/components/layout/AppShell.tsx");
 const topBar = source("../src/components/layout/TopBar.tsx");
 const sidebar = source("../src/components/layout/Sidebar.tsx");
@@ -92,13 +93,14 @@ test("the document and app are bounded to one dynamic viewport frame", () => {
 test("login stays inside pinned chrome with one bounded scroll owner", () => {
   const shellRoute = app.indexOf('<Route element={<AppShell />}>');
   const loginRoute = app.indexOf(
-    '<Route path="/login" element={<AuthFeature />} />',
+    '<Route path={APP_ROUTES.login} element={<AuthFeature />} />',
   );
   const catchAll = app.indexOf('<Route path="*" element={<NotFound />} />');
 
   assert.ok(shellRoute >= 0);
   assert.ok(loginRoute > shellRoute);
   assert.ok(loginRoute < catchAll);
+  assert.match(routes, /login: "\/login"/);
   assert.match(shell, /location\.pathname === "\/login"/);
   assert.equal(auth.match(/overflow-y-auto/g)?.length, 1);
   assert.equal(auth.match(/data-route-scroll/g)?.length, 1);

--- a/wallet/zuuli/src/App.tsx
+++ b/wallet/zuuli/src/App.tsx
@@ -17,6 +17,7 @@ import { useSession } from "@/store/session";
 import { useWallet } from "@/store/wallet";
 import { auth, tuzi } from "@/lib/api/free2z";
 import { setToken } from "@/lib/api/http";
+import { APP_ROUTES } from "@/lib/routes";
 import { useAttemptLease } from "@/hooks/useAttemptLease";
 import { recoverMobileOAuth } from "@/lib/oauth/transport";
 import {
@@ -205,7 +206,7 @@ export default function App() {
           {/* Every route lives inside the viewport-bound shell. A single Suspense boundary
               per route keeps the AppShell mounted while the lazy chunk loads. */}
           <Route element={<AppShell />}>
-            <Route path="/login" element={<AuthFeature />} />
+            <Route path={APP_ROUTES.login} element={<AuthFeature />} />
             <Route
               index
               element={
@@ -215,7 +216,7 @@ export default function App() {
               }
             />
             <Route
-              path="/search/*"
+              path={APP_ROUTES.search}
               element={
                 <Suspense fallback={<RouteFallback />}>
                   <SearchFeature />
@@ -223,7 +224,7 @@ export default function App() {
               }
             />
             <Route
-              path="/creator/:username/*"
+              path={APP_ROUTES.creator}
               element={
                 <Suspense fallback={<RouteFallback />}>
                   <CreatorFeature />
@@ -231,7 +232,7 @@ export default function App() {
               }
             />
             <Route
-              path="/profile"
+              path={APP_ROUTES.profile}
               element={
                 <Suspense fallback={<RouteFallback />}>
                   <ProfileFeature />
@@ -239,7 +240,7 @@ export default function App() {
               }
             />
             <Route
-              path="/kyc/*"
+              path={APP_ROUTES.kyc}
               element={
                 <Suspense fallback={<RouteFallback />}>
                   <KycFeature />
@@ -247,7 +248,7 @@ export default function App() {
               }
             />
             <Route
-              path="/wallet/*"
+              path={APP_ROUTES.wallet}
               element={
                 <Suspense fallback={<RouteFallback />}>
                   <WalletFeature />
@@ -255,7 +256,7 @@ export default function App() {
               }
             />
             <Route
-              path="/ai/*"
+              path={APP_ROUTES.ai}
               element={
                 <Suspense fallback={<RouteFallback />}>
                   <AiFeature />
@@ -263,7 +264,7 @@ export default function App() {
               }
             />
             <Route
-              path="/live/*"
+              path={APP_ROUTES.live}
               element={
                 <Suspense fallback={<RouteFallback />}>
                   <LiveFeature />
@@ -271,7 +272,7 @@ export default function App() {
               }
             />
             <Route
-              path="/articles/*"
+              path={APP_ROUTES.articles}
               element={
                 <Suspense fallback={<RouteFallback />}>
                   <ArticlesFeature />
@@ -279,7 +280,7 @@ export default function App() {
               }
             />
             <Route
-              path="/buy/*"
+              path={APP_ROUTES.buy}
               element={<LegacyBuyRedirect />}
             />
 

--- a/wallet/zuuli/src/components/common/Markdown.test.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.test.tsx
@@ -86,10 +86,27 @@ describe("Markdown links", () => {
     expect(markup).toContain('href="/articles/7th-meetup-zcash-club-queretaro"');
   });
 
+  it("preserves query strings and hashes when mapping a free2z content link", () => {
+    const markup = render(
+      "[section](/palmar/7th-meetup?ref=feed#schedule)",
+      "article",
+    );
+
+    expect(markup).toContain(
+      'href="/articles/7th-meetup?ref=feed#schedule"',
+    );
+  });
+
   it("maps a free2z {username} link onto the in-app creator route", () => {
     const markup = render("[palmar](/palmar)", "article");
 
     expect(markup).toContain('href="/creator/palmar"');
+  });
+
+  it("preserves query strings and hashes when mapping a creator link", () => {
+    const markup = render("[posts](/palmar?tab=posts#featured)", "article");
+
+    expect(markup).toContain('href="/creator/palmar?tab=posts#featured"');
   });
 
   it("routes an /uploadz link as out-of-app media instead of the SPA router", () => {

--- a/wallet/zuuli/src/components/common/Markdown.tsx
+++ b/wallet/zuuli/src/components/common/Markdown.tsx
@@ -22,6 +22,7 @@ import rehypeSlug from "rehype-slug";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { isTauri } from "@/lib/platform";
 import { mediaUrl } from "@/lib/api/http";
+import { APP_ROUTE_SEGMENTS } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 
 import remarkOembed from "@/lib/markdown/remark-oembed";
@@ -82,25 +83,6 @@ async function openExternal(url: string) {
 }
 
 /**
- * Path segments ZUULI itself routes (`src/App.tsx`). A relative href whose
- * first segment matches one of these is a genuine in-app path and must keep
- * navigating through the router exactly as before. `""` covers `/` (index).
- */
-const APP_ROUTE_SEGMENTS = new Set([
-  "",
-  "login",
-  "search",
-  "creator",
-  "profile",
-  "kyc",
-  "wallet",
-  "ai",
-  "live",
-  "articles",
-  "buy",
-]);
-
-/**
  * Article bodies are authored on free2z.cash, where relative hrefs mean
  * free2z routes — which mostly don't exist in ZUULI (issue #337). Classify a
  * non-anchor, non-external href so `MarkdownLink` can send it somewhere that
@@ -118,7 +100,9 @@ const APP_ROUTE_SEGMENTS = new Set([
 function classifyInternalHref(
   href: string,
 ): { kind: "app"; to: string } | { kind: "media"; url: string } {
-  const path = href.split(/[?#]/)[0] ?? "";
+  const suffixIndex = href.search(/[?#]/);
+  const path = suffixIndex === -1 ? href : href.slice(0, suffixIndex);
+  const suffix = suffixIndex === -1 ? "" : href.slice(suffixIndex);
   const segments = path.replace(/^\/+/, "").split("/").filter(Boolean);
   const first = segments[0] ?? "";
 
@@ -129,9 +113,9 @@ function classifyInternalHref(
     return { kind: "app", to: href };
   }
   if (segments.length >= 2) {
-    return { kind: "app", to: `/articles/${segments[1]}` };
+    return { kind: "app", to: `/articles/${segments[1]}${suffix}` };
   }
-  return { kind: "app", to: `/creator/${segments[0]}` };
+  return { kind: "app", to: `/creator/${segments[0]}${suffix}` };
 }
 
 /**

--- a/wallet/zuuli/src/lib/routes.ts
+++ b/wallet/zuuli/src/lib/routes.ts
@@ -1,0 +1,25 @@
+/**
+ * Top-level paths mounted by App. Keep route ownership here so consumers that
+ * classify links cannot drift from the router's actual path prefixes.
+ *
+ * `home` represents App's index route; the remaining values are passed
+ * directly to React Router.
+ */
+export const APP_ROUTES = {
+  home: "/",
+  login: "/login",
+  search: "/search/*",
+  creator: "/creator/:username/*",
+  profile: "/profile",
+  kyc: "/kyc/*",
+  wallet: "/wallet/*",
+  ai: "/ai/*",
+  live: "/live/*",
+  articles: "/articles/*",
+  buy: "/buy/*",
+} as const;
+
+/** First path segments that belong to ZUULI rather than free2z content. */
+export const APP_ROUTE_SEGMENTS = new Set(
+  Object.values(APP_ROUTES).map((route) => route.split("/")[1] ?? ""),
+);


### PR DESCRIPTION
Closes #451

## What changed

- define ZUULI's top-level route paths once and derive the Markdown classifier's segment set from them
- preserve query strings and hash fragments when free2z creator/article links map onto native ZUULI routes
- cover both mapped link shapes with focused regression tests
- update the safe-area source contract to follow the shared login route without weakening its `/login` assertion

## Verification

- `npm run typecheck`
- `npx vitest run src/components/common/Markdown.test.tsx` (16 passed)
- `node --test scripts/safe-area-contract.node-test.mjs` (5 passed)
- `npm run build`
