### PR TITLE
supply-chain(rs): add the akd >= 0.13.0 floor; correct three rs/ docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ read a TOML file at the moment they need the value:
 
 | Restatement | Why it cannot just read the file |
 |---|---|
-| `rust-version` in the three `Cargo.toml` manifests | Cargo needs a literal, and it is the **two-component MSRV floor** (`X.Y`) of the three-component channel (`X.Y.Z`) — deliberately a different form, compared as such |
+| `rust-version` in every registered `Cargo.toml` manifest | Cargo needs a literal, and it is the **two-component MSRV floor** (`X.Y`) of the three-component channel (`X.Y.Z`) — deliberately a different form, compared as such |
 | `ZUULI_RUST_VERSION` in `zuuli-packaging.yml` and `zuuli-release.yml` | A workflow-level `env:` cannot be computed from a file, and the release jobs verify the installed compiler with `rustc --version \| grep -F "rustc $ZUULI_RUST_VERSION "` |
 | `dtolnay/rust-toolchain@<sha> # <version>` in packaging/release and target-native Zuuallet jobs | The action's **version branches hardcode the compiler in `action.yml` and do not declare a `toolchain` input at all** — a commit-pinned ref *is* the version pin, and the trailing comment is its only readable record |
 | `dtolnay/rust-toolchain@<sha> # stable` in source-derived gate/Zuuallet jobs | `uses:` cannot contain an expression, so the generic action implementation is commit-pinned while its `toolchain:` input still reads the version from `wallet/rust-toolchain.toml`; the upstream canary deliberately omits that input so only its compiler selection follows `stable` |

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,7 +1,8 @@
 # The `rs/` workspace — one [workspace], one Cargo.lock.
 #
-# See rs/README.md for why this tree exists, why it is named `rs/`, and why the
-# decision recorded here deliberately does not decide #341.
+# See rs/README.md for why this tree exists, why it is named `rs/`, and why a
+# fourth package root here sits inside the workspace boundary decided for #341
+# in docs/architecture/CARGO-WORKSPACE.md rather than cutting across it.
 
 [workspace]
 resolver = "3"

--- a/rs/README.md
+++ b/rs/README.md
@@ -19,26 +19,52 @@ a namespace named for one role would be wrong within a quarter.
 `rs/` is the role-neutral name. `f2z-codec` is the first crate in it and is
 already both: the relay parses frames with it, and so does the browser.
 
-## This does not decide #341
+## #341 is decided, and a root here is inside the decision
 
