### PR TITLE
feat(zuuli): round-trip article tags

### DIFF
--- a/wallet/zuuli/src/features/articles/components/ArticleTagInput.tsx
+++ b/wallet/zuuli/src/features/articles/components/ArticleTagInput.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useId, useMemo, useState } from "react";
+import { Loader2, X } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { articles } from "@/lib/api/free2z";
+import type { ArticleTagSuggestion } from "@/lib/api/types";
+import {
+  MAX_ARTICLE_TAG_LENGTH,
+  MAX_ARTICLE_TAGS,
+  validateArticleTag,
+} from "@/lib/article-tags";
+
+interface ArticleTagInputProps {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  disabled?: boolean;
+}
+
+export function ArticleTagInput({
+  value,
+  onChange,
+  disabled = false,
+}: ArticleTagInputProps) {
+  const listId = useId();
+  const helpId = useId();
+  const errorId = useId();
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [focused, setFocused] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [suggestions, setSuggestions] = useState<ArticleTagSuggestion[]>([]);
+  const valueKey = value.join("\u0000");
+  const full = value.length >= MAX_ARTICLE_TAGS;
+
+  useEffect(() => {
+    if (!focused || disabled || full) {
+      setLoading(false);
+      setSuggestions([]);
+      return;
+    }
+
+    let active = true;
+    const timer = window.setTimeout(() => {
+      setLoading(true);
+      void articles
+        .suggestTags(draft, value)
+        .then((next) => {
+          if (active) setSuggestions(next);
+        })
+        .catch(() => {
+          // The API boundary is already fail-soft, but retain that property if
+          // its implementation changes: authors can always enter a valid tag.
+          if (active) setSuggestions([]);
+        })
+        .finally(() => {
+          if (active) setLoading(false);
+        });
+    }, 150);
+
+    return () => {
+      active = false;
+      window.clearTimeout(timer);
+    };
+    // `valueKey` deliberately captures the selected set without retriggering
+    // for a new array containing the same tags.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disabled, draft, focused, full, valueKey]);
+
+  const describedBy = useMemo(
+    () => (error ? `${helpId} ${errorId}` : helpId),
+    [error, errorId, helpId],
+  );
+
+  function addTag(raw: string) {
+    if (full) {
+      setError(`Articles can have at most ${MAX_ARTICLE_TAGS} tags.`);
+      return;
+    }
+    const result = validateArticleTag(raw);
+    if (!result.tag || result.error) {
+      setError(result.error ?? "Enter a valid tag.");
+      return;
+    }
+    if (value.includes(result.tag)) {
+      setError("That tag is already added.");
+      return;
+    }
+    onChange([...value, result.tag]);
+    setDraft("");
+    setError(null);
+    setSuggestions([]);
+  }
+
+  function removeTag(tag: string) {
+    onChange(value.filter((candidate) => candidate !== tag));
+    setError(null);
+  }
+
+  const showSuggestions =
+    focused && !disabled && !full && suggestions.length > 0;
+
+  return (
+    <div
+      className="space-y-2"
+      onFocus={() => setFocused(true)}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget))
+          setFocused(false);
+      }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <Label htmlFor="art-tags">Tags</Label>
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {value.length}/{MAX_ARTICLE_TAGS}
+        </span>
+      </div>
+
+      {value.length > 0 ? (
+        <div
+          className="flex flex-wrap gap-2"
+          aria-label="Selected article tags"
+        >
+          {value.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => removeTag(tag)}
+              aria-label={`Remove tag ${tag}`}
+              disabled={disabled}
+              className="min-tap inline-flex max-w-full items-center gap-1.5 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-left text-xs font-medium text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+            >
+              <span className="min-w-0 break-words">#{tag}</span>
+              <X className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="relative">
+        <Input
+          id="art-tags"
+          value={draft}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setError(null);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === ",") {
+              event.preventDefault();
+              addTag(draft);
+            } else if (
+              event.key === "Backspace" &&
+              !draft &&
+              value.length > 0
+            ) {
+              removeTag(value[value.length - 1]);
+            } else if (event.key === "Escape") {
+              setFocused(false);
+              event.currentTarget.blur();
+            }
+          }}
+          placeholder={full ? "Maximum tags added" : "Add a topic"}
+          autoComplete="off"
+          maxLength={MAX_ARTICLE_TAG_LENGTH * 3}
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={showSuggestions}
+          aria-controls={showSuggestions ? listId : undefined}
+          aria-describedby={describedBy}
+          aria-invalid={Boolean(error)}
+          disabled={disabled || full}
+          className="pr-10"
+        />
+        {loading ? (
+          <Loader2
+            className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground"
+            aria-label="Loading tag suggestions"
+          />
+        ) : null}
+      </div>
+
+      {showSuggestions ? (
+        <div
+          id={listId}
+          role="listbox"
+          aria-label="Existing article tags"
+          className="overflow-hidden rounded-xl border border-border bg-card shadow-lg"
+        >
+          {suggestions.map((suggestion) => (
+            <button
+              key={suggestion.name}
+              type="button"
+              role="option"
+              aria-selected="false"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => addTag(suggestion.name)}
+              className="flex min-h-11 w-full items-center justify-between gap-3 border-b border-border px-3 py-2 text-left last:border-b-0 hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            >
+              <span className="min-w-0 break-words text-sm">
+                #{suggestion.name}
+              </span>
+              <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                {suggestion.count.toLocaleString()}
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <p id={helpId} className="text-xs text-muted-foreground">
+        Up to {MAX_ARTICLE_TAGS} topics. Press Enter or comma to add; names such
+        as C++ and zero knowledge are welcome.
+      </p>
+      {error ? (
+        <p id={errorId} role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/wallet/zuuli/src/features/articles/pages/Author.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Author.tsx
@@ -16,7 +16,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { EmptyState } from "@/components/common/EmptyState";
 import { Markdown } from "@/components/common/Markdown";
 import { PageHeader } from "@/components/common/PageHeader";
-import { articles } from "@/lib/api/free2z";
+import { ArticlePublishedHydrationError, articles } from "@/lib/api/free2z";
 import { useSession } from "@/store/session";
 import { cn } from "@/lib/utils";
 import { articleHref, readingMinutes, wordCount } from "../lib";
@@ -63,7 +63,12 @@ export function Author() {
       });
       toast.success("Published");
       navigate(articleHref(created));
-    } catch {
+    } catch (error) {
+      if (error instanceof ArticlePublishedHydrationError) {
+        toast.success("Published");
+        navigate(articleHref({ id: error.articleId, slug: undefined }));
+        return;
+      }
       toast.error("Couldn't publish. Please try again.");
       setPublishing(false);
     }

--- a/wallet/zuuli/src/features/articles/pages/Author.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Author.tsx
@@ -20,6 +20,7 @@ import { articles } from "@/lib/api/free2z";
 import { useSession } from "@/store/session";
 import { cn } from "@/lib/utils";
 import { articleHref, readingMinutes, wordCount } from "../lib";
+import { ArticleTagInput } from "../components/ArticleTagInput";
 
 const CATEGORIES = ["Zcash", "Technology", "Community", "Education"];
 
@@ -39,6 +40,7 @@ export function Author() {
   const [title, setTitle] = useState("");
   const [subtitle, setSubtitle] = useState("");
   const [category, setCategory] = useState<string>("");
+  const [tags, setTags] = useState<string[]>([]);
   const [content, setContent] = useState("");
   const [publishing, setPublishing] = useState(false);
 
@@ -57,6 +59,7 @@ export function Author() {
         subtitle: subtitle.trim() || undefined,
         content: content.trim(),
         category: category || undefined,
+        tags,
       });
       toast.success("Published");
       navigate(articleHref(created));
@@ -173,6 +176,12 @@ export function Author() {
             </DropdownMenu>
           </div>
 
+          <ArticleTagInput
+            value={tags}
+            onChange={setTags}
+            disabled={publishing}
+          />
+
           <div className="space-y-2">
             <Label htmlFor="art-content">Content (Markdown)</Label>
             <Textarea
@@ -200,6 +209,21 @@ export function Author() {
                 ) : null}
                 {subtitle ? (
                   <p className="text-lg text-muted-foreground">{subtitle}</p>
+                ) : null}
+                {tags.length > 0 ? (
+                  <div
+                    className="flex flex-wrap gap-2"
+                    aria-label="Article tags preview"
+                  >
+                    {tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="max-w-full break-words rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary"
+                      >
+                        #{tag}
+                      </span>
+                    ))}
+                  </div>
                 ) : null}
                 {content ? (
                   <Markdown>{content}</Markdown>

--- a/wallet/zuuli/src/features/articles/pages/Feed.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Feed.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { Loader2, Newspaper, PenLine, Search, Sparkles, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -7,6 +7,11 @@ import { EmptyState } from "@/components/common/EmptyState";
 import { PageHeader } from "@/components/common/PageHeader";
 import { useRouteScroll } from "@/hooks/useRouteScroll";
 import { cn } from "@/lib/utils";
+import {
+  MAX_ARTICLE_TAGS,
+  parseArticleTagsParam,
+  sanitizeArticleTags,
+} from "@/lib/article-tags";
 import type { ArticleSort } from "@/lib/api/types";
 import { ArticleCard, ArticleCardSkeleton } from "../components/ArticleCard";
 import { useArticleFeed } from "../useArticleFeed";
@@ -20,8 +25,12 @@ const SORTS: { value: ArticleSort; label: string }[] = [
 
 export function Feed() {
   const { viewport } = useRouteScroll();
+  const [params, setParams] = useSearchParams();
   const [sort, setSort] = useState<ArticleSort>("popular");
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const selectedTags = useMemo(
+    () => parseArticleTagsParam(params.get("tags")),
+    [params],
+  );
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
 
@@ -41,7 +50,9 @@ export function Feed() {
   useEffect(() => {
     setKnownTags((prev) => {
       const set = new Set(prev);
-      for (const a of items) for (const t of a.tags ?? []) set.add(t);
+      for (const article of items) {
+        for (const tag of sanitizeArticleTags(article.tags ?? [])) set.add(tag);
+      }
       for (const t of selectedTags) set.add(t);
       const merged = Array.from(set).sort();
       return merged.length === prev.length && merged.every((t, i) => t === prev[i])
@@ -50,10 +61,21 @@ export function Feed() {
     });
   }, [items, selectedTags]);
 
-  const toggleTag = (tag: string) =>
-    setSelectedTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+  function updateSelectedTags(tags: string[]) {
+    const canonical = sanitizeArticleTags(tags).slice(0, MAX_ARTICLE_TAGS);
+    const next = new URLSearchParams(params);
+    if (canonical.length > 0) next.set("tags", canonical.join(","));
+    else next.delete("tags");
+    setParams(next);
+  }
+
+  function toggleTag(tag: string) {
+    updateSelectedTags(
+      selectedTags.includes(tag)
+        ? selectedTags.filter((candidate) => candidate !== tag)
+        : [...selectedTags, tag],
     );
+  }
 
   // Infinite scroll: fire loadMore when the sentinel scrolls into view.
   const [sentinel, setSentinel] = useState<HTMLDivElement | null>(null);
@@ -185,7 +207,7 @@ export function Feed() {
           {selectedTags.length > 0 ? (
             <button
               type="button"
-              onClick={() => setSelectedTags([])}
+              onClick={() => updateSelectedTags([])}
               className="min-tap inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <X className="h-3 w-3" aria-hidden />
@@ -239,7 +261,7 @@ export function Feed() {
               <Button
                 variant="outline"
                 onClick={() => {
-                  setSelectedTags([]);
+                  updateSelectedTags([]);
                   setSearchInput("");
                 }}
               >

--- a/wallet/zuuli/src/features/articles/pages/Reader.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Reader.tsx
@@ -14,6 +14,7 @@ import { RemoteImage } from "@/components/common/RemoteMedia";
 import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { useAsync } from "@/hooks/useAsync";
 import { articles } from "@/lib/api/free2z";
+import { articleTagHref, sanitizeArticleTags } from "@/lib/article-tags";
 import { initials } from "@/lib/format";
 import {
   currentResourceData,
@@ -96,6 +97,7 @@ export function Reader() {
 
   const author = article.author;
   const name = author.display_name || author.username;
+  const tags = sanitizeArticleTags(article.tags ?? []);
 
   return (
     <article className="app-reader-content animate-slide-up w-full min-w-0 overflow-x-clip">
@@ -122,6 +124,19 @@ export function Reader() {
             <p className="break-words text-lg text-muted-foreground">
               {article.subtitle}
             </p>
+          ) : null}
+          {tags.length > 0 ? (
+            <nav className="flex flex-wrap gap-2" aria-label="Article tags">
+              {tags.map((tag) => (
+                <Link
+                  key={tag}
+                  to={articleTagHref(tag)}
+                  className="min-tap inline-flex max-w-full items-center rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <span className="min-w-0 break-words">#{tag}</span>
+                </Link>
+              ))}
+            </nav>
           ) : null}
 
           <div className="flex items-center gap-3 pt-2">

--- a/wallet/zuuli/src/lib/api/article-tags-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/article-tags-contract.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./http", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./http")>();
+  return { ...original, request: vi.fn() };
+});
+
+import { articles } from "./free2z";
+import { request } from "./http";
+
+const requestMock = vi.mocked(request);
+
+describe("article tag HTTP contract", () => {
+  beforeEach(() => requestMock.mockReset());
+
+  it("publishes canonical, deduplicated tags in the zpage body", async () => {
+    requestMock
+      // Documented create response (`zPageUpdate`) has no creator object.
+      .mockResolvedValueOnce({
+        free2zaddr: "article-id",
+        title: "Tagged",
+        content: "Body",
+        tags: ["zero knowledge", "privacy", "c++"],
+      })
+      .mockResolvedValueOnce({
+        free2zaddr: "article-id",
+        title: "Tagged",
+        content: "Body",
+        creator: { username: "alice" },
+        tags: ["Zero Knowledge", "privacy", "C++"],
+      });
+
+    await expect(
+      articles.publish({
+        title: "Tagged",
+        content: "Body",
+        tags: [" Zero Knowledge ", "PRIVACY", "privacy", "C++"],
+      }),
+    ).resolves.toMatchObject({
+      author: { username: "alice" },
+      tags: ["zero knowledge", "privacy", "c++"],
+    });
+
+    expect(requestMock).toHaveBeenCalledWith("/api/zpage/", {
+      method: "POST",
+      body: {
+        title: "Tagged",
+        description: "",
+        content: "Body",
+        category: "",
+        tags: ["zero knowledge", "privacy", "c++"],
+        is_published: true,
+      },
+    });
+    expect(requestMock).toHaveBeenCalledWith("/api/zpage/article-id/", {
+      anonymous: true,
+    });
+  });
+
+  it("uses the public zpage autocomplete contract", async () => {
+    requestMock.mockResolvedValue([
+      { name: "Privacy", count: 12 },
+      { name: "privacy", count: "11" },
+      { name: "C++", count: null },
+      { nope: true },
+      { name: "bad\u0000tag", count: 3 },
+    ]);
+    await expect(articles.suggestTags("pri", ["zcash"])).resolves.toEqual([
+      { name: "privacy", count: 12 },
+      { name: "c++", count: 0 },
+    ]);
+    expect(requestMock).toHaveBeenCalledWith("/api/tagging/autocomplete", {
+      query: {
+        query: "pri",
+        type: "zpage",
+        selected_tags: "zcash",
+        num_results: 10,
+      },
+      anonymous: true,
+    });
+  });
+
+  it("fails soft when optional autocomplete is unavailable or malformed", async () => {
+    requestMock.mockRejectedValueOnce(new Error("offline"));
+    await expect(articles.suggestTags("privacy")).resolves.toEqual([]);
+
+    requestMock.mockResolvedValueOnce({ results: [] });
+    await expect(articles.suggestTags("privacy")).resolves.toEqual([]);
+  });
+});

--- a/wallet/zuuli/src/lib/api/article-tags-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/article-tags-contract.test.ts
@@ -5,7 +5,7 @@ vi.mock("./http", async (importOriginal) => {
   return { ...original, request: vi.fn() };
 });
 
-import { articles } from "./free2z";
+import { ArticlePublishedHydrationError, articles } from "./free2z";
 import { request } from "./http";
 
 const requestMock = vi.mocked(request);
@@ -77,6 +77,36 @@ describe("article tag HTTP contract", () => {
         num_results: 10,
       },
       anonymous: true,
+    });
+  });
+
+  it("preserves a committed article id when canonical hydration is delayed", async () => {
+    requestMock
+      .mockResolvedValueOnce({ free2zaddr: "committed-article" })
+      .mockRejectedValueOnce(new Error("read-after-write delay"));
+
+    const error = await articles
+      .publish({ title: "Committed", content: "Body" })
+      .catch((reason: unknown) => reason);
+    expect(error).toBeInstanceOf(ArticlePublishedHydrationError);
+    expect(error).toMatchObject({
+      name: "ArticlePublishedHydrationError",
+      articleId: "committed-article",
+    });
+    expect(requestMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops a malformed backend tag field without breaking article hydration", async () => {
+    requestMock.mockResolvedValue({
+      free2zaddr: "article-id",
+      title: "Legacy",
+      content: "Body",
+      creator: { username: "alice" },
+      tags: "not-an-array",
+    });
+
+    await expect(articles.get("article-id")).resolves.toMatchObject({
+      tags: [],
     });
   });
 

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -8,6 +8,7 @@
 import { useMock } from "../platform";
 import { MOCK_OTP } from "../env";
 import { usdToTuzis } from "../format";
+import { normalizeArticleTags, sanitizeArticleTags } from "../article-tags";
 import {
   cancelMobileOAuth,
   captureOAuthCode,
@@ -61,6 +62,7 @@ import type {
   Article,
   ArticleFeedPage,
   ArticleFeedParams,
+  ArticleTagSuggestion,
   AuthUser,
   Comment,
   CommentContentType,
@@ -442,7 +444,7 @@ function mapArticle(z: RawZPage): Article {
     votes: z.f2z_score ? Math.round(Number(z.f2z_score)) : 0,
     published_at: z.publish_at || z.created_at,
     reading_minutes: readingMinutes(z.content),
-    tags: z.tags ?? [],
+    tags: sanitizeArticleTags(z.tags ?? []),
   };
 }
 
@@ -1411,22 +1413,126 @@ export const articles = {
     subtitle?: string;
     content: string;
     category?: string;
+    tags?: string[];
   }): Promise<Article> {
+    const tags = normalizeArticleTags(input.tags ?? []);
     if (useMock()) {
       await delay(500);
-      return { ...mockArticles[0], ...input, id: `${Date.now()}`, slug: undefined };
+      const timestamp = Date.now();
+      const author: SimpleCreator = {
+        username: mockUser.username,
+        free2zaddr: mockUser.free2zaddr ?? mockUser.username,
+        display_name: mockUser.display_name,
+        image: mockUser.image,
+        bio: mockUser.bio,
+        is_verified: mockUser.is_verified,
+        member_price: mockUser.member_price,
+      };
+      const created: Article = {
+        ...mockArticles[0],
+        ...input,
+        tags,
+        id: `${timestamp}`,
+        slug: undefined,
+        free2zaddr: `mock-${timestamp}`,
+        author,
+        published_at: new Date().toISOString(),
+      };
+      mockArticles.unshift(created);
+      return created;
     }
-    const z = await request<RawZPage>("/api/zpage/", {
+    const created = await request<unknown>("/api/zpage/", {
       method: "POST",
       body: {
         title: input.title,
         description: input.subtitle || "",
         content: input.content,
         category: input.category || "",
+        tags,
         is_published: true,
       },
     });
-    return mapArticle(z);
+    if (
+      !isRecord(created) ||
+      typeof created.free2zaddr !== "string" ||
+      !created.free2zaddr
+    ) {
+      throw new Error("Malformed published article identity.");
+    }
+
+    // POST uses zPageUpdateSerializer, whose documented response contains the
+    // saved tags but not the creator object required by `Article`. Retrieve the
+    // canonical detail so real mode returns the same complete shape as mock
+    // mode and proves the tags survived persistence rather than echoing input.
+    return articles.get(created.free2zaddr);
+  },
+
+  /** Existing public zpage tags, ordered by platform usage for autocomplete. */
+  async suggestTags(
+    query: string,
+    selected: string[] = [],
+  ): Promise<ArticleTagSuggestion[]> {
+    try {
+      const selectedTags = normalizeArticleTags(selected);
+      if (useMock()) {
+        await delay(80);
+        const counts = new Map<string, number>();
+        for (const article of mockArticles) {
+          for (const tag of sanitizeArticleTags(article.tags ?? [])) {
+            counts.set(tag, (counts.get(tag) ?? 0) + 1);
+          }
+        }
+        const needle = query
+          .normalize("NFKC")
+          .trim()
+          .toLocaleLowerCase("en-US");
+        return [...counts]
+          .filter(
+            ([name]) =>
+              !selectedTags.includes(name) &&
+              (!needle || name.includes(needle)),
+          )
+          .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+          .slice(0, 10)
+          .map(([name, count]) => ({ name, count }));
+      }
+      const response = await request<unknown>("/api/tagging/autocomplete", {
+        query: {
+          query: query.trim(),
+          type: "zpage",
+          selected_tags: selectedTags.join(","),
+          num_results: 10,
+        },
+        anonymous: true,
+      });
+      if (!Array.isArray(response)) return [];
+      return response
+        .flatMap((value): ArticleTagSuggestion[] => {
+          if (!isRecord(value) || typeof value.name !== "string") return [];
+          const [name] = sanitizeArticleTags([value.name]);
+          if (!name) return [];
+          const count = Number(value.count);
+          return [
+            {
+              name,
+              count: Number.isFinite(count)
+                ? Math.max(0, Math.round(count))
+                : 0,
+            },
+          ];
+        })
+        .filter(
+          (suggestion, index, all) =>
+            !selectedTags.includes(suggestion.name) &&
+            all.findIndex((candidate) => candidate.name === suggestion.name) ===
+              index,
+        )
+        .slice(0, 10);
+    } catch {
+      // Autocomplete is an optional authoring aid. Network/schema failures
+      // must never prevent a valid open-vocabulary tag from being entered.
+      return [];
+    }
   },
 };
 

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -444,7 +444,7 @@ function mapArticle(z: RawZPage): Article {
     votes: z.f2z_score ? Math.round(Number(z.f2z_score)) : 0,
     published_at: z.publish_at || z.created_at,
     reading_minutes: readingMinutes(z.content),
-    tags: sanitizeArticleTags(z.tags ?? []),
+    tags: sanitizeArticleTags(Array.isArray(z.tags) ? z.tags : []),
   };
 }
 
@@ -1464,7 +1464,14 @@ export const articles = {
     // saved tags but not the creator object required by `Article`. Retrieve the
     // canonical detail so real mode returns the same complete shape as mock
     // mode and proves the tags survived persistence rather than echoing input.
-    return articles.get(created.free2zaddr);
+    try {
+      return await articles.get(created.free2zaddr);
+    } catch {
+      // The mutation is already committed. Preserve that success boundary so
+      // the composer can navigate to the canonical id and let the reader retry
+      // hydration instead of inviting a second POST and a duplicate article.
+      throw new ArticlePublishedHydrationError(created.free2zaddr);
+    }
   },
 
   /** Existing public zpage tags, ordered by platform usage for autocomplete. */
@@ -1535,6 +1542,16 @@ export const articles = {
     }
   },
 };
+
+export class ArticlePublishedHydrationError extends Error {
+  readonly articleId: string;
+
+  constructor(articleId: string) {
+    super("Article published, but its canonical detail is not available yet.");
+    this.name = "ArticlePublishedHydrationError";
+    this.articleId = articleId;
+  }
+}
 
 // ─── Comments (threaded, on zpages) ──────────────────────────────────────────
 

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -324,6 +324,11 @@ export interface ArticleFeedParams {
   pageSize?: number;
 }
 
+export interface ArticleTagSuggestion {
+  name: string;
+  count: number;
+}
+
 /**
  * One page of the article feed. `next` is the next page number to request, or
  * `null` at the end of the corpus — so infinite scroll never needs the raw

--- a/wallet/zuuli/src/lib/article-tags.test.ts
+++ b/wallet/zuuli/src/lib/article-tags.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  articleTagHref,
+  MAX_ARTICLE_TAG_LENGTH,
+  MAX_ARTICLE_TAGS,
+  normalizeArticleTags,
+  parseArticleTagsParam,
+  sanitizeArticleTags,
+  validateArticleTag,
+} from "./article-tags";
+
+describe("article tag contract", () => {
+  it("normalizes tag syntax and deduplicates case variants", () => {
+    expect(
+      normalizeArticleTags([" #Zero   Knowledge ", "PRIVACY", "privacy"]),
+    ).toEqual(["zero knowledge", "privacy"]);
+  });
+
+  it("supports an open vocabulary while reserving the query delimiter", () => {
+    expect(
+      normalizeArticleTags([
+        "C++",
+        "privacy & policy",
+        "零知识",
+        "🛡️ shielded",
+      ]),
+    ).toEqual(["c++", "privacy & policy", "零知识", "🛡️ shielded"]);
+    expect(validateArticleTag("privacy,security").error).toMatch(/commas/);
+    expect(validateArticleTag("privacy\u0000").error).toMatch(/control/);
+  });
+
+  it("rejects overlong tags and an oversized publish set", () => {
+    expect(
+      validateArticleTag("x".repeat(MAX_ARTICLE_TAG_LENGTH + 1)).error,
+    ).toMatch(/characters/);
+    expect(() =>
+      normalizeArticleTags(
+        Array.from(
+          { length: MAX_ARTICLE_TAGS + 1 },
+          (_, index) => `tag-${index}`,
+        ),
+      ),
+    ).toThrow(/at most/);
+  });
+
+  it("fails soft for malformed share URLs and emits canonical links", () => {
+    expect(
+      parseArticleTagsParam(" Privacy,bad\u0000tag,privacy,zero knowledge "),
+    ).toEqual(["privacy", "zero knowledge"]);
+    expect(sanitizeArticleTags(["Privacy", null, 42, "bad\u0000tag"])).toEqual([
+      "privacy",
+    ]);
+    expect(articleTagHref("Zero Knowledge")).toBe(
+      "/articles?tags=zero%20knowledge",
+    );
+  });
+});

--- a/wallet/zuuli/src/lib/article-tags.ts
+++ b/wallet/zuuli/src/lib/article-tags.ts
@@ -1,0 +1,83 @@
+export const MAX_ARTICLE_TAGS = 8;
+export const MAX_ARTICLE_TAG_LENGTH = 32;
+
+const TAG_CONTROL_PATTERN = /[\p{Cc}\p{Cf}]/u;
+
+export interface ArticleTagValidation {
+  tag: string | null;
+  error: string | null;
+}
+
+/**
+ * Canonicalize one user-entered topic.
+ *
+ * free2z tags are an open vocabulary, so punctuation, spaces, emoji, and
+ * non-Latin scripts are all meaningful (`c++`, `privacy & policy`, `零知识`).
+ * Commas remain reserved for the backend's multi-tag query parameter, and
+ * invisible control/format characters are never useful topic content.
+ */
+export function validateArticleTag(raw: string): ArticleTagValidation {
+  const tag = raw
+    .normalize("NFKC")
+    .trim()
+    .replace(/^#+/, "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLocaleLowerCase("en-US");
+
+  if (!tag) return { tag: null, error: "Enter a tag first." };
+  if (Array.from(tag).length > MAX_ARTICLE_TAG_LENGTH) {
+    return {
+      tag: null,
+      error: `Tags must be ${MAX_ARTICLE_TAG_LENGTH} characters or fewer.`,
+    };
+  }
+  if (tag.includes(",") || TAG_CONTROL_PATTERN.test(tag)) {
+    return {
+      tag: null,
+      error: "Tags cannot contain commas or invisible control characters.",
+    };
+  }
+  return { tag, error: null };
+}
+
+/** Validate, normalize, deduplicate, and bound a publish payload. */
+export function normalizeArticleTags(values: string[]): string[] {
+  const tags: string[] = [];
+  for (const value of values) {
+    const result = validateArticleTag(value);
+    if (!result.tag || result.error) {
+      throw new Error(result.error ?? "Invalid article tag.");
+    }
+    if (!tags.includes(result.tag)) tags.push(result.tag);
+  }
+  if (tags.length > MAX_ARTICLE_TAGS) {
+    throw new Error(`Articles can have at most ${MAX_ARTICLE_TAGS} tags.`);
+  }
+  return tags;
+}
+
+/**
+ * Normalize untrusted tags for display/filtering without letting one legacy
+ * or malformed backend value break an otherwise valid article.
+ */
+export function sanitizeArticleTags(values: readonly unknown[]): string[] {
+  const tags: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const { tag, error } = validateArticleTag(value);
+    if (tag && !error && !tags.includes(tag)) tags.push(tag);
+  }
+  return tags;
+}
+
+/** Parse an untrusted shareable filter without letting a malformed URL break the feed. */
+export function parseArticleTagsParam(value: string | null): string[] {
+  if (!value) return [];
+  return sanitizeArticleTags(value.split(",")).slice(0, MAX_ARTICLE_TAGS);
+}
+
+export function articleTagHref(tag: string): string {
+  const [normalized] = normalizeArticleTags([tag]);
+  return `/articles?tags=${encodeURIComponent(normalized)}`;
+}

--- a/wallet/zuuli/tests/article-tags.pw.ts
+++ b/wallet/zuuli/tests/article-tags.pw.ts
@@ -1,0 +1,88 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function useSignedInSession(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+  });
+}
+
+test("authored tags autocomplete and round-trip into reader filter links", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 760 });
+  await useSignedInSession(page);
+  await page.goto("/articles/new");
+
+  await page
+    .getByRole("textbox", { name: "Title", exact: true })
+    .fill("Open vocabulary tag round-trip");
+  await page
+    .getByLabel("Content (Markdown)")
+    .fill("# Tagged end to end\n\nA deterministic mock publication.");
+
+  const tagInput = page.getByRole("combobox", { name: "Tags" });
+  await tagInput.focus();
+  await expect(page.getByRole("option", { name: /#privacy/ })).toBeVisible();
+  await page.getByRole("option", { name: /#privacy/ }).click();
+  await expect(
+    page.getByRole("button", { name: "Remove tag privacy" }),
+  ).toBeVisible();
+
+  await tagInput.fill("C++");
+  await tagInput.press("Enter");
+  await expect(
+    page.getByRole("button", { name: "Remove tag c++" }),
+  ).toBeVisible();
+
+  await tagInput.fill("PRIVACY");
+  await tagInput.press("Enter");
+  await expect(page.getByRole("alert")).toHaveText(
+    "That tag is already added.",
+  );
+  await tagInput.fill("");
+
+  await page.getByRole("button", { name: "Publish" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Open vocabulary tag round-trip" }),
+  ).toBeVisible();
+
+  const privacy = page.getByRole("link", { name: "#privacy" });
+  const cpp = page.getByRole("link", { name: "#c++" });
+  await expect(privacy).toBeVisible();
+  await expect(cpp).toBeVisible();
+
+  await cpp.click();
+  await expect(page).toHaveURL(/\/articles\?tags=c%2B%2B$/);
+  await expect(
+    page.getByRole("heading", { name: "Open vocabulary tag round-trip" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("1 article tagged c++", { exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "privacy" }).click();
+  expect(new URL(page.url()).searchParams.get("tags")).toBe("c++,privacy");
+  await expect(
+    page.getByText("1 article tagged c++ + privacy", { exact: true }),
+  ).toBeVisible();
+});
+
+test("a direct multi-tag Articles URL remains filtered across reload", async ({
+  page,
+}) => {
+  await page.goto("/articles?tags=Privacy,zcash");
+
+  const resultCount = page.locator("p.tabular-nums").filter({
+    hasText: "tagged privacy + zcash",
+  });
+  await expect(resultCount).toBeVisible();
+  const expected = await resultCount.textContent();
+  await expect(page.locator("[data-article-card]").first()).toBeVisible();
+
+  await page.reload();
+  await expect(resultCount).toHaveText(expected ?? "");
+  expect(new URL(page.url()).searchParams.get("tags")).toBe("Privacy,zcash");
+
+  await page.getByRole("button", { name: "Clear tags" }).click();
+  expect(new URL(page.url()).searchParams.has("tags")).toBe(false);
+});


### PR DESCRIPTION
Closes #250

## What changed
- add accessible, debounced existing-tag autocomplete and validated open-vocabulary tag entry to the article composer
- normalize, deduplicate, bound, and persist up to eight tags through both real and mock publishing
- retrieve the canonical real article after publish so tags and creator data genuinely round-trip
- render reader tag links into URL-backed, shareable AND filters while preserving unrelated query parameters
- sanitize malformed legacy/backend/share tag values without breaking otherwise valid articles

## Verification
- typecheck
- production build
- Vitest: 626 passed, 5 skipped
- focused article-tag unit/API contracts: 7/7 after rebase onto current main
- focused article-tag Playwright: 2/2 at mobile width after rebase
- touch-target audit: 4/4
- UI-copy policy: 2/2
- formatting and git diff checks