### PR TITLE
feat(rs): add f2z-relay-proto, the shared relay protocol layer

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -74,7 +74,8 @@ jobs:
           scripts/check-rust-toolchain.sh --self-test
           scripts/check-rust-toolchain.sh \
             --toolchain-file rs/rust-toolchain.toml \
-            --manifest rs/crates/f2z-codec/Cargo.toml
+            --manifest rs/crates/f2z-codec/Cargo.toml \
+            --manifest rs/crates/f2z-relay-proto/Cargo.toml
 
       - name: Detect changes under rs/
         id: filter
@@ -283,17 +284,23 @@ jobs:
           key: rs-wasm
 
       # ADR 0001 requires one Rust core shared by ZUULI and the web client, so
-      # f2z-codec reaching wasm32 is a protocol-level requirement rather than a
-      # nice property. It is enforced by this job and not by convention, because
-      # "we kept it portable" stops being true the first week nobody checks. The
-      # first accidental `use std::` or tokio dependency fails here.
-      - name: Build f2z-codec for the browser target
+      # these crates reaching wasm32 is a protocol-level requirement rather than
+      # a nice property. It is enforced by this job and not by convention,
+      # because "we kept it portable" stops being true the first week nobody
+      # checks. The first accidental `use std::` or tokio dependency fails here.
+      #
+      # Every crate the clients link belongs on this line. It is spelled out
+      # rather than `--workspace` so that a future server binary — which will be
+      # AGPL, will pull tokio, and will never reach a browser — does not
+      # silently join the wasm build and then fail it.
+      - name: Build the client-linked crates for the browser target
         working-directory: rs
         run: |
           set -euo pipefail
           cargo build --locked --lib \
             --target "${{ steps.rust_toolchain.outputs.target }}" \
-            -p f2z-codec
+            -p f2z-codec \
+            -p f2z-relay-proto
 
   # Branch protection should require this stable context, `rs / gate`. It
   # succeeds only when the change detector and every applicable rs job

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -35,7 +35,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -48,10 +48,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crypto-common"
@@ -64,14 +82,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -94,10 +180,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "f2z-relay-proto"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "f2z-codec",
+ "proptest",
+ "subtle",
+ "tls_codec",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "fnv"
@@ -136,6 +239,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -274,6 +386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +418,29 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "subtle"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -35,6 +35,20 @@ expect_used = "deny"
 [workspace.dependencies]
 blake2 = { version = "0.10", default-features = false }
 tls_codec = { version = "0.4", default-features = false, features = ["derive"] }
+# Ed25519, `WIRE.md` §5. `default-features = false` drops `std` and `fast`:
+# `fast` is curve25519-dalek's precomputed-tables, which trades roughly 30 KiB
+# of table for signing speed, and this graph reaches wasm32 for the browser
+# client (ADR 0001) where the bundle is the scarce resource and the workload is
+# a handful of signatures per connection, not a batch verifier. `zeroize` is
+# kept: it is the only feature that touches what happens to a secret key's
+# bytes when it is dropped.
+ed25519-dalek = { version = "3", default-features = false, features = [
+  "zeroize",
+] }
+# `WIRE.md` §10: the existence-oracle rule requires key comparisons to be
+# constant time. Already in the graph beneath ed25519-dalek; named here so the
+# dependency is a decision rather than an accident of resolution.
+subtle = { version = "2", default-features = false }
 # Dev-dependency only. It builds for the host test runner, never for
 # wasm32-unknown-unknown, so its `std` default costs this crate nothing: the
 # library itself is `no_std` and the wasm job builds `--lib`.

--- a/rs/README.md
+++ b/rs/README.md
@@ -75,7 +75,8 @@ decided is `wallet/rust-toolchain.toml`, and
 
 ```
 scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
-                                --manifest rs/crates/f2z-codec/Cargo.toml
+                                --manifest rs/crates/f2z-codec/Cargo.toml \
+                                --manifest rs/crates/f2z-relay-proto/Cargo.toml
 ```
 
 fails the pull request the moment the two disagree. `.github/workflows/rs.yml`
@@ -108,8 +109,14 @@ prevent.
 | Crate | What it is |
 |---|---|
 | [`crates/f2z-codec`](./crates/f2z-codec) | The canonical encoding layer of `WIRE.md`: `tls_codec` wrappers for every wire structure, the domain-separated signing transcript (§5), the redacting newtypes, and the padding-bucket validator (§9). `no_std` + `alloc`, `#![forbid(unsafe_code)]`, no I/O, no async runtime, and it builds for `wasm32-unknown-unknown`. |
+| [`crates/f2z-relay-proto`](./crates/f2z-relay-proto) | The protocol layer above it: signed-command construction and verification in §5.1's exact order, the timestamp window and fail-closed seen-set (§5.5), the queue lifecycle and ACK arithmetic (§7, §8), the capability document (§11), the `HELLO` proof of possession (§5.2), and §4.3's typed in-flight window. Same constraints — `no_std` + `alloc`, no I/O, no clock, no randomness, and it builds for `wasm32-unknown-unknown`. |
 
-`f2z-codec` is separate from everything that will sit on top of it for three
+**The relay and the clients link both.** That is the licence boundary in
+practice: everything here is MIT because a third-party relay, ZUULI and the WASM
+web client all compile the same rules, and a rule that two implementations
+disagree about is how ciphertext gets deleted before it is read.
+
+`f2z-codec` is separate from everything that sits on top of it for three
 reasons, and each is enforced by a test rather than by intent:
 
 1. **Re-encode equality** (`WIRE.md` §3.3) is implemented once. Every received
