### PR TITLE
fix(markdown): preserve image hover titles

### DIFF
--- a/.github/workflows/ts-react-free2z.yml
+++ b/.github/workflows/ts-react-free2z.yml
@@ -22,9 +22,9 @@ jobs:
         working-directory: ts/react/free2z
         run: npm install
 
-      # - name: Run tests
-      #   working-directory: ts/react/free2z
-      #   run: npm test
+      - name: Run tests
+        working-directory: ts/react/free2z
+        run: npm test -- --watchAll=false
 
       - name: Build the project
         working-directory: ts/react/free2z

--- a/ts/react/free2z/src/components/CustomImage.test.tsx
+++ b/ts/react/free2z/src/components/CustomImage.test.tsx
@@ -1,0 +1,22 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+
+import CustomImage from "./CustomImage";
+
+describe("CustomImage", () => {
+    it("preserves Markdown hover text on the inline and lightbox images", () => {
+        const { container } = render(
+            <CustomImage
+                src="/example.jpg"
+                alt="Alternative text"
+                title="Alternative title"
+            />
+        );
+
+        const images = container.querySelectorAll("img");
+        expect(images).toHaveLength(2);
+        images.forEach((image) => {
+            expect(image).toHaveAttribute("title", "Alternative title");
+        });
+    });
+});

--- a/ts/react/free2z/src/components/CustomImage.tsx
+++ b/ts/react/free2z/src/components/CustomImage.tsx
@@ -23,10 +23,11 @@ const captionStyle = {
 interface LightboxImageProps {
     src?: string
     alt?: string
+    title?: string
     hideCaption?: boolean
 }
 
-function LightboxImage({ src, alt, hideCaption }: LightboxImageProps) {
+function LightboxImage({ src, alt, title, hideCaption }: LightboxImageProps) {
     const [open, setOpen] = useState(false);
     const theme = useTheme();
     const contentElementRef = useRef<HTMLDivElement>(null);
@@ -79,6 +80,7 @@ function LightboxImage({ src, alt, hideCaption }: LightboxImageProps) {
                     <img
                         src={src}
                         alt={alt}
+                        title={title}
                         onClick={handleClickOpen}
                         style={imgStyle}
                     />
@@ -106,6 +108,7 @@ function LightboxImage({ src, alt, hideCaption }: LightboxImageProps) {
                     <img
                         src={src}
                         alt={alt}
+                        title={title}
                         style={lightboxImgStyle}
                     />
                     <Typography variant="caption" style={captionStyle}>{alt}</Typography>


### PR DESCRIPTION
## Summary
- forward Markdown image title text to the inline image and lightbox image
- add a focused renderer regression covering both image elements
- run the classic React test suite in CI

## Verification
- npm test -- --watchAll=false
- CI=false npm run build
- actionlint .github/workflows/ts-react-free2z.yml
- git diff --check

Closes #9