### PR TITLE
ci: gate Windows plugin test execution, and make an ungated workflow fail the checker

### DIFF
--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -302,36 +302,17 @@ jobs:
           cargo test --locked
           --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
 
-  # Compile the target-specific Keychain and Credential Manager adapters on
-  # their native hosts. Linux Secret Service is covered by the `rust` job.
-  custody-platforms:
-    if: github.event_name != 'schedule'
-    name: custody / ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - name: Fetch librustzcash submodule
-        run: git submodule update --init z/zcash/librustzcash
-
-      # `uses:` cannot take an expression, so this commit-pinned version action
-      # restates wallet/rust-toolchain.toml; scripts/check-rust-toolchain.sh
-      # holds it to the source of truth.
-      - uses: dtolnay/rust-toolchain@032958afbdc797a9164d3bc0b56325c1308924a5 # 1.97.1
-
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        with:
-          workspaces: wallet/plugins/tauri-plugin-zcash
-
-      - name: Test native plugin
-        run: >-
-          cargo test --locked
-          --all-targets
-          --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
+  # The macOS/Windows plugin test matrix that used to live here — `custody /
+  # ${{ matrix.os }}` — is now `rust_native_tests` in .github/workflows/zuuli.yml,
+  # where the required `gate` awaits it (#610).
+  #
+  # It ran here, and passed, and could not fail a merge: this workflow publishes
+  # no gate, branch protection does not require any context it emits, and its
+  # `on: pull_request: paths:` filter means it does not run at all for a pull
+  # request that touches nothing it lists. So the one job in the repository that
+  # executed the Win32 file-identity helper was, in merge terms, advisory. The
+  # move keeps the suite whole rather than splitting it: the entire matrix went,
+  # under a selector that covers the same changes this workflow's filter does.
 
   # ---------------------------------------------------------------------------
   # Canary: rebuild against the LATEST librustzcash main + refreshed crates.

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -421,6 +421,67 @@ jobs:
         shell: bash
         run: scripts/check-rust-clippy.sh
 
+  # Native *execution*, not just compilation. `rust_native_clippy` above proves
+  # the macOS and Windows halves of the plugin compile; until #610 nothing that
+  # could fail a merge ever ran them. The Win32 file-identity helper the
+  # legacy-import preview relies on is reachable only from a Windows host, so a
+  # regression in it passed every required check — the plugin's Windows suite
+  # lived in the ungated .github/workflows/zuuallet.yml, which branch protection
+  # does not require and which does not even run for a pull request outside its
+  # `paths:` filter. That job moved here, where the required `gate` awaits it.
+  #
+  # Same selector and same matrix as the lint job deliberately: it is the same
+  # code on the same two hosts, and two selectors over one body of code drift.
+  rust_native_tests:
+    name: Rust / native tests (${{ matrix.target_os }})
+    needs: changes
+    if: needs.changes.outputs.zuuli == 'true' || needs.changes.outputs.zuuallet_schema == 'true'
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target_os: macos
+          - os: windows-latest
+            target_os: windows
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - name: Resolve the pinned Rust toolchain
+        id: rust_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(scripts/check-rust-toolchain.sh --print-channel)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.version }}
+
+      # Separate cache key from rust_native_clippy: clippy and rustc write
+      # different artifacts under the same target directory names, so a shared
+      # key has the two jobs evicting each other's work on every run.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: wallet/plugins/tauri-plugin-zcash
+          key: zuuli-native-tests-${{ matrix.target_os }}
+
+      # --all-targets so the integration and doc-adjacent targets build too;
+      # this is the exact command the retired zuuallet.yml custody job ran, now
+      # under a required context.
+      - name: Test the shared plugin on the native host
+        shell: bash
+        run: >-
+          cargo test --locked
+          --all-targets
+          --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
+
   rust_plugin:
     name: Rust / shared plugin
     needs: changes
@@ -750,7 +811,7 @@ jobs:
   # change detector and every applicable full-stack job succeeded; legitimate
   # non-ZUULI skips continue to report success instead of remaining pending.
   gate:
-    needs: [changes, frontend, rust_fmt, rust_deny, rust_clippy, rust_native_clippy, rust_plugin, rust_android_32, rust_app, zuuallet_schema, rust_crypto_targets]
+    needs: [changes, frontend, rust_fmt, rust_deny, rust_clippy, rust_native_clippy, rust_native_tests, rust_plugin, rust_android_32, rust_app, zuuallet_schema, rust_crypto_targets]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -84,6 +84,51 @@ const REQUIRED_NATIVE_CLIPPY_JOB_LINES = [
   "        shell: bash",
   "        run: scripts/check-rust-clippy.sh",
 ];
