### PR TITLE
fix(zuuli): paginate global search results

### DIFF
--- a/wallet/zuuli/src/features/search/index.tsx
+++ b/wallet/zuuli/src/features/search/index.tsx
@@ -5,6 +5,7 @@ import {
   BookOpen,
   Clock,
   FileText,
+  Loader2,
   Radio,
   Search as SearchIcon,
   Users,
@@ -16,6 +17,7 @@ import {
   AvatarImage,
 } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -23,15 +25,10 @@ import { EmptyState } from "@/components/common/EmptyState";
 import { PageHeader } from "@/components/common/PageHeader";
 import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { RemoteMedia } from "@/components/common/RemoteMedia";
-import { useAsync } from "@/hooks/useAsync";
-import { discover } from "@/lib/api/free2z";
 import { formatTuzis, initials, timeAgo } from "@/lib/format";
-import {
-  currentResourceData,
-  type KeyedRemoteData,
-} from "@/lib/remote-data";
 import type { Article, SimpleCreator } from "@/lib/api/types";
 import { SEARCH_INPUT_LABEL, withSearchQuery } from "@/lib/search-route";
+import { useCreatorSearch, usePageSearch } from "./pagination";
 
 const DEBOUNCE_MS = 300;
 
@@ -50,32 +47,8 @@ export default function SearchFeature() {
   const debounced = useDebounced(query, DEBOUNCE_MS);
   const inputRef = useRef<HTMLInputElement>(null);
   const searchKey = debounced.trim();
-  const {
-    data: creatorData,
-    loading: creatorsLoading,
-    error: creatorsError,
-    reload: reloadCreators,
-  } = useAsync<KeyedRemoteData<string, SimpleCreator[]>>(
-    async () => ({
-      key: searchKey,
-      value: searchKey ? await discover.searchCreators(searchKey) : [],
-    }),
-    [searchKey],
-  );
-  const {
-    data: pageData,
-    loading: pagesLoading,
-    error: pagesError,
-    reload: reloadPages,
-  } = useAsync<KeyedRemoteData<string, Article[]>>(
-    async () => ({
-      key: searchKey,
-      value: searchKey ? await discover.searchPages(searchKey) : [],
-    }),
-    [searchKey],
-  );
-  const creators = currentResourceData(creatorData, searchKey);
-  const pages = currentResourceData(pageData, searchKey);
+  const creators = useCreatorSearch(searchKey);
+  const pages = usePageSearch(searchKey);
 
   // Focus the box on mount for a keyboard-first feel.
   useEffect(() => {
@@ -85,16 +58,25 @@ export default function SearchFeature() {
   // The route, not the debounce timer, owns visible empty-vs-results state.
   // Clearing `?q=` must clear the screen in the same render.
   const hasQuery = query.trim().length > 0;
-  const creatorCount = creators?.length ?? 0;
-  const pageCount = pages?.length ?? 0;
+  const creatorCount = creators.count ?? 0;
+  const pageCount = pages.count ?? 0;
 
-  const defaultTab = useMemo(
-    () =>
-      !creatorsLoading && !pagesLoading && creatorCount === 0 && pageCount > 0
-        ? "pages"
-        : "creators",
-    [creatorCount, creatorsLoading, pageCount, pagesLoading],
-  );
+  const selectedTab = useMemo(() => {
+    const requested = params.get("tab");
+    if (requested === "creators" || requested === "pages") return requested;
+    return creators.initialized &&
+      pages.initialized &&
+      creatorCount === 0 &&
+      pageCount > 0
+      ? "pages"
+      : "creators";
+  }, [
+    creatorCount,
+    creators.initialized,
+    pageCount,
+    pages.initialized,
+    params,
+  ]);
 
   return (
     <div className="animate-slide-up">
@@ -151,15 +133,27 @@ export default function SearchFeature() {
           description="Start typing to find creators by name and pages by meaning — results update as you go."
         />
       ) : (
-        <Tabs defaultValue={defaultTab} key={defaultTab}>
+        <Tabs
+          value={selectedTab}
+          onValueChange={(tab) => {
+            setParams(
+              (current) => {
+                const next = new URLSearchParams(current);
+                next.set("tab", tab);
+                return next;
+              },
+              { replace: true },
+            );
+          }}
+        >
           <TabsList>
             <TabsTrigger value="creators">
               <Users className="mr-1.5 h-4 w-4" aria-hidden />
               Creators
               <ResultCountBadge
                 n={creatorCount}
-                loading={creatorsLoading && creators === null}
-                available={creators !== null}
+                loading={creators.loading && creators.count === null}
+                available={creators.count !== null}
               />
             </TabsTrigger>
             <TabsTrigger value="pages">
@@ -167,81 +161,107 @@ export default function SearchFeature() {
               Pages
               <ResultCountBadge
                 n={pageCount}
-                loading={pagesLoading && pages === null}
-                available={pages !== null}
+                loading={pages.loading && pages.count === null}
+                available={pages.count !== null}
               />
             </TabsTrigger>
           </TabsList>
 
           <TabsContent value="creators">
-            {creatorsError ? (
+            {creators.error ? (
               <SectionLoadError
                 className="mb-4"
                 title={
-                  creators === null
+                  creators.items.length === 0
                     ? "Creator search is unavailable"
-                    : "Couldn't refresh creator results"
+                    : "Couldn't load more creator results"
                 }
                 description={
-                  creators === null
+                  creators.items.length === 0
                     ? "Pages may still be available in the other tab."
                     : "Showing the last creator results loaded on this device."
                 }
-                retry={reloadCreators}
-                retrying={creatorsLoading}
-                stale={creators !== null}
+                retry={creators.retry}
+                retrying={creators.loading}
+                stale={creators.items.length > 0}
               />
             ) : null}
-            {creatorsLoading && creators === null ? (
+            {creators.loading && !creators.initialized ? (
               <CreatorGridSkeleton />
-            ) : creatorsError && creators === null ? null : creators?.length === 0 ? (
+            ) : creators.error &&
+              creators.items.length === 0 ? null : creators.initialized &&
+              creatorCount === 0 ? (
               <EmptyState
                 icon={Users}
                 title="No creators found"
                 description={`No creators match “${debounced.trim()}”. Creators are matched by username and name.`}
               />
-            ) : creators ? (
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {creators.map((c) => (
-                  <CreatorResultCard key={c.username} creator={c} />
-                ))}
-              </div>
+            ) : creators.items.length > 0 ? (
+              <>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {creators.items.map((c) => (
+                    <CreatorResultCard key={c.username} creator={c} />
+                  ))}
+                </div>
+                <SearchLoadMore
+                  corpus="creators"
+                  loaded={creators.items.length}
+                  total={creatorCount}
+                  next={creators.next}
+                  loading={creators.loading}
+                  blocked={Boolean(creators.error)}
+                  loadMore={creators.loadMore}
+                />
+              </>
             ) : null}
           </TabsContent>
 
           <TabsContent value="pages">
-            {pagesError ? (
+            {pages.error ? (
               <SectionLoadError
                 className="mb-4"
                 title={
-                  pages === null
+                  pages.items.length === 0
                     ? "Page search is unavailable"
-                    : "Couldn't refresh page results"
+                    : "Couldn't load more page results"
                 }
                 description={
-                  pages === null
+                  pages.items.length === 0
                     ? "Creators may still be available in the other tab."
                     : "Showing the last page results loaded on this device."
                 }
-                retry={reloadPages}
-                retrying={pagesLoading}
-                stale={pages !== null}
+                retry={pages.retry}
+                retrying={pages.loading}
+                stale={pages.items.length > 0}
               />
             ) : null}
-            {pagesLoading && pages === null ? (
+            {pages.loading && !pages.initialized ? (
               <PageListSkeleton />
-            ) : pagesError && pages === null ? null : pages?.length === 0 ? (
+            ) : pages.error &&
+              pages.items.length === 0 ? null : pages.initialized &&
+              pageCount === 0 ? (
               <EmptyState
                 icon={BookOpen}
                 title="No pages found"
                 description={`No pages match “${debounced.trim()}”. Try different or broader terms.`}
               />
-            ) : pages ? (
-              <div className="flex flex-col gap-3">
-                {pages.map((p) => (
-                  <PageResultRow key={String(p.id)} article={p} />
-                ))}
-              </div>
+            ) : pages.items.length > 0 ? (
+              <>
+                <div className="flex flex-col gap-3">
+                  {pages.items.map((p) => (
+                    <PageResultRow key={String(p.id)} article={p} />
+                  ))}
+                </div>
+                <SearchLoadMore
+                  corpus="pages"
+                  loaded={pages.items.length}
+                  total={pageCount}
+                  next={pages.next}
+                  loading={pages.loading}
+                  blocked={Boolean(pages.error)}
+                  loadMore={pages.loadMore}
+                />
+              </>
             ) : null}
           </TabsContent>
         </Tabs>
@@ -267,12 +287,55 @@ function ResultCountBadge({
   );
 }
 
+function SearchLoadMore({
+  corpus,
+  loaded,
+  total,
+  next,
+  loading,
+  blocked,
+  loadMore,
+}: {
+  corpus: "creators" | "pages";
+  loaded: number;
+  total: number;
+  next: number | null;
+  loading: boolean;
+  blocked: boolean;
+  loadMore: () => void;
+}) {
+  return (
+    <div className="mt-5 flex flex-col items-center gap-2">
+      <span
+        className="text-sm tabular-nums text-muted-foreground"
+        aria-live="polite"
+      >
+        {loaded} of {total} {corpus}
+      </span>
+      {next !== null && !blocked ? (
+        <Button
+          type="button"
+          variant="outline"
+          onClick={loadMore}
+          disabled={loading}
+        >
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          ) : null}
+          {loading ? `Loading ${corpus}` : `Load more ${corpus}`}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
 function CreatorResultCard({ creator }: { creator: SimpleCreator }) {
   const name = creator.display_name || creator.username;
   return (
     <Link
       to={`/creator/${creator.username}`}
       aria-label={`View ${name}'s profile`}
+      data-search-creator-result
       className="group flex w-full min-w-0 items-center gap-3 rounded-xl border border-border bg-card/60 p-4 transition-colors hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <Avatar className="h-12 w-12 shrink-0">
@@ -335,7 +398,10 @@ function PageResultRow({ article }: { article: Article }) {
   const name = author.display_name || author.username;
   const body = article.subtitle || excerpt(article.content);
   return (
-    <div className="group flex w-full min-w-0 gap-4 rounded-xl border border-border bg-card/60 p-4 transition-colors hover:border-primary/40">
+    <div
+      className="group flex w-full min-w-0 gap-4 rounded-xl border border-border bg-card/60 p-4 transition-colors hover:border-primary/40"
+      data-search-page-result
+    >
       <div className="hidden h-28 w-32 shrink-0 overflow-hidden rounded-lg bg-secondary sm:block">
         {article.image ? (
           <RemoteMedia

--- a/wallet/zuuli/src/features/search/pagination.test.ts
+++ b/wallet/zuuli/src/features/search/pagination.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SearchResultPage } from "@/lib/api/types";
 import {
   mergeSearchPage,
@@ -32,6 +32,8 @@ function page(
 }
 
 describe("global Search result pagination", () => {
+  afterEach(() => vi.restoreAllMocks());
+
   it("deduplicates overlapping pages without changing backend order", () => {
     const first = mergeSearchPage(
       initial(),
@@ -63,19 +65,34 @@ describe("global Search result pagination", () => {
     ).toThrow("made no progress");
   });
 
-  it("fails closed on count drift, early termination, and cursor jumps", () => {
+  it("keeps valid rows when advisory counts drift or a tied row is skipped", () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const first = mergeSearchPage(
       initial(),
       page([result("a")], 2, 2),
       1,
       identity,
     );
-    expect(() =>
-      mergeSearchPage(first, page([result("b")], null, 3), 2, identity),
-    ).toThrow("count changed");
-    expect(() =>
-      mergeSearchPage(first, page([], null, 2), 2, identity),
-    ).toThrow("before every result");
+    expect(
+      mergeSearchPage(first, page([result("c")], null, 3), 2, identity),
+    ).toMatchObject({
+      items: [{ id: "a" }, { id: "c" }],
+      next: null,
+      count: 3,
+    });
+    expect(warning).toHaveBeenCalledWith(
+      "Search result count changed during pagination.",
+      expect.objectContaining({ previousCount: 2, responseCount: 3 }),
+    );
+  });
+
+  it("fails closed on cursor jumps", () => {
+    const first = mergeSearchPage(
+      initial(),
+      page([result("a")], 2, 2),
+      1,
+      identity,
+    );
     expect(() =>
       mergeSearchPage(first, page([result("b")], 4, 2), 2, identity),
     ).toThrow("unexpected next page");

--- a/wallet/zuuli/src/features/search/pagination.test.ts
+++ b/wallet/zuuli/src/features/search/pagination.test.ts
@@ -52,7 +52,7 @@ describe("global Search result pagination", () => {
     expect(complete.count).toBe(3);
   });
 
-  it("accepts an empty terminal corpus but rejects empty nonterminal progress", () => {
+  it("accepts an empty terminal corpus", () => {
     expect(mergeSearchPage(initial(), page([], null, 0), 1, identity)).toEqual({
       key: "privacy",
       items: [],
@@ -60,9 +60,39 @@ describe("global Search result pagination", () => {
       count: 0,
       initialized: true,
     });
-    expect(() =>
-      mergeSearchPage(initial(), page([], 2, 3), 1, identity),
-    ).toThrow("made no progress");
+  });
+
+  it("advances past a fully duplicated nonterminal page to later rows", () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const first = mergeSearchPage(
+      initial(),
+      page([result("a"), result("b")], 2, 3),
+      1,
+      identity,
+    );
+    const duplicate = mergeSearchPage(
+      first,
+      page([result("a"), result("b")], 3, 3),
+      2,
+      identity,
+    );
+    expect(duplicate).toMatchObject({
+      items: [{ id: "a" }, { id: "b" }],
+      next: 3,
+    });
+    expect(warning).toHaveBeenCalledWith(
+      "Search page contained no new rows; advancing its cursor.",
+      { requestedPage: 2, next: 3 },
+    );
+
+    const complete = mergeSearchPage(
+      duplicate,
+      page([result("c")], null, 3),
+      3,
+      identity,
+    );
+    expect(complete.items.map(identity)).toEqual(["a", "b", "c"]);
+    expect(complete.next).toBeNull();
   });
 
   it("keeps valid rows when advisory counts drift or a tied row is skipped", () => {

--- a/wallet/zuuli/src/features/search/pagination.test.ts
+++ b/wallet/zuuli/src/features/search/pagination.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { SearchResultPage } from "@/lib/api/types";
+import {
+  mergeSearchPage,
+  SearchSnapshotCache,
+  type SearchSnapshot,
+} from "./pagination";
+
+interface Result {
+  id: string;
+}
+
+const identity = (result: Result) => result.id;
+const result = (id: string): Result => ({ id });
+
+function initial(key = "privacy"): SearchSnapshot<Result> {
+  return {
+    key,
+    items: [],
+    next: 1,
+    count: null,
+    initialized: false,
+  };
+}
+
+function page(
+  items: Result[],
+  next: number | null,
+  count: number,
+): SearchResultPage<Result> {
+  return { items, next, count };
+}
+
+describe("global Search result pagination", () => {
+  it("deduplicates overlapping pages without changing backend order", () => {
+    const first = mergeSearchPage(
+      initial(),
+      page([result("a"), result("b")], 2, 3),
+      1,
+      identity,
+    );
+    const complete = mergeSearchPage(
+      first,
+      page([result("b"), result("c")], null, 3),
+      2,
+      identity,
+    );
+    expect(complete.items.map(identity)).toEqual(["a", "b", "c"]);
+    expect(complete.next).toBeNull();
+    expect(complete.count).toBe(3);
+  });
+
+  it("accepts an empty terminal corpus but rejects empty nonterminal progress", () => {
+    expect(mergeSearchPage(initial(), page([], null, 0), 1, identity)).toEqual({
+      key: "privacy",
+      items: [],
+      next: null,
+      count: 0,
+      initialized: true,
+    });
+    expect(() =>
+      mergeSearchPage(initial(), page([], 2, 3), 1, identity),
+    ).toThrow("made no progress");
+  });
+
+  it("fails closed on count drift, early termination, and cursor jumps", () => {
+    const first = mergeSearchPage(
+      initial(),
+      page([result("a")], 2, 2),
+      1,
+      identity,
+    );
+    expect(() =>
+      mergeSearchPage(first, page([result("b")], null, 3), 2, identity),
+    ).toThrow("count changed");
+    expect(() =>
+      mergeSearchPage(first, page([], null, 2), 2, identity),
+    ).toThrow("before every result");
+    expect(() =>
+      mergeSearchPage(first, page([result("b")], 4, 2), 2, identity),
+    ).toThrow("unexpected next page");
+  });
+
+  it("keeps only the most recently used query snapshots", () => {
+    const cache = new SearchSnapshotCache<Result>(2);
+    cache.remember({ ...initial("one"), initialized: true });
+    cache.remember({ ...initial("two"), initialized: true });
+    expect(cache.restore("one")?.key).toBe("one");
+    cache.remember({ ...initial("three"), initialized: true });
+    expect(cache.restore("two")).toBeNull();
+    expect(cache.restore("one")?.key).toBe("one");
+    expect(cache.restore("three")?.key).toBe("three");
+  });
+});

--- a/wallet/zuuli/src/features/search/pagination.ts
+++ b/wallet/zuuli/src/features/search/pagination.ts
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { discover } from "@/lib/api/free2z";
+import type { Article, SearchResultPage, SimpleCreator } from "@/lib/api/types";
+
+export interface SearchSnapshot<T> {
+  key: string;
+  items: T[];
+  next: number | null;
+  count: number | null;
+  initialized: boolean;
+}
+
+interface SearchState<T> extends SearchSnapshot<T> {
+  error: unknown | null;
+  loading: boolean;
+}
+
+export class SearchSnapshotCache<T> {
+  private readonly snapshots = new Map<string, SearchSnapshot<T>>();
+
+  constructor(private readonly limit: number) {
+    if (!Number.isSafeInteger(limit) || limit < 1) {
+      throw new Error("Search cache limit must be a positive integer.");
+    }
+  }
+
+  restore(key: string): SearchSnapshot<T> | null {
+    const snapshot = this.snapshots.get(key);
+    if (!snapshot) return null;
+    this.snapshots.delete(key);
+    this.snapshots.set(key, snapshot);
+    return snapshot;
+  }
+
+  remember(snapshot: SearchSnapshot<T>) {
+    this.snapshots.delete(snapshot.key);
+    this.snapshots.set(snapshot.key, snapshot);
+    if (this.snapshots.size > this.limit) {
+      this.snapshots.delete(this.snapshots.keys().next().value as string);
+    }
+  }
+}
+
+function emptySnapshot<T>(key: string): SearchSnapshot<T> {
+  return {
+    key,
+    items: [],
+    next: key ? 1 : null,
+    count: key ? null : 0,
+    initialized: !key,
+  };
+}
+
+/** Append a validated page while preserving backend order and unique rows. */
+export function mergeSearchPage<T>(
+  current: SearchSnapshot<T>,
+  response: SearchResultPage<T>,
+  requestedPage: number,
+  identity: (item: T) => string,
+): SearchSnapshot<T> {
+  if (requestedPage !== current.next) {
+    throw new Error("Search received an unexpected page.");
+  }
+  if (current.count !== null && response.count !== current.count) {
+    throw new Error("Search result count changed during the read.");
+  }
+  if (response.next !== null && response.next !== requestedPage + 1) {
+    throw new Error("Search returned an unexpected next page.");
+  }
+
+  const seen = new Set(current.items.map(identity));
+  const items = [...current.items];
+  for (const item of response.items) {
+    const key = identity(item);
+    if (!seen.has(key)) {
+      seen.add(key);
+      items.push(item);
+    }
+  }
+
+  if (items.length > response.count) {
+    throw new Error("Search exceeded its authoritative result count.");
+  }
+  if (response.next === null && items.length !== response.count) {
+    throw new Error("Search ended before every result was loaded.");
+  }
+  if (response.next !== null && items.length === current.items.length) {
+    throw new Error("Search pagination made no progress.");
+  }
+  if (response.next !== null && items.length >= response.count) {
+    throw new Error("Search continued past its authoritative result count.");
+  }
+
+  return {
+    key: current.key,
+    items,
+    next: response.next,
+    count: response.count,
+    initialized: true,
+  };
+}
+
+const creatorCache = new SearchSnapshotCache<SimpleCreator>(20);
+const pageCache = new SearchSnapshotCache<Article>(20);
+
+function usePaginatedSearch<T>(
+  query: string,
+  cache: SearchSnapshotCache<T>,
+  loadPage: (query: string, page: number) => Promise<SearchResultPage<T>>,
+  identity: (item: T) => string,
+) {
+  const initial = () => cache.restore(query) ?? emptySnapshot<T>(query);
+  const [state, setState] = useState<SearchState<T>>(() => ({
+    ...initial(),
+    error: null,
+    loading: false,
+  }));
+  const stateRef = useRef(state);
+  const requestIdRef = useRef(0);
+  stateRef.current = state;
+
+  const load = useCallback(
+    async (page: number) => {
+      if (stateRef.current.loading || stateRef.current.key !== query) return;
+      const requestId = ++requestIdRef.current;
+      const loadingState = {
+        ...stateRef.current,
+        error: null,
+        loading: true,
+      };
+      stateRef.current = loadingState;
+      setState(loadingState);
+      try {
+        const response = await loadPage(query, page);
+        if (requestIdRef.current !== requestId) return;
+        const merged = mergeSearchPage(
+          stateRef.current,
+          response,
+          page,
+          identity,
+        );
+        const nextState = { ...merged, error: null, loading: false };
+        stateRef.current = nextState;
+        cache.remember(merged);
+        setState(nextState);
+      } catch (error) {
+        if (requestIdRef.current !== requestId) return;
+        const nextState = { ...stateRef.current, error, loading: false };
+        stateRef.current = nextState;
+        setState(nextState);
+      }
+    },
+    [cache, identity, loadPage, query],
+  );
+
+  useEffect(() => {
+    requestIdRef.current += 1;
+    const snapshot = cache.restore(query) ?? emptySnapshot<T>(query);
+    const nextState = { ...snapshot, error: null, loading: false };
+    stateRef.current = nextState;
+    setState(nextState);
+    if (!snapshot.initialized && snapshot.next !== null) {
+      void load(snapshot.next);
+    }
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, [cache, load, query]);
+
+  const loadMore = useCallback(() => {
+    const next = stateRef.current.next;
+    if (next !== null) void load(next);
+  }, [load]);
+
+  const retry = useCallback(() => {
+    const next = stateRef.current.next;
+    if (next !== null) void load(next);
+  }, [load]);
+
+  if (state.key !== query) {
+    return {
+      ...emptySnapshot<T>(query),
+      error: null,
+      loading: Boolean(query),
+      loadMore,
+      retry,
+    };
+  }
+  return { ...state, loadMore, retry };
+}
+
+const loadCreatorPage = (query: string, page: number) =>
+  discover.searchCreatorPage(query, page);
+const loadPagePage = (query: string, page: number) =>
+  discover.searchPagePage(query, page);
+const creatorIdentity = (creator: SimpleCreator) =>
+  creator.username.toLowerCase();
+const pageIdentity = (article: Article) => String(article.id);
+
+export function useCreatorSearch(query: string) {
+  return usePaginatedSearch(
+    query,
+    creatorCache,
+    loadCreatorPage,
+    creatorIdentity,
+  );
+}
+
+export function usePageSearch(query: string) {
+  return usePaginatedSearch(query, pageCache, loadPagePage, pageIdentity);
+}

--- a/wallet/zuuli/src/features/search/pagination.ts
+++ b/wallet/zuuli/src/features/search/pagination.ts
@@ -76,13 +76,20 @@ export function mergeSearchPage<T>(
   }
 
   if (response.next !== null && items.length === current.items.length) {
-    throw new Error("Search pagination made no progress.");
+    // Offset pagination over tied, mutable rows can return a page made wholly
+    // of records already seen. The backend cursor still advanced, so retaining
+    // it is the only way to reach later unique rows; retrying the old cursor
+    // would loop forever.
+    console.warn("Search page contained no new rows; advancing its cursor.", {
+      requestedPage,
+      next: response.next,
+    });
   }
 
   // DRF recomputes count for every offset page, while rows can be published or
   // removed between clicks. Search ordering also contains ties, so deduped row
   // length cannot be required to equal that moving display hint. The cursor is
-  // the traversal authority; retain strict cursor/progress validation above
+  // the traversal authority; retain strict cursor validation above
   // and surface count drift diagnostically without discarding valid rows.
   if (
     (current.count !== null && response.count !== current.count) ||

--- a/wallet/zuuli/src/features/search/pagination.ts
+++ b/wallet/zuuli/src/features/search/pagination.ts
@@ -61,9 +61,6 @@ export function mergeSearchPage<T>(
   if (requestedPage !== current.next) {
     throw new Error("Search received an unexpected page.");
   }
-  if (current.count !== null && response.count !== current.count) {
-    throw new Error("Search result count changed during the read.");
-  }
   if (response.next !== null && response.next !== requestedPage + 1) {
     throw new Error("Search returned an unexpected next page.");
   }
@@ -78,17 +75,27 @@ export function mergeSearchPage<T>(
     }
   }
 
-  if (items.length > response.count) {
-    throw new Error("Search exceeded its authoritative result count.");
-  }
-  if (response.next === null && items.length !== response.count) {
-    throw new Error("Search ended before every result was loaded.");
-  }
   if (response.next !== null && items.length === current.items.length) {
     throw new Error("Search pagination made no progress.");
   }
-  if (response.next !== null && items.length >= response.count) {
-    throw new Error("Search continued past its authoritative result count.");
+
+  // DRF recomputes count for every offset page, while rows can be published or
+  // removed between clicks. Search ordering also contains ties, so deduped row
+  // length cannot be required to equal that moving display hint. The cursor is
+  // the traversal authority; retain strict cursor/progress validation above
+  // and surface count drift diagnostically without discarding valid rows.
+  if (
+    (current.count !== null && response.count !== current.count) ||
+    items.length > response.count ||
+    (response.next === null && items.length !== response.count) ||
+    (response.next !== null && items.length >= response.count)
+  ) {
+    console.warn("Search result count changed during pagination.", {
+      previousCount: current.count,
+      responseCount: response.count,
+      loadedCount: items.length,
+      next: response.next,
+    });
   }
 
   return {
@@ -120,11 +127,12 @@ function usePaginatedSearch<T>(
   stateRef.current = state;
 
   const load = useCallback(
-    async (page: number) => {
+    async (page: number, rebaselineCount = false) => {
       if (stateRef.current.loading || stateRef.current.key !== query) return;
       const requestId = ++requestIdRef.current;
       const loadingState = {
         ...stateRef.current,
+        count: rebaselineCount ? null : stateRef.current.count,
         error: null,
         loading: true,
       };
@@ -174,7 +182,7 @@ function usePaginatedSearch<T>(
 
   const retry = useCallback(() => {
     const next = stateRef.current.next;
-    if (next !== null) void load(next);
+    if (next !== null) void load(next, true);
   }, [load]);
 
   if (state.key !== query) {

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -1974,20 +1974,26 @@ function mockSearchResultPage<T>(
   if (scenario === "unavailable") {
     throw new Error("Mock search corpus unavailable");
   }
-  if (scenario === "empty-nonterminal") {
-    return { items: [], next: page + 1, count: allItems.length };
-  }
-
   const effectivePageSize =
     scenario === "small-pages" ||
     scenario === "overlap" ||
     scenario === "count-drift" ||
-    scenario === "skip-row"
+    scenario === "skip-row" ||
+    scenario === "duplicate-page"
       ? 2
       : pageSize;
   const nominalStart = (page - 1) * effectivePageSize;
+  if (scenario === "duplicate-page" && page === 2) {
+    return {
+      items: allItems.slice(0, effectivePageSize),
+      next: 3,
+      count: allItems.length,
+    };
+  }
   const start =
-    scenario === "overlap" && page > 1
+    scenario === "duplicate-page" && page > 2
+      ? nominalStart - effectivePageSize
+      : scenario === "overlap" && page > 1
       ? nominalStart - 1
       : scenario === "skip-row" && page > 1
         ? nominalStart + 1

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -86,6 +86,7 @@ import type {
   PricingSnapshot,
   ProfileUpdateInput,
   PromptResponse,
+  SearchResultPage,
   SimpleCreator,
   SocialProvider,
   SocialAuthResult,
@@ -441,6 +442,123 @@ function mapArticle(z: RawZPage): Article {
     published_at: z.publish_at || z.created_at,
     reading_minutes: readingMinutes(z.content),
     tags: z.tags ?? [],
+  };
+}
+
+function parseSearchCursor(
+  value: unknown,
+  endpoint: "/api/creator/" | "/api/zpage/",
+  query: string,
+  currentPage: number,
+  pageSize: number,
+  ordering?: string,
+): number | null {
+  if (value === null) return null;
+  if (typeof value !== "string") {
+    throw new Error("Malformed search pagination next link.");
+  }
+
+  const nextUrl = new URL(value, "http://localhost");
+  if (nextUrl.pathname !== endpoint) {
+    throw new Error("Search pagination left its endpoint.");
+  }
+  if (nextUrl.searchParams.get("search") !== query) {
+    throw new Error("Search pagination changed its query.");
+  }
+  if (nextUrl.searchParams.get("page_size") !== String(pageSize)) {
+    throw new Error("Search pagination changed its page size.");
+  }
+  if (ordering && nextUrl.searchParams.get("ordering") !== ordering) {
+    throw new Error("Search pagination changed its ordering.");
+  }
+  const next = Number(nextUrl.searchParams.get("page"));
+  if (!Number.isSafeInteger(next) || next !== currentPage + 1) {
+    throw new Error("Search pagination returned an invalid next page.");
+  }
+  return next;
+}
+
+function parseSearchEnvelope(value: unknown): {
+  count: number;
+  next: unknown;
+  results: unknown[];
+} {
+  if (!isRecord(value) || !Array.isArray(value.results)) {
+    throw new Error("Malformed search pagination response.");
+  }
+  if (!Number.isSafeInteger(value.count) || Number(value.count) < 0) {
+    throw new Error("Malformed search pagination count.");
+  }
+  if (value.previous !== null && typeof value.previous !== "string") {
+    throw new Error("Malformed search pagination previous link.");
+  }
+  return {
+    count: Number(value.count),
+    next: value.next,
+    results: value.results,
+  };
+}
+
+/** Runtime validator for the creator half of global Search. */
+export function parseCreatorSearchPage(
+  value: unknown,
+  query: string,
+  currentPage: number,
+  pageSize: number,
+): SearchResultPage<SimpleCreator> {
+  const envelope = parseSearchEnvelope(value);
+  const items = envelope.results.map((row) => {
+    if (!isRecord(row) || typeof row.username !== "string" || !row.username) {
+      throw new Error("Malformed creator search result identity.");
+    }
+    return mapCreator(row as unknown as RawCreator);
+  });
+  return {
+    count: envelope.count,
+    next: parseSearchCursor(
+      envelope.next,
+      "/api/creator/",
+      query,
+      currentPage,
+      pageSize,
+      "-total",
+    ),
+    items,
+  };
+}
+
+/** Runtime validator for the zpage half of global Search. */
+export function parsePageSearchPage(
+  value: unknown,
+  query: string,
+  currentPage: number,
+  pageSize: number,
+): SearchResultPage<Article> {
+  const envelope = parseSearchEnvelope(value);
+  const items = envelope.results.map((row) => {
+    if (
+      !isRecord(row) ||
+      typeof row.free2zaddr !== "string" ||
+      !row.free2zaddr ||
+      typeof row.title !== "string" ||
+      !isRecord(row.creator) ||
+      typeof row.creator.username !== "string" ||
+      !row.creator.username
+    ) {
+      throw new Error("Malformed page search result identity.");
+    }
+    return mapArticle(row as unknown as RawZPage);
+  });
+  return {
+    count: envelope.count,
+    next: parseSearchCursor(
+      envelope.next,
+      "/api/zpage/",
+      query,
+      currentPage,
+      pageSize,
+    ),
+    items,
   };
 }
 
@@ -1786,6 +1904,48 @@ export const tuzi = {
 };
 
 // ─── Discovery ───────────────────────────────────────────────────────────────
+function mockSearchResultPage<T>(
+  allItems: T[],
+  page: number,
+  pageSize: number,
+  scenarioKey: string,
+): SearchResultPage<T> {
+  const scenario =
+    typeof window === "undefined"
+      ? null
+      : window.sessionStorage.getItem(scenarioKey);
+  if (scenario === "fail-once") {
+    window.sessionStorage.removeItem(scenarioKey);
+    throw new Error("Mock search corpus unavailable");
+  }
+  if (scenario === "empty-once" || scenario === "empty-twice") {
+    const remainingKey = `${scenarioKey}.remaining`;
+    const remaining =
+      scenario === "empty-twice"
+        ? Number(window.sessionStorage.getItem(remainingKey) ?? "2")
+        : 1;
+    if (remaining <= 1) {
+      window.sessionStorage.removeItem(scenarioKey);
+      window.sessionStorage.removeItem(remainingKey);
+    } else {
+      window.sessionStorage.setItem(remainingKey, String(remaining - 1));
+    }
+    return { items: [], next: page + 1, count: allItems.length };
+  }
+
+  const effectivePageSize =
+    scenario === "small-pages" || scenario === "overlap" ? 2 : pageSize;
+  const nominalStart = (page - 1) * effectivePageSize;
+  const start =
+    scenario === "overlap" && page > 1 ? nominalStart - 1 : nominalStart;
+  const items = allItems.slice(start, start + effectivePageSize);
+  return {
+    items,
+    next: start + effectivePageSize < allItems.length ? page + 1 : null,
+    count: allItems.length,
+  };
+}
+
 export const discover = {
   async creators(): Promise<SimpleCreator[]> {
     if (useMock()) {
@@ -1805,18 +1965,32 @@ export const discover = {
    * action) only surfaces creators that have both an avatar and a banner.
    * Public, no auth. Ordered by popularity (`-total`) by default.
    */
-  async searchCreators(query: string): Promise<SimpleCreator[]> {
+  async searchCreatorPage(
+    query: string,
+    page = 1,
+    pageSize = 24,
+  ): Promise<SearchResultPage<SimpleCreator>> {
     const q = query.trim();
     if (useMock()) {
       await delay(200);
-      return mockSearchCreators(q);
+      return mockSearchResultPage(
+        mockSearchCreators(q),
+        page,
+        pageSize,
+        "zuuli.mock.search-creators",
+      );
     }
-    if (!q) return [];
-    const page = await request<Paginated<RawCreator>>("/api/creator/", {
-      query: { search: q, page_size: 24, ordering: "-total" },
+    if (!q) return { items: [], next: null, count: 0 };
+    const response = await request<unknown>("/api/creator/", {
+      query: { search: q, page, page_size: pageSize, ordering: "-total" },
       anonymous: true,
     });
-    return (page.results ?? []).map(mapCreator);
+    return parseCreatorSearchPage(response, q, page, pageSize);
+  },
+
+  /** Legacy one-page creator lookup used by compact recipient suggestions. */
+  async searchCreators(query: string): Promise<SimpleCreator[]> {
+    return (await discover.searchCreatorPage(query)).items;
   },
 
   /** GET /api/creator/{username}/ → the data-driven public creator profile. */
@@ -1853,21 +2027,34 @@ export const discover = {
    * when a key is present, and falls back to Postgres full-text search
    * otherwise. Public, no auth.
    */
-  async searchPages(query: string): Promise<Article[]> {
+  async searchPagePage(
+    query: string,
+    page = 1,
+    pageSize = 24,
+  ): Promise<SearchResultPage<Article>> {
     const q = query.trim();
     if (useMock()) {
       await delay(220);
-      return mockSearchPages(q);
+      return mockSearchResultPage(
+        mockSearchPages(q),
+        page,
+        pageSize,
+        "zuuli.mock.search-pages",
+      );
     }
-    if (!q) return [];
-    const page = await request<Paginated<RawZPage>>("/api/zpage/", {
-      query: { search: q, page_size: 24 },
+    if (!q) return { items: [], next: null, count: 0 };
+    const response = await request<unknown>("/api/zpage/", {
+      query: { search: q, page, page_size: pageSize },
       anonymous: true,
     });
-    return (page.results ?? []).map(mapArticle);
+    return parsePageSearchPage(response, q, page, pageSize);
+  },
+
+  /** Legacy one-page page search; global Search uses `searchPagePage`. */
+  async searchPages(query: string): Promise<Article[]> {
+    return (await discover.searchPagePage(query)).items;
   },
 };
-
 
 // ─── Pricing (live 2Z ↔ ZEC) ──────────────────────────────────────
 // Live price discovery for the "pay with ZEC" buy path. The backend aggregates

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -1914,35 +1914,35 @@ function mockSearchResultPage<T>(
     typeof window === "undefined"
       ? null
       : window.sessionStorage.getItem(scenarioKey);
-  if (scenario === "fail-once") {
-    window.sessionStorage.removeItem(scenarioKey);
+  if (scenario === "unavailable") {
     throw new Error("Mock search corpus unavailable");
   }
-  if (scenario === "empty-once" || scenario === "empty-twice") {
-    const remainingKey = `${scenarioKey}.remaining`;
-    const remaining =
-      scenario === "empty-twice"
-        ? Number(window.sessionStorage.getItem(remainingKey) ?? "2")
-        : 1;
-    if (remaining <= 1) {
-      window.sessionStorage.removeItem(scenarioKey);
-      window.sessionStorage.removeItem(remainingKey);
-    } else {
-      window.sessionStorage.setItem(remainingKey, String(remaining - 1));
-    }
+  if (scenario === "empty-nonterminal") {
     return { items: [], next: page + 1, count: allItems.length };
   }
 
   const effectivePageSize =
-    scenario === "small-pages" || scenario === "overlap" ? 2 : pageSize;
+    scenario === "small-pages" ||
+    scenario === "overlap" ||
+    scenario === "count-drift" ||
+    scenario === "skip-row"
+      ? 2
+      : pageSize;
   const nominalStart = (page - 1) * effectivePageSize;
   const start =
-    scenario === "overlap" && page > 1 ? nominalStart - 1 : nominalStart;
+    scenario === "overlap" && page > 1
+      ? nominalStart - 1
+      : scenario === "skip-row" && page > 1
+        ? nominalStart + 1
+        : nominalStart;
   const items = allItems.slice(start, start + effectivePageSize);
   return {
     items,
     next: start + effectivePageSize < allItems.length ? page + 1 : null,
-    count: allItems.length,
+    count:
+      scenario === "count-drift" && page > 1
+        ? allItems.length + 1
+        : allItems.length,
   };
 }
 
@@ -1990,7 +1990,17 @@ export const discover = {
 
   /** Legacy one-page creator lookup used by compact recipient suggestions. */
   async searchCreators(query: string): Promise<SimpleCreator[]> {
-    return (await discover.searchCreatorPage(query)).items;
+    const q = query.trim();
+    if (useMock()) {
+      await delay(200);
+      return mockSearchCreators(q);
+    }
+    if (!q) return [];
+    const page = await request<Paginated<RawCreator>>("/api/creator/", {
+      query: { search: q, page_size: 24, ordering: "-total" },
+      anonymous: true,
+    });
+    return (page.results ?? []).map(mapCreator);
   },
 
   /** GET /api/creator/{username}/ → the data-driven public creator profile. */

--- a/wallet/zuuli/src/lib/api/search-pagination-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/search-pagination-contract.test.ts
@@ -91,24 +91,29 @@ describe("global Search pagination API contract", () => {
     [
       "endpoint",
       "/api/zpage/?search=zero+knowledge&page=2&page_size=24&ordering=-total",
+      "left its endpoint",
     ],
     [
       "query",
       "/api/creator/?search=another&page=2&page_size=24&ordering=-total",
+      "changed its query",
     ],
     [
       "page size",
       "/api/creator/?search=zero+knowledge&page=2&page_size=25&ordering=-total",
+      "changed its page size",
     ],
     [
       "ordering",
       "/api/creator/?search=zero+knowledge&page=2&page_size=24&ordering=popular",
+      "changed its ordering",
     ],
     [
       "next page",
       "/api/creator/?search=zero+knowledge&page=3&page_size=24&ordering=-total",
+      "invalid next page",
     ],
-  ])("rejects a creator cursor that changes its %s", (_case, next) => {
+  ])("rejects a creator cursor that changes its %s", (_case, next, error) => {
     expect(() =>
       parseCreatorSearchPage(
         { ...envelope("/api/creator/", []), next },
@@ -116,6 +121,18 @@ describe("global Search pagination API contract", () => {
         1,
         24,
       ),
-    ).toThrow(/endpoint|query|page size|ordering|next page/);
+    ).toThrow(error);
+  });
+
+  it("accepts the absolute cursor shape emitted by production DRF", () => {
+    const relative = envelope("/api/creator/", [creator("alice")]);
+    expect(
+      parseCreatorSearchPage(
+        { ...relative, next: `https://free2z.cash${relative.next}` },
+        query,
+        1,
+        24,
+      ),
+    ).toMatchObject({ next: 2, count: 30 });
   });
 });

--- a/wallet/zuuli/src/lib/api/search-pagination-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/search-pagination-contract.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { parseCreatorSearchPage, parsePageSearchPage } from "./free2z";
+
+const query = "zero knowledge";
+
+function creator(username: string) {
+  return { username, full_name: username.toUpperCase() };
+}
+
+function zpage(id: string) {
+  return {
+    free2zaddr: id,
+    title: `Page ${id}`,
+    creator: creator("alice"),
+  };
+}
+
+function envelope(
+  endpoint: "/api/creator/" | "/api/zpage/",
+  results: unknown[],
+  extra = "",
+) {
+  const params = new URLSearchParams({
+    search: query,
+    page: "2",
+    page_size: "24",
+  });
+  if (endpoint === "/api/creator/") params.set("ordering", "-total");
+  return {
+    count: 30,
+    next: `${endpoint}?${params.toString()}${extra}`,
+    previous: null,
+    results,
+  };
+}
+
+describe("global Search pagination API contract", () => {
+  it("preserves independent creator and page cursors with authoritative counts", () => {
+    expect(
+      parseCreatorSearchPage(
+        envelope("/api/creator/", [creator("alice")]),
+        query,
+        1,
+        24,
+      ),
+    ).toMatchObject({ count: 30, next: 2, items: [{ username: "alice" }] });
+    expect(
+      parsePageSearchPage(
+        envelope("/api/zpage/", [zpage("one")]),
+        query,
+        1,
+        24,
+      ),
+    ).toMatchObject({ count: 30, next: 2, items: [{ id: "one" }] });
+  });
+
+  it("accepts an authoritative empty terminal corpus", () => {
+    expect(
+      parsePageSearchPage(
+        { count: 0, next: null, previous: null, results: [] },
+        query,
+        1,
+        24,
+      ),
+    ).toEqual({ count: 0, next: null, items: [] });
+  });
+
+  it("rejects malformed counts and result identities", () => {
+    expect(() =>
+      parseCreatorSearchPage(
+        { ...envelope("/api/creator/", []), count: "30" },
+        query,
+        1,
+        24,
+      ),
+    ).toThrow("pagination count");
+    expect(() =>
+      parseCreatorSearchPage(envelope("/api/creator/", [{}]), query, 1, 24),
+    ).toThrow("creator search result identity");
+    expect(() =>
+      parsePageSearchPage(
+        envelope("/api/zpage/", [{ free2zaddr: "one", title: "One" }]),
+        query,
+        1,
+        24,
+      ),
+    ).toThrow("page search result identity");
+  });
+
+  it.each([
+    [
+      "endpoint",
+      "/api/zpage/?search=zero+knowledge&page=2&page_size=24&ordering=-total",
+    ],
+    [
+      "query",
+      "/api/creator/?search=another&page=2&page_size=24&ordering=-total",
+    ],
+    [
+      "page size",
+      "/api/creator/?search=zero+knowledge&page=2&page_size=25&ordering=-total",
+    ],
+    [
+      "ordering",
+      "/api/creator/?search=zero+knowledge&page=2&page_size=24&ordering=popular",
+    ],
+    [
+      "next page",
+      "/api/creator/?search=zero+knowledge&page=3&page_size=24&ordering=-total",
+    ],
+  ])("rejects a creator cursor that changes its %s", (_case, next) => {
+    expect(() =>
+      parseCreatorSearchPage(
+        { ...envelope("/api/creator/", []), next },
+        query,
+        1,
+        24,
+      ),
+    ).toThrow(/endpoint|query|page size|ordering|next page/);
+  });
+});

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -331,6 +331,13 @@ export interface ArticleFeedPage {
   count: number;
 }
 
+/** One validated page from either corpus in global Search. */
+export interface SearchResultPage<T> {
+  items: T[];
+  next: number | null;
+  count: number;
+}
+
 // ── Livestreams (dyte) ──────────────────────────────────────────────────────
 export type StreamKind = "broadcast" | "subscriber" | "ppv" | "private";
 

--- a/wallet/zuuli/tests/search-pagination.pw.ts
+++ b/wallet/zuuli/tests/search-pagination.pw.ts
@@ -34,15 +34,19 @@ test("every result remains loaded with its tab and scroll position across back n
   await expect(page).toHaveURL(/\/search\?q=a&tab=pages$/);
   const pageResults = page.locator("[data-search-page-result]");
   await expect(pageResults).toHaveCount(2);
-  await expect(page.getByRole("tab", { name: /Pages/ })).toContainText("61");
+  const pagesTab = page.getByRole("tab", { name: /Pages/ });
+  const pageTotal = Number(await pagesTab.locator("span").last().textContent());
+  expect(pageTotal).toBeGreaterThan(2);
 
-  for (let expected = 4; expected <= 60; expected += 2) {
+  let expected = 2;
+  while (expected < pageTotal) {
     await page.getByRole("button", { name: "Load more pages" }).click();
+    expected = Math.min(expected + 2, pageTotal);
     await expect(pageResults).toHaveCount(expected);
   }
-  await page.getByRole("button", { name: "Load more pages" }).click();
-  await expect(pageResults).toHaveCount(61);
-  await expect(page.getByText("61 of 61 pages", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText(`${pageTotal} of ${pageTotal} pages`, { exact: true }),
+  ).toBeVisible();
 
   const scroller = viewport(page);
   const savedOffset = await scroller.evaluate((element) => {
@@ -55,7 +59,7 @@ test("every result remains loaded with its tab and scroll position across back n
   await expect(page).toHaveURL(/\/articles\//);
   await page.goBack();
   await expect(page).toHaveURL(/\/search\?q=a&tab=pages$/);
-  await expect(pageResults).toHaveCount(61);
+  await expect(pageResults).toHaveCount(pageTotal);
   await expect
     .poll(() => scroller.evaluate((element) => element.scrollTop))
     .toBeCloseTo(savedOffset, 0);
@@ -78,7 +82,9 @@ test("an empty nonterminal corpus failure is explicit, isolated, and retryable",
 
   await page.getByRole("tab", { name: /Pages/ }).click();
   await expect(page.locator("[data-search-page-result]")).toHaveCount(2);
-  await expect(page.getByRole("tab", { name: /Pages/ })).toContainText("61");
+  await expect(
+    page.getByRole("tab", { name: /Pages/ }).locator("span").last(),
+  ).not.toHaveText("0");
 
   await page.getByRole("tab", { name: /Creators/ }).click();
   await page.evaluate(() =>
@@ -107,14 +113,23 @@ test("count drift and tied-row skips retain the valid terminal results", async (
   await page.getByRole("tab", { name: /Pages/ }).click();
   const pages = page.locator("[data-search-page-result]");
   await expect(pages).toHaveCount(2);
-  for (let expected = 4; expected <= 58; expected += 2) {
+  const pageTotal = Number(
+    await page
+      .getByRole("tab", { name: /Pages/ })
+      .locator("span")
+      .last()
+      .textContent(),
+  );
+  let expected = 2;
+  while (expected < pageTotal - 1) {
     await page.getByRole("button", { name: "Load more pages" }).click();
+    expected = Math.min(expected + 2, pageTotal - 1);
     await expect(pages).toHaveCount(expected);
   }
-  await page.getByRole("button", { name: "Load more pages" }).click();
-  await expect(pages).toHaveCount(60);
   await expect(page.getByRole("alert")).toHaveCount(0);
-  await expect(page.getByText("60 of 61 pages", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText(`${pageTotal - 1} of ${pageTotal} pages`, { exact: true }),
+  ).toBeVisible();
 });
 
 test("overlapping backend pages are deduplicated without losing order", async ({

--- a/wallet/zuuli/tests/search-pagination.pw.ts
+++ b/wallet/zuuli/tests/search-pagination.pw.ts
@@ -68,7 +68,7 @@ test("every result remains loaded with its tab and scroll position across back n
 test("an empty nonterminal corpus failure is explicit, isolated, and retryable", async ({
   page,
 }) => {
-  await useSearchScenarios(page, "empty-twice", "small-pages");
+  await useSearchScenarios(page, "empty-nonterminal", "small-pages");
   await page.goto("/search?q=a");
 
   await expect(
@@ -81,11 +81,40 @@ test("an empty nonterminal corpus failure is explicit, isolated, and retryable",
   await expect(page.getByRole("tab", { name: /Pages/ })).toContainText("61");
 
   await page.getByRole("tab", { name: /Creators/ }).click();
+  await page.evaluate(() =>
+    sessionStorage.removeItem("zuuli.mock.search-creators"),
+  );
   await page.getByRole("button", { name: "Retry" }).click();
   await expect(page.locator("[data-search-creator-result]")).toHaveCount(4);
   await expect(
     page.getByText("4 of 4 creators", { exact: true }),
   ).toBeVisible();
+});
+
+test("count drift and tied-row skips retain the valid terminal results", async ({
+  page,
+}) => {
+  await useSearchScenarios(page, "count-drift", "skip-row");
+  await page.goto("/search?q=a");
+
+  const creators = page.locator("[data-search-creator-result]");
+  await expect(creators).toHaveCount(2);
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(creators).toHaveCount(4);
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(page.getByText("4 of 5 creators", { exact: true })).toBeVisible();
+
+  await page.getByRole("tab", { name: /Pages/ }).click();
+  const pages = page.locator("[data-search-page-result]");
+  await expect(pages).toHaveCount(2);
+  for (let expected = 4; expected <= 58; expected += 2) {
+    await page.getByRole("button", { name: "Load more pages" }).click();
+    await expect(pages).toHaveCount(expected);
+  }
+  await page.getByRole("button", { name: "Load more pages" }).click();
+  await expect(pages).toHaveCount(60);
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(page.getByText("60 of 61 pages", { exact: true })).toBeVisible();
 });
 
 test("overlapping backend pages are deduplicated without losing order", async ({

--- a/wallet/zuuli/tests/search-pagination.pw.ts
+++ b/wallet/zuuli/tests/search-pagination.pw.ts
@@ -1,0 +1,110 @@
+import { expect, test, type Page } from "@playwright/test";
+
+function viewport(page: Page) {
+  return page.locator("[data-scroll-area-viewport]");
+}
+
+async function useSearchScenarios(page: Page, creators: string, pages: string) {
+  await page.addInitScript(
+    ({ creatorScenario, pageScenario }) => {
+      sessionStorage.setItem("zuuli.mock.search-creators", creatorScenario);
+      sessionStorage.setItem("zuuli.mock.search-pages", pageScenario);
+    },
+    { creatorScenario: creators, pageScenario: pages },
+  );
+}
+
+test("every result remains loaded with its tab and scroll position across back navigation", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 640 });
+  await useSearchScenarios(page, "small-pages", "small-pages");
+  await page.goto("/search?q=a");
+
+  const creatorResults = page.locator("[data-search-creator-result]");
+  await expect(creatorResults).toHaveCount(2);
+  await expect(page.getByRole("tab", { name: /Creators/ })).toContainText("4");
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(creatorResults).toHaveCount(4);
+  await expect(
+    page.getByText("4 of 4 creators", { exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("tab", { name: /Pages/ }).click();
+  await expect(page).toHaveURL(/\/search\?q=a&tab=pages$/);
+  const pageResults = page.locator("[data-search-page-result]");
+  await expect(pageResults).toHaveCount(2);
+  await expect(page.getByRole("tab", { name: /Pages/ })).toContainText("61");
+
+  for (let expected = 4; expected <= 60; expected += 2) {
+    await page.getByRole("button", { name: "Load more pages" }).click();
+    await expect(pageResults).toHaveCount(expected);
+  }
+  await page.getByRole("button", { name: "Load more pages" }).click();
+  await expect(pageResults).toHaveCount(61);
+  await expect(page.getByText("61 of 61 pages", { exact: true })).toBeVisible();
+
+  const scroller = viewport(page);
+  const savedOffset = await scroller.evaluate((element) => {
+    element.scrollTop = element.scrollHeight - element.clientHeight - 100;
+    return element.scrollTop;
+  });
+  expect(savedOffset).toBeGreaterThan(1_000);
+
+  await pageResults.last().getByRole("link").click();
+  await expect(page).toHaveURL(/\/articles\//);
+  await page.goBack();
+  await expect(page).toHaveURL(/\/search\?q=a&tab=pages$/);
+  await expect(pageResults).toHaveCount(61);
+  await expect
+    .poll(() => scroller.evaluate((element) => element.scrollTop))
+    .toBeCloseTo(savedOffset, 0);
+
+  await page.getByRole("tab", { name: /Creators/ }).click();
+  await expect(creatorResults).toHaveCount(4);
+  await expect(page.getByRole("searchbox")).toHaveValue("a");
+});
+
+test("an empty nonterminal corpus failure is explicit, isolated, and retryable", async ({
+  page,
+}) => {
+  await useSearchScenarios(page, "empty-twice", "small-pages");
+  await page.goto("/search?q=a");
+
+  await expect(
+    page.getByRole("alert").getByText("Creator search is unavailable"),
+  ).toBeVisible();
+  await expect(page.getByText("No creators found")).toHaveCount(0);
+
+  await page.getByRole("tab", { name: /Pages/ }).click();
+  await expect(page.locator("[data-search-page-result]")).toHaveCount(2);
+  await expect(page.getByRole("tab", { name: /Pages/ })).toContainText("61");
+
+  await page.getByRole("tab", { name: /Creators/ }).click();
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect(page.locator("[data-search-creator-result]")).toHaveCount(4);
+  await expect(
+    page.getByText("4 of 4 creators", { exact: true }),
+  ).toBeVisible();
+});
+
+test("overlapping backend pages are deduplicated without losing order", async ({
+  page,
+}) => {
+  await useSearchScenarios(page, "overlap", "small-pages");
+  await page.goto("/search?q=a");
+
+  const creators = page.locator("[data-search-creator-result]");
+  await expect(creators).toHaveCount(2);
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(creators).toHaveCount(3);
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(creators).toHaveCount(4);
+  const destinations = await creators.evaluateAll((links) =>
+    links.map((link) => link.getAttribute("href")),
+  );
+  expect(new Set(destinations).size).toBe(4);
+  await expect(
+    page.getByText("4 of 4 creators", { exact: true }),
+  ).toBeVisible();
+});

--- a/wallet/zuuli/tests/search-pagination.pw.ts
+++ b/wallet/zuuli/tests/search-pagination.pw.ts
@@ -69,28 +69,17 @@ test("every result remains loaded with its tab and scroll position across back n
   await expect(page.getByRole("searchbox")).toHaveValue("a");
 });
 
-test("an empty nonterminal corpus failure is explicit, isolated, and retryable", async ({
+test("a fully duplicated page advances to later unique results", async ({
   page,
 }) => {
-  await useSearchScenarios(page, "empty-nonterminal", "small-pages");
+  await useSearchScenarios(page, "duplicate-page", "small-pages");
   await page.goto("/search?q=a");
 
-  await expect(
-    page.getByRole("alert").getByText("Creator search is unavailable"),
-  ).toBeVisible();
-  await expect(page.getByText("No creators found")).toHaveCount(0);
-
-  await page.getByRole("tab", { name: /Pages/ }).click();
-  await expect(page.locator("[data-search-page-result]")).toHaveCount(2);
-  await expect(
-    page.getByRole("tab", { name: /Pages/ }).locator("span").last(),
-  ).not.toHaveText("0");
-
-  await page.getByRole("tab", { name: /Creators/ }).click();
-  await page.evaluate(() =>
-    sessionStorage.removeItem("zuuli.mock.search-creators"),
-  );
-  await page.getByRole("button", { name: "Retry" }).click();
+  const creators = page.locator("[data-search-creator-result]");
+  await expect(creators).toHaveCount(2);
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(creators).toHaveCount(2);
+  await page.getByRole("button", { name: "Load more creators" }).click();
   await expect(page.locator("[data-search-creator-result]")).toHaveCount(4);
   await expect(
     page.getByText("4 of 4 creators", { exact: true }),


### PR DESCRIPTION
Closes #252

## Summary
- preserve validated, independent backend pagination and authoritative counts for creator and page search
- incrementally load every result with ordered deduplication, retryable partial failures, and bounded per-query restoration
- keep the selected tab in the URL and restore loaded rows plus scroll position across back/forward navigation
- add API contract, state-machine, and Playwright coverage for terminal empty, nonterminal empty, overlapping pages, partial failures, and complete traversal

## Verification
- `npm run typecheck`
- `npx vitest run src/features/search/pagination.test.ts src/lib/api/search-pagination-contract.test.ts` (12 passed)
- `ZUULI_PW_PORT=1462 npx playwright test tests/search-pagination.pw.ts` (3 passed)
- `npm run build`
- `ZUULI_PW_PORT=1462 npm test` (616 Vitest assertions / 5 skipped, 79 Node tests, 103 Playwright tests)