### PR TITLE
feat(kt): add experimental authority assertion layer

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -319,7 +319,8 @@ jobs:
           cargo build --locked --lib \
             --target "${{ steps.rust_toolchain.outputs.target }}" \
             -p f2z-codec \
-            -p f2z-relay-proto
+            -p f2z-relay-proto \
+            -p f2z-authority
 
   # Branch protection should require this stable context, `rs / gate`. It
   # succeeds only when the change detector and every applicable rs job

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -171,6 +171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "f2z-authority"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "f2z-codec",
+ "tls_codec",
+]
+
+[[package]]
 name = "f2z-codec"
 version = "0.1.0"
 dependencies = [

--- a/rs/README.md
+++ b/rs/README.md
@@ -112,11 +112,14 @@ prevent.
 |---|---|
 | [`crates/f2z-codec`](./crates/f2z-codec) | The canonical encoding layer of `WIRE.md`: `tls_codec` wrappers for every wire structure, the domain-separated signing transcript (§5), the redacting newtypes, and the padding-bucket validator (§9). `no_std` + `alloc`, `#![forbid(unsafe_code)]`, no I/O, no async runtime, and it builds for `wasm32-unknown-unknown`. |
 | [`crates/f2z-relay-proto`](./crates/f2z-relay-proto) | The protocol layer above it: signed-command construction and verification in §5.1's exact order, the timestamp window and fail-closed seen-set (§5.5), the queue lifecycle and ACK arithmetic (§7, §8), the capability document (§11), the `HELLO` proof of possession (§5.2), and §4.3's typed in-flight window. Same constraints — `no_std` + `alloc`, no I/O, no clock, no randomness, and it builds for `wasm32-unknown-unknown`. |
+| [`crates/f2z-authority`](./crates/f2z-authority) | An **experimental candidate** for the directory's non-cryptographic trust-root layer: the proposed `HandleAssertion`, a partial assertion-layer check, `AuthoritySet`, and `f2z-assert`. `KT.md` does not yet ratify these structures or first-entry/no-authority semantics (#594), and its result is not §4.4 directory authorization. Same portability constraints. |
 
-**The relay and the clients link both.** That is the licence boundary in
-practice: everything here is MIT because a third-party relay, ZUULI and the WASM
-web client all compile the same rules, and a rule that two implementations
-disagree about is how ciphertext gets deleted before it is read.
+The current dependency graph is narrower than that intended architecture:
+`f2z-relay-proto` depends on `f2z-codec`, while `f2z-authority` is still a
+standalone experimental leaf and no workspace package depends on it. Wiring the
+authority candidate into a relay or client is future integration work, not a
+property this README claims today. All three remain MIT so downstream relays and
+clients can share the rules once that integration exists.
 
 `f2z-codec` is separate from everything that sits on top of it for three
 reasons, and each is enforced by a test rather than by intent:
@@ -136,7 +139,8 @@ reasons, and each is enforced by a test rather than by intent:
 ```bash
 cd rs
 cargo test
-cargo build --target wasm32-unknown-unknown --lib -p f2z-codec -p f2z-relay-proto
+cargo build --target wasm32-unknown-unknown --lib \
+  -p f2z-codec -p f2z-relay-proto -p f2z-authority
 ```
 
 The gates are the repository's shared scripts, pointed here with `--root`:

--- a/rs/crates/f2z-authority/Cargo.toml
+++ b/rs/crates/f2z-authority/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "f2z-authority"
+version = "0.1.0"
+description = "Handle-ownership assertions for the free2z key-transparency log: the one non-cryptographic trust root, isolated so it can be read in full"
+edition.workspace = true
+# A restatement of wallet/rust-toolchain.toml's channel in Cargo's MSRV form,
+# registered in `scripts/check-rust-toolchain.sh`'s `MANIFESTS` auto-census so
+# it cannot drift. Not inherited: that check reads this literal line.
+rust-version = "1.97"
+# Permissive, deliberately and explicitly, so clients and third-party relays
+# can eventually share the same assertion verifier. This experimental crate is
+# currently a standalone leaf: no browser, ZUULI, or log package depends on it
+# yet. The AGPL-3.0 boundary starts at server binaries, not here. Stated
+# literally rather than inherited so it is visible to anyone opening the
+# crate; rs/deny.toml enforces it.
+license = "MIT"
+repository.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ed25519-dalek = { workspace = true }
+# `version` beside `path` is not redundant: rs/deny.toml sets
+# `wildcards = "deny"`, and a bare path dependency is a wildcard requirement.
+f2z-codec = { path = "../f2z-codec", version = "0.1.0" }
+tls_codec = { workspace = true }
+
+# The example issuer. It is a `bin` in this package rather than a crate of its
+# own so that a self-hoster reading "how do I issue an assertion by hand" reads
+# the same source tree that defines what an assertion is. The library is
+# `no_std`; this target is not, and that is fine — `rs.yml`'s wasm job builds
+# `--lib`, so a browser never compiles it.
+[[bin]]
+name = "f2z-assert"
+path = "src/bin/f2z-assert.rs"

--- a/rs/crates/f2z-authority/src/assertion.rs
+++ b/rs/crates/f2z-authority/src/assertion.rs
@@ -1,0 +1,631 @@
+//! The two signed structures: what an authority says, and what the identity
+//! key it names says back.
+//!
+//! **Experimental proposal, not `KT.md` v1 wire format.** `KT.md` leaves
+//! first-entry authorization unresolved in #594 and defines none of these
+//! structures or no-authority semantics. The presentation below and the byte
+//! vectors in this module pin this crate's candidate layout for review only.
+//!
+//! ```text
+//! struct {
+//!     opaque label<0..255>;      /* exactly "free2z/kt/v1/handle-assertion" */
+//!     opaque authority_id[32];   /* H("free2z/kt/v1/authority-id", authority_pk) */
+//!     opaque log_id[32];
+//!     opaque handle<1..30>;
+//!     opaque handle_id[32];      /* H("free2z/kt/v1/handle-id", handle)          */
+//!     opaque identity_pk[32];    /* ISK.public — the key this vouches for        */
+//!     uint8  intent;             /* bind(1), reset(2)                            */
+//!     uint32 account_epoch;
+//!     uint64 issued_ms;
+//!     uint64 expires_ms;
+//!     opaque nonce[16];
+//! } HandleAssertionTBS;
+//!
+//! struct {
+//!     HandleAssertionTBS assertion;
+//!     opaque             signature[64];   /* Ed25519 by authority_id's key */
+//! } HandleAssertion;
+//!
+//! struct {
+//!     opaque label<0..255>;      /* exactly "free2z/kt/v1/assertion-binding" */
+//!     opaque log_id[32];
+//!     opaque handle<1..30>;
+//!     opaque identity_pk[32];
+//!     opaque assertion_digest[32];  /* H(".../assertion-digest", tls_codec(HandleAssertion));
+//!                                      all-zero when this entry carries none */
+//!     opaque entry_digest[32];      /* the submission's AkdValue, KT.md §3.3 */
+//! } AssertionBindingTBS;
+//! ```
+//!
+//! # Why there are two, and not one
+//!
+//! An assertion is a **bearer** document: it is bytes an authority signed,
+//! served over a network, sitting in a log's request queue and in whatever
+//! debugging archive the operator kept. Anyone who obtains a copy holds
+//! everything the authority said. If holding it were enough to submit under the
+//! handle it names, then intercepting one — from a TLS-terminating proxy, from
+//! a log's access log, from a stolen backup — would be a handle takeover, and
+//! the authority would have no way to tell the thief from the subject.
+//!
+//! [`AssertionBindingTBS`] closes that. It is signed by the **identity private
+//! key the assertion is about**, and it commits to the exact submission the
+//! assertion is being presented with. A thief holding the assertion cannot
+//! produce it, because producing it needs the key the assertion vouches *for* —
+//! which is the key the thief was trying to replace. The stolen assertion is
+//! worthless.
+//!
+//! This proposal requires this pairing. This crate makes it structural: there is no
+//! function here or in [`crate::authority`] that checks an authority's
+//! signature without also checking the binding, so a caller cannot arrive at a
+//! verified assertion by a route that skipped it.
+//!
+//! Including `entry_digest` rather than only the assertion is what stops the
+//! *subject's own* binding from being reusable: a binding signed for one
+//! submission does not authorize a second, so a log that saw one cannot resubmit
+//! it against different entry bytes. Including `log_id` rather than relying on
+//! the digest to carry it is one field for a whole class of cross-log replay.
+
+use alloc::vec::Vec;
+// `tls_codec`'s derive macros build their error strings with `format!` and
+// return `Vec<u8>`; both need to be in scope in a `no_std` crate.
+use alloc::format;
+
+use f2z_codec::canonical::Canonical;
+use f2z_codec::hash::hash;
+use f2z_codec::types::{Digest, PublicKey, ShortBytes, Signature};
+use tls_codec::{TlsDeserializeBytes, TlsSerializeBytes, TlsSize};
+
+use crate::error::{AuthorityError, Result};
+use crate::key::SigningKey;
+use crate::labels::{LABEL_ASSERTION_BINDING_TBS, LABEL_ASSERTION_DIGEST, LABEL_ASSERTION_TBS};
+use crate::types::{AssertionNonce, AuthorityId, Handle, HandleId, Intent, LogId, authority_id};
+
+/// What an authority signs.
+///
+/// Every field is checked by [`AuthorityConfig::check_assertion_layer`] — the type carries no
+/// invariant of its own beyond decoding, deliberately, so that a decoded
+/// assertion is *data* until a policy has judged it.
+///
+/// The derived `Debug` is safe because every field that holds bytes is one of
+/// the redacting newtypes; `label` renders because [`ShortBytes`] prints
+/// printable ASCII and that is the field's entire purpose.
+///
+/// [`AuthorityConfig::check_assertion_layer`]: crate::authority::AuthorityConfig::check_assertion_layer
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct HandleAssertionTBS {
+    /// Exactly [`LABEL_ASSERTION_TBS`]. The domain-separated signing prefix.
+    pub label: ShortBytes,
+    /// Which authority is speaking.
+    pub authority_id: AuthorityId,
+    /// Which log this is for.
+    pub log_id: LogId,
+    /// The handle being vouched for.
+    pub handle: Handle,
+    /// `H("free2z/kt/v1/handle-id", handle)`.
+    pub handle_id: HandleId,
+    /// The identity key (ISK.public) the handle is being bound to.
+    pub identity_pk: PublicKey,
+    /// Bind, or reset.
+    pub intent: Intent,
+    /// The authority's counter for the *account* behind the handle. It
+    /// increments whenever the account changes hands or is recovered, which is
+    /// the only thing that justifies a reset.
+    pub account_epoch: u32,
+    /// When the authority issued this, in milliseconds since the Unix epoch.
+    pub issued_ms: u64,
+    /// When it stops being usable.
+    pub expires_ms: u64,
+    /// 16 bytes of issuer CSPRNG, fresh per assertion.
+    pub nonce: AssertionNonce,
+}
+
+impl HandleAssertionTBS {
+    /// Build an assertion body, deriving `authority_id` and `handle_id` rather
+    /// than accepting them.
+    ///
+    /// Deriving both here is why a hand-built assertion cannot contradict
+    /// itself in the two ways that would otherwise be easy: naming one
+    /// authority while being signed by another, and naming one handle while
+    /// being indexed under another.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::Malformed`] if the label does not fit `<0..255>`,
+    /// which it always does — the check is there so the constructor has no
+    /// unwrap in it.
+    // Nine arguments, and deliberately not a builder. Every one of them is a
+    // field of a structure that is about to be signed, and a builder would make
+    // each one omissible: forgetting `expires_ms` on a builder yields a
+    // compiling program that mints an assertion with a zero expiry, while
+    // forgetting it here does not compile. `authority_id` and `handle_id` are
+    // the two fields that are *not* arguments, because they are derived.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        authority_pk: &PublicKey,
+        log_id: LogId,
+        handle: Handle,
+        identity_pk: PublicKey,
+        intent: Intent,
+        account_epoch: u32,
+        issued_ms: u64,
+        expires_ms: u64,
+        nonce: AssertionNonce,
+    ) -> Result<Self> {
+        let handle_id = handle.handle_id();
+        Ok(Self {
+            label: ShortBytes::new(LABEL_ASSERTION_TBS).map_err(AuthorityError::from)?,
+            authority_id: authority_id(authority_pk),
+            log_id,
+            handle,
+            handle_id,
+            identity_pk,
+            intent,
+            account_epoch,
+            issued_ms,
+            expires_ms,
+            nonce,
+        })
+    }
+
+    /// The exact bytes the authority signs.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>> {
+        Ok(self.encode_canonical()?)
+    }
+
+    /// Sign this body, producing the assertion an issuer hands out.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::Malformed`] if the structure cannot be encoded.
+    pub fn sign(self, key: &SigningKey) -> Result<HandleAssertion> {
+        let signature = key.sign(&self.signing_bytes()?);
+        Ok(HandleAssertion {
+            assertion: self,
+            signature,
+        })
+    }
+}
+
+/// A signed assertion: the bearer document.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct HandleAssertion {
+    /// What was signed.
+    pub assertion: HandleAssertionTBS,
+    /// Ed25519 over `tls_codec(HandleAssertionTBS)`, by the key whose digest is
+    /// `assertion.authority_id`.
+    pub signature: Signature,
+}
+
+impl HandleAssertion {
+    /// `H("free2z/kt/v1/assertion-digest", tls_codec(HandleAssertion))` — what
+    /// the identity key's binding commits to.
+    ///
+    /// Over the assertion **including its signature**, on `KT.md` §4.2's
+    /// reasoning for `prev_entry_hash`: committing to the authorization as well
+    /// as the contents means an assertion cannot be re-signed after the subject
+    /// has bound itself to it.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::Malformed`] if the structure cannot be encoded.
+    pub fn digest(&self) -> Result<Digest> {
+        Ok(hash(LABEL_ASSERTION_DIGEST, &self.encode_canonical()?))
+    }
+}
+
+/// What the identity key signs: this assertion, for this submission, on this
+/// log.
+///
+/// See the module note. `assertion_digest` is 32 zero bytes when the entry
+/// carries no assertion — the proposed unvouched mode and routine entries — so
+/// the submitter still answers for this exact entry.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct AssertionBindingTBS {
+    /// Exactly [`LABEL_ASSERTION_BINDING_TBS`].
+    pub label: ShortBytes,
+    /// The log the submission is going to.
+    pub log_id: LogId,
+    /// The handle being claimed.
+    pub handle: Handle,
+    /// The identity key doing the claiming — and the key that signs this.
+    pub identity_pk: PublicKey,
+    /// [`HandleAssertion::digest`], or 32 zero bytes on a log with no
+    /// authority.
+    pub assertion_digest: Digest,
+    /// The submission's `AkdValue`:
+    /// `H("free2z/kt/v1/value", tls_codec(DirectoryEntry))` (`KT.md` §3.3).
+    pub entry_digest: Digest,
+}
+
+impl AssertionBindingTBS {
+    /// The binding for a submission that carries an assertion.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::Malformed`] if the label does not fit `<0..255>`.
+    pub fn for_assertion(
+        log_id: LogId,
+        handle: Handle,
+        identity_pk: PublicKey,
+        assertion_digest: Digest,
+        entry_digest: Digest,
+    ) -> Result<Self> {
+        Ok(Self {
+            label: ShortBytes::new(LABEL_ASSERTION_BINDING_TBS).map_err(AuthorityError::from)?,
+            log_id,
+            handle,
+            identity_pk,
+            assertion_digest,
+            entry_digest,
+        })
+    }
+
+    /// The binding for a submission to a log with **no** authority, where there
+    /// is no assertion to commit to.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::Malformed`] if the label does not fit `<0..255>`.
+    pub fn unvouched(
+        log_id: LogId,
+        handle: Handle,
+        identity_pk: PublicKey,
+        entry_digest: Digest,
+    ) -> Result<Self> {
+        Self::for_assertion(log_id, handle, identity_pk, Digest::zero(), entry_digest)
+    }
+
+    /// The exact bytes the identity key signs.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::Malformed`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>> {
+        Ok(self.encode_canonical()?)
+    }
+
+    /// Sign this binding with the identity key it names.
+    ///
+    /// Nothing checks here that `key` *is* `identity_pk`; the verifier does,
+    /// because it is the verifier's job and a signing-side check would be
+    /// advice rather than a rule.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::Malformed`] if the structure cannot be encoded.
+    pub fn sign(&self, key: &SigningKey) -> Result<Signature> {
+        Ok(key.sign(&self.signing_bytes()?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_codec::canonical::decode_canonical;
+
+    struct Field {
+        bytes: Vec<u8>,
+    }
+
+    fn declared_encoded_width(declaration: &str, bytes: &[u8]) -> usize {
+        if let Some(bits) = declaration
+            .split_whitespace()
+            .next()
+            .and_then(|kind| kind.strip_prefix("uint"))
+        {
+            let bits: usize = bits.parse().unwrap();
+            assert_eq!(bits % 8, 0, "`{declaration}` is not byte-aligned");
+            return bits / 8;
+        }
+
+        if let Some((_, width)) = declaration
+            .strip_suffix(']')
+            .and_then(|without_close| without_close.rsplit_once('['))
+        {
+            assert!(
+                declaration.starts_with("opaque "),
+                "unsupported fixed-width declaration `{declaration}`"
+            );
+            return width.parse().unwrap();
+        }
+
+        if let Some((_, bounds)) = declaration
+            .strip_suffix('>')
+            .and_then(|without_close| without_close.rsplit_once('<'))
+        {
+            assert!(
+                declaration.starts_with("opaque "),
+                "unsupported variable-width declaration `{declaration}`"
+            );
+            let (min, max) = bounds.split_once("..").unwrap();
+            let min: usize = min.parse().unwrap();
+            let max: usize = max.parse().unwrap();
+            let (&encoded_len, payload) = bytes.split_first().unwrap();
+            assert_eq!(
+                usize::from(encoded_len),
+                payload.len(),
+                "`{declaration}` length prefix says {encoded_len} bytes but the literal supplies {}",
+                payload.len()
+            );
+            assert!(
+                (min..=max).contains(&payload.len()),
+                "`{declaration}` permits {min}..{max} bytes but the literal supplies {}",
+                payload.len()
+            );
+            return bytes.len();
+        }
+
+        assert_eq!(
+            declaration, "HandleAssertionTBS assertion",
+            "unsupported wire declaration `{declaration}`"
+        );
+        bytes.len()
+    }
+
+    fn field(declaration: &'static str, bytes: impl AsRef<[u8]>) -> Field {
+        let bytes = bytes.as_ref().to_vec();
+        let width = declared_encoded_width(declaration, &bytes);
+        assert_eq!(
+            bytes.len(),
+            width,
+            "`{declaration}` says {width} bytes but the literal supplies {}",
+            bytes.len()
+        );
+        Field { bytes }
+    }
+
+    fn fill(byte: u8, width: usize) -> Vec<u8> {
+        alloc::vec![byte; width]
+    }
+
+    fn hand_derived(fields: &[Field]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for value in fields {
+            bytes.extend_from_slice(&value.bytes);
+        }
+        bytes
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "`opaque authority_id[31]` says 31 bytes but the literal supplies 32"
+    )]
+    fn the_wire_declaration_width_is_a_live_guard() {
+        let _ = field("opaque authority_id[31]", fill(0x11, 32));
+    }
+
+    #[test]
+    #[should_panic(expected = "`uint64 account_epoch` says 8 bytes but the literal supplies 4")]
+    fn the_integer_declaration_drives_its_encoded_width() {
+        let _ = field("uint64 account_epoch", [0u8; 4]);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "`opaque handle<1..30>` length prefix says 4 bytes but the literal supplies 5"
+    )]
+    fn the_variable_opaque_declaration_checks_its_length_prefix() {
+        let _ = field("opaque handle<1..30>", b"\x04alice");
+    }
+
+    fn vector_tbs() -> HandleAssertionTBS {
+        HandleAssertionTBS {
+            label: ShortBytes::new(b"free2z/kt/v1/handle-assertion").unwrap(),
+            authority_id: AuthorityId::new([0x11; 32]),
+            log_id: LogId::new([0x22; 32]),
+            handle: Handle::parse(b"alice").unwrap(),
+            handle_id: HandleId::new([0x33; 32]),
+            identity_pk: PublicKey::new([0x44; 32]),
+            intent: Intent::Bind,
+            account_epoch: 0x0102_0304,
+            issued_ms: 0x0102_0304_0506_0708,
+            expires_ms: 0x1112_1314_1516_1718,
+            nonce: AssertionNonce::new([0x55; 16]),
+        }
+    }
+
+    fn tbs_fields() -> Vec<Field> {
+        alloc::vec![
+            field("opaque label<0..255>", b"\x1dfree2z/kt/v1/handle-assertion",),
+            field("opaque authority_id[32]", fill(0x11, 32)),
+            field("opaque log_id[32]", fill(0x22, 32)),
+            field("opaque handle<1..30>", b"\x05alice"),
+            field("opaque handle_id[32]", fill(0x33, 32)),
+            field("opaque identity_pk[32]", fill(0x44, 32)),
+            field("uint8 intent", [0x01]),
+            field("uint32 account_epoch", [0x01, 0x02, 0x03, 0x04]),
+            field("uint64 issued_ms", [1, 2, 3, 4, 5, 6, 7, 8]),
+            field(
+                "uint64 expires_ms",
+                [0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18],
+            ),
+            field("opaque nonce[16]", fill(0x55, 16)),
+        ]
+    }
+
+    fn tbs() -> HandleAssertionTBS {
+        let authority = SigningKey::from_seed(&[1u8; 32]);
+        HandleAssertionTBS::new(
+            &authority.public_key(),
+            LogId::new([9u8; 32]),
+            Handle::parse(b"alice").unwrap(),
+            PublicKey::new([2u8; 32]),
+            Intent::Bind,
+            0,
+            1_000,
+            2_000,
+            AssertionNonce::new([3u8; 16]),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn the_constructor_derives_both_ids() {
+        let authority = SigningKey::from_seed(&[1u8; 32]);
+        let value = tbs();
+        assert_eq!(value.authority_id, authority_id(&authority.public_key()));
+        assert_eq!(value.handle_id, value.handle.handle_id());
+        assert_eq!(value.label.as_slice(), LABEL_ASSERTION_TBS);
+    }
+
+    #[test]
+    fn an_assertion_round_trips_canonically() {
+        let signed = tbs().sign(&SigningKey::from_seed(&[1u8; 32])).unwrap();
+        let bytes = signed.encode_canonical().unwrap();
+        assert_eq!(
+            decode_canonical::<HandleAssertion>(&bytes).unwrap().value(),
+            &signed
+        );
+
+        // A trailing byte is not slack.
+        let mut tampered = bytes.clone();
+        tampered.push(0);
+        assert!(decode_canonical::<HandleAssertion>(&tampered).is_err());
+    }
+
+    #[test]
+    fn the_signing_prefix_is_the_label_field() {
+        let bytes = tbs().signing_bytes().unwrap();
+        let mut expected = alloc::vec::Vec::new();
+        // `opaque label<0..255>`: one length byte, then the bytes.
+        expected.push(u8::try_from(LABEL_ASSERTION_TBS.len()).unwrap());
+        expected.extend_from_slice(LABEL_ASSERTION_TBS);
+        assert!(bytes.starts_with(&expected));
+    }
+
+    #[test]
+    fn proposal_handle_assertion_tbs_has_the_literal_candidate_field_order() {
+        assert_eq!(
+            vector_tbs().signing_bytes().unwrap(),
+            hand_derived(&tbs_fields())
+        );
+    }
+
+    #[test]
+    fn proposal_signed_assertion_has_the_literal_candidate_field_order() {
+        let actual = HandleAssertion {
+            assertion: vector_tbs(),
+            signature: Signature::new([0x66; 64]),
+        }
+        .encode_canonical()
+        .unwrap();
+        let fields = alloc::vec![
+            field("HandleAssertionTBS assertion", hand_derived(&tbs_fields()),),
+            field("opaque signature[64]", fill(0x66, 64)),
+        ];
+        assert_eq!(actual, hand_derived(&fields));
+    }
+
+    #[test]
+    fn proposal_binding_tbs_has_the_literal_candidate_field_order() {
+        let binding = AssertionBindingTBS {
+            label: ShortBytes::new(b"free2z/kt/v1/assertion-binding").unwrap(),
+            log_id: LogId::new([0x22; 32]),
+            handle: Handle::parse(b"alice").unwrap(),
+            identity_pk: PublicKey::new([0x44; 32]),
+            assertion_digest: Digest::new([0x77; 32]),
+            entry_digest: Digest::new([0x88; 32]),
+        };
+        let fields = alloc::vec![
+            field(
+                "opaque label<0..255>",
+                b"\x1efree2z/kt/v1/assertion-binding",
+            ),
+            field("opaque log_id[32]", fill(0x22, 32)),
+            field("opaque handle<1..30>", b"\x05alice"),
+            field("opaque identity_pk[32]", fill(0x44, 32)),
+            field("opaque assertion_digest[32]", fill(0x77, 32)),
+            field("opaque entry_digest[32]", fill(0x88, 32)),
+        ];
+        assert_eq!(binding.signing_bytes().unwrap(), hand_derived(&fields));
+    }
+
+    #[test]
+    fn the_digest_covers_the_signature_too() {
+        let body = tbs();
+        let one = body
+            .clone()
+            .sign(&SigningKey::from_seed(&[1u8; 32]))
+            .unwrap();
+        let mut two = one.clone();
+        two.signature = Signature::new([0u8; 64]);
+        assert_ne!(one.digest().unwrap(), two.digest().unwrap());
+    }
+
+    #[test]
+    fn assertion_digest_matches_the_independent_nonuniform_canonical_vector() {
+        // This is the literal tls_codec byte sequence for one signed
+        // assertion. Its BLAKE2b-256 expectation was derived independently as
+        // b2sum -l 256(label || these 265 bytes), not by this crate's hash or
+        // encoding helpers.
+        let mut canonical = b"\x1dfree2z/kt/v1/handle-assertion".to_vec();
+        canonical.extend_from_slice(&[
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+            0x1c, 0x1d, 0x1e, 0x1f,
+        ]);
+        canonical.extend_from_slice(&[
+            0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d,
+            0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b,
+            0x3c, 0x3d, 0x3e, 0x3f,
+        ]);
+        canonical.extend_from_slice(b"\x05a1_b2");
+        canonical.extend_from_slice(&[
+            0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d,
+            0x4e, 0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b,
+            0x5c, 0x5d, 0x5e, 0x5f,
+        ]);
+        canonical.extend_from_slice(&[
+            0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d,
+            0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x7b,
+            0x7c, 0x7d, 0x7e, 0x7f,
+        ]);
+        canonical.extend_from_slice(&[
+            0x02, 0x01, 0x23, 0x45, 0x67, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x11,
+            0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        ]);
+        canonical.extend_from_slice(&[
+            0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d,
+            0x8e, 0x8f,
+        ]);
+        canonical.extend(0x90..=0xcf);
+        assert_eq!(canonical.len(), 265);
+
+        let assertion = decode_canonical::<HandleAssertion>(&canonical)
+            .unwrap()
+            .value()
+            .clone();
+        assert_eq!(assertion.encode_canonical().unwrap(), canonical);
+        assert_eq!(
+            assertion.digest().unwrap().as_bytes(),
+            &[
+                0x1e, 0x3f, 0x8c, 0x54, 0x9c, 0x81, 0x6a, 0xbd, 0x45, 0x0a, 0xe7, 0x9a, 0xbb, 0xac,
+                0x86, 0xcc, 0xa7, 0xda, 0x04, 0xd9, 0x3e, 0x47, 0x89, 0x1e, 0xc8, 0x6a, 0x5c, 0x1e,
+                0x1e, 0xc1, 0x00, 0x67,
+            ]
+        );
+    }
+
+    #[test]
+    fn an_unvouched_binding_carries_a_zero_assertion_digest() {
+        let binding = AssertionBindingTBS::unvouched(
+            LogId::new([9u8; 32]),
+            Handle::parse(b"alice").unwrap(),
+            PublicKey::new([2u8; 32]),
+            Digest::new([4u8; 32]),
+        )
+        .unwrap();
+        assert_eq!(binding.assertion_digest, Digest::zero());
+        let bytes = binding.encode_canonical().unwrap();
+        assert_eq!(
+            decode_canonical::<AssertionBindingTBS>(&bytes)
+                .unwrap()
+                .value(),
+            &binding
+        );
+    }
+}

--- a/rs/crates/f2z-authority/src/authority.rs
+++ b/rs/crates/f2z-authority/src/authority.rs
@@ -1,0 +1,1151 @@
+//! The trust root: who may vouch, and the one door an assertion comes through.
+//!
+//! # The whole of it, in one function
+//!
+//! [`AuthorityConfig::check_assertion_layer`] is the only public verification
+//! path for this experimental assertion proposal. There is no
+//! `verify_assertion`, no `check_authority_signature`, and no `is_expired`:
+//! those narrower helpers would make it easy to mistake one successful rule
+//! for the complete assertion-layer check. The single assertion-layer door is
+//! the design. Even its result is explicitly partial with respect to the
+//! directory's separate entry-authorization rules.
+//!
+//! In particular, **there is no path that checks an assertion without also
+//! checking that the identity key it names signed for itself.** An assertion is
+//! a bearer document (see [`crate::assertion`]); the binding signature is what
+//! makes a stolen copy worthless. `check_assertion_layer` takes both or refuses.
+//!
+//! # Rotation is set membership
+//!
+//! [`AuthoritySet`] holds `(authority_id, public key)` entries and nothing
+//! else. Adding a new issuing key is adding an entry; retiring one is removing
+//! it. There is no rotation *protocol* here, no signed succession message and
+//! no chain — deliberately. A rotation ceremony would be a second trust root
+//! guarding the first, and this crate exists precisely because the trust root
+//! should be the shortest thing in the system to read.
+//!
+//! # "No authority" is a configuration, and it is reported
+//!
+//! This proposal models a self-hosted log with no user directory through
+//! [`AuthoritySet::none`]. `KT.md` does not ratify that behavior; #594 remains
+//! open. It is *spelled*, not reached by leaving the set empty, which is
+//! [`AuthorityError::EmptyAuthoritySet`] instead.
+//!
+//! It is not silent. Every successful assertion-layer check on such a log returns
+//! [`Vouch::Unvouched`], and [`AuthoritySet::status`] answers the same question
+//! before a single submission arrives, so a client connecting to the log can
+//! learn that `@alice` there means "whoever got there first" rather than
+//! "whoever the directory says". A client that renders the two identically has
+//! taken the assertion layer away from its user without telling them.
+//!
+//! What does **not** change on such a log is the identity self-signature. A
+//! submitter still answers for its own key; all that is missing is anyone
+//! saying which person that key belongs to.
+
+use alloc::vec::Vec;
+use core::fmt;
+
+use f2z_codec::canonical::decode_canonical;
+use f2z_codec::types::{Digest, PublicKey, Signature};
+
+use crate::assertion::{AssertionBindingTBS, HandleAssertion};
+use crate::error::{AuthorityError, Result};
+use crate::key::VerifyingKey;
+use crate::labels::LABEL_ASSERTION_TBS;
+use crate::nonce::NonceSeen;
+use crate::types::{AuthorityId, Handle, Intent, LogId, authority_id};
+
+/// The default cap on `expires_ms - issued_ms`, in milliseconds: 15 minutes.
+///
+/// > **Invented here, and a proposed placeholder.** `KT.md` gives no value
+/// > because it gives no assertion. The *structure* of the rule — that the log
+/// > holds the cap, not the issuer — is what matters, and 15 minutes is chosen
+/// > to be long enough for a user to complete a submission after the platform
+/// > issued for them and short enough that a captured assertion is stale before
+/// > it can be carried anywhere. Measure it before shipping.
+pub const DEFAULT_MAX_VALIDITY_MS: u64 = 900_000;
+
+/// The default clock skew allowed on `issued_ms`, in milliseconds: 2 minutes.
+///
+/// The same value `WIRE.md` §5.5 publishes for the relay's timestamp window,
+/// restated rather than shared because it is a different clock relationship
+/// between different parties.
+pub const DEFAULT_CLOCK_SKEW_MS: u64 = 120_000;
+
+/// One issuing key, and the id derived from it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AuthorityKey {
+    id: AuthorityId,
+    key: PublicKey,
+}
+
+impl AuthorityKey {
+    /// Adopt an issuing public key, deriving its id.
+    ///
+    /// The key is not decompressed here. A configured key that is not a curve
+    /// point fails at the point of use, as [`AuthorityError::BadAuthoritySignature`],
+    /// because that is the only outcome it can ever produce and reporting it
+    /// twice would give a caller two things to handle for one fact.
+    #[must_use]
+    pub fn new(key: PublicKey) -> Self {
+        Self {
+            id: authority_id(&key),
+            key,
+        }
+    }
+
+    /// Adopt a key that already carries an id, checking that the two agree.
+    ///
+    /// For a config file that writes both, so that a typo in either is caught
+    /// where it was typed.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::AuthorityIdNotDerived`] if `id` is not
+    /// `H("free2z/kt/v1/authority-id", key)`.
+    pub fn from_parts(id: AuthorityId, key: PublicKey) -> Result<Self> {
+        let derived = authority_id(&key);
+        if derived != id {
+            return Err(AuthorityError::AuthorityIdNotDerived);
+        }
+        Ok(Self { id, key })
+    }
+
+    /// The key id.
+    #[must_use]
+    pub const fn id(&self) -> AuthorityId {
+        self.id
+    }
+
+    /// The public key.
+    #[must_use]
+    pub const fn key(&self) -> PublicKey {
+        self.key
+    }
+}
+
+/// Whether a log has authorities at all, and how many — the answer a client
+/// wants *before* it resolves a handle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VouchingStatus {
+    /// Handles on this log are vouched, by one of this many authorities.
+    Vouched {
+        /// How many issuing keys are configured.
+        authorities: usize,
+    },
+    /// This log has no user directory. Handles on it are **unvouched**: a
+    /// handle means whoever submitted it first, and no party has said which
+    /// person that is.
+    Unvouched,
+}
+
+impl fmt::Display for VouchingStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Vouched { authorities } => {
+                write!(f, "handles are vouched by {authorities} authority key(s)")
+            }
+            Self::Unvouched => {
+                f.write_str("handles on this log are UNVOUCHED: no authority attests who owns them")
+            }
+        }
+    }
+}
+
+/// Private so that the only ways to build an [`AuthoritySet`] are the two
+/// constructors, and "empty" and "no authority" cannot be confused.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SetInner {
+    Keys(Vec<AuthorityKey>),
+    NoAuthority,
+}
+
+/// The configured issuing keys — or an explicit declaration that there are
+/// none.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthoritySet(SetInner);
+
+impl AuthoritySet {
+    /// A set of one or more issuing keys.
+    ///
+    /// # Errors
+    ///
+    /// - [`AuthorityError::EmptyAuthoritySet`] if `keys` is empty. An empty set
+    ///   is not "no authority": one is a configuration mistake that would
+    ///   refuse every submission, the other is a deployment choice that changes
+    ///   what a handle *means*, and a constructor that quietly turned the first
+    ///   into the second would downgrade a log by typo.
+    /// - [`AuthorityError::DuplicateAuthority`] if two entries share an id.
+    ///   Since the id is derived, that is the same key twice — harmless in
+    ///   itself, and a sign that whoever wrote the config believes they
+    ///   configured two independent issuers.
+    pub fn new(keys: Vec<AuthorityKey>) -> Result<Self> {
+        if keys.is_empty() {
+            return Err(AuthorityError::EmptyAuthoritySet);
+        }
+        for (index, key) in keys.iter().enumerate() {
+            if keys
+                .iter()
+                .skip(index.saturating_add(1))
+                .any(|other| other.id() == key.id())
+            {
+                return Err(AuthorityError::DuplicateAuthority);
+            }
+        }
+        Ok(Self(SetInner::Keys(keys)))
+    }
+
+    /// A set of one key. The common case.
+    ///
+    /// # Errors
+    ///
+    /// Never, in practice; it shares [`AuthoritySet::new`]'s signature so that
+    /// switching between the two is not a refactor.
+    pub fn single(key: PublicKey) -> Result<Self> {
+        Self::new(alloc::vec![AuthorityKey::new(key)])
+    }
+
+    /// **Experimental proposal:** this log has no user directory, so handles
+    /// on it are unvouched. `KT.md` has not ratified this mode (#594).
+    ///
+    /// See the module note: this must be chosen, and it is reported on every
+    /// assertion-layer check.
+    #[must_use]
+    pub const fn none() -> Self {
+        Self(SetInner::NoAuthority)
+    }
+
+    /// What a client should be told about this log before it resolves anything.
+    #[must_use]
+    pub fn status(&self) -> VouchingStatus {
+        match &self.0 {
+            SetInner::Keys(keys) => VouchingStatus::Vouched {
+                authorities: keys.len(),
+            },
+            SetInner::NoAuthority => VouchingStatus::Unvouched,
+        }
+    }
+
+    /// Whether any authority vouches for handles here.
+    #[must_use]
+    pub fn vouches(&self) -> bool {
+        matches!(self.0, SetInner::Keys(_))
+    }
+
+    /// The configured keys. Empty when there is no authority.
+    #[must_use]
+    pub fn keys(&self) -> &[AuthorityKey] {
+        match &self.0 {
+            SetInner::Keys(keys) => keys,
+            SetInner::NoAuthority => &[],
+        }
+    }
+
+    /// The key with this id, if it is configured.
+    #[must_use]
+    pub fn find(&self, id: AuthorityId) -> Option<&AuthorityKey> {
+        self.keys().iter().find(|key| key.id() == id)
+    }
+}
+
+/// The vouching state carried by this assertion-layer check.
+///
+/// For a routine entry this value is copied from [`Submission::previous_vouch`]
+/// and is **not verified by this crate**. The directory integration must derive
+/// it from the verified predecessor history; current authority configuration
+/// is not evidence that this particular handle was ever vouched.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[must_use]
+pub enum Vouch {
+    /// This authority signed for the handle.
+    By(AuthorityId),
+    /// The log has no authority. Nobody has said who owns this handle; the
+    /// submitter proved only that it holds the identity key.
+    Unvouched,
+}
+
+impl Vouch {
+    /// Whether an authority actually vouched.
+    #[must_use]
+    pub const fn is_vouched(self) -> bool {
+        matches!(self, Self::By(_))
+    }
+
+    /// The vouching authority, if there was one.
+    #[must_use]
+    pub const fn authority(self) -> Option<AuthorityId> {
+        match self {
+            Self::By(id) => Some(id),
+            Self::Unvouched => None,
+        }
+    }
+}
+
+impl fmt::Display for Vouch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::By(_) => f.write_str("vouched"),
+            Self::Unvouched => f.write_str("UNVOUCHED"),
+        }
+    }
+}
+
+/// Why this directory entry exists.
+///
+/// The last three variants are `KT.md`'s `EntryKind`. [`InitialBind`] names
+/// this crate's **unratified candidate** for the first-entry case that `KT.md`
+/// and #594 deliberately leave open. It must not be read as merged protocol.
+///
+/// [`InitialBind`]: Self::InitialBind
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EntryKind {
+    /// The handle's first entry.
+    InitialBind,
+    /// A routine update that retains the identity key.
+    SameKey,
+    /// A user-authorized identity-key rotation.
+    KeyChange,
+    /// The exceptional platform-authorized reset path.
+    PlatformReset,
+}
+
+/// The result of checking only this crate's experimental assertion layer.
+///
+/// This is deliberately **not** an authorization-to-publish token. In
+/// particular, for `same_key` and `key_change` this crate does not parse or
+/// verify `KT.md` §4.4's `EntryAuthorization`, the prior DirectoryAuthKey
+/// signature, or a `RotationProof`. The directory integration must verify
+/// those independently before accepting the entry. The type name keeps that
+/// partial boundary visible at every call site.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[must_use]
+pub struct AssertionLayerCheck {
+    handle: Handle,
+    identity_pk: PublicKey,
+    kind: EntryKind,
+    vouch: Vouch,
+    intent: Option<Intent>,
+    account_epoch: u32,
+}
+
+impl AssertionLayerCheck {
+    /// The handle.
+    #[must_use]
+    pub const fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    /// The identity key it is bound to.
+    #[must_use]
+    pub const fn identity_pk(&self) -> &PublicKey {
+        &self.identity_pk
+    }
+
+    /// The directory entry kind whose assertion-layer subset was checked.
+    #[must_use]
+    pub const fn kind(&self) -> EntryKind {
+        self.kind
+    }
+
+    /// Who vouched — **check this.** [`Vouch::Unvouched`] is a normal, valid
+    /// outcome on a log configured without an authority, and it means something
+    /// materially weaker than [`Vouch::By`].
+    ///
+    /// On a routine entry this is the exact predecessor value supplied by the
+    /// caller, not a fresh verdict from this crate.
+    ///
+    /// No `#[must_use]` here: [`Vouch`] already carries one, and clippy's
+    /// `double_must_use` is right that repeating it says nothing new.
+    pub const fn vouch(&self) -> Vouch {
+        self.vouch
+    }
+
+    /// The assertion's intent, when this entry required a platform assertion.
+    #[must_use]
+    pub const fn intent(&self) -> Option<Intent> {
+        self.intent
+    }
+
+    /// The `account_epoch` to retain for this handle. A platform assertion
+    /// advances it; a routine entry carries the required previous value
+    /// forward. The experimental unvouched initial path starts at zero. Feed
+    /// it back as [`Submission::previous_account_epoch`] next time.
+    #[must_use]
+    pub const fn account_epoch(&self) -> u32 {
+        self.account_epoch
+    }
+}
+
+/// Everything the log holds about one submission, presented together.
+///
+/// It is one structure rather than a list of arguments so that the
+/// `identity_signature` field is *visible* beside the assertion — the pairing
+/// is the security property, and an argument list is where a required argument
+/// goes to look optional.
+#[derive(Clone, Copy)]
+pub struct Submission<'a> {
+    /// The canonical `tls_codec` bytes of the [`HandleAssertion`], as they
+    /// arrived.
+    ///
+    /// Present only for [`EntryKind::InitialBind`] or
+    /// [`EntryKind::PlatformReset`] on a vouched log. Routine
+    /// [`EntryKind::SameKey`] and [`EntryKind::KeyChange`] entries are
+    /// user-authorized and reject a platform assertion as a category error.
+    pub assertion: Option<&'a [u8]>,
+    /// The authorization case this submission's directory entry declares.
+    pub kind: EntryKind,
+    /// The `handle` of the accompanying `DirectoryEntry`.
+    pub handle: &'a Handle,
+    /// The `identity_pk` of the accompanying `DirectoryEntry`.
+    pub identity_pk: &'a PublicKey,
+    /// The accompanying entry's `entry_version` (`KT.md` §4.2) — the sequence
+    /// position the intent is checked against. 1 for a handle's first entry.
+    pub entry_version: u32,
+    /// The submission's `AkdValue`:
+    /// `H("free2z/kt/v1/value", tls_codec(DirectoryEntry))` (`KT.md` §3.3).
+    pub entry_digest: &'a Digest,
+    /// Ed25519 over `tls_codec(AssertionBindingTBS)` by `identity_pk`.
+    ///
+    /// **Never optional, on any path.** See [`crate::assertion`].
+    pub identity_signature: &'a Signature,
+    /// The `identity_pk` of the handle's **published previous entry**, or
+    /// `None` if this is its first.
+    ///
+    /// The log must *hold* the predecessor to fill this in; it cannot assert
+    /// what the previous key was, exactly as `KT.md` §4.4 rule 4 requires it to
+    /// hold the previous entry to check `prev_entry_hash`. It is what rule 14
+    /// uses to refuse an assertion spent on an entry that changes nothing —
+    /// see [`AuthorityError::IdentityUnchanged`].
+    pub previous_identity_pk: Option<&'a PublicKey>,
+    /// The vouching state recorded with the verified predecessor, or `None`
+    /// only for the first entry.
+    ///
+    /// This crate checks presence and preserves the exact value on routine
+    /// entries; it cannot verify predecessor history itself.
+    pub previous_vouch: Option<Vouch>,
+    /// The predecessor's retained `account_epoch`, or `None` only if this is
+    /// the first entry. Every non-initial entry must carry it, including an
+    /// unvouched history whose experimental baseline is zero.
+    pub previous_account_epoch: Option<u32>,
+}
+
+/// Hand-written, and this is the exact case `f2z-codec` documents.
+///
+/// Every typed field here is already a redacting newtype, so a derived `Debug`
+/// looks safe — except `assertion`, which is a bare `&[u8]`. `Debug` for a byte
+/// slice renders **a list of decimal integers**: a complete dump of the
+/// assertion, containing no hex at all, so a hex-only redaction test passes
+/// while every byte leaks. A decimal dump is a dump.
+///
+/// The bytes are public signed material rather than a secret, which is why this
+/// prints a length rather than refusing to exist. What makes it worth redacting
+/// anyway is volume and linkability: one log line per submission, each carrying
+/// a full assertion naming a handle and an identity key, is a directory
+/// reconstructed out of a trace log.
+impl fmt::Debug for Submission<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Submission")
+            .field(
+                "assertion",
+                &format_args!(
+                    "{}",
+                    match self.assertion {
+                        Some(bytes) => alloc::format!("Some(<redacted; {} bytes>)", bytes.len()),
+                        None => alloc::string::String::from("None"),
+                    }
+                ),
+            )
+            .field("handle", &self.handle)
+            .field("identity_pk", &self.identity_pk)
+            .field("kind", &self.kind)
+            .field("entry_version", &self.entry_version)
+            .field("entry_digest", &self.entry_digest)
+            .field("identity_signature", &self.identity_signature)
+            .field("previous_identity_pk", &self.previous_identity_pk)
+            .field("previous_vouch", &self.previous_vouch)
+            .field("previous_account_epoch", &self.previous_account_epoch)
+            .finish()
+    }
+}
+
+/// A log's assertion policy: which log it is, who may vouch, and how long an
+/// assertion may live.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthorityConfig {
+    log_id: LogId,
+    authorities: AuthoritySet,
+    max_validity_ms: u64,
+    clock_skew_ms: u64,
+}
+
+impl AuthorityConfig {
+    /// Build a policy.
+    ///
+    /// `max_validity_ms` is **the log's own** cap on `expires_ms - issued_ms`.
+    /// It is not read from the assertion and it is not negotiated: an issuer
+    /// that could choose its own validity would, once compromised, mint one
+    /// assertion good for a decade, and every later rotation of the authority
+    /// set would leave that assertion working. Capping it here is what bounds
+    /// the blast radius of a compromised issuer to the cap.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::InvalidPolicy`] if `max_validity_ms` is zero — which
+    /// would refuse every assertion — or if the cap and the skew together
+    /// cannot be represented.
+    pub fn new(
+        log_id: LogId,
+        authorities: AuthoritySet,
+        max_validity_ms: u64,
+        clock_skew_ms: u64,
+    ) -> Result<Self> {
+        if max_validity_ms == 0 || max_validity_ms.checked_add(clock_skew_ms).is_none() {
+            return Err(AuthorityError::InvalidPolicy);
+        }
+        Ok(Self {
+            log_id,
+            authorities,
+            max_validity_ms,
+            clock_skew_ms,
+        })
+    }
+
+    /// A policy with [`DEFAULT_MAX_VALIDITY_MS`] and [`DEFAULT_CLOCK_SKEW_MS`].
+    ///
+    /// # Errors
+    ///
+    /// As [`AuthorityConfig::new`]; never, with these constants.
+    pub fn with_defaults(log_id: LogId, authorities: AuthoritySet) -> Result<Self> {
+        Self::new(
+            log_id,
+            authorities,
+            DEFAULT_MAX_VALIDITY_MS,
+            DEFAULT_CLOCK_SKEW_MS,
+        )
+    }
+
+    /// The log this policy is for.
+    #[must_use]
+    pub const fn log_id(&self) -> LogId {
+        self.log_id
+    }
+
+    /// The configured authorities.
+    #[must_use]
+    pub const fn authorities(&self) -> &AuthoritySet {
+        &self.authorities
+    }
+
+    /// What a client should be told about this log. See [`VouchingStatus`].
+    #[must_use]
+    pub fn status(&self) -> VouchingStatus {
+        self.authorities.status()
+    }
+
+    /// The log's cap on an assertion's validity window.
+    #[must_use]
+    pub const fn max_validity_ms(&self) -> u64 {
+        self.max_validity_ms
+    }
+
+    /// The allowance on `issued_ms` being ahead of this clock.
+    ///
+    /// It is deliberately **not** applied to `expires_ms`: an assertion is
+    /// refused the moment this clock reaches its expiry. The asymmetry is
+    /// fail-closed — a verifier whose clock runs fast refuses a little early
+    /// rather than accepting a little late — and it keeps the widest window any
+    /// assertion can be accepted in at `max_validity_ms + clock_skew_ms`, which
+    /// is a number an operator can state.
+    #[must_use]
+    pub const fn clock_skew_ms(&self) -> u64 {
+        self.clock_skew_ms
+    }
+
+    /// The transcript the submitter's identity key must sign, built from this
+    /// policy so that the signer and the verifier cannot disagree about it.
+    ///
+    /// Pass the assertion the submission carries, or `None` for an unvouched
+    /// initial bind and for `same_key`/`key_change`; their separate user
+    /// authorization is outside this crate.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::Malformed`] if the assertion cannot be encoded.
+    pub fn binding(
+        &self,
+        handle: &Handle,
+        identity_pk: &PublicKey,
+        assertion: Option<&HandleAssertion>,
+        entry_digest: &Digest,
+    ) -> Result<AssertionBindingTBS> {
+        let assertion_digest = match assertion {
+            Some(assertion) => assertion.digest()?,
+            None => Digest::zero(),
+        };
+        AssertionBindingTBS::for_assertion(
+            self.log_id,
+            handle.clone(),
+            *identity_pk,
+            assertion_digest,
+            *entry_digest,
+        )
+    }
+
+    /// Check this crate's experimental assertion layer.
+    ///
+    /// The returned [`AssertionLayerCheck`] is partial, not permission to
+    /// publish a directory entry. `same_key` and `key_change` still require the
+    /// caller to verify all of `KT.md` §4.4, including the prior
+    /// DirectoryAuthKey signature and (for `key_change`) the outgoing identity
+    /// key's `RotationProof`. This crate has neither structure and cannot judge
+    /// either one.
+    ///
+    /// The rules, in the order they run — cheap and flood-resistant first,
+    /// signatures next, and the one rule that mutates state last, so that a
+    /// submission which fails anything never burns a nonce:
+    ///
+    /// 1. An assertion is present iff this is an initial bind or platform
+    ///    reset on a vouched log. `same_key` and `key_change` must be
+    ///    authorized separately under `KT.md` §4.4 and must not require the
+    ///    platform here.
+    /// 2. The bytes decode **and re-encode identically** (`WIRE.md` §3.3).
+    /// 3. `label` is exactly `free2z/kt/v1/handle-assertion`.
+    /// 4. `log_id` is this log's.
+    /// 5. `handle_id` is the digest of `handle` — the assertion agrees with
+    ///    itself.
+    /// 6. `handle` is the submission's handle, compared as bytes. Charset
+    ///    conformance is a type invariant of [`Handle`]: bytes that are not
+    ///    `[a-z0-9_]{1,30}` never decode into one, so there is no state in
+    ///    which a non-conforming handle reaches this rule.
+    /// 7. `identity_pk` is the submission's identity key. An assertion about
+    ///    one key cannot authorize another.
+    /// 8. `expires_ms > issued_ms`.
+    /// 9. `expires_ms - issued_ms <= max_validity_ms`, **this log's** cap.
+    /// 10. `issued_ms` is not further ahead than `clock_skew_ms`.
+    /// 11. `now_ms < expires_ms`.
+    /// 12. `authority_id` is in the configured set.
+    /// 13. The authority's signature verifies, strictly, over the re-encoded
+    ///     body.
+    /// 14. `intent` matches the entry kind: `bind` for an initial claim and
+    ///     `reset` for `platform_reset`; the discriminator's separate shape
+    ///     check holds both to the sequence and predecessor, including that a
+    ///     reset actually replaces the predecessor's `identity_pk`.
+    /// 15. Every non-initial entry supplies its predecessor's retained
+    ///     `account_epoch`; a platform assertion's epoch is strictly greater.
+    /// 16. **The identity key signed the binding.** Without this a stolen
+    ///     assertion is usable by the thief; with it, it is useless.
+    /// 17. `(authority_id, nonce)` has not been admitted before.
+    ///
+    /// On a path without an assertion, rules 2–15 and 17 have nothing to run
+    /// against and rule 16 is the whole check in this layer — the submitter
+    /// proves it holds the identity key. The caller remains responsible for
+    /// `KT.md` §4.4's directory signature and rotation proof on routine entries.
+    ///
+    /// # Errors
+    ///
+    /// One [`AuthorityError`] per rule; see that type for the `KT.md` §9.5 code
+    /// each travels as.
+    pub fn check_assertion_layer<S: NonceSeen + ?Sized>(
+        &self,
+        submission: &Submission<'_>,
+        now_ms: u64,
+        ledger: &mut S,
+    ) -> Result<AssertionLayerCheck> {
+        // 1. Presence, both directions, selected by entry kind rather than by
+        //    the mere existence of an authority configuration.
+        let Some(bytes) = submission.assertion else {
+            return match submission.kind {
+                EntryKind::SameKey | EntryKind::KeyChange => {
+                    self.check_routine_assertion_layer(submission)
+                }
+                EntryKind::InitialBind if !self.authorities.vouches() => {
+                    let _ = self.check_entry_shape(submission)?;
+                    self.check_unvouched_initial(submission)
+                }
+                EntryKind::InitialBind | EntryKind::PlatformReset => {
+                    Err(AuthorityError::MissingAssertion)
+                }
+            };
+        };
+        if matches!(submission.kind, EntryKind::SameKey | EntryKind::KeyChange)
+            || !self.authorities.vouches()
+        {
+            return Err(AuthorityError::UnexpectedAssertion);
+        }
+
+        let previous_account_epoch = self.check_entry_shape(submission)?;
+
+        let expected_intent = match submission.kind {
+            EntryKind::InitialBind => Intent::Bind,
+            EntryKind::PlatformReset => Intent::Reset,
+            EntryKind::SameKey | EntryKind::KeyChange => {
+                return Err(AuthorityError::EntryKindMismatch);
+            }
+        };
+
+        // 2. Re-encode equality. The re-encoded bytes — never the received
+        //    ones — are what the signature is checked over.
+        let decoded = decode_canonical::<HandleAssertion>(bytes)?;
+        let assertion = decoded.value();
+        let body = &assertion.assertion;
+
+        // 3-7. The assertion agrees with itself and with the submission.
+        if body.label.as_slice() != LABEL_ASSERTION_TBS {
+            return Err(AuthorityError::WrongLabel);
+        }
+        if body.log_id != self.log_id {
+            return Err(AuthorityError::WrongLog);
+        }
+        if body.handle_id != body.handle.handle_id() {
+            return Err(AuthorityError::HandleIdMismatch);
+        }
+        if body.handle.as_bytes() != submission.handle.as_bytes() {
+            return Err(AuthorityError::HandleMismatch);
+        }
+        if body.identity_pk != *submission.identity_pk {
+            return Err(AuthorityError::IdentityMismatch);
+        }
+
+        // 8-11. Time.
+        let Some(validity_ms) = body.expires_ms.checked_sub(body.issued_ms) else {
+            return Err(AuthorityError::EmptyValidity);
+        };
+        if validity_ms == 0 {
+            return Err(AuthorityError::EmptyValidity);
+        }
+        if validity_ms > self.max_validity_ms {
+            return Err(AuthorityError::ValidityTooLong);
+        }
+        if body.issued_ms > now_ms.saturating_add(self.clock_skew_ms) {
+            return Err(AuthorityError::NotYetIssued);
+        }
+        if now_ms >= body.expires_ms {
+            return Err(AuthorityError::Expired);
+        }
+
+        // 12-13. The authority, and its signature over this exact body.
+        let key = self
+            .authorities
+            .find(body.authority_id)
+            .ok_or(AuthorityError::UnknownAuthority)?;
+        VerifyingKey::from_public_key(&key.key(), AuthorityError::BadAuthoritySignature)?.verify(
+            &body.signing_bytes()?,
+            &assertion.signature,
+            AuthorityError::BadAuthoritySignature,
+        )?;
+
+        // 14. Intent against the declared authorization case.
+        if body.intent != expected_intent {
+            return Err(AuthorityError::IntentMismatch);
+        }
+
+        // 15. Account-epoch monotonicity. Strict: a reset is a distinct
+        //     account-ownership event, so an assertion for an epoch already
+        //     seen is one that has already been spent.
+        if let Some(previous) = previous_account_epoch
+            && body.account_epoch <= previous
+        {
+            return Err(AuthorityError::AccountEpochRegression);
+        }
+
+        // 16. The rule that makes the whole thing sound.
+        self.verify_binding(submission, Some(assertion))?;
+
+        // 17. Last, and the only step that writes.
+        ledger.observe(now_ms, body.authority_id, body.nonce, body.expires_ms)?;
+
+        Ok(AssertionLayerCheck {
+            handle: body.handle.clone(),
+            identity_pk: body.identity_pk,
+            kind: submission.kind,
+            vouch: Vouch::By(body.authority_id),
+            intent: Some(body.intent),
+            account_epoch: body.account_epoch,
+        })
+    }
+
+    /// The assertion-layer subset for two routine §4.4 paths. This is not the
+    /// routine authorization verdict; the caller still verifies §4.4 itself.
+    fn check_routine_assertion_layer(
+        &self,
+        submission: &Submission<'_>,
+    ) -> Result<AssertionLayerCheck> {
+        let Some(previous_account_epoch) = self.check_entry_shape(submission)? else {
+            // `check_entry_shape` returns `None` only for InitialBind, which
+            // cannot reach this routine-only helper.
+            return Err(AuthorityError::EntryKindMismatch);
+        };
+        let previous_vouch = submission
+            .previous_vouch
+            .ok_or(AuthorityError::MissingPriorVouch)?;
+        self.verify_binding(submission, None)?;
+        Ok(AssertionLayerCheck {
+            handle: submission.handle.clone(),
+            identity_pk: *submission.identity_pk,
+            kind: submission.kind,
+            vouch: previous_vouch,
+            intent: None,
+            account_epoch: previous_account_epoch,
+        })
+    }
+
+    /// Hold the `EntryKind` discriminator to the sequence and predecessor.
+    fn check_entry_shape(&self, submission: &Submission<'_>) -> Result<Option<u32>> {
+        match (submission.kind, submission.previous_vouch) {
+            (EntryKind::InitialBind, Some(_)) => {
+                return Err(AuthorityError::UnexpectedPriorVouch);
+            }
+            (EntryKind::PlatformReset, None) => {
+                return Err(AuthorityError::MissingPriorVouch);
+            }
+            _ => {}
+        }
+        if matches!(submission.kind, EntryKind::InitialBind)
+            && submission.previous_account_epoch.is_some()
+        {
+            return Err(AuthorityError::UnexpectedPriorAccountEpoch);
+        }
+        let previous_account_epoch = match submission.kind {
+            EntryKind::InitialBind => None,
+            EntryKind::SameKey | EntryKind::KeyChange | EntryKind::PlatformReset => Some(
+                submission
+                    .previous_account_epoch
+                    .ok_or(AuthorityError::MissingPriorAccountEpoch)?,
+            ),
+        };
+        match (
+            submission.kind,
+            submission.entry_version,
+            submission.previous_identity_pk,
+        ) {
+            (EntryKind::InitialBind, 1, None) => Ok(previous_account_epoch),
+            (EntryKind::SameKey, version, Some(previous)) if version > 1 => {
+                if previous == submission.identity_pk {
+                    Ok(previous_account_epoch)
+                } else {
+                    Err(AuthorityError::EntryKindMismatch)
+                }
+            }
+            (EntryKind::KeyChange | EntryKind::PlatformReset, version, Some(previous))
+                if version > 1 =>
+            {
+                if previous != submission.identity_pk {
+                    Ok(previous_account_epoch)
+                } else {
+                    Err(AuthorityError::IdentityUnchanged)
+                }
+            }
+            _ => Err(AuthorityError::EntryKindMismatch),
+        }
+    }
+
+    /// The no-authority path. Private, and reachable only when
+    /// [`AuthoritySet::none`] was configured *and* no assertion was presented,
+    /// so it is not a bypass of the vouched path — it is the other half of rule
+    /// 1.
+    fn check_unvouched_initial(&self, submission: &Submission<'_>) -> Result<AssertionLayerCheck> {
+        self.verify_binding(submission, None)?;
+        Ok(AssertionLayerCheck {
+            handle: submission.handle.clone(),
+            identity_pk: *submission.identity_pk,
+            kind: submission.kind,
+            vouch: Vouch::Unvouched,
+            intent: None,
+            account_epoch: 0,
+        })
+    }
+
+    /// Rule 16, shared by both paths so that neither can be written without it.
+    fn verify_binding(
+        &self,
+        submission: &Submission<'_>,
+        assertion: Option<&HandleAssertion>,
+    ) -> Result<()> {
+        let binding = self.binding(
+            submission.handle,
+            submission.identity_pk,
+            assertion,
+            submission.entry_digest,
+        )?;
+        let identity_key = VerifyingKey::from_public_key(
+            submission.identity_pk,
+            AuthorityError::BadIdentitySignature,
+        )?;
+        identity_key.verify(
+            &binding.signing_bytes()?,
+            submission.identity_signature,
+            AuthorityError::BadIdentitySignature,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assertion::HandleAssertionTBS;
+    use crate::key::SigningKey;
+    use crate::nonce::NonceLedger;
+    use crate::types::{AssertionNonce, AuthorityId, HandleId};
+    use f2z_codec::canonical::Canonical as _;
+    use f2z_codec::types::ShortBytes;
+
+    #[test]
+    fn an_empty_set_is_not_no_authority() {
+        assert_eq!(
+            AuthoritySet::new(Vec::new()).unwrap_err(),
+            AuthorityError::EmptyAuthoritySet
+        );
+        assert_eq!(AuthoritySet::none().status(), VouchingStatus::Unvouched);
+        assert!(!AuthoritySet::none().vouches());
+    }
+
+    #[test]
+    fn the_same_key_twice_is_a_duplicate() {
+        let key = SigningKey::from_seed(&[1u8; 32]).public_key();
+        assert_eq!(
+            AuthoritySet::new(alloc::vec![AuthorityKey::new(key), AuthorityKey::new(key)])
+                .unwrap_err(),
+            AuthorityError::DuplicateAuthority
+        );
+    }
+
+    #[test]
+    fn rotation_is_set_membership_and_nothing_else() {
+        let old = SigningKey::from_seed(&[1u8; 32]).public_key();
+        let new = SigningKey::from_seed(&[2u8; 32]).public_key();
+        let both =
+            AuthoritySet::new(alloc::vec![AuthorityKey::new(old), AuthorityKey::new(new)]).unwrap();
+        assert_eq!(both.status(), VouchingStatus::Vouched { authorities: 2 });
+        assert!(both.find(authority_id(&old)).is_some());
+        assert!(both.find(authority_id(&new)).is_some());
+
+        let retired = AuthoritySet::single(new).unwrap();
+        assert!(retired.find(authority_id(&old)).is_none());
+    }
+
+    #[test]
+    fn a_mistyped_key_id_is_caught_where_it_was_typed() {
+        let key = SigningKey::from_seed(&[1u8; 32]).public_key();
+        assert!(AuthorityKey::from_parts(authority_id(&key), key).is_ok());
+        assert_eq!(
+            AuthorityKey::from_parts(AuthorityId::new([0u8; 32]), key).unwrap_err(),
+            AuthorityError::AuthorityIdNotDerived
+        );
+    }
+
+    #[test]
+    fn a_zero_validity_cap_is_refused() {
+        let set = AuthoritySet::none();
+        assert_eq!(
+            AuthorityConfig::new(LogId::new([1u8; 32]), set.clone(), 0, 0).unwrap_err(),
+            AuthorityError::InvalidPolicy
+        );
+        assert_eq!(
+            AuthorityConfig::new(LogId::new([1u8; 32]), set, u64::MAX, 1).unwrap_err(),
+            AuthorityError::InvalidPolicy
+        );
+    }
+
+    #[test]
+    fn binding_maps_every_nonuniform_input_to_the_literal_canonical_transcript() {
+        const CONFIG_LOG_ID: [u8; 32] = [
+            0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd,
+            0xde, 0xdf, 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb,
+            0xec, 0xed, 0xee, 0xef,
+        ];
+        const MAPPED_IDENTITY_PK: [u8; 32] = [
+            0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d,
+            0x3e, 0x3f, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b,
+            0x4c, 0x4d, 0x4e, 0x4f,
+        ];
+        const ENTRY_DIGEST_BYTES: [u8; 32] = [
+            0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d,
+            0x5e, 0x5f, 0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b,
+            0x6c, 0x6d, 0x6e, 0x6f,
+        ];
+        // This independently hashed 265-byte vector is built field-by-field,
+        // so the mapper test does not depend on signing or verification as its
+        // oracle.
+        let assertion = HandleAssertion {
+            assertion: HandleAssertionTBS {
+                label: ShortBytes::new(LABEL_ASSERTION_TBS).unwrap(),
+                authority_id: AuthorityId::new([
+                    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+                    0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+                    0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+                ]),
+                log_id: LogId::new([
+                    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c,
+                    0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
+                    0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+                ]),
+                handle: Handle::parse(b"a1_b2").unwrap(),
+                handle_id: HandleId::new([
+                    0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c,
+                    0x4d, 0x4e, 0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59,
+                    0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f,
+                ]),
+                identity_pk: PublicKey::new([
+                    0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c,
+                    0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79,
+                    0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+                ]),
+                intent: Intent::Reset,
+                account_epoch: 0x0123_4567,
+                issued_ms: 0x0102_0304_0506_0708,
+                expires_ms: 0x1112_1314_1516_1718,
+                nonce: AssertionNonce::new([
+                    0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c,
+                    0x8d, 0x8e, 0x8f,
+                ]),
+            },
+            signature: Signature::new([
+                0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d,
+                0x9e, 0x9f, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab,
+                0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9,
+                0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7,
+                0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf,
+            ]),
+        };
+
+        let config =
+            AuthorityConfig::with_defaults(LogId::new(CONFIG_LOG_ID), AuthoritySet::none())
+                .unwrap();
+        let handle = Handle::parse(b"map_7").unwrap();
+        let identity_pk = PublicKey::new(MAPPED_IDENTITY_PK);
+        let entry_digest = Digest::new(ENTRY_DIGEST_BYTES);
+        let binding = config
+            .binding(&handle, &identity_pk, Some(&assertion), &entry_digest)
+            .unwrap();
+
+        let mut expected = b"\x1efree2z/kt/v1/assertion-binding".to_vec();
+        expected.extend_from_slice(&CONFIG_LOG_ID);
+        expected.extend_from_slice(b"\x05map_7");
+        expected.extend_from_slice(&MAPPED_IDENTITY_PK);
+        expected.extend_from_slice(&[
+            0x1e, 0x3f, 0x8c, 0x54, 0x9c, 0x81, 0x6a, 0xbd, 0x45, 0x0a, 0xe7, 0x9a, 0xbb, 0xac,
+            0x86, 0xcc, 0xa7, 0xda, 0x04, 0xd9, 0x3e, 0x47, 0x89, 0x1e, 0xc8, 0x6a, 0x5c, 0x1e,
+            0x1e, 0xc1, 0x00, 0x67,
+        ]);
+        expected.extend_from_slice(&ENTRY_DIGEST_BYTES);
+        assert_eq!(binding.encode_canonical().unwrap(), expected);
+    }
+
+    #[test]
+    fn a_log_with_no_authority_refuses_an_assertion_rather_than_ignoring_it() {
+        let config =
+            AuthorityConfig::with_defaults(LogId::new([1u8; 32]), AuthoritySet::none()).unwrap();
+        let handle = Handle::parse(b"alice").unwrap();
+        let identity = SigningKey::from_seed(&[3u8; 32]);
+        let mut ledger = NonceLedger::new(8, DEFAULT_CLOCK_SKEW_MS);
+        let submission = Submission {
+            assertion: Some(&[0u8; 4]),
+            kind: EntryKind::InitialBind,
+            handle: &handle,
+            identity_pk: &identity.public_key(),
+            entry_version: 1,
+            entry_digest: &Digest::new([7u8; 32]),
+            identity_signature: &Signature::new([0u8; 64]),
+            previous_identity_pk: None,
+            previous_vouch: None,
+            previous_account_epoch: None,
+        };
+        assert_eq!(
+            config
+                .check_assertion_layer(&submission, 0, &mut ledger)
+                .unwrap_err(),
+            AuthorityError::UnexpectedAssertion
+        );
+    }
+
+    #[test]
+    fn a_log_with_an_authority_refuses_a_submission_with_no_assertion() {
+        let authority = SigningKey::from_seed(&[1u8; 32]);
+        let config = AuthorityConfig::with_defaults(
+            LogId::new([1u8; 32]),
+            AuthoritySet::single(authority.public_key()).unwrap(),
+        )
+        .unwrap();
+        let handle = Handle::parse(b"alice").unwrap();
+        let identity = SigningKey::from_seed(&[3u8; 32]);
+        let mut ledger = NonceLedger::new(8, DEFAULT_CLOCK_SKEW_MS);
+        let submission = Submission {
+            assertion: None,
+            kind: EntryKind::InitialBind,
+            handle: &handle,
+            identity_pk: &identity.public_key(),
+            entry_version: 1,
+            entry_digest: &Digest::new([7u8; 32]),
+            identity_signature: &Signature::new([0u8; 64]),
+            previous_identity_pk: None,
+            previous_vouch: None,
+            previous_account_epoch: None,
+        };
+        assert_eq!(
+            config
+                .check_assertion_layer(&submission, 0, &mut ledger)
+                .unwrap_err(),
+            AuthorityError::MissingAssertion
+        );
+    }
+
+    #[test]
+    fn an_unvouched_log_still_requires_the_identity_to_answer_for_itself() {
+        let config =
+            AuthorityConfig::with_defaults(LogId::new([1u8; 32]), AuthoritySet::none()).unwrap();
+        let handle = Handle::parse(b"alice").unwrap();
+        let identity = SigningKey::from_seed(&[3u8; 32]);
+        let entry_digest = Digest::new([7u8; 32]);
+        let mut ledger = NonceLedger::new(8, DEFAULT_CLOCK_SKEW_MS);
+
+        let binding = config
+            .binding(&handle, &identity.public_key(), None, &entry_digest)
+            .unwrap();
+        let signature = binding.sign(&identity).unwrap();
+
+        let checked = config
+            .check_assertion_layer(
+                &Submission {
+                    assertion: None,
+                    kind: EntryKind::InitialBind,
+                    handle: &handle,
+                    identity_pk: &identity.public_key(),
+                    entry_version: 1,
+                    entry_digest: &entry_digest,
+                    identity_signature: &signature,
+                    previous_identity_pk: None,
+                    previous_vouch: None,
+                    previous_account_epoch: None,
+                },
+                0,
+                &mut ledger,
+            )
+            .unwrap();
+        assert_eq!(checked.vouch(), Vouch::Unvouched);
+        assert!(!checked.vouch().is_vouched());
+        assert_eq!(checked.intent(), None);
+
+        // …and a wrong signature is still fatal there.
+        assert_eq!(
+            config
+                .check_assertion_layer(
+                    &Submission {
+                        assertion: None,
+                        kind: EntryKind::InitialBind,
+                        handle: &handle,
+                        identity_pk: &identity.public_key(),
+                        entry_version: 1,
+                        entry_digest: &entry_digest,
+                        identity_signature: &Signature::new([0u8; 64]),
+                        previous_identity_pk: None,
+                        previous_vouch: None,
+                        previous_account_epoch: None,
+                    },
+                    0,
+                    &mut ledger,
+                )
+                .unwrap_err(),
+            AuthorityError::BadIdentitySignature
+        );
+    }
+}

--- a/rs/crates/f2z-authority/src/bin/f2z-assert.rs
+++ b/rs/crates/f2z-authority/src/bin/f2z-assert.rs
@@ -1,0 +1,533 @@
+//! `f2z-assert` — issue a handle assertion by hand.
+//!
+//! A log operator with a web application in front of it will issue assertions
+//! from that application. A self-hoster running the log and nothing else has no
+//! such place to put the code, and would otherwise have to write a program
+//! before they could bind their first handle. This is that program.
+//!
+//! It is deliberately tiny and dependency-free: it reads a key file, builds a
+//! [`HandleAssertionTBS`], signs it, and writes the `tls_codec` bytes out. Every
+//! rule that decides whether the result is *acceptable* lives in the library,
+//! where the log and the client both run it; nothing here is a second opinion
+//! about validity.
+//!
+//! ```text
+//! f2z-assert keygen   [--out FILE]
+//! f2z-assert authority --key FILE
+//! f2z-assert issue --key FILE --log-id HEX --handle NAME --identity-pk HEX
+//!                  [--intent bind|reset] [--account-epoch N]
+//!                  [--issued-ms N] [--expires-ms N] [--validity-ms N]
+//!                  [--nonce HEX] [--out FILE]
+//! ```
+//!
+//! Randomness comes from `/dev/urandom`, read with the standard library and
+//! nothing else. On a platform without it, `keygen` refuses and `issue`
+//! requires an explicit `--nonce`: refusing is the only honest option, because
+//! silently substituting a weaker source in a tool that mints identity claims is
+//! the failure nobody would notice.
+
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write as _;
+use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use f2z_authority::{
+    AssertionNonce, DEFAULT_MAX_VALIDITY_MS, Handle, HandleAssertionTBS, Intent, LogId, SigningKey,
+    authority_id,
+};
+use f2z_codec::canonical::Canonical as _;
+use f2z_codec::types::PublicKey;
+
+const USAGE: &str = "\
+f2z-assert — issue a free2z handle-ownership assertion (docs/e2ee/KT.md)
+
+USAGE:
+  f2z-assert keygen [--out FILE]
+      Generate an Ed25519 issuing key. Writes 64 hex characters.
+
+  f2z-assert authority --key FILE
+      Print the authority_id and public key for a key file, in the form an
+      AuthoritySet entry takes.
+
+  f2z-assert issue --key FILE --log-id HEX --handle NAME --identity-pk HEX
+                   [--intent bind|reset] [--account-epoch N]
+                   [--issued-ms N] [--expires-ms N] [--validity-ms N]
+                   [--nonce HEX] [--out FILE]
+      Sign an assertion. Writes hex to stdout, or raw bytes with --out.
+
+NOTES:
+  A key file holds 64 hex characters or 32 raw bytes. Surrounding whitespace is
+  ignored. It is a private key: mode 0600, and never in a repository.
+
+  --intent defaults to bind. Use reset only for ADR 0014's platform-reset path,
+  where an account has changed hands; the log refuses a reset on a handle's
+  first entry and refuses a bind on any later one.
+
+  --validity-ms defaults to 900000 (15 minutes) and is ignored when --expires-ms
+  is given. The LOG caps this independently: an assertion whose window exceeds
+  the log's own cap is refused however it was signed.
+";
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().skip(1).collect();
+    match run(&args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            eprintln!("f2z-assert: {message}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(args: &[String]) -> Result<(), String> {
+    let Some(command) = args.first() else {
+        print!("{USAGE}");
+        return Err("no subcommand given".into());
+    };
+    let rest = args.get(1..).unwrap_or_default();
+    match command.as_str() {
+        "keygen" => keygen(rest),
+        "authority" => authority(rest),
+        "issue" => issue(rest),
+        "-h" | "--help" | "help" => {
+            print!("{USAGE}");
+            Ok(())
+        }
+        other => Err(format!("unknown subcommand `{other}`; try --help")),
+    }
+}
+
+// ---------------------------------------------------------------- subcommands
+
+fn keygen(args: &[String]) -> Result<(), String> {
+    let options = Options::parse(args)?;
+    options.reject_unknown(&["out"])?;
+    let mut seed = [0u8; 32];
+    fill_os_random(&mut seed)?;
+    let hex = to_hex(&seed);
+    match options.get("out") {
+        Some(path) => {
+            write_new_private_key(path, hex.as_bytes())?;
+            eprintln!("wrote a new issuing key to {path}");
+            eprintln!(
+                "authority_id {}",
+                to_hex(authority_id(&SigningKey::from_seed(&seed).public_key()).as_bytes(),)
+            );
+        }
+        None => println!("{hex}"),
+    }
+    Ok(())
+}
+
+/// Create the issuing-key file atomically with its final permissions.
+///
+/// `create_new` is the no-clobber guard. On Unix, `mode` is applied by the
+/// opening syscall itself, so there is no interval in which another process
+/// can read a newly-created 0644 private key before a later chmod.
+fn open_private_key(path: &str) -> Result<File, String> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    options
+        .open(path)
+        .map_err(|error| format!("creating new private key {path}: {error}"))
+}
+
+fn write_new_private_key(path: &str, bytes: &[u8]) -> Result<(), String> {
+    let mut file = open_private_key(path)?;
+    file.write_all(bytes)
+        .map_err(|error| format!("writing {path}: {error}"))
+}
+
+fn authority(args: &[String]) -> Result<(), String> {
+    let options = Options::parse(args)?;
+    options.reject_unknown(&["key"])?;
+    let key = read_key(options.require("key")?)?;
+    let public = key.public_key();
+    println!("authority_id  {}", to_hex(authority_id(&public).as_bytes()));
+    println!("public_key    {}", to_hex(public.as_bytes()));
+    Ok(())
+}
+
+fn issue(args: &[String]) -> Result<(), String> {
+    let options = Options::parse(args)?;
+    options.reject_unknown(&[
+        "key",
+        "log-id",
+        "handle",
+        "identity-pk",
+        "intent",
+        "account-epoch",
+        "issued-ms",
+        "expires-ms",
+        "validity-ms",
+        "nonce",
+        "out",
+    ])?;
+
+    let key = read_key(options.require("key")?)?;
+    let log_id = LogId::new(fixed_hex::<32>(options.require("log-id")?, "--log-id")?);
+    let handle = Handle::parse(options.require("handle")?.as_bytes())
+        .map_err(|error| format!("--handle: {error}"))?;
+    let identity_pk = PublicKey::new(fixed_hex::<32>(
+        options.require("identity-pk")?,
+        "--identity-pk",
+    )?);
+
+    let intent = match options.get("intent").map(String::as_str) {
+        None | Some("bind") => Intent::Bind,
+        Some("reset") => Intent::Reset,
+        Some(other) => return Err(format!("--intent must be bind or reset, not `{other}`")),
+    };
+    let account_epoch = match options.get("account-epoch") {
+        Some(value) => parse_u32(value, "--account-epoch")?,
+        None => 0,
+    };
+
+    let issued_ms = match options.get("issued-ms") {
+        Some(value) => parse_u64(value, "--issued-ms")?,
+        None => now_ms()?,
+    };
+    let expires_ms = match options.get("expires-ms") {
+        Some(value) => parse_u64(value, "--expires-ms")?,
+        None => {
+            let validity = match options.get("validity-ms") {
+                Some(value) => parse_u64(value, "--validity-ms")?,
+                None => DEFAULT_MAX_VALIDITY_MS,
+            };
+            issued_ms
+                .checked_add(validity)
+                .ok_or("issued_ms + validity overflows")?
+        }
+    };
+    if expires_ms <= issued_ms {
+        return Err("expires_ms must be after issued_ms".into());
+    }
+
+    let nonce = match options.get("nonce") {
+        Some(value) => AssertionNonce::new(fixed_hex::<16>(value, "--nonce")?),
+        None => {
+            let mut bytes = [0u8; 16];
+            fill_os_random(&mut bytes)?;
+            AssertionNonce::new(bytes)
+        }
+    };
+
+    let assertion = HandleAssertionTBS::new(
+        &key.public_key(),
+        log_id,
+        handle,
+        identity_pk,
+        intent,
+        account_epoch,
+        issued_ms,
+        expires_ms,
+        nonce,
+    )
+    .map_err(|error| format!("building the assertion: {error}"))?
+    .sign(&key)
+    .map_err(|error| format!("signing: {error}"))?;
+
+    let bytes = assertion
+        .encode_canonical()
+        .map_err(|error| format!("encoding: {error}"))?;
+
+    eprintln!(
+        "issued {} for a {} intent, valid {} ms, authority_id {}",
+        options.require("handle")?,
+        intent,
+        expires_ms.saturating_sub(issued_ms),
+        to_hex(authority_id(&key.public_key()).as_bytes()),
+    );
+    eprintln!(
+        "the submitter must ALSO sign the binding with the identity private key; \
+         an assertion alone is not a submission (KT.md)"
+    );
+
+    match options.get("out") {
+        Some(path) => {
+            fs::write(path, &bytes).map_err(|error| format!("writing {path}: {error}"))?;
+            eprintln!("wrote {} bytes to {path}", bytes.len());
+        }
+        None => println!("{}", to_hex(&bytes)),
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------------- helpers
+
+/// `--name value` pairs, in order, with no abbreviation and no clustering.
+struct Options(Vec<(String, String)>);
+
+impl Options {
+    fn parse(args: &[String]) -> Result<Self, String> {
+        let mut pairs = Vec::new();
+        let mut index = 0usize;
+        while let Some(flag) = args.get(index) {
+            let name = flag
+                .strip_prefix("--")
+                .ok_or_else(|| format!("expected a --flag, found `{flag}`"))?;
+            let value = args
+                .get(index.saturating_add(1))
+                .ok_or_else(|| format!("--{name} needs a value"))?;
+            pairs.push((name.to_owned(), value.clone()));
+            index = index.saturating_add(2);
+        }
+        Ok(Self(pairs))
+    }
+
+    fn get(&self, name: &str) -> Option<&String> {
+        self.0
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value)
+    }
+
+    fn require(&self, name: &str) -> Result<&String, String> {
+        self.get(name)
+            .ok_or_else(|| format!("--{name} is required"))
+    }
+
+    /// A misspelled flag must be an error, not a silent default. This tool
+    /// mints identity claims; `--handel alice` quietly issuing for something
+    /// else is exactly the class of mistake it must not have.
+    fn reject_unknown(&self, allowed: &[&str]) -> Result<(), String> {
+        for (name, _) in &self.0 {
+            if !allowed.contains(&name.as_str()) {
+                return Err(format!("unknown flag --{name}; try --help"));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn read_key(path: &str) -> Result<SigningKey, String> {
+    let raw = fs::read(path).map_err(|error| format!("reading {path}: {error}"))?;
+    let trimmed: Vec<u8> = {
+        let start = raw
+            .iter()
+            .position(|byte| !byte.is_ascii_whitespace())
+            .unwrap_or(raw.len());
+        let end = raw
+            .iter()
+            .rposition(|byte| !byte.is_ascii_whitespace())
+            .map_or(start, |index| index.saturating_add(1));
+        raw.get(start..end).unwrap_or_default().to_vec()
+    };
+
+    if trimmed.len() == 64 {
+        let text = core::str::from_utf8(&trimmed)
+            .map_err(|_| format!("{path} is 64 bytes but is not hex"))?;
+        return Ok(SigningKey::from_seed(&fixed_hex::<32>(text, path)?));
+    }
+    let seed: [u8; 32] = trimmed.as_slice().try_into().map_err(|_| {
+        format!(
+            "{path} must hold 64 hex characters or 32 raw bytes, found {} bytes",
+            trimmed.len()
+        )
+    })?;
+    Ok(SigningKey::from_seed(&seed))
+}
+
+fn fixed_hex<const N: usize>(text: &str, what: &str) -> Result<[u8; N], String> {
+    let bytes = parse_hex(text).map_err(|error| format!("{what}: {error}"))?;
+    bytes.as_slice().try_into().map_err(|_| {
+        format!(
+            "{what}: expected {N} bytes ({} hex characters), found {}",
+            N.saturating_mul(2),
+            bytes.len()
+        )
+    })
+}
+
+fn parse_hex(text: &str) -> Result<Vec<u8>, String> {
+    let digits: Vec<u8> = text
+        .bytes()
+        .filter(|byte| !byte.is_ascii_whitespace())
+        .collect();
+    if !digits.len().is_multiple_of(2) {
+        return Err("an odd number of hex characters".into());
+    }
+    let mut out = Vec::with_capacity(digits.len() / 2);
+    for pair in digits.chunks(2) {
+        let (Some(high), Some(low)) = (pair.first(), pair.get(1)) else {
+            return Err("an odd number of hex characters".into());
+        };
+        let high = nibble(*high)?;
+        let low = nibble(*low)?;
+        out.push(high.saturating_mul(16).saturating_add(low));
+    }
+    Ok(out)
+}
+
+fn nibble(byte: u8) -> Result<u8, String> {
+    match byte {
+        b'0'..=b'9' => Ok(byte.saturating_sub(b'0')),
+        b'a'..=b'f' => Ok(byte.saturating_sub(b'a').saturating_add(10)),
+        b'A'..=b'F' => Ok(byte.saturating_sub(b'A').saturating_add(10)),
+        other => Err(format!("`{}` is not a hex digit", char::from(other))),
+    }
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len().saturating_mul(2));
+    for byte in bytes {
+        out.push(char::from(hex_digit(byte >> 4)));
+        out.push(char::from(hex_digit(byte & 0x0f)));
+    }
+    out
+}
+
+fn hex_digit(value: u8) -> u8 {
+    if value < 10 {
+        b'0'.saturating_add(value)
+    } else {
+        b'a'.saturating_add(value.saturating_sub(10))
+    }
+}
+
+fn parse_u32(text: &str, what: &str) -> Result<u32, String> {
+    text.parse().map_err(|_| format!("{what} must be a number"))
+}
+
+fn parse_u64(text: &str, what: &str) -> Result<u64, String> {
+    text.parse().map_err(|_| format!("{what} must be a number"))
+}
+
+fn now_ms() -> Result<u64, String> {
+    let since = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| "the system clock is before 1970".to_owned())?;
+    u64::try_from(since.as_millis()).map_err(|_| "the system clock is implausible".to_owned())
+}
+
+/// Fill `buffer` from `/dev/urandom`.
+///
+/// No `getrandom`, no `rand`: one `open` and one `read_exact` is the whole
+/// requirement, and a dependency in an issuing tool is a dependency in the
+/// trust root. See the module note on why an unavailable source is a refusal
+/// rather than a fallback.
+fn fill_os_random(buffer: &mut [u8]) -> Result<(), String> {
+    let mut source = fs::File::open("/dev/urandom").map_err(|error| {
+        format!(
+            "no random source (/dev/urandom: {error}). \
+             Pass --nonce explicitly, and generate keys on a platform that has one."
+        )
+    })?;
+    fill_random(&mut source, buffer).map_err(|error| format!("reading /dev/urandom: {error}"))
+}
+
+fn fill_random(source: &mut impl std::io::Read, buffer: &mut [u8]) -> std::io::Result<()> {
+    source.read_exact(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    fn unused_path(name: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        env::temp_dir().join(format!(
+            "f2z-authority-{name}-{}-{unique}",
+            std::process::id()
+        ))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_key_is_mode_0600_at_the_open_boundary() {
+        use std::process::Command;
+
+        let key_path = unused_path("mode");
+        let probe_path = unused_path("umask-probe");
+        let status = Command::new("/bin/sh")
+            .args(["-c", "umask 000; exec \"$@\"", "f2z-authority-mode-test"])
+            .arg(env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "tests::private_key_mode_subprocess",
+                "--nocapture",
+            ])
+            .env("F2Z_AUTHORITY_MODE_TEST_KEY", &key_path)
+            .env("F2Z_AUTHORITY_MODE_TEST_PROBE", &probe_path)
+            .status()
+            .unwrap();
+
+        let key_created = key_path.is_file();
+        let probe_created = probe_path.is_file();
+        let _ = fs::remove_file(key_path);
+        let _ = fs::remove_file(probe_path);
+        assert!(status.success(), "the isolated mode-at-open check failed");
+        assert!(
+            key_created && probe_created,
+            "the isolated mode-at-open helper did not create both fixtures"
+        );
+    }
+
+    /// Subprocess half of `private_key_is_mode_0600_at_the_open_boundary`.
+    ///
+    /// The probe proves the parent installed a zero umask before this process
+    /// started. That makes a relaxed production mode observable even when the
+    /// shell which launched Cargo has a restrictive umask such as 077.
+    #[cfg(unix)]
+    #[test]
+    fn private_key_mode_subprocess() {
+        use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+
+        let Ok(key_path) = env::var("F2Z_AUTHORITY_MODE_TEST_KEY") else {
+            return;
+        };
+        let probe_path = env::var("F2Z_AUTHORITY_MODE_TEST_PROBE").unwrap();
+        let probe = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o666)
+            .open(&probe_path)
+            .unwrap();
+        let probe_mode = probe.metadata().unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            probe_mode, 0o666,
+            "the isolated subprocess did not start with umask 000"
+        );
+
+        let file = open_private_key(&key_path).unwrap();
+        let mode = file.metadata().unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "the file was visible with mode {mode:o} at open"
+        );
+    }
+
+    #[test]
+    fn private_key_creation_never_clobbers_an_existing_file() {
+        let path = unused_path("clobber");
+        let path_text = path.to_str().unwrap();
+        fs::write(&path, b"existing sentinel").unwrap();
+
+        assert!(write_new_private_key(path_text, b"replacement").is_err());
+        assert_eq!(fs::read(&path).unwrap(), b"existing sentinel");
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn successful_random_reads_preserve_every_nonzero_source_byte() {
+        let expected = [
+            0x81, 0x02, 0x93, 0x14, 0xa5, 0x26, 0xb7, 0x38, 0xc9, 0x4a, 0xdb, 0x5c, 0xed, 0x6e,
+            0xff, 0x70,
+        ];
+        let mut source = std::io::Cursor::new(expected);
+        let mut actual = [0xa5; 16];
+        fill_random(&mut source, &mut actual).unwrap();
+        assert_eq!(actual, expected);
+    }
+}

--- a/rs/crates/f2z-authority/src/error.rs
+++ b/rs/crates/f2z-authority/src/error.rs
@@ -1,0 +1,310 @@
+//! Every way an assertion can be refused, and the `KT.md` §9.5 code each one
+//! travels as.
+//!
+//! The variants are finer-grained than the wire codes on purpose. §9.5 has one
+//! code — `ERR_BAD_AUTHORIZATION` — for the whole of §4.4, which is the right
+//! answer *on the wire* (a submitter learns that its submission was not
+//! authorized, and nothing about which of a dozen rules caught it) and the
+//! wrong answer *in a log*, where an operator debugging a real user's failed
+//! submission needs to know whether the clock, the charset or the nonce was the
+//! problem. Keeping both is what [`AuthorityError::kt_error_code`] is for: the
+//! detail stays local, the code goes out.
+
+use core::fmt;
+
+use f2z_codec::CodecError;
+
+/// `ERR_MALFORMED` — `KT.md` §9.5 code 1.
+pub const ERR_MALFORMED: u16 = 1;
+/// `ERR_UNSUPPORTED_VERSION` — `KT.md` §9.5 code 2. Also "a `log_id` this
+/// server does not serve", which is what a wrong-log assertion is.
+pub const ERR_UNSUPPORTED_VERSION: u16 = 2;
+/// `ERR_BAD_SIGNATURE` — `KT.md` §9.5 code 3.
+pub const ERR_BAD_SIGNATURE: u16 = 3;
+/// `ERR_BAD_AUTHORIZATION` — `KT.md` §9.5 code 4.
+pub const ERR_BAD_AUTHORIZATION: u16 = 4;
+/// `ERR_RATE_LIMITED` — `KT.md` §9.5 code 9.
+pub const ERR_RATE_LIMITED: u16 = 9;
+/// `ERR_INTERNAL` — `KT.md` §9.5 code 11. Carries no detail, ever.
+pub const ERR_INTERNAL: u16 = 11;
+
+/// Anything this crate refuses to do.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AuthorityError {
+    /// The bytes did not decode, re-encoded to something else (`WIRE.md`
+    /// §3.3), or were the wrong length for a fixed-width field.
+    Malformed,
+    /// The `label` field is not [`LABEL_ASSERTION_TBS`].
+    ///
+    /// [`LABEL_ASSERTION_TBS`]: crate::labels::LABEL_ASSERTION_TBS
+    WrongLabel,
+    /// The bytes are not `[a-z0-9_]{1,30}` (`WIRE.md` §14.1).
+    HandleCharset,
+    /// `handle_id` is not the digest of `handle`. The assertion contradicts
+    /// itself.
+    HandleIdMismatch,
+    /// The assertion's `handle` is not the handle of the submission it was
+    /// presented with.
+    HandleMismatch,
+    /// The assertion's `identity_pk` is not the submission's `identity_pk`.
+    IdentityMismatch,
+    /// `log_id` names a different log.
+    WrongLog,
+    /// No configured authority has the assertion's `authority_id`. Either the
+    /// issuer is not one of ours, or a rotation removed it.
+    UnknownAuthority,
+    /// The authority's signature over the assertion did not verify.
+    BadAuthoritySignature,
+    /// The identity key's signature over the binding did not verify — or, for a
+    /// key that is not a curve point, could never have.
+    ///
+    /// **This is the refusal that makes a stolen assertion worthless.** See
+    /// [`crate::authority`].
+    BadIdentitySignature,
+    /// `expires_ms` is not strictly after `issued_ms`.
+    EmptyValidity,
+    /// `expires_ms - issued_ms` is longer than the log's own cap.
+    ///
+    /// Checked by the log against its *own* policy, never against a number the
+    /// assertion carries: a compromised issuer that could choose its own
+    /// validity would mint one assertion good for a decade.
+    ValidityTooLong,
+    /// `issued_ms` is further in the future than the clock skew allows.
+    NotYetIssued,
+    /// `now_ms` has reached `expires_ms`.
+    Expired,
+    /// This `(authority_id, nonce)` pair has been admitted before.
+    ReplayedNonce,
+    /// The nonce ledger is full of unexpired entries. A refusal, never an
+    /// eviction — see [`crate::nonce`].
+    LedgerFull,
+    /// An assertion's `intent` does not match the declared entry kind:
+    /// `bind` is for the initial claim and `reset` is for `platform_reset`.
+    IntentMismatch,
+    /// The declared entry kind disagrees with its sequence position or with
+    /// whether it retains or changes the published identity key.
+    EntryKindMismatch,
+    /// A non-initial entry did not carry the predecessor's vouching state.
+    MissingPriorVouch,
+    /// An initial entry claimed a predecessor vouching state it cannot have.
+    UnexpectedPriorVouch,
+    /// A non-initial entry did not carry its predecessor's `account_epoch`.
+    MissingPriorAccountEpoch,
+    /// An initial entry claimed a predecessor `account_epoch` it cannot have.
+    UnexpectedPriorAccountEpoch,
+    /// A `reset` assertion was presented for a submission that keeps the
+    /// identity key it is replacing.
+    ///
+    /// The same refusal also covers a `key_change` entry that keeps its key:
+    /// both exceptional cases claim a key transition and therefore have to
+    /// replace the predecessor.
+    IdentityUnchanged,
+    /// `account_epoch` did not advance past the last admitted assertion for
+    /// this handle.
+    AccountEpochRegression,
+    /// An initial bind or platform reset on a vouched log arrived without its
+    /// platform assertion.
+    MissingAssertion,
+    /// An assertion appeared where none can be judged: either the log has no
+    /// authority, or a routine user-authorized entry carried a platform
+    /// assertion. Refused rather than ignored.
+    UnexpectedAssertion,
+    /// An [`AuthoritySet`] was built with no entries. Not the same thing as
+    /// having no authority, which has to be spelled — see [`AuthoritySet`].
+    ///
+    /// [`AuthoritySet`]: crate::authority::AuthoritySet
+    EmptyAuthoritySet,
+    /// Two entries in an [`AuthoritySet`] share an `authority_id`.
+    ///
+    /// [`AuthoritySet`]: crate::authority::AuthoritySet
+    DuplicateAuthority,
+    /// An [`AuthorityKey`] was built whose id is not the digest of its key.
+    ///
+    /// [`AuthorityKey`]: crate::authority::AuthorityKey
+    AuthorityIdNotDerived,
+    /// A policy was built with a zero or absurd validity cap.
+    InvalidPolicy,
+}
+
+impl AuthorityError {
+    /// The `KT.md` §9.5 code a log answers a submission with.
+    ///
+    /// | This crate | §9.5 |
+    /// |---|---|
+    /// | decode / charset / length | `ERR_MALFORMED` (1) |
+    /// | wrong `log_id` | `ERR_UNSUPPORTED_VERSION` (2) |
+    /// | either signature | `ERR_BAD_SIGNATURE` (3) |
+    /// | every other rule | `ERR_BAD_AUTHORIZATION` (4) |
+    /// | ledger full | `ERR_RATE_LIMITED` (9) |
+    /// | configuration fault | `ERR_INTERNAL` (11) |
+    ///
+    /// The last row is the one to notice: a misconfigured authority set is the
+    /// log's fault, not the submitter's, and §9.5 is explicit that
+    /// `ERR_INTERNAL` carries no detail. A log that answered
+    /// `ERR_BAD_AUTHORIZATION` there would blame a user for an operator error
+    /// and hide the operator error.
+    #[must_use]
+    pub const fn kt_error_code(self) -> u16 {
+        match self {
+            Self::Malformed | Self::HandleCharset => ERR_MALFORMED,
+            Self::WrongLog => ERR_UNSUPPORTED_VERSION,
+            Self::BadAuthoritySignature | Self::BadIdentitySignature => ERR_BAD_SIGNATURE,
+            Self::LedgerFull => ERR_RATE_LIMITED,
+            Self::EmptyAuthoritySet
+            | Self::DuplicateAuthority
+            | Self::AuthorityIdNotDerived
+            | Self::InvalidPolicy => ERR_INTERNAL,
+            Self::WrongLabel
+            | Self::HandleIdMismatch
+            | Self::HandleMismatch
+            | Self::IdentityMismatch
+            | Self::UnknownAuthority
+            | Self::EmptyValidity
+            | Self::ValidityTooLong
+            | Self::NotYetIssued
+            | Self::Expired
+            | Self::ReplayedNonce
+            | Self::IntentMismatch
+            | Self::EntryKindMismatch
+            | Self::MissingPriorVouch
+            | Self::UnexpectedPriorVouch
+            | Self::MissingPriorAccountEpoch
+            | Self::UnexpectedPriorAccountEpoch
+            | Self::IdentityUnchanged
+            | Self::AccountEpochRegression
+            | Self::MissingAssertion
+            | Self::UnexpectedAssertion => ERR_BAD_AUTHORIZATION,
+        }
+    }
+
+    /// Whether this is the log's own misconfiguration rather than a verdict on
+    /// a submission.
+    #[must_use]
+    pub const fn is_configuration_fault(self) -> bool {
+        self.kt_error_code() == ERR_INTERNAL
+    }
+
+    /// A stable, one-line explanation. No user data ever appears in it.
+    #[must_use]
+    pub const fn detail(self) -> &'static str {
+        match self {
+            Self::Malformed => "the bytes are not a canonical assertion",
+            Self::WrongLabel => "the label field is not free2z/kt/v1/handle-assertion",
+            Self::HandleCharset => "the handle is not [a-z0-9_]{1,30} (WIRE.md §14.1)",
+            Self::HandleIdMismatch => "handle_id is not the digest of handle",
+            Self::HandleMismatch => "the assertion is for a different handle",
+            Self::IdentityMismatch => "the assertion is about a different identity key",
+            Self::WrongLog => "the assertion names a different log",
+            Self::UnknownAuthority => "no configured authority has that authority_id",
+            Self::BadAuthoritySignature => "the authority signature did not verify",
+            Self::BadIdentitySignature => "the identity self-signature did not verify",
+            Self::EmptyValidity => "expires_ms is not after issued_ms",
+            Self::ValidityTooLong => "the validity window exceeds this log's cap",
+            Self::NotYetIssued => "issued_ms is in the future",
+            Self::Expired => "the assertion has expired",
+            Self::ReplayedNonce => "this (authority_id, nonce) has been admitted before",
+            Self::LedgerFull => "the nonce ledger is full of unexpired entries",
+            Self::IntentMismatch => "intent does not match the entry sequence position",
+            Self::EntryKindMismatch => {
+                "the entry kind does not match its version or predecessor identity key"
+            }
+            Self::MissingPriorVouch => "a non-initial entry is missing its prior vouching state",
+            Self::UnexpectedPriorVouch => "an initial entry cannot have a prior vouching state",
+            Self::MissingPriorAccountEpoch => {
+                "a non-initial entry is missing its prior account_epoch"
+            }
+            Self::UnexpectedPriorAccountEpoch => {
+                "an initial entry cannot have a prior account_epoch"
+            }
+            Self::IdentityUnchanged => "a reset assertion was spent on an unchanged identity key",
+            Self::AccountEpochRegression => "account_epoch did not advance",
+            Self::MissingAssertion => "this log requires an assertion and none was presented",
+            Self::UnexpectedAssertion => "this entry kind must not carry a platform assertion",
+            Self::EmptyAuthoritySet => "an authority set needs at least one key",
+            Self::DuplicateAuthority => "two authority keys share an authority_id",
+            Self::AuthorityIdNotDerived => "authority_id is not the digest of the key",
+            Self::InvalidPolicy => "the validity cap is zero or unrepresentable",
+        }
+    }
+}
+
+impl fmt::Display for AuthorityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} (KT.md §9.5 code {})",
+            self.detail(),
+            self.kt_error_code()
+        )
+    }
+}
+
+impl core::error::Error for AuthorityError {}
+
+impl From<CodecError> for AuthorityError {
+    /// Every codec failure here is the same event — the bytes are not a
+    /// canonical assertion — and flattening them is deliberate. `f2z-codec`
+    /// distinguishes `Decode` from `NotCanonical` because a relay's §10 table
+    /// does; §9.5 does not, and carrying a distinction nothing can report is
+    /// how a caller ends up inventing a code for it.
+    fn from(_: CodecError) -> Self {
+        Self::Malformed
+    }
+}
+
+/// The result of everything in this crate.
+pub type Result<T> = core::result::Result<T, AuthorityError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+
+    #[test]
+    fn signature_failures_are_code_three_and_nothing_else_is() {
+        assert_eq!(
+            AuthorityError::BadAuthoritySignature.kt_error_code(),
+            ERR_BAD_SIGNATURE
+        );
+        assert_eq!(
+            AuthorityError::BadIdentitySignature.kt_error_code(),
+            ERR_BAD_SIGNATURE
+        );
+        assert_eq!(
+            AuthorityError::Expired.kt_error_code(),
+            ERR_BAD_AUTHORIZATION
+        );
+    }
+
+    #[test]
+    fn configuration_faults_never_blame_the_submitter() {
+        for error in [
+            AuthorityError::EmptyAuthoritySet,
+            AuthorityError::DuplicateAuthority,
+            AuthorityError::AuthorityIdNotDerived,
+            AuthorityError::InvalidPolicy,
+        ] {
+            assert!(error.is_configuration_fault(), "{error}");
+            assert_eq!(error.kt_error_code(), ERR_INTERNAL);
+        }
+        assert!(!AuthorityError::Expired.is_configuration_fault());
+    }
+
+    #[test]
+    fn a_codec_failure_is_malformed() {
+        assert_eq!(
+            AuthorityError::from(CodecError::NotCanonical),
+            AuthorityError::Malformed
+        );
+        assert_eq!(
+            AuthorityError::from(CodecError::Decode).kt_error_code(),
+            ERR_MALFORMED
+        );
+    }
+
+    #[test]
+    fn display_carries_the_code() {
+        assert!(format!("{}", AuthorityError::Expired).contains("code 4"));
+    }
+}

