### PR TITLE
fix(zuuli): persist canonical Send draft amounts

### DIFF
--- a/wallet/zuuli/src/features/wallet/funding/SendTab.tsx
+++ b/wallet/zuuli/src/features/wallet/funding/SendTab.tsx
@@ -111,7 +111,10 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
     if (!restoredSend || restoredHandled.current) return;
     restoredHandled.current = true;
     dispatch({ type: "queryChanged", query: restoredSend.query });
-    const restoredAmount = parseTuzis(restoredSend.amount);
+    const restoredAmount =
+      typeof restoredSend.amount === "number"
+        ? restoredSend.amount
+        : parseTuzis(restoredSend.amount);
     if (
       restoredAmount !== null &&
       TIP_PRESETS.some((preset) => preset === restoredAmount)
@@ -119,7 +122,11 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
       setSelectedAmount(restoredAmount);
       setCustom("");
     } else {
-      setCustom(restoredSend.amount);
+      setCustom(
+        typeof restoredSend.amount === "number"
+          ? restoredSend.amount.toLocaleString()
+          : restoredSend.amount,
+      );
     }
   }, [restoredSend]);
 
@@ -317,7 +324,7 @@ export function SendTab({ onNeedBuy }: { onNeedBuy: () => void }) {
     const returnTo = preservePaidIntent("/wallet/fund/send", {
       kind: "send",
       query: recipientState.query,
-      amount: custom || String(selectedAmount),
+      amount: validAmount && amount !== null ? amount : custom,
     });
     navigate("/login", { state: { returnTo } });
   }

--- a/wallet/zuuli/src/lib/auth/paid-intent.test.ts
+++ b/wallet/zuuli/src/lib/auth/paid-intent.test.ts
@@ -35,6 +35,47 @@ describe("paid login intent", () => {
     expect(consumePaidIntent("/ai", "ai", storage, 200)).toBeNull();
   });
 
