### PR TITLE
fix(zpages): preview first body image in cards

### DIFF
--- a/ts/react/free2z/config-overrides.js
+++ b/ts/react/free2z/config-overrides.js
@@ -27,3 +27,20 @@ module.exports = function override(config, env) {
     return config
 }
 
+module.exports.jest = function overrideJest(config) {
+    // The production Markdown stack is ESM-only. Transform it in Jest so card
+    // image tests execute the same parser instead of a mock or parallel parser.
+    const parserTransformPattern =
+        "node_modules/(?!(?:bail|character-entities|decode-named-character-reference|devlop|is-plain-obj|mdast-util-[^/]+|micromark(?:-[^/]*)?|remark-parse|trough|unified|unist-util-[^/]+|vfile(?:-message)?)/)"
+    config.transformIgnorePatterns = config.transformIgnorePatterns.map(
+        (pattern) =>
+            pattern.includes("node_modules") ? parserTransformPattern : pattern
+    )
+    config.moduleNameMapper = {
+        ...config.moduleNameMapper,
+        "^#minpath$": "<rootDir>/node_modules/vfile/lib/minpath.js",
+        "^#minproc$": "<rootDir>/node_modules/vfile/lib/minproc.js",
+        "^#minurl$": "<rootDir>/node_modules/vfile/lib/minurl.js",
+    }
+    return config
+}

--- a/ts/react/free2z/package-lock.json
+++ b/ts/react/free2z/package-lock.json
@@ -81,6 +81,7 @@
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "remark-oembed": "^1.2.2",
+        "remark-parse": "^11.0.0",
         "slugify": "^1.6.6",
         "swiper": "^9.4.1",
         "three": "^0.168.0",

--- a/ts/react/free2z/package.json
+++ b/ts/react/free2z/package.json
@@ -76,6 +76,7 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "remark-oembed": "^1.2.2",
+    "remark-parse": "^11.0.0",
     "slugify": "^1.6.6",
     "swiper": "^9.4.1",
     "three": "^0.168.0",

--- a/ts/react/free2z/src/components/PageListRow2.test.tsx
+++ b/ts/react/free2z/src/components/PageListRow2.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+
+import PageListRow from "./PageListRow2";
+
+jest.mock("@mui/icons-material", () => ({
+  Edit: () => null,
+  MoreVert: () => null,
+}));
+
+jest.mock("@mui/material", () => {
+  const React = require("react");
+  const Wrapper = ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  const CardMedia = React.forwardRef(
+    (
+      {
+        image,
+        style,
+        title,
+      }: { image: string; style: { opacity: number }; title: string },
+      ref: React.ForwardedRef<HTMLDivElement>
+    ) => (
+      <div
+        ref={ref}
+        data-testid="page-card-image"
+        data-image={image}
+        data-opacity={style.opacity}
+        title={title}
+      />
+    )
+  );
+  CardMedia.displayName = "CardMedia";
+
+  return {
+    Avatar: Wrapper,
+    Box: Wrapper,
+    Card: Wrapper,
+    CardContent: Wrapper,
+    CardHeader: Wrapper,
+    CardMedia,
+    Divider: Wrapper,
+    Grid: Wrapper,
+    IconButton: Wrapper,
+    Link: Wrapper,
+    ListItem: Wrapper,
+    Popover: Wrapper,
+    Stack: Wrapper,
+    Tooltip: Wrapper,
+    Typography: Wrapper,
+    useMediaQuery: () => false,
+  };
+});
+
+jest.mock("moment", () => () => ({ fromNow: () => "now" }));
+jest.mock("../state/global", () => ({
+  useGlobalState: () => [{ username: "viewer", stars: [] }, jest.fn()],
+}));
+jest.mock("../hooks/useTransitionNavigate", () => ({
+  useTransitionNavigate: () => jest.fn(),
+}));
+jest.mock("./CreatorDonate", () => () => null);
+jest.mock("./UpDownPage", () => () => null);
+jest.mock("./TransitionLink", () => () => null);
+jest.mock("./profile/CreatorSupport", () => () => null);
+
+const page = {
+  creator: {
+    username: "alice",
+    is_verified: false,
+    total: 0,
+    full_name: "Alice",
+    description: "",
+    p2paddr: "creator-address",
+    zpages: 1,
+    member_price: "",
+    can_stream: false,
+    avatar_image: null,
+    banner_image: null,
+  },
+  get_url: "/alice/article",
+  vanity: "article",
+  title: "Article",
+  content: "![Body](/uploads/body.jpg)",
+  description: "",
+  tags: [],
+  free2zaddr: "article-id",
+  p2paddr: "address",
+  featured_image: {
+    name: "featured.jpg",
+    title: "Featured",
+    access: "public" as const,
+    thumbnail: "/uploads/featured.jpg",
+  },
+  is_verified: false,
+  is_published: true,
+  is_subscriber_only: false,
+  total: "0",
+  f2z_score: "0",
+  created_at: "2026-08-23T00:00:00Z",
+  updated_at: "2026-08-23T00:00:00Z",
+  comments: [],
+};
+
+test("uses the selected card image and fallback opacity in the classic card", () => {
+  const { rerender } = render(<PageListRow {...page} mine={false} />);
+  expect(screen.getByTestId("page-card-image").getAttribute("data-image")).toBe(
+    "/uploads/featured.jpg"
+  );
+  expect(
+    screen.getByTestId("page-card-image").getAttribute("data-opacity")
+  ).toBe("1");
+
+  rerender(<PageListRow {...page} featured_image={null} mine={false} />);
+  expect(screen.getByTestId("page-card-image").getAttribute("data-image")).toBe(
+    "/uploads/body.jpg"
+  );
+  expect(
+    screen.getByTestId("page-card-image").getAttribute("data-opacity")
+  ).toBe("1");
+
+  rerender(
+    <PageListRow
+      {...page}
+      content="Text only"
+      featured_image={null}
+      mine={false}
+    />
+  );
+  expect(screen.getByTestId("page-card-image").getAttribute("data-image")).toBe(
+    "/docs/img/tuzi.svg"
+  );
+  expect(
+    screen.getByTestId("page-card-image").getAttribute("data-opacity")
+  ).toBe("0.25");
+});

