### PR TITLE
feat(kt): add f2z-kt-core, the key-transparency crate (KT.md v1)

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -74,7 +74,8 @@ jobs:
           scripts/check-rust-toolchain.sh --self-test
           scripts/check-rust-toolchain.sh \
             --toolchain-file rs/rust-toolchain.toml \
-            --manifest rs/crates/f2z-codec/Cargo.toml
+            --manifest rs/crates/f2z-codec/Cargo.toml \
+            --manifest rs/crates/f2z-kt-core/Cargo.toml
 
       - name: Detect changes under rs/
         id: filter
@@ -294,6 +295,22 @@ jobs:
           cargo build --locked --lib \
             --target "${{ steps.rust_toolchain.outputs.target }}" \
             -p f2z-codec
+
+      # KT.md §11.4: the log, the witness and the client link one crate. Only
+      # the *client* half reaches the browser — `akd::auditor::audit_verify`
+      # hardcodes AzksParallelismConfig::default() and reaches
+      # tokio::task::spawn, so it compiles for wasm32 and then traps at runtime
+      # (KT.md §11.3). `--no-default-features --features verifier` is therefore
+      # not a size optimisation, it is the supported configuration, and this
+      # step is what stops the auditor being pulled into a browser bundle by an
+      # innocent-looking feature edit.
+      - name: Build the f2z-kt-core client verifier for the browser target
+        working-directory: rs
+        run: |
+          set -euo pipefail
+          cargo build --locked --lib \
+            --target "${{ steps.rust_toolchain.outputs.target }}" \
+            -p f2z-kt-core --no-default-features --features verifier
 
   # Branch protection should require this stable context, `rs / gate`. It
   # succeeds only when the change detector and every applicable rs job

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -3,10 +3,92 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "akd"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65dd81c1ad91ef0dcfbcae8cc8d3a78ce9d26cd799c495dc5451266b7ec637b2"
+dependencies = [
+ "akd_core",
+ "async-recursion",
+ "async-trait",
+ "dashmap",
+ "hex",
+ "log",
+ "protobuf",
+ "tokio",
+]
+
+[[package]]
+name = "akd_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce56523cc567545912841354a5efe22db939f87eb4e817372466491c7845053f"
+dependencies = [
+ "async-trait",
+ "blake3",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "hex",
+ "protobuf",
+ "protobuf-codegen",
+ "protobuf-parse",
+ "zeroize",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -39,6 +121,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,10 +143,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crypto-common"
@@ -61,6 +196,56 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -75,13 +260,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -94,10 +316,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "f2z-kt-core"
+version = "0.1.0"
+dependencies = [
+ "akd",
+ "akd_core",
+ "ed25519-dalek",
+ "f2z-codec",
+ "proptest",
+ "protobuf",
+ "tls_codec",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fnv"
@@ -113,6 +360,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -139,6 +397,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,9 +441,39 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+dependencies = [
+ "value-bag",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-traits"
@@ -164,6 +489,35 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -203,6 +557,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "protobuf",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror",
+ "which",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,7 +641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -246,7 +651,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -264,7 +678,39 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -272,6 +718,28 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "rustix"
@@ -282,8 +750,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -296,6 +764,90 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -316,6 +868,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,8 +887,28 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -346,7 +929,16 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -368,6 +960,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "value-bag"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068e763e8279de7ab94b6afebded2cb701678af094feb1c12ccb061b4783c1be"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,12 +981,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -399,12 +1015,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -429,7 +1118,7 @@ checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -449,5 +1138,5 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -34,6 +34,35 @@ expect_used = "deny"
 [workspace.dependencies]
 blake2 = { version = "0.10", default-features = false }
 tls_codec = { version = "0.4", default-features = false, features = ["derive"] }
+
+# First-party. `f2z-kt-core` builds the transparency envelope on top of
+# `f2z-codec`'s canonical encoding, so the re-encode-equality rule of WIRE.md
+# §3.3 has exactly one implementation in this tree.
+#
+# `version` is carried alongside `path` even though nothing here is published:
+# a bare path dependency has no version requirement, and `rs/deny.toml` sets
+# `wildcards = "deny"` for every dependency including ours.
+f2z-codec = { path = "crates/f2z-codec", version = "0.1.0" }
+
+# Ed25519 verification for every signature KT.md §6.2's label table names. The
+# `vrf` feature of `akd_core` already pulls this crate, so naming it here costs
+# no new tree; `default-features = false` keeps `std` out of the wasm build.
+ed25519-dalek = { version = "2", default-features = false }
+
+# The append-only zero-knowledge set, ADR 0013.
+#
+# `>= 0.13.0` is a HARD FLOOR and it is NOT held by this line. A
+# `[patch.crates-io]`, a path dependency or a vendored copy all walk under a
+# manifest requirement without comment, and facebook/akd#495 — the auditor
+# append-only bypass this floor exists for — has no RustSec/OSV advisory, so
+# `cargo audit` passes on a vulnerable pin forever. The floor is the
+# `[[bans.deny]]` entry in rs/deny.toml. Do not remove it.
+#
+# `akd_core` is the client verifier and reaches wasm32-unknown-unknown; `akd`
+# is the server/witness crate and does not (KT.md §11.3).
+akd_core = { version = "0.13", default-features = false, features = ["vrf", "whatsapp_v1", "protobuf"] }
+protobuf = { version = "3", default-features = false }
+akd = { version = "0.13", default-features = false, features = ["whatsapp_v1", "public_auditing"] }
 # Dev-dependency only. It builds for the host test runner, never for
 # wasm32-unknown-unknown, so its `std` default costs this crate nothing: the
 # library itself is `no_std` and the wasm job builds `--lib`.

--- a/rs/README.md
+++ b/rs/README.md
@@ -49,7 +49,8 @@ decided is `wallet/rust-toolchain.toml`, and
 
 ```
 scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
-                                --manifest rs/crates/f2z-codec/Cargo.toml
+                                --manifest rs/crates/f2z-codec/Cargo.toml \
+                                --manifest rs/crates/f2z-kt-core/Cargo.toml
 ```
 
 fails the pull request the moment the two disagree. `.github/workflows/rs.yml`
@@ -82,6 +83,27 @@ prevent.
 | Crate | What it is |
 |---|---|
 | [`crates/f2z-codec`](./crates/f2z-codec) | The canonical encoding layer of `WIRE.md`: `tls_codec` wrappers for every wire structure, the domain-separated signing transcript (§5), the redacting newtypes, and the padding-bucket validator (§9). `no_std` + `alloc`, `#![forbid(unsafe_code)]`, no I/O, no async runtime, and it builds for `wasm32-unknown-unknown`. |
+| [`crates/f2z-kt-core`](./crates/f2z-kt-core) | Key transparency, [`docs/e2ee/KT.md`](../docs/e2ee/KT.md) v1: `DirectoryEntry` and the §4.4 authorization rules, `SignedTreeHead` and its monotonicity checks, log-key rotation, `WitnessCosignature` and the threshold rule, and the client verifier over `akd_core`. Built on `f2z-codec`, `#![forbid(unsafe_code)]`, no I/O, no clock, no keys. |
+
+`f2z-kt-core` is the **one** crate the log server, the witness and the client all
+link (`KT.md` §11.4). That is not tidiness: a witness that verified with a
+different implementation than the log builds with would produce cosignatures that
+mean nothing, and §7.4's only structural defence against a lazy witness is that
+there are not two implementations to disagree.
+
+Its `verifier` feature reaches `wasm32-unknown-unknown`; its `auditor` feature
+does not, and must never be enabled for the browser — `akd::auditor::audit_verify`
+hardcodes `AzksParallelismConfig::default()` and reaches `tokio::task::spawn`, so
+it compiles for that target and then traps at runtime (`KT.md` §11.3). The wasm CI
+job builds `--no-default-features --features verifier` for exactly that reason.
+
+**`rs/deny.toml` carries the `akd >= 0.13.0` floor and it is load-bearing.**
+[facebook/akd#495](https://github.com/facebook/akd/pull/495) — an auditor
+append-only bypass letting a malicious log rewrite a label's value while still
+producing a *valid* append-only proof — has no RustSec or OSV advisory and never
+will, so `cargo audit` passes on a vulnerable pin forever
+([ADR 0013](../docs/e2ee/decisions/0013-key-transparency-log.md)). A reviewer who
+removes those `[[bans.deny]]` entries has removed the floor.
 
 `f2z-codec` is separate from everything that will sit on top of it for three
 reasons, and each is enforced by a test rather than by intent:
@@ -102,13 +124,16 @@ reasons, and each is enforced by a test rather than by intent:
 cd rs
 cargo test
 cargo build --target wasm32-unknown-unknown -p f2z-codec
+cargo build --target wasm32-unknown-unknown -p f2z-kt-core \
+            --no-default-features --features verifier
 ```
 
 The gates are the repository's shared scripts, pointed here with `--root`:
 
 ```bash
 scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
-                                --manifest rs/crates/f2z-codec/Cargo.toml
+                                --manifest rs/crates/f2z-codec/Cargo.toml \
+                                --manifest rs/crates/f2z-kt-core/Cargo.toml
 scripts/check-rust-fmt.sh    --root rs
 scripts/check-rust-clippy.sh --root rs
 scripts/check-rust-deny.sh   --root rs --config rs/deny.toml

--- a/rs/crates/f2z-kt-core/Cargo.toml
+++ b/rs/crates/f2z-kt-core/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "f2z-kt-core"
+version = "0.1.0"
+description = "Key-transparency core for the free2z directory (docs/e2ee/KT.md v1): entry authorization, signed tree heads, witness cosignatures and the client verifier"
+edition.workspace = true
+# A restatement of wallet/rust-toolchain.toml's channel in Cargo's MSRV form,
+# registered with `scripts/check-rust-toolchain.sh --manifest` so it cannot
+# drift. Not inherited from the workspace: that check reads this literal line.
+rust-version = "1.97"
+# Permissive, deliberately and explicitly. KT.md §11.4: this crate is linked by
+# the log server, by the witness, and by the ZUULI and WASM clients. The
+# AGPL-3.0 boundary starts at the server binaries, not here. rs/deny.toml
+# enforces it.
+license = "MIT"
+repository.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["verifier", "auditor"]
+# The client half of KT.md §8: inclusion and key-history verification. Reaches
+# wasm32-unknown-unknown; `akd_core` builds for the browser with no shim.
+verifier = ["dep:akd_core", "dep:protobuf"]
+# The witness half of KT.md §7.1 step 4. Pulls the server crate `akd` for
+# `audit_verify`, which reaches `tokio::task::spawn` and therefore does NOT
+# work on wasm32-unknown-unknown (KT.md §11.3). Never enable it for the browser.
+auditor = ["dep:akd", "verifier"]
+
+[dependencies]
+ed25519-dalek = { workspace = true }
+f2z-codec = { workspace = true }
+tls_codec = { workspace = true }
+
+akd_core = { workspace = true, optional = true }
+akd = { workspace = true, optional = true }
+# Only to reach `protobuf::Message::parse_from_bytes` for `akd_core`'s own proof
+# types (KT.md §9.4). Declared rather than inherited through `akd_core`, per
+# AGENTS.md: a feature enabled only by another crate's unification is a feature
+# we do not actually have.
+protobuf = { workspace = true, optional = true }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/rs/crates/f2z-kt-core/src/auditor.rs
+++ b/rs/crates/f2z-kt-core/src/auditor.rs
@@ -1,0 +1,399 @@
+//! The witness-side append-only path — `KT.md` §7.1 step 4 and §7.4.
+//!
+//! # A witness that does not verify the append-only proof is worthless
+//!
+//! Restated here so it cannot be skipped by an implementer optimising a poll
+//! loop:
+//!
+//! - A witness that verifies the **signature** and cosigns is attesting that the
+//!   log signed something. **The log's own signature already proved that.** Such
+//!   a cosignature adds exactly zero information.
+//! - A witness that verifies **monotonicity** and cosigns detects a log that
+//!   contradicts itself *in the stream that witness was shown*. Much weaker than
+//!   it sounds: a log that maintains two internally-consistent branches and
+//!   shows each witness only one passes every monotonicity check every time.
+//! - Only the **append-only proof** establishes that the new root extends the old
+//!   one rather than replacing part of it. It is the only check that catches
+//!   [facebook/akd#495](https://github.com/facebook/akd/pull/495) — a value
+//!   rewritten under a proof that still verifies — and it is the check no client
+//!   can run for itself, because the proof is O(entries added): 3.9 MB and
+//!   1–3 seconds for five epochs.
+//!
+//! There is no way for a client to tell a lazy witness from a diligent one by
+//! inspecting cosignatures. §7.4's mitigation is structural rather than
+//! cryptographic, and this module is where the structure lives:
+//!
+//! - **The log and the witness link the same verifier.** `audit_verify` is
+//!   `akd`'s, used by both, at the same pinned version. "Cosign without
+//!   verifying" is then not a state a conforming implementation can drift into
+//!   by omission — it takes deleting a call, not forgetting one.
+//! - [`WitnessState::advance`] **takes an [`AppendOnlyVerified`]**, and
+//!   [`verify_append_only`] is the only thing that produces one. A witness built
+//!   on this crate cannot reach the point of emitting a cosignature without
+//!   having run the check, because the token is the argument the next step
+//!   needs.
+//!
+//! A witness that is actively malicious simply removes the check, and we will
+//! not know. The mitigation for that is the independence of the witness set, not
+//! code.
+//!
+//! # This does not reach the browser, on purpose
+//!
+//! `akd::auditor::audit_verify` compiles for `wasm32-unknown-unknown` and then
+//! traps at runtime, because `verify_append_only_hash` hardcodes
+//! `AzksParallelismConfig::default()` — `AvailableOr(32)` — reaching
+//! `tokio::task::spawn`, and that target has no runtime and no threads (§11.3).
+//! It fails on a 33 KB proof as readily as on a 3.9 MB one, so it is not a size
+//! or stack problem. The witness is a native outbound-polling daemon (§9.3), so
+//! this costs us nothing; the `auditor` feature exists so the wasm build cannot
+//! pull it in by accident.
+
+use akd::AppendOnlyProof;
+use akd::auditor::audit_verify;
+use akd_core::configuration::WhatsAppV1Configuration;
+use f2z_codec::types::Digest;
+use protobuf::Message as _;
+
+use crate::error::KtError;
+use crate::sth::{LogView, SignedTreeHead};
+
+/// Proof that `audit_verify` ran and accepted, for the epochs it names.
+///
+/// No public constructor. [`verify_append_only`] is the only thing that builds
+/// one, and [`WitnessState::advance`] is the only thing that consumes one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AppendOnlyVerified {
+    from_epoch: u64,
+    to_epoch: u64,
+    to_root: Digest,
+}
+
+impl AppendOnlyVerified {
+    /// The epoch the verified range starts at — the last root the witness had
+    /// already accepted.
+    #[must_use]
+    pub const fn from_epoch(&self) -> u64 {
+        self.from_epoch
+    }
+
+    /// The epoch the verified range ends at.
+    #[must_use]
+    pub const fn to_epoch(&self) -> u64 {
+        self.to_epoch
+    }
+
+    /// The root at [`AppendOnlyVerified::to_epoch`].
+    #[must_use]
+    pub const fn to_root(&self) -> &Digest {
+        &self.to_root
+    }
+}
+
+/// §7.1 step 4 — verify that every root in `heads` extends the one before it.
+///
+/// `heads` is the run of tree heads covering `(last.epoch, new.epoch]`
+/// **inclusive of the last accepted head at position 0**, so `heads.len()` is
+/// one more than the number of epoch transitions — the shape
+/// `akd::auditor::audit_verify` wants, and the shape §6.3 rule 7 already forces
+/// a witness to hold anyway.
+///
+/// The heads' signatures and monotonicity are **not** re-checked here; that is
+/// [`LogView::accept_chain`], and a witness runs it first (step 3 before step
+/// 4). What this adds is the only thing those checks cannot give: that the tree
+/// grew rather than changed.
+///
+/// # Errors
+///
+/// - [`KtError::Malformed`] if `heads` has fewer than two entries, if the proof
+///   is not decodable protobuf, or if the proof's epoch list does not line up
+///   with the heads.
+/// - [`KtError::AppendOnlyFailure`] if `audit_verify` rejected. **Halt and
+///   report** (§7.3); a witness MUST NOT catch up past a fault, because an
+///   automatic resync is an automatic way to erase the only record of the thing
+///   the witness exists to find.
+pub async fn verify_append_only(
+    heads: &[SignedTreeHead],
+    append_only_proof: &[u8],
+) -> Result<AppendOnlyVerified, KtError> {
+    let (Some(first), Some(last)) = (heads.first(), heads.last()) else {
+        return Err(KtError::Malformed);
+    };
+    if heads.len() < 2 {
+        return Err(KtError::Malformed);
+    }
+
+    let proto = akd_core::proto::specs::types::AppendOnlyProof::parse_from_bytes(append_only_proof)
+        .map_err(|_| KtError::Malformed)?;
+    let proof = AppendOnlyProof::try_from(&proto).map_err(|_| KtError::Malformed)?;
+
+    // `audit_verify` checks `proof.epochs.len() + 1 == hashes.len()` itself, but
+    // not that the epochs are *ours*. Without this, a log could serve a
+    // perfectly valid proof for a different, earlier range and it would verify
+    // against root hashes it happens to match.
+    if proof.epochs.len().saturating_add(1) != heads.len() {
+        return Err(KtError::Malformed);
+    }
+    for (proof_epoch, head) in proof.epochs.iter().zip(heads.iter()) {
+        if *proof_epoch != head.sth.epoch {
+            return Err(KtError::Malformed);
+        }
+    }
+
+    let hashes = heads
+        .iter()
+        .map(|head| *head.sth.root_hash.as_bytes())
+        .collect();
+    audit_verify::<WhatsAppV1Configuration>(hashes, proof)
+        .await
+        .map_err(|_| KtError::AppendOnlyFailure)?;
+
+    Ok(AppendOnlyVerified {
+        from_epoch: first.sth.epoch,
+        to_epoch: last.sth.epoch,
+        to_root: last.sth.root_hash,
+    })
+}
+
+/// The durable state of a witness (§7.1, §7.5) — a few hundred bytes in a file,
+/// per §9.3's promise that a witness needs no database.
+///
+/// # Persist before you emit, and the order is a correctness requirement
+///
+/// §7.1 puts step 5 (persist, `fsync` plus atomic rename) before step 6 (emit
+/// the cosignature) and the reason is not hygiene. A witness that emits first
+/// and crashes before persisting comes back believing it is still at the old
+/// epoch. It will then happily cosign whatever it is served for that epoch next
+/// — and if the log serves it a *different* root, the witness has signed two
+/// contradictory statements for one epoch. That is exactly the non-repudiable
+/// evidence §7.2 is designed to produce, and the witness manufactured it against
+/// itself for a fault that was its own crash. Persist first and the worst case is
+/// a missed cosignature, which is invisible and harmless.
+///
+/// This type therefore does not emit anything. [`WitnessState::advance`] returns
+/// the statement a witness should cosign **after** it has durably written the
+/// new state, and the caller owns both the storage and the key.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WitnessState {
+    view: LogView,
+    halted: Option<crate::witness::FaultKind>,
+}
+
+impl WitnessState {
+    /// Start following a log from a tree head, with the key currently accepted
+    /// for it.
+    #[must_use]
+    pub const fn new(view: LogView) -> Self {
+        Self { view, halted: None }
+    }
+
+    /// The pinned view — `(log_id, accepted_log_pk, epoch, tree_size,
+    /// root_hash, sth_hash)`.
+    #[must_use]
+    pub const fn view(&self) -> &LogView {
+        &self.view
+    }
+
+    /// The fault this witness halted on, if it has.
+    #[must_use]
+    pub const fn halted(&self) -> Option<crate::witness::FaultKind> {
+        self.halted
+    }
+
+    /// Advance past a verified append-only range.
+    ///
+    /// The `heads` are the same run handed to [`verify_append_only`], including
+    /// the already-accepted head at position 0. §6.3's rules are applied to
+    /// every head after that one; the token proves the append-only check ran
+    /// over the same range.
+    ///
+    /// **A witness MUST NOT "catch up" past a fault.** Once this returns an
+    /// error the witness is halted, [`WitnessState::halted`] reports what it
+    /// found, and every later call returns the same fault until a human looks at
+    /// the evidence.
+    ///
+    /// # Errors
+    ///
+    /// - [`KtError::Malformed`] if the token does not describe this run of
+    ///   heads, or the run does not start at the currently pinned epoch.
+    /// - Whatever [`LogView::accept`] returns — and the witness halts on it.
+    pub fn advance(
+        &mut self,
+        heads: &[SignedTreeHead],
+        verified: &AppendOnlyVerified,
+    ) -> Result<&LogView, KtError> {
+        if let Some(kind) = self.halted {
+            return Err(fault_to_error(kind));
+        }
+        let (Some(first), Some(last)) = (heads.first(), heads.last()) else {
+            return Err(KtError::Malformed);
+        };
+        // The token must be about *this* range, starting where we actually are.
+        if first.sth.epoch != self.view.epoch()
+            || first.sth.root_hash != *self.view.root_hash()
+            || verified.from_epoch() != first.sth.epoch
+            || verified.to_epoch() != last.sth.epoch
+            || verified.to_root() != &last.sth.root_hash
+        {
+            return Err(KtError::Malformed);
+        }
+
+        let Some(rest) = heads.get(1..) else {
+            return Err(KtError::Malformed);
+        };
+        if let Err(error) = self.view.accept_chain(rest) {
+            self.halted = Some(error_to_fault(error));
+            return Err(error);
+        }
+        Ok(&self.view)
+    }
+
+    /// Record a fault found outside [`WitnessState::advance`] — a bad signature
+    /// on a key transition, or a receipt whose `merge_by_ms` passed unmet — and
+    /// halt.
+    pub fn halt(&mut self, kind: crate::witness::FaultKind) {
+        if self.halted.is_none() {
+            self.halted = Some(kind);
+        }
+    }
+}
+
+/// The `FaultKind` a §6.3 verdict corresponds to (§7.3).
+const fn error_to_fault(error: KtError) -> crate::witness::FaultKind {
+    use crate::witness::FaultKind;
+    match error {
+        KtError::Fork => FaultKind::Fork,
+        KtError::ChainBreak | KtError::EpochGap => FaultKind::ChainBreak,
+        KtError::VrfKeyChange => FaultKind::VrfKeyChange,
+        KtError::AppendOnlyFailure => FaultKind::AppendOnlyFailure,
+        KtError::BadSignature
+        | KtError::WrongLabel
+        | KtError::WrongLog
+        | KtError::UnsupportedVersion
+        | KtError::BadKeyTransition => FaultKind::BadSignature,
+        // Rollback is the residual verdict, and every remaining variant reaching
+        // here would be a bug rather than a fault of the log — reporting it as a
+        // rollback keeps the witness halted, which is the safe direction.
+        _ => FaultKind::Rollback,
+    }
+}
+
+const fn fault_to_error(kind: crate::witness::FaultKind) -> KtError {
+    use crate::witness::FaultKind;
+    match kind {
+        FaultKind::Fork => KtError::Fork,
+        FaultKind::ChainBreak => KtError::ChainBreak,
+        FaultKind::VrfKeyChange => KtError::VrfKeyChange,
+        FaultKind::AppendOnlyFailure => KtError::AppendOnlyFailure,
+        FaultKind::BadSignature => KtError::BadSignature,
+        FaultKind::MergeDelayExceeded | FaultKind::Rollback => KtError::Rollback,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TestLog;
+    use crate::witness::FaultKind;
+    use f2z_codec::types::Digest;
+
+    /// A witness cannot advance without the token, and the token cannot be
+    /// forged: there is no constructor. This test states the property the type
+    /// system already enforces, so that a future refactor that adds a
+    /// constructor fails review with a reason attached.
+    #[test]
+    fn advancing_requires_a_token_for_exactly_this_range() {
+        let log = TestLog::new();
+        let view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+        let mut state = WitnessState::new(view);
+        let heads = [log.head(0), log.head(1), log.head(2)];
+
+        // A token for a different range must not advance this one. Built by
+        // hand here precisely because no caller can build one.
+        let wrong = AppendOnlyVerified {
+            from_epoch: 0,
+            to_epoch: 9,
+            to_root: Digest::new([0u8; 32]),
+        };
+        assert_eq!(state.advance(&heads, &wrong), Err(KtError::Malformed));
+        assert_eq!(state.view().epoch(), 0);
+
+        let right = AppendOnlyVerified {
+            from_epoch: 0,
+            to_epoch: 2,
+            to_root: log.head(2).sth.root_hash,
+        };
+        assert!(state.advance(&heads, &right).is_ok());
+        assert_eq!(state.view().epoch(), 2);
+    }
+
+    #[test]
+    fn a_halted_witness_stays_halted() {
+        let log = TestLog::new();
+        let view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+        let mut state = WitnessState::new(view);
+
+        // §6.3 rule 7: epoch 2 chains to epoch 1, which this witness has never
+        // seen. The append-only proof could be perfect and the head correctly
+        // signed; a gap is still refused, because a gap accepted on trust is a
+        // branch accepted on trust.
+        let heads = [log.head(0), log.head(2)];
+        let token = AppendOnlyVerified {
+            from_epoch: 0,
+            to_epoch: 2,
+            to_root: log.head(2).sth.root_hash,
+        };
+        assert_eq!(state.advance(&heads, &token), Err(KtError::EpochGap));
+        assert_eq!(state.halted(), Some(FaultKind::ChainBreak));
+
+        // §7.1: "A witness MUST NOT catch up past a fault." Once halted it stays
+        // halted until a human looks at the evidence — an automatic resync is an
+        // automatic way to erase the only record of the thing the witness exists
+        // to find.
+        let honest = [log.head(0), log.head(1)];
+        let token = AppendOnlyVerified {
+            from_epoch: 0,
+            to_epoch: 1,
+            to_root: log.head(1).sth.root_hash,
+        };
+        assert_eq!(state.advance(&honest, &token), Err(KtError::ChainBreak));
+        assert_eq!(state.view().epoch(), 0);
+    }
+
+    #[test]
+    fn halting_is_recorded_once() {
+        let log = TestLog::new();
+        let view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+        let mut state = WitnessState::new(view);
+        state.halt(FaultKind::MergeDelayExceeded);
+        state.halt(FaultKind::Fork);
+        assert_eq!(state.halted(), Some(FaultKind::MergeDelayExceeded));
+    }
+
+    #[test]
+    fn a_proof_whose_epochs_are_not_ours_is_refused() {
+        // Not a cryptographic check — `audit_verify` would run happily — but a
+        // proof for another range that happens to match root hashes would
+        // otherwise pass. Empty proof bytes stand in for "any proof at all"
+        // because the epoch check runs before verification.
+        let log = TestLog::new();
+        let heads = [log.head(0), log.head(1)];
+        let result = futures_block_on(verify_append_only(&heads, &[]));
+        assert_eq!(result, Err(KtError::Malformed));
+    }
+
+    /// A one-poll executor.
+    ///
+    /// `audit_verify` is `async` only because `akd`'s storage trait is; the
+    /// auditor itself awaits nothing that can pend, so a test does not need a
+    /// runtime and this crate does not depend on one. `Waker::noop` is the safe
+    /// constructor, which matters because the crate forbids unsafe code.
+    fn futures_block_on<F: core::future::Future>(future: F) -> F::Output {
+        use core::task::{Context, Poll, Waker};
+        let mut context = Context::from_waker(Waker::noop());
+        let mut pinned = core::pin::pin!(future);
+        match pinned.as_mut().poll(&mut context) {
+            Poll::Ready(value) => value,
+            Poll::Pending => unreachable!("akd's auditor awaits nothing that can pend"),
+        }
+    }
+}

--- a/rs/crates/f2z-kt-core/src/cosign.rs
+++ b/rs/crates/f2z-kt-core/src/cosign.rs
@@ -1,0 +1,263 @@
+//! `WitnessCosignature` — `KT.md` §7.2.
+//!
+//! **It signs the contents — `log_id`, `epoch`, `tree_size`, `root_hash` — and
+//! not the log's signature over them.** Three consequences, and the design is
+//! chosen for all three:
+//!
+//! 1. **The statement is verifiable by someone who never saw the log's
+//!    signature**, and who does not have or trust the log's public key.
+//!    "Witness W says the log with id L had root R at epoch E with size S" is a
+//!    complete, checkable claim from the cosignature bytes and W's public key
+//!    alone. A cosignature over the log's signature bytes would be meaningless
+//!    without first obtaining the log's signature *and* its key, from the very
+//!    party under suspicion.
+//! 2. **Two conflicting statements are directly non-repudiable against the
+//!    witness** — see [`WitnessCosignature::contradicts`]. No third document is
+//!    needed to establish the contradiction. That is what makes a witness
+//!    accountable rather than merely helpful.
+//! 3. **`witness_pk` is inside the signed bytes**, so a cosignature cannot be
+//!    re-attributed to another witness, and a witness cannot later claim a
+//!    cosignature was someone else's.
+//!
+//! # What a cosignature does not say
+//!
+//! It does not say the witness verified the append-only proof (§7.4). It does
+//! not say the root is *correct*, only that this witness saw it and that its own
+//! history is consistent with it. And a witness that never cosigns at all is
+//! indistinguishable from one that is offline; absence is not evidence.
+
+use f2z_codec::canonical::encode;
+use f2z_codec::types::{Digest, PublicKey, ShortBytes, Signature};
+use tls_codec::{TlsDeserializeBytes, TlsSerializeBytes, TlsSize};
+
+use crate::KT_VERSION;
+use crate::error::KtError;
+use crate::labels::LABEL_COSIG;
+use crate::sig;
+use crate::sth::SignedTreeHead;
+use crate::types::{LogId, check_label, label_field};
+
+/// The `WitnessCosignatureTBS` of §7.2.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct WitnessCosignatureTBS {
+    /// Exactly `"free2z/kt/v1/cosig"`.
+    pub label: ShortBytes,
+    /// `0x0001`.
+    pub kt_version: u16,
+    /// The log observed.
+    pub log_id: LogId,
+    /// The epoch observed.
+    pub epoch: u64,
+    /// The tree size at that epoch.
+    pub tree_size: u64,
+    /// The root at that epoch.
+    pub root_hash: Digest,
+    /// The witness making the statement. **Inside** the signed bytes, so the
+    /// statement cannot be re-attributed.
+    pub witness_pk: PublicKey,
+    /// When the witness saw it. Deliberately **excluded** from the
+    /// contradiction test — see [`WitnessCosignature::contradicts`].
+    pub observed_at_ms: u64,
+}
+
+impl WitnessCosignatureTBS {
+    /// Check the constants a decoder cannot.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`] or [`KtError::UnsupportedVersion`].
+    pub fn validate(&self) -> Result<(), KtError> {
+        check_label(&self.label, LABEL_COSIG)?;
+        if self.kt_version != KT_VERSION {
+            return Err(KtError::UnsupportedVersion);
+        }
+        Ok(())
+    }
+
+    /// The exact bytes the witness signs.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
+        encode(self).map_err(KtError::from)
+    }
+
+    /// Build the `label` field for a cosignature.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the constant does not fit, which it does.
+    pub fn label_bytes() -> Result<ShortBytes, KtError> {
+        label_field(LABEL_COSIG)
+    }
+}
+
+/// A `WitnessCosignature` (§7.2).
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct WitnessCosignature {
+    /// The signed statement.
+    pub statement: WitnessCosignatureTBS,
+    /// Ed25519 by `statement.witness_pk`.
+    pub signature: Signature,
+}
+
+impl WitnessCosignature {
+    /// Verify the signature under the `witness_pk` inside the statement.
+    ///
+    /// Note there is no key parameter: the key is in the signed bytes, and a
+    /// caller who could supply a different one could re-attribute the statement.
+    /// Whether that key is a witness the caller *trusts* is
+    /// [`crate::witness::verify_threshold`]'s question, not this one's.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`], [`KtError::UnsupportedVersion`] or
+    /// [`KtError::BadSignature`].
+    pub fn verify(&self) -> Result<(), KtError> {
+        self.statement.validate()?;
+        sig::verify(
+            &self.statement.witness_pk,
+            &self.statement.signing_bytes()?,
+            &self.signature,
+        )
+    }
+
+    /// Whether this cosignature is **about** the tree head `head` — the same
+    /// `(log_id, epoch, tree_size, root_hash)`.
+    ///
+    /// §8.3 requires cosignatures over *exactly* this tuple. A cosignature that
+    /// agrees on the epoch and disagrees on the root is not a weaker
+    /// endorsement of the head; it is a different statement, and counting it
+    /// would be counting a witness's contradiction as its support.
+    #[must_use]
+    pub fn covers(&self, head: &SignedTreeHead) -> bool {
+        self.statement.log_id == head.sth.log_id
+            && self.statement.epoch == head.sth.epoch
+            && self.statement.tree_size == head.sth.tree_size
+            && self.statement.root_hash == head.sth.root_hash
+    }
+
+    /// Whether these two cosignatures are a contradiction on their face (§7.2).
+    ///
+    /// The test is exactly `(log_id, epoch)` equal and `(tree_size, root_hash)`
+    /// differing. **`observed_at_ms` is deliberately excluded**: two
+    /// cosignatures over the same root at different times are not a conflict,
+    /// they are normal — a witness re-serving its history, or two clients
+    /// fetching it at different moments.
+    ///
+    /// This returns `false` when the two are by different witnesses. Two
+    /// witnesses disagreeing about an epoch is evidence against the **log**, not
+    /// against either witness, and is [`KtError::Fork`]'s business; the
+    /// non-repudiation §7.2 claims is specifically that *one* witness signed two
+    /// contradictory statements, which is a fault of that witness and needs no
+    /// third document to establish.
+    #[must_use]
+    pub fn contradicts(&self, other: &Self) -> bool {
+        self.statement.witness_pk == other.statement.witness_pk
+            && self.statement.log_id == other.statement.log_id
+            && self.statement.epoch == other.statement.epoch
+            && (self.statement.tree_size != other.statement.tree_size
+                || self.statement.root_hash != other.statement.root_hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TestLog;
+    use f2z_codec::canonical::{Canonical as _, decode_canonical};
+
+    #[test]
+    fn a_cosignature_round_trips_and_verifies_from_its_own_bytes() {
+        let log = TestLog::new();
+        let head = log.head(4);
+        let cosig = log.cosign(&head, 1, 1_700_000_000_000);
+        assert_eq!(cosig.verify(), Ok(()));
+        assert!(cosig.covers(&head));
+
+        let bytes = cosig.encode_canonical().unwrap();
+        let decoded = decode_canonical::<WitnessCosignature>(&bytes).unwrap();
+        assert_eq!(decoded.value(), &cosig);
+        assert_eq!(decoded.value().verify(), Ok(()));
+    }
+
+    #[test]
+    fn a_cosignature_cannot_be_reattributed() {
+        let log = TestLog::new();
+        let head = log.head(4);
+        let mut cosig = log.cosign(&head, 1, 1);
+        cosig.statement.witness_pk = PublicKey::new([7u8; 32]);
+        assert_eq!(
+            cosig.verify(),
+            Err(KtError::BadSignature),
+            "witness_pk is inside the signed bytes",
+        );
+    }
+
+    #[test]
+    fn covers_is_exact_on_all_four_fields() {
+        let log = TestLog::new();
+        let head = log.head(4);
+        let cosig = log.cosign(&head, 1, 1);
+
+        let mut other = head.clone();
+        other.sth.root_hash = Digest::new([1u8; 32]);
+        assert!(!cosig.covers(&other));
+
+        let mut other = head.clone();
+        other.sth.tree_size = head.sth.tree_size.saturating_add(1);
+        assert!(!cosig.covers(&other));
+
+        let mut other = head.clone();
+        other.sth.epoch = head.sth.epoch.saturating_add(1);
+        assert!(!cosig.covers(&other));
+
+        let mut other = head;
+        other.sth.log_id = LogId::new([9u8; 32]);
+        assert!(!cosig.covers(&other));
+    }
+
+    #[test]
+    fn two_roots_for_one_epoch_by_one_witness_are_non_repudiable() {
+        let log = TestLog::new();
+        let head = log.head(4);
+        let mut forked = head.clone();
+        forked.sth.root_hash = Digest::new([0xaa; 32]);
+        let forked = log.resign(forked);
+
+        let a = log.cosign(&head, 1, 1_700_000_000_000);
+        let b = log.cosign(&forked, 1, 1_700_000_100_000);
+        assert!(a.contradicts(&b));
+        assert!(b.contradicts(&a));
+        // Both verify. That is the point: the contradiction needs no third
+        // document, only the two cosignatures and the witness's public key.
+        assert_eq!(a.verify(), Ok(()));
+        assert_eq!(b.verify(), Ok(()));
+    }
+
+    #[test]
+    fn the_same_root_at_two_times_is_not_a_contradiction() {
+        let log = TestLog::new();
+        let head = log.head(4);
+        let a = log.cosign(&head, 1, 1_700_000_000_000);
+        let b = log.cosign(&head, 1, 1_700_009_999_999);
+        assert!(
+            !a.contradicts(&b),
+            "observed_at_ms is excluded from the test on purpose",
+        );
+    }
+
+    #[test]
+    fn two_witnesses_disagreeing_is_not_one_witness_contradicting_itself() {
+        let log = TestLog::new();
+        let head = log.head(4);
+        let mut forked = head.clone();
+        forked.sth.root_hash = Digest::new([0xbb; 32]);
+        let forked = log.resign(forked);
+
+        let a = log.cosign(&head, 1, 1);
+        let b = log.cosign(&forked, 2, 1);
+        assert!(!a.contradicts(&b), "that is evidence against the log");
+    }
+}

--- a/rs/crates/f2z-kt-core/src/descriptor.rs
+++ b/rs/crates/f2z-kt-core/src/descriptor.rs
@@ -1,0 +1,209 @@
+//! `LogDescriptor` — `KT.md` §9.1, a log's entire externally-relevant policy in
+//! one signed document that a human can read before trusting it.
+//!
+//! `reset_authority_pk` being published here does **not** discharge ADR 0014's
+//! requirement that it be **pinned in clients**. A reset authority key a client
+//! learns from the log is a key the log chooses, which is no authority at all.
+//! The published copy exists so a human can compare it against the pinned one,
+//! which is why [`LogDescriptor::matches_pinned_reset_authority`] takes the
+//! pinned key as an argument and why nothing in this crate ever reads
+//! `reset_authority_pk` out of a descriptor to verify with.
+
+use f2z_codec::canonical::encode;
+use f2z_codec::types::{PublicKey, ShortBytes, Signature};
+use f2z_codec::vec::VecU8;
+use tls_codec::{TlsDeserializeBytes, TlsSerializeBytes, TlsSize};
+
+use crate::KT_VERSION;
+use crate::error::KtError;
+use crate::labels::log_id as derive_log_id;
+use crate::sig;
+use crate::types::LogId;
+
+/// The `akd` configuration a log is built on (§3.2).
+///
+/// **The choice is not changeable later.** The configuration determines every
+/// label and every commitment in the tree, so changing it invalidates every
+/// proof ever issued and every root ever cosigned. Migrating means standing up a
+/// new log with a new `log_id` and having clients re-pin, which is a
+/// distinguishable event and not a silent upgrade.
+pub const CONFIGURATION_WHATSAPP_V1: u8 = 1;
+
+/// The `LogDescriptor` of §9.1.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct LogDescriptor {
+    /// The `kt_version`s this log serves.
+    pub kt_versions: VecU8<u16>,
+    /// `H("free2z/kt/v1/log-id", genesis_log_pk)`.
+    pub log_id: LogId,
+    /// The key currently signing tree heads (§6.4 for succession).
+    pub log_signing_pk: PublicKey,
+    /// The key `log_id` is derived from, forever.
+    pub genesis_log_pk: PublicKey,
+    /// The ECVRF key labels are derived under.
+    pub vrf_public_key: PublicKey,
+    /// [`CONFIGURATION_WHATSAPP_V1`].
+    pub configuration: u8,
+    /// The published cadence (§5.1).
+    pub epoch_interval_seconds: u32,
+    /// The published merge promise (§5.2).
+    pub max_merge_delay_seconds: u32,
+    /// ADR 0014's reset cooldown.
+    pub reset_cooldown_seconds: u32,
+    /// The reset authority key, published for comparison against the **pinned**
+    /// one and for no other purpose.
+    pub reset_authority_pk: PublicKey,
+    /// Who runs this log.
+    pub operator_name: ShortBytes,
+    /// How to reach them.
+    pub operator_contact: ShortBytes,
+    /// Under whose law they operate.
+    pub operator_jurisdiction: ShortBytes,
+    /// Their published policy.
+    pub operator_policy_url: ShortBytes,
+    /// Where the code is.
+    pub source_repo_url: ShortBytes,
+    /// Which commit is deployed.
+    pub source_commit: ShortBytes,
+    /// The reproducible-build digest of that commit.
+    pub build_digest: ShortBytes,
+    /// When this descriptor was published.
+    pub published_at_ms: u64,
+}
+
+impl LogDescriptor {
+    /// Check the invariants a decoder cannot.
+    ///
+    /// # Errors
+    ///
+    /// - [`KtError::UnsupportedVersion`] if this build's [`KT_VERSION`] is not
+    ///   among `kt_versions`.
+    /// - [`KtError::WrongLog`] if `log_id` is not the digest of
+    ///   `genesis_log_pk` — a log that publishes an unrelated pair is claiming
+    ///   an identity it cannot derive.
+    /// - [`KtError::Malformed`] if `configuration` is not
+    ///   [`CONFIGURATION_WHATSAPP_V1`].
+    pub fn validate(&self) -> Result<(), KtError> {
+        if !self.kt_versions.as_slice().contains(&KT_VERSION) {
+            return Err(KtError::UnsupportedVersion);
+        }
+        if self.log_id != derive_log_id(&self.genesis_log_pk) {
+            return Err(KtError::WrongLog);
+        }
+        // §3.2 fixes WhatsAppV1 and calls the choice permanent. A descriptor
+        // announcing anything else is announcing a tree whose labels and
+        // commitments this build cannot verify, so it is refused rather than
+        // ignored.
+        if self.configuration != CONFIGURATION_WHATSAPP_V1 {
+            return Err(KtError::Malformed);
+        }
+        Ok(())
+    }
+
+    /// Whether the published reset authority key equals the one the client has
+    /// **pinned** (ADR 0014).
+    ///
+    /// A `false` here is not a decode failure and not necessarily an attack — a
+    /// reset authority key rotation is §12's named open gap, and there is no
+    /// specified path for one. It is a fact a human must be shown.
+    #[must_use]
+    pub fn matches_pinned_reset_authority(&self, pinned: &PublicKey) -> bool {
+        self.reset_authority_pk == *pinned
+    }
+
+    /// The exact bytes the log signs.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
+        encode(self).map_err(KtError::from)
+    }
+}
+
+/// A `SignedLogDescriptor` (§9.1).
+///
+/// Served at `GET /.well-known/free2z-kt/v1/log` as `tls_codec` bytes **and** as
+/// JSON with the same values and the same signature. Nothing forces the two
+/// representations to agree except the operator; what makes divergence costly is
+/// that both are signed by the same key.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct SignedLogDescriptor {
+    /// The signed policy.
+    pub descriptor: LogDescriptor,
+    /// Ed25519 by `descriptor.log_signing_pk`.
+    pub signature: Signature,
+}
+
+impl SignedLogDescriptor {
+    /// Verify the descriptor's shape and the log's signature over it.
+    ///
+    /// # Errors
+    ///
+    /// As [`LogDescriptor::validate`], plus [`KtError::BadSignature`].
+    pub fn verify(&self) -> Result<(), KtError> {
+        self.descriptor.validate()?;
+        sig::verify(
+            &self.descriptor.log_signing_pk,
+            &self.descriptor.signing_bytes()?,
+            &self.signature,
+        )
+    }
+
+    /// The `log_id` a client should pin from this descriptor.
+    ///
+    /// Derived from `genesis_log_pk` rather than read out of the `log_id` field,
+    /// so a descriptor whose two fields disagree cannot install the field's
+    /// value. [`LogDescriptor::validate`] already refuses that case; deriving
+    /// here means the refusal is not the only thing standing between the two.
+    #[must_use]
+    pub fn derived_log_id(&self) -> LogId {
+        derive_log_id(&self.descriptor.genesis_log_pk)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TestLog;
+
+    #[test]
+    fn a_descriptor_verifies_and_derives_its_own_log_id() {
+        let log = TestLog::new();
+        let descriptor = log.descriptor();
+        assert_eq!(descriptor.verify(), Ok(()));
+        assert_eq!(&descriptor.derived_log_id(), log.log_id());
+    }
+
+    #[test]
+    fn a_log_id_that_is_not_the_digest_of_the_genesis_key_is_refused() {
+        let log = TestLog::new();
+        let mut descriptor = log.descriptor();
+        descriptor.descriptor.log_id = LogId::new([1u8; 32]);
+        assert_eq!(descriptor.descriptor.validate(), Err(KtError::WrongLog));
+    }
+
+    #[test]
+    fn an_experimental_configuration_is_refused() {
+        let log = TestLog::new();
+        let mut descriptor = log.descriptor();
+        descriptor.descriptor.configuration = 2;
+        assert_eq!(descriptor.descriptor.validate(), Err(KtError::Malformed));
+    }
+
+    #[test]
+    fn the_published_reset_authority_is_compared_never_trusted() {
+        let log = TestLog::new();
+        let descriptor = log.descriptor();
+        assert!(
+            descriptor
+                .descriptor
+                .matches_pinned_reset_authority(log.reset_authority_pk())
+        );
+        assert!(
+            !descriptor
+                .descriptor
+                .matches_pinned_reset_authority(&PublicKey::new([2u8; 32]))
+        );
+    }
+}

--- a/rs/crates/f2z-kt-core/src/entry.rs
+++ b/rs/crates/f2z-kt-core/src/entry.rs
@@ -1,0 +1,767 @@
+//! `DirectoryEntry` and everything that authorizes one — `KT.md` §4.
+//!
+//! This module holds the **shapes**. The rules that decide whether a shape may
+//! enter the log live in [`crate::submit`], and they are not reachable from
+//! here: nothing in this module verifies a signature, and no `validate` below
+//! does more than check the constants, charsets and ranges a `tls_codec` decode
+//! cannot express.
+//!
+//! That separation is deliberate and it is the whole architecture of the crate.
+//! §4.4's rules are the only thing standing between `akd` and an entry nobody
+//! authorized, so they must be impossible to satisfy by accident — which means
+//! they cannot be a method on the type a caller already holds.
+//!
+//! # `DeviceCredential` repeats itself on purpose
+//!
+//! It carries `identity_pk` and `handle` that the enclosing entry also carries
+//! (§4.1). It is the MLS `Credential` in a member's `LeafNode`
+//! (`ARCHITECTURE.md` §4.2), validated by peers who have no directory access at
+//! all, so it cannot depend on its envelope for meaning. Deduplicating those two
+//! fields would save 40 bytes and break the only property that makes the
+//! structure useful outside the directory.
+
+use f2z_codec::canonical::{Canonical as _, encode};
+use f2z_codec::types::{Digest, PublicKey, QueueAddress, RelayId, ShortBytes, Signature};
+use f2z_codec::vec::VecU16;
+use tls_codec::{
+    DeserializeBytes, Error as TlsError, SerializeBytes, Size, TlsDeserializeBytes,
+    TlsSerializeBytes, TlsSize,
+};
+
+use crate::KT_VERSION;
+use crate::error::KtError;
+use crate::labels::{
+    LABEL_DEVICE_CREDENTIAL, LABEL_ENTRY, LABEL_RESET, LABEL_ROTATION, prev_entry_hash,
+};
+use crate::types::{Handle, KemPublicKey, LogId, check_label, label_field};
+
+/// The `DeviceCredentialTBS` of §4.1 — what the user's `IdentitySigningKey`
+/// signs.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct DeviceCredentialTBS {
+    /// Exactly `"free2z/device-credential/v1"`.
+    pub label: ShortBytes,
+    /// `ISK.public` (`ARCHITECTURE.md` §4.2).
+    pub identity_pk: PublicKey,
+    /// The handle this device speaks for.
+    pub handle: Handle,
+    /// `DSK.public`, the MLS leaf `signature_key`.
+    pub device_pk: PublicKey,
+    /// X-Wing hybrid (X25519 + ML-KEM-768).
+    pub device_kem_pk: KemPublicKey,
+    /// Validity start, milliseconds since the Unix epoch.
+    pub not_before_ms: u64,
+    /// Validity end, milliseconds since the Unix epoch.
+    pub not_after_ms: u64,
+}
+
+impl DeviceCredentialTBS {
+    /// Check the invariants a decoder cannot express.
+    ///
+    /// # Errors
+    ///
+    /// - [`KtError::WrongLabel`] if `label` is not the §6.2 constant.
+    /// - [`KtError::BadHandle`] if `handle` is outside `[a-z0-9_]{1,30}`.
+    /// - [`KtError::Malformed`] if `device_kem_pk` is empty (`<1..2^16-1>`) or
+    ///   the validity window is inverted.
+    pub fn validate(&self) -> Result<(), KtError> {
+        check_label(&self.label, LABEL_DEVICE_CREDENTIAL)?;
+        self.handle.validate()?;
+        if self.device_kem_pk.is_empty() {
+            return Err(KtError::Malformed);
+        }
+        // Invented here: §4.1 gives the two fields and no ordering rule. A
+        // credential whose window is empty or inverted can never be valid at any
+        // instant, so accepting one would put a permanently-dead credential in an
+        // append-only record. `not_after_ms == not_before_ms` is refused too: an
+        // instantaneous credential is not a credential.
+        if self.not_after_ms <= self.not_before_ms {
+            return Err(KtError::Malformed);
+        }
+        Ok(())
+    }
+
+    /// The exact bytes the `IdentitySigningKey` signs.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
+        encode(self).map_err(KtError::from)
+    }
+}
+
+/// A `DeviceCredential` (§4.1): the signed binding of an identity key to a
+/// device key.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct DeviceCredential {
+    /// The signed contents.
+    pub credential: DeviceCredentialTBS,
+    /// Ed25519 by `credential.identity_pk`.
+    pub signature: Signature,
+}
+
+/// A published device revocation (§4.1).
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct DeviceRevocation {
+    /// The `DSK.public` being revoked.
+    pub device_pk: PublicKey,
+    /// When, by the submitter's clock.
+    pub revoked_at_ms: u64,
+    /// Human-readable, advisory, **never parsed**.
+    pub reason: ShortBytes,
+}
+
+/// A contact endpoint (§4.1): where first contact for this handle is delivered.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct ContactEndpoint {
+    /// `wss://…/relay/v1`.
+    pub relay_url: ShortBytes,
+    /// `WIRE.md` §5.2.
+    pub relay_id: RelayId,
+    /// `WIRE.md` §12.2.
+    pub contact_addr: QueueAddress,
+}
+
+impl ContactEndpoint {
+    /// Check the one invariant a decoder cannot: `relay_url` is `<1..255>`.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if `relay_url` is empty.
+    pub fn validate(&self) -> Result<(), KtError> {
+        if self.relay_url.is_empty() {
+            return Err(KtError::Malformed);
+        }
+        Ok(())
+    }
+}
+
+/// What kind of change an entry makes (§4.1), and therefore what authorizes it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum EntryKind {
+    /// Adding or revoking a device, or updating contact endpoints. The identity
+    /// key is unchanged (ADR 0014 case 1).
+    SameKey,
+    /// Rotating to a new identity key while still holding the old one
+    /// (ADR 0014 case 2).
+    KeyChange,
+    /// A platform-authority reset, for a user who cannot sign with the outgoing
+    /// key at all (ADR 0014 case 3).
+    PlatformReset,
+}
+
+impl EntryKind {
+    /// Every kind, in wire order.
+    pub const ALL: [Self; 3] = [Self::SameKey, Self::KeyChange, Self::PlatformReset];
+
+    /// The wire value.
+    #[must_use]
+    pub const fn code(self) -> u8 {
+        match self {
+            Self::SameKey => 1,
+            Self::KeyChange => 2,
+            Self::PlatformReset => 3,
+        }
+    }
+
+    /// The kind this build knows by that value.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] for anything else. Note this is **not** the
+    /// forgiving treatment `WIRE.md` §10 gives an unknown *error code*: an
+    /// unknown `EntryKind` is a variant whose authorization rule this build does
+    /// not know, and mapping it to a default is exactly the silent-variant
+    /// hazard the re-encode-equality rule exists to forbid.
+    pub const fn from_code(code: u8) -> Result<Self, KtError> {
+        Ok(match code {
+            1 => Self::SameKey,
+            2 => Self::KeyChange,
+            3 => Self::PlatformReset,
+            _ => return Err(KtError::Malformed),
+        })
+    }
+}
+
+impl Size for EntryKind {
+    fn tls_serialized_len(&self) -> usize {
+        1
+    }
+}
+
+impl SerializeBytes for EntryKind {
+    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        Ok(vec![self.code()])
+    }
+}
+
+impl DeserializeBytes for EntryKind {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (code, rest) = u8::tls_deserialize_bytes(bytes)?;
+        let kind = Self::from_code(code).map_err(|_| {
+            TlsError::DecodingError(format!(
+                "EntryKind {code} is not one of same_key(1), key_change(2), platform_reset(3)"
+            ))
+        })?;
+        Ok((kind, rest))
+    }
+}
+
+/// The `RotationProofTBS` of §4.4 — signed by the **outgoing** identity key.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct RotationProofTBS {
+    /// Exactly `"free2z/kt/v1/rotation"`.
+    pub label: ShortBytes,
+    /// The log this proof is valid at.
+    pub log_id: LogId,
+    /// The handle being rotated.
+    pub handle: Handle,
+    /// The version this proof authorizes.
+    pub entry_version: u32,
+    /// The identity key in force before the rotation.
+    pub old_identity_pk: PublicKey,
+    /// The identity key in force after it.
+    pub new_identity_pk: PublicKey,
+    /// The hash of the previous entry, binding this proof to one history.
+    pub prev_entry_hash: Digest,
+    /// Submitter's clock. Authenticated, and not trustworthy (§4.2).
+    pub created_at_ms: u64,
+}
+
+impl RotationProofTBS {
+    /// Check the constants and charsets.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`] or [`KtError::BadHandle`].
+    pub fn validate(&self) -> Result<(), KtError> {
+        check_label(&self.label, LABEL_ROTATION)?;
+        self.handle.validate()
+    }
+
+    /// The exact bytes the outgoing `IdentitySigningKey` signs.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
+        encode(self).map_err(KtError::from)
+    }
+}
+
+/// A `RotationProof` (§4.4).
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct RotationProof {
+    /// The signed contents.
+    pub proof: RotationProofTBS,
+    /// Ed25519 by `proof.old_identity_pk`.
+    pub signature: Signature,
+}
+
+/// The `ResetAuthorizationTBS` of §4.4 — signed by the pinned reset authority.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct ResetAuthorizationTBS {
+    /// Exactly `"free2z/kt/v1/reset"`.
+    pub label: ShortBytes,
+    /// The log this authorization is valid at.
+    pub log_id: LogId,
+    /// The handle being reset.
+    pub handle: Handle,
+    /// The version this authorization covers.
+    pub entry_version: u32,
+    /// The identity key being displaced.
+    pub old_identity_pk: PublicKey,
+    /// The identity key being installed.
+    pub new_identity_pk: PublicKey,
+    /// When the authority signed.
+    pub created_at_ms: u64,
+    /// `>= created_at_ms + cooldown` (ADR 0014). The log MUST NOT publish the
+    /// entry before this instant.
+    pub effective_at_ms: u64,
+}
+
+impl ResetAuthorizationTBS {
+    /// Check the constants and charsets.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`] or [`KtError::BadHandle`].
+    pub fn validate(&self) -> Result<(), KtError> {
+        check_label(&self.label, LABEL_RESET)?;
+        self.handle.validate()
+    }
+
+    /// The exact bytes the reset authority signs.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
+        encode(self).map_err(KtError::from)
+    }
+}
+
+/// A `ResetAuthorization` (§4.4).
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct ResetAuthorization {
+    /// The signed contents.
+    pub reset: ResetAuthorizationTBS,
+    /// Ed25519 by the **pinned** reset authority key. A reset authority key a
+    /// client learns from the log is a key the log chooses, which is no
+    /// authority at all (§9.1).
+    pub reset_signature: Signature,
+}
+
+/// What authorizes an entry (§4.4).
+///
+/// The `select (EntryAuthorization.kind)` of §4.4, as a Rust enum. The wire
+/// encoding is `kind` as one byte followed by the selected body, and the
+/// `tls_codec` traits are hand-written because the presentation language's
+/// discriminated union has no derive.
+///
+/// **A key change carries two signatures and neither alone is sufficient**
+/// (ADR 0014). That is why [`EntryAuthorization::KeyChange`] has no constructor
+/// that omits the `RotationProof`: the outgoing signature stops the log operator
+/// from swapping a key, and the incoming signature stops a stolen or
+/// mis-transcribed new key from being installed without proof of possession.
+/// Neither is optional, and there is no representation of a key change carrying
+/// only one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EntryAuthorization {
+    /// `same_key`: one signature, by the `directory_auth_pk` **published in the
+    /// previous entry**.
+    SameKey {
+        /// Ed25519 over `tls_codec(DirectoryEntryTBS)`.
+        auth_signature: Signature,
+    },
+    /// `key_change`: a `RotationProof` by the outgoing ISK, **plus** a signature
+    /// by the `directory_auth_pk` in **this** entry.
+    KeyChange {
+        /// Signed by the outgoing `identity_pk`.
+        rotation: RotationProof,
+        /// Ed25519 over `tls_codec(DirectoryEntryTBS)` by the new
+        /// `directory_auth_pk`.
+        auth_signature: Signature,
+    },
+    /// `platform_reset`: a `ResetAuthorization` by the pinned reset authority,
+    /// **plus** a signature by the `directory_auth_pk` in this entry.
+    PlatformReset {
+        /// Signed by the pinned reset authority key.
+        reset: ResetAuthorization,
+        /// Ed25519 over `tls_codec(DirectoryEntryTBS)`.
+        auth_signature: Signature,
+    },
+}
+
+impl EntryAuthorization {
+    /// The `kind` this authorization is for. §4.4 requires it to equal
+    /// `entry.kind`.
+    #[must_use]
+    pub const fn kind(&self) -> EntryKind {
+        match self {
+            Self::SameKey { .. } => EntryKind::SameKey,
+            Self::KeyChange { .. } => EntryKind::KeyChange,
+            Self::PlatformReset { .. } => EntryKind::PlatformReset,
+        }
+    }
+
+    /// The signature over `tls_codec(DirectoryEntryTBS)`, whichever variant.
+    #[must_use]
+    pub const fn auth_signature(&self) -> &Signature {
+        match self {
+            Self::SameKey { auth_signature }
+            | Self::KeyChange { auth_signature, .. }
+            | Self::PlatformReset { auth_signature, .. } => auth_signature,
+        }
+    }
+}
+
+impl Size for EntryAuthorization {
+    fn tls_serialized_len(&self) -> usize {
+        let body = match self {
+            Self::SameKey { auth_signature } => auth_signature.tls_serialized_len(),
+            Self::KeyChange {
+                rotation,
+                auth_signature,
+            } => rotation
+                .tls_serialized_len()
+                .saturating_add(auth_signature.tls_serialized_len()),
+            Self::PlatformReset {
+                reset,
+                auth_signature,
+            } => reset
+                .tls_serialized_len()
+                .saturating_add(auth_signature.tls_serialized_len()),
+        };
+        body.saturating_add(1)
+    }
+}
+
+impl SerializeBytes for EntryAuthorization {
+    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        let mut out = vec![self.kind().code()];
+        match self {
+            Self::SameKey { auth_signature } => {
+                out.extend_from_slice(&auth_signature.tls_serialize()?);
+            }
+            Self::KeyChange {
+                rotation,
+                auth_signature,
+            } => {
+                out.extend_from_slice(&rotation.tls_serialize()?);
+                out.extend_from_slice(&auth_signature.tls_serialize()?);
+            }
+            Self::PlatformReset {
+                reset,
+                auth_signature,
+            } => {
+                out.extend_from_slice(&reset.tls_serialize()?);
+                out.extend_from_slice(&auth_signature.tls_serialize()?);
+            }
+        }
+        Ok(out)
+    }
+}
+
+impl DeserializeBytes for EntryAuthorization {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (kind, rest) = EntryKind::tls_deserialize_bytes(bytes)?;
+        match kind {
+            EntryKind::SameKey => {
+                let (auth_signature, rest) = Signature::tls_deserialize_bytes(rest)?;
+                Ok((Self::SameKey { auth_signature }, rest))
+            }
+            EntryKind::KeyChange => {
+                let (rotation, rest) = RotationProof::tls_deserialize_bytes(rest)?;
+                let (auth_signature, rest) = Signature::tls_deserialize_bytes(rest)?;
+                Ok((
+                    Self::KeyChange {
+                        rotation,
+                        auth_signature,
+                    },
+                    rest,
+                ))
+            }
+            EntryKind::PlatformReset => {
+                let (reset, rest) = ResetAuthorization::tls_deserialize_bytes(rest)?;
+                let (auth_signature, rest) = Signature::tls_deserialize_bytes(rest)?;
+                Ok((
+                    Self::PlatformReset {
+                        reset,
+                        auth_signature,
+                    },
+                    rest,
+                ))
+            }
+        }
+    }
+}
+
+/// The `DirectoryEntryTBS` of §4.1 — what the user's `DirectoryAuthKey` signs.
+///
+/// Note what is **not** in it: no display name, no avatar, no profile field, no
+/// relay list beyond contact endpoints, and no `KeyPackage`. A directory entry
+/// is an append-only public record that every peer of the user will fetch; every
+/// field added to it is a field published forever about everyone.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct DirectoryEntryTBS {
+    /// Exactly `"free2z/kt/v1/entry"`.
+    pub label: ShortBytes,
+    /// `0x0001`.
+    pub kt_version: u16,
+    /// The log this entry belongs to (§6.1).
+    pub log_id: LogId,
+    /// The handle.
+    pub handle: Handle,
+    /// The `akd` version for this label; starts at 1 and increases by exactly 1
+    /// (§4.2).
+    pub entry_version: u32,
+    /// What kind of change this is, and therefore what must authorize it.
+    pub kind: EntryKind,
+    /// `ISK.public` in force from here on.
+    pub identity_pk: PublicKey,
+    /// `DirectoryAuthKey.public` in force from here on (§4.4).
+    pub directory_auth_pk: PublicKey,
+    /// The device credentials in force.
+    pub devices: VecU16<DeviceCredential>,
+    /// The revocations published so far.
+    pub revocations: VecU16<DeviceRevocation>,
+    /// Where first contact is delivered.
+    pub contact_endpoints: VecU16<ContactEndpoint>,
+    /// `H("free2z/kt/v1/prev", tls_codec(previous DirectoryEntry))`; all-zero at
+    /// `entry_version` 1 (§4.2).
+    pub prev_entry_hash: Digest,
+    /// ADR 0014's opt-out: 1 means the platform reset path does not apply to
+    /// this handle, ever.
+    pub no_reset: u8,
+    /// The **submitter's** clock. Signed, therefore authenticated; not
+    /// trustworthy. Ordering is established by `entry_version` and by the epoch
+    /// the entry appears in, never by this field (§4.2).
+    pub created_at_ms: u64,
+}
+
+impl DirectoryEntryTBS {
+    /// Check every invariant a `tls_codec` decode cannot express.
+    ///
+    /// This is shape only. It says nothing about whether the entry is
+    /// **authorized** — that is [`crate::submit::validate_submission`], and the
+    /// distinction is §4.4's central point.
+    ///
+    /// # Errors
+    ///
+    /// - [`KtError::WrongLabel`] if `label` is not `"free2z/kt/v1/entry"`.
+    /// - [`KtError::UnsupportedVersion`] if `kt_version` is not [`KT_VERSION`].
+    /// - [`KtError::BadHandle`] if `handle` is outside the charset, or if a
+    ///   device credential names a different handle.
+    /// - [`KtError::VersionConflict`] if `entry_version` is 0, or if the
+    ///   all-zero `prev_entry_hash` rule of §4.2 is broken in either direction.
+    /// - [`KtError::Malformed`] for a bad `no_reset`, an inner structure that
+    ///   fails its own `validate`, or two credentials sharing a `device_pk`.
+    pub fn validate(&self) -> Result<(), KtError> {
+        // §6.2: the label first, before anything else.
+        check_label(&self.label, LABEL_ENTRY)?;
+        if self.kt_version != KT_VERSION {
+            return Err(KtError::UnsupportedVersion);
+        }
+        self.handle.validate()?;
+
+        // §4.2: versions start at 1. Version 0 has no meaning in `akd` either.
+        if self.entry_version == 0 {
+            return Err(KtError::VersionConflict);
+        }
+        // §4.2: "all-zero at entry_version 1". Read as an iff — a version-1
+        // entry with a non-zero predecessor hash claims a history that cannot
+        // exist, and a later entry with an all-zero one claims to be a genesis
+        // it is not. Both are rejected here rather than left to the submission
+        // path, because both are self-contradictory on the bytes alone.
+        if (self.entry_version == 1) != self.prev_entry_hash.is_zero() {
+            return Err(KtError::VersionConflict);
+        }
+
+        // Invented here: ADR 0014 gives `no_reset` as a flag and KT.md §4.1 as a
+        // `uint8`, with no statement about other values. Accepting 2 would mean
+        // two distinct byte strings with one meaning inside a structure that is
+        // hashed and signed, which is exactly what re-encode equality exists to
+        // prevent elsewhere. 0 and 1 only.
+        if self.no_reset > 1 {
+            return Err(KtError::Malformed);
+        }
+
+        for credential in self.devices.as_slice() {
+            credential.credential.validate()?;
+            // A credential is self-contained (§4.1), so it *can* disagree with
+            // its envelope. If it did, the MLS peers who validate it without
+            // directory access and the directory clients who validate it with
+            // would reach different conclusions about the same device.
+            if credential.credential.handle != self.handle {
+                return Err(KtError::BadHandle);
+            }
+        }
+        // §4.4 rule 8: no two credentials share a `device_pk`. Two credentials
+        // for one device key are two different validity windows and two
+        // different KEM keys for the same MLS leaf.
+        for (index, credential) in self.devices.as_slice().iter().enumerate() {
+            for other in self.devices.as_slice().iter().skip(index.saturating_add(1)) {
+                if credential.credential.device_pk == other.credential.device_pk {
+                    return Err(KtError::Malformed);
+                }
+            }
+        }
+
+        for endpoint in self.contact_endpoints.as_slice() {
+            endpoint.validate()?;
+        }
+        Ok(())
+    }
+
+    /// The exact bytes the `DirectoryAuthKey` signs (§4.4).
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
+        encode(self).map_err(KtError::from)
+    }
+}
+
+/// A `DirectoryEntry` (§4.1): the contents plus what authorized them.
+///
+/// The tree commits to `H("free2z/kt/v1/value", tls_codec(DirectoryEntry))` —
+/// **this whole structure, authorization included** — so an entry cannot be
+/// re-authorized after publication (§3.3).
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct DirectoryEntry {
+    /// The signed contents.
+    pub entry: DirectoryEntryTBS,
+    /// §4.4.
+    pub authorization: EntryAuthorization,
+}
+
+impl DirectoryEntry {
+    /// Shape validation, including §4.4's `authorization.kind == entry.kind`.
+    ///
+    /// # Errors
+    ///
+    /// As [`DirectoryEntryTBS::validate`], plus [`KtError::BadAuthorization`] if
+    /// the two kinds disagree, and [`KtError::WrongLabel`] /
+    /// [`KtError::BadHandle`] from the inner proof structures.
+    pub fn validate(&self) -> Result<(), KtError> {
+        self.entry.validate()?;
+        // §4.4 rule 5, first half. The kind is encoded twice — once in the
+        // contents the user signed and once in the authorization envelope — and
+        // a mismatch means the bytes that were signed describe a different
+        // operation from the one being performed.
+        if self.authorization.kind() != self.entry.kind {
+            return Err(KtError::BadAuthorization);
+        }
+        match &self.authorization {
+            EntryAuthorization::SameKey { .. } => {}
+            EntryAuthorization::KeyChange { rotation, .. } => rotation.proof.validate()?,
+            EntryAuthorization::PlatformReset { reset, .. } => reset.reset.validate()?,
+        }
+        Ok(())
+    }
+
+    /// `H("free2z/kt/v1/prev", tls_codec(self))` — what the **next** entry's
+    /// `prev_entry_hash` must equal (§4.2).
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn chain_hash(&self) -> Result<Digest, KtError> {
+        Ok(prev_entry_hash(&self.encode_canonical()?))
+    }
+}
+
+/// Build a `<0..255>` label field for a `DirectoryEntryTBS`.
+///
+/// # Errors
+///
+/// [`KtError::Malformed`] if the constant does not fit, which it does.
+pub fn entry_label() -> Result<ShortBytes, KtError> {
+    label_field(LABEL_ENTRY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::{TestDirectory, signing_key};
+    use f2z_codec::canonical::decode_canonical;
+
+    #[test]
+    fn entry_kind_rejects_a_value_this_build_does_not_know() {
+        assert_eq!(EntryKind::from_code(0), Err(KtError::Malformed));
+        assert_eq!(EntryKind::from_code(4), Err(KtError::Malformed));
+        assert_eq!(EntryKind::from_code(255), Err(KtError::Malformed));
+        for kind in EntryKind::ALL {
+            assert_eq!(EntryKind::from_code(kind.code()), Ok(kind));
+        }
+    }
+
+    #[test]
+    fn an_entry_round_trips_under_re_encode_equality() {
+        let directory = TestDirectory::new();
+        let entry = directory.genesis();
+        let bytes = entry.encode_canonical().unwrap();
+        let decoded = decode_canonical::<DirectoryEntry>(&bytes).unwrap();
+        assert_eq!(decoded.value(), &entry);
+        assert_eq!(decoded.bytes(), bytes.as_slice());
+
+        let mut trailing = bytes.clone();
+        trailing.push(0);
+        assert!(decode_canonical::<DirectoryEntry>(&trailing).is_err());
+    }
+
+    #[test]
+    fn every_authorization_variant_round_trips() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let rotated = directory.key_change(&genesis, &signing_key(40), &signing_key(41));
+        let reset = directory.platform_reset(&genesis, &signing_key(50), &signing_key(51), 0);
+        for entry in [genesis, rotated, reset] {
+            let bytes = entry.encode_canonical().unwrap();
+            assert_eq!(
+                decode_canonical::<DirectoryEntry>(&bytes).unwrap().value(),
+                &entry
+            );
+        }
+    }
+
+    #[test]
+    fn an_unknown_kind_byte_fails_to_decode_rather_than_defaulting() {
+        let directory = TestDirectory::new();
+        let mut bytes = directory.genesis().encode_canonical().unwrap();
+        // The `kind` byte inside DirectoryEntryTBS: label(1+18) + kt_version(2)
+        // + log_id(32) + handle(1+5) + entry_version(4) = 63.
+        let offset = 1 + LABEL_ENTRY.len() + 2 + 32 + 1 + 5 + 4;
+        assert_eq!(bytes.get(offset), Some(&EntryKind::SameKey.code()));
+        if let Some(byte) = bytes.get_mut(offset) {
+            *byte = 9;
+        }
+        assert!(decode_canonical::<DirectoryEntry>(&bytes).is_err());
+    }
+
+    #[test]
+    fn shape_validation_catches_what_the_decoder_cannot() {
+        let directory = TestDirectory::new();
+
+        let mut entry = directory.genesis();
+        entry.entry.no_reset = 2;
+        assert_eq!(entry.entry.validate(), Err(KtError::Malformed));
+
+        let mut entry = directory.genesis();
+        entry.entry.kt_version = 2;
+        assert_eq!(entry.entry.validate(), Err(KtError::UnsupportedVersion));
+
+        let mut entry = directory.genesis();
+        entry.entry.label = ShortBytes::new(b"free2z/kt/v1/sth".to_vec()).unwrap();
+        assert_eq!(entry.entry.validate(), Err(KtError::WrongLabel));
+
+        // §4.2's all-zero rule, both directions.
+        let mut entry = directory.genesis();
+        entry.entry.prev_entry_hash = Digest::new([7u8; 32]);
+        assert_eq!(entry.entry.validate(), Err(KtError::VersionConflict));
+
+        let mut entry = directory.genesis();
+        entry.entry.entry_version = 2;
+        assert_eq!(entry.entry.validate(), Err(KtError::VersionConflict));
+    }
+
+    #[test]
+    fn two_credentials_for_one_device_key_are_refused() {
+        let directory = TestDirectory::new();
+        let mut entry = directory.genesis();
+        let credential = entry
+            .entry
+            .devices
+            .as_slice()
+            .first()
+            .expect("the genesis entry has one device")
+            .clone();
+        entry.entry.devices = VecU16::new(vec![credential.clone(), credential]);
+        assert_eq!(entry.entry.validate(), Err(KtError::Malformed));
+    }
+
+    #[test]
+    fn a_credential_naming_another_handle_is_refused() {
+        let directory = TestDirectory::new();
+        let mut entry = directory.genesis();
+        if let Some(credential) = entry.entry.devices.as_slice().first() {
+            let mut credential = credential.clone();
+            credential.credential.handle = Handle::new(b"mallory".to_vec()).unwrap();
+            entry.entry.devices = VecU16::new(vec![credential]);
+        }
+        assert_eq!(entry.entry.validate(), Err(KtError::BadHandle));
+    }
+
+    #[test]
+    fn a_kind_that_disagrees_with_its_authorization_is_refused() {
+        let directory = TestDirectory::new();
+        let mut entry = directory.genesis();
+        entry.entry.kind = EntryKind::KeyChange;
+        assert_eq!(entry.validate(), Err(KtError::BadAuthorization));
+    }
+}