+  it("round-trips canonical numeric Send amounts while accepting the legacy string shape", () => {
+    const storage = new MemoryStorage();
+
+    preservePaidIntent(
+      "/wallet/fund/send",
+      { kind: "send", query: "alice", amount: 3_000 },
+      storage,
+      100,
+    );
+    expect(consumePaidIntent("/wallet/fund/send", "send", storage, 200)).toEqual({
+      kind: "send",
+      query: "alice",
+      amount: 3_000,
+    });
+
+    storage.value = JSON.stringify({
+      returnTo: "/wallet/fund/send",
+      createdAt: 100,
+      intent: { kind: "send", query: "alice", amount: "3,000" },
+    });
+    expect(consumePaidIntent("/wallet/fund/send", "send", storage, 200)).toEqual({
+      kind: "send",
+      query: "alice",
+      amount: "3,000",
+    });
+  });
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 1_000_001])(
+    "rejects an invalid canonical Send amount (%s)",
+    (amount) => {
+      const storage = new MemoryStorage();
+      preservePaidIntent(
+        "/wallet/fund/send",
+        { kind: "send", query: "alice", amount } as never,
+        storage,
+        100,
+      );
+      expect(storage.value).toBeNull();
+    },
+  );
+
   it.each([
     ["/ai", { kind: "ai", draft: "draft" }],
     [

--- a/wallet/zuuli/src/lib/auth/paid-intent.ts
+++ b/wallet/zuuli/src/lib/auth/paid-intent.ts
@@ -2,6 +2,7 @@ import {
   safeLoginDestination,
   type LoginDestination,
 } from "./login-destination";
+import { MAX_TUZIS } from "@/lib/format";
 
 const STORAGE_KEY = "zuuli.auth.pending-paid-intent";
 const MAX_AGE_MS = 30 * 60 * 1000;
@@ -16,7 +17,7 @@ export type PaidIntent =
   | { kind: "article-tip"; subject: string; amount: string }
   | { kind: "creator-tip"; subject: string; amount: string }
   | { kind: "creator-subscription"; subject: string }
-  | { kind: "send"; query: string; amount: string }
+  | { kind: "send"; query: string; amount: number | string }
   | { kind: "live-entry"; subject: string; mode: "ppv" | "subscriber" };
 
 interface StoredPaidIntent {
@@ -42,6 +43,19 @@ function usernameString(value: unknown): value is string {
   return typeof value === "string" && [...value].length <= MAX_USERNAME;
 }
 
+function sendAmount(value: unknown): value is number | string {
+  // Strings are the one-release migration shape and deliberately remain
+  // permissive: malformed legacy input must restore as invalid UI text rather
+  // than being coerced into a different amount. New valid drafts use numbers.
+  return (
+    shortString(value, 32) ||
+    (typeof value === "number" &&
+      Number.isSafeInteger(value) &&
+      value >= 1 &&
+      value <= MAX_TUZIS)
+  );
+}
+
 function validIntent(value: unknown): value is PaidIntent {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
@@ -54,7 +68,7 @@ function validIntent(value: unknown): value is PaidIntent {
     case "creator-subscription":
       return usernameString(record.subject);
     case "send":
-      return usernameString(record.query) && shortString(record.amount, 32);
+      return usernameString(record.query) && sendAmount(record.amount);
     case "live-entry":
       return (
         usernameString(record.subject) &&

--- a/wallet/zuuli/tests/paid-actions.pw.ts
+++ b/wallet/zuuli/tests/paid-actions.pw.ts
@@ -99,7 +99,7 @@ test("send restores its bounded draft only after login and never diagnoses a gue
   await page
     .getByRole("combobox", { name: "Search for a 2Z recipient" })
     .fill("maya");
-  await page.getByLabel("Custom tip amount in 2Z").fill("5000");
+  await page.getByLabel("Custom tip amount in 2Z").fill("3,000");
   await expectNoAnonymousBalanceDiagnosis(page);
   await page.getByRole("button", { name: "Sign in to send 2Z" }).click();
 
@@ -108,8 +108,36 @@ test("send restores its bounded draft only after login and never diagnoses a gue
     .poll(() => storedIntent(page))
     .toMatchObject({
       returnTo: "/wallet/fund/send",
-      intent: { kind: "send", query: "maya", amount: "5000" },
+      intent: { kind: "send", query: "maya", amount: 3000 },
     });
+});
+
+test.describe("locale-invariant Send drafts", () => {
+  test.use({ locale: "de-DE" });
+
+  test("formats a canonical amount in the locale active after login", async ({
+    page,
+  }) => {
+    await page.setViewportSize(PHONE);
+    await page.addInitScript(() => {
+      localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+      sessionStorage.setItem(
+        "zuuli.auth.pending-paid-intent",
+        JSON.stringify({
+          returnTo: "/wallet/fund/send",
+          createdAt: Date.now(),
+          intent: { kind: "send", query: "maya", amount: 3000 },
+        }),
+      );
+    });
+
+    await page.goto("/wallet/fund/send");
+    await page.locator("[data-app-frame]").waitFor();
+
+    await expect(page.getByLabel("Custom tip amount in 2Z")).toHaveValue(
+      "3.000",
+    );
+  });
 });
 
 test("send keeps malformed restored money text invalid instead of coercing it to a preset", async ({


### PR DESCRIPTION
Closes #450

## What changed

- persist valid Send amounts as bounded whole numbers instead of locale-formatted display strings
- format canonical numbers only when restoring into the current runtime locale
- accept the legacy string shape for migration and keep malformed legacy text invalid rather than coercing it
- reject invalid numeric persisted amounts at the paid-intent boundary

## Verification

- `npm run typecheck`
- `npx vitest run src/lib/auth/paid-intent.test.ts` (22 passed)
- `npx playwright test tests/paid-actions.pw.ts` (16 passed)
- `npm run build`
- `npm test` (479 Vitest passed, 5 skipped; 79 Node contract passed; 99 Playwright passed)

The browser coverage writes grouped `3,000` under en-US, asserts storage contains the locale-invariant number `3000`, and restores that canonical number under de-DE as `3.000`. The existing malformed-string regression remains green.
