### PR TITLE
fix(release): keep release-index reruns idempotent

### DIFF
--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -1420,19 +1420,14 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          pattern: zuuli-*-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
+          pattern: zuuli-{android,ios,linux,macos}-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}
           path: release-downloads
+          merge-multiple: false
       - name: Verify release-index source binding
         env:
+          RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}
           EXPECTED_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
-        run: |
-          set -euo pipefail
-          count=0
-          while IFS= read -r -d '' manifest; do
-            jq -e --arg sha "$EXPECTED_SOURCE_SHA" '.source.commit == $sha' "$manifest" >/dev/null
-            count=$((count + 1))
-          done < <(find release-downloads -type f -name provenance.json -print0)
-          test "$count" -gt 0
+        run: wallet/zuuli/scripts/verify-release-index.sh release-downloads "$RELEASE_IDENTITY" "$EXPECTED_SOURCE_SHA"
       - name: Publish idempotent draft release
         if: needs.prepare.outputs.dry_run == 'false' && needs.prepare.outputs.tag_exists == 'true'
         env:

--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -694,6 +694,8 @@ for (const publishContract of [
 for (const releaseTagContract of [
   'RELEASE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}',
   'Verify release-index source binding',
+  'pattern: zuuli-{android,ios,linux,macos}-${{ needs.prepare.outputs.identity }}-${{ needs.prepare.outputs.source_sha }}',
+  'scripts/verify-release-index.sh release-downloads "$RELEASE_IDENTITY" "$EXPECTED_SOURCE_SHA"',
   'scripts/publish-github-release.sh "$RELEASE_TAG" "$RELEASE_IDENTITY" "$RELEASE_SOURCE_SHA" release-downloads',
 ]) {
   if (!releaseWorkflow.includes(releaseTagContract))

--- a/wallet/zuuli/scripts/release-tag-identity.node-test.mjs
+++ b/wallet/zuuli/scripts/release-tag-identity.node-test.mjs
@@ -9,7 +9,9 @@ import test from "node:test";
 const scripts = dirname(fileURLToPath(import.meta.url));
 const verify = resolve(scripts, "verify-release-tag.sh");
 const publish = resolve(scripts, "publish-github-release.sh");
+const verifyIndex = resolve(scripts, "verify-release-index.sh");
 const tag = "zuuli-v9.8.7+654";
+const identity = "9.8.7+654";
 
 function git(cwd, ...args) {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -96,4 +98,48 @@ test("a retarget during release creation leaves the release draft and stops uplo
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /not prepared commit|identity changed/);
   assert.equal((await readFile(state, "utf8")).trim(), "draft");
+});
+
+test("release index accepts only source-bound platform artifacts", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "zuuli-release-index-test-"));
+  const sha = "a".repeat(40);
+  for (const platform of ["android", "linux"]) {
+    const directory = resolve(root, `zuuli-${platform}-${identity}-${sha}`);
+    await mkdir(directory);
+    await writeFile(resolve(directory, "provenance.json"), `${JSON.stringify({ source: { commit: sha } })}\n`);
+  }
+
+  execFileSync(verifyIndex, [root, identity, sha]);
+});
+
+test("release index rejects a recursively downloaded prior index", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "zuuli-release-index-test-"));
+  const sha = "b".repeat(40);
+  const platform = resolve(root, `zuuli-android-${identity}-${sha}`);
+  const priorIndex = resolve(root, `zuuli-release-index-${identity}-${sha}`);
+  await mkdir(platform);
+  await mkdir(priorIndex);
+  await writeFile(resolve(platform, "provenance.json"), `${JSON.stringify({ source: { commit: sha } })}\n`);
+  await writeFile(resolve(priorIndex, "provenance.json"), `${JSON.stringify({ source: { commit: sha } })}\n`);
+
+  const result = spawnSync(verifyIndex, [root, identity, sha], { encoding: "utf8" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unexpected release-index entry/);
+});
+
+test("every platform artifact needs exactly one top-level matching provenance", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "zuuli-release-index-test-"));
+  const sha = "c".repeat(40);
+  const platform = resolve(root, `zuuli-ios-${identity}-${sha}`);
+  await mkdir(resolve(platform, "nested"), { recursive: true });
+  await writeFile(resolve(platform, "provenance.json"), `${JSON.stringify({ source: { commit: sha } })}\n`);
+  await writeFile(resolve(platform, "nested", "provenance.json"), `${JSON.stringify({ source: { commit: sha } })}\n`);
+
+  const duplicate = spawnSync(verifyIndex, [root, identity, sha], { encoding: "utf8" });
+  assert.notEqual(duplicate.status, 0);
+  assert.match(duplicate.stderr, /exactly one provenance/);
+
+  await writeFile(resolve(platform, "nested", "provenance.json"), `${JSON.stringify({ source: { commit: "d".repeat(40) } })}\n`);
+  const mismatch = spawnSync(verifyIndex, [root, identity, sha], { encoding: "utf8" });
+  assert.notEqual(mismatch.status, 0);
 });

