### PR TITLE
security(relay): commit replay keys after authentication

### DIFF
--- a/rs/crates/f2z-relay-proto/src/command.rs
+++ b/rs/crates/f2z-relay-proto/src/command.rs
@@ -15,11 +15,14 @@
 //!    and a non-canonical structure inside it would survive a frame-level
 //!    re-encode untouched.
 //! 2. Timestamp window (§5.5) → `ERR_STALE_TIMESTAMP`.
-//! 3. `(signer_key, nonce)` seen-set (§5.5) → `ERR_REPLAY`.
+//! 3. Preflight `(signer_key, nonce)` against the seen-set (§5.5) →
+//!    `ERR_REPLAY`, without inserting it.
 //! 4. Rebuild the transcript **from the relay's own `relay_id` and its own
 //!    `channel_binding`** and verify the signature → `ERR_BAD_SIGNATURE`.
 //! 5. Address and self-authentication rules (§6.2, §6.3) → `ERR_NO_ACCESS`.
 //! 6. Policy — the payload's padding bucket (§9).
+//! 7. Commit the authenticated `(signer_key, nonce)` with insert-if-absent
+//!    semantics. A competing commit loses as `ERR_REPLAY`.
 //!
 //! Steps 2 and 3 precede the signature check because they are cheap and they
 //! are the flood-resistant filters. Step 5 follows it so that an unsigned guess
@@ -484,12 +487,19 @@ impl<C: RelayCommand> SignedCommand<C> {
     }
 }
 
-/// A command that passed every check of §5.1.
+/// A command accepted through every check prescribed for `C`.
 ///
 /// There is no public constructor. The only way to hold one is to have run
