### PR TITLE
ci(rust): let the Rust hygiene gates police a second tree

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -239,6 +239,12 @@ jobs:
           toolchain: ${{ steps.rust_toolchain.outputs.version }}
           components: rustfmt
 
+      # A check nobody has watched fail is not a check: this builds a scratch
+      # tree under --root and proves the verdict tracks it, unformatted case
+      # included. Seconds, and it is what keeps --root honest for a second tree.
+      - name: Prove the formatting gate still fails
+        run: scripts/check-rust-fmt.sh --self-test
+
       - name: Check formatting of every Rust crate under wallet/
         run: scripts/check-rust-fmt.sh
 
@@ -278,6 +284,12 @@ jobs:
       # the version and digests are pinned in the script. Deliberately not a
       # third-party installer action — the tool that polices our supply chain
       # should not arrive through an unpinned one.
+      # Judges one scratch crate under two policies that disagree about its
+      # licence. Passing both ways would mean --config is decorative, which is
+      # the whole mechanism a second tree's own policy rests on.
+      - name: Prove the policy still decides the verdict
+        run: scripts/check-rust-deny.sh --self-test
+
       - name: Check advisories, licences and sources
         run: scripts/check-rust-deny.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,13 @@ integrate, and move it forward alongside everything else.
   and a check that ran on whatever was installed would report version skew as a
   code defect. Each has a mirrored job in `zuuallet.yml`, because the required
   `gate` lives in `zuuli.yml` and its change detector does not select
-  `wallet/zuuallet/**`.
+  `wallet/zuuallet/**`. Which tree they judge is `--root`'s to say (default
+  `wallet`, so the wallet gate is unchanged), `--config` chooses the policy
+  `check-rust-deny.sh` enforces, and clippy's `z/zcash/librustzcash`
+  requirement is read out of the manifests rather than assumed — so a second
+  top-level Rust namespace is policed by the same three gates without
+  inheriting the wallet's path-dependency baggage. All three carry a
+  `--self-test` that proves they still fail on the thing they exist to catch.
 - **Target-native clippy is part of the required gate.** Linux cannot compile
   macOS- and Windows-only Keychain, Credential Manager, filesystem, and OAuth
   branches. The `rust_native_clippy` matrix in `.github/workflows/zuuli.yml`
@@ -209,6 +215,13 @@ read a TOML file at the moment they need the value:
 | `dtolnay/rust-toolchain@<sha> # <version>` in packaging/release and target-native Zuuallet jobs | The action's **version branches hardcode the compiler in `action.yml` and do not declare a `toolchain` input at all** — a commit-pinned ref *is* the version pin, and the trailing comment is its only readable record |
 | `dtolnay/rust-toolchain@<sha> # stable` in source-derived gate/Zuuallet jobs | `uses:` cannot contain an expression, so the generic action implementation is commit-pinned while its `toolchain:` input still reads the version from `wallet/rust-toolchain.toml`; the upstream canary deliberately omits that input so only its compiler selection follows `stable` |
 | MSRV/`cargo +<version>` lines in the wallet READMEs, the plugin `CLAUDE.md`, and `wallet/zuuli/docs/releasing.md` | Prose |
+
+A second top-level Rust tree does not get a decision of its own either. It needs
+its own `rust-toolchain.toml`, because Cargo picks the toolchain from the
+directory it runs in, and its crates carry their own `rust-version` — both are
+restatements. Register them with `scripts/check-rust-toolchain.sh
+--toolchain-file <path>` and `--manifest <path>` and they are held to
+`wallet/rust-toolchain.toml` exactly like every row above.
 
 The `wallet/zuuli` gate reads the channel out of the file (`--print-channel`) and
 feeds it to the toolchain action, so the required CI jobs hold **no literal at

--- a/scripts/check-rust-clippy.sh
+++ b/scripts/check-rust-clippy.sh
@@ -1,25 +1,32 @@
 #!/usr/bin/env bash
-# Hold every Rust crate under wallet/ to `cargo clippy -D warnings`.
+# Hold every Rust crate under a Rust tree to `cargo clippy -D warnings`.
 #
 # Clippy's lint set is not stable across compiler versions: lints are added,
 # promoted between groups, and taught new patterns with every release, so the
 # same source can be clean on one toolchain and warn on the next. A check that
 # ran on whatever compiler happened to be installed would report that version
 # skew as if it were a code defect. So, exactly like scripts/check-rust-fmt.sh,
-# this renders a verdict only on the toolchain named by
-# wallet/rust-toolchain.toml — it runs cargo from the directory holding that
-# file so rustup selects the pin, and refuses to continue if a different
-# compiler answers. Bumping the pin is therefore the one moment new lints can
-# appear, and they appear in the bump's own pull request.
+# this renders a verdict only on the toolchain named by the tree's
+# rust-toolchain.toml — it runs cargo from the directory holding that file so
+# rustup selects the pin, and refuses to continue if a different compiler
+# answers. Bumping the pin is therefore the one moment new lints can appear, and
+# they appear in the bump's own pull request.
 #
-# Crates are discovered rather than listed. A new crate under wallet/ is gated
+# The tree defaults to wallet/. A second top-level Rust namespace is gated by
+# pointing --root at it; its rust-toolchain.toml is a restatement of
+# wallet/rust-toolchain.toml, not a second decision, and
+# scripts/check-rust-toolchain.sh is what holds it to that.
+#
+# Crates are discovered rather than listed. A new crate under the tree is gated
 # from its first commit, which is the cheapest moment and never gets cheaper.
 #
 # Unlike scripts/check-rust-fmt.sh this genuinely compiles: clippy is a rustc
-# driver and needs the whole dependency graph, so z/zcash/librustzcash must be
-# checked out — the wallet crates reach the Zcash crates by path into it — and
-# the Tauri system libraries must be installed. Budget it alongside the real
-# builds, not alongside the formatting check.
+# driver and needs the whole dependency graph. The wallet crates reach the Zcash
+# crates by path into z/zcash/librustzcash, so for that tree the submodule must
+# be checked out and the Tauri system libraries installed — budget it alongside
+# the real builds, not alongside the formatting check. That requirement is read
+# out of the manifests rather than assumed, so a tree whose crates never point
+# into the submodule is not held to a checkout it does not use.
 #
 # --all-targets so tests, benches and examples are linted too. Test code that
 # nobody lints is where the next warning backlog comes from.
@@ -27,6 +34,7 @@
 # Usage:
 #   scripts/check-rust-clippy.sh          fail on any clippy warning
 #   scripts/check-rust-clippy.sh --self-test <target-os>
+#   scripts/check-rust-clippy.sh --root DIR   lint a different Rust tree (default: wallet)
 #   scripts/check-rust-clippy.sh --fix    apply clippy's machine-applicable fixes
 #
 # After --fix, read every edit before committing it and run
@@ -37,55 +45,97 @@
 set -euo pipefail
 
 REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+# Absolute, because the self-test re-invokes this script after cd'ing into the
+# tree under test.
+SELF=$REPO_ROOT/scripts/$(basename -- "${BASH_SOURCE[0]}")
 
