### PR TITLE
test(zuuli): stop git's detached maintenance racing the screenshot-contract teardown

### DIFF
--- a/wallet/zuuli/scripts/store-screenshot-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/store-screenshot-contract.node-test.mjs
@@ -58,10 +58,34 @@ async function rejectsCode(operation, code) {
   await assert.rejects(operation, (error) => error instanceof ScreenshotContractError && error.code === code);
 }
 
+// Keep every fixture `git` call strictly foreground. `git commit` otherwise runs
+// `git maintenance run --auto --detach`, which git deliberately daemonizes: it
+// outlives the child we await and then creates `.git/objects/maintenance.lock`
+// — measured at ~23ms after `git commit` had already returned (Linux, git
+// 2.43). The recursive teardown below is descending `.git/objects` at exactly
+// that moment, so its closing rmdir finds the directory non-empty and fails
+// ENOTEMPTY, reddening the required gate on a green change (issue #561).
+// GIT_CONFIG_COUNT applies the guard with no config file and no repo state, so
+// it covers `git init` before any repo exists. Do not simplify this env away.
+const GIT_FIXTURE_ENV = Object.freeze({
+  GIT_CONFIG_COUNT: "2",
+  GIT_CONFIG_KEY_0: "gc.auto",
+  GIT_CONFIG_VALUE_0: "0",
+  GIT_CONFIG_KEY_1: "maintenance.auto",
+  GIT_CONFIG_VALUE_1: "false",
+});
+
+// Backstop for the same failure class: `fs.rm` defaults to `maxRetries: 0`, and
+// `force` suppresses ENOENT, not ENOTEMPTY. Retrying absorbs any future
+// concurrent writer the env guard above does not already prevent.
+function removeGitFixture(root) {
+  return rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+}
+
 async function git(root, args) {
   const output = [];
   await new Promise((accept, reject) => {
-    const child = spawn("git", args, { cwd: root });
+    const child = spawn("git", args, { cwd: root, env: { ...process.env, ...GIT_FIXTURE_ENV } });
     child.stdout.on("data", (chunk) => output.push(chunk));
     child.on("error", reject);
     child.on("exit", (code) => code === 0 ? accept() : reject(new Error(`git ${args[0]} failed`)));
@@ -202,7 +226,7 @@ test("capture inputs cannot be symlinks", async (t) => {
 
 test("capture rejects every local Vite or npm override, including ignored npm config", async (t) => {
   const root = await fixture();
-  t.after(() => rm(root, { recursive: true, force: true }));
+  t.after(() => removeGitFixture(root));
   await assertNoLocalCaptureOverrides(root);
   const cleanDigest = await computeCaptureSourceDigest(root);
   await git(root, ["init", "-q"]);
@@ -311,7 +335,7 @@ test("capture artifact commit preserves a concurrent manifest edit", async (t) =
 
 test("source comparison includes untracked render inputs", async (t) => {
   const root = await fixture();
-  t.after(() => rm(root, { recursive: true, force: true }));
+  t.after(() => removeGitFixture(root));
   await git(root, ["init", "-q"]);
   await git(root, ["config", "user.name", "Capture Contract"]);
   await git(root, ["config", "user.email", "capture-contract@example.invalid"]);


### PR DESCRIPTION
Closes #561

## What the flake is

`frontend` failed on PR #556's merge-only head with:

```
[Error: ENOTEMPTY: directory not empty, rmdir '/tmp/zuuli-screenshot-contract-IilLBc/.git/objects']
```

The CI log pins it to exactly one test — `source comparison includes untracked render inputs`, the only one that runs `git commit` — with every assertion green and the failure entirely in `t.after`.

## Mechanism, as measured

The issue guessed "background `git gc` writes loose objects". The direction was right, the writer was not — and the difference matters, because the fixture has ~230 loose objects and `gc.auto` needs >27 in the `objects/17` fanout (≈6700 total) before it repacks anything. gc would never have fired. Measured on Linux (`ubuntu:24.04`, git 2.43, i.e. CI's platform, not the macOS dev box):

**1. `git commit` leaves a git process running after the awaited child exits.** `GIT_TRACE` on the fixture sequence:

```
trace: run_command: git maintenance run --auto --quiet --detach
```

`--detach` is git's own choice; it daemonizes. In the `GIT_TRACE2_EVENT` stream the maintenance process's final `exit`/`atexit` land *after* `git commit`'s own `exit`/`atexit` — the `await` in the `git` helper has already resolved.

**2. That detached process creates a file directly inside `.git/objects`, even though gc does nothing.** `inotifywait -m -r` on `.git/objects`, timestamps relative to the instant `git commit` returned:

```
== no guard ==
  .git/objects/maintenance.lock CREATE         (+0.0229s after git commit returned)
  .git/objects/maintenance.lock OPEN           (+0.0234s)
  .git/objects/maintenance.lock CLOSE_WRITE    (+0.0318s)
  .git/objects/maintenance.lock DELETE         (+0.0324s)
== with the env guard ==
  maintenance.lock events under .git/objects: 0
```

`strace -f` confirms a *different* pid does it: `openat(".../.git/objects/maintenance.lock", O_RDWR|O_CREAT|O_EXCL)`. So the concurrent writer is git's **maintenance lock**, which is taken on every commit regardless of gc thresholds — not a repack.

**3. A concurrent writer in `.git/objects` produces exactly this error under the current teardown, and `maxRetries` absorbs it.** Node 24 on Linux, 200-entry `objects/` dir, writer churning `objects/maintenance.lock`:

```
rm(recursive, force)                                 → 30 iterations, 22 ENOTEMPTY
rm(recursive, force, maxRetries: 10, retryDelay: 50) → 30 iterations,  0 ENOTEMPTY
```

**4. The fix removes the cause on the real code path.** `GIT_TRACE` written to a file (the helper pipes and discards stderr, so tracing to stderr shows nothing), running the actual test file:

```
BEFORE (origin/main): 16 git invocations, 1 `maintenance run --auto` spawn
AFTER  (this branch): 15 git invocations, 0 `maintenance run --auto` spawns
```

## The change

- `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n` set `gc.auto=0` and `maintenance.auto=false` for every fixture `git` call. No config file, no repo state, so it also covers `git init` before a repo exists. **This removes the cause.**
- `maxRetries: 10, retryDelay: 50` on the two git-using teardowns, as a backstop against a future concurrent writer. `force` suppresses ENOENT, not ENOTEMPTY, and `maxRetries` defaults to `0`.
- A comment recording the mechanism, so the env is not "simplified" away later.

## What is not proven

- **The end-to-end flake was not reproduced.** 50 runs of the pre-fix test file (30 idle + 20 under 12x CPU load) all passed. A ~30ms race on a loaded hosted runner does not reproduce on demand, and a green run cannot prove a race is gone. The claim here is narrower and each link is measured: git leaves a detached process writing into `.git/objects` after the awaited child exits (1,2); such a writer makes this exact `rm` call fail ENOTEMPTY (3); the fix stops the process from being spawned at all (4).
- **The precise CI interference pattern is not pinned down.** A single transient lock create/delete injected mid-`rm` was absorbed by Node's own ENOTEMPTY handling in 40/40 trials; only a sustained writer reproduced the error. So the observed CI failure implies harsher scheduling skew than the minimal model. Both the guard and the backstop are justified regardless of which end of that spectrum CI hit.

## Regression checks

- `npm run test:store-listing` (the CI step that runs this test): 56/56 pass.
- `npm run store:validate`, `npm run typecheck`: clean.
- `npm run test` (full `frontend` test command): 327/327 node+vitest pass; 2 Playwright viewport/touch-target tests hit the 60s timeout on this loaded laptop and both pass on re-run in isolation (12/12) — unrelated files, no git or temp-dir involvement.
- The test file is not in `CAPTURE_INPUTS`, so no capture digest moves.
- No workflow files touched; `.github/workflows/zuuli.yml`'s `changes` policy step is untouched.
- **#477 shell hygiene: 0 bare `[[ ]]` / `(( ))` statements added** — this PR adds no shell at all.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
