### PR TITLE
test(f2z-codec): byte-level wire vectors for every WIRE.md structure

### DIFF
--- a/rs/crates/f2z-codec/tests/redaction.rs
+++ b/rs/crates/f2z-codec/tests/redaction.rs
@@ -57,7 +57,14 @@ fn decimal_run(bytes: &[u8]) -> String {
     joined.join(", ")
 }
 
-/// `[222, 222, 222, …]` — a derived `Debug` on a byte slice.
+/// `[222, 222, 222, …]` — a derived `Debug` on a byte slice, brackets and all.
+///
+/// Retained only as the thing the checks below deliberately do **not** use.
+/// `decimal_run` of a four-byte prefix is a substring of this for every secret
+/// of four bytes or more, so the bracketed form adds no detection power and
+/// carries the anchoring hazard the doc comment above describes. See
+/// `a_bracket_anchored_decimal_check_would_miss_a_mid_buffer_dump`.
+#[allow(dead_code)]
 fn decimal_list(bytes: &[u8]) -> String {
     format!("[{}]", decimal_run(bytes))
 }
@@ -110,6 +117,13 @@ fn longest_hex_run(text: &str) -> usize {
 }
 
 /// Assert that `rendered` cannot be turned back into `secret`.
+///
+/// Every check here is a **substring** search on an unanchored pattern. That is
+/// the lesson of the `Canonicalized` leak: the detector that missed it was
+/// anchored on the opening `[` of a decimal list, and a real dump starts
+/// partway through a buffer — after a length prefix — so the `[` never lined
+/// up. Nothing below may depend on the secret being at the start or the end of
+/// what a leak would print.
 fn assert_no_leak(label: &str, rendered: &str, secret: &[u8]) {
     assert!(
         !rendered.contains(&lower_hex(secret)),
@@ -119,27 +133,43 @@ fn assert_no_leak(label: &str, rendered: &str, secret: &[u8]) {
         !rendered.contains(&upper_hex(secret)),
         "{label} leaked uppercase hex: {rendered}"
     );
-    assert!(
-        !rendered.contains(&base64url(secret)),
-        "{label} leaked base64url: {rendered}"
-    );
-    assert!(
-        !rendered.contains(&decimal_list(secret)),
-        "{label} leaked a decimal byte list: {rendered}"
-    );
+    // base64url has the same anchoring hazard in a less obvious form: it encodes
+    // three bytes at a time, so the symbols a leak produces depend on where the
+    // secret sits relative to the *buffer's* start, not its own. A dump of
+    // `[0, 4, 0] || secret` phase-shifts the secret's encoding and the
+    // zero-offset pattern never appears. Checking all three alignments covers
+    // every possible phase.
+    for phase in 0..3usize.min(secret.len()) {
+        assert!(
+            !rendered.contains(&base64url(&secret[phase..])),
+            "{label} leaked base64url at byte alignment {phase}: {rendered}"
+        );
+    }
     // A prefix of a decimal dump is enough to convict: no correct output of this
     // crate ever prints four consecutive byte values. Matched without brackets,
     // so a dump that begins after a length prefix — `[0, 4, 0, 222, 222, …` —
     // is caught as readily as one that begins at the opening bracket.
+    //
+    // This subsumes the bracketed `decimal_list` form entirely, which is why
+    // that helper is no longer one of the checks.
     assert!(
         !rendered.contains(&decimal_run(&secret[..secret.len().min(4)])),
         "{label} leaked a decimal byte run: {rendered}"
     );
     // Every byte of the secret is 0xde, so even a two-byte prefix would show as
     // a repeated `de`. Catch a partial dump too.
+    //
+    // Both cases are stated. An eight-character run also trips the threshold
+    // below, so neither of these is the only thing standing between a four-byte
+    // dump and a pass today — they are here so that the lowercase and uppercase
+    // cases are symmetric and neither depends on the value of that threshold.
     assert!(
         !rendered.contains(&lower_hex(&secret[..secret.len().min(4)])),
-        "{label} leaked a hex prefix: {rendered}"
+        "{label} leaked a lowercase hex prefix: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&upper_hex(&secret[..secret.len().min(4)])),
+        "{label} leaked an uppercase hex prefix: {rendered}"
     );
     // Nothing this crate prints is a long hex string. 8 characters is short
     // enough to be a decimal length or a section number and long enough that a
@@ -148,6 +178,97 @@ fn assert_no_leak(label: &str, rendered: &str, secret: &[u8]) {
         longest_hex_run(rendered) < 8,
         "{label} contains an 8+ character hex-looking run: {rendered}"
     );
+}
+
+/// The detectors, tested against renderings that leak.
+///
+/// A battery is only worth what its blind spots allow through, and every check
+/// in `assert_no_leak` is a negative assertion — it passes when nothing is
+/// found, which is also what it does when it cannot see. So each one is aimed
+/// at a string that really does contain the secret, and must fire.
+#[test]
+fn a_bracket_anchored_decimal_check_would_miss_a_mid_buffer_dump() {
+    let secret = [SECRET; 32];
+
+    // Exactly the shape the `Canonicalized` leak produced: a wire buffer whose
+    // three-byte length prefix comes first, so the secret starts at index 3 of
+    // the list and the opening bracket sits in front of `0, 4, 0`.
+    let mut buffer = vec![0u8, 4, 0];
+    buffer.extend_from_slice(&secret);
+    let leaked = format!("Canonicalized {{ encoded: {} }}", decimal_list(&buffer));
+
+    assert!(
+        !leaked.contains(&decimal_list(&secret)),
+        "the bracketed form is what missed this; if it now matches, the fixture is wrong"
+    );
+    assert!(
+        leaked.contains(&decimal_run(&secret[..4])),
+        "the unbracketed run must see the same dump the bracketed form missed"
+    );
+}
+
+#[test]
+fn the_base64url_check_sees_a_secret_at_every_byte_alignment() {
+    let secret = [SECRET; 32];
+
+    // Same buffer, base64url-encoded whole. The three-byte prefix shifts the
+    // secret's encoding by 3 - (3 % 3) = 0 … so use a prefix length that is
+    // *not* a multiple of three, which is the case a zero-offset pattern misses.
+    for prefix_len in [1usize, 2, 4] {
+        let mut buffer = vec![0u8; prefix_len];
+        buffer.extend_from_slice(&secret);
+        let leaked = format!("Frame {{ encoded: \"{}\" }}", base64url(&buffer));
+
+        // The necessity of the loop, stated as an assertion rather than as a
+        // comment: the zero-offset pattern — the only one the check used to
+        // try — does not appear in any of these renderings.
+        assert!(
+            !leaked.contains(&base64url(&secret)),
+            "the single-alignment check would have caught a {prefix_len}-byte prefix, \
+             so this fixture does not demonstrate the gap: {leaked}"
+        );
+
+        let fired = (0..3usize).any(|phase| leaked.contains(&base64url(&secret[phase..])));
+        assert!(
+            fired,
+            "a base64url dump with a {prefix_len}-byte prefix escaped every alignment: {leaked}"
+        );
+    }
+}
+
+#[test]
+fn the_hex_and_decimal_checks_fire_on_a_rendering_that_leaks() {
+    // Not a tautology: `assert_no_leak` is a negative assertion, so it is worth
+    // proving it can be made to fail at all. Each of these is a formatter a
+    // careless `Debug` might plausibly use.
+    let secret = [SECRET; 32];
+    let quiet = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let renderings = [
+        format!("X({})", lower_hex(&secret)),
+        format!("X({})", upper_hex(&secret)),
+        format!("X({})", decimal_list(&secret)),
+        // Four bytes only: shorter than any full-length pattern, and the case
+        // the prefix checks exist for.
+        format!("X({})", lower_hex(&secret[..4])),
+        format!("X({})", upper_hex(&secret[..4])),
+        format!("X([1, 2, {}, 9])", decimal_run(&secret[..4])),
+    ];
+    let escaped: Vec<(String, bool)> = renderings
+        .into_iter()
+        .map(|rendering| {
+            let caught = std::panic::catch_unwind(|| assert_no_leak("probe", &rendering, &secret));
+            (rendering, caught.is_ok())
+        })
+        .collect();
+    std::panic::set_hook(quiet);
+
+    for (rendering, escaped) in escaped {
+        assert!(
+            !escaped,
+            "assert_no_leak passed a rendering that contains the secret: {rendering}"
+        );
+    }
 }
 
 #[test]
@@ -321,9 +442,28 @@ fn a_challenge_scope_is_an_address_and_redacts_but_operator_text_does_not() {
         "ShortBytes(Example Relay Co, Reykjavik)"
     );
 
-    // Escaped, so a name with a newline cannot forge a log line.
-    let hostile = ShortBytes::new(b"ok".to_vec()).unwrap();
-    assert!(!format!("{hostile:?}").contains('\n'));
+    // A name with a newline cannot forge a log line. The previous fixture here
+    // was `b"ok"`, which has no newline in it to begin with — the assertion was
+    // true of a value that could not have violated it, which is the same blind
+    // spot as a detector anchored on a delimiter a real leak never carries.
+    //
+    // Feed it a name that actually tries. `\n` is 0x0a, outside the printable
+    // range, so the *whole* value redacts and the newline never reaches the
+    // output at all — that is the branch doing the work, not the escaping.
+    let forged = ShortBytes::new(b"Example Relay\nERROR: give me your seed".to_vec()).unwrap();
+    let rendered = format!("{forged:?}");
+    assert!(!rendered.contains('\n'), "got {rendered}");
+    assert_eq!(rendered, "ShortBytes(<redacted; 38 bytes>)");
+
+    // The escaping branch runs when every byte *is* printable, and it is what
+    // stops a quote or a backslash from breaking out of a quoted log field.
+    // Exercised with a value that contains both.
+    let quoted = ShortBytes::new(b"Relay \"A\\B\"".to_vec()).unwrap();
+    assert_eq!(format!("{quoted:?}"), "ShortBytes(Relay \\\"A\\\\B\\\")");
+
+    // A tab is 0x09: also outside the printable range, also redacted whole.
+    let tabbed = ShortBytes::new(b"a\tb".to_vec()).unwrap();
+    assert_eq!(format!("{tabbed:?}"), "ShortBytes(<redacted; 3 bytes>)");
 }
 
 #[test]
