### PR TITLE
ci(toolchain): make crate registration a control, not a discipline

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -67,15 +67,18 @@ jobs:
           node scripts/check-workflow-gates.mjs
 
       # rs/rust-toolchain.toml and rs/crates/*/Cargo.toml restate
-      # wallet/rust-toolchain.toml. Registering them here is what holds them to
-      # it; without the flags they would be a second, unpoliced source of truth.
+      # wallet/rust-toolchain.toml, and are registered in the script's own
+      # TOOLCHAIN_RESTATEMENTS/MANIFESTS arrays rather than by flags here. A
+      # flag in one workflow is not a registration: the bare invocation the
+      # required zuuli gate runs passes no flags, so anything registered only
+      # here would be unpoliced there. Registering in the script instead means
+      # its census — which enumerates every tracked manifest and toolchain file
+      # and fails on any that is unregistered — covers this tree from both
+      # workflows. See #553.
       - name: Verify the Rust toolchain pin has not drifted
         run: |
           scripts/check-rust-toolchain.sh --self-test
-          scripts/check-rust-toolchain.sh \
-            --toolchain-file rs/rust-toolchain.toml \
-            --manifest rs/crates/f2z-codec/Cargo.toml \
-            --manifest rs/crates/f2z-relay-proto/Cargo.toml
+          scripts/check-rust-toolchain.sh
 
       - name: Detect changes under rs/
         id: filter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,9 +160,11 @@ integrate, and move it forward alongside everything else.
   librustzcash `main` + refreshed crates, so upstream drift surfaces as an early
   warning **before** we bump the submodule in a PR.
 - **`scripts/check-rust-toolchain.sh`** proves every Rust toolchain pin still
-  agrees with `wallet/rust-toolchain.toml`. The `wallet/zuuli` gate runs it on
-  every pull request, so a half-finished bump fails in review instead of in a
-  protected store release. See below.
+  agrees with `wallet/rust-toolchain.toml`, and — since #553 — that **every**
+  tracked `Cargo.toml` and `rust-toolchain.toml` outside `z/` is registered with
+  it, so a crate cannot escape the MSRV check by never being registered. The
+  `wallet/zuuli` gate runs it on every pull request, so a half-finished bump
+  fails in review instead of in a protected store release. See below.
 - **`scripts/check-rust-fmt.sh`**, **`scripts/check-rust-clippy.sh`** and
   **`scripts/check-rust-deny.sh`** hold every Rust crate under `wallet/` to
   rustfmt, `clippy -D warnings`, and the `wallet/deny.toml` supply-chain policy.
@@ -219,9 +221,21 @@ read a TOML file at the moment they need the value:
 A second top-level Rust tree does not get a decision of its own either. It needs
 its own `rust-toolchain.toml`, because Cargo picks the toolchain from the
 directory it runs in, and its crates carry their own `rust-version` — both are
