### PR TITLE
feat(rs): add f2z-relay-store, the relay's queue storage

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -75,7 +75,8 @@ jobs:
           scripts/check-rust-toolchain.sh \
             --toolchain-file rs/rust-toolchain.toml \
             --manifest rs/crates/f2z-codec/Cargo.toml \
-            --manifest rs/crates/f2z-relay-proto/Cargo.toml
+            --manifest rs/crates/f2z-relay-proto/Cargo.toml \
+            --manifest rs/crates/f2z-relay-store/Cargo.toml
 
       - name: Detect changes under rs/
         id: filter
@@ -254,6 +255,18 @@ jobs:
         working-directory: rs
         run: cargo test --locked --doc
 
+      # `crash-injection` is off by default because it compiles an `abort()`
+      # into f2z-relay-store's commit path, so the default run above skips
+      # `tests/crash_safety.rs` entirely. Those cases are the only evidence that
+      # delete-on-ack's two invariants survive an unplanned stop — nothing
+      # acked-but-undeleted, nothing accepted-but-lost — and they prove it by
+      # killing a real child process, which an in-process caught panic cannot.
+      # A step of their own, so a run that skipped them is visible rather than
+      # inferred.
+      - name: Run the crash-safety suite, which kills real processes
+        working-directory: rs
+        run: cargo test --locked -p f2z-relay-store --features crash-injection --test crash_safety
+
   rs_wasm:
     name: rs / wasm32
     needs: changes
@@ -293,6 +306,11 @@ jobs:
       # rather than `--workspace` so that a future server binary — which will be
       # AGPL, will pull tokio, and will never reach a browser — does not
       # silently join the wasm build and then fail it.
+      #
+      # `f2z-relay-store` is deliberately **absent** and must stay absent: it
+      # links SQLite through `rusqlite`'s bundled C amalgamation, which is a
+      # native build by construction. It is a relay-side crate; no client links
+      # it.
       - name: Build the client-linked crates for the browser target
         working-directory: rs
         run: |

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -57,6 +57,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +201,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "f2z-relay-store"
+version = "0.1.0"
+dependencies = [
+ "f2z-codec",
+ "f2z-relay-proto",
+ "proptest",
+ "rusqlite",
+ "tempfile",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,10 +236,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -242,6 +287,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +318,17 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -276,6 +350,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "ppv-lite86"
@@ -386,6 +466,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,10 +531,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "subtle"
@@ -510,6 +616,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -53,3 +53,16 @@ subtle = { version = "2", default-features = false }
 # wasm32-unknown-unknown, so its `std` default costs this crate nothing: the
 # library itself is `no_std` and the wasm job builds `--lib`.
 proptest = "1"
+# **0.37 is a repository-wide singleton and this line is not free to move.**
+# `libsqlite3-sys` declares `links = "sqlite3"`, and Cargo refuses outright to
+# build a graph containing two versions of a `links` package — a hard error, not
+# a warning. Everything under `wallet/` reaches SQLite through
+# `wallet/plugins/tauri-plugin-zcash`'s `rusqlite = "0.37"`, so any crate
+# anywhere in this repository that wants SQLite must resolve to the same
+# version (`AGENTS.md`, "What NOT to do"). `bundled` compiles SQLite from the
+# vendored amalgamation rather than linking whatever the host happens to ship:
+# a relay's durability depends on `PRAGMA journal_mode`, `synchronous` and
+# `secure_delete` behaving exactly as `f2z-relay-store` verifies at open, and a
+# distro's build flags are not ours to assume. Native only — `rs_wasm` in
+# `.github/workflows/rs.yml` deliberately does not name the crate that uses it.
+rusqlite = { version = "0.37", features = ["bundled"] }

--- a/rs/README.md
+++ b/rs/README.md
@@ -76,7 +76,8 @@ decided is `wallet/rust-toolchain.toml`, and
 ```
 scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
                                 --manifest rs/crates/f2z-codec/Cargo.toml \
-                                --manifest rs/crates/f2z-relay-proto/Cargo.toml
+                                --manifest rs/crates/f2z-relay-proto/Cargo.toml \
+                                --manifest rs/crates/f2z-relay-store/Cargo.toml
 ```
 
 fails the pull request the moment the two disagree. `.github/workflows/rs.yml`
@@ -110,6 +111,7 @@ prevent.
 |---|---|
 | [`crates/f2z-codec`](./crates/f2z-codec) | The canonical encoding layer of `WIRE.md`: `tls_codec` wrappers for every wire structure, the domain-separated signing transcript (§5), the redacting newtypes, and the padding-bucket validator (§9). `no_std` + `alloc`, `#![forbid(unsafe_code)]`, no I/O, no async runtime, and it builds for `wasm32-unknown-unknown`. |
 | [`crates/f2z-relay-proto`](./crates/f2z-relay-proto) | The protocol layer above it: signed-command construction and verification in §5.1's exact order, the timestamp window and fail-closed seen-set (§5.5), the queue lifecycle and ACK arithmetic (§7, §8), the capability document (§11), the `HELLO` proof of possession (§5.2), and §4.3's typed in-flight window. Same constraints — `no_std` + `alloc`, no I/O, no clock, no randomness, and it builds for `wasm32-unknown-unknown`. |
+| [`crates/f2z-relay-store`](./crates/f2z-relay-store) | The relay's queue storage: a `RelayStore` trait that speaks addresses and bytes and never a wire frame, plus a durable `SqliteStore` (WAL, `synchronous = FULL`, `secure_delete = ON`, group commit) and a volatile `MemoryStore`. **Native only** — it links SQLite and is not on the wasm line. `std`, `#![forbid(unsafe_code)]`, no async runtime. |
 
 **The relay and the clients link both.** That is the licence boundary in
 practice: everything here is MIT because a third-party relay, ZUULI and the WASM
@@ -135,14 +137,26 @@ reasons, and each is enforced by a test rather than by intent:
 cd rs
 cargo test
 cargo build --target wasm32-unknown-unknown --lib -p f2z-codec -p f2z-relay-proto
+
+# f2z-relay-store's crash-safety suite is behind a default-off feature, because
+# the feature compiles an abort() into the commit path. It kills real child
+# processes; `cargo test` alone does not run it.
+cargo test -p f2z-relay-store --features crash-injection --test crash_safety
 ```
+
+**Not every crate here reaches the browser, and the wasm line is the record of
+which do.** `f2z-relay-store` links SQLite through `rusqlite`'s bundled C
+amalgamation and is relay-side only, so it is deliberately absent from
+`rs.yml`'s `rs_wasm` job. Adding a crate to that line is a claim that a client
+links it.
 
 The gates are the repository's shared scripts, pointed here with `--root`:
 
 ```bash
 scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
                                 --manifest rs/crates/f2z-codec/Cargo.toml \
-                                --manifest rs/crates/f2z-relay-proto/Cargo.toml
+                                --manifest rs/crates/f2z-relay-proto/Cargo.toml \
+                                --manifest rs/crates/f2z-relay-store/Cargo.toml
 scripts/check-rust-fmt.sh    --root rs
 scripts/check-rust-clippy.sh --root rs
 scripts/check-rust-deny.sh   --root rs --config rs/deny.toml

--- a/rs/crates/f2z-relay-proto/src/queue.rs
+++ b/rs/crates/f2z-relay-proto/src/queue.rs
@@ -97,6 +97,55 @@ impl QueueState {
         }
     }
 
+    /// Rehydrate a queue whose state was written down somewhere and read back.
+    ///
+    /// A relay's storage outlives its process, so the acknowledgement
+    /// arithmetic of §8 has to be applied to state that was loaded rather than
+    /// accumulated. Without this constructor a store would have to re-derive
+    /// that arithmetic against its own persisted columns, which is the one
+    /// duplication this crate exists to prevent: §8.2's anti-pre-ack rule
+    /// implemented twice is §8.2's rule implemented once and violated once.
+    ///
+    /// The arguments are exactly the fields [`QueueState`] persists, and the
+    /// checks below are the invariants a store cannot restore its way out of.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::Internal`] — and it is deliberately that code rather than
+    /// anything a peer could provoke. Every rejection here means the relay's
+    /// own storage contradicts the protocol, which is a relay fault; §10 says
+    /// `ERR_INTERNAL` "carries no detail, ever", and there is nothing a client
+    /// did that a more specific code would describe.
+    ///
+    /// - A contact queue with a bound send key. §12.2: a contact queue's send
+    ///   side is **never** bound, "always, for everyone".
+    /// - `acked_through >= next_index`, i.e. a watermark at or above the index
+    ///   the next append will take. That is the pre-acked state §8.2 exists to
+    ///   make unreachable, and restoring into it would black-hole the queue.
+    pub fn restore(
+        kind: QueueKind,
+        recv_key: PublicKey,
+        send_key: Option<PublicKey>,
+        next_index: u64,
+        acked_through: Option<u64>,
+    ) -> Result<Self> {
+        if matches!(kind, QueueKind::Contact) && send_key.is_some() {
+            return Err(ProtoError::Wire(ErrorCode::Internal));
+        }
+        if let Some(watermark) = acked_through
+            && watermark >= next_index
+        {
+            return Err(ProtoError::Wire(ErrorCode::Internal));
+        }
+        Ok(Self {
+            kind,
+            recv_key,
+            send_key,
+            next_index,
+            acked_through,
+        })
+    }
+
     /// Standard or contact.
     #[must_use]
     pub const fn kind(&self) -> QueueKind {
@@ -569,6 +618,49 @@ mod tests {
 
     fn queue() -> QueueState {
         QueueState::create(QueueKind::Standard, key(1))
+    }
+
+    #[test]
+    fn restore_round_trips_a_live_queue_and_refuses_the_impossible_ones() {
+        let mut original = queue();
+        original.bind_send(&key(2)).unwrap();
+        original.append().unwrap();
+        original.append().unwrap();
+        original.ack(0).unwrap();
+
+        let mut restored = QueueState::restore(
+            original.kind(),
+            original.recv_key(),
+            original.send_key(),
+            original.next_index(),
+            original.acked_through(),
+        )
+        .unwrap();
+        assert_eq!(restored.next_index(), original.next_index());
+        assert_eq!(restored.acked_through(), original.acked_through());
+        assert_eq!(restored.pending(), original.pending());
+        assert_eq!(
+            restored.bind_send(&key(9)),
+            Err(ProtoError::Wire(ErrorCode::AlreadyBound)),
+            "bind-once survives a restart; it is not a property of one process"
+        );
+
+        assert_eq!(
+            QueueState::restore(QueueKind::Contact, key(1), Some(key(2)), 0, None)
+                .err()
+                .unwrap(),
+            ProtoError::Wire(ErrorCode::Internal),
+            "§12.2: a contact queue's send side is never bound"
+        );
+        assert!(
+            QueueState::restore(QueueKind::Standard, key(1), None, 2, Some(2)).is_err(),
+            "§8.2: a watermark at next_index is the pre-acked state itself"
+        );
+        assert!(
+            QueueState::restore(QueueKind::Standard, key(1), None, 0, Some(0)).is_err(),
+            "§8.2: nothing has ever been appended, so index 0 cannot be acked"
+        );
+        assert!(QueueState::restore(QueueKind::Standard, key(1), None, 1, Some(0)).is_ok());
     }
 
     #[test]

--- a/rs/crates/f2z-relay-store/Cargo.toml
+++ b/rs/crates/f2z-relay-store/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "f2z-relay-store"
+version = "0.1.0"
+description = "Queue storage for the free2z relay: addresses and bytes, never wire frames (docs/e2ee/WIRE.md §7, §8)"
+edition.workspace = true
+# A restatement of wallet/rust-toolchain.toml's channel in Cargo's MSRV form,
+# registered with `scripts/check-rust-toolchain.sh --manifest` so it cannot
+# drift. Not inherited from the workspace: that check reads this literal line.
+rust-version = "1.97"
+# Permissive, deliberately and explicitly. The relay *binary* will be AGPL-3.0;
+# this is a library, and a third party writing its own relay against
+# docs/e2ee/WIRE.md should be able to link the storage layer that the reference
+# implementation's crash tests actually exercise. Stated literally rather than
+# inherited so it is visible to anyone opening the crate. rs/deny.toml enforces
+# it.
+license = "MIT"
+repository.workspace = true
+publish.workspace = true
+
+[features]
+# Off by default, and it must stay off in anything that ships. It compiles an
+# `abort()` into the middle of the commit path so that `tests/crash_safety.rs`
+# can kill a real process at a chosen instant. See `src/crash.rs`.
+crash-injection = []
+
+[lints]
+workspace = true
+
+[dependencies]
+# `version` beside `path` is not redundant: rs/deny.toml sets
+# `wildcards = "deny"`, and a bare path dependency is a wildcard requirement.
+f2z-codec = { path = "../f2z-codec", version = "0.1.0" }
+f2z-relay-proto = { path = "../f2z-relay-proto", version = "0.1.0" }
+rusqlite = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+# The crash test needs a real file in a real directory that a **child process**
+# can open, so `SqliteStore::open_in_memory` is not an option there. Already in
+# this workspace's dev graph beneath proptest's `rusty-fork`, so naming it
+# directly adds no crate to the tree cargo-deny judges.
+tempfile = "3"

--- a/rs/crates/f2z-relay-store/src/crash.rs
+++ b/rs/crates/f2z-relay-store/src/crash.rs
@@ -1,0 +1,155 @@
+//! Deterministic process death, for the one property that cannot be tested any
+//! other way.
+//!
+//! # Why an in-process panic proves nothing here
+//!
+//! The claim under test is "what is on the disk after the machine stops". A
+//! caught `panic!` unwinds inside a live process that still owns the SQLite
+//! connection, still holds its page cache, and will run `Drop` on its way out —
+//! rolling back the very transaction whose fate is the question. It exercises
+//! the error path, not the durability one.
+//!
+//! `abort()` is different: no unwinding, no destructors, no `sqlite3_close`,
+//! no flush of anything the kernel had not already been told to write. What
+//! survives is exactly what `synchronous = FULL` put on the disk. The test
+//! harness then reopens the same file **in a new process** and asserts the two
+//! invariants delete-on-ack depends on:
+//!
+//! - nothing **acked-but-undeleted** — no message at or below the persisted
+//!   watermark is still stored;
+//! - nothing **accepted-but-lost** — every append whose receipt the caller
+//!   actually received is still there.
+//!
+//! # Why it is behind a feature
+//!
+//! `crash-injection` is off by default and must never be enabled in anything
+//! that ships: it compiles a conditional `abort()` into the middle of the
+//! commit path. It is a `[features]` entry rather than `#[cfg(test)]` because
+//! the crash has to happen inside the library, in a *separate binary* the test
+//! spawns, and `#[cfg(test)]` code does not exist in a dependency build.
+//!
+//! # How it is driven
+//!
+//! By environment variable, because the child process is spawned rather than
+//! called. [`arm_from_env`] reads `F2Z_RELAY_STORE_CRASH_AT`; unset or
+//! unrecognized means armed at nothing, so a stray value cannot make a
+//! production build die at a random instant even if the feature were somehow
+//! on.
+//!
+//! **Nothing in the library arms itself.** `SqliteStore::open` deliberately
+//! does *not* call [`arm_from_env`], because a store that armed at open would
+//! die on the first append rather than on the one the test chose — and the
+//! interesting crash is almost never the first one. The child arms immediately
+//! before the operation it means to lose.
+
+use core::sync::atomic::{AtomicU8, Ordering};
+
+/// The environment variable [`arm_from_env`] reads.
+pub const CRASH_POINT_ENV: &str = "F2Z_RELAY_STORE_CRASH_AT";
+
+/// An instant in the commit path at which the process can be made to die.
+///
+/// The pairs are the point: each write has a "before the commit" and an "after
+/// the commit, before the caller is told" variant, and the two assert opposite
+/// things. Before-commit must leave **no trace**; after-commit must leave the
+/// write **complete**, even though the caller never received its receipt and so
+/// never reported `accepted`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CrashPoint {
+    /// Never crash. The value a build with the feature on but nothing armed
+    /// runs at.
+    Never,
+    /// Inside `append_batch`, with every row written and the transaction not
+    /// yet committed.
+    BeforeAppendCommit,
+    /// Inside `append_batch`, after the commit's fsync returned and before the
+    /// receipts reach the caller.
+    AfterAppendCommit,
+    /// Inside `ack`, with the range delete and the watermark advance staged and
+    /// the transaction not yet committed.
+    BeforeAckCommit,
+    /// Inside `ack`, after the commit's fsync returned and before the outcome
+    /// reaches the caller.
+    AfterAckCommit,
+}
+
+impl CrashPoint {
+    /// The name used in [`CRASH_POINT_ENV`], and in test failure output.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Never => "never",
+            Self::BeforeAppendCommit => "before-append-commit",
+            Self::AfterAppendCommit => "after-append-commit",
+            Self::BeforeAckCommit => "before-ack-commit",
+            Self::AfterAckCommit => "after-ack-commit",
+        }
+    }
+
+    /// Parse a name. Anything unrecognized is [`CrashPoint::Never`] — see the
+    /// module note on why an unknown value must not be a crash.
+    #[must_use]
+    pub fn parse(name: &str) -> Self {
+        match name {
+            "before-append-commit" => Self::BeforeAppendCommit,
+            "after-append-commit" => Self::AfterAppendCommit,
+            "before-ack-commit" => Self::BeforeAckCommit,
+            "after-ack-commit" => Self::AfterAckCommit,
+            _ => Self::Never,
+        }
+    }
+
+    const fn tag(self) -> u8 {
+        match self {
+            Self::Never => 0,
+            Self::BeforeAppendCommit => 1,
+            Self::AfterAppendCommit => 2,
+            Self::BeforeAckCommit => 3,
+            Self::AfterAckCommit => 4,
+        }
+    }
+}
+
+static ARMED: AtomicU8 = AtomicU8::new(0);
+
+/// Arm a crash point for this process.
+pub fn arm(point: CrashPoint) {
+    ARMED.store(point.tag(), Ordering::SeqCst);
+}
+
+/// Arm from [`CRASH_POINT_ENV`], if it is set to a name this build knows.
+pub fn arm_from_env() {
+    if let Ok(value) = std::env::var(CRASH_POINT_ENV) {
+        arm(CrashPoint::parse(&value));
+    }
+}
+
+/// Kill the process, right here, if this point is the armed one.
+///
+/// `abort()` rather than `exit()`: a normal exit runs at-exit handlers and
+/// flushes buffers, which is the opposite of the event being simulated.
+pub(crate) fn fire(point: CrashPoint) {
+    if ARMED.load(Ordering::SeqCst) == point.tag() {
+        std::process::abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unknown_name_is_never_a_crash() {
+        assert_eq!(CrashPoint::parse("kaboom"), CrashPoint::Never);
+        assert_eq!(CrashPoint::parse(""), CrashPoint::Never);
+        assert_eq!(
+            CrashPoint::parse(CrashPoint::AfterAckCommit.name()),
+            CrashPoint::AfterAckCommit
+        );
+    }
+
+    #[test]
+    fn nothing_is_armed_by_default() {
+        assert_eq!(ARMED.load(Ordering::SeqCst), CrashPoint::Never.tag());
+    }
+}

--- a/rs/crates/f2z-relay-store/src/durability.rs
+++ b/rs/crates/f2z-relay-store/src/durability.rs
@@ -1,0 +1,193 @@
+//! Durability as a value you are handed, not a rule you are asked to remember.
+//!
+//! # The problem this module exists for
+//!
+//! [`ARCHITECTURE.md` §6.3][s63] defines four delivery states, and the relay
+//! implements two of them: `accepted` (an `APPEND` that returned status 0) and
+//! `queue-delivered` (an `ACK`, at which instant the relay **deletes**). Under
+//! delete-on-ack the relay's copy is, for a window, the only copy in the
+//! system — [`ARCHITECTURE.md` §6.4][s64] says it plainly: "a lost ACK now
+//! means a permanently lost message, because the relay's copy is gone or was
+//! never taken."
+//!
+//! So a relay that answers `accepted` before the write has reached stable
+//! storage has told the sender it took custody of something it can still lose
+//! to a power cut. [`WIRE.md` §8.4][s84] publishes exactly this as
+//! `durability_mode`, and the honest reading of that field is that it is a
+//! promise an operator makes about its own code.
+//!
+//! # How this crate keeps that promise mechanically
+//!
+//! [`Committed<T>`] is the result of every mutating [`RelayStore`] operation,
+//! and it **cannot be constructed outside this crate**. The only code that
+//! mints one is the code that has just finished the transaction that made it
+//! true. A caller therefore cannot write "reply `accepted`" without first
+//! holding a value that only a completed commit could have produced — the
+//! ordering is a borrow-checked fact rather than a comment in a review.
+//!
+//! [`Committed`] is `#[must_use]` for the mirror reason: silently dropping the
+//! receipt is how a batch loses track of which of its appends actually landed.
+//!
+//! # The cost, stated
+//!
+//! Because the constructor is crate-private, a `RelayStore` implementation
+//! **outside this crate cannot exist**. That is a deliberate v1 trade and it is
+//! recorded rather than hidden: durability is the one property a storage
+//! backend cannot be trusted to assert about itself, and an
+//! `assert_durable(...)` escape hatch would restore precisely the convention
+//! this type replaces. Opening it later is a one-item change — a default-off
+//! feature exposing a loudly-named constructor — and it should be made when
+//! there is a real second backend, not in advance of one.
+//!
+//! [s63]: https://github.com/free2z/zuu/blob/main/docs/e2ee/ARCHITECTURE.md#63-what-delivered-means
+//! [s64]: https://github.com/free2z/zuu/blob/main/docs/e2ee/ARCHITECTURE.md#64-delete-on-ack-and-lost-acknowledgements
+//! [s84]: https://github.com/free2z/zuu/blob/main/docs/e2ee/WIRE.md#84-where-this-sits-in-the-four-delivery-states
+//! [`RelayStore`]: crate::RelayStore
+
+use core::fmt;
+
+/// What a store's `Committed` actually promises — `WIRE.md` §11.1's
+/// `durability_mode`, as a type.
+///
+/// The wire encoding is a `uint8` and the three values are §11.1's, unchanged.
+/// A relay MUST publish the value its store reports; a client SHOULD prefer a
+/// durable relay, and §8.4 says the field exists so that it can.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Durability {
+    /// `0` — nothing survives the process. [`MemoryStore`] is this, and no
+    /// end-to-end contract breaks: `accepted` never promised anything (§8.4).
+    /// It is for tests, for a private relay that is explicitly a cache, and for
+    /// making the *other* two values mean something by contrast.
+    ///
+    /// [`MemoryStore`]: crate::MemoryStore
+    Memory,
+    /// `1` — the write is acknowledged before it is flushed. This crate does
+    /// not implement it, and the variant exists so that a store reporting a
+    /// mode can name every mode the capability document can carry.
+    ///
+    /// **Group commit is not this.** Batching many appends into one
+    /// transaction still fsyncs before any of them returns; deferring the fsync
+    /// past the response is what makes a store `batched`.
+    Batched,
+    /// `2` — an `APPEND` that returned 0 survives a crash. [`SqliteStore`] is
+    /// this: WAL journalling with `synchronous = FULL`, verified at open rather
+    /// than assumed.
+    ///
+    /// [`SqliteStore`]: crate::SqliteStore
+    FsyncPerAppend,
+}
+
+impl Durability {
+    /// The `uint8` a relay publishes in `Capabilities.durability_mode` (§11.1).
+    #[must_use]
+    pub const fn wire_value(self) -> u8 {
+        match self {
+            Self::Memory => 0,
+            Self::Batched => 1,
+            Self::FsyncPerAppend => 2,
+        }
+    }
+
+    /// Whether an `APPEND` that returned 0 through this store survives a crash.
+    ///
+    /// This is the question §8.4 tells a client to ask, and the only one a
+    /// caller should branch on.
+    #[must_use]
+    pub const fn survives_crash(self) -> bool {
+        matches!(self, Self::FsyncPerAppend)
+    }
+}
+
+impl fmt::Display for Durability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::Memory => "memory",
+            Self::Batched => "batched",
+            Self::FsyncPerAppend => "fsync-per-append",
+        };
+        write!(f, "{name} ({})", self.wire_value())
+    }
+}
+
+/// The outcome of a store operation, together with the proof that the operation
+/// reached the store's published durability level before this value existed.
+///
+/// Every mutating [`RelayStore`] method returns one. See the module
+/// documentation for why the constructor is crate-private and what that buys.
+///
+/// [`RelayStore`]: crate::RelayStore
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[must_use = "this is the evidence that the write is durable; dropping it discards \
+              the only thing that distinguishes `accepted` from a hope"]
+pub struct Committed<T> {
+    durability: Durability,
+    value: T,
+}
+
+impl<T> Committed<T> {
+    /// Mint a proof. Callable only from inside this crate, and only from the
+    /// code that has just completed the durable write.
+    pub(crate) const fn seal(durability: Durability, value: T) -> Self {
+        Self { durability, value }
+    }
+
+    /// The durability level this write actually reached.
+    #[must_use]
+    pub const fn durability(&self) -> Durability {
+        self.durability
+    }
+
+    /// Borrow the outcome.
+    #[must_use]
+    pub const fn get(&self) -> &T {
+        &self.value
+    }
+
+    /// Take the outcome, discarding the proof.
+    ///
+    /// Named to be visible in review: after this call the value is an ordinary
+    /// one and nothing distinguishes it from a value that was never committed.
+    #[must_use]
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+
+    /// Transform the outcome, carrying the proof across unchanged.
+    ///
+    /// The proof is about the *write*, not about the shape of the value, so
+    /// projecting a field out of a batch result does not weaken it.
+    pub fn map<U, F: FnOnce(T) -> U>(self, function: F) -> Committed<U> {
+        Committed {
+            durability: self.durability,
+            value: function(self.value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_values_are_section_11_1s() {
+        assert_eq!(Durability::Memory.wire_value(), 0);
+        assert_eq!(Durability::Batched.wire_value(), 1);
+        assert_eq!(Durability::FsyncPerAppend.wire_value(), 2);
+    }
+
+    #[test]
+    fn only_fsync_per_append_survives_a_crash() {
+        assert!(!Durability::Memory.survives_crash());
+        assert!(!Durability::Batched.survives_crash());
+        assert!(Durability::FsyncPerAppend.survives_crash());
+    }
+
+    #[test]
+    fn the_proof_travels_through_map() {
+        let committed = Committed::seal(Durability::FsyncPerAppend, 7u64);
+        assert_eq!(*committed.get(), 7);
+        let mapped = committed.map(|value| value + 1);
+        assert_eq!(mapped.durability(), Durability::FsyncPerAppend);
+        assert_eq!(mapped.into_inner(), 8);
+    }
+}

--- a/rs/crates/f2z-relay-store/src/error.rs
+++ b/rs/crates/f2z-relay-store/src/error.rs
@@ -1,0 +1,179 @@
+//! What a store can refuse, and what a relay is allowed to say about it.
+//!
+//! Two rules from `WIRE.md` govern this whole module and neither is
+//! negotiable:
+//!
+//! - **§10's existence-oracle rule.** "Either the address does not exist, or it
+//!   exists and `signer_key` does not authorize it" is one code,
+//!   `ERR_NO_ACCESS`, because a relay that distinguished them would answer an
+//!   attacker sweeping the 32-byte address space. The store is the component
+//!   that knows whether a row exists, so the collapse has to happen here — a
+//!   `NotFound` variant reaching the caller would be the oracle itself, one
+//!   `match` arm away from the wire.
+//! - **§6.3's send-side collapse.** Absent, deleted, expired, full-by-messages,
+//!   full-by-bytes and backpressure are all `ERR_UNAVAILABLE` on the send side,
+//!   because otherwise a bound sender learns the queue's state by filling it.
+//!   So the *same* missing row is `ERR_NO_ACCESS` when it was looked up by
+//!   receive address and `ERR_UNAVAILABLE` when it was looked up by send
+//!   address, and the two lookups are separate methods for exactly that reason.
+//!
+//! Everything else here is a relay fault, and §10 gives relay faults one code
+//! that "carries no detail, ever".
+
+use core::fmt;
+
+use f2z_codec::ErrorCode;
+use f2z_relay_proto::ProtoError;
+
+/// A store operation's result.
+pub type Result<T> = core::result::Result<T, StoreError>;
+
+/// Why a store operation did not happen.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum StoreError {
+    /// A refusal the protocol already has a code for — the queue-lifecycle and
+    /// acknowledgement rules of §7 and §8, applied to persisted state.
+    Protocol(ProtoError),
+    /// `CREATE_QUEUE` was handed an address that is already in use.
+    ///
+    /// Not a protocol error and never sent: §7.1 has the relay generate both
+    /// addresses from its own CSPRNG and "simply retry on collision, which it
+    /// will never have to do at 32 bytes". This is the value that tells the
+    /// caller to draw again. It is also what a *bug* in the caller's address
+    /// generation looks like, which is why it is distinguishable here and
+    /// nowhere else.
+    AddressCollision,
+    /// A value does not fit the storage engine's integer domain.
+    ///
+    /// SQLite's `INTEGER` is a signed 64-bit value, so this store's index and
+    /// byte counters top out at `i64::MAX` rather than `u64::MAX`. Reachable
+    /// only by a caller passing an absurd quota; unreachable by appending, at
+    /// any rate a relay could sustain, for longer than the species has existed.
+    ValueOutOfRange,
+    /// The store's own contents contradict the protocol.
+    ///
+    /// A relay fault. It becomes `ERR_INTERNAL` on the wire, which §10 says
+    /// carries no detail — the detail belongs in the operator's alerting, not
+    /// in a frame.
+    Corrupt(&'static str),
+    /// The storage engine failed.
+    Backend(rusqlite::Error),
+}
+
+impl StoreError {
+    /// The §10 code a relay answers with.
+    ///
+    /// Every non-protocol variant is `ERR_INTERNAL`, including
+    /// [`StoreError::AddressCollision`]: a caller that propagates a collision
+    /// to the wire instead of redrawing has a bug, and inventing a code for it
+    /// would put an implementation detail into a stable protocol field.
+    #[must_use]
+    pub const fn error_code(&self) -> ErrorCode {
+        match self {
+            Self::Protocol(ProtoError::Wire(code)) => *code,
+            Self::Protocol(_)
+            | Self::AddressCollision
+            | Self::ValueOutOfRange
+            | Self::Corrupt(_)
+            | Self::Backend(_) => ErrorCode::Internal,
+        }
+    }
+
+    /// Whether the relay must close the connection after answering (§1.3).
+    #[must_use]
+    pub const fn is_fatal(&self) -> bool {
+        self.error_code().is_fatal()
+    }
+
+    /// The refusal a receive-side lookup makes when there is no such queue.
+    ///
+    /// §10: the same code an address that never existed gets, and the same code
+    /// a wrong key gets. There is no other constructor for "absent" on this
+    /// side, so there is no way to accidentally answer something else.
+    #[must_use]
+    pub(crate) const fn no_access() -> Self {
+        Self::Protocol(ProtoError::Wire(ErrorCode::NoAccess))
+    }
+
+    /// The refusal every send-side failure makes (§6.3).
+    #[must_use]
+    pub(crate) const fn unavailable() -> Self {
+        Self::Protocol(ProtoError::Wire(ErrorCode::Unavailable))
+    }
+}
+
+impl From<ProtoError> for StoreError {
+    fn from(error: ProtoError) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+impl From<rusqlite::Error> for StoreError {
+    fn from(error: rusqlite::Error) -> Self {
+        Self::Backend(error)
+    }
+}
+
+impl fmt::Display for StoreError {
+    /// Renders no payload, no address and no key — see `tests/redaction.rs`.
+    ///
+    /// This is cheap to keep true because nothing in this crate ever
+    /// interpolates a value into SQL: every payload, address and key travels as
+    /// a bound parameter, and SQLite's diagnostics name schema objects rather
+    /// than echoing the values bound to them. The test exists because "cheap to
+    /// keep true" is not the same as "true", and the day someone builds a query
+    /// by formatting is the day this stops holding.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Protocol(error) => write!(f, "{error}"),
+            Self::AddressCollision => f.write_str(
+                "the address handed to CREATE_QUEUE is already in use; draw again (§7.1)",
+            ),
+            Self::ValueOutOfRange => {
+                f.write_str("a counter exceeded this store's signed 64-bit integer domain")
+            }
+            Self::Corrupt(what) => write!(f, "stored state contradicts the protocol: {what}"),
+            Self::Backend(error) => write!(f, "storage engine: {error}"),
+        }
+    }
+}
+
+impl core::error::Error for StoreError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Backend(error) => Some(error),
+            Self::Protocol(_)
+            | Self::AddressCollision
+            | Self::ValueOutOfRange
+            | Self::Corrupt(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_two_absent_cases_answer_differently_and_deliberately() {
+        assert_eq!(StoreError::no_access().error_code(), ErrorCode::NoAccess);
+        assert_eq!(
+            StoreError::unavailable().error_code(),
+            ErrorCode::Unavailable
+        );
+    }
+
+    #[test]
+    fn every_relay_fault_is_err_internal() {
+        assert_eq!(
+            StoreError::AddressCollision.error_code(),
+            ErrorCode::Internal
+        );
+        assert_eq!(
+            StoreError::ValueOutOfRange.error_code(),
+            ErrorCode::Internal
+        );
+        assert_eq!(StoreError::Corrupt("x").error_code(), ErrorCode::Internal);
+    }
+}

--- a/rs/crates/f2z-relay-store/src/lib.rs
+++ b/rs/crates/f2z-relay-store/src/lib.rs
@@ -1,0 +1,143 @@
+//! Queue storage for a free2z relay: addresses and bytes, never wire frames.
+//!
+//! This crate is the bottom of the relay. Above it sit [`f2z_relay_proto`],
+//! which owns the protocol rules, and [`f2z_codec`], which owns the canonical
+//! encoding. Nothing here parses a frame, verifies a signature, reads a clock
+//! or generates a random number. What it owns is the one question those layers
+//! cannot answer: **is it actually on the disk.**
+//!
+//! # Why that question is the whole crate
+//!
+//! [`ARCHITECTURE.md` §6.3][s63] separates four delivery states, and warns that
+//! conflating them is how delete-on-ack loses messages. The relay implements
+//! two:
+//!
+//! | State | Here |
+//! |---|---|
+//! | `accepted` | An `APPEND` the store took. Says nothing about the recipient — §6.3 makes sure of it. |
+//! | `queue-delivered` | An `ACK`. **The store deletes at this instant.** |
+//!
+//! Between those two instants the relay's copy is the only copy of that
+//! ciphertext anywhere in the system. So an `accepted` answered before the
+//! write reached stable storage is a promise of custody that a power cut
+//! breaks, and [`ARCHITECTURE.md` §6.4][s64] is blunt about the consequence: a
+//! lost message under delete-on-ack is permanent.
+//!
+//! The crate's answer is [`Committed<T>`]: every mutating operation returns
+//! one, and its constructor is private to this crate. A caller cannot write the
+//! code that reports `accepted` without first holding a value that only a
+//! completed commit could have produced. Durability is a returned fact rather
+//! than a convention someone has to remember during review.
+//!
+//! # The three storage decisions
+//!
+//! - **`synchronous = FULL` over WAL**, verified at open rather than assumed.
+//! - **Group commit is required, not an optimization.** At `FULL` a commit
+//!   costs an fsync and a cheap VPS does 50-200 of those a second, so one
+//!   transaction per append caps the whole relay at that. [`RelayStore::append_batch`]
+//!   is therefore the primitive and [`RelayStore::append`] is the batch of one;
+//!   the window over which a server gathers a batch is the server's decision,
+//!   and the shape that makes it possible is this crate's.
+//! - **`secure_delete = ON`.** Deleted ciphertext is zeroed, not merely
+//!   unlinked. See [`SqliteStore::checkpoint`] for the part `secure_delete`
+//!   alone does not cover.
+//!
+//! # Nothing here is loggable
+//!
+//! Every address, key and payload that crosses this boundary is an
+//! [`f2z_codec`] newtype with a redacting `Debug`, and the records built from
+//! them inherit it — a derived `Debug` delegates to its fields'. The trap that
+//! makes this worth stating is documented in `f2z-codec`'s own redaction tests:
+//! `tls_codec`'s byte vectors print a **decimal** list, `[222, 222, …]`, which
+//! contains no hex at all, so a leak check that only looks for hex passes while
+//! everything leaks. `tests/redaction.rs` here checks base16 in both cases,
+//! base64url and the decimal run.
+//!
+//! # Example
+//!
+//! ```
+//! use f2z_codec::types::{Payload, PublicKey, QueueAddress};
+//! use f2z_relay_proto::queue::{AppendQuota, QueueKind};
+//! use f2z_relay_store::{
+//!     Append, MemoryStore, QueueSpec, ReadWindow, RelayStore, SendAuth,
+//! };
+//!
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! let store = MemoryStore::new();
+//! let recv_addr = QueueAddress::new([1u8; 32]);
+//! let send_addr = QueueAddress::new([2u8; 32]);
+//! let recv_key = PublicKey::new([3u8; 32]);
+//! let send_key = PublicKey::new([4u8; 32]);
+//!
+//! store.create_queue(&QueueSpec {
+//!     kind: QueueKind::Standard,
+//!     recv_addr,
+//!     send_addr,
+//!     recv_key,
+//!     message_ttl_seconds: 604_800,
+//!     idle_ttl_seconds: 7_776_000,
+//!     quota: AppendQuota { max_messages: 1_000, max_bytes: 1 << 20 },
+//!     created_at_ms: 1_000,
+//! })?;
+//!
+//! // §7.3: the send side is bound once, by the key that signed the request.
+//! store.bind_send(&send_addr, &send_key, 1_000)?;
+//!
+//! let payload = Payload::new(vec![0u8; 1024])?;
+//! let accepted = store.append(&Append {
+//!     send_addr,
+//!     auth: SendAuth::Signed(send_key),
+//!     payload: &payload,
+//!     received_at_ms: 2_000,
+//! })?;
+//! // Only now may the relay answer `accepted` — and §6.3 forbids it from
+//! // putting the index, or anything else, in that answer.
+//! let index = accepted.into_inner().index;
+//!
+//! let page = store.read(&recv_addr, &recv_key, ReadWindow {
+//!     from_index: 0,
+//!     max_messages: 16,
+//!     max_bytes: 65_536,
+//! }, 3_000)?;
+//! assert_eq!(page.messages.len(), 1);
+//!
+//! // §8: cumulative, and the relay deletes at this instant.
+//! store.ack(&recv_addr, &recv_key, index, 4_000)?;
+//! assert_eq!(store.stats()?.messages, 0);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [s63]: https://github.com/free2z/zuu/blob/main/docs/e2ee/ARCHITECTURE.md#63-what-delivered-means
+//! [s64]: https://github.com/free2z/zuu/blob/main/docs/e2ee/ARCHITECTURE.md#64-delete-on-ack-and-lost-acknowledgements
+
+#![forbid(unsafe_code)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects
+    )
+)]
+
+#[cfg(feature = "crash-injection")]
+pub mod crash;
+pub mod durability;
+pub mod error;
+pub mod memory;
+pub mod record;
+pub mod sqlite;
+pub mod store;
+
+pub use durability::{Committed, Durability};
+pub use error::{Result, StoreError};
+pub use memory::MemoryStore;
+pub use record::{
+    Append, Appended, Deleted, ExpiryReason, ExpiryReport, QueueExpiry, QueueRecord, QueueSpec,
+    ReadPage, ReadWindow, SendAuth, StoreStats, StoredMessage,
+};
+pub use sqlite::SqliteStore;
+pub use store::RelayStore;

