### PR TITLE
test(zuuli): mutation-prove git fixture teardown guards

### DIFF
--- a/wallet/zuuli/scripts/store-screenshot-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/store-screenshot-contract.node-test.mjs
@@ -111,6 +111,7 @@ test("fixture git children disable automatic gc and maintenance", async (t) => {
   await writeFile(emptyGlobalConfig, "");
   const isolatedEnv = {
     ...process.env,
+    GIT_CONFIG_COUNT: "0",
     GIT_CONFIG_NOSYSTEM: "1",
     GIT_CONFIG_GLOBAL: emptyGlobalConfig,
   };
@@ -142,6 +143,57 @@ test("git fixture teardown exhausts deterministic ENOTEMPTY races before succeed
   assert.equal(attempts, 11);
   assert.deepEqual(pauses, [50, 100, 150, 200, 250, 300, 350, 400, 450, 500]);
   await assert.rejects(() => readFile(resolve(root, "fixture")), { code: "ENOENT" });
+});
+
+test("git fixture teardown rejects a non-ENOTEMPTY error immediately and unchanged", async () => {
+  const injectedError = new Error("injected permission failure");
+  injectedError.code = "EACCES";
+  let attempts = 0;
+  const pauses = [];
+
+  await assert.rejects(
+    () => removeGitFixture("unused", {
+      remove: async () => {
+        attempts += 1;
+        throw injectedError;
+      },
+      pause: async (milliseconds) => pauses.push(milliseconds),
+    }),
+    (error) => {
+      assert.equal(error, injectedError);
+      return true;
+    },
+  );
+
+  assert.equal(attempts, 1);
+  assert.deepEqual(pauses, []);
+});
+
+test("git fixture teardown rejects the eleventh consecutive ENOTEMPTY after ten pauses", async () => {
+  const injectedError = new Error("injected persistent directory race");
+  injectedError.code = "ENOTEMPTY";
+  let attempts = 0;
+  const pauses = [];
+
+  await assert.rejects(
+    () => removeGitFixture("unused", {
+      remove: async () => {
+        attempts += 1;
+        throw injectedError;
+      },
+      pause: async (milliseconds) => {
+        pauses.push(milliseconds);
+        assert.ok(pauses.length <= 10, "retry limit allowed an eleventh pause");
+      },
+    }),
+    (error) => {
+      assert.equal(error, injectedError);
+      return true;
+    },
+  );
+
+  assert.equal(attempts, 11);
+  assert.deepEqual(pauses, [50, 100, 150, 200, 250, 300, 350, 400, 450, 500]);
 });
 
 async function preflight(env) {

--- a/wallet/zuuli/scripts/store-screenshot-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/store-screenshot-contract.node-test.mjs
@@ -5,6 +5,7 @@ import { cp, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/pr
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import test from "node:test";
+import { setTimeout as wait } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import {
   CAPTURE_CONFIG_PATH,
@@ -78,20 +79,70 @@ const GIT_FIXTURE_ENV = Object.freeze({
 // Backstop for the same failure class: `fs.rm` defaults to `maxRetries: 0`, and
 // `force` suppresses ENOENT, not ENOTEMPTY. Retrying absorbs any future
 // concurrent writer the env guard above does not already prevent.
-function removeGitFixture(root) {
-  return rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+async function removeGitFixture(root, { remove = rm, pause = wait } = {}) {
+  let retries = 0;
+  for (;;) {
+    try {
+      await remove(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (error?.code !== "ENOTEMPTY" || retries >= 10) throw error;
+      retries += 1;
+      await pause(50 * retries);
+    }
+  }
 }
 
-async function git(root, args) {
+async function git(root, args, baseEnv = process.env) {
   const output = [];
   await new Promise((accept, reject) => {
-    const child = spawn("git", args, { cwd: root, env: { ...process.env, ...GIT_FIXTURE_ENV } });
+    const child = spawn("git", args, { cwd: root, env: { ...baseEnv, ...GIT_FIXTURE_ENV } });
     child.stdout.on("data", (chunk) => output.push(chunk));
     child.on("error", reject);
     child.on("exit", (code) => code === 0 ? accept() : reject(new Error(`git ${args[0]} failed`)));
   });
   return Buffer.concat(output).toString("utf8").trim();
 }
+
+test("fixture git children disable automatic gc and maintenance", async (t) => {
+  const root = await mkdtemp(resolve(tmpdir(), "zuuli-git-config-contract-"));
+  t.after(() => removeGitFixture(root));
+  const emptyGlobalConfig = resolve(root, "empty-global-gitconfig");
+  await writeFile(emptyGlobalConfig, "");
+  const isolatedEnv = {
+    ...process.env,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: emptyGlobalConfig,
+  };
+
+  await git(root, ["init", "-q"], isolatedEnv);
+  assert.equal(await git(root, ["config", "--default", "missing", "--get", "gc.auto"], isolatedEnv), "0");
+  assert.equal(await git(root, ["config", "--default", "missing", "--get", "maintenance.auto"], isolatedEnv), "false");
+});
+
+test("git fixture teardown exhausts deterministic ENOTEMPTY races before succeeding", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "zuuli-git-remove-contract-"));
+  await writeFile(resolve(root, "fixture"), "present\n");
+  let attempts = 0;
+  const pauses = [];
+
+  await removeGitFixture(root, {
+    remove: async (...args) => {
+      attempts += 1;
+      if (attempts <= 10) {
+        const error = new Error(`injected directory race on attempt ${attempts}`);
+        error.code = "ENOTEMPTY";
+        throw error;
+      }
+      await rm(...args);
+    },
+    pause: async (milliseconds) => pauses.push(milliseconds),
+  });
+
+  assert.equal(attempts, 11);
+  assert.deepEqual(pauses, [50, 100, 150, 200, 250, 300, 350, 400, 450, 500]);
+  await assert.rejects(() => readFile(resolve(root, "fixture")), { code: "ENOENT" });
+});
 
 async function preflight(env) {
   await new Promise((accept, reject) => {


### PR DESCRIPTION
Closes #596

## What changed

- Exercise the real fixture `git(...)` child and ask Git itself for `gc.auto` and `maintenance.auto` under an isolated empty system/global configuration. The isolated base environment explicitly resets `GIT_CONFIG_COUNT=0`; the production spread must then supply literal `0` and `false`. Assertions do not read `GIT_FIXTURE_ENV`.
- Make fixture removal retries explicit and narrowly injectable. Production permits only 10 `ENOTEMPTY` retries with 50 ms linear backoff.
- Prove deterministic success after ten injected `ENOTEMPTY` races, immediate unchanged rejection of injected `EACCES`, and unchanged rejection of persistent `ENOTEMPTY` on attempt 11 after exactly ten pauses. Tests inspect behavior, not options, and do not race timers.

## Exact integrated-base mutation proof

Normal-merged exact `origin/main` base `06193aee60b9735d697114d1652a382e7dc70671` (#611). No force-push. Exact tested and pushed head: `ef1812f89e3771503d957f5f6446a5ca2682d632`.

Each guard was mutated independently on this integrated tree, observed red, and restored before green verification:

1. Remove production `...GIT_FIXTURE_ENV`: exit `1`; actual `missing` differs from required `0`.
2. Zero retry allowance (`retries >= 10` -> `retries >= 0`): exit `1`; attempt 1 rejects `ENOTEMPTY`.
3. Zero retry delay (`50 * retries` -> `0 * retries`): exit `1`; ten zero pauses differ from `[50, 100, ..., 500]`.
4. Remove non-`ENOTEMPTY` rejection (`error?.code !== "ENOTEMPTY" ||`): exit `1`; attempts `11 !== 1`, proving `EACCES` was wrongly retried.
5. Remove retry cap (`|| retries >= 10`): exit `1`; forbidden eleventh pause and rejection no longer preserves the exact persistent `ENOTEMPTY` error.

All five mutants were independently restored. Index and worktree are clean.

## Restored-green verification on exact head

- Focused Git/teardown controls — 4/4.
- Node `24.18.0`: `npm run test:store-listing` — 60/60.
- GitHub Actions policy — 74 source, 7 gate-verdict, 129 current-workflow mutation cases; live green.
- Workflow topology — 20/20; live green (2 gates, 56 jobs, 14 workflows).
- Hash-domain labels — 17/17; live green across #611's E2EE documentation.
- Rust toolchain — 14 drift controls plus census/second-tree controls; live green.
- CI cache policy — 7/7; live green.
- `git diff --check`; clean index/worktree after restore.

Ready under the active sole-candidate lock; do not introduce another train candidate until this PR resolves.
