### PR TITLE
docs(e2ee): bind `same_key` to `identity_pk`; name the first-entry authorization hole

### DIFF
--- a/docs/e2ee/ARCHITECTURE.md
+++ b/docs/e2ee/ARCHITECTURE.md
@@ -1212,6 +1212,23 @@ deliberate.
   portable evidence rather than a local error dialog are all unspecified.
   `KT.md` defines the evidence structures but deliberately does not invent the
   protocol that exchanges them.
+- **S. What authorizes a handle's first directory entry.** Opened 2026-08-24 by
+  [`KT.md` §4.4](./KT.md#44-what-authorizes-an-entry), and **blocking**. §9.2
+  above specifies an append-only log of `(handle → identity key, …)` and does not
+  say who is entitled to a handle; [ADR 0014](./decisions/0014-directory-key-rotation.md)
+  settles authorization for a handle that already has an entry — same-key update,
+  key change, lost key — and takes no position on the first one. `KT.md` §4.4
+  inherited that silence, and as its rules are enumerated they accept a first
+  entry for an unregistered handle from **whoever submits one**. Closing it means
+  deciding who may vouch that a handle belongs to a submitter, whether a log may
+  run with no such authority (a self-hosted log must be able to, under
+  [ADR 0005](./decisions/0005-federation.md)) and whether clients must be told
+  when it does, what binds a vouching artifact to the key being installed, and
+  what a compromise of the vouching key costs. That is a product-and-trust
+  decision of the same weight as ADR 0014's reset authority — which is what
+  [#551](https://github.com/free2z/zuu/issues/551) is open about — so `KT.md`
+  states the option space and deliberately answers none of it.
+  [#594](https://github.com/free2z/zuu/issues/594).
 
 ### 13.1 Closed
 

--- a/docs/e2ee/KT.md
+++ b/docs/e2ee/KT.md
@@ -27,7 +27,9 @@ signature, no cadence and no protocol; §9.3 named the witness role and specifie
 no message. [ADR 0013](./decisions/0013-key-transparency-log.md) settled the
 construction — adopt [`akd`](https://github.com/facebook/akd) — and
 [ADR 0014](./decisions/0014-directory-key-rotation.md) settled what authorizes an
-entry. **Everything between those two decisions and an implementation is
+entry **once a handle already has one** — it distinguishes a same-key update, a
+key change and a lost key, and takes no position on a handle's *first* entry
+(§1.2, §4.4). **Everything between those two decisions and an implementation is
 invented below**, and where a choice was invented rather than inherited it says
 so at the point of use. Nothing here should be read as "the merged docs already
 said this."
@@ -38,7 +40,9 @@ said this."
 
 ### 1.1 What this document fixes
 
-The `DirectoryEntry` structure and its authorization; the `SignedTreeHead` format
+The `DirectoryEntry` structure and its authorization **from the second entry
+onward** — the first entry's authorization is §1.2's first bullet and is not
+fixed here; the `SignedTreeHead` format
 and its signing transcript; log-key rotation; epoch cadence and the maximum merge
 delay; the submission receipt; the witness poll-verify-cosign protocol, its
 state-update ordering and its fault evidence; the `WitnessCosignature` format;
@@ -47,6 +51,14 @@ surface and its stable error codes; and where `akd`'s types sit underneath ours.
 
 ### 1.2 What it deliberately does not fix
 
+- **What authorizes a handle's *first* directory entry.** §4.4 fixes the
+  authorization of every entry that follows one, and **does not fix the first**.
+  This is not a tidy deferral: it is a hole in merged normative text, it is
+  **blocking**, and §4.4 carries a dated correction saying so at the point an
+  implementer would otherwise walk past it. Who may vouch for handle ownership is
+  a product-and-trust decision, not a wire encoding, and inventing one here is
+  exactly the mistake [#551](https://github.com/free2z/zuu/issues/551) is open
+  about. §12, [#594](https://github.com/free2z/zuu/issues/594).
 - **The client gossip protocol.** §9.3 and
   [#311](https://github.com/free2z/zuu/issues/311) make gossip load-bearing — it
   is the only anti-equivocation that functions before independent witnesses
@@ -101,7 +113,7 @@ surface and its stable error codes; and where `akd`'s types sit underneath ours.
 
 | Role | Holds | Reachability | Fails how |
 |---|---|---|---|
-| **Log** | The tree, every entry, the log signing key, the VRF key | Public HTTPS listener | Can equivocate, can withhold, can refuse. Cannot forge an entry (§4.4) or forge a cosignature. |
+| **Log** | The tree, every entry, the log signing key, the VRF key | Public HTTPS listener | Can equivocate, can withhold, can refuse. Cannot forge an entry for a handle that **already has one** (§4.4), and cannot forge a cosignature. What authorizes a handle's **first** entry is open and blocking (§4.4, §12). |
 | **Witness** | Its own signing key, and its last accepted tree head — a few hundred bytes | **Outbound only.** No inbound port, no TLS certificate, no domain, no database | Can refuse to sign, can sign falsely, can cosign without checking (§7.4). Cannot make a client accept a root alone unless *t* = 1. |
 | **Client** | Its own keys, its pinned view of handles it has resolved, its witness policy | Outbound only | Can be lied to if the witness set is not independent. |
 | **Reset authority** | An offline key, per [ADR 0014](./decisions/0014-directory-key-rotation.md) | Not networked | Compromise is compromise of every handle without `no_reset`. |
@@ -378,18 +390,29 @@ Verification rules the log MUST apply, in order, before an entry enters a batch:
    ([`WIRE.md` §3.3](./WIRE.md#33-the-re-encode-equality-rule--mandatory)).
 2. `label`, `kt_version` and `log_id` are exactly this log's.
 3. `handle` matches the charset rule and `entry_version` is `previous + 1` (or 1).
-4. `prev_entry_hash` matches the published previous entry.
+   **The `(or 1)` case is not an authorization rule and MUST NOT be read as one**
+   — see the second correction at the end of this section; what authorizes a
+   handle's *first* entry is open and blocking (§12).
+4. `prev_entry_hash` matches the published previous entry, or is all-zero when
+   `entry_version` is 1 (§4.2).
 5. `authorization.kind == entry.kind`, and the table above holds.
-6. For `key_change`: the `RotationProof`'s `old_identity_pk` equals the previous
+6. For `same_key`: `identity_pk` **MUST equal the previous entry's
+   `identity_pk`.** A `same_key` entry that carries a different one is an
+   identity-key change installed on a single signature — by a key that
+   [ADR 0014](./decisions/0014-directory-key-rotation.md) does not make
+   sufficient to install a new identity — and the log MUST reject it with
+   `ERR_BAD_AUTHORIZATION` (§9.5) rather than treat it as a rotation. This rule
+   constrains `identity_pk` only.
+7. For `key_change`: the `RotationProof`'s `old_identity_pk` equals the previous
    entry's `identity_pk`, its `new_identity_pk` equals this entry's, its
    `entry_version` and `prev_entry_hash` match, and its signature verifies.
    **A key change carrying only one of the two signatures MUST be rejected.**
-7. For `platform_reset`: the reset signature verifies under the pinned reset
+8. For `platform_reset`: the reset signature verifies under the pinned reset
    authority key, `effective_at_ms - created_at_ms` is at least the published
    cooldown, and the log MUST NOT publish the entry before `effective_at_ms`.
-8. Every `DeviceCredential` signature verifies under this entry's `identity_pk`,
+9. Every `DeviceCredential` signature verifies under this entry's `identity_pk`,
    and no two credentials share a `device_pk`.
-9. §4.3's uniqueness rule.
+10. §4.3's uniqueness rule.
 
 **And the thing an implementer must understand about all of that: `akd` enforces
 none of it.** The library will happily commit any bytes to any label. Every rule
@@ -405,7 +428,98 @@ target in the system for our own testing.
 *can* do is refuse a legitimate submission, or publish a
 `platform_reset` — which by [ADR 0014](./decisions/0014-directory-key-rotation.md)
 is loud, delayed and permanently counted, and is a real weakening announced
-rather than hidden.
+rather than hidden. **Read "a live key" strictly**: everything in this paragraph
+is scoped to a handle that already has an entry in the log, and the second
+correction below is why that scope is doing work.
+
+> **Correction (2026-08-24) — rule 6 is new, and the list above was incomplete
+> without it.** As first published, this section's numbered rules never required
+> a `same_key` entry to keep `identity_pk` unchanged. The constraint was implied
+> by the case's *name*, and by
+> [ADR 0014](./decisions/0014-directory-key-rotation.md)'s case 1 — "the identity
+> key is unchanged and available" — but it was absent from the list an
+> implementer is told to apply **in order**, and an implementer applies the list.
+> A conforming implementation of the first revision therefore accepted a
+> `same_key` entry carrying a brand-new `identity_pk` from a party holding only
+> the previous entry's `directory_auth_pk`: an identity change installed on
+> **one** signature, which ADR 0014 requires the log to reject and which rule 7's
+> `RotationProof` exists to prevent. **An implementer working from the first
+> revision must add the check**; two independent implementations
+> ([#584](https://github.com/free2z/zuu/issues/584),
+> [#593](https://github.com/free2z/zuu/issues/593)) inferred the stricter reading
+> and recorded it as an addition, which is how the omission was found
+> ([#594](https://github.com/free2z/zuu/issues/594)).
+>
+> Rule 6 is deliberately narrow. Whether a `same_key` entry may rotate
+> `directory_auth_pk` is **not** stated by this document in either direction, and
+> the new rule does not settle it.
+
+> **Correction (2026-08-24) — nothing in this section authorizes a handle's
+> *first* entry, and the section read as though the table above were
+> exhaustive.** It is not, and the gap is **open and blocking** (§12).
+>
+> Every row of the `auth_signature` table authorizes an entry by reference to a
+> key that some *earlier* state already established: the `directory_auth_pk`
+> published in the previous entry, the outgoing `identity_pk` a previous entry
+> named, or the pinned reset authority acting on a handle someone already holds.
+> At `entry_version == 1` **there is no previous entry and no earlier state.**
+> Rule 3 admits that case explicitly. So the rules above, applied exactly as
+> enumerated, accept a first `DirectoryEntry` for any unregistered handle **from
+> whoever submits one** — first-come-first-served handle claiming, in the
+> document whose entire purpose is that the log cannot lie about who you are
+> talking to ([#133](https://github.com/free2z/zuu/issues/133)).
+>
+> **What an implementer must not do.** Do not read the silence as permission. Do
+> not invent a rule and ship it as though this document specified it. In
+> particular, do not treat a version-1 entry's own `directory_auth_pk` as
+> self-authorizing: a self-signed first entry authenticates **the submitter's
+> key**, never **the submitter's claim to the handle**, and conflating those two
+> statements is the whole of the defect. Until this is decided, any
+> implementation of §4.4 is incomplete by construction and should say so where
+> its users can see it.
+>
+> **What a decision has to settle.** Stated as questions, because this is not a
+> question the specification gets to answer for the project:
+>
+> - **Who may vouch that a handle belongs to a submitter, and against what
+>   record.** On free2z the obvious answer is the platform account system, which
+>   makes the platform the voucher — a trust concentration of the same kind as
+>   [ADR 0014](./decisions/0014-directory-key-rotation.md)'s reset authority, and
+>   one that should be weighed as such rather than adopted because it is
+>   convenient. [#551](https://github.com/free2z/zuu/issues/551) is open because
+>   that comparable authority was created in a specification rather than decided
+>   on the record; this one must not repeat it.
+> - **Whether a log may run with no such authority at all** — which a
+>   self-hosted log must be able to do under
+>   [ADR 0005](./decisions/0005-federation.md) — and, if so, whether a client is
+>   entitled to be *told* that the handles in that log are unvouched. A client
+>   that cannot distinguish a vouched handle from an unvouched one is being shown
+>   a reassuring name for a property it does not have, which is the failure §8.3
+>   refuses for witness counts.
+> - **What binds the vouching to the key being installed**, so that an
+>   intercepted, replayed or reordered vouching artifact cannot install a key
+>   other than the one it was issued for.
+> - **What the log-side bounds are** — validity window, replay scope, rotation of
+>   the vouching key, and what a compromise of it costs. Those bounds are the
+>   terms on which the concentration above is or is not acceptable, so they are
+>   part of the decision and not an implementation detail of it.
+>
+> **A candidate exists and it is unratified.** The owner decision recorded on
+> [#305](https://github.com/free2z/zuu/issues/305) named a signed-assertion
+> submission authority and was never turned into a specification;
+> [#554](https://github.com/free2z/zuu/issues/554)'s brief did not name it, so
+> this document inherited the gap rather than introducing it.
+> [#593](https://github.com/free2z/zuu/issues/593) (branch `feature/kt-authority`)
+> implements a proposed `HandleAssertion` — a short-lived, domain-separated
+> assertion issued by a configured authority, verified alongside a signature by
+> the identity key the assertion is about, with an authority set that supports
+> rotation and an explicitly reported no-authority mode — and offers it as a
+> proposal for this document to catch up with. **Nothing about it is specified
+> here, and no part of it is ratified**: not its fields, not its encoding, not
+> its signing transcript, not its validity rules, and not the semantics of a
+> no-authority mode. Deciding those is a product-and-trust decision, and it is
+> deliberately not taken in this document.
+> [#594](https://github.com/free2z/zuu/issues/594).
 
 ---
 
@@ -899,7 +1013,10 @@ To resolve `@alice`:
 5. `akd_core::verify::lookup::lookup_verify` against `root_hash` and
    `vrf_public_key` from the verified tree head.
 6. Verify the entry's own authorization (§4.4) — the log's proof says the entry
-   is *in the tree*, not that it was *authorized*.
+   is *in the tree*, not that it was *authorized*. **At `entry_version == 1`
+   there is nothing here to verify**: §4.4 does not yet say what authorizes a
+   handle's first entry, so this step establishes nothing about a handle being
+   resolved for the first time. See §4.4's second correction and §12.
 7. Pin `(handle, identity_pk, entry_version, prev_entry_hash, epoch)`.
 
 **A handle that is not registered returns a proof of non-membership, not an
@@ -1003,7 +1120,8 @@ Stated at the point of use, and it is the correction
 | Non-membership of a handle at a root | That a witness actually ran the append-only check (§7.4) |
 | Its own key history, unbroken by version and by hash chain (~2.6 ms) | That the witness set is independent — a social fact ([`THREAT-MODEL.md` §3.9](./THREAT-MODEL.md#39-malicious-directory-witness)) |
 | Monotonicity and the tree-head chain across roots **it has seen** (§6.3) | That the roots it has seen are the roots everyone else was shown |
-| That an entry was authorized under §4.4 | That the log did not refuse someone else's submission |
+| That an entry **after the first** was authorized under §4.4 | That the log did not refuse someone else's submission |
+| — | That a handle's **first** entry came from whoever is entitled to the handle — §4.4 does not say what authorizes `entry_version == 1` (§12) |
 | That a `SubmissionReceipt`'s deadline was met, for its own submissions | That a log which met the deadline did so on the branch everyone else sees |
 
 **A client cannot substitute its own consistency check for a witness's.** There
@@ -1147,7 +1265,7 @@ is never reused** — [`WIRE.md` §10](./WIRE.md#10-error-codes)'s rule, for
 | 1 | `ERR_MALFORMED` | Decode failure, re-encode mismatch, oversize body. |
 | 2 | `ERR_UNSUPPORTED_VERSION` | Unknown `kt_version`, or a `log_id` this server does not serve. |
 | 3 | `ERR_BAD_SIGNATURE` | An `auth_signature`, `RotationProof`, reset or cosignature failed verification. |
-| 4 | `ERR_BAD_AUTHORIZATION` | Structurally valid but §4.4's rules unmet — e.g. a key change with one signature. |
+| 4 | `ERR_BAD_AUTHORIZATION` | Structurally valid but §4.4's rules unmet — e.g. a key change with one signature (rule 7), or a `same_key` entry that changes `identity_pk` (rule 6). |
 | 5 | `ERR_VERSION_CONFLICT` | `entry_version` not `previous + 1`, `prev_entry_hash` mismatch, or a second entry for this handle in this epoch (§4.3). |
 | 6 | `ERR_COOLDOWN` | A `platform_reset` whose `effective_at_ms` has not arrived. |
 | 7 | `ERR_EPOCH_UNAVAILABLE` | The requested epoch or audit range is outside the served horizon (§9.3). |
@@ -1260,6 +1378,20 @@ which is §7.4's structural mitigation and is not merely tidy.
 
 Deliberately, and listed rather than invented.
 
+- **What authorizes a handle's first entry — open, blocking, and not the
+  specification's decision to take.** §4.4's rules authorize `entry_version >= 2`
+  by reference to state a previous entry established, and say **nothing** about
+  `entry_version == 1`; as enumerated they accept a first entry for an
+  unregistered handle from whoever submits one. The second correction in §4.4
+  states the hole, the option space and what a decision has to settle, and
+  deliberately settles none of it: naming a vouching authority for handle
+  ownership is a product-and-trust decision of the same weight as
+  [ADR 0014](./decisions/0014-directory-key-rotation.md)'s reset authority, which
+  [#551](https://github.com/free2z/zuu/issues/551) is open about precisely
+  because it was created in a specification instead. **Until it is decided, an
+  implementation of §4.4 is incomplete by construction.**
+  [#594](https://github.com/free2z/zuu/issues/594),
+  [§13-S](./ARCHITECTURE.md#13-open-questions).
 - **Epoch cadence and maximum merge delay values** —
   [§13-P](./ARCHITECTURE.md#13-open-questions). §5's 600 s / 3,600 s are
   placeholders chosen to make silence detectable, not measured answers.

--- a/docs/e2ee/README.md
+++ b/docs/e2ee/README.md
@@ -35,7 +35,7 @@ deliberately and can be reviewed by a third party.
 | [`THREAT-MODEL.md`](./THREAT-MODEL.md) | Adversaries, what each can do, and for each one the defense — or a plain statement that there is none. Includes the known, accepted limits. |
 | [`WIRE.md`](./WIRE.md) | The relay protocol, specified for a second implementer: transport, framing, canonical serialization, the command set with request/response shapes and stable error codes, the signing transcript, anti-replay, queue lifecycle, ACK semantics, TTLs, padding enforcement, the capability document, first contact, and anti-abuse. Also carries the two resolved pre-checks — the messaging handle charset (§14) and the SimpleX clean-room posture (§15). |
 | [`CLIENT-CONTRACT.md`](./CLIENT-CONTRACT.md) | The client interface, specified for a frontend developer who will not read any Rust: the Tauri command surface (`plugin:f2zmsg\|<cmd>`), why enrollment lives in the app crate rather than the plugin, the `types.ts` / `bridge.ts` / `mock.ts` / `events.ts` boundary and the mechanical mock-covers-bridge parity test, the event set and its ordering guarantees, the engine and four-delivery-state machines, the ordering rule, the closed `ErrorCode` union, the rules that must not be broken, what is deliberately not in v1, and the browser client's durability and handle-eligibility obligations. Field shapes are marked provisional; the backend is being implemented now. |
-| [`KT.md`](./KT.md) | The key-transparency protocol — `WIRE.md`'s analogue for the directory, specified for a second implementer: the `DirectoryEntry` structure and what authorizes it, `SignedTreeHead` and its signing transcript, log-key rotation, epoch cadence and maximum merge delay, the submission receipt, the witness poll-verify-cosign protocol and its fault evidence, the `WitnessCosignature` format, the client threshold rule and fail-closed behaviour, the proof-serving API, and where `akd`'s types sit underneath ours. |
+| [`KT.md`](./KT.md) | The key-transparency protocol — `WIRE.md`'s analogue for the directory, specified for a second implementer: the `DirectoryEntry` structure and what authorizes it — **after the first entry**; what authorizes a handle's first one is named as an open, blocking gap rather than invented — `SignedTreeHead` and its signing transcript, log-key rotation, epoch cadence and maximum merge delay, the submission receipt, the witness poll-verify-cosign protocol and its fault evidence, the `WitnessCosignature` format, the client threshold rule and fail-closed behaviour, the proof-serving API, and where `akd`'s types sit underneath ours. |
 | [`decisions/`](./decisions/) | One ADR per decision, `0001`–`0014`. |
 
 ## The binding decisions
@@ -125,7 +125,26 @@ normative requirement on the **union** of every document's labels, and
 `scripts/check-hash-domain-labels.mjs` enforces it on every pull request
 ([#602](https://github.com/free2z/zuu/issues/602)).
 
-Still open above the relay: `KeyPackage` publication, push notifications, padding
+Two further corrections landed on 2026-08-24, both against
+[`KT.md` §4.4](./KT.md#44-what-authorizes-an-entry)'s authorization rules and
+both found by implementing against them
+([#594](https://github.com/free2z/zuu/issues/594)). The first is **closed**: the
+numbered rules never required a `same_key` entry to leave `identity_pk`
+unchanged, so as enumerated they admitted an identity-key change on **one**
+signature, and that is now rule 6. The second is **open, blocking, and
+deliberately not answered here**: nothing in §4.4 says what authorizes a handle's
+**first** entry, so the rules as written accept a first entry for an unregistered
+handle from whoever submits one. Who may vouch for handle ownership is a
+product-and-trust decision of the same weight as ADR 0014's reset authority —
+which is what [#551](https://github.com/free2z/zuu/issues/551) is open about — so
+§4.4 states the option space, names the unratified candidate *as* a candidate,
+and settles none of it.
+[`THREAT-MODEL.md` §3.1](./THREAT-MODEL.md#31-malicious-or-compromised-free2z-server)
+carries the scoping consequence, and it is
+[`ARCHITECTURE.md` §13-S](./ARCHITECTURE.md#13-open-questions).
+
+Still open above the relay: **what authorizes a handle's first directory entry**,
+`KeyPackage` publication, push notifications, padding
 bucket sizes, the redundancy factor *k*, the client gossip protocol, the witness
 independence criterion and the default *t*, and the KT epoch cadence. All are
 listed in [`ARCHITECTURE.md` §13](./ARCHITECTURE.md#13-open-questions) and in

--- a/docs/e2ee/THREAT-MODEL.md
+++ b/docs/e2ee/THREAT-MODEL.md
@@ -71,7 +71,7 @@ data it stores or relays.
 - **Cannot substitute an identity key undetectably.** The KT directory is an
   append-only log with inclusion and consistency proofs; every client self-audits
   its own handle every epoch and alarms on any key change it did not initiate.
-  An attempted substitution is visible **to the victim**. — **Two corrections
+  An attempted substitution is visible **to the victim**. — **Three corrections
   below narrow this bullet; read them with it.**
 - **Cannot equivocate on the directory without leaving evidence**, once an
   independent witness set exists. Witness cosigning plus client gossip means two
@@ -126,6 +126,28 @@ data it stores or relays.
 > It does not prevent it. A user who ignores the alarm is MITM'd, and a user who
 > set `no_reset` has foreclosed the path entirely at the cost of permanent handle
 > loss on a lost seed.
+
+> **Correction (2026-08-24) — the bullet is scoped to a handle that already has
+> a directory entry, and that qualifier was never written down.** "Substitute an
+> identity key" presupposes a key already published for the handle; self-audit,
+> the alarm and the key-change rules all hang off the entry that key lives in.
+> For a handle with **no** entry yet, none of that machinery has anything to act
+> on, and
+> [`KT.md` §4.4](./KT.md#44-what-authorizes-an-entry) does not say what authorizes
+> a handle's **first** entry — as its rules are enumerated, a first entry is
+> accepted from whoever submits one, including the log itself
+> ([#594](https://github.com/free2z/zuu/issues/594),
+> [§13-S](./ARCHITECTURE.md#13-open-questions)). A server that publishes a first
+> entry for a handle whose owner never enrolled is not *substituting* a key, so
+> the bullet above stays literally true — and a peer who resolves that handle is
+> MITM'd anyway, with no self-audit anywhere to fire, because the person who
+> would audit is not a user of the system. **The bullet is therefore not a claim
+> about unregistered handles and must not be restated as one**, which is exactly
+> the failure the scoping convention in
+> [`README.md`](./README.md) exists to catch; the summary row in §5 has been
+> narrowed to match. What closes the gap is a decision that has not been taken —
+> `KT.md` §4.4 states the option space and answers none of it — so this
+> correction records a limit rather than a fix.
 
 **Not defended.**
 
@@ -637,14 +659,14 @@ open question is
 the claim.** A **Yes** means yes under the conditions that section states, and
 nothing wider. Every correction this document carries has the same cause — a
 property that holds under stated conditions, later restated without them (§3.1,
-twice; §4.10, once) — so where a summary line and a section disagree, the
+three times; §4.10, once) — so where a summary line and a section disagree, the
 section's narrower reading is the one intended.
 
 | Property | ZUULI (native) | Web (WASM) |
 |---|---|---|
 | Server cannot read content | **Yes**, unconditionally | **Only if the served bundle is honest** (§3.6) |
 | Server cannot forge messages | **Yes** | Same caveat |
-| Server cannot MITM the identity | **Yes, and read §3.1's two corrections** — KT inclusion + self-audit catch a substitution; append-only-ness is a *witness* property, not a client one, and it is not real until independent witnesses exist. The ADR 0014 reset path is a loud, delayed, recorded exception. | Same caveat |
+| Server cannot MITM the identity **of a handle that already has a directory entry** | **Yes, and read §3.1's three corrections** — KT inclusion + self-audit catch a substitution; append-only-ness is a *witness* property, not a client one, and it is not real until independent witnesses exist. The ADR 0014 reset path is a loud, delayed, recorded exception. For a handle with **no** entry yet, what authorizes the first one is undecided ([`KT.md` §4.4](./KT.md#44-what-authorizes-an-entry)) and this row claims nothing. | Same caveat |
 | Server cannot MITM WebRTC | **Yes** — in-band fingerprints | Same caveat |
 | Forward secrecy | **Yes** — MLS epochs | Yes, same caveat |
 | Post-compromise security | **Yes** — MLS Updates | Yes, same caveat |


### PR DESCRIPTION
`KT.md` §4.4's numbered rules are the only thing in the system that proves the log did not *make an entry up* — `akd` enforces none of them. As merged the list was incomplete in two ways, and [#594](https://github.com/free2z/zuu/issues/594) found both while implementing against it.

**This PR does the defect-fix half and deliberately leaves the product-decision half open.** `Refs #594` rather than `Closes`.

## What I did

**1. `same_key` MUST NOT change `identity_pk` — now numbered rule 6.**
The constraint was implied by the case's *name* and by ADR 0014's case 1, and absent from the list an implementer is told to apply "in order". As enumerated, a party holding only the previous entry's `directory_auth_pk` could publish a `same_key` entry carrying a brand-new `identity_pk`: an identity change installed on **one** signature, which ADR 0014 requires the log to reject. `f2z-kt-core` (#584) and `f2z-authority` (#593) both inferred the stricter reading; the spec was the thing that was behind. Fixed in place, with a dated correction saying an implementer working from the first revision must add the check.

**2. The `entry_version == 1` hole is stated in the document, as an open blocking question, with dated-correction treatment.**
Every row of the `auth_signature` table authorizes an entry by reference to state a *previous* entry established. At version 1 there is no previous entry, and rule 3 admits the case explicitly — so the rules as written accept a first `DirectoryEntry` for any unregistered handle from whoever submits one. The correction states the hole, says what an implementer must not assume (in particular: a self-signed first entry authenticates the submitter's *key*, never the submitter's *claim to the handle*), lays out what a decision would have to settle as four questions, and describes `feature/kt-authority`'s `HandleAssertion` **as a candidate and as unratified**.

It is now impossible to read §4.4 and not notice: rule 3 carries the pointer, §1.1 no longer claims the document fixes it, §1.2 lists it first, §2's roles table is scoped, §8.1 step 6 and §8.5 say what a client does *not* get at version 1, §12 lists it, and it is `ARCHITECTURE.md` §13-S.

**3. Mechanical inconsistencies found in the same pass.**
- Rule 4 (`prev_entry_hash` matches the published previous entry) never covered the all-zero case at version 1 that §4.1 and §4.2 both specify.
- §2's roles table said the log "cannot forge an entry (§4.4)", unscoped — false for a first entry.
- §8.1 step 6 and §8.5's "client can verify" column claimed verification of an authorization that does not exist at version 1.
- The document intro and §1.1 said ADR 0014 "settled what authorizes an entry"; ADR 0014 distinguishes same-key update / key change / lost key and takes no position on the first entry.
- `ERR_BAD_AUTHORIZATION`'s example list now names rule 6 alongside rule 7.
- `THREAT-MODEL.md` §3.1's "cannot substitute an identity key undetectably" bullet is scoped to a handle that already has an entry, and that qualifier was never written down — a third dated correction, plus the two counters ("two corrections", "§3.1, twice") and §5's summary row updated so the summary does not restate the claim without its scope. This is the failure mode the scoping convention exists to catch.

## What I deliberately did **not** do

The remaining #594 acceptance bullets are one decision, not four, and it is not the specification's to take:

- `HandleAssertion`'s fields, encoding, signing transcript and validity rules — **not specified**.
- The `expires_ms - issued_ms` cap — **not specified** (it is named as one of the bounds a decision has to settle).
- The identity self-signature requirement — **not made normative**; it is described as part of the candidate's structure, not adopted.
- The no-authority mode and its reporting requirement — **not specified**.

[#551](https://github.com/free2z/zuu/issues/551) is open precisely because ADR 0014's reset authority was invented in a specification under a heading disclaiming owner-decision status. Naming who may vouch for handle ownership is the same weight of decision, so it is stated as an option space with the questions a ruling must answer, and none of them is answered.

## Was item 2 writable without implying an answer?

Yes. The option space is genuinely stateable as constraints on *any* answer — binding to the installed key, bounded validity, what a self-hosted log does, whether clients are told — without picking one. The one place it came close was rule 6's scope, so the correction says explicitly that rule 6 constrains `identity_pk` only and that whether a `same_key` entry may rotate `directory_auth_pk` is not stated in either direction. That is a real second gap, left named rather than closed.

## Verification

- `node scripts/check-hash-domain-labels.mjs` — pass (30 labels, 7 registered documents). No label added or renamed: the correction describes the candidate's signing prefix without minting one.
- `node scripts/check-hash-domain-labels.mjs --self-test` — 17 cases pass.
- `scripts/check-public-repo-boundary.sh` — pass. No production measurement, no absolute counts, no private repo or issue reference; the system described is unimplemented, so nothing here describes a live-product weakness.
- Every relative link and `#anchor` across `docs/e2ee/` resolves, including the new `#13-open-questions`, `#44-what-authorizes-an-entry` and `#31-malicious-or-compromised-free2z-server` targets.
- `WIRE.md` untouched — #588 is open and rewrites §5.5/§6.3/§10.
- `.github/workflows/` untouched. Docs only.
- Dates stamped `2026-08-24`, the **local** date of this commit (`-0400`).

Refs #594, #584, #593, #551.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD