### PR TITLE
feat(rs): add f2z-relay-testkit, the FakeRelay

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -75,7 +75,8 @@ jobs:
           scripts/check-rust-toolchain.sh \
             --toolchain-file rs/rust-toolchain.toml \
             --manifest rs/crates/f2z-codec/Cargo.toml \
-            --manifest rs/crates/f2z-relay-proto/Cargo.toml
+            --manifest rs/crates/f2z-relay-proto/Cargo.toml \
+            --manifest rs/crates/f2z-relay-testkit/Cargo.toml
 
       - name: Detect changes under rs/
         id: filter
@@ -293,6 +294,11 @@ jobs:
       # rather than `--workspace` so that a future server binary — which will be
       # AGPL, will pull tokio, and will never reach a browser — does not
       # silently join the wasm build and then fail it.
+      #
+      # f2z-relay-testkit is deliberately absent for exactly that reason: it
+      # opens sockets, spawns tasks and reads a clock, and a test harness that
+      # could reach the browser build would be a test harness that could end up
+      # in the shipped bundle.
       - name: Build the client-linked crates for the browser target
         working-directory: rs
         run: |

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -57,10 +57,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cpufeatures"
@@ -114,8 +137,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "digest"
@@ -135,6 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid",
  "crypto-common 0.2.2",
 ]
 
@@ -191,6 +221,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "f2z-relay-testkit"
+version = "0.1.0"
+dependencies = [
+ "f2z-codec",
+ "f2z-relay-proto",
+ "futures-util",
+ "tls_codec",
+ "tokio",
+ "tokio-tungstenite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +249,37 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -239,7 +312,24 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
@@ -249,6 +339,12 @@ checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
@@ -261,6 +357,23 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "num-traits"
@@ -276,6 +389,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "ppv-lite86"
@@ -305,7 +424,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -348,7 +467,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -358,7 +488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -371,12 +501,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -426,6 +562,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +590,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +616,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -473,6 +647,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "tls_codec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,7 +684,61 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "sha1",
+ "thiserror",
 ]
 
 [[package]]
@@ -525,6 +773,12 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -573,7 +827,7 @@ checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -593,5 +847,5 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]

--- a/rs/README.md
+++ b/rs/README.md
@@ -76,7 +76,8 @@ decided is `wallet/rust-toolchain.toml`, and
 ```
 scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
                                 --manifest rs/crates/f2z-codec/Cargo.toml \
-                                --manifest rs/crates/f2z-relay-proto/Cargo.toml
+                                --manifest rs/crates/f2z-relay-proto/Cargo.toml \
+                                --manifest rs/crates/f2z-relay-testkit/Cargo.toml
 ```
 
 fails the pull request the moment the two disagree. `.github/workflows/rs.yml`
@@ -110,8 +111,9 @@ prevent.
 |---|---|
 | [`crates/f2z-codec`](./crates/f2z-codec) | The canonical encoding layer of `WIRE.md`: `tls_codec` wrappers for every wire structure, the domain-separated signing transcript (§5), the redacting newtypes, and the padding-bucket validator (§9). `no_std` + `alloc`, `#![forbid(unsafe_code)]`, no I/O, no async runtime, and it builds for `wasm32-unknown-unknown`. |
 | [`crates/f2z-relay-proto`](./crates/f2z-relay-proto) | The protocol layer above it: signed-command construction and verification in §5.1's exact order, the timestamp window and fail-closed seen-set (§5.5), the queue lifecycle and ACK arithmetic (§7, §8), the capability document (§11), the `HELLO` proof of possession (§5.2), and §4.3's typed in-flight window. Same constraints — `no_std` + `alloc`, no I/O, no clock, no randomness, and it builds for `wasm32-unknown-unknown`. |
+| [`crates/f2z-relay-testkit`](./crates/f2z-relay-testkit) | **FakeRelay**: a spec-conforming relay a client can develop against before `f2z-relay` exists, over an in-process pipe *and* a real `ws://127.0.0.1:0` listener running the same implementation, plus fault injection and a conformance vector suite the real relay will later be run against unchanged. Also ships the `f2z-fakerelay` binary and `rs/deploy/docker-compose.dev.yml`. **Native only** — it opens sockets, spawns tasks and reads a clock, and is deliberately absent from the `wasm32` job. |
 
-**The relay and the clients link both.** That is the licence boundary in
+**The relay and the clients link the first two.** That is the licence boundary in
 practice: everything here is MIT because a third-party relay, ZUULI and the WASM
 web client all compile the same rules, and a rule that two implementations
 disagree about is how ciphertext gets deleted before it is read.
@@ -135,7 +137,14 @@ reasons, and each is enforced by a test rather than by intent:
 cd rs
 cargo test
 cargo build --target wasm32-unknown-unknown --lib -p f2z-codec -p f2z-relay-proto
+
+# A relay endpoint for a client developer, in one command.
+cargo run -p f2z-relay-testkit --bin f2z-fakerelay
 ```
+
+`f2z-relay-testkit` is **not** on the `wasm32` line above, and that absence is
+the rule rather than an oversight: a test harness that could reach the browser
+build is a test harness that could end up in the shipped bundle.
 
 The gates are the repository's shared scripts, pointed here with `--root`:
 

--- a/rs/crates/f2z-relay-testkit/Cargo.toml
+++ b/rs/crates/f2z-relay-testkit/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "f2z-relay-testkit"
+version = "0.1.0"
+description = "FakeRelay: a spec-conforming, fault-injecting free2z relay for client development (docs/e2ee/WIRE.md v1)"
+edition.workspace = true
+# A restatement of wallet/rust-toolchain.toml's channel in Cargo's MSRV form,
+# registered with `scripts/check-rust-toolchain.sh --manifest` so it cannot
+# drift. Not inherited from the workspace: that check reads this literal line.
+rust-version = "1.97"
+# Permissive, deliberately and explicitly. A test harness is linked by client
+# test suites — ZUULI's, the web client's, and any third party's — so it sits on
+# the same side of the boundary as the crates it exercises. The AGPL-3.0
+# boundary starts at the real server binaries, and `f2z-fakerelay` is not one:
+# it stores nothing durably, it is refused a non-loopback bind, and it exists to
+# be linked into other people's tests. Stated literally rather than inherited so
+# it is visible to anyone opening the crate. rs/deny.toml enforces it.
+license = "MIT"
+repository.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+f2z-codec = { path = "../f2z-codec", version = "0.1.0" }
+# `version` beside `path` is not redundant: rs/deny.toml sets
+# `wildcards = "deny"`, and a bare path dependency is a wildcard requirement.
+f2z-relay-proto = { path = "../f2z-relay-proto", version = "0.1.0" }
+tls_codec = { workspace = true }
+# Native-only, on purpose. This crate is NOT on rs.yml's wasm32 line: it opens
+# sockets, spawns tasks and reads a clock, none of which a browser build of the
+# client core may ever pull in. Keeping it off that line is what stops a testkit
+# dependency from leaking into the shipped WASM bundle.
+tokio = { version = "1", features = [
+  "io-util",
+  "macros",
+  "net",
+  "rt",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }
+# The real WebSocket half of `WIRE.md` §2. The in-process transport cannot
+# exercise framing, ordering or reconnection, so the same relay is also served
+# over a real listener, and that needs a real RFC 6455 implementation rather
+# than one of ours.
+tokio-tungstenite = "0.30"
+# `BoxFuture` for the object-safe transport trait, and `SinkExt`/`StreamExt` for
+# the WebSocket stream. Already in tokio-tungstenite's graph.
+futures-util = { version = "0.3", default-features = false, features = [
+  "sink",
+  "std",
+] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }

--- a/rs/crates/f2z-relay-testkit/README.md
+++ b/rs/crates/f2z-relay-testkit/README.md
@@ -1,0 +1,188 @@
+# `f2z-relay-testkit` — the FakeRelay
+
+A spec-conforming free2z relay you can break on purpose, so a client can be
+built and tested **before `f2z-relay` exists**.
+
+It implements [`docs/e2ee/WIRE.md`](../../../docs/e2ee/WIRE.md) v1 §2 through
+§13 on top of `f2z-codec` (canonical encoding, framing, re-encode equality) and
+`f2z-relay-proto` (the signing transcript, anti-replay, queue and ACK rules, the
+capability document). Nothing in those two crates is reimplemented here — a
+conformance fake that held a second opinion about the protocol would be worse
+than none.
+
+## One command, one endpoint
+
+```sh
+cargo run -p f2z-relay-testkit --bin f2z-fakerelay
+# → ws://127.0.0.1:9944/relay/v1
+```
+
+or
+
+```sh
+cd rs/deploy && docker compose -f docker-compose.dev.yml up
+```
+
+## In a test
+
+```rust,no_run
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_testkit::fake::FakeRelay;
+
+# async fn example() -> Result<(), Box<dyn core::error::Error>> {
+let relay = FakeRelay::with_defaults()?;
+let mut bob = relay.client().await?;                      // in-process, no sockets
+let bob_key = SigningKey::from_seed(&[1u8; 32]);
+let queue = bob.create_queue(&bob_key, 0, 0, None).await?;
+
+let mut alice = relay.client().await?;
+let alice_key = SigningKey::from_seed(&[2u8; 32]);
+alice.bind_send(&alice_key, queue.send_addr).await?;
+alice.append(&alice_key, queue.send_addr, b"ciphertext").await?;
+
+let read = bob.read(&bob_key, queue.recv_addr, 0, 0, 0).await?;
+// …the durable local write happens HERE — WIRE.md §8.4's MUST — and only then:
+bob.ack(&bob_key, queue.recv_addr, 0).await?;
+# Ok(())
+# }
+```
+
+Over a real socket instead, which is where framing and ordering bugs actually
+appear:
+
+```rust,no_run
+# async fn example() -> Result<(), Box<dyn core::error::Error>> {
+# use f2z_relay_testkit::{fake::FakeRelay, client::Client, websocket};
+let relay = FakeRelay::with_defaults()?;
+let server = relay.listen_loopback().await?;              // ws://127.0.0.1:0
+let transport = websocket::connect(&server.url()).await?;
+let mut client = Client::connect(transport, relay.client_config()).await?;
+# Ok(())
+# }
+```
+
+## Breaking it on purpose
+
+Under delete-on-ack the failure paths are where data loss lives. A client that
+gets `APPEND` and `READ` right and gets a **dropped `ACK` response** wrong will
+lose messages in production and pass every test that only ever sees a healthy
+relay.
+
+```rust,no_run
+# use std::time::Duration;
+# use f2z_codec::{ErrorCode, commands::Command};
+# use f2z_relay_testkit::faults::{Effect, Fault, PolicyFaults, Trigger};
+# fn example(relay: &f2z_relay_testkit::fake::FakeRelay) {
+// The command runs; its answer never arrives. WIRE.md §2.5: unknown status.
+relay.faults().arm(Fault::once(Trigger::Command(Command::Ack), Effect::Drop));
+
+// §4.3: "a relay MAY complete a cheap PING before an expensive READ … and will"
+relay.faults().arm(Fault::once(Trigger::Command(Command::Read), Effect::Reorder));
+
+// §10: every code, including the ones a healthy relay never emits.
+relay.faults().arm(Fault::once(
+    Trigger::Command(Command::Append),
+    Effect::Refuse(ErrorCode::Backpressure),
+));
+
+// §7.7: expire a seven-day TTL now. §13.1: hit a quota. §5.5 + #586: publish a
+// capability document a conforming client must refuse.
+relay.faults().set_policy(PolicyFaults {
+    expire_messages_after: Some(Duration::ZERO),
+    max_queue_messages: Some(1),
+    unsound_antireplay_window: true,
+    ..PolicyFaults::default()
+});
+# }
+```
+
+Faults make the relay behave **worse** than the specification allows, in ways a
+real relay or a real network can. They are not the same as
+`config::Relaxations`, which make it **accept** something a conforming relay
+would reject — the single most dangerous thing a test double can do. Every
+relaxation is opt-in, off by default, and named after the rule it suspends.
+
+## The conformance suite
+
+`vectors::suite()` is a set of `(input, expected output)` cases driven through
+the ordinary client API against an `Endpoint`. Three targets:
+
+```rust,no_run
+# use std::sync::Arc;
+# use f2z_relay_testkit::{fake::{Endpoint, FakeRelay, WebSocketEndpoint}, vectors};
+# async fn example() -> Result<(), Box<dyn core::error::Error>> {
+let relay = FakeRelay::with_defaults()?;
+
+// 1. in-process
+let report = vectors::run(Arc::new(relay.in_process_endpoint())).await;
+
+// 2. this crate's own ws:// listener
+let server = relay.listen_loopback().await?;
+let report = vectors::run(Arc::new(relay.websocket_endpoint(&server))).await;
+
+// 3. the real relay, later, with this file unchanged
+let report = vectors::run(Arc::new(WebSocketEndpoint::new(
+    "wss://relay.example/relay/v1",
+)))
+.await;
+println!("{}", report.summary());
+# Ok(())
+# }
+```
+
+A vector that needs to break the relay declares `Needs::Faults` or
+`Needs::Clock` and reports **skipped** against a target with no such handle —
+never passed. `tests/conformance.rs` additionally runs the suite against the
+in-process and WebSocket transports and asserts the verdicts are identical,
+which is what makes "both transports run the same implementation" a check
+rather than a claim.
+
+## `f2z-fakerelay` is not a relay
+
+Three properties make deploying it a security incident rather than a mistake,
+and all three are published in the signed capability document it serves:
+
+| Property | What `WIRE.md` requires | Why it is this way |
+|---|---|---|
+| Queue addresses are **predictable** | §7.1: from the relay's own CSPRNG, unpredictable so they cannot be squatted | A conformance vector that produced different addresses each run would not be a vector |
+| Serves **`ws://`** | §2.1: `wss://` only | No certificate, no trust decision; taken honestly as §2.3's `--insecure-listen` case, published as `transport_security: none` and `channel_binding_mode: none` |
+| **Nothing is durable** | §8.4 publishes `durability_mode`; this is `memory` | It is a `BTreeMap` that dies with the process |
+
+§2.3's binding rule is enforced, not printed: a non-loopback bind is refused
+unless `--insecure-listen` is typed, and typing it prints the three obligations
+§2.3 attaches to the override.
+
+A conforming client **refuses** this relay unless it opts in per relay:
+
+```rust,no_run
+# use f2z_relay_proto::capabilities::ClientPolicy;
+let policy = ClientPolicy { allow_insecure_transport: true, ..ClientPolicy::default() };
+```
+
+That refusal is §2.3 obligation 3 working as designed. A client author should
+see it fail before they see it pass.
+
+## Known gaps
+
+- **The `.well-known` capability document of §11.2 is not served.** The document
+  is available over the protocol (`GET_CAPABILITIES`) and its digest is
+  comparable against `HELLO` (`capabilities::check_digest`), but the plain-HTTPS
+  JSON representation is not. Serving it would mean adding an HTTP parser beside
+  the WebSocket one, which is the second parser §2.2 argues against, for an
+  affordance aimed at humans rather than at clients. A client's "fetch the
+  well-known copy and compare digests" path therefore cannot be exercised
+  against this harness.
+- **`queue_creation_mode: token` is not implemented.** §13.1 defines it as an
+  operator-issued bearer credential and gives it no protocol shape in v1;
+  configuring it is refused at construction rather than faked.
+- **The channel binding is not a TLS exporter.** `ChannelBindingSource::Simulated`
+  hands both ends a constant so the §5.3 exporter code path is reachable, but it
+  binds a signature to *this configuration*, not to a TLS session. A passing test
+  there is not evidence about RFC 8446 §7.5.
+
+## Licence
+
+MIT, like `f2z-codec` and `f2z-relay-proto`, and for the same reason: client
+test suites link it. The AGPL-3.0 boundary starts at the real server binaries,
+and this is not one — it stores nothing, is refused a non-loopback bind, and
+exists to be linked into other people's tests.

--- a/rs/crates/f2z-relay-testkit/src/bin/f2z-fakerelay.rs
+++ b/rs/crates/f2z-relay-testkit/src/bin/f2z-fakerelay.rs
@@ -1,0 +1,310 @@
+//! `f2z-fakerelay` — a relay endpoint in one command, for client development.
+//!
+//! ```text
+//! cargo run -p f2z-relay-testkit --bin f2z-fakerelay
+//! # → ws://127.0.0.1:9944/relay/v1
+//! ```
+//!
+//! # Read this before pointing anything real at it
+//!
+//! **This is not a relay.** It is a conforming test double, and three of its
+//! properties make deployment a security incident rather than a mistake:
+//!
+//! 1. **Its addresses are predictable.** `WIRE.md` §7.1 requires queue
+//!    addresses from the relay's own CSPRNG, and §7.1's whole argument is that
+//!    a client cannot predict or squat them. This process derives them from a
+//!    seed with BLAKE2b in counter mode, so anyone who knows the seed — and the
+//!    default seed is a constant in this repository — knows every address it
+//!    will ever hand out.
+//! 2. **It serves `ws://`.** §2.1 admits `wss://` only. Everything except MLS
+//!    ciphertext — connection metadata, queue addresses, commands — travels in
+//!    the clear. That is published honestly as `transport_security: none` and
+//!    `channel_binding_mode: none`, and a conforming client refuses it without
+//!    an explicit per-relay opt-in (§2.3 obligation 3).
+//! 3. **It stores nothing durably.** `durability_mode: memory`. Every queue and
+//!    every message dies with the process.
+//!
+//! §2.3's binding rule is enforced rather than printed: a non-loopback address
+//! is refused unless `--insecure-listen` is typed, and typing it prints the
+//! three obligations §2.3 attaches to the override.
+
+use std::net::SocketAddr;
+use std::process::ExitCode;
+
+use f2z_relay_testkit::config::RelayConfig;
+use f2z_relay_testkit::fake::FakeRelay;
+use f2z_relay_testkit::faults::PolicyFaults;
+
+const DEFAULT_LISTEN: &str = "127.0.0.1:9944";
+
+const USAGE: &str = "\
+f2z-fakerelay — a spec-conforming FakeRelay over ws://, for client development.
+
+USAGE:
+    f2z-fakerelay [OPTIONS]
+
+OPTIONS:
+    --listen ADDR             Address to bind (default 127.0.0.1:9944).
+    --insecure-listen         Allow a non-loopback bind. WIRE.md §2.3 requires
+                              this to be an explicit act; it is refused
+                              otherwise, and the obligations are printed.
+    --pow                     Demand a proof-of-work stamp for queue creation
+                              (WIRE.md §13.1's default mode). The difficulty is
+                              deliberately trivial; see the crate docs.
+    --frozen-clock            Freeze the relay clock instead of following the
+                              host. Useful when driving TTLs from a script;
+                              a real client's timestamps will fall outside the
+                              window unless it reads GET_CHALLENGE(clock).
+    --seed HEX                32-byte hex seed for the address generator.
+    --identity-seed HEX       32-byte hex seed for the relay identity key.
+    --ping-interval-ms MS     WebSocket Ping interval (WIRE.md §2.4, default
+                              25000 in this binary).
+    --unsound-antireplay      Publish antireplay_window_ms below 2 x
+                              clock_skew_ms and enforce it — the capability
+                              document of https://github.com/free2z/zuu/issues/586,
+                              which the specification currently permits and a
+                              conforming client must refuse.
+    --backpressure            Start in WIRE.md §13.1 layer 4 global backpressure.
+    -h, --help                Print this and exit.
+";
+
+fn main() -> ExitCode {
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let options = match parse(&arguments) {
+        Ok(Some(options)) => options,
+        Ok(None) => {
+            print!("{USAGE}");
+            return ExitCode::SUCCESS;
+        }
+        Err(reason) => {
+            eprintln!("f2z-fakerelay: {reason}\n");
+            eprint!("{USAGE}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match run(options) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(reason) => {
+            eprintln!("f2z-fakerelay: {reason}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+struct Options {
+    listen: SocketAddr,
+    insecure_listen: bool,
+    pow: bool,
+    frozen_clock: bool,
+    seed: Option<[u8; 32]>,
+    identity_seed: Option<[u8; 32]>,
+    ping_interval_ms: u64,
+    unsound_antireplay: bool,
+    backpressure: bool,
+}
+
+fn parse(arguments: &[String]) -> Result<Option<Options>, String> {
+    let mut options = Options {
+        listen: DEFAULT_LISTEN
+            .parse()
+            .map_err(|_| "the built-in default address is unparseable".to_owned())?,
+        insecure_listen: false,
+        pow: false,
+        frozen_clock: false,
+        seed: None,
+        identity_seed: None,
+        // §2.4's published default. The library default is far shorter so tests
+        // do not wait 25 seconds to see a Ping; a binary a human runs should
+        // behave like the specification.
+        ping_interval_ms: 25_000,
+        unsound_antireplay: false,
+        backpressure: false,
+    };
+
+    let mut index = 0usize;
+    while let Some(argument) = arguments.get(index) {
+        index = index.saturating_add(1);
+        match argument.as_str() {
+            "-h" | "--help" => return Ok(None),
+            "--insecure-listen" => options.insecure_listen = true,
+            "--pow" => options.pow = true,
+            "--frozen-clock" => options.frozen_clock = true,
+            "--unsound-antireplay" => options.unsound_antireplay = true,
+            "--backpressure" => options.backpressure = true,
+            "--listen" => {
+                let value = value_of(arguments, &mut index, "--listen")?;
+                options.listen = value
+                    .parse()
+                    .map_err(|_| format!("--listen: {value} is not an address:port"))?;
+            }
+            "--seed" => {
+                let value = value_of(arguments, &mut index, "--seed")?;
+                options.seed = Some(parse_seed(&value)?);
+            }
+            "--identity-seed" => {
+                let value = value_of(arguments, &mut index, "--identity-seed")?;
+                options.identity_seed = Some(parse_seed(&value)?);
+            }
+            "--ping-interval-ms" => {
+                let value = value_of(arguments, &mut index, "--ping-interval-ms")?;
+                options.ping_interval_ms = value
+                    .parse()
+                    .map_err(|_| format!("--ping-interval-ms: {value} is not a number"))?;
+            }
+            other => return Err(format!("unknown option {other}")),
+        }
+    }
+    Ok(Some(options))
+}
+
+fn value_of(arguments: &[String], index: &mut usize, name: &str) -> Result<String, String> {
+    let value = arguments
+        .get(*index)
+        .ok_or_else(|| format!("{name} needs a value"))?;
+    *index = index.saturating_add(1);
+    Ok(value.clone())
+}
+
+fn parse_seed(text: &str) -> Result<[u8; 32], String> {
+    if text.len() != 64 {
+        return Err(format!("a seed is 64 hex characters, got {}", text.len()));
+    }
+    let mut seed = [0u8; 32];
+    let bytes = text.as_bytes();
+    for (slot, index) in seed.iter_mut().zip((0usize..64).step_by(2)) {
+        let pair = bytes
+            .get(index..index.saturating_add(2))
+            .and_then(|pair| std::str::from_utf8(pair).ok())
+            .ok_or_else(|| "a seed must be hex".to_owned())?;
+        *slot = u8::from_str_radix(pair, 16).map_err(|_| "a seed must be hex".to_owned())?;
+    }
+    Ok(seed)
+}
+
+fn run(options: Options) -> Result<(), String> {
+    let mut config = RelayConfig::default();
+    if !options.frozen_clock {
+        config = config.with_system_clock();
+    }
+    if options.pow {
+        config = config.with_pow();
+    }
+    if let Some(seed) = options.seed {
+        config.rng_seed = seed;
+    }
+    if let Some(seed) = options.identity_seed {
+        config.identity_seed = seed;
+    }
+    config.ping_interval = std::time::Duration::from_millis(options.ping_interval_ms);
+    config.policy_faults = PolicyFaults {
+        unsound_antireplay_window: options.unsound_antireplay,
+        global_backpressure: options.backpressure,
+        ..PolicyFaults::default()
+    };
+
+    let relay = FakeRelay::new(config).map_err(|error| error.to_string())?;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start the async runtime: {error}"))?;
+
+    runtime.block_on(async move {
+        let server = relay
+            .listen(options.listen, options.insecure_listen)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        announce(&relay, &server, &options);
+
+        // Serve until the process is signalled. There is no graceful-shutdown
+        // path on purpose: nothing here is durable, so there is nothing a
+        // graceful shutdown could preserve.
+        std::future::pending::<()>().await;
+        drop(server);
+        Ok(())
+    })
+}
+
+fn announce(
+    relay: &FakeRelay,
+    server: &f2z_relay_testkit::websocket::RelayServer,
+    options: &Options,
+) {
+    let published = relay.published_capabilities();
+    println!("f2z-fakerelay — a TEST DOUBLE. Do not deploy this.");
+    println!("  endpoint            {}", server.url());
+    println!(
+        "  relay_id            {}",
+        base64url(relay.relay_id().as_ref())
+    );
+    println!(
+        "  relay_identity_pk   {}",
+        base64url(relay.identity_key().as_ref())
+    );
+    println!("  protocol            WIRE.md v1, subprotocol free2z-relay.v1");
+    println!("  transport_security  none      (ws://, WIRE.md §2.3)");
+    println!("  channel_binding     none      (no TLS session to export from, §5.3)");
+    println!("  durability_mode     memory    (§8.4: an accepted APPEND may not survive)");
+    println!(
+        "  queue_creation      {}",
+        if options.pow { "pow" } else { "open" }
+    );
+    println!(
+        "  clock_skew_ms       {}   antireplay_window_ms {}",
+        published.clock_skew_ms, published.antireplay_window_ms
+    );
+    println!(
+        "  padding_sizes       {:?}",
+        published.padding_sizes.as_slice()
+    );
+    println!();
+    println!("A conforming client REFUSES this relay unless it opts in per-relay:");
+    println!("  ClientPolicy {{ allow_insecure_transport: true, .. }}   (§2.3 obligation 3)");
+    if options.unsound_antireplay {
+        println!();
+        println!("  !! --unsound-antireplay is on: antireplay_window_ms < 2 x clock_skew_ms.");
+        println!("     https://github.com/free2z/zuu/issues/586 — the document is VALID under");
+        println!("     WIRE.md as written, and a conforming client must refuse it anyway.");
+    }
+    if !server.local_addr().ip().is_loopback() {
+        println!();
+        println!("  !! Bound to a non-loopback address without TLS (§2.3 override). Obligations:");
+        println!("     1. transport_security: none is published. It is.");
+        println!("     2. channel_binding_mode: none is published. It is.");
+        println!("     3. Clients must refuse by default and require an explicit opt-in.");
+        println!("     Queue addresses from this process are PREDICTABLE. Do not use it.");
+    }
+}
+
+/// base64url without padding — `WIRE.md` §3.4's form for byte strings in
+/// human-readable output.
+fn base64url(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::with_capacity(bytes.len().saturating_mul(4).saturating_div(3));
+    for chunk in bytes.chunks(3) {
+        let first = chunk.first().copied().unwrap_or(0);
+        let second = chunk.get(1).copied().unwrap_or(0);
+        let third = chunk.get(2).copied().unwrap_or(0);
+        let triple = (u32::from(first) << 16) | (u32::from(second) << 8) | u32::from(third);
+        let indices = [
+            (triple >> 18) & 0x3f,
+            (triple >> 12) & 0x3f,
+            (triple >> 6) & 0x3f,
+            triple & 0x3f,
+        ];
+        let take = match chunk.len() {
+            1 => 2,
+            2 => 3,
+            _ => 4,
+        };
+        for index in indices.iter().take(take) {
+            let position = usize::try_from(*index).unwrap_or(0);
+            if let Some(symbol) = ALPHABET.get(position) {
+                out.push(char::from(*symbol));
+            }
+        }
+    }
+    out
+}

--- a/rs/crates/f2z-relay-testkit/src/client.rs
+++ b/rs/crates/f2z-relay-testkit/src/client.rs
@@ -1,0 +1,1000 @@
+//! A client, so the fake has something to be exercised by.
+//!
+//! This is not the client. ZUULI's engine and the WASM web client are the
+//! clients, and neither of them will link this. What this is: the smallest
+//! thing that can drive every command of §6 correctly, so that a conformance
+//! vector is a statement about the *relay* rather than about a test's ability
+//! to build a frame.
+//!
+//! It does obey the client-side MUSTs, though, and deliberately:
+//!
+//! - It verifies `relay_proof` before sending any signed command, and compares
+//!   `relay_id` against an expected value when it has one (§2.5, §5.2). Those
+//!   are `f2z-relay-proto::hello::verify_hello_response`, not code here.
+//! - It correlates strictly by `request_id` and never by arrival order, through
+//!   `f2z-relay-proto::inflight`'s typed ticket (§4.3).
+//! - It pads to a bucket before sending (§9) rather than relying on the relay
+//!   to tell it the size was wrong.
+//! - It re-reads the relay's clock rather than assuming its own (§5.5), and
+//!   never sets a system clock from it — there is no system clock here to set.
+//!
+//! Everything a vector needs to *break* on purpose is also here — a raw frame,
+//! a text frame, a chosen timestamp, a reused nonce — because a conformance
+//! suite that can only send valid frames tests half a protocol.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use f2z_codec::canonical::{Canonical, decode_canonical};
+use f2z_codec::commands::{
+    AckRequest, AckResponse, AppendRequest, BindSendRequest, ChallengePurpose, ChallengeRequest,
+    ChallengeResponse, ContactAppendRequest, CreateContactQueueRequest, CreateContactQueueResponse,
+    CreateQueueRequest, CreateQueueResponse, HelloRequest, PushEvent, ReadRequest, ReadResponse,
+    SignedCapabilities, SubscribeResponse,
+};
+use f2z_codec::frame::Push;
+use f2z_codec::frame::{FramePayload, RelayFrame, Response};
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::pow::{PowParams, PowStamp};
+use f2z_codec::types::{
+    Challenge, ChannelBinding, Nonce, Payload, QueueAddress, RelayId, ShortBytes,
+};
+use f2z_codec::{ErrorCode, PROTOCOL_VERSION};
+use f2z_relay_proto::ProtoError;
+use f2z_relay_proto::capabilities::ClientPolicy;
+use f2z_relay_proto::command::{Empty, RelayCommand, SignedCommand, ops, unsigned_request};
+use f2z_relay_proto::hello::{RelaySession, verify_hello_response};
+use f2z_relay_proto::inflight::InFlight;
+use f2z_relay_proto::key::SigningKey;
+
+use crate::error::{Result, TestkitError};
+use crate::rng::Csprng;
+use crate::transport::{Transport, TransportSink, TransportStream, WireMessage};
+
+/// How a client is set up before it says `HELLO`.
+#[derive(Clone)]
+pub struct ClientConfig {
+    /// §11.3's checklist, as a policy. Defaults here allow the insecure
+    /// transport a `FakeRelay` publishes, because refusing it is the *correct*
+    /// default and a harness that could not opt in could not test anything.
+    pub policy: ClientPolicy,
+    /// The `relay_id` an in-band advert named (§7.2), when there is one. A
+    /// mismatch is fatal and is reported as a substitution.
+    pub expected_relay_id: Option<RelayId>,
+    /// The value this client computed from its own TLS state — zeros when the
+    /// relay published `channel_binding_mode: none` (§5.3).
+    pub channel_binding: ChannelBinding,
+    /// The nonce stream. Deterministic, so a failing vector replays.
+    pub nonce_seed: [u8; 32],
+    /// How long any single read waits before giving up. Not a protocol value:
+    /// a timeout is a decision about a test, and §2.5's "unknown status" is
+    /// what a real client is left with.
+    pub read_timeout: Duration,
+    /// The sizes this client pads to (§9). The relay's published set MUST be a
+    /// superset.
+    pub padding: PaddingBuckets,
+}
+
+// `nonce_seed` decides every nonce this client will ever present, and a nonce
+// is half of §5.5's replay key. A derived `Debug` would print it as a decimal
+// byte dump.
+impl std::fmt::Debug for ClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientConfig")
+            .field("expected_relay_id", &self.expected_relay_id)
+            .field("channel_binding", &self.channel_binding)
+            .field("nonce_seed", &"<redacted>")
+            .field("read_timeout", &self.read_timeout)
+            .field("padding", &self.padding)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            policy: ClientPolicy {
+                // §2.3 obligation 3: an explicit, per-relay opt-in. A test
+                // harness pointing at a `ws://` fake is exactly the case the
+                // obligation contemplates, and saying so here is the opt-in.
+                allow_insecure_transport: true,
+                ..ClientPolicy::default()
+            },
+            expected_relay_id: None,
+            channel_binding: ChannelBinding::zero(),
+            nonce_seed: *b"f2z-relay-testkit/client-nonces!",
+            read_timeout: Duration::from_secs(2),
+            padding: PaddingBuckets::default(),
+        }
+    }
+}
+
+/// A connected client.
+pub struct Client {
+    sink: Box<dyn TransportSink>,
+    stream: Box<dyn TransportStream>,
+    session: RelaySession,
+    inflight: InFlight,
+    rng: Csprng,
+    next_request_id: u32,
+    pushes: VecDeque<Push>,
+    read_timeout: Duration,
+    padding: PaddingBuckets,
+    opened: Instant,
+    /// Relay time at the last synchronisation, and the local instant it was
+    /// taken. §5.5: a client with an unreliable clock learns the relay's time
+    /// and applies the offset locally — it MUST NOT set its system clock.
+    relay_time_ms: u64,
+    relay_time_taken: Instant,
+    /// A deliberate override, for the vectors that need a stale timestamp.
+    timestamp_override: Option<u64>,
+    closed: bool,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("relay_id", &self.session.relay_id())
+            .field("inflight", &self.inflight.len())
+            .field("queued_pushes", &self.pushes.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Client {
+    /// Complete §2.5's steps 2 and 3 and open a session.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Protocol`] carrying a `Refusal` when the relay fails one
+    /// of §2.5's or §11.3's checks; [`TestkitError::Transport`] or
+    /// [`TestkitError::Timeout`] when it does not answer.
+    pub async fn connect(transport: Transport, config: ClientConfig) -> Result<Self> {
+        let (mut sink, mut stream) = transport.split();
+        let mut rng = Csprng::from_seed(config.nonce_seed);
+        let client_nonce = rng.next_challenge();
+        let offer = HelloRequest {
+            min_version: PROTOCOL_VERSION,
+            max_version: PROTOCOL_VERSION,
+            client_nonce,
+        };
+
+        // `HELLO` is exchanged before a `Client` exists, so there is no moment
+        // at which this type holds a session the relay has not proved. A
+        // placeholder would have been a hole in exactly the property
+        // `f2z-relay-proto` exists to give: a `RelaySession` is obtainable only
+        // by verifying `relay_proof`.
+        let mut inflight = InFlight::default();
+        let ticket = inflight.issue::<ops::Hello>(1)?;
+        let frame = unsigned_request::<ops::Hello>(1, &offer)?;
+        sink.send(WireMessage::Binary(frame.encode_canonical()?))
+            .await?;
+        let (request_id, response) =
+            await_hello(&mut sink, &mut stream, config.read_timeout).await?;
+        let hello = inflight.complete::<ops::Hello>(ticket, request_id, &response)?;
+
+        // The MUST that everything else rests on: verify the proof of
+        // possession, recompute `relay_id`, and compare it against the advert
+        // *before* any signed command exists.
+        let session = verify_hello_response(
+            &hello,
+            &offer,
+            &config.channel_binding,
+            config.expected_relay_id.as_ref(),
+            &config.policy,
+        )?;
+
+        let relay_time_ms = session.relay_time_ms();
+        Ok(Self {
+            sink,
+            stream,
+            session,
+            inflight,
+            rng,
+            next_request_id: 2,
+            pushes: VecDeque::new(),
+            read_timeout: config.read_timeout,
+            padding: config.padding.clone(),
+            opened: Instant::now(),
+            relay_time_ms,
+            relay_time_taken: Instant::now(),
+            timestamp_override: None,
+            closed: false,
+        })
+    }
+
+    /// The session opened by `HELLO`.
+    #[must_use]
+    pub const fn session(&self) -> &RelaySession {
+        &self.session
+    }
+
+    /// The relay's identity binding, as proved in `HELLO`.
+    #[must_use]
+    pub const fn relay_id(&self) -> RelayId {
+        self.session.relay_id()
+    }
+
+    /// How long this connection has been open. Only useful for diagnostics.
+    #[must_use]
+    pub fn age(&self) -> Duration {
+        self.opened.elapsed()
+    }
+
+    /// The client's current estimate of the relay's clock (§5.5).
+    #[must_use]
+    pub fn relay_time_ms(&self) -> u64 {
+        if let Some(override_ms) = self.timestamp_override {
+            return override_ms;
+        }
+        let elapsed = u64::try_from(self.relay_time_taken.elapsed().as_millis()).unwrap_or(0);
+        self.relay_time_ms.saturating_add(elapsed)
+    }
+
+    /// Force every subsequent signed command to carry this `timestamp_ms`.
+    ///
+    /// The only way to reach `ERR_STALE_TIMESTAMP` deliberately, and the only
+    /// way to build the two frames a replay test needs.
+    pub const fn set_timestamp(&mut self, timestamp_ms: Option<u64>) {
+        self.timestamp_override = timestamp_ms;
+    }
+
+    /// Re-read the relay's clock (§5.5's `GET_CHALLENGE(clock)`).
+    ///
+    /// A test that moves a frozen relay clock must call this, exactly as a
+    /// client whose device slept must.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::challenge`].
+    pub async fn resync_clock(&mut self) -> Result<()> {
+        let response = self.challenge(ChallengePurpose::Clock, &[]).await?;
+        self.relay_time_ms = response.relay_time_ms;
+        self.relay_time_taken = Instant::now();
+        Ok(())
+    }
+
+    /// The padding buckets this client emits to (§9).
+    #[must_use]
+    pub const fn padding(&self) -> &PaddingBuckets {
+        &self.padding
+    }
+
+    /// How long a single read waits. A vector that expects *nothing* to arrive
+    /// shortens this: waiting the full default to prove a negative is how a
+    /// suite becomes too slow to run.
+    pub const fn set_read_timeout(&mut self, timeout: Duration) {
+        self.read_timeout = timeout;
+    }
+
+    /// A fresh nonce from this client's deterministic stream.
+    pub fn nonce(&mut self) -> Nonce {
+        Nonce::new(self.rng.next_bytes::<16>())
+    }
+
+    // -- the command surface ----------------------------------------------
+
+    /// `GET_CAPABILITIES` (§6.1).
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_unsigned`].
+    pub async fn capabilities(&mut self) -> Result<SignedCapabilities> {
+        self.call_unsigned::<ops::GetCapabilities>(&Empty).await
+    }
+
+    /// `GET_CHALLENGE` (§6.1).
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_unsigned`].
+    pub async fn challenge(
+        &mut self,
+        purpose: ChallengePurpose,
+        scope: &[u8],
+    ) -> Result<ChallengeResponse> {
+        let body = ChallengeRequest {
+            purpose: purpose.code(),
+            scope: ShortBytes::new(scope.to_vec())?,
+        };
+        self.call_unsigned::<ops::GetChallenge>(&body).await
+    }
+
+    /// `PING` (§6.1) — the application-level probe, distinct from §2.4's
+    /// WebSocket Ping, which a browser cannot send.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_unsigned`].
+    pub async fn ping(&mut self) -> Result<()> {
+        self.call_unsigned::<ops::Ping>(&Empty).await.map(|_| ())
+    }
+
+    /// `CREATE_QUEUE` (§6.2), solving a stamp first if the relay demands one.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`], plus anything `GET_CHALLENGE` returns.
+    pub async fn create_queue(
+        &mut self,
+        recv_key: &SigningKey,
+        message_ttl_seconds: u32,
+        idle_ttl_seconds: u32,
+        pow: Option<PowParams>,
+    ) -> Result<CreateQueueResponse> {
+        let stamp = self
+            .stamp_for(ChallengePurpose::QueueCreate, &[], pow)
+            .await?;
+        let body = CreateQueueRequest {
+            recv_key: recv_key.public_key(),
+            req_message_ttl_seconds: message_ttl_seconds,
+            req_idle_ttl_seconds: idle_ttl_seconds,
+            flags: 0,
+            stamp,
+        };
+        self.call_signed::<ops::CreateQueue>(recv_key, QueueAddress::zero(), &body)
+            .await
+    }
+
+    /// `CREATE_CONTACT_QUEUE` (§12.2).
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::create_queue`].
+    pub async fn create_contact_queue(
+        &mut self,
+        recv_key: &SigningKey,
+        message_ttl_seconds: u32,
+        idle_ttl_seconds: u32,
+        pow: Option<PowParams>,
+    ) -> Result<CreateContactQueueResponse> {
+        let stamp = self
+            .stamp_for(ChallengePurpose::QueueCreate, &[], pow)
+            .await?;
+        let body = CreateContactQueueRequest {
+            recv_key: recv_key.public_key(),
+            req_message_ttl_seconds: message_ttl_seconds,
+            req_idle_ttl_seconds: idle_ttl_seconds,
+            stamp,
+        };
+        self.call_signed::<ops::CreateContactQueue>(recv_key, QueueAddress::zero(), &body)
+            .await
+    }
+
+    /// `SUBSCRIBE` (§6.2).
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn subscribe(
+        &mut self,
+        recv_key: &SigningKey,
+        recv_addr: QueueAddress,
+    ) -> Result<SubscribeResponse> {
+        self.call_signed::<ops::Subscribe>(recv_key, recv_addr, &Empty)
+            .await
+    }
+
+    /// `UNSUBSCRIBE` (§6.2).
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn unsubscribe(
+        &mut self,
+        recv_key: &SigningKey,
+        recv_addr: QueueAddress,
+    ) -> Result<()> {
+        self.call_signed::<ops::Unsubscribe>(recv_key, recv_addr, &Empty)
+            .await
+            .map(|_| ())
+    }
+
+    /// `READ` (§6.2). Never mutates.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn read(
+        &mut self,
+        recv_key: &SigningKey,
+        recv_addr: QueueAddress,
+        from_index: u64,
+        max_messages: u16,
+        max_bytes: u32,
+    ) -> Result<ReadResponse> {
+        let body = ReadRequest {
+            from_index,
+            max_messages,
+            max_bytes,
+        };
+        self.call_signed::<ops::Read>(recv_key, recv_addr, &body)
+            .await
+    }
+
+    /// `ACK` (§6.2).
+    ///
+    /// **A real client MUST NOT call this before its durable local write has
+    /// completed.** ACK-on-read plus a crash is permanent message loss, because
+    /// the relay has already deleted the only copy (§8.4, `CLIENT-CONTRACT.md`
+    /// §9 rule 1). The wire protocol cannot enforce it and neither can this
+    /// function; it is restated here because this is where an implementer's
+    /// cursor will be.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn ack(
+        &mut self,
+        recv_key: &SigningKey,
+        recv_addr: QueueAddress,
+        up_to_index: u64,
+    ) -> Result<AckResponse> {
+        let body = AckRequest { up_to_index };
+        self.call_signed::<ops::Ack>(recv_key, recv_addr, &body)
+            .await
+    }
+
+    /// `DELETE_QUEUE` (§6.2). Irreversible.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn delete_queue(
+        &mut self,
+        recv_key: &SigningKey,
+        recv_addr: QueueAddress,
+    ) -> Result<()> {
+        self.call_signed::<ops::DeleteQueue>(recv_key, recv_addr, &Empty)
+            .await
+            .map(|_| ())
+    }
+
+    /// `BIND_SEND` (§6.3). Once-only and irreversible.
+    ///
+    /// `ERR_ALREADY_BOUND` on a first attempt for an address from a fresh
+    /// advert is a loud, non-dismissible failure (§7.4), not a retry.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn bind_send(
+        &mut self,
+        send_key: &SigningKey,
+        send_addr: QueueAddress,
+    ) -> Result<()> {
+        let body = BindSendRequest {
+            send_key: send_key.public_key(),
+        };
+        self.call_signed::<ops::BindSend>(send_key, send_addr, &body)
+            .await
+            .map(|_| ())
+    }
+
+    /// `APPEND` (§6.3), padded to a bucket first.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] if the plaintext is larger than the largest
+    /// bucket — §9 says chunk it client-side, and chunking is the application's
+    /// job, not this one's. Otherwise as [`Client::call_signed`].
+    pub async fn append(
+        &mut self,
+        send_key: &SigningKey,
+        send_addr: QueueAddress,
+        plaintext: &[u8],
+    ) -> Result<()> {
+        let payload = self.pad(plaintext)?;
+        let body = AppendRequest { payload };
+        self.call_signed::<ops::Append>(send_key, send_addr, &body)
+            .await
+            .map(|_| ())
+    }
+
+    /// `APPEND` with a payload of exactly this length, bucket or not.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`]. `ERR_BAD_SIZE` when the length is not a
+    /// published bucket, which is the point.
+    pub async fn append_raw_size(
+        &mut self,
+        send_key: &SigningKey,
+        send_addr: QueueAddress,
+        len: usize,
+    ) -> Result<()> {
+        let body = AppendRequest {
+            payload: Payload::new(vec![0u8; len])?,
+        };
+        self.call_signed::<ops::Append>(send_key, send_addr, &body)
+            .await
+            .map(|_| ())
+    }
+
+    /// `CONTACT_APPEND` (§12.2), solving a stamp scoped to `contact_addr`.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_unsigned`], plus anything `GET_CHALLENGE` returns.
+    pub async fn contact_append(
+        &mut self,
+        contact_addr: QueueAddress,
+        plaintext: &[u8],
+        pow: Option<PowParams>,
+    ) -> Result<()> {
+        let payload = self.pad(plaintext)?;
+        let stamp = self
+            .stamp_for(
+                ChallengePurpose::ContactAppend,
+                contact_addr.as_bytes(),
+                pow,
+            )
+            .await?;
+        let body = ContactAppendRequest {
+            contact_addr,
+            payload,
+            stamp,
+        };
+        self.call_unsigned::<ops::ContactAppend>(&body)
+            .await
+            .map(|_| ())
+    }
+
+    // -- the machinery ----------------------------------------------------
+
+    /// Pad to the smallest bucket that fits (§9).
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] when the plaintext exceeds the largest bucket.
+    pub fn pad(&self, plaintext: &[u8]) -> Result<Payload> {
+        let Some(bucket) = self.padding.bucket_for(plaintext.len()) else {
+            return Err(TestkitError::Config(
+                "payload exceeds the largest padding bucket; chunk it client-side (WIRE.md §9)",
+            ));
+        };
+        let mut bytes = plaintext.to_vec();
+        bytes.resize(usize::try_from(bucket).unwrap_or(plaintext.len()), 0);
+        Ok(Payload::new(bytes)?)
+    }
+
+    /// Issue a signed command and wait for its answer.
+    ///
+    /// # Errors
+    ///
+    /// The relay's §10 code, or a transport failure.
+    pub async fn call_signed<C: RelayCommand>(
+        &mut self,
+        key: &SigningKey,
+        address: QueueAddress,
+        body: &C::Request,
+    ) -> Result<C::Response> {
+        let request_id = self.take_request_id();
+        let ticket = self.inflight.issue::<C>(request_id)?;
+        let nonce = self.nonce();
+        let timestamp = self.relay_time_ms();
+        let signed = SignedCommand::<C>::create(
+            self.session.transcripts(),
+            request_id,
+            address,
+            timestamp,
+            nonce,
+            key,
+            body,
+        )?;
+        self.send_frame(&signed.frame()?).await?;
+        let (frame_id, response) = self.await_response().await?;
+        Ok(self.inflight.complete::<C>(ticket, frame_id, &response)?)
+    }
+
+    /// Issue an unsigned command and wait for its answer.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn call_unsigned<C: RelayCommand>(
+        &mut self,
+        body: &C::Request,
+    ) -> Result<C::Response> {
+        let request_id = self.take_request_id();
+        let ticket = self.inflight.issue::<C>(request_id)?;
+        let frame = unsigned_request::<C>(request_id, body)?;
+        self.send_frame(&frame).await?;
+        let (frame_id, response) = self.await_response().await?;
+        Ok(self.inflight.complete::<C>(ticket, frame_id, &response)?)
+    }
+
+    /// Send a signed command and return without waiting, so a caller can fill
+    /// §4.3's in-flight window or interleave two commands.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`], minus the response.
+    pub async fn send_signed<C: RelayCommand>(
+        &mut self,
+        key: &SigningKey,
+        address: QueueAddress,
+        body: &C::Request,
+    ) -> Result<u32> {
+        let request_id = self.take_request_id();
+        let nonce = self.nonce();
+        let timestamp = self.relay_time_ms();
+        let signed = SignedCommand::<C>::create(
+            self.session.transcripts(),
+            request_id,
+            address,
+            timestamp,
+            nonce,
+            key,
+            body,
+        )?;
+        self.send_frame(&signed.frame()?).await?;
+        Ok(request_id)
+    }
+
+    /// Send an unsigned command without waiting, so a caller can fill §4.3's
+    /// in-flight window.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_unsigned`], minus the response.
+    pub async fn send_unsigned<C: RelayCommand>(&mut self, body: &C::Request) -> Result<u32> {
+        let request_id = self.take_request_id();
+        let frame = unsigned_request::<C>(request_id, body)?;
+        self.send_frame(&frame).await?;
+        Ok(request_id)
+    }
+
+    /// The next response frame, whatever it answers.
+    ///
+    /// §4.3: responses may arrive out of order, so a caller that issued several
+    /// requests must be able to take them as they come and correlate itself.
+    /// Pushes are queued rather than returned.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Closed`] or [`TestkitError::Timeout`].
+    pub async fn next_response(&mut self) -> Result<(u32, Response)> {
+        self.await_response().await
+    }
+
+    /// The bytes of a signed command, without sending it. For the vectors that
+    /// replay a frame verbatim (§5.5, §5.6).
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Protocol`] if the command cannot be built.
+    pub fn encode_signed<C: RelayCommand>(
+        &mut self,
+        key: &SigningKey,
+        address: QueueAddress,
+        body: &C::Request,
+    ) -> Result<Vec<u8>> {
+        let request_id = self.take_request_id();
+        let nonce = self.nonce();
+        let timestamp = self.relay_time_ms();
+        let signed = SignedCommand::<C>::create(
+            self.session.transcripts(),
+            request_id,
+            address,
+            timestamp,
+            nonce,
+            key,
+            body,
+        )?;
+        Ok(signed.encode()?)
+    }
+
+    /// Write arbitrary bytes as a binary frame.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Transport`] if the write fails.
+    pub async fn send_raw(&mut self, bytes: Vec<u8>) -> Result<()> {
+        self.sink.send(WireMessage::Binary(bytes)).await?;
+        Ok(())
+    }
+
+    /// Write a text frame. §4.2: the relay must answer with a fatal
+    /// `ERR_FRAME_TYPE` and close with status 1003.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Transport`] if the write fails.
+    pub async fn send_text(&mut self, text: &str) -> Result<()> {
+        self.sink
+            .send(WireMessage::Text(text.as_bytes().to_vec()))
+            .await?;
+        Ok(())
+    }
+
+    /// The next push, waiting up to the configured read timeout.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Timeout`] if none arrives, [`TestkitError::Closed`] if
+    /// the connection ends first.
+    pub async fn next_push(&mut self) -> Result<Push> {
+        if let Some(push) = self.pushes.pop_front() {
+            return Ok(push);
+        }
+        loop {
+            match self.read_frame().await?.1 {
+                FramePayload::Push(push) => return Ok(push),
+                // A response nobody is waiting for. Keep reading rather than
+                // failing: a delayed or reordered response can legitimately
+                // arrive here after its caller gave up.
+                FramePayload::Request(_) | FramePayload::Response(_) => {}
+            }
+        }
+    }
+
+    /// The next push, decoded as a `QUEUE_EVENT` body.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::next_push`], plus [`TestkitError::Expectation`] if the push
+    /// was a different event.
+    pub async fn next_queue_event(&mut self) -> Result<f2z_codec::commands::QueueEventPush> {
+        let push = self.next_push().await?;
+        if push.event() != Some(PushEvent::QueueEvent) {
+            return Err(TestkitError::Expectation(format!(
+                "expected QUEUE_EVENT, got event {:#06x}",
+                push.event
+            )));
+        }
+        Ok(decode_canonical::<f2z_codec::commands::QueueEventPush>(push.body())?.into_value())
+    }
+
+    /// The next push, decoded as a `MSG` body.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::next_push`], plus [`TestkitError::Expectation`] if the push
+    /// was a different event.
+    pub async fn next_message(&mut self) -> Result<f2z_codec::commands::MsgPush> {
+        let push = self.next_push().await?;
+        if push.event() != Some(PushEvent::Msg) {
+            return Err(TestkitError::Expectation(format!(
+                "expected MSG, got event {:#06x}",
+                push.event
+            )));
+        }
+        Ok(decode_canonical::<f2z_codec::commands::MsgPush>(push.body())?.into_value())
+    }
+
+    /// Wait for the relay to close, which is what §1.3's fatal errors require
+    /// after the response.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Expectation`] if a frame arrives instead, or
+    /// [`TestkitError::Timeout`].
+    pub async fn expect_closed(&mut self) -> Result<()> {
+        loop {
+            let message = self.read_message().await?;
+            match message {
+                None | Some(WireMessage::Close(_)) => {
+                    self.closed = true;
+                    return Ok(());
+                }
+                Some(WireMessage::Ping(payload)) => {
+                    let _ = self.sink.send(WireMessage::Pong(payload)).await;
+                }
+                Some(WireMessage::Pong(_)) => {}
+                Some(WireMessage::Binary(bytes)) => {
+                    return Err(TestkitError::Expectation(format!(
+                        "expected the relay to close; it sent {} bytes instead",
+                        bytes.len()
+                    )));
+                }
+                Some(WireMessage::Text(_)) => {
+                    return Err(TestkitError::Expectation(
+                        "the relay sent a text frame, which no relay may do".to_owned(),
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Whether the peer has closed.
+    #[must_use]
+    pub const fn is_closed(&self) -> bool {
+        self.closed
+    }
+
+    /// Close from this side.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Transport`] if the close cannot be written.
+    pub async fn close(&mut self) -> Result<()> {
+        self.closed = true;
+        self.sink.close(crate::outbound::CLOSE_NORMAL).await?;
+        Ok(())
+    }
+
+    /// Solve a stamp, or return the empty one when no work is required.
+    ///
+    /// # Errors
+    ///
+    /// Anything `GET_CHALLENGE` returns.
+    pub async fn stamp_for(
+        &mut self,
+        purpose: ChallengePurpose,
+        scope: &[u8],
+        pow: Option<PowParams>,
+    ) -> Result<PowStamp> {
+        let params = match pow {
+            Some(params) if params.is_required() => params,
+            Some(_) => return Ok(PowStamp::empty()),
+            None => return Ok(PowStamp::empty()),
+        };
+        let issued = self.challenge(purpose, scope).await?;
+        Ok(solve(
+            issued.challenge,
+            &mut self.rng,
+            params.difficulty_bits,
+        ))
+    }
+
+    fn take_request_id(&mut self) -> u32 {
+        let id = self.next_request_id;
+        // §4.3: nonzero, and unique among the *currently in-flight* requests.
+        // Wrapping past zero is the one value it may never take.
+        self.next_request_id = self.next_request_id.checked_add(1).unwrap_or(1);
+        id
+    }
+
+    async fn send_frame(&mut self, frame: &RelayFrame) -> Result<()> {
+        let bytes = frame.encode_canonical()?;
+        self.sink.send(WireMessage::Binary(bytes)).await?;
+        Ok(())
+    }
+
+    async fn await_response(&mut self) -> Result<(u32, Response)> {
+        loop {
+            let (request_id, payload) = self.read_frame().await?;
+            match payload {
+                FramePayload::Response(response) => return Ok((request_id, response)),
+                // §4.3: responses may arrive out of order and a push may arrive
+                // between them. Queue it rather than treating it as the answer.
+                FramePayload::Push(push) => self.pushes.push_back(push),
+                FramePayload::Request(_) => {
+                    return Err(TestkitError::Expectation(
+                        "a relay sent a request frame, which no relay may do".to_owned(),
+                    ));
+                }
+            }
+        }
+    }
+
+    async fn read_frame(&mut self) -> Result<(u32, FramePayload)> {
+        loop {
+            let Some(message) = self.read_message().await? else {
+                self.closed = true;
+                return Err(TestkitError::Closed);
+            };
+            match message {
+                WireMessage::Binary(bytes) => {
+                    // §3.3 applies in both directions: a client that skipped it
+                    // would be the permissive decoder the rule exists to kill.
+                    let frame = decode_canonical::<RelayFrame>(&bytes)?.into_value();
+                    frame.validate()?;
+                    return Ok((frame.request_id, frame.payload));
+                }
+                WireMessage::Ping(payload) => {
+                    // §2.4: clients MUST respond to Ping with Pong. The browser
+                    // runtime does this without asking; a native client has to.
+                    let _ = self.sink.send(WireMessage::Pong(payload)).await;
+                }
+                WireMessage::Pong(_) => {}
+                WireMessage::Close(_) => {
+                    self.closed = true;
+                    return Err(TestkitError::Closed);
+                }
+                WireMessage::Text(_) => {
+                    return Err(TestkitError::Expectation(
+                        "the relay sent a text frame, which no relay may do".to_owned(),
+                    ));
+                }
+            }
+        }
+    }
+
+    async fn read_message(&mut self) -> Result<Option<WireMessage>> {
+        match tokio::time::timeout(self.read_timeout, self.stream.recv()).await {
+            Ok(Ok(message)) => Ok(message),
+            Ok(Err(error)) => Err(TestkitError::from(error)),
+            Err(_) => Err(TestkitError::Timeout),
+        }
+    }
+}
+
+/// Search for a stamp meeting `difficulty_bits` (§13.1).
+///
+/// A leading-zero-bit search over BLAKE2b, chosen so verification is a single
+/// hash. §12.4 is honest that this taxes phones far more than rented GPUs and
+/// that no tuning fixes it; at the testkit's difficulty the point is the shape
+/// of the exchange, not the cost.
+#[must_use]
+pub fn solve(challenge: Challenge, rng: &mut Csprng, difficulty_bits: u8) -> PowStamp {
+    let salt = f2z_codec::types::Salt::new(rng.next_bytes::<16>());
+    let mut stamp = PowStamp {
+        challenge,
+        salt,
+        counter: 0,
+    };
+    loop {
+        if stamp.meets_difficulty(difficulty_bits) {
+            return stamp;
+        }
+        stamp.counter = stamp.counter.wrapping_add(1);
+    }
+}
+
+/// Read the `HELLO` response before a `Client` exists.
+///
+/// Answers §2.4's Ping while it waits, because a relay whose keepalive fires
+/// during a slow handshake is not misbehaving.
+async fn await_hello(
+    sink: &mut Box<dyn TransportSink>,
+    stream: &mut Box<dyn TransportStream>,
+    read_timeout: Duration,
+) -> Result<(u32, Response)> {
+    loop {
+        let message = match tokio::time::timeout(read_timeout, stream.recv()).await {
+            Ok(Ok(Some(message))) => message,
+            Ok(Ok(None)) => return Err(TestkitError::Closed),
+            Ok(Err(error)) => return Err(TestkitError::from(error)),
+            Err(_) => return Err(TestkitError::Timeout),
+        };
+        match message {
+            WireMessage::Binary(bytes) => {
+                let frame = decode_canonical::<RelayFrame>(&bytes)?.into_value();
+                frame.validate()?;
+                match frame.payload {
+                    FramePayload::Response(response) => return Ok((frame.request_id, response)),
+                    FramePayload::Push(_) | FramePayload::Request(_) => {
+                        return Err(TestkitError::Expectation(
+                            "the relay answered HELLO with something that is not a response"
+                                .to_owned(),
+                        ));
+                    }
+                }
+            }
+            WireMessage::Ping(payload) => {
+                let _ = sink.send(WireMessage::Pong(payload)).await;
+            }
+            WireMessage::Pong(_) => {}
+            WireMessage::Close(_) => return Err(TestkitError::Closed),
+            WireMessage::Text(_) => {
+                return Err(TestkitError::Expectation(
+                    "the relay sent a text frame, which no relay may do".to_owned(),
+                ));
+            }
+        }
+    }
+}
+
+/// Convenience: the error code a call returned, if it returned one.
+#[must_use]
+pub fn code_of<T>(result: &Result<T>) -> Option<ErrorCode> {
+    match result {
+        Err(error) => error.wire_code(),
+        Ok(_) => None,
+    }
+}
+
+/// Convenience: whether a call was refused by the client rather than by the
+/// relay (§11.3).
+#[must_use]
+pub fn refusal_of<T>(result: &Result<T>) -> Option<f2z_relay_proto::Refusal> {
+    match result {
+        Err(TestkitError::Protocol(ProtoError::Refused(refusal))) => Some(*refusal),
+        _ => None,
+    }
+}
+
+/// The command marker types, re-exported so a vector needs one import.
+pub use f2z_relay_proto::command::ops as commands;

--- a/rs/crates/f2z-relay-testkit/src/clock.rs
+++ b/rs/crates/f2z-relay-testkit/src/clock.rs
@@ -1,0 +1,196 @@
+//! The relay's clock, made steerable.
+//!
+//! `f2z-relay-proto` is deliberately clock-free: every rule that needs the time
+//! takes it as an argument, because the same code has to run in a browser. That
+//! leaves somebody holding the clock, and in a test harness it should be the
+//! test.
+//!
+//! Three things in `WIRE.md` are only reachable by moving time:
+//!
+//! - `ERR_STALE_TIMESTAMP` (§5.5) needs a client and a relay that disagree by
+//!   more than `clock_skew_ms`.
+//! - Message TTL and queue idle TTL (§7.7) are seven days and ninety days.
+//!   Nobody tests those by waiting.
+//! - The seen-set ages entries out on a wall-clock schedule (§5.5), and the
+//!   `antireplay_window_ms < 2 × clock_skew_ms` defect of [#586] is a statement
+//!   about exactly that schedule.
+//!
+//! So [`Clock::manual`] freezes time and lets a test step it, and
+//! [`Clock::system`] follows the wall clock with an adjustable offset for the
+//! cases where a real listener wants real time. Both are cheap to clone and
+//! shared by every connection of one relay, because a relay has one clock.
+//!
+//! [#586]: https://github.com/free2z/zuu/issues/586
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A relay clock, in milliseconds since the Unix epoch.
+#[derive(Clone, Debug)]
+pub struct Clock {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    /// `Some` for a frozen clock: the current value, stepped by `advance`.
+    frozen: Option<AtomicU64>,
+    /// Applied to both modes, so a system-time relay can also be nudged.
+    offset_ms: AtomicI64,
+}
+
+impl Clock {
+    /// A clock that follows the host's wall clock.
+    ///
+    /// This is what `f2z-fakerelay` runs on: a client developer pointing a real
+    /// application at the endpoint expects `relay_time_ms` to be the real time,
+    /// because their own `timestamp_ms` will be.
+    #[must_use]
+    pub fn system() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                frozen: None,
+                offset_ms: AtomicI64::new(0),
+            }),
+        }
+    }
+
+    /// A clock frozen at `now_ms`, moved only by [`Clock::advance`] and
+    /// [`Clock::set`].
+    ///
+    /// Frozen is the default for the in-process relay. A test that asserts on a
+    /// timestamp window or a TTL must not also be a test of how long the CI
+    /// runner took to schedule a task.
+    #[must_use]
+    pub fn manual(now_ms: u64) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                frozen: Some(AtomicU64::new(now_ms)),
+                offset_ms: AtomicI64::new(0),
+            }),
+        }
+    }
+
+    /// The current relay time, in milliseconds since the Unix epoch.
+    #[must_use]
+    pub fn now_ms(&self) -> u64 {
+        let base = match &self.inner.frozen {
+            Some(frozen) => frozen.load(Ordering::SeqCst),
+            None => u64::try_from(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_or(0, |since| since.as_millis()),
+            )
+            .unwrap_or(u64::MAX),
+        };
+        let offset = self.inner.offset_ms.load(Ordering::SeqCst);
+        if offset >= 0 {
+            base.saturating_add(u64::try_from(offset).unwrap_or(0))
+        } else {
+            base.saturating_sub(offset.unsigned_abs())
+        }
+    }
+
+    /// Move time forward by `millis`.
+    ///
+    /// Works in both modes: on a frozen clock it steps the value, on a system
+    /// clock it moves the offset, so a test can make a relay's clock disagree
+    /// with its own by a known amount without touching the host.
+    pub fn advance(&self, millis: u64) {
+        match &self.inner.frozen {
+            Some(frozen) => {
+                let _ = frozen.fetch_add(millis, Ordering::SeqCst);
+            }
+            None => {
+                let step = i64::try_from(millis).unwrap_or(i64::MAX);
+                let _ = self.inner.offset_ms.fetch_add(step, Ordering::SeqCst);
+            }
+        }
+    }
+
+    /// Move time backward by `millis`. A relay whose clock went backwards is a
+    /// real operational event, and `ERR_STALE_TIMESTAMP` has a future half.
+    pub fn rewind(&self, millis: u64) {
+        match &self.inner.frozen {
+            Some(frozen) => {
+                let _ = frozen.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                    Some(current.saturating_sub(millis))
+                });
+            }
+            None => {
+                let step = i64::try_from(millis).unwrap_or(i64::MAX);
+                let _ = self.inner.offset_ms.fetch_sub(step, Ordering::SeqCst);
+            }
+        }
+    }
+
+    /// Set a frozen clock to an absolute time. A no-op on a system clock, whose
+    /// base is not ours to set.
+    pub fn set(&self, now_ms: u64) {
+        if let Some(frozen) = &self.inner.frozen {
+            frozen.store(now_ms, Ordering::SeqCst);
+        }
+    }
+
+    /// Whether this clock is frozen.
+    #[must_use]
+    pub fn is_manual(&self) -> bool {
+        self.inner.frozen.is_some()
+    }
+}
+
+impl Default for Clock {
+    /// Frozen at a fixed, arbitrary instant in 2027, so that a default-built
+    /// relay produces the same timestamps on every run and in every timezone.
+    fn default() -> Self {
+        Self::manual(DEFAULT_EPOCH_MS)
+    }
+}
+
+/// The instant [`Clock::default`] freezes at: 2027-01-01T00:00:00Z.
+///
+/// Any fixed value would do. It is in the future rather than the past so that a
+/// test which subtracts a TTL from it does not underflow into 1970.
+pub const DEFAULT_EPOCH_MS: u64 = 1_798_761_600_000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_frozen_clock_does_not_move_on_its_own() {
+        let clock = Clock::manual(1_000);
+        assert_eq!(clock.now_ms(), 1_000);
+        assert_eq!(clock.now_ms(), 1_000);
+        clock.advance(500);
+        assert_eq!(clock.now_ms(), 1_500);
+        clock.rewind(2_000);
+        assert_eq!(clock.now_ms(), 0);
+        clock.set(42);
+        assert_eq!(clock.now_ms(), 42);
+    }
+
+    #[test]
+    fn clones_share_one_clock() {
+        let clock = Clock::manual(0);
+        let other = clock.clone();
+        clock.advance(7);
+        assert_eq!(other.now_ms(), 7);
+    }
+
+    #[test]
+    fn a_system_clock_can_still_be_nudged() {
+        let clock = Clock::system();
+        let before = clock.now_ms();
+        clock.advance(60_000);
+        assert!(clock.now_ms() >= before.saturating_add(60_000));
+        assert!(!clock.is_manual());
+    }
+
+    #[test]
+    fn the_default_is_frozen_and_reproducible() {
+        assert_eq!(Clock::default().now_ms(), DEFAULT_EPOCH_MS);
+        assert!(Clock::default().is_manual());
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/config.rs
+++ b/rs/crates/f2z-relay-testkit/src/config.rs
@@ -1,0 +1,468 @@
+//! What a `FakeRelay` is configured with, and the one place a deliberate
+//! departure from `WIRE.md` can be turned on.
+//!
+//! # The published document is the contract, including here
+//!
+//! Every policy value below ends up in the signed capability document of §11.1,
+//! and the relay then enforces exactly what it published. That is not a detail:
+//! §11.3 has a client *decide whether to talk to a relay at all* from that
+//! document, so a test harness whose behaviour and whose document disagree
+//! would teach clients to ignore it.
+//!
+//! The default document is therefore honest about what a `FakeRelay` is:
+//!
+//! - `transport_security: none` and `channel_binding_mode: none`. It serves
+//!   `ws://`, not `wss://` — it is the §2.3 `--insecure-listen` case, and §2.3
+//!   obligations 1 and 2 require exactly this pair. Clients must set
+//!   [`ClientPolicy::allow_insecure_transport`], which is §2.3 obligation 3
+//!   working as designed rather than a workaround.
+//! - `durability_mode: memory`. Storage is a `BTreeMap` that dies with the
+//!   process. §8.4 says an `APPEND` that returned 0 may not survive a crash in
+//!   this mode, which is true here in the strongest possible sense.
+//! - `queue_creation_mode: open`. §13.1 permits it for "a private relay on a
+//!   closed network", which is what a test double is. [`RelayConfig::with_pow`]
+//!   turns on `pow` mode for a client that wants to exercise stamps, at a
+//!   difficulty a phone would laugh at.
+//! - `antireplay_persistence: volatile`, because it is.
+//!
+//! None of those is a relaxation. Each is a policy `WIRE.md` allows, published
+//! where a client can read it and refuse.
+//!
+//! [`ClientPolicy::allow_insecure_transport`]: f2z_relay_proto::capabilities::ClientPolicy::allow_insecure_transport
+
+use std::time::Duration;
+
+use f2z_codec::commands::Capabilities;
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::pow::{ALGORITHM_BLAKE2B_LEADING_ZERO_BITS, PowParams};
+use f2z_codec::types::{ChannelBinding, ShortBytes};
+use f2z_relay_proto::capabilities::{
+    self, AntiReplayPersistence, ChannelBindingMode, DurabilityMode, QueueCreationMode,
+    TransportSecurity,
+};
+use f2z_relay_proto::key::SigningKey;
+
+use crate::clock::Clock;
+use crate::error::{Result, TestkitError};
+use crate::faults::PolicyFaults;
+
+/// The proof-of-work difficulty a `FakeRelay` demands when it demands any.
+///
+/// Eight leading zero bits is 256 expected hashes — microseconds. §12.4 is
+/// blunt that a difficulty high enough to cost an attacker anything is a
+/// difficulty that makes a cheap phone sit there heating up, and a test suite
+/// is the wrong place to pay that. What the low value still buys is the whole
+/// *shape* of the exchange: `GET_CHALLENGE`, a stamp over a relay-issued,
+/// single-use, expiring challenge, scoped to the target address, consumed on
+/// use. Every one of those is a client obligation and every one is exercised.
+pub const TESTKIT_POW_DIFFICULTY_BITS: u8 = 8;
+
+/// Where the channel binding of §5.3 comes from.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ChannelBindingSource {
+    /// 32 zero bytes, published as `channel_binding_mode: none`.
+    ///
+    /// The only honest choice for a relay with no TLS session, and §5.3's
+    /// stated consequence follows: the restart argument for a volatile
+    /// seen-set does not hold, so the document also says
+    /// `antireplay_persistence: volatile` and a client may refuse.
+    None,
+    /// A fixed value both ends are told, published as
+    /// `channel_binding_mode: tls-exporter`.
+    ///
+    /// **This is a simulation and is not a TLS exporter.** There is no TLS
+    /// session; the value is a constant handed to both ends, so it binds a
+    /// signature to *this configuration*, not to a session. It exists because
+    /// the exporter path is code a client must have and would otherwise be
+    /// unreachable without terminating TLS in a test. A client that treats a
+    /// passing test here as evidence about RFC 8446 §7.5 has misread it.
+    Simulated([u8; 32]),
+}
+
+// A channel binding is what every signature on the connection is bound to
+// (§5.3). It is never transmitted, and it is not printed either.
+impl core::fmt::Debug for ChannelBindingSource {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::None => f.write_str("ChannelBindingSource::None"),
+            Self::Simulated(_) => f.write_str("ChannelBindingSource::Simulated(<redacted>)"),
+        }
+    }
+}
+
+impl ChannelBindingSource {
+    /// The binding value both ends use.
+    #[must_use]
+    pub const fn value(self) -> ChannelBinding {
+        match self {
+            Self::None => ChannelBinding::zero(),
+            Self::Simulated(bytes) => ChannelBinding::new(bytes),
+        }
+    }
+
+    /// The `channel_binding_mode` byte this source publishes.
+    #[must_use]
+    pub const fn mode(self) -> ChannelBindingMode {
+        match self {
+            Self::None => ChannelBindingMode::None,
+            Self::Simulated(_) => ChannelBindingMode::TlsExporter,
+        }
+    }
+}
+
+/// Deliberate departures from `WIRE.md`, all off by default.
+///
+/// **Every field here makes the relay accept something a conforming relay would
+/// reject.** That is the most dangerous thing this crate can do: a fake that
+/// accepts what the real relay refuses teaches a client to write code that
+/// works in tests and fails in production. So each one is opt-in, each one is
+/// named after the rule it suspends, and [`Relaxations::any`] lets a harness
+/// assert that a run used none of them.
+///
+/// If you find yourself turning one on to make a client pass, the client is
+/// wrong. The exception is deliberately narrow: a *relay* implementer bringing
+/// up one layer at a time may want the layers below to stop refusing.
+///
+/// Deliberately **not** `#[non_exhaustive]`: like [`crate::faults::PolicyFaults`]
+/// this is built by the caller, in their own file, with struct-update syntax.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Relaxations {
+    /// Accept a payload whose length is not one of the published
+    /// `padding_sizes` (§9). Suspends `ERR_BAD_SIZE`.
+    pub accept_any_payload_size: bool,
+    /// Accept `timestamp_ms` outside `±clock_skew_ms` (§5.5). Suspends
+    /// `ERR_STALE_TIMESTAMP`. The seen-set still runs.
+    pub accept_any_timestamp: bool,
+    /// Accept `CREATE_QUEUE`, `CREATE_CONTACT_QUEUE` and `CONTACT_APPEND`
+    /// without a valid stamp even while the document demands one (§13.1).
+    /// Suspends `ERR_POW_REQUIRED` and `ERR_POW_INVALID`.
+    pub accept_missing_pow: bool,
+    /// Answer a second `HELLO` on one connection instead of refusing it
+    /// (§2.5, §3.5).
+    pub accept_repeated_hello: bool,
+}
+
+impl Relaxations {
+    /// Whether any rule is suspended.
+    #[must_use]
+    pub const fn any(self) -> bool {
+        self.accept_any_payload_size
+            || self.accept_any_timestamp
+            || self.accept_missing_pow
+            || self.accept_repeated_hello
+    }
+}
+
+/// Everything a [`FakeRelay`] is built from.
+///
+/// [`FakeRelay`]: crate::FakeRelay
+#[derive(Clone)]
+pub struct RelayConfig {
+    /// The 32-byte seed of the relay's long-term Ed25519 identity key. Fixed by
+    /// default so `relay_id` is reproducible across runs and can be written
+    /// into a test's expectations.
+    pub identity_seed: [u8; 32],
+    /// The seed of the address and challenge generator. See [`crate::rng`] for
+    /// why a test harness wants this deterministic and why that means
+    /// `f2z-fakerelay` must never be deployed.
+    pub rng_seed: [u8; 32],
+    /// The relay's clock. Frozen by default (§5.5, §7.7 are unreachable
+    /// otherwise).
+    pub clock: Clock,
+    /// Where §5.3's channel binding comes from.
+    pub channel_binding: ChannelBindingSource,
+    /// §2.5's deadline between accept and a valid `HELLO`.
+    pub handshake_timeout: Duration,
+    /// §2.4's server-side WebSocket Ping interval. Short by default so a test
+    /// does not wait 25 seconds to observe one.
+    pub ping_interval: Duration,
+    /// §2.4: close after this many consecutive missed Pongs.
+    pub missed_pongs_before_close: u32,
+    /// The published policy. Start from [`RelayConfig::default`] and edit; the
+    /// relay enforces what is in here, so an edit is a real policy change.
+    pub capabilities: Capabilities,
+    /// Deliberate departures from the specification. All off by default.
+    pub relaxations: Relaxations,
+    /// Faults that are properties of the relay rather than of a frame. Can also
+    /// be changed at runtime through [`crate::faults::FaultInjector`].
+    pub policy_faults: PolicyFaults,
+}
+
+// The two seeds decide the relay's identity key and every address it will hand
+// out. Neither is printed: the identity seed is genuinely secret key material,
+// and the address seed is §7.1's unpredictability in one value.
+impl core::fmt::Debug for RelayConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RelayConfig")
+            .field("identity_seed", &"<redacted>")
+            .field("rng_seed", &"<redacted>")
+            .field("clock", &self.clock)
+            .field("channel_binding", &self.channel_binding)
+            .field("handshake_timeout", &self.handshake_timeout)
+            .field("ping_interval", &self.ping_interval)
+            .field("relaxations", &self.relaxations)
+            .field("policy_faults", &self.policy_faults)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The default identity seed. A fixed, obviously-fake value: a `relay_id` that
+/// shows up in a production log is a `f2z-fakerelay` that should not be there.
+pub const DEFAULT_IDENTITY_SEED: [u8; 32] = *b"f2z-relay-testkit/fake-identity!";
+
+/// The default address-generator seed.
+pub const DEFAULT_RNG_SEED: [u8; 32] = *b"f2z-relay-testkit/fake-addresses";
+
+impl Default for RelayConfig {
+    fn default() -> Self {
+        let clock = Clock::default();
+        let identity = SigningKey::from_seed(&DEFAULT_IDENTITY_SEED);
+        let capabilities = default_capabilities(&identity, clock.now_ms())
+            // `defaults` is fallible only because its empty operator strings go
+            // through the same length-checked constructor as any other, and the
+            // testkit's strings are short constants. A default that cannot be
+            // built is a bug in this crate, not a condition a caller can act
+            // on, so it degrades to the unedited document rather than panicking
+            // inside `Default`.
+            .unwrap_or_else(|_| fallback_capabilities(&identity, clock.now_ms()));
+        Self {
+            identity_seed: DEFAULT_IDENTITY_SEED,
+            rng_seed: DEFAULT_RNG_SEED,
+            clock,
+            channel_binding: ChannelBindingSource::None,
+            handshake_timeout: Duration::from_millis(10_000),
+            ping_interval: Duration::from_millis(500),
+            missed_pongs_before_close: 2,
+            capabilities,
+            relaxations: Relaxations::default(),
+            policy_faults: PolicyFaults::default(),
+        }
+    }
+}
+
+impl RelayConfig {
+    /// The relay's identity key.
+    #[must_use]
+    pub fn identity(&self) -> SigningKey {
+        SigningKey::from_seed(&self.identity_seed)
+    }
+
+    /// Demand a proof-of-work stamp for queue creation (§13.1's default mode),
+    /// at [`TESTKIT_POW_DIFFICULTY_BITS`].
+    #[must_use]
+    pub fn with_pow(mut self) -> Self {
+        self.capabilities.queue_creation_mode = QueueCreationMode::Pow.code();
+        self.capabilities.queue_creation_pow = testkit_pow();
+        self
+    }
+
+    /// Run on the host's wall clock instead of a frozen one. What
+    /// `f2z-fakerelay` does, so a real client's real `timestamp_ms` lands
+    /// inside the window.
+    #[must_use]
+    pub fn with_system_clock(mut self) -> Self {
+        self.clock = Clock::system();
+        self
+    }
+
+    /// Simulate a TLS exporter binding. Read [`ChannelBindingSource::Simulated`]
+    /// before relying on what this proves.
+    #[must_use]
+    pub fn with_simulated_channel_binding(mut self, value: [u8; 32]) -> Self {
+        self.channel_binding = ChannelBindingSource::Simulated(value);
+        self.capabilities.channel_binding_mode = ChannelBindingMode::TlsExporter.code();
+        self
+    }
+
+    /// Set the published padding buckets, and enforce them.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] if the set is not the strictly ascending,
+    /// non-empty, non-zero set §11.1 declares.
+    pub fn with_padding(mut self, buckets: &PaddingBuckets) -> Result<Self> {
+        self.capabilities.padding_sizes = buckets.sizes().to_vec().into();
+        self.capabilities.max_frame_bytes = self
+            .capabilities
+            .max_frame_bytes
+            .max(buckets.largest().saturating_add(4096));
+        capabilities::validate(&self.capabilities)
+            .map_err(|_| TestkitError::Config("padding set makes the document inconsistent"))?;
+        Ok(self)
+    }
+
+    /// The padding buckets this relay publishes and enforces.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] if the configured document does not carry a
+    /// valid set.
+    pub fn padding(&self) -> Result<PaddingBuckets> {
+        PaddingBuckets::new(self.capabilities.padding_sizes.as_slice().to_vec())
+            .map_err(|_| TestkitError::Config("padding_sizes is not a valid ascending set"))
+    }
+
+    /// The capability document this configuration will actually publish, with
+    /// every policy fault applied.
+    ///
+    /// Separate from [`RelayConfig::capabilities`] because a fault that changes
+    /// behaviour must also change the published document — a relay whose
+    /// document and conduct disagree is the one thing a client cannot defend
+    /// against.
+    #[must_use]
+    pub fn published_capabilities(&self, faults: PolicyFaults) -> Capabilities {
+        let mut published = self.capabilities.clone();
+        published.channel_binding_mode = self.channel_binding.mode().code();
+        if faults.unsound_antireplay_window {
+            // Exactly the document #586 says a relay may publish today while
+            // fully conforming, and exactly the one a client should refuse.
+            published.antireplay_window_ms = published.clock_skew_ms;
+        }
+        if let Some(max) = faults.max_queue_messages {
+            published.max_queue_messages = max;
+        }
+        if let Some(max) = faults.max_queue_bytes {
+            published.max_queue_bytes = max;
+        }
+        published
+    }
+}
+
+/// The proof-of-work parameters a `FakeRelay` publishes when it demands work.
+#[must_use]
+pub fn testkit_pow() -> PowParams {
+    PowParams {
+        algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+        difficulty_bits: TESTKIT_POW_DIFFICULTY_BITS,
+        challenge_ttl_ms: 60_000,
+    }
+}
+
+/// The document a `FakeRelay` publishes by default.
+///
+/// # Errors
+///
+/// [`TestkitError::Config`] if the operator strings do not fit their length
+/// prefixes, which they do.
+pub fn default_capabilities(identity: &SigningKey, published_at_ms: u64) -> Result<Capabilities> {
+    let mut capabilities = capabilities::defaults(&identity.public_key(), published_at_ms)
+        .map_err(|_| TestkitError::Config("could not build the default capability document"))?;
+
+    // §2.3: no TLS, so no exporter, so both bytes say so. A relay that lies
+    // about `transport_security` is lying in its signed document, and the point
+    // of publishing it is that lying becomes an act with evidence.
+    capabilities.transport_security = TransportSecurity::None.code();
+    capabilities.channel_binding_mode = ChannelBindingMode::None.code();
+    capabilities.antireplay_persistence = AntiReplayPersistence::Volatile.code();
+    // §8.4: a BTreeMap that dies with the process.
+    capabilities.durability_mode = DurabilityMode::Memory.code();
+    // §13.1: `open` is permitted for a private relay on a closed network.
+    capabilities.queue_creation_mode = QueueCreationMode::Open.code();
+    capabilities.queue_creation_pow = PowParams::none();
+    // §12.3 requires proof of work whenever contact queues are offered, so the
+    // difficulty is trivial rather than absent.
+    capabilities.contact_append_pow = testkit_pow();
+    // §13.3: nothing here rate-limits by source, and the field says so rather
+    // than claiming a control that is not implemented.
+    capabilities.per_source_limits = 0;
+
+    // §11.1's operator block is "the point of the document". Filling it with
+    // the truth about what this process is beats leaving it empty.
+    capabilities.operator_name = short("f2z-relay-testkit FakeRelay (NOT A RELAY)")?;
+    capabilities.operator_contact = short("https://github.com/free2z/zuu/issues")?;
+    capabilities.operator_abuse_contact = short("https://github.com/free2z/zuu/issues")?;
+    capabilities.operator_jurisdiction = short("none - a test double, running in a test process")?;
+    capabilities.operator_policy_url =
+        short("https://github.com/free2z/zuu/blob/main/rs/crates/f2z-relay-testkit/README.md")?;
+    capabilities.source_repo_url = short("https://github.com/free2z/zuu")?;
+    capabilities.source_commit = short("unversioned - built from a working tree")?;
+    capabilities.build_digest = short("none - this binary is not reproducibly built")?;
+
+    Ok(capabilities)
+}
+
+fn fallback_capabilities(identity: &SigningKey, published_at_ms: u64) -> Capabilities {
+    // Reached only if a short ASCII constant above stops fitting in 255 bytes.
+    // The unedited document is still a valid one; it just answers none of the
+    // questions §11.1 exists to answer.
+    capabilities::defaults(&identity.public_key(), published_at_ms).unwrap_or_else(|_| {
+        // `defaults` itself cannot fail for a well-formed key. Rather than
+        // panic in `Default`, fall through to a document built from the same
+        // call with the same argument; if that is impossible the process has
+        // bigger problems than its capability document.
+        #[expect(
+            clippy::unwrap_used,
+            reason = "unreachable: capabilities::defaults is fallible only on an \
+                      over-long operator string, and this call passes none"
+        )]
+        capabilities::defaults(&identity.public_key(), published_at_ms).unwrap()
+    })
+}
+
+fn short(text: &str) -> Result<ShortBytes> {
+    ShortBytes::new(text.as_bytes().to_vec())
+        .map_err(|_| TestkitError::Config("an operator string exceeds 255 bytes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_relay_proto::capabilities::ClientPolicy;
+
+    #[test]
+    fn the_default_document_is_valid_and_says_what_it_is() {
+        let config = RelayConfig::default();
+        assert!(capabilities::validate(&config.capabilities).is_ok());
+        assert_eq!(
+            config.capabilities.transport_security,
+            TransportSecurity::None.code()
+        );
+        assert_eq!(
+            config.capabilities.durability_mode,
+            DurabilityMode::Memory.code()
+        );
+        assert!(!config.relaxations.any());
+    }
+
+    #[test]
+    fn a_default_client_refuses_the_default_relay_until_it_opts_in() {
+        // §2.3 obligation 3, working. This is the correct behaviour and a
+        // client author should see it fail before they see it pass.
+        let config = RelayConfig::default();
+        let strict = ClientPolicy::default();
+        assert!(strict.accept(&config.capabilities).is_err());
+
+        let opted_in = ClientPolicy {
+            allow_insecure_transport: true,
+            ..ClientPolicy::default()
+        };
+        assert!(opted_in.accept(&config.capabilities).is_ok());
+    }
+
+    #[test]
+    fn the_unsound_antireplay_fault_changes_the_published_document() {
+        let config = RelayConfig::default();
+        let faults = PolicyFaults {
+            unsound_antireplay_window: true,
+            ..PolicyFaults::default()
+        };
+        let published = config.published_capabilities(faults);
+        assert_eq!(published.antireplay_window_ms, published.clock_skew_ms);
+        // Still a *valid* document — that is the whole finding of #586.
+        assert!(capabilities::validate(&published).is_ok());
+        // And still refused by a client that checks the relation.
+        let policy = ClientPolicy {
+            allow_insecure_transport: true,
+            ..ClientPolicy::default()
+        };
+        assert!(policy.accept(&published).is_err());
+    }
+
+    #[test]
+    fn pow_mode_publishes_parameters_a_client_can_satisfy() {
+        let config = RelayConfig::default().with_pow();
+        assert!(capabilities::validate(&config.capabilities).is_ok());
+        assert!(config.capabilities.queue_creation_pow.is_required());
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/connection.rs
+++ b/rs/crates/f2z-relay-testkit/src/connection.rs
@@ -1,0 +1,311 @@
+//! One connection, driven identically over a pipe and over a socket.
+//!
+//! [`drive`] is the only connection loop in this crate. `FakeRelay::connect`
+//! hands it one end of a `tokio::io::duplex`; the `ws://` listener hands it a
+//! WebSocket. Everything below this line — the handshake deadline of §2.5, the
+//! keepalive of §2.4, the fatal-close rule of §1.3, and every fault effect — is
+//! written once and therefore cannot differ between the two.
+//!
+//! # Why the writer is a separate task
+//!
+//! Three of the fault effects are about *time*, not about content: a delay, a
+//! reorder, and a stall. None of them is expressible in a loop that reads a
+//! frame and writes its answer before reading again, because the answer to
+//! request 2 has to be able to overtake the answer to request 1. §4.3 says a
+//! relay "MAY complete a cheap `PING` before an expensive `READ` issued
+//! earlier, and will" — so a fake that could not do that would be a fake that
+//! quietly promised ordering the protocol denies.
+//!
+//! The split also makes the in-flight accounting honest. A dropped response is
+//! one the relay *sent*, so its `request_id` is released; a stalled response is
+//! one the relay never produced, so its id stays outstanding and §4.3's window
+//! fills. That distinction is decided in the engine, before the frame reaches
+//! the writer, and is the reason [`crate::faults::Effect::Stall`] and
+//! [`crate::faults::Effect::Drop`] are two effects rather than one.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{mpsc, watch};
+
+use crate::engine::Relay;
+use crate::faults::{Effect, FaultInjector};
+use crate::outbound::{CLOSE_NORMAL, CLOSE_PROTOCOL_ERROR, OutKind, Outbound};
+use crate::transport::{Transport, TransportSink, WireMessage};
+
+/// Serve one connection until either end closes.
+pub async fn drive(relay: Arc<Relay>, transport: Transport) {
+    let (sink, mut stream) = transport.split();
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<Outbound>();
+    let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+
+    let mut connection = relay.open_connection(outbound_tx.clone());
+    let faults = relay.faults().clone();
+    let writer = tokio::spawn(writer_task(sink, outbound_rx, faults, shutdown_tx));
+
+    let handshake_timeout = relay.config().handshake_timeout;
+    let ping_interval = relay.config().ping_interval;
+    let missed_pongs_before_close = relay.config().missed_pongs_before_close;
+    let mut missed_pongs = 0u32;
+    let mut ping = tokio::time::interval(ping_interval);
+    // The first tick of an `interval` fires immediately; a Ping before the
+    // client has even said HELLO is noise, not keepalive.
+    ping.tick().await;
+
+    loop {
+        let waiting_for_hello = !connection.hello_done;
+        let received = tokio::select! {
+            biased;
+            _ = shutdown_rx.changed() => break,
+            _ = ping.tick(), if !waiting_for_hello => {
+                // §2.4: the relay sends a Ping every `ws_ping_interval_seconds`
+                // and closes after two consecutive missed Pongs. Server-driven
+                // rather than client-driven because the browser WebSocket API
+                // cannot send a Ping frame at all, so a client-side keepalive
+                // would be a second mechanism only one of the two clients has.
+                missed_pongs = missed_pongs.saturating_add(1);
+                if missed_pongs > missed_pongs_before_close {
+                    let _ = outbound_tx.send(close_now(CLOSE_NORMAL));
+                    break;
+                }
+                let _ = outbound_tx.send(Outbound::keepalive());
+                continue;
+            }
+            message = read_with_deadline(&mut stream, waiting_for_hello, handshake_timeout) => message,
+        };
+
+        let message = match received {
+            Ok(Some(message)) => message,
+            // End of stream, a transport error, or §2.5's handshake deadline.
+            Ok(None) | Err(()) => break,
+        };
+
+        match message {
+            WireMessage::Binary(bytes) => {
+                for outbound in relay.handle_binary(&mut connection, &bytes) {
+                    if outbound_tx.send(outbound).is_err() {
+                        break;
+                    }
+                }
+            }
+            WireMessage::Text(_) => {
+                // §4.2, and nothing else: no decode attempt, no UTF-8
+                // validation of our own, no treating it as an accidental
+                // binary frame.
+                for outbound in relay.handle_text() {
+                    let _ = outbound_tx.send(outbound);
+                }
+                break;
+            }
+            WireMessage::Ping(payload) => {
+                let _ = outbound_tx.send(pong(payload));
+            }
+            WireMessage::Pong(_) => {
+                missed_pongs = 0;
+            }
+            WireMessage::Close(_) => break,
+        }
+    }
+
+    relay.close_connection(&connection);
+    drop(outbound_tx);
+    let _ = writer.await;
+}
+
+async fn read_with_deadline(
+    stream: &mut Box<dyn crate::transport::TransportStream>,
+    waiting_for_hello: bool,
+    timeout: Duration,
+) -> Result<Option<WireMessage>, ()> {
+    // §2.5: "A relay MUST cap the time between TCP accept and a valid `HELLO`
+    // (`handshake_timeout_ms`, default 10 000) and close on expiry." The cap
+    // applies only until HELLO; after that a subscribed client on a quiet queue
+    // legitimately sends nothing for hours, and §2.4's keepalive is what
+    // notices a dead one.
+    let read = stream.recv();
+    if waiting_for_hello {
+        match tokio::time::timeout(timeout, read).await {
+            Ok(Ok(message)) => Ok(message),
+            Ok(Err(_)) | Err(_) => Err(()),
+        }
+    } else {
+        read.await.map_err(|_| ())
+    }
+}
+
+fn pong(payload: Vec<u8>) -> Outbound {
+    Outbound {
+        bytes: payload,
+        kind: OutKind::Keepalive,
+        close_after: None,
+    }
+}
+
+fn close_now(status: u16) -> Outbound {
+    Outbound {
+        bytes: Vec::new(),
+        kind: OutKind::Response { effect: None },
+        close_after: Some(status),
+    }
+}
+
+/// The writer: the only place frames are actually put on the wire, and the only
+/// place delivery faults are applied.
+///
+/// It is a small scheduler rather than a loop, because a delay that blocked the
+/// frames behind it would not be a delay — it would be a stall of the whole
+/// connection, and §4.3's "responses may arrive out of order … and will" would
+/// be untestable. A delayed frame is parked with a deadline and the writer goes
+/// back to serving whatever else is ready.
+async fn writer_task(
+    mut sink: Box<dyn TransportSink>,
+    mut outbound: mpsc::UnboundedReceiver<Outbound>,
+    faults: FaultInjector,
+    shutdown: watch::Sender<bool>,
+) {
+    // §4.3's reordering, as a one-frame hold. Held frames are flushed when the
+    // connection ends, so a reorder rule that never sees a second frame
+    // degrades to a delay rather than to a silent drop — a fake that lost a
+    // frame here would be teaching a client the wrong lesson.
+    let mut held: Option<Outbound> = None;
+    let mut parked: Vec<(tokio::time::Instant, Outbound)> = Vec::new();
+    let mut inbound_open = true;
+
+    loop {
+        let due = parked.iter().map(|(deadline, _)| *deadline).min();
+
+        let frame = tokio::select! {
+            biased;
+            () = wait_until(due) => {
+                let Some(index) = earliest(&parked) else { continue };
+                if index >= parked.len() {
+                    continue;
+                }
+                let (_, mut frame) = parked.remove(index);
+                frame.kind = OutKind::Ready;
+                frame
+            }
+            received = outbound.recv(), if inbound_open => {
+                match received {
+                    Some(frame) => frame,
+                    None => {
+                        inbound_open = false;
+                        if parked.is_empty() {
+                            break;
+                        }
+                        continue;
+                    }
+                }
+            }
+        };
+
+        let effect = match frame.kind {
+            OutKind::Response { effect } => effect,
+            OutKind::Push { event } => faults.take_push_effect(event),
+            // Never faulted: a suppressed keepalive presents as a hung relay
+            // rather than as the fault it is. A parked frame has already had
+            // its rule applied.
+            OutKind::Keepalive | OutKind::Ready => None,
+        };
+
+        match effect {
+            Some(Effect::Drop | Effect::Stall) => continue,
+            Some(Effect::Delay(duration)) => {
+                let deadline = tokio::time::Instant::now()
+                    .checked_add(duration)
+                    // A delay longer than the runtime's clock can express is a
+                    // configuration mistake, not a fault worth honouring; the
+                    // frame goes out now rather than never.
+                    .unwrap_or_else(tokio::time::Instant::now);
+                parked.push((deadline, frame));
+                continue;
+            }
+            Some(Effect::Reorder) => {
+                if held.is_none() {
+                    held = Some(frame);
+                    continue;
+                }
+            }
+            Some(Effect::CloseBefore) => {
+                let _ = sink.close(CLOSE_PROTOCOL_ERROR).await;
+                let _ = shutdown.send(true);
+                return;
+            }
+            // A refusal never reaches the writer: it was applied in the engine,
+            // before the command ran, and arrived here as an ordinary error
+            // response.
+            Some(Effect::Close | Effect::Refuse(_)) | None => {}
+        }
+
+        let closing = frame.close_after;
+        let close_after_effect = matches!(effect, Some(Effect::Close));
+        if write(&mut sink, frame).await.is_err() {
+            break;
+        }
+        if let Some(waiting) = held.take()
+            && write(&mut sink, waiting).await.is_err()
+        {
+            break;
+        }
+        if let Some(status) = closing {
+            let _ = sink.close(status).await;
+            let _ = shutdown.send(true);
+            return;
+        }
+        if close_after_effect {
+            let _ = sink.close(CLOSE_NORMAL).await;
+            let _ = shutdown.send(true);
+            return;
+        }
+        if !inbound_open && parked.is_empty() {
+            break;
+        }
+    }
+
+    if let Some(waiting) = held.take() {
+        let _ = write(&mut sink, waiting).await;
+    }
+    let _ = sink.close(CLOSE_NORMAL).await;
+    let _ = shutdown.send(true);
+}
+
+/// Sleep until `deadline`, or forever when there is nothing parked.
+async fn wait_until(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+fn earliest(parked: &[(tokio::time::Instant, Outbound)]) -> Option<usize> {
+    let mut best: Option<(usize, tokio::time::Instant)> = None;
+    for (index, (deadline, _)) in parked.iter().enumerate() {
+        match best {
+            Some((_, current)) if current <= *deadline => {}
+            _ => best = Some((index, *deadline)),
+        }
+    }
+    best.map(|(index, _)| index)
+}
+
+async fn write(sink: &mut Box<dyn TransportSink>, frame: Outbound) -> std::io::Result<()> {
+    match frame.kind {
+        // A keepalive with an empty body is §2.4's Ping; one with a body is the
+        // Pong that answers a client's own Ping.
+        OutKind::Keepalive if frame.bytes.is_empty() => {
+            sink.send(WireMessage::Ping(Vec::new())).await
+        }
+        OutKind::Keepalive => sink.send(WireMessage::Pong(frame.bytes)).await,
+        // An empty-bodied response is not a frame at all: it is the bare close
+        // of a fatal error whose `request_id` could not be recovered (§4.2, and
+        // the unreadable-header case of §4.1).
+        OutKind::Response { .. } | OutKind::Push { .. } | OutKind::Ready
+            if frame.bytes.is_empty() =>
+        {
+            Ok(())
+        }
+        OutKind::Response { .. } | OutKind::Push { .. } | OutKind::Ready => {
+            sink.send(WireMessage::Binary(frame.bytes)).await
+        }
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/engine.rs
+++ b/rs/crates/f2z-relay-testkit/src/engine.rs
@@ -1,0 +1,1190 @@
+//! The relay itself: one frame in, zero or more frames out.
+//!
+//! This is the whole of `WIRE.md` that is not storage and not a socket, and it
+//! is the *only* implementation in this crate. The in-process transport and the
+//! real `ws://` listener both call [`Relay::handle_binary`]; if they did not,
+//! the fake would be two fakes and the in-process one would be lying about the
+//! other.
+//!
+//! # What is reused rather than rewritten
+//!
+//! Almost everything. `f2z-codec` owns re-encode equality (§3.3) and the
+//! framing (§4); `f2z-relay-proto` owns the verification order of §5.1, the
+//! anti-replay of §5.5, the queue rules of §7 and §8, and the capability
+//! document of §11. A relay that re-derived any of those would be a second
+//! opinion about the protocol, and the point of a conformance fake is that
+//! there is only one.
+//!
+//! What is genuinely decided here is the part those crates deliberately leave
+//! to a server: the order of the connection lifecycle (§2.5), the in-flight
+//! window (§4.3), which code answers which refusal, when a push is emitted, and
+//! the anti-abuse layering of §13.1.
+//!
+//! # The refusal codes, and the one rule behind most of them
+//!
+//! §6.3: **every send-side refusal that would distinguish queue state collapses
+//! to `ERR_UNAVAILABLE`.** Absent, deleted, expired, full-by-messages,
+//! full-by-bytes, unbound, wrong key, relay backpressure — one code. If they
+//! differed, a bound sender could learn the queue's depth by filling it, which
+//! is the escalation the two-address split exists to prevent. §10's table
+//! assigns "absent" to code 10 and therefore contradicts §6.3; [#586] tracks
+//! it, #583 resolved it in §6.3's favour, and this engine does the same.
+//!
+//! On the receive side the mirror rule is §10's existence-oracle rule: "no such
+//! queue" and "exists, but your key does not authorize it" return the same code
+//! 10, and the absent path performs a dummy Ed25519 verification first so the
+//! dominant CPU cost is present in both. That narrowing is exactly what §10
+//! says it is — a narrowing, not a closure.
+//!
+//! [#586]: https://github.com/free2z/zuu/issues/586
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+
+use f2z_codec::canonical::{Canonical, decode_canonical};
+use f2z_codec::commands::{
+    AckRequest, AckResponse, AppendRequest, Capabilities, ChallengePurpose, ChallengeRequest,
+    ChallengeResponse, Command, ContactAppendRequest, CreateContactQueueRequest,
+    CreateContactQueueResponse, CreateQueueRequest, CreateQueueResponse, HelloRequest,
+    HelloResponse, PushEvent, ReadRequest, ReadResponse, SubscribeResponse,
+};
+use f2z_codec::frame::{FramePayload, RelayFrame, Request, Response};
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::pow::{PowParams, PowStamp};
+use f2z_codec::transcript::TranscriptBuilder;
+use f2z_codec::types::{Digest, QueueAddress, RelayId};
+use f2z_codec::{ErrorCode, PROTOCOL_VERSION};
+use f2z_relay_proto::capabilities::{
+    self, ChannelBindingMode, QueueCreationMode, TransportSecurity,
+};
+use f2z_relay_proto::command::{CommandVerifier, Empty, RelayCommand, Verified, ops};
+use f2z_relay_proto::hello::{RelayAnnouncement, hello_response};
+use f2z_relay_proto::key::{SigningKey, dummy_verify};
+use f2z_relay_proto::queue::{AppendQuota, QueueKind, TtlPolicy};
+use f2z_relay_proto::replay::{SeenSet, TimestampWindow};
+use f2z_relay_proto::{ProtoError, capabilities::AntiReplayPersistence};
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::clock::Clock;
+use crate::config::{ChannelBindingSource, RelayConfig};
+use crate::error::{Result, TestkitError};
+use crate::faults::{Effect, FaultInjector, PolicyFaults};
+use crate::outbound::{
+    CLOSE_PROTOCOL_ERROR, CLOSE_UNSUPPORTED_DATA, OutKind, Outbound, push as push_frame,
+};
+use crate::state::{NOTICE_CAPABILITIES_CHANGED, RelayState};
+
+/// The default `antireplay_seen_max` of §5.5.
+///
+/// `WIRE.md` publishes the field but no default. 65 536 entries is about 3 MiB
+/// of `(key, nonce)` pairs, which is a bound a test process will never reach by
+/// accident and a fault can shrink deliberately.
+pub const DEFAULT_SEEN_MAX: usize = 65_536;
+
+/// One relay, shared by every connection it serves.
+pub struct Relay {
+    config: RelayConfig,
+    identity: SigningKey,
+    relay_id: RelayId,
+    clock: Clock,
+    faults: FaultInjector,
+    padding: PaddingBuckets,
+    ttl: TtlPolicy,
+    state: Mutex<RelayState>,
+}
+
+impl std::fmt::Debug for Relay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Relay")
+            .field("relay_id", &self.relay_id)
+            .field("armed_faults", &self.faults.armed())
+            .finish_non_exhaustive()
+    }
+}
+
+/// One connection's state.
+///
+/// §6.2: "a subscription is scoped to the connection and dies with it", and
+/// §4.3's in-flight window is per connection too. Everything else a relay knows
+/// is shared.
+#[derive(Debug)]
+pub struct Connection {
+    /// Identifier, so a subscription can be found and dropped.
+    pub id: u64,
+    /// Whether `HELLO` has completed (§2.5 step 2).
+    pub hello_done: bool,
+    /// §4.3's outstanding `request_id`s.
+    pub inflight: BTreeSet<u32>,
+    /// The receive addresses this connection is subscribed to.
+    pub subscriptions: BTreeSet<QueueAddress>,
+    /// Where pushes go.
+    pub pushes: UnboundedSender<Outbound>,
+    /// The transcript builder for this connection: the relay's own `relay_id`
+    /// and its own `channel_binding`, never the frame's (§5.2, §5.3).
+    pub transcripts: TranscriptBuilder,
+}
+
+impl Relay {
+    /// Build a relay from a configuration.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] if the configured capability document is not a
+    /// valid one, if its padding set is malformed, or if it selects
+    /// `queue_creation_mode: token`, which this crate does not implement — a
+    /// bearer token is an operator-issued credential with no protocol shape in
+    /// v1, and faking one would be inventing protocol rather than testing it.
+    pub fn new(config: RelayConfig) -> Result<Self> {
+        capabilities::validate(&config.capabilities)
+            .map_err(|_| TestkitError::Config("the configured capability document is invalid"))?;
+        if config.capabilities.queue_creation_mode == QueueCreationMode::Token.code() {
+            return Err(TestkitError::Config(
+                "queue_creation_mode: token is not implemented; \
+                 a bearer token has no protocol shape in WIRE.md v1",
+            ));
+        }
+        // §2.3 obligations 1 and 2 are a pair. A document that claims TLS while
+        // the process serves ws:// would be the one thing a client cannot
+        // defend against.
+        if config.capabilities.transport_security == TransportSecurity::Tls.code() {
+            return Err(TestkitError::Config(
+                "a FakeRelay serves ws://, so transport_security must be none (WIRE.md §2.3)",
+            ));
+        }
+        if config.capabilities.channel_binding_mode != config.channel_binding.mode().code() {
+            return Err(TestkitError::Config(
+                "channel_binding_mode disagrees with the configured binding source",
+            ));
+        }
+
+        let padding = config.padding()?;
+        let identity = config.identity();
+        let relay_id = f2z_codec::hash::relay_id(&identity.public_key());
+        let ttl = capabilities::ttl_policy(&config.capabilities);
+        let faults = FaultInjector::new();
+        faults.set_policy(config.policy_faults);
+        let clock = config.clock.clone();
+        let seen = Self::seen_set(&config, config.policy_faults);
+        let state = Mutex::new(RelayState::new(config.rng_seed, seen));
+        Ok(Self {
+            config,
+            identity,
+            relay_id,
+            clock,
+            faults,
+            padding,
+            ttl,
+            state,
+        })
+    }
+
+    fn seen_set(config: &RelayConfig, faults: PolicyFaults) -> SeenSet {
+        let published = config.published_capabilities(faults);
+        SeenSet::new(
+            u64::from(published.antireplay_window_ms),
+            faults.seen_set_max.unwrap_or(DEFAULT_SEEN_MAX),
+        )
+    }
+
+    /// The relay's identity binding (§5.2).
+    #[must_use]
+    pub const fn relay_id(&self) -> RelayId {
+        self.relay_id
+    }
+
+    /// The relay's long-term public key.
+    #[must_use]
+    pub fn identity_key(&self) -> f2z_codec::types::PublicKey {
+        self.identity.public_key()
+    }
+
+    /// The relay's clock.
+    #[must_use]
+    pub const fn clock(&self) -> &Clock {
+        &self.clock
+    }
+
+    /// The live fault handle.
+    #[must_use]
+    pub const fn faults(&self) -> &FaultInjector {
+        &self.faults
+    }
+
+    /// The configuration this relay was built from.
+    #[must_use]
+    pub const fn config(&self) -> &RelayConfig {
+        &self.config
+    }
+
+    /// The channel binding both ends use (§5.3).
+    #[must_use]
+    pub const fn channel_binding(&self) -> f2z_codec::types::ChannelBinding {
+        self.config.channel_binding.value()
+    }
+
+    /// The document as it stands right now, with every policy fault applied.
+    ///
+    /// Recomputed rather than cached because a fault armed mid-connection is a
+    /// policy change, and §6.4's `NOTICE(3)` exists precisely so a client can
+    /// find out about one without polling.
+    #[must_use]
+    pub fn published_capabilities(&self) -> Capabilities {
+        self.config.published_capabilities(self.faults.policy())
+    }
+
+    /// The signed document (§11.1).
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] if the document cannot be signed, which needs
+    /// an operator string longer than its length prefix.
+    pub fn signed_capabilities(&self) -> Result<f2z_codec::commands::SignedCapabilities> {
+        capabilities::sign(&self.identity, self.published_capabilities())
+            .map_err(|_| TestkitError::Config("could not sign the capability document"))
+    }
+
+    /// `capabilities_digest` for `HELLO` (§6.1).
+    ///
+    /// # Errors
+    ///
+    /// As [`Relay::signed_capabilities`].
+    pub fn capabilities_digest(&self) -> Result<Digest> {
+        capabilities::digest(&self.published_capabilities())
+            .map_err(|_| TestkitError::Config("could not digest the capability document"))
+    }
+
+    /// Announce a capability change to every subscribed connection — §6.4's
+    /// `NOTICE(3)`.
+    ///
+    /// Arming a policy fault changes the document; calling this afterwards is
+    /// what makes a client's re-fetch path reachable.
+    pub fn announce_capability_change(&self) {
+        let now = self.clock.now_ms();
+        if let Ok(state) = self.state.lock() {
+            state.notify_all(NOTICE_CAPABILITIES_CHANGED, now);
+        }
+    }
+
+    /// Open a connection.
+    pub fn open_connection(&self, pushes: UnboundedSender<Outbound>) -> Connection {
+        let id = self
+            .state
+            .lock()
+            .map_or(0, |mut state| state.next_connection_id());
+        Connection {
+            id,
+            hello_done: false,
+            inflight: BTreeSet::new(),
+            subscriptions: BTreeSet::new(),
+            pushes,
+            transcripts: TranscriptBuilder::new(
+                PROTOCOL_VERSION,
+                self.relay_id,
+                self.channel_binding(),
+            ),
+        }
+    }
+
+    /// Release a connection's subscriptions (§6.2).
+    pub fn close_connection(&self, connection: &Connection) {
+        if let Ok(mut state) = self.state.lock() {
+            state.drop_connection(connection.id, &connection.subscriptions);
+        }
+    }
+
+    /// Whether §13.1 layer 4's global backpressure is on.
+    fn backpressured(&self) -> bool {
+        self.faults.policy().global_backpressure
+    }
+
+    // ---------------------------------------------------------------------
+    // The frame path.
+    // ---------------------------------------------------------------------
+
+    /// §4.2: a text frame is a fatal `ERR_FRAME_TYPE`, closed with status 1003.
+    ///
+    /// The relay MUST NOT attempt to decode it, MUST NOT attempt UTF-8
+    /// validation beyond what the WebSocket layer already did, and MUST NOT
+    /// treat it as an accidental binary frame. All three are the absence of
+    /// code here.
+    #[must_use]
+    pub fn handle_text(&self) -> Vec<Outbound> {
+        // A text frame carries no recoverable `request_id`, so there is no
+        // response frame a conforming relay could build: §4.3 requires a
+        // response's id to be nonzero. The connection closes with 1003, which
+        // is what §4.2 actually names.
+        vec![Outbound {
+            bytes: Vec::new(),
+            kind: OutKind::Response { effect: None },
+            close_after: Some(CLOSE_UNSUPPORTED_DATA),
+        }]
+    }
+
+    /// Handle one binary frame (§4.1).
+    #[must_use]
+    pub fn handle_binary(&self, connection: &mut Connection, bytes: &[u8]) -> Vec<Outbound> {
+        let now = self.clock.now_ms();
+        let published = self.published_capabilities();
+
+        // §4.1: a frame exceeding `max_frame_bytes` is `ERR_MALFORMED`, fatal,
+        // and the relay MUST NOT buffer the remainder to produce a tidy error.
+        if bytes.len() > published.max_frame_bytes as usize {
+            return self.fatal(recover_request_id(bytes), ErrorCode::Malformed);
+        }
+
+        // §3.3 on the frame. Decode, re-encode, byte-compare — and the
+        // *re-encoded* bytes are what any signature covers.
+        let Ok(frame) = decode_canonical::<RelayFrame>(bytes) else {
+            return self.fatal(recover_request_id(bytes), ErrorCode::Malformed);
+        };
+        let frame = frame.into_value();
+        if frame.validate().is_err() {
+            return self.fatal(recover_request_id(bytes), ErrorCode::Malformed);
+        }
+        let request_id = frame.request_id;
+        let FramePayload::Request(request) = &frame.payload else {
+            // A client that sends a response or a push is speaking the wrong
+            // half of the protocol. §10 has no code for it; `ERR_MALFORMED` is
+            // the reading, and it is fatal, which is right for a frame no
+            // conforming client emits.
+            return self.fatal(request_id, ErrorCode::Malformed);
+        };
+
+        // §2.5 step 2: `HELLO` MUST be the first frame; a relay that receives
+        // any other frame first responds `ERR_UNSUPPORTED_VERSION` and closes.
+        let command = request.command();
+        if !connection.hello_done && command != Some(Command::Hello) {
+            return self.fatal(request_id, ErrorCode::UnsupportedVersion);
+        }
+        if connection.hello_done
+            && command == Some(Command::Hello)
+            && !self.config.relaxations.accept_repeated_hello
+        {
+            // §3.5: "version negotiation happens once, in HELLO, and applies to
+            // the whole connection." A second HELLO is a renegotiation attempt
+            // and gets the same code a version failure does. Listed as an
+            // ambiguity call: §10 does not name this case.
+            return self.fatal(request_id, ErrorCode::UnsupportedVersion);
+        }
+
+        // §4.3. A duplicate in-flight id is a fatal `ERR_MALFORMED`; exceeding
+        // the window is a fatal `ERR_TOO_MANY_INFLIGHT`. Both bounds exist so a
+        // single connection cannot make the relay allocate unbounded
+        // per-request state before any quota check has run.
+        if connection.inflight.contains(&request_id) {
+            return self.fatal(request_id, ErrorCode::Malformed);
+        }
+        if connection.inflight.len() >= usize::from(published.max_inflight) {
+            return self.fatal(request_id, ErrorCode::TooManyInflight);
+        }
+        connection.inflight.insert(request_id);
+
+        // A fault may refuse the command outright. Consulted here, before any
+        // state changes, so a refused APPEND really did not append.
+        let outcome = match self.faults.take_refusal(command) {
+            Some(code) => Err(ProtoError::Wire(code)),
+            None => match command {
+                Some(command) => self.dispatch(connection, now, request_id, command, request),
+                // §3.5: an unknown command code is a *non-fatal*
+                // `ERR_UNKNOWN_COMMAND`. The frame was well-formed framing, so
+                // the connection survives.
+                None => Err(ProtoError::Wire(ErrorCode::UnknownCommand)),
+            },
+        };
+
+        let (response, fatal) = match outcome {
+            Ok(body) => (
+                Response::ok(body).unwrap_or_else(|_| Response::error(ErrorCode::Internal)),
+                false,
+            ),
+            Err(error) => {
+                let code = error.wire_code().unwrap_or(ErrorCode::Internal);
+                (Response::error(code), code.is_fatal())
+            }
+        };
+
+        // §4.3's window is released when the relay answers. A stalled response
+        // is never answered, so its id stays outstanding — which is the whole
+        // point of the fault: a client that never times out will fill the
+        // window and earn a fatal `ERR_TOO_MANY_INFLIGHT`.
+        let effect = self.faults.take_response_effect(command);
+        if matches!(effect, Some(Effect::Stall)) {
+            return Vec::new();
+        }
+        connection.inflight.remove(&request_id);
+
+        let close = if fatal {
+            Some(CLOSE_PROTOCOL_ERROR)
+        } else {
+            None
+        };
+        match Outbound::response(request_id, response, effect) {
+            Some(mut outbound) => {
+                outbound.close_after = close;
+                vec![outbound]
+            }
+            None => self.fatal(request_id, ErrorCode::Internal),
+        }
+    }
+
+    fn fatal(&self, request_id: u32, code: ErrorCode) -> Vec<Outbound> {
+        // A frame whose `request_id` could not be recovered has no response a
+        // conforming relay can build (§4.3 forbids a zero id on a response), so
+        // the connection simply closes. Listed as an ambiguity call: §4.1 says
+        // "send the error and close" and does not say what to send when the id
+        // is unreadable.
+        if request_id == 0 {
+            return vec![Outbound {
+                bytes: Vec::new(),
+                kind: OutKind::Response { effect: None },
+                close_after: Some(CLOSE_PROTOCOL_ERROR),
+            }];
+        }
+        Outbound::fatal(request_id, code, CLOSE_PROTOCOL_ERROR)
+            .map_or_else(Vec::new, |outbound| vec![outbound])
+    }
+
+    // ---------------------------------------------------------------------
+    // Command dispatch.
+    // ---------------------------------------------------------------------
+
+    fn dispatch(
+        &self,
+        connection: &mut Connection,
+        now: u64,
+        request_id: u32,
+        command: Command,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        match command {
+            Command::Hello => self.hello(connection, request),
+            Command::GetCapabilities => self.get_capabilities(request),
+            Command::GetChallenge => self.get_challenge(now, request),
+            Command::Ping => self.ping(request),
+            Command::CreateQueue => self.create_queue(connection, now, request_id, request),
+            Command::CreateContactQueue => {
+                self.create_contact_queue(connection, now, request_id, request)
+            }
+            Command::Subscribe => self.subscribe(connection, now, request_id, request),
+            Command::Unsubscribe => self.unsubscribe(connection, now, request_id, request),
+            Command::Read => self.read(connection, now, request_id, request),
+            Command::Ack => self.ack(connection, now, request_id, request),
+            Command::DeleteQueue => self.delete_queue(connection, now, request_id, request),
+            Command::BindSend => self.bind_send(connection, now, request_id, request),
+            Command::Append => self.append(connection, now, request_id, request),
+            Command::ContactAppend => self.contact_append(now, request),
+            // `Command` is `#[non_exhaustive]`: a code added to f2z-codec but
+            // not handled here is a hole in this relay, not in the client that
+            // sent it. §3.5's non-fatal `ERR_UNKNOWN_COMMAND` is the honest
+            // answer — this build genuinely does not implement it.
+            _ => Err(ProtoError::Wire(ErrorCode::UnknownCommand)),
+        }
+    }
+
+    // -- §6.1, unsigned ----------------------------------------------------
+
+    fn hello(
+        &self,
+        connection: &mut Connection,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let offer: HelloRequest = self.accept_unsigned::<ops::Hello>(request)?.into_body();
+        if offer.min_version > offer.max_version
+            || PROTOCOL_VERSION < offer.min_version
+            || PROTOCOL_VERSION > offer.max_version
+        {
+            return Err(ProtoError::Wire(ErrorCode::UnsupportedVersion));
+        }
+        let digest = self
+            .capabilities_digest()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+        let announcement = RelayAnnouncement {
+            protocol_version: PROTOCOL_VERSION,
+            relay_time_ms: self.clock.now_ms(),
+            channel_binding_mode: match self.config.channel_binding {
+                ChannelBindingSource::None => ChannelBindingMode::None,
+                ChannelBindingSource::Simulated(_) => ChannelBindingMode::TlsExporter,
+            },
+            transport_security: TransportSecurity::None,
+            capabilities_digest: digest,
+        };
+        let response: HelloResponse = hello_response(
+            &self.identity,
+            &announcement,
+            &self.channel_binding(),
+            &offer.client_nonce,
+        );
+        connection.hello_done = true;
+        Ok(response.encode_canonical()?)
+    }
+
+    fn get_capabilities(&self, request: &Request) -> std::result::Result<Vec<u8>, ProtoError> {
+        let _: Empty = self
+            .accept_unsigned::<ops::GetCapabilities>(request)?
+            .into_body();
+        let signed = self
+            .signed_capabilities()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+        Ok(signed.encode_canonical()?)
+    }
+
+    fn ping(&self, request: &Request) -> std::result::Result<Vec<u8>, ProtoError> {
+        let _: Empty = self.accept_unsigned::<ops::Ping>(request)?.into_body();
+        Ok(Vec::new())
+    }
+
+    fn get_challenge(
+        &self,
+        now: u64,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let body: ChallengeRequest = self
+            .accept_unsigned::<ops::GetChallenge>(request)?
+            .into_body();
+        // `purpose` is a raw byte so an unknown value round-trips through §3.3
+        // rather than failing to decode. §10 has no code for "an enum value in
+        // a body that this build does not know", so `ERR_MALFORMED` is the
+        // reading here and it is listed as an ambiguity call.
+        let purpose = body
+            .purpose()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Malformed))?;
+        let params = self.pow_params_for(purpose);
+        let ttl = if params.challenge_ttl_ms == 0 {
+            60_000
+        } else {
+            params.challenge_ttl_ms
+        };
+        let expires_at_ms = now.saturating_add(u64::from(ttl));
+
+        let challenge = {
+            let mut state = self.state()?;
+            state.expire_challenges(now);
+            state.issue_challenge(purpose.code(), body.scope.as_slice(), expires_at_ms)
+        };
+
+        let response = ChallengeResponse {
+            relay_time_ms: now,
+            challenge,
+            expires_at_ms,
+            pow: params,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn pow_params_for(&self, purpose: ChallengePurpose) -> PowParams {
+        let published = self.published_capabilities();
+        match purpose {
+            // §6.1: the field is zeroed when no PoW is required, and a clock
+            // read never requires one.
+            ChallengePurpose::Clock => PowParams::none(),
+            ChallengePurpose::QueueCreate => published.queue_creation_pow,
+            ChallengePurpose::ContactAppend => published.contact_append_pow,
+        }
+    }
+
+    // -- §6.2, signed by the receive key -----------------------------------
+
+    fn create_queue(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::CreateQueue>(connection, now, request_id, request)?;
+        let body: CreateQueueRequest = verified.into_body();
+
+        // §13.1 layer 4, in the order the section states it: creation is the
+        // first thing refused.
+        if self.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Backpressure));
+        }
+        self.check_creation_stamp(now, &body.stamp)?;
+
+        let published = self.published_capabilities();
+        let message_ttl = self.ttl.grant_message_ttl(body.req_message_ttl_seconds);
+        let idle_ttl = self.ttl.grant_idle_ttl(body.req_idle_ttl_seconds);
+        let quota = AppendQuota {
+            max_messages: u64::from(published.max_queue_messages),
+            max_bytes: published.max_queue_bytes,
+        };
+
+        let mut state = self.state()?;
+        if let Some(max) = self.faults.policy().max_queues
+            && state.queue_count() >= max
+        {
+            // §10 code 14: a recv-side quota. Unlike the send side, the receive
+            // side is allowed a distinguishable code — the party being refused
+            // is the one that owns the queues.
+            return Err(ProtoError::Wire(ErrorCode::Quota));
+        }
+        let (recv_addr, send_addr) = state.create_queue(
+            QueueKind::Standard,
+            body.recv_key,
+            message_ttl,
+            idle_ttl,
+            quota,
+            now,
+        );
+        drop(state);
+
+        let response = CreateQueueResponse {
+            recv_addr,
+            send_addr,
+            message_ttl_seconds: message_ttl,
+            idle_ttl_seconds: idle_ttl,
+            created_at_ms: now,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn create_contact_queue(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified =
+            self.verify::<ops::CreateContactQueue>(connection, now, request_id, request)?;
+        let body: CreateContactQueueRequest = verified.into_body();
+
+        let published = self.published_capabilities();
+        if published.contact_queues_enabled == 0 {
+            return Err(ProtoError::Wire(ErrorCode::NotPermitted));
+        }
+        if self.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Backpressure));
+        }
+        self.check_creation_stamp(now, &body.stamp)?;
+
+        let message_ttl = self.ttl.grant_message_ttl(body.req_message_ttl_seconds);
+        let idle_ttl = self.ttl.grant_idle_ttl(body.req_idle_ttl_seconds);
+        // §12.3: a contact queue is hard-capped, because point 2 of §12.2 means
+        // the whole internet may write to it.
+        let quota = AppendQuota {
+            max_messages: u64::from(published.contact_max_pending),
+            max_bytes: published.contact_max_bytes,
+        };
+
+        let mut state = self.state()?;
+        if let Some(max) = self.faults.policy().max_queues
+            && state.queue_count() >= max
+        {
+            return Err(ProtoError::Wire(ErrorCode::Quota));
+        }
+        let (recv_addr, contact_addr) = state.create_queue(
+            QueueKind::Contact,
+            body.recv_key,
+            message_ttl,
+            idle_ttl,
+            quota,
+            now,
+        );
+        drop(state);
+
+        let response = CreateContactQueueResponse {
+            recv_addr,
+            contact_addr,
+            message_ttl_seconds: message_ttl,
+            idle_ttl_seconds: idle_ttl,
+            max_pending: published.contact_max_pending,
+            max_bytes: published.contact_max_bytes,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn subscribe(
+        &self,
+        connection: &mut Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::Subscribe>(connection, now, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_recv(&recv_addr) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&signer)?;
+        queue.touch(now);
+        let next_index = queue.state.next_index();
+        let pending = queue.pending();
+        state.subscribe(recv_addr, connection.id, connection.pushes.clone());
+        drop(state);
+        connection.subscriptions.insert(recv_addr);
+
+        let response = SubscribeResponse {
+            next_index,
+            pending,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn unsubscribe(
+        &self,
+        connection: &mut Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::Unsubscribe>(connection, now, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_recv(&recv_addr) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&signer)?;
+        state.unsubscribe(&recv_addr, connection.id);
+        drop(state);
+        connection.subscriptions.remove(&recv_addr);
+        Ok(Vec::new())
+    }
+
+    fn read(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::Read>(connection, now, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+        let body: ReadRequest = verified.into_body();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_recv(&recv_addr) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&signer)?;
+        // §13.1 layer 4: READ is never refused for backpressure. It is one of
+        // the operations that make the relay smaller, and refusing it under
+        // load is a deadlock.
+        let Some((messages, has_more)) = state.read(
+            &recv_addr,
+            body.from_index,
+            body.max_messages,
+            body.max_bytes,
+            now,
+        ) else {
+            return Err(self.absent_recv());
+        };
+        drop(state);
+
+        let response = ReadResponse {
+            messages: messages.into(),
+            has_more: u8::from(has_more),
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn ack(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::Ack>(connection, now, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+        let body: AckRequest = verified.into_body();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_recv(&recv_addr) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&signer)?;
+        let (outcome, pending) = state.ack(&recv_addr, body.up_to_index, now)?;
+        drop(state);
+
+        let response = AckResponse {
+            next_index: outcome.next_index,
+            pending,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn delete_queue(
+        &self,
+        connection: &mut Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::DeleteQueue>(connection, now, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_recv(&recv_addr) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&signer)?;
+        state.delete_queue(&recv_addr);
+        drop(state);
+        connection.subscriptions.remove(&recv_addr);
+        Ok(Vec::new())
+    }
+
+    // -- §6.3, signed by the send key --------------------------------------
+
+    fn bind_send(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::BindSend>(connection, now, request_id, request)?;
+        let send_addr = verified.address();
+        let signer = verified.signer_key();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_second(&send_addr) else {
+            return Err(self.absent_send());
+        };
+        // §7.3, and §7.4's consequence: the second bind is `ERR_ALREADY_BOUND`
+        // with any key, including the same key. A client that gets this on a
+        // first bind attempt for an address from a fresh advert must treat it
+        // as a loud, non-dismissible failure — the relay operator may have read
+        // `send_addr` out of its own database and bound first.
+        queue.state.bind_send(&signer)?;
+        queue.touch(now);
+        Ok(Vec::new())
+    }
+
+    fn append(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::Append>(connection, now, request_id, request)?;
+        let send_addr = verified.address();
+        let signer = verified.signer_key();
+        let body: AppendRequest = verified.into_body();
+
+        // §13.1 layer 4 step 2: an append under backpressure is
+        // `ERR_UNAVAILABLE`, never a code that says why.
+        if self.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        }
+
+        let payload_len = u64::try_from(body.payload.len()).unwrap_or(u64::MAX);
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_second(&send_addr) else {
+            return Err(self.absent_send());
+        };
+        // A contact queue's second address takes `CONTACT_APPEND`, not
+        // `APPEND`: its send side is never bound, so `authorize_send` refuses
+        // it with the same `ERR_UNAVAILABLE` everything else on this side gets.
+        queue.state.authorize_send(&signer)?;
+        let recv_addr = queue.recv_addr;
+        state.admit(&recv_addr, payload_len, self.faults.policy())?;
+        state.append(&recv_addr, body.payload, now)?;
+        drop(state);
+
+        // §6.3: the response body is empty. No index, no depth, no timestamp,
+        // no queue state of any kind.
+        Ok(Vec::new())
+    }
+
+    // -- §12.2, contact queues ---------------------------------------------
+
+    fn contact_append(
+        &self,
+        now: u64,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.accept_unsigned::<ops::ContactAppend>(request)?;
+        let body: ContactAppendRequest = verified.into_body();
+
+        if self.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        }
+
+        let published = self.published_capabilities();
+        let params = published.contact_append_pow;
+        let payload_len = u64::try_from(body.payload.len()).unwrap_or(u64::MAX);
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_second(&body.contact_addr) else {
+            return Err(self.absent_send());
+        };
+        if !matches!(queue.kind, QueueKind::Contact) {
+            // An ordinary send address is not a contact address. Same collapse:
+            // a stranger probing addresses learns nothing about which is which.
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        }
+        let recv_addr = queue.recv_addr;
+
+        // §12.3: the stamp is over a relay-issued, single-use, expiring
+        // challenge **scoped to this contact address**, so stamps cannot be
+        // precomputed in bulk, cannot be reused, and cannot be computed for one
+        // victim and spent on another.
+        self.check_stamp(
+            &mut state,
+            now,
+            &body.stamp,
+            &params,
+            ChallengePurpose::ContactAppend,
+            body.contact_addr.as_bytes(),
+        )?;
+
+        state.admit(&recv_addr, payload_len, self.faults.policy())?;
+        state.append(&recv_addr, body.payload, now)?;
+        drop(state);
+        Ok(Vec::new())
+    }
+
+    // ---------------------------------------------------------------------
+    // Shared helpers.
+    // ---------------------------------------------------------------------
+
+    fn state(&self) -> std::result::Result<std::sync::MutexGuard<'_, RelayState>, ProtoError> {
+        let mut guard = self
+            .state
+            .lock()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+        let now = self.clock.now_ms();
+        // §7.7's two timers are applied on every command rather than on a
+        // timer task, so a test that moves the clock sees the consequence on
+        // its very next request and never has to race a sweep.
+        guard.expire(now, self.faults.policy());
+        Ok(guard)
+    }
+
+    /// §10's existence-oracle rule, receive side.
+    fn absent_recv(&self) -> ProtoError {
+        // "On the absent path, perform a dummy Ed25519 verification against a
+        // fixed key so that the dominant CPU cost is present in both paths",
+        // and do not short-circuit before it. The return value is consumed so
+        // the call cannot be optimized away.
+        if dummy_verify() {
+            return ProtoError::Wire(ErrorCode::Internal);
+        }
+        ProtoError::Wire(ErrorCode::NoAccess)
+    }
+
+    /// §6.3's collapse, send side.
+    fn absent_send(&self) -> ProtoError {
+        if dummy_verify() {
+            return ProtoError::Wire(ErrorCode::Internal);
+        }
+        ProtoError::Wire(ErrorCode::Unavailable)
+    }
+
+    fn check_creation_stamp(
+        &self,
+        now: u64,
+        stamp: &PowStamp,
+    ) -> std::result::Result<(), ProtoError> {
+        let published = self.published_capabilities();
+        if published.queue_creation_mode != QueueCreationMode::Pow.code() {
+            return Ok(());
+        }
+        let params = published.queue_creation_pow;
+        let mut state = self.state()?;
+        self.check_stamp(
+            &mut state,
+            now,
+            stamp,
+            &params,
+            ChallengePurpose::QueueCreate,
+            &[],
+        )
+    }
+
+    fn check_stamp(
+        &self,
+        state: &mut RelayState,
+        now: u64,
+        stamp: &PowStamp,
+        params: &PowParams,
+        purpose: ChallengePurpose,
+        scope: &[u8],
+    ) -> std::result::Result<(), ProtoError> {
+        if !params.is_required() || self.config.relaxations.accept_missing_pow {
+            return Ok(());
+        }
+        if stamp.is_empty() {
+            return Err(ProtoError::Wire(ErrorCode::PowRequired));
+        }
+        // Verification is one hash, and §12.3 chose the function for exactly
+        // that: the relay's own cost under flood is what must stay near zero.
+        // Checked before the challenge is consumed so a garbage flood does not
+        // burn the challenge table.
+        if !stamp.meets_difficulty(params.difficulty_bits) {
+            return Err(ProtoError::Wire(ErrorCode::PowInvalid));
+        }
+        state.consume_challenge(&stamp.challenge, purpose.code(), scope, now)
+    }
+
+    fn window(&self) -> TimestampWindow {
+        if self.config.relaxations.accept_any_timestamp {
+            // A window wide enough that no timestamp is outside it. The
+            // seen-set still runs, so a replay is still a replay.
+            TimestampWindow::new(u64::MAX)
+        } else {
+            TimestampWindow::new(u64::from(self.published_capabilities().clock_skew_ms))
+        }
+    }
+
+    fn verify<C: RelayCommand>(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Verified<C>, ProtoError> {
+        let padding = self.verifier_padding::<C>(request);
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+        let seen = state.take_seen();
+        let mut verifier =
+            CommandVerifier::new(connection.transcripts.clone(), self.window(), seen, padding);
+        let outcome = verifier.verify::<C>(now, request_id, request);
+        let retention = verifier.seen_set().retention_ms();
+        let max_entries = verifier.seen_set().max_entries();
+        let seen = core::mem::replace(
+            verifier.seen_set_mut(),
+            SeenSet::new(retention, max_entries),
+        );
+        state.put_seen(seen);
+        drop(state);
+        outcome
+    }
+
+    fn accept_unsigned<C: RelayCommand>(
+        &self,
+        request: &Request,
+    ) -> std::result::Result<Verified<C>, ProtoError> {
+        let padding = self.verifier_padding::<C>(request);
+        // The seen-set is untouched by an unsigned command — there is no
+        // `(signer_key, nonce)` to record — so a throwaway one is honest here
+        // rather than a shortcut.
+        let verifier = CommandVerifier::new(
+            TranscriptBuilder::new(PROTOCOL_VERSION, self.relay_id, self.channel_binding()),
+            self.window(),
+            SeenSet::new(0, 0),
+            padding,
+        );
+        verifier.accept_unsigned::<C>(request)
+    }
+
+    /// The padding set the verifier enforces (§9).
+    ///
+    /// Normally the published set, exactly. Under
+    /// [`Relaxations::accept_any_payload_size`] the payload's own length is
+    /// merged in, which is the only way to suspend a rule whose enforcement
+    /// lives inside a shared crate — and the reason that relaxation is opt-in
+    /// and off by default.
+    ///
+    /// [`Relaxations::accept_any_payload_size`]: crate::config::Relaxations::accept_any_payload_size
+    fn verifier_padding<C: RelayCommand>(&self, request: &Request) -> PaddingBuckets {
+        if !self.config.relaxations.accept_any_payload_size {
+            return self.padding.clone();
+        }
+        let Ok(body) = decode_canonical::<C::Request>(request.body()) else {
+            return self.padding.clone();
+        };
+        let Some(payload) = C::payload(body.value()) else {
+            return self.padding.clone();
+        };
+        let Ok(len) = u32::try_from(payload.len()) else {
+            return self.padding.clone();
+        };
+        let mut sizes = self.padding.sizes().to_vec();
+        if len > 0 && !sizes.contains(&len) {
+            sizes.push(len);
+            sizes.sort_unstable();
+        }
+        PaddingBuckets::new(sizes).unwrap_or_else(|_| self.padding.clone())
+    }
+
+    /// A `NOTICE` push built for the tests that want one (§6.4).
+    #[must_use]
+    pub fn notice(kind: u8, at_ms: u64) -> Option<Outbound> {
+        push_frame(
+            PushEvent::Notice,
+            &f2z_codec::commands::NoticePush { kind, at_ms },
+        )
+    }
+
+    /// Whether the published document declares a durable seen-set (§5.5).
+    #[must_use]
+    pub fn antireplay_is_durable(&self) -> bool {
+        self.published_capabilities().antireplay_persistence
+            == AntiReplayPersistence::Durable.code()
+    }
+}
+
+/// Recover a `request_id` from a frame whose body did not decode.
+///
+/// The frame header is fixed-width — one kind byte, then a big-endian `u32` —
+/// so almost every malformed frame still carries a readable id, and §1.3's
+/// "send the response, then close" is satisfiable. `0` means it was not
+/// recoverable, which [`Relay::fatal`] turns into a bare close.
+fn recover_request_id(bytes: &[u8]) -> u32 {
+    let Some(kind) = bytes.first() else {
+        return 0;
+    };
+    // Only a request frame has a client-chosen id to answer on.
+    if *kind != 1 {
+        return 0;
+    }
+    bytes
+        .get(1..5)
+        .and_then(|slice| <[u8; 4]>::try_from(slice).ok())
+        .map_or(0, u32::from_be_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_request_id_survives_a_body_that_does_not_decode() {
+        let mut bytes = vec![1u8, 0, 0, 0, 9];
+        bytes.extend_from_slice(&[0xff; 3]);
+        assert_eq!(recover_request_id(&bytes), 9);
+        assert_eq!(recover_request_id(&[]), 0);
+        assert_eq!(recover_request_id(&[2, 0, 0, 0, 9]), 0);
+        assert_eq!(recover_request_id(&[1, 0, 0]), 0);
+    }
+
+    #[test]
+    fn token_mode_is_refused_at_construction_rather_than_faked() {
+        let mut config = RelayConfig::default();
+        config.capabilities.queue_creation_mode = QueueCreationMode::Token.code();
+        assert!(Relay::new(config).is_err());
+    }
+
+    #[test]
+    fn a_document_claiming_tls_is_refused() {
+        let mut config = RelayConfig::default();
+        config.capabilities.transport_security = TransportSecurity::Tls.code();
+        assert!(Relay::new(config).is_err());
+    }
+
+    #[test]
+    fn the_relay_id_is_the_digest_of_the_identity_key() {
+        let relay = Relay::new(RelayConfig::default()).unwrap();
+        assert_eq!(
+            relay.relay_id(),
+            f2z_codec::hash::relay_id(&relay.identity_key())
+        );
+        let published = relay.published_capabilities();
+        assert_eq!(published.relay_id, relay.relay_id());
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/error.rs
+++ b/rs/crates/f2z-relay-testkit/src/error.rs
@@ -1,0 +1,120 @@
+//! What the harness itself can fail at, as opposed to what the protocol can
+//! refuse.
+//!
+//! The distinction matters more here than it looks. `f2z-relay-proto` already
+//! separates a **wire refusal** (a §10 code the relay answers with) from a
+//! **client refusal** (a decision a client makes about a relay). This crate
+//! adds a third thing that is neither: the harness lost the connection, or the
+//! test's own timeout elapsed, or the configuration was nonsense. A test that
+//! collapses those into a protocol error will report "the relay answered
+//! `ERR_INTERNAL`" when what actually happened is that the socket closed, and
+//! the client author will go looking in the wrong place.
+
+use std::fmt;
+
+use f2z_codec::ErrorCode;
+use f2z_relay_proto::ProtoError;
+
+/// Anything this crate can fail at.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum TestkitError {
+    /// The protocol refused — a §10 code from the relay, or a client-side
+    /// refusal of the relay. Carries `f2z-relay-proto`'s own type unchanged, so
+    /// the code and its fatality survive.
+    Protocol(ProtoError),
+    /// The transport failed: the socket closed, the duplex peer went away, the
+    /// WebSocket handshake was rejected.
+    Transport(String),
+    /// The peer closed while a request was outstanding. §2.5: the command's
+    /// status is **unknown**, and the retry rules of §7.3 and §8.3 apply.
+    Closed,
+    /// A read waited longer than the caller allowed. Not a protocol event: the
+    /// relay may still answer.
+    Timeout,
+    /// The configuration cannot produce a conforming relay.
+    Config(&'static str),
+    /// A conformance vector's expectation did not hold.
+    Expectation(String),
+}
+
+impl TestkitError {
+    /// The §10 code, when the failure was a wire refusal.
+    #[must_use]
+    pub fn wire_code(&self) -> Option<ErrorCode> {
+        match self {
+            Self::Protocol(error) => error.wire_code(),
+            _ => None,
+        }
+    }
+
+    /// Whether this is the relay answering `code`.
+    #[must_use]
+    pub fn is_wire(&self, code: ErrorCode) -> bool {
+        self.wire_code() == Some(code)
+    }
+}
+
+impl fmt::Display for TestkitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Protocol(error) => write!(f, "{error}"),
+            Self::Transport(detail) => write!(f, "transport failure: {detail}"),
+            Self::Closed => f.write_str(
+                "the connection closed with a request outstanding; \
+                 its status is unknown (WIRE.md §2.5)",
+            ),
+            Self::Timeout => f.write_str("timed out waiting for the relay"),
+            Self::Config(detail) => write!(f, "invalid relay configuration: {detail}"),
+            Self::Expectation(detail) => write!(f, "expectation not met: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for TestkitError {}
+
+impl From<ProtoError> for TestkitError {
+    fn from(error: ProtoError) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+impl From<f2z_codec::CodecError> for TestkitError {
+    fn from(error: f2z_codec::CodecError) -> Self {
+        Self::Protocol(ProtoError::from(error))
+    }
+}
+
+impl From<ErrorCode> for TestkitError {
+    fn from(code: ErrorCode) -> Self {
+        Self::Protocol(ProtoError::Wire(code))
+    }
+}
+
+impl From<std::io::Error> for TestkitError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Transport(error.to_string())
+    }
+}
+
+/// The result of everything in this crate.
+pub type Result<T> = std::result::Result<T, TestkitError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_wire_refusal_keeps_its_code_and_a_transport_failure_has_none() {
+        let refused = TestkitError::from(ErrorCode::Unavailable);
+        assert!(refused.is_wire(ErrorCode::Unavailable));
+        assert!(!refused.is_wire(ErrorCode::NoAccess));
+        assert_eq!(TestkitError::Closed.wire_code(), None);
+        assert_eq!(TestkitError::Timeout.wire_code(), None);
+    }
+
+    #[test]
+    fn a_lost_connection_says_the_status_is_unknown() {
+        assert!(TestkitError::Closed.to_string().contains("unknown"));
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/fake.rs
+++ b/rs/crates/f2z-relay-testkit/src/fake.rs
@@ -1,0 +1,361 @@
+//! `FakeRelay` — the handle a client developer actually holds.
+//!
+//! One relay, two ways to reach it, and the same [`crate::engine::Relay`]
+//! behind both:
+//!
+//! ```text
+//!                       ┌────────────────────────────┐
+//!   FakeRelay::connect ─┤                            │
+//!    (tokio::io::duplex)│   connection::drive         │
+//!                       │        engine::Relay        │
+//!   ws://127.0.0.1:0 ───┤                            │
+//!    (RelayServer)      └────────────────────────────┘
+//! ```
+//!
+//! The in-process path is for the tests that run in milliseconds. The socket
+//! path is for the framing, ordering and reconnection bugs the in-process path
+//! physically cannot expose. Running the conformance suite against both and
+//! comparing the verdicts is what turns "they share an implementation" from a
+//! claim into a check — `tests/conformance.rs` does exactly that.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use f2z_codec::commands::{Capabilities, SignedCapabilities};
+use f2z_codec::types::{ChannelBinding, PublicKey, RelayId};
+use futures_util::future::BoxFuture;
+
+use crate::client::{Client, ClientConfig};
+use crate::clock::Clock;
+use crate::config::RelayConfig;
+use crate::engine::Relay;
+use crate::error::Result;
+use crate::faults::FaultInjector;
+use crate::transport::{Transport, duplex};
+use crate::websocket::{self, RelayServer};
+
+/// The buffer of an in-process connection, in bytes.
+///
+/// Generous on purpose: a relay writer and a client writer that both block on a
+/// full pipe is a deadlock in the harness, not a finding about the protocol.
+/// §4.1's `max_frame_bytes` is what should refuse an oversize frame.
+const DUPLEX_CAPACITY: usize = 4 * 1024 * 1024;
+
+/// A spec-conforming relay you can break on purpose.
+#[derive(Clone, Debug)]
+pub struct FakeRelay {
+    relay: Arc<Relay>,
+    /// How many client configurations this relay has handed out.
+    ///
+    /// §5.5's seen-set is relay-wide, and on a frozen clock nothing in it ever
+    /// ages out. Two connections drawing nonces from one stream would therefore
+    /// collide on `(signer_key, nonce)` the moment the same queue key signed
+    /// from both, and the second command would be refused as a replay — a
+    /// harness bug that looks exactly like a relay bug and costs an afternoon.
+    /// Each configuration gets its own stream, derived from this counter, so it
+    /// is unique *and* reproducible.
+    connections: Arc<AtomicU64>,
+}
+
+impl FakeRelay {
+    /// Build a relay.
+    ///
+    /// # Errors
+    ///
+    /// As [`Relay::new`].
+    pub fn new(config: RelayConfig) -> Result<Self> {
+        Ok(Self {
+            relay: Arc::new(Relay::new(config)?),
+            connections: Arc::new(AtomicU64::new(0)),
+        })
+    }
+
+    /// A relay on [`RelayConfig::default`]: frozen clock, `ws://`-honest
+    /// capability document, open queue creation, nothing faulted.
+    ///
+    /// # Errors
+    ///
+    /// As [`Relay::new`].
+    pub fn with_defaults() -> Result<Self> {
+        Self::new(RelayConfig::default())
+    }
+
+    /// The live fault handle. Cloneable, and armed rules take effect on the
+    /// next frame — arming is not a restart.
+    #[must_use]
+    pub fn faults(&self) -> FaultInjector {
+        self.relay.faults().clone()
+    }
+
+    /// The relay's clock. Frozen unless the configuration said otherwise.
+    #[must_use]
+    pub fn clock(&self) -> Clock {
+        self.relay.clock().clone()
+    }
+
+    /// §5.2's identity binding.
+    #[must_use]
+    pub fn relay_id(&self) -> RelayId {
+        self.relay.relay_id()
+    }
+
+    /// The relay's long-term public key.
+    #[must_use]
+    pub fn identity_key(&self) -> PublicKey {
+        self.relay.identity_key()
+    }
+
+    /// The channel binding both ends use (§5.3). Zeros in `none` mode.
+    #[must_use]
+    pub fn channel_binding(&self) -> ChannelBinding {
+        self.relay.channel_binding()
+    }
+
+    /// The document as it stands now, policy faults included.
+    #[must_use]
+    pub fn published_capabilities(&self) -> Capabilities {
+        self.relay.published_capabilities()
+    }
+
+    /// The signed document (§11.1).
+    ///
+    /// # Errors
+    ///
+    /// As [`Relay::signed_capabilities`].
+    pub fn signed_capabilities(&self) -> Result<SignedCapabilities> {
+        self.relay.signed_capabilities()
+    }
+
+    /// Send `NOTICE(3)` to every subscribed connection (§6.4).
+    ///
+    /// Arming a policy fault changes the published document; this is how a
+    /// client's re-fetch path gets exercised rather than assumed.
+    pub fn announce_capability_change(&self) {
+        self.relay.announce_capability_change();
+    }
+
+    /// A client configuration that already knows this relay: its channel
+    /// binding, its `relay_id`, and its published padding set.
+    ///
+    /// Supplying `expected_relay_id` mirrors what a real client has — §7.2's
+    /// advert carries `(relay_url, relay_id, send_addr)` together, and §5.2's
+    /// substitution check is only possible because of it.
+    #[must_use]
+    pub fn client_config(&self) -> ClientConfig {
+        let published = self.published_capabilities();
+        let padding =
+            f2z_codec::padding::PaddingBuckets::new(published.padding_sizes.as_slice().to_vec())
+                .unwrap_or_default();
+        ClientConfig {
+            channel_binding: self.channel_binding(),
+            expected_relay_id: Some(self.relay_id()),
+            padding,
+            nonce_seed: self.next_nonce_seed(),
+            ..ClientConfig::default()
+        }
+    }
+
+    /// A nonce stream no other client of this relay has been given.
+    fn next_nonce_seed(&self) -> [u8; 32] {
+        let ordinal = self.connections.fetch_add(1, Ordering::SeqCst);
+        let mut input = [0u8; 40];
+        if let Some(slot) = input.get_mut(..32) {
+            slot.copy_from_slice(&self.relay.config().rng_seed);
+        }
+        if let Some(slot) = input.get_mut(32..) {
+            slot.copy_from_slice(&ordinal.to_be_bytes());
+        }
+        *f2z_codec::hash::hash(b"f2z-relay-testkit/client-nonce-seed/v1", &input).as_bytes()
+    }
+
+    /// Open an in-process connection and spawn the relay side of it.
+    ///
+    /// Needs a Tokio runtime, because the relay half runs as a task.
+    #[must_use]
+    pub fn connect(&self) -> Transport {
+        let (client_side, relay_side) = duplex(DUPLEX_CAPACITY);
+        let relay = Arc::clone(&self.relay);
+        tokio::spawn(crate::connection::drive(relay, relay_side));
+        client_side
+    }
+
+    /// An in-process connection with `HELLO` already completed.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::connect`].
+    pub async fn client(&self) -> Result<Client> {
+        Client::connect(self.connect(), self.client_config()).await
+    }
+
+    /// Listen on `127.0.0.1:0` and return the running server.
+    ///
+    /// # Errors
+    ///
+    /// As [`websocket::bind`] and [`websocket::serve`].
+    pub async fn listen_loopback(&self) -> Result<RelayServer> {
+        let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+        self.listen(addr, false).await
+    }
+
+    /// Listen on `addr`.
+    ///
+    /// §2.3: a non-loopback bind without TLS is refused unless
+    /// `insecure_listen` is set, which is a deliberate act with published
+    /// consequences rather than a warning.
+    ///
+    /// # Errors
+    ///
+    /// As [`websocket::bind`] and [`websocket::serve`].
+    pub async fn listen(&self, addr: SocketAddr, insecure_listen: bool) -> Result<RelayServer> {
+        let listener = websocket::bind(addr, insecure_listen).await?;
+        websocket::serve(Arc::clone(&self.relay), listener)
+    }
+
+    /// This relay as an in-process conformance target.
+    #[must_use]
+    pub fn in_process_endpoint(&self) -> InProcessEndpoint {
+        InProcessEndpoint {
+            relay: self.clone(),
+        }
+    }
+
+    /// This relay as a conformance target reached over a real socket.
+    #[must_use]
+    pub fn websocket_endpoint(&self, server: &RelayServer) -> WebSocketEndpoint {
+        WebSocketEndpoint {
+            url: server.url(),
+            config: self.client_config(),
+            faults: Some(self.faults()),
+            clock: Some(self.clock()),
+        }
+    }
+}
+
+/// Something the conformance suite can be run against.
+///
+/// Two implementations ship here — in-process and WebSocket — and a third is
+/// the whole point: `f2z-relay`, once it exists, is a [`WebSocketEndpoint`]
+/// with a URL and no fault handle. The suite then reports the fault vectors as
+/// skipped rather than failing them, so the same file is a real check of both
+/// relays instead of two files that drift.
+pub trait Endpoint: Send + Sync {
+    /// Open a transport to this relay.
+    fn connect(&self) -> BoxFuture<'_, Result<Transport>>;
+
+    /// A client configuration suited to this relay.
+    fn client_config(&self) -> ClientConfig;
+
+    /// The fault handle, when the target is one we can break on purpose.
+    /// `None` for a real relay, which is not a failure — it is the reason the
+    /// suite reports "skipped" rather than "passed".
+    fn faults(&self) -> Option<FaultInjector> {
+        None
+    }
+
+    /// The clock, when the target's clock can be steered.
+    fn clock(&self) -> Option<Clock> {
+        None
+    }
+
+    /// How to name this target in a report.
+    fn describe(&self) -> String;
+}
+
+/// The in-process target.
+#[derive(Clone, Debug)]
+pub struct InProcessEndpoint {
+    relay: FakeRelay,
+}
+
+impl InProcessEndpoint {
+    /// The relay behind it.
+    #[must_use]
+    pub const fn relay(&self) -> &FakeRelay {
+        &self.relay
+    }
+}
+
+impl Endpoint for InProcessEndpoint {
+    fn connect(&self) -> BoxFuture<'_, Result<Transport>> {
+        Box::pin(async move { Ok(self.relay.connect()) })
+    }
+
+    fn client_config(&self) -> ClientConfig {
+        self.relay.client_config()
+    }
+
+    fn faults(&self) -> Option<FaultInjector> {
+        Some(self.relay.faults())
+    }
+
+    fn clock(&self) -> Option<Clock> {
+        Some(self.relay.clock())
+    }
+
+    fn describe(&self) -> String {
+        "in-process (tokio::io::duplex)".to_owned()
+    }
+}
+
+/// A target reached over a real WebSocket — a `FakeRelay`'s listener, or any
+/// other relay that speaks `WIRE.md` v1.
+#[derive(Clone, Debug)]
+pub struct WebSocketEndpoint {
+    url: String,
+    config: ClientConfig,
+    faults: Option<FaultInjector>,
+    clock: Option<Clock>,
+}
+
+impl WebSocketEndpoint {
+    /// A target at `url`, with default client policy.
+    ///
+    /// This is the constructor `f2z-relay` will be run through. It has no fault
+    /// handle and no clock, which the suite reports honestly.
+    #[must_use]
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            config: ClientConfig::default(),
+            faults: None,
+            clock: None,
+        }
+    }
+
+    /// Use this client configuration instead of the default.
+    #[must_use]
+    pub fn with_client_config(mut self, config: ClientConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// The endpoint URL.
+    #[must_use]
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+impl Endpoint for WebSocketEndpoint {
+    fn connect(&self) -> BoxFuture<'_, Result<Transport>> {
+        Box::pin(async move { websocket::connect(&self.url).await })
+    }
+
+    fn client_config(&self) -> ClientConfig {
+        self.config.clone()
+    }
+
+    fn faults(&self) -> Option<FaultInjector> {
+        self.faults.clone()
+    }
+
+    fn clock(&self) -> Option<Clock> {
+        self.clock.clone()
+    }
+
+    fn describe(&self) -> String {
+        format!("websocket {}", self.url)
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/faults.rs
+++ b/rs/crates/f2z-relay-testkit/src/faults.rs
@@ -1,0 +1,442 @@
+//! Fault injection — the half of the testkit that is worth more than the happy
+//! path.
+//!
+//! Under delete-on-ack the failure paths are where data loss lives. A client
+//! that gets `APPEND` and `READ` right and gets a dropped `ACK` response wrong
+//! will lose messages in production and pass every test that only ever sees a
+//! healthy relay. `WIRE.md` §2.5 states the shape of the problem outright: "an
+//! in-flight command whose response was not received has **unknown** status",
+//! and §8.3 spells out the two halves of the answer — `ACK` is idempotent so a
+//! retry is safe, `APPEND` is not so a retry duplicates. Neither sentence is
+//! testable against a relay that always answers.
+//!
+//! So every fault here exists to make a specific client obligation reachable:
+//!
+//! | Fault | The client rule it tests |
+//! |---|---|
+//! | [`Effect::Drop`] | §2.5 unknown status; §8.3 idempotent `ACK` retry |
+//! | [`Effect::Delay`] | §4.3 correlate by `request_id`, never by arrival order |
+//! | [`Effect::Reorder`] | §4.3 "responses may arrive out of order … and will" |
+//! | [`Effect::Close`] / [`Effect::CloseBefore`] | §2.5 close at any time; reconnect and re-`SUBSCRIBE` |
+//! | [`Effect::Refuse`] | §10, every code, including the ones a healthy relay never emits |
+//! | [`Effect::Stall`] | §4.3 in-flight window: a client that never times out fills it and gets a fatal `ERR_TOO_MANY_INFLIGHT` |
+//! | [`PolicyFaults::expire_messages_after`] | §7.7 TTL expiry, and `QUEUE_EVENT(3)` |
+//! | [`PolicyFaults::max_queue_messages`] | §6.3 `ERR_UNAVAILABLE` collapse: a full queue is indistinguishable from an absent one |
+//! | [`PolicyFaults::unsound_antireplay_window`] | [#586] — the capability document a conforming relay may publish and a client must refuse |
+//!
+//! # These are faults, not relaxations
+//!
+//! Everything here makes the relay behave *worse* than the specification
+//! allows in ways a real relay or a real network can. Nothing here makes it
+//! accept something a conforming relay would reject — that is
+//! [`crate::config::Relaxations`], which is a separate type for exactly this
+//! reason.
+//!
+//! [#586]: https://github.com/free2z/zuu/issues/586
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::commands::{Command, PushEvent};
+
+/// Which outbound frames a rule applies to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Trigger {
+    /// Responses to one command code.
+    Command(Command),
+    /// Every response, whatever the command.
+    AnyResponse,
+    /// Pushes of one event kind (§6.4).
+    Push(PushEvent),
+    /// Every push.
+    AnyPush,
+}
+
+impl Trigger {
+    /// Whether this trigger selects a response to `command`.
+    ///
+    /// `command` is `None` for a response to a code the relay does not know
+    /// (`ERR_UNKNOWN_COMMAND`, §3.5), which [`Trigger::AnyResponse`] still
+    /// selects — a client has to handle a dropped error response too.
+    #[must_use]
+    pub fn matches_response(self, command: Option<Command>) -> bool {
+        match self {
+            Self::AnyResponse => true,
+            Self::Command(wanted) => command == Some(wanted),
+            Self::Push(_) | Self::AnyPush => false,
+        }
+    }
+
+    /// Whether this trigger selects a push of `event`.
+    #[must_use]
+    pub fn matches_push(self, event: Option<PushEvent>) -> bool {
+        match self {
+            Self::AnyPush => true,
+            Self::Push(wanted) => event == Some(wanted),
+            Self::Command(_) | Self::AnyResponse => false,
+        }
+    }
+}
+
+/// What a rule does to the frames it selects.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Effect {
+    /// Silently discard the frame. The command still executed: this is the
+    /// lost-response case of §2.5, not a refusal.
+    Drop,
+    /// Hold the frame for this long before writing it.
+    Delay(Duration),
+    /// Hold the frame until the next outbound frame is ready, then write that
+    /// one first (§4.3).
+    ///
+    /// A held frame is flushed when the connection closes, so a reorder rule
+    /// that never sees a second frame degrades to a delay rather than to a
+    /// silent drop.
+    Reorder,
+    /// Never write the frame and never release the request. The command still
+    /// executed; the client's `request_id` stays outstanding, which is what
+    /// puts pressure on §4.3's in-flight window.
+    Stall,
+    /// Write the frame, then close the connection.
+    Close,
+    /// Close the connection instead of writing the frame — the mid-stream
+    /// disconnect where the client cannot know whether the command applied.
+    CloseBefore,
+    /// Answer the command with this code instead of executing it.
+    ///
+    /// Applied *before* any state changes, so a refused `APPEND` really did not
+    /// append. This is the one effect that is evaluated in the engine rather
+    /// than on the way out.
+    Refuse(ErrorCode),
+}
+
+/// How many times a rule fires.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Times {
+    /// Every matching frame, for as long as the rule is armed.
+    Always,
+    /// The next `n` matching frames, then the rule retires itself.
+    Exactly(u32),
+}
+
+/// One fault rule: what to match, what to do, how often.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Fault {
+    /// Which frames this rule selects.
+    pub trigger: Trigger,
+    /// What happens to them.
+    pub effect: Effect,
+    /// How many times.
+    pub times: Times,
+}
+
+impl Fault {
+    /// A rule that fires on every matching frame.
+    #[must_use]
+    pub const fn always(trigger: Trigger, effect: Effect) -> Self {
+        Self {
+            trigger,
+            effect,
+            times: Times::Always,
+        }
+    }
+
+    /// A rule that fires once and retires.
+    #[must_use]
+    pub const fn once(trigger: Trigger, effect: Effect) -> Self {
+        Self {
+            trigger,
+            effect,
+            times: Times::Exactly(1),
+        }
+    }
+
+    /// A rule that fires `n` times and retires.
+    #[must_use]
+    pub const fn times(trigger: Trigger, effect: Effect, n: u32) -> Self {
+        Self {
+            trigger,
+            effect,
+            times: Times::Exactly(n),
+        }
+    }
+
+    /// Consume one firing. Returns `false` when the rule has retired.
+    fn consume(&mut self) -> bool {
+        match &mut self.times {
+            Times::Always => true,
+            Times::Exactly(remaining) => {
+                if *remaining == 0 {
+                    false
+                } else {
+                    *remaining = remaining.saturating_sub(1);
+                    true
+                }
+            }
+        }
+    }
+
+    fn retired(&self) -> bool {
+        matches!(self.times, Times::Exactly(0))
+    }
+}
+
+/// Faults that are properties of the relay's policy rather than of one frame.
+///
+/// These change what the relay *is*, so they are read on every relevant
+/// decision instead of being consumed. Several of them also change the
+/// published capability document, which is the point: a client that reads
+/// policy from `GET_CAPABILITIES` must see the policy it is about to be held
+/// to.
+///
+/// Deliberately **not** `#[non_exhaustive]`: a client developer builds one of
+/// these with struct-update syntax in their own test file, and a crate whose
+/// test-harness configuration could only be constructed from inside the crate
+/// would be unusable for the thing it exists to do.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PolicyFaults {
+    /// Expire stored messages this long after they were appended, whatever TTL
+    /// the queue was granted (§7.7).
+    ///
+    /// `Some(Duration::ZERO)` expires a message the instant the clock is read
+    /// again, which is the fastest way to reach `QUEUE_EVENT(3)` and to prove a
+    /// client does not assume a `READ` returns what it appended.
+    pub expire_messages_after: Option<Duration>,
+    /// Expire a queue this long after its last activity, whatever idle TTL it
+    /// was granted (§7.7). Reaches `QUEUE_EVENT(2)` and, for the sender,
+    /// `ERR_UNAVAILABLE` on a queue that used to work.
+    pub expire_queue_after: Option<Duration>,
+    /// Override `max_queue_messages` (§13.1 layer 2). Set it to 1 and the
+    /// second `APPEND` is `ERR_UNAVAILABLE` — the §6.3 collapse, reached
+    /// cheaply.
+    pub max_queue_messages: Option<u32>,
+    /// Override `max_queue_bytes` (§13.1 layer 2).
+    pub max_queue_bytes: Option<u64>,
+    /// Refuse `CREATE_QUEUE` with `ERR_QUOTA` once the relay holds this many
+    /// queues (§10 code 14 — a recv-side quota, which unlike the send side is
+    /// allowed to be distinguishable).
+    pub max_queues: Option<usize>,
+    /// §13.1 layer 4. Creation answers `ERR_BACKPRESSURE`, appends answer
+    /// `ERR_UNAVAILABLE`, and `READ` / `ACK` / `DELETE_QUEUE` are **never**
+    /// refused — refusing the operations that make the relay smaller is a
+    /// deadlock, and a client that cannot drain under backpressure will find
+    /// out here.
+    pub global_backpressure: bool,
+    /// Publish, and then actually enforce, `antireplay_window_ms =
+    /// clock_skew_ms` — below the `2 × clock_skew_ms` floor that [#586] says
+    /// `WIRE.md` should state and does not.
+    ///
+    /// Both halves matter. The document is what
+    /// `ClientPolicy::require_sound_antireplay_window` refuses on; the
+    /// enforcement is what makes the refusal *justified*, because with the
+    /// short retention the relay really does age a seen-set entry out while the
+    /// frame it covers is still inside the timestamp window.
+    ///
+    /// [#586]: https://github.com/free2z/zuu/issues/586
+    pub unsound_antireplay_window: bool,
+    /// Shrink the seen-set bound so `ERR_BACKPRESSURE` from §5.5 is reachable
+    /// without sending 65 536 commands.
+    pub seen_set_max: Option<usize>,
+}
+
+/// A live handle to one relay's faults.
+///
+/// Cheap to clone and shared with every connection, so a test can arm a fault
+/// in the middle of a conversation — which is the only way to reach half of
+/// them. Arming is not a restart.
+#[derive(Clone, Debug, Default)]
+pub struct FaultInjector {
+    inner: Arc<Mutex<Faults>>,
+}
+
+#[derive(Debug, Default)]
+struct Faults {
+    rules: Vec<Fault>,
+    policy: PolicyFaults,
+}
+
+impl FaultInjector {
+    /// An injector with nothing armed.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Arm a rule.
+    pub fn arm(&self, fault: Fault) {
+        if let Ok(mut faults) = self.inner.lock() {
+            faults.rules.push(fault);
+        }
+    }
+
+    /// Arm several rules at once.
+    pub fn arm_all(&self, faults: impl IntoIterator<Item = Fault>) {
+        for fault in faults {
+            self.arm(fault);
+        }
+    }
+
+    /// Disarm every rule. Policy faults are left alone; use
+    /// [`FaultInjector::set_policy`] for those.
+    pub fn disarm(&self) {
+        if let Ok(mut faults) = self.inner.lock() {
+            faults.rules.clear();
+        }
+    }
+
+    /// Replace the policy faults.
+    pub fn set_policy(&self, policy: PolicyFaults) {
+        if let Ok(mut faults) = self.inner.lock() {
+            faults.policy = policy;
+        }
+    }
+
+    /// The current policy faults.
+    #[must_use]
+    pub fn policy(&self) -> PolicyFaults {
+        self.inner
+            .lock()
+            .map(|faults| faults.policy)
+            .unwrap_or_default()
+    }
+
+    /// How many rules are armed. Retired rules are removed as they retire.
+    #[must_use]
+    pub fn armed(&self) -> usize {
+        self.inner.lock().map_or(0, |faults| faults.rules.len())
+    }
+
+    /// The refusal a rule demands for `command`, consuming one firing.
+    ///
+    /// Called by the engine before the command runs, so a refusal really does
+    /// prevent the state change.
+    #[must_use]
+    pub fn take_refusal(&self, command: Option<Command>) -> Option<ErrorCode> {
+        match self.take(|fault| match fault.effect {
+            Effect::Refuse(_) if fault.trigger.matches_response(command) => Some(fault.effect),
+            _ => None,
+        }) {
+            Some(Effect::Refuse(code)) => Some(code),
+            _ => None,
+        }
+    }
+
+    /// The delivery effect a rule demands for a response, consuming one firing.
+    #[must_use]
+    pub fn take_response_effect(&self, command: Option<Command>) -> Option<Effect> {
+        self.take(|fault| match fault.effect {
+            Effect::Refuse(_) => None,
+            effect if fault.trigger.matches_response(command) => Some(effect),
+            _ => None,
+        })
+    }
+
+    /// The delivery effect a rule demands for a push, consuming one firing.
+    #[must_use]
+    pub fn take_push_effect(&self, event: Option<PushEvent>) -> Option<Effect> {
+        self.take(|fault| match fault.effect {
+            Effect::Refuse(_) => None,
+            effect if fault.trigger.matches_push(event) => Some(effect),
+            _ => None,
+        })
+    }
+
+    /// First matching rule wins, and firing it may retire it.
+    fn take(&self, select: impl Fn(&Fault) -> Option<Effect>) -> Option<Effect> {
+        let mut faults = self.inner.lock().ok()?;
+        let mut chosen = None;
+        for fault in &mut faults.rules {
+            if let Some(effect) = select(fault)
+                && fault.consume()
+            {
+                chosen = Some(effect);
+                break;
+            }
+        }
+        faults.rules.retain(|fault| !fault.retired());
+        chosen
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_once_rule_fires_once_and_retires() {
+        let injector = FaultInjector::new();
+        injector.arm(Fault::once(Trigger::Command(Command::Ack), Effect::Drop));
+        assert_eq!(injector.armed(), 1);
+        assert_eq!(
+            injector.take_response_effect(Some(Command::Ack)),
+            Some(Effect::Drop)
+        );
+        assert_eq!(injector.take_response_effect(Some(Command::Ack)), None);
+        assert_eq!(injector.armed(), 0);
+    }
+
+    #[test]
+    fn a_command_rule_ignores_other_commands() {
+        let injector = FaultInjector::new();
+        injector.arm(Fault::always(Trigger::Command(Command::Read), Effect::Drop));
+        assert_eq!(injector.take_response_effect(Some(Command::Ack)), None);
+        assert_eq!(
+            injector.take_response_effect(Some(Command::Read)),
+            Some(Effect::Drop)
+        );
+        // Always means always.
+        assert_eq!(
+            injector.take_response_effect(Some(Command::Read)),
+            Some(Effect::Drop)
+        );
+    }
+
+    #[test]
+    fn refusals_and_delivery_effects_do_not_steal_each_others_rules() {
+        let injector = FaultInjector::new();
+        injector.arm(Fault::always(
+            Trigger::Command(Command::Append),
+            Effect::Refuse(ErrorCode::Unavailable),
+        ));
+        assert_eq!(injector.take_response_effect(Some(Command::Append)), None);
+        assert_eq!(
+            injector.take_refusal(Some(Command::Append)),
+            Some(ErrorCode::Unavailable)
+        );
+    }
+
+    #[test]
+    fn push_rules_and_response_rules_are_separate() {
+        let injector = FaultInjector::new();
+        injector.arm(Fault::always(Trigger::AnyPush, Effect::Drop));
+        assert_eq!(injector.take_response_effect(Some(Command::Read)), None);
+        assert_eq!(
+            injector.take_push_effect(Some(PushEvent::Msg)),
+            Some(Effect::Drop)
+        );
+    }
+
+    #[test]
+    fn every_error_code_can_be_demanded() {
+        // §10's codes are stable forever and a client has to handle all of
+        // them, including the ones a healthy relay never emits.
+        let injector = FaultInjector::new();
+        for code in ErrorCode::ALL {
+            injector.arm(Fault::once(
+                Trigger::Command(Command::Append),
+                Effect::Refuse(code),
+            ));
+        }
+        for code in ErrorCode::ALL {
+            assert_eq!(
+                injector.take_refusal(Some(Command::Append)),
+                Some(code),
+                "rules fire in the order they were armed"
+            );
+        }
+        assert_eq!(injector.armed(), 0);
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/lib.rs
+++ b/rs/crates/f2z-relay-testkit/src/lib.rs
@@ -1,0 +1,142 @@
+//! **FakeRelay** — a spec-conforming free2z relay you can break on purpose, so
+//! that a client can be built and tested before `f2z-relay` exists.
+//!
+//! ```no_run
+//! # async fn example() -> Result<(), Box<dyn core::error::Error>> {
+//! use f2z_relay_proto::key::SigningKey;
+//! use f2z_relay_testkit::fake::FakeRelay;
+//!
+//! let relay = FakeRelay::with_defaults()?;
+//! let mut bob = relay.client().await?;              // in-process, no sockets
+//! let bob_key = SigningKey::from_seed(&[1u8; 32]);
+//! let queue = bob.create_queue(&bob_key, 0, 0, None).await?;
+//!
+//! let mut alice = relay.client().await?;
+//! let alice_key = SigningKey::from_seed(&[2u8; 32]);
+//! alice.bind_send(&alice_key, queue.send_addr).await?;
+//! alice.append(&alice_key, queue.send_addr, b"ciphertext").await?;
+//!
+//! let read = bob.read(&bob_key, queue.recv_addr, 0, 0, 0).await?;
+//! // …durable local write happens HERE — WIRE.md §8.4's MUST — and only then:
+//! bob.ack(&bob_key, queue.recv_addr, 0).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # What this crate is for
+//!
+//! [`docs/e2ee/WIRE.md`] specifies a relay that does not exist yet, and
+//! [`docs/e2ee/CLIENT-CONTRACT.md`] describes clients that have to be built
+//! against it now. This crate is the thing in between: a relay that implements
+//! §2 through §13 faithfully, runs in a test process, and can be *told to
+//! misbehave*.
+//!
+//! It reuses rather than reimplements. [`f2z_codec`] owns the canonical
+//! encoding, the framing and re-encode equality (§3.3); [`f2z_relay_proto`]
+//! owns the verification order of §5.1, the anti-replay of §5.5, the queue and
+//! acknowledgement rules of §7 and §8, and the capability document of §11. The
+//! part decided here is what those crates deliberately leave to a server: the
+//! connection lifecycle, the in-flight window, which code answers which
+//! refusal, when a push is emitted, and the anti-abuse layering of §13.
+//!
+//! # The three things worth knowing before you use it
+//!
+//! **1. It serves both an in-process pipe and a real socket, and they are the
+//! same relay.** [`fake::FakeRelay::connect`] gives a
+//! [`tokio::io::duplex`]-backed transport for tests that run in milliseconds;
+//! [`fake::FakeRelay::listen_loopback`] serves `ws://127.0.0.1:0` for the
+//! framing, ordering and reconnection bugs an in-memory pipe physically cannot
+//! expose. Both go through [`connection::drive`] and [`engine::Relay`], and
+//! `tests/conformance.rs` runs the whole vector suite against both and compares
+//! the verdicts — because "they share an implementation" is worth nothing as a
+//! claim and everything as a check.
+//!
+//! **2. Faults are the point.** Under delete-on-ack the failure paths are where
+//! data loss lives. A client that handles `APPEND` and `READ` correctly and
+//! mishandles a dropped `ACK` response loses messages in production and passes
+//! every test that only ever sees a healthy relay. [`faults`] can drop a
+//! response, delay one, reorder two, close mid-stream, refuse a command with
+//! any §10 code, stall a response so §4.3's window fills, expire a TTL, hit a
+//! quota, enter global backpressure, and publish the capability document of
+//! [#586].
+//!
+//! **3. Relaxations are not faults, and are off.** A fault makes the relay
+//! behave *worse* than the specification allows, in ways a real relay or a real
+//! network can. A [`config::Relaxations`] makes it **accept** something a
+//! conforming relay would reject — which is the single most dangerous thing a
+//! test double can do, because it teaches a client to write code that works in
+//! tests and fails against the real thing. Each one is opt-in, each is named
+//! after the rule it suspends, and [`config::Relaxations::any`] lets a harness
+//! assert that a run used none.
+//!
+//! # The conformance suite
+//!
+//! [`vectors`] is a set of `(input, expected output)` cases driven through the
+//! ordinary client API against an [`fake::Endpoint`]. Three targets exist:
+//! in-process, this crate's WebSocket listener, and — later, unchanged —
+//! `f2z-relay` itself as a [`fake::WebSocketEndpoint`] with a URL. Vectors that
+//! need to break the relay declare [`vectors::Needs::Faults`] or
+//! [`vectors::Needs::Clock`] and report **skipped** against a target that
+//! cannot be told to misbehave, never passed.
+//!
+//! # What this crate is not
+//!
+//! **Not a relay.** `f2z-fakerelay` serves `ws://` rather than `wss://` (§2.1),
+//! derives queue addresses from a seed so vectors replay (§7.1 requires them to
+//! be unpredictable), and keeps everything in memory (§8.4's
+//! `durability_mode: memory`). All three are published in the signed capability
+//! document it serves, and a conforming client refuses it without an explicit
+//! per-relay opt-in. See [`rng`] and the `f2z-fakerelay` binary docs.
+//!
+//! **Not the client.** [`client::Client`] is the smallest thing that can drive
+//! every command of §6 correctly, so a vector is a statement about the relay
+//! rather than about a test's ability to build a frame. ZUULI's engine and the
+//! WASM web client are the clients, and neither links this.
+//!
+//! **Native only.** This crate opens sockets, spawns tasks and reads a clock.
+//! It is deliberately absent from the `wasm32` job that
+//! [`f2z_codec`] and [`f2z_relay_proto`] must pass: [ADR 0001] requires one
+//! Rust core shared by ZUULI and the browser, and a test harness must not be
+//! able to leak into it.
+//!
+//! [`docs/e2ee/WIRE.md`]: https://github.com/free2z/zuu/blob/main/docs/e2ee/WIRE.md
+//! [`docs/e2ee/CLIENT-CONTRACT.md`]: https://github.com/free2z/zuu/blob/main/docs/e2ee/CLIENT-CONTRACT.md
+//! [ADR 0001]: https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0001-platform-priority.md
+//! [#586]: https://github.com/free2z/zuu/issues/586
+
+#![forbid(unsafe_code)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects
+    )
+)]
+
+pub mod client;
+pub mod clock;
+pub mod config;
+pub mod connection;
+pub mod engine;
+pub mod error;
+pub mod fake;
+pub mod faults;
+pub mod outbound;
+pub mod rng;
+pub mod state;
+pub mod transport;
+pub mod vectors;
+pub mod websocket;
+
+pub use client::{Client, ClientConfig};
+pub use config::{Relaxations, RelayConfig};
+pub use error::{Result, TestkitError};
+pub use fake::{Endpoint, FakeRelay, InProcessEndpoint, WebSocketEndpoint};
+pub use faults::{Effect, Fault, FaultInjector, PolicyFaults, Trigger};
+pub use vectors::{Report, Status, Vector};
+
+/// The protocol version this harness speaks, restated from [`f2z_codec`].
+pub const PROTOCOL_VERSION: u16 = f2z_codec::PROTOCOL_VERSION;

--- a/rs/crates/f2z-relay-testkit/src/outbound.rs
+++ b/rs/crates/f2z-relay-testkit/src/outbound.rs
@@ -1,0 +1,136 @@
+//! What the engine hands the writer.
+//!
+//! One type for responses, pushes and keepalives, because the writer applies
+//! fault effects uniformly and a second shape would be a second place for them
+//! to be forgotten.
+
+use f2z_codec::canonical::Canonical;
+use f2z_codec::commands::{PushEvent, QueuedMessage};
+use f2z_codec::frame::{Push, RelayFrame, Response};
+use f2z_codec::types::QueueAddress;
+use f2z_codec::{ErrorCode, commands::MsgPush};
+
+use crate::faults::Effect;
+
+/// What kind of frame this is, and what the writer must know about it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutKind {
+    /// A response. The effect was already resolved by the engine, which is
+    /// where [`Effect::Stall`] has to be decided: a stalled response must leave
+    /// its `request_id` outstanding in §4.3's window, and only the engine holds
+    /// that.
+    Response {
+        /// The delivery effect, if a fault selected one.
+        effect: Option<Effect>,
+    },
+    /// An unsolicited push (§6.4). The writer resolves its effect, because a
+    /// push is generated deep inside the state under a lock.
+    Push {
+        /// The event, for the fault lookup. `None` for a code this build does
+        /// not know, which cannot happen from our own engine.
+        event: Option<PushEvent>,
+    },
+    /// §2.4's server-driven keepalive. Never faulted: a fault that could stop
+    /// the keepalive would look like a hung relay rather than like the fault it
+    /// is.
+    Keepalive,
+    /// A frame whose fault has already been applied — a delayed one coming back
+    /// round. Written as-is, so a rule cannot fire twice on one frame.
+    Ready,
+}
+
+/// One frame on its way out.
+#[derive(Clone)]
+pub struct Outbound {
+    /// The canonical frame bytes (§3.3): the relay encodes once, here.
+    pub bytes: Vec<u8>,
+    /// What the writer needs to know about it.
+    pub kind: OutKind,
+    /// Close the connection after writing, with this RFC 6455 status.
+    ///
+    /// `WIRE.md` §1.3 defines a fatal error as "send the response, then close
+    /// the WebSocket connection" and §4.2 fixes status 1003 for a text frame.
+    /// It names no status for the other fatal codes; 1002 (protocol error) is
+    /// the reading used here and is listed as an ambiguity call.
+    pub close_after: Option<u16>,
+}
+
+// `bytes` is an encoded relay frame, and for a `MSG` push that is the whole of
+// somebody's ciphertext. Reported by length, like `f2z-codec`'s `Payload`.
+impl core::fmt::Debug for Outbound {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Outbound")
+            .field(
+                "bytes",
+                &format_args!("<redacted; {} bytes>", self.bytes.len()),
+            )
+            .field("kind", &self.kind)
+            .field("close_after", &self.close_after)
+            .finish()
+    }
+}
+
+impl Outbound {
+    /// A response frame.
+    #[must_use]
+    pub fn response(request_id: u32, response: Response, effect: Option<Effect>) -> Option<Self> {
+        Some(Self {
+            bytes: RelayFrame::response(request_id, response)
+                .encode_canonical()
+                .ok()?,
+            kind: OutKind::Response { effect },
+            close_after: None,
+        })
+    }
+
+    /// A response that closes the connection after it (§1.3).
+    #[must_use]
+    pub fn fatal(request_id: u32, code: ErrorCode, status: u16) -> Option<Self> {
+        let mut outbound = Self::response(request_id, Response::error(code), None)?;
+        outbound.close_after = Some(status);
+        Some(outbound)
+    }
+
+    /// The keepalive of §2.4.
+    #[must_use]
+    pub const fn keepalive() -> Self {
+        Self {
+            bytes: Vec::new(),
+            kind: OutKind::Keepalive,
+            close_after: None,
+        }
+    }
+}
+
+/// Encode a push frame (§6.4).
+#[must_use]
+pub fn push<B: Canonical>(event: PushEvent, body: &B) -> Option<Outbound> {
+    let frame = RelayFrame::push(Push::new(event.code(), body.encode_canonical().ok()?).ok()?);
+    Some(Outbound {
+        bytes: frame.encode_canonical().ok()?,
+        kind: OutKind::Push { event: Some(event) },
+        close_after: None,
+    })
+}
+
+/// The `MSG` push of §6.4, which goes only to the receive side, ever.
+#[must_use]
+pub fn msg_push(recv_addr: QueueAddress, message: &QueuedMessage) -> Option<Outbound> {
+    push(
+        PushEvent::Msg,
+        &MsgPush {
+            recv_addr,
+            msg: message.clone(),
+        },
+    )
+}
+
+/// RFC 6455 status 1002, "protocol error": the close used for every fatal §10
+/// code except §4.2's, which fixes 1003.
+pub const CLOSE_PROTOCOL_ERROR: u16 = 1002;
+
+/// RFC 6455 status 1003, "unsupported data": §4.2's text frame.
+pub const CLOSE_UNSUPPORTED_DATA: u16 = 1003;
+
+/// RFC 6455 status 1000, "normal closure".
+pub const CLOSE_NORMAL: u16 = 1000;

--- a/rs/crates/f2z-relay-testkit/src/rng.rs
+++ b/rs/crates/f2z-relay-testkit/src/rng.rs
@@ -1,0 +1,165 @@
+//! The address and nonce source — deterministic on purpose, and **not**
+//! cryptographically unpredictable.
+//!
+//! `WIRE.md` §7.1 requires a relay to generate both queue addresses "from its
+//! own CSPRNG", and §7.1's whole argument for relay-chosen addresses is that a
+//! client cannot predict or squat them. This type does not provide that
+//! property and does not claim to: it is BLAKE2b in counter mode over a seed
+//! the caller supplies, so a caller who knows the seed knows every address the
+//! relay will ever hand out.
+//!
+//! That is deliberate, it is the right trade for a test harness, and it is the
+//! single clearest reason `f2z-fakerelay` must never be deployed:
+//!
+//! - A conformance vector that produced different addresses on every run could
+//!   not be a vector. Reproducibility is what lets a failure be replayed
+//!   verbatim, in CI, six months later.
+//! - Seeding it from the operating system would need `getrandom`, i.e. a
+//!   dependency added to a crate whose randomness is documented not to matter.
+//!
+//! [`Csprng::from_clock`] exists so the binary does not hand every deployment
+//! the same addresses; it is a *variety* source, not an entropy source, and the
+//! difference is stated rather than blurred.
+
+use f2z_codec::hash::hash;
+use f2z_codec::types::{Challenge, QueueAddress};
+
+/// The domain label for this generator's stream.
+///
+/// It is deliberately not one of `f2z_codec::hash::LABELS`: nothing in the
+/// protocol hashes with it, and adding a testkit label to the protocol's
+/// prefix-free set would put a test harness inside the domain separation
+/// argument of `WIRE.md` §1.3.
+const LABEL: &[u8] = b"f2z-relay-testkit/rng/v1";
+
+/// A reproducible byte source for relay-generated addresses and challenges.
+#[derive(Clone)]
+pub struct Csprng {
+    seed: [u8; 32],
+    counter: u64,
+}
+
+// The seed is not secret in the sense a signing key is — the default is a
+// constant in this repository — but printing it hands a reader every address
+// the relay will ever produce, which is the one thing §7.1 wants withheld.
+// Same rule as `f2z-codec`'s newtypes, and for the same reason: `--log-level
+// trace` must not become a capability archive.
+impl core::fmt::Debug for Csprng {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Csprng")
+            .field("seed", &"<redacted>")
+            .field("counter", &self.counter)
+            .finish()
+    }
+}
+
+impl Csprng {
+    /// A stream fixed by `seed`. Two relays with the same seed hand out the
+    /// same addresses in the same order.
+    #[must_use]
+    pub const fn from_seed(seed: [u8; 32]) -> Self {
+        Self { seed, counter: 0 }
+    }
+
+    /// A stream varied by the wall clock.
+    ///
+    /// Read the module note before using this for anything: it is a variety
+    /// source so two runs of `f2z-fakerelay` do not collide, not an entropy
+    /// source, and the addresses it produces are guessable by anyone who knows
+    /// roughly when the process started.
+    #[must_use]
+    pub fn from_clock() -> Self {
+        let millis = core::time::Duration::from_secs(0);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or(millis);
+        let mut seed = [0u8; 32];
+        let stamp = hash(LABEL, &now.as_nanos().to_be_bytes());
+        seed.copy_from_slice(stamp.as_bytes());
+        Self::from_seed(seed)
+    }
+
+    /// The next 32 bytes of the stream.
+    #[must_use]
+    pub fn next_block(&mut self) -> [u8; 32] {
+        let mut input = [0u8; 40];
+        let (seed, counter) = input.split_at_mut(32);
+        seed.copy_from_slice(&self.seed);
+        counter.copy_from_slice(&self.counter.to_be_bytes());
+        self.counter = self.counter.wrapping_add(1);
+        *hash(LABEL, &input).as_bytes()
+    }
+
+    /// The next `N` bytes, for the fixed-width newtypes of `f2z-codec`.
+    #[must_use]
+    pub fn next_bytes<const N: usize>(&mut self) -> [u8; N] {
+        let mut out = [0u8; N];
+        let mut written = 0usize;
+        while written < N {
+            let block = self.next_block();
+            let take = core::cmp::min(32, N.saturating_sub(written));
+            let end = written.saturating_add(take);
+            match (out.get_mut(written..end), block.get(..take)) {
+                (Some(slot), Some(source)) => slot.copy_from_slice(source),
+                // Unreachable by the loop bound; the workspace forbids
+                // indexing, so the impossible branch is written out rather
+                // than asserted away.
+                _ => break,
+            }
+            written = end;
+        }
+        out
+    }
+
+    /// A fresh 32-byte queue address (§7.1).
+    #[must_use]
+    pub fn next_address(&mut self) -> QueueAddress {
+        QueueAddress::new(self.next_block())
+    }
+
+    /// A fresh 32-byte challenge (§6.1).
+    #[must_use]
+    pub fn next_challenge(&mut self) -> Challenge {
+        Challenge::new(self.next_block())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_same_seed_yields_the_same_stream() {
+        let mut left = Csprng::from_seed([7u8; 32]);
+        let mut right = Csprng::from_seed([7u8; 32]);
+        for _ in 0..8 {
+            assert_eq!(left.next_block(), right.next_block());
+        }
+    }
+
+    #[test]
+    fn different_seeds_diverge_immediately() {
+        let mut left = Csprng::from_seed([7u8; 32]);
+        let mut right = Csprng::from_seed([8u8; 32]);
+        assert_ne!(left.next_block(), right.next_block());
+    }
+
+    #[test]
+    fn successive_addresses_differ() {
+        let mut rng = Csprng::from_seed([1u8; 32]);
+        let first = rng.next_address();
+        let second = rng.next_address();
+        assert_ne!(first, second);
+        assert!(!first.is_zero());
+    }
+
+    #[test]
+    fn odd_widths_are_filled_completely() {
+        let mut rng = Csprng::from_seed([2u8; 32]);
+        let short: [u8; 16] = rng.next_bytes();
+        let long: [u8; 48] = rng.next_bytes();
+        assert!(short.iter().any(|byte| *byte != 0));
+        assert!(long.iter().any(|byte| *byte != 0));
+        assert!(long.iter().skip(32).any(|byte| *byte != 0));
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/state.rs
+++ b/rs/crates/f2z-relay-testkit/src/state.rs
@@ -1,0 +1,868 @@
+//! The relay's storage, and the parts of `WIRE.md` §7, §8 and §12 that are
+//! about *holding* things rather than about rules.
+//!
+//! `f2z-relay-proto::queue` already owns every rule that can lose a message:
+//! bind-once, cumulative-monotone-idempotent acknowledgement, and the anti-
+//! pre-ack bound. None of it is re-implemented here. What is here is the state
+//! those rules are applied to — a `BTreeMap` of ciphertext, a subscriber list,
+//! and the challenge table — plus the two behaviours that only exist once
+//! something is stored: TTL expiry (§7.7) and the quota admission of §13.1
+//! layer 2.
+//!
+//! # In-memory, and that is published
+//!
+//! §11.1's `durability_mode` has three values and this is `memory`: an `APPEND`
+//! that returned 0 does not survive the process. §8.4 says no end-to-end
+//! contract breaks in the weaker modes because `accepted` never promised
+//! anything — which is true, and is also exactly why a client must not treat
+//! `accepted` as delivery. A test harness that silently offered durability
+//! would hide that.
+//!
+//! # The one rule that is *not* here, restated because it is the important one
+//!
+//! §13.2: **under no circumstance does a relay delete an unacknowledged message
+//! to free space.** Not the oldest, not the largest, not from the fullest
+//! queue. When it runs out of room it refuses new writes. There is no eviction
+//! path in this module, and the absence is deliberate rather than an omission:
+//! the only deletions are acknowledgement (§8), TTL expiry (§7.7) and
+//! `DELETE_QUEUE` (§7.6).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use f2z_codec::ErrorCode;
+use f2z_codec::commands::{NoticePush, PushEvent, QueueEventPush, QueuedMessage};
+use f2z_codec::types::{Challenge, Payload, PublicKey, QueueAddress};
+use f2z_relay_proto::ProtoError;
+use f2z_relay_proto::queue::{AckOutcome, AppendQuota, QueueKind, QueueState};
+use f2z_relay_proto::replay::SeenSet;
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::error::Result;
+use crate::faults::PolicyFaults;
+use crate::outbound::Outbound;
+use crate::rng::Csprng;
+
+/// `QUEUE_EVENT` reason 1 (§6.4): the queue was deleted.
+pub const QUEUE_EVENT_DELETED: u8 = 1;
+/// `QUEUE_EVENT` reason 2 (§6.4): the queue's idle TTL elapsed.
+pub const QUEUE_EVENT_IDLE_EXPIRED: u8 = 2;
+/// `QUEUE_EVENT` reason 3 (§6.4): stored messages hit their TTL.
+pub const QUEUE_EVENT_MESSAGES_EXPIRED: u8 = 3;
+/// `QUEUE_EVENT` reason 4 (§6.4): a quota was reached.
+pub const QUEUE_EVENT_QUOTA: u8 = 4;
+
+/// `NOTICE` kind 3 (§6.4): the capability document changed.
+pub const NOTICE_CAPABILITIES_CHANGED: u8 = 3;
+
+/// One stored ciphertext.
+#[derive(Clone, Debug)]
+pub struct Stored {
+    /// The index it was appended at.
+    pub index: u64,
+    /// The opaque payload. The relay never looks inside one.
+    pub payload: Payload,
+    /// Relay clock at acceptance — `QueuedMessage.received_at_ms`.
+    pub received_at_ms: u64,
+    /// When §7.7's message TTL drops it.
+    pub expires_at_ms: u64,
+}
+
+impl Stored {
+    fn as_message(&self) -> QueuedMessage {
+        QueuedMessage {
+            index: self.index,
+            received_at_ms: self.received_at_ms,
+            payload: self.payload.clone(),
+        }
+    }
+}
+
+/// One queue: the rules from `f2z-relay-proto`, plus what it holds.
+#[derive(Clone, Debug)]
+pub struct Queue {
+    /// Standard or contact (§12.2).
+    pub kind: QueueKind,
+    /// Authorization and acknowledgement state — the rules, not re-derived.
+    pub state: QueueState,
+    /// The receive address: `SUBSCRIBE`, `READ`, `ACK`, `DELETE_QUEUE`.
+    pub recv_addr: QueueAddress,
+    /// The second address: bindable `send_addr` for a standard queue, published
+    /// and never bindable `contact_addr` for a contact queue.
+    pub second_addr: QueueAddress,
+    /// Stored ciphertext, by index.
+    pub messages: BTreeMap<u64, Stored>,
+    /// Bytes currently held, for §13.1 layer 2's byte cap.
+    pub bytes: u64,
+    /// The granted message TTL (§7.7), after clamping.
+    pub message_ttl_seconds: u32,
+    /// The granted idle TTL (§7.7), after clamping.
+    pub idle_ttl_seconds: u32,
+    /// Relay clock at creation.
+    pub created_at_ms: u64,
+    /// Last successful `APPEND`, `READ`, `ACK` or `SUBSCRIBE` — §7.7's idle
+    /// reset list, exactly as written.
+    pub last_activity_ms: u64,
+    /// The per-queue caps this queue is admitted against.
+    pub quota: AppendQuota,
+}
+
+impl Queue {
+    /// Messages present and not yet acknowledged — §6.2's `pending`.
+    ///
+    /// Counted from storage rather than from the index arithmetic, because TTL
+    /// expiry removes messages without moving the watermark and the index-space
+    /// count is only an upper bound. `f2z-relay-proto::queue` says so and hands
+    /// the decision here, which is where the storage is.
+    #[must_use]
+    pub fn pending(&self) -> u64 {
+        u64::try_from(self.messages.len()).unwrap_or(u64::MAX)
+    }
+
+    /// Touch §7.7's idle timer.
+    pub fn touch(&mut self, now_ms: u64) {
+        self.last_activity_ms = now_ms;
+    }
+
+    fn idle_deadline(&self, faults: PolicyFaults) -> u64 {
+        match faults.expire_queue_after {
+            Some(after) => self
+                .last_activity_ms
+                .saturating_add(u64::try_from(after.as_millis()).unwrap_or(u64::MAX)),
+            None => self
+                .last_activity_ms
+                .saturating_add(u64::from(self.idle_ttl_seconds).saturating_mul(1_000)),
+        }
+    }
+
+    fn message_deadline(&self, stored: &Stored, faults: PolicyFaults) -> u64 {
+        match faults.expire_messages_after {
+            Some(after) => stored
+                .received_at_ms
+                .saturating_add(u64::try_from(after.as_millis()).unwrap_or(u64::MAX)),
+            None => stored.expires_at_ms,
+        }
+    }
+
+    fn effective_quota(&self, faults: PolicyFaults) -> AppendQuota {
+        AppendQuota {
+            max_messages: faults
+                .max_queue_messages
+                .map_or(self.quota.max_messages, u64::from),
+            max_bytes: faults.max_queue_bytes.unwrap_or(self.quota.max_bytes),
+        }
+    }
+}
+
+/// A connection that asked for `MSG` pushes on a queue (§6.2, §6.4).
+#[derive(Clone, Debug)]
+struct Subscriber {
+    connection: u64,
+    sender: UnboundedSender<Outbound>,
+}
+
+/// A challenge the relay issued and has not yet consumed (§6.1, §12.3).
+#[derive(Clone)]
+struct Issued {
+    purpose: u8,
+    scope: Vec<u8>,
+    expires_at_ms: u64,
+}
+
+// `scope` is a published contact address for a `contact_append` challenge —
+// public by design, but still a capability, and §12.2 point 3 makes it the one
+// address in the system meant to be looked up rather than logged.
+impl core::fmt::Debug for Issued {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Issued")
+            .field("purpose", &self.purpose)
+            .field(
+                "scope",
+                &format_args!("<redacted; {} bytes>", self.scope.len()),
+            )
+            .field("expires_at_ms", &self.expires_at_ms)
+            .finish()
+    }
+}
+
+/// Everything one relay holds.
+#[derive(Debug)]
+pub struct RelayState {
+    rng: Csprng,
+    queues: BTreeMap<QueueAddress, Queue>,
+    /// `send_addr` or `contact_addr` → `recv_addr`.
+    second_index: BTreeMap<QueueAddress, QueueAddress>,
+    challenges: BTreeMap<Challenge, Issued>,
+    subscribers: BTreeMap<QueueAddress, Vec<Subscriber>>,
+    /// §5.5's seen-set, relay-wide rather than per connection. In
+    /// `channel_binding_mode: none` — which is what a `ws://` test double
+    /// publishes — the binding is a constant, so a frame captured on one
+    /// connection verifies on another and a per-connection set would not close
+    /// the window at all.
+    seen: SeenSet,
+    next_connection_id: u64,
+}
+
+impl RelayState {
+    /// A fresh, empty relay.
+    #[must_use]
+    pub fn new(rng_seed: [u8; 32], seen: SeenSet) -> Self {
+        Self {
+            rng: Csprng::from_seed(rng_seed),
+            queues: BTreeMap::new(),
+            second_index: BTreeMap::new(),
+            challenges: BTreeMap::new(),
+            subscribers: BTreeMap::new(),
+            seen,
+            next_connection_id: 1,
+        }
+    }
+
+    /// Take the seen-set out for one verification, leaving a placeholder.
+    ///
+    /// `CommandVerifier` owns its seen-set because §5.1's ordering — window,
+    /// then seen-set, then signature — has to live in one function. Moving the
+    /// real set in and out per command is what lets that single implementation
+    /// be reused while the set stays relay-wide.
+    pub fn take_seen(&mut self) -> SeenSet {
+        let placeholder = SeenSet::new(self.seen.retention_ms(), self.seen.max_entries());
+        core::mem::replace(&mut self.seen, placeholder)
+    }
+
+    /// Put the seen-set back after a verification.
+    pub fn put_seen(&mut self, seen: SeenSet) {
+        self.seen = seen;
+    }
+
+    /// The seen-set, for assertions.
+    #[must_use]
+    pub const fn seen(&self) -> &SeenSet {
+        &self.seen
+    }
+
+    /// A connection identifier, so a subscription can be dropped when its
+    /// connection goes (§6.2: "a subscription is scoped to the connection and
+    /// dies with it").
+    pub fn next_connection_id(&mut self) -> u64 {
+        let id = self.next_connection_id;
+        self.next_connection_id = self.next_connection_id.saturating_add(1);
+        id
+    }
+
+    /// How many queues exist, for §13.1's creation quota.
+    #[must_use]
+    pub fn queue_count(&self) -> usize {
+        self.queues.len()
+    }
+
+    /// The relay's own CSPRNG (§7.1). See [`crate::rng`] for what it is not.
+    pub const fn rng(&mut self) -> &mut Csprng {
+        &mut self.rng
+    }
+
+    // -- queues ------------------------------------------------------------
+
+    /// Create a queue, generating both addresses from the relay's own generator
+    /// (§7.1).
+    pub fn create_queue(
+        &mut self,
+        kind: QueueKind,
+        recv_key: PublicKey,
+        message_ttl_seconds: u32,
+        idle_ttl_seconds: u32,
+        quota: AppendQuota,
+        now_ms: u64,
+    ) -> (QueueAddress, QueueAddress) {
+        // §7.1: 32 uniformly random bytes each, independent of one another and
+        // of any key, retried on collision — which at 32 bytes never happens,
+        // but the retry is what makes that a fact rather than a hope.
+        let recv_addr = self.fresh_address();
+        let second_addr = self.fresh_address();
+        let queue = Queue {
+            kind,
+            state: QueueState::create(kind, recv_key),
+            recv_addr,
+            second_addr,
+            messages: BTreeMap::new(),
+            bytes: 0,
+            message_ttl_seconds,
+            idle_ttl_seconds,
+            created_at_ms: now_ms,
+            last_activity_ms: now_ms,
+            quota,
+        };
+        self.queues.insert(recv_addr, queue);
+        self.second_index.insert(second_addr, recv_addr);
+        (recv_addr, second_addr)
+    }
+
+    fn fresh_address(&mut self) -> QueueAddress {
+        loop {
+            let candidate = self.rng.next_address();
+            if candidate.is_zero() {
+                continue;
+            }
+            if !self.queues.contains_key(&candidate) && !self.second_index.contains_key(&candidate)
+            {
+                return candidate;
+            }
+        }
+    }
+
+    /// The queue a receive address names, if any.
+    #[must_use]
+    pub fn queue_by_recv(&mut self, recv_addr: &QueueAddress) -> Option<&mut Queue> {
+        self.queues.get_mut(recv_addr)
+    }
+
+    /// The queue a send or contact address names, if any.
+    #[must_use]
+    pub fn queue_by_second(&mut self, second_addr: &QueueAddress) -> Option<&mut Queue> {
+        let recv = self.second_index.get(second_addr).copied()?;
+        self.queues.get_mut(&recv)
+    }
+
+    /// Whether an address is a queue's second address at all.
+    #[must_use]
+    pub fn is_second_address(&self, address: &QueueAddress) -> bool {
+        self.second_index.contains_key(address)
+    }
+
+    /// Delete a queue, its addresses and every message it holds (§7.6).
+    ///
+    /// Leaves no tombstone: §7.6 forbids retaining anything that distinguishes
+    /// "deleted" from "never existed" in an externally observable way, so the
+    /// record is dropped rather than flagged.
+    pub fn delete_queue(&mut self, recv_addr: &QueueAddress) -> bool {
+        let Some(queue) = self.queues.remove(recv_addr) else {
+            return false;
+        };
+        self.second_index.remove(&queue.second_addr);
+        self.notify_queue_event(recv_addr, QUEUE_EVENT_DELETED);
+        self.subscribers.remove(recv_addr);
+        true
+    }
+
+    /// Append a payload, after the caller has authorized it and admitted it
+    /// against the quota.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::Unavailable`] if the index space is exhausted — a send-side
+    /// refusal like every other (§6.3).
+    pub fn append(
+        &mut self,
+        recv_addr: &QueueAddress,
+        payload: Payload,
+        now_ms: u64,
+    ) -> std::result::Result<u64, ProtoError> {
+        let Some(queue) = self.queues.get_mut(recv_addr) else {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        };
+        let index = queue.state.append()?;
+        let expires_at_ms =
+            now_ms.saturating_add(u64::from(queue.message_ttl_seconds).saturating_mul(1_000));
+        let stored = Stored {
+            index,
+            payload,
+            received_at_ms: now_ms,
+            expires_at_ms,
+        };
+        queue.bytes = queue
+            .bytes
+            .saturating_add(u64::try_from(stored.payload.len()).unwrap_or(u64::MAX));
+        let message = stored.as_message();
+        queue.messages.insert(index, stored);
+        queue.touch(now_ms);
+        self.notify_message(recv_addr, &message);
+        Ok(index)
+    }
+
+    /// Admit one payload against a queue's caps (§13.1 layer 2, §12.3).
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::Unavailable`], never a code that says which cap was hit.
+    pub fn admit(
+        &mut self,
+        recv_addr: &QueueAddress,
+        payload_bytes: u64,
+        faults: PolicyFaults,
+    ) -> std::result::Result<(), ProtoError> {
+        let Some(queue) = self.queues.get(recv_addr) else {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        };
+        let quota = queue.effective_quota(faults);
+        let admitted = quota.admit(queue.pending(), queue.bytes, payload_bytes);
+        if admitted.is_err() {
+            self.notify_queue_event(recv_addr, QUEUE_EVENT_QUOTA);
+        }
+        admitted
+    }
+
+    /// Read from `from_index`, clamped to the acked watermark (§6.2).
+    ///
+    /// Returns the messages and whether more remain past the last one.
+    #[must_use]
+    pub fn read(
+        &mut self,
+        recv_addr: &QueueAddress,
+        from_index: u64,
+        max_messages: u16,
+        max_bytes: u32,
+        now_ms: u64,
+    ) -> Option<(Vec<QueuedMessage>, bool)> {
+        let queue = self.queues.get_mut(recv_addr)?;
+        queue.touch(now_ms);
+        let start = queue.state.read_from(from_index);
+
+        // §6.2 gives no meaning to a zero limit, and the reading that keeps a
+        // queue drainable is "no client-side limit" — the same reading
+        // f2z-relay-proto takes for a zero TTL. A zero that meant "return
+        // nothing" would make a client that forgot to set the field loop
+        // forever against a queue it can never empty.
+        let message_limit = if max_messages == 0 {
+            usize::MAX
+        } else {
+            usize::from(max_messages)
+        };
+        let byte_limit = if max_bytes == 0 {
+            u64::MAX
+        } else {
+            u64::from(max_bytes)
+        };
+
+        let mut messages = Vec::new();
+        let mut bytes = 0u64;
+        let mut has_more = false;
+        for stored in queue.messages.range(start..).map(|(_, stored)| stored) {
+            let size = u64::try_from(stored.payload.len()).unwrap_or(u64::MAX);
+            if !messages.is_empty()
+                && (messages.len() >= message_limit || bytes.saturating_add(size) > byte_limit)
+            {
+                has_more = true;
+                break;
+            }
+            bytes = bytes.saturating_add(size);
+            messages.push(stored.as_message());
+        }
+        Some((messages, has_more))
+    }
+
+    /// Apply an `ACK` and delete what it acknowledges (§8).
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::AckTooHigh`] from §8.2's anti-pre-ack rule, or
+    /// [`ErrorCode::NoAccess`] if the queue is gone.
+    pub fn ack(
+        &mut self,
+        recv_addr: &QueueAddress,
+        up_to_index: u64,
+        now_ms: u64,
+    ) -> std::result::Result<(AckOutcome, u64), ProtoError> {
+        let Some(queue) = self.queues.get_mut(recv_addr) else {
+            return Err(ProtoError::Wire(ErrorCode::NoAccess));
+        };
+        let outcome = queue.state.ack(up_to_index)?;
+        // The watermark moved (or did not, idempotently). Either way the
+        // messages at or below it are gone: §8.1, "the relay deletes them and
+        // advances the queue's acked watermark".
+        let acknowledged: Vec<u64> = queue
+            .messages
+            .range(..=up_to_index)
+            .map(|(index, _)| *index)
+            .collect();
+        for index in acknowledged {
+            if let Some(stored) = queue.messages.remove(&index) {
+                queue.bytes = queue
+                    .bytes
+                    .saturating_sub(u64::try_from(stored.payload.len()).unwrap_or(0));
+            }
+        }
+        queue.touch(now_ms);
+        Ok((outcome, queue.pending()))
+    }
+
+    // -- subscriptions -----------------------------------------------------
+
+    /// Register a connection for `MSG` pushes on a receive address (§6.2).
+    pub fn subscribe(
+        &mut self,
+        recv_addr: QueueAddress,
+        connection: u64,
+        sender: UnboundedSender<Outbound>,
+    ) {
+        let entries = self.subscribers.entry(recv_addr).or_default();
+        if entries
+            .iter()
+            .any(|subscriber| subscriber.connection == connection)
+        {
+            return;
+        }
+        entries.push(Subscriber { connection, sender });
+    }
+
+    /// Drop one connection's subscription to one address.
+    pub fn unsubscribe(&mut self, recv_addr: &QueueAddress, connection: u64) {
+        if let Some(entries) = self.subscribers.get_mut(recv_addr) {
+            entries.retain(|subscriber| subscriber.connection != connection);
+            if entries.is_empty() {
+                self.subscribers.remove(recv_addr);
+            }
+        }
+    }
+
+    /// Drop every subscription a connection holds — §6.2's "dies with it".
+    pub fn drop_connection(&mut self, connection: u64, addresses: &BTreeSet<QueueAddress>) {
+        for address in addresses {
+            self.unsubscribe(address, connection);
+        }
+    }
+
+    fn notify_message(&self, recv_addr: &QueueAddress, message: &QueuedMessage) {
+        let Some(entries) = self.subscribers.get(recv_addr) else {
+            return;
+        };
+        for subscriber in entries {
+            let push = crate::outbound::msg_push(*recv_addr, message);
+            if let Some(outbound) = push {
+                let _ = subscriber.sender.send(outbound);
+            }
+        }
+    }
+
+    fn notify_queue_event(&self, recv_addr: &QueueAddress, reason: u8) {
+        let Some(entries) = self.subscribers.get(recv_addr) else {
+            return;
+        };
+        let body = QueueEventPush {
+            recv_addr: *recv_addr,
+            reason,
+        };
+        for subscriber in entries {
+            if let Some(outbound) = crate::outbound::push(PushEvent::QueueEvent, &body) {
+                let _ = subscriber.sender.send(outbound);
+            }
+        }
+    }
+
+    /// Send a `NOTICE` to every subscribed connection (§6.4).
+    pub fn notify_all(&self, kind: u8, at_ms: u64) {
+        let body = NoticePush { kind, at_ms };
+        for entries in self.subscribers.values() {
+            for subscriber in entries {
+                if let Some(outbound) = crate::outbound::push(PushEvent::Notice, &body) {
+                    let _ = subscriber.sender.send(outbound);
+                }
+            }
+        }
+    }
+
+    // -- expiry ------------------------------------------------------------
+
+    /// Apply §7.7's two timers. Called before every command, so a test that
+    /// moves the clock sees the consequence on its next request.
+    pub fn expire(&mut self, now_ms: u64, faults: PolicyFaults) {
+        let mut messages_expired: Vec<QueueAddress> = Vec::new();
+        let mut idle_expired: Vec<QueueAddress> = Vec::new();
+
+        for (recv_addr, queue) in &mut self.queues {
+            if queue.idle_deadline(faults) <= now_ms {
+                idle_expired.push(*recv_addr);
+                continue;
+            }
+            let expired: Vec<u64> = queue
+                .messages
+                .iter()
+                .filter(|(_, stored)| queue.message_deadline(stored, faults) <= now_ms)
+                .map(|(index, _)| *index)
+                .collect();
+            if expired.is_empty() {
+                continue;
+            }
+            for index in expired {
+                if let Some(stored) = queue.messages.remove(&index) {
+                    queue.bytes = queue
+                        .bytes
+                        .saturating_sub(u64::try_from(stored.payload.len()).unwrap_or(0));
+                }
+            }
+            messages_expired.push(*recv_addr);
+        }
+
+        for recv_addr in messages_expired {
+            self.notify_queue_event(&recv_addr, QUEUE_EVENT_MESSAGES_EXPIRED);
+        }
+        for recv_addr in idle_expired {
+            if let Some(queue) = self.queues.remove(&recv_addr) {
+                self.second_index.remove(&queue.second_addr);
+            }
+            self.notify_queue_event(&recv_addr, QUEUE_EVENT_IDLE_EXPIRED);
+            self.subscribers.remove(&recv_addr);
+        }
+    }
+
+    // -- challenges --------------------------------------------------------
+
+    /// Issue a single-use, expiring challenge (§6.1, §12.3).
+    pub fn issue_challenge(&mut self, purpose: u8, scope: &[u8], expires_at_ms: u64) -> Challenge {
+        let challenge = self.rng.next_challenge();
+        self.challenges.insert(
+            challenge,
+            Issued {
+                purpose,
+                scope: scope.to_vec(),
+                expires_at_ms,
+            },
+        );
+        challenge
+    }
+
+    /// Consume a challenge, checking purpose, scope and expiry (§12.3).
+    ///
+    /// Binding the stamp to the target address and to a relay-issued challenge
+    /// is what means stamps cannot be precomputed before a campaign, cannot be
+    /// reused, and cannot be computed for one victim and spent on another. All
+    /// three properties are this one function.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::PowInvalid`] — §10 code 17 covers "invalid, expired, for
+    /// the wrong challenge, or already consumed" with one code, so none of the
+    /// four is distinguishable from outside.
+    pub fn consume_challenge(
+        &mut self,
+        challenge: &Challenge,
+        purpose: u8,
+        scope: &[u8],
+        now_ms: u64,
+    ) -> std::result::Result<(), ProtoError> {
+        let Some(issued) = self.challenges.remove(challenge) else {
+            return Err(ProtoError::Wire(ErrorCode::PowInvalid));
+        };
+        if issued.purpose != purpose
+            || issued.expires_at_ms <= now_ms
+            || (!scope.is_empty() && issued.scope != scope)
+        {
+            return Err(ProtoError::Wire(ErrorCode::PowInvalid));
+        }
+        Ok(())
+    }
+
+    /// Drop expired challenges. Cheap, and keeps a long-lived relay's table
+    /// from growing without bound.
+    pub fn expire_challenges(&mut self, now_ms: u64) {
+        self.challenges
+            .retain(|_, issued| issued.expires_at_ms > now_ms);
+    }
+}
+
+/// A convenience for callers that want the whole state guarded.
+pub type SharedResult<T> = Result<T>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_codec::types::Payload;
+
+    fn state() -> RelayState {
+        RelayState::new([3u8; 32], SeenSet::new(240_000, 1024))
+    }
+
+    fn quota() -> AppendQuota {
+        AppendQuota {
+            max_messages: 8,
+            max_bytes: 64 * 1024,
+        }
+    }
+
+    #[test]
+    fn a_created_queue_has_two_distinct_nonzero_addresses() {
+        let mut state = state();
+        let (recv, send) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            600,
+            3_600,
+            quota(),
+            1_000,
+        );
+        assert_ne!(recv, send);
+        assert!(!recv.is_zero());
+        assert!(!send.is_zero());
+        assert!(state.queue_by_recv(&recv).is_some());
+        assert!(state.queue_by_second(&send).is_some());
+    }
+
+    #[test]
+    fn deleting_a_queue_leaves_no_tombstone() {
+        let mut state = state();
+        let (recv, send) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            600,
+            3_600,
+            quota(),
+            1_000,
+        );
+        assert!(state.delete_queue(&recv));
+        assert!(state.queue_by_recv(&recv).is_none());
+        assert!(state.queue_by_second(&send).is_none());
+        assert!(!state.is_second_address(&send));
+        // A second delete is indistinguishable from deleting one that never
+        // existed, which is exactly §7.6.
+        assert!(!state.delete_queue(&recv));
+    }
+
+    #[test]
+    fn acking_deletes_and_read_never_resurrects() {
+        let mut state = state();
+        let (recv, _) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            600,
+            3_600,
+            quota(),
+            1_000,
+        );
+        for _ in 0..3 {
+            state
+                .append(&recv, Payload::new(vec![0u8; 1024]).unwrap(), 1_000)
+                .unwrap();
+        }
+        let (outcome, pending) = state.ack(&recv, 1, 1_000).unwrap();
+        assert_eq!(outcome.acknowledged, 2);
+        assert_eq!(pending, 1);
+
+        // §6.2: a READ from below the watermark starts at the watermark and
+        // does not error.
+        let (messages, has_more) = state.read(&recv, 0, 0, 0, 1_000).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages.first().map(|m| m.index), Some(2));
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn a_read_always_returns_at_least_one_message() {
+        // A byte limit below the first message must not stall the queue
+        // forever: the client would never be able to drain it, and there is no
+        // other way out because READ never mutates.
+        let mut state = state();
+        let (recv, _) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            600,
+            3_600,
+            quota(),
+            1_000,
+        );
+        state
+            .append(&recv, Payload::new(vec![0u8; 4096]).unwrap(), 1_000)
+            .unwrap();
+        state
+            .append(&recv, Payload::new(vec![0u8; 4096]).unwrap(), 1_000)
+            .unwrap();
+        let (messages, has_more) = state.read(&recv, 0, 0, 1, 1_000).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn ttl_expiry_removes_messages_without_moving_the_watermark() {
+        let mut state = state();
+        let (recv, _) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            60,
+            3_600,
+            quota(),
+            1_000,
+        );
+        state
+            .append(&recv, Payload::new(vec![0u8; 1024]).unwrap(), 1_000)
+            .unwrap();
+        state.expire(1_000 + 60_001, PolicyFaults::default());
+        let queue = state.queue_by_recv(&recv).unwrap();
+        assert_eq!(queue.messages.len(), 0);
+        assert_eq!(queue.state.acked_through(), None);
+        assert_eq!(queue.state.next_index(), 1);
+        // And the reader can still not pre-ack past what was appended.
+        assert!(state.ack(&recv, 5, 1_000).is_err());
+    }
+
+    #[test]
+    fn an_idle_queue_disappears_with_both_its_addresses() {
+        let mut state = state();
+        let (recv, send) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            60,
+            3_600,
+            quota(),
+            1_000,
+        );
+        state.expire(1_000 + 3_600_001, PolicyFaults::default());
+        assert!(state.queue_by_recv(&recv).is_none());
+        assert!(!state.is_second_address(&send));
+    }
+
+    #[test]
+    fn a_challenge_is_single_use_and_scoped() {
+        let mut state = state();
+        let scope = [9u8; 32];
+        let challenge = state.issue_challenge(2, &scope, 10_000);
+        assert!(
+            state
+                .consume_challenge(&challenge, 2, &[8u8; 32], 1_000)
+                .is_err(),
+            "a stamp computed for one victim must not be spendable on another"
+        );
+        // …and the wrong-scope attempt still consumed it, which is what makes
+        // a challenge single-use rather than single-*success*.
+        let challenge = state.issue_challenge(2, &scope, 10_000);
+        assert!(
+            state
+                .consume_challenge(&challenge, 2, &scope, 1_000)
+                .is_ok()
+        );
+        assert!(
+            state
+                .consume_challenge(&challenge, 2, &scope, 1_000)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn an_expired_challenge_is_refused() {
+        let mut state = state();
+        let challenge = state.issue_challenge(1, &[], 10_000);
+        assert!(state.consume_challenge(&challenge, 1, &[], 10_001).is_err());
+    }
+
+    #[test]
+    fn there_is_no_eviction_path() {
+        // §13.2: the relay refuses new writes rather than deleting an
+        // unacknowledged message. Asserted by admitting past the cap and
+        // checking that nothing already stored moved.
+        let mut state = state();
+        let (recv, _) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            600,
+            3_600,
+            AppendQuota {
+                max_messages: 1,
+                max_bytes: 64 * 1024,
+            },
+            1_000,
+        );
+        state
+            .append(&recv, Payload::new(vec![0u8; 1024]).unwrap(), 1_000)
+            .unwrap();
+        assert!(state.admit(&recv, 1024, PolicyFaults::default()).is_err());
+        assert_eq!(
+            state.queue_by_recv(&recv).map(|queue| queue.messages.len()),
+            Some(1)
+        );
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/transport.rs
+++ b/rs/crates/f2z-relay-testkit/src/transport.rs
@@ -1,0 +1,373 @@
+//! The one seam between "a relay" and "how its bytes travel".
+//!
+//! `WIRE.md` §2.1 admits exactly one transport, and §2.2 gives the reason: a
+//! second transport is a second parser and a second fuzz target. This crate
+//! does not add one. What it adds is a *seam*, so that the identical relay can
+//! be driven either over a real WebSocket or over an in-memory pipe.
+//!
+//! # Why both, and why they must be the same code
+//!
+//! An in-process transport is fast, deterministic and has no sockets, which
+//! makes it the right thing for a unit test. It is also a liar: it cannot
+//! reorder, cannot fragment, cannot drop a connection at a TCP boundary, and
+//! cannot tell you that your frame writer forgot to set the binary opcode. A
+//! client that only ever runs against it will ship framing bugs.
+//!
+//! So [`crate::FakeRelay`] serves both, and both go through
+//! [`crate::connection::drive`] — one function, one engine, one set of rules. If
+//! the two ever diverge the fake is lying about the thing it exists to prove,
+//! which is why `tests/conformance.rs` runs the whole vector suite twice and
+//! compares the verdicts rather than trusting that they agree.
+//!
+//! # The in-process framing is not protocol
+//!
+//! A WebSocket message is self-delimiting and typed; a byte pipe is neither. So
+//! [`duplex`] frames each message as `opcode || length || payload`, mirroring
+//! RFC 6455's opcodes closely enough that §4.2's "a text frame is a fatal
+//! `ERR_FRAME_TYPE`" is reachable in-process. **This framing exists nowhere in
+//! `WIRE.md` and no client should implement it.** It is the moral equivalent of
+//! a test double's constructor.
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::future::BoxFuture;
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
+
+/// One protocol unit as it crosses the seam.
+///
+/// The variants are RFC 6455's, restricted to what `WIRE.md` uses: §4.1's
+/// binary frames, §4.2's rejected text frames, and §2.4's server-driven
+/// keepalive.
+#[derive(Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum WireMessage {
+    /// A relay frame (§4.1). The only kind that carries protocol.
+    Binary(Vec<u8>),
+    /// A text frame. §4.2: fatal `ERR_FRAME_TYPE`, close with status 1003. The
+    /// relay MUST NOT try to decode it, and this crate MUST be able to send
+    /// one, or that rule is untested.
+    Text(Vec<u8>),
+    /// §2.4's server-side Ping. A browser cannot send one, which is why the
+    /// relay drives the keepalive.
+    Ping(Vec<u8>),
+    /// The answer to a Ping. Clients MUST send it; the browser runtime does.
+    Pong(Vec<u8>),
+    /// A close, carrying RFC 6455's status code.
+    Close(u16),
+}
+
+// A binary message is a whole relay frame — an `APPEND` payload included — and
+// a derived `Debug` would render it as a list of decimal integers. 1 KiB of
+// ciphertext becomes 5 KiB of log, written by the operator, at rest, for as
+// long as rotation keeps it. The length is public; the bytes are not.
+impl std::fmt::Debug for WireMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Binary(bytes) => write!(f, "Binary(<redacted; {} bytes>)", bytes.len()),
+            Self::Text(bytes) => write!(f, "Text(<redacted; {} bytes>)", bytes.len()),
+            Self::Ping(bytes) => write!(f, "Ping(<{} bytes>)", bytes.len()),
+            Self::Pong(bytes) => write!(f, "Pong(<{} bytes>)", bytes.len()),
+            Self::Close(code) => write!(f, "Close({code})"),
+        }
+    }
+}
+
+impl WireMessage {
+    /// The relay-frame bytes, if this is one.
+    #[must_use]
+    pub fn binary(&self) -> Option<&[u8]> {
+        match self {
+            Self::Binary(bytes) => Some(bytes),
+            _ => None,
+        }
+    }
+
+    /// The RFC 6455 opcode, as the in-process framing writes it.
+    #[must_use]
+    pub const fn opcode(&self) -> u8 {
+        match self {
+            Self::Text(_) => 0x1,
+            Self::Binary(_) => 0x2,
+            Self::Close(_) => 0x8,
+            Self::Ping(_) => 0x9,
+            Self::Pong(_) => 0xa,
+        }
+    }
+}
+
+/// The write half of a connection.
+///
+/// Object-safe rather than `async fn` in a trait, because the relay's writer
+/// task holds one behind a `Box<dyn …>` and must not care which transport it
+/// got.
+pub trait TransportSink: Send {
+    /// Write one message.
+    fn send(&mut self, message: WireMessage) -> BoxFuture<'_, io::Result<()>>;
+
+    /// Close the connection with an RFC 6455 status code.
+    fn close(&mut self, code: u16) -> BoxFuture<'_, io::Result<()>>;
+}
+
+/// The read half of a connection.
+pub trait TransportStream: Send {
+    /// Read the next message, or `None` at end of stream.
+    fn recv(&mut self) -> BoxFuture<'_, io::Result<Option<WireMessage>>>;
+}
+
+/// A connection, split so a writer task and a reader loop can hold one half
+/// each.
+pub struct Transport {
+    /// The write half.
+    pub sink: Box<dyn TransportSink>,
+    /// The read half.
+    pub stream: Box<dyn TransportStream>,
+}
+
+impl Transport {
+    /// Pair a sink and a stream.
+    #[must_use]
+    pub fn new(sink: Box<dyn TransportSink>, stream: Box<dyn TransportStream>) -> Self {
+        Self { sink, stream }
+    }
+
+    /// Split into the two halves.
+    #[must_use]
+    pub fn split(self) -> (Box<dyn TransportSink>, Box<dyn TransportStream>) {
+        (self.sink, self.stream)
+    }
+}
+
+impl std::fmt::Debug for Transport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Transport { .. }")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The in-process framing.
+// ---------------------------------------------------------------------------
+
+/// The in-process frame header: one opcode byte, then a big-endian `u32`
+/// length. Testkit-only; see the module note.
+const HEADER_LEN: usize = 5;
+
+/// The largest in-process message, so a corrupt length prefix cannot ask for an
+/// unbounded allocation. Well above §4.1's 1 MiB default `max_frame_bytes`, so
+/// the relay's own limit is what a test observes rather than this one.
+const MAX_IN_PROCESS_MESSAGE: usize = 16 * 1024 * 1024;
+
+/// The write half of an in-process connection.
+pub struct DuplexSink<W> {
+    writer: W,
+}
+
+impl<W: AsyncWrite + Unpin + Send> DuplexSink<W> {
+    /// Wrap a writer.
+    pub const fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    async fn write_message(&mut self, message: WireMessage) -> io::Result<()> {
+        let (opcode, payload) = match message {
+            WireMessage::Binary(bytes) => (0x2u8, bytes),
+            WireMessage::Text(bytes) => (0x1, bytes),
+            WireMessage::Ping(bytes) => (0x9, bytes),
+            WireMessage::Pong(bytes) => (0xa, bytes),
+            WireMessage::Close(code) => (0x8, code.to_be_bytes().to_vec()),
+        };
+        let len = u32::try_from(payload.len())
+            .map_err(|_| io::Error::other("message longer than the in-process framing allows"))?;
+        let mut header = [0u8; HEADER_LEN];
+        if let Some(first) = header.first_mut() {
+            *first = opcode;
+        }
+        if let Some(slot) = header.get_mut(1..HEADER_LEN) {
+            slot.copy_from_slice(&len.to_be_bytes());
+        }
+        self.writer.write_all(&header).await?;
+        self.writer.write_all(&payload).await?;
+        self.writer.flush().await
+    }
+}
+
+impl<W: AsyncWrite + Unpin + Send> TransportSink for DuplexSink<W> {
+    fn send(&mut self, message: WireMessage) -> BoxFuture<'_, io::Result<()>> {
+        Box::pin(self.write_message(message))
+    }
+
+    fn close(&mut self, code: u16) -> BoxFuture<'_, io::Result<()>> {
+        Box::pin(async move {
+            // A best-effort close frame, then a real shutdown. The frame is
+            // what carries §4.2's status 1003; the shutdown is what makes the
+            // peer's read return `None`.
+            let _ = self.write_message(WireMessage::Close(code)).await;
+            self.writer.shutdown().await
+        })
+    }
+}
+
+/// The read half of an in-process connection.
+pub struct DuplexStream<R> {
+    reader: R,
+}
+
+impl<R: AsyncRead + Unpin + Send> DuplexStream<R> {
+    /// Wrap a reader.
+    pub const fn new(reader: R) -> Self {
+        Self { reader }
+    }
+
+    async fn read_message(&mut self) -> io::Result<Option<WireMessage>> {
+        let mut header = [0u8; HEADER_LEN];
+        match self.reader.read_exact(&mut header).await {
+            Ok(_) => {}
+            Err(error) if is_eof(&error) => return Ok(None),
+            Err(error) => return Err(error),
+        }
+        let opcode = header.first().copied().unwrap_or(0);
+        let mut length = [0u8; 4];
+        match header.get(1..HEADER_LEN) {
+            Some(slice) => length.copy_from_slice(slice),
+            None => return Err(io::Error::other("short in-process header")),
+        }
+        let len = usize::try_from(u32::from_be_bytes(length))
+            .map_err(|_| io::Error::other("in-process length does not fit in usize"))?;
+        if len > MAX_IN_PROCESS_MESSAGE {
+            return Err(io::Error::other("in-process message length is implausible"));
+        }
+        let mut payload = vec![0u8; len];
+        match self.reader.read_exact(&mut payload).await {
+            Ok(_) => {}
+            Err(error) if is_eof(&error) => return Ok(None),
+            Err(error) => return Err(error),
+        }
+        Ok(Some(match opcode {
+            0x1 => WireMessage::Text(payload),
+            0x2 => WireMessage::Binary(payload),
+            0x8 => {
+                let code = payload
+                    .get(..2)
+                    .and_then(|bytes| <[u8; 2]>::try_from(bytes).ok())
+                    .map_or(1000, u16::from_be_bytes);
+                WireMessage::Close(code)
+            }
+            0x9 => WireMessage::Ping(payload),
+            0xa => WireMessage::Pong(payload),
+            other => {
+                return Err(io::Error::other(format!(
+                    "unknown in-process opcode {other:#x}"
+                )));
+            }
+        }))
+    }
+}
+
+impl<R: AsyncRead + Unpin + Send> TransportStream for DuplexStream<R> {
+    fn recv(&mut self) -> BoxFuture<'_, io::Result<Option<WireMessage>>> {
+        Box::pin(self.read_message())
+    }
+}
+
+fn is_eof(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::UnexpectedEof
+            | io::ErrorKind::BrokenPipe
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::ConnectionAborted
+    )
+}
+
+/// A bidirectional in-memory pipe: the two ends of one connection.
+///
+/// `capacity` is the pipe's buffer. It is deliberately generous so a test does
+/// not deadlock on backpressure it did not mean to test — a relay writer and a
+/// client writer that both block on a full pipe is a bug in the test, not a
+/// finding about the protocol.
+#[must_use]
+pub fn duplex(capacity: usize) -> (Transport, Transport) {
+    let (left, right) = tokio::io::duplex(capacity);
+    (wrap_duplex(left), wrap_duplex(right))
+}
+
+fn wrap_duplex(stream: tokio::io::DuplexStream) -> Transport {
+    let (reader, writer) = tokio::io::split(stream);
+    Transport::new(
+        Box::new(DuplexSink::new(writer)),
+        Box::new(DuplexStream::new(reader)),
+    )
+}
+
+/// A stream that yields nothing and never ends, for a half that is not used.
+pub struct PendingStream;
+
+impl TransportStream for PendingStream {
+    fn recv(&mut self) -> BoxFuture<'_, io::Result<Option<WireMessage>>> {
+        Box::pin(Pending)
+    }
+}
+
+struct Pending;
+
+impl std::future::Future for Pending {
+    type Output = io::Result<Option<WireMessage>>;
+
+    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn every_message_kind_round_trips_in_process() {
+        let (mut left, mut right) = duplex(64 * 1024);
+        let sent = [
+            WireMessage::Binary(vec![1, 2, 3]),
+            WireMessage::Text(b"not protocol".to_vec()),
+            WireMessage::Ping(vec![]),
+            WireMessage::Pong(vec![7]),
+        ];
+        for message in &sent {
+            left.sink.send(message.clone()).await.unwrap();
+        }
+        for message in &sent {
+            assert_eq!(right.stream.recv().await.unwrap(), Some(message.clone()));
+        }
+    }
+
+    #[tokio::test]
+    async fn a_closed_peer_reads_as_end_of_stream() {
+        let (mut left, mut right) = duplex(1024);
+        left.sink.send(WireMessage::Binary(vec![9])).await.unwrap();
+        left.sink.close(1000).await.unwrap();
+        assert_eq!(
+            right.stream.recv().await.unwrap(),
+            Some(WireMessage::Binary(vec![9]))
+        );
+        assert_eq!(
+            right.stream.recv().await.unwrap(),
+            Some(WireMessage::Close(1000))
+        );
+        assert_eq!(right.stream.recv().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn a_large_frame_survives_the_pipe_buffer() {
+        // The relay's own `max_frame_bytes` must be what refuses an oversize
+        // frame (§4.1), not the harness's pipe.
+        let (mut left, mut right) = duplex(8 * 1024);
+        let big = WireMessage::Binary(vec![0u8; 512 * 1024]);
+        let writer = tokio::spawn(async move { left.sink.send(big).await });
+        let received = right.stream.recv().await.unwrap();
+        writer.await.unwrap().unwrap();
+        assert_eq!(
+            received.and_then(|m| m.binary().map(<[u8]>::len)),
+            Some(524_288)
+        );
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/vectors.rs
+++ b/rs/crates/f2z-relay-testkit/src/vectors.rs
@@ -1,0 +1,1784 @@
+//! The conformance suite: `(input, expected output)` for every rule of
+//! `WIRE.md` this crate can reach.
+//!
+//! # Why this file is the deliverable
+//!
+//! A fake relay that nobody checks is an untested claim about the protocol,
+//! and a client built against an untested claim inherits every mistake in it.
+//! So the rules are not asserted in the engine's own unit tests, where they
+//! would only ever prove that the engine agrees with itself. They are stated
+//! here, as inputs and expected outputs, driven through the ordinary client
+//! API, over a transport — which is exactly how `f2z-relay` will be driven when
+//! it exists.
+//!
+//! [`run`] takes an [`Endpoint`]. `FakeRelay` provides two, and the real relay
+//! will be a third:
+//!
+//! ```text
+//!   run(InProcessEndpoint)  ─┐
+//!   run(WebSocketEndpoint)  ─┼─→ the same Vec<Vector>, the same verdicts
+//!   run(WebSocketEndpoint::new("wss://relay.example/relay/v1"))
+//! ```
+//!
+//! A vector that needs to *break* the relay — drop a response, expire a TTL,
+//! publish the [#586] capability document — declares [`Needs::Faults`] or
+//! [`Needs::Clock`]. Against a relay with no such handle it is reported
+//! **skipped**, never passed. A suite that silently counted an unrunnable
+//! vector as green would be worse than not having it.
+//!
+//! # What a vector may assume
+//!
+//! Only what `WIRE.md` guarantees. In particular no vector asserts a queue
+//! address, an index origin beyond what §8.2 forces, or a message ordering the
+//! relay never promised — a test that pinned one of those would fail a
+//! conforming relay, which is the failure mode that makes conformance suites
+//! get deleted.
+//!
+//! [#586]: https://github.com/free2z/zuu/issues/586
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::canonical::Canonical;
+use f2z_codec::commands::{AckRequest, ChallengePurpose, Command, PushEvent};
+use f2z_codec::types::QueueAddress;
+use f2z_relay_proto::capabilities::{self, ClientPolicy};
+use f2z_relay_proto::command::ops;
+use f2z_relay_proto::key::SigningKey;
+use futures_util::future::BoxFuture;
+
+use crate::client::{Client, solve};
+use crate::clock::Clock;
+use crate::error::{Result, TestkitError};
+use crate::fake::Endpoint;
+use crate::faults::{Effect, Fault, FaultInjector, PolicyFaults, Trigger};
+use crate::rng::Csprng;
+use crate::state::{QUEUE_EVENT_DELETED, QUEUE_EVENT_MESSAGES_EXPIRED};
+use crate::transport::Transport;
+
+/// What a vector needs from the target before it can mean anything.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Needs {
+    /// Nothing but a conforming relay. Every one of these runs against
+    /// `f2z-relay` unchanged.
+    Nothing,
+    /// A fault handle. Skipped against a relay that cannot be told to
+    /// misbehave.
+    Faults,
+    /// A steerable clock. Skipped against a relay whose clock is the world's.
+    Clock,
+}
+
+/// One `(input, expected output)` case.
+pub struct Vector {
+    /// The case's name, stable so a failure can be searched for.
+    pub name: &'static str,
+    /// The `WIRE.md` section it pins.
+    pub section: &'static str,
+    /// What the target must provide.
+    pub needs: Needs,
+    /// The case itself.
+    pub run: VectorFn,
+}
+
+/// A vector body.
+pub type VectorFn = for<'a> fn(&'a mut Context) -> BoxFuture<'a, Result<()>>;
+
+/// What a vector is handed.
+pub struct Context {
+    endpoint: Arc<dyn Endpoint>,
+    /// A connection with `HELLO` already completed.
+    pub client: Client,
+    /// The target's fault handle, when it has one.
+    pub faults: Option<FaultInjector>,
+    /// The target's clock, when it can be steered.
+    pub clock: Option<Clock>,
+    keys: Csprng,
+    nonces: Csprng,
+}
+
+impl Context {
+    /// Open a second connection, `HELLO` completed.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::connect`].
+    pub async fn open(&mut self) -> Result<Client> {
+        let transport = self.endpoint.connect().await?;
+        Client::connect(transport, self.client_config()).await
+    }
+
+    /// A client configuration whose nonce stream has never been used.
+    ///
+    /// §5.5's seen-set is relay-wide and, on a frozen clock, nothing in it ever
+    /// ages out. Two connections drawing from one nonce stream would therefore
+    /// collide on `(signer_key, nonce)` and the second would be refused as a
+    /// replay — a harness bug that would look exactly like a relay bug. Each
+    /// connection gets its own stream, and each vector's streams are derived
+    /// from its own name, so a vector is reproducible in isolation and cannot
+    /// collide with any other.
+    fn client_config(&mut self) -> crate::client::ClientConfig {
+        let mut config = self.endpoint.client_config();
+        config.nonce_seed = self.nonces.next_block();
+        config
+    }
+
+    /// Open a raw transport with **no** `HELLO`, for the vectors that test what
+    /// happens before one.
+    ///
+    /// # Errors
+    ///
+    /// As [`Endpoint::connect`].
+    pub async fn raw(&mut self) -> Result<Transport> {
+        self.endpoint.connect().await
+    }
+
+    /// A fresh queue key. Deterministic, so a failing vector replays.
+    pub fn key(&mut self) -> SigningKey {
+        SigningKey::from_seed(&self.keys.next_block())
+    }
+
+    /// The fault handle, or a skip.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] when the target has none.
+    pub fn require_faults(&self) -> Result<FaultInjector> {
+        self.faults
+            .clone()
+            .ok_or(TestkitError::Config("this target has no fault handle"))
+    }
+
+    /// The clock, or a skip.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] when the target has none.
+    pub fn require_clock(&self) -> Result<Clock> {
+        self.clock
+            .clone()
+            .ok_or(TestkitError::Config("this target has no steerable clock"))
+    }
+}
+
+/// How a vector ended.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Status {
+    /// The expected output was observed.
+    Passed,
+    /// The target could not provide what the vector needs. Never a pass.
+    Skipped(String),
+    /// The expected output was not observed.
+    Failed(String),
+}
+
+/// One vector's result.
+#[derive(Clone, Debug)]
+pub struct Outcome {
+    /// The vector's name.
+    pub name: &'static str,
+    /// The section it pins.
+    pub section: &'static str,
+    /// What happened.
+    pub status: Status,
+}
+
+/// A whole run.
+#[derive(Clone, Debug)]
+pub struct Report {
+    /// How the target was reached.
+    pub target: String,
+    /// Every vector, in suite order.
+    pub outcomes: Vec<Outcome>,
+}
+
+impl Report {
+    /// How many passed.
+    #[must_use]
+    pub fn passed(&self) -> usize {
+        self.count(|status| matches!(status, Status::Passed))
+    }
+
+    /// How many were skipped for want of a handle.
+    #[must_use]
+    pub fn skipped(&self) -> usize {
+        self.count(|status| matches!(status, Status::Skipped(_)))
+    }
+
+    /// How many failed.
+    #[must_use]
+    pub fn failed(&self) -> usize {
+        self.count(|status| matches!(status, Status::Failed(_)))
+    }
+
+    fn count(&self, predicate: impl Fn(&Status) -> bool) -> usize {
+        self.outcomes
+            .iter()
+            .filter(|outcome| predicate(&outcome.status))
+            .count()
+    }
+
+    /// The names and reasons of every failure.
+    #[must_use]
+    pub fn failures(&self) -> Vec<String> {
+        self.outcomes
+            .iter()
+            .filter_map(|outcome| match &outcome.status {
+                Status::Failed(reason) => {
+                    Some(format!("{} ({}): {reason}", outcome.name, outcome.section))
+                }
+                Status::Passed | Status::Skipped(_) => None,
+            })
+            .collect()
+    }
+
+    /// A one-line summary.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        format!(
+            "{}: {} passed, {} skipped, {} failed, of {}",
+            self.target,
+            self.passed(),
+            self.skipped(),
+            self.failed(),
+            self.outcomes.len()
+        )
+    }
+
+    /// The pass/skip/fail verdict of each vector, by name, for comparing two
+    /// runs of the same suite against two targets.
+    #[must_use]
+    pub fn verdicts(&self) -> Vec<(&'static str, Status)> {
+        self.outcomes
+            .iter()
+            .map(|outcome| (outcome.name, outcome.status.clone()))
+            .collect()
+    }
+}
+
+/// Run the whole suite against a target.
+///
+/// Each vector gets its own connection, and any fault it armed is disarmed
+/// afterwards — a vector that leaked a fault into the next one would produce a
+/// failure nobody could reproduce in isolation.
+pub async fn run(endpoint: Arc<dyn Endpoint>) -> Report {
+    run_selected(endpoint, &suite()).await
+}
+
+/// Run a chosen subset.
+pub async fn run_selected(endpoint: Arc<dyn Endpoint>, vectors: &[Vector]) -> Report {
+    let target = endpoint.describe();
+    let mut outcomes = Vec::with_capacity(vectors.len());
+
+    for vector in vectors {
+        let faults = endpoint.faults();
+        let clock = endpoint.clock();
+        let status = match (vector.needs, faults.is_some(), clock.is_some()) {
+            (Needs::Faults, false, _) => {
+                Status::Skipped("the target has no fault handle".to_owned())
+            }
+            (Needs::Clock, _, false) => {
+                Status::Skipped("the target has no steerable clock".to_owned())
+            }
+            _ => run_one(&endpoint, vector, faults.clone(), clock).await,
+        };
+
+        if let Some(faults) = faults {
+            faults.disarm();
+            faults.set_policy(PolicyFaults::default());
+        }
+        outcomes.push(Outcome {
+            name: vector.name,
+            section: vector.section,
+            status,
+        });
+    }
+
+    Report { target, outcomes }
+}
+
+fn seed_for(name: &str, purpose: &[u8]) -> [u8; 32] {
+    let mut input = Vec::with_capacity(name.len().saturating_add(purpose.len()).saturating_add(1));
+    input.extend_from_slice(purpose);
+    input.push(b'/');
+    input.extend_from_slice(name.as_bytes());
+    *f2z_codec::hash::hash(b"f2z-relay-testkit/vector-seed/v1", &input).as_bytes()
+}
+
+async fn run_one(
+    endpoint: &Arc<dyn Endpoint>,
+    vector: &Vector,
+    faults: Option<FaultInjector>,
+    clock: Option<Clock>,
+) -> Status {
+    let transport = match endpoint.connect().await {
+        Ok(transport) => transport,
+        Err(error) => return Status::Failed(format!("could not connect: {error}")),
+    };
+    // Both streams are derived from the vector's own name rather than from its
+    // position in the suite, so running one vector alone produces exactly the
+    // keys and nonces it produces in a full run.
+    let mut nonces = Csprng::from_seed(seed_for(vector.name, b"nonces"));
+    let mut config = endpoint.client_config();
+    config.nonce_seed = nonces.next_block();
+    let client = match Client::connect(transport, config).await {
+        Ok(client) => client,
+        Err(error) => return Status::Failed(format!("HELLO failed: {error}")),
+    };
+    let mut context = Context {
+        endpoint: Arc::clone(endpoint),
+        client,
+        faults,
+        clock,
+        keys: Csprng::from_seed(seed_for(vector.name, b"keys")),
+        nonces,
+    };
+    match (vector.run)(&mut context).await {
+        Ok(()) => Status::Passed,
+        Err(error) => Status::Failed(error.to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Assertions.
+// ---------------------------------------------------------------------------
+
+/// Assert that a call was refused with exactly this §10 code.
+///
+/// # Errors
+///
+/// [`TestkitError::Expectation`] when it was not.
+pub fn expect_code<T>(result: Result<T>, expected: ErrorCode) -> Result<()> {
+    match result {
+        Ok(_) => Err(TestkitError::Expectation(format!(
+            "expected {} and the relay accepted the command",
+            expected.name()
+        ))),
+        Err(error) => match error.wire_code() {
+            Some(code) if code == expected => Ok(()),
+            Some(code) => Err(TestkitError::Expectation(format!(
+                "expected {}, got {}",
+                expected.name(),
+                code.name()
+            ))),
+            None => Err(TestkitError::Expectation(format!(
+                "expected {}, got {error}",
+                expected.name()
+            ))),
+        },
+    }
+}
+
+/// Assert a boolean, with a reason.
+///
+/// # Errors
+///
+/// [`TestkitError::Expectation`] when it does not hold.
+pub fn expect(condition: bool, reason: &str) -> Result<()> {
+    if condition {
+        Ok(())
+    } else {
+        Err(TestkitError::Expectation(reason.to_owned()))
+    }
+}
+
+/// Assert equality of two values that can be shown.
+///
+/// # Errors
+///
+/// [`TestkitError::Expectation`] when they differ.
+pub fn expect_eq<T: PartialEq + std::fmt::Debug>(left: T, right: T, reason: &str) -> Result<()> {
+    if left == right {
+        Ok(())
+    } else {
+        Err(TestkitError::Expectation(format!(
+            "{reason}: {left:?} != {right:?}"
+        )))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The suite.
+// ---------------------------------------------------------------------------
+
+macro_rules! suite {
+    ($( $needs:ident, $section:literal, $name:ident );* $(;)?) => {
+        /// Every vector, in the order `WIRE.md` states the rules.
+        #[must_use]
+        pub fn suite() -> Vec<Vector> {
+            vec![$(
+                Vector {
+                    name: stringify!($name),
+                    section: $section,
+                    needs: Needs::$needs,
+                    run: |context| Box::pin($name(context)),
+                }
+            ),*]
+        }
+    };
+}
+
+suite! {
+    // §2 — transport and lifecycle
+    Nothing, "§2.5", hello_must_be_the_first_frame;
+    Nothing, "§2.5", a_second_hello_is_refused;
+    Nothing, "§3.5", an_unofferable_version_is_refused;
+    Nothing, "§5.2", relay_id_is_the_digest_of_the_proven_key;
+
+    // §3, §4 — serialization and framing
+    Nothing, "§3.3", trailing_bytes_in_a_frame_are_fatally_malformed;
+    Nothing, "§3.3", a_non_canonical_body_is_fatally_malformed;
+    Nothing, "§4.1", an_oversize_frame_is_fatally_malformed;
+    Nothing, "§4.2", a_text_frame_closes_the_connection;
+    Nothing, "§3.5", an_unknown_command_is_not_fatal;
+    Faults,  "§4.3", a_duplicate_inflight_request_id_is_fatal;
+    Faults,  "§4.3", exceeding_the_inflight_window_is_fatal;
+
+    // §5 — the signing transcript
+    Nothing, "§5.1", a_tampered_signature_is_refused;
+    Nothing, "§5.1", the_transcript_binds_the_request_id;
+    Nothing, "§5.5", a_stale_timestamp_is_refused;
+    Nothing, "§5.5", a_replayed_frame_is_refused;
+    Nothing, "§5.1", a_key_that_does_not_authorize_the_address_is_refused;
+
+    // §6, §7 — queue lifecycle
+    Nothing, "§7.1", create_queue_returns_two_distinct_addresses;
+    Nothing, "§7.7", requested_ttls_are_clamped_and_reported;
+    Nothing, "§7.3", bind_send_is_once_only;
+    Nothing, "§6.3", append_requires_the_bound_key;
+    Nothing, "§6.3", append_before_bind_is_unavailable;
+    Nothing, "§6.3", an_append_response_carries_no_queue_state;
+    Nothing, "§10",  an_absent_recv_address_is_no_access;
+    Nothing, "§6.3", an_absent_send_address_is_unavailable;
+    Nothing, "§7.6", a_deleted_queue_looks_like_one_that_never_existed;
+    Nothing, "§6.2", read_never_mutates;
+    Nothing, "§6.2", reading_below_the_watermark_starts_at_the_watermark;
+
+    // §8 — acknowledgement
+    Nothing, "§8.1", ack_is_cumulative_monotone_and_idempotent;
+    Nothing, "§8.2", acking_beyond_the_highest_index_is_refused;
+    Nothing, "§8.1", acking_deletes_the_ciphertext;
+
+    // §6.4 — pushes
+    Nothing, "§6.4", a_subscriber_is_pushed_the_message;
+    Nothing, "§6.4", unsubscribing_stops_the_pushes;
+    Nothing, "§6.4", deleting_a_queue_pushes_queue_event_one;
+
+    // §9 — padding
+    Nothing, "§9",   a_payload_outside_the_buckets_is_bad_size;
+
+    // §11 — the capability document
+    Nothing, "§11.1", the_capability_document_verifies_and_is_valid;
+    Nothing, "§6.1",  the_hello_digest_matches_the_document;
+    Faults,  "§5.5",  an_unsound_antireplay_window_is_published_and_refused;
+
+    // §12 — first contact
+    Nothing, "§12.2", bind_send_on_a_contact_address_is_not_permitted;
+    Nothing, "§12.3", contact_append_requires_a_stamp;
+    Nothing, "§12.3", a_contact_stamp_is_single_use;
+    Nothing, "§12.3", a_contact_stamp_is_scoped_to_its_target;
+    Nothing, "§12.5", first_contact_reaches_the_recipient;
+
+    // §13 — anti-abuse
+    Faults,  "§13.1", a_full_queue_is_indistinguishable_from_an_absent_one;
+    Faults,  "§13.1", backpressure_never_refuses_read_ack_or_delete;
+    Faults,  "§13.1", the_queue_creation_quota_is_a_distinguishable_code;
+    Faults,  "§10",   every_error_code_can_reach_a_client;
+
+    // §7.7 — TTLs
+    Faults,  "§7.7",  an_expired_message_is_gone_and_announced;
+    Clock,   "§7.7",  an_idle_queue_disappears;
+
+    // Failure paths — the ones delete-on-ack makes expensive to get wrong
+    Faults,  "§8.3",  a_lost_ack_response_is_safe_to_retry;
+    Faults,  "§4.3",  a_delayed_response_still_correlates;
+    Faults,  "§4.3",  reordered_responses_still_correlate;
+    Faults,  "§2.5",  a_mid_stream_close_leaves_the_status_unknown;
+}
+
+// ---------------------------------------------------------------------------
+// §2, §3, §4.
+// ---------------------------------------------------------------------------
+
+async fn hello_must_be_the_first_frame(context: &mut Context) -> Result<()> {
+    // A fresh transport with no HELLO. §2.5: "A relay that receives any other
+    // frame first responds ERR_UNSUPPORTED_VERSION and closes."
+    let transport = context.raw().await?;
+    let (mut sink, mut stream) = transport.split();
+    let frame = f2z_relay_proto::command::unsigned_request::<ops::Ping>(1, &Default::default())?;
+    sink.send(crate::transport::WireMessage::Binary(
+        frame.encode_canonical()?,
+    ))
+    .await?;
+    let code = read_response_code(&mut stream).await?;
+    expect_eq(
+        code,
+        Some(ErrorCode::UnsupportedVersion),
+        "a frame before HELLO must be ERR_UNSUPPORTED_VERSION",
+    )
+}
+
+async fn a_second_hello_is_refused(context: &mut Context) -> Result<()> {
+    let result = context
+        .client
+        .call_unsigned::<ops::Hello>(&f2z_codec::commands::HelloRequest {
+            min_version: f2z_codec::PROTOCOL_VERSION,
+            max_version: f2z_codec::PROTOCOL_VERSION,
+            client_nonce: f2z_codec::types::Challenge::new([9u8; 32]),
+        })
+        .await;
+    // §3.5: negotiation happens once and applies to the whole connection.
+    expect_code(result, ErrorCode::UnsupportedVersion)
+}
+
+async fn an_unofferable_version_is_refused(context: &mut Context) -> Result<()> {
+    let transport = context.raw().await?;
+    let (mut sink, mut stream) = transport.split();
+    let offer = f2z_codec::commands::HelloRequest {
+        // A range this build cannot be inside.
+        min_version: 2,
+        max_version: 3,
+        client_nonce: f2z_codec::types::Challenge::new([1u8; 32]),
+    };
+    let frame = f2z_relay_proto::command::unsigned_request::<ops::Hello>(1, &offer)?;
+    sink.send(crate::transport::WireMessage::Binary(
+        frame.encode_canonical()?,
+    ))
+    .await?;
+    let code = read_response_code(&mut stream).await?;
+    expect_eq(
+        code,
+        Some(ErrorCode::UnsupportedVersion),
+        "no common version must be ERR_UNSUPPORTED_VERSION",
+    )
+}
+
+async fn relay_id_is_the_digest_of_the_proven_key(context: &mut Context) -> Result<()> {
+    // The client already refused to open a session unless this held; asserting
+    // it here makes the property a vector rather than an implementation detail
+    // of the harness.
+    let session = context.client.session();
+    expect_eq(
+        session.relay_id(),
+        f2z_codec::hash::relay_id(&session.relay_identity_pk()),
+        "relay_id must be H(\"free2z/relay/v1/relay-id\", relay_identity_pk)",
+    )
+}
+
+async fn trailing_bytes_in_a_frame_are_fatally_malformed(context: &mut Context) -> Result<()> {
+    let mut client = context.open().await?;
+    let key = context.key();
+    let mut bytes = client.encode_signed::<ops::Ack>(
+        &key,
+        QueueAddress::new([1u8; 32]),
+        &AckRequest { up_to_index: 0 },
+    )?;
+    bytes.push(0);
+    client.send_raw(bytes).await?;
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::Malformed),
+        "a trailing byte must fail re-encode equality",
+    )?;
+    // §1.3: fatal means send the response, then close.
+    client.expect_closed().await
+}
+
+async fn a_non_canonical_body_is_fatally_malformed(context: &mut Context) -> Result<()> {
+    let mut client = context.open().await?;
+    let key = context.key();
+    // A frame that is canonical at the framing layer and carries one trailing
+    // byte inside its opaque body. §3.3 has to be applied twice, and a relay
+    // that applies it once accepts this.
+    let timestamp = client.relay_time_ms();
+    let nonce = client.nonce();
+    let signed = f2z_relay_proto::command::SignedCommand::<ops::Ack>::create(
+        client.session().transcripts(),
+        4_242,
+        QueueAddress::new([2u8; 32]),
+        timestamp,
+        nonce,
+        &key,
+        &AckRequest { up_to_index: 0 },
+    )?;
+    let mut body = signed.body().to_vec();
+    body.push(0);
+    let request = f2z_codec::frame::Request::new(
+        Command::Ack.code(),
+        f2z_codec::frame::CommandAuth::Signed(signed.auth().clone()),
+        body,
+    )?;
+    let frame = f2z_codec::frame::RelayFrame::request(4_242, request);
+    client.send_raw(frame.encode_canonical()?).await?;
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::Malformed),
+        "a non-canonical body inside a canonical frame must still be refused",
+    )
+}
+
+async fn an_oversize_frame_is_fatally_malformed(context: &mut Context) -> Result<()> {
+    let mut client = context.open().await?;
+    let capabilities = client.capabilities().await?.capabilities;
+    let size = usize::try_from(capabilities.max_frame_bytes)
+        .unwrap_or(usize::MAX)
+        .saturating_add(1);
+    let mut probe = context.open().await?;
+    probe.send_raw(vec![0u8; size]).await?;
+    // §4.1: `ERR_MALFORMED`, and the relay MUST NOT buffer the remainder to
+    // produce a tidy error. The bytes are not a decodable frame, so the id is
+    // unrecoverable and the connection simply closes.
+    probe.expect_closed().await
+}
+
+async fn a_text_frame_closes_the_connection(context: &mut Context) -> Result<()> {
+    let mut client = context.open().await?;
+    client.send_text("this is not protocol").await?;
+    // §4.2: fatal ERR_FRAME_TYPE, WebSocket status 1003. A text frame carries
+    // no `request_id`, so what a client observes is the close.
+    client.expect_closed().await
+}
+
+async fn an_unknown_command_is_not_fatal(context: &mut Context) -> Result<()> {
+    let request = f2z_codec::frame::Request::new(
+        0xbeef,
+        f2z_codec::frame::CommandAuth::Unsigned,
+        Vec::new(),
+    )?;
+    let frame = f2z_codec::frame::RelayFrame::request(7, request);
+    context.client.send_raw(frame.encode_canonical()?).await?;
+    let (_, response) = context.client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::UnknownCommand),
+        "an unknown command code must be ERR_UNKNOWN_COMMAND",
+    )?;
+    // Non-fatal: the connection still works.
+    context.client.ping().await
+}
+
+async fn a_duplicate_inflight_request_id_is_fatal(context: &mut Context) -> Result<()> {
+    // §4.3's duplicate rule is about ids that are *currently* in flight, and a
+    // relay releases an id the moment it answers. So the rule is only
+    // observable while a response is being held — which is why this vector
+    // needs a fault handle and is reported as skipped against a relay that has
+    // none, rather than being made into a race that passes by luck.
+    let faults = context.require_faults()?;
+    let mut client = context.open().await?;
+    faults.arm(Fault::once(Trigger::Command(Command::Ping), Effect::Stall));
+
+    let ping = f2z_relay_proto::command::unsigned_request::<ops::Ping>(9_000, &Default::default())?;
+    let bytes = ping.encode_canonical()?;
+    client.send_raw(bytes.clone()).await?;
+    client.send_raw(bytes).await?;
+
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::Malformed),
+        "a duplicate in-flight request_id must be ERR_MALFORMED",
+    )?;
+    // §1.3: fatal means send the response, then close.
+    client.expect_closed().await
+}
+
+async fn exceeding_the_inflight_window_is_fatal(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let mut client = context.open().await?;
+    let capabilities = client.capabilities().await?.capabilities;
+    let window = usize::from(capabilities.max_inflight);
+
+    // Stall every PING so nothing is ever released.
+    faults.arm(Fault::always(
+        Trigger::Command(Command::Ping),
+        Effect::Stall,
+    ));
+    for _ in 0..window {
+        client
+            .send_unsigned::<ops::Ping>(&Default::default())
+            .await?;
+    }
+    client
+        .send_unsigned::<ops::Ping>(&Default::default())
+        .await?;
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::TooManyInflight),
+        "the in-flight window must be enforced with ERR_TOO_MANY_INFLIGHT",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// §5.
+// ---------------------------------------------------------------------------
+
+async fn a_tampered_signature_is_refused(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 0, None).await?;
+    let mut client = context.open().await?;
+    let timestamp = client.relay_time_ms();
+    let nonce = client.nonce();
+    let signed = f2z_relay_proto::command::SignedCommand::<ops::Ack>::create(
+        client.session().transcripts(),
+        11,
+        created.recv_addr,
+        timestamp,
+        nonce,
+        &key,
+        &AckRequest { up_to_index: 0 },
+    )?;
+    let mut auth = signed.auth().clone();
+    let mut signature = *auth.signature.as_bytes();
+    signature[0] ^= 0xff;
+    auth.signature = f2z_codec::types::Signature::new(signature);
+    let request = f2z_codec::frame::Request::new(
+        Command::Ack.code(),
+        f2z_codec::frame::CommandAuth::Signed(auth),
+        signed.body().to_vec(),
+    )?;
+    client
+        .send_raw(f2z_codec::frame::RelayFrame::request(11, request).encode_canonical()?)
+        .await?;
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::BadSignature),
+        "a tampered signature must be ERR_BAD_SIGNATURE",
+    )
+}
+
+async fn the_transcript_binds_the_request_id(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 0, None).await?;
+    let mut client = context.open().await?;
+    // Sign for one `request_id`, then present the frame under another. §5.1
+    // puts `request_id` in the transcript, so this cannot verify — and it is a
+    // *fresh* nonce, so the refusal is the signature check and not the replay
+    // check.
+    let mut bytes = client.encode_signed::<ops::Ack>(
+        &key,
+        created.recv_addr,
+        &AckRequest { up_to_index: 0 },
+    )?;
+    let original = bytes
+        .get(1..5)
+        .and_then(|slice| <[u8; 4]>::try_from(slice).ok())
+        .map_or(0, u32::from_be_bytes);
+    let replacement = original.wrapping_add(1).max(1).to_be_bytes();
+    if let Some(slot) = bytes.get_mut(1..5) {
+        slot.copy_from_slice(&replacement);
+    }
+    client.send_raw(bytes).await?;
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::BadSignature),
+        "the transcript covers request_id, so moving it must break the signature",
+    )
+}
+
+async fn a_stale_timestamp_is_refused(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 0, None).await?;
+    let capabilities = context.client.capabilities().await?.capabilities;
+    let mut client = context.open().await?;
+    let now = client.relay_time_ms();
+    // Outside ±clock_skew_ms in the past. §5.5 gives the same code for the
+    // future half, deliberately: splitting them would tell a caller which way
+    // its clock is wrong, which fingerprints the caller.
+    client.set_timestamp(Some(now.saturating_sub(
+        u64::from(capabilities.clock_skew_ms).saturating_add(60_000),
+    )));
+    let result = client.ack(&key, created.recv_addr, 0).await;
+    expect_code(result, ErrorCode::StaleTimestamp)
+}
+
+async fn a_replayed_frame_is_refused(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 0, None).await?;
+    let mut client = context.open().await?;
+    // A queue with nothing appended: ACK 0 is ERR_ACK_TOO_HIGH, which proves
+    // the frame was *verified* the first time. The second presentation must
+    // stop earlier, at the seen-set.
+    let bytes = client.encode_signed::<ops::Ack>(
+        &key,
+        created.recv_addr,
+        &AckRequest { up_to_index: 0 },
+    )?;
+    client.send_raw(bytes.clone()).await?;
+    let (_, first) = client.next_response().await?;
+    expect_eq(
+        first.error_code(),
+        Some(ErrorCode::AckTooHigh),
+        "the first presentation must be verified and then refused on its merits",
+    )?;
+    client.send_raw(bytes).await?;
+    let (_, second) = client.next_response().await?;
+    expect_eq(
+        second.error_code(),
+        Some(ErrorCode::Replay),
+        "the same (signer_key, nonce) twice must be ERR_REPLAY",
+    )
+}
+
+async fn a_key_that_does_not_authorize_the_address_is_refused(context: &mut Context) -> Result<()> {
+    let owner = context.key();
+    let stranger = context.key();
+    let created = context.client.create_queue(&owner, 0, 0, None).await?;
+    let mut client = context.open().await?;
+    let result = client.read(&stranger, created.recv_addr, 0, 0, 0).await;
+    // §10's existence-oracle rule: the same code an address that never existed
+    // gets.
+    expect_code(result, ErrorCode::NoAccess)
+}
+
+// ---------------------------------------------------------------------------
+// §6, §7.
+// ---------------------------------------------------------------------------
+
+async fn create_queue_returns_two_distinct_addresses(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 0, None).await?;
+    expect(!created.recv_addr.is_zero(), "recv_addr must not be zero")?;
+    expect(!created.send_addr.is_zero(), "send_addr must not be zero")?;
+    expect(
+        created.recv_addr != created.send_addr,
+        "the two addresses must differ; they are two capabilities",
+    )
+}
+
+async fn requested_ttls_are_clamped_and_reported(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    // A century. §7.7 caps the message TTL at 30 days and a relay MUST NOT
+    // grant more, whatever its own configured maximum says.
+    let created = context
+        .client
+        .create_queue(&key, u32::MAX, u32::MAX, None)
+        .await?;
+    expect(
+        created.message_ttl_seconds <= f2z_codec::MAX_MESSAGE_TTL_SECONDS,
+        "message_ttl_seconds must be clamped to the 30-day ceiling",
+    )?;
+    expect(
+        created.idle_ttl_seconds <= f2z_relay_proto::queue::MAX_IDLE_TTL_SECONDS,
+        "idle_ttl_seconds must be clamped to the published ceiling",
+    )
+}
+
+async fn bind_send_is_once_only(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let other_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    // §7.3: with any key, including the same key.
+    let again = sender.bind_send(&send_key, created.send_addr).await;
+    expect_code(again, ErrorCode::AlreadyBound)?;
+    let stolen = sender.bind_send(&other_key, created.send_addr).await;
+    expect_code(stolen, ErrorCode::AlreadyBound)
+}
+
+async fn append_requires_the_bound_key(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let impostor = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    let result = sender
+        .append(&impostor, created.send_addr, b"not yours")
+        .await;
+    // §6.3: never a distinguishable code.
+    expect_code(result, ErrorCode::Unavailable)
+}
+
+async fn append_before_bind_is_unavailable(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    let result = sender.append(&send_key, created.send_addr, b"early").await;
+    expect_code(result, ErrorCode::Unavailable)
+}
+
+async fn an_append_response_carries_no_queue_state(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    let request_id = sender
+        .send_signed::<ops::Append>(
+            &send_key,
+            created.send_addr,
+            &f2z_codec::commands::AppendRequest {
+                payload: sender.pad(b"one")?,
+            },
+        )
+        .await?;
+    let (id, response) = sender.next_response().await?;
+    expect_eq(id, request_id, "the response must answer the request")?;
+    expect(response.is_ok(), "the append must be accepted")?;
+    // The requirement, literally: no index, no depth, no timestamp, no queue
+    // state of any kind. Each of those would convert the send capability into a
+    // weak read capability.
+    expect_eq(
+        response.body().len(),
+        0,
+        "an APPEND response body must be empty",
+    )
+}
+
+async fn an_absent_recv_address_is_no_access(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let result = context
+        .client
+        .read(&key, QueueAddress::new([0x5a; 32]), 0, 0, 0)
+        .await;
+    expect_code(result, ErrorCode::NoAccess)
+}
+
+async fn an_absent_send_address_is_unavailable(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let result = context
+        .client
+        .append(&key, QueueAddress::new([0x5b; 32]), b"nowhere")
+        .await;
+    expect_code(result, ErrorCode::Unavailable)
+}
+
+async fn a_deleted_queue_looks_like_one_that_never_existed(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    context
+        .client
+        .delete_queue(&recv_key, created.recv_addr)
+        .await?;
+
+    // §7.6: no tombstone distinguishable from outside. The recv side gets the
+    // same code an address that never existed gets…
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await;
+    expect_code(read, ErrorCode::NoAccess)?;
+    // …and the sender learns nothing except that its next APPEND fails.
+    let append = sender.append(&send_key, created.send_addr, b"gone").await;
+    expect_code(append, ErrorCode::Unavailable)
+}
+
+async fn read_never_mutates(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender.append(&send_key, created.send_addr, b"once").await?;
+
+    let first = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    let second = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(
+        first.messages.len(),
+        second.messages.len(),
+        "READ must not consume",
+    )?;
+    expect_eq(
+        first.messages.len(),
+        1,
+        "the appended message must be there",
+    )
+}
+
+async fn reading_below_the_watermark_starts_at_the_watermark(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    for _ in 0..3 {
+        sender.append(&send_key, created.send_addr, b"m").await?;
+    }
+    let all = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(all.messages.len(), 3, "three appends, three messages")?;
+    let first_index = all.messages.as_slice().first().map_or(0, |m| m.index);
+    context
+        .client
+        .ack(&recv_key, created.recv_addr, first_index)
+        .await?;
+
+    // §6.2: below the watermark returns from the watermark, does not error, and
+    // does not resurrect. A client recovering from a crash simply asks for
+    // everything it might have missed.
+    let again = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(
+        again.messages.len(),
+        2,
+        "the acked message must not come back",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// §8.
+// ---------------------------------------------------------------------------
+
+async fn ack_is_cumulative_monotone_and_idempotent(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    for _ in 0..3 {
+        sender.append(&send_key, created.send_addr, b"m").await?;
+    }
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    let last = read.messages.as_slice().last().map_or(0, |m| m.index);
+
+    let first = context
+        .client
+        .ack(&recv_key, created.recv_addr, last)
+        .await?;
+    expect_eq(
+        first.pending,
+        0,
+        "a cumulative ACK clears everything below it",
+    )?;
+    // Idempotent: the retry after a lost response is safe, which is what makes
+    // the connection-loss case tractable at all (§8.3).
+    let repeat = context
+        .client
+        .ack(&recv_key, created.recv_addr, last)
+        .await?;
+    expect_eq(repeat.pending, 0, "a repeated ACK is a no-op")?;
+    // Monotone: below the watermark is accepted and does nothing.
+    let below = context.client.ack(&recv_key, created.recv_addr, 0).await?;
+    expect_eq(
+        below.pending,
+        0,
+        "an ACK below the watermark must not move it",
+    )?;
+    expect_eq(
+        below.next_index,
+        first.next_index,
+        "next_index must not move backwards",
+    )
+}
+
+async fn acking_beyond_the_highest_index_is_refused(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender.append(&send_key, created.send_addr, b"m").await?;
+
+    // §8.2 exists to stop a reader pre-acking: with the watermark set high,
+    // every future APPEND would be deleted the instant it landed while the
+    // sender kept receiving successful, empty responses.
+    let result = context
+        .client
+        .ack(&recv_key, created.recv_addr, u64::MAX)
+        .await;
+    expect_code(result, ErrorCode::AckTooHigh)?;
+    // …and the watermark did not move.
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(read.messages.len(), 1, "a refused ACK must not delete")
+}
+
+async fn acking_deletes_the_ciphertext(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender.append(&send_key, created.send_addr, b"m").await?;
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    let index = read.messages.as_slice().first().map_or(0, |m| m.index);
+    context
+        .client
+        .ack(&recv_key, created.recv_addr, index)
+        .await?;
+    let after = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(
+        after.messages.len(),
+        0,
+        "ACK is queue-delivered: the relay deletes at that instant",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// §6.4.
+// ---------------------------------------------------------------------------
+
+async fn a_subscriber_is_pushed_the_message(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let subscribed = context
+        .client
+        .subscribe(&recv_key, created.recv_addr)
+        .await?;
+    expect_eq(subscribed.pending, 0, "a fresh queue holds nothing")?;
+
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender
+        .append(&send_key, created.send_addr, b"push me")
+        .await?;
+
+    let push = context.client.next_message().await?;
+    expect_eq(
+        push.recv_addr,
+        created.recv_addr,
+        "a MSG push names the subscribed receive address",
+    )
+}
+
+async fn unsubscribing_stops_the_pushes(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    context
+        .client
+        .subscribe(&recv_key, created.recv_addr)
+        .await?;
+    context
+        .client
+        .unsubscribe(&recv_key, created.recv_addr)
+        .await?;
+
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender
+        .append(&send_key, created.send_addr, b"silent")
+        .await?;
+
+    // A PING round-trips after the append, so the absence of a push is an
+    // observation rather than a race, and the wait is short because what is
+    // being proved is a negative.
+    context.client.ping().await?;
+    context.client.set_read_timeout(Duration::from_millis(250));
+    match context.client.next_push().await {
+        Err(TestkitError::Timeout) => Ok(()),
+        Ok(_) => Err(TestkitError::Expectation(
+            "a push arrived after UNSUBSCRIBE".to_owned(),
+        )),
+        Err(error) => Err(error),
+    }
+}
+
+async fn deleting_a_queue_pushes_queue_event_one(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    context
+        .client
+        .subscribe(&recv_key, created.recv_addr)
+        .await?;
+    context
+        .client
+        .delete_queue(&recv_key, created.recv_addr)
+        .await?;
+    let event = context.client.next_queue_event().await?;
+    expect_eq(event.reason, QUEUE_EVENT_DELETED, "reason 1 is 'deleted'")
+}
+
+// ---------------------------------------------------------------------------
+// §9.
+// ---------------------------------------------------------------------------
+
+async fn a_payload_outside_the_buckets_is_bad_size(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    let bucket = sender.padding().sizes().first().copied().unwrap_or(1024);
+    let odd = usize::try_from(bucket).unwrap_or(1024).saturating_sub(1);
+    let result = sender
+        .append_raw_size(&send_key, created.send_addr, odd)
+        .await;
+    expect_code(result, ErrorCode::BadSize)
+}
+
+// ---------------------------------------------------------------------------
+// §11.
+// ---------------------------------------------------------------------------
+
+async fn the_capability_document_verifies_and_is_valid(context: &mut Context) -> Result<()> {
+    let signed = context.client.capabilities().await?;
+    let proven = context.client.session().relay_identity_pk();
+    // §11.3 step 1: verify against the key proved in HELLO, not against the
+    // key the document names — a document is self-signed, so verifying it
+    // against its own embedded key proves only that one hand wrote both.
+    capabilities::verify(&signed, &proven)?;
+    capabilities::validate(&signed.capabilities)?;
+    // §11.3's checklist, under a policy that has opted into the insecure
+    // transport a ws:// relay publishes.
+    let policy = ClientPolicy {
+        allow_insecure_transport: true,
+        ..ClientPolicy::default()
+    };
+    policy.accept(&signed.capabilities)?;
+    Ok(())
+}
+
+async fn the_hello_digest_matches_the_document(context: &mut Context) -> Result<()> {
+    let signed = context.client.capabilities().await?;
+    let expected = context.client.session().capabilities_digest();
+    capabilities::check_digest(&signed.capabilities, &expected)?;
+    Ok(())
+}
+
+async fn an_unsound_antireplay_window_is_published_and_refused(
+    context: &mut Context,
+) -> Result<()> {
+    let faults = context.require_faults()?;
+    faults.set_policy(PolicyFaults {
+        unsound_antireplay_window: true,
+        ..PolicyFaults::default()
+    });
+
+    let mut client = context.open().await?;
+    let signed = client.capabilities().await?;
+    let published = &signed.capabilities;
+    expect(
+        u64::from(published.antireplay_window_ms)
+            < u64::from(published.clock_skew_ms).saturating_mul(2),
+        "the fault must actually publish a window below 2 x clock_skew_ms",
+    )?;
+    // The finding of #586, in two halves. First: the document is *valid*. The
+    // specification as written permits it, which is exactly why the defect is
+    // a defect and not an implementation bug.
+    capabilities::validate(published)?;
+    // Second: a client that checks the relation refuses it, and the check is
+    // on by default in `f2z-relay-proto`.
+    let policy = ClientPolicy {
+        allow_insecure_transport: true,
+        ..ClientPolicy::default()
+    };
+    match policy.accept(published) {
+        Err(f2z_relay_proto::ProtoError::Refused(
+            f2z_relay_proto::Refusal::AntiReplayWindowTooShort,
+        )) => Ok(()),
+        Err(other) => Err(TestkitError::Expectation(format!(
+            "expected AntiReplayWindowTooShort, got {other}"
+        ))),
+        Ok(()) => Err(TestkitError::Expectation(
+            "a client must refuse a relay whose seen-set ages out inside the timestamp window"
+                .to_owned(),
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// §12.
+// ---------------------------------------------------------------------------
+
+async fn bind_send_on_a_contact_address_is_not_permitted(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let binder = context.key();
+    let created = context
+        .client
+        .create_contact_queue(&recv_key, 0, 0, None)
+        .await?;
+    let mut client = context.open().await?;
+    let result = client.bind_send(&binder, created.contact_addr).await;
+    // §12.2 point 1: always, for everyone. There is no key that authorizes
+    // writing to it, which means there is no key that can be stolen.
+    expect_code(result, ErrorCode::NotPermitted)
+}
+
+async fn contact_append_requires_a_stamp(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let created = context
+        .client
+        .create_contact_queue(&recv_key, 0, 0, None)
+        .await?;
+    let mut stranger = context.open().await?;
+    let body = f2z_codec::commands::ContactAppendRequest {
+        contact_addr: created.contact_addr,
+        payload: stranger.pad(b"hello bob")?,
+        stamp: f2z_codec::pow::PowStamp::empty(),
+    };
+    let result = stranger
+        .call_unsigned::<ops::ContactAppend>(&body)
+        .await
+        .map(|_| ());
+    expect_code(result, ErrorCode::PowRequired)
+}
+
+async fn a_contact_stamp_is_single_use(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let created = context
+        .client
+        .create_contact_queue(&recv_key, 0, 0, None)
+        .await?;
+    let mut stranger = context.open().await?;
+    let capabilities = stranger.capabilities().await?.capabilities;
+    let params = capabilities.contact_append_pow;
+    let issued = stranger
+        .challenge(
+            ChallengePurpose::ContactAppend,
+            created.contact_addr.as_bytes(),
+        )
+        .await?;
+    let mut rng = Csprng::from_seed([0x33; 32]);
+    let stamp = solve(issued.challenge, &mut rng, params.difficulty_bits);
+    let body = f2z_codec::commands::ContactAppendRequest {
+        contact_addr: created.contact_addr,
+        payload: stranger.pad(b"hello bob")?,
+        stamp,
+    };
+    stranger.call_unsigned::<ops::ContactAppend>(&body).await?;
+    // §12.3: the challenge is consumed on use, so stamps cannot be replayed.
+    let again = stranger
+        .call_unsigned::<ops::ContactAppend>(&body)
+        .await
+        .map(|_| ());
+    expect_code(again, ErrorCode::PowInvalid)
+}
+
+async fn a_contact_stamp_is_scoped_to_its_target(context: &mut Context) -> Result<()> {
+    let first_key = context.key();
+    let second_key = context.key();
+    let victim = context
+        .client
+        .create_contact_queue(&first_key, 0, 0, None)
+        .await?;
+    let other = context
+        .client
+        .create_contact_queue(&second_key, 0, 0, None)
+        .await?;
+
+    let mut stranger = context.open().await?;
+    let capabilities = stranger.capabilities().await?.capabilities;
+    let params = capabilities.contact_append_pow;
+    let issued = stranger
+        .challenge(
+            ChallengePurpose::ContactAppend,
+            victim.contact_addr.as_bytes(),
+        )
+        .await?;
+    let mut rng = Csprng::from_seed([0x44; 32]);
+    let stamp = solve(issued.challenge, &mut rng, params.difficulty_bits);
+    // Computed for one victim, spent on another. §12.3 binds the challenge to
+    // the target address precisely so this cannot work.
+    let body = f2z_codec::commands::ContactAppendRequest {
+        contact_addr: other.contact_addr,
+        payload: stranger.pad(b"misdirected")?,
+        stamp,
+    };
+    let result = stranger
+        .call_unsigned::<ops::ContactAppend>(&body)
+        .await
+        .map(|_| ());
+    expect_code(result, ErrorCode::PowInvalid)
+}
+
+async fn first_contact_reaches_the_recipient(context: &mut Context) -> Result<()> {
+    // §12.5, steps 1 to 8, minus the directory: Alice writes to Bob's published
+    // contact address with a stamp, Bob reads it from the ordinary receive side
+    // of the same queue and acknowledges.
+    let bob = context.key();
+    let created = context
+        .client
+        .create_contact_queue(&bob, 0, 0, None)
+        .await?;
+    let capabilities = context.client.capabilities().await?.capabilities;
+
+    let mut alice = context.open().await?;
+    alice
+        .contact_append(
+            created.contact_addr,
+            b"welcome",
+            Some(capabilities.contact_append_pow),
+        )
+        .await?;
+
+    let read = context
+        .client
+        .read(&bob, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(read.messages.len(), 1, "the contact message must arrive")?;
+    let index = read.messages.as_slice().first().map_or(0, |m| m.index);
+    // The §8.4 MUST is Bob's: durable write *first*, then ACK. Here the "write"
+    // is the assertion above.
+    let acked = context.client.ack(&bob, created.recv_addr, index).await?;
+    expect_eq(acked.pending, 0, "the contact queue drains like any other")
+}
+
+// ---------------------------------------------------------------------------
+// §13.
+// ---------------------------------------------------------------------------
+
+async fn a_full_queue_is_indistinguishable_from_an_absent_one(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+
+    faults.set_policy(PolicyFaults {
+        max_queue_messages: Some(1),
+        ..PolicyFaults::default()
+    });
+    sender
+        .append(&send_key, created.send_addr, b"first")
+        .await?;
+    let full = sender.append(&send_key, created.send_addr, b"second").await;
+    expect_code(full, ErrorCode::Unavailable)?;
+
+    // The same code an absent address gets. If they differed, a bound sender
+    // could learn the queue's depth by filling it.
+    let absent = sender
+        .append(&send_key, QueueAddress::new([0x77; 32]), b"nowhere")
+        .await;
+    expect_code(absent, ErrorCode::Unavailable)
+}
+
+async fn backpressure_never_refuses_read_ack_or_delete(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender
+        .append(&send_key, created.send_addr, b"stored")
+        .await?;
+
+    faults.set_policy(PolicyFaults {
+        global_backpressure: true,
+        ..PolicyFaults::default()
+    });
+
+    // §13.1 layer 4, in order: creation refuses with ERR_BACKPRESSURE…
+    let creation = context.client.create_queue(&recv_key, 0, 0, None).await;
+    expect_code(creation, ErrorCode::Backpressure)?;
+    // …appends refuse with ERR_UNAVAILABLE…
+    let append = sender.append(&send_key, created.send_addr, b"more").await;
+    expect_code(append, ErrorCode::Unavailable)?;
+    // …and READ, ACK and DELETE_QUEUE are never refused, because they are the
+    // operations that make the relay smaller and refusing them is a deadlock.
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    let index = read.messages.as_slice().first().map_or(0, |m| m.index);
+    context
+        .client
+        .ack(&recv_key, created.recv_addr, index)
+        .await?;
+    context
+        .client
+        .delete_queue(&recv_key, created.recv_addr)
+        .await
+}
+
+async fn the_queue_creation_quota_is_a_distinguishable_code(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let key = context.key();
+    faults.set_policy(PolicyFaults {
+        max_queues: Some(0),
+        ..PolicyFaults::default()
+    });
+    let result = context.client.create_queue(&key, 0, 0, None).await;
+    // §10 code 14. The receive side is allowed a code that says what happened:
+    // the party being refused is the one that owns the queues, so there is no
+    // state to leak to a stranger.
+    expect_code(result, ErrorCode::Quota)
+}
+
+async fn every_error_code_can_reach_a_client(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    // §10's codes are stable forever and a client has to handle all of them,
+    // including the ones a healthy relay never emits. A client that panics on
+    // an unexpected code finds out here rather than in production.
+    for code in ErrorCode::ALL {
+        if code.is_fatal() {
+            // A fatal code closes the connection, so each one needs its own.
+            let mut client = context.open().await?;
+            faults.arm(Fault::once(
+                Trigger::Command(Command::Ping),
+                Effect::Refuse(code),
+            ));
+            let result = client.ping().await;
+            expect_code(result, code)?;
+            client.expect_closed().await?;
+        } else {
+            faults.arm(Fault::once(
+                Trigger::Command(Command::Ping),
+                Effect::Refuse(code),
+            ));
+            let result = context.client.ping().await;
+            expect_code(result, code)?;
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// §7.7.
+// ---------------------------------------------------------------------------
+
+async fn an_expired_message_is_gone_and_announced(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    context
+        .client
+        .subscribe(&recv_key, created.recv_addr)
+        .await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender
+        .append(&send_key, created.send_addr, b"perishable")
+        .await?;
+    let _ = context.client.next_message().await?;
+
+    faults.set_policy(PolicyFaults {
+        expire_messages_after: Some(Duration::ZERO),
+        ..PolicyFaults::default()
+    });
+    // Any command re-runs the sweep.
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(read.messages.len(), 0, "an expired message must be gone")?;
+    let event = context.client.next_queue_event().await?;
+    expect_eq(
+        event.reason,
+        QUEUE_EVENT_MESSAGES_EXPIRED,
+        "reason 3 is 'messages TTL-expired'",
+    )?;
+    // §8.2 still holds afterwards: expiry does not move the watermark, so the
+    // reader still cannot pre-ack.
+    let ack = context
+        .client
+        .ack(&recv_key, created.recv_addr, u64::MAX)
+        .await;
+    expect_code(ack, ErrorCode::AckTooHigh)
+}
+
+async fn an_idle_queue_disappears(context: &mut Context) -> Result<()> {
+    let clock = context.require_clock()?;
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 60, None).await?;
+    // Past the granted idle TTL. §7.7 is explicit about the cost: a user whose
+    // device is offline longer than this loses their queues, and their peers'
+    // adverts become dead addresses.
+    clock.advance(
+        u64::from(created.idle_ttl_seconds)
+            .saturating_mul(1_000)
+            .saturating_add(1_000),
+    );
+    context.client.resync_clock().await?;
+    let result = context.client.read(&key, created.recv_addr, 0, 0, 0).await;
+    expect_code(result, ErrorCode::NoAccess)
+}
+
+// ---------------------------------------------------------------------------
+// The failure paths.
+// ---------------------------------------------------------------------------
+
+async fn a_lost_ack_response_is_safe_to_retry(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender.append(&send_key, created.send_addr, b"m").await?;
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    let index = read.messages.as_slice().first().map_or(0, |m| m.index);
+
+    // Drop exactly one ACK response. The command *ran*; the answer never
+    // arrived. §2.5: the status is unknown. §8.3: the retry is safe, and a
+    // client must not try to find out by reading — the messages may
+    // legitimately be gone.
+    faults.arm(Fault::once(Trigger::Command(Command::Ack), Effect::Drop));
+    context.client.set_read_timeout(Duration::from_millis(250));
+    let lost = context
+        .client
+        .ack(&recv_key, created.recv_addr, index)
+        .await;
+    expect(
+        matches!(lost, Err(TestkitError::Timeout | TestkitError::Closed)),
+        "a dropped response must present as an unknown outcome, not as a refusal",
+    )?;
+
+    let mut retry = context.open().await?;
+    let outcome = retry.ack(&recv_key, created.recv_addr, index).await?;
+    expect_eq(
+        outcome.pending,
+        0,
+        "the retry must be a no-op that reports the same state",
+    )
+}
+
+async fn a_delayed_response_still_correlates(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let mut client = context.open().await?;
+    faults.arm(Fault::once(
+        Trigger::Command(Command::GetCapabilities),
+        Effect::Delay(Duration::from_millis(120)),
+    ));
+    let slow = client
+        .send_unsigned::<ops::GetCapabilities>(&Default::default())
+        .await?;
+    let quick = client
+        .send_unsigned::<ops::Ping>(&Default::default())
+        .await?;
+
+    // §4.3: "A relay MAY complete a cheap PING before an expensive READ issued
+    // earlier, and will." A client that assumed order would mis-decode here.
+    let (first_id, _) = client.next_response().await?;
+    let (second_id, _) = client.next_response().await?;
+    expect_eq(first_id, quick, "the cheap command answered first")?;
+    expect_eq(second_id, slow, "the delayed command answered second")
+}
+
+async fn reordered_responses_still_correlate(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let mut client = context.open().await?;
+    faults.arm(Fault::once(
+        Trigger::Command(Command::GetCapabilities),
+        Effect::Reorder,
+    ));
+    let held = client
+        .send_unsigned::<ops::GetCapabilities>(&Default::default())
+        .await?;
+    let overtaking = client
+        .send_unsigned::<ops::Ping>(&Default::default())
+        .await?;
+
+    let (first_id, first) = client.next_response().await?;
+    let (second_id, second) = client.next_response().await?;
+    expect_eq(first_id, overtaking, "the second request answered first")?;
+    expect_eq(second_id, held, "the held response arrived after it")?;
+    expect(
+        first.is_ok() && second.is_ok(),
+        "both answers are successes",
+    )
+}
+
+async fn a_mid_stream_close_leaves_the_status_unknown(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+
+    // Close before the APPEND's answer is written. The append *happened*; the
+    // sender cannot know that. §8.3: APPEND is not idempotent at the relay, so
+    // a retry produces a duplicate — which is why deduplication lives
+    // end-to-end at `msg_id` and not here.
+    faults.arm(Fault::once(
+        Trigger::Command(Command::Append),
+        Effect::CloseBefore,
+    ));
+    sender.set_read_timeout(Duration::from_millis(250));
+    let outcome = sender
+        .append(&send_key, created.send_addr, b"unknown")
+        .await;
+    expect(
+        matches!(outcome, Err(TestkitError::Closed | TestkitError::Timeout)),
+        "a mid-stream close must present as an unknown outcome",
+    )?;
+
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(
+        read.messages.len(),
+        1,
+        "the command applied even though its answer was never delivered",
+    )?;
+
+    let mut retry = context.open().await?;
+    retry
+        .append(&send_key, created.send_addr, b"unknown")
+        .await?;
+    let after = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(
+        after.messages.len(),
+        2,
+        "retrying an APPEND duplicates, by design",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Shared plumbing.
+// ---------------------------------------------------------------------------
+
+async fn read_response_code(
+    stream: &mut Box<dyn crate::transport::TransportStream>,
+) -> Result<Option<ErrorCode>> {
+    loop {
+        let message = match tokio::time::timeout(Duration::from_secs(5), stream.recv()).await {
+            Ok(Ok(Some(message))) => message,
+            Ok(Ok(None)) => return Err(TestkitError::Closed),
+            Ok(Err(error)) => return Err(TestkitError::from(error)),
+            Err(_) => return Err(TestkitError::Timeout),
+        };
+        match message {
+            crate::transport::WireMessage::Binary(bytes) => {
+                let frame =
+                    f2z_codec::canonical::decode_canonical::<f2z_codec::frame::RelayFrame>(&bytes)?
+                        .into_value();
+                if let f2z_codec::frame::FramePayload::Response(response) = frame.payload {
+                    return Ok(response.error_code());
+                }
+            }
+            crate::transport::WireMessage::Close(_) => return Err(TestkitError::Closed),
+            _ => {}
+        }
+    }
+}
+
+/// Every push event this suite knows how to name, so a reader can see the set
+/// without opening `f2z-codec`.
+pub const OBSERVED_PUSH_EVENTS: [PushEvent; 3] =
+    [PushEvent::Msg, PushEvent::QueueEvent, PushEvent::Notice];

--- a/rs/crates/f2z-relay-testkit/src/websocket.rs
+++ b/rs/crates/f2z-relay-testkit/src/websocket.rs
@@ -1,0 +1,405 @@
+//! The real transport — `WIRE.md` §2.1 — minus the TLS.
+//!
+//! # Why a real socket exists at all
+//!
+//! An in-process transport cannot fragment, cannot reorder at a TCP boundary,
+//! cannot half-close, and cannot tell a client that it forgot to set the binary
+//! opcode. Every one of those is a bug a client can ship. So the same relay is
+//! served over a real `ws://127.0.0.1:0` listener and the conformance suite is
+//! run against both, which is the only way to know the fast path is not lying.
+//!
+//! # `ws://`, not `wss://`, and that is published
+//!
+//! §2.1 admits `wss://` only. A test double that terminated TLS would need a
+//! certificate, a trust decision, and a story about what the client should do
+//! with a self-signed one — and it would still not be able to compute the §5.3
+//! exporter through the abstraction this crate uses. So it serves `ws://` and
+//! takes §2.3's `--insecure-listen` path honestly: `transport_security: none`,
+//! `channel_binding_mode: none`, both in the signed capability document, and a
+//! client that must explicitly opt in.
+//!
+//! §2.3's binding rule is enforced rather than described: [`bind`] refuses a
+//! non-loopback address unless the caller passes `insecure_listen`, and
+//! `f2z-fakerelay` makes the operator type the flag.
+//!
+//! # What *is* faithful here
+//!
+//! The path (`/relay/v1`), the mandatory subprotocol (`free2z-relay.v1`) in
+//! both directions, binary versus text framing, Ping/Pong, and close codes. A
+//! client that gets any of those wrong fails against this listener, which is
+//! the point.
+
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt as _, StreamExt as _};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tokio_tungstenite::tungstenite::handshake::server::{
+    ErrorResponse, Request as HandshakeRequest, Response as HandshakeResponse,
+};
+use tokio_tungstenite::tungstenite::http::{HeaderValue, StatusCode};
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::{Bytes, Message};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+use crate::engine::Relay;
+use crate::error::{Result, TestkitError};
+use crate::transport::{Transport, TransportSink, TransportStream, WireMessage};
+
+/// §2.1's path.
+pub const RELAY_PATH: &str = "/relay/v1";
+
+/// §2.1's mandatory subprotocol, in both directions. "A relay that does not
+/// echo `free2z-relay.v1` MUST be treated by the client as not speaking this
+/// protocol, and the client MUST close rather than guess."
+pub const SUBPROTOCOL: &str = "free2z-relay.v1";
+
+const HEADER_SUBPROTOCOL: &str = "sec-websocket-protocol";
+
+// ---------------------------------------------------------------------------
+// The WebSocket half of the transport seam.
+// ---------------------------------------------------------------------------
+
+/// A WebSocket write half.
+pub struct WsSink<S> {
+    inner: SplitSink<WebSocketStream<S>, Message>,
+}
+
+impl<S> WsSink<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    async fn write(&mut self, message: WireMessage) -> io::Result<()> {
+        let message = match message {
+            WireMessage::Binary(bytes) => Message::Binary(Bytes::from(bytes)),
+            WireMessage::Text(bytes) => Message::Text(
+                String::from_utf8(bytes)
+                    .map_err(|_| io::Error::other("text frame is not UTF-8"))?
+                    .into(),
+            ),
+            WireMessage::Ping(bytes) => Message::Ping(Bytes::from(bytes)),
+            WireMessage::Pong(bytes) => Message::Pong(Bytes::from(bytes)),
+            WireMessage::Close(code) => Message::Close(Some(CloseFrame {
+                code: CloseCode::from(code),
+                reason: String::new().into(),
+            })),
+        };
+        self.inner.send(message).await.map_err(io::Error::other)
+    }
+}
+
+impl<S> TransportSink for WsSink<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    fn send(
+        &mut self,
+        message: WireMessage,
+    ) -> futures_util::future::BoxFuture<'_, io::Result<()>> {
+        Box::pin(self.write(message))
+    }
+
+    fn close(&mut self, code: u16) -> futures_util::future::BoxFuture<'_, io::Result<()>> {
+        Box::pin(async move {
+            let _ = self.write(WireMessage::Close(code)).await;
+            self.inner.close().await.map_err(io::Error::other)
+        })
+    }
+}
+
+/// A WebSocket read half.
+pub struct WsStream<S> {
+    inner: SplitStream<WebSocketStream<S>>,
+}
+
+impl<S> WsStream<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    async fn read(&mut self) -> io::Result<Option<WireMessage>> {
+        loop {
+            let Some(next) = self.inner.next().await else {
+                return Ok(None);
+            };
+            let message = next.map_err(io::Error::other)?;
+            return Ok(Some(match message {
+                Message::Binary(bytes) => WireMessage::Binary(bytes.to_vec()),
+                Message::Text(text) => WireMessage::Text(text.as_bytes().to_vec()),
+                Message::Ping(bytes) => WireMessage::Ping(bytes.to_vec()),
+                Message::Pong(bytes) => WireMessage::Pong(bytes.to_vec()),
+                Message::Close(frame) => {
+                    WireMessage::Close(frame.map_or(1000, |frame| frame.code.into()))
+                }
+                // A raw frame never surfaces from a `WebSocketStream` in read
+                // mode; skip rather than invent a protocol event for it.
+                Message::Frame(_) => continue,
+            }));
+        }
+    }
+}
+
+impl<S> TransportStream for WsStream<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    fn recv(&mut self) -> futures_util::future::BoxFuture<'_, io::Result<Option<WireMessage>>> {
+        Box::pin(self.read())
+    }
+}
+
+/// Wrap a negotiated WebSocket as a [`Transport`].
+pub fn wrap<S>(socket: WebSocketStream<S>) -> Transport
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let (sink, stream) = socket.split();
+    Transport::new(
+        Box::new(WsSink { inner: sink }),
+        Box::new(WsStream { inner: stream }),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The listener.
+// ---------------------------------------------------------------------------
+
+/// A running `ws://` listener.
+pub struct RelayServer {
+    addr: SocketAddr,
+    shutdown: watch::Sender<bool>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl std::fmt::Debug for RelayServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RelayServer")
+            .field("addr", &self.addr)
+            .finish()
+    }
+}
+
+impl RelayServer {
+    /// The bound address. With port 0 this is the port the OS chose.
+    #[must_use]
+    pub const fn local_addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// The endpoint URL, path included.
+    #[must_use]
+    pub fn url(&self) -> String {
+        format!("ws://{}{RELAY_PATH}", self.addr)
+    }
+
+    /// Stop accepting and wait for the accept loop to finish.
+    ///
+    /// Connections already open are not torn down: a client that is mid-request
+    /// when a test ends should see the request finish, not a truncated stream
+    /// that looks like a fault it did not arm.
+    pub async fn shutdown(self) {
+        let _ = self.shutdown.send(true);
+        let _ = self.handle.await;
+    }
+}
+
+/// Bind a listener, refusing a non-loopback address without an explicit
+/// override (§2.3).
+///
+/// # Errors
+///
+/// [`TestkitError::Config`] for a non-loopback address without
+/// `insecure_listen`, or [`TestkitError::Transport`] if the bind fails.
+pub async fn bind(addr: SocketAddr, insecure_listen: bool) -> Result<TcpListener> {
+    // §2.3: "A relay MUST refuse to bind a non-loopback address without TLS.
+    // This is a startup check, not a warning: the process exits." This process
+    // has no TLS at all, so the check is unconditional on the address.
+    if !is_loopback(addr.ip()) && !insecure_listen {
+        return Err(TestkitError::Config(
+            "refusing to bind a non-loopback address without TLS (WIRE.md §2.3); \
+             pass --insecure-listen if you really mean it",
+        ));
+    }
+    TcpListener::bind(addr).await.map_err(TestkitError::from)
+}
+
+fn is_loopback(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_loopback(),
+        IpAddr::V6(v6) => v6.is_loopback(),
+    }
+}
+
+/// Serve `relay` on `listener` until the returned handle is shut down.
+///
+/// # Errors
+///
+/// [`TestkitError::Transport`] if the listener cannot report its own address.
+pub fn serve(relay: Arc<Relay>, listener: TcpListener) -> Result<RelayServer> {
+    let addr = listener.local_addr()?;
+    let (shutdown, mut shutdown_rx) = watch::channel(false);
+    let handle = tokio::spawn(async move {
+        loop {
+            let accepted = tokio::select! {
+                _ = shutdown_rx.changed() => break,
+                accepted = listener.accept() => accepted,
+            };
+            let Ok((stream, _peer)) = accepted else {
+                break;
+            };
+            let relay = Arc::clone(&relay);
+            tokio::spawn(async move {
+                if let Some(transport) = handshake(stream).await {
+                    crate::connection::drive(relay, transport).await;
+                }
+            });
+        }
+    });
+    Ok(RelayServer {
+        addr,
+        shutdown,
+        handle,
+    })
+}
+
+async fn handshake(stream: TcpStream) -> Option<Transport> {
+    let socket = tokio_tungstenite::accept_hdr_async(stream, check_upgrade)
+        .await
+        .ok()?;
+    Some(wrap(socket))
+}
+
+/// §2.1's two mandatory properties of the upgrade, enforced.
+///
+/// The `Err` variant is `tungstenite`'s own `http::Response`, whose size is not
+/// ours to change, and this is a handshake callback rather than a hot path: one
+/// oversized `Result` per TCP accept costs nothing measurable. Boxing it would
+/// mean converting at the one call site `tungstenite` allows, for no benefit.
+#[allow(
+    clippy::result_large_err,
+    reason = "the error type is tungstenite's Callback contract, once per accept"
+)]
+fn check_upgrade(
+    request: &HandshakeRequest,
+    mut response: HandshakeResponse,
+) -> std::result::Result<HandshakeResponse, ErrorResponse> {
+    if request.uri().path() != RELAY_PATH {
+        return Err(reject("the relay serves only /relay/v1 (WIRE.md §2.1)"));
+    }
+    let offered = request
+        .headers()
+        .get(HEADER_SUBPROTOCOL)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    if !offered
+        .split(',')
+        .map(str::trim)
+        .any(|value| value == SUBPROTOCOL)
+    {
+        return Err(reject(
+            "the subprotocol header is mandatory in both directions (WIRE.md §2.1)",
+        ));
+    }
+    // Echo it. A relay that does not is one the client must refuse.
+    response
+        .headers_mut()
+        .insert(HEADER_SUBPROTOCOL, HeaderValue::from_static(SUBPROTOCOL));
+    Ok(response)
+}
+
+fn reject(reason: &'static str) -> ErrorResponse {
+    let mut response = ErrorResponse::new(Some(reason.to_owned()));
+    *response.status_mut() = StatusCode::BAD_REQUEST;
+    response
+}
+
+// ---------------------------------------------------------------------------
+// The client side.
+// ---------------------------------------------------------------------------
+
+/// Open a client connection to a `ws://` or `wss://` relay endpoint.
+///
+/// Enforces §2.1's client obligation: the relay MUST echo `free2z-relay.v1`,
+/// and a client that does not check has no way to tell this protocol from
+/// something else answering on the same path.
+///
+/// # Errors
+///
+/// [`TestkitError::Transport`] if the URL is unusable, the handshake fails, or
+/// the relay did not echo the subprotocol.
+pub async fn connect(url: &str) -> Result<Transport> {
+    let request = tokio_tungstenite::tungstenite::http::Request::builder()
+        .method("GET")
+        .uri(url)
+        .header("Host", host_of(url)?)
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Key", generate_key())
+        .header(HEADER_SUBPROTOCOL, SUBPROTOCOL)
+        .body(())
+        .map_err(|error| TestkitError::Transport(error.to_string()))?;
+
+    let (socket, response) = tokio_tungstenite::connect_async(request)
+        .await
+        .map_err(|error| TestkitError::Transport(error.to_string()))?;
+
+    let echoed = response
+        .headers()
+        .get(HEADER_SUBPROTOCOL)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    if echoed != SUBPROTOCOL {
+        return Err(TestkitError::Transport(format!(
+            "the relay did not echo {SUBPROTOCOL}; it is not speaking this protocol (WIRE.md §2.1)"
+        )));
+    }
+
+    Ok(wrap::<MaybeTlsStream<TcpStream>>(socket))
+}
+
+fn generate_key() -> String {
+    tokio_tungstenite::tungstenite::handshake::client::generate_key()
+}
+
+fn host_of(url: &str) -> Result<String> {
+    let rest = url
+        .strip_prefix("ws://")
+        .or_else(|| url.strip_prefix("wss://"))
+        .ok_or(TestkitError::Config("a relay URL must be ws:// or wss://"))?;
+    let authority = rest.split('/').next().unwrap_or(rest);
+    if authority.is_empty() {
+        return Err(TestkitError::Config("a relay URL must name a host"));
+    }
+    Ok(authority.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_host_header_comes_from_the_url() {
+        assert_eq!(
+            host_of("ws://127.0.0.1:9000/relay/v1").unwrap(),
+            "127.0.0.1:9000"
+        );
+        assert_eq!(
+            host_of("wss://relay.example/relay/v1").unwrap(),
+            "relay.example"
+        );
+        assert!(host_of("http://relay.example/relay/v1").is_err());
+    }
+
+    #[tokio::test]
+    async fn a_non_loopback_bind_is_refused_without_the_override() {
+        let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        assert!(bind(addr, false).await.is_err());
+        // And with the override it is allowed, because §2.3 says an operator
+        // may take that path deliberately and publish that they did.
+        assert!(bind(addr, true).await.is_ok());
+    }
+}

--- a/rs/crates/f2z-relay-testkit/tests/conformance.rs
+++ b/rs/crates/f2z-relay-testkit/tests/conformance.rs
@@ -1,0 +1,140 @@
+//! The conformance suite, run twice, and the two runs compared.
+//!
+//! Running it in-process proves the rules. Running it over a real
+//! `ws://127.0.0.1:0` listener proves that the in-process path is not lying:
+//! the framing, the ordering, the close codes and the keepalive all exist on
+//! only one of the two, and a divergence would mean the fast transport is a
+//! second implementation wearing the first one's tests.
+//!
+//! The third assertion is the one that will matter later. `f2z-relay` will be a
+//! `WebSocketEndpoint` with a URL and no fault handle, and this same file will
+//! run against it unchanged — the fault-driven vectors reporting *skipped*
+//! rather than passing, which is the honest verdict for a relay nobody can tell
+//! to misbehave.
+
+// An integration test is its own crate, so the workspace's `panic`/`unwrap`/
+// `expect` denials — written for a relay's unauthenticated request path — apply
+// here too. A test that cannot assert is not a test, so they are lifted for
+// this file and nowhere else.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+use std::sync::Arc;
+
+use f2z_relay_testkit::config::RelayConfig;
+use f2z_relay_testkit::fake::{Endpoint, FakeRelay, WebSocketEndpoint};
+use f2z_relay_testkit::vectors::{self, Needs, Status};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_suite_passes_in_process() {
+    let relay = FakeRelay::with_defaults().expect("a default relay is configurable");
+    let endpoint: Arc<dyn Endpoint> = Arc::new(relay.in_process_endpoint());
+    let report = vectors::run(endpoint).await;
+
+    println!("{}", report.summary());
+    assert_eq!(report.failed(), 0, "{:#?}", report.failures());
+    assert_eq!(
+        report.skipped(),
+        0,
+        "the in-process endpoint has both a fault handle and a clock, \
+         so nothing should be skipped"
+    );
+    assert!(report.passed() >= 40, "the suite should be substantial");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_suite_passes_over_a_real_socket() {
+    // A wall-clock relay would make the clock vectors untestable, so the socket
+    // relay is frozen like the in-process one. The socket is what differs; the
+    // relay must not.
+    let relay = FakeRelay::new(RelayConfig::default()).expect("a default relay is configurable");
+    let server = relay
+        .listen_loopback()
+        .await
+        .expect("binding 127.0.0.1:0 succeeds");
+    let endpoint: Arc<dyn Endpoint> = Arc::new(relay.websocket_endpoint(&server));
+
+    let report = vectors::run(endpoint).await;
+    println!("{}", report.summary());
+    assert_eq!(report.failed(), 0, "{:#?}", report.failures());
+    assert_eq!(report.skipped(), 0);
+
+    server.shutdown().await;
+}
+
+/// The check that makes "both transports run the same implementation" a fact.
+#[tokio::test(flavor = "multi_thread")]
+async fn both_transports_reach_the_same_verdicts() {
+    let in_process_relay = FakeRelay::with_defaults().expect("configurable");
+    let in_process: Arc<dyn Endpoint> = Arc::new(in_process_relay.in_process_endpoint());
+    let in_process_report = vectors::run(in_process).await;
+
+    let socket_relay = FakeRelay::with_defaults().expect("configurable");
+    let server = socket_relay.listen_loopback().await.expect("binds");
+    let socket: Arc<dyn Endpoint> = Arc::new(socket_relay.websocket_endpoint(&server));
+    let socket_report = vectors::run(socket).await;
+
+    assert_eq!(
+        in_process_report.verdicts(),
+        socket_report.verdicts(),
+        "the in-process transport and the WebSocket transport disagreed; \
+         one of them is not running the relay the other is"
+    );
+    server.shutdown().await;
+}
+
+/// A target with no fault handle — the shape `f2z-relay` will arrive in.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_target_without_a_fault_handle_skips_rather_than_passes() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let server = relay.listen_loopback().await.expect("binds");
+
+    // Constructed the way a third-party relay would be: a URL, and nothing
+    // else. Same suite, same file, no fault handle, no clock.
+    let endpoint: Arc<dyn Endpoint> =
+        Arc::new(WebSocketEndpoint::new(server.url()).with_client_config(relay.client_config()));
+    let report = vectors::run(endpoint).await;
+    println!("{}", report.summary());
+
+    let expected_skips = vectors::suite()
+        .iter()
+        .filter(|vector| !matches!(vector.needs, Needs::Nothing))
+        .count();
+    assert_eq!(
+        report.skipped(),
+        expected_skips,
+        "every fault- or clock-driven vector must report Skipped, never Passed"
+    );
+    assert_eq!(report.failed(), 0, "{:#?}", report.failures());
+    assert!(
+        report
+            .outcomes
+            .iter()
+            .any(|outcome| matches!(outcome.status, Status::Skipped(_))),
+        "at least one vector must be skipped for this test to mean anything"
+    );
+
+    server.shutdown().await;
+}
+
+/// The suite is stable in composition, so a vector cannot silently disappear.
+#[test]
+fn every_vector_declares_a_section_and_a_unique_name() {
+    let suite = vectors::suite();
+    let mut names: Vec<&str> = suite.iter().map(|vector| vector.name).collect();
+    names.sort_unstable();
+    let before = names.len();
+    names.dedup();
+    assert_eq!(before, names.len(), "vector names must be unique");
+    for vector in &suite {
+        assert!(
+            vector.section.starts_with('§'),
+            "{} does not name the WIRE.md section it pins",
+            vector.name
+        );
+    }
+}

--- a/rs/crates/f2z-relay-testkit/tests/faults.rs
+++ b/rs/crates/f2z-relay-testkit/tests/faults.rs
@@ -1,0 +1,378 @@
+//! Every fault mode, fired on demand, in one place.
+//!
+//! The conformance suite exercises these as *rules*; this file exercises them
+//! as *controls*, so a client developer can see what each one does before
+//! reaching for it. Under delete-on-ack the failure paths are where data loss
+//! lives, and a client that has never seen a dropped `ACK` response has never
+//! been tested on the case that costs a user their messages.
+
+// An integration test is its own crate, so the workspace's `panic`/`unwrap`/
+// `expect` denials — written for a relay's unauthenticated request path — apply
+// here too. A test that cannot assert is not a test, so they are lifted for
+// this file and nowhere else.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+use std::time::Duration;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::commands::Command;
+use f2z_relay_proto::capabilities::ClientPolicy;
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_testkit::client::Client;
+use f2z_relay_testkit::error::TestkitError;
+use f2z_relay_testkit::fake::FakeRelay;
+use f2z_relay_testkit::faults::{Effect, Fault, PolicyFaults, Trigger};
+
+async fn queue(
+    relay: &FakeRelay,
+    seed: u8,
+) -> (
+    Client,
+    SigningKey,
+    Client,
+    SigningKey,
+    f2z_codec::commands::CreateQueueResponse,
+) {
+    let mut recv = relay.client().await.expect("connects");
+    let recv_key = SigningKey::from_seed(&[seed; 32]);
+    let created = recv
+        .create_queue(&recv_key, 0, 0, None)
+        .await
+        .expect("CREATE_QUEUE");
+    let mut send = relay.client().await.expect("connects");
+    let send_key = SigningKey::from_seed(&[seed.wrapping_add(1); 32]);
+    send.bind_send(&send_key, created.send_addr)
+        .await
+        .expect("BIND_SEND");
+    (recv, recv_key, send, send_key, created)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_a_response() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let (mut recv, recv_key, mut send, send_key, created) = queue(&relay, 0x10).await;
+    send.append(&send_key, created.send_addr, b"m")
+        .await
+        .expect("APPEND");
+
+    relay
+        .faults()
+        .arm(Fault::once(Trigger::Command(Command::Ack), Effect::Drop));
+    recv.set_read_timeout(Duration::from_millis(200));
+    let lost = recv.ack(&recv_key, created.recv_addr, 0).await;
+    assert!(
+        matches!(lost, Err(TestkitError::Timeout)),
+        "a dropped response is an unknown outcome (§2.5), not a refusal"
+    );
+
+    // The command ran. §8.3: the retry is a safe no-op, which is what makes the
+    // connection-loss case tractable at all.
+    let mut again = relay.client().await.expect("connects");
+    let outcome = again
+        .ack(&recv_key, created.recv_addr, 0)
+        .await
+        .expect("the retry is safe");
+    assert_eq!(outcome.pending, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delay_a_response_without_blocking_the_ones_behind_it() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let mut client = relay.client().await.expect("connects");
+    relay.faults().arm(Fault::once(
+        Trigger::Command(Command::GetCapabilities),
+        Effect::Delay(Duration::from_millis(150)),
+    ));
+    let slow = client
+        .send_unsigned::<f2z_relay_proto::command::ops::GetCapabilities>(&Default::default())
+        .await
+        .expect("send");
+    let quick = client
+        .send_unsigned::<f2z_relay_proto::command::ops::Ping>(&Default::default())
+        .await
+        .expect("send");
+
+    let (first, _) = client.next_response().await.expect("a response");
+    let (second, _) = client.next_response().await.expect("a response");
+    assert_eq!(first, quick, "§4.3: a cheap command may overtake, and will");
+    assert_eq!(second, slow);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reorder_two_responses() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let mut client = relay.client().await.expect("connects");
+    relay.faults().arm(Fault::once(
+        Trigger::Command(Command::GetCapabilities),
+        Effect::Reorder,
+    ));
+    let held = client
+        .send_unsigned::<f2z_relay_proto::command::ops::GetCapabilities>(&Default::default())
+        .await
+        .expect("send");
+    let overtaking = client
+        .send_unsigned::<f2z_relay_proto::command::ops::Ping>(&Default::default())
+        .await
+        .expect("send");
+    let (first, _) = client.next_response().await.expect("a response");
+    let (second, _) = client.next_response().await.expect("a response");
+    assert_eq!(first, overtaking);
+    assert_eq!(second, held);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn close_the_connection_mid_stream() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let (recv, recv_key, mut send, send_key, created) = queue(&relay, 0x20).await;
+    drop(recv);
+
+    relay.faults().arm(Fault::once(
+        Trigger::Command(Command::Append),
+        Effect::CloseBefore,
+    ));
+    send.set_read_timeout(Duration::from_millis(250));
+    let outcome = send.append(&send_key, created.send_addr, b"m").await;
+    assert!(matches!(
+        outcome,
+        Err(TestkitError::Closed | TestkitError::Timeout)
+    ));
+
+    // The append applied even though its answer was never delivered. §8.3:
+    // APPEND is not idempotent at the relay, which is why deduplication lives
+    // end-to-end at `msg_id`.
+    let mut reader = relay.client().await.expect("connects");
+    let read = reader
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ");
+    assert_eq!(read.messages.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stall_an_ack_forever() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let (mut recv, recv_key, mut send, send_key, created) = queue(&relay, 0x30).await;
+    send.append(&send_key, created.send_addr, b"m")
+        .await
+        .expect("APPEND");
+
+    relay
+        .faults()
+        .arm(Fault::always(Trigger::Command(Command::Ack), Effect::Stall));
+    recv.set_read_timeout(Duration::from_millis(200));
+    let stalled = recv.ack(&recv_key, created.recv_addr, 0).await;
+    assert!(matches!(stalled, Err(TestkitError::Timeout)));
+
+    // A stalled response keeps its `request_id` outstanding, so a client that
+    // never gives up fills §4.3's window and earns a fatal
+    // ERR_TOO_MANY_INFLIGHT rather than hanging forever.
+    let capabilities = relay.published_capabilities();
+    for _ in 0..capabilities.max_inflight {
+        let _ = recv.ack(&recv_key, created.recv_addr, 0).await;
+    }
+    let overflow = recv.ack(&recv_key, created.recv_addr, 0).await;
+    assert!(
+        overflow.is_err(),
+        "the in-flight window must eventually refuse"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn refuse_an_append_with_every_error_code() {
+    // §10's codes are stable forever and a client has to handle all of them,
+    // including the ones a healthy relay never emits on this command.
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    for code in ErrorCode::ALL {
+        let (_recv, _recv_key, mut send, send_key, created) = queue(&relay, 0x40).await;
+        relay.faults().arm(Fault::once(
+            Trigger::Command(Command::Append),
+            Effect::Refuse(code),
+        ));
+        let refused = send.append(&send_key, created.send_addr, b"m").await;
+        assert_eq!(
+            refused.as_ref().err().and_then(TestkitError::wire_code),
+            Some(code),
+            "the injector must be able to produce {}",
+            code.name()
+        );
+        if code.is_fatal() {
+            send.expect_closed().await.expect("§1.3: then close");
+        }
+        relay.faults().disarm();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_refused_append_did_not_append() {
+    // The refusal is applied before the command runs, which is the only reading
+    // that makes `Effect::Refuse` usable: a fake that refused *after* mutating
+    // would teach a client that ERR_UNAVAILABLE means "not stored" when it did
+    // not.
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let (mut recv, recv_key, mut send, send_key, created) = queue(&relay, 0x50).await;
+    relay.faults().arm(Fault::once(
+        Trigger::Command(Command::Append),
+        Effect::Refuse(ErrorCode::Unavailable),
+    ));
+    let _ = send.append(&send_key, created.send_addr, b"m").await;
+    let read = recv
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ");
+    assert_eq!(read.messages.len(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expire_a_ttl_early() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let (mut recv, recv_key, mut send, send_key, created) = queue(&relay, 0x60).await;
+    recv.subscribe(&recv_key, created.recv_addr)
+        .await
+        .expect("SUBSCRIBE");
+    send.append(&send_key, created.send_addr, b"perishable")
+        .await
+        .expect("APPEND");
+    let _ = recv.next_message().await.expect("MSG push");
+
+    relay.faults().set_policy(PolicyFaults {
+        expire_messages_after: Some(Duration::ZERO),
+        ..PolicyFaults::default()
+    });
+    let read = recv
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ");
+    assert_eq!(read.messages.len(), 0, "§7.7: the message TTL fired");
+    let event = recv.next_queue_event().await.expect("QUEUE_EVENT push");
+    assert_eq!(event.reason, 3, "reason 3 is 'messages TTL-expired'");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expire_a_queue_by_moving_the_clock() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let mut client = relay.client().await.expect("connects");
+    let key = SigningKey::from_seed(&[0x70; 32]);
+    let created = client
+        .create_queue(&key, 0, 3_600, None)
+        .await
+        .expect("CREATE_QUEUE");
+
+    // §7.7's honest cost: a device offline longer than the idle TTL loses its
+    // queues, and its peers' adverts become dead addresses.
+    relay
+        .clock()
+        .advance(u64::from(created.idle_ttl_seconds).saturating_mul(1_000) + 1_000);
+    client.resync_clock().await.expect("§5.5's clock read");
+    let gone = client.read(&key, created.recv_addr, 0, 0, 0).await;
+    assert_eq!(
+        gone.err().and_then(|error| error.wire_code()),
+        Some(ErrorCode::NoAccess)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn hit_a_quota() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+
+    // The send-side cap collapses to ERR_UNAVAILABLE (§6.3): if a full queue
+    // and an absent one differed, a bound sender could learn the depth by
+    // filling it.
+    let (_recv, _recv_key, mut send, send_key, created) = queue(&relay, 0x80).await;
+    relay.faults().set_policy(PolicyFaults {
+        max_queue_messages: Some(1),
+        ..PolicyFaults::default()
+    });
+    send.append(&send_key, created.send_addr, b"first")
+        .await
+        .expect("the first fits");
+    let full = send.append(&send_key, created.send_addr, b"second").await;
+    assert_eq!(
+        full.err().and_then(|error| error.wire_code()),
+        Some(ErrorCode::Unavailable)
+    );
+
+    // The recv-side creation quota is allowed to say what happened: the party
+    // refused is the one that owns the queues.
+    relay.faults().set_policy(PolicyFaults {
+        max_queues: Some(0),
+        ..PolicyFaults::default()
+    });
+    let mut creator = relay.client().await.expect("connects");
+    let key = SigningKey::from_seed(&[0x81; 32]);
+    let refused = creator.create_queue(&key, 0, 0, None).await;
+    assert_eq!(
+        refused.err().and_then(|error| error.wire_code()),
+        Some(ErrorCode::Quota)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn force_the_capability_document_violation_from_586() {
+    // https://github.com/free2z/zuu/issues/586 §1: `WIRE.md` §11.1 publishes
+    // `antireplay_window_ms` and `clock_skew_ms` as independent fields and
+    // relates them nowhere, so a relay may publish a seen-set retention shorter
+    // than the replay window its own timestamp policy creates — and be fully
+    // conforming while it does.
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    relay.faults().set_policy(PolicyFaults {
+        unsound_antireplay_window: true,
+        ..PolicyFaults::default()
+    });
+
+    let mut client = relay.client().await.expect("connects");
+    let signed = client.capabilities().await.expect("GET_CAPABILITIES");
+    let published = &signed.capabilities;
+    assert!(
+        u64::from(published.antireplay_window_ms)
+            < u64::from(published.clock_skew_ms).saturating_mul(2),
+        "the fault must publish the violating relation, not just behave badly"
+    );
+
+    // Half one: the document is *valid*. That is the defect.
+    f2z_relay_proto::capabilities::validate(published).expect("the spec permits this document");
+
+    // Half two: a client that checks the relation refuses, and the check is on
+    // by default.
+    let policy = ClientPolicy {
+        allow_insecure_transport: true,
+        ..ClientPolicy::default()
+    };
+    let refusal = policy.accept(published).expect_err("a client must refuse");
+    assert!(
+        matches!(
+            refusal,
+            f2z_relay_proto::ProtoError::Refused(
+                f2z_relay_proto::Refusal::AntiReplayWindowTooShort
+            )
+        ),
+        "expected AntiReplayWindowTooShort, got {refusal}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_fault_can_be_armed_mid_conversation_and_disarmed_again() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let mut client = relay.client().await.expect("connects");
+    client.ping().await.expect("healthy");
+
+    relay.faults().arm(Fault::times(
+        Trigger::Command(Command::Ping),
+        Effect::Refuse(ErrorCode::RateLimited),
+        2,
+    ));
+    for _ in 0..2 {
+        let refused = client.ping().await;
+        assert_eq!(
+            refused.err().and_then(|error| error.wire_code()),
+            Some(ErrorCode::RateLimited)
+        );
+    }
+    // The rule retired itself after its two firings.
+    client.ping().await.expect("healthy again");
+    assert_eq!(relay.faults().armed(), 0);
+}

--- a/rs/crates/f2z-relay-testkit/tests/worked_example.rs
+++ b/rs/crates/f2z-relay-testkit/tests/worked_example.rs
@@ -1,0 +1,207 @@
+//! The worked example: two clients, one real socket, and the delete observed.
+//!
+//! This is the flow a client developer has to get right before anything else
+//! works, driven end to end over `ws://127.0.0.1:0` — a real TCP accept, a real
+//! RFC 6455 upgrade with the mandatory subprotocol, real binary frames:
+//!
+//! ```text
+//!   Bob   CREATE_QUEUE                       → (recv_addr, send_addr)
+//!   Bob   SUBSCRIBE   recv_addr
+//!   Alice BIND_SEND   send_addr  (fresh key) → empty, once and forever
+//!   Alice APPEND      send_addr              → empty; no index, no depth
+//!   Bob   ← MSG push
+//!   Bob   READ        recv_addr              → the ciphertext, unchanged
+//!   Bob   (durable write)                    ← the §8.4 MUST happens here
+//!   Bob   ACK         recv_addr, index
+//!   Bob   READ        recv_addr              → empty: the relay deleted it
+//!   Bob   DELETE_QUEUE
+//!   Alice APPEND                             → ERR_UNAVAILABLE
+//! ```
+//!
+//! Run it with `cargo test -p f2z-relay-testkit --test worked_example -- --nocapture`
+//! to watch it narrate.
+
+// An integration test is its own crate, so the workspace's `panic`/`unwrap`/
+// `expect` denials — written for a relay's unauthenticated request path — apply
+// here too. A test that cannot assert is not a test, so they are lifted for
+// this file and nowhere else.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+use f2z_codec::ErrorCode;
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_testkit::client::Client;
+use f2z_relay_testkit::config::RelayConfig;
+use f2z_relay_testkit::fake::FakeRelay;
+use f2z_relay_testkit::websocket;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_bind_append_read_ack_delete_over_a_real_socket() {
+    // A wall-clock relay, as `f2z-fakerelay` runs, so nothing about this
+    // example depends on a frozen clock.
+    let relay = FakeRelay::new(RelayConfig::default().with_system_clock())
+        .expect("a default relay is configurable");
+    let server = relay.listen_loopback().await.expect("binds 127.0.0.1:0");
+    let url = server.url();
+    println!("relay listening at {url}");
+    println!("  relay_id      {:?}", relay.relay_id());
+    println!(
+        "  transport     ws:// — transport_security: none, channel_binding_mode: none (WIRE.md §2.3)"
+    );
+
+    // -- Bob creates the queue. §7.1: the recipient creates it, and the relay
+    //    generates both addresses from its own CSPRNG.
+    let mut bob = connect(&url, &relay).await;
+    let bob_key = SigningKey::from_seed(&[0xb0; 32]);
+    let queue = bob
+        .create_queue(&bob_key, 0, 0, None)
+        .await
+        .expect("CREATE_QUEUE");
+    println!(
+        "CREATE_QUEUE  → message_ttl {}s, idle_ttl {}s (granted after clamping, §7.7)",
+        queue.message_ttl_seconds, queue.idle_ttl_seconds
+    );
+    assert_ne!(queue.recv_addr, queue.send_addr);
+
+    let subscribed = bob
+        .subscribe(&bob_key, queue.recv_addr)
+        .await
+        .expect("SUBSCRIBE");
+    println!(
+        "SUBSCRIBE     → next_index {}, pending {}",
+        subscribed.next_index, subscribed.pending
+    );
+
+    // -- Alice binds the send side. §7.2 has `send_addr` reach her in-band,
+    //    inside the MLS group; the relay never sees that advert.
+    let mut alice = connect(&url, &relay).await;
+    let alice_key = SigningKey::from_seed(&[0xa1; 32]);
+    alice
+        .bind_send(&alice_key, queue.send_addr)
+        .await
+        .expect("BIND_SEND");
+    println!("BIND_SEND     → empty response, once and forever (§7.3)");
+
+    // §7.4: a second bind is ERR_ALREADY_BOUND, and on a *first* attempt for a
+    // fresh advert that is a loud, non-dismissible failure — the relay operator
+    // may have read `send_addr` out of its own database and bound first.
+    let stolen = alice.bind_send(&alice_key, queue.send_addr).await;
+    assert_eq!(
+        stolen.err().and_then(|e| e.wire_code()),
+        Some(ErrorCode::AlreadyBound)
+    );
+    println!("BIND_SEND #2  → ERR_ALREADY_BOUND (§7.4: noisy, not prevented)");
+
+    // -- Alice appends. §6.3: the response carries no index, no depth, no
+    //    timestamp and no queue state of any kind.
+    alice
+        .append(&alice_key, queue.send_addr, b"ciphertext")
+        .await
+        .expect("APPEND");
+    println!("APPEND        → empty response: no index, no depth, no timestamp (§6.3)");
+
+    // -- Bob gets the push, then reads.
+    let push = bob.next_message().await.expect("MSG push");
+    assert_eq!(push.recv_addr, queue.recv_addr);
+    println!(
+        "← MSG push    → index {} (§6.4, receive side only)",
+        push.msg.index
+    );
+
+    let read = bob
+        .read(&bob_key, queue.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ");
+    assert_eq!(read.messages.len(), 1);
+    let index = read.messages.as_slice().first().expect("one message").index;
+    println!(
+        "READ          → 1 message at index {index}, has_more {}",
+        read.has_more
+    );
+
+    // READ never mutates: the same read twice returns the same thing.
+    let again = bob
+        .read(&bob_key, queue.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ again");
+    assert_eq!(again.messages.len(), 1, "READ must not consume (§6.2)");
+
+    // -- The durable write goes HERE. §8.4 and CLIENT-CONTRACT.md §9 rule 1: a
+    //    device MUST NOT send ACK before its durable local write has completed,
+    //    because the relay deletes on ACK and ACK-on-read plus a crash is
+    //    permanent message loss.
+    let durably_written = read.messages.as_slice().first().map(|m| m.payload.len());
+    assert_eq!(durably_written, Some(1024), "padded to a bucket (§9)");
+    println!("(durable write completes — the §8.4 MUST)");
+
+    let acked = bob
+        .ack(&bob_key, queue.recv_addr, index)
+        .await
+        .expect("ACK");
+    println!(
+        "ACK           → next_index {}, pending {}",
+        acked.next_index, acked.pending
+    );
+    assert_eq!(acked.pending, 0);
+
+    // -- The delete, observed.
+    let after = bob
+        .read(&bob_key, queue.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ after ACK");
+    assert_eq!(
+        after.messages.len(),
+        0,
+        "the relay deletes at the instant of ACK (§8.1, §8.4 queue-delivered)"
+    );
+    println!("READ          → 0 messages: the ciphertext is gone (§8.1)");
+
+    // §8.2: and the reader still cannot pre-ack the queue it just drained.
+    let preack = bob.ack(&bob_key, queue.recv_addr, u64::MAX).await;
+    assert_eq!(
+        preack.err().and_then(|e| e.wire_code()),
+        Some(ErrorCode::AckTooHigh)
+    );
+    println!("ACK u64::MAX  → ERR_ACK_TOO_HIGH (§8.2: no pre-acking)");
+
+    // -- Bob retires the queue. §7.6: no observable tombstone.
+    bob.delete_queue(&bob_key, queue.recv_addr)
+        .await
+        .expect("DELETE_QUEUE");
+    println!("DELETE_QUEUE  → empty response, irreversible (§7.6)");
+
+    let event = bob.next_queue_event().await.expect("QUEUE_EVENT push");
+    assert_eq!(event.reason, 1, "reason 1 is 'deleted' (§6.4)");
+    println!("← QUEUE_EVENT → reason 1 (deleted)");
+
+    // The sender learns nothing except that its next APPEND fails.
+    let orphaned = alice.append(&alice_key, queue.send_addr, b"too late").await;
+    assert_eq!(
+        orphaned.err().and_then(|e| e.wire_code()),
+        Some(ErrorCode::Unavailable)
+    );
+    println!("APPEND        → ERR_UNAVAILABLE (§6.3: the collapse, so no state leaks)");
+
+    // And the receive side is indistinguishable from an address that never was.
+    let gone = bob.read(&bob_key, queue.recv_addr, 0, 0, 0).await;
+    assert_eq!(
+        gone.err().and_then(|e| e.wire_code()),
+        Some(ErrorCode::NoAccess)
+    );
+    println!("READ          → ERR_NO_ACCESS, same as an address that never existed (§10)");
+
+    server.shutdown().await;
+}
+
+async fn connect(url: &str, relay: &FakeRelay) -> Client {
+    let transport = websocket::connect(url)
+        .await
+        .expect("the WebSocket upgrade");
+    Client::connect(transport, relay.client_config())
+        .await
+        .expect("HELLO, relay_proof, and the relay_id comparison")
+}

--- a/rs/deploy/Dockerfile
+++ b/rs/deploy/Dockerfile
@@ -1,0 +1,36 @@
+# f2z-fakerelay — a TEST DOUBLE for client development. NOT a relay.
+#
+# WIRE.md §2.1 admits `wss://` only and §7.1 requires unpredictable queue
+# addresses from the relay's own CSPRNG. This image provides neither: it serves
+# `ws://`, and its addresses come from a seeded BLAKE2b counter so that a
+# conformance vector can be replayed byte for byte. Both facts are published in
+# the capability document it serves, and a conforming client refuses it without
+# an explicit per-relay opt-in (§2.3 obligation 3).
+#
+# Build it, run it on a developer's machine, point a client at it. Do not put it
+# on a network anyone else can reach.
+
+# The compiler is pinned by rs/rust-toolchain.toml, which restates
+# wallet/rust-toolchain.toml and is held to it by
+# scripts/check-rust-toolchain.sh. `rust:1-slim` ships rustup, which reads that
+# file and fetches the pinned channel — so the version lives in one place here
+# too, rather than being restated in a FROM line nothing checks.
+FROM docker.io/library/rust:1-slim AS build
+WORKDIR /src
+# The whole rs/ workspace: one [workspace], one Cargo.lock, and `--locked` below
+# only means something if the lockfile is the one in the repository.
+COPY . /src
+RUN cargo build --locked --release -p f2z-relay-testkit --bin f2z-fakerelay
+
+FROM docker.io/library/debian:stable-slim
+# Nothing here writes to disk — durability_mode is `memory` (§8.4) — so the
+# runtime image needs no volume, no user data directory and no root.
+RUN useradd --create-home --uid 10001 fakerelay
+COPY --from=build /src/target/release/f2z-fakerelay /usr/local/bin/f2z-fakerelay
+USER fakerelay
+EXPOSE 9944
+ENTRYPOINT ["/usr/local/bin/f2z-fakerelay"]
+# --insecure-listen is required because the container binds 0.0.0.0, which
+# WIRE.md §2.3 refuses without an explicit override. Typing it here rather than
+# defaulting it away is the point: the override is meant to be visible.
+CMD ["--listen", "0.0.0.0:9944", "--insecure-listen"]

--- a/rs/deploy/docker-compose.dev.yml
+++ b/rs/deploy/docker-compose.dev.yml
@@ -1,0 +1,60 @@
+# A relay endpoint in one command, for client development.
+#
+#   cd rs/deploy && docker compose -f docker-compose.dev.yml up
+#   # → ws://127.0.0.1:9944/relay/v1
+#
+# WHAT THIS IS NOT: a relay. `f2z-fakerelay` serves `ws://` (WIRE.md §2.1 admits
+# `wss://` only), derives queue addresses from a fixed seed so vectors replay
+# (§7.1 requires them to be unpredictable), and keeps everything in memory
+# (§8.4's `durability_mode: memory`). All three are published in its signed
+# capability document, and a conforming client refuses it unless the developer
+# opts in per relay (§2.3 obligation 3):
+#
+#   ClientPolicy { allow_insecure_transport: true, .. }
+#
+# The `faulty` service is the same relay with the capability document of
+# https://github.com/free2z/zuu/issues/586 — `antireplay_window_ms` below
+# `2 x clock_skew_ms`, which the specification as written permits and a
+# conforming client must refuse. Point a client at it and watch the refusal;
+# if the client connects anyway, that is the bug the issue is about.
+
+name: f2z-fakerelay
+
+services:
+  fakerelay:
+    build:
+      # rs/ — the workspace root, because the build needs one Cargo.lock.
+      context: ..
+      dockerfile: deploy/Dockerfile
+    # Loopback-only by default. Change this and you are exposing a relay whose
+    # queue addresses anyone can predict.
+    ports:
+      - "127.0.0.1:9944:9944"
+    command:
+      - "--listen"
+      - "0.0.0.0:9944"
+      - "--insecure-listen"
+    read_only: true
+    healthcheck:
+      # A TCP accept is the whole health signal: the process holds no state to
+      # be unhealthy about.
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/9944 || exit 1"]
+      interval: 10s
+      timeout: 2s
+      retries: 3
+
+  # Optional: the same relay, publishing the capability document of #586.
+  # `docker compose -f docker-compose.dev.yml --profile faults up faulty`
+  faulty:
+    profiles: ["faults"]
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    ports:
+      - "127.0.0.1:9945:9945"
+    command:
+      - "--listen"
+      - "0.0.0.0:9945"
+      - "--insecure-listen"
+      - "--unsound-antireplay"
+    read_only: true


### PR DESCRIPTION
Builds `rs/crates/f2z-relay-testkit` — the **FakeRelay**: a spec-conforming
free2z relay a client developer can build and test against **before
`f2z-relay` exists**, and can drive failure modes on demand.

`WIRE.md` specifies a relay that does not exist. `CLIENT-CONTRACT.md` (merged
today) describes clients that have to be built against it now. This is the
thing in between.

> **Status: draft, and auto-closed by the merge-train lock**, which posted
> *"#598 is the sole active merge candidate. The branch is preserved; this PR
> will be reopened as draft automatically after #598 lands."* Nothing here is
> asking to merge. The branch is `feature/relay-testkit` at `0806212`, on base
> `2d114c8`.
>
> **CI did run before the lock closed it, and both required gates are green:**
> `gate` ✅ · `rs / gate` ✅ · `rs / rustfmt` ✅ · `rs / clippy` ✅ ·
> `rs / cargo-deny` ✅ · `rs / tests` ✅ · `rs / wasm32` ✅
> ([run](https://github.com/free2z/zuu/actions/runs/32688893466)).
> The local evidence below was gathered on the pinned toolchain against the
> same base and agrees with it.

Refs #305. Related: #586 (this PR implements the defect as a fault, and does
not fix the document).

---

## What lands

| | |
|---|---|
| **In-process `FakeRelay`** | over `tokio::io::duplex`, no sockets, milliseconds |
| **The same relay over `ws://127.0.0.1:0`** | real TCP accept, real RFC 6455 upgrade, mandatory subprotocol, binary/text framing, Ping/Pong, close codes |
| **`f2z-fakerelay` binary + `rs/deploy/docker-compose.dev.yml`** | an endpoint in one command |
| **Fault injection** | drop, delay, reorder, close mid-stream, refuse with every §10 code, stall, TTL expiry, quotas, backpressure, the #586 capability document |
| **52 conformance vectors** | driven through the ordinary client API against an `Endpoint`; `f2z-relay` runs the same file unchanged |

Storage is in-memory and self-contained. **No dependency on
`f2z-relay-store`** — that crate is being built concurrently and this must not
block on it.

## The two structural claims, and how each is checked

**1. Both transports run the same implementation.** `connection::drive` and
`engine::Relay` are the only connection loop and the only relay in the crate;
the in-process pipe and the WebSocket listener are two `TransportSink` /
`TransportStream` pairs feeding them. That is an architecture claim, so
`tests/conformance.rs::both_transports_reach_the_same_verdicts` runs the whole
suite against both and asserts the per-vector verdicts are **identical**. If
the fast path ever diverges, it fails.

**2. The suite is the real relay's suite too.** `vectors::run` takes an
`Arc<dyn Endpoint>`. `f2z-relay` will be a `WebSocketEndpoint::new(url)` with
no fault handle, and `tests/conformance.rs::a_target_without_a_fault_handle_skips_rather_than_passes`
already exercises exactly that shape: 39 pass, 13 report **`Skipped`**, 0 fail.
A vector that needs to break the relay is never counted as green against a
relay nobody can tell to misbehave.

## Faults are not relaxations, and that distinction is the safety property

The brief's main hazard is a fake that accepts what the real relay would
reject. So the crate has two separate types and they are not interchangeable:

- **`faults::*`** makes the relay behave **worse** than the spec allows, in
  ways a real relay or a real network can. Always available.
- **`config::Relaxations`** makes it **accept** something a conforming relay
  would reject. Four fields, every one **off by default**, each named after the
  rule it suspends (`accept_any_payload_size`, `accept_any_timestamp`,
  `accept_missing_pow`, `accept_repeated_hello`), and `Relaxations::any()`
  exists so a harness can assert a run used none.

Nothing in the test suite turns a relaxation on.

## Reuse, not reimplementation

`f2z-codec` owns re-encode equality (§3.3) and framing (§4). `f2z-relay-proto`
owns §5.1's verification order, §5.5's anti-replay, §7/§8's queue and ACK
rules, and §11's capability document. None of it is re-derived here — a
conformance fake holding a second opinion about the protocol is worse than no
fake. What the engine decides is what those crates deliberately leave to a
server: the §2.5 lifecycle, §4.3's in-flight window, which code answers which
refusal, when a push is emitted, and §13.1's layering.

Two rules are worth calling out because they are easy to get backwards and are
implemented literally:

- **§6.3's collapse.** Every send-side refusal — absent, deleted, expired,
  full-by-messages, full-by-bytes, unbound, wrong key, backpressure — is
  `ERR_UNAVAILABLE`. A vector asserts that a full queue and an absent address
  are indistinguishable.
- **§10's existence-oracle rule.** "No such queue" and "exists but your key
  does not authorize it" both return code 10, and the absent path calls
  `f2z_relay_proto::key::dummy_verify()` first and consumes its result, so the
  dominant CPU cost is present in both paths. §10's residual timing channel is
  narrowed, not closed, exactly as the section says.

## Verification — local, base `2d114c8`, toolchain 1.97.1

```
scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
  --manifest rs/crates/f2z-codec/Cargo.toml \
  --manifest rs/crates/f2z-relay-proto/Cargo.toml \
  --manifest rs/crates/f2z-relay-testkit/Cargo.toml
  → Every Rust toolchain pin agrees with wallet/rust-toolchain.toml: channel 1.97.1, MSRV 1.97.

scripts/check-rust-fmt.sh    --root rs   → All 4 Rust crate(s) under rs/ are formatted.
scripts/check-rust-clippy.sh --root rs   → All 4 Rust crate(s) under rs/ are clippy-clean.  (-D warnings)
scripts/check-rust-deny.sh   --root rs --config rs/deny.toml
                                         → advisories ok, bans ok, licenses ok, sources ok.

cd rs && cargo test --locked --all-targets   → 267 passed, 0 failed  (14 binaries)
cd rs && cargo test --locked --doc           → 1 passed, 0 failed

node scripts/check-github-actions-pins.mjs   → passed
node scripts/check-workflow-gates.mjs        → passed
```

New manifest registered with `scripts/check-rust-toolchain.sh` in
`.github/workflows/rs.yml`, and **deliberately not** added to `rs_wasm` — it
opens sockets, spawns tasks and reads a clock, and a test harness that could
reach the browser build could end up in the shipped bundle. The reason is
written into the workflow beside the `-p` list.

### The worked example, over the real socket

`cargo test -p f2z-relay-testkit --test worked_example -- --nocapture`:

```
relay listening at ws://127.0.0.1:55826/relay/v1
  relay_id      RelayId(<redacted>)
  transport     ws:// — transport_security: none, channel_binding_mode: none (WIRE.md §2.3)
CREATE_QUEUE  → message_ttl 604800s, idle_ttl 7776000s (granted after clamping, §7.7)
SUBSCRIBE     → next_index 0, pending 0
BIND_SEND     → empty response, once and forever (§7.3)
BIND_SEND #2  → ERR_ALREADY_BOUND (§7.4: noisy, not prevented)
APPEND        → empty response: no index, no depth, no timestamp (§6.3)
← MSG push    → index 0 (§6.4, receive side only)
READ          → 1 message at index 0, has_more 0
(durable write completes — the §8.4 MUST)
ACK           → next_index 1, pending 0
READ          → 0 messages: the ciphertext is gone (§8.1)
ACK u64::MAX  → ERR_ACK_TOO_HIGH (§8.2: no pre-acking)
DELETE_QUEUE  → empty response, irreversible (§7.6)
← QUEUE_EVENT → reason 1 (deleted)
APPEND        → ERR_UNAVAILABLE (§6.3: the collapse, so no state leaks)
READ          → ERR_NO_ACCESS, same as an address that never existed (§10)
```

### The conformance suite, both transports

```
in-process (tokio::io::duplex):            52 passed,  0 skipped, 0 failed, of 52
websocket ws://127.0.0.1:.../relay/v1:     52 passed,  0 skipped, 0 failed, of 52
websocket, no fault handle (f2z-relay's shape):
                                           39 passed, 13 skipped, 0 failed, of 52
```

### Fault modes, each demonstrably firing

`cargo test -p f2z-relay-testkit --test faults` — 12 tests, all passing:
`drop_a_response`, `delay_a_response_without_blocking_the_ones_behind_it`,
`reorder_two_responses`, `close_the_connection_mid_stream`,
`stall_an_ack_forever`, `refuse_an_append_with_every_error_code` (all 21 §10
codes), `a_refused_append_did_not_append`, `expire_a_ttl_early`,
`expire_a_queue_by_moving_the_clock`, `hit_a_quota`,
`force_the_capability_document_violation_from_586`,
`a_fault_can_be_armed_mid_conversation_and_disarmed_again`.

The `f2z-fakerelay` binary was run by hand; §2.3's binding rule is enforced,
not printed:

```
$ f2z-fakerelay --listen 0.0.0.0:9999
f2z-fakerelay: invalid relay configuration: refusing to bind a non-loopback
address without TLS (WIRE.md §2.3); pass --insecure-listen if you really mean it
```

---

## Ambiguity calls — every one, with the reading taken

Ordered by section. Each is a place `WIRE.md` does not say, and each is
implemented one way and commented at the point of use.

**§1.3 / §4.1 — the WebSocket close status for a fatal error.** §4.2 fixes
1003 for a text frame and no other status is named. **Taken:** 1002 (protocol
error) for every other fatal code.

**§4.1 / §4.3 — a fatal error on a frame whose `request_id` is unreadable.**
§1.3 says "send the response, then close"; §4.3 says a response's `request_id`
must be nonzero. For a frame under 5 bytes, or one whose kind byte is not
`request(1)`, there is no id to answer on and both rules cannot hold.
**Taken:** best-effort recovery of the id from the fixed 5-byte header — which
covers almost every malformed frame — and, when that fails, close with **no
response frame** rather than emit one §4.3 forbids. Applies to an oversize
frame (§4.1) and to §4.2's text frame, which carries no id at all.

**§2.5 / §3.5 — a second `HELLO` on one connection.** §3.5 says negotiation
happens once and applies to the whole connection; §10 names no code for a
renegotiation attempt. **Taken:** `ERR_UNSUPPORTED_VERSION`, fatal — the same
code §10 already assigns to "a frame before `HELLO`". Suspendable with
`Relaxations::accept_repeated_hello`.

**§4.1 — a client that sends a response or a push frame.** §10 has no code.
**Taken:** `ERR_MALFORMED`, fatal; it is a frame no conforming client emits.

**§6.1 — an unknown `ChallengePurpose` byte.** `f2z-codec` keeps it raw so it
round-trips §3.3, and its doc says a purpose this build does not know is "the
relay's to refuse with a code" — but §10 has no code for an unknown enum value
inside a body. **Taken:** `ERR_MALFORMED`. Flagged as the weakest call here;
it is fatal, and a non-fatal code would be defensible if one existed.

**§6.1 / §12.3 — validating `GET_CHALLENGE`'s `scope` at issuance.** Nothing
requires the relay to check it. **Taken:** issue whatever scope is asked for
and enforce the binding at **consumption**, where §12.3 actually needs it
(the stamp's challenge must have been issued for that `contact_addr`). This
keeps a wrong-length scope out of the fatal path.

**§6.2 — `READ` with `max_messages == 0` or `max_bytes == 0`.** No meaning is
given. **Taken:** "no client-side limit", matching `f2z-relay-proto`'s reading
of a zero TTL as "no preference". A zero that meant "return nothing" would let
a client that forgot the field loop forever against a queue it can never
drain.

**§6.2 — `READ` whose first message exceeds `max_bytes`.** **Taken:** always
return at least one message, with `has_more` set accordingly. The alternative
stalls the queue permanently, because `READ` never mutates and there is no
other way out.

**§6.2 — `pending` after TTL expiry.** `f2z-relay-proto` computes it in index
space and documents that this is an upper bound because expiry removes
messages without moving the watermark. **Taken:** count from storage, which is
what that crate says a relay with storage should do.

**§6.3 / §12.2 — `APPEND` to a *contact* queue's published address.** §12.2
gives contact queues `CONTACT_APPEND`; it does not say what `APPEND` does
there. **Taken:** the contact send side is never bound, so `authorize_send`
refuses with `ERR_UNAVAILABLE` — the §6.3 collapse, with no new rule.

**§6.3 vs §10 — the send-side "absent" case.** §6.3 collapses everything to
`ERR_UNAVAILABLE`; §10's table assigns "absent" to code 10. They contradict.
**Taken:** §6.3, as #583 did, because §6.3's rule carries the security
argument. This is defect 2 of #586 and is not fixed here.

**§7.3 — `BIND_SEND` on an address that does not exist.** **Taken:**
`ERR_UNAVAILABLE`, per the same collapse. `ERR_NOT_PERMITTED` remains
distinguishable for a *contact* address, per §12.2's explicit "always, for
everyone" — and that address is published by design, so it leaks nothing.

**§5.5 / §11.1 — where the seen-set lives.** §5.5 says "the relay keeps the
set" without saying whether it is per connection. **Taken:** relay-wide. In
`channel_binding_mode: none` — which a `ws://` fake must publish — the binding
is a constant, so a frame captured on one connection verifies on another and a
per-connection set would not close the window at all.

**§11.1 — `antireplay_seen_max` has no published default.** **Taken:** 65 536.

**§13.1 — `queue_creation_mode: token`.** §13.1 defines it as an
operator-issued bearer credential and gives it no protocol shape in v1.
**Taken:** refuse it at construction rather than invent one.

**§2.4 — the keepalive is never faulted.** A suppressed Ping presents as a
hung relay rather than as the fault it is, so `Effect::*` does not apply to
keepalives. A deliberate limitation, not an oversight.

## Spec defects, reported rather than worked around

**#586 defect 1 — `antireplay_window_ms` is unrelated to `clock_skew_ms`.**
Not fixed here (docs-only issue), but now *demonstrable*:
`PolicyFaults::unsound_antireplay_window` publishes
`antireplay_window_ms = clock_skew_ms` **and enforces it**, so the relay really
does age a seen-set entry out while the frame it covers is still inside the
timestamp window. A vector asserts both halves — that
`capabilities::validate` **accepts** the document (the spec as written permits
it, which is the finding) and that `ClientPolicy::accept` **refuses** it. Also
reachable from the binary as `--unsound-antireplay` and from
`docker-compose.dev.yml`'s `faulty` profile.

**#586 defect 2 — §6.3 vs §10.** Implemented in §6.3's favour, as above. No
new finding; the contradiction is exactly as #586 describes it.

**No new spec defects found.** The list above is ambiguity, not contradiction.

## Known gaps, stated

- **§11.2's `.well-known` JSON document is not served.** `GET_CAPABILITIES`
  and the `HELLO` digest comparison both work; the plain-HTTPS representation
  does not exist. Serving it means an HTTP parser beside the WebSocket one —
  the second parser §2.2 argues against — for an affordance aimed at humans.
  So a client's "fetch the well-known copy and compare digests" path cannot be
  exercised against this harness. Worth doing if a client author asks.
- **The channel binding is not a TLS exporter.**
  `ChannelBindingSource::Simulated` hands both ends a constant so the §5.3
  exporter code path is reachable; it binds a signature to *this
  configuration*, not to a TLS session. A passing test there is not evidence
  about RFC 8446 §7.5, and the type says so.
- **Queue addresses are predictable, by design.** §7.1 requires the opposite.
  A conformance vector that produced different addresses each run would not be
  a vector, so the generator is BLAKE2b in counter mode over a seed. This is
  the first of three reasons `f2z-fakerelay` must never be deployed, and it is
  in the crate docs, the binary's `--help` banner, the README and the
  Dockerfile.
- **`§4.3`'s duplicate-`request_id` rule needs a fault handle to observe.** A
  relay releases an id the moment it answers, so the rule is only visible while
  a response is held. That vector declares `Needs::Faults` and reports
  *skipped* against a real relay rather than being turned into a race that
  passes by luck.

## Reviewer's shortlist

- `src/engine.rs` — the refusal-code decisions and §5.1's ordering.
- `src/vectors.rs` — the 52 cases; each names the section it pins.
- `src/config.rs::Relaxations` — confirm nothing turns one on by default.
- `.github/workflows/rs.yml` — the manifest registration, and the `rs_wasm`
  absence.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
