### PR TITLE
security(e2ee): make the H() label namespace prefix-free, and assert it over the union

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -66,6 +66,20 @@ jobs:
           node scripts/check-workflow-gates.mjs --self-test
           node scripts/check-workflow-gates.mjs
 
+      # Deliberately in this always-running job and not behind the rs/ filter.
+      # The labels it judges live in docs/e2ee/*.md as much as in rs/, and the
+      # collision it exists to catch (#602) arrived in a docs-only pull request
+      # — a diff for which `filter` below sets rs=false and every rs job skips.
+      # A check that only runs when Rust changes would not have run on the
+      # commit that broke the invariant. Its own step rather than a line added
+      # to one above, so the exact ordered command assertion that
+      # scripts/check-github-actions-pins.mjs holds over the required workflow's
+      # policy step stays a single reviewed unit.
+      - name: Verify hash-domain labels are prefix-free across the tree
+        run: |
+          node scripts/check-hash-domain-labels.mjs --self-test
+          node scripts/check-hash-domain-labels.mjs
+
       # rs/rust-toolchain.toml and rs/crates/*/Cargo.toml restate
       # wallet/rust-toolchain.toml, and are registered in the script's own
       # TOOLCHAIN_RESTATEMENTS/MANIFESTS arrays rather than by flags here. A
@@ -332,6 +346,12 @@ jobs:
       # Re-run the workflow policy here so that even a job-level
       # continue-on-error on `changes` cannot turn that job's deliberately
       # failing policy verdict into the `success` conclusion this gate consumes.
+      #
+      # The label check is re-run here for the same reason, and this is how it
+      # reaches the required context: this step's `outcome` is bound below as
+      # POLICY_OUTCOME and the verdict refuses to pass unless it is `success`.
+      # `needs:` a job without reading its result is the defect of #512 and
+      # #515–#518; a step whose outcome is read is not that shape.
       - name: Recheck the workflow policy
         id: policy
         run: |
@@ -339,6 +359,8 @@ jobs:
           node scripts/check-github-actions-pins.mjs
           node scripts/check-workflow-gates.mjs --self-test
           node scripts/check-workflow-gates.mjs
+          node scripts/check-hash-domain-labels.mjs --self-test
+          node scripts/check-hash-domain-labels.mjs
 
       - name: Verify required jobs succeeded or legitimately skipped
         shell: bash

