### PR TITLE
test(release): lock index source binding

### DIFF
--- a/wallet/zuuli/scripts/release-identity.mjs
+++ b/wallet/zuuli/scripts/release-identity.mjs
@@ -202,6 +202,7 @@ const ascTestFlight = read("scripts/asc-testflight.mjs");
 const gateWorkflow = read("../../.github/workflows/zuuli.yml");
 const releaseWorkflow = read("../../.github/workflows/zuuli-release.yml");
 const githubReleasePublisher = read("scripts/publish-github-release.sh");
+const releaseIndexVerifier = read("scripts/verify-release-index.sh");
 const testFlightRecoveryWorkflow = read(
   "../../.github/workflows/zuuli-testflight-recovery.yml",
 );
@@ -708,6 +709,23 @@ for (const releasePublishContract of [
 ]) {
   if (!githubReleasePublisher.includes(releasePublishContract))
     failures.push(`GitHub release publication identity contract is missing: ${releasePublishContract}`);
+}
+for (const releaseIndexContract of [
+  '[[ -d "$artifact_root" ]]',
+  '[[ "$identity" =~ ^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\+(0|[1-9][0-9]*)$ ]]',
+  '[[ "$expected_commit" =~ ^[0-9a-f]{40}$ ]]',
+  '"zuuli-android-$identity-$expected_commit"',
+  '"zuuli-ios-$identity-$expected_commit"',
+  '"zuuli-linux-$identity-$expected_commit"',
+  '"zuuli-macos-$identity-$expected_commit"',
+  '[[ -d "$directory" ]]',
+  '[[ -f "$directory/provenance.json" ]]',
+  "'.source.commit == $sha'",
+  '[[ "$provenance_count" -eq 1 ]]',
+  '[[ "$artifact_count" -gt 0 ]]',
+]) {
+  if (!releaseIndexVerifier.includes(releaseIndexContract))
+    failures.push(`release-index verifier contract is missing: ${releaseIndexContract}`);
 }
 if (/gh release edit[^\n]*(?:--draft(?:=|\s+)false|--draft=false)/.test(githubReleasePublisher))
   failures.push("GitHub release publication must not make a draft public without a final tag identity gate");

--- a/wallet/zuuli/scripts/release-tag-identity.node-test.mjs
+++ b/wallet/zuuli/scripts/release-tag-identity.node-test.mjs
@@ -13,6 +13,10 @@ const verifyIndex = resolve(scripts, "verify-release-index.sh");
 const tag = "zuuli-v9.8.7+654";
 const identity = "9.8.7+654";
 
+function runIndex(root, releaseIdentity, sha) {
+  return spawnSync(verifyIndex, [root, releaseIdentity, sha], { encoding: "utf8" });
+}
+
 function git(cwd, ...args) {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 }
@@ -112,6 +116,23 @@ test("release index accepts only source-bound platform artifacts", async () => {
   execFileSync(verifyIndex, [root, identity, sha]);
 });
 
