### PR TITLE
fix(release): catch multiline and semicolon Apple assertions

### DIFF
--- a/wallet/zuuli/scripts/apple-credential-boundary.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.mjs
@@ -101,7 +101,7 @@ function containsBareBashDoubleBracket(source) {
   // etc. do not begin at one of these boundaries and remain allowed.
   const shell = source.replace(/\\\r?\n[\t ]*/g, " ");
   const starts =
-    /(?:^|[;\n]|(?<!&)&(?!&)|&&|\|\||\bthen\b|\bdo\b|\belse\b|\btime\b|[({)])[\t ]*\[\[/gm;
+    /(?:^|[;\n]|(?<!&)&(?!&)|&&|\|\||\bthen\b|\bdo\b|\belse\b|\btime\b(?:[\t ]+-p)?|[({)])[\t ]*\[\[/gm;
   for (const match of shell.matchAll(starts)) {
     const open = match.index + match[0].lastIndexOf("[[");
     let quote = null;

--- a/wallet/zuuli/scripts/apple-credential-boundary.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.mjs
@@ -101,7 +101,7 @@ function containsBareBashDoubleBracket(source) {
   // etc. do not begin at one of these boundaries and remain allowed.
   const shell = source.replace(/\\\r?\n[\t ]*/g, " ");
   const starts =
-    /(?:^|[;\n]|&&|\|\||\bthen\b|\bdo\b|\belse\b|[({)])[\t ]*\[\[/gm;
+    /(?:^|[;\n]|(?<!&)&(?!&)|&&|\|\||\bthen\b|\bdo\b|\belse\b|\btime\b|[({)])[\t ]*\[\[/gm;
   for (const match of shell.matchAll(starts)) {
     const open = match.index + match[0].lastIndexOf("[[");
     let quote = null;

--- a/wallet/zuuli/scripts/apple-credential-boundary.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.mjs
@@ -91,6 +91,16 @@ function sourceForNode(workflow, node) {
   return node?.range ? workflow.slice(node.range[0], node.range[2]) : "";
 }
 
+function containsBareBashDoubleBracket(source) {
+  // Bash treats a failing `[[ ]]` in statement position as exempt from
+  // `errexit` on the macOS runner's Bash 3.2. Join shell continuations first
+  // so splitting the expression across physical lines cannot evade the guard.
+  const logicalLines = source.replace(/\\\r?\n[\t ]*/g, " ");
+  return /^[\t ]*\[\[[^\n]*\]\][\t ]*;?[\t ]*(?:#[^\n]*)?$/m.test(
+    logicalLines,
+  );
+}
+
 function sha256(source) {
   return createHash("sha256").update(source).digest("hex");
 }
@@ -237,7 +247,7 @@ export function verifyAppleCredentialBoundary(
   }
   for (const name of [...BUILD_JOBS, ...CREDENTIAL_JOBS, ...FINALIZE_JOBS]) {
     const source = jobs.get(name) ?? "";
-    if (/^[\t ]*\[\[[^\n]*\]\](?:[\t ]*#[^\n]*)?[\t ]*$/m.test(source)) {
+    if (containsBareBashDoubleBracket(source)) {
       failures.push(`${name} contains a bare Bash [[ ]] assertion that does not fail closed on macOS Bash 3.2`);
     }
   }

--- a/wallet/zuuli/scripts/apple-credential-boundary.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.mjs
@@ -93,12 +93,43 @@ function sourceForNode(workflow, node) {
 
 function containsBareBashDoubleBracket(source) {
   // Bash treats a failing `[[ ]]` in statement position as exempt from
-  // `errexit` on the macOS runner's Bash 3.2. Join shell continuations first
-  // so splitting the expression across physical lines cannot evade the guard.
-  const logicalLines = source.replace(/\\\r?\n[\t ]*/g, " ");
-  return /^[\t ]*\[\[[^\n]*\]\][\t ]*;?[\t ]*(?:#[^\n]*)?$/m.test(
-    logicalLines,
-  );
+  // `errexit` on the macOS runner's Bash 3.2. Join explicit continuations,
+  // then inspect command boundaries rather than only whole lines: a bare test
+  // after `then`, `do`, a group opener, or an AND/OR list is just as inert.
+  // `[[` can also continue implicitly across a newline while its expression
+  // is incomplete. Deliberate conditions introduced by `if`, `while`, `!`,
+  // etc. do not begin at one of these boundaries and remain allowed.
+  const shell = source.replace(/\\\r?\n[\t ]*/g, " ");
+  const starts =
+    /(?:^|[;\n]|&&|\|\||\bthen\b|\bdo\b|\belse\b|[({)])[\t ]*\[\[/gm;
+  for (const match of shell.matchAll(starts)) {
+    const open = match.index + match[0].lastIndexOf("[[");
+    let quote = null;
+    let close = -1;
+    for (let index = open + 2; index < shell.length; index += 1) {
+      const char = shell[index];
+      if (char === "\\" && quote !== "'") {
+        index += 1;
+        continue;
+      }
+      if (quote) {
+        if (char === quote) quote = null;
+        continue;
+      }
+      if (char === "'" || char === '"') {
+        quote = char;
+        continue;
+      }
+      if (char === "]" && shell[index + 1] === "]") {
+        close = index;
+        break;
+      }
+    }
+    if (close < 0) return true;
+    const continuation = shell.slice(close + 2).match(/^[\t ]*(\|\||&&)/);
+    if (!continuation) return true;
+  }
+  return false;
 }
 
 function sha256(source) {

--- a/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
@@ -164,10 +164,20 @@ const unsealedMacJobs = [
 const inertAssertionForms = [
   ["trailing semicolon", "[[ 1 -eq 2 ]];"],
   ["spaced trailing semicolon", "[[ 1 -eq 2 ]] ;"],
+  ["trailing command", "[[ 1 -eq 2 ]]; echo REACHED"],
+  ["mid-line statement", "echo prep; [[ 1 -eq 2 ]]; echo REACHED"],
+  ["then-list statement", "if true; then [[ 1 -eq 2 ]]; echo REACHED; fi"],
+  ["and-list trailing statement", "true && [[ 1 -eq 2 ]]; echo REACHED"],
+  ["group statement", "{ [[ 1 -eq 2 ]]; echo REACHED; }"],
+  [
+    "do-list statement",
+    "for item in one; do [[ 1 -eq 2 ]]; echo REACHED; done",
+  ],
   [
     "line continuation",
     `[[ 1 -eq 1 && ${String.fromCharCode(92)}\n  1 -eq 2 ]]`,
   ],
+  ["implicit multiline condition", "[[ 1 -eq 1 &&\n  1 -eq 2 ]]"],
 ];
 
 for (const job of unsealedMacJobs) {
@@ -194,6 +204,30 @@ for (const job of unsealedMacJobs) {
       );
     });
   }
+}
+
+const guardedAssertionForms = [
+  ["if condition", "if [[ 1 -eq 2 ]]; then echo skipped; fi"],
+  ["while condition", "while [[ 1 -eq 2 ]]; do echo skipped; done"],
+  ["negated condition", "! [[ 1 -eq 2 ]]"],
+  ["and-list condition", "[[ 1 -eq 2 ]] && echo skipped"],
+  ["explicit failure guard", "[[ 1 -eq 2 ]] || exit 1"],
+];
+
+for (const [form, assertion] of guardedAssertionForms) {
+  test(`accepts ${form} in an unsealed build job`, () => {
+    const mutated = validWorkflow.replace(
+      "          tauri ios build --archive-only --no-sign\n",
+      `          ${assertion}\n          tauri ios build --archive-only --no-sign\n`,
+    );
+    const failures = verifyFixture(mutated);
+    assert.ok(
+      failures.every(
+        (failure) => !failure.includes("bare Bash [[ ]] assertion"),
+      ),
+      failures.join("\n"),
+    );
+  });
 }
 
 test("an explicit assertion guard aborts before credential work continues", () => {

--- a/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
@@ -154,6 +154,48 @@ test("rejects a bare Bash assertion in an Apple release job", () => {
   );
 });
 
+const unsealedMacJobs = [
+  "ios-build",
+  "macos-build",
+  "ios-verify",
+  "ios-finalize",
+  "macos-finalize",
+];
+const inertAssertionForms = [
+  ["trailing semicolon", "[[ 1 -eq 2 ]];"],
+  ["spaced trailing semicolon", "[[ 1 -eq 2 ]] ;"],
+  [
+    "line continuation",
+    `[[ 1 -eq 1 && ${String.fromCharCode(92)}\n  1 -eq 2 ]]`,
+  ],
+];
+
+for (const job of unsealedMacJobs) {
+  for (const [form, assertion] of inertAssertionForms) {
+    test(`rejects ${form} assertion in unsealed ${job}`, () => {
+      const marker = `  ${job}:\n    steps:\n`;
+      const script = assertion
+        .split("\n")
+        .map((line) => `          ${line}`)
+        .join("\n");
+      const mutated = validWorkflow.replace(
+        marker,
+        `${marker}      - run: |\n${script}\n`,
+      );
+      assert.notEqual(mutated, validWorkflow, `missing fixture job ${job}`);
+      const failures = verifyFixture(mutated);
+      assert.ok(
+        failures.some(
+          (failure) =>
+            failure.includes(job) &&
+            failure.includes("bare Bash [[ ]] assertion"),
+        ),
+        failures.join("\n"),
+      );
+    });
+  }
+}
+
 test("an explicit assertion guard aborts before credential work continues", () => {
   const result = spawnSync(
     "/bin/bash",

--- a/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
@@ -169,6 +169,8 @@ const inertAssertionForms = [
   ["then-list statement", "if true; then [[ 1 -eq 2 ]]; echo REACHED; fi"],
   ["and-list trailing statement", "true && [[ 1 -eq 2 ]]; echo REACHED"],
   ["group statement", "{ [[ 1 -eq 2 ]]; echo REACHED; }"],
+  ["background-list statement", "sleep 0 & [[ 1 -eq 2 ]]; echo REACHED"],
+  ["timed statement", "time [[ 1 -eq 2 ]]; echo REACHED"],
   [
     "do-list statement",
     "for item in one; do [[ 1 -eq 2 ]]; echo REACHED; done",

--- a/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/apple-credential-boundary.node-test.mjs
@@ -171,6 +171,7 @@ const inertAssertionForms = [
   ["group statement", "{ [[ 1 -eq 2 ]]; echo REACHED; }"],
   ["background-list statement", "sleep 0 & [[ 1 -eq 2 ]]; echo REACHED"],
   ["timed statement", "time [[ 1 -eq 2 ]]; echo REACHED"],
+  ["POSIX timed statement", "time -p [[ 1 -eq 2 ]]; echo REACHED"],
   [
     "do-list statement",
     "for item in one; do [[ 1 -eq 2 ]]; echo REACHED; done",


### PR DESCRIPTION
Closes #494

## What changed
- normalize explicit Bash line continuations and scan complete double-bracket expressions across physical lines
- reject unguarded assertions at every reviewed statement boundary, including line/semicolon, single background ampersand, then/do/else, group/subshell/case boundaries, AND/OR-list positions, and Bash time/time -p
- preserve deliberate conditional/control-flow forms: if, while, negation, and assertions continued by AND/OR guards
- mutation-test thirteen inert forms across all five unsealed macOS-runner jobs, plus safe false-positive controls

## Verification
- Apple credential boundary: 132/132 Node tests
- 30 independent exact single-cause rejection mutations
- 40 safe-control acceptance mutations
- current release workflow boundary and release verifiers
- actionlint
- git diff --check