### PR TITLE
security: bind macOS SBOMs to shipped artifacts

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -427,19 +427,26 @@ jobs:
           [[ ${#zips[@]} -eq 1 && -f "${zips[0]}" ]] || { echo "expected exactly one macOS app ZIP" >&2; exit 1; }
           node scripts/artifact-sbom.mjs prepare --artifact="${dmgs[0]}" --root=artifact-sbom-work/macos-dmg/root
           node scripts/artifact-sbom.mjs prepare --artifact="${zips[0]}" --root=artifact-sbom-work/macos-zip/root
-      - name: Download Syft for macOS shipped artifacts
+      - name: Scan macOS DMG shipped artifact
         if: runner.os == 'macOS'
-        id: desktop_artifact_syft
-        uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
           syft-version: v1.50.0
-      - name: Scan macOS shipped artifacts
+          path: wallet/zuuli/artifact-sbom-work/macos-dmg/root
+          config: wallet/zuuli/syft-artifact.yaml
+          format: cyclonedx-json
+          output-file: wallet/zuuli/artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json
+          upload-artifact: false
+      - name: Scan macOS app ZIP shipped artifact
         if: runner.os == 'macOS'
-        env:
-          SYFT: ${{ steps.desktop_artifact_syft.outputs.cmd }}
-        run: |
-          "$SYFT" scan dir:artifact-sbom-work/macos-dmg/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json
-          "$SYFT" scan dir:artifact-sbom-work/macos-zip/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          syft-version: v1.50.0
+          path: wallet/zuuli/artifact-sbom-work/macos-zip/root
+          config: wallet/zuuli/syft-artifact.yaml
+          format: cyclonedx-json
+          output-file: wallet/zuuli/artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json
+          upload-artifact: false
       - name: Bind macOS shipped-artifact SBOMs
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -418,6 +418,35 @@ jobs:
           else
             test -n "$(find release-artifacts -type f -print -quit)"
           fi
+      - name: Prepare macOS shipped-artifact inventories
+        if: runner.os == 'macOS'
+        run: |
+          dmgs=(release-artifacts/*.dmg)
+          zips=(release-artifacts/*-macos-universal-unsigned.zip)
+          [[ ${#dmgs[@]} -eq 1 && -f "${dmgs[0]}" ]] || { echo "expected exactly one macOS DMG" >&2; exit 1; }
+          [[ ${#zips[@]} -eq 1 && -f "${zips[0]}" ]] || { echo "expected exactly one macOS app ZIP" >&2; exit 1; }
+          node scripts/artifact-sbom.mjs prepare --artifact="${dmgs[0]}" --root=artifact-sbom-work/macos-dmg/root
+          node scripts/artifact-sbom.mjs prepare --artifact="${zips[0]}" --root=artifact-sbom-work/macos-zip/root
+      - name: Download Syft for macOS shipped artifacts
+        if: runner.os == 'macOS'
+        id: desktop-artifact-syft
+        uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          syft-version: v1.50.0
+      - name: Scan macOS shipped artifacts
+        if: runner.os == 'macOS'
+        env:
+          SYFT: ${{ steps.desktop-artifact-syft.outputs.cmd }}
+        run: |
+          "$SYFT" scan dir:artifact-sbom-work/macos-dmg/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json
+          "$SYFT" scan dir:artifact-sbom-work/macos-zip/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json
+      - name: Bind macOS shipped-artifact SBOMs
+        if: runner.os == 'macOS'
+        run: |
+          dmgs=(release-artifacts/*.dmg)
+          zips=(release-artifacts/*-macos-universal-unsigned.zip)
+          node scripts/artifact-sbom.mjs finalize-artifact --artifact="${dmgs[0]}" --root=artifact-sbom-work/macos-dmg/root --raw-sbom=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json
+          node scripts/artifact-sbom.mjs finalize-artifact --artifact="${zips[0]}" --root=artifact-sbom-work/macos-zip/root --raw-sbom=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json
       - name: Prepare explicitly labeled source inventory
         run: mkdir -p artifact-sbom-work
       - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
@@ -432,6 +461,12 @@ jobs:
         run: node scripts/artifact-sbom.mjs label-source --raw-sbom=artifact-sbom-work/ZUULI-desktop.source.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-desktop.source.sbom.cdx.json --source-root=wallet/zuuli
       - name: Record checksums and provenance
         run: |
+          if [[ "${{ runner.os }}" == macOS ]]; then
+            dmgs=(release-artifacts/*.dmg)
+            zips=(release-artifacts/*-macos-universal-unsigned.zip)
+            node scripts/artifact-sbom.mjs verify-artifact --artifact="${dmgs[0]}" --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json
+            node scripts/artifact-sbom.mjs verify-artifact --artifact="${zips[0]}" --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json
+          fi
           jq -e '(.metadata.properties // [] | any(.name == "free2z:inventory-scope" and .value == "source-tree")) and ((.components // []) | length >= 50)' release-artifacts/ZUULI-desktop.source.sbom.cdx.json
           npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6

--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -429,14 +429,14 @@ jobs:
           node scripts/artifact-sbom.mjs prepare --artifact="${zips[0]}" --root=artifact-sbom-work/macos-zip/root
       - name: Download Syft for macOS shipped artifacts
         if: runner.os == 'macOS'
-        id: desktop-artifact-syft
+        id: desktop_artifact_syft
         uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
           syft-version: v1.50.0
       - name: Scan macOS shipped artifacts
         if: runner.os == 'macOS'
         env:
-          SYFT: ${{ steps.desktop-artifact-syft.outputs.cmd }}
+          SYFT: ${{ steps.desktop_artifact_syft.outputs.cmd }}
         run: |
           "$SYFT" scan dir:artifact-sbom-work/macos-dmg/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json
           "$SYFT" scan dir:artifact-sbom-work/macos-zip/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -903,10 +903,7 @@ jobs:
         run: git submodule update --init z/zcash/librustzcash
         working-directory: .
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          {
-            node-version: "24.18.0",
-          }
+        with: { node-version: "24.18.0" }
       - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with: { toolchain: "${{ env.ZUULI_RUST_VERSION }}" }
       - name: Restore reviewed Linux Rust dependencies
@@ -999,10 +996,7 @@ jobs:
           sudo xcode-select --switch /Applications/Xcode_26.6.app
           xcodebuild -version | grep -Fx 'Xcode 26.6'
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          {
-            node-version: "24.18.0",
-          }
+        with: { node-version: "24.18.0" }
       - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
         with:
           {
@@ -1412,6 +1406,29 @@ jobs:
           mkdir release-artifacts
           cp "$dmg" "signed-macos/ZUULI-${EXPECTED_IDENTITY}-macos-universal.zip" \
             signed-macos/signing-record.json release-artifacts/
+      - name: Prepare macOS shipped-artifact inventories
+        env:
+          RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}
+        run: |
+          node scripts/artifact-sbom.mjs prepare --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --root=artifact-sbom-work/macos-dmg/root
+          node scripts/artifact-sbom.mjs prepare --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --root=artifact-sbom-work/macos-zip/root
+      - name: Download Syft for macOS shipped artifacts
+        id: macos-artifact-syft
+        uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          syft-version: v1.50.0
+      - name: Scan macOS shipped artifacts
+        env:
+          SYFT: ${{ steps.macos-artifact-syft.outputs.cmd }}
+        run: |
+          "$SYFT" scan dir:artifact-sbom-work/macos-dmg/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json
+          "$SYFT" scan dir:artifact-sbom-work/macos-zip/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json
+      - name: Bind macOS shipped-artifact SBOMs
+        env:
+          RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}
+        run: |
+          node scripts/artifact-sbom.mjs finalize-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --root=artifact-sbom-work/macos-dmg/root --raw-sbom=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json
+          node scripts/artifact-sbom.mjs finalize-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --root=artifact-sbom-work/macos-zip/root --raw-sbom=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json
       - name: Prepare explicitly labeled source inventory
         run: mkdir -p artifact-sbom-work
       - uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
@@ -1428,6 +1445,9 @@ jobs:
         run: node scripts/artifact-sbom.mjs label-source --raw-sbom=artifact-sbom-work/ZUULI-macos.source.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos.source.sbom.cdx.json --source-root=wallet/zuuli
       - name: Record checksums and provenance
         run: |
+          RELEASE_IDENTITY=${{ needs.prepare.outputs.identity }}
+          node scripts/artifact-sbom.mjs verify-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json
+          node scripts/artifact-sbom.mjs verify-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json
           jq -e '(.metadata.properties // [] | any(.name == "free2z:inventory-scope" and .value == "source-tree")) and ((.components // []) | length >= 50)' release-artifacts/ZUULI-macos.source.sbom.cdx.json
           node scripts/release-manifest.mjs --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json
       - uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -1412,17 +1412,28 @@ jobs:
         run: |
           node scripts/artifact-sbom.mjs prepare --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --root=artifact-sbom-work/macos-dmg/root
           node scripts/artifact-sbom.mjs prepare --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --root=artifact-sbom-work/macos-zip/root
-      - name: Download Syft for macOS shipped artifacts
-        id: macos_artifact_syft
-        uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+      - name: Scan macOS DMG shipped artifact
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
-          syft-version: v1.50.0
-      - name: Scan macOS shipped artifacts
-        env:
-          SYFT: ${{ steps.macos_artifact_syft.outputs.cmd }}
-        run: |
-          "$SYFT" scan dir:artifact-sbom-work/macos-dmg/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json
-          "$SYFT" scan dir:artifact-sbom-work/macos-zip/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json
+          {
+            syft-version: v1.50.0,
+            path: wallet/zuuli/artifact-sbom-work/macos-dmg/root,
+            config: wallet/zuuli/syft-artifact.yaml,
+            format: cyclonedx-json,
+            output-file: wallet/zuuli/artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json,
+            upload-artifact: false,
+          }
+      - name: Scan macOS app ZIP shipped artifact
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          {
+            syft-version: v1.50.0,
+            path: wallet/zuuli/artifact-sbom-work/macos-zip/root,
+            config: wallet/zuuli/syft-artifact.yaml,
+            format: cyclonedx-json,
+            output-file: wallet/zuuli/artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json,
+            upload-artifact: false,
+          }
       - name: Bind macOS shipped-artifact SBOMs
         env:
           RELEASE_IDENTITY: ${{ needs.prepare.outputs.identity }}

--- a/.github/workflows/zuuli-release.yml
+++ b/.github/workflows/zuuli-release.yml
@@ -1413,13 +1413,13 @@ jobs:
           node scripts/artifact-sbom.mjs prepare --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --root=artifact-sbom-work/macos-dmg/root
           node scripts/artifact-sbom.mjs prepare --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --root=artifact-sbom-work/macos-zip/root
       - name: Download Syft for macOS shipped artifacts
-        id: macos-artifact-syft
+        id: macos_artifact_syft
         uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
         with:
           syft-version: v1.50.0
       - name: Scan macOS shipped artifacts
         env:
-          SYFT: ${{ steps.macos-artifact-syft.outputs.cmd }}
+          SYFT: ${{ steps.macos_artifact_syft.outputs.cmd }}
         run: |
           "$SYFT" scan dir:artifact-sbom-work/macos-dmg/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json
           "$SYFT" scan dir:artifact-sbom-work/macos-zip/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json

--- a/wallet/zuuli/docs/releasing.md
+++ b/wallet/zuuli/docs/releasing.md
@@ -21,14 +21,15 @@ checkout and is not evidence about package contents. Both carry
 `free2z:inventory-scope` metadata so downstream automation need not infer scope
 from a filename.
 
-The packaging smoke workflow scans the unsigned Android AAB and iOS app ZIP.
-The protected release scans the signed Android AAB and iOS IPA. For each of
-these ZIP-family artifacts the release train:
+The packaging smoke workflow scans the unsigned Android AAB, iOS app ZIP,
+macOS app ZIP, and macOS layout DMG. The protected release scans the signed
+Android AAB, iOS IPA, notarized macOS app ZIP, and notarized macOS DMG. For each
+artifact the release train:
 
 1. validates archive member paths and unpacks the actual package;
 2. runs Syft on that unpacked root;
 3. adds a complete, digest-bearing inventory of every regular file and a
-   target-bearing inventory of every safe relative symlink;
+   target-bearing inventory of every safe symlink;
 4. writes a separate binding record containing the exact artifact and SBOM
    SHA-256 digests and byte counts; and
 5. independently re-extracts the exact digest-bound archive into a fresh
@@ -36,16 +37,18 @@ these ZIP-family artifacts the release train:
    manifest and build-provenance attestation are created. Verification never
    accepts the mutable root that Syft scanned as evidence of shipped bytes.
 
+ZIP extraction rejects escaping symlinks. DMGs are mounted read-only at a
+private mountpoint, copied with a walker that never follows symlinks (including
+the canonical absolute `/Applications` link), and detached before Syft runs.
 Any omitted, altered, duplicate, escaping, or unsupported payload entry fails
 closed. Archive size, entry-count, and expanded-byte ceilings bound extraction
 resource use. The release manifest then hashes the artifact, SBOM, and binding
 record, and protected jobs attest every member of `release-artifacts`.
 
-Artifact-level extraction for Linux AppImage, deb, and rpm packages and for the
-macOS DMG and signed app ZIP remains tracked in issue #379. Those jobs retain
-their existing source-tree inventories, now explicitly labeled as such; they
-must not be described as artifact SBOMs until format-specific extraction and
-verification land.
+Artifact-level extraction for Linux AppImage, deb, and rpm packages remains
+tracked in issue #379. Linux retains its explicitly labeled source-tree
+inventory and must not describe it as an artifact SBOM until format-specific
+extraction and verification land.
 
 `release.json` schema v2 is the source of truth. It must remain valid UTF-8 and
 byte-canonical pretty-printed JSON; the verifier uses fatal UTF-8 decoding and
@@ -486,7 +489,6 @@ allowed to execute in a credential-bearing job.
    cannot honestly name its own SHA) or the later release-identity commit. For
    a real promotion, the protected workflow reads the marker from the immutable
    release source and requires all of the following:
-
    - the recorded SHA is on the release commit parent's first-parent history;
    - between that SHA and the release parent, the required ZUULI gate's
      release-impacting surface changed only in `STATUS.md`; and
@@ -501,6 +503,7 @@ allowed to execute in a credential-bearing job.
    dry run nor this source-bound check creates production/native evidence. A
    stale immutable release source also cannot be made eligible for real recovery
    by editing `STATUS.md` later; re-derive first and advance the release identity.
+
 2. Merge only with the required `gate` and `ZUULI / packaging smoke` green.
 3. From a clean version worktree run
    `npm run release:bump -- --version=<VERSION> --build=<BUILD>`, review every
@@ -516,17 +519,17 @@ allowed to execute in a credential-bearing job.
    release, read `release.json`, inspect that identity's exact protected run,
    and confirm both stores directly.
 
-   | Identity | Durable protected-run evidence | Historical result |
-   |---|---|---|
-   | `0.1.0+2` | [run 31245152190](https://github.com/free2z/zuu/actions/runs/31245152190) | Play internal succeeded; iOS exposed the PKCS#12 import failure. |
-   | `0.1.0+3` | [run 31248731230](https://github.com/free2z/zuu/actions/runs/31248731230) | Play internal succeeded; iOS again stopped before upload. |
-   | `0.1.0+4` | [run 31253299730](https://github.com/free2z/zuu/actions/runs/31253299730) | Play internal succeeded; iOS signing/export passed, then generated-plist ordering failed. |
-   | `0.1.0+5` | [run 31254971614](https://github.com/free2z/zuu/actions/runs/31254971614) | Play internal succeeded; Apple rejected a bundled static archive with error 90171. |
-   | `0.1.0+6` | [run 31257912883](https://github.com/free2z/zuu/actions/runs/31257912883) | Both protected jobs succeeded after the static archive became link-only; App Store Connect required the build-specific exempt-encryption answer before beta testing. |
-   | `0.1.0+7` | [run 31270095364](https://github.com/free2z/zuu/actions/runs/31270095364) | iOS upload succeeded with the declaration packaged; Android exposed the 32-bit app-data-migration compile error. |
-   | `0.1.0+8` | [run 31293265075](https://github.com/free2z/zuu/actions/runs/31293265075) | Play internal succeeded and Apple accepted the iOS upload after the cross-ABI fix; the historical workflow did not prove TestFlight group availability. |
-   | `0.1.0+9` | [run 31301302280](https://github.com/free2z/zuu/actions/runs/31301302280) | Play internal succeeded and Apple accepted the iOS upload; the historical workflow did not prove TestFlight group availability. |
-   | `0.1.0+10` | [run 31323759501](https://github.com/free2z/zuu/actions/runs/31323759501) | Play internal succeeded and Apple accepted the iOS upload; use the protected read-only recovery below for current processing/group evidence. |
+   | Identity   | Durable protected-run evidence                                            | Historical result                                                                                                                                                    |
+   | ---------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `0.1.0+2`  | [run 31245152190](https://github.com/free2z/zuu/actions/runs/31245152190) | Play internal succeeded; iOS exposed the PKCS#12 import failure.                                                                                                     |
+   | `0.1.0+3`  | [run 31248731230](https://github.com/free2z/zuu/actions/runs/31248731230) | Play internal succeeded; iOS again stopped before upload.                                                                                                            |
+   | `0.1.0+4`  | [run 31253299730](https://github.com/free2z/zuu/actions/runs/31253299730) | Play internal succeeded; iOS signing/export passed, then generated-plist ordering failed.                                                                            |
+   | `0.1.0+5`  | [run 31254971614](https://github.com/free2z/zuu/actions/runs/31254971614) | Play internal succeeded; Apple rejected a bundled static archive with error 90171.                                                                                   |
+   | `0.1.0+6`  | [run 31257912883](https://github.com/free2z/zuu/actions/runs/31257912883) | Both protected jobs succeeded after the static archive became link-only; App Store Connect required the build-specific exempt-encryption answer before beta testing. |
+   | `0.1.0+7`  | [run 31270095364](https://github.com/free2z/zuu/actions/runs/31270095364) | iOS upload succeeded with the declaration packaged; Android exposed the 32-bit app-data-migration compile error.                                                     |
+   | `0.1.0+8`  | [run 31293265075](https://github.com/free2z/zuu/actions/runs/31293265075) | Play internal succeeded and Apple accepted the iOS upload after the cross-ABI fix; the historical workflow did not prove TestFlight group availability.              |
+   | `0.1.0+9`  | [run 31301302280](https://github.com/free2z/zuu/actions/runs/31301302280) | Play internal succeeded and Apple accepted the iOS upload; the historical workflow did not prove TestFlight group availability.                                      |
+   | `0.1.0+10` | [run 31323759501](https://github.com/free2z/zuu/actions/runs/31323759501) | Play internal succeeded and Apple accepted the iOS upload; use the protected read-only recovery below for current processing/group evidence.                         |
 
    Packaging is a separate credential-free signal. Query the
    [scheduled packaging runs](https://github.com/free2z/zuu/actions/workflows/zuuli-packaging.yml?query=event%3Aschedule)
@@ -534,6 +537,7 @@ allowed to execute in a credential-bearing job.
    [run 32006817573](https://github.com/free2z/zuu/actions/runs/32006817573)
    is the cache-free, all-target success recorded for the commit audited by
    issue #389.
+
 5. Inspect the signed packages, SBOMs, checksum manifests, and GitHub
    attestations. For a dry run or partial-failure recovery, dispatch **ZUULI /
    protected release** with the exact full SHA, identity, missing target, and
@@ -655,7 +659,7 @@ that ZUULI's non-OS cryptography uses published, non-proprietary algorithms and
 is limited to its Zcash wallet and financial-transaction functionality. Build 6
 proved this answer through App Store Connect, and Build 7 makes it package data.
 
-Apple directs apps that use no encryption *or only exempt encryption* to set the
+Apple directs apps that use no encryption _or only exempt encryption_ to set the
 Boolean to `NO`; omitting the key causes the export-compliance questions to recur
 for each upload. Apple also says the developer remains responsible for the
 classification and may have separate reporting obligations. See Apple's

--- a/wallet/zuuli/scripts/artifact-sbom.mjs
+++ b/wallet/zuuli/scripts/artifact-sbom.mjs
@@ -768,9 +768,8 @@ export function artifactSbomWorkflowFailures(packaging, release) {
       [
         'node scripts/artifact-sbom.mjs prepare --artifact="${dmgs[0]}" --root=artifact-sbom-work/macos-dmg/root',
         'node scripts/artifact-sbom.mjs prepare --artifact="${zips[0]}" --root=artifact-sbom-work/macos-zip/root',
-        "uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d",
-        '"$SYFT" scan dir:artifact-sbom-work/macos-dmg/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json',
-        '"$SYFT" scan dir:artifact-sbom-work/macos-zip/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json',
+        "output-file: wallet/zuuli/artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json",
+        "output-file: wallet/zuuli/artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json",
         'node scripts/artifact-sbom.mjs finalize-artifact --artifact="${dmgs[0]}" --root=artifact-sbom-work/macos-dmg/root --raw-sbom=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json',
         'node scripts/artifact-sbom.mjs finalize-artifact --artifact="${zips[0]}" --root=artifact-sbom-work/macos-zip/root --raw-sbom=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json',
         'node scripts/artifact-sbom.mjs verify-artifact --artifact="${dmgs[0]}" --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json',
@@ -785,9 +784,8 @@ export function artifactSbomWorkflowFailures(packaging, release) {
       [
         'node scripts/artifact-sbom.mjs prepare --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --root=artifact-sbom-work/macos-dmg/root',
         'node scripts/artifact-sbom.mjs prepare --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --root=artifact-sbom-work/macos-zip/root',
-        "uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d",
-        '"$SYFT" scan dir:artifact-sbom-work/macos-dmg/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json',
-        '"$SYFT" scan dir:artifact-sbom-work/macos-zip/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json',
+        "output-file: wallet/zuuli/artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json",
+        "output-file: wallet/zuuli/artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json",
         'node scripts/artifact-sbom.mjs finalize-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --root=artifact-sbom-work/macos-dmg/root --raw-sbom=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json',
         'node scripts/artifact-sbom.mjs finalize-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --root=artifact-sbom-work/macos-zip/root --raw-sbom=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json',
         'node scripts/artifact-sbom.mjs verify-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json',

--- a/wallet/zuuli/scripts/artifact-sbom.mjs
+++ b/wallet/zuuli/scripts/artifact-sbom.mjs
@@ -277,24 +277,31 @@ function cloneMountedTree(sourcePath, destinationPath) {
   visit(source, destinationPath);
 }
 
-function extractDmg(artifact, root) {
+export function extractDmg(
+  artifact,
+  root,
+  { execute = execFileSync } = {},
+) {
   const temporary = mkdtempSync(resolve(tmpdir(), "zuuli-dmg-mount-"));
   const mountpoint = resolve(temporary, "mount");
   mkdirSync(mountpoint);
-  let mounted = false;
+  let attachAttempted = false;
   try {
-    execFileSync(
+    // Treat the mount as live from the instant attach starts. `hdiutil` can
+    // time out or return non-zero after DiskImages has already mounted the
+    // filesystem, so a successful process exit is not a safe cleanup signal.
+    attachAttempted = true;
+    execute(
       "hdiutil",
       ["attach", artifact, "-readonly", "-nobrowse", "-mountpoint", mountpoint],
       { stdio: ["ignore", "ignore", "pipe"], timeout: 120_000 },
     );
-    mounted = true;
     cloneMountedTree(mountpoint, root);
   } finally {
-    let detached = !mounted;
-    if (mounted) {
+    let detached = !attachAttempted;
+    if (attachAttempted) {
       try {
-        execFileSync("hdiutil", ["detach", mountpoint], {
+        execute("hdiutil", ["detach", mountpoint], {
           stdio: ["ignore", "ignore", "pipe"],
           timeout: 120_000,
         });
@@ -304,7 +311,7 @@ function extractDmg(artifact, root) {
           // Spotlight or Finder can briefly hold a newly mounted image. This
           // mount is private and read-only, so a bounded forced detach is the
           // safe fallback used by the release verifier too.
-          execFileSync("hdiutil", ["detach", mountpoint, "-force"], {
+          execute("hdiutil", ["detach", mountpoint, "-force"], {
             stdio: ["ignore", "ignore", "pipe"],
             timeout: 120_000,
           });

--- a/wallet/zuuli/scripts/artifact-sbom.mjs
+++ b/wallet/zuuli/scripts/artifact-sbom.mjs
@@ -3,7 +3,9 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import {
+  chmodSync,
   closeSync,
+  copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -16,6 +18,7 @@ import {
   realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -147,7 +150,10 @@ function zipMembers(artifact) {
   return members;
 }
 
-export function inventoryRoot(rootPath) {
+export function inventoryRoot(
+  rootPath,
+  { allowExternalSymlinks = false } = {},
+) {
   const root = realpathSync(rootPath);
   const entries = [];
   let regularBytes = 0;
@@ -178,7 +184,7 @@ export function inventoryRoot(rootPath) {
         });
       } else if (info.isSymbolicLink()) {
         const target = readlinkSync(absolute);
-        if (isAbsolute(target)) {
+        if (isAbsolute(target) && !allowExternalSymlinks) {
           throw new Error(
             `artifact symlink must be relative: ${path} -> ${target}`,
           );
@@ -186,11 +192,13 @@ export function inventoryRoot(rootPath) {
         if (/[\u0000-\u001f\u007f]/.test(target)) {
           throw new Error(`artifact symlink target has control bytes: ${path}`);
         }
-        const resolvedTarget = realpathSync(absolute);
-        if (!isInside(root, resolvedTarget)) {
-          throw new Error(
-            `artifact symlink escapes payload: ${path} -> ${target}`,
-          );
+        if (!allowExternalSymlinks) {
+          const resolvedTarget = realpathSync(absolute);
+          if (!isInside(root, resolvedTarget)) {
+            throw new Error(
+              `artifact symlink escapes payload: ${path} -> ${target}`,
+            );
+          }
         }
         entries.push({ path, kind: "symlink", target });
       } else {
@@ -205,6 +213,113 @@ export function inventoryRoot(rootPath) {
   return entries;
 }
 
+function artifactFormat(artifact) {
+  const lower = artifact.toLowerCase();
+  if (lower.endsWith(".dmg")) return "dmg";
+  const extension = lower.split(".").at(-1);
+  if (["aab", "ipa", "zip"].includes(extension)) return "zip";
+  throw new Error(`unsupported artifact format .${extension}`);
+}
+
+function cloneMountedTree(sourcePath, destinationPath) {
+  const source = realpathSync(sourcePath);
+  let entries = 0;
+  let regularBytes = 0;
+  mkdirSync(destinationPath);
+  const visit = (sourceDirectory, destinationDirectory) => {
+    for (const entry of readdirSync(sourceDirectory, { withFileTypes: true })) {
+      entries += 1;
+      if (entries > MAX_ARCHIVE_ENTRIES) {
+        throw new Error(
+          `artifact has too many entries: ${entries} > ${MAX_ARCHIVE_ENTRIES}`,
+        );
+      }
+      const sourceEntry = resolve(sourceDirectory, entry.name);
+      const relativePath = relative(source, sourceEntry).split(sep).join("/");
+      if (!safeArchiveMember(relativePath)) {
+        throw new Error(
+          `unsafe mounted artifact path: ${JSON.stringify(relativePath)}`,
+        );
+      }
+      const destinationEntry = resolve(destinationDirectory, entry.name);
+      const info = lstatSync(sourceEntry);
+      if (info.isDirectory()) {
+        mkdirSync(destinationEntry);
+        chmodSync(destinationEntry, info.mode & 0o777);
+        visit(sourceEntry, destinationEntry);
+      } else if (info.isFile()) {
+        regularBytes += info.size;
+        if (regularBytes > MAX_UNPACKED_BYTES) {
+          throw new Error(
+            `artifact expands beyond the ${MAX_UNPACKED_BYTES}-byte safety limit`,
+          );
+        }
+        copyFileSync(sourceEntry, destinationEntry);
+        chmodSync(destinationEntry, info.mode & 0o777);
+      } else if (info.isSymbolicLink()) {
+        const target = readlinkSync(sourceEntry);
+        if (/[\u0000-\u001f\u007f]/.test(target)) {
+          throw new Error(
+            `artifact symlink target has control bytes: ${relativePath}`,
+          );
+        }
+        // A read-only DMG commonly ships an absolute /Applications link. Copy
+        // the link bytes without dereferencing them; no destination write can
+        // escape through it because this walker never descends into symlinks.
+        symlinkSync(target, destinationEntry);
+      } else {
+        throw new Error(
+          `unsupported mounted artifact member type: ${relativePath}`,
+        );
+      }
+    }
+  };
+  visit(source, destinationPath);
+}
+
+function extractDmg(artifact, root) {
+  const temporary = mkdtempSync(resolve(tmpdir(), "zuuli-dmg-mount-"));
+  const mountpoint = resolve(temporary, "mount");
+  mkdirSync(mountpoint);
+  let mounted = false;
+  try {
+    execFileSync(
+      "hdiutil",
+      ["attach", artifact, "-readonly", "-nobrowse", "-mountpoint", mountpoint],
+      { stdio: ["ignore", "ignore", "pipe"], timeout: 120_000 },
+    );
+    mounted = true;
+    cloneMountedTree(mountpoint, root);
+  } finally {
+    let detached = !mounted;
+    if (mounted) {
+      try {
+        execFileSync("hdiutil", ["detach", mountpoint], {
+          stdio: ["ignore", "ignore", "pipe"],
+          timeout: 120_000,
+        });
+        detached = true;
+      } catch {
+        try {
+          // Spotlight or Finder can briefly hold a newly mounted image. This
+          // mount is private and read-only, so a bounded forced detach is the
+          // safe fallback used by the release verifier too.
+          execFileSync("hdiutil", ["detach", mountpoint, "-force"], {
+            stdio: ["ignore", "ignore", "pipe"],
+            timeout: 120_000,
+          });
+          detached = true;
+        } catch {
+          // Never recursively remove a live mount. Leave the private path in
+          // place for the runner cleanup and fail the artifact boundary.
+        }
+      }
+    }
+    if (!detached) throw new Error("failed to detach artifact DMG safely");
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
 export function prepareArtifact({ artifact, root }) {
   const artifactInfo = requireRegularFile(artifact, "artifact");
   if (artifactInfo.size > MAX_ARCHIVE_BYTES) {
@@ -212,16 +327,19 @@ export function prepareArtifact({ artifact, root }) {
       `artifact exceeds the ${MAX_ARCHIVE_BYTES}-byte safety limit`,
     );
   }
-  const extension = artifact.toLowerCase().split(".").at(-1);
-  if (!["aab", "ipa", "zip"].includes(extension)) {
-    throw new Error(`unsupported artifact format .${extension}`);
-  }
-  zipMembers(artifact);
+  const format = artifactFormat(artifact);
+  if (format === "zip") zipMembers(artifact);
   if (existsSync(root)) throw new Error(`scan root already exists: ${root}`);
   mkdirSync(dirname(root), { recursive: true });
-  mkdirSync(root);
-  execFileSync("unzip", ["-qq", artifact, "-d", root]);
-  const inventory = inventoryRoot(root);
+  if (format === "zip") {
+    mkdirSync(root);
+    execFileSync("unzip", ["-qq", artifact, "-d", root]);
+  } else {
+    extractDmg(artifact, root);
+  }
+  const inventory = inventoryRoot(root, {
+    allowExternalSymlinks: format === "dmg",
+  });
   console.log(
     `unpacked ${basename(artifact)} into ${inventory.length} shipped payload entries`,
   );
@@ -466,7 +584,9 @@ export function finalizeArtifactSbom({
   const document = parseJson(rawSbom, "raw Syft SBOM");
   requireCycloneDx(document, "raw Syft SBOM");
   const artifactInfo = artifactMetadata(artifact);
-  const inventory = inventoryRoot(root);
+  const inventory = inventoryRoot(root, {
+    allowExternalSymlinks: artifactFormat(artifact) === "dmg",
+  });
   const packageComponents = (document.components ?? []).filter((component) => {
     if (component?.type !== "file") return true;
     const properties = propertyMap(component.properties);
@@ -642,6 +762,40 @@ export function artifactSbomWorkflowFailures(packaging, release) {
         "actions/attest-build-provenance@",
       ],
     ],
+    [
+      "packaging macos",
+      jobBlock(packaging, "desktop"),
+      [
+        'node scripts/artifact-sbom.mjs prepare --artifact="${dmgs[0]}" --root=artifact-sbom-work/macos-dmg/root',
+        'node scripts/artifact-sbom.mjs prepare --artifact="${zips[0]}" --root=artifact-sbom-work/macos-zip/root',
+        "uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d",
+        '"$SYFT" scan dir:artifact-sbom-work/macos-dmg/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json',
+        '"$SYFT" scan dir:artifact-sbom-work/macos-zip/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json',
+        'node scripts/artifact-sbom.mjs finalize-artifact --artifact="${dmgs[0]}" --root=artifact-sbom-work/macos-dmg/root --raw-sbom=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json',
+        'node scripts/artifact-sbom.mjs finalize-artifact --artifact="${zips[0]}" --root=artifact-sbom-work/macos-zip/root --raw-sbom=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json',
+        'node scripts/artifact-sbom.mjs verify-artifact --artifact="${dmgs[0]}" --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json',
+        'node scripts/artifact-sbom.mjs verify-artifact --artifact="${zips[0]}" --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json',
+        "npm run release:manifest -- --artifacts=release-artifacts",
+        "actions/upload-artifact@",
+      ],
+    ],
+    [
+      "release macos artifacts",
+      jobBlock(release, "macos-finalize"),
+      [
+        'node scripts/artifact-sbom.mjs prepare --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --root=artifact-sbom-work/macos-dmg/root',
+        'node scripts/artifact-sbom.mjs prepare --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --root=artifact-sbom-work/macos-zip/root',
+        "uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d",
+        '"$SYFT" scan dir:artifact-sbom-work/macos-dmg/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json',
+        '"$SYFT" scan dir:artifact-sbom-work/macos-zip/root --config syft-artifact.yaml --output cyclonedx-json=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json',
+        'node scripts/artifact-sbom.mjs finalize-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --root=artifact-sbom-work/macos-dmg/root --raw-sbom=artifact-sbom-work/macos-dmg/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json',
+        'node scripts/artifact-sbom.mjs finalize-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --root=artifact-sbom-work/macos-zip/root --raw-sbom=artifact-sbom-work/macos-zip/syft.raw.sbom.cdx.json --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json',
+        'node scripts/artifact-sbom.mjs verify-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json',
+        'node scripts/artifact-sbom.mjs verify-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json',
+        "node scripts/release-manifest.mjs --artifacts=release-artifacts",
+        "actions/attest-build-provenance@",
+      ],
+    ],
   ]) {
     requireOrdered(label, block, markers, failures);
   }
@@ -681,6 +835,31 @@ export function artifactSbomWorkflowFailures(packaging, release) {
         '[[ ${#artifacts[@]} -eq 1 && -f "${artifacts[0]}" ]] || { echo "expected exactly one iOS IPA" >&2; exit 1; }',
         "artifact=${artifacts[0]}",
         'node scripts/artifact-sbom.mjs verify-artifact --artifact="$artifact" --sbom=release-artifacts/ZUULI-ios.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-ios.artifact.sbom-binding.json',
+        "node scripts/release-manifest.mjs --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json",
+      ],
+    ],
+    [
+      "packaging macos",
+      jobBlock(packaging, "desktop"),
+      [
+        'if [[ "${{ runner.os }}" == macOS ]]; then',
+        "dmgs=(release-artifacts/*.dmg)",
+        "zips=(release-artifacts/*-macos-universal-unsigned.zip)",
+        'node scripts/artifact-sbom.mjs verify-artifact --artifact="${dmgs[0]}" --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json',
+        'node scripts/artifact-sbom.mjs verify-artifact --artifact="${zips[0]}" --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json',
+        "fi",
+        'jq -e \'(.metadata.properties // [] | any(.name == "free2z:inventory-scope" and .value == "source-tree")) and ((.components // []) | length >= 50)\' release-artifacts/ZUULI-desktop.source.sbom.cdx.json',
+        "npm run release:manifest -- --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json",
+      ],
+    ],
+    [
+      "release macos artifacts",
+      jobBlock(release, "macos-finalize"),
+      [
+        "RELEASE_IDENTITY=${{ needs.prepare.outputs.identity }}",
+        'node scripts/artifact-sbom.mjs verify-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos.dmg" --sbom=release-artifacts/ZUULI-macos-dmg.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-dmg.artifact.sbom-binding.json',
+        'node scripts/artifact-sbom.mjs verify-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json --binding=release-artifacts/ZUULI-macos-zip.artifact.sbom-binding.json',
+        'jq -e \'(.metadata.properties // [] | any(.name == "free2z:inventory-scope" and .value == "source-tree")) and ((.components // []) | length >= 50)\' release-artifacts/ZUULI-macos.source.sbom.cdx.json',
         "node scripts/release-manifest.mjs --artifacts=release-artifacts --checksums=release-artifacts/CHECKSUMS.sha256 --output=release-artifacts/provenance.json",
       ],
     ],

--- a/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
+++ b/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
@@ -199,6 +199,87 @@ test("verification re-extracts the artifact instead of trusting a mutated scan r
   }
 });
 
+test(
+  "macOS DMG inventory is copied without following its Applications link",
+  { skip: process.platform !== "darwin" },
+  () => {
+    const temporary = mkdtempSync(resolve(tmpdir(), "zuuli-artifact-dmg-"));
+    try {
+      const source = resolve(temporary, "source");
+      const executable = resolve(source, "ZUULI.app/Contents/MacOS/ZUULI");
+      mkdirSync(dirname(executable), { recursive: true });
+      writeFileSync(executable, "signed macOS executable fixture\n");
+      symlinkSync("/Applications", resolve(source, "Applications"));
+      const artifact = resolve(temporary, "ZUULI-test.dmg");
+      execFileSync(
+        "hdiutil",
+        [
+          "create",
+          "-quiet",
+          "-ov",
+          "-format",
+          "UDZO",
+          "-volname",
+          "ZUULI test",
+          "-srcfolder",
+          source,
+          artifact,
+        ],
+        { timeout: 120_000 },
+      );
+      const root = resolve(temporary, "unpacked");
+      const rawSbom = resolve(temporary, "raw.cdx.json");
+      const sbom = resolve(temporary, "artifact.sbom.cdx.json");
+      const binding = resolve(temporary, "artifact.sbom-binding.json");
+      writeJson(rawSbom, minimalCycloneDx());
+
+      const inventory = prepareArtifact({ artifact, root });
+      assert.ok(
+        inventory.some(
+          (entry) =>
+            entry.path === "Applications" &&
+            entry.kind === "symlink" &&
+            entry.target === "/Applications",
+        ),
+      );
+      assert.ok(
+        inventory.some(
+          (entry) => entry.path === "ZUULI.app/Contents/MacOS/ZUULI",
+        ),
+      );
+      finalizeArtifactSbom({ artifact, root, rawSbom, sbom, binding });
+      assert.doesNotThrow(() =>
+        verifyArtifactSbom({ artifact, sbom, binding }),
+      );
+
+      writeFileSync(
+        resolve(root, "ZUULI.app/Contents/MacOS/not-shipped.dylib"),
+        "scan-root injection\n",
+      );
+      const poisonedSbom = resolve(temporary, "poisoned.sbom.cdx.json");
+      const poisonedBinding = resolve(temporary, "poisoned.binding.json");
+      finalizeArtifactSbom({
+        artifact,
+        root,
+        rawSbom,
+        sbom: poisonedSbom,
+        binding: poisonedBinding,
+      });
+      assert.throws(
+        () =>
+          verifyArtifactSbom({
+            artifact,
+            sbom: poisonedSbom,
+            binding: poisonedBinding,
+          }),
+        /artifact file inventory count mismatch|omits shipped artifact entry/,
+      );
+    } finally {
+      rmSync(temporary, { recursive: true, force: true });
+    }
+  },
+);
+
 test("source inventory is labeled without pretending to describe an artifact", () => {
   const temporary = mkdtempSync(resolve(tmpdir(), "zuuli-source-sbom-"));
   try {
@@ -275,7 +356,7 @@ test("payload inventory rejects a relative symlink that resolves outside the roo
   }
 });
 
-test("workflow contract catches removal of a mobile artifact scan", () => {
+test("workflow contract catches removal or weakening of artifact scans", () => {
   const packaging = readFileSync(
     resolve(repoRoot, ".github/workflows/zuuli-packaging.yml"),
     "utf8",
@@ -321,5 +402,24 @@ test("workflow contract catches removal of a mobile artifact scan", () => {
       (failure) => failure.includes("packaging ios"),
     ),
     "the policy must reject replacing fresh artifact verification with the mutable Syft root",
+  );
+  const skippedMacDmg = packaging.replace(
+    'node scripts/artifact-sbom.mjs prepare --artifact="${dmgs[0]}" --root=artifact-sbom-work/macos-dmg/root',
+    'node scripts/artifact-sbom.mjs prepare-disabled --artifact="${dmgs[0]}" --root=artifact-sbom-work/macos-dmg/root',
+  );
+  assert.ok(
+    artifactSbomWorkflowFailures(skippedMacDmg, release).some((failure) =>
+      failure.includes("packaging macos"),
+    ),
+  );
+  const mutableMacRoot = release.replace(
+    'node scripts/artifact-sbom.mjs verify-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json',
+    'node scripts/artifact-sbom.mjs verify-artifact --artifact="release-artifacts/ZUULI-${RELEASE_IDENTITY}-macos-universal.zip" --root=artifact-sbom-work/macos-zip/root --sbom=release-artifacts/ZUULI-macos-zip.artifact.sbom.cdx.json',
+  );
+  assert.ok(
+    artifactSbomWorkflowFailures(packaging, mutableMacRoot).some((failure) =>
+      failure.includes("release macos artifacts"),
+    ),
+    "the policy must reject reusing the mutable macOS Syft root for release verification",
   );
 });

--- a/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
+++ b/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   artifactSbomWorkflowFailures,
+  extractDmg,
   finalizeArtifactSbom,
   inventoryRoot,
   labelSourceSbom,
@@ -279,6 +280,76 @@ test(
     }
   },
 );
+
+test("a failed DMG attach is detached before its temporary tree is removed", () => {
+  const temporary = mkdtempSync(resolve(tmpdir(), "zuuli-dmg-attach-failure-"));
+  let mountpoint;
+  const calls = [];
+  try {
+    assert.throws(
+      () =>
+        extractDmg(resolve(temporary, "broken.dmg"), resolve(temporary, "root"), {
+          execute(command, args) {
+            assert.equal(command, "hdiutil");
+            calls.push(args);
+            if (args[0] === "attach") {
+              mountpoint = args.at(-1);
+              throw new Error("attach failed after a partial mount");
+            }
+            return Buffer.alloc(0);
+          },
+        }),
+      /attach failed after a partial mount/,
+    );
+    assert.deepEqual(calls.map((args) => args[0]), ["attach", "detach"]);
+    assert.equal(
+      lstatSync(dirname(mountpoint), { throwIfNoEntry: false }),
+      undefined,
+      "the private tree is removable only after detach succeeds",
+    );
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+});
+
+test("a failed DMG detach leaves the potentially live mount tree intact", () => {
+  const temporary = mkdtempSync(resolve(tmpdir(), "zuuli-dmg-detach-failure-"));
+  let mountpoint;
+  const calls = [];
+  try {
+    assert.throws(
+      () =>
+        extractDmg(resolve(temporary, "broken.dmg"), resolve(temporary, "root"), {
+          execute(command, args) {
+            assert.equal(command, "hdiutil");
+            calls.push(args);
+            if (args[0] === "attach") {
+              mountpoint = args.at(-1);
+              throw new Error("attach timed out after a partial mount");
+            }
+            throw new Error("detach failed");
+          },
+        }),
+      /failed to detach artifact DMG safely/,
+    );
+    assert.deepEqual(calls.map((args) => args.join(" ")), [
+      calls[0].join(" "),
+      `detach ${mountpoint}`,
+      `detach ${mountpoint} -force`,
+    ]);
+    assert.equal(
+      lstatSync(dirname(mountpoint)).isDirectory(),
+      true,
+      "a possibly mounted tree must be left for runner cleanup",
+    );
+  } finally {
+    if (mountpoint) {
+      // The injected command never created a real mount.
+      rmSync(dirname(mountpoint), { recursive: true, force: true });
+    }
+    rmSync(temporary, { recursive: true, force: true });
+  }
+});
 
 test("source inventory is labeled without pretending to describe an artifact", () => {
   const temporary = mkdtempSync(resolve(tmpdir(), "zuuli-source-sbom-"));


### PR DESCRIPTION
## Summary
- safely mount each macOS DMG read-only, clone its payload without following symlinks, and detach before scanning
- generate exact-artifact SBOMs and digest/byte bindings for both DMG and app ZIP in packaging smoke and protected release
- independently re-extract each exact artifact before manifests/provenance; extend workflow mutation policy and DMG adversarial fixtures

## Safety boundary
The canonical absolute `/Applications` link is recorded as link bytes but never traversed. A private mount is detached normally or with bounded forced cleanup; a live mount is never recursively removed. Verification uses a fresh private extraction and rejects a Syft-root-only injection.

## Verification
- artifact SBOM tests 7/7, including real local DMG create/mount/detach and mutation canary
- `actionlint` for both workflows
- `npm run release:verify`
- Prettier and `git diff --check`

Refs #379

This intentionally leaves Linux AppImage/deb/rpm extraction open.