### PR TITLE
fix(zuuli): allow Playwright port override

### DIFF
--- a/wallet/zuuli/CLAUDE.md
+++ b/wallet/zuuli/CLAUDE.md
@@ -21,6 +21,7 @@ cd wallet/zuuli
 npm install
 npm run typecheck          # tsc --noEmit
 npm run build              # tsc && vite build
+ZUULI_PW_PORT=1433 npm run test # use a distinct Playwright port in parallel worktrees (default: 1432)
 VITE_MOCK=1 npm run dev    # browser fixtures on :1423 (UI/demo only)
 npm run dev                # real staging API on :1423; no native wallet
 npm run tauri dev          # native wallet + staging API by default

--- a/wallet/zuuli/playwright.config.ts
+++ b/wallet/zuuli/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "@playwright/test";
 
-const port = 1432;
+const port = Number(process.env.ZUULI_PW_PORT ?? 1432);
 
 export default defineConfig({
   testDir: "./tests",


### PR DESCRIPTION
Closes #459

## Summary
- allow `ZUULI_PW_PORT` to override Playwright’s dev-server and base URL port
- preserve port 1432 as the default
- document a parallel-worktree test invocation in `wallet/zuuli/CLAUDE.md`

## Verification
- `npm run typecheck`
- `npm run build`
- concurrent `npm run test` on default port 1432 and `ZUULI_PW_PORT=1433` (both passed: 472 Vitest assertions + 5 skipped, 79 Node contract tests, 98 Playwright tests)