@@ -127,14 +134,15 @@ reasons, and each is enforced by a test rather than by intent:
 ```bash
 cd rs
 cargo test
-cargo build --target wasm32-unknown-unknown -p f2z-codec
+cargo build --target wasm32-unknown-unknown --lib -p f2z-codec -p f2z-relay-proto
 ```
 
 The gates are the repository's shared scripts, pointed here with `--root`:
 
 ```bash
 scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
-                                --manifest rs/crates/f2z-codec/Cargo.toml
+                                --manifest rs/crates/f2z-codec/Cargo.toml \
+                                --manifest rs/crates/f2z-relay-proto/Cargo.toml
 scripts/check-rust-fmt.sh    --root rs
 scripts/check-rust-clippy.sh --root rs
 scripts/check-rust-deny.sh   --root rs --config rs/deny.toml

--- a/rs/crates/f2z-relay-proto/Cargo.toml
+++ b/rs/crates/f2z-relay-proto/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "f2z-relay-proto"
+version = "0.1.0"
+description = "Signed commands, anti-replay, queue lifecycle and capability documents for the free2z relay protocol (docs/e2ee/WIRE.md v1)"
+edition.workspace = true
+# A restatement of wallet/rust-toolchain.toml's channel in Cargo's MSRV form,
+# registered with `scripts/check-rust-toolchain.sh --manifest` so it cannot
+# drift. Not inherited from the workspace: that check reads this literal line.
+rust-version = "1.97"
+# Permissive, deliberately and explicitly. Both the relay and the clients link
+# this crate — that is the entire reason it exists as a separate layer — so the
+# AGPL-3.0 boundary starts at the server binaries and not here. Stated
+# literally rather than inherited so it is visible to anyone opening the crate.
+# rs/deny.toml enforces it.
+license = "MIT"
+repository.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ed25519-dalek = { workspace = true }
+# `version` beside `path` is not redundant: rs/deny.toml sets
+# `wildcards = "deny"`, and a bare path dependency is a wildcard requirement.
+f2z-codec = { path = "../f2z-codec", version = "0.1.0" }
+tls_codec = { workspace = true }
+subtle = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/rs/crates/f2z-relay-proto/src/capabilities.rs
+++ b/rs/crates/f2z-relay-proto/src/capabilities.rs
@@ -1,0 +1,779 @@
+//! The capability document — `WIRE.md` §11: signing it, verifying it,
+//! checking it against itself, and deciding whether to talk to the relay that
+//! published it.
+//!
+//! §11.1 calls this "a relay's entire externally-relevant policy, in one signed
+//! structure … the document a client reads to decide whether to use a relay at
+//! all, and the document a human reads to decide whether to trust its
+//! operator." Both of those readers are served here, and they are separated on
+//! purpose:
+//!
+//! - [`validate`] asks whether the document is a *valid* one — whether it
+//!   contradicts itself or claims a policy the architecture forbids. Every
+//!   check in it is a MUST that `WIRE.md` states.
+//! - [`ClientPolicy::accept`] asks whether *this* client will use *this* relay.
+//!   Every check in it is a client-side decision — §11.3's numbered list — and
+//!   a relay that fails one is not misbehaving, it is merely unsuitable.
+//!
+//! Collapsing the two would mean a client's strictness setting deciding what
+//! counts as a conforming relay, which is exactly backwards.
+//!
+//! # The honest note §11.2 makes, restated
+//!
+//! The document is served twice: canonically over the protocol, and as JSON at
+//! `/.well-known/free2z-relay/v1/capabilities` so that a human, a journalist or
+//! a researcher can read a relay's policy without a client. **Nothing forces
+//! the two representations to agree except the operator.** What makes
+//! divergence costly is that both are signed by the same key and both carry the
+//! same digest, so a client that fetches the well-known document and compares
+//! digests detects it. That comparison is [`check_digest`]; the fetching is not
+//! this crate's business, because this crate has no I/O.
+
+use alloc::vec::Vec;
+
+use f2z_codec::canonical::Canonical;
+use f2z_codec::commands::{Capabilities, SignedCapabilities};
+use f2z_codec::hash;
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::pow::{ALGORITHM_BLAKE2B_LEADING_ZERO_BITS, PowParams};
+use f2z_codec::types::{Digest, PublicKey, ShortBytes};
+
+use crate::error::{ProtoError, Refusal, Result};
+use crate::key::{SigningKey, VerifyingKey, keys_equal};
+use crate::queue::{
+    DEFAULT_IDLE_TTL_SECONDS, DEFAULT_MESSAGE_TTL_SECONDS, MAX_IDLE_TTL_SECONDS,
+    MAX_MESSAGE_TTL_SECONDS, TtlPolicy,
+};
+
+/// `transport_security` (§2.3).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransportSecurity {
+    /// `0` — the `--insecure-listen` override. The relay MUST publish this; a
+    /// relay that lies here is lying in its signed capability document, which
+    /// is the point of publishing it.
+    None,
+    /// `1` — TLS 1.3, the only conforming transport.
+    Tls,
+}
+
+/// `channel_binding_mode` (§5.3).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChannelBindingMode {
+    /// `0` — the relay cannot compute a TLS exporter, most often because TLS
+    /// is terminated at a load balancer, a CDN or an ingress controller. The
+    /// transcript uses 32 zero bytes and §5.5's restart argument stops holding.
+    None,
+    /// `1` — RFC 8446 §7.5 exporter, computed independently at both ends and
+    /// never transmitted.
+    TlsExporter,
+}
+
+/// `antireplay_persistence` (§5.3, §5.5).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AntiReplayPersistence {
+    /// `0` — the seen-set is lost on restart. Sound when the channel binding is
+    /// a TLS exporter, because a restart destroys every session; **not** sound
+    /// in `channel_binding_mode: none`, where the binding is a constant.
+    Volatile,
+    /// `1` — the seen-set survives a restart.
+    Durable,
+}
+
+/// `queue_creation_mode` (§13.1 layer 3).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QueueCreationMode {
+    /// `0` — no gate. Appropriate only for a private relay on a closed network.
+    Open,
+    /// `1` — the default: a `PowStamp` over a relay-issued challenge.
+    Pow,
+    /// `2` — an operator-issued bearer token. **A token is an identifier**: it
+    /// lets the operator link every queue created with it, which reintroduces
+    /// the linkability that opaque per-pair addresses exist to remove.
+    Token,
+}
+
+/// `durability_mode` (§8.4, §11.1).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DurabilityMode {
+    /// `0` — an `APPEND` that returned 0 may not survive a crash.
+    Memory,
+    /// `1` — batched writes; same caveat, smaller window.
+    Batched,
+    /// `2` — an `APPEND` that returned 0 survives a crash.
+    FsyncPerAppend,
+}
+
+macro_rules! byte_enum {
+    ($name:ident, $($value:expr => $variant:ident),+ $(,)?) => {
+        impl $name {
+            /// The published byte.
+            #[must_use]
+            pub const fn code(self) -> u8 {
+                match self {
+                    $(Self::$variant => $value,)+
+                }
+            }
+
+            /// Resolve a published byte.
+            ///
+            /// # Errors
+            ///
+            /// [`Refusal::CapabilitiesInconsistent`] for a value §11.1 does not
+            /// define. A mode byte outside its range is not a forward-compatible
+            /// extension: §3.5 is explicit that v1 has no "ignore what you do
+            /// not know", and a client that guessed would be guessing about the
+            /// relay's security posture.
+            pub const fn from_code(code: u8) -> Result<Self> {
+                Ok(match code {
+                    $($value => Self::$variant,)+
+                    _ => return Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent)),
+                })
+            }
+        }
+    };
+}
+
+byte_enum!(TransportSecurity, 0 => None, 1 => Tls);
+byte_enum!(ChannelBindingMode, 0 => None, 1 => TlsExporter);
+byte_enum!(AntiReplayPersistence, 0 => Volatile, 1 => Durable);
+byte_enum!(QueueCreationMode, 0 => Open, 1 => Pow, 2 => Token);
+byte_enum!(DurabilityMode, 0 => Memory, 1 => Batched, 2 => FsyncPerAppend);
+
+/// The exact bytes a relay signs, and the exact bytes a client verifies.
+///
+/// # Errors
+///
+/// [`f2z_codec::CodecError`] if the document cannot be encoded — in practice,
+/// an operator string longer than its length prefix can describe.
+pub fn signing_bytes(capabilities: &Capabilities) -> Result<Vec<u8>> {
+    Ok(capabilities.encode_canonical()?)
+}
+
+/// `capabilities_digest = H("free2z/relay/v1/caps", tls_codec(Capabilities))`
+/// (§6.1).
+///
+/// # Errors
+///
+/// As [`signing_bytes`].
+pub fn digest(capabilities: &Capabilities) -> Result<Digest> {
+    Ok(hash::capabilities_digest(&signing_bytes(capabilities)?))
+}
+
+/// Sign a capability document.
+///
+/// The key MUST be the relay's long-term identity key — the one whose public
+/// half is `relay_identity_pk` in the document itself. That is checked here
+/// rather than assumed, because a document signed by any other key is one that
+/// no client can ever verify and every client will refuse.
+///
+/// # Errors
+///
+/// - [`Refusal::CapabilitiesInconsistent`] if `capabilities.relay_identity_pk`
+///   is not this key's public half.
+/// - As [`signing_bytes`].
+pub fn sign(key: &SigningKey, capabilities: Capabilities) -> Result<SignedCapabilities> {
+    if !keys_equal(&capabilities.relay_identity_pk, &key.public_key()) {
+        return Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent));
+    }
+    let signature = key.sign(&signing_bytes(&capabilities)?);
+    Ok(SignedCapabilities {
+        capabilities,
+        signature,
+    })
+}
+
+/// Verify a document's signature under the key it names (§11.3 step 1).
+///
+/// `proven_identity` is the `relay_identity_pk` the relay proved possession of
+/// in `HELLO` (§5.2). Passing it is what makes this a check rather than a
+/// tautology: a document is self-signed, so verifying it against its own
+/// embedded key proves only that whoever wrote the key also wrote the
+/// signature. The binding to a *particular* relay comes from `HELLO`.
+///
+/// # Errors
+///
+/// - [`Refusal::CapabilitiesInconsistent`] if the document names a key other
+///   than the one proven in `HELLO`.
+/// - [`Refusal::CapabilitiesSignatureInvalid`] if the signature does not
+///   verify.
+/// - [`Refusal::RelayKeyInvalid`] if the key is not a curve point.
+pub fn verify(signed: &SignedCapabilities, proven_identity: &PublicKey) -> Result<()> {
+    if !keys_equal(&signed.capabilities.relay_identity_pk, proven_identity) {
+        return Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent));
+    }
+    let key = VerifyingKey::from_public_key(proven_identity)
+        .map_err(|_| ProtoError::Refused(Refusal::RelayKeyInvalid))?;
+    key.verify(&signing_bytes(&signed.capabilities)?, &signed.signature)
+        .map_err(|_| ProtoError::Refused(Refusal::CapabilitiesSignatureInvalid))
+}
+
+/// Compare a document against the `capabilities_digest` a `HELLO` carried
+/// (§6.1, §11.2).
+///
+/// §6.1's reason for the field: a client can detect a policy change
+/// mid-connection without refetching. §11.2's reason: a client that also
+/// fetches the well-known JSON document can detect a relay serving one policy
+/// to humans and another to clients. Clients SHOULD do the second on first use
+/// of a relay and MUST refuse on mismatch.
+///
+/// # Errors
+///
+/// [`Refusal::CapabilitiesDigestMismatch`].
+pub fn check_digest(capabilities: &Capabilities, expected: &Digest) -> Result<()> {
+    if digest(capabilities)? == *expected {
+        Ok(())
+    } else {
+        Err(ProtoError::Refused(Refusal::CapabilitiesDigestMismatch))
+    }
+}
+
+/// Is this document a valid one at all? (§11.1)
+///
+/// Every check here is a MUST the specification states, and none of them is a
+/// preference. A document that fails one is not a relay this client dislikes;
+/// it is a relay contradicting the protocol it claims to speak.
+///
+/// # Errors
+///
+/// - [`Refusal::RelayIdNotDerived`] if `relay_id` is not the digest of
+///   `relay_identity_pk` (§5.2).
+/// - [`Refusal::TtlCeilingExceeded`] if `max_message_ttl_seconds` is above the
+///   architecture's 30-day ceiling (§11.3 step 5).
+/// - [`Refusal::PowAlgorithmUnknown`] if a `PowParams` names an algorithm v1
+///   does not define (§13.1).
+/// - [`Refusal::CapabilitiesInconsistent`] for everything else: an undefined
+///   mode byte, an empty version or padding list, a padding set that is not
+///   strictly ascending, a TTL band whose default sits outside its own clamps,
+///   a frame cap below the relay's own largest padding bucket, a `none`
+///   transport that still claims a channel binding, a `pow` creation mode with
+///   no parameters, or contact queues offered without the proof of work §12.3
+///   requires.
+pub fn validate(capabilities: &Capabilities) -> Result<()> {
+    let inconsistent = ProtoError::Refused(Refusal::CapabilitiesInconsistent);
+
+    // §5.2: the identity binding must actually be the digest of the identity.
+    if hash::relay_id(&capabilities.relay_identity_pk) != capabilities.relay_id {
+        return Err(ProtoError::Refused(Refusal::RelayIdNotDerived));
+    }
+
+    // `uint16 protocol_versions<1..255>` — the lower bound is 1.
+    if capabilities.protocol_versions.is_empty() {
+        return Err(inconsistent);
+    }
+
+    let transport = TransportSecurity::from_code(capabilities.transport_security)?;
+    let binding = ChannelBindingMode::from_code(capabilities.channel_binding_mode)?;
+    AntiReplayPersistence::from_code(capabilities.antireplay_persistence)?;
+    let creation = QueueCreationMode::from_code(capabilities.queue_creation_mode)?;
+    DurabilityMode::from_code(capabilities.durability_mode)?;
+    let contact_queues = flag(capabilities.contact_queues_enabled)?;
+    flag(capabilities.per_source_limits)?;
+
+    // §2.3 obligation 2: no TLS session, so no exporter to derive from.
+    if matches!(transport, TransportSecurity::None) && !matches!(binding, ChannelBindingMode::None)
+    {
+        return Err(inconsistent);
+    }
+
+    if capabilities.max_inflight == 0 {
+        return Err(inconsistent);
+    }
+
+    // §9: `uint32 padding_sizes<1..2^16-1>`, ascending. `PaddingBuckets`
+    // refuses anything else, including duplicates and a zero-length bucket.
+    let buckets = PaddingBuckets::new(capabilities.padding_sizes.as_slice().to_vec())
+        .map_err(|_| inconsistent)?;
+    // A relay whose frame cap cannot carry its own largest bucket has published
+    // a set no client can use. This is a necessary condition, not a sufficient
+    // one — the frame also carries an auth block and a body prefix.
+    if u64::from(capabilities.max_frame_bytes) < u64::from(buckets.largest()) {
+        return Err(inconsistent);
+    }
+
+    if capabilities.max_message_ttl_seconds > MAX_MESSAGE_TTL_SECONDS {
+        return Err(ProtoError::Refused(Refusal::TtlCeilingExceeded));
+    }
+    if !ttl_policy(capabilities).is_consistent() {
+        return Err(inconsistent);
+    }
+
+    validate_pow(&capabilities.queue_creation_pow)?;
+    validate_pow(&capabilities.contact_append_pow)?;
+    // §13.1: `pow` mode without parameters is a gate with nothing behind it.
+    if matches!(creation, QueueCreationMode::Pow) && !capabilities.queue_creation_pow.is_required()
+    {
+        return Err(inconsistent);
+    }
+    // §12.3: a relay MUST enforce all four contact-queue caps, and proof of
+    // work is one of them. Offering contact queues without it is offering an
+    // unsigned, unmetered write endpoint to the whole internet.
+    if contact_queues && !capabilities.contact_append_pow.is_required() {
+        return Err(inconsistent);
+    }
+
+    Ok(())
+}
+
+/// A relay's §7.7 clamps, lifted out of its capability document.
+#[must_use]
+pub fn ttl_policy(capabilities: &Capabilities) -> TtlPolicy {
+    TtlPolicy {
+        min_message_ttl_seconds: capabilities.min_message_ttl_seconds,
+        max_message_ttl_seconds: capabilities.max_message_ttl_seconds,
+        default_message_ttl_seconds: capabilities.default_message_ttl_seconds,
+        min_idle_ttl_seconds: capabilities.min_idle_ttl_seconds,
+        max_idle_ttl_seconds: capabilities.max_idle_ttl_seconds,
+        default_idle_ttl_seconds: capabilities.default_idle_ttl_seconds,
+    }
+}
+
+fn validate_pow(params: &PowParams) -> Result<()> {
+    params
+        .validate()
+        .map_err(|_| ProtoError::Refused(Refusal::PowAlgorithmUnknown))
+}
+
+fn flag(byte: u8) -> Result<bool> {
+    match byte {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent)),
+    }
+}
+
+/// What *this* client requires of a relay (§11.3).
+///
+/// Defaults are the conservative reading of §11.3: refuse a plaintext relay,
+/// refuse an implausible padding set, refuse a token-gated one. The two that
+/// §5.3 and §5.5 describe as a *strict mode* — requiring a channel binding and
+/// requiring a durable seen-set — default to off, because a relay behind a
+/// TLS-terminating proxy is "a common and legitimate deployment" and refusing
+/// every one of them by default would be a stricter policy than the
+/// specification's.
+#[derive(Clone, Debug)]
+pub struct ClientPolicy {
+    /// §2.3: connect to a relay serving without TLS. MUST be an explicit,
+    /// per-relay user opt-in, and the UI must state that message ciphertext is
+    /// protected by MLS but that connection metadata, queue addresses and
+    /// commands travel in the clear.
+    pub allow_insecure_transport: bool,
+    /// §5.3's strict mode: refuse `channel_binding_mode: none`.
+    pub require_channel_binding: bool,
+    /// §5.5: refuse `antireplay_persistence: volatile`.
+    pub require_durable_antireplay: bool,
+    /// Refuse a relay whose seen-set retention is shorter than twice its own
+    /// clock skew. See [`Refusal::AntiReplayWindowTooShort`] — this is a check
+    /// `WIRE.md` does not state and, on the reading in that variant's
+    /// documentation, should.
+    pub require_sound_antireplay_window: bool,
+    /// §9: refuse an implausibly fine-grained padding set.
+    pub require_plausible_padding: bool,
+    /// §13.1: refuse `queue_creation_mode: token`, which is linkable.
+    pub allow_token_queue_creation: bool,
+    /// §11.3 step 4: the sizes this client will emit. The relay's set MUST be a
+    /// superset.
+    pub emitted_padding: PaddingBuckets,
+}
+
+impl Default for ClientPolicy {
+    fn default() -> Self {
+        Self {
+            allow_insecure_transport: false,
+            require_channel_binding: false,
+            require_durable_antireplay: false,
+            require_sound_antireplay_window: true,
+            require_plausible_padding: true,
+            allow_token_queue_creation: false,
+            emitted_padding: PaddingBuckets::default(),
+        }
+    }
+}
+
+impl ClientPolicy {
+    /// §11.3's checklist, in order, over a document that has already been
+    /// signature-verified.
+    ///
+    /// # Errors
+    ///
+    /// [`validate`]'s errors, then the [`Refusal`] naming the policy the relay
+    /// failed.
+    pub fn accept(&self, capabilities: &Capabilities) -> Result<()> {
+        validate(capabilities)?;
+
+        // Step 2.
+        if matches!(
+            TransportSecurity::from_code(capabilities.transport_security)?,
+            TransportSecurity::None
+        ) && !self.allow_insecure_transport
+        {
+            return Err(ProtoError::Refused(Refusal::InsecureTransport));
+        }
+        // Step 3.
+        if matches!(
+            ChannelBindingMode::from_code(capabilities.channel_binding_mode)?,
+            ChannelBindingMode::None
+        ) && self.require_channel_binding
+        {
+            return Err(ProtoError::Refused(Refusal::NoChannelBinding));
+        }
+        if matches!(
+            AntiReplayPersistence::from_code(capabilities.antireplay_persistence)?,
+            AntiReplayPersistence::Volatile
+        ) && self.require_durable_antireplay
+        {
+            return Err(ProtoError::Refused(Refusal::VolatileAntiReplay));
+        }
+        if self.require_sound_antireplay_window
+            && u64::from(capabilities.antireplay_window_ms)
+                < u64::from(capabilities.clock_skew_ms).saturating_mul(2)
+        {
+            return Err(ProtoError::Refused(Refusal::AntiReplayWindowTooShort));
+        }
+        // Step 4.
+        let buckets = PaddingBuckets::new(capabilities.padding_sizes.as_slice().to_vec())
+            .map_err(|_| ProtoError::Refused(Refusal::CapabilitiesInconsistent))?;
+        if !buckets.is_superset_of(&self.emitted_padding) {
+            return Err(ProtoError::Refused(Refusal::PaddingNotSuperset));
+        }
+        if self.require_plausible_padding && !buckets.is_plausible() {
+            return Err(ProtoError::Refused(Refusal::PaddingImplausible));
+        }
+        // Step 6.
+        if matches!(
+            QueueCreationMode::from_code(capabilities.queue_creation_mode)?,
+            QueueCreationMode::Token
+        ) && !self.allow_token_queue_creation
+        {
+            return Err(ProtoError::Refused(Refusal::QueueCreationTokenGated));
+        }
+
+        Ok(())
+    }
+}
+
+/// A capability document carrying every default `WIRE.md` publishes, for a
+/// relay that has not been configured yet.
+///
+/// The operator and provenance blocks are **empty**, and that is not something
+/// to ship: §11.1 is explicit that `operator_jurisdiction`, the contact fields,
+/// `source_commit` and `build_digest` are the point of the document — they are
+/// what turns "open source and self-hostable" into something a third party can
+/// check, and what makes a user's choice among *k* relays an informed one. A
+/// relay that publishes this unedited is publishing a document that answers
+/// none of the questions it exists to answer.
+///
+/// # Errors
+///
+/// [`f2z_codec::CodecError`] cannot actually arise here; the signature is
+/// fallible only because the empty operator strings are constructed through the
+/// same length-checked constructor as any other.
+pub fn defaults(relay_identity_pk: &PublicKey, published_at_ms: u64) -> Result<Capabilities> {
+    let empty = ShortBytes::new(&b""[..])?;
+    Ok(Capabilities {
+        protocol_versions: alloc::vec![f2z_codec::PROTOCOL_VERSION].into(),
+
+        relay_identity_pk: *relay_identity_pk,
+        relay_id: hash::relay_id(relay_identity_pk),
+
+        transport_security: TransportSecurity::Tls.code(),
+        channel_binding_mode: ChannelBindingMode::TlsExporter.code(),
+        // §4.1 default.
+        max_frame_bytes: 1024 * 1024,
+        // §4.3 default.
+        max_inflight: crate::inflight::DEFAULT_MAX_INFLIGHT,
+        // §2.4: operators MUST set any front-end idle timeout to at least 3x.
+        ws_ping_interval_seconds: 25,
+        // §2.5 default.
+        handshake_timeout_ms: 10_000,
+
+        // §5.5 default: ±2 minutes.
+        clock_skew_ms: 120_000,
+        // Twice the skew, for the reason `Refusal::AntiReplayWindowTooShort`
+        // gives. `WIRE.md` publishes no default for this field.
+        antireplay_window_ms: 240_000,
+        antireplay_persistence: AntiReplayPersistence::Volatile.code(),
+
+        padding_sizes: PaddingBuckets::default().sizes().to_vec().into(),
+        // §9 default.
+        max_chunk_bytes: f2z_codec::padding::DEFAULT_MAX_CHUNK_BYTES,
+
+        min_message_ttl_seconds: 60,
+        max_message_ttl_seconds: MAX_MESSAGE_TTL_SECONDS,
+        default_message_ttl_seconds: DEFAULT_MESSAGE_TTL_SECONDS,
+        min_idle_ttl_seconds: 3_600,
+        max_idle_ttl_seconds: MAX_IDLE_TTL_SECONDS,
+        default_idle_ttl_seconds: DEFAULT_IDLE_TTL_SECONDS,
+        max_queue_messages: 4_096,
+        max_queue_bytes: 64 * 1024 * 1024,
+
+        // §13.1: `pow` is the default.
+        queue_creation_mode: QueueCreationMode::Pow.code(),
+        queue_creation_pow: PowParams {
+            algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+            difficulty_bits: 20,
+            challenge_ttl_ms: 60_000,
+        },
+        contact_queues_enabled: 1,
+        contact_max_pending: 64,
+        contact_max_bytes: 256 * 1024,
+        contact_append_pow: PowParams {
+            algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+            difficulty_bits: 20,
+            challenge_ttl_ms: 60_000,
+        },
+        per_source_limits: 1,
+        durability_mode: DurabilityMode::FsyncPerAppend.code(),
+
+        operator_name: empty.clone(),
+        operator_contact: empty.clone(),
+        operator_abuse_contact: empty.clone(),
+        operator_jurisdiction: empty.clone(),
+        operator_policy_url: empty.clone(),
+
+        source_repo_url: empty.clone(),
+        source_commit: empty.clone(),
+        build_digest: empty,
+
+        published_at_ms,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn identity() -> SigningKey {
+        SigningKey::from_seed(&[0x21; 32])
+    }
+
+    fn document() -> Capabilities {
+        defaults(&identity().public_key(), 1_800_000_000_000).unwrap()
+    }
+
+    #[test]
+    fn the_published_defaults_are_a_valid_document() {
+        let capabilities = document();
+        assert!(validate(&capabilities).is_ok());
+        assert!(ClientPolicy::default().accept(&capabilities).is_ok());
+    }
+
+    #[test]
+    fn a_document_verifies_only_against_the_key_hello_proved() {
+        let key = identity();
+        let signed = sign(&key, document()).unwrap();
+        assert!(verify(&signed, &key.public_key()).is_ok());
+
+        let impostor = SigningKey::from_seed(&[0x22; 32]);
+        assert_eq!(
+            verify(&signed, &impostor.public_key()),
+            Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent))
+        );
+
+        // A document whose bytes changed after signing.
+        let mut tampered = signed.clone();
+        tampered.capabilities.max_queue_messages += 1;
+        assert_eq!(
+            verify(&tampered, &key.public_key()),
+            Err(ProtoError::Refused(Refusal::CapabilitiesSignatureInvalid))
+        );
+    }
+
+    #[test]
+    fn signing_with_the_wrong_key_is_refused_at_the_source() {
+        let impostor = SigningKey::from_seed(&[0x23; 32]);
+        assert_eq!(
+            sign(&impostor, document()).map(|_| ()),
+            Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent))
+        );
+    }
+
+    #[test]
+    fn the_digest_detects_a_document_that_changed_under_us() {
+        let capabilities = document();
+        let expected = digest(&capabilities).unwrap();
+        assert!(check_digest(&capabilities, &expected).is_ok());
+
+        let mut changed = capabilities;
+        changed.min_idle_ttl_seconds += 1;
+        assert_eq!(
+            check_digest(&changed, &expected),
+            Err(ProtoError::Refused(Refusal::CapabilitiesDigestMismatch))
+        );
+    }
+
+    #[test]
+    fn a_relay_id_that_is_not_the_digest_of_the_key_is_refused() {
+        let mut capabilities = document();
+        capabilities.relay_id = f2z_codec::types::RelayId::new([0u8; 32]);
+        assert_eq!(
+            validate(&capabilities),
+            Err(ProtoError::Refused(Refusal::RelayIdNotDerived))
+        );
+    }
+
+    #[test]
+    fn a_ttl_above_the_architectures_ceiling_is_refused() {
+        let mut capabilities = document();
+        capabilities.max_message_ttl_seconds = MAX_MESSAGE_TTL_SECONDS + 1;
+        assert_eq!(
+            validate(&capabilities),
+            Err(ProtoError::Refused(Refusal::TtlCeilingExceeded))
+        );
+    }
+
+    #[test]
+    fn a_plaintext_relay_must_also_declare_no_channel_binding() {
+        let mut capabilities = document();
+        capabilities.transport_security = TransportSecurity::None.code();
+        assert_eq!(
+            validate(&capabilities),
+            Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent)),
+            "§2.3: there is no TLS session to export from"
+        );
+
+        capabilities.channel_binding_mode = ChannelBindingMode::None.code();
+        assert!(validate(&capabilities).is_ok());
+        assert_eq!(
+            ClientPolicy::default().accept(&capabilities),
+            Err(ProtoError::Refused(Refusal::InsecureTransport))
+        );
+        let opted_in = ClientPolicy {
+            allow_insecure_transport: true,
+            ..ClientPolicy::default()
+        };
+        assert!(opted_in.accept(&capabilities).is_ok());
+        let strict = ClientPolicy {
+            allow_insecure_transport: true,
+            require_channel_binding: true,
+            ..ClientPolicy::default()
+        };
+        assert_eq!(
+            strict.accept(&capabilities),
+            Err(ProtoError::Refused(Refusal::NoChannelBinding))
+        );
+    }
+
+    #[test]
+    fn undefined_mode_bytes_are_refused_rather_than_guessed() {
+        for mutate in [
+            (|c: &mut Capabilities| c.transport_security = 2) as fn(&mut Capabilities),
+            |c| c.channel_binding_mode = 2,
+            |c| c.antireplay_persistence = 2,
+            |c| c.queue_creation_mode = 3,
+            |c| c.durability_mode = 3,
+            |c| c.per_source_limits = 2,
+            |c| c.contact_queues_enabled = 2,
+        ] {
+            let mut capabilities = document();
+            mutate(&mut capabilities);
+            assert_eq!(
+                validate(&capabilities),
+                Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent))
+            );
+        }
+    }
+
+    #[test]
+    fn a_padding_set_that_is_not_ascending_is_refused() {
+        let mut capabilities = document();
+        capabilities.padding_sizes = vec![4096u32, 1024].into();
+        assert_eq!(
+            validate(&capabilities),
+            Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent))
+        );
+    }
+
+    #[test]
+    fn a_client_refuses_a_relay_that_cannot_carry_its_own_sizes() {
+        let capabilities = document();
+        let finer = ClientPolicy {
+            emitted_padding: PaddingBuckets::new(vec![1024, 2048]).unwrap(),
+            ..ClientPolicy::default()
+        };
+        assert_eq!(
+            finer.accept(&capabilities),
+            Err(ProtoError::Refused(Refusal::PaddingNotSuperset))
+        );
+    }
+
+    #[test]
+    fn an_implausibly_fine_grained_relay_set_is_refused() {
+        let mut capabilities = document();
+        capabilities.padding_sizes = vec![1024u32, 1280, 4096, 16_384, 65_536].into();
+        assert!(validate(&capabilities).is_ok(), "ascending, so it is valid");
+        assert_eq!(
+            ClientPolicy::default().accept(&capabilities),
+            Err(ProtoError::Refused(Refusal::PaddingImplausible)),
+            "…but a client SHOULD still refuse it"
+        );
+    }
+
+    #[test]
+    fn a_token_gated_relay_is_refused_unless_the_user_accepts_the_linkability() {
+        let mut capabilities = document();
+        capabilities.queue_creation_mode = QueueCreationMode::Token.code();
+        assert!(validate(&capabilities).is_ok());
+        assert_eq!(
+            ClientPolicy::default().accept(&capabilities),
+            Err(ProtoError::Refused(Refusal::QueueCreationTokenGated))
+        );
+        let permissive = ClientPolicy {
+            allow_token_queue_creation: true,
+            ..ClientPolicy::default()
+        };
+        assert!(permissive.accept(&capabilities).is_ok());
+    }
+
+    #[test]
+    fn pow_mode_without_parameters_is_a_gate_with_nothing_behind_it() {
+        let mut capabilities = document();
+        capabilities.queue_creation_pow = PowParams::none();
+        assert_eq!(
+            validate(&capabilities),
+            Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent))
+        );
+    }
+
+    #[test]
+    fn contact_queues_without_proof_of_work_are_refused() {
+        let mut capabilities = document();
+        capabilities.contact_append_pow = PowParams::none();
+        assert_eq!(
+            validate(&capabilities),
+            Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent))
+        );
+        // Turning contact queues off makes the same document valid again.
+        capabilities.contact_queues_enabled = 0;
+        assert!(validate(&capabilities).is_ok());
+    }
+
+    #[test]
+    fn an_unknown_pow_algorithm_is_refused() {
+        let mut capabilities = document();
+        capabilities.contact_append_pow.algorithm = 9;
+        assert_eq!(
+            validate(&capabilities),
+            Err(ProtoError::Refused(Refusal::PowAlgorithmUnknown))
+        );
+    }
+
+    #[test]
+    fn a_seen_set_window_shorter_than_twice_the_skew_is_refused_by_default() {
+        let mut capabilities = document();
+        capabilities.antireplay_window_ms = capabilities.clock_skew_ms;
+        assert!(
+            validate(&capabilities).is_ok(),
+            "WIRE.md permits this; that is the defect"
+        );
+        assert_eq!(
+            ClientPolicy::default().accept(&capabilities),
+            Err(ProtoError::Refused(Refusal::AntiReplayWindowTooShort))
+        );
+        let lenient = ClientPolicy {
+            require_sound_antireplay_window: false,
+            ..ClientPolicy::default()
+        };
+        assert!(lenient.accept(&capabilities).is_ok());
+    }
+}

--- a/rs/crates/f2z-relay-proto/src/command.rs
+++ b/rs/crates/f2z-relay-proto/src/command.rs
@@ -1,0 +1,1220 @@
+//! Signed commands: building one, and verifying one.
+//!
+//! This is `WIRE.md` §5 and §6 turned into two operations that are each other's
+//! inverse, plus the typed pairing that keeps a command's request and response
+//! from drifting apart.
+//!
+//! # The verification order is the security argument
+//!
+//! §5.1 fixes an order and says "it matters". [`CommandVerifier::verify`]
+//! implements exactly it:
+//!
+//! 1. Decode and re-encode-compare (§3.3). The frame half is `f2z-codec`'s and
+//!    has already happened by the time a [`Request`] exists; the *body* half
+//!    happens here, because a frame's body is opaque bytes at the framing layer
+//!    and a non-canonical structure inside it would survive a frame-level
+//!    re-encode untouched.
+//! 2. Timestamp window (§5.5) → `ERR_STALE_TIMESTAMP`.
+//! 3. `(signer_key, nonce)` seen-set (§5.5) → `ERR_REPLAY`.
+//! 4. Rebuild the transcript **from the relay's own `relay_id` and its own
+//!    `channel_binding`** and verify the signature → `ERR_BAD_SIGNATURE`.
+//! 5. Address and self-authentication rules (§6.2, §6.3) → `ERR_NO_ACCESS`.
+//! 6. Policy — the payload's padding bucket (§9).
+//!
+//! Steps 2 and 3 precede the signature check because they are cheap and they
+//! are the flood-resistant filters. Step 5 follows it so that an unsigned guess
+//! cannot probe the address space. Reordering any of that is a security change,
+//! which is why the whole sequence lives in one function instead of being
+//! composed by each call site.
+//!
+//! What this module does **not** do is look anything up. Steps 5's *second*
+//! half — "the address exists and `signer_key` is the key registered for it" —
+//! and step 6's quotas are relay state; they live in [`crate::queue`] and above.
+
+use core::fmt;
+use core::marker::PhantomData;
+
+use alloc::vec::Vec;
+
+use f2z_codec::canonical::{Canonical, decode_canonical};
+use f2z_codec::commands::{
+    AckRequest, AckResponse, AppendRequest, Auth, BindSendRequest, ChallengeRequest,
+    ChallengeResponse, Command, ContactAppendRequest, CreateContactQueueRequest,
+    CreateContactQueueResponse, CreateQueueRequest, CreateQueueResponse, HelloRequest,
+    HelloResponse, ReadRequest, ReadResponse, SignedCapabilities, SubscribeResponse,
+    TranscriptAddress,
+};
+use f2z_codec::frame::{CommandAuth, RelayFrame, Request, SignedAuth};
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::transcript::{AuthContext, TranscriptBuilder};
+use f2z_codec::types::{Body, Nonce, Payload, PublicKey, QueueAddress};
+use f2z_codec::{ErrorCode, PROTOCOL_VERSION};
+
+use crate::error::{ProtoError, Result};
+use crate::key::{SigningKey, keys_equal};
+use crate::replay::{ReplayKey, SeenSet, TimestampWindow};
+
+pub use empty::Empty;
+
+mod empty {
+    use alloc::vec::Vec;
+
+    use tls_codec::{DeserializeBytes, Error as TlsError, SerializeBytes, Size};
+
+    /// A body of zero bytes.
+    ///
+    /// Several commands have empty bodies **by rule** rather than by accident:
+    /// `BIND_SEND`'s response is empty because §6.3 says so, and `APPEND`'s is
+    /// empty because an index, a depth or a timestamp would convert the send
+    /// capability into a weak read capability. Giving that its own type means
+    /// the pairing in [`RelayCommand`] can state it, and means a caller cannot
+    /// quietly start putting queue state in one.
+    ///
+    /// [`RelayCommand`]: crate::command::RelayCommand
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct Empty;
+
+    impl Size for Empty {
+        fn tls_serialized_len(&self) -> usize {
+            0
+        }
+    }
+
+    impl SerializeBytes for Empty {
+        fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl DeserializeBytes for Empty {
+        fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+            // Consumes nothing. `decode_canonical` demands the whole input be
+            // consumed, so a non-empty body decoded as `Empty` is rejected
+            // there rather than silently ignored — which is §3.5's "no ignoring
+            // unknown trailing bytes" applied to the emptiest case.
+            Ok((Self, bytes))
+        }
+    }
+}
+
+/// One command of §6, with its request body type and its response body type
+/// bound together.
+///
+/// The pairing is the point. A relay handler and a client call site both name
+/// the *command*, never a pair of body types, so there is no place to write a
+/// `READ` request beside an `ACK` response. [`crate::inflight::Ticket`] carries
+/// the same type from the moment a request is issued to the moment its response
+/// is decoded, which is what makes a mismatched correlation a compile error
+/// rather than a runtime surprise.
+pub trait RelayCommand: Sized {
+    /// The §6 command this implements.
+    const COMMAND: Command;
+
+    /// The request body, encoded per §6.
+    type Request: Canonical + fmt::Debug;
+
+    /// The response body, encoded per §6. [`Empty`] where the specification
+    /// says the response carries nothing.
+    type Response: Canonical + fmt::Debug;
+
+    /// The command's own validity and self-authentication rules.
+    ///
+    /// `auth` is `None` for the unsigned commands of §6.1 and §12.2. The
+    /// default accepts everything; the two creation commands and `BIND_SEND`
+    /// override it, because for them the signature proves possession of a key
+    /// carried *in the body* rather than of a key the relay has on file.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the command's own rule says.
+    fn check(request: &Self::Request, auth: Option<&SignedAuth>) -> Result<()> {
+        let _ = (request, auth);
+        Ok(())
+    }
+
+    /// The ciphertext payload this command carries, if any (§9).
+    ///
+    /// Exactly two commands have one — `APPEND` and `CONTACT_APPEND` — and
+    /// naming them here is what lets [`CommandVerifier`] enforce the padding
+    /// buckets without a match on the command code at every call site.
+    fn payload(request: &Self::Request) -> Option<&Payload> {
+        let _ = request;
+        None
+    }
+}
+
+/// The marker types, one per command code of §6.
+///
+/// They exist only to carry [`RelayCommand`]'s associated types; none of them
+/// is ever constructed.
+pub mod ops {
+    use super::{
+        AckRequest, AckResponse, AppendRequest, BindSendRequest, ChallengeRequest,
+        ChallengeResponse, Command, ContactAppendRequest, CreateContactQueueRequest,
+        CreateContactQueueResponse, CreateQueueRequest, CreateQueueResponse, Empty, ErrorCode,
+        HelloRequest, HelloResponse, Payload, ProtoError, ReadRequest, ReadResponse, RelayCommand,
+        Result, SignedAuth, SignedCapabilities, SubscribeResponse, keys_equal,
+    };
+
+    macro_rules! command {
+        (
+            $(#[$meta:meta])*
+            $name:ident, $command:ident, $request:ty, $response:ty
+        ) => {
+            $(#[$meta])*
+            #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+            pub struct $name;
+
+            impl RelayCommand for $name {
+                const COMMAND: Command = Command::$command;
+                type Request = $request;
+                type Response = $response;
+            }
+        };
+    }
+
+    command!(
+        /// `0x0001` (§6.1). MUST be the first frame on a connection.
+        Hello,
+        Hello,
+        HelloRequest,
+        HelloResponse
+    );
+    command!(
+        /// `0x0002` (§6.1). The response is the §11.1 document plus the
+        /// relay's signature over it.
+        GetCapabilities,
+        GetCapabilities,
+        Empty,
+        SignedCapabilities
+    );
+    command!(
+        /// `0x0003` (§6.1). Clock, single-use challenge, and current PoW
+        /// parameters.
+        GetChallenge,
+        GetChallenge,
+        ChallengeRequest,
+        ChallengeResponse
+    );
+    command!(
+        /// `0x0004` (§6.1). Application-level liveness, distinct from §2.4's
+        /// WebSocket Ping, which a browser client cannot send.
+        Ping,
+        Ping,
+        Empty,
+        Empty
+    );
+    command!(
+        /// `0x0011` (§6.2). Registers the connection for `MSG` pushes.
+        Subscribe,
+        Subscribe,
+        Empty,
+        SubscribeResponse
+    );
+    command!(
+        /// `0x0012` (§6.2).
+        ///
+        /// §6.2 gives `SUBSCRIBE` and `UNSUBSCRIBE` "empty bodies" and then
+        /// specifies a `SubscribeResponse`, so the empty-body sentence is about
+        /// the requests. It never states `UNSUBSCRIBE`'s response shape.
+        /// Reading it as empty is the only choice that does not invent a
+        /// structure: there is no queue state an unsubscribe could report that
+        /// `SUBSCRIBE` did not already return.
+        Unsubscribe,
+        Unsubscribe,
+        Empty,
+        Empty
+    );
+    command!(
+        /// `0x0013` (§6.2). Never mutates.
+        Read,
+        Read,
+        ReadRequest,
+        ReadResponse
+    );
+    command!(
+        /// `0x0014` (§6.2). Cumulative, monotone, idempotent, never selective.
+        Ack,
+        Ack,
+        AckRequest,
+        AckResponse
+    );
+    command!(
+        /// `0x0015` (§6.2). Irreversible, and leaves no observable tombstone
+        /// (§7.6).
+        DeleteQueue,
+        DeleteQueue,
+        Empty,
+        Empty
+    );
+
+    /// `0x0010` (§6.2). Both addresses come from the relay's CSPRNG (§7.1).
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct CreateQueue;
+
+    impl RelayCommand for CreateQueue {
+        const COMMAND: Command = Command::CreateQueue;
+        type Request = CreateQueueRequest;
+        type Response = CreateQueueResponse;
+
+        /// §6.2: the transcript's `address` is 32 zero bytes and `signer_key`
+        /// MUST equal `recv_key`, so the request is self-authenticating — it
+        /// proves possession of the key the new queue will be bound to.
+        ///
+        /// The mismatch is reported as `ERR_NO_ACCESS` rather than
+        /// `ERR_BAD_SIGNATURE`: the signature is valid, and what failed is that
+        /// the key which made it does not authorize the queue being asked for.
+        /// That is precisely §10's code 10, and no address exists yet for it to
+        /// be an oracle about.
+        fn check(request: &Self::Request, auth: Option<&SignedAuth>) -> Result<()> {
+            request.validate()?;
+            let auth = auth.ok_or(ProtoError::Wire(ErrorCode::BadSignature))?;
+            if keys_equal(&auth.signer_key, &request.recv_key) {
+                Ok(())
+            } else {
+                Err(ProtoError::Wire(ErrorCode::NoAccess))
+            }
+        }
+    }
+
+    /// `0x0030` (§12.2). Like `CREATE_QUEUE`, but the second address is
+    /// published and can never be bound.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct CreateContactQueue;
+
+    impl RelayCommand for CreateContactQueue {
+        const COMMAND: Command = Command::CreateContactQueue;
+        type Request = CreateContactQueueRequest;
+        type Response = CreateContactQueueResponse;
+
+        /// §12.2 does not restate `CREATE_QUEUE`'s self-authentication rule,
+        /// but the command has the same shape — a `recv_key` in the body, a
+        /// zero address in the transcript, and no existing queue to look the
+        /// signer up against — so the same rule is the only one that
+        /// authenticates it at all. Applied here, and listed as an
+        /// interpretation.
+        fn check(request: &Self::Request, auth: Option<&SignedAuth>) -> Result<()> {
+            let auth = auth.ok_or(ProtoError::Wire(ErrorCode::BadSignature))?;
+            if keys_equal(&auth.signer_key, &request.recv_key) {
+                Ok(())
+            } else {
+                Err(ProtoError::Wire(ErrorCode::NoAccess))
+            }
+        }
+    }
+
+    /// `0x0020` (§6.3). Once-only and irreversible (§7.3).
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct BindSend;
+
+    impl RelayCommand for BindSend {
+        const COMMAND: Command = Command::BindSend;
+        type Request = BindSendRequest;
+        /// **Empty by rule, not "empty for now"** (§6.3).
+        type Response = Empty;
+
+        /// §6's table has `BIND_SEND` signed by the send key, and §7.3 has the
+        /// peer generating a fresh key and binding it. The send side is unbound
+        /// until this command succeeds, so there is no registered key for §5.1
+        /// step 5 to compare against: the only thing the signature can prove is
+        /// possession of the key in the body. Requiring `signer_key ==
+        /// send_key` is what makes that proof mean anything — without it a
+        /// caller could bind a key it does not hold, which is the §7.4 theft
+        /// with no work at all.
+        fn check(request: &Self::Request, auth: Option<&SignedAuth>) -> Result<()> {
+            let auth = auth.ok_or(ProtoError::Wire(ErrorCode::BadSignature))?;
+            if keys_equal(&auth.signer_key, &request.send_key) {
+                Ok(())
+            } else {
+                Err(ProtoError::Wire(ErrorCode::NoAccess))
+            }
+        }
+    }
+
+    /// `0x0021` (§6.3). The response body is empty and carries no queue state
+    /// of any kind.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct Append;
+
+    impl RelayCommand for Append {
+        const COMMAND: Command = Command::Append;
+        type Request = AppendRequest;
+        type Response = Empty;
+
+        fn payload(request: &Self::Request) -> Option<&Payload> {
+            Some(&request.payload)
+        }
+    }
+
+    /// `0x0031` (§12.2). Unsigned; the proof-of-work stamp is the gate.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct ContactAppend;
+
+    impl RelayCommand for ContactAppend {
+        const COMMAND: Command = Command::ContactAppend;
+        type Request = ContactAppendRequest;
+        type Response = Empty;
+
+        fn payload(request: &Self::Request) -> Option<&Payload> {
+            Some(&request.payload)
+        }
+    }
+}
+
+/// A command that has been signed and is ready to send.
+///
+/// Constructed by [`SignedCommand::create`], which derives `signer_key` from
+/// the signing key itself rather than taking it as an argument: a `SignedAuth`
+/// whose `signer_key` is not the key that made the signature is a frame that
+/// can only ever be refused, and there is no reason to be able to build one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignedCommand<C> {
+    request_id: u32,
+    auth: SignedAuth,
+    body: Body,
+    marker: PhantomData<fn() -> C>,
+}
+
+impl<C: RelayCommand> SignedCommand<C> {
+    /// Build and sign a command (§5.1).
+    ///
+    /// `address` is the queue address the command acts on, and MUST agree with
+    /// §6's table: [`QueueAddress::zero`] for the two creation commands, the
+    /// real address for everything else. `nonce` MUST be fresh from the
+    /// caller's CSPRNG and `timestamp_ms` MUST be the caller's best estimate of
+    /// the *relay's* clock (§5.5: a client with an unreliable clock learns the
+    /// offset from `HELLO` and applies it locally, and MUST NOT set its system
+    /// clock from it).
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::Internal`] if `C` is an unsigned command — building a
+    ///   signature for one is this process's own mistake, and §10's code 21 is
+    ///   the one that carries no detail.
+    /// - [`ErrorCode::Malformed`] if `request_id` is zero (§4.3) or the address
+    ///   does not match §6's table for this command.
+    /// - Whatever [`RelayCommand::check`] says.
+    pub fn create(
+        transcripts: &TranscriptBuilder,
+        request_id: u32,
+        address: QueueAddress,
+        timestamp_ms: u64,
+        nonce: Nonce,
+        signing_key: &SigningKey,
+        body: &C::Request,
+    ) -> Result<Self> {
+        if matches!(C::COMMAND.auth(), Auth::None) {
+            return Err(ProtoError::Wire(ErrorCode::Internal));
+        }
+        if request_id == 0 {
+            return Err(ProtoError::Wire(ErrorCode::Malformed));
+        }
+        check_transcript_address(C::COMMAND, &address)?;
+
+        let encoded = body.encode_canonical()?;
+        let context = AuthContext {
+            address,
+            signer_key: signing_key.public_key(),
+            timestamp_ms,
+            nonce,
+        };
+        let transcript = transcripts.build(C::COMMAND.code(), request_id, &context, &encoded)?;
+        let signature = signing_key.sign(&transcript.signing_bytes()?);
+        let auth = context.into_auth(signature);
+        C::check(body, Some(&auth))?;
+
+        Ok(Self {
+            request_id,
+            auth,
+            body: Body::new(encoded)?,
+            marker: PhantomData,
+        })
+    }
+
+    /// The `request_id` this command was signed for. It is covered by the
+    /// transcript, so it cannot be changed after the fact.
+    #[must_use]
+    pub const fn request_id(&self) -> u32 {
+        self.request_id
+    }
+
+    /// The authenticator that will travel in the frame.
+    #[must_use]
+    pub const fn auth(&self) -> &SignedAuth {
+        &self.auth
+    }
+
+    /// The canonical body bytes the signature covers.
+    #[must_use]
+    pub fn body(&self) -> &[u8] {
+        self.body.as_slice()
+    }
+
+    /// The framing-layer request.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::Malformed`] only if the body outgrew its length prefix,
+    /// which [`SignedCommand::create`] already ruled out.
+    pub fn request(&self) -> Result<Request> {
+        Ok(Request::new(
+            C::COMMAND.code(),
+            CommandAuth::Signed(self.auth.clone()),
+            self.body.as_slice().to_vec(),
+        )?)
+    }
+
+    /// The whole frame, ready to encode with
+    /// [`Canonical::encode_canonical`].
+    ///
+    /// # Errors
+    ///
+    /// As [`SignedCommand::request`].
+    pub fn frame(&self) -> Result<RelayFrame> {
+        Ok(RelayFrame::request(self.request_id, self.request()?))
+    }
+
+    /// The canonical bytes of the whole frame.
+    ///
+    /// # Errors
+    ///
+    /// As [`SignedCommand::request`].
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        Ok(self.frame()?.encode_canonical()?)
+    }
+}
+
+/// A command that passed every check of §5.1.
+///
+/// There is no public constructor. The only way to hold one is to have run
+/// [`CommandVerifier::verify`] or [`CommandVerifier::accept_unsigned`], which
+/// is what makes "we verified this" a fact about the type rather than a comment
+/// on a call site.
+#[derive(Debug)]
+pub struct Verified<C: RelayCommand> {
+    body: C::Request,
+    address: QueueAddress,
+    signer_key: PublicKey,
+    timestamp_ms: u64,
+    nonce: Nonce,
+}
+
+// Written out rather than derived: a derive would demand `C: PartialEq` and
+// still not know that `C::Request` is comparable, and the thing worth comparing
+// is the body.
+impl<C: RelayCommand> PartialEq for Verified<C>
+where
+    C::Request: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.body == other.body
+            && self.address == other.address
+            && self.signer_key == other.signer_key
+            && self.timestamp_ms == other.timestamp_ms
+            && self.nonce == other.nonce
+    }
+}
+
+impl<C: RelayCommand> Eq for Verified<C> where C::Request: Eq {}
+
+impl<C: RelayCommand> Verified<C> {
+    /// The decoded, canonical request body.
+    pub const fn body(&self) -> &C::Request {
+        &self.body
+    }
+
+    /// Take the body.
+    #[must_use]
+    pub fn into_body(self) -> C::Request {
+        self.body
+    }
+
+    /// The address the command acts on. [`QueueAddress::zero`] for the
+    /// creation commands and for the unsigned commands.
+    #[must_use]
+    pub const fn address(&self) -> QueueAddress {
+        self.address
+    }
+
+    /// The key that signed it — what §5.1 step 5 compares against the key
+    /// registered for the address. [`PublicKey::zero`] for unsigned commands.
+    #[must_use]
+    pub const fn signer_key(&self) -> PublicKey {
+        self.signer_key
+    }
+
+    /// The client clock the command carried, already inside the window.
+    #[must_use]
+    pub const fn timestamp_ms(&self) -> u64 {
+        self.timestamp_ms
+    }
+
+    /// The nonce, already recorded in the seen-set.
+    #[must_use]
+    pub const fn nonce(&self) -> Nonce {
+        self.nonce
+    }
+}
+
+/// The receiving half of §5: one connection's transcript builder, timestamp
+/// window, seen-set and padding policy.
+///
+/// It holds the [`TranscriptBuilder`] rather than taking one per call for the
+/// reason `f2z-codec` gives: `protocol_version`, `relay_id` and
+/// `channel_binding` are constant for the life of a connection, and §5.2's
+/// replay-across-relays attack and §5.3's replay-across-sessions attack are
+/// both closed by exactly that. A per-command parameter would be a per-command
+/// opportunity to pass the peer's value.
+#[derive(Clone, Debug)]
+pub struct CommandVerifier {
+    transcripts: TranscriptBuilder,
+    window: TimestampWindow,
+    seen: SeenSet,
+    padding: PaddingBuckets,
+}
+
+impl CommandVerifier {
+    /// Bind a verifier to one connection.
+    #[must_use]
+    pub const fn new(
+        transcripts: TranscriptBuilder,
+        window: TimestampWindow,
+        seen: SeenSet,
+        padding: PaddingBuckets,
+    ) -> Self {
+        Self {
+            transcripts,
+            window,
+            seen,
+            padding,
+        }
+    }
+
+    /// This connection's transcript builder.
+    #[must_use]
+    pub const fn transcripts(&self) -> &TranscriptBuilder {
+        &self.transcripts
+    }
+
+    /// The seen-set, for an operator that wants to sweep or measure it.
+    #[must_use]
+    pub const fn seen_set(&self) -> &SeenSet {
+        &self.seen
+    }
+
+    /// The seen-set, mutably.
+    pub const fn seen_set_mut(&mut self) -> &mut SeenSet {
+        &mut self.seen
+    }
+
+    /// The published padding buckets this verifier enforces (§9).
+    #[must_use]
+    pub const fn padding(&self) -> &PaddingBuckets {
+        &self.padding
+    }
+
+    /// Verify a signed command, in §5.1's order.
+    ///
+    /// `now_ms` is the relay's clock. `request_id` is the frame's, not the
+    /// body's — it is covered by the transcript, so a relay that passes a
+    /// different one here will simply fail to verify, which is the intent.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::Internal`] if `request` is not for `C` at all. Dispatching
+    ///   to the wrong handler is a relay fault, and §10's code 21 is the one
+    ///   that carries no detail — telling the peer would be describing our own
+    ///   internals to an unauthenticated caller.
+    /// - [`ErrorCode::BadSignature`] if a signed command arrived unsigned, if
+    ///   the signer key is not a curve point, or if the signature does not
+    ///   verify. A missing signature is not `ERR_MALFORMED`: the frame is
+    ///   well-formed and §10's fatal codes are for framing failures, so a
+    ///   client that forgot to sign gets a non-fatal answer and may retry.
+    /// - [`ErrorCode::Malformed`] if the body is not canonical (§3.3) or the
+    ///   transcript address does not match §6's table. Both are fatal.
+    /// - [`ErrorCode::StaleTimestamp`], [`ErrorCode::Replay`] or
+    ///   [`ErrorCode::Backpressure`] from the anti-replay layer.
+    /// - [`ErrorCode::NoAccess`] from a self-authentication rule.
+    /// - [`ErrorCode::BadSize`] if the payload is not exactly one of the
+    ///   published padding sizes (§9).
+    pub fn verify<C: RelayCommand>(
+        &mut self,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Verified<C>> {
+        if request.command != C::COMMAND.code() {
+            return Err(ProtoError::Wire(ErrorCode::Internal));
+        }
+        if matches!(C::COMMAND.auth(), Auth::None) {
+            return Err(ProtoError::Wire(ErrorCode::Internal));
+        }
+        let auth = match &request.auth {
+            CommandAuth::Signed(auth) => auth,
+            // A command that must be signed and was not. Non-fatal: nothing
+            // about the framing was wrong.
+            CommandAuth::Unsigned => return Err(ProtoError::Wire(ErrorCode::BadSignature)),
+        };
+
+        // Step 1, body half. The frame's re-encode equality has already been
+        // proved by `f2z-codec`; the opaque body inside it has not, and the
+        // bytes a signature covers are these.
+        let body = decode_canonical::<C::Request>(request.body())?;
+
+        // Step 2.
+        self.window.check(now_ms, auth.timestamp_ms)?;
+        // Step 3.
+        self.seen
+            .observe(now_ms, ReplayKey::new(auth.signer_key, auth.nonce))?;
+
+        // Step 4. `relay_id` and `channel_binding` come from `self`; only the
+        // rest comes from the frame.
+        let verifying_key = crate::key::VerifyingKey::from_public_key(&auth.signer_key)?;
+        let transcript = self.transcripts.rebuild_from_auth(
+            C::COMMAND.code(),
+            request_id,
+            auth,
+            body.bytes(),
+        )?;
+        verifying_key.verify(&transcript.signing_bytes()?, &auth.signature)?;
+
+        // Step 5, frame half.
+        check_transcript_address(C::COMMAND, &auth.address)?;
+        C::check(body.value(), Some(auth))?;
+
+        // Step 6.
+        if let Some(payload) = C::payload(body.value()) {
+            self.padding.validate_payload(payload)?;
+        }
+
+        Ok(Verified {
+            address: auth.address,
+            signer_key: auth.signer_key,
+            timestamp_ms: auth.timestamp_ms,
+            nonce: auth.nonce,
+            body: body.into_value(),
+        })
+    }
+
+    /// Accept an unsigned command (§6.1, §12.2).
+    ///
+    /// There is no timestamp, no nonce and no signature to check, so this is
+    /// §3.3 on the body plus the command's own rules. The gate on
+    /// `CONTACT_APPEND` is a proof-of-work stamp over a relay-issued,
+    /// single-use, expiring challenge (§12.3) — challenge issuance and
+    /// consumption are relay state, so this crate checks the stamp's hash
+    /// through `f2z-codec` and leaves the rest to the relay.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::Internal`] if `request` is not for `C`, or if `C` is a
+    ///   signed command.
+    /// - [`ErrorCode::Malformed`] if the frame carries a `SignedAuth` for a
+    ///   command that has no transcript. That one *is* fatal: §5.1 has no
+    ///   verification path for it, so accepting the frame would mean carrying
+    ///   an authenticator nothing ever checks.
+    /// - [`ErrorCode::BadSize`] if the payload is not exactly one of the
+    ///   published padding sizes (§9).
+    pub fn accept_unsigned<C: RelayCommand>(&self, request: &Request) -> Result<Verified<C>> {
+        if request.command != C::COMMAND.code() {
+            return Err(ProtoError::Wire(ErrorCode::Internal));
+        }
+        if !matches!(C::COMMAND.auth(), Auth::None) {
+            return Err(ProtoError::Wire(ErrorCode::Internal));
+        }
+        if request.auth.signed().is_some() {
+            return Err(ProtoError::Wire(ErrorCode::Malformed));
+        }
+
+        let body = decode_canonical::<C::Request>(request.body())?;
+        C::check(body.value(), None)?;
+        if let Some(payload) = C::payload(body.value()) {
+            self.padding.validate_payload(payload)?;
+        }
+
+        Ok(Verified {
+            address: QueueAddress::zero(),
+            signer_key: PublicKey::zero(),
+            timestamp_ms: 0,
+            nonce: Nonce::zero(),
+            body: body.into_value(),
+        })
+    }
+}
+
+/// §6's table, as a check: the transcript's `address` is zeros for the creation
+/// commands and a real address for the rest.
+///
+/// The zero address is the sentinel for "no queue exists yet", so a non-creation
+/// command carrying it is a command about no queue at all. `ERR_MALFORMED` is
+/// the reading implemented here — the frame is not a valid instance of its own
+/// command — and it is fatal, which is the right direction: this is not a state
+/// disagreement between honest peers, it is a frame no conforming client emits.
+fn check_transcript_address(command: Command, address: &QueueAddress) -> Result<()> {
+    let ok = match command.transcript_address() {
+        TranscriptAddress::Zeros => address.is_zero(),
+        TranscriptAddress::RecvAddr | TranscriptAddress::SendAddr => !address.is_zero(),
+        // Unsigned: there is no transcript, so there is nothing to check.
+        TranscriptAddress::None => true,
+    };
+    if ok {
+        Ok(())
+    } else {
+        Err(ProtoError::Wire(ErrorCode::Malformed))
+    }
+}
+
+/// The unsigned `HELLO` request frame that MUST be a connection's first frame
+/// (§2.5).
+///
+/// # Errors
+///
+/// [`ErrorCode::Malformed`] if `request_id` is zero (§4.3).
+pub fn hello_request(request_id: u32, body: &HelloRequest) -> Result<RelayFrame> {
+    unsigned_request::<ops::Hello>(request_id, body)
+}
+
+/// Build any unsigned request frame (§6.1, §12.2).
+///
+/// # Errors
+///
+/// - [`ErrorCode::Internal`] if `C` is a signed command.
+/// - [`ErrorCode::Malformed`] if `request_id` is zero (§4.3).
+pub fn unsigned_request<C: RelayCommand>(request_id: u32, body: &C::Request) -> Result<RelayFrame> {
+    if !matches!(C::COMMAND.auth(), Auth::None) {
+        return Err(ProtoError::Wire(ErrorCode::Internal));
+    }
+    if request_id == 0 {
+        return Err(ProtoError::Wire(ErrorCode::Malformed));
+    }
+    let request = Request::new(
+        C::COMMAND.code(),
+        CommandAuth::Unsigned,
+        body.encode_canonical()?,
+    )?;
+    Ok(RelayFrame::request(request_id, request))
+}
+
+/// Every command's protocol version, restated so a caller building a
+/// [`TranscriptBuilder`] does not have to reach into `f2z-codec` for it.
+pub const VERSION: u16 = PROTOCOL_VERSION;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use f2z_codec::pow::PowStamp;
+    use f2z_codec::types::{ChannelBinding, RelayId};
+
+    fn transcripts() -> TranscriptBuilder {
+        TranscriptBuilder::new(
+            VERSION,
+            RelayId::new([0xaa; 32]),
+            ChannelBinding::new([0xbb; 32]),
+        )
+    }
+
+    fn verifier() -> CommandVerifier {
+        CommandVerifier::new(
+            transcripts(),
+            TimestampWindow::default(),
+            SeenSet::new(240_000, 1024),
+            PaddingBuckets::default(),
+        )
+    }
+
+    fn nonce(byte: u8) -> Nonce {
+        Nonce::new([byte; 16])
+    }
+
+    const NOW: u64 = 1_800_000_000_000;
+
+    #[test]
+    fn a_signed_append_round_trips_through_verification() {
+        let key = SigningKey::from_seed(&[1u8; 32]);
+        let address = QueueAddress::new([9u8; 32]);
+        let body = AppendRequest {
+            payload: Payload::new(vec![0u8; 1024]).unwrap(),
+        };
+        let signed = SignedCommand::<ops::Append>::create(
+            &transcripts(),
+            7,
+            address,
+            NOW,
+            nonce(1),
+            &key,
+            &body,
+        )
+        .unwrap();
+
+        let frame = signed.frame().unwrap();
+        let bytes = frame.encode_canonical().unwrap();
+        let decoded = decode_canonical::<RelayFrame>(&bytes).unwrap();
+        assert_eq!(decoded.value(), &frame);
+
+        let verified = verifier()
+            .verify::<ops::Append>(NOW, 7, &signed.request().unwrap())
+            .unwrap();
+        assert_eq!(verified.address(), address);
+        assert_eq!(verified.signer_key(), key.public_key());
+        assert_eq!(verified.body(), &body);
+    }
+
+    #[test]
+    fn a_signature_made_for_one_relay_fails_at_another() {
+        let key = SigningKey::from_seed(&[2u8; 32]);
+        let signed = SignedCommand::<ops::Ack>::create(
+            &transcripts(),
+            3,
+            QueueAddress::new([5u8; 32]),
+            NOW,
+            nonce(2),
+            &key,
+            &AckRequest { up_to_index: 4 },
+        )
+        .unwrap();
+
+        let mut elsewhere = CommandVerifier::new(
+            TranscriptBuilder::new(
+                VERSION,
+                RelayId::new([0xcc; 32]),
+                ChannelBinding::new([0xbb; 32]),
+            ),
+            TimestampWindow::default(),
+            SeenSet::new(240_000, 16),
+            PaddingBuckets::default(),
+        );
+        assert_eq!(
+            elsewhere.verify::<ops::Ack>(NOW, 3, &signed.request().unwrap()),
+            Err(ProtoError::Wire(ErrorCode::BadSignature))
+        );
+    }
+
+    #[test]
+    fn the_request_id_is_covered_by_the_transcript() {
+        let key = SigningKey::from_seed(&[3u8; 32]);
+        let signed = SignedCommand::<ops::Read>::create(
+            &transcripts(),
+            11,
+            QueueAddress::new([5u8; 32]),
+            NOW,
+            nonce(3),
+            &key,
+            &ReadRequest {
+                from_index: 0,
+                max_messages: 8,
+                max_bytes: 4096,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            verifier().verify::<ops::Read>(NOW, 12, &signed.request().unwrap()),
+            Err(ProtoError::Wire(ErrorCode::BadSignature))
+        );
+    }
+
+    #[test]
+    fn a_replayed_frame_is_refused_on_the_second_presentation() {
+        let key = SigningKey::from_seed(&[4u8; 32]);
+        let signed = SignedCommand::<ops::Subscribe>::create(
+            &transcripts(),
+            2,
+            QueueAddress::new([6u8; 32]),
+            NOW,
+            nonce(4),
+            &key,
+            &Empty,
+        )
+        .unwrap();
+        let request = signed.request().unwrap();
+        let mut verifier = verifier();
+        assert!(verifier.verify::<ops::Subscribe>(NOW, 2, &request).is_ok());
+        assert_eq!(
+            verifier.verify::<ops::Subscribe>(NOW, 2, &request),
+            Err(ProtoError::Wire(ErrorCode::Replay))
+        );
+    }
+
+    #[test]
+    fn the_timestamp_window_is_checked_before_the_signature() {
+        let key = SigningKey::from_seed(&[5u8; 32]);
+        let signed = SignedCommand::<ops::Subscribe>::create(
+            &transcripts(),
+            2,
+            QueueAddress::new([6u8; 32]),
+            NOW,
+            nonce(5),
+            &key,
+            &Empty,
+        )
+        .unwrap();
+        let mut verifier = verifier();
+        assert_eq!(
+            verifier.verify::<ops::Subscribe>(NOW + 120_001, 2, &signed.request().unwrap()),
+            Err(ProtoError::Wire(ErrorCode::StaleTimestamp))
+        );
+        // …and a stale frame did not consume a seen-set slot.
+        assert!(verifier.seen_set().is_empty());
+    }
+
+    #[test]
+    fn create_queue_must_be_signed_by_the_key_it_registers() {
+        let key = SigningKey::from_seed(&[6u8; 32]);
+        let other = SigningKey::from_seed(&[7u8; 32]);
+        let body = CreateQueueRequest {
+            recv_key: other.public_key(),
+            req_message_ttl_seconds: 0,
+            req_idle_ttl_seconds: 0,
+            flags: 0,
+            stamp: PowStamp::empty(),
+        };
+        assert_eq!(
+            SignedCommand::<ops::CreateQueue>::create(
+                &transcripts(),
+                1,
+                QueueAddress::zero(),
+                NOW,
+                nonce(6),
+                &key,
+                &body,
+            ),
+            Err(ProtoError::Wire(ErrorCode::NoAccess))
+        );
+    }
+
+    #[test]
+    fn create_queue_must_carry_the_zero_address() {
+        let key = SigningKey::from_seed(&[8u8; 32]);
+        let body = CreateQueueRequest {
+            recv_key: key.public_key(),
+            req_message_ttl_seconds: 0,
+            req_idle_ttl_seconds: 0,
+            flags: 0,
+            stamp: PowStamp::empty(),
+        };
+        assert_eq!(
+            SignedCommand::<ops::CreateQueue>::create(
+                &transcripts(),
+                1,
+                QueueAddress::new([1u8; 32]),
+                NOW,
+                nonce(7),
+                &key,
+                &body,
+            ),
+            Err(ProtoError::Wire(ErrorCode::Malformed))
+        );
+        assert!(
+            SignedCommand::<ops::CreateQueue>::create(
+                &transcripts(),
+                1,
+                QueueAddress::zero(),
+                NOW,
+                nonce(7),
+                &key,
+                &body,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn bind_send_must_be_signed_by_the_key_it_binds() {
+        let key = SigningKey::from_seed(&[9u8; 32]);
+        let other = SigningKey::from_seed(&[10u8; 32]);
+        assert_eq!(
+            SignedCommand::<ops::BindSend>::create(
+                &transcripts(),
+                1,
+                QueueAddress::new([2u8; 32]),
+                NOW,
+                nonce(8),
+                &key,
+                &BindSendRequest {
+                    send_key: other.public_key()
+                },
+            ),
+            Err(ProtoError::Wire(ErrorCode::NoAccess))
+        );
+    }
+
+    #[test]
+    fn an_append_outside_the_padding_buckets_is_bad_size() {
+        let key = SigningKey::from_seed(&[11u8; 32]);
+        let signed = SignedCommand::<ops::Append>::create(
+            &transcripts(),
+            4,
+            QueueAddress::new([3u8; 32]),
+            NOW,
+            nonce(9),
+            &key,
+            &AppendRequest {
+                payload: Payload::new(vec![0u8; 1023]).unwrap(),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            verifier().verify::<ops::Append>(NOW, 4, &signed.request().unwrap()),
+            Err(ProtoError::Wire(ErrorCode::BadSize))
+        );
+    }
+
+    #[test]
+    fn a_signed_command_that_arrives_unsigned_is_not_fatal() {
+        let request = Request::new(
+            Command::Ack.code(),
+            CommandAuth::Unsigned,
+            AckRequest { up_to_index: 1 }.encode_canonical().unwrap(),
+        )
+        .unwrap();
+        let error = verifier().verify::<ops::Ack>(NOW, 1, &request).unwrap_err();
+        assert_eq!(error, ProtoError::Wire(ErrorCode::BadSignature));
+        assert!(!error.is_fatal());
+    }
+
+    #[test]
+    fn an_unsigned_command_that_arrives_signed_is_fatal() {
+        let key = SigningKey::from_seed(&[12u8; 32]);
+        let auth = AuthContext {
+            address: QueueAddress::zero(),
+            signer_key: key.public_key(),
+            timestamp_ms: NOW,
+            nonce: nonce(10),
+        }
+        .into_auth(key.sign(b"whatever"));
+        let request =
+            Request::new(Command::Ping.code(), CommandAuth::Signed(auth), Vec::new()).unwrap();
+        let error = verifier()
+            .accept_unsigned::<ops::Ping>(&request)
+            .unwrap_err();
+        assert_eq!(error, ProtoError::Wire(ErrorCode::Malformed));
+        assert!(error.is_fatal());
+    }
+
+    #[test]
+    fn a_non_canonical_body_is_malformed_even_inside_a_canonical_frame() {
+        let key = SigningKey::from_seed(&[13u8; 32]);
+        let signed = SignedCommand::<ops::Ack>::create(
+            &transcripts(),
+            5,
+            QueueAddress::new([4u8; 32]),
+            NOW,
+            nonce(11),
+            &key,
+            &AckRequest { up_to_index: 3 },
+        )
+        .unwrap();
+        // One trailing byte inside the opaque body. The frame still re-encodes
+        // byte-identically, which is exactly why the body needs its own §3.3.
+        let mut body = signed.body().to_vec();
+        body.push(0);
+        let request = Request::new(
+            Command::Ack.code(),
+            CommandAuth::Signed(signed.auth().clone()),
+            body,
+        )
+        .unwrap();
+        assert_eq!(
+            verifier().verify::<ops::Ack>(NOW, 5, &request),
+            Err(ProtoError::Wire(ErrorCode::Malformed))
+        );
+    }
+
+    #[test]
+    fn dispatching_to_the_wrong_handler_is_a_relay_fault() {
+        let key = SigningKey::from_seed(&[14u8; 32]);
+        let signed = SignedCommand::<ops::Ack>::create(
+            &transcripts(),
+            6,
+            QueueAddress::new([4u8; 32]),
+            NOW,
+            nonce(12),
+            &key,
+            &AckRequest { up_to_index: 3 },
+        )
+        .unwrap();
+        assert_eq!(
+            verifier().verify::<ops::Read>(NOW, 6, &signed.request().unwrap()),
+            Err(ProtoError::Wire(ErrorCode::Internal))
+        );
+    }
+
+    #[test]
+    fn unsigned_commands_cannot_be_signed_and_signed_ones_cannot_be_unsigned() {
+        let key = SigningKey::from_seed(&[15u8; 32]);
+        assert_eq!(
+            SignedCommand::<ops::Ping>::create(
+                &transcripts(),
+                1,
+                QueueAddress::zero(),
+                NOW,
+                nonce(13),
+                &key,
+                &Empty,
+            ),
+            Err(ProtoError::Wire(ErrorCode::Internal))
+        );
+        assert_eq!(
+            unsigned_request::<ops::Ack>(1, &AckRequest { up_to_index: 0 }).map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::Internal))
+        );
+    }
+
+    #[test]
+    fn an_unsigned_contact_append_is_accepted_and_size_checked() {
+        let good = ContactAppendRequest {
+            contact_addr: QueueAddress::new([7u8; 32]),
+            payload: Payload::new(vec![0u8; 4096]).unwrap(),
+            stamp: PowStamp::empty(),
+        };
+        let frame = unsigned_request::<ops::ContactAppend>(1, &good).unwrap();
+        let f2z_codec::frame::FramePayload::Request(request) = &frame.payload else {
+            unreachable!()
+        };
+        assert!(
+            verifier()
+                .accept_unsigned::<ops::ContactAppend>(request)
+                .is_ok()
+        );
+
+        let bad = ContactAppendRequest {
+            payload: Payload::new(vec![0u8; 4097]).unwrap(),
+            ..good
+        };
+        let frame = unsigned_request::<ops::ContactAppend>(1, &bad).unwrap();
+        let f2z_codec::frame::FramePayload::Request(request) = &frame.payload else {
+            unreachable!()
+        };
+        assert_eq!(
+            verifier()
+                .accept_unsigned::<ops::ContactAppend>(request)
+                .map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::BadSize))
+        );
+    }
+
+    #[test]
+    fn an_empty_body_rejects_anything_but_zero_bytes() {
+        let request = Request::new(Command::Ping.code(), CommandAuth::Unsigned, vec![0u8]).unwrap();
+        assert_eq!(
+            verifier()
+                .accept_unsigned::<ops::Ping>(&request)
+                .map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::Malformed))
+        );
+    }
+
+    #[test]
+    fn hello_is_an_unsigned_frame_with_a_nonzero_request_id() {
+        let body = HelloRequest {
+            min_version: 1,
+            max_version: 1,
+            client_nonce: f2z_codec::types::Challenge::new([1u8; 32]),
+        };
+        assert!(hello_request(1, &body).is_ok());
+        assert_eq!(
+            hello_request(0, &body).map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::Malformed))
+        );
+    }
+}