--- a/rs/crates/f2z-kt-core/src/error.rs
+++ b/rs/crates/f2z-kt-core/src/error.rs
@@ -1,0 +1,379 @@
+//! `KT.md` §9.5's wire error codes, and this crate's failure type.
+
+use core::fmt;
+
+use f2z_codec::CodecError;
+
+/// A key-transparency wire error code (`KT.md` §9.5).
+///
+/// `uint16`, and **stable forever**: a code's meaning is never changed and a
+/// retired code is never reused — `WIRE.md` §10's rule, for `WIRE.md` §10's
+/// reason. `0` is success and is therefore not a variant.
+///
+/// **There is no "unknown handle" code**, deliberately: an unregistered handle
+/// is answered with a proof of non-membership (§8.1), because handles are meant
+/// to be public and "there is no such user" is a claim the log must prove
+/// rather than assert. That is the opposite of `WIRE.md` §10's existence-oracle
+/// rule, for the opposite reason, and the contrast is in §8.1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum ErrorCode {
+    /// Decode failure, re-encode mismatch, oversize body.
+    Malformed,
+    /// Unknown `kt_version`, or a `log_id` this server does not serve.
+    UnsupportedVersion,
+    /// An `auth_signature`, `RotationProof`, reset or cosignature failed
+    /// verification.
+    BadSignature,
+    /// Structurally valid but §4.4's rules unmet — e.g. a key change with one
+    /// signature.
+    BadAuthorization,
+    /// `entry_version` not `previous + 1`, `prev_entry_hash` mismatch, or a
+    /// second entry for this handle in this epoch (§4.3).
+    VersionConflict,
+    /// A `platform_reset` whose `effective_at_ms` has not arrived.
+    Cooldown,
+    /// The requested epoch or audit range is outside the served horizon (§9.3).
+    EpochUnavailable,
+    /// An audit range above the published maximum.
+    RangeTooWide,
+    /// Retry later.
+    RateLimited,
+    /// `/kt/v1/cosign` from a key the log does not recognise. Advisory only —
+    /// the log's opinion of who is a witness has **no bearing** on a client's
+    /// configured set (§8.3).
+    NotAWitness,
+    /// Log fault. Carries no detail, ever.
+    Internal,
+}
+
+impl ErrorCode {
+    /// Every code, in wire order. Used by the exhaustiveness test.
+    pub const ALL: [Self; 11] = [
+        Self::Malformed,
+        Self::UnsupportedVersion,
+        Self::BadSignature,
+        Self::BadAuthorization,
+        Self::VersionConflict,
+        Self::Cooldown,
+        Self::EpochUnavailable,
+        Self::RangeTooWide,
+        Self::RateLimited,
+        Self::NotAWitness,
+        Self::Internal,
+    ];
+
+    /// The wire code.
+    #[must_use]
+    pub const fn code(self) -> u16 {
+        match self {
+            Self::Malformed => 1,
+            Self::UnsupportedVersion => 2,
+            Self::BadSignature => 3,
+            Self::BadAuthorization => 4,
+            Self::VersionConflict => 5,
+            Self::Cooldown => 6,
+            Self::EpochUnavailable => 7,
+            Self::RangeTooWide => 8,
+            Self::RateLimited => 9,
+            Self::NotAWitness => 10,
+            Self::Internal => 11,
+        }
+    }
+
+    /// The code this build knows by that number, if any.
+    ///
+    /// `None` is not an error: §9.5 keeps codes stable so an old client can
+    /// still log a code it does not recognize.
+    #[must_use]
+    pub const fn from_code(code: u16) -> Option<Self> {
+        Some(match code {
+            1 => Self::Malformed,
+            2 => Self::UnsupportedVersion,
+            3 => Self::BadSignature,
+            4 => Self::BadAuthorization,
+            5 => Self::VersionConflict,
+            6 => Self::Cooldown,
+            7 => Self::EpochUnavailable,
+            8 => Self::RangeTooWide,
+            9 => Self::RateLimited,
+            10 => Self::NotAWitness,
+            11 => Self::Internal,
+            _ => return None,
+        })
+    }
+
+    /// The stable screaming-snake name from §9.5's table, for logs.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Malformed => "ERR_MALFORMED",
+            Self::UnsupportedVersion => "ERR_UNSUPPORTED_VERSION",
+            Self::BadSignature => "ERR_BAD_SIGNATURE",
+            Self::BadAuthorization => "ERR_BAD_AUTHORIZATION",
+            Self::VersionConflict => "ERR_VERSION_CONFLICT",
+            Self::Cooldown => "ERR_COOLDOWN",
+            Self::EpochUnavailable => "ERR_EPOCH_UNAVAILABLE",
+            Self::RangeTooWide => "ERR_RANGE_TOO_WIDE",
+            Self::RateLimited => "ERR_RATE_LIMITED",
+            Self::NotAWitness => "ERR_NOT_A_WITNESS",
+            Self::Internal => "ERR_INTERNAL",
+        }
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.name(), self.code())
+    }
+}
+
+impl core::error::Error for ErrorCode {}
+
+/// Everything this crate can refuse to do.
+///
+/// Each variant carries the [`ErrorCode`] a log would put on the wire, so a
+/// caller never has to re-derive one and never has to invent one.
+///
+/// The variants are finer-grained than the wire codes on purpose: several of
+/// them are also [`FaultKind`]s, and the difference between "this tree head
+/// rolled back" and "this tree head forked" is the difference between two
+/// pieces of evidence a witness publishes, even though neither ever reaches a
+/// client as a wire code.
+///
+/// [`FaultKind`]: crate::witness::FaultKind
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum KtError {
+    /// The bytes did not decode, re-encoded to something else (`WIRE.md` §3.3),
+    /// or a field value is not one version 1 may hold.
+    Malformed,
+    /// A structure's first field was not the exact §6.2 constant for its type.
+    ///
+    /// Checked **before anything else**, per §6.2: a verifier that accepts a
+    /// signature "from the log" over bytes it did not type-check is one
+    /// field-alignment coincidence away from accepting a receipt as a tree head.
+    WrongLabel,
+    /// A `kt_version` this build does not implement.
+    UnsupportedVersion,
+    /// A `log_id` other than the one this verifier is pinned to.
+    WrongLog,
+    /// A handle outside `[a-z0-9_]{1,30}` (§1.3).
+    BadHandle,
+    /// An Ed25519 signature did not verify.
+    BadSignature,
+    /// Structurally valid, and §4.4's authorization rules are not satisfied.
+    BadAuthorization,
+    /// `entry_version` is not `previous + 1`, or `prev_entry_hash` does not
+    /// match the published previous entry (§4.2).
+    VersionConflict,
+    /// A second entry for this handle in this epoch (§4.3).
+    ///
+    /// Separate from [`KtError::VersionConflict`] although §9.5 gives them the
+    /// same wire code, because this one is the NCC Group finding — `publish()`
+    /// with duplicate labels in one batch — and a log that hits it should be
+    /// able to say so in its own logs.
+    DuplicateInEpoch,
+    /// A `platform_reset` whose `effective_at_ms` has not arrived, or whose
+    /// cooldown is shorter than the published one (§4.4 rule 7).
+    Cooldown,
+    /// §6.3: `epoch`, `tree_size` or `published_at_ms` moved backwards.
+    Rollback,
+    /// §6.3 rule 8: the same epoch with a different root, size or timestamp.
+    /// Fatal, and it is fork evidence.
+    Fork,
+    /// §6.3 rule 7: `prev_sth_hash` does not connect to the last accepted head.
+    ChainBreak,
+    /// §6.3 rule 7: the new head skips epochs. The verifier MUST fetch every
+    /// intervening head and check the chain link by link; **it MUST NOT skip.**
+    /// A gap accepted on trust is a branch accepted on trust.
+    EpochGap,
+    /// §6.1: `vrf_public_key` changed within a `log_id`. Treat as a fork, never
+    /// as an update — it determines every label in the tree, so changing it
+    /// silently invalidates every prior proof while producing proofs that still
+    /// verify under the new key.
+    VrfKeyChange,
+    /// Fewer than *t* valid cosignatures from **distinct witnesses in the
+    /// caller's own configured set** (§8.3). The client fails closed.
+    ThresholdUnmet,
+    /// §6.4: a log signing-key transition that does not satisfy all four
+    /// conditions. A witness MUST halt and report, not fall back to trusting
+    /// the new key.
+    BadKeyTransition,
+    /// `akd`'s verifier rejected an inclusion or history proof.
+    ProofInvalid,
+    /// The entry served alongside a proof does not hash to the value the proof
+    /// commits to (§8.1 step 4). Never use a value the log asserts.
+    ValueMismatch,
+    /// `akd`'s auditor rejected the append-only proof (§7.1 step 4). The only
+    /// check that catches a value rewritten under a proof that still verifies.
+    AppendOnlyFailure,
+    /// A history response is not an unbroken `entry_version` sequence, or its
+    /// `prev_entry_hash` chain does not connect (§8.2 step 4). A log that omits
+    /// a version from a history response is otherwise serving a truthful subset.
+    HistoryIncomplete,
+}
+
+impl KtError {
+    /// The wire code a log sends for this failure (§9.5).
+    #[must_use]
+    pub const fn error_code(self) -> ErrorCode {
+        match self {
+            Self::Malformed | Self::WrongLabel | Self::BadHandle => ErrorCode::Malformed,
+            Self::UnsupportedVersion | Self::WrongLog => ErrorCode::UnsupportedVersion,
+            Self::BadSignature => ErrorCode::BadSignature,
+            Self::BadAuthorization | Self::BadKeyTransition => ErrorCode::BadAuthorization,
+            Self::VersionConflict | Self::DuplicateInEpoch => ErrorCode::VersionConflict,
+            Self::Cooldown => ErrorCode::Cooldown,
+            // Everything below is a *client- or witness-side* verdict about the
+            // log. None of them is a reply a log sends to a submitter, and
+            // collapsing them onto ERR_INTERNAL states that plainly rather than
+            // inventing a code §9.5 does not have.
+            Self::Rollback
+            | Self::Fork
+            | Self::ChainBreak
+            | Self::EpochGap
+            | Self::VrfKeyChange
+            | Self::ThresholdUnmet
+            | Self::ProofInvalid
+            | Self::ValueMismatch
+            | Self::AppendOnlyFailure
+            | Self::HistoryIncomplete => ErrorCode::Internal,
+        }
+    }
+}
+
+impl fmt::Display for KtError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let text = match self {
+            Self::Malformed => "bytes did not decode canonically (WIRE.md §3.3)",
+            Self::WrongLabel => "domain-separation label is not this structure's (KT.md §6.2)",
+            Self::UnsupportedVersion => "unsupported kt_version",
+            Self::WrongLog => "log_id is not the pinned one",
+            Self::BadHandle => "handle is not [a-z0-9_]{1,30} (KT.md §1.3)",
+            Self::BadSignature => "signature did not verify",
+            Self::BadAuthorization => "entry authorization rules unmet (KT.md §4.4)",
+            Self::VersionConflict => "entry_version or prev_entry_hash does not chain (KT.md §4.2)",
+            Self::DuplicateInEpoch => "a second entry for this handle in this epoch (KT.md §4.3)",
+            Self::Cooldown => "platform_reset before effective_at_ms (KT.md §4.4)",
+            Self::Rollback => "tree head moved backwards (KT.md §6.3)",
+            Self::Fork => "two different tree heads for one epoch (KT.md §6.3 rule 8)",
+            Self::ChainBreak => "prev_sth_hash does not connect (KT.md §6.3 rule 7)",
+            Self::EpochGap => "tree head skips epochs; fetch every intervening head (KT.md §6.3)",
+            Self::VrfKeyChange => "vrf_public_key changed within a log_id (KT.md §6.1)",
+            Self::ThresholdUnmet => {
+                "fewer than t cosignatures from the configured set (KT.md §8.3)"
+            }
+            Self::BadKeyTransition => "log signing-key transition unverifiable (KT.md §6.4)",
+            Self::ProofInvalid => "akd rejected the proof",
+            Self::ValueMismatch => "the served entry does not hash to the committed value",
+            Self::AppendOnlyFailure => "the append-only proof did not verify (KT.md §7.1)",
+            Self::HistoryIncomplete => "key history is not an unbroken chain (KT.md §8.2)",
+        };
+        write!(f, "{text}: {}", self.error_code())
+    }
+}
+
+impl core::error::Error for KtError {}
+
+impl From<CodecError> for KtError {
+    fn from(error: CodecError) -> Self {
+        match error {
+            // `f2z-codec` distinguishes these because a relay answers them with
+            // different wire codes. Here they are all the same verdict: the
+            // bytes are not a structure this protocol may act on.
+            CodecError::Decode
+            | CodecError::NotCanonical
+            | CodecError::InvalidValue
+            | CodecError::BadSize
+            | CodecError::Overflow => Self::Malformed,
+            // `CodecError` is #[non_exhaustive]; a variant added upstream must
+            // fail closed rather than compile into an accept.
+            _ => Self::Malformed,
+        }
+    }
+}
+
+impl From<tls_codec::Error> for KtError {
+    fn from(_: tls_codec::Error) -> Self {
+        Self::Malformed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codes_are_the_table_in_kt_md_section_9_5() {
+        for (index, code) in ErrorCode::ALL.iter().enumerate() {
+            let expected = u16::try_from(index).map(|value| value + 1);
+            assert_eq!(Ok(code.code()), expected);
+            assert_eq!(ErrorCode::from_code(code.code()), Some(*code));
+        }
+        assert_eq!(
+            ErrorCode::from_code(0),
+            None,
+            "0 is success, never an error"
+        );
+        assert_eq!(ErrorCode::from_code(12), None);
+    }
+
+    #[test]
+    fn there_is_no_unknown_handle_code() {
+        // §9.5 states this deliberately: an unregistered handle is answered
+        // with a non-membership proof, not an error. If someone adds one, this
+        // test is where they are told why they must not.
+        for code in ErrorCode::ALL {
+            assert!(
+                !code.name().contains("HANDLE"),
+                "an unknown-handle code would let the log assert what it must prove"
+            );
+        }
+    }
+
+    #[test]
+    fn every_failure_has_a_wire_code_and_a_message() {
+        // Not exhaustive over KtError by construction — it is #[non_exhaustive]
+        // — but every variant this build knows is checked to render.
+        let all = [
+            KtError::Malformed,
+            KtError::WrongLabel,
+            KtError::UnsupportedVersion,
+            KtError::WrongLog,
+            KtError::BadHandle,
+            KtError::BadSignature,
+            KtError::BadAuthorization,
+            KtError::VersionConflict,
+            KtError::DuplicateInEpoch,
+            KtError::Cooldown,
+            KtError::Rollback,
+            KtError::Fork,
+            KtError::ChainBreak,
+            KtError::EpochGap,
+            KtError::VrfKeyChange,
+            KtError::ThresholdUnmet,
+            KtError::BadKeyTransition,
+            KtError::ProofInvalid,
+            KtError::ValueMismatch,
+            KtError::AppendOnlyFailure,
+            KtError::HistoryIncomplete,
+        ];
+        for error in all {
+            let rendered = format!("{error}");
+            assert!(
+                rendered.contains("ERR_"),
+                "{error:?} rendered as {rendered}"
+            );
+        }
+        assert_eq!(
+            KtError::BadAuthorization.error_code(),
+            ErrorCode::BadAuthorization
+        );
+        assert_eq!(
+            KtError::DuplicateInEpoch.error_code(),
+            ErrorCode::VersionConflict,
+            "§4.3's rule is answered with ERR_VERSION_CONFLICT",
+        );
+    }
+}

--- a/rs/crates/f2z-kt-core/src/labels.rs
+++ b/rs/crates/f2z-kt-core/src/labels.rs
@@ -1,0 +1,245 @@
+//! Domain separation — `KT.md` §6.2's closed label set, and the four labels
+//! that go to `H`.
+//!
+//! Two different mechanisms share the word "label" in `KT.md` and they must not
+//! be confused, so this module keeps them in two arrays:
+//!
+//! - **[`SIGNING_LABELS`]** are *fields*. Every structure the protocol signs
+//!   carries a distinct versioned ASCII constant in its **first** field, inside
+//!   the signed bytes, and a verifier MUST check it before anything else (§6.2).
+//!   The log's signing key signs tree heads, receipts **and** key transitions;
+//!   without an in-band, checked type constant a verifier that accepts "a
+//!   signature from the log" over bytes it did not type-check is one
+//!   field-alignment coincidence away from accepting a receipt as a tree head.
+//!   The set is closed: §6.2's table is reproduced here in full and
+//!   [`SIGNING_LABELS`] is what a test asserts against it.
+//!
+//! - **[`HASH_LABELS`]** are arguments to `H(label, x) = BLAKE2b-256(label || x)`
+//!   (§1.3), the idiom `WIRE.md` §1.3 already fixes: exact ASCII bytes, **no
+//!   separator and no terminator**. No separator means the label set must be
+//!   prefix-free or an attacker-chosen message can complete one label into
+//!   another, and [`HASH_LABELS`] exists so a test can check that mechanically
+//!   rather than by inspection.
+//!
+//! A signing label is never handed to `H` and a hash label never appears in a
+//! signed structure, which is why `"free2z/kt/v1/sth"` being a prefix of
+//! `"free2z/kt/v1/sth-hash"` is not a collision: only the second is ever a
+//! `H` argument. The test asserts prefix-freeness **within** [`HASH_LABELS`],
+//! and distinctness within [`SIGNING_LABELS`], and nothing across the two.
+
+use f2z_codec::hash::hash;
+use f2z_codec::types::{Digest, PublicKey};
+
+use crate::types::LogId;
+
+// ---------------------------------------------------------------------------
+// §6.2 — the closed set of signing labels.
+// ---------------------------------------------------------------------------
+
+/// `SignedTreeHeadTBS.label`, signed by the log (§6.1).
+pub const LABEL_STH: &[u8] = b"free2z/kt/v1/sth";
+
+/// `WitnessCosignatureTBS.label`, signed by a witness (§7.2).
+pub const LABEL_COSIG: &[u8] = b"free2z/kt/v1/cosig";
+
+/// `SubmissionReceiptTBS.label`, signed by the log (§5.3).
+pub const LABEL_RECEIPT: &[u8] = b"free2z/kt/v1/receipt";
+
+/// `DirectoryEntryTBS.label`, signed by the user's `DirectoryAuthKey` (§4.1).
+pub const LABEL_ENTRY: &[u8] = b"free2z/kt/v1/entry";
+
+/// `RotationProofTBS.label`, signed by the user's **outgoing** ISK (§4.4).
+pub const LABEL_ROTATION: &[u8] = b"free2z/kt/v1/rotation";
+
+/// `ResetAuthorizationTBS.label`, signed by the pinned reset authority (§4.4).
+pub const LABEL_RESET: &[u8] = b"free2z/kt/v1/reset";
+
+/// `LogKeyTransitionTBS.label`, signed by **both** log keys (§6.4).
+pub const LABEL_LOG_KEY_TRANSITION: &[u8] = b"free2z/kt/v1/log-key-transition";
+
+/// `FaultReportTBS.label`, signed by a witness (§7.3).
+pub const LABEL_FAULT: &[u8] = b"free2z/kt/v1/fault";
+
+/// `DeviceCredentialTBS.label`, signed by the user's ISK (§4.1).
+///
+/// The one label that is not under `free2z/kt/v1/`: a `DeviceCredential` is
+/// carried as the MLS `Credential` in a `LeafNode` and is validated by peers who
+/// have no directory access at all (`ARCHITECTURE.md` §4.2), so it is not a
+/// key-transparency structure and does not carry the directory's version.
+pub const LABEL_DEVICE_CREDENTIAL: &[u8] = b"free2z/device-credential/v1";
+
+/// §6.2's table, in the order it is written there.
+///
+/// Closed on purpose. A structure this crate signs or verifies that is not in
+/// this list is a structure whose type is not checked, and a test asserts the
+/// list matches the constants above.
+pub const SIGNING_LABELS: [&[u8]; 9] = [
+    LABEL_STH,
+    LABEL_COSIG,
+    LABEL_RECEIPT,
+    LABEL_ENTRY,
+    LABEL_ROTATION,
+    LABEL_RESET,
+    LABEL_LOG_KEY_TRANSITION,
+    LABEL_FAULT,
+    LABEL_DEVICE_CREDENTIAL,
+];
+
+// ---------------------------------------------------------------------------
+// The arguments to H. These must stay prefix-free.
+// ---------------------------------------------------------------------------
+
+/// `log_id = H("free2z/kt/v1/log-id", genesis_log_pk)` (§6.1).
+pub const LABEL_LOG_ID: &[u8] = b"free2z/kt/v1/log-id";
+
+/// `AkdValue = H("free2z/kt/v1/value", tls_codec(DirectoryEntry))` (§3.3).
+pub const LABEL_VALUE: &[u8] = b"free2z/kt/v1/value";
+
+/// `prev_entry_hash = H("free2z/kt/v1/prev", tls_codec(previous DirectoryEntry))`
+/// (§4.2).
+pub const LABEL_PREV: &[u8] = b"free2z/kt/v1/prev";
+
+/// `prev_sth_hash = H("free2z/kt/v1/sth-hash", tls_codec(prev SignedTreeHeadTBS))`
+/// (§6.1).
+pub const LABEL_STH_HASH: &[u8] = b"free2z/kt/v1/sth-hash";
+
+/// Every label this crate hands to `H`, so a test can assert the set is
+/// prefix-free. See the module note on `H`'s missing separator.
+pub const HASH_LABELS: [&[u8]; 4] = [LABEL_LOG_ID, LABEL_VALUE, LABEL_PREV, LABEL_STH_HASH];
+
+/// The `AkdLabel` prefix: `"free2z/kt/v1/handle:" || handle` (§3.3).
+///
+/// Domain separation against the same log ever being asked to hold a second
+/// kind of record. It sits inside the VRF input, so it is not visible in the
+/// tree and costs nothing in privacy.
+pub const AKD_LABEL_PREFIX: &[u8] = b"free2z/kt/v1/handle:";
+
+// ---------------------------------------------------------------------------
+// The derivations.
+// ---------------------------------------------------------------------------
+
+/// `log_id = H("free2z/kt/v1/log-id", genesis_log_pk)` (§6.1).
+///
+/// Derived from the log's **genesis** signing key and never changing, including
+/// across a signing-key rotation (§6.4). If it changed, every rotation would
+/// present as a new log and every client's pinned history would be discarded —
+/// which is exactly the state an attacker wants a client in.
+#[must_use]
+pub fn log_id(genesis_log_pk: &PublicKey) -> LogId {
+    LogId::new(*hash(LABEL_LOG_ID, genesis_log_pk.as_bytes()).as_bytes())
+}
+
+/// `AkdValue = H("free2z/kt/v1/value", tls_codec(DirectoryEntry))` (§3.3).
+///
+/// The tree commits to this 32-byte hash, not to the entry. The bytes passed in
+/// MUST be the **canonical** encoding of the whole `DirectoryEntry` including
+/// its authorization, so that an entry cannot be re-authorized after
+/// publication.
+#[must_use]
+pub fn entry_value(canonical_entry: &[u8]) -> Digest {
+    hash(LABEL_VALUE, canonical_entry)
+}
+
+/// `prev_entry_hash = H("free2z/kt/v1/prev", tls_codec(previous DirectoryEntry))`
+/// (§4.2), over the previous entry **including its authorization**.
+#[must_use]
+pub fn prev_entry_hash(canonical_entry: &[u8]) -> Digest {
+    hash(LABEL_PREV, canonical_entry)
+}
+
+/// `H("free2z/kt/v1/sth-hash", tls_codec(SignedTreeHeadTBS))` (§6.1).
+///
+/// Note the argument is the **`SignedTreeHeadTBS`**, not the `SignedTreeHead`:
+/// the chain link covers the signed contents, not the signature over them.
+#[must_use]
+pub fn sth_hash(canonical_sth_tbs: &[u8]) -> Digest {
+    hash(LABEL_STH_HASH, canonical_sth_tbs)
+}
+
+/// `AkdLabel = "free2z/kt/v1/handle:" || handle` (§3.3).
+///
+/// The handle is ASCII `[a-z0-9_]{1,30}` (§1.3), which is why the log's labels
+/// are not homograph-attackable and why a bare concatenation is unambiguous
+/// here: no handle can contain the prefix's `:`.
+#[must_use]
+pub fn akd_label(handle: &crate::types::Handle) -> Vec<u8> {
+    let mut label = Vec::with_capacity(AKD_LABEL_PREFIX.len().saturating_add(handle.len()));
+    label.extend_from_slice(AKD_LABEL_PREFIX);
+    label.extend_from_slice(handle.as_slice());
+    label
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_labels_are_prefix_free() {
+        // `H` concatenates label and message with no separator, so a label that
+        // is a prefix of another is a cross-domain collision waiting for an
+        // attacker-chosen message.
+        for (i, a) in HASH_LABELS.iter().enumerate() {
+            for (j, b) in HASH_LABELS.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+                assert!(
+                    !b.starts_with(a),
+                    "hash label {:?} is a prefix of {:?}",
+                    core::str::from_utf8(a),
+                    core::str::from_utf8(b)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_signing_label_set_is_closed_and_distinct() {
+        // §6.2's table has nine rows. If a tenth structure is signed, this
+        // assertion is where the reviewer is told to look at §6.2 first.
+        assert_eq!(SIGNING_LABELS.len(), 9);
+        for (i, a) in SIGNING_LABELS.iter().enumerate() {
+            for (j, b) in SIGNING_LABELS.iter().enumerate() {
+                assert!(
+                    i == j || a != b,
+                    "two structures share a domain-separation constant"
+                );
+            }
+        }
+        // Every one is ASCII and versioned, so a verifier comparing bytes is
+        // comparing what §6.2 wrote down.
+        for label in SIGNING_LABELS {
+            assert!(label.is_ascii(), "a label must be exact ASCII bytes");
+            assert!(!label.is_empty());
+        }
+    }
+
+    #[test]
+    fn a_signing_label_is_never_a_hash_label() {
+        // Not a security property on its own — the two mechanisms are
+        // separate — but a constant that appeared in both would mean someone
+        // had confused them, and this is cheaper than finding out later.
+        for signing in SIGNING_LABELS {
+            for hashed in HASH_LABELS {
+                assert_ne!(signing, hashed);
+            }
+        }
+    }
+
+    #[test]
+    fn the_four_derivations_are_domain_separated() {
+        let message = b"the same 32 bytes................";
+        assert_ne!(entry_value(message), prev_entry_hash(message));
+        assert_ne!(entry_value(message), sth_hash(message));
+        assert_ne!(prev_entry_hash(message), sth_hash(message));
+    }
+
+    #[test]
+    fn log_id_is_the_digest_of_the_genesis_key() {
+        let genesis = PublicKey::new([5u8; 32]);
+        assert_eq!(
+            log_id(&genesis).as_bytes(),
+            hash(LABEL_LOG_ID, genesis.as_bytes()).as_bytes()
+        );
+    }
+}

--- a/rs/crates/f2z-kt-core/src/lib.rs
+++ b/rs/crates/f2z-kt-core/src/lib.rs
@@ -1,0 +1,170 @@
+//! Key transparency for the free2z directory, version 1 — the implementation of
+//! [`docs/e2ee/KT.md`].
+//!
+//! **One crate, three consumers** (`KT.md` §11.4). The log server, the witness
+//! and the client all link this crate, native and WASM. That is not tidiness: a
+//! witness that verified with a different implementation than the log builds
+//! with would produce cosignatures that mean nothing, and §7.4's only structural
+//! defence against a lazy witness is that there are not two implementations to
+//! disagree.
+//!
+//! # What this crate is for, in one paragraph
+//!
+//! [ADR 0013] adopts [`akd`](https://github.com/facebook/akd) for the
+//! append-only zero-knowledge set — the sparse Patricia tree over VRF-derived
+//! labels, the commitments, and the membership, non-membership and append-only
+//! proofs. That is the entire cryptographic core, and it is the part we do not
+//! write. It is also **all** we get: `akd` ships no signed tree heads, no
+//! cosigning, no gossip, no receipts and only an in-memory database. Everything
+//! between that library and a key-transparency deployment is here.
+//!
+//! # The single most important thing in this crate
+//!
+//! > **`akd` enforces none of our authorization rules.** The library will
+//! > happily commit any bytes to any label. Every rule in `KT.md` §4.4 lives in
+//! > our submission path, and a log that skips them produces inclusion, history
+//! > and append-only proofs that verify **perfectly** for entries nobody
+//! > authorized. The transparency machinery proves that the log did not *change
+//! > its mind*; §4.4 is the only thing that proves the log did not *make it up*.
+//!
+//! So the crate is built around choke points rather than helpers, and the type
+//! system carries the rules:
+//!
+//! | To get | You must first | Which requires |
+//! |---|---|---|
+//! | [`submit::AcceptedSubmission`] — the only carrier of an `AkdLabel`/`AkdValue` pair | [`submit::validate_submission`] | every rule in §4.4, in order |
+//! | [`witness::AcceptedRoot`] — the only root a proof may be verified against | [`witness::verify_threshold`] | ≥ *t* cosignatures from the caller's **own** witness set (§8.3) |
+//! | an advanced [`sth::LogView`] | [`sth::LogView::accept`] | all eight of §6.3's monotonicity rules, with no skipping over an epoch gap |
+//! | an advanced [`auditor::WitnessState`] | [`auditor::verify_append_only`] | `akd`'s auditor actually having run (§7.4) |
+//! | a successor log signing key | [`sth::LogView::accept_log_key_transition`] | a **cosigned** announcement plus both signatures (§6.4) |
+//!
+//! None of these has a public constructor and none of them has a bypass flag.
+//! Forgetting a rule is not a state a caller can reach by omission; it takes
+//! deleting a call, not failing to write one.
+//!
+//! # Features
+//!
+//! - `verifier` — the client half (§8.1, §8.2), wrapping `akd_core`. **Reaches
+//!   `wasm32-unknown-unknown`**, and the CI wasm job builds exactly this.
+//! - `auditor` — the witness half (§7.1 step 4), wrapping the server crate
+//!   `akd`. **Does not work on wasm**: `audit_verify` hardcodes
+//!   `AzksParallelismConfig::default()` and reaches `tokio::task::spawn`, so it
+//!   compiles for that target and traps at runtime (§11.3). The witness is a
+//!   native outbound-polling daemon (§9.3), so this costs nothing.
+//!
+//! Both are on by default, because the log server wants both and because
+//! `cargo deny` judges the default graph — a floor that is only in an optional
+//! feature is a floor nothing checks. The browser build is
+//! `--no-default-features --features verifier`.
+//!
+//! # The version floor is not in this manifest
+//!
+//! `akd >= 0.13.0` is a **hard floor**, and it is held by a `[[bans.deny]]`
+//! entry in `rs/deny.toml` rather than by the version requirement in
+//! `Cargo.toml`. [facebook/akd#495] — the auditor append-only bypass that sets
+//! the floor, where a malicious log could rewrite a label's value while still
+//! producing a **valid** append-only proof — has **no RustSec or OSV advisory**
+//! and never will, so `cargo audit` and `cargo deny advisories` pass on a stale
+//! `0.12.0` pin silently and forever. A manifest requirement is not a floor
+//! either: a `[patch.crates-io]`, a path dependency, a workspace inheritance
+//! change or a vendored copy all walk under it without comment. **A reviewer who
+//! removes that entry has removed the floor; there is no second line of
+//! defence.**
+//!
+//! # What this crate deliberately does not do
+//!
+//! No signing, no key generation, no randomness, no clocks, no sockets, no
+//! storage, no HTTP and no policy numbers. It verifies, it validates, and it
+//! builds the exact byte strings that the layers above sign and send. `KT.md`
+//! §12's open questions — the epoch cadence, the default *t*, the shipped
+//! witness list, the gossip protocol, reset-authority pinning — are open here
+//! too, and are left as caller-supplied values rather than answered by
+//! invention.
+//!
+//! [`docs/e2ee/KT.md`]: https://github.com/free2z/zuu/blob/main/docs/e2ee/KT.md
+//! [ADR 0013]: https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0013-key-transparency-log.md
+//! [facebook/akd#495]: https://github.com/facebook/akd/pull/495
+
+#![forbid(unsafe_code)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects
+    )
+)]
+// The builders in `testing` are `#[cfg(test)]` and are held to the same lints
+// as the tests that use them.
+#![cfg_attr(test, allow(clippy::missing_panics_doc, clippy::missing_errors_doc))]
+
+pub mod cosign;
+pub mod descriptor;
+pub mod entry;
+pub mod error;
+pub mod labels;
+pub mod receipt;
+pub mod sig;
+pub mod sth;
+pub mod submit;
+pub mod types;
+pub mod witness;
+
+#[cfg(feature = "auditor")]
+pub mod auditor;
+#[cfg(feature = "verifier")]
+pub mod verify;
+
+#[cfg(test)]
+mod testing;
+
+pub use cosign::{WitnessCosignature, WitnessCosignatureTBS};
+pub use descriptor::{LogDescriptor, SignedLogDescriptor};
+pub use entry::{
+    ContactEndpoint, DeviceCredential, DeviceCredentialTBS, DeviceRevocation, DirectoryEntry,
+    DirectoryEntryTBS, EntryAuthorization, EntryKind, ResetAuthorization, ResetAuthorizationTBS,
+    RotationProof, RotationProofTBS,
+};
+pub use error::{ErrorCode, KtError};
+pub use receipt::{SubmissionReceipt, SubmissionReceiptTBS};
+pub use sth::{LogKeyTransition, LogKeyTransitionTBS, LogView, SignedTreeHead, SignedTreeHeadTBS};
+pub use submit::{
+    AcceptedSubmission, LogPolicy, PublishedEntry, SubmissionContext, validate_submission,
+};
+pub use types::{Handle, KemPublicKey, LogId};
+pub use witness::{
+    AcceptedRoot, ConfiguredWitness, FaultKind, FaultReport, FaultReportTBS, WitnessSet,
+    verify_threshold,
+};
+
+/// The key-transparency protocol version this crate implements.
+///
+/// `KT.md` §4.1 and §6.1: `kt_version` is `0x0001`, and it appears inside every
+/// signed structure that carries one so that a verifier checks it before acting
+/// on the bytes.
+pub const KT_VERSION: u16 = 0x0001;
+
+/// `KT.md` §5.1's proposed epoch cadence, in seconds.
+///
+/// **A placeholder, and stated as one.** §5.1 and §12 are explicit that the
+/// value needs measurement
+/// ([§13-P](https://github.com/free2z/zuu/issues/311)); what matters is the
+/// *structure* of the rule — the log publishes an epoch whether or not there is
+/// anything to publish, so that silence becomes a **detectable fault with a
+/// timestamp** rather than an ambiguity between "nobody changed a key", "the log
+/// has stopped" and "the log is serving me a stale branch."
+///
+/// It is a constant here only so a log's configuration has something to default
+/// from, and nothing in this crate reads it.
+pub const PROPOSED_EPOCH_INTERVAL_SECONDS: u32 = 600;
+
+/// `KT.md` §5.2's proposed maximum merge delay, in seconds — six epochs.
+///
+/// The same placeholder caveat as [`PROPOSED_EPOCH_INTERVAL_SECONDS`]. The
+/// property that matters is that a published MMD turns "the log accepted my
+/// entry and then never published it" from a complaint into a **breach of a
+/// signed promise with a deadline**, provable from two documents anyone can
+/// check.
+pub const PROPOSED_MAX_MERGE_DELAY_SECONDS: u32 = 3_600;

--- a/rs/crates/f2z-kt-core/src/receipt.rs
+++ b/rs/crates/f2z-kt-core/src/receipt.rs
@@ -1,0 +1,165 @@
+//! `SubmissionReceipt` — `KT.md` §5.3, the RFC 6962 SCT analogue.
+//!
+//! The log MUST return a receipt on every accepted submission and MUST NOT
+//! return one for a submission it rejects. A client MUST store the receipt until
+//! it has seen the entry included under a cosigned tree head.
+//!
+//! # What the receipt proves
+//!
+//! A `SubmissionReceipt` with `merge_by_ms` in the past, together with the
+//! cosigned `SignedTreeHead` chain covering that instant and a non-membership
+//! proof for `(handle, entry_version)` at the latest of those roots, is a
+//! self-contained, self-authenticating demonstration that the log broke a
+//! **signed promise with a deadline**. It needs no trust in the complainant.
+//!
+//! # What it does not prove, stated because a receipt looks stronger than it is
+//!
+//! - It does not prove the log *will* publish. It converts a silent failure into
+//!   a provable one. That is the whole of its value.
+//! - It does not prove anyone else saw the promise. A log can hand a receipt to
+//!   one user and to nobody else; the receipt is evidence only once it is
+//!   published, which the victim must actually do.
+//! - It does not defend against a log that includes the entry in a **fork**. The
+//!   entry appears, the receipt is honoured, and the root it appears under is one
+//!   only this user is shown.
+//! - A log that refuses to issue receipts at all is refusing service — visible,
+//!   and not something a receipt can fix.
+
+use f2z_codec::canonical::encode;
+use f2z_codec::types::{Digest, PublicKey, ShortBytes, Signature};
+use tls_codec::{TlsDeserializeBytes, TlsSerializeBytes, TlsSize};
+
+use crate::KT_VERSION;
+use crate::error::KtError;
+use crate::labels::LABEL_RECEIPT;
+use crate::sig;
+use crate::types::{Handle, LogId, check_label, label_field};
+
+/// The `SubmissionReceiptTBS` of §5.3.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct SubmissionReceiptTBS {
+    /// Exactly `"free2z/kt/v1/receipt"`.
+    pub label: ShortBytes,
+    /// `0x0001`.
+    pub kt_version: u16,
+    /// The log making the promise.
+    pub log_id: LogId,
+    /// The handle submitted for.
+    pub handle: Handle,
+    /// The version submitted.
+    pub entry_version: u32,
+    /// `AkdValue` — `H("free2z/kt/v1/value", tls_codec(DirectoryEntry))` (§3.3).
+    pub entry_hash: Digest,
+    /// When the log accepted the submission.
+    pub received_at_ms: u64,
+    /// `received_at_ms + max_merge_delay_seconds * 1000` (§5.2).
+    pub merge_by_ms: u64,
+}
+
+impl SubmissionReceiptTBS {
+    /// Check the constants and charsets a decoder cannot.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`], [`KtError::UnsupportedVersion`] or
+    /// [`KtError::BadHandle`].
+    pub fn validate(&self) -> Result<(), KtError> {
+        check_label(&self.label, LABEL_RECEIPT)?;
+        if self.kt_version != KT_VERSION {
+            return Err(KtError::UnsupportedVersion);
+        }
+        self.handle.validate()
+    }
+
+    /// The exact bytes the log signs.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
+        encode(self).map_err(KtError::from)
+    }
+
+    /// Build the `label` field for a receipt.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the constant does not fit, which it does.
+    pub fn label_bytes() -> Result<ShortBytes, KtError> {
+        label_field(LABEL_RECEIPT)
+    }
+}
+
+/// A `SubmissionReceipt` (§5.3).
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct SubmissionReceipt {
+    /// The signed promise.
+    pub receipt: SubmissionReceiptTBS,
+    /// Ed25519 by the log signing key.
+    pub signature: Signature,
+}
+
+impl SubmissionReceipt {
+    /// Verify the log's signature and the constants.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`], [`KtError::UnsupportedVersion`],
+    /// [`KtError::BadHandle`], [`KtError::WrongLog`] or
+    /// [`KtError::BadSignature`].
+    pub fn verify(&self, log_id: &LogId, log_pk: &PublicKey) -> Result<(), KtError> {
+        self.receipt.validate()?;
+        if self.receipt.log_id != *log_id {
+            return Err(KtError::WrongLog);
+        }
+        sig::verify(log_pk, &self.receipt.signing_bytes()?, &self.signature)
+    }
+
+    /// Whether the promised merge deadline has passed as of `now_ms`.
+    ///
+    /// This says the deadline is **past**, not that it was **missed**: missing
+    /// it also requires a non-membership proof for `(handle, entry_version)` at
+    /// a root covering that instant, which is §8.1's business and needs the
+    /// network this crate does not have.
+    #[must_use]
+    pub const fn deadline_passed(&self, now_ms: u64) -> bool {
+        now_ms > self.receipt.merge_by_ms
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TestLog;
+    use f2z_codec::canonical::{Canonical as _, decode_canonical};
+
+    #[test]
+    fn a_receipt_verifies_round_trips_and_reports_its_deadline() {
+        let log = TestLog::new();
+        let receipt = log.receipt(Digest::new([4u8; 32]), 3, 1_000, 3_601_000);
+        assert_eq!(receipt.verify(log.log_id(), log.log_pk()), Ok(()));
+        assert!(!receipt.deadline_passed(3_601_000));
+        assert!(receipt.deadline_passed(3_601_001));
+
+        let bytes = receipt.encode_canonical().unwrap();
+        assert_eq!(
+            decode_canonical::<SubmissionReceipt>(&bytes)
+                .unwrap()
+                .value(),
+            &receipt
+        );
+    }
+
+    #[test]
+    fn a_tree_head_cannot_be_accepted_as_a_receipt() {
+        // The other half of §6.2's argument: one key signs both, so both check
+        // their own label first.
+        let log = TestLog::new();
+        let mut receipt = log.receipt(Digest::new([4u8; 32]), 3, 1_000, 3_601_000);
+        receipt.receipt.label = ShortBytes::new(crate::labels::LABEL_STH.to_vec()).unwrap();
+        assert_eq!(
+            receipt.verify(log.log_id(), log.log_pk()),
+            Err(KtError::WrongLabel)
+        );
+    }
+}

--- a/rs/crates/f2z-kt-core/src/sig.rs
+++ b/rs/crates/f2z-kt-core/src/sig.rs
@@ -1,0 +1,116 @@
+//! Ed25519 verification, and the one policy decision inside it.
+//!
+//! Every signature `KT.md` §6.2's table names is Ed25519 over the canonical
+//! `tls_codec` encoding of a `*TBS` structure, **signed directly, not
+//! prehashed** (§6.2): the structures are small and fixed-shape, the same
+//! reasoning `WIRE.md` §5.1 uses for the command transcript.
+//!
+//! # This crate verifies and never signs
+//!
+//! There is no signing function here and there is no key type that holds a
+//! secret. The log's signing key, a witness's key and a user's
+//! `DirectoryAuthKey` live in the processes that hold them; what this crate
+//! does is say whether a byte string is a valid signature by a **public** key,
+//! which is a pure function and needs no secrets, no randomness and no clock.
+//! `f2z-codec` draws the same line for the same reason.
+//!
+//! # `verify_strict`, not `verify`
+//!
+//! [`ed25519_dalek::VerifyingKey::verify_strict`] rejects small-order public
+//! keys and non-canonical `R`/`s` encodings; plain `verify` does not. The
+//! difference matters here more than in most places, because §7.2's whole
+//! accountability argument is that **two conflicting cosignatures verifying
+//! under one `witness_pk` are a contradiction on their face**. Under
+//! non-strict verification a signature can be malleated into a second distinct
+//! byte string that still verifies, so "the witness signed two things" and "an
+//! attacker re-encoded one thing" stop being distinguishable, and the
+//! non-repudiation §7.2 claims quietly becomes an accusation instead of a
+//! proof. The same argument covers `LogKeyTransition`'s dual signature and
+//! every `prev_entry_hash`-chained authorization.
+
+use ed25519_dalek::{Signature as DalekSignature, VerifyingKey};
+use f2z_codec::types::{PublicKey, Signature};
+
+use crate::error::KtError;
+
+/// Verify an Ed25519 signature over `message` under `public_key`.
+///
+/// # Errors
+///
+/// [`KtError::BadSignature`] if the key is not a valid Ed25519 point, if the
+/// signature is not a canonical encoding, or if it does not verify. The three
+/// are one verdict on purpose: a caller that could tell them apart would be a
+/// caller that could be asked which one happened.
+pub fn verify(
+    public_key: &PublicKey,
+    message: &[u8],
+    signature: &Signature,
+) -> Result<(), KtError> {
+    let key = VerifyingKey::from_bytes(public_key.as_bytes()).map_err(|_| KtError::BadSignature)?;
+    let signature = DalekSignature::from_bytes(signature.as_bytes());
+    key.verify_strict(message, &signature)
+        .map_err(|_| KtError::BadSignature)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer as _, SigningKey};
+
+    /// A deterministic key, so the tests carry no randomness.
+    pub(crate) fn signing_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    pub(crate) fn public_key_of(key: &SigningKey) -> PublicKey {
+        PublicKey::new(key.verifying_key().to_bytes())
+    }
+
+    pub(crate) fn sign(key: &SigningKey, message: &[u8]) -> Signature {
+        Signature::new(key.sign(message).to_bytes())
+    }
+
+    #[test]
+    fn a_valid_signature_verifies_and_a_flipped_bit_does_not() {
+        let key = signing_key(1);
+        let public = public_key_of(&key);
+        let message = b"free2z/kt/v1/sth ...";
+        let signature = sign(&key, message);
+        assert_eq!(verify(&public, message, &signature), Ok(()));
+
+        let mut tampered = *signature.as_bytes();
+        tampered[0] ^= 0x01;
+        assert_eq!(
+            verify(&public, message, &Signature::new(tampered)),
+            Err(KtError::BadSignature)
+        );
+
+        assert_eq!(
+            verify(&public, b"a different message", &signature),
+            Err(KtError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn another_key_does_not_verify() {
+        let signer = signing_key(1);
+        let other = public_key_of(&signing_key(2));
+        let message = b"one message";
+        assert_eq!(
+            verify(&other, message, &sign(&signer, message)),
+            Err(KtError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn a_key_that_is_not_a_point_is_refused_rather_than_panicking() {
+        // All-zero is not a valid compressed Edwards point in `verify_strict`'s
+        // sense; the important property is that it is a verdict, not a panic.
+        let key = signing_key(3);
+        let message = b"m";
+        assert_eq!(
+            verify(&PublicKey::zero(), message, &sign(&key, message)),
+            Err(KtError::BadSignature)
+        );
+    }
+}

--- a/rs/crates/f2z-kt-core/src/sth.rs
+++ b/rs/crates/f2z-kt-core/src/sth.rs
@@ -1,0 +1,601 @@
+//! `SignedTreeHead`, its monotonicity rules, and log signing-key rotation —
+//! `KT.md` §6.
+//!
+//! # The rules a client can run unaided
+//!
+//! §6.3's checks are the only part of the log's honesty a client can verify
+//! with no proof, no witness and no network beyond the heads it already holds.
+//! They are cheap, they are mandatory for clients as well as witnesses, and
+//! rules 3 and 8 together are the **rollback** and **fork** tests. [`LogView`]
+//! is where they live, and it is the only way to advance a pinned view of a log
+//! in this crate.
+//!
+//! # Why a gap is an error and not a fetch
+//!
+//! §6.3 rule 7 says that if the new head is more than one epoch ahead, the
+//! verifier MUST fetch every intervening head and check the chain link by link,
+//! and **MUST NOT skip**. This crate has no network, so [`LogView::accept`]
+//! answers a gap with [`KtError::EpochGap`] rather than silently accepting one:
+//! *a gap accepted on trust is a branch accepted on trust*. A caller that has
+//! fetched the intervening heads hands them to [`LogView::accept_chain`], which
+//! walks them in order. There is no third method, and no flag that turns the
+//! check off.
+
+use f2z_codec::canonical::{Canonical as _, encode};
+use f2z_codec::types::{Digest, PublicKey, ShortBytes, Signature};
+use tls_codec::{TlsDeserializeBytes, TlsSerializeBytes, TlsSize};
+
+use crate::KT_VERSION;
+use crate::error::KtError;
+use crate::labels::{LABEL_LOG_KEY_TRANSITION, LABEL_STH, sth_hash};
+use crate::sig;
+use crate::types::{LogId, check_label, label_field};
+
+/// The `SignedTreeHeadTBS` of §6.1 — the log's periodic statement about itself.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct SignedTreeHeadTBS {
+    /// Exactly `"free2z/kt/v1/sth"`.
+    pub label: ShortBytes,
+    /// `0x0001`.
+    pub kt_version: u16,
+    /// `H("free2z/kt/v1/log-id", genesis_log_pk)`. **Never changes**, including
+    /// across a signing-key rotation (§6.4).
+    pub log_id: LogId,
+    /// Increments by exactly 1 per published epoch, empty epochs included.
+    pub epoch: u64,
+    /// Total `(label, version)` insertions committed.
+    pub tree_size: u64,
+    /// The `akd` `Azks` root at this epoch.
+    pub root_hash: Digest,
+    /// `H("free2z/kt/v1/sth-hash", tls_codec(prev SignedTreeHeadTBS))`.
+    pub prev_sth_hash: Digest,
+    /// The ECVRF key labels are derived under. **MUST NOT** change within a
+    /// `log_id` (§6.1).
+    pub vrf_public_key: PublicKey,
+    /// The log's clock.
+    pub published_at_ms: u64,
+    /// Platform resets in this epoch (ADR 0014). In the signed contents, so an
+    /// abnormal rate is visible to anyone tracking tree heads without a single
+    /// per-handle lookup.
+    pub reset_count: u32,
+    /// The published cadence (§5.1).
+    pub epoch_interval_seconds: u32,
+    /// The published merge promise (§5.2).
+    pub max_merge_delay_seconds: u32,
+    /// All-zero = none (§6.4).
+    pub successor_log_pk: PublicKey,
+}
+
+impl SignedTreeHeadTBS {
+    /// Check the constants a decoder cannot.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`] or [`KtError::UnsupportedVersion`].
+    pub fn validate(&self) -> Result<(), KtError> {
+        check_label(&self.label, LABEL_STH)?;
+        if self.kt_version != KT_VERSION {
+            return Err(KtError::UnsupportedVersion);
+        }
+        Ok(())
+    }
+
+    /// The exact bytes the log signs — encoded and signed directly, not
+    /// prehashed (§6.2).
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
+        encode(self).map_err(KtError::from)
+    }
+
+    /// `H("free2z/kt/v1/sth-hash", tls_codec(self))` — what the **next** head's
+    /// `prev_sth_hash` must equal (§6.1).
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn chain_hash(&self) -> Result<Digest, KtError> {
+        Ok(sth_hash(&self.signing_bytes()?))
+    }
+
+    /// Whether this head announces a successor signing key (§6.4).
+    #[must_use]
+    pub fn announces_successor(&self) -> bool {
+        !self.successor_log_pk.is_zero()
+    }
+
+    /// Build the `label` field for a tree head.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the constant does not fit, which it does.
+    pub fn label_bytes() -> Result<ShortBytes, KtError> {
+        label_field(LABEL_STH)
+    }
+}
+
+/// A `SignedTreeHead` (§6.1).
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct SignedTreeHead {
+    /// The signed contents.
+    pub sth: SignedTreeHeadTBS,
+    /// Ed25519 over `tls_codec(sth)`.
+    pub signature: Signature,
+}
+
+impl SignedTreeHead {
+    /// Verify the signature under a log key, having first checked the label,
+    /// version and `log_id` constants (§6.3 rules 1 and 2).
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`], [`KtError::UnsupportedVersion`],
+    /// [`KtError::WrongLog`] or [`KtError::BadSignature`].
+    pub fn verify(&self, log_id: &LogId, log_pk: &PublicKey) -> Result<(), KtError> {
+        self.sth.validate()?;
+        if self.sth.log_id != *log_id {
+            return Err(KtError::WrongLog);
+        }
+        sig::verify(log_pk, &self.sth.signing_bytes()?, &self.signature)
+    }
+}
+
+/// A pinned view of one log: the state §7.1 says a witness holds durably, and
+/// the state §8.1 step 7 says a client pins.
+///
+/// A few hundred bytes. Advancing it is [`LogView::accept`] and there is no
+/// other way, so §6.3's rules cannot be skipped by a caller that forgot them.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LogView {
+    log_id: LogId,
+    accepted_log_pk: PublicKey,
+    epoch: u64,
+    tree_size: u64,
+    root_hash: Digest,
+    sth_hash: Digest,
+    vrf_public_key: PublicKey,
+    published_at_ms: u64,
+}
+
+impl LogView {
+    /// Pin a log from the first tree head this party has ever seen, having
+    /// verified its signature under the key it trusts for this `log_id`.
+    ///
+    /// **This is trust on first use and nothing more.** The first head cannot be
+    /// checked against anything; §6.3's rules are all relative. What makes the
+    /// pin worth having is every head after it.
+    ///
+    /// # Errors
+    ///
+    /// As [`SignedTreeHead::verify`].
+    pub fn pin(
+        log_id: LogId,
+        accepted_log_pk: PublicKey,
+        head: &SignedTreeHead,
+    ) -> Result<Self, KtError> {
+        head.verify(&log_id, &accepted_log_pk)?;
+        Ok(Self {
+            log_id,
+            accepted_log_pk,
+            epoch: head.sth.epoch,
+            tree_size: head.sth.tree_size,
+            root_hash: head.sth.root_hash,
+            sth_hash: head.sth.chain_hash()?,
+            vrf_public_key: head.sth.vrf_public_key,
+            published_at_ms: head.sth.published_at_ms,
+        })
+    }
+
+    /// The pinned `log_id`.
+    #[must_use]
+    pub const fn log_id(&self) -> &LogId {
+        &self.log_id
+    }
+
+    /// The log signing key currently accepted for this `log_id` (§6.4).
+    #[must_use]
+    pub const fn accepted_log_pk(&self) -> &PublicKey {
+        &self.accepted_log_pk
+    }
+
+    /// The last accepted epoch.
+    #[must_use]
+    pub const fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// The last accepted tree size.
+    #[must_use]
+    pub const fn tree_size(&self) -> u64 {
+        self.tree_size
+    }
+
+    /// The last accepted root hash.
+    #[must_use]
+    pub const fn root_hash(&self) -> &Digest {
+        &self.root_hash
+    }
+
+    /// `H("free2z/kt/v1/sth-hash", …)` of the last accepted head.
+    #[must_use]
+    pub const fn sth_hash(&self) -> &Digest {
+        &self.sth_hash
+    }
+
+    /// The VRF key every label in the tree is derived under.
+    #[must_use]
+    pub const fn vrf_public_key(&self) -> &PublicKey {
+        &self.vrf_public_key
+    }
+
+    /// Apply §6.3 in full and advance to `head`.
+    ///
+    /// The eight rules, in §6.3's order:
+    ///
+    /// 1. the signature verifies under the currently accepted log key;
+    /// 2. `label`, `kt_version` and `log_id` are exact;
+    /// 3. `epoch > last.epoch`;
+    /// 4. `tree_size >= last.tree_size`;
+    /// 5. `published_at_ms > last.published_at_ms`;
+    /// 6. `vrf_public_key == last.vrf_public_key`;
+    /// 7. the `prev_sth_hash` chain connects, with **no skipping** over a gap;
+    /// 8. an equal epoch must be byte-identical in root, size and timestamp.
+    ///
+    /// # Errors
+    ///
+    /// - [`KtError::Fork`] — rule 8, and it is fatal. The two heads are the
+    ///   complete evidence (§8.4).
+    /// - [`KtError::Rollback`] — rules 3, 4 or 5.
+    /// - [`KtError::VrfKeyChange`] — rule 6. Treat as a fork, never as an
+    ///   update (§6.1).
+    /// - [`KtError::EpochGap`] — rule 7 with a gap. Fetch the intervening heads
+    ///   and use [`LogView::accept_chain`].
+    /// - [`KtError::ChainBreak`] — rule 7 with a broken link.
+    /// - [`KtError::BadSignature`], [`KtError::WrongLog`],
+    ///   [`KtError::WrongLabel`], [`KtError::UnsupportedVersion`] — rules 1
+    ///   and 2.
+    pub fn accept(&mut self, head: &SignedTreeHead) -> Result<(), KtError> {
+        // Rules 1 and 2.
+        head.verify(&self.log_id, &self.accepted_log_pk)?;
+
+        // Rule 8 first among the ordering rules, because a repeat of the epoch
+        // we already hold is either a no-op or the single most important thing
+        // this function can detect, and reporting it as a rollback would name
+        // the wrong fault in the evidence a witness publishes.
+        if head.sth.epoch == self.epoch {
+            if head.sth.root_hash == self.root_hash
+                && head.sth.tree_size == self.tree_size
+                && head.sth.published_at_ms == self.published_at_ms
+            {
+                // The same head again. Idempotent, and not an advance.
+                return Ok(());
+            }
+            return Err(KtError::Fork);
+        }
+        // Rule 3.
+        if head.sth.epoch < self.epoch {
+            return Err(KtError::Rollback);
+        }
+        // Rule 4.
+        if head.sth.tree_size < self.tree_size {
+            return Err(KtError::Rollback);
+        }
+        // Rule 5.
+        if head.sth.published_at_ms <= self.published_at_ms {
+            return Err(KtError::Rollback);
+        }
+        // Rule 6.
+        if head.sth.vrf_public_key != self.vrf_public_key {
+            return Err(KtError::VrfKeyChange);
+        }
+        // Rule 7. `epoch > self.epoch` here, so the only two cases are the
+        // direct link and a gap; there is no branch that advances without one.
+        if head.sth.epoch != self.epoch.saturating_add(1) {
+            return Err(KtError::EpochGap);
+        }
+        if head.sth.prev_sth_hash != self.sth_hash {
+            return Err(KtError::ChainBreak);
+        }
+
+        self.epoch = head.sth.epoch;
+        self.tree_size = head.sth.tree_size;
+        self.root_hash = head.sth.root_hash;
+        self.sth_hash = head.sth.chain_hash()?;
+        self.published_at_ms = head.sth.published_at_ms;
+        Ok(())
+    }
+
+    /// Walk a contiguous run of tree heads, applying [`LogView::accept`] to
+    /// each in turn.
+    ///
+    /// This is how §6.3 rule 7's *"fetch every intervening tree head and check
+    /// the chain link by link"* is satisfied. The view is advanced only as far
+    /// as the run verified: on failure the caller holds a view pinned to the
+    /// last head that passed, which is the state a witness must persist before
+    /// it halts (§7.1).
+    ///
+    /// # Errors
+    ///
+    /// As [`LogView::accept`], for the first head that fails.
+    pub fn accept_chain(&mut self, heads: &[SignedTreeHead]) -> Result<(), KtError> {
+        for head in heads {
+            self.accept(head)?;
+        }
+        Ok(())
+    }
+
+    /// Install a successor log signing key (§6.4).
+    ///
+    /// All four conditions must hold, and the caller supplies the evidence for
+    /// the first:
+    ///
+    /// 1. the **announcing** head was observed and carried ≥ *t* valid
+    ///    cosignatures from the caller's own witness set — proved by handing in
+    ///    an [`AcceptedRoot`] for it;
+    /// 2. `effective_epoch > announce_epoch`, with at least one full epoch of
+    ///    separation;
+    /// 3. the transition's `announce_sth_hash` matches that head and **both**
+    ///    signatures verify;
+    /// 4. the first head signed by the successor chains to the last one signed
+    ///    by the outgoing key and satisfies §6.3 in full — which is the caller's
+    ///    next [`LogView::accept`], now against the new key.
+    ///
+    /// **The cosignature requirement is not optional.** A party that accepts a
+    /// new signing key on the strength of a signature by that same new key
+    /// accepts any key from any attacker; a party that accepts it on the
+    /// outgoing key alone is safe only until the outgoing key is the thing that
+    /// was compromised — which is the most likely reason to be rotating.
+    /// Requiring that the announcement was itself witnessed means an attacker
+    /// must have already defeated the threshold, at which point they did not
+    /// need the rotation path. That is why this method takes an
+    /// [`AcceptedRoot`], which only [`crate::witness::verify_threshold`]
+    /// constructs.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::BadKeyTransition`] if any structural condition fails,
+    /// [`KtError::BadSignature`] if either signature does not verify,
+    /// [`KtError::WrongLabel`] if the transition is not a transition, and
+    /// [`KtError::WrongLog`] if it is another log's.
+    ///
+    /// [`AcceptedRoot`]: crate::witness::AcceptedRoot
+    pub fn accept_log_key_transition(
+        &mut self,
+        announcing: &SignedTreeHead,
+        announcing_root: &crate::witness::AcceptedRoot,
+        transition: &LogKeyTransition,
+    ) -> Result<(), KtError> {
+        // §6.2, before anything else.
+        check_label(&transition.transition.label, LABEL_LOG_KEY_TRANSITION)?;
+        if transition.transition.log_id != self.log_id {
+            return Err(KtError::WrongLog);
+        }
+        // Condition 1: the cosigned root and the announcing head are the same
+        // head. `AcceptedRoot` cannot be built without meeting the threshold, so
+        // this comparison is what binds that evidence to *this* announcement.
+        if announcing_root.log_id() != &self.log_id
+            || announcing_root.epoch() != announcing.sth.epoch
+            || announcing_root.root_hash() != &announcing.sth.root_hash
+            || announcing_root.tree_size() != announcing.sth.tree_size
+        {
+            return Err(KtError::BadKeyTransition);
+        }
+        announcing.verify(&self.log_id, &self.accepted_log_pk)?;
+        if !announcing.sth.announces_successor() {
+            return Err(KtError::BadKeyTransition);
+        }
+        if announcing.sth.successor_log_pk != transition.transition.successor_log_pk {
+            return Err(KtError::BadKeyTransition);
+        }
+        if transition.transition.outgoing_log_pk != self.accepted_log_pk {
+            return Err(KtError::BadKeyTransition);
+        }
+        if transition.transition.announce_epoch != announcing.sth.epoch {
+            return Err(KtError::BadKeyTransition);
+        }
+        // Condition 3, the hash half.
+        if transition.transition.announce_sth_hash != announcing.sth.chain_hash()? {
+            return Err(KtError::BadKeyTransition);
+        }
+        // Condition 2: strictly later, and at least one full epoch of
+        // separation, so the announcement is visible before it takes effect.
+        // "> announce_epoch, with at least one full epoch of separation" reads
+        // as effective_epoch >= announce_epoch + 2: `announce_epoch + 1` is the
+        // very next epoch, which leaves no epoch in between for anyone to see
+        // the announcement in.
+        if transition.transition.effective_epoch < announcing.sth.epoch.saturating_add(2) {
+            return Err(KtError::BadKeyTransition);
+        }
+        // Condition 3, the signature half: BOTH keys, outgoing and successor.
+        let bytes = transition.transition.signing_bytes()?;
+        sig::verify(
+            &transition.transition.outgoing_log_pk,
+            &bytes,
+            &transition.outgoing_signature,
+        )?;
+        sig::verify(
+            &transition.transition.successor_log_pk,
+            &bytes,
+            &transition.successor_signature,
+        )?;
+
+        // Condition 4 is the caller's next `accept`, which now runs against the
+        // successor key. `log_id` is deliberately untouched: it is derived from
+        // the *genesis* key and never changes (§6.1).
+        self.accepted_log_pk = transition.transition.successor_log_pk;
+        Ok(())
+    }
+}
+
+/// The `LogKeyTransitionTBS` of §6.4.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct LogKeyTransitionTBS {
+    /// Exactly `"free2z/kt/v1/log-key-transition"`.
+    pub label: ShortBytes,
+    /// The log whose key is changing. Unchanged by the rotation (§6.1).
+    pub log_id: LogId,
+    /// The epoch of the announcing tree head.
+    pub announce_epoch: u64,
+    /// `H("free2z/kt/v1/sth-hash", tls_codec(announcing sth))`.
+    pub announce_sth_hash: Digest,
+    /// The key being retired.
+    pub outgoing_log_pk: PublicKey,
+    /// The key being installed.
+    pub successor_log_pk: PublicKey,
+    /// The first epoch signed by the successor.
+    pub effective_epoch: u64,
+}
+
+impl LogKeyTransitionTBS {
+    /// The exact bytes **both** log keys sign.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
+        encode(self).map_err(KtError::from)
+    }
+}
+
+/// A `LogKeyTransition` (§6.4): dual-signed, published, and delayed.
+///
+/// Deliberately the same shape as ADR 0014's user key change — dual signature,
+/// plus published evidence, plus a delay.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct LogKeyTransition {
+    /// The signed contents.
+    pub transition: LogKeyTransitionTBS,
+    /// Ed25519 by `transition.outgoing_log_pk`.
+    pub outgoing_signature: Signature,
+    /// Ed25519 by `transition.successor_log_pk`.
+    pub successor_signature: Signature,
+}
+
+impl LogKeyTransition {
+    /// The canonical bytes, for publication alongside the announcing head.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, KtError> {
+        self.encode_canonical().map_err(KtError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TestLog;
+
+    #[test]
+    fn a_clean_chain_advances() {
+        let log = TestLog::new();
+        let head0 = log.head(0);
+        let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &head0).unwrap();
+        assert_eq!(view.epoch(), 0);
+        for epoch in 1..=5 {
+            assert_eq!(view.accept(&log.head(epoch)), Ok(()));
+            assert_eq!(view.epoch(), epoch);
+        }
+    }
+
+    #[test]
+    fn the_same_head_twice_is_idempotent_and_a_different_one_is_a_fork() {
+        let log = TestLog::new();
+        let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+        view.accept(&log.head(1)).unwrap();
+        assert_eq!(view.accept(&log.head(1)), Ok(()));
+
+        // §6.3 rule 8: same epoch, different root. Fatal, and it is exactly the
+        // evidence §8.4 says two gossiping clients would exchange.
+        let mut forked = log.head(1);
+        forked.sth.root_hash = Digest::new([0xaa; 32]);
+        let forked = log.resign(forked);
+        assert_eq!(view.accept(&forked), Err(KtError::Fork));
+    }
+
+    #[test]
+    fn a_rollback_is_refused_in_every_field_that_can_roll_back() {
+        let log = TestLog::new();
+        let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+        view.accept(&log.head(1)).unwrap();
+        view.accept(&log.head(2)).unwrap();
+
+        assert_eq!(view.accept(&log.head(1)), Err(KtError::Rollback));
+
+        let mut shrunk = log.head(3);
+        shrunk.sth.tree_size = 0;
+        assert_eq!(view.accept(&log.resign(shrunk)), Err(KtError::Rollback));
+
+        let mut stale = log.head(3);
+        stale.sth.published_at_ms = 0;
+        assert_eq!(view.accept(&log.resign(stale)), Err(KtError::Rollback));
+    }
+
+    #[test]
+    fn a_gap_is_never_skipped() {
+        let log = TestLog::new();
+        let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+        // Epoch 3 is signed, chains correctly to epoch 2, and is still refused:
+        // the verifier has not seen 1 or 2.
+        assert_eq!(view.accept(&log.head(3)), Err(KtError::EpochGap));
+        assert_eq!(view.epoch(), 0, "a refused head must not advance the view");
+
+        let intervening = [log.head(1), log.head(2), log.head(3)];
+        assert_eq!(view.accept_chain(&intervening), Ok(()));
+        assert_eq!(view.epoch(), 3);
+    }
+
+    #[test]
+    fn a_broken_chain_link_is_refused() {
+        let log = TestLog::new();
+        let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+        let mut broken = log.head(1);
+        broken.sth.prev_sth_hash = Digest::new([1u8; 32]);
+        assert_eq!(view.accept(&log.resign(broken)), Err(KtError::ChainBreak));
+    }
+
+    #[test]
+    fn a_changed_vrf_key_is_a_fork_not_an_update() {
+        let log = TestLog::new();
+        let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+        let mut swapped = log.head(1);
+        swapped.sth.vrf_public_key = PublicKey::new([9u8; 32]);
+        assert_eq!(
+            view.accept(&log.resign(swapped)),
+            Err(KtError::VrfKeyChange),
+            "it determines every label in the tree; a change invalidates every prior proof",
+        );
+    }
+
+    #[test]
+    fn another_logs_head_and_another_key_are_both_refused() {
+        let log = TestLog::new();
+        let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+
+        let mut foreign = log.head(1);
+        foreign.sth.log_id = LogId::new([3u8; 32]);
+        assert_eq!(view.accept(&log.resign(foreign)), Err(KtError::WrongLog));
+
+        // An unsigned edit: the contents changed and the signature did not.
+        let mut tampered = log.head(1);
+        tampered.sth.reset_count = 41;
+        assert_eq!(view.accept(&tampered), Err(KtError::BadSignature));
+    }
+
+    #[test]
+    fn a_receipt_cannot_be_accepted_as_a_tree_head() {
+        // §6.2's stated reason for the label field: the log's signing key signs
+        // tree heads, receipts and key transitions, so a verifier that accepts
+        // "a signature from the log" over bytes it did not type-check is one
+        // field-alignment coincidence away from this.
+        let log = TestLog::new();
+        let mut head = log.head(1);
+        head.sth.label = ShortBytes::new(crate::labels::LABEL_RECEIPT.to_vec()).unwrap();
+        let head = log.resign(head);
+        let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+        assert_eq!(view.accept(&head), Err(KtError::WrongLabel));
+    }
+}

