### PR TITLE
test(wallet): mutation-prove Zcash send behavior

### DIFF
--- a/scripts/check-librustzcash-compat.mjs
+++ b/scripts/check-librustzcash-compat.mjs
@@ -165,6 +165,23 @@ function occurrences(source, needle) {
   return count;
 }
 
+function rustFunctionBody(source, name) {
+  const marker = `fn ${name}<`;
+  if (occurrences(source, marker) !== 1) return null;
+
+  const declaration = source.indexOf(marker);
+  const bodyStart = source.indexOf("{", declaration + marker.length);
+  if (bodyStart < 0) return null;
+
+  let depth = 1;
+  for (let index = bodyStart + 1; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") depth -= 1;
+    if (depth === 0) return source.slice(bodyStart + 1, index).trim();
+  }
+  return null;
+}
+
 function packageVersions(lock, expectedPackages) {
   const versions = new Map();
   for (const block of lock.split(/^\[\[package\]\]$/m).slice(1)) {
@@ -205,14 +222,50 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
       "transaction version decision must remain one exact audited None helper",
     );
   }
+  const sharedProposalCore = rustFunctionBody(
+    send,
+    "propose_native_send_with_policy",
+  );
+  const defaultProposalBoundary = rustFunctionBody(send, "propose_native_send");
+  const fixedSendBoundary = rustFunctionBody(send, "propose_fixed_native_send");
+  const sendAllBoundary = rustFunctionBody(
+    send,
+    "propose_send_all_native_attempt",
+  );
   const auditedTail =
-    "&SpendPolicy::default(), proposal_lock_request(), proposed_transaction_version(),";
+    "request, ConfirmationsPolicy::default(), spend_policy, proposal_lock_request(), proposed_transaction_version(),";
   if (
-    occurrences(send, "propose_transfer::<") !== 2 ||
-    occurrences(send, auditedTail) !== 2
+    sharedProposalCore === null ||
+    occurrences(send, "propose_transfer::<") !== 1 ||
+    occurrences(sharedProposalCore ?? "", "propose_transfer::<") !== 1 ||
+    occurrences(sharedProposalCore ?? "", auditedTail) !== 1
   ) {
     errors.push(
-      "both transfer proposal paths must consume the audited lock and version decisions",
+      "the shared proposal core must remain the only direct propose_transfer authority and consume the exact audited depth, spend, lock, and version decisions",
+    );
+  }
+  const defaultPolicyCall =
+    "propose_native_send_with_policy(db, params, account_id, request, &SpendPolicy::default())";
+  if (
+    defaultProposalBoundary === null ||
+    occurrences(defaultProposalBoundary ?? "", defaultPolicyCall) !== 1 ||
+    occurrences(send, defaultPolicyCall) !== 1
+  ) {
+    errors.push(
+      "the default native-send boundary must enter the shared proposal core exactly once",
+    );
+  }
+  const sharedDefaultCall =
+    "propose_native_send(db, params, account_id, request)";
+  if (
+    fixedSendBoundary === null ||
+    sendAllBoundary === null ||
+    occurrences(fixedSendBoundary ?? "", sharedDefaultCall) !== 1 ||
+    occurrences(sendAllBoundary ?? "", sharedDefaultCall) !== 1 ||
+    occurrences(send, sharedDefaultCall) !== 2
+  ) {
+    errors.push(
+      "fixed send and send-all must each delegate exactly once to the shared default proposal boundary",
     );
   }
 
@@ -287,6 +340,40 @@ function mutated(snapshot, file, target, replacement, mutation) {
         replacement,
         mutation,
       ),
+    },
+  };
+}
+
+function mutatedOccurrence(
+  snapshot,
+  file,
+  target,
+  replacement,
+  occurrence,
+  expectedCount,
+  mutation,
+) {
+  const source = snapshot.files[file];
+  const offsets = [];
+  let offset = 0;
+  while ((offset = source.indexOf(target, offset)) !== -1) {
+    offsets.push(offset);
+    offset += target.length;
+  }
+  if (offsets.length !== expectedCount || occurrence >= offsets.length) {
+    throw new Error(
+      `${mutation}: mutation target must occur exactly ${expectedCount} time(s), found ${offsets.length}`,
+    );
+  }
+  const selected = offsets[occurrence];
+  return {
+    ...snapshot,
+    files: {
+      ...snapshot.files,
+      [file]:
+        source.slice(0, selected) +
+        replacement +
+        source.slice(selected + target.length),
     },
   };
 }
