### PR TITLE
fix(zuuli): mutation-prove native send routes

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -482,6 +482,7 @@ jobs:
         run: >-
           cargo test --locked
           --all-targets
+          --features production-route-probe
           --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
 
   rust_plugin:
@@ -536,7 +537,7 @@ jobs:
           key: zuuli-plugin
 
       - name: Build and test shared Zcash plugin
-        run: cargo test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
+        run: cargo test --locked --all-targets --features production-route-probe --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml
 
   # PR packaging builds only arm64 Android. Keep one cheap 32-bit type-check in
   # the required gate because libc's Android ABI types can differ on armv7; the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,12 +156,25 @@ integrate, and move it forward alongside everything else.
   typecheck+build; Rust `cargo build` of the Tauri backend through the
   librustzcash path deps) on every change to the app, its deps, or the
   `z/zcash/librustzcash` submodule pointer. If a bump breaks us, CI says so.
-- **`scripts/check-librustzcash-compat.mjs` is a source-text change detector,
-  not send-path behavioural coverage.** It pins the reviewed librustzcash
+- **`scripts/check-librustzcash-compat.mjs` is a source-identity change detector,
+  not a transaction oracle.** It pins the reviewed librustzcash
   gitlink, the exact versions of 11 Zcash packages in each of the 3 shipping
   lockfiles that contain that graph, and the API-adaptation source shapes that
