### PR TITLE
docs(e2ee): replace §14 handle-charset unknowns with measured production facts

### DIFF
--- a/docs/e2ee/ARCHITECTURE.md
+++ b/docs/e2ee/ARCHITECTURE.md
@@ -1148,14 +1148,37 @@ deliberate.
   Messaging handles are `[a-z0-9_]{1,30}`, ASCII, so that homograph and
   mixed-script impersonation does not exist. free2z usernames are broader
   (`^[\w.@+-]+$`, up to 150 characters), so some existing accounts are not
-  eligible. **How many is not known** — this repository holds no user data — and
-  it must be measured before the rule ships, because it is the difference between
-  a rounding error and a migration project. Two sub-questions are also open:
-  whether the `Creator` model uses Django's Unicode or ASCII username validator
-  (undeterminable from this repository, and it decides whether the platform's
-  existing handle space already contains the homograph surface); and whether the
-  excluded population is served by a separate opt-in messaging handle, which is
-  directory design and touches §13-K.
+  eligible. **Measured 2026-08-24 — and still open**, because measurement was
+  never the whole question. What the measurement settled:
+  - **How many, closed.** **Approximately 90% of existing accounts are eligible
+    after case-folding and approximately 10% are not** — overwhelmingly because
+    the username contains `.` `@` `+` or `-`; non-ASCII characters and
+    over-length names account for very few. It is neither the rounding error nor
+    the migration project the question was framed around, and it is not a set of
+    dead rows: **every ineligible account has logged in at least once and all but
+    one is still active.** Absolute counts are business data and are deliberately
+    not published in this repository; they are recorded in the deployment
+    repository.
+  - **Which validator, closed.** `Creator(AbstractUser)` does not override
+    `username`; the field is recorded with
+    `UnicodeUsernameValidator`. **Non-ASCII usernames are legal on free2z today
+    and a small, non-zero number of accounts carry one** — so the platform's
+    existing handle space already contains the homograph surface, in the present
+    tense, as a property of the shipped product rather than a risk of a future one
+    ([`WIRE.md` §14.2](./WIRE.md#142-checked-against-free2zs-real-username-rules--measured),
+    [`THREAT-MODEL.md` §4.10](./THREAT-MODEL.md#410-the-platform-username-space-contains-homographs-messaging-handles-do-not)).
+  - **Still open — and it is a product decision, not a measurement.** Is that
+    ~10% of real users simply excluded from messaging discovery in v1, or are
+    they served by a separate opt-in messaging handle? The latter is directory
+    design and touches §13-K. Nobody has decided, so this stays open.
+  - **Surfaced by the measurement, and blocking.** Case-insensitive username
+    uniqueness is enforced only in two serializers, not in the database, and
+    **production holds case-variant duplicate accounts today, in more than one
+    group**. Those must
+    be resolved before the handle mapping ships; the correction and the intended
+    end state (a database-level `UniqueConstraint(Lower("username"))`) are in
+    [`WIRE.md` §14.3](./WIRE.md#143-the-decision-and-the-cost-accepted). The
+    backend work is tracked in the deployment repository.
 - **P. KT epoch cadence and maximum merge delay.** Opened 2026-08-23 by
   [`KT.md` §5](./KT.md#5-epochs-and-the-merge-promise). The values there — a
   600-second epoch published whether or not there is work, and a 3,600-second

--- a/docs/e2ee/THREAT-MODEL.md
+++ b/docs/e2ee/THREAT-MODEL.md
@@ -555,6 +555,36 @@ read, ACK or delete, and a sender-side key that cannot drain the queue. It is
 simply not unlinkability, and the earlier text in this document that said
 otherwise was wrong.
 
+### 4.10 The platform username space contains homographs; messaging handles do not
+
+Stated in the present tense because it is a property of the product as it ships
+today, not a risk of a future one. free2z usernames are validated by Django's
+`UnicodeUsernameValidator`, confirmed against the model's migration history, so
+non-ASCII usernames are legal and — measured on production 2026-08-24 — **a
+small, non-zero number of accounts carry one today**
+([`WIRE.md` §14.2](./WIRE.md#142-checked-against-free2zs-real-username-rules--measured)).
+For a threat model the count is beside the point; that it is not zero is the
+point.
+`@аlice` with a Cyrillic а and `@alice` with a Latin a are two different,
+equally valid, equally registerable free2z accounts right now. **The homograph
+attack surface in the platform's handle space is present, not hypothetical.**
+
+Messaging handles are `[a-z0-9_]{1,30}` compared as bytes
+([`WIRE.md` §14](./WIRE.md#14-handle-charset-for-messaging--blocking-pre-check-resolved)),
+so the KT directory's label space contains no confusable pairs and homograph
+impersonation **does not exist inside the messenger** — that is why the charset
+was restricted, and it is what makes the log's labels not homograph-attackable
+([`KT.md` §1.3](./KT.md#13-conventions)).
+
+What that does **not** do is fix the platform. A profile page, a comment byline
+or a link on free2z can still carry a homograph username, and a user who copies
+a handle from one of those surfaces into a contact search is relying on the
+platform's charset, not on ours. The mitigation is narrow and worth stating
+exactly: such a string does not match the messaging charset, so the directory
+refuses to resolve it at all, which turns a silent impersonation into a lookup
+failure. Making free2z's own username space safe is backend and product work,
+out of scope for this design, and **no property of it is claimed here**.
+
 ## 5. Summary: what we claim, precisely
 
 | Property | ZUULI (native) | Web (WASM) |

--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -1735,35 +1735,85 @@ which? is `ﬁ` `fi`? is `ı` `i`?), and a charset with no case, no scripts and 
 confusable pairs makes an entire class of homograph and mixed-script impersonation
 **not exist** rather than be defended against.
 
-### 14.2 Checked against free2z's real username rules
+### 14.2 Checked against free2z's real username rules — measured
 
 **This was checked before being written down**, and the answer is that real
-usernames are considerably broader.
+usernames are considerably broader. The first revision of this section flagged
+three things it could not settle from this repository — which username validator
+is attached, whether case-insensitive uniqueness is a database property, and how
+many existing accounts the rule excludes. **All three have since been measured**:
+the model and its migration history were read out of band, and the counts were
+run against the production database on **2026-08-24**. The findings below are
+facts, not conditionals.
+
+**On what this section reports.** No username or other user-identifying value
+appears here, and neither do free2z's absolute user metrics: this is a public
+repository, and account totals are business data rather than protocol data.
+Findings are given as **proportions and categories** — which is the form the
+design decision actually rests on, since what matters is *what fraction* of
+existing accounts the rule excludes, not how many accounts exist. The precise
+figures behind every proportion below are recorded in the deployment repository.
 
 | Source | Finding |
 |---|---|
 | `py/dj/free2z/openapi/f2z.yaml` — `Registration`, `CreatorDetail`, `CreatorList`, `CommentAuthor` | `username` is `type: string`, **`pattern: ^[\w.@+-]+$`**, **`maxLength: 150`**, described as *"Letters, digits and @/./+/-/_ only."* This is Django's `AbstractUser.username` contract. |
-| `py/dj/free2z/settings.py:29` | `AUTH_USER_MODEL = 'g12f.Creator'`. **The `Creator` model itself is not present in this repository** — only serializers and views are — so which of Django's two username validators is attached **cannot be determined here**. |
-| `py/dj/apps/g12f/serializers/creator.py` | Uniqueness is enforced **case-insensitively** at the application layer (`Creator.objects.filter(username__iexact=...)`, in `RegistrationSerializer.validate_username` and `CreatorProfileUpdateSerializer.validate_username`). `FORBIDDEN_USERNAMES` additionally reserves route-shadowing names. |
+| `py/dj/free2z/settings.py:29` | `AUTH_USER_MODEL = 'g12f.Creator'`. The `Creator` model itself is not present in this repository — only serializers and views are — so the validator cannot be read *here*. **Determined out of band, 2026-08-24:** `Creator(AbstractUser)` does **not** override `username`; the initial migration records the field as `max_length=150, unique=True, validators=[django.contrib.auth.validators.UnicodeUsernameValidator()]`. **The Unicode validator is the one in use.** |
+| `py/dj/apps/g12f/serializers/creator.py` | Uniqueness is enforced **case-insensitively at the application layer only** (`Creator.objects.filter(username__iexact=...)`, in `RegistrationSerializer.validate_username` and `CreatorProfileUpdateSerializer.validate_username`). `FORBIDDEN_USERNAMES` additionally reserves route-shadowing names. **Determined out of band, 2026-08-24:** nothing backs this in the database — see the correction in §14.3. |
 | `py/dj/apps/g12f/views/creator.py` | Reads are `username__iexact` (`lookup_field = "username__iexact"`; `get_object_or_404(Creator, username__iexact=...)`). |
 | `ts/svelte/free2z/src/routes/[username]/+page.svelte` | Handles are rendered verbatim as `@{creator.username}` and URL-encoded into paths. The front end applies **no** narrower rule. |
 | `ts/svelte/free2z/src/routes/[username]/dashboard/billing/+page.server.ts` | Contains `USERNAME_PATTERN = /^[a-zA-Z0-9_]{1,64}$/`, but this validates a subscription-target parameter in one dashboard action — it is not the registration rule, and it is already **narrower than what registration accepts**, so accounts with `.`/`@`/`+`/`-` in their name cannot use that page today. |
+| Production database, 2026-08-24 | The eligibility proportions below. |
 
 Two things follow, and the second is the one that matters most:
 
 1. **The published contract is broader than `[a-z0-9_]{1,30}` on every axis**:
    uppercase is allowed, `.` `@` `+` `-` are allowed, and the length limit is 150
    rather than 30.
-2. **Whether non-ASCII is allowed is genuinely undetermined from this
-   repository.** `\w` in Python's `re` is Unicode-aware on `str` unless `re.ASCII`
-   is set. Django's `UnicodeUsernameValidator` (the default on `AbstractUser`)
-   leaves it Unicode-aware and therefore admits Cyrillic, Greek, full-width Latin
-   and mixed-script handles; `ASCIIUsernameValidator` does not. The OpenAPI
-   schema emits the same `^[\w.@+-]+$` for both, so the schema cannot settle it.
-   **This MUST be confirmed against the `Creator` model before the rule is
-   enforced.** If the Unicode validator is in use, the platform's handle space
-   today already contains the homograph attack surface, and that is a finding
-   about the existing product, not only about messaging.
+2. **Non-ASCII usernames are legal on free2z today, and accounts with one exist
+   in production.** `\w` in Python's `re` is Unicode-aware on `str` unless
+   `re.ASCII` is set, and
+   `UnicodeUsernameValidator` — confirmed above as the validator actually
+   attached — leaves it Unicode-aware. Cyrillic, Greek, full-width Latin and
+   mixed-script usernames are accepted at registration, and a small number of
+   accounts carry one today — the number is small but it is **not zero**, which
+   is the only part of it that matters.
+   **The platform's handle space already contains the homograph attack surface.**
+   This is stated in the present tense on purpose: it is a finding about the
+   existing product, not a conditional about messaging. `@аlice` with a Cyrillic
+   а and `@alice` with a Latin a are two different, equally valid, equally
+   registerable free2z accounts right now.
+
+#### Eligibility, measured on production 2026-08-24
+
+Eligibility is evaluated as `lowercase(username) matches /^[a-z0-9_]{1,30}$/`
+(§14.3).
+
+| Of all existing accounts | Share |
+|---|---:|
+| Eligible after case-folding | **~90%** |
+| **Ineligible** | **~10%** |
+
+Which properties the population carries — these overlap, and each share is of
+**all existing accounts**, not of the ineligible subset:
+
+| Property | Prevalence | Disqualifying? |
+|---|---|---|
+| Contains an uppercase letter | A little over half of all accounts | **No** — folded by the mapping |
+| Contains `.`, `@`, `+` or `-` | Just under a tenth of all accounts — **the dominant cause of ineligibility** | Yes |
+| Contains a non-ASCII character | A small number of accounts, and not zero | Yes |
+| Longer than 30 characters | Vanishingly rare | Yes |
+
+The three disqualifying properties overlap in only a single account, so their
+shares are effectively additive and the punctuation rule is almost the whole of
+the exclusion. Uppercase is by far the most common deviation from the messaging
+charset and it costs nobody a handle, which is the entire reason the mapping
+folds case — but see §14.3, where the *argument* originally given for folding
+case turns out to be false.
+
+**These are not abandoned rows.** **Every ineligible account has logged in at
+least once**, and all but one are **currently active**. Every account the rule
+excludes belongs to a real person who has used the product — which is the finding
+that turns this from a data-cleanup question into a product one.
 
 ### 14.3 The decision, and the cost accepted
 
@@ -1777,7 +1827,8 @@ lowercase(username) matches /^[a-z0-9_]{1,30}$/
 The lowercase mapping is included deliberately: because platform uniqueness is
 already enforced case-insensitively, folding case **cannot** introduce a
 collision between two distinct existing accounts — so uppercase costs nobody
-their handle and there is no reason to exclude it.
+their handle and there is no reason to exclude it. — **This argument is false as
+written; see the correction below.**
 
 **Caveat, and it must be checked before this is relied on:** that argument holds
 only if case-insensitive uniqueness actually holds *in the database*. It is
@@ -1788,18 +1839,68 @@ a social-login path that bypasses the serializer — **cannot be established fro
 this repository and must be settled with a query.** Any colliding pair must be
 resolved by hand before the mapping ships.
 
+> **Correction (2026-08-24) — the case-folding argument above is false, and the
+> property it rests on does not hold.** The two paragraphs above are left
+> standing rather than edited away, so an auditor can see exactly what was
+> claimed and what replaced it. The claim was that folding case *"cannot
+> introduce a collision between two distinct existing accounts"* **because**
+> platform uniqueness is already enforced case-insensitively. The caveat was
+> right to flag it and the query has now been run. It settles the question the
+> other way.
+>
+> **Case-insensitive uniqueness is not a database property.** The `username`
+> column carries a plain, case-**sensitive** `unique=True` and nothing else: no
+> migration adds a `Lower("username")` functional index, no `UniqueConstraint`,
+> no `citext` column. The case-insensitive check exists **only** in
+> `RegistrationSerializer.validate_username` and
+> `CreatorProfileUpdateSerializer.validate_username`. It is therefore an
+> application convention, not an invariant — any path that does not pass through
+> those two serializers (the admin, a data migration, a management command, a
+> social-login flow) can create a case-variant duplicate, and the database will
+> accept it.
+>
+> **And it has.** Measured on production 2026-08-24: **case-variant duplicate
+> accounts exist today, in more than one group.** The count is small and is
+> recorded in the deployment repository rather than here; the count is not the
+> finding. **The existence is the finding**, because a single colliding pair is
+> enough to make the claim above false. Folding case *does* collide two distinct
+> existing accounts.
+>
+> **What survives and what does not.** The *decision* is unchanged: messaging
+> handles use the restricted charset and eligibility is evaluated on the
+> lowercased username. Uppercase on its own still disqualifies nobody — a little
+> over half of all accounts carry an uppercase letter and none is excluded for
+> that reason (§14.2). What does not survive is the claim that the mapping is
+> free. It is not: **every account in those collision groups must be resolved by
+> hand before the mapping ships**, because within each group two distinct
+> accounts map to one messaging handle and the directory would otherwise have to
+> pick a winner — in the one mapping whose integrity the whole system rests on.
+> The clean end state is a database-level `UniqueConstraint(Lower("username"))`,
+> so that the property the serializers already assume is actually enforced where
+> it can be relied on. That constraint and the resolution of the colliding
+> accounts are tracked in the deployment repository; they are backend work and
+> are not specified here.
+
 **Accepted product cost, stated plainly.** Existing accounts whose username
 contains `.`, `@`, `+` or `-`, contains any non-ASCII character, or exceeds 30
 characters after lowercasing are **not eligible for a messaging handle in v1**.
 Those users can use free2z exactly as they do today; they cannot be discovered by
 handle in the messenger until they have a compliant handle.
 
-**How large is that population? We do not know.** This repository holds no user
-data and the count cannot be estimated from it. **The number MUST be measured
-before the rule ships**, because it is the difference between a rounding error
-and a migration project, and discovering which one it is at launch is not
-acceptable. Recorded as
-[`ARCHITECTURE.md` §13-O](./ARCHITECTURE.md#13-open-questions).
+**How large is that population? Measured 2026-08-24: approximately 10% of
+existing accounts.** The first revision of this section said the number "MUST be
+measured before the rule ships, because it is the difference between a rounding
+error and a migration project." The answer is neither, and that is the awkward
+result. It is about one account in ten, and **every ineligible account has logged
+in at least once, with all but one still active** — they are real users, not
+abandoned rows (§14.2). A rounding error would need no decision; a migration
+project would force one. This forces a *product* decision instead: exclude that
+~10% from messaging discovery in v1, or serve them with the separate opt-in
+messaging handle deferred in §14.4. That decision is not made here, so
+[`ARCHITECTURE.md` §13-O](./ARCHITECTURE.md#13-open-questions) **stays open** —
+its measurement sub-questions are closed, its policy sub-question is not.
+(Absolute counts are deliberately not published here; they are in the deployment
+repository.)
 
 ### 14.4 Alternatives rejected
 
@@ -1914,7 +2015,12 @@ Deliberately, and listed rather than invented:
 - **Proof-of-work function and calibration** —
   [§13-N](./ARCHITECTURE.md#13-open-questions), opened by §12.4.
 - **Messaging-handle eligibility for existing accounts** —
-  [§13-O](./ARCHITECTURE.md#13-open-questions), opened by §14.3.
+  [§13-O](./ARCHITECTURE.md#13-open-questions), opened by §14.3. **Measured
+  2026-08-24 and still open**: the measurement is in (approximately 10% of
+  existing accounts are ineligible, and all of them are real users), so the
+  measurement sub-question is closed; whether those users are simply excluded
+  from messaging discovery in v1 or given a separate opt-in messaging handle is a
+  product decision nobody has made.
 
 ---
 


### PR DESCRIPTION
`WIRE.md` §14 specified the messaging handle charset and flagged three things as MUST-confirm-before-relying-on, because they could not be determined from this public repository. **All three have now been determined** — the username validator from the `Creator` model's migration history, and the eligibility and collision measurements against the production database on **2026-08-24**. This PR replaces the uncertainty with the facts and fixes what the facts contradict.

Docs only. **No code, crates, or workflows.**

## On what is and is not published here

`zuu` is public and public history is a one-way ratchet, so **free2z's absolute account metrics are deliberately not in this diff, this description, or the commit message.** Account totals are business data, not protocol data. Findings are given as **proportions and categories**, which is the form the design decision actually rests on — what matters is *what fraction* of existing accounts the rule excludes, not how many accounts exist. Note also that a percentage plus any single absolute count reconstructs a total exactly, so neither form is used anywhere. The precise figures are recorded in the deployment repository. No username or other user-identifying value appears anywhere.

## What changed

### `WIRE.md` §14.2 — now a measurement, not a conditional

- The validator is **`UnicodeUsernameValidator`** (`Creator(AbstractUser)` does not override `username`). So **non-ASCII usernames are legal on free2z today, and a small but non-zero number of accounts carry one.** The old conditional ("*if* the Unicode validator is in use, the platform's handle space already contains the homograph attack surface") is now unconditional and stated in the present tense as a finding about the shipped product.
- Adds the measured eligibility proportions: **~90% of existing accounts eligible after case-folding, ~10% not**, with a qualitative prevalence table showing that punctuation (`.@+-`) is the dominant cause of ineligibility, non-ASCII and over-length names are rare, and uppercase — the most common deviation of all — costs nobody a handle because the mapping folds case.
- The material point: **every ineligible account has logged in at least once, and all but one is still active.** Real users, not abandoned rows.

### `WIRE.md` §14.3 — the case-folding argument was false; dated correction added

§14.3 argued that folding case *cannot* collide two distinct existing accounts **because** platform uniqueness is enforced case-insensitively, and correctly caveated that this holds only if the property is real in the database.

**It is not real, and the query settles it the other way.** The column has a plain case-**sensitive** `unique=True`; no migration adds a `Lower("username")` functional index, a `UniqueConstraint`, or `citext`. The check exists only in `RegistrationSerializer.validate_username` and `CreatorProfileUpdateSerializer.validate_username`, so any path bypassing them (admin, data migration, management command, social login) can create a case-variant duplicate — **and production holds such duplicates today, in more than one group.** The existence is the finding; a single colliding pair is enough to falsify the argument, so the count adds nothing and is not published.

Handled with a dated correction block in the style of `ARCHITECTURE.md` §4.9 / §5.4 and ADR 0007 — **the original claim is left standing with a pointer, not silently rewritten**. The *decision* (fold case) survives; the claim that it is free does not. Every colliding account must be resolved by hand before the mapping ships, and the clean end state is a DB-level `UniqueConstraint(Lower("username"))`, tracked in the deployment repository.

### `ARCHITECTURE.md` §13-O — measured, and **still open**

Restructured with the measurement. Two sub-questions are marked **closed** (what fraction; which validator). The question itself **stays open**, and the bullet says why: the *policy* question is unanswered and is a product decision — is that ~10% of real users simply excluded from messaging discovery in v1, or served by a separate opt-in messaging handle (§13-K)? A fourth sub-bullet records the case-collision blocker surfaced by the measurement.

### `THREAT-MODEL.md` §4.10 — new known limit (consistency)

The threat model did not mention homographs at all, which now reads as an omission: the surface is present in the shipped product. New §4.10 states it in the present tense, notes the messaging charset makes the attack not exist *inside* the messenger, and is explicit that this **does not fix the platform** — a homograph username can still appear on a profile page or comment byline. The mitigation is narrow and stated exactly (a non-conforming string does not resolve, so silent impersonation becomes a lookup failure), and no property of free2z's own username space is claimed.

## Checks

- `scripts/check-public-repo-boundary.sh` passes; private tracking is referred to obliquely ("the deployment repository"), no private repo named, no private issue linked.
- All new cross-document anchors verified against their target headings.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
