### PR TITLE
docs(e2ee): scope the "no confusable pairs" claim in all three files, and repair what #573's redaction left behind

### DIFF
--- a/docs/e2ee/ARCHITECTURE.md
+++ b/docs/e2ee/ARCHITECTURE.md
@@ -1145,20 +1145,26 @@ deliberate.
   a memory-hard function is affordable at relay scale is undecided.
 - **O. Messaging-handle eligibility for existing accounts.** Opened 2026-08-23 by
   [`WIRE.md` §14](./WIRE.md#14-handle-charset-for-messaging--blocking-pre-check-resolved).
-  Messaging handles are `[a-z0-9_]{1,30}`, ASCII, so that homograph and
-  mixed-script impersonation does not exist. free2z usernames are broader
+  Messaging handles are `[a-z0-9_]{1,30}`, ASCII, so that **cross-script**
+  homograph and mixed-script impersonation does not exist — same-script ASCII
+  lookalikes such as `1`/`l` remain and are a client rendering problem
+  ([`THREAT-MODEL.md` §4.10](./THREAT-MODEL.md#410-the-platform-username-space-contains-homographs-messaging-handles-do-not)).
+  free2z usernames are broader
   (`^[\w.@+-]+$`, up to 150 characters), so some existing accounts are not
-  eligible. **Measured 2026-08-24 — and still open**, because measurement was
+  eligible. **Measured 2026-08-23 — and still open**, because measurement was
   never the whole question. What the measurement settled:
-  - **How many, closed.** **Approximately 90% of existing accounts are eligible
+  - **What share, closed.** **Approximately 90% of existing accounts are eligible
     after case-folding and approximately 10% are not** — overwhelmingly because
     the username contains `.` `@` `+` or `-`; non-ASCII characters and
-    over-length names account for very few. It is neither the rounding error nor
-    the migration project the question was framed around, and it is not a set of
-    dead rows: **every ineligible account has logged in at least once and all but
-    one is still active.** Absolute counts are business data and are deliberately
-    not published in this repository; they are recorded in the deployment
-    repository.
+    over-length names account for very few. It is not a set of dead rows:
+    **every ineligible account has logged in at least once and all but one is
+    still active.** Whether that is a rounding error or a migration project is a
+    question about the *absolute* count and not about the share, and absolute
+    counts are business data, deliberately not published in this repository; they
+    are recorded in the deployment repository. The earlier answer that it was
+    "neither" rested on a scale qualifier that the redaction to proportions
+    removed, and is withdrawn — see the correction in
+    [`WIRE.md` §14.3](./WIRE.md#143-the-decision-and-the-cost-accepted).
   - **Which validator, closed.** `Creator(AbstractUser)` does not override
     `username`; the field is recorded with
     `UnicodeUsernameValidator`. **Non-ASCII usernames are legal on free2z today

--- a/docs/e2ee/CLIENT-CONTRACT.md
+++ b/docs/e2ee/CLIENT-CONTRACT.md
@@ -1415,11 +1415,36 @@ A messaging handle is:
 /^[a-z0-9_]{1,30}$/     ASCII only, compared as bytes, no normalization
 ```
 
-The restriction is not tidiness. A charset with no case, no scripts and no
-confusable pairs makes an entire class of homograph and mixed-script
-impersonation **not exist**, rather than be defended against — and a
-normalization function is itself the attack surface
+The restriction is not tidiness. A charset with no case and a single script makes
+an entire class of homograph and mixed-script impersonation **not exist**, rather
+than be defended against — `@аlice` with a Cyrillic а cannot be encoded as a
+messaging handle at all — and a normalization function is itself the attack
+surface
 ([`WIRE.md` §14](./WIRE.md#14-handle-charset-for-messaging--blocking-pre-check-resolved)).
+
+**An entire class, not every class — and the remainder is your job, not the
+protocol's.** `[a-z0-9_]` still contains `1`/`l` and `0`/`o`, indistinguishable
+in most UI sans-serif faces: `@a1ice` and `@alice`, or `@b0b` and `@bob`, are
+pairs a user cannot separate by reading them. Nothing below the UI defends
+against that. Three build rules follow.
+
+- **Render handles in a face that disambiguates** — monospace, or a text face
+  with a slashed or dotted zero and a distinguishable `1`/`l`. A handle set in
+  the same proportional sans as body copy cannot be checked by eye, and every
+  surface that shows a handle counts: search results, invites, message headers,
+  profile links.
+- **Never write copy that sells the charset as a safety property.** "Handles are
+  ASCII, so they can't be faked" is false and must not ship. What is true, and
+  is the most a string of copy may claim, is that a handle cannot contain
+  characters from another script.
+- **Point the user at the check that is real.** Who a peer *is*, is established
+  by safety-number verification — always available, and the strongest check in
+  the system regardless of directory state
+  ([§6.3](#63-verification-state),
+  [§6.4](#64-witness-threshold--the-fail-closed-matrix)). A handle is an
+  address, not an authentication, and first-contact copy should say so rather
+  than implying the handle did the work.
+
 An account is eligible iff `lowercase(username)` matches the pattern; case
 folding is safe because platform uniqueness is already enforced
 case-insensitively.
@@ -1430,7 +1455,7 @@ character, or exceeding 30 characters after lowercasing are not eligible for a
 messaging handle in v1.**
 
 **How many accounts that is, is now measured, and the answer is the reason this
-screen matters.** Measured against production on 2026-08-24
+screen matters.** Measured against production on 2026-08-23
 ([`WIRE.md` §14.2](./WIRE.md#142-checked-against-free2zs-real-username-rules--measured),
 [§13-O](./ARCHITECTURE.md#13-open-questions)):
 
@@ -1554,7 +1579,7 @@ transfer ([§13-K](./ARCHITECTURE.md#13-open-questions)), group scale
 ([§13-N](./ARCHITECTURE.md#13-open-questions)) — which directly sets how slow
 first contact feels on a phone — messaging-handle eligibility
 ([§13-O](./ARCHITECTURE.md#13-open-questions): the *measurement* is closed as of
-2026-08-24 and is in §11.3, but the **product** question of whether the ~10% is
+2026-08-23 and is in §11.3, but the **product** question of whether the ~10% is
 excluded in v1 or served by a separate opt-in handle is not), KT epoch cadence
 ([§13-P](./ARCHITECTURE.md#13-open-questions)), witness independence and the
 default *t* ([§13-Q](./ARCHITECTURE.md#13-open-questions)), the client gossip

--- a/docs/e2ee/KT.md
+++ b/docs/e2ee/KT.md
@@ -89,7 +89,11 @@ surface and its stable error codes; and where `akd`'s types sit underneath ours.
   ([ADR 0001](./decisions/0001-platform-priority.md)).
 - A **handle** is `[a-z0-9_]{1,30}`, ASCII, per
   [`WIRE.md` §14](./WIRE.md#14-handle-charset-for-messaging--blocking-pre-check-resolved).
-  It is the log's label and it is why the log's labels are not homograph-attackable.
+  It is the log's label, and it is why a label cannot carry a **cross-script**
+  homograph: with one script and no case there is no `а`-for-`a` substitution to
+  encode. Same-script ASCII lookalikes (`1`/`l`, `0`/`o`) are in the label space
+  and are out of scope for the directory — see
+  [`THREAT-MODEL.md` §4.10](./THREAT-MODEL.md#410-the-platform-username-space-contains-homographs-messaging-handles-do-not).
 
 ---
 

--- a/docs/e2ee/README.md
+++ b/docs/e2ee/README.md
@@ -122,3 +122,17 @@ independence criterion and the default *t*, and the KT epoch cadence. All are
 listed in [`ARCHITECTURE.md` §13](./ARCHITECTURE.md#13-open-questions) and in
 [`KT.md` §12](./KT.md#12-what-this-document-leaves-open) rather than answered by
 invention.
+
+**Dating convention.** Corrections, closures and measurements in these documents
+are stamped with the **author's local date** — the local date of the commit
+that introduces them, not the UTC date. The dating is the whole reason a
+correction is worth anything to an auditor, so a stamp that runs ahead of its own
+commit is a defect: correct it, and say in the change that you corrected it
+rather than adjusting it quietly. One such fix is recorded in
+[`WIRE.md` §14.2](./WIRE.md#142-checked-against-free2zs-real-username-rules--measured).
+
+**Scoping convention.** A claim in these documents is scoped by the section that
+states it, and the scope is part of the claim. Three corrections in
+[`THREAT-MODEL.md`](./THREAT-MODEL.md) exist because a property that holds under
+stated conditions was later restated without them; when restating a claim
+somewhere else, carry its qualifiers with it or do not carry the claim.

--- a/docs/e2ee/THREAT-MODEL.md
+++ b/docs/e2ee/THREAT-MODEL.md
@@ -560,7 +560,7 @@ otherwise was wrong.
 Stated in the present tense because it is a property of the product as it ships
 today, not a risk of a future one. free2z usernames are validated by Django's
 `UnicodeUsernameValidator`, confirmed against the model's migration history, so
-non-ASCII usernames are legal and — measured on production 2026-08-24 — **a
+non-ASCII usernames are legal and — measured on production 2026-08-23 — **a
 small, non-zero number of accounts carry one today**
 ([`WIRE.md` §14.2](./WIRE.md#142-checked-against-free2zs-real-username-rules--measured)).
 For a threat model the count is beside the point; that it is not zero is the
@@ -574,7 +574,30 @@ Messaging handles are `[a-z0-9_]{1,30}` compared as bytes
 so the KT directory's label space contains no confusable pairs and homograph
 impersonation **does not exist inside the messenger** — that is why the charset
 was restricted, and it is what makes the log's labels not homograph-attackable
-([`KT.md` §1.3](./KT.md#13-conventions)).
+([`KT.md` §1.3](./KT.md#13-conventions)). **That sentence over-claims; see the
+correction below.**
+
+> **Correction (2026-08-23) — the charset removes the cross-script class of
+> confusables, not every confusable.** The paragraph above is left standing
+> rather than edited away, so an auditor can see exactly what was claimed and
+> what replaced it. `[a-z0-9_]` **does** contain confusable pairs: `1`/`l` and
+> `0`/`o` are the canonical ASCII homoglyphs and are indistinguishable in most UI
+> sans-serif faces, so `@a1ice` and `@alice`, or `@b0b` and `@bob`, are two
+> handles a reader cannot separate by eye. "No confusable pairs" is false as
+> written, and "homograph impersonation does not exist inside the messenger" is
+> true only of the cross-script kind.
+>
+> The scoped claim is the one that survives, and it is the one
+> [`WIRE.md` §14.1](./WIRE.md#141-proposed-rule) already states — *"an entire
+> class of homograph and mixed-script impersonation"*: an entire class, not every
+> class. With one script and no case there is no `а`-for-`a` substitution to
+> make, so a mixed-script impersonation of a messaging handle cannot be encoded
+> at all and never reaches the directory. That is real and it is why the charset
+> was restricted. Same-script ASCII lookalikes are **out of scope for this
+> mechanism**: nothing in the protocol defends against them, and the defense is
+> whatever the client does at render time and at verification time
+> ([`CLIENT-CONTRACT.md` §11.3](./CLIENT-CONTRACT.md#113-the-handle-charset-and-accounts-that-cannot-have-a-handle)),
+> which this document does not specify.
 
 What that does **not** do is fix the platform. A profile page, a comment byline
 or a link on free2z can still carry a homograph username, and a user who copies
@@ -583,9 +606,39 @@ platform's charset, not on ours. The mitigation is narrow and worth stating
 exactly: such a string does not match the messaging charset, so the directory
 refuses to resolve it at all, which turns a silent impersonation into a lookup
 failure. Making free2z's own username space safe is backend and product work,
-out of scope for this design, and **no property of it is claimed here**.
+out of scope for this design.
+
+The distinction that matters, since this document is read for what it claims:
+this section states two *factual* properties of the platform username space —
+that `UnicodeUsernameValidator` is the validator in use, and that accounts with a
+non-ASCII username exist today — because both are facts an adversary can act
+on, and both were measured. What it claims is **no safety property** of that
+space. Nothing here should be read as asserting that free2z's username space
+resists homograph or mixed-script impersonation. It does not, that is the
+finding, and no part of this design changes it.
+
+**The same mapping carries a second directory-integrity failure, and it involves
+no confusable at all.** Eligibility is evaluated on the *lowercased* username,
+platform case-insensitive uniqueness turns out to be an application convention in
+two serializers rather than a database constraint, and production holds
+case-variant duplicate accounts today. Within each colliding group, two distinct
+real accounts map to one messaging handle and the directory would have to pick a
+winner — the same outcome a successful homograph produces, reached without one.
+It is **blocking**: those accounts must be resolved before the mapping ships. The
+correction, the evidence and the intended end state (a database-level
+`UniqueConstraint(Lower("username"))`) are in
+[`WIRE.md` §14.3](./WIRE.md#143-the-decision-and-the-cost-accepted), and the
+open question is
+[`ARCHITECTURE.md` §13-O](./ARCHITECTURE.md#13-open-questions).
 
 ## 5. Summary: what we claim, precisely
+
+**Every entry below is scoped by the section it cites, and the scope is part of
+the claim.** A **Yes** means yes under the conditions that section states, and
+nothing wider. Every correction this document carries has the same cause — a
+property that holds under stated conditions, later restated without them (§3.1,
+twice; §4.10, once) — so where a summary line and a section disagree, the
+section's narrower reading is the one intended.
 
 | Property | ZUULI (native) | Web (WASM) |
 |---|---|---|

--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -1731,20 +1731,30 @@ messaging_handle = /^[a-z0-9_]{1,30}$/     ASCII only, NFC (trivially satisfied)
 Compared as bytes. **No normalization is performed at comparison time** — a
 handle either matches the pattern exactly or it is not a handle. That is the
 point: a normalization function is itself the attack surface (which forms fold to
-which? is `ﬁ` `fi`? is `ı` `i`?), and a charset with no case, no scripts and no
-confusable pairs makes an entire class of homograph and mixed-script impersonation
-**not exist** rather than be defended against.
+which? is `ﬁ` `fi`? is `ı` `i`?), and a charset with no case and a single
+script makes an entire class of homograph and mixed-script impersonation **not
+exist** rather than be defended against.
+
+**An entire class, not every class.** `[a-z0-9_]` is not free of confusable
+pairs: it contains `1`/`l` and `0`/`o`, which are indistinguishable in most UI
+sans-serif faces. What the restriction removes is the **cross-script** class —
+there is no `а`-for-`a` substitution to make when there is only one script —
+and that is the whole of what is claimed for it, here or anywhere in this set.
+Same-script ASCII lookalikes remain, are not defended against by anything in this
+document, and are a rendering and verification obligation on the client
+([`THREAT-MODEL.md` §4.10](./THREAT-MODEL.md#410-the-platform-username-space-contains-homographs-messaging-handles-do-not),
+[`CLIENT-CONTRACT.md` §11.3](./CLIENT-CONTRACT.md#113-the-handle-charset-and-accounts-that-cannot-have-a-handle)).
 
 ### 14.2 Checked against free2z's real username rules — measured
 
 **This was checked before being written down**, and the answer is that real
-usernames are considerably broader. The first revision of this section flagged
-three things it could not settle from this repository — which username validator
-is attached, whether case-insensitive uniqueness is a database property, and how
-many existing accounts the rule excludes. **All three have since been measured**:
-the model and its migration history were read out of band, and the counts were
-run against the production database on **2026-08-24**. The findings below are
-facts, not conditionals.
+usernames are considerably broader. The first revision of §14 flagged three
+things it could not settle from this repository — which username validator is
+attached (flagged here in §14.2), and whether case-insensitive uniqueness is a
+database property and how many existing accounts the rule excludes (both flagged
+in §14.3). **All three have since been measured**: the model and its migration
+history were read out of band, and the counts were run against the production
+database on **2026-08-23**. The findings below are facts, not conditionals.
 
 **On what this section reports.** No username or other user-identifying value
 appears here, and neither do free2z's absolute user metrics: this is a public
@@ -1754,15 +1764,29 @@ design decision actually rests on, since what matters is *what fraction* of
 existing accounts the rule excludes, not how many accounts exist. The precise
 figures behind every proportion below are recorded in the deployment repository.
 
+> **Re-stamped 2026-08-23.** §14.2 and §14.3 were first published stamped
+> `2026-08-24` — the UTC date of a commit whose own local timestamp is
+> 2026-08-23. Nothing here was measured or written on the 24th, and a measurement
+> dated after the commit that carries it invites exactly the wrong reading in a
+> document whose corrections are only worth anything because they are dated. The
+> stamps in this section, in
+> [`THREAT-MODEL.md` §4.10](./THREAT-MODEL.md#410-the-platform-username-space-contains-homographs-messaging-handles-do-not),
+> [`ARCHITECTURE.md` §13-O](./ARCHITECTURE.md#13-open-questions) and
+> [`CLIENT-CONTRACT.md` §11.3](./CLIENT-CONTRACT.md#113-the-handle-charset-and-accounts-that-cannot-have-a-handle)
+> were corrected to the local date under
+> [#575](https://github.com/free2z/zuu/issues/575), and **no figure changed**.
+> The convention — local date, matching the commit — is now written down in
+> [`README.md`](./README.md#status) so it stops recurring.
+
 | Source | Finding |
 |---|---|
 | `py/dj/free2z/openapi/f2z.yaml` — `Registration`, `CreatorDetail`, `CreatorList`, `CommentAuthor` | `username` is `type: string`, **`pattern: ^[\w.@+-]+$`**, **`maxLength: 150`**, described as *"Letters, digits and @/./+/-/_ only."* This is Django's `AbstractUser.username` contract. |
-| `py/dj/free2z/settings.py:29` | `AUTH_USER_MODEL = 'g12f.Creator'`. The `Creator` model itself is not present in this repository — only serializers and views are — so the validator cannot be read *here*. **Determined out of band, 2026-08-24:** `Creator(AbstractUser)` does **not** override `username`; the initial migration records the field as `max_length=150, unique=True, validators=[django.contrib.auth.validators.UnicodeUsernameValidator()]`. **The Unicode validator is the one in use.** |
-| `py/dj/apps/g12f/serializers/creator.py` | Uniqueness is enforced **case-insensitively at the application layer only** (`Creator.objects.filter(username__iexact=...)`, in `RegistrationSerializer.validate_username` and `CreatorProfileUpdateSerializer.validate_username`). `FORBIDDEN_USERNAMES` additionally reserves route-shadowing names. **Determined out of band, 2026-08-24:** nothing backs this in the database — see the correction in §14.3. |
+| `py/dj/free2z/settings.py:29` | `AUTH_USER_MODEL = 'g12f.Creator'`. The `Creator` model itself is not present in this repository — only serializers and views are — so the validator cannot be read *here*. **Determined out of band, 2026-08-23:** `Creator(AbstractUser)` does **not** override `username`; the initial migration records the field as `max_length=150, unique=True, validators=[django.contrib.auth.validators.UnicodeUsernameValidator()]`. **The Unicode validator is the one in use.** |
+| `py/dj/apps/g12f/serializers/creator.py` | Uniqueness is enforced **case-insensitively at the application layer only** (`Creator.objects.filter(username__iexact=...)`, in `RegistrationSerializer.validate_username` and `CreatorProfileUpdateSerializer.validate_username`). `FORBIDDEN_USERNAMES` additionally reserves route-shadowing names. **Determined out of band, 2026-08-23:** nothing backs this in the database — see the correction in §14.3. |
 | `py/dj/apps/g12f/views/creator.py` | Reads are `username__iexact` (`lookup_field = "username__iexact"`; `get_object_or_404(Creator, username__iexact=...)`). |
 | `ts/svelte/free2z/src/routes/[username]/+page.svelte` | Handles are rendered verbatim as `@{creator.username}` and URL-encoded into paths. The front end applies **no** narrower rule. |
 | `ts/svelte/free2z/src/routes/[username]/dashboard/billing/+page.server.ts` | Contains `USERNAME_PATTERN = /^[a-zA-Z0-9_]{1,64}$/`, but this validates a subscription-target parameter in one dashboard action — it is not the registration rule, and it is already **narrower than what registration accepts**, so accounts with `.`/`@`/`+`/`-` in their name cannot use that page today. |
-| Production database, 2026-08-24 | The eligibility proportions below. |
+| Production database, 2026-08-23 | The eligibility proportions below. |
 
 Two things follow, and the second is the one that matters most:
 
@@ -1783,7 +1807,7 @@ Two things follow, and the second is the one that matters most:
    а and `@alice` with a Latin a are two different, equally valid, equally
    registerable free2z accounts right now.
 
-#### Eligibility, measured on production 2026-08-24
+#### Eligibility, measured on production 2026-08-23
 
 Eligibility is evaluated as `lowercase(username) matches /^[a-z0-9_]{1,30}$/`
 (§14.3).
@@ -1800,15 +1824,16 @@ Which properties the population carries — these overlap, and each share is of
 |---|---|---|
 | Contains an uppercase letter | A little over half of all accounts | **No** — folded by the mapping |
 | Contains `.`, `@`, `+` or `-` | Just under a tenth of all accounts — **the dominant cause of ineligibility** | Yes |
-| Contains a non-ASCII character | A small number of accounts, and not zero | Yes |
+| Contains a non-ASCII character | A very small share of all accounts — small, and **not zero** | Yes |
 | Longer than 30 characters | Vanishingly rare | Yes |
 
 The three disqualifying properties overlap in only a single account, so their
-shares are effectively additive and the punctuation rule is almost the whole of
-the exclusion. Uppercase is by far the most common deviation from the messaging
-charset and it costs nobody a handle, which is the entire reason the mapping
-folds case — but see §14.3, where the *argument* originally given for folding
-case turns out to be false.
+shares are effectively additive and the punctuation rule is the dominant term —
+by a wide margin, but **not the whole** of the exclusion: the non-ASCII and
+over-length shares are each tiny and neither of them is zero. Uppercase is by
+far the most common deviation from the messaging charset and it costs nobody a
+handle, which is the entire reason the mapping folds case — but see §14.3,
+where the *argument* originally given for folding case turns out to be false.
 
 **These are not abandoned rows.** **Every ineligible account has logged in at
 least once**, and all but one are **currently active**. Every account the rule
@@ -1839,7 +1864,7 @@ a social-login path that bypasses the serializer — **cannot be established fro
 this repository and must be settled with a query.** Any colliding pair must be
 resolved by hand before the mapping ships.
 
-> **Correction (2026-08-24) — the case-folding argument above is false, and the
+> **Correction (2026-08-23) — the case-folding argument above is false, and the
 > property it rests on does not hold.** The two paragraphs above are left
 > standing rather than edited away, so an auditor can see exactly what was
 > claimed and what replaced it. The claim was that folding case *"cannot
@@ -1859,7 +1884,7 @@ resolved by hand before the mapping ships.
 > social-login flow) can create a case-variant duplicate, and the database will
 > accept it.
 >
-> **And it has.** Measured on production 2026-08-24: **case-variant duplicate
+> **And it has.** Measured on production 2026-08-23: **case-variant duplicate
 > accounts exist today, in more than one group.** The count is small and is
 > recorded in the deployment repository rather than here; the count is not the
 > finding. **The existence is the finding**, because a single colliding pair is
@@ -1887,20 +1912,38 @@ characters after lowercasing are **not eligible for a messaging handle in v1**.
 Those users can use free2z exactly as they do today; they cannot be discovered by
 handle in the messenger until they have a compliant handle.
 
-**How large is that population? Measured 2026-08-24: approximately 10% of
+**How large is that population? Measured 2026-08-23: approximately 10% of
 existing accounts.** The first revision of this section said the number "MUST be
 measured before the rule ships, because it is the difference between a rounding
-error and a migration project." The answer is neither, and that is the awkward
-result. It is about one account in ten, and **every ineligible account has logged
-in at least once, with all but one still active** — they are real users, not
-abandoned rows (§14.2). A rounding error would need no decision; a migration
-project would force one. This forces a *product* decision instead: exclude that
-~10% from messaging discovery in v1, or serve them with the separate opt-in
+error and a migration project." **The share alone does not settle that question,
+and this document does not settle it.** Which of the two it is depends on the
+absolute count rather than the proportion: one account in ten of a user base of a
+few thousand is an afternoon of hand resolution, and one account in ten of a user
+base of a few million is a programme of work. The absolute count is business data
+and is deliberately not published here; it is recorded in the deployment
+repository, and whoever plans the work has to read it there.
+
+What the share *does* settle is the part the design turns on. This is **about
+one account in ten**, not a fringe, and **every ineligible account has logged in
+at least once, with all but one still active** — they are real users, not
+abandoned rows (§14.2). That is enough to force a *product* decision: exclude
+that ~10% from messaging discovery in v1, or serve them with the separate opt-in
 messaging handle deferred in §14.4. That decision is not made here, so
 [`ARCHITECTURE.md` §13-O](./ARCHITECTURE.md#13-open-questions) **stays open** —
 its measurement sub-questions are closed, its policy sub-question is not.
-(Absolute counts are deliberately not published here; they are in the deployment
-repository.)
+
+> **Correction (2026-08-23) — the "neither a rounding error nor a migration
+> project" answer is withdrawn.** The first published version of the paragraph
+> above answered the rounding-error-or-migration-project question with *"The
+> answer is neither, and that is the awkward result."* What supported that answer
+> was a clause naming ~10% **of a small user base**, and that clause went away in
+> the same change that redacted absolute counts to proportions. The redaction was
+> right — this is a public repository and account totals are business data —
+> but it removed the evidence and left the conclusion standing. A bare proportion
+> cannot distinguish a rounding error from a migration project, so the conclusion
+> is withdrawn rather than re-derived from a number this repository should not
+> carry. The *product* consequence is unchanged and is what the share supports on
+> its own.
 
 ### 14.4 Alternatives rejected
 
@@ -2016,7 +2059,7 @@ Deliberately, and listed rather than invented:
   [§13-N](./ARCHITECTURE.md#13-open-questions), opened by §12.4.
 - **Messaging-handle eligibility for existing accounts** —
   [§13-O](./ARCHITECTURE.md#13-open-questions), opened by §14.3. **Measured
-  2026-08-24 and still open**: the measurement is in (approximately 10% of
+  2026-08-23 and still open**: the measurement is in (approximately 10% of
   existing accounts are ineligible, and all of them are real users), so the
   measurement sub-question is closed; whether those users are simply excluded
   from messaging discovery in v1 or given a separate opt-in messaging handle is a


### PR DESCRIPTION
Closes #575.

Docs only, `docs/e2ee/` only. No code, no workflows, no `rs/`.

## 1. The over-claim, in all three files it reached

The claim landed in three places, not one. `WIRE.md:1729` and
`THREAT-MODEL.md:574` came from #573; `CLIENT-CONTRACT.md:1418-1419` restated it
in #574 after the issue was filed. All three now carry the same scoping, taken
from the formulation `WIRE.md` §14.1 already had right — *"an entire class of
homograph and mixed-script impersonation"*: **an entire class, not every class.**

**Before** (`THREAT-MODEL.md:574`):

> Messaging handles are `[a-z0-9_]{1,30}` compared as bytes ([`WIRE.md` §14]),
> so the KT directory's label space contains **no confusable pairs** and
> homograph impersonation **does not exist inside the messenger** — that is why
> the charset was restricted, and it is what makes the log's labels not
> homograph-attackable ([`KT.md` §1.3]).

**After** — the sentence is left standing verbatim with an inline pointer, and
the correction is appended as a dated blockquote:

> …([`KT.md` §1.3](./KT.md#13-conventions)). **That sentence over-claims; see the
> correction below.**
>
> > **Correction (2026-08-23) — the charset removes the cross-script class of
> > confusables, not every confusable.** … `[a-z0-9_]` **does** contain
> > confusable pairs: `1`/`l` and `0`/`o` are the canonical ASCII homoglyphs and
> > are indistinguishable in most UI sans-serif faces, so `@a1ice` and `@alice`,
> > or `@b0b` and `@bob`, are two handles a reader cannot separate by eye. "No
> > confusable pairs" is false as written, and "homograph impersonation does not
> > exist inside the messenger" is true only of the cross-script kind. …
> > Same-script ASCII lookalikes are **out of scope for this mechanism**…

`WIRE.md` §14.1 keeps its (already correctly scoped) conclusion and gains a short
"an entire class, not every class" paragraph naming the residual ASCII pairs.

**`CLIENT-CONTRACT.md` got different treatment on purpose.** That document tells
frontend developers what to build and what copy to write, so a hedge there is
useless — an unactionable caveat ships as UI text anyway. It gets three build
rules instead: render handles in a disambiguating face on every surface; never
write copy that sells the charset as a safety property ("Handles are ASCII, so
they can't be faked" is named as false and must-not-ship); and point the user at
safety-number verification, because a handle is an address, not an
authentication.

**Two more instances found while checking for drift**, both fixed the same way so
the set cannot diverge again: `KT.md:92` ("why the log's labels are not
homograph-attackable") and `ARCHITECTURE.md:1148` ("so that homograph and
mixed-script impersonation does not exist"). Both were the unscoped form.

## 2. Correction pattern vs. wording fix — the split, and why

The house pattern (leave the wrong claim standing, inline pointer, dated
blockquote — `ARCHITECTURE.md:332`/`:342`/`:780`, `THREAT-MODEL.md:93`/`:115`,
`WIRE.md` §14.3) is expensive and it is meant to be. I applied it twice.

**Corrections (pattern applied):**

- **Item 1, `THREAT-MODEL.md` §4.10.** A published, false, security-relevant
  claim in the security-claims document. Exactly what the pattern exists for.
- **Item 4, `WIRE.md` §14.3.** "The answer is neither, and that is the awkward
  result" was published and its support was deleted. Withdrawing a published
  conclusion is a correction even when what replaces it is silence.

**Wording and structure (fixed in place):**

- **Item 2, `:586`.** "No property of it is claimed here" was ambiguous, not
  false — the intended meaning ("no *safety* property") is now written out
  alongside the two factual properties the section does claim.
- **Item 3.** A missing cross-reference is an omission; adding one corrects
  nothing.
- **Item 5**, `ARCHITECTURE.md:1153` "How many, closed." → "What share, closed."
  A heading that does not match its own body is a typo with ambition.
- **Item 6**, the three `WIRE.md` §14.2 nits (table unit, "almost the whole",
  "this section flagged three things"). Presentation.
- **`WIRE.md` §14.1 / `KT.md` / `ARCHITECTURE.md` §13-O.** These are restatements
  whose *operative* conclusion was already scoped or is a one-line summary
  pointing elsewhere; three more blockquotes would bury the one correction that
  matters. Each now points at `THREAT-MODEL.md` §4.10, which carries it.

Applying the pattern everywhere would make it noise; applying it nowhere would
lose the audit trail. The line I drew is: **published + false + load-bearing.**

## 3. Item 4 — no absolute count restored

The redaction to proportions was deliberate and correct, so I did **not** restore
an order-of-magnitude qualifier. Anything of the form "~10% of *N*" is an
absolute count to one significant figure, and zuu is public.

Instead the neither/nor conclusion is **withdrawn**, with the reason stated: the
rounding-error/migration-project question is about the absolute count, not the
share, and the count lives in the deployment repository. The paragraph now
illustrates the gap without asserting either pole ("one account in ten of a user
base of a few thousand is an afternoon of hand resolution; one in ten of a few
million is a programme of work") and keeps what the share *does* support on its
own — about one in ten, all real active users, therefore a product decision.
`ARCHITECTURE.md` §13-O carries the one-line version and links the correction.

## 4. Date stamps — I corrected them, and said so

**Decision: re-stamp `2026-08-24` → `2026-08-23` across `docs/e2ee/`, and record
both the re-stamp and the convention in the documents themselves.**

The argument for leaving them: rewriting a date after the fact is itself a small
honesty question, and these documents are only worth anything because their
dating is trustworthy.

The argument that won: the stamp is provably wrong, not merely
convention-divergent. #573 is `2026-08-23 19:14:52 -0700` and #574 is
`2026-08-23 19:20:07 -0700`. Nothing in them was measured or written on the 24th
— **a measurement cannot postdate the commit that carries it.** `2026-08-24` is
the UTC date, and #557 already set local date as the convention. Leaving a
knowably-false date in place to avoid the appearance of rewriting a date is the
wrong trade in a document whose whole claim is that it doesn't leave known-false
statements standing unmarked.

What makes it not a silent rewrite:

- A **`> Re-stamped 2026-08-23.`** note in `WIRE.md` §14.2 states what the old
  stamps were, why they were wrong, every file that changed, and that **no figure
  changed**.
- `README.md` gains a **Dating convention** paragraph (local date, matching the
  commit; a stamp ahead of its own commit is a defect — correct it and say so)
  and a **Scoping convention** paragraph, so the pattern behind #551/#558/#575
  is written down rather than rediscovered a fourth time.

Also added, per the issue's suggestion: a one-paragraph preamble to
`THREAT-MODEL.md` §5's "what we claim, precisely" table stating that every entry
is scoped by the section it cites, and that every correction in the document has
the same cause.

## Verification

- Every relative link and `#anchor` across `docs/e2ee/` resolves (checked
  programmatically over all 20 files; the only reported miss is a pre-existing
  `...sampleArgs` fragment inside a `CLIENT-CONTRACT.md` code sample).
- `scripts/check-public-repo-boundary.sh` passes.
- No absolute user count, production measurement, private repo name or issue
  number, or new description of an unpatched weakness is introduced. The
  case-collision blocker cross-reference restates what `WIRE.md` §14.3 already
  publishes.
- No contradiction introduced with `WIRE.md` §14 (which now states the scoped
  form itself), `KT.md`'s `[a-z0-9_]{1,30}`, or ADR 0013/0014.

## Deliberately not touched

- `CLIENT-CONTRACT.md:1423-1425` still says case folding is safe "because
  platform uniqueness is already enforced case-insensitively" — the argument
  `WIRE.md` §14.3 retracted. That is #576 and is left alone, as instructed.
  Flagging it here only so it isn't read as an oversight.
- #577, #578, `rs/`, `scripts/`.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
