### PR TITLE
ci: give rs.yml's gate a unique status-check context, and make the collision a control

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -10,9 +10,13 @@ name: rs
 # workflow demonstrated both directions: an rs/-only diff yields zuuli=false,
 # and a wallet/-only diff yields rs=false.
 #
-# The `gate` job at the end is what branch protection should require. Adding it
-# as a required status check is a repository-settings change and cannot be made
-# in this file.
+# The `gate` job at the end publishes the context `rs / gate`, and that is what
+# branch protection should require alongside the wallet's `gate`. Every job here
+# carries an `rs / ` display name so none of them collides with a job id in
+# another workflow: check-run names are the only thing branch protection matches
+# on, and a name two workflows both publish resolves by report order rather than
+# by policy. Adding `rs / gate` as a required status check is a
+# repository-settings change and cannot be made in this file.
 
 on:
   pull_request:
@@ -36,6 +40,7 @@ env:
 
 jobs:
   changes:
+    name: rs / changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -290,15 +295,23 @@ jobs:
             --target "${{ steps.rust_toolchain.outputs.target }}" \
             -p f2z-codec
 
-  # Branch protection should require this stable context. It succeeds only when
-  # the change detector and every applicable rs job succeeded; a legitimate
-  # non-rs skip reports success rather than remaining pending.
+  # Branch protection should require this stable context, `rs / gate`. It
+  # succeeds only when the change detector and every applicable rs job
+  # succeeded; a legitimate non-rs skip reports success rather than remaining
+  # pending.
+  #
+  # The `name:` is not cosmetic. Without it this job would publish its job id,
+  # `gate`, which is the context zuuli.yml's full-stack gate already publishes
+  # and the one branch protection requires — two producers for one name, with
+  # the winner decided by report order (#562).
   #
   # Every job in `needs:` below is bound into `env:` AND named on the `results=`
   # line. scripts/check-workflow-gates.mjs enforces that the three sets are
   # equal, so a job that is awaited but never inspected fails review instead of
-  # quietly making this gate decorative.
+  # quietly making this gate decorative. It also requires this `needs:` to cover
+  # every job in this file, so adding a job without wiring it here fails.
   gate:
+    name: rs / gate
     needs: [changes, rs_fmt, rs_clippy, rs_deny, rs_test, rs_wasm]
     if: always()
     runs-on: ubuntu-latest

--- a/scripts/check-workflow-gates.mjs
+++ b/scripts/check-workflow-gates.mjs
@@ -29,6 +29,26 @@
 // list is therefore a deliberate act, and EXHAUSTIVE_VERIFIERS is short on
 // purpose.
 //
+// Two further properties are checked, because a gate can be perfectly wired to
+// the jobs it awaits and still not be the verdict branch protection thinks it
+// is:
+//
+//   3. UNIQUE CONTEXT. A job publishes its check-run name — `name:` when
+//      present, otherwise the job id — and branch protection matches required
+//      checks by that name. GitHub's own documentation says to "make sure that
+//      job names are unique across all workflows. Using the same job name in
+//      multiple workflows can cause ambiguous status check results and block
+//      pull requests from being merged." Two workflows answering to one name
+//      makes which run satisfies the context a function of report order rather
+//      than policy, so this rejects duplicates across the whole tree.
+//
+//   4. TOTAL COVERAGE. A gate's `needs:` must cover every job in its own file.
+//      The wiring rules above only prove `needs` / `env:` / `results=` agree
+//      *with each other*; a job added to the file and never added to `needs`
+//      satisfies all three and is invisible to the gate. That is the likeliest
+//      future regression, so `needs ⊇ {jobs in file} − {gate}` is asserted,
+//      with an explicit per-file opt-out for jobs deliberately left outside.
+//
 // Usage:
 //   node scripts/check-workflow-gates.mjs             judge every workflow
 //   node scripts/check-workflow-gates.mjs --self-test negative controls first