--- a/rs/crates/f2z-kt-core/src/submit.rs
+++ b/rs/crates/f2z-kt-core/src/submit.rs
@@ -1,0 +1,942 @@
+//! **The one door into the log.** `KT.md` §4.4's submission rules, as the
+//! single function a directory server calls before anything reaches `akd`.
+//!
+//! # Read this before changing anything in this file
+//!
+//! > **`akd` enforces none of it.** The library will happily commit any bytes to
+//! > any label. Every rule below lives in our submission path, and a log that
+//! > skips them produces inclusion, history and append-only proofs that verify
+//! > **perfectly** for entries nobody authorized. The transparency machinery
+//! > proves that the log did not *change its mind*; §4.4 is the only thing that
+//! > proves the log did not *make it up*.
+//!
+//! That is why this module offers exactly one entry point,
+//! [`validate_submission`], and no helpers. There is no `check_rotation`, no
+//! `verify_device_credentials`, no "validate the easy parts now and the rest
+//! later". A server cannot route around the rules because there is nothing to
+//! route around them *to*: the only value that carries the bytes `akd` needs is
+//! [`AcceptedSubmission`], it has no public constructor, and every accessor on
+//! it — the canonical bytes, the `AkdValue`, the `AkdLabel` — exists only on
+//! that type.
+//!
+//! The same reasoning shapes [`PublishedEntry`]. The log does not get to *assert*
+//! what the previous entry's `prev_entry_hash` or `directory_auth_pk` were; it
+//! must hold the previous `DirectoryEntry` and let
+//! [`PublishedEntry::from_entry`] recompute them. A log that could pass in a
+//! hash of its choosing could authorize any successor it liked.
+//!
+//! # Where this is stricter than §4.4's enumerated list, and why
+//!
+//! §4.4 enumerates nine rules and its table names three authorization shapes.
+//! Four things follow from ADR 0014's case analysis but are not in the numbered
+//! list, and this module enforces all four. They are called out at the point of
+//! use below and repeated here so a reviewer sees them together:
+//!
+//! 1. **A `same_key` entry MUST NOT change `identity_pk`.** Without this the
+//!    rule set has a hole large enough to drive ADR 0014 through: `same_key` is
+//!    authorized by the *previous* `directory_auth_pk` alone, so a party holding
+//!    only that key could publish a new `identity_pk` — a key change with one
+//!    signature, which is exactly what ADR 0014 says the log MUST reject.
+//! 2. **A `key_change` or `platform_reset` MUST change `identity_pk`.**
+//!    Otherwise one operation has two encodings inside a structure that is
+//!    hashed, signed and committed.
+//! 3. **A `platform_reset` MUST be refused when the previous entry set
+//!    `no_reset`.** That flag is a user's declaration that the reset path does
+//!    not apply to their handle; a flag nothing enforces is a comment.
+//! 4. **A `ResetAuthorization` is bound to its handle, log, version and
+//!    outgoing key**, exactly as §4.4 rule 6 binds a `RotationProof`. §4.4
+//!    rule 7 mentions only the signature and the cooldown, which would leave a
+//!    reset signed for `@alice` at version 3 usable against `@bob`.
+
+use f2z_codec::canonical::decode_canonical;
+use f2z_codec::types::{Digest, PublicKey};
+
+use crate::entry::{DirectoryEntry, EntryAuthorization};
+use crate::error::KtError;
+use crate::labels::{akd_label, entry_value, prev_entry_hash};
+use crate::sig;
+use crate::types::{Handle, LogId};
+
+/// The published policy a submission is judged against (§9.1).
+///
+/// `reset_authority_pk` is here because the **log** must check a reset against
+/// the same key clients pinned. That the log also publishes the key in its
+/// descriptor is a convenience for humans comparing it; it is not where either
+/// side gets the key it verifies with.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LogPolicy {
+    log_id: LogId,
+    reset_authority_pk: PublicKey,
+    reset_cooldown_seconds: u32,
+}
+
+impl LogPolicy {
+    /// Fix the policy a submission is judged against.
+    #[must_use]
+    pub const fn new(
+        log_id: LogId,
+        reset_authority_pk: PublicKey,
+        reset_cooldown_seconds: u32,
+    ) -> Self {
+        Self {
+            log_id,
+            reset_authority_pk,
+            reset_cooldown_seconds,
+        }
+    }
+
+    /// The log this policy is for.
+    #[must_use]
+    pub const fn log_id(&self) -> &LogId {
+        &self.log_id
+    }
+
+    /// The pinned reset authority key (ADR 0014).
+    #[must_use]
+    pub const fn reset_authority_pk(&self) -> &PublicKey {
+        &self.reset_authority_pk
+    }
+
+    /// The published cooldown a `platform_reset` must observe.
+    #[must_use]
+    pub const fn reset_cooldown_seconds(&self) -> u32 {
+        self.reset_cooldown_seconds
+    }
+
+    /// The cooldown in milliseconds, saturating.
+    #[must_use]
+    pub const fn reset_cooldown_ms(&self) -> u64 {
+        (self.reset_cooldown_seconds as u64).saturating_mul(1_000)
+    }
+}
+
+/// What the log has already **published** for a handle.
+///
+/// Deliberately not constructible from loose fields. The only way to build one
+/// is from the previous `DirectoryEntry` itself — [`PublishedEntry::from_entry`]
+/// — or from the submission that produced it —
+/// [`AcceptedSubmission::published`]. Everything in here is *derived* from bytes
+/// the log committed to, so a log cannot hand [`validate_submission`] a
+/// predecessor of its own invention.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublishedEntry {
+    handle: Handle,
+    entry_version: u32,
+    chain_hash: Digest,
+    identity_pk: PublicKey,
+    directory_auth_pk: PublicKey,
+    no_reset: bool,
+}
+
+impl PublishedEntry {
+    /// Derive the published state from the previous entry's own bytes.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the entry cannot be re-encoded, and whatever
+    /// [`DirectoryEntry::validate`] returns for an entry that never should have
+    /// been published.
+    pub fn from_entry(entry: &DirectoryEntry) -> Result<Self, KtError> {
+        entry.validate()?;
+        Ok(Self {
+            handle: entry.entry.handle.clone(),
+            entry_version: entry.entry.entry_version,
+            chain_hash: entry.chain_hash()?,
+            identity_pk: entry.entry.identity_pk,
+            directory_auth_pk: entry.entry.directory_auth_pk,
+            no_reset: entry.entry.no_reset != 0,
+        })
+    }
+
+    /// The handle this state is for.
+    #[must_use]
+    pub const fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    /// The published `entry_version`.
+    #[must_use]
+    pub const fn entry_version(&self) -> u32 {
+        self.entry_version
+    }
+
+    /// `H("free2z/kt/v1/prev", tls_codec(previous DirectoryEntry))` — what the
+    /// next entry's `prev_entry_hash` must equal.
+    #[must_use]
+    pub const fn chain_hash(&self) -> &Digest {
+        &self.chain_hash
+    }
+
+    /// The identity key in force.
+    #[must_use]
+    pub const fn identity_pk(&self) -> &PublicKey {
+        &self.identity_pk
+    }
+
+    /// The directory-auth key in force — the key a `same_key` update must be
+    /// signed by.
+    #[must_use]
+    pub const fn directory_auth_pk(&self) -> &PublicKey {
+        &self.directory_auth_pk
+    }
+
+    /// Whether this handle has foreclosed the platform reset path (ADR 0014).
+    #[must_use]
+    pub const fn no_reset(&self) -> bool {
+        self.no_reset
+    }
+}
+
+/// Everything [`validate_submission`] needs that is not in the submitted bytes.
+#[derive(Clone, Copy, Debug)]
+pub struct SubmissionContext<'a> {
+    /// The log's published policy.
+    pub policy: &'a LogPolicy,
+    /// The previously published entry for this handle, or `None` if the handle
+    /// has never been registered.
+    pub previous: Option<&'a PublishedEntry>,
+    /// Whether an entry for this handle is already accepted into the epoch
+    /// currently being assembled (§4.3).
+    ///
+    /// **This is the NCC Group finding.** `publish()` with duplicate labels in
+    /// one batch left a dangling interior node and no valid key for the user.
+    /// The library defect is fixed; the property that a caller must not hand
+    /// `publish()` duplicate labels is a property of the *integration*, which is
+    /// precisely the region NCC said its review did not cover.
+    pub pending_in_epoch: bool,
+    /// The log's clock, milliseconds since the Unix epoch.
+    ///
+    /// Passed in rather than read, so this crate has no clock and a test can
+    /// stand at any instant. Used for exactly one thing: §4.4 rule 7's *"the log
+    /// MUST NOT publish the entry before `effective_at_ms`."*
+    pub now_ms: u64,
+}
+
+/// A submission that satisfied every rule in §4.4.
+///
+/// The only way to obtain the bytes and the label/value pair `akd` needs. No
+/// public constructor, no `From`, no field access — because the point of this
+/// crate is that a server holding a `DirectoryEntry` cannot get to `publish()`
+/// without going through [`validate_submission`] first.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AcceptedSubmission {
+    entry: DirectoryEntry,
+    canonical: Vec<u8>,
+    akd_value: Digest,
+    akd_label: Vec<u8>,
+}
+
+impl AcceptedSubmission {
+    /// The validated entry.
+    #[must_use]
+    pub const fn entry(&self) -> &DirectoryEntry {
+        &self.entry
+    }
+
+    /// The canonical bytes, per re-encode equality (`WIRE.md` §3.3). These, and
+    /// never the received bytes, are what was hashed.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical
+    }
+
+    /// `AkdValue = H("free2z/kt/v1/value", tls_codec(DirectoryEntry))` (§3.3) —
+    /// the 32 bytes the tree commits to.
+    #[must_use]
+    pub const fn akd_value(&self) -> &Digest {
+        &self.akd_value
+    }
+
+    /// `AkdLabel = "free2z/kt/v1/handle:" || handle` (§3.3).
+    #[must_use]
+    pub fn akd_label(&self) -> &[u8] {
+        &self.akd_label
+    }
+
+    /// The published state this entry becomes once it is in a tree — the
+    /// `previous` for the next submission.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the entry cannot be re-encoded, which it can:
+    /// it was decoded from bytes.
+    pub fn published(&self) -> Result<PublishedEntry, KtError> {
+        PublishedEntry::from_entry(&self.entry)
+    }
+}
+
+/// **Validate a submitted `DirectoryEntry` against every rule in `KT.md` §4.4.**
+///
+/// The rules are applied in §4.4's stated order. Each numbered comment in the
+/// body is the corresponding numbered rule, and the four additional rules the
+/// module note explains are marked where they run.
+///
+/// # Errors
+///
+/// - [`KtError::Malformed`] — rule 1: the bytes did not decode, or re-encoded
+///   differently. Also a shape violation a decoder cannot express: a bad
+///   `no_reset`, a duplicated `device_pk`, an empty KEM key.
+/// - [`KtError::WrongLabel`] / [`KtError::UnsupportedVersion`] /
+///   [`KtError::WrongLog`] — rule 2.
+/// - [`KtError::BadHandle`] — rule 3's charset half.
+/// - [`KtError::VersionConflict`] — rule 3's version half and rule 4.
+/// - [`KtError::BadAuthorization`] — rule 5, and rules 6/7's structural halves.
+///   The wire code is `ERR_BAD_AUTHORIZATION`: *structurally valid but §4.4's
+///   rules unmet — e.g. a key change with one signature.*
+/// - [`KtError::BadSignature`] — any signature that did not verify, including
+///   rule 6's `RotationProof`, rule 7's reset and rule 8's device credentials.
+/// - [`KtError::Cooldown`] — rule 7's timing half.
+/// - [`KtError::DuplicateInEpoch`] — rule 9.
+pub fn validate_submission(
+    submitted: &[u8],
+    context: &SubmissionContext<'_>,
+) -> Result<AcceptedSubmission, KtError> {
+    // ---- Rule 1. Re-encode equality (WIRE.md §3.3). --------------------------
+    //
+    // Delegated to `f2z-codec`, which is the only implementation of the rule in
+    // this tree. It hands back the *re-encoded* bytes, never the received ones,
+    // so everything hashed below is canonical by construction rather than by
+    // discipline.
+    let decoded = decode_canonical::<DirectoryEntry>(submitted)?;
+    let entry = decoded.value().clone();
+    let canonical = decoded.bytes().to_vec();
+
+    // ---- Rules 2, 3 (charset), 5 (kind agreement) and 8 (duplicate device
+    // ---- keys), plus the shape checks a decode cannot express. ---------------
+    //
+    // `DirectoryEntry::validate` checks the label first, per §6.2's "a verifier
+    // MUST check it before anything else".
+    entry.validate()?;
+
+    // ---- Rule 2, the log_id half. -------------------------------------------
+    if entry.entry.log_id != *context.policy.log_id() {
+        return Err(KtError::WrongLog);
+    }
+
+    // ---- Rule 3, the version half, and rule 4. ------------------------------
+    match context.previous {
+        None => {
+            // A handle nobody has registered. §4.2 fixes the version and the
+            // all-zero `prev_entry_hash`; `DirectoryEntry::validate` has already
+            // tied those two together, so only the version needs saying here.
+            if entry.entry.entry_version != 1 {
+                return Err(KtError::VersionConflict);
+            }
+        }
+        Some(previous) => {
+            if previous.handle() != &entry.entry.handle {
+                // The caller looked up the wrong predecessor. Refusing rather
+                // than trusting the lookup keeps the chain rules meaningful.
+                return Err(KtError::VersionConflict);
+            }
+            if entry.entry.entry_version != previous.entry_version().saturating_add(1) {
+                return Err(KtError::VersionConflict);
+            }
+            // Rule 4.
+            if entry.entry.prev_entry_hash != *previous.chain_hash() {
+                return Err(KtError::VersionConflict);
+            }
+        }
+    }
+
+    // ---- Rule 5. The authorization table of §4.4. ---------------------------
+    //
+    // `authorization.kind == entry.kind` was checked by `validate`. What is left
+    // is the table itself: which key signs `auth_signature`, and what else must
+    // be present.
+    let entry_bytes = entry.entry.signing_bytes()?;
+    match (&entry.authorization, context.previous) {
+        // -- same_key ---------------------------------------------------------
+        (EntryAuthorization::SameKey { auth_signature }, previous) => {
+            let signing_key = match previous {
+                // §4.4's table: the `directory_auth_pk` **published in the
+                // previous entry**. The blast-radius argument in §4.4 depends on
+                // this being the previous key and not this entry's: if a
+                // submission could nominate the key that authorizes it, the
+                // signature would prove only that whoever wrote the entry also
+                // wrote the entry.
+                Some(previous) => {
+                    // ADDITIONAL RULE 1 (see the module note). ADR 0014 case 1
+                    // is "the identity key is unchanged"; §4.4's numbered list
+                    // does not restate it, and without it a party holding only
+                    // the previous `DirectoryAuthKey` could install a new
+                    // `identity_pk` — a key change with one signature, which
+                    // ADR 0014 says the log MUST reject.
+                    if entry.entry.identity_pk != *previous.identity_pk() {
+                        return Err(KtError::BadAuthorization);
+                    }
+                    previous.directory_auth_pk()
+                }
+                // Version 1: there is no previous entry and therefore no
+                // previously published key. AMBIGUITY CALL — §4.4's table has no
+                // row for a handle's first entry. Read as trust-on-first-
+                // registration: the entry is self-signed by the
+                // `directory_auth_pk` it publishes. Nothing weaker is possible
+                // (there is no earlier key) and nothing stronger is specified;
+                // what makes it safe is that the *registration* is what a client
+                // pins, and every later change is chained to it.
+                None => &entry.entry.directory_auth_pk,
+            };
+            sig::verify(signing_key, &entry_bytes, auth_signature)?;
+        }
+
+        // -- key_change -------------------------------------------------------
+        (
+            EntryAuthorization::KeyChange {
+                rotation,
+                auth_signature,
+            },
+            previous,
+        ) => {
+            // AMBIGUITY CALL — a key change needs a key to change *from*. §4.4
+            // rule 6 requires the `RotationProof`'s `old_identity_pk` to equal
+            // "the previous entry's `identity_pk`", which does not exist at
+            // version 1, so a version-1 key change cannot satisfy rule 6 and is
+            // refused here rather than left to fail obscurely.
+            let Some(previous) = previous else {
+                return Err(KtError::BadAuthorization);
+            };
+
+            // ---- Rule 6, structural half. -----------------------------------
+            //
+            // "A key change carrying only one of the two signatures MUST be
+            // rejected." That is enforced by the type: `EntryAuthorization`
+            // has no key-change variant without a `RotationProof`, so a
+            // submission carrying one signature does not decode as a key change
+            // at all. What is left to check is that the proof is about *this*
+            // rotation.
+            let proof = &rotation.proof;
+            if proof.log_id != *context.policy.log_id()
+                || proof.handle != entry.entry.handle
+                || proof.entry_version != entry.entry.entry_version
+                || proof.prev_entry_hash != entry.entry.prev_entry_hash
+                || proof.old_identity_pk != *previous.identity_pk()
+                || proof.new_identity_pk != entry.entry.identity_pk
+            {
+                return Err(KtError::BadAuthorization);
+            }
+            // ADDITIONAL RULE 2. A "key change" that changes no key is a
+            // `same_key` update wearing the wrong label, and would give one
+            // operation two encodings inside a structure that is hashed and
+            // signed.
+            if proof.old_identity_pk == proof.new_identity_pk {
+                return Err(KtError::BadAuthorization);
+            }
+
+            // ---- Rule 6, signature half: the OUTGOING identity key. ---------
+            //
+            // "The outgoing signature stops the log operator from swapping a
+            // key" (ADR 0014).
+            sig::verify(
+                &proof.old_identity_pk,
+                &proof.signing_bytes()?,
+                &rotation.signature,
+            )?;
+
+            // ---- Rule 5, the table: the NEW `directory_auth_pk`. ------------
+            //
+            // "The incoming signature stops a stolen or mis-transcribed new key
+            // from being installed without proof of possession" (ADR 0014).
+            sig::verify(&entry.entry.directory_auth_pk, &entry_bytes, auth_signature)?;
+        }
+
+        // -- platform_reset ---------------------------------------------------
+        (
+            EntryAuthorization::PlatformReset {
+                reset,
+                auth_signature,
+            },
+            previous,
+        ) => {
+            // AMBIGUITY CALL, as for `key_change`: a reset displaces an existing
+            // key, and §4.4 has no reading under which an unregistered handle
+            // has one. A platform-authority registration of a fresh handle would
+            // be a different operation with different consequences, and
+            // inventing it here is not this crate's to do.
+            let Some(previous) = previous else {
+                return Err(KtError::BadAuthorization);
+            };
+
+            // ADDITIONAL RULE 3. ADR 0014: a user who sets `no_reset` is
+            // declaring that the reset path does not apply to their handle —
+            // "losing the key means losing the handle, permanently, with no
+            // recovery." A flag nothing enforces is a comment, and this is the
+            // strongest posture the system offers.
+            if previous.no_reset() {
+                return Err(KtError::BadAuthorization);
+            }
+
+            let authorization = &reset.reset;
+            // ADDITIONAL RULE 4. §4.4 rule 7 names only the signature and the
+            // cooldown. Binding the authorization to its handle, log, version
+            // and outgoing key is what stops a reset signed for `@alice` at
+            // version 3 from being replayed against `@bob` — exactly the
+            // bindings rule 6 already demands of a `RotationProof`.
+            if authorization.log_id != *context.policy.log_id()
+                || authorization.handle != entry.entry.handle
+                || authorization.entry_version != entry.entry.entry_version
+                || authorization.old_identity_pk != *previous.identity_pk()
+                || authorization.new_identity_pk != entry.entry.identity_pk
+            {
+                return Err(KtError::BadAuthorization);
+            }
+            // ADDITIONAL RULE 2 again, for the same reason.
+            if authorization.old_identity_pk == authorization.new_identity_pk {
+                return Err(KtError::BadAuthorization);
+            }
+
+            // ---- Rule 7, signature half: the PINNED reset authority. --------
+            sig::verify(
+                context.policy.reset_authority_pk(),
+                &authorization.signing_bytes()?,
+                &reset.reset_signature,
+            )?;
+
+            // ---- Rule 7, timing half. ---------------------------------------
+            //
+            // "The cooldown is the part that gives the victim something to do"
+            // (ADR 0014). Two separate conditions and both are required: the
+            // authorization must *declare* at least the published cooldown, and
+            // the log must not publish before the declared instant.
+            let declared = authorization
+                .effective_at_ms
+                .checked_sub(authorization.created_at_ms)
+                .ok_or(KtError::Cooldown)?;
+            if declared < context.policy.reset_cooldown_ms() {
+                return Err(KtError::Cooldown);
+            }
+            if context.now_ms < authorization.effective_at_ms {
+                return Err(KtError::Cooldown);
+            }
+
+            // ---- Rule 5, the table: this entry's `directory_auth_pk`. -------
+            sig::verify(&entry.entry.directory_auth_pk, &entry_bytes, auth_signature)?;
+        }
+    }
+
+    // ---- Rule 8. Device credentials. ----------------------------------------
+    //
+    // "Every `DeviceCredential` signature verifies under **this entry's**
+    // `identity_pk`" — under the entry's key, not under the key the credential
+    // carries, or a credential could authenticate itself. The two are then
+    // required to be equal, because an MLS peer validating the credential in a
+    // `LeafNode` has no directory access and will use the embedded key; if the
+    // two could differ, the peer and the directory client would reach different
+    // verdicts about the same device.
+    //
+    // The "no two credentials share a `device_pk`" half ran in `validate`.
+    for credential in entry.entry.devices.as_slice() {
+        if credential.credential.identity_pk != entry.entry.identity_pk {
+            return Err(KtError::BadAuthorization);
+        }
+        sig::verify(
+            &entry.entry.identity_pk,
+            &credential.credential.signing_bytes()?,
+            &credential.signature,
+        )?;
+    }
+
+    // ---- Rule 9. §4.3's uniqueness rule. ------------------------------------
+    //
+    // "The log MUST accept at most one entry per handle per epoch." Last in
+    // §4.4's order, and it is not a convenience rule: it is the mitigation for
+    // NCC Group's Medium-severity finding against `akd`.
+    if context.pending_in_epoch {
+        return Err(KtError::DuplicateInEpoch);
+    }
+
+    let akd_value = entry_value(&canonical);
+    let akd_label = akd_label(&entry.entry.handle);
+    Ok(AcceptedSubmission {
+        entry,
+        canonical,
+        akd_value,
+        akd_label,
+    })
+}
+
+/// `H("free2z/kt/v1/prev", …)` of an entry the caller already holds.
+///
+/// A thin convenience for a log that is rebuilding its index from stored bytes.
+/// It is *not* a way around [`validate_submission`]: it produces a hash, not an
+/// [`AcceptedSubmission`], and nothing downstream accepts a bare hash.
+#[must_use]
+pub fn chain_hash_of(canonical_entry: &[u8]) -> Digest {
+    prev_entry_hash(canonical_entry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::{TestDirectory, signing_key};
+    use f2z_codec::canonical::Canonical as _;
+    use f2z_codec::types::Signature;
+
+    fn accept(
+        directory: &TestDirectory,
+        entry: &DirectoryEntry,
+        previous: Option<&PublishedEntry>,
+        now_ms: u64,
+    ) -> Result<AcceptedSubmission, KtError> {
+        let policy = directory.policy();
+        let context = SubmissionContext {
+            policy: &policy,
+            previous,
+            pending_in_epoch: false,
+            now_ms,
+        };
+        validate_submission(&entry.encode_canonical().unwrap(), &context)
+    }
+
+    #[test]
+    fn the_happy_path_registers_a_handle_and_then_updates_it() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let accepted = accept(&directory, &genesis, None, 0).expect("a valid registration");
+        assert_eq!(
+            accepted.akd_label(),
+            b"free2z/kt/v1/handle:alice",
+            "§3.3's label shape",
+        );
+        assert_eq!(
+            accepted.akd_value(),
+            &entry_value(&genesis.encode_canonical().unwrap()),
+        );
+
+        let published = accepted.published().unwrap();
+        let update = directory.same_key_update(&genesis);
+        let accepted = accept(&directory, &update, Some(&published), 0).expect("a valid update");
+        assert_eq!(accepted.entry().entry.entry_version, 2);
+    }
+
+    #[test]
+    fn a_wrong_prev_entry_hash_is_refused() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+
+        let mut update = directory.same_key_update(&genesis);
+        update.entry.prev_entry_hash = Digest::new([0x5a; 32]);
+        let update = directory.reauthorize_same_key(update, &genesis);
+        assert_eq!(
+            accept(&directory, &update, Some(&published), 0),
+            Err(KtError::VersionConflict),
+            "a truncated or substituted history has to break a hash, not merely omit a proof",
+        );
+    }
+
+    #[test]
+    fn a_version_gap_or_repeat_is_refused() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+
+        let mut skipped = directory.same_key_update(&genesis);
+        skipped.entry.entry_version = 3;
+        let skipped = directory.reauthorize_same_key(skipped, &genesis);
+        assert_eq!(
+            accept(&directory, &skipped, Some(&published), 0),
+            Err(KtError::VersionConflict),
+        );
+
+        // And a replay of the entry that is already published.
+        assert_eq!(
+            accept(&directory, &genesis, Some(&published), 0),
+            Err(KtError::VersionConflict),
+        );
+    }
+
+    #[test]
+    fn a_registration_must_be_version_one() {
+        let directory = TestDirectory::new();
+        let mut entry = directory.genesis();
+        entry.entry.entry_version = 2;
+        entry.entry.prev_entry_hash = Digest::new([1u8; 32]);
+        let entry = directory.reauthorize_genesis(entry);
+        assert_eq!(
+            accept(&directory, &entry, None, 0),
+            Err(KtError::VersionConflict),
+        );
+    }
+
+    #[test]
+    fn a_key_change_signed_by_only_the_new_key_is_rejected() {
+        // ADR 0014: "The log MUST reject a key change carrying only one."
+        // A key change whose RotationProof does not verify is exactly that:
+        // the new key's signature is present and valid, and the outgoing key's
+        // is not.
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+        let new_isk = signing_key(60);
+        let new_auth = signing_key(61);
+
+        let mut rotated = directory.key_change(&genesis, &new_isk, &new_auth);
+        if let EntryAuthorization::KeyChange { rotation, .. } = &mut rotated.authorization {
+            rotation.signature = Signature::new([0u8; 64]);
+        }
+        assert_eq!(
+            accept(&directory, &rotated, Some(&published), 0),
+            Err(KtError::BadSignature),
+        );
+    }
+
+    #[test]
+    fn a_key_change_signed_by_only_the_old_key_is_rejected() {
+        // The mirror image: a valid RotationProof by the outgoing ISK, and no
+        // valid proof of possession of the new key.
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+        let new_isk = signing_key(60);
+        let new_auth = signing_key(61);
+
+        let mut rotated = directory.key_change(&genesis, &new_isk, &new_auth);
+        if let EntryAuthorization::KeyChange { auth_signature, .. } = &mut rotated.authorization {
+            *auth_signature = Signature::new([0u8; 64]);
+        }
+        assert_eq!(
+            accept(&directory, &rotated, Some(&published), 0),
+            Err(KtError::BadSignature),
+        );
+    }
+
+    #[test]
+    fn a_key_change_authorized_by_a_rotation_proof_for_another_handle_is_rejected() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+        let new_isk = signing_key(60);
+        let new_auth = signing_key(61);
+
+        let mut rotated = directory.key_change(&genesis, &new_isk, &new_auth);
+        if let EntryAuthorization::KeyChange { rotation, .. } = &mut rotated.authorization {
+            rotation.proof.handle = Handle::new(b"mallory".to_vec()).unwrap();
+            // Re-sign, so this is a *correctly signed* proof about a different
+            // handle rather than a signature failure.
+            *rotation = directory.sign_rotation(rotation.proof.clone(), &directory.identity_key());
+        }
+        assert_eq!(
+            accept(&directory, &rotated, Some(&published), 0),
+            Err(KtError::BadAuthorization),
+        );
+    }
+
+    #[test]
+    fn a_same_key_entry_must_not_change_the_identity_key() {
+        // The hole in §4.4's numbered list. `same_key` is authorized by the
+        // PREVIOUS directory_auth_pk alone, so without this rule a party holding
+        // only that key rotates the identity with one signature.
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+
+        let mut smuggled = directory.same_key_update(&genesis);
+        smuggled.entry.identity_pk = crate::testing::public_key_of(&signing_key(70));
+        let smuggled = directory.reauthorize_same_key(smuggled, &genesis);
+        assert_eq!(
+            accept(&directory, &smuggled, Some(&published), 0),
+            Err(KtError::BadAuthorization),
+            "a key change with one signature, wearing a same_key label",
+        );
+    }
+
+    #[test]
+    fn a_reset_before_its_cooldown_is_refused() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+        let new_isk = signing_key(80);
+        let new_auth = signing_key(81);
+        let cooldown_ms = directory.policy().reset_cooldown_ms();
+
+        // Declares the full cooldown, submitted one millisecond early.
+        let reset = directory.platform_reset(&genesis, &new_isk, &new_auth, 0);
+        assert_eq!(
+            accept(
+                &directory,
+                &reset,
+                Some(&published),
+                cooldown_ms.saturating_sub(1)
+            ),
+            Err(KtError::Cooldown),
+        );
+        assert!(accept(&directory, &reset, Some(&published), cooldown_ms).is_ok());
+
+        // Declares a shorter cooldown than the log published: refused whenever
+        // it is submitted, including long afterwards.
+        let mut short = directory.platform_reset(&genesis, &new_isk, &new_auth, 0);
+        if let EntryAuthorization::PlatformReset { reset, .. } = &mut short.authorization {
+            reset.reset.effective_at_ms = reset.reset.created_at_ms.saturating_add(1_000);
+            *reset = directory.sign_reset(reset.reset.clone());
+        }
+        let short = directory.reauthorize_reset(short, &new_auth);
+        assert_eq!(
+            accept(&directory, &short, Some(&published), u64::MAX),
+            Err(KtError::Cooldown),
+        );
+    }
+
+    #[test]
+    fn a_reset_signed_by_anything_but_the_pinned_authority_is_refused() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+        let cooldown_ms = directory.policy().reset_cooldown_ms();
+
+        let mut reset = directory.platform_reset(&genesis, &signing_key(80), &signing_key(81), 0);
+        if let EntryAuthorization::PlatformReset { reset, .. } = &mut reset.authorization {
+            // A valid signature by a key that is not the pinned authority.
+            reset.reset_signature =
+                crate::testing::sign(&signing_key(99), &reset.reset.signing_bytes().unwrap());
+        }
+        assert_eq!(
+            accept(&directory, &reset, Some(&published), cooldown_ms),
+            Err(KtError::BadSignature),
+        );
+    }
+
+    #[test]
+    fn a_reset_is_refused_against_a_handle_that_set_no_reset() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis_no_reset();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+        assert!(published.no_reset());
+        let cooldown_ms = directory.policy().reset_cooldown_ms();
+
+        let reset = directory.platform_reset(&genesis, &signing_key(80), &signing_key(81), 0);
+        assert_eq!(
+            accept(&directory, &reset, Some(&published), cooldown_ms),
+            Err(KtError::BadAuthorization),
+            "ADR 0014: losing the key means losing the handle, permanently",
+        );
+    }
+
+    #[test]
+    fn a_device_credential_signed_by_the_wrong_identity_key_is_refused() {
+        let directory = TestDirectory::new();
+        let genesis = directory.wrong_signer_credential();
+        assert_eq!(
+            accept(&directory, &genesis, None, 0),
+            Err(KtError::BadSignature),
+        );
+    }
+
+    #[test]
+    fn a_device_credential_naming_another_identity_key_is_refused() {
+        // Self-consistent — signed by the key it names — and still refused: an
+        // MLS peer would validate it against the embedded key and reach a
+        // different verdict from the directory client.
+        let directory = TestDirectory::new();
+        let genesis = directory.foreign_identity_credential();
+        assert_eq!(
+            accept(&directory, &genesis, None, 0),
+            Err(KtError::BadAuthorization),
+        );
+    }
+
+    #[test]
+    fn a_second_entry_for_a_handle_in_one_epoch_is_refused() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+        let update = directory.same_key_update(&genesis);
+        let policy = directory.policy();
+        let context = SubmissionContext {
+            policy: &policy,
+            previous: Some(&published),
+            pending_in_epoch: true,
+            now_ms: 0,
+        };
+        assert_eq!(
+            validate_submission(&update.encode_canonical().unwrap(), &context),
+            Err(KtError::DuplicateInEpoch),
+            "NCC Group's Medium finding: publish() must never see duplicate labels",
+        );
+    }
+
+    #[test]
+    fn an_entry_for_another_log_is_refused() {
+        let directory = TestDirectory::new();
+        let mut entry = directory.genesis();
+        entry.entry.log_id = LogId::new([0x77; 32]);
+        let entry = directory.reauthorize_genesis(entry);
+        assert_eq!(accept(&directory, &entry, None, 0), Err(KtError::WrongLog));
+    }
+
+    #[test]
+    fn trailing_bytes_are_refused_before_any_signature_is_checked() {
+        let directory = TestDirectory::new();
+        let policy = directory.policy();
+        let context = SubmissionContext {
+            policy: &policy,
+            previous: None,
+            pending_in_epoch: false,
+            now_ms: 0,
+        };
+        let mut bytes = directory.genesis().encode_canonical().unwrap();
+        bytes.push(0);
+        assert_eq!(
+            validate_submission(&bytes, &context),
+            Err(KtError::Malformed),
+        );
+    }
+
+    #[test]
+    fn a_key_change_or_reset_at_version_one_is_refused() {
+        // AMBIGUITY CALL, tested: §4.4's table has no row for a handle's first
+        // entry, and rules 6 and 7 both bind the authorization to "the previous
+        // entry's identity_pk", which does not exist. A registration is a
+        // `same_key` entry; nothing else.
+        let directory = TestDirectory::new();
+        assert_eq!(
+            accept(&directory, &directory.key_change_at_version_one(), None, 0),
+            Err(KtError::BadAuthorization),
+        );
+        assert_eq!(
+            accept(
+                &directory,
+                &directory.platform_reset_at_version_one(),
+                None,
+                u64::MAX,
+            ),
+            Err(KtError::BadAuthorization),
+        );
+    }
+
+    #[test]
+    fn a_later_version_with_no_published_predecessor_is_refused() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let update = directory.same_key_update(&genesis);
+        assert_eq!(
+            accept(&directory, &update, None, 0),
+            Err(KtError::VersionConflict),
+        );
+    }
+
+    #[test]
+    fn a_key_change_that_changes_no_key_is_refused() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+        let rotated = directory.key_change(&genesis, &directory.identity_key(), &signing_key(61));
+        assert_eq!(
+            accept(&directory, &rotated, Some(&published), 0),
+            Err(KtError::BadAuthorization),
+        );
+    }
+
+    #[test]
+    fn the_previous_entry_must_be_the_one_for_this_handle() {
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let other = TestDirectory::for_handle(b"bob");
+        let published = PublishedEntry::from_entry(&other.genesis()).unwrap();
+        let update = directory.same_key_update(&genesis);
+        assert_eq!(
+            accept(&directory, &update, Some(&published), 0),
+            Err(KtError::VersionConflict),
+        );
+    }
+}

