### PR TITLE
fix(zuuli): make native send policy authority unique

### DIFF
--- a/scripts/check-librustzcash-compat.mjs
+++ b/scripts/check-librustzcash-compat.mjs
@@ -14,6 +14,8 @@ const EXPECTED_LIBRUSTZCASH_SHA =
   "330e4c0aa9e25199acdb93a56bf70126d0d3f2b9";
 const SEND_SOURCE =
   "wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs";
+const NATIVE_SEND_POLICY_SOURCE =
+  "wallet/plugins/tauri-plugin-zcash/src/wallet/send/native.rs";
 const WALLET_SOURCE =
   "wallet/plugins/tauri-plugin-zcash/src/wallet/mod.rs";
 const LOCKFILES = [
@@ -203,7 +205,59 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     );
   }
 
-  const send = normalizedRust(snapshot.files[SEND_SOURCE]);
+  const orchestrationSource = snapshot.files[SEND_SOURCE];
+  const nativePolicySource = snapshot.files[NATIVE_SEND_POLICY_SOURCE];
+  const outsidePolicySource = snapshot.policyAuthorityPeers
+    .map((relative) => snapshot.files[relative])
+    .join("\n");
+  const send = normalizedRust(nativePolicySource);
+  const orchestration = normalizedRust(orchestrationSource);
+
+  if (
+    occurrences(orchestrationSource, "mod native;") !== 1 ||
+    occurrences(orchestrationSource, "pub mod native;") !== 0
+  ) {
+    errors.push(
+      "native send policy must remain in one private child module",
+    );
+  }
+  const forbiddenOutsidePolicyModule = [
+    "CreateErrT",
+    "DustOutputPolicy",
+    "GreedyInputSelector",
+    "LockRequest",
+    "OvkPolicy",
+    "ProposeTransferErrT",
+    "SingleOutputChangeStrategy",
+    "SpendPolicy",
+    "TxVersion",
+    "Zip317FeeRule",
+    "create_proposed_transactions",
+    "propose_transfer",
+  ];
+  for (const symbol of forbiddenOutsidePolicyModule) {
+    if (occurrences(outsidePolicySource, symbol) !== 0) {
+      errors.push(
+        `${symbol} must remain inaccessible outside the private native send policy module`,
+      );
+    }
+  }
+  const allowedPolicyExports = [
+    "pub(super) fn create_transactions<",
+    "pub(super) fn propose_fixed<",
+    "pub(super) fn propose_send_all_attempt<",
+  ];
+  if (
+    occurrences(send, "pub(super)") !== allowedPolicyExports.length ||
+    allowedPolicyExports.some((declaration) => occurrences(send, declaration) !== 1) ||
+    occurrences(send, "pub(crate)") !== 0 ||
+    occurrences(send, "pub(in ") !== 0 ||
+    occurrences(send, "pub ") !== 0
+  ) {
+    errors.push(
+      "private native send policy module must expose only its three audited safe boundaries",
+    );
+  }
   const lockHelper =
     "fn proposal_lock_request() -> Option<LockRequest> { None }";
   const versionHelper =
@@ -224,13 +278,13 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
   }
   const sharedProposalCore = rustFunctionBody(
     send,
-    "propose_native_send_with_policy",
+    "propose_with_policy",
   );
-  const defaultProposalBoundary = rustFunctionBody(send, "propose_native_send");
-  const fixedSendBoundary = rustFunctionBody(send, "propose_fixed_native_send");
+  const defaultProposalBoundary = rustFunctionBody(send, "propose_default");
+  const fixedSendBoundary = rustFunctionBody(send, "propose_fixed");
   const sendAllBoundary = rustFunctionBody(
     send,
-    "propose_send_all_native_attempt",
+    "propose_send_all_attempt",
   );
   const auditedTail =
     "request, ConfirmationsPolicy::default(), spend_policy, proposal_lock_request(), proposed_transaction_version(),";
@@ -245,7 +299,7 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     );
   }
   const defaultPolicyCall =
-    "propose_native_send_with_policy(db, params, account_id, request, &SpendPolicy::default())";
+    "propose_with_policy(db, params, account_id, request, &SpendPolicy::default())";
   if (
     defaultProposalBoundary === null ||
     occurrences(defaultProposalBoundary ?? "", defaultPolicyCall) !== 1 ||
@@ -256,7 +310,7 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     );
   }
   const sharedDefaultCall =
-    "propose_native_send(db, params, account_id, request)";
+    "propose_default(db, params, account_id, request)";
   if (
     fixedSendBoundary === null ||
     sendAllBoundary === null ||
@@ -267,6 +321,20 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     errors.push(
       "fixed send and send-all must each delegate exactly once to the shared default proposal boundary",
     );
+  }
+  for (const [boundary, call] of [
+    ["fixed send", "propose_fixed(db, &state.network, account_id, request)"],
+    [
+      "send-all",
+      "propose_send_all_attempt(db, &state.network, account_id, request)",
+    ],
+    ["transaction creation", "create_transactions("],
+  ]) {
+    if (occurrences(orchestration, call) !== 1) {
+      errors.push(
+        `${boundary} orchestration must enter its only accessible native send boundary exactly once`,
+      );
+    }
   }
 
   const wallet = normalizedRust(snapshot.files[WALLET_SOURCE]);
