### PR TITLE
fix(zuuli): preserve stored article tags

### DIFF
--- a/wallet/zuuli/src/features/articles/pages/Feed.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Feed.tsx
@@ -8,6 +8,7 @@ import { PageHeader } from "@/components/common/PageHeader";
 import { useRouteScroll } from "@/hooks/useRouteScroll";
 import { cn } from "@/lib/utils";
 import {
+  isArticleTagFilterable,
   MAX_ARTICLE_TAGS,
   parseArticleTagsParam,
   sanitizeArticleTags,
@@ -187,6 +188,17 @@ export function Feed() {
         <div className="mb-6 flex flex-wrap items-center gap-2" aria-label="Filter by tag">
           {knownTags.map((tag) => {
             const on = selectedTags.includes(tag);
+            if (!isArticleTagFilterable(tag)) {
+              return (
+                <span
+                  key={tag}
+                  className="min-tap inline-flex max-w-full items-center rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground"
+                  title="This stored tag cannot be represented by the server's comma-delimited filter."
+                >
+                  <span className="min-w-0 break-words">{tag}</span>
+                </span>
+              );
+            }
             return (
               <button
                 key={tag}
@@ -194,7 +206,7 @@ export function Feed() {
                 aria-pressed={on}
                 onClick={() => toggleTag(tag)}
                 className={cn(
-                  "min-tap rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "min-tap max-w-full break-words rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   on
                     ? "border-primary bg-primary/15 text-primary"
                     : "border-border bg-transparent text-muted-foreground hover:bg-secondary hover:text-foreground",

--- a/wallet/zuuli/src/features/articles/pages/Reader.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Reader.tsx
@@ -28,6 +28,32 @@ import { ArticleScore } from "../components/ArticleScore";
 import { coverTone } from "@/lib/cover";
 import { formatPublished } from "../lib";
 
+const articleTagClassName =
+  "min-tap inline-flex max-w-full items-center rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary";
+
+function StoredArticleTag({ tag }: { tag: string }) {
+  const href = articleTagHref(tag);
+  const label = <span className="min-w-0 break-words">#{tag}</span>;
+  if (!href) {
+    return (
+      <span
+        className={articleTagClassName}
+        title="This stored tag cannot be represented by the server's comma-delimited filter."
+      >
+        {label}
+      </span>
+    );
+  }
+  return (
+    <Link
+      to={href}
+      className={`${articleTagClassName} transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
+    >
+      {label}
+    </Link>
+  );
+}
+
 export function Reader() {
   const { slug } = useParams<{ slug: string }>();
   const key = slug ?? "";
@@ -128,13 +154,7 @@ export function Reader() {
           {tags.length > 0 ? (
             <nav className="flex flex-wrap gap-2" aria-label="Article tags">
               {tags.map((tag) => (
-                <Link
-                  key={tag}
-                  to={articleTagHref(tag)}
-                  className="min-tap inline-flex max-w-full items-center rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  <span className="min-w-0 break-words">#{tag}</span>
-                </Link>
+                <StoredArticleTag key={tag} tag={tag} />
               ))}
             </nav>
           ) : null}

--- a/wallet/zuuli/src/lib/api/article-tags-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/article-tags-contract.test.ts
@@ -38,7 +38,7 @@ describe("article tag HTTP contract", () => {
       }),
     ).resolves.toMatchObject({
       author: { username: "alice" },
-      tags: ["zero knowledge", "privacy", "c++"],
+      tags: ["Zero Knowledge", "privacy", "C++"],
     });
 
     expect(requestMock).toHaveBeenCalledWith("/api/zpage/", {
@@ -57,6 +57,22 @@ describe("article tag HTTP contract", () => {
     });
   });
 
+  it("preserves the backend's legal stored tag vocabulary on read", async () => {
+    const rtl = "مرحبا\u200f";
+    const long = "L".repeat(100);
+    requestMock.mockResolvedValue({
+      free2zaddr: "article-id",
+      title: "Stored tags",
+      content: "Body",
+      creator: { username: "alice" },
+      tags: ["ART", "🏳️‍🌈 pride", rtl, "machine learning, deep learning", long],
+    });
+
+    await expect(articles.get("article-id")).resolves.toMatchObject({
+      tags: ["ART", "🏳️‍🌈 pride", rtl, "machine learning, deep learning", long],
+    });
+  });
+
   it("uses the public zpage autocomplete contract", async () => {
     requestMock.mockResolvedValue([
       { name: "Privacy", count: 12 },
@@ -66,8 +82,9 @@ describe("article tag HTTP contract", () => {
       { name: "bad\u0000tag", count: 3 },
     ]);
     await expect(articles.suggestTags("pri", ["zcash"])).resolves.toEqual([
-      { name: "privacy", count: 12 },
-      { name: "c++", count: 0 },
+      { name: "Privacy", count: 12 },
+      { name: "privacy", count: 11 },
+      { name: "C++", count: 0 },
     ]);
     expect(requestMock).toHaveBeenCalledWith("/api/tagging/autocomplete", {
       query: {

--- a/wallet/zuuli/src/lib/article-tags.test.ts
+++ b/wallet/zuuli/src/lib/article-tags.test.ts
@@ -3,6 +3,7 @@ import {
   articleTagHref,
   MAX_ARTICLE_TAG_LENGTH,
   MAX_ARTICLE_TAGS,
+  MAX_STORED_ARTICLE_TAG_LENGTH,
   normalizeArticleTags,
   parseArticleTagsParam,
   sanitizeArticleTags,
@@ -43,15 +44,53 @@ describe("article tag contract", () => {
     ).toThrow(/at most/);
   });
 
-  it("fails soft for malformed share URLs and emits canonical links", () => {
+  it("preserves legal stored tags without reapplying authoring rules", () => {
+    const rtl = "مرحبا\u200f";
+    const long = "L".repeat(MAX_STORED_ARTICLE_TAG_LENGTH);
+    expect(
+      sanitizeArticleTags([
+        "ART",
+        "🏳️‍🌈 pride",
+        rtl,
+        "machine learning, deep learning",
+        long,
+        null,
+        42,
+        "bad\u0000tag",
+        "x".repeat(MAX_STORED_ARTICLE_TAG_LENGTH + 1),
+      ]),
+    ).toEqual([
+      "ART",
+      "🏳️‍🌈 pride",
+      rtl,
+      "machine learning, deep learning",
+      long,
+    ]);
+  });
+
+  it("fails soft and bounds malformed share URLs", () => {
     expect(
       parseArticleTagsParam(" Privacy,bad\u0000tag,privacy,zero knowledge "),
-    ).toEqual(["privacy", "zero knowledge"]);
-    expect(sanitizeArticleTags(["Privacy", null, 42, "bad\u0000tag"])).toEqual([
-      "privacy",
-    ]);
-    expect(articleTagHref("Zero Knowledge")).toBe(
-      "/articles?tags=zero%20knowledge",
+    ).toEqual(["Privacy", "zero knowledge"]);
+    expect(
+      parseArticleTagsParam(
+        Array.from(
+          { length: MAX_ARTICLE_TAGS + 20 },
+          (_, index) => `tag-${index}`,
+        ).join(","),
+      ),
+    ).toEqual(
+      Array.from({ length: MAX_ARTICLE_TAGS }, (_, index) => `tag-${index}`),
     );
+  });
+
+  it("links filterable stored tags without rewriting them", () => {
+    expect(articleTagHref("Zero Knowledge")).toBe(
+      "/articles?tags=Zero%20Knowledge",
+    );
+    expect(articleTagHref("🏳️‍🌈 pride")).toBe(
+      `/articles?tags=${encodeURIComponent("🏳️‍🌈 pride")}`,
+    );
+    expect(articleTagHref("machine learning, deep learning")).toBeNull();
   });
 });

--- a/wallet/zuuli/src/lib/article-tags.test.ts
+++ b/wallet/zuuli/src/lib/article-tags.test.ts
@@ -57,6 +57,7 @@ describe("article tag contract", () => {
         null,
         42,
         "bad\u0000tag",
+        "\ud800",
         "x".repeat(MAX_STORED_ARTICLE_TAG_LENGTH + 1),
       ]),
     ).toEqual([
@@ -92,5 +93,6 @@ describe("article tag contract", () => {
       `/articles?tags=${encodeURIComponent("🏳️‍🌈 pride")}`,
     );
     expect(articleTagHref("machine learning, deep learning")).toBeNull();
+    expect(articleTagHref("\ud800")).toBeNull();
   });
 });

--- a/wallet/zuuli/src/lib/article-tags.ts
+++ b/wallet/zuuli/src/lib/article-tags.ts
@@ -1,7 +1,9 @@
 export const MAX_ARTICLE_TAGS = 8;
 export const MAX_ARTICLE_TAG_LENGTH = 32;
+export const MAX_STORED_ARTICLE_TAG_LENGTH = 100;
 
-const TAG_CONTROL_PATTERN = /[\p{Cc}\p{Cf}]/u;
+const AUTHORING_TAG_CONTROL_PATTERN = /[\p{Cc}\p{Cf}]/u;
+const STORED_TAG_CONTROL_PATTERN = /\p{Cc}/u;
 
 export interface ArticleTagValidation {
   tag: string | null;
@@ -32,7 +34,7 @@ export function validateArticleTag(raw: string): ArticleTagValidation {
       error: `Tags must be ${MAX_ARTICLE_TAG_LENGTH} characters or fewer.`,
     };
   }
-  if (tag.includes(",") || TAG_CONTROL_PATTERN.test(tag)) {
+  if (tag.includes(",") || AUTHORING_TAG_CONTROL_PATTERN.test(tag)) {
     return {
       tag: null,
       error: "Tags cannot contain commas or invisible control characters.",
@@ -58,15 +60,31 @@ export function normalizeArticleTags(values: string[]): string[] {
 }
 
 /**
- * Normalize untrusted tags for display/filtering without letting one legacy
- * or malformed backend value break an otherwise valid article.
+ * Preserve server-owned tags for display/filtering without applying this
+ * client's stricter authoring policy to already-published data.
+ *
+ * Django-taggit's stored vocabulary permits 100 characters. Format code
+ * points are meaningful in emoji and bidirectional scripts, so only empty,
+ * over-server-limit, or actual control-character values are discarded here.
  */
 export function sanitizeArticleTags(values: readonly unknown[]): string[] {
   const tags: string[] = [];
+  const seen = new Set<string>();
   for (const value of values) {
     if (typeof value !== "string") continue;
-    const { tag, error } = validateArticleTag(value);
-    if (tag && !error && !tags.includes(tag)) tags.push(tag);
+    const tag = value.trim();
+    if (
+      !tag ||
+      Array.from(tag).length > MAX_STORED_ARTICLE_TAG_LENGTH ||
+      STORED_TAG_CONTROL_PATTERN.test(tag)
+    ) {
+      continue;
+    }
+    const comparisonKey = tag.toLocaleLowerCase("en-US");
+    if (!seen.has(comparisonKey)) {
+      seen.add(comparisonKey);
+      tags.push(tag);
+    }
   }
   return tags;
 }
@@ -77,7 +95,14 @@ export function parseArticleTagsParam(value: string | null): string[] {
   return sanitizeArticleTags(value.split(",")).slice(0, MAX_ARTICLE_TAGS);
 }
 
-export function articleTagHref(tag: string): string {
-  const [normalized] = normalizeArticleTags([tag]);
-  return `/articles?tags=${encodeURIComponent(normalized)}`;
+/** The backend's comma-delimited filter has no escaping for comma-bearing tags. */
+export function isArticleTagFilterable(tag: string): boolean {
+  const [stored] = sanitizeArticleTags([tag]);
+  return Boolean(stored && !stored.includes(","));
+}
+
+export function articleTagHref(tag: string): string | null {
+  const [stored] = sanitizeArticleTags([tag]);
+  if (!stored || !isArticleTagFilterable(stored)) return null;
+  return `/articles?tags=${encodeURIComponent(stored)}`;
 }

--- a/wallet/zuuli/src/lib/article-tags.ts
+++ b/wallet/zuuli/src/lib/article-tags.ts
@@ -4,6 +4,9 @@ export const MAX_STORED_ARTICLE_TAG_LENGTH = 100;
 
 const AUTHORING_TAG_CONTROL_PATTERN = /[\p{Cc}\p{Cf}]/u;
 const STORED_TAG_CONTROL_PATTERN = /\p{Cc}/u;
+// With Unicode matching enabled, valid surrogate pairs are one code point;
+// this range therefore catches only ill-formed, unpaired UTF-16 surrogates.
+const UNPAIRED_SURROGATE_PATTERN = /[\uD800-\uDFFF]/u;
 
 export interface ArticleTagValidation {
   tag: string | null;
@@ -76,7 +79,8 @@ export function sanitizeArticleTags(values: readonly unknown[]): string[] {
     if (
       !tag ||
       Array.from(tag).length > MAX_STORED_ARTICLE_TAG_LENGTH ||
-      STORED_TAG_CONTROL_PATTERN.test(tag)
+      STORED_TAG_CONTROL_PATTERN.test(tag) ||
+      UNPAIRED_SURROGATE_PATTERN.test(tag)
     ) {
       continue;
     }


### PR DESCRIPTION
Closes #504

## What changed

- keep strict normalization and character/count limits on the article authoring path
- preserve server-owned tags on read, including original case, ZWJ emoji, RTL marks, commas, and the backend's 100-character maximum
- continue failing soft for non-string, empty, over-limit, and actual control-character response values
- display comma-bearing tags without offering a misleading filter link, since the backend filter uses an unescaped comma delimiter
- lock the share-URL filter to eight tags with a regression that fails if the bound is removed

## Verification

- `npx vitest run` — 646 passed, 5 skipped
- `npm run typecheck` — pass
- `npm run build` — pass
- focused tag/API contract tests — 12/12 pass
- `git diff --check` — pass
