### PR TITLE
fix(free2z): remove iOS 15 regex lookbehind

### DIFF
--- a/ts/react/free2z/config-overrides.js
+++ b/ts/react/free2z/config-overrides.js
@@ -1,29 +1,48 @@
-const { exit } = require("process")
-const { getCombinedModifierFlags } = require("typescript")
+const path = require("path");
 
+const ios15RegexCompatLoader = path.resolve(
+  __dirname,
+  "scripts/ios15-regex-compat-loader.js"
+);
+const gfmAutolinkEntry = require.resolve("mdast-util-gfm-autolink-literal");
+const gfmAutolinkSource = path.join(
+  path.dirname(gfmAutolinkEntry),
+  "lib/index.js"
+);
 
-// config-overrides.js
 module.exports = function override(config, env) {
-    // New config, e.g. config.plugins.push...
+  // New config, e.g. config.plugins.push...
 
-    console.log(config.resolve)
-    config.resolve.fallback = {
-        // assert: require.resolve('assert'),
-        // crypto: require.resolve('crypto-browserify'),
-        // http: require.resolve('stream-http'),
-        // https: require.resolve('https-browserify'),
-        // os: require.resolve('os-browserify/browser'),
-        // stream: require.resolve('stream-browserify'),
-        // path: require.resolve('path-browserify'),
-        // buffer: require.resolve("buffer/"),
-        // zlib: require.resolve("browserify-zlib"),
-        path: false,
-        fs: false,
-        net: false,
-        tls: false,
-        dns: false,
-        process: false,
-    }
-    return config
-}
+  console.log(config.resolve);
+  config.resolve.fallback = {
+    // assert: require.resolve('assert'),
+    // crypto: require.resolve('crypto-browserify'),
+    // http: require.resolve('stream-http'),
+    // https: require.resolve('https-browserify'),
+    // os: require.resolve('os-browserify/browser'),
+    // stream: require.resolve('stream-browserify'),
+    // path: require.resolve('path-browserify'),
+    // buffer: require.resolve("buffer/"),
+    // zlib: require.resolve("browserify-zlib"),
+    path: false,
+    fs: false,
+    net: false,
+    tls: false,
+    dns: false,
+    process: false,
+  };
 
+  // mdast-util-gfm-autolink-literal@2 emits a lookbehind regex literal.
+  // Safari on iOS 15 rejects the whole bundle while parsing it, before the
+  // app can render. Its existing `previous(match, true)` guard performs the
+  // same boundary check, so remove only that redundant syntax at build time.
+  // The loader fails closed if the upstream source changes shape.
+  config.module.rules.push({
+    test: /\.js$/,
+    include: [gfmAutolinkSource],
+    enforce: "pre",
+    use: [{ loader: ios15RegexCompatLoader }],
+  });
+
+  return config;
+};

--- a/ts/react/free2z/package-lock.json
+++ b/ts/react/free2z/package-lock.json
@@ -104,6 +104,7 @@
         "@types/testing-library__react": "^10.2.0",
         "@types/three": "^0.168.0",
         "@types/uuid": "^10.0.0",
+        "acorn": "^8.15.0",
         "prettier": "2.6.2",
         "react-app-rewired": "^2.2.1"
       }

--- a/ts/react/free2z/package.json
+++ b/ts/react/free2z/package.json
@@ -91,7 +91,8 @@
   "proxy": "https://test.free2z.com",
   "scripts": {
     "start": "react-app-rewired start --host 0.0.0.0",
-    "build": "react-app-rewired build",
+    "prebuild": "node scripts/ios15-regex-compat.test.js",
+    "build": "react-app-rewired build && node scripts/check-ios15-bundle.js",
     "test": "react-app-rewired test",
     "eject": "react-scripts eject",
     "prettier": "prettier -c './**/*.{tsx,js,jsx,ts,json}'",
@@ -127,6 +128,7 @@
     "@types/testing-library__react": "^10.2.0",
     "@types/three": "^0.168.0",
     "@types/uuid": "^10.0.0",
+    "acorn": "^8.15.0",
     "prettier": "2.6.2",
     "react-app-rewired": "^2.2.1"
   }