-restatements. Register them with `scripts/check-rust-toolchain.sh
---toolchain-file <path>` and `--manifest <path>` and they are held to
-`wallet/rust-toolchain.toml` exactly like every row above.
+restatements. Register them in `scripts/check-rust-toolchain.sh`'s
+`TOOLCHAIN_RESTATEMENTS` and `MANIFESTS` arrays and they are held to
+`wallet/rust-toolchain.toml` exactly like every row above. (`--toolchain-file`
+and `--manifest` still register a path ad hoc for a local run, but a flag in one
+workflow is **not** a registration: the bare invocation the required gate runs
+passes no flags.)
+
+**Registration is enforced, not remembered.** The same script's **census**
+enumerates every `Cargo.toml` and `rust-toolchain.toml` git tracks outside `z/`
+and fails, naming the file, on any that declares `[package]` — or restates the
+toolchain — and is registered nowhere. Before that existed, an unregistered
+crate was simply invisible to the check and shipped with a wrong MSRV, or none,
+behind a green check identical to a registered crate's; it held only because
+people remembered (#553). A virtual workspace root is excused because it
+declares no `[package]`, recognised structurally rather than by a path list.
 
 The `wallet/zuuli` gate reads the channel out of the file (`--print-channel`) and
 feeds it to the toolchain action, so the required CI jobs hold **no literal at

--- a/rs/README.md
+++ b/rs/README.md
@@ -74,13 +74,15 @@ here. It is **not a second source of truth.** The one place the version is
 decided is `wallet/rust-toolchain.toml`, and
 
 ```
-scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
-                                --manifest rs/crates/f2z-codec/Cargo.toml \
-                                --manifest rs/crates/f2z-relay-proto/Cargo.toml
+scripts/check-rust-toolchain.sh
 ```
 
 fails the pull request the moment the two disagree. `.github/workflows/rs.yml`
-runs exactly that. Bumping the compiler means editing
+runs exactly that. `rs/rust-toolchain.toml` and every `rs/crates/*/Cargo.toml`
+are registered in the script's own `TOOLCHAIN_RESTATEMENTS` and `MANIFESTS`
+arrays — not by `--manifest` flags in this workflow, because the bare invocation
+the required ZUULI gate runs passes no flags and would be blind to anything
+registered only here. Bumping the compiler means editing
 `wallet/rust-toolchain.toml` and running `scripts/check-rust-toolchain.sh`,
 which names every restatement that still needs updating — this one included.
 
@@ -140,37 +142,41 @@ cargo build --target wasm32-unknown-unknown --lib -p f2z-codec -p f2z-relay-prot
 The gates are the repository's shared scripts, pointed here with `--root`:
 
 ```bash
-scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
-                                --manifest rs/crates/f2z-codec/Cargo.toml \
-                                --manifest rs/crates/f2z-relay-proto/Cargo.toml
+scripts/check-rust-toolchain.sh
 scripts/check-rust-fmt.sh    --root rs
 scripts/check-rust-clippy.sh --root rs
 scripts/check-rust-deny.sh   --root rs --config rs/deny.toml
 ```
 
-**Three of the four discover crates; the toolchain check does not.**
+**All four now discover crates, by two different mechanisms.**
 `check-rust-fmt.sh`, `check-rust-clippy.sh` and `check-rust-deny.sh` find every
 `Cargo.toml` under `--root`, so a new crate under `rs/` is formatted, linted and
-supply-chain-gated from its first commit. `check-rust-toolchain.sh` reads a
-hardcoded manifest list plus the explicit `--manifest` flags above, so **a second
-crate under `rs/crates/` would ship with a wrong MSRV, or none, and still pass.**
+supply-chain-gated from its first commit.
 
-Proved by adding a throwaway `rs/crates/scratch/Cargo.toml` with no
-`rust-version` and no `license`, then running all four with the flags above
-unchanged:
+`check-rust-toolchain.sh` still verifies a *registry* — it has to, because an
+MSRV is a value to compare, not a tree to walk — but registration is no longer a
+discipline. Its **census** enumerates every `Cargo.toml` and `rust-toolchain.toml`
+git tracks outside `z/` and fails on any that declares `[package]` (or restates
+the toolchain) and is registered nowhere. Proved by adding a throwaway
+`rs/crates/scratch/Cargo.toml` with no `rust-version` and no `license`:
 
 | Script | Sees it? | Verdict |
 |---|---|---|
-| `check-rust-fmt.sh --root rs` | yes | RED — `3 crate(s) are not formatted: … rs/crates/scratch` |
+| `check-rust-fmt.sh --root rs` | yes | RED — `4 crate(s) are not formatted: … rs/crates/scratch` |
 | `check-rust-clippy.sh --root rs` | yes | RED — `2 crate(s) failed the clippy gate: … rs/crates/scratch` |
 | `check-rust-deny.sh --root rs --config rs/deny.toml` | yes | RED — `error[unlicensed]: scratch = 0.0.0 is unlicensed` |
-| `check-rust-toolchain.sh --toolchain-file … --manifest …/f2z-codec/Cargo.toml` | **no** | **GREEN** |
+| `check-rust-toolchain.sh` | yes | RED — `rs/crates/scratch/Cargo.toml declares [package] but is registered nowhere` |
 
-So **every new crate in this tree needs another `--manifest` flag added to
-`rs.yml`** in the same commit that creates it, until
-[#553](https://github.com/free2z/zuu/issues/553) makes that check discover
-manifests too. `.github/workflows/rs.yml` runs all four, plus `cargo test` and
-the WASM build, behind its own `gate`.
+Before [#553](https://github.com/free2z/zuu/issues/553) that last row was
+**GREEN and blind**, and every new crate in this tree needed a `--manifest` flag
+added to `rs.yml` by hand. It now needs a line in `MANIFESTS` instead — and the
+check names the file and says so, rather than a reviewer having to notice.
+`.github/workflows/rs.yml` runs all four, plus `cargo test` and the WASM build,
+behind its own `gate`.
+
+A virtual workspace root like `rs/Cargo.toml` is excused because it declares no
+`[package]` and so has no `rust-version` to pin — recognised by that structure,
+not by a path exclusion list that could later be widened to excuse a real crate.
 
 ### Workspace lints
 

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -26,6 +26,14 @@
 #
 #   scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
 #                                   --manifest rs/relay/Cargo.toml
+#
+# Registration used to be a discipline: this script only ever looked at the
+# arrays below plus whatever flags a caller passed, so a crate nobody remembered
+# to register was simply invisible to it and shipped with a wrong MSRV, or none,
+# behind a green check identical to the one a registered crate gets. The
+# registration census (check_census) closes that: it enumerates the manifests and
+# toolchain files git actually tracks and fails on any that is not registered.
+# See #553.
 
 set -euo pipefail
 
@@ -37,19 +45,31 @@ TOOLCHAIN_FILE=wallet/rust-toolchain.toml
 # Crate manifests. These carry the two-component MSRV form (1.88) of the
 # three-component channel (1.88.0) — Cargo's `rust-version` is a floor, not an
 # exact toolchain, so the forms are deliberately different and compared as such.
+#
+# This array is the registry, and check_census makes it exhaustive: every
+# tracked Cargo.toml outside z/ that declares a [package] table must appear
+# here. `--manifest` still works for an ad-hoc or not-yet-committed manifest,
+# but a workflow flag is not a registration — the census runs in every
+# invocation, including the bare one the required gate runs, which passes no
+# flags at all and would fail on anything registered only elsewhere.
 MANIFESTS=(
   wallet/zuuli/wasm-spike/Cargo.toml
   wallet/zuuli/crypto-target-spike/Cargo.toml
   wallet/zuuli/src-tauri/Cargo.toml
   wallet/zuuallet/src-tauri/Cargo.toml
   wallet/plugins/tauri-plugin-zcash/Cargo.toml
+  rs/crates/f2z-codec/Cargo.toml
+  rs/crates/f2z-relay-proto/Cargo.toml
 )
 
 # Other rust-toolchain.toml files. Cargo picks the toolchain from the directory
 # it runs in, so a second Rust tree needs its own copy — but a copy is a
 # restatement, never a second source of truth, and every entry here must repeat
-# TOOLCHAIN_FILE's channel exactly. Extend with --toolchain-file.
-TOOLCHAIN_RESTATEMENTS=()
+# TOOLCHAIN_FILE's channel exactly. Extend with --toolchain-file. check_census
+# holds this array to the tracked tree the same way it holds MANIFESTS.
+TOOLCHAIN_RESTATEMENTS=(
+  rs/rust-toolchain.toml
+)
 
 # Workflows whose jobs verify the installed compiler with
 # `rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "`. GitHub cannot
@@ -89,6 +109,12 @@ ACCEPTED_EXPRESSIONS=(
 )
 
 WASM_TARGET=wasm32-unknown-unknown
+
+# Vendored ecosystem sources. Their MSRVs are upstream's decision, not ours, so
+# the census stops at this prefix. They are submodules, so the superproject
+# index does not list their contents in the first place — this is belt and
+# braces for the day something under z/ stops being a submodule.
+VENDORED_PREFIX=z/
 
 # These are implementation identities, not alternate version decisions. The
 # generic branch commit accepts the source-derived `toolchain:` input; the
@@ -415,6 +441,85 @@ check_toolchain_restatements() {
   done
 }
 
+# --- the registration census -------------------------------------------------
+#
+# Everything above verifies what it was *told about*. This is what makes the
+# telling mandatory: the tracked tree is the input, so a crate cannot escape the
+# MSRV check by never being mentioned. Without it, `check_manifests` and
+# `check_toolchain_restatements` return the same green verdict whether a new
+# crate was registered or forgotten, and only a reviewer noticing tells the two
+# apart.
+
+# The census input: every Cargo.toml and rust-toolchain.toml git tracks.
+# `git ls-files` rather than a filesystem walk, so build artefacts, scratch
+# checkouts and target/ directories cannot inflate or distract it.
+census_tracked_files() {
+  git -C "$REPO_ROOT" ls-files -- '*Cargo.toml' '*rust-toolchain.toml'
+}
+
+# Split out from check_census so the self-test can hand it a synthetic listing
+# and watch each verdict, instead of asserting the census works.
+check_census_listing() {
+  local root=$1 listing=$2
+  local rel base seen=0
+  local registered_toolchains=("$TOOLCHAIN_FILE")
+
+  if (( ${#TOOLCHAIN_RESTATEMENTS[@]} > 0 )); then
+    registered_toolchains+=("${TOOLCHAIN_RESTATEMENTS[@]}")
+  fi
+
+  while IFS= read -r rel; do
+    if [[ -z $rel ]]; then
+      continue
+    fi
+    if [[ $rel == "$VENDORED_PREFIX"* ]]; then
+      continue
+    fi
+
+    base=${rel##*/}
+    if [[ $base == rust-toolchain.toml ]]; then
+      seen=$((seen + 1))
+      if contains "$rel" "${registered_toolchains[@]}"; then
+        continue
+      fi
+      fail "$rel is an unregistered Rust toolchain file; nothing holds it to $TOOLCHAIN_FILE. Add it to TOOLCHAIN_RESTATEMENTS in scripts/check-rust-toolchain.sh"
+      continue
+    fi
+
+    # Registered paths are checked for existence by check_manifests; a listed
+    # path absent from this root is the staged-tree case, not a finding.
+    if [[ ! -f "$root/$rel" ]]; then
+      continue
+    fi
+    # A crate is a manifest that declares a [package] table. A virtual
+    # workspace root declares only [workspace] and has no rust-version to pin,
+    # so it is excused by that structure — not by a path list that could later
+    # be widened to excuse a real crate.
+    if ! grep -qE '^[[:space:]]*\[package\]' "$root/$rel"; then
+      continue
+    fi
+
+    seen=$((seen + 1))
+    if contains "$rel" "${MANIFESTS[@]}"; then
+      continue
+    fi
+    fail "$rel declares [package] but is registered nowhere, so nothing holds its rust-version to $TOOLCHAIN_FILE. Add it to MANIFESTS in scripts/check-rust-toolchain.sh"
+  done <<<"$listing"
+
+  (( seen > 0 )) ||
+    fail "no tracked crate manifests or toolchain files were enumerated; the registration census has gone blind"
+}
+
+check_census() {
+  local root=$1 listing
+
+  if ! listing=$(census_tracked_files 2>/dev/null); then
+    fail "git could not enumerate tracked files; the registration census has gone blind"
+    return
+  fi
+  check_census_listing "$root" "$listing"
+}
+
 check_docs() {
   local root=$1 channel=$2 msrv=$3
   local entry rel needle
@@ -455,6 +560,7 @@ run_checks() {
   check_workflows "$root" "$channel"
   check_manifests "$root" "$channel" "$msrv"
   check_toolchain_restatements "$root" "$channel"
+  check_census "$root"
   check_docs "$root" "$channel" "$msrv"
   check_wasm_target "$root"
 
@@ -588,6 +694,7 @@ self_test() {
     printf 'self-test: caught drift when %s.\n' "$description"
   done
 
+  self_test_census "$scratch" || failures=$((failures + $?))
   self_test_second_tree "$scratch" "$channel" "$msrv" || failures=$((failures + $?))
 
   if (( failures > 0 )); then
@@ -595,6 +702,115 @@ self_test() {
     return 1
   fi
   printf 'self-test: %d drift case(s) caught.\n' "${#SELF_TEST_MUTATIONS[@]}"
+}
+
+# --- self-test: the registration census --------------------------------------
+#
+# The census reads git, not a staged tree, so the mutation loop above cannot
+# exercise it. Each case hands check_census_listing a synthetic listing and
+# asserts on the verdict *and* the path the verdict names — a census that
+# rejected the wrong file, or rejected everything, would pass a bare
+# "it failed" assertion and is caught here instead.
+
+# `expect` is reject or accept; `needle` is the path the verdict must name when
+# rejecting, and the path it must not complain about when accepting.
+self_test_census_case() {
+  local root=$1 description=$2 expect=$3 needle=$4 listing=$5
+  local output raised
+
+  output=$(
+    errors=0
+    check_census_listing "$root" "$listing" 2>&1
+    printf 'errors=%s\n' "$errors"
+  )
+  raised=${output##*errors=}
+
+  if [[ $expect == reject ]]; then
+    if (( raised == 0 )); then
+      printf 'self-test FAILED: the census accepted %s.\n' "$description" >&2
+      return 1
+    fi
+    if [[ $output != *"$needle"* ]]; then
+      printf 'self-test FAILED: the census rejected %s without naming %s:\n%s\n' \
+        "$description" "$needle" "$output" >&2
+      return 1
+    fi
+    printf 'self-test: the census rejects %s.\n' "$description"
+    return 0
+  fi
+
+  if (( raised != 0 )); then
+    printf 'self-test FAILED: the census rejected %s:\n%s\n' "$description" "$output" >&2
+    return 1
+  fi
+  printf 'self-test: the census accepts %s.\n' "$description"
+}
+
+self_test_census() {
+  local scratch=$1
+  local tree=$scratch/census
+  local failures=0
+  local registered=rs/crates/f2z-codec/Cargo.toml
+
+  stage_tree "$tree"
+
+  mkdir -p "$tree/rs/crates/scratch" "$tree/wallet/scratch-crate" "$tree/z/vendored/crate"
+  printf '[package]\nname = "scratch"\nversion = "0.0.0"\n' \
+    > "$tree/rs/crates/scratch/Cargo.toml"
+  printf '[package]\nname = "wallet-scratch"\nversion = "0.0.0"\n' \
+    > "$tree/wallet/scratch-crate/Cargo.toml"
+  printf '[package]\nname = "vendored"\nversion = "0.0.0"\n' \
+    > "$tree/z/vendored/crate/Cargo.toml"
+  printf '[toolchain]\nchannel = "9.99.9"\n' \
+    > "$tree/wallet/scratch-crate/rust-toolchain.toml"
+  # A virtual workspace root: no [package], so there is no rust-version to pin
+  # and nothing to register. Recognised by that structure, not by its path.
+  printf '[workspace]\nresolver = "3"\nmembers = ["crates/*"]\n' > "$tree/rs/Cargo.toml"
+
+  self_test_census_case "$tree" \
+    'a new crate under rs/ that nobody registered' \
+    reject rs/crates/scratch/Cargo.toml \
+    "$registered"$'\n''rs/crates/scratch/Cargo.toml' ||
+    failures=$((failures + 1))
+
+  self_test_census_case "$tree" \
+    'a new crate under wallet/ that nobody registered' \
+    reject wallet/scratch-crate/Cargo.toml \
+    "$registered"$'\n''wallet/scratch-crate/Cargo.toml' ||
+    failures=$((failures + 1))
+
+  self_test_census_case "$tree" \
+    'a second rust-toolchain.toml that nobody registered' \
+    reject wallet/scratch-crate/rust-toolchain.toml \
+    "$registered"$'\n''wallet/scratch-crate/rust-toolchain.toml' ||
+    failures=$((failures + 1))
+
+  self_test_census_case "$tree" \
+    'a listing of nothing at all (the census gone blind)' \
+    reject 'gone blind' '' ||
+    failures=$((failures + 1))
+
+  self_test_census_case "$tree" \
+    'a registered crate manifest' \
+    accept '' "$registered" ||
+    failures=$((failures + 1))
+
+  self_test_census_case "$tree" \
+    'a virtual workspace root that declares no [package]' \
+    accept '' "$registered"$'\n''rs/Cargo.toml' ||
+    failures=$((failures + 1))
+
+  self_test_census_case "$tree" \
+    'the source of truth itself, which is registered by being it' \
+    accept '' "$registered"$'\n'"$TOOLCHAIN_FILE" ||
+    failures=$((failures + 1))
+
+  self_test_census_case "$tree" \
+    'a vendored crate under z/, whose MSRV is upstream to decide' \
+    accept '' "$registered"$'\n''z/vendored/crate/Cargo.toml' ||
+    failures=$((failures + 1))
+
+  return "$failures"
 }
 
 # --- self-test: a second Rust tree -------------------------------------------


### PR DESCRIPTION
Closes #553

## The finding: three of four scripts discover a new crate, the toolchain check did not

Throwaway `rs/crates/scratch/Cargo.toml` with no `rust-version` and no `license`, tracked, run against the **unmodified** scripts on `main`:

| Script | Sees it? | Verdict |
|---|---|---|
| `check-rust-fmt.sh --root rs` | yes | **RED** — `4 crate(s) are not formatted: rs/. rs/crates/f2z-codec rs/crates/f2z-relay-proto rs/crates/scratch` |
| `check-rust-clippy.sh --root rs` | yes | **RED** — `2 crate(s) failed the clippy gate: rs/. rs/crates/scratch` |
| `check-rust-deny.sh --root rs --config rs/deny.toml` | yes | **RED** — `error[unlicensed]: scratch = 0.0.0 is unlicensed` |
| `check-rust-toolchain.sh` (with rs.yml's exact flags) | **no** | **GREEN and blind** |

Raw:

```
############ 1. check-rust-toolchain.sh (UNMODIFIED, rs.yml flags) ############
note: 1 Rust compiler selection(s) intentionally follow the stable channel (upstream canaries).
Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.97.1, MSRV 1.97.
exit=0
############ toolchain BARE ############
note: 1 Rust compiler selection(s) intentionally follow the stable channel (upstream canaries).
Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.97.1, MSRV 1.97.
exit=0
```

Two honesty notes, because "seen" and "red" are not the same word:

- The clippy row goes red on the deliberately unformatted `src/lib.rs`, and the crate opted into `[lints] workspace = true`. Discovery (`==> cargo clippy -- rs/crates/scratch`) happened regardless.
- The deny row needed `rs/Cargo.lock` regenerated first (`--locked` otherwise fails on the unknown workspace member, which is *also* discovery, just a less interesting message). With the lock updated it is the real `error[unlicensed]`.

The same contrast holds in the wallet tree: `wallet/scratch-crate/Cargo.toml` → `check-rust-fmt.sh` says `1 crate(s) are not formatted: wallet/scratch-crate`; the toolchain check said nothing.

## Red → green, after

Same two throwaway crates, tracked, against this branch:

```
###### NEW check, bare, throwaway crates still tracked ######
drift: rs/crates/scratch/Cargo.toml declares [package] but is registered nowhere, so nothing holds its rust-version to wallet/rust-toolchain.toml. Add it to MANIFESTS in scripts/check-rust-toolchain.sh
drift: wallet/scratch-crate/Cargo.toml declares [package] but is registered nowhere, so nothing holds its rust-version to wallet/rust-toolchain.toml. Add it to MANIFESTS in scripts/check-rust-toolchain.sh
2 pin(s) disagree with wallet/rust-toolchain.toml (channel 1.97.1, MSRV 1.97).
exit=1
```

Register both, and the *next* thing it demands is the MSRV that was the whole point:

```
###### registered, but no rust-version ######
drift: rs/crates/scratch/Cargo.toml does not declare rust-version
drift: wallet/scratch-crate/Cargo.toml does not declare rust-version
exit=1

###### registered + correct MSRV ######
Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.97.1, MSRV 1.97.
exit=0

###### now drift the MSRV ######
drift: rs/crates/scratch/Cargo.toml declares rust-version = "1.90", expected "1.97" (the MSRV form of channel 1.97.1)
exit=1
```

A second, unregistered `rust-toolchain.toml` is caught the same way:

```
drift: wallet/scratch-crate/rust-toolchain.toml is an unregistered Rust toolchain file; nothing holds it to wallet/rust-toolchain.toml. Add it to TOOLCHAIN_RESTATEMENTS in scripts/check-rust-toolchain.sh
```

Both throwaway crates were removed before committing; the diff is 4 files (`scripts/check-rust-toolchain.sh`, `.github/workflows/rs.yml`, `AGENTS.md`, `rs/README.md`) and `git status --porcelain` was clean of them.

## Where the check lives, and why

**Inside `scripts/check-rust-toolchain.sh`, in `run_checks`** — so it is gate-bound the moment it exists. `zuuli.yml`'s always-running `changes` job already invokes the script under its own `Verify the Rust toolchain pin has not drifted` step (`zuuli.yml:53-56`), before change detection, on every event. **No edit to that job's contended `Verify immutable actions and fail-closed required jobs` step**, so no collision with #556. `rs.yml:72` runs the same script under `rs / gate`.

## No workflow YAML parsing — the registry moved instead

The stated constraint was that the check must see the `--manifest` flags the *workflows* pass. Parsing `.github/workflows/*.yml` from a bash script would be the fragile way to do that. The cleaner shape is to make the question not arise:

`rs/crates/f2z-codec`, `rs/crates/f2z-relay-proto` and `rs/rust-toolchain.toml` moved from `rs.yml`'s flags into the script's own `MANIFESTS` / `TOOLCHAIN_RESTATEMENTS` arrays. **A flag in one workflow is not a registration**, and the census makes that concrete rather than rhetorical — the bare invocation the required ZUULI gate runs passes no flags at all:

```
### registered ONLY by a --manifest flag (as rs.yml used to do) ###
Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.97.1, MSRV 1.97.
exit=0

### the same tree, bare — what the required zuuli gate runs ###
drift: rs/crates/scratch/Cargo.toml declares [package] but is registered nowhere, so nothing holds its rust-version to wallet/rust-toolchain.toml. Add it to MANIFESTS in scripts/check-rust-toolchain.sh
exit=1
```

So flag-only registration cannot be how a crate gets registered — it fails the required gate — and there is nothing left in a workflow for the script to need to read. `--manifest` / `--toolchain-file` survive for ad-hoc local runs and for the synthetic second tree in `--self-test`.

`rs.yml`'s step is now the bare invocation. That is a **deletion** in an uncontended workflow, not an addition, and `check-github-actions-pins.mjs` asserts no ordered command list for it (verified: no assertion anywhere on that step or on `rs.yml`'s toolchain flags).

## No exclusion list

The issue suggested "a small explicit exclusion list for genuine non-crates … recognised structurally rather than by path if you can". It can be, so there is **no list at all**: a manifest is subject to the census iff it declares a `[package]` table. `rs/Cargo.toml` is excused because it is `[workspace]`-only and has no `rust-version` to pin — nothing to widen later to excuse a real crate. Vendored sources under `z/` are upstream's MSRV to decide and stop at the prefix (they are submodules, so the superproject index does not list their contents anyway).

The input is `git ls-files -- '*Cargo.toml' '*rust-toolchain.toml'`, not a filesystem walk, so `target/`, scratch checkouts and build artefacts cannot inflate or distract it. An empty enumeration fails closed (`the registration census has gone blind`).

## Census matched the issue exactly

```
$ git ls-tree -r --name-only origin/main | grep 'Cargo.toml$' | grep -v '^z/'
rs/Cargo.toml
rs/crates/f2z-codec/Cargo.toml
rs/crates/f2z-relay-proto/Cargo.toml
wallet/plugins/tauri-plugin-zcash/Cargo.toml
wallet/zuuallet/src-tauri/Cargo.toml
wallet/zuuli/crypto-target-spike/Cargo.toml
wallet/zuuli/src-tauri/Cargo.toml
wallet/zuuli/wasm-spike/Cargo.toml
```

Eight, as stated. Nothing new had landed.

## Self-test: 8 new controls, each broken and watched fail

```
self-test: the census rejects a new crate under rs/ that nobody registered.
self-test: the census rejects a new crate under wallet/ that nobody registered.
self-test: the census rejects a second rust-toolchain.toml that nobody registered.
self-test: the census rejects a listing of nothing at all (the census gone blind).
self-test: the census accepts a registered crate manifest.
self-test: the census accepts a virtual workspace root that declares no [package].
self-test: the census accepts the source of truth itself, which is registered by being it.
self-test: the census accepts a vendored crate under z/, whose MSRV is upstream to decide.
```

Each case asserts on the verdict **and** the path the verdict names, so a census that rejected the wrong file would not pass a bare "it failed" assertion. Then eight mutations of the census itself, one at a time, each confirmed to land on the intended line before judging:

| Mutation | Case(s) reported |
|---|---|
| M1 `fail` → `:` for unregistered manifests | `the census accepted a new crate under rs/…` + `…under wallet/…` |
| M2 `fail` → `:` for unregistered toolchain files | `the census accepted a second rust-toolchain.toml…` |
| M3 `(( seen > 0 ))` → `(( 1 > 0 ))` | `the census accepted a listing of nothing at all…` |
| M4 `grep -qE '^[[:space:]]*\[package\]'` → `grep -qE "^"` | `the census rejected a virtual workspace root that declares no [package]` |
| M5 `contains "$rel" …` → `contains "NOT-A-REAL-PATH" …` | all four accept cases, + the unmodified tree stops passing |
| M6 `$VENDORED_PREFIX` → `NO_SUCH_PREFIX/` | `the census rejected a vendored crate under z/…` |
| M7 `registered_toolchains=("$TOOLCHAIN_FILE")` → `("NOT_THE_SOURCE")` | `the census rejected the source of truth itself…`, + the unmodified tree stops passing |
| M8 message says `a manifest` instead of `$rel` | `…rejected a new crate under rs/ **without naming** rs/crates/scratch/Cargo.toml` (×2) |

M5 and M7 also break the real tree, so the self-test aborts at its `the unmodified tree must pass` gate; the rows above were obtained by additionally lifting that early `return 1` so the census cases still ran, and both reported their specific case. M8 is the control that the *message* is load-bearing, not just the exit code.

Full run, everything green: 14 drift cases + 8 census cases + 4 second-tree cases.

## #477 shell hygiene

**Bare `[[ ]]` statements added: 0.** Every bracket expression added is the condition of an `if`:

```
$ git diff -U0 scripts/check-rust-toolchain.sh | grep '^+' | grep '\[\['
+    if [[ -z $rel ]]; then
+    if [[ $rel == "$VENDORED_PREFIX"* ]]; then
+    if [[ $base == rust-toolchain.toml ]]; then
+    if [[ ! -f "$root/$rel" ]]; then
+    if ! grep -qE '^[[:space:]]*\[package\]' "$root/$rel"; then
+    if [[ $expect == reject ]]; then
+    if [[ $output != *"$needle"* ]]; then
```

Added `(( ))`: `(( ${#TOOLCHAIN_RESTATEMENTS[@]} > 0 ))`, `(( raised == 0 ))`, `(( raised != 0 ))` — all `if` conditions; `(( seen > 0 )) || fail …` — enforcing `||`; and `x=$((x + 1))` assignments, which always return 0 (deliberately not `((x++))`, which returns 1 when the old value is 0).

Everything above was run on **`GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)`**, invoked as `/bin/bash`, not zsh and not a modern bash. `bash -n` clean; `shellcheck -S warning` reports only the pre-existing SC1007 on `CDPATH= cd` at line 40.

## Other checks

| Check | Result |
|---|---|
| `check-rust-toolchain.sh` (bare) | pass |
| `check-rust-toolchain.sh --self-test` | pass, 14 + 8 + 4 cases |
| `--print-channel` / `--print-msrv` / `--print-targets` | `1.97.1` / `1.97` / `wasm32-unknown-unknown` |
| `check-rust-fmt.sh --root rs` | `All 3 Rust crate(s) under rs/ are formatted (rustfmt from 1.97.1).` |
| `check-rust-clippy.sh --root rs` | `All 3 Rust crate(s) under rs/ are clippy-clean (clippy from 1.97.1).` |
| `check-rust-deny.sh --root rs --config rs/deny.toml` | `All 3 Rust crate(s) under rs/ satisfy rs/deny.toml.` |
| `node scripts/check-github-actions-pins.mjs --self-test` | `70 source-policy, 7 gate-verdict, and 99 current-workflow mutation case(s) passed.` |
| `node scripts/check-github-actions-pins.mjs` | pass (178 external references, 15 files) |
| `node scripts/check-workflow-gates.mjs --self-test` | `20 case(s) passed.` |
| `node scripts/check-workflow-gates.mjs` | pass (2 gates, 56 jobs, 14 workflow files) |
| `node scripts/check-zuuli-linux-image.mjs` | pass |
| `scripts/check-public-repo-boundary.sh` | pass |

`rs/deny.toml` is **untouched** (`git diff --stat rs/deny.toml` empty) — the `akd` / `akd_core` `<0.13.0` bans and the `akd_mysql` ban are all still present verbatim.

## Docs

`AGENTS.md` and `rs/README.md` both described the gap; `rs/README.md`'s four-script table said the toolchain row was **GREEN and blind** and told contributors to add a `--manifest` flag to `rs.yml` per crate. Both now describe the census and the new registration path, and the table's fourth row is red with the message the check actually prints.