@@ -51,6 +71,40 @@ const CHANGE_DETECTOR = "changes";
 /// Commands that consume `toJSON(needs)` by iterating every entry. Each has been
 /// read and does. Adding one means reading the new verifier first.
 const EXHAUSTIVE_VERIFIERS = ["--verify-gate-results"];
+
+/// Check-run names that more than one workflow is knowingly allowed to publish,
+/// mapped to the exact set of files allowed to publish them. Every entry is a
+/// documented exception, not a category: a *new* producer of one of these names
+/// still fails, because the value is the full file list rather than a wildcard.
+///
+/// Neither name below is a required status check, so neither can currently
+/// decide a merge — that is the whole reason they are tolerated rather than
+/// treated as the `gate` collision was. Renaming them is a follow-up, tracked
+/// in #567; adding to this map instead of fixing a collision needs the same.
+const TOLERATED_CONTEXT_COLLISIONS = new Map([
+  [
+    "build",
+    [
+      ".github/workflows/docs-about-free2z.yml",
+      ".github/workflows/ts-react-free2z.yml",
+      ".github/workflows/ts-svelte-free2z.yml",
+    ],
+  ],
+  [
+    "frontend",
+    [".github/workflows/zuuallet.yml", ".github/workflows/zuuli.yml"],
+  ],
+]);
+
+/// Jobs a gate is deliberately not required to await, per workflow file.
+///
+/// Empty on purpose: today both gates await every job in their own file, so
+/// nothing needs excusing. It exists because the excuse must be written down
+/// next to the rule when one is eventually needed — a scheduled canary that is
+/// not part of a PR verdict is the foreseeable case — rather than the rule
+/// being weakened to accommodate it. The self-test exercises this path with an
+/// injected map so the opt-out is not untested code.
+const GATE_EXEMPT_JOBS = new Map();
 
 const NEEDS_RESULT = /needs\.([A-Za-z0-9_-]+)\.result/g;
 const TO_JSON_NEEDS = /toJSON\(\s*needs\s*\)/;
@@ -105,6 +159,26 @@ function jobsIn(lines) {
   }
   if (current) current.end = lines.length;
   return jobs;