--- a/rs/crates/f2z-kt-core/src/testing.rs
+++ b/rs/crates/f2z-kt-core/src/testing.rs
@@ -1,0 +1,633 @@
+//! Deterministic builders for the crate's own tests.
+//!
+//! `#[cfg(test)]` only, and deliberately so: shipping a fixture builder would
+//! ship a way to construct a plausible directory entry, and the whole design of
+//! [`crate::submit`] is that the only route to a validated entry is through
+//! validation. Nothing here is reachable from a release build.
+//!
+//! Every key is derived from a `u8` seed so the tests carry no randomness and no
+//! clock. That matters more than convenience: a signature test that depends on
+//! entropy is a test whose failures cannot be reproduced from the failure
+//! message.
+
+use ed25519_dalek::{Signer as _, SigningKey};
+use f2z_codec::types::{Digest, PublicKey, QueueAddress, RelayId, ShortBytes, Signature};
+use f2z_codec::vec::{VecU8, VecU16};
+
+use crate::KT_VERSION;
+use crate::cosign::{WitnessCosignature, WitnessCosignatureTBS};
+use crate::descriptor::{CONFIGURATION_WHATSAPP_V1, LogDescriptor, SignedLogDescriptor};
+use crate::entry::{
+    ContactEndpoint, DeviceCredential, DeviceCredentialTBS, DirectoryEntry, DirectoryEntryTBS,
+    EntryAuthorization, EntryKind, ResetAuthorization, ResetAuthorizationTBS, RotationProof,
+    RotationProofTBS,
+};
+use crate::labels;
+use crate::receipt::{SubmissionReceipt, SubmissionReceiptTBS};
+use crate::sth::{SignedTreeHead, SignedTreeHeadTBS};
+use crate::submit::LogPolicy;
+use crate::types::{Handle, KemPublicKey, LogId};
+
+/// A deterministic Ed25519 key from a one-byte seed.
+pub(crate) fn signing_key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+/// The public half.
+pub(crate) fn public_key_of(key: &SigningKey) -> PublicKey {
+    PublicKey::new(key.verifying_key().to_bytes())
+}
+
+/// Sign a message.
+pub(crate) fn sign(key: &SigningKey, message: &[u8]) -> Signature {
+    Signature::new(key.sign(message).to_bytes())
+}
+
+fn short(bytes: &[u8]) -> ShortBytes {
+    ShortBytes::new(bytes.to_vec()).expect("a test constant shorter than 256 bytes")
+}
+
+/// ADR 0014's proposed cooldown: seven days.
+pub(crate) const RESET_COOLDOWN_SECONDS: u32 = 7 * 24 * 60 * 60;
+
+// ---------------------------------------------------------------------------
+// A log: tree heads, cosignatures, receipts, a descriptor.
+// ---------------------------------------------------------------------------
+
+/// A test log with one signing key, a fixed VRF key and a chain of tree heads.
+pub(crate) struct TestLog {
+    log_key: SigningKey,
+    reset_authority: SigningKey,
+    log_id: LogId,
+    log_pk: PublicKey,
+    vrf_public_key: PublicKey,
+    reset_authority_pk: PublicKey,
+}
+
+impl TestLog {
+    pub(crate) fn new() -> Self {
+        let log_key = signing_key(0x10);
+        let reset_authority = signing_key(0x20);
+        let log_pk = public_key_of(&log_key);
+        Self {
+            log_id: labels::log_id(&log_pk),
+            log_pk,
+            vrf_public_key: PublicKey::new([0x33; 32]),
+            reset_authority_pk: public_key_of(&reset_authority),
+            log_key,
+            reset_authority,
+        }
+    }
+
+    pub(crate) const fn log_id(&self) -> &LogId {
+        &self.log_id
+    }
+
+    pub(crate) const fn log_pk(&self) -> &PublicKey {
+        &self.log_pk
+    }
+
+    pub(crate) const fn reset_authority_pk(&self) -> &PublicKey {
+        &self.reset_authority_pk
+    }
+
+    /// The witness key for a seed.
+    pub(crate) fn witness_pk(&self, seed: u8) -> PublicKey {
+        public_key_of(&signing_key(seed))
+    }
+
+    fn head_tbs(&self, epoch: u64) -> SignedTreeHeadTBS {
+        let prev_sth_hash = match epoch.checked_sub(1) {
+            None => Digest::zero(),
+            Some(previous) => self
+                .head_tbs(previous)
+                .chain_hash()
+                .expect("a test tree head encodes"),
+        };
+        SignedTreeHeadTBS {
+            label: short(labels::LABEL_STH),
+            kt_version: KT_VERSION,
+            log_id: self.log_id,
+            epoch,
+            tree_size: epoch.saturating_mul(10),
+            root_hash: Digest::new([u8::try_from(epoch % 251).unwrap_or(0); 32]),
+            prev_sth_hash,
+            vrf_public_key: self.vrf_public_key,
+            published_at_ms: 1_700_000_000_000u64.saturating_add(epoch.saturating_mul(600_000)),
+            reset_count: 0,
+            epoch_interval_seconds: 600,
+            max_merge_delay_seconds: 3_600,
+            successor_log_pk: PublicKey::zero(),
+        }
+    }
+
+    /// The honest tree head at `epoch`, correctly chained to its predecessor.
+    pub(crate) fn head(&self, epoch: u64) -> SignedTreeHead {
+        self.sign_head(self.head_tbs(epoch))
+    }
+
+    fn sign_head(&self, sth: SignedTreeHeadTBS) -> SignedTreeHead {
+        let signature = sign(
+            &self.log_key,
+            &sth.signing_bytes().expect("a test tree head encodes"),
+        );
+        SignedTreeHead { sth, signature }
+    }
+
+    /// Re-sign a head whose contents a test has edited, so the test is about the
+    /// edit rather than about a broken signature.
+    pub(crate) fn resign(&self, head: SignedTreeHead) -> SignedTreeHead {
+        self.sign_head(head.sth)
+    }
+
+    /// A cosignature over `head` by the witness with this seed.
+    pub(crate) fn cosign(
+        &self,
+        head: &SignedTreeHead,
+        witness_seed: u8,
+        observed_at_ms: u64,
+    ) -> WitnessCosignature {
+        let key = signing_key(witness_seed);
+        let statement = WitnessCosignatureTBS {
+            label: short(labels::LABEL_COSIG),
+            kt_version: KT_VERSION,
+            log_id: head.sth.log_id,
+            epoch: head.sth.epoch,
+            tree_size: head.sth.tree_size,
+            root_hash: head.sth.root_hash,
+            witness_pk: public_key_of(&key),
+            observed_at_ms,
+        };
+        let signature = sign(
+            &key,
+            &statement.signing_bytes().expect("a cosignature encodes"),
+        );
+        WitnessCosignature {
+            statement,
+            signature,
+        }
+    }
+
+    /// A submission receipt.
+    pub(crate) fn receipt(
+        &self,
+        entry_hash: Digest,
+        entry_version: u32,
+        received_at_ms: u64,
+        merge_by_ms: u64,
+    ) -> SubmissionReceipt {
+        let receipt = SubmissionReceiptTBS {
+            label: short(labels::LABEL_RECEIPT),
+            kt_version: KT_VERSION,
+            log_id: self.log_id,
+            handle: Handle::new(b"alice".to_vec()).expect("a valid handle"),
+            entry_version,
+            entry_hash,
+            received_at_ms,
+            merge_by_ms,
+        };
+        let signature = sign(
+            &self.log_key,
+            &receipt.signing_bytes().expect("a receipt encodes"),
+        );
+        SubmissionReceipt { receipt, signature }
+    }
+
+    /// A signed log descriptor.
+    pub(crate) fn descriptor(&self) -> SignedLogDescriptor {
+        let descriptor = LogDescriptor {
+            kt_versions: VecU8::new(vec![KT_VERSION]),
+            log_id: self.log_id,
+            log_signing_pk: self.log_pk,
+            genesis_log_pk: self.log_pk,
+            vrf_public_key: self.vrf_public_key,
+            configuration: CONFIGURATION_WHATSAPP_V1,
+            epoch_interval_seconds: 600,
+            max_merge_delay_seconds: 3_600,
+            reset_cooldown_seconds: RESET_COOLDOWN_SECONDS,
+            reset_authority_pk: self.reset_authority_pk,
+            operator_name: short(b"free2z"),
+            operator_contact: short(b"kt@free2z.example"),
+            operator_jurisdiction: short(b"nowhere"),
+            operator_policy_url: short(b"https://free2z.example/kt"),
+            source_repo_url: short(b"https://github.com/free2z/zuu"),
+            source_commit: short(b"0000000000000000000000000000000000000000"),
+            build_digest: short(b"sha256:0"),
+            published_at_ms: 1_700_000_000_000,
+        };
+        let signature = sign(
+            &self.log_key,
+            &descriptor.signing_bytes().expect("a descriptor encodes"),
+        );
+        SignedLogDescriptor {
+            descriptor,
+            signature,
+        }
+    }
+
+    /// The reset authority's signing key, for the directory builder.
+    pub(crate) const fn reset_authority(&self) -> &SigningKey {
+        &self.reset_authority
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A directory: entries for one handle, in every authorization shape.
+// ---------------------------------------------------------------------------
+
+/// A test directory for one handle, holding its identity, directory-auth and
+/// device keys.
+pub(crate) struct TestDirectory {
+    log: TestLog,
+    handle: Handle,
+    identity_key: SigningKey,
+    auth_key: SigningKey,
+    device_key: SigningKey,
+}
+
+impl TestDirectory {
+    pub(crate) fn new() -> Self {
+        Self::for_handle(b"alice")
+    }
+
+    pub(crate) fn for_handle(handle: &[u8]) -> Self {
+        Self {
+            log: TestLog::new(),
+            handle: Handle::new(handle.to_vec()).expect("a valid test handle"),
+            identity_key: signing_key(0x41),
+            auth_key: signing_key(0x42),
+            device_key: signing_key(0x43),
+        }
+    }
+
+    pub(crate) fn identity_key(&self) -> SigningKey {
+        self.identity_key.clone()
+    }
+
+    /// The policy `validate_submission` judges against.
+    pub(crate) fn policy(&self) -> LogPolicy {
+        LogPolicy::new(
+            *self.log.log_id(),
+            *self.log.reset_authority_pk(),
+            RESET_COOLDOWN_SECONDS,
+        )
+    }
+
+    fn credential(&self, identity: &SigningKey, signer: &SigningKey) -> DeviceCredential {
+        let credential = DeviceCredentialTBS {
+            label: short(labels::LABEL_DEVICE_CREDENTIAL),
+            identity_pk: public_key_of(identity),
+            handle: self.handle.clone(),
+            device_pk: public_key_of(&self.device_key),
+            device_kem_pk: KemPublicKey::new(vec![0x55; 1216]).expect("a non-empty KEM key"),
+            not_before_ms: 1_600_000_000_000,
+            not_after_ms: 1_900_000_000_000,
+        };
+        let signature = sign(
+            signer,
+            &credential.signing_bytes().expect("a credential encodes"),
+        );
+        DeviceCredential {
+            credential,
+            signature,
+        }
+    }
+
+    fn contents(
+        &self,
+        version: u32,
+        kind: EntryKind,
+        identity: &SigningKey,
+        auth: &SigningKey,
+        prev_entry_hash: Digest,
+        no_reset: u8,
+    ) -> DirectoryEntryTBS {
+        DirectoryEntryTBS {
+            label: short(labels::LABEL_ENTRY),
+            kt_version: KT_VERSION,
+            log_id: *self.log.log_id(),
+            handle: self.handle.clone(),
+            entry_version: version,
+            kind,
+            identity_pk: public_key_of(identity),
+            directory_auth_pk: public_key_of(auth),
+            devices: VecU16::new(vec![self.credential(identity, identity)]),
+            revocations: VecU16::new(Vec::new()),
+            contact_endpoints: VecU16::new(vec![ContactEndpoint {
+                relay_url: short(b"wss://relay.example/relay/v1"),
+                relay_id: RelayId::new([0x61; 32]),
+                contact_addr: QueueAddress::new([0x62; 32]),
+            }]),
+            prev_entry_hash,
+            no_reset,
+            created_at_ms: 1_700_000_000_000,
+        }
+    }
+
+    fn authorize_same_key(&self, entry: DirectoryEntryTBS, auth: &SigningKey) -> DirectoryEntry {
+        let auth_signature = sign(auth, &entry.signing_bytes().expect("an entry encodes"));
+        DirectoryEntry {
+            entry,
+            authorization: EntryAuthorization::SameKey { auth_signature },
+        }
+    }
+
+    /// A version-1 registration.
+    pub(crate) fn genesis(&self) -> DirectoryEntry {
+        let entry = self.contents(
+            1,
+            EntryKind::SameKey,
+            &self.identity_key,
+            &self.auth_key,
+            Digest::zero(),
+            0,
+        );
+        self.authorize_same_key(entry, &self.auth_key)
+    }
+
+    /// A version-1 registration that forecloses the reset path (ADR 0014).
+    pub(crate) fn genesis_no_reset(&self) -> DirectoryEntry {
+        let entry = self.contents(
+            1,
+            EntryKind::SameKey,
+            &self.identity_key,
+            &self.auth_key,
+            Digest::zero(),
+            1,
+        );
+        self.authorize_same_key(entry, &self.auth_key)
+    }
+
+    /// A registration whose device credential is signed by a key that is not the
+    /// identity key it names.
+    pub(crate) fn wrong_signer_credential(&self) -> DirectoryEntry {
+        let mut entry = self.contents(
+            1,
+            EntryKind::SameKey,
+            &self.identity_key,
+            &self.auth_key,
+            Digest::zero(),
+            0,
+        );
+        entry.devices = VecU16::new(vec![
+            self.credential(&self.identity_key, &signing_key(0x77)),
+        ]);
+        self.authorize_same_key(entry, &self.auth_key)
+    }
+
+    /// A registration whose device credential names — and is signed by — a
+    /// different identity key entirely.
+    pub(crate) fn foreign_identity_credential(&self) -> DirectoryEntry {
+        let foreign = signing_key(0x78);
+        let mut entry = self.contents(
+            1,
+            EntryKind::SameKey,
+            &self.identity_key,
+            &self.auth_key,
+            Digest::zero(),
+            0,
+        );
+        entry.devices = VecU16::new(vec![self.credential(&foreign, &foreign)]);
+        self.authorize_same_key(entry, &self.auth_key)
+    }
+
+    /// A `same_key` successor to `previous`.
+    pub(crate) fn same_key_update(&self, previous: &DirectoryEntry) -> DirectoryEntry {
+        let mut entry = self.contents(
+            previous.entry.entry_version.saturating_add(1),
+            EntryKind::SameKey,
+            &self.identity_key,
+            &self.auth_key,
+            previous.chain_hash().expect("an entry encodes"),
+            previous.entry.no_reset,
+        );
+        // Something has to differ, or the update is a re-publication. A second
+        // contact endpoint is the most boring change §4.1 permits.
+        entry.contact_endpoints = VecU16::new(vec![
+            ContactEndpoint {
+                relay_url: short(b"wss://relay.example/relay/v1"),
+                relay_id: RelayId::new([0x61; 32]),
+                contact_addr: QueueAddress::new([0x62; 32]),
+            },
+            ContactEndpoint {
+                relay_url: short(b"wss://second.example/relay/v1"),
+                relay_id: RelayId::new([0x63; 32]),
+                contact_addr: QueueAddress::new([0x64; 32]),
+            },
+        ]);
+        self.authorize_same_key(entry, &self.auth_key)
+    }
+
+    /// Re-sign a `same_key` entry a test has edited, under the previous
+    /// directory-auth key.
+    pub(crate) fn reauthorize_same_key(
+        &self,
+        entry: DirectoryEntry,
+        _previous: &DirectoryEntry,
+    ) -> DirectoryEntry {
+        self.authorize_same_key(entry.entry, &self.auth_key)
+    }
+
+    /// Re-sign a genesis entry a test has edited.
+    pub(crate) fn reauthorize_genesis(&self, entry: DirectoryEntry) -> DirectoryEntry {
+        self.authorize_same_key(entry.entry, &self.auth_key)
+    }
+
+    /// Sign a rotation proof.
+    pub(crate) fn sign_rotation(
+        &self,
+        proof: RotationProofTBS,
+        outgoing: &SigningKey,
+    ) -> RotationProof {
+        let signature = sign(
+            outgoing,
+            &proof.signing_bytes().expect("a rotation proof encodes"),
+        );
+        RotationProof { proof, signature }
+    }
+
+    /// Sign a reset authorization under the pinned authority key.
+    pub(crate) fn sign_reset(&self, reset: ResetAuthorizationTBS) -> ResetAuthorization {
+        let reset_signature = sign(
+            self.log.reset_authority(),
+            &reset
+                .signing_bytes()
+                .expect("a reset authorization encodes"),
+        );
+        ResetAuthorization {
+            reset,
+            reset_signature,
+        }
+    }
+
+    /// A `key_change` successor to `previous`, rotating to `new_identity` and
+    /// `new_auth`.
+    pub(crate) fn key_change(
+        &self,
+        previous: &DirectoryEntry,
+        new_identity: &SigningKey,
+        new_auth: &SigningKey,
+    ) -> DirectoryEntry {
+        let version = previous.entry.entry_version.saturating_add(1);
+        let prev_entry_hash = previous.chain_hash().expect("an entry encodes");
+        let entry = self.contents(
+            version,
+            EntryKind::KeyChange,
+            new_identity,
+            new_auth,
+            prev_entry_hash,
+            previous.entry.no_reset,
+        );
+        let rotation = self.sign_rotation(
+            RotationProofTBS {
+                label: short(labels::LABEL_ROTATION),
+                log_id: *self.log.log_id(),
+                handle: self.handle.clone(),
+                entry_version: version,
+                old_identity_pk: previous.entry.identity_pk,
+                new_identity_pk: public_key_of(new_identity),
+                prev_entry_hash,
+                created_at_ms: 1_700_000_000_000,
+            },
+            &self.identity_key,
+        );
+        let auth_signature = sign(new_auth, &entry.signing_bytes().expect("an entry encodes"));
+        DirectoryEntry {
+            entry,
+            authorization: EntryAuthorization::KeyChange {
+                rotation,
+                auth_signature,
+            },
+        }
+    }
+
+    /// A `key_change` at version 1 — a rotation of a handle that has never been
+    /// registered, which §4.4 rule 6 cannot be satisfied for.
+    pub(crate) fn key_change_at_version_one(&self) -> DirectoryEntry {
+        let new_identity = signing_key(0x60);
+        let new_auth = signing_key(0x61);
+        let entry = self.contents(
+            1,
+            EntryKind::KeyChange,
+            &new_identity,
+            &new_auth,
+            Digest::zero(),
+            0,
+        );
+        let rotation = self.sign_rotation(
+            RotationProofTBS {
+                label: short(labels::LABEL_ROTATION),
+                log_id: *self.log.log_id(),
+                handle: self.handle.clone(),
+                entry_version: 1,
+                old_identity_pk: public_key_of(&self.identity_key),
+                new_identity_pk: public_key_of(&new_identity),
+                prev_entry_hash: Digest::zero(),
+                created_at_ms: 1_700_000_000_000,
+            },
+            &self.identity_key,
+        );
+        let auth_signature = sign(&new_auth, &entry.signing_bytes().expect("an entry encodes"));
+        DirectoryEntry {
+            entry,
+            authorization: EntryAuthorization::KeyChange {
+                rotation,
+                auth_signature,
+            },
+        }
+    }
+
+    /// A `platform_reset` at version 1 — a reset of a handle that has never been
+    /// registered.
+    pub(crate) fn platform_reset_at_version_one(&self) -> DirectoryEntry {
+        let new_identity = signing_key(0x80);
+        let new_auth = signing_key(0x81);
+        let entry = self.contents(
+            1,
+            EntryKind::PlatformReset,
+            &new_identity,
+            &new_auth,
+            Digest::zero(),
+            0,
+        );
+        let reset = self.sign_reset(ResetAuthorizationTBS {
+            label: short(labels::LABEL_RESET),
+            log_id: *self.log.log_id(),
+            handle: self.handle.clone(),
+            entry_version: 1,
+            old_identity_pk: public_key_of(&self.identity_key),
+            new_identity_pk: public_key_of(&new_identity),
+            created_at_ms: 0,
+            effective_at_ms: u64::from(RESET_COOLDOWN_SECONDS).saturating_mul(1_000),
+        });
+        let auth_signature = sign(&new_auth, &entry.signing_bytes().expect("an entry encodes"));
+        DirectoryEntry {
+            entry,
+            authorization: EntryAuthorization::PlatformReset {
+                reset,
+                auth_signature,
+            },
+        }
+    }
+
+    /// A `platform_reset` successor to `previous`.
+    pub(crate) fn platform_reset(
+        &self,
+        previous: &DirectoryEntry,
+        new_identity: &SigningKey,
+        new_auth: &SigningKey,
+        created_at_ms: u64,
+    ) -> DirectoryEntry {
+        let version = previous.entry.entry_version.saturating_add(1);
+        let entry = self.contents(
+            version,
+            EntryKind::PlatformReset,
+            new_identity,
+            new_auth,
+            previous.chain_hash().expect("an entry encodes"),
+            previous.entry.no_reset,
+        );
+        let reset = self.sign_reset(ResetAuthorizationTBS {
+            label: short(labels::LABEL_RESET),
+            log_id: *self.log.log_id(),
+            handle: self.handle.clone(),
+            entry_version: version,
+            old_identity_pk: previous.entry.identity_pk,
+            new_identity_pk: public_key_of(new_identity),
+            created_at_ms,
+            effective_at_ms: created_at_ms
+                .saturating_add(u64::from(RESET_COOLDOWN_SECONDS).saturating_mul(1_000)),
+        });
+        let auth_signature = sign(new_auth, &entry.signing_bytes().expect("an entry encodes"));
+        DirectoryEntry {
+            entry,
+            authorization: EntryAuthorization::PlatformReset {
+                reset,
+                auth_signature,
+            },
+        }
+    }
+
+    /// Re-sign a `platform_reset` entry a test has edited, under `new_auth`.
+    pub(crate) fn reauthorize_reset(
+        &self,
+        entry: DirectoryEntry,
+        new_auth: &SigningKey,
+    ) -> DirectoryEntry {
+        let auth_signature = sign(
+            new_auth,
+            &entry.entry.signing_bytes().expect("an entry encodes"),
+        );
+        let authorization = match entry.authorization {
+            EntryAuthorization::PlatformReset { reset, .. } => EntryAuthorization::PlatformReset {
+                reset,
+                auth_signature,
+            },
+            other => other,
+        };
+        DirectoryEntry {
+            entry: entry.entry,
+            authorization,
+        }
+    }
+}

--- a/rs/crates/f2z-kt-core/src/types.rs
+++ b/rs/crates/f2z-kt-core/src/types.rs
@@ -1,0 +1,417 @@
+//! The newtypes this crate adds on top of `f2z-codec`'s, and the redacting
+//! `Debug` they all carry.
+//!
+//! `f2z-codec`'s [`PublicKey`], [`Signature`], [`Digest`] and [`ShortBytes`] are
+//! reused verbatim rather than restated: they are the same wire shapes with the
+//! same redaction requirement, and a second copy of a `Debug` impl is a second
+//! chance to get it wrong. What is added here is what the directory needs and
+//! the relay does not — a [`LogId`], a charset-checked [`Handle`], and a
+//! `<0..2^16-1>` byte string for the X-Wing KEM key.
+//!
+//! **The trap this module exists to avoid** is the one `f2z-codec`'s redaction
+//! test names: `tls_codec`'s own byte vectors derive `Debug` and print
+//! `TlsByteVecU16 { vec: [222, 222, …] }` — a complete dump containing no hex at
+//! all. Every variable-length field in a `DirectoryEntry` is therefore a newtype
+//! here, never a bare `tls_codec` vector, and `tests/redaction.rs` checks the
+//! decimal encoding specifically.
+//!
+//! A `DirectoryEntry` is public by design — it is how `@alice` is discoverable —
+//! so redaction here is not confidentiality. It is the same operational property
+//! `ADR 0004` buys: `--log-level trace` on a directory server must not become a
+//! downloadable copy of the social graph, written by the operator, to disk, for
+//! as long as log rotation keeps it.
+//!
+//! [`PublicKey`]: f2z_codec::types::PublicKey
+//! [`Signature`]: f2z_codec::types::Signature
+//! [`Digest`]: f2z_codec::types::Digest
+//! [`ShortBytes`]: f2z_codec::types::ShortBytes
+
+use core::fmt;
+
+use tls_codec::{
+    DeserializeBytes, Error as TlsError, SerializeBytes, Size, TlsByteVecU8, TlsByteVecU16,
+};
+
+use crate::error::KtError;
+
+/// Declare a fixed-width byte newtype with a redacting `Debug` and the three
+/// `tls_codec` traits delegated to `[u8; N]`.
+///
+/// The same shape as `f2z-codec`'s `opaque_fixed!`. It is repeated rather than
+/// exported because a macro crossing a crate boundary would fix the error type
+/// of `from_slice` in the wrong crate.
+macro_rules! opaque_fixed {
+    ($(#[$meta:meta])* $name:ident, $len:expr) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name([u8; $len]);
+
+        impl $name {
+            #[doc = concat!("The wire width of a `", stringify!($name), "`, in bytes.")]
+            pub const LEN: usize = $len;
+
+            #[doc = concat!("Wrap ", stringify!($len), " bytes.")]
+            #[must_use]
+            pub const fn new(bytes: [u8; $len]) -> Self {
+                Self(bytes)
+            }
+
+            /// The all-zero value.
+            #[must_use]
+            pub const fn zero() -> Self {
+                Self([0u8; $len])
+            }
+
+            /// Borrow the bytes.
+            #[must_use]
+            pub const fn as_bytes(&self) -> &[u8; $len] {
+                &self.0
+            }
+
+            /// Whether every byte is zero.
+            ///
+            /// `KT.md` gives all-zero a meaning in two places: a
+            /// `prev_entry_hash` at `entry_version` 1 (§4.2) and a
+            /// `successor_log_pk` that announces no successor (§6.4).
+            #[must_use]
+            pub fn is_zero(&self) -> bool {
+                self.0.iter().all(|byte| *byte == 0)
+            }
+
+            /// Wrap a slice of exactly the right length.
+            ///
+            /// # Errors
+            ///
+            /// [`KtError::Malformed`] if the slice is a different length.
+            pub fn from_slice(bytes: &[u8]) -> Result<Self, KtError> {
+                let array: [u8; $len] = bytes.try_into().map_err(|_| KtError::Malformed)?;
+                Ok(Self(array))
+            }
+        }
+
+        impl From<[u8; $len]> for $name {
+            fn from(bytes: [u8; $len]) -> Self {
+                Self(bytes)
+            }
+        }
+
+        impl AsRef<[u8]> for $name {
+            fn as_ref(&self) -> &[u8] {
+                &self.0
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(concat!(stringify!($name), "(<redacted>)"))
+            }
+        }
+
+        impl Size for $name {
+            fn tls_serialized_len(&self) -> usize {
+                $len
+            }
+        }
+
+        impl SerializeBytes for $name {
+            fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+                self.0.tls_serialize()
+            }
+        }
+
+        impl DeserializeBytes for $name {
+            fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+                let (array, rest) = <[u8; $len]>::tls_deserialize_bytes(bytes)?;
+                Ok((Self(array), rest))
+            }
+        }
+    };
+}
+
+opaque_fixed!(
+    /// `log_id = H("free2z/kt/v1/log-id", genesis_log_pk)` (`KT.md` §6.1).
+    ///
+    /// A distinct type from [`Digest`] on purpose. It is compared against a
+    /// pinned value in nine different structures, and a root hash reaching a
+    /// `log_id` comparison by accident would be a silent accept.
+    ///
+    /// [`Digest`]: f2z_codec::types::Digest
+    LogId,
+    32
+);
+
+/// A directory handle: `opaque handle<1..30>`, ASCII `[a-z0-9_]{1,30}`.
+///
+/// `WIRE.md` §14 fixes the charset and `KT.md` §1.3 states the consequence:
+/// **it is the log's label, and it is why the log's labels are not
+/// homograph-attackable.** The charset is checked on construction and again on
+/// decode, so a handle that reached this type is a handle the VRF input can be
+/// built from without further thought.
+///
+/// Unlike every other variable-length field here, a `Handle` renders in `Debug`.
+/// A handle is the one field of a directory entry whose entire purpose is to be
+/// public and human-readable, and hiding it would make a log's diagnostics
+/// useless while protecting nothing that is not already published. The rendering
+/// is safe because the charset admits no control characters, so a handle cannot
+/// forge a log line.
+#[derive(Clone, PartialEq, Eq, Default)]
+pub struct Handle(TlsByteVecU8);
+
+impl Handle {
+    /// The longest handle `WIRE.md` §14 allows.
+    pub const MAX_LEN: usize = 30;
+
+    /// Wrap bytes after checking `[a-z0-9_]{1,30}`.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::BadHandle`] if the bytes are empty, longer than
+    /// [`Handle::MAX_LEN`], or contain anything outside the charset.
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Result<Self, KtError> {
+        let bytes = bytes.into();
+        if !Self::is_valid(&bytes) {
+            return Err(KtError::BadHandle);
+        }
+        Ok(Self(TlsByteVecU8::new(bytes)))
+    }
+
+    /// Whether these bytes are a valid handle (`WIRE.md` §14).
+    #[must_use]
+    pub fn is_valid(bytes: &[u8]) -> bool {
+        !bytes.is_empty()
+            && bytes.len() <= Self::MAX_LEN
+            && bytes
+                .iter()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'_')
+    }
+
+    /// Re-check the charset on a decoded value.
+    ///
+    /// `tls_codec` cannot express `[a-z0-9_]`, so a `Handle` that arrived over
+    /// the wire has had its length checked and nothing else. Every structure
+    /// carrying one calls this from its own `validate`.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::BadHandle`] as [`Handle::new`].
+    pub fn validate(&self) -> Result<(), KtError> {
+        if Self::is_valid(self.as_slice()) {
+            Ok(())
+        } else {
+            Err(KtError::BadHandle)
+        }
+    }
+
+    /// The handle bytes.
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    /// The handle length in bytes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.as_slice().len()
+    }
+
+    /// Whether the handle is empty — only reachable from a decode, never from
+    /// [`Handle::new`].
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.as_slice().is_empty()
+    }
+}
+
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // A decoded handle has not been charset-checked yet, so render defensively
+        // rather than assuming the invariant this type is *supposed* to hold.
+        let bytes = self.0.as_slice();
+        match (Self::is_valid(bytes), core::str::from_utf8(bytes)) {
+            (true, Ok(text)) => write!(f, "Handle({text})"),
+            _ => write!(f, "Handle(<invalid; {} bytes>)", bytes.len()),
+        }
+    }
+}
+
+impl Size for Handle {
+    fn tls_serialized_len(&self) -> usize {
+        self.0.tls_serialized_len()
+    }
+}
+
+impl SerializeBytes for Handle {
+    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        self.0.tls_serialize()
+    }
+}
+
+impl DeserializeBytes for Handle {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (inner, rest) = TlsByteVecU8::tls_deserialize_bytes(bytes)?;
+        Ok((Self(inner), rest))
+    }
+}
+
+/// An X-Wing hybrid KEM public key: `opaque device_kem_pk<1..2^16-1>`
+/// (`KT.md` §4.1).
+///
+/// X25519 + ML-KEM-768, so it is roughly 1.2 KB and cannot use the `<0..255>`
+/// prefix [`ShortBytes`] carries. A newtype rather than a bare `TlsByteVecU16`
+/// for the reason the module note gives: a derived `Debug` on a `tls_codec`
+/// vector prints every byte as a decimal list.
+///
+/// [`ShortBytes`]: f2z_codec::types::ShortBytes
+#[derive(Clone, PartialEq, Eq, Default)]
+pub struct KemPublicKey(TlsByteVecU16);
+
+impl KemPublicKey {
+    /// The largest value the `<0..2^16-1>` length prefix can describe.
+    pub const MAX_LEN: usize = (1usize << 16) - 1;
+
+    /// Wrap bytes.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the bytes are empty — the field is
+    /// `<1..2^16-1>` — or longer than [`KemPublicKey::MAX_LEN`].
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Result<Self, KtError> {
+        let bytes = bytes.into();
+        if bytes.is_empty() || bytes.len() > Self::MAX_LEN {
+            return Err(KtError::Malformed);
+        }
+        Ok(Self(TlsByteVecU16::new(bytes)))
+    }
+
+    /// The key bytes.
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    /// The key length in bytes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.as_slice().len()
+    }
+
+    /// Whether the key is empty. `<1..2^16-1>` forbids it, so this is only
+    /// reachable from a decode and is what `validate` rejects.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.as_slice().is_empty()
+    }
+}
+
+impl fmt::Debug for KemPublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "KemPublicKey(<redacted; {} bytes>)", self.len())
+    }
+}
+
+impl Size for KemPublicKey {
+    fn tls_serialized_len(&self) -> usize {
+        self.0.tls_serialized_len()
+    }
+}
+
+impl SerializeBytes for KemPublicKey {
+    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        self.0.tls_serialize()
+    }
+}
+
+impl DeserializeBytes for KemPublicKey {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (inner, rest) = TlsByteVecU16::tls_deserialize_bytes(bytes)?;
+        Ok((Self(inner), rest))
+    }
+}
+
+/// Check a `<0..255>` field against the exact constant `KT.md` §6.2 requires.
+///
+/// The first thing every `validate` does, per §6.2: *"a verifier MUST check it
+/// before anything else."*
+///
+/// # Errors
+///
+/// [`KtError::WrongLabel`] if the field is anything but `expected`.
+pub fn check_label(actual: &f2z_codec::types::ShortBytes, expected: &[u8]) -> Result<(), KtError> {
+    if actual.as_slice() == expected {
+        Ok(())
+    } else {
+        Err(KtError::WrongLabel)
+    }
+}
+
+/// Build a `<0..255>` field holding a §6.2 label constant.
+///
+/// # Errors
+///
+/// [`KtError::Malformed`] if the constant is longer than 255 bytes, which no
+/// label in §6.2 is.
+pub fn label_field(label: &[u8]) -> Result<f2z_codec::types::ShortBytes, KtError> {
+    f2z_codec::types::ShortBytes::new(label).map_err(KtError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_codec::canonical::{Canonical, decode_canonical};
+
+    #[test]
+    fn the_handle_charset_is_wire_md_section_14() {
+        assert!(Handle::new(b"alice".to_vec()).is_ok());
+        assert!(Handle::new(b"a_1".to_vec()).is_ok());
+        assert!(Handle::new(vec![b'a'; 30]).is_ok());
+
+        assert_eq!(Handle::new(b"".to_vec()), Err(KtError::BadHandle));
+        assert_eq!(Handle::new(vec![b'a'; 31]), Err(KtError::BadHandle));
+        assert_eq!(Handle::new(b"Alice".to_vec()), Err(KtError::BadHandle));
+        assert_eq!(Handle::new(b"al-ice".to_vec()), Err(KtError::BadHandle));
+        // The homograph case §1.3 names: a Cyrillic 'а' is not ASCII 'a'.
+        assert_eq!(
+            Handle::new("аlice".as_bytes().to_vec()),
+            Err(KtError::BadHandle)
+        );
+        assert_eq!(Handle::new(b"ali ce".to_vec()), Err(KtError::BadHandle));
+    }
+
+    #[test]
+    fn a_decoded_handle_is_re_checked_not_trusted() {
+        // A handle that never went through `Handle::new`: the length prefix is
+        // all `tls_codec` enforces, so an uppercase handle decodes cleanly.
+        let bytes = [5u8, b'A', b'l', b'i', b'c', b'e'];
+        let decoded = decode_canonical::<Handle>(&bytes).unwrap();
+        assert_eq!(decoded.value().validate(), Err(KtError::BadHandle));
+    }
+
+    #[test]
+    fn handles_round_trip_canonically() {
+        let handle = Handle::new(b"alice_2".to_vec()).unwrap();
+        let bytes = handle.encode_canonical().unwrap();
+        assert_eq!(bytes, [7u8, b'a', b'l', b'i', b'c', b'e', b'_', b'2']);
+        assert_eq!(decode_canonical::<Handle>(&bytes).unwrap().value(), &handle);
+    }
+
+    #[test]
+    fn a_kem_key_must_not_be_empty() {
+        assert_eq!(KemPublicKey::new(Vec::new()), Err(KtError::Malformed));
+        assert_eq!(KemPublicKey::new(vec![7u8; 1216]).unwrap().len(), 1216);
+    }
+
+    #[test]
+    fn log_id_zero_is_recognisable() {
+        assert!(LogId::zero().is_zero());
+        assert!(!LogId::new([1u8; 32]).is_zero());
+    }
+
+    #[test]
+    fn debug_renders_a_handle_and_redacts_a_kem_key() {
+        let handle = Handle::new(b"alice".to_vec()).unwrap();
+        assert_eq!(format!("{handle:?}"), "Handle(alice)");
+        let key = KemPublicKey::new(vec![0xdeu8; 1216]).unwrap();
+        assert_eq!(format!("{key:?}"), "KemPublicKey(<redacted; 1216 bytes>)");
+        assert_eq!(format!("{:?}", LogId::new([0xde; 32])), "LogId(<redacted>)");
+    }
+}

--- a/rs/crates/f2z-kt-core/src/verify.rs
+++ b/rs/crates/f2z-kt-core/src/verify.rs
@@ -1,0 +1,323 @@
+//! The client verifier — `KT.md` §8.1 and §8.2, wrapping `akd_core`.
+//!
+//! This is the half of the crate that reaches `wasm32-unknown-unknown`. It is
+//! behind the `verifier` feature, and the `auditor` feature — which pulls the
+//! server crate — is deliberately **not** enabled by it: `akd::auditor`
+//! hardcodes `AzksParallelismConfig::default()` and reaches
+//! `tokio::task::spawn`, so it compiles for that target and then traps at
+//! runtime (§11.3).
+//!
+//! # `akd`'s proof bytes are carried opaquely, and that is safe
+//!
+//! Proofs arrive as `akd_core::proto` protobuf. We do not re-encode them into
+//! `tls_codec`, so re-encode equality **does not apply inside those bytes**, and
+//! protobuf is not canonical. It is safe for a precise reason: **nothing we sign
+//! is derived from a proof's encoding.** A proof is an *input to verification*,
+//! never a signed object and never a committed value. The value compared against
+//! is `H("free2z/kt/v1/value", tls_codec(DirectoryEntry))`, computed here from
+//! entry bytes that **are** under re-encode equality, and the root comes from a
+//! `tls_codec` tree head. The only thing a malleable proof encoding can produce
+//! is a different verification *outcome*, and both outcomes are handled: verify,
+//! or reject.
+//!
+//! Consequently nothing in this crate hashes a proof or compares two proofs for
+//! equality.
+//!
+//! # What a client cannot verify, stated at the point of use (§8.5)
+//!
+//! Inclusion of a handle at a root: yes, about 1.1 ms. Non-membership: yes. Its
+//! own key history, unbroken by version **and** by hash chain: yes, about
+//! 2.6 ms. **Append-only consistency between roots: no.** The proof is
+//! O(entries added) — 3.9 MB and 1–3 s for five epochs — so there is no cheap
+//! check available to a client and therefore no fallback when the witness set is
+//! absent, unreachable, or not independent. That is [`crate::auditor`], and it
+//! is a witness's job.
+
+use akd_core::configuration::WhatsAppV1Configuration;
+use akd_core::verify::{HistoryVerificationParams, key_history_verify, lookup_verify};
+use akd_core::{AkdLabel, HistoryProof, LookupProof};
+use f2z_codec::canonical::decode_canonical;
+use protobuf::Message as _;
+
+use crate::entry::DirectoryEntry;
+use crate::error::KtError;
+use crate::labels::{akd_label, entry_value};
+use crate::submit::{PublishedEntry, SubmissionContext, validate_submission};
+use crate::types::Handle;
+use crate::witness::AcceptedRoot;
+
+/// The `akd` configuration this log is built on (§3.2). Fixed, and permanent:
+/// it determines every label and every commitment in the tree.
+pub type Configuration = WhatsAppV1Configuration;
+
+/// An entry whose **inclusion** at a witnessed root has been proved.
+///
+/// Inclusion is not authorization. §8.1 is explicit about the difference at step
+/// 6: *"the log's proof says the entry is **in the tree**, not that it was
+/// **authorized**."* [`VerifiedEntry::verify_authorization`] is the second half,
+/// and it runs the same §4.4 code the log runs — there is not a second
+/// implementation to disagree with the first.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedEntry {
+    entry: DirectoryEntry,
+    canonical: Vec<u8>,
+    epoch: u64,
+    version: u64,
+}
+
+impl VerifiedEntry {
+    /// The entry.
+    #[must_use]
+    pub const fn entry(&self) -> &DirectoryEntry {
+        &self.entry
+    }
+
+    /// The canonical bytes the value commitment was computed over.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical
+    }
+
+    /// The epoch `akd` says this version entered the tree in.
+    #[must_use]
+    pub const fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// The `akd` version, which is `DirectoryEntryTBS::entry_version` (§4.2).
+    #[must_use]
+    pub const fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// §8.1 step 6 — verify the entry's own authorization under §4.4.
+    ///
+    /// This is [`validate_submission`], the same function the log calls, run
+    /// with `pending_in_epoch: false` because §4.3's one-per-epoch rule is about
+    /// a batch being assembled and has no meaning to a client reading a
+    /// published entry. Everything else applies unchanged.
+    ///
+    /// A client that holds the previous entry passes it as
+    /// `context.previous`; one that does not — a first lookup of a stranger —
+    /// passes `None`, which is exactly right for a version-1 registration and
+    /// which correctly **refuses** to bless a later entry it cannot chain.
+    ///
+    /// # Errors
+    ///
+    /// As [`validate_submission`].
+    pub fn verify_authorization(
+        &self,
+        context: &SubmissionContext<'_>,
+    ) -> Result<crate::submit::AcceptedSubmission, KtError> {
+        validate_submission(&self.canonical, context)
+    }
+
+    /// The published state this entry represents, for chaining the next one.
+    ///
+    /// # Errors
+    ///
+    /// As [`PublishedEntry::from_entry`].
+    pub fn published(&self) -> Result<PublishedEntry, KtError> {
+        PublishedEntry::from_entry(&self.entry)
+    }
+}
+
+/// Decode and bind an entry to the value a proof commits to (§8.1 step 4).
+///
+/// The value is **recomputed here from the returned entry bytes**, under
+/// re-encode equality, and that is what goes into `lookup_verify` — never a
+/// value the log asserts.
+fn bind_entry(
+    root: &AcceptedRoot,
+    handle: &Handle,
+    entry_bytes: &[u8],
+) -> Result<(DirectoryEntry, Vec<u8>, akd_core::AkdValue), KtError> {
+    let decoded = decode_canonical::<DirectoryEntry>(entry_bytes)?;
+    let entry = decoded.value().clone();
+    let canonical = decoded.bytes().to_vec();
+    entry.validate()?;
+    if entry.entry.log_id != *root.log_id() {
+        return Err(KtError::WrongLog);
+    }
+    if entry.entry.handle != *handle {
+        // The log answered about a different handle. A proof for `@mallory`
+        // verifies perfectly; it just does not answer the question that was
+        // asked, and accepting it is the whole of the substitution attack.
+        return Err(KtError::BadHandle);
+    }
+    let value = akd_core::AkdValue(entry_value(&canonical).as_bytes().to_vec());
+    Ok((entry, canonical, value))
+}
+
+/// §8.1 — resolve a handle at a witnessed root.
+///
+/// `root` is an [`AcceptedRoot`], which only
+/// [`crate::witness::verify_threshold`] constructs, so §8.3's threshold rule
+/// cannot be skipped on the way here. §6.3's monotonicity checks are
+/// [`crate::sth::LogView`]'s and must already have passed — a client MUST make
+/// them itself, and any failure is fatal and is fork evidence.
+///
+/// Returns the entry whose inclusion is proved. **Call
+/// [`VerifiedEntry::verify_authorization`] next**; this function deliberately
+/// does not, because the context it needs — the previous entry, the pinned reset
+/// authority — is the caller's and cannot be guessed.
+///
+/// # Errors
+///
+/// - [`KtError::Malformed`] if the entry bytes are not canonical, or the proof
+///   is not decodable protobuf.
+/// - [`KtError::WrongLog`] / [`KtError::BadHandle`] if the log answered about
+///   another log or another handle.
+/// - [`KtError::ProofInvalid`] if `akd_core` rejected the proof.
+/// - [`KtError::ValueMismatch`] if the proof commits to a different value than
+///   the entry bytes hash to, or to a different version than the entry claims.
+pub fn verify_lookup(
+    root: &AcceptedRoot,
+    handle: &Handle,
+    entry_bytes: &[u8],
+    lookup_proof: &[u8],
+) -> Result<VerifiedEntry, KtError> {
+    handle.validate()?;
+    let (entry, canonical, value) = bind_entry(root, handle, entry_bytes)?;
+
+    let proto = akd_core::proto::specs::types::LookupProof::parse_from_bytes(lookup_proof)
+        .map_err(|_| KtError::Malformed)?;
+    let proof = LookupProof::try_from(&proto).map_err(|_| KtError::Malformed)?;
+
+    let result = lookup_verify::<Configuration>(
+        root.vrf_public_key().as_bytes(),
+        *root.root_hash().as_bytes(),
+        root.epoch(),
+        AkdLabel(akd_label(handle)),
+        proof,
+    )
+    .map_err(|_| KtError::ProofInvalid)?;
+
+    // The binding, and it is the point of the whole call: the tree commits to a
+    // hash of the entry, so the proof is only about *this* entry if the hash the
+    // proof carries is the hash of the bytes we were handed.
+    if result.value != value {
+        return Err(KtError::ValueMismatch);
+    }
+    if result.version != u64::from(entry.entry.entry_version) {
+        return Err(KtError::ValueMismatch);
+    }
+
+    Ok(VerifiedEntry {
+        entry,
+        canonical,
+        epoch: result.epoch,
+        version: result.version,
+    })
+}
+
+/// §8.2 — verify a handle's key history at a witnessed root.
+///
+/// `entries` are the full `DirectoryEntry` byte strings served alongside the
+/// proof, in the **same order as the proof's update proofs**, which `akd` emits
+/// in **decreasing** version order.
+///
+/// `pinned` is the client's last known published entry for this handle, or
+/// `None` when it is starting from a complete history.
+///
+/// # Step 4 is not redundant with step 3
+///
+/// `key_history_verify` proves the versions returned are in the tree. The
+/// `entry_version` sequence and the `prev_entry_hash` chain prove the client was
+/// shown **all** of them: a log that omits a version from a history response is
+/// otherwise serving a truthful subset, and every proof in it verifies.
+///
+/// # Errors
+///
+/// - [`KtError::Malformed`] if the proof or any entry is undecodable, or the
+///   number of entries does not match the number of update proofs.
+/// - [`KtError::ProofInvalid`] if `akd_core` rejected the proof.
+/// - [`KtError::ValueMismatch`] if any proved value is not the hash of the entry
+///   served for it.
+/// - [`KtError::HistoryIncomplete`] if the versions are not contiguous, if the
+///   `prev_entry_hash` chain breaks, or if the oldest entry shown is neither
+///   version 1 nor a successor of `pinned`.
+/// - [`KtError::WrongLog`] / [`KtError::BadHandle`] as [`verify_lookup`].
+pub fn verify_key_history(
+    root: &AcceptedRoot,
+    handle: &Handle,
+    entries: &[&[u8]],
+    history_proof: &[u8],
+    pinned: Option<&PublishedEntry>,
+    params: HistoryVerificationParams,
+) -> Result<Vec<VerifiedEntry>, KtError> {
+    handle.validate()?;
+    if entries.is_empty() {
+        return Err(KtError::HistoryIncomplete);
+    }
+
+    let proto = akd_core::proto::specs::types::HistoryProof::parse_from_bytes(history_proof)
+        .map_err(|_| KtError::Malformed)?;
+    let proof = HistoryProof::try_from(&proto).map_err(|_| KtError::Malformed)?;
+    if proof.update_proofs.len() != entries.len() {
+        return Err(KtError::Malformed);
+    }
+
+    let results = key_history_verify::<Configuration>(
+        root.vrf_public_key().as_bytes(),
+        *root.root_hash().as_bytes(),
+        root.epoch(),
+        AkdLabel(akd_label(handle)),
+        proof,
+        params,
+    )
+    .map_err(|_| KtError::ProofInvalid)?;
+    if results.len() != entries.len() {
+        return Err(KtError::Malformed);
+    }
+
+    // Bind every proved value to the entry served for it, in the order `akd`
+    // returned them (decreasing version).
+    let mut verified = Vec::with_capacity(entries.len());
+    for (result, bytes) in results.iter().zip(entries.iter()) {
+        let (entry, canonical, value) = bind_entry(root, handle, bytes)?;
+        if result.value != value {
+            return Err(KtError::ValueMismatch);
+        }
+        if result.version != u64::from(entry.entry.entry_version) {
+            return Err(KtError::ValueMismatch);
+        }
+        verified.push(VerifiedEntry {
+            entry,
+            canonical,
+            epoch: result.epoch,
+            version: result.version,
+        });
+    }
+
+    // §8.2 step 4, walked oldest-first so the chain reads forwards.
+    let mut previous: Option<PublishedEntry> = pinned.cloned();
+    for current in verified.iter().rev() {
+        match &previous {
+            None => {
+                // Nothing pinned and nothing shown before this: the only entry
+                // that can legitimately start a history is the registration.
+                if current.entry.entry.entry_version != 1
+                    || !current.entry.entry.prev_entry_hash.is_zero()
+                {
+                    return Err(KtError::HistoryIncomplete);
+                }
+            }
+            Some(previous) => {
+                if current.entry.entry.entry_version != previous.entry_version().saturating_add(1) {
+                    return Err(KtError::HistoryIncomplete);
+                }
+                if current.entry.entry.prev_entry_hash != *previous.chain_hash() {
+                    return Err(KtError::HistoryIncomplete);
+                }
+            }
+        }
+        previous = Some(current.published()?);
+    }
+
+    Ok(verified)
+}
+
+/// Re-export so a caller does not have to depend on `akd_core` to name the
+/// history parameters `KT.md` §8.2 hands to the verifier.
+pub use akd_core::verify::history::HistoryParams;

