### PR TITLE
docs(e2ee): freeze the Phase 1 relay wire specification

### DIFF
--- a/docs/e2ee/ARCHITECTURE.md
+++ b/docs/e2ee/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 [#132](https://github.com/free2z/zuu/issues/132),
 [#133](https://github.com/free2z/zuu/issues/133),
 [#134](https://github.com/free2z/zuu/issues/134).
-**Companion:** [`THREAT-MODEL.md`](./THREAT-MODEL.md),
+**Companion:** [`THREAT-MODEL.md`](./THREAT-MODEL.md), [`WIRE.md`](./WIRE.md),
 [`decisions/`](./decisions/).
 
 This document is written to be read by a third-party security auditor. Where
@@ -329,7 +329,7 @@ is the mechanism we intend to use for component-scoped exports as it stabilizes.
 |---|---|---|---|
 | FROST/DKG (§11) | `free2z/frost/v1` | `ceremony_id` | Session domain separator, transcript binding, outer AEAD for part-2 shares |
 | WebRTC binding (§10) | `free2z/webrtc/v1` | `session_id` | Binds DTLS fingerprints to the group |
-| Queue rotation (§6.2) | `free2z/queue/v1` | `peer_leaf_index` | Derives the next queue addresses without a round trip |
+| Queue rotation (§6.2) | `free2z/queue/v1` | `peer_leaf_index` | Derives the next queue **signing keys** and the rotation schedule — see the correction below |
 | Local history wrap | `free2z/history/v1` | `conversation_id` | At-rest key for retained plaintext |
 
 Because these are exporter outputs, they inherit the group's forward secrecy and
@@ -338,6 +338,17 @@ precisely the "confidential, authenticated, replay-bound channel between an
 agreed participant list" that
 [#132](https://github.com/free2z/zuu/issues/132) requires, obtained from a
 standard instead of invented.
+
+> **Correction (2026-08-23).** An earlier revision of the table above said the
+> queue exporter *"derives the next queue addresses without a round trip."* That
+> is no longer accurate and should not be read as though it were.
+> [ADR 0009](./decisions/0009-queue-addressing-and-binding.md) has the **relay**
+> generate both queue addresses from its own CSPRNG, because client-chosen
+> addresses permit squatting and collisions. The exporter therefore derives the
+> rotation *schedule* and the next queue *signing keys*; the new address comes
+> back from the relay and still has to reach the peer in an in-band advert. **A
+> rotation costs one relay round trip and one in-band message** —
+> [`WIRE.md` §7.5](./WIRE.md#75-rotation-needs-no-new-command).
 
 ### 5.5 What hybrid PQ does and does not buy
 
@@ -380,9 +391,19 @@ Its design follows SimpleX's SMP: pairwise, unidirectional, opaque queues with
 no user identifiers anywhere. We adopt the *protocol design*; the implementation
 is clean-room.
 
-> **Action item (§13-E):** verify SimpleX's server licensing **before** anyone
-> reads their server source. Parts of that project are copyleft and we need a
-> clean-room posture.
+> **§13-E, closed 2026-08-23.** The licence was verified from published
+> repository metadata only, without reading any source file: `simplex-chat/simplexmq`
+> — the reference SMP server — is **AGPL-3.0**. The binding rule and the full
+> clean-room posture are recorded in
+> [`WIRE.md` §15](./WIRE.md#15-clean-room-posture-toward-simplex--blocking-pre-check-resolved):
+> **nobody on this project reads `simplexmq` source**; the design derives solely
+> from the public protocol description.
+
+The relay's wire protocol — transport, framing, canonical serialization, the
+command set, the signing transcript, anti-replay, queue lifecycle, ACK semantics,
+TTLs, padding enforcement, error codes, the capability document, first contact and
+anti-abuse — is specified in [`WIRE.md`](./WIRE.md). Where that document narrows
+or corrects something below, it says so at the point of use.
 
 ### 6.1 What the relay is
 
@@ -443,6 +464,16 @@ via the server. Addresses rotate on a schedule using the
 `free2z/queue/v1` exporter so a long-lived relationship does not present a
 long-lived identifier.
 
+> **This paragraph is circular for a pair that has never spoken**, and the gap is
+> real rather than a detail: there is no path for the `Welcome` that creates the
+> group in the first place, because the recipient has no queue the sender is
+> authorized to write to.
+> [ADR 0011](./decisions/0011-first-contact-contact-queues.md) and
+> [`WIRE.md` §12](./WIRE.md#12-first-contact) close it with a hard-capped
+> **contact queue** whose send side is never bound and whose address is published
+> in the owner's directory entry — together with the honest limits on what its
+> anti-abuse actually buys.
+
 **Fan-out (D2):** a message to a recipient with *d* registered devices is sent
 to *d* queues, one per device, as *d* independently encrypted MLS messages
 (each device is its own MLS leaf). Group messages to a group with *m* member
@@ -476,10 +507,14 @@ Three properties follow, and each is deliberate:
    themselves MLS application messages. The relay cannot forge, suppress
    undetectably (§7), or observe it.
 
-Undelivered ciphertext has a **TTL ceiling** (proposed: 30 days) after which the
-relay drops it and the sender learns only from the continued absence of a
-receipt. Quota and TTL are relay policy and are published in the relay's
-capability document so clients can choose.
+Undelivered ciphertext has a **TTL ceiling** (30 days) after which the relay
+drops it and the sender learns only from the continued absence of a receipt.
+Quota and TTL are relay policy and are published in the relay's capability
+document so clients can choose. The wire-level rules — a per-queue message TTL
+clamped to that 30-day ceiling, a **queue idle TTL** that the merged docs did not
+have and without which the queue table grows without bound, and the exact ACK
+semantics that make delete-on-ack safe — are
+[`WIRE.md` §7.7](./WIRE.md#77-ttls) and [§8](./WIRE.md#8-ack-semantics).
 
 ### 6.4 Delete-on-ack and lost acknowledgements
 
@@ -502,7 +537,13 @@ colluding relay. Real text is ~100 bytes; the padding dominates, which is the
 intent.
 
 > **Open question (§13-F):** bucket sizes need a traffic study. The values above
-> are placeholders chosen for arithmetic convenience, not measurement.
+> are placeholders chosen for arithmetic convenience, not measurement. Because of
+> that, [`WIRE.md` §9](./WIRE.md#9-padding-enforcement) puts the accepted size set
+> in the relay's **capability document** rather than in the protocol, so that
+> adopting the measured answer is an operator config change rather than a
+> federation-wide flag day — and states plainly that the relay's list is a filter,
+> not the source of truth: the property comes from the client padding to its own
+> set before the ciphertext leaves the device.
 
 ### 6.6 Delivery receipts
 
@@ -720,11 +761,28 @@ A CONIKS / SEEMless / Parakeet-lineage **append-only log** of
   loud, non-dismissible alarm on any key change it did not initiate. This is
   what makes an attempted MITM *detectable by the victim*, which is the whole
   point.
+- **Key rotation rules** —
+  [ADR 0014](./decisions/0014-directory-key-rotation.md): a same-key entry is
+  self-signed; a key *change* requires both a rotation proof signed by the
+  outgoing key and a signature by the new key; a *lost* key requires a
+  platform-authority reset that raises a **non-dismissible** peer alarm and
+  applies a multi-day cooldown during which clients keep using the old key. That
+  reset is a real weakening — platform-assisted recovery is indistinguishable
+  from platform-assisted attack — and announcing it loudly is the entire
+  mitigation.
 - **Manual safety-number verification** remains available and is the strongest
   check; ZUULI additionally offers verification over a shielded Zcash memo
   between two users who already know each other's payment address — an
   authenticated, private, *remote* out-of-band channel, which is genuinely
   unusual (see [ADR 0006](./decisions/0006-zcash-coupling.md)).
+
+> **Deliberately still unspecified: the log construction itself.** The
+> `SignedTreeHead` format, the epoch cadence, the inclusion- and
+> consistency-proof encodings, the full `DirectoryEntry` structure and the
+> witness-cosignature message format land in a companion `KT.md` with **ADR
+> 0013**, both of which are blocked on spike
+> [#544](https://github.com/free2z/zuu/issues/544). The gap in the ADR numbering
+> is intentional, so that its absence is visible rather than silent.
 
 ### 9.3 Anti-equivocation without a blockchain
 
@@ -998,10 +1056,11 @@ deliberate.
   local history (§8.1), do we transfer it device-to-device (requiring a secure
   pairing channel), and what does that do to the forward-secrecy claim?
   Unresolved.
-- **E. SimpleX licensing.** Verify the server licence **before** anyone reads
-  their source; adopt the SMP protocol design with a clean-room implementation.
 - **F. Padding bucket sizes.** Need a traffic study; current values are
-  placeholders.
+  placeholders. [`WIRE.md` §9](./WIRE.md#9-padding-enforcement) deliberately puts
+  the size set in the relay's capability document rather than in the protocol, so
+  that adopting the measured answer is a configuration change rather than a
+  federation-wide flag day.
 - **G. Relay redundancy factor *k*.** Default value, and whether it is per
   conversation or global.
 - **H. Push notifications.** APNs/FCM are the standard way to avoid a persistent
@@ -1012,13 +1071,42 @@ deliberate.
 - **I. Anonymous credentials for quota.** The zkgroup/KVAC-style design for
   "prove you paid for capacity without revealing who you are"
   ([ADR 0006](./decisions/0006-zcash-coupling.md), optional tier) is unspecified.
+  It remains the real answer to the abuse cases that
+  [ADR 0012](./decisions/0012-anti-abuse-v1.md) explicitly does **not** close.
 - **K. Handle rename and transfer.** How the KT log represents a handle changing
   owner without creating a MITM window.
+  [ADR 0014](./decisions/0014-directory-key-rotation.md) settles directory *key
+  rotation* — including the lost-key case — and deliberately does **not** settle
+  rename or transfer, which are a change of owner rather than of key and create a
+  MITM window of a different shape. Still open.
 - **L. Encrypted media attachments.** Out of scope for the first release, but the
   storage decision (zero-egress object storage) should be made before we build,
   not after — retrofitting off S3-style egress pricing is painful.
 - **M. Group scale limits.** MLS is O(log N) for rekey but the delivery fan-out
   is O(members × devices). At what size do we need a different fan-out strategy?
+- **N. Proof-of-work function and calibration.** Opened 2026-08-23 by
+  [`WIRE.md` §12.4](./WIRE.md#124-the-honest-limits). v1 specifies a
+  leading-zero-bit search over BLAKE2b, chosen so the relay's verification cost is
+  a single hash — the property that matters under flood. That is also the family
+  of function commodity parallel hardware accelerates best, so it **taxes phones
+  far more than rented GPUs**, and no difficulty setting fixes that. A memory-hard
+  function narrows the hardware gap and multiplies the relay's own verification
+  cost by the same factor. What difficulty is simultaneously a real cost to an
+  attacker and tolerable on a cheap Android device is **unmeasured**, and whether
+  a memory-hard function is affordable at relay scale is undecided.
+- **O. Messaging-handle eligibility for existing accounts.** Opened 2026-08-23 by
+  [`WIRE.md` §14](./WIRE.md#14-handle-charset-for-messaging--blocking-pre-check-resolved).
+  Messaging handles are `[a-z0-9_]{1,30}`, ASCII, so that homograph and
+  mixed-script impersonation does not exist. free2z usernames are broader
+  (`^[\w.@+-]+$`, up to 150 characters), so some existing accounts are not
+  eligible. **How many is not known** — this repository holds no user data — and
+  it must be measured before the rule ships, because it is the difference between
+  a rounding error and a migration project. Two sub-questions are also open:
+  whether the `Creator` model uses Django's Unicode or ASCII username validator
+  (undeterminable from this repository, and it decides whether the platform's
+  existing handle space already contains the homograph surface); and whether the
+  excluded population is served by a separate opt-in messaging handle, which is
+  directory design and touches §13-K.
 
 ### 13.1 Closed
 
@@ -1034,6 +1122,22 @@ finds the answer instead of a hole.
   This closes the question of whether the library has been audited; it does not
   close the question of auditing *our* use of it, which per #305's economics
   remains the dominant cost of the system.
+- **E. SimpleX licensing — closed 2026-08-23.** The check was performed from
+  **published repository metadata only** (GitHub's REST repository endpoint and a
+  top-level contents listing), by an agent working on
+  [#545](https://github.com/free2z/zuu/issues/545). **No source file from that
+  project was fetched, opened or read.** Result:
+  `simplex-chat/simplexmq` — the reference implementation of SMP, i.e. the
+  server — reports **AGPL-3.0**, as does `simplex-chat/simplex-chat`. The
+  operative consequence is recorded as a binding rule in
+  [`WIRE.md` §15](./WIRE.md#15-clean-room-posture-toward-simplex--blocking-pre-check-resolved):
+  **nobody on this project reads `simplexmq` source**, and the design derives
+  solely from the public protocol description. Also recorded there, rather than
+  glossed: the published protocol document lives in that same AGPL repository, so
+  the clean-room posture rests on the distinction between the expression of a
+  specification and the protocol it describes. That is our position, stated so it
+  can be challenged; it is not legal advice, and anything beyond avoiding the code
+  requires actual advice.
 - **J. Retention unanimity — closed 2026-08-08, by removing the premise.** The
   negotiated-unanimity retention model was withdrawn (§8.1). With retention a
   per-user local choice there is no group policy to change unanimously or

--- a/docs/e2ee/README.md
+++ b/docs/e2ee/README.md
@@ -1,10 +1,19 @@
-# free2z E2EE — Phase 0 design documentation
+# free2z E2EE — design and specification
 
-This directory holds the Phase 0 deliverable of
-[issue #305](https://github.com/free2z/zuu/issues/305) — the design of free2z's
-end-to-end encrypted messaging system. **No code ships from Phase 0.** These are
-specifications and decision records written before implementation so that the
-architecture is chosen deliberately and can be reviewed by a third party.
+This directory holds the design of free2z's end-to-end encrypted messaging
+system, from [issue #305](https://github.com/free2z/zuu/issues/305).
+**No code ships from these documents.** They are specifications and decision
+records written before implementation so that the architecture is chosen
+deliberately and can be reviewed by a third party.
+
+- **Phase 0** ([#318](https://github.com/free2z/zuu/issues/318),
+  [#346](https://github.com/free2z/zuu/issues/346)) is the design:
+  `ARCHITECTURE.md`, `THREAT-MODEL.md`, ADRs `0001`–`0007`. It deliberately
+  marked every constant, label and wire encoding a *proposed placeholder*.
+- **Phase 1** ([#545](https://github.com/free2z/zuu/issues/545)) fixes the relay
+  wire protocol: `WIRE.md` and ADRs `0008`–`0012`, `0014`. Nothing could be
+  implemented against placeholders, so this closes those gaps **on the record**,
+  before code exists.
 
 ## Contents
 
@@ -12,7 +21,14 @@ architecture is chosen deliberately and can be reviewed by a third party.
 |---|---|
 | [`ARCHITECTURE.md`](./ARCHITECTURE.md) | The design. Layers, key hierarchy and derivation, delivery-service semantics, retention model, metadata model, federation and relay trust, FROST/DKG application design, open questions. |
 | [`THREAT-MODEL.md`](./THREAT-MODEL.md) | Adversaries, what each can do, and for each one the defense — or a plain statement that there is none. Includes the known, accepted limits. |
-| [`decisions/`](./decisions/) | One ADR per owner decision, `0001`–`0007`. |
+| [`WIRE.md`](./WIRE.md) | The relay protocol, specified for a second implementer: transport, framing, canonical serialization, the command set with request/response shapes and stable error codes, the signing transcript, anti-replay, queue lifecycle, ACK semantics, TTLs, padding enforcement, the capability document, first contact, and anti-abuse. Also carries the two resolved pre-checks — the messaging handle charset (§14) and the SimpleX clean-room posture (§15). |
+| [`decisions/`](./decisions/) | One ADR per decision, `0001`–`0012` and `0014`. |
+
+**Not here yet, deliberately:** `KT.md` and **ADR 0013** — the key-transparency
+log construction (`SignedTreeHead`, epoch cadence, proof encodings, the full
+`DirectoryEntry`, witness-cosignature format). They are blocked on spike
+[#544](https://github.com/free2z/zuu/issues/544). The gap in the ADR numbering is
+intentional so that the absence is visible rather than silent.
 
 ## The binding decisions
 
@@ -31,6 +47,23 @@ which is what ADR 0007 does to ADR 0003.
 | [0005](./decisions/0005-federation.md) | **Federation** — full multi-relay. The relay is a separate small Rust service, open source and self-hostable from the first release. |
 | [0006](./decisions/0006-zcash-coupling.md) | **Zcash** — client-side cryptography only. Seed-derived messaging identity; no blockchain in the critical path. |
 | [0007](./decisions/0007-retention-per-user.md) | **History (supersedes 0003)** — retention is a per-user local choice, plus a non-binding, authenticated ephemeral hint that conforming clients honor. FROST transcripts retained by default because the participant wants the evidence. |
+
+## The Phase 1 wire decisions
+
+Not owner decisions — these are **invented in the specification**, each recording
+what the merged docs left open, the answer chosen, and the alternatives rejected.
+An implementation PR that contradicts one should be rejected, or should first
+change the decision on the record.
+
+| ADR | Decision |
+|---|---|
+| [0008](./decisions/0008-transport-and-serialization.md) | **Transport + serialization** — WebSocket over TLS 1.3 only; `tls_codec` (TLS presentation language); one binary frame per message; **mandatory re-encode equality**, signing over the re-encoded bytes, so there is no parse-versus-verify gap. |
+| [0009](./decisions/0009-queue-addressing-and-binding.md) | **Queue addressing** — the recipient creates the queue and the **relay** generates both addresses from its own CSPRNG; `send_addr` is advertised in-band inside MLS; `BIND_SEND` is **once-only and irreversible**. An operator that binds first steals the write capability — the design makes that **noisy, not impossible**. Narrows `ARCHITECTURE.md` §5.4. |
+| [0010](./decisions/0010-signing-transcript-and-ack-semantics.md) | **Transcript, anti-replay, ACK** — a fixed transcript including a **relay identity binding** (closing a live cross-relay `ACK` replay that deletes messages) and a **TLS exporter channel binding** (absent behind a terminating proxy, and the consequences stated); a bounded timestamp window plus a fail-closed `(key, nonce)` seen-set; ACK cumulative, monotone, idempotent, never selective, never beyond the head. |
+| [0011](./decisions/0011-first-contact-contact-queues.md) | **First contact** — a hard-capped **contact queue** whose send side is never bound, published in the owner's directory entry, accepting unsigned proof-of-work-stamped appends. Closes a genuine hole: there was no path for the `Welcome` that creates the group. PoW taxes phones far more than rented GPUs, and disk exhaustion is made expensive, not closed. |
+| [0012](./decisions/0012-anti-abuse-v1.md) | **Anti-abuse v1** — connection limits, per-queue quotas, PoW-gated queue creation, global backpressure. **Never delete un-acked messages to make room**; refusing new writes is the correct failure mode. States what is not closed. |
+| — | **0013 is deliberately absent** — the key-transparency log construction, blocked on [#544](https://github.com/free2z/zuu/issues/544). |
+| [0014](./decisions/0014-directory-key-rotation.md) | **Directory key rotation** — same-key entries self-signed; a key *change* needs both a rotation proof by the outgoing key and a signature by the new key; a *lost* key needs a platform-authority reset that raises a **non-dismissible** alarm and applies a multi-day cooldown. A real weakening, announced loudly, which is the whole mitigation. |
 
 ## Prior art in this repo
 
@@ -54,6 +87,15 @@ Where each of those is addressed is tabulated in
 
 ## Status
 
-Phase 0 documentation. Nothing here is implemented. The phasing plan lives in
+Specification only. **Nothing here is implemented.** The phasing plan lives in
 [#305 §8](https://github.com/free2z/zuu/issues/305); child issues are filed
 against it.
+
+Phase 0's caveat still governs everything it wrote: constants and encodings it
+marked *proposed* were placeholders. `WIRE.md` and ADRs `0008`–`0012`, `0014`
+replace those placeholders for the relay protocol, and say so where they narrow or
+correct a Phase 0 statement. Everything above the relay — the KT log
+construction, `KeyPackage` publication, push notifications, padding bucket sizes,
+the redundancy factor *k* — remains open and is listed in
+[`ARCHITECTURE.md` §13](./ARCHITECTURE.md#13-open-questions) rather than answered
+by invention.

--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -1,0 +1,1921 @@
+# free2z E2EE — Relay wire protocol, version 1
+
+**Status:** Phase 1 specification. Nothing described here is implemented.
+**Refs:** [#305](https://github.com/free2z/zuu/issues/305) (epic),
+[#545](https://github.com/free2z/zuu/issues/545) (this document),
+[#131](https://github.com/free2z/zuu/issues/131).
+**Companion:** [`ARCHITECTURE.md`](./ARCHITECTURE.md),
+[`THREAT-MODEL.md`](./THREAT-MODEL.md), [`decisions/`](./decisions/).
+**Decides:** [ADR 0008](./decisions/0008-transport-and-serialization.md),
+[0009](./decisions/0009-queue-addressing-and-binding.md),
+[0010](./decisions/0010-signing-transcript-and-ack-semantics.md),
+[0011](./decisions/0011-first-contact-contact-queues.md),
+[0012](./decisions/0012-anti-abuse-v1.md),
+[0014](./decisions/0014-directory-key-rotation.md).
+
+This document is written to be read by a third-party security auditor and by an
+independent implementer. It fixes the wire encodings that
+[`ARCHITECTURE.md`](./ARCHITECTURE.md) deliberately left as *proposed*
+placeholders. Where a property does not hold it is stated as not holding. Where
+something remains undecided it is listed in §16 and in
+[`ARCHITECTURE.md` §13](./ARCHITECTURE.md#13-open-questions), not answered by
+invention.
+
+**Almost everything in this document is invented here.** The merged Phase 0 docs
+named capabilities (`APPEND` / `READ` / `ACK` / `DELETE`) in prose and nothing
+more: no grammar, no serialization, no anti-replay construction, no queue
+lifecycle, no first-contact path, no quotas. Each significant choice below is
+recorded in an ADR with the alternatives that were rejected and why. Nothing here
+should be read as "the merged docs already said this."
+
+---
+
+## 1. Scope
+
+### 1.1 What this document fixes
+
+The relay protocol: transport, framing, canonical serialization, the full command
+set with request and response shapes, the signing transcript, anti-replay, queue
+lifecycle, ACK semantics, TTLs, padding enforcement, stable error codes, the
+capability document, first contact, and anti-abuse v1.
+
+### 1.2 What it deliberately does not fix
+
+**The key-transparency log construction is not in this document and not in this
+change.** `SignedTreeHead` format, epoch cadence, inclusion- and consistency-proof
+encodings, the full `DirectoryEntry` structure and the witness-cosignature message
+format belong in a companion `KT.md` with **ADR 0013**, and both are blocked on
+the outcome of spike [#544](https://github.com/free2z/zuu/issues/544). The ADR
+numbering here skips 0013 for exactly that reason: the gap is intentional and
+visible rather than silent.
+
+Two places below depend on that missing design and say so at the point of use:
+
+- §12.2 — a contact endpoint is a field of a directory entry whose full structure
+  is deferred.
+- §12.5 — MLS `KeyPackage` publication, last-resort key packages and their
+  exhaustion behaviour are directory design, not relay design.
+
+[ADR 0014](./decisions/0014-directory-key-rotation.md) settles directory *key
+rotation* only, and is written so that it can be implemented on whatever log
+construction #544 selects.
+
+### 1.3 Conventions
+
+- **MUST / MUST NOT / SHOULD / MAY** are used in the RFC 2119 sense.
+- All integers are unsigned and **big-endian** (network byte order).
+- `H(label, x)` means `BLAKE2b-256(label || x)` where `label` is the exact ASCII
+  bytes shown, with no separator and no terminator — the idiom already used for
+  `msg_id` in [`ARCHITECTURE.md` §7](./ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering).
+- Structures are written in the **TLS presentation language**
+  ([RFC 8446 §3](https://datatracker.ietf.org/doc/html/rfc8446#section-3)); see §3.
+- "The relay" is the server. "The client" is a ZUULI or WASM device
+  ([ADR 0001](./decisions/0001-platform-priority.md)).
+- A **fatal** error means: send the response, then close the WebSocket
+  connection. A non-fatal error means: send the response, keep the connection.
+
+---
+
+## 2. Transport
+
+### 2.1 WebSocket over TLS, and nothing else
+
+A relay listens for **WebSocket connections over TLS 1.3** and offers no other
+transport.
+
+| Parameter | Value |
+|---|---|
+| Scheme | `wss://` only |
+| Path | `/relay/v1` |
+| Subprotocol | `Sec-WebSocket-Protocol: free2z-relay.v1` |
+| TLS | **1.3 minimum.** A relay MUST NOT negotiate TLS 1.2 or below. |
+| ALPN | `h1` or `h2` as the WebSocket upgrade requires; not otherwise constrained |
+
+The subprotocol header is mandatory in both directions. A relay that does not
+echo `free2z-relay.v1` MUST be treated by the client as not speaking this
+protocol, and the client MUST close rather than guess.
+
+TLS 1.3 is a floor rather than a preference because the channel binding in §5.3
+is the TLS 1.3 exporter (RFC 8446 §7.5); there is no defined binding for this
+protocol over TLS 1.2.
+
+### 2.2 Why exactly one transport
+
+Because [ADR 0001](./decisions/0001-platform-priority.md) requires the WASM web
+client to speak *the same protocol* as ZUULI, and a browser can only open a
+WebSocket. Any second transport — QUIC, a raw TCP framing, an HTTP long-poll
+fallback — would be a transport that only the native client could use, and the
+one thing ADR 0001 buys is that there is no second code path to diverge.
+
+The security argument is separate and stronger: **a second transport is a second
+parser and a second fuzz target.** The relay is an unauthenticated network
+listener that anyone on the internet may speak to before any signature is
+checked. Its attack surface is its parser. Halving the number of parsers is worth
+more than any efficiency a second transport could deliver, and the efficiency
+claim is weak anyway — the cost driver is concurrent connections, not framing
+overhead ([ADR 0005](./decisions/0005-federation.md)).
+
+See [ADR 0008](./decisions/0008-transport-and-serialization.md).
+
+### 2.3 Listener rules, and the insecure override
+
+A relay **MUST refuse to bind a non-loopback address without TLS.** This is a
+startup check, not a warning: the process exits.
+
+An operator may override it with an explicit flag (`--insecure-listen`, or the
+equivalent configuration key). Local development on a container network, and
+deployments that terminate TLS in a sidecar on the same host, are real cases and
+we do not pretend otherwise. The override carries three obligations:
+
+1. The relay MUST set `transport_security: "none"` in its capability document
+   (§11). The override is not a private operational detail; it is published.
+2. The relay MUST set `channel_binding_mode: "none"` (§5.3), because there is no
+   TLS session from which to export.
+3. Clients MUST refuse such a relay by default and MUST require an explicit,
+   per-relay user opt-in to connect. The UI must state that message ciphertext is
+   protected by MLS but that connection metadata, queue addresses and commands
+   travel in the clear.
+
+A relay that lies about `transport_security` is a relay that is lying in its
+signed capability document; the point of publishing it is that lying becomes an
+act with evidence rather than an omission.
+
+### 2.4 Keepalive
+
+**The relay sends a WebSocket Ping every 25 seconds** on every open connection
+and closes the connection after two consecutive missed Pongs (~75 s). The
+interval is published as `ws_ping_interval_seconds`.
+
+This is load-bearing rather than cosmetic. A relay is almost always deployed
+behind a load balancer or reverse proxy with a backend idle timeout, and a
+subscribed client on a quiet queue sends nothing for hours. If the proxy's idle
+timeout is below the ping interval, every long-lived subscription is torn down on
+a timer, every client reconnects, and the relay sees a reconnect storm that looks
+like an attack and behaves like one.
+
+- Operators **MUST** set any front-end idle timeout to at least **3×** the ping
+  interval.
+- Server-side ping is chosen over client-side deliberately: the browser
+  WebSocket API cannot send a Ping frame at all, so a client-driven keepalive
+  would have to be an application-level message, which means a second mechanism
+  that only one of the two clients uses. Same reasoning as §2.2.
+- Clients MUST respond to Ping with Pong (browsers do this in the runtime) and
+  SHOULD additionally treat 90 s of total silence as a dead connection.
+
+### 2.5 Connection lifecycle
+
+1. TLS 1.3 handshake, subprotocol negotiation.
+2. The client sends `HELLO` (§6.1). It MUST be the first frame. A relay that
+   receives any other frame first responds `ERR_UNSUPPORTED_VERSION` and closes.
+3. The client verifies the relay's identity proof (§6.1) and, if it holds an
+   expected `relay_id` from an in-band advert (§7.2), compares it. A mismatch is
+   fatal and MUST be surfaced, not retried against.
+4. Commands, pipelined, in any order (§4).
+5. Close. Either side may close at any time; an in-flight command whose response
+   was not received has **unknown** status and MUST be retried under the retry
+   rules in §8.3 and §7.3.
+
+A relay MUST cap the time between TCP accept and a valid `HELLO`
+(`handshake_timeout_ms`, default 10 000) and close on expiry.
+
+---
+
+## 3. Serialization
+
+### 3.1 The choice: `tls_codec`
+
+Every frame body is encoded with the **TLS presentation language** of
+[RFC 8446 §3](https://datatracker.ietf.org/doc/html/rfc8446#section-3), as
+implemented by the `tls_codec` crate.
+
+Three reasons, in the order that decided it:
+
+1. **It is canonical by construction, because no encoding options exist.** There
+   is no indefinite-length form, no map, no key ordering question, no duplicate
+   key, no tag, no float, no "shortest form" rule to enforce. A value of a given
+   type has exactly one encoding. Canonicalization is not a rule the
+   implementation has to remember to apply; it is the absence of any alternative.
+   This matters here more than usual because we sign over encoded bytes (§5).
+2. **It is already in the client's dependency graph.** OpenMLS is built on
+   `tls_codec` — RFC 9420 is itself written in the TLS presentation language. The
+   crypto core already contains this decoder, already ships it to WASM, and
+   already has it in whatever audit scope the core has. Adding CBOR would add a
+   second serializer to the WASM bundle and to the audit.
+3. **An auditor reading an MLS system reads TLS presentation syntax without
+   translation.** The reviewer who is checking our framing against RFC 9420 is
+   already fluent in this notation. Presenting the relay protocol in a different
+   notation costs the reviewer a translation step on every structure, for no gain.
+
+### 3.2 Why not CBOR, and why not a hand-rolled codec
+
+**CBOR** ([RFC 8949](https://datatracker.ietf.org/doc/html/rfc8949)) is the
+obvious alternative and it was rejected. CBOR has *many* encodings of the same
+value: definite and indefinite lengths, non-minimal integer widths, map key
+ordering, duplicate keys, and tags. It has a canonical profile
+([deterministically encoded CBOR](https://datatracker.ietf.org/doc/html/rfc8949#section-4.2)),
+which is precisely the problem — a canonical *profile* is a rule that an
+implementation must apply correctly and that a decoder will happily let you skip.
+Every "canonical CBOR" bug in the wild is a decoder that accepted a
+non-conforming encoding and a verifier that then signed or compared the wrong
+bytes. We would be adding a serializer whose *default* behaviour is unsafe for
+our use, in order to gain self-description we do not want. The relay is not an
+extensible document format; it is a fixed command set.
+
+**A hand-rolled codec** was rejected on the plainest grounds available: it is a
+new parser, written by us, on the unauthenticated path, and it would be the only
+component of the relay with no prior review anywhere. `tls_codec` is not
+formally verified either, but it is exercised by every MLS implementation that
+uses it.
+
+### 3.3 The re-encode-equality rule — mandatory
+
+On every received frame, in both directions, the receiver MUST:
+
+1. **Decode** the bytes into the typed structure.
+2. **Re-encode** that structure with the same codec.
+3. **Byte-compare** the re-encoding against the received bytes.
+4. Use the **re-encoded** bytes — never the received bytes — as the input to any
+   hash or signature operation (§5).
+
+**A mismatch at step 3 is a fatal `ERR_MALFORMED`.** No retry, no partial
+acceptance, no "we understood what you meant": send the error and close the
+connection.
+
+This is the single rule that closes the parse-versus-verify gap. The class of bug
+it eliminates is the one where a decoder is more permissive than the encoder —
+trailing bytes after the last field, an over-wide length prefix, a vector whose
+declared length exceeds its contents, an unknown-variant byte silently mapped to
+a default. In such a system two parties can disagree about what a signature
+covered while both believe they verified it. With re-encode equality there is
+exactly one byte string that a given value can be, the signature covers that byte
+string, and any encoding that is not it is rejected before any state changes.
+
+Note honestly what this rule is and is not. The TLS presentation language is
+already unambiguous, so re-encode equality is **not** compensating for format
+ambiguity — it is compensating for *implementation slack* in decoders, which is
+where the bugs actually are. It costs one extra encode per frame, which is
+negligible against a signature verification, and it converts a whole class of
+subtle divergence into an immediate, loud, testable failure.
+
+### 3.4 Notation
+
+```
+uint8, uint16, uint32, uint64      fixed-width, big-endian
+opaque x[n]                        fixed-length byte string
+opaque x<0..2^k-1>                 variable-length, k-bit length prefix
+struct { ... } Name;               fixed field order, no padding
+enum { a(1), b(2), (255) } Name;   explicit width from the maximum
+```
+
+Byte strings that appear in URLs, adverts or human-readable documents are written
+**base64url without padding**. On the wire they are raw bytes.
+
+### 3.5 Versioning
+
+`protocol_version` is a `uint16`. Version 1 is `0x0001`.
+
+- A relay MUST reject a request whose command code it does not know with
+  `ERR_UNKNOWN_COMMAND` (non-fatal).
+- A relay MUST NOT skip unknown trailing bytes in a body — §3.3 forbids it.
+  **There is no "ignore unknown fields" extensibility in v1.** Adding a field to
+  an existing command is a new command code or a new protocol version, and that
+  is deliberate: silent tolerance of unknown bytes is how a signature ends up
+  covering something the verifier did not look at.
+- Version negotiation happens once, in `HELLO`, and applies to the whole
+  connection.
+
+---
+
+## 4. Framing
+
+### 4.1 One frame, one message
+
+**One binary WebSocket frame carries exactly one request, one response, or one
+push.** There is no in-frame batching and no message that spans frames. A
+WebSocket implementation's own fragmentation is transparent and irrelevant here;
+what matters is that one *message* is one protocol unit.
+
+```
+enum { request(1), response(2), push(3), (255) } FrameKind;
+
+struct {
+    FrameKind kind;
+    uint32    request_id;
+    select (RelayFrame.kind) {
+        case request:  Request;
+        case response: Response;
+        case push:     Push;
+    } payload;
+} RelayFrame;
+
+struct {
+    uint16      command;
+    CommandAuth auth;
+    opaque      body<0..2^24-1>;
+} Request;
+
+struct {
+    uint16 status;                  /* 0 = ok; otherwise an error code from §10 */
+    opaque body<0..2^24-1>;         /* MUST be empty when status != 0 */
+} Response;
+
+struct {
+    uint16 event;
+    opaque body<0..2^24-1>;
+} Push;
+```
+
+**Error responses carry a code and nothing else.** There is no human-readable
+message field, deliberately: a free-text field on an unauthenticated path is a
+covert channel out of the relay, a fingerprinting surface, and a place where
+implementations leak internal state by accident. Diagnostics belong in the
+operator's own logs.
+
+`max_frame_bytes` is published (default 1 MiB). A frame exceeding it is
+`ERR_MALFORMED`, fatal — the relay MUST NOT buffer the remainder to produce a
+tidy error.
+
+### 4.2 Text frames are rejected
+
+A WebSocket **text** frame is a fatal `ERR_FRAME_TYPE`, and the connection closes
+with WebSocket status 1003 (unsupported data). The relay MUST NOT attempt to
+decode it, MUST NOT attempt UTF-8 validation beyond what the WebSocket layer
+already did, and MUST NOT treat it as an accidental binary frame.
+
+This is a one-line rule with a real purpose: it removes any path by which a
+browser-side bug, a proxy that transcodes, or an attacker's crafted intermediary
+can present the same bytes through two different framings.
+
+### 4.3 Request ids, pipelining and the in-flight window
+
+- `request_id` is chosen by the client, is a nonzero `uint32`, and MUST be unique
+  among that connection's currently in-flight requests. It MAY be reused after
+  its response has been received.
+- Push frames use `request_id = 0`.
+- **Responses may arrive out of order.** A client MUST correlate by
+  `request_id` and MUST NOT assume ordering. A relay MAY complete a cheap `PING`
+  before an expensive `READ` issued earlier, and will.
+- **A bounded in-flight window.** `max_inflight` is published (default 32).
+  Issuing a request while `max_inflight` are outstanding is a fatal
+  `ERR_TOO_MANY_INFLIGHT`. The bound exists so that a single connection cannot
+  make the relay allocate unbounded per-request state before any quota check has
+  run — it is an anti-abuse control (§13.1) as much as a flow-control one.
+- A duplicate `request_id` among in-flight requests is a fatal `ERR_MALFORMED`.
+
+Out-of-order responses plus a bounded window is the smallest design that lets a
+client fetch, acknowledge and append concurrently on one connection without
+head-of-line blocking, and without giving the relay an unbounded queue.
+
+### 4.4 Pushes
+
+A push is unsolicited and unacknowledged at the framing layer. Push events are
+listed in §6.4. A client that has not subscribed receives no pushes; a client
+that has subscribed and cannot keep up is subject to §13.1's backpressure rules,
+not to unbounded server-side buffering.
+
+---
+
+## 5. The signing transcript
+
+### 5.1 Construction
+
+Every **signed** command carries a `SignedAuth` and is authenticated by an
+Ed25519 signature over a `CommandTranscript`. The transcript is a fixed-shape
+structure, encoded with `tls_codec` (§3) and signed directly — Ed25519 is not
+prehashed and the transcript is small.
+
+```
+struct {
+    uint8 present;                       /* 0 = unsigned command, 1 = signed */
+    select (CommandAuth.present) {
+        case 0: struct {};
+        case 1: SignedAuth;
+    } auth;
+} CommandAuth;
+
+struct {
+    opaque address[32];        /* the queue address acted on; zeros where none */
+    opaque signer_key[32];     /* Ed25519 public key claimed to authorize this */
+    uint64 timestamp_ms;       /* client clock, milliseconds since Unix epoch  */
+    opaque nonce[16];          /* client CSPRNG, fresh per command             */
+    opaque signature[64];      /* Ed25519 over CommandTranscript               */
+} SignedAuth;
+
+struct {
+    opaque label<0..255>;      /* exactly "free2z/relay/v1/cmd"                */
+    uint16 protocol_version;
+    opaque relay_id[32];       /* §5.2                                         */
+    opaque channel_binding[32];/* §5.3                                         */
+    uint16 command;
+    uint32 request_id;
+    opaque address[32];
+    opaque signer_key[32];
+    uint64 timestamp_ms;
+    opaque nonce[16];
+    opaque body_hash[32];      /* H("free2z/relay/v1/body", body)              */
+} CommandTranscript;
+```
+
+`body_hash` is computed over the **re-encoded** body bytes per §3.3. Carrying a
+hash rather than the body keeps the transcript fixed-length and keeps the
+signature independent of body size.
+
+Verification order at the relay, and it matters:
+
+1. Decode and re-encode-compare the frame (§3.3). Fail → `ERR_MALFORMED`, fatal.
+2. Check `timestamp_ms` against the window (§5.5). Fail → `ERR_STALE_TIMESTAMP`.
+3. Check `(signer_key, nonce)` against the seen-set (§5.5). Fail → `ERR_REPLAY`.
+4. Reconstruct `CommandTranscript` from the relay's own `relay_id`, its own
+   computed `channel_binding`, and the frame's fields. Verify the signature.
+   Fail → `ERR_BAD_SIGNATURE`.
+5. Look up the address and check that `signer_key` is the key registered for it.
+   Fail → `ERR_NO_ACCESS` (§10 — the same code as "no such queue").
+6. Apply quota and policy. Then, and only then, mutate state.
+
+Steps 2 and 3 precede signature verification because they are cheap and they are
+the flood-resistant filters; step 5 follows verification so that an unsigned
+guess cannot probe the address space.
+
+### 5.2 Relay identity binding — the attack it closes
+
+```
+relay_id = H("free2z/relay/v1/relay-id", relay_identity_pk)
+```
+
+where `relay_identity_pk` is the relay's long-term Ed25519 public key. It is
+published in the capability document, returned in `HELLO`, and **included in
+every signed command's transcript.**
+
+Without it there is a live attack, not a theoretical one.
+[ADR 0005](./decisions/0005-federation.md) has a device publishing its queue
+addresses on *k* relays and senders sending to all *k*. Suppose relay A and
+relay B both host queues for the same pair. A signed `APPEND` sent to A is a
+self-contained, valid, signed message. Relay A takes that frame verbatim and
+submits it to relay B. Nothing in the frame says which relay it was for, so B
+verifies the signature happily and applies it. The same holds for `ACK`, and
+`ACK` is worse: relay A replays the recipient's cumulative `ACK` to relay B and
+**B deletes ciphertext the recipient never received from B.** That is silent,
+permanent message loss caused by one relay against another, using only bytes the
+victim itself signed.
+
+Binding the transcript to `relay_id` makes a signature valid at exactly one
+relay. A frame replayed elsewhere fails at step 4.
+
+Two consequences follow, and both are requirements:
+
+- **The relay MUST prove possession of the identity key**, otherwise any relay
+  could simply claim another's `relay_id` and the binding would be decoration.
+  The `HELLO` response carries
+  `relay_proof = Sign(relay_identity_sk, "free2z/relay/v1/hello" || channel_binding || client_nonce)`,
+  and the client MUST verify it before sending any signed command.
+- **The client must know which `relay_id` to expect.** It does: a queue advert
+  (§7.2) travels inside the MLS group and carries `(relay_url, relay_id,
+  send_addr)` together, authenticated by the peer. A relay substituted at the DNS
+  or TLS layer presents a different `relay_id`, the client compares, and the
+  mismatch is fatal. This is the same shape as the WebRTC fingerprint rule in
+  [`ARCHITECTURE.md` §10](./ARCHITECTURE.md#10-p2p-webrtc--an-optimization-not-a-dependency):
+  the identifying material comes from inside the authenticated channel, never
+  from the infrastructure being authenticated.
+
+### 5.3 TLS exporter channel binding — with the caveat stated
+
+```
+channel_binding = TLS-Exporter("EXPORTER-free2z-relay-v1", "", 32)
+```
+
+per [RFC 8446 §7.5](https://datatracker.ietf.org/doc/html/rfc8446#section-7.5)
+(exporters; see also [RFC 5705](https://datatracker.ietf.org/doc/html/rfc5705)).
+Both ends compute it from their own TLS state; it is never transmitted. The relay
+recomputes it and reconstructs the transcript with its own value, so a signature
+made on a different TLS session simply fails to verify.
+
+This binds a signed command to the exact TLS session it was issued on. Combined
+with §5.2 it means a captured frame is useless anywhere except the connection it
+was captured from — and on that connection, §5.5 catches it.
+
+**The honest caveat: a relay behind a TLS-terminating proxy cannot compute it.**
+If TLS is terminated at a load balancer, a CDN, or an ingress controller, the
+relay process has no TLS session and no exporter. This is a common and legitimate
+deployment. There is no fix at this layer: proposals to have the proxy forward
+the exporter value exist, none is standardized, and trusting a proxy-supplied
+value would defeat the point.
+
+Therefore:
+
+- Such a relay MUST set `channel_binding_mode: "none"` in its capability
+  document and MUST use **32 zero bytes** in the transcript.
+- A client MAY refuse such a relay outright, and the reference client SHOULD make
+  this a user-visible setting with a strict mode that refuses.
+- **In `none` mode the restart argument of §5.5 does not hold**, so the relay
+  MUST either persist its seen-set across restarts or declare
+  `antireplay_persistence: "volatile"` and accept a replay window equal to the
+  timestamp window across a restart. This is spelled out in §5.5 rather than
+  buried, because it is the concrete cost of the mode.
+
+### 5.4 What the transcript deliberately does not cover
+
+- **Relative ordering of commands.** Two `APPEND`s on one connection can be
+  reordered by anything in the path, and nothing in the transcript prevents it.
+  Message ordering is not a relay property in this design; it is
+  [`ARCHITECTURE.md` §7](./ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering)'s
+  hash-linked DAG, precisely so that ordering survives a hostile relay. Stated
+  here so nobody looks for it in the wrong layer.
+- **The relay's response.** Responses are unsigned. A relay can lie about a
+  response and no signature detects it. This is deliberate: every response that
+  matters end-to-end is verified by other means (a `READ` result is MLS
+  ciphertext that authenticates itself; a claimed deletion is unverifiable in any
+  case per
+  [`THREAT-MODEL.md` §4.5](./THREAT-MODEL.md#45-server-side-deletion-is-auditable-not-verifiable)),
+  and signing responses would buy an audit trail against an adversary who can
+  simply refuse to answer.
+- **Anything about the sender's identity.** `signer_key` is a per-queue Ed25519
+  key with no link to a handle, an account, or an identity key — by construction
+  ([ADR 0004](./decisions/0004-metadata-ambition.md)).
+
+### 5.5 Anti-replay: a bounded window plus a seen-set
+
+Two mechanisms, together:
+
+1. **Timestamp window.** `timestamp_ms` MUST be within `±clock_skew_ms` of the
+   relay's clock. Default `120000` (±2 minutes), published. Outside the window →
+   `ERR_STALE_TIMESTAMP`. Clients with an unreliable clock learn the relay's time
+   from `HELLO` and `GET_CHALLENGE` and apply the offset locally; they MUST NOT
+   set their system clock from it.
+2. **Seen-set.** The relay keeps the set of `(signer_key, nonce)` pairs observed
+   within the window and rejects a repeat with `ERR_REPLAY`. `nonce` is 16 bytes
+   from the client's CSPRNG, fresh per command; the birthday bound is 2^64 per
+   key, which is not reachable inside a two-minute window at any rate a relay
+   would serve.
+
+**The seen-set is fail-closed.** It is bounded (`antireplay_seen_max`, published)
+and when the bound is reached the relay returns `ERR_BACKPRESSURE` and refuses new
+signed commands until entries age out. It MUST NOT evict live entries to make
+room: an eviction policy that discards unexpired entries silently reopens the
+replay window at exactly the moment the relay is under load, which is exactly when
+an attacker would arrange to be.
+
+**Why the seen-set deliberately need not survive a restart.** A restart destroys
+every TLS session. Every command signed before the restart carries a
+`channel_binding` derived from a session that no longer exists, so it cannot
+verify against any new session — the channel binding has already invalidated the
+entire pre-restart corpus. Persisting the seen-set would add a durability
+obligation and a write on the hot path to re-derive a property the transcript
+already provides. So it lives in memory, and that is a decision rather than an
+oversight.
+
+**The exception, stated:** in `channel_binding_mode: "none"` (§5.3) that argument
+does not hold, because the binding is a constant. Such a relay MUST persist the
+seen-set or declare `antireplay_persistence: "volatile"` and accept that a
+restart reopens a replay window of `clock_skew_ms` for any frame an adversary
+captured. Clients read that field and may refuse.
+
+### 5.6 The residual, stated
+
+Within the window, on the same TLS session, a party that can observe the frames
+can replay them. That party is the relay itself, or a TLS-terminating proxy in
+front of it — i.e. the operator, who by
+[`THREAT-MODEL.md` §3.3](./THREAT-MODEL.md#33-compromised-relay-operator-third-party-or-ours)
+already has full control of its own storage. What the operator gains from a replay
+is bounded by what the commands do:
+
+| Replayed command | Effect of the replay |
+|---|---|
+| `APPEND` | A duplicate ciphertext in the queue. Deduplicated end-to-end by `msg_id` ([`ARCHITECTURE.md` §7](./ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering)). Costs quota. |
+| `ACK` | No-op. ACK is cumulative, monotone and idempotent (§8). |
+| `READ` | No-op; reads do not mutate. Reveals nothing the operator does not hold. |
+| `DELETE_QUEUE` | No-op after the first. |
+| `CREATE_QUEUE` | A second queue, at the operator's own expense, with addresses only the operator learns. |
+| `BIND_SEND` | No-op after the first (§7.3). |
+
+So the residual is "duplicate or no-op, at the operator's expense, against an
+adversary who could already refuse service." That is acceptable. It is **not**
+zero, and the reason it is acceptable is the bound, not the absence.
+
+---
+
+## 6. Command set
+
+Codes are `uint16` and are **stable forever** — see §10 for the same rule applied
+to error codes.
+
+| Code | Command | Auth | Address in transcript |
+|---|---|---|---|
+| `0x0001` | `HELLO` | none | — |
+| `0x0002` | `GET_CAPABILITIES` | none | — |
+| `0x0003` | `GET_CHALLENGE` | none | — |
+| `0x0004` | `PING` | none | — |
+| `0x0010` | `CREATE_QUEUE` | recv key | zeros |
+| `0x0011` | `SUBSCRIBE` | recv key | `recv_addr` |
+| `0x0012` | `UNSUBSCRIBE` | recv key | `recv_addr` |
+| `0x0013` | `READ` | recv key | `recv_addr` |
+| `0x0014` | `ACK` | recv key | `recv_addr` |
+| `0x0015` | `DELETE_QUEUE` | recv key | `recv_addr` |
+| `0x0020` | `BIND_SEND` | send key | `send_addr` |
+| `0x0021` | `APPEND` | send key | `send_addr` |
+| `0x0030` | `CREATE_CONTACT_QUEUE` | recv key | zeros |
+| `0x0031` | `CONTACT_APPEND` | none (PoW) | — |
+
+### 6.1 Unsigned commands
+
+#### `HELLO` — `0x0001`
+
+```
+struct {
+    uint16 min_version;
+    uint16 max_version;
+    opaque client_nonce[32];
+} HelloRequest;
+
+struct {
+    uint16 protocol_version;          /* the version selected for this connection */
+    opaque relay_identity_pk[32];
+    opaque relay_id[32];              /* MUST equal H("free2z/relay/v1/relay-id", relay_identity_pk) */
+    opaque relay_proof[64];           /* §5.2 */
+    uint64 relay_time_ms;
+    uint8  channel_binding_mode;      /* 0 = none, 1 = tls-exporter */
+    uint8  transport_security;        /* 0 = none, 1 = tls */
+    opaque capabilities_digest[32];   /* §11 */
+} HelloResponse;
+```
+
+MUST be the first frame. If no version in `[min_version, max_version]` is
+supported → `ERR_UNSUPPORTED_VERSION`, fatal. The client MUST verify
+`relay_proof`, MUST recompute `relay_id` from `relay_identity_pk`, and MUST
+compare `relay_id` against any value it obtained from an in-band advert (§7.2).
+
+#### `GET_CAPABILITIES` — `0x0002`
+
+Empty request. The response is the `Capabilities` structure of §11.1, plus the
+relay's signature over it. `capabilities_digest` in `HelloResponse` is
+`H("free2z/relay/v1/caps", tls_codec(Capabilities))`, so a client can detect a
+policy change mid-connection without refetching.
+
+#### `GET_CHALLENGE` — `0x0003`
+
+```
+enum { clock(0), queue_create(1), contact_append(2), (255) } ChallengePurpose;
+
+struct {
+    ChallengePurpose purpose;
+    opaque scope<0..255>;    /* for contact_append: the target contact_addr */
+} ChallengeRequest;
+
+struct {
+    uint64    relay_time_ms;
+    opaque    challenge[32];
+    uint64    expires_at_ms;
+    PowParams pow;           /* §13.1; zeroed when no PoW is required */
+} ChallengeResponse;
+```
+
+Three jobs, and each is a real reason for the command to exist:
+
+1. It gives a client with an unreliable clock the relay's current time, so it can
+   place `timestamp_ms` inside the window without guessing.
+2. It issues a **single-use, expiring** `challenge` that a proof-of-work stamp
+   must be computed over (§13.1). Because the challenge comes from the relay and
+   is consumed on use, stamps cannot be precomputed in bulk before an attack, and
+   a stamp cannot be replayed.
+3. It publishes the *current* PoW parameters, so an operator raising difficulty
+   under load takes effect immediately rather than at the next capability fetch.
+
+Challenge issuance is itself rate-limited per source (§13.1), or it becomes the
+cheapest way to make the relay do work.
+
+#### `PING` — `0x0004`
+
+Empty request, empty response. An application-level liveness probe, distinct from
+the WebSocket Ping of §2.4 (which the browser client cannot send). Rate-limited
+like everything else.
+
+### 6.2 Commands signed by the receive-side queue key
+
+#### `CREATE_QUEUE` — `0x0010`
+
+```
+struct {
+    opaque    recv_key[32];           /* Ed25519 public key authorizing the recv side */
+    uint32    req_message_ttl_seconds;
+    uint32    req_idle_ttl_seconds;
+    uint16    flags;                  /* reserved; MUST be 0 in v1 */
+    PowStamp  stamp;                  /* §13.1; empty when queue_creation_mode = open */
+} CreateQueueRequest;
+
+struct {
+    opaque recv_addr[32];
+    opaque send_addr[32];
+    uint32 message_ttl_seconds;       /* granted, after clamping (§7.7) */
+    uint32 idle_ttl_seconds;          /* granted, after clamping (§7.7) */
+    uint64 created_at_ms;
+} CreateQueueResponse;
+```
+
+The transcript's `address` field is 32 zero bytes (no address exists yet) and
+`signer_key` MUST equal `recv_key`, so the request is self-authenticating: it
+proves possession of the key that the new queue will be bound to.
+
+**Both addresses are generated by the relay from its own CSPRNG** (§7.1).
+
+#### `SUBSCRIBE` — `0x0011` / `UNSUBSCRIBE` — `0x0012`
+
+Empty bodies. `SUBSCRIBE` registers the connection to receive `MSG` pushes (§6.4)
+for `recv_addr` and returns the current `next_index` so the client can decide
+whether to `READ` first. A subscription is scoped to the connection and dies with
+it.
+
+```
+struct {
+    uint64 next_index;   /* the index the next appended message will receive */
+    uint64 pending;      /* messages present and not yet acked */
+} SubscribeResponse;
+```
+
+`pending` is disclosed to the **reader** only. The reader is the recipient; it is
+about to learn this by reading. No equivalent is ever disclosed to a sender
+(§6.3).
+
+#### `READ` — `0x0013`
+
+```
+struct {
+    uint64 from_index;
+    uint16 max_messages;
+    uint32 max_bytes;
+} ReadRequest;
+
+struct {
+    uint64  index;
+    uint64  received_at_ms;
+    opaque  payload<0..2^24-1>;
+} QueuedMessage;
+
+struct {
+    QueuedMessage messages<0..2^24-1>;
+    uint8         has_more;
+} ReadResponse;
+```
+
+`READ` never mutates. Messages remain until acknowledged (§8) or until a TTL
+expires (§7.7). `from_index` below the current acked watermark returns from the
+watermark; the relay MUST NOT resurrect deleted messages and MUST NOT error, so
+that a client recovering from a crash can simply ask for everything it might have
+missed.
+
+#### `ACK` — `0x0014`
+
+```
+struct {
+    uint64 up_to_index;      /* inclusive, cumulative */
+} AckRequest;
+
+struct {
+    uint64 next_index;
+    uint64 pending;
+} AckResponse;
+```
+
+Semantics are §8. In summary: cumulative, monotone, idempotent, and never
+selective. `up_to_index` beyond the highest appended index is `ERR_ACK_TOO_HIGH`.
+
+#### `DELETE_QUEUE` — `0x0015`
+
+Empty request, empty response. Deletes the queue, both addresses, and every
+message it holds, acknowledged or not. Irreversible. The relay MUST subsequently
+answer both addresses with `ERR_NO_ACCESS` — the same code an address that never
+existed gets (§10).
+
+The sender, if any, learns nothing except that its next `APPEND` fails with
+`ERR_UNAVAILABLE` (§6.3). Telling the peer that a queue was retired is the
+application's job, in-band, and is a `queue_advert` that names a replacement
+(§7.5).
+
+### 6.3 Commands signed by the send-side queue key
+
+#### `BIND_SEND` — `0x0020`
+
+```
+struct {
+    opaque send_key[32];     /* Ed25519 public key that will authorize APPEND */
+} BindSendRequest;
+```
+
+**Empty response.** Not "empty for now" — empty by rule, for the reason in §6.3's
+closing paragraph.
+
+Binding is **once-only and irreversible** (§7.3). A second `BIND_SEND` on the
+same address, with any key including the same key, is `ERR_ALREADY_BOUND`.
+
+#### `APPEND` — `0x0021`
+
+```
+struct {
+    opaque payload<0..2^24-1>;   /* length MUST be exactly one of the padding sizes (§9) */
+} AppendRequest;
+```
+
+**The response body is empty. It carries no index, no queue depth, no timestamp
+and no queue state of any kind.**
+
+This is a requirement, not an omission.
+[`ARCHITECTURE.md` §6.2](./ARCHITECTURE.md#62-queues) states that *"a sender
+learns nothing about what is queued or whether it was taken."* An index would
+tell the sender how many messages the queue has ever held; a depth would tell it
+whether the recipient has read; a server timestamp would give it a clock to
+correlate against. Each of those converts the send capability into a weak read
+capability, which is precisely the escalation the two-address split exists to
+prevent.
+
+**The same rule governs errors, and this is easy to get wrong.** If "queue full"
+and "no such queue" returned different codes, a bound sender could learn the
+queue's state by filling it. Therefore **every send-side refusal that would
+distinguish queue state collapses to the single code `ERR_UNAVAILABLE`**: absent
+queue, deleted queue, expired queue, queue at its message cap, queue at its byte
+cap, relay in global backpressure. See §10.
+
+Two honest consequences:
+
+- **A sender cannot back off intelligently.** `ERR_UNAVAILABLE` does not say
+  whether to retry in a second or never. The rule is: retry with exponential
+  backoff up to `send_retry_max` attempts, then surface to the application layer,
+  which asks the peer in-band for a fresh advert. Delivery latency in the
+  failure case is worse than it would be with informative errors. That is the
+  price and we are paying it deliberately.
+- **§6.2's claim is exactly true for successful appends and approximately true
+  for refusals.** A sender that keeps appending until it is refused has learned
+  that the queue is at capacity — one bit about queue state. The bit is cheap for
+  the sender to obtain and is bounded (the caps are published, so a sender that
+  counts its own successful appends can compute the same thing), but it is not
+  nothing, and the merged text's "learns nothing" should be read with this
+  qualification.
+
+### 6.4 Server pushes
+
+| Event | Code | Body | Meaning |
+|---|---|---|---|
+| `MSG` | `0x0080` | `opaque recv_addr[32]; QueuedMessage msg;` | A message arrived on a subscribed queue. |
+| `QUEUE_EVENT` | `0x0081` | `opaque recv_addr[32]; uint8 reason;` | `1` = deleted, `2` = idle-expired, `3` = messages TTL-expired, `4` = quota reached. |
+| `NOTICE` | `0x0082` | `uint8 kind; uint64 at_ms;` | `1` = draining (stop sending), `2` = shutdown at `at_ms`, `3` = capability document changed. |
+
+`MSG` pushes go **only** to the receive side, only on an active subscription.
+There is no push to a sender, ever — a push to a sender would be a channel that
+tells it something about queue state, which §6.3 forbids.
+
+`NOTICE(3)` lets a client re-fetch capabilities without polling, which matters
+because §9 and §13 both depend on the client's picture of policy being current.
+
+### 6.5 Contact-queue commands
+
+`CREATE_CONTACT_QUEUE` (`0x0030`) and `CONTACT_APPEND` (`0x0031`) are specified
+in §12, where the design they serve is explained.
+
+---
+
+## 7. Queue lifecycle
+
+### 7.1 Creation, and why the relay picks the addresses
+
+**The recipient creates the queue.** The recipient is the party that will store
+the quota, hold the read capability, and pay for the space; nobody else can
+usefully create it.
+
+**The relay generates both addresses from its own CSPRNG.** 32 uniformly random
+bytes each, independent of one another and of any key.
+
+Client-chosen addresses were rejected, for two reasons:
+
+1. **Squatting.** If a client names its own address, an adversary can create
+   queues at addresses it predicts a victim will want — for example addresses
+   derived from an exporter whose inputs it can guess, or simply a large sweep of
+   the space — so that the victim's `CREATE_QUEUE` fails or, worse, succeeds
+   against an existing attacker-controlled record. Relay-generated addresses make
+   the question unaskable.
+2. **Collisions.** Two independent clients deriving addresses from their own key
+   material will eventually collide, and a collision between two unrelated
+   conversations at a relay is a cross-conversation delivery bug with no clean
+   recovery. A single CSPRNG at the relay can simply retry on collision, which it
+   will never have to do at 32 bytes.
+
+The cost is a round trip: the address is not known until the relay answers. §7.5
+explains why that is affordable.
+
+See [ADR 0009](./decisions/0009-queue-addressing-and-binding.md).
+
+### 7.2 The send address is advertised in-band, never through the server
+
+After creation the recipient holds `recv_addr` and `send_addr`. It keeps
+`recv_addr` and gives `send_addr` to exactly one peer, in a `queue_advert`
+application message **inside the MLS group**
+([`ARCHITECTURE.md` §6.2](./ARCHITECTURE.md#62-queues)) — confidential,
+authenticated, attributable, and never seen by any relay.
+
+```
+queue_advert = {
+  type:        "free2z/queue-advert/v1",
+  endpoints:   [ { relay_url, relay_id, send_addr }, ... ],   // one per relay, ADR 0005's k
+  valid_from_epoch: uint64,
+  replaces:    [ send_addr, ... ],       // addresses this advert retires
+}
+```
+
+`relay_id` travels with the address because §5.2 needs it: it is what lets the
+sender detect that it is talking to a different relay than the one the recipient
+chose.
+
+A relay never sees a `queue_advert`; it sees an opaque MLS `PrivateMessage` like
+every other payload.
+
+### 7.3 `BIND_SEND` — once-only and irreversible
+
+The send side of a fresh queue is **unbound**: no key authorizes `APPEND` yet.
+The peer that received the advert generates a fresh Ed25519 `QueueKey`, and calls
+`BIND_SEND` once. From that instant, `APPEND` on that address requires a
+signature by that key, forever.
+
+**Binding is once-only and irreversible.** There is no rebind, no unbind, no
+"reset by the recv key". A queue whose send side is bound to the wrong key is
+dead and must be replaced by a new queue (§7.5).
+
+The alternative — letting the recv-side key rebind — was rejected because it
+turns the recv key into a control over the send side, and the recv key is the
+one that lives on the recipient's device with the ability to drain the queue. We
+would be adding a second capability to the strongest key in the system, in order
+to recover from a failure that has a clean, cheap alternative: make a new queue.
+
+### 7.4 The consequence, said plainly
+
+**A relay operator who reads `send_addr` out of its own database and calls
+`BIND_SEND` first steals the write capability.** The legitimate sender then gets
+`ERR_ALREADY_BOUND`, and the operator can append whatever it likes to the
+recipient's queue.
+
+The client rule is therefore: **`ERR_ALREADY_BOUND` on a first bind attempt for
+an address that arrived in a fresh `queue_advert` is a loud, non-dismissible
+failure.** Not a retry, not a warning toast, not a log line. The conversation is
+marked as compromised at the transport layer, the queue is abandoned, and the
+user is told that the relay it names behaved incorrectly.
+
+**This does not prevent the theft of the write capability. It makes it noisy.**
+The operator gets the capability; what it does not get is silence. That is the
+entire property, and it should be read as exactly that much and no more:
+
+- The operator cannot **read** the queue — `send_addr` authorizes `APPEND` only,
+  and the recv key is not derivable from it
+  ([`ARCHITECTURE.md` §6.2](./ARCHITECTURE.md#62-queues)).
+- Anything the operator appends fails MLS authentication at the recipient, so it
+  is garbage, not forgery
+  ([`THREAT-MODEL.md` §3.3](./THREAT-MODEL.md#33-compromised-relay-operator-third-party-or-ours)).
+- What the operator gains is the ability to **deny** the legitimate sender its
+  queue, and to fill the recipient's quota. Both are denial of service, which the
+  operator already had by simply refusing to serve.
+- What the design buys is that the denial is **attributable to a specific relay
+  at a specific moment**, rather than presenting as flaky delivery.
+
+An operator willing to be caught can do this. Nothing here stops it. The relevant
+comparison is not "secure versus insecure" but "detected versus undetected", and
+the same comparison governs
+[`THREAT-MODEL.md` §4.5](./THREAT-MODEL.md#45-server-side-deletion-is-auditable-not-verifiable).
+
+A partial narrowing that was considered and **not** adopted in v1: requiring the
+recipient to pre-commit to the sender's key at creation time
+(`CREATE_QUEUE{expected_send_key}`), which would close the race entirely. It was
+rejected because the recipient does not know the sender's fresh queue key at
+creation time — learning it would need an extra in-band round trip *before* the
+advert, turning a one-message advert into a three-message handshake for every
+queue and every rotation. It is the right answer if the race ever proves to
+matter in practice, and it is recorded here so the option is on the record rather
+than rediscovered later.
+
+### 7.5 Rotation needs no new command
+
+Queue rotation is: **create a new queue, advertise it in-band, delete the old
+one.** There is no `ROTATE` command and there should not be one.
+
+```
+1. Recipient: CREATE_QUEUE           → (recv_addr', send_addr')
+2. Recipient: queue_advert{ send_addr', replaces: [send_addr] }   (inside MLS)
+3. Sender:    BIND_SEND on send_addr' with a fresh key
+4. Sender:    APPEND to send_addr' from valid_from_epoch onward
+5. Recipient: drains recv_addr, then DELETE_QUEUE on recv_addr
+```
+
+The schedule is the `free2z/queue/v1` exporter of
+[`ARCHITECTURE.md` §5.4](./ARCHITECTURE.md#54-exporter-derived-application-secrets),
+with context `peer_leaf_index`, so both sides know a rotation is due at the same
+moment without negotiating it.
+
+**A narrowing of §5.4 that must be stated.** `ARCHITECTURE.md` §5.4's table says
+the queue exporter *"derives the next queue addresses without a round trip."*
+Under §7.1 that is no longer accurate, and the docs should not be read as though
+it were. What the exporter derives is the **rotation schedule and the next queue
+signing keys**:
+
+```
+rot = MLS-Exporter("free2z/queue/v1", peer_leaf_index || rotation_counter, 64)
+      → (next_recv_queue_key_seed, next_send_queue_key_seed)
+```
+
+The **addresses still come from the relay**, and the new `send_addr` still has to
+reach the peer in an advert. So rotation costs one relay round trip and one
+in-band message that the pair was not otherwise sending. That is the price of
+refusing client-chosen addresses (§7.1), it is small — one message per rotation
+period, against a conversation that is exchanging messages anyway — and it is
+recorded here rather than left as a contradiction between two documents. The
+tracking note is in
+[`ARCHITECTURE.md` §5.4](./ARCHITECTURE.md#54-exporter-derived-application-secrets).
+
+Overlap: the old queue MUST remain readable until the recipient has drained it.
+The sender switches at `valid_from_epoch`; the recipient deletes only after the
+old queue is empty and acknowledged. A message in flight during the switch lands
+in the old queue and is read from it.
+
+### 7.6 Deletion
+
+`DELETE_QUEUE` removes the queue and its contents unconditionally. A relay MUST
+NOT retain a tombstone that distinguishes "deleted" from "never existed" in any
+externally observable way (§10).
+
+### 7.7 TTLs
+
+Two independent timers. Both are per-queue, both are requested at creation, both
+are clamped by relay policy, and both granted values are returned in
+`CreateQueueResponse` so the client knows what it actually got.
+
+| Timer | Field | Default | Ceiling | Resets on |
+|---|---|---|---|---|
+| Message TTL | `message_ttl_seconds` | 604 800 (7 days) | **2 592 000 (30 days)** | — (per message, from append) |
+| Queue idle TTL | `idle_ttl_seconds` | 7 776 000 (90 days) | 31 536 000 (365 days) | any successful `APPEND`, `READ`, `ACK`, `SUBSCRIBE` |
+
+**Message TTL** is the ceiling from
+[`ARCHITECTURE.md` §6.3](./ARCHITECTURE.md#63-what-delivered-means): undelivered
+ciphertext is dropped after it, and the sender learns only from the continued
+absence of a receipt. A relay MUST NOT grant more than 30 days. The 7-day default
+is chosen because a device that has been offline for a week has stale MLS state
+anyway and will be repairing gaps (§7 of the architecture) rather than draining a
+month-old queue; a client that wants longer asks and the relay clamps.
+
+**Queue idle TTL is new here.** The merged docs specify nothing of the kind, and
+without it the queue table grows without bound: every abandoned device, every
+uninstalled client, every rotation whose `DELETE_QUEUE` never arrived leaves a
+row that no timer ever removes, and messages TTL out while the row itself is
+immortal. A relay's storage cost is then unbounded in *queues* even though it is
+bounded in *ciphertext*, which quietly defeats
+[ADR 0005](./decisions/0005-federation.md)'s "$5/month VPS" economics.
+
+The failure mode is real and must be stated: **a user whose device is offline
+longer than the idle TTL loses their queues.** Their peers' adverts become dead
+addresses, `APPEND` starts returning `ERR_UNAVAILABLE`, and the pair must
+re-establish — via a contact queue (§12) if no live queue remains in either
+direction. Ninety days is chosen to be far longer than any plausible holiday and
+far shorter than "forever". It is a policy value, published, and an operator
+serving a population of intermittently-connected users should raise it.
+
+Expiry of either timer is silent to the sender and surfaces to a subscribed
+reader as `QUEUE_EVENT` (§6.4).
+
+---
+
+## 8. ACK semantics
+
+### 8.1 Cumulative and monotone, never selective
+
+`ACK{up_to_index}` acknowledges **every** message with index ≤ `up_to_index`. The
+relay deletes them and advances the queue's acked watermark.
+
+- **Monotone.** An `ACK` whose `up_to_index` is below the current watermark is
+  accepted and is a no-op. The watermark never moves backwards.
+- **Never selective.** There is no "ack message 7 but not 5". Selective
+  acknowledgement would require the relay to hold a per-message state bitmap,
+  which is per-queue state proportional to the queue rather than a single
+  integer, and it would let a reader hold a message indefinitely while
+  acknowledging later ones — a shape with no legitimate use and an obvious abuse.
+  A reader that cannot process message 5 must not acknowledge 7.
+
+### 8.2 Acking beyond the highest appended index is an error
+
+`up_to_index` greater than the highest index the relay has ever appended to that
+queue is `ERR_ACK_TOO_HIGH`, and the watermark does not move.
+
+The reason is specific and it is not tidiness. Without this rule a reader could
+**pre-ack** — set the watermark to a very large value — after which every future
+`APPEND` is deleted the instant it lands, while the sender continues to receive
+successful (empty) `APPEND` responses because §6.3 forbids telling it anything.
+A device could black-hole its own queue silently and indefinitely, and the only
+symptom anywhere in the system would be the absence of `device-delivered`
+receipts, which is indistinguishable from the recipient being offline
+([`THREAT-MODEL.md` §4.4](./THREAT-MODEL.md#44-tail-truncation-is-not-detectable-by-hash-links)).
+The rule costs one comparison and removes the possibility.
+
+### 8.3 Idempotent, so retries are safe
+
+Replaying or retrying an `ACK` is a no-op by §8.1's monotonicity. This is what
+makes the connection-loss case tractable: a client that sent an `ACK` and never
+saw the response simply sends it again after reconnecting. It does not need to
+know whether the first one arrived, and it must not try to find out by reading —
+the messages may legitimately be gone.
+
+The same is *not* true of `APPEND`, which is not idempotent at the relay: a
+retried `APPEND` after an unknown outcome produces a duplicate. That is by design
+and it is why deduplication lives end-to-end, at `msg_id`
+([`ARCHITECTURE.md` §7](./ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering)).
+Duplicate-tolerant delivery plus idempotent acknowledgement is the combination
+that survives [#131](https://github.com/free2z/zuu/issues/131)'s core observation
+that a dropped connection tells you nothing about what arrived.
+
+### 8.4 Where this sits in the four delivery states
+
+[`ARCHITECTURE.md` §6.3](./ARCHITECTURE.md#63-what-delivered-means) defines four
+states and warns that conflating them is how delete-on-ack loses messages. This
+document implements exactly one of them:
+
+| State | Implemented by |
+|---|---|
+| `accepted` | An `APPEND` that returned status 0. Says nothing about the recipient — §6.3 makes sure of it. |
+| `queue-delivered` | **`ACK` in this document.** The relay deletes at this instant. |
+| `device-delivered` | An MLS `DeliveryReceipt` inside the group. Not a relay concept; the relay never sees one. |
+| `delivered` | Computed by the sender from receipts across the recipient's whole device set. Not a relay concept. |
+
+**And the rule that everything depends on, restated because it belongs next to
+the wire format:**
+
+> **A device MUST NOT send `ACK` before its durable local write has completed.**
+
+ACK-on-read plus a crash equals permanent message loss, because the relay has
+already deleted the only copy. This is a MUST in the client, it is the single
+most safety-critical rule in the delivery layer
+([ADR 0002](./decisions/0002-multi-device.md)), and the wire protocol cannot
+enforce it — the relay has no way to know whether a write completed. It is stated
+here so that an implementer reading only this document still meets it.
+
+A relay's own durability is the mirror image and is published as
+`durability_mode` (§11.1): `fsync-per-append` means an `APPEND` that returned 0
+survives a crash; `batched` and `memory` mean it may not. No end-to-end contract
+breaks in the weaker modes, because `accepted` never promised anything — but a
+client SHOULD prefer durable relays and the value is published so it can.
+
+---
+
+## 9. Padding enforcement
+
+A payload's length MUST be **exactly** one of the sizes in the relay's published
+`padding_sizes`. Any other length is `ERR_BAD_SIZE`, non-fatal.
+
+Payloads larger than the largest bucket are chunked client-side into
+`max_chunk_bytes` units (default 64 KiB) and appended as separate messages, per
+[`ARCHITECTURE.md` §6.5](./ARCHITECTURE.md#65-padding). This leaks the chunk
+count, and therefore the approximate length of anything larger than one bucket.
+That is inherent in chunking and is not new here; it is noted so it is not
+mistaken for a property the padding provides.
+
+**The size set lives in the capability document, not in the protocol.** This is
+deliberate. [`ARCHITECTURE.md` §13-F](./ARCHITECTURE.md#13-open-questions) records
+that the bucket sizes are placeholders chosen for arithmetic convenience and need
+a traffic study. When that study lands, an operator should change a configuration
+value and restart — not coordinate a flag day across a federation to bump a
+protocol version. Putting the set in a versioned protocol structure would make
+the eventual measured answer maximally expensive to adopt, which is a good way to
+guarantee it never gets adopted.
+
+**But the relay's list is a filter, not the source of truth.** The security
+property comes from the *client* padding to its own configured bucket set before
+the ciphertext ever leaves the device. The relay's rejection is a backstop against
+a sloppy client and against a malicious client trying to use length as a covert
+channel to a colluding relay ([ADR 0004](./decisions/0004-metadata-ambition.md)).
+It follows that:
+
+- A client MUST pad to its **own** set and MUST refuse a relay whose published
+  set is not a superset of the sizes the client will emit.
+- A client SHOULD refuse a relay whose published set is implausibly fine-grained
+  (v1 rule of thumb: more than 16 entries, or a spacing below 512 bytes between
+  adjacent buckets), because such a set is indistinguishable from an attempt to
+  let a colluding client leak length through size.
+- A relay that publishes a coarse set and a client that pads to a fine set simply
+  fails at `ERR_BAD_SIZE`, loudly, which is the correct direction for the failure
+  to point.
+
+---
+
+## 10. Error codes
+
+`uint16`. **Stable forever: a code's meaning is never changed and a retired code
+is never reused.** The same rule the architecture applies to open-question letters
+applies here, and for the same reason — a client in the field, a log archive, and
+a bug report from two years ago must all still mean the same thing.
+
+| Code | Name | Fatal | Meaning |
+|---:|---|:---:|---|
+| 0 | — | | Success. Reserved; never an error. |
+| 1 | `ERR_MALFORMED` | ● | Decode failure, re-encode mismatch (§3.3), oversize frame, duplicate in-flight `request_id`. |
+| 2 | `ERR_UNSUPPORTED_VERSION` | ● | No common protocol version, or a frame before `HELLO`. |
+| 3 | `ERR_FRAME_TYPE` | ● | A text WebSocket frame (§4.2). |
+| 4 | `ERR_TOO_MANY_INFLIGHT` | ● | `max_inflight` exceeded (§4.3). |
+| 5 | `ERR_UNKNOWN_COMMAND` | | Unknown command code. |
+| 6 | `ERR_BAD_SIGNATURE` | | Signature verification failed (§5.1 step 4). |
+| 7 | `ERR_STALE_TIMESTAMP` | | Outside `clock_skew_ms` (§5.5). |
+| 8 | `ERR_REPLAY` | | `(signer_key, nonce)` already seen (§5.5). |
+| 9 | `ERR_CHANNEL_BINDING` | | Reserved for a future binding-mode mismatch; unused in v1. |
+| 10 | `ERR_NO_ACCESS` | | **Either** the address does not exist **or** it exists and `signer_key` does not authorize it. See below. |
+| 11 | `ERR_ALREADY_BOUND` | | `BIND_SEND` on an already-bound send address (§7.3). |
+| 12 | `ERR_BAD_SIZE` | | Payload length not in `padding_sizes` (§9). |
+| 13 | `ERR_ACK_TOO_HIGH` | | `up_to_index` above the highest appended index (§8.2). |
+| 14 | `ERR_QUOTA` | | A recv-side quota was exceeded (queue count, creation rate). |
+| 15 | `ERR_UNAVAILABLE` | | **Send side only.** Absent, deleted, expired, full-by-messages, full-by-bytes, or relay backpressure — collapsed into one code (§6.3). |
+| 16 | `ERR_POW_REQUIRED` | | A stamp is required and was absent (§13.1). |
+| 17 | `ERR_POW_INVALID` | | Stamp invalid, expired, for the wrong challenge, or already consumed. |
+| 18 | `ERR_BACKPRESSURE` | | Global resource limit; retry later (§13.1). Also the seen-set bound (§5.5). |
+| 19 | `ERR_RATE_LIMITED` | | Per-connection or per-source rate limit. |
+| 20 | `ERR_NOT_PERMITTED` | | The command is not valid for this queue kind — e.g. `BIND_SEND` on a contact queue (§12.2). |
+| 21 | `ERR_INTERNAL` | | Relay fault. Carries no detail, ever. |
+
+### The existence-oracle rule
+
+**"No such queue" and "exists, but your key does not authorize it" MUST return
+the same code (10).** If they differ, the relay is an oracle for the existence of
+queue addresses: an attacker sweeping the address space learns which 32-byte
+values are live queues, which is exactly the information the opaque addressing of
+[ADR 0004](./decisions/0004-metadata-ambition.md) exists to withhold. A 32-byte
+space is not sweepable by brute force, but an oracle is also useful against
+addresses obtained by other means — a leaked log line, a partially-observed
+advert, a database from a decommissioned relay — and there is no reason to
+provide it.
+
+**And the honest limit: this is not constant time, and we do not claim it is.**
+The two paths do different amounts of work. The absent path is an index miss. The
+present-but-unauthorized path is an index hit — touching storage, possibly a
+cache line, possibly a disk page — followed by a key comparison and a signature
+verification. A patient attacker measuring response latency across many probes
+can distinguish them statistically.
+
+What a relay MUST do is narrow it, not claim to close it:
+
+- On the absent path, perform a **dummy Ed25519 verification against a fixed
+  key** so that the dominant CPU cost is present in both paths.
+- Compare keys with a constant-time comparison.
+- Do not short-circuit before the dummy work.
+
+What remains after that is storage-layer behaviour — cache residency, page
+faults, index depth — which is not equalizable without a design that keeps every
+lookup uniform, and that is a much larger change than v1 warrants. **The residual
+timing side channel is real and is stated here rather than papered over.**
+
+---
+
+## 11. The capability document
+
+### 11.1 What an operator publishes
+
+A relay's entire externally-relevant policy, in one signed structure. It is the
+document a client reads to decide whether to use a relay at all, and the document
+a human reads to decide whether to trust its operator.
+
+```
+struct {
+    uint16   protocol_versions<1..255>;
+
+    /* identity */
+    opaque   relay_identity_pk[32];
+    opaque   relay_id[32];
+
+    /* transport */
+    uint8    transport_security;          /* 0 = none (override, §2.3), 1 = tls */
+    uint8    channel_binding_mode;        /* 0 = none, 1 = tls-exporter */
+    uint32   max_frame_bytes;
+    uint16   max_inflight;
+    uint16   ws_ping_interval_seconds;
+    uint32   handshake_timeout_ms;
+
+    /* anti-replay */
+    uint32   clock_skew_ms;
+    uint32   antireplay_window_ms;
+    uint8    antireplay_persistence;      /* 0 = volatile, 1 = durable (§5.3, §5.5) */
+
+    /* padding */
+    uint32   padding_sizes<1..2^16-1>;    /* ascending, §9 */
+    uint32   max_chunk_bytes;
+
+    /* queues */
+    uint32   min_message_ttl_seconds;
+    uint32   max_message_ttl_seconds;     /* MUST be <= 2592000 */
+    uint32   default_message_ttl_seconds;
+    uint32   min_idle_ttl_seconds;
+    uint32   max_idle_ttl_seconds;
+    uint32   default_idle_ttl_seconds;
+    uint32   max_queue_messages;
+    uint64   max_queue_bytes;
+
+    /* anti-abuse */
+    uint8    queue_creation_mode;         /* 0 = open, 1 = pow, 2 = token (§13.1) */
+    PowParams queue_creation_pow;
+    uint8    contact_queues_enabled;
+    uint32   contact_max_pending;
+    uint64   contact_max_bytes;
+    PowParams contact_append_pow;
+    uint8    per_source_limits;           /* 0 = off, 1 = on (§13.3) */
+    uint8    durability_mode;             /* 0 = memory, 1 = batched, 2 = fsync-per-append */
+
+    /* operator — human-readable, and the point of the document */
+    opaque   operator_name<0..255>;
+    opaque   operator_contact<0..255>;    /* how to reach a human */
+    opaque   operator_abuse_contact<0..255>;
+    opaque   operator_jurisdiction<0..255>;  /* where the operator and hardware sit */
+    opaque   operator_policy_url<0..255>;
+
+    /* provenance */
+    opaque   source_repo_url<0..255>;
+    opaque   source_commit<0..255>;
+    opaque   build_digest<0..255>;        /* reproducible-build digest of the running binary */
+
+    uint64   published_at_ms;
+} Capabilities;
+
+struct {
+    Capabilities capabilities;
+    opaque       signature[64];   /* Ed25519 by relay_identity_pk over tls_codec(capabilities) */
+} SignedCapabilities;
+```
+
+Note what the last two blocks are for. `operator_jurisdiction` and the contact
+fields are not decoration: a user choosing among *k* relays
+([ADR 0005](./decisions/0005-federation.md)) is making a jurisdictional choice
+whether or not anyone tells them so, and publishing where the hardware sits is the
+minimum that makes that choice informed. `source_commit` and `build_digest` are
+what turn "open source and self-hostable" into something a third party can check
+— they are the difference between an auditable claim and an unverifiable one
+([`THREAT-MODEL.md` §4.5](./THREAT-MODEL.md#45-server-side-deletion-is-auditable-not-verifiable)).
+
+### 11.2 Served two ways, on purpose
+
+1. **Over the protocol**, via `GET_CAPABILITIES` (§6.1). Canonical `tls_codec`
+   bytes, signed. This is what the client parses.
+2. **Over plain HTTPS**, at
+   `GET https://<host>/.well-known/free2z-relay/v1/capabilities`, as JSON, with
+   the same values, the same signature (base64url), and the same
+   `capabilities_digest`.
+
+The second exists so that **a human can read a relay's policy before connecting**
+— and so can a journalist, a researcher, or a client author comparing relays. It
+needs no client, no WebSocket and no protocol knowledge. It also makes policy
+publicly diffable over time: a relay that quietly shortens its TTLs, turns on
+per-source limits, or changes jurisdiction is doing so at a URL anyone can poll,
+which converts a silent policy change into an observable one.
+
+Honest note: **nothing forces the two representations to agree except the
+operator.** A relay could serve one policy to humans and another to clients. What
+makes that costly is that both are signed by the same key and both carry the same
+digest field, so a client that fetches the well-known document and compares
+digests detects the divergence. Clients SHOULD do this on first use of a relay and
+MUST refuse on mismatch.
+
+### 11.3 What a client does with it
+
+On first use of a relay, and on `NOTICE(3)`:
+
+1. Fetch, verify the signature against the `relay_identity_pk` proven in `HELLO`.
+2. Refuse if `transport_security = none` without explicit user opt-in (§2.3).
+3. Refuse if `channel_binding_mode = none` and the user's policy is strict
+   (§5.3).
+4. Refuse if `padding_sizes` is not a superset of what this client emits, or is
+   implausibly fine-grained (§9).
+5. Refuse if `max_message_ttl_seconds > 2592000` — the relay is claiming a policy
+   the architecture forbids.
+6. Record `queue_creation_mode`, quotas and PoW parameters for §13.
+7. Surface operator name, jurisdiction and contact in the relay-picker UI.
+
+---
+
+## 12. First contact
+
+### 12.1 The gap — and it is a real one in the merged design
+
+[`ARCHITECTURE.md` §6.2](./ARCHITECTURE.md#62-queues) says queue addresses are
+established *"inside the MLS group — a member advertises its `QueueSendAddr` set
+to peers in an authenticated application message, never via the server."*
+
+That is correct and it is circular. **There is no path for the `Welcome` that
+creates the group in the first place.** Alice cannot advertise a queue to Bob
+inside a group that does not exist, and she cannot send Bob the `Welcome` that
+would create it, because Bob has no queue that Alice is allowed to write to. As
+merged, two people who have never spoken can never begin.
+
+This section closes that hole. It is invented here in full; see
+[ADR 0011](./decisions/0011-first-contact-contact-queues.md).
+
+### 12.2 The contact queue
+
+A **contact queue** is a distinctly-flavoured queue, created with
+`CREATE_CONTACT_QUEUE` (`0x0030`), whose shape differs from an ordinary queue in
+exactly four ways:
+
+1. **Its send side is never bound.** `BIND_SEND` on a contact address returns
+   `ERR_NOT_PERMITTED`, always, for everyone. There is no key that authorizes
+   writing to it, which means there is no key that can be stolen, squatted (§7.4)
+   or lost.
+2. **It accepts unsigned appends**, via `CONTACT_APPEND` (`0x0031`), from anyone
+   who presents a valid proof-of-work stamp.
+3. **Its address is published**, in the owner's directory entry, rather than
+   advertised in-band. It is a public address by design — the one address in the
+   system that is meant to be looked up.
+4. **It is hard-capped** (§12.3), because point 2 means the whole internet may
+   write to it.
+
+```
+struct {
+    opaque    recv_key[32];
+    uint32    req_message_ttl_seconds;
+    uint32    req_idle_ttl_seconds;
+    PowStamp  stamp;
+} CreateContactQueueRequest;
+
+struct {
+    opaque recv_addr[32];
+    opaque contact_addr[32];      /* the published address; never bindable */
+    uint32 message_ttl_seconds;
+    uint32 idle_ttl_seconds;
+    uint32 max_pending;           /* granted cap */
+    uint64 max_bytes;             /* granted cap */
+} CreateContactQueueResponse;
+
+struct {
+    opaque    contact_addr[32];
+    opaque    payload<0..2^24-1>;   /* length MUST be in padding_sizes (§9) */
+    PowStamp  stamp;                /* over a relay-issued challenge (§6.1) */
+} ContactAppendRequest;
+```
+
+`CONTACT_APPEND`'s response is **empty**, for the same reason `APPEND`'s is
+(§6.3): a stranger writing to Bob's contact queue must learn nothing about how
+full it is or whether Bob has read it. Refusals collapse to `ERR_UNAVAILABLE` on
+the same rule.
+
+Reading, acknowledging and deleting a contact queue use the ordinary recv-side
+commands, signed by `recv_key`. Its receive side is a perfectly normal queue.
+
+The **published address** lives in the owner's directory entry:
+
+```
+contact_endpoints: [ { relay_url, relay_id, contact_addr }, ... ]
+```
+
+The full `DirectoryEntry` structure is deferred with `KT.md` and **ADR 0013**
+(§1.2). This document specifies only that the field exists, what it contains, and
+that it is covered by whatever signature the entry carries — a contact endpoint
+that is not authenticated by the directory is a server-supplied address, which is
+the MITM of [#133](https://github.com/free2z/zuu/issues/133) reintroduced at the
+point of first contact.
+
+### 12.3 The caps, because anyone can write
+
+A relay MUST enforce all four, and MUST publish all four:
+
+| Cap | Field | Default | What it stops |
+|---|---|---|---|
+| Pending messages | `contact_max_pending` | 64 | Unbounded growth from one flood. |
+| Total bytes | `contact_max_bytes` | 256 KiB | Large-payload amplification. |
+| Per-source rate | `per_source_limits` | on | Trivial single-host flooding. |
+| Proof of work | `contact_append_pow` | required | Cheap bulk sending. |
+
+The stamp MUST be computed over a **relay-issued, single-use, expiring
+challenge** obtained from `GET_CHALLENGE(purpose = contact_append, scope =
+contact_addr)`. Binding the stamp to the target address and to a relay-issued
+challenge means stamps cannot be precomputed at leisure before a campaign, cannot
+be reused, and cannot be computed for one victim and spent on another.
+
+Stamp construction (§13.1) is a leading-zero-bit search over BLAKE2b, chosen so
+that **verification is a single hash** — the relay's own cost under flood is the
+thing that must stay near zero.
+
+### 12.4 The honest limits
+
+**Proof of work taxes phones far more than it taxes rented GPUs.** This is the
+central weakness and it is not fixable by tuning. A leading-zero-bit search is
+precisely the workload that commodity parallel hardware accelerates best; the
+ratio between a rented GPU-hour and a mid-range phone's battery-constrained
+budget is orders of magnitude. Any difficulty high enough to meaningfully cost an
+attacker is a difficulty that makes a cheap Android device sit there heating up
+before it can say hello. We have chosen a difficulty that is a nuisance to
+attackers and tolerable to phones, which means it is *only* a nuisance. A
+memory-hard function (Argon2id and relatives) would narrow the hardware gap, and
+it was rejected for v1 because it multiplies the *relay's* verification cost by
+the same factor that it raises the attacker's — the wrong trade at the moment of
+a flood, when the relay is the resource under pressure. The calibration is
+unresolved and is recorded as
+[`ARCHITECTURE.md` §13-N](./ARCHITECTURE.md#13-open-questions).
+
+**Disk exhaustion by mass queue creation is made expensive, not closed.** Nothing
+here prevents an adversary with real resources from creating a very large number
+of legitimate-looking queues, each with a valid stamp, from a large number of
+sources. The caps bound what any *one* queue costs; they do not bound how many
+queues exist. §13.1's global backpressure is what keeps the relay alive under
+that, and its effect is to degrade service for everyone rather than to identify
+the attacker — because identifying the attacker requires exactly the identity the
+relay deliberately does not have.
+[`ARCHITECTURE.md` §13-I](./ARCHITECTURE.md#13-open-questions)'s anonymous
+credentials — prove you paid for capacity without revealing who you are — are the
+real answer, and they remain deferred and unspecified.
+
+**A contact queue can be filled to deny first contact.** An attacker willing to
+pay `contact_max_pending` stamps can keep Bob's contact queue full, so that
+nobody new can reach him until he drains it. Existing conversations are entirely
+unaffected (they use ordinary queues), and Bob's client drains aggressively, but
+during a sustained flood Bob is unreachable to strangers. His remedy is to create
+a new contact queue and republish his directory entry — which costs a directory
+epoch, so it is slow. This is a real, unmitigated denial of service against
+first contact and it should be read as one.
+
+**Unsigned appends are unauthenticated by construction.** The filter is
+cryptographic and it happens at Bob's device, not at the relay: a payload that is
+not a `Welcome` addressed to one of Bob's published `KeyPackage`s fails to
+decrypt and is discarded. Junk costs Bob bandwidth and a stamp costs the attacker
+work; well-formed unwanted contact requests are a moderation problem and are
+surfaced to Bob as requests, not as messages.
+
+### 12.5 The full handshake, end to end
+
+Alice has never spoken to Bob. She knows `@bob`.
+
+```
+1.  Alice → directory:  resolve "@bob"
+                        → identity key, device credentials, KeyPackages,
+                          contact_endpoints [ {relay_url, relay_id, contact_addr} ]
+                        with an inclusion proof, verified against a cosigned root
+                        (ARCHITECTURE.md §9.2, §9.3)
+
+2.  Alice (local):      build the MLS group, produce Welcome addressed to Bob's
+                        KeyPackage; pad to a bucket in padding_sizes
+
+3.  Alice → relay:      HELLO; verify relay_proof; compare relay_id against the
+                        value in Bob's directory entry
+4.  Alice → relay:      GET_CHALLENGE(contact_append, scope = contact_addr)
+5.  Alice (local):      compute PowStamp over the challenge
+6.  Alice → relay:      CONTACT_APPEND{contact_addr, payload, stamp}   → empty OK
+
+7.  Bob   → relay:      SUBSCRIBE / READ on his contact queue's recv_addr (signed)
+8.  Bob   (local):      durable write, then ACK  ← the §8.4 MUST
+9.  Bob   (local):      process Welcome; join the group; show Alice as a contact
+                        request in the UI, not as a message
+
+10. Bob   → relay:      CREATE_QUEUE  → (recv_addr_B, send_addr_B)
+11. Bob   → Alice:      queue_advert{ send_addr_B, ... }        INSIDE the MLS group
+12. Alice → relay:      BIND_SEND on send_addr_B with a fresh key
+13. Alice → relay:      CREATE_QUEUE  → (recv_addr_A, send_addr_A)
+14. Alice → Bob:        queue_advert{ send_addr_A, ... }        INSIDE the MLS group
+15. Bob   → relay:      BIND_SEND on send_addr_A with a fresh key
+
+    From here the contact queue plays no further part for this pair.
+```
+
+Three properties of this flow are worth stating explicitly:
+
+- **The contact queue is used exactly once per pair**, for one message, in one
+  direction. Everything afterwards is ordinary queues with bound send keys.
+- **The relay learns that someone contacted `contact_addr`**, which is a public
+  address associated with Bob in a public directory. It does not learn who: the
+  append is unsigned and carries no client identity. It does see the source IP,
+  as it does for everything ([`THREAT-MODEL.md` §3.3](./THREAT-MODEL.md#33-compromised-relay-operator-third-party-or-ours)).
+- **The directory lookup at step 1 reveals interest in `@bob`** — the accepted,
+  documented limit of
+  [`THREAT-MODEL.md` §4.1](./THREAT-MODEL.md#41-directory-lookup-reveals-interest-in-a-handle).
+  First contact is exactly the moment that limit applies, and this flow does not
+  worsen it.
+
+**Dependency, flagged rather than invented:** step 1 assumes Bob has published
+MLS `KeyPackage`s that Alice can fetch, and step 2 assumes one is available and
+unexpired. KeyPackage publication, last-resort key packages, exhaustion behaviour
+and rate limiting on fetches are **directory design**, deferred with `KT.md` and
+ADR 0013 (§1.2). This document does not specify them and must not be read as
+having done so.
+
+---
+
+## 13. Anti-abuse v1
+
+See [ADR 0012](./decisions/0012-anti-abuse-v1.md).
+
+### 13.1 The layers
+
+**Layer 1 — connection limits.** Maximum concurrent connections per source
+address; maximum new connections per second per source; `handshake_timeout_ms`
+(§2.5); `max_frame_bytes` (§4.1); `max_inflight` (§4.3); a per-connection command
+rate limit yielding `ERR_RATE_LIMITED`. All cheap, all applied before any
+signature verification.
+
+**Layer 2 — per-queue quotas.** `max_queue_messages`, `max_queue_bytes`, and an
+append rate limit, all per queue. Exceeding any of them on the send side is
+`ERR_UNAVAILABLE` (§6.3), never a distinguishable code.
+
+**Layer 3 — queue-creation control.** Creating a queue is the only command that
+allocates durable state out of nothing, so it is the one that needs a gate.
+`queue_creation_mode` is one of:
+
+- `open` — no gate. Appropriate only for a private relay on a closed network.
+- `pow` — **the default.** `CREATE_QUEUE` and `CREATE_CONTACT_QUEUE` require a
+  `PowStamp` over a relay-issued challenge.
+- `token` — an operator-issued bearer token. Honest note: **a token is an
+  identifier.** It lets the operator link every queue created with it, which
+  reintroduces exactly the linkability that opaque per-pair addresses exist to
+  remove ([ADR 0004](./decisions/0004-metadata-ambition.md)). Token mode is
+  supported because a closed deployment may legitimately want it, it MUST be
+  declared in the capability document, and clients SHOULD prefer `pow` relays and
+  SHOULD say in the UI what a token-gated relay can correlate.
+
+```
+struct {
+    uint8  algorithm;        /* 1 = blake2b-leading-zero-bits; no other value in v1 */
+    uint8  difficulty_bits;
+    uint32 challenge_ttl_ms;
+} PowParams;
+
+struct {
+    opaque challenge[32];    /* from GET_CHALLENGE; single-use, expiring */
+    opaque salt[16];
+    uint64 counter;
+} PowStamp;
+```
+
+A stamp is valid iff
+`H("free2z/relay/v1/pow", challenge || salt || counter)` has at least
+`difficulty_bits` leading zero bits, the challenge is unconsumed and unexpired,
+and (for `contact_append`) the challenge was issued for that `contact_addr`.
+Verification is one hash; the relay marks the challenge consumed. The choice of a
+verify-cheap, GPU-friendly function and its consequences are argued in §12.4.
+
+**Layer 4 — global backpressure.** The relay tracks storage and memory against
+published high-water marks. On crossing them it refuses work in this order:
+
+1. `CREATE_QUEUE` / `CREATE_CONTACT_QUEUE` → `ERR_BACKPRESSURE`
+2. `APPEND` / `CONTACT_APPEND` → `ERR_UNAVAILABLE`
+3. New connections → refused at accept
+
+`READ`, `ACK` and `DELETE_QUEUE` are **never** refused for backpressure. They are
+the operations that make the relay smaller, and refusing them under load is a
+deadlock.
+
+### 13.2 Never delete un-acked messages to make room
+
+**Under no circumstance does a relay delete an unacknowledged message to free
+space.** Not the oldest, not the largest, not from the fullest queue. When it runs
+out of room it **refuses new writes**.
+
+The reason is the other half of delete-on-ack. The entire contract is: the relay
+holds ciphertext until the reader durably writes it and acknowledges, then
+deletes. A sender that received `accepted` has been told the relay took custody;
+if the relay may later discard that message to make room, then `accepted` means
+nothing at all and the recipient's `ACK` is not the only thing that removes data.
+The system would then be losing messages by a mechanism that
+[`ARCHITECTURE.md` §7](./ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering)'s
+DAG detects only when a *later* message arrives to dangle a parent — i.e. the
+tail-truncation blind spot of
+[`THREAT-MODEL.md` §4.4](./THREAT-MODEL.md#44-tail-truncation-is-not-detectable-by-hash-links),
+reached by ordinary operation rather than by attack.
+
+Refusing a write is loud, immediate, and lands on the party that can do something
+about it. Silently dropping an accepted message is quiet, delayed, and lands on
+someone who cannot. **Refusal is the correct failure mode**, and a relay that is
+persistently refusing is a relay that needs a bigger disk or fewer users — which
+is exactly the signal an operator should receive.
+
+The one deletion that is not a refusal is TTL expiry (§7.7), which is
+announced in advance in the capability document, bounded by the architecture's
+30-day ceiling, and visible to a subscribed reader as `QUEUE_EVENT`.
+
+### 13.3 What is not closed
+
+- **Distributed queue-creation flooding with valid stamps.** An adversary with
+  many sources and real compute creates many legitimate queues. Every stamp is
+  valid, every queue is well-formed, and the relay has no basis on which to
+  distinguish them from users — because the basis would be identity, which it
+  deliberately does not have. Backpressure keeps it alive by degrading service
+  for everyone. This is not solved; §13-I's anonymous credentials are the
+  intended answer and are deferred.
+- **An abusive but legitimately bound sender.** Once `BIND_SEND` has succeeded,
+  the relay cannot tell wanted traffic from unwanted traffic — the payload is
+  opaque ciphertext and that is the point. The remedy is entirely client-side and
+  in-band: the recipient stops acknowledging, deletes the queue (§6.2), and does
+  not advertise a replacement to that peer. That is correct, and it is slower and
+  clumsier than a block button on a server that could see who was talking. We
+  chose the metadata property; this is part of its cost.
+- **Per-source limits harm exactly the users who most need the system.** A Tor
+  exit node, a CGNAT block, a university NAT and a shared VPN egress all present
+  as one source address carrying many legitimate users. Per-source limits will
+  throttle them. There is **no good answer** without an identity the relay
+  deliberately lacks: allowlisting Tor exits removes the limit for the population
+  most able to rotate addresses, and rate-limiting by anything more granular than
+  an address requires knowing something about the client. Operators SHOULD publish
+  whether per-source limits are on (`per_source_limits`) so that a user behind
+  shared egress can choose a relay that does not use them, and that is the whole
+  of the mitigation.
+
+---
+
+## 14. Handle charset for messaging — blocking pre-check, resolved
+
+[`ARCHITECTURE.md` §9](./ARCHITECTURE.md#9-identity-directory-key-transparency-and-federation)
+makes the `@handle → identity key` mapping the foundation everything else rests
+on: encrypting perfectly to the wrong key is not security. A charset that admits
+homographs and mixed scripts puts an impersonation attack *below* the
+cryptography, where no amount of key transparency helps — `@аlice` with a
+Cyrillic а is a different handle with a different, perfectly valid, perfectly
+audited key.
+
+### 14.1 Proposed rule
+
+```
+messaging_handle = /^[a-z0-9_]{1,30}$/     ASCII only, NFC (trivially satisfied)
+```
+
+Compared as bytes. **No normalization is performed at comparison time** — a
+handle either matches the pattern exactly or it is not a handle. That is the
+point: a normalization function is itself the attack surface (which forms fold to
+which? is `ﬁ` `fi`? is `ı` `i`?), and a charset with no case, no scripts and no
+confusable pairs makes an entire class of homograph and mixed-script impersonation
+**not exist** rather than be defended against.
+
+### 14.2 Checked against free2z's real username rules
+
+**This was checked before being written down**, and the answer is that real
+usernames are considerably broader.
+
+| Source | Finding |
+|---|---|
+| `py/dj/free2z/openapi/f2z.yaml` — `Registration`, `CreatorDetail`, `CreatorList`, `CommentAuthor` | `username` is `type: string`, **`pattern: ^[\w.@+-]+$`**, **`maxLength: 150`**, described as *"Letters, digits and @/./+/-/_ only."* This is Django's `AbstractUser.username` contract. |
+| `py/dj/free2z/settings.py:29` | `AUTH_USER_MODEL = 'g12f.Creator'`. **The `Creator` model itself is not present in this repository** — only serializers and views are — so which of Django's two username validators is attached **cannot be determined here**. |
+| `py/dj/apps/g12f/serializers/creator.py` | Uniqueness is enforced **case-insensitively** at the application layer (`Creator.objects.filter(username__iexact=...)`, in `RegistrationSerializer.validate_username` and `CreatorProfileUpdateSerializer.validate_username`). `FORBIDDEN_USERNAMES` additionally reserves route-shadowing names. |
+| `py/dj/apps/g12f/views/creator.py` | Reads are `username__iexact` (`lookup_field = "username__iexact"`; `get_object_or_404(Creator, username__iexact=...)`). |
+| `ts/svelte/free2z/src/routes/[username]/+page.svelte` | Handles are rendered verbatim as `@{creator.username}` and URL-encoded into paths. The front end applies **no** narrower rule. |
+| `ts/svelte/free2z/src/routes/[username]/dashboard/billing/+page.server.ts` | Contains `USERNAME_PATTERN = /^[a-zA-Z0-9_]{1,64}$/`, but this validates a subscription-target parameter in one dashboard action — it is not the registration rule, and it is already **narrower than what registration accepts**, so accounts with `.`/`@`/`+`/`-` in their name cannot use that page today. |
+
+Two things follow, and the second is the one that matters most:
+
+1. **The published contract is broader than `[a-z0-9_]{1,30}` on every axis**:
+   uppercase is allowed, `.` `@` `+` `-` are allowed, and the length limit is 150
+   rather than 30.
+2. **Whether non-ASCII is allowed is genuinely undetermined from this
+   repository.** `\w` in Python's `re` is Unicode-aware on `str` unless `re.ASCII`
+   is set. Django's `UnicodeUsernameValidator` (the default on `AbstractUser`)
+   leaves it Unicode-aware and therefore admits Cyrillic, Greek, full-width Latin
+   and mixed-script handles; `ASCIIUsernameValidator` does not. The OpenAPI
+   schema emits the same `^[\w.@+-]+$` for both, so the schema cannot settle it.
+   **This MUST be confirmed against the `Creator` model before the rule is
+   enforced.** If the Unicode validator is in use, the platform's handle space
+   today already contains the homograph attack surface, and that is a finding
+   about the existing product, not only about messaging.
+
+### 14.3 The decision, and the cost accepted
+
+**Messaging handles use the restricted charset.** A platform username is eligible
+for a messaging handle iff:
+
+```
+lowercase(username) matches /^[a-z0-9_]{1,30}$/
+```
+
+The lowercase mapping is included deliberately: because platform uniqueness is
+already enforced case-insensitively, folding case **cannot** introduce a
+collision between two distinct existing accounts — so uppercase costs nobody
+their handle and there is no reason to exclude it.
+
+**Caveat, and it must be checked before this is relied on:** that argument holds
+only if case-insensitive uniqueness actually holds *in the database*. It is
+enforced in the two serializers reachable from this repository, but the `Creator`
+model is not here, so whether a database-level constraint backs it — and whether
+any account predates the check, or was created through admin, a data migration or
+a social-login path that bypasses the serializer — **cannot be established from
+this repository and must be settled with a query.** Any colliding pair must be
+resolved by hand before the mapping ships.
+
+**Accepted product cost, stated plainly.** Existing accounts whose username
+contains `.`, `@`, `+` or `-`, contains any non-ASCII character, or exceeds 30
+characters after lowercasing are **not eligible for a messaging handle in v1**.
+Those users can use free2z exactly as they do today; they cannot be discovered by
+handle in the messenger until they have a compliant handle.
+
+**How large is that population? We do not know.** This repository holds no user
+data and the count cannot be estimated from it. **The number MUST be measured
+before the rule ships**, because it is the difference between a rounding error
+and a migration project, and discovering which one it is at launch is not
+acceptable. Recorded as
+[`ARCHITECTURE.md` §13-O](./ARCHITECTURE.md#13-open-questions).
+
+### 14.4 Alternatives rejected
+
+- **Accept the platform charset as-is.** Rejected. It admits mixed-script
+  impersonation into the one mapping whose integrity the entire system depends on
+  (§9 of the architecture), and it does so at the exact point — first contact —
+  where the user has the least context to notice.
+- **Normalize aggressively** (strip dots, fold confusables, NFKC). Rejected on
+  two grounds: normalization creates collisions between existing distinct
+  accounts, which is a data-loss migration; and a confusable-folding function is
+  precisely the homograph attack surface we set out to remove, relocated into our
+  own code.
+- **A separate, opt-in messaging handle decoupled from the platform username.**
+  Not rejected — **deferred.** It is the cleanest answer for the excluded
+  population and it is directory design: it needs a second namespace, a claim
+  protocol, and a rule for what happens when the two diverge. It touches
+  [`ARCHITECTURE.md` §13-K](./ARCHITECTURE.md#13-open-questions) (handle rename
+  and transfer) and belongs with `KT.md`.
+- **Allow up to 150 characters.** Rejected as a UI and verification concern
+  rather than a security one: handles appear in safety-number confirmations and
+  in contact-request UI, where a 150-character string is unreadable and therefore
+  unverifiable by a human.
+
+---
+
+## 15. Clean-room posture toward SimpleX — blocking pre-check, resolved
+
+[`ARCHITECTURE.md` §6](./ARCHITECTURE.md#6-delivery-service) adopts SimpleX's
+SMP *protocol design* and flags the licensing question as
+[§13-E](./ARCHITECTURE.md#13-open-questions): *"verify SimpleX's server licensing
+**before** anyone reads their server source."*
+
+**The check was performed on 2026-08-23**, by an agent working on
+[#545](https://github.com/free2z/zuu/issues/545), **using published repository
+metadata only** — GitHub's REST repository endpoint (`GET /repos/{owner}/{repo}`),
+whose `license` field GitHub derives from the repository's licence file, and the
+repository contents-listing endpoint for top-level directory names. **No source
+file from that project was fetched, opened or read**, and no source file from that
+project has been read by anyone on this project.
+
+**Result:**
+
+| Repository | Reported licence |
+|---|---|
+| `simplex-chat/simplexmq` — *"a reference implementation of the SimpleX Messaging Protocol"*, i.e. the server | **AGPL-3.0** (`license.spdx_id: "AGPL-3.0"`) |
+| `simplex-chat/simplex-chat` — the client applications | **AGPL-3.0** |
+
+**Confidence: high, with a stated boundary.** GitHub's `license` field is a
+machine-readable statement derived from the project's own licence file. That is
+sufficient to establish the operative fact — *the server implementation is
+copyleft, therefore nobody on this project reads it* — and it is **not** a legal
+opinion. If we ever need to do more than avoid the code (link against it, vendor
+anything from it, or distribute anything derived from it), we obtain actual legal
+advice rather than relying on a metadata field.
+
+**A nuance we record rather than gloss.** The published protocol documents live
+in the **same repository** as the source: the top-level listing of
+`simplex-chat/simplexmq` contains both `src/` and `protocol/`, and
+`protocol/simplex-messaging.md` is the document rendered at
+[simplex.chat/docs/simplex.html](https://simplex.chat/docs/simplex.html) that
+`ARCHITECTURE.md` §3 cites. So "reading the public protocol document" means
+reading a document inside an AGPL-licensed repository. Copyright subsists in the
+*expression* of that document, not in the protocol it describes; an independent
+implementation written from the specification, copying neither its prose nor any
+source file, is clean. We state that as our posture, not as advice, so that a
+reviewer can challenge it rather than discover it.
+
+**The binding rule, recorded here because a rule nobody can find is not a rule:**
+
+1. **Nobody on this project reads `simplexmq` source.** Not to check a detail, not
+   to resolve an ambiguity, not "just to see how they did it".
+2. The design in [`ARCHITECTURE.md` §6](./ARCHITECTURE.md#6-delivery-service) and
+   in this document derives **solely** from the public protocol description and
+   from our own reasoning about the problem.
+3. Where this document differs from SMP, it says so. Where it resembles SMP, it
+   resembles it because the same problem has the same shape — unidirectional
+   queues with split capabilities is the natural answer to "deliver without
+   identifiers", not a borrowed one.
+4. If an implementer finds themselves wanting to look at their code, the correct
+   action is to write down the question they cannot answer from the specification
+   and raise it, so the gap gets fixed in *our* specification.
+
+This closes [`ARCHITECTURE.md` §13-E](./ARCHITECTURE.md#131-closed).
+
+---
+
+## 16. What this document leaves open
+
+Deliberately, and listed rather than invented:
+
+- **The key-transparency log construction** — `SignedTreeHead`, epoch cadence,
+  proof encodings, the full `DirectoryEntry`, witness-cosignature format. Blocked
+  on [#544](https://github.com/free2z/zuu/issues/544); lands as `KT.md` with
+  ADR 0013 (§1.2).
+- **MLS `KeyPackage` publication and exhaustion** (§12.5) — directory design.
+- **Padding bucket sizes** — [§13-F](./ARCHITECTURE.md#13-open-questions).
+  This document deliberately puts the set in configuration so the measured answer
+  is cheap to adopt (§9).
+- **Relay redundancy factor *k*** — [§13-G](./ARCHITECTURE.md#13-open-questions).
+  The protocol supports any *k*; the default is not chosen here.
+- **Anonymous credentials for quota** —
+  [§13-I](./ARCHITECTURE.md#13-open-questions). The real answer to §13.3's first
+  bullet, and still unspecified.
+- **Push notifications** — [§13-H](./ARCHITECTURE.md#13-open-questions). This
+  protocol assumes a held WebSocket. It does not define a push-notification
+  address or an offline-wake path, because we still have no position on the
+  metadata cost of one.
+- **Proof-of-work function and calibration** —
+  [§13-N](./ARCHITECTURE.md#13-open-questions), opened by §12.4.
+- **Messaging-handle eligibility for existing accounts** —
+  [§13-O](./ARCHITECTURE.md#13-open-questions), opened by §14.3.
+
+---
+
+## 17. References
+
+[RFC 8446 — TLS 1.3](https://datatracker.ietf.org/doc/html/rfc8446) (§3
+presentation language, §7.5 exporters) ·
+[RFC 5705 — TLS keying material exporters](https://datatracker.ietf.org/doc/html/rfc5705) ·
+[RFC 6455 — The WebSocket Protocol](https://datatracker.ietf.org/doc/html/rfc6455) ·
+[RFC 9420 — MLS](https://datatracker.ietf.org/doc/html/rfc9420) ·
+[RFC 8949 — CBOR](https://datatracker.ietf.org/doc/html/rfc8949) ·
+[RFC 8615 — well-known URIs](https://datatracker.ietf.org/doc/html/rfc8615) ·
+[SimpleX SMP protocol documentation](https://simplex.chat/docs/simplex.html)
+(read as documentation only — §15)

--- a/docs/e2ee/decisions/0008-transport-and-serialization.md
+++ b/docs/e2ee/decisions/0008-transport-and-serialization.md
@@ -1,0 +1,126 @@
+# ADR 0008 — Transport and canonical serialization: WebSocket over TLS, `tls_codec`, and mandatory re-encode equality
+
+**Status:** Accepted (Phase 1 specification, 2026-08-23) ·
+**Refs:** [#545](https://github.com/free2z/zuu/issues/545),
+[#305](https://github.com/free2z/zuu/issues/305) ·
+**Specifies:** [`../WIRE.md` §2](../WIRE.md#2-transport),
+[§3](../WIRE.md#3-serialization), [§4](../WIRE.md#4-framing)
+
+> **Invented here.** The merged Phase 0 documents named relay *capabilities*
+> (`APPEND` / `READ` / `ACK` / `DELETE`) in prose and specified neither a
+> transport, a framing, nor a serialization. Nothing below should be read as
+> having already been decided.
+
+## Context
+
+The relay is a public, unauthenticated network listener: anyone on the internet
+may connect and send bytes to it before any signature has been checked. Its
+attack surface is, overwhelmingly, its parser.
+
+Three constraints bound the choice.
+
+1. **[ADR 0001](./0001-platform-priority.md) requires the WASM web client to
+   speak the same protocol as ZUULI**, from one Rust crypto core, so that there
+   is no second implementation to diverge. A browser can open a WebSocket and
+   nothing else.
+2. **[ADR 0005](./0005-federation.md) makes concurrent connections, not
+   bandwidth, the cost driver**, and requires the relay to be sustainable on a
+   ~$5/month VPS run by a volunteer. Framing efficiency is not where that budget
+   is won or lost.
+3. **Commands are signed** ([`../WIRE.md` §5](../WIRE.md#5-the-signing-transcript)),
+   so the encoding is not merely a transport detail — it is the thing signatures
+   cover. Any encoding with more than one representation of a value is an
+   invitation to a parse-versus-verify divergence.
+
+## Decision
+
+**Transport: WebSocket over TLS 1.3, and no second transport.** `wss://` only,
+path `/relay/v1`, subprotocol `free2z-relay.v1`. The relay refuses to bind a
+non-loopback address without TLS unless explicitly overridden, and the override is
+published in the capability document. The relay sends a WebSocket Ping every ~25
+seconds.
+
+**Serialization: the TLS presentation language (`tls_codec`).**
+
+**Framing: one binary WebSocket frame carries exactly one request, response or
+push.** Text frames are a fatal error. Requests are pipelined within a bounded
+in-flight window and responses may complete out of order, correlated by a
+client-chosen `request_id`.
+
+**And the rule that makes the serialization choice load-bearing: every received
+frame MUST be decoded, re-encoded, and byte-compared against the input, with all
+hashing and signing performed over the re-encoded bytes. A mismatch is a fatal
+error.**
+
+## Consequences
+
+- **One parser on the unauthenticated path.** A second transport would be a
+  second parser and a second fuzz target, for a client population that cannot use
+  it (browsers) and a cost model that does not need it.
+- **No parse-versus-verify gap.** Re-encode equality means there is exactly one
+  byte string a given value can be; the signature covers that byte string; any
+  encoding that is not it is rejected before any state changes. The class of bug
+  this removes — a decoder more permissive than its encoder, so that two parties
+  disagree about what a signature covered while both believe they verified it —
+  is one of the most reliably exploitable in signed protocols.
+- **The rule compensates for implementation slack, not format ambiguity**, and
+  should be described that way. The TLS presentation language is already
+  unambiguous; decoders are not. The cost is one extra encode per frame,
+  negligible beside a signature verification.
+- **No "ignore unknown fields" extensibility.** Re-encode equality forbids it.
+  Adding a field means a new command code or a new protocol version. This is a
+  real ergonomic cost — evolving the protocol is more ceremonious than it would
+  be with a self-describing format — and it is accepted, because silent tolerance
+  of unknown bytes is how a signature ends up covering something the verifier
+  never looked at.
+- **The keepalive is load-bearing in production.** A relay behind a proxy whose
+  idle timeout is below the ping interval tears down every long-lived
+  subscription on a timer and sees a reconnect storm that looks like an attack.
+  Operators MUST set any front-end idle timeout to at least 3× the ping interval.
+  Server-side ping is chosen because the browser WebSocket API cannot send a Ping
+  frame — a client-driven keepalive would be a second mechanism used by only one
+  of the two clients.
+- **`transport_security: "none"` is published, not hidden.** The insecure-listen
+  override exists because sidecar TLS termination and container-local development
+  are real. Making it a field of a signed capability document means using it is an
+  act with evidence, and clients refuse such relays by default.
+- **Error responses carry a code and nothing else** — no free-text message. A
+  free-text field on an unauthenticated path is a covert channel out of the
+  relay, a fingerprinting surface, and a place where implementations leak
+  internal state by accident.
+- **Out-of-order responses require correlation state in the client**, which is
+  slightly more work than a lock-step protocol, and buys the ability to fetch,
+  acknowledge and append concurrently on one connection without head-of-line
+  blocking.
+
+## Alternatives rejected
+
+- **CBOR ([RFC 8949](https://datatracker.ietf.org/doc/html/rfc8949)).** Rejected.
+  CBOR has many encodings of the same value — definite and indefinite lengths,
+  non-minimal integer widths, map key ordering, duplicate keys, tags — and its
+  canonical form is a *profile*: a rule an implementation must remember to apply
+  and that a decoder will happily let it skip. We would be adding a serializer
+  whose default behaviour is unsafe for our use, plus a second decoder in the
+  WASM bundle and in the audit scope, to gain self-description we do not want.
+  The relay is a fixed command set, not an extensible document format.
+- **A hand-rolled binary codec.** Rejected on the plainest grounds available: it
+  would be a new parser, written by us, on the unauthenticated path, and the only
+  component of the relay with no prior review anywhere. `tls_codec` is not
+  formally verified either, but it is exercised by every MLS implementation built
+  on it, including ours.
+- **Protocol Buffers / FlatBuffers.** Rejected: same canonicality problem as CBOR
+  (field ordering, unknown-field preservation, default-vs-absent), plus a code
+  generator and a schema toolchain in the build.
+- **JSON.** Rejected on canonicality (number representation, key ordering,
+  string escaping), on size, and because signing over JSON requires a
+  canonicalization scheme whose failure modes are well documented and numerous.
+- **Adding QUIC, raw TCP, or an HTTP long-poll fallback.** Rejected: a transport
+  the browser client cannot use is a transport that breaks ADR 0001's
+  one-implementation property, and each is another parser on the front door.
+- **Skipping re-encode equality and signing the received bytes directly.**
+  Rejected. It appears equivalent and is not: it makes the *signature* agree with
+  the received bytes while leaving the *application state* derived from whatever
+  the permissive decoder produced, which is the divergence with the sharp edge.
+- **TLS 1.2 support.** Rejected: the channel binding
+  ([ADR 0010](./0010-signing-transcript-and-ack-semantics.md)) is the TLS 1.3
+  exporter, and there is no defined binding for this protocol below 1.3.

--- a/docs/e2ee/decisions/0009-queue-addressing-and-binding.md
+++ b/docs/e2ee/decisions/0009-queue-addressing-and-binding.md
@@ -1,0 +1,124 @@
+# ADR 0009 — Queue addressing: relay-generated addresses, in-band adverts, and once-only send-key binding
+
+**Status:** Accepted (Phase 1 specification, 2026-08-23) ·
+**Refs:** [#545](https://github.com/free2z/zuu/issues/545),
+[ADR 0004](./0004-metadata-ambition.md), [ADR 0005](./0005-federation.md) ·
+**Specifies:** [`../WIRE.md` §7](../WIRE.md#7-queue-lifecycle)
+
+> **Invented here.** [`../ARCHITECTURE.md` §6.2](../ARCHITECTURE.md#62-queues)
+> specified that a queue has two addresses, that each is bound to an Ed25519 key
+> at creation, and that addresses are advertised inside the MLS group. It
+> specified nothing about **who generates an address**, how the send side comes
+> to be bound, or what rotation costs.
+
+## Context
+
+Three questions were left open and each has a wrong answer that looks reasonable.
+
+**Who picks the address?** Deriving it client-side from an exporter is the
+obvious move and [`../ARCHITECTURE.md` §5.4](../ARCHITECTURE.md#54-exporter-derived-application-secrets)
+gestures at it, promising rotation "without a round trip."
+
+**How does the send side become authorized?** The recipient creates the queue and
+holds the recv key. The sender is a different device that does not exist, from the
+relay's point of view, until it appears.
+
+**What does rotation cost?** [ADR 0004](./0004-metadata-ambition.md) requires
+rotation so that a long-lived relationship does not present a long-lived
+identifier.
+
+## Decision
+
+1. **The recipient creates the queue**, with `CREATE_QUEUE` signed by the recv
+   key it is registering.
+2. **The relay generates both addresses from its own CSPRNG** — 32 uniformly
+   random bytes each, independent of one another and of any key. Clients do not
+   choose addresses.
+3. **The send side starts unbound.** No key authorizes `APPEND` until one is
+   bound.
+4. **The peer learns `send_addr` from an authenticated `queue_advert` inside the
+   MLS group, never through the server**, and the advert carries `relay_id`
+   alongside the address.
+5. **The sender binds once with `BIND_SEND`. Binding is once-only and
+   irreversible.** A second bind — with any key, including the same key — is
+   `ERR_ALREADY_BOUND`.
+6. **Rotation needs no new command:** create a new queue on the
+   `free2z/queue/v1` exporter schedule, advertise it in-band, delete the old one
+   once drained.
+
+## Consequences
+
+- **Squatting is unaskable.** With client-chosen addresses, an adversary could
+  create queues at addresses it predicts a victim will want — derived from
+  exporter inputs it can guess, or by sweeping — so that the victim's creation
+  fails or, worse, succeeds against an existing attacker-controlled record.
+  Relay-generated addresses remove the question.
+- **Collisions become the relay's problem, and it can solve them.** Two clients
+  independently deriving addresses will eventually collide, and a collision
+  between unrelated conversations is a cross-conversation delivery bug with no
+  clean recovery. A single CSPRNG can retry, which at 32 bytes it never will.
+- **A narrowing of `ARCHITECTURE.md` §5.4 that must be stated.** §5.4's table says
+  the `free2z/queue/v1` exporter *"derives the next queue addresses without a
+  round trip."* That is no longer accurate. The exporter derives the **rotation
+  schedule and the next queue signing keys**; the addresses come from the relay
+  and the new `send_addr` still has to reach the peer in an advert. Rotation
+  therefore costs one relay round trip and one in-band message. The cost is small
+  — one message per rotation period between parties already exchanging messages —
+  and it is the price of refusing client-chosen addresses. It is recorded rather
+  than left as a contradiction between two documents; see
+  [`../WIRE.md` §7.5](../WIRE.md#75-rotation-needs-no-new-command).
+- **The relay operator can steal the write capability, and the design makes it
+  noisy rather than impossible.** An operator that reads `send_addr` out of its
+  own database and calls `BIND_SEND` first wins the race; the legitimate sender
+  then receives `ERR_ALREADY_BOUND`. **This does not prevent the theft. It makes
+  it loud.** The client MUST treat `ERR_ALREADY_BOUND` on a first bind for a
+  freshly advertised address as a **non-dismissible failure**: not a retry, not a
+  toast, not a log line — the conversation is marked compromised at the transport
+  layer, the queue abandoned, and the user told which relay misbehaved.
+- **What the thief gets is bounded.** It cannot read the queue (`send_addr`
+  authorizes `APPEND` only). Anything it appends fails MLS authentication at the
+  recipient, so it is garbage rather than forgery. What it gains is the ability to
+  deny the legitimate sender its queue and to consume the recipient's quota —
+  denial of service, which it already had by refusing to serve. The property
+  bought is **attributable denial rather than flaky delivery**, which is the same
+  detected-versus-undetected trade as
+  [`../THREAT-MODEL.md` §4.5](../THREAT-MODEL.md#45-server-side-deletion-is-auditable-not-verifiable).
+- **Rebind is deliberately absent.** Allowing the recv key to rebind would give
+  the strongest key in the system — the one that can drain the queue — a second
+  capability over the send side, to recover from a failure that already has a
+  clean, cheap alternative: make a new queue.
+- **Rotation overlaps rather than switching atomically.** The old queue stays
+  readable until drained; the sender switches at `valid_from_epoch`; a message in
+  flight during the switch lands in the old queue and is read from it.
+- **`relay_id` travels with the address.** Without it, the sender has no
+  authenticated statement of *which relay* the recipient chose, and the relay
+  identity binding of [ADR 0010](./0010-signing-transcript-and-ack-semantics.md)
+  would have nothing to compare against.
+
+## Alternatives rejected
+
+- **Client-derived addresses from the `free2z/queue/v1` exporter.** Rejected on
+  squatting and collisions, above. This is the alternative the merged docs
+  implied, and rejecting it is the reason §5.4's "without a round trip" is
+  narrowed.
+- **Addresses derived from the queue public key** (e.g. `H(pk)`). Rejected: it
+  ties the address to the key, so rotating one forces rotating the other, and it
+  makes the address a commitment to a key an attacker may later learn.
+- **A rebindable send side, controlled by the recv key.** Rejected: it adds a
+  capability to the most powerful key in the system to solve a problem that
+  creating a new queue already solves.
+- **Pre-committing to the sender's key at creation
+  (`CREATE_QUEUE{expected_send_key}`).** This would close the operator-binds-first
+  race entirely, and it was **rejected for v1 on cost, not on merit**: the
+  recipient does not know the sender's fresh queue key at creation time, so
+  learning it needs an extra in-band round trip *before* the advert, turning a
+  one-message advert into a three-message handshake for every queue and every
+  rotation. It is the right answer if the race proves to matter in practice, and
+  it is recorded here so the option is on the record rather than rediscovered.
+- **A dedicated `ROTATE` command.** Rejected: it would be create-plus-delete with
+  extra state and a new failure mode (a half-rotated queue), to save a client
+  three lines of sequencing.
+- **Server-assigned sequential or structured addresses.** Rejected: any structure
+  in an address is information the relay hands to anyone who obtains one, and
+  enumerable addresses defeat the opacity that
+  [ADR 0004](./0004-metadata-ambition.md) exists to provide.

--- a/docs/e2ee/decisions/0010-signing-transcript-and-ack-semantics.md
+++ b/docs/e2ee/decisions/0010-signing-transcript-and-ack-semantics.md
@@ -1,0 +1,153 @@
+# ADR 0010 — The signing transcript, anti-replay, and ACK semantics
+
+**Status:** Accepted (Phase 1 specification, 2026-08-23) ·
+**Refs:** [#545](https://github.com/free2z/zuu/issues/545),
+[#131](https://github.com/free2z/zuu/issues/131),
+[ADR 0002](./0002-multi-device.md), [ADR 0005](./0005-federation.md) ·
+**Specifies:** [`../WIRE.md` §5](../WIRE.md#5-the-signing-transcript),
+[§8](../WIRE.md#8-ack-semantics)
+
+> **Invented here.** [`../ARCHITECTURE.md` §6.2](../ARCHITECTURE.md#62-queues)
+> said only that *"every relay command is signed with the relevant queue key."*
+> There was no transcript, no statement of what the signature covers, no
+> anti-replay construction, and no acknowledgement semantics beyond "ACK arrives
+> → delete."
+
+## Context
+
+"Signed with the queue key" is not a specification. A signature over the command
+body alone is replayable everywhere: to the same relay later, to a different
+relay, on a different connection, under a different request id. Two of those are
+live attacks in *this* system rather than textbook ones.
+
+**Cross-relay replay is live because of [ADR 0005](./0005-federation.md).** A
+device publishes its queue addresses on *k* relays and senders send to all *k*.
+If a signed command does not name a relay, relay A can take a frame verbatim and
+submit it to relay B, which verifies it happily. For `APPEND` that is a duplicate.
+For `ACK` it is worse: **A replays the recipient's cumulative `ACK` to B, and B
+deletes ciphertext the recipient never received from B** — silent, permanent
+message loss, caused by one relay against another, using only bytes the victim
+signed.
+
+**Acknowledgement semantics are load-bearing because of delete-on-ack.** The relay
+deletes on ACK, so the ACK rule is the rule that decides whether messages survive.
+[`../ARCHITECTURE.md` §6.3](../ARCHITECTURE.md#63-what-delivered-means) defines
+four delivery states and warns that conflating them is how delete-on-ack loses
+messages; the relay implements exactly one of them and must implement it exactly.
+
+## Decision
+
+**The signing transcript.** Every signed command is an Ed25519 signature over a
+fixed-shape `CommandTranscript` covering, in order: a domain-separation label
+(`"free2z/relay/v1/cmd"`), the protocol version, **the relay identity binding**,
+**the TLS exporter channel binding**, the command code, the request id, the queue
+address, the signer key, a timestamp, a 16-byte client nonce, and a hash of the
+re-encoded body.
+
+- `relay_id = H("free2z/relay/v1/relay-id", relay_identity_pk)`. The relay proves
+  possession of that key in `HELLO`; the client compares it against the value
+  carried in the peer's in-band `queue_advert`
+  ([ADR 0009](./0009-queue-addressing-and-binding.md)).
+- `channel_binding = TLS-Exporter("EXPORTER-free2z-relay-v1", "", 32)`
+  ([RFC 8446 §7.5](https://datatracker.ietf.org/doc/html/rfc8446#section-7.5)).
+
+**Anti-replay** is a bounded timestamp window (`±clock_skew_ms`, default 2
+minutes) plus a `(signer_key, nonce)` seen-set covering that window. The seen-set
+is **fail-closed**: at its bound the relay returns `ERR_BACKPRESSURE` rather than
+evicting live entries. It is **in memory and need not survive a restart**.
+
+**ACK is cumulative, monotone, idempotent, and never selective.** Acking beyond
+the highest appended index is an error.
+
+## Consequences
+
+- **A signature is valid at exactly one relay, on exactly one TLS session, for
+  exactly one request id.** The cross-relay `ACK` replay above fails at signature
+  verification; a captured frame replayed on a new connection fails on the channel
+  binding; a frame replayed on the same connection fails on the seen-set.
+- **The relay MUST prove possession of its identity key**, or `relay_id` is
+  decoration that any relay can claim. `HELLO` returns
+  `Sign(relay_identity_sk, "free2z/relay/v1/hello" || channel_binding || client_nonce)`
+  and the client verifies it before sending any signed command.
+- **The channel binding cannot be computed behind a TLS-terminating proxy, and we
+  say so.** Such a relay declares `channel_binding_mode: "none"`, uses 32 zero
+  bytes, and a client may refuse it. There is no fix at this layer: no
+  standardized way for a proxy to forward the exporter exists, and trusting a
+  proxy-supplied value would defeat the purpose.
+- **In `none` mode the seen-set argument breaks, and the consequence is
+  spelled out rather than buried.** The reason the seen-set may be volatile is
+  that a restart destroys every TLS session, so every pre-restart signature is
+  already invalid against every new session — the binding has invalidated the
+  corpus. With the binding zeroed that no longer holds, so such a relay MUST
+  either persist its seen-set or declare `antireplay_persistence: "volatile"` and
+  accept a replay window of `clock_skew_ms` across a restart. Clients read the
+  field and may refuse.
+- **The residual is bounded, not zero.** Within the window, on the same session, a
+  party that sees the frames can replay them — that party being the operator or
+  its proxy, who already controls the relay. `APPEND` replay yields a duplicate
+  deduplicated end-to-end by `msg_id`; `ACK`, `READ`, `DELETE_QUEUE` and
+  `BIND_SEND` replays are no-ops; `CREATE_QUEUE` replay costs the operator a
+  queue. "Duplicate or no-op, at the operator's expense, against an adversary who
+  could already refuse service" is acceptable — because of the bound, not because
+  it is nothing.
+- **The transcript deliberately does not cover relative ordering.** Two `APPEND`s
+  can be reordered by anything in the path. Ordering is not a relay property in
+  this design; it is the hash-linked DAG of
+  [`../ARCHITECTURE.md` §7](../ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering),
+  precisely so it survives a hostile relay.
+- **Responses are unsigned.** Every response that matters end-to-end is verified
+  by other means, and signing responses would buy an audit trail against an
+  adversary who can simply refuse to answer.
+- **Cumulative ACK keeps relay state to one integer per queue.** Selective
+  acknowledgement would need a per-message bitmap — state proportional to the
+  queue rather than constant — and would let a reader hold one message
+  indefinitely while acknowledging later ones, a shape with no legitimate use.
+- **Acking beyond the highest appended index is an error, and this is not
+  tidiness.** Without the rule a reader could **pre-ack** to a very large index,
+  after which every future `APPEND` is deleted the instant it lands while the
+  sender keeps receiving successful (empty) `APPEND` responses — because
+  [`../WIRE.md` §6.3](../WIRE.md#63-commands-signed-by-the-send-side-queue-key)
+  forbids telling a sender anything about queue state. A device could black-hole
+  its own queue silently and indefinitely, and the only symptom anywhere would be
+  absent `device-delivered` receipts, indistinguishable from the recipient being
+  offline
+  ([`../THREAT-MODEL.md` §4.4](../THREAT-MODEL.md#44-tail-truncation-is-not-detectable-by-hash-links)).
+  One comparison removes the possibility.
+- **Idempotent ACK is what makes [#131](https://github.com/free2z/zuu/issues/131)
+  tractable.** A dropped connection tells you nothing about what arrived; a client
+  that never saw its ACK response simply sends it again. `APPEND` is *not*
+  idempotent at the relay, deliberately — deduplication lives end-to-end at
+  `msg_id`. Duplicate-tolerant delivery plus idempotent acknowledgement is the
+  combination that survives an unreliable network.
+- **The client-side MUST that the wire cannot enforce, restated where an
+  implementer will meet it:** a device MUST NOT ACK before its durable local write
+  completes ([ADR 0002](./0002-multi-device.md)). The relay has no way to know
+  whether a write happened, so this rule lives entirely in the client and is the
+  single most safety-critical rule in the delivery layer.
+
+## Alternatives rejected
+
+- **Signing the command body alone.** Rejected: replayable to another relay, on
+  another session, at another time. This is the alternative the merged text's
+  "signed with the relevant queue key" would most naturally be read as.
+- **A server-issued challenge on every signed command.** Rejected: it makes every
+  command a two-round-trip operation, which at a mobile client's latency is the
+  difference between a responsive messenger and a slow one, to replace a
+  timestamp-plus-nonce construction that achieves the same bound.
+- **Persisting the seen-set unconditionally.** Rejected for the TLS-exporter
+  mode: it adds a durability obligation and a write on the hot path to re-derive a
+  property the channel binding already provides. Retained as a requirement for
+  `none` mode, where the property is genuinely absent.
+- **Evicting seen-set entries under pressure.** Rejected outright. An eviction
+  policy that discards unexpired entries reopens the replay window at exactly the
+  moment the relay is under load — which is exactly when an attacker would arrange
+  to be.
+- **Selective acknowledgement.** Rejected on relay state and on abuse shape,
+  above.
+- **Letting an ACK beyond the head succeed as a no-op.** Rejected: it is
+  indistinguishable at the relay from pre-acking, and the failure it enables is
+  silent.
+- **Server-assigned sequence numbers as the ordering authority.** Rejected
+  already by [`../ARCHITECTURE.md` §12](../ARCHITECTURE.md#12-disposition-of-prior-review-feedback)
+  in response to #131, and nothing here reopens it: relay indices are per-queue
+  bookkeeping for acknowledgement, never message order.

--- a/docs/e2ee/decisions/0011-first-contact-contact-queues.md
+++ b/docs/e2ee/decisions/0011-first-contact-contact-queues.md
@@ -1,0 +1,143 @@
+# ADR 0011 — First contact: a distinctly-flavoured contact queue
+
+**Status:** Accepted (Phase 1 specification, 2026-08-23) ·
+**Refs:** [#545](https://github.com/free2z/zuu/issues/545),
+[#133](https://github.com/free2z/zuu/issues/133),
+[ADR 0004](./0004-metadata-ambition.md) ·
+**Specifies:** [`../WIRE.md` §12](../WIRE.md#12-first-contact)
+
+> **Invented here — and it closes a genuine hole in the merged design**, not a
+> detail left for later.
+
+## Context
+
+[`../ARCHITECTURE.md` §6.2](../ARCHITECTURE.md#62-queues) says queue addresses are
+established *"inside the MLS group — a member advertises its `QueueSendAddr` set
+to peers in an authenticated application message, never via the server."*
+
+That is correct, and it is circular. **There is no path for the `Welcome` that
+creates the group in the first place.** Alice cannot advertise a queue to Bob
+inside a group that does not exist, and she cannot send Bob the `Welcome` that
+would create it, because Bob has no queue Alice is authorized to write to. As
+merged, two people who have never spoken can never begin. Every implementation PR
+in the Phase 1 wave would hit this on its first end-to-end test.
+
+The shape of the answer is forced: **something has to accept a write from a
+stranger.** The only questions are what that something is, how tightly it is
+capped, and how honest we are about what it costs.
+
+## Decision
+
+**A contact queue**: a queue that differs from an ordinary queue in exactly four
+ways.
+
+1. **Its send side is never bound.** `BIND_SEND` on a contact address returns
+   `ERR_NOT_PERMITTED`, always, for everyone. There is no key authorizing writes,
+   so there is no key to steal, squat
+   ([ADR 0009](./0009-queue-addressing-and-binding.md)) or lose.
+2. **It accepts unsigned appends** (`CONTACT_APPEND`) from anyone presenting a
+   valid proof-of-work stamp.
+3. **Its address is published** in the owner's directory entry, authenticated by
+   whatever signature that entry carries, rather than advertised in-band. It is
+   the one address in the system meant to be looked up.
+4. **It is hard-capped**: a pending-message cap, a byte cap, a per-source token
+   bucket, and a required proof-of-work stamp computed over a **relay-issued,
+   single-use, expiring challenge** scoped to the target address.
+
+Its receive side is an ordinary queue: read, acknowledge and delete with the
+normal recv-side commands, signed by the recv key.
+
+The contact queue carries **one message, in one direction, once per pair**. Both
+sides then create ordinary queues and advertise them inside the group, and the
+contact queue plays no further part for that pair.
+
+## Consequences
+
+- **First contact works**, and it works without the server ever being trusted:
+  the `Welcome` is addressed to a `KeyPackage` Alice obtained from a
+  key-transparency-verified directory entry, so a relay that substitutes or
+  fabricates content produces something Bob cannot decrypt. The contact endpoint
+  is authenticated by the directory entry, which matters — an unauthenticated
+  contact address supplied by a server is
+  [#133](https://github.com/free2z/zuu/issues/133)'s MITM reintroduced at the one
+  moment the user has least context to notice.
+- **Unsigned appends are unauthenticated by construction, and the filter is
+  cryptographic and client-side.** A payload that is not a `Welcome` addressed to
+  one of Bob's published `KeyPackage`s fails to decrypt and is discarded. Junk
+  costs Bob bandwidth and costs the attacker a stamp. Well-formed but unwanted
+  contact requests are a moderation problem, surfaced to Bob as requests rather
+  than as messages.
+- **`CONTACT_APPEND` returns nothing**, on the same rule as `APPEND`: a stranger
+  must learn neither how full the queue is nor whether Bob has read it.
+- **Proof of work taxes phones far more than rented GPUs. This is the central
+  weakness and it is not fixable by tuning.** A leading-zero-bit search is
+  precisely the workload commodity parallel hardware accelerates best; the ratio
+  between a rented GPU-hour and a battery-constrained mid-range phone is orders of
+  magnitude. A difficulty high enough to meaningfully cost an attacker is a
+  difficulty that makes a cheap Android device heat up before it can say hello. We
+  have chosen a difficulty that is a nuisance to attackers and tolerable to
+  phones, which means it is *only* a nuisance.
+- **Disk exhaustion via mass queue creation is made expensive, not closed.**
+  Nothing prevents an adversary with real resources from creating very many
+  legitimate-looking queues with valid stamps from many sources. The caps bound
+  what one queue costs; they do not bound how many exist. Global backpressure
+  ([ADR 0012](./0012-anti-abuse-v1.md)) keeps the relay alive by degrading service
+  for everyone, because identifying the attacker would require exactly the
+  identity the relay deliberately lacks.
+  [`../ARCHITECTURE.md` §13-I](../ARCHITECTURE.md#13-open-questions)'s anonymous
+  credentials are the real answer and remain deferred and unspecified.
+- **A contact queue can be filled to deny first contact.** An attacker willing to
+  pay `contact_max_pending` stamps keeps Bob unreachable to strangers until he
+  drains it. Existing conversations are entirely unaffected — they use ordinary
+  queues — and Bob's client drains aggressively, but under a sustained flood Bob's
+  remedy is to create a new contact queue and republish his directory entry, which
+  costs a directory epoch and is therefore slow. This is a real, unmitigated denial
+  of service against first contact.
+- **The directory lookup reveals interest in a handle**, which is the accepted
+  limit of [`../THREAT-MODEL.md` §4.1](../THREAT-MODEL.md#41-directory-lookup-reveals-interest-in-a-handle).
+  First contact is exactly the moment that limit applies. This design does not
+  worsen it and does not fix it.
+- **The relay learns that someone contacted a public address.** It does not learn
+  who — the append is unsigned and carries no client identity — but it sees the
+  source IP, as it does for everything.
+- **A dependency is flagged, not invented.** The flow assumes Bob has published
+  MLS `KeyPackage`s Alice can fetch, and that one is available and unexpired.
+  KeyPackage publication, last-resort key packages, exhaustion behaviour and fetch
+  rate limiting are **directory design**, deferred with `KT.md` and **ADR 0013**,
+  which is blocked on [#544](https://github.com/free2z/zuu/issues/544).
+
+## Alternatives rejected
+
+- **Do nothing and require an out-of-band invite** (a QR code, a link, a shared
+  secret). Rejected as a product decision: free2z is a public creator platform
+  where `@handle` *is* the discovery mechanism
+  ([ADR 0004](./0004-metadata-ambition.md)), and a messenger where you cannot
+  message a creator you just found is not the product. Retained as an *additional*
+  path, not as the only one.
+- **Let the free2z application server hold and forward first-contact messages.**
+  Rejected outright: it gives the server a `Welcome`-shaped message with a
+  recipient it knows, which is the social graph the whole queue design exists to
+  withhold, and it puts the server back in the position of choosing what reaches
+  whom.
+- **Signed appends to the contact queue, authorized by the sender's identity
+  key.** Rejected: it would require the recipient's relay to know and check
+  identity keys, which reintroduces identity at exactly the layer
+  [ADR 0004](./0004-metadata-ambition.md) removed it from, and it would tell the
+  relay who contacted whom.
+- **A memory-hard proof of work (Argon2id and relatives).** Rejected for v1 with
+  regret. It would genuinely narrow the phone-versus-GPU gap. It also multiplies
+  the **relay's own verification cost** by the same factor it raises the
+  attacker's, which is the wrong trade at the moment of a flood, when the relay is
+  the resource under pressure. Verification must stay a single hash. Recorded as
+  an open question ([§13-N](../ARCHITECTURE.md#13-open-questions)) rather than
+  closed.
+- **Payment (shielded ZEC) for first contact.** Not rejected — **deferred**, and
+  it is the same deferral as [§13-I](../ARCHITECTURE.md#13-open-questions):
+  [ADR 0006](./0006-zcash-coupling.md) already contemplates prepaid quota
+  credentials redeemed via blind-issued tokens. That design is unspecified, and
+  shipping payment before anonymous credentials would mean shipping an identifier.
+- **Reusing an ordinary queue with a well-known send key.** Rejected: a published
+  send key is a key everyone holds, i.e. exactly an unbound send side, but with
+  the added false suggestion that a signature means something.
+- **No caps, relying on PoW alone.** Rejected: PoW bounds the *rate* of writes,
+  not the *total*, so an attacker with patience fills any uncapped queue.

--- a/docs/e2ee/decisions/0012-anti-abuse-v1.md
+++ b/docs/e2ee/decisions/0012-anti-abuse-v1.md
@@ -1,0 +1,134 @@
+# ADR 0012 — Anti-abuse v1: layered limits, and refusing writes rather than dropping messages
+
+**Status:** Accepted (Phase 1 specification, 2026-08-23) ·
+**Refs:** [#545](https://github.com/free2z/zuu/issues/545),
+[ADR 0004](./0004-metadata-ambition.md), [ADR 0005](./0005-federation.md),
+[ADR 0006](./0006-zcash-coupling.md) ·
+**Specifies:** [`../WIRE.md` §13](../WIRE.md#13-anti-abuse-v1)
+
+> **Invented here.** The merged documents contain **no** quota or rate-limit
+> mechanism at all. [`../ARCHITECTURE.md` §13-I](../ARCHITECTURE.md#13-open-questions)
+> defers the anonymous-credential design explicitly and specifies nothing in its
+> place, and §6.3 mentions only that "quota and TTL are relay policy."
+
+## Context
+
+A relay is an anonymous, unauthenticated service that allocates durable storage on
+request. It has no accounts, no identities and no contact lists, by design
+([ADR 0004](./0004-metadata-ambition.md)) — which means it also has none of the
+levers a normal service uses against abuse. It must nonetheless survive on a
+volunteer's ~$5/month VPS ([ADR 0005](./0005-federation.md)), because the economics
+of self-hosting are what make the federation real rather than nominal.
+
+The genuinely dangerous failure is not "the relay falls over." It is **the relay
+staying up by quietly discarding messages it already accepted**, which would break
+the other half of delete-on-ack and would do so through the one blind spot the
+architecture has ([`../THREAT-MODEL.md` §4.4](../THREAT-MODEL.md#44-tail-truncation-is-not-detectable-by-hash-links)).
+
+## Decision
+
+**Four layers**, each cheaper than the one below it and applied first:
+
+1. **Connection limits** — concurrent connections and new-connection rate per
+   source, handshake timeout, maximum frame size, bounded in-flight window,
+   per-connection command rate. All applied before any signature verification.
+2. **Per-queue quotas** — maximum messages, maximum bytes, append rate. Send-side
+   refusals collapse to a single code so the sender learns nothing about queue
+   state.
+3. **Queue-creation control** — `open`, `pow`, or `token`, **defaulting to
+   `pow`**: a proof-of-work stamp over a relay-issued, single-use, expiring
+   challenge, verifiable in one hash.
+4. **Global backpressure** — on crossing published high-water marks the relay
+   refuses, in order: queue creation, then appends, then new connections.
+   `READ`, `ACK` and `DELETE_QUEUE` are **never** refused for backpressure.
+
+**And the rule that outranks all of them: a relay MUST NOT delete an
+unacknowledged message to make room. When it runs out of space it refuses new
+writes.**
+
+## Consequences
+
+- **Refusal is the correct failure mode, and the reasoning is the delete-on-ack
+  contract itself.** The contract is: the relay holds ciphertext until the reader
+  durably writes it and acknowledges, then deletes. A sender that received
+  `accepted` has been told the relay took custody. If the relay may later discard
+  that message for space, `accepted` means nothing and the recipient's ACK is no
+  longer the only thing that removes data. The system would then lose messages
+  through a mechanism the hash-linked DAG detects only when a *later* message
+  arrives to dangle a parent — i.e. through the tail-truncation blind spot,
+  reached by ordinary operation rather than by attack. Refusing a write is loud,
+  immediate, and lands on the party that can do something about it; silently
+  dropping an accepted message is quiet, delayed, and lands on someone who cannot.
+- **A persistently refusing relay is a signal, not a bug.** It needs a bigger disk
+  or fewer users, and that is exactly what an operator should be told.
+- **`READ`, `ACK` and `DELETE_QUEUE` are exempt from backpressure** because they
+  are the operations that make the relay smaller. Refusing them under load is a
+  deadlock.
+- **PoW is the default gate on creation** because creation is the only command
+  that allocates durable state out of nothing. Verification is one hash, which is
+  the property that matters: the relay's own cost under flood must stay near zero.
+  The consequences for phones are argued in
+  [ADR 0011](./0011-first-contact-contact-queues.md) and are not restated as
+  though they were solved.
+- **`token` mode is supported and is honestly labelled: a token is an
+  identifier.** It lets the operator link every queue created with it, which
+  reintroduces precisely the linkability that opaque per-pair addresses exist to
+  remove. It is offered because a closed or invitational deployment may
+  legitimately want it, it MUST be declared in the capability document, and
+  clients SHOULD prefer `pow` relays and SHOULD say in the UI what a token-gated
+  relay can correlate.
+- **Everything is published.** Limits, TTLs, creation mode, PoW parameters,
+  whether per-source limits are on, and the durability mode all live in the signed
+  capability document, so a client can choose a relay on policy rather than
+  discovering it by failing.
+
+### What is not closed — stated plainly
+
+- **Distributed queue-creation flooding with valid stamps.** Many sources, real
+  compute, well-formed queues, valid stamps. The relay has no basis on which to
+  distinguish that from users, because the basis would be identity. Backpressure
+  keeps it alive by degrading service for everyone. Not solved.
+  [§13-I](../ARCHITECTURE.md#13-open-questions)'s anonymous credentials — prove you
+  paid for capacity without revealing who you are, per
+  [ADR 0006](./0006-zcash-coupling.md)'s optional tier — are the intended answer
+  and remain deferred.
+- **An abusive but legitimately bound sender.** Once `BIND_SEND` has succeeded the
+  relay cannot tell wanted traffic from unwanted: the payload is opaque ciphertext
+  and that is the point. The remedy is entirely client-side and in-band — stop
+  acknowledging, delete the queue, do not advertise a replacement to that peer.
+  That is correct, and it is slower and clumsier than a block button on a server
+  that could see who was talking. We chose the metadata property; this is part of
+  its price.
+- **Per-source limits harm exactly the users who most need the system.** A Tor
+  exit, a CGNAT block, a university NAT and a shared VPN egress each present as one
+  source carrying many legitimate users, and per-source limits will throttle them.
+  **There is no good answer** without an identity the relay deliberately lacks:
+  allowlisting Tor exits removes the limit for the population most able to rotate
+  addresses, and anything more granular than an address requires knowing something
+  about the client. The whole of the mitigation is that operators publish whether
+  per-source limits are on, so a user behind shared egress can choose a relay that
+  does not use them.
+
+## Alternatives rejected
+
+- **Deleting the oldest un-acked messages to make room.** Rejected — the central
+  decision of this ADR, for the reasons above.
+- **Accounts, API keys, or registration.** Rejected: it is the identity that
+  [ADR 0004](./0004-metadata-ambition.md) exists to remove, and it would let the
+  relay build the social graph directly.
+- **CAPTCHA on queue creation.** Rejected: it requires a human at the moment of
+  creation (queues are created and rotated automatically, often while the user is
+  not looking), it usually means a third-party service in the path of an anonymity
+  system, and it is defeated by paid solving services more cheaply than PoW is
+  defeated by GPUs.
+- **Payment for queue creation, in the clear.** Rejected: a payment is an
+  identifier unless it is blind-issued, and the blind-issuance design is exactly
+  what §13-I defers.
+- **Reputation or behavioural scoring.** Rejected: it requires longitudinal state
+  about clients, which is the state the relay is designed not to keep.
+- **No limits at all, relying on federation to route around abuse.** Rejected: the
+  first relay to fall over is the free relay run by a volunteer, and losing those
+  is losing the federation.
+- **Per-queue limits only, without global backpressure.** Rejected: per-queue
+  limits bound the cost of a queue, not the number of queues, so they do not bound
+  the relay.

--- a/docs/e2ee/decisions/0014-directory-key-rotation.md
+++ b/docs/e2ee/decisions/0014-directory-key-rotation.md
@@ -1,0 +1,169 @@
+# ADR 0014 — Directory key rotation: dual-signed changes, and a loud, delayed platform reset
+
+**Status:** Accepted (Phase 1 specification, 2026-08-23) ·
+**Refs:** [#545](https://github.com/free2z/zuu/issues/545),
+[#133](https://github.com/free2z/zuu/issues/133),
+[ADR 0006](./0006-zcash-coupling.md) ·
+**Relates to:** [`../ARCHITECTURE.md` §13-K](../ARCHITECTURE.md#13-open-questions)
+(handle rename and transfer — still open) ·
+**Depends on:** the key-transparency log construction, **ADR 0013**, which is
+**deliberately not in this change** — it is blocked on
+[#544](https://github.com/free2z/zuu/issues/544).
+
+> **Invented here.** [`../ARCHITECTURE.md` §9.2](../ARCHITECTURE.md#92-the-directory)
+> specifies an append-only log of `(handle → IdentitySigningKey.public, epoch,
+> DeviceCredential set)` with inclusion proofs, consistency proofs and per-handle
+> self-audit. It does **not** specify what authorizes a new entry, and in
+> particular says nothing about what happens when the key that would authorize one
+> is gone.
+
+## Context
+
+The directory is the foundation: [#133](https://github.com/free2z/zuu/issues/133)
+is that the server today decides who you are connected to, and §9 exists so that a
+substituted identity key is at least *detectable by the victim*. Self-audit gives
+detection. It does not give a rule for **authorization** — which entries the log
+should accept in the first place.
+
+Three cases have to be distinguished and they have different answers.
+
+1. **A same-key update.** Adding or revoking a device credential, updating contact
+   endpoints ([ADR 0011](./0011-first-contact-contact-queues.md)). The identity key
+   is unchanged and available.
+2. **A key change.** The user is rotating to a new identity key and still holds
+   the old one.
+3. **A lost key.** The user cannot sign with the outgoing key at all.
+
+Case 3 is where every system of this kind either introduces a weakness or tells a
+population of users that they have permanently lost their handle. Under
+[ADR 0006](./0006-zcash-coupling.md) the identity key is **seed-derived**, so
+"lost key" means "lost mnemonic" — which also means the user has lost their
+wallet. That narrows the population needing recovery to people who have already
+suffered a worse loss, but it does not empty it, and free2z is a public creator
+platform where a handle is an audience.
+
+## Decision
+
+**Case 1 — a same-key entry is self-signed.** One signature, by the current
+`DirectoryAuthKey`, over the canonical encoding of the new entry, the handle, the
+epoch, and the hash of the previous entry. The log accepts it iff the signature
+verifies under the key already published for that handle.
+
+**Case 2 — a key change requires two signatures, and neither alone is
+sufficient.**
+
+- A **`RotationProof` signed by the outgoing key**, binding the old key, the new
+  key, the handle, the epoch, and the hash of the previous entry.
+- **A signature by the new key** over the new entry, which includes the
+  `RotationProof`.
+
+The log MUST reject a key change carrying only one. The outgoing signature stops
+the log operator from swapping a key; the incoming signature stops a stolen or
+mis-transcribed new key from being installed without proof of possession.
+
+**Case 3 — a lost key requires a platform-authority reset**, which:
+
+- is an entry signed by a dedicated **reset authority key**, held offline, whose
+  public key is published and pinned in clients;
+- **raises a non-dismissible alarm on every peer** that holds the old key, naming
+  the handle, both key fingerprints, and — explicitly — the fact that the change
+  was **platform-assisted rather than user-authorized**;
+- applies a **cooldown** (proposed: 7 days) during which conforming clients
+  **keep using the old key** and refuse to encrypt to the new one, so that a user
+  who still holds the old key can cancel the reset with a `RotationProof`;
+- is published in the log like every other entry, so it is permanently visible
+  and countable;
+- is counted per epoch, with the count published alongside the tree head, so an
+  abnormal rate of resets is visible to anyone without a single per-handle lookup.
+
+**An entry MAY additionally carry a `no_reset` flag.** A user who sets it is
+declaring that the reset path does not apply to their handle: losing the key means
+losing the handle, permanently, with no recovery. This is the strongest available
+posture and it costs nothing to offer.
+
+## Consequences
+
+- **Neither the log operator nor the platform can change a live key silently.**
+  Case 2 needs a signature the platform does not have; case 3 is loud by
+  construction.
+- **This is a real weakening, and announcing it loudly is the entire
+  mitigation.** A platform-assisted recovery is **cryptographically
+  indistinguishable from a platform-assisted attack.** There is no signature that
+  separates "Alice lost her seed and asked us" from "someone compelled us to hand
+  Alice's handle to a different key" — in both cases the only authority is the
+  platform's. What separates them is that both are announced, both land in an
+  append-only log that anyone can audit and count, and both are delayed. This is
+  the standard delay-and-notify recovery pattern, with the standard property: it
+  converts an undetectable substitution into a detectable one, and it does not
+  prevent anything.
+- **A user who ignores the alarm gets MITM'd, and so does one whose client
+  dismisses it.** "Non-dismissible" is therefore a hard product requirement, not a
+  UX preference: a peer must be unable to continue the conversation without
+  acknowledging that the key changed by platform action. Copy that reads "Alice's
+  security code changed" is a defect; it must say that the change was made by the
+  platform without Alice's old key.
+- **The cooldown is the part that gives the victim something to do.** Notification
+  without a window tells a user they have been attacked after the attacker already
+  has their traffic. During the cooldown, conforming clients keep encrypting to
+  the old key, so an attacker who obtained a reset gets nothing readable until the
+  window elapses, and the legitimate holder of the old key can cancel.
+- **The reset authority key is a high-value target and must be treated as one.**
+  Offline, split if practicable, its use rare and publicly counted. A compromise
+  of that key is a compromise of every handle that has not set `no_reset`. This is
+  the concentrated risk the decision creates, and it should be read as such.
+- **`no_reset` is not free for the user.** It is the correct choice for a
+  high-risk user and the wrong default for a creator whose handle is their
+  livelihood. It must be presented with a plain statement of what it forecloses,
+  and it MUST NOT be silently defaulted either way.
+- **This does not answer handle rename or transfer.** A rename is not a key
+  change; a transfer is a change of *owner* rather than of key, and it creates a
+  MITM window of a different shape. That remains
+  [§13-K](../ARCHITECTURE.md#13-open-questions), open.
+- **It is written to be implementable on whatever log #544 selects.** The decision
+  constrains what authorizes an entry, not how entries are stored, proved or
+  cosigned. Those are ADR 0013's, and their absence here is deliberate rather than
+  an oversight — see [`../WIRE.md` §1.2](../WIRE.md#12-what-it-deliberately-does-not-fix).
+- **The threat-model claim that must be updated when this ships.**
+  [`../THREAT-MODEL.md` §3.1](../THREAT-MODEL.md#31-malicious-or-compromised-free2z-server)
+  currently states that the server "cannot substitute an identity key
+  undetectably." That remains true with this decision — the reset is maximally
+  detectable — but the sentence is doing more work than it looks like it is, and
+  the reset path is the reason. It should be annotated when the KT documents land,
+  not left to be discovered.
+
+## Alternatives rejected
+
+- **No recovery at all: lose the seed, lose the handle.** This is the strongest
+  security answer and it was rejected as a *default*, not on its merits. free2z is
+  a creator platform where a handle is an audience and a livelihood, and a
+  messenger that permanently destroys both on a lost backup will not be adopted by
+  the people it is for. It survives as the opt-in `no_reset` flag, because users
+  who want it should have it.
+- **Instant reset with notification but no cooldown.** Rejected: notification
+  without a window gives the victim nothing to do in time. The attacker has the
+  traffic before the alarm is read.
+- **Reset without a peer alarm.** Rejected outright. That is an undetectable
+  server-mediated identity substitution — precisely the attack
+  [#133](https://github.com/free2z/zuu/issues/133) and
+  [`../ARCHITECTURE.md` §9](../ARCHITECTURE.md#9-identity-directory-key-transparency-and-federation)
+  exist to prevent — with a support ticket as its authorization.
+- **A dismissible alarm.** Rejected: an alarm a user can clear with one tap is an
+  alarm that will be cleared with one tap, most reliably by the users under the
+  most pressure.
+- **Social recovery (M-of-N contacts attest to the new key).** Not rejected —
+  **deferred.** It genuinely removes the platform from the trust path, and it
+  needs a contact-attestation format, a threshold policy, a rule for what happens
+  when contacts are unreachable or collude, and UI for all of it. That is more
+  machinery than v1 warrants, and it moves trust rather than removing it. Worth
+  revisiting once the log construction exists.
+- **A single signature by the new key alone for a key change.** Rejected: it lets
+  anyone who can get an entry into the log take over a handle, which is the log
+  operator's capability by definition.
+- **A single signature by the outgoing key alone.** Rejected: it installs a new
+  key with no proof that anyone possesses it, so a typo, a truncated transfer or a
+  malicious substitution of the new key material by the log operator all produce a
+  handle nobody controls.
+- **On-chain anchoring of key changes.** Rejected here for the same reason
+  [ADR 0006](./0006-zcash-coupling.md) rejected it for checkpoints: it buys
+  nothing that witness cosigning does not, and adds a hard external dependency to
+  the recovery path — the worst possible place for one.


### PR DESCRIPTION
Closes #545. **Docs only — no code, no crates, no manifests, no workflow changes.** Everything is under `docs/e2ee/`.

Phase 0 deliberately marked every constant, label and wire encoding a *proposed placeholder*. Nothing can be implemented against placeholders, so this closes those gaps on the record, before code exists, in the voice the merged docs established: written for a third-party auditor, properties that do not hold stated as not holding, open questions listed rather than answered by invention.

## What landed

**`docs/e2ee/WIRE.md`** — the relay protocol, specified concretely enough that an independent implementer could build an interoperable relay from it alone.

- **Transport:** WebSocket over TLS 1.3 only. Justified on ADR 0001 (the WASM client can only do WebSocket, and there must be one implementation) and on the plainer point that a second transport is a second parser and a second fuzz target on an unauthenticated front door. The relay refuses to bind a non-loopback address without TLS unless explicitly overridden, and the override is published in the signed capability document. Server-side Ping every ~25 s, with the load-balancer idle-timeout trap called out as the most common way a working relay behaves badly in production.
- **Serialization: `tls_codec`.** Canonical by construction (no encoding options exist), already in the client's graph via OpenMLS, and an auditor reading an MLS system reads TLS presentation syntax without translation. CBOR rejected — its canonical form is a *profile*, i.e. a rule a decoder will let you skip. **Mandatory re-encode-equality rule:** decode, re-encode, byte-compare, sign over the re-encoded bytes; a mismatch is fatal. Stated honestly as compensating for implementation slack in decoders rather than for format ambiguity.
- **Framing:** one binary frame = one message; text frames fatally rejected; bounded in-flight window with pipelining and out-of-order responses correlated by request id. Errors carry a code and no free-text field.
- **Command set** with full request/response shapes: unsigned `HELLO` / `GET_CAPABILITIES` / `GET_CHALLENGE` / `PING`; recv-key-signed `CREATE_QUEUE` / `SUBSCRIBE` / `UNSUBSCRIBE` / `READ` / `ACK` / `DELETE_QUEUE`; send-key-signed `BIND_SEND` / `APPEND`. **`APPEND` returns no index and no depth** — and the same rule is extended to *errors*, because otherwise a bound sender learns queue state by filling it. All send-side refusals collapse to one code, and the residual bit a sender can still obtain is stated rather than glossed.
- **The signing transcript** covers a domain-separation label, the version, the request id, a timestamp, a client nonce — plus:
  - a **relay identity binding**, closing a live attack: with ADR 0005 publishing addresses on *k* relays, relay A can otherwise replay a signed `ACK` to relay B and **B deletes ciphertext the recipient never received**. The relay must prove possession of the identity key in `HELLO`, and the expected `relay_id` travels with the address in the in-band advert.
  - a **TLS exporter channel binding** (RFC 8446 §7.5), with the honest caveat that a relay behind a TLS-terminating proxy cannot compute it; in that mode it is zeroed, the capability document says so, and a client may refuse.
- **Anti-replay:** bounded timestamp window plus a fail-closed `(key, nonce)` seen-set. Why it need not survive restart is explained — a restart changes the TLS session, so the channel binding already invalidated the corpus — **and the exception is stated**: in proxied mode that argument does not hold, so such a relay must persist the seen-set or declare `antireplay_persistence: "volatile"`.
- **Queue lifecycle:** the recipient creates; **the relay generates both addresses from its own CSPRNG** (client-chosen addresses allow squatting and collisions); the send side starts unbound; the peer learns `send_addr` from an authenticated advert inside MLS; `BIND_SEND` is **once-only and irreversible**. The consequence is said plainly: an operator that binds first causes the legitimate sender to get `ERR_ALREADY_BOUND`, which the client MUST treat as a loud non-dismissible failure — **this does not prevent the theft of the write capability, it makes it noisy.**
- **Rotation** needs no new command. It also **narrows `ARCHITECTURE.md` §5.4**, which claimed the exporter "derives the next queue addresses without a round trip": it derives the next queue *keys*.
- **ACK:** cumulative, monotone, idempotent, never selective; acking beyond the head is an error, because pre-acking would let a reader silently black-hole its own queue while senders still see `accepted`. Tied to §6.3's four states, with the durable-write MUST restated where an implementer will meet it.
- **TTLs:** per-queue message TTL clamped to the 30-day ceiling, **plus a queue idle TTL** the merged docs had nothing for — without it abandoned queues grow the queue table without bound. Its failure mode (a user offline past the TTL loses their queues) is stated.
- **Padding:** relay rejects non-conforming sizes, and the accepted set lives in the **capability document**, not the protocol, so §13-F's traffic study becomes a config change rather than a flag day. The relay's list is called what it is: a filter, not the source of truth.
- **Stable numeric error codes.** "No such queue" and "exists but your key does not authorize it" return the **same** code, or the relay is an existence oracle. And the timing side channel that remains — the two paths do different amounts of database work — is stated, with a dummy-verification mitigation and **no claim of constant time**.
- **The capability document:** limits, TTLs, padding sizes, channel-binding mode, durability mode, anti-abuse mode, operator contact and jurisdiction, source commit and build digest. Served over the protocol *and* over plain HTTPS at a well-known path so a human can read a relay's policy before connecting — with the honest note that nothing but the operator forces the two to agree.

**First contact — a genuine hole in the merged design.** §6.2 only describes queues advertised *inside* an existing group, so there was **no path for the `Welcome` that creates the group**. Closed with a distinctly-flavoured **contact queue**: send side never bound, published in the owner's directory entry, unsigned appends, hard-capped (pending cap, byte cap, per-source bucket, required PoW stamp over a relay-issued single-use challenge). Limits stated: PoW taxes phones far more than rented GPUs; disk exhaustion via mass queue creation is **made expensive, not closed** (§13-I is the real answer, still deferred); and a contact queue can be filled to deny first contact.

**Anti-abuse v1:** connection limits, per-queue quotas, queue-creation control (open / PoW / token, defaulting to PoW, with `token` labelled as the identifier it is), and global backpressure. **Never delete un-acked messages to make room** — refusing writes is correct, because silently dropping accepted messages breaks the other half of delete-on-ack through the tail-truncation blind spot. What is not closed is named: distributed creation flooding with valid stamps; an abusive but legitimately bound sender; per-source limits harming Tor and CGNAT users, with no good answer absent identity the relay deliberately lacks.

**ADRs 0008–0012 and 0014**, in the existing format. **0013 is deliberately absent** — the KT log construction is blocked on #544 — and its absence is noted in `WIRE.md` §1.2, in `ARCHITECTURE.md` §9.2, in the README ADR table, and in ADR 0014, so the gap is visibly intentional.

**§13 housekeeping.** Only **§13-E** was genuinely closed and moved to §13.1. §13-B, F, G, I, K, L, M were **not** closed — several are cited by this spec as deliberately open. Two new letters opened: **§13-N** (PoW function and calibration) and **§13-O** (messaging-handle eligibility). Letters retired, never reused.

## The two blocking pre-checks

**1. Handle charset — checked, and real usernames are broader.** Proposed `[a-z0-9_]{1,30}`, ASCII, so homograph and mixed-script impersonation does not exist. Against the tree:

- `py/dj/free2z/openapi/f2z.yaml` publishes `username` as `pattern: ^[\w.@+-]+$`, `maxLength: 150` on `Registration`, `CreatorDetail`, `CreatorList` and `CommentAuthor` — Django's `AbstractUser` default. Uppercase, `.`, `@`, `+`, `-` and 150 characters are all allowed today.
- **Whether non-ASCII is allowed cannot be determined from this repository.** `AUTH_USER_MODEL = 'g12f.Creator'` (`py/dj/free2z/settings.py:29`) but the model module is not vendored here, and the OpenAPI pattern is emitted identically for Django's Unicode and ASCII username validators. Recorded as a MUST-confirm, because under the Unicode validator the platform's existing handle space already contains the homograph surface.
- Uniqueness is enforced case-insensitively in the serializers (`username__iexact`), and reads use `__iexact`. The front ends narrow nothing — `@{creator.username}` is rendered verbatim and URL-encoded into paths; the one narrower guard (`/^[a-zA-Z0-9_]{1,64}$/` in the billing `+page.server.ts`) validates a route parameter and is already narrower than registration.

**Decision and cost accepted:** eligibility is `lowercase(username)` matching `[a-z0-9_]{1,30}`. Case folding is included because platform uniqueness is already case-insensitive, so it cannot collide — **with the caveat that this must be confirmed with a query**, since the model is not here and a database-level constraint cannot be assumed. Accounts with `.`, `@`, `+`, `-`, non-ASCII, or >30 characters are **not eligible for messaging in v1**. **How many is unknown** — no user data in this repo — and §13-O says it must be measured before the rule ships. Aggressive normalization was rejected (it creates collisions and relocates the homograph surface into our own code); a separate opt-in messaging handle is deferred to directory design.

**2. SimpleX licensing (§13-E) — verified, no source read.** Performed 2026-08-23 from **published repository metadata only** (GitHub's REST repository endpoint and a top-level contents listing). `simplex-chat/simplexmq` — the reference SMP server — reports **AGPL-3.0**; `simplex-chat/simplex-chat` likewise. No source file was fetched, opened or read. The clean-room posture is recorded as a binding rule in `WIRE.md` §15: **nobody on this project reads `simplexmq` source**; the design derives solely from the public protocol description. The nuance is recorded rather than glossed — the protocol document lives in that same AGPL repository, so the posture rests on the distinction between the expression of a specification and the protocol it describes, stated as our position and explicitly not as legal advice.

## Notes for review

- Every invented decision says it is invented, gives the reasoning, and lists the rejected alternatives. Nothing is presented as though the merged docs already said it.
- `scripts/check-public-repo-boundary.sh` passes locally (exit 0).
- `ARCHITECTURE.md` edits go slightly beyond §13: the §5.4 exporter claim is corrected, §6.2's circularity is flagged, and §6's SimpleX action item is closed. Leaving a now-wrong statement uncorrected seemed worse than a small, clearly-marked edit — happy to split those out if the reviewer prefers.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
