### PR TITLE
test(zuuli): assert bundled fonts at runtime

### DIFF
--- a/wallet/zuuli/tests/fonts.pw.ts
+++ b/wallet/zuuli/tests/fonts.pw.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+
+test("bundled IBM Plex faces load and are applied", async ({ page }) => {
+  await page.goto("/");
+
+  const numeral = page.locator(".numeral").first();
+  await expect(numeral).toBeVisible();
+
+  const typography = await numeral.evaluate(async (element) => {
+    async function loaded(font: string, sample: string) {
+      try {
+        const faces = await document.fonts.load(font, sample);
+        return (
+          faces.length > 0 &&
+          faces.every((face) => face.status === "loaded") &&
+          document.fonts.check(font, sample)
+        );
+      } catch {
+        return false;
+      }
+    }
+
+    function primaryFamily(element: Element) {
+      return getComputedStyle(element).fontFamily
+        .split(",", 1)[0]
+        .trim()
+        .replace(/^['"]|['"]$/g, "");
+    }
+
+    const [sansLoaded, ...monoWeightsLoaded] = await Promise.all([
+      loaded('400 16px "IBM Plex Sans Variable"', "ZUULI"),
+      ...[400, 500, 600].map((weight) =>
+        loaded(`${weight} 16px "IBM Plex Mono"`, "0123456789"),
+      ),
+    ]);
+
+    return {
+      bodyPrimaryFamily: primaryFamily(document.body),
+      monoPrimaryFamily: primaryFamily(element),
+      sansLoaded,
+      monoLoaded: monoWeightsLoaded.every(Boolean),
+    };
+  });
+
+  expect(typography.sansLoaded, "the bundled Plex Sans face must load").toBe(true);
+  expect(typography.bodyPrimaryFamily, "Plex Sans must be applied to body text").toBe(
+    "IBM Plex Sans Variable",
+  );
+  expect(typography.monoLoaded, "the bundled Plex Mono face must load").toBe(true);
+  expect(typography.monoPrimaryFamily, "Plex Mono must be applied to numerals").toBe(
+    "IBM Plex Mono",
+  );
+});


### PR DESCRIPTION
Closes #458

## Summary
- load the bundled IBM Plex Sans variable face and every shipped IBM Plex Mono weight in a real browser
- require the font loads to resolve to actual FontFace entries with loaded status
- require Plex Sans and Plex Mono to be the primary computed families on body text and a rendered numeral surface

## Verification
- npm run typecheck
- npm run build
- npx playwright test tests/fonts.pw.ts
- npm test (472 Vitest assertions with 5 skipped, 79 Node contract tests, 99 Playwright tests)

## Red-path proof
Temporarily changed the Plex Sans source to /deliberately-missing-ibm-plex-sans.woff2: the focused Playwright test failed with a font NetworkError. Restored Sans, then temporarily changed the Plex Mono 500 source to /deliberately-missing-ibm-plex-mono.woff2: the focused test failed with the same NetworkError. Both mutations and the local-only Playwright port workaround were restored before commit.