--- a/rs/crates/f2z-authority/src/key.rs
+++ b/rs/crates/f2z-authority/src/key.rs
@@ -1,0 +1,220 @@
+//! Ed25519, verified strictly, and signing for the issuer.
+//!
+//! **Strict verification.** Both verifications in this crate go through
+//! `verify_strict`, which additionally rejects small-order public keys and
+//! small-order `R` components. Plain Ed25519 verification does not, and the
+//! consequence is that a signature can verify under more than one key — and
+//! that a key can exist under which *every* signature verifies. This crate's
+//! entire job is to decide that a specific authority vouched for a specific
+//! handle and that a specific identity key answered for it, so a key that
+//! verifies everything is a key that claims every handle. The cost is one extra
+//! point check.
+//!
+//! **Redaction.** [`SigningKey`] holds the issuer's private key; its `Debug`
+//! prints nothing about it, not even a fingerprint.
+
+use core::fmt;
+
+use ed25519_dalek::Signer as _;
+use f2z_codec::types::{PublicKey, Signature};
+
+use crate::error::{AuthorityError, Result};
+
+/// An Ed25519 public key that has been decompressed and is ready to verify.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct VerifyingKey(ed25519_dalek::VerifyingKey);
+
+impl VerifyingKey {
+    /// Decompress a wire public key.
+    ///
+    /// # Errors
+    ///
+    /// The `bad_signature` argument, so that a caller decides *whose*
+    /// signature the failure belongs to. "Your key is not a key" and "your
+    /// signature is not a signature" are the same event from outside — the
+    /// thing was not authorized — and this crate reports the party rather than
+    /// the mechanism.
+    pub fn from_public_key(key: &PublicKey, bad_signature: AuthorityError) -> Result<Self> {
+        ed25519_dalek::VerifyingKey::from_bytes(key.as_bytes())
+            .map(Self)
+            .map_err(|_| bad_signature)
+    }
+
+    /// The wire form.
+    #[must_use]
+    pub fn to_public_key(self) -> PublicKey {
+        PublicKey::new(self.0.to_bytes())
+    }
+
+    /// Verify a signature over `message`, strictly (see the module note).
+    ///
+    /// # Errors
+    ///
+    /// The `bad_signature` argument.
+    pub fn verify(
+        self,
+        message: &[u8],
+        signature: &Signature,
+        bad_signature: AuthorityError,
+    ) -> Result<()> {
+        let signature = ed25519_dalek::Signature::from_bytes(signature.as_bytes());
+        self.0
+            .verify_strict(message, &signature)
+            .map_err(|_| bad_signature)
+    }
+}
+
+// Public, but linkable: an identity key names a person to anyone who has seen
+// it elsewhere. Same rule as `f2z-codec`'s newtypes, and no alternate formatter
+// that renders the bytes — an escape hatch would be found and used.
+impl fmt::Debug for VerifyingKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("VerifyingKey(<redacted>)")
+    }
+}
+
+/// An Ed25519 signing key — an authority's issuing key, or an identity key
+/// answering for itself.
+///
+/// This crate never generates one: it has no clock, no randomness and no I/O,
+/// because it compiles for `wasm32-unknown-unknown`. `f2z-assert` owns the
+/// seed.
+#[derive(Clone)]
+pub struct SigningKey(ed25519_dalek::SigningKey);
+
+impl SigningKey {
+    /// Adopt a 32-byte seed.
+    ///
+    /// The seed is secret key material and the caller owns its lifetime; this
+    /// type zeroizes its own copy on drop but cannot reach the caller's.
+    #[must_use]
+    pub fn from_seed(seed: &[u8; 32]) -> Self {
+        Self(ed25519_dalek::SigningKey::from_bytes(seed))
+    }
+
+    /// The public half, in wire form.
+    #[must_use]
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey::new(self.0.verifying_key().to_bytes())
+    }
+
+    /// Sign a message. The transcripts here are small, so nothing is prehashed.
+    #[must_use]
+    pub fn sign(&self, message: &[u8]) -> Signature {
+        Signature::new(self.0.sign(message).to_bytes())
+    }
+}
+
+// The one value in this crate whose disclosure is unrecoverable.
+impl fmt::Debug for SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SigningKey(<redacted>)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+
+    /// The canonical Ed25519 identity point. With `R = A` and `s = 0`, plain
+    /// verification accepts every message while strict verification rejects
+    /// the small-order public key. Other small-order encodings accept only
+    /// message-dependent residue classes and are therefore softer fixtures.
+    const FORGERY_KEY: [u8; 32] = [
+        0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0,
+    ];
+
+    #[test]
+    fn a_signature_verifies_only_over_the_message_it_covers() {
+        let key = SigningKey::from_seed(&[7u8; 32]);
+        let verifier =
+            VerifyingKey::from_public_key(&key.public_key(), AuthorityError::BadAuthoritySignature)
+                .unwrap();
+        let signature = key.sign(b"the message");
+        assert!(
+            verifier
+                .verify(
+                    b"the message",
+                    &signature,
+                    AuthorityError::BadAuthoritySignature
+                )
+                .is_ok()
+        );
+        assert_eq!(
+            verifier.verify(
+                b"the messagf",
+                &signature,
+                AuthorityError::BadAuthoritySignature
+            ),
+            Err(AuthorityError::BadAuthoritySignature)
+        );
+    }
+
+    #[test]
+    fn the_identity_point_forgery_is_plainly_accepted_and_strictly_refused() {
+        use ed25519_dalek::Verifier as _;
+
+        let mut signature = [0u8; 64];
+        signature
+            .get_mut(..32)
+            .unwrap()
+            .copy_from_slice(&FORGERY_KEY);
+        let forged = Signature::new(signature);
+        let key = PublicKey::new(FORGERY_KEY);
+        let verifier =
+            VerifyingKey::from_public_key(&key, AuthorityError::BadIdentitySignature).unwrap();
+        let raw = ed25519_dalek::VerifyingKey::from_bytes(&FORGERY_KEY).unwrap();
+        assert!(
+            raw.is_weak(),
+            "the fixture stopped being a small-order point"
+        );
+        let dalek_signature = ed25519_dalek::Signature::from_bytes(forged.as_bytes());
+
+        for byte in 0..64u8 {
+            let message = [byte; 7];
+            assert!(
+                raw.verify(&message, &dalek_signature).is_ok(),
+                "message {byte}: plain verification refused the fixture, so the test no longer proves strictness matters"
+            );
+            assert_eq!(
+                verifier.verify(&message, &forged, AuthorityError::BadIdentitySignature),
+                Err(AuthorityError::BadIdentitySignature),
+                "message {byte}: strict verification accepted a universal forgery"
+            );
+        }
+    }
+
+    #[test]
+    fn a_key_that_is_not_a_curve_point_never_verifies_anything() {
+        // Whether a given 32 bytes is refused at decompression or at
+        // verification is `ed25519-dalek`'s business and has moved between its
+        // versions. What this crate needs is the property that survives either
+        // answer: bytes that are not a usable key cannot make a signature
+        // verify. Asserting only that is what stops the test from being a
+        // restatement of the dependency's current internals.
+        for candidate in [[0xffu8; 32], [0x01u8; 32], [0x00u8; 32]] {
+            let key = PublicKey::new(candidate);
+            let outcome = VerifyingKey::from_public_key(&key, AuthorityError::BadIdentitySignature)
+                .and_then(|verifier| {
+                    verifier.verify(
+                        b"anything",
+                        &Signature::new([0u8; 64]),
+                        AuthorityError::BadIdentitySignature,
+                    )
+                });
+            assert_eq!(outcome, Err(AuthorityError::BadIdentitySignature));
+        }
+    }
+
+    #[test]
+    fn neither_key_type_renders_its_bytes() {
+        let key = SigningKey::from_seed(&[1u8; 32]);
+        assert_eq!(format!("{key:?}"), "SigningKey(<redacted>)");
+        let verifier =
+            VerifyingKey::from_public_key(&key.public_key(), AuthorityError::BadIdentitySignature)
+                .unwrap();
+        assert_eq!(format!("{verifier:?}"), "VerifyingKey(<redacted>)");
+    }
+}

