### PR TITLE
fix(zuuli): paginate creator catalogs

### DIFF
--- a/wallet/zuuli/src/features/creator/catalog.test.ts
+++ b/wallet/zuuli/src/features/creator/catalog.test.ts
@@ -51,4 +51,27 @@ describe("creator catalog pagination", () => {
       ),
     ).toThrow("count changed");
   });
+
+  it("fails closed when a nonterminal page adds no unique rows", () => {
+    expect(() =>
+      mergeCreatorCatalogPage(
+        initial(2),
+        { items: [], next: 2, count: 2 },
+        1,
+      ),
+    ).toThrow("made no progress");
+
+    const first = mergeCreatorCatalogPage(
+      initial(2),
+      { items: [article(1)], next: 2, count: 2 },
+      1,
+    );
+    expect(() =>
+      mergeCreatorCatalogPage(
+        first,
+        { items: [article(1)], next: 3, count: 2 },
+        2,
+      ),
+    ).toThrow("made no progress");
+  });
 });

--- a/wallet/zuuli/src/features/creator/catalog.test.ts
+++ b/wallet/zuuli/src/features/creator/catalog.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { Article } from "@/lib/api/types";
+import {
+  mergeCreatorCatalogPage,
+  type CreatorCatalogSnapshot,
+} from "./catalog";
+
+function article(id: number): Article {
+  return {
+    id,
+    free2zaddr: String(id),
+    title: `Page ${id}`,
+    content: "",
+    author: { username: "creator", free2zaddr: "creator" },
+  };
+}
+
+function initial(count: number): CreatorCatalogSnapshot {
+  return { items: [], next: 1, count, initialized: false };
+}
+
+describe("creator catalog pagination", () => {
+  it("deduplicates overlapping pages and completes at the authoritative count", () => {
+    const first = mergeCreatorCatalogPage(
+      initial(3),
+      { items: [article(1), article(2)], next: 2, count: 3 },
+      1,
+    );
+    const complete = mergeCreatorCatalogPage(
+      first,
+      { items: [article(2), article(3)], next: null, count: 3 },
+      2,
+    );
+    expect(complete.items.map(({ id }) => id)).toEqual([1, 2, 3]);
+    expect(complete.next).toBeNull();
+  });
+
+  it("fails closed on count drift or an incomplete terminal page", () => {
+    expect(() =>
+      mergeCreatorCatalogPage(
+        initial(2),
+        { items: [article(1)], next: null, count: 2 },
+        1,
+      ),
+    ).toThrow("incomplete catalog");
+    expect(() =>
+      mergeCreatorCatalogPage(
+        initial(2),
+        { items: [article(1)], next: null, count: 3 },
+        1,
+      ),
+    ).toThrow("count changed");
+  });
+});

--- a/wallet/zuuli/src/features/creator/catalog.test.ts
+++ b/wallet/zuuli/src/features/creator/catalog.test.ts
@@ -15,14 +15,14 @@ function article(id: number): Article {
   };
 }
 
