### PR TITLE
ci(wallet): require fresh Zuuallet schemas in the protected gate

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       zuuli: ${{ steps.filter.outputs.zuuli }}
+      zuuallet_schema: ${{ steps.filter.outputs.zuuallet_schema }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -79,25 +80,34 @@ jobs:
              ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
             echo "::notice::No usable base commit; running the full ZUULI gate."
             echo "zuuli=true" >> "$GITHUB_OUTPUT"
+            echo "zuuallet_schema=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if ! changed_files=$(git diff --name-only --no-renames "$BASE_SHA" "$GITHUB_SHA"); then
             echo "::warning::Diff failed; running the full ZUULI gate."
             echo "zuuli=true" >> "$GITHUB_OUTPUT"
+            echo "zuuallet_schema=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           zuuli=false
+          zuuallet_schema=false
           while IFS= read -r file; do
             case "$file" in
               wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-github-actions-pins.mjs|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zcash-permissions.mjs|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-store-audit.yml|.github/workflows/zuuli-store-publish.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
                 zuuli=true
                 ;;
             esac
+            case "$file" in
+              wallet/zuuallet/src-tauri/*|wallet/plugins/*|wallet/rust-toolchain.toml|scripts/check-rust-toolchain.sh|scripts/check-zcash-permissions.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/actions/zuuli-rust-cache/*)
+                zuuallet_schema=true
+                ;;
+            esac
           done <<< "$changed_files"
 
           echo "zuuli=$zuuli" >> "$GITHUB_OUTPUT"
+          echo "zuuallet_schema=$zuuallet_schema" >> "$GITHUB_OUTPUT"
 
   frontend:
     needs: changes
@@ -440,11 +450,87 @@ jobs:
       - name: Test ZUULI Tauri backend
         run: cargo test --locked --manifest-path wallet/zuuli/src-tauri/Cargo.toml
 
+  # A static permission parity check cannot see schema-shape drift introduced
+  # by a Tauri dependency update. Regenerate Zuuallet's Linux target schema in
+  # a clean required-gate job, then reject every tracked or untracked change.
+  zuuallet_schema:
+    name: Zuuallet / generated schema freshness
+    needs: changes
+    if: needs.changes.outputs.zuuallet_schema == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/free2z/zuuli-linux-ci@sha256:1f51900724b8ccac86832dbf573a019fdd405f3ad4a407382047e2e4087055a1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
+    steps:
+      - name: Verify pinned Linux build image
+        working-directory: /
+        run: |
+          set -euo pipefail
+          /usr/local/bin/verify-zuuli-linux-image
+          test -n "$BASH_VERSION"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Configure exact Git workspace trust
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: wallet/zuuallet/src-tauri -> ${{ github.workspace }}/target
+          key: zuuallet-required-schema
+
+      - name: Regenerate Zuuallet permissions and target schema
+        env:
+          # These values are build-script inputs, so restored Cargo artifacts
+          # cannot turn this freshness assertion into a no-op.
+          TAURI_SCHEMA_GENERATION_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
+          TAURI_PERMISSION_GENERATION_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: cargo build --locked --manifest-path wallet/zuuallet/src-tauri/Cargo.toml
+
+      - name: Reject generated permission or schema drift
+        run: |
+          set -euo pipefail
+          node scripts/check-zcash-permissions.mjs --self-test
+          node scripts/check-zcash-permissions.mjs
+          for generated in \
+            wallet/plugins/tauri-plugin-zcash/permissions \
+            wallet/zuuallet/src-tauri/gen/schemas; do
+            git diff --exit-code -- "$generated"
+            untracked=$(git ls-files --others --exclude-standard -- "$generated")
+            test -z "$untracked" || {
+              echo "Unexpected generated files under $generated:" >&2
+              echo "$untracked" >&2
+              exit 1
+            }
+          done
+
   # Branch protection requires this stable context. It succeeds only when the
   # change detector and every applicable full-stack job succeeded; legitimate
   # non-ZUULI skips continue to report success instead of remaining pending.
   gate:
-    needs: [changes, frontend, rust_fmt, rust_deny, rust_clippy, rust_plugin, rust_app]
+    needs: [changes, frontend, rust_fmt, rust_deny, rust_clippy, rust_plugin, rust_app, zuuallet_schema]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -453,12 +539,14 @@ jobs:
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
           ZUULI_CHANGED: ${{ needs.changes.outputs.zuuli }}
+          ZUUALLET_SCHEMA_CHANGED: ${{ needs.changes.outputs.zuuallet_schema }}
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           RUST_FMT_RESULT: ${{ needs.rust_fmt.result }}
           RUST_DENY_RESULT: ${{ needs.rust_deny.result }}
           RUST_CLIPPY_RESULT: ${{ needs.rust_clippy.result }}
           RUST_PLUGIN_RESULT: ${{ needs.rust_plugin.result }}
           RUST_APP_RESULT: ${{ needs.rust_app.result }}
+          ZUUALLET_SCHEMA_RESULT: ${{ needs.zuuallet_schema.result }}
         run: |
           set -euo pipefail
           [ "$CHANGES_RESULT" = "success" ] || {
@@ -480,4 +568,12 @@ jobs:
               echo "Expected every applicable job to be $expected, got: $result"; exit 1;
             }
           done
+          case "$ZUUALLET_SCHEMA_CHANGED" in
+            true) schema_expected=success ;;
+            false) schema_expected=skipped ;;
+            *) echo "Invalid or missing Zuuallet schema change output: $ZUUALLET_SCHEMA_CHANGED"; exit 1 ;;
+          esac
+          [ "$ZUUALLET_SCHEMA_RESULT" = "$schema_expected" ] || {
+            echo "Expected Zuuallet schema job to be $schema_expected, got: $ZUUALLET_SCHEMA_RESULT"; exit 1;
+          }
           echo "The full-stack gate is internally consistent and passed."

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -61,6 +61,15 @@ jobs:
           scripts/check-public-repo-boundary.sh --self-test
           scripts/check-public-repo-boundary.sh
 
+      # This policy checker owns the schema job's pinned build image, selector
+      # coverage, and attachment to the required gate. Run both its mutation
+      # controls and current-tree verdict in the always-required job so those
+      # guarantees cannot regress behind an advisory workflow.
+      - name: Verify the required schema build policy
+        run: |
+          node scripts/check-zuuli-linux-image.mjs --self-test
+          node scripts/check-zuuli-linux-image.mjs
+
       - name: Verify Zcash command and permission parity
         run: |
           node scripts/check-zcash-permissions.mjs --self-test
@@ -100,7 +109,7 @@ jobs:
                 ;;
             esac
             case "$file" in
-              wallet/zuuallet/src-tauri/*|wallet/plugins/*|wallet/rust-toolchain.toml|scripts/check-rust-toolchain.sh|scripts/check-zcash-permissions.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/actions/zuuli-rust-cache/*)
+              wallet/zuuallet/src-tauri/*|wallet/plugins/*|wallet/rust-toolchain.toml|scripts/check-rust-toolchain.sh|scripts/check-zcash-permissions.mjs|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/actions/zuuli-rust-cache/*)
                 zuuallet_schema=true
                 ;;
             esac

--- a/scripts/check-zcash-permissions.mjs
+++ b/scripts/check-zcash-permissions.mjs
@@ -2,6 +2,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -49,6 +50,21 @@ function assertIdentical(entries, label) {
   }
 }
 
+function schemaNamesFromTrackedPaths(listing, schemaDir) {
+  const prefix = `${schemaDir}/`;
+  const names = listing
+    .split("\n")
+    .filter(Boolean)
+    .map((entry) => {
+      if (!entry.startsWith(prefix) || !entry.endsWith("-schema.json")) {
+        throw new Error(`unexpected tracked Zuuallet schema path: ${entry}`);
+      }
+      return entry.slice(prefix.length);
+    });
+  if (!names.length) throw new Error("no tracked Zuuallet target schemas found");
+  return unique(names, "tracked Zuuallet target schemas");
+}
+
 function expectFailure(fn, pattern) {
   try {
     fn();
@@ -79,6 +95,20 @@ function selfTest() {
         "target schemas",
       ),
     /target schemas differ: linux, macOS/,
+  );
+  const discoveredSchemas = schemaNamesFromTrackedPaths(
+    "wallet/zuuallet/src-tauri/gen/schemas/linux-schema.json\n" +
+      "wallet/zuuallet/src-tauri/gen/schemas/windows-schema.json\n",
+    "wallet/zuuallet/src-tauri/gen/schemas",
+  );
+  assertSameSet(
+    ["linux-schema.json", "windows-schema.json"],
+    discoveredSchemas,
+    "dynamic target schema discovery",
+  );
+  expectFailure(
+    () => schemaNamesFromTrackedPaths("", "wallet/zuuallet/src-tauri/gen/schemas"),
+    /no tracked Zuuallet target schemas/,
   );
   console.log("Zcash permission parity negative controls passed.");
 }
@@ -154,7 +184,14 @@ const referenceIds = unique(
 assertSameSet(permissionIds, referenceIds, "command TOMLs and permission reference");
 
 const appSchemaDir = path.join(root, "wallet/zuuallet/src-tauri/gen/schemas");
-const appSchemaNames = ["linux-schema.json", "macOS-schema.json", "desktop-schema.json"];
+const appSchemaRelativeDir = "wallet/zuuallet/src-tauri/gen/schemas";
+const appSchemaNames = schemaNamesFromTrackedPaths(
+  execFileSync("git", ["ls-files", "--", `${appSchemaRelativeDir}/*-schema.json`], {
+    cwd: root,
+    encoding: "utf8",
+  }),
+  appSchemaRelativeDir,
+);
 const namespacedPermissionIds = permissionIds.map((identifier) => `zcash:${identifier}`);
 const expectedAppSchemaIds = [...namespacedPermissionIds, "zcash:default"];
 const appSchemas = appSchemaNames.map((name) => {

--- a/scripts/check-zuuli-linux-image.mjs
+++ b/scripts/check-zuuli-linux-image.mjs
@@ -35,11 +35,12 @@ const imageRepository = "ghcr.io/free2z/zuuli-linux-ci";
 const lockedImageDigest = "sha256:1f51900724b8ccac86832dbf573a019fdd405f3ad4a407382047e2e4087055a1";
 const lockedImageSourceHash = "6801078c61b2de196e642a8d57402949c3ff94b74a10be9df133f4400d2c4475";
 const lockedImage = `${imageRepository}@${lockedImageDigest}`;
-const expectedConsumerCount = 6;
+const expectedConsumerCount = 7;
 const requiredConsumerJobs = new Set([
   ".github/workflows/zuuli.yml:rust_clippy",
   ".github/workflows/zuuli.yml:rust_plugin",
   ".github/workflows/zuuli.yml:rust_app",
+  ".github/workflows/zuuli.yml:zuuallet_schema",
   ".github/workflows/zuuli-packaging.yml:desktop",
   ".github/workflows/zuuli-release.yml:linux",
   ".github/workflows/zuuallet.yml:rust",
@@ -216,6 +217,21 @@ function validateConsumerJob(job, failures) {
       }
     }
   }
+  if (job.name === ".github/workflows/zuuli.yml:zuuallet_schema") {
+    for (const expected of [
+      "persist-credentials: false",
+      pinnedZuualletToolchain,
+      pinnedRustCache,
+      "cargo build --locked --manifest-path wallet/zuuallet/src-tauri/Cargo.toml",
+      "TAURI_SCHEMA_GENERATION_NONCE",
+      "git diff --exit-code",
+      "git ls-files --others --exclude-standard",
+    ]) {
+      if (countOccurrences(job.contents, expected) !== 1) {
+        failures.push(`${job.name}: required schema regeneration contract is missing ${expected}`);
+      }
+    }
+  }
 }
 
 function validate(root) {
@@ -378,6 +394,33 @@ function validate(root) {
   const fullGateFallbacks = requiredGate.match(/echo "zuuli=true" >> "\$GITHUB_OUTPUT"/g) ?? [];
   if (!requiredGate.includes("set -euo pipefail") || fullGateFallbacks.length < 2) {
     failures.push("required gate: base/diff failures must select the full suite fail-closed");
+  }
+  const requiredGateJobs = workflowJobs(requiredGate, consumerWorkflows[0]);
+  const schemaJob = requiredGateJobs.find(
+    (job) => job.name === ".github/workflows/zuuli.yml:zuuallet_schema",
+  );
+  const gateJob = requiredGateJobs.find(
+    (job) => job.name === ".github/workflows/zuuli.yml:gate",
+  );
+  if (!schemaJob?.contents.includes("if: needs.changes.outputs.zuuallet_schema == 'true'")) {
+    failures.push("required gate: Zuuallet schema job is not selected by its change output");
+  }
+  if (!gateJob?.contents.match(/^\s+needs: \[[^\n]*\bzuuallet_schema\b[^\n]*\]$/m)) {
+    failures.push("required gate: gate does not await the Zuuallet schema job");
+  }
+  for (const expected of [
+    "ZUUALLET_SCHEMA_CHANGED: ${{ needs.changes.outputs.zuuallet_schema }}",
+    "ZUUALLET_SCHEMA_RESULT: ${{ needs.zuuallet_schema.result }}",
+    '[ "$ZUUALLET_SCHEMA_RESULT" = "$schema_expected" ]',
+  ]) {
+    if (!gateJob?.contents.includes(expected)) {
+      failures.push(`required gate: gate does not enforce Zuuallet schema result: ${expected}`);
+    }
+  }
+  const schemaGateFallbacks =
+    requiredGate.match(/echo "zuuallet_schema=true" >> "\$GITHUB_OUTPUT"/g) ?? [];
+  if (schemaGateFallbacks.length < 2) {
+    failures.push("required gate: base/diff failures must select schema regeneration fail-closed");
   }
   for (const phaseAPath of phaseATriggerPaths) {
     if (!workflow.includes(phaseAPath)) {
@@ -586,6 +629,21 @@ function runSelfTest() {
           'echo "zuuli=false" >> "$GITHUB_OUTPUT"',
         ),
         expected: "select the full suite fail-closed",
+      },
+      {
+        name: "schema regeneration detached from required gate",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace(", zuuallet_schema]", "]"),
+        expected: "gate does not await the Zuuallet schema job",
+      },
+      {
+        name: "fail-open schema regeneration fallback",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace(
+          'echo "zuuallet_schema=true" >> "$GITHUB_OUTPUT"',
+          'echo "zuuallet_schema=false" >> "$GITHUB_OUTPUT"',
+        ),
+        expected: "select schema regeneration fail-closed",
       },
       {
         name: "mismatched attestation digest",

--- a/scripts/check-zuuli-linux-image.mjs
+++ b/scripts/check-zuuli-linux-image.mjs
@@ -58,6 +58,20 @@ const phaseASamplePaths = [
   "docs/ZUULI-LINUX-BUILD-IMAGE.md",
   "scripts/check-zuuli-linux-image.mjs",
 ];
+const schemaGateSamplePaths = [
+  "wallet/zuuallet/src-tauri/Cargo.toml",
+  "wallet/plugins/tauri-plugin-zcash/build.rs",
+  "wallet/rust-toolchain.toml",
+  "scripts/check-rust-toolchain.sh",
+  "scripts/check-zcash-permissions.mjs",
+  "scripts/check-zuuli-linux-image.mjs",
+  "z/zcash/librustzcash",
+  ".gitmodules",
+  ".github/containers/zuuli-linux/Dockerfile",
+  ".github/workflows/zuuli.yml",
+  ".github/workflows/zuuli-linux-image.yml",
+  ".github/actions/zuuli-rust-cache/action.yml",
+];
 const pinnedActions = [
   "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
   "docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0",
@@ -396,12 +410,41 @@ function validate(root) {
     failures.push("required gate: base/diff failures must select the full suite fail-closed");
   }
   const requiredGateJobs = workflowJobs(requiredGate, consumerWorkflows[0]);
+  const changesJob = requiredGateJobs.find(
+    (job) => job.name === ".github/workflows/zuuli.yml:changes",
+  );
   const schemaJob = requiredGateJobs.find(
     (job) => job.name === ".github/workflows/zuuli.yml:zuuallet_schema",
   );
   const gateJob = requiredGateJobs.find(
     (job) => job.name === ".github/workflows/zuuli.yml:gate",
   );
+  for (const expected of [
+    "node scripts/check-zuuli-linux-image.mjs --self-test",
+    "node scripts/check-zuuli-linux-image.mjs",
+  ]) {
+    const exactLines = (changesJob?.contents ?? "")
+      .split("\n")
+      .filter((line) => line.trim() === expected);
+    if (exactLines.length !== 1) {
+      failures.push(`required gate: changes job does not run image/schema policy: ${expected}`);
+    }
+  }
+  const schemaPatternMatch = requiredGate.match(
+    /case "\$file" in\s*\n\s*([^\n]+)\)\s*\n\s*zuuallet_schema=true/,
+  );
+  if (!schemaPatternMatch) {
+    failures.push("required gate: cannot parse the Zuuallet schema change-detector patterns");
+  } else {
+    const schemaPatterns = schemaPatternMatch[1]
+      .split("|")
+      .map((pattern) => pattern.trim());
+    for (const schemaInput of schemaGateSamplePaths) {
+      if (!schemaPatterns.some((pattern) => shellPatternMatches(pattern, schemaInput))) {
+        failures.push(`required gate: schema input must select regeneration: ${schemaInput}`);
+      }
+    }
+  }
   if (!schemaJob?.contents.includes("if: needs.changes.outputs.zuuallet_schema == 'true'")) {
     failures.push("required gate: Zuuallet schema job is not selected by its change output");
   }
@@ -635,6 +678,42 @@ function runSelfTest() {
         path: consumerWorkflows[0],
         mutate: (value) => value.replace(", zuuallet_schema]", "]"),
         expected: "gate does not await the Zuuallet schema job",
+      },
+      {
+        name: "schema policy removed from always-required changes job",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace(
+          "          node scripts/check-zuuli-linux-image.mjs --self-test\n",
+          "",
+        ),
+        expected: "changes job does not run image/schema policy",
+      },
+      {
+        name: "Zuuallet source stops selecting schema regeneration",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace(
+          "wallet/zuuallet/src-tauri/*|wallet/plugins/*|wallet/rust-toolchain.toml|scripts/check-rust-toolchain.sh",
+          "wallet/plugins/*|wallet/rust-toolchain.toml|scripts/check-rust-toolchain.sh",
+        ),
+        expected: "schema input must select regeneration: wallet/zuuallet/src-tauri/Cargo.toml",
+      },
+      {
+        name: "plugin source stops selecting schema regeneration",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace(
+          "wallet/zuuallet/src-tauri/*|wallet/plugins/*|wallet/rust-toolchain.toml|scripts/check-rust-toolchain.sh",
+          "wallet/zuuallet/src-tauri/*|wallet/rust-toolchain.toml|scripts/check-rust-toolchain.sh",
+        ),
+        expected: "schema input must select regeneration: wallet/plugins/tauri-plugin-zcash/build.rs",
+      },
+      {
+        name: "schema policy changes stop selecting regeneration",
+        path: consumerWorkflows[0],
+        mutate: (value) => value.replace(
+          "scripts/check-rust-toolchain.sh|scripts/check-zcash-permissions.mjs|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash",
+          "scripts/check-rust-toolchain.sh|scripts/check-zcash-permissions.mjs|z/zcash/librustzcash",
+        ),
+        expected: "schema input must select regeneration: scripts/check-zuuli-linux-image.mjs",
       },
       {
         name: "fail-open schema regeneration fallback",


### PR DESCRIPTION
Closes #480

## What changed
- add a cache-busted Zuuallet schema regeneration job to the required `gate` aggregation
- select it for backend, plugin, toolchain, submodule, build-image, and gate-policy changes, failing closed when the comparison base is unavailable
- reject tracked diffs and untracked generated permission/schema files after the fresh build
- discover every tracked `*-schema.json` dynamically instead of hardcoding target names
- extend the Linux image policy self-test to prove the new build stays attached to `gate` and its fail-closed contract

## Verification
- `actionlint .github/workflows/zuuli.yml`
- `node scripts/check-zcash-permissions.mjs --self-test`
- `node scripts/check-zcash-permissions.mjs`
- `node scripts/check-zuuli-linux-image.mjs --self-test` (27 negative cases + libxdo runtime cases)
- `node scripts/check-zuuli-linux-image.mjs`
- `scripts/check-rust-toolchain.sh`
- `node scripts/check-github-actions-pins.mjs`
- `git diff --check`