--- a/rs/crates/f2z-kt-core/src/witness.rs
+++ b/rs/crates/f2z-kt-core/src/witness.rs
@@ -1,0 +1,697 @@
+//! The threshold rule, fail-closed acceptance, and fault evidence — `KT.md`
+//! §7.3, §7.5 and §8.3.
+//!
+//! # The threshold rule, and why the witness set is the caller's
+//!
+//! §8.3: a client accepts a `SignedTreeHead` only if it carries ≥ *t* valid
+//! `WitnessCosignature`s **from distinct witnesses in its own configured
+//! witness set**, over exactly this `(log_id, epoch, tree_size, root_hash)`.
+//! Cosignatures from witnesses the client did not configure are ignored — not
+//! weighed, not counted, not displayed as reassurance. **A witness list supplied
+//! by the log is a list chosen by the party the witnesses exist to audit**, so
+//! [`WitnessSet`] is always constructed by the caller and this crate ships no
+//! default one.
+//!
+//! # Failing closed is the default and there is no other path
+//!
+//! [`verify_threshold`] returns an [`AcceptedRoot`] or it returns
+//! [`KtError::ThresholdUnmet`]. There is no "accept anyway" flag and no partial
+//! result carrying a count, because the owner decision on
+//! [#311](https://github.com/free2z/zuu/issues/311) is that *"proceeding
+//! silently would overclaim and must not be the default."* Which operations may
+//! continue when the threshold is unmet is a product decision §8.3 tabulates —
+//! an established conversation continues, resolving a **new** handle does not —
+//! and it is made by the caller holding the `Err`, never by weakening this
+//! function.
+//!
+//! # The bootstrap statement, which is the honest part
+//!
+//! At launch free2z operates the log and every witness, and witnesses free2z
+//! operates are not independent witnesses. **Whatever *t* is configured, the
+//! cryptographic value of meeting it is zero** until at least two witnesses are
+//! run by parties outside free2z. [`WitnessSet::independent_count`] exists so a
+//! UI can display the number §8.3 requires it to display — the count of
+//! *independent* witnesses — rather than the number of configured ones, which
+//! would be a reassuring number for a property the client does not have.
+
+use f2z_codec::canonical::encode;
+use f2z_codec::types::{Digest, PublicKey, ShortBytes, Signature};
+use f2z_codec::vec::VecU24;
+use tls_codec::{
+    DeserializeBytes, Error as TlsError, SerializeBytes, Size, TlsDeserializeBytes,
+    TlsSerializeBytes, TlsSize,
+};
+
+use crate::KT_VERSION;
+use crate::cosign::WitnessCosignature;
+use crate::error::KtError;
+use crate::labels::LABEL_FAULT;
+use crate::sig;
+use crate::sth::SignedTreeHead;
+use crate::types::{LogId, check_label, label_field};
+
+/// One witness in a client's configured set, and whether the client considers
+/// it **independent**.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConfiguredWitness {
+    /// The witness's Ed25519 public key.
+    pub public_key: PublicKey,
+    /// Whether this witness is operated by a party outside the party that
+    /// operates the log.
+    ///
+    /// A social fact, not a cryptographic one
+    /// (`THREAT-MODEL.md` §3.9), so it is the caller's assertion and this crate
+    /// never infers it. It is carried here only so §8.3's display requirement
+    /// has something to read.
+    pub independent: bool,
+}
+
+impl ConfiguredWitness {
+    /// A witness the caller operates itself, or otherwise does not count as
+    /// independent.
+    #[must_use]
+    pub const fn dependent(public_key: PublicKey) -> Self {
+        Self {
+            public_key,
+            independent: false,
+        }
+    }
+
+    /// A witness the caller asserts is run by an outside party.
+    #[must_use]
+    pub const fn independent(public_key: PublicKey) -> Self {
+        Self {
+            public_key,
+            independent: true,
+        }
+    }
+}
+
+/// A client's own witness policy: who it will count, and how many it needs.
+///
+/// `KT.md` §12 leaves the default *t* and the shipped witness list open
+/// ([§13-Q](https://github.com/free2z/zuu/issues/311)). This crate fixes the
+/// **rule** and the **failure behaviour** and ships no numbers, which is why
+/// there is no `Default` implementation: a default witness set would be this
+/// crate inventing the answer §12 declines to invent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WitnessSet {
+    witnesses: Vec<ConfiguredWitness>,
+    threshold: usize,
+}
+
+impl WitnessSet {
+    /// Configure a witness set and a threshold *t*.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::ThresholdUnmet`] if `threshold` is 0, or is larger than the
+    /// number of distinct witnesses configured. A threshold of 0 accepts any
+    /// root from nobody, which is the fail-open behaviour §8.3 forbids; a
+    /// threshold larger than the set can never be met, which is a
+    /// misconfiguration that would otherwise present as a permanently broken
+    /// directory. Duplicate keys are refused for the same reason: §8.3 counts
+    /// **distinct** witnesses, and a set listing one key twice would claim a
+    /// redundancy it does not have.
+    pub fn new(witnesses: Vec<ConfiguredWitness>, threshold: usize) -> Result<Self, KtError> {
+        if threshold == 0 || threshold > witnesses.len() {
+            return Err(KtError::ThresholdUnmet);
+        }
+        for (index, witness) in witnesses.iter().enumerate() {
+            for other in witnesses.iter().skip(index.saturating_add(1)) {
+                if witness.public_key == other.public_key {
+                    return Err(KtError::ThresholdUnmet);
+                }
+            }
+        }
+        Ok(Self {
+            witnesses,
+            threshold,
+        })
+    }
+
+    /// The threshold *t*.
+    #[must_use]
+    pub const fn threshold(&self) -> usize {
+        self.threshold
+    }
+
+    /// Every configured witness.
+    #[must_use]
+    pub fn witnesses(&self) -> &[ConfiguredWitness] {
+        &self.witnesses
+    }
+
+    /// How many configured witnesses the caller has asserted are independent.
+    ///
+    /// **§8.3 requires the UI to display this number and not
+    /// [`WitnessSet::len`]**, and to state plainly when it is zero. A client
+    /// that displays "3 of 3 witnesses" while this returns 0 is displaying a
+    /// reassuring number for a property it does not have, which is worse than
+    /// displaying nothing.
+    #[must_use]
+    pub fn independent_count(&self) -> usize {
+        self.witnesses
+            .iter()
+            .filter(|witness| witness.independent)
+            .count()
+    }
+
+    /// How many witnesses are configured.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.witnesses.len()
+    }
+
+    /// Whether the set is empty — unreachable through [`WitnessSet::new`],
+    /// which refuses a threshold of 0.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.witnesses.is_empty()
+    }
+
+    /// Whether this key is one the caller configured.
+    #[must_use]
+    pub fn contains(&self, public_key: &PublicKey) -> bool {
+        self.witnesses
+            .iter()
+            .any(|witness| witness.public_key == *public_key)
+    }
+}
+
+/// A root that met the threshold: the only value in this crate that says "this
+/// `(log_id, epoch, tree_size, root_hash)` is safe to verify a proof against."
+///
+/// It has no public constructor. [`verify_threshold`] is the only thing that
+/// builds one, and every operation that must not proceed on an unwitnessed root
+/// — [`crate::verify::verify_lookup`], [`crate::verify::verify_key_history`],
+/// [`crate::sth::LogView::accept_log_key_transition`] — takes one by reference.
+/// The threshold rule is therefore not a step a caller can forget; it is the
+/// only way to obtain the argument the next step needs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AcceptedRoot {
+    log_id: LogId,
+    epoch: u64,
+    tree_size: u64,
+    root_hash: Digest,
+    vrf_public_key: PublicKey,
+    cosignature_count: usize,
+    independent_cosignature_count: usize,
+}
+
+impl AcceptedRoot {
+    /// The log this root belongs to.
+    #[must_use]
+    pub const fn log_id(&self) -> &LogId {
+        &self.log_id
+    }
+
+    /// The epoch.
+    #[must_use]
+    pub const fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// The tree size at this epoch.
+    #[must_use]
+    pub const fn tree_size(&self) -> u64 {
+        self.tree_size
+    }
+
+    /// The `akd` root hash to verify proofs against.
+    #[must_use]
+    pub const fn root_hash(&self) -> &Digest {
+        &self.root_hash
+    }
+
+    /// The VRF key labels in this tree are derived under, taken from the
+    /// **verified tree head** and never from a proof or a log assertion
+    /// (§8.1 step 5).
+    #[must_use]
+    pub const fn vrf_public_key(&self) -> &PublicKey {
+        &self.vrf_public_key
+    }
+
+    /// How many distinct configured witnesses cosigned this exact root.
+    #[must_use]
+    pub const fn cosignature_count(&self) -> usize {
+        self.cosignature_count
+    }
+
+    /// How many of those the caller asserts are independent (§8.3).
+    ///
+    /// This, not [`AcceptedRoot::cosignature_count`], is what a UI displays.
+    #[must_use]
+    pub const fn independent_cosignature_count(&self) -> usize {
+        self.independent_cosignature_count
+    }
+}
+
+/// Apply §8.3's threshold rule to a tree head and the cosignatures served with
+/// it.
+///
+/// The head must **already** have been accepted into a [`LogView`] — §6.3's
+/// monotonicity and chain rules are a client's own responsibility and are not
+/// re-run here — and this function adds the second, independent question: did
+/// enough parties the caller trusts say they saw this same root?
+///
+/// Counting is by **distinct `witness_pk` in the configured set**. A duplicate
+/// cosignature from one witness counts once; a cosignature from a witness the
+/// caller did not configure is ignored entirely, including when it verifies.
+///
+/// # Errors
+///
+/// - [`KtError::WrongLog`] if the head is not for `log_id`.
+/// - [`KtError::ThresholdUnmet`] if fewer than *t* distinct configured
+///   witnesses produced a valid cosignature over exactly this root. **This is
+///   the fail-closed path and it carries no partial result.**
+///
+/// [`LogView`]: crate::sth::LogView
+pub fn verify_threshold(
+    head: &SignedTreeHead,
+    cosignatures: &[WitnessCosignature],
+    set: &WitnessSet,
+    log_id: &LogId,
+) -> Result<AcceptedRoot, KtError> {
+    if head.sth.log_id != *log_id {
+        return Err(KtError::WrongLog);
+    }
+    head.sth.validate()?;
+
+    let mut counted: Vec<PublicKey> = Vec::new();
+    let mut independent = 0usize;
+    for cosignature in cosignatures {
+        // Exactly this `(log_id, epoch, tree_size, root_hash)`, first: a
+        // signature check on a statement about a different root is wasted work
+        // and, worse, invites a caller to read "it verified" as "it agreed".
+        if !cosignature.covers(head) {
+            continue;
+        }
+        let Some(configured) = set
+            .witnesses()
+            .iter()
+            .find(|witness| witness.public_key == cosignature.statement.witness_pk)
+        else {
+            // Not weighed, not counted, not displayed as reassurance.
+            continue;
+        };
+        if counted.contains(&configured.public_key) {
+            continue;
+        }
+        if cosignature.verify().is_err() {
+            continue;
+        }
+        counted.push(configured.public_key);
+        if configured.independent {
+            independent = independent.saturating_add(1);
+        }
+    }
+
+    if counted.len() < set.threshold() {
+        return Err(KtError::ThresholdUnmet);
+    }
+
+    Ok(AcceptedRoot {
+        log_id: head.sth.log_id,
+        epoch: head.sth.epoch,
+        tree_size: head.sth.tree_size,
+        root_hash: head.sth.root_hash,
+        vrf_public_key: head.sth.vrf_public_key,
+        cosignature_count: counted.len(),
+        independent_cosignature_count: independent,
+    })
+}
+
+/// What a witness found (§7.3).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum FaultKind {
+    /// Epoch or root moved backwards.
+    Rollback,
+    /// Same epoch, different root or size.
+    Fork,
+    /// `prev_sth_hash` does not connect.
+    ChainBreak,
+    /// A tree-head or key-transition signature is invalid.
+    BadSignature,
+    /// `audit_verify` rejected.
+    AppendOnlyFailure,
+    /// `vrf_public_key` changed within a `log_id`.
+    VrfKeyChange,
+    /// A receipt's `merge_by_ms` passed unmet.
+    MergeDelayExceeded,
+}
+
+impl FaultKind {
+    /// Every kind, in wire order.
+    pub const ALL: [Self; 7] = [
+        Self::Rollback,
+        Self::Fork,
+        Self::ChainBreak,
+        Self::BadSignature,
+        Self::AppendOnlyFailure,
+        Self::VrfKeyChange,
+        Self::MergeDelayExceeded,
+    ];
+
+    /// The wire value.
+    #[must_use]
+    pub const fn code(self) -> u8 {
+        match self {
+            Self::Rollback => 1,
+            Self::Fork => 2,
+            Self::ChainBreak => 3,
+            Self::BadSignature => 4,
+            Self::AppendOnlyFailure => 5,
+            Self::VrfKeyChange => 6,
+            Self::MergeDelayExceeded => 7,
+        }
+    }
+
+    /// The kind this build knows by that value.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] for anything else.
+    pub const fn from_code(code: u8) -> Result<Self, KtError> {
+        Ok(match code {
+            1 => Self::Rollback,
+            2 => Self::Fork,
+            3 => Self::ChainBreak,
+            4 => Self::BadSignature,
+            5 => Self::AppendOnlyFailure,
+            6 => Self::VrfKeyChange,
+            7 => Self::MergeDelayExceeded,
+            _ => return Err(KtError::Malformed),
+        })
+    }
+
+    /// Whether a third party can check this report from its bytes alone (§7.3).
+    ///
+    /// **Six of the seven are.** The evidence is two or more tree heads signed
+    /// by the log's own key, or a log-signed receipt: anyone with the log's
+    /// public key checks it in milliseconds and needs to trust nobody.
+    ///
+    /// [`FaultKind::AppendOnlyFailure`] is **not**. The claim is "this proof does
+    /// not verify," and a third party must re-run `audit_verify` on the bytes in
+    /// `detail` to see it. A witness could report this falsely, and a log could
+    /// serve a bad proof to one witness only. It is a **prompt to check**, not a
+    /// verdict — and §9.4 explains why it cannot be made self-authenticating:
+    /// protobuf is not canonical, so no part of this specification hashes or
+    /// compares a proof.
+    #[must_use]
+    pub const fn is_self_authenticating(self) -> bool {
+        !matches!(self, Self::AppendOnlyFailure)
+    }
+}
+
+impl Size for FaultKind {
+    fn tls_serialized_len(&self) -> usize {
+        1
+    }
+}
+
+impl SerializeBytes for FaultKind {
+    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        Ok(vec![self.code()])
+    }
+}
+
+impl DeserializeBytes for FaultKind {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (code, rest) = u8::tls_deserialize_bytes(bytes)?;
+        let kind = Self::from_code(code)
+            .map_err(|_| TlsError::DecodingError(format!("FaultKind {code} is not in §7.3")))?;
+        Ok((kind, rest))
+    }
+}
+
+/// The `FaultReportTBS` of §7.3.
+///
+/// The witness's own signature on a report binds it to the accusation, which is
+/// the point: a witness that cries wolf is on the record too.
+///
+/// Where fault reports are published, and who is expected to act on one, is not
+/// specified — it is a social and operational question (§12). What the format
+/// guarantees is that the evidence is **portable**.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct FaultReportTBS {
+    /// Exactly `"free2z/kt/v1/fault"`.
+    pub label: ShortBytes,
+    /// `0x0001`.
+    pub kt_version: u16,
+    /// The log accused.
+    pub log_id: LogId,
+    /// What was found.
+    pub kind: FaultKind,
+    /// The witness making the accusation.
+    pub witness_pk: PublicKey,
+    /// The tree heads the witness holds, in order.
+    pub a: VecU24<SignedTreeHead>,
+    /// The conflicting ones; empty where not applicable.
+    pub b: VecU24<SignedTreeHead>,
+    /// Proof bytes, or a `SubmissionReceipt`.
+    pub detail: f2z_codec::types::Payload,
+    /// When the witness observed the fault.
+    pub observed_at_ms: u64,
+}
+
+impl FaultReportTBS {
+    /// Check the constants a decoder cannot.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`] or [`KtError::UnsupportedVersion`].
+    pub fn validate(&self) -> Result<(), KtError> {
+        check_label(&self.label, LABEL_FAULT)?;
+        if self.kt_version != KT_VERSION {
+            return Err(KtError::UnsupportedVersion);
+        }
+        Ok(())
+    }
+
+    /// The exact bytes the witness signs.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
+        encode(self).map_err(KtError::from)
+    }
+
+    /// Build the `label` field for a fault report.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::Malformed`] if the constant does not fit, which it does.
+    pub fn label_bytes() -> Result<ShortBytes, KtError> {
+        label_field(LABEL_FAULT)
+    }
+}
+
+/// A `FaultReport` (§7.3).
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct FaultReport {
+    /// The signed accusation.
+    pub report: FaultReportTBS,
+    /// Ed25519 by `report.witness_pk`.
+    pub signature: Signature,
+}
+
+impl FaultReport {
+    /// Verify the witness's signature over its own accusation.
+    ///
+    /// This says the named witness made the claim. Whether the claim is *true*
+    /// depends on [`FaultKind::is_self_authenticating`]: for six of the seven
+    /// kinds the enclosed tree heads settle it under the log's own key, and for
+    /// `append_only_failure` a third party must re-run the auditor.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`], [`KtError::UnsupportedVersion`] or
+    /// [`KtError::BadSignature`].
+    pub fn verify(&self) -> Result<(), KtError> {
+        self.report.validate()?;
+        sig::verify(
+            &self.report.witness_pk,
+            &self.report.signing_bytes()?,
+            &self.signature,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TestLog;
+
+    fn set_of(log: &TestLog, seeds: &[u8], threshold: usize) -> WitnessSet {
+        let witnesses = seeds
+            .iter()
+            .map(|seed| ConfiguredWitness::dependent(log.witness_pk(*seed)))
+            .collect();
+        WitnessSet::new(witnesses, threshold).expect("a well-formed witness policy")
+    }
+
+    #[test]
+    fn a_threshold_of_zero_or_more_than_the_set_is_refused() {
+        let log = TestLog::new();
+        let one = vec![ConfiguredWitness::dependent(log.witness_pk(1))];
+        assert_eq!(
+            WitnessSet::new(one.clone(), 0),
+            Err(KtError::ThresholdUnmet)
+        );
+        assert_eq!(
+            WitnessSet::new(one.clone(), 2),
+            Err(KtError::ThresholdUnmet)
+        );
+        assert!(WitnessSet::new(one, 1).is_ok());
+
+        let duplicated = vec![
+            ConfiguredWitness::dependent(log.witness_pk(1)),
+            ConfiguredWitness::dependent(log.witness_pk(1)),
+        ];
+        assert_eq!(
+            WitnessSet::new(duplicated, 2),
+            Err(KtError::ThresholdUnmet),
+            "§8.3 counts distinct witnesses",
+        );
+    }
+
+    #[test]
+    fn the_threshold_is_met_by_distinct_configured_witnesses() {
+        let log = TestLog::new();
+        let head = log.head(7);
+        let set = set_of(&log, &[1, 2, 3], 2);
+        let cosigs = [log.cosign(&head, 1, 10), log.cosign(&head, 2, 11)];
+        let root = verify_threshold(&head, &cosigs, &set, log.log_id()).unwrap();
+        assert_eq!(root.epoch(), 7);
+        assert_eq!(root.cosignature_count(), 2);
+        assert_eq!(root.root_hash(), &head.sth.root_hash);
+        assert_eq!(root.vrf_public_key(), &head.sth.vrf_public_key);
+    }
+
+    #[test]
+    fn one_witness_cosigning_twice_counts_once() {
+        let log = TestLog::new();
+        let head = log.head(7);
+        let set = set_of(&log, &[1, 2], 2);
+        let cosigs = [log.cosign(&head, 1, 10), log.cosign(&head, 1, 20)];
+        assert_eq!(
+            verify_threshold(&head, &cosigs, &set, log.log_id()),
+            Err(KtError::ThresholdUnmet),
+        );
+    }
+
+    #[test]
+    fn a_witness_the_client_did_not_configure_is_ignored_not_weighed() {
+        let log = TestLog::new();
+        let head = log.head(7);
+        let set = set_of(&log, &[1], 1);
+        // Valid cosignatures, by keys the client never chose. §8.3: a witness
+        // list supplied by the log is a list chosen by the party the witnesses
+        // exist to audit.
+        let cosigs = [
+            log.cosign(&head, 50, 10),
+            log.cosign(&head, 51, 11),
+            log.cosign(&head, 52, 12),
+        ];
+        for cosig in &cosigs {
+            assert_eq!(cosig.verify(), Ok(()));
+        }
+        assert_eq!(
+            verify_threshold(&head, &cosigs, &set, log.log_id()),
+            Err(KtError::ThresholdUnmet),
+        );
+    }
+
+    #[test]
+    fn a_cosignature_over_another_root_does_not_count_for_this_one() {
+        let log = TestLog::new();
+        let head = log.head(7);
+        let other = log.head(8);
+        let set = set_of(&log, &[1, 2], 1);
+        let cosigs = [log.cosign(&other, 1, 10), log.cosign(&other, 2, 11)];
+        assert_eq!(
+            verify_threshold(&head, &cosigs, &set, log.log_id()),
+            Err(KtError::ThresholdUnmet),
+        );
+    }
+
+    #[test]
+    fn a_forged_cosignature_from_a_configured_key_does_not_count() {
+        let log = TestLog::new();
+        let head = log.head(7);
+        let set = set_of(&log, &[1, 2], 2);
+        let good = log.cosign(&head, 1, 10);
+        let mut forged = log.cosign(&head, 2, 11);
+        forged.signature = f2z_codec::types::Signature::new([0u8; 64]);
+        assert_eq!(
+            verify_threshold(&head, &[good, forged], &set, log.log_id()),
+            Err(KtError::ThresholdUnmet),
+        );
+    }
+
+    #[test]
+    fn no_cosignatures_at_all_fails_closed() {
+        let log = TestLog::new();
+        let head = log.head(7);
+        let set = set_of(&log, &[1], 1);
+        assert_eq!(
+            verify_threshold(&head, &[], &set, log.log_id()),
+            Err(KtError::ThresholdUnmet),
+        );
+    }
+
+    #[test]
+    fn independence_is_the_callers_assertion_and_is_reported_separately() {
+        let log = TestLog::new();
+        let head = log.head(7);
+        let set = WitnessSet::new(
+            vec![
+                ConfiguredWitness::dependent(log.witness_pk(1)),
+                ConfiguredWitness::independent(log.witness_pk(2)),
+            ],
+            2,
+        )
+        .unwrap();
+        assert_eq!(set.independent_count(), 1);
+        let cosigs = [log.cosign(&head, 1, 1), log.cosign(&head, 2, 2)];
+        let root = verify_threshold(&head, &cosigs, &set, log.log_id()).unwrap();
+        assert_eq!(root.cosignature_count(), 2);
+        assert_eq!(
+            root.independent_cosignature_count(),
+            1,
+            "§8.3: the UI displays this number, not the configured count",
+        );
+    }
+
+    #[test]
+    fn a_head_from_another_log_is_refused_before_anything_is_counted() {
+        let log = TestLog::new();
+        let head = log.head(7);
+        let set = set_of(&log, &[1], 1);
+        assert_eq!(
+            verify_threshold(
+                &head,
+                &[log.cosign(&head, 1, 1)],
+                &set,
+                &LogId::new([9u8; 32])
+            ),
+            Err(KtError::WrongLog),
+        );
+    }
+
+    #[test]
+    fn append_only_failure_is_the_only_kind_that_is_not_self_authenticating() {
+        for kind in FaultKind::ALL {
+            assert_eq!(
+                kind.is_self_authenticating(),
+                kind != FaultKind::AppendOnlyFailure,
+            );
+            assert_eq!(FaultKind::from_code(kind.code()), Ok(kind));
+        }
+        assert_eq!(FaultKind::from_code(0), Err(KtError::Malformed));
+        assert_eq!(FaultKind::from_code(8), Err(KtError::Malformed));
+    }
+}

--- a/rs/crates/f2z-kt-core/tests/negative.rs
+++ b/rs/crates/f2z-kt-core/tests/negative.rs
@@ -1,0 +1,96 @@
+//! Negative testing of the public API, which is NCC Group's own strategic
+//! recommendation for `akd` and is cheap for us to actually do.
+//!
+//! ADR 0013 is blunt about where the risk sits: the audit covers `akd`, not our
+//! use of `akd`, and NCC said so directly — *"the correct behavior of akd relies
+//! on proper integration with an external application that authenticates users
+//! and publishes updates to the directory. This integration must be done
+//! properly."* [`f2z_kt_core::validate_submission`] **is** that integration, and
+//! it is the first thing an unauthenticated submission reaches.
+//!
+//! So the property asserted here is the weakest interesting one, and the one a
+//! log's availability depends on: **for arbitrary bytes, the submission path
+//! returns a verdict.** It never panics, never overflows, never indexes out of
+//! bounds, and never loops. The workspace already denies the arithmetic and
+//! unwrap families precisely because a panic on the unauthenticated path is a
+//! remote denial of service; this is the test that watches the denial hold.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use f2z_codec::canonical::decode_canonical;
+use f2z_codec::types::PublicKey;
+use f2z_kt_core::submit::{LogPolicy, SubmissionContext, validate_submission};
+use f2z_kt_core::types::LogId;
+use f2z_kt_core::{DirectoryEntry, KtError};
+use proptest::prelude::*;
+
+fn policy() -> LogPolicy {
+    LogPolicy::new(
+        LogId::new([0x11; 32]),
+        PublicKey::new([0x22; 32]),
+        7 * 24 * 60 * 60,
+    )
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    /// Arbitrary bytes reach a verdict, never a panic.
+    #[test]
+    fn arbitrary_bytes_are_a_verdict_not_a_crash(bytes in prop::collection::vec(any::<u8>(), 0..4096)) {
+        let policy = policy();
+        let context = SubmissionContext {
+            policy: &policy,
+            previous: None,
+            pending_in_epoch: false,
+            now_ms: 1_700_000_000_000,
+        };
+        // The only assertion that matters is that this returns at all. The
+        // verdict itself is uninteresting: no random byte string is a validly
+        // signed directory entry, so every case here is an `Err`.
+        prop_assert!(validate_submission(&bytes, &context).is_err());
+    }
+
+    /// Structured noise — bytes that begin with the right label field, so the
+    /// decoder gets further in before failing — also reaches a verdict.
+    #[test]
+    fn a_plausible_prefix_does_not_change_that(tail in prop::collection::vec(any::<u8>(), 0..2048)) {
+        let mut bytes = vec![18u8];
+        bytes.extend_from_slice(b"free2z/kt/v1/entry");
+        bytes.extend_from_slice(&tail);
+        let policy = policy();
+        let context = SubmissionContext {
+            policy: &policy,
+            previous: None,
+            pending_in_epoch: false,
+            now_ms: 1_700_000_000_000,
+        };
+        prop_assert!(validate_submission(&bytes, &context).is_err());
+    }
+
+    /// The decoder itself is total: it either produces a `DirectoryEntry` whose
+    /// re-encoding is byte-identical to its input, or it refuses.
+    ///
+    /// This is `WIRE.md` §3.3 stated as a property rather than as a handful of
+    /// examples. There is no third outcome, and in particular no outcome in
+    /// which a decoder is more permissive than its encoder.
+    #[test]
+    fn decoding_is_total_and_canonical(bytes in prop::collection::vec(any::<u8>(), 0..4096)) {
+        match decode_canonical::<DirectoryEntry>(&bytes) {
+            Err(_) => {}
+            Ok(decoded) => prop_assert_eq!(decoded.bytes(), bytes.as_slice()),
+        }
+    }
+}
+
+#[test]
+fn an_empty_submission_is_malformed_rather_than_anything_else() {
+    let policy = policy();
+    let context = SubmissionContext {
+        policy: &policy,
+        previous: None,
+        pending_in_epoch: false,
+        now_ms: 0,
+    };
+    assert_eq!(validate_submission(&[], &context), Err(KtError::Malformed));
+}

--- a/rs/crates/f2z-kt-core/tests/redaction.rs
+++ b/rs/crates/f2z-kt-core/tests/redaction.rs
@@ -1,0 +1,220 @@
+//! `--log-level trace` on a directory server must not become a downloadable
+//! copy of the social graph.
+//!
+//! A `DirectoryEntry` is public by design, so this is not confidentiality. It is
+//! the operational property `f2z-codec`'s own redaction test protects: a derived
+//! `Debug` on the structures a server holds, plus an operator turning logging up
+//! while debugging, writes every device key and every contact address of every
+//! user to disk, at rest, for as long as log rotation keeps it. That is a very
+//! different artefact from a directory that answers one lookup at a time, and
+//! the difference is worth a newtype per field.
+//!
+//! **The decimal case is the one that matters and it is not hypothetical.**
+//! `tls_codec`'s own byte vectors derive `Debug` and print
+//! `TlsByteVecU16 { vec: [222, 222, 222, …] }` — a complete dump that contains no
+//! hex at all, so a test that only looked for hex would pass over it. Every
+//! variable-length field in this crate is therefore a newtype with a
+//! hand-written `Debug`, and the assertions below check base16 in both cases,
+//! base64url, a decimal byte list, and any long hex-looking run.
+
+// Test code, run on the host by a person reading the failure. The workspace
+// denies these because a panic in a parser is a remote denial of service;
+// neither hazard exists here.
+#![allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_codec::types::{Digest, PublicKey, QueueAddress, RelayId, ShortBytes, Signature};
+use f2z_codec::vec::VecU16;
+use f2z_kt_core::entry::{
+    ContactEndpoint, DeviceCredential, DeviceCredentialTBS, DeviceRevocation, DirectoryEntry,
+    DirectoryEntryTBS, EntryAuthorization, EntryKind,
+};
+use f2z_kt_core::types::{Handle, KemPublicKey, LogId};
+use f2z_kt_core::{KT_VERSION, labels};
+
+/// A byte pattern that is unmistakable in any encoding a leak might use.
+const SECRET: u8 = 0xde;
+
+fn lower_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn upper_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02X}")).collect()
+}
+
+/// `[222, 222, 222, …]` — a derived `Debug` on a byte slice.
+fn decimal_list(bytes: &[u8]) -> String {
+    let joined: Vec<String> = bytes.iter().map(|byte| byte.to_string()).collect();
+    format!("[{}]", joined.join(", "))
+}
+
+fn base64url(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::new();
+    for chunk in bytes.chunks(3) {
+        let mut buffer = [0u8; 3];
+        buffer[..chunk.len()].copy_from_slice(chunk);
+        let value =
+            (u32::from(buffer[0]) << 16) | (u32::from(buffer[1]) << 8) | u32::from(buffer[2]);
+        let symbols = match chunk.len() {
+            1 => 2,
+            2 => 3,
+            _ => 4,
+        };
+        for index in 0..symbols {
+            let shift = 18 - 6 * index;
+            let symbol = ((value >> shift) & 0x3f) as usize;
+            out.push(ALPHABET[symbol] as char);
+        }
+    }
+    out
+}
+
+/// The longest run of characters that could be a hex dump.
+///
+/// A run of pure decimal digits does not count: this crate legitimately prints
+/// millisecond timestamps and byte lengths. A run has to contain at least one
+/// `a`-`f` to be evidence of base16.
+fn longest_hex_run(text: &str) -> usize {
+    let mut longest = 0usize;
+    let mut current = 0usize;
+    let mut has_alpha = false;
+    for character in text.chars() {
+        if character.is_ascii_hexdigit() {
+            current += 1;
+            has_alpha |= character.is_ascii_alphabetic();
+            if has_alpha {
+                longest = longest.max(current);
+            }
+        } else {
+            current = 0;
+            has_alpha = false;
+        }
+    }
+    longest
+}
+
+fn assert_no_leak(label: &str, rendered: &str, secret: &[u8]) {
+    assert!(
+        !rendered.contains(&lower_hex(secret)),
+        "{label} leaked lowercase hex: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&upper_hex(secret)),
+        "{label} leaked uppercase hex: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&base64url(secret)),
+        "{label} leaked base64url: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&decimal_list(secret)),
+        "{label} leaked a decimal byte list: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&decimal_list(&secret[..secret.len().min(4)])),
+        "{label} leaked a decimal byte list prefix: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&lower_hex(&secret[..secret.len().min(4)])),
+        "{label} leaked a hex prefix: {rendered}"
+    );
+    assert!(
+        longest_hex_run(rendered) < 8,
+        "{label} contains an 8+ character hex-looking run: {rendered}"
+    );
+}
+
+fn short(bytes: &[u8]) -> ShortBytes {
+    ShortBytes::new(bytes.to_vec()).unwrap()
+}
+
+/// A structurally complete entry whose every opaque field is `0xde`.
+fn loaded_entry() -> DirectoryEntry {
+    let credential = DeviceCredential {
+        credential: DeviceCredentialTBS {
+            label: short(labels::LABEL_DEVICE_CREDENTIAL),
+            identity_pk: PublicKey::new([SECRET; 32]),
+            handle: Handle::new(b"alice".to_vec()).unwrap(),
+            device_pk: PublicKey::new([SECRET; 32]),
+            device_kem_pk: KemPublicKey::new(vec![SECRET; 1216]).unwrap(),
+            not_before_ms: 1_600_000_000_000,
+            not_after_ms: 1_900_000_000_000,
+        },
+        signature: Signature::new([SECRET; 64]),
+    };
+    DirectoryEntry {
+        entry: DirectoryEntryTBS {
+            label: short(labels::LABEL_ENTRY),
+            kt_version: KT_VERSION,
+            log_id: LogId::new([SECRET; 32]),
+            handle: Handle::new(b"alice".to_vec()).unwrap(),
+            entry_version: 1,
+            kind: EntryKind::SameKey,
+            identity_pk: PublicKey::new([SECRET; 32]),
+            directory_auth_pk: PublicKey::new([SECRET; 32]),
+            devices: VecU16::new(vec![credential]),
+            revocations: VecU16::new(vec![DeviceRevocation {
+                device_pk: PublicKey::new([SECRET; 32]),
+                revoked_at_ms: 1_700_000_000_000,
+                reason: short(b"rotated"),
+            }]),
+            contact_endpoints: VecU16::new(vec![ContactEndpoint {
+                relay_url: short(b"wss://relay.example/relay/v1"),
+                relay_id: RelayId::new([SECRET; 32]),
+                contact_addr: QueueAddress::new([SECRET; 32]),
+            }]),
+            prev_entry_hash: Digest::zero(),
+            no_reset: 0,
+            created_at_ms: 1_700_000_000_000,
+        },
+        authorization: EntryAuthorization::SameKey {
+            auth_signature: Signature::new([SECRET; 64]),
+        },
+    }
+}
+
+#[test]
+fn a_whole_directory_entry_renders_without_a_single_secret_byte() {
+    // The realistic disaster: a server derives Debug on its request types and
+    // an operator turns trace logging on in production.
+    let rendered = format!("{:?}", loaded_entry());
+    assert_no_leak("DirectoryEntry", &rendered, &[SECRET; 32]);
+    assert_no_leak("DirectoryEntry", &rendered, &[SECRET; 64]);
+    // The X-Wing KEM key is 1.2 KB and is the field a bare `TlsByteVecU16`
+    // would have dumped in full.
+    assert_no_leak("DirectoryEntry", &rendered, &[SECRET; 1216]);
+    assert!(rendered.contains("<redacted"), "got {rendered}");
+}
+
+#[test]
+fn a_kem_key_reports_its_length_and_nothing_else() {
+    let key = KemPublicKey::new(vec![SECRET; 1216]).unwrap();
+    let rendered = format!("{key:?}");
+    assert_eq!(rendered, "KemPublicKey(<redacted; 1216 bytes>)");
+    assert_no_leak("KemPublicKey", &rendered, &[SECRET; 1216]);
+}
+
+#[test]
+fn a_log_id_redacts() {
+    let rendered = format!("{:?}", LogId::new([SECRET; 32]));
+    assert_eq!(rendered, "LogId(<redacted>)");
+    assert_no_leak("LogId", &rendered, &[SECRET; 32]);
+}
+
+#[test]
+fn a_handle_renders_because_it_is_the_one_field_that_must() {
+    // The exception, and it is deliberate: a handle is what the directory
+    // exists to publish, and redacting it would make a log's diagnostics
+    // useless while protecting something already public.
+    let handle = Handle::new(b"alice_2".to_vec()).unwrap();
+    assert_eq!(format!("{handle:?}"), "Handle(alice_2)");
+    // The charset admits no control characters, so a handle cannot forge a log
+    // line — which is why rendering it is safe in the first place.
+    assert!(Handle::new(b"a\nb".to_vec()).is_err());
+    assert!(!format!("{handle:?}").contains('\n'));
+}