--- a/docs/e2ee/KT.md
+++ b/docs/e2ee/KT.md
@@ -505,7 +505,7 @@ struct {
     uint64 epoch;
     uint64 tree_size;             /* total (label, version) insertions committed */
     opaque root_hash[32];         /* the akd Azks root at this epoch */
-    opaque prev_sth_hash[32];     /* H("free2z/kt/v1/sth-hash", tls_codec(prev SignedTreeHeadTBS)) */
+    opaque prev_sth_hash[32];     /* H("free2z/kt/v1/tree-head-hash", tls_codec(prev SignedTreeHeadTBS)) */
     opaque vrf_public_key[32];    /* the ECVRF key labels are derived under */
     uint64 published_at_ms;
     uint32 reset_count;           /* platform resets in this epoch — ADR 0014 */
@@ -535,6 +535,31 @@ change. It **MUST NOT** change within a `log_id`: it determines every label in
 the tree, so changing it silently invalidates every prior proof while producing
 proofs that still verify under the new key. A client or witness that observes a
 `vrf_public_key` change MUST treat it as a fork (§7.3), not as an update.
+
+> **Correction (2026-08-24) — the tree-head digest label was renamed, and the
+> old one must not be used.** As first published, this document computed
+> `prev_sth_hash` and `announce_sth_hash` (§6.4) under the label formed by
+> appending `-hash` to `free2z/kt/v1/sth`. That label was a **proper prefix
+> violation**: `free2z/kt/v1/sth` — the signing-transcript constant of
+> `SignedTreeHeadTBS` two paragraphs below — is a proper prefix of it, and
+> [`WIRE.md` §1.3](./WIRE.md#13-conventions) defines `H(label, x)` as
+> `BLAKE2b-256(label || x)` with **no separator and no terminator**. A digest
+> taken in the `free2z/kt/v1/sth` domain over any message whose first five bytes
+> were `-hash` was therefore bit-identical to a digest taken in the old
+> tree-head-digest domain over the remainder: between those two domains,
+> separation was absent rather than weakened, over exactly the structure the
+> anti-equivocation argument in §7 rests on.
+>
+> The label is now **`free2z/kt/v1/tree-head-hash`**, which no other label in the
+> namespace prefixes and which prefixes no other. **Any digest computed under the
+> old label is invalid and MUST be recomputed**; no shipped code held the old
+> value — the crates that will use these labels are not written — but an
+> implementer working from the first revision of this document must change it.
+> `WIRE.md` §1.3 now states prefix-freeness as a normative requirement on the
+> union of every document's labels rather than leaving it an unwritten
+> assumption, and `scripts/check-hash-domain-labels.mjs` enforces it on every
+> pull request. [#602](https://github.com/free2z/zuu/issues/602); predicted in
+> [#552](https://github.com/free2z/zuu/issues/552).
 
 ### 6.2 The signing transcript, and domain separation
 
@@ -578,7 +603,7 @@ following hold** against the last one it accepted for this `log_id`:
 5. `published_at_ms > last.published_at_ms`.
 6. `vrf_public_key == last.vrf_public_key`.
 7. **The `prev_sth_hash` chain connects.** If `epoch == last.epoch + 1`, then
-   `prev_sth_hash == H("free2z/kt/v1/sth-hash", tls_codec(last.sth))` directly.
+   `prev_sth_hash == H("free2z/kt/v1/tree-head-hash", tls_codec(last.sth))` directly.
    If `epoch > last.epoch + 1`, the verifier MUST fetch every intervening tree
    head and check the chain link by link. **It MUST NOT skip.** A gap accepted on
    trust is a branch accepted on trust.
@@ -603,7 +628,7 @@ struct {
     opaque label<0..255>;        /* exactly "free2z/kt/v1/log-key-transition" */
     opaque log_id[32];
     uint64 announce_epoch;       /* the epoch of the announcing STH */
-    opaque announce_sth_hash[32];/* H("free2z/kt/v1/sth-hash", tls_codec(announcing sth)) */
+    opaque announce_sth_hash[32];/* H("free2z/kt/v1/tree-head-hash", tls_codec(announcing sth)) */
     opaque outgoing_log_pk[32];
     opaque successor_log_pk[32];
     uint64 effective_epoch;      /* first epoch signed by the successor */

--- a/docs/e2ee/README.md
+++ b/docs/e2ee/README.md
@@ -116,6 +116,15 @@ witnesses can**), with the consequences carried into
 [`THREAT-MODEL.md` §3.1](./THREAT-MODEL.md#31-malicious-or-compromised-free2z-server)
 and [§3.9](./THREAT-MODEL.md#39-malicious-directory-witness).
 
+A Phase 1 constant has since been corrected the same way:
+[`KT.md` §6.1](./KT.md#61-structure) (2026-08-24) **renames the tree-head digest
+label to `free2z/kt/v1/tree-head-hash`**, because the name it shipped with was a
+proper extension of `free2z/kt/v1/sth` and `H` has no separator, so the two
+domains were not separated at all. `WIRE.md` §1.3 now states prefix-freeness as a
+normative requirement on the **union** of every document's labels, and
+`scripts/check-hash-domain-labels.mjs` enforces it on every pull request
+([#602](https://github.com/free2z/zuu/issues/602)).
+
 Still open above the relay: `KeyPackage` publication, push notifications, padding
 bucket sizes, the redundancy factor *k*, the client gossip protocol, the witness
 independence criterion and the default *t*, and the KT epoch cadence. All are

--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -71,6 +71,35 @@ construction #544 selects.
 - `H(label, x)` means `BLAKE2b-256(label || x)` where `label` is the exact ASCII
   bytes shown, with no separator and no terminator — the idiom already used for
   `msg_id` in [`ARCHITECTURE.md` §7](./ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering).
+- **The label set MUST be prefix-free.** No label used with `H` — in this
+  document, in [`KT.md`](./KT.md), or in any later document that uses `H` — may
+  be a proper prefix of any other such label. The rule extends to labels
+  concatenated the same way without `H`, such as the §5.2 signing prefix
+  `"free2z/relay/v1/hello"`, and to the first-field `label` constants of the
+  signed structures, because those constants and these arguments are drawn from
+  one namespace and a future construction will reuse one for the other.
+
+  This is the precondition of the construction, not a naming preference. With no
+  separator, if label `A` is a proper prefix of label `B` — so that
+  `B == A || s` for some nonempty `s` — then
+
+  ```
+  H(A, s || y) = BLAKE2b-256(A || s || y) = BLAKE2b-256(B || y) = H(B, y)
+  ```
+
+  bit for bit, and the two domains are not separated for any `A`-domain message
+  beginning with `s`.
+
+  The requirement is on the **union** of every document's labels, never on each
+  document's set separately: a set that is internally prefix-free says nothing
+  about its neighbours, and that scoping mistake is how
+  [#602](https://github.com/free2z/zuu/issues/602) put `free2z/kt/v1/sth` and a
+  label extending it into the same namespace. `scripts/check-hash-domain-labels.mjs`
+  asserts the property mechanically over every label in the repository on every
+  pull request, from the always-running `rs / changes` job, and its verdict is
+  re-checked inside the required `rs / gate` context. **Adding a label means
+  running that check**; a label that has not been through it is a label nobody
+  has checked against the rest of the namespace.
 - Structures are written in the **TLS presentation language**
   ([RFC 8446 §3](https://datatracker.ietf.org/doc/html/rfc8446#section-3)); see §3.
 - "The relay" is the server. "The client" is a ZUULI or WASM device

--- a/rs/crates/f2z-codec/src/hash.rs
+++ b/rs/crates/f2z-codec/src/hash.rs
@@ -7,9 +7,17 @@
 //! No separator means the labels themselves have to be non-ambiguous, and they
 //! are: every label below is a full path under `free2z/relay/v1/` and no label
 //! is a prefix of another with a message that could complete it. That is a
-//! property of this fixed set, not of the construction, so a new label must be
-//! checked against the same rule before it is added — [`LABELS`] exists so a
-//! test can do that mechanically.
+//! property of *a set*, not of the construction, so a new label must be checked
+//! against the same rule before it is added.
+//!
+//! **The set that matters is the union, not this array.** `WIRE.md` §1.3 now
+//! states prefix-freeness as a normative requirement over every label in every
+//! document that uses `H`, and `scripts/check-hash-domain-labels.mjs` enforces
+//! it across the whole repository — the specifications under `docs/e2ee/` as
+//! well as these constants. [`LABELS`] and the test below cover this crate's
+//! own six, which is worth keeping and is not sufficient on its own: `KT.md`'s
+//! labels were internally prefix-free too, and collided anyway
+//! ([#602](https://github.com/free2z/zuu/issues/602)).
 
 use blake2::digest::consts::U32;
 use blake2::{Blake2b, Digest as _};
@@ -134,6 +142,13 @@ mod tests {
         // is a prefix of another label is a cross-domain collision waiting for
         // an attacker-chosen message. Assert the property rather than trusting
         // that whoever adds the next label remembers it.
+        //
+        // Scope, stated because it is the part that was wrong before #602: this
+        // ranges over this crate's `LABELS` and nothing else. The union with
+        // `KT.md`'s and `ARCHITECTURE.md`'s labels — which is where the property
+        // actually has to hold — is asserted by
+        // `scripts/check-hash-domain-labels.mjs`, from a CI job that runs on
+        // every pull request including the docs-only ones this test never sees.
         for (i, a) in LABELS.iter().enumerate() {
             for (j, b) in LABELS.iter().enumerate() {
                 if i == j {

--- a/scripts/check-hash-domain-labels.mjs
+++ b/scripts/check-hash-domain-labels.mjs
@@ -1,0 +1,688 @@
+#!/usr/bin/env node
+//
+// Prove that the E2EE hash-domain labels are prefix-free across the whole tree.
+//
+// `docs/e2ee/WIRE.md` §1.3 defines the one hash the protocol uses as
+//
+//     H(label, x) = BLAKE2b-256(label || x)
+//
+// with **no separator and no terminator**. That construction separates domains
+// only if the label set is prefix-free. If label `A` is a proper prefix of label
+// `B`, then for the suffix `s` with `A || s == B`,
+//
+//     H(A, s || y) == BLAKE2b-256(A || s || y) == BLAKE2b-256(B || y) == H(B, y)
+//
+// bit for bit. Separation between those two domains is not weakened, it is
+// absent for every `A`-domain message that begins with `s`.
+//
+// Prefix-freeness is therefore a property of *the set*, not of the
+// construction, and a set has no owner. `f2z-codec` already asserted it — over
+// its own `LABELS` array (`rs/crates/f2z-codec/src/hash.rs`). That is the right
+// shape and the wrong scope: `WIRE.md`'s labels were internally consistent,
+// `KT.md`'s labels were internally consistent, and the pair that actually
+// collided — `free2z/kt/v1/sth` against `free2z/kt/v1/sth-hash` — lived in a
+// document no crate reads (#602). #552 predicted exactly this a document
+// earlier. So this check ranges over the **union**: every label in every
+// tracked file, specifications and Rust alike.
+//
+// ## Why this is a script and not a Rust test
+//
+// Three reasons, each of which would sink a `#[test]` on its own.
+//
+//   1. `KT.md` has no crate. `f2z-kt-core` and `f2z-authority` are not merged.
+//      A Rust test could only assert over a hand-copied restatement of `KT.md`'s
+//      label set — and a hand-maintained copy of a document's set drifting from
+//      the document is the *same* failure that produced #602.
+//   2. The collision arrived in a docs-only pull request. `rs.yml`'s change
+//      detector selects `rs=false` for such a diff and skips `rs / tests`
+//      entirely, so a Rust test would not have run on the commit that
+//      introduced the defect. This script runs from `rs / changes`, which runs
+//      on every event unconditionally, and its verdict is re-run inside
+//      `rs / gate` where the gate consumes the step outcome.
+//   3. The labels are minted in prose. The source of truth is the sentence in
+//      the specification that says `opaque label<0..255>` is *exactly* these
+//      bytes; reading the documents directly means the check cannot go stale
+//      relative to the spec.
+//
+// ## What counts as a label
+//
+// A token matching `free2z/<namespace>/v<n>` with an optional `/<leaf>`, in any
+// tracked file. The leaf is optional because several domain constants have none
+// — `free2z/device-credential/v1` is a `SignedTreeHead`-family signing label in
+// `KT.md` §6.2's closed table, `free2z/queue-advert/v1` is a `WIRE.md` §12.2
+// document type — and a leafless label is a prefix of *every* leafed label in
+// its namespace, which is the sharpest form of the defect this check exists for.
+//
+// The MLS exporter labels (`free2z/queue/v1`, `free2z/frost/v1`,
+// `free2z/webrtc/v1`, `free2z/history/v1`) are swept in as well. They are not
+// arguments to `H` — MLS's exporter frames its label — so prefix-freeness is not
+// load-bearing for them today. They are included anyway because the cost is
+// zero, because the set of constructions a label gets reused in only ever grows,
+// and because a check that holds a *subset* of the namespace is exactly how #602
+// happened.
+//
+// Three exclusions, each narrow and each deliberate:
+//
+//   * **A trailing slash marks a namespace, not a label.** `free2z/relay/v1/`
+//     is how the documents and `hash.rs`'s module note refer to the namespace
+//     itself. Counting it would make it a prefix of every relay label at once —
+//     nine false collisions, no true one. The slash is the whole signal: a
+//     leafless `free2z/relay/v1` written without it *is* judged as a label,
+//     because that spelling is indistinguishable from a real leafless constant
+//     such as `free2z/device-credential/v1`.
+//
+//   * **Registered fixtures are not labels.** `FIXTURE_TOKENS` names a file, an
+//     exact token and a reason. `free2z/relay/v1/cmd2` and
+//     `free2z/relay/v1/cmX` are deliberately *wrong* labels, fed to validators
+//     to prove they reject them; `free2z/relay/v1/dummy` is signature-check
+//     filler. None is a domain.
+//
+//   * **This file declares nothing.** The checker's own prose quotes labels
+//     other files mint, and its self-test fixtures invent labels in reserved
+//     `demo`/`other`/`third` namespaces. Scanning it would make the checker
+//     report collisions between its own examples. `NON_DECLARING_FILES` names
+//     it by exact path and requires that path to be tracked, so renaming the
+//     checker fails this check rather than quietly leaving a file unscanned.
+//
+// The exclusion is by registration and never by heuristic, because every
+// available heuristic is wrong here. "It is in a test file" would have dropped
+// the six genuine labels `rs/crates/f2z-codec/tests/wire_vectors.rs` pins; "it
+// is not in a `LABELS` array" is the scoping mistake this script exists to fix.
+// A registered entry that no longer occurs in its file is itself a failure, so
+// the registry cannot rot into a blanket excuse for a token nobody can find.
+//
+// ## The coverage anchor
+//
+// The union is only a union if the scan reaches the documents.
+// `LABEL_BEARING_DOCUMENTS` registers every document under `docs/` that names a
+// label, and is checked in both directions:
+//
+//   * each registered document must exist and must yield at least one label —
+//     so a rename, a move, or a scan that quietly stops reading Markdown fails
+//     loudly instead of passing over a smaller set;
+//   * each tracked `docs/**.md` that yields labels must be registered — so a
+//     future `KT.md`-shaped document cannot join the tree without the person
+//     adding it being told that its labels now share one namespace with
+//     everyone else's.
+//
+// Without the anchor, narrowing this check to one document is a silent green.
+// The self-test proves the anchor fires on exactly that mutation.
+//
+// Usage:
+//   node scripts/check-hash-domain-labels.mjs             judge the tree
+//   node scripts/check-hash-domain-labels.mjs --self-test negative controls first
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+/// A domain-separation label: the `free2z/` namespace, a version segment, and an
+/// optional leaf. The leaf charset is wider than any label in use (`:` for
+/// `KT.md`'s `AkdLabel` prefix, `.` and `_` so a malformed neighbour is still
+/// seen rather than truncated into a shorter token that collides with nothing).
+const LABEL_TOKEN = /free2z\/[a-z0-9-]+\/v[0-9]+(?:\/[A-Za-z0-9:._-]*)?/g;
+
+/// A trailing slash with nothing after it. See the module note: that is how the
+/// documents and `hash.rs` name a namespace, and it is not a label. A namespace
+/// written *without* the trailing slash is not covered by this and is judged as
+/// the leafless label it looks like — which is the conservative direction.
+const NAMESPACE_MENTION = /\/$/;
+
+/// Tokens that look like labels and are not, keyed by the exact file they may
+/// appear in. Adding an entry is a deliberate act with a written reason; an
+/// entry whose token no longer occurs in its file fails this check.
+const FIXTURE_TOKENS = [
+  {
+    file: "rs/crates/f2z-codec/src/transcript.rs",
+    token: "free2z/relay/v1/cmd2",
+    reason:
+      "negative control: the wrong transcript label, asserted to be rejected by CommandTranscript::validate",
+  },
+  {
+    file: "rs/crates/f2z-codec/tests/wire_vectors.rs",
+    token: "free2z/relay/v1/cmX",
+    reason:
+      "negative control: a one-byte corruption of LABEL_COMMAND, asserted to fail the §5.1 vector",
+  },
+  {
+    file: "rs/crates/f2z-relay-proto/src/key.rs",
+    token: "free2z/relay/v1/dummy",
+    reason:
+      "signature-verification filler: an arbitrary message handed to verify() with a zero signature",
+  },
+];
+
+/// Files that quote labels without declaring any, excluded whole. Exactly one
+/// entry, and it is this file: see the module note. Each entry must be a tracked
+/// path, so the exclusion cannot outlive the file it excuses.
+const NON_DECLARING_FILES = [
+  {
+    file: "scripts/check-hash-domain-labels.mjs",
+    reason:
+      "the checker itself: it quotes labels other files mint and invents fixture labels in reserved namespaces",
+  },
+];
+
+/// Every document under `docs/` that names a label — the specifications that
+/// mint them and the index that quotes them. See the module note on the anchor:
+/// registered documents must yield labels, and label-naming documents must be
+/// registered.
+const LABEL_BEARING_DOCUMENTS = [
+  "docs/e2ee/ARCHITECTURE.md",
+  "docs/e2ee/KT.md",
+  "docs/e2ee/README.md",
+  "docs/e2ee/THREAT-MODEL.md",
+  "docs/e2ee/WIRE.md",
+  "docs/e2ee/decisions/0009-queue-addressing-and-binding.md",
+  "docs/e2ee/decisions/0010-signing-transcript-and-ack-semantics.md",
+];
+
+/// Files under this prefix are subject to the registration half of the anchor.
+const DOCS_ROOT = "docs/";
+
+/// A floor on the size of the union, so a scan that reaches almost nothing
+/// cannot report a vacuous pass. Deliberately a floor and not an exact count:
+/// adding a label should not require editing this file, but losing two thirds
+/// of the set should never be quiet.
+const MINIMUM_LABELS = 24;
+
+/// Every tracked path, from git. Anything git does not track is invisible here
+/// on purpose — a stray untracked scratch file must not be able to fail, or to
+/// pass, a policy check that runs on a clean checkout in CI.
+function trackedFiles(root) {
+  const listing = execFileSync("git", ["-C", root, "ls-files", "-z"], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return listing.split("\0").filter(Boolean);
+}
+
+/// Read a tracked path as text, or `null` when it is not a readable text file
+/// (a submodule gitlink, a symlink to nowhere, a binary asset).
+function readText(root, relativeFile) {
+  const absolute = path.join(root, relativeFile);
+  let stats;
+  try {
+    stats = fs.statSync(absolute);
+  } catch {
+    return null;
+  }
+  if (!stats.isFile()) return null;
+  let text;
+  try {
+    text = fs.readFileSync(absolute, "utf8");
+  } catch {
+    return null;
+  }
+  if (text.includes("\0")) return null;
+  return text;
+}
+
+function sorted(values) {
+  return [...values].sort().join(", ") || "(none)";
+}
+
+/// Collect the label union and judge it.
+///
+/// Every input is injectable so the self-test judges fixtures against fixture
+/// configuration: a registration added for the real tree must never change what
+/// a self-test case means.
+export function scanRepository(root, options = {}) {
+  const {
+    files = trackedFiles(root),
+    fixtures = FIXTURE_TOKENS,
+    nonDeclaring = NON_DECLARING_FILES,
+    labelBearingDocuments = LABEL_BEARING_DOCUMENTS,
+    docsRoot = DOCS_ROOT,
+    minimumLabels = MINIMUM_LABELS,
+  } = options;
+
+  const failures = [];
+  /// label -> Map<file, Set<line number>>
+  const labels = new Map();
+  const namespaceMentions = new Set();
+  const fixtureHits = new Set();
+  const labelBearingDocs = new Set();
+  let scanned = 0;
+
+  const excused = new Map();
+  for (const entry of fixtures) {
+    if (!excused.has(entry.file)) excused.set(entry.file, new Set());
+    excused.get(entry.file).add(entry.token);
+  }
+
+  const skipped = new Set(nonDeclaring.map((entry) => entry.file));
+  for (const entry of nonDeclaring) {
+    if (files.includes(entry.file)) continue;
+    failures.push(
+      `NON_DECLARING_FILES excludes ${entry.file}, which is not a tracked file; ` +
+        "a stale whole-file exclusion is a file nobody is reading",
+    );
+  }
+
+  for (const relativeFile of files) {
+    if (skipped.has(relativeFile)) continue;
+    const text = readText(root, relativeFile);
+    if (text === null) continue;
+    scanned += 1;
+    if (!text.includes("free2z/")) continue;
+
+    for (const [index, line] of text.split(/\r?\n/).entries()) {
+      for (const match of line.matchAll(LABEL_TOKEN)) {
+        const token = match[0];
+        if (NAMESPACE_MENTION.test(token)) {
+          namespaceMentions.add(token);
+          continue;
+        }
+        if (excused.get(relativeFile)?.has(token)) {
+          fixtureHits.add(`${relativeFile}\0${token}`);
+          continue;
+        }
+        if (!labels.has(token)) labels.set(token, new Map());
+        const sites = labels.get(token);
+        if (!sites.has(relativeFile)) sites.set(relativeFile, new Set());
+        sites.get(relativeFile).add(index + 1);
+        if (relativeFile.startsWith(docsRoot)) {
+          labelBearingDocs.add(relativeFile);
+        }
+      }
+    }
+  }
+
+  // The property. Every ordered pair, both directions, so the message always
+  // names the shorter label first.
+  const names = [...labels.keys()].sort();
+  let collisions = 0;
+  for (const shorter of names) {
+    for (const longer of names) {
+      if (shorter === longer) continue;
+      if (!longer.startsWith(shorter)) continue;
+      collisions += 1;
+      const suffix = longer.slice(shorter.length);
+      failures.push(
+        `"${shorter}" is a proper prefix of "${longer}": ` +
+          `H("${shorter}", "${suffix}" || y) is bit-identical to H("${longer}", y), ` +
+          `so those two domains are not separated. ` +
+          `${shorter} at ${describe(labels.get(shorter))}; ` +
+          `${longer} at ${describe(labels.get(longer))}`,
+      );
+    }
+  }
+
+  // The fixture registry may not carry an entry nobody can find: a stale
+  // exclusion is an exclusion that has stopped being reviewed.
+  for (const entry of fixtures) {
+    if (fixtureHits.has(`${entry.file}\0${entry.token}`)) continue;
+    failures.push(
+      `FIXTURE_TOKENS excuses "${entry.token}" in ${entry.file}, which no longer contains it; ` +
+        "remove the entry rather than leaving an unreviewed exclusion in place",
+    );
+  }
+
+  // The anchor, both directions.
+  for (const document of labelBearingDocuments) {
+    if (!files.includes(document)) {
+      failures.push(
+        `LABEL_BEARING_DOCUMENTS registers ${document}, which is not a tracked file; ` +
+          "the union this check reports is smaller than the union it is named for",
+      );
+      continue;
+    }
+    if (!labelBearingDocs.has(document)) {
+      failures.push(
+        `LABEL_BEARING_DOCUMENTS registers ${document}, which yielded no labels; ` +
+          "either it stopped minting labels or this scan stopped reading it",
+      );
+    }
+  }
+  const unregistered = [...labelBearingDocs].filter(
+    (document) => !labelBearingDocuments.includes(document),
+  );
+  if (unregistered.length) {
+    failures.push(
+      `${sorted(unregistered)} mint labels but are not in LABEL_BEARING_DOCUMENTS; ` +
+        "register them, so that adding a specification is an acknowledgement that its labels " +
+        "share one prefix-free namespace with every other document's",
+    );
+  }
+
+  if (labels.size < minimumLabels) {
+    failures.push(
+      `the union holds ${labels.size} label(s), below the floor of ${minimumLabels}; ` +
+        "a scan that reaches almost nothing must not report a pass",
+    );
+  }
+
+  return {
+    failures,
+    labels,
+    collisions,
+    scanned,
+    namespaceMentions: namespaceMentions.size,
+    fixtures: fixtureHits.size,
+    documents: labelBearingDocs.size,
+  };
+}
+
+function describe(sites) {
+  return [...sites.entries()]
+    .sort(([left], [right]) => (left < right ? -1 : 1))
+    .map(([file, lines]) => `${file}:${[...lines].sort((a, b) => a - b)[0]}`)
+    .join(", ");
+}
+
+// ---------------------------------------------------------------------------
+// Self-test
+// ---------------------------------------------------------------------------
+
+/// A minimal tree that passes: two specifications, one crate file, one
+/// registered fixture, one bare namespace mention.
+const CLEAN_TREE = {
+  "docs/spec/ONE.md": [
+    "# One",
+    'label is exactly `"free2z/demo/v1/alpha"`.',
+    '`H("free2z/demo/v1/bravo", x)`',
+    "The namespace is `free2z/demo/v1/` and every leaf lives under it.",
+  ].join("\n"),
+  "docs/spec/TWO.md": [
+    "# Two",
+    '`H("free2z/other/v1/charlie", x)`',
+    '`H("free2z/other/v1/delta", x)`',
+  ].join("\n"),
+  "src/labels.rs": [
+    'pub const LABEL_ALPHA: &[u8] = b"free2z/demo/v1/alpha";',
+    'pub const LABEL_BRAVO: &[u8] = b"free2z/demo/v1/bravo";',
+    'let wrong = b"free2z/demo/v1/alpha2";',
+  ].join("\n"),
+};
+
+const CLEAN_OPTIONS = {
+  fixtures: [
+    {
+      file: "src/labels.rs",
+      token: "free2z/demo/v1/alpha2",
+      reason:
+        "self-test fixture: a wrong label asserted to be rejected. It would collide with " +
+        "free2z/demo/v1/alpha if it were a domain, which is what makes it worth registering.",
+    },
+  ],
+  nonDeclaring: [],
+  labelBearingDocuments: ["docs/spec/ONE.md", "docs/spec/TWO.md"],
+  docsRoot: "docs/",
+  minimumLabels: 4,
+};
+
+/// A file that quotes labels — including one that would collide — and declares
+/// none, standing in for the checker itself.
+const QUOTING_FILE = [
+  "// This tool prints a report about free2z/demo/v1/alpha and would, if it were",
+  '// scanned, appear to mint "free2z/demo/v1/alpha-quoted" as a second domain.',
+].join("\n");
+
+function withTree(tree, body) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "zuu-label-self-test-"));
+  try {
+    for (const [relativeFile, text] of Object.entries(tree)) {
+      const absolute = path.join(root, relativeFile);
+      fs.mkdirSync(path.dirname(absolute), { recursive: true });
+      fs.writeFileSync(absolute, text);
+    }
+    return body(root, Object.keys(tree).sort());
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function run(tree, options = {}) {
+  return withTree(tree, (root, files) =>
+    scanRepository(root, { files, ...CLEAN_OPTIONS, ...options }),
+  );
+}
+
+let cases = 0;
+
+function expectClean(label, tree, options = {}) {
+  const result = run(tree, options);
+  if (result.failures.length) {
+    throw new Error(
+      `self-test FAILED: ${label} should pass, got: ${result.failures.join("; ")}`,
+    );
+  }
+  cases += 1;
+  console.log(`self-test: ${label} passes.`);
+}
+
+function expectDetected(label, tree, pattern, options = {}) {
+  const result = run(tree, options);
+  const joined = result.failures.join("; ");
+  if (!pattern.test(joined)) {
+    throw new Error(
+      `self-test FAILED: ${label} was not detected. Failures: ${joined || "(none)"}`,
+    );
+  }
+  cases += 1;
+  console.log(`self-test: ${label} is detected.`);
+}
+
+/// Replace one file in a fixture tree, refusing a mutation that changed
+/// nothing.
+///
+/// A `String.replace` whose needle does not occur returns the original string
+/// silently, so a negative control built on one can end up asserting that the
+/// *unmutated* tree fails — which is either a false pass or a false failure,
+/// and both look like the check working. This makes that a crash.
+function withFile(tree, relativeFile, mutate) {
+  const before = tree[relativeFile];
+  if (before === undefined) {
+    throw new Error(`self-test bug: no fixture file ${relativeFile}`);
+  }
+  const after = mutate(before);
+  if (after === before) {
+    throw new Error(
+      `self-test bug: the mutation of ${relativeFile} changed nothing`,
+    );
+  }
+  return { ...tree, [relativeFile]: after };
+}
+
+function selfTest() {
+  expectClean("a prefix-free tree", CLEAN_TREE);
+
+  // The property itself, on a fresh label added to a document.
+  expectDetected(
+    "a new label that extends an existing one",
+    withFile(
+      CLEAN_TREE,
+      "docs/spec/ONE.md",
+      (text) => `${text}\n\`H("free2z/demo/v1/alpha-hash", x)\``,
+    ),
+    /"free2z\/demo\/v1\/alpha" is a proper prefix of "free2z\/demo\/v1\/alpha-hash"/,
+  );
+
+  // The historical case, reproduced verbatim rather than in the abstract: this
+  // is the pair #602 found, and the message must name it. A future refactor
+  // that keeps the check green on generic input but stops seeing `sth-hash`
+  // fails here.
+  expectDetected(
+    "the KT.md sth / sth-hash collision, verbatim",
+    {
+      "docs/spec/ONE.md": [
+        "# One",
+        '    opaque label<0..255>;      /* exactly "free2z/kt/v1/sth" */',
+        '    opaque prev_sth_hash[32];  /* H("free2z/kt/v1/sth-hash", tls_codec(prev)) */',
+      ].join("\n"),
+      "docs/spec/TWO.md": [
+        "# Two",
+        '`H("free2z/kt/v1/value", x)`',
+        '`H("free2z/kt/v1/prev", x)`',
+      ].join("\n"),
+    },
+    /"free2z\/kt\/v1\/sth" is a proper prefix of "free2z\/kt\/v1\/sth-hash".*docs\/spec\/ONE\.md:2.*docs\/spec\/ONE\.md:3/,
+    { fixtures: [], minimumLabels: 4 },
+  );
+
+  // A collision that spans two documents is the whole reason this ranges over
+  // the union: neither document is wrong on its own.
+  expectDetected(
+    "a collision between two documents, each internally consistent",
+    withFile(
+      CLEAN_TREE,
+      "docs/spec/TWO.md",
+      (text) => `${text}\n\`H("free2z/demo/v1/alpha-extended", x)\``,
+    ),
+    /"free2z\/demo\/v1\/alpha" is a proper prefix of "free2z\/demo\/v1\/alpha-extended"/,
+  );
+
+  // A collision in Rust that no document mentions is still a collision.
+  expectDetected(
+    "a collision minted only in code",
+    withFile(
+      CLEAN_TREE,
+      "src/labels.rs",
+      (text) => `${text}\npub const X: &[u8] = b"free2z/demo/v1/bravo-2";`,
+    ),
+    /"free2z\/demo\/v1\/bravo" is a proper prefix of "free2z\/demo\/v1\/bravo-2"/,
+  );
+
+  // Fixtures. The registry is file-scoped and self-invalidating.
+  expectDetected(
+    "a fixture token that has left its file",
+    withFile(CLEAN_TREE, "src/labels.rs", (text) =>
+      text.replace('\nlet wrong = b"free2z/demo/v1/alpha2";', ""),
+    ),
+    /FIXTURE_TOKENS excuses "free2z\/demo\/v1\/alpha2" in src\/labels\.rs, which no longer contains it/,
+  );
+  expectDetected(
+    "the same token in a file the registry does not name",
+    withFile(
+      CLEAN_TREE,
+      "docs/spec/TWO.md",
+      (text) => `${text}\n\`H("free2z/demo/v1/alpha2", x)\``,
+    ),
+    /"free2z\/demo\/v1\/alpha" is a proper prefix of "free2z\/demo\/v1\/alpha2"/,
+  );
+  // And an unregistered fixture-shaped token is judged as a label, which is the
+  // point: no heuristic about test files, only the registry.
+  expectDetected(
+    "a wrong-label fixture that nobody registered",
+    withFile(
+      CLEAN_TREE,
+      "src/labels.rs",
+      (text) => `${text}\nlet other = b"free2z/demo/v1/alpha3";`,
+    ),
+    /"free2z\/demo\/v1\/alpha" is a proper prefix of "free2z\/demo\/v1\/alpha3"/,
+  );
+
+  // Whole-file exclusion: the checker's own self-reference, in miniature.
+  expectDetected(
+    "a quoting file that nobody excluded",
+    { ...CLEAN_TREE, "tools/report.mjs": QUOTING_FILE },
+    /"free2z\/demo\/v1\/alpha" is a proper prefix of "free2z\/demo\/v1\/alpha-quoted"/,
+  );
+  expectClean(
+    "a quoting file excluded whole",
+    { ...CLEAN_TREE, "tools/report.mjs": QUOTING_FILE },
+    {
+      nonDeclaring: [
+        { file: "tools/report.mjs", reason: "self-test: quotes, declares nothing" },
+      ],
+    },
+  );
+  expectDetected(
+    "a whole-file exclusion for a file that is no longer tracked",
+    CLEAN_TREE,
+    /NON_DECLARING_FILES excludes tools\/report\.mjs, which is not a tracked file/,
+    {
+      nonDeclaring: [
+        { file: "tools/report.mjs", reason: "self-test: quotes, declares nothing" },
+      ],
+    },
+  );
+
+  // The bare namespace. It must not be a label, and its exclusion must not be
+  // wide enough to swallow a leaf.
+  expectClean(
+    "a bare namespace mention alongside every label under it",
+    withFile(
+      CLEAN_TREE,
+      "docs/spec/TWO.md",
+      (text) => `${text}\nEverything lives under \`free2z/other/v1/\`.`,
+    ),
+  );
+
+  // The coverage anchor, both directions. Narrowing the check to one document
+  // is the mutation it exists to catch.
+  expectDetected(
+    "the check narrowed to a single document",
+    CLEAN_TREE,
+    /LABEL_BEARING_DOCUMENTS registers docs\/spec\/TWO\.md, which yielded no labels|docs\/spec\/TWO\.md mint labels but are not in LABEL_BEARING_DOCUMENTS/,
+    { labelBearingDocuments: ["docs/spec/ONE.md"] },
+  );
+  expectDetected(
+    "a registered document that is no longer tracked",
+    CLEAN_TREE,
+    /LABEL_BEARING_DOCUMENTS registers docs\/spec\/THREE\.md, which is not a tracked file/,
+    {
+      labelBearingDocuments: ["docs/spec/ONE.md", "docs/spec/TWO.md", "docs/spec/THREE.md"],
+    },
+  );
+  expectDetected(
+    "a registered document that has stopped minting labels",
+    withFile(CLEAN_TREE, "docs/spec/TWO.md", () => "# Two\n\nNothing here.\n"),
+    /LABEL_BEARING_DOCUMENTS registers docs\/spec\/TWO\.md, which yielded no labels/,
+  );
+  expectDetected(
+    "a new specification nobody registered",
+    {
+      ...CLEAN_TREE,
+      "docs/spec/THREE.md": '# Three\n`H("free2z/third/v1/echo", x)`\n',
+    },
+    /docs\/spec\/THREE\.md mint labels but are not in LABEL_BEARING_DOCUMENTS/,
+  );
+
+  // The floor. A scan that reaches almost nothing looks exactly like a pass.
+  expectDetected(
+    "a union far below its floor",
+    CLEAN_TREE,
+    /the union holds 4 label\(s\), below the floor of 40/,
+    { minimumLabels: 40 },
+  );
+
+  console.log(`check-hash-domain-labels self-test: ${cases} case(s) passed.`);
+}
+
+const mode = process.argv[2];
+if (mode && mode !== "--self-test") {
+  console.error("usage: node scripts/check-hash-domain-labels.mjs [--self-test]");
+  process.exit(2);
+}
+
+if (mode === "--self-test") {
+  selfTest();
+  process.exit(0);
+}
+
+const result = scanRepository(REPO_ROOT);
+if (result.failures.length) {
+  console.error("Hash-domain label separation failed:");
+  for (const failure of result.failures) console.error(`- ${failure}`);
+  console.error(
+    `${result.failures.length} failure(s) over ${result.labels.size} label(s) ` +
+      `from ${result.scanned} tracked file(s).`,
+  );
+  process.exit(1);
+}
+console.log(
+  `No label is a proper prefix of another: ${result.labels.size} label(s) across ` +
+    `${result.documents} registered document(s) under docs/ and the crates under rs/, ` +
+    `read from ${result.scanned} tracked file(s) ` +
+    `(${result.namespaceMentions} bare namespace mention(s) and ` +
+    `${result.fixtures} registered fixture token(s) excluded).`,
+);


### PR DESCRIPTION
`WIRE.md` §1.3 defines `H(label, x) = BLAKE2b-256(label || x)` with **no
separator and no terminator**. That separates domains only if the label set is
prefix-free. `KT.md`'s was not.

`Closes #602.`

## Red before

`scripts/check-hash-domain-labels.mjs` copied onto a pristine `origin/main`
checkout (`2dffff0`) and run there:

```console
$ git worktree add --detach /tmp/probe602 origin/main
$ cp scripts/check-hash-domain-labels.mjs /tmp/probe602/scripts/
$ cd /tmp/probe602 && git add scripts/check-hash-domain-labels.mjs
$ node scripts/check-hash-domain-labels.mjs
Hash-domain label separation failed:
- "free2z/kt/v1/sth" is a proper prefix of "free2z/kt/v1/sth-hash": H("free2z/kt/v1/sth", "-hash" || y) is bit-identical to H("free2z/kt/v1/sth-hash", y), so those two domains are not separated. free2z/kt/v1/sth at docs/e2ee/KT.md:502; free2z/kt/v1/sth-hash at docs/e2ee/KT.md:508
- LABEL_BEARING_DOCUMENTS registers docs/e2ee/README.md, which yielded no labels; either it stopped minting labels or this scan stopped reading it
2 failure(s) over 30 label(s) from 1389 tracked file(s).
$ echo $?
1
```

The first failure is the defect. The second is an artifact of running this
branch's registry against a tree that predates it — `README.md` gains its first
label reference in this PR — and is itself the coverage anchor doing its job.

## Green after

```console
$ node scripts/check-hash-domain-labels.mjs
No label is a proper prefix of another: 30 label(s) across 7 registered document(s) under docs/ and the crates under rs/, read from 1389 tracked file(s) (1 bare namespace mention(s) and 3 registered fixture token(s) excluded).
$ echo $?
0
```

And the fix is not load-bearing on the fixture — reintroducing the old label on
the real line it lived on brings the failure straight back:

```console
$ sed -i '' '508s|tree-head-hash|sth-hash|' docs/e2ee/KT.md
$ node scripts/check-hash-domain-labels.mjs
Hash-domain label separation failed:
- "free2z/kt/v1/sth" is a proper prefix of "free2z/kt/v1/sth-hash": ... free2z/kt/v1/sth at docs/e2ee/KT.md:502, docs/e2ee/README.md:122, docs/e2ee/WIRE.md:96; free2z/kt/v1/sth-hash at docs/e2ee/KT.md:508
1 failure(s) over 31 label(s) from 1389 tracked file(s).
```

## Verifying the premises

Both held.

**The collision is real, and it is the only one.** Enumerating every
`free2z/<ns>/v<n>[/<leaf>]` token in every tracked file on `origin/main` and
testing all ordered pairs gives 11 prefix relations, of which exactly one is a
defect: `free2z/kt/v1/sth` ≺ `free2z/kt/v1/sth-hash`. The other ten are
`free2z/relay/v1/` (a bare namespace mention in `hash.rs`'s module note, a prefix
of all nine relay labels) and `free2z/relay/v1/cmd` ≺ `free2z/relay/v1/cmd2` (the
negative-control fixture at `transcript.rs:358`). Both are handled below.

**Nothing consumes the KT labels.** `grep -rn 'free2z/kt/v1' rs/` on `origin/main`
returns nothing; `f2z-kt-core` and `f2z-authority` are not merged and `rs/` holds
only `f2z-codec`, `f2z-relay-proto` and one more crate. The rename changes no
shipped digest.

**The set is larger than the issue described.** The issue's `grep` for quoted
`free2z/kt/v1/...` finds 12 labels. The real namespace holds 30, including six
constants with **no leaf** — `free2z/device-credential/v1` (a
`SignedTreeHead`-family signing label in `KT.md` §6.2's closed table),
`free2z/queue-advert/v1`, and the four MLS exporter labels `free2z/queue/v1`,
`free2z/frost/v1`, `free2z/webrtc/v1`, `free2z/history/v1`. A leafless label is a
prefix of *every* leafed label in its namespace, which is the sharpest form of
this defect, so the check covers them. They are prefix-free today.

## Which label was renamed, and why

**`free2z/kt/v1/sth-hash` → `free2z/kt/v1/tree-head-hash`.** The longer one.

- **`sth` is a wire field of five signed structures; `sth-hash` is not.**
  `free2z/kt/v1/sth` is the first-field `label<0..255>` constant of
  `SignedTreeHeadTBS` and a row in `KT.md` §6.2's *closed* transcript table,
  whose other eight rows are all a bare noun matching their TBS struct — `cosig`,
  `receipt`, `entry`, `rotation`, `reset`, `log-key-transition`, `fault`.
  Renaming `sth` would break that table's one visible pattern to fix a problem
  the other member caused. `sth-hash` is a digest label used at three sites and
  named in no table.
- **It removes the prefix relation rather than moving it.** `tree-head-hash`
  shares no prefix with `sth` in either direction. Renaming `sth` to, say,
  `sth-tbs` would have left two labels differing only in their last segment,
  which reads as a near-miss rather than as two domains.
- **It spells out what `sth` abbreviates.** These labels are read by a second
  implementer working from the document alone; `tree-head-hash` is
  self-describing where `sth-hash` needs §6.1 open beside it.

Struct field names (`prev_sth_hash`, `announce_sth_hash`) are unchanged — they
are fields, not domains.

## The normative invariant

`WIRE.md` §1.3 now carries it as a **MUST**, in the section that defines `H`,
scoped to the **union** of every document's labels and extended to the labels
concatenated the same way without `H` (§5.2's `relay_proof` signing prefix, and
the first-field constants of the signed structures). #552 said one sentence would
fix it; this is that sentence plus the derivation and a pointer to the check.

## Correction convention

`docs/e2ee/README.md`'s rule, as #592 phrased it: *a claim that is made true is
fixed in place; a claim that is withdrawn gets a dated correction.* The rename is
neither, so it is decided rather than defaulted, and the two halves go different
ways:

- **`KT.md` §6.1 gets a dated correction (2026-08-24).** `KT.md` is a frozen
  Phase 1 specification. `free2z/kt/v1/sth-hash` was a normative constant, and
  every digest under it is now invalid. An implementer working from the first
  revision must be told, at the point of use, that a value they may have wired is
  withdrawn — a frozen spec has a stronger claim on this treatment than a new
  document precisely because someone may have relied on it. The correction states
  the old label, why it was wrong, the new one, and that any digest under the old
  label MUST be recomputed. It deliberately does not spell the old label as a
  literal token — it names it as "`-hash` appended to `free2z/kt/v1/sth`" — so a
  withdrawn label does not live on in the namespace the checker reads.
- **`WIRE.md` §1.3 is fixed in place, no correction note.** Nothing there is
  withdrawn. Prefix-freeness was always the construction's precondition; §1.3 was
  silent about it, and silence corrected into a MUST is a claim *made true*, not
  a claim retracted.

`README.md`'s Status section records the correction alongside the two Phase 0
ones.

## Where the check lives, and how it reaches the gate

`scripts/check-hash-domain-labels.mjs`, not a Rust test. Three reasons, each
sufficient on its own:

1. **`KT.md` has no crate.** A Rust test could only assert over a hand-copied
   restatement of the document's label set — and a hand-maintained copy drifting
   from its document is the same failure that produced #602.
2. **The collision arrived in a docs-only PR.** `rs.yml`'s detector sets
   `rs=false` for such a diff and every rs job skips, so a Rust test would not
   have run on the commit that broke the invariant.
3. **The labels are minted in prose.** Reading the documents directly means the
   check cannot go stale relative to the spec.

Wiring, stated concretely because this repo has a history of gates that `needs:` a
job without reading its result (#512, #515–#518):

- A **new step** in `rs.yml`'s `changes` job — `Verify hash-domain labels are
  prefix-free across the tree` — running `--self-test` then the bare check. That
  job has no `if:` and runs on every `pull_request`, `merge_group`, `push` to
  `main` and `workflow_dispatch`, so a docs-only PR is judged.
- The same two commands appended to `rs / gate`'s `Recheck the workflow policy`
  step (`id: policy`). The gate's verdict step binds `POLICY_OUTCOME:
  ${{ steps.policy.outcome }}` and exits 1 unless it is `success`. The result is
  consumed, not merely awaited.
- `rs / gate` is one of the two required contexts on `main` (`gate`,
  `rs / gate`), confirmed by `check-workflow-gates.mjs`'s `PROTECTED_CONTEXTS`.
- **A separate step, deliberately.** `scripts/check-github-actions-pins.mjs`
  holds an exact ordered six-command assertion over the `changes` policy step —
  but only for `.github/workflows/zuuli.yml` (`REQUIRED_WORKFLOW_PATH`, applied
  via `gatePolicyFailures`, which `scanRepository` calls for that path alone).
  `rs.yml` is not subject to it. A separate step keeps it that way even if the
  assertion is ever widened, which is why `check-workflow-gates.mjs` and
  `check-rust-toolchain.sh` already have their own steps.

## Fixtures vs. labels — where the line is drawn

By **registration, never by heuristic**. `FIXTURE_TOKENS` names a file, an exact
token and a reason:

| file | token | why it is not a domain |
|---|---|---|
| `f2z-codec/src/transcript.rs:358` | `free2z/relay/v1/cmd2` | negative control, asserted to be rejected by `CommandTranscript::validate` |
| `f2z-codec/tests/wire_vectors.rs:761` | `free2z/relay/v1/cmX` | one-byte corruption of `LABEL_COMMAND`, asserted to fail the §5.1 vector |
| `f2z-relay-proto/src/key.rs:160` | `free2z/relay/v1/dummy` | filler message handed to `verify()` with a zero signature |

Every available heuristic is wrong here, which is the argument for a registry:

- *"It is in a test file"* would drop the **six genuine labels**
  `wire_vectors.rs` pins at lines 271–276 — the authoritative byte-level
  assertion of `WIRE.md`'s label set.
- *"It is not in a `LABELS` array"* is the exact scoping mistake this script
  exists to fix.

The registry cannot loosen into a blanket excuse: it is keyed by **file**, so the
same token elsewhere is judged as a label; and an entry whose token no longer
occurs in its file **fails**, so it cannot outlive review. Proven on the real
tree:

```console
$ sed -i '' 's|b"free2z/relay/v1/cmd2"|b"free2z/relay/v1/wrong"|' rs/crates/f2z-codec/src/transcript.rs
$ node scripts/check-hash-domain-labels.mjs
Hash-domain label separation failed:
- FIXTURE_TOKENS excuses "free2z/relay/v1/cmd2" in rs/crates/f2z-codec/src/transcript.rs, which no longer contains it; remove the entry rather than leaving an unreviewed exclusion in place
```

Two other exclusions, both narrow: a token ending in `/` is a **namespace
mention** (`free2z/relay/v1/` in `hash.rs`'s module note) and not a label — a
leafless name written *without* the slash is still judged as a label, which is
the conservative direction; and the checker's own file is excluded whole via
`NON_DECLARING_FILES`, because it quotes labels it does not mint and invents
fixture labels in reserved `demo`/`other`/`third` namespaces. That exclusion is
load-bearing and self-limiting — its path must be tracked, so renaming the
checker fails rather than silently leaving a file unread. With it emptied the
checker reports seven collisions among its own examples, which is what a
scanned-self looks like.

## Anchor proof

Narrowing the check to a single document is red, not a smaller green:

```console
$ # LABEL_BEARING_DOCUMENTS = ["docs/e2ee/WIRE.md"]
$ node scripts/check-hash-domain-labels.mjs
Hash-domain label separation failed:
- docs/e2ee/ARCHITECTURE.md, docs/e2ee/KT.md, docs/e2ee/README.md, docs/e2ee/THREAT-MODEL.md, docs/e2ee/decisions/0009-queue-addressing-and-binding.md, docs/e2ee/decisions/0010-signing-transcript-and-ack-semantics.md mint labels but are not in LABEL_BEARING_DOCUMENTS; register them, so that adding a specification is an acknowledgement that its labels share one prefix-free namespace with every other document's
1 failure(s) over 30 label(s) from 1389 tracked file(s).
$ echo $?
1
```

The anchor runs both ways: a registered document that yields no labels fails
(a rename or a scan that stops reading Markdown), and a label-bearing document
under `docs/` that is unregistered fails (a new `KT.md`). It fired for real
during this PR — adding the label names to `README.md` turned the check red until
`README.md` was registered. A `MINIMUM_LABELS` floor of 24 catches a scan that
collapses without either condition tripping.

## Self-test

17 cases, following `check-workflow-gates.mjs`'s convention: fixtures judged
against fixture configuration, every negative control a one-line mutation of a
tree that passes. Includes the requested negative control for **this specific
case** — the `sth` / `sth-hash` pair reproduced verbatim, asserting the message
names both labels *and* their line numbers, so a refactor that stays green on
generic input but stops seeing `sth-hash` fails here.

`withFile` throws when a mutation changes nothing, so a negative control built on
a `String.replace` whose needle has drifted cannot silently assert against the
unmutated tree. That caught a real bug in this PR's own self-test.

```console
$ node scripts/check-hash-domain-labels.mjs --self-test
self-test: a prefix-free tree passes.
self-test: a new label that extends an existing one is detected.
self-test: the KT.md sth / sth-hash collision, verbatim is detected.
self-test: a collision between two documents, each internally consistent is detected.
self-test: a collision minted only in code is detected.
self-test: a fixture token that has left its file is detected.
self-test: the same token in a file the registry does not name is detected.
self-test: a wrong-label fixture that nobody registered is detected.
self-test: a quoting file that nobody excluded is detected.
self-test: a quoting file excluded whole passes.
self-test: a whole-file exclusion for a file that is no longer tracked is detected.
self-test: a bare namespace mention alongside every label under it passes.
self-test: the check narrowed to a single document is detected.
self-test: a registered document that is no longer tracked is detected.
self-test: a registered document that has stopped minting labels is detected.
self-test: a new specification nobody registered is detected.
self-test: a union far below its floor is detected.
check-hash-domain-labels self-test: 17 case(s) passed.
```

## `f2z-codec`'s existing guard

Kept, and its scope now stated where it was previously implied. The module note
said the property held of "this fixed set" and pointed at `LABELS` as the
mechanism; it now says the set that matters is the union, names the script that
checks it, and records why the per-crate test is not sufficient — `KT.md`'s
labels were internally prefix-free too.

## Checks run

| command | result |
|---|---|
| `node scripts/check-github-actions-pins.mjs --self-test` | 70 source-policy, 7 gate-verdict, 120 current-workflow cases passed |
| `node scripts/check-github-actions-pins.mjs` | 178 external refs, 15 files — pass |
| `node scripts/check-workflow-gates.mjs --self-test` | 20 cases passed |
| `node scripts/check-workflow-gates.mjs` | 2 gates, 56 jobs, 14 workflow files — pass |
| `scripts/check-rust-toolchain.sh --self-test` | 14 drift cases caught (incl. the #600 census) |
| `scripts/check-rust-toolchain.sh` | channel 1.97.1, MSRV 1.97 — pass |
| `node scripts/check-hash-domain-labels.mjs --self-test` | 17 cases passed |
| `node scripts/check-hash-domain-labels.mjs` | 30 labels, 1389 files — pass |
| `scripts/check-rust-fmt.sh --root rs` | 3 crates formatted |
| `scripts/check-rust-clippy.sh --root rs` | 3 crates clippy-clean |
| `scripts/check-rust-deny.sh --root rs --config rs/deny.toml` | advisories/bans/licenses/sources ok |
| `cargo test --locked --all-targets` + `--doc` | 212 tests + 1 doctest, all pass |

**#477:** bare `[[ ]]` / `(( ))` statements added — **0**. The check is
JavaScript; the workflow additions are plain `run:` command lists with no shell
conditionals.

Related: #552 (the unstated invariant), #592 (the correction rule), #597 (the
coverage-anchor pattern this borrows), #600 (the registration census).