+// The macOS/Windows job that *executes* the shared plugin's test suite. Held to
+// its exact source for the same reason as the lint job beside it: this is the
+// only required job that runs Win32 and Darwin code paths, so weakening the
+// command, the matrix or the selector silently restores the #610 state where
+// Windows execution could not fail a merge.
+const REQUIRED_NATIVE_TESTS_JOB_LINES = [
+  "  rust_native_tests:",
+  "    name: Rust / native tests (${{ matrix.target_os }})",
+  "    needs: changes",
+  "    if: needs.changes.outputs.zuuli == 'true' || needs.changes.outputs.zuuallet_schema == 'true'",
+  "    timeout-minutes: 90",
+  "    strategy:",
+  "      fail-fast: false",
+  "      matrix:",
+  "        include:",
+  "          - os: macos-latest",
+  "            target_os: macos",
+  "          - os: windows-latest",
+  "            target_os: windows",
+  "    runs-on: ${{ matrix.os }}",
+  "    steps:",
+  `      - uses: ${GATE_CHECKOUT_REFERENCE} # v7.0.1`,
+  "      - name: Fetch librustzcash submodule",
+  "        run: git submodule update --init z/zcash/librustzcash",
+  "      - name: Resolve the pinned Rust toolchain",
+  "        id: rust_toolchain",
+  "        shell: bash",
+  "        run: |",
+  "          set -euo pipefail",
+  "          version=$(scripts/check-rust-toolchain.sh --print-channel)",
+  '          echo "version=$version" >> "$GITHUB_OUTPUT"',
+  "      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable",
+  "        with:",
+  "          toolchain: ${{ steps.rust_toolchain.outputs.version }}",
+  "      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2",
+  "        with:",
+  "          workspaces: wallet/plugins/tauri-plugin-zcash",
+  "          key: zuuli-native-tests-${{ matrix.target_os }}",
+  "      - name: Test the shared plugin on the native host",
+  "        shell: bash",
+  "        run: >-",
+  "          cargo test --locked",
+  "          --all-targets",
+  "          --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml",
+];
 const REQUIRED_CRYPTO_TARGET_JOB_LINES = [
   "  rust_crypto_targets:",
   "    name: Rust / modern crypto targets (${{ matrix.family }})",
@@ -1744,8 +1789,31 @@ function gatePolicyFailures(repoRoot, relativeFile, lines) {
   if (enforceNativeClippy && !parsedNeeds.values.includes("rust_native_clippy")) {
     failures.push(`${relativeFile}:${needsProperty.index + 1}: gate must await rust_native_clippy`);
   }
+  if (enforceNativeClippy && !parsedNeeds.values.includes("rust_native_tests")) {
+    failures.push(`${relativeFile}:${needsProperty.index + 1}: gate must await rust_native_tests`);
+  }
   if (enforceNativeClippy && !parsedNeeds.values.includes("rust_crypto_targets")) {
     failures.push(`${relativeFile}:${needsProperty.index + 1}: gate must await rust_crypto_targets`);
+  }
+
+  const nativeTests = jobs.get("rust_native_tests");
+  if (enforceNativeClippy && !nativeTests) {
+    failures.push(
+      `${relativeFile}: required workflow must contain rust_native_tests`,
+    );
+  } else if (enforceNativeClippy) {
+    const actualNativeTestsJobLines = lines
+      .slice(nativeTests.start, nativeTests.end)
+      .filter((line) => line.trim() && !line.trimStart().startsWith("#"))
+      .map((line) => line.trimEnd());
+    if (
+      JSON.stringify(actualNativeTestsJobLines) !==
+      JSON.stringify(REQUIRED_NATIVE_TESTS_JOB_LINES)
+    ) {
+      failures.push(
+        `${relativeFile}:${nativeTests.start + 1}: rust_native_tests must match the exact current-source native execution contract`,
+      );
+    }
   }
 
   const nativeClippy = jobs.get("rust_native_clippy");
@@ -1977,8 +2045,13 @@ function verifyGateResults(policyOutcome, serializedNeeds) {
     changes.outputs.zuuallet_schema,
     "Zuuallet schema",
   );
-  const nativeClippyExpected =
+  // The two native macOS/Windows jobs share one selector because they judge one
+  // body of code: rust_native_clippy compiles it and rust_native_tests executes
+  // it. Deriving both expectations from the same value here means the gate can
+  // never accept a skip from one that it would reject from the other.
+  const nativeExpected =
     zuuliExpected === "success" || schemaExpected === "success" ? "success" : "skipped";
+  const NATIVE_JOBS = new Set(["rust_native_clippy", "rust_native_tests"]);
 
   const verdicts = [];
   for (const [job, state] of entries) {
@@ -1994,8 +2067,8 @@ function verifyGateResults(policyOutcome, serializedNeeds) {
         ? "success"
         : job === "zuuallet_schema"
           ? schemaExpected
-          : job === "rust_native_clippy"
-            ? nativeClippyExpected
+          : NATIVE_JOBS.has(job)
+            ? nativeExpected
             : zuuliExpected;
     if (state.result !== expected) {
       throw new Error(
@@ -2189,6 +2262,46 @@ function runCurrentWorkflowMutationTests(repoRoot) {
       source: source.replace(
         "    if: needs.changes.outputs.zuuli == 'true' || needs.changes.outputs.zuuallet_schema == 'true'",
         "    if: needs.changes.outputs.zuuli == 'true'",
+      ),
+    },
+    {
+      name: "real workflow rejects native tests detached from gate",
+      needle: "gate must await rust_native_tests",
+      source: source.replace(", rust_native_tests", ""),
+    },
+    {
+      name: "real workflow rejects a weakened native test command",
+      needle:
+        "rust_native_tests must match the exact current-source native execution contract",
+      // Unique in the file: rust_plugin runs the same command on one line, so
+      // only the folded form belongs to rust_native_tests. Dropping --locked is
+      // the realistic weakening — it makes a stale lockfile build anyway.
+      source: source.replace(
+        "          cargo test --locked\n          --all-targets\n",
+        "          cargo test\n          --all-targets\n",
+      ),
+    },
+    {
+      name: "real workflow rejects a weakened native test selector",
+      needle:
+        "rust_native_tests must match the exact current-source native execution contract",
+      // replaceLast, not replace: rust_native_clippy carries the identical
+      // selector earlier in the file, and mutating that one would prove the
+      // clippy contract rather than this one.
+      source: replaceLast(
+        source,
+        "    if: needs.changes.outputs.zuuli == 'true' || needs.changes.outputs.zuuallet_schema == 'true'",
+        "    if: needs.changes.outputs.zuuli == 'true'",
+      ),
+    },
+    {
+      name: "real workflow rejects dropping the Windows native test leg",
+      needle:
+        "rust_native_tests must match the exact current-source native execution contract",
+      source: replaceLast(
+        source,
+        "          - os: windows-latest\n            target_os: windows\n",
+        "",
       ),
     },
     {
@@ -4083,6 +4196,44 @@ function runSelfTest(repoRoot) {
         },
         rust_native_clippy: { result: "skipped", outputs: {} },
         zuuallet_schema: { result: "success", outputs: {} },
+      },
+    },
+    {
+      name: "native tests cannot skip a Zuuallet-only Rust change",
+      policyOutcome: "success",
+      needle: "required job rust_native_tests must be success, got skipped",
+      needs: {
+        changes: {
+          result: "success",
+          outputs: { zuuli: "false", zuuallet_schema: "true" },
+        },
+        rust_native_tests: { result: "skipped", outputs: {} },
+        zuuallet_schema: { result: "success", outputs: {} },
+      },
+    },
+    {
+      name: "native tests follow the shared native selector when neither is set",
+      policyOutcome: "success",
+      needs: {
+        changes: {
+          result: "success",
+          outputs: { zuuli: "false", zuuallet_schema: "false" },
+        },
+        rust_native_clippy: { result: "skipped", outputs: {} },
+        rust_native_tests: { result: "skipped", outputs: {} },
+        zuuallet_schema: { result: "skipped", outputs: {} },
+      },
+    },
+    {
+      name: "a failed native test run is rejected",
+      policyOutcome: "success",
+      needle: "required job rust_native_tests must be success, got failure",
+      needs: {
+        changes: {
+          result: "success",
+          outputs: { zuuli: "true", zuuallet_schema: "false" },
+        },
+        rust_native_tests: { result: "failure", outputs: {} },
       },
     },
     {

--- a/scripts/check-workflow-gates.mjs
+++ b/scripts/check-workflow-gates.mjs
@@ -58,6 +58,17 @@
 //      workflow emits never reports at all, so PRs hang pending forever with
 //      nothing anywhere going red.
 //
+//   6. EVERY WORKFLOW ACCOUNTED FOR. Rules 1–5 all reason *about a gate*, so a
+//      workflow that has no gate presents nothing to be wrong about and passes
+//      by having no surface. That is not a hypothetical: `zuuallet.yml` ran the
+//      wallet plugin's Windows test suite for months with no required check
+//      able to fail on it, and this script had nothing to say (#610). So the
+//      population is enumerated off the filesystem and each file must either
+//      publish a gate resolving to a required context or appear in
+//      `UNGATED_WORKFLOWS` with a reason. A registration for a file the
+//      enumeration did not produce fails, which is what makes narrowing the
+//      enumeration red rather than quietly smaller.
+//
 // Usage:
 //   node scripts/check-workflow-gates.mjs             judge every workflow
 //   node scripts/check-workflow-gates.mjs --self-test negative controls first
@@ -147,6 +158,115 @@ const TOLERATED_CONTEXT_COLLISIONS = new Map([
 /// being weakened to accommodate it. The self-test exercises this path with an
 /// injected map so the opt-out is not untested code.
 const GATE_EXEMPT_JOBS = new Map();
+
+/// The shortest string that can pass as a recorded reason in the registry
+/// below. It exists so `""` — the thing a hurried edit reaches for — is red
+/// rather than a silent exemption.
+const MINIMUM_REGISTRY_REASON = 40;
+
+/// Workflows that deliberately publish no `gate`, each mapped to why not.
+///
+/// Every rule above this line reasons *about a gate*: it reads a `gate` job and
+/// judges what that gate awaits, binds, reports and publishes. A workflow with
+/// no gate therefore presents nothing to judge, and passes by having no
+/// surface — which is exactly how `.github/workflows/zuuallet.yml` came to run
+/// the plugin's Windows test suite with no required check able to fail on it
+/// (#610). "Nothing to complain about" and "nothing is checked" produced the
+/// same green.
+///
+/// So the population is read off the filesystem — every `.yml`/`.yaml` under
+/// `.github/workflows` — and each file must either publish a gate that resolves
+/// to a context branch protection requires, or appear here with a reason. Not
+/// every workflow should be gated (`cache-cleanup.yml` plainly should not),
+/// which is why this is a registration and not a blanket rule.
+///
+/// Three properties make the registration an anchor rather than a list:
+///
+///   * An entry naming a file the enumeration did not produce fails. That is
+///     what makes narrowing `workflowFiles` red instead of quietly shrinking
+///     the population — the check names what it stopped covering.
+///   * An entry naming a file that has since *gained* a gate fails, so the
+///     registration cannot outlive the situation that justified it.
+///   * An entry with no substantive reason fails, so the escape hatch costs a
+///     sentence of justification rather than a comma.
+///
+/// The recurring reason below deserves stating once here: GitHub does not run a
+/// workflow whose `on: pull_request:` carries a `paths:` filter when a pull
+/// request touches nothing matching, and a required context from a workflow
+/// that did not run never reports — every pull request waits on it forever with
+/// nothing anywhere going red. So "add it to branch protection" is not a
+/// one-line change for any of these: it means first moving the filter into a
+/// change-detector job the way `zuuli.yml` and `rs.yml` do.
+const UNGATED_WORKFLOWS = new Map([
+  [
+    ".github/workflows/cache-cleanup.yml",
+    "Maintenance only: reclaims Actions cache entries on `pull_request_target: closed`, " +
+      "schedule and dispatch. It builds and tests nothing, and no event it listens for exists " +
+      "while a pull request is still open, so a required context from it could never report.",
+  ],
+  [
+    ".github/workflows/docs-about-free2z.yml",
+    "Advisory build of docs/about-free2z/**, selected by an `on: pull_request: paths:` filter; " +
+      "gating it means first moving that filter into a change-detector job.",
+  ],
+  [
+    ".github/workflows/ts-react-free2z.yml",
+    "Advisory build of the free2z React app, selected by an `on: pull_request: paths:` filter; " +
+      "gating it means first moving that filter into a change-detector job.",
+  ],
+  [
+    ".github/workflows/ts-svelte-free2z.yml",
+    "Advisory build of the SvelteKit port of free2z, selected by an `on: pull_request: paths:` " +
+      "filter; gating it means first moving that filter into a change-detector job.",
+  ],
+  [
+    ".github/workflows/zuuallet.yml",
+    "Advisory build of the Zuuallet reference wallet behind an `on: pull_request: paths:` filter. " +
+      "Its jobs restate gated work: `fmt`, `deny` and `clippy` run the same scripts as zuuli.yml's " +
+      "`rust_fmt`, `rust_deny` and `rust_clippy`, and the plugin's native macOS/Windows test " +
+      "execution moved to zuuli.yml's gated `rust_native_tests` in #610 rather than staying here " +
+      "ungated. What remains is Zuuallet-only build coverage, which cannot fail a merge and is not " +
+      "claimed to.",
+  ],
+  [
+    ".github/workflows/zuuli-linux-image.yml",
+    "Builds and publishes the pinned Linux CI container image: its pull-request leg is path-filtered " +
+      "and its `publish` leg only runs on main. The property that must hold for a merge — that the " +
+      "required jobs consume the pinned digest — is enforced from inside the gate by " +
+      "scripts/check-zuuli-linux-image.mjs.",
+  ],
+  [
+    ".github/workflows/zuuli-packaging.yml",
+    "Path-filtered Android/iOS/desktop packaging rehearsal, plus a weekly cache-free run. The Rust " +
+      "and TypeScript surface it packages is gated through zuuli.yml; this workflow proves the " +
+      "packaging steps, on a filter that would leave a required context pending.",
+  ],
+  [
+    ".github/workflows/zuuli-release.yml",
+    "Release pipeline: `push` to main on wallet/zuuli/release.json, plus manual dispatch. It runs " +
+      "after a merge, never on the pull request that produced it, so there is no verdict to gate.",
+  ],
+  [
+    ".github/workflows/zuuli-store-audit.yml",
+    "`workflow_dispatch` only — an operator-run read-only audit of the published store listing. No " +
+      "pull-request event triggers it.",
+  ],
+  [
+    ".github/workflows/zuuli-store-publish.yml",
+    "`workflow_dispatch` only — an operator-run store publication guarded by a typed confirmation " +
+      "input. No pull-request event triggers it.",
+  ],
+  [
+    ".github/workflows/zuuli-testflight-bootstrap.yml",
+    "`workflow_dispatch` only — an operator-run TestFlight bootstrap against an explicit source SHA. " +
+      "No pull-request event triggers it.",
+  ],
+  [
+    ".github/workflows/zuuli-testflight-recovery.yml",
+    "`workflow_dispatch` only — an operator-run TestFlight state inspection against an explicit " +
+      "source SHA. No pull-request event triggers it.",
+  ],
+]);
 
 const NEEDS_RESULT = /needs\.([A-Za-z0-9_-]+)\.result/g;
 const TO_JSON_NEEDS = /toJSON\(\s*needs\s*\)/;
@@ -481,12 +601,98 @@ export function protectedProducerFailures(published, protectedContexts) {
   return failures;
 }
 
+/// Require every workflow in the tree to be either gate-bearing or registered.
+///
+/// `gateContexts` maps each enumerated workflow to the check-run names its
+/// `gate` job(s) publish — empty for a workflow that has no gate at all. That
+/// distinction is the whole point: the rules above can only speak about a gate
+/// they can see, so a file with none is invisible to them and this is the only
+/// place it can be reached.
+///
+/// Four failures, and the last two are what keep the registry honest rather
+/// than merely present:
+///
+///   1. A workflow with no gate and no registration. The #610 defect.
+///   2. A workflow whose gate publishes no context branch protection requires.
+///      Such a gate can be perfectly wired and still decide nothing, which is
+///      the same "green means nothing" shape one level up.
+///   3. A registration naming a file the enumeration did not produce. Deleting
+///      the workflow and forgetting the entry looks identical to `workflowFiles`
+///      quietly stopping at a narrower population, so both are red and the
+///      message names the file that lost its coverage.
+///   4. A registration for a file that now has a gate, or with no substantive
+///      reason. An excuse that outlives its situation is worse than none,
+///      because it reads as considered.
+export function ungatedWorkflowFailures(
+  relativeFiles,
+  gateContexts,
+  registry,
+  protectedContexts,
+) {
+  const failures = [];
+  const enumerated = new Set(relativeFiles);
+
+  for (const file of relativeFiles) {
+    const contexts = gateContexts.get(file) ?? [];
+    if (contexts.length === 0) {
+      if (registry.has(file)) continue;
+      failures.push(
+        `${file}: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS; ` +
+          "every rule in this check reasons about a gate, so a workflow without one is judged by nothing at all " +
+          "— give it a gate whose name is a required status check, or register it with the reason it does not need one",
+      );
+      continue;
+    }
+    const required = contexts.filter((context) =>
+      protectedContexts.has(context),
+    );
+    if (required.length === 0) {
+      failures.push(
+        `${file}: gate job publishes ${contexts.map((context) => `"${context}"`).join(", ")}, ` +
+          `none of which branch protection requires (${[...protectedContexts].sort().join(", ")}); ` +
+          "a gate no required context resolves to cannot fail a merge, whatever it concludes",
+      );
+    }
+  }
+
+  for (const file of [...registry.keys()].sort()) {
+    if (!enumerated.has(file)) {
+      failures.push(
+        `UNGATED_WORKFLOWS registers ${file}, which is not among the ${relativeFiles.length} workflow file(s) ` +
+          "this check enumerated; either the workflow was deleted and the entry is stale, or the enumeration " +
+          "stopped covering it and that file is now judged by nothing",
+      );
+      continue;
+    }
+    if ((gateContexts.get(file) ?? []).length > 0) {
+      failures.push(
+        `UNGATED_WORKFLOWS registers ${file} as deliberately ungated, but it now publishes a gate; ` +
+          "remove the stale entry so the gate is held to the rules the registration excused it from",
+      );
+      continue;
+    }
+    const reason = (registry.get(file) ?? "").trim();
+    if (reason.length < MINIMUM_REGISTRY_REASON) {
+      failures.push(
+        `UNGATED_WORKFLOWS registers ${file} with no substantive reason ` +
+          `(${reason.length} character(s), at least ${MINIMUM_REGISTRY_REASON} required); ` +
+          "an unexplained exemption is indistinguishable from an oversight",
+      );
+    }
+  }
+
+  return failures;
+}
+
 export function scanRepository(root, options = {}) {
   const tolerated = options.tolerated ?? TOLERATED_CONTEXT_COLLISIONS;
   const protectedContexts = options.protectedContexts ?? PROTECTED_CONTEXTS;
   const exemptions = options.exempt ?? GATE_EXEMPT_JOBS;
+  const registry = options.ungated ?? UNGATED_WORKFLOWS;
   const failures = [];
   const published = [];
+  const relativeFiles = [];
+  const gateContexts = new Map();
   let gates = 0;
   const files = workflowFiles(root);
   for (const file of files) {
@@ -498,21 +704,37 @@ export function scanRepository(root, options = {}) {
     const jobs = jobsIn(lines);
     const siblings = jobs.map((job) => job.name);
     const exempt = new Set(exemptions.get(relativeFile) ?? []);
+    relativeFiles.push(relativeFile);
+    gateContexts.set(relativeFile, []);
     for (const job of jobs) {
-      published.push({
-        file: relativeFile,
-        job: job.name,
-        context: publishedContext(lines, job),
-      });
+      const context = publishedContext(lines, job);
+      published.push({ file: relativeFile, job: job.name, context });
       if (job.name !== "gate") continue;
       gates += 1;
+      gateContexts.get(relativeFile).push(context);
       failures.push(...gateFailures(relativeFile, lines, job, siblings, exempt));
     }
   }
   failures.push(...protectedToleranceFailures(tolerated, protectedContexts));
   failures.push(...contextCollisionFailures(published, tolerated));
   failures.push(...protectedProducerFailures(published, protectedContexts));
-  return { failures, gates, files: files.length, contexts: published.length };
+  failures.push(
+    ...ungatedWorkflowFailures(
+      relativeFiles,
+      gateContexts,
+      registry,
+      protectedContexts,
+    ),
+  );
+  return {
+    failures,
+    gates,
+    files: files.length,
+    contexts: published.length,
+    registered: [...registry.keys()].filter((file) =>
+      relativeFiles.includes(file),
+    ).length,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -626,6 +848,26 @@ jobs:
           echo "$results"
 `;
 
+/// A workflow with no gate at all — the shape rule 6 exists to reach. It is
+/// deliberately well-formed in every other respect, so nothing but the absence
+/// of a gate distinguishes it from a file this check would judge.
+const UNGATED_WORKFLOW = `name: aside fixture
+
+on:
+  workflow_dispatch:
+
+jobs:
+  aside:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo aside
+`;
+
+/// A reason long enough to satisfy MINIMUM_REGISTRY_REASON, so cases about
+/// *which* file is registered are not accidentally testing the reason rule.
+const FIXTURE_REASON =
+  "Dispatch-only fixture that no pull-request event can ever trigger.";
+
 /// An extra job in the same file as a gate that never awaits it.
 const UNAWAITED_JOB = `  gamma:
     needs: changes
@@ -662,6 +904,7 @@ function fixtureOptions(options) {
   return {
     protectedContexts: new Set(["gate"]),
     tolerated: new Map(),
+    ungated: new Map(),
     ...options,
   };
 }
@@ -784,10 +1027,15 @@ function selfTest() {
     { "fixture.yml": EXPLICIT_GATE, "other.yml": EXPLICIT_GATE },
     /2 job\(s\) publish the status-check context "gate"/,
   );
+  // Both contexts are declared protected here because rule 6 now also asks
+  // whether a gate resolves to a name branch protection requires; without that
+  // this case would fail on the second gate being decorative rather than on the
+  // property it exists to prove, which is that distinct `name:` values do not
+  // collide.
   expectClean(
     "two gates in one tree with distinct display names",
     { "fixture.yml": EXPLICIT_GATE, "other.yml": NAMED_GATE },
-    { gates: 2 },
+    { gates: 2, protectedContexts: new Set(["gate", "other / gate"]) },
   );
   // The tolerated map is keyed by the exact producing files, not by the name,
   // so a third producer of a knowingly-duplicated name is still a failure.
@@ -860,7 +1108,56 @@ function selfTest() {
     /requires the status-check context "gate", which 2 jobs publish/,
   );
 
-  console.log("check-workflow-gates self-test: 20 case(s) passed.");
+  // Rule 6: every workflow accounted for. These are the only cases in this file
+  // whose subject is a workflow the other rules cannot see at all, so each one
+  // is checked against a tree that is otherwise entirely well-formed — the
+  // gated `fixture.yml` is present throughout, and only the unjudged file
+  // changes.
+  expectDetected(
+    "a workflow with no gate that nothing registers",
+    { "fixture.yml": EXPLICIT_GATE, "aside.yml": UNGATED_WORKFLOW },
+    /aside\.yml: workflow publishes no gate job and is not registered/,
+  );
+  expectClean(
+    "a workflow registered as deliberately ungated",
+    { "fixture.yml": EXPLICIT_GATE, "aside.yml": UNGATED_WORKFLOW },
+    { ungated: new Map([[".github/workflows/aside.yml", FIXTURE_REASON]]) },
+  );
+  // The registration is only worth having if it decays: an entry naming a file
+  // the enumeration did not produce is either a deleted workflow whose excuse
+  // outlived it, or — the case this is really for — an enumeration that quietly
+  // stopped covering that file.
+  expectDetected(
+    "a registration for a workflow the enumeration did not produce",
+    { "fixture.yml": EXPLICIT_GATE },
+    /UNGATED_WORKFLOWS registers \.github\/workflows\/aside\.yml, which is not among the 1 workflow file\(s\)/,
+    { ungated: new Map([[".github/workflows/aside.yml", FIXTURE_REASON]]) },
+  );
+  expectDetected(
+    "a registration for a workflow that has since gained a gate",
+    { "fixture.yml": EXPLICIT_GATE, "other.yml": NAMED_GATE },
+    /UNGATED_WORKFLOWS registers \.github\/workflows\/other\.yml as deliberately ungated, but it now publishes a gate/,
+    {
+      protectedContexts: new Set(["gate", "other / gate"]),
+      ungated: new Map([[".github/workflows/other.yml", FIXTURE_REASON]]),
+    },
+  );
+  expectDetected(
+    "a registration with no substantive reason",
+    { "fixture.yml": EXPLICIT_GATE, "aside.yml": UNGATED_WORKFLOW },
+    /UNGATED_WORKFLOWS registers \.github\/workflows\/aside\.yml with no substantive reason/,
+    { ungated: new Map([[".github/workflows/aside.yml", "  because  "]]) },
+  );
+  // A gate can satisfy every wiring rule above and still resolve to no name
+  // branch protection requires, which is the whole defect one level up: it
+  // concludes correctly and cannot fail a merge.
+  expectDetected(
+    "a gate that no required context resolves to",
+    { "fixture.yml": EXPLICIT_GATE, "other.yml": NAMED_GATE },
+    /other\.yml: gate job publishes "other \/ gate", none of which branch protection requires/,
+  );
+
+  console.log("check-workflow-gates self-test: 26 case(s) passed.");
 }
 
 const mode = process.argv[2];
@@ -891,7 +1188,9 @@ if (result.failures.length) {
 }
 console.log(
   `Every gate inspects every job it awaits and covers every job in its file, ` +
-    `no two workflows publish one status-check context, and each protected context ` +
-    `(${[...PROTECTED_CONTEXTS].sort().join(", ")}) has exactly one producer and no allowlist entry: ` +
-    `${result.gates} gate(s), ${result.contexts} job(s), ${result.files} workflow file(s).`,
+    `no two workflows publish one status-check context, each protected context ` +
+    `(${[...PROTECTED_CONTEXTS].sort().join(", ")}) has exactly one producer and no allowlist entry, ` +
+    `and every workflow either feeds a required context or is registered as deliberately ungated: ` +
+    `${result.gates} gate(s), ${result.registered} registered ungated, ` +
+    `${result.contexts} job(s), ${result.files} workflow file(s).`,
 );

--- a/wallet/plugins/tauri-plugin-zcash/src/legacy_import_preview.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/legacy_import_preview.rs
@@ -948,6 +948,11 @@ mod tests {
     /// below is the exact mirror — identical bytes, length and mtime, differing
     /// only in identity — and between them each property is proved to be load
     /// bearing on its own.
+    ///
+    /// Not the same test as `in_place_source_content_change_after_copy_is_rejected`,
+    /// which writes a short string over the source: that one also changes the
+    /// length, so `len` alone would fail it. This is the strict form, where the
+    /// hash is the only thing left to notice.
     #[test]
     fn same_length_mtime_and_identity_but_distinct_content_after_copy_is_rejected() {
         let tree = TestTree::new();

--- a/wallet/plugins/tauri-plugin-zcash/src/legacy_import_preview.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/legacy_import_preview.rs
@@ -931,8 +931,25 @@ mod tests {
         }
     }
 
+    /// Content, isolated from every other observed property.
+    ///
+    /// This test used to be called `source_content_or_identity_change_after_copy`
+    /// and swapped a whole different file in with `fs::rename`, which changes the
+    /// bytes, the length, the modification time *and* the inode at once. Any one
+    /// of the four would have failed it, so it proved nothing in particular about
+    /// content and — despite the name — nothing at all about identity: it stayed
+    /// green under a build whose identity check was bypassed entirely (#610,
+    /// found while reviewing #598).
+    ///
+    /// So the replacement is written in place, at the same length, with the
+    /// modification time restored: `hash` is the only field of `Observation` that
+    /// differs, and the assertion below is therefore about the hash and nothing
+    /// else. `same_content_length_and_mtime_but_distinct_identity_after_copy_is_rejected`
+    /// below is the exact mirror — identical bytes, length and mtime, differing
+    /// only in identity — and between them each property is proved to be load
+    /// bearing on its own.
     #[test]
-    fn source_content_or_identity_change_after_copy_is_rejected() {
+    fn same_length_mtime_and_identity_but_distinct_content_after_copy_is_rejected() {
         let tree = TestTree::new();
         fs::create_dir(tree.legacy()).expect("legacy");
         let db = tree.legacy().join("wallet.sqlite");
@@ -945,10 +962,34 @@ mod tests {
             created_at: String::new(),
             backup_required: false,
         };
-        let replacement = tree.root.join("replacement.sqlite");
-        create_db(&replacement, &[valid_ufvk(1)]);
+
+        let original = observe(&db).expect("observe original source");
+        let mut edited = fs::read(&db).expect("read original source");
+        let last = edited.len() - 1;
+        edited[last] ^= 0xff;
+
         let rejected = inspect_wallet_with_hook(&tree.legacy(), &entry, false, || {
-            fs::rename(&replacement, &db).expect("replace source after copy");
+            // Truncating write, not a rename: the directory entry and the inode
+            // behind it survive, so identity is untouched.
+            fs::write(&db, &edited).expect("rewrite source in place after copy");
+            let file = OpenOptions::new()
+                .write(true)
+                .open(&db)
+                .expect("open rewritten source for timestamp restoration");
+            file.set_times(
+                fs::FileTimes::new().set_modified(
+                    original
+                        .modified
+                        .expect("SQLite source has a modification time"),
+                ),
+            )
+            .expect("restore source modification time");
+
+            let rewritten = observe(&db).expect("observe rewritten source");
+            assert_eq!(rewritten.len, original.len);
+            assert_eq!(rewritten.modified, original.modified);
+            assert_eq!(rewritten.identity, original.identity);
+            assert_ne!(rewritten.hash, original.hash);
         });
         assert_eq!(rejected, Err("Legacy data changed during preview."));
     }


### PR DESCRIPTION
Closes #610.

## The red before

`check-workflow-gates.mjs` grew rule 6 — every workflow file must either publish a
gate resolving to a required context, or be registered in `UNGATED_WORKFLOWS` with
a recorded reason. Run against **unmodified `origin/main`** with the registry
empty, the rule names twelve workflows, not one:

```
Required-gate wiring failed:
- .github/workflows/cache-cleanup.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/docs-about-free2z.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/ts-react-free2z.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/ts-svelte-free2z.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/zuuallet.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/zuuli-linux-image.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/zuuli-packaging.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/zuuli-release.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/zuuli-store-audit.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/zuuli-store-publish.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/zuuli-testflight-bootstrap.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
- .github/workflows/zuuli-testflight-recovery.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS
12 failure(s) across 2 gate(s) in 14 workflow file(s).
```

(The message is elided after the first clause here; the full text names the fix.)

Twelve of fourteen workflows had no gate, and the checker had nothing to say about
any of them — including four that run on `pull_request` and build real artifacts:
`zuuli-packaging.yml`, `zuuli-linux-image.yml`, `ts-react-free2z.yml`,
`ts-svelte-free2z.yml`. Not all of them *should* be gated, which is why this is a
registration and not a blanket rule. But "nothing to complain about" and "nothing
is checked" were producing the same green, and that is the #610 defect stated in
general.

Green after: `2 gate(s), 12 registered ungated, 56 job(s), 14 workflow file(s).`

## The execution gap: option 2, and why

The issue offered two ways to make a required check able to fail on Windows *test
execution*. I took the second — moving the plugin's native suite under
`zuuli.yml`'s existing gate — after working through what option 1 actually costs.

**Option 1 is not a one-line branch-protection edit.** `zuuallet.yml` is
`on: pull_request:` **with a `paths:` filter**. GitHub does not run a
path-filtered workflow for a pull request that matches nothing, and a required
context from a workflow that did not run *never reports* — every PR waits on it
forever with nothing anywhere going red. That is the failure mode called out in
this checker's own rule 5. Making `zuuallet.yml` gate-bearing therefore means
deleting its trigger filters, adding `merge_group:`, building it a
change-detector job, gating all six jobs on it, exempting the scheduled
`upstream-canary`, and *then* editing branch protection. That is a rewrite of the
workflow's whole selection model.

It also creates a second required context with none of the hardening the first
two carry: `check-github-actions-pins.mjs` treats `.github/workflows/zuuli.yml`
as *the* required workflow and holds its gate, its change detector and several of
its jobs to exact reviewed source. A new required context outside that contract
would be materially weaker than the ones it joins.

**What option 2 buys.** `rust_native_clippy` in `zuuli.yml` already runs on
`windows-latest` and `macos-latest`, under the required `gate`, with the right
selector, the right caches, and an exact-source contract in the pins checker. The
gap was never the platform — it was that the gated native job only ever *compiles*.
So:

- **New `rust_native_tests` job in `zuuli.yml`**, `name: Rust / native tests
  (${{ matrix.target_os }})`, same matrix and same selector as the lint job beside
  it, running the exact command the retired custody job ran:
  `cargo test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml`.
- **Added to the gate's `needs:`**, and `verifyGateResults` now derives its
  expected result from the shared native selector, so the gate can never accept a
  skip from it that it would reject from `rust_native_clippy`.
- **`custody-platforms` deleted from `zuuallet.yml`.** The *whole* matrix moved —
  macOS as well as Windows — so the suite is not split across workflows and not
  duplicated. A comment where it stood records where it went and why.

`zuuallet.yml` stays ungated and is registered as such, with the reason spelled
out: its remaining jobs restate gated work (`fmt`/`deny`/`clippy` run the same
scripts as `rust_fmt`/`rust_deny`/`rust_clippy`), and what is left is
Zuuallet-only build coverage that cannot fail a merge and is no longer claimed to.

The new job is held to its exact source by `REQUIRED_NATIVE_TESTS_JOB_LINES`, for
the same reason the lint job is: dropping `--locked`, dropping the Windows matrix
leg, or narrowing the selector would each silently restore the #610 state.

## Branch protection: no change required, and that is the point

**The required-context list stays exactly `["gate", "rs / gate"]`. There is nothing
for you to change, now or later.**

`rust_native_tests` reports into the existing `gate` context because the gate
awaits it — so the moment this merges, a Windows test failure fails a required
check. No new context to add, nothing to sequence, and no window in which a
required name nobody publishes leaves PRs pending forever. Given that #562 came
from exactly that class of mistake, avoiding the sequencing problem entirely was
worth more than the extra reach option 1 offers.

If you ever *do* want `zuuallet.yml` gated, rule 6 now makes the order explicit:
give it a gate with a distinct `name:` (never a bare `gate:` — #562), land that,
confirm the context is reporting on a real PR, and only then add it to branch
protection; the registration entry must be removed in the same change or the
checker fails on the stale entry.

## Proofs

**The anchor.** Narrowing the enumeration does not quietly shrink the population —
it names what it stopped covering. With `workflowFiles` filtered to skip two files:

```
- UNGATED_WORKFLOWS registers .github/workflows/zuuallet.yml, which is not among the 12 workflow file(s) this check enumerated; either the workflow was deleted and the entry is stale, or the enumeration stopped covering it and that file is now judged by nothing
- UNGATED_WORKFLOWS registers .github/workflows/zuuli-packaging.yml, which is not among the 12 workflow file(s) this check enumerated; ...
2 failure(s) across 2 gate(s) in 12 workflow file(s).
```

The registry is the anchor: shrink the population and the registered files go
missing; shrink it the other way and rule 5 loses a producer for a protected
context. No hand-maintained count to go stale.

**Stale registrations fail, three ways.**

```
# a registered workflow that does not exist
- UNGATED_WORKFLOWS registers .github/workflows/zuuli-ghost.yml, which is not among the 14 workflow file(s) this check enumerated; ...

# a registered workflow that has a gate (registered zuuli.yml)
- UNGATED_WORKFLOWS registers .github/workflows/zuuli.yml as deliberately ungated, but it now publishes a gate; remove the stale entry so the gate is held to the rules the registration excused it from

# an entry whose reason was emptied
- UNGATED_WORKFLOWS registers .github/workflows/cache-cleanup.yml with no substantive reason (0 character(s), at least 40 required); an unexplained exemption is indistinguishable from an oversight
```

**A newly added ungated workflow is red**, and the enumeration reads the directory
rather than `git ls-files`, so an *untracked* probe file is still seen:

```
- .github/workflows/probe-ungated.yml: workflow publishes no gate job and is not registered in UNGATED_WORKFLOWS; ...
1 failure(s) across 2 gate(s) in 15 workflow file(s).
```

**Negative controls, and each one broken in turn.** Six new cases in
`check-workflow-gates.mjs --self-test` (20 → 26). Each was proved non-inert by
mutating the rule it covers and confirming the self-test names *that* case:

| mutation | self-test reports |
| --- | --- |
| unregistered ungated workflow not reported | `a workflow with no gate that nothing registers was not detected` |
| registration no longer consulted | `a workflow registered as deliberately ungated should pass, got: ...` |
| missing-file registration tolerated | `a registration for a workflow the enumeration did not produce was not detected` |
| gained-a-gate registration tolerated | `a registration for a workflow that has since gained a gate was not detected` |
| `MINIMUM_REGISTRY_REASON = 0` | `a registration with no substantive reason was not detected` |
| gate-feeds-no-required-context tolerated | `a gate that no required context resolves to was not detected` |

Seven new cases in `check-github-actions-pins.mjs --self-test` (3 gate-verdict, 4
current-workflow mutation), broken the same way:

| mutation | self-test reports |
| --- | --- |
| `gate must await rust_native_tests` rule removed | `real workflow rejects native tests detached from gate: expected "gate must await rust_native_tests"` |
| exact native-tests contract removed | `real workflow rejects a weakened native test command: expected "...exact current-source native execution contract"` |
| `rust_native_tests` dropped from the shared native selector | `native tests cannot skip a Zuuallet-only Rust change: ... got success` |
| verdict loop skips `rust_native_tests` | `native tests cannot skip a Zuuallet-only Rust change: ... got success` |

## The nit in `legacy_import_preview.rs`

`source_content_or_identity_change_after_copy_is_rejected` claimed identity
coverage it did not have. It swapped a whole different file in with `fs::rename`,
which changes bytes, length, mtime *and* inode simultaneously — any one of the four
would have failed it, so it isolated neither content nor identity, and it stayed
green under the identity bypass #598's test kills.

Rather than rename it into a weaker promise, it now *earns* the content half:
`same_length_mtime_and_identity_but_distinct_content_after_copy_is_rejected`
rewrites the source **in place** at the same length and restores the modification
time, asserting inside the hook that `len`, `modified` and `identity` all match the
original and only `hash` differs. It is the exact mirror of
`same_content_length_and_mtime_but_distinct_identity_after_copy_is_rejected`
below it, so between the two every observed property is proved load-bearing on its
own.

**Mutation-proved, and the old test proved inert in the same run.** Blinding
`observe` to content (`hash: [0u8; 32]`, so neither `read_observed` nor the
snapshot comparison can see a byte change) and running both the new test and a
verbatim copy of the old one side by side:

```
test ...::same_length_mtime_and_identity_but_distinct_content_after_copy_is_rejected ... FAILED
test ...::probe_old_rename_based_content_or_identity_test ... ok
```

The old rename-based test passes a build that observes no content at all — its
`fs::rename` changes the inode, so the identity check alone still rejects it.
That is the exact shape of the complaint: the name said content *or* identity,
and it was load-bearing for neither. The identity mirror
(`same_content_length_and_mtime_but_distinct_identity_...`) and the in-place
neighbour both stay green under this mutation, as they should — each fails only
for its own reason.

Full suite restored and green: `142 passed; 0 failed` on the pinned 1.97.1
toolchain, `check-rust-fmt.sh` clean.

## Also

- `node scripts/check-workflow-gates.mjs` / `--self-test`,
  `check-github-actions-pins.mjs` / `--self-test`,
  `check-hash-domain-labels.mjs` / `--self-test`,
  `check-rust-toolchain.sh` / `--self-test`,
  `check-librustzcash-compat.mjs`, `check-zuuli-linux-image.mjs`,
  `check-zuuli-android-gate.mjs`, `check-zcash-permissions.mjs`,
  `check-public-repo-boundary.sh`, `check-rust-fmt.sh` — all green, bare and
  self-test.
- **#477:** bare `[[ ]]` / `(( ))` statements added: **0**. The one shell block
  added restates the reviewed toolchain-resolution step verbatim and every command
  in it is enforcing under `set -euo pipefail`.
- Every `uses:` added is 40-hex SHA-pinned with a version comment (#442), reusing
  references already present in the file.
- Deliberately untouched: `zuuli.yml`'s policy and gate-recheck steps (#591), and
  `WIRE.md` (#588). The only `zuuli.yml` edits are one new job and one job id
  appended to the gate's `needs:`.
