### PR TITLE
fix(zuuli): sanitize public app fixtures

### DIFF
--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs scripts/auth-session-boundary.node-test.mjs scripts/mermaid-security.node-test.mjs scripts/send-review-boundary.node-test.mjs scripts/ui-copy-truncation.node-test.mjs scripts/apple-credential-boundary.node-test.mjs scripts/release-tag-identity.node-test.mjs && node scripts/apple-credential-boundary.mjs && playwright test",
+    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs scripts/auth-session-boundary.node-test.mjs scripts/mermaid-security.node-test.mjs scripts/send-review-boundary.node-test.mjs scripts/ui-copy-truncation.node-test.mjs scripts/fixture-privacy.node-test.mjs scripts/apple-credential-boundary.node-test.mjs scripts/release-tag-identity.node-test.mjs && node scripts/apple-credential-boundary.mjs && playwright test",
     "test:mermaid-security": "node scripts/check-mermaid-security.mjs && node --test scripts/mermaid-security.node-test.mjs && playwright test tests/mermaid-security.pw.ts",
     "test:send-review": "node --test scripts/send-review-boundary.node-test.mjs && playwright test tests/send-review.pw.ts",
     "test:apple-credential-boundary": "node --test scripts/apple-credential-boundary.node-test.mjs && node scripts/apple-credential-boundary.mjs",

--- a/wallet/zuuli/scripts/fixture-privacy.node-test.mjs
+++ b/wallet/zuuli/scripts/fixture-privacy.node-test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const fixturePaths = ["src/lib/api/mock-data.ts", "src/lib/wallet/mock.ts"];
+const emailPattern = /[a-z0-9._%+-]+@([a-z0-9.-]+\.[a-z]{2,})/gi;
+const reservedEmailDomains = new Set(["example.com", "example.net", "example.org"]);
+
+test("the primary app fixture uses an explicitly fictional editorial identity", async () => {
+  const source = await readFile(resolve(root, fixturePaths[0]), "utf8");
+  for (const contract of [
+    'username: "demo-creator"',
+    'email: "demo.creator@example.com"',
+    'free2zaddr: "demo-creator"',
+    'display_name: "Demo Creator"',
+  ]) {
+    assert.ok(source.includes(contract), `app fixture is missing its fictional identity contract: ${contract}`);
+  }
+});
+
+test("app fixture sources allow only reserved example-domain emails", async () => {
+  const violations = [];
+  for (const fixturePath of fixturePaths) {
+    const source = await readFile(resolve(root, fixturePath), "utf8");
+    for (const match of source.matchAll(emailPattern)) {
+      const domain = match[1].toLowerCase();
+      if (!reservedEmailDomains.has(domain)) violations.push(`${fixturePath}: non-example email domain`);
+    }
+  }
+  assert.deepEqual(violations, []);
+});

--- a/wallet/zuuli/src/components/layout/TopBar.signed-in.test.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.signed-in.test.tsx
@@ -7,8 +7,8 @@ import { TopBar } from "./TopBar";
 vi.mock("@/store/session", () => ({
   useSession: () => ({
     user: {
-      username: "skyl",
-      display_name: "Skylar",
+      username: "demo-creator",
+      display_name: "Demo Creator",
       image: null,
     },
     tuzis: 4210,

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -29,10 +29,10 @@ import type {
 // (`profile.update`) persists across the mock session and reflects in `auth.me()`.
 export const mockUser: AuthUser = {
   id: 1,
-  username: "skyl",
-  email: "skylar.saveland@gmail.com",
-  free2zaddr: "skyl",
-  display_name: "Skylar Saveland-Okonkwo Þórsdóttir",
+  username: "demo-creator",
+  email: "demo.creator@example.com",
+  free2zaddr: "demo-creator",
+  display_name: "Demo Creator",
   image: null,
   banner: null,
   bio: "Building on Zcash. Shielded by default.",

--- a/wallet/zuuli/tests/touch-targets.pw.ts
+++ b/wallet/zuuli/tests/touch-targets.pw.ts
@@ -5,7 +5,7 @@ const ROUTES = [
   "/",
   "/search",
   "/search?q=zcash",
-  "/creator/skyl",
+  "/creator/demo-creator",
   "/profile",
   "/kyc",
   "/wallet",

--- a/wallet/zuuli/tests/viewport.pw.ts
+++ b/wallet/zuuli/tests/viewport.pw.ts
@@ -5,7 +5,7 @@ const ROUTES = [
   "/",
   "/search",
   "/search?q=zcash",
-  "/creator/skyl",
+  "/creator/demo-creator",
   "/profile",
   "/kyc",
   "/wallet",


### PR DESCRIPTION
Closes #483

- replace the real dev/demo identity with an explicitly fictional creator and reserved example-domain email
- update the signed-in and empty-creator audit fixtures consistently
- add a fixture privacy contract that rejects non-example email domains across both app fixture sources

Verification:
- privacy Node contracts: 2/2
- full Vitest: 609 assertions (604 passed, 5 skipped)
- affected touch-target/viewport Playwright: 13/13
- TypeScript typecheck