### PR TITLE
fix(zcash): follow current librustzcash API

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/CLAUDE.md
+++ b/wallet/plugins/tauri-plugin-zcash/CLAUDE.md
@@ -31,12 +31,21 @@ pub type WalletProposal = zcash_client_backend::proposal::Proposal<
 
 ## librustzcash API gotchas
 
-- **`BirthdayError`** — has NO `Debug` or `Display` impl. Must pattern-match variants: `BirthdayError::HeightInvalid(e)` and `BirthdayError::Decode(e)`.
+- **`BirthdayError`** — is `#[non_exhaustive]`. Preserve actionable messages
+  for `HeightInvalid` and `Decode`, and retain a wildcard arm for future
+  upstream variants.
 - **`ConfirmationsPolicy`** — at `zcash_client_backend::data_api::wallet::ConfirmationsPolicy`, use `::default()`.
 - **`OvkPolicy`** — at `zcash_client_backend::wallet::OvkPolicy` (NOT `data_api::wallet`).
 - **`SingleOutputChangeStrategy::new`** — 4 args: `(FeeRule, Option<MemoBytes>, ShieldedProtocol, DustOutputPolicy)`.
 - **`Payment::new`** — returns `Result<Self, zip321::PaymentError>` (changed from `Option`), takes `Option<Zatoshis>` for amount. Six args: `(recipient, amount, memo, label, message, other_params)`. Use `.map_err(...)?`, not `.ok_or(...)?`.
-- **`propose_transfer`** — takes **9** args and has phantom `CommitmentTreeErrT`. Use turbofish: `propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(...)`. The last two args are `spend_policy: &input_selection::SpendPolicy` (use `SpendPolicy::default()` to preserve fully-shielded behavior) and `proposed_version: Option<TxVersion>` (use `None` to let target height decide).
+- **`propose_transfer`** — takes **10** args and has phantom
+  `CommitmentTreeErrT`. Use turbofish:
+  `propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(...)`.
+  The last three args are `spend_policy: &input_selection::SpendPolicy` (use
+  `SpendPolicy::default()` to preserve fully-shielded behavior),
+  `lock_inputs: Option<LockRequest>` (currently `None`; durable lock ownership
+  and unlock recovery must be designed together), and
+  `proposed_version: Option<TxVersion>` (`None` lets target height decide).
 - **`create_proposed_transactions`** — takes **8** args and has phantom `InputsErrT` + `ChangeErrT`. Use `std::convert::Infallible` for both. The 8th arg is `expiry_height: Option<BlockHeight>` (use `None` to keep the builder-derived expiry). The transaction version is now carried on the proposal itself (`proposal.proposed_version()`), not passed here.
 - **Ironwood (NU6.3) is a third shielded pool, not a cargo feature.** There is no `ironwood` feature flag; the pool is unconditional in `zcash_protocol` (`ShieldedPool::Ironwood`) and its sync/tree/note plumbing in `zcash_client_backend`/`zcash_client_sqlite` is gated behind the existing **`orchard`** feature (Ironwood reuses `MerkleHashOrchard`). Because we enable `orchard`, we get Ironwood.
 - **`AccountBalance` has THREE shielded pools** — `sapling_balance()`, `orchard_balance()`, `ironwood_balance()`. Any code summing shielded value MUST include Ironwood; after NU6.3 activation Orchard becomes spend-only and new shielded value accrues to Ironwood.

--- a/wallet/plugins/tauri-plugin-zcash/Cargo.lock
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.lock
@@ -692,6 +692,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1172,18 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "endi"
@@ -3215,9 +3236,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -3356,6 +3377,32 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "password-hash",
+]
+
+[[package]]
+name = "pczt"
+version = "0.9.3"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
 ]
 
 [[package]]