--- a/wallet/zuuli/scripts/verify-release-index.sh
+++ b/wallet/zuuli/scripts/verify-release-index.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: scripts/verify-release-index.sh <artifact-root> <identity> <expected-commit>" >&2
+  exit 64
+fi
+
+artifact_root=$1
+identity=$2
+expected_commit=$3
+
+[[ -d "$artifact_root" ]] || { echo "artifact root does not exist: $artifact_root" >&2; exit 66; }
+[[ "$identity" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\+(0|[1-9][0-9]*)$ ]] || {
+  echo "invalid release identity: $identity" >&2
+  exit 65
+}
+[[ "$expected_commit" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "expected commit must be a full lowercase SHA-1" >&2
+  exit 65
+}
+
+artifact_count=0
+for directory in "$artifact_root"/*; do
+  [[ -e "$directory" ]] || continue
+  name=$(basename "$directory")
+  case "$name" in
+    "zuuli-android-$identity-$expected_commit"|\
+    "zuuli-ios-$identity-$expected_commit"|\
+    "zuuli-linux-$identity-$expected_commit"|\
+    "zuuli-macos-$identity-$expected_commit") ;;
+    *)
+      echo "unexpected release-index entry: $name" >&2
+      exit 65
+      ;;
+  esac
+
+  [[ -d "$directory" ]] || { echo "release artifact is not a directory: $name" >&2; exit 65; }
+  [[ -f "$directory/provenance.json" ]] || {
+    echo "release artifact has no top-level provenance.json: $name" >&2
+    exit 65
+  }
+
+  provenance_count=0
+  while IFS= read -r -d '' manifest; do
+    jq -e --arg sha "$expected_commit" '.source.commit == $sha' "$manifest" >/dev/null
+    provenance_count=$((provenance_count + 1))
+  done < <(find "$directory" -type f -name provenance.json -print0)
+  [[ "$provenance_count" -eq 1 ]] || {
+    echo "release artifact must contain exactly one provenance.json: $name" >&2
+    exit 65
+  }
+  artifact_count=$((artifact_count + 1))
+done
+
+[[ "$artifact_count" -gt 0 ]] || { echo "release index contains no platform artifacts" >&2; exit 65; }


### PR DESCRIPTION
Closes #376

Fix-forward for the independently reported rerun gap after #479 merged.

- download only the four exact platform artifact families, excluding prior release-index artifacts
- fail closed on any unexpected top-level package
- require exactly one top-level, source-bound provenance manifest per packaged platform
- add regressions for recursive prior indexes and duplicate/mismatched provenance
- preserve the workflow contract in release verification

The live repository tag ruleset is also installed and API-verified as ruleset `21224853`: active on `refs/tags/zuuli-v*`, no bypass actors, and update/deletion/non-fast-forward protection.

Verification so far:
- release tag/index Node tests: 6/6
- `npm run release:verify`
- `actionlint .github/workflows/zuuli-release.yml`
- full `npm test` running on isolated Playwright port 1478