-# The directory holding rust-toolchain.toml. Cargo is invoked from here so
-# rustup's toolchain selection — which keys off the working directory, not the
-# --manifest-path — lands on the pinned channel.
-RUST_ROOT=$REPO_ROOT/wallet
-TOOLCHAIN_FILE=$RUST_ROOT/rust-toolchain.toml
+# The Rust tree to lint, relative to the repository root.
+DEFAULT_ROOT=wallet
 SUBMODULE=$REPO_ROOT/z/zcash/librustzcash
 
 mode=check
+root=$DEFAULT_ROOT
 expected_target_os=
-case "${1-}" in
-  "") ;;
-  --self-test)
-    mode=self-test
-    expected_target_os=${2-}
-    case "$expected_target_os" in
-      linux | macos | windows) ;;
-      *)
-        printf '%s\n' 'Usage: scripts/check-rust-clippy.sh --self-test <linux|macos|windows>' >&2
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --self-test)
+      mode=self-test
+      expected_target_os=${2-}
+      case "$expected_target_os" in
+        linux | macos | windows) ;;
+        *)
+          printf '%s\n' 'Usage: scripts/check-rust-clippy.sh --self-test <linux|macos|windows>' >&2
+          exit 2
+          ;;
+      esac
+      shift
+      ;;
+    --fix) mode=fix ;;
+    --root)
+      root=${2-}
+      if [[ -z $root ]]; then
+        printf -- '--root needs a directory.\n' >&2
         exit 2