+}
+
+/// The check-run name a job publishes, which is what branch protection matches
+/// a required context against: the job's `name:` when it declares one, and the
+/// job id otherwise.
+///
+/// Conservative about matrix jobs on purpose. A job with a `strategy.matrix`
+/// publishes `<name> (<values>)` per leg, so two files sharing a base name are
+/// not literally the same context — but the resolution is still to give them
+/// distinct names, so the base name is what is compared.
+function publishedContext(lines, job) {
+  for (let index = job.start + 1; index < job.end; index += 1) {
+    const line = lines[index];
+    if (isBlank(line)) continue;
+    if (indentOf(line) <= 2) break;
+    if (indentOf(line) !== 4) continue;
+    const match = /^ {4}name:\s*(.+?)\s*$/.exec(line);
+    if (match) return match[1].replace(/^['"]|['"]$/g, "");
+  }
+  return job.name;
 }
 
 /// The job ids in a job's `needs:`, in any of the three shapes GitHub accepts.
@@ -182,7 +256,16 @@ function difference(left, right) {
 }
 
 /// Judge one `gate` job. Returns an array of human-readable failures.
-export function gateFailures(relativeFile, lines, job) {
+///
+/// `siblings` is every job id defined in the same file, and `exempt` the ids
+/// that file is allowed to leave outside the gate.
+export function gateFailures(
+  relativeFile,
+  lines,
+  job,
+  siblings = [],
+  exempt = new Set(),
+) {
   const failures = [];
   const needs = parseNeeds(lines, job);
   if (!needs) {
@@ -195,6 +278,21 @@ export function gateFailures(relativeFile, lines, job) {
       `${relativeFile}:${needs.index + 1}: gate must await ${CHANGE_DETECTOR}`,
     );
   }
+
+  // Coverage. Wiring the three sets to each other proves nothing about a job
+  // that was never wired at all, so require the gate to await every job its own
+  // workflow defines.
+  const unawaited = difference(
+    difference(new Set(siblings.filter((id) => id !== job.name)), exempt),
+    awaited,
+  );
+  if (unawaited.size) {
+    failures.push(
+      `${relativeFile}:${needs.index + 1}: gate does not await ${sorted(unawaited)}, ` +
+        "defined in the same workflow; a job outside the gate's needs is a job the gate cannot fail on",
+    );
+  }
+
   const judged = difference(awaited, new Set([CHANGE_DETECTOR]));
   if (judged.size === 0) {
     failures.push(
@@ -255,8 +353,47 @@ export function gateFailures(relativeFile, lines, job) {
   return failures;
 }
 
-export function scanRepository(root) {
+/// Reject two workflows answering to one check-run name.
+///
+/// Branch protection resolves a required context by name, so a duplicated name
+/// makes *which* run satisfies the context a function of report order. The
+/// tolerated map is keyed by the exact file list, so a new producer of an
+/// already-tolerated name still fails.
+///
+/// Triggers are deliberately not consulted. A name that is unique only because
+/// the two workflows happen to run on different events stops being unique the
+/// moment someone adds `pull_request:` to one of them, which is a one-line edit
+/// nobody would think of as touching branch protection.
+export function contextCollisionFailures(published, tolerated) {
   const failures = [];
+  const byContext = new Map();
+  for (const entry of published) {
+    if (!byContext.has(entry.context)) byContext.set(entry.context, []);
+    byContext.get(entry.context).push(entry);
+  }
+  for (const [context, entries] of [...byContext].sort(([a], [b]) =>
+    a < b ? -1 : a > b ? 1 : 0,
+  )) {
+    if (entries.length < 2) continue;
+    const producers = [...new Set(entries.map((entry) => entry.file))].sort();
+    const allowed = tolerated.get(context);
+    if (allowed && [...allowed].sort().join("\0") === producers.join("\0")) {
+      continue;
+    }
+    failures.push(
+      `${producers.join(", ")}: ${entries.length} job(s) publish the status-check context "${context}" ` +
+        `(${entries.map((entry) => `${entry.file}#${entry.job}`).join(", ")}); ` +
+        "branch protection matches contexts by name, so a duplicate resolves by report order rather than policy",
+    );
+  }
+  return failures;
+}
+
+export function scanRepository(root, options = {}) {
+  const tolerated = options.tolerated ?? TOLERATED_CONTEXT_COLLISIONS;
+  const exemptions = options.exempt ?? GATE_EXEMPT_JOBS;
+  const failures = [];
+  const published = [];
   let gates = 0;
   const files = workflowFiles(root);
   for (const file of files) {
@@ -265,13 +402,22 @@ export function scanRepository(root) {
       .split(path.sep)
       .join("/");
     const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
-    for (const job of jobsIn(lines)) {
+    const jobs = jobsIn(lines);
+    const siblings = jobs.map((job) => job.name);
+    const exempt = new Set(exemptions.get(relativeFile) ?? []);
+    for (const job of jobs) {
+      published.push({
+        file: relativeFile,
+        job: job.name,
+        context: publishedContext(lines, job),
+      });
       if (job.name !== "gate") continue;
       gates += 1;
-      failures.push(...gateFailures(relativeFile, lines, job));
+      failures.push(...gateFailures(relativeFile, lines, job, siblings, exempt));
     }
   }
-  return { failures, gates, files: files.length };
+  failures.push(...contextCollisionFailures(published, tolerated));
+  return { failures, gates, files: files.length, contexts: published.length };
 }
 
 // ---------------------------------------------------------------------------
@@ -346,22 +492,79 @@ jobs:
         run: node scripts/check-github-actions-pins.mjs --verify-gate-results
 `;
 
+/// The same workflow as EXPLICIT_GATE, with every job carrying a display name.
+/// Its purpose is to be a second file in the tree that does *not* collide, which
+/// is what proves the collision detection reads `name:` and not the file count.
+const NAMED_GATE = `name: other fixture
+
+on:
+  pull_request:
+
+jobs:
+  changes:
+    name: other / changes
+    runs-on: ubuntu-latest
+    outputs:
+      selected: \${{ steps.filter.outputs.selected }}
+    steps:
+      - run: echo selected=true >> "$GITHUB_OUTPUT"
+
+  alpha:
+    name: other / alpha
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo alpha
+
+  gate:
+    name: other / gate
+    needs: [changes, alpha]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs succeeded or legitimately skipped
+        env:
+          CHANGES: \${{ needs.changes.result }}
+          ALPHA: \${{ needs.alpha.result }}
+        run: |
+          results="alpha=$ALPHA"
+          echo "$results"
+`;
+
+/// An extra job in the same file as a gate that never awaits it.
+const UNAWAITED_JOB = `  gamma:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo gamma
+
+  gate:`;
+
+/// `contents` is either one workflow's text, written as `fixture.yml`, or a
+/// `{ filename: text }` map when a case needs more than one workflow in a tree.
 function withFixture(contents, body) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "zuu-gate-self-test-"));
   try {
     const directory = path.join(root, ".github", "workflows");
     fs.mkdirSync(directory, { recursive: true });
-    fs.writeFileSync(path.join(directory, "fixture.yml"), contents);
+    const files =
+      typeof contents === "string" ? { "fixture.yml": contents } : contents;
+    for (const [name, text] of Object.entries(files)) {
+      fs.writeFileSync(path.join(directory, name), text);
+    }
     return body(root);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
 }
 
-function expectClean(label, contents) {
-  const result = withFixture(contents, (root) => scanRepository(root));
-  if (result.gates !== 1) {
-    throw new Error(`self-test FAILED: ${label} did not present exactly one gate`);
+function expectClean(label, contents, options = {}) {
+  const { gates = 1, ...scan } = options;
+  const result = withFixture(contents, (root) => scanRepository(root, scan));
+  if (result.gates !== gates) {
+    throw new Error(
+      `self-test FAILED: ${label} presented ${result.gates} gate(s), expected ${gates}`,
+    );
   }
   if (result.failures.length) {
     throw new Error(
@@ -371,8 +574,8 @@ function expectClean(label, contents) {
   console.log(`self-test: ${label} passes.`);
 }
 
-function expectDetected(label, contents, pattern) {
-  const result = withFixture(contents, (root) => scanRepository(root));
+function expectDetected(label, contents, pattern, options = {}) {
+  const result = withFixture(contents, (root) => scanRepository(root, options));
   const joined = result.failures.join("; ");
   if (!pattern.test(joined)) {
     throw new Error(
@@ -449,7 +652,54 @@ function selfTest() {
     ),
   );
 
-  console.log("check-workflow-gates self-test: 10 case(s) passed.");
+  // Coverage: a job the gate never awaits. It is well-formed and would run on
+  // every PR; the gate simply has no opinion about how it concluded.
+  expectDetected(
+    "a job in the file that the gate does not await",
+    EXPLICIT_GATE.replace("  gate:", UNAWAITED_JOB),
+    /gate does not await gamma, defined in the same workflow/,
+  );
+  // And the opt-out actually excuses it, which is the only way to know the
+  // escape hatch works before someone needs it under pressure.
+  expectClean(
+    "a job excused by the per-file opt-out",
+    EXPLICIT_GATE.replace("  gate:", UNAWAITED_JOB),
+    { exempt: new Map([[".github/workflows/fixture.yml", ["gamma"]]]) },
+  );
+
+  // Unique contexts: two workflows answering to one name. Both fixtures are
+  // individually well-formed gates, so nothing but the duplicate name differs.
+  expectDetected(
+    "two workflows publishing the same status-check context",
+    { "fixture.yml": EXPLICIT_GATE, "other.yml": EXPLICIT_GATE },
+    /2 job\(s\) publish the status-check context "gate"/,
+  );
+  expectClean(
+    "two gates in one tree with distinct display names",
+    { "fixture.yml": EXPLICIT_GATE, "other.yml": NAMED_GATE },
+    { gates: 2 },
+  );
+  // The tolerated map is keyed by the exact producing files, not by the name,
+  // so a third producer of a knowingly-duplicated name is still a failure.
+  expectDetected(
+    "a third producer of a tolerated duplicate context",
+    {
+      "fixture.yml": EXPLICIT_GATE,
+      "other.yml": EXPLICIT_GATE,
+      "third.yml": EXPLICIT_GATE,
+    },
+    /3 job\(s\) publish the status-check context "gate"/,
+    {
+      tolerated: new Map([
+        [
+          "gate",
+          [".github/workflows/fixture.yml", ".github/workflows/other.yml"],
+        ],
+      ]),
+    },
+  );
+
+  console.log("check-workflow-gates self-test: 15 case(s) passed.");
 }
 
 const mode = process.argv[2];
@@ -479,5 +729,7 @@ if (result.failures.length) {
   process.exit(1);
 }
 console.log(
-  `Every gate inspects every job it awaits: ${result.gates} gate(s) across ${result.files} workflow file(s).`,
+  `Every gate inspects every job it awaits and covers every job in its file, ` +
+    `and no two workflows publish one status-check context: ${result.gates} gate(s), ` +
+    `${result.contexts} job(s), ${result.files} workflow file(s).`,
 );


### PR DESCRIPTION
Closes #562.

`rs.yml`'s `gate` and `changes` jobs declared no `name:`, so they published their job ids as check-run names — the same names `zuuli.yml`'s jobs publish. `rs.yml` triggers on every `pull_request` with no path filter and its gate is `if: always()`, so **every PR produced two check runs named `gate`**, one of which reports success in ten seconds regardless of what the PR touched. `gate` is the only context branch protection requires, and GitHub resolves a required context by name, so which run satisfied the protected context was a function of report order rather than policy.

Two lines fix it. The rest of this PR makes the defect impossible to reintroduce silently, because the script whose entire purpose is "the required gate is not decorative" counted three same-named gates and exited 0.

## 1. The fix

`.github/workflows/rs.yml` — `name: rs / gate` and `name: rs / changes`, matching the display names the file's other five jobs (`rs / rustfmt`, `rs / clippy`, `rs / cargo-deny`, `rs / tests`, `rs / wasm32`) already carry.

The file's header comment claimed "the `gate` job at the end is what branch protection should require", which named a context that did not exist unambiguously. It now names `rs / gate` and says why the display name is load-bearing rather than cosmetic.

## 2. `check-workflow-gates.mjs` gains two assertions

**(a) No two workflows may publish the same check-run context**, computed as `name ?? job_id` across every workflow file.

**(b) A gate's `needs:` must cover every job in its own file.** The existing rules prove `needs` / `env:` bindings / the `results=` line agree *with each other*; a job added to the file and never wired into `needs` satisfies all three and is invisible to the gate.

---

# Mutation testing

Every assertion below was run. Nothing here is predicted.

## (a) RED before the rename, GREEN after

New assertion code present, rename **not** applied — the tree exactly as `origin/main` has it:

```console
$ node scripts/check-workflow-gates.mjs
Required-gate wiring failed:
- .github/workflows/rs.yml, .github/workflows/zuuli.yml: 2 job(s) publish the status-check context "changes" (.github/workflows/rs.yml#changes, .github/workflows/zuuli.yml#changes); branch protection matches contexts by name, so a duplicate resolves by report order rather than policy
- .github/workflows/rs.yml, .github/workflows/zuuli.yml: 2 job(s) publish the status-check context "gate" (.github/workflows/rs.yml#gate, .github/workflows/zuuli.yml#gate); branch protection matches contexts by name, so a duplicate resolves by report order rather than policy
2 failure(s) across 2 gate(s) in 14 workflow file(s).
EXIT=1
```

With the rename applied — this branch:

```console
$ node scripts/check-workflow-gates.mjs
Every gate inspects every job it awaits and covers every job in its file, and no two workflows publish one status-check context: 2 gate(s), 56 job(s), 14 workflow file(s).
EXIT=0
```

## (b) RED with a real unawaited job

Not a fixture — an actual seventh job injected into `rs.yml`, well-formed, `needs: changes`, gated on `needs.changes.outputs.rs == 'true'`, with a real checkout and a real `cargo audit` step, and simply absent from `gate.needs`:

```console
$ node scripts/check-workflow-gates.mjs
Required-gate wiring failed:
- .github/workflows/rs.yml:326: gate does not await rs_audit, defined in the same workflow; a job outside the gate's needs is a job the gate cannot fail on
1 failure(s) across 2 gate(s) in 14 workflow file(s).
EXIT=1
```

Reverted; the tree in this PR contains no `rs_audit` (`grep -c rs_audit .github/workflows/rs.yml` → `0`) and is green again.

## The new self-test controls actually fire

Five cases added (10 → 15). Each was then proven to be doing the detecting, by breaking the production code path it exercises and confirming the self-test names that exact case:

| Mutation to `check-workflow-gates.mjs` | Self-test result |
|---|---|
| coverage assertion disabled (`unawaited` forced empty) | **EXIT=1** — `self-test FAILED: a job in the file that the gate does not await was not detected. Failures: (none)` |
| collision assertion disabled (`contextCollisionFailures` returns `[]`) | **EXIT=1** — `self-test FAILED: two workflows publishing the same status-check context was not detected. Failures: (none)` |
| tolerated map treated as a wildcard (file list not compared) | **EXIT=1** — `self-test FAILED: a third producer of a tolerated duplicate context was not detected.` (the `gate` group passed under the wildcard while `alpha`/`beta`/`changes` still failed — the control is specific to `gate`, not incidentally satisfied) |
| per-file opt-out ignored (`exempt` forced empty) | **EXIT=1** — `self-test FAILED: a job excused by the per-file opt-out should pass, got: .github/workflows/fixture.yml:33: gate does not await gamma, defined in the same workflow; …` |

Restored:

```console
$ node scripts/check-workflow-gates.mjs --self-test
self-test: an explicitly wired gate passes.
self-test: an exhaustively wired gate passes.
self-test: a job awaited but never bound is detected.
self-test: a job bound but never reported is detected.
self-test: a name reported that is not awaited is detected.
self-test: a result bound for a job that is not awaited is detected.
self-test: a needs object handed to nothing that reads it is detected.
self-test: a gate that awaits only the change detector is detected.
self-test: a gate that does not await the change detector is detected.
self-test: a gate whose needs is a block sequence passes.
self-test: a job in the file that the gate does not await is detected.
self-test: a job excused by the per-file opt-out passes.
self-test: two workflows publishing the same status-check context is detected.
self-test: two gates in one tree with distinct display names passes.
self-test: a third producer of a tolerated duplicate context is detected.
check-workflow-gates self-test: 15 case(s) passed.
EXIT=0
```

---

# Pre-existing collisions found by the scan

Assertion (a) was run against the whole tree with `TOLERATED_CONTEXT_COLLISIONS` emptied, before deciding what to tolerate. There are **four** duplicated contexts on `main`, not two:

```console
jobs scanned: 56 across 14 workflow file(s)
- docs-about-free2z.yml, ts-react-free2z.yml, ts-svelte-free2z.yml: 3 job(s) publish "build"
- rs.yml, zuuli.yml: 2 job(s) publish "changes"
- zuuallet.yml, zuuli.yml: 2 job(s) publish "frontend"
- rs.yml, zuuli.yml: 2 job(s) publish "gate"
```

`gate` and `changes` are fixed here. `build` and `frontend` are **not renamed in this PR** — they are recorded in `TOLERATED_CONTEXT_COLLISIONS` with the reason, and filed as #567.

The reason for the split: branch protection requires exactly one context (`{"contexts":["gate"]}`), so neither `build` nor `frontend` can decide a merge today — the ambiguity is cosmetic for them and was load-bearing for `gate`. Renaming five jobs across five workflows is also unrelated churn in a PR about the required context.

The tolerated map is **keyed by the exact set of producing files, not by the name**, so it is not a category exemption: a fourth `build` producer still fails. That property has its own negative control (row 3 of the table above).

# Was the opt-out list needed for (b)?

**No — it is implemented and tested, but empty in production.** Both gates already await every job in their own file:

- `rs.yml`: 6 non-gate jobs (`changes`, `rs_fmt`, `rs_clippy`, `rs_deny`, `rs_test`, `rs_wasm`), all 6 in `gate.needs`.
- `zuuli.yml`: 10 non-gate jobs, all 10 in `gate.needs`.

`GATE_EXEMPT_JOBS` exists anyway because the excuse has to be written next to the rule when someone eventually needs one — a scheduled canary that is not part of a PR verdict is the foreseeable case, and `zuuallet.yml#upstream-canary` is exactly that shape should a gate ever be added there. To keep it from being untested code, `scanRepository` accepts an injected map and the self-test exercises both directions (excused → passes; ignored → the coverage failure returns).

# Other checks

```console
$ node scripts/check-github-actions-pins.mjs --self-test
self-test: 70 source-policy, 7 gate-verdict, and 99 current-workflow mutation case(s) passed.

$ node scripts/check-github-actions-pins.mjs
GitHub Actions policy passed: every external action/reusable workflow is immutably pinned, and every required-gate dependency is bound to the enforcing verdict (178 external reference(s), 15 file(s)).

$ node scripts/check-zuuli-android-gate.mjs --self-test
Android gate policy self-test passed (31 mutations).

$ scripts/check-rust-toolchain.sh --self-test
self-test: 14 drift case(s) caught.
$ scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml --manifest rs/crates/f2z-codec/Cargo.toml
Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.97.1, MSRV 1.97.
```

The exact-length assertion hazard (#556) was avoided: nothing in `check-github-actions-pins.mjs` is touched, and its gate-structure assertions are scoped to `REQUIRED_WORKFLOW_PATH = ".github/workflows/zuuli.yml"`, which this PR does not modify. Adding a `name:` key changes no job id, so every `needs:` and `needs.<job>.result` binding is unaffected.

**#477 shell hygiene: 0 bare `[[ ]]` or `(( ))` added.** This PR adds no shell at all — the one `+ run:` line in the diff is `- run: echo gamma` inside a JavaScript fixture string.

---

# Required follow-up: branch protection

**After this merges, branch protection must add `rs / gate` as a second required context**, so `main` requires `["gate", "rs / gate"]`. That is a repository-settings change and cannot be made from a workflow file.

**The sequencing is not arbitrary — rename first, settings second.** Renaming first makes the currently-protected `gate` context unambiguous immediately: it becomes the wallet's full-stack gate and nothing else, which is the property that is broken right now. Adding `rs / gate` to protection first would change nothing, because no job publishes that name yet, and would leave the ambiguity on `gate` in place for the whole interval.

In the window between this merge and the settings change, `rs` is reporting-only — which is what #560's own body says it expects — and `gate` means the wallet suite, correctly.

Also deferred, from #562's acceptance list: `zuuli.yml`'s gate does not re-run `check-workflow-gates.mjs` the way `rs.yml`'s does. Adding it means changing an exact ordered two-command assertion in `check-github-actions-pins.mjs` and its mutation cases — the #556 hazard — so it is filed as #568 rather than folded in here.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD