### PR TITLE
security(oauth): bind every callback to its session

### DIFF
--- a/wallet/zuuli/scripts/auth-session-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/auth-session-boundary.node-test.mjs
@@ -53,11 +53,13 @@ test("every social OAuth transport pins completion to its initiating session", (
 
   assert.match(transport, /sessionBinding: string/);
   assert.match(transport, /transport: OAuthCallbackTransport/);
-  assert.match(transport, /onTokenChange\(\(token\)/);
-  assert.match(transport, /export async function assertOAuthSession/);
+  assert.match(transport, /onTokenChange\(\(\) => controller\.abort\(\)\)/);
+  assert.match(transport, /export async function withOAuthSession/);
   assert.doesNotMatch(transport, /assertMobileOAuthSession/);
-  assert.match(completion, /const initiatingToken = await assertOAuthSession\(capture\)/);
-  assert.match(completion, /authToken: initiatingToken \?\? undefined/);
+  assert.match(completion, /return withOAuthSession<SocialAuthResult>\(capture/);
+  assert.match(completion, /authToken: lease\.initiatingToken \?\? undefined/);
+  assert.match(completion, /auth\.me\(lease\.initiatingToken \?\? undefined, lease\.signal\)/);
+  assert.match(completion, /signal: lease\.signal/);
 
   const logout = between(api, "  async logout():", "  /**\n   * Login with Zcash:");
   assert.match(

--- a/wallet/zuuli/scripts/auth-session-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/auth-session-boundary.node-test.mjs
@@ -39,6 +39,33 @@ test("uncommitted profile probes use a private explicit token header", () => {
   assert.match(requestBody, /headers\["Authorization"\] = `Token \$\{token\}`/);
 });
 
+test("every social OAuth transport pins completion to its initiating session", () => {
+  const api = readFileSync(new URL("../src/lib/api/free2z.ts", import.meta.url), "utf8");
+  const transport = readFileSync(
+    new URL("../src/lib/oauth/transport.ts", import.meta.url),
+    "utf8",
+  );
+  const completion = between(
+    api,
+    "  async completeSocialOAuth(",
+    "};\n\n// ─── Profile",
+  );
+
+  assert.match(transport, /sessionBinding: string/);
+  assert.match(transport, /transport: OAuthCallbackTransport/);
+  assert.match(transport, /onTokenChange\(\(token\)/);
+  assert.match(transport, /export async function assertOAuthSession/);
+  assert.doesNotMatch(transport, /assertMobileOAuthSession/);
+  assert.match(completion, /const initiatingToken = await assertOAuthSession\(capture\)/);
+  assert.match(completion, /authToken: initiatingToken \?\? undefined/);
+
+  const logout = between(api, "  async logout():", "  /**\n   * Login with Zcash:");
+  assert.match(
+    logout,
+    /const token = getToken\(\);[\s\S]*?setToken\(null\);[\s\S]*?authToken: token \?\? undefined/,
+  );
+});
+
 test("recovery phrases cannot enter browser persistence, URLs, logs, or toasts", () => {
   const flow = readFileSync(
     new URL("../src/features/auth/useZcashChallengeFlow.ts", import.meta.url),

--- a/wallet/zuuli/src-tauri/src/oauth.rs
+++ b/wallet/zuuli/src-tauri/src/oauth.rs
@@ -18,7 +18,10 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -32,13 +35,26 @@ const MOBILE_HOST: &str = "oauth";
 const MOBILE_PATH: &str = "/callback";
 const OAUTH_TTL: Duration = Duration::from_secs(10 * 60);
 const LOOPBACK_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const LOOPBACK_CANCEL_POLL: Duration = Duration::from_millis(50);
 const MAX_CALLBACK_URL_BYTES: usize = 8 * 1024;
 const MAX_CODE_BYTES: usize = 4 * 1024;
 const MAX_STATE_BYTES: usize = 512;
 const PENDING_VERSION: u8 = 1;
 
+enum LoopbackFlow {
+    Ready {
+        server: Server,
+        nonce: String,
+    },
+    Waiting {
+        server: Arc<Server>,
+        nonce: String,
+        cancelled: Arc<AtomicBool>,
+    },
+}
+
 #[derive(Default)]
-pub struct OauthLoopbackState(Mutex<Option<(Server, String)>>);
+pub struct OauthLoopbackState(Arc<Mutex<Option<LoopbackFlow>>>);
 
 /// Serializes every read/transition/write of the crash-safe mobile record.
 #[derive(Default)]
@@ -446,6 +462,93 @@ pub fn oauth_callback_transport() -> &'static str {
     }
 }
 
+fn wait_for_loopback(
+    server: &Server,
+    nonce: &str,
+    expected_state: &str,
+    cancelled: &AtomicBool,
+    timeout: Duration,
+) -> Result<OauthCapture, String> {
+    let deadline = Instant::now() + timeout;
+    let expected_path = format!("/{nonce}");
+    loop {
+        if cancelled.load(Ordering::Acquire) {
+            return Err("Sign-in was cancelled.".to_string());
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err("timed out waiting for the OAuth redirect".to_string());
+        }
+        let request = match server.recv_timeout(remaining.min(LOOPBACK_CANCEL_POLL)) {
+            Ok(Some(request)) => request,
+            Ok(None) => continue,
+            Err(error) => return Err(format!("OAuth loopback listener error: {error}")),
+        };
+        if request.method() != &Method::Get {
+            let _ = request.respond(
+                Response::from_string("Method not allowed").with_status_code(StatusCode(405)),
+            );
+            continue;
+        }
+        let target = request.url();
+        if target.len() > MAX_CALLBACK_URL_BYTES {
+            let _ = request.respond(
+                Response::from_string("Request too large").with_status_code(StatusCode(414)),
+            );
+            continue;
+        }
+        let url = match Url::parse(&format!("http://127.0.0.1{target}")) {
+            Ok(url) if url.path() == expected_path && url.fragment().is_none() => url,
+            _ => {
+                let _ = request
+                    .respond(Response::from_string("Not found").with_status_code(StatusCode(404)));
+                continue;
+            }
+        };
+        let parsed = match parse_callback(&url) {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                let _ = request.respond(html_response(INCOMPLETE_HTML));
+                continue;
+            }
+        };
+        match parsed {
+            ParsedCallback::Code { code, state } if state == expected_state => {
+                let _ = request.respond(html_response(SUCCESS_HTML));
+                return Ok(OauthCapture { code, state });
+            }
+            ParsedCallback::Error { state } if state == expected_state => {
+                let _ = request.respond(html_response(INCOMPLETE_HTML));
+                return Err("Sign-in was cancelled.".to_string());
+            }
+            _ => {
+                // A local process that did not know the backend-minted state
+                // cannot consume the listener. Keep waiting.
+                let _ = request.respond(html_response(INCOMPLETE_HTML));
+            }
+        }
+    }
+}
+
+fn cancel_loopback(flow: &mut Option<LoopbackFlow>, redirect_path: &str) -> bool {
+    match flow {
+        Some(LoopbackFlow::Ready { nonce, .. }) if nonce == redirect_path => {
+            flow.take();
+            true
+        }
+        Some(LoopbackFlow::Waiting {
+            server,
+            nonce,
+            cancelled,
+        }) if nonce == redirect_path => {
+            cancelled.store(true, Ordering::Release);
+            server.unblock();
+            true
+        }
+        _ => false,
+    }
+}
+
 #[tauri::command]
 pub async fn oauth_loopback_start(
     state: State<'_, OauthLoopbackState>,
@@ -464,11 +567,19 @@ pub async fn oauth_loopback_start(
         .to_ip()
         .map(|addr| addr.port())
         .ok_or_else(|| "loopback listener bound to a non-IP address".to_string())?;
-    *state
+    let mut flow = state
         .0
         .lock()
-        .map_err(|_| "OAuth loopback state lock poisoned".to_string())? =
-        Some((server, nonce.clone()));
+        .map_err(|_| "OAuth loopback state lock poisoned".to_string())?;
+    match flow.as_ref() {
+        Some(LoopbackFlow::Waiting { cancelled, .. }) if cancelled.load(Ordering::Acquire) => {}
+        Some(_) => return Err("an OAuth loopback listener is already active".to_string()),
+        None => {}
+    }
+    *flow = Some(LoopbackFlow::Ready {
+        server,
+        nonce: nonce.clone(),
+    });
     Ok(LoopbackStart {
         port,
         redirect_path: nonce,
@@ -479,87 +590,72 @@ pub async fn oauth_loopback_start(
 pub async fn oauth_loopback_wait(
     state: State<'_, OauthLoopbackState>,
     expected_state: String,
+    redirect_path: String,
 ) -> Result<OauthCapture, String> {
-    if !valid_state(&expected_state) {
+    if !valid_state(&expected_state)
+        || redirect_path.len() != 32
+        || !redirect_path.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
         return Err("free2z returned an invalid OAuth state".to_string());
     }
-    let (server, nonce) = state
-        .0
-        .lock()
-        .map_err(|_| "OAuth loopback state lock poisoned".to_string())?
-        .take()
-        .ok_or_else(|| "no OAuth loopback listener is active".to_string())?;
-
-    tauri::async_runtime::spawn_blocking(move || {
-        let deadline = Instant::now() + LOOPBACK_TIMEOUT;
-        let expected_path = format!("/{nonce}");
-        loop {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                return Err("timed out waiting for the OAuth redirect".to_string());
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let server = {
+        let mut flow = state
+            .0
+            .lock()
+            .map_err(|_| "OAuth loopback state lock poisoned".to_string())?;
+        match flow.take() {
+            Some(LoopbackFlow::Ready { server, nonce }) if nonce == redirect_path => {
+                let server = Arc::new(server);
+                *flow = Some(LoopbackFlow::Waiting {
+                    server: Arc::clone(&server),
+                    nonce,
+                    cancelled: Arc::clone(&cancelled),
+                });
+                server
             }
-            let request = match server.recv_timeout(remaining) {
-                Ok(Some(request)) => request,
-                Ok(None) => continue,
-                Err(error) => return Err(format!("OAuth loopback listener error: {error}")),
-            };
-            if request.method() != &Method::Get {
-                let _ = request.respond(
-                    Response::from_string("Method not allowed").with_status_code(StatusCode(405)),
-                );
-                continue;
+            Some(other) => {
+                *flow = Some(other);
+                return Err("OAuth loopback listener does not match this flow".to_string());
             }
-            let target = request.url();
-            if target.len() > MAX_CALLBACK_URL_BYTES {
-                let _ = request.respond(
-                    Response::from_string("Request too large").with_status_code(StatusCode(414)),
-                );
-                continue;
-            }
-            let url = match Url::parse(&format!("http://127.0.0.1{target}")) {
-                Ok(url) if url.path() == expected_path && url.fragment().is_none() => url,
-                _ => {
-                    let _ = request.respond(
-                        Response::from_string("Not found").with_status_code(StatusCode(404)),
-                    );
-                    continue;
-                }
-            };
-            let parsed = match parse_callback(&url) {
-                Ok(parsed) => parsed,
-                Err(_) => {
-                    let _ = request.respond(html_response(INCOMPLETE_HTML));
-                    continue;
-                }
-            };
-            match parsed {
-                ParsedCallback::Code { code, state } if state == expected_state => {
-                    let _ = request.respond(html_response(SUCCESS_HTML));
-                    return Ok(OauthCapture { code, state });
-                }
-                ParsedCallback::Error { state } if state == expected_state => {
-                    let _ = request.respond(html_response(INCOMPLETE_HTML));
-                    return Err("Sign-in was cancelled.".to_string());
-                }
-                _ => {
-                    // A local process that did not know the backend-minted
-                    // state cannot consume the listener. Keep waiting.
-                    let _ = request.respond(html_response(INCOMPLETE_HTML));
-                }
-            }
+            None => return Err("no OAuth loopback listener is active".to_string()),
         }
+    };
+    let shared = Arc::clone(&state.0);
+    let completed_path = redirect_path.clone();
+    let joined = tauri::async_runtime::spawn_blocking(move || {
+        wait_for_loopback(
+            server.as_ref(),
+            &redirect_path,
+            &expected_state,
+            &cancelled,
+            LOOPBACK_TIMEOUT,
+        )
     })
-    .await
-    .map_err(|e| e.to_string())?
+    .await;
+
+    let mut flow = shared
+        .lock()
+        .map_err(|_| "OAuth loopback state lock poisoned".to_string())?;
+    if matches!(
+        flow.as_ref(),
+        Some(LoopbackFlow::Waiting { nonce, .. }) if nonce == &completed_path
+    ) {
+        flow.take();
+    }
+    joined.map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub fn oauth_loopback_cancel(state: State<'_, OauthLoopbackState>) -> Result<(), String> {
-    state
+pub fn oauth_loopback_cancel(
+    state: State<'_, OauthLoopbackState>,
+    redirect_path: String,
+) -> Result<(), String> {
+    let mut flow = state
         .0
         .lock()
-        .map_err(|_| "OAuth loopback state lock poisoned".to_string())?
-        .take();
+        .map_err(|_| "OAuth loopback state lock poisoned".to_string())?;
+    cancel_loopback(&mut flow, &redirect_path);
     Ok(())
 }
 
@@ -755,6 +851,62 @@ pub fn oauth_mobile_cancel<R: Runtime>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn in_flight_loopback_wait_stops_promptly_when_cancelled() {
+        let server = Arc::new(Server::http("127.0.0.1:0").unwrap());
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let worker_server = Arc::clone(&server);
+        let worker_cancelled = Arc::clone(&cancelled);
+        let mut flow = Some(LoopbackFlow::Waiting {
+            server,
+            nonce: "0123456789abcdef0123456789abcdef".to_string(),
+            cancelled,
+        });
+        let started = Instant::now();
+        let worker = std::thread::spawn(move || {
+            wait_for_loopback(
+                worker_server.as_ref(),
+                "0123456789abcdef0123456789abcdef",
+                "abcdefghijklmnopqrstuvwxyz012345",
+                &worker_cancelled,
+                Duration::from_secs(5),
+            )
+        });
+
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(cancel_loopback(
+            &mut flow,
+            "0123456789abcdef0123456789abcdef"
+        ));
+        let result = worker.join().unwrap();
+        assert!(matches!(result, Err(message) if message.contains("cancelled")));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn loopback_cancel_is_scoped_to_the_exact_flow() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let mut flow = Some(LoopbackFlow::Waiting {
+            server: Arc::new(Server::http("127.0.0.1:0").unwrap()),
+            nonce: "current-flow".to_string(),
+            cancelled: Arc::clone(&cancelled),
+        });
+
+        assert!(!cancel_loopback(&mut flow, "stale-flow"));
+        assert!(!cancelled.load(Ordering::Acquire));
+        assert!(cancel_loopback(&mut flow, "current-flow"));
+        assert!(cancelled.load(Ordering::Acquire));
+
+        let mut ready = Some(LoopbackFlow::Ready {
+            server: Server::http("127.0.0.1:0").unwrap(),
+            nonce: "new-flow".to_string(),
+        });
+        assert!(!cancel_loopback(&mut ready, "current-flow"));
+        assert!(matches!(ready, Some(LoopbackFlow::Ready { .. })));
+        assert!(cancel_loopback(&mut ready, "new-flow"));
+        assert!(ready.is_none());
+    }
 
     fn pending() -> PendingMobileOauth {
         PendingMobileOauth {

--- a/wallet/zuuli/src/App.tsx
+++ b/wallet/zuuli/src/App.tsx
@@ -19,7 +19,10 @@ import { auth, tuzi } from "@/lib/api/free2z";
 import { setToken } from "@/lib/api/http";
 import { APP_ROUTES } from "@/lib/routes";
 import { useAttemptLease } from "@/hooks/useAttemptLease";
-import { recoverMobileOAuth } from "@/lib/oauth/transport";
+import {
+  assertOAuthResultCurrent,
+  recoverMobileOAuth,
+} from "@/lib/oauth/transport";
 import {
   clearPendingSocialLoginDestination,
   consumePendingSocialLoginDestination,
@@ -86,6 +89,7 @@ function MobileOAuthRecovery() {
         if (!isCurrent() || !capture) return;
         const result = await auth.completeSocialOAuth(capture);
         if (!isCurrent()) return;
+        assertOAuthResultCurrent(result.sessionGeneration);
         if (result.status === "authenticated") {
           setToken(result.session.token);
           setUser(result.session.user);

--- a/wallet/zuuli/src/components/common/SocialButtons.tsx
+++ b/wallet/zuuli/src/components/common/SocialButtons.tsx
@@ -22,6 +22,7 @@ import { Loader2, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useSocialProviders } from "@/hooks/useSocialProviders";
 import { auth } from "@/lib/api/free2z";
+import { assertOAuthResultCurrent } from "@/lib/oauth/transport";
 import { setToken } from "@/lib/api/http";
 import { useSession } from "@/store/session";
 import { useAttemptLease } from "@/hooks/useAttemptLease";
@@ -135,6 +136,9 @@ export function SocialButtons({
     try {
       const result = await auth.socialLogin(provider, { associate });
       if (!isCurrent()) return;
+      // The API lease ends as its promise settles. Fence the following global
+      // publication synchronously in case another queued login changed token.
+      assertOAuthResultCurrent(result.sessionGeneration);
       const name = PROVIDER_NAME[provider];
       if (associate) {
         if (result.status !== "associated") throw new Error("Unexpected login result");

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -9,11 +9,11 @@ import { useMock } from "../platform";
 import { MOCK_OTP } from "../env";
 import { usdToTuzis } from "../format";
 import {
-  assertOAuthSession,
   cancelMobileOAuth,
   captureOAuthCode,
   finishMobileOAuth,
   oauthCallbackTransport,
+  withOAuthSession,
   type OAuthCapture,
 } from "../oauth/transport";
 import type { OAuthStartResponse } from "../oauth/protocol";
@@ -589,7 +589,7 @@ export const auth = {
     return { token, user: await auth.me(token) };
   },
 
-  async me(authToken?: string): Promise<AuthUser> {
+  async me(authToken?: string, signal?: AbortSignal): Promise<AuthUser> {
     if (useMock()) {
       await delay(120);
       return { ...mockUser };
@@ -606,7 +606,7 @@ export const auth = {
       tuzis?: string;
       avatar_image?: RawImage | null;
       banner_image?: RawImage | null;
-    }>("/api/auth/user/", { cache: "no-store", authToken });
+    }>("/api/auth/user/", { cache: "no-store", authToken, signal });
     return {
       username: u.username,
       email: u.email,
@@ -826,72 +826,81 @@ export const auth = {
    * callback through exactly the same backend path as the live button flow.
    */
   async completeSocialOAuth(capture: OAuthCapture): Promise<SocialAuthResult> {
-    const { provider, associate, code, state, redirectUri, codeVerifier } = capture;
-    const initiatingToken = await assertOAuthSession(capture);
-    const body = {
-      code,
-      state,
-      redirect_uri: redirectUri,
-      ...(codeVerifier ? { code_verifier: codeVerifier } : {}),
-    };
+    return withOAuthSession<SocialAuthResult>(capture, async (lease) => {
+      const { provider, associate, code, state, redirectUri, codeVerifier } = capture;
+      const body = {
+        code,
+        state,
+        redirect_uri: redirectUri,
+        ...(codeVerifier ? { code_verifier: codeVerifier } : {}),
+      };
 
-    if (associate) {
-      try {
-        // Deliberately NOT `anonymous: true` — the point is that the request
-        // carries `Authorization: Token <knox token>`.
-        await request<unknown>(`/api/auth/social/${provider}/`, {
-          method: "POST",
-          body,
-          // Pin the exchange to the token whose one-way binding was captured
-          // before provider navigation. Mutable global state is never read a
-          // second time between validation and this request.
-          authToken: initiatingToken ?? undefined,
-        });
-        // The backend mutation already succeeded. Local scratch-file cleanup
-        // must not turn a completed link into a user-visible auth failure.
-        await finishMobileOAuth(state).catch(() => undefined);
-      } catch (e) {
-        if (e instanceof ApiError && e.status >= 400 && e.status < 500) {
+      if (associate) {
+        try {
+          // Deliberately NOT `anonymous: true` — the request is pinned to the
+          // exact token whose one-way binding preceded provider navigation.
+          await request<unknown>(`/api/auth/social/${provider}/`, {
+            method: "POST",
+            body,
+            authToken: lease.initiatingToken ?? undefined,
+            signal: lease.signal,
+          });
+          lease.assertCurrent();
+          // The backend mutation already succeeded. Local scratch-file cleanup
+          // must not turn a completed link into a user-visible auth failure.
+          await finishMobileOAuth(state).catch(() => undefined);
+          lease.assertCurrent();
+        } catch (e) {
+          if (e instanceof ApiError && e.status >= 400 && e.status < 500) {
+            await cancelMobileOAuth(state).catch(() => undefined);
+          }
+          if (e instanceof ApiError && e.status === 409) {
+            throw new Error(
+              "That account is already linked — either to a different free2z account, or this account already has a linked identity for this provider. Unlink it there first, or use a different account.",
+            );
+          }
+          throw e;
+        }
+        const me = await auth.me(lease.initiatingToken ?? undefined, lease.signal);
+        lease.assertCurrent();
+        return {
+          status: "associated",
+          sessionGeneration: lease.sessionGeneration,
+          user: {
+            ...me,
+            social_identities: { ...me.social_identities, [provider]: true },
+          },
+        };
+      }
+
+      const tok = await request<{ token: string }>(`/api/auth/social/${provider}/`, {
+        method: "POST",
+        body,
+        anonymous: true,
+        signal: lease.signal,
+      }).catch(async (error) => {
+        if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
           await cancelMobileOAuth(state).catch(() => undefined);
         }
-        if (e instanceof ApiError && e.status === 409) {
-          throw new Error(
-            "That account is already linked — either to a different free2z account, or this account already has a linked identity for this provider. Unlink it there first, or use a different account.",
-          );
-        }
-        throw e;
-      }
-      const me = await auth.me();
+        throw error;
+      });
+      lease.assertCurrent();
+      await finishMobileOAuth(state).catch(() => undefined);
+      lease.assertCurrent();
+      const me = await auth.me(tok.token, lease.signal);
+      lease.assertCurrent();
       return {
-        status: "associated",
-        user: {
-          ...me,
-          social_identities: { ...me.social_identities, [provider]: true },
+        status: "authenticated",
+        sessionGeneration: lease.sessionGeneration,
+        session: {
+          token: tok.token,
+          user: {
+            ...me,
+            social_identities: { ...me.social_identities, [provider]: true },
+          },
         },
       };
-    }
-
-    const tok = await request<{ token: string }>(
-      `/api/auth/social/${provider}/`,
-      { method: "POST", body, anonymous: true },
-    ).catch(async (error) => {
-      if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
-        await cancelMobileOAuth(state).catch(() => undefined);
-      }
-      throw error;
     });
-    await finishMobileOAuth(state).catch(() => undefined);
-    const me = await auth.me(tok.token);
-    return {
-      status: "authenticated",
-      session: {
-        token: tok.token,
-        user: {
-          ...me,
-          social_identities: { ...me.social_identities, [provider]: true },
-        },
-      },
-    };
   },
 };
 

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -9,7 +9,7 @@ import { useMock } from "../platform";
 import { MOCK_OTP } from "../env";
 import { usdToTuzis } from "../format";
 import {
-  assertMobileOAuthSession,
+  assertOAuthSession,
   cancelMobileOAuth,
   captureOAuthCode,
   finishMobileOAuth,
@@ -17,7 +17,7 @@ import {
   type OAuthCapture,
 } from "../oauth/transport";
 import type { OAuthStartResponse } from "../oauth/protocol";
-import { ApiError, basicLogin, mediaUrl, request, setToken } from "./http";
+import { ApiError, basicLogin, getToken, mediaUrl, request, setToken } from "./http";
 import {
   DonationContractError,
   IDEMPOTENT_DONATION_ROUTE,
@@ -627,14 +627,22 @@ export const auth = {
   },
 
   async logout(): Promise<void> {
+    // Invalidate the renderer session synchronously so every outstanding OAuth
+    // transport aborts before the revocation request crosses the network.
+    // The request is pinned to the captured token and never re-reads global
+    // state after the account transition.
+    const token = getToken();
+    setToken(null);
     if (!useMock()) {
       try {
-        await request("/api/token/logout/", { method: "POST" });
+        await request("/api/token/logout/", {
+          method: "POST",
+          authToken: token ?? undefined,
+        });
       } catch {
         /* best-effort */
       }
     }
-    setToken(null);
   },
 
   /**
@@ -819,7 +827,7 @@ export const auth = {
    */
   async completeSocialOAuth(capture: OAuthCapture): Promise<SocialAuthResult> {
     const { provider, associate, code, state, redirectUri, codeVerifier } = capture;
-    await assertMobileOAuthSession(capture);
+    const initiatingToken = await assertOAuthSession(capture);
     const body = {
       code,
       state,
@@ -834,6 +842,10 @@ export const auth = {
         await request<unknown>(`/api/auth/social/${provider}/`, {
           method: "POST",
           body,
+          // Pin the exchange to the token whose one-way binding was captured
+          // before provider navigation. Mutable global state is never read a
+          // second time between validation and this request.
+          authToken: initiatingToken ?? undefined,
         });
         // The backend mutation already succeeded. Local scratch-file cleanup
         // must not turn a completed link into a user-visible auth failure.

--- a/wallet/zuuli/src/lib/api/http.test.ts
+++ b/wallet/zuuli/src/lib/api/http.test.ts
@@ -19,4 +19,18 @@ describe("process-local token transitions", () => {
     expect(observed).toEqual(["account-a", "account-b", null]);
     expect(getToken()).toBe("ignored-after-unsubscribe");
   });
+
+  it("isolates listeners so one failure cannot hide a transition", () => {
+    const observed: Array<string | null> = [];
+    const stopThrowing = onTokenChange(() => {
+      throw new Error("stale subscriber");
+    });
+    const stopObserving = onTokenChange((token) => observed.push(token));
+
+    expect(() => setToken("account-a")).not.toThrow();
+    expect(observed).toEqual(["account-a"]);
+
+    stopThrowing();
+    stopObserving();
+  });
 });

--- a/wallet/zuuli/src/lib/api/http.test.ts
+++ b/wallet/zuuli/src/lib/api/http.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getToken, onTokenChange, setToken } from "./http";
+
+afterEach(() => setToken(null));
+
+describe("process-local token transitions", () => {
+  it("notifies active flows exactly when the authenticated session changes", () => {
+    setToken(null);
+    const observed: Array<string | null> = [];
+    const stop = onTokenChange((token) => observed.push(token));
+
+    setToken("account-a");
+    setToken("account-a");
+    setToken("account-b");
+    setToken(null);
+    stop();
+    setToken("ignored-after-unsubscribe");
+
+    expect(observed).toEqual(["account-a", "account-b", null]);
+    expect(getToken()).toBe("ignored-after-unsubscribe");
+  });
+});

--- a/wallet/zuuli/src/lib/api/http.ts
+++ b/wallet/zuuli/src/lib/api/http.ts
@@ -16,6 +16,7 @@ import { isTauri } from "../platform";
 const TOKEN_KEY = "zuuli.knox.token";
 
 let inMemoryToken: string | null = null;
+const tokenListeners = new Set<(token: string | null) => void>();
 
 export function getToken(): string | null {
   if (inMemoryToken) return inMemoryToken;
@@ -28,6 +29,7 @@ export function getToken(): string | null {
 }
 
 export function setToken(token: string | null): void {
+  const previous = getToken();
   inMemoryToken = token;
   try {
     if (token) localStorage.setItem(TOKEN_KEY, token);
@@ -35,6 +37,17 @@ export function setToken(token: string | null): void {
   } catch {
     /* ignore */
   }
+  if (previous !== token) {
+    for (const listener of tokenListeners) listener(token);
+  }
+}
+
+/** Observe process-local account transitions without exposing the token to
+ * persistent browser state. OAuth transports use this to cancel a flow as
+ * soon as its initiating session changes. */
+export function onTokenChange(listener: (token: string | null) => void): () => void {
+  tokenListeners.add(listener);
+  return () => tokenListeners.delete(listener);
 }
 
 export function isAuthed(): boolean {

--- a/wallet/zuuli/src/lib/api/http.ts
+++ b/wallet/zuuli/src/lib/api/http.ts
@@ -16,7 +16,13 @@ import { isTauri } from "../platform";
 const TOKEN_KEY = "zuuli.knox.token";
 
 let inMemoryToken: string | null = null;
+let tokenGeneration = 0;
 const tokenListeners = new Set<(token: string | null) => void>();
+
+export interface TokenSnapshot {
+  token: string | null;
+  generation: number;
+}
 
 export function getToken(): string | null {
   if (inMemoryToken) return inMemoryToken;
@@ -26,6 +32,12 @@ export function getToken(): string | null {
     /* restricted context */
   }
   return inMemoryToken;
+}
+
+/** A process-local generation makes A -> B -> A observable even though the
+ * final token value matches. Security-sensitive async work must compare both. */
+export function getTokenSnapshot(): TokenSnapshot {
+  return { token: getToken(), generation: tokenGeneration };
 }
 
 export function setToken(token: string | null): void {
@@ -38,7 +50,16 @@ export function setToken(token: string | null): void {
     /* ignore */
   }
   if (previous !== token) {
-    for (const listener of tokenListeners) listener(token);
+    tokenGeneration += 1;
+    // A stale or faulty subscriber must never prevent the remaining security
+    // listeners from observing an account transition, nor break logout/login.
+    for (const listener of [...tokenListeners]) {
+      try {
+        listener(token);
+      } catch {
+        /* listeners are isolated; they must handle their own reporting */
+      }
+    }
   }
 }
 

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -114,8 +114,12 @@ export type SocialProvider = (typeof SOCIAL_PROVIDERS)[number];
 export type SocialProvidersStatus = Record<SocialProvider, boolean>;
 
 export type SocialAuthResult =
-  | { status: "authenticated"; session: AuthenticatedSession }
-  | { status: "associated"; user: AuthUser };
+  | {
+      status: "authenticated";
+      session: AuthenticatedSession;
+      sessionGeneration: number;
+    }
+  | { status: "associated"; user: AuthUser; sessionGeneration: number };
 
 /**
  * Editable fields for the signed-in user's own profile —

--- a/wallet/zuuli/src/lib/oauth/protocol.test.ts
+++ b/wallet/zuuli/src/lib/oauth/protocol.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { SocialProvider } from "../api/types";
 import {
   MOBILE_REDIRECT_URI,
+  assertSessionBinding,
   buildSessionBinding,
   canResumeMobileOAuth,
   generatePkcePair,
@@ -110,6 +111,31 @@ describe("buildSessionBinding", () => {
     expect(binding).toMatch(/^associate:[0-9a-f]{64}$/);
     expect(binding).not.toContain("secret-token");
     await expect(buildSessionBinding(true, null)).rejects.toThrow(/expired/);
+  });
+});
+
+describe("assertSessionBinding", () => {
+  it("returns only the exact initiating association token", async () => {
+    const binding = await buildSessionBinding(true, "account-a-token");
+    await expect(
+      assertSessionBinding(binding, true, "account-a-token"),
+    ).resolves.toBe("account-a-token");
+    await expect(
+      assertSessionBinding(binding, true, "account-b-token"),
+    ).rejects.toThrow(/session changed/);
+  });
+
+  it("fails closed across logout, relogin, and authenticated login transitions", async () => {
+    const association = await buildSessionBinding(true, "first-token");
+    await expect(assertSessionBinding(association, true, null)).rejects.toThrow();
+    await expect(
+      assertSessionBinding(association, true, "replacement-token"),
+    ).rejects.toThrow();
+
+    await expect(assertSessionBinding("login:none", false, null)).resolves.toBeNull();
+    await expect(
+      assertSessionBinding("login:none", false, "unexpected-session"),
+    ).rejects.toThrow();
   });
 });
 

--- a/wallet/zuuli/src/lib/oauth/protocol.ts
+++ b/wallet/zuuli/src/lib/oauth/protocol.ts
@@ -181,6 +181,25 @@ export async function buildSessionBinding(
   return `associate:${hex}`;
 }
 
+/** Recompute and compare the exact initiating session before OAuth exchange.
+ * Returns the verified token so callers can pin the authenticated request to
+ * it instead of consulting mutable global state a second time. */
+export async function assertSessionBinding(
+  expectedBinding: string,
+  associate: boolean,
+  token: string | null,
+): Promise<string | null> {
+  const currentBinding = await buildSessionBinding(associate, token);
+  if (currentBinding !== expectedBinding) {
+    throw new Error(
+      associate
+        ? "Your account session changed while linking this identity. Start again."
+        : "Your sign-in session changed while the provider was open. Start again.",
+    );
+  }
+  return associate ? token : null;
+}
+
 /** Whether the current auth mode can still complete the pending OAuth flow. */
 export function canResumeMobileOAuth(
   associate: boolean,

--- a/wallet/zuuli/src/lib/oauth/transport.test.ts
+++ b/wallet/zuuli/src/lib/oauth/transport.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isTauri: false,
+  invoke: vi.fn(),
+  getCurrent: vi.fn(),
+  onOpenUrl: vi.fn(),
+  openUrl: vi.fn(),
+}));
+
+vi.mock("../platform", () => ({
+  isTauri: () => mocks.isTauri,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@tauri-apps/plugin-deep-link", () => ({
+  getCurrent: mocks.getCurrent,
+  onOpenUrl: mocks.onOpenUrl,
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: mocks.openUrl,
+}));
+
+const STATE = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+const CHALLENGE = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+
+function startResponse(redirectUri: string) {
+  const url = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("state", STATE);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("code_challenge", CHALLENGE);
+  url.searchParams.set("code_challenge_method", "S256");
+  return { authorize_url: url.toString(), state: STATE };
+}
+
+function installBrowser(open: (url?: string | URL) => unknown = () => null) {
+  const storage = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  });
+  vi.stubGlobal("window", {
+    location: { origin: "https://app.example" },
+    open,
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    setInterval: globalThis.setInterval.bind(globalThis),
+    clearInterval: globalThis.clearInterval.bind(globalThis),
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  mocks.isTauri = false;
+  mocks.invoke.mockReset();
+  mocks.getCurrent.mockReset();
+  mocks.onOpenUrl.mockReset();
+  mocks.openUrl.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("OAuth session lifecycle", () => {
+  it("closes and rejects a web popup when the initiating token changes", async () => {
+    let opened!: () => void;
+    const didOpen = new Promise<void>((resolve) => {
+      opened = resolve;
+    });
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      get location(): Location {
+        throw new DOMException("cross origin");
+      },
+    };
+    installBrowser(() => {
+      opened();
+      return popup;
+    });
+    const [{ captureOAuthCode }, { setToken }] = await Promise.all([
+      import("./transport"),
+      import("../api/http"),
+    ]);
+    setToken(null);
+
+    const capture = captureOAuthCode("google", false, async (redirectUri) =>
+      startResponse(redirectUri),
+    );
+    await didOpen;
+    setToken("another-account");
+
+    await expect(capture).rejects.toThrow(/session changed/i);
+    expect(popup.close).toHaveBeenCalledOnce();
+  });
+
+  it("cancels persisted mobile recovery when its session changes", async () => {
+    installBrowser();
+    mocks.isTauri = true;
+    let listening!: () => void;
+    const didListen = new Promise<void>((resolve) => {
+      listening = resolve;
+    });
+    let installListener!: (stop: () => void) => void;
+    const listenerInstall = new Promise<() => void>((resolve) => {
+      installListener = resolve;
+    });
+    const stopListening = vi.fn();
+    mocks.onOpenUrl.mockImplementation(() => {
+      listening();
+      return listenerInstall;
+    });
+    mocks.getCurrent.mockResolvedValue(null);
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === "oauth_callback_transport") return "mobile";
+      if (command === "oauth_mobile_pending") {
+        return {
+          provider: "google",
+          associate: true,
+          phase: "armed",
+          state: STATE,
+        };
+      }
+      if (command === "oauth_mobile_resume") return { status: "ignored" };
+      if (command === "oauth_mobile_cancel") return undefined;
+      throw new Error(`unexpected command: ${command}`);
+    });
+    const [{ recoverMobileOAuth }, { setToken }] = await Promise.all([
+      import("./transport"),
+      import("../api/http"),
+    ]);
+    setToken("account-a");
+
+    const recovery = recoverMobileOAuth();
+    await didListen;
+    setToken("account-b");
+    installListener(stopListening);
+
+    await expect(recovery).resolves.toBeNull();
+    expect(stopListening).toHaveBeenCalledOnce();
+    expect(mocks.invoke).toHaveBeenCalledWith("oauth_mobile_cancel", {
+      args: { state: STATE },
+    });
+  });
+
+  it("rejects a token change while completion is awaiting backend work", async () => {
+    installBrowser();
+    const [{ withOAuthSession }, { buildSessionBinding }, http] = await Promise.all([
+      import("./transport"),
+      import("./protocol"),
+      import("../api/http"),
+    ]);
+    http.setToken("account-a");
+    const snapshot = http.getTokenSnapshot();
+    const capture = {
+      provider: "google" as const,
+      associate: true,
+      code: "provider-code",
+      state: STATE,
+      redirectUri: "https://app.example",
+      sessionBinding: await buildSessionBinding(true, snapshot.token),
+      sessionGeneration: snapshot.generation,
+      transport: "web" as const,
+    };
+    let finishWork!: () => void;
+    const backendWork = new Promise<void>((resolve) => {
+      finishWork = resolve;
+    });
+    const completion = withOAuthSession(capture, async () => {
+      await backendWork;
+      return "should-not-publish";
+    });
+
+    http.setToken("account-b");
+    finishWork();
+
+    await expect(completion).rejects.toThrow(/session changed/i);
+  });
+
+  it("rejects logout/relogin to the same token before completion", async () => {
+    installBrowser();
+    const [{ withOAuthSession }, { buildSessionBinding }, http] = await Promise.all([
+      import("./transport"),
+      import("./protocol"),
+      import("../api/http"),
+    ]);
+    http.setToken("account-a");
+    const snapshot = http.getTokenSnapshot();
+    const capture = {
+      provider: "google" as const,
+      associate: true,
+      code: "provider-code",
+      state: STATE,
+      redirectUri: "https://app.example",
+      sessionBinding: await buildSessionBinding(true, snapshot.token),
+      sessionGeneration: snapshot.generation,
+      transport: "web" as const,
+    };
+    http.setToken(null);
+    http.setToken("account-a");
+    const exchange = vi.fn(async () => "must-not-run");
+
+    await expect(withOAuthSession(capture, exchange)).rejects.toThrow(/session changed/i);
+    expect(exchange).not.toHaveBeenCalled();
+  });
+});

--- a/wallet/zuuli/src/lib/oauth/transport.ts
+++ b/wallet/zuuli/src/lib/oauth/transport.ts
@@ -2,11 +2,12 @@
 // loopback; iOS/Android use the canonical private-use callback registered by
 // tauri-plugin-deep-link; plain web uses a same-origin popup.
 
-import { getToken } from "../api/http";
+import { getToken, onTokenChange } from "../api/http";
 import type { SocialProvider } from "../api/types";
 import { isTauri } from "../platform";
 import {
   MOBILE_REDIRECT_URI,
+  assertSessionBinding,
   buildSessionBinding,
   canResumeMobileOAuth,
   generatePkcePair,
@@ -21,6 +22,9 @@ export interface OAuthCapture {
   state: string;
   redirectUri: string;
   codeVerifier?: string;
+  /** One-way binding to the exact session present before provider navigation. */
+  sessionBinding: string;
+  transport: OAuthCallbackTransport;
 }
 
 interface LoopbackStart {
@@ -40,9 +44,11 @@ interface MobilePendingSummary {
   state: string;
 }
 
+type NativeOAuthCapture = Omit<OAuthCapture, "sessionBinding" | "transport">;
+
 type MobileClaimResult =
   | { status: "ignored" }
-  | { status: "captured"; capture: OAuthCapture }
+  | { status: "captured"; capture: NativeOAuthCapture }
   | { status: "rejected" | "cancelled"; message: string };
 
 async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
@@ -53,6 +59,26 @@ async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T
 const POPUP_POLL_MS = 350;
 const OAUTH_TIMEOUT_MS = 10 * 60 * 1_000;
 const POPUP_FEATURES = "width=480,height=680,noopener=no,noreferrer=no";
+
+const SESSION_CHANGED = "Your account session changed while the provider was open. Start again.";
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(new Error(SESSION_CHANGED));
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => reject(new Error(SESSION_CHANGED));
+    signal.addEventListener("abort", abort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
+}
 
 let transportKind: Promise<"desktop" | "mobile"> | null = null;
 async function nativeTransport(): Promise<"desktop" | "mobile"> {
@@ -89,19 +115,33 @@ export async function isMobileTauri(): Promise<boolean> {
 async function runDesktopLoopback(
   provider: SocialProvider,
   associate: boolean,
+  sessionBinding: string,
+  signal: AbortSignal,
   buildStart: (redirectUri: string) => Promise<OAuthStartResponse>,
 ): Promise<OAuthCapture> {
-  const loopback = await invoke<LoopbackStart>("oauth_loopback_start");
-  const redirectUri = `http://127.0.0.1:${loopback.port}/${loopback.redirectPath}`;
   try {
-    const start = await buildStart(redirectUri);
+    const loopback = await abortable(
+      invoke<LoopbackStart>("oauth_loopback_start"),
+      signal,
+    );
+    const redirectUri = `http://127.0.0.1:${loopback.port}/${loopback.redirectPath}`;
+    const start = await abortable(buildStart(redirectUri), signal);
     const authorizeUrl = validateAuthorizationStart(provider, start, redirectUri, false);
     const { openUrl } = await import("@tauri-apps/plugin-opener");
-    await openUrl(authorizeUrl);
-    const result = await invoke<LoopbackResult>("oauth_loopback_wait", {
-      expectedState: start.state,
-    });
-    return { provider, associate, code: result.code, state: result.state, redirectUri };
+    await abortable(openUrl(authorizeUrl), signal);
+    const result = await abortable(
+      invoke<LoopbackResult>("oauth_loopback_wait", { expectedState: start.state }),
+      signal,
+    );
+    return {
+      provider,
+      associate,
+      code: result.code,
+      state: result.state,
+      redirectUri,
+      sessionBinding,
+      transport: "desktop",
+    };
   } catch (error) {
     await invoke<void>("oauth_loopback_cancel").catch(() => undefined);
     throw error;
@@ -110,7 +150,7 @@ async function runDesktopLoopback(
 
 function settleMobileResult(
   result: MobileClaimResult,
-  resolve: (capture: OAuthCapture) => void,
+  resolve: (capture: NativeOAuthCapture) => void,
   reject: (error: Error) => void,
 ): boolean {
   if (result.status === "captured") {
@@ -128,14 +168,14 @@ async function waitForMobileCallback(
   associate: boolean,
   expectedState: string,
   signal?: AbortSignal,
-): Promise<OAuthCapture> {
+): Promise<NativeOAuthCapture> {
   const { getCurrent, onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
   let finished = false;
   let unlisten: (() => void) | undefined;
   let timer: number | undefined;
 
-  const promise = new Promise<OAuthCapture>((resolve, reject) => {
-    const finishResolve = (capture: OAuthCapture) => {
+  const promise = new Promise<NativeOAuthCapture>((resolve, reject) => {
+    const finishResolve = (capture: NativeOAuthCapture) => {
       if (finished) return;
       finished = true;
       if (timer !== undefined) window.clearTimeout(timer);
@@ -203,14 +243,18 @@ async function waitForMobileCallback(
 async function runMobileDeepLink(
   provider: SocialProvider,
   associate: boolean,
+  sessionBinding: string,
+  outerSignal: AbortSignal,
   buildStart: (
     redirectUri: string,
     codeChallenge?: string,
   ) => Promise<OAuthStartResponse>,
 ): Promise<OAuthCapture> {
-  const sessionBinding = await buildSessionBinding(associate, getToken());
-  const pkce = await generatePkcePair();
-  const start = await buildStart(MOBILE_REDIRECT_URI, pkce.challenge);
+  const pkce = await abortable(generatePkcePair(), outerSignal);
+  const start = await abortable(
+    buildStart(MOBILE_REDIRECT_URI, pkce.challenge),
+    outerSignal,
+  );
   const authorizeUrl = validateAuthorizationStart(
     provider,
     start,
@@ -218,26 +262,36 @@ async function runMobileDeepLink(
     true,
     pkce.challenge,
   );
-  await invoke<void>("oauth_mobile_arm", {
-    args: {
-      provider,
-      state: start.state,
-      associate,
-      sessionBinding,
-      codeVerifier: pkce.verifier,
-    },
-  });
+  await abortable(
+    invoke<void>("oauth_mobile_arm", {
+      args: {
+        provider,
+        state: start.state,
+        associate,
+        sessionBinding,
+        codeVerifier: pkce.verifier,
+      },
+    }),
+    outerSignal,
+  );
   recoveryController?.abort();
   recoveryController = null;
   const controller = new AbortController();
+  const abortFromSessionChange = () => controller.abort();
+  outerSignal.addEventListener("abort", abortFromSessionChange, { once: true });
+  if (outerSignal.aborted) controller.abort();
   const callback = waitForMobileCallback(associate, start.state, controller.signal);
   // Observe listener/setup failures immediately; the original promise is
   // still awaited below so the caller receives the same rejection.
   void callback.catch(() => undefined);
   try {
     const { openUrl } = await import("@tauri-apps/plugin-opener");
-    await openUrl(authorizeUrl);
-    return await callback;
+    await abortable(openUrl(authorizeUrl), outerSignal);
+    return {
+      ...(await callback),
+      sessionBinding,
+      transport: "mobile",
+    };
   } catch (error) {
     controller.abort();
     await invoke<void>("oauth_mobile_cancel", {
@@ -245,6 +299,8 @@ async function runMobileDeepLink(
     }).catch(() => undefined);
     await callback.catch(() => undefined);
     throw error;
+  } finally {
+    outerSignal.removeEventListener("abort", abortFromSessionChange);
   }
 }
 
@@ -253,6 +309,8 @@ function runWebPopup(
   associate: boolean,
   start: OAuthStartResponse,
   redirectUri: string,
+  sessionBinding: string,
+  signal: AbortSignal,
 ): Promise<OAuthCapture> {
   const authorizeUrl = validateAuthorizationStart(provider, start, redirectUri, false);
   return new Promise((resolve, reject) => {
@@ -262,17 +320,20 @@ function runWebPopup(
       return;
     }
     const expected = new URL(redirectUri);
-    const deadline = window.setTimeout(() => {
-      window.clearInterval(poll);
+    let deadline: number | undefined;
+    let poll: number | undefined;
+    let abort = () => undefined;
+    const finish = () => {
+      if (deadline !== undefined) window.clearTimeout(deadline);
+      if (poll !== undefined) window.clearInterval(poll);
       popup.close();
+      signal.removeEventListener("abort", abort);
+    };
+    deadline = window.setTimeout(() => {
+      finish();
       reject(new Error("Timed out waiting for the OAuth redirect."));
     }, OAUTH_TIMEOUT_MS);
-    const finish = () => {
-      window.clearTimeout(deadline);
-      window.clearInterval(poll);
-      popup.close();
-    };
-    const poll = window.setInterval(() => {
+    poll = window.setInterval(() => {
       if (popup.closed) {
         finish();
         reject(new Error("Sign-in was cancelled."));
@@ -301,7 +362,15 @@ function runWebPopup(
         reject(new Error("The provider callback did not match this sign-in attempt."));
       } else if (codes.length === 1 && errors.length === 0 && codes[0]) {
         finish();
-        resolve({ provider, associate, code: codes[0], state: states[0], redirectUri });
+        resolve({
+          provider,
+          associate,
+          code: codes[0],
+          state: states[0],
+          redirectUri,
+          sessionBinding,
+          transport: "web",
+        });
       } else if (errors.length === 1 && codes.length === 0) {
         finish();
         reject(new Error("Sign-in was cancelled."));
@@ -310,6 +379,12 @@ function runWebPopup(
         reject(new Error("The provider callback was malformed."));
       }
     }, POPUP_POLL_MS);
+    abort = () => {
+      finish();
+      reject(new Error(SESSION_CHANGED));
+    };
+    if (signal.aborted) abort();
+    else signal.addEventListener("abort", abort, { once: true });
   });
 }
 
@@ -321,15 +396,44 @@ export async function captureOAuthCode(
     codeChallenge?: string,
   ) => Promise<OAuthStartResponse>,
 ): Promise<OAuthCapture> {
-  const transport = await oauthCallbackTransport();
-  if (transport !== "web") {
-    return transport === "mobile"
-      ? runMobileDeepLink(provider, associate, buildStart)
-      : runDesktopLoopback(provider, associate, buildStart);
+  const initiatingToken = getToken();
+  const sessionBinding = await buildSessionBinding(associate, initiatingToken);
+  const controller = new AbortController();
+  const stopWatching = onTokenChange((token) => {
+    if (token !== initiatingToken) controller.abort();
+  });
+  try {
+    const transport = await abortable(oauthCallbackTransport(), controller.signal);
+    if (transport !== "web") {
+      return transport === "mobile"
+        ? runMobileDeepLink(
+            provider,
+            associate,
+            sessionBinding,
+            controller.signal,
+            buildStart,
+          )
+        : runDesktopLoopback(
+            provider,
+            associate,
+            sessionBinding,
+            controller.signal,
+            buildStart,
+          );
+    }
+    const redirectUri = window.location.origin;
+    const start = await abortable(buildStart(redirectUri), controller.signal);
+    return runWebPopup(
+      provider,
+      associate,
+      start,
+      redirectUri,
+      sessionBinding,
+      controller.signal,
+    );
+  } finally {
+    stopWatching();
   }
-  const redirectUri = window.location.origin;
-  const start = await buildStart(redirectUri);
-  return runWebPopup(provider, associate, start, redirectUri);
 }
 
 let recovery: Promise<OAuthCapture | null> | null = null;
@@ -361,20 +465,27 @@ export function recoverMobileOAuth(): Promise<OAuthCapture | null> {
       // the waiter also closes the cold-start race.
       const controller = new AbortController();
       recoveryController = controller;
+      const stopWatching = onTokenChange((current) => {
+        if (current !== token) controller.abort();
+      });
       try {
-        return await waitForMobileCallback(
+        const capture = await waitForMobileCallback(
           pending.associate,
           pending.state,
           controller.signal,
         );
+        return { ...capture, sessionBinding, transport: "mobile" };
       } catch (error) {
         if (controller.signal.aborted) return null;
         throw error;
       } finally {
+        stopWatching();
         if (recoveryController === controller) recoveryController = null;
       }
     }
-    if (result.status === "captured") return result.capture;
+    if (result.status === "captured") {
+      return { ...result.capture, sessionBinding, transport: "mobile" };
+    }
     if (result.status === "rejected" || result.status === "cancelled") {
       throw new Error(result.message);
     }
@@ -388,12 +499,31 @@ export async function finishMobileOAuth(state: string): Promise<void> {
   await invoke<void>("oauth_mobile_finish", { args: { state } });
 }
 
-/** Revalidate the initiating session immediately before backend exchange. */
-export async function assertMobileOAuthSession(capture: OAuthCapture): Promise<void> {
-  if (!isTauri() || (await nativeTransport()) !== "mobile") return;
-  const sessionBinding = await buildSessionBinding(capture.associate, getToken());
+/** Revalidate every transport's initiating session immediately before backend
+ * exchange and return the exact token that passed the binding check. */
+export async function assertOAuthSession(
+  capture: OAuthCapture,
+): Promise<string | null> {
+  const token = getToken();
+  let verifiedToken: string | null;
+  try {
+    verifiedToken = await assertSessionBinding(
+      capture.sessionBinding,
+      capture.associate,
+      token,
+    );
+  } catch (error) {
+    if (capture.transport === "mobile") {
+      await invoke<void>("oauth_mobile_cancel", {
+        args: { state: capture.state },
+      }).catch(() => undefined);
+    }
+    throw error;
+  }
+  if (capture.transport !== "mobile") return verifiedToken;
+
   const result = await invoke<MobileClaimResult>("oauth_mobile_resume", {
-    args: { sessionBinding, expectedState: capture.state },
+    args: { sessionBinding: capture.sessionBinding, expectedState: capture.state },
   });
   if (
     result.status !== "captured" ||
@@ -410,6 +540,7 @@ export async function assertMobileOAuthSession(capture: OAuthCapture): Promise<v
         : "The mobile sign-in session no longer matches this callback.",
     );
   }
+  return verifiedToken;
 }
 
 export async function cancelMobileOAuth(state: string): Promise<void> {

--- a/wallet/zuuli/src/lib/oauth/transport.ts
+++ b/wallet/zuuli/src/lib/oauth/transport.ts
@@ -2,7 +2,12 @@
 // loopback; iOS/Android use the canonical private-use callback registered by
 // tauri-plugin-deep-link; plain web uses a same-origin popup.
 
-import { getToken, onTokenChange } from "../api/http";
+import {
+  getToken,
+  getTokenSnapshot,
+  onTokenChange,
+  type TokenSnapshot,
+} from "../api/http";
 import type { SocialProvider } from "../api/types";
 import { isTauri } from "../platform";
 import {
@@ -24,6 +29,8 @@ export interface OAuthCapture {
   codeVerifier?: string;
   /** One-way binding to the exact session present before provider navigation. */
   sessionBinding: string;
+  /** Detects token changes even when a later token has the same value. */
+  sessionGeneration: number;
   transport: OAuthCallbackTransport;
 }
 
@@ -44,7 +51,10 @@ interface MobilePendingSummary {
   state: string;
 }
 
-type NativeOAuthCapture = Omit<OAuthCapture, "sessionBinding" | "transport">;
+type NativeOAuthCapture = Omit<
+  OAuthCapture,
+  "sessionBinding" | "sessionGeneration" | "transport"
+>;
 
 type MobileClaimResult =
   | { status: "ignored" }
@@ -78,6 +88,61 @@ function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
       },
     );
   });
+}
+
+interface OAuthSessionLease {
+  initiatingToken: string | null;
+  generation: number;
+  signal: AbortSignal;
+  assertCurrent: () => void;
+  stop: () => void;
+}
+
+export interface OAuthCompletionLease {
+  initiatingToken: string | null;
+  sessionGeneration: number;
+  signal: AbortSignal;
+  assertCurrent: () => void;
+}
+
+function sessionChanged(): Error {
+  return new Error(SESSION_CHANGED);
+}
+
+function tokenSnapshotIsCurrent(snapshot: TokenSnapshot): boolean {
+  const current = getTokenSnapshot();
+  return current.generation === snapshot.generation && current.token === snapshot.token;
+}
+
+function watchTokenSnapshot(snapshot: TokenSnapshot): OAuthSessionLease {
+  const controller = new AbortController();
+  const stop = onTokenChange(() => controller.abort());
+  const assertCurrent = () => {
+    if (controller.signal.aborted || !tokenSnapshotIsCurrent(snapshot)) {
+      controller.abort();
+      throw sessionChanged();
+    }
+  };
+  // Close the snapshot -> listener-registration edge before the first await.
+  try {
+    assertCurrent();
+  } catch (error) {
+    stop();
+    throw error;
+  }
+  return {
+    initiatingToken: snapshot.token,
+    generation: snapshot.generation,
+    signal: controller.signal,
+    assertCurrent,
+    stop,
+  };
+}
+
+/** Last synchronous fence used by UI callers immediately before publishing an
+ * OAuth result into global session/user state. */
+export function assertOAuthResultCurrent(sessionGeneration: number): void {
+  if (getTokenSnapshot().generation !== sessionGeneration) throw sessionChanged();
 }
 
 let transportKind: Promise<"desktop" | "mobile"> | null = null;
@@ -116,23 +181,32 @@ async function runDesktopLoopback(
   provider: SocialProvider,
   associate: boolean,
   sessionBinding: string,
+  sessionGeneration: number,
   signal: AbortSignal,
   buildStart: (redirectUri: string) => Promise<OAuthStartResponse>,
 ): Promise<OAuthCapture> {
+  let redirectPath: string | undefined;
   try {
-    const loopback = await abortable(
-      invoke<LoopbackStart>("oauth_loopback_start"),
-      signal,
-    );
+    // The native start is local and fast. Await it directly so that, if abort
+    // races its resolution, we still retain the flow id needed to cancel it.
+    const loopback = await invoke<LoopbackStart>("oauth_loopback_start");
+    redirectPath = loopback.redirectPath;
+    if (signal.aborted) throw sessionChanged();
     const redirectUri = `http://127.0.0.1:${loopback.port}/${loopback.redirectPath}`;
     const start = await abortable(buildStart(redirectUri), signal);
     const authorizeUrl = validateAuthorizationStart(provider, start, redirectUri, false);
     const { openUrl } = await import("@tauri-apps/plugin-opener");
+    if (signal.aborted) throw sessionChanged();
     await abortable(openUrl(authorizeUrl), signal);
+    if (signal.aborted) throw sessionChanged();
     const result = await abortable(
-      invoke<LoopbackResult>("oauth_loopback_wait", { expectedState: start.state }),
+      invoke<LoopbackResult>("oauth_loopback_wait", {
+        expectedState: start.state,
+        redirectPath: loopback.redirectPath,
+      }),
       signal,
     );
+    if (signal.aborted) throw sessionChanged();
     return {
       provider,
       associate,
@@ -140,10 +214,13 @@ async function runDesktopLoopback(
       state: result.state,
       redirectUri,
       sessionBinding,
+      sessionGeneration,
       transport: "desktop",
     };
   } catch (error) {
-    await invoke<void>("oauth_loopback_cancel").catch(() => undefined);
+    if (redirectPath) {
+      await invoke<void>("oauth_loopback_cancel", { redirectPath }).catch(() => undefined);
+    }
     throw error;
   }
 }
@@ -205,6 +282,7 @@ async function waitForMobileCallback(
           // start would let a sign-out/account switch while Safari/Chrome is
           // open associate the returning identity with the wrong account.
           const currentBinding = await buildSessionBinding(associate, getToken());
+          if (finished) return;
           const result = await invoke<MobileClaimResult>("oauth_mobile_claim", {
             args: { callbackUrl, sessionBinding: currentBinding, expectedState },
           });
@@ -221,6 +299,10 @@ async function waitForMobileCallback(
 
     void onOpenUrl((urls) => void processUrls(urls))
       .then((stop) => {
+        if (finished) {
+          stop();
+          return null;
+        }
         unlisten = stop;
         return getCurrent();
       })
@@ -244,6 +326,7 @@ async function runMobileDeepLink(
   provider: SocialProvider,
   associate: boolean,
   sessionBinding: string,
+  sessionGeneration: number,
   outerSignal: AbortSignal,
   buildStart: (
     redirectUri: string,
@@ -262,18 +345,24 @@ async function runMobileDeepLink(
     true,
     pkce.challenge,
   );
-  await abortable(
-    invoke<void>("oauth_mobile_arm", {
-      args: {
-        provider,
-        state: start.state,
-        associate,
-        sessionBinding,
-        codeVerifier: pkce.verifier,
-      },
-    }),
-    outerSignal,
-  );
+  if (outerSignal.aborted) throw sessionChanged();
+  // Await the local arm command directly: if cancellation races the command,
+  // we must know that the persisted record exists before returning/rejecting.
+  await invoke<void>("oauth_mobile_arm", {
+    args: {
+      provider,
+      state: start.state,
+      associate,
+      sessionBinding,
+      codeVerifier: pkce.verifier,
+    },
+  });
+  if (outerSignal.aborted) {
+    await invoke<void>("oauth_mobile_cancel", {
+      args: { state: start.state },
+    }).catch(() => undefined);
+    throw sessionChanged();
+  }
   recoveryController?.abort();
   recoveryController = null;
   const controller = new AbortController();
@@ -286,10 +375,13 @@ async function runMobileDeepLink(
   void callback.catch(() => undefined);
   try {
     const { openUrl } = await import("@tauri-apps/plugin-opener");
+    if (outerSignal.aborted) throw sessionChanged();
     await abortable(openUrl(authorizeUrl), outerSignal);
+    if (outerSignal.aborted) throw sessionChanged();
     return {
       ...(await callback),
       sessionBinding,
+      sessionGeneration,
       transport: "mobile",
     };
   } catch (error) {
@@ -310,6 +402,7 @@ function runWebPopup(
   start: OAuthStartResponse,
   redirectUri: string,
   sessionBinding: string,
+  sessionGeneration: number,
   signal: AbortSignal,
 ): Promise<OAuthCapture> {
   const authorizeUrl = validateAuthorizationStart(provider, start, redirectUri, false);
@@ -369,6 +462,7 @@ function runWebPopup(
           state: states[0],
           redirectUri,
           sessionBinding,
+          sessionGeneration,
           transport: "web",
         });
       } else if (errors.length === 1 && codes.length === 0) {
@@ -396,43 +490,50 @@ export async function captureOAuthCode(
     codeChallenge?: string,
   ) => Promise<OAuthStartResponse>,
 ): Promise<OAuthCapture> {
-  const initiatingToken = getToken();
-  const sessionBinding = await buildSessionBinding(associate, initiatingToken);
-  const controller = new AbortController();
-  const stopWatching = onTokenChange((token) => {
-    if (token !== initiatingToken) controller.abort();
-  });
+  const lease = watchTokenSnapshot(getTokenSnapshot());
   try {
-    const transport = await abortable(oauthCallbackTransport(), controller.signal);
+    const sessionBinding = await abortable(
+      buildSessionBinding(associate, lease.initiatingToken),
+      lease.signal,
+    );
+    lease.assertCurrent();
+    const transport = await abortable(oauthCallbackTransport(), lease.signal);
+    lease.assertCurrent();
     if (transport !== "web") {
-      return transport === "mobile"
+      // `return await` is intentional: a bare returned promise executes this
+      // function's finally immediately and silently removes the session watch.
+      return await (transport === "mobile"
         ? runMobileDeepLink(
             provider,
             associate,
             sessionBinding,
-            controller.signal,
+            lease.generation,
+            lease.signal,
             buildStart,
           )
         : runDesktopLoopback(
             provider,
             associate,
             sessionBinding,
-            controller.signal,
+            lease.generation,
+            lease.signal,
             buildStart,
-          );
+          ));
     }
     const redirectUri = window.location.origin;
-    const start = await abortable(buildStart(redirectUri), controller.signal);
-    return runWebPopup(
+    const start = await abortable(buildStart(redirectUri), lease.signal);
+    lease.assertCurrent();
+    return await runWebPopup(
       provider,
       associate,
       start,
       redirectUri,
       sessionBinding,
-      controller.signal,
+      lease.generation,
+      lease.signal,
     );
   } finally {
-    stopWatching();
+    lease.stop();
   }
 }
 
@@ -445,7 +546,8 @@ export function recoverMobileOAuth(): Promise<OAuthCapture | null> {
     if (!isTauri() || (await nativeTransport()) !== "mobile") return null;
     const pending = await invoke<MobilePendingSummary | null>("oauth_mobile_pending");
     if (!pending) return null;
-    const token = getToken();
+    const snapshot = getTokenSnapshot();
+    const token = snapshot.token;
     if (!canResumeMobileOAuth(pending.associate, token)) {
       // Session bootstrap may have signed in, signed out, or invalidated a
       // token while the app was away. Consume the now-impossible flow instead
@@ -456,26 +558,45 @@ export function recoverMobileOAuth(): Promise<OAuthCapture | null> {
       return null;
     }
     const sessionBinding = await buildSessionBinding(pending.associate, token);
+    if (!tokenSnapshotIsCurrent(snapshot)) {
+      await invoke<void>("oauth_mobile_cancel", {
+        args: { state: pending.state },
+      }).catch(() => undefined);
+      return null;
+    }
     const result = await invoke<MobileClaimResult>("oauth_mobile_resume", {
       args: { sessionBinding, expectedState: pending.state },
     });
+    if (!tokenSnapshotIsCurrent(snapshot)) {
+      await invoke<void>("oauth_mobile_cancel", {
+        args: { state: pending.state },
+      }).catch(() => undefined);
+      return null;
+    }
     if (result.status === "ignored" && pending.phase === "armed") {
       // The app may have been reopened manually while the system browser is
       // still active. Keep a warm-start listener alive; getCurrent() inside
       // the waiter also closes the cold-start race.
       const controller = new AbortController();
       recoveryController = controller;
-      const stopWatching = onTokenChange((current) => {
-        if (current !== token) controller.abort();
-      });
+      const stopWatching = onTokenChange(() => controller.abort());
+      if (!tokenSnapshotIsCurrent(snapshot)) controller.abort();
       try {
         const capture = await waitForMobileCallback(
           pending.associate,
           pending.state,
           controller.signal,
         );
-        return { ...capture, sessionBinding, transport: "mobile" };
+        return {
+          ...capture,
+          sessionBinding,
+          sessionGeneration: snapshot.generation,
+          transport: "mobile",
+        };
       } catch (error) {
+        await invoke<void>("oauth_mobile_cancel", {
+          args: { state: pending.state },
+        }).catch(() => undefined);
         if (controller.signal.aborted) return null;
         throw error;
       } finally {
@@ -484,7 +605,12 @@ export function recoverMobileOAuth(): Promise<OAuthCapture | null> {
       }
     }
     if (result.status === "captured") {
-      return { ...result.capture, sessionBinding, transport: "mobile" };
+      return {
+        ...result.capture,
+        sessionBinding,
+        sessionGeneration: snapshot.generation,
+        transport: "mobile",
+      };
     }
     if (result.status === "rejected" || result.status === "cancelled") {
       throw new Error(result.message);
@@ -499,48 +625,67 @@ export async function finishMobileOAuth(state: string): Promise<void> {
   await invoke<void>("oauth_mobile_finish", { args: { state } });
 }
 
-/** Revalidate every transport's initiating session immediately before backend
- * exchange and return the exact token that passed the binding check. */
-export async function assertOAuthSession(
+/** Hold the initiating session across native claim, backend exchange, profile
+ * read, and the final post-await generation check. */
+export async function withOAuthSession<T>(
   capture: OAuthCapture,
-): Promise<string | null> {
-  const token = getToken();
-  let verifiedToken: string | null;
+  complete: (lease: OAuthCompletionLease) => Promise<T>,
+): Promise<T> {
+  const snapshot = getTokenSnapshot();
+  if (snapshot.generation !== capture.sessionGeneration) throw sessionChanged();
+  const lease = watchTokenSnapshot(snapshot);
   try {
-    verifiedToken = await assertSessionBinding(
-      capture.sessionBinding,
-      capture.associate,
-      token,
+    const verifiedToken = await abortable(
+      assertSessionBinding(
+        capture.sessionBinding,
+        capture.associate,
+        lease.initiatingToken,
+      ),
+      lease.signal,
     );
+    lease.assertCurrent();
+
+    if (capture.transport === "mobile") {
+      const result = await abortable(
+        invoke<MobileClaimResult>("oauth_mobile_resume", {
+          args: { sessionBinding: capture.sessionBinding, expectedState: capture.state },
+        }),
+        lease.signal,
+      );
+      lease.assertCurrent();
+      if (
+        result.status !== "captured" ||
+        result.capture.state !== capture.state ||
+        result.capture.provider !== capture.provider ||
+        result.capture.associate !== capture.associate
+      ) {
+        throw new Error(
+          result.status === "rejected" || result.status === "cancelled"
+            ? result.message
+            : "The mobile sign-in session no longer matches this callback.",
+        );
+      }
+    }
+
+    const completed = await complete({
+      initiatingToken: verifiedToken,
+      sessionGeneration: lease.generation,
+      signal: lease.signal,
+      assertCurrent: lease.assertCurrent,
+    });
+    lease.assertCurrent();
+    return completed;
   } catch (error) {
     if (capture.transport === "mobile") {
       await invoke<void>("oauth_mobile_cancel", {
         args: { state: capture.state },
       }).catch(() => undefined);
     }
+    if (lease.signal.aborted) throw sessionChanged();
     throw error;
+  } finally {
+    lease.stop();
   }
-  if (capture.transport !== "mobile") return verifiedToken;
-
-  const result = await invoke<MobileClaimResult>("oauth_mobile_resume", {
-    args: { sessionBinding: capture.sessionBinding, expectedState: capture.state },
-  });
-  if (
-    result.status !== "captured" ||
-    result.capture.state !== capture.state ||
-    result.capture.provider !== capture.provider ||
-    result.capture.associate !== capture.associate
-  ) {
-    await invoke<void>("oauth_mobile_cancel", {
-      args: { state: capture.state },
-    }).catch(() => undefined);
-    throw new Error(
-      result.status === "rejected" || result.status === "cancelled"
-        ? result.message
-        : "The mobile sign-in session no longer matches this callback.",
-    );
-  }
-  return verifiedToken;
 }
 
 export async function cancelMobileOAuth(state: string): Promise<void> {

--- a/wallet/zuuli/src/store/session-balance.test.ts
+++ b/wallet/zuuli/src/store/session-balance.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { auth } from "@/lib/api/free2z";
 import type { AuthUser } from "@/lib/api/types";
 import { useSession } from "./session";
 
@@ -9,6 +10,7 @@ const user: AuthUser = {
 };
 
 afterEach(() => {
+  vi.restoreAllMocks();
   useSession.setState({ user: null, tuzis: 0, loading: true });
 });
 
@@ -19,5 +21,23 @@ describe("authoritative session balance", () => {
 
     expect(useSession.getState().tuzis).toBe(875.5);
     expect(useSession.getState().user?.tuzis).toBe(875.5);
+  });
+
+  it("clears private renderer state before remote revocation settles", async () => {
+    let finishRevocation!: () => void;
+    vi.spyOn(auth, "logout").mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRevocation = resolve;
+        }),
+    );
+    useSession.setState({ user, tuzis: user.tuzis, loading: false });
+
+    const logout = useSession.getState().logout();
+
+    expect(useSession.getState().user).toBeNull();
+    expect(useSession.getState().tuzis).toBe(0);
+    finishRevocation();
+    await logout;
   });
 });

--- a/wallet/zuuli/src/store/session.ts
+++ b/wallet/zuuli/src/store/session.ts
@@ -87,8 +87,8 @@ export const useSession = create<SessionState>((set, get) => ({
     // Clear private pending input before awaiting a network logout. Even if
     // that request fails, the draft must not survive for another account.
     discardPaidIntent();
-    await auth.logout();
     set({ user: null, tuzis: 0 });
+    await auth.logout();
   },
 
   adjustTuzis(delta) {


### PR DESCRIPTION
## Summary

- bind web, desktop, Android, and iOS OAuth captures to a one-way digest of the exact initiating Knox session
- abort in-flight provider flows immediately when logout, token rotation, or account switching changes that session
- revalidate immediately before backend exchange and pin association to the verified initiating token rather than mutable global state
- clear renderer auth before awaiting server logout while revoking with the captured token

## Verification

- focused OAuth/token Vitest: 26/26
- auth session contract: 4/4
- full suite: 609 Vitest passing / 5 skipped, 80 Node contract tests, 100 Playwright tests
- typecheck
- production build

Refs #380

---

_Reviewer note: changed `Closes #380` to `Refs #380`. The session binding is renderer-side only and is never sent to the backend, so #380's requirement for an explicit backend association transaction with atomic validation and one-time consumption is not addressed. #380 stays open for that._