-/// [`CommandVerifier::verify`] or [`CommandVerifier::accept_unsigned`], which
-/// is what makes "we verified this" a fact about the type rather than a comment
-/// on a call site.
+/// [`CommandVerifier::verify`] for a signed command, or
+/// [`CommandVerifier::accept_unsigned`] for an unsigned command. The signed
+/// path proves §5.1, including the timestamp window, signature, command policy,
+/// and a replay key committed to that verifier's process-local [`SeenSet`]. It
+/// does not attest that a relay also committed external, durable, or
+/// cross-worker state. The unsigned path has no authenticator, timestamp, or
+/// replay key to verify; it proves canonical encoding plus that command's own
+/// rules and stores zero values in the authentication-only accessors below.
+/// Holding this type therefore proves the checks for `C`'s prescribed path,
+/// not that an arbitrary `Verified<C>` was authenticated.
 #[derive(Debug)]
 pub struct Verified<C: RelayCommand> {
     body: C::Request,
@@ -536,20 +546,24 @@ impl<C: RelayCommand> Verified<C> {
         self.address
     }
 
-    /// The key that signed it — what §5.1 step 5 compares against the key
-    /// registered for the address. [`PublicKey::zero`] for unsigned commands.
+    /// For a signed command, the key that signed it — what §5.1 step 5 compares
+    /// against the key registered for the address. [`PublicKey::zero`] for an
+    /// unsigned command, which has no signer.
     #[must_use]
     pub const fn signer_key(&self) -> PublicKey {
         self.signer_key
     }
 
-    /// The client clock the command carried, already inside the window.
+    /// For a signed command, the client clock it carried after the timestamp
+    /// window check. Zero for an unsigned command, which carries no timestamp.
     #[must_use]
     pub const fn timestamp_ms(&self) -> u64 {
         self.timestamp_ms
     }
 
-    /// The nonce, already recorded in the seen-set.
+    /// For a signed command, its nonce after the corresponding replay key was
+    /// committed to the seen-set. [`Nonce::zero`] for an unsigned command,
+    /// which carries no nonce and does not touch the seen-set.
     #[must_use]
     pub const fn nonce(&self) -> Nonce {
         self.nonce
@@ -565,6 +579,11 @@ impl<C: RelayCommand> Verified<C> {
 /// replay-across-relays attack and §5.3's replay-across-sessions attack are
 /// both closed by exactly that. A per-command parameter would be a per-command
 /// opportunity to pass the peer's value.
+///
+/// Cloning this value snapshots its [`SeenSet`]; it does not share replay
+/// authority. Callers processing one replay domain in parallel must synchronize
+/// one verifier or enforce the same atomic commit in external state. Likewise,
+/// the in-memory set alone does not satisfy a durable anti-replay policy.
 #[derive(Clone, Debug)]
 pub struct CommandVerifier {
     transcripts: TranscriptBuilder,
@@ -663,9 +682,10 @@ impl CommandVerifier {
 
         // Step 2.
         self.window.check(now_ms, auth.timestamp_ms)?;
-        // Step 3.
-        self.seen
-            .observe(now_ms, ReplayKey::new(auth.signer_key, auth.nonce))?;
+        // Step 3 checks only. Inserting an unauthenticated pair here would let
+        // random invalid signatures consume the bounded global replay set.
+        let replay_key = ReplayKey::new(auth.signer_key, auth.nonce);
+        self.seen.preflight(now_ms, &replay_key)?;
 
         // Step 4. `relay_id` and `channel_binding` come from `self`; only the
         // rest comes from the frame.
@@ -686,6 +706,11 @@ impl CommandVerifier {
         if let Some(payload) = C::payload(body.value()) {
             self.padding.validate_payload(payload)?;
         }
+
+        // Commit only after authentication and every command check succeeds.
+        // `commit` repeats the membership and capacity checks so two callers
+        // that both won preflight cannot both accept the same pair.
+        self.seen.commit(now_ms, replay_key)?;
 
         Ok(Verified {
             address: auth.address,
@@ -896,11 +921,16 @@ mod tests {
                 send_key: victim.public_key(),
             },
         );
+        let mut verifier = verifier();
         assert_eq!(
-            verifier()
+            verifier
                 .verify::<ops::BindSend>(NOW, 1, &stolen)
                 .map(|_| ()),
             Err(ProtoError::Wire(ErrorCode::NoAccess))
+        );
+        assert!(
+            verifier.seen_set().is_empty(),
+            "an authenticated but unauthorized frame must not consume replay capacity"
         );
     }
 
@@ -1038,6 +1068,55 @@ mod tests {
     }
 
     #[test]
+    fn verified_metadata_matches_the_signed_or_unsigned_acceptance_path() {
+        let key = SigningKey::from_seed(&[0x81; 32]);
+        let signer_key = key.public_key();
+        let signed_address = QueueAddress::new([0x83; 32]);
+        let signed_nonce = nonce(0x82);
+        let verification_now = NOW + 1;
+        let signed = SignedCommand::<ops::Append>::create(
+            &transcripts(),
+            17,
+            signed_address,
+            NOW,
+            signed_nonce,
+            &key,
+            &AppendRequest {
+                payload: Payload::new(vec![0u8; 1024]).unwrap(),
+            },
+        )
+        .unwrap();
+        let mut verifier = verifier();
+
+        let verified_signed = verifier
+            .verify::<ops::Append>(verification_now, 17, &signed.request().unwrap())
+            .unwrap();
+        assert_eq!(verified_signed.address(), signed_address);
+        assert_eq!(verified_signed.signer_key(), signer_key);
+        assert_eq!(verified_signed.timestamp_ms(), NOW);
+        assert_eq!(verified_signed.nonce(), signed_nonce);
+        assert!(
+            verifier
+                .seen_set()
+                .contains(&ReplayKey::new(signer_key, signed_nonce)),
+            "returning the signed result must imply its replay key is committed"
+        );
+
+        let unsigned =
+            Request::new(Command::Ping.code(), CommandAuth::Unsigned, Vec::new()).unwrap();
+        let verified_unsigned = verifier.accept_unsigned::<ops::Ping>(&unsigned).unwrap();
+        assert_eq!(verified_unsigned.address(), QueueAddress::zero());
+        assert_eq!(verified_unsigned.signer_key(), PublicKey::zero());
+        assert_eq!(verified_unsigned.timestamp_ms(), 0);
+        assert_eq!(verified_unsigned.nonce(), Nonce::zero());
+        assert_eq!(
+            verifier.seen_set().len(),
+            1,
+            "the unsigned path must not create a replay-set entry"
+        );
+    }
+
+    #[test]
     fn a_signature_made_for_one_relay_fails_at_another() {
         let key = SigningKey::from_seed(&[2u8; 32]);
         let signed = SignedCommand::<ops::Ack>::create(
@@ -1064,6 +1143,10 @@ mod tests {
         assert_eq!(
             elsewhere.verify::<ops::Ack>(NOW, 3, &signed.request().unwrap()),
             Err(ProtoError::Wire(ErrorCode::BadSignature))
+        );
+        assert!(
+            elsewhere.seen_set().is_empty(),
+            "an unauthenticated frame must not consume replay capacity"
         );
     }
 
@@ -1109,6 +1192,11 @@ mod tests {
         assert_eq!(
             verifier.verify::<ops::Subscribe>(NOW, 2, &request),
             Err(ProtoError::Wire(ErrorCode::Replay))
+        );
+        assert_eq!(
+            verifier.verify::<ops::Subscribe>(NOW, 3, &request),
+            Err(ProtoError::Wire(ErrorCode::Replay)),
+            "seen-set preflight must reject before the changed request id makes the signature fail"
         );
     }
 
@@ -1230,9 +1318,14 @@ mod tests {
             },
         )
         .unwrap();
+        let mut verifier = verifier();
         assert_eq!(
-            verifier().verify::<ops::Append>(NOW, 4, &signed.request().unwrap()),
+            verifier.verify::<ops::Append>(NOW, 4, &signed.request().unwrap()),
             Err(ProtoError::Wire(ErrorCode::BadSize))
+        );
+        assert!(
+            verifier.seen_set().is_empty(),
+            "a frame rejected by policy must not consume replay capacity"
         );
     }
 

--- a/rs/crates/f2z-relay-proto/src/lib.rs
+++ b/rs/crates/f2z-relay-proto/src/lib.rs
@@ -35,9 +35,11 @@
 //! Rust core shared by ZUULI and the web client and a crate that cannot reach
 //! the browser breaks that.
 //!
-//! It also does not store anything. Message bodies, addresses, quotas and
-//! challenge issuance are relay state; this crate holds the rules those states
-//! must obey.
+//! It also performs no application I/O or durable storage. Its state machines
+//! and [`SeenSet`] do hold bounded, process-local protocol bookkeeping. Message
+//! bodies, addresses, quotas, challenge issuance, sharing a replay authority
+//! across workers, and durable replay persistence are relay state; this crate
+//! holds the rules those states must obey.
 //!
 //! # A connection, end to end
 //!

--- a/rs/crates/f2z-relay-proto/src/replay.rs
+++ b/rs/crates/f2z-relay-proto/src/replay.rs
@@ -15,8 +15,17 @@
 //! commands until entries age out. It **MUST NOT** evict live entries to make
 //! room. An eviction policy that discards unexpired entries silently reopens
 //! the replay window at exactly the moment the relay is under load — which is
-//! exactly when an attacker would arrange to be. [`SeenSet::observe`] therefore
+//! exactly when an attacker would arrange to be. [`SeenSet::commit`] therefore
 //! has no eviction path at all; the only way an entry leaves is expiry.
+//!
+//! A lookup and an insert are deliberately separate. [`SeenSet::preflight`] is
+//! the cheap §5.1 step-3 filter; [`SeenSet::commit`] records the pair only after
+//! its signature and command checks succeed. `commit` repeats the lookup and
+//! capacity check atomically under its exclusive borrow, so two callers that
+//! both passed preflight against the **same set instance** cannot both commit
+//! the same pair. The borrow is not a distributed lock: clones and independent
+//! sets do not coordinate. A multi-worker relay must serialize one shared set
+//! or give an external store the same atomic insert-if-absent semantics.
 //!
 //! # Why the set need not survive a restart, and when that stops being true
 //!
@@ -218,7 +227,8 @@ impl SeenSet {
 
     /// Drop every entry whose retention has elapsed, and report how many went.
     ///
-    /// Called by [`SeenSet::observe`] before anything else, so a relay never
+    /// Called by [`SeenSet::preflight`] and [`SeenSet::commit`] before anything
+    /// else, so a relay never
     /// has to schedule a sweep. It is public because an idle relay that stops
     /// receiving signed commands would otherwise hold its last entries
     /// forever, and an operator may want to reclaim that.
@@ -228,10 +238,12 @@ impl SeenSet {
         before.saturating_sub(self.entries.len())
     }
 
-    /// Record a `(signer_key, nonce)` pair, or refuse it.
+    /// Check a `(signer_key, nonce)` pair without recording it.
     ///
     /// Step 3 of §5.1's verification order: it runs *before* the signature
-    /// check, because it is cheap and flood-resistant.
+    /// check, because it is cheap. An unauthenticated frame must not consume a
+    /// slot, so successful preflight never inserts the candidate key. It may
+    /// still purge unrelated entries whose retention has elapsed.
     ///
     /// # Errors
     ///
@@ -242,10 +254,10 @@ impl SeenSet {
     /// - [`ErrorCode::Backpressure`] if the set is full of unexpired entries.
     ///   The relay refuses new signed commands until entries age out. It does
     ///   **not** evict.
-    pub fn observe(&mut self, now_ms: u64, key: ReplayKey) -> Result<()> {
+    pub fn preflight(&mut self, now_ms: u64, key: &ReplayKey) -> Result<()> {
         self.expire(now_ms);
 
-        if self.entries.contains_key(&key) {
+        if self.entries.contains_key(key) {
             return Err(ProtoError::Wire(ErrorCode::Replay));
         }
         // Checked after the replay lookup on purpose: a full set that is being
@@ -255,6 +267,23 @@ impl SeenSet {
             return Err(ProtoError::Wire(ErrorCode::Backpressure));
         }
 
+        Ok(())
+    }
+
+    /// Record an authenticated `(signer_key, nonce)` pair using
+    /// insert-if-absent semantics.
+    ///
+    /// Call this only after every verification step succeeds. It repeats
+    /// [`SeenSet::preflight`] while holding `&mut self`; therefore a competing
+    /// commit that won the same preflight window is rejected as
+    /// [`ErrorCode::Replay`] rather than silently replacing the entry.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorCode::Replay`] if the pair was committed already.
+    /// - [`ErrorCode::Backpressure`] if authenticated entries fill the set.
+    pub fn commit(&mut self, now_ms: u64, key: ReplayKey) -> Result<()> {
+        self.preflight(now_ms, &key)?;
         let expires_at = now_ms.saturating_add(self.retention_ms);
         self.entries.insert(key, expires_at);
         Ok(())
@@ -306,19 +335,37 @@ mod tests {
     #[test]
     fn a_repeat_inside_the_window_is_a_replay() {
         let mut seen = SeenSet::new(1_000, 8);
-        assert!(seen.observe(0, key(1)).is_ok());
+        assert!(seen.commit(0, key(1)).is_ok());
         assert_eq!(
-            seen.observe(500, key(1)),
+            seen.commit(500, key(1)),
             Err(ProtoError::Wire(ErrorCode::Replay))
         );
         // And a different nonce under the same key is not.
         assert!(
-            seen.observe(
+            seen.commit(
                 500,
                 ReplayKey::new(PublicKey::new([1; 32]), Nonce::new([2; 16]))
             )
             .is_ok()
         );
+    }
+
+    #[test]
+    fn two_preflight_winners_cannot_both_commit() {
+        let mut seen = SeenSet::new(1_000, 8);
+        let replay_key = key(1);
+
+        assert!(seen.preflight(0, &replay_key).is_ok());
+        assert!(seen.preflight(0, &replay_key).is_ok());
+        assert!(seen.is_empty(), "preflight must not reserve capacity");
+
+        assert!(seen.commit(0, replay_key).is_ok());
+        assert_eq!(
+            seen.commit(0, replay_key),
+            Err(ProtoError::Wire(ErrorCode::Replay)),
+            "commit must repeat the membership test atomically"
+        );
+        assert_eq!(seen.len(), 1);
     }
 
     #[test]
@@ -330,21 +377,21 @@ mod tests {
         // millisecond at the boundary; it is pinned by a test so it cannot
         // change unnoticed.
         let mut seen = SeenSet::new(1_000, 8);
-        seen.observe(0, key(1)).unwrap();
+        seen.commit(0, key(1)).unwrap();
         assert_eq!(
-            seen.observe(999, key(1)),
+            seen.commit(999, key(1)),
             Err(ProtoError::Wire(ErrorCode::Replay))
         );
-        assert!(seen.observe(1_000, key(1)).is_ok());
+        assert!(seen.commit(1_000, key(1)).is_ok());
     }
 
     #[test]
     fn a_full_set_refuses_rather_than_evicting() {
         let mut seen = SeenSet::new(10_000, 2);
-        seen.observe(0, key(1)).unwrap();
-        seen.observe(0, key(2)).unwrap();
+        seen.commit(0, key(1)).unwrap();
+        seen.commit(0, key(2)).unwrap();
         assert_eq!(
-            seen.observe(0, key(3)),
+            seen.commit(0, key(3)),
             Err(ProtoError::Wire(ErrorCode::Backpressure))
         );
         // The live entries are still live. This is the property: an eviction
@@ -352,19 +399,19 @@ mod tests {
         assert!(seen.contains(&key(1)));
         assert!(seen.contains(&key(2)));
         assert_eq!(
-            seen.observe(0, key(1)),
+            seen.commit(0, key(1)),
             Err(ProtoError::Wire(ErrorCode::Replay))
         );
         // …and once they age out, the set accepts again.
-        assert!(seen.observe(10_001, key(3)).is_ok());
+        assert!(seen.commit(10_001, key(3)).is_ok());
     }
 
     #[test]
     fn a_replay_is_reported_even_when_the_set_is_full() {
         let mut seen = SeenSet::new(10_000, 1);
-        seen.observe(0, key(1)).unwrap();
+        seen.commit(0, key(1)).unwrap();
         assert_eq!(
-            seen.observe(0, key(1)),
+            seen.commit(0, key(1)),
             Err(ProtoError::Wire(ErrorCode::Replay)),
             "capacity must not mask an attack"
         );
@@ -382,8 +429,8 @@ mod tests {
     #[test]
     fn expire_reports_what_it_dropped() {
         let mut seen = SeenSet::new(100, 8);
-        seen.observe(0, key(1)).unwrap();
-        seen.observe(0, key(2)).unwrap();
+        seen.commit(0, key(1)).unwrap();
+        seen.commit(0, key(2)).unwrap();
         assert_eq!(seen.expire(50), 0);
         assert_eq!(seen.len(), 2);
         assert_eq!(seen.expire(101), 2);

--- a/rs/crates/f2z-relay-proto/tests/properties.rs
+++ b/rs/crates/f2z-relay-proto/tests/properties.rs
@@ -168,7 +168,7 @@ proptest! {
 
         for (key_bytes, nonce_bytes) in pairs {
             let key = ReplayKey::new(PublicKey::new(key_bytes), Nonce::new(nonce_bytes));
-            match seen.observe(NOW, key) {
+            match seen.commit(NOW, key) {
                 Ok(()) => {
                     prop_assert!(!accepted.contains(&key));
                     accepted.push(key);

--- a/rs/crates/f2z-relay-proto/tests/redaction.rs
+++ b/rs/crates/f2z-relay-proto/tests/redaction.rs
@@ -164,7 +164,7 @@ fn a_signing_key_never_renders_anything_about_itself() {
 fn a_seen_set_does_not_render_the_keys_and_nonces_it_holds() {
     let mut seen = SeenSet::new(240_000, 8);
     let key = ReplayKey::new(PublicKey::new([SECRET; 32]), Nonce::new([SECRET; 16]));
-    seen.observe(NOW, key).unwrap();
+    seen.commit(NOW, key).unwrap();
 
     assert_no_leak("ReplayKey", &format!("{key:?}"), &[SECRET; 32]);
     assert_no_leak("ReplayKey", &format!("{key:?}"), &[SECRET; 16]);


### PR DESCRIPTION
Closes #590

Commit replay keys only after authentication and all local command checks succeed.

The replay transaction is split into a non-inserting preflight and an atomic final commit that repeats replay/capacity checks. Invalid signatures, self-auth failures, and bad padding cannot consume the bounded set; two preflight winners cannot both commit.

Mutation proof on exact head `571fcab6ef50565439d3de9f54d7416af455f27f`:

- preflight insertion/deletion, early commit before signature/self-auth/padding: red
- final recheck/commit/capacity deletion and replay-vs-capacity inversion: red
- all signed Verified fields, including client timestamp distinct from relay verification time: red
- every unsigned sentinel and any unsigned replay insertion: red

Restored green: 85 unit, 6 property, 8 redaction, 1 doctest, clippy with warnings denied, formatting and diff check.

Public docs explicitly scope the guarantee to the verifier's process-local SeenSet and disclaim durable, restart, clone, cross-worker, and external-state coordination. Independent adversarial review approved this exact one-commit head.