### PR TITLE
release(zuuli): prepare internal build 0.1.0+14

### DIFF
--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.zuuli",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 13,
+  "build": 14,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "13").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "14").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "13"
+        CFBundleVersion: "14"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -34,14 +34,14 @@
       "icons/icon.ico"
     ],
     "iOS": {
-      "bundleVersion": "13",
+      "bundleVersion": "14",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 13
+      "versionCode": 14
     }
   },
   "plugins": {


### PR DESCRIPTION
> **Merging this PR triggers a real store upload.** A push to `main` that
> changes an existing `release.json` pins the pushed SHA, proves `build`
> strictly increased and `version` did not decrease, then builds, signs, and
> **uploads to TestFlight and Play internal**. This is not a dry run.

Bumps the ZUULI release identity to **`0.1.0+14`**, keeping the marketing
version at `0.1.0`. Builds 12 and 13 both shipped successfully to TestFlight
and Play internal.

## Commits since build 13 (`db1d880`)

`git log --oneline db1d880..origin/main`

```
c0120a3 feat(zuuli): round-trip article tags (#500)
2e7b06f fix(markdown): preserve image hover titles (#501)
9267a41 test(release): lock index source binding (#491)
83cd608 fix(release): catch multiline and semicolon Apple assertions (#498)
12d3151 fix(zuuli): separate AI context switches (#499)
```

- **#500** — article tags now round-trip through the editor/API path.
- **#501** — markdown images keep their hover `title` text.
- **#491** — adds a test locking the release-index-to-source binding.
- **#498** — hardens the Apple credential-boundary guard so multiline and
  semicolon-joined assertions can no longer slip past it.
- **#499** — AI context switches are kept separate from one another.

Two of the five (#491, #498) harden the release path itself; the other three
are product fixes.

## Version bump

Produced solely by:

```
npm run release:bump -- --version=0.1.0 --build=14
```

```
updated ZUULI release identity to 0.1.0+14
review the diff and run npm run release:verify before committing
```

Diff is exactly 5 files / 6 lines, version-identity only — nothing else was
touched:

```
 wallet/zuuli/release.json                               | 2 +-
 wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts | 2 +-
 wallet/zuuli/src-tauri/gen/apple/project.yml            | 2 +-
 wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist   | 2 +-
 wallet/zuuli/src-tauri/tauri.conf.json                  | 4 ++--
 5 files changed, 6 insertions(+), 6 deletions(-)
```

`release.json` `build` 13 → 14; `tauri.conf.json` iOS `bundleVersion` `"13"` →
`"14"` and Android `versionCode` `13` → `14`; `project.yml` `CFBundleVersion`
`"13"` → `"14"`; `Info.plist` `CFBundleVersion` `13` → `14`;
`build.gradle.kts` `versionCode` default `"13"` → `"14"`.

## `npm run release:verify` (exit 0)

```
> zuuli@0.1.0 release:verify
> node scripts/release-identity.mjs

{"applicationId":"cash.free2z.zuuli","version":"0.1.0","build":14,"identity":"0.1.0+14","tag":"zuuli-v0.1.0+14"}
```

Identity `0.1.0+14`, tag `zuuli-v0.1.0+14`.

## Release-path verification

Several PRs touched the release path since build 13, so it was re-checked
against this commit rather than assumed.

**iOS archive resolution** — `wallet/zuuli/scripts/resolve-ios-xcarchive.sh`
exists (mode 0755) and is referenced by both workflows:

```
.github/workflows/zuuli-packaging.yml:264:        run: scripts/resolve-ios-xcarchive.sh
.github/workflows/zuuli-release.yml:397:          archive=$(scripts/resolve-ios-xcarchive.sh)
```

**Release index / tag verifiers** — both exist (mode 0755) and are reachable
from `zuuli-release.yml`:

```
.github/workflows/zuuli-release.yml:1430:  wallet/zuuli/scripts/verify-release-index.sh release-downloads "$RELEASE_IDENTITY" "$EXPECTED_SOURCE_SHA"
.github/workflows/zuuli-release.yml:1438:  wallet/zuuli/scripts/publish-github-release.sh "$RELEASE_TAG" "$RELEASE_IDENTITY" "$RELEASE_SOURCE_SHA" release-downloads
wallet/zuuli/scripts/publish-github-release.sh:21:  "$script_dir/verify-release-tag.sh" "$tag" "$expected_commit" "$tag_identity"
wallet/zuuli/scripts/publish-github-release.sh:24:  "$script_dir/verify-release-tag.sh" "$tag" "$expected_commit" "$verification_copy"
```

`verify-release-tag.sh` is invoked one hop deeper, from
`publish-github-release.sh` — as expected.

**Android deep-link manifest** —
`src-tauri/gen/android/app/src/main/AndroidManifest.xml`:

| Check | Expected | Actual |
|---|---|---|
| `DEEP LINK PLUGIN` markers | 2 | **2** (lines 33, 60) |
| `android:host="oauth"` | 1 | **1** (line 41) |
| `android:host="checkout"` | 1 | **1** (line 54) |

**Workflow shell hardening (new since build 13)** —
`.github/workflows/zuuli-release.yml` contains **no bare `[[ ]]` statement
lines**. 73 `[[` occurrences total; 53 are guarded
`[[ … ]] || { echo …; exit 1; }` lines and the rest sit inside
`if`/`elif`/`while` conditions. The only non-guarded, non-conditional hits are
five false positives: two comment lines (395–396, explaining that bash 3.2 on
macOS runners does not apply `set -e` to a failing bare `[[ ]]`) and three
`[[:space:]]` POSIX character classes inside `sed` expressions (512, 1091,
1180).

`node scripts/apple-credential-boundary.mjs` → exit **0**:

```
Apple release build, credential, and finalization boundaries verified.
```

**`npm run typecheck`** (`tsc --noEmit`) → exit **0**, no diagnostics.

## Notes

- `STATUS.md` is deliberately untouched. The PR that would make promotion fail
  closed on a stale `STATUS.md` is unmerged pending the owner's decision, so
  the current staleness does not block this build. Advancing that marker
  without re-running production evidence would make the document assert
  something nobody verified.
- `scripts/assert-no-apple-credentials.sh` was not run: it is a runner-
  environment canary about the current machine, not about this commit.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
