### PR TITLE
fix(profile): prevent mobile dashboard overflow

### DIFF
--- a/ts/svelte/free2z/src/routes/[username]/dashboard/profile/+page.svelte
+++ b/ts/svelte/free2z/src/routes/[username]/dashboard/profile/+page.svelte
@@ -286,19 +286,21 @@
     <section class="grid grid-cols-2 gap-4 sm:grid-cols-4">
       <a href={allPagesUrl} class={STAT_CARD_LINK} data-testid="stat-published">
         <Card class={STAT_CARD}>
-          <CardContent class="flex items-center gap-3 p-4">
+          <CardContent
+            class="flex flex-col items-start gap-2 p-4 sm:flex-row sm:items-center sm:gap-3"
+          >
             <div class="shrink-0 rounded-full bg-primary/10 p-2.5">
               <FileText class="size-5 text-primary" />
             </div>
             <div class="min-w-0">
               <p
-                class="truncate text-2xl font-bold tabular-nums"
+                class="text-xl font-bold tabular-nums sm:text-2xl"
                 title={formatCount(publishedCount)}
               >
                 {formatCount(publishedCount)}
               </p>
               <p
-                class="truncate text-xs font-medium tracking-wider text-muted-foreground uppercase"
+                class="text-xs font-medium tracking-wider text-muted-foreground uppercase"
               >
                 Published
               </p>
@@ -309,19 +311,21 @@
 
       <a href="#drafts" class={STAT_CARD_LINK} data-testid="stat-drafts">
         <Card class={STAT_CARD}>
-          <CardContent class="flex items-center gap-3 p-4">
+          <CardContent
+            class="flex flex-col items-start gap-2 p-4 sm:flex-row sm:items-center sm:gap-3"
+          >
             <div class="shrink-0 rounded-full bg-primary/10 p-2.5">
               <Edit3 class="size-5 text-primary" />
             </div>
             <div class="min-w-0">
               <p
-                class="truncate text-2xl font-bold tabular-nums"
+                class="text-xl font-bold tabular-nums sm:text-2xl"
                 title={formatCount(draftCount)}
               >
                 {formatCount(draftCount)}
               </p>
               <p
-                class="truncate text-xs font-medium tracking-wider text-muted-foreground uppercase"
+                class="text-xs font-medium tracking-wider text-muted-foreground uppercase"
               >
                 Drafts
               </p>
@@ -338,23 +342,25 @@
       -->
       <a
         href={`/${creator.username}/dashboard/billing`}
-        class={STAT_CARD_LINK}
+        class={`${STAT_CARD_LINK} col-span-2 sm:col-span-1`}
         data-testid="stat-balance"
       >
         <Card class={STAT_CARD}>
-          <CardContent class="flex items-center gap-3 p-4">
+          <CardContent
+            class="flex flex-col items-start gap-2 p-4 sm:flex-row sm:items-center sm:gap-3"
+          >
             <div class="shrink-0 rounded-full bg-primary/10 p-2.5">
               <Sparkles class="size-5 text-primary" />
             </div>
             <div class="min-w-0">
               <p
-                class="truncate text-2xl font-bold tabular-nums"
+                class="text-xl font-bold tabular-nums sm:text-2xl"
                 title={formatTuzis(creator.tuzis)}
               >
                 {formatTuzis(creator.tuzis)}
               </p>
               <p
-                class="truncate text-xs font-medium tracking-wider text-muted-foreground uppercase"
+                class="text-xs font-medium tracking-wider text-muted-foreground uppercase"
               >
                 2Z Balance
               </p>
@@ -367,23 +373,25 @@
            reads `?section=subscribers` off the URL and selects that tab. -->
       <a
         href={`/${creator.username}/dashboard/billing?section=subscribers`}
-        class={STAT_CARD_LINK}
+        class={`${STAT_CARD_LINK} col-span-2 sm:col-span-1`}
         data-testid="stat-fans"
       >
         <Card class={STAT_CARD}>
-          <CardContent class="flex items-center gap-3 p-4">
+          <CardContent
+            class="flex flex-col items-start gap-2 p-4 sm:flex-row sm:items-center sm:gap-3"
+          >
             <div class="shrink-0 rounded-full bg-primary/10 p-2.5">
               <Users class="size-5 text-primary" />
             </div>
             <div class="min-w-0">
               <p
-                class="truncate text-2xl font-bold tabular-nums"
+                class="text-xl font-bold tabular-nums sm:text-2xl"
                 title={formatCount(creator.fans?.length || 0)}
               >
                 {formatCount(creator.fans?.length || 0)}
               </p>
               <p
-                class="truncate text-xs font-medium tracking-wider text-muted-foreground uppercase"
+                class="text-xs font-medium tracking-wider text-muted-foreground uppercase"
               >
                 Fans
               </p>
@@ -444,7 +452,7 @@
                   class="group space-y-2 rounded-xl border bg-card p-4 transition-colors hover:border-primary/50"
                 >
                   <div
-                    class="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center"
+                    class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"
                   >
                     <div class="min-w-0 flex-1 space-y-1">
                       <div class="flex items-center gap-2">
@@ -458,7 +466,7 @@
                         >
                       </div>
                       <h3
-                        class="truncate pr-4 text-base font-semibold text-foreground"
+                        class="line-clamp-2 pr-4 text-base font-semibold break-words text-foreground"
                       >
                         {draft.title || "Untitled"}
                       </h3>
