### PR TITLE
ci(zuuli): gate 32-bit Android type checks

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -70,6 +70,11 @@ jobs:
           node scripts/check-zuuli-linux-image.mjs --self-test
           node scripts/check-zuuli-linux-image.mjs
 
+      - name: Verify the required 32-bit Android type-check policy
+        run: |
+          node scripts/check-zuuli-android-gate.mjs --self-test
+          node scripts/check-zuuli-android-gate.mjs
+
       - name: Verify Zcash command and permission parity
         run: |
           node scripts/check-zcash-permissions.mjs --self-test
@@ -104,7 +109,7 @@ jobs:
           zuuallet_schema=false
           while IFS= read -r file; do
             case "$file" in
-              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-github-actions-pins.mjs|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zcash-permissions.mjs|scripts/check-zuuli-linux-image.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-store-audit.yml|.github/workflows/zuuli-store-publish.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
+              wallet/zuuli/*|wallet/plugins/*|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-github-actions-pins.mjs|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zcash-permissions.mjs|scripts/check-zuuli-linux-image.mjs|scripts/check-zuuli-android-gate.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-store-audit.yml|.github/workflows/zuuli-store-publish.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
                 zuuli=true
                 ;;
             esac
@@ -379,6 +384,59 @@ jobs:
       - name: Build and test shared Zcash plugin
         run: cargo test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
 
+  # PR packaging builds only arm64 Android. Keep one cheap 32-bit type-check in
+  # the required gate because libc's Android ABI types can differ on armv7; the
+  # exact class escaped arm64 CI and broke build 7 only in the release lane.
+  rust_android_32:
+    name: Rust / Android 32-bit
+    needs: changes
+    if: needs.changes.outputs.zuuli == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - name: Resolve the pinned Rust toolchain
+        id: rust_toolchain
+        run: |
+          set -euo pipefail
+          version=$(scripts/check-rust-toolchain.sh --print-channel)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
+          targets: armv7-linux-androideabi
+
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '21.0.12'
+
+      - name: Install the pinned Android NDK
+        run: |
+          set -euo pipefail
+          set +e
+          yes 2>/dev/null | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
+            'ndk;27.0.12077973' >/dev/null
+          sdk_status=${PIPESTATUS[1]}
+          set -e
+          [[ "$sdk_status" -eq 0 ]] || { echo "sdkmanager failed ($sdk_status)" >&2; exit 1; }
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: wallet/plugins/tauri-plugin-zcash
+          key: zuuli-plugin-android-armv7
+
+      - name: Type-check the shared plugin on 32-bit Android
+        run: |
+          set -euo pipefail
+          source wallet/zuuli/scripts/android-toolchain-env.sh
+          cargo check --locked --target armv7-linux-androideabi --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
+
   # The app and standalone plugin have independent lockfiles and resolve some
   # crates differently. Run them in parallel so a cold gate takes the slower
   # job's time instead of compiling both graphs serially.
@@ -539,7 +597,7 @@ jobs:
   # change detector and every applicable full-stack job succeeded; legitimate
   # non-ZUULI skips continue to report success instead of remaining pending.
   gate:
-    needs: [changes, frontend, rust_fmt, rust_deny, rust_clippy, rust_plugin, rust_app, zuuallet_schema]
+    needs: [changes, frontend, rust_fmt, rust_deny, rust_clippy, rust_plugin, rust_android_32, rust_app, zuuallet_schema]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -554,6 +612,7 @@ jobs:
           RUST_DENY_RESULT: ${{ needs.rust_deny.result }}
           RUST_CLIPPY_RESULT: ${{ needs.rust_clippy.result }}
           RUST_PLUGIN_RESULT: ${{ needs.rust_plugin.result }}
+          RUST_ANDROID_32_RESULT: ${{ needs.rust_android_32.result }}
           RUST_APP_RESULT: ${{ needs.rust_app.result }}
           ZUUALLET_SCHEMA_RESULT: ${{ needs.zuuallet_schema.result }}
         run: |
@@ -564,7 +623,7 @@ jobs:
 
           # Every job in `needs:` above must appear here as well; a job that is
           # awaited but not inspected makes the gate decorative for that job.
-          results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_DENY_RESULT $RUST_CLIPPY_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"
+          results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_DENY_RESULT $RUST_CLIPPY_RESULT $RUST_PLUGIN_RESULT $RUST_ANDROID_32_RESULT $RUST_APP_RESULT"
           echo "ZUULI changed: $ZUULI_CHANGED; job results: $results"
           case "$ZUULI_CHANGED" in
             true) expected=success ;;

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -429,7 +429,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: wallet/plugins/tauri-plugin-zcash
-          key: zuuli-plugin-android-armv7
+          key: zuuli-plugin-android-armv7-ndk27.0.12077973-api29
 
       - name: Type-check the shared plugin on 32-bit Android
         run: |

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -602,6 +602,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Enforce the 32-bit Android result
+        env:
+          ZUULI_CHANGED: ${{ needs.changes.outputs.zuuli }}
+          RUST_ANDROID_32_RESULT: ${{ needs.rust_android_32.result }}
+        run: |
+          set -euo pipefail
+          case "$ZUULI_CHANGED:$RUST_ANDROID_32_RESULT" in
+            true:success|false:skipped) ;;
+            *) echo "32-bit Android result is inconsistent: changed=$ZUULI_CHANGED result=$RUST_ANDROID_32_RESULT"; exit 1 ;;
+          esac
+
       - name: Verify required jobs succeeded or legitimately skipped
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -406,7 +406,8 @@ jobs:
           version=$(scripts/check-rust-toolchain.sh --print-channel)
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - name: Install the pinned 32-bit Android Rust target
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
           targets: armv7-linux-androideabi
@@ -426,7 +427,8 @@ jobs:
           set -e
           [[ "$sdk_status" -eq 0 ]] || { echo "sdkmanager failed ($sdk_status)" >&2; exit 1; }
 
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - name: Restore the 32-bit Android Rust cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: wallet/plugins/tauri-plugin-zcash
           key: zuuli-plugin-android-armv7-ndk27.0.12077973-api29

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -14,6 +14,8 @@ const ndk = "27.0.12077973";
 const cacheKey = `zuuli-plugin-android-armv7-ndk${ndk}-api29`;
 const changeDetectorDigest =
   "6d8ed19ac60777c842ab06f791f2ac22c734dce248e20451f5bc9f947fb2b1fb";
+const toolchainEnvDigest =
+  "403f59c58bca0a37b98a3bb0ea0ae7f1c289b3531d6e1eec8496643866ee2013";
 
 function job(workflow, name) {
   const start = new RegExp(`^  ${name}:\\n`, "m").exec(workflow);
@@ -151,19 +153,9 @@ function check(workflow, toolchainEnv) {
   if (typecheckStep !== expectedTypecheckStep) {
     failures.push("32-bit Android type-check step must execute the exact reviewed command block");
   }
-  const requiredArchiverLines = [
-    'export AR_aarch64_linux_android="$zuuli_ndk_bin/llvm-ar"',
-    'export AR_armv7_linux_androideabi="$zuuli_ndk_bin/llvm-ar"',
-    'export AR_i686_linux_android="$zuuli_ndk_bin/llvm-ar"',
-    'export AR_x86_64_linux_android="$zuuli_ndk_bin/llvm-ar"',
-    '[[ -x "$zuuli_ndk_bin/llvm-ar" ]] || {',
-  ];
-  for (const line of requiredArchiverLines) {
-    requireLine(
-      failures,
-      toolchainEnv,
-      line,
-      `Android toolchain environment must retain pinned NDK archiver contract: ${line}`,
+  if (createHash("sha256").update(toolchainEnv).digest("hex") !== toolchainEnvDigest) {
+    failures.push(
+      "Android toolchain environment differs from the reviewed linker/compiler/archiver contract",
     );
   }
 
@@ -314,8 +306,15 @@ function runSelfTest(workflow, toolchainEnv) {
   if (check(workflow, missingArmv7Archiver).length === 0) {
     throw new Error("mutation escaped policy: armv7 uses an unpinned archiver");
   }
+  const deadPinnedArmv7Archiver = toolchainEnv.replace(
+    'export AR_armv7_linux_androideabi="$zuuli_ndk_bin/llvm-ar"',
+    'export AR_armv7_linux_androideabi="/usr/bin/ar"\nif false; then\n  export AR_armv7_linux_androideabi="$zuuli_ndk_bin/llvm-ar"\nfi',
+  );
+  if (check(workflow, deadPinnedArmv7Archiver).length === 0) {
+    throw new Error("mutation escaped policy: pinned armv7 archiver is dead decoration");
+  }
   console.log(
-    `Android gate policy self-test passed (${mutations.length + 3} mutations).`,
+    `Android gate policy self-test passed (${mutations.length + 4} mutations).`,
   );
 }
 

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -10,6 +11,8 @@ const policyPath = "scripts/check-zuuli-android-gate.mjs";
 const target = "armv7-linux-androideabi";
 const ndk = "27.0.12077973";
 const cacheKey = `zuuli-plugin-android-armv7-ndk${ndk}-api29`;
+const changeDetectorDigest =
+  "6d8ed19ac60777c842ab06f791f2ac22c734dce248e20451f5bc9f947fb2b1fb";
 
 function job(workflow, name) {
   const start = new RegExp(`^  ${name}:\\n`, "m").exec(workflow);
@@ -61,6 +64,12 @@ function check(workflow) {
     failures.push("changes job must execute the exact Android gate policy step");
   }
   const detector = namedStep(changes, "Detect release-impacting ZUULI changes");
+  const detectorDigest = createHash("sha256").update(detector).digest("hex");
+  if (detectorDigest !== changeDetectorDigest) {
+    failures.push(
+      "change detector differs from the reviewed fail-open/fail-closed selector step",
+    );
+  }
   const zuuliCase = detector.match(
     /case "\$file" in\n\s+([^\n]+)\)\n\s+zuuli=true/,
   );
@@ -270,8 +279,20 @@ function runSelfTest(workflow) {
   if (check(decoratedSelector).length === 0) {
     throw new Error("mutation escaped policy: dead text replaces the real change selector");
   }
+  const deadZuuliCase = workflow
+    .replace(
+      '          while IFS= read -r file; do\n            case "$file" in',
+      '          while IFS= read -r file; do\n            if false; then\n            case "$file" in',
+    )
+    .replace(
+      '            esac\n            case "$file" in',
+      '            esac\n            fi\n            case "$file" in',
+    );
+  if (check(deadZuuliCase).length === 0) {
+    throw new Error("mutation escaped policy: real ZUULI selector case is dead code");
+  }
   console.log(
-    `Android gate policy self-test passed (${mutations.length + 1} mutations).`,
+    `Android gate policy self-test passed (${mutations.length + 2} mutations).`,
   );
 }
 

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -82,27 +82,48 @@ function check(workflow) {
   requireLine(
     failures,
     android,
-    `targets: ${target}`,
-    `32-bit Android job must install ${target}`,
-  );
-  requireLine(
-    failures,
-    android,
     "run: git submodule update --init z/zcash/librustzcash",
     "32-bit Android job must fetch the in-source Zcash dependency",
   );
-  requireLine(
-    failures,
-    android,
-    `'ndk;${ndk}' >/dev/null`,
-    `32-bit Android job must install NDK ${ndk}`,
-  );
-  requireLine(
-    failures,
-    android,
-    `key: ${cacheKey}`,
-    "32-bit Android cache must bind the target, NDK, and API level",
-  );
+  const expectedTargetStep = [
+    "      - name: Install the pinned 32-bit Android Rust target",
+    "        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable",
+    "        with:",
+    "          toolchain: ${{ steps.rust_toolchain.outputs.version }}",
+    `          targets: ${target}`,
+  ].join("\n");
+  if (
+    namedStep(android, "Install the pinned 32-bit Android Rust target") !==
+    expectedTargetStep
+  ) {
+    failures.push(`32-bit Android job must install ${target} with the pinned action`);
+  }
+  const expectedNdkStep = [
+    "      - name: Install the pinned Android NDK",
+    "        run: |",
+    "          set -euo pipefail",
+    "          set +e",
+    '          yes 2>/dev/null | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \\',
+    `            'ndk;${ndk}' >/dev/null`,
+    "          sdk_status=${PIPESTATUS[1]}",
+    "          set -e",
+    '          [[ "$sdk_status" -eq 0 ]] || { echo "sdkmanager failed ($sdk_status)" >&2; exit 1; }',
+  ].join("\n");
+  if (namedStep(android, "Install the pinned Android NDK") !== expectedNdkStep) {
+    failures.push(`32-bit Android job must install the exact NDK ${ndk}`);
+  }
+  const expectedCacheStep = [
+    "      - name: Restore the 32-bit Android Rust cache",
+    "        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2",
+    "        with:",
+    "          workspaces: wallet/plugins/tauri-plugin-zcash",
+    `          key: ${cacheKey}`,
+  ].join("\n");
+  if (
+    namedStep(android, "Restore the 32-bit Android Rust cache") !== expectedCacheStep
+  ) {
+    failures.push("32-bit Android cache must bind its pinned action, target, NDK, and API level");
+  }
   const expectedTypecheckStep = [
     "      - name: Type-check the shared plugin on 32-bit Android",
     "        run: |",
@@ -160,6 +181,21 @@ function runSelfTest(workflow) {
     ["the target check is replaced", `--target ${target}`, "--target aarch64-linux-android"],
     ["the pinned NDK is changed", `'ndk;${ndk}'`, "'ndk;latest'"],
     ["the cache drops its NDK boundary", `key: ${cacheKey}`, "key: zuuli-plugin-android-armv7"],
+    [
+      "the target action is replaced by decorative text",
+      "      - name: Install the pinned 32-bit Android Rust target\n        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable",
+      `      - name: Install the pinned 32-bit Android Rust target\n        run: echo 'targets: ${target}'`,
+    ],
+    [
+      "the NDK install is replaced by decorative text",
+      "      - name: Install the pinned Android NDK\n        run: |\n          set -euo pipefail",
+      `      - name: Install the pinned Android NDK\n        run: echo "'ndk;${ndk}' >/dev/null"`,
+    ],
+    [
+      "the cache action is replaced by decorative text",
+      "      - name: Restore the 32-bit Android Rust cache\n        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2",
+      `      - name: Restore the 32-bit Android Rust cache\n        run: echo 'key: ${cacheKey}'`,
+    ],
     [
       "the job is detached from change detection",
       "  rust_android_32:\n    name: Rust / Android 32-bit\n    needs: changes",

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const workflowPath = ".github/workflows/zuuli.yml";
 const policyPath = "scripts/check-zuuli-android-gate.mjs";
+const toolchainEnvPath = "wallet/zuuli/scripts/android-toolchain-env.sh";
 const target = "armv7-linux-androideabi";
 const ndk = "27.0.12077973";
 const cacheKey = `zuuli-plugin-android-armv7-ndk${ndk}-api29`;
@@ -45,7 +46,7 @@ function requireLine(failures, contents, expected, message) {
   if (!lines.includes(expected)) failures.push(message);
 }
 
-function check(workflow) {
+function check(workflow, toolchainEnv) {
   const failures = [];
   const changes = job(workflow, "changes");
   const android = job(workflow, "rust_android_32");
@@ -150,6 +151,21 @@ function check(workflow) {
   if (typecheckStep !== expectedTypecheckStep) {
     failures.push("32-bit Android type-check step must execute the exact reviewed command block");
   }
+  const requiredArchiverLines = [
+    'export AR_aarch64_linux_android="$zuuli_ndk_bin/llvm-ar"',
+    'export AR_armv7_linux_androideabi="$zuuli_ndk_bin/llvm-ar"',
+    'export AR_i686_linux_android="$zuuli_ndk_bin/llvm-ar"',
+    'export AR_x86_64_linux_android="$zuuli_ndk_bin/llvm-ar"',
+    '[[ -x "$zuuli_ndk_bin/llvm-ar" ]] || {',
+  ];
+  for (const line of requiredArchiverLines) {
+    requireLine(
+      failures,
+      toolchainEnv,
+      line,
+      `Android toolchain environment must retain pinned NDK archiver contract: ${line}`,
+    );
+  }
 
   const expectedGateHeader = [
     "  gate:",
@@ -201,7 +217,7 @@ function check(workflow) {
   return failures;
 }
 
-function runSelfTest(workflow) {
+function runSelfTest(workflow, toolchainEnv) {
   const mutations = [
     ["the armv7 target is replaced", `targets: ${target}`, "targets: aarch64-linux-android"],
     ["the target check is replaced", `--target ${target}`, "--target aarch64-linux-android"],
@@ -261,13 +277,13 @@ function runSelfTest(workflow) {
     ],
   ];
 
-  const baseline = check(workflow);
+  const baseline = check(workflow, toolchainEnv);
   if (baseline.length > 0) {
     throw new Error(`cannot self-test an invalid baseline:\n${baseline.join("\n")}`);
   }
   for (const [name, from, to] of mutations) {
     if (!workflow.includes(from)) throw new Error(`self-test fixture missing: ${name}`);
-    const failures = check(workflow.replace(from, to));
+    const failures = check(workflow.replace(from, to), toolchainEnv);
     if (failures.length === 0) throw new Error(`mutation escaped policy: ${name}`);
   }
   const decoratedSelector = workflow
@@ -276,7 +292,7 @@ function runSelfTest(workflow) {
       "  frontend:\n",
       `  # Dead decoration must not satisfy the real selector.\n  # if false; then : '|${policyPath}|'; fi\n  frontend:\n`,
     );
-  if (check(decoratedSelector).length === 0) {
+  if (check(decoratedSelector, toolchainEnv).length === 0) {
     throw new Error("mutation escaped policy: dead text replaces the real change selector");
   }
   const deadZuuliCase = workflow
@@ -288,19 +304,27 @@ function runSelfTest(workflow) {
       '            esac\n            case "$file" in',
       '            esac\n            fi\n            case "$file" in',
     );
-  if (check(deadZuuliCase).length === 0) {
+  if (check(deadZuuliCase, toolchainEnv).length === 0) {
     throw new Error("mutation escaped policy: real ZUULI selector case is dead code");
   }
+  const missingArmv7Archiver = toolchainEnv.replace(
+    'export AR_armv7_linux_androideabi="$zuuli_ndk_bin/llvm-ar"',
+    'export AR_armv7_linux_androideabi="arm-linux-androideabi-ar"',
+  );
+  if (check(workflow, missingArmv7Archiver).length === 0) {
+    throw new Error("mutation escaped policy: armv7 uses an unpinned archiver");
+  }
   console.log(
-    `Android gate policy self-test passed (${mutations.length + 2} mutations).`,
+    `Android gate policy self-test passed (${mutations.length + 3} mutations).`,
   );
 }
 
 const workflow = readFileSync(resolve(repoRoot, workflowPath), "utf8");
+const toolchainEnv = readFileSync(resolve(repoRoot, toolchainEnvPath), "utf8");
 if (process.argv.includes("--self-test")) {
-  runSelfTest(workflow);
+  runSelfTest(workflow, toolchainEnv);
 } else {
-  const failures = check(workflow);
+  const failures = check(workflow, toolchainEnv);
   if (failures.length > 0) {
     console.error(failures.map((failure) => `- ${failure}`).join("\n"));
     process.exit(1);

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const workflowPath = ".github/workflows/zuuli.yml";
+const policyPath = "scripts/check-zuuli-android-gate.mjs";
+const target = "armv7-linux-androideabi";
+
+function job(workflow, name) {
+  const start = new RegExp(`^  ${name}:\\n`, "m").exec(workflow);
+  if (!start) return "";
+  const tail = workflow.slice(start.index + start[0].length);
+  const next = /^  [a-zA-Z0-9_]+:\n/m.exec(tail);
+  return workflow.slice(
+    start.index,
+    next ? start.index + start[0].length + next.index : workflow.length,
+  );
+}
+
+function requireLine(failures, contents, expected, message) {
+  const lines = contents.split("\n").map((line) => line.trim());
+  if (!lines.includes(expected)) failures.push(message);
+}
+
+function check(workflow) {
+  const failures = [];
+  const changes = job(workflow, "changes");
+  const android = job(workflow, "rust_android_32");
+  const gate = job(workflow, "gate");
+
+  const changeLines = changes.split("\n").map((line) => line.trim());
+  if (!changeLines.includes(`node ${policyPath} --self-test`)) {
+    failures.push("changes job must run the Android gate policy self-test");
+  }
+  if (!changeLines.includes(`node ${policyPath}`)) {
+    failures.push("changes job must enforce the Android gate policy");
+  }
+  const escapedPolicyPath = policyPath.replaceAll(".", "\\.");
+  if (!new RegExp(`^\\s+[^#\\n]*\\|${escapedPolicyPath}\\|`, "m").test(workflow)) {
+    failures.push("Android gate policy changes must select the full ZUULI suite");
+  }
+
+  if (!android) failures.push("required rust_android_32 job is missing");
+  requireLine(
+    failures,
+    android,
+    "name: Rust / Android 32-bit",
+    "32-bit Android job must retain its stable check name",
+  );
+  requireLine(
+    failures,
+    android,
+    "needs: changes",
+    "32-bit Android job must depend on change detection",
+  );
+  requireLine(
+    failures,
+    android,
+    "if: needs.changes.outputs.zuuli == 'true'",
+    "32-bit Android job must run for every ZUULI-impacting change",
+  );
+  requireLine(
+    failures,
+    android,
+    `targets: ${target}`,
+    `32-bit Android job must install ${target}`,
+  );
+  requireLine(
+    failures,
+    android,
+    "run: git submodule update --init z/zcash/librustzcash",
+    "32-bit Android job must fetch the in-source Zcash dependency",
+  );
+  requireLine(
+    failures,
+    android,
+    "source wallet/zuuli/scripts/android-toolchain-env.sh",
+    "32-bit Android job must use the pinned NDK linker environment",
+  );
+  requireLine(
+    failures,
+    android,
+    `cargo check --locked --target ${target} --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml`,
+    "32-bit Android job must type-check the shared plugin for armv7 with its lockfile",
+  );
+
+  if (!/^\s+needs: \[[^\n]*\brust_android_32\b[^\n]*\]$/m.test(gate)) {
+    failures.push("gate must await rust_android_32");
+  }
+  requireLine(
+    failures,
+    gate,
+    "RUST_ANDROID_32_RESULT: ${{ needs.rust_android_32.result }}",
+    "gate must read the 32-bit Android result",
+  );
+  if (!/^\s+results="[^\n]*\$RUST_ANDROID_32_RESULT[^\n]*"$/m.test(gate)) {
+    failures.push("gate must enforce the 32-bit Android result");
+  }
+
+  return failures;
+}
+
+function runSelfTest(workflow) {
+  const mutations = [
+    ["the armv7 target is replaced", `targets: ${target}`, "targets: aarch64-linux-android"],
+    ["the target check is replaced", `--target ${target}`, "--target aarch64-linux-android"],
+    [
+      "the job is detached from change detection",
+      "  rust_android_32:\n    name: Rust / Android 32-bit\n    needs: changes",
+      "  rust_android_32:\n    name: Rust / Android 32-bit\n    needs: []",
+    ],
+    ["the job is removed from gate needs", ", rust_android_32", ""],
+    [
+      "the gate result input is redirected",
+      "RUST_ANDROID_32_RESULT: ${{ needs.rust_android_32.result }}",
+      "RUST_ANDROID_32_RESULT: success",
+    ],
+    ["the policy no longer selects itself", `|${policyPath}|`, "|"],
+    [
+      "the live policy invocation is removed",
+      `          node ${policyPath}\n`,
+      "",
+    ],
+  ];
+
+  const baseline = check(workflow);
+  if (baseline.length > 0) {
+    throw new Error(`cannot self-test an invalid baseline:\n${baseline.join("\n")}`);
+  }
+  for (const [name, from, to] of mutations) {
+    if (!workflow.includes(from)) throw new Error(`self-test fixture missing: ${name}`);
+    const failures = check(workflow.replace(from, to));
+    if (failures.length === 0) throw new Error(`mutation escaped policy: ${name}`);
+  }
+  console.log(`Android gate policy self-test passed (${mutations.length} mutations).`);
+}
+
+const workflow = readFileSync(resolve(repoRoot, workflowPath), "utf8");
+if (process.argv.includes("--self-test")) {
+  runSelfTest(workflow);
+} else {
+  const failures = check(workflow);
+  if (failures.length > 0) {
+    console.error(failures.map((failure) => `- ${failure}`).join("\n"));
+    process.exit(1);
+  }
+  console.log(`Required ZUULI gate type-checks ${target}.`);
+}

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -48,37 +48,43 @@ function check(workflow) {
   const android = job(workflow, "rust_android_32");
   const gate = job(workflow, "gate");
 
-  const changeLines = changes.split("\n").map((line) => line.trim());
-  if (!changeLines.includes(`node ${policyPath} --self-test`)) {
-    failures.push("changes job must run the Android gate policy self-test");
+  const expectedPolicyStep = [
+    "      - name: Verify the required 32-bit Android type-check policy",
+    "        run: |",
+    `          node ${policyPath} --self-test`,
+    `          node ${policyPath}`,
+  ].join("\n");
+  if (
+    namedStep(changes, "Verify the required 32-bit Android type-check policy") !==
+    expectedPolicyStep
+  ) {
+    failures.push("changes job must execute the exact Android gate policy step");
   }
-  if (!changeLines.includes(`node ${policyPath}`)) {
-    failures.push("changes job must enforce the Android gate policy");
-  }
-  const escapedPolicyPath = policyPath.replaceAll(".", "\\.");
-  if (!new RegExp(`^\\s+[^#\\n]*\\|${escapedPolicyPath}\\|`, "m").test(workflow)) {
+  const detector = namedStep(changes, "Detect release-impacting ZUULI changes");
+  const zuuliCase = detector.match(
+    /case "\$file" in\n\s+([^\n]+)\)\n\s+zuuli=true/,
+  );
+  const selectedPatterns = zuuliCase?.[1].split("|").map((entry) => entry.trim()) ?? [];
+  if (!selectedPatterns.includes(policyPath)) {
     failures.push("Android gate policy changes must select the full ZUULI suite");
   }
 
   if (!android) failures.push("required rust_android_32 job is missing");
-  requireLine(
-    failures,
-    android,
-    "name: Rust / Android 32-bit",
-    "32-bit Android job must retain its stable check name",
-  );
-  requireLine(
-    failures,
-    android,
-    "needs: changes",
-    "32-bit Android job must depend on change detection",
-  );
-  requireLine(
-    failures,
-    android,
-    "if: needs.changes.outputs.zuuli == 'true'",
-    "32-bit Android job must run for every ZUULI-impacting change",
-  );
+  const expectedAndroidHeader = [
+    "  rust_android_32:",
+    "    name: Rust / Android 32-bit",
+    "    needs: changes",
+    "    if: needs.changes.outputs.zuuli == 'true'",
+    "    runs-on: ubuntu-latest",
+    "    timeout-minutes: 35",
+    "    steps:",
+  ].join("\n");
+  if (!android.startsWith(expectedAndroidHeader)) {
+    failures.push("32-bit Android job must retain its exact required-job header");
+  }
+  if (/^\s+continue-on-error:/m.test(android)) {
+    failures.push("32-bit Android job and steps must fail closed");
+  }
   requireLine(
     failures,
     android,
@@ -136,8 +142,19 @@ function check(workflow) {
     failures.push("32-bit Android type-check step must execute the exact reviewed command block");
   }
 
-  if (!/^\s+needs: \[[^\n]*\brust_android_32\b[^\n]*\]$/m.test(gate)) {
+  const expectedGateHeader = [
+    "  gate:",
+    "    needs: [changes, frontend, rust_fmt, rust_deny, rust_clippy, rust_plugin, rust_android_32, rust_app, zuuallet_schema]",
+    "    if: always()",
+    "    runs-on: ubuntu-latest",
+    "    timeout-minutes: 5",
+    "    steps:",
+  ].join("\n");
+  if (!gate.startsWith(expectedGateHeader)) {
     failures.push("gate must await rust_android_32");
+  }
+  if (/^\s+continue-on-error:/m.test(gate)) {
+    failures.push("required gate and its steps must fail closed");
   }
   requireLine(
     failures,
@@ -228,6 +245,11 @@ function runSelfTest(workflow) {
       `          node ${policyPath}\n`,
       "",
     ],
+    [
+      "the policy invocation is hidden behind a false condition",
+      `          node ${policyPath} --self-test\n          node ${policyPath}`,
+      `          if false; then\n            node ${policyPath} --self-test\n            node ${policyPath}\n          fi`,
+    ],
   ];
 
   const baseline = check(workflow);
@@ -239,7 +261,18 @@ function runSelfTest(workflow) {
     const failures = check(workflow.replace(from, to));
     if (failures.length === 0) throw new Error(`mutation escaped policy: ${name}`);
   }
-  console.log(`Android gate policy self-test passed (${mutations.length} mutations).`);
+  const decoratedSelector = workflow
+    .replace(`|${policyPath}|`, "|")
+    .replace(
+      "  frontend:\n",
+      `  # Dead decoration must not satisfy the real selector.\n  # if false; then : '|${policyPath}|'; fi\n  frontend:\n`,
+    );
+  if (check(decoratedSelector).length === 0) {
+    throw new Error("mutation escaped policy: dead text replaces the real change selector");
+  }
+  console.log(
+    `Android gate policy self-test passed (${mutations.length + 1} mutations).`,
+  );
 }
 
 const workflow = readFileSync(resolve(repoRoot, workflowPath), "utf8");

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -8,6 +8,8 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const workflowPath = ".github/workflows/zuuli.yml";
 const policyPath = "scripts/check-zuuli-android-gate.mjs";
 const target = "armv7-linux-androideabi";
+const ndk = "27.0.12077973";
+const cacheKey = `zuuli-plugin-android-armv7-ndk${ndk}-api29`;
 
 function job(workflow, name) {
   const start = new RegExp(`^  ${name}:\\n`, "m").exec(workflow);
@@ -83,6 +85,18 @@ function check(workflow) {
   requireLine(
     failures,
     android,
+    `'ndk;${ndk}' >/dev/null`,
+    `32-bit Android job must install NDK ${ndk}`,
+  );
+  requireLine(
+    failures,
+    android,
+    `key: ${cacheKey}`,
+    "32-bit Android cache must bind the target, NDK, and API level",
+  );
+  requireLine(
+    failures,
+    android,
     `cargo check --locked --target ${target} --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml`,
     "32-bit Android job must type-check the shared plugin for armv7 with its lockfile",
   );
@@ -107,6 +121,8 @@ function runSelfTest(workflow) {
   const mutations = [
     ["the armv7 target is replaced", `targets: ${target}`, "targets: aarch64-linux-android"],
     ["the target check is replaced", `--target ${target}`, "--target aarch64-linux-android"],
+    ["the pinned NDK is changed", `'ndk;${ndk}'`, "'ndk;latest'"],
+    ["the cache drops its NDK boundary", `key: ${cacheKey}`, "key: zuuli-plugin-android-armv7"],
     [
       "the job is detached from change detection",
       "  rust_android_32:\n    name: Rust / Android 32-bit\n    needs: changes",

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -22,6 +22,21 @@ function job(workflow, name) {
   );
 }
 
+function namedStep(jobContents, name) {
+  const start = new RegExp(`^      - name: ${name.replaceAll("/", "\\/")}\\n`, "m").exec(
+    jobContents,
+  );
+  if (!start) return "";
+  const tail = jobContents.slice(start.index + start[0].length);
+  const next = /^(?:      - (?:name|uses):|  (?=\S))/m.exec(tail);
+  return jobContents
+    .slice(
+      start.index,
+      next ? start.index + start[0].length + next.index : jobContents.length,
+    )
+    .trimEnd();
+}
+
 function requireLine(failures, contents, expected, message) {
   const lines = contents.split("\n").map((line) => line.trim());
   if (!lines.includes(expected)) failures.push(message);
@@ -79,12 +94,6 @@ function check(workflow) {
   requireLine(
     failures,
     android,
-    "source wallet/zuuli/scripts/android-toolchain-env.sh",
-    "32-bit Android job must use the pinned NDK linker environment",
-  );
-  requireLine(
-    failures,
-    android,
     `'ndk;${ndk}' >/dev/null`,
     `32-bit Android job must install NDK ${ndk}`,
   );
@@ -94,12 +103,17 @@ function check(workflow) {
     `key: ${cacheKey}`,
     "32-bit Android cache must bind the target, NDK, and API level",
   );
-  requireLine(
-    failures,
-    android,
-    `cargo check --locked --target ${target} --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml`,
-    "32-bit Android job must type-check the shared plugin for armv7 with its lockfile",
-  );
+  const expectedTypecheckStep = [
+    "      - name: Type-check the shared plugin on 32-bit Android",
+    "        run: |",
+    "          set -euo pipefail",
+    "          source wallet/zuuli/scripts/android-toolchain-env.sh",
+    `          cargo check --locked --target ${target} --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml`,
+  ].join("\n");
+  const typecheckStep = namedStep(android, "Type-check the shared plugin on 32-bit Android");
+  if (typecheckStep !== expectedTypecheckStep) {
+    failures.push("32-bit Android type-check step must execute the exact reviewed command block");
+  }
 
   if (!/^\s+needs: \[[^\n]*\brust_android_32\b[^\n]*\]$/m.test(gate)) {
     failures.push("gate must await rust_android_32");
@@ -110,8 +124,31 @@ function check(workflow) {
     "RUST_ANDROID_32_RESULT: ${{ needs.rust_android_32.result }}",
     "gate must read the 32-bit Android result",
   );
-  if (!/^\s+results="[^\n]*\$RUST_ANDROID_32_RESULT[^\n]*"$/m.test(gate)) {
+  const resultAssignments = gate.match(/^\s+results=.*$/gm) ?? [];
+  if (
+    resultAssignments.length !== 1 ||
+    !resultAssignments[0].includes("$RUST_ANDROID_32_RESULT")
+  ) {
     failures.push("gate must enforce the 32-bit Android result");
+  }
+  const expectedGateStep = [
+    "      - name: Enforce the 32-bit Android result",
+    "        env:",
+    "          ZUULI_CHANGED: ${{ needs.changes.outputs.zuuli }}",
+    "          RUST_ANDROID_32_RESULT: ${{ needs.rust_android_32.result }}",
+    "        run: |",
+    "          set -euo pipefail",
+    '          case "$ZUULI_CHANGED:$RUST_ANDROID_32_RESULT" in',
+    "            true:success|false:skipped) ;;",
+    '            *) echo "32-bit Android result is inconsistent: changed=$ZUULI_CHANGED result=$RUST_ANDROID_32_RESULT"; exit 1 ;;',
+    "          esac",
+  ].join("\n");
+  const gateStep = namedStep(gate, "Enforce the 32-bit Android result");
+  if (gateStep !== expectedGateStep) {
+    failures.push("gate must directly reject an unexpected 32-bit Android result");
+  }
+  if (/\b(?:export\s+)?RUST_ANDROID_32_RESULT\s*=/.test(gate)) {
+    failures.push("gate must not overwrite the 32-bit Android result");
   }
 
   return failures;
@@ -133,6 +170,21 @@ function runSelfTest(workflow) {
       "the gate result input is redirected",
       "RUST_ANDROID_32_RESULT: ${{ needs.rust_android_32.result }}",
       "RUST_ANDROID_32_RESULT: success",
+    ],
+    [
+      "the exact type-check command is hidden behind a false condition",
+      "          source wallet/zuuli/scripts/android-toolchain-env.sh\n",
+      "          if false; then\n          source wallet/zuuli/scripts/android-toolchain-env.sh\n          fi\n",
+    ],
+    [
+      "the gate overwrites the checked result",
+      '          results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_DENY_RESULT $RUST_CLIPPY_RESULT $RUST_PLUGIN_RESULT $RUST_ANDROID_32_RESULT $RUST_APP_RESULT"',
+      '          results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_DENY_RESULT $RUST_CLIPPY_RESULT $RUST_PLUGIN_RESULT $RUST_ANDROID_32_RESULT $RUST_APP_RESULT"\n          results="$FRONTEND_RESULT $RUST_FMT_RESULT $RUST_DENY_RESULT $RUST_CLIPPY_RESULT $RUST_PLUGIN_RESULT $RUST_APP_RESULT"',
+    ],
+    [
+      "the dedicated gate check is disabled",
+      "        run: |\n          set -euo pipefail\n          case \"$ZUULI_CHANGED:$RUST_ANDROID_32_RESULT\" in",
+      "        if: false\n        run: |\n          set -euo pipefail\n          case \"$ZUULI_CHANGED:$RUST_ANDROID_32_RESULT\" in",
     ],
     ["the policy no longer selects itself", `|${policyPath}|`, "|"],
     [

--- a/wallet/zuuli/scripts/android-toolchain-env.sh
+++ b/wallet/zuuli/scripts/android-toolchain-env.sh
@@ -24,6 +24,10 @@ export CXX_aarch64_linux_android="${CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER}++
 export CXX_armv7_linux_androideabi="${CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER}++"
 export CXX_i686_linux_android="${CARGO_TARGET_I686_LINUX_ANDROID_LINKER}++"
 export CXX_x86_64_linux_android="${CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER}++"
+export AR_aarch64_linux_android="$zuuli_ndk_bin/llvm-ar"
+export AR_armv7_linux_androideabi="$zuuli_ndk_bin/llvm-ar"
+export AR_i686_linux_android="$zuuli_ndk_bin/llvm-ar"
+export AR_x86_64_linux_android="$zuuli_ndk_bin/llvm-ar"
 
 for zuuli_compiler in \
   "$CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER" \
@@ -32,4 +36,8 @@ for zuuli_compiler in \
   "$CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER"; do
   [[ -x "$zuuli_compiler" ]] || { echo "missing pinned NDK compiler: $zuuli_compiler" >&2; return 1; }
 done
+[[ -x "$zuuli_ndk_bin/llvm-ar" ]] || {
+  echo "missing pinned NDK archiver: $zuuli_ndk_bin/llvm-ar" >&2
+  return 1
+}
 unset zuuli_compiler zuuli_ndk_bin zuuli_ndk_host


### PR DESCRIPTION
Closes #321

## Summary

- add a required `Rust / Android 32-bit` job that type-checks the shared Zcash plugin for `armv7-linux-androideabi` with the pinned Rust toolchain and NDK
- wire the job result into the stable required `gate` for both ZUULI changes and legitimate skips
- bind target installation, NDK installation, cache restoration, type-check execution, and gate enforcement to exact named-step contracts with a 18-mutation policy self-test

## Verification

- fixed tree: `cargo +1.97.1 check --locked --target armv7-linux-androideabi --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml` — pass
- negative control: temporarily restored the historical bare `st_mode & S_IFMT` expression; the same command failed in 5.3s with the exact E0277/E0308 four-error signature from build 7; restored tree passed again
- `node scripts/check-zuuli-android-gate.mjs --self-test` — 18 mutations caught, including decorative target/NDK/cache/type-check/gate replacements
- `node scripts/check-zuuli-android-gate.mjs`
- `actionlint .github/workflows/zuuli.yml`
- action-pin, Rust-toolchain, and Linux-image policy checks
- `git diff --check`