-[#341](https://github.com/free2z/zuu/issues/341) asks whether the *repository*
-should have a single Rust workspace. **Nothing here answers that**, and this
-file exists partly to say so out loud, because "a second workspace was added
-after #341 was filed" is exactly the kind of fact that later gets read as a
-decision.
+[#341](https://github.com/free2z/zuu/issues/341) asked whether the *repository*
+should have a single Rust workspace. It is **decided**, and the answer is in
+[`docs/architecture/CARGO-WORKSPACE.md`](../docs/architecture/CARGO-WORKSPACE.md)
+— accepted 2026-08-23 — not in the issue thread. Read the ADR, not this section,
+when the question comes up again.
 
-Every argument against consolidation in #341 is wallet-specific:
+The ADR keeps the wallet's three Rust package roots independent and rules out a
+repository-root workspace outright, because Cargo enrols path dependencies below
+a workspace root and `z/` holds upstream Cargo projects that are not ours to
+govern as members. Its own words:
 
-- Tauri's mobile project layout expects the app crate where it is.
+> If a wallet-wide workspace is ever adopted, its candidate root is `wallet/`,
+> with explicit members and exclusions.
+
+**So the consolidation the ADR leaves open is `wallet/`-scoped, and `rs/` is not
+under `wallet/`.** A fourth package root here does not make that consolidation
+harder; the two trees were never candidates to merge under it. The ADR's reasons
+for the boundary are wallet-specific in exactly the same way:
+
+- The release system runs the Tauri CLI from the app directories and reads
+  `src-tauri/Cargo.lock` and `src-tauri/target`; Tauri's generated mobile
+  projects expect the app crate where it is.
 - The wallet's three lockfiles resolve the Zcash and Tauri graphs **differently
-  on purpose**, and unifying them would silently change what ships.
+  on purpose** — Tauri 2.11.5 / `aws-lc-rs` 1.17.3 on one side, 2.10.2 / 1.15.4
+  on the other — so unifying them starts with a coordinated dependency update,
+  not a relocation.
 - `libsqlite3-sys` declares `links = "sqlite3"`, so Cargo hard-errors on a graph
   containing two versions — which makes `rusqlite 0.37` a repo-wide singleton and
   makes any workspace merge a resolution question, not a layout question.
 
-None of those applies to a fresh tree with no Tauri, no SQLite and no path
-dependencies into `z/`. If #341 later chooses one repo-wide workspace, `rs/`
-folds into it by moving these members and deleting one `[workspace]` table.
+None of those engages a tree with no Tauri, no SQLite and no path dependencies
+into `z/`. What `rs/` does owe the ADR is its "Adding Rust crates" step 5 — run
+the repository's manifest-discovering format, clippy and cargo-deny checks, and
+add explicit locked build/test coverage for the context the crate promises. That
+is what `.github/workflows/rs.yml` is.
+
+The ADR does not freeze the question; it lists **revisit triggers** — a shared
+release cadence, two or more further shared crates, a divergence that escapes
+the per-app locked builds, measured CI data, or release tooling made independent
+of the app-local lock and target paths — and it accepts consolidation only after
+a migration proves the whole list of builds and tests. None of those triggers is
+about `rs/`. If one ever fires and this tree is in scope, folding it in is one
+reviewed dependency-resolution diff across both lockfiles — not the deletion of
+a `[workspace]` table.
 
 ## The toolchain pin is a restatement
 
@@ -114,9 +140,29 @@ scripts/check-rust-clippy.sh --root rs
 scripts/check-rust-deny.sh   --root rs --config rs/deny.toml
 ```
 
-All four discover crates rather than listing them, so a new crate under `rs/` is
-gated from its first commit. `.github/workflows/rs.yml` runs them, plus
-`cargo test` and the WASM build, behind its own `gate`.
+**Three of the four discover crates; the toolchain check does not.**
+`check-rust-fmt.sh`, `check-rust-clippy.sh` and `check-rust-deny.sh` find every
+`Cargo.toml` under `--root`, so a new crate under `rs/` is formatted, linted and
+supply-chain-gated from its first commit. `check-rust-toolchain.sh` reads a
+hardcoded manifest list plus the explicit `--manifest` flags above, so **a second
+crate under `rs/crates/` would ship with a wrong MSRV, or none, and still pass.**
+
+Proved by adding a throwaway `rs/crates/scratch/Cargo.toml` with no
+`rust-version` and no `license`, then running all four with the flags above
+unchanged:
+
+| Script | Sees it? | Verdict |
+|---|---|---|
+| `check-rust-fmt.sh --root rs` | yes | RED — `3 crate(s) are not formatted: … rs/crates/scratch` |
+| `check-rust-clippy.sh --root rs` | yes | RED — `2 crate(s) failed the clippy gate: … rs/crates/scratch` |
+| `check-rust-deny.sh --root rs --config rs/deny.toml` | yes | RED — `error[unlicensed]: scratch = 0.0.0 is unlicensed` |
+| `check-rust-toolchain.sh --toolchain-file … --manifest …/f2z-codec/Cargo.toml` | **no** | **GREEN** |
+
+So **every new crate in this tree needs another `--manifest` flag added to
+`rs.yml`** in the same commit that creates it, until
+[#553](https://github.com/free2z/zuu/issues/553) makes that check discover
+manifests too. `.github/workflows/rs.yml` runs all four, plus `cargo test` and
+the WASM build, behind its own `gate`.
 
 ### Workspace lints
 

--- a/rs/deny.toml
+++ b/rs/deny.toml
@@ -28,6 +28,18 @@
 # Evaluate every target. This tree compiles for wasm32-unknown-unknown as well
 # as for the servers' hosts, and a host-only view would miss whatever the wasm
 # half pulls in.
+#
+# `targets` is the knob that decides that, and an empty list is cargo-deny's
+# "every target". It is stated rather than left absent because this is a
+# property we rely on: an absent key is indistinguishable from an unconsidered
+# one, and a default that changes upstream would narrow the graph silently,
+# between two CI runs, with no commit of ours in between.
+targets = []
+
+# A *feature* knob, not a target one. `--all-features` would judge a graph
+# nothing in this tree compiles; the crates here are checked with the features
+# they actually build with. Restated rather than inherited so that turning it on
+# is a visible, reviewed edit.
 all-features = false
 
 # =============================================================================
@@ -105,6 +117,26 @@ exceptions = []
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+
+[[bans.deny]]
+# akd < 0.13.0 contains an auditor append-only bypass, facebook/akd#495, merged
+# 2026-08-12 and released in 0.13.0 on 2026-08-13: a malicious log can rewrite an
+# existing label's value while still producing a VALID append-only proof, which
+# defeats the witness role entirely (see docs/e2ee/KT.md §7).
+# There is no RustSec/OSV advisory — an OSV query for `akd` returns {} — so
+# `cargo audit` and `cargo deny advisories` will NOT catch a downgrade. This entry
+# is the floor. Do not remove it, and do not assume tooling is holding it.
+name = "akd"
+version = "<0.13.0"
+
+[[bans.deny]]
+name = "akd_core"
+version = "<0.13.0"
+
+[[bans.deny]]
+# akd_mysql's last release is 0.8.9 (2023-03-15) and it is not maintained.
+# The durable Database impl is ours (KT.md §11.2).
+name = "akd_mysql"
 
 # =============================================================================
 # Sources. Everything resolves to crates.io. Making that a rule rather than a

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -39,6 +39,7 @@ TOOLCHAIN_FILE=wallet/rust-toolchain.toml
 # exact toolchain, so the forms are deliberately different and compared as such.
 MANIFESTS=(
   wallet/zuuli/wasm-spike/Cargo.toml
+  wallet/zuuli/crypto-target-spike/Cargo.toml
   wallet/zuuli/src-tauri/Cargo.toml
   wallet/zuuallet/src-tauri/Cargo.toml
   wallet/plugins/tauri-plugin-zcash/Cargo.toml


### PR DESCRIPTION
Closes #565
Closes #566

## The akd floor, mutation-tested

`rs/deny.toml` now carries ADR 0013's three `[[bans.deny]]` entries verbatim —
`akd` and `akd_core` floored at `0.13.0`, `akd_mysql` banned outright — with the
inline comment naming [`facebook/akd#495`](https://github.com/facebook/akd/pull/495)
and stating that no RustSec/OSV advisory exists, so `cargo audit` and
`cargo deny check advisories` will never catch a downgrade. That comment is the
load-bearing part: it is what stops the next reviewer deleting the entry as
redundant with `cargo audit`, which is exactly the mistake it exists to survive.

**Method.** Scratch workspace member `rs/crates/akd-floor-probe` depending on
`akd = "0.12.0"`, `rs/Cargo.lock` resolved from crates.io (`akd v0.12.0`,
`akd_core v0.12.0`), then each check run separately. The scratch member and the
regenerated lockfile are **not** in this diff — `git status` is clean of them and
`rs/Cargo.lock` is byte-identical to `main`.

### `akd = "0.12.0"` — advisories **GREEN**

```console
$ scripts/check-rust-deny.sh --root rs --config rs/deny.toml advisories

==> cargo-deny check advisories -- rs/.
advisories ok

==> cargo-deny check advisories -- rs/crates/akd-floor-probe
advisories ok

==> cargo-deny check advisories -- rs/crates/f2z-codec
advisories ok

All 3 Rust crate(s) under rs/ satisfy rs/deny.toml.
```

### `akd = "0.12.0"` — bans **RED**

```console
$ scripts/check-rust-deny.sh --root rs --config rs/deny.toml bans

==> cargo-deny check bans -- rs/.
error[banned]: crate 'akd = 0.12.0' is explicitly banned
    │         ━━━ banned here
error[banned]: crate 'akd_core = 0.12.0' is explicitly banned
    │         ━━━━━━━━ banned here
bans FAILED

==> cargo-deny check bans -- rs/crates/akd-floor-probe
error[banned]: crate 'akd = 0.12.0' is explicitly banned
error[banned]: crate 'akd_core = 0.12.0' is explicitly banned
bans FAILED

==> cargo-deny check bans -- rs/crates/f2z-codec
bans ok

2 crate(s) failed the supply-chain policy: rs/. rs/crates/akd-floor-probe
```

**Advisories green while bans is red, on the same lockfile, at the same commit.**
That asymmetry is the entire justification for the entry: there is nothing in the
advisory databases to find, so the ban is the only control.

### `akd = "0.13"` (resolves `akd v0.13.0`, `akd_core v0.13.0`) — both **GREEN**

```console
$ scripts/check-rust-deny.sh --root rs --config rs/deny.toml advisories
advisories ok  (×3)
All 3 Rust crate(s) under rs/ satisfy rs/deny.toml.

$ scripts/check-rust-deny.sh --root rs --config rs/deny.toml bans
bans ok  (×3)
All 3 Rust crate(s) under rs/ satisfy rs/deny.toml.
```

Not a blanket ban: `0.13.0` passes, `0.12.0` does not, and the failure names the
crate and the version.

### `docs/e2ee/KT.md:1180-1184`

Unchanged, deliberately. It stated the floor in the present tense — "hard,
enforced by a `[[bans.deny]]` entry" — and describes a control that now exists.
Re-read against the landed entry, every clause is true as written, including
"there is no second line of defence". Nothing to correct.

## #566/1 — `rs/README.md` claimed a discovery guarantee that does not hold

Verified here, not taken on trust. Throwaway `rs/crates/scratch/Cargo.toml` with
no `rust-version` and no `license`, all four scripts run with their registered
flags unchanged:

| Script (registered flags) | Sees it? | Verdict |
|---|---|---|
| `check-rust-fmt.sh --root rs` | yes | **RED** — `3 crate(s) are not formatted: rs/. rs/crates/f2z-codec rs/crates/scratch` |
| `check-rust-clippy.sh --root rs` | yes | **RED** — `2 crate(s) failed the clippy gate: rs/. rs/crates/scratch` |
| `check-rust-deny.sh --root rs --config rs/deny.toml` | yes | **RED** — `error[unlicensed]: scratch = 0.0.0 is unlicensed` |
| `check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml --manifest rs/crates/f2z-codec/Cargo.toml` | **no** | **GREEN** |

Three of four discover; the toolchain check greps a hardcoded `MANIFESTS` array
plus explicit `--manifest` flags, so a second crate under `rs/crates/` ships with
a wrong MSRV, or none, and passes. The README now says so, tables the evidence,
tells the next author to add a `--manifest` flag in the same commit that creates
the crate, and points at #553 for the real fix. The throwaway crate is removed
and `rs/Cargo.lock` restored.

One honest note on the clippy row: the throwaway is only clippy-red once it opts
into `[lints] workspace = true`. Discovery — the claim under test — happened
either way; `==> cargo clippy -- rs/crates/scratch` appears in both runs.

## #566/2 — `rs/README.md` argued a decided question as open

`docs/architecture/CARGO-WORKSPACE.md` (accepted 2026-08-23, PR #519) is in the
tree. The section is rewritten to cite the ADR rather than the closed issue, and
the `:40-41` hedge — "If #341 later chooses one repo-wide workspace, `rs/` folds
into it by … deleting one `[workspace]` table" — is gone, because the ADR rules
that scenario out and the hedge understated the cost anyway.

The argument got stronger rather than shorter. The ADR's decided consolidation
target is **`wallet/`**, not repo-wide ("If a wallet-wide workspace is ever
adopted, its candidate root is `wallet/`"), and `rs/` is not under `wallet/` — so
a fourth root here does not obstruct the accepted consolidation; the two trees
were never candidates to merge. The wallet-specific reasons are re-sourced from
the ADR (release tooling reads `src-tauri/Cargo.lock` and `src-tauri/target`;
the locks resolve Tauri 2.11.5 / `aws-lc-rs` 1.17.3 against 2.10.2 / 1.15.4; the
`links = "sqlite3"` singleton), and the hedge is replaced with the ADR's own
revisit-trigger framing. It also records that `rs.yml` is how this tree satisfies
the ADR's "Adding Rust crates" step 5.

## #566/3 — `rs/deny.toml`'s `[graph]` comment described a directive that was not there

Chose **`targets = []` explicit, comment attached to it**, rather than moving the
comment. The comment states an intent — evaluate the wasm target too — that we
actually depend on; leaving it to a default means an absent key is
indistinguishable from an unconsidered one, and an upstream default change would
narrow the graph silently between two CI runs with no commit of ours in between.
`all-features = false` keeps a separate, accurate comment saying it is a
*feature* knob. Neither line changes today's behaviour; the point is that the
file now says which line delivers which property.

## `crypto-target-spike` — registered

`wallet/zuuli/crypto-target-spike/Cargo.toml:5` declared `rust-version = "1.97"`
and nothing checked it. Registered as one line in `check-rust-toolchain.sh`'s
`MANIFESTS` array rather than a workflow `--manifest` flag, because `zuuli.yml`
runs the script bare — so the array is where a *wallet* manifest belongs, and no
workflow needed editing. Green both ways:

```console
$ scripts/check-rust-toolchain.sh
Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.97.1, MSRV 1.97.

$ scripts/check-rust-toolchain.sh --self-test
self-test: 14 drift case(s) caught.
```

`AGENTS.md`'s restatement table said "the three `Cargo.toml` manifests"; it is now
"every registered `Cargo.toml` manifest", which does not rot with the count.

## Checks

```
scripts/check-rust-deny.sh --root rs --config rs/deny.toml      advisories ok, bans ok, licenses ok, sources ok (2 crates, zero warnings)
scripts/check-rust-deny.sh --self-test                          4 case(s) passed; cargo-deny 0.20.2
scripts/check-rust-fmt.sh --root rs                             2 crate(s) formatted (rustfmt 1.97.1)
scripts/check-rust-clippy.sh --root rs                          2 crate(s) clippy-clean (clippy 1.97.1)
scripts/check-rust-toolchain.sh --toolchain-file rs/... --manifest rs/crates/f2z-codec/Cargo.toml   pass
scripts/check-rust-toolchain.sh                                 pass
scripts/check-rust-toolchain.sh --self-test                     14 drift case(s) caught
node scripts/check-workflow-gates.mjs [--self-test]             15 case(s); 2 gates, 56 jobs, 14 workflow files
node scripts/check-github-actions-pins.mjs [--self-test]         176 case(s); 178 external refs, 15 files
```

No workflow file is touched, so `.github/workflows/zuuli.yml`'s `changes` policy
step and its ordered command assertion are untouched (#556's hazard).

**#477 shell hygiene: 0 bare `[[ ]]` / `(( ))` statements added.** The only shell
change in the diff is one array element; the three `[[bans.deny]]` lines a naive
grep flags are TOML array-of-tables in `rs/deny.toml`.