@@ -303,8 +371,34 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
 }
 
 function liveSnapshot() {
+  const policyAuthorityPeers = execFileSync(
+    "git",
+    [
+      "ls-files",
+      "--",
+      ":(glob)wallet/plugins/tauri-plugin-zcash/src/**/*.rs",
+    ],
+    { cwd: REPO_ROOT, encoding: "utf8" },
+  )
+    .trim()
+    .split("\n")
+    .filter(
+      (relative) =>
+        relative.length > 0 && relative !== NATIVE_SEND_POLICY_SOURCE,
+    );
+  if (!policyAuthorityPeers.includes(SEND_SOURCE)) {
+    throw new Error("native send authority census must include send orchestration");
+  }
+  const sourceFiles = [
+    ...new Set([
+      ...policyAuthorityPeers,
+      NATIVE_SEND_POLICY_SOURCE,
+      WALLET_SOURCE,
+      ...LOCKFILES,
+    ]),
+  ];
   const files = Object.fromEntries(
-    [SEND_SOURCE, WALLET_SOURCE, ...LOCKFILES].map((relative) => [
+    sourceFiles.map((relative) => [
       relative,
       fs.readFileSync(path.join(REPO_ROOT, relative), "utf8"),
     ]),
@@ -315,7 +409,11 @@ function liveSnapshot() {
     { cwd: REPO_ROOT, encoding: "utf8" },
   ).trim();
   const match = stage.match(/^160000 ([0-9a-f]{40}) 0\t/);
-  return { files, gitlink: match?.[1] ?? `invalid index entry: ${stage}` };
+  return {
+    files,
+    gitlink: match?.[1] ?? `invalid index entry: ${stage}`,
+    policyAuthorityPeers,
+  };
 }
 
 function replaceOnce(source, target, replacement, mutation) {
@@ -473,10 +571,98 @@ function runSelfTest() {
   ];
   const cases = [
     [
-      "LockRequest helper drift",
+      "native send policy module becomes public",
       mutated(
         baseline,
         SEND_SOURCE,
+        "mod native;",
+        "pub mod native;",
+        "native send policy module becomes public",
+      ),
+      "one private child module",
+    ],
+    [
+      "private policy core becomes parent-visible",
+      mutated(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "fn propose_with_policy<",
+        "pub(super) fn propose_with_policy<",
+        "private policy core becomes parent-visible",
+      ),
+      "expose only its three audited safe boundaries",
+    ],
+    [
+      "fixed safe boundary loses parent visibility",
+      mutated(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "pub(super) fn propose_fixed<",
+        "fn propose_fixed<",
+        "fixed safe boundary loses parent visibility",
+      ),
+      "expose only its three audited safe boundaries",
+    ],
+    [
+      "policy module re-exports a policy type",
+      mutated(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "use zcash_client_backend::fees::DustOutputPolicy;",
+        "use zcash_client_backend::fees::DustOutputPolicy;\npub(super) use zcash_client_backend::data_api::wallet::input_selection::SpendPolicy as ExposedSpendPolicy;",
+        "policy module re-exports a policy type",
+      ),
+      "expose only its three audited safe boundaries",
+    ],
+    [
+      "parent imports a forbidden policy type",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "use native::{create_transactions, propose_fixed, propose_send_all_attempt};",
+        "use native::{create_transactions, propose_fixed, propose_send_all_attempt};\nuse zcash_client_backend::data_api::wallet::input_selection::SpendPolicy;",
+        "parent imports a forbidden policy type",
+      ),
+      "SpendPolicy must remain inaccessible",
+    ],
+    [
+      "parent aliases direct proposal authority",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "use native::{create_transactions, propose_fixed, propose_send_all_attempt};",
+        "use native::{create_transactions, propose_fixed, propose_send_all_attempt};\nuse zcash_client_backend::data_api::wallet::propose_transfer as aliased_proposal;",
+        "parent aliases direct proposal authority",
+      ),
+      "propose_transfer must remain inaccessible",
+    ],
+    [
+      "fixed orchestration drops its only safe boundary",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "propose_fixed(db, &state.network, account_id, request)",
+        "propose_send_all_attempt(db, &state.network, account_id, request)",
+        "fixed orchestration drops its only safe boundary",
+      ),
+      "fixed send orchestration",
+    ],
+    [
+      "send-all orchestration drops its only safe boundary",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "propose_send_all_attempt(db, &state.network, account_id, request)",
+        "propose_fixed(db, &state.network, account_id, request)",
+        "send-all orchestration drops its only safe boundary",
+      ),
+      "send-all orchestration",
+    ],
+    [
+      "LockRequest helper drift",
+      mutated(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
         "fn proposal_lock_request() -> Option<LockRequest> {",
         "fn proposal_lock_request() -> Option<LockRequest> { panic!(\"mutant\");",
         "LockRequest helper drift",
@@ -487,7 +673,7 @@ function runSelfTest() {
       "TxVersion helper drift",
       mutated(
         baseline,
-        SEND_SOURCE,
+        NATIVE_SEND_POLICY_SOURCE,
         "fn proposed_transaction_version() -> Option<TxVersion> {",
         "fn proposed_transaction_version() -> Option<TxVersion> { panic!(\"mutant\");",
         "TxVersion helper drift",
@@ -498,9 +684,9 @@ function runSelfTest() {
       "shared proposal core is no longer recognizable",
       mutated(
         baseline,
-        SEND_SOURCE,
-        "fn propose_native_send_with_policy<",
-        "fn propose_native_send_with_policy_mutant<",
+        NATIVE_SEND_POLICY_SOURCE,
+        "fn propose_with_policy<",
+        "fn propose_with_policy_mutant<",
         "shared proposal core is no longer recognizable",
       ),
       "shared proposal core",
@@ -509,7 +695,7 @@ function runSelfTest() {
       "a duplicated direct proposal path revives the old split authority",
       mutated(
         baseline,
-        SEND_SOURCE,
+        NATIVE_SEND_POLICY_SOURCE,
         "    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(",
         "    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(\n    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(",
         "a duplicated direct proposal path revives the old split authority",
@@ -520,7 +706,7 @@ function runSelfTest() {
       "shared proposal core bypasses the exact lock decision",
       mutated(
         baseline,
-        SEND_SOURCE,
+        NATIVE_SEND_POLICY_SOURCE,
         "        proposal_lock_request(),\n",
         "        None,\n",
         "shared proposal core bypasses the exact lock decision",
@@ -531,7 +717,7 @@ function runSelfTest() {
       "shared proposal core bypasses the exact version decision",
       mutated(
         baseline,
-        SEND_SOURCE,
+        NATIVE_SEND_POLICY_SOURCE,
         "        proposed_transaction_version(),\n",
         "        None,\n",
         "shared proposal core bypasses the exact version decision",
@@ -542,9 +728,9 @@ function runSelfTest() {
       "default policy boundary bypasses the shared proposal core",
       mutated(
         baseline,
-        SEND_SOURCE,
-        "fn propose_native_send<",
-        "fn propose_native_send_mutant<",
+        NATIVE_SEND_POLICY_SOURCE,
+        "fn propose_default<",
+        "fn propose_default_mutant<",
         "default policy boundary bypasses the shared proposal core",
       ),
       "default native-send boundary",
@@ -553,9 +739,9 @@ function runSelfTest() {
       "fixed send bypasses the shared default boundary",
       mutatedOccurrence(
         baseline,
-        SEND_SOURCE,
-        "    propose_native_send(db, params, account_id, request)",
-        "    propose_native_send_with_policy(db, params, account_id, request, &SpendPolicy::default())",
+        NATIVE_SEND_POLICY_SOURCE,
+        "    propose_default(db, params, account_id, request)",
+        "    propose_with_policy(db, params, account_id, request, &SpendPolicy::default())",
         0,
         2,
         "fixed send bypasses the shared default boundary",
@@ -566,9 +752,9 @@ function runSelfTest() {
       "send-all bypasses the shared default boundary",
       mutatedOccurrence(
         baseline,
-        SEND_SOURCE,
-        "    propose_native_send(db, params, account_id, request)",
-        "    propose_native_send_with_policy(db, params, account_id, request, &SpendPolicy::default())",
+        NATIVE_SEND_POLICY_SOURCE,
+        "    propose_default(db, params, account_id, request)",
+        "    propose_with_policy(db, params, account_id, request, &SpendPolicy::default())",
         1,
         2,
         "send-all bypasses the shared default boundary",

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
@@ -11,23 +11,12 @@ use std::{
 use rand::{RngCore, rngs::OsRng};
 use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
-use zcash_client_backend::data_api::wallet::{
-    ConfirmationsPolicy, CreateErrT, LockRequest, ProposeTransferErrT, SpendingKeys,
-    create_proposed_transactions,
-    input_selection::{GreedyInputSelector, SpendPolicy},
-    propose_transfer,
-};
-use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead, WalletWrite};
-use zcash_client_backend::fees::DustOutputPolicy;
-use zcash_client_backend::fees::zip317::SingleOutputChangeStrategy;
-use zcash_client_backend::proposal::Proposal;
+use zcash_client_backend::data_api::WalletRead;
+use zcash_client_backend::data_api::wallet::{ConfirmationsPolicy, SpendingKeys};
 use zcash_client_backend::proto::service::{RawTransaction, TxFilter};
-use zcash_client_backend::wallet::OvkPolicy;
 use zcash_keys::address::Address;
-use zcash_primitives::transaction::{TxVersion, fees::zip317::FeeRule as Zip317FeeRule};
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::PoolType;
-use zcash_protocol::consensus;
 use zcash_protocol::memo::{Memo, MemoBytes};
 use zcash_protocol::value::Zatoshis;
 use zcash_protocol::{ShieldedPool, TxId};
@@ -40,6 +29,10 @@ use crate::models::{
 use crate::wallet::client::connect_to_lightwalletd;
 use crate::wallet::keys;
 use crate::wallet::{WalletProposal, WalletState};
+
+mod native;
+
+use native::{create_transactions, propose_fixed, propose_send_all_attempt};
 
 /// A transaction that has already been created in the wallet database.
 /// Retrying this record always rebroadcasts `raw_transaction`; it never signs
@@ -74,156 +67,6 @@ const SEND_CONFIRMATION_TOKEN_DOMAIN: &[u8] = b"ZUULI_SEND_CONFIRMATION_TOKEN\0"
 const SEND_FEE_POLICY: &str = "zip317-standard";
 const SEND_CHANGE_POLICY: &str = "zip317-shielded-auto";
 const SEND_CONFIRMATION_TTL: Duration = Duration::from_secs(2 * 60);
-
-fn proposal_lock_request() -> Option<LockRequest> {
-    // The process-local send state machine already serializes proposal and
-    // execution. Preserve the pre-locking API behavior until durable owner and
-    // unlock recovery semantics are designed together.
-    None
-}
-
-fn proposed_transaction_version() -> Option<TxVersion> {
-    // Let librustzcash select the consensus transaction version for the target
-    // height, matching the behavior before this argument was introduced.
-    None
-}
-
-type NativeSendChangeStrategy<DbT> = SingleOutputChangeStrategy<Zip317FeeRule, DbT>;
-type NativeSendProposalError<DbT> = ProposeTransferErrT<
-    DbT,
-    zcash_client_sqlite::wallet::commitment_tree::Error,
-    GreedyInputSelector<DbT>,
-    NativeSendChangeStrategy<DbT>,
->;
-
-/// The single production authority for money-affecting proposal policy. Both
-/// fixed-amount sends and every send-all retry cross this exact boundary.
-#[allow(clippy::type_complexity)]
-fn propose_native_send_with_policy<DbT, ParamsT>(
-    db: &mut DbT,
-    params: &ParamsT,
-    account_id: <DbT as InputSource>::AccountId,
-    request: zip321::TransactionRequest,
-    spend_policy: &SpendPolicy,
-) -> std::result::Result<
-    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
-    NativeSendProposalError<DbT>,
->
-where
-    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
-    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
-    ParamsT: consensus::Parameters + Clone,
-{
-    let input_selector = GreedyInputSelector::new();
-    let change_strategy = SingleOutputChangeStrategy::new(
-        Zip317FeeRule::standard(),
-        None,
-        ShieldedPool::Orchard,
-        DustOutputPolicy::default(),
-    );
-
-    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(
-        db,
-        params,
-        account_id,
-        &input_selector,
-        &change_strategy,
-        request,
-        ConfirmationsPolicy::default(),
-        spend_policy,
-        proposal_lock_request(),
-        proposed_transaction_version(),
-    )
-}
-
-#[allow(clippy::type_complexity)]
-fn propose_native_send<DbT, ParamsT>(
-    db: &mut DbT,
-    params: &ParamsT,
-    account_id: <DbT as InputSource>::AccountId,
-    request: zip321::TransactionRequest,
-) -> std::result::Result<
-    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
-    NativeSendProposalError<DbT>,
->
-where
-    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
-    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
-    ParamsT: consensus::Parameters + Clone,
-{
-    propose_native_send_with_policy(db, params, account_id, request, &SpendPolicy::default())
-}
-
-#[allow(clippy::type_complexity)]
-fn propose_fixed_native_send<DbT, ParamsT>(
-    db: &mut DbT,
-    params: &ParamsT,
-    account_id: <DbT as InputSource>::AccountId,
-    request: zip321::TransactionRequest,
-) -> std::result::Result<
-    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
-    NativeSendProposalError<DbT>,
->
-where
-    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
-    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
-    ParamsT: consensus::Parameters + Clone,
-{
-    propose_native_send(db, params, account_id, request)
-}
-
-#[allow(clippy::type_complexity)]
-fn propose_send_all_native_attempt<DbT, ParamsT>(
-    db: &mut DbT,
-    params: &ParamsT,
-    account_id: <DbT as InputSource>::AccountId,
-    request: zip321::TransactionRequest,
-) -> std::result::Result<
-    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
-    NativeSendProposalError<DbT>,
->
-where
-    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
-    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
-    ParamsT: consensus::Parameters + Clone,
-{
-    propose_native_send(db, params, account_id, request)
-}
-
-type NativeSendCreationError<DbT> = CreateErrT<
-    DbT,
-    std::convert::Infallible,
-    Zip317FeeRule,
-    std::convert::Infallible,
-    <DbT as InputSource>::NoteRef,
->;
-
-/// The single production authority for transaction creation and outgoing
-/// viewing-key retention.
-#[allow(clippy::type_complexity)]
-fn create_native_send_transactions<DbT, ParamsT>(
-    db: &mut DbT,
-    params: &ParamsT,
-    prover: &LocalTxProver,
-    spending_keys: &SpendingKeys,
-    proposal: &Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
-) -> std::result::Result<nonempty::NonEmpty<TxId>, NativeSendCreationError<DbT>>
-where
-    DbT: WalletWrite + WalletCommitmentTrees + InputSource,
-    ParamsT: consensus::Parameters + Clone,
-{
-    create_proposed_transactions::<_, _, std::convert::Infallible, _, std::convert::Infallible, _>(
-        db,
-        params,
-        prover,
-        prover,
-        spending_keys,
-        OvkPolicy::Sender,
-        proposal,
-        // Preserve the builder-derived expiry height for every proposal step.
-        None,
-    )
-}
 
 #[derive(Clone, Copy)]
 struct ConfirmationClock {
@@ -1543,7 +1386,7 @@ pub async fn propose_send(
         .copied()
         .ok_or(Error::SendError("no accounts found".into()))?;
 
-    let proposal = propose_fixed_native_send(db, &state.network, account_id, request)
+    let proposal = propose_fixed(db, &state.network, account_id, request)
         .map_err(|e| Error::SendError(format!("failed to propose transfer: {e:?}")));
 
     drop(db_guard);
@@ -1679,7 +1522,7 @@ pub async fn propose_send_all(
             .copied()
             .ok_or(Error::SendError("no accounts found".into()))?;
 
-        let result = propose_send_all_native_attempt(db, &state.network, account_id, request);
+        let result = propose_send_all_attempt(db, &state.network, account_id, request);
 
         drop(db_guard);
 
@@ -1905,7 +1748,7 @@ pub async fn execute_send(
 
     let mut transaction_created = false;
     let created = (|| -> Result<PendingBroadcast> {
-        let txids = create_native_send_transactions(
+        let txids = create_transactions(
             db,
             &state.network,
             prover,
@@ -1915,7 +1758,7 @@ pub async fn execute_send(
         .map_err(|e| Error::SendError(format!("failed to create transaction: {e:?}")))?;
         transaction_created = true;
 
-        // `create_proposed_transactions` returns `NonEmpty<TxId>`.
+        // The native creation boundary returns `NonEmpty<TxId>`.
         let txid = *txids.first();
         let tx = db
             .get_transaction(txid)
@@ -2369,19 +2212,7 @@ async fn broadcast_record(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use transparent::{
-        bundle::{OutPoint, TxOut},
-        keys::TransparentKeyScope,
-    };
     use zcash_address::unified::{Address as UnifiedAddress, Encoding, Receiver};
-    use zcash_client_backend::data_api::Account;
-    use zcash_client_backend::data_api::testing::{
-        orchard::OrchardPoolTester,
-        pool::{ShieldedPoolTester, dsl::TestDsl},
-    };
-    use zcash_client_backend::data_api::wallet::input_selection::TransparentSpendPolicy;
-    use zcash_client_backend::wallet::WalletTransparentOutput;
-    use zcash_client_sqlite::testing::{BlockCache, db::TestDbFactory};
     use zcash_protocol::consensus::{Network, NetworkType};
 
     const MAINNET_TADDR: &str = "t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs";
@@ -2392,201 +2223,6 @@ mod tests {
     const WALLET_ID: &str = "wallet-a";
     const SESSION_ID: [u8; 32] = [0x11; 32];
     const OTHER_SESSION_ID: [u8; 32] = [0x22; 32];
-
-    fn payment_request(
-        network: &impl consensus::Parameters,
-        recipient: &Address,
-        amount: u64,
-    ) -> zip321::TransactionRequest {
-        zip321::TransactionRequest::new(vec![zip321::Payment::without_memo(
-            recipient.to_zcash_address(network),
-            Zatoshis::const_from_u64(amount),
-        )])
-        .expect("the independently fixed test payment is valid")
-    }
-
-    #[test]
-    fn production_send_boundaries_preserve_pool_depth_fee_and_sender_recovery() {
-        const NOTE_VALUE: u64 = 60_000;
-        const FIXED_SEND_VALUE: u64 = 10_000;
-        const SEND_ALL_VALUE: u64 = 50_000;
-        const EXPECTED_FEE: u64 = 10_000;
-
-        let mut st =
-            TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
-                .build::<OrchardPoolTester>();
-        let (_, _, _) = st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(NOTE_VALUE));
-
-        let recipient_key = OrchardPoolTester::sk(&[0xf5; 32]);
-        let recipient = OrchardPoolTester::sk_default_address(&recipient_key);
-        let account = st.get_account();
-        let account_id = account.id();
-        let network = *st.network();
-
-        let immature = propose_fixed_native_send(
-            st.wallet_mut(),
-            &network,
-            account_id,
-            payment_request(&network, &recipient, FIXED_SEND_VALUE),
-        );
-        assert!(
-            immature.is_err(),
-            "an externally received Orchard note must not be spendable after one confirmation"
-        );
-
-        st.add_empty_blocks(9);
-        let proposal = propose_fixed_native_send(
-            st.wallet_mut(),
-            &network,
-            account_id,
-            payment_request(&network, &recipient, FIXED_SEND_VALUE),
-        )
-        .expect("the same Orchard note must be spendable after ten confirmations");
-        assert_eq!(proposal.steps().len(), 1);
-        assert_eq!(proposal.input_count_in_pool(PoolType::ORCHARD), 1);
-        assert_eq!(proposal.input_count_in_pool(PoolType::SAPLING), 0);
-        assert_eq!(
-            proposal
-                .steps()
-                .head
-                .change_count_in_pool(PoolType::ORCHARD),
-            1
-        );
-        assert_eq!(
-            proposal
-                .steps()
-                .head
-                .change_count_in_pool(PoolType::SAPLING),
-            0
-        );
-        assert_eq!(
-            u64::from(proposal.steps().head.balance().fee_required()),
-            EXPECTED_FEE
-        );
-
-        // Exercise the production wrapper used by every send-all retry. Spending the
-        // independently fixed note value minus the expected fee must consume the whole note,
-        // retain ZIP 317's fee, and return no value as change. Orchard padding can retain a
-        // zero-valued change entry, so value rather than vector shape is the behavior at stake.
-        let send_all_proposal = propose_send_all_native_attempt(
-            st.wallet_mut(),
-            &network,
-            account_id,
-            payment_request(&network, &recipient, SEND_ALL_VALUE),
-        )
-        .expect("the send-all-shaped request must be proposed by the shared boundary");
-        assert_eq!(send_all_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
-        assert_eq!(
-            u64::from(send_all_proposal.steps().head.balance().fee_required()),
-            EXPECTED_FEE
-        );
-        assert_eq!(
-            send_all_proposal
-                .steps()
-                .head
-                .balance()
-                .proposed_change()
-                .iter()
-                .map(|change| u64::from(change.value()))
-                .sum::<u64>(),
-            0
-        );
-
-        let spending_keys = SpendingKeys::from_unified_spending_key(account.usk().clone());
-        let prover = LocalTxProver::bundled();
-        let recovery_height = proposal.min_target_height().into();
-        let txids = create_native_send_transactions(
-            st.wallet_mut(),
-            &network,
-            &prover,
-            &spending_keys,
-            &proposal,
-        )
-        .expect("the production creation boundary must build and persist the transaction");
-        let tx = st
-            .wallet()
-            .get_transaction(txids.head)
-            .expect("the test wallet database remains readable")
-            .expect("the created transaction is persisted");
-        let sender_fvk = OrchardPoolTester::test_account_fvk(&st);
-        let (_, recovered_recipient, _) =
-            OrchardPoolTester::try_output_recovery(&network, recovery_height, &tx, &sender_fvk)
-                .expect("the sender OVK must recover the external Orchard output");
-        assert_eq!(recovered_recipient, recipient);
-    }
-
-    #[test]
-    fn production_transparent_spend_shields_change_to_orchard() {
-        const UTXO_VALUE: u64 = 60_000;
-        const PAYMENT_VALUE: u64 = 10_000;
-        const EXPECTED_CHANGE: u64 = 35_000;
-
-        let mut st =
-            TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
-                .build::<OrchardPoolTester>();
-        let account = st.get_account();
-        let account_id = account.id();
-        let network = *st.network();
-        let (transparent_recipient, _) = account.usk().default_transparent_address();
-        let received_height = st.add_empty_blocks(1);
-        let utxo = WalletTransparentOutput::from_parts(
-            OutPoint::fake(),
-            TxOut::new(
-                Zatoshis::const_from_u64(UTXO_VALUE),
-                transparent_recipient.script().into(),
-            ),
-            Some(received_height),
-            Some(account_id),
-            Some(TransparentKeyScope::EXTERNAL),
-            None,
-        )
-        .expect("the independently constructed transparent UTXO is valid");
-        st.wallet_mut()
-            .put_received_transparent_utxo(&utxo)
-            .expect("the real wallet database accepts the transparent UTXO");
-        st.add_empty_blocks(9);
-
-        let spend_policy =
-            SpendPolicy::default().with_transparent(TransparentSpendPolicy::any_account_addr());
-        let proposal = propose_native_send_with_policy(
-            st.wallet_mut(),
-            &network,
-            account_id,
-            payment_request(
-                &network,
-                &Address::from(transparent_recipient),
-                PAYMENT_VALUE,
-            ),
-            &spend_policy,
-        )
-        .expect("the production proposal core proposes the mature transparent spend");
-        assert_eq!(proposal.input_count_in_pool(PoolType::TRANSPARENT), 1);
-        assert_eq!(
-            proposal
-                .steps()
-                .head
-                .change_count_in_pool(PoolType::ORCHARD),
-            1
-        );
-        assert_eq!(
-            proposal
-                .steps()
-                .head
-                .change_count_in_pool(PoolType::SAPLING),
-            0
-        );
-        assert_eq!(
-            proposal
-                .steps()
-                .head
-                .balance()
-                .proposed_change()
-                .iter()
-                .map(|change| u64::from(change.value()))
-                .sum::<u64>(),
-            EXPECTED_CHANGE
-        );
-    }
 
     fn pending(status: BroadcastStatus) -> PendingBroadcast {
         PendingBroadcast {

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send/native.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send/native.rs
@@ -1,0 +1,376 @@
+use zcash_client_backend::data_api::wallet::{
+    ConfirmationsPolicy, CreateErrT, LockRequest, ProposeTransferErrT, SpendingKeys,
+    create_proposed_transactions,
+    input_selection::{GreedyInputSelector, SpendPolicy},
+    propose_transfer,
+};
+use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead, WalletWrite};
+use zcash_client_backend::fees::DustOutputPolicy;
+use zcash_client_backend::fees::zip317::SingleOutputChangeStrategy;
+use zcash_client_backend::proposal::Proposal;
+use zcash_client_backend::wallet::OvkPolicy;
+use zcash_primitives::transaction::{TxVersion, fees::zip317::FeeRule as Zip317FeeRule};
+use zcash_proofs::prover::LocalTxProver;
+use zcash_protocol::consensus;
+use zcash_protocol::{ShieldedPool, TxId};
+
+fn proposal_lock_request() -> Option<LockRequest> {
+    // The process-local send state machine already serializes proposal and
+    // execution. Preserve the pre-locking API behavior until durable owner and
+    // unlock recovery semantics are designed together.
+    None
+}
+
+fn proposed_transaction_version() -> Option<TxVersion> {
+    // Let librustzcash select the consensus transaction version for the target
+    // height, matching the behavior before this argument was introduced.
+    None
+}
+
+type NativeSendChangeStrategy<DbT> = SingleOutputChangeStrategy<Zip317FeeRule, DbT>;
+type NativeSendProposalError<DbT> = ProposeTransferErrT<
+    DbT,
+    zcash_client_sqlite::wallet::commitment_tree::Error,
+    GreedyInputSelector<DbT>,
+    NativeSendChangeStrategy<DbT>,
+>;
+
+/// The private production authority for money-affecting proposal policy.
+/// Parent orchestration can reach only the behavior-tested fixed and send-all
+/// entry points below, never this policy-bearing core or its types.
+#[allow(clippy::type_complexity)]
+fn propose_with_policy<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    account_id: <DbT as InputSource>::AccountId,
+    request: zip321::TransactionRequest,
+    spend_policy: &SpendPolicy,
+) -> std::result::Result<
+    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
+    NativeSendProposalError<DbT>,
+>
+where
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    ParamsT: consensus::Parameters + Clone,
+{
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = SingleOutputChangeStrategy::new(
+        Zip317FeeRule::standard(),
+        None,
+        ShieldedPool::Orchard,
+        DustOutputPolicy::default(),
+    );
+
+    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(
+        db,
+        params,
+        account_id,
+        &input_selector,
+        &change_strategy,
+        request,
+        ConfirmationsPolicy::default(),
+        spend_policy,
+        proposal_lock_request(),
+        proposed_transaction_version(),
+    )
+}
+
+#[allow(clippy::type_complexity)]
+fn propose_default<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    account_id: <DbT as InputSource>::AccountId,
+    request: zip321::TransactionRequest,
+) -> std::result::Result<
+    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
+    NativeSendProposalError<DbT>,
+>
+where
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    ParamsT: consensus::Parameters + Clone,
+{
+    propose_with_policy(db, params, account_id, request, &SpendPolicy::default())
+}
+
+#[allow(clippy::type_complexity)]
+pub(super) fn propose_fixed<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    account_id: <DbT as InputSource>::AccountId,
+    request: zip321::TransactionRequest,
+) -> std::result::Result<
+    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
+    NativeSendProposalError<DbT>,
+>
+where
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    ParamsT: consensus::Parameters + Clone,
+{
+    propose_default(db, params, account_id, request)
+}
+
+#[allow(clippy::type_complexity)]
+pub(super) fn propose_send_all_attempt<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    account_id: <DbT as InputSource>::AccountId,
+    request: zip321::TransactionRequest,
+) -> std::result::Result<
+    Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
+    NativeSendProposalError<DbT>,
+>
+where
+    DbT: WalletWrite + InputSource<Error = <DbT as WalletRead>::Error>,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    ParamsT: consensus::Parameters + Clone,
+{
+    propose_default(db, params, account_id, request)
+}
+
+type NativeSendCreationError<DbT> = CreateErrT<
+    DbT,
+    std::convert::Infallible,
+    Zip317FeeRule,
+    std::convert::Infallible,
+    <DbT as InputSource>::NoteRef,
+>;
+
+/// The private production authority for transaction creation and outgoing
+/// viewing-key retention.
+#[allow(clippy::type_complexity)]
+pub(super) fn create_transactions<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    prover: &LocalTxProver,
+    spending_keys: &SpendingKeys,
+    proposal: &Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
+) -> std::result::Result<nonempty::NonEmpty<TxId>, NativeSendCreationError<DbT>>
+where
+    DbT: WalletWrite + WalletCommitmentTrees + InputSource,
+    ParamsT: consensus::Parameters + Clone,
+{
+    create_proposed_transactions::<_, _, std::convert::Infallible, _, std::convert::Infallible, _>(
+        db,
+        params,
+        prover,
+        prover,
+        spending_keys,
+        OvkPolicy::Sender,
+        proposal,
+        // Preserve the builder-derived expiry height for every proposal step.
+        None,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use transparent::{
+        bundle::{OutPoint, TxOut},
+        keys::TransparentKeyScope,
+    };
+    use zcash_client_backend::data_api::Account;
+    use zcash_client_backend::data_api::testing::{
+        orchard::OrchardPoolTester,
+        pool::{ShieldedPoolTester, dsl::TestDsl},
+    };
+    use zcash_client_backend::data_api::wallet::input_selection::TransparentSpendPolicy;
+    use zcash_client_backend::wallet::WalletTransparentOutput;
+    use zcash_client_sqlite::testing::{BlockCache, db::TestDbFactory};
+    use zcash_protocol::PoolType;
+    use zcash_protocol::value::Zatoshis;
+
+    fn payment_request(
+        network: &impl consensus::Parameters,
+        recipient: &zcash_keys::address::Address,
+        amount: u64,
+    ) -> zip321::TransactionRequest {
+        zip321::TransactionRequest::new(vec![zip321::Payment::without_memo(
+            recipient.to_zcash_address(network),
+            Zatoshis::const_from_u64(amount),
+        )])
+        .expect("the independently fixed test payment is valid")
+    }
+
+    #[test]
+    fn production_send_boundaries_preserve_pool_depth_fee_and_sender_recovery() {
+        const NOTE_VALUE: u64 = 60_000;
+        const FIXED_SEND_VALUE: u64 = 10_000;
+        const SEND_ALL_VALUE: u64 = 50_000;
+        const EXPECTED_FEE: u64 = 10_000;
+
+        let mut st =
+            TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
+                .build::<OrchardPoolTester>();
+        let (_, _, _) = st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(NOTE_VALUE));
+
+        let recipient_key = OrchardPoolTester::sk(&[0xf5; 32]);
+        let recipient = OrchardPoolTester::sk_default_address(&recipient_key);
+        let account = st.get_account();
+        let account_id = account.id();
+        let network = *st.network();
+
+        let immature = propose_fixed(
+            st.wallet_mut(),
+            &network,
+            account_id,
+            payment_request(&network, &recipient, FIXED_SEND_VALUE),
+        );
+        assert!(
+            immature.is_err(),
+            "an externally received Orchard note must not be spendable after one confirmation"
+        );
+
+        st.add_empty_blocks(9);
+        let proposal = propose_fixed(
+            st.wallet_mut(),
+            &network,
+            account_id,
+            payment_request(&network, &recipient, FIXED_SEND_VALUE),
+        )
+        .expect("the same Orchard note must be spendable after ten confirmations");
+        assert_eq!(proposal.steps().len(), 1);
+        assert_eq!(proposal.input_count_in_pool(PoolType::ORCHARD), 1);
+        assert_eq!(proposal.input_count_in_pool(PoolType::SAPLING), 0);
+        assert_eq!(
+            proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::ORCHARD),
+            1
+        );
+        assert_eq!(
+            proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::SAPLING),
+            0
+        );
+        assert_eq!(
+            u64::from(proposal.steps().head.balance().fee_required()),
+            EXPECTED_FEE
+        );
+
+        let send_all_proposal = propose_send_all_attempt(
+            st.wallet_mut(),
+            &network,
+            account_id,
+            payment_request(&network, &recipient, SEND_ALL_VALUE),
+        )
+        .expect("the send-all-shaped request must be proposed by the shared boundary");
+        assert_eq!(send_all_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
+        assert_eq!(
+            u64::from(send_all_proposal.steps().head.balance().fee_required()),
+            EXPECTED_FEE
+        );
+        assert_eq!(
+            send_all_proposal
+                .steps()
+                .head
+                .balance()
+                .proposed_change()
+                .iter()
+                .map(|change| u64::from(change.value()))
+                .sum::<u64>(),
+            0
+        );
+
+        let spending_keys = SpendingKeys::from_unified_spending_key(account.usk().clone());
+        let prover = LocalTxProver::bundled();
+        let recovery_height = proposal.min_target_height().into();
+        let txids = create_transactions(
+            st.wallet_mut(),
+            &network,
+            &prover,
+            &spending_keys,
+            &proposal,
+        )
+        .expect("the production creation boundary must build and persist the transaction");
+        let tx = st
+            .wallet()
+            .get_transaction(txids.head)
+            .expect("the test wallet database remains readable")
+            .expect("the created transaction is persisted");
+        let sender_fvk = OrchardPoolTester::test_account_fvk(&st);
+        let (_, recovered_recipient, _) =
+            OrchardPoolTester::try_output_recovery(&network, recovery_height, &tx, &sender_fvk)
+                .expect("the sender OVK must recover the external Orchard output");
+        assert_eq!(recovered_recipient, recipient);
+    }
+
+    #[test]
+    fn production_transparent_spend_shields_change_to_orchard() {
+        const UTXO_VALUE: u64 = 60_000;
+        const PAYMENT_VALUE: u64 = 10_000;
+        const EXPECTED_CHANGE: u64 = 35_000;
+
+        let mut st =
+            TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
+                .build::<OrchardPoolTester>();
+        let account = st.get_account();
+        let account_id = account.id();
+        let network = *st.network();
+        let (transparent_recipient, _) = account.usk().default_transparent_address();
+        let received_height = st.add_empty_blocks(1);
+        let utxo = WalletTransparentOutput::from_parts(
+            OutPoint::fake(),
+            TxOut::new(
+                Zatoshis::const_from_u64(UTXO_VALUE),
+                transparent_recipient.script().into(),
+            ),
+            Some(received_height),
+            Some(account_id),
+            Some(TransparentKeyScope::EXTERNAL),
+            None,
+        )
+        .expect("the independently constructed transparent UTXO is valid");
+        st.wallet_mut()
+            .put_received_transparent_utxo(&utxo)
+            .expect("the real wallet database accepts the transparent UTXO");
+        st.add_empty_blocks(9);
+
+        let spend_policy =
+            SpendPolicy::default().with_transparent(TransparentSpendPolicy::any_account_addr());
+        let proposal = propose_with_policy(
+            st.wallet_mut(),
+            &network,
+            account_id,
+            payment_request(
+                &network,
+                &zcash_keys::address::Address::from(transparent_recipient),
+                PAYMENT_VALUE,
+            ),
+            &spend_policy,
+        )
+        .expect("the private production proposal core proposes the mature transparent spend");
+        assert_eq!(proposal.input_count_in_pool(PoolType::TRANSPARENT), 1);
+        assert_eq!(
+            proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::ORCHARD),
+            1
+        );
+        assert_eq!(
+            proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::SAPLING),
+            0
+        );
+        assert_eq!(
+            proposal
+                .steps()
+                .head
+                .balance()
+                .proposed_change()
+                .iter()
+                .map(|change| u64::from(change.value()))
+                .sum::<u64>(),
+            EXPECTED_CHANGE
+        );
+    }
+}

--- a/wallet/zuuli/scripts/send-review-boundary.node-test.mjs
+++ b/wallet/zuuli/scripts/send-review-boundary.node-test.mjs
@@ -2,109 +2,6 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-function rustCodeOnly(source) {
-  let output = "";
-  let state = "code";
-  let blockDepth = 0;
-  let rawTerminator = "";
-
-  const charLiteralLength = (offset) => {
-    if (source[offset] !== "'") return 0;
-    let cursor = offset + 1;
-    if (source[cursor] === "\\") {
-      cursor += 1;
-      if (source[cursor] === "u" && source[cursor + 1] === "{") {
-        const close = source.indexOf("}", cursor + 2);
-        if (close < 0) return 0;
-        cursor = close + 1;
-      } else if (source[cursor] === "x") {
-        cursor += 3;
-      } else {
-        cursor += 1;
-      }
-    } else {
-      cursor += 1;
-    }
-    return source[cursor] === "'" ? cursor - offset + 1 : 0;
-  };
-
-  for (let index = 0; index < source.length; index += 1) {
-    const current = source[index];
-    const next = source[index + 1];
-
-    if (state === "line-comment") {
-      output += current === "\n" ? "\n" : " ";
-      if (current === "\n") state = "code";
-      continue;
-    }
-    if (state === "block-comment") {
-      if (current === "/" && next === "*") {
-        blockDepth += 1;
-        output += "  ";
-        index += 1;
-      } else if (current === "*" && next === "/") {
-        blockDepth -= 1;
-        output += "  ";
-        index += 1;
-        if (blockDepth === 0) state = "code";
-      } else {
-        output += current === "\n" ? "\n" : " ";
-      }
-      continue;
-    }
-    if (state === "string") {
-      output += current === "\n" ? "\n" : " ";
-      if (current === "\\" && next !== undefined) {
-        output += next === "\n" ? "\n" : " ";
-        index += 1;
-      } else if (current === '"') {
-        state = "code";
-      }
-      continue;
-    }
-    if (state === "raw-string") {
-      if (source.startsWith(rawTerminator, index)) {
-        output += " ".repeat(rawTerminator.length);
-        index += rawTerminator.length - 1;
-        state = "code";
-      } else {
-        output += current === "\n" ? "\n" : " ";
-      }
-      continue;
-    }
-
-    const charLength = charLiteralLength(index);
-    const rawStart = source
-      .slice(index)
-      .match(/^(?:br|cr|r)(#{0,255})"/);
-    if (charLength > 0) {
-      output += " ".repeat(charLength);
-      index += charLength - 1;
-    } else if (rawStart) {
-      rawTerminator = `"${rawStart[1]}`;
-      output += " ".repeat(rawStart[0].length);
-      index += rawStart[0].length - 1;
-      state = "raw-string";
-    } else if (current === "/" && next === "/") {
-      output += "  ";
-      index += 1;
-      state = "line-comment";
-    } else if (current === "/" && next === "*") {
-      output += "  ";
-      index += 1;
-      blockDepth = 1;
-      state = "block-comment";
-    } else if (current === '"') {
-      output += " ";
-      state = "string";
-    } else {
-      output += current;
-    }
-  }
-
-  return output;
-}
-
 const [
   send,
   bridge,
@@ -138,45 +35,6 @@ const [
     "../zuuallet/src-tauri/src/lib.rs",
   ].map((path) => readFile(new URL(`../${path}`, import.meta.url), "utf8")),
 );
-
-test("Rust routing scan ignores comments and literals without hiding live code", () => {
-  const route = "propose_fixed_native_send(";
-  const hidden = [
-    ["line comment", `// ${route}\nlet live = true;`],
-    ["block comment", `/* ${route} */ let live = true;`],
-    ["nested block comment", `/* outer /* nested */ ${route} */ let live = true;`],
-    ["normal string", `let marker = "${route}";`],
-    ["byte string", `let marker = b"${route}";`],
-    ["escaped quote in string", String.raw`let marker = "escaped \" ${route}";`],
-    ["raw string with an embedded quote", `let marker = r#"embedded " ${route}"#;`],
-    ["byte raw string", `let marker = br##"embedded "# ${route}"##;`],
-  ];
-  for (const [name, source] of hidden) {
-    assert.equal(
-      rustCodeOnly(source).includes(route),
-      false,
-      `${name} cannot forge a native proposal route`,
-    );
-  }
-
-  const visible = [
-    ["ordinary code", `${route});`],
-    ["line comment termination", `// noise\n${route});`],
-    ["block comment termination", `/* noise */ ${route});`],
-    ["raw string termination", `let noise = r#"embedded " quote"#; ${route});`],
-    ["comment markers inside a string", `let noise = "// /*"; ${route});`],
-    ["double quote character literal", `let quote = b'"'; ${route});`],
-    ["apostrophe character literal", String.raw`let quote = '\''; ${route});`],
-    ["lifetime", `fn borrow<'a>(value: &'a str) { ${route}); }`],
-  ];
-  for (const [name, source] of visible) {
-    assert.equal(
-      rustCodeOnly(source).includes(route),
-      true,
-      `${name} must leave a real native proposal route visible`,
-    );
-  }
-});
 
 test("confirmation renders only the immutable native review", () => {
   assert.match(send, /proposal\.review\.payments/);
@@ -334,7 +192,6 @@ test("every stale UI path has an exact native discard boundary", () => {
 });
 
 test("ZIP-321 parsing is single-payment and bound to native network authority", () => {
-  const nativeSendCode = rustCodeOnly(nativeSend);
   const parseCommand = nativeCommands.match(
     /pub\(crate\) async fn parse_payment_uri[\s\S]*?(?=\n\/\/\/|\n#\[command\])/,
   )?.[0];
@@ -351,32 +208,4 @@ test("ZIP-321 parsing is single-payment and bound to native network authority", 
   assert.match(nativeSend, /zip321_requires_exactly_one_payment/);
   assert.match(nativeSend, /zip321_recipient_is_bound_to_the_active_network/);
   assert.match(nativeSend, /unified_address_requires_a_receiver_this_wallet_can_pay/);
-  for (const [functionName, nativeProposalBoundary] of [
-    ["propose_send", "propose_fixed_native_send("],
-    ["propose_send_all", "propose_send_all_native_attempt("],
-  ]) {
-    const proposalFunction = nativeSendCode.match(
-      new RegExp(`pub async fn ${functionName}\\([\\s\\S]*?(?=\\npub async fn )`),
-    )?.[0];
-    assert.ok(proposalFunction, `${functionName} must remain inspectable`);
-    const validationIndex = proposalFunction.indexOf("parse_recipient(&state.network");
-    const proposalIndex = proposalFunction.indexOf(nativeProposalBoundary);
-    assert.notEqual(validationIndex, -1, `${functionName} must validate its recipient`);
-    assert.notEqual(proposalIndex, -1, `${functionName} must build a native proposal`);
-    for (const lowerLevelBoundary of [
-      "propose_native_send_with_policy(",
-      "propose_native_send(",
-      "propose_transfer::<",
-    ]) {
-      assert.equal(
-        proposalFunction.indexOf(lowerLevelBoundary),
-        -1,
-        `${functionName} must not bypass its dedicated native proposal boundary`,
-      );
-    }
-    assert.ok(
-      validationIndex < proposalIndex,
-      `${functionName} must reject incompatible recipients before native proposal`,
-    );
-  }
 });


### PR DESCRIPTION
Closes #547

Fix-forward for the architectural bypass found after #613 review.

- moves all native proposal policy authority into a private child module
- exposes only the three safe fixed/send-all/create orchestration boundaries
- makes the exact dead-route/Sapling-only alias mutant fail compilation with E0603
- fail-closed scans the parent and every other plugin Rust file for direct authority symbols and aliases
- removes the comment/string-sensitive frontend routing oracle

Mutation proof before this PR:

- 72 compatibility source mutants killed, including public-module, export-inventory, alias, and orchestration bypasses
- all five money-behavior mutants independently red
- exact impossible-branch alias mutant red both at compile time and in the compatibility verdict

Restored green on the exact tree: focused behavior 2/2, plugin 144/144, frontend 6/6, fmt, clippy, deny, compatibility, actions, workflow, toolchain, and public-boundary gates.

The PR tree is byte-for-byte identical to the locally mutation-tested tree 973eb31d77393f784c12ce821a2344d457ac2783. Independent adversarial review is running against that exact tree.