### PR TITLE
fix(zuuli): separate follows from paid memberships

### DIFF
--- a/wallet/zuuli/src/features/creator/index.tsx
+++ b/wallet/zuuli/src/features/creator/index.tsx
@@ -485,6 +485,35 @@ function SubscribeButton({
   const renewing =
     renewOverride ?? (sub ? Number(sub.max_price ?? 0) > 0 : true);
 
+  async function follow() {
+    const currentUser = useSession.getState().user;
+    if (!currentUser || gate === "sign-in") {
+      signInToSubscribe();
+      return;
+    }
+    if (gate !== "ready") return;
+    setBusy(true);
+    try {
+      await tuzi.follow(creator.username);
+      setUnfollowed(false);
+      setJustSubscribed({
+        fan: {
+          username: currentUser.username,
+          free2zaddr: currentUser.free2zaddr ?? currentUser.username,
+        },
+        star: { username: creator.username, free2zaddr: creator.free2zaddr },
+        expires: new Date(Date.now() + 30 * 86400000).toISOString(),
+        max_price: "0",
+      });
+      toast.success(`Followed ${name}`);
+      void reloadSubscriptions();
+    } catch {
+      toast.error("Couldn't follow. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
   // A fresh subscribe and a resume-renewal are the same backend call — POST
   // /api/tuzis/subscribe/{username} get-or-creates the membership and (re)sets
   // renewal at the current price — so they share one runner and differ only in
@@ -580,7 +609,7 @@ function SubscribeButton({
     }
     setBusy(true);
     try {
-      await tuzi.unsubscribe(creator.username);
+      await tuzi.unfollow(creator.username);
       setUnfollowed(true);
       setJustSubscribed(null);
       toast.success(`Unfollowed ${name}`);
@@ -597,16 +626,18 @@ function SubscribeButton({
     return (
       <Button
         variant={subscribed ? "secondary" : "default"}
-        onClick={subscribed ? unfollow : subscribe}
+        onClick={subscribed ? unfollow : follow}
         disabled={busy || gate === "loading"}
-        aria-label={subscribed ? `Unfollow ${name}` : `Follow ${name}`}
+        aria-label={
+          subscribed ? `Following ${name} · Unfollow` : `Follow ${name}`
+        }
       >
         {busy ? (
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
         ) : subscribed ? (
           <Check className="h-4 w-4" aria-hidden />
         ) : null}
-        {subscribed ? "Following" : "Subscribe"}
+        {subscribed ? "Following" : "Follow"}
       </Button>
     );
   }

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -40,6 +40,7 @@ import {
   mockCreatorDetail,
   mockCreators,
   mockDeletePersonality,
+  mockFollow,
   mockKycIdentityDocuments,
   mockKycProfile,
   mockKycTaxForm,
@@ -52,6 +53,7 @@ import {
   mockSubscriptions,
   mockTransactions,
   mockUnsubscribe,
+  mockUnfollow,
   mockUpdatePersonality,
   mockUser,
 } from "./mock-data";
@@ -1654,6 +1656,30 @@ export const tuzi = {
       },
     );
     return normalizeDonationResult(response, tuzis);
+  },
+
+  /**
+   * Create a free creator relationship. The API currently transports this
+   * over its legacy subscribe route; a separate client method keeps free
+   * follow behavior and messages independent from paid memberships.
+   */
+  async follow(username: string): Promise<void> {
+    if (useMock()) {
+      await delay(400);
+      mockFollow(username);
+      return;
+    }
+    await request(`/api/tuzis/subscribe/${username}`, { method: "POST" });
+  },
+
+  /** Remove a free creator relationship. */
+  async unfollow(username: string): Promise<void> {
+    if (useMock()) {
+      await delay(300);
+      mockUnfollow(username);
+      return;
+    }
+    await request(`/api/tuzis/subscribe/${username}`, { method: "DELETE" });
   },
 
   async subscribe(

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -721,12 +721,12 @@ function mockFan(): SimpleCreator {
 /**
  * The mock signed-in user's active memberships — mirrors GET
  * /api/tuzis/my-subscriptions (`fan=request.user`, `expires__gt=now`).
- * Mutated in place (via `push`/field writes, never reassigned) by
- * `mockSubscribe`/`mockUnsubscribe`, same pattern as `mockUser` above, so a
- * subscribe in one screen is reflected everywhere that refetches this list.
+ * Mutated in place (via `push`/field writes, never reassigned) by the paid
+ * membership and free-follow helpers below, same pattern as `mockUser` above,
+ * so a relationship change is reflected everywhere that refetches this list.
  *
- * Seeded with one already-active membership (mining_maya) so BOTH the
- * "Member" and "Subscribe" states are demoable without doing anything first.
+ * Seeded with one already-active paid membership (mining_maya) and one free
+ * follow (f2z) so both relationship contracts are demoable after a reload.
  */
 export const mockSubscriptions: Subscription[] = [
   {
@@ -735,7 +735,52 @@ export const mockSubscriptions: Subscription[] = [
     expires: new Date(Date.now() + 18 * 86400000).toISOString(),
     max_price: String(mockCreators[1].member_price ?? 0),
   },
+  {
+    fan: mockFan(),
+    star: mockCreators[2], // f2z, no paid membership tier
+    expires: new Date(Date.now() + 18 * 86400000).toISOString(),
+    max_price: "0",
+  },
 ];
+
+/**
+ * Mock a free creator follow. Its product contract has no price, charge,
+ * subscriber entitlement, or renewal.
+ */
+export function mockFollow(username: string): void {
+  const star = mockCreators.find(
+    (candidate) =>
+      candidate.username.toLowerCase() === username.toLowerCase(),
+  );
+  if (!star) throw new Error("Creator not found");
+  if (Number(star.member_price ?? 0) > 0) {
+    throw new Error("Creator has a paid membership tier");
+  }
+  const existing = mockSubscriptions.find(
+    (subscription) =>
+      subscription.star.username.toLowerCase() === username.toLowerCase(),
+  );
+  if (existing) return;
+  mockSubscriptions.push({
+    fan: mockFan(),
+    star,
+    expires: new Date(Date.now() + 30 * 86400000).toISOString(),
+    max_price: "0",
+  });
+}
+
+/** Remove a free creator follow rather than changing paid renewal state. */
+export function mockUnfollow(username: string): void {
+  const index = mockSubscriptions.findIndex(
+    (subscription) =>
+      subscription.star.username.toLowerCase() === username.toLowerCase(),
+  );
+  if (index < 0) return;
+  if (Number(mockSubscriptions[index].star.member_price ?? 0) > 0) {
+    throw new Error("Creator has a paid membership tier");
+  }
+  mockSubscriptions.splice(index, 1);
+}
 
 /**
  * Mock `tuzi.subscribe(username)`. Mirrors `CreatorSubscribeView.post`:

--- a/wallet/zuuli/tests/creator-follow.pw.ts
+++ b/wallet/zuuli/tests/creator-follow.pw.ts
@@ -1,0 +1,85 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function openSignedInCreator(page: Page, username: string) {
+  await page.addInitScript(() => {
+    localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+  });
+  await page.goto(`/creator/${username}`);
+  await page.locator("[data-creator-profile]").waitFor();
+  await expect(
+    page.getByRole("button", { name: "Account menu" }),
+  ).toBeVisible();
+}
+
+async function expectNoPaidRelationshipCopy(page: Page) {
+  const actions = page.locator("[data-creator-actions]");
+  await expect(actions.getByText(/subscribe|member|renew/i)).toHaveCount(0);
+  await expect(
+    page.getByText(/subscriber posts|subscriber livestreams|unlocked/i),
+  ).toHaveCount(0);
+}
+
+test("free creator actions consistently follow and unfollow without paid claims", async ({
+  page,
+}) => {
+  await openSignedInCreator(page, "shielded_sam");
+
+  const follow = page.getByRole("button", {
+    name: "Follow Antidisestablishmentarianismsam",
+  });
+  await expect(follow).toHaveText("Follow");
+  await expectNoPaidRelationshipCopy(page);
+
+  await follow.click();
+  await expect(
+    page.getByText("Followed Antidisestablishmentarianismsam", { exact: true }),
+  ).toBeVisible();
+
+  const unfollow = page.getByRole("button", {
+    name: "Following Antidisestablishmentarianismsam · Unfollow",
+  });
+  await expect(unfollow).toHaveText("Following");
+  await expectNoPaidRelationshipCopy(page);
+
+  await unfollow.click();
+  await expect(
+    page.getByText("Unfollowed Antidisestablishmentarianismsam", {
+      exact: true,
+    }),
+  ).toBeVisible();
+  await expect(follow).toHaveText("Follow");
+  await expectNoPaidRelationshipCopy(page);
+});
+
+test("an existing free relationship is restored from the backend after reload", async ({
+  page,
+}) => {
+  await openSignedInCreator(page, "f2z");
+
+  const unfollow = page.getByRole("button", {
+    name: "Following Free2Z · Unfollow",
+  });
+  await expect(unfollow).toHaveText("Following");
+  await expectNoPaidRelationshipCopy(page);
+
+  await page.reload();
+  await page.locator("[data-creator-profile]").waitFor();
+  await expect(unfollow).toHaveText("Following");
+  await expectNoPaidRelationshipCopy(page);
+});
+
+test("subscribe and membership language remains on a priced creator", async ({
+  page,
+}) => {
+  await openSignedInCreator(page, "zooko");
+
+  const subscribe = page.getByRole("button", {
+    name: "Subscribe to Zooko · 500 2Z/mo",
+  });
+  await expect(subscribe).toHaveText("Subscribe · 500 2Z/mo");
+  await subscribe.click();
+  await expect(
+    page.getByRole("dialog", { name: "Subscribe to Zooko" }),
+  ).toBeVisible();
+  await expect(page.getByText("Membership · monthly")).toBeVisible();
+});


### PR DESCRIPTION
## What

- routes free creator actions through explicit `follow` / `unfollow` client methods while retaining the deployed API route as the wire transport
- makes visible and accessible copy agree on **Follow / Following / Unfollow**, with free-only success and failure messages
- keeps Subscribe, Member, subscriber-entitlement, price, and renewal language on creators that publish a paid membership price
- restores a working free-follow mock contract and seeds an existing free relationship so reload reconciliation is exercised end to end
- adds browser regression coverage for follow, unfollow, backend-restored state, paid-copy gating, and accessible names

## Verification

- `npm run typecheck`
- `npm run build`
- focused Playwright: creator follow + creator responsive + paid actions — 22 passed
- full `npm test` on the rebased head — 609 Vitest tests passed (5 skipped), 85 Node contract tests passed, 103 Playwright tests passed

Refs #261