### PR TITLE
ci: mutation-prove Rust root ownership census

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -111,7 +111,9 @@ jobs:
             exit 0
           fi
 
-          if ! changed_files=$(git diff --name-only --no-renames "$BASE_SHA" "$GITHUB_SHA"); then
+          changed_files=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/rs-changed-files.XXXXXX")
+          trap 'rm -f -- "$changed_files"' EXIT
+          if ! git diff --name-only -z --no-renames "$BASE_SHA" "$GITHUB_SHA" > "$changed_files"; then
             echo "::warning::Diff failed; running the full rs gate."
             echo "rs=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -127,13 +129,13 @@ jobs:
           # Listing it would make every wallet pin bump run the rs suite twice
           # over for no additional coverage.
           rs=false
-          while IFS= read -r file; do
+          while IFS= read -r -d '' file; do
             case "$file" in
               rs/*|scripts/check-rust-fmt.sh|scripts/check-rust-clippy.sh|scripts/check-rust-deny.sh|scripts/check-rust-toolchain.sh|.github/workflows/rs.yml)
                 rs=true
                 ;;
             esac
-          done <<< "$changed_files"
+          done < "$changed_files"
 
           echo "rs=$rs" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -108,7 +108,9 @@ jobs:
             exit 0
           fi
 
-          if ! changed_files=$(git diff --name-only --no-renames "$BASE_SHA" "$GITHUB_SHA"); then
+          changed_files=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/zuuli-changed-files.XXXXXX")
+          trap 'rm -f -- "$changed_files"' EXIT
+          if ! git diff --name-only -z --no-renames "$BASE_SHA" "$GITHUB_SHA" > "$changed_files"; then
             echo "::warning::Diff failed; running the full ZUULI gate."
             echo "zuuli=true" >> "$GITHUB_OUTPUT"
             echo "zuuallet_schema=true" >> "$GITHUB_OUTPUT"
@@ -117,9 +119,9 @@ jobs:
 
           zuuli=false
           zuuallet_schema=false
-          while IFS= read -r file; do
+          while IFS= read -r -d '' file; do
             case "$file" in
-              Cargo.toml|Cargo.lock|.cargo/*|clippy.toml|.clippy.toml|wallet/Cargo.toml|wallet/Cargo.lock|wallet/.cargo/*|wallet/clippy.toml|wallet/.clippy.toml|wallet/*.rs|wallet/*/Cargo.toml|wallet/*/Cargo.lock|wallet/*/.cargo/*|wallet/*/clippy.toml|wallet/*/.clippy.toml|wallet/zuuli/*|wallet/plugins/*|wallet/zuuallet/src/hooks/useWallet.ts|wallet/zuuallet/src/lib/mnemonic.ts|wallet/zuuallet/src/lib/sensitive-seed-session.ts|wallet/zuuallet/src/lib/sensitive-seed.ts|wallet/zuuallet/src/lib/tauri.ts|wallet/zuuallet/src/pages/CreateWallet.tsx|wallet/zuuallet/src/pages/RestoreWallet.tsx|wallet/zuuallet/src/pages/Settings.tsx|wallet/zuuallet/src/pages/Welcome.tsx|wallet/zuuallet/src/types/index.ts|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-github-actions-pins.mjs|scripts/check-librustzcash-compat.mjs|scripts/check-rust-toolchain.sh|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zcash-permissions.mjs|scripts/check-zuuli-linux-image.mjs|scripts/check-zuuli-android-gate.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-store-audit.yml|.github/workflows/zuuli-store-publish.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
+              Cargo.toml|Cargo.lock|.cargo/*|clippy.toml|.clippy.toml|wallet/Cargo.toml|wallet/Cargo.lock|wallet/.cargo/*|wallet/clippy.toml|wallet/.clippy.toml|wallet/*|wallet/*.rs|wallet/*/Cargo.toml|wallet/*/Cargo.lock|wallet/*/.cargo/*|wallet/*/clippy.toml|wallet/*/.clippy.toml|wallet/zuuli/*|wallet/plugins/*|wallet/zuuallet/src/hooks/useWallet.ts|wallet/zuuallet/src/lib/mnemonic.ts|wallet/zuuallet/src/lib/sensitive-seed-session.ts|wallet/zuuallet/src/lib/sensitive-seed.ts|wallet/zuuallet/src/lib/tauri.ts|wallet/zuuallet/src/pages/CreateWallet.tsx|wallet/zuuallet/src/pages/RestoreWallet.tsx|wallet/zuuallet/src/pages/Settings.tsx|wallet/zuuallet/src/pages/Welcome.tsx|wallet/zuuallet/src/types/index.ts|wallet/rust-toolchain.toml|wallet/deny.toml|scripts/check-github-actions-pins.mjs|scripts/check-librustzcash-compat.mjs|scripts/check-rust-toolchain.sh|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-zcash-permissions.mjs|scripts/check-zuuli-linux-image.mjs|scripts/check-zuuli-android-gate.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-store-audit.yml|.github/workflows/zuuli-store-publish.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
                 zuuli=true
                 ;;
             esac
@@ -128,7 +130,7 @@ jobs:
                 zuuallet_schema=true
                 ;;
             esac
-          done <<< "$changed_files"
+          done < "$changed_files"
 
           echo "zuuli=$zuuli" >> "$GITHUB_OUTPUT"
           echo "zuuallet_schema=$zuuallet_schema" >> "$GITHUB_OUTPUT"
@@ -218,8 +220,8 @@ jobs:
   # formatting failure no longer costs a full rebuild to re-check.
   #
   # It covers every crate under wallet/, including wallet/zuuallet/src-tauri,
-  # which this workflow's change filter does not select on its own; a
-  # Zuuallet-only pull request is covered by the matching job in zuuallet.yml.
+  # The root selector above deliberately selects every wallet/ path, including
+  # future crates and Zuuallet-only changes.
   rust_fmt:
     name: Rust / formatting
     needs: changes
@@ -251,7 +253,7 @@ jobs:
         run: scripts/check-rust-fmt.sh --self-test
 
       - name: Check formatting of every Rust crate under wallet/
-        run: scripts/check-rust-fmt.sh
+        run: scripts/check-rust-fmt.sh --root wallet
 
   # Supply chain: RustSec advisories, licences, and crate sources for all three
   # wallet lockfiles. Like rust_fmt this compiles nothing — cargo-deny works
@@ -296,7 +298,7 @@ jobs:
         run: scripts/check-rust-deny.sh --self-test
 
       - name: Check advisories, licences and sources
-        run: scripts/check-rust-deny.sh
+        run: scripts/check-rust-deny.sh --root wallet --config wallet/deny.toml
 
   # Lints, at `-D warnings`, for every crate under wallet/. Unlike rust_fmt and
   # rust_deny this one genuinely compiles — clippy is a rustc driver and needs
@@ -308,9 +310,8 @@ jobs:
   # artifacts into the same target directory names, so sharing a key would make
   # the two kinds of job evict each other's work on every run.
   #
-  # Like rust_fmt it covers wallet/zuuallet/src-tauri, which this workflow's
-  # change filter does not select on its own; the matching job in zuuallet.yml
-  # covers a Zuuallet-only pull request.
+  # Like rust_fmt it covers wallet/zuuallet/src-tauri through the exact wallet/
+  # root selector rather than a hand-maintained list of today's crates.
   rust_clippy:
     name: Rust / lints
     needs: changes
@@ -366,7 +367,7 @@ jobs:
           key: zuuli-clippy
 
       - name: Lint every Rust crate under wallet/ at -D warnings
-        run: scripts/check-rust-clippy.sh
+        run: scripts/check-rust-clippy.sh --root wallet
 
   # Linux cannot compile the target-specific Keychain, Credential Manager,
   # filesystem, and OAuth branches. Run the same all-wallet clippy verdict on
@@ -420,7 +421,7 @@ jobs:
 
       - name: Lint every Rust crate under wallet/ at -D warnings
         shell: bash
-        run: scripts/check-rust-clippy.sh
+        run: scripts/check-rust-clippy.sh --root wallet
 
   # Native *execution*, not just compilation. `rust_native_clippy` above proves
   # the macOS and Windows halves of the plugin compile; until #610 nothing that

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -2,6 +2,7 @@
 
 import fs from "node:fs";
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -40,6 +41,65 @@ const WASM_POLICY_SELF_TEST_COMMAND =
   "node wallet/zuuli/scripts/wasm-boundary.mjs --self-test";
 const WASM_POLICY_COMMAND = "node wallet/zuuli/scripts/wasm-boundary.mjs";
 const FRONTEND_CHECKOUT_REFERENCE = GATE_CHECKOUT_REFERENCE;
+const POLICED_RUST_ROOTS = ["wallet", "rs"];
+const RUST_ROOT_CONTRACTS = [
+  {
+    root: "wallet",
+    workflow: ".github/workflows/zuuli.yml",
+    selectorStep: "Detect release-impacting ZUULI changes",
+    selectorId: "filter",
+    selectorOutput: "zuuli",
+    selectorOutputs: [
+      { name: "zuuli", probeRoot: "wallet" },
+      {
+        name: "zuuallet_schema",
+        probeRoot: "wallet/zuuallet/src-tauri",
+      },
+    ],
+    jobs: [
+      [
+        "rust_fmt",
+        "Check formatting of every Rust crate under wallet/",
+        "scripts/check-rust-fmt.sh --root wallet",
+      ],
+      [
+        "rust_clippy",
+        "Lint every Rust crate under wallet/ at -D warnings",
+        "scripts/check-rust-clippy.sh --root wallet",
+      ],
+      [
+        "rust_deny",
+        "Check advisories, licences and sources",
+        "scripts/check-rust-deny.sh --root wallet --config wallet/deny.toml",
+      ],
+    ],
+  },
+  {
+    root: "rs",
+    workflow: ".github/workflows/rs.yml",
+    selectorStep: "Detect changes under rs/",
+    selectorId: "filter",
+    selectorOutput: "rs",
+    selectorOutputs: [{ name: "rs", probeRoot: "rs" }],
+    jobs: [
+      [
+        "rs_fmt",
+        "Check every crate under rs/",
+        "scripts/check-rust-fmt.sh --root rs",
+      ],
+      [
+        "rs_clippy",
+        "Lint every crate under rs/ at -D warnings",
+        "scripts/check-rust-clippy.sh --root rs",
+      ],
+      [
+        "rs_deny",
+        "Enforce rs/deny.toml over every crate under rs/",
+        "scripts/check-rust-deny.sh --root rs --config rs/deny.toml",
+      ],
+    ],
+  },
+];
 const REQUIRED_NATIVE_CLIPPY_JOB_LINES = [
   "  rust_native_clippy:",
   "    name: Rust / native lints (${{ matrix.target_os }})",
@@ -82,7 +142,7 @@ const REQUIRED_NATIVE_CLIPPY_JOB_LINES = [
   '        run: scripts/check-rust-clippy.sh --self-test "${{ matrix.target_os }}"',
   "      - name: Lint every Rust crate under wallet/ at -D warnings",
   "        shell: bash",
-  "        run: scripts/check-rust-clippy.sh",
+  "        run: scripts/check-rust-clippy.sh --root wallet",
 ];
 // The macOS/Windows job that *executes* the shared plugin's test suite. Held to
 // its exact source for the same reason as the lint job beside it: this is the
@@ -1438,10 +1498,13 @@ function policyWorkflowJobs(relativeFile, lines, failures) {
   if (workflowEnvironments.length > 1) {
     failures.push(`${relativeFile}: required workflow cannot repeat env`);
   }
-  const expectedWorkflowEnvironment =
-    relativeFile.split(path.sep).join("/") === REQUIRED_WORKFLOW_PATH
-      ? REQUIRED_WORKFLOW_ENVIRONMENT
-      : new Map();
+  const normalizedRelativeFile = relativeFile.split(path.sep).join("/");
+  const expectedWorkflowEnvironment = [
+    REQUIRED_WORKFLOW_PATH,
+    ".github/workflows/rs.yml",
+  ].includes(normalizedRelativeFile)
+    ? REQUIRED_WORKFLOW_ENVIRONMENT
+    : new Map();
   for (const environment of workflowEnvironments) {
     const actual = environmentMap(
       relativeFile,
@@ -1572,6 +1635,434 @@ function policyWorkflowJobs(relativeFile, lines, failures) {
   return jobs;
 }
 
+// Read one canonical block mapping below a job property. Required selector
+// outputs are a security boundary: checking the step body alone is circular if
+// the job publishes a different key, reads a different step id, or drops an
+// output that downstream `if:` expressions consume.
+function policyBlockMapping(
+  relativeFile,
+  lines,
+  property,
+  containerEnd,
+  failures,
+  label,
+) {
+  const entries = new Map();
+  if (!property || property.value) {
+    failures.push(
+      `${relativeFile}:${(property?.index ?? 0) + 1}: ${label} must use a block mapping`,
+    );
+    return entries;
+  }
+  for (let index = property.index + 1; index < containerEnd; index += 1) {
+    const line = workflowLine(lines[index]);
+    if (!line) continue;
+    if (line.error) {
+      failures.push(`${relativeFile}:${index + 1}: ${line.error}`);
+      continue;
+    }
+    if (line.indent <= property.indent) break;
+    if (line.indent !== property.indent + 2) {
+      failures.push(
+        `${relativeFile}:${index + 1}: ${label} must use canonical ${property.indent + 2}-space entry indentation`,
+      );
+      continue;
+    }
+    const entry = mappingEntry(line.text, `${label} entry`);
+    if (entry.error) {
+      failures.push(`${relativeFile}:${index + 1}: ${entry.error}`);
+      continue;
+    }
+    if (entries.has(entry.key)) {
+      failures.push(
+        `${relativeFile}:${index + 1}: duplicate ${label} entry ${entry.key}`,
+      );
+      continue;
+    }
+    entries.set(entry.key, entry.value);
+  }
+  return entries;
+}
+
+const rustRootSelectorProbeCache = new Map();
+const rustRootSelectorProbeDirectories = new Set();
+process.on("exit", () => {
+  for (const directory of rustRootSelectorProbeDirectories) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function runSelectorProbeGit(cwd, args) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_EMAIL: "selector-probe@example.invalid",
+      GIT_AUTHOR_NAME: "Rust root selector probe",
+      GIT_COMMITTER_EMAIL: "selector-probe@example.invalid",
+      GIT_COMMITTER_NAME: "Rust root selector probe",
+      HOME: cwd,
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${result.stderr?.trim() || `status ${result.status}`}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function rustRootSelectorProbeFixture(probePath) {
+  if (rustRootSelectorProbeCache.has(probePath)) {
+    return rustRootSelectorProbeCache.get(probePath);
+  }
+
+  const repo = fs.mkdtempSync(
+    path.join(os.tmpdir(), "rust-root-selector-git-"),
+  );
+  rustRootSelectorProbeDirectories.add(repo);
+  runSelectorProbeGit(repo, ["init", "--quiet"]);
+  runSelectorProbeGit(repo, [
+    "commit",
+    "--quiet",
+    "--allow-empty",
+    "-m",
+    "base",
+  ]);
+  const base = runSelectorProbeGit(repo, ["rev-parse", "HEAD"]);
+  writeFixture(repo, probePath, "selector probe\n");
+  runSelectorProbeGit(repo, ["add", "--", probePath]);
+  runSelectorProbeGit(repo, ["commit", "--quiet", "-m", "head"]);
+  const head = runSelectorProbeGit(repo, ["rev-parse", "HEAD"]);
+  const fixture = { base, head, repo };
+  rustRootSelectorProbeCache.set(probePath, fixture);
+  return fixture;
+}
+
+// GitHub applies the last assignment to a step output. Looking for any earlier
+// `name=true` line lets a later `name=false` silently skip every guarded job.
+// Parse both simple and heredoc output records and return the effective value.
+function effectiveGithubOutput(outputFile, name) {
+  if (!fs.existsSync(outputFile)) return undefined;
+  const lines = fs.readFileSync(outputFile, "utf8").split(/\r?\n/);
+  let effective;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const simplePrefix = `${name}=`;
+    const heredocPrefix = `${name}<<`;
+    if (line.startsWith(simplePrefix)) {
+      effective = line.slice(simplePrefix.length);
+      continue;
+    }
+    if (!line.startsWith(heredocPrefix)) continue;
+    const delimiter = line.slice(heredocPrefix.length);
+    const value = [];
+    index += 1;
+    while (index < lines.length && lines[index] !== delimiter) {
+      value.push(lines[index]);
+      index += 1;
+    }
+    if (index < lines.length) effective = value.join("\n");
+  }
+  return effective;
+}
+
+function executeRustRootSelector(
+  body,
+  fixture,
+  contract,
+  head,
+  base = fixture.base,
+) {
+  const outputDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "rust-root-selector-output-"),
+  );
+  const outputFile = path.join(outputDirectory, "github-output");
+  try {
+    const result = spawnSync("/bin/bash", ["-c", body], {
+      cwd: fixture.repo,
+      encoding: "utf8",
+      env: {
+        BASE_SHA: base,
+        GITHUB_SHA: head,
+        GITHUB_OUTPUT: outputFile,
+        HOME: fixture.repo,
+        PATH: "/usr/bin:/bin",
+        RUNNER_TEMP: outputDirectory,
+      },
+    });
+    return {
+      effective: new Map(
+        contract.selectorOutputs.map(({ name }) => [
+          name,
+          effectiveGithubOutput(outputFile, name),
+        ]),
+      ),
+      status: result.status,
+    };
+  } finally {
+    fs.rmSync(outputDirectory, { recursive: true, force: true });
+  }
+}
+
+function rustRootWorkflowFailures(relativeFile, lines, contract) {
+  const failures = [];
+  const jobs = policyWorkflowJobs(relativeFile, lines, failures);
+  const changes = jobs.get("changes");
+  if (!changes) {
+    failures.push(
+      `${relativeFile}: ${contract.root}/ owner must contain changes`,
+    );
+    return failures;
+  }
+
+  const publishedOutputs = policyBlockMapping(
+    relativeFile,
+    lines,
+    changes.properties.get("outputs"),
+    changes.end,
+    failures,
+    `${contract.root}/ changes outputs`,
+  );
+  const expectedOutputs = new Map(
+    contract.selectorOutputs.map(({ name }) => [
+      name,
+      "${{ steps." + contract.selectorId + ".outputs." + name + " }}",
+    ]),
+  );
+  if (
+    publishedOutputs.size !== expectedOutputs.size ||
+    [...expectedOutputs].some(
+      ([name, expression]) => publishedOutputs.get(name) !== expression,
+    )
+  ) {
+    failures.push(
+      `${relativeFile}:${changes.start + 1}: ${contract.root}/ changes must publish exactly ${[...expectedOutputs].map(([name, expression]) => `${name}: ${expression}`).join(", ")}`,
+    );
+  }
+
+  const changeSteps = policyJobSteps(
+    relativeFile,
+    lines,
+    changes,
+    failures,
+    `${contract.root} root owner changes`,
+  );
+  const toolchainSteps = changeSteps.filter(
+    (step) =>
+      step.properties.get("name")?.value ===
+      "Verify the Rust toolchain pin has not drifted",
+  );
+  const toolchain = toolchainSteps[0];
+  const toolchainRun = toolchain?.properties.get("run");
+  const toolchainCommands = toolchainRun
+    ? blockScalarCommands(lines, toolchainRun, toolchain.end)
+    : [];
+  if (
+    toolchainSteps.length !== 1 ||
+    !hasExactKeys(toolchain?.properties ?? new Map(), ["name", "run"]) ||
+    toolchainRun?.value !== "|" ||
+    JSON.stringify(toolchainCommands) !==
+      JSON.stringify([
+        "scripts/check-rust-toolchain.sh --self-test",
+        "scripts/check-rust-toolchain.sh",
+      ])
+  ) {
+    failures.push(
+      `${relativeFile}:${changes.start + 1}: ${contract.root}/ owner must run one unconditional, non-soft-failing toolchain self-test and live verdict`,
+    );
+  }
+
+  const selectorSteps = changeSteps.filter(
+    (step) => step.properties.get("name")?.value === contract.selectorStep,
+  );
+  const selector = selectorSteps[0];
+  const selectorRun = selector?.properties.get("run");
+  if (
+    selectorSteps.length !== 1 ||
+    !hasExactKeys(selector?.properties ?? new Map(), [
+      "name",
+      "id",
+      "shell",
+      "env",
+      "run",
+    ]) ||
+    selector?.properties.get("id")?.value !== contract.selectorId ||
+    selectorRun?.value !== "|"
+  ) {
+    failures.push(
+      `${relativeFile}:${changes.start + 1}: ${contract.root}/ owner must retain one live, non-soft-failing selector step`,
+    );
+  } else {
+    const body = lines.slice(selectorRun.index + 1, selector.end).join("\n");
+    const selectorArms = [
+      ...body.matchAll(
+        /^\s*case "\$file" in\s*\n\s*([^\n)]+)\)\s*\n\s*([A-Za-z0-9_]+)=true\s*\n\s*;;\s*\n\s*esac\s*$/gm,
+      ),
+    ].filter((match) => match[2] === contract.selectorOutput);
+    const exactRootPattern = `${contract.root}/*`;
+    if (
+      selectorArms.length !== 1 ||
+      !selectorArms[0][1]
+        .split("|")
+        .map((pattern) => pattern.trim())
+        .includes(exactRootPattern)
+    ) {
+      failures.push(
+        `${relativeFile}:${selector.start + 1}: ${contract.root}/ owner selector must contain the exact active ${exactRootPattern} case pattern`,
+      );
+    }
+    try {
+      for (const { name, probeRoot } of contract.selectorOutputs) {
+        const probePaths = [
+          `${probeRoot}/ordinary.rs`,
+          `${probeRoot}/space name.rs`,
+          `${probeRoot}/tab\tname.rs`,
+          `${probeRoot}/newline\nname.rs`,
+          `${probeRoot}/back\\slash.rs`,
+          `${probeRoot}/-dash.rs`,
+        ];
+        for (const probePath of probePaths) {
+          const fixture = rustRootSelectorProbeFixture(probePath);
+          const result = executeRustRootSelector(
+            body,
+            fixture,
+            contract,
+            fixture.head,
+          );
+          if (
+            result.status !== 0 ||
+            result.effective.get(name) !== "true"
+          ) {
+            const subject =
+              name === contract.selectorOutput
+                ? `${contract.root}/ owner selector`
+                : `${contract.root}/ owner selector output ${name}`;
+            failures.push(
+              `${relativeFile}:${selector.start + 1}: ${subject} must actively select ${JSON.stringify(probePath)} as its effective last value`,
+            );
+          }
+        }
+      }
+      const fixture = rustRootSelectorProbeFixture(
+        `${contract.root}/ordinary.rs`,
+      );
+      const failedDiff = executeRustRootSelector(
+        body,
+        fixture,
+        contract,
+        "f".repeat(40),
+      );
+      for (const { name } of contract.selectorOutputs) {
+        if (
+          failedDiff.status !== 0 ||
+          failedDiff.effective.get(name) !== "true"
+        ) {
+          const subject =
+            name === contract.selectorOutput
+              ? `${contract.root}/ owner selector`
+              : `${contract.root}/ owner selector output ${name}`;
+          failures.push(
+            `${relativeFile}:${selector.start + 1}: ${subject} must fail open to its full gate when the real Git diff fails`,
+          );
+        }
+      }
+      const unusableBase = executeRustRootSelector(
+        body,
+        fixture,
+        contract,
+        fixture.head,
+        "not-a-commit-sha",
+      );
+      for (const { name } of contract.selectorOutputs) {
+        if (
+          unusableBase.status !== 0 ||
+          unusableBase.effective.get(name) !== "true"
+        ) {
+          const subject =
+            name === contract.selectorOutput
+              ? `${contract.root}/ owner selector`
+              : `${contract.root}/ owner selector output ${name}`;
+          failures.push(
+            `${relativeFile}:${selector.start + 1}: ${subject} must fail open to its full gate when no usable base commit exists`,
+          );
+        }
+      }
+    } catch (error) {
+      failures.push(
+        `${relativeFile}:${selector.start + 1}: ${contract.root}/ owner selector real-Git probe failed closed: ${error.message}`,
+      );
+    }
+  }
+
+  for (const [jobId, stepName, command] of contract.jobs) {
+    const job = jobs.get(jobId);
+    if (!job) {
+      failures.push(
+        `${relativeFile}: ${contract.root}/ owner is missing required job ${jobId}`,
+      );
+      continue;
+    }
+    const expectedIf = `needs.changes.outputs.${contract.selectorOutput} == 'true'`;
+    if (job.properties.get("if")?.value !== expectedIf) {
+      failures.push(
+        `${relativeFile}:${job.start + 1}: ${contract.root}/ owner job ${jobId} must run exactly when its root selector is true`,
+      );
+    }
+    if (job.properties.has("continue-on-error")) {
+      failures.push(
+        `${relativeFile}:${job.start + 1}: ${contract.root}/ owner job ${jobId} cannot soft-fail`,
+      );
+    }
+    const steps = policyJobSteps(
+      relativeFile,
+      lines,
+      job,
+      failures,
+      `${contract.root} root owner ${jobId}`,
+    );
+    const verdicts = steps.filter(
+      (step) => step.properties.get("name")?.value === stepName,
+    );
+    const verdict = verdicts[0];
+    if (
+      verdicts.length !== 1 ||
+      !hasExactKeys(verdict?.properties ?? new Map(), ["name", "run"]) ||
+      verdict?.properties.get("run")?.value !== command
+    ) {
+      failures.push(
+        `${relativeFile}:${job.start + 1}: ${contract.root}/ owner job ${jobId} must run exactly one unconditional, non-soft-failing ${command}`,
+      );
+    }
+  }
+
+  return failures;
+}
+
+function rustRootOwnershipFailures(contracts) {
+  const failures = [];
+  const roots = contracts.map(({ root }) => root);
+  const workflows = contracts.map(({ workflow }) => workflow);
+  if (
+    JSON.stringify([...roots].sort()) !==
+    JSON.stringify([...POLICED_RUST_ROOTS].sort())
+  ) {
+    failures.push(
+      `owner registry must cover exactly the policed Rust roots: ${POLICED_RUST_ROOTS.join(", ")}`,
+    );
+  }
+  if (
+    new Set(roots).size !== contracts.length ||
+    new Set(workflows).size !== contracts.length
+  ) {
+    failures.push(
+      "policed Rust roots and their owning workflows must form a one-to-one mapping",
+    );
+  }
+  return failures;
+}
+
 function requiredJobUsesReference(relativeFile, property, failures) {
   const parsed = usesFromLine(`uses: ${property.value}`);
   if (!parsed || parsed.error) {
@@ -1681,7 +2172,10 @@ function nativeClippySelectorFailures(relativeFile, lines, changes) {
         `${relativeFile}:${detector.start + 1}: release-impacting change detector has duplicate ${output} selector arms`,
       );
     } else {
-      arms.set(output, match[1].split("|").map((pattern) => pattern.trim()));
+      arms.set(
+        output,
+        match[1].split("|").map((pattern) => pattern.trim()),
+      );
     }
   }
   if (!arms.has("zuuli") || !arms.has("zuuallet_schema")) {
@@ -1707,8 +2201,13 @@ function cryptoProbeInputFailures(repoRoot, overrides = new Map()) {
   for (const [input, expectedDigest] of REQUIRED_CRYPTO_PROBE_INPUTS) {
     const absoluteInput = path.resolve(repoRoot, input);
     if (!overrides.has(input)) {
-      if (!fs.existsSync(absoluteInput) || !fs.lstatSync(absoluteInput).isFile()) {
-        failures.push(`${input}: required crypto probe input must be a regular file`);
+      if (
+        !fs.existsSync(absoluteInput) ||
+        !fs.lstatSync(absoluteInput).isFile()
+      ) {
+        failures.push(
+          `${input}: required crypto probe input must be a regular file`,
+        );
         continue;
       }
     }
@@ -1717,7 +2216,9 @@ function cryptoProbeInputFailures(repoRoot, overrides = new Map()) {
       : fs.readFileSync(absoluteInput);
     const actualDigest = createHash("sha256").update(contents).digest("hex");
     if (actualDigest !== expectedDigest) {
-      failures.push(`${input}: crypto probe input differs from its reviewed digest`);
+      failures.push(
+        `${input}: crypto probe input differs from its reviewed digest`,
+      );
     }
   }
   return failures;
@@ -1787,14 +2288,29 @@ function gatePolicyFailures(repoRoot, relativeFile, lines) {
   if (enforceNativeClippy) {
     failures.push(...librustzcashScopeFailures());
   }
-  if (enforceNativeClippy && !parsedNeeds.values.includes("rust_native_clippy")) {
-    failures.push(`${relativeFile}:${needsProperty.index + 1}: gate must await rust_native_clippy`);
+  if (
+    enforceNativeClippy &&
+    !parsedNeeds.values.includes("rust_native_clippy")
+  ) {
+    failures.push(
+      `${relativeFile}:${needsProperty.index + 1}: gate must await rust_native_clippy`,
+    );
   }
-  if (enforceNativeClippy && !parsedNeeds.values.includes("rust_native_tests")) {
-    failures.push(`${relativeFile}:${needsProperty.index + 1}: gate must await rust_native_tests`);
+  if (
+    enforceNativeClippy &&
+    !parsedNeeds.values.includes("rust_native_tests")
+  ) {
+    failures.push(
+      `${relativeFile}:${needsProperty.index + 1}: gate must await rust_native_tests`,
+    );
   }
-  if (enforceNativeClippy && !parsedNeeds.values.includes("rust_crypto_targets")) {
-    failures.push(`${relativeFile}:${needsProperty.index + 1}: gate must await rust_crypto_targets`);
+  if (
+    enforceNativeClippy &&
+    !parsedNeeds.values.includes("rust_crypto_targets")
+  ) {
+    failures.push(
+      `${relativeFile}:${needsProperty.index + 1}: gate must await rust_crypto_targets`,
+    );
   }
 
   const nativeTests = jobs.get("rust_native_tests");
@@ -1819,7 +2335,9 @@ function gatePolicyFailures(repoRoot, relativeFile, lines) {
 
   const nativeClippy = jobs.get("rust_native_clippy");
   if (enforceNativeClippy && !nativeClippy) {
-    failures.push(`${relativeFile}: required workflow must contain rust_native_clippy`);
+    failures.push(
+      `${relativeFile}: required workflow must contain rust_native_clippy`,
+    );
   } else if (enforceNativeClippy) {
     const actualNativeClippyJobLines = lines
       .slice(nativeClippy.start, nativeClippy.end)
@@ -1860,7 +2378,8 @@ function gatePolicyFailures(repoRoot, relativeFile, lines) {
       .map((line) => /^\s+- os:\s+(\S+)\s*$/.exec(line)?.[1])
       .filter(Boolean);
     if (
-      JSON.stringify(targetOperatingSystems) !== JSON.stringify(["macos", "windows"]) ||
+      JSON.stringify(targetOperatingSystems) !==
+        JSON.stringify(["macos", "windows"]) ||
       JSON.stringify(runnerOperatingSystems) !==
         JSON.stringify(["macos-latest", "windows-latest"])
     ) {
@@ -1878,26 +2397,35 @@ function gatePolicyFailures(repoRoot, relativeFile, lines) {
     );
     const stepsByName = (name) =>
       nativeSteps.filter((step) => step.properties.get("name")?.value === name);
-    const selfTests = stepsByName("Prove native target selection and -D warnings");
+    const selfTests = stepsByName(
+      "Prove native target selection and -D warnings",
+    );
     const selfTest = selfTests[0];
     if (
       selfTests.length !== 1 ||
-      !hasExactKeys(selfTest?.properties ?? new Map(), ["name", "shell", "run"]) ||
+      !hasExactKeys(selfTest?.properties ?? new Map(), [
+        "name",
+        "shell",
+        "run",
+      ]) ||
       selfTest?.properties.get("shell")?.value !== "bash" ||
       selfTest?.properties.get("run")?.value !==
-      'scripts/check-rust-clippy.sh --self-test "${{ matrix.target_os }}"'
+        'scripts/check-rust-clippy.sh --self-test "${{ matrix.target_os }}"'
     ) {
       failures.push(
         `${relativeFile}:${nativeClippy.start + 1}: rust_native_clippy must run exactly one unconditional target-bound negative control`,
       );
     }
-    const lints = stepsByName("Lint every Rust crate under wallet/ at -D warnings");
+    const lints = stepsByName(
+      "Lint every Rust crate under wallet/ at -D warnings",
+    );
     const lint = lints[0];
     if (
       lints.length !== 1 ||
       !hasExactKeys(lint?.properties ?? new Map(), ["name", "shell", "run"]) ||
       lint?.properties.get("shell")?.value !== "bash" ||
-      lint?.properties.get("run")?.value !== "scripts/check-rust-clippy.sh"
+      lint?.properties.get("run")?.value !==
+        "scripts/check-rust-clippy.sh --root wallet"
     ) {
       failures.push(
         `${relativeFile}:${nativeClippy.start + 1}: rust_native_clippy must run exactly one unconditional all-wallet lint entrypoint`,
@@ -1907,7 +2435,9 @@ function gatePolicyFailures(repoRoot, relativeFile, lines) {
 
   const cryptoTargets = jobs.get("rust_crypto_targets");
   if (enforceNativeClippy && !cryptoTargets) {
-    failures.push(`${relativeFile}: required workflow must contain rust_crypto_targets`);
+    failures.push(
+      `${relativeFile}: required workflow must contain rust_crypto_targets`,
+    );
   } else if (enforceNativeClippy) {
     const actualCryptoTargetJobLines = lines
       .slice(cryptoTargets.start, cryptoTargets.end)
@@ -2051,7 +2581,9 @@ function verifyGateResults(policyOutcome, serializedNeeds) {
   // it. Deriving both expectations from the same value here means the gate can
   // never accept a skip from one that it would reject from the other.
   const nativeExpected =
-    zuuliExpected === "success" || schemaExpected === "success" ? "success" : "skipped";
+    zuuliExpected === "success" || schemaExpected === "success"
+      ? "success"
+      : "skipped";
   const NATIVE_JOBS = new Set(["rust_native_clippy", "rust_native_tests"]);
 
   const verdicts = [];
@@ -2117,7 +2649,14 @@ function localTarget(repoRoot, reference) {
   return { file: actionFiles[0] };
 }
 
-function scanRepository(repoRoot) {
+function scanRepository(
+  repoRoot,
+  {
+    enforceRustRootOwners = true,
+    rustRootOwnerOverrides = null,
+    rustRootContracts = RUST_ROOT_CONTRACTS,
+  } = {},
+) {
   repoRoot = fs.realpathSync(repoRoot);
   const queued = [
     ...yamlFilesBelow(path.join(repoRoot, ".github", "workflows")),
@@ -2126,6 +2665,36 @@ function scanRepository(repoRoot) {
   const seen = new Set();
   const failures = [];
   let externalReferences = 0;
+
+  if (enforceRustRootOwners) {
+    failures.push(...rustRootOwnershipFailures(rustRootContracts));
+    for (const contract of rustRootContracts) {
+      const owner = path.join(repoRoot, contract.workflow);
+      const overridden = rustRootOwnerOverrides?.has(contract.workflow);
+      if (!overridden && !fs.existsSync(owner)) {
+        failures.push(
+          `${contract.root}/ owning workflow is missing: ${contract.workflow}`,
+        );
+        continue;
+      }
+      const ownerSource = overridden
+        ? rustRootOwnerOverrides.get(contract.workflow)
+        : fs.readFileSync(owner, "utf8");
+      if (ownerSource === null) {
+        failures.push(
+          `${contract.root}/ owning workflow is missing: ${contract.workflow}`,
+        );
+        continue;
+      }
+      failures.push(
+        ...rustRootWorkflowFailures(
+          contract.workflow,
+          ownerSource.split(/\r?\n/),
+          contract,
+        ),
+      );
+    }
+  }
 
   while (queued.length) {
     const file = queued.shift();
@@ -2184,6 +2753,462 @@ function writeFixture(root, relative, contents) {
   const destination = path.join(root, relative);
   fs.mkdirSync(path.dirname(destination), { recursive: true });
   fs.writeFileSync(destination, contents);
+}
+
+function runRustRootWorkflowMutationTests(repoRoot) {
+  let cases = 0;
+
+  // Enter through the same default-enabled repository scan as live mode.  The
+  // detailed controls below deliberately inject owner policy, so they cannot
+  // prove that the production entry point retains its default enforcement.
+  const productionContract = RUST_ROOT_CONTRACTS[0];
+  const productionSource = fs.readFileSync(
+    path.join(repoRoot, productionContract.workflow),
+    "utf8",
+  );
+  const productionMutant = productionSource.replace(
+    "        run: scripts/check-rust-fmt.sh --root wallet",
+    "        run: scripts/check-rust-fmt.sh --root rs",
+  );
+  if (productionMutant === productionSource) {
+    throw new Error("live Rust-root owner scan: mutation target was not found");
+  }
+  const productionFailures = scanRepository(repoRoot, {
+    rustRootOwnerOverrides: new Map([
+      [productionContract.workflow, productionMutant],
+    ]),
+  }).failures;
+  const productionNeedle =
+    "wallet/ owner job rust_fmt must run exactly one unconditional";
+  if (
+    !productionFailures.some((failure) => failure.includes(productionNeedle))
+  ) {
+    throw new Error(
+      `live Rust-root owner scan: expected ${JSON.stringify(productionNeedle)}, got ${productionFailures.join("; ")}`,
+    );
+  }
+  console.log(
+    "self-test: live repository scan enforces its default Rust-root owner policy: passed",
+  );
+  cases += 1;
+
+  const assertOwnershipFailure = (name, contracts, needle) => {
+    const failures = scanRepository(repoRoot, {
+      rustRootContracts: contracts,
+    }).failures;
+    if (!failures.some((failure) => failure.includes(needle))) {
+      throw new Error(
+        `${name}: expected ${JSON.stringify(needle)}, got ${failures.join("; ")}`,
+      );
+    }
+    console.log(`self-test: ${name}: passed`);
+    cases += 1;
+  };
+  assertOwnershipFailure(
+    "Rust-root registry rejects a missing owner",
+    RUST_ROOT_CONTRACTS.slice(0, 1),
+    "cover exactly",
+  );
+  assertOwnershipFailure(
+    "Rust-root registry rejects a duplicate owner workflow",
+    RUST_ROOT_CONTRACTS.map((contract, index) =>
+      index === 1
+        ? { ...contract, workflow: RUST_ROOT_CONTRACTS[0].workflow }
+        : contract,
+    ),
+    "one-to-one",
+  );
+  assertOwnershipFailure(
+    "Rust-root registry rejects a substituted root",
+    RUST_ROOT_CONTRACTS.map((contract, index) =>
+      index === 1 ? { ...contract, root: "third" } : contract,
+    ),
+    "cover exactly",
+  );
+
+  const jobSlice = (source, jobId) => {
+    const start = source.indexOf(`\n  ${jobId}:`);
+    if (start < 0) return null;
+    const nextJob = /\n  [A-Za-z0-9_-]+:\s*(?:\n|$)/g;
+    nextJob.lastIndex = start + 1;
+    const match = nextJob.exec(source);
+    return { start, end: match ? match.index : source.length };
+  };
+  const mutateJob = (source, jobId, target, replacement) => {
+    const slice = jobSlice(source, jobId);
+    if (!slice) return source;
+    const body = source.slice(slice.start, slice.end);
+    const changed = body.replace(target, replacement);
+    return source.slice(0, slice.start) + changed + source.slice(slice.end);
+  };
+  const parkBroadSelector = (source, contract) => {
+    const slice = jobSlice(source, "changes");
+    if (!slice) return source;
+    const body = source.slice(slice.start, slice.end);
+    const marker = '            case "$file" in';
+    const start = body.indexOf(marker);
+    const endMarker = "            esac";
+    const endStart = body.indexOf(endMarker, start);
+    if (start < 0 || endStart < 0) return source;
+    const end = endStart + endMarker.length;
+    const broad = body.slice(start, end);
+    if (
+      !broad.includes(`${contract.root}/*`) ||
+      !broad.includes(`${contract.selectorOutput}=true`)
+    ) {
+      return source;
+    }
+    const parked = [
+      "            if false; then",
+      broad,
+      "            fi",
+      '            case "${file}" in',
+      `              ${contract.root}/known/*)`,
+      `                ${contract.selectorOutput}=true`,
+      "                ;;",
+      "            esac",
+    ].join("\n");
+    const changed = body.slice(0, start) + parked + body.slice(end);
+    return source.slice(0, slice.start) + changed + source.slice(slice.end);
+  };
+  const assertWorkflowFailure = (contract, source, name, mutate, needle) => {
+    const changed = mutate(source);
+    if (changed === source)
+      throw new Error(`${name}: mutation target was not found`);
+    const failures = scanRepository(repoRoot, {
+      rustRootOwnerOverrides: new Map([[contract.workflow, changed]]),
+    }).failures;
+    if (!failures.some((failure) => failure.includes(needle))) {
+      throw new Error(
+        `${name}: expected ${JSON.stringify(needle)}, got ${failures.join("; ")}`,
+      );
+    }
+    console.log(`self-test: ${name}: passed`);
+    cases += 1;
+  };
+
+  for (const contract of RUST_ROOT_CONTRACTS) {
+    const source = fs.readFileSync(
+      path.join(repoRoot, contract.workflow),
+      "utf8",
+    );
+    const baseline = rustRootWorkflowFailures(
+      contract.workflow,
+      source.split(/\r?\n/),
+      contract,
+    );
+    if (baseline.length) {
+      throw new Error(
+        `${contract.root}/ owner is not a valid mutation base: ${baseline.join("; ")}`,
+      );
+    }
+
+    const ownerPrefix = `${contract.root}/ owner`;
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects deleting its owner workflow`,
+      () => null,
+      `${contract.root}/ owning workflow is missing`,
+    );
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects deleting the live toolchain verdict`,
+      (value) => value.replace("        scripts/check-rust-toolchain.sh\n", ""),
+      `${ownerPrefix} must run one unconditional`,
+    );
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects a dead toolchain guard`,
+      (value) =>
+        value.replace(
+          "      - name: Verify the Rust toolchain pin has not drifted",
+          "      - name: Verify the Rust toolchain pin has not drifted\n        if: false",
+        ),
+      `${ownerPrefix} must run one unconditional`,
+    );
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects a soft-failing toolchain guard`,
+      (value) =>
+        value.replace(
+          "      - name: Verify the Rust toolchain pin has not drifted",
+          "      - name: Verify the Rust toolchain pin has not drifted\n        continue-on-error: true",
+        ),
+      `${ownerPrefix} must run one unconditional`,
+    );
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects a renamed selector step id`,
+      (value) =>
+        mutateJob(
+          value,
+          "changes",
+          `        id: ${contract.selectorId}`,
+          "        id: renamed_filter",
+        ),
+      `${ownerPrefix} must retain one live`,
+    );
+    for (const { name } of contract.selectorOutputs) {
+      const publication = `      ${name}: \${{ steps.${contract.selectorId}.outputs.${name} }}`;
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/ rejects renaming published selector output ${name}`,
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            publication,
+            `      renamed_${name}: \${{ steps.${contract.selectorId}.outputs.${name} }}`,
+          ),
+        `${contract.root}/ changes must publish exactly`,
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/ rejects repointing published selector output ${name}`,
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            publication,
+            `      ${name}: \${{ steps.${contract.selectorId}.outputs.missing_${name} }}`,
+          ),
+        `${contract.root}/ changes must publish exactly`,
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/ rejects duplicate published selector output ${name}`,
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            publication,
+            `${publication}\n${publication}`,
+        ),
+        `duplicate ${contract.root}/ changes outputs entry ${name}`,
+      );
+      const failOpenVouch = `            echo "${name}=true" >> "$GITHUB_OUTPUT"`;
+      const failOpenNeedle =
+        name === contract.selectorOutput
+          ? `${ownerPrefix} selector must fail open to its full gate when no usable base commit exists`
+          : `${ownerPrefix} selector output ${name} must fail open to its full gate when no usable base commit exists`;
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/ rejects a false ${name} output for an unusable base`,
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            failOpenVouch,
+            `            echo "${name}=false" >> "$GITHUB_OUTPUT"`,
+          ),
+        failOpenNeedle,
+      );
+    }
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects a line-delimited real Git diff`,
+      (value) =>
+        mutateJob(
+          value,
+          "changes",
+          "git diff --name-only -z --no-renames",
+          "git diff --name-only --no-renames",
+        ),
+      `${ownerPrefix} selector must actively select`,
+    );
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects a line-delimited diff consumer`,
+      (value) =>
+        mutateJob(
+          value,
+          "changes",
+          "while IFS= read -r -d '' file; do",
+          "while IFS= read -r file; do",
+      ),
+      `${ownerPrefix} selector must actively select`,
+    );
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects an inverted real Git diff-failure guard`,
+      (value) =>
+        mutateJob(
+          value,
+          "changes",
+          "if ! git diff --name-only -z --no-renames",
+          "if git diff --name-only -z --no-renames",
+        ),
+      `${ownerPrefix} selector must fail open`,
+    );
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects a narrowed root selector`,
+      (value) =>
+        mutateJob(
+          value,
+          "changes",
+          `${contract.root}/*|`,
+          `${contract.root}/known/*|`,
+        ),
+      `${ownerPrefix} selector must contain the exact active`,
+    );
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects a dead broad selector beside a narrowed live selector`,
+      (value) => parkBroadSelector(value, contract),
+      `${ownerPrefix} selector must actively select`,
+    );
+    const outputVouch = `          echo "${contract.selectorOutput}=$${contract.selectorOutput}" >> "$GITHUB_OUTPUT"`;
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects a selector that exits after writing its vouch`,
+      (value) =>
+        mutateJob(
+          value,
+          "changes",
+          outputVouch,
+          `${outputVouch}\n          false`,
+        ),
+      `${ownerPrefix} selector must actively select`,
+    );
+    assertWorkflowFailure(
+      contract,
+      source,
+      `${contract.root}/ rejects a true selector output overwritten false`,
+      (value) =>
+        mutateJob(
+          value,
+          "changes",
+          outputVouch,
+          `${outputVouch}\n          echo "${contract.selectorOutput}=false" >> "$GITHUB_OUTPUT"`,
+        ),
+      `${ownerPrefix} selector must actively select`,
+    );
+    for (const { name } of contract.selectorOutputs) {
+      if (name === contract.selectorOutput) continue;
+      const additionalVouch = `          echo "${name}=$${name}" >> "$GITHUB_OUTPUT"`;
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/ rejects a true ${name} output overwritten false`,
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            additionalVouch,
+            `${additionalVouch}\n          echo "${name}=false" >> "$GITHUB_OUTPUT"`,
+          ),
+        `${ownerPrefix} selector output ${name} must actively select`,
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/ rejects a true ${name} heredoc output overwritten false`,
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            additionalVouch,
+            `${additionalVouch}\n          echo '${name}<<OVERRIDE' >> "$GITHUB_OUTPUT"\n          echo false >> "$GITHUB_OUTPUT"\n          echo OVERRIDE >> "$GITHUB_OUTPUT"`,
+          ),
+        `${ownerPrefix} selector output ${name} must actively select`,
+      );
+    }
+
+    for (const [jobId, stepName, command] of contract.jobs) {
+      const exactIf = `    if: needs.changes.outputs.${contract.selectorOutput} == 'true'`;
+      const verdictNeedle = `${ownerPrefix} job ${jobId} must run exactly one`;
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/${jobId} rejects selector bypass`,
+        (value) => mutateJob(value, jobId, exactIf, "    if: true"),
+        `${ownerPrefix} job ${jobId} must run exactly when`,
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/${jobId} rejects job-level soft failure`,
+        (value) =>
+          mutateJob(
+            value,
+            jobId,
+            `  ${jobId}:`,
+            `  ${jobId}:\n    continue-on-error: true`,
+          ),
+        `${ownerPrefix} job ${jobId} cannot soft-fail`,
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/${jobId} rejects deleting its live verdict`,
+        (value) =>
+          mutateJob(
+            value,
+            jobId,
+            `        run: ${command}`,
+            "        run: echo checked",
+          ),
+        verdictNeedle,
+      );
+      const otherRoot = contract.root === "wallet" ? "rs" : "wallet";
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/${jobId} rejects a wrong-root verdict`,
+        (value) =>
+          mutateJob(
+            value,
+            jobId,
+            `        run: ${command}`,
+            `        run: ${command.replace(`--root ${contract.root}`, `--root ${otherRoot}`)}`,
+          ),
+        verdictNeedle,
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/${jobId} rejects a dead live verdict`,
+        (value) =>
+          mutateJob(
+            value,
+            jobId,
+            `      - name: ${stepName}`,
+            `      - name: ${stepName}\n        if: false`,
+          ),
+        verdictNeedle,
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        `${contract.root}/${jobId} rejects a soft-failing live verdict`,
+        (value) =>
+          mutateJob(
+            value,
+            jobId,
+            `      - name: ${stepName}`,
+            `      - name: ${stepName}\n        continue-on-error: true`,
+          ),
+        verdictNeedle,
+      );
+    }
+  }
+  return cases;
 }
 
 function runCurrentWorkflowMutationTests(repoRoot) {
@@ -2255,7 +3280,10 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     {
       name: "real workflow rejects a non-native target matrix",
       needle: "must use the exact macOS/Windows native matrix",
-      source: source.replace("            target_os: windows", "            target_os: linux"),
+      source: source.replace(
+        "            target_os: windows",
+        "            target_os: linux",
+      ),
     },
     {
       name: "real workflow rejects a weakened native clippy selector",
@@ -2312,7 +3340,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects a stale crypto source reset",
-      needle: "rust_crypto_targets must match the exact reviewed target/source/test contract",
+      needle:
+        "rust_crypto_targets must match the exact reviewed target/source/test contract",
       source: source.replace(
         "      - name: Verify exact clean source identity",
         "      - name: Substitute an earlier clean source\n        run: git reset --hard HEAD~1\n\n      - name: Verify exact clean source identity",
@@ -2320,12 +3349,14 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects a removed crypto target",
-      needle: "rust_crypto_targets must match the exact reviewed target/source/test contract",
+      needle:
+        "rust_crypto_targets must match the exact reviewed target/source/test contract",
       source: source.replace(",i686-linux-android", ""),
     },
     {
       name: "real workflow rejects crypto type-check substituted for code generation",
-      needle: "rust_crypto_targets must match the exact reviewed target/source/test contract",
+      needle:
+        "rust_crypto_targets must match the exact reviewed target/source/test contract",
       source: source.replace(
         "            cargo build --locked --release --lib --target",
         "            cargo check --locked --release --lib --target",
@@ -2333,7 +3364,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects a skipped crypto host runtime test",
-      needle: "rust_crypto_targets must match the exact reviewed target/source/test contract",
+      needle:
+        "rust_crypto_targets must match the exact reviewed target/source/test contract",
       source: source.replace(
         "      - name: Execute the representative crypto probe on the hosted OS\n        shell: bash",
         "      - name: Execute the representative crypto probe on the hosted OS\n        if: false\n        shell: bash",
@@ -2341,7 +3373,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects deletion of crypto source identity",
-      needle: "rust_crypto_targets must match the exact reviewed target/source/test contract",
+      needle:
+        "rust_crypto_targets must match the exact reviewed target/source/test contract",
       source: source.replace(
         '          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"\n',
         "",
@@ -2349,62 +3382,75 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow selects root Cargo workspace inputs for native clippy",
-      needle: "native clippy input must select at least one native lint path: Cargo.toml",
+      needle:
+        "native clippy input must select at least one native lint path: Cargo.toml",
       source: source.replaceAll("Cargo.toml|Cargo.lock|", ""),
     },
     {
       name: "real workflow selects root Cargo configuration for native clippy",
-      needle: "native clippy input must select at least one native lint path: .cargo/config.toml",
+      needle:
+        "native clippy input must select at least one native lint path: .cargo/config.toml",
       source: source.replaceAll(".cargo/*|", ""),
     },
     {
       name: "real workflow selects root Clippy configuration for native clippy",
-      needle: "native clippy input must select at least one native lint path: clippy.toml",
+      needle:
+        "native clippy input must select at least one native lint path: clippy.toml",
       source: source.replaceAll("clippy.toml|.clippy.toml|", ""),
     },
     {
       name: "real workflow selects wallet parent workspace manifests for native clippy",
-      needle: "native clippy input must select at least one native lint path: wallet/Cargo.toml",
-      source: source.replaceAll("wallet/Cargo.toml|wallet/Cargo.lock|", ""),
+      needle:
+        "native clippy input must select at least one native lint path: wallet/Cargo.toml",
+      source: source
+        .replaceAll("wallet/*|", "")
+        .replaceAll("wallet/Cargo.toml|wallet/Cargo.lock|", ""),
     },
     {
       name: "real workflow selects wallet parent lint configuration for native clippy",
-      needle: "native clippy input must select at least one native lint path: wallet/.cargo/config.toml",
-      source: source.replaceAll(
-        "wallet/.cargo/*|wallet/clippy.toml|wallet/.clippy.toml|",
-        "",
-      ),
+      needle:
+        "native clippy input must select at least one native lint path: wallet/.cargo/config.toml",
+      source: source
+        .replaceAll("wallet/*|", "")
+        .replaceAll(
+          "wallet/.cargo/*|wallet/clippy.toml|wallet/.clippy.toml|",
+          "",
+        ),
     },
     {
       name: "real workflow selects future wallet Rust sources for native clippy",
-      needle: "native clippy input must select at least one native lint path: wallet/future-crate/src/lib.rs",
-      source: source.replaceAll("wallet/*.rs|", ""),
+      needle:
+        "native clippy input must select at least one native lint path: wallet/future-crate/src/lib.rs",
+      source: source.replaceAll("wallet/*|", "").replaceAll("wallet/*.rs|", ""),
     },
     {
       name: "real workflow selects future wallet manifests for native clippy",
-      needle: "native clippy input must select at least one native lint path: wallet/future-crate/Cargo.toml",
-      source: source.replaceAll(
-        "wallet/*/Cargo.toml|wallet/*/Cargo.lock|",
-        "",
-      ),
+      needle:
+        "native clippy input must select at least one native lint path: wallet/future-crate/Cargo.toml",
+      source: source
+        .replaceAll("wallet/*|", "")
+        .replaceAll("wallet/*/Cargo.toml|wallet/*/Cargo.lock|", ""),
     },
     {
       name: "real workflow selects future wallet Cargo configuration for native clippy",
       needle:
         "native clippy input must select at least one native lint path: wallet/future-crate/.cargo/config.toml",
-      source: source.replaceAll("wallet/*/.cargo/*|", ""),
+      source: source
+        .replaceAll("wallet/*|", "")
+        .replaceAll("wallet/*/.cargo/*|", ""),
     },
     {
       name: "real workflow selects future wallet Clippy configuration for native clippy",
-      needle: "native clippy input must select at least one native lint path: wallet/future-crate/clippy.toml",
-      source: source.replaceAll(
-        "wallet/*/clippy.toml|wallet/*/.clippy.toml|",
-        "",
-      ),
+      needle:
+        "native clippy input must select at least one native lint path: wallet/future-crate/clippy.toml",
+      source: source
+        .replaceAll("wallet/*|", "")
+        .replaceAll("wallet/*/clippy.toml|wallet/*/.clippy.toml|", ""),
     },
     {
       name: "real workflow rejects a decorative native negative control",
-      needle: "must run exactly one unconditional target-bound negative control",
+      needle:
+        "must run exactly one unconditional target-bound negative control",
       source: source.replace(
         '        run: scripts/check-rust-clippy.sh --self-test "${{ matrix.target_os }}"',
         '        run: echo "native clippy self-test"',
@@ -2412,7 +3458,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects a skipped native negative control",
-      needle: "must run exactly one unconditional target-bound negative control",
+      needle:
+        "must run exactly one unconditional target-bound negative control",
       source: source.replace(
         '        run: scripts/check-rust-clippy.sh --self-test "${{ matrix.target_os }}"',
         '        run: scripts/check-rust-clippy.sh --self-test "${{ matrix.target_os }}"\n        if: false',
@@ -2422,7 +3469,7 @@ function runCurrentWorkflowMutationTests(repoRoot) {
       name: "real workflow rejects a decorative native lint verdict",
       needle: "must run exactly one unconditional all-wallet lint entrypoint",
       source: source.replace(
-        "      - name: Lint every Rust crate under wallet/ at -D warnings\n        shell: bash\n        run: scripts/check-rust-clippy.sh",
+        "      - name: Lint every Rust crate under wallet/ at -D warnings\n        shell: bash\n        run: scripts/check-rust-clippy.sh --root wallet",
         "      - name: Lint every Rust crate under wallet/ at -D warnings\n        shell: bash\n        run: echo clean",
       ),
     },
@@ -2430,8 +3477,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
       name: "real workflow rejects a skipped native lint verdict",
       needle: "must run exactly one unconditional all-wallet lint entrypoint",
       source: source.replace(
-        "      - name: Lint every Rust crate under wallet/ at -D warnings\n        shell: bash\n        run: scripts/check-rust-clippy.sh",
-        "      - name: Lint every Rust crate under wallet/ at -D warnings\n        shell: bash\n        run: scripts/check-rust-clippy.sh\n        if: false",
+        "      - name: Lint every Rust crate under wallet/ at -D warnings\n        shell: bash\n        run: scripts/check-rust-clippy.sh --root wallet",
+        "      - name: Lint every Rust crate under wallet/ at -D warnings\n        shell: bash\n        run: scripts/check-rust-clippy.sh --root wallet\n        if: false",
       ),
     },
     {
@@ -2515,11 +3562,7 @@ function runCurrentWorkflowMutationTests(repoRoot) {
       name: "real workflow rejects a missing gate workflow-policy verdict",
       needle:
         "gate policy recheck must be exact, unconditional, and non-soft-failing",
-      source: replaceLast(
-        source,
-        `          ${WORKFLOW_GATES_COMMAND}\n`,
-        "",
-      ),
+      source: replaceLast(source, `          ${WORKFLOW_GATES_COMMAND}\n`, ""),
     },
     {
       name: "real workflow rejects a reordered gate workflow-policy self-test",
@@ -2661,10 +3704,7 @@ function runCurrentWorkflowMutationTests(repoRoot) {
       name: "real workflow rejects a missing librustzcash policy verdict",
       needle:
         "changes policy step must exactly self-test and enforce the current-source policy",
-      source: source.replace(
-        `          ${LIBRUSTZCASH_POLICY_COMMAND}\n`,
-        "",
-      ),
+      source: source.replace(`          ${LIBRUSTZCASH_POLICY_COMMAND}\n`, ""),
     },
     {
       name: "real workflow rejects a missing WASM boundary policy",
@@ -2718,7 +3758,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow selector cannot narrow away future nested WASM Rust source",
-      needle: "ZUULI selector must contain one active wallet/zuuli/* case pattern",
+      needle:
+        "ZUULI selector must contain one active wallet/zuuli/* case pattern",
       source: source.replace(
         "wallet/zuuli/*|wallet/plugins/*",
         "wallet/zuuli/src/*|wallet/plugins/*",
@@ -2726,7 +3767,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow selector cannot launder nested WASM coverage through a comment",
-      needle: "ZUULI selector must contain one active wallet/zuuli/* case pattern",
+      needle:
+        "ZUULI selector must contain one active wallet/zuuli/* case pattern",
       source: source.replace(
         "wallet/zuuli/*|wallet/plugins/*",
         "wallet/zuuli/src/*|wallet/plugins/* # wallet/zuuli/*|",
@@ -2739,19 +3781,14 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow selector cannot omit the librustzcash verifier",
-      needle:
-        "ZUULI selector must cover scripts/check-librustzcash-compat.mjs",
+      needle: "ZUULI selector must cover scripts/check-librustzcash-compat.mjs",
       source: source.replace("|scripts/check-librustzcash-compat.mjs", ""),
     },
     {
       name: "real workflow schema selector cannot omit the librustzcash verifier",
       needle:
         "Zuuallet schema selector must cover scripts/check-librustzcash-compat.mjs",
-      source: replaceLast(
-        source,
-        "|scripts/check-librustzcash-compat.mjs",
-        "",
-      ),
+      source: replaceLast(source, "|scripts/check-librustzcash-compat.mjs", ""),
     },
     ...REQUIRED_CLASSIC_SEED_BOUNDARY_INPUTS.map((input) => ({
       name: `real workflow selects classic seed-boundary input ${input}`,
@@ -2760,7 +3797,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     })),
     {
       name: "real workflow requires the unique frontend display context",
-      needle: "frontend must match the complete exact current-source execution program",
+      needle:
+        "frontend must match the complete exact current-source execution program",
       source: replaceFrontend("    name: zuuli / frontend\n", ""),
     },
     {
@@ -2783,7 +3821,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects a stale-source reset after frontend checkout",
-      needle: "frontend must match the complete exact current-source execution program",
+      needle:
+        "frontend must match the complete exact current-source execution program",
       source: replaceFrontend(
         `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1`,
         `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1\n      - name: Substitute stale frontend source after checkout\n        run: cd ../.. && git reset --hard HEAD~1`,
@@ -2791,7 +3830,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects a stale-source checkout after frontend checkout",
-      needle: "frontend must match the complete exact current-source execution program",
+      needle:
+        "frontend must match the complete exact current-source execution program",
       source: replaceFrontend(
         `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1`,
         `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1\n      - name: Check out stale frontend source\n        run: cd ../.. && git checkout HEAD~1`,
@@ -2799,7 +3839,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects frontend source overwrite after checkout",
-      needle: "frontend must match the complete exact current-source execution program",
+      needle:
+        "frontend must match the complete exact current-source execution program",
       source: replaceFrontend(
         `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1`,
         `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1\n      - name: Overwrite checked-out frontend source\n        run: printf stale > src/main.tsx`,
@@ -2807,7 +3848,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects frontend build-script substitution after checkout",
-      needle: "frontend must match the complete exact current-source execution program",
+      needle:
+        "frontend must match the complete exact current-source execution program",
       source: replaceFrontend(
         `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1`,
         `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1\n      - name: Substitute the WASM build script\n        run: cp package.json scripts/wasm-build.mjs`,
@@ -2815,7 +3857,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects an extra unnamed frontend step",
-      needle: "frontend must match the complete exact current-source execution program",
+      needle:
+        "frontend must match the complete exact current-source execution program",
       source: replaceFrontend(
         `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1`,
         `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1\n      - run: true`,
@@ -2823,7 +3866,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     },
     {
       name: "real workflow rejects stale-source substitution inside dependency install",
-      needle: "frontend must match the complete exact current-source execution program",
+      needle:
+        "frontend must match the complete exact current-source execution program",
       source: replaceFrontend(
         "      - name: Install locked dependencies\n        run: npm ci",
         "      - name: Install locked dependencies\n        run: cd ../.. && git reset --hard HEAD~1 && cd wallet/zuuli && npm ci",
@@ -3198,11 +4242,17 @@ function runCurrentWorkflowMutationTests(repoRoot) {
       repoRoot,
       new Map([[input, Buffer.concat([original, Buffer.from("\nmutated")])]]),
     );
-    if (!failures.some((failure) => failure.includes("differs from its reviewed digest"))) {
+    if (
+      !failures.some((failure) =>
+        failure.includes("differs from its reviewed digest"),
+      )
+    ) {
       throw new Error(`crypto input mutation escaped policy: ${input}`);
     }
     cryptoInputMutations += 1;
-    console.log(`self-test: crypto input digest rejects mutation: ${input}: passed`);
+    console.log(
+      `self-test: crypto input digest rejects mutation: ${input}: passed`,
+    );
   }
   const reviewedScope = reviewedCompatibilityScope();
   const baselineScopeFailures = librustzcashScopeFailures(reviewedScope);
@@ -3894,8 +4944,7 @@ function runSelfTest(repoRoot) {
       files: gateFixture(
         withGatePolicyLines(
           gatePolicyLines.filter(
-            (line) =>
-              line !== `          ${WORKFLOW_GATES_SELF_TEST_COMMAND}`,
+            (line) => line !== `          ${WORKFLOW_GATES_SELF_TEST_COMMAND}`,
           ),
         ),
       ),
@@ -4143,7 +5192,9 @@ function runSelfTest(repoRoot) {
       for (const [relative, contents] of Object.entries(testCase.files)) {
         writeFixture(fixture, relative, contents);
       }
-      const result = scanRepository(fixture);
+      const result = scanRepository(fixture, {
+        enforceRustRootOwners: false,
+      });
       if (testCase.valid) {
         if (result.failures.length) {
           throw new Error(
@@ -4305,9 +5356,11 @@ function runSelfTest(repoRoot) {
     console.log(`self-test: gate verdict: ${testCase.name}: passed`);
   }
   const currentWorkflowMutations = runCurrentWorkflowMutationTests(repoRoot);
+  const rustRootWorkflowMutations = runRustRootWorkflowMutationTests(repoRoot);
   console.log(
     `self-test: ${cases.length} source-policy, ${gateResultCases.length} gate-verdict, ` +
-      `and ${currentWorkflowMutations} current-workflow mutation case(s) passed.`,
+      `${currentWorkflowMutations} current-workflow, and ${rustRootWorkflowMutations} ` +
+      `Rust-root ownership mutation case(s) passed.`,
   );
 }
 

--- a/scripts/check-rust-fmt.sh
+++ b/scripts/check-rust-fmt.sh
@@ -106,16 +106,21 @@ fi
 if [[ $mode == self-test ]]; then
   fixture=$(mktemp -d "${TMPDIR:-/tmp}/zuuli-fmt-self-test.XXXXXX")
   trap 'rm -rf -- "$fixture"' EXIT
+  cases=0
+
+  # Install the required toolchain declaration before the empty-tree control.
+  # Otherwise the child can fail early for a missing pin and never exercise
+  # the manifest-count guard that this case claims to prove.
+  printf '[toolchain]\nchannel = "%s"\n' "$channel" > "$fixture/rust-toolchain.toml"
 
   if "$SELF" --root "$fixture" >/dev/null 2>&1; then
     printf 'self-test FAILED: --root accepted a tree holding no Cargo manifests.\n' >&2
     exit 1
   fi
+  cases=$((cases + 1))
   printf 'self-test: --root refuses a tree with no crates to judge.\n'
 
   mkdir -p "$fixture/relay/src"
-  # The second tree restates the pinned channel so rustup selects it here too.
-  printf '[toolchain]\nchannel = "%s"\n' "$channel" > "$fixture/rust-toolchain.toml"
   cat > "$fixture/relay/Cargo.toml" <<'EOF'
 [package]
 name = "zuuli-fmt-self-test"
@@ -130,7 +135,36 @@ EOF
     printf 'self-test FAILED: --root rejected a correctly formatted second tree.\n' >&2
     exit 1
   fi
+  cases=$((cases + 1))
   printf 'self-test: --root accepts a formatted second tree.\n'
+
+  # A depth limit is a future-crate escape: the ownership census permits Rust
+  # roots to grow at any depth, so formatting discovery must do the same.
+  mkdir -p "$fixture/future/depth/four/src"
+  cat > "$fixture/future/depth/four/Cargo.toml" <<'EOF'
+[package]
+name = "zuuli-fmt-deep-control"
+version = "0.0.0"
+edition = "2024"
+
+[workspace]
+EOF
+  printf 'pub fn deep(  value:bool )->bool{value}\n' \
+    > "$fixture/future/depth/four/src/lib.rs"
+  if "$SELF" --root "$fixture" >/dev/null 2>&1; then
+    printf 'self-test FAILED: --root missed an unformatted crate below depth three.\n' >&2
+    exit 1
+  fi
+  cases=$((cases + 1))
+  printf 'self-test: --root discovers crates below depth three.\n'
+
+  "$SELF" --root "$fixture" --fix >/dev/null
+  if ! "$SELF" --root "$fixture" >/dev/null; then
+    printf 'self-test FAILED: --fix missed a crate below depth three.\n' >&2
+    exit 1
+  fi
+  cases=$((cases + 1))
+  printf 'self-test: --fix formats crates below depth three.\n'
 
   # Negative control: the same tree, unformatted.
   printf 'pub fn negate(  value:bool )->bool{!value}\n' > "$fixture/relay/src/lib.rs"
@@ -138,6 +172,7 @@ EOF
     printf 'self-test FAILED: --root accepted an unformatted crate.\n' >&2
     exit 1
   fi
+  cases=$((cases + 1))
   printf 'self-test: --root rejects an unformatted crate.\n'
 
   "$SELF" --root "$fixture" --fix >/dev/null
@@ -145,17 +180,20 @@ EOF
     printf 'self-test FAILED: --fix did not reach the crate under --root.\n' >&2
     exit 1
   fi
+  cases=$((cases + 1))
   printf 'self-test: --fix formats crates under --root.\n'
 
-  printf 'self-test: 4 case(s) passed; rustfmt from %s.\n' "$channel"
+  printf 'self-test: %d case(s) passed; rustfmt from %s.\n' "$cases" "$channel"
   exit 0
 fi
 
 # Tracked, buildable crates only: target/ holds vendored and generated
 # manifests, node_modules/ holds npm packages that ship Rust sources.
 manifests=()
+manifest_count=0
 while IFS= read -r manifest; do
   manifests+=("${manifest#./}")
+  manifest_count=$((manifest_count + 1))
 done < <(
   find . -name Cargo.toml \
     -not -path './target/*' \
@@ -164,38 +202,42 @@ done < <(
     LC_ALL=C sort
 )
 
-if [[ ${#manifests[@]} -eq 0 ]]; then
+if (( manifest_count == 0 )); then
   printf 'no Cargo manifests found under %s/; this check has gone blind.\n' "$LABEL" >&2
   exit 1
 fi
 
 failed=()
-for manifest in "${manifests[@]}"; do
-  crate=$(dirname "$manifest")
-  if [[ $mode == fix ]]; then
-    printf '==> formatting %s/%s\n' "$LABEL" "$crate"
-    cargo fmt --all --manifest-path "$manifest"
-    continue
-  fi
+failed_count=0
+if (( manifest_count > 0 )); then
+  for manifest in "${manifests[@]}"; do
+    crate=$(dirname "$manifest")
+    if [[ $mode == fix ]]; then
+      printf '==> formatting %s/%s\n' "$LABEL" "$crate"
+      cargo fmt --all --manifest-path "$manifest"
+      continue
+    fi
 
-  printf '==> checking %s/%s\n' "$LABEL" "$crate"
-  if cargo fmt --all --check --manifest-path "$manifest"; then
-    continue
-  fi
-  failed+=("$LABEL/$crate")
-done
+    printf '==> checking %s/%s\n' "$LABEL" "$crate"
+    if cargo fmt --all --check --manifest-path "$manifest"; then
+      continue
+    fi
+    failed+=("$LABEL/$crate")
+    failed_count=$((failed_count + 1))
+  done
+fi
 
 if [[ $mode == fix ]]; then
   printf 'Formatted %d crate(s) with rustfmt from the pinned %s toolchain.\n' \
-    "${#manifests[@]}" "$channel"
+    "$manifest_count" "$channel"
   exit 0
 fi
 
-if [[ ${#failed[@]} -gt 0 ]]; then
-  printf '\n%d crate(s) are not formatted: %s\n' "${#failed[@]}" "${failed[*]}" >&2
+if (( failed_count > 0 )); then
+  printf '\n%d crate(s) are not formatted: %s\n' "$failed_count" "${failed[*]}" >&2
   printf 'Run `scripts/check-rust-fmt.sh --fix` and commit the result; do not hand-edit.\n' >&2
   exit 1
 fi
 
 printf 'All %d Rust crate(s) under %s/ are formatted (rustfmt from %s).\n' \
-  "${#manifests[@]}" "$LABEL" "$channel"
+  "$manifest_count" "$LABEL" "$channel"

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -116,6 +116,15 @@ WASM_TARGET=wasm32-unknown-unknown
 # braces for the day something under z/ stops being a submodule.
 VENDORED_PREFIX=z/
 
+# Every first-party Cargo manifest, including a virtual workspace manifest,
+# belongs to exactly one of these independently gated Rust trees.  This is a
+# path boundary, not a package registry: adding a third top-level Rust tree is
+# therefore a policy change that must add both its root and its owner workflow.
+POLICED_RUST_ROOTS=(
+  wallet
+  rs
+)
+
 # These are implementation identities, not alternate version decisions. The
 # generic branch commit accepts the source-derived `toolchain:` input; the
 # version-branch commit hardcodes exactly PINNED_ACTION_CHANNEL. Re-derive both
@@ -441,6 +450,38 @@ check_toolchain_restatements() {
   done
 }
 
+# Ask the pinned Cargo itself whether a manifest is a package or a virtual
+# workspace.  TOML permits whitespace and quoted, inline, and dotted keys, so a
+# source grep for `[package]` is neither complete nor sound. `read-manifest`
+# succeeds only for a package and emits one exact diagnostic for a valid
+# virtual manifest; every other failure is a parse/classification failure and
+# must fail closed.
+CARGO_MANIFEST_KIND=
+classify_cargo_manifest() {
+  local root=$1 rel=$2 channel=$3 diagnostic_file diagnostic virtual_suffix
+
+  CARGO_MANIFEST_KIND=
+  diagnostic_file=$(mktemp "${TMPDIR:-/tmp}/cargo-manifest-classification.XXXXXX")
+  if cargo +"$channel" read-manifest --manifest-path "$root/$rel" \
+    >/dev/null 2>"$diagnostic_file"; then
+    CARGO_MANIFEST_KIND=package
+    rm -f -- "$diagnostic_file"
+    return 0
+  fi
+
+  diagnostic=$(cat "$diagnostic_file")
+  rm -f -- "$diagnostic_file"
+  virtual_suffix='` is a virtual manifest, but this command requires running against an actual package in this workspace'
+  if [[ $diagnostic == 'error: manifest path `'*"$virtual_suffix" ]]; then
+    CARGO_MANIFEST_KIND=virtual
+    return 0
+  fi
+
+  diagnostic=${diagnostic//$'\n'/; }
+  fail "$rel could not be classified by pinned Cargo $channel: ${diagnostic:-no diagnostic}"
+  return 1
+}
+
 # --- the registration census -------------------------------------------------
 #
 # Everything above verifies what it was *told about*. This is what makes the
@@ -454,31 +495,43 @@ check_toolchain_restatements() {
 # `git ls-files` rather than a filesystem walk, so build artefacts, scratch
 # checkouts and target/ directories cannot inflate or distract it.
 census_tracked_files() {
-  git -C "$REPO_ROOT" ls-files -- '*Cargo.toml' '*rust-toolchain.toml'
+  local root=$1 output=$2
+  git -C "$root" ls-files -z -- '*Cargo.toml' '*rust-toolchain.toml' >"$output"
 }
 
-# Split out from check_census so the self-test can hand it a synthetic listing
-# and watch each verdict, instead of asserting the census works.
-check_census_listing() {
-  local root=$1 listing=$2
-  local rel base seen=0
+# Consume the NUL-delimited inventory directly. Shell variables never hold the
+# complete stream, so tabs and newlines in a tracked path remain data rather
+# than becoming record separators (and Bash 3.2 does not need mapfile).
+check_census_inventory() {
+  local root=$1 inventory=$2 channel=$3
+  local rel base seen=0 owner owner_count
   local registered_toolchains=("$TOOLCHAIN_FILE")
 
   if (( ${#TOOLCHAIN_RESTATEMENTS[@]} > 0 )); then
     registered_toolchains+=("${TOOLCHAIN_RESTATEMENTS[@]}")
   fi
 
-  while IFS= read -r rel; do
-    if [[ -z $rel ]]; then
-      continue
-    fi
+  while IFS= read -r -d '' rel; do
     if [[ $rel == "$VENDORED_PREFIX"* ]]; then
       continue
     fi
 
     base=${rel##*/}
