### PR TITLE
release(zuuli): prepare internal build 0.1.0+12

### DIFF
--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.zuuli",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 11,
+  "build": 12,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "11").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "12").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "11"
+        CFBundleVersion: "12"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -34,14 +34,14 @@
       "icons/icon.ico"
     ],
     "iOS": {
-      "bundleVersion": "11",
+      "bundleVersion": "12",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 11
+      "versionCode": 12
     }
   },
   "plugins": {


### PR DESCRIPTION
## ⚠️ Merging this PR performs a real store upload

A push to `main` that changes an existing `release.json` pins the pushed SHA and
runs **ZUULI / protected release**: it signs both mobile artifacts and uploads
them to **TestFlight** and the **Play internal track**. This is not a dry run.
Merge only when you intend to ship `0.1.0+12` to internal testers.

## What changed

`npm run release:bump -- --version=0.1.0 --build=12`. Version stays `0.1.0`; the
build identity moves 11 → 12 across every generated representation. 5 files, 6
lines, identity only — no behaviour, UI, dependency, or workflow change.

| File | Change |
|---|---|
| `wallet/zuuli/release.json` | `"build": 11` → `12` |
| `wallet/zuuli/src-tauri/tauri.conf.json` | `iOS.bundleVersion` `"11"` → `"12"`, `android.versionCode` `11` → `12` |
| `wallet/zuuli/src-tauri/gen/apple/project.yml` | `CFBundleVersion: "11"` → `"12"` |
| `wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist` | `CFBundleVersion` `11` → `12` |
| `wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts` | `versionCode` default `"11"` → `"12"` |

## Why 12 rather than re-dispatching 11

Both mobile jobs of `0.1.0+11` failed — iOS collecting the archive from a path
Xcode does not write, Android on generated-manifest drift — and both are now
fixed and merged. But the release **cannot** simply be re-run at the fixed code.
`.github/workflows/zuuli-release.yml` requires, on the `workflow_dispatch` path,
that `source_sha` be the exact commit that established the identity:

```bash
identity_sha=$(git log -1 --format=%H "$source_sha" -- ':(top)wallet/zuuli/release.json')
[[ "$identity_sha" == "$source_sha" ]] || exit 1
```

For `0.1.0+11` that commit is `54fe596`, which predates both fixes, so a manual
dispatch could only ever rebuild the broken tree. A new `release.json` commit is
the only way to release the fixed code — hence build 12.

**Nothing reached TestFlight or Play under build 11**, so no store has consumed
that identity; it is simply superseded.

## Fixes this build carries

- **#476** `8e40571` — `fix(ci): collect the iOS release archive from its real path`
- **#473** `d922d3b` — `fix(android): restore deep-link marker in the generated manifest`

Both are ancestors of this branch (it is branched from `origin/main` = `8e40571`).
Verified present rather than assumed:

**iOS archive resolver (#476)** — `wallet/zuuli/scripts/resolve-ios-xcarchive.sh`
exists (mode `0755`) and is referenced by **both** workflows, once each; those two
lines are its only references anywhere in the repo:

```
.github/workflows/zuuli-release.yml:397:          archive=$(scripts/resolve-ios-xcarchive.sh)
.github/workflows/zuuli-packaging.yml:252:        run: scripts/resolve-ios-xcarchive.sh
```

**Android manifest (#473)** — `src-tauri/gen/android/app/src/main/AndroidManifest.xml`
marker/host counts, no duplication:

| Pattern | Count | Expected |
|---|---|---|
| `DEEP LINK PLUGIN` | **2** | 2 |
| `android:host="oauth"` | **1** | 1 |
| `android:host="checkout"` | **1** | 1 |

```
33:            <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
41:                <data android:host="oauth" />
54:                <data android:host="checkout" />
60:            <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
```

Both deep-link filters now sit inside a single marker pair, which is what
`insert_into_xml` replaces wholesale on regeneration.

## Verification (Node `24.18.0`, the pinned train version)

```
$ npm run release:verify
> zuuli@0.1.0 release:verify
> node scripts/release-identity.mjs

{"applicationId":"cash.free2z.zuuli","version":"0.1.0","build":12,"identity":"0.1.0+12","tag":"zuuli-v0.1.0+12"}
release:verify exit=0

$ npm run typecheck
> zuuli@0.1.0 typecheck
> tsc --noEmit

typecheck exit=0

$ node scripts/apple-credential-boundary.mjs
Apple release build, credential, and finalization boundaries verified.
boundary exit=0
```

Generated-tree stability, run locally — both normalizers are no-ops and
`git status` shows only the five intended bump files:

```
$ node scripts/normalize-generated-android-manifest.mjs   # exit 0, no write
$ node scripts/normalize-generated-ios-project.mjs --self-test   # exit 0
$ node scripts/normalize-generated-ios-project.mjs        # exit 0, no write
$ git status --short
 M wallet/zuuli/release.json
 M wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
 M wallet/zuuli/src-tauri/gen/apple/project.yml
 M wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
 M wallet/zuuli/src-tauri/tauri.conf.json
```

Scoping that honestly: `normalize-generated-android-manifest.mjs` only strips
whitespace-only lines — it does not regenerate the manifest. It proves the
committed file is already normalized, not that a real build reproduces it. The
actual regeneration proof is the `ZUULI / packaging smoke` Android job, which
(since #473) runs the normalizer plus `git diff --exit-code` **after** a real
`tauri android build`. That job is the gate for this PR and must be green.

`scripts/assert-no-apple-credentials.sh` was not run: it is a runner-environment
canary asserting the *current machine* holds no signing authority, and it trips
on the owner's legitimate local team identity. It is meaningful only on CI.

## Merge checklist

1. Required `gate` green.
2. `ZUULI / packaging smoke` green — this is the job that proves the #473 and
   #476 fixes actually hold on a real build.
3. Then squash-merge, accepting that TestFlight and Play internal uploads follow.
4. After the protected run, require the iOS job's evidence to show `uploaded`,
   `processed`, **and** `availableToInternalTesters`; confirm the Play internal
   release is available to the tester list.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