@@ -545,7 +553,7 @@
                   class="group space-y-2 rounded-xl border bg-card p-4 transition-colors hover:border-primary/50"
                 >
                   <div
-                    class="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center"
+                    class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"
                   >
                     <div class="min-w-0 flex-1 space-y-1">
                       <div class="flex items-center gap-2">
@@ -559,7 +567,7 @@
                         >
                       </div>
                       <h3
-                        class="truncate pr-4 text-base font-semibold text-foreground"
+                        class="line-clamp-2 pr-4 text-base font-semibold break-words text-foreground"
                       >
                         <a
                           href={pageUrl(page)}

--- a/ts/svelte/free2z/tests/profile-mobile-layout.test.mjs
+++ b/ts/svelte/free2z/tests/profile-mobile-layout.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const PROFILE = "src/routes/[username]/dashboard/profile/+page.svelte";
+const source = readFileSync(
+  fileURLToPath(new URL(`../${PROFILE}`, import.meta.url)),
+  "utf8",
+);
+
+// These mirror the shapes that exposed the production bug. They document why
+// the row contract requires wrapping instead of `truncate`, even though this
+// repository does not yet have a browser layout harness.
+const LONG_TITLE =
+  "A production-shaped creator title that stays readable on narrow mobile screens";
+const UNBROKEN_TITLE = "z".repeat(80);
+
+function occurrences(haystack, needle) {
+  return haystack.split(needle).length - 1;
+}
+
+function openingTagForTestId(testId) {
+  const marker = `data-testid="${testId}"`;
+  const markerIndex = source.indexOf(marker);
+  assert.notEqual(markerIndex, -1, `${PROFILE} must retain ${marker}`);
+  const start = source.lastIndexOf("<a", markerIndex);
+  const end = source.indexOf(">", markerIndex);
+  assert.notEqual(start, -1, `${testId} must remain an anchor`);
+  assert.notEqual(end, -1, `${testId} anchor must have a closing bracket`);
+  return source.slice(start, end + 1);
+}
+
+test("profile title fixtures cover production-shaped wrapping pressure", () => {
+  assert.ok(LONG_TITLE.length >= 60 && LONG_TITLE.length <= 90);
+  assert.match(LONG_TITLE, /\s/);
+  assert.equal(UNBROKEN_TITLE.length, 80);
+  assert.doesNotMatch(UNBROKEN_TITLE, /\s/);
+});
+
+test("mobile stat tiles stack without truncating interface copy", () => {
+  const sectionStart = source.indexOf(
+    '<section class="grid grid-cols-2 gap-4 sm:grid-cols-4">',
+  );
+  const sectionEnd = source.indexOf("</section>", sectionStart);
+  assert.notEqual(sectionStart, -1, "stats section must exist");
+  assert.notEqual(sectionEnd, -1, "stats section must close");
+  const stats = source.slice(sectionStart, sectionEnd);
+
+  assert.equal(
+    occurrences(
+      stats,
+      'class="flex flex-col items-start gap-2 p-4 sm:flex-row sm:items-center sm:gap-3"',
+    ),
+    4,
+    "all four stat tiles must stack on mobile",
+  );
+  assert.equal(
+    occurrences(stats, "text-xl font-bold tabular-nums sm:text-2xl"),
+    4,
+    "all four stat values must use the measured responsive size",
+  );
+  assert.doesNotMatch(
+    stats,
+    /\btruncate\b/,
+    "interface copy must never truncate",
+  );
+
+  for (const testId of ["stat-balance", "stat-fans"]) {
+    assert.match(
+      openingTagForTestId(testId),
+      /col-span-2 sm:col-span-1/,
+      `${testId} must span the mobile grid without leaving a hole`,
+    );
+  }
+});
+
+test("draft and published rows shrink while user titles wrap and clamp", () => {
+  assert.equal(
+    occurrences(
+      source,
+      'class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"',
+    ),
+    2,
+    "both page rows must stretch their mobile children to the available width",
+  );
+  assert.doesNotMatch(
+    source,
+    /flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center/,
+  );
+  assert.equal(
+    occurrences(
+      source,
+      'class="line-clamp-2 pr-4 text-base font-semibold break-words text-foreground"',
+    ),
+    2,
+    "long and unbroken user-authored titles must wrap before clamping",
+  );
+});


### PR DESCRIPTION
## Summary

- apply the measured mobile stat-tile layout: stack at narrow widths, remove UI-copy truncation, and let balance/fans span the two-column grid
- let draft and published rows stretch their content width, then wrap and clamp user-authored titles
- add a focused source-contract regression test covering all affected rows and tiles, with production-shaped and unbroken title fixtures

## Verification

- negative control: the new layout test failed on the original markup (0/4 mobile stat layouts and 0/2 shrinkable page rows)
- `npm test` (44 passed)
- `npm run check` (0 errors; 2 pre-existing deprecation warnings)
- `npm run build`
- targeted Prettier check
- headless Chrome checks at 320px, 360px, and 390px: no horizontal overflow; long/unbroken titles and stat copy fit
- `git diff --check origin/main...HEAD`

## Limitation

This Svelte app has no committed browser-test harness. The durable regression is therefore a source-contract test; the viewport checks used the generated production CSS and local headless Chrome.

Closes #382