### PR TITLE
chore(security): require release code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Release-control changes need review from an owner who did not push the final
+# commit. Branch protection dismisses stale approvals and enforces that
+# separation on the exact merged tree.
+/.github/CODEOWNERS @skyl @azhrcs
+/.github/workflows/ @skyl @azhrcs
+/.github/actions/ @skyl @azhrcs
+
+# Release identity, credential boundaries, packaging, and publication logic.
+/wallet/zuuli/release.json @skyl @azhrcs
+/wallet/zuuli/release.schema.json @skyl @azhrcs
+/wallet/zuuli/scripts/ @skyl @azhrcs
+
+# Native authority/signing configuration and checked-in platform projects.
+/wallet/zuuli/src-tauri/tauri.conf.json @skyl @azhrcs
+/wallet/zuuli/src-tauri/capabilities/ @skyl @azhrcs
+/wallet/zuuli/src-tauri/gen/apple/ @skyl @azhrcs
+/wallet/zuuli/src-tauri/gen/android/ @skyl @azhrcs
+
+# Store-facing metadata and listing media are part of the promoted release.
+/wallet/zuuli/store/ @skyl @azhrcs


### PR DESCRIPTION
Refs #370

## Outcome

Adds source-controlled code ownership for every release-authority surface named by the security audit:

- GitHub workflows and local actions
- release identity/schema and packaging/publication/security scripts
- Tauri capability and native signing/project configuration
- App Store / Play metadata and listing media
- CODEOWNERS itself

Both repository owner `@skyl` and the only other direct write collaborator `@azhrcs` are owners. With the live branch setting that now dismisses stale approvals and rejects approval by the last pusher, either can review the other's exact final tree without making all application paths code-owner-gated.

## Live protection already applied

The repository now has:
- `dismiss_stale_reviews=true`
- `require_last_push_approval=true`
- required linear history
- required conversation resolution
- the existing strict `gate` preserved

After this PR merges and GitHub validates the file, `require_code_owner_reviews` will be enabled. The independent `zuuli-app-stores` environment reviewer remains a separate owner/operator assignment; this PR does not guess who accepts that deployment duty.

## Verification

- `git diff --check`
- GitHub CODEOWNERS parser queried on the pushed branch
- full hosted required gate