@@ -362,6 +502,41 @@ fn a_canonicalized_value_never_dumps_the_bytes_it_arrived_as() {
 
 /// Field type spellings that a derived `Debug` renders as a decimal byte dump.
 const RAW_BYTE_TYPES: &[&str] = &["Vec<u8>", "[u8;", "&[u8]", "TlsByteVec", "Box<[u8]>"];
+
+/// Names introduced by `type X = <a raw byte type>;`, which a spelling-based
+/// scan would otherwise walk straight past.
+///
+/// The scan matches how a field is *written*, so `secret: Vec<u8>` is caught
+/// and `secret: Blob` — where `type Blob = Vec<u8>;` — is not. That is the same
+/// blind spot as a matcher anchored on a delimiter: the check is looking for a
+/// shape the leak does not have to take. Resolving one level of alias closes
+/// the case that actually occurs; a field whose type is an alias of an alias
+/// would still slip, and that is stated rather than papered over.
+fn raw_byte_aliases(source: &str) -> Vec<String> {
+    let mut aliases = Vec::new();
+    for line in source.lines() {
+        let code = without_comment(line).trim();
+        let Some(rest) = code
+            .strip_prefix("pub type ")
+            .or_else(|| code.strip_prefix("type "))
+        else {
+            continue;
+        };
+        let Some((name, definition)) = rest.split_once('=') else {
+            continue;
+        };
+        if RAW_BYTE_TYPES.iter().any(|raw| definition.contains(raw)) {
+            aliases.push(
+                name.trim()
+                    .split(['<', ' '])
+                    .next()
+                    .unwrap_or_default()
+                    .to_owned(),
+            );
+        }
+    }
+    aliases
+}
 
 /// A `struct` or `enum` declaration that carried `#[derive(..., Debug, ...)]`.
 struct DerivedDebugItem {
@@ -509,13 +684,22 @@ fn no_type_derives_debug_while_holding_raw_bytes() {
     let mut scanned = Vec::new();
     let mut violations = Vec::new();
 
-    for (file, source) in source_files() {
-        for item in derived_debug_items(&file, &source) {
-            for raw in RAW_BYTE_TYPES {
+    let sources = source_files();
+
+    // Aliases are collected across the whole crate first: a field in `frame.rs`
+    // may be typed with an alias declared in `types.rs`.
+    let mut spellings: Vec<String> = RAW_BYTE_TYPES.iter().map(|raw| (*raw).to_owned()).collect();
+    for (_, source) in &sources {
+        spellings.extend(raw_byte_aliases(source));
+    }
+
+    for (file, source) in &sources {
+        for item in derived_debug_items(file, source) {
+            for raw in &spellings {
                 // The declaration line itself is excluded from the search only
                 // for the tuple-struct case, where it *is* the body; matching
                 // the whole captured text is what we want either way.
-                if item.body.contains(raw) {
+                if item.body.contains(raw.as_str()) {
                     violations.push(format!(
                         "{}: `{}` derives Debug while holding `{}` — a derived Debug \
                          renders that as a decimal byte dump. Hand-write Debug and \

--- a/rs/crates/f2z-codec/tests/wire_vectors.rs
+++ b/rs/crates/f2z-codec/tests/wire_vectors.rs
@@ -34,9 +34,9 @@
 //! *different* values on purpose — a swap is only detectable if the two values
 //! differ.
 //!
-//! The BLAKE2b known answers in [`labels`] were computed with two tools that
-//! are not this crate: `python3 -c 'hashlib.blake2b(data, digest_size=32)'` and
-//! `b2sum -l 256`, which agree.
+//! The BLAKE2b known answers were computed with two tools that are not this
+//! crate — `python3 -c 'hashlib.blake2b(data, digest_size=32)'` and
+//! `b2sum -l 256` — which agree with each other.
 //!
 //! # Encoding rules used throughout, from the spec
 //!
@@ -51,14 +51,13 @@
 
 // Test code, read by a person looking at a failure. The workspace denies these
 // because a panic in the relay's parser is a remote denial of service; that
-// hazard does not exist in a test binary.
+// hazard does not exist in a test binary. `clippy::panic` is allowed because
+// `assert_wire` reports which spec field the first divergent byte falls in,
+// which `assert_eq!` cannot do.
 #![allow(
     clippy::unwrap_used,
     clippy::indexing_slicing,
     clippy::arithmetic_side_effects,
-    // `assert_wire` reports which spec field the first divergence falls in,
-    // which `assert_eq!` cannot do. The lint exists because a panic in the
-    // relay's parser is a remote denial of service; this is a test binary.
     clippy::panic
 )]
 

--- a/rs/crates/f2z-codec/tests/wire_vectors.rs
+++ b/rs/crates/f2z-codec/tests/wire_vectors.rs
@@ -1,0 +1,1819 @@
+//! Byte-level wire vectors for every structure in `docs/e2ee/WIRE.md`.
+//!
+//! # Why this file exists, and what makes it different from every other test
+//!
+//! `tests/reencode_equality.rs` proves §3.3: decode, re-encode, byte-compare.
+//! That is the right test for a *decoder-slack* property and it must stay. It
+//! is not a **format** test. Every `TlsSerializeBytes`/`TlsDeserializeBytes`
+//! derive pair moves together, so swapping two fields of a struct, or widening
+//! a length prefix, changes the bytes on the wire and every round-trip stays
+//! green. Measured: 11 of 20 real mutations to the encoding passed the whole
+//! suite (#564).
+//!
+//! So the assertions below are **encode-side and one-directional**. Each one
+//! pins what a structure's bytes *are*, against a value written out here by
+//! hand.
+//!
+//! # The rule this file is written under
+//!
+//! **Every expected byte below was derived by hand from the `WIRE.md` spec
+//! text — not by printing what the implementation emits.** Generating the
+//! expectations from the code would lock in whatever bug is already there and
+//! make the problem worse, which is exactly the defect class #564 is about.
+//!
+//! The derivation is visible: each field carries the specification's own
+//! declaration (`opaque address[32]`, `uint64 timestamp_ms`, …), the width that
+//! declaration fixes, and the bytes that width holds for this fixture.
+//! [`vector`] asserts the stated width and the supplied bytes agree before it
+//! compares anything, so a derivation whose arithmetic is wrong fails on its
+//! own terms rather than quietly agreeing with the code.
+//!
+//! Fixture integers are chosen so the big-endian encoding is self-evident:
+//! `0x0102_0304_0506_0708` encodes as `01 02 03 04 05 06 07 08`, and a reviewer
+//! can check it without running anything. Adjacent same-width fields are given
+//! *different* values on purpose — a swap is only detectable if the two values
+//! differ.
+//!
+//! The BLAKE2b known answers in [`labels`] were computed with two tools that
+//! are not this crate: `python3 -c 'hashlib.blake2b(data, digest_size=32)'` and
+//! `b2sum -l 256`, which agree.
+//!
+//! # Encoding rules used throughout, from the spec
+//!
+//! - §1.3: "All integers are unsigned and **big-endian** (network byte order)."
+//! - §3.4: `opaque x[n]` is `n` raw bytes with no prefix; `opaque x<0..2^k-1>`
+//!   is a `k`-bit length prefix followed by the bytes; `struct { … }` is fixed
+//!   field order with no padding.
+//! - §3.4: `T x<0..2^k-1>` for a non-byte element type prefixes the number of
+//!   **bytes** the elements occupy (RFC 8446 §3.4), not the element count.
+//! - §3.1: "A value of a given type has exactly one encoding." There is no
+//!   alignment, no padding and no optional field anywhere below.
+
+// Test code, read by a person looking at a failure. The workspace denies these
+// because a panic in the relay's parser is a remote denial of service; that
+// hazard does not exist in a test binary.
+#![allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    // `assert_wire` reports which spec field the first divergence falls in,
+    // which `assert_eq!` cannot do. The lint exists because a panic in the
+    // relay's parser is a remote denial of service; this is a test binary.
+    clippy::panic
+)]
+
+use f2z_codec::canonical::Canonical;
+use f2z_codec::commands::{
+    AckRequest, AckResponse, AppendRequest, BindSendRequest, Capabilities, ChallengePurpose,
+    ChallengeRequest, ChallengeResponse, Command, ContactAppendRequest, CreateContactQueueRequest,
+    CreateContactQueueResponse, CreateQueueRequest, CreateQueueResponse, HelloRequest,
+    HelloResponse, MsgPush, NoticePush, PushEvent, QueueEventPush, QueuedMessage, ReadRequest,
+    ReadResponse, SignedCapabilities, SubscribeResponse,
+};
+use f2z_codec::frame::{CommandAuth, FrameKind, Push, RelayFrame, Request, Response, SignedAuth};
+use f2z_codec::hash::{
+    LABEL_BODY, LABEL_CAPS, LABEL_COMMAND, LABEL_HELLO, LABEL_POW, LABEL_RELAY_ID, LABELS,
+    body_hash, capabilities_digest, hash, hash2, hello_proof_message, relay_id,
+};
+use f2z_codec::pow::{PowParams, PowStamp};
+use f2z_codec::transcript::{AuthContext, TRANSCRIPT_LEN, TranscriptBuilder};
+use f2z_codec::types::{
+    Body, Challenge, ChannelBinding, Digest, Nonce, Payload, PublicKey, QueueAddress, RelayId,
+    Salt, ShortBytes, Signature,
+};
+use f2z_codec::vec::{VecU8, VecU16, VecU24};
+
+// ---------------------------------------------------------------------------
+// The derivation harness
+// ---------------------------------------------------------------------------
+
+/// One field of a hand-derived expectation.
+struct Field {
+    /// The specification's own declaration for this field, copied from
+    /// `WIRE.md` so a reviewer can diff the list against the spec struct.
+    decl: &'static str,
+    /// The width in bytes that declaration fixes. Stated separately from the
+    /// bytes so the two can be checked against each other.
+    width: usize,
+    /// The bytes this fixture puts in that width, big-endian per §1.3.
+    bytes: Vec<u8>,
+}
+
+/// Declare a field: its spec declaration, the width that declaration fixes,
+/// and the bytes.
+fn f(decl: &'static str, width: usize, bytes: impl AsRef<[u8]>) -> Field {
+    Field {
+        decl,
+        width,
+        bytes: bytes.as_ref().to_vec(),
+    }
+}
+
+/// `n` copies of `byte` — for `opaque x[n]` fields, where a distinct fill value
+/// per field is what makes a field swap visible.
+fn fill(byte: u8, n: usize) -> Vec<u8> {
+    vec![byte; n]
+}
+
+/// Concatenate a hand-derived field list, checking each field's stated width
+/// against the bytes supplied for it.
+fn vector(name: &str, fields: &[Field]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for field in fields {
+        assert_eq!(
+            field.bytes.len(),
+            field.width,
+            "{name}: the derivation of `{}` declares width {} but supplies {} bytes — \
+             the hand-derivation is wrong, independently of what the code does",
+            field.decl,
+            field.width,
+            field.bytes.len()
+        );
+        out.extend_from_slice(&field.bytes);
+    }
+    out
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+/// Assert that `actual` is exactly the concatenation of the hand-derived field
+/// list, and say which spec field the first divergence lands in.
+fn assert_wire(name: &str, actual: &[u8], fields: &[Field]) {
+    let expected = vector(name, fields);
+    if actual == expected {
+        return;
+    }
+
+    let divergence = actual
+        .iter()
+        .zip(expected.iter())
+        .position(|(a, b)| a != b)
+        .unwrap_or(actual.len().min(expected.len()));
+
+    let mut offset = 0usize;
+    let mut culprit = String::from("<past the end of the derived vector>");
+    for field in fields {
+        if divergence < offset + field.width {
+            culprit = format!(
+                "`{}` at offset {offset} (+{} into the field)",
+                field.decl,
+                divergence - offset
+            );
+            break;
+        }
+        offset += field.width;
+    }
+
+    panic!(
+        "{name}: encoded bytes do not match the vector derived from WIRE.md.\n\
+         first divergence at byte {divergence}, in {culprit}\n\
+         expected ({} bytes): {}\n\
+         actual   ({} bytes): {}",
+        expected.len(),
+        hex(&expected),
+        actual.len(),
+        hex(actual)
+    );
+}
+
+/// Assert a whole structure encodes to a hand-derived vector.
+fn assert_encodes<T: Canonical>(name: &str, value: &T, fields: &[Field]) {
+    let actual = value.encode_canonical().unwrap();
+    assert_wire(name, &actual, fields);
+}
+
+// ---------------------------------------------------------------------------
+// Fixture values.
+//
+// Every integer is written so that its big-endian encoding can be read off the
+// literal. Every fixed-width opaque field gets its own fill byte, so that two
+// fields swapping places changes the bytes.
+// ---------------------------------------------------------------------------
+
+/// `uint64` fixture: `01 02 03 04 05 06 07 08`.
+const U64_A: u64 = 0x0102_0304_0506_0708;
+const U64_A_BE: [u8; 8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+
+/// A second `uint64`, distinct from the first: `11 12 13 14 15 16 17 18`.
+const U64_B: u64 = 0x1112_1314_1516_1718;
+const U64_B_BE: [u8; 8] = [0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18];
+
+/// `uint32` fixture: `0a 0b 0c 0d`.
+const U32_A: u32 = 0x0a0b_0c0d;
+const U32_A_BE: [u8; 4] = [0x0a, 0x0b, 0x0c, 0x0d];
+
+/// A second `uint32`: `1a 1b 1c 1d`.
+const U32_B: u32 = 0x1a1b_1c1d;
+const U32_B_BE: [u8; 4] = [0x1a, 0x1b, 0x1c, 0x1d];
+
+/// The payload every fixture that needs one carries: 8 bytes of `0x77`.
+const PAYLOAD_FILL: u8 = 0x77;
+const PAYLOAD_LEN: usize = 8;
+
+/// `AppendRequest{payload = 8 x 0x77}` on the wire, derived in
+/// [`append_request_is_a_three_byte_length_prefix_then_the_payload`]:
+/// `opaque payload<0..2^24-1>` is a 3-byte length prefix (`00 00 08`) followed
+/// by the 8 bytes. This is the body used by the framing and transcript
+/// vectors below, so those tests depend on this one being right.
+const APPEND_BODY: [u8; 11] = [
+    0x00, 0x00, 0x08, 0x77, 0x77, 0x77, 0x77, 0x77, 0x77, 0x77, 0x77,
+];
+
+fn payload() -> Payload {
+    Payload::new(vec![PAYLOAD_FILL; PAYLOAD_LEN]).unwrap()
+}
+
+/// The 3-byte length prefix `opaque x<0..2^24-1>` puts before 8 bytes.
+/// 8 = `0x000008`.
+const LEN24_OF_8: [u8; 3] = [0x00, 0x00, 0x08];
+
+// ---------------------------------------------------------------------------
+// §1.3 — `H(label, x)`, and the labels
+//
+// There is no known-answer vector for `H` anywhere else in the tree, so
+// `H(label, x)` could be turned into `H(x, label)` — inverting the construction
+// from a prefix to a suffix — and `hash::tests::labels_are_prefix_free` would
+// then be asserting the wrong invariant with nothing noticing (#564 M21).
+//
+// The digests below were produced by two tools outside this crate:
+//
+//   python3 -c 'import hashlib,sys; print(hashlib.blake2b(LABEL+MSG, digest_size=32).hexdigest())'
+//   printf ... | b2sum -l 256
+//
+// which agree with each other. WIRE.md:67-69 defines
+// `H(label, x) = BLAKE2b-256(label || x)` — no separator, no terminator — so
+// the input to each is the label's ASCII bytes immediately followed by the
+// message's, and nothing else.
+// ---------------------------------------------------------------------------
+
+/// The message every label known-answer is taken over: `01 02 03 04 05 06 07 08`.
+///
+/// Deliberately non-empty and non-palindromic. With an empty message
+/// `H(label, x)` and `H(x, label)` are the same value, so an empty message
+/// could not detect an inverted construction.
+const KAT_MESSAGE: [u8; 8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+
+fn from_hex(text: &str) -> [u8; 32] {
+    assert_eq!(text.len(), 64, "a BLAKE2b-256 digest is 64 hex characters");
+    let mut out = [0u8; 32];
+    for (index, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&text[index * 2..index * 2 + 2], 16).unwrap();
+    }
+    out
+}
+
+#[test]
+fn every_label_is_exactly_the_ascii_the_spec_prints() {
+    // WIRE.md:409, :419, :446, :473, :654, :1641. A one-byte change to any of
+    // these is a silent domain-separation change: every digest and every
+    // signature moves and no round-trip notices.
+    assert_eq!(LABEL_COMMAND, b"free2z/relay/v1/cmd".as_slice());
+    assert_eq!(LABEL_BODY, b"free2z/relay/v1/body".as_slice());
+    assert_eq!(LABEL_RELAY_ID, b"free2z/relay/v1/relay-id".as_slice());
+    assert_eq!(LABEL_CAPS, b"free2z/relay/v1/caps".as_slice());
+    assert_eq!(LABEL_HELLO, b"free2z/relay/v1/hello".as_slice());
+    assert_eq!(LABEL_POW, b"free2z/relay/v1/pow".as_slice());
+
+    // The transcript's `label<0..255>` field is these exact bytes, and its
+    // length is what the 1-byte prefix carries: 19 = 0x13.
+    assert_eq!(LABEL_COMMAND.len(), 19);
+    assert_eq!(LABEL_BODY.len(), 20);
+    assert_eq!(LABEL_RELAY_ID.len(), 24);
+    assert_eq!(LABEL_CAPS.len(), 20);
+    assert_eq!(LABEL_HELLO.len(), 21);
+    assert_eq!(LABEL_POW.len(), 19);
+
+    assert_eq!(LABELS.len(), 6);
+}
+
+#[test]
+fn h_is_blake2b_256_of_label_then_message_and_the_digests_are_known_answers() {
+    // Each of these is `BLAKE2b-256(label || 01 02 03 04 05 06 07 08)`,
+    // computed outside this crate. They pin two things at once: that the label
+    // bytes have not changed, and that `H` prefixes rather than suffixes.
+    let cases: [(&[u8], &str); 6] = [
+        (
+            LABEL_COMMAND,
+            "4bc151a976ac6f79d6ee7a4cf2dc17beb11a9d548be94ef264bc027e09e3d123",
+        ),
+        (
+            LABEL_BODY,
+            "a7e3812152f4b53d83fc39e8f1bb8491ba9ab6326c746f3a7ac30e171a0e1827",
+        ),
+        (
+            LABEL_RELAY_ID,
+            "ea9f075070b908622b9c8bf338107edd9668efd8061681630961c86d75567f53",
+        ),
+        (
+            LABEL_CAPS,
+            "c3e91853eeb30976b317362d87fdfb1287fe9123822a9e1d494fcf3e6f474b58",
+        ),
+        (
+            LABEL_HELLO,
+            "346966d976fe23d44adf35fd0d390b4c852cf8325cf27c282bc033e616fc5258",
+        ),
+        (
+            LABEL_POW,
+            "fb9185a4f4127e391d8029011c757b6501e086ba81969f55fc7e7e41f047e050",
+        ),
+    ];
+
+    for (label, expected) in cases {
+        let actual = hash(label, &KAT_MESSAGE);
+        assert_eq!(
+            actual.as_bytes(),
+            &from_hex(expected),
+            "H({:?}, 01..08) is not the known answer",
+            core::str::from_utf8(label)
+        );
+    }
+}
+
+#[test]
+fn hash2_is_the_same_construction_with_the_message_in_two_pieces() {
+    // WIRE.md §5.2 and §13.1 both hash a label over a concatenation.
+    // `BLAKE2b-256("free2z/relay/v1/pow" || "aa" || "bb")`, computed outside
+    // this crate.
+    assert_eq!(
+        hash2(LABEL_POW, b"aa", b"bb").as_bytes(),
+        &from_hex("747efbe531ef92e3e76c205ff141d6e88ae197c8d1865cae6fbae6cd565b19d2")
+    );
+    // …and the split is not observable, which is the property §5.2 relies on.
+    assert_eq!(hash2(LABEL_POW, b"aa", b"bb"), hash(LABEL_POW, b"aabb"));
+}
+
+#[test]
+fn relay_id_is_a_known_answer_over_the_identity_key() {
+    // WIRE.md:446 — `relay_id = H("free2z/relay/v1/relay-id", relay_identity_pk)`.
+    // `BLAKE2b-256("free2z/relay/v1/relay-id" || a1 x 32)`, computed outside
+    // this crate.
+    let key = PublicKey::new([0xa1; 32]);
+    assert_eq!(
+        relay_id(&key).as_bytes(),
+        &from_hex("507bf541b79bc24df2f313606e858c19e8166dca62274336f95f245683eda48e")
+    );
+}
+
+#[test]
+fn body_hash_is_a_known_answer_over_the_re_encoded_body() {
+    // WIRE.md:419 — `body_hash = H("free2z/relay/v1/body", body)`, over the
+    // §3.3 re-encoded bytes. The body here is `APPEND_BODY`, whose own
+    // derivation is one test below.
+    // `BLAKE2b-256("free2z/relay/v1/body" || 00 00 08 77 77 77 77 77 77 77 77)`.
+    assert_eq!(
+        body_hash(&APPEND_BODY).as_bytes(),
+        &from_hex("a0a5cdf686d12c0f701cf3e6573c6498af130d090da8f8a5c53ac2140363ccab")
+    );
+}
+
+#[test]
+fn capabilities_digest_is_a_known_answer() {
+    // WIRE.md:654 — `H("free2z/relay/v1/caps", tls_codec(Capabilities))`. The
+    // digest is over whatever bytes it is handed, so the known answer is taken
+    // over the same fixed message as the other labels; the `Capabilities`
+    // encoding itself is pinned separately below.
+    assert_eq!(
+        capabilities_digest(&KAT_MESSAGE).as_bytes(),
+        &from_hex("c3e91853eeb30976b317362d87fdfb1287fe9123822a9e1d494fcf3e6f474b58")
+    );
+}
+
+#[test]
+fn the_hello_proof_message_is_the_label_then_binding_then_nonce() {
+    // WIRE.md:473 —
+    // `relay_proof = Sign(relay_identity_sk, "free2z/relay/v1/hello" || channel_binding || client_nonce)`.
+    // Not an argument to `H`: a signing prefix over a plain concatenation.
+    let message = hello_proof_message(
+        &ChannelBinding::new([0xa1; 32]),
+        &Challenge::new([0xb2; 32]),
+    );
+    assert_wire(
+        "hello_proof_message",
+        &message,
+        &[
+            f("\"free2z/relay/v1/hello\"", 21, b"free2z/relay/v1/hello"),
+            f("channel_binding[32]", 32, fill(0xa1, 32)),
+            f("client_nonce[32]", 32, fill(0xb2, 32)),
+        ],
+    );
+    assert_eq!(message.len(), 21 + 32 + 32);
+}
+
+#[test]
+fn labels_are_prefix_free_over_the_bytes_the_spec_prints() {
+    // `hash::tests::labels_are_prefix_free` asserts this too, but through
+    // `LABELS`. Restated here over the literal ASCII, because the invariant is
+    // only meaningful given that `H` is a *prefix* construction — which the
+    // known answers above are what actually pin.
+    let spelled: [&[u8]; 6] = [
+        b"free2z/relay/v1/cmd",
+        b"free2z/relay/v1/body",
+        b"free2z/relay/v1/relay-id",
+        b"free2z/relay/v1/caps",
+        b"free2z/relay/v1/hello",
+        b"free2z/relay/v1/pow",
+    ];
+    for (i, a) in spelled.iter().enumerate() {
+        for (j, b) in spelled.iter().enumerate() {
+            assert!(
+                i == j || !b.starts_with(a),
+                "{:?} is a prefix of {:?}",
+                core::str::from_utf8(a),
+                core::str::from_utf8(b)
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// §3.4 — the primitives everything else is built out of
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_fixed_opaque_field_is_raw_bytes_with_no_prefix() {
+    // §3.4: `opaque x[n]` — fixed-length byte string. No length, no padding.
+    assert_wire(
+        "QueueAddress",
+        &QueueAddress::new([0xa1; 32]).encode_canonical().unwrap(),
+        &[f("opaque address[32]", 32, fill(0xa1, 32))],
+    );
+    assert_wire(
+        "Signature",
+        &Signature::new([0xd4; 64]).encode_canonical().unwrap(),
+        &[f("opaque signature[64]", 64, fill(0xd4, 64))],
+    );
+    assert_wire(
+        "Nonce",
+        &Nonce::new([0xc3; 16]).encode_canonical().unwrap(),
+        &[f("opaque nonce[16]", 16, fill(0xc3, 16))],
+    );
+}
+
+#[test]
+fn a_variable_opaque_field_is_a_length_prefix_of_the_declared_width() {
+    // §3.4: `opaque x<0..2^k-1>` — a k-bit length prefix. `<0..255>` is one
+    // byte; `<0..2^24-1>` is three.
+    assert_wire(
+        "ShortBytes",
+        &ShortBytes::new(b"free2z".to_vec())
+            .unwrap()
+            .encode_canonical()
+            .unwrap(),
+        &[
+            f("uint8 length = 6", 1, [0x06]),
+            f("\"free2z\"", 6, b"free2z"),
+        ],
+    );
+    assert_wire(
+        "Payload",
+        &payload().encode_canonical().unwrap(),
+        &[
+            f("uint24 length = 8", 3, LEN24_OF_8),
+            f("8 payload bytes", 8, fill(PAYLOAD_FILL, 8)),
+        ],
+    );
+    assert_wire(
+        "Body",
+        &Body::new(vec![0x5a; 3])
+            .unwrap()
+            .encode_canonical()
+            .unwrap(),
+        &[
+            f("uint24 length = 3", 3, [0x00, 0x00, 0x03]),
+            f("3 body bytes", 3, fill(0x5a, 3)),
+        ],
+    );
+    // The empty body several commands have by rule (§6.2, §6.3) is the prefix
+    // and nothing else.
+    assert_eq!(
+        Body::default().encode_canonical().unwrap(),
+        vec![0x00, 0x00, 0x00]
+    );
+}
+
+#[test]
+fn a_vector_of_non_byte_elements_prefixes_bytes_not_elements() {
+    // §3.4 / RFC 8446 §3.4: the prefix on `T x<0..2^k-1>` is the number of
+    // bytes the elements occupy. Two `uint16`s are four bytes, not two
+    // elements.
+    assert_wire(
+        "VecU8<u16> (as `uint16 protocol_versions<1..255>`)",
+        &VecU8::<u16>::from(vec![0x0001u16, 0x0002])
+            .encode_canonical()
+            .unwrap(),
+        &[
+            f("uint8 byte length = 4", 1, [0x04]),
+            f("uint16 = 0x0001", 2, [0x00, 0x01]),
+            f("uint16 = 0x0002", 2, [0x00, 0x02]),
+        ],
+    );
+    assert_wire(
+        "VecU16<u32> (as `uint32 padding_sizes<1..2^16-1>`)",
+        &VecU16::<u32>::from(vec![U32_A]).encode_canonical().unwrap(),
+        &[
+            f("uint16 byte length = 4", 2, [0x00, 0x04]),
+            f("uint32 = 0x0a0b0c0d", 4, U32_A_BE),
+        ],
+    );
+    assert_wire(
+        "VecU24<u32>",
+        &VecU24::<u32>::from(vec![U32_A]).encode_canonical().unwrap(),
+        &[
+            f("uint24 byte length = 4", 3, [0x00, 0x00, 0x04]),
+            f("uint32 = 0x0a0b0c0d", 4, U32_A_BE),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §4 — framing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn frame_kind_is_one_byte_with_the_values_the_spec_assigns() {
+    // §4.1: `enum { request(1), response(2), push(3), (255) } FrameKind;` —
+    // the `(255)` fixes the width at one byte and is not a variant.
+    assert_eq!(FrameKind::Request.code(), 1);
+    assert_eq!(FrameKind::Response.code(), 2);
+    assert_eq!(FrameKind::Push.code(), 3);
+}
+
+#[test]
+fn a_request_frame_is_kind_request_id_command_auth_body() {
+    // §4.1:
+    //   struct { FrameKind kind; uint32 request_id; ... } RelayFrame;
+    //   struct { uint16 command; CommandAuth auth; opaque body<0..2^24-1>; } Request;
+    let frame = RelayFrame::request(
+        U32_A,
+        Request::new(
+            Command::Append.code(),
+            CommandAuth::Unsigned,
+            APPEND_BODY.to_vec(),
+        )
+        .unwrap(),
+    );
+    assert_encodes(
+        "RelayFrame(request)",
+        &frame,
+        &[
+            f("FrameKind kind = request(1)", 1, [0x01]),
+            f("uint32 request_id = 0x0a0b0c0d", 4, U32_A_BE),
+            f("uint16 command = APPEND (0x0021)", 2, [0x00, 0x21]),
+            f("CommandAuth.present = 0 (unsigned)", 1, [0x00]),
+            f("uint24 body length = 11", 3, [0x00, 0x00, 0x0b]),
+            f("AppendRequest body", 11, APPEND_BODY),
+        ],
+    );
+}
+
+#[test]
+fn a_response_frame_is_kind_request_id_status_body() {
+    // §4.1: `struct { uint16 status; opaque body<0..2^24-1>; } Response;`
+    // §10: an error response carries a code and nothing else, so the body is
+    // an empty `<0..2^24-1>` — a zero prefix, not zero bytes.
+    assert_encodes(
+        "RelayFrame(response, ERR_UNAVAILABLE)",
+        &RelayFrame::response(U32_A, Response::error(f2z_codec::ErrorCode::Unavailable)),
+        &[
+            f("FrameKind kind = response(2)", 1, [0x02]),
+            f("uint32 request_id = 0x0a0b0c0d", 4, U32_A_BE),
+            f("uint16 status = ERR_UNAVAILABLE (15)", 2, [0x00, 0x0f]),
+            f("uint24 body length = 0", 3, [0x00, 0x00, 0x00]),
+        ],
+    );
+
+    assert_encodes(
+        "RelayFrame(response, ok)",
+        &RelayFrame::response(U32_B, Response::ok(vec![0x5a, 0x5b]).unwrap()),
+        &[
+            f("FrameKind kind = response(2)", 1, [0x02]),
+            f("uint32 request_id = 0x1a1b1c1d", 4, U32_B_BE),
+            f("uint16 status = 0 (success)", 2, [0x00, 0x00]),
+            f("uint24 body length = 2", 3, [0x00, 0x00, 0x02]),
+            f("body", 2, [0x5a, 0x5b]),
+        ],
+    );
+}
+
+#[test]
+fn a_push_frame_is_kind_zero_request_id_event_body() {
+    // §4.1: `struct { uint16 event; opaque body<0..2^24-1>; } Push;`
+    // §4.3: "Push frames use `request_id = 0`."
+    assert_encodes(
+        "RelayFrame(push)",
+        &RelayFrame::push(Push::new(PushEvent::Notice.code(), vec![0x03]).unwrap()),
+        &[
+            f("FrameKind kind = push(3)", 1, [0x03]),
+            f("uint32 request_id = 0", 4, [0x00, 0x00, 0x00, 0x00]),
+            f("uint16 event = NOTICE (0x0082)", 2, [0x00, 0x82]),
+            f("uint24 body length = 1", 3, [0x00, 0x00, 0x01]),
+            f("body", 1, [0x03]),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §5.1 — the signing transcript.
+//
+// These two are the highest-blast-radius vectors in the file: `SignedAuth`'s
+// and `CommandTranscript`'s field order is what every Ed25519 signature in the
+// protocol commits to. Swapping `address` and `signer_key` in either changes
+// the signed bytes and changes nothing a round-trip can see.
+// ---------------------------------------------------------------------------
+
+fn signed_auth() -> SignedAuth {
+    SignedAuth {
+        address: QueueAddress::new([0xa1; 32]),
+        signer_key: PublicKey::new([0xb2; 32]),
+        timestamp_ms: U64_A,
+        nonce: Nonce::new([0xc3; 16]),
+        signature: Signature::new([0xd4; 64]),
+    }
+}
+
+/// `SignedAuth`'s fields, in the order `WIRE.md:400-406` prints them.
+///
+/// ```text
+/// struct {
+///     opaque address[32];        /* the queue address acted on; zeros where none */
+///     opaque signer_key[32];     /* Ed25519 public key claimed to authorize this */
+///     uint64 timestamp_ms;       /* client clock, milliseconds since Unix epoch  */
+///     opaque nonce[16];          /* client CSPRNG, fresh per command             */
+///     opaque signature[64];      /* Ed25519 over CommandTranscript               */
+/// } SignedAuth;
+/// ```
+fn signed_auth_fields() -> Vec<Field> {
+    vec![
+        f("opaque address[32]", 32, fill(0xa1, 32)),
+        f("opaque signer_key[32]", 32, fill(0xb2, 32)),
+        f("uint64 timestamp_ms = 0x0102030405060708", 8, U64_A_BE),
+        f("opaque nonce[16]", 16, fill(0xc3, 16)),
+        f("opaque signature[64]", 64, fill(0xd4, 64)),
+    ]
+}
+
+#[test]
+fn signed_auth_is_address_then_signer_key_then_timestamp_nonce_signature() {
+    // Widths: 32 + 32 + 8 + 16 + 64 = 152.
+    let encoded = signed_auth().encode_canonical().unwrap();
+    assert_eq!(encoded.len(), 152);
+    assert_wire("SignedAuth", &encoded, &signed_auth_fields());
+
+    // Said the other way, because this is the field order the whole signature
+    // scheme rests on: the *first* 32 bytes are the address, and the address
+    // fixture is 0xa1.
+    assert_eq!(&encoded[..32], &[0xa1u8; 32]);
+    assert_eq!(&encoded[32..64], &[0xb2u8; 32]);
+}
+
+#[test]
+fn command_auth_is_a_present_byte_then_the_authenticator_if_present() {
+    // §5.1:
+    //   struct {
+    //       uint8 present;   /* 0 = unsigned command, 1 = signed */
+    //       select (CommandAuth.present) { case 0: struct {}; case 1: SignedAuth; } auth;
+    //   } CommandAuth;
+    //
+    // `case 0: struct {}` is the empty structure: the present byte and nothing
+    // after it.
+    assert_wire(
+        "CommandAuth::Unsigned",
+        &CommandAuth::Unsigned.encode_canonical().unwrap(),
+        &[f("uint8 present = 0", 1, [0x00])],
+    );
+
+    let mut fields = vec![f("uint8 present = 1", 1, [0x01])];
+    fields.extend(signed_auth_fields());
+    let encoded = CommandAuth::Signed(signed_auth())
+        .encode_canonical()
+        .unwrap();
+    assert_eq!(encoded.len(), 1 + 152);
+    assert_wire("CommandAuth::Signed", &encoded, &fields);
+}
+
+#[test]
+fn the_command_transcript_is_the_eleven_fields_of_section_5_1_in_order() {
+    // WIRE.md:408-420:
+    //
+    // ```text
+    // struct {
+    //     opaque label<0..255>;      /* exactly "free2z/relay/v1/cmd"    */
+    //     uint16 protocol_version;
+    //     opaque relay_id[32];       /* §5.2                             */
+    //     opaque channel_binding[32];/* §5.3                             */
+    //     uint16 command;
+    //     uint32 request_id;
+    //     opaque address[32];
+    //     opaque signer_key[32];
+    //     uint64 timestamp_ms;
+    //     opaque nonce[16];
+    //     opaque body_hash[32];      /* H("free2z/relay/v1/body", body)  */
+    // } CommandTranscript;
+    // ```
+    //
+    // Widths: (1 + 19) + 2 + 32 + 32 + 2 + 4 + 32 + 32 + 8 + 16 + 32 = 212.
+    let builder = TranscriptBuilder::new(
+        0x0001,
+        RelayId::new([0xe5; 32]),
+        ChannelBinding::new([0xf6; 32]),
+    );
+    let context = AuthContext {
+        address: QueueAddress::new([0xa1; 32]),
+        signer_key: PublicKey::new([0xb2; 32]),
+        timestamp_ms: U64_A,
+        nonce: Nonce::new([0xc3; 16]),
+    };
+    let transcript = builder
+        .build(Command::Append.code(), U32_A, &context, &APPEND_BODY)
+        .unwrap();
+
+    let signing_bytes = transcript.signing_bytes().unwrap();
+    assert_eq!(signing_bytes.len(), 212);
+    assert_eq!(signing_bytes.len(), TRANSCRIPT_LEN);
+
+    assert_wire(
+        "CommandTranscript",
+        &signing_bytes,
+        &[
+            f("uint8 label length = 19", 1, [0x13]),
+            f("\"free2z/relay/v1/cmd\"", 19, b"free2z/relay/v1/cmd"),
+            f("uint16 protocol_version = 1", 2, [0x00, 0x01]),
+            f("opaque relay_id[32]", 32, fill(0xe5, 32)),
+            f("opaque channel_binding[32]", 32, fill(0xf6, 32)),
+            f("uint16 command = APPEND (0x0021)", 2, [0x00, 0x21]),
+            f("uint32 request_id = 0x0a0b0c0d", 4, U32_A_BE),
+            f("opaque address[32]", 32, fill(0xa1, 32)),
+            f("opaque signer_key[32]", 32, fill(0xb2, 32)),
+            f("uint64 timestamp_ms = 0x0102030405060708", 8, U64_A_BE),
+            f("opaque nonce[16]", 16, fill(0xc3, 16)),
+            f(
+                "opaque body_hash[32] = H(\"free2z/relay/v1/body\", APPEND_BODY)",
+                32,
+                from_hex("a0a5cdf686d12c0f701cf3e6573c6498af130d090da8f8a5c53ac2140363ccab"),
+            ),
+        ],
+    );
+
+    // §5.1: the label is `exactly` those bytes, and nothing else validates.
+    assert!(transcript.validate().is_ok());
+    let mut wrong = transcript;
+    wrong.label = ShortBytes::new(b"free2z/relay/v1/cmX".to_vec()).unwrap();
+    assert!(wrong.validate().is_err());
+}
+
+#[test]
+fn rebuilding_the_transcript_from_a_received_auth_gives_the_same_bytes() {
+    // §5.1 step 4: the relay reconstructs the transcript from *its own*
+    // `relay_id` and `channel_binding` and the frame's remaining fields. The
+    // reconstruction must land on the identical byte string or every signature
+    // fails, so it is pinned against the same hand-derived vector.
+    let builder = TranscriptBuilder::new(
+        0x0001,
+        RelayId::new([0xe5; 32]),
+        ChannelBinding::new([0xf6; 32]),
+    );
+    let rebuilt = builder
+        .signing_bytes_for_auth(Command::Append.code(), U32_A, &signed_auth(), &APPEND_BODY)
+        .unwrap();
+    assert_eq!(
+        hex(&rebuilt[..20]),
+        "1366726565327a2f72656c61792f76312f636d64"
+    );
+    assert_eq!(rebuilt.len(), TRANSCRIPT_LEN);
+    // `address` starts at byte 92 and `signer_key` at 124:
+    // (1 + 19) label + 2 version + 32 relay_id + 32 channel_binding
+    // + 2 command + 4 request_id = 92.
+    assert_eq!(&rebuilt[92..124], &[0xa1u8; 32], "address");
+    assert_eq!(&rebuilt[124..156], &[0xb2u8; 32], "signer_key");
+}
+
+// ---------------------------------------------------------------------------
+// §6.1 — unsigned commands
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hello_request_is_min_version_max_version_client_nonce() {
+    // WIRE.md:623-627:
+    //   struct { uint16 min_version; uint16 max_version; opaque client_nonce[32]; } HelloRequest;
+    // Widths: 2 + 2 + 32 = 36.
+    assert_encodes(
+        "HelloRequest",
+        &HelloRequest {
+            min_version: 0x0001,
+            max_version: 0x0002,
+            client_nonce: Challenge::new([0xa1; 32]),
+        },
+        &[
+            f("uint16 min_version = 1", 2, [0x00, 0x01]),
+            f("uint16 max_version = 2", 2, [0x00, 0x02]),
+            f("opaque client_nonce[32]", 32, fill(0xa1, 32)),
+        ],
+    );
+}
+
+#[test]
+fn hello_response_puts_channel_binding_mode_before_transport_security() {
+    // WIRE.md:629-638:
+    //
+    // ```text
+    // struct {
+    //     uint16 protocol_version;
+    //     opaque relay_identity_pk[32];
+    //     opaque relay_id[32];
+    //     opaque relay_proof[64];
+    //     uint64 relay_time_ms;
+    //     uint8  channel_binding_mode;    /* 0 = none, 1 = tls-exporter */
+    //     uint8  transport_security;      /* 0 = none, 1 = tls */
+    //     opaque capabilities_digest[32];
+    // } HelloResponse;
+    // ```
+    //
+    // The two `uint8`s are adjacent and mean different things, so the fixture
+    // gives them different values: a relay that swapped them would publish
+    // "TLS but no channel binding" as "channel binding but no TLS".
+    // Widths: 2 + 32 + 32 + 64 + 8 + 1 + 1 + 32 = 172.
+    assert_encodes(
+        "HelloResponse",
+        &HelloResponse {
+            protocol_version: 0x0001,
+            relay_identity_pk: PublicKey::new([0xa1; 32]),
+            relay_id: RelayId::new([0xb2; 32]),
+            relay_proof: Signature::new([0xc3; 64]),
+            relay_time_ms: U64_A,
+            channel_binding_mode: 1,
+            transport_security: 0,
+            capabilities_digest: Digest::new([0xd4; 32]),
+        },
+        &[
+            f("uint16 protocol_version = 1", 2, [0x00, 0x01]),
+            f("opaque relay_identity_pk[32]", 32, fill(0xa1, 32)),
+            f("opaque relay_id[32]", 32, fill(0xb2, 32)),
+            f("opaque relay_proof[64]", 64, fill(0xc3, 64)),
+            f("uint64 relay_time_ms = 0x0102030405060708", 8, U64_A_BE),
+            f("uint8 channel_binding_mode = 1 (tls-exporter)", 1, [0x01]),
+            f("uint8 transport_security = 0 (none)", 1, [0x00]),
+            f("opaque capabilities_digest[32]", 32, fill(0xd4, 32)),
+        ],
+    );
+}
+
+#[test]
+fn challenge_request_is_a_purpose_byte_then_a_short_scope() {
+    // WIRE.md:642-647:
+    //   enum { clock(0), queue_create(1), contact_append(2), (255) } ChallengePurpose;
+    //   struct { ChallengePurpose purpose; opaque scope<0..255>; } ChallengeRequest;
+    //
+    // §12.3: for `contact_append` the scope is the target `contact_addr`, so
+    // the fixture's scope is 32 bytes and its prefix is 0x20.
+    assert_eq!(ChallengePurpose::Clock.code(), 0);
+    assert_eq!(ChallengePurpose::QueueCreate.code(), 1);
+    assert_eq!(ChallengePurpose::ContactAppend.code(), 2);
+
+    assert_encodes(
+        "ChallengeRequest",
+        &ChallengeRequest {
+            purpose: ChallengePurpose::ContactAppend.code(),
+            scope: ShortBytes::new(vec![0xa1; 32]).unwrap(),
+        },
+        &[
+            f("ChallengePurpose purpose = contact_append(2)", 1, [0x02]),
+            f("uint8 scope length = 32", 1, [0x20]),
+            f("scope = contact_addr", 32, fill(0xa1, 32)),
+        ],
+    );
+
+    // The empty scope of a `clock` challenge is the prefix alone.
+    assert_encodes(
+        "ChallengeRequest(clock)",
+        &ChallengeRequest {
+            purpose: ChallengePurpose::Clock.code(),
+            scope: ShortBytes::default(),
+        },
+        &[
+            f("ChallengePurpose purpose = clock(0)", 1, [0x00]),
+            f("uint8 scope length = 0", 1, [0x00]),
+        ],
+    );
+}
+
+#[test]
+fn challenge_response_puts_the_challenge_before_the_expiry() {
+    // WIRE.md:648-653:
+    //
+    // ```text
+    // struct {
+    //     uint64    relay_time_ms;
+    //     opaque    challenge[32];
+    //     uint64    expires_at_ms;
+    //     PowParams pow;           /* §13.1; zeroed when no PoW is required */
+    // } ChallengeResponse;
+    // ```
+    //
+    // Widths: 8 + 32 + 8 + (1 + 1 + 4) = 54.
+    assert_encodes(
+        "ChallengeResponse",
+        &ChallengeResponse {
+            relay_time_ms: U64_A,
+            challenge: Challenge::new([0xa1; 32]),
+            expires_at_ms: U64_B,
+            pow: PowParams {
+                algorithm: 1,
+                difficulty_bits: 20,
+                challenge_ttl_ms: 60_000,
+            },
+        },
+        &[
+            f("uint64 relay_time_ms = 0x0102030405060708", 8, U64_A_BE),
+            f("opaque challenge[32]", 32, fill(0xa1, 32)),
+            f("uint64 expires_at_ms = 0x1112131415161718", 8, U64_B_BE),
+            f("PowParams.algorithm = 1", 1, [0x01]),
+            f("PowParams.difficulty_bits = 20", 1, [0x14]),
+            f(
+                "PowParams.challenge_ttl_ms = 60000 = 0x0000ea60",
+                4,
+                [0x00, 0x00, 0xea, 0x60],
+            ),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §6.2 — commands signed by the receive-side queue key
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_queue_request_is_key_two_ttls_flags_stamp() {
+    // WIRE.md:700-707:
+    //
+    // ```text
+    // struct {
+    //     opaque    recv_key[32];
+    //     uint32    req_message_ttl_seconds;
+    //     uint32    req_idle_ttl_seconds;
+    //     uint16    flags;                  /* reserved; MUST be 0 in v1 */
+    //     PowStamp  stamp;
+    // } CreateQueueRequest;
+    // ```
+    //
+    // Widths: 32 + 4 + 4 + 2 + (32 + 16 + 8) = 98.
+    // §7.7 defaults: message TTL 604 800 = 0x0009_3A80,
+    //                idle TTL    7 776 000 = 0x0076_A700.
+    assert_encodes(
+        "CreateQueueRequest",
+        &CreateQueueRequest {
+            recv_key: PublicKey::new([0xa1; 32]),
+            req_message_ttl_seconds: 604_800,
+            req_idle_ttl_seconds: 7_776_000,
+            flags: 0,
+            stamp: PowStamp {
+                challenge: Challenge::new([0xb2; 32]),
+                salt: Salt::new([0xc3; 16]),
+                counter: U64_A,
+            },
+        },
+        &[
+            f("opaque recv_key[32]", 32, fill(0xa1, 32)),
+            f(
+                "uint32 req_message_ttl_seconds = 604800 = 0x00093a80",
+                4,
+                [0x00, 0x09, 0x3a, 0x80],
+            ),
+            f(
+                "uint32 req_idle_ttl_seconds = 7776000 = 0x0076a700",
+                4,
+                [0x00, 0x76, 0xa7, 0x00],
+            ),
+            f("uint16 flags = 0", 2, [0x00, 0x00]),
+            f("PowStamp.challenge[32]", 32, fill(0xb2, 32)),
+            f("PowStamp.salt[16]", 16, fill(0xc3, 16)),
+            f("PowStamp.counter = 0x0102030405060708", 8, U64_A_BE),
+        ],
+    );
+
+    // §13.1's "empty when queue_creation_mode = open": the structure is
+    // fixed-width, so an empty stamp is 56 zero bytes, not zero bytes.
+    let open = CreateQueueRequest {
+        recv_key: PublicKey::zero(),
+        req_message_ttl_seconds: 0,
+        req_idle_ttl_seconds: 0,
+        flags: 0,
+        stamp: PowStamp::empty(),
+    };
+    assert_eq!(open.encode_canonical().unwrap(), vec![0u8; 98]);
+}
+
+#[test]
+fn create_queue_response_puts_recv_addr_before_send_addr() {
+    // WIRE.md:709-715:
+    //
+    // ```text
+    // struct {
+    //     opaque recv_addr[32];
+    //     opaque send_addr[32];
+    //     uint32 message_ttl_seconds;       /* granted, after clamping (§7.7) */
+    //     uint32 idle_ttl_seconds;          /* granted, after clamping (§7.7) */
+    //     uint64 created_at_ms;
+    // } CreateQueueResponse;
+    // ```
+    //
+    // The order is the security-relevant part. `recv_addr` is the read
+    // capability and stays on the recipient's device; `send_addr` is handed to
+    // a peer in an advert (§7.2). A client that read them in the wrong order
+    // would publish its own read capability to its peer.
+    // Widths: 32 + 32 + 4 + 4 + 8 = 80.
+    assert_encodes(
+        "CreateQueueResponse",
+        &CreateQueueResponse {
+            recv_addr: QueueAddress::new([0xa1; 32]),
+            send_addr: QueueAddress::new([0xb2; 32]),
+            message_ttl_seconds: 604_800,
+            idle_ttl_seconds: 7_776_000,
+            created_at_ms: U64_A,
+        },
+        &[
+            f("opaque recv_addr[32]", 32, fill(0xa1, 32)),
+            f("opaque send_addr[32]", 32, fill(0xb2, 32)),
+            f(
+                "uint32 message_ttl_seconds = 604800 = 0x00093a80",
+                4,
+                [0x00, 0x09, 0x3a, 0x80],
+            ),
+            f(
+                "uint32 idle_ttl_seconds = 7776000 = 0x0076a700",
+                4,
+                [0x00, 0x76, 0xa7, 0x00],
+            ),
+            f("uint64 created_at_ms = 0x0102030405060708", 8, U64_A_BE),
+        ],
+    );
+}
+
+#[test]
+fn subscribe_response_is_next_index_then_pending() {
+    // WIRE.md:723-726:
+    //   struct { uint64 next_index; uint64 pending; } SubscribeResponse;
+    assert_encodes(
+        "SubscribeResponse",
+        &SubscribeResponse {
+            next_index: U64_A,
+            pending: U64_B,
+        },
+        &[
+            f("uint64 next_index = 0x0102030405060708", 8, U64_A_BE),
+            f("uint64 pending = 0x1112131415161718", 8, U64_B_BE),
+        ],
+    );
+}
+
+#[test]
+fn read_request_is_from_index_max_messages_max_bytes() {
+    // WIRE.md:736-740:
+    //   struct { uint64 from_index; uint16 max_messages; uint32 max_bytes; } ReadRequest;
+    // Widths: 8 + 2 + 4 = 14. Note the `uint16` sits between two wider fields,
+    // with no alignment padding — §3.4's "no padding".
+    assert_encodes(
+        "ReadRequest",
+        &ReadRequest {
+            from_index: U64_A,
+            max_messages: 0x0102,
+            max_bytes: U32_A,
+        },
+        &[
+            f("uint64 from_index = 0x0102030405060708", 8, U64_A_BE),
+            f("uint16 max_messages = 0x0102", 2, [0x01, 0x02]),
+            f("uint32 max_bytes = 0x0a0b0c0d", 4, U32_A_BE),
+        ],
+    );
+    assert_eq!(
+        ReadRequest {
+            from_index: U64_A,
+            max_messages: 0x0102,
+            max_bytes: U32_A,
+        }
+        .encode_canonical()
+        .unwrap()
+        .len(),
+        14
+    );
+}
+
+fn queued_message() -> QueuedMessage {
+    QueuedMessage {
+        index: U64_A,
+        received_at_ms: U64_B,
+        payload: payload(),
+    }
+}
+
+/// `QueuedMessage`'s fields (`WIRE.md:742-746`), 8 + 8 + (3 + 8) = 27 bytes.
+fn queued_message_fields() -> Vec<Field> {
+    vec![
+        f("uint64 index = 0x0102030405060708", 8, U64_A_BE),
+        f("uint64 received_at_ms = 0x1112131415161718", 8, U64_B_BE),
+        f("uint24 payload length = 8", 3, LEN24_OF_8),
+        f("payload bytes", 8, fill(PAYLOAD_FILL, 8)),
+    ]
+}
+
+#[test]
+fn a_queued_message_is_index_timestamp_payload() {
+    // WIRE.md:742-746:
+    //   struct { uint64 index; uint64 received_at_ms; opaque payload<0..2^24-1>; } QueuedMessage;
+    let encoded = queued_message().encode_canonical().unwrap();
+    assert_eq!(encoded.len(), 27);
+    assert_wire("QueuedMessage", &encoded, &queued_message_fields());
+}
+
+#[test]
+fn read_response_uses_a_three_byte_vector_prefix() {
+    // WIRE.md:748-751:
+    //   struct { QueuedMessage messages<0..2^24-1>; uint8 has_more; } ReadResponse;
+    //
+    // `<0..2^24-1>` is a **three**-byte prefix. Narrowing it to two would cap a
+    // READ response at 64 KiB and desynchronise every other implementation —
+    // and, because the prefix counts bytes, two 27-byte messages here occupy
+    // 54 = 0x000036, which a two-byte prefix would render as `00 36`.
+    let response = ReadResponse {
+        messages: vec![queued_message(), queued_message()].into(),
+        has_more: 1,
+    };
+
+    let mut fields = vec![f(
+        "uint24 messages byte length = 2 x 27 = 54 = 0x000036",
+        3,
+        [0x00, 0x00, 0x36],
+    )];
+    fields.extend(queued_message_fields());
+    fields.extend(queued_message_fields());
+    fields.push(f("uint8 has_more = 1", 1, [0x01]));
+
+    let encoded = response.encode_canonical().unwrap();
+    assert_eq!(encoded.len(), 3 + 54 + 1);
+    assert_wire("ReadResponse", &encoded, &fields);
+
+    // An empty READ response is the three-byte zero prefix and the flag.
+    assert_eq!(
+        ReadResponse {
+            messages: Vec::new().into(),
+            has_more: 0,
+        }
+        .encode_canonical()
+        .unwrap(),
+        vec![0x00, 0x00, 0x00, 0x00]
+    );
+}
+
+#[test]
+fn ack_request_and_response_are_bare_indices() {
+    // WIRE.md:759-766:
+    //   struct { uint64 up_to_index; } AckRequest;
+    //   struct { uint64 next_index; uint64 pending; } AckResponse;
+    assert_encodes(
+        "AckRequest",
+        &AckRequest { up_to_index: U64_A },
+        &[f("uint64 up_to_index = 0x0102030405060708", 8, U64_A_BE)],
+    );
+    assert_encodes(
+        "AckResponse",
+        &AckResponse {
+            next_index: U64_A,
+            pending: U64_B,
+        },
+        &[
+            f("uint64 next_index = 0x0102030405060708", 8, U64_A_BE),
+            f("uint64 pending = 0x1112131415161718", 8, U64_B_BE),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §6.3 — commands signed by the send-side queue key
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bind_send_request_is_one_bare_key() {
+    // WIRE.md:786-788: `struct { opaque send_key[32]; } BindSendRequest;`
+    // The response is empty **by rule** (§6.3), which is the zero-length body
+    // pinned in the response-frame vector above.
+    assert_encodes(
+        "BindSendRequest",
+        &BindSendRequest {
+            send_key: PublicKey::new([0xa1; 32]),
+        },
+        &[f("opaque send_key[32]", 32, fill(0xa1, 32))],
+    );
+}
+
+#[test]
+fn append_request_is_a_three_byte_length_prefix_then_the_payload() {
+    // WIRE.md:798-800: `struct { opaque payload<0..2^24-1>; } AppendRequest;`
+    // This is where `APPEND_BODY` comes from, and the transcript's `body_hash`
+    // known answer is taken over exactly these 11 bytes.
+    let encoded = AppendRequest { payload: payload() }
+        .encode_canonical()
+        .unwrap();
+    assert_wire(
+        "AppendRequest",
+        &encoded,
+        &[
+            f("uint24 payload length = 8", 3, LEN24_OF_8),
+            f("payload bytes", 8, fill(PAYLOAD_FILL, 8)),
+        ],
+    );
+    assert_eq!(encoded, APPEND_BODY.to_vec());
+}
+
+// ---------------------------------------------------------------------------
+// §6.4 — push bodies
+// ---------------------------------------------------------------------------
+
+#[test]
+fn push_event_codes_and_bodies_are_the_table_in_section_6_4() {
+    // WIRE.md:857-861: MSG 0x0080, QUEUE_EVENT 0x0081, NOTICE 0x0082.
+    assert_eq!(PushEvent::Msg.code(), 0x0080);
+    assert_eq!(PushEvent::QueueEvent.code(), 0x0081);
+    assert_eq!(PushEvent::Notice.code(), 0x0082);
+
+    // `MSG`: `opaque recv_addr[32]; QueuedMessage msg;`
+    let mut msg_fields = vec![f("opaque recv_addr[32]", 32, fill(0xa1, 32))];
+    msg_fields.extend(queued_message_fields());
+    assert_encodes(
+        "MsgPush",
+        &MsgPush {
+            recv_addr: QueueAddress::new([0xa1; 32]),
+            msg: queued_message(),
+        },
+        &msg_fields,
+    );
+
+    // `QUEUE_EVENT`: `opaque recv_addr[32]; uint8 reason;`
+    // 1 = deleted, 2 = idle-expired, 3 = messages TTL-expired, 4 = quota.
+    assert_encodes(
+        "QueueEventPush",
+        &QueueEventPush {
+            recv_addr: QueueAddress::new([0xa1; 32]),
+            reason: 2,
+        },
+        &[
+            f("opaque recv_addr[32]", 32, fill(0xa1, 32)),
+            f("uint8 reason = 2 (idle-expired)", 1, [0x02]),
+        ],
+    );
+
+    // `NOTICE`: `uint8 kind; uint64 at_ms;` — the byte comes first.
+    assert_encodes(
+        "NoticePush",
+        &NoticePush {
+            kind: 3,
+            at_ms: U64_A,
+        },
+        &[
+            f("uint8 kind = 3 (capability document changed)", 1, [0x03]),
+            f("uint64 at_ms = 0x0102030405060708", 8, U64_A_BE),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §12.2 — contact queues
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_contact_queue_request_has_no_flags_field() {
+    // WIRE.md:1408-1413:
+    //
+    // ```text
+    // struct {
+    //     opaque    recv_key[32];
+    //     uint32    req_message_ttl_seconds;
+    //     uint32    req_idle_ttl_seconds;
+    //     PowStamp  stamp;
+    // } CreateContactQueueRequest;
+    // ```
+    //
+    // Note against `CreateQueueRequest`: no `flags`. Widths: 32 + 4 + 4 + 56 = 96.
+    assert_encodes(
+        "CreateContactQueueRequest",
+        &CreateContactQueueRequest {
+            recv_key: PublicKey::new([0xa1; 32]),
+            req_message_ttl_seconds: 604_800,
+            req_idle_ttl_seconds: 7_776_000,
+            stamp: PowStamp {
+                challenge: Challenge::new([0xb2; 32]),
+                salt: Salt::new([0xc3; 16]),
+                counter: U64_A,
+            },
+        },
+        &[
+            f("opaque recv_key[32]", 32, fill(0xa1, 32)),
+            f(
+                "uint32 req_message_ttl_seconds = 604800 = 0x00093a80",
+                4,
+                [0x00, 0x09, 0x3a, 0x80],
+            ),
+            f(
+                "uint32 req_idle_ttl_seconds = 7776000 = 0x0076a700",
+                4,
+                [0x00, 0x76, 0xa7, 0x00],
+            ),
+            f("PowStamp.challenge[32]", 32, fill(0xb2, 32)),
+            f("PowStamp.salt[16]", 16, fill(0xc3, 16)),
+            f("PowStamp.counter = 0x0102030405060708", 8, U64_A_BE),
+        ],
+    );
+}
+
+#[test]
+fn create_contact_queue_response_puts_recv_addr_before_contact_addr() {
+    // WIRE.md:1415-1423:
+    //
+    // ```text
+    // struct {
+    //     opaque recv_addr[32];
+    //     opaque contact_addr[32];      /* the published address; never bindable */
+    //     uint32 message_ttl_seconds;
+    //     uint32 idle_ttl_seconds;
+    //     uint32 max_pending;           /* granted cap */
+    //     uint64 max_bytes;             /* granted cap */
+    // } CreateContactQueueResponse;
+    // ```
+    //
+    // `contact_addr` is *published* in a directory entry and `recv_addr` is
+    // not, so reading them in the wrong order publishes the read capability.
+    // Widths: 32 + 32 + 4 + 4 + 4 + 8 = 84.
+    // §12.3 defaults: contact_max_pending 64 = 0x00000040,
+    //                 contact_max_bytes 256 KiB = 262 144 = 0x0000000000040000.
+    assert_encodes(
+        "CreateContactQueueResponse",
+        &CreateContactQueueResponse {
+            recv_addr: QueueAddress::new([0xa1; 32]),
+            contact_addr: QueueAddress::new([0xb2; 32]),
+            message_ttl_seconds: 604_800,
+            idle_ttl_seconds: 7_776_000,
+            max_pending: 64,
+            max_bytes: 262_144,
+        },
+        &[
+            f("opaque recv_addr[32]", 32, fill(0xa1, 32)),
+            f("opaque contact_addr[32]", 32, fill(0xb2, 32)),
+            f(
+                "uint32 message_ttl_seconds = 604800 = 0x00093a80",
+                4,
+                [0x00, 0x09, 0x3a, 0x80],
+            ),
+            f(
+                "uint32 idle_ttl_seconds = 7776000 = 0x0076a700",
+                4,
+                [0x00, 0x76, 0xa7, 0x00],
+            ),
+            f(
+                "uint32 max_pending = 64 = 0x00000040",
+                4,
+                [0x00, 0x00, 0x00, 0x40],
+            ),
+            f(
+                "uint64 max_bytes = 262144 = 0x0000000000040000",
+                8,
+                [0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00],
+            ),
+        ],
+    );
+}
+
+#[test]
+fn contact_append_request_is_address_payload_stamp() {
+    // WIRE.md:1425-1429:
+    //
+    // ```text
+    // struct {
+    //     opaque    contact_addr[32];
+    //     opaque    payload<0..2^24-1>;
+    //     PowStamp  stamp;
+    // } ContactAppendRequest;
+    // ```
+    //
+    // The stamp comes *after* a variable-length field, so its offset moves with
+    // the payload — which is exactly the shape a hand-rolled parser gets wrong.
+    // Widths: 32 + (3 + 8) + 56 = 99.
+    assert_encodes(
+        "ContactAppendRequest",
+        &ContactAppendRequest {
+            contact_addr: QueueAddress::new([0xa1; 32]),
+            payload: payload(),
+            stamp: PowStamp {
+                challenge: Challenge::new([0xb2; 32]),
+                salt: Salt::new([0xc3; 16]),
+                counter: U64_A,
+            },
+        },
+        &[
+            f("opaque contact_addr[32]", 32, fill(0xa1, 32)),
+            f("uint24 payload length = 8", 3, LEN24_OF_8),
+            f("payload bytes", 8, fill(PAYLOAD_FILL, 8)),
+            f("PowStamp.challenge[32]", 32, fill(0xb2, 32)),
+            f("PowStamp.salt[16]", 16, fill(0xc3, 16)),
+            f("PowStamp.counter = 0x0102030405060708", 8, U64_A_BE),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §13.1 — proof of work
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pow_params_and_pow_stamp_encode_as_declared() {
+    // WIRE.md:1622-1633:
+    //   struct { uint8 algorithm; uint8 difficulty_bits; uint32 challenge_ttl_ms; } PowParams;
+    //   struct { opaque challenge[32]; opaque salt[16]; uint64 counter; } PowStamp;
+    assert_encodes(
+        "PowParams",
+        &PowParams {
+            algorithm: 1,
+            difficulty_bits: 20,
+            challenge_ttl_ms: 60_000,
+        },
+        &[
+            f("uint8 algorithm = 1 (blake2b-leading-zero-bits)", 1, [0x01]),
+            f("uint8 difficulty_bits = 20 = 0x14", 1, [0x14]),
+            f(
+                "uint32 challenge_ttl_ms = 60000 = 0x0000ea60",
+                4,
+                [0x00, 0x00, 0xea, 0x60],
+            ),
+        ],
+    );
+    assert_eq!(PowParams::none().encode_canonical().unwrap(), vec![0u8; 6]);
+
+    assert_encodes(
+        "PowStamp",
+        &PowStamp {
+            challenge: Challenge::new([0xa1; 32]),
+            salt: Salt::new([0xb2; 16]),
+            counter: U64_A,
+        },
+        &[
+            f("opaque challenge[32]", 32, fill(0xa1, 32)),
+            f("opaque salt[16]", 16, fill(0xb2, 16)),
+            f("uint64 counter = 0x0102030405060708", 8, U64_A_BE),
+        ],
+    );
+    assert_eq!(PowStamp::empty().encode_canonical().unwrap(), vec![0u8; 56]);
+}
+
+#[test]
+fn the_pow_digest_is_a_known_answer_with_a_big_endian_counter() {
+    // WIRE.md:1640-1642: a stamp is valid iff
+    // `H("free2z/relay/v1/pow", challenge || salt || counter)` has at least
+    // `difficulty_bits` leading zero bits.
+    //
+    // §1.3 makes `counter` big-endian like every other integer. This is the one
+    // number a relay and a client must agree on byte-for-byte: if the two ends
+    // disagree about the counter's endianness every stamp fails verification,
+    // and nothing but a known answer detects it.
+    //
+    // `BLAKE2b-256("free2z/relay/v1/pow" || a1 x 32 || b2 x 16 || 01 02 03 04 05 06 07 08)`,
+    // computed outside this crate.
+    let stamp = PowStamp {
+        challenge: Challenge::new([0xa1; 32]),
+        salt: Salt::new([0xb2; 16]),
+        counter: U64_A,
+    };
+    assert_eq!(
+        stamp.digest().as_bytes(),
+        &from_hex("659018a6e5b82a415b23f69f62e2a747c8cc83f402eb3d07924b38a2a8896467")
+    );
+
+    // The little-endian reading of the same counter has a different digest —
+    // stated so the assertion above is visibly load-bearing rather than
+    // incidentally true.
+    assert_ne!(
+        stamp.digest().as_bytes(),
+        &from_hex("6ce45f2d37e3706991237386d55de04bfe5d0fe464bbee9bea3e347d83a9c8d7")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §11.1 — the capability document
+// ---------------------------------------------------------------------------
+
+fn capabilities() -> Capabilities {
+    Capabilities {
+        protocol_versions: vec![0x0001u16].into(),
+        relay_identity_pk: PublicKey::new([0xa1; 32]),
+        relay_id: RelayId::new([0xb2; 32]),
+        transport_security: 1,
+        channel_binding_mode: 0,
+        max_frame_bytes: 1_048_576,
+        max_inflight: 32,
+        ws_ping_interval_seconds: 25,
+        handshake_timeout_ms: 10_000,
+        clock_skew_ms: 120_000,
+        antireplay_window_ms: 240_000,
+        antireplay_persistence: 1,
+        padding_sizes: vec![1024u32, 4096].into(),
+        max_chunk_bytes: 65_536,
+        min_message_ttl_seconds: 3_600,
+        max_message_ttl_seconds: 2_592_000,
+        default_message_ttl_seconds: 604_800,
+        min_idle_ttl_seconds: 86_400,
+        max_idle_ttl_seconds: 31_536_000,
+        default_idle_ttl_seconds: 7_776_000,
+        max_queue_messages: 10_000,
+        max_queue_bytes: U64_A,
+        queue_creation_mode: 1,
+        queue_creation_pow: PowParams {
+            algorithm: 1,
+            difficulty_bits: 20,
+            challenge_ttl_ms: 60_000,
+        },
+        contact_queues_enabled: 1,
+        contact_max_pending: 64,
+        contact_max_bytes: 262_144,
+        contact_append_pow: PowParams {
+            algorithm: 1,
+            difficulty_bits: 22,
+            challenge_ttl_ms: 30_000,
+        },
+        per_source_limits: 1,
+        durability_mode: 2,
+        operator_name: ShortBytes::new(b"Example Relay Co".to_vec()).unwrap(),
+        operator_contact: ShortBytes::new(b"ops@example.org".to_vec()).unwrap(),
+        operator_abuse_contact: ShortBytes::new(b"abuse@example.org".to_vec()).unwrap(),
+        operator_jurisdiction: ShortBytes::new(b"IS".to_vec()).unwrap(),
+        operator_policy_url: ShortBytes::new(b"https://example.org/policy".to_vec()).unwrap(),
+        source_repo_url: ShortBytes::new(b"https://example.org/relay".to_vec()).unwrap(),
+        source_commit: ShortBytes::new(b"a1162ca".to_vec()).unwrap(),
+        build_digest: ShortBytes::new(b"sha256:00".to_vec()).unwrap(),
+        published_at_ms: U64_B,
+    }
+}
+
+/// The 38 fields of `Capabilities`, in the order `WIRE.md:1270-1330` prints
+/// them.
+fn capabilities_fields() -> Vec<Field> {
+    vec![
+        // uint16 protocol_versions<1..255> — a one-byte *byte* length, then the
+        // uint16 elements. One version is two bytes, so the prefix is 0x02.
+        f("uint8 protocol_versions byte length = 2", 1, [0x02]),
+        f("uint16 protocol_versions[0] = 1", 2, [0x00, 0x01]),
+        // identity
+        f("opaque relay_identity_pk[32]", 32, fill(0xa1, 32)),
+        f("opaque relay_id[32]", 32, fill(0xb2, 32)),
+        // transport
+        f("uint8 transport_security = 1 (tls)", 1, [0x01]),
+        f("uint8 channel_binding_mode = 0 (none)", 1, [0x00]),
+        f(
+            "uint32 max_frame_bytes = 1048576 = 0x00100000",
+            4,
+            [0x00, 0x10, 0x00, 0x00],
+        ),
+        f("uint16 max_inflight = 32 = 0x0020", 2, [0x00, 0x20]),
+        f(
+            "uint16 ws_ping_interval_seconds = 25 = 0x0019",
+            2,
+            [0x00, 0x19],
+        ),
+        f(
+            "uint32 handshake_timeout_ms = 10000 = 0x00002710",
+            4,
+            [0x00, 0x00, 0x27, 0x10],
+        ),
+        // anti-replay
+        f(
+            "uint32 clock_skew_ms = 120000 = 0x0001d4c0",
+            4,
+            [0x00, 0x01, 0xd4, 0xc0],
+        ),
+        f(
+            "uint32 antireplay_window_ms = 240000 = 0x0003a980",
+            4,
+            [0x00, 0x03, 0xa9, 0x80],
+        ),
+        f("uint8 antireplay_persistence = 1 (durable)", 1, [0x01]),
+        // padding — uint32 padding_sizes<1..2^16-1>: a two-byte *byte* length,
+        // then the uint32 elements. Two entries are eight bytes: 0x0008.
+        f("uint16 padding_sizes byte length = 8", 2, [0x00, 0x08]),
+        f(
+            "uint32 padding_sizes[0] = 1024 = 0x00000400",
+            4,
+            [0x00, 0x00, 0x04, 0x00],
+        ),
+        f(
+            "uint32 padding_sizes[1] = 4096 = 0x00001000",
+            4,
+            [0x00, 0x00, 0x10, 0x00],
+        ),
+        f(
+            "uint32 max_chunk_bytes = 65536 = 0x00010000",
+            4,
+            [0x00, 0x01, 0x00, 0x00],
+        ),
+        // queues
+        f(
+            "uint32 min_message_ttl_seconds = 3600 = 0x00000e10",
+            4,
+            [0x00, 0x00, 0x0e, 0x10],
+        ),
+        f(
+            "uint32 max_message_ttl_seconds = 2592000 = 0x00278d00",
+            4,
+            [0x00, 0x27, 0x8d, 0x00],
+        ),
+        f(
+            "uint32 default_message_ttl_seconds = 604800 = 0x00093a80",
+            4,
+            [0x00, 0x09, 0x3a, 0x80],
+        ),
+        f(
+            "uint32 min_idle_ttl_seconds = 86400 = 0x00015180",
+            4,
+            [0x00, 0x01, 0x51, 0x80],
+        ),
+        f(
+            "uint32 max_idle_ttl_seconds = 31536000 = 0x01e13380",
+            4,
+            [0x01, 0xe1, 0x33, 0x80],
+        ),
+        f(
+            "uint32 default_idle_ttl_seconds = 7776000 = 0x0076a700",
+            4,
+            [0x00, 0x76, 0xa7, 0x00],
+        ),
+        f(
+            "uint32 max_queue_messages = 10000 = 0x00002710",
+            4,
+            [0x00, 0x00, 0x27, 0x10],
+        ),
+        f("uint64 max_queue_bytes = 0x0102030405060708", 8, U64_A_BE),
+        // anti-abuse
+        f("uint8 queue_creation_mode = 1 (pow)", 1, [0x01]),
+        f("PowParams queue_creation_pow.algorithm = 1", 1, [0x01]),
+        f(
+            "PowParams queue_creation_pow.difficulty_bits = 20 = 0x14",
+            1,
+            [0x14],
+        ),
+        f(
+            "PowParams queue_creation_pow.challenge_ttl_ms = 60000 = 0x0000ea60",
+            4,
+            [0x00, 0x00, 0xea, 0x60],
+        ),
+        f("uint8 contact_queues_enabled = 1", 1, [0x01]),
+        f(
+            "uint32 contact_max_pending = 64 = 0x00000040",
+            4,
+            [0x00, 0x00, 0x00, 0x40],
+        ),
+        f(
+            "uint64 contact_max_bytes = 262144 = 0x0000000000040000",
+            8,
+            [0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00],
+        ),
+        f("PowParams contact_append_pow.algorithm = 1", 1, [0x01]),
+        f(
+            "PowParams contact_append_pow.difficulty_bits = 22 = 0x16",
+            1,
+            [0x16],
+        ),
+        f(
+            "PowParams contact_append_pow.challenge_ttl_ms = 30000 = 0x00007530",
+            4,
+            [0x00, 0x00, 0x75, 0x30],
+        ),
+        f("uint8 per_source_limits = 1 (on)", 1, [0x01]),
+        f("uint8 durability_mode = 2 (fsync-per-append)", 1, [0x02]),
+        // operator — every one is `opaque x<0..255>`: a one-byte length, then
+        // the ASCII.
+        f("uint8 operator_name length = 16", 1, [0x10]),
+        f("\"Example Relay Co\"", 16, b"Example Relay Co"),
+        f("uint8 operator_contact length = 15", 1, [0x0f]),
+        f("\"ops@example.org\"", 15, b"ops@example.org"),
+        f("uint8 operator_abuse_contact length = 17", 1, [0x11]),
+        f("\"abuse@example.org\"", 17, b"abuse@example.org"),
+        f("uint8 operator_jurisdiction length = 2", 1, [0x02]),
+        f("\"IS\"", 2, b"IS"),
+        f("uint8 operator_policy_url length = 26", 1, [0x1a]),
+        f(
+            "\"https://example.org/policy\"",
+            26,
+            b"https://example.org/policy",
+        ),
+        // provenance
+        f("uint8 source_repo_url length = 25", 1, [0x19]),
+        f(
+            "\"https://example.org/relay\"",
+            25,
+            b"https://example.org/relay",
+        ),
+        f("uint8 source_commit length = 7", 1, [0x07]),
+        f("\"a1162ca\"", 7, b"a1162ca"),
+        f("uint8 build_digest length = 9", 1, [0x09]),
+        f("\"sha256:00\"", 9, b"sha256:00"),
+        f("uint64 published_at_ms = 0x1112131415161718", 8, U64_B_BE),
+    ]
+}
+
+#[test]
+fn the_capability_document_encodes_field_for_field_as_section_11_1_declares() {
+    // WIRE.md:1270-1330. This is the document a client parses to decide whether
+    // to use a relay at all and a human reads at
+    // `/.well-known/free2z-relay/v1/capabilities`; §11.2 requires the two
+    // representations to carry the same `capabilities_digest`, so the byte
+    // layout is the thing both sides have to agree on.
+    assert_encodes("Capabilities", &capabilities(), &capabilities_fields());
+}
+
+#[test]
+fn signed_capabilities_is_the_document_then_a_signature() {
+    // WIRE.md:1332-1335:
+    //   struct { Capabilities capabilities; opaque signature[64]; } SignedCapabilities;
+    let mut fields = capabilities_fields();
+    fields.push(f("opaque signature[64]", 64, fill(0xd4, 64)));
+    assert_encodes(
+        "SignedCapabilities",
+        &SignedCapabilities {
+            capabilities: capabilities(),
+            signature: Signature::new([0xd4; 64]),
+        },
+        &fields,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §6, §10 — the code tables, as the numbers they are on the wire
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_command_code_is_the_uint16_the_table_assigns() {
+    // WIRE.md:598-613. Codes are `uint16` and are **stable forever**, so they
+    // are pinned as the two bytes they occupy rather than as integers.
+    let expected: [(Command, [u8; 2]); 14] = [
+        (Command::Hello, [0x00, 0x01]),
+        (Command::GetCapabilities, [0x00, 0x02]),
+        (Command::GetChallenge, [0x00, 0x03]),
+        (Command::Ping, [0x00, 0x04]),
+        (Command::CreateQueue, [0x00, 0x10]),
+        (Command::Subscribe, [0x00, 0x11]),
+        (Command::Unsubscribe, [0x00, 0x12]),
+        (Command::Read, [0x00, 0x13]),
+        (Command::Ack, [0x00, 0x14]),
+        (Command::DeleteQueue, [0x00, 0x15]),
+        (Command::BindSend, [0x00, 0x20]),
+        (Command::Append, [0x00, 0x21]),
+        (Command::CreateContactQueue, [0x00, 0x30]),
+        (Command::ContactAppend, [0x00, 0x31]),
+    ];
+    assert_eq!(expected.len(), Command::ALL.len());
+    for (command, bytes) in expected {
+        let request = Request::new(command.code(), CommandAuth::Unsigned, Vec::new()).unwrap();
+        let encoded = request.encode_canonical().unwrap();
+        assert_eq!(
+            &encoded[..2],
+            &bytes,
+            "{command:?} does not encode as the table's code"
+        );
+    }
+}
+
+#[test]
+fn every_error_code_is_the_uint16_the_table_assigns() {
+    // WIRE.md:1201-1223. A code's meaning is never changed and a retired code
+    // is never reused, so each one is pinned as the status field's two bytes.
+    use f2z_codec::ErrorCode;
+    let expected: [(ErrorCode, [u8; 2]); 21] = [
+        (ErrorCode::Malformed, [0x00, 0x01]),
+        (ErrorCode::UnsupportedVersion, [0x00, 0x02]),
+        (ErrorCode::FrameType, [0x00, 0x03]),
+        (ErrorCode::TooManyInflight, [0x00, 0x04]),
+        (ErrorCode::UnknownCommand, [0x00, 0x05]),
+        (ErrorCode::BadSignature, [0x00, 0x06]),
+        (ErrorCode::StaleTimestamp, [0x00, 0x07]),
+        (ErrorCode::Replay, [0x00, 0x08]),
+        (ErrorCode::ChannelBinding, [0x00, 0x09]),
+        (ErrorCode::NoAccess, [0x00, 0x0a]),
+        (ErrorCode::AlreadyBound, [0x00, 0x0b]),
+        (ErrorCode::BadSize, [0x00, 0x0c]),
+        (ErrorCode::AckTooHigh, [0x00, 0x0d]),
+        (ErrorCode::Quota, [0x00, 0x0e]),
+        (ErrorCode::Unavailable, [0x00, 0x0f]),
+        (ErrorCode::PowRequired, [0x00, 0x10]),
+        (ErrorCode::PowInvalid, [0x00, 0x11]),
+        (ErrorCode::Backpressure, [0x00, 0x12]),
+        (ErrorCode::RateLimited, [0x00, 0x13]),
+        (ErrorCode::NotPermitted, [0x00, 0x14]),
+        (ErrorCode::Internal, [0x00, 0x15]),
+    ];
+    for (code, bytes) in expected {
+        let encoded = Response::error(code).encode_canonical().unwrap();
+        assert_eq!(
+            &encoded[..2],
+            &bytes,
+            "{code:?} does not encode as the table's code"
+        );
+        // §4.1: an error response carries a code and nothing else.
+        assert_eq!(&encoded[2..], &[0x00, 0x00, 0x00]);
+    }
+}


### PR DESCRIPTION
`Closes #564`

`f2z-codec` encodes all 33 `WIRE.md` structures correctly, and nothing asserted
what any structure's bytes actually **are**. 11 of 20 real mutations to the wire
format passed the entire 71-test suite green — including swapping `address` and
`signer_key` in `CommandTranscript` and `SignedAuth`, which changes what every
Ed25519 signature in the protocol commits to.

This adds `rs/crates/f2z-codec/tests/wire_vectors.rs`: 42 **encode-side** tests
pinning the byte layout of every structure in the document, plus known-answer
BLAKE2b digests for every `LABEL_*` constant.

## The mutation table, re-run

Each mutation applied to `rs/crates/f2z-codec/src`, then
`cargo test --locked --all-targets && cargo test --locked --doc`, then reverted.
`git status` clean between every row.

**19 of 19 caught. Nothing survives.**

| # | Mutation | Site | Before (#564) | Now |
|---|---|---|---|---|
| M1 | `ReadResponse.messages`: `VecU24` → `VecU16` | `commands.rs:438` | NOT CAUGHT | **caught** — `read_response_uses_a_three_byte_vector_prefix` |
| M2 | `CreateQueueResponse`: swap `recv_addr` / `send_addr` | `commands.rs:396` | NOT CAUGHT | **caught** — `create_queue_response_puts_recv_addr_before_send_addr` |
| M3 | `HelloResponse`: swap `channel_binding_mode` / `transport_security` | `commands.rs:245` | NOT CAUGHT | **caught** — `hello_response_puts_channel_binding_mode_before_transport_security` |
| M4 | `LABEL_BODY` `…/v1/body` → `…/v1/bodx` | `hash.rs:25` | NOT CAUGHT | **caught** — 4 tests: `every_label_is_exactly_the_ascii_the_spec_prints`, `h_is_blake2b_256_of_label_then_message_and_the_digests_are_known_answers`, `body_hash_is_a_known_answer_over_the_re_encoded_body`, `the_command_transcript_is_the_eleven_fields_of_section_5_1_in_order` |
| M7 | `CommandTranscript`: swap `address` / `signer_key` | `transcript.rs:71` | NOT CAUGHT | **caught** — `the_command_transcript_is_the_eleven_fields_of_section_5_1_in_order`, `rebuilding_the_transcript_from_a_received_auth_gives_the_same_bytes` |
| M8 | `Capabilities.protocol_versions`: `VecU8` → `VecU16` | `commands.rs:590` | NOT CAUGHT | **caught** — `the_capability_document_encodes_field_for_field_as_section_11_1_declares`, `signed_capabilities_is_the_document_then_a_signature` |
| M10 | `SignedAuth`: swap `address` / `signer_key` | `frame.rs:424` | NOT CAUGHT | **caught** — `signed_auth_is_address_then_signer_key_then_timestamp_nonce_signature`, `command_auth_is_a_present_byte_then_the_authenticator_if_present` |
| M13 | `LABEL_RELAY_ID` one byte | `hash.rs:29` | NOT CAUGHT | **caught** — 3 tests: `every_label_is_exactly_the_ascii_the_spec_prints`, `h_is_blake2b_256_…`, `relay_id_is_a_known_answer_over_the_identity_key` |
| M17 | `PowStamp` digest: `counter.to_be_bytes()` → `to_le_bytes()` | `pow.rs:145` | NOT CAUGHT | **caught** — `the_pow_digest_is_a_known_answer_with_a_big_endian_counter` |
| M19 | `ChallengeResponse`: swap `challenge` / `expires_at_ms` | `commands.rs:329` | NOT CAUGHT | **caught** — `challenge_response_puts_the_challenge_before_the_expiry` |
| M21 | `H(label, x)` → `H(x, label)` in **both** `hash` and `hash2` | `hash.rs:62` | NOT CAUGHT | **caught** — 7 tests, including `h_is_blake2b_256_…`, `hash2_is_the_same_construction_with_the_message_in_two_pieces`, `relay_id_is_a_known_answer_…`, `the_pow_digest_is_a_known_answer_…` |
| M5 | `MAX_PLAUSIBLE_BUCKETS` 16 → 17 | `padding.rs:44` | caught | still caught — `padding::tests::implausibly_fine_grained_sets_are_flagged` |
| M6 | fixed newtype `Debug` prints inner bytes | `types.rs:97` | caught | still caught — `types::tests::debug_never_renders_bytes` |
| M9 | `ErrorCode::Quota` 14 → 24 | `error.rs:114` | caught | still caught — `error::tests::codes_are_the_table_in_wire_md_section_10` |
| M11 | `Command::Read` `0x0013` → `0x0016` | `commands.rs:113` | caught | still caught — `commands::tests::command_codes_are_the_table_in_section_6` |
| M12 | `PROPOSED_BUCKETS` `65_536` → `32_768` | `padding.rs:37` | caught | still caught — 2 `padding::tests` |
| M14 | `ShortBytes` prefix `U8` → `U16` | `types.rs:337` | caught | still caught — `transcript::tests::transcript_is_fixed_length_and_starts_with_the_label` |
| M15 | `FrameKind::Push` 3 → 4 | `frame.rs:62` | caught | still caught — `every_frame_round_trips_byte_for_byte`, `structured_noise_never_normalizes` |
| M16 | `RelayFrame.request_id` BE → LE | `frame.rs:367` | caught | still caught — 2 `frame::tests` |

**No row is still NOT CAUGHT.**

The "Before" column is #564's measurement, and this run confirms it without
re-measuring: for all eleven previously-surviving mutations, **every** test that
now catches them is one added by this PR. Not one of them is caught by a test
that existed before — which is precisely what "NOT CAUGHT" meant. The eight
previously-caught mutations are still caught by the same pre-existing tests, so
there is no regression.

## The expectations were derived from the spec, not from the code

This is the part that matters, because generating the expectations from the
implementation would have locked in whatever bug was already there and made the
problem worse. Every byte was written by hand from the `WIRE.md` text.

The mechanism that makes that checkable: each expectation is a list of fields
carrying the specification's own declaration, the width that declaration fixes,
and the bytes. `vector()` asserts the stated width and the supplied bytes agree
*before* it compares anything to the code, so a derivation with bad arithmetic
fails on its own terms rather than quietly agreeing.

```rust
f("uint8 label length = 19", 1, [0x13]),
f("\"free2z/relay/v1/cmd\"", 19, b"free2z/relay/v1/cmd"),
f("uint16 protocol_version = 1", 2, [0x00, 0x01]),
f("opaque relay_id[32]", 32, fill(0xe5, 32)),
```

Fixture integers are chosen so the big-endian encoding is legible on sight —
`0x0102_0304_0506_0708` encodes as `01 02 03 04 05 06 07 08` — and adjacent
same-width fields get *different* values, because a swap is only detectable if
the two values differ. A failure names the spec field the first divergent byte
falls in:

```
CommandTranscript: encoded bytes do not match the vector derived from WIRE.md.
first divergence at byte 92, in `opaque address[32]` at offset 92 (+0 into the field)
```

### Two worked derivations, for spot-checking

**`CommandTranscript` (§5.1, `WIRE.md:408-420`).** Field by field, with widths
from §3.4 and big-endian from §1.3:

| Spec declaration | Width | Bytes |
|---|---:|---|
| `opaque label<0..255>` | 1 + 19 | `13` + `"free2z/relay/v1/cmd"` |
| `uint16 protocol_version` | 2 | `00 01` |
| `opaque relay_id[32]` | 32 | `e5 …` |
| `opaque channel_binding[32]` | 32 | `f6 …` |
| `uint16 command` | 2 | `00 21` (APPEND, §6's table) |
| `uint32 request_id` | 4 | `0a 0b 0c 0d` |
| `opaque address[32]` | 32 | `a1 …` |
| `opaque signer_key[32]` | 32 | `b2 …` |
| `uint64 timestamp_ms` | 8 | `01 02 03 04 05 06 07 08` |
| `opaque nonce[16]` | 16 | `c3 …` |
| `opaque body_hash[32]` | 32 | `a0a5cdf6…` |

`1 + 19 + 2 + 32 + 32 + 2 + 4 + 32 + 32 + 8 + 16 + 32 = 212`, which is also what
`TRANSCRIPT_LEN` claims. `address` therefore begins at byte 92 and `signer_key`
at 124 — asserted directly, because that is the pair M7 swaps.

**`body_hash`.** §1.3: `H(label, x) = BLAKE2b-256(label || x)`, no separator and
no terminator. The body is `AppendRequest{payload = 8 × 0x77}`, which by §3.4's
`opaque payload<0..2^24-1>` is a three-byte length prefix and the bytes:
`00 00 08 77 77 77 77 77 77 77 77`. So:

```
$ printf 'free2z/relay/v1/body\x00\x00\x08\x77\x77\x77\x77\x77\x77\x77\x77' | b2sum -l 256
a0a5cdf686d12c0f701cf3e6573c6498af130d090da8f8a5c53ac2140363ccab
```

`python3 -c 'hashlib.blake2b(..., digest_size=32)'` agrees. Two tools, neither of
them this crate. Every `LABEL_*` digest in the file was produced the same way,
over the fixed message `01 02 03 04 05 06 07 08` — non-empty on purpose, since
`H(label, "")` and `H("", label)` are the same value and an empty message could
not detect M21's inverted construction.

### The one thing worth noting about the result

41 of the 42 tests passed the first time they compiled. The single failure was a
typo in my own fixture (a `request_id` I wrote two ways), not a disagreement
about byte layout. That is independent confirmation of #564's finding: the
encoding was already right everywhere, and the entire gap was the absence of
anything asserting it.

## Coverage

All 33 structures the document declares — `RelayFrame`, `Request`, `Response`,
`Push`, `FrameKind`, `CommandAuth`, `SignedAuth`, `CommandTranscript`,
`HelloRequest`, `HelloResponse`, `ChallengePurpose`, `ChallengeRequest`,
`ChallengeResponse`, `CreateQueueRequest`, `CreateQueueResponse`,
`SubscribeResponse`, `ReadRequest`, `QueuedMessage`, `ReadResponse`,
`AckRequest`, `AckResponse`, `BindSendRequest`, `AppendRequest`, `MsgPush`,
`QueueEventPush`, `NoticePush`, `CreateContactQueueRequest`,
`CreateContactQueueResponse`, `ContactAppendRequest`, `Capabilities`,
`SignedCapabilities`, `PowParams`, `PowStamp` — plus the §3.4 primitives every
one is built from (fixed `opaque x[n]`, `opaque x<0..2^k-1>` at all three prefix
widths, and `T x<0..2^k-1>`'s byte-counting prefix), the §6 command-code table
and the §10 error-code table as the `uint16`s they occupy on the wire.

`tests/reencode_equality.rs` is untouched. It is the correct test for §3.3, which
is a decoder-slack property; it was simply never a format test.

## The redaction sweep (#572's lesson, applied to the rest of the file)

#572 found `assert_no_leak`'s decimal detector anchored on the opening bracket,
so a dump starting mid-buffer slid past it. I swept every other detector and
assertion in `tests/redaction.rs` for the same class of blind spot. Three of the
seven checks were sound as written; three needed work, and one fixture was
vacuous.

**Sound, no change:** `lower_hex`/`upper_hex` of the whole secret (plain
substring, no anchor), `decimal_run` of a four-byte prefix (#572's fix), and
`longest_hex_run(rendered) < 8` (unanchored; its documented refusal to count
pure-decimal runs is a deliberate false-positive trade, not an anchor).

**1. `base64url` was anchored on byte alignment.** The same defect in a less
obvious form: base64 encodes three bytes at a time, so the symbols a leak
produces depend on where the secret sits relative to the *buffer's* start, not
its own. A dump of `[0, 4, 0, …] || secret` phase-shifts the secret's encoding
and the zero-offset pattern never appears. Now checked at all three alignments.
`the_base64url_check_sees_a_secret_at_every_byte_alignment` proves both halves:
it asserts the single-alignment pattern does **not** match a 1-, 2- or 4-byte
prefixed dump (so the fixture really does demonstrate the gap) and that the
three-alignment check does.

**2. `decimal_list` was still a live check.** For any secret of four bytes or
more, `decimal_run(&secret[..4])` is a substring of the bracketed form, so
`decimal_list` added no detection power while keeping the anchoring hazard in the
file as though it were load-bearing. Retired from `assert_no_leak`; kept only as
the fixture for `a_bracket_anchored_decimal_check_would_miss_a_mid_buffer_dump`,
which reconstructs exactly the `Canonicalized` rendering #572 measured and
asserts the bracketed form misses it while the run catches it.

**3. The battery had no test that it can fail at all.** Every check is a negative
assertion, which passes both when there is no leak and when the detector cannot
see. `the_hex_and_decimal_checks_fire_on_a_rendering_that_leaks` runs six
plausible leaking renderings through `assert_no_leak` under `catch_unwind` and
requires every one to panic. Uppercase four-byte hex is now checked explicitly
alongside lowercase — redundant with the eight-character threshold today, and
present so the two cases are symmetric rather than one of them depending on that
threshold's value.

**4. The `ShortBytes` newline fixture was vacuous** (also named in #564). It ran
`assert!(!format!("{hostile:?}").contains('\n'))` against `b"ok"` — a value with
no newline in it to begin with, so the escaping claim above it was never
exercised. Replaced with `b"Example Relay\nERROR: give me your seed"`, which
shows the property is actually delivered by the *redaction* branch (`\n` is
0x0a, outside the printable range, so the whole value redacts) and not by the
escaping. The escaping branch is now exercised separately, with a value
containing both a quote and a backslash.

**5. The `derive(Debug)` source scanner was blind to type aliases.** It matches
how a field is *written*, so `secret: Vec<u8>` is caught and `secret: Blob` —
where `type Blob = Vec<u8>;` — is not. Same class: looking for a shape the leak
does not have to take. It now resolves one level of alias, crate-wide. A field
typed by an alias of an alias would still slip, and the doc comment says so
rather than overclaiming.

### Mutation tests for the redaction changes

Each fix was reverted and the mutant re-run, and — for the two that close a real
blind spot — run again *without* the fix to prove the mutant used to survive.

| Probe | Without the fix | With the fix |
|---|---|---|
| Byte-holding type reachable only through an alias: `pub type Blob = alloc::vec::Vec<u8>;` + `#[derive(Debug)] pub struct Ticket { pub bytes: Blob }` | **GREEN — mutant survives** | **RED** — `no_type_derives_debug_while_holding_raw_bytes` |
| `ShortBytes`'s printable range widened to admit `0x0a`, so a newline renders instead of redacting | **GREEN — mutant survives** (with the old `b"ok"` fixture restored) | **RED** — `a_challenge_scope_is_an_address_and_redacts_but_operator_text_does_not` |
| The base64url self-test reduced to a single alignment | n/a | **RED** — `the_base64url_check_sees_a_secret_at_every_byte_alignment` |
| `decimal_run` re-anchored on `[`, undoing #572 | n/a | **RED** — `the_hex_and_decimal_checks_fire_on_a_rendering_that_leaks` |

The first two rows are the ones that matter: each mutant passed the suite before
this PR and fails after it, which is the definition of a closed blind spot. The
last two show the new self-tests detect a regression in the detectors
themselves — including a re-introduction of the exact anchoring bug #572 fixed.

One honest note on scope: `assert_no_leak`'s base64url loop cannot be
mutation-caught from inside the crate, because no type here emits base64, so no
fixture leaks through it. The self-test is what carries the proof — it builds a
base64url dump of `prefix || secret` and asserts the single-alignment pattern
misses it while the three-alignment check does not.

## `WIRE.md` gaps found while deriving by hand

Checked against #550 and #552 first; these are not in either.

1. **`CreateQueueRequest.stamp` is "empty when `queue_creation_mode = open`"
   (`:705`), and "empty" is undefined for a fixed-width structure.** `PowStamp`
   has no variable-length field and §3.3 forbids omitting bytes, so the only
   consistent reading is 56 zero bytes — which is what this crate implements and
   documents. But the spec never says it, and an implementer who reads "empty" as
   "omit the field" is 56 bytes out of sync on the first `CREATE_QUEUE` of every
   open relay. Sharpened by the contrast one section earlier: `ChallengeResponse.pow`
   is described as **"zeroed** when no PoW is required" (`:652`). Two adjacent
   fields of the same type, two different words, one of them unambiguous.
2. **`ReadResponse.has_more` is a `uint8` with no declared value set** (`:750`).
   Every other flag byte in the document enumerates its values —
   `QUEUE_EVENT.reason` (1-4), `NOTICE.kind` (1-3), `channel_binding_mode` (0/1),
   `durability_mode` (0-2). `has_more` does not, so whether it is a boolean or a
   count, and whether `has_more = 2` is legal, is left to the implementer. §3.3
   makes any value canonical, so nothing catches the divergence.
3. **§13.1's PoW preimage is the one integer in the protocol concatenated
   outside a `tls_codec` struct.** `H("free2z/relay/v1/pow", challenge || salt ||
   counter)` (`:1641`) is prose, not a structure, so `counter`'s width and
   endianness come only from §1.3's global rule and are stated nowhere at the
   point of use. This is exactly the M17 site: flip the endianness and every
   stamp fails verification between two implementations that both believe they
   read the spec. One clause — "`counter` as a big-endian `uint64`" — closes it.
4. **`ChallengeRequest.scope` has no defined value for the other two purposes.**
   `:646` says "for `contact_append`: the target `contact_addr`" and never says
   what `clock` and `queue_create` put there. Empty is the obvious reading and
   this crate emits it; a relay that *requires* empty and one that ignores the
   field disagree about a valid request.
5. **`Capabilities`' eight operator and provenance fields are `opaque x<0..255>`
   with no charset**, yet §11.3 step 7 requires a client to "surface operator
   name, jurisdiction and contact in the relay-picker UI". They are
   operator-controlled bytes rendered in UI with no encoding, validation or
   escaping rule stated anywhere. The crate's `ShortBytes` `Debug` handles this
   for logs by redacting anything non-printable; the *display* rule is the
   spec's to make.

## Checks

- `cargo test --locked --all-targets`: **115 passed** (49 unit + 7 padding +
  10 redaction + 7 reencode-equality + 42 wire-vectors), was 70.
- `cargo test --locked --doc`: 1 passed. Total **116**, was 71.
- `cargo build --locked --lib --target wasm32-unknown-unknown -p f2z-codec`:
  clean. Nothing was added to the library; both changed files are test targets,
  so `no_std` + `alloc` + `forbid(unsafe_code)` is untouched.
- `scripts/check-rust-fmt.sh --root rs`, `check-rust-clippy.sh --root rs`,
  `check-rust-deny.sh --root rs --config rs/deny.toml`: all clean. One narrow
  `#![allow(clippy::panic)]` on the test file, because `assert_wire` reports
  which spec field the first divergence lands in and `assert_eq!` cannot.

`.github/workflows/zuuli.yml` is untouched.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