--- a/rs/crates/f2z-relay-proto/src/error.rs
+++ b/rs/crates/f2z-relay-proto/src/error.rs
@@ -1,0 +1,264 @@
+//! What this crate can refuse to do, and which of those refusals travel.
+//!
+//! There are exactly two kinds, and keeping them apart is the point of this
+//! module:
+//!
+//! - A **wire refusal** is one a relay answers with a `uint16` from
+//!   [`WIRE.md` §10][s10]. It carries an [`ErrorCode`] and nothing else,
+//!   because §4.1 forbids a free-text field on the unauthenticated path.
+//! - A **client refusal** is a decision a *client* makes about a relay —
+//!   §2.5's `relay_id` mismatch, §11.3's capability checks. It never travels;
+//!   the client simply does not connect, or disconnects. Giving these their own
+//!   type is what stops one of them from being reported to a peer as though it
+//!   were a protocol error.
+//!
+//! [s10]: https://github.com/free2z/zuu/blob/main/docs/e2ee/WIRE.md
+
+use core::fmt;
+
+use f2z_codec::{CodecError, ErrorCode};
+
+/// Anything this crate refuses to do.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProtoError {
+    /// A refusal with a §10 code. On a relay this is what goes in the
+    /// [`Response`]; on a client it is the code that came back.
+    ///
+    /// [`Response`]: f2z_codec::frame::Response
+    Wire(ErrorCode),
+    /// A client's decision about a relay (§2.5, §5.2, §11.3). Never sent.
+    Refused(Refusal),
+    /// A response carried a nonzero `status` this build does not know.
+    ///
+    /// Not a failure of the peer. §10 keeps codes stable forever precisely so
+    /// that "a client in the field, a log archive, and a bug report from two
+    /// years ago must all still mean the same thing", which means a client
+    /// older than a code must be able to carry it around and log it rather than
+    /// flatten it into something it is not.
+    UnknownStatus(u16),
+}
+
+impl ProtoError {
+    /// The §10 code a relay would put on the wire, if this refusal has one.
+    ///
+    /// [`Refusal`] deliberately has none: a client that declines a relay owes
+    /// that relay no explanation, and inventing a code for it would put a
+    /// client-side policy decision into a protocol field.
+    #[must_use]
+    pub const fn wire_code(self) -> Option<ErrorCode> {
+        match self {
+            Self::Wire(code) => Some(code),
+            Self::Refused(_) | Self::UnknownStatus(_) => None,
+        }
+    }
+
+    /// Whether a relay answering this must also close the connection (§1.3).
+    #[must_use]
+    pub const fn is_fatal(self) -> bool {
+        match self {
+            Self::Wire(code) => code.is_fatal(),
+            Self::Refused(_) | Self::UnknownStatus(_) => false,
+        }
+    }
+}
+
+impl From<ErrorCode> for ProtoError {
+    fn from(code: ErrorCode) -> Self {
+        Self::Wire(code)
+    }
+}
+
+impl From<Refusal> for ProtoError {
+    fn from(refusal: Refusal) -> Self {
+        Self::Refused(refusal)
+    }
+}
+
+impl From<CodecError> for ProtoError {
+    /// Every codec failure already knows its own wire code — §3.3's re-encode
+    /// mismatch is `ERR_MALFORMED`, a bad payload length is `ERR_BAD_SIZE` —
+    /// so this conversion never has to choose one.
+    fn from(error: CodecError) -> Self {
+        Self::Wire(error.error_code())
+    }
+}
+
+impl fmt::Display for ProtoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Wire(code) => write!(f, "{code}"),
+            Self::Refused(refusal) => write!(f, "{refusal}"),
+            Self::UnknownStatus(status) => {
+                write!(
+                    f,
+                    "relay answered with status {status}, which this build does not know"
+                )
+            }
+        }
+    }
+}
+
+impl core::error::Error for ProtoError {}
+
+/// A client's reason for refusing a relay.
+///
+/// Every variant is a MUST or a SHOULD from the specification, and each one
+/// names the section it comes from. None of them is a wire code: they are the
+/// answers to "should this client talk to this relay at all", asked before and
+/// during a connection, and the only action they support is refusing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Refusal {
+    /// §2.5 / §5.2: the relay's `relay_id` is not the one the peer's in-band
+    /// advert named. Fatal, and MUST be surfaced rather than retried against —
+    /// the relay was substituted at the DNS or TLS layer.
+    RelayIdMismatch,
+    /// §6.1: `relay_id` is not `H("free2z/relay/v1/relay-id",
+    /// relay_identity_pk)`. The relay contradicted itself in one frame.
+    RelayIdNotDerived,
+    /// §5.2: `relay_proof` did not verify, so the relay has not proved
+    /// possession of the identity key it claims. Without this proof the
+    /// `relay_id` binding is decoration.
+    RelayProofInvalid,
+    /// §5.2: the relay's identity key is not a valid Ed25519 public key.
+    RelayKeyInvalid,
+    /// §2.5 / §3.5: the relay selected a version outside the range the client
+    /// offered, or one it does not implement.
+    VersionNotOffered,
+    /// §5.3: `channel_binding_mode` is `tls-exporter` but the value handed in
+    /// is 32 zero bytes, or it is `none` and the value is not.
+    ChannelBindingMismatch,
+    /// §2.3: `transport_security = none` without the explicit per-relay user
+    /// opt-in that section requires.
+    InsecureTransport,
+    /// §5.3 / §11.3 step 3: `channel_binding_mode = none` under a strict
+    /// client policy.
+    NoChannelBinding,
+    /// §5.5: `antireplay_persistence = volatile` under a strict client policy —
+    /// a restart reopens a replay window of `clock_skew_ms`.
+    VolatileAntiReplay,
+    /// §5.5 / §11.1: `antireplay_window_ms` is shorter than `2 ×
+    /// clock_skew_ms`, so seen-set entries age out while the frames they cover
+    /// are still inside the timestamp window.
+    ///
+    /// **`WIRE.md` does not state this relation and it should** — see
+    /// [`SeenSet::retention_is_sound`]. Reported as a client-side refusal
+    /// rather than as a document-validity failure, because the document is
+    /// exactly what the specification permits; it is the specification that is
+    /// missing the constraint.
+    ///
+    /// [`SeenSet::retention_is_sound`]: crate::replay::SeenSet::retention_is_sound
+    AntiReplayWindowTooShort,
+    /// §11.3 step 4: the relay's `padding_sizes` is not a superset of the
+    /// sizes this client emits.
+    PaddingNotSuperset,
+    /// §9 / §11.3 step 4: the relay's `padding_sizes` is fine-grained enough
+    /// to be indistinguishable from a covert length channel.
+    PaddingImplausible,
+    /// §11.3 step 5: `max_message_ttl_seconds` exceeds the architecture's
+    /// 30-day ceiling. The relay is claiming a policy the architecture forbids.
+    TtlCeilingExceeded,
+    /// §11.1: the capability document is internally inconsistent — a mode byte
+    /// outside its defined range, a TTL band whose default sits outside its own
+    /// clamps, a `padding_sizes` that is not ascending.
+    CapabilitiesInconsistent,
+    /// §11.1: the document's signature does not verify under
+    /// `relay_identity_pk`.
+    CapabilitiesSignatureInvalid,
+    /// §6.1 / §11.2: `capabilities_digest` does not match the document the
+    /// relay served. Either the two representations disagree (§11.2) or the
+    /// document changed under the client mid-connection.
+    CapabilitiesDigestMismatch,
+    /// §13.1: the relay demands a proof-of-work algorithm v1 does not define,
+    /// so no conforming client can create a queue on it.
+    PowAlgorithmUnknown,
+    /// §13.1: `queue_creation_mode = token`. Not invalid — a token is an
+    /// operator-issued bearer credential and a closed deployment may want one —
+    /// but it is an identifier that links every queue created with it, so a
+    /// client whose policy is unlinkability refuses.
+    QueueCreationTokenGated,
+}
+
+impl Refusal {
+    /// The section of `WIRE.md` this refusal comes from, for logs and UI.
+    #[must_use]
+    pub const fn section(self) -> &'static str {
+        match self {
+            Self::RelayIdMismatch => "§2.5, §5.2",
+            Self::RelayIdNotDerived | Self::CapabilitiesDigestMismatch => "§6.1",
+            Self::RelayProofInvalid | Self::RelayKeyInvalid => "§5.2",
+            Self::VersionNotOffered => "§3.5",
+            Self::ChannelBindingMismatch | Self::NoChannelBinding => "§5.3",
+            Self::InsecureTransport => "§2.3",
+            Self::VolatileAntiReplay | Self::AntiReplayWindowTooShort => "§5.5",
+            Self::PaddingNotSuperset | Self::PaddingImplausible => "§9",
+            Self::TtlCeilingExceeded => "§11.3",
+            Self::CapabilitiesInconsistent | Self::CapabilitiesSignatureInvalid => "§11.1",
+            Self::PowAlgorithmUnknown | Self::QueueCreationTokenGated => "§13.1",
+        }
+    }
+}
+
+impl fmt::Display for Refusal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let text = match self {
+            Self::RelayIdMismatch => "relay_id does not match the peer's advert",
+            Self::RelayIdNotDerived => "relay_id is not the digest of relay_identity_pk",
+            Self::RelayProofInvalid => "the relay did not prove possession of its identity key",
+            Self::RelayKeyInvalid => "relay_identity_pk is not a valid Ed25519 public key",
+            Self::VersionNotOffered => "the relay selected a protocol version we did not offer",
+            Self::ChannelBindingMismatch => "channel_binding_mode disagrees with the binding value",
+            Self::InsecureTransport => "the relay serves without TLS and was not opted into",
+            Self::NoChannelBinding => "the relay cannot bind commands to the TLS session",
+            Self::VolatileAntiReplay => "the relay's seen-set does not survive a restart",
+            Self::AntiReplayWindowTooShort => {
+                "antireplay_window_ms is shorter than twice clock_skew_ms"
+            }
+            Self::PaddingNotSuperset => "padding_sizes does not cover the sizes this client emits",
+            Self::PaddingImplausible => "padding_sizes is fine-grained enough to leak length",
+            Self::TtlCeilingExceeded => "max_message_ttl_seconds exceeds the 30-day ceiling",
+            Self::CapabilitiesInconsistent => "the capability document contradicts itself",
+            Self::CapabilitiesSignatureInvalid => "the capability document's signature is invalid",
+            Self::CapabilitiesDigestMismatch => "capabilities_digest does not match the document",
+            Self::PowAlgorithmUnknown => "the relay demands a proof-of-work v1 does not define",
+            Self::QueueCreationTokenGated => "the relay gates queue creation on a linkable token",
+        };
+        write!(f, "refused the relay ({}): {text}", self.section())
+    }
+}
+
+impl core::error::Error for Refusal {}
+
+/// The result of everything in this crate.
+pub type Result<T> = core::result::Result<T, ProtoError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codec_failures_keep_the_code_the_codec_chose() {
+        assert_eq!(
+            ProtoError::from(CodecError::NotCanonical).wire_code(),
+            Some(ErrorCode::Malformed)
+        );
+        assert_eq!(
+            ProtoError::from(CodecError::BadSize).wire_code(),
+            Some(ErrorCode::BadSize)
+        );
+    }
+
+    #[test]
+    fn a_client_refusal_has_no_wire_code_and_is_not_fatal_to_a_peer() {
+        let refusal = ProtoError::from(Refusal::RelayIdMismatch);
+        assert_eq!(refusal.wire_code(), None);
+        assert!(!refusal.is_fatal());
+    }
+
+    #[test]
+    fn fatality_comes_from_the_code_not_from_this_type() {
+        assert!(ProtoError::from(ErrorCode::Malformed).is_fatal());
+        assert!(!ProtoError::from(ErrorCode::BadSize).is_fatal());
+    }
+}

