### PR TITLE
fix(converse): prevent async embed scroll jumps

### DIFF
--- a/ts/react/free2z/src/ConverseList.css
+++ b/ts/react/free2z/src/ConverseList.css
@@ -1,0 +1,4 @@
+.converse-feed {
+  /* Virtuoso remeasures async embeds; native anchoring would move the window too. */
+  overflow-anchor: none;
+}

--- a/ts/react/free2z/src/ConverseList.test.tsx
+++ b/ts/react/free2z/src/ConverseList.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { VirtuosoMockContext } from "react-virtuoso";
@@ -74,6 +75,14 @@ jest.mock("./components/CommentCardInfinite", () => {
       </article>
     );
   };
+});
+
+test("disables native scroll anchoring at the Converse feed boundary", () => {
+  const css = readFileSync(`${__dirname}/ConverseList.css`, "utf8");
+
+  expect(css).toMatch(
+    /\.converse-feed\s*\{[^}]*overflow-anchor\s*:\s*none\s*;?[^}]*\}/
+  );
 });
 
 test("keeps async embed resizes from selecting a native scroll anchor in the virtual feed", async () => {

--- a/ts/react/free2z/src/ConverseList.test.tsx
+++ b/ts/react/free2z/src/ConverseList.test.tsx
@@ -1,0 +1,107 @@
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { VirtuosoMockContext } from "react-virtuoso";
+
+import ConverseList from "./ConverseList";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock("react-query", () => ({
+  useInfiniteQuery: () => ({
+    data: {
+      pages: [
+        {
+          count: 1,
+          next: null,
+          previous: null,
+          results: [
+            {
+              uuid: "async-embed-comment",
+              author: { username: "alice" },
+              parent: null,
+              headline: "An asynchronously sized embed",
+              content: "::embed[https://example.com/video]",
+              tuzis: 0,
+              created_at: "2026-08-23T00:00:00Z",
+              updated_at: "2026-08-23T00:00:00Z",
+              num_children: 0,
+              content_url: null,
+            },
+          ],
+        },
+      ],
+    },
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+  }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useLocation: () => ({ pathname: "/converse" }),
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock("react-helmet-async", () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("./components/ConverseListFilters", () => ({
+  ConverseListFilters: () => <div>Search filters</div>,
+}));
+
+jest.mock("./components/CommentCardInfinite", () => {
+  const React = require("react");
+
+  return function AsyncEmbedComment() {
+    const [loaded, setLoaded] = React.useState(false);
+
+    React.useEffect(() => {
+      const timeout = globalThis.setTimeout(() => setLoaded(true), 10);
+      return () => globalThis.clearTimeout(timeout);
+    }, []);
+
+    return (
+      <article
+        data-testid="async-embed"
+        style={{ height: loaded ? "500px" : "20px" }}
+      >
+        {loaded ? "Embed loaded" : "Loading embed"}
+      </article>
+    );
+  };
+});
+
+test("keeps async embed resizes from selecting a native scroll anchor in the virtual feed", async () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <VirtuosoMockContext.Provider
+        value={{ viewportHeight: 600, itemHeight: 20 }}
+      >
+        <ConverseList />
+      </VirtuosoMockContext.Provider>
+    );
+  });
+
+  const feed = container.querySelector(".converse-feed");
+  expect(feed).not.toBeNull();
+
+  await act(async () => {
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
+  });
+  expect(
+    container.querySelector('[data-testid="async-embed"]')?.textContent
+  ).toBe("Embed loaded");
+  expect(container.querySelector(".converse-feed")).toBe(feed);
+
+  await act(async () => root.unmount());
+  container.remove();
+});

--- a/ts/react/free2z/src/ConverseList.tsx
+++ b/ts/react/free2z/src/ConverseList.tsx
@@ -14,6 +14,8 @@ import { QueryFunctionContext, useInfiniteQuery } from 'react-query';
 import { CommentData } from './components/DisplayThreadedComments';
 import { Helmet } from 'react-helmet-async';
 
+import './ConverseList.css';
+
 
 type CommentPageData = {
     count: number;
@@ -289,6 +291,7 @@ export default function ConverseList() {
                     {data && (
                         <Virtuoso
                             ref={virtuosoRef}
+                            className="converse-feed"
                             data={flattenedData}
                             itemContent={(index, item) => <CommentCard comment={item} key={item.uuid} />}
                             endReached={handleEndReached}


### PR DESCRIPTION
Closes #137

## What changed
- exclude the window-scrolled Converse virtual feed from native browser scroll anchoring
- keep React Virtuoso responsible for measuring asynchronously resized cards without a second browser-level `window.scrollY` adjustment
- add a focused regression that renders the real Virtuoso boundary while an embed-sized card expands asynchronously

## Why
When an embed above Chrome’s selected scroll anchor grows after loading, native scroll anchoring advances the document scroll position. Because Converse uses `useWindowScroll` underneath a fixed search/filter panel, that compensation moves the feed beneath the panel. `overflow-anchor: none` at the feed boundary prevents the competing browser adjustment while preserving Virtuoso measurement and user scrolling.

## Verification
- `CI=true npm test -- --watchAll=false --runInBand src/ConverseList.test.tsx`
- `CI=false npm run build`
- `npx prettier --check src/ConverseList.test.tsx src/ConverseList.css`
- `git diff --check`
- headless Chromium reproduction: delayed 500px content growth changed `scrollY` 300 → 800 before the boundary; it remained 300 → 300 with the boundary