--- a/rs/crates/f2z-authority/src/labels.rs
+++ b/rs/crates/f2z-authority/src/labels.rs
@@ -1,0 +1,112 @@
+//! Domain separation: every label this crate signs under or hashes with.
+//!
+//! `KT.md` §1.3 fixes `H(label, x) = BLAKE2b-256(label || x)` with **no
+//! separator and no terminator**, which is only unambiguous while no label is a
+//! prefix of another. That is a property of a *set*, not of the construction,
+//! so it has to be asserted rather than assumed — [`LABELS`] exists so a test
+//! can do it mechanically, and [`KT_LABELS`] extends the same test across the
+//! labels `KT.md` already spends, because a new label here that shadows one
+//! there is the same bug even though it is in a different file.
+//!
+//! The two `*_TBS` labels are not hash prefixes. They are the `opaque
+//! label<0..255>` **first field** of a signed structure, exactly as
+//! `DirectoryEntryTBS`, `RotationProofTBS` and `ResetAuthorizationTBS` carry
+//! theirs (`KT.md` §4.1, §4.4). Because the field is length-prefixed, they are
+//! separated by construction — they are held to the prefix-free rule anyway, so
+//! that nobody has to work out which of the five is which before adding a
+//! sixth.
+
+/// The `label` field of a [`HandleAssertionTBS`], and therefore the first bytes
+/// of everything an authority signs.
+///
+/// This is the "domain-separated signing prefix": an authority key that is also
+/// used elsewhere cannot have one of its other signatures reinterpreted as an
+/// assertion, because no other structure in the system starts with these bytes
+/// under a `<0..255>` length prefix.
+///
+/// [`HandleAssertionTBS`]: crate::assertion::HandleAssertionTBS
+pub const LABEL_ASSERTION_TBS: &[u8] = b"free2z/kt/v1/handle-assertion";
+
+/// The `label` field of an [`AssertionBindingTBS`] — what the *identity* key
+/// signs.
+///
+/// [`AssertionBindingTBS`]: crate::assertion::AssertionBindingTBS
+pub const LABEL_ASSERTION_BINDING_TBS: &[u8] = b"free2z/kt/v1/assertion-binding";
+
+/// `authority_id = H("free2z/kt/v1/authority-id", authority_pk)`.
+///
+/// The same shape as `WIRE.md` §5.2's `relay_id`, and for the same reason: a
+/// key id that is *derived* from the key cannot disagree with it, so an
+/// [`AuthoritySet`] entry cannot name one authority and carry another's key.
+///
+/// [`AuthoritySet`]: crate::authority::AuthoritySet
+pub const LABEL_AUTHORITY_ID: &[u8] = b"free2z/kt/v1/authority-id";
+
+/// `handle_id = H("free2z/kt/v1/handle-id", handle)`.
+pub const LABEL_HANDLE_ID: &[u8] = b"free2z/kt/v1/handle-id";
+
+/// `assertion_digest = H("free2z/kt/v1/assertion-digest", tls_codec(HandleAssertion))`
+/// — the value the identity key's binding signature commits to.
+pub const LABEL_ASSERTION_DIGEST: &[u8] = b"free2z/kt/v1/assertion-digest";
+
+/// Every label this crate defines, so a test can hold the set prefix-free.
+pub const LABELS: [&[u8]; 5] = [
+    LABEL_ASSERTION_TBS,
+    LABEL_ASSERTION_BINDING_TBS,
+    LABEL_AUTHORITY_ID,
+    LABEL_HANDLE_ID,
+    LABEL_ASSERTION_DIGEST,
+];
+
+/// The labels `KT.md` v1 already spends, restated here **only** so the
+/// prefix-free test can range over both sets.
+///
+/// This is not a second source of truth for them and nothing in this crate
+/// reads it: the log's own crate owns those structures. It is here because the
+/// property that matters — no label is a prefix of another — is a property of
+/// every label in the `free2z/kt/v1/` namespace at once, and a test that only
+/// sees half of them proves half of it.
+pub const KT_LABELS: [&[u8]; 7] = [
+    b"free2z/kt/v1/entry",
+    b"free2z/kt/v1/rotation",
+    b"free2z/kt/v1/reset",
+    b"free2z/kt/v1/receipt",
+    b"free2z/kt/v1/prev",
+    b"free2z/kt/v1/value",
+    b"free2z/kt/v1/handle:",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn no_label_is_a_prefix_of_another_anywhere_in_the_namespace() {
+        let all: Vec<&[u8]> = LABELS.iter().chain(KT_LABELS.iter()).copied().collect();
+        for (i, a) in all.iter().enumerate() {
+            for (j, b) in all.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+                assert!(
+                    !b.starts_with(a),
+                    "label {:?} is a prefix of {:?}",
+                    core::str::from_utf8(a),
+                    core::str::from_utf8(b)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_label_is_in_the_kt_v1_namespace() {
+        for label in LABELS {
+            assert!(
+                label.starts_with(b"free2z/kt/v1/"),
+                "{:?} is outside the namespace",
+                core::str::from_utf8(label)
+            );
+        }
+    }
+}

--- a/rs/crates/f2z-authority/src/lib.rs
+++ b/rs/crates/f2z-authority/src/lib.rs
@@ -1,0 +1,187 @@
+//! Handle-ownership assertions for the free2z key-transparency log.
+//!
+//! **Experimental proposal.** `KT.md` v1 does not define `HandleAssertion`,
+//! its binding transcript, or the no-authority behavior implemented here.
+//! Issue #594 keeps first-entry authorization explicitly unresolved. This
+//! crate is an implementation candidate for review, not a claim that those
+//! choices are ratified protocol.
+//!
+//! # Why this is a crate and not a module
+//!
+//! Everything else in the directory is cryptographic. `akd` proves the tree is
+//! append-only; `KT.md` §4.4 proves an entry was authorized by the key that
+//! held the handle before; the witnesses prove the log did not equivocate. None
+//! of it answers the first question a user actually asks, which is *"is this
+//! `@alice` the `@alice` I know?"* — because a key-transparency log will
+//! faithfully, verifiably and permanently publish a key for a handle **whoever
+//! got there first**.
+//!
+//! Something has to say who owns a handle, and no amount of cryptography can
+//! derive it. That something is a **non-cryptographic trust root**, and this
+//! crate is the whole of it. It is separate so that a self-hoster deciding
+//! whether to trust our directory, or swapping our authority for their own, or
+//! running with none at all, reads **one short crate** — not a server, not a
+//! grep through a submission path, not a policy spread over three layers.
+//!
+//! ```text
+//!   the platform (or whoever runs the user directory)
+//!         │  signs a HandleAssertion: "@alice is this identity key"
+//!         ▼
+//!   ┌──────────────┐   the assertion, plus the identity key's own
+//!   │ f2z-authority│   signature over the submission it accompanies
+//!   └──────────────┘
+//!         │  AssertionLayerCheck (partial) — or a refusal
+//!         ▼
+//!   the log's §4.4 submission path, then akd, then the witnesses
+//! ```
+//!
+//! # The rule that makes it sound
+//!
+//! An assertion is a **bearer document**. Whoever holds a copy holds everything
+//! the authority said, so if holding it were enough to submit under the handle
+//! it names, intercepting one would be a takeover.
+//!
+//! This proposal requires that the submission carrying an assertion **also** be
+//! signed by the identity private key the assertion is *about*. That is what
+//! makes a stolen assertion worthless: producing the second signature needs
+//! the very key the thief was trying to replace.
+//!
+//! [`AuthorityConfig::check_assertion_layer`] takes
+//! [`Submission::identity_signature`] on every branch, including the proposed
+//! no-authority branch; and there is no `verify_assertion` beside it that could
+//! skip the binding. Its result is intentionally named [`AssertionLayerCheck`]:
+//! it does **not** prove §4.4's directory authorization and must never be used
+//! alone as permission to publish an entry.
+//!
+//! # What it enforces
+//!
+//! Authority membership and signature, `log_id`, timestamps, **a validity cap
+//! the log holds rather than the issuer**, nonce freshness, `handle_id`
+//! agreement, the `[a-z0-9_]{1,30}` charset, entry-kind shape, assertion intent,
+//! and `account_epoch` monotonicity. [`AuthorityConfig::check_assertion_layer`]'s documentation
+//! lists all seventeen asserted-path rules in the order they run, and names the
+//! smaller routine assertion-layer path explicitly.
+//!
+//! # What it deliberately does not do
+//!
+//! No clocks, no randomness, no I/O, no storage and no `std`: `now_ms` is an
+//! argument and the nonce ledger is a trait, because this crate compiles for
+//! `wasm32-unknown-unknown` and clients verify assertions too. It does not
+//! parse a `DirectoryEntry`, apply `KT.md` §4.4's own rules, or touch the tree —
+//! that is the log's crate. And it has **no username-to-handle mapping**: see
+//! [`Handle`] for why that function would be a security decision this crate
+//! must not make on anyone's behalf.
+//!
+//! # Issuing by hand
+//!
+//! `f2z-assert`, the binary in this package, signs an assertion from a key
+//! file, so a self-hoster running a log with no web application can issue one
+//! without writing code.
+//!
+//! ```
+//! use f2z_authority::{
+//!     AssertionNonce, AuthorityConfig, AuthoritySet, EntryKind, Handle, HandleAssertionTBS,
+//!     Intent, LogId, NonceLedger, SigningKey, Submission, Vouch,
+//! };
+//! use f2z_codec::types::Digest;
+//!
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! let log_id = LogId::new([0x11; 32]);
+//! let authority = SigningKey::from_seed(&[0x22; 32]);   // the directory's key
+//! let identity = SigningKey::from_seed(&[0x33; 32]);    // @alice's ISK
+//! let handle = Handle::parse(b"alice")?;
+//! let entry_digest = Digest::new([0x44; 32]);           // the submission's AkdValue
+//!
+//! let config = AuthorityConfig::with_defaults(
+//!     log_id,
+//!     AuthoritySet::single(authority.public_key())?,
+//! )?;
+//!
+//! // The authority vouches…
+//! let assertion = HandleAssertionTBS::new(
+//!     &authority.public_key(),
+//!     log_id,
+//!     handle.clone(),
+//!     identity.public_key(),
+//!     Intent::Bind,
+//!     0,
+//!     1_000,
+//!     61_000,
+//!     AssertionNonce::new([0x55; 16]),
+//! )?
+//! .sign(&authority)?;
+//!
+//! // …and @alice answers for herself. Both, or neither.
+//! let binding = config.binding(&handle, &identity.public_key(), Some(&assertion), &entry_digest)?;
+//! let identity_signature = binding.sign(&identity)?;
+//!
+//! let mut ledger = NonceLedger::new(4096, config.clock_skew_ms());
+//! let checked = config.check_assertion_layer(
+//!     &Submission {
+//!         assertion: Some(&f2z_codec::canonical::encode(&assertion)?),
+//!         kind: EntryKind::InitialBind,
+//!         handle: &handle,
+//!         identity_pk: &identity.public_key(),
+//!         entry_version: 1,
+//!         entry_digest: &entry_digest,
+//!         identity_signature: &identity_signature,
+//!         previous_identity_pk: None,
+//!         previous_vouch: None,
+//!         previous_account_epoch: None,
+//!     },
+//!     2_000,
+//!     &mut ledger,
+//! )?;
+//!
+//! assert!(checked.vouch().is_vouched());
+//! assert_ne!(checked.vouch(), Vouch::Unvouched);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`Handle`]: crate::types::Handle
+//! [`Submission::identity_signature`]: crate::authority::Submission::identity_signature
+
+#![no_std]
+#![forbid(unsafe_code)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects
+    )
+)]
+
+extern crate alloc;
+
+pub mod assertion;
+pub mod authority;
+pub mod error;
+pub mod key;
+pub mod labels;
+pub mod nonce;
+pub mod types;
+
+pub use assertion::{AssertionBindingTBS, HandleAssertion, HandleAssertionTBS};
+pub use authority::{
+    AssertionLayerCheck, AuthorityConfig, AuthorityKey, AuthoritySet, DEFAULT_CLOCK_SKEW_MS,
+    DEFAULT_MAX_VALIDITY_MS, EntryKind, Submission, Vouch, VouchingStatus,
+};
+pub use error::{AuthorityError, Result};
+pub use key::{SigningKey, VerifyingKey};
+pub use nonce::{NonceLedger, NonceSeen};
+pub use types::{
+    AssertionNonce, AuthorityId, HANDLE_MAX_LEN, Handle, HandleId, Intent, LogId, authority_id,
+};
+
+/// The key-transparency protocol version this crate's structures belong to.
+///
+/// `KT.md` §4.1 carries a `kt_version` field inside `DirectoryEntryTBS`; a
+/// [`HandleAssertionTBS`] does not, because its `label` already spells `/v1/`
+/// and a second version marker inside one structure is a second thing to
+/// disagree with the first. Stated here so the version is written down
+/// somewhere a caller can read it.
+pub const KT_VERSION: u16 = 0x0001;