--- a/rs/crates/f2z-relay-proto/src/hello.rs
+++ b/rs/crates/f2z-relay-proto/src/hello.rs
@@ -1,0 +1,514 @@
+//! The `HELLO` exchange — `WIRE.md` §2.5 and §5.2 — and the session it
+//! establishes.
+//!
+//! §2.5's connection lifecycle puts three checks between "the socket opened"
+//! and "a signed command may be sent", and all three are here:
+//!
+//! 1. A version is selected, once, for the whole connection.
+//! 2. The client **MUST** verify `relay_proof` before sending any signed
+//!    command. Without it, §5.2's `relay_id` binding is decoration: any relay
+//!    could claim another's identity, and the whole point of the binding is
+//!    that it does not let a signed `ACK` be replayed at a second relay to make
+//!    that relay delete ciphertext the recipient never received from it.
+//! 3. The client **MUST** recompute `relay_id` from `relay_identity_pk` and
+//!    compare it against any value it obtained from an in-band advert (§7.2).
+//!    A mismatch is fatal and MUST be surfaced, not retried against — a relay
+//!    substituted at the DNS or TLS layer presents a different `relay_id`, and
+//!    the identifying material comes from inside the authenticated channel,
+//!    never from the infrastructure being authenticated.
+//!
+//! [`verify_hello_response`] returns a [`RelaySession`], and a `RelaySession`
+//! is the only thing in this crate that hands out a [`TranscriptBuilder`]. That
+//! is deliberate: it makes "the proof was checked" a precondition of being able
+//! to sign anything, rather than a step someone remembers.
+
+use f2z_codec::commands::{HelloRequest, HelloResponse};
+use f2z_codec::hash;
+use f2z_codec::transcript::TranscriptBuilder;
+use f2z_codec::types::{Challenge, ChannelBinding, Digest, PublicKey, RelayId, Signature};
+
+use crate::capabilities::{ChannelBindingMode, ClientPolicy, TransportSecurity};
+use crate::error::{ProtoError, Refusal, Result};
+use crate::key::{SigningKey, VerifyingKey};
+
+/// The bytes a relay signs to prove possession of its identity key (§5.2):
+/// `"free2z/relay/v1/hello" || channel_binding || client_nonce`.
+///
+/// Note that this is a signing *prefix*, not an argument to `H` — the proof is
+/// over the concatenation directly.
+#[must_use]
+pub fn relay_proof(
+    identity: &SigningKey,
+    channel_binding: &ChannelBinding,
+    client_nonce: &Challenge,
+) -> Signature {
+    identity.sign(&hash::hello_proof_message(channel_binding, client_nonce))
+}
+
+/// What a relay announces about itself in `HELLO` (§6.1).
+///
+/// Grouped rather than passed as loose arguments because every field is a
+/// policy value the relay also publishes in its capability document, and the
+/// two MUST agree: `capabilities_digest` is what a client compares to detect
+/// that they do not (§11.2).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RelayAnnouncement {
+    /// The version selected for this connection (§3.5).
+    pub protocol_version: u16,
+    /// The relay's clock, for clients whose own is unreliable (§5.5).
+    pub relay_time_ms: u64,
+    /// Whether the relay can bind commands to the TLS session (§5.3).
+    pub channel_binding_mode: ChannelBindingMode,
+    /// Whether the connection is carried by TLS at all (§2.3).
+    pub transport_security: TransportSecurity,
+    /// `H("free2z/relay/v1/caps", tls_codec(Capabilities))` (§6.1).
+    pub capabilities_digest: Digest,
+}
+
+/// Build the `HelloResponse` a relay answers with (§6.1).
+///
+/// `relay_id` is recomputed here rather than taken as an argument so that a
+/// relay cannot publish one that is not the digest of its own key.
+#[must_use]
+pub fn hello_response(
+    identity: &SigningKey,
+    announcement: &RelayAnnouncement,
+    channel_binding: &ChannelBinding,
+    client_nonce: &Challenge,
+) -> HelloResponse {
+    let relay_identity_pk = identity.public_key();
+    HelloResponse {
+        protocol_version: announcement.protocol_version,
+        relay_identity_pk,
+        relay_id: hash::relay_id(&relay_identity_pk),
+        relay_proof: relay_proof(identity, channel_binding, client_nonce),
+        relay_time_ms: announcement.relay_time_ms,
+        channel_binding_mode: announcement.channel_binding_mode.code(),
+        transport_security: announcement.transport_security.code(),
+        capabilities_digest: announcement.capabilities_digest,
+    }
+}
+
+/// A connection whose relay has proved who it is.
+///
+/// Holds the three values that are constant for the connection and that §5.2
+/// and §5.3 require be the *relay's own*, never the frame's: the negotiated
+/// version, the relay identity, and this session's channel binding.
+#[derive(Clone, Debug)]
+pub struct RelaySession {
+    transcripts: TranscriptBuilder,
+    relay_identity_pk: PublicKey,
+    relay_time_ms: u64,
+    channel_binding_mode: ChannelBindingMode,
+    transport_security: TransportSecurity,
+    capabilities_digest: Digest,
+}
+
+impl RelaySession {
+    /// The transcript builder every signed command on this connection is built
+    /// and verified through.
+    #[must_use]
+    pub const fn transcripts(&self) -> &TranscriptBuilder {
+        &self.transcripts
+    }
+
+    /// The version selected for this connection (§3.5: negotiation happens
+    /// once, in `HELLO`, and applies to the whole connection).
+    #[must_use]
+    pub const fn protocol_version(&self) -> u16 {
+        self.transcripts.protocol_version()
+    }
+
+    /// The relay's identity binding.
+    #[must_use]
+    pub const fn relay_id(&self) -> RelayId {
+        self.transcripts.relay_id()
+    }
+
+    /// The relay's long-term public key, proved in `HELLO`. This is what a
+    /// capability document must be signed by (§11.3 step 1).
+    #[must_use]
+    pub const fn relay_identity_pk(&self) -> PublicKey {
+        self.relay_identity_pk
+    }
+
+    /// The relay's clock at `HELLO`.
+    ///
+    /// §5.5: a client with an unreliable clock learns the relay's time here and
+    /// applies the offset locally. It **MUST NOT** set its system clock from
+    /// it.
+    #[must_use]
+    pub const fn relay_time_ms(&self) -> u64 {
+        self.relay_time_ms
+    }
+
+    /// The channel-binding mode this connection is operating in.
+    #[must_use]
+    pub const fn channel_binding_mode(&self) -> ChannelBindingMode {
+        self.channel_binding_mode
+    }
+
+    /// Whether the connection is carried by TLS at all (§2.3).
+    #[must_use]
+    pub const fn transport_security(&self) -> TransportSecurity {
+        self.transport_security
+    }
+
+    /// The digest of the capability document in force when the connection
+    /// opened. Compare with [`crate::capabilities::check_digest`] after
+    /// fetching, and again on `NOTICE(3)` (§6.4).
+    #[must_use]
+    pub const fn capabilities_digest(&self) -> Digest {
+        self.capabilities_digest
+    }
+
+    /// The client's own estimate of the relay's clock, `elapsed_ms` after the
+    /// `HELLO` response arrived.
+    ///
+    /// This is the value to put in a signed command's `timestamp_ms` (§5.5).
+    /// Taking the elapsed time as an argument keeps the crate clock-free.
+    #[must_use]
+    pub const fn relay_time_after(&self, elapsed_ms: u64) -> u64 {
+        self.relay_time_ms.saturating_add(elapsed_ms)
+    }
+}
+
+/// Verify a `HELLO` response and open a session (§2.5 steps 2-3, §5.2).
+///
+/// `channel_binding` is the value **this client computed from its own TLS
+/// state** — [`ChannelBinding::zero`] when the relay published
+/// `channel_binding_mode: none`. It is never transmitted; both ends derive it
+/// and the transcript binds to it, which is what makes a captured frame useless
+/// on any other connection.
+///
+/// `expected_relay_id` is the value from the peer's in-band advert (§7.2), when
+/// there is one. First contact via a directory entry has one too (§12.5 step
+/// 3): the contact endpoint carries `relay_id` beside `contact_addr`, covered
+/// by the directory's authorization signature.
+///
+/// # Errors
+///
+/// - [`Refusal::VersionNotOffered`] if the selected version is outside the
+///   offered range, or is one this build does not implement.
+/// - [`Refusal::RelayIdNotDerived`] if `relay_id` is not the digest of
+///   `relay_identity_pk`.
+/// - [`Refusal::RelayIdMismatch`] if it is not the one the advert named. This
+///   is the fatal one — the relay was substituted.
+/// - [`Refusal::ChannelBindingMismatch`] if the published mode and the supplied
+///   binding disagree.
+/// - [`Refusal::RelayKeyInvalid`] or [`Refusal::RelayProofInvalid`] if the
+///   proof of possession does not hold.
+/// - [`Refusal::InsecureTransport`] if the relay serves without TLS and the
+///   policy has not opted in.
+/// - [`Refusal::NoChannelBinding`] under a strict policy against a relay that
+///   cannot bind.
+pub fn verify_hello_response(
+    response: &HelloResponse,
+    offer: &HelloRequest,
+    channel_binding: &ChannelBinding,
+    expected_relay_id: Option<&RelayId>,
+    policy: &ClientPolicy,
+) -> Result<RelaySession> {
+    // §3.5: one version, selected once, for the whole connection.
+    if response.protocol_version < offer.min_version
+        || response.protocol_version > offer.max_version
+        || response.protocol_version != f2z_codec::PROTOCOL_VERSION
+    {
+        return Err(ProtoError::Refused(Refusal::VersionNotOffered));
+    }
+
+    // §6.1: `relay_id` MUST equal H("free2z/relay/v1/relay-id",
+    // relay_identity_pk). A relay that publishes anything else has contradicted
+    // itself inside one frame.
+    if hash::relay_id(&response.relay_identity_pk) != response.relay_id {
+        return Err(ProtoError::Refused(Refusal::RelayIdNotDerived));
+    }
+    // §2.5 step 3 and §5.2. Checked before the proof so that a substituted
+    // relay is reported as a substitution rather than as a bad signature — the
+    // two failures call for very different things from a user.
+    if let Some(expected) = expected_relay_id
+        && *expected != response.relay_id
+    {
+        return Err(ProtoError::Refused(Refusal::RelayIdMismatch));
+    }
+
+    let binding_mode = ChannelBindingMode::from_code(response.channel_binding_mode)
+        .map_err(|_| ProtoError::Refused(Refusal::ChannelBindingMismatch))?;
+    let transport = TransportSecurity::from_code(response.transport_security)
+        .map_err(|_| ProtoError::Refused(Refusal::InsecureTransport))?;
+
+    // §5.3: `none` mode MUST use 32 zero bytes. The converse is checked too: a
+    // relay claiming an exporter while the client derived nothing means the two
+    // ends disagree about what the transcript covers, and a signature made
+    // under that disagreement fails later, obscurely. Fail now, clearly.
+    //
+    // A genuine exporter output of 32 zero bytes has probability 2^-256, so
+    // treating zero as "absent" costs nothing real and removes the sentinel
+    // ambiguity.
+    let binding_is_zero = channel_binding.is_zero();
+    let binding_ok = match binding_mode {
+        ChannelBindingMode::None => binding_is_zero,
+        ChannelBindingMode::TlsExporter => !binding_is_zero,
+    };
+    if !binding_ok {
+        return Err(ProtoError::Refused(Refusal::ChannelBindingMismatch));
+    }
+
+    // §2.3 obligation 3 and §5.3's strict mode. Policy, not validity.
+    if matches!(transport, TransportSecurity::None) && !policy.allow_insecure_transport {
+        return Err(ProtoError::Refused(Refusal::InsecureTransport));
+    }
+    if matches!(binding_mode, ChannelBindingMode::None) && policy.require_channel_binding {
+        return Err(ProtoError::Refused(Refusal::NoChannelBinding));
+    }
+
+    // §5.2: proof of possession, over this session's binding and this client's
+    // nonce, so it cannot be replayed from another connection.
+    let identity = VerifyingKey::from_public_key(&response.relay_identity_pk)
+        .map_err(|_| ProtoError::Refused(Refusal::RelayKeyInvalid))?;
+    identity
+        .verify(
+            &hash::hello_proof_message(channel_binding, &offer.client_nonce),
+            &response.relay_proof,
+        )
+        .map_err(|_| ProtoError::Refused(Refusal::RelayProofInvalid))?;
+
+    Ok(RelaySession {
+        transcripts: TranscriptBuilder::new(
+            response.protocol_version,
+            response.relay_id,
+            *channel_binding,
+        ),
+        relay_identity_pk: response.relay_identity_pk,
+        relay_time_ms: response.relay_time_ms,
+        channel_binding_mode: binding_mode,
+        transport_security: transport,
+        capabilities_digest: response.capabilities_digest,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities;
+
+    const NOW: u64 = 1_800_000_000_000;
+
+    fn offer() -> HelloRequest {
+        HelloRequest {
+            min_version: 1,
+            max_version: 1,
+            client_nonce: Challenge::new([0x5a; 32]),
+        }
+    }
+
+    fn binding() -> ChannelBinding {
+        ChannelBinding::new([0x33; 32])
+    }
+
+    fn relay() -> SigningKey {
+        SigningKey::from_seed(&[0x44; 32])
+    }
+
+    fn announcement(
+        identity: &SigningKey,
+        channel_binding_mode: ChannelBindingMode,
+        transport_security: TransportSecurity,
+    ) -> RelayAnnouncement {
+        let capabilities = capabilities::defaults(&identity.public_key(), NOW).unwrap();
+        RelayAnnouncement {
+            protocol_version: 1,
+            relay_time_ms: NOW,
+            channel_binding_mode,
+            transport_security,
+            capabilities_digest: capabilities::digest(&capabilities).unwrap(),
+        }
+    }
+
+    fn response(identity: &SigningKey, binding: &ChannelBinding) -> HelloResponse {
+        hello_response(
+            identity,
+            &announcement(
+                identity,
+                ChannelBindingMode::TlsExporter,
+                TransportSecurity::Tls,
+            ),
+            binding,
+            &offer().client_nonce,
+        )
+    }
+
+    #[test]
+    fn a_well_formed_hello_opens_a_session() {
+        let identity = relay();
+        let response = response(&identity, &binding());
+        let session = verify_hello_response(
+            &response,
+            &offer(),
+            &binding(),
+            Some(&hash::relay_id(&identity.public_key())),
+            &ClientPolicy::default(),
+        )
+        .unwrap();
+        assert_eq!(session.protocol_version(), 1);
+        assert_eq!(session.relay_identity_pk(), identity.public_key());
+        assert_eq!(session.relay_time_after(1_500), NOW + 1_500);
+        assert_eq!(session.transcripts().channel_binding(), binding());
+    }
+
+    #[test]
+    fn a_substituted_relay_is_caught_by_the_advert() {
+        let identity = relay();
+        let response = response(&identity, &binding());
+        assert_eq!(
+            verify_hello_response(
+                &response,
+                &offer(),
+                &binding(),
+                Some(&RelayId::new([0u8; 32])),
+                &ClientPolicy::default(),
+            )
+            .map(|_| ()),
+            Err(ProtoError::Refused(Refusal::RelayIdMismatch))
+        );
+    }
+
+    #[test]
+    fn a_relay_id_that_is_not_the_digest_of_the_key_is_caught_without_an_advert() {
+        let identity = relay();
+        let mut response = response(&identity, &binding());
+        response.relay_id = RelayId::new([1u8; 32]);
+        assert_eq!(
+            verify_hello_response(
+                &response,
+                &offer(),
+                &binding(),
+                None,
+                &ClientPolicy::default()
+            )
+            .map(|_| ()),
+            Err(ProtoError::Refused(Refusal::RelayIdNotDerived))
+        );
+    }
+
+    #[test]
+    fn a_proof_from_another_session_does_not_verify() {
+        let identity = relay();
+        // The relay signed over a different TLS session's exporter.
+        let response = response(&identity, &ChannelBinding::new([0x99; 32]));
+        assert_eq!(
+            verify_hello_response(
+                &response,
+                &offer(),
+                &binding(),
+                None,
+                &ClientPolicy::default()
+            )
+            .map(|_| ()),
+            Err(ProtoError::Refused(Refusal::RelayProofInvalid))
+        );
+    }
+
+    #[test]
+    fn a_proof_for_another_clients_nonce_does_not_verify() {
+        let identity = relay();
+        let response = response(&identity, &binding());
+        let replayed_at = HelloRequest {
+            client_nonce: Challenge::new([0x5b; 32]),
+            ..offer()
+        };
+        assert_eq!(
+            verify_hello_response(
+                &response,
+                &replayed_at,
+                &binding(),
+                None,
+                &ClientPolicy::default()
+            )
+            .map(|_| ()),
+            Err(ProtoError::Refused(Refusal::RelayProofInvalid))
+        );
+    }
+
+    #[test]
+    fn a_relay_that_claims_an_exporter_we_do_not_have_is_refused() {
+        let identity = relay();
+        let response = response(&identity, &ChannelBinding::zero());
+        assert_eq!(
+            verify_hello_response(
+                &response,
+                &offer(),
+                &ChannelBinding::zero(),
+                None,
+                &ClientPolicy::default()
+            )
+            .map(|_| ()),
+            Err(ProtoError::Refused(Refusal::ChannelBindingMismatch))
+        );
+    }
+
+    #[test]
+    fn none_mode_requires_the_zero_binding_and_works_with_it() {
+        let identity = relay();
+        let zero = ChannelBinding::zero();
+        let response = hello_response(
+            &identity,
+            &announcement(&identity, ChannelBindingMode::None, TransportSecurity::Tls),
+            &zero,
+            &offer().client_nonce,
+        );
+        let session =
+            verify_hello_response(&response, &offer(), &zero, None, &ClientPolicy::default())
+                .unwrap();
+        assert_eq!(session.channel_binding_mode(), ChannelBindingMode::None);
+
+        let strict = ClientPolicy {
+            require_channel_binding: true,
+            ..ClientPolicy::default()
+        };
+        assert_eq!(
+            verify_hello_response(&response, &offer(), &zero, None, &strict).map(|_| ()),
+            Err(ProtoError::Refused(Refusal::NoChannelBinding))
+        );
+    }
+
+    #[test]
+    fn a_version_outside_the_offer_is_refused() {
+        let identity = relay();
+        let mut response = response(&identity, &binding());
+        response.protocol_version = 2;
+        assert_eq!(
+            verify_hello_response(
+                &response,
+                &offer(),
+                &binding(),
+                None,
+                &ClientPolicy::default()
+            )
+            .map(|_| ()),
+            Err(ProtoError::Refused(Refusal::VersionNotOffered))
+        );
+    }
+
+    #[test]
+    fn a_plaintext_relay_needs_an_explicit_opt_in() {
+        let identity = relay();
+        let zero = ChannelBinding::zero();
+        let response = hello_response(
+            &identity,
+            &announcement(&identity, ChannelBindingMode::None, TransportSecurity::None),
+            &zero,
+            &offer().client_nonce,
+        );
+        assert_eq!(
+            verify_hello_response(&response, &offer(), &zero, None, &ClientPolicy::default())
+                .map(|_| ()),
+            Err(ProtoError::Refused(Refusal::InsecureTransport))
+        );
+        let opted_in = ClientPolicy {
+            allow_insecure_transport: true,
+            ..ClientPolicy::default()
+        };
+        assert!(verify_hello_response(&response, &offer(), &zero, None, &opted_in).is_ok());
+    }
+}

--- a/rs/crates/f2z-relay-proto/src/inflight.rs
+++ b/rs/crates/f2z-relay-proto/src/inflight.rs
@@ -1,0 +1,336 @@
+//! The in-flight window of `WIRE.md` §4.3, and the typed correlation that
+//! keeps a response attached to the request it answers.
+//!
+//! §4.3 states four rules and this module is all four:
+//!
+//! - `request_id` is chosen by the client, is a **nonzero** `uint32`, and MUST
+//!   be unique among that connection's currently in-flight requests. It MAY be
+//!   reused once its response has been received.
+//! - **Responses may arrive out of order.** A client MUST correlate by
+//!   `request_id` and MUST NOT assume ordering: a relay may complete a cheap
+//!   `PING` before an expensive `READ` issued earlier, "and will".
+//! - A bounded window, `max_inflight` (default 32). Exceeding it is a **fatal**
+//!   `ERR_TOO_MANY_INFLIGHT`. The bound is an anti-abuse control as much as a
+//!   flow-control one (§13.1): it is what stops one connection from making the
+//!   relay allocate unbounded per-request state before any quota check has run.
+//! - A duplicate in-flight `request_id` is a fatal `ERR_MALFORMED`.
+//!
+//! # Why the ticket is typed
+//!
+//! Out-of-order responses mean a client cannot rely on position, so the only
+//! thing tying a response to its request is a `uint32` it chose. If that number
+//! is all the correlation there is, then decoding a response body is a guess
+//! about what the number meant, and a wrong guess decodes an `AckResponse` as a
+//! `SubscribeResponse` — same two `uint64` fields, same length, different
+//! meaning, no error anywhere.
+//!
+//! [`Ticket`] closes that. It is created by [`InFlight::issue`], carries the
+//! command as a type parameter, is neither `Clone` nor `Copy`, and is consumed
+//! by [`InFlight::complete`], which decodes exactly `C::Response`. Correlating
+//! the wrong response to a request stops being a runtime hazard and becomes a
+//! type error.
+
+use alloc::collections::BTreeMap;
+use core::marker::PhantomData;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::canonical::decode_canonical;
+use f2z_codec::frame::Response;
+
+use crate::command::RelayCommand;
+use crate::error::{ProtoError, Result};
+
+/// §4.3's default `max_inflight`.
+pub const DEFAULT_MAX_INFLIGHT: u16 = 32;
+
+/// Proof that a request with this id is outstanding, and a record of which
+/// command it was.
+///
+/// Deliberately not `Clone`, not `Copy`, and with no public constructor: one
+/// issued request is one ticket is one response.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Ticket<C> {
+    request_id: u32,
+    marker: PhantomData<fn() -> C>,
+}
+
+impl<C: RelayCommand> Ticket<C> {
+    /// The `request_id` this ticket is for. It is also covered by the signing
+    /// transcript of a signed command (§5.1), so it cannot be changed after the
+    /// request is built.
+    #[must_use]
+    pub const fn request_id(&self) -> u32 {
+        self.request_id
+    }
+}
+
+/// One connection's outstanding requests.
+///
+/// Useful in both directions, which is why it is not called a client: a client
+/// uses it to correlate responses, and a relay uses it to enforce §4.3's
+/// duplicate and window rules on what arrives. The relay side ignores
+/// [`Ticket`] and reads [`InFlight::command_for`].
+#[derive(Clone, Debug)]
+pub struct InFlight {
+    /// `request_id` → the command code it was issued for.
+    entries: BTreeMap<u32, u16>,
+    max_inflight: u16,
+}
+
+impl InFlight {
+    /// A window of `max_inflight` outstanding requests.
+    #[must_use]
+    pub const fn new(max_inflight: u16) -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            max_inflight,
+        }
+    }
+
+    /// The published bound.
+    #[must_use]
+    pub const fn max_inflight(&self) -> u16 {
+        self.max_inflight
+    }
+
+    /// How many requests are outstanding.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether nothing is outstanding.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The command code an outstanding `request_id` was issued for.
+    #[must_use]
+    pub fn command_for(&self, request_id: u32) -> Option<u16> {
+        self.entries.get(&request_id).copied()
+    }
+
+    /// Claim a `request_id` for command `C`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::Malformed`] — fatal — if `request_id` is zero (that is a
+    ///   push's id, §4.3) or is already outstanding.
+    /// - [`ErrorCode::TooManyInflight`] — fatal — if the window is full.
+    pub fn issue<C: RelayCommand>(&mut self, request_id: u32) -> Result<Ticket<C>> {
+        if request_id == 0 {
+            return Err(ProtoError::Wire(ErrorCode::Malformed));
+        }
+        if self.entries.contains_key(&request_id) {
+            return Err(ProtoError::Wire(ErrorCode::Malformed));
+        }
+        if self.entries.len() >= usize::from(self.max_inflight) {
+            return Err(ProtoError::Wire(ErrorCode::TooManyInflight));
+        }
+        self.entries.insert(request_id, C::COMMAND.code());
+        Ok(Ticket {
+            request_id,
+            marker: PhantomData,
+        })
+    }
+
+    /// Release a `request_id` without a response.
+    ///
+    /// §2.5: an in-flight command whose response was not received has
+    /// **unknown** status. This is how a caller records that it has stopped
+    /// waiting — it does not mean the command did not happen, and `APPEND` in
+    /// particular is not idempotent (§8.3), so the retry rules apply.
+    pub fn cancel<C: RelayCommand>(&mut self, ticket: Ticket<C>) {
+        self.entries.remove(&ticket.request_id);
+    }
+
+    /// Match a response to its ticket and decode the paired body type.
+    ///
+    /// `frame_request_id` is the id on the received frame; it is checked
+    /// against the ticket rather than trusted, so a relay that answers on the
+    /// wrong id cannot get a body decoded as something else.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::Malformed`] if the frame's id is not the ticket's, if the
+    ///   ticket is not outstanding, or if a failing response carried a body
+    ///   (§4.1 forbids it).
+    /// - The relay's own code, when `status != 0`.
+    /// - [`ProtoError::UnknownStatus`] for a nonzero status this build does not
+    ///   know. §10 keeps codes stable so that an old client can still record
+    ///   one it has never heard of.
+    /// - [`ErrorCode::Malformed`] if the body is not a canonical `C::Response`
+    ///   (§3.3).
+    pub fn complete<C: RelayCommand>(
+        &mut self,
+        ticket: Ticket<C>,
+        frame_request_id: u32,
+        response: &Response,
+    ) -> Result<C::Response> {
+        if frame_request_id != ticket.request_id {
+            return Err(ProtoError::Wire(ErrorCode::Malformed));
+        }
+        if self.entries.remove(&ticket.request_id).is_none() {
+            return Err(ProtoError::Wire(ErrorCode::Malformed));
+        }
+        response.validate()?;
+        if !response.is_ok() {
+            return Err(match response.error_code() {
+                Some(code) => ProtoError::Wire(code),
+                None => ProtoError::UnknownStatus(response.status),
+            });
+        }
+        Ok(decode_canonical::<C::Response>(response.body())?.into_value())
+    }
+}
+
+impl Default for InFlight {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_INFLIGHT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::{Empty, ops};
+    use alloc::vec;
+    use f2z_codec::canonical::Canonical;
+    use f2z_codec::commands::{AckResponse, SubscribeResponse};
+
+    #[test]
+    fn ids_are_nonzero_unique_and_bounded() {
+        let mut inflight = InFlight::new(2);
+        let first = inflight.issue::<ops::Ack>(1).unwrap();
+        assert_eq!(
+            inflight.issue::<ops::Read>(0).map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::Malformed))
+        );
+        assert_eq!(
+            inflight.issue::<ops::Read>(1).map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::Malformed)),
+            "a duplicate in-flight id is a fatal ERR_MALFORMED"
+        );
+        let second = inflight.issue::<ops::Read>(2).unwrap();
+        assert_eq!(
+            inflight.issue::<ops::Ping>(3).map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::TooManyInflight))
+        );
+
+        // Reusable once the response has been received.
+        let body = AckResponse {
+            next_index: 4,
+            pending: 0,
+        };
+        inflight
+            .complete(
+                first,
+                1,
+                &Response::ok(body.encode_canonical().unwrap()).unwrap(),
+            )
+            .unwrap();
+        let third = inflight.issue::<ops::Ping>(1).unwrap();
+        inflight.cancel(third);
+        inflight.cancel(second);
+        assert!(inflight.is_empty());
+    }
+
+    #[test]
+    fn responses_correlate_out_of_order() {
+        let mut inflight = InFlight::default();
+        let read = inflight.issue::<ops::Read>(10).unwrap();
+        let ping = inflight.issue::<ops::Ping>(11).unwrap();
+        assert_eq!(inflight.command_for(10), Some(0x0013));
+
+        // The cheap PING completes first, exactly as §4.3 warns.
+        assert_eq!(
+            inflight.complete(ping, 11, &Response::ok(vec![]).unwrap()),
+            Ok(Empty)
+        );
+        let body = f2z_codec::commands::ReadResponse {
+            messages: vec![].into(),
+            has_more: 0,
+        };
+        assert!(
+            inflight
+                .complete(
+                    read,
+                    10,
+                    &Response::ok(body.encode_canonical().unwrap()).unwrap()
+                )
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn a_response_on_the_wrong_id_is_refused() {
+        let mut inflight = InFlight::default();
+        let ticket = inflight.issue::<ops::Ping>(5).unwrap();
+        assert_eq!(
+            inflight.complete(ticket, 6, &Response::ok(vec![]).unwrap()),
+            Err(ProtoError::Wire(ErrorCode::Malformed))
+        );
+    }
+
+    #[test]
+    fn an_error_status_surfaces_the_relays_code() {
+        let mut inflight = InFlight::default();
+        let ticket = inflight.issue::<ops::Append>(1).unwrap();
+        assert_eq!(
+            inflight.complete(ticket, 1, &Response::error(ErrorCode::Unavailable)),
+            Err(ProtoError::Wire(ErrorCode::Unavailable))
+        );
+        // …and the slot is freed, so the client can retry on the same id.
+        assert!(inflight.is_empty());
+    }
+
+    #[test]
+    fn an_unknown_status_is_carried_rather_than_flattened() {
+        let mut inflight = InFlight::default();
+        let ticket = inflight.issue::<ops::Append>(1).unwrap();
+        let response = Response {
+            status: 4242,
+            body: f2z_codec::types::Body::default(),
+        };
+        assert_eq!(
+            inflight.complete(ticket, 1, &response),
+            Err(ProtoError::UnknownStatus(4242))
+        );
+    }
+
+    #[test]
+    fn a_failing_response_may_not_carry_a_body() {
+        let mut inflight = InFlight::default();
+        let ticket = inflight.issue::<ops::Append>(1).unwrap();
+        let response = Response {
+            status: ErrorCode::Unavailable.code(),
+            body: f2z_codec::types::Body::new(vec![1u8]).unwrap(),
+        };
+        assert_eq!(
+            inflight.complete(ticket, 1, &response),
+            Err(ProtoError::Wire(ErrorCode::Malformed))
+        );
+    }
+
+    #[test]
+    fn an_append_response_may_not_carry_queue_state() {
+        // §6.3: the response body is empty, and that is a requirement rather
+        // than an omission. A relay that answered with an index would be
+        // handing the sender a weak read capability; `Empty` refuses it.
+        let mut inflight = InFlight::default();
+        let ticket = inflight.issue::<ops::Append>(1).unwrap();
+        let sneaky = SubscribeResponse {
+            next_index: 7,
+            pending: 3,
+        };
+        assert_eq!(
+            inflight.complete(
+                ticket,
+                1,
+                &Response::ok(sneaky.encode_canonical().unwrap()).unwrap()
+            ),
+            Err(ProtoError::Wire(ErrorCode::Malformed))
+        );
+    }
+}

--- a/rs/crates/f2z-relay-proto/src/key.rs
+++ b/rs/crates/f2z-relay-proto/src/key.rs
@@ -1,0 +1,253 @@
+//! Ed25519 keys, signatures, and the two properties `WIRE.md` asks of them
+//! that a naive wrapper would miss.
+//!
+//! **Strict verification.** Everything here verifies with `verify_strict`,
+//! which additionally rejects small-order public keys and small-order `R`
+//! components. Plain Ed25519 verification does not, and the consequence is
+//! signature *malleability*: a signature can verify under more than one key,
+//! and a key can exist under which every signature verifies. This protocol
+//! treats a verifying signature as proof that a specific key authorized a
+//! specific command — [`WIRE.md` §5.1][s5] step 5 compares `signer_key`
+//! against the key registered for an address — so a key that verifies
+//! everything is a key that steals every queue it is registered against. The
+//! cost of `verify_strict` is one extra point check.
+//!
+//! **Redaction.** [`SigningKey`] holds the one genuinely secret value in the
+//! system; its `Debug` prints nothing about it, not even a fingerprint.
+//! [`VerifyingKey`] is public but linkable — a per-queue key identifies a
+//! conversation to anyone who has seen it elsewhere ([ADR 0004]) — so it
+//! redacts too, exactly as `f2z-codec`'s newtypes do.
+//!
+//! [s5]: https://github.com/free2z/zuu/blob/main/docs/e2ee/WIRE.md
+//! [ADR 0004]: https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0004-metadata-ambition.md
+
+use core::fmt;
+
+use ed25519_dalek::Signer as _;
+use f2z_codec::ErrorCode;
+use f2z_codec::types::{PublicKey, Signature};
+use subtle::ConstantTimeEq as _;
+
+use crate::error::{ProtoError, Result};
+
+/// An Ed25519 public key that has been decompressed and is ready to verify.
+///
+/// Constructing one is the only place a malformed key is rejected, so a
+/// [`VerifyingKey`] in hand is a key that decodes to a curve point. It is not a
+/// promise that the point is safe: that check belongs to each verification, and
+/// [`VerifyingKey::verify`] makes it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct VerifyingKey(ed25519_dalek::VerifyingKey);
+
+impl VerifyingKey {
+    /// Decompress a wire public key.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::BadSignature`] if the bytes are not a curve point. That is
+    /// the same code a bad signature gets, deliberately: from a peer's side
+    /// "your key is not a key" and "your signature is not a signature" are the
+    /// same event — the command was not authorized — and splitting them would
+    /// tell an unauthenticated caller which half of its guess was wrong.
+    pub fn from_public_key(key: &PublicKey) -> Result<Self> {
+        ed25519_dalek::VerifyingKey::from_bytes(key.as_bytes())
+            .map(Self)
+            .map_err(|_| ProtoError::Wire(ErrorCode::BadSignature))
+    }
+
+    /// The wire form.
+    #[must_use]
+    pub fn to_public_key(&self) -> PublicKey {
+        PublicKey::new(self.0.to_bytes())
+    }
+
+    /// Verify a signature over `message`, strictly (see the module note).
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::BadSignature`].
+    pub fn verify(&self, message: &[u8], signature: &Signature) -> Result<()> {
+        let signature = ed25519_dalek::Signature::from_bytes(signature.as_bytes());
+        self.0
+            .verify_strict(message, &signature)
+            .map_err(|_| ProtoError::Wire(ErrorCode::BadSignature))
+    }
+}
+
+// Public, but linkable. Same rule as `f2z-codec`'s newtypes, and no alternate
+// formatter that renders the bytes — an escape hatch would be found and used.
+impl fmt::Debug for VerifyingKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("VerifyingKey(<redacted>)")
+    }
+}
+
+/// An Ed25519 signing key: a relay identity key, or a per-queue send or
+/// receive key.
+///
+/// This crate never generates one. Randomness is the caller's — a client draws
+/// queue keys from the MLS exporter of `ARCHITECTURE.md` §5.4, and this crate
+/// has no runtime, no clock and no CSPRNG by design.
+#[derive(Clone)]
+pub struct SigningKey(ed25519_dalek::SigningKey);
+
+impl SigningKey {
+    /// Adopt a 32-byte seed.
+    ///
+    /// The seed is secret key material and the caller owns its lifetime; this
+    /// type zeroizes its own copy on drop but cannot reach the caller's.
+    #[must_use]
+    pub fn from_seed(seed: &[u8; 32]) -> Self {
+        Self(ed25519_dalek::SigningKey::from_bytes(seed))
+    }
+
+    /// The public half.
+    #[must_use]
+    pub fn verifying_key(&self) -> VerifyingKey {
+        VerifyingKey(self.0.verifying_key())
+    }
+
+    /// The public half in wire form — what goes in `signer_key`, `recv_key`,
+    /// `send_key` or `relay_identity_pk`.
+    #[must_use]
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey::new(self.0.verifying_key().to_bytes())
+    }
+
+    /// Sign a message.
+    ///
+    /// `WIRE.md` §5.1: Ed25519 is not prehashed here and the transcript is
+    /// small, so the message is signed directly.
+    #[must_use]
+    pub fn sign(&self, message: &[u8]) -> Signature {
+        Signature::new(self.0.sign(message).to_bytes())
+    }
+}
+
+// The one value in this crate whose disclosure is unrecoverable.
+impl fmt::Debug for SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SigningKey(<redacted>)")
+    }
+}
+
+/// Compare two public keys in constant time.
+///
+/// `WIRE.md` §10 requires this where a key comparison decides whether an
+/// address authorizes a caller: a data-dependent comparison there is a
+/// byte-at-a-time oracle on a value the relay is trying not to confirm.
+#[must_use]
+pub fn keys_equal(left: &PublicKey, right: &PublicKey) -> bool {
+    left.as_bytes().ct_eq(right.as_bytes()).into()
+}
+
+/// A verification against a fixed key that always fails, for §10's absent path.
+///
+/// `WIRE.md` §10 requires a relay that is about to answer `ERR_NO_ACCESS` for
+/// an address it does not hold to "perform a dummy Ed25519 verification against
+/// a fixed key so that the dominant CPU cost is present in both paths", and to
+/// not short-circuit before it. That is what this is for, and the return value
+/// exists so the call cannot be optimized away — a caller MUST consume it.
+///
+/// Read this as exactly what §10 says it is: a narrowing, not a closure. The
+/// storage-layer difference between an index miss and an index hit remains, and
+/// the specification states that residual rather than papering over it.
+#[must_use]
+pub fn dummy_verify() -> bool {
+    // A fixed, deliberately public key and an all-zero signature. The
+    // verification fails; the point is the arithmetic it does first.
+    let key = SigningKey::from_seed(&[0x11; 32]).verifying_key();
+    key.verify(b"free2z/relay/v1/dummy", &Signature::zero())
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+
+    #[test]
+    fn a_signature_verifies_under_its_own_key_and_no_other() {
+        let key = SigningKey::from_seed(&[7u8; 32]);
+        let other = SigningKey::from_seed(&[8u8; 32]);
+        let signature = key.sign(b"transcript");
+        assert!(
+            key.verifying_key()
+                .verify(b"transcript", &signature)
+                .is_ok()
+        );
+        assert_eq!(
+            other.verifying_key().verify(b"transcript", &signature),
+            Err(ProtoError::Wire(ErrorCode::BadSignature))
+        );
+        assert_eq!(
+            key.verifying_key().verify(b"transcripT", &signature),
+            Err(ProtoError::Wire(ErrorCode::BadSignature))
+        );
+    }
+
+    #[test]
+    fn the_public_key_round_trips_through_the_wire_form() {
+        let key = SigningKey::from_seed(&[3u8; 32]);
+        let wire = key.public_key();
+        let decoded = VerifyingKey::from_public_key(&wire).unwrap();
+        assert_eq!(decoded.to_public_key(), wire);
+        assert_eq!(decoded, key.verifying_key());
+    }
+
+    #[test]
+    fn a_key_that_is_not_a_curve_point_is_refused_as_a_bad_signature() {
+        // Roughly half of all 32-byte strings decompress to a curve point and
+        // half do not, so the property is searched for rather than asserted
+        // about one hand-picked constant — a constant would be a claim about
+        // curve25519-dalek's encoding rules that this test cannot check.
+        let mut candidate = [0u8; 32];
+        let refused = (0..64u8).any(|byte| {
+            candidate[0] = byte;
+            VerifyingKey::from_public_key(&PublicKey::new(candidate))
+                == Err(ProtoError::Wire(ErrorCode::BadSignature))
+        });
+        assert!(refused, "no 32-byte string in the sample was refused");
+    }
+
+    #[test]
+    fn small_order_keys_are_rejected_by_strict_verification() {
+        // The canonical small-order point of order 8. Under non-strict
+        // verification a signature can be made to verify under a key like
+        // this; §5.1 step 5 then reads a queue as authorized by a key nobody
+        // possesses.
+        let small_order = PublicKey::new([
+            0xc7, 0x17, 0x6a, 0x70, 0x3d, 0x4d, 0xd8, 0x4f, 0xba, 0x3c, 0x0b, 0x76, 0x0d, 0x10,
+            0x67, 0x0f, 0x2a, 0x20, 0x53, 0xfa, 0x2c, 0x39, 0xcc, 0xc6, 0x4e, 0xc7, 0xfd, 0x77,
+            0x92, 0xac, 0x03, 0x7a,
+        ]);
+        let key = VerifyingKey::from_public_key(&small_order).unwrap();
+        assert_eq!(
+            key.verify(b"anything", &Signature::new([0u8; 64])),
+            Err(ProtoError::Wire(ErrorCode::BadSignature))
+        );
+    }
+
+    #[test]
+    fn keys_equal_agrees_with_equality() {
+        let a = SigningKey::from_seed(&[1u8; 32]).public_key();
+        let b = SigningKey::from_seed(&[2u8; 32]).public_key();
+        assert!(keys_equal(&a, &a));
+        assert!(!keys_equal(&a, &b));
+    }
+
+    #[test]
+    fn the_dummy_verification_does_work_and_fails() {
+        assert!(!dummy_verify());
+    }
+
+    #[test]
+    fn keys_never_render_their_bytes() {
+        let key = SigningKey::from_seed(&[0xde; 32]);
+        assert_eq!(format!("{key:?}"), "SigningKey(<redacted>)");
+        assert_eq!(
+            format!("{:?}", key.verifying_key()),
+            "VerifyingKey(<redacted>)"
+        );
+    }
+}

--- a/rs/crates/f2z-relay-proto/src/lib.rs
+++ b/rs/crates/f2z-relay-proto/src/lib.rs
@@ -1,0 +1,147 @@
+//! The free2z relay protocol, above the wire format and below the socket.
+//!
+//! This crate implements the parts of [`docs/e2ee/WIRE.md`] that a relay and a
+//! client must agree on *exactly* and that neither can own: the signing
+//! transcript's signature (§5), anti-replay (§5.5), the queue lifecycle and
+//! acknowledgement arithmetic (§7, §8), the capability document (§11), and the
+//! typed pairing of a request with its response (§4.3, §6). It sits on
+//! [`f2z_codec`], which owns the canonical encoding, the framing and the
+//! transcript's *bytes*.
+//!
+//! Both sides link it, and that is the design rather than a convenience. Every
+//! rule below is one where a relay and a client disagreeing means either lost
+//! ciphertext or a signature that verifies where it should not:
+//!
+//! - **[`command`]** — building a signed command and verifying one, in §5.1's
+//!   exact order, with the relay's own `relay_id` and `channel_binding`.
+//! - **[`replay`]** — the timestamp window and the fail-closed seen-set.
+//! - **[`queue`]** — bind-once, cumulative-monotone-idempotent `ACK`, and the
+//!   rule that makes pre-acking impossible.
+//! - **[`capabilities`]** — the signed policy document, what makes it valid,
+//!   and what makes a client refuse the relay that published it.
+//! - **[`hello`]** — proof of possession, and the session that hands out the
+//!   only transcript builder in the crate.
+//! - **[`inflight`]** — §4.3's bounded, out-of-order window, with a typed
+//!   ticket so a response cannot be decoded as the wrong command's.
+//!
+//! # What it deliberately does not do
+//!
+//! No I/O, no sockets, no TLS, no async runtime, no filesystem, **no clock and
+//! no randomness**. Every function that needs the time takes it as an argument
+//! and every function that needs a nonce is given one. That is what lets the
+//! same code run in a relay and in a browser: it is `no_std` + `alloc`, it
+//! carries `#![forbid(unsafe_code)]`, and CI builds it for
+//! `wasm32-unknown-unknown` on every change, because [ADR 0001] requires one
+//! Rust core shared by ZUULI and the web client and a crate that cannot reach
+//! the browser breaks that.
+//!
+//! It also does not store anything. Message bodies, addresses, quotas and
+//! challenge issuance are relay state; this crate holds the rules those states
+//! must obey.
+//!
+//! # A connection, end to end
+//!
+//! ```
+//! use f2z_codec::commands::{AppendRequest, HelloRequest};
+//! use f2z_codec::padding::PaddingBuckets;
+//! use f2z_codec::types::{Challenge, ChannelBinding, Nonce, Payload, QueueAddress};
+//! use f2z_relay_proto::capabilities::{self, ChannelBindingMode, ClientPolicy, TransportSecurity};
+//! use f2z_relay_proto::command::{CommandVerifier, SignedCommand, ops};
+//! use f2z_relay_proto::hello::{RelayAnnouncement, hello_response, verify_hello_response};
+//! use f2z_relay_proto::key::SigningKey;
+//! use f2z_relay_proto::replay::{SeenSet, TimestampWindow};
+//!
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! let now = 1_800_000_000_000;
+//! // The relay's long-term identity, and this TLS session's exporter (§5.3).
+//! let relay_identity = SigningKey::from_seed(&[1u8; 32]);
+//! let binding = ChannelBinding::new([2u8; 32]);
+//!
+//! // The client offers a version range and a nonce; the relay answers with a
+//! // proof of possession over this session's binding and that nonce.
+//! let offer = HelloRequest { min_version: 1, max_version: 1, client_nonce: Challenge::new([3u8; 32]) };
+//! let published = capabilities::defaults(&relay_identity.public_key(), now)?;
+//! let hello = hello_response(
+//!     &relay_identity,
+//!     &RelayAnnouncement {
+//!         protocol_version: 1,
+//!         relay_time_ms: now,
+//!         channel_binding_mode: ChannelBindingMode::TlsExporter,
+//!         transport_security: TransportSecurity::Tls,
+//!         capabilities_digest: capabilities::digest(&published)?,
+//!     },
+//!     &binding,
+//!     &offer.client_nonce,
+//! );
+//!
+//! // The client verifies the proof before signing anything. A session is the
+//! // only way to obtain a transcript builder.
+//! let session = verify_hello_response(&hello, &offer, &binding, None, &ClientPolicy::default())?;
+//! capabilities::check_digest(&published, &session.capabilities_digest())?;
+//!
+//! // A signed APPEND, padded to a published bucket (§9).
+//! let send_key = SigningKey::from_seed(&[4u8; 32]);
+//! let signed = SignedCommand::<ops::Append>::create(
+//!     session.transcripts(),
+//!     1,
+//!     QueueAddress::new([5u8; 32]),
+//!     session.relay_time_after(20),
+//!     Nonce::new([6u8; 16]),
+//!     &send_key,
+//!     &AppendRequest { payload: Payload::new(vec![0u8; 1024])? },
+//! )?;
+//!
+//! // And the relay verifies it, in §5.1's order, against its own values.
+//! let mut verifier = CommandVerifier::new(
+//!     session.transcripts().clone(),
+//!     TimestampWindow::default(),
+//!     SeenSet::new(240_000, 65_536),
+//!     PaddingBuckets::default(),
+//! );
+//! let verified = verifier.verify::<ops::Append>(now, 1, &signed.request()?)?;
+//! assert_eq!(verified.signer_key(), send_key.public_key());
+//!
+//! // The same frame a second time is a replay, whatever it was the first time.
+//! assert!(verifier.verify::<ops::Append>(now, 1, &signed.request()?).is_err());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`docs/e2ee/WIRE.md`]: https://github.com/free2z/zuu/blob/main/docs/e2ee/WIRE.md
+//! [ADR 0001]: https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0001-platform-priority.md
+
+#![no_std]
+#![forbid(unsafe_code)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects
+    )
+)]
+
+extern crate alloc;
+
+pub mod capabilities;
+pub mod command;
+pub mod error;
+pub mod hello;
+pub mod inflight;
+pub mod key;
+pub mod queue;
+pub mod replay;
+
+pub use command::{CommandVerifier, RelayCommand, SignedCommand, Verified};
+pub use error::{ProtoError, Refusal};
+pub use hello::RelaySession;
+pub use inflight::{InFlight, Ticket};
+pub use key::{SigningKey, VerifyingKey};
+pub use queue::{QueueKind, QueueState};
+pub use replay::{SeenSet, TimestampWindow};
+
+/// The protocol version this crate speaks, restated from [`f2z_codec`] so a
+/// caller does not have to reach past this layer for it. `WIRE.md` §3.5.
+pub const PROTOCOL_VERSION: u16 = f2z_codec::PROTOCOL_VERSION;

