### PR TITLE
release(zuuli): prepare internal build 0.1.0+13

### DIFF
--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.zuuli",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 12,
+  "build": 13,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "12").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "13").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "12"
+        CFBundleVersion: "13"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -34,14 +34,14 @@
       "icons/icon.ico"
     ],
     "iOS": {
-      "bundleVersion": "12",
+      "bundleVersion": "13",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 12
+      "versionCode": 13
     }
   },
   "plugins": {


### PR DESCRIPTION
> **MERGING THIS PR TRIGGERS A REAL RELEASE.** A push to `main` that changes an
> existing `release.json` pins the pushed SHA, proves `build` strictly increased,
> then builds, signs, and **uploads to TestFlight and Play internal**. Do not
> merge unless you intend to ship build 13 to testers.

Bumps ZUULI to **`0.1.0+13`**. The marketing `version` stays `0.1.0`; only the
build identity moves.

`0.1.0+12` shipped to TestFlight and Play internal. Since then **13 commits**
have landed on `main` and none are in testers' hands. This build ships them.

## What build 13 ships (`git log --oneline a50fddc..origin/main`)

```
ee43f09 fix(zuuli): sanitize public app fixtures (#487)
859a106 fix(release): keep index reruns idempotent (#486)
f8d53c1 security(release): pin tag identity at publication (#479)
2fdbdfe fix(wallet): keep generated Tauri schemas current (#475)
1f5c18a fix(zuuli): validate branded social-link hosts (#471)
c89d956 fix(zuuli): persist canonical Send draft amounts (#470)
d991cbb fix(profile): prevent mobile dashboard overflow (#469)
623daf7 ci(zuuli): cover packaging workflow inputs (#468)
6023d55 docs: clarify tiered upload limits (#467)
56c21c5 security(docs): guard public repo boundary (#466)
78655a1 test(zuuli): assert bundled fonts at runtime (#465)
bec1952 fix(zuuli): harden internal markdown routes (#463)
513b20b fix(zuuli): allow Playwright port override (#464)
```

Roughly: two release-pipeline hardening changes (tag identity pinned at
publication, idempotent release-index reruns), user-visible ZUULI fixes
(canonical Send draft amounts, branded social-link host validation, mobile
profile-dashboard overflow, hardened internal markdown routes, sanitized public
app fixtures), generated Tauri schema refresh, plus CI/test/docs work
(packaging-input coverage, runtime bundled-font assertion, Playwright port
override, upload-limit and public-repo-boundary docs).

## Generation

```
$ npm run release:bump -- --version=0.1.0 --build=13
> zuuli@0.1.0 release:bump
> node scripts/release-bump.mjs --version=0.1.0 --build=13

updated ZUULI release identity to 0.1.0+13
review the diff and run npm run release:verify before committing
```

```
$ npm run release:verify
> zuuli@0.1.0 release:verify
> node scripts/release-identity.mjs

{"applicationId":"cash.free2z.zuuli","version":"0.1.0","build":13,"identity":"0.1.0+13","tag":"zuuli-v0.1.0+13"}
```

## Diff — 5 files, 6 lines, version identity only

```
 wallet/zuuli/release.json                               | 2 +-
 wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts | 2 +-
 wallet/zuuli/src-tauri/gen/apple/project.yml            | 2 +-
 wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist   | 2 +-
 wallet/zuuli/src-tauri/tauri.conf.json                  | 4 ++--
 5 files changed, 6 insertions(+), 6 deletions(-)
```

- `release.json`: `"build": 12` → `13`
- `tauri.conf.json`: iOS `bundleVersion "12"` → `"13"`, Android `versionCode 12` → `13`
- `gen/apple/project.yml`: `CFBundleVersion: "12"` → `"13"`
- `gen/apple/zuuli_iOS/Info.plist`: `CFBundleVersion` `12` → `13`
- `gen/android/app/build.gradle.kts`: `versionCode` default `"12"` → `"13"`

`version` is unchanged, so `package.json`, `package-lock.json`, and `Cargo.toml`/
`Cargo.lock` are untouched. Nothing outside the bump output is in this PR.

## Release-path sanity check (several PRs changed it since build 12)

Verified on this branch:

- `wallet/zuuli/scripts/resolve-ios-xcarchive.sh` exists and is referenced by both workflows:
  - `.github/workflows/zuuli-packaging.yml:264` — `run: scripts/resolve-ios-xcarchive.sh`
  - `.github/workflows/zuuli-release.yml:397` — `archive=$(scripts/resolve-ios-xcarchive.sh)`
- `wallet/zuuli/scripts/verify-release-index.sh` exists and is invoked directly from
  `.github/workflows/zuuli-release.yml:1430` —
  `wallet/zuuli/scripts/verify-release-index.sh release-downloads "$RELEASE_IDENTITY" "$EXPECTED_SOURCE_SHA"`
- `wallet/zuuli/scripts/verify-release-tag.sh` exists and is invoked from
  `zuuli-release.yml` **indirectly**: `zuuli-release.yml:1438` runs
  `wallet/zuuli/scripts/publish-github-release.sh "$RELEASE_TAG" "$RELEASE_IDENTITY" "$RELEASE_SOURCE_SHA" release-downloads`,
  and `publish-github-release.sh:21,24` calls `verify-release-tag.sh "$tag" "$expected_commit" …`
  (tag identity is verified, then re-verified). `release-identity.mjs` asserts exactly
  this chain (`scripts/publish-github-release.sh …` in the workflow, and
  `verify-release-tag.sh" "$tag" "$expected_commit"` in the publisher), and
  `release:verify` passed — so the wiring is contract-enforced, not just present.
  This is the shape introduced by #479 (tag identity pinned at publication);
  there is no direct `verify-release-tag.sh` line in the workflow YAML.
- `src-tauri/gen/android/app/src/main/AndroidManifest.xml`: exactly **2**
  `DEEP LINK PLUGIN` markers (lines 33, 60), exactly **one**
  `android:host="oauth"` (line 41) and **one** `android:host="checkout"` (line 54).

## Checks run locally on this branch

- `npm run release:verify` — pass, identity `0.1.0+13` (output above)
- `node scripts/apple-credential-boundary.mjs` — exit 0,
  `Apple release build, credential, and finalization boundaries verified.`
- `npm run typecheck` (`tsc --noEmit`) — exit 0, no output

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