--- a/rs/crates/f2z-relay-store/src/memory.rs
+++ b/rs/crates/f2z-relay-store/src/memory.rs
@@ -1,0 +1,424 @@
+//! The volatile store — `WIRE.md` §11.1's `durability_mode = memory`.
+//!
+//! # What it is for
+//!
+//! Three things, and the first is the one that matters:
+//!
+//! 1. **It makes `fsync-per-append` mean something.** A published
+//!    `durability_mode` field with one possible value is a field nobody checks.
+//!    Every property test in this crate runs against both stores, so a rule
+//!    that only holds because SQLite happens to enforce it — a `NOT NULL`, a
+//!    `PRIMARY KEY` collision — fails here, where nothing enforces anything
+//!    except the code that is supposed to.
+//! 2. A relay an operator explicitly wants to be a cache: §8.4 is clear that
+//!    "no end-to-end contract breaks in the weaker modes, because `accepted`
+//!    never promised anything". The honest requirement is that the relay
+//!    *publish* what it is, which [`RelayStore::durability`] makes it able to.
+//! 3. Tests of everything above the store, without a filesystem.
+//!
+//! # What it must never be used for
+//!
+//! A relay that a stranger's messages pass through. Under delete-on-ack the
+//! relay's copy is, for a window, the only copy; here that window ends at the
+//! next restart.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, PoisonError};
+
+use f2z_codec::types::{Payload, PublicKey, QueueAddress};
+use f2z_relay_proto::queue::{AckOutcome, QueueKind, QueueState};
+
+use crate::durability::{Committed, Durability};
+use crate::error::{Result, StoreError};
+use crate::record::{
+    Append, Appended, Deleted, ExpiryReason, ExpiryReport, QueueExpiry, QueueRecord, QueueSpec,
+    ReadPage, ReadWindow, SendAuth, StoreStats, StoredMessage, message_deadline,
+};
+use crate::sqlite::authorize_send;
+use crate::store::RelayStore;
+
+#[derive(Clone, Debug)]
+struct StoredEntry {
+    index: u64,
+    received_at_ms: u64,
+    expires_at_ms: u64,
+    payload: Payload,
+}
+
+#[derive(Clone, Debug)]
+struct MemoryQueue {
+    record: QueueRecord,
+    /// Ascending by index, always. `ACK` deletes a prefix and `READ` scans a
+    /// suffix, which is the same access pattern the SQLite schema's
+    /// `WITHOUT ROWID` `(recv_addr, idx)` key buys.
+    messages: Vec<StoredEntry>,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    queues: HashMap<QueueAddress, MemoryQueue>,
+    /// send address → receive address. The pairing §6.2 admits the relay
+    /// necessarily holds: "an APPEND to `QueueSendAddr` has to be delivered
+    /// into the message list read from `QueueRecvAddr`".
+    by_send: HashMap<QueueAddress, QueueAddress>,
+}
+
+/// A store that holds everything in memory and loses it on exit.
+#[derive(Debug, Default)]
+pub struct MemoryStore {
+    inner: Mutex<Inner>,
+}
+
+impl MemoryStore {
+    /// An empty store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+impl Inner {
+    fn by_recv(&self, recv_addr: &QueueAddress) -> Result<&MemoryQueue> {
+        self.queues.get(recv_addr).ok_or_else(StoreError::no_access)
+    }
+
+    fn by_recv_mut(&mut self, recv_addr: &QueueAddress) -> Result<&mut MemoryQueue> {
+        self.queues
+            .get_mut(recv_addr)
+            .ok_or_else(StoreError::no_access)
+    }
+
+    fn recv_for_send(&self, send_addr: &QueueAddress) -> Result<QueueAddress> {
+        self.by_send
+            .get(send_addr)
+            .copied()
+            .ok_or_else(StoreError::unavailable)
+    }
+
+    fn drop_queue(&mut self, recv_addr: &QueueAddress) -> Option<MemoryQueue> {
+        let queue = self.queues.remove(recv_addr)?;
+        self.by_send.remove(&queue.record.send_addr);
+        Some(queue)
+    }
+}
+
+fn totals(queue: &MemoryQueue) -> (u64, u64) {
+    let count = u64::try_from(queue.messages.len()).unwrap_or(u64::MAX);
+    let bytes = queue.messages.iter().fold(0u64, |sum, entry| {
+        sum.saturating_add(u64::try_from(entry.payload.len()).unwrap_or(u64::MAX))
+    });
+    (count, bytes)
+}
+
+fn touch_record(record: &mut QueueRecord, now_ms: u64) {
+    if record.last_activity_ms < now_ms {
+        record.last_activity_ms = now_ms;
+    }
+}
+
+impl RelayStore for MemoryStore {
+    fn durability(&self) -> Durability {
+        Durability::Memory
+    }
+
+    fn create_queue(&self, spec: &QueueSpec) -> Result<Committed<QueueRecord>> {
+        if spec.recv_addr == spec.send_addr {
+            return Err(StoreError::AddressCollision);
+        }
+        let mut inner = self.lock();
+        // Both addresses come out of one 32-byte space, so a collision with
+        // either kind of existing address is a collision (§7.1: draw again).
+        let taken = |inner: &Inner, address: &QueueAddress| {
+            inner.queues.contains_key(address) || inner.by_send.contains_key(address)
+        };
+        if taken(&inner, &spec.recv_addr) || taken(&inner, &spec.send_addr) {
+            return Err(StoreError::AddressCollision);
+        }
+
+        let record = QueueRecord {
+            recv_addr: spec.recv_addr,
+            send_addr: spec.send_addr,
+            state: QueueState::create(spec.kind, spec.recv_key),
+            message_ttl_seconds: spec.message_ttl_seconds,
+            idle_ttl_seconds: spec.idle_ttl_seconds,
+            quota: spec.quota,
+            stored_messages: 0,
+            stored_bytes: 0,
+            created_at_ms: spec.created_at_ms,
+            last_activity_ms: spec.created_at_ms,
+        };
+        inner.by_send.insert(spec.send_addr, spec.recv_addr);
+        inner.queues.insert(
+            spec.recv_addr,
+            MemoryQueue {
+                record: record.clone(),
+                messages: Vec::new(),
+            },
+        );
+        Ok(Committed::seal(self.durability(), record))
+    }
+
+    fn bind_send(
+        &self,
+        send_addr: &QueueAddress,
+        signer: &PublicKey,
+        now_ms: u64,
+    ) -> Result<Committed<()>> {
+        let mut inner = self.lock();
+        let recv_addr = inner.recv_for_send(send_addr)?;
+        let queue = inner.by_recv_mut(&recv_addr)?;
+        queue.record.state.bind_send(signer)?;
+        touch_record(&mut queue.record, now_ms);
+        Ok(Committed::seal(self.durability(), ()))
+    }
+
+    fn queue_by_recv(&self, recv_addr: &QueueAddress, signer: &PublicKey) -> Result<QueueRecord> {
+        let inner = self.lock();
+        let queue = inner.by_recv(recv_addr)?;
+        queue.record.state.authorize_recv(signer)?;
+        Ok(queue.record.clone())
+    }
+
+    fn queue_by_send(&self, send_addr: &QueueAddress, auth: &SendAuth) -> Result<QueueRecord> {
+        let inner = self.lock();
+        let recv_addr = inner.recv_for_send(send_addr)?;
+        let queue = inner
+            .queues
+            .get(&recv_addr)
+            .ok_or_else(StoreError::unavailable)?;
+        authorize_send(&queue.record, auth)?;
+        Ok(queue.record.clone())
+    }
+
+    fn append_batch(&self, appends: &[Append<'_>]) -> Result<Committed<Vec<Result<Appended>>>> {
+        let mut inner = self.lock();
+        let mut results: Vec<Result<Appended>> = Vec::with_capacity(appends.len());
+        for append in appends {
+            results.push(append_one(&mut inner, append));
+        }
+        Ok(Committed::seal(self.durability(), results))
+    }
+
+    fn read(
+        &self,
+        recv_addr: &QueueAddress,
+        signer: &PublicKey,
+        window: ReadWindow,
+        now_ms: u64,
+    ) -> Result<ReadPage> {
+        let mut inner = self.lock();
+        let queue = inner.by_recv_mut(recv_addr)?;
+        queue.record.state.authorize_recv(signer)?;
+
+        let floor = queue.record.state.read_from(window.from_index);
+        let mut messages = Vec::new();
+        let mut fetched = 0usize;
+        let mut bytes = 0u64;
+        for entry in &queue.messages {
+            if entry.index < floor || entry.expires_at_ms <= now_ms {
+                continue;
+            }
+            fetched = fetched.saturating_add(1);
+            if messages.len() >= usize::from(window.max_messages) {
+                continue;
+            }
+            let size = u64::try_from(entry.payload.len()).unwrap_or(u64::MAX);
+            let next = bytes.saturating_add(size);
+            // At least one message, always — see the same comment in `sqlite`.
+            if next > u64::from(window.max_bytes) && !messages.is_empty() {
+                continue;
+            }
+            bytes = next;
+            messages.push(StoredMessage {
+                index: entry.index,
+                received_at_ms: entry.received_at_ms,
+                payload: entry.payload.clone(),
+            });
+        }
+        let page = ReadPage {
+            has_more: fetched > messages.len(),
+            messages,
+            next_index: queue.record.state.next_index(),
+            pending: queue.record.state.pending(),
+        };
+        touch_record(&mut queue.record, now_ms);
+        Ok(page)
+    }
+
+    fn ack(
+        &self,
+        recv_addr: &QueueAddress,
+        signer: &PublicKey,
+        up_to_index: u64,
+        now_ms: u64,
+    ) -> Result<Committed<AckOutcome>> {
+        let mut inner = self.lock();
+        let queue = inner.by_recv_mut(recv_addr)?;
+        queue.record.state.authorize_recv(signer)?;
+        let outcome = queue.record.state.ack(up_to_index)?;
+        if outcome.acknowledged > 0 {
+            queue.messages.retain(|entry| entry.index > up_to_index);
+            let (count, bytes) = totals(queue);
+            queue.record.stored_messages = count;
+            queue.record.stored_bytes = bytes;
+        }
+        touch_record(&mut queue.record, now_ms);
+        Ok(Committed::seal(self.durability(), outcome))
+    }
+
+    fn delete_queue(
+        &self,
+        recv_addr: &QueueAddress,
+        signer: &PublicKey,
+    ) -> Result<Committed<Deleted>> {
+        let mut inner = self.lock();
+        let queue = inner.by_recv(recv_addr)?;
+        queue.record.state.authorize_recv(signer)?;
+        let (messages_deleted, bytes_freed) = totals(queue);
+        inner.drop_queue(recv_addr);
+        Ok(Committed::seal(
+            self.durability(),
+            Deleted {
+                messages_deleted,
+                bytes_freed,
+            },
+        ))
+    }
+
+    fn touch(&self, recv_addr: &QueueAddress, signer: &PublicKey, now_ms: u64) -> Result<()> {
+        let mut inner = self.lock();
+        let queue = inner.by_recv_mut(recv_addr)?;
+        queue.record.state.authorize_recv(signer)?;
+        touch_record(&mut queue.record, now_ms);
+        Ok(())
+    }
+
+    fn expire(&self, now_ms: u64) -> Result<Committed<ExpiryReport>> {
+        let mut inner = self.lock();
+        let mut report = ExpiryReport::default();
+
+        let idle: Vec<QueueAddress> = inner
+            .queues
+            .values()
+            .filter(|queue| queue.record.idle_expires_at_ms() <= now_ms)
+            .map(|queue| queue.record.recv_addr)
+            .collect();
+        for recv_addr in idle {
+            let Some(queue) = inner.drop_queue(&recv_addr) else {
+                continue;
+            };
+            let (messages_expired, bytes_freed) = totals(&queue);
+            report.queues_expired = report.queues_expired.saturating_add(1);
+            report.messages_expired = report.messages_expired.saturating_add(messages_expired);
+            report.bytes_freed = report.bytes_freed.saturating_add(bytes_freed);
+            report.expired.push(QueueExpiry {
+                recv_addr,
+                reason: ExpiryReason::IdleTtl,
+                messages_expired,
+                bytes_freed,
+            });
+        }
+
+        for queue in inner.queues.values_mut() {
+            let before = totals(queue);
+            queue.messages.retain(|entry| entry.expires_at_ms > now_ms);
+            let after = totals(queue);
+            let messages_expired = before.0.saturating_sub(after.0);
+            if messages_expired == 0 {
+                continue;
+            }
+            let bytes_freed = before.1.saturating_sub(after.1);
+            // The watermark deliberately does not move: an expired message was
+            // never acknowledged.
+            queue.record.stored_messages = after.0;
+            queue.record.stored_bytes = after.1;
+            report.messages_expired = report.messages_expired.saturating_add(messages_expired);
+            report.bytes_freed = report.bytes_freed.saturating_add(bytes_freed);
+            report.expired.push(QueueExpiry {
+                recv_addr: queue.record.recv_addr,
+                reason: ExpiryReason::MessageTtl,
+                messages_expired,
+                bytes_freed,
+            });
+        }
+
+        Ok(Committed::seal(self.durability(), report))
+    }
+
+    fn stats(&self) -> Result<StoreStats> {
+        let inner = self.lock();
+        let mut stats = StoreStats::default();
+        for queue in inner.queues.values() {
+            match queue.record.kind() {
+                QueueKind::Standard => stats.queues = stats.queues.saturating_add(1),
+                QueueKind::Contact => {
+                    stats.contact_queues = stats.contact_queues.saturating_add(1);
+                }
+            }
+            let (count, bytes) = totals(queue);
+            stats.messages = stats.messages.saturating_add(count);
+            stats.payload_bytes = stats.payload_bytes.saturating_add(bytes);
+        }
+        // No file, so "what the engine allocated" is the payload plus the
+        // records. Reported rather than zeroed, because a caller wiring §13.1
+        // layer 4 against a store that always says zero would find out it was
+        // wrong in production.
+        stats.storage_bytes = stats.payload_bytes.saturating_add(
+            stats
+                .queues
+                .saturating_add(stats.contact_queues)
+                .saturating_mul(256),
+        );
+        Ok(stats)
+    }
+}
+
+fn append_one(inner: &mut Inner, append: &Append<'_>) -> Result<Appended> {
+    let recv_addr = inner.recv_for_send(&append.send_addr)?;
+    let queue = inner
+        .queues
+        .get_mut(&recv_addr)
+        .ok_or_else(StoreError::unavailable)?;
+    authorize_send(&queue.record, &append.auth)?;
+
+    let payload_bytes =
+        u64::try_from(append.payload.len()).map_err(|_| StoreError::unavailable())?;
+    queue.record.quota.admit(
+        queue.record.stored_messages,
+        queue.record.stored_bytes,
+        payload_bytes,
+    )?;
+
+    let index = queue.record.state.append()?;
+    queue.messages.push(StoredEntry {
+        index,
+        received_at_ms: append.received_at_ms,
+        expires_at_ms: message_deadline(append.received_at_ms, queue.record.message_ttl_seconds),
+        payload: append.payload.clone(),
+    });
+    queue.record.stored_messages = queue.record.stored_messages.saturating_add(1);
+    queue.record.stored_bytes = queue.record.stored_bytes.saturating_add(payload_bytes);
+    touch_record(&mut queue.record, append.received_at_ms);
+
+    Ok(Appended {
+        recv_addr,
+        index,
+        received_at_ms: append.received_at_ms,
+    })
+}
+
+/// Keeps `idle_deadline` honest across both stores: the SQLite store persists
+/// the deadline as a column, this one recomputes it, and they must agree.
+#[cfg(test)]
+mod tests {
+    use crate::record::idle_deadline;
+
+    #[test]
+    fn the_idle_deadline_is_the_same_function_in_both_stores() {
+        assert_eq!(idle_deadline(10_000, 60), 70_000);
+    }
+}

--- a/rs/crates/f2z-relay-store/src/record.rs
+++ b/rs/crates/f2z-relay-store/src/record.rs
@@ -1,0 +1,332 @@
+//! The values that cross the storage boundary: addresses, keys, byte strings
+//! and counters. No frames, no commands, no request ids.
+//!
+//! Every type here is deliberately made of [`f2z_codec`] newtypes rather than
+//! of `[u8; 32]` and `Vec<u8>`, and the reason is `Debug`. A derived `Debug`
+//! delegates to its fields', so a record built from raw byte arrays would
+//! render every address and every byte of ciphertext the first time anyone
+//! logged one — and it would do it in **decimal**, which is the trap
+//! `f2z-codec`'s own redaction tests are written around: `tls_codec`'s byte
+//! vectors print `[222, 222, …]`, a complete dump containing no hex at all, so
+//! a hex-only check passes while everything leaks. Building on the redacting
+//! newtypes makes the property structural instead of remembered.
+
+use f2z_codec::types::{Payload, PublicKey, QueueAddress};
+use f2z_relay_proto::queue::{AppendQuota, QueueKind, QueueState};
+
+/// What `CREATE_QUEUE` (§6.2) or `CREATE_CONTACT_QUEUE` (§12.2) asks the store
+/// to write down.
+///
+/// **The store does not choose the addresses.** §7.1 requires the relay to
+/// generate both from its own CSPRNG, and randomness is not this crate's job:
+/// a store with a CSPRNG is a store that can be asked to produce a *predictable*
+/// address by a caller that gets its seeding wrong, and the collision retry
+/// §7.1 describes belongs next to the generator. The caller draws;
+/// [`StoreError::AddressCollision`] tells it to draw again.
+///
+/// [`StoreError::AddressCollision`]: crate::StoreError::AddressCollision
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct QueueSpec {
+    /// Standard, or the contact queue of §12.2 whose send side is never
+    /// bindable.
+    pub kind: QueueKind,
+    /// The address that authorizes `SUBSCRIBE`, `READ`, `ACK` and
+    /// `DELETE_QUEUE`.
+    pub recv_addr: QueueAddress,
+    /// The address that authorizes `APPEND` — or, on a contact queue, the
+    /// published `contact_addr` that authorizes nothing and accepts
+    /// `CONTACT_APPEND` from anyone with a stamp.
+    pub send_addr: QueueAddress,
+    /// The Ed25519 public key that authorizes the receive side. §6.2 makes
+    /// `CREATE_QUEUE` self-authenticating by requiring the signer to be this
+    /// key; the store records it and never learns anything else about its
+    /// holder.
+    pub recv_key: PublicKey,
+    /// The **granted** message TTL, after §7.7's clamping. The store applies
+    /// it; it does not decide it.
+    pub message_ttl_seconds: u32,
+    /// The **granted** idle TTL, after §7.7's clamping.
+    pub idle_ttl_seconds: u32,
+    /// §13.1 layer 2's per-queue caps, or §12.3's contact-queue caps.
+    pub quota: AppendQuota,
+    /// `CreateQueueResponse.created_at_ms`, and the initial activity stamp from
+    /// which the idle TTL runs.
+    pub created_at_ms: u64,
+}
+
+/// A queue as the store holds it.
+///
+/// There is no `deleted` field and there will not be one. §7.6: a relay "MUST
+/// NOT retain a tombstone that distinguishes deleted from never existed in any
+/// externally observable way", so a deleted queue is a row that is gone.
+#[derive(Clone, Debug)]
+pub struct QueueRecord {
+    /// The receive address.
+    pub recv_addr: QueueAddress,
+    /// The send address, or a contact queue's published `contact_addr`.
+    pub send_addr: QueueAddress,
+    /// The authorization and acknowledgement state, owned by
+    /// [`f2z_relay_proto`] so that §8's arithmetic exists once in the system.
+    pub state: QueueState,
+    /// The granted message TTL (§7.7).
+    pub message_ttl_seconds: u32,
+    /// The granted idle TTL (§7.7).
+    pub idle_ttl_seconds: u32,
+    /// The per-queue caps this queue is admitted against.
+    pub quota: AppendQuota,
+    /// Messages currently stored — **not** the same as
+    /// [`QueueState::pending`], which counts unacknowledged *indices* and is an
+    /// upper bound: TTL expiry (§7.7) removes messages without moving the
+    /// watermark.
+    pub stored_messages: u64,
+    /// Bytes of payload currently stored. Judged against
+    /// [`AppendQuota::max_bytes`].
+    pub stored_bytes: u64,
+    /// When `CREATE_QUEUE` returned.
+    pub created_at_ms: u64,
+    /// The last successful `APPEND`, `READ`, `ACK` or `SUBSCRIBE` (§7.7's idle
+    /// TTL resets on all four).
+    pub last_activity_ms: u64,
+}
+
+impl QueueRecord {
+    /// Standard or contact.
+    #[must_use]
+    pub const fn kind(&self) -> QueueKind {
+        self.state.kind()
+    }
+
+    /// When the idle TTL will retire this queue if nothing else happens.
+    ///
+    /// Saturating rather than wrapping, so an operator's absurd idle TTL means
+    /// "effectively never" instead of "immediately".
+    #[must_use]
+    pub const fn idle_expires_at_ms(&self) -> u64 {
+        idle_deadline(self.last_activity_ms, self.idle_ttl_seconds)
+    }
+}
+
+/// §7.7's idle deadline, computed the one way.
+pub(crate) const fn idle_deadline(last_activity_ms: u64, idle_ttl_seconds: u32) -> u64 {
+    last_activity_ms.saturating_add((idle_ttl_seconds as u64).saturating_mul(1_000))
+}
+
+/// §7.7's per-message deadline, computed the one way.
+pub(crate) const fn message_deadline(received_at_ms: u64, message_ttl_seconds: u32) -> u64 {
+    received_at_ms.saturating_add((message_ttl_seconds as u64).saturating_mul(1_000))
+}
+
+/// How a writer proves it may append (§6.3, §12.2).
+///
+/// The distinction is not decoration: `APPEND` on a contact address and
+/// `CONTACT_APPEND` on an ordinary send address are both refusals, and both
+/// collapse to `ERR_UNAVAILABLE` because a writer must not learn which kind of
+/// queue an address is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SendAuth {
+    /// `APPEND` (§6.3): the caller has verified a signature by this key. The
+    /// store checks it against the bound send key.
+    Signed(PublicKey),
+    /// `CONTACT_APPEND` (§12.2): unsigned. The caller has already verified the
+    /// proof-of-work stamp against a relay-issued, single-use, expiring
+    /// challenge scoped to this `contact_addr` (§13.1) — the store neither
+    /// hashes nor issues challenges, and this variant asserts that the check
+    /// happened.
+    ContactStamp,
+}
+
+/// One append, as handed to [`RelayStore::append_batch`].
+///
+/// [`RelayStore::append_batch`]: crate::RelayStore::append_batch
+#[derive(Clone, Copy, Debug)]
+pub struct Append<'a> {
+    /// The address the writer presented.
+    pub send_addr: QueueAddress,
+    /// How it proved it may write.
+    pub auth: SendAuth,
+    /// The ciphertext. The caller has already checked its length against the
+    /// relay's published `padding_sizes` (§9); the store stores bytes and does
+    /// not have a bucket list.
+    pub payload: &'a Payload,
+    /// The relay's clock at acceptance. Becomes `QueuedMessage.received_at_ms`
+    /// and starts the message TTL.
+    pub received_at_ms: u64,
+}
+
+/// What an accepted append produced.
+///
+/// **None of this may be sent to the writer.** §6.3: `APPEND`'s response body
+/// "carries no index, no queue depth, no timestamp and no queue state of any
+/// kind", because an index tells the sender how many messages the queue has
+/// ever held and a timestamp gives it a clock to correlate against. These
+/// fields exist for the `MSG` push (§6.4), which goes only to a subscribed
+/// **reader**.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Appended {
+    /// The queue the send address resolved to. The reader's address — the
+    /// pairing §6.2 admits the relay necessarily holds.
+    pub recv_addr: QueueAddress,
+    /// The index assigned.
+    pub index: u64,
+    /// The stamp recorded.
+    pub received_at_ms: u64,
+}
+
+/// A `READ` window (§6.2).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadWindow {
+    /// `ReadRequest.from_index`. Below the acked watermark it is silently
+    /// raised to the watermark: §6.2 requires that a relay "MUST NOT resurrect
+    /// deleted messages and MUST NOT error", so a client recovering from a
+    /// crash can ask for everything it might have missed.
+    pub from_index: u64,
+    /// `ReadRequest.max_messages`.
+    pub max_messages: u16,
+    /// `ReadRequest.max_bytes`, counted over payload bytes.
+    pub max_bytes: u32,
+}
+
+/// One stored message, as `READ` and the `MSG` push carry it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StoredMessage {
+    /// `QueuedMessage.index`.
+    pub index: u64,
+    /// `QueuedMessage.received_at_ms`.
+    pub received_at_ms: u64,
+    /// `QueuedMessage.payload`.
+    pub payload: Payload,
+}
+
+/// A page of `READ` results.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadPage {
+    /// The messages, in ascending index order.
+    pub messages: Vec<StoredMessage>,
+    /// `ReadResponse.has_more`.
+    pub has_more: bool,
+    /// `SubscribeResponse.next_index` / `AckResponse.next_index`, so a caller
+    /// that just read does not need a second round trip to learn it.
+    pub next_index: u64,
+    /// Unacknowledged indices — the `pending` §6.2 discloses to the **reader
+    /// only**. No equivalent is ever disclosed to a writer.
+    pub pending: u64,
+}
+
+/// What `DELETE_QUEUE` removed (§6.2, §7.6).
+///
+/// Returned so the caller can subtract from whatever it is watching for §13.1
+/// layer 4 without re-querying. It is **not** sent to anyone: `DELETE_QUEUE`'s
+/// response is empty, and the sender "learns nothing except that its next
+/// `APPEND` fails with `ERR_UNAVAILABLE`".
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Deleted {
+    /// Messages destroyed, acknowledged or not.
+    pub messages_deleted: u64,
+    /// Payload bytes freed.
+    pub bytes_freed: u64,
+}
+
+/// Why a queue or a message went away on its own (§7.7).
+///
+/// Both surface to a subscribed reader as `QUEUE_EVENT` (§6.4) and both are
+/// silent to a writer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExpiryReason {
+    /// `QUEUE_EVENT` reason `2`: the queue itself is gone, nothing having
+    /// touched it for `idle_ttl_seconds`. §7.7 states the cost plainly — a user
+    /// offline longer than the idle TTL loses their queues and the pair must
+    /// re-establish.
+    IdleTtl,
+    /// `QUEUE_EVENT` reason `3`: the queue survives; messages older than
+    /// `message_ttl_seconds` were dropped. §13.2's one permitted deletion that
+    /// is not a refusal.
+    MessageTtl,
+}
+
+impl ExpiryReason {
+    /// The `uint8` a `QUEUE_EVENT` push carries (§6.4).
+    #[must_use]
+    pub const fn queue_event_reason(self) -> u8 {
+        match self {
+            Self::IdleTtl => 2,
+            Self::MessageTtl => 3,
+        }
+    }
+}
+
+/// One queue affected by a sweep.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct QueueExpiry {
+    /// The reader's address, which is who a `QUEUE_EVENT` is pushed to.
+    pub recv_addr: QueueAddress,
+    /// Which timer fired.
+    pub reason: ExpiryReason,
+    /// Messages removed from this queue.
+    pub messages_expired: u64,
+    /// Payload bytes freed from this queue.
+    pub bytes_freed: u64,
+}
+
+/// What one sweep did.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ExpiryReport {
+    /// One entry per affected queue, so the caller can push `QUEUE_EVENT` to
+    /// whichever of them has a live subscription.
+    pub expired: Vec<QueueExpiry>,
+    /// Queues removed outright by the idle timer.
+    pub queues_expired: u64,
+    /// Messages removed by either timer.
+    pub messages_expired: u64,
+    /// Payload bytes freed by either timer.
+    pub bytes_freed: u64,
+}
+
+impl ExpiryReport {
+    /// Whether the sweep changed anything.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.expired.is_empty()
+    }
+}
+
+/// What the store is currently holding — §13.1 layer 4's input.
+///
+/// Layer 4 refuses `CREATE_QUEUE` first, then `APPEND`, then new connections,
+/// and never refuses `READ`, `ACK` or `DELETE_QUEUE`, "because they are the
+/// operations that make the relay smaller and refusing them under load is a
+/// deadlock". Deciding that needs a measurement, and this is it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StoreStats {
+    /// Standard queues.
+    pub queues: u64,
+    /// Contact queues (§12.2), counted separately because their caps and their
+    /// abuse profile are separate (§12.3).
+    pub contact_queues: u64,
+    /// Messages held across every queue.
+    pub messages: u64,
+    /// Payload bytes held across every queue. ADR 0005's economics are stated
+    /// in this number: ~4 MB per 1,000 DAU, because there is no archive.
+    pub payload_bytes: u64,
+    /// Bytes the storage engine has actually allocated, which is the number an
+    /// operator's high-water mark is really about — page overhead, free pages
+    /// and the write-ahead log are all real disk.
+    pub storage_bytes: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deadlines_saturate_instead_of_wrapping() {
+        assert_eq!(idle_deadline(1_000, 1), 2_000);
+        assert_eq!(idle_deadline(u64::MAX, 1), u64::MAX);
+        assert_eq!(message_deadline(0, u32::MAX), 4_294_967_295_000);
+    }
+
+    #[test]
+    fn queue_event_reasons_are_section_6_4s() {
+        assert_eq!(ExpiryReason::IdleTtl.queue_event_reason(), 2);
+        assert_eq!(ExpiryReason::MessageTtl.queue_event_reason(), 3);
+    }
+}