-        ;;
-    esac
-    ;;
-  --fix) mode=fix ;;
-  -h | --help)
-    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
-    exit 0
-    ;;
-  *)
-    printf 'unknown argument: %s\n' "$1" >&2
-    exit 2
-    ;;
+      fi
+      shift
+      ;;
+    -h | --help)
+      awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# The directory holding rust-toolchain.toml. Cargo is invoked from here so
+# rustup's toolchain selection — which keys off the working directory, not the
+# --manifest-path — lands on the pinned channel. An absolute --root is accepted
+# so the self-test can point this at a scratch tree.
+case "$root" in
+  /*) RUST_ROOT=$root ;;
+  *) RUST_ROOT=$REPO_ROOT/$root ;;
 esac
+LABEL=${root%/}
+TOOLCHAIN_FILE=$RUST_ROOT/rust-toolchain.toml
+
+# Tracked, buildable crates only: target/ holds vendored and generated
+# manifests, node_modules/ holds npm packages that ship Rust sources.
+discover_manifests() {
+  find . -name Cargo.toml \
+    -not -path './target/*' \
+    -not -path '*/target/*' \
+    -not -path '*/node_modules/*' |
+    LC_ALL=C sort
+}
+
+# Whether these crates reach outside their own tree into the librustzcash
+# submodule by path dependency. Derived from the manifests, not declared per
+# tree, so the requirement follows the code instead of a list that can rot: the
+# wallet crates say `path = "../../../z/zcash/librustzcash/..."` and are held to
+# a checked-out submodule, a tree that says so nowhere is not.
+manifests_need_submodule() {
+  local manifest
+  for manifest in "$@"; do
+    if grep -qE 'path[[:space:]]*=[[:space:]]*"[^"]*z/zcash/librustzcash/' "$manifest"; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 if [[ ! -f $TOOLCHAIN_FILE ]]; then
-  printf 'wallet/rust-toolchain.toml is missing; it decides which clippy this check trusts.\n' >&2
+  printf '%s/rust-toolchain.toml is missing; it decides which clippy this check trusts.\n' "$LABEL" >&2
   exit 1
 fi
 
 channel=$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' "$TOOLCHAIN_FILE")
 if [[ ! $channel =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  printf 'channel in wallet/rust-toolchain.toml must be a three-component version, got "%s".\n' \
-    "$channel" >&2
-  exit 1
-fi
-
-if [[ ! -f $SUBMODULE/Cargo.toml ]]; then
-  printf 'z/zcash/librustzcash is not checked out; clippy resolves and compiles the whole graph.\n' >&2
-  printf 'Run: git submodule update --init z/zcash/librustzcash\n' >&2
+  printf 'channel in %s/rust-toolchain.toml must be a three-component version, got "%s".\n' \
+    "$LABEL" "$channel" >&2
   exit 1
 fi
 
@@ -93,8 +143,8 @@ cd "$RUST_ROOT"
 
 installed=$(rustc --version)
 if [[ $installed != "rustc $channel "* ]]; then
-  printf 'refusing to judge lints: wallet/rust-toolchain.toml pins %s but `rustc --version` says "%s".\n' \
-    "$channel" "$installed" >&2
+  printf 'refusing to judge lints: %s/rust-toolchain.toml pins %s but `rustc --version` says "%s".\n' \
+    "$LABEL" "$channel" "$installed" >&2
   printf "clippy's lint set differs between compiler versions, so this run could only produce a misleading verdict.\n" >&2
   exit 1
 fi
@@ -140,24 +190,76 @@ EOF
   fi
   printf 'Clippy -D warnings rejected the target-native negative control for %s on %s.\n' \
     "$expected_target_os" "$(rustc -vV | awk -F': ' '/^host:/ { print $2 }')"
+
+  # The submodule requirement is per-tree and derived, so prove the derivation
+  # both ways: this tree — wallet, unless --root said otherwise — must still be
+  # held to a checked-out librustzcash, and a tree that never points into it
+  # must not be.
+  self_test_manifests=()
+  while IFS= read -r manifest; do
+    self_test_manifests+=("${manifest#./}")
+  done < <(discover_manifests)
+  if [[ ${#self_test_manifests[@]} -eq 0 ]]; then
+    printf 'self-test FAILED: no Cargo manifests found under %s/ to derive the submodule requirement from.\n' \
+      "$LABEL" >&2
+    exit 1
+  fi
+  if ! manifests_need_submodule "${self_test_manifests[@]}"; then
+    printf 'self-test FAILED: %s/ no longer reads as needing z/zcash/librustzcash; the requirement has gone silent.\n' \
+      "$LABEL" >&2
+    exit 1
+  fi
+  printf 'self-test: %s/ still requires the z/zcash/librustzcash checkout.\n' "$LABEL"
+
+  if manifests_need_submodule "$fixture/Cargo.toml"; then
+    printf 'self-test FAILED: a tree with no path dependency into z/zcash/librustzcash was held to it anyway.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: a tree that never points into z/zcash/librustzcash is not held to it.\n'
+
+  # And prove --root reaches a second tree at all, with the negative control
+  # first: an unlintable crate under --root must fail.
+  mkdir -p "$fixture/tree/relay/src"
+  printf '[toolchain]\nchannel = "%s"\n' "$channel" > "$fixture/tree/rust-toolchain.toml"
+  cat > "$fixture/tree/relay/Cargo.toml" <<'EOF'
+[package]
+name = "zuuli-clippy-root-control"
+version = "0.0.0"
+edition = "2024"
+
+[workspace]
+EOF
+  cp "$fixture/src/lib.rs" "$fixture/tree/relay/src/lib.rs"
+  # The real run lints --locked, so the fixture needs the lockfile it judges.
+  cargo generate-lockfile --manifest-path "$fixture/tree/relay/Cargo.toml"
+  if CARGO_TARGET_DIR="$fixture/target" "$SELF" --root "$fixture/tree" >/dev/null 2>&1; then
+    printf 'self-test FAILED: --root accepted a crate with a known clippy warning.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: --root rejects a crate with a known clippy warning.\n'
+
+  printf 'pub fn negate(value: bool) -> bool {\n    !value\n}\n' > "$fixture/tree/relay/src/lib.rs"
+  if ! CARGO_TARGET_DIR="$fixture/target" "$SELF" --root "$fixture/tree" >/dev/null; then
+    printf 'self-test FAILED: --root rejected a clippy-clean second tree.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: --root accepts a clippy-clean second tree.\n'
   exit 0
 fi
 
-# Tracked, buildable crates only: target/ holds vendored and generated
-# manifests, node_modules/ holds npm packages that ship Rust sources.
 manifests=()
 while IFS= read -r manifest; do
   manifests+=("${manifest#./}")
-done < <(
-  find . -name Cargo.toml \
-    -not -path './target/*' \
-    -not -path '*/target/*' \
-    -not -path '*/node_modules/*' |
-    LC_ALL=C sort
-)
+done < <(discover_manifests)
 
 if [[ ${#manifests[@]} -eq 0 ]]; then
-  printf 'no Cargo manifests found under wallet/; this check has gone blind.\n' >&2
+  printf 'no Cargo manifests found under %s/; this check has gone blind.\n' "$LABEL" >&2
+  exit 1
+fi
+
+if manifests_need_submodule "${manifests[@]}" && [[ ! -f $SUBMODULE/Cargo.toml ]]; then
+  printf 'z/zcash/librustzcash is not checked out; clippy resolves and compiles the whole graph.\n' >&2
+  printf 'Run: git submodule update --init z/zcash/librustzcash\n' >&2
   exit 1
 fi
 
@@ -165,7 +267,7 @@ failed=()
 for manifest in "${manifests[@]}"; do
   crate=$(dirname "$manifest")
   if [[ $mode == fix ]]; then
-    printf '\n==> applying clippy fixes to wallet/%s\n' "$crate"
+    printf '\n==> applying clippy fixes to %s/%s\n' "$LABEL" "$crate"
     # --allow-dirty/--allow-staged: this is run deliberately, mid-change, by
     # someone who will read the diff. Refusing on a dirty tree only pushes them
     # to stash and lose that context.
@@ -174,13 +276,13 @@ for manifest in "${manifests[@]}"; do
     continue
   fi
 
-  printf '\n==> cargo clippy -- wallet/%s\n' "$crate"
+  printf '\n==> cargo clippy -- %s/%s\n' "$LABEL" "$crate"
   # --locked: lint the lockfile CI actually builds, so a resolution that only
   # happens locally cannot change the verdict.
   if cargo clippy --locked --all-targets --manifest-path "$manifest" -- -D warnings; then
     continue
   fi
-  failed+=("wallet/$crate")
+  failed+=("$LABEL/$crate")
 done
 
 if [[ $mode == fix ]]; then
@@ -197,5 +299,5 @@ if [[ ${#failed[@]} -gt 0 ]]; then
   exit 1
 fi
 
-printf '\nAll %d Rust crate(s) under wallet/ are clippy-clean (clippy from %s).\n' \
-  "${#manifests[@]}" "$channel"
+printf '\nAll %d Rust crate(s) under %s/ are clippy-clean (clippy from %s).\n' \
+  "${#manifests[@]}" "$LABEL" "$channel"

--- a/scripts/check-rust-deny.sh
+++ b/scripts/check-rust-deny.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
-# Run cargo-deny's supply-chain checks over every Rust crate under wallet/.
+# Run cargo-deny's supply-chain checks over every Rust crate under a Rust tree.
 #
 # The three wallet crates have independent lockfiles that resolve the Zcash and
 # Tauri graphs differently, so each is checked separately — against one shared
 # policy, wallet/deny.toml, so they cannot drift into disagreeing about what is
-# acceptable. Crates are discovered rather than listed, so a new crate under
-# wallet/ is gated from its first commit.
+# acceptable. Crates are discovered rather than listed, so a new crate under the
+# tree is gated from its first commit.
+#
+# The tree defaults to wallet/ and the policy to <tree>/deny.toml. A second
+# top-level Rust namespace is gated by pointing --root at it; --config gives it
+# its own policy, because "which advisories we accept" is a judgement about a
+# particular dependency graph and a server graph is not the wallet's.
 #
 # cargo-deny is fetched as a checksum-verified release binary rather than built
 # from source or installed by a third-party action. A tool whose job is to
@@ -14,19 +19,28 @@
 # they are in the repository where they can be reviewed and bumped deliberately.
 #
 # Unlike scripts/check-rust-fmt.sh this needs the dependency graph resolved, so
-# z/zcash/librustzcash must be checked out — the wallet crates reach the Zcash
-# crates through path dependencies into it.
+# z/zcash/librustzcash must be checked out for any tree whose crates reach the
+# Zcash crates through path dependencies into it.
 #
 # Usage:
 #   scripts/check-rust-deny.sh                  advisories, bans, licences, sources
 #   scripts/check-rust-deny.sh advisories       one check only (any cargo-deny check)
+#   scripts/check-rust-deny.sh --root DIR       judge a different Rust tree (default: wallet)
+#   scripts/check-rust-deny.sh --config PATH    policy to enforce (default: <root>/deny.toml)
 #   scripts/check-rust-deny.sh --print-version  print the pinned cargo-deny version
+#   scripts/check-rust-deny.sh --self-test      prove the policy still decides the verdict
 
 set -euo pipefail
 
 REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
-RUST_ROOT=$REPO_ROOT/wallet
-CONFIG=$RUST_ROOT/deny.toml
+# Absolute, because the self-test re-invokes this script after cd'ing into the
+# tree under test, and because a relative --config is resolved against the
+# directory the caller typed it in.
+SELF=$REPO_ROOT/scripts/$(basename -- "${BASH_SOURCE[0]}")
+INVOCATION_DIR=$PWD
+
+# The Rust tree to judge, relative to the repository root.
+DEFAULT_ROOT=wallet
 
 # Bumping: change the version, then replace all four digests with the contents
 # of the matching .sha256 files from the release. Never bump the version alone.
@@ -36,22 +50,72 @@ CARGO_DENY_SHA256_aarch64_unknown_linux_musl=995c82be0defc7a025cae49a2aa2644ce82
 CARGO_DENY_SHA256_x86_64_apple_darwin=248da7f581724e470071990c088ffc55c811981715f4cbdb258621fb79f8b7a6
 CARGO_DENY_SHA256_aarch64_apple_darwin=fe67d82a10d8597a3549364cb733a3f9cc1bfff9031b7ae46384a9f2a72090c3
 
-if [[ ${1-} == --print-version ]]; then
-  printf '%s\n' "$CARGO_DENY_VERSION"
-  exit 0
-fi
+mode=check
+root=$DEFAULT_ROOT
+config=
+check=
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --print-version)
+      printf '%s\n' "$CARGO_DENY_VERSION"
+      exit 0
+      ;;
+    --self-test) mode=self-test ;;
+    --root)
+      root=${2-}
+      if [[ -z $root ]]; then
+        printf -- '--root needs a directory.\n' >&2
+        exit 2
+      fi
+      shift
+      ;;
+    --config)
+      config=${2-}
+      if [[ -z $config ]]; then
+        printf -- '--config needs a path to a deny.toml.\n' >&2
+        exit 2
+      fi
+      shift
+      ;;
+    -h | --help)
+      awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    -*)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n $check ]]; then
+        printf 'unknown argument: %s\n' "$1" >&2
+        exit 2
+      fi
+      check=$1
+      ;;
+  esac
+  shift
+done
+check=${check:-all}
 
-if [[ ${1-} == -h || ${1-} == --help ]]; then
-  awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
-  exit 0
-fi
+# An absolute --root is accepted so the self-test can point this at a scratch
+# tree; a relative one is a path from the repository root.
+case "$root" in
+  /*) RUST_ROOT=$root ;;
+  *) RUST_ROOT=$REPO_ROOT/$root ;;
+esac
+LABEL=${root%/}
 
-check=${1-all}
-
-if [[ ! -f $CONFIG ]]; then
-  printf 'wallet/deny.toml is missing; it is the supply-chain policy this check enforces.\n' >&2
-  exit 1
+# --config is resolved before the cd below, against the directory the caller was
+# standing in, so a relative path means what it looks like it means.
+if [[ -z $config ]]; then
+  CONFIG=$RUST_ROOT/deny.toml
+else
+  case "$config" in
+    /*) CONFIG=$config ;;
+    *) CONFIG=$INVOCATION_DIR/$config ;;
+  esac
 fi
+CONFIG_LABEL=${CONFIG#"$REPO_ROOT"/}
 
 host_target() {
   local os arch
@@ -126,6 +190,66 @@ install_cargo_deny() {
   printf '%s' "$dest"
 }
 
+# --- self-test ---------------------------------------------------------------
+#
+# Builds a scratch crate with a known licence and judges it twice under two
+# policies that disagree about that licence. Passing both ways would mean
+# --config is decorative; failing both ways would mean the tree is unreachable.
+# A check nobody has watched fail is not a check.
+if [[ $mode == self-test ]]; then
+  fixture=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-deny-self-test.XXXXXX")
+  trap 'rm -rf -- "$fixture"' EXIT
+
+  if "$SELF" --root "$fixture" >/dev/null 2>&1; then
+    printf 'self-test FAILED: --root accepted a tree with no policy to enforce.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: --root refuses a tree whose deny.toml is missing.\n'
+
+  mkdir -p "$fixture/relay/src"
+  cat > "$fixture/relay/Cargo.toml" <<'EOF'
+[package]
+name = "zuuli-deny-self-test"
+version = "0.0.0"
+edition = "2024"
+license = "GPL-3.0"
+
+[workspace]
+EOF
+  printf 'pub fn negate(value: bool) -> bool {\n    !value\n}\n' > "$fixture/relay/src/lib.rs"
+  # cargo-deny judges --locked, so the fixture needs the lockfile it judges.
+  cargo generate-lockfile --manifest-path "$fixture/relay/Cargo.toml"
+
+  printf '[licenses]\nallow = ["GPL-3.0"]\n' > "$fixture/deny.toml"
+  if ! "$SELF" --root "$fixture" licenses >/dev/null 2>&1; then
+    printf 'self-test FAILED: a permitted licence was rejected under <root>/deny.toml.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: --root enforces <root>/deny.toml.\n'
+
+  # Negative control: same tree, same crate, a policy that forbids its licence.
+  printf '[licenses]\nallow = ["MIT"]\n' > "$fixture/strict.toml"
+  if "$SELF" --root "$fixture" --config "$fixture/strict.toml" licenses >/dev/null 2>&1; then
+    printf 'self-test FAILED: --config did not decide the verdict; a forbidden licence passed.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: --config decides the verdict (a forbidden licence fails).\n'
+
+  if "$SELF" --root "$fixture" --config "$fixture/absent.toml" licenses >/dev/null 2>&1; then
+    printf 'self-test FAILED: --config accepted a policy file that does not exist.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: --config refuses a policy file that is not there.\n'
+
+  printf 'self-test: 4 case(s) passed; cargo-deny %s.\n' "$CARGO_DENY_VERSION"
+  exit 0
+fi
+
+if [[ ! -f $CONFIG ]]; then
+  printf '%s is missing; it is the supply-chain policy this check enforces.\n' "$CONFIG_LABEL" >&2
+  exit 1
+fi
+
 CARGO_DENY=$(install_cargo_deny)
 
 cd "$RUST_ROOT"
@@ -142,14 +266,14 @@ done < <(
 )
 
 if [[ ${#manifests[@]} -eq 0 ]]; then
-  printf 'no Cargo manifests found under wallet/; this check has gone blind.\n' >&2
+  printf 'no Cargo manifests found under %s/; this check has gone blind.\n' "$LABEL" >&2
   exit 1
 fi
 
 failed=()
 for manifest in "${manifests[@]}"; do
   crate=$(dirname "$manifest")
-  printf '\n==> cargo-deny check %s -- wallet/%s\n' "$check" "$crate"
+  printf '\n==> cargo-deny check %s -- %s/%s\n' "$check" "$LABEL" "$crate"
   # One shared policy across three lockfiles means some ignore entries apply to
   # a different lockfile than the one being checked; cargo-deny reports those as
   # `advisory-not-detected` warnings. They are expected and are not failures.
@@ -159,14 +283,14 @@ for manifest in "${manifests[@]}"; do
   if "$CARGO_DENY" --manifest-path "$manifest" --config "$CONFIG" --locked check "$check"; then
     continue
   fi
-  failed+=("wallet/$crate")
+  failed+=("$LABEL/$crate")
 done
 
 if [[ ${#failed[@]} -gt 0 ]]; then
   printf '\n%d crate(s) failed the supply-chain policy: %s\n' "${#failed[@]}" "${failed[*]}" >&2
-  printf 'Fix the dependency, or add a specific, reasoned entry to wallet/deny.toml.\n' >&2
+  printf 'Fix the dependency, or add a specific, reasoned entry to %s.\n' "$CONFIG_LABEL" >&2
   printf 'Do not broaden a category to make this pass.\n' >&2
   exit 1
 fi
 
-printf '\nAll %d Rust crate(s) under wallet/ satisfy wallet/deny.toml.\n' "${#manifests[@]}"
+printf '\nAll %d Rust crate(s) under %s/ satisfy %s.\n' "${#manifests[@]}" "$LABEL" "$CONFIG_LABEL"

--- a/scripts/check-rust-fmt.sh
+++ b/scripts/check-rust-fmt.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
-# Prove every Rust crate under wallet/ is formatted the way the pinned rustfmt
-# formats it.
+# Prove every Rust crate under a Rust tree is formatted the way the pinned
+# rustfmt formats it.
 #
 # rustfmt's output is *not* stable across compiler versions: the same file
 # formatted by 1.88.0 and by a newer stable can differ, and a check that runs on
 # whatever compiler happens to be installed reports version skew as if it were a
 # formatting mistake. So this script renders a verdict only on the toolchain
-# named by wallet/rust-toolchain.toml — it runs cargo from the directory that
+# named by the tree's rust-toolchain.toml — it runs cargo from the directory that
 # holds that file, so rustup selects the pin, and it refuses to continue if the
 # compiler that answers is a different one.
 #
-# Crates are discovered rather than listed. A new crate under wallet/ is gated
+# The tree defaults to wallet/. A second top-level Rust namespace is gated by
+# pointing --root at it; its rust-toolchain.toml is a restatement of
+# wallet/rust-toolchain.toml, not a second decision, and
+# scripts/check-rust-toolchain.sh is what holds it to that.
+#
+# Crates are discovered rather than listed. A new crate under the tree is gated
 # from its first commit, which is the cheapest moment and never gets cheaper.
 #
 # `cargo fmt` reads the manifest with `cargo metadata --no-deps`, which does not
@@ -18,42 +23,67 @@
 # out and without compiling anything.
 #
 # Usage:
-#   scripts/check-rust-fmt.sh          fail on any unformatted file
-#   scripts/check-rust-fmt.sh --fix    rewrite the offending files in place
+#   scripts/check-rust-fmt.sh              fail on any unformatted file
+#   scripts/check-rust-fmt.sh --fix        rewrite the offending files in place
+#   scripts/check-rust-fmt.sh --root DIR   judge a different Rust tree (default: wallet)
+#   scripts/check-rust-fmt.sh --self-test  prove the check still fails on unformatted code
 
 set -euo pipefail
 
 REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+# Absolute, because the self-test re-invokes this script after cd'ing into the
+# tree under test.
+SELF=$REPO_ROOT/scripts/$(basename -- "${BASH_SOURCE[0]}")
+
+# The Rust tree to judge, relative to the repository root.
+DEFAULT_ROOT=wallet
+
+mode=check
+root=$DEFAULT_ROOT
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix) mode=fix ;;
+    --self-test) mode=self-test ;;
+    --root)
+      root=${2-}
+      if [[ -z $root ]]; then
+        printf -- '--root needs a directory.\n' >&2
+        exit 2
+      fi
+      shift
+      ;;
+    -h | --help)
+      awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
 
 # The directory holding rust-toolchain.toml. Cargo is invoked from here so
 # rustup's toolchain selection — which keys off the working directory, not the
-# --manifest-path — lands on the pinned channel.
-RUST_ROOT=$REPO_ROOT/wallet
+# --manifest-path — lands on the pinned channel. An absolute --root is accepted
+# so the self-test can point this at a scratch tree.
+case "$root" in
+  /*) RUST_ROOT=$root ;;
+  *) RUST_ROOT=$REPO_ROOT/$root ;;
+esac
+LABEL=${root%/}
 TOOLCHAIN_FILE=$RUST_ROOT/rust-toolchain.toml
 
-mode=check
-case "${1-}" in
-  "") ;;
-  --fix) mode=fix ;;
-  -h | --help)
-    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
-    exit 0
-    ;;
-  *)
-    printf 'unknown argument: %s\n' "$1" >&2
-    exit 2
-    ;;
-esac
-
 if [[ ! -f $TOOLCHAIN_FILE ]]; then
-  printf 'wallet/rust-toolchain.toml is missing; it decides which rustfmt this check trusts.\n' >&2
+  printf '%s/rust-toolchain.toml is missing; it decides which rustfmt this check trusts.\n' "$LABEL" >&2
   exit 1
 fi
 
 channel=$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' "$TOOLCHAIN_FILE")
 if [[ ! $channel =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  printf 'channel in wallet/rust-toolchain.toml must be a three-component version, got "%s".\n' \
-    "$channel" >&2
+  printf 'channel in %s/rust-toolchain.toml must be a three-component version, got "%s".\n' \
+    "$LABEL" "$channel" >&2
   exit 1
 fi
 
@@ -61,10 +91,64 @@ cd "$RUST_ROOT"
 
 installed=$(rustc --version)
 if [[ $installed != "rustc $channel "* ]]; then
-  printf 'refusing to judge formatting: wallet/rust-toolchain.toml pins %s but `rustc --version` says "%s".\n' \
-    "$channel" "$installed" >&2
+  printf 'refusing to judge formatting: %s/rust-toolchain.toml pins %s but `rustc --version` says "%s".\n' \
+    "$LABEL" "$channel" "$installed" >&2
   printf 'rustfmt output differs between compiler versions, so this run could only produce a misleading verdict.\n' >&2
   exit 1
+fi
+
+# --- self-test ---------------------------------------------------------------
+#
+# Builds a scratch Rust tree, points --root at it, and confirms the verdict
+# tracks the fixture: blind on an empty tree, clean on formatted code, and —
+# the case that matters — failing on unformatted code. A check nobody has
+# watched fail is not a check.
+if [[ $mode == self-test ]]; then
+  fixture=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-fmt-self-test.XXXXXX")
+  trap 'rm -rf -- "$fixture"' EXIT
+
+  if "$SELF" --root "$fixture" >/dev/null 2>&1; then
+    printf 'self-test FAILED: --root accepted a tree holding no Cargo manifests.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: --root refuses a tree with no crates to judge.\n'
+
+  mkdir -p "$fixture/relay/src"
+  # The second tree restates the pinned channel so rustup selects it here too.
+  printf '[toolchain]\nchannel = "%s"\n' "$channel" > "$fixture/rust-toolchain.toml"
+  cat > "$fixture/relay/Cargo.toml" <<'EOF'
+[package]
+name = "zuuli-fmt-self-test"
+version = "0.0.0"
+edition = "2024"
+
+[workspace]
+EOF
+  printf 'pub fn negate(value: bool) -> bool {\n    !value\n}\n' > "$fixture/relay/src/lib.rs"
+
+  if ! "$SELF" --root "$fixture" >/dev/null; then
+    printf 'self-test FAILED: --root rejected a correctly formatted second tree.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: --root accepts a formatted second tree.\n'
+
+  # Negative control: the same tree, unformatted.
+  printf 'pub fn negate(  value:bool )->bool{!value}\n' > "$fixture/relay/src/lib.rs"
+  if "$SELF" --root "$fixture" >/dev/null 2>&1; then
+    printf 'self-test FAILED: --root accepted an unformatted crate.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: --root rejects an unformatted crate.\n'
+
+  "$SELF" --root "$fixture" --fix >/dev/null
+  if ! "$SELF" --root "$fixture" >/dev/null; then
+    printf 'self-test FAILED: --fix did not reach the crate under --root.\n' >&2
+    exit 1
+  fi
+  printf 'self-test: --fix formats crates under --root.\n'
+
+  printf 'self-test: 4 case(s) passed; rustfmt from %s.\n' "$channel"
+  exit 0
 fi
 
 # Tracked, buildable crates only: target/ holds vendored and generated
@@ -81,7 +165,7 @@ done < <(
 )
 
 if [[ ${#manifests[@]} -eq 0 ]]; then
-  printf 'no Cargo manifests found under wallet/; this check has gone blind.\n' >&2
+  printf 'no Cargo manifests found under %s/; this check has gone blind.\n' "$LABEL" >&2
   exit 1
 fi
 
@@ -89,16 +173,16 @@ failed=()
 for manifest in "${manifests[@]}"; do
   crate=$(dirname "$manifest")
   if [[ $mode == fix ]]; then
-    printf '==> formatting wallet/%s\n' "$crate"
+    printf '==> formatting %s/%s\n' "$LABEL" "$crate"
     cargo fmt --all --manifest-path "$manifest"
     continue
   fi
 
-  printf '==> checking wallet/%s\n' "$crate"
+  printf '==> checking %s/%s\n' "$LABEL" "$crate"
   if cargo fmt --all --check --manifest-path "$manifest"; then
     continue
   fi
-  failed+=("wallet/$crate")
+  failed+=("$LABEL/$crate")
 done
 
 if [[ $mode == fix ]]; then
@@ -113,5 +197,5 @@ if [[ ${#failed[@]} -gt 0 ]]; then
   exit 1
 fi
 
-printf 'All %d Rust crate(s) under wallet/ are formatted (rustfmt from %s).\n' \
-  "${#manifests[@]}" "$channel"
+printf 'All %d Rust crate(s) under %s/ are formatted (rustfmt from %s).\n' \
+  "${#manifests[@]}" "$LABEL" "$channel"

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -18,6 +18,14 @@
 #   scripts/check-rust-toolchain.sh --print-msrv     print the MSRV floor (X.Y)
 #   scripts/check-rust-toolchain.sh --print-targets  print the canonical WASM target
 #   scripts/check-rust-toolchain.sh --self-test      prove the check still fails on drift
+#
+# A second top-level Rust tree needs its own rust-toolchain.toml so rustup
+# selects the pin when cargo runs from it, and its crates carry their own
+# rust-version. Neither is a second decision: register them as restatements and
+# they are held to the one below, exactly like every other restatement.
+#
+#   scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
+#                                   --manifest rs/relay/Cargo.toml
 
 set -euo pipefail
 
@@ -35,6 +43,12 @@ MANIFESTS=(
   wallet/zuuallet/src-tauri/Cargo.toml
   wallet/plugins/tauri-plugin-zcash/Cargo.toml
 )
+
+# Other rust-toolchain.toml files. Cargo picks the toolchain from the directory
+# it runs in, so a second Rust tree needs its own copy — but a copy is a
+# restatement, never a second source of truth, and every entry here must repeat
+# TOOLCHAIN_FILE's channel exactly. Extend with --toolchain-file.
+TOOLCHAIN_RESTATEMENTS=()
 
 # Workflows whose jobs verify the installed compiler with
 # `rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "`. GitHub cannot
@@ -375,6 +389,31 @@ check_manifests() {
   done
 }
 
+check_toolchain_restatements() {
+  local root=$1 channel=$2
+  local rel value
+
+  (( ${#TOOLCHAIN_RESTATEMENTS[@]} > 0 )) || return 0
+
+  for rel in "${TOOLCHAIN_RESTATEMENTS[@]}"; do
+    if [[ $rel == "$TOOLCHAIN_FILE" ]]; then
+      fail "$rel is the source of truth, not a restatement of it"
+      continue
+    fi
+    if [[ ! -f "$root/$rel" ]]; then
+      fail "$rel is missing"
+      continue
+    fi
+    value=$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' "$root/$rel")
+    if [[ -z $value ]]; then
+      fail "$rel does not declare a channel"
+      continue
+    fi
+    [[ $value == "$channel" ]] ||
+      fail "$rel pins channel \"$value\", expected \"$channel\" (from $TOOLCHAIN_FILE)"
+  done
+}
+
 check_docs() {
   local root=$1 channel=$2 msrv=$3
   local entry rel needle
@@ -414,6 +453,7 @@ run_checks() {
 
   check_workflows "$root" "$channel"
   check_manifests "$root" "$channel" "$msrv"
+  check_toolchain_restatements "$root" "$channel"
   check_docs "$root" "$channel" "$msrv"
   check_wasm_target "$root"
 
@@ -454,6 +494,9 @@ staged_paths() {
   local entry file
   printf '%s\n' "$TOOLCHAIN_FILE"
   printf '%s\n' "${MANIFESTS[@]}"
+  if (( ${#TOOLCHAIN_RESTATEMENTS[@]} > 0 )); then
+    printf '%s\n' "${TOOLCHAIN_RESTATEMENTS[@]}"
+  fi
   for entry in "${DOC_PINS[@]}"; do
     printf '%s\n' "${entry%%$'\t'*}"
   done
@@ -468,6 +511,9 @@ stage_tree() {
   local dest=$1 rel
   while IFS= read -r rel; do
     [[ -e "$dest/$rel" ]] && continue
+    # A registered path that does not exist yet is the check's own finding to
+    # report, not the staging step's to die on.
+    [[ -e "$REPO_ROOT/$rel" ]] || continue
     mkdir -p "$dest/$(dirname "$rel")"
     cp "$REPO_ROOT/$rel" "$dest/$rel"
   done < <(staged_paths)
@@ -541,6 +587,8 @@ self_test() {
     printf 'self-test: caught drift when %s.\n' "$description"
   done
 
+  self_test_second_tree "$scratch" "$channel" "$msrv" || failures=$((failures + $?))
+
   if (( failures > 0 )); then
     printf '%d self-test case(s) failed.\n' "$failures" >&2
     return 1
@@ -548,12 +596,144 @@ self_test() {
   printf 'self-test: %d drift case(s) caught.\n' "${#SELF_TEST_MUTATIONS[@]}"
 }
 
+# --- self-test: a second Rust tree -------------------------------------------
+#
+# The capability that lets `rs/` be policed by the same source of truth is
+# proven here rather than by the existence of a second tree, so it is verified
+# before the first one lands. A synthetic tree is registered through
+# --toolchain-file and --manifest, confirmed to pass while it restates the pin,
+# and then broken one way at a time.
+self_test_second_tree() {
+  local scratch=$1 channel=$2 msrv=$3
+  local tree=$scratch/second-tree
+  local failures=0
+  local saved_manifests=("${MANIFESTS[@]}")
+  local saved_restatements=()
+  (( ${#TOOLCHAIN_RESTATEMENTS[@]} > 0 )) &&
+    saved_restatements=("${TOOLCHAIN_RESTATEMENTS[@]}")
+
+  stage_tree "$tree"
+  mkdir -p "$tree/rs/relay/src"
+  printf '[toolchain]\nchannel = "%s"\n' "$channel" > "$tree/rs/rust-toolchain.toml"
+  printf '[package]\nname = "relay"\nversion = "0.0.0"\nedition = "2024"\nrust-version = "%s"\n' \
+    "$msrv" > "$tree/rs/relay/Cargo.toml"
+
+  MANIFESTS+=(rs/relay/Cargo.toml)
+  TOOLCHAIN_RESTATEMENTS+=(rs/rust-toolchain.toml)
+
+  if run_checks "$tree" >/dev/null; then
+    printf 'self-test: a second Rust tree that restates the pin passes.\n'
+  else
+    printf 'self-test FAILED: a second tree that restates the pin must pass.\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  self_test_second_tree_case "$tree" \
+    'a second tree pins a channel of its own' \
+    rs/rust-toolchain.toml "s|channel = \"$channel\"|channel = \"9.99.9\"|" ||
+    failures=$((failures + 1))
+
+  self_test_second_tree_case "$tree" \
+    "a second tree's crate MSRV drifts" \
+    rs/relay/Cargo.toml "s|rust-version = \"$msrv\"|rust-version = \"9.99\"|" ||
+    failures=$((failures + 1))
+
+  rm -f "$tree/rs/rust-toolchain.toml"
+  if run_checks "$tree" >/dev/null 2>&1; then
+    printf 'self-test FAILED: drift went undetected when a second tree loses its toolchain file.\n' >&2
+    failures=$((failures + 1))
+  else
+    printf 'self-test: caught drift when a second tree loses its toolchain file.\n'
+  fi
+
+  # A restatement that is really the source of truth proves nothing, so saying
+  # so must be an error rather than a tautological pass.
+  printf '[toolchain]\nchannel = "%s"\n' "$channel" > "$tree/rs/rust-toolchain.toml"
+  TOOLCHAIN_RESTATEMENTS+=("$TOOLCHAIN_FILE")
+  if run_checks "$tree" >/dev/null 2>&1; then
+    printf 'self-test FAILED: the source of truth was accepted as a restatement of itself.\n' >&2
+    failures=$((failures + 1))
+  else
+    printf 'self-test: the source of truth is rejected as a restatement of itself.\n'
+  fi
+
+  MANIFESTS=("${saved_manifests[@]}")
+  TOOLCHAIN_RESTATEMENTS=()
+  (( ${#saved_restatements[@]} > 0 )) &&
+    TOOLCHAIN_RESTATEMENTS=("${saved_restatements[@]}")
+
+  return "$failures"
+}
+
+self_test_second_tree_case() {
+  local tree=$1 description=$2 rel=$3 script=$4
+  local before after
+
+  before=$(cat "$tree/$rel")
+  apply_sed "$tree/$rel" "$script"
+  after=$(cat "$tree/$rel")
+  if [[ $before == "$after" ]]; then
+    printf 'self-test FAILED: the second-tree case (%s) changed nothing.\n' "$description" >&2
+    return 1
+  fi
+
+  if run_checks "$tree" >/dev/null 2>&1; then
+    printf 'self-test FAILED: drift went undetected when %s.\n' "$description" >&2
+    printf '%s\n' "$before" > "$tree/$rel"
+    return 1
+  fi
+  printf 'self-test: caught drift when %s.\n' "$description"
+  printf '%s\n' "$before" > "$tree/$rel"
+}
+
 usage() {
   awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
 }
 
 main() {
-  case "${1-}" in
+  local mode=''
+  local channel
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --print-channel | --print-msrv | --print-targets | --self-test)
+        if [[ -n $mode ]]; then
+          printf 'conflicting arguments: %s and %s\n' "$mode" "$1" >&2
+          usage >&2
+          return 2
+        fi
+        mode=$1
+        ;;
+      --toolchain-file)
+        if [[ -z ${2-} ]]; then
+          printf -- '--toolchain-file needs a path relative to the repository root.\n' >&2
+          return 2
+        fi
+        TOOLCHAIN_RESTATEMENTS+=("$2")
+        shift
+        ;;
+      --manifest)
+        if [[ -z ${2-} ]]; then
+          printf -- '--manifest needs a path relative to the repository root.\n' >&2
+          return 2
+        fi
+        MANIFESTS+=("$2")
+        shift
+        ;;
+      -h | --help)
+        usage
+        return 0
+        ;;
+      *)
+        printf 'unknown argument: %s\n' "$1" >&2
+        usage >&2
+        return 2
+        ;;
+    esac
+    shift
+  done
+
+  case "$mode" in
     "")
       run_checks "$REPO_ROOT"
       ;;
@@ -561,7 +741,6 @@ main() {
       read_channel "$REPO_ROOT"
       ;;
     --print-msrv)
-      local channel
       channel=$(read_channel "$REPO_ROOT")
       printf '%s\n' "${channel%.*}"
       ;;
@@ -570,14 +749,6 @@ main() {
       ;;
     --self-test)
       self_test
-      ;;
-    -h | --help)
-      usage
-      ;;
-    *)
-      printf 'unknown argument: %s\n' "$1" >&2
-      usage >&2
-      return 2
       ;;
   esac
 }


### PR DESCRIPTION
Closes #543. Part of #305.

The three crate gates hardcoded `RUST_ROOT=$REPO_ROOT/wallet`, and
`check-rust-toolchain.sh` carried a literal `MANIFESTS=(wallet/...)` list plus
`TOOLCHAIN_FILE=wallet/rust-toolchain.toml`. The `rs/` namespace would have
landed with **zero** coverage from all four. This PR is **purely the
capability** — no `rs/` directory, no new crate, no new tree.

## What changed

**`--root <dir>` on `check-rust-fmt.sh`, `check-rust-clippy.sh`,
`check-rust-deny.sh`**, defaulting to `wallet`. An absolute `--root` is accepted
so the self-tests can point at a scratch tree. Every message that said `wallet/`
now says the root it actually judged, which for the default is the same string.

**`--config <path>` on `check-rust-deny.sh`**, defaulting to `<root>/deny.toml`.
Which advisories we accept is a judgement about a particular dependency graph,
and a server graph is not the wallet's — so a second tree gets its own policy
rather than an `ignore` list that means two different things at once.

**clippy's `z/zcash/librustzcash` requirement is now derived, not assumed.** The
crates that reach into the submodule say so themselves, by path dependency
(`path = "../../../z/zcash/librustzcash/..."`), so the requirement is read out
of the discovered manifests instead of being demanded unconditionally.
`wallet/` is still held to it; a tree that never points into it is not. The
self-test asserts the derivation **both ways**, so it cannot go silent for
`wallet` without the gate saying so.

**`check-rust-toolchain.sh` gains `--toolchain-file` and `--manifest`.** A second
tree needs its own `rust-toolchain.toml`, because Cargo picks the toolchain from
the directory it runs in — but that file is a **restatement**, not a second
decision. Registered files must repeat `wallet/rust-toolchain.toml`'s channel
exactly, and naming the source of truth as a restatement of itself is an error
rather than a tautological pass. `--print-channel` is untouched;
`.github/workflows/zuuli.yml` depends on it and still gets `1.97.1`.

**Self-tests.** `check-rust-toolchain.sh --self-test` keeps all 14 existing
drift cases and gains a synthetic second tree; `check-rust-clippy.sh --self-test
<target-os>` keeps its target-native negative control and gains four more.
`check-rust-fmt.sh` and `check-rust-deny.sh` had no self-test at all and now
have one each, negative control included. The gate runs both new ones — a check
nobody has watched fail is not a check.

## Verification (macOS, pinned 1.97.1, librustzcash checked out)

Old = `scripts/check-rust-*.sh` as it stands on `origin/main`, run from this same
worktree so `REPO_ROOT` resolves identically.

### `check-rust-fmt.sh` — byte-identical

```
diff old-no-arg new-no-arg          -> identical
diff old-no-arg new "--root wallet" -> identical

==> checking wallet/plugins/tauri-plugin-zcash
==> checking wallet/zuuallet/src-tauri
==> checking wallet/zuuli/crypto-target-spike
==> checking wallet/zuuli/src-tauri
==> checking wallet/zuuli/wasm-spike
All 5 Rust crate(s) under wallet/ are formatted (rustfmt from 1.97.1).
```

```
$ scripts/check-rust-fmt.sh --self-test
self-test: --root refuses a tree with no crates to judge.
self-test: --root accepts a formatted second tree.
self-test: --root rejects an unformatted crate.        <- negative control
self-test: --fix formats crates under --root.
self-test: 4 case(s) passed; rustfmt from 1.97.1.
```

### `check-rust-deny.sh` — byte-identical

`cargo-deny` interleaves its own warning blocks nondeterministically across
runs (old-vs-old differs too), so the script's own output is compared on stdout,
and the full stream is compared sorted.

```
diff old-stdout new-stdout                          -> identical
diff old-stdout new-stdout "--root wallet"          -> identical
diff <(sort old) <(sort new)                        -> identical
diff <(sort old) <(sort new --root wallet)          -> identical
diff <(sort old) <(sort new --root wallet --config wallet/deny.toml) -> identical

==> cargo-deny check all -- wallet/plugins/tauri-plugin-zcash
advisories ok, bans ok, licenses ok, sources ok
... (5 crates) ...
All 5 Rust crate(s) under wallet/ satisfy wallet/deny.toml.

$ scripts/check-rust-deny.sh --print-version
0.20.2                     # old prints the same
```

```
$ scripts/check-rust-deny.sh --self-test
self-test: --root refuses a tree whose deny.toml is missing.
self-test: --root enforces <root>/deny.toml.
self-test: --config decides the verdict (a forbidden licence fails).   <- negative control
self-test: --config refuses a policy file that is not there.
self-test: 4 case(s) passed; cargo-deny 0.20.2.
```

The negative control is one scratch crate judged under two policies that
disagree about its licence. Passing both ways would mean `--config` is
decorative, which is the whole mechanism a second tree's policy rests on.

### `check-rust-clippy.sh`

The `wallet/` verdict is the ~45-minute job this PR deliberately triggers; the
required `rust_clippy` and `rust_native_clippy` gates are the proof and this PR
sits inside `zuuli.yml`'s `changes` glob so all of them run. Locally verified:

```
$ scripts/check-rust-clippy.sh                     # submodule deliberately absent
z/zcash/librustzcash is not checked out; clippy resolves and compiles the whole graph.
Run: git submodule update --init z/zcash/librustzcash
exit=1
$ scripts/check-rust-clippy.sh --root wallet       # identical, same exit
```

That is the point of item 3: making the requirement conditional did **not**
loosen it for `wallet`.

```
$ scripts/check-rust-clippy.sh --self-test macos
Clippy -D warnings rejected the target-native negative control for macos on x86_64-apple-darwin.
self-test: wallet/ still requires the z/zcash/librustzcash checkout.
self-test: a tree that never points into z/zcash/librustzcash is not held to it.
self-test: --root rejects a crate with a known clippy warning.     <- negative control
self-test: --root accepts a clippy-clean second tree.
```

And from this PR's own `Rust / native lints (windows)` job — the extended
self-test and the full `wallet/` verdict, on the required gate:

```
Run scripts/check-rust-clippy.sh --self-test "windows"
Clippy -D warnings rejected the target-native negative control for windows on x86_64-pc-windows-msvc.
self-test: wallet/ still requires the z/zcash/librustzcash checkout.
self-test: a tree that never points into z/zcash/librustzcash is not held to it.
self-test: --root rejects a crate with a known clippy warning.
self-test: --root accepts a clippy-clean second tree.
...
All 5 Rust crate(s) under wallet/ are clippy-clean (clippy from 1.97.1).
```

### `check-rust-toolchain.sh` — byte-identical

```
diff old-no-arg new-no-arg -> identical

note: 1 Rust compiler selection(s) intentionally follow the stable channel (upstream canaries).
Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.97.1, MSRV 1.97.

$ scripts/check-rust-toolchain.sh --print-channel   ->  1.97.1   (old: 1.97.1)
$ scripts/check-rust-toolchain.sh --print-msrv      ->  1.97
$ scripts/check-rust-toolchain.sh --print-targets   ->  wasm32-unknown-unknown
```

`--self-test` keeps all 14 existing cases verbatim and adds five:

```
self-test: the unmodified tree passes.
... 14 existing drift cases, unchanged ...
self-test: a second Rust tree that restates the pin passes.
self-test: caught drift when a second tree pins a channel of its own.     <- negative control
self-test: caught drift when a second tree's crate MSRV drifts.           <- negative control
self-test: caught drift when a second tree loses its toolchain file.      <- negative control
self-test: the source of truth is rejected as a restatement of itself.    <- negative control
self-test: 14 drift case(s) caught.
```

And the flags on a real tree:

```
$ scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml
drift: rs/rust-toolchain.toml is missing

$ scripts/check-rust-toolchain.sh --toolchain-file wallet/rust-toolchain.toml
drift: wallet/rust-toolchain.toml is the source of truth, not a restatement of it

$ scripts/check-rust-toolchain.sh --manifest wallet/zuuli/src-tauri/Cargo.toml
Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.97.1, MSRV 1.97.

$ scripts/check-rust-toolchain.sh --manifest wallet/rust-toolchain.toml
drift: wallet/rust-toolchain.toml does not declare rust-version
```

### Everything else in `scripts/`

`check-github-actions-pins.mjs`, `check-public-repo-boundary.sh`,
`check-zcash-permissions.mjs`, `check-zuuli-android-gate.mjs` and
`check-zuuli-linux-image.mjs` all pass. `shellcheck` finding counts are
unchanged from `origin/main` for all four scripts (3 / 2 / 5 / 3).

## Notes for review

- The two new gate steps (`rust_fmt` and `rust_deny` self-tests) add seconds to
  jobs that already install the toolchain and, for deny, already fetch the
  pinned `cargo-deny`. They are added only in `zuuli.yml`: the self-test is
  about the script, not the tree, so running it once in the required gate is
  enough — the `zuuallet.yml` mirrors keep running the real checks only.
- The clippy submodule check moved after manifest discovery, since that is what
  it is now derived from. It still runs before any crate is linted.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