+    seen=$((seen + 1))
+
+    if [[ $base == Cargo.toml ]]; then
+      owner_count=0
+      for owner in "${POLICED_RUST_ROOTS[@]}"; do
+        if [[ $rel == "$owner/"* ]]; then
+          owner_count=$((owner_count + 1))
+        fi
+      done
+      if (( owner_count != 1 )); then
+        fail "$rel belongs to $owner_count policed Rust roots; every first-party Cargo.toml must belong to exactly one of: ${POLICED_RUST_ROOTS[*]}"
+      fi
+    fi
+
     if [[ $base == rust-toolchain.toml ]]; then
-      seen=$((seen + 1))
       if contains "$rel" "${registered_toolchains[@]}"; then
         continue
       fi
@@ -491,33 +544,41 @@ check_census_listing() {
     if [[ ! -f "$root/$rel" ]]; then
       continue
     fi
-    # A crate is a manifest that declares a [package] table. A virtual
-    # workspace root declares only [workspace] and has no rust-version to pin,
-    # so it is excused by that structure — not by a path list that could later
-    # be widened to excuse a real crate.
-    if ! grep -qE '^[[:space:]]*\[package\]' "$root/$rel"; then
+
+    # Let the pinned Cargo parse and classify the manifest. This recognizes
+    # every Cargo-valid spelling of the package table and cannot be vouched for
+    # by a comment or multiline string containing `[package]`.
+    if ! classify_cargo_manifest "$root" "$rel" "$channel"; then
+      continue
+    fi
+    if [[ $CARGO_MANIFEST_KIND == virtual ]]; then
+      if contains "$rel" "${MANIFESTS[@]}"; then
+        fail "$rel is registered in MANIFESTS as a package, but pinned Cargo $channel classifies it as a virtual manifest"
+      fi
       continue
     fi
 
-    seen=$((seen + 1))
     if contains "$rel" "${MANIFESTS[@]}"; then
       continue
     fi
     fail "$rel declares [package] but is registered nowhere, so nothing holds its rust-version to $TOOLCHAIN_FILE. Add it to MANIFESTS in scripts/check-rust-toolchain.sh"
-  done <<<"$listing"
+  done <"$inventory"
 
   (( seen > 0 )) ||
     fail "no tracked crate manifests or toolchain files were enumerated; the registration census has gone blind"
 }
 
 check_census() {
-  local root=$1 listing
+  local root=$1 channel=$2 inventory
 
-  if ! listing=$(census_tracked_files 2>/dev/null); then
+  inventory=$(mktemp "${TMPDIR:-/tmp}/rust-census.XXXXXX")
+  if ! census_tracked_files "$root" "$inventory" 2>/dev/null; then
+    rm -f -- "$inventory"
     fail "git could not enumerate tracked files; the registration census has gone blind"
     return
   fi
-  check_census_listing "$root" "$listing"
+  check_census_inventory "$root" "$inventory" "$channel"
+  rm -f -- "$inventory"
 }
 
 check_docs() {
@@ -560,7 +621,7 @@ run_checks() {
   check_workflows "$root" "$channel"
   check_manifests "$root" "$channel" "$msrv"
   check_toolchain_restatements "$root" "$channel"
-  check_census "$root"
+  check_census "$root" "$channel"
   check_docs "$root" "$channel" "$msrv"
   check_wasm_target "$root"
 
@@ -615,7 +676,7 @@ staged_paths() {
 }
 
 stage_tree() {
-  local dest=$1 rel
+  local dest=$1 rel manifest_dir target
   while IFS= read -r rel; do
     [[ -e "$dest/$rel" ]] && continue
     # A registered path that does not exist yet is the check's own finding to
@@ -624,6 +685,34 @@ stage_tree() {
     mkdir -p "$dest/$(dirname "$rel")"
     cp "$REPO_ROOT/$rel" "$dest/$rel"
   done < <(staged_paths)
+
+  # Include virtual workspace manifests in the census even though they are not
+  # package registrations, then make the scratch tree a real Git index so the
+  # self-test exercises the production producer end to end.
+  while IFS= read -r -d '' rel; do
+    [[ -e "$dest/$rel" ]] && continue
+    mkdir -p "$dest/$(dirname "$rel")"
+    cp "$REPO_ROOT/$rel" "$dest/$rel"
+  done < <(git -C "$REPO_ROOT" ls-files -z -- '*Cargo.toml' '*rust-toolchain.toml')
+
+  # Cargo's semantic package classifier also verifies that a package has a
+  # target. Preserve the conventional tracked targets in the staged tree so
+  # classification exercises the manifest, rather than failing because the
+  # deliberately minimal fixture omitted src/lib.rs or src/main.rs.
+  while IFS= read -r -d '' rel; do
+    manifest_dir=$(dirname "$rel")
+    for target in \
+      "$manifest_dir/src/lib.rs" \
+      "$manifest_dir/src/main.rs" \
+      "$manifest_dir/build.rs"; do
+      [[ -e "$REPO_ROOT/$target" ]] || continue
+      mkdir -p "$dest/$(dirname "$target")"
+      cp "$REPO_ROOT/$target" "$dest/$target"
+    done
+  done < <(git -C "$REPO_ROOT" ls-files -z -- '*Cargo.toml')
+
+  git -C "$dest" init -q
+  git -C "$dest" add -A
 }
 
 apply_sed() {
@@ -706,108 +795,174 @@ self_test() {
 
 # --- self-test: the registration census --------------------------------------
 #
-# The census reads git, not a staged tree, so the mutation loop above cannot
-# exercise it. Each case hands check_census_listing a synthetic listing and
-# asserts on the verdict *and* the path the verdict names — a census that
-# rejected the wrong file, or rejected everything, would pass a bare
-# "it failed" assertion and is caught here instead.
-
-# `expect` is reject or accept; `needle` is the path the verdict must name when
-# rejecting, and the path it must not complain about when accepting.
+# Every census case mutates a real staged Git index and enters through
+# run_checks. This proves the filename producer, NUL boundary, ownership rule,
+# and registration verdict together rather than testing a synthetic parser.
 self_test_census_case() {
-  local root=$1 description=$2 expect=$3 needle=$4 listing=$5
-  local output raised
+  local root=$1 description=$2 expect=$3 needle=$4
+  local output
 
-  output=$(
-    errors=0
-    check_census_listing "$root" "$listing" 2>&1
-    printf 'errors=%s\n' "$errors"
-  )
-  raised=${output##*errors=}
-
-  if [[ $expect == reject ]]; then
-    if (( raised == 0 )); then
+  output=$(run_checks "$root" 2>&1) && {
+    if [[ $expect == reject ]]; then
       printf 'self-test FAILED: the census accepted %s.\n' "$description" >&2
       return 1
     fi
-    if [[ $output != *"$needle"* ]]; then
-      printf 'self-test FAILED: the census rejected %s without naming %s:\n%s\n' \
-        "$description" "$needle" "$output" >&2
-      return 1
-    fi
-    printf 'self-test: the census rejects %s.\n' "$description"
+    printf 'self-test: the census accepts %s.\n' "$description"
     return 0
-  fi
+  }
 
-  if (( raised != 0 )); then
+  if [[ $expect == accept ]]; then
     printf 'self-test FAILED: the census rejected %s:\n%s\n' "$description" "$output" >&2
     return 1
   fi
-  printf 'self-test: the census accepts %s.\n' "$description"
+  if [[ $output != *"$needle"* ]]; then
+    printf 'self-test FAILED: the census rejected %s without naming the expected finding (%s):\n%s\n' \
+      "$description" "$needle" "$output" >&2
+    return 1
+  fi
+  printf 'self-test: the census rejects %s.\n' "$description"
 }
 
 self_test_census() {
   local scratch=$1
-  local tree=$scratch/census
+  local tree rel case_index=0
   local failures=0
-  local registered=rs/crates/f2z-codec/Cargo.toml
+  local saved_roots=("${POLICED_RUST_ROOTS[@]}")
+  local saved_manifests=("${MANIFESTS[@]}")
 
+  for rel in \
+    outside/ordinary/Cargo.toml \
+    outside/wallet/nested/Cargo.toml \
+    walletish/Cargo.toml \
+    rs-other/Cargo.toml \
+    zebra/Cargo.toml \
+    ' leading/Cargo.toml' \
+    'outside/trailing /Cargo.toml' \
+    'outside/space root/Cargo.toml' \
+    $'outside/tab\troot/Cargo.toml' \
+    $'outside/back\\slash/Cargo.toml' \
+    $'outside/newline\nroot/Cargo.toml'; do
+    case_index=$((case_index + 1))
+    tree=$scratch/census-path-$case_index
+    stage_tree "$tree"
+    mkdir -p "$tree/$(dirname "$rel")"
+    printf '[workspace]\nresolver = "3"\n' >"$tree/$rel"
+    git -C "$tree" add -- "$rel"
+    self_test_census_case "$tree" "an unowned Cargo manifest named $(printf '%q' "$rel")" \
+      reject "drift: $rel belongs to 0 policed Rust roots" || failures=$((failures + 1))
+  done
+
+  tree=$scratch/census-overlapping-owner
   stage_tree "$tree"
+  rel=wallet/nested/Cargo.toml
+  mkdir -p "$tree/$(dirname "$rel")"
+  printf '[workspace]\nresolver = "3"\n' >"$tree/$rel"
+  git -C "$tree" add -- "$rel"
+  POLICED_RUST_ROOTS+=(wallet/nested)
+  self_test_census_case "$tree" 'a manifest claimed by overlapping Rust roots' \
+    reject "$rel belongs to 2 policed Rust roots" || failures=$((failures + 1))
+  POLICED_RUST_ROOTS=("${saved_roots[@]}")
 
-  mkdir -p "$tree/rs/crates/scratch" "$tree/wallet/scratch-crate" "$tree/z/vendored/crate"
-  printf '[package]\nname = "scratch"\nversion = "0.0.0"\n' \
-    > "$tree/rs/crates/scratch/Cargo.toml"
-  printf '[package]\nname = "wallet-scratch"\nversion = "0.0.0"\n' \
-    > "$tree/wallet/scratch-crate/Cargo.toml"
-  printf '[package]\nname = "vendored"\nversion = "0.0.0"\n' \
-    > "$tree/z/vendored/crate/Cargo.toml"
-  printf '[toolchain]\nchannel = "9.99.9"\n' \
-    > "$tree/wallet/scratch-crate/rust-toolchain.toml"
-  # A virtual workspace root: no [package], so there is no rust-version to pin
-  # and nothing to register. Recognised by that structure, not by its path.
-  printf '[workspace]\nresolver = "3"\nmembers = ["crates/*"]\n' > "$tree/rs/Cargo.toml"
+  tree=$scratch/census-unregistered
+  stage_tree "$tree"
+  rel=rs/crates/scratch/Cargo.toml
+  mkdir -p "$tree/$(dirname "$rel")/src"
+  printf '[package]\nname = "scratch"\nversion = "0.0.0"\n' >"$tree/$rel"
+  printf 'pub fn scratch() {}\n' >"$tree/$(dirname "$rel")/src/lib.rs"
+  git -C "$tree" add -- "$rel" "$(dirname "$rel")/src/lib.rs"
+  self_test_census_case "$tree" 'a new crate under rs/ that nobody registered' \
+    reject "$rel declares [package] but is registered nowhere" || failures=$((failures + 1))
 
+  # Cargo accepts many TOML spellings of the package table. Each fixture is a
+  # real staged path with a real target, and must reach the same registration
+  # verdict; a source grep for the canonical `[package]` spelling misses all
+  # but the first control.
+  local package_form description manifest package_case=0
+  local package_forms=(
+    $'canonical table\t[package]\nname = "census-form-%INDEX%"\nversion = "0.0.0"\nedition = "2024"'
+    $'space inside table brackets\t[ package ]\nname = "census-form-%INDEX%"\nversion = "0.0.0"\nedition = "2024"'
+    $'space before closing table bracket\t[package ]\nname = "census-form-%INDEX%"\nversion = "0.0.0"\nedition = "2024"'
+    $'double-quoted table key\t["package"]\nname = "census-form-%INDEX%"\nversion = "0.0.0"\nedition = "2024"'
+    $'single-quoted table key\t[\'package\']\nname = "census-form-%INDEX%"\nversion = "0.0.0"\nedition = "2024"'
+    $'inline package table\tpackage = { name = "census-form-%INDEX%", version = "0.0.0", edition = "2024" }'
+    $'dotted package keys\tpackage.name = "census-form-%INDEX%"\npackage.version = "0.0.0"\npackage.edition = "2024"'
+  )
+  for package_form in "${package_forms[@]}"; do
+    package_case=$((package_case + 1))
+    description=${package_form%%$'\t'*}
+    manifest=${package_form#*$'\t'}
+    manifest=${manifest//%INDEX%/$package_case}
+    tree=$scratch/census-package-form-$package_case
+    stage_tree "$tree"
+    rel=wallet/census-package-form-$package_case/Cargo.toml
+    mkdir -p "$tree/$(dirname "$rel")/src"
+    printf '%s\n' "$manifest" >"$tree/$rel"
+    printf 'pub fn package_form() {}\n' >"$tree/$(dirname "$rel")/src/lib.rs"
+    git -C "$tree" add -- "$rel" "$(dirname "$rel")/src/lib.rs"
+    self_test_census_case "$tree" "an unregistered Cargo-valid package using $description" \
+      reject "$rel declares [package] but is registered nowhere" || failures=$((failures + 1))
+  done
+
+  tree=$scratch/census-invalid-manifest
+  stage_tree "$tree"
+  rel=wallet/census-invalid/Cargo.toml
+  mkdir -p "$tree/$(dirname "$rel")/src"
+  printf '[package\nname = "invalid"\nversion = "0.0.0"\n' >"$tree/$rel"
+  printf 'pub fn invalid() {}\n' >"$tree/$(dirname "$rel")/src/lib.rs"
+  git -C "$tree" add -- "$rel" "$(dirname "$rel")/src/lib.rs"
+  self_test_census_case "$tree" 'a malformed manifest that Cargo cannot classify' \
+    reject "$rel could not be classified by pinned Cargo" || failures=$((failures + 1))
+
+  tree=$scratch/census-virtual-string
+  stage_tree "$tree"
+  rel=wallet/census-virtual-string/Cargo.toml
+  mkdir -p "$tree/$(dirname "$rel")"
+  printf 'note = """\n[package]\n"""\n[workspace]\nresolver = "3"\n' >"$tree/$rel"
+  git -C "$tree" add -- "$rel"
   self_test_census_case "$tree" \
-    'a new crate under rs/ that nobody registered' \
-    reject rs/crates/scratch/Cargo.toml \
-    "$registered"$'\n''rs/crates/scratch/Cargo.toml' ||
+    'a valid virtual manifest whose multiline string mentions [package]' accept '' ||
     failures=$((failures + 1))
 
+  tree=$scratch/census-registered-virtual
+  stage_tree "$tree"
+  rel=wallet/census-registered-virtual/Cargo.toml
+  local registered_msrv
+  registered_msrv=$(read_channel "$tree")
+  registered_msrv=${registered_msrv%.*}
+  mkdir -p "$tree/$(dirname "$rel")"
+  printf 'note = """\nrust-version = "%s"\n"""\n[workspace]\nresolver = "3"\n' \
+    "$registered_msrv" >"$tree/$rel"
+  git -C "$tree" add -- "$rel"
+  MANIFESTS+=("$rel")
   self_test_census_case "$tree" \
-    'a new crate under wallet/ that nobody registered' \
-    reject wallet/scratch-crate/Cargo.toml \
-    "$registered"$'\n''wallet/scratch-crate/Cargo.toml' ||
+    'a virtual manifest cannot masquerade as a registered package through string text' \
+    reject "$rel is registered in MANIFESTS as a package" || failures=$((failures + 1))
+  MANIFESTS=("${saved_manifests[@]}")
+
+  tree=$scratch/census-third-root
+  stage_tree "$tree"
+  rel=third/Cargo.toml
+  mkdir -p "$tree/third"
+  printf '[workspace]\nresolver = "3"\n' >"$tree/$rel"
+  git -C "$tree" add -- "$rel"
+  self_test_census_case "$tree" 'a virtual manifest introduces a third Rust root' \
+    reject "$rel belongs to 0 policed Rust roots" || failures=$((failures + 1))
+
+  tree=$scratch/census-z
+  stage_tree "$tree"
+  rel=z/Cargo.toml
+  mkdir -p "$tree/z"
+  printf '[package]\nname = "vendored"\nversion = "0.0.0"\n' >"$tree/$rel"
+  git -C "$tree" add -- "$rel"
+  self_test_census_case "$tree" 'the exact vendored z/ boundary' accept '' ||
     failures=$((failures + 1))
 
-  self_test_census_case "$tree" \
-    'a second rust-toolchain.toml that nobody registered' \
-    reject wallet/scratch-crate/rust-toolchain.toml \
-    "$registered"$'\n''wallet/scratch-crate/rust-toolchain.toml' ||
-    failures=$((failures + 1))
-
-  self_test_census_case "$tree" \
-    'a listing of nothing at all (the census gone blind)' \
-    reject 'gone blind' '' ||
-    failures=$((failures + 1))
-
-  self_test_census_case "$tree" \
-    'a registered crate manifest' \
-    accept '' "$registered" ||
-    failures=$((failures + 1))
-
-  self_test_census_case "$tree" \
-    'a virtual workspace root that declares no [package]' \
-    accept '' "$registered"$'\n''rs/Cargo.toml' ||
-    failures=$((failures + 1))
-
-  self_test_census_case "$tree" \
-    'the source of truth itself, which is registered by being it' \
-    accept '' "$registered"$'\n'"$TOOLCHAIN_FILE" ||
-    failures=$((failures + 1))
-
-  self_test_census_case "$tree" \
-    'a vendored crate under z/, whose MSRV is upstream to decide' \
-    accept '' "$registered"$'\n''z/vendored/crate/Cargo.toml' ||
+  tree=$scratch/census-empty
+  stage_tree "$tree"
+  while IFS= read -r -d '' rel; do
+    git -C "$tree" rm --cached -q -- "$rel"
+  done < <(git -C "$tree" ls-files -z -- '*Cargo.toml' '*rust-toolchain.toml')
+  self_test_census_case "$tree" 'an empty tracked Rust inventory' reject 'gone blind' ||
     failures=$((failures + 1))
 
   return "$failures"
@@ -830,12 +985,15 @@ self_test_second_tree() {
     saved_restatements=("${TOOLCHAIN_RESTATEMENTS[@]}")
 
   stage_tree "$tree"
-  mkdir -p "$tree/rs/relay/src"
+  mkdir -p "$tree/rs/crates/relay/src"
   printf '[toolchain]\nchannel = "%s"\n' "$channel" > "$tree/rs/rust-toolchain.toml"
   printf '[package]\nname = "relay"\nversion = "0.0.0"\nedition = "2024"\nrust-version = "%s"\n' \
-    "$msrv" > "$tree/rs/relay/Cargo.toml"
+    "$msrv" > "$tree/rs/crates/relay/Cargo.toml"
+  printf 'pub fn relay() {}\n' > "$tree/rs/crates/relay/src/lib.rs"
+  git -C "$tree" add -- \
+    rs/rust-toolchain.toml rs/crates/relay/Cargo.toml rs/crates/relay/src/lib.rs
 
-  MANIFESTS+=(rs/relay/Cargo.toml)
+  MANIFESTS+=(rs/crates/relay/Cargo.toml)
   TOOLCHAIN_RESTATEMENTS+=(rs/rust-toolchain.toml)
 
   if run_checks "$tree" >/dev/null; then
@@ -852,7 +1010,7 @@ self_test_second_tree() {
 
   self_test_second_tree_case "$tree" \
     "a second tree's crate MSRV drifts" \
-    rs/relay/Cargo.toml "s|rust-version = \"$msrv\"|rust-version = \"9.99\"|" ||
+    rs/crates/relay/Cargo.toml "s|rust-version = \"$msrv\"|rust-version = \"9.99\"|" ||
     failures=$((failures + 1))
 
   rm -f "$tree/rs/rust-toolchain.toml"

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -453,32 +453,39 @@ check_toolchain_restatements() {
 # Ask the pinned Cargo itself whether a manifest is a package or a virtual
 # workspace.  TOML permits whitespace and quoted, inline, and dotted keys, so a
 # source grep for `[package]` is neither complete nor sound. `read-manifest`
-# succeeds only for a package and emits one exact diagnostic for a valid
-# virtual manifest; every other failure is a parse/classification failure and
-# must fail closed.
+# succeeds only for a package. When it fails, a second semantic command,
+# `metadata`, succeeds for a valid virtual workspace. Classification never
+# depends on Cargo/rustup diagnostic wording, ANSI colour, or startup prelude;
+# both commands failing is malformed or otherwise unclassifiable and fails
+# closed.
 CARGO_MANIFEST_KIND=
 classify_cargo_manifest() {
-  local root=$1 rel=$2 channel=$3 diagnostic_file diagnostic virtual_suffix
+  local root=$1 rel=$2 channel=$3
+  local read_diagnostic_file metadata_diagnostic_file read_diagnostic metadata_diagnostic
 
   CARGO_MANIFEST_KIND=
-  diagnostic_file=$(mktemp "${TMPDIR:-/tmp}/cargo-manifest-classification.XXXXXX")
+  read_diagnostic_file=$(mktemp "${TMPDIR:-/tmp}/cargo-read-manifest.XXXXXX")
+  metadata_diagnostic_file=$(mktemp "${TMPDIR:-/tmp}/cargo-metadata.XXXXXX")
   if cargo +"$channel" read-manifest --manifest-path "$root/$rel" \
-    >/dev/null 2>"$diagnostic_file"; then
+    >/dev/null 2>"$read_diagnostic_file"; then
     CARGO_MANIFEST_KIND=package
-    rm -f -- "$diagnostic_file"
+    rm -f -- "$read_diagnostic_file" "$metadata_diagnostic_file"
     return 0
   fi
 
-  diagnostic=$(cat "$diagnostic_file")
-  rm -f -- "$diagnostic_file"
-  virtual_suffix='` is a virtual manifest, but this command requires running against an actual package in this workspace'
-  if [[ $diagnostic == 'error: manifest path `'*"$virtual_suffix" ]]; then
+  if cargo +"$channel" metadata --no-deps --format-version 1 \
+    --manifest-path "$root/$rel" >/dev/null 2>"$metadata_diagnostic_file"; then
     CARGO_MANIFEST_KIND=virtual
+    rm -f -- "$read_diagnostic_file" "$metadata_diagnostic_file"
     return 0
   fi
 
-  diagnostic=${diagnostic//$'\n'/; }
-  fail "$rel could not be classified by pinned Cargo $channel: ${diagnostic:-no diagnostic}"
+  read_diagnostic=$(tail -n 3 "$read_diagnostic_file")
+  metadata_diagnostic=$(tail -n 3 "$metadata_diagnostic_file")
+  rm -f -- "$read_diagnostic_file" "$metadata_diagnostic_file"
+  read_diagnostic=${read_diagnostic//$'\n'/; }
+  metadata_diagnostic=${metadata_diagnostic//$'\n'/; }
+  fail "$rel could not be classified by pinned Cargo $channel (read-manifest: ${read_diagnostic:-no diagnostic}; metadata: ${metadata_diagnostic:-no diagnostic})"
   return 1
 }
 
@@ -903,6 +910,22 @@ self_test_census() {
       reject "$rel declares [package] but is registered nowhere" || failures=$((failures + 1))
   done
 
+  # Cargo and rustup may decorate stderr before Cargo's own diagnostic. CI
+  # deliberately sets CARGO_TERM_COLOR=always, and rustup may print a sync
+  # prelude on a cold runner. A real wrapper injects both shapes before the
+  # pinned Cargo commands: semantic command success must remain the only
+  # classifier, while a malformed manifest must still fail closed.
+  local cargo_noise_bin real_cargo
+  cargo_noise_bin=$scratch/cargo-classifier-noise-bin
+  real_cargo=$(command -v cargo)
+  mkdir -p "$cargo_noise_bin"
+  cat >"$cargo_noise_bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+printf '\033[1;33minfo: syncing channel updates for classifier fixture\033[0m\n' >&2
+exec "$CENSUS_REAL_CARGO" "$@"
+EOF
+  chmod +x "$cargo_noise_bin/cargo"
+
   tree=$scratch/census-invalid-manifest
   stage_tree "$tree"
   rel=wallet/census-invalid/Cargo.toml
@@ -910,8 +933,14 @@ self_test_census() {
   printf '[package\nname = "invalid"\nversion = "0.0.0"\n' >"$tree/$rel"
   printf 'pub fn invalid() {}\n' >"$tree/$(dirname "$rel")/src/lib.rs"
   git -C "$tree" add -- "$rel" "$(dirname "$rel")/src/lib.rs"
-  self_test_census_case "$tree" 'a malformed manifest that Cargo cannot classify' \
-    reject "$rel could not be classified by pinned Cargo" || failures=$((failures + 1))
+  (
+    export PATH="$cargo_noise_bin:$PATH"
+    export CENSUS_REAL_CARGO="$real_cargo"
+    export CARGO_TERM_COLOR=always
+    self_test_census_case "$tree" \
+      'a malformed manifest despite ANSI and rustup prelude diagnostics' \
+      reject "$rel could not be classified by pinned Cargo"
+  ) || failures=$((failures + 1))
 
   tree=$scratch/census-virtual-string
   stage_tree "$tree"
@@ -919,9 +948,14 @@ self_test_census() {
   mkdir -p "$tree/$(dirname "$rel")"
   printf 'note = """\n[package]\n"""\n[workspace]\nresolver = "3"\n' >"$tree/$rel"
   git -C "$tree" add -- "$rel"
-  self_test_census_case "$tree" \
-    'a valid virtual manifest whose multiline string mentions [package]' accept '' ||
-    failures=$((failures + 1))
+  (
+    export PATH="$cargo_noise_bin:$PATH"
+    export CENSUS_REAL_CARGO="$real_cargo"
+    export CARGO_TERM_COLOR=always
+    self_test_census_case "$tree" \
+      'a valid virtual manifest despite ANSI/rustup prelude and multiline [package] text' \
+      accept ''
+  ) || failures=$((failures + 1))
 
   tree=$scratch/census-registered-virtual
   stage_tree "$tree"

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -13,7 +13,7 @@ const target = "armv7-linux-androideabi";
 const ndk = "27.0.12077973";
 const cacheKey = `zuuli-plugin-android-armv7-ndk${ndk}-api29`;
 const changeDetectorDigest =
-  "0a18f5b385da5ebfee7392fd1f5fc9df137ae0cc02ab4101332066a5ba65b7dc";
+  "c6310395af8224c88b3e58fddf182950d65c52cf12caf6b48bbf82815694f52b";
 const toolchainEnvDigest =
   "403f59c58bca0a37b98a3bb0ea0ae7f1c289b3531d6e1eec8496643866ee2013";
 const classicSeedBoundaryInputs = [
@@ -228,6 +228,16 @@ function check(workflow, toolchainEnv) {
 
 function runSelfTest(workflow, toolchainEnv) {
   const mutations = [
+    [
+      "the change detector restores a line-delimited Git producer",
+      "git diff --name-only -z --no-renames",
+      "git diff --name-only --no-renames",
+    ],
+    [
+      "the change detector restores a line-delimited consumer",
+      "while IFS= read -r -d '' file; do",
+      "while IFS= read -r file; do",
+    ],
     ["the armv7 target is replaced", `targets: ${target}`, "targets: aarch64-linux-android"],
     ["the target check is replaced", `--target ${target}`, "--target aarch64-linux-android"],
     ["the pinned NDK is changed", `'ndk;${ndk}'`, "'ndk;latest'"],


### PR DESCRIPTION
Closes #608

## Summary

- census every tracked first-party Cargo manifest and toolchain file from the real NUL-delimited Git index
- classify package versus virtual manifests with Cargo semantics, failing closed on malformed manifests
- require exact ownership by the wallet/ or rs/ Rust root and one owning workflow per root
- make both workflow selectors NUL-safe under Bash 3.2 and bind their exact step IDs, published outputs, downstream consumers, and effective last values
- make rustfmt discover every manifest at arbitrary depth and fail closed on an empty tree

## Mutation proof

Every guard was broken before publication and shown red. Independent review killed:

- Cargo-valid quoted, spaced, inline, and dotted package spellings; malformed manifests; multiline-string virtual false positives
- plain/non-NUL Git producers and consumers across spaces, tabs, newlines, backslashes, and dash paths
- narrowed, dead, overlapping, adjacent-prefix, and vendored-root ownership selectors
- diff-failure inversion and unusable-base skips
- appended false outputs, wrong/duplicate output publications, renamed detector IDs, and downstream selector bypasses
- empty/depth-limited rustfmt census and one-to-one workflow ownership mutations

Restored baselines pass the toolchain, Actions-policy, workflow-gate, and rustfmt self/live suites. Exact independently approved head: 271730d00335e7677c05cec8382d6aae3fdb62b5.
