### PR TITLE
fix(ci): collect the iOS release archive from its real path

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -238,6 +238,11 @@ jobs:
         # A device archive has the same Rust target as TestFlight. It remains
         # unsigned and this job receives no Apple credentials.
         run: ./node_modules/.bin/tauri ios build --ci --no-sign --target aarch64 -- --locked
+      - name: Verify the release archive collection path
+        # The protected release resolves the .xcarchive it ships with this exact
+        # script. Exercising it on every pull request is what keeps a
+        # release-only path from breaking unobserved until a real release.
+        run: scripts/resolve-ios-xcarchive.sh
       - name: Verify unsigned iOS bundle structure
         run: |
           apps=()

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -392,10 +392,12 @@ jobs:
           ./node_modules/.bin/tauri ios build --ci --no-sign --archive-only -- --locked
           node scripts/normalize-generated-ios-project.mjs
           git diff --exit-code
-          archives=(src-tauri/gen/apple/build/arm64/*.xcarchive)
-          [[ ${#archives[@]} -eq 1 && -d "${archives[0]}" ]]
+          # `test`, not `[[ ]]`: macOS runners execute this step with bash 3.2,
+          # which does not apply `set -e` to a failing bare `[[ ]]`.
+          archive=$(scripts/resolve-ios-xcarchive.sh)
+          test -d "$archive"
           mkdir unsigned-ios
-          ditto -c -k --sequesterRsrc --keepParent "${archives[0]}" unsigned-ios/ZUULI.xcarchive.zip
+          ditto -c -k --sequesterRsrc --keepParent "$archive" unsigned-ios/ZUULI.xcarchive.zip
           cat > unsigned-ios/ExportOptions.plist <<'PLIST'
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/wallet/zuuli/scripts/resolve-ios-xcarchive.sh
+++ b/wallet/zuuli/scripts/resolve-ios-xcarchive.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Print the single .xcarchive that `tauri ios build` produced.
+#
+# Tauri writes the archive flat at `src-tauri/gen/apple/build/<scheme>.xcarchive`
+# (`config.archive_dir().join("<scheme>.xcarchive")`) regardless of `--target`.
+# The arch-scoped `src-tauri/gen/apple/build/<arch>/` directories hold *export*
+# products (`ZUULI.ipa`, `ZUULI.app`) and never the archive itself.
+#
+# The protected release and the pull-request packaging smoke both resolve the
+# archive through this one script, so the release can never consume a path that
+# no pull request has proven exists.
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+app_dir=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+build_dir="$app_dir/src-tauri/gen/apple/build"
+
+archives=()
+if [[ -d "$build_dir" ]]; then
+  while IFS= read -r -d '' archive; do
+    archives+=("$archive")
+  done < <(find "$build_dir" -type d -name '*.xcarchive' -prune -print0)
+fi
+
+if [[ ${#archives[@]} -ne 1 ]]; then
+  echo "expected exactly one iOS .xcarchive under $build_dir, found ${#archives[@]}" >&2
+  [[ ${#archives[@]} -eq 0 ]] || printf '%s\n' "${archives[@]}" >&2
+  exit 1
+fi
+
+printf '%s\n' "${archives[0]}"


### PR DESCRIPTION
**This unblocks the in-flight `0.1.0+11` release.** Run
[32613227134](https://github.com/free2z/zuu/actions/runs/32613227134) failed in
`iOS / credential-free unsigned archive`, which skipped signing, verification,
TestFlight, and provenance. No version or build number changes here — the
release identity stays `0.1.0+11`.

## The bug

`.github/workflows/zuuli-release.yml` collected the archive from an arch-scoped
subdirectory that `--archive-only` never creates:

```bash
archives=(src-tauri/gen/apple/build/arm64/*.xcarchive)
```

The glob matched nothing, stayed literal, and `ditto` failed:

```
ditto: Cannot get the real path for source 'src-tauri/gen/apple/build/arm64/*.xcarchive'
```

Both lines arrived together in #443 and have contradicted each other since; no
release ran between then and now, so `0.1.0+11` was their first execution.

## The real path, observed

I ran the exact release build command on macOS with Xcode 26.6 (matching CI):

```
node scripts/normalize-generated-ios-project.mjs --prepare-manual-signing
./node_modules/.bin/tauri ios build --ci --no-sign --archive-only -- --locked
```

```
    Finished 1 iOS Bundle at:
        .../wallet/zuuli/src-tauri/gen/apple/build/zuuli_iOS.xcarchive

$ find src-tauri/gen/apple/build -maxdepth 3
src-tauri/gen/apple/build
src-tauri/gen/apple/build/zuuli_iOS.xcarchive
src-tauri/gen/apple/build/zuuli_iOS.xcarchive/dSYMs
src-tauri/gen/apple/build/zuuli_iOS.xcarchive/dSYMs/ZUULI.app.dSYM
src-tauri/gen/apple/build/zuuli_iOS.xcarchive/Info.plist
src-tauri/gen/apple/build/zuuli_iOS.xcarchive/Products
src-tauri/gen/apple/build/zuuli_iOS.xcarchive/Products/Applications
```

There is no `arm64/` directory at all. Reproducing the old glob locally gives
byte-for-byte the CI error.

## (a) fix the glob, not (b) add `--target aarch64`

I chose **(a)**, and (b) is not merely riskier — it does not work. In
tauri-cli 2.11.4 the archive path is
`config.archive_dir().join("<scheme>.xcarchive")`, computed **before** and
independently of the target loop; `--target` only affects the *export* directory,
`config.export_dir().join(target.arch)`. That is where `build/arm64/` comes from
in the packaging smoke, whose log ends at `build/arm64/ZUULI.ipa` — an export
product, never the archive. Adding `--target aarch64` would leave the archive
flat and the glob still broken.

It would also be a no-op for architecture: with no `--target`, tauri already uses
`Target::DEFAULT_KEY`, the arm64 device target — confirmed by the artifact below.

## The archive is a device arm64 App Store archive

```
$ file .../ZUULI.app/ZUULI
Mach-O 64-bit executable arm64
$ lipo -info .../ZUULI.app/ZUULI
Non-fat file: ... is architecture: arm64
$ vtool -show-build .../ZUULI.app/ZUULI
 platform IOS          # not IOSSIMULATOR
    minos 18.0
```

`ZUULI.app/Info.plist` reports `DTPlatformName = iphoneos`, and the archive's
`Info.plist` reports `Architectures = [arm64]`, `CFBundleShortVersionString =
0.1.0`, `CFBundleVersion = 11`.

I also ran the fixed collection step end to end and confirmed the downstream
`ios-sign` contract still holds: `ditto --keepParent` on the (absolute) resolved
path stores a single top-level `zuuli_iOS.xcarchive`, and `ios-sign`'s
`archive-root/*.xcarchive` glob finds exactly one after extraction.

## Closing the coverage gap

The deeper problem is that `zuuli-packaging.yml`, which runs on every PR, never
exercised the release's archive-collection path, so a release-only break stayed
invisible until a real release.

Both workflows now resolve the archive through one shared script,
`wallet/zuuli/scripts/resolve-ios-xcarchive.sh`, which fails loudly unless
exactly one `.xcarchive` exists under `src-tauri/gen/apple/build`. The PR
packaging smoke calls it directly, so this class of break now fails on the PR
that introduces it. The resolver is location-agnostic, so it also survives a
future tauri layout change instead of silently picking up the wrong thing.

No credential boundary, checksum, provenance, or `git diff --exit-code`
assertion was weakened. `scripts/apple-credential-boundary.mjs` passes
unchanged; `ios-build` is not one of the digest-sealed credential jobs, so no
`CREDENTIAL_JOB_SHA256` update is involved.

## Verified

- `node scripts/check-github-actions-pins.mjs` — pass (131 references, 14 files)
- `wallet/zuuli`: `node scripts/apple-credential-boundary.mjs` — pass
- `wallet/zuuli`: `node scripts/release-identity.mjs` — pass
- `wallet/zuuli`: `npm run typecheck` — pass
- the real `tauri ios build --ci --no-sign --archive-only` on macOS/Xcode 26.6,
  including the `--prepare-manual-signing` → build → normalize → `git diff
  --exit-code` round trip, which came back clean

## Two findings for follow-up, not fixed here

**1. `[[ ]]` assertions are inert on the macOS release runners.** GitHub runs
these steps with `/bin/bash` — bash 3.2 — which does not apply `set -e` to a
failing bare `[[ ]]`. That is why the broken guard on the line above the `ditto`
call did not stop the job: it evaluated false and execution simply continued.
Verified on bash 3.2.57:

```
set -euo pipefail
[[ 1 -eq 2 ]]
echo "reached"        # prints; `test 1 -eq 2` and `false` both abort correctly
```

Every bare `[[ ]]` assertion in the macOS-hosted jobs is therefore decorative,
including security-relevant ones in `ios-sign` (provisioning-profile UUID, name,
team, application-identifier, and `profile_authorizes_identity`) and `ios-upload`
(the `expected_members` payload comparison and the regular-file/non-symlink
checks). They only ever "fire" when a following command happens to fail too.
Fixing this means rewriting many assertions across digest-sealed credential jobs
and updating `CREDENTIAL_JOB_SHA256` — deliberately out of scope for a hotfix on
a live release. The one assertion this PR touches now uses `test`, not `[[ ]]`.

**2. `Android / Play internal` also failed in the same run**, for an unrelated
reason: `tauri android build` regenerated `AndroidManifest.xml`, so
`scripts/mobile-release.sh`'s `git diff --exit-code` failed after a successful
AAB build. That was fixed by #473 while this branch was in flight, and #473 also
added the matching `normalize + git diff --exit-code` step to
`zuuli-packaging.yml` — the same coverage-gap shape, closed the same way. Both
mobile legs of `0.1.0+11` therefore need this PR *and* #473 to get a green run.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