--- a/rs/deny.toml
+++ b/rs/deny.toml
@@ -106,6 +106,34 @@ exceptions = []
 multiple-versions = "warn"
 wildcards = "deny"
 
+# -----------------------------------------------------------------------------
+# THE `akd` VERSION FLOOR. ADR 0013 decides this; the entry lives here because
+# nothing else can hold it.
+#
+# A reviewer who removes these entries has removed the floor. There is no second
+# line of defence — read the comment on the first one before touching either.
+# -----------------------------------------------------------------------------
+
+[[bans.deny]]
+# akd < 0.13.0 contains an auditor append-only bypass, facebook/akd#495, merged
+# 2026-08-12 and released in 0.13.0 on 2026-08-13: a malicious log can rewrite an
+# existing label's value while still producing a VALID append-only proof, which
+# defeats the witness role entirely (see docs/e2ee/KT.md §7).
+# There is no RustSec/OSV advisory — an OSV query for `akd` returns {} — so
+# `cargo audit` and `cargo deny advisories` will NOT catch a downgrade. This entry
+# is the floor. Do not remove it, and do not assume tooling is holding it.
+name = "akd"
+version = "<0.13.0"
+
+[[bans.deny]]
+name = "akd_core"
+version = "<0.13.0"
+
+[[bans.deny]]
+# akd_mysql's last release is 0.8.9 (2023-03-15) and it is not maintained.
+# The durable Database impl is ours (KT.md §11.2).
+name = "akd_mysql"
+
 # =============================================================================
 # Sources. Everything resolves to crates.io. Making that a rule rather than a
 # coincidence means a `git = "..."` dependency on someone's fork cannot appear