--- a/ts/react/free2z/src/components/PageListRow2.tsx
+++ b/ts/react/free2z/src/components/PageListRow2.tsx
@@ -5,7 +5,7 @@ import {
     Popover, Divider, Tooltip, Box,
 } from "@mui/material";
 import moment from "moment";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import CreatorDonate from "./CreatorDonate";
 import { PageInterface } from "./PageRenderer";
 import UpDownPage from "./UpDownPage";
@@ -13,6 +13,7 @@ import { useGlobalState } from "../state/global";
 import TransitionLink from "./TransitionLink";
 import { useTransitionNavigate } from "../hooks/useTransitionNavigate";
 import CreatorSupport from "./profile/CreatorSupport";
+import { getPageCardImage } from "../lib/page-card-image";
 
 
 export interface PageListRowProps extends PageInterface {
@@ -27,6 +28,10 @@ export default function PageListRow(page: PageListRowProps) {
     const isSmallerScreen = useMediaQuery('(max-width: 800px)');
     const [user, setUser] = useGlobalState("creator")
     const navigate = useTransitionNavigate()
+    const cardImage = useMemo(
+        () => getPageCardImage(page.featured_image?.thumbnail, page.content),
+        [page.featured_image?.thumbnail, page.content],
+    )
 
     useEffect(() => {
         function updateCardContentHeight() {
@@ -52,7 +57,6 @@ export default function PageListRow(page: PageListRowProps) {
     }
 
     const isSubbed = user.stars.indexOf(page.creator.username) !== -1
-
     return (
         <Card
             sx={{
@@ -323,9 +327,9 @@ export default function PageListRow(page: PageListRowProps) {
                             height: 0,
                             paddingTop: '56.25%',  // 16:9
                             marginRight: "0.5em",
-                            opacity: page.featured_image ? 1 : 0.25,
+                            opacity: cardImage.source === "fallback" ? 0.25 : 1,
                         }}
-                        image={page.featured_image?.thumbnail || "/docs/img/tuzi.svg"}
+                        image={cardImage.url}
                         title={page.title}
                     />
                     {/* </Suspense> */}

--- a/ts/react/free2z/src/lib/page-card-image.test.ts
+++ b/ts/react/free2z/src/lib/page-card-image.test.ts
@@ -1,0 +1,80 @@
+import { extractFirstArticleImage, getPageCardImage } from "./page-card-image";
+
+describe("extractFirstArticleImage", () => {
+  it("returns the first rendered Markdown image", () => {
+    const content = [
+      "`![not an image](https://example.com/code.jpg)`",
+      '![First](https://images.example.com/first_(large).jpg "A title")',
+      "![Second](/uploads/second.jpg)",
+    ].join("\n\n");
+
+    expect(extractFirstArticleImage(content)).toBe(
+      "https://images.example.com/first_(large).jpg"
+    );
+  });
+
+  it("ignores images in comments and fenced code", () => {
+    const content = [
+      "<!-- ![Comment](/uploads/comment.jpg) -->",
+      "~~~markdown",
+      "![Code](/uploads/code.jpg)",
+      "~~~",
+      "![Visible](/uploads/visible.jpg)",
+    ].join("\n");
+
+    expect(extractFirstArticleImage(content)).toBe("/uploads/visible.jpg");
+  });
+
+  it("resolves reference-style body images", () => {
+    const content = [
+      "![Article photograph][hero]",
+      "",
+      "[hero]: /uploads/article-hero.webp",
+    ].join("\n");
+
+    expect(extractFirstArticleImage(content)).toBe(
+      "/uploads/article-hero.webp"
+    );
+  });
+
+  it("skips unsafe image URLs and can use a later safe image", () => {
+    const content = [
+      "![Unsafe](javascript:alert(1))",
+      "![Safe](../uploads/safe.png)",
+    ].join("\n\n");
+
+    expect(extractFirstArticleImage(content)).toBe("../uploads/safe.png");
+  });
+
+  it("fails safely for empty or malformed input", () => {
+    expect(extractFirstArticleImage(undefined)).toBeNull();
+    expect(
+      extractFirstArticleImage("![unfinished](<https://example.com")
+    ).toBeNull();
+    expect(
+      extractFirstArticleImage("![unfinished](https://example.com no-close")
+    ).toBeNull();
+  });
+});
+
+describe("getPageCardImage", () => {
+  it("prefers a featured image over an article-body image", () => {
+    expect(
+      getPageCardImage("/uploads/featured.jpg", "![Body](/uploads/body.jpg)")
+    ).toEqual({ url: "/uploads/featured.jpg", source: "featured" });
+  });
+
+  it("uses an article-body image before the Tuzi fallback", () => {
+    expect(getPageCardImage(null, "![Body](/uploads/body.jpg)")).toEqual({
+      url: "/uploads/body.jpg",
+      source: "body",
+    });
+  });
+
+  it("preserves the Tuzi fallback when there is no usable image", () => {
+    expect(getPageCardImage(null, "Text only")).toEqual({
+      url: "/docs/img/tuzi.svg",
+      source: "fallback",
+    });
+  });
+});

--- a/ts/react/free2z/src/lib/page-card-image.test.ts
+++ b/ts/react/free2z/src/lib/page-card-image.test.ts
@@ -25,6 +25,29 @@ describe("extractFirstArticleImage", () => {
     expect(extractFirstArticleImage(content)).toBe("/uploads/visible.jpg");
   });
 
+  it.each([
+    ["indented code", "    ![Code](/uploads/code.jpg)"],
+    ["a raw HTML block", "<div>\n![HTML](/uploads/html.jpg)\n</div>"],
+  ])("ignores images in %s", (_label, hiddenImage) => {
+    expect(
+      extractFirstArticleImage(
+        `${hiddenImage}\n\n![Visible](/uploads/visible.jpg)`
+      )
+    ).toBe("/uploads/visible.jpg");
+  });
+
+  it.each([
+    ["backtick fence", "```markdown"],
+    ["tilde fence", "~~~markdown"],
+    ["HTML comment", "<!--"],
+  ])("does not escape an unterminated %s", (_label, opener) => {
+    expect(
+      extractFirstArticleImage(
+        `${opener}\n![Hidden](/uploads/hidden.jpg)\n\n![Still hidden](/uploads/later.jpg)`
+      )
+    ).toBeNull();
+  });
+
   it("resolves reference-style body images", () => {
     const content = [
       "![Article photograph][hero]",
@@ -37,6 +60,25 @@ describe("extractFirstArticleImage", () => {
     );
   });
 
+  it("uses the first CommonMark definition for duplicate references", () => {
+    const content = [
+      "![Article photograph][hero]",
+      "",
+      "[hero]: /uploads/first.webp",
+      "[hero]: /uploads/second.webp",
+    ].join("\n");
+
+    expect(extractFirstArticleImage(content)).toBe("/uploads/first.webp");
+  });
+
+  it("decodes Markdown character references in destinations", () => {
+    expect(
+      extractFirstArticleImage(
+        "![Signed image](https://images.example.com/signed.png?x=1&amp;y=2)"
+      )
+    ).toBe("https://images.example.com/signed.png?x=1&y=2");
+  });
+
   it("skips unsafe image URLs and can use a later safe image", () => {
     const content = [
       "![Unsafe](javascript:alert(1))",
@@ -44,6 +86,36 @@ describe("extractFirstArticleImage", () => {
     ].join("\n\n");
 
     expect(extractFirstArticleImage(content)).toBe("../uploads/safe.png");
+  });
+
+  it.each([
+    "data:image/png;base64,AA",
+    "ftp://example.com/image.png",
+    `java${"script"}:alert(1)`,
+    "https://example.com/control\u0000.png",
+    "http://",
+  ])("rejects a non-HTTP or malformed destination: %s", (destination) => {
+    expect(
+      extractFirstArticleImage(
+        `![Rejected](${destination})\n\n![Safe](/uploads/safe.png)`
+      )
+    ).toBe("/uploads/safe.png");
+  });
+
+  it("does not promote a malformed angle-bracket destination", () => {
+    expect(
+      extractFirstArticleImage(
+        "![Malformed](<https://images.example.com/a<bad.png>)\n\n![Safe](/uploads/safe.png)"
+      )
+    ).toBe("/uploads/safe.png");
+  });
+
+  it("handles many unmatched image openers without quadratic rescanning", () => {
+    const content = "![".repeat(50_000);
+    const startedAt = performance.now();
+
+    expect(extractFirstArticleImage(content)).toBeNull();
+    expect(performance.now() - startedAt).toBeLessThan(2_000);
   });
 
   it("fails safely for empty or malformed input", () => {

--- a/ts/react/free2z/src/lib/page-card-image.ts
+++ b/ts/react/free2z/src/lib/page-card-image.ts
@@ -1,9 +1,24 @@
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
 const TUZI_CARD_IMAGE = "/docs/img/tuzi.svg";
 
 type PageCardImage = {
   url: string;
   source: "featured" | "body" | "fallback";
 };
+
+type MarkdownNode = {
+  type: string;
+  children?: MarkdownNode[];
+  identifier?: unknown;
+  url?: unknown;
+};
+
+// ReactMarkdown uses this same remark-parse/CommonMark AST as its foundation.
+// Images, references, code, HTML, escapes, and character references are all
+// resolved here before the renderer's additional GFM/directive plugins run.
+const markdownParser = unified().use(remarkParse);
 
 function safeImageUrl(value: unknown): string | null {
   if (typeof value !== "string") {
@@ -15,7 +30,9 @@ function safeImageUrl(value: unknown): string | null {
     const code = character.charCodeAt(0);
     return code <= 31 || code === 127;
   });
-  if (!candidate || hasControlCharacter) {
+  // CommonMark replaces a literal NUL with U+FFFD while parsing. Treat that
+  // replacement as malformed input rather than silently changing the URL.
+  if (!candidate || hasControlCharacter || candidate.includes("\uFFFD")) {
     return null;
   }
 
@@ -29,179 +46,22 @@ function safeImageUrl(value: unknown): string | null {
   }
 }
 
-function isEscaped(value: string, index: number): boolean {
-  let backslashes = 0;
-  for (
-    let cursor = index - 1;
-    cursor >= 0 && value[cursor] === "\\";
-    cursor -= 1
-  ) {
-    backslashes += 1;
-  }
-  return backslashes % 2 === 1;
-}
+function visitInDocumentOrder(
+  root: MarkdownNode,
+  visitor: (node: MarkdownNode) => boolean | void
+): void {
+  const stack = [root];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) continue;
+    if (visitor(node)) return;
 
-function maskMatches(markdown: string, pattern: RegExp): string {
-  const characters = markdown.split("");
-  let match: RegExpExecArray | null = null;
-  while ((match = pattern.exec(markdown)) !== null) {
-    const start = match.index || 0;
-    for (let cursor = start; cursor < start + match[0].length; cursor += 1) {
-      if (characters[cursor] !== "\n" && characters[cursor] !== "\r") {
-        characters[cursor] = " ";
-      }
+    const children = node.children;
+    if (!children) continue;
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      stack.push(children[index]);
     }
   }
-  return characters.join("");
-}
-
-function maskCode(markdown: string): string {
-  const withoutComments = maskMatches(markdown, /<!--[\s\S]*?-->/g);
-  const withoutTildeFences = maskMatches(
-    withoutComments,
-    /^ {0,3}~{3,}[^\r\n]*(?:\r?\n|$)[\s\S]*?^ {0,3}~{3,}[ \t]*(?=\r?$)/gm
-  );
-  const characters = withoutTildeFences.split("");
-
-  for (let index = 0; index < withoutTildeFences.length; ) {
-    if (
-      withoutTildeFences[index] !== "`" ||
-      isEscaped(withoutTildeFences, index)
-    ) {
-      index += 1;
-      continue;
-    }
-
-    let runLength = 1;
-    while (withoutTildeFences[index + runLength] === "`") {
-      runLength += 1;
-    }
-
-    const marker = "`".repeat(runLength);
-    const closingIndex = withoutTildeFences.indexOf(marker, index + runLength);
-    if (closingIndex === -1) {
-      index += runLength;
-      continue;
-    }
-
-    for (let cursor = index; cursor < closingIndex + runLength; cursor += 1) {
-      if (characters[cursor] !== "\n" && characters[cursor] !== "\r") {
-        characters[cursor] = " ";
-      }
-    }
-    index = closingIndex + runLength;
-  }
-
-  return characters.join("");
-}
-
-function unescapeDestination(value: string): string {
-  return value.replace(/\\([!-/:-@[-`{-~])/g, "$1");
-}
-
-function normalizeReference(value: string): string {
-  return value.trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-function referenceDefinitions(markdown: string): Map<string, string> {
-  const definitions = new Map<string, string>();
-  const definitionPattern =
-    /^[ \t]{0,3}\[([^\]]+)\]:[ \t]*(?:<([^>\r\n]+)>|([^\s]+))/gm;
-
-  let match: RegExpExecArray | null = null;
-  while ((match = definitionPattern.exec(markdown)) !== null) {
-    const url = safeImageUrl(unescapeDestination(match[2] || match[3]));
-    if (url) {
-      definitions.set(normalizeReference(match[1]), url);
-    }
-  }
-
-  return definitions;
-}
-
-function closingBracket(markdown: string, start: number): number {
-  let depth = 0;
-  for (let index = start; index < markdown.length; index += 1) {
-    if (isEscaped(markdown, index)) {
-      continue;
-    }
-    if (markdown[index] === "[") {
-      depth += 1;
-    } else if (markdown[index] === "]") {
-      if (depth === 0) {
-        return index;
-      }
-      depth -= 1;
-    }
-  }
-  return -1;
-}
-
-function inlineDestination(markdown: string, start: number): string | null {
-  let cursor = start;
-  while (markdown[cursor] === " " || markdown[cursor] === "\t") {
-    cursor += 1;
-  }
-
-  if (markdown[cursor] === "<") {
-    const end = markdown.indexOf(">", cursor + 1);
-    if (end === -1 || !hasValidDestinationEnd(markdown, end + 1)) {
-      return null;
-    }
-    return unescapeDestination(markdown.slice(cursor + 1, end));
-  }
-
-  const destinationStart = cursor;
-  let parenthesisDepth = 0;
-  for (; cursor < markdown.length; cursor += 1) {
-    const character = markdown[cursor];
-    if (isEscaped(markdown, cursor)) {
-      continue;
-    }
-    if (character === "(") {
-      parenthesisDepth += 1;
-    } else if (character === ")") {
-      if (parenthesisDepth === 0) {
-        return unescapeDestination(markdown.slice(destinationStart, cursor));
-      }
-      parenthesisDepth -= 1;
-    } else if (/\s/.test(character) && parenthesisDepth === 0) {
-      return hasValidDestinationEnd(markdown, cursor)
-        ? unescapeDestination(markdown.slice(destinationStart, cursor))
-        : null;
-    }
-  }
-
-  return null;
-}
-
-function hasValidDestinationEnd(markdown: string, start: number): boolean {
-  let cursor = start;
-  while (/\s/.test(markdown[cursor] || "")) {
-    cursor += 1;
-  }
-  if (markdown[cursor] === ")") {
-    return true;
-  }
-
-  const opener = markdown[cursor];
-  const closer = opener === "(" ? ")" : opener;
-  if (opener !== '"' && opener !== "'" && opener !== "(") {
-    return false;
-  }
-
-  cursor += 1;
-  while (cursor < markdown.length) {
-    if (markdown[cursor] === closer && !isEscaped(markdown, cursor)) {
-      cursor += 1;
-      while (/\s/.test(markdown[cursor] || "")) {
-        cursor += 1;
-      }
-      return markdown[cursor] === ")";
-    }
-    cursor += 1;
-  }
-  return false;
 }
 
 export function extractFirstArticleImage(content: unknown): string | null {
@@ -209,48 +69,44 @@ export function extractFirstArticleImage(content: unknown): string | null {
     return null;
   }
 
-  const markdown = maskCode(content);
-  const definitions = referenceDefinitions(markdown);
-
-  for (let index = 0; index < markdown.length - 1; index += 1) {
-    if (
-      markdown[index] !== "!" ||
-      markdown[index + 1] !== "[" ||
-      isEscaped(markdown, index)
-    ) {
-      continue;
-    }
-
-    const altEnd = closingBracket(markdown, index + 2);
-    if (altEnd === -1) {
-      continue;
-    }
-
-    const nextCharacter = markdown[altEnd + 1];
-    let candidate: string | null = null;
-    if (nextCharacter === "(") {
-      candidate = inlineDestination(markdown, altEnd + 2);
-    } else if (nextCharacter === "[") {
-      const referenceEnd = closingBracket(markdown, altEnd + 2);
-      if (referenceEnd !== -1) {
-        const reference =
-          markdown.slice(altEnd + 2, referenceEnd) ||
-          markdown.slice(index + 2, altEnd);
-        candidate = definitions.get(normalizeReference(reference)) || null;
-      }
-    } else {
-      const reference = markdown.slice(index + 2, altEnd);
-      candidate = definitions.get(normalizeReference(reference)) || null;
-    }
-
-    const safeCandidate = safeImageUrl(candidate);
-    if (safeCandidate) {
-      return safeCandidate;
-    }
-    index = altEnd;
+  let tree: MarkdownNode;
+  try {
+    tree = markdownParser.parse(content) as MarkdownNode;
+  } catch {
+    return null;
   }
 
-  return null;
+  const definitions = new Map<string, unknown>();
+  visitInDocumentOrder(tree, (node) => {
+    if (
+      node.type === "definition" &&
+      typeof node.identifier === "string" &&
+      !definitions.has(node.identifier)
+    ) {
+      // CommonMark resolves duplicate labels to their first definition.
+      definitions.set(node.identifier, node.url);
+    }
+  });
+
+  let firstSafeImage: string | null = null;
+  visitInDocumentOrder(tree, (node) => {
+    let candidate: unknown;
+    if (node.type === "image") {
+      candidate = node.url;
+    } else if (
+      node.type === "imageReference" &&
+      typeof node.identifier === "string"
+    ) {
+      candidate = definitions.get(node.identifier);
+    } else {
+      return false;
+    }
+
+    firstSafeImage = safeImageUrl(candidate);
+    return firstSafeImage !== null;
+  });
+
+  return firstSafeImage;
 }
 
 export function getPageCardImage(

--- a/ts/react/free2z/src/lib/page-card-image.ts
+++ b/ts/react/free2z/src/lib/page-card-image.ts
@@ -1,0 +1,270 @@
+const TUZI_CARD_IMAGE = "/docs/img/tuzi.svg";
+
+type PageCardImage = {
+  url: string;
+  source: "featured" | "body" | "fallback";
+};
+
+function safeImageUrl(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const candidate = value.trim();
+  const hasControlCharacter = candidate.split("").some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+  if (!candidate || hasControlCharacter) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(candidate, "https://free2z.invalid");
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? candidate
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isEscaped(value: string, index: number): boolean {
+  let backslashes = 0;
+  for (
+    let cursor = index - 1;
+    cursor >= 0 && value[cursor] === "\\";
+    cursor -= 1
+  ) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function maskMatches(markdown: string, pattern: RegExp): string {
+  const characters = markdown.split("");
+  let match: RegExpExecArray | null = null;
+  while ((match = pattern.exec(markdown)) !== null) {
+    const start = match.index || 0;
+    for (let cursor = start; cursor < start + match[0].length; cursor += 1) {
+      if (characters[cursor] !== "\n" && characters[cursor] !== "\r") {
+        characters[cursor] = " ";
+      }
+    }
+  }
+  return characters.join("");
+}
+
+function maskCode(markdown: string): string {
+  const withoutComments = maskMatches(markdown, /<!--[\s\S]*?-->/g);
+  const withoutTildeFences = maskMatches(
+    withoutComments,
+    /^ {0,3}~{3,}[^\r\n]*(?:\r?\n|$)[\s\S]*?^ {0,3}~{3,}[ \t]*(?=\r?$)/gm
+  );
+  const characters = withoutTildeFences.split("");
+
+  for (let index = 0; index < withoutTildeFences.length; ) {
+    if (
+      withoutTildeFences[index] !== "`" ||
+      isEscaped(withoutTildeFences, index)
+    ) {
+      index += 1;
+      continue;
+    }
+
+    let runLength = 1;
+    while (withoutTildeFences[index + runLength] === "`") {
+      runLength += 1;
+    }
+
+    const marker = "`".repeat(runLength);
+    const closingIndex = withoutTildeFences.indexOf(marker, index + runLength);
+    if (closingIndex === -1) {
+      index += runLength;
+      continue;
+    }
+
+    for (let cursor = index; cursor < closingIndex + runLength; cursor += 1) {
+      if (characters[cursor] !== "\n" && characters[cursor] !== "\r") {
+        characters[cursor] = " ";
+      }
+    }
+    index = closingIndex + runLength;
+  }
+
+  return characters.join("");
+}
+
+function unescapeDestination(value: string): string {
+  return value.replace(/\\([!-/:-@[-`{-~])/g, "$1");
+}
+
+function normalizeReference(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function referenceDefinitions(markdown: string): Map<string, string> {
+  const definitions = new Map<string, string>();
+  const definitionPattern =
+    /^[ \t]{0,3}\[([^\]]+)\]:[ \t]*(?:<([^>\r\n]+)>|([^\s]+))/gm;
+
+  let match: RegExpExecArray | null = null;
+  while ((match = definitionPattern.exec(markdown)) !== null) {
+    const url = safeImageUrl(unescapeDestination(match[2] || match[3]));
+    if (url) {
+      definitions.set(normalizeReference(match[1]), url);
+    }
+  }
+
+  return definitions;
+}
+
+function closingBracket(markdown: string, start: number): number {
+  let depth = 0;
+  for (let index = start; index < markdown.length; index += 1) {
+    if (isEscaped(markdown, index)) {
+      continue;
+    }
+    if (markdown[index] === "[") {
+      depth += 1;
+    } else if (markdown[index] === "]") {
+      if (depth === 0) {
+        return index;
+      }
+      depth -= 1;
+    }
+  }
+  return -1;
+}
+
+function inlineDestination(markdown: string, start: number): string | null {
+  let cursor = start;
+  while (markdown[cursor] === " " || markdown[cursor] === "\t") {
+    cursor += 1;
+  }
+
+  if (markdown[cursor] === "<") {
+    const end = markdown.indexOf(">", cursor + 1);
+    if (end === -1 || !hasValidDestinationEnd(markdown, end + 1)) {
+      return null;
+    }
+    return unescapeDestination(markdown.slice(cursor + 1, end));
+  }
+
+  const destinationStart = cursor;
+  let parenthesisDepth = 0;
+  for (; cursor < markdown.length; cursor += 1) {
+    const character = markdown[cursor];
+    if (isEscaped(markdown, cursor)) {
+      continue;
+    }
+    if (character === "(") {
+      parenthesisDepth += 1;
+    } else if (character === ")") {
+      if (parenthesisDepth === 0) {
+        return unescapeDestination(markdown.slice(destinationStart, cursor));
+      }
+      parenthesisDepth -= 1;
+    } else if (/\s/.test(character) && parenthesisDepth === 0) {
+      return hasValidDestinationEnd(markdown, cursor)
+        ? unescapeDestination(markdown.slice(destinationStart, cursor))
+        : null;
+    }
+  }
+
+  return null;
+}
+
+function hasValidDestinationEnd(markdown: string, start: number): boolean {
+  let cursor = start;
+  while (/\s/.test(markdown[cursor] || "")) {
+    cursor += 1;
+  }
+  if (markdown[cursor] === ")") {
+    return true;
+  }
+
+  const opener = markdown[cursor];
+  const closer = opener === "(" ? ")" : opener;
+  if (opener !== '"' && opener !== "'" && opener !== "(") {
+    return false;
+  }
+
+  cursor += 1;
+  while (cursor < markdown.length) {
+    if (markdown[cursor] === closer && !isEscaped(markdown, cursor)) {
+      cursor += 1;
+      while (/\s/.test(markdown[cursor] || "")) {
+        cursor += 1;
+      }
+      return markdown[cursor] === ")";
+    }
+    cursor += 1;
+  }
+  return false;
+}
+
+export function extractFirstArticleImage(content: unknown): string | null {
+  if (typeof content !== "string" || !content.trim()) {
+    return null;
+  }
+
+  const markdown = maskCode(content);
+  const definitions = referenceDefinitions(markdown);
+
+  for (let index = 0; index < markdown.length - 1; index += 1) {
+    if (
+      markdown[index] !== "!" ||
+      markdown[index + 1] !== "[" ||
+      isEscaped(markdown, index)
+    ) {
+      continue;
+    }
+
+    const altEnd = closingBracket(markdown, index + 2);
+    if (altEnd === -1) {
+      continue;
+    }
+
+    const nextCharacter = markdown[altEnd + 1];
+    let candidate: string | null = null;
+    if (nextCharacter === "(") {
+      candidate = inlineDestination(markdown, altEnd + 2);
+    } else if (nextCharacter === "[") {
+      const referenceEnd = closingBracket(markdown, altEnd + 2);
+      if (referenceEnd !== -1) {
+        const reference =
+          markdown.slice(altEnd + 2, referenceEnd) ||
+          markdown.slice(index + 2, altEnd);
+        candidate = definitions.get(normalizeReference(reference)) || null;
+      }
+    } else {
+      const reference = markdown.slice(index + 2, altEnd);
+      candidate = definitions.get(normalizeReference(reference)) || null;
+    }
+
+    const safeCandidate = safeImageUrl(candidate);
+    if (safeCandidate) {
+      return safeCandidate;
+    }
+    index = altEnd;
+  }
+
+  return null;
+}
+
+export function getPageCardImage(
+  featuredImageUrl: string | null | undefined,
+  content: unknown
+): PageCardImage {
+  if (featuredImageUrl) {
+    return { url: featuredImageUrl, source: "featured" };
+  }
+
+  const bodyImageUrl = extractFirstArticleImage(content);
+  if (bodyImageUrl) {
+    return { url: bodyImageUrl, source: "body" };
+  }
+
+  return { url: TUZI_CARD_IMAGE, source: "fallback" };
+}


### PR DESCRIPTION
Closes #51

## Summary
- keep an explicitly selected featured image as the first choice for classic zpage cards
- otherwise extract the first safe Markdown image from the article body before using the existing Tuzi fallback
- ignore image-like text in comments/code, reject non-HTTP(S) schemes, and support inline/reference Markdown destinations
- keep the fallback dimmed while showing featured/body images at full opacity

## Verification
- `CI=true npm test -- --runInBand --watchAll=false` (3 suites, 11 tests)
- `npx eslint src/lib/page-card-image.ts src/lib/page-card-image.test.ts`
- `CI=false npm run build` (passes with pre-existing repository warnings)
- `git diff --check`