@@ -3617,6 +3664,18 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -7023,7 +7082,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7073,7 +7132,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
+version = "0.22.0"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -7087,6 +7146,7 @@ dependencies = [
  "maybe-rayon",
  "nonempty",
  "orchard",
+ "pczt",
  "prost",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -7108,6 +7168,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
+ "zcash_pool_migration",
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
@@ -7118,6 +7179,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -7126,7 +7189,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
+version = "0.16.1"
 dependencies = [
  "bech32",
  "bip32",
@@ -7167,8 +7230,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_pool_migration"
+version = "0.1.0"
+dependencies = [
+ "blake2b_simd",
+ "corez",
+ "getset",
+ "incrementalmerkletree",
+ "libm",
+ "orchard",
+ "pczt",
+ "rand_core 0.6.4",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zip32",
+]
+
+[[package]]
 name = "zcash_primitives"
-version = "0.29.0"
+version = "0.30.1"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7197,7 +7280,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7218,7 +7301,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
+version = "0.10.5"
 dependencies = [
  "corez",
  "document-features",
@@ -7255,7 +7338,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bip32",
  "bs58",
@@ -7385,7 +7468,7 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/wallet/plugins/tauri-plugin-zcash/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/commands.rs
@@ -6,9 +6,7 @@ use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
 use secrecy::ExposeSecret;
 use zcash_client_backend::data_api::wallet::ConfirmationsPolicy;
-use zcash_client_backend::data_api::{
-    Account, AccountBirthday, BirthdayError, WalletRead, WalletWrite,
-};
+use zcash_client_backend::data_api::{Account, AccountBirthday, WalletRead, WalletWrite};
 use zcash_client_backend::proto::service::BlockId;
 use zcash_keys::keys::UnifiedAddressRequest;
 use zeroize::Zeroizing;
@@ -18,13 +16,6 @@ use crate::models::*;
 use crate::wallet::client::connect_to_lightwalletd;
 use crate::wallet::{keys, send, storage};
 use crate::{Result, ZcashExt};
-
-fn format_birthday_error(e: BirthdayError) -> String {
-    match e {
-        BirthdayError::HeightInvalid(e) => format!("invalid height: {e}"),
-        BirthdayError::Decode(e) => format!("decode error: {e}"),
-    }
-}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct PreviousSyncContext {
@@ -336,7 +327,12 @@ pub(crate) async fn create_wallet<R: Runtime>(
         .into_inner();
 
     let birthday = AccountBirthday::from_treestate(tree_state, None)
-        .map_err(|e| Error::DatabaseError(format!("failed to create birthday: {}", format_birthday_error(e))))?;
+        .map_err(|e| {
+            Error::DatabaseError(format!(
+                "failed to create birthday: {}",
+                crate::wallet::format_birthday_error(e),
+            ))
+        })?;
 
     // Allocate an identity, but keep it out of the durable manifest until its
     // database and native seed custody have both committed.
@@ -790,7 +786,12 @@ pub(crate) async fn restore_wallet<R: Runtime>(
 
     let recover_until = zcash_protocol::consensus::BlockHeight::from_u32(chain_tip as u32);
     let birthday = AccountBirthday::from_treestate(tree_state, Some(recover_until))
-        .map_err(|e| Error::DatabaseError(format!("failed to create birthday: {}", format_birthday_error(e))))?;
+        .map_err(|e| {
+            Error::DatabaseError(format!(
+                "failed to create birthday: {}",
+                crate::wallet::format_birthday_error(e),
+            ))
+        })?;
 
     // Allocate an identity, but keep it out of the durable manifest until its
     // database and native seed custody have both committed. Unlike a newly

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/accounts.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/accounts.rs
@@ -1,16 +1,9 @@
-use zcash_client_backend::data_api::{Account, BirthdayError, WalletRead, WalletWrite};
+use zcash_client_backend::data_api::{Account, WalletRead, WalletWrite};
 use zcash_keys::keys::UnifiedAddressRequest;
 
 use crate::error::{Error, Result};
 use crate::models::AccountInfo;
-use crate::wallet::WalletState;
-
-fn format_birthday_error(e: BirthdayError) -> String {
-    match e {
-        BirthdayError::HeightInvalid(e) => format!("invalid height: {e}"),
-        BirthdayError::Decode(e) => format!("decode error: {e}"),
-    }
-}
+use crate::wallet::{WalletState, format_birthday_error};
 
 /// Create a new account in the wallet.
 pub async fn create_account(state: &WalletState) -> Result<AccountInfo> {

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64};
 use tokio::sync::{Mutex, MutexGuard, RwLock};
-use zcash_client_backend::data_api::{Account, WalletRead};
+use zcash_client_backend::data_api::{Account, BirthdayError, WalletRead};
 use zcash_protocol::consensus::Network;
 use zeroize::Zeroizing;
 
@@ -33,6 +33,14 @@ pub type WalletDatabase = zcash_client_sqlite::WalletDb<
     zcash_client_sqlite::util::SystemClock,
     rand::rngs::OsRng,
 >;
+
+pub(crate) fn format_birthday_error(error: BirthdayError) -> String {
+    match error {
+        BirthdayError::HeightInvalid(error) => format!("invalid height: {error}"),
+        BirthdayError::Decode(error) => format!("decode error: {error}"),
+        other => other.to_string(),
+    }
+}
 
 /// Proof that an identity-sensitive operation owns the wallet transition.
 /// Custody retrieval requires this token so a future caller cannot accidentally
@@ -316,5 +324,26 @@ impl WalletState {
             .map_err(|error| {
                 crate::error::Error::KeyError(format!("secure-storage task panicked: {error}"))
             })?
+    }
+}
+
+#[cfg(test)]
+mod birthday_error_tests {
+    use super::format_birthday_error;
+    use std::io;
+    use zcash_client_backend::data_api::BirthdayError;
+
+    #[test]
+    fn known_birthday_errors_keep_actionable_context() {
+        let height_error = u32::try_from(u64::MAX).expect_err("height is out of range");
+        let formatted = format_birthday_error(BirthdayError::HeightInvalid(height_error));
+        assert!(formatted.starts_with("invalid height: "));
+        assert!(formatted.len() > "invalid height: ".len());
+
+        let decode_error = io::Error::new(io::ErrorKind::InvalidData, "bad frontier");
+        assert_eq!(
+            format_birthday_error(BirthdayError::Decode(decode_error)),
+            "decode error: bad frontier",
+        );
     }
 }

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
@@ -13,7 +13,7 @@ use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
 use zcash_client_backend::data_api::WalletRead;
 use zcash_client_backend::data_api::wallet::{
-    ConfirmationsPolicy, SpendingKeys, create_proposed_transactions,
+    ConfirmationsPolicy, LockRequest, SpendingKeys, create_proposed_transactions,
     input_selection::{GreedyInputSelector, SpendPolicy},
     propose_transfer,
 };
@@ -22,6 +22,7 @@ use zcash_client_backend::fees::zip317::SingleOutputChangeStrategy;
 use zcash_client_backend::proto::service::{RawTransaction, TxFilter};
 use zcash_client_backend::wallet::OvkPolicy;
 use zcash_keys::address::Address;
+use zcash_primitives::transaction::TxVersion;
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::PoolType;
 use zcash_protocol::memo::{Memo, MemoBytes};
@@ -70,6 +71,19 @@ const SEND_CONFIRMATION_TOKEN_DOMAIN: &[u8] = b"ZUULI_SEND_CONFIRMATION_TOKEN\0"
 const SEND_FEE_POLICY: &str = "zip317-standard";
 const SEND_CHANGE_POLICY: &str = "zip317-shielded-auto";
 const SEND_CONFIRMATION_TTL: Duration = Duration::from_secs(2 * 60);
+
+fn proposal_lock_request() -> Option<LockRequest> {
+    // The process-local send state machine already serializes proposal and
+    // execution. Preserve the pre-locking API behavior until durable owner and
+    // unlock recovery semantics are designed together.
+    None
+}
+
+fn proposed_transaction_version() -> Option<TxVersion> {
+    // Let librustzcash select the consensus transaction version for the target
+    // height, matching the behavior before this argument was introduced.
+    None
+}
 
 #[derive(Clone, Copy)]
 struct ConfirmationClock {
@@ -1409,7 +1423,8 @@ pub async fn propose_send(
             request,
             policy,
             &SpendPolicy::default(),
-            None,
+            proposal_lock_request(),
+            proposed_transaction_version(),
         )
         .map_err(|e| Error::SendError(format!("failed to propose transfer: {e:?}")));
 
@@ -1566,7 +1581,8 @@ pub async fn propose_send_all(
                 request,
                 policy,
                 &SpendPolicy::default(),
-                None,
+                proposal_lock_request(),
+                proposed_transaction_version(),
             );
 
         drop(db_guard);
@@ -2279,6 +2295,12 @@ mod tests {
     const WALLET_ID: &str = "wallet-a";
     const SESSION_ID: [u8; 32] = [0x11; 32];
     const OTHER_SESSION_ID: [u8; 32] = [0x22; 32];
+
+    #[test]
+    fn proposal_defaults_preserve_unlocked_height_selected_transactions() {
+        assert!(proposal_lock_request().is_none());
+        assert!(proposed_transaction_version().is_none());
+    }
 
     fn pending(status: BroadcastStatus) -> PendingBroadcast {
         PendingBroadcast {

--- a/wallet/zuuallet/src-tauri/Cargo.lock
+++ b/wallet/zuuallet/src-tauri/Cargo.lock
@@ -706,6 +706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1186,18 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "endi"
@@ -3260,9 +3281,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -3407,6 +3428,32 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "password-hash",
+]
+
+[[package]]
+name = "pczt"
+version = "0.9.3"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
 ]
 
 [[package]]
@@ -3668,6 +3715,18 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -7151,7 +7210,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7201,7 +7260,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
+version = "0.22.0"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -7215,6 +7274,7 @@ dependencies = [
  "maybe-rayon",
  "nonempty",
  "orchard",
+ "pczt",
  "prost",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -7236,6 +7296,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
+ "zcash_pool_migration",
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
@@ -7246,6 +7307,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -7254,7 +7317,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
+version = "0.16.1"
 dependencies = [
  "bech32",
  "bip32",
@@ -7295,8 +7358,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_pool_migration"
+version = "0.1.0"
+dependencies = [
+ "blake2b_simd",
+ "corez",
+ "getset",
+ "incrementalmerkletree",
+ "libm",
+ "orchard",
+ "pczt",
+ "rand_core 0.6.4",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zip32",
+]
+
+[[package]]
 name = "zcash_primitives"
-version = "0.29.0"
+version = "0.30.1"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7325,7 +7408,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7346,7 +7429,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
+version = "0.10.5"
 dependencies = [
  "corez",
  "document-features",
@@ -7383,7 +7466,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bip32",
  "bs58",
@@ -7513,7 +7596,7 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/wallet/zuuli/src-tauri/Cargo.lock
+++ b/wallet/zuuli/src-tauri/Cargo.lock
@@ -3445,9 +3445,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -3596,6 +3596,32 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "password-hash",
+]
+
+[[package]]
+name = "pczt"
+version = "0.9.3"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
 ]
 
 [[package]]
@@ -7362,7 +7388,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7412,7 +7438,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
+version = "0.22.0"
 dependencies = [
  "bip32",
  "bitflags 2.13.1",
@@ -7426,6 +7452,7 @@ dependencies = [
  "maybe-rayon",
  "nonempty",
  "orchard",
+ "pczt",
  "prost",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -7447,6 +7474,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
+ "zcash_pool_migration",
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
@@ -7457,6 +7485,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -7465,7 +7495,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
+version = "0.16.1"
 dependencies = [
  "bech32",
  "bip32",
@@ -7506,8 +7536,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_pool_migration"
+version = "0.1.0"
+dependencies = [
+ "blake2b_simd",
+ "corez",
+ "getset",
+ "incrementalmerkletree",
+ "libm",
+ "orchard",
+ "pczt",
+ "rand_core 0.6.4",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zip32",
+]
+
+[[package]]
 name = "zcash_primitives"
-version = "0.29.0"
+version = "0.30.1"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7536,7 +7586,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7557,7 +7607,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
+version = "0.10.5"
 dependencies = [
  "corez",
  "document-features",
@@ -7594,7 +7644,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bip32",
  "bs58",
@@ -7724,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
+version = "0.9.0"
 dependencies = [
  "base64 0.22.1",
  "nom",


### PR DESCRIPTION
Refs #239

Prerequisite for the daily all-first-party upstream-HEAD canary. This keeps the canary green on day one instead of recording a known-red baseline. The umbrella issue remains open for the canary follow-up.

## What changed

- advance `z/zcash/librustzcash` from `6cfb3857d248428cb53c7fb1f2b60ba15d5298a1` to exact upstream HEAD `330e4c0aa9e25199acdb93a56bf70126d0d3f2b9`
- regenerate the plugin, ZUULI, and Zuuallet locks; update Orchard narrowly from 0.15.0 to the compatible 0.15.3 after the stale lock failed current `zcash_primitives`
- pass the new `propose_transfer` `LockRequest` argument as `None`, preserving the existing process-local serialized send behavior until durable lock ownership and unlock recovery are designed together
- continue passing `None` for `TxVersion`, allowing librustzcash to choose it from the target height
- centralize `BirthdayError` formatting and retain a wildcard arm for its new `#[non_exhaustive]` contract
- add focused regression tests for both compatibility decisions and update the plugin API notes

## Local proof (Rust 1.97.1, macOS)

- plugin `cargo check --locked` and `cargo build --locked`
- ZUULI `cargo check --locked` and `cargo build --locked`
- Zuuallet `cargo check --locked` and `cargo build --locked`
- plugin `cargo test --locked --all-targets`: 131 passed
- plugin `cargo check --locked --target aarch64-apple-ios`
- repository rustfmt: 5/5 crates
- clippy negative control + live `-D warnings`: 5/5 crates
- cargo-deny: 5/5 crates (`advisories`, `bans`, `licenses`, `sources`)
- Rust toolchain live + 14 mutation cases
- Zcash permission parity live + negative controls
- GitHub Actions policy live + 70 source, 7 gate, and 99 workflow mutation cases
- public repository boundary live + self-test
- `git diff --check`

Android NDK is not installed on this machine; hosted CI supplies Android and the other platform-specific proof.