--- a/ts/react/free2z/scripts/check-ios15-bundle.js
+++ b/ts/react/free2z/scripts/check-ios15-bundle.js
@@ -1,0 +1,71 @@
+const fs = require("fs");
+const path = require("path");
+const acorn = require("acorn");
+
+function findLookbehindRegexLiterals(source, filename = "<source>") {
+  const failures = [];
+  const tokens = acorn.tokenizer(source, {
+    ecmaVersion: "latest",
+    locations: true,
+  });
+
+  for (const token of tokens) {
+    if (
+      token.type.label === "regexp" &&
+      (token.value.pattern.includes("(?<=") ||
+        token.value.pattern.includes("(?<!"))
+    ) {
+      failures.push(
+        `${filename}:${token.loc.start.line}:${token.loc.start.column + 1}`
+      );
+    }
+  }
+
+  return failures;
+}
+
+function javascriptFiles(directory) {
+  if (!fs.existsSync(directory)) {
+    throw new Error(`Missing production bundle directory: ${directory}`);
+  }
+
+  const files = fs
+    .readdirSync(directory)
+    .filter((name) => name.endsWith(".js"))
+    .map((name) => path.join(directory, name));
+
+  if (files.length === 0) {
+    throw new Error(`No JavaScript bundles found in: ${directory}`);
+  }
+
+  return files;
+}
+
+function checkBundle(directory) {
+  return javascriptFiles(directory).flatMap((filename) =>
+    findLookbehindRegexLiterals(fs.readFileSync(filename, "utf8"), filename)
+  );
+}
+
+if (require.main === module) {
+  const bundleDirectory = path.resolve(
+    process.argv[2] || path.join("build", "static", "js")
+  );
+  const failures = checkBundle(bundleDirectory);
+
+  if (failures.length > 0) {
+    console.error(
+      "iOS 15-incompatible lookbehind regex literals found:\n" +
+        failures.map((failure) => `- ${failure}`).join("\n")
+    );
+    process.exitCode = 1;
+  } else {
+    console.log(
+      `iOS 15 regex compatibility passed (${
+        javascriptFiles(bundleDirectory).length
+      } bundles scanned).`
+    );
+  }
+}
+
+module.exports = { checkBundle, findLookbehindRegexLiterals, javascriptFiles };

--- a/ts/react/free2z/scripts/ios15-regex-compat-loader.js
+++ b/ts/react/free2z/scripts/ios15-regex-compat-loader.js
@@ -1,0 +1,22 @@
+const unsupportedEmailPattern = String.raw`/(?<=^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu`;
+const compatibleEmailPattern = String.raw`/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu`;
+const existingBoundaryGuard = "!previous(match, true)";
+
+module.exports = function ios15RegexCompatLoader(source) {
+  const occurrences = source.split(unsupportedEmailPattern).length - 1;
+  const guardOccurrences = source.split(existingBoundaryGuard).length - 1;
+
+  if (occurrences !== 1 || guardOccurrences !== 1) {
+    throw new Error(
+      "Expected one mdast GFM email lookbehind and its existing boundary " +
+        `guard; found ${occurrences} lookbehind(s) and ${guardOccurrences} guard(s). ` +
+        "Re-audit the dependency before changing this compatibility rewrite."
+    );
+  }
+
+  return source.replace(unsupportedEmailPattern, compatibleEmailPattern);
+};
+
+module.exports.compatibleEmailPattern = compatibleEmailPattern;
+module.exports.existingBoundaryGuard = existingBoundaryGuard;
+module.exports.unsupportedEmailPattern = unsupportedEmailPattern;