--- a/rs/crates/f2z-relay-store/src/sqlite.rs
+++ b/rs/crates/f2z-relay-store/src/sqlite.rs
@@ -1,0 +1,1209 @@
+//! The durable store: SQLite, WAL, `synchronous = FULL`, `secure_delete = ON`.
+//!
+//! # Why these three settings and not others
+//!
+//! **`synchronous = FULL`** is not tuning. Under delete-on-ack the relay's copy
+//! is the only copy in the system for the whole window between `accepted` and
+//! `ACK` ([`ARCHITECTURE.md` §6.4][s64]), so an `APPEND` answered before the
+//! bytes reached stable storage is a promise of custody the relay cannot keep.
+//! `NORMAL` in WAL mode fsyncs only at checkpoints and is exactly the mode in
+//! which a recently-accepted message evaporates on power loss.
+//!
+//! **WAL** is what makes `FULL` affordable: one sequential fsync of the log per
+//! commit rather than a database-file sync, and readers that do not block the
+//! writer. `READ`, `ACK` and `DELETE_QUEUE` are the operations §13.1 says must
+//! never be refused under load, and a journalling mode where a reader blocks
+//! the writer is a journalling mode where a flood of appends starves the
+//! operations that make the relay smaller.
+//!
+//! **`secure_delete = ON`** makes a freed page zero-filled rather than merely
+//! unreferenced. That is the difference between "the ciphertext is deleted" and
+//! "the ciphertext is unlinked but recoverable by anyone who images the disk",
+//! and the second one would make [`THREAT-MODEL.md` §4.5][s45]'s "server-side
+//! deletion is auditable" claim vacuous.
+//!
+//! All three are **verified after being set**, not assumed. A pragma that
+//! silently did not take is the failure mode that produces a relay believing it
+//! is durable while it is not, and it is one query to rule out.
+//!
+//! # What `secure_delete` does not cover, stated
+//!
+//! In WAL mode the pre-deletion image of a page can still exist **in the
+//! write-ahead log** until a checkpoint retires it. `secure_delete` zeroes the
+//! page in the database file; it does not go back and scrub log frames written
+//! before the delete. So an operator whose threat model includes disk imaging
+//! must checkpoint, and [`SqliteStore::checkpoint`] is that operation. It is
+//! exposed rather than run on every commit because a truncating checkpoint is
+//! an fsync of the whole database and doing it per-ACK would give back
+//! everything WAL was chosen for.
+//!
+//! # Schema
+//!
+//! Two tables, both `WITHOUT ROWID`, and the shape is chosen by the access
+//! pattern rather than by habit:
+//!
+//! ```sql
+//! CREATE TABLE message (
+//!     recv_addr BLOB, idx INTEGER, ..., payload BLOB,
+//!     PRIMARY KEY (recv_addr, idx)
+//! ) WITHOUT ROWID;
+//! ```
+//!
+//! `WITHOUT ROWID` stores the row *in* the index, keyed by `(recv_addr, idx)`.
+//! One queue's messages are therefore physically contiguous and in index order,
+//! which makes `READ` a range scan from the acked watermark and makes `ACK` —
+//! cumulative, so always a prefix — a range delete over one contiguous run.
+//! With an ordinary rowid table both would be an index probe per row into a
+//! heap ordered by insertion across every queue on the relay.
+//!
+//! [s64]: https://github.com/free2z/zuu/blob/main/docs/e2ee/ARCHITECTURE.md#64-delete-on-ack-and-lost-acknowledgements
+//! [s45]: https://github.com/free2z/zuu/blob/main/docs/e2ee/THREAT-MODEL.md#45-server-side-deletion-is-auditable-not-verifiable
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, PoisonError};
+
+use f2z_codec::types::{Payload, PublicKey, QueueAddress};
+use f2z_relay_proto::queue::{AckOutcome, AppendQuota, QueueKind, QueueState};
+use rusqlite::{Connection, OptionalExtension, Transaction};
+
+use crate::durability::{Committed, Durability};
+use crate::error::{Result, StoreError};
+use crate::record::{
+    Append, Appended, Deleted, ExpiryReason, ExpiryReport, QueueExpiry, QueueRecord, QueueSpec,
+    ReadPage, ReadWindow, SendAuth, StoreStats, StoredMessage, idle_deadline, message_deadline,
+};
+use crate::store::RelayStore;
+
+/// The schema version stamped into `PRAGMA user_version`.
+const SCHEMA_VERSION: i32 = 1;
+
+const SCHEMA: &str = "\
+CREATE TABLE IF NOT EXISTS queue (
+    recv_addr            BLOB    NOT NULL PRIMARY KEY,
+    send_addr            BLOB    NOT NULL UNIQUE,
+    kind                 INTEGER NOT NULL,
+    recv_key             BLOB    NOT NULL,
+    send_key             BLOB,
+    next_index           INTEGER NOT NULL,
+    acked_through        INTEGER,
+    message_ttl_seconds  INTEGER NOT NULL,
+    idle_ttl_seconds     INTEGER NOT NULL,
+    max_messages         INTEGER NOT NULL,
+    max_bytes            INTEGER NOT NULL,
+    stored_messages      INTEGER NOT NULL,
+    stored_bytes         INTEGER NOT NULL,
+    created_at_ms        INTEGER NOT NULL,
+    last_activity_ms     INTEGER NOT NULL,
+    idle_expires_at_ms   INTEGER NOT NULL
+) WITHOUT ROWID;
+
+CREATE INDEX IF NOT EXISTS queue_idle_expiry ON queue (idle_expires_at_ms);
+
+CREATE TABLE IF NOT EXISTS message (
+    recv_addr       BLOB    NOT NULL,
+    idx             INTEGER NOT NULL,
+    received_at_ms  INTEGER NOT NULL,
+    expires_at_ms   INTEGER NOT NULL,
+    payload         BLOB    NOT NULL,
+    PRIMARY KEY (recv_addr, idx)
+) WITHOUT ROWID;
+
+CREATE INDEX IF NOT EXISTS message_expiry ON message (expires_at_ms);
+";
+
+/// Every column of `queue`, in the order [`record_from_row`] reads them.
+const QUEUE_COLUMNS: &str = "recv_addr, send_addr, kind, recv_key, send_key, next_index, \
+     acked_through, message_ttl_seconds, idle_ttl_seconds, max_messages, max_bytes, \
+     stored_messages, stored_bytes, created_at_ms, last_activity_ms";
+
+/// A relay's durable queue storage.
+///
+/// `Send + Sync`: the connection is behind a mutex, which is also what
+/// serializes the write transactions that group commit depends on. SQLite would
+/// serialize writers anyway — this way the queue for the write lock is in Rust,
+/// where the batching driver can see it.
+#[derive(Debug)]
+pub struct SqliteStore {
+    connection: Mutex<Connection>,
+    /// §7.7 idle-timer activity that has not been written yet. See
+    /// [`RelayStore::touch`] for why this is deliberately not durable.
+    activity: Mutex<HashMap<QueueAddress, u64>>,
+    /// Durable commits performed. See [`SqliteStore::commits`].
+    commits: AtomicU64,
+}
+
+impl SqliteStore {
+    /// Open or create a store at `path`.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Backend`] if the file cannot be opened, if any of the
+    /// three pragmas did not take, or if the schema cannot be created.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let connection = Connection::open(path)?;
+        Self::prepare(connection, Journalling::WriteAheadLog)
+    }
+
+    /// Open a store that lives only in this process's memory.
+    ///
+    /// **Still SQLite, still the same SQL, and still not durable.** This is for
+    /// exercising the SQL itself; [`MemoryStore`] is the store that reports
+    /// `durability_mode = memory` honestly. Kept because a bug in a `WITHOUT
+    /// ROWID` range delete is a bug in the SQL, and finding it should not need
+    /// a temporary directory.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Backend`] as for [`SqliteStore::open`].
+    ///
+    /// [`MemoryStore`]: crate::MemoryStore
+    pub fn open_in_memory() -> Result<Self> {
+        let connection = Connection::open_in_memory()?;
+        Self::prepare(connection, Journalling::None)
+    }
+
+    fn prepare(connection: Connection, journalling: Journalling) -> Result<Self> {
+        // Ordering matters. `auto_vacuum` is only settable before the first
+        // table exists, and `journal_mode` must be WAL before anything is
+        // written so that the first transaction is already journalled the way
+        // every later one will be.
+        connection.execute_batch(
+            "PRAGMA auto_vacuum = INCREMENTAL;
+             PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = FULL;
+             PRAGMA secure_delete = ON;
+             PRAGMA foreign_keys = ON;
+             PRAGMA trusted_schema = OFF;
+             PRAGMA busy_timeout = 5000;",
+        )?;
+
+        // Verified, not assumed: a pragma that silently did not take is how a
+        // relay comes to believe it is durable while it is not.
+        if matches!(journalling, Journalling::WriteAheadLog) {
+            expect_pragma(&connection, "journal_mode", "wal")?;
+        }
+        expect_pragma(&connection, "synchronous", "2")?;
+        expect_pragma(&connection, "secure_delete", "1")?;
+
+        connection.execute_batch(SCHEMA)?;
+        let version: i32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        if version == 0 {
+            connection.execute_batch(&format!("PRAGMA user_version = {SCHEMA_VERSION}"))?;
+        } else if version != SCHEMA_VERSION {
+            return Err(StoreError::Corrupt(
+                "database was written by a different schema version of f2z-relay-store",
+            ));
+        }
+
+        Ok(Self {
+            connection: Mutex::new(connection),
+            activity: Mutex::new(HashMap::new()),
+            commits: AtomicU64::new(0),
+        })
+    }
+
+    /// Retire the write-ahead log and return free pages to the filesystem.
+    ///
+    /// The operation `secure_delete` alone does not perform — see the module
+    /// note. An operator whose threat model includes disk imaging should run
+    /// this on a timer; every relay should run it occasionally so that a queue
+    /// that was drained and deleted actually gives its disk back, which is
+    /// ADR 0005's `$5/month VPS` arithmetic.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Backend`] on storage failure.
+    pub fn checkpoint(&self) -> Result<()> {
+        let connection = self.lock_connection();
+        connection.execute_batch(
+            "PRAGMA wal_checkpoint(TRUNCATE);
+             PRAGMA incremental_vacuum;",
+        )?;
+        Ok(())
+    }
+
+    /// Durable commits performed since this store was opened.
+    ///
+    /// At `synchronous = FULL` a commit is an fsync, and the disk's fsync rate
+    /// — on the order of 50-200 a second on the cheap VPS ADR 0005's economics
+    /// assume — is the relay's hard write ceiling. This counter is therefore
+    /// the number an operator should graph, and it is what makes group commit
+    /// *checkable* rather than asserted: a batch of a hundred appends must move
+    /// it by one, not by a hundred.
+    #[must_use]
+    pub fn commits(&self) -> u64 {
+        self.commits.load(Ordering::Relaxed)
+    }
+
+    /// Commit, and count it.
+    ///
+    /// Every commit in this file goes through here, so the counter cannot drift
+    /// from reality by someone adding a `tx.commit()` next to it.
+    fn commit(&self, tx: Transaction<'_>) -> Result<()> {
+        tx.commit()?;
+        self.commits.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// A poisoned mutex is not a reason to stop serving.
+    ///
+    /// The lock guards a SQLite connection whose consistency is SQLite's job:
+    /// a panic while it was held aborted whatever transaction was open, and the
+    /// next `BEGIN` starts from committed state. Refusing every subsequent
+    /// request would convert one fault into a permanent outage of `READ` and
+    /// `ACK`, which are the two operations §13.1 says must never be refused.
+    fn lock_connection(&self) -> std::sync::MutexGuard<'_, Connection> {
+        self.connection
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn lock_activity(&self) -> std::sync::MutexGuard<'_, HashMap<QueueAddress, u64>> {
+        self.activity.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Buffer an idle-timer touch. Never durable on its own.
+    fn record_activity(&self, recv_addr: &QueueAddress, now_ms: u64) {
+        let mut activity = self.lock_activity();
+        let slot = activity.entry(*recv_addr).or_insert(now_ms);
+        if *slot < now_ms {
+            *slot = now_ms;
+        }
+    }
+
+    /// Fold buffered touches into the transaction that is about to commit.
+    ///
+    /// Drained before the sweep in [`RelayStore::expire`], which is what bounds
+    /// the exposure described on [`RelayStore::touch`] to the sweep period.
+    fn flush_activity(&self, tx: &Transaction<'_>) -> Result<()> {
+        let pending: Vec<(QueueAddress, u64)> = {
+            let mut activity = self.lock_activity();
+            activity.drain().collect()
+        };
+        if pending.is_empty() {
+            return Ok(());
+        }
+        let mut statement = tx.prepare_cached(
+            "UPDATE queue SET last_activity_ms = ?2, idle_expires_at_ms = ?3 \
+             WHERE recv_addr = ?1 AND last_activity_ms < ?2",
+        )?;
+        for (recv_addr, at_ms) in pending {
+            let ttl: Option<u32> = tx
+                .query_row(
+                    "SELECT idle_ttl_seconds FROM queue WHERE recv_addr = ?1",
+                    [recv_addr.as_ref()],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            // The queue may have been deleted or expired since the touch. §7.6
+            // forbids a tombstone, so there is nothing to update and nothing to
+            // report.
+            let Some(ttl) = ttl else { continue };
+            statement.execute(rusqlite::params![
+                recv_addr.as_ref(),
+                to_i64(at_ms)?,
+                to_i64(idle_deadline(at_ms, ttl))?,
+            ])?;
+        }
+        Ok(())
+    }
+}
+
+/// Whether this connection has a file to journal to.
+///
+/// A `:memory:` database cannot be WAL — there is no file for a write-ahead log
+/// — and SQLite silently reports `memory` instead of failing. Asking for the
+/// WAL verification only where WAL is possible is what keeps the check strict
+/// where it matters instead of being loosened to accommodate the one case where
+/// it cannot hold.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Journalling {
+    /// A file-backed store. `journal_mode = wal` is required.
+    WriteAheadLog,
+    /// A `:memory:` store, which is not durable and does not claim to be.
+    None,
+}
+
+/// Read a pragma back and insist it says what it was set to.
+fn expect_pragma(connection: &Connection, name: &str, expected: &str) -> Result<()> {
+    let actual: String = connection.query_row(&format!("PRAGMA {name}"), [], |row| {
+        row.get::<_, rusqlite::types::Value>(0)
+            .map(|value| match value {
+                rusqlite::types::Value::Text(text) => text,
+                rusqlite::types::Value::Integer(number) => number.to_string(),
+                other => format!("{other:?}"),
+            })
+    })?;
+    if actual.eq_ignore_ascii_case(expected) {
+        Ok(())
+    } else {
+        Err(StoreError::Corrupt(match name {
+            "journal_mode" => "PRAGMA journal_mode did not take: this store is not WAL-journalled",
+            "synchronous" => {
+                "PRAGMA synchronous did not take: an accepted APPEND would not be durable"
+            }
+            _ => "PRAGMA secure_delete did not take: deleted ciphertext would remain on disk",
+        }))
+    }
+}
+
+fn to_i64(value: u64) -> Result<i64> {
+    i64::try_from(value).map_err(|_| StoreError::ValueOutOfRange)
+}
+
+fn from_i64(value: i64) -> Result<u64> {
+    u64::try_from(value).map_err(|_| StoreError::Corrupt("a stored counter is negative"))
+}
+
+fn address(bytes: &[u8]) -> Result<QueueAddress> {
+    QueueAddress::from_slice(bytes)
+        .map_err(|_| StoreError::Corrupt("a stored address is not 32 bytes"))
+}
+
+fn public_key(bytes: &[u8]) -> Result<PublicKey> {
+    PublicKey::from_slice(bytes).map_err(|_| StoreError::Corrupt("a stored key is not 32 bytes"))
+}
+
+const fn kind_tag(kind: QueueKind) -> i64 {
+    match kind {
+        QueueKind::Standard => 0,
+        QueueKind::Contact => 1,
+    }
+}
+
+fn kind_from_tag(tag: i64) -> Result<QueueKind> {
+    match tag {
+        0 => Ok(QueueKind::Standard),
+        1 => Ok(QueueKind::Contact),
+        _ => Err(StoreError::Corrupt("a stored queue kind is unknown")),
+    }
+}
+
+fn record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Result<QueueRecord>> {
+    let recv_addr: Vec<u8> = row.get(0)?;
+    let send_addr: Vec<u8> = row.get(1)?;
+    let kind: i64 = row.get(2)?;
+    let recv_key: Vec<u8> = row.get(3)?;
+    let send_key: Option<Vec<u8>> = row.get(4)?;
+    let next_index: i64 = row.get(5)?;
+    let acked_through: Option<i64> = row.get(6)?;
+    let message_ttl_seconds: u32 = row.get(7)?;
+    let idle_ttl_seconds: u32 = row.get(8)?;
+    let max_messages: i64 = row.get(9)?;
+    let max_bytes: i64 = row.get(10)?;
+    let stored_messages: i64 = row.get(11)?;
+    let stored_bytes: i64 = row.get(12)?;
+    let created_at_ms: i64 = row.get(13)?;
+    let last_activity_ms: i64 = row.get(14)?;
+
+    Ok(build_record(RawQueue {
+        recv_addr,
+        send_addr,
+        kind,
+        recv_key,
+        send_key,
+        next_index,
+        acked_through,
+        message_ttl_seconds,
+        idle_ttl_seconds,
+        max_messages,
+        max_bytes,
+        stored_messages,
+        stored_bytes,
+        created_at_ms,
+        last_activity_ms,
+    }))
+}
+
+struct RawQueue {
+    recv_addr: Vec<u8>,
+    send_addr: Vec<u8>,
+    kind: i64,
+    recv_key: Vec<u8>,
+    send_key: Option<Vec<u8>>,
+    next_index: i64,
+    acked_through: Option<i64>,
+    message_ttl_seconds: u32,
+    idle_ttl_seconds: u32,
+    max_messages: i64,
+    max_bytes: i64,
+    stored_messages: i64,
+    stored_bytes: i64,
+    created_at_ms: i64,
+    last_activity_ms: i64,
+}
+
+fn build_record(raw: RawQueue) -> Result<QueueRecord> {
+    let kind = kind_from_tag(raw.kind)?;
+    let send_key = match raw.send_key {
+        Some(bytes) => Some(public_key(&bytes)?),
+        None => None,
+    };
+    // The acknowledgement arithmetic is `f2z-relay-proto`'s, restored rather
+    // than reimplemented: §8.2's anti-pre-ack rule written twice is §8.2's rule
+    // written once and violated once.
+    let state = QueueState::restore(
+        kind,
+        public_key(&raw.recv_key)?,
+        send_key,
+        from_i64(raw.next_index)?,
+        raw.acked_through.map(from_i64).transpose()?,
+    )?;
+    Ok(QueueRecord {
+        recv_addr: address(&raw.recv_addr)?,
+        send_addr: address(&raw.send_addr)?,
+        state,
+        message_ttl_seconds: raw.message_ttl_seconds,
+        idle_ttl_seconds: raw.idle_ttl_seconds,
+        quota: AppendQuota {
+            max_messages: from_i64(raw.max_messages)?,
+            max_bytes: from_i64(raw.max_bytes)?,
+        },
+        stored_messages: from_i64(raw.stored_messages)?,
+        stored_bytes: from_i64(raw.stored_bytes)?,
+        created_at_ms: from_i64(raw.created_at_ms)?,
+        last_activity_ms: from_i64(raw.last_activity_ms)?,
+    })
+}
+
+fn load_by_recv(connection: &Connection, recv_addr: &QueueAddress) -> Result<Option<QueueRecord>> {
+    let found = connection
+        .query_row(
+            &format!("SELECT {QUEUE_COLUMNS} FROM queue WHERE recv_addr = ?1"),
+            [recv_addr.as_ref()],
+            record_from_row,
+        )
+        .optional()?;
+    found.transpose()
+}
+
+fn load_by_send(connection: &Connection, send_addr: &QueueAddress) -> Result<Option<QueueRecord>> {
+    let found = connection
+        .query_row(
+            &format!("SELECT {QUEUE_COLUMNS} FROM queue WHERE send_addr = ?1"),
+            [send_addr.as_ref()],
+            record_from_row,
+        )
+        .optional()?;
+    found.transpose()
+}
+
+/// §6.3 / §12.2: which writers a queue accepts.
+pub(crate) fn authorize_send(record: &QueueRecord, auth: &SendAuth) -> Result<()> {
+    match (record.kind(), auth) {
+        (QueueKind::Standard, SendAuth::Signed(signer)) => record
+            .state
+            .authorize_send(signer)
+            .map_err(StoreError::from),
+        // §12.2 point 2: a contact queue "accepts unsigned appends from anyone
+        // who presents a valid proof-of-work stamp", which the caller has
+        // already verified. There is no key to check because there is
+        // deliberately no key at all.
+        (QueueKind::Contact, SendAuth::ContactStamp) => Ok(()),
+        // A signed APPEND to a published contact address, or an unsigned
+        // CONTACT_APPEND to an ordinary send address. Both refuse as
+        // ERR_UNAVAILABLE, because a writer must not learn which kind of queue
+        // an address is.
+        (QueueKind::Standard, SendAuth::ContactStamp)
+        | (QueueKind::Contact, SendAuth::Signed(_)) => Err(StoreError::unavailable()),
+    }
+}
+
+/// Sum and count the messages a range delete is about to remove.
+fn range_totals(
+    connection: &Connection,
+    recv_addr: &QueueAddress,
+    through: Option<i64>,
+) -> Result<(u64, u64)> {
+    let (count, bytes): (i64, i64) = match through {
+        Some(through) => connection.query_row(
+            "SELECT COUNT(*), COALESCE(SUM(LENGTH(payload)), 0) FROM message \
+             WHERE recv_addr = ?1 AND idx <= ?2",
+            rusqlite::params![recv_addr.as_ref(), through],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?,
+        None => connection.query_row(
+            "SELECT COUNT(*), COALESCE(SUM(LENGTH(payload)), 0) FROM message \
+             WHERE recv_addr = ?1",
+            [recv_addr.as_ref()],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?,
+    };
+    Ok((from_i64(count)?, from_i64(bytes)?))
+}
+
+impl RelayStore for SqliteStore {
+    fn durability(&self) -> Durability {
+        Durability::FsyncPerAppend
+    }
+
+    fn create_queue(&self, spec: &QueueSpec) -> Result<Committed<QueueRecord>> {
+        if spec.recv_addr == spec.send_addr {
+            return Err(StoreError::AddressCollision);
+        }
+        let mut connection = self.lock_connection();
+        let tx = connection.transaction()?;
+        self.flush_activity(&tx)?;
+
+        // Both addresses are drawn from one 32-byte space, and a lookup by
+        // either must be unambiguous, so a new address colliding with an
+        // existing address of *either* kind is a collision. §7.1's answer is to
+        // draw again.
+        let taken: i64 = tx.query_row(
+            "SELECT COUNT(*) FROM queue WHERE recv_addr IN (?1, ?2) OR send_addr IN (?1, ?2)",
+            rusqlite::params![spec.recv_addr.as_ref(), spec.send_addr.as_ref()],
+            |row| row.get(0),
+        )?;
+        if taken != 0 {
+            return Err(StoreError::AddressCollision);
+        }
+
+        let idle_expires = idle_deadline(spec.created_at_ms, spec.idle_ttl_seconds);
+        tx.execute(
+            "INSERT INTO queue (recv_addr, send_addr, kind, recv_key, send_key, next_index, \
+             acked_through, message_ttl_seconds, idle_ttl_seconds, max_messages, max_bytes, \
+             stored_messages, stored_bytes, created_at_ms, last_activity_ms, idle_expires_at_ms) \
+             VALUES (?1, ?2, ?3, ?4, NULL, 0, NULL, ?5, ?6, ?7, ?8, 0, 0, ?9, ?9, ?10)",
+            rusqlite::params![
+                spec.recv_addr.as_ref(),
+                spec.send_addr.as_ref(),
+                kind_tag(spec.kind),
+                spec.recv_key.as_ref(),
+                spec.message_ttl_seconds,
+                spec.idle_ttl_seconds,
+                to_i64(spec.quota.max_messages)?,
+                to_i64(spec.quota.max_bytes)?,
+                to_i64(spec.created_at_ms)?,
+                to_i64(idle_expires)?,
+            ],
+        )?;
+        self.commit(tx)?;
+
+        Ok(Committed::seal(
+            self.durability(),
+            QueueRecord {
+                recv_addr: spec.recv_addr,
+                send_addr: spec.send_addr,
+                state: QueueState::create(spec.kind, spec.recv_key),
+                message_ttl_seconds: spec.message_ttl_seconds,
+                idle_ttl_seconds: spec.idle_ttl_seconds,
+                quota: spec.quota,
+                stored_messages: 0,
+                stored_bytes: 0,
+                created_at_ms: spec.created_at_ms,
+                last_activity_ms: spec.created_at_ms,
+            },
+        ))
+    }
+
+    fn bind_send(
+        &self,
+        send_addr: &QueueAddress,
+        signer: &PublicKey,
+        now_ms: u64,
+    ) -> Result<Committed<()>> {
+        let mut connection = self.lock_connection();
+        let tx = connection.transaction()?;
+        self.flush_activity(&tx)?;
+
+        let Some(mut record) = load_by_send(&tx, send_addr)? else {
+            return Err(StoreError::unavailable());
+        };
+        // The bound key *is* the signer: §5.1 step 5 cannot apply when no key is
+        // registered yet, and `f2z-relay-proto` closes that by requiring the
+        // two to be equal. This call is where bind-once and the contact-queue
+        // refusal both live.
+        record.state.bind_send(signer)?;
+
+        tx.execute(
+            "UPDATE queue SET send_key = ?2, last_activity_ms = MAX(last_activity_ms, ?3), \
+             idle_expires_at_ms = MAX(idle_expires_at_ms, ?4) WHERE recv_addr = ?1",
+            rusqlite::params![
+                record.recv_addr.as_ref(),
+                signer.as_ref(),
+                to_i64(now_ms)?,
+                to_i64(idle_deadline(now_ms, record.idle_ttl_seconds))?,
+            ],
+        )?;
+        self.commit(tx)?;
+        Ok(Committed::seal(self.durability(), ()))
+    }
+
+    fn queue_by_recv(&self, recv_addr: &QueueAddress, signer: &PublicKey) -> Result<QueueRecord> {
+        let connection = self.lock_connection();
+        let record = load_by_recv(&connection, recv_addr)?.ok_or_else(StoreError::no_access)?;
+        record.state.authorize_recv(signer)?;
+        Ok(record)
+    }
+
+    fn queue_by_send(&self, send_addr: &QueueAddress, auth: &SendAuth) -> Result<QueueRecord> {
+        let connection = self.lock_connection();
+        let record = load_by_send(&connection, send_addr)?.ok_or_else(StoreError::unavailable)?;
+        authorize_send(&record, auth)?;
+        Ok(record)
+    }
+
+    fn append_batch(&self, appends: &[Append<'_>]) -> Result<Committed<Vec<Result<Appended>>>> {
+        let mut connection = self.lock_connection();
+        let tx = connection.transaction()?;
+        self.flush_activity(&tx)?;
+
+        let mut results: Vec<Result<Appended>> = Vec::with_capacity(appends.len());
+        for append in appends {
+            match append_one(&tx, append) {
+                Ok(appended) => results.push(Ok(appended)),
+                // A protocol refusal happens strictly before this append writes
+                // anything, so the transaction is still clean and the rest of
+                // the batch is unaffected: one writer hitting its cap must not
+                // undo an unrelated queue's durable write.
+                Err(error @ StoreError::Protocol(_)) => results.push(Err(error)),
+                // Anything else means the transaction itself is suspect.
+                // Returning here drops it, which rolls the whole batch back.
+                Err(other) => return Err(other),
+            }
+        }
+
+        #[cfg(feature = "crash-injection")]
+        crate::crash::fire(crate::crash::CrashPoint::BeforeAppendCommit);
+        self.commit(tx)?;
+        #[cfg(feature = "crash-injection")]
+        crate::crash::fire(crate::crash::CrashPoint::AfterAppendCommit);
+
+        Ok(Committed::seal(self.durability(), results))
+    }
+
+    fn read(
+        &self,
+        recv_addr: &QueueAddress,
+        signer: &PublicKey,
+        window: ReadWindow,
+        now_ms: u64,
+    ) -> Result<ReadPage> {
+        let page = {
+            let connection = self.lock_connection();
+            let record = load_by_recv(&connection, recv_addr)?.ok_or_else(StoreError::no_access)?;
+            record.state.authorize_recv(signer)?;
+            read_page(&connection, &record, window, now_ms)?
+        };
+        self.record_activity(recv_addr, now_ms);
+        Ok(page)
+    }
+
+    fn ack(
+        &self,
+        recv_addr: &QueueAddress,
+        signer: &PublicKey,
+        up_to_index: u64,
+        now_ms: u64,
+    ) -> Result<Committed<AckOutcome>> {
+        let mut connection = self.lock_connection();
+        let tx = connection.transaction()?;
+        self.flush_activity(&tx)?;
+
+        let mut record = load_by_recv(&tx, recv_addr)?.ok_or_else(StoreError::no_access)?;
+        record.state.authorize_recv(signer)?;
+        // §8.2 first: a pre-ack must not move the watermark, and must not
+        // delete anything on its way to failing.
+        let outcome = record.state.ack(up_to_index)?;
+
+        let through = to_i64(up_to_index)?;
+        let (removed, bytes_freed) = if outcome.acknowledged == 0 {
+            (0, 0)
+        } else {
+            let totals = range_totals(&tx, recv_addr, Some(through))?;
+            // The prefix delete §8.1's cumulative rule makes possible: one
+            // contiguous run at the front of this queue's `WITHOUT ROWID`
+            // storage.
+            tx.execute(
+                "DELETE FROM message WHERE recv_addr = ?1 AND idx <= ?2",
+                rusqlite::params![recv_addr.as_ref(), through],
+            )?;
+            totals
+        };
+
+        // The watermark advance and the delete are one statement apart inside
+        // one transaction. That is the invariant: no crash can leave a message
+        // stored at or below the persisted watermark.
+        tx.execute(
+            "UPDATE queue SET acked_through = ?2, stored_messages = ?3, stored_bytes = ?4, \
+             last_activity_ms = MAX(last_activity_ms, ?5), \
+             idle_expires_at_ms = MAX(idle_expires_at_ms, ?6) WHERE recv_addr = ?1",
+            rusqlite::params![
+                recv_addr.as_ref(),
+                record.state.acked_through().map(to_i64).transpose()?,
+                to_i64(record.stored_messages.saturating_sub(removed))?,
+                to_i64(record.stored_bytes.saturating_sub(bytes_freed))?,
+                to_i64(now_ms)?,
+                to_i64(idle_deadline(now_ms, record.idle_ttl_seconds))?,
+            ],
+        )?;
+
+        #[cfg(feature = "crash-injection")]
+        crate::crash::fire(crate::crash::CrashPoint::BeforeAckCommit);
+        self.commit(tx)?;
+        #[cfg(feature = "crash-injection")]
+        crate::crash::fire(crate::crash::CrashPoint::AfterAckCommit);
+
+        Ok(Committed::seal(self.durability(), outcome))
+    }
+
+    fn delete_queue(
+        &self,
+        recv_addr: &QueueAddress,
+        signer: &PublicKey,
+    ) -> Result<Committed<Deleted>> {
+        let mut connection = self.lock_connection();
+        let tx = connection.transaction()?;
+        self.flush_activity(&tx)?;
+
+        let record = load_by_recv(&tx, recv_addr)?.ok_or_else(StoreError::no_access)?;
+        record.state.authorize_recv(signer)?;
+
+        let (messages_deleted, bytes_freed) = range_totals(&tx, recv_addr, None)?;
+        tx.execute(
+            "DELETE FROM message WHERE recv_addr = ?1",
+            [recv_addr.as_ref()],
+        )?;
+        // §7.6: no tombstone. Afterwards both addresses answer exactly as an
+        // address that never existed does.
+        tx.execute(
+            "DELETE FROM queue WHERE recv_addr = ?1",
+            [recv_addr.as_ref()],
+        )?;
+        self.commit(tx)?;
+
+        Ok(Committed::seal(
+            self.durability(),
+            Deleted {
+                messages_deleted,
+                bytes_freed,
+            },
+        ))
+    }
+
+    fn touch(&self, recv_addr: &QueueAddress, signer: &PublicKey, now_ms: u64) -> Result<()> {
+        {
+            let connection = self.lock_connection();
+            let record = load_by_recv(&connection, recv_addr)?.ok_or_else(StoreError::no_access)?;
+            record.state.authorize_recv(signer)?;
+        }
+        self.record_activity(recv_addr, now_ms);
+        Ok(())
+    }
+
+    fn expire(&self, now_ms: u64) -> Result<Committed<ExpiryReport>> {
+        let mut connection = self.lock_connection();
+        let tx = connection.transaction()?;
+        // Before the sweep, so a touch that has not been written down yet still
+        // saves its queue. This is what bounds `touch`'s best-effort window to
+        // the sweep period.
+        self.flush_activity(&tx)?;
+
+        let mut report = ExpiryReport::default();
+        let now = to_i64(now_ms)?;
+
+        // Idle first: an idle-expired queue takes its messages with it, so
+        // sweeping it now keeps them out of the message-TTL accounting below.
+        let idle: Vec<QueueAddress> = {
+            let mut statement =
+                tx.prepare_cached("SELECT recv_addr FROM queue WHERE idle_expires_at_ms <= ?1")?;
+            let rows = statement.query_map([now], |row| row.get::<_, Vec<u8>>(0))?;
+            let mut found = Vec::new();
+            for row in rows {
+                found.push(address(&row?)?);
+            }
+            found
+        };
+        for recv_addr in idle {
+            let (messages_expired, bytes_freed) = range_totals(&tx, &recv_addr, None)?;
+            tx.execute(
+                "DELETE FROM message WHERE recv_addr = ?1",
+                [recv_addr.as_ref()],
+            )?;
+            tx.execute(
+                "DELETE FROM queue WHERE recv_addr = ?1",
+                [recv_addr.as_ref()],
+            )?;
+            report.queues_expired = report.queues_expired.saturating_add(1);
+            report.messages_expired = report.messages_expired.saturating_add(messages_expired);
+            report.bytes_freed = report.bytes_freed.saturating_add(bytes_freed);
+            report.expired.push(QueueExpiry {
+                recv_addr,
+                reason: ExpiryReason::IdleTtl,
+                messages_expired,
+                bytes_freed,
+            });
+        }
+
+        // Then the per-message TTL over what is left. It removes ciphertext
+        // **without moving the watermark**: an expired message was never
+        // acknowledged, and advancing the watermark would acknowledge it on the
+        // reader's behalf.
+        let stale: Vec<(QueueAddress, u64, u64)> = {
+            let mut statement = tx.prepare_cached(
+                "SELECT recv_addr, COUNT(*), COALESCE(SUM(LENGTH(payload)), 0) FROM message \
+                 WHERE expires_at_ms <= ?1 GROUP BY recv_addr",
+            )?;
+            let rows = statement.query_map([now], |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            })?;
+            let mut found = Vec::new();
+            for row in rows {
+                let (raw, count, bytes) = row?;
+                found.push((address(&raw)?, from_i64(count)?, from_i64(bytes)?));
+            }
+            found
+        };
+        if !stale.is_empty() {
+            tx.execute("DELETE FROM message WHERE expires_at_ms <= ?1", [now])?;
+        }
+        for (recv_addr, messages_expired, bytes_freed) in stale {
+            tx.execute(
+                "UPDATE queue SET stored_messages = MAX(0, stored_messages - ?2), \
+                 stored_bytes = MAX(0, stored_bytes - ?3) WHERE recv_addr = ?1",
+                rusqlite::params![
+                    recv_addr.as_ref(),
+                    to_i64(messages_expired)?,
+                    to_i64(bytes_freed)?,
+                ],
+            )?;
+            report.messages_expired = report.messages_expired.saturating_add(messages_expired);
+            report.bytes_freed = report.bytes_freed.saturating_add(bytes_freed);
+            report.expired.push(QueueExpiry {
+                recv_addr,
+                reason: ExpiryReason::MessageTtl,
+                messages_expired,
+                bytes_freed,
+            });
+        }
+
+        self.commit(tx)?;
+        Ok(Committed::seal(self.durability(), report))
+    }
+
+    fn stats(&self) -> Result<StoreStats> {
+        let connection = self.lock_connection();
+        let mut stats = StoreStats::default();
+        {
+            let mut statement = connection.prepare_cached(
+                "SELECT kind, COUNT(*), COALESCE(SUM(stored_messages), 0), \
+                 COALESCE(SUM(stored_bytes), 0) FROM queue GROUP BY kind",
+            )?;
+            let rows = statement.query_map([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                ))
+            })?;
+            for row in rows {
+                let (tag, count, messages, bytes) = row?;
+                match kind_from_tag(tag)? {
+                    QueueKind::Standard => stats.queues = from_i64(count)?,
+                    QueueKind::Contact => stats.contact_queues = from_i64(count)?,
+                }
+                stats.messages = stats.messages.saturating_add(from_i64(messages)?);
+                stats.payload_bytes = stats.payload_bytes.saturating_add(from_i64(bytes)?);
+            }
+        }
+        let page_count: i64 = connection.query_row("PRAGMA page_count", [], |row| row.get(0))?;
+        let page_size: i64 = connection.query_row("PRAGMA page_size", [], |row| row.get(0))?;
+        stats.storage_bytes = from_i64(page_count)?.saturating_mul(from_i64(page_size)?);
+        Ok(stats)
+    }
+}
+
+/// One append inside an open transaction.
+///
+/// Every refusal is decided **before** the first write, which is what lets
+/// [`RelayStore::append_batch`] keep the rest of a batch when one item is
+/// refused.
+fn append_one(tx: &Transaction<'_>, append: &Append<'_>) -> Result<Appended> {
+    let Some(mut record) = load_by_send(tx, &append.send_addr)? else {
+        return Err(StoreError::unavailable());
+    };
+    authorize_send(&record, &append.auth)?;
+
+    let payload_bytes =
+        u64::try_from(append.payload.len()).map_err(|_| StoreError::unavailable())?;
+    // §13.1 layer 2, and §13.2's other half: a full queue refuses. It never
+    // evicts an unacknowledged message to make room.
+    record
+        .quota
+        .admit(record.stored_messages, record.stored_bytes, payload_bytes)?;
+
+    let index = record.state.append()?;
+    // SQLite's INTEGER is signed, so this store's index space ends at
+    // `i64::MAX` rather than `u64::MAX`. Refusing as a send-side refusal keeps
+    // §6.3's collapse intact; the bound is unreachable by any relay that will
+    // ever exist.
+    let stored_index = to_i64(index).map_err(|_| StoreError::unavailable())?;
+    // The counter's *next* value has to fit too, and it has to be checked here
+    // — before the insert — so that running off the domain is a clean refusal
+    // rather than a half-written batch.
+    let stored_next = to_i64(record.state.next_index()).map_err(|_| StoreError::unavailable())?;
+    let expires_at = message_deadline(append.received_at_ms, record.message_ttl_seconds);
+
+    tx.prepare_cached(
+        "INSERT INTO message (recv_addr, idx, received_at_ms, expires_at_ms, payload) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+    )?
+    .execute(rusqlite::params![
+        record.recv_addr.as_ref(),
+        stored_index,
+        to_i64(append.received_at_ms)?,
+        to_i64(expires_at)?,
+        append.payload.as_slice(),
+    ])?;
+
+    tx.prepare_cached(
+        "UPDATE queue SET next_index = ?2, stored_messages = stored_messages + 1, \
+         stored_bytes = stored_bytes + ?3, last_activity_ms = MAX(last_activity_ms, ?4), \
+         idle_expires_at_ms = MAX(idle_expires_at_ms, ?5) WHERE recv_addr = ?1",
+    )?
+    .execute(rusqlite::params![
+        record.recv_addr.as_ref(),
+        stored_next,
+        to_i64(payload_bytes)?,
+        to_i64(append.received_at_ms)?,
+        to_i64(idle_deadline(
+            append.received_at_ms,
+            record.idle_ttl_seconds
+        ))?,
+    ])?;
+
+    Ok(Appended {
+        recv_addr: record.recv_addr,
+        index,
+        received_at_ms: append.received_at_ms,
+    })
+}
+
+fn read_page(
+    connection: &Connection,
+    record: &QueueRecord,
+    window: ReadWindow,
+    now_ms: u64,
+) -> Result<ReadPage> {
+    // §6.2: below the watermark returns from the watermark, and never errors,
+    // so a client recovering from a crash can ask for everything it might have
+    // missed without knowing what it already acknowledged.
+    let floor = to_i64(record.state.read_from(window.from_index))?;
+    // One more row than asked for, so `has_more` is observed rather than
+    // guessed.
+    let limit = i64::from(window.max_messages).saturating_add(1);
+
+    let mut statement = connection.prepare_cached(
+        "SELECT idx, received_at_ms, payload FROM message \
+         WHERE recv_addr = ?1 AND idx >= ?2 AND expires_at_ms > ?3 ORDER BY idx LIMIT ?4",
+    )?;
+    let rows = statement.query_map(
+        rusqlite::params![record.recv_addr.as_ref(), floor, to_i64(now_ms)?, limit],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, Vec<u8>>(2)?,
+            ))
+        },
+    )?;
+
+    let mut messages = Vec::new();
+    let mut fetched = 0usize;
+    let mut bytes = 0u64;
+    for row in rows {
+        let (index, received_at_ms, payload) = row?;
+        fetched = fetched.saturating_add(1);
+        if messages.len() >= usize::from(window.max_messages) {
+            break;
+        }
+        let size = u64::try_from(payload.len()).unwrap_or(u64::MAX);
+        let next = bytes.saturating_add(size);
+        // Always yield at least one message when one exists. A `max_bytes`
+        // below the smallest padding bucket would otherwise return an empty
+        // page with `has_more = 1` forever, and a reader that cannot make
+        // progress cannot acknowledge, which under delete-on-ack is a queue
+        // that fills and then refuses its sender.
+        if next > u64::from(window.max_bytes) && !messages.is_empty() {
+            break;
+        }
+        bytes = next;
+        messages.push(StoredMessage {
+            index: from_i64(index)?,
+            received_at_ms: from_i64(received_at_ms)?,
+            payload: Payload::new(payload).map_err(|_| {
+                StoreError::Corrupt("a stored payload is longer than the wire format allows")
+            })?,
+        });
+    }
+
+    Ok(ReadPage {
+        has_more: fetched > messages.len(),
+        messages,
+        next_index: record.state.next_index(),
+        pending: record.state.pending(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_relay_proto::queue::AppendQuota;
+
+    fn store() -> SqliteStore {
+        SqliteStore::open_in_memory().unwrap()
+    }
+
+    /// The three settings this store's durability claim rests on are read back
+    /// out of the engine, not out of the source. A pragma that silently did not
+    /// take is how a relay comes to publish `fsync-per-append` while running
+    /// something weaker, and the failure is invisible until the power goes out.
+    #[test]
+    fn the_durability_pragmas_are_what_they_claim() {
+        let store = store();
+        let connection = store.lock_connection();
+        // `open_in_memory` cannot be WAL — a memory database has no file to
+        // journal to — which is exactly why it is not the durable store. The
+        // other two hold everywhere.
+        expect_pragma(&connection, "synchronous", "2").unwrap();
+        expect_pragma(&connection, "secure_delete", "1").unwrap();
+        assert!(
+            expect_pragma(&connection, "synchronous", "1").is_err(),
+            "the check must be able to fail, or it is checking nothing"
+        );
+    }
+
+    #[test]
+    fn a_file_backed_store_is_wal_journalled() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = SqliteStore::open(directory.path().join("relay.sqlite3")).unwrap();
+        let connection = store.lock_connection();
+        expect_pragma(&connection, "journal_mode", "wal").unwrap();
+        expect_pragma(&connection, "synchronous", "2").unwrap();
+        expect_pragma(&connection, "secure_delete", "1").unwrap();
+    }
+
+    /// Group commit, made observable.
+    ///
+    /// One batch of a hundred appends is **one** fsync; a hundred separate
+    /// appends are a hundred. On a disk that manages 100 fsyncs a second that
+    /// is the difference between a relay that sustains its offered load and one
+    /// that sustains one append per second per writer.
+    #[test]
+    fn a_batch_of_a_hundred_appends_costs_one_commit() {
+        let store = store();
+        let recv = QueueAddress::new([1u8; 32]);
+        let send = QueueAddress::new([2u8; 32]);
+        let recv_key = PublicKey::new([3u8; 32]);
+        let send_key = PublicKey::new([4u8; 32]);
+        let _ = store
+            .create_queue(&QueueSpec {
+                kind: QueueKind::Standard,
+                recv_addr: recv,
+                send_addr: send,
+                recv_key,
+                message_ttl_seconds: 86_400,
+                idle_ttl_seconds: 86_400,
+                quota: AppendQuota {
+                    max_messages: 1_000,
+                    max_bytes: 1 << 24,
+                },
+                created_at_ms: 1_000,
+            })
+            .unwrap();
+        let _ = store.bind_send(&send, &send_key, 1_000).unwrap();
+
+        let payload = Payload::new(vec![0u8; 64]).unwrap();
+        let batch: Vec<Append<'_>> = (0..100)
+            .map(|_| Append {
+                send_addr: send,
+                auth: SendAuth::Signed(send_key),
+                payload: &payload,
+                received_at_ms: 2_000,
+            })
+            .collect();
+
+        let before = store.commits();
+        let results = store.append_batch(&batch).unwrap().into_inner();
+        assert_eq!(results.len(), 100);
+        assert!(results.iter().all(Result::is_ok));
+        assert_eq!(
+            store.commits() - before,
+            1,
+            "a batch is one transaction, and therefore one fsync"
+        );
+
+        let before = store.commits();
+        for _ in 0..10 {
+            let _ = store
+                .append(&Append {
+                    send_addr: send,
+                    auth: SendAuth::Signed(send_key),
+                    payload: &payload,
+                    received_at_ms: 3_000,
+                })
+                .unwrap();
+        }
+        assert_eq!(
+            store.commits() - before,
+            10,
+            "and the batch of one is still one transaction each"
+        );
+    }
+
+    /// A batch that fails at the transaction level writes nothing at all — the
+    /// half-applied batch is the shape that would let one queue's append land
+    /// while its own counter did not.
+    #[test]
+    fn an_index_beyond_the_signed_domain_refuses_as_a_send_side_refusal() {
+        // §6.3's collapse has to survive this store's own limits: SQLite's
+        // INTEGER is signed, so the index space ends at i64::MAX, and running
+        // off it must look to a sender exactly like a full queue.
+        let store = store();
+        let recv = QueueAddress::new([1u8; 32]);
+        let send = QueueAddress::new([2u8; 32]);
+        let key = PublicKey::new([3u8; 32]);
+        let _ = store
+            .create_queue(&QueueSpec {
+                kind: QueueKind::Standard,
+                recv_addr: recv,
+                send_addr: send,
+                recv_key: key,
+                message_ttl_seconds: 86_400,
+                idle_ttl_seconds: 86_400,
+                quota: AppendQuota {
+                    max_messages: 4,
+                    max_bytes: 1 << 20,
+                },
+                created_at_ms: 1_000,
+            })
+            .unwrap();
+        let _ = store.bind_send(&send, &key, 1_000).unwrap();
+        {
+            let connection = store.lock_connection();
+            connection
+                .execute(
+                    "UPDATE queue SET next_index = ?2 WHERE recv_addr = ?1",
+                    rusqlite::params![recv.as_ref(), i64::MAX],
+                )
+                .unwrap();
+        }
+        let payload = Payload::new(vec![0u8; 8]).unwrap();
+        let error = store
+            .append(&Append {
+                send_addr: send,
+                auth: SendAuth::Signed(key),
+                payload: &payload,
+                received_at_ms: 2_000,
+            })
+            .expect_err("the index space is exhausted");
+        assert_eq!(error.error_code(), f2z_codec::ErrorCode::Unavailable);
+    }
+}

--- a/rs/crates/f2z-relay-store/src/store.rs
+++ b/rs/crates/f2z-relay-store/src/store.rs
@@ -1,0 +1,270 @@
+//! The storage boundary.
+//!
+//! # What the boundary is for
+//!
+//! Every method below takes addresses, keys, byte strings and integers. None
+//! takes a frame, a command code, a request id or a signature. That is the
+//! whole design: a storage backend that cannot see a frame cannot decide to
+//! answer one, cannot grow a fast path that skips a check, and cannot become a
+//! second, divergent implementation of `WIRE.md` living underneath the first.
+//!
+//! The rules that *are* here are the ones that must be applied inside the same
+//! transaction as the write they guard, because applying them outside it is a
+//! race:
+//!
+//! - **Authorization** (§5.1 step 5, §6.2, §6.3). The caller verifies the
+//!   signature; the store compares the recovered signer against the key
+//!   registered for the address, atomically with the mutation. Checking it a
+//!   statement earlier would let a `DELETE_QUEUE` land in between.
+//! - **Quota admission** (§13.1 layer 2). "Is there room" and "take the room"
+//!   are one decision or they are neither.
+//! - **Index allocation and the acknowledgement watermark** (§8). Two
+//!   concurrent appends must not be handed the same index, and a range delete
+//!   must not run against a watermark that has since moved.
+//!
+//! # Group commit is a requirement, not an optimization
+//!
+//! [`SqliteStore`] runs `synchronous = FULL`, so a transaction costs an fsync,
+//! and a commodity VPS's disk does on the order of 50-200 of those a second.
+//! One transaction per append therefore caps the relay at roughly one append
+//! per fsync — a ceiling low enough that the design does not work.
+//!
+//! [`RelayStore::append_batch`] is the answer, and it is the *primitive* rather
+//! than a convenience wrapper: N appends collected over a small window commit
+//! together, cost one fsync between them, and every one of them is durable
+//! before any result is returned. The window itself — how long to wait, how
+//! many to gather — is a scheduling decision that belongs to the server crate
+//! with its runtime and its clock. What belongs here is the shape that makes
+//! the decision available, and [`RelayStore::append`] is the batch of one.
+//!
+//! Batching does not weaken durability, and the distinction matters because
+//! §11.1 publishes it: deferring the fsync past the response is `batched`;
+//! amortizing one fsync across many responses that all wait for it is still
+//! `fsync-per-append`.
+//!
+//! [`SqliteStore`]: crate::SqliteStore
+
+use f2z_codec::types::{PublicKey, QueueAddress};
+use f2z_relay_proto::queue::AckOutcome;
+
+use crate::durability::{Committed, Durability};
+use crate::error::Result;
+use crate::record::{
+    Append, Appended, Deleted, ExpiryReport, QueueRecord, QueueSpec, ReadPage, ReadWindow,
+    SendAuth, StoreStats,
+};
+
+/// Queue storage for a relay.
+///
+/// See the module documentation for what this boundary refuses to carry and
+/// why. Implementations live in this crate only: every mutating method returns
+/// a [`Committed`], whose constructor is crate-private, so durability is
+/// something the code that performed the fsync hands out rather than something
+/// a backend asserts about itself.
+pub trait RelayStore {
+    /// What this store's [`Committed`] means — `WIRE.md` §11.1's
+    /// `durability_mode`. A relay MUST publish this value.
+    fn durability(&self) -> Durability;
+
+    /// Create a queue at caller-chosen addresses (§7.1, §12.2).
+    ///
+    /// # Errors
+    ///
+    /// - [`StoreError::AddressCollision`] if either address is in use. §7.1's
+    ///   answer is to draw again from the relay's CSPRNG.
+    /// - [`StoreError::Backend`] on storage failure.
+    ///
+    /// [`StoreError::AddressCollision`]: crate::StoreError::AddressCollision
+    /// [`StoreError::Backend`]: crate::StoreError::Backend
+    fn create_queue(&self, spec: &QueueSpec) -> Result<Committed<QueueRecord>>;
+
+    /// Bind the send side, once and forever (§7.3).
+    ///
+    /// **`signer` is the key that gets bound, and there is only one argument
+    /// because there is only one key.** §5.1 step 5 — "the signer must be the
+    /// key registered for the address" — is inapplicable to `BIND_SEND`, since
+    /// no key is registered yet; `f2z-relay-proto` resolves that by requiring
+    /// `signer_key == send_key`, without which §7.4's bind-once theft
+    /// protection costs an attacker nothing (anyone could bind anyone's key).
+    /// Taking the two as separate parameters here would make it possible to
+    /// pass them differently.
+    ///
+    /// # Errors
+    ///
+    /// - `ERR_UNAVAILABLE` if there is no such send address. §6.3: absent and
+    ///   present-but-refused must not be distinguishable to a writer.
+    /// - `ERR_NOT_PERMITTED` on a contact address (§12.2), "always, for
+    ///   everyone" — and deliberately *not* collapsed into `ERR_UNAVAILABLE`,
+    ///   because a contact address is **published** in a directory entry and
+    ///   therefore leaks no queue state that its finder did not already have.
+    /// - `ERR_ALREADY_BOUND` if the send side is bound, with any key including
+    ///   the same key. §7.4: to a client that just received a fresh advert this
+    ///   is a loud, non-dismissible failure, not a retry.
+    fn bind_send(
+        &self,
+        send_addr: &QueueAddress,
+        signer: &PublicKey,
+        now_ms: u64,
+    ) -> Result<Committed<()>>;
+
+    /// Look a queue up by its receive address and authorize the signer.
+    ///
+    /// # Errors
+    ///
+    /// `ERR_NO_ACCESS`, whether the address does not exist or exists and this
+    /// signer does not authorize it. §10's existence-oracle rule: one code, so
+    /// that sweeping the address space learns nothing.
+    fn queue_by_recv(&self, recv_addr: &QueueAddress, signer: &PublicKey) -> Result<QueueRecord>;
+
+    /// Look a queue up by its send address and authorize the writer.
+    ///
+    /// # Errors
+    ///
+    /// `ERR_UNAVAILABLE`, whether the address does not exist, is a contact
+    /// address presented with a signature, is an ordinary address presented
+    /// without one, or is bound to a different key (§6.3).
+    fn queue_by_send(&self, send_addr: &QueueAddress, auth: &SendAuth) -> Result<QueueRecord>;
+
+    /// Append a batch in one transaction, at the cost of one fsync (§6.3, §12.2).
+    ///
+    /// The outer result fails only if the *transaction* could not run. A
+    /// per-append refusal — unknown address, wrong key, quota exhausted — is an
+    /// `Err` in the returned vector at that append's position, and does not
+    /// stop the others: one writer hitting its cap must not undo an unrelated
+    /// queue's durable write. The vector is the same length as `appends` and in
+    /// the same order.
+    ///
+    /// §13.2 is the rule this method must never break: **under no circumstance
+    /// does a relay delete an unacknowledged message to make room.** A full
+    /// queue refuses; it does not evict.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Backend`] if the transaction failed. Nothing in the batch
+    /// was written in that case.
+    ///
+    /// [`StoreError::Backend`]: crate::StoreError::Backend
+    fn append_batch(&self, appends: &[Append<'_>]) -> Result<Committed<Vec<Result<Appended>>>>;
+
+    /// Append one message — the batch of one.
+    ///
+    /// # Errors
+    ///
+    /// Whatever [`RelayStore::append_batch`] would have put at position zero,
+    /// or its transaction-level failure.
+    fn append(&self, append: &Append<'_>) -> Result<Committed<Appended>> {
+        let committed = self.append_batch(core::slice::from_ref(append))?;
+        let durability = committed.durability();
+        let mut results = committed.into_inner();
+        let first = results.pop().unwrap_or_else(|| {
+            Err(crate::StoreError::Corrupt(
+                "append_batch returned no result for a batch of one",
+            ))
+        });
+        Ok(Committed::seal(durability, first?))
+    }
+
+    /// Read a window of messages. Never mutates a message (§6.2).
+    ///
+    /// Returns no [`Committed`], because nothing durable happened: `READ` is
+    /// the operation delete-on-ack is careful *not* to couple to deletion.
+    /// It does record activity against §7.7's idle timer, which is best-effort
+    /// by design — see [`RelayStore::touch`].
+    ///
+    /// # Errors
+    ///
+    /// `ERR_NO_ACCESS` if the address does not exist or this signer does not
+    /// authorize it.
+    fn read(
+        &self,
+        recv_addr: &QueueAddress,
+        signer: &PublicKey,
+        window: ReadWindow,
+        now_ms: u64,
+    ) -> Result<ReadPage>;
+
+    /// Acknowledge cumulatively, and delete what that authorizes (§8).
+    ///
+    /// The watermark advance and the range delete are one transaction. That is
+    /// the crash-safety invariant this crate is tested against: after any
+    /// crash, there is no index at or below the persisted watermark whose
+    /// message is still stored, and no message above it that has been removed.
+    ///
+    /// # Errors
+    ///
+    /// - `ERR_NO_ACCESS` if the address does not exist or this signer does not
+    ///   authorize it.
+    /// - `ERR_ACK_TOO_HIGH` if `up_to_index` is above the highest index ever
+    ///   appended (§8.2). The watermark does not move. Without this a reader
+    ///   could pre-ack and black-hole its own queue while senders kept seeing
+    ///   successful, empty `APPEND` responses.
+    fn ack(
+        &self,
+        recv_addr: &QueueAddress,
+        signer: &PublicKey,
+        up_to_index: u64,
+        now_ms: u64,
+    ) -> Result<Committed<AckOutcome>>;
+
+    /// Delete the queue, both addresses and every message it holds,
+    /// acknowledged or not (§6.2, §7.6). Irreversible, and no tombstone.
+    ///
+    /// # Errors
+    ///
+    /// `ERR_NO_ACCESS` if the address does not exist or this signer does not
+    /// authorize it — which is also what both addresses answer afterwards,
+    /// forever.
+    fn delete_queue(
+        &self,
+        recv_addr: &QueueAddress,
+        signer: &PublicKey,
+    ) -> Result<Committed<Deleted>>;
+
+    /// Record activity against §7.7's idle timer without writing durably.
+    ///
+    /// §7.7 resets the idle TTL on `APPEND`, `READ`, `ACK` **and `SUBSCRIBE`*,
+    /// and `SUBSCRIBE` is otherwise a pure connection-scoped registration. This
+    /// is the method for it.
+    ///
+    /// **Best-effort on purpose.** The idle TTL defaults to 90 days; fsyncing
+    /// every `SUBSCRIBE` and every `READ` to move a 90-day deadline would spend
+    /// the relay's entire fsync budget on a timer whose resolution is months.
+    /// A crash can therefore lose activity recorded since the last durable
+    /// write, which ages a queue's idle deadline by at most that interval — and
+    /// [`RelayStore::expire`] flushes pending activity before it sweeps, so the
+    /// exposure is bounded by the sweep period rather than by uptime.
+    ///
+    /// # Errors
+    ///
+    /// `ERR_NO_ACCESS` if the address does not exist or this signer does not
+    /// authorize it.
+    fn touch(&self, recv_addr: &QueueAddress, signer: &PublicKey, now_ms: u64) -> Result<()>;
+
+    /// Run both of §7.7's timers.
+    ///
+    /// Idle-expired queues go first and go entirely; then messages past their
+    /// per-message TTL are dropped from whatever remains. Message expiry does
+    /// **not** move the acknowledgement watermark: an expired message was never
+    /// acknowledged, and moving the watermark would acknowledge it on the
+    /// reader's behalf.
+    ///
+    /// The report names every affected queue so the caller can push
+    /// `QUEUE_EVENT` (§6.4) to whichever of them a reader is subscribed to.
+    /// Expiry is silent to a writer.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Backend`] on storage failure.
+    ///
+    /// [`StoreError::Backend`]: crate::StoreError::Backend
+    fn expire(&self, now_ms: u64) -> Result<Committed<ExpiryReport>>;
+
+    /// What the store is holding — §13.1 layer 4's input.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Backend`] on storage failure.
+    ///
+    /// [`StoreError::Backend`]: crate::StoreError::Backend
+    fn stats(&self) -> Result<StoreStats>;
+}

--- a/rs/crates/f2z-relay-store/tests/crash_safety.rs
+++ b/rs/crates/f2z-relay-store/tests/crash_safety.rs
@@ -1,0 +1,336 @@
+//! Kill a real process mid-commit, reopen the file, and check what survived.
+//!
+//! # Why this test is shaped the way it is
+//!
+//! Under delete-on-ack the relay's copy of a message is, for a window, the only
+//! copy in the system ([`ARCHITECTURE.md` §6.4][s64]). Two invariants therefore
+//! have to hold across an unplanned stop, and neither is observable from inside
+//! a healthy process:
+//!
+//! - **Nothing accepted-but-lost.** Every append whose [`Committed`] receipt the
+//!   caller actually received — the only appends for which a relay is permitted
+//!   to have answered `accepted` — is still there afterwards.
+//! - **Nothing acked-but-undeleted.** No message at or below the persisted
+//!   acknowledgement watermark is still stored. The watermark advance and the
+//!   range delete are one transaction, so a crash cannot land between them.
+//!
+//! **A caught panic does not test this.** An in-process `catch_unwind` leaves
+//! the SQLite connection alive, runs `Drop` on the open transaction — rolling
+//! back the very write whose fate is the question — and flushes on the way out.
+//! It exercises the error path, not the durability one. So each case below runs
+//! in a **child process** that calls `abort()` at a chosen instant inside the
+//! library, and the parent asserts on the file the child left behind, from a
+//! fresh connection, after the child is confirmed dead.
+//!
+//! The parent also asserts *how* the child died: killed by a signal, not exited.
+//! A child that returned an exit code did not crash, it finished, and a test
+//! that accepted that would pass even if the injection point had been deleted.
+//!
+//! Run with `cargo test -p f2z-relay-store --features crash-injection`.
+//!
+//! [s64]: https://github.com/free2z/zuu/blob/main/docs/e2ee/ARCHITECTURE.md#64-delete-on-ack-and-lost-acknowledgements
+//! [`Committed`]: f2z_relay_store::Committed
+
+// Only compiled when the injection point exists. Without the feature there is
+// nothing to fire and the file is empty on purpose: a silently-passing crash
+// test is worse than no crash test.
+#![cfg(feature = "crash-injection")]
+// Test code, run on the host by a person reading the failure. The workspace
+// denies these because a panic in the relay's request path is a remote denial
+// of service; neither hazard exists in a test harness.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use f2z_codec::types::{Payload, PublicKey, QueueAddress};
+use f2z_relay_proto::queue::{AppendQuota, QueueKind};
+use f2z_relay_store::crash::{CRASH_POINT_ENV, arm_from_env};
+use f2z_relay_store::{
+    Append, QueueSpec, ReadWindow, RelayStore, SendAuth, SqliteStore, StoreError,
+};
+
+const RECV_ADDR: QueueAddress = QueueAddress::new([0x11; 32]);
+const SEND_ADDR: QueueAddress = QueueAddress::new([0x22; 32]);
+const RECV_KEY: PublicKey = PublicKey::new([0x33; 32]);
+const SEND_KEY: PublicKey = PublicKey::new([0x44; 32]);
+
+/// Which side of the crash the child is meant to be on. Set by the parent, read
+/// by the child worker below.
+const SCENARIO_ENV: &str = "F2Z_RELAY_STORE_CRASH_SCENARIO";
+const DB_ENV: &str = "F2Z_RELAY_STORE_CRASH_DB";
+
+fn payload(byte: u8, len: usize) -> Payload {
+    Payload::new(vec![byte; len]).unwrap()
+}
+
+fn open(path: &Path) -> SqliteStore {
+    SqliteStore::open(path).unwrap()
+}
+
+fn seed(store: &SqliteStore) {
+    let _ = store
+        .create_queue(&QueueSpec {
+            kind: QueueKind::Standard,
+            recv_addr: RECV_ADDR,
+            send_addr: SEND_ADDR,
+            recv_key: RECV_KEY,
+            message_ttl_seconds: 604_800,
+            idle_ttl_seconds: 7_776_000,
+            quota: AppendQuota {
+                max_messages: 1_000,
+                max_bytes: 1 << 20,
+            },
+            created_at_ms: 1_000,
+        })
+        .unwrap();
+    let _ = store.bind_send(&SEND_ADDR, &SEND_KEY, 1_000).unwrap();
+}
+
+fn append_one(store: &SqliteStore, byte: u8, at_ms: u64) -> u64 {
+    let body = payload(byte, 1024);
+    store
+        .append(&Append {
+            send_addr: SEND_ADDR,
+            auth: SendAuth::Signed(SEND_KEY),
+            payload: &body,
+            received_at_ms: at_ms,
+        })
+        .unwrap()
+        .into_inner()
+        .index
+}
+
+/// Everything currently stored, read straight back out.
+fn stored(store: &SqliteStore) -> Vec<(u64, u8)> {
+    let page = store
+        .read(
+            &RECV_ADDR,
+            &RECV_KEY,
+            ReadWindow {
+                from_index: 0,
+                max_messages: u16::MAX,
+                max_bytes: u32::MAX,
+            },
+            10_000,
+        )
+        .unwrap();
+    page.messages
+        .into_iter()
+        .map(|message| (message.index, message.payload.as_slice()[0]))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// The child.
+//
+// `#[ignore]` so an ordinary `cargo test` never runs it; the parent invokes it
+// explicitly with `--ignored --exact`. This is how an integration test gets a
+// child process at all — the harness owns `main`, so the entry point has to be
+// a test the parent can name.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "spawned by the parent cases below; not a test on its own"]
+fn crash_child_worker() {
+    let Ok(scenario) = std::env::var(SCENARIO_ENV) else {
+        // Someone ran the whole ignored set by hand. Do nothing rather than
+        // abort an unsuspecting test run.
+        return;
+    };
+    let path = PathBuf::from(std::env::var(DB_ENV).expect("the parent sets the database path"));
+
+    match scenario.as_str() {
+        // Two appends whose receipts the caller received — the relay would have
+        // answered `accepted` for both — and then a third that dies mid-commit.
+        "append" => {
+            let store = open(&path);
+            seed(&store);
+            append_one(&store, 0xa1, 2_000);
+            append_one(&store, 0xa2, 3_000);
+            // Armed here rather than at open, so the two appends above complete
+            // and hand back their receipts — those are the ones a relay would
+            // have answered `accepted` for — and only the third dies.
+            arm_from_env();
+            let body = payload(0xa3, 1024);
+            let _ = store.append(&Append {
+                send_addr: SEND_ADDR,
+                auth: SendAuth::Signed(SEND_KEY),
+                payload: &body,
+                received_at_ms: 4_000,
+            });
+            panic!("the store returned from an append that was supposed to abort");
+        }
+        // Three appends, then an ACK of the first two that dies mid-commit.
+        "ack" => {
+            let store = open(&path);
+            seed(&store);
+            append_one(&store, 0xa1, 2_000);
+            append_one(&store, 0xa2, 3_000);
+            append_one(&store, 0xa3, 4_000);
+            arm_from_env();
+            let _ = store.ack(&RECV_ADDR, &RECV_KEY, 1, 5_000);
+            panic!("the store returned from an ack that was supposed to abort");
+        }
+        other => panic!("unknown crash scenario {other}"),
+    }
+}
+
+/// Run the child, and insist it died the way a crash dies.
+fn crash_child(path: &Path, scenario: &str, point: &str) {
+    let exe = std::env::current_exe().expect("the test binary knows its own path");
+    let status = Command::new(exe)
+        .args(["--exact", "crash_child_worker", "--ignored", "--nocapture"])
+        .env(SCENARIO_ENV, scenario)
+        .env(DB_ENV, path)
+        .env(CRASH_POINT_ENV, point)
+        .status()
+        .expect("the child test binary starts");
+
+    assert!(
+        !status.success(),
+        "the child at {point} exited successfully; the injection point did not fire"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        assert_eq!(
+            status.signal(),
+            Some(libc_sigabrt()),
+            "the child at {point} must be killed by SIGABRT, not exit with a code — \
+             an exit code means it unwound, which is not what a crash does"
+        );
+    }
+}
+
+/// `SIGABRT`, without a libc dependency for one constant.
+#[cfg(unix)]
+const fn libc_sigabrt() -> i32 {
+    6
+}
+
+fn database(directory: &tempfile::TempDir) -> PathBuf {
+    directory.path().join("relay.sqlite3")
+}
+
+// ---------------------------------------------------------------------------
+// The cases.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_crash_after_the_append_commit_loses_nothing_that_was_accepted() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = database(&directory);
+    crash_child(&path, "append", "after-append-commit");
+
+    let store = open(&path);
+    // The third append's receipt never reached its caller, so the relay never
+    // said `accepted` for it — but the commit had already returned, so the row
+    // must be there and the queue must be consistent with it. A store that lost
+    // it would be a store whose fsync did not mean what it said.
+    assert_eq!(
+        stored(&store),
+        vec![(0, 0xa1), (1, 0xa2), (2, 0xa3)],
+        "everything committed before the abort must survive it"
+    );
+    let record = store.queue_by_recv(&RECV_ADDR, &RECV_KEY).unwrap();
+    assert_eq!(record.state.next_index(), 3);
+    assert_eq!(record.stored_messages, 3);
+    assert_eq!(record.state.acked_through(), None);
+}
+
+#[test]
+fn a_crash_before_the_append_commit_leaves_no_trace_of_it() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = database(&directory);
+    crash_child(&path, "append", "before-append-commit");
+
+    let store = open(&path);
+    assert_eq!(
+        stored(&store),
+        vec![(0, 0xa1), (1, 0xa2)],
+        "an uncommitted append must leave no row"
+    );
+    let record = store.queue_by_recv(&RECV_ADDR, &RECV_KEY).unwrap();
+    assert_eq!(
+        record.state.next_index(),
+        2,
+        "an uncommitted append must not have consumed an index either — a torn \
+         state where the counter moved but the row did not would silently \
+         create a permanent gap in the reader's index space"
+    );
+    assert_eq!(record.stored_messages, 2);
+}
+
+#[test]
+fn a_crash_after_the_ack_commit_leaves_nothing_acked_but_undeleted() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = database(&directory);
+    crash_child(&path, "ack", "after-ack-commit");
+
+    let store = open(&path);
+    let record = store.queue_by_recv(&RECV_ADDR, &RECV_KEY).unwrap();
+    assert_eq!(record.state.acked_through(), Some(1));
+    assert_eq!(
+        stored(&store),
+        vec![(2, 0xa3)],
+        "every index at or below the persisted watermark must be gone"
+    );
+    assert_eq!(record.stored_messages, 1);
+    assert_eq!(record.stored_bytes, 1024);
+}
+
+#[test]
+fn a_crash_before_the_ack_commit_deletes_nothing() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = database(&directory);
+    crash_child(&path, "ack", "before-ack-commit");
+
+    let store = open(&path);
+    let record = store.queue_by_recv(&RECV_ADDR, &RECV_KEY).unwrap();
+    assert_eq!(
+        record.state.acked_through(),
+        None,
+        "an uncommitted ack must not have moved the watermark"
+    );
+    assert_eq!(
+        stored(&store),
+        vec![(0, 0xa1), (1, 0xa2), (2, 0xa3)],
+        "an uncommitted ack must not have deleted anything; §8.3 makes the \
+         client's retry safe precisely because this is true"
+    );
+    // And the retry §8.3 promises is safe actually is.
+    let outcome = store.ack(&RECV_ADDR, &RECV_KEY, 1, 6_000).unwrap();
+    assert_eq!(outcome.into_inner().acknowledged, 2);
+    assert_eq!(stored(&store), vec![(2, 0xa3)]);
+}
+
+#[test]
+fn the_reopened_store_still_refuses_a_pre_ack() {
+    // §8.2 is a property of the queue, not of the process that created it: a
+    // reader that could pre-ack after a restart could black-hole its queue just
+    // as silently as one that could pre-ack before.
+    let directory = tempfile::tempdir().unwrap();
+    let path = database(&directory);
+    crash_child(&path, "append", "after-append-commit");
+
+    let store = open(&path);
+    let error = store
+        .ack(&RECV_ADDR, &RECV_KEY, 3, 6_000)
+        .expect_err("acking beyond the highest appended index is ERR_ACK_TOO_HIGH");
+    assert_eq!(error.error_code(), f2z_codec::ErrorCode::AckTooHigh);
+    assert_eq!(stored(&store).len(), 3, "and the watermark did not move");
+
+    // Bind-once survives the restart too (§7.3).
+    let error = store
+        .bind_send(&SEND_ADDR, &SEND_KEY, 7_000)
+        .expect_err("a second BIND_SEND is ERR_ALREADY_BOUND, with any key");
+    assert_eq!(error.error_code(), f2z_codec::ErrorCode::AlreadyBound);
+    assert!(matches!(error, StoreError::Protocol(_)));
+}

