### PR TITLE
fix(android): restore deep-link marker in the generated manifest

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -164,6 +164,13 @@ jobs:
             # Play so the protected release can restore a complete cache.
             ./node_modules/.bin/tauri android build --ci --aab -- --locked
           fi
+      - name: Verify generated Android project remains clean
+        # scripts/mobile-release.sh runs exactly this pair after its build, so a
+        # stale gen/android tree only surfaced during a protected store upload.
+        # Repeating it here fails the pull request that introduces the drift.
+        run: |
+          node scripts/normalize-generated-android-manifest.mjs
+          git diff --exit-code
       - name: Collect package
         run: |
           mkdir release-artifacts

--- a/wallet/zuuli/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/wallet/zuuli/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -44,16 +44,20 @@
 
 
             </intent-filter>
-            <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
-            <intent-filter>
+            <intent-filter >
                 <action android:name="android.intent.action.VIEW" />
+                <!-- ChromeOS ARC++ uses a different action for deep links -->
                 <action android:name="org.chromium.arc.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="cash.free2z.zuuli" />
                 <data android:host="checkout" />
                 <data android:path="/return" />
+
+
+
             </intent-filter>
+            <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
         </activity>
 
         <provider


### PR DESCRIPTION
## Unblocks the in-flight ZUULI `0.1.0+11` release

The **Android / Play internal** job built the AAB successfully and then died on
`scripts/mobile-release.sh`'s source-integrity assertion:

```
             </intent-filter>
+            <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
         </activity>
##[error]Process completed with exit code 1
```

The assertion was right. This PR makes the tree match it; nothing about the
assertion, `release.json`, the version identity (`0.1.0+11`), or any credential
/ provenance control is touched.

## What the plugin actually generates, and how I determined it

Read verbatim from the pinned dependency sources, and then confirmed by a real
`tauri android build --ci --aab` on Linux CI (see the evidence section below):

- `tauri-plugin-deep-link-2.4.9/build.rs` renders **one `<intent-filter>` per
  `plugins.deep-link.mobile` entry**, `join`ed with `\n`, and hands the whole
  string to `tauri_plugin::mobile::update_android_manifest("DEEP LINK PLUGIN", "activity", ...)`.
- `tauri-utils-2.9.3/src/build.rs::insert_into_xml` **toggles** on the marker
  line: content *between* the two `<!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->`
  markers is discarded and re-emitted, content *outside* them is user content and
  is preserved. It then writes `marker + contents + marker` immediately before
  `</activity>`.

So the plugin's output is **one marker pair wrapping both filters** — not one
marker per filter.

## Root cause

cc56fc1 (#406) did the *config* half correctly: `tauri.conf.json` already
declares both mobile deep links, so **it is already the source of truth and is
unchanged by this PR.** What #406 also did was hand-write an `<intent-filter>`
into the generated manifest **after the closing marker**, where
`insert_into_xml` reads it as user content.

The consequence is worse than the one-line diff suggests. Because the
hand-written filter lives outside the managed block, a real build **keeps it and
adds the plugin's own copy inside the block**. Regenerating the committed file
verbatim yields a *duplicated* checkout filter:

| occurrences | committed (before) | what a build regenerates from it | after this PR |
|---|---|---|---|
| `android:scheme="cash.free2z.zuuli"` | 2 | **3** | 2 |
| `android:host="oauth"` / `android:path="/callback"` | 1 / 1 | 1 / 1 | 1 / 1 |
| `android:host="checkout"` / `android:path="/return"` | 1 / 1 | **2 / 2** | 1 / 1 |
| `android.intent.category.BROWSABLE` | 2 | **3** | 2 |

Those regenerated counts also violate the pinned Rust test
`generated_android_manifest_registers_exact_mobile_redirect` in
`src-tauri/src/oauth.rs`. The committed file was simply never the plugin's
output.

## The fix

Rewrite the manifest to be exactly what the plugin emits — both filters inside a
single marker pair, in the plugin's own formatting (`<intent-filter >`, the
ChromeOS ARC++ comment, the empty path-pattern/prefix/suffix lines that
`scripts/normalize-generated-android-manifest.mjs` blanks). No config change was
needed, which is the durable outcome: generated output now derives entirely from
`tauri.conf.json`.

Verified as a **fixed point**: applying the plugin's exact algorithm to the new
file reproduces the new file byte-for-byte, so repeat builds converge instead of
re-drifting.

## Evidence: before vs. after

**Before** — the protected release job on `main`, after the AAB had already built:

```
             </intent-filter>
+            <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
         </activity>
##[error]Process completed with exit code 1
```

**After** — this branch's `Android / unsigned AAB` job ran a real
`tauri android build --ci --aab --target aarch64 -- --locked` on `ubuntu-24.04`
and then the newly added assertion, with no diff output and a zero exit:

```
    Finished 1 AAB at:
        /home/runner/work/zuu/zuu/wallet/zuuli/src-tauri/gen/android/app/build/outputs/bundle/universalRelease/app-universal-release.aab

##[group]Run node scripts/normalize-generated-android-manifest.mjs
node scripts/normalize-generated-android-manifest.mjs
git diff --exit-code
...
##[endgroup]
##[group]Run mkdir release-artifacts        <- next step; nothing printed, exit 0
```

Job steps, all green:

```
  Build unsigned release bundle: success
  Verify generated Android project remains clean: success
```

`Rust / ZUULI backend` also passes on this branch, and that job runs
`cargo test`, which executes
`generated_android_manifest_registers_exact_mobile_redirect` against this exact
manifest.


## Deep links both survive, unaltered

Neither registration's scheme, host, or path changes, and neither is widened —
`cash.free2z.zuuli://oauth/callback` (load-bearing for mobile OAuth; `wallet/zuuli/CLAUDE.md`
forbids widening it) and `cash.free2z.zuuli://checkout/return` (#406's reason for
existing) are both present exactly once, each with `DEFAULT` + `BROWSABLE`,
`appLink: false`. The exact-count table above is the evidence; the pinned Rust
test asserts the same invariants and this file satisfies them, whereas the
regenerated old file would not.

## Closing the coverage gap

`scripts/mobile-release.sh` runs `build → normalize → git diff --exit-code`, but
that pair existed **only** inside the protected release script. The PR-level
Android packaging job built the AAB and never checked the generated tree, so the
drift #406 introduced stayed invisible from that PR until a live store upload.

This adds the same two lines to `.github/workflows/zuuli-packaging.yml`'s Android
job, right after the build — mirroring what the iOS job already does for the
Xcode project and what the desktop job already does with a bare
`git diff --exit-code`. Build outputs under `gen/android` are gitignored, so the
assertion sees only tracked generated sources.

`.github/workflows/zuuli-release.yml` is deliberately untouched (owned by a
concurrent fix).

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