-function initial(count: number): CreatorCatalogSnapshot {
-  return { items: [], next: 1, count, initialized: false };
+function initial(): CreatorCatalogSnapshot {
+  return { items: [], next: 1, count: null, initialized: false };
 }
 
 describe("creator catalog pagination", () => {
   it("deduplicates overlapping pages and completes at the authoritative count", () => {
     const first = mergeCreatorCatalogPage(
-      initial(3),
+      initial(),
       { items: [article(1), article(2)], next: 2, count: 3 },
       1,
     );
@@ -35,34 +35,52 @@ describe("creator catalog pagination", () => {
     expect(complete.next).toBeNull();
   });
 
-  it("fails closed on count drift or an incomplete terminal page", () => {
+  it("adopts the first list response count independently of its profile hint", () => {
+    expect(
+      mergeCreatorCatalogPage(
+        initial(),
+        { items: [article(1)], next: null, count: 1 },
+        1,
+      ),
+    ).toMatchObject({ count: 1, initialized: true });
+    expect(
+      mergeCreatorCatalogPage(
+        initial(),
+        { items: [], next: null, count: 0 },
+        1,
+      ),
+    ).toMatchObject({ count: 0, initialized: true });
+  });
+
+  it("fails closed on list count drift or an incomplete terminal page", () => {
     expect(() =>
       mergeCreatorCatalogPage(
-        initial(2),
+        initial(),
         { items: [article(1)], next: null, count: 2 },
         1,
       ),
     ).toThrow("incomplete catalog");
+    const first = mergeCreatorCatalogPage(
+      initial(),
+      { items: [article(1)], next: 2, count: 2 },
+      1,
+    );
     expect(() =>
       mergeCreatorCatalogPage(
-        initial(2),
-        { items: [article(1)], next: null, count: 3 },
-        1,
+        first,
+        { items: [article(2)], next: null, count: 3 },
+        2,
       ),
     ).toThrow("count changed");
   });
 
   it("fails closed when a nonterminal page adds no unique rows", () => {
     expect(() =>
-      mergeCreatorCatalogPage(
-        initial(2),
-        { items: [], next: 2, count: 2 },
-        1,
-      ),
+      mergeCreatorCatalogPage(initial(), { items: [], next: 2, count: 2 }, 1),
     ).toThrow("made no progress");
 
     const first = mergeCreatorCatalogPage(
-      initial(2),
+      initial(),
       { items: [article(1)], next: 2, count: 2 },
       1,
     );

--- a/wallet/zuuli/src/features/creator/catalog.ts
+++ b/wallet/zuuli/src/features/creator/catalog.ts
@@ -5,7 +5,8 @@ import type { Article, CreatorPagesPage } from "@/lib/api/types";
 export interface CreatorCatalogSnapshot {
   items: Article[];
   next: number | null;
-  count: number;
+  /** Authoritative list count, unknown until page 1 succeeds. */
+  count: number | null;
   initialized: boolean;
 }
 
@@ -30,17 +31,14 @@ function remember(username: string, snapshot: CreatorCatalogSnapshot) {
   }
 }
 
-function initialCatalog(
-  username: string,
-  expectedCount: number,
-): CreatorCatalogSnapshot {
+function initialCatalog(username: string): CreatorCatalogSnapshot {
   const cached = catalogCache.get(cacheKey(username));
-  if (cached?.count === expectedCount) return cached;
+  if (cached) return cached;
   return {
     items: [],
-    next: expectedCount === 0 ? null : 1,
-    count: expectedCount,
-    initialized: expectedCount === 0,
+    next: 1,
+    count: null,
+    initialized: false,
   };
 }
 
@@ -53,12 +51,13 @@ export function mergeCreatorCatalogPage(
   response: CreatorPagesPage,
   requestedPage: number,
 ): CreatorCatalogSnapshot {
-  if (response.count !== current.count) {
+  if (current.count !== null && response.count !== current.count) {
     throw new Error("Creator catalog count changed during the read.");
   }
   if (requestedPage !== current.next) {
     throw new Error("Creator catalog received an unexpected page.");
   }
+  const count = current.count ?? response.count;
 
   const seen = new Set(current.items.map((item) => String(item.id)));
   const items = [...current.items];
@@ -70,16 +69,16 @@ export function mergeCreatorCatalogPage(
     }
   }
 
-  if (items.length > current.count) {
+  if (items.length > count) {
     throw new Error("Creator catalog exceeded its authoritative count.");
   }
-  if (response.next === null && items.length !== current.count) {
+  if (response.next === null && items.length !== count) {
     throw new Error("Creator pagination returned an incomplete catalog.");
   }
   if (response.next !== null && items.length === current.items.length) {
     throw new Error("Creator pagination made no progress.");
   }
-  if (response.next !== null && items.length >= current.count) {
+  if (response.next !== null && items.length >= count) {
     throw new Error(
       "Creator pagination continued past its authoritative count.",
     );
@@ -88,20 +87,20 @@ export function mergeCreatorCatalogPage(
   return {
     items,
     next: response.next,
-    count: current.count,
+    count,
     initialized: true,
   };
 }
 
-export function useCreatorCatalog(username: string, expectedCount: number) {
+export function useCreatorCatalog(username: string) {
   const [state, setState] = useState<CreatorCatalogState>(() => ({
-    ...initialCatalog(username, expectedCount),
+    ...initialCatalog(username),
     error: null,
     loading: false,
   }));
   const stateRef = useRef(state);
   const requestIdRef = useRef(0);
-  const resourceRef = useRef(`${cacheKey(username)}:${expectedCount}`);
+  const resourceRef = useRef(cacheKey(username));
   stateRef.current = state;
 
   const load = useCallback(
@@ -133,11 +132,11 @@ export function useCreatorCatalog(username: string, expectedCount: number) {
   );
 
   useEffect(() => {
-    const resource = `${cacheKey(username)}:${expectedCount}`;
+    const resource = cacheKey(username);
     if (resourceRef.current !== resource) {
       resourceRef.current = resource;
       requestIdRef.current += 1;
-      const initial = initialCatalog(username, expectedCount);
+      const initial = initialCatalog(username);
       setState({ ...initial, error: null, loading: false });
       stateRef.current = { ...initial, error: null, loading: false };
     }
@@ -145,7 +144,7 @@ export function useCreatorCatalog(username: string, expectedCount: number) {
     if (!current.initialized && current.next !== null && !current.loading) {
       void load(current.next);
     }
-  }, [expectedCount, load, username]);
+  }, [load, username]);
 
   const loadMore = useCallback(() => {
     const next = stateRef.current.next;

--- a/wallet/zuuli/src/features/creator/catalog.ts
+++ b/wallet/zuuli/src/features/creator/catalog.ts
@@ -76,6 +76,9 @@ export function mergeCreatorCatalogPage(
   if (response.next === null && items.length !== current.count) {
     throw new Error("Creator pagination returned an incomplete catalog.");
   }
+  if (response.next !== null && items.length === current.items.length) {
+    throw new Error("Creator pagination made no progress.");
+  }
   if (response.next !== null && items.length >= current.count) {
     throw new Error(
       "Creator pagination continued past its authoritative count.",

--- a/wallet/zuuli/src/features/creator/catalog.ts
+++ b/wallet/zuuli/src/features/creator/catalog.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { discover } from "@/lib/api/free2z";
+import type { Article, CreatorPagesPage } from "@/lib/api/types";
+
+export interface CreatorCatalogSnapshot {
+  items: Article[];
+  next: number | null;
+  count: number;
+  initialized: boolean;
+}
+
+interface CreatorCatalogState extends CreatorCatalogSnapshot {
+  error: unknown | null;
+  loading: boolean;
+}
+
+const catalogCache = new Map<string, CreatorCatalogSnapshot>();
+const MAX_CACHED_CREATORS = 20;
+
+function cacheKey(username: string): string {
+  return username.toLowerCase();
+}
+
+function remember(username: string, snapshot: CreatorCatalogSnapshot) {
+  const key = cacheKey(username);
+  catalogCache.delete(key);
+  catalogCache.set(key, snapshot);
+  if (catalogCache.size > MAX_CACHED_CREATORS) {
+    catalogCache.delete(catalogCache.keys().next().value as string);
+  }
+}
+
+function initialCatalog(
+  username: string,
+  expectedCount: number,
+): CreatorCatalogSnapshot {
+  const cached = catalogCache.get(cacheKey(username));
+  if (cached?.count === expectedCount) return cached;
+  return {
+    items: [],
+    next: expectedCount === 0 ? null : 1,
+    count: expectedCount,
+    initialized: expectedCount === 0,
+  };
+}
+
+/**
+ * Append one API page without allowing count drift or duplicate cards.
+ * A terminal cursor is accepted only when every authoritative row is present.
+ */
+export function mergeCreatorCatalogPage(
+  current: CreatorCatalogSnapshot,
+  response: CreatorPagesPage,
+  requestedPage: number,
+): CreatorCatalogSnapshot {
+  if (response.count !== current.count) {
+    throw new Error("Creator catalog count changed during the read.");
+  }
+  if (requestedPage !== current.next) {
+    throw new Error("Creator catalog received an unexpected page.");
+  }
+
+  const seen = new Set(current.items.map((item) => String(item.id)));
+  const items = [...current.items];
+  for (const item of response.items) {
+    const identity = String(item.id);
+    if (!seen.has(identity)) {
+      seen.add(identity);
+      items.push(item);
+    }
+  }
+
+  if (items.length > current.count) {
+    throw new Error("Creator catalog exceeded its authoritative count.");
+  }
+  if (response.next === null && items.length !== current.count) {
+    throw new Error("Creator pagination returned an incomplete catalog.");
+  }
+  if (response.next !== null && items.length >= current.count) {
+    throw new Error(
+      "Creator pagination continued past its authoritative count.",
+    );
+  }
+
+  return {
+    items,
+    next: response.next,
+    count: current.count,
+    initialized: true,
+  };
+}
+
+export function useCreatorCatalog(username: string, expectedCount: number) {
+  const [state, setState] = useState<CreatorCatalogState>(() => ({
+    ...initialCatalog(username, expectedCount),
+    error: null,
+    loading: false,
+  }));
+  const stateRef = useRef(state);
+  const requestIdRef = useRef(0);
+  const resourceRef = useRef(`${cacheKey(username)}:${expectedCount}`);
+  stateRef.current = state;
+
+  const load = useCallback(
+    async (page: number) => {
+      if (stateRef.current.loading) return;
+      const requestId = ++requestIdRef.current;
+      stateRef.current = { ...stateRef.current, error: null, loading: true };
+      setState((current) => ({ ...current, error: null, loading: true }));
+      try {
+        const response = await discover.creatorPages(username, page);
+        if (requestIdRef.current !== requestId) return;
+        const merged = mergeCreatorCatalogPage(
+          stateRef.current,
+          response,
+          page,
+        );
+        const nextState = { ...merged, error: null, loading: false };
+        stateRef.current = nextState;
+        remember(username, merged);
+        setState(nextState);
+      } catch (error) {
+        if (requestIdRef.current !== requestId) return;
+        const nextState = { ...stateRef.current, error, loading: false };
+        stateRef.current = nextState;
+        setState(nextState);
+      }
+    },
+    [username],
+  );
+
+  useEffect(() => {
+    const resource = `${cacheKey(username)}:${expectedCount}`;
+    if (resourceRef.current !== resource) {
+      resourceRef.current = resource;
+      requestIdRef.current += 1;
+      const initial = initialCatalog(username, expectedCount);
+      setState({ ...initial, error: null, loading: false });
+      stateRef.current = { ...initial, error: null, loading: false };
+    }
+    const current = stateRef.current;
+    if (!current.initialized && current.next !== null && !current.loading) {
+      void load(current.next);
+    }
+  }, [expectedCount, load, username]);
+
+  const loadMore = useCallback(() => {
+    const next = stateRef.current.next;
+    if (next !== null) void load(next);
+  }, [load]);
+
+  const retry = useCallback(() => {
+    const next = stateRef.current.next;
+    if (next !== null) void load(next);
+  }, [load]);
+
+  return { ...state, loadMore, retry };
+}

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -150,7 +150,8 @@ function CreatorProfile({
     "creator-subscription",
     "creator-tip",
   ]);
-  const pages = useCreatorCatalog(creator.username, creator.zpages);
+  const pages = useCreatorCatalog(creator.username);
+  const pageCount = pages.count ?? creator.zpages;
   const { body: bio, socials } = useMemo(
     () => parseBioFrontmatter(creator.bio),
     [creator.bio],
@@ -230,9 +231,9 @@ function CreatorProfile({
             <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
               <span className="tabular-nums">
                 <span className="font-semibold text-foreground">
-                  {creator.zpages}
+                  {pageCount}
                 </span>{" "}
-                {creator.zpages === 1 ? "page" : "pages"}
+                {pageCount === 1 ? "page" : "pages"}
               </span>
               <span className="tabular-nums">
                 <span className="font-semibold text-foreground">
@@ -292,7 +293,7 @@ function CreatorProfile({
             className="text-sm tabular-nums text-muted-foreground"
             aria-live="polite"
           >
-            {pages.items.length} of {creator.zpages}
+            {pages.items.length} of {pageCount}
           </span>
         </div>
         {pages.error ? (
@@ -319,8 +320,9 @@ function CreatorProfile({
               <PageCardSkeleton key={i} />
             ))}
           </div>
-        ) : pages.error && pages.items.length === 0 ? null : creator.zpages ===
-          0 ? (
+        ) : pages.error &&
+          pages.items.length === 0 ? null : pages.initialized &&
+          pages.count === 0 ? (
           <EmptyState
             icon={FileText}
             title="No pages yet"

--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -56,6 +56,7 @@ import type { Article, CreatorDetail, Subscription } from "@/lib/api/types";
 import { paidActionGate } from "@/lib/auth/paid-action";
 import { preservePaidIntent, type PaidIntent } from "@/lib/auth/paid-intent";
 import { CreatorSocialLinks } from "./SocialLinks";
+import { useCreatorCatalog } from "./catalog";
 
 export default function CreatorFeature() {
   const { username = "" } = useParams<{ username: string }>();
@@ -149,19 +150,7 @@ function CreatorProfile({
     "creator-subscription",
     "creator-tip",
   ]);
-  const {
-    data: pagesData,
-    loading: pagesLoading,
-    error: pagesError,
-    reload: reloadPages,
-  } = useAsync<KeyedRemoteData<string, Article[]>>(
-    async () => ({
-      key: creator.username,
-      value: await discover.creatorPages(creator.username),
-    }),
-    [creator.username],
-  );
-  const pages = currentResourceData(pagesData, creator.username);
+  const pages = useCreatorCatalog(creator.username, creator.zpages);
   const { body: bio, socials } = useMemo(
     () => parseBioFrontmatter(creator.bio),
     [creator.bio],
@@ -295,45 +284,71 @@ function CreatorProfile({
 
       {/* Pages */}
       <div className="creator-profile-inset mt-10" data-creator-pages>
-        <h2 className="mb-4 text-lg font-semibold tracking-tight">
-          Pages by {name}
-        </h2>
-        {pagesError ? (
+        <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+          <h2 className="text-lg font-semibold tracking-tight">
+            Pages by {name}
+          </h2>
+          <span
+            className="text-sm tabular-nums text-muted-foreground"
+            aria-live="polite"
+          >
+            {pages.items.length} of {creator.zpages}
+          </span>
+        </div>
+        {pages.error ? (
           <SectionLoadError
             className="mb-4"
             title={
-              pages === null
+              pages.items.length === 0
                 ? "Couldn't load this creator's pages"
-                : "Couldn't refresh this creator's pages"
+                : "Couldn't load more of this creator's pages"
             }
             description={
-              pages === null
+              pages.items.length === 0
                 ? "The published pages are temporarily unavailable."
-                : "Showing the last pages loaded on this device."
+                : "The pages already loaded are still available."
             }
-            retry={reloadPages}
-            retrying={pagesLoading}
-            stale={pages !== null}
+            retry={pages.retry}
+            retrying={pages.loading}
+            stale={pages.items.length > 0}
           />
         ) : null}
-        {pagesLoading && pages === null ? (
+        {pages.loading && !pages.initialized && pages.items.length === 0 ? (
           <div className="creator-pages-grid grid grid-cols-1 gap-4">
             {Array.from({ length: 3 }).map((_, i) => (
               <PageCardSkeleton key={i} />
             ))}
           </div>
-        ) : pagesError && pages === null ? null : pages?.length === 0 ? (
+        ) : pages.error && pages.items.length === 0 ? null : creator.zpages ===
+          0 ? (
           <EmptyState
             icon={FileText}
             title="No pages yet"
             description={`${name} hasn't published any pages yet.`}
           />
-        ) : pages ? (
-          <div className="creator-pages-grid grid grid-cols-1 gap-4">
-            {pages.map((p) => (
-              <PageCard key={String(p.id)} article={p} />
-            ))}
-          </div>
+        ) : pages.items.length > 0 ? (
+          <>
+            <div className="creator-pages-grid grid grid-cols-1 gap-4">
+              {pages.items.map((p) => (
+                <PageCard key={String(p.id)} article={p} />
+              ))}
+            </div>
+            {pages.next !== null && !pages.error ? (
+              <div className="mt-5 flex justify-center">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={pages.loadMore}
+                  disabled={pages.loading}
+                >
+                  {pages.loading ? (
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  ) : null}
+                  {pages.loading ? "Loading pages" : "Load more pages"}
+                </Button>
+              </div>
+            ) : null}
+          </>
         ) : null}
       </div>
     </div>
@@ -981,7 +996,10 @@ function TipButton({
 // ─── Page card ────────────────────────────────────────────────────────────────
 function PageCard({ article }: { article: Article }) {
   return (
-    <div className="group flex flex-col overflow-hidden rounded-xl border border-border/60 bg-card/60 transition-colors hover:border-primary/40">
+    <div
+      className="group flex flex-col overflow-hidden rounded-xl border border-border/60 bg-card/60 transition-colors hover:border-primary/40"
+      data-creator-page-card
+    >
       <div className="aspect-[16/9] w-full overflow-hidden bg-secondary">
         {article.image ? (
           <RemoteMedia

--- a/wallet/zuuli/src/lib/api/creator-pagination-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/creator-pagination-contract.test.ts
@@ -50,5 +50,12 @@ describe("creator pagination API contract", () => {
         1,
       ),
     ).toThrow("left its endpoint");
+    expect(() =>
+      parseCreatorPagesPage(
+        page({ next: "/api/zpage/?username=zooko&page=3" }),
+        "zooko",
+        1,
+      ),
+    ).toThrow("invalid next page");
   });
 });

--- a/wallet/zuuli/src/lib/api/creator-pagination-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/creator-pagination-contract.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { parseCreatorPagesPage } from "./free2z";
+
+function row(id: string) {
+  return {
+    free2zaddr: id,
+    vanity: id,
+    title: `Page ${id}`,
+    creator: { username: "zooko" },
+  };
+}
+
+function page(overrides: Record<string, unknown> = {}) {
+  return {
+    count: 2,
+    next: "/api/zpage/?username=zooko&page=2",
+    previous: null,
+    results: [row("one")],
+    ...overrides,
+  };
+}
+
+describe("creator pagination API contract", () => {
+  it("parses a same-filter forward cursor", () => {
+    expect(parseCreatorPagesPage(page(), "zooko", 1)).toMatchObject({
+      count: 2,
+      next: 2,
+      items: [{ id: "one", title: "Page one" }],
+    });
+  });
+
+  it("rejects malformed rows and pagination metadata", () => {
+    expect(() =>
+      parseCreatorPagesPage(page({ count: "2" }), "zooko", 1),
+    ).toThrow("pagination count");
+    expect(() =>
+      parseCreatorPagesPage(page({ results: [{}] }), "zooko", 1),
+    ).toThrow("page identity");
+    expect(() =>
+      parseCreatorPagesPage(
+        page({ next: "/api/zpage/?username=someone-else&page=2" }),
+        "zooko",
+        1,
+      ),
+    ).toThrow("changed its creator filter");
+    expect(() =>
+      parseCreatorPagesPage(
+        page({ next: "/api/creator/?username=zooko&page=2" }),
+        "zooko",
+        1,
+      ),
+    ).toThrow("left its endpoint");
+  });
+});

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -489,7 +489,7 @@ export function parseCreatorPagesPage(
       throw new Error("Creator pagination changed its creator filter.");
     }
     next = Number(nextUrl.searchParams.get("page"));
-    if (!Number.isSafeInteger(next) || next <= currentPage) {
+    if (!Number.isSafeInteger(next) || next !== currentPage + 1) {
       throw new Error("Creator pagination returned an invalid next page.");
     }
   }
@@ -1910,6 +1910,10 @@ export const discover = {
       const items = mockArticles.filter(
         (a) => a.author.username.toLowerCase() === username.toLowerCase(),
       );
+      if (scenario === "empty-once") {
+        window.sessionStorage.removeItem("zuuli.mock.creator-pages");
+        return { items: [], next: page + 1, count: items.length };
+      }
       const start = (page - 1) * pageSize;
       return {
         items: items.slice(start, start + pageSize),

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -67,6 +67,7 @@ import type {
   CommentInput,
   CommentVote,
   CreatorDetail,
+  CreatorPagesPage,
   DyteJoinTicket,
   KycIdentityDocType,
   KycIdentityDocuments,
@@ -441,6 +442,62 @@ function mapArticle(z: RawZPage): Article {
     published_at: z.publish_at || z.created_at,
     reading_minutes: readingMinutes(z.content),
     tags: z.tags ?? [],
+  };
+}
+
+function parseCreatorZPage(value: unknown): RawZPage {
+  if (
+    !isRecord(value) ||
+    typeof value.free2zaddr !== "string" ||
+    value.free2zaddr.length === 0 ||
+    typeof value.title !== "string" ||
+    !isRecord(value.creator) ||
+    typeof value.creator.username !== "string" ||
+    value.creator.username.length === 0
+  ) {
+    throw new Error("Malformed creator page response: page identity.");
+  }
+  return value as unknown as RawZPage;
+}
+
+/** Runtime validator for the creator catalog's DRF pagination contract. */
+export function parseCreatorPagesPage(
+  value: unknown,
+  username: string,
+  currentPage: number,
+): CreatorPagesPage {
+  if (!isRecord(value) || !Array.isArray(value.results)) {
+    throw new Error("Malformed creator pagination response.");
+  }
+  if (!Number.isSafeInteger(value.count) || Number(value.count) < 0) {
+    throw new Error("Malformed creator pagination count.");
+  }
+  if (value.next !== null && typeof value.next !== "string") {
+    throw new Error("Malformed creator pagination next link.");
+  }
+  if (value.previous !== null && typeof value.previous !== "string") {
+    throw new Error("Malformed creator pagination previous link.");
+  }
+
+  let next: number | null = null;
+  if (typeof value.next === "string") {
+    const nextUrl = new URL(value.next, "http://localhost");
+    if (nextUrl.pathname !== "/api/zpage/") {
+      throw new Error("Creator pagination left its endpoint.");
+    }
+    if (nextUrl.searchParams.get("username") !== username) {
+      throw new Error("Creator pagination changed its creator filter.");
+    }
+    next = Number(nextUrl.searchParams.get("page"));
+    if (!Number.isSafeInteger(next) || next <= currentPage) {
+      throw new Error("Creator pagination returned an invalid next page.");
+    }
+  }
+
+  return {
+    count: Number(value.count),
+    next,
+    items: value.results.map((row) => mapArticle(parseCreatorZPage(row))),
   };
 }
 
@@ -1832,19 +1889,39 @@ export const discover = {
     return mapCreatorDetail(c);
   },
 
-  /** A creator's published zpages — GET /api/zpage/?username=<username>. */
-  async creatorPages(username: string): Promise<Article[]> {
+  /** A validated page of a creator's published zpages. */
+  async creatorPages(
+    username: string,
+    page = 1,
+    pageSize = 12,
+  ): Promise<CreatorPagesPage> {
     if (useMock()) {
       await delay(160);
-      return mockArticles.filter(
+      const scenario =
+        typeof window === "undefined"
+          ? null
+          : window.sessionStorage.getItem("zuuli.mock.creator-pages");
+      if (scenario === "fail" || scenario === "fail-once") {
+        if (scenario === "fail-once") {
+          window.sessionStorage.removeItem("zuuli.mock.creator-pages");
+        }
+        throw new Error("Mock creator catalog unavailable");
+      }
+      const items = mockArticles.filter(
         (a) => a.author.username.toLowerCase() === username.toLowerCase(),
       );
+      const start = (page - 1) * pageSize;
+      return {
+        items: items.slice(start, start + pageSize),
+        next: start + pageSize < items.length ? page + 1 : null,
+        count: items.length,
+      };
     }
-    const page = await request<Paginated<RawZPage>>("/api/zpage/", {
-      query: { username, page_size: 12, ordering: "-created_at" },
+    const response = await request<unknown>("/api/zpage/", {
+      query: { username, page, page_size: pageSize, ordering: "-created_at" },
       anonymous: true,
     });
-    return (page.results ?? []).map(mapArticle);
+    return parseCreatorPagesPage(response, username, page);
   },
 
   /**

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -1880,7 +1880,12 @@ export const discover = {
   async creator(username: string): Promise<CreatorDetail> {
     if (useMock()) {
       await delay(180);
-      return mockCreatorDetail(username);
+      const detail = mockCreatorDetail(username);
+      const scenario =
+        typeof window === "undefined"
+          ? null
+          : window.sessionStorage.getItem("zuuli.mock.creator-pages");
+      return scenario === "zero-count-hint" ? { ...detail, zpages: 0 } : detail;
     }
     const c = await request<RawCreator>(
       `/api/creator/${encodeURIComponent(username)}/`,

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -948,9 +948,9 @@ export function mockCreatorDetail(username: string): CreatorDetail {
     is_verified: base?.is_verified ?? false,
     can_stream: seed % 2 === 0,
     member_price: base?.member_price ?? null,
-    // Match the production creator detail contract: this is the authoritative
-    // published-catalog count, not a hand-maintained fixture estimate.
-    zpages: pages,
+    // Preserve deliberate fixture drift: the creator payload is only a display
+    // hint, while the independently paginated catalog owns its exact count.
+    zpages: base?.zpages ?? pages,
     total: (seed % 900) + 42,
     p2paddr: `u1mock${uname}zcashaddressplaceholderxxxxxxxxxxxxxxxxxxxxxxxx`,
   };

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -607,7 +607,9 @@ function genArticles(n: number): Article[] {
   return out;
 }
 
-export const mockArticles: Article[] = [...featuredArticles, ...genArticles(57)];
+// Keep at least one creator above the production-shaped 12-row catalog page so
+// the creator screen's pagination path is exercised in local/demo mode.
+export const mockArticles: Article[] = [...featuredArticles, ...genArticles(63)];
 
 function articleTime(a: Article): number {
   const t = a.published_at ? new Date(a.published_at).getTime() : 0;
@@ -946,7 +948,9 @@ export function mockCreatorDetail(username: string): CreatorDetail {
     is_verified: base?.is_verified ?? false,
     can_stream: seed % 2 === 0,
     member_price: base?.member_price ?? null,
-    zpages: base?.zpages ?? pages,
+    // Match the production creator detail contract: this is the authoritative
+    // published-catalog count, not a hand-maintained fixture estimate.
+    zpages: pages,
     total: (seed % 900) + 42,
     p2paddr: `u1mock${uname}zcashaddressplaceholderxxxxxxxxxxxxxxxxxxxxxxxx`,
   };

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -331,6 +331,9 @@ export interface ArticleFeedPage {
   count: number;
 }
 
+/** One validated page of a creator's published catalog. */
+export type CreatorPagesPage = ArticleFeedPage;
+
 // ── Livestreams (dyte) ──────────────────────────────────────────────────────
 export type StreamKind = "broadcast" | "subscriber" | "ppv" | "private";
 

--- a/wallet/zuuli/tests/creator-pagination.pw.ts
+++ b/wallet/zuuli/tests/creator-pagination.pw.ts
@@ -23,13 +23,18 @@ test("all creator pages remain loaded and positioned across reader back navigati
   ).toHaveCount(0);
 
   const scroller = viewport(page);
-  const savedOffset = await scroller.evaluate((element) => {
+  await scroller.evaluate((element) => {
     element.scrollTop = element.scrollHeight - element.clientHeight - 120;
-    return element.scrollTop;
   });
+  const lastPageLink = cards.last().getByRole("link");
+  // Capture the position after Playwright has made the destination fully
+  // actionable. Otherwise click() may legitimately nudge a partially visible
+  // link and the router should restore that later departure offset instead.
+  await lastPageLink.scrollIntoViewIfNeeded();
+  const savedOffset = await scroller.evaluate((element) => element.scrollTop);
   expect(savedOffset).toBeGreaterThan(500);
 
-  await cards.last().getByRole("link").click();
+  await lastPageLink.click();
   await expect(page).toHaveURL(/\/articles\//);
   await page.goBack();
   await expect(page).toHaveURL(/\/creator\/zooko$/);

--- a/wallet/zuuli/tests/creator-pagination.pw.ts
+++ b/wallet/zuuli/tests/creator-pagination.pw.ts
@@ -1,0 +1,57 @@
+import { expect, test, type Page } from "@playwright/test";
+
+function viewport(page: Page) {
+  return page.locator("[data-scroll-area-viewport]");
+}
+
+test("all creator pages remain loaded and positioned across reader back navigation", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 640 });
+  await page.goto("/creator/zooko");
+
+  const cards = page.locator("[data-creator-page-card]");
+  await expect(page.getByText("13 pages", { exact: true })).toBeVisible();
+  await expect(cards).toHaveCount(12);
+  await expect(page.getByText("12 of 13", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Load more pages" }).click();
+  await expect(cards).toHaveCount(13);
+  await expect(page.getByText("13 of 13", { exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Load more pages" }),
+  ).toHaveCount(0);
+
+  const scroller = viewport(page);
+  const savedOffset = await scroller.evaluate((element) => {
+    element.scrollTop = element.scrollHeight - element.clientHeight - 120;
+    return element.scrollTop;
+  });
+  expect(savedOffset).toBeGreaterThan(500);
+
+  await cards.last().getByRole("link").click();
+  await expect(page).toHaveURL(/\/articles\//);
+  await page.goBack();
+  await expect(page).toHaveURL(/\/creator\/zooko$/);
+  await expect(cards).toHaveCount(13);
+  await expect
+    .poll(() => scroller.evaluate((element) => element.scrollTop))
+    .toBeCloseTo(savedOffset, 0);
+});
+
+test("a failed creator catalog load is explicit and retryable", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    sessionStorage.setItem("zuuli.mock.creator-pages", "fail-once");
+  });
+  await page.goto("/creator/zooko");
+
+  await expect(
+    page.getByRole("alert").getByText("Couldn't load this creator's pages"),
+  ).toBeVisible();
+  await expect(page.getByText("No pages yet")).toHaveCount(0);
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect(page.locator("[data-creator-page-card]")).toHaveCount(12);
+  await expect(page.getByText("12 of 13", { exact: true })).toBeVisible();
+});

--- a/wallet/zuuli/tests/creator-pagination.pw.ts
+++ b/wallet/zuuli/tests/creator-pagination.pw.ts
@@ -44,6 +44,21 @@ test("all creator pages remain loaded and positioned across reader back navigati
     .toBeCloseTo(savedOffset, 0);
 });
 
+test("the catalog count overrides a zero creator-summary hint", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    sessionStorage.setItem("zuuli.mock.creator-pages", "zero-count-hint");
+  });
+  await page.goto("/creator/zooko");
+
+  const cards = page.locator("[data-creator-page-card]");
+  await expect(cards).toHaveCount(12);
+  await expect(page.getByText("12 of 13", { exact: true })).toBeVisible();
+  await expect(page.getByText("13 pages", { exact: true })).toBeVisible();
+  await expect(page.getByText("No pages yet")).toHaveCount(0);
+});
+
 for (const scenario of ["fail-once", "empty-once"] as const) {
   test(`${scenario} creator catalog load is explicit and retryable`, async ({
     page,

--- a/wallet/zuuli/tests/creator-pagination.pw.ts
+++ b/wallet/zuuli/tests/creator-pagination.pw.ts
@@ -39,19 +39,21 @@ test("all creator pages remain loaded and positioned across reader back navigati
     .toBeCloseTo(savedOffset, 0);
 });
 
-test("a failed creator catalog load is explicit and retryable", async ({
-  page,
-}) => {
-  await page.addInitScript(() => {
-    sessionStorage.setItem("zuuli.mock.creator-pages", "fail-once");
-  });
-  await page.goto("/creator/zooko");
+for (const scenario of ["fail-once", "empty-once"] as const) {
+  test(`${scenario} creator catalog load is explicit and retryable`, async ({
+    page,
+  }) => {
+    await page.addInitScript((mockScenario) => {
+      sessionStorage.setItem("zuuli.mock.creator-pages", mockScenario);
+    }, scenario);
+    await page.goto("/creator/zooko");
 
-  await expect(
-    page.getByRole("alert").getByText("Couldn't load this creator's pages"),
-  ).toBeVisible();
-  await expect(page.getByText("No pages yet")).toHaveCount(0);
-  await page.getByRole("button", { name: "Retry" }).click();
-  await expect(page.locator("[data-creator-page-card]")).toHaveCount(12);
-  await expect(page.getByText("12 of 13", { exact: true })).toBeVisible();
-});
+    await expect(
+      page.getByRole("alert").getByText("Couldn't load this creator's pages"),
+    ).toBeVisible();
+    await expect(page.getByText("No pages yet")).toHaveCount(0);
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(page.locator("[data-creator-page-card]")).toHaveCount(12);
+    await expect(page.getByText("12 of 13", { exact: true })).toBeVisible();
+  });
+}


### PR DESCRIPTION
Closes #253

## Summary
- validate creator pagination metadata and keep the displayed catalog count coherent with the creator profile
- append and deduplicate every catalog page with a bounded navigation cache so reader/back restores loaded cards and position
- show explicit retry states for initial and continuation failures
- cover contract failures, overlapping pages, full catalog reachability, retry, and reader/back restoration

## Verification
- `npm run typecheck`
- `npm test` (476 Vitest assertions, 79 boundary tests, 100 Playwright tests)
- `npm run build`
- focused creator pagination unit and Playwright tests