### PR TITLE
security(rs): fail the build if any crate verifies Ed25519 non-strictly

### DIFF
--- a/rs/crates/f2z-codec/tests/common/mod.rs
+++ b/rs/crates/f2z-codec/tests/common/mod.rs
@@ -1,0 +1,269 @@
+//! The source walk shared by this crate's workspace-wide source scans.
+//!
+//! # Why this is a module and not a copy in each scan
+//!
+//! `workspace_debug_scan.rs` exists because #572's `Debug` scan resolved its
+//! root from `CARGO_MANIFEST_DIR` and so covered one crate. The fix was a walk
+//! over every crate under `rs/crates/` plus a **coverage anchor** asserting
+//! every crate was reached. When #603 asked for a second workspace-wide scan,
+//! the obvious move was to copy that walk — which is the thing
+//! `workspace_debug_scan.rs`'s own module note rejects in a different guise:
+//! "*n* copies of a scanner drift, and the copy that matters is the one in the
+//! crate whose author did not know to add it".
+//!
+//! Two copies of the enumeration is exactly that failure at file scale: the
+//! anchor's promise is that *the list of crates cannot silently narrow*, and
+//! two lists can narrow independently. So there is one list, here, and both
+//! scans assert against it.
+//!
+//! Cargo does not build `tests/common/mod.rs` as its own test target — only
+//! top-level files in `tests/` become targets — so this is a plain module each
+//! scan declares with `mod common;`.
+
+// Each scan uses a different subset of these helpers, and every integration
+// test is its own crate, so what one does not call is dead code there.
+#![allow(dead_code)]
+// Test code, run on the host by a person reading the failure. The workspace
+// denies these because a panic in the relay's parser is a remote denial of
+// service; neither hazard exists here.
+#![allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+/// One `.rs` file under some workspace crate's `src/`.
+pub struct SourceFile {
+    /// The crate directory name under `rs/crates/`.
+    pub krate: String,
+    /// `<crate>/<path within the crate>`, e.g. `f2z-relay-proto/src/key.rs`.
+    /// This is what a violation names, so it is the path a reader can open.
+    pub label: String,
+    /// The file's contents.
+    pub source: String,
+}
+
+/// `rs/crates/`, resolved from this crate's manifest rather than from the
+/// process CWD so the tests do not depend on where cargo was invoked.
+pub fn crates_root() -> std::path::PathBuf {
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let root = manifest.parent().unwrap().to_path_buf();
+    assert!(
+        root.join("f2z-codec").join("Cargo.toml").is_file(),
+        "{root:?} is not rs/crates/; this test's idea of the workspace layout is stale"
+    );
+    root
+}
+
+/// Every crate directory under `rs/crates/`, by name.
+///
+/// This is the list the scans must cover, and it is read off the filesystem
+/// rather than written down here — a crate added tomorrow appears in it
+/// without anyone editing this file, which is the whole point. `rs/Cargo.toml`
+/// declares `members = ["crates/*"]`, so the glob and this walk agree by
+/// construction.
+pub fn workspace_crates() -> Vec<String> {
+    let mut names: Vec<String> = std::fs::read_dir(crates_root())
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path.join("Cargo.toml").is_file())
+        .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    assert!(
+        names.len() >= 2,
+        "found {} crate(s) under rs/crates/, which is too few to be real: {names:?}",
+        names.len()
+    );
+    names
+}
+
+/// Every `.rs` file under every workspace crate's `src/`, labelled
+/// `<crate>/<path>` so a violation names the crate it is in.
+pub fn source_files() -> Vec<SourceFile> {
+    fn walk(
+        krate: &str,
+        crate_dir: &std::path::Path,
+        dir: &std::path::Path,
+        out: &mut Vec<SourceFile>,
+    ) {
+        let read = std::fs::read_dir(dir);
+        assert!(read.is_ok(), "could not read {dir:?}");
+        let entries = read.unwrap();
+        let mut paths: Vec<std::path::PathBuf> =
+            entries.map(|entry| entry.unwrap().path()).collect();
+        // `read_dir` order is filesystem order. Sorting makes a failure list
+        // reproducible between a developer's machine and CI.
+        paths.sort();
+        for path in paths {
+            if path.is_dir() {
+                walk(krate, crate_dir, &path, out);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                let within = path.strip_prefix(crate_dir).unwrap();
+                out.push(SourceFile {
+                    krate: krate.to_owned(),
+                    label: format!("{krate}/{}", within.to_string_lossy().replace('\\', "/")),
+                    source: std::fs::read_to_string(&path).unwrap(),
+                });
+            }
+        }
+    }
+    let root = crates_root();
+    let mut out = Vec::new();
+    for krate in workspace_crates() {
+        let crate_dir = root.join(&krate);
+        let src = crate_dir.join("src");
+        assert!(
+            src.is_dir(),
+            "{krate} has a Cargo.toml but no src/, so the scan cannot see it"
+        );
+        walk(&krate, &crate_dir, &src, &mut out);
+    }
+    assert!(!out.is_empty(), "found no source files to scan");
+    out
+}
+
+/// Strip a line comment, so a brace inside a doc comment does not confuse the
+/// depth count. Struct bodies contain no string literals, so a naive cut is
+/// safe there and a real parser is not worth the dependency; function bodies
+/// do, which is what [`code_only`] is for.
+pub fn without_comment(line: &str) -> &str {
+    match line.find("//") {
+        Some(index) => &line[..index],
+        None => line,
+    }
+}
+
+/// A line with its string literals, character literals and line comment
+/// removed, so that neither a `{` inside a `format!` nor a `.verify(` inside a
+/// doc comment is read as code.
+///
+/// This is the stricter cousin of [`without_comment`], needed wherever a scan
+/// looks at *function* bodies. It is a lexer, not a parser: a raw string with
+/// an embedded quote (`r#"..."#`) is not modelled, and a block comment is not
+/// modelled. Neither appears in the tree today, and both would make the scan
+/// noisier rather than blinder — a `//`-free `/* ... */` mentioning
+/// `.verify(` would be reported, and the report names a file and a line for a
+/// person to read.
+pub fn code_only(line: &str) -> String {
+    let bytes: Vec<char> = line.chars().collect();
+    let mut out = String::with_capacity(line.len());
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let current = bytes[index];
+        if current == '/' && bytes.get(index + 1) == Some(&'/') {
+            break;
+        }
+        if current == '"' {
+            index += 1;
+            while index < bytes.len() {
+                if bytes[index] == '\\' {
+                    index += 2;
+                    continue;
+                }
+                if bytes[index] == '"' {
+                    index += 1;
+                    break;
+                }
+                index += 1;
+            }
+            // Leave a placeholder so `"a".len()` does not become `.len()`
+            // glued to whatever preceded the literal.
+            out.push('_');
+            continue;
+        }
+        // A character literal, distinguished from a lifetime by the closing
+        // quote: `'a'` and `'\n'` are literals, `'a` in `&'a str` is not.
+        if current == '\'' {
+            let escaped = bytes.get(index + 1) == Some(&'\\');
+            let closing = if escaped { index + 3 } else { index + 2 };
+            if bytes.get(closing) == Some(&'\'') {
+                out.push('_');
+                index = closing + 1;
+                continue;
+            }
+        }
+        out.push(current);
+        index += 1;
+    }
+    out
+}
+
+/// True when `haystack` contains `needle` as a whole identifier — not as part
+/// of a longer one. `CommandVerifier` does not contain the identifier
+/// `Verifier`, and `verify_strict` does not contain `verify`.
+pub fn contains_identifier(haystack: &str, needle: &str) -> bool {
+    identifier_positions(haystack, needle).next().is_some()
+}
+
+/// Byte offsets at which `needle` appears in `haystack` as a whole identifier.
+pub fn identifier_positions<'a>(
+    haystack: &'a str,
+    needle: &'a str,
+) -> impl Iterator<Item = usize> + 'a {
+    haystack.match_indices(needle).filter_map(move |(at, _)| {
+        let before_ok = haystack[..at]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !is_identifier_char(c));
+        let after = at + needle.len();
+        let after_ok = haystack[after..]
+            .chars()
+            .next()
+            .is_none_or(|c| !is_identifier_char(c));
+        (before_ok && after_ok).then_some(at)
+    })
+}
+
+/// Whether `c` can appear inside a Rust identifier.
+pub fn is_identifier_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// The half-open line ranges covered by `#[cfg(test)]` items.
+///
+/// Used to hold the registered exemptions in the strict-verification scan to
+/// test code: a deliberate non-strict call is a fixture proving what plain
+/// verification accepts, and a fixture lives under `#[cfg(test)]`. An
+/// exemption that drifted into a shipped code path would stop matching this
+/// and the scan would refuse it.
+pub fn cfg_test_ranges(source: &str) -> Vec<(usize, usize)> {
+    let lines: Vec<String> = source.lines().map(code_only).collect();
+    let mut ranges = Vec::new();
+    let mut index = 0usize;
+    while index < lines.len() {
+        if !lines[index].contains("#[cfg(test)]") {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        // Walk forward to the item's opening brace, then to its match.
+        let mut depth = 0i32;
+        let mut opened = false;
+        let mut cursor = index;
+        while cursor < lines.len() {
+            let line = &lines[cursor];
+            depth += i32::try_from(line.matches('{').count()).unwrap();
+            depth -= i32::try_from(line.matches('}').count()).unwrap();
+            if line.contains('{') {
+                opened = true;
+            }
+            cursor += 1;
+            if opened && depth <= 0 {
+                break;
+            }
+        }
+        if opened {
+            ranges.push((start, cursor));
+        }
+        index = cursor.max(start + 1);
+    }
+    ranges
+}
+
+/// Whether `line` (a zero-based line index) sits inside a `#[cfg(test)]` item.
+pub fn in_cfg_test(ranges: &[(usize, usize)], line: usize) -> bool {
+    ranges
+        .iter()
+        .any(|(start, end)| line >= *start && line < *end)
+}

--- a/rs/crates/f2z-codec/tests/workspace_debug_scan.rs
+++ b/rs/crates/f2z-codec/tests/workspace_debug_scan.rs
@@ -95,84 +95,9 @@ struct DerivedDebugItem {
     body: String,
 }
 
-/// `rs/crates/`, resolved from this crate's manifest rather than from the
-/// process CWD so the test does not depend on where cargo was invoked.
-fn crates_root() -> std::path::PathBuf {
-    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let root = manifest.parent().unwrap().to_path_buf();
-    assert!(
-        root.join("f2z-codec").join("Cargo.toml").is_file(),
-        "{root:?} is not rs/crates/; this test's idea of the workspace layout is stale"
-    );
-    root
-}
+mod common;
 
-/// Every crate directory under `rs/crates/`, by name.
-///
-/// This is the list the scan must cover, and it is read off the filesystem
-/// rather than written down here — a crate added tomorrow appears in it
-/// without anyone editing this file, which is the whole point. `rs/Cargo.toml`
-/// declares `members = ["crates/*"]`, so the glob and this walk agree by
-/// construction.
-fn workspace_crates() -> Vec<String> {
-    let mut names: Vec<String> = std::fs::read_dir(crates_root())
-        .unwrap()
-        .map(|entry| entry.unwrap().path())
-        .filter(|path| path.join("Cargo.toml").is_file())
-        .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
-        .collect();
-    names.sort();
-    assert!(
-        names.len() >= 2,
-        "found {} crate(s) under rs/crates/, which is too few to be real: {names:?}",
-        names.len()
-    );
-    names
-}
-
-/// Every `.rs` file under every workspace crate's `src/`, labelled
-/// `<crate>/<file>` so a violation names the crate it is in.
-fn source_files() -> Vec<(String, String)> {
-    fn walk(krate: &str, dir: &std::path::Path, out: &mut Vec<(String, String)>) {
-        let read = std::fs::read_dir(dir);
-        assert!(read.is_ok(), "could not read {dir:?}");
-        let entries = read.unwrap();
-        for entry in entries {
-            let path = entry.unwrap().path();
-            if path.is_dir() {
-                walk(krate, &path, out);
-            } else if path.extension().is_some_and(|ext| ext == "rs") {
-                let name = path.file_name().unwrap().to_string_lossy().into_owned();
-                out.push((
-                    format!("{krate}/{name}"),
-                    std::fs::read_to_string(&path).unwrap(),
-                ));
-            }
-        }
-    }
-    let root = crates_root();
-    let mut out = Vec::new();
-    for krate in workspace_crates() {
-        let src = root.join(&krate).join("src");
-        assert!(
-            src.is_dir(),
-            "{krate} has a Cargo.toml but no src/, so the scan cannot see it"
-        );
-        walk(&krate, &src, &mut out);
-    }
-    assert!(!out.is_empty(), "found no source files to scan");
-    out
-}
-
-/// Strip a line comment, so a brace inside a doc comment does not confuse the
-/// depth count. Struct bodies contain no string literals, so a naive cut is
-/// safe here and a real parser is not worth the dependency.
-fn without_comment(line: &str) -> &str {
-    match line.find("//") {
-        Some(index) => &line[..index],
-        None => line,
-    }
-}
+use common::{source_files, without_comment, workspace_crates};
 
 /// Collect every `struct`/`enum` in `source` whose derive list contains `Debug`.
 fn derived_debug_items(file: &str, source: &str) -> Vec<DerivedDebugItem> {
@@ -284,16 +209,15 @@ fn no_type_derives_debug_while_holding_raw_bytes() {
     // `f2z-codec`'s `frame.rs` may be typed with an alias declared in its
     // `types.rs`, and a field in another crate may be typed with either.
     let mut spellings: Vec<String> = RAW_BYTE_TYPES.iter().map(|raw| (*raw).to_owned()).collect();
-    for (_, source) in &sources {
-        spellings.extend(raw_byte_aliases(source));
+    for file in &sources {
+        spellings.extend(raw_byte_aliases(&file.source));
     }
 
-    for (file, source) in &sources {
-        let krate = file.split('/').next().unwrap().to_owned();
-        if !crates_reached.contains(&krate) {
-            crates_reached.push(krate);
+    for file in &sources {
+        if !crates_reached.contains(&file.krate) {
+            crates_reached.push(file.krate.clone());
         }
-        for item in derived_debug_items(file, source) {
+        for item in derived_debug_items(&file.label, &file.source) {
             for raw in &spellings {
                 // The declaration line itself is excluded from the search only
                 // for the tuple-struct case, where it *is* the body; matching

--- a/rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs
+++ b/rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs
@@ -1,0 +1,881 @@
+//! No crate in the `rs/` workspace may verify an Ed25519 signature
+//! non-strictly.
+//!
+//! # The defect this exists for
+//!
+//! `ed25519_dalek`'s plain `verify` is the uncofactored `R' == R` comparison.
+//! `verify_strict` screens a small-order `A` and a small-order `R` first.
+//! Measured in this tree (ed25519-dalek 3.0.0 / curve25519-dalek 5.0.0), with
+//! `A` the identity point — little-endian `0x01` then 31 zero bytes — and
+//! `sig = A || [0u8; 32]`:
+//!
+//! ```text
+//! ed25519 verify        -> ACCEPTS 64/64 distinct messages
+//! ed25519 verify_strict -> REJECTS all 64
+//! ```
+//!
+//! That is a **universal forgery key**: one public key whose single signature
+//! validates against any message, for which nobody knows — or needs — a
+//! private key. `WIRE.md` §5.1 step 5 compares `signer_key` against the key
+//! registered for an address, so a key that verifies everything steals every
+//! queue it is registered against.
+//!
+//! # Why a scan and not a fixture
+//!
+//! Because the fixture is the thing that failed. #589 found
+//! `f2z-relay-proto`'s `small_order_keys_are_rejected_by_strict_verification`
+//! used an **all-zero signature**, which *both* functions reject, so the test
+//! passed whether or not strict verification was in use; #597 fixed it. #603
+//! then found `f2z-authority` had independently written the same inert
+//! fixture, where the end-to-end consequence is `admit` returning
+//! `Ok(AdmittedHandle)` for a handle claimed with no private key at all.
+//!
+//! Two crates, written separately, reproduced the same mistake, because the
+//! mistake is natural: an all-zero signature *looks* like the degenerate case
+//! you would test, and it *does* fail, so the test goes green and reads as
+//! correct. A third fixture would be a third chance to write it wrong. This
+//! scan does not ask whether a fixture is convincing; it asks whether the
+//! non-strict function is *reachable from the source at all*.
+//!
+//! # Where the line between "safe" and "non-strict" is drawn
+//!
+//! Naively grepping for `.verify(` produces three hits in this workspace that
+//! are all **correct** — `hello.rs`, `capabilities.rs` and `command.rs` each
+//! call `f2z_relay_proto::key::VerifyingKey::verify`, the crate's own wrapper,
+//! which calls `verify_strict` inside. A check that cries wolf on correct code
+//! gets silenced, and then it protects nothing. So the scan does not look at
+//! `.verify(` as a spelling. It draws the line in three places, and each is
+//! anchored so that it cannot quietly stop matching:
+//!
+//! 1. **The trait-import gate.** `ed25519_dalek::VerifyingKey` has **no
+//!    inherent `verify`** — the method comes only from
+//!    `impl Verifier<ed25519::Signature> for VerifyingKey`
+//!    (`ed25519-dalek-3.0.0/src/verifying.rs:567`), and Rust requires a trait
+//!    to be in scope to call its methods, through a `.` receiver or through a
+//!    `Type::method` path alike. So a file that never names a `Verifier`
+//!    trait *cannot* call plain Ed25519 verification. [`VERIFIER_TRAITS`]
+//!    therefore flags the *name*, anywhere in the file, rather than the call:
+//!    that survives `as _`, `as VK`, a re-export under another name (the
+//!    re-export itself names it), and the fully-qualified
+//!    `<K as ed25519_dalek::Verifier<S>>::verify(…)` form, which needs no
+//!    import at all. A glob import of any module whose path mentions
+//!    `ed25519` or `signature` is flagged too, since that is the one way the
+//!    trait arrives unnamed. All four spellings were tried against this scan
+//!    and all four are caught; what is *not* caught is a third-party crate
+//!    re-exporting the trait under a different name, because then no file here
+//!    ever writes `Verifier`.
+//!
+//! 2. **The non-strict entry points that need no trait.** `verify_prehashed`,
+//!    `verify_stream`, `verify_batch`, `multipart_verify`, `verify_digest` and
+//!    `raw_verify` are reachable without importing anything, and none of them
+//!    screens small-order points. They are matched by name, as whole
+//!    identifiers, so `verify_prehashed_strict` is not confused for
+//!    `verify_prehashed`. Most sit behind `digest`/`hazmat`/`batch` features
+//!    this workspace disables, which feature unification can turn back on
+//!    without anybody editing a manifest here.
+//!
+//! 3. **The receiver rule.** A binding, or a struct field, whose type is
+//!    `ed25519_dalek::VerifyingKey`, followed by `.verify(` on it — plus the
+//!    fully-qualified spellings `ed25519_dalek::VerifyingKey::verify(` and
+//!    `Verifier::verify(`. This is what gives a violation a line number rather
+//!    than an import to go and read, and it is what catches the mutation #589
+//!    demonstrated: `self.0.verify_strict(…)` becoming `self.0.verify(…)`
+//!    inside the wrapper itself.
+//!
+//! And the wrapper is not *assumed* safe. [`WORKSPACE_VERIFY_FNS`] registers
+//! every `fn verify…` defined under `rs/crates/*/src/` together with what
+//! makes it strict, and the registration is checked against the source: the
+//! one at the bottom must contain `verify_strict` in its body, and every other
+//! must delegate to a registered one. An unregistered `fn verify…` fails the
+//! scan by name — the #609 shape, where narrowing the list is louder than
+//! leaving it alone, rather than a list that silently covers less.
+//!
+//! # What this cannot catch
+//!
+//! Stated plainly, as `workspace_debug_scan.rs` states its own:
+//!
+//! - **Another crate's non-strict Ed25519.** The rules name `ed25519_dalek`.
+//!   A different Ed25519 implementation, wrapping non-strict verification
+//!   behind its own type, would pass. `ed25519-dalek` is the workspace's only
+//!   signature dependency today and `rs/Cargo.lock` is committed, so this is a
+//!   change a reviewer would see; it is not a change this scan would report.
+//! - **A macro that generates the call.** Nothing here expands macros.
+//! - **A receiver whose type is inferred through a function return.**
+//!   `let k = decode(bytes); k.verify(…)` where `decode` returns a dalek key
+//!   is not resolved. Rule 1 still catches it — the file must import
+//!   `Verifier` for that call to compile — which is why the gate is on the
+//!   import and not only on the call.
+//! - **Anything outside a crate's `src/`.** `tests/`, `benches/`, `examples/`
+//!   and a `build.rs` are walked by nothing here — demonstrated, not assumed:
+//!   a `use ed25519_dalek::Verifier as _;` plus a `key.verify(…)` added to
+//!   `f2z-relay-proto/tests/properties.rs` leaves this scan green. That is
+//!   deliberate rather than an oversight: none of those is compiled into the
+//!   library a relay links, so a non-strict call there cannot reach
+//!   `CommandVerifier::verify` or an `admit`-style authorization boundary, and
+//!   the inert *fixture* half of #603 is a different check with a different
+//!   remedy. Widening the walk would also mean widening the exemption rule,
+//!   since an integration test's fixture is not inside a `#[cfg(test)]` item.
+//! - **Anything outside `rs/crates/`.** The wallet's Rust is a different
+//!   toolchain, a different lockfile, and a different lint set.
+//!
+//! A `cargo test -p f2z-relay-proto` alone will not run this. `cargo test
+//! --locked --all-targets` from `rs/`, which is what `rs / tests` runs, will.
+//!
+//! # Why it lives in `f2z-codec/tests/`
+//!
+//! Same three-way choice `workspace_debug_scan.rs` made, and the same answer:
+//! a copy in every crate drifts and is missing from the crate that needs it, a
+//! crate that exists only to host it costs a manifest and a `rs/deny.toml`
+//! entry and a toolchain registration for zero production code, and
+//! `f2z-codec` is the root of the workspace dependency graph. It shares that
+//! scan's crate walk outright (`tests/common/mod.rs`) so the two coverage
+//! anchors cannot narrow independently of each other.
+//!
+//! It is a Rust test and not a `scripts/` checker — unlike
+//! `check-hash-domain-labels.mjs`, whose subject lives partly in Markdown that
+//! `rs.yml`'s change detector would skip. This scan's subject is Rust source
+//! under `rs/crates/`, so any diff that could introduce a violation selects
+//! `rs=true` by construction.
+
+// Test code, run on the host by a person reading the failure. The workspace
+// denies these because a panic in the relay's parser is a remote denial of
+// service; neither hazard exists here.
+#![allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::panic
+)]
+
+mod common;
+
+use common::{
+    cfg_test_ranges, code_only, contains_identifier, identifier_positions, in_cfg_test,
+    source_files, workspace_crates,
+};
+
+/// Trait names whose presence in a `use` makes non-strict Ed25519
+/// verification callable in that file.
+///
+/// `Verifier` is the one that matters: it is `signature::Verifier`, which
+/// `ed25519_dalek` re-exports (`lib.rs:294`) and which `ed25519::signature`
+/// re-exports too, so the path is not a reliable signal but the imported name
+/// is. The other three are the same hazard through the multipart, prehashed
+/// and streaming impls on the same type.
+///
+/// Matched as whole identifiers, so `CommandVerifier` — this workspace's own
+/// type, imported by two test files — is not a hit.
+const VERIFIER_TRAITS: &[&str] = &[
+    "Verifier",
+    "MultipartVerifier",
+    "DigestVerifier",
+    "StreamVerifier",
+];
+
+/// Non-strict Ed25519 verification entry points that need no trait import.
+///
+/// Every one of these skips the small-order screen that `verify_strict` and
+/// `verify_prehashed_strict` perform. Matched as whole identifiers followed by
+/// a call, so `verify_prehashed_strict(` is not read as `verify_prehashed(`.
+const NON_STRICT_ENTRY_POINTS: &[&str] = &[
+    "verify_prehashed",
+    "verify_stream",
+    "verify_batch",
+    "multipart_verify",
+    "verify_digest",
+    "raw_verify",
+];
+
+/// Fully-qualified spellings of a plain `verify` on a dalek key, which name no
+/// local binding for the receiver rule to track.
+const QUALIFIED_NON_STRICT_CALLS: &[&str] = &[
+    "ed25519_dalek::VerifyingKey::verify(",
+    "Verifier::verify(",
+    "as Verifier>::verify(",
+];
+
+/// A deliberate non-strict call, registered with the reason it is not a
+/// defect.
+///
+/// This is the escape hatch, and it is deliberately awkward: an entry names a
+/// file and the exact text of the line, it must still match something (a stale
+/// entry fails the scan, so the list cannot outlive what it excuses), and it
+/// must sit inside `#[cfg(test)]` — a fixture proving what plain verification
+/// accepts is the only honest reason to call it, and a fixture lives in a test
+/// module. An entry that drifted into a shipped code path stops being covered
+/// and the scan refuses it.
+struct Registered {
+    /// The `<crate>/<path>` label, as [`common::SourceFile`] spells it.
+    file: &'static str,
+    /// Text that must appear on the flagged line.
+    line: &'static str,
+    /// Why this is not the defect.
+    why: &'static str,
+}
+
+/// The registered deliberate non-strict calls in this workspace.
+///
+/// Both entries are `f2z-relay-proto`'s universal-forgery fixture from #597 —
+/// the test that asserts plain `verify` **accepts** the identity-point forgery
+/// for 64 distinct messages and that the crate's wrapper **rejects** it. That
+/// test cannot be written without calling the non-strict function, and a
+/// fixture that could not call it would be back to asserting nothing, which is
+/// the #589 defect exactly.
+///
+/// They double as this scan's positive control: if either stops matching, the
+/// scanner has stopped seeing the one call in the tree it is known to be able
+/// to see, and it fails rather than passing with nothing found.
+const REGISTERED_NON_STRICT: &[Registered] = &[
+    Registered {
+        file: "f2z-relay-proto/src/key.rs",
+        line: "use ed25519_dalek::Verifier as _;",
+        why: "the #597 universal-forgery fixture must call plain `verify` to assert it \
+              ACCEPTS the identity-point forgery; without that half the test would pass \
+              for a reason unrelated to strictness, which is #589",
+    },
+    Registered {
+        file: "f2z-relay-proto/src/key.rs",
+        line: "raw.verify(&message, &dalek_signature).is_ok(),",
+        why: "the call itself, inside that fixture's assertion",
+    },
+];
+
+/// The `.verify(` call sites in this workspace that a naive grep flags and
+/// that are **correct** — each calls `f2z_relay_proto::key::VerifyingKey`'s
+/// wrapper, which calls `verify_strict` inside (and
+/// [`WORKSPACE_VERIFY_FNS`] holds it to that).
+///
+/// They are registered as *negative* controls. A check that cries wolf on
+/// correct code gets silenced, and then it protects nothing, so "these three
+/// are not flagged" is asserted rather than observed once. Each entry names a
+/// text that must still be in the file, so a control cannot go vacuous by the
+/// call it guards being deleted.
+const SAFE_WRAPPER_CALL_SITES: &[(&str, &str)] = &[
+    ("f2z-relay-proto/src/hello.rs", ".verify("),
+    (
+        "f2z-relay-proto/src/capabilities.rs",
+        "key.verify(&signing_bytes(",
+    ),
+    (
+        "f2z-relay-proto/src/command.rs",
+        "verifying_key.verify(&transcript.signing_bytes()?",
+    ),
+];
+
+/// What makes one of this workspace's own `verify` functions strict.
+enum Strictness {
+    /// Its body calls `verify_strict` and contains no non-strict entry point.
+    /// There is exactly one of these, and it is the whole basis for the rest.
+    CallsVerifyStrict,
+    /// Its body calls a registered strict verifier, named `<file>::<fn>`.
+    DelegatesTo(&'static str),
+}
+
+/// A `fn verify…` defined under `rs/crates/*/src/`, and why it is strict.
+struct VerifyFn {
+    /// The `<crate>/<path>` label.
+    file: &'static str,
+    /// The function name as written after `fn`.
+    name: &'static str,
+    /// What holds it to strict verification.
+    strictness: Strictness,
+}
+
+/// Every `fn verify…` in the workspace, registered.
+///
+/// This is what answers "why is `key.verify(…)` in `capabilities.rs` not a
+/// finding?" mechanically rather than by trust. The scan enumerates the
+/// definitions from the source and requires the two lists to match exactly, so
+/// a crate that lands a new `fn verify_signature` fails by name until somebody
+/// says what makes it strict — and the entry at the bottom of every delegation
+/// chain is checked against the source, so the mutation #589 demonstrated
+/// (`verify_strict` → `verify` in the wrapper) turns this red from another
+/// crate.
+const WORKSPACE_VERIFY_FNS: &[VerifyFn] = &[
+    VerifyFn {
+        file: "f2z-relay-proto/src/key.rs",
+        name: "verify",
+        strictness: Strictness::CallsVerifyStrict,
+    },
+    VerifyFn {
+        file: "f2z-relay-proto/src/capabilities.rs",
+        name: "verify",
+        strictness: Strictness::DelegatesTo("f2z-relay-proto/src/key.rs::verify"),
+    },
+    VerifyFn {
+        file: "f2z-relay-proto/src/command.rs",
+        name: "verify",
+        strictness: Strictness::DelegatesTo("f2z-relay-proto/src/key.rs::verify"),
+    },
+    VerifyFn {
+        file: "f2z-relay-proto/src/hello.rs",
+        name: "verify_hello_response",
+        strictness: Strictness::DelegatesTo("f2z-relay-proto/src/key.rs::verify"),
+    },
+];
+
+/// A flagged line: where it is, what it says, and which rule caught it.
+struct Finding {
+    file: String,
+    line_number: usize,
+    text: String,
+    rule: String,
+    line_index: usize,
+}
+
+impl Finding {
+    fn render(&self) -> String {
+        format!(
+            "{}:{}: {} — {}",
+            self.file,
+            self.line_number,
+            self.rule,
+            self.text.trim()
+        )
+    }
+}
+
+/// Join a `use` item that spans several lines into one string, so a brace-list
+/// import is scanned as the single statement it is.
+///
+/// Returns, for each `use` statement, the index of its first line and the
+/// whole statement's code with comments and literals removed.
+fn use_statements(source: &str) -> Vec<(usize, String)> {
+    let lines: Vec<String> = source.lines().map(code_only).collect();
+    let mut out = Vec::new();
+    let mut index = 0usize;
+    while index < lines.len() {
+        let trimmed = lines[index].trim_start();
+        if !(trimmed.starts_with("use ") || trimmed.starts_with("pub use ")) {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        let mut statement = String::new();
+        while index < lines.len() {
+            statement.push(' ');
+            statement.push_str(lines[index].trim());
+            index += 1;
+            if statement.contains(';') {
+                break;
+            }
+        }
+        out.push((start, statement));
+    }
+    out
+}
+
+/// The local names under which `ed25519_dalek::VerifyingKey` is reachable in
+/// this file: always the full path, plus whatever an import binds it to.
+///
+/// One level, like `workspace_debug_scan.rs`'s alias resolution: an alias of
+/// an alias is not followed, and is stated rather than papered over. Rule 1
+/// covers the residue — the call still needs the trait.
+fn dalek_key_names(source: &str) -> Vec<String> {
+    let mut names = vec!["ed25519_dalek::VerifyingKey".to_owned()];
+    for (_, statement) in use_statements(source) {
+        let Some(at) = statement.find("ed25519_dalek::VerifyingKey") else {
+            continue;
+        };
+        let rest = &statement[at + "ed25519_dalek::VerifyingKey".len()..];
+        let tail = rest.trim_start();
+        if let Some(alias) = tail.strip_prefix("as ") {
+            let bound = alias
+                .trim()
+                .split([',', ';', '}', ' '])
+                .next()
+                .unwrap_or_default();
+            if !bound.is_empty() && bound != "_" {
+                names.push(bound.to_owned());
+            }
+        } else {
+            names.push("VerifyingKey".to_owned());
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Receiver expressions in this file that are known to be an
+/// `ed25519_dalek::VerifyingKey`: `let` bindings built from one, and struct
+/// fields declared as one (reached as `self.<field>`, `self.0` for a
+/// tuple struct).
+fn dalek_receivers(source: &str) -> Vec<String> {
+    let names = dalek_key_names(source);
+    let mut receivers = Vec::new();
+    for line in source.lines() {
+        let code = code_only(line);
+        let trimmed = code.trim();
+        let mentions_dalek_key = names.iter().any(|name| {
+            if name.contains("::") {
+                code.contains(name.as_str())
+            } else {
+                contains_identifier(&code, name)
+            }
+        });
+        if !mentions_dalek_key {
+            continue;
+        }
+
+        // `let raw = ed25519_dalek::VerifyingKey::from_bytes(..)` and
+        // `let raw: ed25519_dalek::VerifyingKey = ..`.
+        if let Some(rest) = trimmed.strip_prefix("let ") {
+            let binding = rest
+                .trim_start_matches("mut ")
+                .split([':', ' ', '=', ';', ')'])
+                .next()
+                .unwrap_or_default()
+                .trim();
+            if !binding.is_empty() {
+                receivers.push(binding.to_owned());
+            }
+            continue;
+        }
+
+        // A tuple struct's single field: `pub struct VerifyingKey(ed25519_dalek::VerifyingKey);`
+        if trimmed.contains("struct ") && trimmed.contains('(') {
+            receivers.push("self.0".to_owned());
+            continue;
+        }
+
+        // A named field: `inner: ed25519_dalek::VerifyingKey,`
+        if let Some((head, _)) = trimmed.split_once(':')
+            && !head.contains('(')
+            && !head.contains(' ')
+            && !head.is_empty()
+            && head.chars().all(common::is_identifier_char)
+        {
+            receivers.push(format!("self.{head}"));
+        }
+    }
+    receivers.sort();
+    receivers.dedup();
+    receivers
+}
+
+/// Each physical line's code with any method chain it continues glued to the
+/// front of it.
+///
+/// `rustfmt` breaks a chain across lines, so the wrapper's own call is written
+///
+/// ```text
+/// self.0
+///     .verify_strict(message, &signature)
+/// ```
+///
+/// and the text `self.0.verify(` never appears in the file even when the call
+/// is `self.0.verify(…)`. A receiver rule that matched physical lines would
+/// therefore miss the exact mutation #589 demonstrated. The reported line
+/// stays the physical one the call sits on, so a failure points at the code.
+fn chained_lines(source: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut carry = String::new();
+    for line in source.lines() {
+        let code = code_only(line);
+        let trimmed = code.trim().to_owned();
+        let logical = if trimmed.starts_with('.') {
+            format!("{carry}{trimmed}")
+        } else {
+            trimmed
+        };
+        carry = logical.clone();
+        out.push(logical);
+    }
+    out
+}
+
+/// Every non-strict Ed25519 finding in one file.
+fn findings_in(label: &str, source: &str) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let lines: Vec<&str> = source.lines().collect();
+
+    let mut push = |line_index: usize, rule: String| {
+        findings.push(Finding {
+            file: label.to_owned(),
+            line_number: line_index + 1,
+            text: lines
+                .get(line_index)
+                .copied()
+                .unwrap_or_default()
+                .to_owned(),
+            rule,
+            line_index,
+        });
+    };
+
+    // Rule 1a: the trait gate. The name may not appear in workspace source at
+    // all — not in a `use`, not in a `<T as ed25519_dalek::Verifier<S>>::`
+    // qualification, not in an `impl`. Naming the trait is the only thing that
+    // makes the non-strict method callable, and a rule about the *name* rather
+    // than about the `use` also covers the fully-qualified form, which needs
+    // no import.
+    for (index, line) in source.lines().enumerate() {
+        let code = code_only(line);
+        for trait_name in VERIFIER_TRAITS {
+            if contains_identifier(&code, trait_name) {
+                push(
+                    index,
+                    format!(
+                        "names the `{trait_name}` trait, which is the only thing that makes \
+                         `ed25519_dalek`'s non-strict verification callable. Nothing in this \
+                         workspace should need it outside a fixture"
+                    ),
+                );
+            }
+        }
+    }
+
+    // Rule 1b: a glob import that could carry one of those traits in without
+    // naming it. Any `::*` whose path mentions ed25519 or signature counts,
+    // rather than a fixed list of paths — `ed25519_dalek::*`,
+    // `signature::prelude::*` and `ed25519_dalek::ed25519::signature::*` all
+    // re-export the same trait, and enumerating re-export paths is a game the
+    // scan would lose.
+    for (at, statement) in use_statements(source) {
+        if !statement.contains("::*") {
+            continue;
+        }
+        let lowered = statement.to_ascii_lowercase();
+        if lowered.contains("ed25519") || lowered.contains("signature") {
+            push(
+                at,
+                "glob-imports a module that re-exports the `Verifier` trait, bringing \
+                 non-strict Ed25519 verification into scope without naming it"
+                    .to_owned(),
+            );
+        }
+    }
+
+    let receivers = dalek_receivers(source);
+    let chained = chained_lines(source);
+    for (index, line) in lines.iter().enumerate() {
+        let code = code_only(line);
+        let logical = chained.get(index).cloned().unwrap_or_default();
+
+        // Rule 2: entry points that need no trait import.
+        for entry in NON_STRICT_ENTRY_POINTS {
+            let called = identifier_positions(&code, entry).any(|at| {
+                let after = &code[at + entry.len()..];
+                after.starts_with('(') || after.starts_with("::<")
+            });
+            if called {
+                push(
+                    index,
+                    format!(
+                        "calls `{entry}`, an Ed25519 entry point that does not screen \
+                         small-order points"
+                    ),
+                );
+            }
+        }
+
+        // Rule 3: a plain `verify` on something known to be a dalek key.
+        for qualified in QUALIFIED_NON_STRICT_CALLS {
+            // The chain is consulted for the receiver, but the finding is only
+            // raised on the physical line the call is written on, so a chain
+            // continuing past it is not reported a second time.
+            if logical.contains(qualified) && code.contains("verify(") {
+                push(
+                    index,
+                    format!("calls `{qualified}`, `ed25519_dalek`'s non-strict verification"),
+                );
+            }
+        }
+        for receiver in &receivers {
+            if logical.contains(&format!("{receiver}.verify(")) && code.contains(".verify(") {
+                push(
+                    index,
+                    format!(
+                        "calls `.verify(` on `{receiver}`, which this file declares as an \
+                         `ed25519_dalek::VerifyingKey`; that is the non-strict function. Use \
+                         `verify_strict`"
+                    ),
+                );
+            }
+        }
+    }
+
+    findings
+}
+
+/// The body of `fn <name>` in `source`, from its declaration to the matching
+/// close brace, with comments and literals removed.
+fn function_body(source: &str, name: &str) -> Option<String> {
+    let lines: Vec<String> = source.lines().map(code_only).collect();
+    let declaration = lines.iter().position(|line| {
+        let Some(at) = line.find("fn ") else {
+            return false;
+        };
+        let after = &line[at + 3..];
+        identifier_positions(after, name)
+            .next()
+            .is_some_and(|start| start == 0 && after[name.len()..].starts_with(['(', '<']))
+    })?;
+
+    let mut body = String::new();
+    let mut depth = 0i32;
+    let mut opened = false;
+    for line in lines.iter().skip(declaration) {
+        body.push_str(line);
+        body.push('\n');
+        depth += i32::try_from(line.matches('{').count()).unwrap();
+        depth -= i32::try_from(line.matches('}').count()).unwrap();
+        if line.contains('{') {
+            opened = true;
+        }
+        if opened && depth <= 0 {
+            return Some(body);
+        }
+    }
+    None
+}
+
+/// Every `fn verify…` defined in `source`, as `(name, line number)`, skipping
+/// `#[test]` functions — a test named `verify_refuses_…` is not a verification
+/// API and registering four of them would only teach a reader to ignore the
+/// list.
+fn verify_fn_definitions(source: &str) -> Vec<(String, usize)> {
+    let lines: Vec<String> = source.lines().map(code_only).collect();
+    let mut out = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        let Some(at) = line.find("fn ") else {
+            continue;
+        };
+        let after = line[at + 3..].trim_start();
+        if !after.starts_with("verify") {
+            continue;
+        }
+        let name: String = after
+            .chars()
+            .take_while(|c| common::is_identifier_char(*c))
+            .collect();
+        if name == "verify" || name.starts_with("verify_") {
+            let is_test = lines[..index]
+                .iter()
+                .rev()
+                .take_while(|previous| {
+                    let trimmed = previous.trim();
+                    trimmed.is_empty() || trimmed.starts_with('#')
+                })
+                .any(|previous| previous.contains("#[test]"));
+            if !is_test {
+                out.push((name, index + 1));
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn no_crate_verifies_ed25519_signatures_non_strictly() {
+    let sources = source_files();
+    let mut crates_reached: Vec<String> = Vec::new();
+    let mut violations: Vec<String> = Vec::new();
+    let mut matched_registrations = vec![false; REGISTERED_NON_STRICT.len()];
+
+    for file in &sources {
+        if !crates_reached.contains(&file.krate) {
+            crates_reached.push(file.krate.clone());
+        }
+        let test_ranges = cfg_test_ranges(&file.source);
+        for finding in findings_in(&file.label, &file.source) {
+            let registered = REGISTERED_NON_STRICT
+                .iter()
+                .position(|entry| entry.file == finding.file && finding.text.contains(entry.line));
+            match registered {
+                Some(at) => {
+                    matched_registrations[at] = true;
+                    assert!(
+                        in_cfg_test(&test_ranges, finding.line_index),
+                        "{}:{} is registered in REGISTERED_NON_STRICT but no longer sits \
+                         inside a #[cfg(test)] item. A deliberate non-strict verification is \
+                         only defensible as a fixture; this one now compiles into the crate.",
+                        finding.file,
+                        finding.line_number
+                    );
+                }
+                None => violations.push(finding.render()),
+            }
+        }
+    }
+
+    // The coverage anchor, and the reason #597 gave this shape a name: a crate
+    // added under `rs/crates/` must be *reached*, not merely listed. The
+    // failure it replaces was a scan that quietly stopped at one crate's
+    // boundary while still passing.
+    let mut expected = workspace_crates();
+    expected.sort();
+    crates_reached.sort();
+    assert_eq!(
+        crates_reached, expected,
+        "the scan did not reach every crate under rs/crates/. A crate outside it is a crate \
+         where a non-strict Ed25519 verification goes unnoticed — which is #603 exactly."
+    );
+
+    // The detection anchor. A scanner that silently matched nothing would pass
+    // forever, and the tree contains one call it is known to be able to see.
+    for (index, entry) in REGISTERED_NON_STRICT.iter().enumerate() {
+        assert!(
+            matched_registrations[index],
+            "REGISTERED_NON_STRICT names `{}` in {} but the scan did not flag it. It is \
+             registered because {}. Either that fixture is gone — in which case nothing is \
+             testing the distinction any more — or this scanner has stopped recognising a \
+             non-strict call.",
+            entry.line, entry.file, entry.why
+        );
+    }
+
+    assert!(
+        violations.is_empty(),
+        "non-strict Ed25519 verification in the rs/ workspace. Plain `verify` accepts a \
+         signature under the identity point for *every* message; `verify_strict` rejects it. \
+         Use `verify_strict`, or register a test-only fixture in REGISTERED_NON_STRICT with \
+         a reason:\n  {}",
+        violations.join("\n  ")
+    );
+}
+
+#[test]
+fn every_verify_function_in_the_workspace_is_registered_as_strict() {
+    let sources = source_files();
+    let mut crates_reached: Vec<String> = Vec::new();
+    let mut found: Vec<(String, String, usize)> = Vec::new();
+
+    for file in &sources {
+        if !crates_reached.contains(&file.krate) {
+            crates_reached.push(file.krate.clone());
+        }
+        for (name, line) in verify_fn_definitions(&file.source) {
+            found.push((file.label.clone(), name, line));
+        }
+    }
+
+    let mut expected = workspace_crates();
+    expected.sort();
+    crates_reached.sort();
+    assert_eq!(
+        crates_reached, expected,
+        "the registry census did not reach every crate under rs/crates/, so a crate could \
+         define an unregistered `verify` without this failing."
+    );
+
+    // Every definition must be registered …
+    let unregistered: Vec<String> = found
+        .iter()
+        .filter(|(file, name, _)| {
+            !WORKSPACE_VERIFY_FNS
+                .iter()
+                .any(|entry| entry.file == file && entry.name == name)
+        })
+        .map(|(file, name, line)| format!("{file}:{line}: fn {name}"))
+        .collect();
+    assert!(
+        unregistered.is_empty(),
+        "these verification functions are not registered in WORKSPACE_VERIFY_FNS, so nothing \
+         says what makes them strict:\n  {}",
+        unregistered.join("\n  ")
+    );
+
+    // … and every registration must still exist, so the list cannot be
+    // narrowed to whatever still passes.
+    let missing: Vec<String> = WORKSPACE_VERIFY_FNS
+        .iter()
+        .filter(|entry| {
+            !found
+                .iter()
+                .any(|(file, name, _)| file == entry.file && name == entry.name)
+        })
+        .map(|entry| format!("{}::{}", entry.file, entry.name))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "WORKSPACE_VERIFY_FNS registers functions that no longer exist, so the registry has \
+         drifted from the source it is supposed to describe:\n  {}",
+        missing.join("\n  ")
+    );
+
+    // The bottom of every delegation chain is checked against the source.
+    for entry in WORKSPACE_VERIFY_FNS {
+        let file = sources
+            .iter()
+            .find(|source| source.label == entry.file)
+            .unwrap_or_else(|| panic!("{} is registered but was not walked", entry.file));
+        let body = function_body(&file.source, entry.name).unwrap_or_else(|| {
+            panic!(
+                "could not read the body of {}::{}; this scanner has stopped parsing the source",
+                entry.file, entry.name
+            )
+        });
+        match entry.strictness {
+            Strictness::CallsVerifyStrict => {
+                assert!(
+                    contains_identifier(&body, "verify_strict"),
+                    "{}::{} is registered as calling `verify_strict` and its body no longer \
+                     does. Every other verification in this workspace delegates to it, so this \
+                     is a universal forgery away from `admit`-style authorization returning Ok \
+                     for a key nobody holds. See #589, #597, #603.",
+                    entry.file,
+                    entry.name
+                );
+            }
+            Strictness::DelegatesTo(target) => {
+                let (target_file, target_name) = target.rsplit_once("::").unwrap();
+                assert!(
+                    WORKSPACE_VERIFY_FNS
+                        .iter()
+                        .any(|other| other.file == target_file
+                            && other.name == target_name
+                            && matches!(other.strictness, Strictness::CallsVerifyStrict)),
+                    "{}::{} delegates to {target}, which is not registered as a strict \
+                     verifier",
+                    entry.file,
+                    entry.name
+                );
+                assert!(
+                    body.contains(".verify("),
+                    "{}::{} is registered as delegating to {target} and its body contains no \
+                     call to it, so the registration describes something that is not there.",
+                    entry.file,
+                    entry.name
+                );
+            }
+        }
+    }
+
+    assert!(
+        found.len() >= WORKSPACE_VERIFY_FNS.len(),
+        "the scanner found {} verification functions, fewer than the {} registered; it is no \
+         longer reading the source",
+        found.len(),
+        WORKSPACE_VERIFY_FNS.len()
+    );
+}
+
+#[test]
+fn the_crates_own_strict_wrapper_is_not_mistaken_for_ed25519_dalek() {
+    let sources = source_files();
+    for (label, needle) in SAFE_WRAPPER_CALL_SITES {
+        let file = sources
+            .iter()
+            .find(|source| source.label == *label)
+            .unwrap_or_else(|| panic!("{label} is a registered safe call site but was not walked"));
+        assert!(
+            file.source.contains(needle),
+            "{label} no longer contains `{needle}`, so this negative control proves nothing. \
+             Either the call moved — repoint the control — or the strict wrapper is no longer \
+             used there, which is the thing to look at."
+        );
+        let findings = findings_in(&file.label, &file.source);
+        assert!(
+            findings.is_empty(),
+            "{label} calls this workspace's own strict wrapper and the scan flagged it \
+             anyway. A check that cries wolf on correct code gets deleted:\n  {}",
+            findings
+                .iter()
+                .map(Finding::render)
+                .collect::<Vec<_>>()
+                .join("\n  ")
+        );
+    }
+}


### PR DESCRIPTION
Refs #603. This is the **workspace-wide half** only — #603's other half is
`f2z-authority`'s own fixture, and `f2z-authority` lives on the unmerged
`feature/kt-authority` branch, so it cannot be fixed from `main`. The point of
landing this half first is that when that crate arrives, its defect is caught
**on arrival** rather than rediscovered a third time.

`rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs`, three tests,
plus `tests/common/mod.rs` — the crate walk, now shared with
`workspace_debug_scan.rs` instead of copied.

## 1. Green on unmodified `main`, and the three correct call sites are not flagged

A naive grep for `.verify(` produces three hits on `main` today, and **all
three are correct** — each calls `f2z_relay_proto::key::VerifyingKey::verify`,
the crate's own wrapper, which calls `verify_strict` inside (`key.rs:72`):

```
rs/crates/f2z-relay-proto/src/hello.rs:270          identity.verify(…)
rs/crates/f2z-relay-proto/src/capabilities.rs:206   key.verify(…)
rs/crates/f2z-relay-proto/src/command.rs:679        verifying_key.verify(…)
```

A check that cries wolf on correct code gets silenced, and then it protects
nothing — so "these three are not flagged" is a **test**, not an observation:
`the_crates_own_strict_wrapper_is_not_mistaken_for_ed25519_dalek` registers
each one, asserts the call text is still in the file (so the control cannot go
vacuous by the call being deleted) and asserts the scan reports **zero**
findings for it.

```
$ cd rs && cargo test --locked --all-targets
test result: ok. 49 passed   # f2z-codec lib
test result: ok. 7  passed   # padding
test result: ok. 9  passed   # f2z-codec redaction
test result: ok. 7  passed   # reencode_equality
test result: ok. 42 passed   # wire_vectors
test result: ok. 1  passed   # workspace_debug_scan
test result: ok. 3  passed   # workspace_strict_verification_scan   <- new
test result: ok. 83 passed   # f2z-relay-proto lib
test result: ok. 6  passed   # properties
test result: ok. 8  passed   # f2z-relay-proto redaction

$ cargo test --locked --test workspace_strict_verification_scan
test every_verify_function_in_the_workspace_is_registered_as_strict ... ok
test the_crates_own_strict_wrapper_is_not_mistaken_for_ed25519_dalek ... ok
test no_crate_verifies_ed25519_signatures_non_strictly ... ok
```

`--all-targets` 212 → **215** (+3). `--doc` 2 → **2**.

## 2. Where the wrapper/`ed25519_dalek` line is drawn, and why there

The scan never matches `.verify(` as a spelling. Three rules, and each rests on
a fact about the dependency rather than on a naming convention.

**Rule 1 — the trait gate.** `ed25519_dalek::VerifyingKey` has **no inherent
`verify`**. The method exists only through
`impl Verifier<ed25519::Signature> for VerifyingKey`
(`ed25519-dalek-3.0.0/src/verifying.rs:567`), and Rust requires a trait to be
in scope to call its methods — through a `.` receiver *or* a `Type::method`
path. `verify_strict` is inherent (`verifying.rs:367`); `verify` is not. So a
file that never names a `Verifier` trait **cannot** call plain Ed25519
verification, whatever it calls its variables.

The rule therefore flags the *name* — `Verifier`, `MultipartVerifier`,
`DigestVerifier`, `StreamVerifier`, matched as whole identifiers so
`CommandVerifier` is not a hit — anywhere in the file, not just in a `use`.
Flagging the name rather than the import is what covers the fully-qualified
`<K as ed25519_dalek::Verifier<S>>::verify(…)` form, which needs no import at
all. A glob import of any module whose path mentions `ed25519` or `signature`
is flagged too, since that is the one way the trait can arrive unnamed.

**Rule 2 — the entry points that need no trait.** `verify_prehashed`,
`verify_stream`, `verify_batch`, `multipart_verify`, `verify_digest`,
`raw_verify`. None screens small-order points and none needs an import.
Matched as whole identifiers *followed by a call*, so `verify_prehashed_strict`
is not mistaken for `verify_prehashed`. Most sit behind `digest`/`hazmat`/
`batch`, which this workspace disables — and which feature unification can turn
back on without anybody editing a manifest here.

**Rule 3 — the receiver rule.** A `let` binding or a struct field whose type is
`ed25519_dalek::VerifyingKey` (one level of alias resolved, as
`workspace_debug_scan.rs` does for `type Blob = Vec<u8>`), followed by
`.verify(` on it. This is what turns a violation into a **line number**.

It reads method chains, which matters more than it sounds: `rustfmt` writes the
wrapper as

```rust
self.0
    .verify_strict(message, &signature)
```

so the text `self.0.verify(` never appears even when the call *is*
`self.0.verify(…)`. A physical-line matcher would have missed the exact
mutation #589 demonstrated. (It did, in the first draft — see §4.)

**And the wrapper is not assumed safe.** `WORKSPACE_VERIFY_FNS` registers every
`fn verify…` defined under `rs/crates/*/src/` with what makes it strict, and
checks the registration against the source: `key.rs::verify` is
`CallsVerifyStrict` and its body must contain `verify_strict`; the other three
are `DelegatesTo` and must contain a call to it. An **unregistered** `fn verify…`
fails by name, and a registration whose function no longer exists fails too —
the #609 shape, where narrowing the list is louder than leaving it alone.

That registry is why the three grep hits in §1 are provably fine rather than
taken on trust: they call a function this test holds to `verify_strict`.

## 3. Red when a violation is introduced, in another crate

The test is hosted in `f2z-codec`; the violation goes in **`f2z-relay-proto`**.
Real, compiling code (`cargo build --locked -p f2z-relay-proto` succeeds), added
to `capabilities.rs` — *not* `key.rs`, which is where the registered fixture
lives:

```rust
pub fn verify_legacy_capabilities(signed: &SignedCapabilities, identity: &PublicKey) -> Result<()> {
    use ed25519_dalek::Verifier as _;
    let raw = ed25519_dalek::VerifyingKey::from_bytes(identity.as_bytes())…?;
    let sig = ed25519_dalek::Signature::from_bytes(signed.signature.as_bytes());
    raw.verify(&signing_bytes(&signed.capabilities)?, &sig)…
}
```

All three tests go red, naming file and line:

```
---- no_crate_verifies_ed25519_signatures_non_strictly ----
non-strict Ed25519 verification in the rs/ workspace. …
  f2z-relay-proto/src/capabilities.rs:215: names the `Verifier` trait, which is the only
    thing that makes `ed25519_dalek`'s non-strict verification callable. … — use ed25519_dalek::Verifier as _;
  f2z-relay-proto/src/capabilities.rs:219: calls `.verify(` on `raw`, which this file declares
    as an `ed25519_dalek::VerifyingKey`; that is the non-strict function. Use `verify_strict`
    — raw.verify(&signing_bytes(&signed.capabilities)?, &sig)

---- every_verify_function_in_the_workspace_is_registered_as_strict ----
these verification functions are not registered in WORKSPACE_VERIFY_FNS, so nothing says
what makes them strict:
  f2z-relay-proto/src/capabilities.rs:211: fn verify_legacy_capabilities
```

### And red on the mutation #589/#603 are actually about

`key.rs:72`, `verify_strict` → `verify` — the landed line printed back before
the run was judged:

```
BEFORE line 72: '            .verify_strict(message, &signature)'
AFTER  line 72: '            .verify(message, &signature)'
```

Two independent rules fire, from a different crate:

```
---- no_crate_verifies_ed25519_signatures_non_strictly ----
  f2z-relay-proto/src/key.rs:72: calls `.verify(` on `self.0`, which this file declares as an
    `ed25519_dalek::VerifyingKey`; that is the non-strict function. Use `verify_strict`

---- every_verify_function_in_the_workspace_is_registered_as_strict ----
f2z-relay-proto/src/key.rs::verify is registered as calling `verify_strict` and its body no
longer does. Every other verification in this workspace delegates to it, so this is a universal
forgery away from `admit`-style authorization returning Ok for a key nobody holds.
```

### The escape hatch cannot be moved into shipped code

`REGISTERED_NON_STRICT` has two entries, both the #597 universal-forgery
fixture, which *must* call plain `verify` to assert it **accepts** the
identity-point forgery. Each entry must still match something — a stale entry
fails — and each must sit inside a `#[cfg(test)]` item. Hoisting the registered
`use ed25519_dalek::Verifier as _;` from the test module (line 254) to module
scope (line 27):

```
f2z-relay-proto/src/key.rs:27 is registered in REGISTERED_NON_STRICT but no longer sits inside
a #[cfg(test)] item. A deliberate non-strict verification is only defensible as a fixture;
this one now compiles into the crate.
```

Those two entries are also the scan's **detection anchor**: if either stops
matching, the scan fails rather than passing with nothing found.

## 4. The anchor: red on the anchor, not green with a smaller count

`workspace_debug_scan.rs`'s walk and `workspace_crates()` now live in
`tests/common/mod.rs` and both scans assert against **one** list. That is the
same argument that file makes about copies of a scanner, applied at file scale:
the anchor's promise is that the crate list cannot silently narrow, and two
lists can narrow independently.

**Narrowing the walk** (`source_files()` filtered to `f2z-codec`, list left
intact) — this is #589 item 3's original defect exactly:

```
---- no_crate_verifies_ed25519_signatures_non_strictly ----
assertion `left == right` failed: the scan did not reach every crate under rs/crates/. A crate
outside it is a crate where a non-strict Ed25519 verification goes unnoticed — which is #603 exactly.
  left: ["f2z-codec"]
 right: ["f2z-codec", "f2z-relay-proto"]

---- every_verify_function_in_the_workspace_is_registered_as_strict ----
assertion `left == right` failed: the registry census did not reach every crate under rs/crates/…
  left: ["f2z-codec"]
 right: ["f2z-codec", "f2z-relay-proto"]

---- the_crates_own_strict_wrapper_is_not_mistaken_for_ed25519_dalek ----
f2z-relay-proto/src/hello.rs is a registered safe call site but was not walked

test result: FAILED. 0 passed; 3 failed
```

`workspace_debug_scan.rs` goes red on the same mutation, from the same shared
list. **Narrowing the list itself** hits the floor guard instead — also red,
never a smaller green:

```
found 1 crate(s) under rs/crates/, which is too few to be real: ["f2z-codec"]
```

## 5. Trying to defeat it — what it catches, and what it does not

Three attempts, all compiled (`cargo build --locked -p f2z-relay-proto`), all
in one module, **all caught**:

| attempt | caught by |
|---|---|
| `use ed25519_dalek::VerifyingKey as VK;` + `use ed25519_dalek::Verifier as Checker;` + `Checker::verify(&k, …)` | rule 1, at the import — the alias is written *after* the name |
| `<ed25519_dalek::VerifyingKey as ed25519_dalek::Verifier<…>>::verify(…)` with **no import at all** | rule 1, at the call — the name is on the line |
| `use ed25519_dalek::ed25519::signature::*;` then `k.verify(…)` — a re-export path no fixed list would contain | rule 1b (any `::*` whose path mentions `ed25519`/`signature`) **and** rule 3 on `k` |

```
f2z-relay-proto/src/capabilities.rs:214: names the `Verifier` trait … — use ed25519_dalek::Verifier as Checker;
f2z-relay-proto/src/capabilities.rs:227: names the `Verifier` trait … — <ed25519_dalek::VerifyingKey as ed25519_dalek::Verifier<ed25519_dalek::Signature>>::verify(
f2z-relay-proto/src/capabilities.rs:237: glob-imports a module that re-exports the `Verifier` trait … — use ed25519_dalek::ed25519::signature::*;
f2z-relay-proto/src/capabilities.rs:243: calls `.verify(` on `k`, which this file declares as an `ed25519_dalek::VerifyingKey` …
```

### What it does not catch — demonstrated, not guessed

- **Anything outside a crate's `src/`.** Not a claim, a measurement: adding
  `use ed25519_dalek::Verifier as _;` and `key.verify(b"anything", &sig)` to
  `f2z-relay-proto/tests/properties.rs` leaves the scan **green**. This is a
  deliberate boundary — `tests/`, `benches/`, `examples/` and `build.rs` are
  not compiled into the library a relay links, so a non-strict call there
  cannot reach `CommandVerifier::verify` or an `admit`-style authorization
  boundary, and the inert-*fixture* half of #603 is a different check with a
  different remedy. Widening the walk would also mean widening the exemption
  rule, since an integration test's fixture is not inside a `#[cfg(test)]` item.
  It is stated in the file's own module note.
- **A third-party crate re-exporting the trait under a different name.**
  `use some_dep::Checker;` where `some_dep` did `pub use ed25519_dalek::Verifier
  as Checker;` — then no file *here* ever writes `Verifier`. A re-export
  *within* this workspace is caught, because the re-export line names it.
- **Another Ed25519 implementation entirely.** The rules name `ed25519_dalek`.
  It is the workspace's only signature dependency and `rs/Cargo.lock` is
  committed, so adding another is a change a reviewer sees — it is not a change
  this scan reports.
- **A macro that generates the call.** Nothing here expands macros. In practice
  `macro_rules!` needs the trait in scope at the *expansion* site and a
  fully-qualified path inside the macro still writes `Verifier`, so both are
  caught today; a proc macro is not, and that is not something a text scan can
  promise.
- **A receiver typed through a function return** (`let k = decode(b); k.verify(…)`)
  is not resolved by rule 3 — rule 1 still catches it, which is why the gate is
  on the trait and not only on the call.

## Also run

```
scripts/check-rust-fmt.sh --root rs                 All 3 Rust crate(s) under rs/ are formatted
scripts/check-rust-clippy.sh --root rs              All 3 Rust crate(s) under rs/ are clippy-clean
scripts/check-rust-deny.sh --root rs --config rs/deny.toml
                                                    advisories ok, bans ok, licenses ok, sources ok
scripts/check-rust-toolchain.sh                     channel 1.97.1, MSRV 1.97
scripts/check-rust-toolchain.sh --self-test         self-test: 14 drift case(s) caught
node scripts/check-workflow-gates.mjs               2 gate(s), 56 job(s), 14 workflow file(s)
node scripts/check-hash-domain-labels.mjs           30 label(s) across 7 registered document(s)
```

`clippy::panic` is allowed in the new test file, beside the `unwrap_used` /
`indexing_slicing` / `arithmetic_side_effects` allowances
`workspace_debug_scan.rs` already carries and for the same reason: this is host
test code read by a person, not the relay's parser.

The toolchain **registration census** (#600) is unaffected — this adds test
files to an existing crate, no manifest and no `rust-toolchain.toml`.
`rs/deny.toml`'s `akd` / `akd_core` `<0.13.0` bans are **untouched**, as is
`.github/workflows/zuuli.yml` (`git diff origin/main` over both: empty).

**#477:** bare `[[ ]]` / `(( ))` statements added: **0** — no shell script is
touched by this change.