--- a/rs/crates/f2z-authority/src/nonce.rs
+++ b/rs/crates/f2z-authority/src/nonce.rs
@@ -1,0 +1,257 @@
+//! The nonce ledger: bounded, fail-closed, and expiring.
+//!
+//! An assertion is replayable for as long as it is inside its own validity
+//! window. Everything else in [`crate::authority`] is a stateless check on the
+//! bytes, so this is the one rule that needs memory — and the one an
+//! implementation is most likely to get subtly wrong in the two ways below.
+//!
+//! **It refuses; it does not evict.** Discarding an unexpired entry to make
+//! room silently reopens the replay window at exactly the moment the log is
+//! under load, which is exactly when an attacker would arrange to be. Reaching
+//! [`NonceLedger::max_entries`] is therefore [`AuthorityError::LedgerFull`] —
+//! `ERR_RATE_LIMITED` — and the only way an entry leaves is expiry. This
+//! follows `f2z-relay-proto`'s `SeenSet`, which took the same decision for
+//! `WIRE.md` §5.5 and reported the missing spec sentence rather than inventing
+//! a policy.
+//!
+//! **Retention is derived, not published.** `f2z-relay-proto` had to reject
+//! operator-published values that did not cover their own window (#586). Here
+//! there is nothing to publish: the entry expires when the *assertion* does,
+//! plus the clock skew the verifier already allows, so the retention can never
+//! be shorter than the window it protects. That is not extra strictness, it is
+//! the one arrangement in which the bug cannot be configured.
+//!
+//! **`(authority_id, nonce)`, not the assertion digest.** Keying on the digest
+//! would only catch a byte-identical replay. Keying on the pair also catches an
+//! issuer that reused a nonce across two *different* assertions — an issuer bug
+//! or a compromised issuer trying to make two claims look like one — which is
+//! the case worth failing on.
+
+use alloc::collections::BTreeMap;
+use core::fmt;
+
+use crate::error::{AuthorityError, Result};
+use crate::types::{AssertionNonce, AuthorityId};
+
+/// Where an admitted assertion's nonce is recorded so it cannot be presented
+/// twice.
+///
+/// A trait so a log with durable storage can keep the ledger in its database
+/// (a restart must not reopen the window: unlike a relay's seen-set, nothing
+/// here is invalidated by a lost TLS session) while a client verifying a served
+/// assertion uses [`NonceLedger`] in memory.
+pub trait NonceSeen {
+    /// Record `(authority_id, nonce)` as admitted, or refuse it.
+    ///
+    /// `expires_ms` is the assertion's own expiry; the implementation MUST
+    /// retain the entry at least that long.
+    ///
+    /// # Errors
+    ///
+    /// - [`AuthorityError::ReplayedNonce`] if the pair is already held.
+    /// - [`AuthorityError::LedgerFull`] if the store is full of unexpired
+    ///   entries. Refuse; never evict.
+    fn observe(
+        &mut self,
+        now_ms: u64,
+        authority_id: AuthorityId,
+        nonce: AssertionNonce,
+        expires_ms: u64,
+    ) -> Result<()>;
+}
+
+/// The ledger key.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct NonceKey {
+    authority_id: AuthorityId,
+    nonce: AssertionNonce,
+}
+
+// Both halves are linkable — an authority id names an issuer, a nonce names one
+// user's assertion. Neither renders.
+impl fmt::Debug for NonceKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("NonceKey(<redacted>)")
+    }
+}
+
+/// An in-memory [`NonceSeen`].
+///
+/// A `BTreeMap` rather than a hash map for two reasons: this crate is `no_std`
+/// so `HashMap` is not available without pulling a hasher, and a tree has no
+/// hash-collision behaviour for an attacker who controls a nonce to aim at.
+#[derive(Clone, Debug)]
+pub struct NonceLedger {
+    entries: BTreeMap<NonceKey, u64>,
+    max_entries: usize,
+    skew_ms: u64,
+}
+
+impl NonceLedger {
+    /// A ledger holding at most `max_entries`, retaining each until its
+    /// assertion's `expires_ms` plus `skew_ms`.
+    ///
+    /// `skew_ms` must be the same value the [`AuthorityConfig`] uses, so that
+    /// an entry never ages out while the assertion it covers would still be
+    /// accepted.
+    ///
+    /// [`AuthorityConfig`]: crate::authority::AuthorityConfig
+    #[must_use]
+    pub const fn new(max_entries: usize, skew_ms: u64) -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            max_entries,
+            skew_ms,
+        }
+    }
+
+    /// The bound at which the ledger fails closed.
+    #[must_use]
+    pub const fn max_entries(&self) -> usize {
+        self.max_entries
+    }
+
+    /// How many entries are held right now.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the ledger is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Drop every entry whose assertion can no longer be accepted, and report
+    /// how many went.
+    ///
+    /// Called by [`NonceSeen::observe`] first, so nothing has to schedule a
+    /// sweep — this crate has no runtime and no timer. Public because an idle
+    /// log would otherwise hold its last entries forever.
+    pub fn expire(&mut self, now_ms: u64) -> usize {
+        let before = self.entries.len();
+        self.entries.retain(|_, drop_after| *drop_after > now_ms);
+        before.saturating_sub(self.entries.len())
+    }
+}
+
+impl NonceSeen for NonceLedger {
+    fn observe(
+        &mut self,
+        now_ms: u64,
+        authority_id: AuthorityId,
+        nonce: AssertionNonce,
+        expires_ms: u64,
+    ) -> Result<()> {
+        self.expire(now_ms);
+
+        let key = NonceKey {
+            authority_id,
+            nonce,
+        };
+        if self.entries.contains_key(&key) {
+            return Err(AuthorityError::ReplayedNonce);
+        }
+        // Checked after the replay lookup on purpose: a full ledger that is
+        // handed a genuine replay should say so. Reporting capacity there would
+        // hide an attack behind a load message.
+        if self.entries.len() >= self.max_entries {
+            return Err(AuthorityError::LedgerFull);
+        }
+
+        self.entries
+            .insert(key, expires_ms.saturating_add(self.skew_ms));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+
+    fn id(byte: u8) -> AuthorityId {
+        AuthorityId::new([byte; 32])
+    }
+
+    fn nonce(byte: u8) -> AssertionNonce {
+        AssertionNonce::new([byte; 16])
+    }
+
+    #[test]
+    fn the_same_pair_twice_is_a_replay() {
+        let mut ledger = NonceLedger::new(8, 0);
+        assert!(ledger.observe(0, id(1), nonce(1), 1_000).is_ok());
+        assert_eq!(
+            ledger.observe(500, id(1), nonce(1), 1_000),
+            Err(AuthorityError::ReplayedNonce)
+        );
+        // A different nonce under the same authority is not.
+        assert!(ledger.observe(500, id(1), nonce(2), 1_000).is_ok());
+        // Nor is the same nonce under a different authority.
+        assert!(ledger.observe(500, id(2), nonce(1), 1_000).is_ok());
+    }
+
+    #[test]
+    fn an_entry_outlives_the_assertion_it_covers_by_the_skew() {
+        let mut ledger = NonceLedger::new(8, 100);
+        assert!(ledger.observe(0, id(1), nonce(1), 1_000).is_ok());
+        // Still held right up to `expires_ms + skew`. The assertion itself
+        // stopped being acceptable at `expires_ms` — 100 ms earlier — so the
+        // entry outliving it is the margin, which is the direction that has to
+        // be true.
+        assert_eq!(
+            ledger.observe(1_099, id(1), nonce(1), 1_000),
+            Err(AuthorityError::ReplayedNonce)
+        );
+        // Released once nothing it covers could be accepted anyway.
+        assert!(ledger.observe(1_100, id(1), nonce(1), 1_000).is_ok());
+    }
+
+    #[test]
+    fn a_full_ledger_refuses_and_does_not_evict() {
+        let mut ledger = NonceLedger::new(2, 0);
+        assert!(ledger.observe(0, id(1), nonce(1), 1_000).is_ok());
+        assert!(ledger.observe(0, id(1), nonce(2), 1_000).is_ok());
+        assert_eq!(
+            ledger.observe(0, id(1), nonce(3), 1_000),
+            Err(AuthorityError::LedgerFull)
+        );
+        // …and the entries that were already there are still there.
+        assert_eq!(
+            ledger.observe(0, id(1), nonce(1), 1_000),
+            Err(AuthorityError::ReplayedNonce)
+        );
+        assert_eq!(ledger.len(), 2);
+    }
+
+    #[test]
+    fn a_full_ledger_still_names_a_replay_a_replay() {
+        let mut ledger = NonceLedger::new(1, 0);
+        assert!(ledger.observe(0, id(1), nonce(1), 1_000).is_ok());
+        assert_eq!(
+            ledger.observe(0, id(1), nonce(1), 1_000),
+            Err(AuthorityError::ReplayedNonce)
+        );
+    }
+
+    #[test]
+    fn expiry_reclaims_and_reports() {
+        let mut ledger = NonceLedger::new(8, 0);
+        assert!(ledger.observe(0, id(1), nonce(1), 100).is_ok());
+        assert!(ledger.observe(0, id(1), nonce(2), 200).is_ok());
+        assert_eq!(ledger.expire(150), 1);
+        assert_eq!(ledger.len(), 1);
+        assert!(!ledger.is_empty());
+    }
+
+    #[test]
+    fn the_key_never_renders_its_bytes() {
+        let key = NonceKey {
+            authority_id: id(1),
+            nonce: nonce(1),
+        };
+        assert_eq!(format!("{key:?}"), "NonceKey(<redacted>)");
+    }
+}

--- a/rs/crates/f2z-authority/src/types.rs
+++ b/rs/crates/f2z-authority/src/types.rs
@@ -1,0 +1,498 @@
+//! The newtypes an assertion is built from, and the charset rule that makes a
+//! handle a handle.
+//!
+//! Fixed-width values follow `f2z-codec`'s `opaque_fixed!` pattern verbatim,
+//! **including the trap that pattern exists for**: `tls_codec`'s own byte
+//! vectors derive `Debug` and render their contents as a list of decimal
+//! integers, so any type that wraps one and derives `Debug` prints every byte
+//! it holds the moment somebody logs the structure containing it. A decimal
+//! dump is a dump. Every `Debug` below is therefore hand-written, and none of
+//! them offers an alternate formatter that renders the bytes — an escape hatch
+//! would be found and used.
+
+use alloc::vec::Vec;
+use core::fmt;
+
+use f2z_codec::hash::hash;
+use tls_codec::{DeserializeBytes, Error as TlsError, SerializeBytes, Size};
+
+use crate::error::AuthorityError;
+use crate::labels::{LABEL_AUTHORITY_ID, LABEL_HANDLE_ID};
+
+/// Declare a fixed-width byte newtype with a redacting `Debug` and the three
+/// `tls_codec` traits delegated to `[u8; N]`.
+///
+/// A local copy of `f2z-codec`'s macro rather than a re-export: that one is
+/// private to its crate, and the alternative — making it public — would export
+/// a macro whose whole job is to be applied carefully, in one place, by
+/// somebody who has read why.
+macro_rules! opaque_fixed {
+    ($(#[$meta:meta])* $name:ident, $len:expr) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name([u8; $len]);
+
+        impl $name {
+            #[doc = concat!("The wire width of a `", stringify!($name), "`, in bytes.")]
+            pub const LEN: usize = $len;
+
+            #[doc = concat!("Wrap ", stringify!($len), " bytes.")]
+            #[must_use]
+            pub const fn new(bytes: [u8; $len]) -> Self {
+                Self(bytes)
+            }
+
+            /// Borrow the bytes.
+            #[must_use]
+            pub const fn as_bytes(&self) -> &[u8; $len] {
+                &self.0
+            }
+
+            /// Wrap a slice of exactly the right length.
+            ///
+            /// # Errors
+            ///
+            /// [`AuthorityError::Malformed`] if the slice is a different length.
+            pub fn from_slice(bytes: &[u8]) -> Result<Self, AuthorityError> {
+                let array: [u8; $len] =
+                    bytes.try_into().map_err(|_| AuthorityError::Malformed)?;
+                Ok(Self(array))
+            }
+        }
+
+        impl From<[u8; $len]> for $name {
+            fn from(bytes: [u8; $len]) -> Self {
+                Self(bytes)
+            }
+        }
+
+        impl AsRef<[u8]> for $name {
+            fn as_ref(&self) -> &[u8] {
+                &self.0
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(concat!(stringify!($name), "(<redacted>)"))
+            }
+        }
+
+        impl Size for $name {
+            fn tls_serialized_len(&self) -> usize {
+                $len
+            }
+        }
+
+        impl SerializeBytes for $name {
+            fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+                self.0.tls_serialize()
+            }
+        }
+
+        impl DeserializeBytes for $name {
+            fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+                let (array, rest) = <[u8; $len]>::tls_deserialize_bytes(bytes)?;
+                Ok((Self(array), rest))
+            }
+        }
+    };
+}
+
+opaque_fixed!(
+    /// A key id: `authority_id = H("free2z/kt/v1/authority-id", authority_pk)`.
+    ///
+    /// Derived rather than assigned, so rotation is a set-membership change and
+    /// nothing else — see [`AuthoritySet`]. An operator cannot mislabel a key,
+    /// because the label *is* the key.
+    ///
+    /// [`AuthoritySet`]: crate::authority::AuthoritySet
+    AuthorityId,
+    32
+);
+
+opaque_fixed!(
+    /// The log this assertion is for (`KT.md` §6.1).
+    ///
+    /// An assertion naming a different log is refused rather than ignored: an
+    /// authority that vouches for `@alice` on one log has said nothing about
+    /// `@alice` on another, and treating the field as advisory would make every
+    /// log in existence a replay target for every other log's assertions.
+    LogId,
+    32
+);
+
+opaque_fixed!(
+    /// `handle_id = H("free2z/kt/v1/handle-id", handle)`.
+    HandleId,
+    32
+);
+
+opaque_fixed!(
+    /// The assertion's anti-replay nonce. 16 bytes of issuer CSPRNG.
+    AssertionNonce,
+    16
+);
+
+/// The handle charset: `[a-z0-9_]{1,30}`, ASCII (`WIRE.md` §14.1, `KT.md`
+/// §1.3).
+pub const HANDLE_MAX_LEN: usize = 30;
+
+/// A messaging handle.
+///
+/// # The charset is the security property, and normalization is not part of it
+///
+/// A handle is `[a-z0-9_]{1,30}`, ASCII, **compared as bytes**. `WIRE.md` §14.1
+/// is explicit that *no normalization is performed at comparison time*: a
+/// handle either matches the pattern exactly or it is not a handle. The reason
+/// is that a normalization function is itself the attack surface — which forms
+/// fold to which, is `ﬁ` `fi`, is `ı` `i` — and a charset with one script and no
+/// case makes the whole cross-script homograph class **not exist** rather than
+/// be defended against. So [`Handle::parse`] rejects `Alice`; it does not fold
+/// it. Anything in this crate that compared two handles by any rule other than
+/// byte equality would be reintroducing exactly what §14.1 removed.
+///
+/// It removes an entire class, not every class. `1`/`l` and `0`/`o` are in the
+/// charset and are indistinguishable in most sans-serif faces; that is a
+/// rendering obligation on the client (`THREAT-MODEL.md` §4.10) and nothing
+/// here defends against it.
+///
+/// # There is deliberately no `from_username`
+///
+/// `WIRE.md` §14.3 evaluates eligibility as
+/// `lowercase(username) matches /^[a-z0-9_]{1,30}$/`, and its 2026-08-23
+/// correction records that **`lowercase(username)` is not a unique key**: the
+/// platform's `username` column carries a plain case-*sensitive* `unique=True`,
+/// the case-insensitive check lives only in two serializers, and case-variant
+/// duplicate accounts exist in production today. Two distinct accounts can
+/// therefore fold to one handle.
+///
+/// A `Handle::from_username` here would be a function that silently picks a
+/// winner in the one mapping the entire system rests on. The mapping is the
+/// authority's job — it is precisely the judgement an assertion exists to
+/// record — and this crate refuses to guess at it. What it offers is
+/// [`Handle::parse`], which answers only "are these bytes a handle".
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Handle(Vec<u8>);
+
+impl Handle {
+    /// Whether a byte is in the handle charset.
+    #[must_use]
+    pub const fn is_handle_byte(byte: u8) -> bool {
+        byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'
+    }
+
+    /// Parse bytes as a handle.
+    ///
+    /// # Errors
+    ///
+    /// [`AuthorityError::HandleCharset`] if the bytes are empty, longer than
+    /// [`HANDLE_MAX_LEN`], or contain any byte outside `[a-z0-9_]`. Uppercase
+    /// ASCII is *outside* the charset and is refused, not folded — see the type
+    /// documentation.
+    pub fn parse(bytes: &[u8]) -> Result<Self, AuthorityError> {
+        if bytes.is_empty() || bytes.len() > HANDLE_MAX_LEN {
+            return Err(AuthorityError::HandleCharset);
+        }
+        if !bytes.iter().copied().all(Self::is_handle_byte) {
+            return Err(AuthorityError::HandleCharset);
+        }
+        Ok(Self(bytes.to_vec()))
+    }
+
+    /// The handle bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// The handle as text. Always succeeds: the charset is ASCII.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        core::str::from_utf8(&self.0).unwrap_or("")
+    }
+
+    /// The length in bytes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the handle is empty. It never is — [`Handle::parse`] refuses an
+    /// empty one — but clippy asks for this beside `len`.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// `handle_id = H("free2z/kt/v1/handle-id", handle)`.
+    #[must_use]
+    pub fn handle_id(&self) -> HandleId {
+        HandleId::new(*hash(LABEL_HANDLE_ID, &self.0).as_bytes())
+    }
+}
+
+/// Redacted, and the choice is worth defending.
+///
+/// A handle is not secret — it is how `@alice` is discoverable, and the log
+/// learns it because it has to answer. What it is, is **linkable**: "who asked
+/// about whom" is exactly the interest-in-a-handle metadata `THREAT-MODEL.md`
+/// §4.1 bounds rather than removes, and a `--log-level trace` that prints every
+/// handle a client resolved hands an operator the social graph the bound was
+/// supposed to cost them something. [`Handle::as_str`] exists for the caller
+/// who has decided to render one; `Debug` does not decide that for them.
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Handle(<redacted; {} bytes>)", self.0.len())
+    }
+}
+
+impl Size for Handle {
+    fn tls_serialized_len(&self) -> usize {
+        // `opaque handle<1..30>`: a one-byte length prefix.
+        self.0.len().saturating_add(1)
+    }
+}
+
+impl SerializeBytes for Handle {
+    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        let len = u8::try_from(self.0.len()).map_err(|_| TlsError::InvalidVectorLength)?;
+        if self.0.is_empty() || self.0.len() > HANDLE_MAX_LEN {
+            return Err(TlsError::InvalidVectorLength);
+        }
+        let mut out = Vec::with_capacity(self.tls_serialized_len());
+        out.push(len);
+        out.extend_from_slice(&self.0);
+        Ok(out)
+    }
+}
+
+impl DeserializeBytes for Handle {
+    /// Decoding enforces the charset, so a non-conforming handle cannot
+    /// round-trip through re-encode equality and reach a verification rule as
+    /// bytes-that-decoded.
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (&len, rest) = bytes.split_first().ok_or(TlsError::EndOfStream)?;
+        let len = usize::from(len);
+        if len == 0 || len > HANDLE_MAX_LEN {
+            return Err(TlsError::InvalidVectorLength);
+        }
+        let value = rest.get(..len).ok_or(TlsError::EndOfStream)?;
+        let remainder = rest.get(len..).ok_or(TlsError::EndOfStream)?;
+        let handle = Handle::parse(value).map_err(|_| {
+            TlsError::DecodingError(alloc::string::String::from(
+                "handle outside [a-z0-9_]{1,30}",
+            ))
+        })?;
+        Ok((handle, remainder))
+    }
+}
+
+/// What an assertion is *for* (`bind` or `reset`).
+///
+/// The two are not interchangeable and the verifier ties each to a position in
+/// the handle's entry sequence — see [`crate::authority`]. Splitting them means
+/// an assertion issued to hand somebody a fresh handle cannot be re-presented
+/// to take over an established one.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[repr(u8)]
+pub enum Intent {
+    /// First binding of this handle to an identity key. Valid only at
+    /// `entry_version == 1`.
+    Bind = 1,
+    /// The platform-reset path of ADR 0014: the account behind the handle
+    /// changed hands (or lost its keys) and a new identity key takes over.
+    /// Valid only at `entry_version > 1`.
+    Reset = 2,
+}
+
+impl Intent {
+    /// Both intents, in wire order.
+    pub const ALL: [Self; 2] = [Self::Bind, Self::Reset];
+
+    /// The wire byte.
+    #[must_use]
+    pub const fn code(self) -> u8 {
+        self as u8
+    }
+
+    /// The intent this build knows by that byte, if any.
+    #[must_use]
+    pub const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::Bind),
+            2 => Some(Self::Reset),
+            _ => None,
+        }
+    }
+
+    /// A stable name, for logs and error messages.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Bind => "bind",
+            Self::Reset => "reset",
+        }
+    }
+}
+
+impl fmt::Display for Intent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+impl Size for Intent {
+    fn tls_serialized_len(&self) -> usize {
+        1
+    }
+}
+
+impl SerializeBytes for Intent {
+    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        Ok(alloc::vec![self.code()])
+    }
+}
+
+impl DeserializeBytes for Intent {
+    /// An unknown intent byte is a decode failure, never a default.
+    ///
+    /// `WIRE.md` §3.3 names "unknown variant bytes silently mapped to a
+    /// default" as one of the four things re-encode equality exists to make
+    /// loud. Mapping an unrecognised intent to `bind` would be the worst
+    /// available default: it is the one that creates a handle.
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (&code, rest) = bytes.split_first().ok_or(TlsError::EndOfStream)?;
+        let intent = Self::from_code(code)
+            .ok_or_else(|| TlsError::DecodingError(alloc::format!("unknown intent {code}")))?;
+        Ok((intent, rest))
+    }
+}
+
+/// `authority_id = H("free2z/kt/v1/authority-id", authority_pk)`.
+#[must_use]
+pub fn authority_id(authority_pk: &f2z_codec::types::PublicKey) -> AuthorityId {
+    AuthorityId::new(*hash(LABEL_AUTHORITY_ID, authority_pk.as_bytes()).as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::format;
+    use f2z_codec::canonical::{Canonical, decode_canonical};
+
+    #[test]
+    fn the_charset_is_exactly_a_to_z_zero_to_nine_and_underscore() {
+        for byte in 0u8..=255 {
+            let expected = byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_';
+            assert_eq!(
+                Handle::parse(&[byte]).is_ok(),
+                expected,
+                "byte {byte:#04x} disagreed with the charset"
+            );
+        }
+    }
+
+    #[test]
+    fn uppercase_is_refused_and_never_folded() {
+        assert_eq!(Handle::parse(b"Alice"), Err(AuthorityError::HandleCharset));
+        assert_eq!(Handle::parse(b"ALICE"), Err(AuthorityError::HandleCharset));
+        // …and the lowercase spelling is a different value, not the same one.
+        assert_ne!(
+            Handle::parse(b"alice").unwrap().as_bytes(),
+            b"Alice".as_slice()
+        );
+    }
+
+    #[test]
+    fn the_length_bounds_are_one_and_thirty() {
+        assert_eq!(Handle::parse(b""), Err(AuthorityError::HandleCharset));
+        assert!(Handle::parse(&[b'a'; 30]).is_ok());
+        assert_eq!(
+            Handle::parse(&[b'a'; 31]),
+            Err(AuthorityError::HandleCharset)
+        );
+    }
+
+    #[test]
+    fn non_ascii_is_refused_bytewise() {
+        // The Cyrillic а of WIRE.md §14, UTF-8 encoded. Two bytes, neither of
+        // which is in the charset.
+        assert_eq!(
+            Handle::parse("аlice".as_bytes()),
+            Err(AuthorityError::HandleCharset)
+        );
+    }
+
+    #[test]
+    fn a_handle_round_trips_and_a_bad_one_does_not_decode() {
+        let handle = Handle::parse(b"alice").unwrap();
+        let bytes = handle.encode_canonical().unwrap();
+        assert_eq!(bytes, alloc::vec![5, b'a', b'l', b'i', b'c', b'e']);
+        assert_eq!(decode_canonical::<Handle>(&bytes).unwrap().value(), &handle);
+
+        // Same shape, uppercase payload: refused by the decoder, so it can
+        // never reach a verification rule as bytes-that-decoded.
+        assert!(decode_canonical::<Handle>(&[5, b'A', b'l', b'i', b'c', b'e']).is_err());
+        // Zero length is not a handle either.
+        assert!(decode_canonical::<Handle>(&[0]).is_err());
+    }
+
+    #[test]
+    fn intent_bytes_are_stable_and_unknown_ones_do_not_decode() {
+        assert_eq!(Intent::Bind.code(), 1);
+        assert_eq!(Intent::Reset.code(), 2);
+        for intent in Intent::ALL {
+            assert_eq!(Intent::from_code(intent.code()), Some(intent));
+        }
+        assert_eq!(Intent::from_code(0), None);
+        assert!(decode_canonical::<Intent>(&[0]).is_err());
+        assert!(decode_canonical::<Intent>(&[3]).is_err());
+    }
+
+    #[test]
+    fn debug_never_renders_bytes() {
+        assert_eq!(
+            format!("{:?}", AuthorityId::new([0xab; 32])),
+            "AuthorityId(<redacted>)"
+        );
+        assert_eq!(
+            format!("{:?}", Handle::parse(b"alice").unwrap()),
+            "Handle(<redacted; 5 bytes>)"
+        );
+    }
+
+    #[test]
+    fn handle_id_is_the_digest_of_the_handle_bytes() {
+        let handle = Handle::parse(b"alice").unwrap();
+        assert_eq!(
+            handle.handle_id().as_bytes(),
+            hash(LABEL_HANDLE_ID, b"alice").as_bytes()
+        );
+        assert_ne!(
+            handle.handle_id(),
+            Handle::parse(b"alicf").unwrap().handle_id()
+        );
+    }
+
+    #[test]
+    fn authority_id_matches_the_independent_nonuniform_digest_vector() {
+        // Independently derived with:
+        // printf(label || 00..1f) | b2sum -l 256
+        // The expected bytes are a fixed protocol vector, not another call to
+        // the production hash helper under test.
+        let public_key = f2z_codec::types::PublicKey::new([
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+            0x1c, 0x1d, 0x1e, 0x1f,
+        ]);
+        assert_eq!(
+            authority_id(&public_key).as_bytes(),
+            &[
+                0x6a, 0x83, 0xfd, 0x51, 0xbb, 0x57, 0xde, 0x5c, 0xef, 0x24, 0x71, 0x77, 0xdf, 0xb5,
+                0x63, 0x36, 0xfc, 0xc7, 0x2a, 0x1e, 0x7c, 0x82, 0x2a, 0xd8, 0xc9, 0x2f, 0xf4, 0x76,
+                0xf1, 0x33, 0xad, 0xb2,
+            ]
+        );
+    }
+}

--- a/rs/crates/f2z-authority/tests/adversarial.rs
+++ b/rs/crates/f2z-authority/tests/adversarial.rs
@@ -1,0 +1,1482 @@
+//! Every way a bad assertion must fail, attacked one rule at a time.
+//!
+//! `KT.md` §4.4 says the thing this file exists for, about the layer beneath:
+//!
+//! > `akd` enforces none of it. The library will happily commit any bytes to
+//! > any label. […] a log that skips them produces inclusion, history and
+//! > append-only proofs that verify **perfectly** for entries nobody
+//! > authorized.
+//!
+//! The same is true one level up. The tree can prove that `@alice`'s key was
+//! published and never changed behind anyone's back, and prove it beautifully,
+//! for a handle that was taken by someone who was not Alice. Nothing downstream
+//! of this crate can detect that, which makes each rule below the last place it
+//! can be caught.
+//!
+//! Assertion-path tests start from a submission that passes the experimental
+//! assertion-layer check and break exactly one thing. Routine-path tests are
+//! explicit that this crate does not verify §4.4's DirectoryAuthKey signature
+//! or RotationProof and that their result is partial.
+
+// Test code, run on the host by a person reading the failure. The workspace
+// denies these because a panic in the log's submission path is a remote denial
+// of service; neither hazard exists here.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_authority::{
+    AssertionLayerCheck, AssertionNonce, AuthorityConfig, AuthorityError, AuthorityId,
+    AuthorityKey, AuthoritySet, EntryKind, Handle, HandleAssertion, HandleAssertionTBS, Intent,
+    LogId, NonceLedger, NonceSeen, SigningKey, Submission, Vouch, VouchingStatus,
+};
+use f2z_codec::canonical::{Canonical, decode_canonical};
+use f2z_codec::types::{Digest, PublicKey, Signature};
+
+const NOW_MS: u64 = 1_700_000_000_000;
+const ISSUED_MS: u64 = NOW_MS - 1_000;
+const EXPIRES_MS: u64 = NOW_MS + 60_000;
+
+fn log_id() -> LogId {
+    LogId::new([0x11; 32])
+}
+
+fn authority() -> SigningKey {
+    SigningKey::from_seed(&[0x22; 32])
+}
+
+fn identity() -> SigningKey {
+    SigningKey::from_seed(&[0x33; 32])
+}
+
+fn handle() -> Handle {
+    Handle::parse(b"alice").unwrap()
+}
+
+fn entry_digest() -> Digest {
+    Digest::new([0x44; 32])
+}
+
+fn config() -> AuthorityConfig {
+    AuthorityConfig::with_defaults(
+        log_id(),
+        AuthoritySet::single(authority().public_key()).unwrap(),
+    )
+    .unwrap()
+}
+
+fn ledger() -> NonceLedger {
+    NonceLedger::new(64, f2z_authority::DEFAULT_CLOCK_SKEW_MS)
+}
+
+/// A valid assertion body. Every test starts here and breaks one field.
+fn body() -> HandleAssertionTBS {
+    HandleAssertionTBS::new(
+        &authority().public_key(),
+        log_id(),
+        handle(),
+        identity().public_key(),
+        Intent::Bind,
+        7,
+        ISSUED_MS,
+        EXPIRES_MS,
+        AssertionNonce::new([0x55; 16]),
+    )
+    .unwrap()
+}
+
+/// Sign a body, sign the matching binding, and hand back both.
+fn present(body: HandleAssertionTBS) -> (Vec<u8>, Signature) {
+    let assertion = body.sign(&authority()).unwrap();
+    let binding = config()
+        .binding(
+            &handle(),
+            &identity().public_key(),
+            Some(&assertion),
+            &entry_digest(),
+        )
+        .unwrap();
+    let signature = binding.sign(&identity()).unwrap();
+    (assertion.encode_canonical().unwrap(), signature)
+}
+
+fn submission<'a>(
+    assertion: &'a [u8],
+    identity_signature: &'a Signature,
+    identity_pk: &'a PublicKey,
+    handle: &'a Handle,
+) -> Submission<'a> {
+    Submission {
+        assertion: Some(assertion),
+        kind: EntryKind::InitialBind,
+        handle,
+        identity_pk,
+        entry_version: 1,
+        entry_digest: &ENTRY_DIGEST,
+        identity_signature,
+        previous_identity_pk: None,
+        previous_vouch: None,
+        previous_account_epoch: None,
+    }
+}
+
+static ENTRY_DIGEST: Digest = Digest::new([0x44; 32]);
+
+/// Run the default happy-path submission with one field of the assertion
+/// changed by `mutate`.
+fn check_assertion_with(
+    mutate: impl FnOnce(&mut HandleAssertionTBS),
+) -> Result<Vouch, AuthorityError> {
+    let mut value = body();
+    mutate(&mut value);
+    let (bytes, signature) = present(value);
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    config()
+        .check_assertion_layer(
+            &submission(&bytes, &signature, &identity_pk, &handle),
+            NOW_MS,
+            &mut ledger(),
+        )
+        .map(|checked| checked.vouch())
+}
+
+fn checked_initial_vouch() -> Vouch {
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    config()
+        .check_assertion_layer(
+            &submission(&bytes, &signature, &identity_pk, &handle),
+            NOW_MS,
+            &mut ledger(),
+        )
+        .unwrap()
+        .vouch()
+}
+
+fn historical_vouch(marker: u8) -> Vouch {
+    let vouch = Vouch::By(AuthorityId::new([marker; 32]));
+    assert_ne!(
+        vouch,
+        Vouch::By(f2z_authority::authority_id(&authority().public_key())),
+        "the predecessor fixture must not be the currently configured authority",
+    );
+    vouch
+}
+
+fn check_key_change(
+    previous_vouch: Option<Vouch>,
+    previous_account_epoch: Option<u32>,
+) -> Result<AssertionLayerCheck, AuthorityError> {
+    let incoming = SigningKey::from_seed(&[0x77; 32]);
+    let incoming_pk = incoming.public_key();
+    let outgoing_pk = identity().public_key();
+    let handle = handle();
+    let binding = config()
+        .binding(&handle, &incoming_pk, None, &ENTRY_DIGEST)
+        .unwrap();
+    let signature = binding.sign(&incoming).unwrap();
+    config().check_assertion_layer(
+        &Submission {
+            assertion: None,
+            kind: EntryKind::KeyChange,
+            handle: &handle,
+            identity_pk: &incoming_pk,
+            entry_version: 5,
+            entry_digest: &ENTRY_DIGEST,
+            identity_signature: &signature,
+            previous_identity_pk: Some(&outgoing_pk),
+            previous_vouch,
+            previous_account_epoch,
+        },
+        NOW_MS,
+        &mut ledger(),
+    )
+}
+
+// ----------------------------------------------------------------- the control
+
+#[test]
+fn a_correct_asserted_submission_passes_the_partial_check() {
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let checked = config()
+        .check_assertion_layer(
+            &submission(&bytes, &signature, &identity_pk, &handle),
+            NOW_MS,
+            &mut ledger(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        checked.vouch(),
+        Vouch::By(f2z_authority::authority_id(&authority().public_key()))
+    );
+    assert!(checked.vouch().is_vouched());
+    assert_eq!(checked.handle().as_str(), "alice");
+    assert_eq!(checked.identity_pk(), &identity().public_key());
+    assert_eq!(checked.kind(), EntryKind::InitialBind);
+    assert_eq!(checked.intent(), Some(Intent::Bind));
+    assert_eq!(checked.account_epoch(), 7);
+    assert_eq!(
+        config().status(),
+        VouchingStatus::Vouched { authorities: 1 }
+    );
+}
+
+#[test]
+fn asserted_bind_and_reset_preserve_each_signed_epoch_and_kind() {
+    for account_epoch in [3, 41] {
+        let mut asserted = body();
+        asserted.account_epoch = account_epoch;
+        let (bytes, signature) = present(asserted);
+        let identity_pk = identity().public_key();
+        let handle = handle();
+        let checked = config()
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap();
+
+        assert_eq!(checked.kind(), EntryKind::InitialBind);
+        assert_eq!(checked.account_epoch(), account_epoch);
+    }
+
+    for (previous_account_epoch, asserted_account_epoch) in [(5, 19), (53, 89)] {
+        let mut asserted = body();
+        asserted.intent = Intent::Reset;
+        asserted.account_epoch = asserted_account_epoch;
+        let (bytes, signature) = present(asserted);
+        let identity_pk = identity().public_key();
+        let handle = handle();
+        let outgoing = PublicKey::new([0x66; 32]);
+        let mut reset = submission(&bytes, &signature, &identity_pk, &handle);
+        reset.kind = EntryKind::PlatformReset;
+        reset.entry_version = 9;
+        reset.previous_identity_pk = Some(&outgoing);
+        reset.previous_vouch = Some(historical_vouch(0xf6));
+        reset.previous_account_epoch = Some(previous_account_epoch);
+
+        let checked = config()
+            .check_assertion_layer(&reset, NOW_MS, &mut ledger())
+            .unwrap();
+        assert_eq!(checked.kind(), EntryKind::PlatformReset);
+        assert_eq!(checked.account_epoch(), asserted_account_epoch);
+    }
+}
+
+#[test]
+fn initial_bind_refuses_a_predecessor_epoch_on_both_deployments() {
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let mut asserted = submission(&bytes, &signature, &identity_pk, &handle);
+    asserted.previous_account_epoch = Some(91);
+    assert_eq!(
+        config()
+            .check_assertion_layer(&asserted, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::UnexpectedPriorAccountEpoch
+    );
+
+    let unvouched = AuthorityConfig::with_defaults(log_id(), AuthoritySet::none()).unwrap();
+    let unvouched_signature = unvouched
+        .binding(&handle, &identity_pk, None, &ENTRY_DIGEST)
+        .unwrap()
+        .sign(&identity())
+        .unwrap();
+    let bare = Submission {
+        assertion: None,
+        kind: EntryKind::InitialBind,
+        handle: &handle,
+        identity_pk: &identity_pk,
+        entry_version: 1,
+        entry_digest: &ENTRY_DIGEST,
+        identity_signature: &unvouched_signature,
+        previous_identity_pk: None,
+        previous_vouch: None,
+        previous_account_epoch: Some(37),
+    };
+    assert_eq!(
+        unvouched
+            .check_assertion_layer(&bare, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::UnexpectedPriorAccountEpoch
+    );
+}
+
+#[test]
+fn initial_bind_refuses_a_predecessor_vouch_on_both_deployments() {
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let mut asserted = submission(&bytes, &signature, &identity_pk, &handle);
+    asserted.previous_vouch = Some(historical_vouch(0x71));
+    assert_eq!(
+        config()
+            .check_assertion_layer(&asserted, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::UnexpectedPriorVouch
+    );
+
+    let unvouched = AuthorityConfig::with_defaults(log_id(), AuthoritySet::none()).unwrap();
+    let unvouched_signature = unvouched
+        .binding(&handle, &identity_pk, None, &ENTRY_DIGEST)
+        .unwrap()
+        .sign(&identity())
+        .unwrap();
+    let bare = Submission {
+        assertion: None,
+        kind: EntryKind::InitialBind,
+        handle: &handle,
+        identity_pk: &identity_pk,
+        entry_version: 1,
+        entry_digest: &ENTRY_DIGEST,
+        identity_signature: &unvouched_signature,
+        previous_identity_pk: None,
+        previous_vouch: Some(Vouch::Unvouched),
+        previous_account_epoch: None,
+    };
+    assert_eq!(
+        unvouched
+            .check_assertion_layer(&bare, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::UnexpectedPriorVouch
+    );
+}
+
+#[test]
+fn same_key_check_needs_no_platform_assertion_and_preserves_prior_vouch() {
+    let identity = identity();
+    let identity_pk = identity.public_key();
+    let handle = handle();
+    let binding = config()
+        .binding(&handle, &identity_pk, None, &ENTRY_DIGEST)
+        .unwrap();
+    let signature = binding.sign(&identity).unwrap();
+    let prior_vouch = historical_vouch(0xa1);
+    let submission = Submission {
+        assertion: None,
+        kind: EntryKind::SameKey,
+        handle: &handle,
+        identity_pk: &identity_pk,
+        entry_version: 5,
+        entry_digest: &ENTRY_DIGEST,
+        identity_signature: &signature,
+        previous_identity_pk: Some(&identity_pk),
+        previous_vouch: Some(prior_vouch),
+        previous_account_epoch: Some(7),
+    };
+
+    let checked = config()
+        .check_assertion_layer(&submission, NOW_MS, &mut ledger())
+        .unwrap();
+    assert_eq!(checked.kind(), EntryKind::SameKey);
+    assert_eq!(checked.vouch(), prior_vouch);
+    assert!(checked.vouch().is_vouched());
+    assert_eq!(checked.account_epoch(), 7);
+
+    let mut wrong_shape = submission;
+    let different = PublicKey::new([0x99; 32]);
+    wrong_shape.previous_identity_pk = Some(&different);
+    assert_eq!(
+        config()
+            .check_assertion_layer(&wrong_shape, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::EntryKindMismatch
+    );
+
+    let mut missing_history = submission;
+    missing_history.previous_vouch = None;
+    assert_eq!(
+        config()
+            .check_assertion_layer(&missing_history, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::MissingPriorVouch
+    );
+
+    let mut missing_epoch = submission;
+    missing_epoch.previous_account_epoch = None;
+    assert_eq!(
+        config()
+            .check_assertion_layer(&missing_epoch, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::MissingPriorAccountEpoch
+    );
+}
+
+#[test]
+fn current_authority_configuration_cannot_upgrade_an_unvouched_history() {
+    let identity = identity();
+    let identity_pk = identity.public_key();
+    let handle = handle();
+    let unvouched = AuthorityConfig::with_defaults(log_id(), AuthoritySet::none()).unwrap();
+    let initial_binding = unvouched
+        .binding(&handle, &identity_pk, None, &ENTRY_DIGEST)
+        .unwrap();
+    let initial_signature = initial_binding.sign(&identity).unwrap();
+    let initial = Submission {
+        assertion: None,
+        kind: EntryKind::InitialBind,
+        handle: &handle,
+        identity_pk: &identity_pk,
+        entry_version: 1,
+        entry_digest: &ENTRY_DIGEST,
+        identity_signature: &initial_signature,
+        previous_identity_pk: None,
+        previous_vouch: None,
+        previous_account_epoch: None,
+    };
+    let prior = unvouched
+        .check_assertion_layer(&initial, NOW_MS, &mut ledger())
+        .unwrap()
+        .vouch();
+    assert_eq!(prior, Vouch::Unvouched);
+
+    let routine_binding = config()
+        .binding(&handle, &identity_pk, None, &ENTRY_DIGEST)
+        .unwrap();
+    let routine_signature = routine_binding.sign(&identity).unwrap();
+    let routine = Submission {
+        assertion: None,
+        kind: EntryKind::SameKey,
+        handle: &handle,
+        identity_pk: &identity_pk,
+        entry_version: 2,
+        entry_digest: &ENTRY_DIGEST,
+        identity_signature: &routine_signature,
+        previous_identity_pk: Some(&identity_pk),
+        previous_vouch: Some(prior),
+        previous_account_epoch: Some(0),
+    };
+    let checked = config()
+        .check_assertion_layer(&routine, NOW_MS, &mut ledger())
+        .unwrap();
+    assert_eq!(checked.vouch(), Vouch::Unvouched);
+    assert!(!checked.vouch().is_vouched());
+    assert_eq!(checked.account_epoch(), 0);
+}
+
+#[test]
+fn attacker_controlled_incoming_key_gets_only_a_partial_key_change_check() {
+    let incoming = SigningKey::from_seed(&[0x77; 32]);
+    let incoming_pk = incoming.public_key();
+    let outgoing_pk = identity().public_key();
+    let handle = handle();
+    let binding = config()
+        .binding(&handle, &incoming_pk, None, &ENTRY_DIGEST)
+        .unwrap();
+    let signature = binding.sign(&incoming).unwrap();
+    let prior_vouch = historical_vouch(0xb2);
+    let submission = Submission {
+        assertion: None,
+        kind: EntryKind::KeyChange,
+        handle: &handle,
+        identity_pk: &incoming_pk,
+        entry_version: 5,
+        entry_digest: &ENTRY_DIGEST,
+        identity_signature: &signature,
+        previous_identity_pk: Some(&outgoing_pk),
+        previous_vouch: Some(prior_vouch),
+        previous_account_epoch: Some(31),
+    };
+
+    // Deliberately no outgoing-key RotationProof or DirectoryAuthKey signature
+    // exists in this fixture. The incoming key can therefore obtain only the
+    // explicitly partial assertion-layer type, never a publish authorization.
+    let checked: AssertionLayerCheck = config()
+        .check_assertion_layer(&submission, NOW_MS, &mut ledger())
+        .unwrap();
+    assert_eq!(checked.kind(), EntryKind::KeyChange);
+    assert_eq!(checked.vouch(), prior_vouch);
+    assert_eq!(checked.account_epoch(), 31);
+
+    let mut wrong_shape = submission;
+    wrong_shape.previous_identity_pk = Some(&incoming_pk);
+    assert_eq!(
+        config()
+            .check_assertion_layer(&wrong_shape, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::IdentityUnchanged
+    );
+}
+
+#[test]
+fn key_change_preserves_distinct_predecessor_histories() {
+    for (previous_account_epoch, previous_vouch) in
+        [(11, historical_vouch(0xc3)), (47, historical_vouch(0xd4))]
+    {
+        let checked = check_key_change(Some(previous_vouch), Some(previous_account_epoch)).unwrap();
+        assert_eq!(checked.kind(), EntryKind::KeyChange);
+        assert_eq!(checked.vouch(), previous_vouch);
+        assert_eq!(checked.account_epoch(), previous_account_epoch);
+    }
+}
+
+#[test]
+fn key_change_requires_explicit_previous_vouch() {
+    assert_eq!(
+        check_key_change(None, Some(11)).unwrap_err(),
+        AuthorityError::MissingPriorVouch
+    );
+}
+
+#[test]
+fn key_change_requires_explicit_previous_account_epoch() {
+    assert_eq!(
+        check_key_change(Some(historical_vouch(0xe5)), None).unwrap_err(),
+        AuthorityError::MissingPriorAccountEpoch
+    );
+}
+
+#[test]
+fn experimental_unvouched_initial_check_refuses_the_identity_point_forgery() {
+    use ed25519_dalek::Verifier as _;
+
+    let mut identity_point = [0u8; 32];
+    identity_point[0] = 1;
+    let identity_pk = PublicKey::new(identity_point);
+    let mut signature_bytes = [0u8; 64];
+    signature_bytes[..32].copy_from_slice(&identity_point);
+    let forged = Signature::new(signature_bytes);
+
+    // Positive control: these are not merely bad-looking bytes. Plain dalek
+    // verification accepts this exact key/signature over the exact transcript
+    // that reaches the assertion-layer boundary, so the refusal below depends
+    // on strictness.
+    let config = AuthorityConfig::with_defaults(log_id(), AuthoritySet::none()).unwrap();
+    let handle = handle();
+    let binding = config
+        .binding(&handle, &identity_pk, None, &ENTRY_DIGEST)
+        .unwrap();
+    let message = binding.signing_bytes().unwrap();
+    let raw = ed25519_dalek::VerifyingKey::from_bytes(&identity_point).unwrap();
+    let raw_signature = ed25519_dalek::Signature::from_bytes(forged.as_bytes());
+    assert!(raw.verify(&message, &raw_signature).is_ok());
+
+    let submission = Submission {
+        assertion: None,
+        kind: EntryKind::InitialBind,
+        handle: &handle,
+        identity_pk: &identity_pk,
+        entry_version: 1,
+        entry_digest: &ENTRY_DIGEST,
+        identity_signature: &forged,
+        previous_identity_pk: None,
+        previous_vouch: None,
+        previous_account_epoch: None,
+    };
+    assert_eq!(
+        config
+            .check_assertion_layer(&submission, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::BadIdentitySignature
+    );
+}
+
+#[test]
+fn routine_entry_checks_refuse_a_platform_assertion() {
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let previous = identity_pk;
+    let handle = handle();
+    for kind in [EntryKind::SameKey, EntryKind::KeyChange] {
+        let mut value = submission(&bytes, &signature, &identity_pk, &handle);
+        value.kind = kind;
+        value.entry_version = 2;
+        value.previous_identity_pk = Some(&previous);
+        assert_eq!(
+            config()
+                .check_assertion_layer(&value, NOW_MS, &mut ledger())
+                .unwrap_err(),
+            AuthorityError::UnexpectedAssertion,
+            "{kind:?} accepted a platform assertion"
+        );
+    }
+}
+
+#[test]
+fn routine_entry_checks_still_require_the_identity_binding() {
+    let current = identity().public_key();
+    let prior = PublicKey::new([0x99; 32]);
+    let handle = handle();
+    for (kind, previous) in [
+        (EntryKind::SameKey, &current),
+        (EntryKind::KeyChange, &prior),
+    ] {
+        let submission = Submission {
+            assertion: None,
+            kind,
+            handle: &handle,
+            identity_pk: &current,
+            entry_version: 5,
+            entry_digest: &ENTRY_DIGEST,
+            identity_signature: &Signature::new([0u8; 64]),
+            previous_identity_pk: Some(previous),
+            previous_vouch: Some(Vouch::Unvouched),
+            previous_account_epoch: Some(7),
+        };
+        assert_eq!(
+            config()
+                .check_assertion_layer(&submission, NOW_MS, &mut ledger())
+                .unwrap_err(),
+            AuthorityError::BadIdentitySignature,
+            "{kind:?} bypassed the identity binding"
+        );
+    }
+}
+
+#[test]
+fn platform_reset_requires_its_platform_assertion() {
+    let incoming = SigningKey::from_seed(&[0x77; 32]);
+    let incoming_pk = incoming.public_key();
+    let outgoing_pk = identity().public_key();
+    let handle = handle();
+    let binding = config()
+        .binding(&handle, &incoming_pk, None, &ENTRY_DIGEST)
+        .unwrap();
+    let signature = binding.sign(&incoming).unwrap();
+    let submission = Submission {
+        assertion: None,
+        kind: EntryKind::PlatformReset,
+        handle: &handle,
+        identity_pk: &incoming_pk,
+        entry_version: 5,
+        entry_digest: &ENTRY_DIGEST,
+        identity_signature: &signature,
+        previous_identity_pk: Some(&outgoing_pk),
+        previous_vouch: Some(Vouch::Unvouched),
+        previous_account_epoch: Some(7),
+    };
+    assert_eq!(
+        config()
+            .check_assertion_layer(&submission, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::MissingAssertion
+    );
+}
+
+// ---------------------------------------------------- the six named negatives
+
+#[test]
+fn an_expired_assertion_is_rejected() {
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    // One millisecond past `expires_ms`. The boundary is exclusive: at exactly
+    // `expires_ms` the assertion is already gone.
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                EXPIRES_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::Expired
+    );
+    assert!(
+        config()
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                EXPIRES_MS - 1,
+                &mut ledger(),
+            )
+            .is_ok()
+    );
+}
+
+#[test]
+fn an_assertion_for_another_log_is_rejected() {
+    assert_eq!(
+        check_assertion_with(|body| body.log_id = LogId::new([0x99; 32])).unwrap_err(),
+        AuthorityError::WrongLog
+    );
+}
+
+#[test]
+fn a_replayed_nonce_is_rejected() {
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let mut ledger = ledger();
+    let submission = submission(&bytes, &signature, &identity_pk, &handle);
+
+    assert!(
+        config()
+            .check_assertion_layer(&submission, NOW_MS, &mut ledger)
+            .is_ok()
+    );
+    assert_eq!(
+        config()
+            .check_assertion_layer(&submission, NOW_MS, &mut ledger)
+            .unwrap_err(),
+        AuthorityError::ReplayedNonce
+    );
+}
+
+#[test]
+fn an_over_long_validity_is_rejected_by_the_log_not_the_issuer() {
+    // The issuer signs whatever it likes; the cap is the log's.
+    let over = f2z_authority::DEFAULT_MAX_VALIDITY_MS + 1;
+    assert_eq!(
+        check_assertion_with(|body| body.expires_ms = body.issued_ms + over).unwrap_err(),
+        AuthorityError::ValidityTooLong
+    );
+    // Exactly at the cap is fine — the bound is inclusive.
+    assert!(
+        check_assertion_with(|body| {
+            body.issued_ms = NOW_MS;
+            body.expires_ms = NOW_MS + f2z_authority::DEFAULT_MAX_VALIDITY_MS;
+        })
+        .is_ok()
+    );
+
+    // And a log that publishes a tighter cap gets the tighter cap, over the
+    // same bytes an unmodified log accepts.
+    let strict = AuthorityConfig::new(
+        log_id(),
+        AuthoritySet::single(authority().public_key()).unwrap(),
+        30_000,
+        f2z_authority::DEFAULT_CLOCK_SKEW_MS,
+    )
+    .unwrap();
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    assert_eq!(
+        strict
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::ValidityTooLong
+    );
+}
+
+#[test]
+fn an_assertion_without_a_matching_identity_self_signature_is_rejected() {
+    // **The test the whole design exists for.** A thief holds a perfectly good
+    // assertion — real authority, real signature, in date, right log, right
+    // handle — and cannot produce the one signature that needs the key the
+    // assertion is about.
+    let assertion = body().sign(&authority()).unwrap();
+    let stolen = assertion.encode_canonical().unwrap();
+    let identity_pk = identity().public_key();
+    let handle = handle();
+
+    // 1. No signature to offer: 64 zero bytes is the best a thief can do.
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(&stolen, &Signature::new([0u8; 64]), &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::BadIdentitySignature
+    );
+
+    // 2. Signed with the thief's own key instead. The binding names the
+    //    assertion's identity_pk, and that is the key it is verified under.
+    let thief = SigningKey::from_seed(&[0x66; 32]);
+    let binding = config()
+        .binding(&handle, &identity_pk, Some(&assertion), &entry_digest())
+        .unwrap();
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(
+                    &stolen,
+                    &binding.sign(&thief).unwrap(),
+                    &identity_pk,
+                    &handle
+                ),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::BadIdentitySignature
+    );
+
+    // 3. A real binding, signed by the real identity key, but for a *different*
+    //    submission. Replaying the subject's own signature onto other entry
+    //    bytes fails too, which is why the binding commits to entry_digest.
+    let other = config()
+        .binding(
+            &handle,
+            &identity_pk,
+            Some(&assertion),
+            &Digest::new([0xee; 32]),
+        )
+        .unwrap();
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(
+                    &stolen,
+                    &other.sign(&identity()).unwrap(),
+                    &identity_pk,
+                    &handle
+                ),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::BadIdentitySignature
+    );
+
+    // 4. A binding signed for a different log. Cross-log replay of the
+    //    submitter's own signature.
+    let elsewhere = AuthorityConfig::with_defaults(
+        LogId::new([0x77; 32]),
+        AuthoritySet::single(authority().public_key()).unwrap(),
+    )
+    .unwrap();
+    let foreign = elsewhere
+        .binding(&handle, &identity_pk, Some(&assertion), &entry_digest())
+        .unwrap();
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(
+                    &stolen,
+                    &foreign.sign(&identity()).unwrap(),
+                    &identity_pk,
+                    &handle
+                ),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::BadIdentitySignature
+    );
+}
+
+#[test]
+fn a_non_conforming_handle_never_becomes_a_handle() {
+    // The charset is a type invariant, so the attack has to be made at the
+    // encoding layer: bytes shaped like an assertion whose handle field is not
+    // one. It does not decode, so no verification rule ever sees it.
+    let (bytes, _) = present(body());
+    let position = bytes
+        .windows(5)
+        .position(|window| window == b"alice")
+        .expect("the fixture handle is in the encoding");
+
+    for replacement in [b'A', b'.', b'-', 0x80] {
+        let mut tampered = bytes.clone();
+        tampered[position] = replacement;
+        assert!(
+            decode_canonical::<HandleAssertion>(&tampered).is_err(),
+            "a handle containing {replacement:#04x} decoded"
+        );
+    }
+
+    // And the parser refuses every shape §14.1 excludes, at the front door.
+    for candidate in [
+        &b""[..],
+        b"Alice",
+        b"alice.smith",
+        b"alice-smith",
+        b"alice@free2z",
+        "\u{430}lice".as_bytes(),
+        &[b'a'; 31],
+    ] {
+        assert_eq!(
+            Handle::parse(candidate).unwrap_err(),
+            AuthorityError::HandleCharset
+        );
+    }
+}
+
+// ------------------------------------------------- the rest of the rule table
+
+#[test]
+fn an_assertion_from_an_unconfigured_authority_is_rejected() {
+    let stranger = SigningKey::from_seed(&[0xaa; 32]);
+    let body = HandleAssertionTBS::new(
+        &stranger.public_key(),
+        log_id(),
+        handle(),
+        identity().public_key(),
+        Intent::Bind,
+        7,
+        ISSUED_MS,
+        EXPIRES_MS,
+        AssertionNonce::new([0x55; 16]),
+    )
+    .unwrap();
+    let assertion = body.sign(&stranger).unwrap();
+    let bytes = assertion.encode_canonical().unwrap();
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let binding = config()
+        .binding(&handle, &identity_pk, Some(&assertion), &entry_digest())
+        .unwrap();
+    let signature = binding.sign(&identity()).unwrap();
+
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::UnknownAuthority
+    );
+
+    // …and adding that key to the set is the whole of what it takes to accept
+    // it. Rotation is set membership.
+    let widened = AuthorityConfig::with_defaults(
+        log_id(),
+        AuthoritySet::new(vec![
+            AuthorityKey::new(authority().public_key()),
+            AuthorityKey::new(stranger.public_key()),
+        ])
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(
+        widened
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .is_ok()
+    );
+}
+
+#[test]
+fn an_assertion_the_authority_did_not_sign_is_rejected() {
+    let assertion = body().sign(&SigningKey::from_seed(&[0xbb; 32])).unwrap();
+    // Re-label it as the configured authority's. Only the signature is wrong.
+    let mut forged = assertion.clone();
+    forged.assertion.authority_id = f2z_authority::authority_id(&authority().public_key());
+    let bytes = forged.encode_canonical().unwrap();
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let signature = config()
+        .binding(&handle, &identity_pk, Some(&forged), &entry_digest())
+        .unwrap()
+        .sign(&identity())
+        .unwrap();
+
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::BadAuthoritySignature
+    );
+}
+
+#[test]
+fn an_assertion_that_disagrees_with_itself_or_its_submission_is_rejected() {
+    assert_eq!(
+        check_assertion_with(
+            |body| body.handle_id = handle().handle_id().as_bytes().map(|b| !b).into()
+        )
+        .unwrap_err(),
+        AuthorityError::HandleIdMismatch
+    );
+    assert_eq!(
+        check_assertion_with(|body| {
+            body.handle = Handle::parse(b"bob").unwrap();
+            body.handle_id = body.handle.handle_id();
+        })
+        .unwrap_err(),
+        AuthorityError::HandleMismatch
+    );
+    assert_eq!(
+        check_assertion_with(|body| body.identity_pk = PublicKey::new([0xcc; 32])).unwrap_err(),
+        AuthorityError::IdentityMismatch
+    );
+    assert_eq!(
+        check_assertion_with(|body| {
+            body.label = f2z_codec::types::ShortBytes::new(b"free2z/kt/v1/entry").unwrap();
+        })
+        .unwrap_err(),
+        AuthorityError::WrongLabel
+    );
+}
+
+#[test]
+fn a_backwards_or_empty_validity_window_is_rejected() {
+    assert_eq!(
+        check_assertion_with(|body| body.expires_ms = body.issued_ms).unwrap_err(),
+        AuthorityError::EmptyValidity
+    );
+    assert_eq!(
+        check_assertion_with(|body| body.expires_ms = body.issued_ms - 1).unwrap_err(),
+        AuthorityError::EmptyValidity
+    );
+}
+
+#[test]
+fn an_assertion_issued_too_far_in_the_future_is_rejected() {
+    let skew = f2z_authority::DEFAULT_CLOCK_SKEW_MS;
+    assert_eq!(
+        check_assertion_with(|body| {
+            body.issued_ms = NOW_MS + skew + 1;
+            body.expires_ms = body.issued_ms + 60_000;
+        })
+        .unwrap_err(),
+        AuthorityError::NotYetIssued
+    );
+    // Exactly at the skew is accepted: the allowance is inclusive.
+    assert!(
+        check_assertion_with(|body| {
+            body.issued_ms = NOW_MS + skew;
+            body.expires_ms = body.issued_ms + 60_000;
+        })
+        .is_ok()
+    );
+}
+
+#[test]
+fn intent_is_tied_to_the_position_in_the_entry_sequence() {
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let previous = PublicKey::new([0xdd; 32]);
+
+    // A bind assertion on anything but a first entry.
+    let (bytes, signature) = present(body());
+    let mut later = submission(&bytes, &signature, &identity_pk, &handle);
+    later.kind = EntryKind::PlatformReset;
+    later.entry_version = 2;
+    later.previous_identity_pk = Some(&previous);
+    later.previous_vouch = Some(checked_initial_vouch());
+    later.previous_account_epoch = Some(7);
+    assert_eq!(
+        config()
+            .check_assertion_layer(&later, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::IntentMismatch
+    );
+
+    // A reset assertion on a first entry.
+    let mut reset_body = body();
+    reset_body.intent = Intent::Reset;
+    let (reset_bytes, reset_signature) = present(reset_body);
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(&reset_bytes, &reset_signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::IntentMismatch
+    );
+
+    // entry_version 0 is not a position at all.
+    let mut zeroth = submission(&bytes, &signature, &identity_pk, &handle);
+    zeroth.entry_version = 0;
+    assert_eq!(
+        config()
+            .check_assertion_layer(&zeroth, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::EntryKindMismatch
+    );
+
+    // A reset that the log has no predecessor for.
+    let mut orphan = submission(&reset_bytes, &reset_signature, &identity_pk, &handle);
+    orphan.kind = EntryKind::PlatformReset;
+    orphan.entry_version = 2;
+    orphan.previous_vouch = Some(checked_initial_vouch());
+    orphan.previous_account_epoch = Some(7);
+    assert_eq!(
+        config()
+            .check_assertion_layer(&orphan, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::EntryKindMismatch
+    );
+
+    // A bind whose handle the log already has an entry for.
+    let mut squatted = submission(&bytes, &signature, &identity_pk, &handle);
+    squatted.previous_identity_pk = Some(&previous);
+    assert_eq!(
+        config()
+            .check_assertion_layer(&squatted, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::EntryKindMismatch
+    );
+}
+
+#[test]
+fn a_reset_that_keeps_the_key_it_replaces_is_rejected() {
+    // The stricter reading of KT.md §4.4 — see AuthorityError::IdentityUnchanged.
+    let mut reset_body = body();
+    reset_body.intent = Intent::Reset;
+    reset_body.account_epoch = 8;
+    let (bytes, signature) = present(reset_body);
+    let identity_pk = identity().public_key();
+    let handle = handle();
+
+    let mut no_op = submission(&bytes, &signature, &identity_pk, &handle);
+    no_op.kind = EntryKind::PlatformReset;
+    no_op.entry_version = 2;
+    no_op.previous_identity_pk = Some(&identity_pk);
+    no_op.previous_vouch = Some(checked_initial_vouch());
+    no_op.previous_account_epoch = Some(7);
+    assert_eq!(
+        config()
+            .check_assertion_layer(&no_op, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::IdentityUnchanged
+    );
+
+    // The same assertion against a predecessor it really does replace is fine.
+    let outgoing = PublicKey::new([0xdd; 32]);
+    let mut real = no_op;
+    real.previous_identity_pk = Some(&outgoing);
+    let checked = config()
+        .check_assertion_layer(&real, NOW_MS, &mut ledger())
+        .unwrap();
+    assert_eq!(checked.account_epoch(), 8);
+}
+
+#[test]
+fn an_account_epoch_that_does_not_advance_is_rejected() {
+    let mut reset_body = body();
+    reset_body.intent = Intent::Reset;
+    let (bytes, signature) = present(reset_body);
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let outgoing = PublicKey::new([0xdd; 32]);
+
+    let mut base = submission(&bytes, &signature, &identity_pk, &handle);
+    base.kind = EntryKind::PlatformReset;
+    base.entry_version = 2;
+    base.previous_identity_pk = Some(&outgoing);
+    base.previous_vouch = Some(checked_initial_vouch());
+
+    assert_eq!(
+        config()
+            .check_assertion_layer(&base, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::MissingPriorAccountEpoch
+    );
+
+    let mut advancing = base;
+    advancing.previous_account_epoch = Some(6);
+    assert!(
+        config()
+            .check_assertion_layer(&advancing, NOW_MS, &mut ledger())
+            .is_ok()
+    );
+
+    // The fixture asserts account_epoch 7. Anything already at or past it is a
+    // spent assertion being presented again.
+    for previous in [7u32, 8, u32::MAX] {
+        let mut replayed = base;
+        replayed.previous_account_epoch = Some(previous);
+        assert_eq!(
+            config()
+                .check_assertion_layer(&replayed, NOW_MS, &mut ledger())
+                .unwrap_err(),
+            AuthorityError::AccountEpochRegression,
+            "previous epoch {previous} was accepted"
+        );
+    }
+}
+
+#[test]
+fn non_canonical_assertion_bytes_are_rejected() {
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+
+    let mut trailing = bytes.clone();
+    trailing.push(0);
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(&trailing, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::Malformed
+    );
+
+    let truncated = &bytes[..bytes.len() - 1];
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(truncated, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::Malformed
+    );
+}
+
+#[test]
+fn a_failed_submission_never_burns_the_nonce() {
+    // If a rejection consumed the nonce, anyone who could make a submission
+    // fail could stop the real one — a denial of service on handle
+    // registration, delivered by replaying somebody else's assertion badly.
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let mut ledger = ledger();
+
+    // Fails at the identity binding, which runs before the ledger is touched.
+    assert!(
+        config()
+            .check_assertion_layer(
+                &submission(&bytes, &Signature::new([0u8; 64]), &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger,
+            )
+            .is_err()
+    );
+    assert!(ledger.is_empty());
+
+    // The genuine submission still works.
+    assert!(
+        config()
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger,
+            )
+            .is_ok()
+    );
+    assert_eq!(ledger.len(), 1);
+}
+
+#[test]
+fn a_reused_nonce_across_two_different_assertions_is_still_a_replay() {
+    // Keying the ledger on (authority_id, nonce) rather than on the assertion
+    // digest is what catches this: two distinct claims that the issuer stamped
+    // with one nonce.
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let mut ledger = ledger();
+
+    let (first, first_signature) = present(body());
+    assert!(
+        config()
+            .check_assertion_layer(
+                &submission(&first, &first_signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger,
+            )
+            .is_ok()
+    );
+
+    let mut second_body = body();
+    second_body.account_epoch = 9;
+    let (second, second_signature) = present(second_body);
+    assert_ne!(first, second);
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(&second, &second_signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger,
+            )
+            .unwrap_err(),
+        AuthorityError::ReplayedNonce
+    );
+}
+
+#[test]
+fn a_full_ledger_refuses_rather_than_forgetting() {
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let mut ledger = NonceLedger::new(0, f2z_authority::DEFAULT_CLOCK_SKEW_MS);
+    assert_eq!(
+        config()
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger,
+            )
+            .unwrap_err(),
+        AuthorityError::LedgerFull
+    );
+}
+
+// ---------------------------------------------------- the no-authority deployment
+
+#[test]
+fn experimental_unvouched_mode_is_reported_and_still_demands_a_self_signature() {
+    let config = AuthorityConfig::with_defaults(log_id(), AuthoritySet::none()).unwrap();
+    assert_eq!(config.status(), VouchingStatus::Unvouched);
+    assert!(
+        config.status().to_string().contains("UNVOUCHED"),
+        "the status a client renders must say so in words"
+    );
+
+    let handle = handle();
+    let identity_pk = identity().public_key();
+    let signature = config
+        .binding(&handle, &identity_pk, None, &entry_digest())
+        .unwrap()
+        .sign(&identity())
+        .unwrap();
+
+    let checked = config
+        .check_assertion_layer(
+            &Submission {
+                assertion: None,
+                kind: EntryKind::InitialBind,
+                handle: &handle,
+                identity_pk: &identity_pk,
+                entry_version: 1,
+                entry_digest: &ENTRY_DIGEST,
+                identity_signature: &signature,
+                previous_identity_pk: None,
+                previous_vouch: None,
+                previous_account_epoch: None,
+            },
+            NOW_MS,
+            &mut ledger(),
+        )
+        .unwrap();
+
+    assert_eq!(checked.vouch(), Vouch::Unvouched);
+    assert!(!checked.vouch().is_vouched());
+    assert_eq!(checked.vouch().authority(), None);
+    assert_eq!(checked.vouch().to_string(), "UNVOUCHED");
+    assert_eq!(checked.account_epoch(), 0);
+}
+
+#[test]
+fn the_two_deployments_do_not_leak_into_each_other() {
+    let vouched = config();
+    let unvouched = AuthorityConfig::with_defaults(log_id(), AuthoritySet::none()).unwrap();
+    let handle = handle();
+    let identity_pk = identity().public_key();
+    let (bytes, signature) = present(body());
+
+    // An assertion offered to a log that cannot judge it.
+    assert_eq!(
+        unvouched
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::UnexpectedAssertion
+    );
+
+    // A submission with nothing to show, to a log that requires one.
+    let mut bare = submission(&bytes, &signature, &identity_pk, &handle);
+    bare.assertion = None;
+    assert_eq!(
+        vouched
+            .check_assertion_layer(&bare, NOW_MS, &mut ledger())
+            .unwrap_err(),
+        AuthorityError::MissingAssertion
+    );
+
+    // And an unvouched binding — the one with an all-zero assertion digest —
+    // does not authorize a submission on the vouched log.
+    let zeroed = vouched
+        .binding(&handle, &identity_pk, None, &entry_digest())
+        .unwrap()
+        .sign(&identity())
+        .unwrap();
+    assert_eq!(
+        vouched
+            .check_assertion_layer(
+                &submission(&bytes, &zeroed, &identity_pk, &handle),
+                NOW_MS,
+                &mut ledger(),
+            )
+            .unwrap_err(),
+        AuthorityError::BadIdentitySignature
+    );
+}
+
+// ------------------------------------------------------------- the error codes
+
+#[test]
+fn every_refusal_carries_a_kt_error_code_that_does_not_blame_the_wrong_party() {
+    use f2z_authority::error::{
+        ERR_BAD_AUTHORIZATION, ERR_BAD_SIGNATURE, ERR_INTERNAL, ERR_MALFORMED,
+        ERR_UNSUPPORTED_VERSION,
+    };
+
+    assert_eq!(AuthorityError::Malformed.kt_error_code(), ERR_MALFORMED);
+    assert_eq!(
+        AuthorityError::WrongLog.kt_error_code(),
+        ERR_UNSUPPORTED_VERSION
+    );
+    assert_eq!(
+        AuthorityError::BadIdentitySignature.kt_error_code(),
+        ERR_BAD_SIGNATURE
+    );
+    assert_eq!(
+        AuthorityError::Expired.kt_error_code(),
+        ERR_BAD_AUTHORIZATION
+    );
+    assert_eq!(
+        AuthorityError::EmptyAuthoritySet.kt_error_code(),
+        ERR_INTERNAL
+    );
+    assert!(!AuthorityError::Expired.is_configuration_fault());
+}
+
+#[test]
+fn the_ledger_trait_is_what_a_durable_log_implements() {
+    // A log keeps the ledger in its database; nothing here assumes otherwise.
+    // The property under test is that the assertion-layer check writes through the trait and
+    // through nothing else.
+    struct Counting {
+        inner: NonceLedger,
+        writes: usize,
+    }
+    impl NonceSeen for Counting {
+        fn observe(
+            &mut self,
+            now_ms: u64,
+            authority_id: f2z_authority::AuthorityId,
+            nonce: AssertionNonce,
+            expires_ms: u64,
+        ) -> Result<(), AuthorityError> {
+            self.writes += 1;
+            self.inner.observe(now_ms, authority_id, nonce, expires_ms)
+        }
+    }
+
+    let mut counting = Counting {
+        inner: ledger(),
+        writes: 0,
+    };
+    let (bytes, signature) = present(body());
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    assert!(
+        config()
+            .check_assertion_layer(
+                &submission(&bytes, &signature, &identity_pk, &handle),
+                NOW_MS,
+                &mut counting,
+            )
+            .is_ok()
+    );
+    assert_eq!(counting.writes, 1);
+}

--- a/rs/crates/f2z-authority/tests/cli.rs
+++ b/rs/crates/f2z-authority/tests/cli.rs
@@ -1,0 +1,527 @@
+//! Behavioral coverage for the shipped `f2z-assert` command.
+//!
+//! The binary's small helpers have unit tests, but these tests deliberately
+//! cross the process boundary. That holds command dispatch, option routing and
+//! output selection to the same contracts as the helpers they reach.
+
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use f2z_authority::{HandleAssertion, Intent, SigningKey, authority_id};
+use f2z_codec::canonical::{Canonical as _, decode_canonical};
+
+const FIXED_KEY_SEED: [u8; 32] = [
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+];
+const LOG_ID_BYTES: [u8; 32] = [
+    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+];
+const IDENTITY_PK_BYTES: [u8; 32] = [
+    0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f,
+    0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f,
+];
+const EXPLICIT_NONCE_BYTES: [u8; 16] = [
+    0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f,
+];
+const RAW_AUTHORITY_SEED: [u8; 32] = [
+    0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f,
+    0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f,
+];
+const RAW_ISSUE_SEED: [u8; 32] = [
+    0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+    0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf,
+];
+
+struct TestDirectory(PathBuf);
+
+impl TestDirectory {
+    fn new(name: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "f2z-authority-cli-{name}-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+
+    fn join(&self, name: &str) -> PathBuf {
+        self.0.join(name)
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn path_text(path: &Path) -> &str {
+    path.to_str().unwrap()
+}
+
+fn command(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_f2z-assert"))
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn command_strings(args: &[String]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_f2z-assert"))
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+#[cfg(unix)]
+fn keygen_with_zero_umask(path: &Path) -> Output {
+    Command::new("/bin/sh")
+        .args(["-c", "umask 000; exec \"$@\"", "f2z-authority-cli-test"])
+        .arg(env!("CARGO_BIN_EXE_f2z-assert"))
+        .args(["keygen", "--out", path_text(path)])
+        .output()
+        .unwrap()
+}
+
+#[cfg(not(unix))]
+fn keygen_with_zero_umask(path: &Path) -> Output {
+    command(&["keygen", "--out", path_text(path)])
+}
+
+fn independent_hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(char::from(DIGITS[usize::from(byte >> 4)]));
+        out.push(char::from(DIGITS[usize::from(byte & 0x0f)]));
+    }
+    out
+}
+
+fn independent_unhex(text: &[u8]) -> Vec<u8> {
+    fn nibble(byte: u8) -> u8 {
+        match byte {
+            b'0'..=b'9' => byte - b'0',
+            b'a'..=b'f' => byte - b'a' + 10,
+            _ => panic!("non-lowercase-hex byte {byte:#x}"),
+        }
+    }
+
+    assert_eq!(text.len() % 2, 0);
+    text.chunks_exact(2)
+        .map(|pair| nibble(pair[0]) * 16 + nibble(pair[1]))
+        .collect()
+}
+
+fn fixed_key_file(directory: &TestDirectory) -> (PathBuf, SigningKey) {
+    let path = directory.join("authority.key");
+    let seed = FIXED_KEY_SEED;
+    fs::write(&path, independent_hex(&seed)).unwrap();
+    (path, SigningKey::from_seed(&seed))
+}
+
+fn raw_key_file(directory: &TestDirectory, name: &str, seed: [u8; 32]) -> (PathBuf, SigningKey) {
+    let path = directory.join(name);
+    fs::write(&path, seed).unwrap();
+    (path, SigningKey::from_seed(&seed))
+}
+
+fn valid_issue_arguments(key_path: &Path) -> Vec<String> {
+    vec![
+        "issue".to_owned(),
+        "--key".to_owned(),
+        path_text(key_path).to_owned(),
+        "--log-id".to_owned(),
+        independent_hex(&LOG_ID_BYTES),
+        "--handle".to_owned(),
+        "alice".to_owned(),
+        "--identity-pk".to_owned(),
+        independent_hex(&IDENTITY_PK_BYTES),
+        "--issued-ms".to_owned(),
+        "1000".to_owned(),
+        "--expires-ms".to_owned(),
+        "5000".to_owned(),
+        "--nonce".to_owned(),
+        independent_hex(&EXPLICIT_NONCE_BYTES),
+    ]
+}
+
+fn decode_assertion(bytes: &[u8]) -> HandleAssertion {
+    decode_canonical::<HandleAssertion>(bytes)
+        .unwrap()
+        .value()
+        .clone()
+}
+
+fn assert_authority_signature(assertion: &HandleAssertion, authority: &SigningKey) {
+    let verifier =
+        ed25519_dalek::VerifyingKey::from_bytes(authority.public_key().as_bytes()).unwrap();
+    let signature = ed25519_dalek::Signature::from_bytes(assertion.signature.as_bytes());
+    assert!(
+        verifier
+            .verify_strict(&assertion.assertion.signing_bytes().unwrap(), &signature)
+            .is_ok(),
+        "the emitted assertion was not signed by the --key authority"
+    );
+}
+
+#[test]
+fn keygen_reaches_the_exact_secure_no_clobber_output_path() {
+    let directory = TestDirectory::new("keygen");
+    let path = directory.join("requested.key");
+    let adjacent = directory.join("requested.key.new");
+
+    let first = keygen_with_zero_umask(&path);
+    assert!(
+        first.status.success(),
+        "keygen failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert!(path.is_file(), "keygen did not create the requested path");
+    assert!(!adjacent.exists(), "keygen wrote an adjacent path instead");
+    let original = fs::read(&path).unwrap();
+    assert_eq!(original.len(), 64);
+    let generated_seed = independent_unhex(&original);
+    assert_eq!(generated_seed.len(), 32);
+    // An all-zero 256-bit sample has probability 2^-256 under the production
+    // OS RNG. Treat it as catastrophic output so this boundary test also holds
+    // the post-read handling in `fill_os_random` to the generated key bytes.
+    assert!(
+        generated_seed.iter().any(|byte| *byte != 0),
+        "production keygen emitted a catastrophic all-zero seed"
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    let second = command(&["keygen", "--out", path_text(&path)]);
+    assert!(!second.status.success(), "keygen clobbered an existing key");
+    assert_eq!(fs::read(&path).unwrap(), original);
+}
+
+#[test]
+fn authority_dispatch_reports_the_derived_id_and_public_key_as_hex() {
+    let directory = TestDirectory::new("authority");
+    let (key_path, authority) = fixed_key_file(&directory);
+    let output = command(&["authority", "--key", path_text(&key_path)]);
+    assert!(
+        output.status.success(),
+        "authority failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let public = authority.public_key();
+    let expected = format!(
+        "authority_id  {}\npublic_key    {}\n",
+        independent_hex(authority_id(&public).as_bytes()),
+        independent_hex(public.as_bytes())
+    );
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), expected);
+
+    let unknown = command(&[
+        "authority",
+        "--key",
+        path_text(&key_path),
+        "--bogus",
+        "value",
+    ]);
+    assert!(!unknown.status.success(), "an unknown flag was accepted");
+    assert!(
+        String::from_utf8_lossy(&unknown.stderr).contains("unknown flag --bogus"),
+        "the parser failed for an unrelated reason: {}",
+        String::from_utf8_lossy(&unknown.stderr)
+    );
+}
+
+#[test]
+fn issue_dispatch_maps_every_explicit_option_and_writes_raw_signed_bytes() {
+    let directory = TestDirectory::new("issue-raw");
+    let (key_path, authority) = fixed_key_file(&directory);
+    let output_path = directory.join("assertion.bin");
+    let log_id = independent_hex(&LOG_ID_BYTES);
+    let identity_pk = independent_hex(&IDENTITY_PK_BYTES);
+    let nonce = independent_hex(&EXPLICIT_NONCE_BYTES);
+
+    let output = command(&[
+        "issue",
+        "--key",
+        path_text(&key_path),
+        "--log-id",
+        &log_id,
+        "--handle",
+        "alice",
+        "--identity-pk",
+        &identity_pk,
+        "--intent",
+        "reset",
+        "--account-epoch",
+        "41",
+        "--issued-ms",
+        "16909060",
+        "--expires-ms",
+        "84281096",
+        "--nonce",
+        &nonce,
+        "--out",
+        path_text(&output_path),
+    ]);
+    assert!(
+        output.status.success(),
+        "issue failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bytes = fs::read(&output_path).unwrap();
+    let assertion = decode_assertion(&bytes);
+    let body = &assertion.assertion;
+    assert_eq!(body.authority_id, authority_id(&authority.public_key()));
+    assert_eq!(body.log_id.as_bytes(), &LOG_ID_BYTES);
+    assert_eq!(body.handle.as_bytes(), b"alice");
+    assert_eq!(body.identity_pk.as_bytes(), &IDENTITY_PK_BYTES);
+    assert_eq!(body.intent, Intent::Reset);
+    assert_eq!(body.account_epoch, 41);
+    assert_eq!(body.issued_ms, 16_909_060);
+    assert_eq!(body.expires_ms, 84_281_096);
+    assert_eq!(body.nonce.as_bytes(), &EXPLICIT_NONCE_BYTES);
+    assert_eq!(body.handle_id, body.handle.handle_id());
+    assert_eq!(bytes, assertion.encode_canonical().unwrap());
+    assert_authority_signature(&assertion, &authority);
+}
+
+#[test]
+fn issue_stdout_is_lowercase_hex_and_validity_maps_to_expiry() {
+    let directory = TestDirectory::new("issue-stdout");
+    let (key_path, authority) = fixed_key_file(&directory);
+    let log_id = independent_hex(&LOG_ID_BYTES);
+    let identity_pk = independent_hex(&IDENTITY_PK_BYTES);
+    let nonce = independent_hex(&EXPLICIT_NONCE_BYTES);
+
+    let output = command(&[
+        "issue",
+        "--key",
+        path_text(&key_path),
+        "--log-id",
+        &log_id,
+        "--handle",
+        "bob_7",
+        "--identity-pk",
+        &identity_pk,
+        "--account-epoch",
+        "7",
+        "--issued-ms",
+        "1000",
+        "--validity-ms",
+        "2500",
+        "--nonce",
+        &nonce,
+    ]);
+    assert!(
+        output.status.success(),
+        "issue failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout.last(), Some(&b'\n'));
+    let encoded = output.stdout.strip_suffix(b"\n").unwrap();
+    let bytes = independent_unhex(encoded);
+    assert_eq!(encoded, independent_hex(&bytes).as_bytes());
+
+    let assertion = decode_assertion(&bytes);
+    assert_eq!(assertion.assertion.intent, Intent::Bind);
+    assert_eq!(assertion.assertion.account_epoch, 7);
+    assert_eq!(assertion.assertion.issued_ms, 1_000);
+    assert_eq!(assertion.assertion.expires_ms, 3_500);
+    assert_authority_signature(&assertion, &authority);
+}
+
+#[test]
+fn issue_refuses_an_expiry_before_issuance_through_the_command_path() {
+    let directory = TestDirectory::new("issue-window");
+    let (key_path, _) = fixed_key_file(&directory);
+    let output = command(&[
+        "issue",
+        "--key",
+        path_text(&key_path),
+        "--log-id",
+        &independent_hex(&LOG_ID_BYTES),
+        "--handle",
+        "alice",
+        "--identity-pk",
+        &independent_hex(&IDENTITY_PK_BYTES),
+        "--issued-ms",
+        "2000",
+        "--expires-ms",
+        "1000",
+        "--nonce",
+        &independent_hex(&EXPLICIT_NONCE_BYTES),
+    ]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("expires_ms must be after issued_ms"));
+}
+
+#[test]
+fn keygen_rejects_unknown_flags_through_its_own_command_path() {
+    let output = command(&["keygen", "--bogus", "value"]);
+    assert!(!output.status.success(), "keygen ignored an unknown flag");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unknown flag --bogus"),
+        "keygen failed for an unrelated reason: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "keygen generated a key before refusing"
+    );
+}
+
+#[test]
+fn issue_rejects_unknown_flags_through_its_own_command_path() {
+    let directory = TestDirectory::new("issue-unknown");
+    let (key_path, _) = fixed_key_file(&directory);
+    let mut args = valid_issue_arguments(&key_path);
+    args.extend(["--bogus".to_owned(), "value".to_owned()]);
+    let output = command_strings(&args);
+    assert!(!output.status.success(), "issue ignored an unknown flag");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unknown flag --bogus"),
+        "issue failed for an unrelated reason: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "issue minted an assertion before refusing"
+    );
+}
+
+#[test]
+fn authority_accepts_the_documented_32_byte_raw_key_file() {
+    let directory = TestDirectory::new("authority-raw-key");
+    let (key_path, authority) = raw_key_file(&directory, "authority.raw", RAW_AUTHORITY_SEED);
+    let output = command(&["authority", "--key", path_text(&key_path)]);
+    assert!(
+        output.status.success(),
+        "authority rejected a raw key: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let public = authority.public_key();
+    let expected = format!(
+        "authority_id  {}\npublic_key    {}\n",
+        independent_hex(authority_id(&public).as_bytes()),
+        independent_hex(public.as_bytes())
+    );
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), expected);
+}
+
+#[test]
+fn issue_accepts_the_documented_32_byte_raw_key_file_and_signs_with_it() {
+    let directory = TestDirectory::new("issue-raw-key");
+    let (key_path, authority) = raw_key_file(&directory, "authority.raw", RAW_ISSUE_SEED);
+    let output_path = directory.join("assertion.bin");
+    let mut args = valid_issue_arguments(&key_path);
+    args.extend(["--out".to_owned(), path_text(&output_path).to_owned()]);
+    let output = command_strings(&args);
+    assert!(
+        output.status.success(),
+        "issue rejected a raw key: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let assertion = decode_assertion(&fs::read(output_path).unwrap());
+    assert_eq!(assertion.assertion.log_id.as_bytes(), &LOG_ID_BYTES);
+    assert_eq!(
+        assertion.assertion.identity_pk.as_bytes(),
+        &IDENTITY_PK_BYTES
+    );
+    assert_eq!(assertion.assertion.nonce.as_bytes(), &EXPLICIT_NONCE_BYTES);
+    assert_eq!(
+        assertion.assertion.authority_id,
+        authority_id(&authority.public_key())
+    );
+    assert_authority_signature(&assertion, &authority);
+}
+
+#[test]
+fn explicit_expiry_takes_precedence_over_validity_through_issue() {
+    let directory = TestDirectory::new("issue-expiry-precedence");
+    let (key_path, _) = fixed_key_file(&directory);
+    let output_path = directory.join("assertion.bin");
+    let mut args = valid_issue_arguments(&key_path);
+    args.extend([
+        "--validity-ms".to_owned(),
+        "1".to_owned(),
+        "--out".to_owned(),
+        path_text(&output_path).to_owned(),
+    ]);
+    let output = command_strings(&args);
+    assert!(
+        output.status.success(),
+        "issue rejected valid explicit-expiry input: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let assertion = decode_assertion(&fs::read(output_path).unwrap());
+    assert_eq!(assertion.assertion.issued_ms, 1_000);
+    assert_eq!(assertion.assertion.expires_ms, 5_000);
+}
+
+#[test]
+fn every_subcommand_rejects_positional_arguments_before_doing_work() {
+    let directory = TestDirectory::new("positionals");
+    let (key_path, _) = fixed_key_file(&directory);
+
+    let keygen = command(&["keygen", "positional"]);
+    assert!(
+        !keygen.status.success(),
+        "keygen accepted a positional argument"
+    );
+    assert!(
+        String::from_utf8_lossy(&keygen.stderr).contains("expected a --flag"),
+        "keygen failed for an unrelated reason: {}",
+        String::from_utf8_lossy(&keygen.stderr)
+    );
+    assert!(keygen.stdout.is_empty());
+
+    let authority = command(&["authority", "--key", path_text(&key_path), "positional"]);
+    assert!(
+        !authority.status.success(),
+        "authority accepted a positional argument"
+    );
+    assert!(
+        String::from_utf8_lossy(&authority.stderr).contains("expected a --flag"),
+        "authority failed for an unrelated reason: {}",
+        String::from_utf8_lossy(&authority.stderr)
+    );
+    assert!(authority.stdout.is_empty());
+
+    let mut issue_args = valid_issue_arguments(&key_path);
+    issue_args.push("positional".to_owned());
+    let issue = command_strings(&issue_args);
+    assert!(
+        !issue.status.success(),
+        "issue accepted a positional argument"
+    );
+    assert!(
+        String::from_utf8_lossy(&issue.stderr).contains("expected a --flag"),
+        "issue failed for an unrelated reason: {}",
+        String::from_utf8_lossy(&issue.stderr)
+    );
+    assert!(issue.stdout.is_empty());
+}

--- a/rs/crates/f2z-authority/tests/redaction.rs
+++ b/rs/crates/f2z-authority/tests/redaction.rs
@@ -1,0 +1,288 @@
+//! `--log-level trace` must not become a directory of who talks to whom.
+//!
+//! This crate holds three things worth keeping out of a log file: an issuing
+//! **private key**, an **identity key**, and a **handle**. The first is
+//! obvious. The other two are the social graph: `THREAT-MODEL.md` §4.1 bounds
+//! "who asked about whom" rather than removing it, and a debug print that
+//! records every handle a client resolved hands the operator back exactly what
+//! the bound was supposed to cost them.
+//!
+//! The checks are `f2z-codec`'s, applied to this crate's types, and they are
+//! deliberately paranoid: absence of lowercase hex is not enough. Base16 in
+//! either case, base64url, a **decimal byte list** and any long run of
+//! hex-looking characters are all checked.
+//!
+//! The decimal case is the one that catches real leaks and is the trap
+//! `f2z-codec` documents: `tls_codec`'s own byte vectors derive `Debug` and
+//! print `TlsByteVecU8 { vec: [222, 222, …] }` — a complete dump containing no
+//! hex at all, so a hex-only assertion passes while everything leaks. Every
+//! structure below is checked against all four encodings for that reason.
+
+// Test code, run on the host by a person reading the failure. The workspace
+// denies these because a panic in the log's submission path is a remote denial
+// of service; neither hazard exists here.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_authority::{
+    AssertionNonce, AuthorityConfig, AuthorityId, AuthorityKey, AuthoritySet, Handle,
+    HandleAssertionTBS, Intent, LogId, NonceLedger, SigningKey, Submission, Vouch,
+};
+use f2z_codec::types::{Digest, PublicKey, Signature};
+
+/// A byte pattern distinctive enough that any encoding of it is recognisable.
+const MARKER: u8 = 0xde;
+
+fn base16_lower(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn base16_upper(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02X}")).collect()
+}
+
+fn decimal_list(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|b| b.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn base64url(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::new();
+    for chunk in bytes.chunks(3) {
+        let mut buffer = [0u8; 3];
+        buffer[..chunk.len()].copy_from_slice(chunk);
+        let value =
+            (u32::from(buffer[0]) << 16) | (u32::from(buffer[1]) << 8) | u32::from(buffer[2]);
+        let count = chunk.len() + 1;
+        for index in 0..count {
+            let shift = 18 - 6 * index;
+            out.push(char::from(ALPHABET[((value >> shift) & 0x3f) as usize]));
+        }
+    }
+    out
+}
+
+/// Assert that `rendered` contains no encoding of `secret`, in any of the four
+/// forms a careless `Debug` produces.
+fn assert_absent(rendered: &str, secret: &[u8], what: &str) {
+    for (form, encoded) in [
+        ("base16 lower", base16_lower(secret)),
+        ("base16 upper", base16_upper(secret)),
+        ("decimal list", decimal_list(secret)),
+        ("base64url", base64url(secret)),
+    ] {
+        assert!(
+            !rendered.contains(&encoded),
+            "{what} leaked as {form}: {rendered}"
+        );
+    }
+    // And no long run of hex-looking characters at all, which catches an
+    // encoding nobody thought of.
+    let mut run = 0usize;
+    for character in rendered.chars() {
+        if character.is_ascii_hexdigit() {
+            run += 1;
+            assert!(run < 24, "{what}: a 24-character hex run in {rendered}");
+        } else {
+            run = 0;
+        }
+    }
+}
+
+#[test]
+fn the_fixed_newtypes_redact() {
+    let bytes = [MARKER; 32];
+    for rendered in [
+        format!("{:?}", AuthorityId::new(bytes)),
+        format!("{:?}", LogId::new(bytes)),
+        format!("{:?}", f2z_authority::HandleId::new(bytes)),
+        format!("{:?}", AssertionNonce::new([MARKER; 16])),
+    ] {
+        assert_absent(&rendered, &bytes, "a fixed newtype");
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+    }
+}
+
+#[test]
+fn a_handle_does_not_render_its_text() {
+    let handle = Handle::parse(b"alice").unwrap();
+    let rendered = format!("{handle:?}");
+    assert!(!rendered.contains("alice"), "{rendered}");
+    assert_eq!(rendered, "Handle(<redacted; 5 bytes>)");
+    // …and `as_str` is the deliberate way out, for a caller that has decided to
+    // render one.
+    assert_eq!(handle.as_str(), "alice");
+}
+
+#[test]
+fn a_signing_key_renders_nothing_at_all() {
+    let key = SigningKey::from_seed(&[MARKER; 32]);
+    let rendered = format!("{key:?}");
+    assert_eq!(rendered, "SigningKey(<redacted>)");
+    assert_absent(&rendered, &[MARKER; 32], "an issuing private key");
+}
+
+#[test]
+fn a_whole_assertion_renders_no_key_and_no_handle() {
+    let authority = SigningKey::from_seed(&[MARKER; 32]);
+    let identity = SigningKey::from_seed(&[0xad; 32]);
+    let assertion = HandleAssertionTBS::new(
+        &authority.public_key(),
+        LogId::new([MARKER; 32]),
+        Handle::parse(b"alice").unwrap(),
+        identity.public_key(),
+        Intent::Bind,
+        1,
+        1_000,
+        2_000,
+        AssertionNonce::new([MARKER; 16]),
+    )
+    .unwrap()
+    .sign(&authority)
+    .unwrap();
+
+    let rendered = format!("{assertion:?}");
+    assert!(!rendered.contains("alice"), "{rendered}");
+    assert_absent(&rendered, identity.public_key().as_bytes(), "identity_pk");
+    assert_absent(&rendered, &[MARKER; 32], "the log id and nonce");
+    // The label is the one field that must render: it is the domain separator,
+    // it is a constant, and hiding it would make a `Debug` useless for the one
+    // thing a reader wants from it.
+    assert!(
+        rendered.contains("free2z/kt/v1/handle-assertion"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn an_assertion_layer_check_renders_no_handle_and_no_key() {
+    let authority = SigningKey::from_seed(&[MARKER; 32]);
+    let identity = SigningKey::from_seed(&[0xad; 32]);
+    let log_id = LogId::new([0x11; 32]);
+    let handle = Handle::parse(b"alice").unwrap();
+    let entry_digest = Digest::new([0x44; 32]);
+    let config = AuthorityConfig::with_defaults(
+        log_id,
+        AuthoritySet::single(authority.public_key()).unwrap(),
+    )
+    .unwrap();
+
+    let assertion = HandleAssertionTBS::new(
+        &authority.public_key(),
+        log_id,
+        handle.clone(),
+        identity.public_key(),
+        Intent::Bind,
+        1,
+        1_000,
+        2_000,
+        AssertionNonce::new([0x55; 16]),
+    )
+    .unwrap()
+    .sign(&authority)
+    .unwrap();
+    let bytes = f2z_codec::canonical::encode(&assertion).unwrap();
+    let signature = config
+        .binding(
+            &handle,
+            &identity.public_key(),
+            Some(&assertion),
+            &entry_digest,
+        )
+        .unwrap()
+        .sign(&identity)
+        .unwrap();
+
+    let checked = config
+        .check_assertion_layer(
+            &Submission {
+                assertion: Some(&bytes),
+                kind: f2z_authority::EntryKind::InitialBind,
+                handle: &handle,
+                identity_pk: &identity.public_key(),
+                entry_version: 1,
+                entry_digest: &entry_digest,
+                identity_signature: &signature,
+                previous_identity_pk: None,
+                previous_vouch: None,
+                previous_account_epoch: None,
+            },
+            1_500,
+            &mut NonceLedger::new(8, f2z_authority::DEFAULT_CLOCK_SKEW_MS),
+        )
+        .unwrap();
+
+    let rendered = format!("{checked:?}");
+    assert!(!rendered.contains("alice"), "{rendered}");
+    assert_absent(&rendered, identity.public_key().as_bytes(), "identity_pk");
+    // The verdict itself must be readable: it is the thing an operator is
+    // looking at the log line for, and `Vouch` carries no bytes worth hiding
+    // beyond the authority id, which redacts on its own.
+    assert!(rendered.contains("By("), "{rendered}");
+}
+
+#[test]
+fn the_configuration_renders_no_key_material() {
+    let authority = SigningKey::from_seed(&[MARKER; 32]);
+    let config = AuthorityConfig::with_defaults(
+        LogId::new([MARKER; 32]),
+        AuthoritySet::new(vec![AuthorityKey::new(authority.public_key())]).unwrap(),
+    )
+    .unwrap();
+    let rendered = format!("{config:?}");
+    assert_absent(
+        &rendered,
+        authority.public_key().as_bytes(),
+        "an issuing key",
+    );
+    assert_absent(&rendered, &[MARKER; 32], "the log id");
+}
+
+#[test]
+fn a_submission_renders_neither_the_assertion_bytes_nor_the_signature() {
+    let identity_pk = PublicKey::new([0xad; 32]);
+    let handle = Handle::parse(b"alice").unwrap();
+    let signature = Signature::new([MARKER; 64]);
+    let entry_digest = Digest::new([MARKER; 32]);
+    let assertion = vec![MARKER; 48];
+
+    let submission = Submission {
+        assertion: Some(&assertion),
+        kind: f2z_authority::EntryKind::InitialBind,
+        handle: &handle,
+        identity_pk: &identity_pk,
+        entry_version: 1,
+        entry_digest: &entry_digest,
+        identity_signature: &signature,
+        previous_identity_pk: None,
+        previous_vouch: None,
+        previous_account_epoch: None,
+    };
+    let rendered = format!("{submission:?}");
+
+    assert!(!rendered.contains("alice"), "{rendered}");
+    assert_absent(&rendered, &[MARKER; 32], "the entry digest");
+    assert_absent(&rendered, identity_pk.as_bytes(), "identity_pk");
+    // `assertion` is a bare `&[u8]`. A derived `Debug` renders one as a list of
+    // decimal integers — the documented trap, and the reason `Submission` has a
+    // hand-written `Debug`. This assertion is what keeps it hand-written.
+    assert_absent(&rendered, &assertion, "the assertion bytes");
+    assert!(
+        rendered.contains("Some(<redacted; 48 bytes>)"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn the_unvouched_verdict_says_so_in_words_that_survive_a_log_line() {
+    assert_eq!(Vouch::Unvouched.to_string(), "UNVOUCHED");
+    assert_eq!(format!("{:?}", Vouch::Unvouched), "Unvouched");
+}

--- a/rs/crates/f2z-codec/tests/common/mod.rs
+++ b/rs/crates/f2z-codec/tests/common/mod.rs
@@ -126,7 +126,7 @@ pub fn source_files() -> Vec<SourceFile> {
 /// Strip a line comment, so a brace inside a doc comment does not confuse the
 /// depth count. Struct bodies contain no string literals, so a naive cut is
 /// safe there and a real parser is not worth the dependency; function bodies
-/// do, which is what [`code_only`] is for.
+/// do, which is what [`code_lines`] is for.
 pub fn without_comment(line: &str) -> &str {
     match line.find("//") {
         Some(index) => &line[..index],
@@ -134,51 +134,151 @@ pub fn without_comment(line: &str) -> &str {
     }
 }
 
-/// A line with its string literals, character literals and line comment
-/// removed, so that neither a `{` inside a `format!` nor a `.verify(` inside a
-/// doc comment is read as code.
+/// Source projected to code-only physical lines.
 ///
-/// This is the stricter cousin of [`without_comment`], needed wherever a scan
-/// looks at *function* bodies. It is a lexer, not a parser: a raw string with
-/// an embedded quote (`r#"..."#`) is not modelled, and a block comment is not
-/// modelled. Neither appears in the tree today, and both would make the scan
-/// noisier rather than blinder — a `//`-free `/* ... */` mentioning
-/// `.verify(` would be reported, and the report names a file and a line for a
-/// person to read.
-pub fn code_only(line: &str) -> String {
-    let bytes: Vec<char> = line.chars().collect();
-    let mut out = String::with_capacity(line.len());
+/// Strings, character literals, line comments, and nested block comments are
+/// replaced while newlines are retained. Keeping the physical line count is
+/// what lets a source scan report the real line that violated its rule. A
+/// malformed unterminated string or block comment is a refusal, not permission
+/// to scan a projection whose state is unknown.
+pub fn code_lines(source: &str) -> Vec<String> {
+    fn raw_string_start(chars: &[char], at: usize) -> Option<(usize, usize)> {
+        let mut cursor = at;
+        if matches!(chars.get(cursor), Some('b' | 'c')) {
+            cursor += 1;
+        }
+        if chars.get(cursor) != Some(&'r') {
+            return None;
+        }
+        cursor += 1;
+        let hashes = chars[cursor..]
+            .iter()
+            .take_while(|byte| **byte == '#')
+            .count();
+        cursor += hashes;
+        (chars.get(cursor) == Some(&'"')).then_some((cursor, hashes))
+    }
+
+    let bytes: Vec<char> = source.chars().collect();
+    let mut out = String::with_capacity(source.len());
     let mut index = 0usize;
     while index < bytes.len() {
         let current = bytes[index];
+        if let Some((quote, hashes)) = raw_string_start(&bytes, index) {
+            for _ in index..=quote {
+                out.push(' ');
+            }
+            index = quote + 1;
+            let mut closed = false;
+            while index < bytes.len() {
+                if bytes[index] == '"'
+                    && bytes
+                        .get(index + 1..index + 1 + hashes)
+                        .is_some_and(|suffix| suffix.iter().all(|byte| *byte == '#'))
+                {
+                    out.push(' ');
+                    for _ in 0..hashes {
+                        out.push(' ');
+                    }
+                    index += 1 + hashes;
+                    closed = true;
+                    break;
+                }
+                out.push(if bytes[index] == '\n' { '\n' } else { ' ' });
+                index += 1;
+            }
+            assert!(
+                closed,
+                "unterminated raw string literal: refusing to scan an incomplete Rust projection"
+            );
+            continue;
+        }
         if current == '/' && bytes.get(index + 1) == Some(&'/') {
-            break;
+            while index < bytes.len() && bytes[index] != '\n' {
+                out.push(' ');
+                index += 1;
+            }
+            continue;
+        }
+        if current == '/' && bytes.get(index + 1) == Some(&'*') {
+            out.push(' ');
+            out.push(' ');
+            index += 2;
+            let mut depth = 1usize;
+            while index < bytes.len() && depth > 0 {
+                if bytes[index] == '/' && bytes.get(index + 1) == Some(&'*') {
+                    out.push(' ');
+                    out.push(' ');
+                    index += 2;
+                    depth += 1;
+                } else if bytes[index] == '*' && bytes.get(index + 1) == Some(&'/') {
+                    out.push(' ');
+                    out.push(' ');
+                    index += 2;
+                    depth -= 1;
+                } else {
+                    out.push(if bytes[index] == '\n' { '\n' } else { ' ' });
+                    index += 1;
+                }
+            }
+            assert_eq!(
+                depth, 0,
+                "unterminated block comment: refusing to scan an incomplete Rust projection"
+            );
+            continue;
         }
         if current == '"' {
+            out.push('_');
             index += 1;
+            let mut closed = false;
             while index < bytes.len() {
                 if bytes[index] == '\\' {
+                    out.push(' ');
+                    if bytes.get(index + 1) == Some(&'\n') {
+                        out.push('\n');
+                    } else {
+                        out.push(' ');
+                    }
                     index += 2;
                     continue;
                 }
                 if bytes[index] == '"' {
+                    out.push(' ');
                     index += 1;
+                    closed = true;
                     break;
                 }
+                out.push(if bytes[index] == '\n' { '\n' } else { ' ' });
                 index += 1;
             }
-            // Leave a placeholder so `"a".len()` does not become `.len()`
-            // glued to whatever preceded the literal.
-            out.push('_');
+            assert!(
+                closed,
+                "unterminated string literal: refusing to scan an incomplete Rust projection"
+            );
             continue;
         }
         // A character literal, distinguished from a lifetime by the closing
-        // quote: `'a'` and `'\n'` are literals, `'a` in `&'a str` is not.
+        // quote after exactly one scalar value or one Rust escape.
         if current == '\'' {
-            let escaped = bytes.get(index + 1) == Some(&'\\');
-            let closing = if escaped { index + 3 } else { index + 2 };
+            let content = index + 1;
+            let closing = if bytes.get(content) == Some(&'\\') {
+                match bytes.get(content + 1) {
+                    Some('x') => content + 4,
+                    Some('u') if bytes.get(content + 2) == Some(&'{') => bytes[content + 3..]
+                        .iter()
+                        .position(|byte| *byte == '}')
+                        .map_or(bytes.len(), |offset| content + 4 + offset),
+                    Some(_) => content + 2,
+                    None => bytes.len(),
+                }
+            } else {
+                content + 1
+            };
             if bytes.get(closing) == Some(&'\'') {
                 out.push('_');
+                for _ in index + 1..=closing {
+                    out.push(' ');
+                }
                 index = closing + 1;
                 continue;
             }
@@ -186,7 +286,7 @@ pub fn code_only(line: &str) -> String {
         out.push(current);
         index += 1;
     }
-    out
+    out.lines().map(str::to_owned).collect()
 }
 
 /// True when `haystack` contains `needle` as a whole identifier — not as part
@@ -228,7 +328,7 @@ pub fn is_identifier_char(c: char) -> bool {
 /// exemption that drifted into a shipped code path would stop matching this
 /// and the scan would refuse it.
 pub fn cfg_test_ranges(source: &str) -> Vec<(usize, usize)> {
-    let lines: Vec<String> = source.lines().map(code_only).collect();
+    let lines = code_lines(source);
     let mut ranges = Vec::new();
     let mut index = 0usize;
     while index < lines.len() {
@@ -266,4 +366,52 @@ pub fn in_cfg_test(ranges: &[(usize, usize)], line: usize) -> bool {
     ranges
         .iter()
         .any(|(start, end)| line >= *start && line < *end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::code_lines;
+
+    #[test]
+    fn code_projection_strips_nested_block_comments_without_moving_lines() {
+        let source = "fn verify() {\n  let _ = r#\"not code \" verify_strict /*\"#;\n  let _ = \"not code \\\" verify_strict }\";\n  let _ = '\\u{7d}';\n  // verify_strict\n  /* outer\n     /* inner */ verify_strict\n  */\n  Ok(())\n}";
+        let lines = code_lines(source);
+        let joined = lines.join("\n");
+        assert_eq!(lines.len(), source.lines().count());
+        assert!(joined.contains("fn verify()"));
+        assert!(joined.contains("Ok(())"));
+        assert!(
+            !joined.contains("verify_strict"),
+            "a comment or literal cannot satisfy a source-code contract"
+        );
+        assert_eq!(
+            joined.matches('}').count(),
+            1,
+            "a brace inside a string or character literal moved function depth"
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "unterminated block comment: refusing to scan an incomplete Rust projection"
+    )]
+    fn code_projection_refuses_an_unterminated_block_comment() {
+        let _ = code_lines("fn verify() { /* verify_strict");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "unterminated string literal: refusing to scan an incomplete Rust projection"
+    )]
+    fn code_projection_refuses_an_unterminated_string() {
+        let _ = code_lines("fn verify() { let claim = \"verify_strict");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "unterminated raw string literal: refusing to scan an incomplete Rust projection"
+    )]
+    fn code_projection_refuses_an_unterminated_raw_string() {
+        let _ = code_lines("fn verify() { let claim = r#\"verify_strict");
+    }
 }

--- a/rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs
+++ b/rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs
@@ -150,7 +150,7 @@
 mod common;
 
 use common::{
-    cfg_test_ranges, code_only, contains_identifier, identifier_positions, in_cfg_test,
+    cfg_test_ranges, code_lines, contains_identifier, identifier_positions, in_cfg_test,
     source_files, workspace_crates,
 };
 
@@ -238,6 +238,16 @@ const REGISTERED_NON_STRICT: &[Registered] = &[
         line: "raw.verify(&message, &dalek_signature).is_ok(),",
         why: "the call itself, inside that fixture's assertion",
     },
+    Registered {
+        file: "f2z-authority/src/key.rs",
+        line: "use ed25519_dalek::Verifier as _;",
+        why: "the #603 universal-forgery fixture must positively prove plain verification accepts what strict verification rejects",
+    },
+    Registered {
+        file: "f2z-authority/src/key.rs",
+        line: "raw.verify(&message, &dalek_signature).is_ok(),",
+        why: "the deliberate non-strict call inside the #603 positive control",
+    },
 ];
 
 /// The `.verify(` call sites in this workspace that a naive grep flags and
@@ -265,10 +275,19 @@ const SAFE_WRAPPER_CALL_SITES: &[(&str, &str)] = &[
 /// What makes one of this workspace's own `verify` functions strict.
 enum Strictness {
     /// Its body calls `verify_strict` and contains no non-strict entry point.
-    /// There is exactly one of these, and it is the whole basis for the rest.
-    CallsVerifyStrict,
+    /// Each crate-level wrapper has one of these, and is the basis for that
+    /// crate's delegation chain.
+    CallsVerifyStrict {
+        /// The expression whose strict method must be called.
+        receiver: &'static str,
+    },
     /// Its body calls a registered strict verifier, named `<file>::<fn>`.
-    DelegatesTo(&'static str),
+    DelegatesTo {
+        /// The registered strict function this call resolves to.
+        target: &'static str,
+        /// The local binding on which the wrapper method must be called.
+        receiver: &'static str,
+    },
 }
 
 /// A `fn verify…` defined under `rs/crates/*/src/`, and why it is strict.
@@ -277,6 +296,12 @@ struct VerifyFn {
     file: &'static str,
     /// The function name as written after `fn`.
     name: &'static str,
+    /// Which non-test definition with this name in this file, from zero.
+    ///
+    /// This makes a registry row identify one definition rather than every
+    /// same-name method in the file. An added second `fn verify` therefore
+    /// needs its own row and its own body check.
+    occurrence: usize,
     /// What holds it to strict verification.
     strictness: Strictness,
 }
@@ -295,22 +320,50 @@ const WORKSPACE_VERIFY_FNS: &[VerifyFn] = &[
     VerifyFn {
         file: "f2z-relay-proto/src/key.rs",
         name: "verify",
-        strictness: Strictness::CallsVerifyStrict,
+        occurrence: 0,
+        strictness: Strictness::CallsVerifyStrict { receiver: "self.0" },
     },
     VerifyFn {
         file: "f2z-relay-proto/src/capabilities.rs",
         name: "verify",
-        strictness: Strictness::DelegatesTo("f2z-relay-proto/src/key.rs::verify"),
+        occurrence: 0,
+        strictness: Strictness::DelegatesTo {
+            target: "f2z-relay-proto/src/key.rs::verify",
+            receiver: "key",
+        },
     },
     VerifyFn {
         file: "f2z-relay-proto/src/command.rs",
         name: "verify",
-        strictness: Strictness::DelegatesTo("f2z-relay-proto/src/key.rs::verify"),
+        occurrence: 0,
+        strictness: Strictness::DelegatesTo {
+            target: "f2z-relay-proto/src/key.rs::verify",
+            receiver: "verifying_key",
+        },
     },
     VerifyFn {
         file: "f2z-relay-proto/src/hello.rs",
         name: "verify_hello_response",
-        strictness: Strictness::DelegatesTo("f2z-relay-proto/src/key.rs::verify"),
+        occurrence: 0,
+        strictness: Strictness::DelegatesTo {
+            target: "f2z-relay-proto/src/key.rs::verify",
+            receiver: "identity",
+        },
+    },
+    VerifyFn {
+        file: "f2z-authority/src/key.rs",
+        name: "verify",
+        occurrence: 0,
+        strictness: Strictness::CallsVerifyStrict { receiver: "self.0" },
+    },
+    VerifyFn {
+        file: "f2z-authority/src/authority.rs",
+        name: "verify_binding",
+        occurrence: 0,
+        strictness: Strictness::DelegatesTo {
+            target: "f2z-authority/src/key.rs::verify",
+            receiver: "identity_key",
+        },
     },
 ];
 
@@ -341,7 +394,7 @@ impl Finding {
 /// Returns, for each `use` statement, the index of its first line and the
 /// whole statement's code with comments and literals removed.
 fn use_statements(source: &str) -> Vec<(usize, String)> {
-    let lines: Vec<String> = source.lines().map(code_only).collect();
+    let lines = code_lines(source);
     let mut out = Vec::new();
     let mut index = 0usize;
     while index < lines.len() {
@@ -404,8 +457,7 @@ fn dalek_key_names(source: &str) -> Vec<String> {
 fn dalek_receivers(source: &str) -> Vec<String> {
     let names = dalek_key_names(source);
     let mut receivers = Vec::new();
-    for line in source.lines() {
-        let code = code_only(line);
+    for code in code_lines(source) {
         let trimmed = code.trim();
         let mentions_dalek_key = names.iter().any(|name| {
             if name.contains("::") {
@@ -471,8 +523,7 @@ fn dalek_receivers(source: &str) -> Vec<String> {
 fn chained_lines(source: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut carry = String::new();
-    for line in source.lines() {
-        let code = code_only(line);
+    for code in code_lines(source) {
         let trimmed = code.trim().to_owned();
         let logical = if trimmed.starts_with('.') {
             format!("{carry}{trimmed}")
@@ -489,6 +540,7 @@ fn chained_lines(source: &str) -> Vec<String> {
 fn findings_in(label: &str, source: &str) -> Vec<Finding> {
     let mut findings = Vec::new();
     let lines: Vec<&str> = source.lines().collect();
+    let projected = code_lines(source);
 
     let mut push = |line_index: usize, rule: String| {
         findings.push(Finding {
@@ -510,10 +562,9 @@ fn findings_in(label: &str, source: &str) -> Vec<Finding> {
     // makes the non-strict method callable, and a rule about the *name* rather
     // than about the `use` also covers the fully-qualified form, which needs
     // no import.
-    for (index, line) in source.lines().enumerate() {
-        let code = code_only(line);
+    for (index, code) in projected.iter().enumerate() {
         for trait_name in VERIFIER_TRAITS {
-            if contains_identifier(&code, trait_name) {
+            if contains_identifier(code, trait_name) {
                 push(
                     index,
                     format!(
@@ -549,13 +600,12 @@ fn findings_in(label: &str, source: &str) -> Vec<Finding> {
 
     let receivers = dalek_receivers(source);
     let chained = chained_lines(source);
-    for (index, line) in lines.iter().enumerate() {
-        let code = code_only(line);
+    for (index, code) in projected.iter().enumerate() {
         let logical = chained.get(index).cloned().unwrap_or_default();
 
         // Rule 2: entry points that need no trait import.
         for entry in NON_STRICT_ENTRY_POINTS {
-            let called = identifier_positions(&code, entry).any(|at| {
+            let called = identifier_positions(code, entry).any(|at| {
                 let after = &code[at + entry.len()..];
                 after.starts_with('(') || after.starts_with("::<")
             });
@@ -601,17 +651,14 @@ fn findings_in(label: &str, source: &str) -> Vec<Finding> {
 
 /// The body of `fn <name>` in `source`, from its declaration to the matching
 /// close brace, with comments and literals removed.
-fn function_body(source: &str, name: &str) -> Option<String> {
-    let lines: Vec<String> = source.lines().map(code_only).collect();
-    let declaration = lines.iter().position(|line| {
-        let Some(at) = line.find("fn ") else {
-            return false;
-        };
-        let after = &line[at + 3..];
-        identifier_positions(after, name)
-            .next()
-            .is_some_and(|start| start == 0 && after[name.len()..].starts_with(['(', '<']))
-    })?;
+fn function_body_at_line(source: &str, declaration_line: usize) -> Option<String> {
+    let lines = code_lines(source);
+    let declaration = declaration_line.checked_sub(1)?;
+    let declaration_text = lines.get(declaration)?;
+    assert!(
+        declaration_text.contains("fn "),
+        "line {declaration_line} is registered as a function declaration but is not one"
+    );
 
     let mut body = String::new();
     let mut depth = 0i32;
@@ -631,12 +678,20 @@ fn function_body(source: &str, name: &str) -> Option<String> {
     None
 }
 
+fn function_body(source: &str, name: &str) -> Option<String> {
+    let declaration_line = verify_fn_definitions(source)
+        .into_iter()
+        .find(|(candidate, _, _)| candidate == name)
+        .map(|(_, line, _)| line)?;
+    function_body_at_line(source, declaration_line)
+}
+
 /// Every `fn verify…` defined in `source`, as `(name, line number)`, skipping
 /// `#[test]` functions — a test named `verify_refuses_…` is not a verification
 /// API and registering four of them would only teach a reader to ignore the
 /// list.
-fn verify_fn_definitions(source: &str) -> Vec<(String, usize)> {
-    let lines: Vec<String> = source.lines().map(code_only).collect();
+fn verify_fn_definitions(source: &str) -> Vec<(String, usize, usize)> {
+    let lines = code_lines(source);
     let mut out = Vec::new();
     for (index, line) in lines.iter().enumerate() {
         let Some(at) = line.find("fn ") else {
@@ -660,11 +715,171 @@ fn verify_fn_definitions(source: &str) -> Vec<(String, usize)> {
                 })
                 .any(|previous| previous.contains("#[test]"));
             if !is_test {
-                out.push((name, index + 1));
+                let occurrence = out
+                    .iter()
+                    .filter(|(previous, _, _)| previous == &name)
+                    .count();
+                out.push((name, index + 1, occurrence));
             }
         }
     }
     out
+}
+
+fn registration_matches(entry: &VerifyFn, file: &str, name: &str, occurrence: usize) -> bool {
+    entry.file == file && entry.name == name && entry.occurrence == occurrence
+}
+
+fn calls_method(body: &str, name: &str) -> bool {
+    identifier_positions(body, name).any(|at| {
+        let before = body[..at].trim_end();
+        let after = body[at + name.len()..].trim_start();
+        (before.ends_with('.') || before.ends_with("::"))
+            && (after.starts_with('(') || after.starts_with("::<"))
+    })
+}
+
+fn calls_method_on(body: &str, receiver: &str, name: &str) -> bool {
+    identifier_positions(body, name).any(|at| {
+        let before = body[..at].trim_end();
+        let after = body[at + name.len()..].trim_start();
+        let Some(before_dot) = before.strip_suffix('.') else {
+            return false;
+        };
+        let before_dot = before_dot.trim_end();
+        let Some(receiver_at) = before_dot.len().checked_sub(receiver.len()) else {
+            return false;
+        };
+        identifier_positions(before_dot, receiver).any(|at| at == receiver_at)
+            && (after.starts_with('(') || after.starts_with("::<"))
+    })
+}
+
+/// Whether a registered verifier's body contains the exact call its registry
+/// row promises. Both the live workspace audit and the wrong-receiver negative
+/// controls go through this function, so the policy cannot quietly fall back
+/// from receiver-specific matching to “somebody called a method with that
+/// name.”
+fn registered_body_has_required_call(strictness: &Strictness, body: &str) -> bool {
+    match strictness {
+        Strictness::CallsVerifyStrict { receiver } => {
+            calls_method_on(body, receiver, "verify_strict")
+        }
+        Strictness::DelegatesTo { receiver, .. } => calls_method_on(body, receiver, "verify"),
+    }
+}
+
+#[test]
+fn a_comment_or_unrelated_identifier_cannot_claim_strict_verification() {
+    for fake in [
+        "fn verify() -> Result<(), ()> { /* verify_strict */ Ok(()) }",
+        "fn verify() { /* self.0.verify_strict(message, signature); */ Ok(()) }",
+        "fn verify() -> Result<(), ()> { let verify_strict = (); let _ = verify_strict; Ok(()) }",
+        "fn verify() { fn verify_strict() {} verify_strict(); }",
+        "fn verify() { let _ = self.verify_strict; }",
+    ] {
+        let body = function_body(fake, "verify").unwrap();
+        assert!(
+            !calls_method(&body, "verify_strict"),
+            "inert source text was mistaken for a strict-verification call: {fake}"
+        );
+    }
+    let real = function_body(
+        "fn verify() { self.0.verify_strict(message, signature); }",
+        "verify",
+    )
+    .unwrap();
+    assert!(calls_method(&real, "verify_strict"));
+    assert!(calls_method_on(&real, "self.0", "verify_strict"));
+    assert!(!calls_method_on(&real, "other", "verify_strict"));
+    let wrong_receiver = function_body(
+        "fn verify() { other.verify_strict(message, signature); }",
+        "verify",
+    )
+    .unwrap();
+    assert!(calls_method(&wrong_receiver, "verify_strict"));
+    assert!(!calls_method_on(&wrong_receiver, "self.0", "verify_strict"));
+    let field = function_body("fn verify() { let _ = self.0.verify_strict; }", "verify").unwrap();
+    assert!(!calls_method_on(&field, "self.0", "verify_strict"));
+}
+
+#[test]
+fn the_live_registry_contract_rejects_the_right_method_on_the_wrong_receiver() {
+    let strict = Strictness::CallsVerifyStrict { receiver: "self.0" };
+    let strict_body = function_body(
+        "fn verify() { self.0.verify_strict(message, signature); }",
+        "verify",
+    )
+    .unwrap();
+    let wrong_strict_receiver = function_body(
+        "fn verify() { other.verify_strict(message, signature); }",
+        "verify",
+    )
+    .unwrap();
+    assert!(registered_body_has_required_call(&strict, &strict_body));
+    assert!(!registered_body_has_required_call(
+        &strict,
+        &wrong_strict_receiver
+    ));
+
+    let delegated = Strictness::DelegatesTo {
+        target: "f2z-authority/src/key.rs::verify",
+        receiver: "identity_key",
+    };
+    let delegated_body = function_body(
+        "fn verify_binding() { identity_key.verify(message, signature); }",
+        "verify_binding",
+    )
+    .unwrap();
+    let wrong_delegate_receiver = function_body(
+        "fn verify_binding() { other.verify(message, signature); }",
+        "verify_binding",
+    )
+    .unwrap();
+    assert!(registered_body_has_required_call(
+        &delegated,
+        &delegated_body
+    ));
+    assert!(!registered_body_has_required_call(
+        &delegated,
+        &wrong_delegate_receiver
+    ));
+}
+
+#[test]
+fn duplicate_verify_definitions_cannot_share_one_registry_row() {
+    let source = "
+        impl First { fn verify(&self) { self.0.verify_strict(message, signature); } }
+        impl Second { fn verify(&self) -> Result<(), ()> { Ok(()) } }
+    ";
+    let definitions = verify_fn_definitions(source);
+    assert_eq!(
+        definitions,
+        vec![("verify".to_owned(), 2, 0), ("verify".to_owned(), 3, 1)]
+    );
+    let registered = VerifyFn {
+        file: "fixture/src/key.rs",
+        name: "verify",
+        occurrence: 0,
+        strictness: Strictness::CallsVerifyStrict { receiver: "self.0" },
+    };
+    assert!(registration_matches(
+        &registered,
+        "fixture/src/key.rs",
+        "verify",
+        0
+    ));
+    assert!(!registration_matches(
+        &registered,
+        "fixture/src/key.rs",
+        "verify",
+        1
+    ));
+    let second_body = function_body_at_line(source, definitions[1].1).unwrap();
+    assert!(!registered_body_has_required_call(
+        &registered.strictness,
+        &second_body
+    ));
 }
 
 #[test]
@@ -740,14 +955,14 @@ fn no_crate_verifies_ed25519_signatures_non_strictly() {
 fn every_verify_function_in_the_workspace_is_registered_as_strict() {
     let sources = source_files();
     let mut crates_reached: Vec<String> = Vec::new();
-    let mut found: Vec<(String, String, usize)> = Vec::new();
+    let mut found: Vec<(String, String, usize, usize)> = Vec::new();
 
     for file in &sources {
         if !crates_reached.contains(&file.krate) {
             crates_reached.push(file.krate.clone());
         }
-        for (name, line) in verify_fn_definitions(&file.source) {
-            found.push((file.label.clone(), name, line));
+        for (name, line, occurrence) in verify_fn_definitions(&file.source) {
+            found.push((file.label.clone(), name, line, occurrence));
         }
     }
 
@@ -763,12 +978,14 @@ fn every_verify_function_in_the_workspace_is_registered_as_strict() {
     // Every definition must be registered …
     let unregistered: Vec<String> = found
         .iter()
-        .filter(|(file, name, _)| {
+        .filter(|(file, name, _, occurrence)| {
             !WORKSPACE_VERIFY_FNS
                 .iter()
-                .any(|entry| entry.file == file && entry.name == name)
+                .any(|entry| registration_matches(entry, file, name, *occurrence))
         })
-        .map(|(file, name, line)| format!("{file}:{line}: fn {name}"))
+        .map(|(file, name, line, occurrence)| {
+            format!("{file}:{line}: fn {name} (occurrence {occurrence})")
+        })
         .collect();
     assert!(
         unregistered.is_empty(),
@@ -782,11 +999,11 @@ fn every_verify_function_in_the_workspace_is_registered_as_strict() {
     let missing: Vec<String> = WORKSPACE_VERIFY_FNS
         .iter()
         .filter(|entry| {
-            !found
-                .iter()
-                .any(|(file, name, _)| file == entry.file && name == entry.name)
+            !found.iter().any(|(file, name, _, occurrence)| {
+                registration_matches(entry, file, name, *occurrence)
+            })
         })
-        .map(|entry| format!("{}::{}", entry.file, entry.name))
+        .map(|entry| format!("{}::{}#{}", entry.file, entry.name, entry.occurrence))
         .collect();
     assert!(
         missing.is_empty(),
@@ -801,16 +1018,28 @@ fn every_verify_function_in_the_workspace_is_registered_as_strict() {
             .iter()
             .find(|source| source.label == entry.file)
             .unwrap_or_else(|| panic!("{} is registered but was not walked", entry.file));
-        let body = function_body(&file.source, entry.name).unwrap_or_else(|| {
+        let declaration_line = found
+            .iter()
+            .find(|(found_file, name, _, occurrence)| {
+                registration_matches(entry, found_file, name, *occurrence)
+            })
+            .map(|(_, _, line, _)| *line)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{}::{}#{} is registered but its definition was not found",
+                    entry.file, entry.name, entry.occurrence
+                )
+            });
+        let body = function_body_at_line(&file.source, declaration_line).unwrap_or_else(|| {
             panic!(
-                "could not read the body of {}::{}; this scanner has stopped parsing the source",
-                entry.file, entry.name
+                "could not read the body of {}::{}#{} at line {declaration_line}; this scanner has stopped parsing the source",
+                entry.file, entry.name, entry.occurrence
             )
         });
         match entry.strictness {
-            Strictness::CallsVerifyStrict => {
+            Strictness::CallsVerifyStrict { .. } => {
                 assert!(
-                    contains_identifier(&body, "verify_strict"),
+                    registered_body_has_required_call(&entry.strictness, &body),
                     "{}::{} is registered as calling `verify_strict` and its body no longer \
                      does. Every other verification in this workspace delegates to it, so this \
                      is a universal forgery away from `admit`-style authorization returning Ok \
@@ -819,21 +1048,21 @@ fn every_verify_function_in_the_workspace_is_registered_as_strict() {
                     entry.name
                 );
             }
-            Strictness::DelegatesTo(target) => {
+            Strictness::DelegatesTo { target, .. } => {
                 let (target_file, target_name) = target.rsplit_once("::").unwrap();
                 assert!(
                     WORKSPACE_VERIFY_FNS
                         .iter()
                         .any(|other| other.file == target_file
                             && other.name == target_name
-                            && matches!(other.strictness, Strictness::CallsVerifyStrict)),
+                            && matches!(other.strictness, Strictness::CallsVerifyStrict { .. })),
                     "{}::{} delegates to {target}, which is not registered as a strict \
                      verifier",
                     entry.file,
                     entry.name
                 );
                 assert!(
-                    body.contains(".verify("),
+                    registered_body_has_required_call(&entry.strictness, &body),
                     "{}::{} is registered as delegating to {target} and its body contains no \
                      call to it, so the registration describes something that is not there.",
                     entry.file,

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -60,6 +60,7 @@ MANIFESTS=(
   wallet/plugins/tauri-plugin-zcash/Cargo.toml
   rs/crates/f2z-codec/Cargo.toml
   rs/crates/f2z-relay-proto/Cargo.toml
+  rs/crates/f2z-authority/Cargo.toml
 )
 
 # Other rust-toolchain.toml files. Cargo picks the toolchain from the directory


### PR DESCRIPTION
Closes #603
Closes #604

## Summary

Adds an experimental, standalone f2z-authority crate and CLI for authority assertions without wiring it into the production KT admission path.

- distinguishes InitialBind, SameKey, KeyChange, and PlatformReset admission rules
- permits user-authorized same-key and key-change entries without a platform reset assertion
- uses strict Ed25519 verification with a workspace-wide definition-aware verifier census
- adds hand-derived canonical vectors for every signed structure and independent digest/transcript vectors
- creates issuing keys at the exact requested path with O_EXCL and mode 0600
- exercises real CLI dispatch, parsing, raw/hex key input, field mapping, timestamps, epochs, nonce handling, and output formats

## Scope

This remains an experimental standalone leaf. It does not claim to solve first-entry authorization (#594), production KT integration, or complete E2EE chat authorization.

## Mutation proof

Every security/format guard was broken and shown red before publication. Independent review covered:

- strict to plain verification and identity-point forgery at both key and admission boundaries
- duplicate same-name verifier definitions, wrong receivers, dead/source-only verifier registrations
- entry-kind, epoch, predecessor-vouch, identity-binding, and nonce-order mutations
- every signed-field ordering and production AuthorityConfig binding-map swap/reversal
- CLI dispatch, unknown/positional options, raw/hex mapping, output path/mode/no-clobber, explicit expiry precedence, byte-order, and random-zeroing mutations
- independent nonuniform authority-ID and assertion-digest vectors rather than implementation-derived expectations

Restored workspace tests/docs, WASM, fmt, clippy, deny, toolchain, Actions, and Android policy gates pass. Exact independently approved head: ed57c515b040b6488b209e07131d753b0a6cfb02.
