### PR TITLE
security(f2z-codec): stop Canonicalized's Debug dumping received bytes

### DIFF
--- a/rs/crates/f2z-codec/src/canonical.rs
+++ b/rs/crates/f2z-codec/src/canonical.rs
@@ -26,6 +26,7 @@
 //! a default all become the same loud, immediate, testable failure.
 
 use alloc::vec::Vec;
+use core::fmt;
 
 use tls_codec::{DeserializeBytes, SerializeBytes};
 
@@ -38,10 +39,32 @@ use crate::error::CodecError;
 /// agree. [`Canonicalized::bytes`] is therefore always safe to hash or sign:
 /// there is no path by which a caller can obtain the *received* bytes from
 /// here.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Canonicalized<T> {
     value: T,
     encoded: Vec<u8>,
+}
+
+/// Hand-written, like every other `Debug` in this crate that stands between a
+/// log line and a ciphertext.
+///
+/// `value` renders through its own `Debug`, which the newtypes of
+/// [`crate::types`] have already redacted. `encoded` is a bare `Vec<u8>` — the
+/// entire received frame, payload included — and a derived `Debug` would print
+/// it as a list of decimal integers. A decimal dump is a dump: 1 KiB of
+/// ciphertext becomes 5 KiB of log. This is the crate's stated property #2, and
+/// `Canonicalized` is the type every receive path holds, so it is the single
+/// worst place in the crate to leave that derived.
+impl<T: fmt::Debug> fmt::Debug for Canonicalized<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Canonicalized")
+            .field("value", &self.value)
+            .field(
+                "encoded",
+                &format_args!("<redacted; {} bytes>", self.encoded.len()),
+            )
+            .finish()
+    }
 }
 
 impl<T> Canonicalized<T> {

--- a/rs/crates/f2z-codec/tests/redaction.rs
+++ b/rs/crates/f2z-codec/tests/redaction.rs
@@ -45,10 +45,21 @@ fn upper_hex(bytes: &[u8]) -> String {
     bytes.iter().map(|byte| format!("{byte:02X}")).collect()
 }
 
+/// `222, 222, 222, …` — the body of a derived `Debug` on a byte slice, with no
+/// surrounding brackets.
+///
+/// Unbracketed on purpose. A real dump is very often *not* the whole list: a
+/// wire buffer opens with a length prefix, so the secret starts partway through
+/// as `[0, 4, 0, 222, 222, …`. Anchoring the pattern on `[` makes the check
+/// miss exactly the shape it exists to catch.
+fn decimal_run(bytes: &[u8]) -> String {
+    let joined: Vec<String> = bytes.iter().map(|byte| byte.to_string()).collect();
+    joined.join(", ")
+}
+
 /// `[222, 222, 222, …]` — a derived `Debug` on a byte slice.
 fn decimal_list(bytes: &[u8]) -> String {
-    let joined: Vec<String> = bytes.iter().map(|byte| byte.to_string()).collect();
-    format!("[{}]", joined.join(", "))
+    format!("[{}]", decimal_run(bytes))
 }
 
 fn base64url(bytes: &[u8]) -> String {
@@ -117,10 +128,12 @@ fn assert_no_leak(label: &str, rendered: &str, secret: &[u8]) {
         "{label} leaked a decimal byte list: {rendered}"
     );
     // A prefix of a decimal dump is enough to convict: no correct output of this
-    // crate ever prints four consecutive byte values.
+    // crate ever prints four consecutive byte values. Matched without brackets,
+    // so a dump that begins after a length prefix — `[0, 4, 0, 222, 222, …` —
+    // is caught as readily as one that begins at the opening bracket.
     assert!(
-        !rendered.contains(&decimal_list(&secret[..secret.len().min(4)])),
-        "{label} leaked a decimal byte list prefix: {rendered}"
+        !rendered.contains(&decimal_run(&secret[..secret.len().min(4)])),
+        "{label} leaked a decimal byte run: {rendered}"
     );
     // Every byte of the secret is 0xde, so even a two-byte prefix would show as
     // a repeated `de`. Catch a partial dump too.
@@ -311,4 +324,225 @@ fn a_challenge_scope_is_an_address_and_redacts_but_operator_text_does_not() {
     // Escaped, so a name with a newline cannot forge a log line.
     let hostile = ShortBytes::new(b"ok".to_vec()).unwrap();
     assert!(!format!("{hostile:?}").contains('\n'));
+}
+
+#[test]
+fn a_canonicalized_value_never_dumps_the_bytes_it_arrived_as() {
+    // `Canonicalized` is what every receive path holds: the decoded value *and*
+    // the canonical bytes §5 hashes. The value's own `Debug` is already
+    // redacted by the newtypes, so this test exists for the other field — the
+    // raw `Vec<u8>`, which is the whole frame, ciphertext included.
+    let body = AppendRequest {
+        payload: Payload::new(vec![SECRET; 1024]).unwrap(),
+    };
+    let wire = body.encode_canonical().unwrap();
+    let canonical = AppendRequest::decode_canonical(&wire).unwrap();
+
+    let rendered = format!("{canonical:?}");
+    assert_no_leak("Canonicalized<AppendRequest>", &rendered, &[SECRET; 1024]);
+    assert!(
+        rendered.contains("<redacted"),
+        "Canonicalized must say it redacted something, got {rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The structural check.
+//
+// Everything above tests one type at a time against a fixture. That is how this
+// defect got in: `Canonicalized` was never formatted, so the guard never looked
+// at it, and the newtype discipline held only where somebody remembered to
+// apply it. Two hand-written `Debug` impls in a row is a convention, not a
+// control.
+//
+// So the check below is on the *source*, not on a value: no type in this crate
+// may derive `Debug` while holding raw bytes. It fires on a type nobody wrote a
+// fixture for, which is precisely the case the fixtures cannot cover.
+// ---------------------------------------------------------------------------
+
+/// Field type spellings that a derived `Debug` renders as a decimal byte dump.
+const RAW_BYTE_TYPES: &[&str] = &["Vec<u8>", "[u8;", "&[u8]", "TlsByteVec", "Box<[u8]>"];
+
+/// A `struct` or `enum` declaration that carried `#[derive(..., Debug, ...)]`.
+struct DerivedDebugItem {
+    file: String,
+    name: String,
+    body: String,
+}
+
+/// Every `.rs` file under `src/`, resolved from the manifest rather than the
+/// process CWD so the test does not depend on where cargo was invoked.
+fn source_files() -> Vec<(String, String)> {
+    fn walk(dir: &std::path::Path, out: &mut Vec<(String, String)>) {
+        let read = std::fs::read_dir(dir);
+        assert!(read.is_ok(), "could not read {dir:?}");
+        let entries = read.unwrap();
+        for entry in entries {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                let name = path.file_name().unwrap().to_string_lossy().into_owned();
+                out.push((name, std::fs::read_to_string(&path).unwrap()));
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(
+        &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+        &mut out,
+    );
+    assert!(!out.is_empty(), "found no source files to scan");
+    out
+}
+
+/// Strip a line comment, so a brace inside a doc comment does not confuse the
+/// depth count. Struct bodies contain no string literals, so a naive cut is
+/// safe here and a real parser is not worth the dependency.
+fn without_comment(line: &str) -> &str {
+    match line.find("//") {
+        Some(index) => &line[..index],
+        None => line,
+    }
+}
+
+/// Collect every `struct`/`enum` in `source` whose derive list contains `Debug`.
+fn derived_debug_items(file: &str, source: &str) -> Vec<DerivedDebugItem> {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut items = Vec::new();
+    let mut index = 0usize;
+
+    while index < lines.len() {
+        if !lines[index].trim_start().starts_with("#[derive(") {
+            index += 1;
+            continue;
+        }
+
+        // A derive list may span several lines (see `pow.rs`'s `PowParams`).
+        let mut derives = String::new();
+        while index < lines.len() {
+            derives.push_str(lines[index]);
+            index += 1;
+            if derives.contains(")]") {
+                break;
+            }
+        }
+        let mentions_debug = derives
+            .split(|c: char| !c.is_alphanumeric() && c != '_')
+            .any(|token| token == "Debug");
+        if !mentions_debug {
+            continue;
+        }
+
+        // Skip any further attributes and comments between the derive and the
+        // item it applies to.
+        while index < lines.len() {
+            let trimmed = lines[index].trim_start();
+            if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with("//") {
+                index += 1;
+            } else {
+                break;
+            }
+        }
+        assert!(index < lines.len(), "{file}: derive with no item after it");
+
+        let declaration = lines[index];
+        let mut words = declaration
+            .split_whitespace()
+            .skip_while(|word| *word != "struct" && *word != "enum");
+        let keyword = words.next();
+        let identifier = words.next();
+        assert!(
+            keyword.is_some() && identifier.is_some(),
+            "{file}: derive(Debug) sits on an item this scanner does not recognise, so it \
+             is not being checked: {declaration}"
+        );
+        let name = identifier
+            .unwrap()
+            .trim_end_matches(['<', '(', '{', ';'])
+            .split(['<', '(', '{'])
+            .next()
+            .unwrap()
+            .to_owned();
+
+        // Accumulate the body: braced items to matching depth, tuple and unit
+        // items to the terminating semicolon.
+        let mut body = String::new();
+        if without_comment(declaration).contains('{') {
+            let mut depth = 0i32;
+            while index < lines.len() {
+                let line = lines[index];
+                body.push_str(line);
+                body.push('\n');
+                let code = without_comment(line);
+                depth += i32::try_from(code.matches('{').count()).unwrap();
+                depth -= i32::try_from(code.matches('}').count()).unwrap();
+                index += 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+        } else {
+            while index < lines.len() {
+                let line = lines[index];
+                body.push_str(line);
+                body.push('\n');
+                index += 1;
+                if without_comment(line).contains(';') {
+                    break;
+                }
+            }
+        }
+
+        items.push(DerivedDebugItem {
+            file: file.to_owned(),
+            name,
+            body,
+        });
+    }
+
+    items
+}
+
+#[test]
+fn no_type_derives_debug_while_holding_raw_bytes() {
+    let mut scanned = Vec::new();
+    let mut violations = Vec::new();
+
+    for (file, source) in source_files() {
+        for item in derived_debug_items(&file, &source) {
+            for raw in RAW_BYTE_TYPES {
+                // The declaration line itself is excluded from the search only
+                // for the tuple-struct case, where it *is* the body; matching
+                // the whole captured text is what we want either way.
+                if item.body.contains(raw) {
+                    violations.push(format!(
+                        "{}: `{}` derives Debug while holding `{}` — a derived Debug \
+                         renders that as a decimal byte dump. Hand-write Debug and \
+                         report the field by length, as `Payload` and `Canonicalized` do.",
+                        item.file, item.name, raw
+                    ));
+                }
+            }
+            scanned.push(item.name);
+        }
+    }
+
+    // A scanner that silently matches nothing would pass forever. Anchor it on
+    // types that certainly do derive `Debug`, so a parser regression is loud.
+    assert!(
+        scanned.iter().any(|name| name == "RelayFrame"),
+        "the scanner did not find RelayFrame; it is no longer parsing the source. Found: {scanned:?}"
+    );
+    assert!(
+        scanned.len() > 20,
+        "the scanner found only {} derive(Debug) types, which is too few to be real: {scanned:?}",
+        scanned.len()
+    );
+
+    assert!(
+        violations.is_empty(),
+        "types deriving Debug over raw bytes:\n  {}",
+        violations.join("\n  ")
+    );
 }


### PR DESCRIPTION
`Canonicalized` is the type **every receive path holds** — the decoded value plus the canonical bytes §5 hashes. Its derived `Debug` rendered the raw `Vec<u8>` as a list of decimal integers.

`Closes #563`

## Red before

Probe: format a `Canonicalized<AppendRequest>` wrapping a 1 KiB payload of `0xde`.

```
LEN: 5223
FIRST 200: Canonicalized { value: AppendRequest { payload: Payload(<redacted; 1024 bytes>) }, encoded: [0, 4, 0, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222, 222
```

5,223 characters of ciphertext from one debug-format of one frame. Note the payload is correctly redacted *inside* `value`; the leak is entirely the sibling field.

## A second defect: the battery could not see it

The first thing I did was add the new case to `tests/redaction.rs`'s detector battery and run it against unmodified `main`. **It passed.** The leak above is real and the battery did not fire.

Every decimal detector in `assert_no_leak` was anchored on the opening bracket — `decimal_list()` builds `"[222, 222, …]"`. A real dump is almost never the whole list: a wire buffer opens with a length prefix, so the secret starts partway through, as `[0, 4, 0, 222, 222, …`. The `[` never lines up. The detector was blind to precisely the shape it existed to catch, and the hex and base64url detectors are irrelevant to a decimal dump.

So this PR also unanchors it: `decimal_run()` matches the joined run without brackets, and the four-byte-prefix assertion uses that. The other five redaction tests still pass unchanged under the stricter detector.

Without this change the new test is ornamental — it goes green against the unfixed code.

## Green after

```
running 7 tests
test a_challenge_scope_is_an_address_and_redacts_but_operator_text_does_not ... ok
test every_command_carrying_a_secret_redacts_it ... ok
test every_opaque_newtype_redacts ... ok
test a_canonicalized_value_never_dumps_the_bytes_it_arrived_as ... ok
test a_payload_reports_its_length_and_nothing_else ... ok
test no_type_derives_debug_while_holding_raw_bytes ... ok
test a_whole_frame_renders_without_a_single_secret_byte ... ok

test result: ok. 7 passed; 0 failed
```

With the detector unanchored but `canonical.rs` untouched, the new test fails as it should:

```
Canonicalized<AppendRequest> leaked a decimal byte run: Canonicalized { value: AppendRequest {
payload: Payload(<redacted; 1024 bytes>) }, encoded: [0, 4, 0, 222, 222, 222, 222, 222, ...
```

## Mutation tests

Every guard here was reverted and confirmed to go red.

**A — revert `Debug` to derived on `Canonicalized`** (run against the final, formatted tree):

```
test a_canonicalized_value_never_dumps_the_bytes_it_arrived_as ... FAILED
test no_type_derives_debug_while_holding_raw_bytes ... FAILED
test result: FAILED. 5 passed; 2 failed
```

```
no_type_derives_debug_while_holding_raw_bytes:
  canonical.rs: `Canonicalized` derives Debug while holding `Vec<u8>` — a derived Debug
  renders that as a decimal byte dump.
```

Both guards fire independently.

**B — add a new byte-holding type with no fixture anywhere.** This is the case the fixtures structurally cannot cover.

```rust
#[derive(Clone, Debug, PartialEq, Eq)]
pub struct SessionTicket { pub issued_at_ms: u64, pub secret: [u8; 32] }
```

```
pow.rs: `SessionTicket` derives Debug while holding `[u8;` — ...
test result: FAILED. 0 passed; 1 failed
```

**C — the tuple-struct branch of the scanner.** No type in the crate currently exercises it, so I verified it is not dead code rather than assuming:

```rust
#[derive(Clone, Debug, PartialEq, Eq)]
pub struct RawTicket(pub alloc::vec::Vec<u8>);
```

```
pow.rs: `RawTicket` derives Debug while holding `Vec<u8>` — ...
test result: FAILED. 0 passed; 1 failed
```

All three mutations were reverted; the tree is clean.

## Sibling audit — every byte-holding type in the crate

Grepped every occurrence of `Vec<u8>`, `TlsByteVec*`, `[u8; N]` and `&[u8]` in a field position across all 11 source files.

| Type | File | Byte storage | `Debug` | Verdict |
|---|---|---|---|---|
| `Canonicalized<T>` | `canonical.rs` | `Vec<u8>` | **was derived** | **the defect — fixed here** |
| `QueueAddress`, `PublicKey`, `RelayId`, `ChannelBinding`, `Challenge`, `Digest` | `types.rs` | `[u8; 32]` | hand-written (macro, `types.rs:95`) | ok — `<redacted>` |
| `Signature` | `types.rs` | `[u8; 64]` | hand-written (same macro) | ok |
| `Nonce`, `Salt` | `types.rs` | `[u8; 16]` | hand-written (same macro) | ok |
| `Payload` | `types.rs:231` | `TlsByteVecU24` | hand-written | ok — length only |
| `Body` | `types.rs:305` | `TlsByteVecU24` | hand-written | ok — length only |
| `ShortBytes` | `types.rs:375` | `TlsByteVecU8` | hand-written | ok — printable ASCII escapes, non-printable redacts |
| `VecU8/U16/U24<T>` | `vec.rs:79` | `Vec<T>`, not bytes | hand-written, delegates to `T` | ok — elements are wire structs, each redacting |
| `PaddingBuckets` | `padding.rs:56` | `Vec<u32>` | derived | ok — published relay policy (§11.1), meant to be read |

`Canonicalized` was the **only** leak. No second fix was needed. Nine fixed-width newtypes, three variable-length ones, and the generic vectors are all correctly hand-written; the one remaining derived `Debug` over a collection holds public policy numbers, not bytes.

There are still no `Display` impls in the crate, so nothing leaks through a second formatter.

## Why I made it a control

The issue asks for this and I think it earns its place: the discipline had now been applied by hand twice, which makes it a convention rather than a control, and the failure mode is silence — a fixture-based guard only covers types someone remembered to write a fixture for. Mutation B is the whole argument: a new byte-holding type goes green forever under the fixtures and red immediately under the scan.

`no_type_derives_debug_while_holding_raw_bytes` walks `src/` (resolved from `CARGO_MANIFEST_DIR`, not the process CWD), finds every `#[derive(...)]` containing `Debug`, captures the struct or enum it applies to, and fails if the body mentions `Vec<u8>`, `[u8;`, `&[u8]`, `TlsByteVec` or `Box<[u8]>`.

It is a textual scan, so I want to be straight about the limits rather than oversell it:

- It handles multi-line derive lists (`PowParams`), attributes and doc comments between the derive and the item, braced and tuple/unit items, and strips line comments before counting braces so a brace in a field doc cannot desync the depth count.
- A syn-based scan would be more precise, but it would mean a dev-dependency and a lot of machinery for a crate of 11 rustfmt-formatted files. The textual scan catches the shape that actually occurs.
- The real risk with a scanner is that it silently stops matching and passes forever, so it is anchored: it asserts it found `RelayFrame` and more than 20 derive-`Debug` types, and it hard-fails if a `derive(Debug)` sits on an item it cannot parse rather than skipping it quietly. A parser regression is loud, not green.
- It checks all types, not only `pub` ones — a private type still renders inside a public `Debug`.

## Checks

| Check | Result |
|---|---|
| `cargo test --locked --all-targets` | 49 + 7 + 7 + 7 = **70** (was 49 + 7 + 5 + 7 = 68) |
| `cargo test --locked --doc` | 1 |
| total | **71** (was 69), +2 new tests |
| `cargo build --locked --lib --target wasm32-unknown-unknown -p f2z-codec` | ok |
| `scripts/check-rust-fmt.sh --root rs` | clean |
| `scripts/check-rust-clippy.sh --root rs` | clean |
| `scripts/check-rust-deny.sh --root rs --config rs/deny.toml` | advisories/bans/licenses/sources ok |

The `Debug` impl uses `core::fmt` and `format_args!` only — no `std`, no `unsafe`, `no_std` + `alloc` intact, and the wasm build confirms it.

Scoped to this defect: #564 (byte-level wire vectors) is untouched, and `.github/workflows/zuuli.yml` is untouched.