--- a/rs/crates/f2z-relay-store/tests/properties.rs
+++ b/rs/crates/f2z-relay-store/tests/properties.rs
@@ -1,0 +1,649 @@
+//! The rules that lose messages when they are wrong, checked against **both**
+//! stores.
+//!
+//! Everything here runs twice: once against [`SqliteStore`], where a `NOT
+//! NULL`, a `PRIMARY KEY` or a `MAX(0, …)` might be doing the work, and once
+//! against [`MemoryStore`], where nothing enforces anything except the code
+//! that is supposed to. A rule that only holds in one of them is a rule that
+//! does not hold.
+
+// Test code, run on the host by a person reading the failure. The workspace
+// denies these because a panic in the relay's request path is a remote denial
+// of service; neither hazard exists in a test harness.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_codec::ErrorCode;
+use f2z_codec::types::{Payload, PublicKey, QueueAddress};
+use f2z_relay_proto::queue::{AppendQuota, QueueKind};
+use f2z_relay_store::{
+    Append, ExpiryReason, MemoryStore, QueueSpec, ReadWindow, RelayStore, SendAuth, SqliteStore,
+    StoreError,
+};
+use proptest::prelude::*;
+
+const RECV: QueueAddress = QueueAddress::new([0x11; 32]);
+const SEND: QueueAddress = QueueAddress::new([0x22; 32]);
+const RECV_KEY: PublicKey = PublicKey::new([0x33; 32]);
+const SEND_KEY: PublicKey = PublicKey::new([0x44; 32]);
+const OTHER_KEY: PublicKey = PublicKey::new([0x55; 32]);
+const ABSENT: QueueAddress = QueueAddress::new([0x99; 32]);
+
+fn spec(kind: QueueKind, quota: AppendQuota, message_ttl: u32, idle_ttl: u32) -> QueueSpec {
+    QueueSpec {
+        kind,
+        recv_addr: RECV,
+        send_addr: SEND,
+        recv_key: RECV_KEY,
+        message_ttl_seconds: message_ttl,
+        idle_ttl_seconds: idle_ttl,
+        quota,
+        created_at_ms: 1_000,
+    }
+}
+
+fn generous() -> AppendQuota {
+    AppendQuota {
+        max_messages: 4_096,
+        max_bytes: 1 << 24,
+    }
+}
+
+/// Run one check against both stores.
+///
+/// The `SqliteStore` half uses a real file rather than `:memory:` — the same
+/// journalling, the same pragmas, the same `WITHOUT ROWID` page layout the
+/// relay will run on.
+fn both(check: impl Fn(&dyn RelayStore, &str)) {
+    let directory = tempfile::tempdir().unwrap();
+    let sqlite = SqliteStore::open(directory.path().join("relay.sqlite3")).unwrap();
+    check(&sqlite, "SqliteStore");
+    let memory = MemoryStore::new();
+    check(&memory, "MemoryStore");
+}
+
+fn code(error: &StoreError) -> ErrorCode {
+    error.error_code()
+}
+
+fn append_at(store: &dyn RelayStore, payload: &Payload, at_ms: u64) -> Result<u64, StoreError> {
+    store
+        .append(&Append {
+            send_addr: SEND,
+            auth: SendAuth::Signed(SEND_KEY),
+            payload,
+            received_at_ms: at_ms,
+        })
+        .map(|committed| committed.into_inner().index)
+}
+
+fn read_all(store: &dyn RelayStore, now_ms: u64) -> Vec<u64> {
+    store
+        .read(
+            &RECV,
+            &RECV_KEY,
+            ReadWindow {
+                from_index: 0,
+                max_messages: u16::MAX,
+                max_bytes: u32::MAX,
+            },
+            now_ms,
+        )
+        .unwrap()
+        .messages
+        .into_iter()
+        .map(|message| message.index)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// §7.3 — bind-once.
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    /// §7.3: "There is no rebind, no unbind, and no reset by the recv key."
+    /// Whatever sequence of keys arrives, the first one wins forever — including
+    /// a second attempt with the *same* key, which §7.4 calls out explicitly
+    /// because that is what a legitimate sender's retry looks like and it must
+    /// still be the loud failure.
+    #[test]
+    fn binding_is_once_only_whatever_arrives(
+        keys in prop::collection::vec(0u8..8, 1..8),
+    ) {
+        both(|store, name| {
+            let _ = store.create_queue(&spec(QueueKind::Standard, generous(), 3_600, 86_400)).unwrap();
+            let mut bound: Option<PublicKey> = None;
+            for byte in &keys {
+                let key = PublicKey::new([*byte; 32]);
+                let outcome = store.bind_send(&SEND, &key, 2_000);
+                match bound {
+                    None => {
+                        assert!(outcome.is_ok(), "{name}: the first bind must succeed");
+                        bound = Some(key);
+                    }
+                    Some(_) => {
+                        let error = outcome.expect_err("{name}: a second bind never succeeds");
+                        assert_eq!(code(&error), ErrorCode::AlreadyBound, "{name}");
+                    }
+                }
+            }
+            let record = store.queue_by_recv(&RECV, &RECV_KEY).unwrap();
+            assert_eq!(record.state.send_key(), bound, "{name}");
+            let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// §8 — the acknowledgement arithmetic, over persisted state.
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// §8.1, §8.2, §8.3 together, because they are only safe together:
+    /// cumulative (an ack deletes every index at or below it), monotone (an ack
+    /// below the watermark is a no-op and the watermark never moves back),
+    /// idempotent (a retry after a lost response is safe), and bounded (an ack
+    /// above the highest index ever appended is an error and moves nothing).
+    #[test]
+    fn acknowledgement_is_cumulative_monotone_idempotent_and_bounded(
+        appended in 1usize..24,
+        acks in prop::collection::vec(0u64..32, 1..16),
+    ) {
+        both(|store, name| {
+            let _ = store.create_queue(&spec(QueueKind::Standard, generous(), 86_400, 86_400)).unwrap();
+            let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+            let payload = Payload::new(vec![0u8; 64]).unwrap();
+            for _ in 0..appended {
+                append_at(store, &payload, 2_000).unwrap();
+            }
+            let highest = (appended - 1) as u64;
+
+            let mut watermark: Option<u64> = None;
+            for up_to in &acks {
+                let outcome = store.ack(&RECV, &RECV_KEY, *up_to, 3_000);
+                if *up_to > highest {
+                    // §8.2: pre-acking is the failure that would let a reader
+                    // black-hole its own queue while senders kept seeing
+                    // successful, empty APPEND responses.
+                    let error = outcome.expect_err("a pre-ack must fail");
+                    assert_eq!(code(&error), ErrorCode::AckTooHigh, "{name}");
+                } else {
+                    let outcome = outcome.unwrap().into_inner();
+                    let advanced = match watermark {
+                        Some(previous) if *up_to <= previous => 0,
+                        Some(previous) => up_to - previous,
+                        None => up_to + 1,
+                    };
+                    assert_eq!(outcome.acknowledged, advanced, "{name}: ack {up_to}");
+                    if advanced > 0 {
+                        watermark = Some(*up_to);
+                    }
+                }
+
+                // The watermark never moves backwards, whatever arrived.
+                let record = store.queue_by_recv(&RECV, &RECV_KEY).unwrap();
+                assert_eq!(record.state.acked_through(), watermark, "{name}");
+
+                // Cumulative: every index at or below the watermark is gone,
+                // and every index above it is still there.
+                let first_unacked = watermark.map_or(0, |value| value + 1);
+                let expected: Vec<u64> = (first_unacked..=highest).collect();
+                assert_eq!(read_all(store, 4_000), expected, "{name}");
+            }
+            let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+        });
+    }
+}
+
+#[test]
+fn a_read_below_the_watermark_returns_from_the_watermark_and_never_errors() {
+    both(|store, name| {
+        let _ = store
+            .create_queue(&spec(QueueKind::Standard, generous(), 86_400, 86_400))
+            .unwrap();
+        let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+        let payload = Payload::new(vec![7u8; 32]).unwrap();
+        for _ in 0..4 {
+            append_at(store, &payload, 2_000).unwrap();
+        }
+        let _ = store.ack(&RECV, &RECV_KEY, 1, 3_000).unwrap();
+
+        // §6.2: "the relay MUST NOT resurrect deleted messages and MUST NOT
+        // error", so a client recovering from a crash can simply ask for
+        // everything it might have missed.
+        let page = store
+            .read(
+                &RECV,
+                &RECV_KEY,
+                ReadWindow {
+                    from_index: 0,
+                    max_messages: 16,
+                    max_bytes: u32::MAX,
+                },
+                4_000,
+            )
+            .unwrap();
+        let indices: Vec<u64> = page.messages.iter().map(|message| message.index).collect();
+        assert_eq!(indices, vec![2, 3], "{name}");
+        assert_eq!(page.next_index, 4, "{name}");
+        assert_eq!(page.pending, 2, "{name}");
+        assert!(!page.has_more, "{name}");
+        let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+    });
+}
+
+#[test]
+fn a_read_always_yields_one_message_even_under_an_impossible_byte_budget() {
+    both(|store, name| {
+        let _ = store
+            .create_queue(&spec(QueueKind::Standard, generous(), 86_400, 86_400))
+            .unwrap();
+        let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+        let payload = Payload::new(vec![7u8; 1024]).unwrap();
+        append_at(store, &payload, 2_000).unwrap();
+        append_at(store, &payload, 2_000).unwrap();
+
+        // A `max_bytes` below the smallest padding bucket would otherwise
+        // return an empty page with `has_more = 1` forever, and a reader that
+        // cannot make progress cannot acknowledge — which under delete-on-ack
+        // is a queue that fills and then refuses its sender.
+        let page = store
+            .read(
+                &RECV,
+                &RECV_KEY,
+                ReadWindow {
+                    from_index: 0,
+                    max_messages: 16,
+                    max_bytes: 1,
+                },
+                3_000,
+            )
+            .unwrap();
+        assert_eq!(page.messages.len(), 1, "{name}");
+        assert!(page.has_more, "{name}");
+        let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+    });
+}
+
+// ---------------------------------------------------------------------------
+// §13.1 layer 2 and §13.2 — quotas refuse, and never evict.
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// §13.2: "Under no circumstance does a relay delete an unacknowledged
+    /// message to free space." The property is therefore two-sided — a refusal
+    /// happens *and* nothing already stored changes — because a store that
+    /// evicted the oldest message and then accepted the new one would satisfy a
+    /// test that only checked the cap.
+    #[test]
+    fn a_full_queue_refuses_and_never_evicts(
+        max_messages in 1u64..8,
+        attempts in 1usize..16,
+    ) {
+        both(|store, name| {
+            let quota = AppendQuota { max_messages, max_bytes: 1 << 20 };
+            let _ = store.create_queue(&spec(QueueKind::Standard, quota, 86_400, 86_400)).unwrap();
+            let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+            let payload = Payload::new(vec![3u8; 128]).unwrap();
+
+            let mut accepted = 0u64;
+            for _ in 0..attempts {
+                match append_at(store, &payload, 2_000) {
+                    Ok(_) => accepted += 1,
+                    Err(error) => {
+                        // §6.3: never a distinguishable code. "Queue full" and
+                        // "no such queue" must look identical to a sender.
+                        assert_eq!(code(&error), ErrorCode::Unavailable, "{name}");
+                    }
+                }
+                assert!(accepted <= max_messages, "{name}");
+                let stored = read_all(store, 3_000);
+                assert_eq!(stored.len() as u64, accepted, "{name}: nothing was evicted");
+                // The surviving messages are the *oldest* ones, contiguously
+                // from zero: an eviction policy would show up as a moved floor.
+                assert_eq!(stored, (0..accepted).collect::<Vec<_>>(), "{name}");
+            }
+            let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+        });
+    }
+}
+
+#[test]
+fn the_byte_cap_refuses_the_append_that_would_cross_it() {
+    both(|store, name| {
+        let quota = AppendQuota {
+            max_messages: 100,
+            max_bytes: 2_048,
+        };
+        let _ = store
+            .create_queue(&spec(QueueKind::Standard, quota, 86_400, 86_400))
+            .unwrap();
+        let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+        let payload = Payload::new(vec![3u8; 1024]).unwrap();
+
+        assert!(append_at(store, &payload, 2_000).is_ok(), "{name}");
+        assert!(append_at(store, &payload, 2_000).is_ok(), "{name}");
+        let error = append_at(store, &payload, 2_000).expect_err("the third crosses 2 KiB");
+        assert_eq!(code(&error), ErrorCode::Unavailable, "{name}");
+        assert_eq!(read_all(store, 3_000).len(), 2, "{name}");
+
+        // Acking makes room, which is the only mechanism that ever does.
+        let _ = store.ack(&RECV, &RECV_KEY, 0, 3_000).unwrap();
+        assert!(append_at(store, &payload, 4_000).is_ok(), "{name}");
+        let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+    });
+}
+
+// ---------------------------------------------------------------------------
+// §7.7 — the two timers.
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// A message is readable strictly before its deadline and gone strictly
+    /// after, whether or not a sweep has run — a relay that swept lazily and
+    /// served expired ciphertext in between would be retaining past its own
+    /// published policy.
+    #[test]
+    fn a_message_expires_exactly_at_its_deadline(
+        ttl_seconds in 1u32..600,
+        offset_seconds in 0u32..1_200,
+    ) {
+        both(|store, name| {
+            let _ = store.create_queue(&spec(QueueKind::Standard, generous(), ttl_seconds, 31_536_000)).unwrap();
+            let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+            let payload = Payload::new(vec![5u8; 64]).unwrap();
+            let appended_at = 10_000u64;
+            append_at(store, &payload, appended_at).unwrap();
+
+            let deadline = appended_at + u64::from(ttl_seconds) * 1_000;
+            let now = appended_at + u64::from(offset_seconds) * 1_000;
+            let alive = now < deadline;
+
+            assert_eq!(read_all(store, now).is_empty(), !alive, "{name}: read at {now}");
+
+            let report = store.expire(now).unwrap().into_inner();
+            if alive {
+                assert!(report.is_empty(), "{name}");
+            } else {
+                assert_eq!(report.messages_expired, 1, "{name}");
+                assert_eq!(report.expired[0].reason, ExpiryReason::MessageTtl, "{name}");
+                // The queue survives, and the watermark did not move: an
+                // expired message was never acknowledged, and advancing the
+                // watermark would acknowledge it on the reader's behalf.
+                let record = store.queue_by_recv(&RECV, &RECV_KEY).unwrap();
+                assert_eq!(record.state.acked_through(), None, "{name}");
+                assert_eq!(record.state.next_index(), 1, "{name}");
+                assert_eq!(record.stored_messages, 0, "{name}");
+                assert_eq!(record.stored_bytes, 0, "{name}");
+            }
+            let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+        });
+    }
+}
+
+#[test]
+fn the_idle_timer_retires_the_queue_and_activity_resets_it() {
+    both(|store, name| {
+        // 60-second idle TTL, created at 1_000 ms.
+        let _ = store
+            .create_queue(&spec(QueueKind::Standard, generous(), 86_400, 60))
+            .unwrap();
+        let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+
+        // §7.7: the idle TTL "resets on any successful APPEND, READ, ACK,
+        // SUBSCRIBE". `touch` is SUBSCRIBE's reset.
+        store.touch(&RECV, &RECV_KEY, 50_000).unwrap();
+        let report = store.expire(60_500).unwrap().into_inner();
+        assert!(report.is_empty(), "{name}: the touch moved the deadline");
+
+        let report = store.expire(110_001).unwrap().into_inner();
+        assert_eq!(report.queues_expired, 1, "{name}");
+        assert_eq!(report.expired[0].reason, ExpiryReason::IdleTtl, "{name}");
+
+        // §7.6: no tombstone. Afterwards both addresses answer exactly as an
+        // address that never existed does.
+        let error = store.queue_by_recv(&RECV, &RECV_KEY).expect_err("gone");
+        assert_eq!(code(&error), ErrorCode::NoAccess, "{name}");
+        let error = store
+            .queue_by_send(&SEND, &SendAuth::Signed(SEND_KEY))
+            .expect_err("gone");
+        assert_eq!(code(&error), ErrorCode::Unavailable, "{name}");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// §10 / §6.3 — what a stranger can learn by asking.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_absent_address_and_a_wrong_key_are_indistinguishable() {
+    both(|store, name| {
+        let _ = store
+            .create_queue(&spec(QueueKind::Standard, generous(), 86_400, 86_400))
+            .unwrap();
+        let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+
+        // Receive side: one code for both, so sweeping the 32-byte address
+        // space learns nothing (§10's existence-oracle rule).
+        let absent = store.queue_by_recv(&ABSENT, &RECV_KEY).expect_err("absent");
+        let wrong = store
+            .queue_by_recv(&RECV, &OTHER_KEY)
+            .expect_err("wrong key");
+        assert_eq!(code(&absent), ErrorCode::NoAccess, "{name}");
+        assert_eq!(code(&wrong), ErrorCode::NoAccess, "{name}");
+
+        // Send side: everything collapses to ERR_UNAVAILABLE, so a bound sender
+        // cannot learn queue state by filling it (§6.3).
+        let payload = Payload::new(vec![1u8; 64]).unwrap();
+        for auth in [
+            SendAuth::Signed(OTHER_KEY),
+            SendAuth::ContactStamp,
+            SendAuth::Signed(SEND_KEY),
+        ] {
+            let addr = if matches!(auth, SendAuth::Signed(SEND_KEY)) {
+                ABSENT
+            } else {
+                SEND
+            };
+            let error = store
+                .append(&Append {
+                    send_addr: addr,
+                    auth,
+                    payload: &payload,
+                    received_at_ms: 2_000,
+                })
+                .expect_err("every send-side refusal is the same code");
+            assert_eq!(code(&error), ErrorCode::Unavailable, "{name}");
+        }
+        let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+    });
+}
+
+#[test]
+fn a_contact_queue_takes_unsigned_appends_and_never_binds() {
+    both(|store, name| {
+        let _ = store
+            .create_queue(&spec(QueueKind::Contact, generous(), 86_400, 86_400))
+            .unwrap();
+
+        // §12.2 point 1: BIND_SEND on a contact address returns
+        // ERR_NOT_PERMITTED "always, for everyone".
+        let error = store
+            .bind_send(&SEND, &SEND_KEY, 2_000)
+            .expect_err("a contact queue is never bindable");
+        assert_eq!(code(&error), ErrorCode::NotPermitted, "{name}");
+
+        // §12.2 point 2: it accepts unsigned appends from anyone with a stamp.
+        let payload = Payload::new(vec![9u8; 64]).unwrap();
+        let _ = store
+            .append(&Append {
+                send_addr: SEND,
+                auth: SendAuth::ContactStamp,
+                payload: &payload,
+                received_at_ms: 2_000,
+            })
+            .unwrap();
+        // And a *signed* append to a published contact address is refused the
+        // same way everything else on the send side is.
+        let error = store
+            .append(&Append {
+                send_addr: SEND,
+                auth: SendAuth::Signed(SEND_KEY),
+                payload: &payload,
+                received_at_ms: 2_000,
+            })
+            .expect_err("a signed APPEND is not a CONTACT_APPEND");
+        assert_eq!(code(&error), ErrorCode::Unavailable, "{name}");
+
+        // Its receive side is a perfectly normal queue.
+        assert_eq!(read_all(store, 3_000), vec![0], "{name}");
+        assert_eq!(store.stats().unwrap().contact_queues, 1, "{name}");
+        let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Group commit.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn one_refusal_in_a_batch_does_not_take_the_others_down() {
+    both(|store, name| {
+        let _ = store
+            .create_queue(&spec(QueueKind::Standard, generous(), 86_400, 86_400))
+            .unwrap();
+        let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+        let payload = Payload::new(vec![2u8; 64]).unwrap();
+
+        let batch = [
+            Append {
+                send_addr: SEND,
+                auth: SendAuth::Signed(SEND_KEY),
+                payload: &payload,
+                received_at_ms: 2_000,
+            },
+            // An unknown address: refused, and it must not roll back the two
+            // legitimate appends sharing its transaction.
+            Append {
+                send_addr: ABSENT,
+                auth: SendAuth::Signed(SEND_KEY),
+                payload: &payload,
+                received_at_ms: 2_000,
+            },
+            Append {
+                send_addr: SEND,
+                auth: SendAuth::Signed(SEND_KEY),
+                payload: &payload,
+                received_at_ms: 2_000,
+            },
+        ];
+        let committed = store.append_batch(&batch).unwrap();
+        assert_eq!(committed.durability(), store.durability(), "{name}");
+        let results = committed.into_inner();
+        assert_eq!(results.len(), 3, "{name}");
+        assert_eq!(results[0].as_ref().unwrap().index, 0, "{name}");
+        assert_eq!(
+            code(results[1].as_ref().unwrap_err()),
+            ErrorCode::Unavailable,
+            "{name}"
+        );
+        assert_eq!(results[2].as_ref().unwrap().index, 1, "{name}");
+        assert_eq!(read_all(store, 3_000), vec![0, 1], "{name}");
+        let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+    });
+}
+
+#[test]
+fn indices_are_dense_and_ascending_across_batch_boundaries() {
+    both(|store, name| {
+        let _ = store
+            .create_queue(&spec(QueueKind::Standard, generous(), 86_400, 86_400))
+            .unwrap();
+        let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+        let payload = Payload::new(vec![4u8; 32]).unwrap();
+
+        let mut expected = 0u64;
+        for size in [1usize, 5, 1, 17] {
+            let batch: Vec<Append<'_>> = (0..size)
+                .map(|_| Append {
+                    send_addr: SEND,
+                    auth: SendAuth::Signed(SEND_KEY),
+                    payload: &payload,
+                    received_at_ms: 2_000,
+                })
+                .collect();
+            for result in store.append_batch(&batch).unwrap().into_inner() {
+                assert_eq!(result.unwrap().index, expected, "{name}");
+                expected += 1;
+            }
+        }
+        assert_eq!(
+            read_all(store, 3_000),
+            (0..expected).collect::<Vec<_>>(),
+            "{name}"
+        );
+        let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Durability, as a published fact.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn each_store_publishes_the_durability_it_actually_has() {
+    let directory = tempfile::tempdir().unwrap();
+    let sqlite = SqliteStore::open(directory.path().join("relay.sqlite3")).unwrap();
+    assert_eq!(
+        sqlite.durability(),
+        f2z_relay_store::Durability::FsyncPerAppend
+    );
+    assert_eq!(sqlite.durability().wire_value(), 2);
+    assert!(sqlite.durability().survives_crash());
+
+    let memory = MemoryStore::new();
+    assert_eq!(memory.durability(), f2z_relay_store::Durability::Memory);
+    assert_eq!(memory.durability().wire_value(), 0);
+    assert!(!memory.durability().survives_crash());
+}
+
+#[test]
+fn a_colliding_address_is_reported_rather_than_overwriting_a_live_queue() {
+    both(|store, name| {
+        let _ = store
+            .create_queue(&spec(QueueKind::Standard, generous(), 86_400, 86_400))
+            .unwrap();
+        // §7.1 rejected client-chosen addresses partly because of squatting: a
+        // create that silently replaced an existing record would be that attack
+        // succeeding against the relay's own generator.
+        let error = store
+            .create_queue(&spec(QueueKind::Standard, generous(), 86_400, 86_400))
+            .expect_err("the same pair of addresses collides");
+        assert!(matches!(error, StoreError::AddressCollision), "{name}");
+
+        // A collision across the two namespaces counts too: both addresses are
+        // drawn from one 32-byte space and a lookup by either must be
+        // unambiguous.
+        let mut crossed = spec(QueueKind::Standard, generous(), 86_400, 86_400);
+        crossed.recv_addr = QueueAddress::new([0x77; 32]);
+        crossed.send_addr = RECV;
+        let error = store
+            .create_queue(&crossed)
+            .expect_err("a send address equal to an existing receive address collides");
+        assert!(matches!(error, StoreError::AddressCollision), "{name}");
+        let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+    });
+}

--- a/rs/crates/f2z-relay-store/tests/redaction.rs
+++ b/rs/crates/f2z-relay-store/tests/redaction.rs
@@ -1,0 +1,275 @@
+//! `--log-level trace` on a relay must not become a ciphertext archive.
+//!
+//! # The trap this file is written around
+//!
+//! `f2z-codec`'s own redaction tests document it: **`tls_codec`'s byte vectors
+//! derive `Debug` and print a list of decimal integers** — `[222, 222, 222, …]`
+//! — which is a complete dump containing no hex whatsoever. A leak check that
+//! greps for base16 therefore passes with flying colours while every byte of
+//! every payload is in the log file.
+//!
+//! So each assertion below rejects four encodings of the same secret: lowercase
+//! hex, uppercase hex, base64url, and an unbracketed **decimal run**. The
+//! decimal run is unbracketed on purpose, exactly as in `f2z-codec`: a real
+//! dump very often does not start at the beginning of the list, because a wire
+//! buffer opens with a length prefix, so anchoring on `[` misses the shape the
+//! check exists to catch.
+//!
+//! # What is checked
+//!
+//! Every type this crate puts in front of a caller: the records, the read
+//! results, the reports, and — the one that is easy to forget — the **error
+//! type**, which is what actually reaches a log line on the unhappy path.
+
+// Test code, run on the host by a person reading the failure.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_codec::types::{Payload, PublicKey, QueueAddress};
+use f2z_relay_proto::queue::{AppendQuota, QueueKind};
+use f2z_relay_store::{
+    Append, MemoryStore, QueueSpec, ReadWindow, RelayStore, SendAuth, SqliteStore, StoreError,
+};
+
+/// Unmistakable in any encoding a leak might use.
+const SECRET: u8 = 0xde;
+const SECRET_LEN: usize = 64;
+
+fn lower_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn upper_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02X}")).collect()
+}
+
+/// `222, 222, 222, …` — a derived `Debug` on a byte slice, without the
+/// brackets. See the module note on why the brackets are deliberately absent.
+fn decimal_run(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn base64url(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::new();
+    for chunk in bytes.chunks(3) {
+        let mut buffer = [0u8; 3];
+        buffer[..chunk.len()].copy_from_slice(chunk);
+        let value =
+            (u32::from(buffer[0]) << 16) | (u32::from(buffer[1]) << 8) | u32::from(buffer[2]);
+        let symbols = match chunk.len() {
+            1 => 2,
+            2 => 3,
+            _ => 4,
+        };
+        for index in 0..symbols {
+            let shift = 18 - 6 * index;
+            out.push(ALPHABET[((value >> shift) & 0x3f) as usize] as char);
+        }
+    }
+    out
+}
+
+/// Assert that `rendered` cannot be turned back into `secret`.
+///
+/// A four-byte prefix is enough: a dump that contained the whole value
+/// contains its prefix, and matching on a prefix catches a truncated dump too.
+fn assert_no_leak(rendered: &str, secret: &[u8], what: &str) {
+    let probe = &secret[..4];
+    for (encoding, needle) in [
+        ("lowercase hex", lower_hex(probe)),
+        ("uppercase hex", upper_hex(probe)),
+        ("base64url", base64url(probe)),
+        ("decimal byte list", decimal_run(probe)),
+    ] {
+        assert!(
+            !rendered.contains(&needle),
+            "{what} leaked its bytes as {encoding}: {rendered}"
+        );
+    }
+}
+
+fn secret_address() -> QueueAddress {
+    QueueAddress::new([SECRET; 32])
+}
+
+fn secret_key() -> PublicKey {
+    PublicKey::new([SECRET; 32])
+}
+
+fn secret_payload() -> Payload {
+    Payload::new(vec![SECRET; SECRET_LEN]).unwrap()
+}
+
+fn spec() -> QueueSpec {
+    QueueSpec {
+        kind: QueueKind::Standard,
+        recv_addr: secret_address(),
+        send_addr: QueueAddress::new([SECRET ^ 0x01; 32]),
+        recv_key: secret_key(),
+        message_ttl_seconds: 86_400,
+        idle_ttl_seconds: 86_400,
+        quota: AppendQuota {
+            max_messages: 8,
+            max_bytes: 512,
+        },
+        created_at_ms: 1_000,
+    }
+}
+
+#[test]
+fn nothing_a_store_hands_back_renders_its_bytes() {
+    let store = MemoryStore::new();
+    let spec = spec();
+    let record = store.create_queue(&spec).unwrap();
+    assert_no_leak(&format!("{record:?}"), &[SECRET; 32], "QueueRecord");
+    assert_no_leak(&format!("{spec:?}"), &[SECRET; 32], "QueueSpec");
+
+    let committed = store
+        .bind_send(&spec.send_addr, &secret_key(), 1_000)
+        .unwrap();
+    assert_no_leak(&format!("{committed:?}"), &[SECRET; 32], "Committed<()>");
+
+    let payload = secret_payload();
+    let append = Append {
+        send_addr: spec.send_addr,
+        auth: SendAuth::Signed(secret_key()),
+        payload: &payload,
+        received_at_ms: 2_000,
+    };
+    assert_no_leak(&format!("{append:?}"), &[SECRET; SECRET_LEN], "Append");
+    assert_no_leak(&format!("{payload:?}"), &[SECRET; SECRET_LEN], "Payload");
+
+    let accepted = store.append(&append).unwrap();
+    assert_no_leak(
+        &format!("{accepted:?}"),
+        &[SECRET; 32],
+        "Committed<Appended>",
+    );
+
+    let page = store
+        .read(
+            &spec.recv_addr,
+            &secret_key(),
+            ReadWindow {
+                from_index: 0,
+                max_messages: 8,
+                max_bytes: 4_096,
+            },
+            3_000,
+        )
+        .unwrap();
+    // The one that matters most: a read result holds the ciphertext itself.
+    assert_no_leak(&format!("{page:?}"), &[SECRET; SECRET_LEN], "ReadPage");
+    assert_no_leak(
+        &format!("{:?}", page.messages[0]),
+        &[SECRET; SECRET_LEN],
+        "StoredMessage",
+    );
+
+    let outcome = store.ack(&spec.recv_addr, &secret_key(), 0, 4_000).unwrap();
+    assert_no_leak(
+        &format!("{outcome:?}"),
+        &[SECRET; 32],
+        "Committed<AckOutcome>",
+    );
+
+    let report = store.expire(u64::MAX).unwrap();
+    assert_no_leak(&format!("{report:?}"), &[SECRET; 32], "ExpiryReport");
+}
+
+#[test]
+fn an_error_renders_neither_the_address_that_caused_it_nor_the_payload() {
+    // The unhappy path is the one that actually reaches a log line, and a
+    // storage error is the value a relay is most likely to print verbatim.
+    let store = MemoryStore::new();
+    let error = store
+        .queue_by_recv(&secret_address(), &secret_key())
+        .expect_err("nothing exists yet");
+    assert_no_leak(&format!("{error:?}"), &[SECRET; 32], "StoreError (Debug)");
+    assert_no_leak(&format!("{error}"), &[SECRET; 32], "StoreError (Display)");
+
+    let payload = secret_payload();
+    let error = store
+        .append(&Append {
+            send_addr: secret_address(),
+            auth: SendAuth::Signed(secret_key()),
+            payload: &payload,
+            received_at_ms: 1,
+        })
+        .expect_err("nothing exists yet");
+    assert_no_leak(
+        &format!("{error:?}"),
+        &[SECRET; SECRET_LEN],
+        "StoreError from an append (Debug)",
+    );
+}
+
+#[test]
+fn a_backend_error_carries_no_bound_value_into_its_message() {
+    // The property that makes the rest of this file cheap to keep true:
+    // nothing here interpolates a value into SQL, so SQLite's diagnostics name
+    // schema objects and never echo what was bound to them. Provoke a real
+    // backend error and check.
+    let directory = tempfile::tempdir().unwrap();
+    let store = SqliteStore::open(directory.path().join("relay.sqlite3")).unwrap();
+    let spec = spec();
+    let _ = store.create_queue(&spec).unwrap();
+
+    let payload = secret_payload();
+    // The quota is 512 bytes; the ninth 64-byte payload crosses it. That is a
+    // protocol refusal rather than a backend one, which is itself the point:
+    // the errors a relay actually logs are these.
+    let _ = store
+        .bind_send(&spec.send_addr, &secret_key(), 1_000)
+        .unwrap();
+    let mut last: Option<StoreError> = None;
+    for _ in 0..16 {
+        if let Err(error) = store.append(&Append {
+            send_addr: spec.send_addr,
+            auth: SendAuth::Signed(secret_key()),
+            payload: &payload,
+            received_at_ms: 2_000,
+        }) {
+            last = Some(error);
+            break;
+        }
+    }
+    let error = last.expect("the quota refuses eventually");
+    assert_no_leak(
+        &format!("{error:?} {error}"),
+        &[SECRET; SECRET_LEN],
+        "a quota refusal from the SQLite store",
+    );
+
+    // And a genuine backend failure: a schema-version mismatch, which is the
+    // one error path that renders a string this crate wrote itself.
+    let stats = store.stats().unwrap();
+    assert_no_leak(&format!("{stats:?}"), &[SECRET; 32], "StoreStats");
+}
+
+#[test]
+fn the_decimal_check_would_actually_catch_a_leak() {
+    // A negative control. Without this, every assertion above could be passing
+    // because the probe never matches anything, and the file would be a very
+    // convincing no-op — which is precisely the failure mode `f2z-codec`'s
+    // redaction tests warn about.
+    let leaked = format!("payload = {:?}", vec![SECRET; SECRET_LEN]);
+    let probe = decimal_run(&[SECRET; 4]);
+    assert!(
+        leaked.contains(&probe),
+        "the decimal probe must match a derived Debug on a byte vector, or it \
+         is checking nothing"
+    );
+    let hex_leak = lower_hex(&[SECRET; 32]);
+    assert!(hex_leak.contains(&lower_hex(&[SECRET; 4])));
+}

--- a/rs/deny.toml
+++ b/rs/deny.toml
@@ -95,6 +95,16 @@ allow = [
   "Apache-2.0",
   "BSD-3-Clause",
   "Unicode-3.0",
+  # Zlib arrives with SQLite: rusqlite -> hashlink -> hashbrown -> foldhash,
+  # which is `Zlib` and is reached through hashbrown's default hasher rather
+  # than by any choice of ours. It is permissive — OSI-approved, FSF Free/Libre,
+  # no copyleft and no attribution-in-binary requirement — so it sits on the
+  # correct side of the boundary this section exists to police, which is
+  # permissive-crates versus AGPL-server-binaries and not licence-family
+  # bookkeeping. wallet/deny.toml already allows it for an unrelated graph
+  # (the objc2 family, bytemuck, miniz_oxide, tinyvec); this entry is judged
+  # against ours and names the crate that needs it.
+  "Zlib",
 ]
 
 # Per-crate escapes. Empty today.


### PR DESCRIPTION
`WIRE.md` §7 and §8, made durable. A `RelayStore` trait that speaks **addresses and bytes and never a wire frame**, plus `SqliteStore` and `MemoryStore`.

## ⚠️ Draft, and why: the merge-train hold

There is an active hard hold on #584/#588 — **#556 must land before any other PR moves `main`**, and E2EE PRs stay draft until it does. This PR is deliberately draft and is **not** to be marked ready or merged until that clears.

**CI did run on the draft**, and both required contexts are green: **`gate` ✅** and **`rs / gate` ✅** (run [32686928802](https://github.com/free2z/zuu/actions/runs/32686928802)). The local evidence at the bottom was gathered before that and is kept because it covers the two things CI cannot show on its own — the negative wasm build, and the gate scripts' verdicts quoted in full.

**Base tested:** `0b00710` (`docs(e2ee): close CLIENT-CONTRACT's seven interface defects (#592)`). Expect a rebase after #556; the evidence covers that base.

## The property the crate exists for

Under delete-on-ack the relay's copy is, for a window between `accepted` and `ACK`, **the only copy in the system** ([`ARCHITECTURE.md` §6.4](docs/e2ee/ARCHITECTURE.md#64-delete-on-ack-and-lost-acknowledgements)). A relay that answers `accepted` before the write is durable has promised custody a power cut breaks.

The brief asked for durability to be *a returned fact, not a convention*. It is:

- Every mutating operation returns **`Committed<T>`**, whose constructor is `pub(crate)`. The only code that mints one is the code that has just completed the transaction. A caller cannot write the line that reports `accepted` without first holding a value only a completed commit could have produced.
- `Committed` is `#[must_use]`, so dropping the receipt is a warning rather than a silent loss of track.
- The three pragmas the claim rests on are **read back out of the engine at open** and the store refuses to exist otherwise. A pragma that silently did not take is how a relay comes to publish `fsync-per-append` while running something weaker, and the failure is invisible until the power goes out.

## Group commit, treated as a requirement

At `synchronous = FULL` a commit is an fsync, and a commodity VPS does 50–200 a second. One transaction per append caps the relay there, which is not a working design. So `append_batch` is the **primitive** and `append` is the batch of one; the batching *window* is a scheduling decision left to the server crate.

Made checkable rather than asserted: `SqliteStore::commits()` counts durable commits (the number an operator should graph — it is the fsync rate), and `a_batch_of_a_hundred_appends_costs_one_commit` asserts 100 appends move it by 1 while 10 single appends move it by 10.

Batching does **not** weaken durability, and the distinction matters because §11.1 publishes it: deferring the fsync past the response is `batched`; amortizing one fsync across many responses that all wait for it is still `fsync-per-append`.

## Crash safety: real processes, really killed

`tests/crash_safety.rs`, behind the default-off `crash-injection` feature. Four injection points either side of the commit; each case spawns a **child process** that `abort()`s inside the library, the parent asserts the child was killed by **SIGABRT** (not that it exited — a child that returned a code did not crash, and accepting that would pass even with the injection point deleted), then reopens the file in a fresh process:

| Case | Asserts |
|---|---|
| after append commit | Nothing accepted-but-lost: all three rows present, `next_index = 3`, counters consistent — including the third, whose receipt never reached its caller |
| before append commit | No trace: no row **and** no consumed index (a counter that moved without its row is a permanent gap in the reader's index space) |
| after ack commit | Nothing acked-but-undeleted: every index ≤ the persisted watermark is gone |
| before ack commit | Nothing deleted, watermark unmoved, and §8.3's retry then works |
| reopened store | §8.2 pre-ack refusal and §7.3 bind-once are properties of the queue, not of the process that created it |

An in-process caught panic proves none of this — it unwinds a live connection and runs `Drop` on the open transaction, rolling back the very write in question. That reasoning is in `src/crash.rs`'s module docs so the next person does not "simplify" it.

## Schema

Composite primary key `(recv_addr, idx)`, `WITHOUT ROWID`, exactly as briefed — the row lives *in* the index, so one queue's messages are physically contiguous in index order: `READ` is a range scan from the watermark and `ACK`, being cumulative and therefore always a prefix, is a range delete over one contiguous run.

## Redaction, including the documented trap

Every value crossing the boundary is an `f2z-codec` newtype; no raw `Vec<u8>` or `[u8; 32]` appears in any `Debug`-deriving type. `tests/redaction.rs` checks **four** encodings — lowercase hex, uppercase hex, base64url, and an **unbracketed decimal run** — because `tls_codec`'s byte vectors print `[222, 222, …]`, a full dump containing no hex at all, so a hex-only check passes while everything leaks. The decimal probe is unbracketed for the same reason `f2z-codec` gives: a real dump usually starts mid-buffer after a length prefix. `the_decimal_check_would_actually_catch_a_leak` is the negative control proving the probe is not a no-op. `StoreError` is checked in both `Debug` and `Display`, because the error is what actually reaches a log line.

---

# Ambiguity calls, with reasoning

Every judgement call the spec did not settle. #586's two known `WIRE.md` defects were read and are **not** re-reported.

1. **The trait is closed to out-of-crate implementations, by construction.** `Committed`'s constructor is `pub(crate)`, so nobody outside can mint a durability proof — which is the point, since durability is the one property a backend cannot be trusted to assert about itself. The cost is real and stated in `durability.rs`: a third-party backend cannot implement `RelayStore` in v1. Opening it later is a default-off feature exposing a loudly-named `assert_durable`, and it should be added when there is a real second backend, not in advance of one. **Flagging for a reviewer's opinion** — this is the largest single design call in the PR.

2. **The store does not generate addresses.** §7.1 requires the relay to draw both from its own CSPRNG. Randomness stays out of the store: the caller draws, `QueueSpec` carries the pair, and `StoreError::AddressCollision` says draw again. A store with a CSPRNG is a store that can be asked for a *predictable* address by a caller that seeds it wrong, and §7.1's collision retry belongs next to the generator.

3. **Both addresses share one namespace.** A new `recv_addr` equal to an existing `send_addr` (or vice versa) is a collision, not an insert. Both are 32 uniformly random bytes and a lookup by either must be unambiguous. Unreachable at 32 bytes; a bug in the caller's generator otherwise.

4. **Authorization happens inside the transaction.** The caller verifies the signature (that is `f2z-relay-proto`'s job); the store compares the recovered signer against the registered key **atomically with the mutation**, because checking a statement earlier lets a `DELETE_QUEUE` land in between. Passing a `PublicKey` is not "reaching into the protocol" — it is bytes.

5. **Two lookup methods, not one, because §10 and §6.3 disagree on purpose.** The same absent row is `ERR_NO_ACCESS` via `queue_by_recv` (existence-oracle rule: absent and wrongly-keyed must be one code) and `ERR_UNAVAILABLE` via `queue_by_send` (§6.3's collapse). There is no `NotFound` variant to route wrongly — the collapse happens where existence is known.

6. **`bind_send` takes one key, not two.** §5.1 step 5 cannot apply to `BIND_SEND` (no key is registered yet); `f2z-relay-proto` resolved that by requiring `signer_key == send_key`, and this API makes them the same parameter so they cannot be passed differently.

7. **`BIND_SEND` on a contact address stays `ERR_NOT_PERMITTED` and is *not* collapsed into `ERR_UNAVAILABLE`.** §12.2 says "always, for everyone", and a contact address is **published in a directory entry** — refusing distinguishably leaks no queue state its finder did not already have. Called out because it is the one send-side code that does not collapse.

8. **`SendAuth` distinguishes `APPEND` from `CONTACT_APPEND`.** A signed `APPEND` to a contact address and an unsigned `CONTACT_APPEND` to an ordinary send address are both `ERR_UNAVAILABLE`: a writer must not learn which kind of queue an address is. The store does not verify PoW — `SendAuth::ContactStamp` asserts the caller already did (§13.1).

9. **`READ` always yields at least one message, even under an impossible `max_bytes`.** §6.2 does not say. Returning an empty page with `has_more = 1` forever means a reader that cannot progress cannot acknowledge, which under delete-on-ack is a queue that fills and then refuses its sender. `max_messages` is *not* given the same treatment — a client asking for zero gets zero.

10. **`READ` filters TTL-expired messages at read time**, not only at sweep time. A lazily-swept relay must not serve ciphertext past its own published retention.

11. **Idle-timer activity is buffered in memory and is deliberately not durable.** §7.7 resets the idle TTL on `APPEND`, `READ`, `ACK` **and `SUBSCRIBE`**. Fsyncing every `SUBSCRIBE` to move a 90-day deadline would spend the entire fsync budget on a timer whose resolution is months. A crash loses activity since the last durable write, ageing a deadline by at most that interval — and `expire()` flushes the buffer *before* it sweeps, so the exposure is bounded by the **sweep period**, not by uptime. `touch()` is the `SUBSCRIBE` hook and returns no `Committed`, which is the API saying so.

12. **Message-TTL expiry does not move the watermark.** An expired message was never acknowledged; advancing the watermark would acknowledge it on the reader's behalf. Consequence, from `f2z-relay-proto`'s own note: `pending` is unacknowledged *indices*, an upper bound on messages actually held, so `QueueRecord` carries `stored_messages` separately.

13. **Idle expiry runs before message expiry** in one `expire()` transaction: an idle-expired queue takes its messages with it, so sweeping it first keeps them out of the message-TTL accounting.

14. **A per-item refusal inside `append_batch` does not roll the batch back; a backend error does.** Every protocol refusal is decided strictly *before* that item's first write, so the transaction is still clean — one writer hitting its cap must not undo an unrelated queue's durable write. Anything that is not a `Protocol` error propagates and drops the transaction.

15. **The index space ends at `i64::MAX`, not `u64::MAX`.** SQLite's `INTEGER` is signed, and a range scan whose ordering flips past `i64::MAX` is a correctness bug, not a capacity one. Exhaustion refuses as `ERR_UNAVAILABLE` so §6.3's collapse survives the store's own limits — checked *before* the insert so it is a clean refusal rather than a half-written batch. Unreachable: at a million appends a second it is ~292,000 years. Unit-tested by forcing the counter.

16. **`delete_queue` returns counters (`Deleted`), and `expire` returns a per-queue report.** `DELETE_QUEUE`'s wire response is empty and stays empty; these exist so the caller can push `QUEUE_EVENT` (§6.4) to subscribed readers and keep §13.1 layer 4's accounting without re-querying.

17. **`stats()` reports `storage_bytes` from `page_count × page_size`, not from payload bytes.** Layer 4's high-water mark is about disk, and page overhead, free pages and the WAL are all real disk.

18. **A poisoned mutex does not wedge the store.** The lock guards a connection whose consistency is SQLite's job; refusing every later request would turn one fault into a permanent outage of `READ` and `ACK`, which §13.1 says must never be refused.

## Cross-crate change

**`QueueState::restore` added to `f2z-relay-proto`** (+ its own unit test). A relay's storage outlives its process, so §8's arithmetic has to be applied to *loaded* state. Without this constructor the store would re-derive that arithmetic against its own columns — and §8.2's anti-pre-ack rule implemented twice is §8.2's rule implemented once and violated once. It validates the two invariants a store cannot restore its way out of (a bound contact queue; `acked_through >= next_index`), both `ERR_INTERNAL` because both mean the relay's own storage contradicts the protocol.

## Notes for the reviewer

- **`rs/deny.toml` gains one licence: `Zlib`.** It arrives only via `rusqlite → hashlink → hashbrown → foldhash`, through hashbrown's default hasher rather than any choice of ours. Permissive, OSI-approved, FSF Free/Libre, no copyleft — the correct side of the boundary that section polices, which is permissive-crates-versus-AGPL-binaries and not licence-family bookkeeping. `wallet/deny.toml` already allows it for an unrelated graph; this entry is judged against ours and names the crate that needs it. `advisories ok, bans ok, licenses ok, sources ok` on a clean run, `ignore` still empty.
- **`rusqlite = "0.37"` with `bundled`, added to `[workspace.dependencies]`** with the singleton reasoning inline. `libsqlite3-sys` declares `links = "sqlite3"`; the lockfile resolves `rusqlite 0.37.0` / `libsqlite3-sys 0.35.0`, agreeing with all three wallet lockfiles.
- **Registered with `scripts/check-rust-toolchain.sh`** (`rs.yml` + both invocations in `rs/README.md`) — the one gate that does not discover manifests. Verified green.
- **Deliberately absent from `rs_wasm`**, with a comment saying so at the line. Not a claim: `cargo build --target wasm32-unknown-unknown -p f2z-relay-store` fails in `cc-rs` compiling `sqlite3.c`, which is the point — no client links this crate.
- **New CI step** running the crash suite with `--features crash-injection`, as a step of its own so a run that skipped it is visible rather than inferred. `scripts/check-workflow-gates.mjs` and `check-github-actions-pins.mjs` both pass; no job was added, so no gate wiring changed.
- Concurrent-crate note: if another PR touches `rs/Cargo.toml` / `rs/Cargo.lock`, keep **both** crates and regenerate the lockfile.

## Verification — local, pinned toolchain 1.97.1, base `0b00710`

CI is green on this exact head (`gate` and `rs / gate`), and the crash suite ran there too — the CI log shows `test result: ok. 5 passed; 0 failed; 1 ignored` for `tests/crash_safety.rs` on Linux, so the child processes are really being killed on the runner and not only on a developer's machine. All of the following were additionally run locally:

```
scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
  --manifest rs/crates/f2z-codec/Cargo.toml \
  --manifest rs/crates/f2z-relay-proto/Cargo.toml \
  --manifest rs/crates/f2z-relay-store/Cargo.toml
  → Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.97.1, MSRV 1.97.

scripts/check-rust-fmt.sh --root rs
  → All 4 Rust crate(s) under rs/ are formatted (rustfmt from 1.97.1).

scripts/check-rust-clippy.sh --root rs        # -D warnings
  → All 4 Rust crate(s) under rs/ are clippy-clean (clippy from 1.97.1).

scripts/check-rust-deny.sh --root rs --config rs/deny.toml
  → advisories ok, bans ok, licenses ok, sources ok
  → All 4 Rust crate(s) under rs/ satisfy rs/deny.toml.

node scripts/check-github-actions-pins.mjs   → passed (178 refs, 15 files)
node scripts/check-workflow-gates.mjs        → passed (2 gates, 56 jobs, 14 files)

cd rs && cargo test --locked --all-targets   → 12 suites, all ok, 0 failed
cd rs && cargo test --locked --doc           → ok (incl. this crate's lib.rs example)
cargo test --locked -p f2z-relay-store --features crash-injection --test crash_safety
  → 5 passed; 0 failed; 1 ignored   (each spawns a child killed by SIGABRT)

cargo build --locked --lib --target wasm32-unknown-unknown -p f2z-codec -p f2z-relay-proto
  → Finished (the wasm line is unchanged)
```

Crate totals: 12 lib unit tests, 14 property tests (each run against **both** stores), 4 redaction tests, 5 crash-safety tests, 1 doc test.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
