### PR TITLE
fix(deps): clear aws-lc security advisories

### DIFF
--- a/wallet/deny.toml
+++ b/wallet/deny.toml
@@ -52,25 +52,6 @@ ignore = [
   # reach it from the committed lockfiles.
   # ---------------------------------------------------------------------------
 
-  # aws-lc-sys 0.37.1; reached via rustls 0.23 -> aws-lc-rs -> aws-lc-sys, which
-  # tonic's TLS stack pulls in. Only the plugin and zuuallet lockfiles are
-  # affected: zuuli/src-tauri already resolves aws-lc-rs 1.17.3 -> aws-lc-sys
-  # 0.43.0 and reports none of these five.
-  #
-  # That is the useful signal here. aws-lc-sys 0.38/0.39 is a semver-major bump
-  # for a 0.x crate, so it can only arrive by way of aws-lc-rs — and aws-lc-rs
-  # has since shipped 1.17.x, which requires the fixed line. The blocker named
-  # when these entries were written (aws-lc-rs 1.15.4 pinning 0.37) is therefore
-  # gone; what is left is bumping aws-lc-rs in the two stale lockfiles, which
-  # moves the TLS stack the wallet uses to reach lightwalletd and so belongs in
-  # its own PR with its own build evidence rather than in the tier-1 sweep.
-  # Tracked as tier 2 of #351.
-  { id = "RUSTSEC-2026-0044", reason = "aws-lc-sys 0.37.1 in the plugin and zuuallet lockfiles: X.509 name-constraint bypass; needs >= 0.39.0, reachable only by bumping aws-lc-rs 1.15.4 -> 1.17.x. Already clear in zuuli" },
-  { id = "RUSTSEC-2026-0045", reason = "aws-lc-sys 0.37.1 in the plugin and zuuallet lockfiles: AES-CCM tag-verification timing side channel; needs >= 0.38.0, same aws-lc-rs bump. Already clear in zuuli" },
-  { id = "RUSTSEC-2026-0046", reason = "aws-lc-sys 0.37.1 in the plugin and zuuallet lockfiles: PKCS7_verify chain-validation bypass; needs >= 0.38.0, same aws-lc-rs bump. We do not call PKCS7_verify" },
-  { id = "RUSTSEC-2026-0047", reason = "aws-lc-sys 0.37.1 in the plugin and zuuallet lockfiles: PKCS7_verify signature-validation bypass; needs >= 0.38.0, same aws-lc-rs bump. We do not call PKCS7_verify" },
-  { id = "RUSTSEC-2026-0048", reason = "aws-lc-sys 0.37.1 in the plugin and zuuallet lockfiles: CRL distribution-point scope logic error; needs >= 0.39.0, same aws-lc-rs bump. We do not consume CRLs" },
-
   # rustls-webpki 0.101.7, reached through rustls 0.21 — an old transitive TLS
   # stack that is still in all three lockfiles alongside the current rustls 0.23.
   # The 0.103 line was bumped to 0.103.13 in the tier-1 sweep, which cleared the

--- a/wallet/plugins/tauri-plugin-zcash/Cargo.lock
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.lock
@@ -234,9 +234,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -244,14 +244,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]

--- a/wallet/zuuallet/src-tauri/Cargo.lock
+++ b/wallet/zuuallet/src-tauri/Cargo.lock
@@ -248,9 +248,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -258,14 +258,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- update the standalone plugin and Zuuallet locks from `aws-lc-rs 1.15.4` / `aws-lc-sys 0.37.1` to the `1.17.3` / `0.43.0` line already shipped by ZUULI
- remove the five now-cleared `RUSTSEC-2026-0044` through `RUSTSEC-2026-0048` ignores and their stale rationale
- leave manifests, ZUULI's already-current lock, and the remaining advisory backlog unchanged

Before updating, removing only these ignores made the repository checker report exactly all five advisories in the plugin and Zuuallet graphs, while ZUULI remained clear. Cargo's precise update changed only the two AWS-LC packages and their new `pkg-config` edge in each stale lock.

## Verification

- `scripts/check-rust-deny.sh advisories`
- `scripts/check-rust-deny.sh`
- `cargo test --locked --all-targets` in `wallet/plugins/tauri-plugin-zcash` (105 passed)
- `cargo build --locked && cargo test --locked` in `wallet/zuuli/src-tauri` (14 passed)
- `cargo build --locked && cargo test --locked` in `wallet/zuuallet/src-tauri`
- `scripts/check-rust-clippy.sh`
- `scripts/check-rust-fmt.sh`
- `scripts/check-rust-toolchain.sh --self-test`
- `scripts/check-rust-toolchain.sh`
- `node scripts/check-zcash-permissions.mjs --self-test`
- `node scripts/check-zcash-permissions.mjs`
- `git diff --check`

Refs #351
