### PR TITLE
test(zuuli): audit populated creator catalog on mobile

### DIFF
--- a/wallet/zuuli/tests/helpers/creator-catalog-audit.ts
+++ b/wallet/zuuli/tests/helpers/creator-catalog-audit.ts
@@ -1,0 +1,14 @@
+import { expect, type Page } from "@playwright/test";
+
+export const POPULATED_CREATOR_ROUTE = "/creator/zooko";
+
+export async function expectPopulatedCreatorCatalog(page: Page) {
+  const catalog = page.locator("[data-creator-pages]");
+
+  await expect(catalog.locator(".creator-pages-grid")).toBeVisible();
+  await expect(catalog.locator("[data-creator-page-card]")).toHaveCount(12);
+  await expect(catalog.getByText("12 of 13", { exact: true })).toBeVisible();
+  await expect(
+    catalog.getByRole("button", { name: "Load more pages" }),
+  ).toBeVisible();
+}

--- a/wallet/zuuli/tests/touch-targets.pw.ts
+++ b/wallet/zuuli/tests/touch-targets.pw.ts
@@ -1,4 +1,8 @@
 import { expect, test, type Page } from "@playwright/test";
+import {
+  expectPopulatedCreatorCatalog,
+  POPULATED_CREATOR_ROUTE,
+} from "./helpers/creator-catalog-audit";
 
 const TOUCH_WIDTHS = [320, 360] as const;
 const ROUTES = [
@@ -6,6 +10,7 @@ const ROUTES = [
   "/search",
   "/search?q=zcash",
   "/creator/demo-creator",
+  POPULATED_CREATOR_ROUTE,
   "/profile",
   "/kyc",
   "/wallet",
@@ -233,6 +238,10 @@ for (const signedIn of [false, true]) {
         await page.goto(route);
         await page.locator("[data-app-frame]").waitFor();
         await page.waitForTimeout(500);
+
+        if (route === POPULATED_CREATOR_ROUTE) {
+          await expectPopulatedCreatorCatalog(page);
+        }
 
         const audit = await auditTouchTargets(page);
         expect(audit.targets, `${route} must expose audited controls`).toBeGreaterThan(0);

--- a/wallet/zuuli/tests/viewport.pw.ts
+++ b/wallet/zuuli/tests/viewport.pw.ts
@@ -1,4 +1,8 @@
 import { expect, test, type Page } from "@playwright/test";
+import {
+  expectPopulatedCreatorCatalog,
+  POPULATED_CREATOR_ROUTE,
+} from "./helpers/creator-catalog-audit";
 
 const WIDTHS = [320, 360, 390, 414] as const;
 const ROUTES = [
@@ -6,6 +10,7 @@ const ROUTES = [
   "/search",
   "/search?q=zcash",
   "/creator/demo-creator",
+  POPULATED_CREATOR_ROUTE,
   "/profile",
   "/kyc",
   "/wallet",
@@ -308,6 +313,10 @@ for (const signedIn of [false, true]) {
         await page.goto(route);
         await page.locator("[data-app-frame]").waitFor();
         await page.waitForTimeout(500);
+
+        if (route === POPULATED_CREATOR_ROUTE) {
+          await expectPopulatedCreatorCatalog(page);
+        }
 
         const audit = await auditHorizontalLayout(page);
         expect(


### PR DESCRIPTION
Closes #481

Supersedes #493, whose current head only adds a comment and does not change either mobile audit route matrix or assert populated catalog/pagination behavior.

## Summary

- preserve the empty `/creator/demo-creator` coverage
- add deterministic `/creator/zooko` coverage to both mobile viewport and touch-target audit matrices
- require the catalog grid, exactly 12 initial cards, the exact `12 of 13` count, and a visible `Load more pages` control before each generic audit proceeds
- share the route and assertions so the two suites cannot silently drift

## Verification

- `ZUULI_PW_PORT=1491 npx playwright test tests/viewport.pw.ts tests/touch-targets.pw.ts --workers=2` — 13 passed
- `npx vitest run` — 643 passed, 5 skipped
- `npm run typecheck`
- `npm run build`
- `git diff --check`