--- a/rs/crates/f2z-relay-proto/src/queue.rs
+++ b/rs/crates/f2z-relay-proto/src/queue.rs
@@ -1,0 +1,771 @@
+//! Queue lifecycle — `WIRE.md` §7, §8 and §12.2 — as pure functions.
+//!
+//! Nothing here stores a message, reads a clock or allocates an address. What
+//! it holds is the part of a queue that is a *rule*: which key authorizes which
+//! side, that binding happens once and never again, and the acknowledgement
+//! arithmetic that decides when ciphertext is destroyed.
+//!
+//! Three of those rules are the ones that lose messages when they are wrong,
+//! and each is stated here next to its test:
+//!
+//! - **Bind-once** (§7.3). There is no rebind, no unbind, and no reset by the
+//!   recv key. A queue whose send side is bound to the wrong key is dead and is
+//!   replaced (§7.5). Letting the recv key rebind was rejected because it turns
+//!   the recv key — the one that can drain the queue — into a control over the
+//!   send side as well.
+//! - **Cumulative, monotone, idempotent acknowledgement** (§8.1, §8.3). An
+//!   `ACK` below the watermark is accepted and does nothing; the watermark
+//!   never moves backwards; a retry after a lost response is safe, which is
+//!   what makes the connection-loss case tractable at all.
+//! - **No pre-acking** (§8.2). `up_to_index` above the highest index ever
+//!   appended is `ERR_ACK_TOO_HIGH`. Without that rule a reader could set the
+//!   watermark to a huge value and every future `APPEND` would be deleted the
+//!   instant it landed, while the sender kept receiving successful, empty
+//!   `APPEND` responses — a device black-holing its own queue silently and
+//!   indefinitely, indistinguishable from being offline.
+//!
+//! # What this deliberately does not model
+//!
+//! TTL expiry (§7.7) removes stored messages **without moving the watermark**,
+//! so `pending` as computed here is the number of unacknowledged *indices*,
+//! which is an upper bound on the number of messages actually held. A relay
+//! that expires messages MUST answer `SUBSCRIBE` and `ACK` from its storage,
+//! not from this count. Saying so is better than modelling storage in a crate
+//! that has none.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::types::{PublicKey, QueueAddress, RelayId};
+
+use crate::error::{ProtoError, Result};
+use crate::key::keys_equal;
+
+/// §7.7's message-TTL ceiling: 30 days. A relay MUST NOT grant more.
+pub const MAX_MESSAGE_TTL_SECONDS: u32 = f2z_codec::MAX_MESSAGE_TTL_SECONDS;
+
+/// §7.7's default message TTL: 7 days.
+pub const DEFAULT_MESSAGE_TTL_SECONDS: u32 = 604_800;
+
+/// §7.7's idle-TTL ceiling: 365 days.
+pub const MAX_IDLE_TTL_SECONDS: u32 = 31_536_000;
+
+/// §7.7's default idle TTL: 90 days.
+pub const DEFAULT_IDLE_TTL_SECONDS: u32 = 7_776_000;
+
+/// Which flavour of queue this is (§12.2).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QueueKind {
+    /// An ordinary queue: two addresses, the send side bindable exactly once.
+    Standard,
+    /// A contact queue. Its send side is **never** bound, it accepts unsigned
+    /// appends from anyone with a valid stamp, its address is published in the
+    /// owner's directory entry, and it is hard-capped because of all three.
+    Contact,
+}
+
+/// A queue's authorization and acknowledgement state.
+///
+/// Deletion is not a state. §7.6 requires that a relay "MUST NOT retain a
+/// tombstone that distinguishes deleted from never existed in any externally
+/// observable way", so a deleted queue is one that no longer exists — dropping
+/// the value is the model, and adding a `deleted` flag would be modelling the
+/// thing the specification forbids.
+#[derive(Clone, Debug)]
+pub struct QueueState {
+    kind: QueueKind,
+    recv_key: PublicKey,
+    send_key: Option<PublicKey>,
+    next_index: u64,
+    acked_through: Option<u64>,
+}
+
+impl QueueState {
+    /// A fresh queue, created by the recipient (§7.1).
+    ///
+    /// The send side of a standard queue starts **unbound**: no key authorizes
+    /// `APPEND` until the peer that received the advert calls `BIND_SEND`.
+    #[must_use]
+    pub const fn create(kind: QueueKind, recv_key: PublicKey) -> Self {
+        Self {
+            kind,
+            recv_key,
+            send_key: None,
+            next_index: 0,
+            acked_through: None,
+        }
+    }
+
+    /// Standard or contact.
+    #[must_use]
+    pub const fn kind(&self) -> QueueKind {
+        self.kind
+    }
+
+    /// The key that authorizes `SUBSCRIBE`, `READ`, `ACK` and `DELETE_QUEUE`.
+    #[must_use]
+    pub const fn recv_key(&self) -> PublicKey {
+        self.recv_key
+    }
+
+    /// The bound send key, if `BIND_SEND` has succeeded.
+    #[must_use]
+    pub const fn send_key(&self) -> Option<PublicKey> {
+        self.send_key
+    }
+
+    /// Whether the send side is bound.
+    #[must_use]
+    pub const fn is_bound(&self) -> bool {
+        self.send_key.is_some()
+    }
+
+    /// The index the next appended message will receive.
+    ///
+    /// Indices start at zero and only ever increase. `WIRE.md` does not name a
+    /// first index; zero is chosen because §8.2's rule is stated as "greater
+    /// than the highest index the relay has **ever** appended", which is a
+    /// clean total order from zero and needs no sentinel for "nothing yet" —
+    /// `next_index == 0` says it.
+    #[must_use]
+    pub const fn next_index(&self) -> u64 {
+        self.next_index
+    }
+
+    /// The acknowledgement watermark: the highest index acknowledged, if any.
+    #[must_use]
+    pub const fn acked_through(&self) -> Option<u64> {
+        self.acked_through
+    }
+
+    /// The lowest index that has not been acknowledged.
+    #[must_use]
+    pub const fn first_unacked(&self) -> u64 {
+        match self.acked_through {
+            Some(watermark) => watermark.saturating_add(1),
+            None => 0,
+        }
+    }
+
+    /// The number of unacknowledged indices — §6.2's `pending`, as an upper
+    /// bound (see the module note on TTL expiry).
+    #[must_use]
+    pub const fn pending(&self) -> u64 {
+        self.next_index.saturating_sub(self.first_unacked())
+    }
+
+    /// Check a receive-side signer against the registered key (§5.1 step 5).
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::NoAccess`] — the same code an address that never existed
+    /// gets. §10's existence-oracle rule requires that: if the two differed,
+    /// the relay would tell an attacker sweeping the address space which
+    /// 32-byte values are live queues.
+    pub fn authorize_recv(&self, signer: &PublicKey) -> Result<()> {
+        if keys_equal(&self.recv_key, signer) {
+            Ok(())
+        } else {
+            Err(ProtoError::Wire(ErrorCode::NoAccess))
+        }
+    }
+
+    /// Check a send-side signer against the bound key.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::Unavailable`], always — never a distinguishable code.
+    /// §6.3: "every send-side refusal that would distinguish queue state
+    /// collapses to the single code `ERR_UNAVAILABLE`", because if "queue full"
+    /// and "no such queue" differed, a bound sender could learn the queue's
+    /// state by filling it. An unbound send side and a wrong key are both
+    /// refusals a sender must not be able to tell apart from a full queue.
+    pub fn authorize_send(&self, signer: &PublicKey) -> Result<()> {
+        match self.send_key {
+            Some(bound) if keys_equal(&bound, signer) => Ok(()),
+            _ => Err(ProtoError::Wire(ErrorCode::Unavailable)),
+        }
+    }
+
+    /// Bind the send side, once and forever (§7.3).
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::NotPermitted`] on a contact queue. §12.2: `BIND_SEND` on
+    ///   a contact address returns this "always, for everyone" — there is no
+    ///   key that authorizes writing to it, which means there is no key that
+    ///   can be stolen, squatted or lost.
+    /// - [`ErrorCode::AlreadyBound`] if the send side is already bound, **with
+    ///   any key, including the same key**. §7.4 is explicit about what this
+    ///   code means to a client that has just received a fresh advert: a loud,
+    ///   non-dismissible failure, because the most likely cause is that the
+    ///   relay operator read `send_addr` out of its own database and bound
+    ///   first. This does not prevent the theft; it makes it noisy.
+    pub fn bind_send(&mut self, send_key: &PublicKey) -> Result<()> {
+        if matches!(self.kind, QueueKind::Contact) {
+            return Err(ProtoError::Wire(ErrorCode::NotPermitted));
+        }
+        if self.send_key.is_some() {
+            return Err(ProtoError::Wire(ErrorCode::AlreadyBound));
+        }
+        self.send_key = Some(*send_key);
+        Ok(())
+    }
+
+    /// Take the next index for an accepted append.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::Unavailable`] if the index space is exhausted — a send-side
+    /// refusal like every other.
+    pub fn append(&mut self) -> Result<u64> {
+        let index = self.next_index;
+        self.next_index = self
+            .next_index
+            .checked_add(1)
+            .ok_or(ProtoError::Wire(ErrorCode::Unavailable))?;
+        Ok(index)
+    }
+
+    /// Where a `READ` actually starts (§6.2).
+    ///
+    /// "`from_index` below the current acked watermark returns from the
+    /// watermark; the relay MUST NOT resurrect deleted messages and MUST NOT
+    /// error", so that a client recovering from a crash can simply ask for
+    /// everything it might have missed. Note that this is not an error path: a
+    /// `READ` from zero on a fully drained queue is a legitimate, successful,
+    /// empty read.
+    #[must_use]
+    pub const fn read_from(&self, from_index: u64) -> u64 {
+        let floor = self.first_unacked();
+        if from_index < floor {
+            floor
+        } else {
+            from_index
+        }
+    }
+
+    /// Apply an `ACK` (§8).
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::AckTooHigh`] if `up_to_index` is above the highest index
+    /// ever appended — §8.2's anti-pre-ack rule. The watermark does not move.
+    pub fn ack(&mut self, up_to_index: u64) -> Result<AckOutcome> {
+        // "Ever appended" is the whole point: the bound is `next_index`, which
+        // never decreases, not the set of messages currently stored. Comparing
+        // against what is stored would let a reader ack past the end of a queue
+        // it had just drained.
+        let highest = match self.next_index.checked_sub(1) {
+            Some(highest) => highest,
+            // Nothing has ever been appended, so no index exists to acknowledge.
+            None => return Err(ProtoError::Wire(ErrorCode::AckTooHigh)),
+        };
+        if up_to_index > highest {
+            return Err(ProtoError::Wire(ErrorCode::AckTooHigh));
+        }
+
+        let previous = self.acked_through;
+        let advanced = match previous {
+            // Monotone: below the watermark is accepted and is a no-op.
+            Some(watermark) if up_to_index <= watermark => 0,
+            Some(watermark) => up_to_index.saturating_sub(watermark),
+            None => up_to_index.saturating_add(1),
+        };
+        if advanced > 0 {
+            self.acked_through = Some(up_to_index);
+        }
+
+        Ok(AckOutcome {
+            acknowledged: advanced,
+            next_index: self.next_index,
+            pending: self.pending(),
+        })
+    }
+}
+
+/// What an `ACK` did.
+///
+/// `acknowledged` is zero for the idempotent case — a retry after a lost
+/// response, or a replay (§5.6 lists `ACK` as a no-op for exactly this reason).
+/// A relay deletes `acknowledged` messages and nothing else.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AckOutcome {
+    /// How many indices the watermark advanced by, i.e. how many messages this
+    /// `ACK` authorizes the relay to delete.
+    pub acknowledged: u64,
+    /// `AckResponse.next_index`.
+    pub next_index: u64,
+    /// `AckResponse.pending`, as an index-space upper bound.
+    pub pending: u64,
+}
+
+/// §7.7's two timers, with the clamps a relay publishes in §11.1.
+///
+/// Both are requested at creation, both are clamped by relay policy, and both
+/// granted values are returned in the create response so the client knows what
+/// it actually got.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TtlPolicy {
+    /// Lower clamp on a requested message TTL.
+    pub min_message_ttl_seconds: u32,
+    /// Upper clamp. MUST be <= [`MAX_MESSAGE_TTL_SECONDS`].
+    pub max_message_ttl_seconds: u32,
+    /// Granted when the client expresses no preference.
+    pub default_message_ttl_seconds: u32,
+    /// Lower clamp on a requested idle TTL.
+    pub min_idle_ttl_seconds: u32,
+    /// Upper clamp on a requested idle TTL.
+    pub max_idle_ttl_seconds: u32,
+    /// Granted when the client expresses no preference.
+    pub default_idle_ttl_seconds: u32,
+}
+
+impl TtlPolicy {
+    /// Grant a message TTL for a request (§7.7).
+    ///
+    /// **A requested value of zero means "no preference".** §7.7 has both a
+    /// requested value and a published default and never says how the two meet;
+    /// a TTL of zero seconds would mean a message expires before it is stored,
+    /// which is not a policy any client can want, so zero is the only value
+    /// free to carry the meaning. Stated as an interpretation, not a rule.
+    ///
+    /// The 30-day ceiling is applied last and unconditionally: a relay MUST NOT
+    /// grant more than [`MAX_MESSAGE_TTL_SECONDS`] even if its own configured
+    /// maximum says otherwise.
+    #[must_use]
+    pub const fn grant_message_ttl(&self, requested: u32) -> u32 {
+        let granted = if requested == 0 {
+            self.default_message_ttl_seconds
+        } else {
+            clamp(
+                requested,
+                self.min_message_ttl_seconds,
+                self.max_message_ttl_seconds,
+            )
+        };
+        if granted > MAX_MESSAGE_TTL_SECONDS {
+            MAX_MESSAGE_TTL_SECONDS
+        } else {
+            granted
+        }
+    }
+
+    /// Grant an idle TTL for a request (§7.7).
+    ///
+    /// Zero means "no preference", as for the message TTL.
+    #[must_use]
+    pub const fn grant_idle_ttl(&self, requested: u32) -> u32 {
+        let granted = if requested == 0 {
+            self.default_idle_ttl_seconds
+        } else {
+            clamp(
+                requested,
+                self.min_idle_ttl_seconds,
+                self.max_idle_ttl_seconds,
+            )
+        };
+        if granted > MAX_IDLE_TTL_SECONDS {
+            MAX_IDLE_TTL_SECONDS
+        } else {
+            granted
+        }
+    }
+
+    /// Whether the policy is self-consistent: each band ordered, each default
+    /// inside its own band, and the message ceiling respected.
+    #[must_use]
+    pub const fn is_consistent(&self) -> bool {
+        self.min_message_ttl_seconds <= self.default_message_ttl_seconds
+            && self.default_message_ttl_seconds <= self.max_message_ttl_seconds
+            && self.max_message_ttl_seconds <= MAX_MESSAGE_TTL_SECONDS
+            && self.min_idle_ttl_seconds <= self.default_idle_ttl_seconds
+            && self.default_idle_ttl_seconds <= self.max_idle_ttl_seconds
+            && self.max_idle_ttl_seconds <= MAX_IDLE_TTL_SECONDS
+    }
+}
+
+impl Default for TtlPolicy {
+    /// §7.7's table.
+    fn default() -> Self {
+        Self {
+            min_message_ttl_seconds: 60,
+            max_message_ttl_seconds: MAX_MESSAGE_TTL_SECONDS,
+            default_message_ttl_seconds: DEFAULT_MESSAGE_TTL_SECONDS,
+            min_idle_ttl_seconds: 3_600,
+            max_idle_ttl_seconds: MAX_IDLE_TTL_SECONDS,
+            default_idle_ttl_seconds: DEFAULT_IDLE_TTL_SECONDS,
+        }
+    }
+}
+
+/// `u32::clamp` without the panic on an inverted range, which the workspace
+/// lints forbid anywhere near the relay's request path.
+const fn clamp(value: u32, low: u32, high: u32) -> u32 {
+    if value < low {
+        low
+    } else if value > high {
+        high
+    } else {
+        value
+    }
+}
+
+/// §13.1 layer 2's per-queue quotas, and §12.3's contact-queue caps — the same
+/// shape, applied to the same decision.
+///
+/// This is a pure admission test over counters the relay keeps; nothing here
+/// stores a message. The refusal is [`ErrorCode::Unavailable`] in both cases,
+/// never a code that says which cap was hit (§6.3).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AppendQuota {
+    /// `max_queue_messages`, or `contact_max_pending` for a contact queue.
+    pub max_messages: u64,
+    /// `max_queue_bytes`, or `contact_max_bytes` for a contact queue.
+    pub max_bytes: u64,
+}
+
+impl AppendQuota {
+    /// Whether one more payload of `payload_bytes` fits.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::Unavailable`]. §13.2 is the other half of this rule and it
+    /// is not expressible as a return value: **under no circumstance does a
+    /// relay delete an unacknowledged message to free space.** When it runs out
+    /// of room it refuses new writes. Refusal is loud, immediate, and lands on
+    /// the party that can do something about it; silently dropping an accepted
+    /// message is quiet, delayed, and lands on someone who cannot.
+    pub const fn admit(
+        &self,
+        stored_messages: u64,
+        stored_bytes: u64,
+        payload_bytes: u64,
+    ) -> Result<()> {
+        if stored_messages >= self.max_messages {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        }
+        match stored_bytes.checked_add(payload_bytes) {
+            Some(total) if total <= self.max_bytes => Ok(()),
+            _ => Err(ProtoError::Wire(ErrorCode::Unavailable)),
+        }
+    }
+}
+
+/// §12.3's contact-queue defaults: 64 pending messages, 256 KiB.
+pub const CONTACT_QUOTA: AppendQuota = AppendQuota {
+    max_messages: 64,
+    max_bytes: 256 * 1024,
+};
+
+/// One relay's coordinates for one queue, as they travel inside a
+/// `queue_advert` (§7.2).
+///
+/// `relay_id` travels with the address because §5.2 needs it: it is what lets
+/// the sender detect that it is talking to a different relay than the one the
+/// recipient chose. The identifying material comes from inside the
+/// authenticated channel, never from the infrastructure being authenticated.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueueEndpoint {
+    /// `wss://` URL of the relay (§2.1).
+    pub relay_url: String,
+    /// The relay identity this address is valid at (§5.2).
+    pub relay_id: RelayId,
+    /// The send address the peer may bind and then append to.
+    pub send_addr: QueueAddress,
+}
+
+/// The in-band advert of §7.2, as a value.
+///
+/// **This type has no wire encoding, and that is deliberate.** §7.2 shows the
+/// advert as an object with named fields and never gives it a `tls_codec`
+/// structure, because a relay never sees one: it travels as an MLS
+/// `PrivateMessage` inside the group, indistinguishable to the relay from any
+/// other payload. Inventing an encoding here would be inventing protocol.
+/// What the type is for is the *check* — carrying `(relay_url, relay_id,
+/// send_addr)` from the group to [`crate::hello::verify_hello_response`], which
+/// is where §5.2's substitution attack is actually caught.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueueAdvert {
+    /// One entry per relay, for ADR 0005's redundancy factor *k*.
+    pub endpoints: Vec<QueueEndpoint>,
+    /// The epoch from which the sender should use these addresses.
+    pub valid_from_epoch: u64,
+    /// The addresses this advert retires.
+    pub replaces: Vec<QueueAddress>,
+}
+
+/// Where a rotation (§7.5) has got to.
+///
+/// There is no `ROTATE` command and there should not be one: rotation is
+/// create, advertise, bind, drain, delete. The stages exist so the one ordering
+/// constraint that can lose messages is checkable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RotationStage {
+    /// Step 1: the replacement queue exists.
+    Created,
+    /// Step 2: the replacement was advertised in-band.
+    Advertised,
+    /// Steps 3-4: the peer has bound the new send address and switched to it at
+    /// `valid_from_epoch`. The old queue is still readable and still being
+    /// drained — a message in flight during the switch lands in the old queue
+    /// and is read from it.
+    Switched,
+    /// Step 5: the old queue was deleted.
+    Retired,
+}
+
+/// A queue rotation in progress (§7.5).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Rotation {
+    stage: RotationStage,
+}
+
+impl Rotation {
+    /// Begin a rotation: the replacement queue has been created.
+    #[must_use]
+    pub const fn started() -> Self {
+        Self {
+            stage: RotationStage::Created,
+        }
+    }
+
+    /// The current stage.
+    #[must_use]
+    pub const fn stage(self) -> RotationStage {
+        self.stage
+    }
+
+    /// Advance to the next stage. Stages never go backwards.
+    pub const fn advance(&mut self, stage: RotationStage) {
+        if stage as u8 > self.stage as u8 {
+            self.stage = stage;
+        }
+    }
+
+    /// Whether the old queue may now be deleted.
+    ///
+    /// §7.5: "the old queue MUST remain readable until the recipient has
+    /// drained it. The sender switches at `valid_from_epoch`; the recipient
+    /// deletes only after the old queue is empty and acknowledged." Both halves
+    /// are required — deleting a drained queue before the peer has switched
+    /// destroys whatever it appends next, and deleting after the switch but
+    /// before draining destroys what is already there.
+    #[must_use]
+    pub fn may_retire_old(self, old: &QueueState) -> bool {
+        self.stage >= RotationStage::Switched && old.pending() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn key(byte: u8) -> PublicKey {
+        PublicKey::new([byte; 32])
+    }
+
+    fn queue() -> QueueState {
+        QueueState::create(QueueKind::Standard, key(1))
+    }
+
+    #[test]
+    fn binding_happens_once_and_never_again() {
+        let mut queue = queue();
+        assert!(!queue.is_bound());
+        assert!(queue.bind_send(&key(2)).is_ok());
+        assert_eq!(queue.send_key(), Some(key(2)));
+        assert_eq!(
+            queue.bind_send(&key(3)),
+            Err(ProtoError::Wire(ErrorCode::AlreadyBound))
+        );
+        assert_eq!(
+            queue.bind_send(&key(2)),
+            Err(ProtoError::Wire(ErrorCode::AlreadyBound)),
+            "§7.3: with any key, including the same key"
+        );
+        assert_eq!(queue.send_key(), Some(key(2)));
+    }
+
+    #[test]
+    fn a_contact_queue_can_never_be_bound() {
+        let mut contact = QueueState::create(QueueKind::Contact, key(1));
+        assert_eq!(
+            contact.bind_send(&key(2)),
+            Err(ProtoError::Wire(ErrorCode::NotPermitted))
+        );
+        assert!(!contact.is_bound());
+    }
+
+    #[test]
+    fn send_side_refusals_all_look_the_same() {
+        let mut queue = queue();
+        // Unbound.
+        assert_eq!(
+            queue.authorize_send(&key(2)),
+            Err(ProtoError::Wire(ErrorCode::Unavailable))
+        );
+        queue.bind_send(&key(2)).unwrap();
+        // Bound to someone else.
+        assert_eq!(
+            queue.authorize_send(&key(3)),
+            Err(ProtoError::Wire(ErrorCode::Unavailable))
+        );
+        assert!(queue.authorize_send(&key(2)).is_ok());
+    }
+
+    #[test]
+    fn the_recv_side_uses_the_existence_oracle_code() {
+        let queue = queue();
+        assert!(queue.authorize_recv(&key(1)).is_ok());
+        assert_eq!(
+            queue.authorize_recv(&key(2)),
+            Err(ProtoError::Wire(ErrorCode::NoAccess))
+        );
+    }
+
+    #[test]
+    fn acking_before_anything_is_appended_is_too_high() {
+        let mut queue = queue();
+        assert_eq!(
+            queue.ack(0),
+            Err(ProtoError::Wire(ErrorCode::AckTooHigh)),
+            "there is no index 0 until something is appended"
+        );
+        assert_eq!(queue.acked_through(), None);
+    }
+
+    #[test]
+    fn acking_past_the_highest_appended_index_is_refused() {
+        let mut queue = queue();
+        assert_eq!(queue.append().unwrap(), 0);
+        assert_eq!(queue.append().unwrap(), 1);
+        assert_eq!(
+            queue.ack(2),
+            Err(ProtoError::Wire(ErrorCode::AckTooHigh)),
+            "§8.2: pre-acking would black-hole every future append"
+        );
+        assert_eq!(queue.acked_through(), None, "the watermark does not move");
+        assert!(queue.ack(1).is_ok());
+    }
+
+    #[test]
+    fn acknowledgement_is_cumulative_monotone_and_idempotent() {
+        let mut queue = queue();
+        for _ in 0..5 {
+            queue.append().unwrap();
+        }
+        let first = queue.ack(2).unwrap();
+        assert_eq!(first.acknowledged, 3, "cumulative: 0, 1 and 2");
+        assert_eq!(first.pending, 2);
+
+        let repeat = queue.ack(2).unwrap();
+        assert_eq!(repeat.acknowledged, 0, "idempotent");
+        assert_eq!(queue.acked_through(), Some(2));
+
+        let backwards = queue.ack(0).unwrap();
+        assert_eq!(backwards.acknowledged, 0, "monotone");
+        assert_eq!(queue.acked_through(), Some(2));
+
+        let rest = queue.ack(4).unwrap();
+        assert_eq!(rest.acknowledged, 2);
+        assert_eq!(rest.pending, 0);
+    }
+
+    #[test]
+    fn a_read_below_the_watermark_starts_at_the_watermark() {
+        let mut queue = queue();
+        for _ in 0..4 {
+            queue.append().unwrap();
+        }
+        queue.ack(1).unwrap();
+        assert_eq!(queue.read_from(0), 2, "never resurrect, never error");
+        assert_eq!(queue.read_from(3), 3);
+        assert_eq!(queue.first_unacked(), 2);
+    }
+
+    #[test]
+    fn ttls_are_clamped_and_the_thirty_day_ceiling_is_absolute() {
+        let policy = TtlPolicy::default();
+        assert!(policy.is_consistent());
+        assert_eq!(policy.grant_message_ttl(0), DEFAULT_MESSAGE_TTL_SECONDS);
+        assert_eq!(policy.grant_message_ttl(1), 60);
+        assert_eq!(policy.grant_message_ttl(86_400), 86_400);
+        assert_eq!(
+            policy.grant_message_ttl(u32::MAX),
+            MAX_MESSAGE_TTL_SECONDS,
+            "§7.7: a relay MUST NOT grant more than 30 days"
+        );
+
+        // Even a relay whose own configured maximum is too high is held to it.
+        let greedy = TtlPolicy {
+            max_message_ttl_seconds: u32::MAX,
+            ..TtlPolicy::default()
+        };
+        assert!(!greedy.is_consistent());
+        assert_eq!(greedy.grant_message_ttl(u32::MAX), MAX_MESSAGE_TTL_SECONDS);
+
+        assert_eq!(policy.grant_idle_ttl(0), DEFAULT_IDLE_TTL_SECONDS);
+        assert_eq!(policy.grant_idle_ttl(u32::MAX), MAX_IDLE_TTL_SECONDS);
+    }
+
+    #[test]
+    fn quotas_refuse_rather_than_making_room() {
+        let quota = CONTACT_QUOTA;
+        assert!(quota.admit(0, 0, 1024).is_ok());
+        assert!(quota.admit(63, 0, 1024).is_ok());
+        assert_eq!(
+            quota.admit(64, 0, 1024),
+            Err(ProtoError::Wire(ErrorCode::Unavailable))
+        );
+        assert_eq!(
+            quota.admit(0, 256 * 1024, 1),
+            Err(ProtoError::Wire(ErrorCode::Unavailable))
+        );
+        assert_eq!(
+            quota.admit(0, u64::MAX, 1),
+            Err(ProtoError::Wire(ErrorCode::Unavailable)),
+            "the byte total must not wrap into acceptance"
+        );
+    }
+
+    #[test]
+    fn the_old_queue_is_retired_only_after_the_switch_and_the_drain() {
+        let mut old = queue();
+        old.bind_send(&key(2)).unwrap();
+        old.append().unwrap();
+
+        let mut rotation = Rotation::started();
+        assert!(!rotation.may_retire_old(&old));
+        rotation.advance(RotationStage::Advertised);
+        assert!(!rotation.may_retire_old(&old));
+        rotation.advance(RotationStage::Switched);
+        assert!(
+            !rotation.may_retire_old(&old),
+            "switched, but the old queue still holds a message"
+        );
+        old.ack(0).unwrap();
+        assert!(rotation.may_retire_old(&old));
+
+        // Stages never go backwards.
+        rotation.advance(RotationStage::Created);
+        assert_eq!(rotation.stage(), RotationStage::Switched);
+    }
+
+    #[test]
+    fn an_advert_carries_the_relay_id_that_makes_section_5_2_checkable() {
+        let advert = QueueAdvert {
+            endpoints: vec![QueueEndpoint {
+                relay_url: String::from("wss://relay.example/relay/v1"),
+                relay_id: RelayId::new([9u8; 32]),
+                send_addr: QueueAddress::new([8u8; 32]),
+            }],
+            valid_from_epoch: 42,
+            replaces: vec![QueueAddress::new([7u8; 32])],
+        };
+        assert_eq!(advert.endpoints.len(), 1);
+        assert_eq!(advert.replaces.len(), 1);
+    }
+}

--- a/rs/crates/f2z-relay-proto/src/replay.rs
+++ b/rs/crates/f2z-relay-proto/src/replay.rs
@@ -1,0 +1,392 @@
+//! Anti-replay — `WIRE.md` §5.5: a bounded timestamp window, plus a
+//! fail-closed seen-set of `(signer_key, nonce)`.
+//!
+//! Both halves are pure. **Nothing here reads a clock**: every method that
+//! needs the time takes `now_ms` as an argument. That is not a testing
+//! convenience, it is the portability requirement — this crate compiles for
+//! `wasm32-unknown-unknown`, where `std::time::SystemTime` panics, and it
+//! compiles with no async runtime, so there is no timer to hang a sweep on
+//! either. The relay owns the clock; this owns the rule.
+//!
+//! # The seen-set is fail-closed, and that is the whole design
+//!
+//! §5.5 is explicit: the set is bounded (`antireplay_seen_max`), and when the
+//! bound is reached the relay returns `ERR_BACKPRESSURE` and refuses new signed
+//! commands until entries age out. It **MUST NOT** evict live entries to make
+//! room. An eviction policy that discards unexpired entries silently reopens
+//! the replay window at exactly the moment the relay is under load — which is
+//! exactly when an attacker would arrange to be. [`SeenSet::observe`] therefore
+//! has no eviction path at all; the only way an entry leaves is expiry.
+//!
+//! # Why the set need not survive a restart, and when that stops being true
+//!
+//! A restart destroys every TLS session, so every command signed before it
+//! carries a `channel_binding` (§5.3) that cannot verify against any new
+//! session. The binding has already invalidated the whole pre-restart corpus.
+//! **In `channel_binding_mode: none` that argument fails**, because the binding
+//! is a constant: such a relay MUST persist the set or publish
+//! `antireplay_persistence: volatile` and accept a replay window of
+//! `clock_skew_ms` across a restart. This type is in-memory either way; the
+//! persistence decision belongs to the relay that owns it.
+
+use alloc::collections::BTreeMap;
+use core::fmt;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::types::{Nonce, PublicKey};
+
+use crate::error::{ProtoError, Result};
+
+/// The default `clock_skew_ms` of §5.5: ±2 minutes.
+pub const DEFAULT_CLOCK_SKEW_MS: u64 = 120_000;
+
+/// §5.5's timestamp window: `timestamp_ms` MUST be within `±clock_skew_ms` of
+/// the relay's clock.
+///
+/// The boundary is **inclusive**. §5.5 says "within `±clock_skew_ms`" and does
+/// not say which side of the boundary a value exactly on it falls; an
+/// exclusive reading would make a correct client whose offset is exactly the
+/// published skew fail intermittently, and the published number is a policy
+/// value rather than a security threshold, so the inclusive reading is the one
+/// implemented here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TimestampWindow {
+    skew_ms: u64,
+}
+
+impl TimestampWindow {
+    /// A window of `±skew_ms`.
+    #[must_use]
+    pub const fn new(skew_ms: u64) -> Self {
+        Self { skew_ms }
+    }
+
+    /// The published `clock_skew_ms`.
+    #[must_use]
+    pub const fn skew_ms(self) -> u64 {
+        self.skew_ms
+    }
+
+    /// Check a command's `timestamp_ms` against the relay's clock.
+    ///
+    /// This is step 2 of §5.1's verification order, and it runs before the
+    /// signature check because it is cheap and it is one of the two
+    /// flood-resistant filters.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::StaleTimestamp`] when the timestamp is outside the window
+    /// in either direction. A timestamp in the *future* is refused with the
+    /// same code as one in the past: §10 defines one code for the window and
+    /// splitting it would tell a caller which way its clock is wrong, which is
+    /// a fingerprint of that caller.
+    pub fn check(self, now_ms: u64, timestamp_ms: u64) -> Result<()> {
+        let distance = now_ms.abs_diff(timestamp_ms);
+        if distance <= self.skew_ms {
+            Ok(())
+        } else {
+            Err(ProtoError::Wire(ErrorCode::StaleTimestamp))
+        }
+    }
+}
+
+impl Default for TimestampWindow {
+    fn default() -> Self {
+        Self::new(DEFAULT_CLOCK_SKEW_MS)
+    }
+}
+
+/// The seen-set key: `(signer_key, nonce)` (§5.5).
+///
+/// `nonce` is 16 bytes of client CSPRNG, fresh per command, so the birthday
+/// bound is 2^64 *per key* — not reachable inside a two-minute window at any
+/// rate a relay would serve. Pairing it with the signing key is what keeps one
+/// client's nonce space from colliding with another's.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayKey {
+    signer_key: PublicKey,
+    nonce: Nonce,
+}
+
+impl ReplayKey {
+    /// Pair a signer key with the nonce it presented.
+    #[must_use]
+    pub const fn new(signer_key: PublicKey, nonce: Nonce) -> Self {
+        Self { signer_key, nonce }
+    }
+
+    /// The signing key half.
+    #[must_use]
+    pub const fn signer_key(&self) -> PublicKey {
+        self.signer_key
+    }
+
+    /// The nonce half.
+    #[must_use]
+    pub const fn nonce(&self) -> Nonce {
+        self.nonce
+    }
+}
+
+// Both halves are linkable: a per-queue key identifies a conversation, and a
+// nonce identifies a command. Neither renders.
+impl fmt::Debug for ReplayKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ReplayKey(<redacted>)")
+    }
+}
+
+/// §5.5's seen-set: bounded, fail-closed, and expiring.
+///
+/// A `BTreeMap` rather than a hash map for two reasons: this crate is `no_std`
+/// so `HashMap` is not available without pulling a hasher, and a tree has no
+/// hash-collision behaviour for an attacker who fully controls both halves of
+/// the key to aim at.
+///
+/// The retention window is separate from the timestamp window on purpose —
+/// §11.1 publishes `antireplay_window_ms` and `clock_skew_ms` as two fields —
+/// but they are not independent. See [`SeenSet::retention_is_sound`].
+#[derive(Clone, Debug)]
+pub struct SeenSet {
+    /// Value is the instant at which the entry may be dropped.
+    entries: BTreeMap<ReplayKey, u64>,
+    retention_ms: u64,
+    max_entries: usize,
+}
+
+impl SeenSet {
+    /// A set retaining each entry for `retention_ms` and holding at most
+    /// `max_entries` of them.
+    ///
+    /// `max_entries` is §5.5's `antireplay_seen_max`. It is a bound on memory,
+    /// and reaching it is a refusal rather than an eviction.
+    #[must_use]
+    pub const fn new(retention_ms: u64, max_entries: usize) -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            retention_ms,
+            max_entries,
+        }
+    }
+
+    /// Whether the published `(antireplay_window_ms, clock_skew_ms)` pair
+    /// actually closes the window.
+    ///
+    /// **This is a check `WIRE.md` does not state, and it should.** §11.1
+    /// publishes the two values independently and nothing relates them, but a
+    /// frame is replayable for as long as its timestamp stays inside the
+    /// window: a command stamped `clock_skew_ms` in the future is still
+    /// acceptable `clock_skew_ms` *after* the relay first saw it, so an entry
+    /// must be retained for `2 × clock_skew_ms` from the moment it was
+    /// observed. A relay publishing `antireplay_window_ms < 2 ×
+    /// clock_skew_ms` ages entries out while their frames are still valid and
+    /// has no seen-set at all for the gap, which is §5.5's stated protection
+    /// silently absent. Reported as a specification defect rather than
+    /// implemented around.
+    #[must_use]
+    pub const fn retention_is_sound(&self, clock_skew_ms: u64) -> bool {
+        match clock_skew_ms.checked_mul(2) {
+            Some(required) => self.retention_ms >= required,
+            // A skew that overflows u64 is not a policy anyone can satisfy.
+            None => false,
+        }
+    }
+
+    /// How long an entry is kept.
+    #[must_use]
+    pub const fn retention_ms(&self) -> u64 {
+        self.retention_ms
+    }
+
+    /// The bound at which the set fails closed.
+    #[must_use]
+    pub const fn max_entries(&self) -> usize {
+        self.max_entries
+    }
+
+    /// How many entries are held right now.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the set is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Drop every entry whose retention has elapsed, and report how many went.
+    ///
+    /// Called by [`SeenSet::observe`] before anything else, so a relay never
+    /// has to schedule a sweep. It is public because an idle relay that stops
+    /// receiving signed commands would otherwise hold its last entries
+    /// forever, and an operator may want to reclaim that.
+    pub fn expire(&mut self, now_ms: u64) -> usize {
+        let before = self.entries.len();
+        self.entries.retain(|_, expires_at| *expires_at > now_ms);
+        before.saturating_sub(self.entries.len())
+    }
+
+    /// Record a `(signer_key, nonce)` pair, or refuse it.
+    ///
+    /// Step 3 of §5.1's verification order: it runs *before* the signature
+    /// check, because it is cheap and flood-resistant.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::Replay`] if the pair is already held. §5.6 bounds what a
+    ///   replay could achieve anyway — duplicate or no-op, at the operator's
+    ///   expense — but the bound is the reason it is acceptable, not a reason
+    ///   to skip the check.
+    /// - [`ErrorCode::Backpressure`] if the set is full of unexpired entries.
+    ///   The relay refuses new signed commands until entries age out. It does
+    ///   **not** evict.
+    pub fn observe(&mut self, now_ms: u64, key: ReplayKey) -> Result<()> {
+        self.expire(now_ms);
+
+        if self.entries.contains_key(&key) {
+            return Err(ProtoError::Wire(ErrorCode::Replay));
+        }
+        // Checked after the replay lookup on purpose: a full set that is being
+        // handed a genuine replay should say so. Reporting backpressure there
+        // would hide an attack behind a capacity message.
+        if self.entries.len() >= self.max_entries {
+            return Err(ProtoError::Wire(ErrorCode::Backpressure));
+        }
+
+        let expires_at = now_ms.saturating_add(self.retention_ms);
+        self.entries.insert(key, expires_at);
+        Ok(())
+    }
+
+    /// Whether the pair is currently held. Does not expire first — call
+    /// [`SeenSet::expire`] if that matters.
+    #[must_use]
+    pub fn contains(&self, key: &ReplayKey) -> bool {
+        self.entries.contains_key(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(byte: u8) -> ReplayKey {
+        ReplayKey::new(PublicKey::new([byte; 32]), Nonce::new([byte; 16]))
+    }
+
+    #[test]
+    fn the_window_boundary_is_inclusive_on_both_sides() {
+        let window = TimestampWindow::new(1_000);
+        let now = 10_000_000;
+        assert!(window.check(now, now).is_ok());
+        assert!(window.check(now, now + 1_000).is_ok());
+        assert!(window.check(now, now - 1_000).is_ok());
+        assert_eq!(
+            window.check(now, now + 1_001),
+            Err(ProtoError::Wire(ErrorCode::StaleTimestamp))
+        );
+        assert_eq!(
+            window.check(now, now - 1_001),
+            Err(ProtoError::Wire(ErrorCode::StaleTimestamp))
+        );
+    }
+
+    #[test]
+    fn a_timestamp_near_the_epoch_does_not_underflow() {
+        let window = TimestampWindow::default();
+        assert!(window.check(0, 0).is_ok());
+        assert_eq!(
+            window.check(0, u64::MAX),
+            Err(ProtoError::Wire(ErrorCode::StaleTimestamp))
+        );
+    }
+
+    #[test]
+    fn a_repeat_inside_the_window_is_a_replay() {
+        let mut seen = SeenSet::new(1_000, 8);
+        assert!(seen.observe(0, key(1)).is_ok());
+        assert_eq!(
+            seen.observe(500, key(1)),
+            Err(ProtoError::Wire(ErrorCode::Replay))
+        );
+        // And a different nonce under the same key is not.
+        assert!(
+            seen.observe(
+                500,
+                ReplayKey::new(PublicKey::new([1; 32]), Nonce::new([2; 16]))
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn an_entry_survives_for_exactly_its_retention() {
+        // Half-open: an entry observed at `t` is held over `[t, t +
+        // retention_ms)`. Which end is closed does not matter to the security
+        // property, because soundness comes from `retention_ms >= 2 *
+        // clock_skew_ms` (`SeenSet::retention_is_sound`) and not from a single
+        // millisecond at the boundary; it is pinned by a test so it cannot
+        // change unnoticed.
+        let mut seen = SeenSet::new(1_000, 8);
+        seen.observe(0, key(1)).unwrap();
+        assert_eq!(
+            seen.observe(999, key(1)),
+            Err(ProtoError::Wire(ErrorCode::Replay))
+        );
+        assert!(seen.observe(1_000, key(1)).is_ok());
+    }
+
+    #[test]
+    fn a_full_set_refuses_rather_than_evicting() {
+        let mut seen = SeenSet::new(10_000, 2);
+        seen.observe(0, key(1)).unwrap();
+        seen.observe(0, key(2)).unwrap();
+        assert_eq!(
+            seen.observe(0, key(3)),
+            Err(ProtoError::Wire(ErrorCode::Backpressure))
+        );
+        // The live entries are still live. This is the property: an eviction
+        // policy would have reopened the window for key(1) here.
+        assert!(seen.contains(&key(1)));
+        assert!(seen.contains(&key(2)));
+        assert_eq!(
+            seen.observe(0, key(1)),
+            Err(ProtoError::Wire(ErrorCode::Replay))
+        );
+        // …and once they age out, the set accepts again.
+        assert!(seen.observe(10_001, key(3)).is_ok());
+    }
+
+    #[test]
+    fn a_replay_is_reported_even_when_the_set_is_full() {
+        let mut seen = SeenSet::new(10_000, 1);
+        seen.observe(0, key(1)).unwrap();
+        assert_eq!(
+            seen.observe(0, key(1)),
+            Err(ProtoError::Wire(ErrorCode::Replay)),
+            "capacity must not mask an attack"
+        );
+    }
+
+    #[test]
+    fn retention_shorter_than_twice_the_skew_is_reported_as_unsound() {
+        let skew = DEFAULT_CLOCK_SKEW_MS;
+        assert!(!SeenSet::new(skew, 1).retention_is_sound(skew));
+        assert!(SeenSet::new(skew * 2, 1).retention_is_sound(skew));
+        assert!(SeenSet::new(skew * 3, 1).retention_is_sound(skew));
+        assert!(!SeenSet::new(u64::MAX, 1).retention_is_sound(u64::MAX));
+    }
+
+    #[test]
+    fn expire_reports_what_it_dropped() {
+        let mut seen = SeenSet::new(100, 8);
+        seen.observe(0, key(1)).unwrap();
+        seen.observe(0, key(2)).unwrap();
+        assert_eq!(seen.expire(50), 0);
+        assert_eq!(seen.len(), 2);
+        assert_eq!(seen.expire(101), 2);
+        assert!(seen.is_empty());
+    }
+}

--- a/rs/crates/f2z-relay-proto/tests/properties.rs
+++ b/rs/crates/f2z-relay-proto/tests/properties.rs
@@ -1,0 +1,311 @@
+//! Property tests for the four rules where a single wrong branch loses
+//! ciphertext or makes a signature valid where it must not be.
+//!
+//! Each one is stated as an invariant over generated inputs rather than as a
+//! handful of hand-picked cases, because the failure mode of every one of them
+//! is an edge: an off-by-one at the acknowledgement watermark, a boundary
+//! millisecond in the timestamp window, a second `BIND_SEND` that arrives with
+//! the same key as the first, a relay id that happens to share a prefix.
+//!
+//! - **Acknowledgement** (§8.1, §8.2, §8.3) — cumulative, monotone, idempotent,
+//!   and never above the highest index ever appended.
+//! - **Anti-replay** (§5.5) — accepted exactly inside `±clock_skew_ms`, and
+//!   never twice for one `(signer_key, nonce)`.
+//! - **Transcript domain separation** (§5.2, §5.3) — a signature made for one
+//!   relay, or on one TLS session, verifies at that relay on that session and
+//!   nowhere else. This is the property whose absence lets relay A replay a
+//!   recipient's cumulative `ACK` at relay B so that **B deletes ciphertext the
+//!   recipient never received from B**.
+//! - **Bind-once** (§7.3) — the first `BIND_SEND` wins, forever, and no later
+//!   attempt with any key changes what is bound.
+
+// Test code, run on the host by a person reading the failure. The workspace
+// denies these because a panic in the relay's parser is a remote denial of
+// service; neither hazard exists here.
+#![allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_codec::ErrorCode;
+use f2z_codec::commands::AckRequest;
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::transcript::TranscriptBuilder;
+use f2z_codec::types::{ChannelBinding, Nonce, PublicKey, QueueAddress, RelayId};
+use f2z_relay_proto::command::{CommandVerifier, SignedCommand, ops};
+use f2z_relay_proto::error::ProtoError;
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_proto::queue::{QueueKind, QueueState};
+use f2z_relay_proto::replay::{ReplayKey, SeenSet, TimestampWindow};
+use proptest::prelude::*;
+
+const NOW: u64 = 1_800_000_000_000;
+
+fn verifier(relay_id: RelayId, binding: ChannelBinding) -> CommandVerifier {
+    CommandVerifier::new(
+        TranscriptBuilder::new(f2z_relay_proto::PROTOCOL_VERSION, relay_id, binding),
+        TimestampWindow::default(),
+        SeenSet::new(240_000, 4_096),
+        PaddingBuckets::default(),
+    )
+}
+
+proptest! {
+    /// §8: whatever sequence of appends and acks arrives, the watermark never
+    /// moves backwards, never passes the highest appended index, and a repeat
+    /// of any accepted ack changes nothing.
+    #[test]
+    fn acknowledgement_is_cumulative_monotone_and_bounded(
+        operations in prop::collection::vec(
+            prop_oneof![
+                (1u64..4).prop_map(Operation::Append),
+                (0u64..12).prop_map(Operation::Ack),
+            ],
+            1..60,
+        )
+    ) {
+        let mut queue = QueueState::create(QueueKind::Standard, PublicKey::new([1u8; 32]));
+        let mut watermark: Option<u64> = None;
+
+        for operation in operations {
+            match operation {
+                Operation::Append(count) => {
+                    for _ in 0..count {
+                        let expected = queue.next_index();
+                        prop_assert_eq!(queue.append().unwrap(), expected);
+                    }
+                }
+                Operation::Ack(up_to) => {
+                    let highest = queue.next_index().checked_sub(1);
+                    match queue.ack(up_to) {
+                        Ok(outcome) => {
+                            // Only ever inside what was appended.
+                            prop_assert!(highest.is_some_and(|highest| up_to <= highest));
+
+                            let advanced = match watermark {
+                                Some(previous) if up_to <= previous => 0,
+                                Some(previous) => up_to - previous,
+                                None => up_to + 1,
+                            };
+                            prop_assert_eq!(outcome.acknowledged, advanced);
+                            if advanced > 0 {
+                                watermark = Some(up_to);
+                            }
+
+                            // Monotone.
+                            prop_assert_eq!(queue.acked_through(), watermark);
+                            // Idempotent: the same ack again does nothing.
+                            let repeat = queue.ack(up_to).unwrap();
+                            prop_assert_eq!(repeat.acknowledged, 0);
+                            prop_assert_eq!(queue.acked_through(), watermark);
+                            // Cumulative: `pending` is exactly what is left.
+                            prop_assert_eq!(
+                                outcome.pending,
+                                queue.next_index() - queue.first_unacked()
+                            );
+                        }
+                        Err(error) => {
+                            // The only refusal §8 defines, and it never moves
+                            // the watermark — this is the rule that makes
+                            // pre-acking impossible.
+                            prop_assert_eq!(error, ProtoError::Wire(ErrorCode::AckTooHigh));
+                            prop_assert!(!highest.is_some_and(|highest| up_to <= highest));
+                            prop_assert_eq!(queue.acked_through(), watermark);
+                        }
+                    }
+                }
+            }
+            // A read never goes below the watermark, and never errors.
+            prop_assert!(queue.read_from(0) >= queue.first_unacked());
+        }
+    }
+
+    /// §8.2: no `ACK` above the highest index ever appended is ever accepted,
+    /// even after the queue has been fully drained — "ever appended" is
+    /// `next_index`, not what is currently stored.
+    #[test]
+    fn a_drained_queue_still_refuses_a_pre_ack(
+        appended in 1u64..50,
+        beyond in 1u64..50,
+    ) {
+        let mut queue = QueueState::create(QueueKind::Standard, PublicKey::new([1u8; 32]));
+        for _ in 0..appended {
+            queue.append().unwrap();
+        }
+        queue.ack(appended - 1).unwrap();
+        prop_assert_eq!(queue.pending(), 0);
+        prop_assert_eq!(
+            queue.ack(appended - 1 + beyond),
+            Err(ProtoError::Wire(ErrorCode::AckTooHigh))
+        );
+        prop_assert_eq!(queue.acked_through(), Some(appended - 1));
+    }
+
+    /// §5.5: the timestamp window accepts exactly `|now - timestamp| <=
+    /// clock_skew_ms`, in both directions, with no wrap at the ends of the
+    /// range.
+    #[test]
+    fn the_timestamp_window_is_exactly_the_published_skew(
+        skew in 0u64..1_000_000,
+        now in 0u64..u64::MAX,
+        timestamp in 0u64..u64::MAX,
+    ) {
+        let window = TimestampWindow::new(skew);
+        let inside = now.abs_diff(timestamp) <= skew;
+        prop_assert_eq!(window.check(now, timestamp).is_ok(), inside);
+    }
+
+    /// §5.5: a `(signer_key, nonce)` pair is accepted at most once inside its
+    /// retention, and a full set refuses rather than evicting a live entry.
+    #[test]
+    fn the_seen_set_never_forgets_a_live_entry(
+        pairs in prop::collection::vec((any::<[u8; 32]>(), any::<[u8; 16]>()), 1..40),
+        capacity in 1usize..40,
+    ) {
+        let mut seen = SeenSet::new(240_000, capacity);
+        let mut accepted: Vec<ReplayKey> = Vec::new();
+
+        for (key_bytes, nonce_bytes) in pairs {
+            let key = ReplayKey::new(PublicKey::new(key_bytes), Nonce::new(nonce_bytes));
+            match seen.observe(NOW, key) {
+                Ok(()) => {
+                    prop_assert!(!accepted.contains(&key));
+                    accepted.push(key);
+                }
+                Err(error) => {
+                    if accepted.contains(&key) {
+                        prop_assert_eq!(error, ProtoError::Wire(ErrorCode::Replay));
+                    } else {
+                        // Only ever because the bound was reached — never
+                        // because something was thrown away to make room.
+                        prop_assert_eq!(error, ProtoError::Wire(ErrorCode::Backpressure));
+                        prop_assert_eq!(seen.len(), capacity);
+                    }
+                }
+            }
+            // Everything ever accepted is still held.
+            for held in &accepted {
+                prop_assert!(seen.contains(held));
+            }
+        }
+    }
+
+    /// §5.2 and §5.3: a signed command verifies at the relay and on the session
+    /// it was made for, and at no other. This is the ACK-replay attack of §5.2
+    /// stated as a property.
+    #[test]
+    fn a_signed_command_verifies_at_exactly_one_relay_on_exactly_one_session(
+        seed in any::<[u8; 32]>(),
+        relay_a in any::<[u8; 32]>(),
+        relay_b in any::<[u8; 32]>(),
+        binding_a in any::<[u8; 32]>(),
+        binding_b in any::<[u8; 32]>(),
+        address in any::<[u8; 32]>(),
+        nonce in any::<[u8; 16]>(),
+        request_id in 1u32..u32::MAX,
+        up_to_index in any::<u64>(),
+    ) {
+        prop_assume!(relay_a != relay_b);
+        prop_assume!(binding_a != binding_b);
+        prop_assume!(address != [0u8; 32]);
+
+        let key = SigningKey::from_seed(&seed);
+        let signed = SignedCommand::<ops::Ack>::create(
+            &TranscriptBuilder::new(
+                f2z_relay_proto::PROTOCOL_VERSION,
+                RelayId::new(relay_a),
+                ChannelBinding::new(binding_a),
+            ),
+            request_id,
+            QueueAddress::new(address),
+            NOW,
+            Nonce::new(nonce),
+            &key,
+            &AckRequest { up_to_index },
+        ).unwrap();
+        let request = signed.request().unwrap();
+
+        // The relay it was made for, on the session it was made on.
+        let verified = verifier(RelayId::new(relay_a), ChannelBinding::new(binding_a))
+            .verify::<ops::Ack>(NOW, request_id, &request)
+            .unwrap();
+        prop_assert_eq!(verified.signer_key(), key.public_key());
+        prop_assert_eq!(verified.body().up_to_index, up_to_index);
+
+        // A second relay, handed the frame verbatim by the first.
+        prop_assert_eq!(
+            verifier(RelayId::new(relay_b), ChannelBinding::new(binding_a))
+                .verify::<ops::Ack>(NOW, request_id, &request)
+                .map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::BadSignature))
+        );
+        // The same relay, a different TLS session.
+        prop_assert_eq!(
+            verifier(RelayId::new(relay_a), ChannelBinding::new(binding_b))
+                .verify::<ops::Ack>(NOW, request_id, &request)
+                .map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::BadSignature))
+        );
+        // And a different `request_id` on the right relay and session, because
+        // the id is covered by the transcript too.
+        prop_assert_eq!(
+            verifier(RelayId::new(relay_a), ChannelBinding::new(binding_a))
+                .verify::<ops::Ack>(NOW, request_id.wrapping_add(1).max(1), &request)
+                .map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::BadSignature))
+        );
+    }
+
+    /// §7.3: whatever sequence of `BIND_SEND` attempts arrives, exactly the
+    /// first one takes effect and nothing later changes the bound key —
+    /// including a repeat of the same key, which §7.3 names explicitly.
+    #[test]
+    fn binding_is_once_only_whatever_arrives(
+        attempts in prop::collection::vec(prop::sample::select(vec![0u8, 1, 2]), 1..20),
+        kind in prop::sample::select(vec![QueueKind::Standard, QueueKind::Contact]),
+    ) {
+        let mut queue = QueueState::create(kind, PublicKey::new([9u8; 32]));
+        let mut bound: Option<PublicKey> = None;
+
+        for attempt in attempts {
+            let candidate = PublicKey::new([attempt; 32]);
+            let result = queue.bind_send(&candidate);
+            match kind {
+                QueueKind::Contact => {
+                    // §12.2: always, for everyone. There is no key that
+                    // authorizes writing to a contact queue, which means there
+                    // is no key that can be stolen, squatted or lost.
+                    prop_assert_eq!(result, Err(ProtoError::Wire(ErrorCode::NotPermitted)));
+                    prop_assert_eq!(queue.send_key(), None);
+                }
+                QueueKind::Standard => match bound {
+                    None => {
+                        prop_assert!(result.is_ok());
+                        bound = Some(candidate);
+                    }
+                    Some(_) => {
+                        prop_assert_eq!(result, Err(ProtoError::Wire(ErrorCode::AlreadyBound)));
+                    }
+                },
+            }
+            prop_assert_eq!(queue.send_key(), bound);
+        }
+
+        // Only the bound key can ever authorize an append, and every other
+        // refusal is indistinguishable from a full queue (§6.3).
+        if let Some(bound) = bound {
+            prop_assert!(queue.authorize_send(&bound).is_ok());
+            prop_assert_eq!(
+                queue.authorize_send(&PublicKey::new([0xff; 32])),
+                Err(ProtoError::Wire(ErrorCode::Unavailable))
+            );
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Operation {
+    Append(u64),
+    Ack(u64),
+}

--- a/rs/crates/f2z-relay-proto/tests/redaction.rs
+++ b/rs/crates/f2z-relay-proto/tests/redaction.rs
@@ -1,0 +1,350 @@
+//! `--log-level trace` must never become a ciphertext archive, and this layer
+//! adds the two values whose disclosure is worst: a signing key, and a decoded
+//! command that has been verified and is about to be acted on.
+//!
+//! The checks are the ones `f2z-codec`'s own redaction test arrived at, applied
+//! to this crate's types, and they are deliberately paranoid: absence of the
+//! obvious lowercase hex is not enough. Base16 in either case, base64url, a
+//! **decimal byte list** and any long run of hex-looking characters are all
+//! checked.
+//!
+//! The decimal case is the one that catches real leaks. `tls_codec`'s own byte
+//! vectors derive `Debug` and print `TlsByteVecU24 { vec: [222, 222, 222, …] }`
+//! — a complete dump containing no hex at all, so a hex-only assertion passes
+//! while everything leaks. Every structure below is checked against all four
+//! encodings for exactly that reason.
+
+// Test code, run on the host by a person reading the failure. The workspace
+// denies these because a panic in the relay's parser is a remote denial of
+// service; neither hazard exists here.
+#![allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_codec::commands::{AppendRequest, ContactAppendRequest, HelloRequest};
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::pow::PowStamp;
+use f2z_codec::types::{Challenge, ChannelBinding, Nonce, Payload, PublicKey, QueueAddress};
+use f2z_relay_proto::capabilities::{self, ChannelBindingMode, ClientPolicy, TransportSecurity};
+use f2z_relay_proto::command::{CommandVerifier, RelayCommand, SignedCommand, ops};
+use f2z_relay_proto::hello::{RelayAnnouncement, hello_response, verify_hello_response};
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_proto::queue::{QueueKind, QueueState};
+use f2z_relay_proto::replay::{ReplayKey, SeenSet, TimestampWindow};
+
+/// A byte pattern that is unmistakable in any encoding a leak might use.
+const SECRET: u8 = 0xde;
+
+const NOW: u64 = 1_800_000_000_000;
+
+fn lower_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn upper_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02X}")).collect()
+}
+
+/// `[222, 222, 222, …]` — a derived `Debug` on a byte slice.
+fn decimal_list(bytes: &[u8]) -> String {
+    let joined: Vec<String> = bytes.iter().map(|byte| byte.to_string()).collect();
+    format!("[{}]", joined.join(", "))
+}
+
+fn base64url(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::new();
+    for chunk in bytes.chunks(3) {
+        let mut buffer = [0u8; 3];
+        buffer[..chunk.len()].copy_from_slice(chunk);
+        let value =
+            (u32::from(buffer[0]) << 16) | (u32::from(buffer[1]) << 8) | u32::from(buffer[2]);
+        let symbols = match chunk.len() {
+            1 => 2,
+            2 => 3,
+            _ => 4,
+        };
+        for index in 0..symbols {
+            let shift = 18 - 6 * index;
+            let symbol = ((value >> shift) & 0x3f) as usize;
+            out.push(ALPHABET[symbol] as char);
+        }
+    }
+    out
+}
+
+/// The longest run of characters that could be a hex dump.
+///
+/// A run of pure decimal digits does not count: these types legitimately print
+/// millisecond timestamps and indices, and treating `1800000000000` as a hex
+/// dump would make the check fire on correct output instead of on a leak.
+fn longest_hex_run(text: &str) -> usize {
+    let mut longest = 0usize;
+    let mut current = 0usize;
+    let mut has_alpha = false;
+    for character in text.chars() {
+        if character.is_ascii_hexdigit() {
+            current += 1;
+            has_alpha |= character.is_ascii_alphabetic();
+            if has_alpha {
+                longest = longest.max(current);
+            }
+        } else {
+            current = 0;
+            has_alpha = false;
+        }
+    }
+    longest
+}
+
+fn assert_no_leak(label: &str, rendered: &str, secret: &[u8]) {
+    assert!(
+        !rendered.contains(&lower_hex(secret)),
+        "{label} leaked lowercase hex: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&upper_hex(secret)),
+        "{label} leaked uppercase hex: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&base64url(secret)),
+        "{label} leaked base64url: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&decimal_list(secret)),
+        "{label} leaked a decimal byte list: {rendered}"
+    );
+    // A prefix of a decimal dump convicts on its own: no correct output of this
+    // crate ever prints four consecutive byte values.
+    assert!(
+        !rendered.contains(&decimal_list(&secret[..secret.len().min(4)])),
+        "{label} leaked the start of a decimal byte list: {rendered}"
+    );
+    assert!(
+        longest_hex_run(rendered) < 16,
+        "{label} contains a {}-character hex-looking run: {rendered}",
+        longest_hex_run(rendered)
+    );
+}
+
+fn signing_key() -> SigningKey {
+    SigningKey::from_seed(&[SECRET; 32])
+}
+
+fn verifier(relay_id: f2z_codec::types::RelayId) -> CommandVerifier {
+    CommandVerifier::new(
+        f2z_codec::transcript::TranscriptBuilder::new(
+            f2z_relay_proto::PROTOCOL_VERSION,
+            relay_id,
+            ChannelBinding::new([SECRET; 32]),
+        ),
+        TimestampWindow::default(),
+        SeenSet::new(240_000, 64),
+        PaddingBuckets::default(),
+    )
+}
+
+#[test]
+fn a_signing_key_never_renders_anything_about_itself() {
+    let key = signing_key();
+    let rendered = format!("{key:?}");
+    assert_eq!(rendered, "SigningKey(<redacted>)");
+    // The seed, and the public half derived from it, are both absent.
+    assert_no_leak("SigningKey", &rendered, &[SECRET; 32]);
+    assert_no_leak("SigningKey", &rendered, key.public_key().as_bytes());
+
+    let public = key.verifying_key();
+    let rendered = format!("{public:?}");
+    assert_no_leak("VerifyingKey", &rendered, key.public_key().as_bytes());
+}
+
+#[test]
+fn a_seen_set_does_not_render_the_keys_and_nonces_it_holds() {
+    let mut seen = SeenSet::new(240_000, 8);
+    let key = ReplayKey::new(PublicKey::new([SECRET; 32]), Nonce::new([SECRET; 16]));
+    seen.observe(NOW, key).unwrap();
+
+    assert_no_leak("ReplayKey", &format!("{key:?}"), &[SECRET; 32]);
+    assert_no_leak("ReplayKey", &format!("{key:?}"), &[SECRET; 16]);
+    // The set itself renders its entries; a derived `Debug` on the map would
+    // print every key it holds, which is a per-command log of who spoke.
+    assert_no_leak("SeenSet", &format!("{seen:?}"), &[SECRET; 32]);
+    assert_no_leak("SeenSet", &format!("{seen:?}"), &[SECRET; 16]);
+}
+
+#[test]
+fn a_signed_command_does_not_render_its_payload_or_its_authenticator() {
+    let key = signing_key();
+    let relay_id = f2z_codec::hash::relay_id(&key.public_key());
+    let payload = vec![SECRET; 1024];
+    let signed = SignedCommand::<ops::Append>::create(
+        &f2z_codec::transcript::TranscriptBuilder::new(
+            f2z_relay_proto::PROTOCOL_VERSION,
+            relay_id,
+            ChannelBinding::new([SECRET; 32]),
+        ),
+        1,
+        QueueAddress::new([SECRET; 32]),
+        NOW,
+        Nonce::new([SECRET; 16]),
+        &key,
+        &AppendRequest {
+            payload: Payload::new(payload.clone()).unwrap(),
+        },
+    )
+    .unwrap();
+
+    let rendered = format!("{signed:?}");
+    assert_no_leak("SignedCommand payload", &rendered, &payload);
+    assert_no_leak("SignedCommand address", &rendered, &[SECRET; 32]);
+    assert_no_leak("SignedCommand nonce", &rendered, &[SECRET; 16]);
+    assert_no_leak(
+        "SignedCommand signature",
+        &rendered,
+        signed.auth().signature.as_bytes(),
+    );
+    assert_no_leak("SignedCommand body", &rendered, signed.body());
+}
+
+#[test]
+fn a_verified_command_does_not_render_what_it_carries() {
+    let key = signing_key();
+    let relay_id = f2z_codec::hash::relay_id(&key.public_key());
+    let payload = vec![SECRET; 4096];
+    let signed = SignedCommand::<ops::Append>::create(
+        &f2z_codec::transcript::TranscriptBuilder::new(
+            f2z_relay_proto::PROTOCOL_VERSION,
+            relay_id,
+            ChannelBinding::new([SECRET; 32]),
+        ),
+        1,
+        QueueAddress::new([SECRET; 32]),
+        NOW,
+        Nonce::new([SECRET; 16]),
+        &key,
+        &AppendRequest {
+            payload: Payload::new(payload.clone()).unwrap(),
+        },
+    )
+    .unwrap();
+
+    let mut verifier = verifier(relay_id);
+    let verified = verifier
+        .verify::<ops::Append>(NOW, 1, &signed.request().unwrap())
+        .unwrap();
+    let rendered = format!("{verified:?}");
+    assert_no_leak("Verified payload", &rendered, &payload);
+    assert_no_leak("Verified address", &rendered, &[SECRET; 32]);
+    assert_no_leak("Verified signer", &rendered, key.public_key().as_bytes());
+
+    // And the verifier itself, which now holds the seen-set entry.
+    assert_no_leak("CommandVerifier", &format!("{verifier:?}"), &[SECRET; 32]);
+    assert_no_leak("CommandVerifier", &format!("{verifier:?}"), &[SECRET; 16]);
+}
+
+#[test]
+fn an_unsigned_contact_append_does_not_render_a_strangers_ciphertext() {
+    let key = signing_key();
+    let relay_id = f2z_codec::hash::relay_id(&key.public_key());
+    let payload = vec![SECRET; 1024];
+    let request = f2z_codec::frame::Request::new(
+        <ops::ContactAppend as RelayCommand>::COMMAND.code(),
+        f2z_codec::frame::CommandAuth::Unsigned,
+        f2z_codec::canonical::Canonical::encode_canonical(&ContactAppendRequest {
+            contact_addr: QueueAddress::new([SECRET; 32]),
+            payload: Payload::new(payload.clone()).unwrap(),
+            stamp: PowStamp {
+                challenge: Challenge::new([SECRET; 32]),
+                salt: f2z_codec::types::Salt::new([SECRET; 16]),
+                counter: 7,
+            },
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    let verified = verifier(relay_id)
+        .accept_unsigned::<ops::ContactAppend>(&request)
+        .unwrap();
+    let rendered = format!("{verified:?}");
+    assert_no_leak("ContactAppend payload", &rendered, &payload);
+    assert_no_leak("ContactAppend challenge", &rendered, &[SECRET; 32]);
+}
+
+#[test]
+fn queue_state_does_not_render_the_keys_that_authorize_it() {
+    let mut queue = QueueState::create(QueueKind::Standard, PublicKey::new([SECRET; 32]));
+    queue.bind_send(&PublicKey::new([SECRET; 32])).unwrap();
+    queue.append().unwrap();
+    assert_no_leak("QueueState", &format!("{queue:?}"), &[SECRET; 32]);
+}
+
+#[test]
+fn a_relay_session_does_not_render_its_binding_or_its_identity() {
+    let identity = signing_key();
+    let binding = ChannelBinding::new([SECRET; 32]);
+    let offer = HelloRequest {
+        min_version: 1,
+        max_version: 1,
+        client_nonce: Challenge::new([SECRET; 32]),
+    };
+    let published = capabilities::defaults(&identity.public_key(), NOW).unwrap();
+    let response = hello_response(
+        &identity,
+        &RelayAnnouncement {
+            protocol_version: 1,
+            relay_time_ms: NOW,
+            channel_binding_mode: ChannelBindingMode::TlsExporter,
+            transport_security: TransportSecurity::Tls,
+            capabilities_digest: capabilities::digest(&published).unwrap(),
+        },
+        &binding,
+        &offer.client_nonce,
+    );
+    let session =
+        verify_hello_response(&response, &offer, &binding, None, &ClientPolicy::default()).unwrap();
+
+    let rendered = format!("{session:?}");
+    assert_no_leak("RelaySession binding", &rendered, &[SECRET; 32]);
+    assert_no_leak(
+        "RelaySession identity",
+        &rendered,
+        identity.public_key().as_bytes(),
+    );
+    assert_no_leak(
+        "RelaySession relay_id",
+        &rendered,
+        session.relay_id().as_bytes(),
+    );
+
+    // The `HELLO` frame the relay sent is a `f2z-codec` structure, but it is
+    // this crate that builds it, so it is checked here too.
+    assert_no_leak(
+        "HelloResponse proof",
+        &format!("{response:?}"),
+        response.relay_proof.as_bytes(),
+    );
+}
+
+#[test]
+fn the_capability_document_still_publishes_what_it_exists_to_publish() {
+    // The mirror image of every other test in this file. §11.1's operator block
+    // is the point of the document — a redaction that swallowed
+    // `operator_jurisdiction` would defeat the reason it is published at all.
+    let identity = signing_key();
+    let mut capabilities = capabilities::defaults(&identity.public_key(), NOW).unwrap();
+    capabilities.operator_jurisdiction =
+        f2z_codec::types::ShortBytes::new(&b"Iceland"[..]).unwrap();
+    let rendered = format!("{capabilities:?}");
+    assert!(
+        rendered.contains("Iceland"),
+        "the operator block must remain readable: {rendered}"
+    );
+    assert_no_leak(
+        "Capabilities identity",
+        &rendered,
+        identity.public_key().as_bytes(),
+    );
+}


### PR DESCRIPTION
`rs/crates/f2z-relay-proto` — the protocol layer above `f2z-codec` that a relay
and a client **both link**. No I/O, no sockets, no filesystem, no async runtime,
**no clock and no randomness**: every function that needs the time takes it as
an argument, which is what makes the rules testable and lets the same code run
in a relay and in a browser.

`no_std` + `alloc`, `#![forbid(unsafe_code)]`, MIT (the AGPL boundary starts at
the server binaries), and it builds for `wasm32-unknown-unknown`.

## What is in it

| Module | `WIRE.md` |
|---|---|
| `command` | §5.1 signed-command construction and verification, in the specified order; §6's command set as typed request/response pairs |
| `replay` | §5.5's timestamp window and fail-closed `(signer_key, nonce)` seen-set |
| `queue` | §7 lifecycle (bind-once, TTL clamping, rotation), §8 ACK arithmetic, §12.2 contact queues, §13.1 layer-2 quotas |
| `capabilities` | §11 document: sign, verify, digest, validity, and §11.3's client policy |
| `hello` | §2.5/§5.2 proof of possession and the session it opens |
| `inflight` | §4.3's bounded, out-of-order window with a typed ticket |
| `key` | Ed25519, `verify_strict`, constant-time key comparison, §10's dummy verification |

`f2z-codec`'s public API is **unchanged** — nothing in it needed to move.

## Design decisions worth reviewing

**The verification order is one function.** `CommandVerifier::verify` runs §5.1's
steps 1-6 in order, with `relay_id` and `channel_binding` coming from the
verifier and everything else from the frame. Reordering it is a security change,
so it is not composable by a call site.

**The body gets its own §3.3.** Frame-level re-encode equality preserves the
opaque body verbatim, so a non-canonical structure *inside* it survives
untouched. The typed body is decoded canonically here, and `body_hash` covers
those re-encoded bytes.

**`verify_strict` everywhere.** Plain Ed25519 verification accepts small-order
public keys, under which a signature can verify for more than one key. §5.1 step
5 treats a verifying signature as proof that a *specific* key authorized a
command, so a key that verifies everything is a key that steals every queue it
is registered against.

**Only a verified `HELLO` hands out a `TranscriptBuilder`.** `RelaySession` is
the sole source in this crate, so "the relay proved possession first" (§5.2's
MUST) is a precondition of being able to sign, not a step someone remembers.

**`Ticket<C>` is neither `Clone` nor `Copy`.** With out-of-order responses
(§4.3) the only correlation is a `uint32`; without a type, an `AckResponse`
decodes cleanly as a `SubscribeResponse` — same two `uint64`s, different
meaning, no error anywhere. Test `an_append_response_may_not_carry_queue_state`
pins §6.3 through this.

## Spec defect found — please read this one

**§11.1 publishes `antireplay_window_ms` and `clock_skew_ms` with no stated
relation, and there must be one.** A command stamped `clock_skew_ms` in the
future is still inside the window `clock_skew_ms` *after* the relay first saw
it, so a seen-set entry must be retained for `2 × clock_skew_ms` from
observation. A relay publishing `antireplay_window_ms < 2 × clock_skew_ms`ages
entries out while the frames they cover are still valid — §5.5's protection
silently absent for the gap, with nothing in the document forbidding it.

Handled without redesigning: `SeenSet::retention_is_sound` states the relation,
and `ClientPolicy::require_sound_antireplay_window` (default **on**) refuses
such a relay. It is deliberately **not** in `capabilities::validate`, because
the document is exactly what the specification permits — it is the specification
that is missing the constraint. `WIRE.md` §11.1 should state it, and §5.5 should
say what the window is measured from.

## Ambiguity calls — every one, with reasoning

1. **§6.3 vs §10 on send-side refusals.** §10 code 10 covers "absent **or**
   unauthorized"; §10 code 15 covers "absent, deleted, expired, full…, send side
   only". Both claim "absent". Resolved in §6.3's favour: `authorize_send`
   returns `ERR_UNAVAILABLE` for everything, because §6.3's reason (a bound
   sender must not learn queue state by filling the queue) dominates, and
   collapsing absent into unavailable creates no oracle — every send-side
   refusal looks identical. `ERR_ALREADY_BOUND` and `ERR_NOT_PERMITTED` stay
   distinguishable because §7.3/§7.4 and §12.2 require it, and §7.4 accepts that
   noise explicitly.
2. **§5.1 step 5 does not apply to `BIND_SEND`.** The send side is unbound until
   the command succeeds, so there is no registered key to compare against. The
   signature can only prove possession of the key in the body, so
   `signer_key == send_key` is required — without it, anyone could bind a key
   they do not hold, which is §7.4's theft with no work at all. Reported as
   `ERR_NO_ACCESS`.
3. **`CREATE_CONTACT_QUEUE` self-authentication.** §12.2 does not restate
   §6.2's `signer_key == recv_key` rule, but the command has the same shape
   (a `recv_key` in the body, a zero transcript address, no existing queue), so
   the same rule is the only thing that authenticates it. Applied.
4. **Wrong transcript address for a command is `ERR_MALFORMED` (fatal).** A
   `CREATE_QUEUE` with a nonzero address, or a `READ` with a zero one, is not a
   state disagreement between honest peers — it is a frame no conforming client
   emits.
5. **A signed command arriving unsigned is `ERR_BAD_SIGNATURE` (non-fatal); an
   unsigned command arriving signed is `ERR_MALFORMED` (fatal).** The first is a
   well-formed frame that failed to authorize. The second carries an
   authenticator §5.1 has no path to check, so accepting it would mean carrying
   bytes nothing verifies.
6. **Dispatching to the wrong handler is `ERR_INTERNAL`.** §10's code 21 is the
   one that carries no detail, which is right for a relay describing its own
   fault to an unauthenticated caller.
7. **`UNSUBSCRIBE`'s response is empty.** §6.2's "empty bodies" sentence is
   about the requests (it then specifies a `SubscribeResponse`). There is no
   queue state an unsubscribe could report that `SUBSCRIBE` did not, and empty
   is the only reading that invents nothing.
8. **Queue indices start at 0**, and §8.2's bound is `next_index`, not what is
   stored — "the highest index the relay has **ever** appended". A drained queue
   still refuses a pre-ack (property-tested).
9. **The timestamp window boundary is inclusive.** Exclusive would make a client
   whose offset is exactly the published skew fail intermittently, and the
   number is a policy value rather than a threshold.
10. **A requested TTL of `0` means "no preference"** and gets the published
    default. §7.7 has both a requested value and a default and never says how
    they meet; a zero-second TTL is not a policy any client can want, so zero is
    the only value free to carry the meaning. The 30-day ceiling is applied last
    and unconditionally, even over a relay's own configured maximum.
11. **`channel_binding_mode: tls-exporter` with a 32-zero-byte binding is
    refused.** A genuine exporter output of zero has probability 2^-256, so
    treating zero as the "absent" sentinel costs nothing and removes an
    ambiguity that would otherwise surface as an obscure signature failure much
    later.
12. **`contact_queues_enabled` requires `contact_append_pow`.** §12.3 says a
    relay MUST enforce all four caps and proof of work is one of them; offering
    contact queues without it is an unsigned, unmetered write endpoint open to
    the internet. Enforced in `validate`.
13. **`max_frame_bytes >= largest padding bucket`** is checked as a necessary
    (not sufficient) consistency condition: a relay whose frame cap cannot carry
    its own largest bucket has published a set no client can use.
14. **`pending` is index-space.** TTL expiry (§7.7) removes stored messages
    without moving the watermark, so this crate's `pending` is an upper bound and
    says so; a relay that expires messages must answer from storage. Modelling
    storage in a crate that has none would have been the worse lie.
15. **`QueueAdvert` has no wire encoding.** §7.2 shows it as a named-field object
    and never gives it a `tls_codec` structure, because a relay never sees one.
    The type exists to carry `(relay_url, relay_id, send_addr)` into the §5.2
    check; inventing an encoding would have been inventing protocol.
16. **`PowStamp::empty()` for "no stamp"** — already `f2z-codec`'s reading, and
    reused rather than re-litigated.

## Dependency notes

- `ed25519-dalek 3` (BSD-3-Clause, already permitted by `rs/deny.toml`) with
  `default-features = false, features = ["zeroize"]`. Dropping `fast` drops
  curve25519-dalek's precomputed tables — ~30 KiB of table against a handful of
  signatures per connection, and this graph reaches wasm32 where the bundle is
  the scarce resource.
- `subtle` for constant-time key comparison (§10). Already in the graph.
- `tls_codec` directly, for the zero-byte `Empty` body type.
- `f2z-codec` is declared with `version` beside `path`: `rs/deny.toml` sets
  `wildcards = "deny"` and a bare path dependency is a wildcard requirement.
- **cargo-deny reports two `digest` versions** (0.10 via `blake2`, 0.11 via
  `sha2`/`curve25519-dalek`). It is a `warn`, and it is two versions of a *trait
  crate*, not two copies of a hash implementation. Recorded rather than silenced;
  it resolves when `blake2` publishes against `digest 0.11`.

## Verification

All run locally from the worktree, all green:

```
scripts/check-rust-fmt.sh    --root rs                      # 3 crates formatted
scripts/check-rust-clippy.sh --root rs                      # -D warnings, clean
scripts/check-rust-deny.sh   --root rs --config rs/deny.toml # advisories/bans/licenses/sources ok
scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
  --manifest rs/crates/f2z-codec/Cargo.toml \
  --manifest rs/crates/f2z-relay-proto/Cargo.toml           # pins agree
node scripts/check-workflow-gates.mjs                       # 2 gates, 56 jobs
node scripts/check-github-actions-pins.mjs                  # 178 refs pinned
cd rs && cargo test --locked --all-targets                  # 163 tests, 0 failed
cd rs && cargo test --locked --doc                          # 2 doctests
cd rs && cargo build --target wasm32-unknown-unknown --lib \
  -p f2z-codec -p f2z-relay-proto                           # ok
```

New tests: 79 unit, 8 redaction, 6 property (93 of the 163).

Re-verified after rebasing onto `origin/main` at cb9756e, which had moved under
this branch with four `rs/` changes (#571's `akd` floor and README correction,
#572's `Canonicalized` `Debug` fix). The only conflict was `rs/README.md`, where
#571's text on `check-rust-toolchain.sh` **not** discovering manifests is kept
verbatim — it says exactly why this PR had to add a `--manifest` flag by hand.

The redaction test follows the trap `f2z-codec` documented — `tls_codec`'s byte
vectors print a decimal byte list containing no hex, so a hex-only assertion
passes while everything leaks. Every structure is checked against lowercase hex,
uppercase hex, base64url, a full decimal list, a four-byte decimal prefix, and
any long hex-looking run. One test asserts the *opposite* for the capability
document: §11.1's operator block must stay readable.

CI changes: `rs / wasm32` now builds both crates (spelled out rather than
`--workspace`, so a future AGPL server binary that pulls tokio does not silently
join the wasm build), and the toolchain check registers the new manifest.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
