### PR TITLE
fix(zuuli): separate AI context switches

### DIFF
--- a/wallet/zuuli/src/features/ai/PersonalityManager.tsx
+++ b/wallet/zuuli/src/features/ai/PersonalityManager.tsx
@@ -53,12 +53,14 @@ export function PersonalityManager({
 }: PersonalityManagerProps) {
   const [view, setView] = useState<View>({ kind: "list" });
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
   // Armed by a first click on the trash icon; a second click on "Confirm"
   // actually deletes. Avoids a blocking `window.confirm()`, which freezes
   // the page (and is untheme-able) — an inline step keeps it in-app.
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
 
   function close(next: boolean) {
+    if (!next && (saving || deletingId !== null)) return;
     if (!next) {
       setView({ kind: "list" });
       setConfirmingId(null);
@@ -157,6 +159,7 @@ export function PersonalityManager({
           <PersonalityForm
             personality={view.personality}
             onCancel={() => setView({ kind: "list" })}
+            onBusyChange={setSaving}
             onSaved={(saved, wasCreate) => {
               onChanged(wasCreate ? { created: saved } : { updated: saved });
               setView({ kind: "list" });
@@ -281,10 +284,12 @@ function PersonalityForm({
   personality,
   onCancel,
   onSaved,
+  onBusyChange,
 }: {
   personality: Personality | null;
   onCancel: () => void;
   onSaved: (saved: Personality, wasCreate: boolean) => void;
+  onBusyChange: (busy: boolean) => void;
 }) {
   const [displayName, setDisplayName] = useState(personality?.display_name ?? "");
   const [systemMessage, setSystemMessage] = useState(
@@ -299,6 +304,7 @@ function PersonalityForm({
   async function save() {
     if (!canSave) return;
     setSaving(true);
+    onBusyChange(true);
     try {
       const input = {
         display_name: displayName.trim(),
@@ -314,6 +320,7 @@ function PersonalityForm({
       toast.error("Couldn't save that personality. Please try again.");
     } finally {
       setSaving(false);
+      onBusyChange(false);
     }
   }
 

--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -14,6 +14,14 @@ import { toast } from "sonner";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { Markdown } from "@/components/common/Markdown";
@@ -46,6 +54,11 @@ interface ChatMessage {
   tuzisCharged?: number;
   inputTokens?: number;
   outputTokens?: number;
+}
+
+interface PendingChatSwitch {
+  model: AIModel;
+  personality: Personality | null;
 }
 
 /**
@@ -115,6 +128,8 @@ export default function AiFeature() {
   const [personalities, setPersonalities] = useState<Personality[]>([]);
   const [personality, setPersonality] = useState<Personality | null>(null);
   const [managerOpen, setManagerOpen] = useState(false);
+  const [pendingSwitch, setPendingSwitch] =
+    useState<PendingChatSwitch | null>(null);
 
   const restoredIntent = usePaidIntent("/ai", "ai");
   const restoredIntentHandled = useRef(false);
@@ -210,6 +225,46 @@ export default function AiFeature() {
     setMessages([]);
     setSessionCost(0);
   }, []);
+
+  const requestChatIdentity = useCallback(
+    (model: AIModel, nextPersonality: Personality | null) => {
+      if (
+        selected?.id === model.id &&
+        personality?.id === nextPersonality?.id
+      ) {
+        return;
+      }
+      if (messages.length === 0) {
+        conversationRef.current = null;
+        setSelected(model);
+        setPersonality(nextPersonality);
+        return;
+      }
+      setPendingSwitch({ model, personality: nextPersonality });
+    },
+    [messages.length, personality?.id, selected?.id],
+  );
+
+  const confirmChatIdentity = useCallback(() => {
+    if (!pendingSwitch) return;
+    startNewChat();
+    setSelected(pendingSwitch.model);
+    setPersonality(pendingSwitch.personality);
+    setPendingSwitch(null);
+  }, [pendingSwitch, startNewChat]);
+
+  const resetForActivePersonalityMutation = useCallback(
+    (nextPersonality: Personality | null) => {
+      if (messages.length > 0) {
+        startNewChat();
+        toast.info(
+          "Started a new chat because the active personality changed.",
+        );
+      }
+      setPersonality(nextPersonality);
+    },
+    [messages.length, startNewChat],
+  );
 
   const send = useCallback(
     async (text: string) => {
@@ -388,7 +443,9 @@ export default function AiFeature() {
                 <ModelPicker
                   models={models}
                   value={selected}
-                  onChange={setSelected}
+                  onChange={(model) =>
+                    requestChatIdentity(model, personality)
+                  }
                   disabled={isSending}
                 />
               </div>
@@ -397,7 +454,11 @@ export default function AiFeature() {
               <PersonalityPicker
                 personalities={personalities}
                 value={personality}
-                onChange={setPersonality}
+                onChange={(nextPersonality) => {
+                  if (selected) {
+                    requestChatIdentity(selected, nextPersonality);
+                  }
+                }}
                 onManage={() => setManagerOpen(true)}
                 ownUsername={user?.username}
                 disabled={isSending}
@@ -579,26 +640,60 @@ export default function AiFeature() {
         onChanged={(change) => {
           if (change.created) {
             setPersonalities((prev) => [...prev, change.created!]);
-            setPersonality(change.created);
+            if (selected) requestChatIdentity(selected, change.created);
           } else if (change.updated) {
             setPersonalities((prev) =>
               prev.map((p) =>
                 p.id === change.updated!.id ? change.updated! : p,
               ),
             );
-            setPersonality((cur) =>
-              cur?.id === change.updated!.id ? change.updated! : cur,
-            );
+            if (personality?.id === change.updated.id) {
+              resetForActivePersonalityMutation(change.updated);
+            }
           } else if (change.deletedId) {
             setPersonalities((prev) =>
               prev.filter((p) => p.id !== change.deletedId),
             );
-            setPersonality((cur) =>
-              cur?.id === change.deletedId ? null : cur,
-            );
+            if (personality?.id === change.deletedId) {
+              resetForActivePersonalityMutation(null);
+            }
           }
         }}
       />
+
+      <Dialog
+        open={pendingSwitch !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingSwitch(null);
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Start a new chat?</DialogTitle>
+            <DialogDescription>
+              Changing the model or personality starts a separate backend
+              conversation. The current transcript will be cleared because the
+              new conversation cannot see it.
+            </DialogDescription>
+          </DialogHeader>
+          {pendingSwitch ? (
+            <div className="rounded-lg border border-border bg-background/50 px-4 py-3 text-sm">
+              <div className="font-medium text-foreground">
+                {pendingSwitch.model.display_name}
+              </div>
+              <div className="mt-1 text-muted-foreground">
+                {pendingSwitch.personality?.display_name ?? "Default persona"}
+              </div>
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setPendingSwitch(null)}>
+              Cancel
+            </Button>
+            <Button onClick={confirmChatIdentity}>Start new chat</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/wallet/zuuli/src/features/ai/index.tsx
+++ b/wallet/zuuli/src/features/ai/index.tsx
@@ -139,11 +139,18 @@ export default function AiFeature() {
   const [sessionCost, setSessionCost] = useState(0);
 
   const abortRef = useRef<AbortController | null>(null);
+  const chatGenerationRef = useRef(0);
   // Which live backend conversation (if any) the next turn continues — pinned
   // to a single (model, personality) pair for its lifetime.
   const conversationRef = useRef<{ id: string; key: string } | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const selectedRef = useRef(selected);
+  const personalityRef = useRef(personality);
+  const messagesRef = useRef(messages);
+  selectedRef.current = selected;
+  personalityRef.current = personality;
+  messagesRef.current = messages;
 
   useEffect(() => {
     if (restoredIntent?.kind !== "ai" || restoredIntentHandled.current) return;
@@ -221,33 +228,44 @@ export default function AiFeature() {
   useEffect(() => () => abortRef.current?.abort(), []);
 
   const startNewChat = useCallback(() => {
+    chatGenerationRef.current += 1;
+    abortRef.current?.abort();
+    abortRef.current = null;
     conversationRef.current = null;
+    messagesRef.current = [];
     setMessages([]);
     setSessionCost(0);
+    setIsSending(false);
   }, []);
 
   const requestChatIdentity = useCallback(
     (model: AIModel, nextPersonality: Personality | null) => {
+      const currentModel = selectedRef.current;
+      const currentPersonality = personalityRef.current;
       if (
-        selected?.id === model.id &&
-        personality?.id === nextPersonality?.id
+        currentModel?.id === model.id &&
+        currentPersonality?.id === nextPersonality?.id
       ) {
         return;
       }
-      if (messages.length === 0) {
+      if (messagesRef.current.length === 0) {
         conversationRef.current = null;
+        selectedRef.current = model;
+        personalityRef.current = nextPersonality;
         setSelected(model);
         setPersonality(nextPersonality);
         return;
       }
       setPendingSwitch({ model, personality: nextPersonality });
     },
-    [messages.length, personality?.id, selected?.id],
+    [],
   );
 
   const confirmChatIdentity = useCallback(() => {
     if (!pendingSwitch) return;
     startNewChat();
+    selectedRef.current = pendingSwitch.model;
+    personalityRef.current = pendingSwitch.personality;
     setSelected(pendingSwitch.model);
     setPersonality(pendingSwitch.personality);
     setPendingSwitch(null);
@@ -255,15 +273,16 @@ export default function AiFeature() {
 
   const resetForActivePersonalityMutation = useCallback(
     (nextPersonality: Personality | null) => {
-      if (messages.length > 0) {
+      if (messagesRef.current.length > 0) {
         startNewChat();
         toast.info(
           "Started a new chat because the active personality changed.",
         );
       }
+      personalityRef.current = nextPersonality;
       setPersonality(nextPersonality);
     },
-    [messages.length, startNewChat],
+    [startNewChat],
   );
 
   const send = useCallback(
@@ -297,6 +316,15 @@ export default function AiFeature() {
 
       const controller = new AbortController();
       abortRef.current = controller;
+      const generation = chatGenerationRef.current;
+      const assertCurrentGeneration = () => {
+        if (
+          controller.signal.aborted ||
+          chatGenerationRef.current !== generation
+        ) {
+          throw new DOMException("Chat context changed", "AbortError");
+        }
+      };
 
       try {
         // A conversation is pinned to one (model, personality) pair for its
@@ -308,6 +336,7 @@ export default function AiFeature() {
             model,
             personality: pers,
           });
+          assertCurrentGeneration();
           conversationRef.current = { id: convo.id, key };
         }
 
@@ -323,6 +352,7 @@ export default function AiFeature() {
             }),
           controller.signal,
         );
+        assertCurrentGeneration();
 
         let tuzisCharged = res.tuzis_charged;
         if (tuzisCharged != null) {
@@ -334,6 +364,7 @@ export default function AiFeature() {
           // breakdown, so sync the authoritative balance from the account
           // and derive the exact charge from the delta.
           await refreshSession();
+          assertCurrentGeneration();
           tuzisCharged = Math.max(0, beforeTuzis - useSession.getState().tuzis);
         }
 
@@ -358,6 +389,7 @@ export default function AiFeature() {
         }
       } catch (err) {
         const aborted = isAbortError(err);
+        if (chatGenerationRef.current !== generation) return;
         const genericMessage =
           "Sorry — the model could not be reached. Please try again.";
         const detail =
@@ -382,8 +414,10 @@ export default function AiFeature() {
         );
         if (!aborted) toast.error(detail ?? "The model could not be reached.");
       } finally {
-        abortRef.current = null;
-        setIsSending(false);
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+          setIsSending(false);
+        }
       }
     },
     [
@@ -640,21 +674,22 @@ export default function AiFeature() {
         onChanged={(change) => {
           if (change.created) {
             setPersonalities((prev) => [...prev, change.created!]);
-            if (selected) requestChatIdentity(selected, change.created);
+            const currentModel = selectedRef.current;
+            if (currentModel) requestChatIdentity(currentModel, change.created);
           } else if (change.updated) {
             setPersonalities((prev) =>
               prev.map((p) =>
                 p.id === change.updated!.id ? change.updated! : p,
               ),
             );
-            if (personality?.id === change.updated.id) {
+            if (personalityRef.current?.id === change.updated.id) {
               resetForActivePersonalityMutation(change.updated);
             }
           } else if (change.deletedId) {
             setPersonalities((prev) =>
               prev.filter((p) => p.id !== change.deletedId),
             );
-            if (personality?.id === change.deletedId) {
+            if (personalityRef.current?.id === change.deletedId) {
               resetForActivePersonalityMutation(null);
             }
           }

--- a/wallet/zuuli/tests/ai-context-switch.pw.ts
+++ b/wallet/zuuli/tests/ai-context-switch.pw.ts
@@ -90,3 +90,32 @@ test("an empty chat switches immediately without a destructive confirmation", as
     page.getByRole("button", { name: "Select AI model" }),
   ).toContainText("Claude Sonnet 5");
 });
+
+test("an in-flight personality save cannot close into a mismatched chat", async ({
+  page,
+}) => {
+  await openSignedInAi(page);
+  await page.getByRole("button", { name: "Select AI personality" }).click();
+  await page.getByRole("menuitem", { name: "Manage personalities…" }).click();
+
+  const manager = page.getByRole("dialog", { name: "Personalities" });
+  await manager.getByRole("button", { name: "New personality" }).click();
+  await page.getByLabel("Name").fill("Late Persona");
+  await page
+    .getByLabel("System message")
+    .fill("Answer as the late but correctly bound persona.");
+  await page.getByRole("button", { name: "Save" }).click();
+  await page.getByRole("button", { name: "Close" }).click();
+
+  await expect(page.getByRole("dialog")).toBeVisible();
+  const savedManager = page.getByRole("dialog", { name: "Personalities" });
+  await expect(savedManager.getByText("Late Persona", { exact: true })).toBeVisible();
+  await savedManager.getByRole("button", { name: "Close" }).click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Select AI personality" }),
+  ).toContainText("Late Persona");
+
+  await sendMessage(page, "This message belongs to Late Persona");
+  await expect(page.getByText(/primed as “Late Persona”/).last()).toBeVisible();
+});

--- a/wallet/zuuli/tests/ai-context-switch.pw.ts
+++ b/wallet/zuuli/tests/ai-context-switch.pw.ts
@@ -1,0 +1,92 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function openSignedInAi(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+  });
+  await page.goto("/ai");
+  await expect(
+    page.getByRole("button", { name: "Select AI model" }),
+  ).toContainText("GPT-4o");
+}
+
+async function sendMessage(page: Page, message: string) {
+  await page.getByRole("textbox", { name: "Message" }).fill(message);
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(page.getByText(message, { exact: true })).toBeVisible();
+  await expect(page.getByText(/Here's a reply in character/).last()).toBeVisible();
+}
+
+async function chooseModel(page: Page, name: string) {
+  await page.getByRole("button", { name: "Select AI model" }).click();
+  const option = page.getByRole("menuitem", { name: new RegExp(name) });
+  // Focus exercises the keyboard-select path even when a long menu places the
+  // requested mock model outside Playwright's compact default viewport.
+  await option.focus();
+  await option.press("Enter");
+}
+
+test("model and personality switches start honest, separate chat threads", async ({
+  page,
+}) => {
+  await openSignedInAi(page);
+  await sendMessage(page, "Context only the first model received");
+
+  await chooseModel(page, "Claude Haiku 4.5");
+  const dialog = page.getByRole("dialog", { name: "Start a new chat?" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText(
+    "The current transcript will be cleared because the new conversation cannot see it.",
+  );
+  await expect(dialog).toContainText("Claude Haiku 4.5");
+  await expect(
+    page.getByText("Context only the first model received", { exact: true }),
+  ).toBeVisible();
+
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(dialog).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Select AI model" }),
+  ).toContainText("GPT-4o");
+  await expect(
+    page.getByText("Context only the first model received", { exact: true }),
+  ).toBeVisible();
+
+  await chooseModel(page, "Claude Haiku 4.5");
+  await dialog.getByRole("button", { name: "Start new chat" }).click();
+  await expect(
+    page.getByRole("button", { name: "Select AI model" }),
+  ).toContainText("Claude Haiku 4.5");
+  await expect(
+    page.getByText("Context only the first model received", { exact: true }),
+  ).toHaveCount(0);
+
+  await sendMessage(page, "Context only Claude received");
+  await expect(page.getByText(/Claude Haiku 4\.5/).last()).toBeVisible();
+
+  await page.getByRole("button", { name: "Select AI personality" }).click();
+  await page.getByRole("menuitem", { name: /ZK Tutor/ }).click();
+  await expect(dialog).toContainText("Claude Haiku 4.5");
+  await expect(dialog).toContainText("ZK Tutor");
+  await dialog.getByRole("button", { name: "Start new chat" }).click();
+  await expect(
+    page.getByRole("button", { name: "Select AI personality" }),
+  ).toContainText("ZK Tutor");
+  await expect(
+    page.getByText("Context only Claude received", { exact: true }),
+  ).toHaveCount(0);
+
+  await sendMessage(page, "Context only the tutor received");
+  await expect(page.getByText(/primed as “ZK Tutor”/).last()).toBeVisible();
+});
+
+test("an empty chat switches immediately without a destructive confirmation", async ({
+  page,
+}) => {
+  await openSignedInAi(page);
+  await chooseModel(page, "Claude Sonnet 5");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Select AI model" }),
+  ).toContainText("Claude Sonnet 5");
+});


### PR DESCRIPTION
Closes #266

## What changed
- require explicit confirmation before model or personality changes discard a visible transcript
- keep model, personality, backend conversation, and transcript unchanged on cancel
- clear transcript, backend conversation identity, and session cost before a confirmed context switch
- reset the visible chat when the active personality is edited or deleted
- keep personality mutation dialogs non-dismissible while save/delete is in flight
- read current identity/transcript state for async mutation completion and generation-fence active sends so stale responses cannot repopulate a reset chat
- switch immediately when the chat is empty

## Verification
- Vitest: 619 passed, 5 skipped
- Node contracts: 90/90
- typecheck
- production build
- focused AI Playwright: 3/3
- independent save and delete race checks
- git diff --check