@@ -408,26 +495,85 @@ function runSelfTest() {
       "transaction version decision",
     ],
     [
-      "primary send bypasses audited helpers",
+      "shared proposal core is no longer recognizable",
       mutated(
         baseline,
         SEND_SOURCE,
-        "            proposal_lock_request(),\n            proposed_transaction_version(),",
-        "            None,\n            None,",
-        "primary send bypasses audited helpers",
+        "fn propose_native_send_with_policy<",
+        "fn propose_native_send_with_policy_mutant<",
+        "shared proposal core is no longer recognizable",
       ),
-      "both transfer proposal paths",
+      "shared proposal core",
     ],
     [
-      "send-all bypasses audited helpers",
+      "a duplicated direct proposal path revives the old split authority",
       mutated(
         baseline,
         SEND_SOURCE,
-        "                proposal_lock_request(),\n                proposed_transaction_version(),",
-        "                None,\n                None,",
-        "send-all bypasses audited helpers",
+        "    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(",
+        "    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(\n    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(",
+        "a duplicated direct proposal path revives the old split authority",
       ),
-      "both transfer proposal paths",
+      "only direct propose_transfer authority",
+    ],
+    [
+      "shared proposal core bypasses the exact lock decision",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "        proposal_lock_request(),\n",
+        "        None,\n",
+        "shared proposal core bypasses the exact lock decision",
+      ),
+      "exact audited depth, spend, lock, and version decisions",
+    ],
+    [
+      "shared proposal core bypasses the exact version decision",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "        proposed_transaction_version(),\n",
+        "        None,\n",
+        "shared proposal core bypasses the exact version decision",
+      ),
+      "exact audited depth, spend, lock, and version decisions",
+    ],
+    [
+      "default policy boundary bypasses the shared proposal core",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "fn propose_native_send<",
+        "fn propose_native_send_mutant<",
+        "default policy boundary bypasses the shared proposal core",
+      ),
+      "default native-send boundary",
+    ],
+    [
+      "fixed send bypasses the shared default boundary",
+      mutatedOccurrence(
+        baseline,
+        SEND_SOURCE,
+        "    propose_native_send(db, params, account_id, request)",
+        "    propose_native_send_with_policy(db, params, account_id, request, &SpendPolicy::default())",
+        0,
+        2,
+        "fixed send bypasses the shared default boundary",
+      ),
+      "fixed send and send-all",
+    ],
+    [
+      "send-all bypasses the shared default boundary",
+      mutatedOccurrence(
+        baseline,
+        SEND_SOURCE,
+        "    propose_native_send(db, params, account_id, request)",
+        "    propose_native_send_with_policy(db, params, account_id, request, &SpendPolicy::default())",
+        1,
+        2,
+        "send-all bypasses the shared default boundary",
+      ),
+      "fixed send and send-all",
     ],
     [
       "known BirthdayError context disappears",

--- a/wallet/plugins/tauri-plugin-zcash/Cargo.lock
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.lock
@@ -54,6 +54,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambassador"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68de4cdc6006162265d0957edb4a860fe4e711b1dc17a5746fd95f952f08285"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +91,12 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-broadcast"
@@ -329,6 +347,21 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -2314,6 +2347,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
  "either",
+ "proptest",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "incrementalmerkletree-testing"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad20fb6cf815e76ce9b9eca74f347740ab99059fe4b5e4a002403d0441a02983"
+dependencies = [
+ "incrementalmerkletree",
+ "proptest",
 ]
 
 [[package]]
@@ -2372,6 +2418,15 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -3257,6 +3312,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "pasta_curves",
+ "proptest",
  "rand 0.8.7",
  "rand_core 0.6.4",
  "reddsa",
@@ -3809,6 +3865,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.7",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,7 +3901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3844,7 +3920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -3858,6 +3934,12 @@ checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -3978,6 +4060,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4299,6 +4390,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4330,6 +4433,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "memuse",
+ "proptest",
  "rand 0.8.7",
  "rand_core 0.6.4",
  "redjubjub",
@@ -5258,6 +5362,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_proofs",
  "zcash_protocol",
+ "zcash_transparent",
  "zeroize",
  "zip32",
  "zip321",
@@ -5878,6 +5983,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6056,6 +6167,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "wagyu-zcash-parameters"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c904628658374e651288f000934c33ef738b2d8b3e65d4100b70b395dbe2bb"
+dependencies = [
+ "wagyu-zcash-parameters-1",
+ "wagyu-zcash-parameters-2",
+ "wagyu-zcash-parameters-3",
+ "wagyu-zcash-parameters-4",
+ "wagyu-zcash-parameters-5",
+ "wagyu-zcash-parameters-6",
+]
+
+[[package]]
+name = "wagyu-zcash-parameters-1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bf2e21bb027d3f8428c60d6a720b54a08bf6ce4e6f834ef8e0d38bb5695da8"
+
+[[package]]
+name = "wagyu-zcash-parameters-2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a616ab2e51e74cc48995d476e94de810fb16fc73815f390bf2941b046cc9ba2c"
+
+[[package]]
+name = "wagyu-zcash-parameters-3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14da1e2e958ff93c0830ee68e91884069253bf3462a67831b02b367be75d6147"
+
+[[package]]
+name = "wagyu-zcash-parameters-4"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f058aeef03a2070e8666ffb5d1057d8bb10313b204a254a6e6103eb958e9a6d6"
+
+[[package]]
+name = "wagyu-zcash-parameters-5"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffe916b30e608c032ae1b734f02574a3e12ec19ab5cc5562208d679efe4969d"
+
+[[package]]
+name = "wagyu-zcash-parameters-6"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b6d5a78adc3e8f198e9cd730f219a695431467f7ec29dcfc63ade885feebe1"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
  "libc",
 ]
 