-  accompanied the pin. It does not compile or exercise a transaction; the
-  money-affecting behavioural coverage remains tracked in **#547**. To bump
+  accompanied the pin. It also keeps production orchestration compiler-bound
+  to the private native send routes, but it does not prove their behavior.
+  Money-affecting coverage lives in the Rust tests, including
+  `ordinary_values_cross_stateful_shipping_callers_and_exact_recovery_bytes`,
+  an integration test that compiles the plugin library without `cfg(test)` and
+  exercises ordinary fixed-send, send-all, and transaction-creation values
+  through the exact generic stateful production callers. It also proves the
+  returned retry bytes exactly equal the independently re-serialized persisted
+  transaction, rather than merely checking that both artifacts exist. Required
+  plugin test jobs enable its CI-only `production-route-probe` feature; default
+  shipping builds expose none of the private caller authority. The same checker
+  also binds each complete `WalletState` adapter body with a comment- and
+  literal-insensitive digest plus ordered transition anchors, so a feature-only
+  route, dead helper, early return, or post-helper mutation cannot leave the
+  behavior-tested private caller parked behind a green call count. To bump
   librustzcash: move the submodule to reviewed upstream HEAD, regenerate all
   three lockfiles on the pinned toolchain, and inspect the resolved graph before
   changing any expected literal. Then update the reviewed SHA/package versions,

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -187,6 +187,7 @@ const REQUIRED_NATIVE_TESTS_JOB_LINES = [
   "        run: >-",
   "          cargo test --locked",
   "          --all-targets",
+  "          --features production-route-probe",
   "          --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml",
 ];
 const REQUIRED_CRYPTO_TARGET_JOB_LINES = [
@@ -4108,8 +4109,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
       needle:
         "required job rust_plugin step Build and test shared Zcash plugin working-directory differs from its exact reviewed value",
       source: source.replace(
-        "      - name: Build and test shared Zcash plugin\n        run: cargo test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml\n",
-        "      - name: Build and test shared Zcash plugin\n        working-directory: bypass\n        run: cargo test --locked --all-targets --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml\n",
+        "      - name: Build and test shared Zcash plugin\n        run: cargo test --locked --all-targets --features production-route-probe --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml\n",
+        "      - name: Build and test shared Zcash plugin\n        working-directory: bypass\n        run: cargo test --locked --all-targets --features production-route-probe --manifest-path wallet/plugins/tauri-plugin-zcash/Cargo.toml\n",
       ),
     },
     {

--- a/scripts/check-librustzcash-compat.mjs
+++ b/scripts/check-librustzcash-compat.mjs
@@ -87,74 +87,155 @@ function scopeErrors(scope) {
   return errors;
 }
 
-function stripRustComments(source) {
-  let output = "";
-  let state = "code";
-  let blockDepth = 0;
-  for (let index = 0; index < source.length; index += 1) {
-    const current = source[index];
-    const next = source[index + 1];
+function rustCodeOnly(source, stripLiterals = true) {
+  const masked = (value) => value.replace(/[^\r\n]/g, " ");
+  const projectedLiteral = (value) =>
+    stripLiterals ? masked(value) : value;
+  const identifier = (value) => /[A-Za-z0-9_]/.test(value ?? "");
+  const rawStringAt = (index) => {
+    if (identifier(source[index - 1])) return null;
+    let prefixLength = 0;
+    if (source[index] === "r") prefixLength = 1;
+    if (
+      (source[index] === "b" || source[index] === "c") &&
+      source[index + 1] === "r"
+    ) {
+      prefixLength = 2;
+    }
+    if (prefixLength === 0) return null;
 
-    if (state === "line") {
-      if (current === "\n") {
-        output += current;
-        state = "code";
-      } else {
-        output += " ";
-      }
-      continue;
+    let cursor = index + prefixLength;
+    while (source[cursor] === "#") cursor += 1;
+    if (source[cursor] !== '"') return null;
+    const hashes = cursor - index - prefixLength;
+    if (hashes > 255) {
+      throw new Error(
+        `malformed Rust raw string at byte ${index}: more than 255 hashes`,
+      );
     }
-    if (state === "block") {
-      if (current === "/" && next === "*") {
-        blockDepth += 1;
-        output += "  ";
-        index += 1;
-      } else if (current === "*" && next === "/") {
-        blockDepth -= 1;
-        output += "  ";
-        index += 1;
-        if (blockDepth === 0) state = "code";
-      } else {
-        output += current === "\n" ? "\n" : " ";
-      }
-      continue;
-    }
-    if (state === "string" || state === "char") {
-      output += current;
-      if (current === "\\") {
-        if (next !== undefined) {
-          output += next;
-          index += 1;
+    return { content: cursor + 1, hashes };
+  };
+  const quotedEnd = (quote, label) => {
+    for (let cursor = quote + 1; cursor < source.length; cursor += 1) {
+      if (source[cursor] === "\\") {
+        if (cursor + 1 >= source.length) {
+          throw new Error(`unterminated Rust ${label} at byte ${quote}`);
         }
-      } else if (
-        (state === "string" && current === '"') ||
-        (state === "char" && current === "'")
-      ) {
-        state = "code";
+        cursor += 1;
+      } else if (source[cursor] === '"') {
+        return cursor + 1;
       }
+    }
+    throw new Error(`unterminated Rust ${label} at byte ${quote}`);
+  };
+  const characterEnd = (quote, label, required) => {
+    let cursor = quote + 1;
+    if (source[cursor] === "\\") {
+      cursor += 1;
+      if (source[cursor] === "x") {
+        cursor += 3;
+      } else if (source[cursor] === "u" && source[cursor + 1] === "{") {
+        const brace = source.indexOf("}", cursor + 2);
+        if (brace < 0) {
+          throw new Error(`unterminated Rust ${label} at byte ${quote}`);
+        }
+        cursor = brace + 1;
+      } else {
+        cursor += 1;
+      }
+    } else {
+      const point = source.codePointAt(cursor);
+      if (point !== undefined) cursor += point > 0xffff ? 2 : 1;
+    }
+    if (source[cursor] === "'") return cursor + 1;
+    if (required) {
+      throw new Error(`malformed Rust ${label} at byte ${quote}`);
+    }
+    return null;
+  };
+
+  let output = "";
+  let index = 0;
+  while (index < source.length) {
+    if (source.startsWith("//", index)) {
+      const end = source.indexOf("\n", index + 2);
+      const boundary = end < 0 ? source.length : end;
+      output += masked(source.slice(index, boundary));
+      index = boundary;
+      continue;
+    }
+    if (source.startsWith("/*", index)) {
+      let depth = 1;
+      let cursor = index + 2;
+      while (cursor < source.length && depth > 0) {
+        if (source.startsWith("/*", cursor)) {
+          depth += 1;
+          cursor += 2;
+        } else if (source.startsWith("*/", cursor)) {
+          depth -= 1;
+          cursor += 2;
+        } else {
+          cursor += 1;
+        }
+      }
+      if (depth !== 0) {
+        throw new Error(`unterminated Rust block comment at byte ${index}`);
+      }
+      output += masked(source.slice(index, cursor));
+      index = cursor;
       continue;
     }
 
-    if (current === "/" && next === "/") {
-      state = "line";
-      output += "  ";
-      index += 1;
-    } else if (current === "/" && next === "*") {
-      state = "block";
-      blockDepth = 1;
-      output += "  ";
-      index += 1;
-    } else {
-      output += current;
-      if (current === '"') state = "string";
-      if (current === "'") state = "char";
+    const raw = rawStringAt(index);
+    if (raw !== null) {
+      const closing = `"${"#".repeat(raw.hashes)}`;
+      const close = source.indexOf(closing, raw.content);
+      if (close < 0) {
+        throw new Error(`unterminated Rust raw string at byte ${index}`);
+      }
+      const end = close + closing.length;
+      output += projectedLiteral(source.slice(index, end));
+      index = end;
+      continue;
     }
+
+    const prefixedLiteral =
+      !identifier(source[index - 1]) &&
+      (source[index] === "b" || source[index] === "c");
+    if (source[index] === '"' || (prefixedLiteral && source[index + 1] === '"')) {
+      const quote = source[index] === '"' ? index : index + 1;
+      const end = quotedEnd(quote, "string");
+      output += projectedLiteral(source.slice(index, end));
+      index = end;
+      continue;
+    }
+    if (prefixedLiteral && source[index + 1] === "'") {
+      const end = characterEnd(index + 1, "byte character", true);
+      output += projectedLiteral(source.slice(index, end));
+      index = end;
+      continue;
+    }
+    if (source[index] === "'") {
+      const end = characterEnd(index, "character", false);
+      if (end !== null) {
+        output += projectedLiteral(source.slice(index, end));
+        index = end;
+        continue;
+      }
+    }
+
+    output += source[index];
+    index += 1;
   }
   return output;
 }
 
 function normalizedRust(source) {
-  return stripRustComments(source).replace(/\s+/g, " ").trim();
+  return rustCodeOnly(source).replace(/\s+/g, " ").trim();
+}
+
+function normalizedRustWithLiterals(source) {
+  return rustCodeOnly(source, false).replace(/\s+/g, " ").trim();
 }
 
 function occurrences(source, needle) {
@@ -168,12 +249,30 @@ function occurrences(source, needle) {
 }
 
 function rustFunctionBody(source, name) {
-  const marker = `fn ${name}<`;
-  if (occurrences(source, marker) !== 1) return null;
+  const markers = [`fn ${name}<`, `fn ${name}(`];
+  const declarations = [];
+  for (const marker of markers) {
+    let offset = 0;
+    while ((offset = source.indexOf(marker, offset)) !== -1) {
+      declarations.push({ offset, marker });
+      offset += marker.length;
+    }
+  }
+  if (declarations.length !== 1) return null;
 
-  const declaration = source.indexOf(marker);
+  const [{ offset: declaration, marker }] = declarations;
   const bodyStart = source.indexOf("{", declaration + marker.length);
   if (bodyStart < 0) return null;
+  let bracketDepth = 0;
+  for (
+    let index = declaration + marker.length;
+    index < bodyStart;
+    index += 1
+  ) {
+    if (source[index] === "[") bracketDepth += 1;
+    if (source[index] === "]") bracketDepth -= 1;
+    if (source[index] === ";" && bracketDepth === 0) return null;
+  }
 
   let depth = 1;
   for (let index = bodyStart + 1; index < source.length; index += 1) {
@@ -182,6 +281,43 @@ function rustFunctionBody(source, name) {
     if (depth === 0) return source.slice(bodyStart + 1, index).trim();
   }
   return null;
+}
+
+function rustBodyDigest(body) {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+function exactAdapterControlFlowErrors(body, contract) {
+  const errors = [];
+  if (body === null) {
+    return [`${contract.boundary} must remain a unique Rust function body`];
+  }
+  if (/\bcfg\s*!?\s*\(/.test(body)) {
+    errors.push(
+      `${contract.boundary} must compile one control-flow body in tests, probes, and shipping builds`,
+    );
+  }
+
+  let cursor = 0;
+  for (const anchor of contract.orderedAnchors) {
+    const count = occurrences(body, anchor);
+    const index = body.indexOf(anchor, cursor);
+    if (count !== 1 || index < cursor) {
+      errors.push(
+        `${contract.boundary} must preserve its ordered ${contract.transition} control flow`,
+      );
+      break;
+    }
+    cursor = index + anchor.length;
+  }
+
+  const digest = rustBodyDigest(body);
+  if (digest !== contract.digest) {
+    errors.push(
+      `${contract.boundary} complete control-flow body must remain ${contract.digest}, got ${digest}`,
+    );
+  }
+  return errors;
 }
 
 function packageVersions(lock, expectedPackages) {
@@ -207,15 +343,32 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
 
   const orchestrationSource = snapshot.files[SEND_SOURCE];
   const nativePolicySource = snapshot.files[NATIVE_SEND_POLICY_SOURCE];
+  let malformedRust = false;
+  const normalize = (relative, source, keepLiterals = false) => {
+    try {
+      return keepLiterals
+        ? normalizedRustWithLiterals(source)
+        : normalizedRust(source);
+    } catch (error) {
+      malformedRust = true;
+      errors.push(`${relative}: ${error.message}`);
+      return "";
+    }
+  };
+  const send = normalize(NATIVE_SEND_POLICY_SOURCE, nativePolicySource);
+  const orchestration = normalize(SEND_SOURCE, orchestrationSource);
   const outsidePolicySource = snapshot.policyAuthorityPeers
-    .map((relative) => snapshot.files[relative])
+    .map((relative) => normalize(relative, snapshot.files[relative]))
     .join("\n");
-  const send = normalizedRust(nativePolicySource);
-  const orchestration = normalizedRust(orchestrationSource);
+  if (malformedRust) return errors;
 
+  const nativeModuleDeclarations = rustCodeOnly(orchestrationSource)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /\bmod\s+native\s*;/.test(line));
   if (
-    occurrences(orchestrationSource, "mod native;") !== 1 ||
-    occurrences(orchestrationSource, "pub mod native;") !== 0
+    nativeModuleDeclarations.length !== 1 ||
+    nativeModuleDeclarations[0] !== "mod native;"
   ) {
     errors.push(
       "native send policy must remain in one private child module",
@@ -244,15 +397,25 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
   }
   const allowedPolicyExports = [
     "pub(super) fn create_transactions<",
-    "pub(super) fn propose_fixed<",
-    "pub(super) fn propose_send_all_attempt<",
+    "pub(super) fn propose_fixed_validated<",
+    "pub(super) fn propose_send_all_validated<",
   ];
+  // Comments are whitespace in Rust and are already masked above. Canonicalize
+  // visibility token spacing before counting so `pub(super /* comment */)`
+  // cannot make a parent-visible policy function look private to this guard.
+  const visibilityCanonical = send
+    .replace(/\bpub\s*\(\s*super\s*\)/g, "pub(super)")
+    .replace(/\bpub\s*\(\s*crate\s*\)/g, "pub(crate)")
+    .replace(/\bpub\s*\(\s*in\s+/g, "pub(in ");
   if (
-    occurrences(send, "pub(super)") !== allowedPolicyExports.length ||
-    allowedPolicyExports.some((declaration) => occurrences(send, declaration) !== 1) ||
-    occurrences(send, "pub(crate)") !== 0 ||
-    occurrences(send, "pub(in ") !== 0 ||
-    occurrences(send, "pub ") !== 0
+    occurrences(visibilityCanonical, "pub(super)") !==
+      allowedPolicyExports.length ||
+    allowedPolicyExports.some(
+      (declaration) => occurrences(visibilityCanonical, declaration) !== 1,
+    ) ||
+    occurrences(visibilityCanonical, "pub(crate)") !== 0 ||
+    occurrences(visibilityCanonical, "pub(in ") !== 0 ||
+    occurrences(visibilityCanonical, "pub ") !== 0
   ) {
     errors.push(
       "private native send policy module must expose only its three audited safe boundaries",
@@ -281,18 +444,31 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     "propose_with_policy",
   );
   const defaultProposalBoundary = rustFunctionBody(send, "propose_default");
-  const fixedSendBoundary = rustFunctionBody(send, "propose_fixed");
+  const fixedSendBoundary = rustFunctionBody(send, "propose_fixed_validated");
   const sendAllBoundary = rustFunctionBody(
     send,
-    "propose_send_all_attempt",
+    "propose_send_all_validated",
   );
-  const auditedTail =
-    "request, ConfirmationsPolicy::default(), spend_policy, proposal_lock_request(), proposed_transaction_version(),";
+  // Bind the sole authority token to the complete audited invocation. Counting
+  // `propose_transfer::<` and its argument tail independently would let a live
+  // function-item reference vouch for a separate aliased call.
+  const auditedDirectProposalCall = [
+    "propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(",
+    "db,",
+    "params,",
+    "account_id,",
+    "&input_selector,",
+    "&change_strategy,",
+    "request,",
+    "ConfirmationsPolicy::default(),",
+    "spend_policy,",
+    "proposal_lock_request(),",
+    "proposed_transaction_version(),",
+    ")",
+  ].join(" ");
   if (
-    sharedProposalCore === null ||
     occurrences(send, "propose_transfer::<") !== 1 ||
-    occurrences(sharedProposalCore ?? "", "propose_transfer::<") !== 1 ||
-    occurrences(sharedProposalCore ?? "", auditedTail) !== 1
+    occurrences(sharedProposalCore ?? "", auditedDirectProposalCall) !== 1
   ) {
     errors.push(
       "the shared proposal core must remain the only direct propose_transfer authority and consume the exact audited depth, spend, lock, and version decisions",
@@ -312,10 +488,8 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
   const sharedDefaultCall =
     "propose_default(db, params, account_id, request)";
   if (
-    fixedSendBoundary === null ||
-    sendAllBoundary === null ||
-    occurrences(fixedSendBoundary ?? "", sharedDefaultCall) !== 1 ||
-    occurrences(sendAllBoundary ?? "", sharedDefaultCall) !== 1 ||
+    fixedSendBoundary !== sharedDefaultCall ||
+    sendAllBoundary !== sharedDefaultCall ||
     occurrences(send, sharedDefaultCall) !== 2
   ) {
     errors.push(
@@ -323,12 +497,12 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     );
   }
   for (const [boundary, call] of [
-    ["fixed send", "propose_fixed(db, &state.network, account_id, request)"],
+    ["fixed send", "self::native::propose_fixed_validated("],
     [
       "send-all",
-      "propose_send_all_attempt(db, &state.network, account_id, request)",
+      "self::native::propose_send_all_validated(",
     ],
-    ["transaction creation", "create_transactions("],
+    ["transaction creation", "self::native::create_transactions("],
   ]) {
     if (occurrences(orchestration, call) !== 1) {
       errors.push(
@@ -336,8 +510,192 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
       );
     }
   }
+  const fixedProductionRouteBody = rustFunctionBody(
+    orchestration,
+    "propose_fixed_production_route",
+  );
+  const sendAllProductionRouteBody = rustFunctionBody(
+    orchestration,
+    "propose_send_all_production_route",
+  );
+  const creationProductionRouteBody = rustFunctionBody(
+    orchestration,
+    "create_production_recovery_route",
+  );
+  for (const [boundary, body] of [
+    ["fixed-send", fixedProductionRouteBody],
+    ["send-all", sendAllProductionRouteBody],
+    ["transaction-creation", creationProductionRouteBody],
+  ]) {
+    if (body === null || /\bcfg\s*!?\s*\(/.test(body)) {
+      errors.push(
+        `${boundary} production route must compile identically in behavior tests and shipping builds`,
+      );
+    }
+  }
+  const fixedNativeRoute =
+    "let proposal = self::native::propose_fixed_validated(db, params, account_id, amount, request) .map_err";
+  if (
+    occurrences(fixedProductionRouteBody ?? "", fixedNativeRoute) !== 1 ||
+    occurrences(orchestration, fixedNativeRoute) !== 1
+  ) {
+    errors.push(
+      "the behavior-tested fixed-send production route must own its only native proposal call",
+    );
+  }
+  const sendAllNativeRoute =
+    "match self::native::propose_send_all_validated(db, params, account_id, amount, request) {";
+  if (
+    occurrences(sendAllProductionRouteBody ?? "", sendAllNativeRoute) !== 1 ||
+    occurrences(orchestration, sendAllNativeRoute) !== 1
+  ) {
+    errors.push(
+      "the behavior-tested send-all production route must own its only native proposal call",
+    );
+  }
+  const creationNativeRoute =
+    "let txids = self::native::create_transactions(db, params, prover, spending_keys, proposal) .map_err";
+  if (
+    occurrences(creationProductionRouteBody ?? "", creationNativeRoute) !== 1 ||
+    occurrences(orchestration, creationNativeRoute) !== 1
+  ) {
+    errors.push(
+      "the behavior-tested transaction-creation production route must own its only native creation call",
+    );
+  }
+  for (const [boundary, body, route] of [
+    [
+      "fixed-send stateful caller",
+      rustFunctionBody(
+        orchestration,
+        "propose_fixed_stateful_production_caller",
+      ),
+      "propose_fixed_production_route(",
+    ],
+    [
+      "send-all stateful caller",
+      rustFunctionBody(
+        orchestration,
+        "propose_send_all_stateful_production_caller",
+      ),
+      "propose_send_all_production_route(",
+    ],
+    [
+      "transaction-creation stateful caller",
+      rustFunctionBody(
+        orchestration,
+        "execute_send_creation_stateful_production_caller",
+      ),
+      "create_production_recovery_route(",
+    ],
+  ]) {
+    if (
+      occurrences(body ?? "", route) !== 1 ||
+      /\bcfg\s*!?\s*\(/.test(body ?? "")
+    ) {
+      errors.push(
+        `${boundary} must be compiler-bound exactly once to its behavior-tested production route`,
+      );
+    }
+  }
+  // These are independently reviewed identities of the complete normalized
+  // Rust bodies, not values derived from the live source into their expected
+  // result. The ordered anchors make the money/state transitions readable;
+  // the digest closes every unlisted control-flow gap before or after them.
+  const adapterContracts = [
+    {
+      boundary: "fixed-send WalletState adapter",
+      functionName: "propose_send_after_recipient_validation",
+      transition: "proposal construction and accepted-state installation",
+      digest: "a0606b0e0b3e8dcbec2c1a4fc322b36dd14296960fec98ca9023020e7cb6c7ca",
+      orderedAnchors: [
+        "let candidate = propose_fixed_stateful_production_caller( db, &state.network, &recipient, amount, memo_bytes.as_ref(), network_label(&state.network), &wallet_id, &state.proposal_counter, state.send_session_id, );",
+        "drop(db_guard);",
+        "let mut pending_broadcast = state.pending_broadcast.lock().await;",
+        "ensure_no_unresolved_broadcast(pending_broadcast.as_ref())?;",
+        "let mut proposal_guard = state.pending_proposal.lock().await;",
+        "let result = install_accepted_proposal(&mut *proposal_guard, candidate);",
+        "match result {",
+        "*pending_broadcast = None; Ok(output)",
+      ],
+    },
+    {
+      boundary: "send-all WalletState adapter",
+      functionName: "propose_send_all_after_recipient_validation",
+      transition: "proposal construction and exact pending-state installation",
+      digest: "6240360464b39a53bd5ba965df13861a98cbe9466995926c93fbd4ffdb67ccbf",
+      orderedAnchors: [
+        "let (pending, public) = propose_send_all_stateful_production_caller( db, &state.network, &recipient, memo_bytes.as_ref(), network_label(&state.network), spendable, &wallet_id, &state.proposal_counter, state.send_session_id, )?;",
+        "drop(db_guard);",
+        "let mut pending_broadcast = state.pending_broadcast.lock().await;",
+        "ensure_no_unresolved_broadcast(pending_broadcast.as_ref())?;",
+        "*state.pending_proposal.lock().await = Some(pending);",
+        "*pending_broadcast = None;",
+        "Ok(public)",
+      ],
+    },
+    {
+      boundary: "transaction execution WalletState adapter",
+      functionName: "execute_send",
+      transition: "creation, exact-byte persistence, and broadcast",
+      digest: "f36decbe6b267c738c564a748f4ef4802b23cc6895123d3cc8b6f5cda5728913",
+      orderedAnchors: [
+        "persist_pending_broadcast(&state.data_dir, &intent)?;",
+        "*broadcast_guard = Some(intent);",
+        "let spending_keys = SpendingKeys::from_unified_spending_key(usk);",
+        "execute_send_creation_stateful_production_caller( db, &state.network, prover, &spending_keys, &pending_proposal.proposal, &wallet_id, proposal_id, &mut broadcast_guard, || clear_pending_broadcast(&state.data_dir, &wallet_id), )?;",
+        "let record = broadcast_guard .as_ref() .ok_or_else",
+        "persist_pending_broadcast(&state.data_dir, record)?;",
+        "drop(db_guard);",
+        "drop(prover_guard);",
+        "let record = broadcast_guard .as_mut() .ok_or_else",
+        "broadcast_record(state, record).await",
+      ],
+    },
+  ];
+  for (const contract of adapterContracts) {
+    errors.push(
+      ...exactAdapterControlFlowErrors(
+        rustFunctionBody(orchestration, contract.functionName),
+        contract,
+      ),
+    );
+  }
+  const fixedOrchestrationBody = rustFunctionBody(
+    orchestration,
+    "propose_send",
+  );
+  const sendAllOrchestrationBody = rustFunctionBody(
+    orchestration,
+    "propose_send_all",
+  );
+  for (const [boundary, body, expectedBody] of [
+    [
+      "fixed send",
+      fixedOrchestrationBody,
+      [
+        "let (recipient, _) = parse_recipient(&state.network, to)?;",
+        "propose_send_after_recipient_validation(state, recipient, amount, memo).await",
+      ].join(" "),
+    ],
+    [
+      "send-all",
+      sendAllOrchestrationBody,
+      [
+        "let (recipient, _) = parse_recipient(&state.network, to)?;",
+        "propose_send_all_after_recipient_validation(state, recipient, memo).await",
+      ].join(" "),
+    ],
+  ]) {
+    if (body !== expectedBody) {
+      errors.push(
+        `${boundary} must validate its recipient as the sole path into proposal orchestration`,
+      );
+    }
+  }
 
-  const wallet = normalizedRust(snapshot.files[WALLET_SOURCE]);
+  const wallet = normalize(WALLET_SOURCE, snapshot.files[WALLET_SOURCE], true);
+  if (malformedRust) return errors;
   const birthdayFormatter = [
     "pub(crate) fn format_birthday_error(error: BirthdayError) -> String {",
     "match error {",
@@ -486,7 +844,116 @@ function requireFailure(name, snapshot, expected, scope) {
   process.stdout.write(`self-test: killed ${name}\n`);
 }
 
+function runRustLexerSelfTest() {
+  const route = "propose_transfer::<";
+  const fixture = [
+    `// ${route} line comment`,
+    `/* ${route} outer /* ${route} nested */ comment */`,
+    `let normal = "${route}";`,
+    String.raw`let escaped = "escaped quote: \" ${route}";`,
+    `let bytes = b"${route}";`,
+    `let c_string = c"${route}";`,
+    `let raw = r#"${route}"#;`,
+    `let raw_hashes = r###"quote " and hash ## ${route}"###;`,
+    `let raw_bytes = br##"quote " before ${route}"##;`,
+    `let raw_c_string = cr#"quote " before ${route}"#;`,
+    "let character = '{';",
+    "let byte_character = b'}';",
+    String.raw`let escaped_character = '\'';`,
+    String.raw`let escaped_backslash = '\\';`,
+    String.raw`let hex_byte_character = b'\x7b';`,
+    String.raw`let unicode_character = '\u{7b}';`,
+    "let astral_character = '🦀';",
+    `fn visible<'a>(value: &'a str) { ${route}Visible>(); }`,
+  ].join("\n");
+  const projected = normalizedRust(fixture);
+  if (occurrences(projected, route) !== 1) {
+    throw new Error(
+      `Rust lexical projection must retain only the live route, got ${JSON.stringify(projected)}`,
+    );
+  }
+  if (occurrences(projected, "fn visible<'a>(value: &'a str)") !== 1) {
+    throw new Error(
+      "Rust lexical projection corrupted a lifetime while stripping characters",
+    );
+  }
+  for (const literal of ["\\x7b", "\\u{7b}", "🦀"]) {
+    if (projected.includes(literal)) {
+      throw new Error(
+        `Rust lexical projection failed to strip character literal ${JSON.stringify(literal)}`,
+      );
+    }
+  }
+
+  const malformed = [
+    ['let value = "unterminated', "unterminated Rust string"],
+    ['let value = r##"unterminated"#;', "unterminated Rust raw string"],
+    ['let value = br#"unterminated', "unterminated Rust raw string"],
+    ["let value = b'x;", "malformed Rust byte character"],
+    ["/* unterminated", "unterminated Rust block comment"],
+    [
+      `let value = r${"#".repeat(256)}"invalid"${"#".repeat(256)};`,
+      "more than 255 hashes",
+    ],
+  ];
+  for (const [source, expected] of malformed) {
+    let message = "";
+    try {
+      normalizedRust(source);
+    } catch (error) {
+      message = error.message;
+    }
+    if (!message.includes(expected)) {
+      throw new Error(
+        `malformed Rust must fail closed with ${JSON.stringify(expected)}, got ${JSON.stringify(message)}`,
+      );
+    }
+  }
+  process.stdout.write(
+    `self-test: Rust lexical projection stripped comments/literals and rejected ${malformed.length} malformed inputs\n`,
+  );
+}
+
+function runRustFunctionBodySelfTest() {
+  const fixture = normalizedRust(`
+    async fn plain() { before(); if ready() { nested(); } after(); }
+    fn generic<T>() { direct(); }
+    fn array(value: [u8; 32]) { exact(value); }
+  `);
+  if (
+    rustFunctionBody(fixture, "plain") !==
+      "before(); if ready() { nested(); } after();" ||
+    rustFunctionBody(fixture, "generic") !== "direct();" ||
+    rustFunctionBody(fixture, "array") !== "exact(value);"
+  ) {
+    throw new Error(
+      "Rust function extraction must support plain/generic functions, array types, and nested blocks",
+    );
+  }
+  if (rustFunctionBody(`${fixture} fn plain() { duplicate(); }`, "plain") !== null) {
+    throw new Error("duplicate Rust function declarations must fail closed");
+  }
+  const declarationOnly = normalizedRust(
+    "trait Contract { fn missing(); } fn later() { live(); }",
+  );
+  if (rustFunctionBody(declarationOnly, "missing") !== null) {
+    throw new Error("a declaration without a body must fail closed");
+  }
+  if (rustFunctionBody("fn unbalanced() { live();", "unbalanced") !== null) {
+    throw new Error("an unbalanced Rust function body must fail closed");
+  }
+  const missingBodyAfterPrior = normalizedRust("} fn missing()");
+  if (rustFunctionBody(missingBodyAfterPrior, "missing") !== null) {
+    throw new Error("a Rust function without any body delimiter must fail closed");
+  }
+  process.stdout.write(
+    "self-test: Rust function extraction handled both declaration shapes and failed closed\n",
+  );
+}
+
 function runSelfTest() {
+  runRustLexerSelfTest();
+  runRustFunctionBodySelfTest();
   const baseline = liveSnapshot();
   const baselineErrors = validate(baseline);
   if (baselineErrors.length) {
@@ -569,6 +1036,39 @@ function runSelfTest() {
       },
     ],
   ];
+  const fixedAdapterCall = `    let candidate = propose_fixed_stateful_production_caller(
+        db,
+        &state.network,
+        &recipient,
+        amount,
+        memo_bytes.as_ref(),
+        network_label(&state.network),
+        &wallet_id,
+        &state.proposal_counter,
+        state.send_session_id,
+    );`;
+  const sendAllAdapterCall = `    let (pending, public) = propose_send_all_stateful_production_caller(
+        db,
+        &state.network,
+        &recipient,
+        memo_bytes.as_ref(),
+        network_label(&state.network),
+        spendable,
+        &wallet_id,
+        &state.proposal_counter,
+        state.send_session_id,
+    )?;`;
+  const executeAdapterCall = `    execute_send_creation_stateful_production_caller(
+        db,
+        &state.network,
+        prover,
+        &spending_keys,
+        &pending_proposal.proposal,
+        &wallet_id,
+        proposal_id,
+        &mut broadcast_guard,
+        || clear_pending_broadcast(&state.data_dir, &wallet_id),
+    )?;`;
   const cases = [
     [
       "native send policy module becomes public",
@@ -578,6 +1078,39 @@ function runSelfTest() {
         "mod native;",
         "pub mod native;",
         "native send policy module becomes public",
+      ),
+      "one private child module",
+    ],
+    ...["pub(crate)", "pub(super)", "pub(in crate)"].map((visibility) => [
+      `native send policy module gains ${visibility} visibility`,
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "mod native;",
+        `${visibility} mod native;`,
+        `native send policy module gains ${visibility} visibility`,
+      ),
+      "one private child module",
+    ]),
+    [
+      "native send policy module declaration is duplicated",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "mod native;",
+        "mod native;\nmod native;",
+        "duplicate native send policy module declaration",
+      ),
+      "one private child module",
+    ],
+    [
+      "native send policy module declaration disappears",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "mod native;",
+        "// native module declaration removed",
+        "remove native send policy module declaration",
       ),
       "one private child module",
     ],
@@ -593,12 +1126,23 @@ function runSelfTest() {
       "expose only its three audited safe boundaries",
     ],
     [
+      "comment spacing cannot hide parent-visible policy core",
+      mutated(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "fn propose_with_policy<",
+        "pub(super /* visibility mutant */) fn propose_with_policy<",
+        "hide parent-visible policy core behind comment spacing",
+      ),
+      "expose only its three audited safe boundaries",
+    ],
+    [
       "fixed safe boundary loses parent visibility",
       mutated(
         baseline,
         NATIVE_SEND_POLICY_SOURCE,
-        "pub(super) fn propose_fixed<",
-        "fn propose_fixed<",
+        "pub(super) fn propose_fixed_validated<",
+        "fn propose_fixed_validated<",
         "fixed safe boundary loses parent visibility",
       ),
       "expose only its three audited safe boundaries",
@@ -619,8 +1163,8 @@ function runSelfTest() {
       mutated(
         baseline,
         SEND_SOURCE,
-        "use native::{create_transactions, propose_fixed, propose_send_all_attempt};",
-        "use native::{create_transactions, propose_fixed, propose_send_all_attempt};\nuse zcash_client_backend::data_api::wallet::input_selection::SpendPolicy;",
+        "mod native;",
+        "mod native;\nuse zcash_client_backend::data_api::wallet::input_selection::SpendPolicy;",
         "parent imports a forbidden policy type",
       ),
       "SpendPolicy must remain inaccessible",
@@ -630,8 +1174,8 @@ function runSelfTest() {
       mutated(
         baseline,
         SEND_SOURCE,
-        "use native::{create_transactions, propose_fixed, propose_send_all_attempt};",
-        "use native::{create_transactions, propose_fixed, propose_send_all_attempt};\nuse zcash_client_backend::data_api::wallet::propose_transfer as aliased_proposal;",
+        "mod native;",
+        "mod native;\nuse zcash_client_backend::data_api::wallet::propose_transfer as aliased_proposal;",
         "parent aliases direct proposal authority",
       ),
       "propose_transfer must remain inaccessible",
@@ -641,8 +1185,8 @@ function runSelfTest() {
       mutated(
         baseline,
         SEND_SOURCE,
-        "propose_fixed(db, &state.network, account_id, request)",
-        "propose_send_all_attempt(db, &state.network, account_id, request)",
+        "self::native::propose_fixed_validated(",
+        "self::native::propose_send_all_validated(",
         "fixed orchestration drops its only safe boundary",
       ),
       "fixed send orchestration",
@@ -652,11 +1196,414 @@ function runSelfTest() {
       mutated(
         baseline,
         SEND_SOURCE,
-        "propose_send_all_attempt(db, &state.network, account_id, request)",
-        "propose_fixed(db, &state.network, account_id, request)",
+        "self::native::propose_send_all_validated(",
+        "self::native::propose_fixed_validated(",
         "send-all orchestration drops its only safe boundary",
       ),
       "send-all orchestration",
+    ],
+    [
+      "fixed validated route gates ordinary requests behind maximum amount",
+      mutatedOccurrence(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "    propose_default(db, params, account_id, request)",
+        "    if _validated_amount == u64::MAX {\n        propose_default(db, params, account_id, request)\n    } else {\n        panic!(\"mutant\")\n    }",
+        0,
+        2,
+        "gate fixed validated route behind maximum amount",
+      ),
+      "fixed send and send-all must each delegate exactly once",
+    ],
+    [
+      "send-all validated route gates ordinary requests behind maximum amount",
+      mutatedOccurrence(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "    propose_default(db, params, account_id, request)",
+        "    if _validated_amount == u64::MAX {\n        propose_default(db, params, account_id, request)\n    } else {\n        panic!(\"mutant\")\n    }",
+        1,
+        2,
+        "gate send-all validated route behind maximum amount",
+      ),
+      "fixed send and send-all must each delegate exactly once",
+    ],
+    [
+      "fixed production call gates ordinary requests behind maximum amount",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let proposal =\n        self::native::propose_fixed_validated(db, params, account_id, amount, request)\n            .map_err(|error| Error::SendError(format!(\"failed to propose transfer: {error:?}\")))?;",
+        "    let proposal = if amount == u64::MAX {\n        self::native::propose_fixed_validated(db, params, account_id, amount, request)\n            .map_err(|error| Error::SendError(format!(\"failed to propose transfer: {error:?}\")))?\n    } else {\n        panic!(\"mutant blocked ordinary fixed request\")\n    };",
+        "gate fixed production call behind maximum amount",
+      ),
+      "behavior-tested fixed-send production route",
+    ],
+    [
+      "fixed production route behaves differently under the test compiler",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let request = single_payment_request(recipient, amount, memo)?;",
+        "    if !cfg!(test) { panic!(\"shipping-only mutant\"); }\n    let request = single_payment_request(recipient, amount, memo)?;",
+        "split fixed production behavior with cfg!(test)",
+      ),
+      "fixed-send production route must compile identically",
+    ],
+    [
+      "fixed production helper is shadowed by a maximum-only function item",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let proposal =\n        self::native::propose_fixed_validated(db, params, account_id, amount, request)\n            .map_err(|error| Error::SendError(format!(\"failed to propose transfer: {error:?}\")))?;",
+        "    let propose_fixed = self::native::propose_fixed_validated;\n    let proposal = propose_fixed(db, params, account_id, amount, request)\n        .map_err(|error| Error::SendError(format!(\"failed to propose transfer: {error:?}\")))?;",
+        "shadow fixed production helper with maximum-only function item",
+      ),
+      "fixed send orchestration must enter its only accessible native send boundary",
+    ],
+    [
+      "send-all production call gates ordinary requests behind maximum amount",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    match self::native::propose_send_all_validated(db, params, account_id, amount, request) {",
+        "    match if amount == u64::MAX {\n        self::native::propose_send_all_validated(db, params, account_id, amount, request)\n    } else {\n        panic!(\"mutant blocked ordinary send-all request\")\n    } {",
+        "gate send-all production call behind maximum amount",
+      ),
+      "behavior-tested send-all production route",
+    ],
+    [
+      "send-all production helper is shadowed by a maximum-only function item",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    match self::native::propose_send_all_validated(db, params, account_id, amount, request) {",
+        "    let propose_send_all = self::native::propose_send_all_validated;\n    match propose_send_all(db, params, account_id, amount, request) {",
+        "shadow send-all production helper with maximum-only function item",
+      ),
+      "send-all orchestration must enter its only accessible native send boundary",
+    ],
+    [
+      "fixed stateful caller disconnects from its behavior-tested route",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let (proposal, review) = propose_fixed_production_route(",
+        "    let (proposal, review) = disconnected_fixed_route(",
+        "disconnect fixed stateful caller from its behavior-tested route",
+      ),
+      "fixed-send stateful caller must be compiler-bound exactly once",
+    ],
+    [
+      "send-all stateful caller disconnects from its behavior-tested route",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "        match propose_send_all_production_route(",
+        "        match disconnected_send_all_route(",
+        "disconnect send-all stateful caller from its behavior-tested route",
+      ),
+      "send-all stateful caller must be compiler-bound exactly once",
+    ],
+    [
+      "transaction-creation stateful caller disconnects from its behavior-tested route",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    match create_production_recovery_route(",
+        "    match disconnected_creation_route(",
+        "disconnect stateful creation caller from its behavior-tested route",
+      ),
+      "transaction-creation stateful caller must be compiler-bound exactly once",
+    ],
+    [
+      "fixed WalletState adapter hides its caller behind the probe feature",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        fixedAdapterCall,
+        `    let candidate = if cfg!(feature = "production-route-probe") {
+        propose_fixed_stateful_production_caller(
+            db,
+            &state.network,
+            &recipient,
+            amount,
+            memo_bytes.as_ref(),
+            network_label(&state.network),
+            &wallet_id,
+            &state.proposal_counter,
+            state.send_session_id,
+        )
+    } else {
+        panic!("shipping fixed-send adapter bypassed its tested caller");
+    };`,
+        "feature-split fixed WalletState adapter",
+      ),
+      "fixed-send WalletState adapter must compile one control-flow body",
+    ],
+    [
+      "send-all WalletState adapter hides its caller behind the probe feature",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        sendAllAdapterCall,
+        `    let (pending, public) = if cfg!(feature = "production-route-probe") {
+        propose_send_all_stateful_production_caller(
+            db,
+            &state.network,
+            &recipient,
+            memo_bytes.as_ref(),
+            network_label(&state.network),
+            spendable,
+            &wallet_id,
+            &state.proposal_counter,
+            state.send_session_id,
+        )
+    } else {
+        return Err(Error::SendError("shipping send-all adapter bypassed its tested caller".into()));
+    }?;`,
+        "feature-split send-all WalletState adapter",
+      ),
+      "send-all WalletState adapter must compile one control-flow body",
+    ],
+    [
+      "execute WalletState adapter hides its caller behind the probe feature",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        executeAdapterCall,
+        `    if cfg!(feature = "production-route-probe") {
+        execute_send_creation_stateful_production_caller(
+            db,
+            &state.network,
+            prover,
+            &spending_keys,
+            &pending_proposal.proposal,
+            &wallet_id,
+            proposal_id,
+            &mut broadcast_guard,
+            || clear_pending_broadcast(&state.data_dir, &wallet_id),
+        )?;
+    } else {
+        return Err(Error::SendError("shipping execute adapter bypassed its tested caller".into()));
+    }`,
+        "feature-split execute WalletState adapter",
+      ),
+      "transaction execution WalletState adapter must compile one control-flow body",
+    ],
+    [
+      "fixed WalletState adapter parks its caller in a dead branch",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        fixedAdapterCall,
+        `    let candidate = if false {
+        propose_fixed_stateful_production_caller(
+            db,
+            &state.network,
+            &recipient,
+            amount,
+            memo_bytes.as_ref(),
+            network_label(&state.network),
+            &wallet_id,
+            &state.proposal_counter,
+            state.send_session_id,
+        )
+    } else {
+        return Err(Error::SendError("fixed-send adapter parked its tested caller".into()));
+    };`,
+        "dead fixed WalletState adapter call",
+      ),
+      "fixed-send WalletState adapter complete control-flow body",
+    ],
+    [
+      "send-all WalletState adapter parks its caller in a dead branch",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        sendAllAdapterCall,
+        `    let (pending, public) = if false {
+        propose_send_all_stateful_production_caller(
+            db,
+            &state.network,
+            &recipient,
+            memo_bytes.as_ref(),
+            network_label(&state.network),
+            spendable,
+            &wallet_id,
+            &state.proposal_counter,
+            state.send_session_id,
+        )
+    } else {
+        return Err(Error::SendError("send-all adapter parked its tested caller".into()));
+    }?;`,
+        "dead send-all WalletState adapter call",
+      ),
+      "send-all WalletState adapter complete control-flow body",
+    ],
+    [
+      "execute WalletState adapter parks its caller before an early error",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        executeAdapterCall,
+        `    if false {
+        execute_send_creation_stateful_production_caller(
+            db,
+            &state.network,
+            prover,
+            &spending_keys,
+            &pending_proposal.proposal,
+            &wallet_id,
+            proposal_id,
+            &mut broadcast_guard,
+            || clear_pending_broadcast(&state.data_dir, &wallet_id),
+        )?;
+    } else {
+        return Err(Error::SendError("execute adapter parked its tested caller".into()));
+    }`,
+        "dead execute WalletState adapter call",
+      ),
+      "transaction execution WalletState adapter complete control-flow body",
+    ],
+    [
+      "fixed WalletState adapter corrupts the reviewed fee after its caller",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        fixedAdapterCall,
+        `${fixedAdapterCall.replace("let candidate =", "let mut candidate =")}
+    if let Ok((_, public)) = &mut candidate {
+        public.review.fee = 0;
+    }`,
+        "fixed WalletState adapter post-call fee corruption",
+      ),
+      "fixed-send WalletState adapter complete control-flow body",
+    ],
+    [
+      "send-all WalletState adapter corrupts the reviewed fee after its caller",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        sendAllAdapterCall,
+        `${sendAllAdapterCall.replace("let (pending, public)", "let (pending, mut public)")}
+    public.review.fee = 0;`,
+        "send-all WalletState adapter post-call fee corruption",
+      ),
+      "send-all WalletState adapter complete control-flow body",
+    ],
+    [
+      "execute WalletState adapter corrupts retry bytes before persistence",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        executeAdapterCall,
+        `${executeAdapterCall}
+    if let Some(record) = broadcast_guard.as_mut() {
+        record.raw_transaction[0] ^= 1;
+    }`,
+        "execute WalletState adapter post-call retry-byte corruption",
+      ),
+      "transaction execution WalletState adapter complete control-flow body",
+    ],
+    [
+      "creation production helper is replaced by a local function item",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let txids = self::native::create_transactions(db, params, prover, spending_keys, proposal)",
+        "    let create = self::native::create_transactions;\n    let txids = create(db, params, prover, spending_keys, proposal)",
+        "replace creation production helper with local function item",
+      ),
+      "transaction creation orchestration must enter its only accessible native send boundary",
+    ],
+    [
+      "fixed send validates its recipient after proposal authority",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let (recipient, _) = parse_recipient(&state.network, to)?;\n    propose_send_after_recipient_validation(state, recipient, amount, memo).await",
+        "    let recipient = zcash_address::ZcashAddress::try_from_encoded(to).map_err(|_| Error::AddressError(\"invalid Zcash address\".into()))?;\n    let result = propose_send_after_recipient_validation(state, recipient, amount, memo).await;\n    let _ = parse_recipient(&state.network, to)?;\n    result",
+        "move fixed-send recipient validation after proposal authority",
+      ),
+      "fixed send must validate its recipient as the sole path",
+    ],
+    [
+      "fixed send drops recipient validation",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let (recipient, _) = parse_recipient(&state.network, to)?;\n    propose_send_after_recipient_validation(state, recipient, amount, memo).await",
+        "    let recipient = zcash_address::ZcashAddress::try_from_encoded(to).map_err(|_| Error::AddressError(\"invalid Zcash address\".into()))?;\n    propose_send_after_recipient_validation(state, recipient, amount, memo).await",
+        "drop fixed-send recipient validation",
+      ),
+      "fixed send must validate its recipient as the sole path",
+    ],
+    [
+      "fixed send inverts recipient validation",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let (recipient, _) = parse_recipient(&state.network, to)?;\n    propose_send_after_recipient_validation(state, recipient, amount, memo).await",
+        "    if parse_recipient(&state.network, to).is_ok() {\n        return Err(Error::AddressError(\"mutant rejected valid recipient\".into()));\n    }\n    let recipient = zcash_address::ZcashAddress::try_from_encoded(to).map_err(|_| Error::AddressError(\"invalid Zcash address\".into()))?;\n    propose_send_after_recipient_validation(state, recipient, amount, memo).await",
+        "invert fixed-send recipient validation",
+      ),
+      "fixed send must validate its recipient as the sole path",
+    ],
+    [
+      "fixed send parks recipient validation in a dead branch",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let (recipient, _) = parse_recipient(&state.network, to)?;\n    propose_send_after_recipient_validation(state, recipient, amount, memo).await",
+        "    if false { let _ = parse_recipient(&state.network, to)?; }\n    let recipient = zcash_address::ZcashAddress::try_from_encoded(to).map_err(|_| Error::AddressError(\"invalid Zcash address\".into()))?;\n    propose_send_after_recipient_validation(state, recipient, amount, memo).await",
+        "park fixed-send recipient validation in a dead branch",
+      ),
+      "fixed send must validate its recipient as the sole path",
+    ],
+    [
+      "send-all validates its recipient after proposal authority",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let (recipient, _) = parse_recipient(&state.network, to)?;\n    propose_send_all_after_recipient_validation(state, recipient, memo).await",
+        "    let recipient = zcash_address::ZcashAddress::try_from_encoded(to).map_err(|_| Error::AddressError(\"invalid Zcash address\".into()))?;\n    let result = propose_send_all_after_recipient_validation(state, recipient, memo).await;\n    let _ = parse_recipient(&state.network, to)?;\n    result",
+        "move send-all recipient validation after proposal authority",
+      ),
+      "send-all must validate its recipient as the sole path",
+    ],
+    [
+      "send-all drops recipient validation",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let (recipient, _) = parse_recipient(&state.network, to)?;\n    propose_send_all_after_recipient_validation(state, recipient, memo).await",
+        "    let recipient = zcash_address::ZcashAddress::try_from_encoded(to).map_err(|_| Error::AddressError(\"invalid Zcash address\".into()))?;\n    propose_send_all_after_recipient_validation(state, recipient, memo).await",
+        "drop send-all recipient validation",
+      ),
+      "send-all must validate its recipient as the sole path",
+    ],
+    [
+      "send-all inverts recipient validation",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let (recipient, _) = parse_recipient(&state.network, to)?;\n    propose_send_all_after_recipient_validation(state, recipient, memo).await",
+        "    if parse_recipient(&state.network, to).is_ok() {\n        return Err(Error::AddressError(\"mutant rejected valid recipient\".into()));\n    }\n    let recipient = zcash_address::ZcashAddress::try_from_encoded(to).map_err(|_| Error::AddressError(\"invalid Zcash address\".into()))?;\n    propose_send_all_after_recipient_validation(state, recipient, memo).await",
+        "invert send-all recipient validation",
+      ),
+      "send-all must validate its recipient as the sole path",
+    ],
+    [
+      "send-all parks recipient validation in a dead branch",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let (recipient, _) = parse_recipient(&state.network, to)?;\n    propose_send_all_after_recipient_validation(state, recipient, memo).await",
+        "    if false { let _ = parse_recipient(&state.network, to)?; }\n    let recipient = zcash_address::ZcashAddress::try_from_encoded(to).map_err(|_| Error::AddressError(\"invalid Zcash address\".into()))?;\n    propose_send_all_after_recipient_validation(state, recipient, memo).await",
+        "park send-all recipient validation in a dead branch",
+      ),
+      "send-all must validate its recipient as the sole path",
     ],
     [
       "LockRequest helper drift",
@@ -699,6 +1646,34 @@ function runSelfTest() {
         "    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(",
         "    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(\n    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(",
         "a duplicated direct proposal path revives the old split authority",
+      ),
+      "only direct propose_transfer authority",
+    ],
+    [
+      "an aliased proposal call cannot be vouched for by an inert string",
+      mutated(
+        mutated(
+          baseline,
+          NATIVE_SEND_POLICY_SOURCE,
+          "    propose_transfer,",
+          "    propose_transfer as routed_proposal,",
+          "alias the real proposal import",
+        ),
+        NATIVE_SEND_POLICY_SOURCE,
+        "    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(",
+        "    let _inert_route = \"propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(\";\n    routed_proposal::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(",
+        "replace the real proposal call with an alias and inert string",
+      ),
+      "only direct propose_transfer authority",
+    ],
+    [
+      "a live function-item reference cannot vouch for an aliased proposal call",
+      mutated(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "    propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>(",
+        "    let routed_proposal = propose_transfer::<_, _, _, _, zcash_client_sqlite::wallet::commitment_tree::Error>;\n    routed_proposal(",
+        "replace the direct proposal call with a local function-item alias",
       ),
       "only direct propose_transfer authority",
     ],

--- a/wallet/plugins/tauri-plugin-zcash/Cargo.toml
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.toml
@@ -9,6 +9,15 @@ publish = false
 description = "Tauri plugin for Zcash wallet operations"
 links = "tauri-plugin-zcash"
 
+[features]
+# CI-only semantic probe. It compiles the library without cfg(test) while
+# enabling librustzcash's real TestDb support, so shipping/test route splits are
+# executable failures instead of source-shape assertions.
+production-route-probe = [
+    "zcash_client_backend/test-dependencies",
+    "zcash_client_sqlite/test-dependencies",
+]
+
 [dependencies]
 tauri = "2"
 tauri-plugin-dialog = "2"
@@ -87,6 +96,10 @@ tauri-build = "2"
 zcash_client_backend = { path = "../../../z/zcash/librustzcash/zcash_client_backend", features = ["test-dependencies"] }
 zcash_client_sqlite = { path = "../../../z/zcash/librustzcash/zcash_client_sqlite", features = ["test-dependencies"] }
 transparent = { package = "zcash_transparent", path = "../../../z/zcash/librustzcash/zcash_transparent", features = ["transparent-inputs"] }
+
+[[test]]
+name = "send_production_routes"
+required-features = ["production-route-probe"]
 
 # ---------------------------------------------------------------------------
 # Build profiles. DO NOT DELETE — see the identical blocks in

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{
     fmt::Write as _,
@@ -11,12 +11,13 @@ use std::{
 use rand::{RngCore, rngs::OsRng};
 use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
-use zcash_client_backend::data_api::WalletRead;
 use zcash_client_backend::data_api::wallet::{ConfirmationsPolicy, SpendingKeys};
+use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead, WalletWrite};
 use zcash_client_backend::proto::service::{RawTransaction, TxFilter};
 use zcash_keys::address::Address;
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::PoolType;
+use zcash_protocol::consensus;
 use zcash_protocol::memo::{Memo, MemoBytes};
 use zcash_protocol::value::Zatoshis;
 use zcash_protocol::{ShieldedPool, TxId};
@@ -31,8 +32,6 @@ use crate::wallet::keys;
 use crate::wallet::{WalletProposal, WalletState};
 
 mod native;
-
-use native::{create_transactions, propose_fixed, propose_send_all_attempt};
 
 /// A transaction that has already been created in the wallet database.
 /// Retrying this record always rebroadcasts `raw_transaction`; it never signs
@@ -220,6 +219,12 @@ impl ProposalAuthorization {
 }
 
 impl PendingProposal {
+    /// Native proposal retained behind the public review credential.
+    #[cfg(any(test, feature = "production-route-probe"))]
+    fn native_proposal(&self) -> &WalletProposal {
+        &self.proposal
+    }
+
     fn verify_native_review(&self) -> Result<()> {
         let expected_digest = send_review_digest(
             &self.review,
@@ -1015,6 +1020,30 @@ pub(crate) fn ensure_wallet_has_no_unknown_send(data_dir: &Path, wallet_id: &str
 }
 
 impl PendingBroadcast {
+    /// Exact bytes retained for retry and broadcast.
+    #[cfg(any(test, feature = "production-route-probe"))]
+    fn raw_transaction_bytes(&self) -> &[u8] {
+        &self.raw_transaction
+    }
+
+    /// Transaction identifier bytes paired with the retained transaction.
+    #[cfg(any(test, feature = "production-route-probe"))]
+    fn transaction_id_bytes(&self) -> &[u8] {
+        &self.txid_bytes
+    }
+
+    /// Wallet identifier bound to this recovery record.
+    #[cfg(any(test, feature = "production-route-probe"))]
+    fn recovery_wallet_id(&self) -> &str {
+        &self.wallet_id
+    }
+
+    /// Proposal identifier bound to this recovery record.
+    #[cfg(any(test, feature = "production-route-probe"))]
+    fn recovery_proposal_id(&self) -> u32 {
+        self.proposal_id
+    }
+
     fn public_status(&self) -> PendingSendStatus {
         PendingSendStatus {
             proposal_id: self.proposal_id,
@@ -1324,10 +1353,259 @@ pub async fn ensure_sapling_params(state: &WalletState) -> Result<SaplingParamsS
     Ok(SaplingParamsStatus { ready: true })
 }
 
+fn single_payment_request(
+    recipient: &zcash_address::ZcashAddress,
+    amount: u64,
+    memo: Option<&MemoBytes>,
+) -> Result<zip321::TransactionRequest> {
+    let zatoshis =
+        Zatoshis::from_u64(amount).map_err(|_| Error::SendError("invalid amount".into()))?;
+    let payment = zip321::Payment::new(
+        recipient.clone(),
+        Some(zatoshis),
+        memo.cloned(),
+        None,
+        None,
+        vec![],
+    )
+    .map_err(|error| Error::SendError(format!("failed to create payment: {error:?}")))?;
+    zip321::TransactionRequest::new(vec![payment]).map_err(|error| {
+        Error::SendError(format!("failed to create transaction request: {error:?}"))
+    })
+}
+
+/// The compiler-bound fixed-send route used by production and behavior tests.
+/// It owns request construction, native proposal authority, and derivation of
+/// the immutable review returned to the caller.
+fn propose_fixed_production_route<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    account_id: <DbT as InputSource>::AccountId,
+    recipient: &zcash_address::ZcashAddress,
+    amount: u64,
+    memo: Option<&MemoBytes>,
+    review_network: &str,
+) -> Result<(WalletProposal, SendReview)>
+where
+    DbT: WalletWrite
+        + InputSource<
+            AccountId = <DbT as WalletRead>::AccountId,
+            NoteRef = zcash_client_sqlite::ReceivedNoteId,
+            Error = <DbT as WalletRead>::Error,
+        >,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    <DbT as WalletRead>::Error: std::fmt::Debug,
+    ParamsT: consensus::Parameters + Clone,
+{
+    let request = single_payment_request(recipient, amount, memo)?;
+    let proposal =
+        self::native::propose_fixed_validated(db, params, account_id, amount, request)
+            .map_err(|error| Error::SendError(format!("failed to propose transfer: {error:?}")))?;
+    let review = review_from_native_proposal(review_network, &proposal)?;
+    Ok((proposal, review))
+}
+
+/// The stateful fixed-send caller shared by the WalletState adapter and the
+/// shipping-mode integration test. Proposal construction and installation are
+/// deliberately one compiler-bound operation so a test-only route cannot
+/// vouch for a different shipping caller.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the production caller binds every reviewed and stateful input explicitly"
+)]
+fn propose_fixed_stateful_production_caller<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    recipient: &zcash_address::ZcashAddress,
+    amount: u64,
+    memo: Option<&MemoBytes>,
+    review_network: &str,
+    wallet_id: &str,
+    proposal_counter: &AtomicU32,
+    session_id: [u8; 32],
+) -> Result<(PendingProposal, SendProposal)>
+where
+    DbT: WalletWrite
+        + InputSource<
+            AccountId = <DbT as WalletRead>::AccountId,
+            NoteRef = zcash_client_sqlite::ReceivedNoteId,
+            Error = <DbT as WalletRead>::Error,
+        >,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    <DbT as WalletRead>::Error: std::fmt::Debug + std::fmt::Display,
+    ParamsT: consensus::Parameters + Clone,
+{
+    let account_ids = db
+        .get_account_ids()
+        .map_err(|error| Error::DatabaseError(format!("{error}")))?;
+    let account_id = account_ids
+        .first()
+        .copied()
+        .ok_or(Error::SendError("no accounts found".into()))?;
+    let (proposal, review) = propose_fixed_production_route(
+        db,
+        params,
+        account_id,
+        recipient,
+        amount,
+        memo,
+        review_network,
+    )?;
+    let id = proposal_counter.fetch_add(1, Ordering::Relaxed);
+    Ok(create_pending_proposal(
+        id,
+        proposal,
+        review,
+        wallet_id.to_owned(),
+        session_id,
+    ))
+}
+
+enum SendAllRouteError {
+    InsufficientFunds { required: u64 },
+    Other(Error),
+}
+
+/// The compiler-bound send-all attempt used by production and behavior tests.
+/// A successful return proves both the ordinary request reached native policy
+/// and the resulting proposal survived native review.
+fn propose_send_all_production_route<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    account_id: <DbT as InputSource>::AccountId,
+    recipient: &zcash_address::ZcashAddress,
+    amount: u64,
+    memo: Option<&MemoBytes>,
+    review_network: &str,
+) -> std::result::Result<(WalletProposal, SendReview), SendAllRouteError>
+where
+    DbT: WalletWrite
+        + InputSource<
+            NoteRef = zcash_client_sqlite::ReceivedNoteId,
+            Error = <DbT as WalletRead>::Error,
+        >,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    <DbT as WalletRead>::Error: std::fmt::Debug,
+    ParamsT: consensus::Parameters + Clone,
+{
+    let request =
+        single_payment_request(recipient, amount, memo).map_err(SendAllRouteError::Other)?;
+    match self::native::propose_send_all_validated(db, params, account_id, amount, request) {
+        Ok(proposal) => {
+            let review = review_from_native_proposal(review_network, &proposal)
+                .map_err(SendAllRouteError::Other)?;
+            Ok((proposal, review))
+        }
+        Err(zcash_client_backend::data_api::error::Error::InsufficientFunds {
+            required, ..
+        }) => Err(SendAllRouteError::InsufficientFunds {
+            required: u64::from(required),
+        }),
+        Err(error) => Err(SendAllRouteError::Other(Error::SendError(format!(
+            "failed to propose transfer: {error:?}"
+        )))),
+    }
+}
+
+/// The stateful send-all caller shared by the WalletState adapter and the
+/// shipping-mode integration test. It owns account selection, every retry,
+/// fee convergence, and installation of the reviewed native proposal.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the production caller binds every reviewed and stateful input explicitly"
+)]
+fn propose_send_all_stateful_production_caller<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    recipient: &zcash_address::ZcashAddress,
+    memo: Option<&MemoBytes>,
+    review_network: &str,
+    spendable: u64,
+    wallet_id: &str,
+    proposal_counter: &AtomicU32,
+    session_id: [u8; 32],
+) -> Result<(PendingProposal, SendProposal)>
+where
+    DbT: WalletWrite
+        + InputSource<
+            AccountId = <DbT as WalletRead>::AccountId,
+            NoteRef = zcash_client_sqlite::ReceivedNoteId,
+            Error = <DbT as WalletRead>::Error,
+        >,
+    <DbT as InputSource>::NoteRef: Copy + Eq + Ord,
+    <DbT as WalletRead>::Error: std::fmt::Debug + std::fmt::Display,
+    ParamsT: consensus::Parameters + Clone,
+{
+    let account_ids = db
+        .get_account_ids()
+        .map_err(|error| Error::DatabaseError(format!("{error}")))?;
+    let account_id = account_ids
+        .first()
+        .copied()
+        .ok_or(Error::SendError("no accounts found".into()))?;
+    let mut amount = spendable
+        .checked_sub(10_000)
+        .ok_or(Error::SendError("insufficient spendable balance".into()))?;
+
+    for _ in 0..3 {
+        match propose_send_all_production_route(
+            db,
+            params,
+            account_id,
+            recipient,
+            amount,
+            memo,
+            review_network,
+        ) {
+            Ok((proposal, review)) => {
+                let actual_fee: u64 = proposal
+                    .steps()
+                    .iter()
+                    .map(|step| u64::from(step.balance().fee_required()))
+                    .sum();
+                if amount + actual_fee <= spendable {
+                    let id = proposal_counter.fetch_add(1, Ordering::Relaxed);
+                    return Ok(create_pending_proposal(
+                        id,
+                        proposal,
+                        review,
+                        wallet_id.to_owned(),
+                        session_id,
+                    ));
+                }
+                amount = spendable - actual_fee;
+            }
+            Err(SendAllRouteError::InsufficientFunds { required }) => {
+                let computed_fee = required.saturating_sub(amount);
+                if spendable > computed_fee {
+                    amount = spendable - computed_fee;
+                    continue;
+                }
+                return Err(Error::SendError("insufficient funds to cover fee".into()));
+            }
+            Err(SendAllRouteError::Other(error)) => return Err(error),
+        }
+    }
+
+    Err(Error::SendError(
+        "could not converge on send-all amount after retries".into(),
+    ))
+}
+
 /// Propose a send transaction and return the actual ZIP-317 fee.
 pub async fn propose_send(
     state: &WalletState,
     to: &str,
+    amount: u64,
+    memo: Option<&str>,
+) -> Result<SendProposal> {
+    let (recipient, _) = parse_recipient(&state.network, to)?;
+    propose_send_after_recipient_validation(state, recipient, amount, memo).await
+}
+
+async fn propose_send_after_recipient_validation(
+    state: &WalletState,
+    recipient: zcash_address::ZcashAddress,
     amount: u64,
     memo: Option<&str>,
 ) -> Result<SendProposal> {
@@ -1345,13 +1623,6 @@ pub async fn propose_send(
     }
     *state.pending_proposal.lock().await = None;
 
-    // Parse the recipient and require it to match this wallet's network.
-    let (recipient, _) = parse_recipient(&state.network, to)?;
-
-    // Build the payment request
-    let zatoshis =
-        Zatoshis::from_u64(amount).map_err(|_| Error::SendError("invalid amount".into()))?;
-
     let memo_bytes = match memo {
         Some(m) => {
             Some(MemoBytes::from(Memo::from_str(m).map_err(|e| {
@@ -1361,49 +1632,24 @@ pub async fn propose_send(
         None => None,
     };
 
-    let payment = zip321::Payment::new(
-        recipient.clone(),
-        Some(zatoshis),
-        memo_bytes,
-        None,
-        None,
-        vec![],
-    )
-    .map_err(|e| Error::SendError(format!("failed to create payment: {e:?}")))?;
-
-    let request = zip321::TransactionRequest::new(vec![payment])
-        .map_err(|e| Error::SendError(format!("failed to create transaction request: {e:?}")))?;
-
     // Propose the transfer (no prover needed)
     let mut db_guard = state.db.lock().await;
     let db = db_guard.as_mut().ok_or(Error::WalletNotInitialized)?;
 
-    let account_ids = db
-        .get_account_ids()
-        .map_err(|e| Error::DatabaseError(format!("{e}")))?;
-    let account_id = account_ids
-        .first()
-        .copied()
-        .ok_or(Error::SendError("no accounts found".into()))?;
-
-    let proposal = propose_fixed(db, &state.network, account_id, request)
-        .map_err(|e| Error::SendError(format!("failed to propose transfer: {e:?}")));
+    let candidate = propose_fixed_stateful_production_caller(
+        db,
+        &state.network,
+        &recipient,
+        amount,
+        memo_bytes.as_ref(),
+        network_label(&state.network),
+        &wallet_id,
+        &state.proposal_counter,
+        state.send_session_id,
+    );
 
     drop(db_guard);
 
-    let candidate = proposal.and_then(|proposal| {
-        let id = state.proposal_counter.fetch_add(1, Ordering::Relaxed);
-        // Derive the displayed and authorized details back from the executable
-        // native proposal, never from the renderer request kept above.
-        let review = review_from_native_proposal(network_label(&state.network), &proposal)?;
-        Ok(create_pending_proposal(
-            id,
-            proposal,
-            review,
-            wallet_id.clone(),
-            state.send_session_id,
-        ))
-    });
     let mut pending_broadcast = state.pending_broadcast.lock().await;
     ensure_no_unresolved_broadcast(pending_broadcast.as_ref())?;
     let mut proposal_guard = state.pending_proposal.lock().await;
@@ -1427,6 +1673,15 @@ pub async fn propose_send(
 pub async fn propose_send_all(
     state: &WalletState,
     to: &str,
+    memo: Option<&str>,
+) -> Result<SendProposal> {
+    let (recipient, _) = parse_recipient(&state.network, to)?;
+    propose_send_all_after_recipient_validation(state, recipient, memo).await
+}
+
+async fn propose_send_all_after_recipient_validation(
+    state: &WalletState,
+    recipient: zcash_address::ZcashAddress,
     memo: Option<&str>,
 ) -> Result<SendProposal> {
     let _send_operation = state.send_operation.lock().await;
@@ -1478,9 +1733,6 @@ pub async fn propose_send_all(
         return Err(Error::SendError("insufficient spendable balance".into()));
     }
 
-    // Parse recipient once and require it to match this wallet's network.
-    let (recipient, _) = parse_recipient(&state.network, to)?;
-
     let memo_bytes = match memo {
         Some(m) => {
             Some(MemoBytes::from(Memo::from_str(m).map_err(|e| {
@@ -1490,103 +1742,29 @@ pub async fn propose_send_all(
         None => None,
     };
 
-    // Start with optimistic estimate: spendable - minimum fee
-    let mut amount = spendable - 10000;
+    let mut db_guard = state.db.lock().await;
+    let db = db_guard.as_mut().ok_or(Error::WalletNotInitialized)?;
+    let (pending, public) = propose_send_all_stateful_production_caller(
+        db,
+        &state.network,
+        &recipient,
+        memo_bytes.as_ref(),
+        network_label(&state.network),
+        spendable,
+        &wallet_id,
+        &state.proposal_counter,
+        state.send_session_id,
+    )?;
+    drop(db_guard);
 
-    for _ in 0..3 {
-        let zatoshis =
-            Zatoshis::from_u64(amount).map_err(|_| Error::SendError("invalid amount".into()))?;
-
-        let payment = zip321::Payment::new(
-            recipient.clone(),
-            Some(zatoshis),
-            memo_bytes.clone(),
-            None,
-            None,
-            vec![],
-        )
-        .map_err(|e| Error::SendError(format!("failed to create payment: {e:?}")))?;
-
-        let request = zip321::TransactionRequest::new(vec![payment]).map_err(|e| {
-            Error::SendError(format!("failed to create transaction request: {e:?}"))
-        })?;
-
-        let mut db_guard = state.db.lock().await;
-        let db = db_guard.as_mut().ok_or(Error::WalletNotInitialized)?;
-
-        let account_ids = db
-            .get_account_ids()
-            .map_err(|e| Error::DatabaseError(format!("{e}")))?;
-        let account_id = account_ids
-            .first()
-            .copied()
-            .ok_or(Error::SendError("no accounts found".into()))?;
-
-        let result = propose_send_all_attempt(db, &state.network, account_id, request);
-
-        drop(db_guard);
-
-        match result {
-            Ok(proposal) => {
-                if proposal.steps().len() != 1 {
-                    return Err(Error::SendError(
-                        "multi-transaction send proposals are not supported safely".into(),
-                    ));
-                }
-                let actual_fee: u64 = proposal
-                    .steps()
-                    .iter()
-                    .map(|s| u64::from(s.balance().fee_required()))
-                    .sum();
-
-                if amount + actual_fee <= spendable {
-                    // This proposal works — store it
-                    let id = state.proposal_counter.fetch_add(1, Ordering::Relaxed);
-                    let mut pending_broadcast = state.pending_broadcast.lock().await;
-                    ensure_no_unresolved_broadcast(pending_broadcast.as_ref())?;
-                    if let Some(record) = pending_broadcast.as_ref() {
-                        clear_pending_broadcast(&state.data_dir, &record.wallet_id)?;
-                    }
-                    let review =
-                        review_from_native_proposal(network_label(&state.network), &proposal)?;
-                    let (pending, public) = create_pending_proposal(
-                        id,
-                        proposal,
-                        review,
-                        wallet_id.clone(),
-                        state.send_session_id,
-                    );
-                    *state.pending_proposal.lock().await = Some(pending);
-                    *pending_broadcast = None;
-                    return Ok(public);
-                }
-
-                // Fee was higher than expected — adjust and retry
-                amount = spendable - actual_fee;
-            }
-            Err(zcash_client_backend::data_api::error::Error::InsufficientFunds {
-                required,
-                ..
-            }) => {
-                let required_u64 = u64::from(required);
-                let computed_fee = required_u64.saturating_sub(amount);
-                if spendable > computed_fee {
-                    amount = spendable - computed_fee;
-                    continue;
-                }
-                return Err(Error::SendError("insufficient funds to cover fee".into()));
-            }
-            Err(e) => {
-                return Err(Error::SendError(format!(
-                    "failed to propose transfer: {e:?}"
-                )));
-            }
-        }
+    let mut pending_broadcast = state.pending_broadcast.lock().await;
+    ensure_no_unresolved_broadcast(pending_broadcast.as_ref())?;
+    if let Some(record) = pending_broadcast.as_ref() {
+        clear_pending_broadcast(&state.data_dir, &record.wallet_id)?;
     }
-
-    Err(Error::SendError(
-        "could not converge on send-all amount after retries".into(),
-    ))
+    *state.pending_proposal.lock().await = Some(pending);
+    *pending_broadcast = None;
+    Ok(public)
 }
 
 /// Validate the renderer's exact proposal credential and return the immutable
@@ -1669,6 +1847,127 @@ pub async fn take_send_proposal(
     })
 }
 
+enum CreationRouteError {
+    BeforeCreation(Error),
+    AfterCreation(Error),
+}
+
+/// The compiler-bound transaction-creation route used by production and
+/// behavior tests. It spans native signing and the complete extraction of the
+/// exact recovery bytes that must exist before broadcast can begin.
+fn create_production_recovery_route<DbT, ParamsT>(
+    db: &mut DbT,
+    params: &ParamsT,
+    prover: &LocalTxProver,
+    spending_keys: &SpendingKeys,
+    proposal: &WalletProposal,
+    wallet_id: &str,
+    proposal_id: u32,
+) -> std::result::Result<PendingBroadcast, CreationRouteError>
+where
+    DbT: WalletWrite
+        + WalletCommitmentTrees
+        + InputSource<NoteRef = zcash_client_sqlite::ReceivedNoteId>,
+    <DbT as WalletRead>::Error: std::fmt::Display,
+    ParamsT: consensus::Parameters + Clone,
+{
+    let txids = self::native::create_transactions(db, params, prover, spending_keys, proposal)
+        .map_err(|error| {
+            CreationRouteError::BeforeCreation(Error::SendError(format!(
+                "failed to create transaction: {error:?}"
+            )))
+        })?;
+    let txid = *txids.first();
+    let tx = db
+        .get_transaction(txid)
+        .map_err(|error| {
+            CreationRouteError::AfterCreation(Error::SendError(format!(
+                "failed to read transaction: {error}"
+            )))
+        })?
+        .ok_or_else(|| {
+            CreationRouteError::AfterCreation(Error::SendError(
+                "transaction not found in wallet DB after creation".into(),
+            ))
+        })?;
+    let mut raw_transaction = Vec::new();
+    tx.write(&mut raw_transaction).map_err(|error| {
+        CreationRouteError::AfterCreation(Error::SendError(format!(
+            "failed to serialize transaction: {error}"
+        )))
+    })?;
+
+    Ok(PendingBroadcast {
+        wallet_id: wallet_id.to_owned(),
+        proposal_id,
+        txid: format!("{txid}"),
+        txid_bytes: txid.as_ref().to_vec(),
+        raw_transaction,
+        status: BroadcastStatus::Unknown,
+        message: None,
+        attempts: 0,
+        had_ambiguous_attempt: false,
+        recovery_error: None,
+    })
+}
+
+/// The stateful creation caller shared by `execute_send` and the shipping-mode
+/// integration test. It owns the before/after-creation distinction and only
+/// installs a broadcast record after exact recovery bytes exist.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the production caller binds native creation and recovery state explicitly"
+)]
+fn execute_send_creation_stateful_production_caller<DbT, ParamsT, ClearIntent>(
+    db: &mut DbT,
+    params: &ParamsT,
+    prover: &LocalTxProver,
+    spending_keys: &SpendingKeys,
+    proposal: &WalletProposal,
+    wallet_id: &str,
+    proposal_id: u32,
+    broadcast_slot: &mut Option<PendingBroadcast>,
+    clear_intent: ClearIntent,
+) -> Result<()>
+where
+    DbT: WalletWrite
+        + WalletCommitmentTrees
+        + InputSource<NoteRef = zcash_client_sqlite::ReceivedNoteId>,
+    <DbT as WalletRead>::Error: std::fmt::Display,
+    ParamsT: consensus::Parameters + Clone,
+    ClearIntent: FnOnce() -> Result<()>,
+{
+    match create_production_recovery_route(
+        db,
+        params,
+        prover,
+        spending_keys,
+        proposal,
+        wallet_id,
+        proposal_id,
+    ) {
+        Ok(record) => {
+            *broadcast_slot = Some(record);
+            Ok(())
+        }
+        Err(CreationRouteError::BeforeCreation(error)) => {
+            match clear_intent() {
+                Ok(()) => *broadcast_slot = None,
+                Err(clear_error) => tracing::error!(
+                    "transaction creation failed and its fail-closed intent could not be cleared: {clear_error}"
+                ),
+            }
+            Err(error)
+        }
+        Err(CreationRouteError::AfterCreation(error)) => {
+            tracing::error!(
+                "transaction was created but exact recovery bytes could not be prepared; leaving the fail-closed intent in place"
+            );
+            Err(error)
+        }
+    }
+}
+
 /// Execute a previously-authorized send transaction. The proposal has already
 /// been consumed, so all failures from this point require a new review.
 pub async fn execute_send(
@@ -1746,64 +2045,17 @@ pub async fn execute_send(
     // Create the transaction
     let spending_keys = SpendingKeys::from_unified_spending_key(usk);
 
-    let mut transaction_created = false;
-    let created = (|| -> Result<PendingBroadcast> {
-        let txids = create_transactions(
-            db,
-            &state.network,
-            prover,
-            &spending_keys,
-            &pending_proposal.proposal,
-        )
-        .map_err(|e| Error::SendError(format!("failed to create transaction: {e:?}")))?;
-        transaction_created = true;
-
-        // The native creation boundary returns `NonEmpty<TxId>`.
-        let txid = *txids.first();
-        let tx = db
-            .get_transaction(txid)
-            .map_err(|e| Error::SendError(format!("failed to read transaction: {e}")))?
-            .ok_or_else(|| {
-                Error::SendError("transaction not found in wallet DB after creation".into())
-            })?;
-        let mut raw_transaction = Vec::new();
-        tx.write(&mut raw_transaction)
-            .map_err(|e| Error::SendError(format!("failed to serialize transaction: {e}")))?;
-
-        Ok(PendingBroadcast {
-            wallet_id: wallet_id.clone(),
-            proposal_id,
-            txid: format!("{txid}"),
-            txid_bytes: txid.as_ref().to_vec(),
-            raw_transaction,
-            // Until a complete lightwalletd response arrives, delivery is unknown.
-            status: BroadcastStatus::Unknown,
-            message: None,
-            attempts: 0,
-            had_ambiguous_attempt: false,
-            recovery_error: None,
-        })
-    })();
-
-    let record = match created {
-        Ok(record) => record,
-        Err(error) => {
-            if transaction_created {
-                tracing::error!(
-                    "transaction was created but exact recovery bytes could not be prepared; leaving the fail-closed intent in place"
-                );
-            } else {
-                match clear_pending_broadcast(&state.data_dir, &wallet_id) {
-                    Ok(()) => *broadcast_guard = None,
-                    Err(clear_error) => tracing::error!(
-                        "transaction creation failed and its fail-closed intent could not be cleared: {clear_error}"
-                    ),
-                }
-            }
-            return Err(error);
-        }
-    };
-    *broadcast_guard = Some(record);
+    execute_send_creation_stateful_production_caller(
+        db,
+        &state.network,
+        prover,
+        &spending_keys,
+        &pending_proposal.proposal,
+        &wallet_id,
+        proposal_id,
+        &mut broadcast_guard,
+        || clear_pending_broadcast(&state.data_dir, &wallet_id),
+    )?;
     // Replace the intent with complete retry bytes before any network I/O.
     // If this fails, the in-memory record remains retryable and the durable
     // intent remains fail-closed after restart.
@@ -2209,10 +2461,192 @@ async fn broadcast_record(
     ))
 }
 
+/// CI-only semantic probe compiled as part of the library without `cfg(test)`.
+/// The integration target calls this module with `production-route-probe`, so
+/// test-only branches inside the exact production callers take their shipping
+/// side and become observable failures.
+#[cfg(feature = "production-route-probe")]
+#[doc(hidden)]
+pub mod production_route_probe {
+    use super::*;
+    use zcash_client_backend::data_api::testing::{
+        orchard::OrchardPoolTester,
+        pool::{ShieldedPoolTester, dsl::TestDsl},
+    };
+    use zcash_client_sqlite::testing::{BlockCache, db::TestDbFactory};
+
+    pub fn assert_ordinary_stateful_shipping_routes() {
+        const NOTE_VALUE: u64 = 60_000;
+        const FIXED_SEND_VALUE: u64 = 10_000;
+        const SEND_ALL_VALUE: u64 = 50_000;
+        const EXPECTED_FEE: u64 = 10_000;
+        const PROPOSAL_ID: u32 = 41;
+        const WALLET_ID: &str = "ordinary-route-wallet";
+        const REVIEW_NETWORK: &str = "independent-test-network";
+        const SESSION_ID: [u8; 32] = [0x11; 32];
+
+        let mut state =
+            TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
+                .build::<OrchardPoolTester>();
+        let (_, _, _) =
+            state.add_a_single_note_checking_balance(Zatoshis::const_from_u64(NOTE_VALUE));
+
+        let recipient_key = OrchardPoolTester::sk(&[0xa7; 32]);
+        let recipient = OrchardPoolTester::sk_default_address(&recipient_key);
+        let network = *state.network();
+        let recipient = recipient.to_zcash_address(&network);
+        let account = state.get_account();
+        let spending_keys = SpendingKeys::from_unified_spending_key(account.usk().clone());
+        let proposal_counter = AtomicU32::new(PROPOSAL_ID);
+
+        let immature = propose_fixed_stateful_production_caller(
+            state.wallet_mut(),
+            &network,
+            &recipient,
+            FIXED_SEND_VALUE,
+            None,
+            REVIEW_NETWORK,
+            WALLET_ID,
+            &proposal_counter,
+            SESSION_ID,
+        );
+        assert!(
+            immature.is_err(),
+            "one-confirmation Orchard value must not cross shipping policy"
+        );
+        assert_eq!(proposal_counter.load(Ordering::Relaxed), PROPOSAL_ID);
+        state.add_empty_blocks(9);
+
+        let (fixed_pending, fixed_public) = propose_fixed_stateful_production_caller(
+            state.wallet_mut(),
+            &network,
+            &recipient,
+            FIXED_SEND_VALUE,
+            None,
+            REVIEW_NETWORK,
+            WALLET_ID,
+            &proposal_counter,
+            SESSION_ID,
+        )
+        .expect("ordinary fixed value must cross the stateful shipping caller");
+        let fixed_proposal = fixed_pending.native_proposal();
+        assert_eq!(fixed_public.proposal_id, PROPOSAL_ID);
+        assert_eq!(fixed_public.review.network, REVIEW_NETWORK);
+        assert_eq!(fixed_public.review.payments.len(), 1);
+        assert_eq!(
+            fixed_public.review.payments[0].recipient,
+            recipient.encode()
+        );
+        assert_eq!(fixed_public.review.payments[0].amount, FIXED_SEND_VALUE);
+        assert_eq!(fixed_public.review.fee, EXPECTED_FEE);
+        assert_eq!(fixed_public.review.total, FIXED_SEND_VALUE + EXPECTED_FEE);
+        assert_eq!(fixed_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
+        assert_eq!(fixed_proposal.input_count_in_pool(PoolType::SAPLING), 0);
+        assert_eq!(
+            fixed_proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::ORCHARD),
+            1
+        );
+        assert_eq!(
+            fixed_proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::SAPLING),
+            0
+        );
+
+        let (send_all_pending, send_all_public) = propose_send_all_stateful_production_caller(
+            state.wallet_mut(),
+            &network,
+            &recipient,
+            None,
+            REVIEW_NETWORK,
+            NOTE_VALUE,
+            WALLET_ID,
+            &proposal_counter,
+            SESSION_ID,
+        )
+        .expect("ordinary value must cross the stateful send-all shipping caller");
+        let send_all_proposal = send_all_pending.native_proposal();
+        assert_eq!(send_all_public.proposal_id, PROPOSAL_ID + 1);
+        assert_eq!(send_all_public.review.payments[0].amount, SEND_ALL_VALUE);
+        assert_eq!(send_all_public.review.fee, EXPECTED_FEE);
+        assert_eq!(send_all_public.review.total, NOTE_VALUE);
+        assert_eq!(send_all_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
+        assert_eq!(
+            send_all_proposal
+                .steps()
+                .head
+                .balance()
+                .proposed_change()
+                .iter()
+                .map(|change| u64::from(change.value()))
+                .sum::<u64>(),
+            0
+        );
+
+        let recovery_height = fixed_proposal.min_target_height().into();
+        let prover = LocalTxProver::bundled();
+        let mut broadcast_slot = None;
+        execute_send_creation_stateful_production_caller(
+            state.wallet_mut(),
+            &network,
+            &prover,
+            &spending_keys,
+            fixed_proposal,
+            WALLET_ID,
+            PROPOSAL_ID,
+            &mut broadcast_slot,
+            || Ok(()),
+        )
+        .expect("ordinary proposal must cross the stateful creation shipping caller");
+        let record = broadcast_slot
+            .as_ref()
+            .expect("successful creation must install exact retry state");
+        assert_eq!(record.recovery_wallet_id(), WALLET_ID);
+        assert_eq!(record.recovery_proposal_id(), PROPOSAL_ID);
+        assert_eq!(record.transaction_id_bytes().len(), 32);
+        assert!(!record.raw_transaction_bytes().is_empty());
+
+        let txid = TxId::from_bytes(
+            record
+                .transaction_id_bytes()
+                .try_into()
+                .expect("32-byte txid"),
+        );
+        let tx = state
+            .wallet()
+            .get_transaction(txid)
+            .expect("the stateful creation caller must leave the wallet readable")
+            .expect("the stateful creation caller must persist its transaction");
+        let mut persisted_transaction_bytes = Vec::new();
+        tx.write(&mut persisted_transaction_bytes)
+            .expect("the persisted transaction must serialize");
+        assert_eq!(
+            record.raw_transaction_bytes(),
+            persisted_transaction_bytes,
+            "returned retry bytes must exactly equal the persisted transaction"
+        );
+
+        let sender_fvk = OrchardPoolTester::test_account_fvk(&state);
+        let (_, recovered_recipient, _) =
+            OrchardPoolTester::try_output_recovery(&network, recovery_height, &tx, &sender_fvk)
+                .expect("shipping creation must retain sender output recovery");
+        assert_eq!(recovered_recipient.to_zcash_address(&network), recipient);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use zcash_address::unified::{Address as UnifiedAddress, Encoding, Receiver};
+    use zcash_client_backend::data_api::testing::{
+        orchard::OrchardPoolTester,
+        pool::{ShieldedPoolTester, dsl::TestDsl},
+    };
+    use zcash_client_sqlite::testing::{BlockCache, db::TestDbFactory};
     use zcash_protocol::consensus::{Network, NetworkType};
 
     const MAINNET_TADDR: &str = "t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs";
@@ -2223,6 +2657,167 @@ mod tests {
     const WALLET_ID: &str = "wallet-a";
     const SESSION_ID: [u8; 32] = [0x11; 32];
     const OTHER_SESSION_ID: [u8; 32] = [0x22; 32];
+
+    #[test]
+    fn ordinary_values_cross_each_complete_production_money_route() {
+        const NOTE_VALUE: u64 = 60_000;
+        const FIXED_SEND_VALUE: u64 = 10_000;
+        const SEND_ALL_VALUE: u64 = 50_000;
+        const EXPECTED_FEE: u64 = 10_000;
+        const PROPOSAL_ID: u32 = 41;
+        const WALLET_ID: &str = "ordinary-route-wallet";
+        const REVIEW_NETWORK: &str = "independent-test-network";
+
+        let mut state =
+            TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
+                .build::<OrchardPoolTester>();
+        let (_, _, _) =
+            state.add_a_single_note_checking_balance(Zatoshis::const_from_u64(NOTE_VALUE));
+
+        let recipient_key = OrchardPoolTester::sk(&[0xa7; 32]);
+        let recipient = OrchardPoolTester::sk_default_address(&recipient_key);
+        let network = *state.network();
+        let recipient = recipient.to_zcash_address(&network);
+        let account = state.get_account();
+        let spending_keys = SpendingKeys::from_unified_spending_key(account.usk().clone());
+        let proposal_counter = AtomicU32::new(PROPOSAL_ID);
+
+        let immature = propose_fixed_stateful_production_caller(
+            state.wallet_mut(),
+            &network,
+            &recipient,
+            FIXED_SEND_VALUE,
+            None,
+            REVIEW_NETWORK,
+            WALLET_ID,
+            &proposal_counter,
+            SESSION_ID,
+        );
+        assert!(
+            immature.is_err(),
+            "an externally received Orchard note must not cross production policy after one confirmation"
+        );
+        assert_eq!(proposal_counter.load(Ordering::Relaxed), PROPOSAL_ID);
+        state.add_empty_blocks(9);
+
+        let (fixed_pending, fixed_public) = propose_fixed_stateful_production_caller(
+            state.wallet_mut(),
+            &network,
+            &recipient,
+            FIXED_SEND_VALUE,
+            None,
+            REVIEW_NETWORK,
+            WALLET_ID,
+            &proposal_counter,
+            SESSION_ID,
+        )
+        .expect("an ordinary fixed-send value must traverse the complete production route");
+        let fixed_proposal = fixed_pending.native_proposal();
+        let fixed_review = &fixed_public.review;
+        assert_eq!(fixed_public.proposal_id, PROPOSAL_ID);
+        assert_eq!(fixed_review.network, REVIEW_NETWORK);
+        assert_eq!(fixed_review.payments.len(), 1);
+        assert_eq!(fixed_review.payments[0].recipient, recipient.encode());
+        assert_eq!(fixed_review.payments[0].amount, FIXED_SEND_VALUE);
+        assert_eq!(fixed_review.fee, EXPECTED_FEE);
+        assert_eq!(fixed_review.total, FIXED_SEND_VALUE + EXPECTED_FEE);
+        assert_eq!(fixed_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
+        assert_eq!(fixed_proposal.input_count_in_pool(PoolType::SAPLING), 0);
+        assert_eq!(
+            fixed_proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::ORCHARD),
+            1
+        );
+        assert_eq!(
+            fixed_proposal
+                .steps()
+                .head
+                .change_count_in_pool(PoolType::SAPLING),
+            0
+        );
+
+        let (send_all_pending, send_all_public) = propose_send_all_stateful_production_caller(
+            state.wallet_mut(),
+            &network,
+            &recipient,
+            None,
+            REVIEW_NETWORK,
+            NOTE_VALUE,
+            WALLET_ID,
+            &proposal_counter,
+            SESSION_ID,
+        )
+        .expect("an ordinary send-all value must traverse the complete production route");
+        let send_all_proposal = send_all_pending.native_proposal();
+        let send_all_review = &send_all_public.review;
+        assert_eq!(send_all_public.proposal_id, PROPOSAL_ID + 1);
+        assert_eq!(send_all_review.payments[0].amount, SEND_ALL_VALUE);
+        assert_eq!(send_all_review.fee, EXPECTED_FEE);
+        assert_eq!(send_all_review.total, NOTE_VALUE);
+        assert_eq!(send_all_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
+        assert_eq!(
+            send_all_proposal
+                .steps()
+                .head
+                .balance()
+                .proposed_change()
+                .iter()
+                .map(|change| u64::from(change.value()))
+                .sum::<u64>(),
+            0
+        );
+
+        let recovery_height = fixed_proposal.min_target_height().into();
+        let prover = LocalTxProver::bundled();
+        let mut broadcast_slot = None;
+        execute_send_creation_stateful_production_caller(
+            state.wallet_mut(),
+            &network,
+            &prover,
+            &spending_keys,
+            fixed_proposal,
+            WALLET_ID,
+            PROPOSAL_ID,
+            &mut broadcast_slot,
+            || Ok(()),
+        )
+        .expect("an ordinary proposal ID must traverse creation through recovery serialization");
+        let record = broadcast_slot
+            .as_ref()
+            .expect("successful creation must install exact retry state");
+        assert_eq!(record.recovery_wallet_id(), WALLET_ID);
+        assert_eq!(record.recovery_proposal_id(), PROPOSAL_ID);
+        assert_eq!(record.transaction_id_bytes().len(), 32);
+        assert!(!record.raw_transaction_bytes().is_empty());
+
+        let txid = TxId::from_bytes(
+            record
+                .transaction_id_bytes()
+                .try_into()
+                .expect("32-byte txid"),
+        );
+        let tx = state
+            .wallet()
+            .get_transaction(txid)
+            .expect("the production route leaves the wallet readable")
+            .expect("the production route persists its created transaction");
+        let mut persisted_transaction_bytes = Vec::new();
+        tx.write(&mut persisted_transaction_bytes)
+            .expect("the persisted transaction must serialize");
+        assert_eq!(
+            record.raw_transaction_bytes(),
+            persisted_transaction_bytes,
+            "the exact returned retry bytes must equal the persisted transaction"
+        );
+        let sender_fvk = OrchardPoolTester::test_account_fvk(&state);
+        let (_, recovered_recipient, _) =
+            OrchardPoolTester::try_output_recovery(&network, recovery_height, &tx, &sender_fvk)
+                .expect("the production route must retain sender output recovery");
+        let recovered_recipient = recovered_recipient.to_zcash_address(&network);
+        assert_eq!(recovered_recipient, recipient);
+    }
 
     fn pending(status: BroadcastStatus) -> PendingBroadcast {
         PendingBroadcast {

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send/native.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send/native.rs
@@ -95,10 +95,11 @@ where
 }
 
 #[allow(clippy::type_complexity)]
-pub(super) fn propose_fixed<DbT, ParamsT>(
+pub(super) fn propose_fixed_validated<DbT, ParamsT>(
     db: &mut DbT,
     params: &ParamsT,
     account_id: <DbT as InputSource>::AccountId,
+    _validated_amount: u64,
     request: zip321::TransactionRequest,
 ) -> std::result::Result<
     Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
@@ -113,10 +114,11 @@ where
 }
 
 #[allow(clippy::type_complexity)]
-pub(super) fn propose_send_all_attempt<DbT, ParamsT>(
+pub(super) fn propose_send_all_validated<DbT, ParamsT>(
     db: &mut DbT,
     params: &ParamsT,
     account_id: <DbT as InputSource>::AccountId,
+    _validated_amount: u64,
     request: zip321::TransactionRequest,
 ) -> std::result::Result<
     Proposal<Zip317FeeRule, <DbT as InputSource>::NoteRef>,
@@ -213,10 +215,11 @@ mod tests {
         let account_id = account.id();
         let network = *st.network();
 
-        let immature = propose_fixed(
+        let immature = propose_fixed_validated(
             st.wallet_mut(),
             &network,
             account_id,
+            FIXED_SEND_VALUE,
             payment_request(&network, &recipient, FIXED_SEND_VALUE),
         );
         assert!(
@@ -225,10 +228,11 @@ mod tests {
         );
 
         st.add_empty_blocks(9);
-        let proposal = propose_fixed(
+        let proposal = propose_fixed_validated(
             st.wallet_mut(),
             &network,
             account_id,
+            FIXED_SEND_VALUE,
             payment_request(&network, &recipient, FIXED_SEND_VALUE),
         )
         .expect("the same Orchard note must be spendable after ten confirmations");
@@ -254,10 +258,11 @@ mod tests {
             EXPECTED_FEE
         );
 
-        let send_all_proposal = propose_send_all_attempt(
+        let send_all_proposal = propose_send_all_validated(
             st.wallet_mut(),
             &network,
             account_id,
+            SEND_ALL_VALUE,
             payment_request(&network, &recipient, SEND_ALL_VALUE),
         )
         .expect("the send-all-shaped request must be proposed by the shared boundary");

--- a/wallet/plugins/tauri-plugin-zcash/tests/send_production_routes.rs
+++ b/wallet/plugins/tauri-plugin-zcash/tests/send_production_routes.rs
@@ -1,0 +1,4 @@
+#[test]
+fn ordinary_values_cross_stateful_shipping_callers_and_exact_recovery_bytes() {
+    tauri_plugin_zcash::wallet::send::production_route_probe::assert_ordinary_stateful_shipping_routes();
+}


### PR DESCRIPTION
Closes #547
Closes #620

## Summary

- routes fixed sends and send-all through one private, compiler-bound native policy authority
- behaviorally exercises ordinary fixed/send-all/creation values against a real librustzcash test database
- verifies confirmation depth, ZIP-317 fee, pool selection, shielded change, sender OVK recovery, persisted transaction bytes, and exact retry bytes
- adds a shipping-mode integration probe that traverses the stateful production callers while keeping money authority private
- binds the complete WalletState adapter bodies so cfg/dead/early-return and post-call corruption cannot hide behind tested helpers

## Mutation proof

Every money-path guard was broken and shown red before publication. Independent review killed:

- fixed/send-all/creation pre- and post-route ordinary-value guards
- shipping-only cfg splits and dead parked helper calls in all three WalletState adapters
- fixed/send-all post-helper fee corruption
- execute-path raw-transaction corruption before persistence/broadcast
- confirmation-depth, recipient presence/order, policy alias/shadow, visibility, pool/fee/change, and sender-recovery mutations
- cfg test-only splits and disconnected helper seams

The compatibility self-test kills 108/108 mutants and the live checker passes. Rust 1.97.1 feature-enabled all-targets passes 145 unit tests plus the shipping integration test; feature clippy, fmt, toolchain, Actions, workflow, public-boundary, and deny gates pass. Exact independently approved head: a0a361ceba77565f47cd7d67c26717019190cd42.