### PR DESCRIPTION
Implements **[`docs/e2ee/KT.md`](https://github.com/free2z/zuu/blob/main/docs/e2ee/KT.md) v1** as `rs/crates/f2z-kt-core` — the one crate the log server, the witness and the client all link (§11.4). A witness that verified with a different implementation than the log builds with would produce cosignatures that mean nothing, and §7.4's only structural defence against a lazy witness is that there are not two implementations to disagree.

Decided by [ADR 0013](https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0013-key-transparency-log.md) (adopt `akd`, floor `>= 0.13.0`) and [ADR 0014](https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0014-directory-key-rotation.md) (what authorizes an entry). Spiked in #544.

## What landed

| Module | `KT.md` |
|---|---|
| `entry` | §4.1/§4.4 — `DirectoryEntry(TBS)`, `DeviceCredential`, `DeviceRevocation`, `ContactEndpoint`, `EntryKind`, `EntryAuthorization`, `RotationProof`, `ResetAuthorization` |
| `submit` | §4.2/§4.3/§4.4 — **`validate_submission`**, the one door into the log |
| `sth` | §6 — `SignedTreeHead`, `LogView` (all eight monotonicity rules), `LogKeyTransition` |
| `cosign` | §7.2 — `WitnessCosignature`, the contradiction test |
| `witness` | §7.3/§8.3 — `WitnessSet`, `verify_threshold`, `AcceptedRoot`, `FaultKind`, `FaultReport` |
| `verify` | §8.1/§8.2 — client inclusion + key-history verification over `akd_core` |
| `auditor` | §7.1 step 4 / §7.4 — the witness append-only path over `akd::auditor`, and `WitnessState` |
| `receipt`, `descriptor`, `error`, `labels`, `types`, `sig` | §5.3, §9.1, §9.5, §6.2, §1.3 |

`f2z-codec` is reused rather than duplicated: re-encode equality (`decode_canonical`), `H(label, x)`, the length-prefixed vectors, and the `PublicKey`/`Signature`/`Digest`/`ShortBytes` redacting newtypes all come from it. What this crate adds is `LogId`, a charset-checked `Handle`, and a `<0..2^16-1>` `KemPublicKey`, following the same `opaque_fixed!` pattern — including the decimal-byte-list trap, which `tests/redaction.rs` checks specifically.

## The single most important thing

> **`akd` enforces none of our authorization rules.** It will commit any bytes to any label, and a log that skips §4.4 produces inclusion, history and append-only proofs that verify **perfectly** for entries nobody authorized.

So the crate is built out of **choke points, not helpers**. Every rule is the argument the next step needs:

| To get | You must first | Which requires |
|---|---|---|
| `AcceptedSubmission` — the only carrier of the `AkdLabel`/`AkdValue` pair `publish()` needs | `validate_submission` | every rule in §4.4, in order |
| `AcceptedRoot` — the only root a proof may be verified against | `verify_threshold` | ≥ *t* cosignatures from the caller's **own** witness set |
| an advanced `LogView` | `LogView::accept` | all eight of §6.3's rules, with **no skipping over an epoch gap** |
| an advanced `WitnessState` | `verify_append_only` | `akd`'s auditor actually having run |
| a successor log signing key | `LogView::accept_log_key_transition` | a **cosigned** announcement plus both signatures |

None has a public constructor and none has a bypass flag. `validate_submission` has no siblings — no `check_rotation`, no `verify_device_credentials` — so there is nothing for a server to route around the rules *to*. `PublishedEntry` is the same idea applied to the predecessor: a log cannot *assert* what the previous entry's `prev_entry_hash` or `directory_auth_pk` were, it must hold the previous `DirectoryEntry` and let `PublishedEntry::from_entry` recompute them.

A key change carrying only one of the two required signatures **cannot be represented**: `EntryAuthorization::KeyChange` has no variant without a `RotationProof`. Both tests (`a_key_change_signed_by_only_the_new_key_is_rejected`, `..._only_the_old_key_...`) attack the signatures instead.

## ⚠️ A gap in `KT.md` §4.4, reported rather than worked around

**§4.4's numbered list does not require a `same_key` entry to keep `identity_pk` unchanged, and without that rule the list has a hole ADR 0014 explicitly forbids.**

`same_key` is authorized by the `directory_auth_pk` **published in the previous entry**, alone. Rules 1–9 check the label, the log id, the version, the chain hash, the kind agreement, the rotation proof (for `key_change` only), the reset (for `platform_reset` only), the device credentials and the epoch uniqueness — none of them looks at `entry.identity_pk`. So a party holding only the previous `DirectoryAuthKey` can publish a `same_key` entry carrying a **brand-new `identity_pk`**: a key change with one signature, which ADR 0014 says the log MUST reject, and which the two-signature rule exists to prevent.

The rule is implied by ADR 0014's case naming ("a same-key update… the identity key is unchanged") but is not in the enumerated list an implementer is told to apply "in order". This crate enforces it (`ADDITIONAL RULE 1` in `submit.rs`, test `a_same_key_entry_must_not_change_the_identity_key`). **`KT.md` §4.4 should gain it as a numbered rule.**

Three smaller rules follow from ADR 0014's case analysis and are also enforced, each marked `ADDITIONAL RULE` at its call site:

2. A `key_change` or `platform_reset` MUST change `identity_pk` — otherwise one operation has two encodings inside a structure that is hashed, signed and committed.
3. A `platform_reset` MUST be refused when the previous entry set `no_reset`. ADR 0014 makes that flag a user's declaration that the reset path does not apply to their handle; §4.4 never checks it, and a flag nothing enforces is a comment.
4. A `ResetAuthorization` is bound to its handle, log, version and outgoing key — exactly as §4.4 rule 6 binds a `RotationProof`. Rule 7 names only the signature and the cooldown, which would leave a reset signed for `@alice` at version 3 replayable against `@bob`.

## Ambiguity calls (every one, as required)

1. **Version-1 authorization.** §4.4's table has no row for a handle's first entry, and `same_key`'s signer ("the previous entry's `directory_auth_pk`") does not exist. **Read as trust-on-first-registration:** at `entry_version == 1` the entry is self-signed by the `directory_auth_pk` it publishes. Nothing weaker is possible; what makes it safe is that the registration is what a client pins.
2. **`key_change` / `platform_reset` at version 1 are refused.** Both bind to "the previous entry's `identity_pk`". A platform-authority *registration* of a fresh handle would be a different operation with different consequences and is not invented here.
3. **`no_reset` accepts only 0 and 1.** §4.1 says `uint8` and ADR 0014 says "flag". Accepting 2 would mean two byte strings with one meaning inside a hashed, signed structure.
4. **§4.2's all-zero `prev_entry_hash` is read as an iff.** A version-1 entry with a non-zero predecessor hash claims a history that cannot exist; a later entry with an all-zero one claims to be a genesis it is not. Both are refused on the bytes alone.
5. **A `DeviceCredential`'s window must be non-empty and non-inverted** (`not_after_ms > not_before_ms`). §4.1 gives the fields and no ordering rule; a permanently-dead credential in an append-only record is not worth accepting.
6. **A `DeviceCredential`'s `identity_pk` must equal the entry's.** §4.4 rule 8 says the signature verifies *under this entry's* `identity_pk`; it does not say the embedded field must match. It must, because an MLS peer validating the credential in a `LeafNode` has no directory access and uses the embedded key — if the two could differ, peer and directory client reach different verdicts about the same device.
7. **§6.4's "at least one full epoch of separation"** is read as `effective_epoch >= announce_epoch + 2`. `announce_epoch + 1` is the very next epoch and leaves no epoch in between for anyone to see the announcement in.
8. **§6.3 rule 8 with fully identical contents is idempotent, not a fork.** Re-serving the head a verifier already holds is normal; only a *differing* root, size or timestamp at an equal epoch is fatal.
9. **An epoch gap returns `EpochGap` rather than being fetched.** The crate has no network. §6.3 rule 7's "MUST NOT skip" becomes: `accept` refuses, `accept_chain` walks a caller-fetched run link by link, and there is no third method.
10. **`WitnessCosignature::contradicts` is `false` across two different witnesses.** §7.2's non-repudiation claim is specifically that *one* witness signed two contradictory statements. Two witnesses disagreeing is evidence against the **log**, and is `LogView`'s `Fork`.
11. **`WitnessSet::new` refuses `t == 0` and `t > |set|`.** §8.3 fixes the rule and leaves the numbers to §13-Q; a threshold of 0 is the fail-open behaviour §8.3 forbids, and one larger than the set can never be met.
12. **`ErrorCode` mapping for verdicts §9.5 has no code for.** `Rollback`/`Fork`/`ChainBreak`/`EpochGap`/`VrfKeyChange`/`ThresholdUnmet`/`ProofInvalid`/`ValueMismatch`/`AppendOnlyFailure`/`HistoryIncomplete` are client- and witness-side verdicts *about* the log, never replies a log sends a submitter. They collapse onto `ERR_INTERNAL` rather than inventing codes §9.5 does not have.
13. **Label mismatch maps to `ERR_MALFORMED`.** §9.5 gives `ERR_MALFORMED` for "decode failure" and `ERR_UNSUPPORTED_VERSION` for an unknown `kt_version`; a wrong §6.2 constant is neither, and is closest to the first.
14. **`kt_versions` in `LogDescriptor` must contain this build's `KT_VERSION`, and `configuration` must be `1` (WhatsAppV1).** §3.2 calls the configuration permanent; a descriptor announcing another one announces a tree this build cannot verify.
15. **`LogDescriptor.log_id` must equal `H("free2z/kt/v1/log-id", genesis_log_pk)`.** §9.1 lists both fields and does not say they are checked against each other. A log publishing an unrelated pair is claiming an identity it cannot derive.
16. **`verify_lookup` does not verify authorization; `VerifiedEntry::verify_authorization` does.** §8.1 separates steps 5 and 6, and the context step 6 needs — the previous entry, the pinned reset authority — is the caller's. That call is `validate_submission` itself, so §4.4 has exactly one implementation, run by both the log and the client.
17. **`verify_key_history` takes the served entry bytes in the proof's order** (decreasing version, as `akd` emits them) and walks §8.2 step 4's chain oldest-first, starting either at version 1 or at a caller-supplied pin.
18. **`verify_append_only` additionally checks the proof's `epochs` against the heads'.** `audit_verify` checks only the count. Without this a log could serve a valid proof for a different range that happens to match the root hashes it was given.
19. **`sig::verify` uses `verify_strict`.** §7.2's accountability argument is that two conflicting cosignatures under one `witness_pk` are a contradiction *on their face*; under malleable verification "the witness signed two things" and "an attacker re-encoded one thing" stop being distinguishable.
20. **`Handle` renders in `Debug`; everything else redacts.** A handle is the one field of a directory entry whose entire purpose is to be public and readable, and its charset admits no control characters, so it cannot forge a log line.
21. **Both features are on by default.** `cargo deny` judges the default graph, so a floor that only exists under an optional feature is a floor nothing checks. The browser build is explicit: `--no-default-features --features verifier`.

## The `akd >= 0.13.0` floor

ADR 0013's stanza is in `rs/deny.toml`, verbatim, comment included. **Verified firing** — with `akd`/`akd_core` pinned to `=0.12.0` and the lockfile regenerated:

```
error[banned]: crate 'akd = 0.12.0' is explicitly banned
    ┌─ rs/deny.toml:125:9
    ├ akd v0.12.0
      └── f2z-kt-core v0.1.0

error[banned]: crate 'akd_core = 0.12.0' is explicitly banned
    ┌─ rs/deny.toml:129:9
```

…while, on the same downgraded lockfile:

```
advisories ok
```

That contrast is the whole of ADR 0013's argument: facebook/akd#495 has no RustSec or OSV advisory and never will, so `cargo audit` and `cargo deny advisories` pass on a vulnerable pin forever. **A reviewer who removes those entries has removed the floor.** The manifest and the lockfile were restored to `0.13.0` after the demonstration.

## Evidence

All run on the pinned `1.97.1`, via the repository's own scripts.

| Check | Result |
|---|---|
| `scripts/check-rust-fmt.sh --root rs` | `All 3 Rust crate(s) under rs/ are formatted` |
| `scripts/check-rust-clippy.sh --root rs` | `All 3 Rust crate(s) under rs/ are clippy-clean` (`-D warnings`, `--all-targets`) |
| `scripts/check-rust-deny.sh --root rs --config rs/deny.toml` | `advisories ok, bans ok, licenses ok, sources ok` ×3; `All 3 Rust crate(s) under rs/ satisfy rs/deny.toml` |
| `cargo test --locked --all-targets` | 79 unit + 4 negative/proptest + 4 redaction, plus f2z-codec's 61 — **all green** |
| `cargo test --locked --doc` | green |
| `cargo build --locked --lib --target wasm32-unknown-unknown -p f2z-kt-core --no-default-features --features verifier` | **succeeds** |

### WASM size

An rlib is not a shippable number, so the client verifier was also measured the way #544 measured it: a size-optimised `cdylib` in a scratch crate outside the repo (`opt-level=3`, `lto=true`, `codegen-units=1`, `panic="abort"`, `strip=true`), exporting `verify_lookup`, `verify_key_history`, `verify_threshold`, `validate_submission`, `WitnessSet::new` and `LogView::pin` so none of them is stripped.

| | raw | gzip -9 | brotli -q11 |
|---|---:|---:|---:|
| **`f2z-kt-core` client verifier `.wasm`** | **281,679 B** (275 KB) | 92,976 B | **70,282 B (69 KB)** |
| #544's `akd_core` alone, `opt-level=3`, for comparison | 183,375 B | 62,023 B | 48,116 B |

**~69 KB brotli over the wire**, of which roughly two thirds is `akd_core` itself. The delta over the spike's figure buys Ed25519 `verify_strict`, the whole `tls_codec` envelope, §4.4's authorization engine and §6.3/§8.3's verifiers — i.e. everything the browser needs to resolve a handle and check it was authorized, not just to check a Merkle proof. Still smaller than most single icon fonts, and the spike's timings (1.11 ms `lookup_verify`, 2.63 ms `key_history_verify` over three versions, in V8) are unaffected: this crate adds one Ed25519 verification per signature to those paths.

No new licences were needed: the whole `akd` tree resolves to MIT / Apache-2.0 / BSD-3-Clause, already in `rs/deny.toml`'s allow list.

One unrelated policy interaction, fixed properly rather than by weakening the policy: a bare `path` dependency has no version requirement, so `wildcards = "deny"` flagged `f2z-codec`. The workspace dependency now carries `version = "0.1.0"` alongside `path`.

### Adversarial tests

The §4.4 suite is the point of the crate, so it is listed:

- wrong `prev_entry_hash`; version gap; version replay; registration not at version 1; a later version with no published predecessor; a predecessor for the wrong handle
- a key change signed by only the new key; only the old key; a correctly-signed `RotationProof` for **another handle**; a key change that changes no key; a key change at version 1
- a `same_key` entry smuggling a new `identity_pk`
- a reset one millisecond before `effective_at_ms`; a reset declaring a shorter cooldown than published (refused even at `u64::MAX`); a reset signed by a valid key that is not the pinned authority; a reset against a `no_reset` handle; a reset at version 1
- a device credential signed by the wrong key; one naming a foreign `identity_pk`; two credentials sharing a `device_pk`; a credential naming another handle
- a second entry for a handle in one epoch (NCC Group's Medium finding)
- an entry for another log; trailing bytes; an unknown `EntryKind` byte (fails to decode rather than defaulting); `no_reset = 2`; a wrong `kt_version`; a wrong label
- §6.3: idempotent re-accept, fork, rollback in all three fields, a skipped epoch, a broken chain link, a changed `vrf_public_key`, another log's head, an unsigned edit, **a receipt accepted as a tree head** (and a tree head as a receipt)
- §8.3: one witness cosigning twice; an unconfigured witness's valid cosignature; a cosignature over another root; a forged cosignature from a configured key; no cosignatures at all
- §7.1: a witness advancing with a token for the wrong range; a halted witness refusing to catch up
- proptest: arbitrary bytes and label-prefixed noise reach a verdict rather than a panic, and decoding is total and canonical — NCC's own strategic recommendation for `akd`'s public API, applied to ours

## Rebased onto #583, and one shared-dependency note for the reviewer

This branch was rebased onto `f2z-relay-proto` (#583) and both crates are kept everywhere they meet: `rs/Cargo.toml`'s workspace dependencies, `rs/README.md`'s crate table and command blocks, and `rs.yml`'s toolchain-manifest list. The `akd` `[[bans.deny]]` stanza was already on `main` from #571, so this PR no longer adds it — it only adds the crate that makes it load-bearing.

**`f2z-kt-core` uses the workspace `ed25519-dalek = "3"`** that #583 introduced, rather than the `"2"` this branch originally carried, so there is exactly one first-party Ed25519 across the tree.

**The graph still contains two major versions of `ed25519-dalek`, and it is not our choice.** `akd_core` 0.13 requires `^2` for its ECVRF, so `2` is in the tree the moment the directory is. `multiple-versions = "warn"` reports it; `cargo deny` is green. Nothing crosses the boundary — no `ed25519-dalek` type from either version appears in an interface between `akd_core` and our code — and it resolves itself when upstream moves. The note is in `rs/Cargo.toml` beside the `akd_core` entry so the next reviewer of that warning does not have to re-derive it.

## What is deliberately not here

No signing, no key generation, no randomness, no clocks, no sockets, no storage, no HTTP. §12's open questions — epoch cadence, default *t*, the shipped witness list, the gossip protocol, reset-authority pinning — stay open, as caller-supplied values. `PROPOSED_EPOCH_INTERVAL_SECONDS` / `PROPOSED_MAX_MERGE_DELAY_SECONDS` are constants labelled placeholders that nothing in the crate reads.

`KT.md`'s own status line still reads "Nothing described here is implemented"; updating it is a docs change and is left out of this PR on purpose.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
