### PR TITLE
fix(android): keep ChromeOS devices installable

### DIFF
--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs scripts/auth-session-boundary.node-test.mjs scripts/mermaid-security.node-test.mjs scripts/send-review-boundary.node-test.mjs scripts/ui-copy-truncation.node-test.mjs scripts/fixture-privacy.node-test.mjs scripts/apple-credential-boundary.node-test.mjs scripts/release-tag-identity.node-test.mjs scripts/status-freshness.node-test.mjs && node scripts/apple-credential-boundary.mjs && playwright test",
+    "test": "vitest run && node --test scripts/safe-area-contract.node-test.mjs scripts/android-device-catalog.node-test.mjs scripts/auth-session-boundary.node-test.mjs scripts/mermaid-security.node-test.mjs scripts/send-review-boundary.node-test.mjs scripts/ui-copy-truncation.node-test.mjs scripts/fixture-privacy.node-test.mjs scripts/apple-credential-boundary.node-test.mjs scripts/release-tag-identity.node-test.mjs scripts/status-freshness.node-test.mjs && node scripts/apple-credential-boundary.mjs && playwright test",
     "test:mermaid-security": "node scripts/check-mermaid-security.mjs && node --test scripts/mermaid-security.node-test.mjs && playwright test tests/mermaid-security.pw.ts",
     "test:send-review": "node --test scripts/send-review-boundary.node-test.mjs && playwright test tests/send-review.pw.ts",
     "test:apple-credential-boundary": "node --test scripts/apple-credential-boundary.node-test.mjs && node scripts/apple-credential-boundary.mjs",

--- a/wallet/zuuli/scripts/android-device-catalog.node-test.mjs
+++ b/wallet/zuuli/scripts/android-device-catalog.node-test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const manifest = readFileSync(
+  new URL(
+    "../src-tauri/gen/android/app/src/main/AndroidManifest.xml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+function featureDeclarations(name) {
+  const escaped = name.replaceAll(".", "\\.");
+  return manifest.match(
+    new RegExp(
+      `<uses-feature\\s+android:name=["']${escaped}["'][^>]*\\/>`,
+      "g",
+    ),
+  ) ?? [];
+}
+
+test("capture and touch hardware do not filter devices in Google Play", () => {
+  const optionalFeatures = [
+    "android.hardware.camera",
+    "android.hardware.camera.autofocus",
+    "android.hardware.camera.any",
+    "android.hardware.microphone",
+    "android.hardware.touchscreen",
+    "android.hardware.faketouch",
+  ];
+
+  for (const name of optionalFeatures) {
+    const declarations = featureDeclarations(name);
+    assert.equal(declarations.length, 1, `${name} must be declared exactly once`);
+    assert.match(
+      declarations[0],
+      /android:required=["']false["']/,
+      `${name} must remain optional`,
+    );
+  }
+});
+
+test("camera permission remains available for hosts without implying hardware", () => {
+  assert.equal(
+    manifest.match(
+      /<uses-permission\s+android:name=["']android\.permission\.CAMERA["']\s*\/>/g,
+    )?.length,
+    1,
+  );
+});

--- a/wallet/zuuli/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/wallet/zuuli/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -5,10 +5,16 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
-    <!-- Livestream viewers can run without capture hardware. Hosts request
-         camera and microphone access at the point of use. -->
+    <!-- Livestream viewers can run without capture or touch hardware. Hosts
+         request camera and microphone access at the point of use. Explicitly
+         override Android's permission-implied camera and touchscreen filters
+         so Google Play keeps camera-less and non-touch ChromeOS devices. -->
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
     <uses-feature android:name="android.hardware.camera.any" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+    <uses-feature android:name="android.hardware.faketouch" android:required="false" />
 
     <application
         android:allowBackup="false"


### PR DESCRIPTION
Refs #302

## What

- explicitly declare camera, autofocus, camera.any, microphone, touchscreen, and faketouch hardware optional in the generated Android manifest
- retain camera permission for livestream hosts while preventing permission-implied Play device filters
- add a regression contract to the standard ZUULI test suite that requires each optional feature exactly once

## Why

Google Play can infer required camera/autofocus hardware from CAMERA permission, and ChromeOS also needs touchscreen declared optional for non-touch devices. These declarations are correct independently of the reporter hardware because ZUULI requests capture access only at point of use.

## Verification

- node --test scripts/android-device-catalog.node-test.mjs
- npm run typecheck
- npm run build
- git diff --check

This intentionally references rather than closes #302. Play Console catalog, published AAB ABI inventory, and a physical Chromebook install still require post-merge release/device verification.