@@ -7084,6 +7254,8 @@ dependencies = [
 name = "zcash_client_backend"
 version = "0.24.0"
 dependencies = [
+ "ambassador",
+ "assert_matches",
  "async-trait",
  "base64 0.22.1",
  "bech32",
@@ -7099,12 +7271,16 @@ dependencies = [
  "hex",
  "hyper-util",
  "incrementalmerkletree",
+ "jubjub",
  "memuse",
  "nonempty",
  "orchard",
  "pasta_curves",
  "percent-encoding",
+ "proptest",
  "prost",
+ "rand 0.8.7",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
  "sapling-crypto",
@@ -7123,6 +7299,7 @@ dependencies = [
  "zcash_keys",
  "zcash_note_encryption",
  "zcash_primitives",
+ "zcash_proofs",
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
@@ -7134,6 +7311,7 @@ dependencies = [
 name = "zcash_client_sqlite"
 version = "0.22.0"
 dependencies = [
+ "ambassador",
  "bip32",
  "bitflags 2.11.0",
  "bs58",
@@ -7149,6 +7327,7 @@ dependencies = [
  "pczt",
  "prost",
  "rand 0.8.7",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rand_distr",
  "regex",
@@ -7161,6 +7340,7 @@ dependencies = [
  "shardtree",
  "static_assertions",
  "subtle",
+ "tempfile",
  "time",
  "tracing",
  "uuid",
@@ -7202,6 +7382,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard",
+ "proptest",
  "rand_core 0.6.4",
  "sapling-crypto",
  "secp256k1",
@@ -7266,6 +7447,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard",
+ "proptest",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -7295,6 +7477,7 @@ dependencies = [
  "redjubjub",
  "sapling-crypto",
  "tracing",
+ "wagyu-zcash-parameters",
  "xdg",
  "zcash_primitives",
 ]
@@ -7306,7 +7489,10 @@ dependencies = [
  "corez",
  "document-features",
  "hex",
+ "incrementalmerkletree",
+ "incrementalmerkletree-testing",
  "memuse",
+ "proptest",
  "zcash_encoding",
 ]
 
@@ -7347,6 +7533,7 @@ dependencies = [
  "getset",
  "hex",
  "nonempty",
+ "proptest",
  "ripemd 0.1.3",
  "secp256k1",
  "sha2 0.10.9",

--- a/wallet/plugins/tauri-plugin-zcash/Cargo.toml
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.toml
@@ -80,6 +80,14 @@ windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Securit
 tauri-plugin = { version = "2", features = ["build"] }
 tauri-build = "2"
 
+[dev-dependencies]
+# The behavioral send tests exercise the same generic production boundary with
+# librustzcash's real in-memory wallet DSL. These features expose test support;
+# they do not replace proposal or transaction behavior with mocks.
+zcash_client_backend = { path = "../../../z/zcash/librustzcash/zcash_client_backend", features = ["test-dependencies"] }
+zcash_client_sqlite = { path = "../../../z/zcash/librustzcash/zcash_client_sqlite", features = ["test-dependencies"] }
+transparent = { package = "zcash_transparent", path = "../../../z/zcash/librustzcash/zcash_transparent", features = ["transparent-inputs"] }
+
 # ---------------------------------------------------------------------------
 # Build profiles. DO NOT DELETE — see the identical blocks in
 # wallet/zuuli/src-tauri/Cargo.toml and wallet/zuuallet/src-tauri/Cargo.toml.

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
@@ -11,20 +11,23 @@ use std::{
 use rand::{RngCore, rngs::OsRng};
 use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
-use zcash_client_backend::data_api::WalletRead;
 use zcash_client_backend::data_api::wallet::{
-    ConfirmationsPolicy, LockRequest, SpendingKeys, create_proposed_transactions,
+    ConfirmationsPolicy, CreateErrT, LockRequest, ProposeTransferErrT, SpendingKeys,
+    create_proposed_transactions,
     input_selection::{GreedyInputSelector, SpendPolicy},
     propose_transfer,
 };
+use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead, WalletWrite};
 use zcash_client_backend::fees::DustOutputPolicy;
 use zcash_client_backend::fees::zip317::SingleOutputChangeStrategy;
+use zcash_client_backend::proposal::Proposal;
 use zcash_client_backend::proto::service::{RawTransaction, TxFilter};
 use zcash_client_backend::wallet::OvkPolicy;
 use zcash_keys::address::Address;
-use zcash_primitives::transaction::TxVersion;
+use zcash_primitives::transaction::{TxVersion, fees::zip317::FeeRule as Zip317FeeRule};
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::PoolType;
+use zcash_protocol::consensus;
 use zcash_protocol::memo::{Memo, MemoBytes};
 use zcash_protocol::value::Zatoshis;
 use zcash_protocol::{ShieldedPool, TxId};
@@ -83,6 +86,143 @@ fn proposed_transaction_version() -> Option<TxVersion> {
     // Let librustzcash select the consensus transaction version for the target
     // height, matching the behavior before this argument was introduced.
     None
+}
+
+type NativeSendChangeStrategy<DbT> = SingleOutputChangeStrategy<Zip317FeeRule, DbT>;
+type NativeSendProposalError<DbT> = ProposeTransferErrT<
+    DbT,
+    zcash_client_sqlite::wallet::commitment_tree::Error,
+    GreedyInputSelector<DbT>,
+    NativeSendChangeStrategy<DbT>,
+>;
+
+/// The single production authority for money-affecting proposal policy. Both
+/// fixed-amount sends and every send-all retry cross this exact boundary.
+#[allow(clippy::type_complexity)]
+fn propose_native_send_with_policy<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    account_id: <DbT as InputSource>::AccountId,
+    request: zip321::TransactionRequest,
+    spend_policy: &SpendPolicy,
+) -> std::result::Result<
+    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
+    NativeSendProposalError<DbT>,
+>
+where
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    ParamsT: consensus::Parameters + Clone,
+{
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = SingleOutputChangeStrategy::new(
+        Zip317FeeRule::standard(),
+        None,
+        ShieldedPool::Orchard,
+        DustOutputPolicy::default(),
+    );
+
+    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(
+        db,
+        params,
+        account_id,
+        &input_selector,
+        &change_strategy,
+        request,
+        ConfirmationsPolicy::default(),
+        spend_policy,
+        proposal_lock_request(),
+        proposed_transaction_version(),
+    )
+}
+
+#[allow(clippy::type_complexity)]
+fn propose_native_send<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    account_id: <DbT as InputSource>::AccountId,
+    request: zip321::TransactionRequest,
+) -> std::result::Result<
+    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
+    NativeSendProposalError<DbT>,
+>
+where
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    ParamsT: consensus::Parameters + Clone,
+{
+    propose_native_send_with_policy(db, params, account_id, request, &SpendPolicy::default())
+}
+
+#[allow(clippy::type_complexity)]
+fn propose_fixed_native_send<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    account_id: <DbT as InputSource>::AccountId,
+    request: zip321::TransactionRequest,
+) -> std::result::Result<
+    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
+    NativeSendProposalError<DbT>,
+>
+where
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    ParamsT: consensus::Parameters + Clone,
+{
+    propose_native_send(db, params, account_id, request)
+}
+
+#[allow(clippy::type_complexity)]
+fn propose_send_all_native_attempt<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    account_id: <DbT as InputSource>::AccountId,
+    request: zip321::TransactionRequest,
+) -> std::result::Result<
+    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
+    NativeSendProposalError<DbT>,
+>
+where
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    ParamsT: consensus::Parameters + Clone,
+{
+    propose_native_send(db, params, account_id, request)
+}
+
+type NativeSendCreationError<DbT> = CreateErrT<
+    DbT,
+    std::convert::Infallible,
+    Zip317FeeRule,
+    std::convert::Infallible,
+    <DbT as InputSource>::NoteRef,
+>;
+
+/// The single production authority for transaction creation and outgoing
+/// viewing-key retention.
+#[allow(clippy::type_complexity)]
+fn create_native_send_transactions<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    prover: &LocalTxProver,
+    spending_keys: &SpendingKeys,
+    proposal: &Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
+) -> std::result::Result<nonempty::NonEmpty<TxId>, NativeSendCreationError<DbT>>
+where
+    DbT: WalletWrite + WalletCommitmentTrees + InputSource,
+    ParamsT: consensus::Parameters + Clone,
+{
+    create_proposed_transactions::<_, _, std::convert::Infallible, _, std::convert::Infallible, _>(
+        db,
+        params,
+        prover,
+        prover,
+        spending_keys,
+        OvkPolicy::Sender,
+        proposal,
+        // Preserve the builder-derived expiry height for every proposal step.
+        None,
+    )
 }
 
 #[derive(Clone, Copy)]
@@ -1403,29 +1543,7 @@ pub async fn propose_send(
         .copied()
         .ok_or(Error::SendError("no accounts found".into()))?;
 
-    let input_selector = GreedyInputSelector::new();
-    let change_strategy = SingleOutputChangeStrategy::new(
-        zcash_primitives::transaction::fees::zip317::FeeRule::standard(),
-        None,
-        ShieldedPool::Orchard,
-        DustOutputPolicy::default(),
-    );
-
-    let policy = ConfirmationsPolicy::default();
-
-    let proposal =
-        propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(
-            db,
-            &state.network,
-            account_id,
-            &input_selector,
-            &change_strategy,
-            request,
-            policy,
-            &SpendPolicy::default(),
-            proposal_lock_request(),
-            proposed_transaction_version(),
-        )
+    let proposal = propose_fixed_native_send(db, &state.network, account_id, request)
         .map_err(|e| Error::SendError(format!("failed to propose transfer: {e:?}")));
 
     drop(db_guard);
@@ -1561,29 +1679,7 @@ pub async fn propose_send_all(
             .copied()
             .ok_or(Error::SendError("no accounts found".into()))?;
 
-        let input_selector = GreedyInputSelector::new();
-        let change_strategy = SingleOutputChangeStrategy::new(
-            zcash_primitives::transaction::fees::zip317::FeeRule::standard(),
-            None,
-            ShieldedPool::Orchard,
-            DustOutputPolicy::default(),
-        );
-
-        let policy = ConfirmationsPolicy::default();
-
-        let result =
-            propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(
-                db,
-                &state.network,
-                account_id,
-                &input_selector,
-                &change_strategy,
-                request,
-                policy,
-                &SpendPolicy::default(),
-                proposal_lock_request(),
-                proposed_transaction_version(),
-            );
+        let result = propose_send_all_native_attempt(db, &state.network, account_id, request);
 
         drop(db_guard);
 
@@ -1809,23 +1905,12 @@ pub async fn execute_send(
 
     let mut transaction_created = false;
     let created = (|| -> Result<PendingBroadcast> {
-        let txids = create_proposed_transactions::<
-            _,
-            _,
-            std::convert::Infallible,
-            _,
-            std::convert::Infallible,
-            _,
-        >(
+        let txids = create_native_send_transactions(
             db,
             &state.network,
             prover,
-            prover,
             &spending_keys,
-            OvkPolicy::Sender,
             &pending_proposal.proposal,
-            // `expiry_height: None` keeps the builder-derived expiry for every step.
-            None,
         )
         .map_err(|e| Error::SendError(format!("failed to create transaction: {e:?}")))?;
         transaction_created = true;
@@ -2284,7 +2369,19 @@ async fn broadcast_record(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use transparent::{
+        bundle::{OutPoint, TxOut},
+        keys::TransparentKeyScope,
+    };
     use zcash_address::unified::{Address as UnifiedAddress, Encoding, Receiver};
+    use zcash_client_backend::data_api::Account;
+    use zcash_client_backend::data_api::testing::{
+        orchard::OrchardPoolTester,
+        pool::{ShieldedPoolTester, dsl::TestDsl},
+    };
+    use zcash_client_backend::data_api::wallet::input_selection::TransparentSpendPolicy;
+    use zcash_client_backend::wallet::WalletTransparentOutput;
+    use zcash_client_sqlite::testing::{BlockCache, db::TestDbFactory};
     use zcash_protocol::consensus::{Network, NetworkType};
 
     const MAINNET_TADDR: &str = "t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs";
@@ -2295,6 +2392,201 @@ mod tests {
     const WALLET_ID: &str = "wallet-a";
     const SESSION_ID: [u8; 32] = [0x11; 32];
     const OTHER_SESSION_ID: [u8; 32] = [0x22; 32];
+
+    fn payment_request(
+        network: &impl consensus::Parameters,
+        recipient: &Address,
+        amount: u64,
+    ) -> zip321::TransactionRequest {
+        zip321::TransactionRequest::new(vec![zip321::Payment::without_memo(
+            recipient.to_zcash_address(network),
+            Zatoshis::const_from_u64(amount),
+        )])
+        .expect("the independently fixed test payment is valid")
+    }
+
+    #[test]
+    fn production_send_boundaries_preserve_pool_depth_fee_and_sender_recovery() {
+        const NOTE_VALUE: u64 = 60_000;
+        const FIXED_SEND_VALUE: u64 = 10_000;
+        const SEND_ALL_VALUE: u64 = 50_000;
+        const EXPECTED_FEE: u64 = 10_000;
+
+        let mut st =
+            TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
+                .build::<OrchardPoolTester>();
+        let (_, _, _) = st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(NOTE_VALUE));
+
+        let recipient_key = OrchardPoolTester::sk(&[0xf5; 32]);
+        let recipient = OrchardPoolTester::sk_default_address(&recipient_key);
+        let account = st.get_account();
+        let account_id = account.id();
+        let network = *st.network();
+
+        let immature = propose_fixed_native_send(
+            st.wallet_mut(),
+            &network,
+            account_id,
+            payment_request(&network, &recipient, FIXED_SEND_VALUE),
+        );
+        assert!(
+            immature.is_err(),
+            "an externally received Orchard note must not be spendable after one confirmation"
+        );
+
+        st.add_empty_blocks(9);
+        let proposal = propose_fixed_native_send(
+            st.wallet_mut(),
+            &network,
+            account_id,
+            payment_request(&network, &recipient, FIXED_SEND_VALUE),
+        )
+        .expect("the same Orchard note must be spendable after ten confirmations");
+        assert_eq!(proposal.steps().len(), 1);
+        assert_eq!(proposal.input_count_in_pool(PoolType::ORCHARD), 1);
+        assert_eq!(proposal.input_count_in_pool(PoolType::SAPLING), 0);
+        assert_eq!(
+            proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::ORCHARD),
+            1
+        );
+        assert_eq!(
+            proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::SAPLING),
+            0
+        );
+        assert_eq!(
+            u64::from(proposal.steps().head.balance().fee_required()),
+            EXPECTED_FEE
+        );
+
+        // Exercise the production wrapper used by every send-all retry. Spending the
+        // independently fixed note value minus the expected fee must consume the whole note,
+        // retain ZIP 317's fee, and return no value as change. Orchard padding can retain a
+        // zero-valued change entry, so value rather than vector shape is the behavior at stake.
+        let send_all_proposal = propose_send_all_native_attempt(
+            st.wallet_mut(),
+            &network,
+            account_id,
+            payment_request(&network, &recipient, SEND_ALL_VALUE),
+        )
+        .expect("the send-all-shaped request must be proposed by the shared boundary");
+        assert_eq!(send_all_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
+        assert_eq!(
+            u64::from(send_all_proposal.steps().head.balance().fee_required()),
+            EXPECTED_FEE
+        );
+        assert_eq!(
+            send_all_proposal
+                .steps()
+                .head
+                .balance()
+                .proposed_change()
+                .iter()
+                .map(|change| u64::from(change.value()))
+                .sum::<u64>(),
+            0
+        );
+
+        let spending_keys = SpendingKeys::from_unified_spending_key(account.usk().clone());
+        let prover = LocalTxProver::bundled();
+        let recovery_height = proposal.min_target_height().into();
+        let txids = create_native_send_transactions(
+            st.wallet_mut(),
+            &network,
+            &prover,
+            &spending_keys,
+            &proposal,
+        )
+        .expect("the production creation boundary must build and persist the transaction");
+        let tx = st
+            .wallet()
+            .get_transaction(txids.head)
+            .expect("the test wallet database remains readable")
+            .expect("the created transaction is persisted");
+        let sender_fvk = OrchardPoolTester::test_account_fvk(&st);
+        let (_, recovered_recipient, _) =
+            OrchardPoolTester::try_output_recovery(&network, recovery_height, &tx, &sender_fvk)
+                .expect("the sender OVK must recover the external Orchard output");
+        assert_eq!(recovered_recipient, recipient);
+    }
+
+    #[test]
+    fn production_transparent_spend_shields_change_to_orchard() {
+        const UTXO_VALUE: u64 = 60_000;
+        const PAYMENT_VALUE: u64 = 10_000;
+        const EXPECTED_CHANGE: u64 = 35_000;
+
+        let mut st =
+            TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
+                .build::<OrchardPoolTester>();
+        let account = st.get_account();
+        let account_id = account.id();
+        let network = *st.network();
+        let (transparent_recipient, _) = account.usk().default_transparent_address();
+        let received_height = st.add_empty_blocks(1);
+        let utxo = WalletTransparentOutput::from_parts(
+            OutPoint::fake(),
+            TxOut::new(
+                Zatoshis::const_from_u64(UTXO_VALUE),
+                transparent_recipient.script().into(),
+            ),
+            Some(received_height),
+            Some(account_id),
+            Some(TransparentKeyScope::EXTERNAL),
+            None,
+        )
+        .expect("the independently constructed transparent UTXO is valid");
+        st.wallet_mut()
+            .put_received_transparent_utxo(&utxo)
+            .expect("the real wallet database accepts the transparent UTXO");
+        st.add_empty_blocks(9);
+
+        let spend_policy =
+            SpendPolicy::default().with_transparent(TransparentSpendPolicy::any_account_addr());
+        let proposal = propose_native_send_with_policy(
+            st.wallet_mut(),
+            &network,
+            account_id,
+            payment_request(
+                &network,
+                &Address::from(transparent_recipient),
+                PAYMENT_VALUE,
+            ),
+            &spend_policy,
+        )
+        .expect("the production proposal core proposes the mature transparent spend");
+        assert_eq!(proposal.input_count_in_pool(PoolType::TRANSPARENT), 1);
+        assert_eq!(
+            proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::ORCHARD),
+            1
+        );
+        assert_eq!(
+            proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::SAPLING),
+            0
+        );
+        assert_eq!(
+            proposal
+                .steps()
+                .head
+                .balance()
+                .proposed_change()
+                .iter()
+                .map(|change| u64::from(change.value()))
+                .sum::<u64>(),
+            EXPECTED_CHANGE
+        );
+    }
 
     #[test]
     fn proposal_defaults_preserve_unlocked_height_selected_transactions() {

--- a/wallet/zuuli/scripts/send-review-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/send-review-boundary.node-test.mjs
@@ -2,6 +2,109 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+function rustCodeOnly(source) {
+  let output = "";
+  let state = "code";
+  let blockDepth = 0;
+  let rawTerminator = "";
+
+  const charLiteralLength = (offset) => {
+    if (source[offset] !== "'") return 0;
+    let cursor = offset + 1;
+    if (source[cursor] === "\\") {
+      cursor += 1;
+      if (source[cursor] === "u" && source[cursor + 1] === "{") {
+        const close = source.indexOf("}", cursor + 2);
+        if (close < 0) return 0;
+        cursor = close + 1;
+      } else if (source[cursor] === "x") {
+        cursor += 3;
+      } else {
+        cursor += 1;
+      }
+    } else {
+      cursor += 1;
+    }
+    return source[cursor] === "'" ? cursor - offset + 1 : 0;
+  };
+
+  for (let index = 0; index < source.length; index += 1) {
+    const current = source[index];
+    const next = source[index + 1];
+
+    if (state === "line-comment") {
+      output += current === "\n" ? "\n" : " ";
+      if (current === "\n") state = "code";
+      continue;
+    }
+    if (state === "block-comment") {
+      if (current === "/" && next === "*") {
+        blockDepth += 1;
+        output += "  ";
+        index += 1;
+      } else if (current === "*" && next === "/") {
+        blockDepth -= 1;
+        output += "  ";
+        index += 1;
+        if (blockDepth === 0) state = "code";
+      } else {
+        output += current === "\n" ? "\n" : " ";
+      }
+      continue;
+    }
+    if (state === "string") {
+      output += current === "\n" ? "\n" : " ";
+      if (current === "\\" && next !== undefined) {
+        output += next === "\n" ? "\n" : " ";
+        index += 1;
+      } else if (current === '"') {
+        state = "code";
+      }
+      continue;
+    }
+    if (state === "raw-string") {
+      if (source.startsWith(rawTerminator, index)) {
+        output += " ".repeat(rawTerminator.length);
+        index += rawTerminator.length - 1;
+        state = "code";
+      } else {
+        output += current === "\n" ? "\n" : " ";
+      }
+      continue;
+    }
+
+    const charLength = charLiteralLength(index);
+    const rawStart = source
+      .slice(index)
+      .match(/^(?:br|cr|r)(#{0,255})"/);
+    if (charLength > 0) {
+      output += " ".repeat(charLength);
+      index += charLength - 1;
+    } else if (rawStart) {
+      rawTerminator = `"${rawStart[1]}`;
+      output += " ".repeat(rawStart[0].length);
+      index += rawStart[0].length - 1;
+      state = "raw-string";
+    } else if (current === "/" && next === "/") {
+      output += "  ";
+      index += 1;
+      state = "line-comment";
+    } else if (current === "/" && next === "*") {
+      output += "  ";
+      index += 1;
+      blockDepth = 1;
+      state = "block-comment";
+    } else if (current === '"') {
+      output += " ";
+      state = "string";
+    } else {
+      output += current;
+    }
+  }
+
+  return output;
+}
+
 const [
   send,
   bridge,
@@ -35,6 +138,45 @@ const [
     "../zuuallet/src-tauri/src/lib.rs",
   ].map((path) => readFile(new URL(`../${path}`, import.meta.url), "utf8")),
 );
+
+test("Rust routing scan ignores comments and literals without hiding live code", () => {
+  const route = "propose_fixed_native_send(";
+  const hidden = [
+    ["line comment", `// ${route}\nlet live = true;`],
+    ["block comment", `/* ${route} */ let live = true;`],
+    ["nested block comment", `/* outer /* nested */ ${route} */ let live = true;`],
+    ["normal string", `let marker = "${route}";`],
+    ["byte string", `let marker = b"${route}";`],
+    ["escaped quote in string", String.raw`let marker = "escaped \" ${route}";`],
+    ["raw string with an embedded quote", `let marker = r#"embedded " ${route}"#;`],
+    ["byte raw string", `let marker = br##"embedded "# ${route}"##;`],
+  ];
+  for (const [name, source] of hidden) {
+    assert.equal(
+      rustCodeOnly(source).includes(route),
+      false,
+      `${name} cannot forge a native proposal route`,
+    );
+  }
+
+  const visible = [
+    ["ordinary code", `${route});`],
+    ["line comment termination", `// noise\n${route});`],
+    ["block comment termination", `/* noise */ ${route});`],
+    ["raw string termination", `let noise = r#"embedded " quote"#; ${route});`],
+    ["comment markers inside a string", `let noise = "// /*"; ${route});`],
+    ["double quote character literal", `let quote = b'"'; ${route});`],
+    ["apostrophe character literal", String.raw`let quote = '\''; ${route});`],
+    ["lifetime", `fn borrow<'a>(value: &'a str) { ${route}); }`],
+  ];
+  for (const [name, source] of visible) {
+    assert.equal(
+      rustCodeOnly(source).includes(route),
+      true,
+      `${name} must leave a real native proposal route visible`,
+    );
+  }
+});
 
 test("confirmation renders only the immutable native review", () => {
   assert.match(send, /proposal\.review\.payments/);
@@ -192,6 +334,7 @@ test("every stale UI path has an exact native discard boundary", () => {
 });
 
 test("ZIP-321 parsing is single-payment and bound to native network authority", () => {
+  const nativeSendCode = rustCodeOnly(nativeSend);
   const parseCommand = nativeCommands.match(
     /pub\(crate\) async fn parse_payment_uri[\s\S]*?(?=\n\/\/\/|\n#\[command\])/,
   )?.[0];
@@ -212,7 +355,7 @@ test("ZIP-321 parsing is single-payment and bound to native network authority", 
     ["propose_send", "propose_fixed_native_send("],
     ["propose_send_all", "propose_send_all_native_attempt("],
   ]) {
-    const proposalFunction = nativeSend.match(
+    const proposalFunction = nativeSendCode.match(
       new RegExp(`pub async fn ${functionName}\\([\\s\\S]*?(?=\\npub async fn )`),
     )?.[0];
     assert.ok(proposalFunction, `${functionName} must remain inspectable`);
@@ -220,6 +363,17 @@ test("ZIP-321 parsing is single-payment and bound to native network authority", 
     const proposalIndex = proposalFunction.indexOf(nativeProposalBoundary);
     assert.notEqual(validationIndex, -1, `${functionName} must validate its recipient`);
     assert.notEqual(proposalIndex, -1, `${functionName} must build a native proposal`);
+    for (const lowerLevelBoundary of [
+      "propose_native_send_with_policy(",
+      "propose_native_send(",
+      "propose_transfer::<",
+    ]) {
+      assert.equal(
+        proposalFunction.indexOf(lowerLevelBoundary),
+        -1,
+        `${functionName} must not bypass its dedicated native proposal boundary`,
+      );
+    }
     assert.ok(
       validationIndex < proposalIndex,
       `${functionName} must reject incompatible recipients before native proposal`,

--- a/wallet/zuuli/scripts/send-review-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/send-review-boundary.node-test.mjs
@@ -208,13 +208,16 @@ test("ZIP-321 parsing is single-payment and bound to native network authority", 
   assert.match(nativeSend, /zip321_requires_exactly_one_payment/);
   assert.match(nativeSend, /zip321_recipient_is_bound_to_the_active_network/);
   assert.match(nativeSend, /unified_address_requires_a_receiver_this_wallet_can_pay/);
-  for (const functionName of ["propose_send", "propose_send_all"]) {
+  for (const [functionName, nativeProposalBoundary] of [
+    ["propose_send", "propose_fixed_native_send("],
+    ["propose_send_all", "propose_send_all_native_attempt("],
+  ]) {
     const proposalFunction = nativeSend.match(
       new RegExp(`pub async fn ${functionName}\\([\\s\\S]*?(?=\\npub async fn )`),
     )?.[0];
     assert.ok(proposalFunction, `${functionName} must remain inspectable`);
     const validationIndex = proposalFunction.indexOf("parse_recipient(&state.network");
-    const proposalIndex = proposalFunction.indexOf("propose_transfer::<");
+    const proposalIndex = proposalFunction.indexOf(nativeProposalBoundary);
     assert.notEqual(validationIndex, -1, `${functionName} must validate its recipient`);
     assert.notEqual(proposalIndex, -1, `${functionName} must build a native proposal`);
     assert.ok(


### PR DESCRIPTION
Closes #547

## What changed

- route fixed sends and every send-all retry through one production proposal boundary
- route execution through one production transaction-creation boundary
- exercise those boundaries with librustzcash's real `TestDsl`, SQLite wallet, Orchard note/transparent UTXO fixtures, and `LocalTxProver`
- assert observed input pools, Orchard change, an independent literal 10,000-zatoshi ZIP-317 fee, default confirmation depth, real send-all value behavior, persistence, and sender-OVK ciphertext recovery
- update the existing librustzcash source-drift policy to lock the new single-authority shape while retaining behavioral tests as the money-path authority

## Behavioral mutation proof

Each production mutant was applied and run independently on exact main `2e5811ec36d4cd8d43656ac95a2358916b1ea215`, then restored:

1. `SpendPolicy::default()` → Sapling-only: red with `InsufficientFunds { available: 0, required: 20000 }` for the mature Orchard note.
2. Orchard fallback change → Sapling: red on observed Orchard change count, `left: 0`, `right: 1`, using a real transparent input that makes the fallback reachable.
3. `ConfirmationsPolicy::default()` → minimum: red because the one-confirmation Orchard note became spendable.
4. `OvkPolicy::Sender` → `Discard`: red because the sender FVK could not recover the external Orchard output.
5. Standard ZIP-317 fee → valid nonstandard 6,000 marginal fee / 2 grace actions: red on the independent fee literal, `left: 12000`, `right: 10000`.

Fixed send and the real send-all retry wrapper both cross the shared production proposal boundary. Execution creates and persists an actual transaction, and recovery uses the proposal target height rather than an incidental fixture height.

## Policy mutation proof

Each new compatibility-policy guard was independently weakened and its self-test went red with `mutant survived`, then restored:

- allow an unrecognized/missing shared proposal core
- allow duplicate direct `propose_transfer` authority, preserving rejection of the old split-call shape
- remove the exact confirmation/spend/lock/version tail requirement

The restored compatibility self-test kills 64 mutants, including independent fixed-send and send-all delegation bypasses.

## Restored verification

- `cargo fmt --all -- --check`
- focused production send tests: 2 passed
- `cargo test --all-targets --all-features`: 144 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- librustzcash compatibility policy self-test + live verdict
- GitHub Actions pin/protected-gate policy self-test + live verdict
- workflow-gate policy self-test + live verdict
- public repository boundary self-test + live verdict
- Rust toolchain policy self-test + live verdict
- Rust deny policy self-test + all five wallet crates