--- a/ts/react/free2z/scripts/ios15-regex-compat.test.js
+++ b/ts/react/free2z/scripts/ios15-regex-compat.test.js
@@ -1,0 +1,69 @@
+const assert = require("node:assert/strict");
+const loader = require("./ios15-regex-compat-loader");
+const { findLookbehindRegexLiterals } = require("./check-ios15-bundle");
+
+const fixture = `const email = ${loader.unsupportedEmailPattern}\nif (${loader.existingBoundaryGuard}) return false`;
+const rewritten = loader(fixture);
+
+function compile(pattern) {
+  return Function(`return ${pattern}`)();
+}
+
+function guardedMatches(pattern, input) {
+  return [...input.matchAll(pattern)]
+    .filter((match) => {
+      const code = input.charCodeAt(match.index - 1);
+      const previous = String.fromCharCode(code);
+
+      return (
+        (match.index === 0 || /[\s\p{P}\p{S}]/u.test(previous)) && code !== 47
+      );
+    })
+    .map((match) => match[0]);
+}
+
+assert.equal(
+  rewritten,
+  `const email = ${loader.compatibleEmailPattern}\nif (${loader.existingBoundaryGuard}) return false`
+);
+assert.deepEqual(findLookbehindRegexLiterals(fixture), ["<source>:1:15"]);
+assert.deepEqual(findLookbehindRegexLiterals(rewritten), []);
+assert.deepEqual(
+  findLookbehindRegexLiterals(
+    'const text = "/(?<=not executable)/"; const named = /(?<name>x)/'
+  ),
+  []
+);
+assert.deepEqual(
+  findLookbehindRegexLiterals("const negative = /(?<!prefix)value/"),
+  ["<source>:1:18"]
+);
+
+const unsupported = compile(loader.unsupportedEmailPattern);
+const compatible = compile(loader.compatibleEmailPattern);
+for (const input of [
+  "person@example.com",
+  "Contact person@example.com today",
+  "(person@example.com)",
+  "$person@example.com",
+  "/person@example.com",
+  "éperson@example.com",
+  "🙂person@example.com",
+]) {
+  assert.deepEqual(
+    guardedMatches(compatible, input),
+    guardedMatches(unsupported, input),
+    input
+  );
+}
+
+assert.throws(
+  () => loader(`const email = ${loader.unsupportedEmailPattern}`),
+  /found 1 lookbehind\(s\) and 0 guard\(s\)/
+);
+assert.throws(
+  () => loader(`${fixture}\n${fixture}`),
+  /found 2 lookbehind\(s\) and 2 guard\(s\)/
+);
+
+console.log("iOS 15 regex compatibility self-test passed.");


### PR DESCRIPTION
Refs #82

## Current-main reproduction

A clean classic frontend production build currently emits a real `/(?<=…)/gu` regex literal from `mdast-util-gfm-autolink-literal@2.0.1`. Safari on iOS 15 cannot parse that syntax, so the bundle aborts before React can render. The other textual lookbehind matches in a lazy chunk are inert strings, not regex literals.

## Fix

- run a narrowly targeted pre-loader on that dependency source
- remove only the redundant email-boundary lookbehind while preserving its existing `previous(match, true)` boundary guard
- fail closed if either audited upstream source shape changes
- tokenize every emitted JavaScript chunk after production builds and reject executable positive or negative lookbehind literals without false-positive failures on strings
- self-test the rewrite, fail-closed behavior, scanner, and equivalent email-boundary behavior

This changes only the public classic client build; there are no backend, credential, deployment, or private-repository changes.

## Verification

- `npm ci`
- `CI=true npm test -- --watchAll=false` — 2 suites, 3 tests passed
- `CI=false npm run build` — optimized build completed; iOS 15 compatibility check scanned 164 JavaScript bundles with zero executable lookbehind literals
- `npm run prebuild` — compatibility self-test passed
- `git diff --check`

---

_Reviewer note: changed `Closes #82` to `Refs #82`. This does not reach production — the production web monorepo is a separate repository whose build config is unchanged — and #82 is iOS ≤15 support generally, while this fixes the lookbehind symptom only. #82 stays open._