+test("release index rejects a missing artifact root and malformed identity inputs", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "zuuli-release-index-test-"));
+  const sha = "a".repeat(40);
+
+  const missingRoot = runIndex(resolve(parent, "missing"), identity, sha);
+  assert.notEqual(missingRoot.status, 0);
+  assert.match(missingRoot.stderr, /artifact root does not exist/);
+
+  const invalidIdentity = runIndex(parent, "9.8+654", sha);
+  assert.notEqual(invalidIdentity.status, 0);
+  assert.match(invalidIdentity.stderr, /invalid release identity/);
+
+  const invalidCommit = runIndex(parent, identity, "A".repeat(40));
+  assert.notEqual(invalidCommit.status, 0);
+  assert.match(invalidCommit.stderr, /full lowercase SHA-1/);
+});
+
 test("release index rejects a recursively downloaded prior index", async () => {
   const root = await mkdtemp(resolve(tmpdir(), "zuuli-release-index-test-"));
   const sha = "b".repeat(40);
@@ -122,24 +143,54 @@ test("release index rejects a recursively downloaded prior index", async () => {
   await writeFile(resolve(platform, "provenance.json"), `${JSON.stringify({ source: { commit: sha } })}\n`);
   await writeFile(resolve(priorIndex, "provenance.json"), `${JSON.stringify({ source: { commit: sha } })}\n`);
 
-  const result = spawnSync(verifyIndex, [root, identity, sha], { encoding: "utf8" });
+  const result = runIndex(root, identity, sha);
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /unexpected release-index entry/);
 });
 
-test("every platform artifact needs exactly one top-level matching provenance", async () => {
+test("release index rejects a non-directory platform entry", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "zuuli-release-index-test-"));
+  const sha = "c".repeat(40);
+  await writeFile(resolve(root, `zuuli-macos-${identity}-${sha}`), "not a directory\n");
+
+  const result = runIndex(root, identity, sha);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /not a directory/);
+});
+
+test("release index requires one top-level provenance per platform", async () => {
   const root = await mkdtemp(resolve(tmpdir(), "zuuli-release-index-test-"));
   const sha = "c".repeat(40);
   const platform = resolve(root, `zuuli-ios-${identity}-${sha}`);
   await mkdir(resolve(platform, "nested"), { recursive: true });
+
+  const missing = runIndex(root, identity, sha);
+  assert.notEqual(missing.status, 0);
+  assert.match(missing.stderr, /no top-level provenance/);
+
   await writeFile(resolve(platform, "provenance.json"), `${JSON.stringify({ source: { commit: sha } })}\n`);
   await writeFile(resolve(platform, "nested", "provenance.json"), `${JSON.stringify({ source: { commit: sha } })}\n`);
 
-  const duplicate = spawnSync(verifyIndex, [root, identity, sha], { encoding: "utf8" });
+  const duplicate = runIndex(root, identity, sha);
   assert.notEqual(duplicate.status, 0);
   assert.match(duplicate.stderr, /exactly one provenance/);
+});
 
-  await writeFile(resolve(platform, "nested", "provenance.json"), `${JSON.stringify({ source: { commit: "d".repeat(40) } })}\n`);
-  const mismatch = spawnSync(verifyIndex, [root, identity, sha], { encoding: "utf8" });
+test("release index rejects a single provenance bound to another commit", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "zuuli-release-index-test-"));
+  const sha = "d".repeat(40);
+  const platform = resolve(root, `zuuli-linux-${identity}-${sha}`);
+  await mkdir(platform);
+  await writeFile(resolve(platform, "provenance.json"), `${JSON.stringify({ source: { commit: "e".repeat(40) } })}\n`);
+
+  const mismatch = runIndex(root, identity, sha);
   assert.notEqual(mismatch.status, 0);
+  assert.match(mismatch.stderr, /not bound to expected commit/);
+});
+
+test("release index rejects an empty artifact root", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "zuuli-release-index-test-"));
+  const result = runIndex(root, identity, "f".repeat(40));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /contains no platform artifacts/);
 });

--- a/wallet/zuuli/scripts/verify-release-index.sh
+++ b/wallet/zuuli/scripts/verify-release-index.sh
@@ -43,7 +43,10 @@ for directory in "$artifact_root"/*; do
 
   provenance_count=0
   while IFS= read -r -d '' manifest; do
-    jq -e --arg sha "$expected_commit" '.source.commit == $sha' "$manifest" >/dev/null
+    jq -e --arg sha "$expected_commit" '.source.commit == $sha' "$manifest" >/dev/null || {
+      echo "release provenance is not bound to expected commit: $name" >&2
+      exit 65
+    }
     provenance_count=$((provenance_count + 1))
   done < <(find "$directory" -type f -name provenance.json -print0)
   [[ "$provenance_count" -eq 1 ]] || {


### PR DESCRIPTION
Closes #488

- add distinct negative cases for missing roots, malformed identity/SHA, non-directory artifacts, missing top-level provenance, wrong source commit, duplicate provenance, and empty indexes
- assert the precise failure reason so one guard cannot accidentally satisfy another test
- give source-binding failures an incident-ready diagnostic
- make release verification read the verifier itself and pin every fail-closed contract, so an empty or hollowed script fails the gate

Verification:
- release tag/index tests: 10/10
- `npm run release:verify`
- diff check