### PR TITLE
feat(rs): f2z-relay — the relay daemon

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -333,6 +333,10 @@ jobs:
       # `f2z-relay-testkit` is absent for a neighbouring reason: it opens
       # sockets, spawns tasks and reads a clock, and a test harness that could
       # reach the browser build could end up in the shipped bundle.
+      #
+      # `f2z-relay` — the server binary the paragraph above anticipated — is all
+      # three at once: AGPL-3.0, tokio and SQLite, and never a browser. Adding a
+      # crate to this line is a claim that a client links it.
       - name: Build the client-linked crates for the browser target
         working-directory: rs
         run: |

--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -75,7 +75,8 @@ jobs:
           scripts/check-rust-toolchain.sh \
             --toolchain-file rs/rust-toolchain.toml \
             --manifest rs/crates/f2z-codec/Cargo.toml \
-            --manifest rs/crates/f2z-relay-proto/Cargo.toml
+            --manifest rs/crates/f2z-relay-proto/Cargo.toml \
+            --manifest rs/crates/f2z-relay-testkit/Cargo.toml
 
       - name: Detect changes under rs/
         id: filter
@@ -293,6 +294,11 @@ jobs:
       # rather than `--workspace` so that a future server binary — which will be
       # AGPL, will pull tokio, and will never reach a browser — does not
       # silently join the wasm build and then fail it.
+      #
+      # f2z-relay-testkit is deliberately absent for exactly that reason: it
+      # opens sockets, spawns tasks and reads a clock, and a test harness that
+      # could reach the browser build would be a test harness that could end up
+      # in the shipped bundle.
       - name: Build the client-linked crates for the browser target
         working-directory: rs
         run: |

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -57,10 +57,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cpufeatures"
@@ -114,8 +137,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "digest"
@@ -135,6 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid",
  "crypto-common 0.2.2",
 ]
 
@@ -191,6 +221,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "f2z-relay-testkit"
+version = "0.1.0"
+dependencies = [
+ "f2z-codec",
+ "f2z-relay-proto",
+ "futures-util",
+ "tls_codec",
+ "tokio",
+ "tokio-tungstenite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +249,37 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -239,7 +312,24 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
@@ -249,6 +339,12 @@ checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
@@ -261,6 +357,23 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "num-traits"
@@ -276,6 +389,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "ppv-lite86"
@@ -305,7 +424,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -348,7 +467,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -358,7 +488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -371,12 +501,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -426,6 +562,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +590,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +616,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -473,6 +647,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "tls_codec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,7 +684,61 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "sha1",
+ "thiserror",
 ]
 
 [[package]]
@@ -525,6 +773,12 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -573,7 +827,7 @@ checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -593,5 +847,5 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -207,7 +207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -226,6 +226,24 @@ dependencies = [
  "blake2",
  "proptest",
  "tls_codec",
+]
+
+[[package]]
+name = "f2z-relay"
+version = "0.1.0"
+dependencies = [
+ "f2z-codec",
+ "f2z-relay-proto",
+ "f2z-relay-store",
+ "f2z-relay-testkit",
+ "futures-util",
+ "rand 0.9.5",
+ "serde",
+ "tls_codec",
+ "tokio",
+ "tokio-rustls",
+ "tokio-tungstenite",
+ "toml",
 ]
 
 [[package]]
@@ -347,6 +365,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -455,7 +484,7 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -611,6 +640,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +686,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -663,6 +741,45 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "sha1"
@@ -693,6 +810,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,7 +844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -758,7 +885,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -812,9 +939,10 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -829,6 +957,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +976,37 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -873,6 +1042,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "vcpkg"
@@ -918,12 +1093,97 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/rs/README.md
+++ b/rs/README.md
@@ -113,15 +113,23 @@ prevent.
 | [`crates/f2z-codec`](./crates/f2z-codec) | The canonical encoding layer of `WIRE.md`: `tls_codec` wrappers for every wire structure, the domain-separated signing transcript (§5), the redacting newtypes, and the padding-bucket validator (§9). `no_std` + `alloc`, `#![forbid(unsafe_code)]`, no I/O, no async runtime, and it builds for `wasm32-unknown-unknown`. |
 | [`crates/f2z-relay-proto`](./crates/f2z-relay-proto) | The protocol layer above it: signed-command construction and verification in §5.1's exact order, the timestamp window and fail-closed seen-set (§5.5), the queue lifecycle and ACK arithmetic (§7, §8), the capability document (§11), the `HELLO` proof of possession (§5.2), and §4.3's typed in-flight window. Same constraints — `no_std` + `alloc`, no I/O, no clock, no randomness, and it builds for `wasm32-unknown-unknown`. |
 | [`crates/f2z-relay-store`](./crates/f2z-relay-store) | The relay's queue storage: a `RelayStore` trait that speaks addresses and bytes and never a wire frame, plus a durable `SqliteStore` (WAL, `synchronous = FULL`, `secure_delete = ON`, group commit) and a volatile `MemoryStore`. **Native only** — it links SQLite and is not on the wasm line. `std`, `#![forbid(unsafe_code)]`, no async runtime. |
-| [`crates/f2z-relay-testkit`](./crates/f2z-relay-testkit) | **FakeRelay**: a spec-conforming relay a client can develop against, over an in-process pipe *and* a real `ws://127.0.0.1:0` listener running the same implementation, plus fault injection and a conformance vector suite a real relay is run against unchanged. Also ships the `f2z-fakerelay` binary and `rs/deploy/docker-compose.dev.yml`. **Native only** — it opens sockets, spawns tasks and reads a clock, and is deliberately absent from the `wasm32` job. |
+| [`crates/f2z-relay-testkit`](./crates/f2z-relay-testkit) | **FakeRelay**: a spec-conforming relay a client can develop against, over an in-process pipe *and* a real `ws://127.0.0.1:0` listener running the same implementation, plus fault injection and the conformance vector suite `f2z-relay` is run against unchanged. Also ships the `f2z-fakerelay` binary and `rs/deploy/docker-compose.dev.yml`. **Native only** — it opens sockets, spawns tasks and reads a clock, and is deliberately absent from the `wasm32` job. |
+| [`crates/f2z-relay`](./crates/f2z-relay) | **The relay daemon** — the server that runs in production. `wss://` listener, §4 framing, §5 signed-command verification with the TLS-exporter binding, the full §6 command set over `RelayStore`, a group-commit writer, TTL expiry, §13 anti-abuse, the signed capability document, and a loopback-only `/healthz` + `/metrics` admin listener. **AGPL-3.0**, native only, never on the wasm line. |
 | [`crates/f2z-authority`](./crates/f2z-authority) | An **experimental candidate** for the directory's non-cryptographic trust-root layer: the proposed `HandleAssertion`, a partial assertion-layer check, `AuthoritySet`, and `f2z-assert`. `KT.md` does not yet ratify these structures or first-entry/no-authority semantics (#594), and its result is not §4.4 directory authorization. Same portability constraints. |
+
+**The clients link `f2z-codec` and `f2z-relay-proto`; the relay links those two
+plus `f2z-relay-store`.** That is the licence boundary in practice: the shared
+crates are MIT because a third-party relay, ZUULI and the WASM web client all
+compile the same rules, and a rule that two implementations disagree about is how
+ciphertext gets deleted before it is read. **`f2z-relay` is the first crate on
+the other side of that boundary** — an AGPL-3.0 server binary, named in
+`rs/deny.toml`'s `exceptions` so crossing it cannot happen by accident.
 
 The current dependency graph is narrower than that intended architecture:
 `f2z-relay-proto` depends on `f2z-codec`, while `f2z-authority` is still a
 standalone experimental leaf and no workspace package depends on it. Wiring the
 authority candidate into a relay or client is future integration work, not a
-property this README claims today. All remain MIT so downstream relays and
-clients can share the rules once that integration exists.
+property this README claims today.
 
 `f2z-codec` is separate from everything that sits on top of it for three
 reasons, and each is enforced by a test rather than by intent:
@@ -151,14 +159,18 @@ cargo test -p f2z-relay-store --features crash-injection --test crash_safety
 
 # A relay endpoint for a client developer, in one command.
 cargo run -p f2z-relay-testkit --bin f2z-fakerelay
+
+# The real thing, on loopback, with an ephemeral store.
+cargo run -p f2z-relay -- --store memory
 ```
 
 **Not every crate here reaches the browser, and the wasm line is the record of
 which do.** `f2z-relay-store` links SQLite through `rusqlite`'s bundled C
-amalgamation and is relay-side only; `f2z-relay-testkit` opens sockets, spawns
-tasks and reads a clock, and a test harness that could reach the browser build
-could end up in the shipped bundle. Both are deliberately absent from `rs.yml`'s
-`rs_wasm` job. Adding a crate to that line is a claim that a client links it.
+amalgamation; `f2z-relay-testkit` opens sockets, spawns tasks and reads a clock,
+and a test harness that could reach the browser build could end up in the
+shipped bundle; `f2z-relay` is an AGPL server binary that does all three. All
+are deliberately absent from `rs.yml`'s `rs_wasm` job. Adding a crate to that
+line is a claim that a client links it.
 
 The gates are the repository's shared scripts, pointed here with `--root`:
 

--- a/rs/README.md
+++ b/rs/README.md
@@ -76,7 +76,8 @@ decided is `wallet/rust-toolchain.toml`, and
 ```
 scripts/check-rust-toolchain.sh --toolchain-file rs/rust-toolchain.toml \
                                 --manifest rs/crates/f2z-codec/Cargo.toml \
-                                --manifest rs/crates/f2z-relay-proto/Cargo.toml
+                                --manifest rs/crates/f2z-relay-proto/Cargo.toml \
+                                --manifest rs/crates/f2z-relay-testkit/Cargo.toml
 ```
 
 fails the pull request the moment the two disagree. `.github/workflows/rs.yml`
@@ -110,8 +111,9 @@ prevent.
 |---|---|
 | [`crates/f2z-codec`](./crates/f2z-codec) | The canonical encoding layer of `WIRE.md`: `tls_codec` wrappers for every wire structure, the domain-separated signing transcript (§5), the redacting newtypes, and the padding-bucket validator (§9). `no_std` + `alloc`, `#![forbid(unsafe_code)]`, no I/O, no async runtime, and it builds for `wasm32-unknown-unknown`. |
 | [`crates/f2z-relay-proto`](./crates/f2z-relay-proto) | The protocol layer above it: signed-command construction and verification in §5.1's exact order, the timestamp window and fail-closed seen-set (§5.5), the queue lifecycle and ACK arithmetic (§7, §8), the capability document (§11), the `HELLO` proof of possession (§5.2), and §4.3's typed in-flight window. Same constraints — `no_std` + `alloc`, no I/O, no clock, no randomness, and it builds for `wasm32-unknown-unknown`. |
+| [`crates/f2z-relay-testkit`](./crates/f2z-relay-testkit) | **FakeRelay**: a spec-conforming relay a client can develop against before `f2z-relay` exists, over an in-process pipe *and* a real `ws://127.0.0.1:0` listener running the same implementation, plus fault injection and a conformance vector suite the real relay will later be run against unchanged. Also ships the `f2z-fakerelay` binary and `rs/deploy/docker-compose.dev.yml`. **Native only** — it opens sockets, spawns tasks and reads a clock, and is deliberately absent from the `wasm32` job. |
 
-**The relay and the clients link both.** That is the licence boundary in
+**The relay and the clients link the first two.** That is the licence boundary in
 practice: everything here is MIT because a third-party relay, ZUULI and the WASM
 web client all compile the same rules, and a rule that two implementations
 disagree about is how ciphertext gets deleted before it is read.
@@ -135,7 +137,14 @@ reasons, and each is enforced by a test rather than by intent:
 cd rs
 cargo test
 cargo build --target wasm32-unknown-unknown --lib -p f2z-codec -p f2z-relay-proto
+
+# A relay endpoint for a client developer, in one command.
+cargo run -p f2z-relay-testkit --bin f2z-fakerelay
 ```
+
+`f2z-relay-testkit` is **not** on the `wasm32` line above, and that absence is
+the rule rather than an oversight: a test harness that could reach the browser
+build is a test harness that could end up in the shipped bundle.
 
 The gates are the repository's shared scripts, pointed here with `--root`:
 

--- a/rs/crates/f2z-codec/tests/workspace_debug_scan.rs
+++ b/rs/crates/f2z-codec/tests/workspace_debug_scan.rs
@@ -129,12 +129,34 @@ fn derived_debug_items(file: &str, source: &str) -> Vec<DerivedDebugItem> {
 
         // Skip any further attributes and comments between the derive and the
         // item it applies to.
+        //
+        // An attribute may span several lines, and its continuation lines do
+        // **not** start with `#`. Stopping at the first line that does not
+        // would take the continuation for the item declaration and abort the
+        // whole scan on the assert below — which is a hole rather than a
+        // failure: one wrapped `#[must_use = "…"]` anywhere under
+        // `rs/crates/*/src/` disables every leak check in this file. An earlier
+        // revision of `f2z-relay-store`'s `Committed` had exactly that shape
+        // and did exactly that. So an attribute is consumed until its brackets
+        // balance.
         while index < lines.len() {
             let trimmed = lines[index].trim_start();
-            if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with("//") {
+            if trimmed.is_empty() || trimmed.starts_with("//") {
                 index += 1;
-            } else {
+                continue;
+            }
+            if !trimmed.starts_with('#') {
                 break;
+            }
+            let mut depth = 0i32;
+            while index < lines.len() {
+                let line = lines[index];
+                depth += i32::try_from(line.matches('[').count()).unwrap_or(0);
+                depth -= i32::try_from(line.matches(']').count()).unwrap_or(0);
+                index += 1;
+                if depth <= 0 {
+                    break;
+                }
             }
         }
         assert!(index < lines.len(), "{file}: derive with no item after it");

--- a/rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs
+++ b/rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs
@@ -350,6 +350,31 @@ const WORKSPACE_VERIFY_FNS: &[VerifyFn] = &[
             receiver: "identity",
         },
     },
+    // The two relays. Neither verifies a signature itself: each builds a
+    // `CommandVerifier` from `f2z-relay-proto` and hands it the frame, so what
+    // they reach is `command.rs::verify`, which reaches `key.rs::verify`'s
+    // `verify_strict`. `target` names the terminal strict verifier and
+    // `receiver` names the local call, exactly as `command.rs::verify`'s own
+    // row does. Registered rather than exempted, because "it only delegates" is
+    // the claim this scan exists to check rather than accept.
+    VerifyFn {
+        file: "f2z-relay/src/engine.rs",
+        name: "verify_with",
+        occurrence: 0,
+        strictness: Strictness::DelegatesTo {
+            target: "f2z-relay-proto/src/key.rs::verify",
+            receiver: "verifier",
+        },
+    },
+    VerifyFn {
+        file: "f2z-relay-testkit/src/engine.rs",
+        name: "verify",
+        occurrence: 0,
+        strictness: Strictness::DelegatesTo {
+            target: "f2z-relay-proto/src/key.rs::verify",
+            receiver: "verifier",
+        },
+    },
     VerifyFn {
         file: "f2z-authority/src/key.rs",
         name: "verify",

--- a/rs/crates/f2z-relay-testkit/Cargo.toml
+++ b/rs/crates/f2z-relay-testkit/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "f2z-relay-testkit"
+version = "0.1.0"
+description = "FakeRelay: a spec-conforming, fault-injecting free2z relay for client development (docs/e2ee/WIRE.md v1)"
+edition.workspace = true
+# A restatement of wallet/rust-toolchain.toml's channel in Cargo's MSRV form,
+# registered with `scripts/check-rust-toolchain.sh --manifest` so it cannot
+# drift. Not inherited from the workspace: that check reads this literal line.
+rust-version = "1.97"
+# Permissive, deliberately and explicitly. A test harness is linked by client
+# test suites — ZUULI's, the web client's, and any third party's — so it sits on
+# the same side of the boundary as the crates it exercises. The AGPL-3.0
+# boundary starts at the real server binaries, and `f2z-fakerelay` is not one:
+# it stores nothing durably, it is refused a non-loopback bind, and it exists to
+# be linked into other people's tests. Stated literally rather than inherited so
+# it is visible to anyone opening the crate. rs/deny.toml enforces it.
+license = "MIT"
+repository.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+f2z-codec = { path = "../f2z-codec", version = "0.1.0" }
+# `version` beside `path` is not redundant: rs/deny.toml sets
+# `wildcards = "deny"`, and a bare path dependency is a wildcard requirement.
+f2z-relay-proto = { path = "../f2z-relay-proto", version = "0.1.0" }
+tls_codec = { workspace = true }
+# Native-only, on purpose. This crate is NOT on rs.yml's wasm32 line: it opens
+# sockets, spawns tasks and reads a clock, none of which a browser build of the
+# client core may ever pull in. Keeping it off that line is what stops a testkit
+# dependency from leaking into the shipped WASM bundle.
+tokio = { version = "1", features = [
+  "io-util",
+  "macros",
+  "net",
+  "rt",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }
+# The real WebSocket half of `WIRE.md` §2. The in-process transport cannot
+# exercise framing, ordering or reconnection, so the same relay is also served
+# over a real listener, and that needs a real RFC 6455 implementation rather
+# than one of ours.
+tokio-tungstenite = "0.30"
+# `BoxFuture` for the object-safe transport trait, and `SinkExt`/`StreamExt` for
+# the WebSocket stream. Already in tokio-tungstenite's graph.
+futures-util = { version = "0.3", default-features = false, features = [
+  "sink",
+  "std",
+] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }

--- a/rs/crates/f2z-relay-testkit/README.md
+++ b/rs/crates/f2z-relay-testkit/README.md
@@ -1,0 +1,188 @@
+# `f2z-relay-testkit` — the FakeRelay
+
+A spec-conforming free2z relay you can break on purpose, so a client can be
+built and tested **before `f2z-relay` exists**.
+
+It implements [`docs/e2ee/WIRE.md`](../../../docs/e2ee/WIRE.md) v1 §2 through
+§13 on top of `f2z-codec` (canonical encoding, framing, re-encode equality) and
+`f2z-relay-proto` (the signing transcript, anti-replay, queue and ACK rules, the
+capability document). Nothing in those two crates is reimplemented here — a
+conformance fake that held a second opinion about the protocol would be worse
+than none.
+
+## One command, one endpoint
+
+```sh
+cargo run -p f2z-relay-testkit --bin f2z-fakerelay
+# → ws://127.0.0.1:9944/relay/v1
+```
+
+or
+
+```sh
+cd rs/deploy && docker compose -f docker-compose.dev.yml up
+```
+
+## In a test
+
+```rust,no_run
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_testkit::fake::FakeRelay;
+
+# async fn example() -> Result<(), Box<dyn core::error::Error>> {
+let relay = FakeRelay::with_defaults()?;
+let mut bob = relay.client().await?;                      // in-process, no sockets
+let bob_key = SigningKey::from_seed(&[1u8; 32]);
+let queue = bob.create_queue(&bob_key, 0, 0, None).await?;
+
+let mut alice = relay.client().await?;
+let alice_key = SigningKey::from_seed(&[2u8; 32]);
+alice.bind_send(&alice_key, queue.send_addr).await?;
+alice.append(&alice_key, queue.send_addr, b"ciphertext").await?;
+
+let read = bob.read(&bob_key, queue.recv_addr, 0, 0, 0).await?;
+// …the durable local write happens HERE — WIRE.md §8.4's MUST — and only then:
+bob.ack(&bob_key, queue.recv_addr, 0).await?;
+# Ok(())
+# }
+```
+
+Over a real socket instead, which is where framing and ordering bugs actually
+appear:
+
+```rust,no_run
+# async fn example() -> Result<(), Box<dyn core::error::Error>> {
+# use f2z_relay_testkit::{fake::FakeRelay, client::Client, websocket};
+let relay = FakeRelay::with_defaults()?;
+let server = relay.listen_loopback().await?;              // ws://127.0.0.1:0
+let transport = websocket::connect(&server.url()).await?;
+let mut client = Client::connect(transport, relay.client_config()).await?;
+# Ok(())
+# }
+```
+
+## Breaking it on purpose
+
+Under delete-on-ack the failure paths are where data loss lives. A client that
+gets `APPEND` and `READ` right and gets a **dropped `ACK` response** wrong will
+lose messages in production and pass every test that only ever sees a healthy
+relay.
+
+```rust,no_run
+# use std::time::Duration;
+# use f2z_codec::{ErrorCode, commands::Command};
+# use f2z_relay_testkit::faults::{Effect, Fault, PolicyFaults, Trigger};
+# fn example(relay: &f2z_relay_testkit::fake::FakeRelay) {
+// The command runs; its answer never arrives. WIRE.md §2.5: unknown status.
+relay.faults().arm(Fault::once(Trigger::Command(Command::Ack), Effect::Drop));
+
+// §4.3: "a relay MAY complete a cheap PING before an expensive READ … and will"
+relay.faults().arm(Fault::once(Trigger::Command(Command::Read), Effect::Reorder));
+
+// §10: every code, including the ones a healthy relay never emits.
+relay.faults().arm(Fault::once(
+    Trigger::Command(Command::Append),
+    Effect::Refuse(ErrorCode::Backpressure),
+));
+
+// §7.7: expire a seven-day TTL now. §13.1: hit a quota. §5.5 + #586: publish a
+// capability document a conforming client must refuse.
+relay.faults().set_policy(PolicyFaults {
+    expire_messages_after: Some(Duration::ZERO),
+    max_queue_messages: Some(1),
+    unsound_antireplay_window: true,
+    ..PolicyFaults::default()
+});
+# }
+```
+
+Faults make the relay behave **worse** than the specification allows, in ways a
+real relay or a real network can. They are not the same as
+`config::Relaxations`, which make it **accept** something a conforming relay
+would reject — the single most dangerous thing a test double can do. Every
+relaxation is opt-in, off by default, and named after the rule it suspends.
+
+## The conformance suite
+
+`vectors::suite()` is a set of `(input, expected output)` cases driven through
+the ordinary client API against an `Endpoint`. Three targets:
+
+```rust,no_run
+# use std::sync::Arc;
+# use f2z_relay_testkit::{fake::{Endpoint, FakeRelay, WebSocketEndpoint}, vectors};
+# async fn example() -> Result<(), Box<dyn core::error::Error>> {
+let relay = FakeRelay::with_defaults()?;
+
+// 1. in-process
+let report = vectors::run(Arc::new(relay.in_process_endpoint())).await;
+
+// 2. this crate's own ws:// listener
+let server = relay.listen_loopback().await?;
+let report = vectors::run(Arc::new(relay.websocket_endpoint(&server))).await;
+
+// 3. the real relay, later, with this file unchanged
+let report = vectors::run(Arc::new(WebSocketEndpoint::new(
+    "wss://relay.example/relay/v1",
+)))
+.await;
+println!("{}", report.summary());
+# Ok(())
+# }
+```
+
+A vector that needs to break the relay declares `Needs::Faults` or
+`Needs::Clock` and reports **skipped** against a target with no such handle —
+never passed. `tests/conformance.rs` additionally runs the suite against the
+in-process and WebSocket transports and asserts the verdicts are identical,
+which is what makes "both transports run the same implementation" a check
+rather than a claim.
+
+## `f2z-fakerelay` is not a relay
+
+Three properties make deploying it a security incident rather than a mistake,
+and all three are published in the signed capability document it serves:
+
+| Property | What `WIRE.md` requires | Why it is this way |
+|---|---|---|
+| Queue addresses are **predictable** | §7.1: from the relay's own CSPRNG, unpredictable so they cannot be squatted | A conformance vector that produced different addresses each run would not be a vector |
+| Serves **`ws://`** | §2.1: `wss://` only | No certificate, no trust decision; taken honestly as §2.3's `--insecure-listen` case, published as `transport_security: none` and `channel_binding_mode: none` |
+| **Nothing is durable** | §8.4 publishes `durability_mode`; this is `memory` | It is a `BTreeMap` that dies with the process |
+
+§2.3's binding rule is enforced, not printed: a non-loopback bind is refused
+unless `--insecure-listen` is typed, and typing it prints the three obligations
+§2.3 attaches to the override.
+
+A conforming client **refuses** this relay unless it opts in per relay:
+
+```rust,no_run
+# use f2z_relay_proto::capabilities::ClientPolicy;
+let policy = ClientPolicy { allow_insecure_transport: true, ..ClientPolicy::default() };
+```
+
+That refusal is §2.3 obligation 3 working as designed. A client author should
+see it fail before they see it pass.
+
+## Known gaps
+
+- **The `.well-known` capability document of §11.2 is not served.** The document
+  is available over the protocol (`GET_CAPABILITIES`) and its digest is
+  comparable against `HELLO` (`capabilities::check_digest`), but the plain-HTTPS
+  JSON representation is not. Serving it would mean adding an HTTP parser beside
+  the WebSocket one, which is the second parser §2.2 argues against, for an
+  affordance aimed at humans rather than at clients. A client's "fetch the
+  well-known copy and compare digests" path therefore cannot be exercised
+  against this harness.
+- **`queue_creation_mode: token` is not implemented.** §13.1 defines it as an
+  operator-issued bearer credential and gives it no protocol shape in v1;
+  configuring it is refused at construction rather than faked.
+- **The channel binding is not a TLS exporter.** `ChannelBindingSource::Simulated`
+  hands both ends a constant so the §5.3 exporter code path is reachable, but it
+  binds a signature to *this configuration*, not to a TLS session. A passing test
+  there is not evidence about RFC 8446 §7.5.
+
+## Licence
+
+MIT, like `f2z-codec` and `f2z-relay-proto`, and for the same reason: client
+test suites link it. The AGPL-3.0 boundary starts at the real server binaries,
+and this is not one — it stores nothing, is refused a non-loopback bind, and
+exists to be linked into other people's tests.

--- a/rs/crates/f2z-relay-testkit/src/bin/f2z-fakerelay.rs
+++ b/rs/crates/f2z-relay-testkit/src/bin/f2z-fakerelay.rs
@@ -1,0 +1,310 @@
+//! `f2z-fakerelay` — a relay endpoint in one command, for client development.
+//!
+//! ```text
+//! cargo run -p f2z-relay-testkit --bin f2z-fakerelay
+//! # → ws://127.0.0.1:9944/relay/v1
+//! ```
+//!
+//! # Read this before pointing anything real at it
+//!
+//! **This is not a relay.** It is a conforming test double, and three of its
+//! properties make deployment a security incident rather than a mistake:
+//!
+//! 1. **Its addresses are predictable.** `WIRE.md` §7.1 requires queue
+//!    addresses from the relay's own CSPRNG, and §7.1's whole argument is that
+//!    a client cannot predict or squat them. This process derives them from a
+//!    seed with BLAKE2b in counter mode, so anyone who knows the seed — and the
+//!    default seed is a constant in this repository — knows every address it
+//!    will ever hand out.
+//! 2. **It serves `ws://`.** §2.1 admits `wss://` only. Everything except MLS
+//!    ciphertext — connection metadata, queue addresses, commands — travels in
+//!    the clear. That is published honestly as `transport_security: none` and
+//!    `channel_binding_mode: none`, and a conforming client refuses it without
+//!    an explicit per-relay opt-in (§2.3 obligation 3).
+//! 3. **It stores nothing durably.** `durability_mode: memory`. Every queue and
+//!    every message dies with the process.
+//!
+//! §2.3's binding rule is enforced rather than printed: a non-loopback address
+//! is refused unless `--insecure-listen` is typed, and typing it prints the
+//! three obligations §2.3 attaches to the override.
+
+use std::net::SocketAddr;
+use std::process::ExitCode;
+
+use f2z_relay_testkit::config::RelayConfig;
+use f2z_relay_testkit::fake::FakeRelay;
+use f2z_relay_testkit::faults::PolicyFaults;
+
+const DEFAULT_LISTEN: &str = "127.0.0.1:9944";
+
+const USAGE: &str = "\
+f2z-fakerelay — a spec-conforming FakeRelay over ws://, for client development.
+
+USAGE:
+    f2z-fakerelay [OPTIONS]
+
+OPTIONS:
+    --listen ADDR             Address to bind (default 127.0.0.1:9944).
+    --insecure-listen         Allow a non-loopback bind. WIRE.md §2.3 requires
+                              this to be an explicit act; it is refused
+                              otherwise, and the obligations are printed.
+    --pow                     Demand a proof-of-work stamp for queue creation
+                              (WIRE.md §13.1's default mode). The difficulty is
+                              deliberately trivial; see the crate docs.
+    --frozen-clock            Freeze the relay clock instead of following the
+                              host. Useful when driving TTLs from a script;
+                              a real client's timestamps will fall outside the
+                              window unless it reads GET_CHALLENGE(clock).
+    --seed HEX                32-byte hex seed for the address generator.
+    --identity-seed HEX       32-byte hex seed for the relay identity key.
+    --ping-interval-ms MS     WebSocket Ping interval (WIRE.md §2.4, default
+                              25000 in this binary).
+    --unsound-antireplay      Publish antireplay_window_ms below 2 x
+                              clock_skew_ms and enforce it — the capability
+                              document of https://github.com/free2z/zuu/issues/586,
+                              which the specification currently permits and a
+                              conforming client must refuse.
+    --backpressure            Start in WIRE.md §13.1 layer 4 global backpressure.
+    -h, --help                Print this and exit.
+";
+
+fn main() -> ExitCode {
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let options = match parse(&arguments) {
+        Ok(Some(options)) => options,
+        Ok(None) => {
+            print!("{USAGE}");
+            return ExitCode::SUCCESS;
+        }
+        Err(reason) => {
+            eprintln!("f2z-fakerelay: {reason}\n");
+            eprint!("{USAGE}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match run(options) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(reason) => {
+            eprintln!("f2z-fakerelay: {reason}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+struct Options {
+    listen: SocketAddr,
+    insecure_listen: bool,
+    pow: bool,
+    frozen_clock: bool,
+    seed: Option<[u8; 32]>,
+    identity_seed: Option<[u8; 32]>,
+    ping_interval_ms: u64,
+    unsound_antireplay: bool,
+    backpressure: bool,
+}
+
+fn parse(arguments: &[String]) -> Result<Option<Options>, String> {
+    let mut options = Options {
+        listen: DEFAULT_LISTEN
+            .parse()
+            .map_err(|_| "the built-in default address is unparseable".to_owned())?,
+        insecure_listen: false,
+        pow: false,
+        frozen_clock: false,
+        seed: None,
+        identity_seed: None,
+        // §2.4's published default. The library default is far shorter so tests
+        // do not wait 25 seconds to see a Ping; a binary a human runs should
+        // behave like the specification.
+        ping_interval_ms: 25_000,
+        unsound_antireplay: false,
+        backpressure: false,
+    };
+
+    let mut index = 0usize;
+    while let Some(argument) = arguments.get(index) {
+        index = index.saturating_add(1);
+        match argument.as_str() {
+            "-h" | "--help" => return Ok(None),
+            "--insecure-listen" => options.insecure_listen = true,
+            "--pow" => options.pow = true,
+            "--frozen-clock" => options.frozen_clock = true,
+            "--unsound-antireplay" => options.unsound_antireplay = true,
+            "--backpressure" => options.backpressure = true,
+            "--listen" => {
+                let value = value_of(arguments, &mut index, "--listen")?;
+                options.listen = value
+                    .parse()
+                    .map_err(|_| format!("--listen: {value} is not an address:port"))?;
+            }
+            "--seed" => {
+                let value = value_of(arguments, &mut index, "--seed")?;
+                options.seed = Some(parse_seed(&value)?);
+            }
+            "--identity-seed" => {
+                let value = value_of(arguments, &mut index, "--identity-seed")?;
+                options.identity_seed = Some(parse_seed(&value)?);
+            }
+            "--ping-interval-ms" => {
+                let value = value_of(arguments, &mut index, "--ping-interval-ms")?;
+                options.ping_interval_ms = value
+                    .parse()
+                    .map_err(|_| format!("--ping-interval-ms: {value} is not a number"))?;
+            }
+            other => return Err(format!("unknown option {other}")),
+        }
+    }
+    Ok(Some(options))
+}
+
+fn value_of(arguments: &[String], index: &mut usize, name: &str) -> Result<String, String> {
+    let value = arguments
+        .get(*index)
+        .ok_or_else(|| format!("{name} needs a value"))?;
+    *index = index.saturating_add(1);
+    Ok(value.clone())
+}
+
+fn parse_seed(text: &str) -> Result<[u8; 32], String> {
+    if text.len() != 64 {
+        return Err(format!("a seed is 64 hex characters, got {}", text.len()));
+    }
+    let mut seed = [0u8; 32];
+    let bytes = text.as_bytes();
+    for (slot, index) in seed.iter_mut().zip((0usize..64).step_by(2)) {
+        let pair = bytes
+            .get(index..index.saturating_add(2))
+            .and_then(|pair| std::str::from_utf8(pair).ok())
+            .ok_or_else(|| "a seed must be hex".to_owned())?;
+        *slot = u8::from_str_radix(pair, 16).map_err(|_| "a seed must be hex".to_owned())?;
+    }
+    Ok(seed)
+}
+
+fn run(options: Options) -> Result<(), String> {
+    let mut config = RelayConfig::default();
+    if !options.frozen_clock {
+        config = config.with_system_clock();
+    }
+    if options.pow {
+        config = config.with_pow();
+    }
+    if let Some(seed) = options.seed {
+        config.rng_seed = seed;
+    }
+    if let Some(seed) = options.identity_seed {
+        config.identity_seed = seed;
+    }
+    config.ping_interval = std::time::Duration::from_millis(options.ping_interval_ms);
+    config.policy_faults = PolicyFaults {
+        unsound_antireplay_window: options.unsound_antireplay,
+        global_backpressure: options.backpressure,
+        ..PolicyFaults::default()
+    };
+
+    let relay = FakeRelay::new(config).map_err(|error| error.to_string())?;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start the async runtime: {error}"))?;
+
+    runtime.block_on(async move {
+        let server = relay
+            .listen(options.listen, options.insecure_listen)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        announce(&relay, &server, &options);
+
+        // Serve until the process is signalled. There is no graceful-shutdown
+        // path on purpose: nothing here is durable, so there is nothing a
+        // graceful shutdown could preserve.
+        std::future::pending::<()>().await;
+        drop(server);
+        Ok(())
+    })
+}
+
+fn announce(
+    relay: &FakeRelay,
+    server: &f2z_relay_testkit::websocket::RelayServer,
+    options: &Options,
+) {
+    let published = relay.published_capabilities();
+    println!("f2z-fakerelay — a TEST DOUBLE. Do not deploy this.");
+    println!("  endpoint            {}", server.url());
+    println!(
+        "  relay_id            {}",
+        base64url(relay.relay_id().as_ref())
+    );
+    println!(
+        "  relay_identity_pk   {}",
+        base64url(relay.identity_key().as_ref())
+    );
+    println!("  protocol            WIRE.md v1, subprotocol free2z-relay.v1");
+    println!("  transport_security  none      (ws://, WIRE.md §2.3)");
+    println!("  channel_binding     none      (no TLS session to export from, §5.3)");
+    println!("  durability_mode     memory    (§8.4: an accepted APPEND may not survive)");
+    println!(
+        "  queue_creation      {}",
+        if options.pow { "pow" } else { "open" }
+    );
+    println!(
+        "  clock_skew_ms       {}   antireplay_window_ms {}",
+        published.clock_skew_ms, published.antireplay_window_ms
+    );
+    println!(
+        "  padding_sizes       {:?}",
+        published.padding_sizes.as_slice()
+    );
+    println!();
+    println!("A conforming client REFUSES this relay unless it opts in per-relay:");
+    println!("  ClientPolicy {{ allow_insecure_transport: true, .. }}   (§2.3 obligation 3)");
+    if options.unsound_antireplay {
+        println!();
+        println!("  !! --unsound-antireplay is on: antireplay_window_ms < 2 x clock_skew_ms.");
+        println!("     https://github.com/free2z/zuu/issues/586 — the document is VALID under");
+        println!("     WIRE.md as written, and a conforming client must refuse it anyway.");
+    }
+    if !server.local_addr().ip().is_loopback() {
+        println!();
+        println!("  !! Bound to a non-loopback address without TLS (§2.3 override). Obligations:");
+        println!("     1. transport_security: none is published. It is.");
+        println!("     2. channel_binding_mode: none is published. It is.");
+        println!("     3. Clients must refuse by default and require an explicit opt-in.");
+        println!("     Queue addresses from this process are PREDICTABLE. Do not use it.");
+    }
+}
+
+/// base64url without padding — `WIRE.md` §3.4's form for byte strings in
+/// human-readable output.
+fn base64url(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::with_capacity(bytes.len().saturating_mul(4).saturating_div(3));
+    for chunk in bytes.chunks(3) {
+        let first = chunk.first().copied().unwrap_or(0);
+        let second = chunk.get(1).copied().unwrap_or(0);
+        let third = chunk.get(2).copied().unwrap_or(0);
+        let triple = (u32::from(first) << 16) | (u32::from(second) << 8) | u32::from(third);
+        let indices = [
+            (triple >> 18) & 0x3f,
+            (triple >> 12) & 0x3f,
+            (triple >> 6) & 0x3f,
+            triple & 0x3f,
+        ];
+        let take = match chunk.len() {
+            1 => 2,
+            2 => 3,
+            _ => 4,
+        };
+        for index in indices.iter().take(take) {
+            let position = usize::try_from(*index).unwrap_or(0);
+            if let Some(symbol) = ALPHABET.get(position) {
+                out.push(char::from(*symbol));
+            }
+        }
+    }
+    out
+}

--- a/rs/crates/f2z-relay-testkit/src/client.rs
+++ b/rs/crates/f2z-relay-testkit/src/client.rs
@@ -1,0 +1,1000 @@
+//! A client, so the fake has something to be exercised by.
+//!
+//! This is not the client. ZUULI's engine and the WASM web client are the
+//! clients, and neither of them will link this. What this is: the smallest
+//! thing that can drive every command of §6 correctly, so that a conformance
+//! vector is a statement about the *relay* rather than about a test's ability
+//! to build a frame.
+//!
+//! It does obey the client-side MUSTs, though, and deliberately:
+//!
+//! - It verifies `relay_proof` before sending any signed command, and compares
+//!   `relay_id` against an expected value when it has one (§2.5, §5.2). Those
+//!   are `f2z-relay-proto::hello::verify_hello_response`, not code here.
+//! - It correlates strictly by `request_id` and never by arrival order, through
+//!   `f2z-relay-proto::inflight`'s typed ticket (§4.3).
+//! - It pads to a bucket before sending (§9) rather than relying on the relay
+//!   to tell it the size was wrong.
+//! - It re-reads the relay's clock rather than assuming its own (§5.5), and
+//!   never sets a system clock from it — there is no system clock here to set.
+//!
+//! Everything a vector needs to *break* on purpose is also here — a raw frame,
+//! a text frame, a chosen timestamp, a reused nonce — because a conformance
+//! suite that can only send valid frames tests half a protocol.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use f2z_codec::canonical::{Canonical, decode_canonical};
+use f2z_codec::commands::{
+    AckRequest, AckResponse, AppendRequest, BindSendRequest, ChallengePurpose, ChallengeRequest,
+    ChallengeResponse, ContactAppendRequest, CreateContactQueueRequest, CreateContactQueueResponse,
+    CreateQueueRequest, CreateQueueResponse, HelloRequest, PushEvent, ReadRequest, ReadResponse,
+    SignedCapabilities, SubscribeResponse,
+};
+use f2z_codec::frame::Push;
+use f2z_codec::frame::{FramePayload, RelayFrame, Response};
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::pow::{PowParams, PowStamp};
+use f2z_codec::types::{
+    Challenge, ChannelBinding, Nonce, Payload, QueueAddress, RelayId, ShortBytes,
+};
+use f2z_codec::{ErrorCode, PROTOCOL_VERSION};
+use f2z_relay_proto::ProtoError;
+use f2z_relay_proto::capabilities::ClientPolicy;
+use f2z_relay_proto::command::{Empty, RelayCommand, SignedCommand, ops, unsigned_request};
+use f2z_relay_proto::hello::{RelaySession, verify_hello_response};
+use f2z_relay_proto::inflight::InFlight;
+use f2z_relay_proto::key::SigningKey;
+
+use crate::error::{Result, TestkitError};
+use crate::rng::Csprng;
+use crate::transport::{Transport, TransportSink, TransportStream, WireMessage};
+
+/// How a client is set up before it says `HELLO`.
+#[derive(Clone)]
+pub struct ClientConfig {
+    /// §11.3's checklist, as a policy. Defaults here allow the insecure
+    /// transport a `FakeRelay` publishes, because refusing it is the *correct*
+    /// default and a harness that could not opt in could not test anything.
+    pub policy: ClientPolicy,
+    /// The `relay_id` an in-band advert named (§7.2), when there is one. A
+    /// mismatch is fatal and is reported as a substitution.
+    pub expected_relay_id: Option<RelayId>,
+    /// The value this client computed from its own TLS state — zeros when the
+    /// relay published `channel_binding_mode: none` (§5.3).
+    pub channel_binding: ChannelBinding,
+    /// The nonce stream. Deterministic, so a failing vector replays.
+    pub nonce_seed: [u8; 32],
+    /// How long any single read waits before giving up. Not a protocol value:
+    /// a timeout is a decision about a test, and §2.5's "unknown status" is
+    /// what a real client is left with.
+    pub read_timeout: Duration,
+    /// The sizes this client pads to (§9). The relay's published set MUST be a
+    /// superset.
+    pub padding: PaddingBuckets,
+}
+
+// `nonce_seed` decides every nonce this client will ever present, and a nonce
+// is half of §5.5's replay key. A derived `Debug` would print it as a decimal
+// byte dump.
+impl std::fmt::Debug for ClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientConfig")
+            .field("expected_relay_id", &self.expected_relay_id)
+            .field("channel_binding", &self.channel_binding)
+            .field("nonce_seed", &"<redacted>")
+            .field("read_timeout", &self.read_timeout)
+            .field("padding", &self.padding)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            policy: ClientPolicy {
+                // §2.3 obligation 3: an explicit, per-relay opt-in. A test
+                // harness pointing at a `ws://` fake is exactly the case the
+                // obligation contemplates, and saying so here is the opt-in.
+                allow_insecure_transport: true,
+                ..ClientPolicy::default()
+            },
+            expected_relay_id: None,
+            channel_binding: ChannelBinding::zero(),
+            nonce_seed: *b"f2z-relay-testkit/client-nonces!",
+            read_timeout: Duration::from_secs(2),
+            padding: PaddingBuckets::default(),
+        }
+    }
+}
+
+/// A connected client.
+pub struct Client {
+    sink: Box<dyn TransportSink>,
+    stream: Box<dyn TransportStream>,
+    session: RelaySession,
+    inflight: InFlight,
+    rng: Csprng,
+    next_request_id: u32,
+    pushes: VecDeque<Push>,
+    read_timeout: Duration,
+    padding: PaddingBuckets,
+    opened: Instant,
+    /// Relay time at the last synchronisation, and the local instant it was
+    /// taken. §5.5: a client with an unreliable clock learns the relay's time
+    /// and applies the offset locally — it MUST NOT set its system clock.
+    relay_time_ms: u64,
+    relay_time_taken: Instant,
+    /// A deliberate override, for the vectors that need a stale timestamp.
+    timestamp_override: Option<u64>,
+    closed: bool,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("relay_id", &self.session.relay_id())
+            .field("inflight", &self.inflight.len())
+            .field("queued_pushes", &self.pushes.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Client {
+    /// Complete §2.5's steps 2 and 3 and open a session.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Protocol`] carrying a `Refusal` when the relay fails one
+    /// of §2.5's or §11.3's checks; [`TestkitError::Transport`] or
+    /// [`TestkitError::Timeout`] when it does not answer.
+    pub async fn connect(transport: Transport, config: ClientConfig) -> Result<Self> {
+        let (mut sink, mut stream) = transport.split();
+        let mut rng = Csprng::from_seed(config.nonce_seed);
+        let client_nonce = rng.next_challenge();
+        let offer = HelloRequest {
+            min_version: PROTOCOL_VERSION,
+            max_version: PROTOCOL_VERSION,
+            client_nonce,
+        };
+
+        // `HELLO` is exchanged before a `Client` exists, so there is no moment
+        // at which this type holds a session the relay has not proved. A
+        // placeholder would have been a hole in exactly the property
+        // `f2z-relay-proto` exists to give: a `RelaySession` is obtainable only
+        // by verifying `relay_proof`.
+        let mut inflight = InFlight::default();
+        let ticket = inflight.issue::<ops::Hello>(1)?;
+        let frame = unsigned_request::<ops::Hello>(1, &offer)?;
+        sink.send(WireMessage::Binary(frame.encode_canonical()?))
+            .await?;
+        let (request_id, response) =
+            await_hello(&mut sink, &mut stream, config.read_timeout).await?;
+        let hello = inflight.complete::<ops::Hello>(ticket, request_id, &response)?;
+
+        // The MUST that everything else rests on: verify the proof of
+        // possession, recompute `relay_id`, and compare it against the advert
+        // *before* any signed command exists.
+        let session = verify_hello_response(
+            &hello,
+            &offer,
+            &config.channel_binding,
+            config.expected_relay_id.as_ref(),
+            &config.policy,
+        )?;
+
+        let relay_time_ms = session.relay_time_ms();
+        Ok(Self {
+            sink,
+            stream,
+            session,
+            inflight,
+            rng,
+            next_request_id: 2,
+            pushes: VecDeque::new(),
+            read_timeout: config.read_timeout,
+            padding: config.padding.clone(),
+            opened: Instant::now(),
+            relay_time_ms,
+            relay_time_taken: Instant::now(),
+            timestamp_override: None,
+            closed: false,
+        })
+    }
+
+    /// The session opened by `HELLO`.
+    #[must_use]
+    pub const fn session(&self) -> &RelaySession {
+        &self.session
+    }
+
+    /// The relay's identity binding, as proved in `HELLO`.
+    #[must_use]
+    pub const fn relay_id(&self) -> RelayId {
+        self.session.relay_id()
+    }
+
+    /// How long this connection has been open. Only useful for diagnostics.
+    #[must_use]
+    pub fn age(&self) -> Duration {
+        self.opened.elapsed()
+    }
+
+    /// The client's current estimate of the relay's clock (§5.5).
+    #[must_use]
+    pub fn relay_time_ms(&self) -> u64 {
+        if let Some(override_ms) = self.timestamp_override {
+            return override_ms;
+        }
+        let elapsed = u64::try_from(self.relay_time_taken.elapsed().as_millis()).unwrap_or(0);
+        self.relay_time_ms.saturating_add(elapsed)
+    }
+
+    /// Force every subsequent signed command to carry this `timestamp_ms`.
+    ///
+    /// The only way to reach `ERR_STALE_TIMESTAMP` deliberately, and the only
+    /// way to build the two frames a replay test needs.
+    pub const fn set_timestamp(&mut self, timestamp_ms: Option<u64>) {
+        self.timestamp_override = timestamp_ms;
+    }
+
+    /// Re-read the relay's clock (§5.5's `GET_CHALLENGE(clock)`).
+    ///
+    /// A test that moves a frozen relay clock must call this, exactly as a
+    /// client whose device slept must.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::challenge`].
+    pub async fn resync_clock(&mut self) -> Result<()> {
+        let response = self.challenge(ChallengePurpose::Clock, &[]).await?;
+        self.relay_time_ms = response.relay_time_ms;
+        self.relay_time_taken = Instant::now();
+        Ok(())
+    }
+
+    /// The padding buckets this client emits to (§9).
+    #[must_use]
+    pub const fn padding(&self) -> &PaddingBuckets {
+        &self.padding
+    }
+
+    /// How long a single read waits. A vector that expects *nothing* to arrive
+    /// shortens this: waiting the full default to prove a negative is how a
+    /// suite becomes too slow to run.
+    pub const fn set_read_timeout(&mut self, timeout: Duration) {
+        self.read_timeout = timeout;
+    }
+
+    /// A fresh nonce from this client's deterministic stream.
+    pub fn nonce(&mut self) -> Nonce {
+        Nonce::new(self.rng.next_bytes::<16>())
+    }
+
+    // -- the command surface ----------------------------------------------
+
+    /// `GET_CAPABILITIES` (§6.1).
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_unsigned`].
+    pub async fn capabilities(&mut self) -> Result<SignedCapabilities> {
+        self.call_unsigned::<ops::GetCapabilities>(&Empty).await
+    }
+
+    /// `GET_CHALLENGE` (§6.1).
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_unsigned`].
+    pub async fn challenge(
+        &mut self,
+        purpose: ChallengePurpose,
+        scope: &[u8],
+    ) -> Result<ChallengeResponse> {
+        let body = ChallengeRequest {
+            purpose: purpose.code(),
+            scope: ShortBytes::new(scope.to_vec())?,
+        };
+        self.call_unsigned::<ops::GetChallenge>(&body).await
+    }
+
+    /// `PING` (§6.1) — the application-level probe, distinct from §2.4's
+    /// WebSocket Ping, which a browser cannot send.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_unsigned`].
+    pub async fn ping(&mut self) -> Result<()> {
+        self.call_unsigned::<ops::Ping>(&Empty).await.map(|_| ())
+    }
+
+    /// `CREATE_QUEUE` (§6.2), solving a stamp first if the relay demands one.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`], plus anything `GET_CHALLENGE` returns.
+    pub async fn create_queue(
+        &mut self,
+        recv_key: &SigningKey,
+        message_ttl_seconds: u32,
+        idle_ttl_seconds: u32,
+        pow: Option<PowParams>,
+    ) -> Result<CreateQueueResponse> {
+        let stamp = self
+            .stamp_for(ChallengePurpose::QueueCreate, &[], pow)
+            .await?;
+        let body = CreateQueueRequest {
+            recv_key: recv_key.public_key(),
+            req_message_ttl_seconds: message_ttl_seconds,
+            req_idle_ttl_seconds: idle_ttl_seconds,
+            flags: 0,
+            stamp,
+        };
+        self.call_signed::<ops::CreateQueue>(recv_key, QueueAddress::zero(), &body)
+            .await
+    }
+
+    /// `CREATE_CONTACT_QUEUE` (§12.2).
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::create_queue`].
+    pub async fn create_contact_queue(
+        &mut self,
+        recv_key: &SigningKey,
+        message_ttl_seconds: u32,
+        idle_ttl_seconds: u32,
+        pow: Option<PowParams>,
+    ) -> Result<CreateContactQueueResponse> {
+        let stamp = self
+            .stamp_for(ChallengePurpose::QueueCreate, &[], pow)
+            .await?;
+        let body = CreateContactQueueRequest {
+            recv_key: recv_key.public_key(),
+            req_message_ttl_seconds: message_ttl_seconds,
+            req_idle_ttl_seconds: idle_ttl_seconds,
+            stamp,
+        };
+        self.call_signed::<ops::CreateContactQueue>(recv_key, QueueAddress::zero(), &body)
+            .await
+    }
+
+    /// `SUBSCRIBE` (§6.2).
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn subscribe(
+        &mut self,
+        recv_key: &SigningKey,
+        recv_addr: QueueAddress,
+    ) -> Result<SubscribeResponse> {
+        self.call_signed::<ops::Subscribe>(recv_key, recv_addr, &Empty)
+            .await
+    }
+
+    /// `UNSUBSCRIBE` (§6.2).
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn unsubscribe(
+        &mut self,
+        recv_key: &SigningKey,
+        recv_addr: QueueAddress,
+    ) -> Result<()> {
+        self.call_signed::<ops::Unsubscribe>(recv_key, recv_addr, &Empty)
+            .await
+            .map(|_| ())
+    }
+
+    /// `READ` (§6.2). Never mutates.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn read(
+        &mut self,
+        recv_key: &SigningKey,
+        recv_addr: QueueAddress,
+        from_index: u64,
+        max_messages: u16,
+        max_bytes: u32,
+    ) -> Result<ReadResponse> {
+        let body = ReadRequest {
+            from_index,
+            max_messages,
+            max_bytes,
+        };
+        self.call_signed::<ops::Read>(recv_key, recv_addr, &body)
+            .await
+    }
+
+    /// `ACK` (§6.2).
+    ///
+    /// **A real client MUST NOT call this before its durable local write has
+    /// completed.** ACK-on-read plus a crash is permanent message loss, because
+    /// the relay has already deleted the only copy (§8.4, `CLIENT-CONTRACT.md`
+    /// §9 rule 1). The wire protocol cannot enforce it and neither can this
+    /// function; it is restated here because this is where an implementer's
+    /// cursor will be.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn ack(
+        &mut self,
+        recv_key: &SigningKey,
+        recv_addr: QueueAddress,
+        up_to_index: u64,
+    ) -> Result<AckResponse> {
+        let body = AckRequest { up_to_index };
+        self.call_signed::<ops::Ack>(recv_key, recv_addr, &body)
+            .await
+    }
+
+    /// `DELETE_QUEUE` (§6.2). Irreversible.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn delete_queue(
+        &mut self,
+        recv_key: &SigningKey,
+        recv_addr: QueueAddress,
+    ) -> Result<()> {
+        self.call_signed::<ops::DeleteQueue>(recv_key, recv_addr, &Empty)
+            .await
+            .map(|_| ())
+    }
+
+    /// `BIND_SEND` (§6.3). Once-only and irreversible.
+    ///
+    /// `ERR_ALREADY_BOUND` on a first attempt for an address from a fresh
+    /// advert is a loud, non-dismissible failure (§7.4), not a retry.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn bind_send(
+        &mut self,
+        send_key: &SigningKey,
+        send_addr: QueueAddress,
+    ) -> Result<()> {
+        let body = BindSendRequest {
+            send_key: send_key.public_key(),
+        };
+        self.call_signed::<ops::BindSend>(send_key, send_addr, &body)
+            .await
+            .map(|_| ())
+    }
+
+    /// `APPEND` (§6.3), padded to a bucket first.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] if the plaintext is larger than the largest
+    /// bucket — §9 says chunk it client-side, and chunking is the application's
+    /// job, not this one's. Otherwise as [`Client::call_signed`].
+    pub async fn append(
+        &mut self,
+        send_key: &SigningKey,
+        send_addr: QueueAddress,
+        plaintext: &[u8],
+    ) -> Result<()> {
+        let payload = self.pad(plaintext)?;
+        let body = AppendRequest { payload };
+        self.call_signed::<ops::Append>(send_key, send_addr, &body)
+            .await
+            .map(|_| ())
+    }
+
+    /// `APPEND` with a payload of exactly this length, bucket or not.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`]. `ERR_BAD_SIZE` when the length is not a
+    /// published bucket, which is the point.
+    pub async fn append_raw_size(
+        &mut self,
+        send_key: &SigningKey,
+        send_addr: QueueAddress,
+        len: usize,
+    ) -> Result<()> {
+        let body = AppendRequest {
+            payload: Payload::new(vec![0u8; len])?,
+        };
+        self.call_signed::<ops::Append>(send_key, send_addr, &body)
+            .await
+            .map(|_| ())
+    }
+
+    /// `CONTACT_APPEND` (§12.2), solving a stamp scoped to `contact_addr`.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_unsigned`], plus anything `GET_CHALLENGE` returns.
+    pub async fn contact_append(
+        &mut self,
+        contact_addr: QueueAddress,
+        plaintext: &[u8],
+        pow: Option<PowParams>,
+    ) -> Result<()> {
+        let payload = self.pad(plaintext)?;
+        let stamp = self
+            .stamp_for(
+                ChallengePurpose::ContactAppend,
+                contact_addr.as_bytes(),
+                pow,
+            )
+            .await?;
+        let body = ContactAppendRequest {
+            contact_addr,
+            payload,
+            stamp,
+        };
+        self.call_unsigned::<ops::ContactAppend>(&body)
+            .await
+            .map(|_| ())
+    }
+
+    // -- the machinery ----------------------------------------------------
+
+    /// Pad to the smallest bucket that fits (§9).
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] when the plaintext exceeds the largest bucket.
+    pub fn pad(&self, plaintext: &[u8]) -> Result<Payload> {
+        let Some(bucket) = self.padding.bucket_for(plaintext.len()) else {
+            return Err(TestkitError::Config(
+                "payload exceeds the largest padding bucket; chunk it client-side (WIRE.md §9)",
+            ));
+        };
+        let mut bytes = plaintext.to_vec();
+        bytes.resize(usize::try_from(bucket).unwrap_or(plaintext.len()), 0);
+        Ok(Payload::new(bytes)?)
+    }
+
+    /// Issue a signed command and wait for its answer.
+    ///
+    /// # Errors
+    ///
+    /// The relay's §10 code, or a transport failure.
+    pub async fn call_signed<C: RelayCommand>(
+        &mut self,
+        key: &SigningKey,
+        address: QueueAddress,
+        body: &C::Request,
+    ) -> Result<C::Response> {
+        let request_id = self.take_request_id();
+        let ticket = self.inflight.issue::<C>(request_id)?;
+        let nonce = self.nonce();
+        let timestamp = self.relay_time_ms();
+        let signed = SignedCommand::<C>::create(
+            self.session.transcripts(),
+            request_id,
+            address,
+            timestamp,
+            nonce,
+            key,
+            body,
+        )?;
+        self.send_frame(&signed.frame()?).await?;
+        let (frame_id, response) = self.await_response().await?;
+        Ok(self.inflight.complete::<C>(ticket, frame_id, &response)?)
+    }
+
+    /// Issue an unsigned command and wait for its answer.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`].
+    pub async fn call_unsigned<C: RelayCommand>(
+        &mut self,
+        body: &C::Request,
+    ) -> Result<C::Response> {
+        let request_id = self.take_request_id();
+        let ticket = self.inflight.issue::<C>(request_id)?;
+        let frame = unsigned_request::<C>(request_id, body)?;
+        self.send_frame(&frame).await?;
+        let (frame_id, response) = self.await_response().await?;
+        Ok(self.inflight.complete::<C>(ticket, frame_id, &response)?)
+    }
+
+    /// Send a signed command and return without waiting, so a caller can fill
+    /// §4.3's in-flight window or interleave two commands.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_signed`], minus the response.
+    pub async fn send_signed<C: RelayCommand>(
+        &mut self,
+        key: &SigningKey,
+        address: QueueAddress,
+        body: &C::Request,
+    ) -> Result<u32> {
+        let request_id = self.take_request_id();
+        let nonce = self.nonce();
+        let timestamp = self.relay_time_ms();
+        let signed = SignedCommand::<C>::create(
+            self.session.transcripts(),
+            request_id,
+            address,
+            timestamp,
+            nonce,
+            key,
+            body,
+        )?;
+        self.send_frame(&signed.frame()?).await?;
+        Ok(request_id)
+    }
+
+    /// Send an unsigned command without waiting, so a caller can fill §4.3's
+    /// in-flight window.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::call_unsigned`], minus the response.
+    pub async fn send_unsigned<C: RelayCommand>(&mut self, body: &C::Request) -> Result<u32> {
+        let request_id = self.take_request_id();
+        let frame = unsigned_request::<C>(request_id, body)?;
+        self.send_frame(&frame).await?;
+        Ok(request_id)
+    }
+
+    /// The next response frame, whatever it answers.
+    ///
+    /// §4.3: responses may arrive out of order, so a caller that issued several
+    /// requests must be able to take them as they come and correlate itself.
+    /// Pushes are queued rather than returned.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Closed`] or [`TestkitError::Timeout`].
+    pub async fn next_response(&mut self) -> Result<(u32, Response)> {
+        self.await_response().await
+    }
+
+    /// The bytes of a signed command, without sending it. For the vectors that
+    /// replay a frame verbatim (§5.5, §5.6).
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Protocol`] if the command cannot be built.
+    pub fn encode_signed<C: RelayCommand>(
+        &mut self,
+        key: &SigningKey,
+        address: QueueAddress,
+        body: &C::Request,
+    ) -> Result<Vec<u8>> {
+        let request_id = self.take_request_id();
+        let nonce = self.nonce();
+        let timestamp = self.relay_time_ms();
+        let signed = SignedCommand::<C>::create(
+            self.session.transcripts(),
+            request_id,
+            address,
+            timestamp,
+            nonce,
+            key,
+            body,
+        )?;
+        Ok(signed.encode()?)
+    }
+
+    /// Write arbitrary bytes as a binary frame.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Transport`] if the write fails.
+    pub async fn send_raw(&mut self, bytes: Vec<u8>) -> Result<()> {
+        self.sink.send(WireMessage::Binary(bytes)).await?;
+        Ok(())
+    }
+
+    /// Write a text frame. §4.2: the relay must answer with a fatal
+    /// `ERR_FRAME_TYPE` and close with status 1003.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Transport`] if the write fails.
+    pub async fn send_text(&mut self, text: &str) -> Result<()> {
+        self.sink
+            .send(WireMessage::Text(text.as_bytes().to_vec()))
+            .await?;
+        Ok(())
+    }
+
+    /// The next push, waiting up to the configured read timeout.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Timeout`] if none arrives, [`TestkitError::Closed`] if
+    /// the connection ends first.
+    pub async fn next_push(&mut self) -> Result<Push> {
+        if let Some(push) = self.pushes.pop_front() {
+            return Ok(push);
+        }
+        loop {
+            match self.read_frame().await?.1 {
+                FramePayload::Push(push) => return Ok(push),
+                // A response nobody is waiting for. Keep reading rather than
+                // failing: a delayed or reordered response can legitimately
+                // arrive here after its caller gave up.
+                FramePayload::Request(_) | FramePayload::Response(_) => {}
+            }
+        }
+    }
+
+    /// The next push, decoded as a `QUEUE_EVENT` body.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::next_push`], plus [`TestkitError::Expectation`] if the push
+    /// was a different event.
+    pub async fn next_queue_event(&mut self) -> Result<f2z_codec::commands::QueueEventPush> {
+        let push = self.next_push().await?;
+        if push.event() != Some(PushEvent::QueueEvent) {
+            return Err(TestkitError::Expectation(format!(
+                "expected QUEUE_EVENT, got event {:#06x}",
+                push.event
+            )));
+        }
+        Ok(decode_canonical::<f2z_codec::commands::QueueEventPush>(push.body())?.into_value())
+    }
+
+    /// The next push, decoded as a `MSG` body.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::next_push`], plus [`TestkitError::Expectation`] if the push
+    /// was a different event.
+    pub async fn next_message(&mut self) -> Result<f2z_codec::commands::MsgPush> {
+        let push = self.next_push().await?;
+        if push.event() != Some(PushEvent::Msg) {
+            return Err(TestkitError::Expectation(format!(
+                "expected MSG, got event {:#06x}",
+                push.event
+            )));
+        }
+        Ok(decode_canonical::<f2z_codec::commands::MsgPush>(push.body())?.into_value())
+    }
+
+    /// Wait for the relay to close, which is what §1.3's fatal errors require
+    /// after the response.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Expectation`] if a frame arrives instead, or
+    /// [`TestkitError::Timeout`].
+    pub async fn expect_closed(&mut self) -> Result<()> {
+        loop {
+            let message = self.read_message().await?;
+            match message {
+                None | Some(WireMessage::Close(_)) => {
+                    self.closed = true;
+                    return Ok(());
+                }
+                Some(WireMessage::Ping(payload)) => {
+                    let _ = self.sink.send(WireMessage::Pong(payload)).await;
+                }
+                Some(WireMessage::Pong(_)) => {}
+                Some(WireMessage::Binary(bytes)) => {
+                    return Err(TestkitError::Expectation(format!(
+                        "expected the relay to close; it sent {} bytes instead",
+                        bytes.len()
+                    )));
+                }
+                Some(WireMessage::Text(_)) => {
+                    return Err(TestkitError::Expectation(
+                        "the relay sent a text frame, which no relay may do".to_owned(),
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Whether the peer has closed.
+    #[must_use]
+    pub const fn is_closed(&self) -> bool {
+        self.closed
+    }
+
+    /// Close from this side.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Transport`] if the close cannot be written.
+    pub async fn close(&mut self) -> Result<()> {
+        self.closed = true;
+        self.sink.close(crate::outbound::CLOSE_NORMAL).await?;
+        Ok(())
+    }
+
+    /// Solve a stamp, or return the empty one when no work is required.
+    ///
+    /// # Errors
+    ///
+    /// Anything `GET_CHALLENGE` returns.
+    pub async fn stamp_for(
+        &mut self,
+        purpose: ChallengePurpose,
+        scope: &[u8],
+        pow: Option<PowParams>,
+    ) -> Result<PowStamp> {
+        let params = match pow {
+            Some(params) if params.is_required() => params,
+            Some(_) => return Ok(PowStamp::empty()),
+            None => return Ok(PowStamp::empty()),
+        };
+        let issued = self.challenge(purpose, scope).await?;
+        Ok(solve(
+            issued.challenge,
+            &mut self.rng,
+            params.difficulty_bits,
+        ))
+    }
+
+    fn take_request_id(&mut self) -> u32 {
+        let id = self.next_request_id;
+        // §4.3: nonzero, and unique among the *currently in-flight* requests.
+        // Wrapping past zero is the one value it may never take.
+        self.next_request_id = self.next_request_id.checked_add(1).unwrap_or(1);
+        id
+    }
+
+    async fn send_frame(&mut self, frame: &RelayFrame) -> Result<()> {
+        let bytes = frame.encode_canonical()?;
+        self.sink.send(WireMessage::Binary(bytes)).await?;
+        Ok(())
+    }
+
+    async fn await_response(&mut self) -> Result<(u32, Response)> {
+        loop {
+            let (request_id, payload) = self.read_frame().await?;
+            match payload {
+                FramePayload::Response(response) => return Ok((request_id, response)),
+                // §4.3: responses may arrive out of order and a push may arrive
+                // between them. Queue it rather than treating it as the answer.
+                FramePayload::Push(push) => self.pushes.push_back(push),
+                FramePayload::Request(_) => {
+                    return Err(TestkitError::Expectation(
+                        "a relay sent a request frame, which no relay may do".to_owned(),
+                    ));
+                }
+            }
+        }
+    }
+
+    async fn read_frame(&mut self) -> Result<(u32, FramePayload)> {
+        loop {
+            let Some(message) = self.read_message().await? else {
+                self.closed = true;
+                return Err(TestkitError::Closed);
+            };
+            match message {
+                WireMessage::Binary(bytes) => {
+                    // §3.3 applies in both directions: a client that skipped it
+                    // would be the permissive decoder the rule exists to kill.
+                    let frame = decode_canonical::<RelayFrame>(&bytes)?.into_value();
+                    frame.validate()?;
+                    return Ok((frame.request_id, frame.payload));
+                }
+                WireMessage::Ping(payload) => {
+                    // §2.4: clients MUST respond to Ping with Pong. The browser
+                    // runtime does this without asking; a native client has to.
+                    let _ = self.sink.send(WireMessage::Pong(payload)).await;
+                }
+                WireMessage::Pong(_) => {}
+                WireMessage::Close(_) => {
+                    self.closed = true;
+                    return Err(TestkitError::Closed);
+                }
+                WireMessage::Text(_) => {
+                    return Err(TestkitError::Expectation(
+                        "the relay sent a text frame, which no relay may do".to_owned(),
+                    ));
+                }
+            }
+        }
+    }
+
+    async fn read_message(&mut self) -> Result<Option<WireMessage>> {
+        match tokio::time::timeout(self.read_timeout, self.stream.recv()).await {
+            Ok(Ok(message)) => Ok(message),
+            Ok(Err(error)) => Err(TestkitError::from(error)),
+            Err(_) => Err(TestkitError::Timeout),
+        }
+    }
+}
+
+/// Search for a stamp meeting `difficulty_bits` (§13.1).
+///
+/// A leading-zero-bit search over BLAKE2b, chosen so verification is a single
+/// hash. §12.4 is honest that this taxes phones far more than rented GPUs and
+/// that no tuning fixes it; at the testkit's difficulty the point is the shape
+/// of the exchange, not the cost.
+#[must_use]
+pub fn solve(challenge: Challenge, rng: &mut Csprng, difficulty_bits: u8) -> PowStamp {
+    let salt = f2z_codec::types::Salt::new(rng.next_bytes::<16>());
+    let mut stamp = PowStamp {
+        challenge,
+        salt,
+        counter: 0,
+    };
+    loop {
+        if stamp.meets_difficulty(difficulty_bits) {
+            return stamp;
+        }
+        stamp.counter = stamp.counter.wrapping_add(1);
+    }
+}
+
+/// Read the `HELLO` response before a `Client` exists.
+///
+/// Answers §2.4's Ping while it waits, because a relay whose keepalive fires
+/// during a slow handshake is not misbehaving.
+async fn await_hello(
+    sink: &mut Box<dyn TransportSink>,
+    stream: &mut Box<dyn TransportStream>,
+    read_timeout: Duration,
+) -> Result<(u32, Response)> {
+    loop {
+        let message = match tokio::time::timeout(read_timeout, stream.recv()).await {
+            Ok(Ok(Some(message))) => message,
+            Ok(Ok(None)) => return Err(TestkitError::Closed),
+            Ok(Err(error)) => return Err(TestkitError::from(error)),
+            Err(_) => return Err(TestkitError::Timeout),
+        };
+        match message {
+            WireMessage::Binary(bytes) => {
+                let frame = decode_canonical::<RelayFrame>(&bytes)?.into_value();
+                frame.validate()?;
+                match frame.payload {
+                    FramePayload::Response(response) => return Ok((frame.request_id, response)),
+                    FramePayload::Push(_) | FramePayload::Request(_) => {
+                        return Err(TestkitError::Expectation(
+                            "the relay answered HELLO with something that is not a response"
+                                .to_owned(),
+                        ));
+                    }
+                }
+            }
+            WireMessage::Ping(payload) => {
+                let _ = sink.send(WireMessage::Pong(payload)).await;
+            }
+            WireMessage::Pong(_) => {}
+            WireMessage::Close(_) => return Err(TestkitError::Closed),
+            WireMessage::Text(_) => {
+                return Err(TestkitError::Expectation(
+                    "the relay sent a text frame, which no relay may do".to_owned(),
+                ));
+            }
+        }
+    }
+}
+
+/// Convenience: the error code a call returned, if it returned one.
+#[must_use]
+pub fn code_of<T>(result: &Result<T>) -> Option<ErrorCode> {
+    match result {
+        Err(error) => error.wire_code(),
+        Ok(_) => None,
+    }
+}
+
+/// Convenience: whether a call was refused by the client rather than by the
+/// relay (§11.3).
+#[must_use]
+pub fn refusal_of<T>(result: &Result<T>) -> Option<f2z_relay_proto::Refusal> {
+    match result {
+        Err(TestkitError::Protocol(ProtoError::Refused(refusal))) => Some(*refusal),
+        _ => None,
+    }
+}
+
+/// The command marker types, re-exported so a vector needs one import.
+pub use f2z_relay_proto::command::ops as commands;

--- a/rs/crates/f2z-relay-testkit/src/clock.rs
+++ b/rs/crates/f2z-relay-testkit/src/clock.rs
@@ -1,0 +1,196 @@
+//! The relay's clock, made steerable.
+//!
+//! `f2z-relay-proto` is deliberately clock-free: every rule that needs the time
+//! takes it as an argument, because the same code has to run in a browser. That
+//! leaves somebody holding the clock, and in a test harness it should be the
+//! test.
+//!
+//! Three things in `WIRE.md` are only reachable by moving time:
+//!
+//! - `ERR_STALE_TIMESTAMP` (§5.5) needs a client and a relay that disagree by
+//!   more than `clock_skew_ms`.
+//! - Message TTL and queue idle TTL (§7.7) are seven days and ninety days.
+//!   Nobody tests those by waiting.
+//! - The seen-set ages entries out on a wall-clock schedule (§5.5), and the
+//!   `antireplay_window_ms < 2 × clock_skew_ms` defect of [#586] is a statement
+//!   about exactly that schedule.
+//!
+//! So [`Clock::manual`] freezes time and lets a test step it, and
+//! [`Clock::system`] follows the wall clock with an adjustable offset for the
+//! cases where a real listener wants real time. Both are cheap to clone and
+//! shared by every connection of one relay, because a relay has one clock.
+//!
+//! [#586]: https://github.com/free2z/zuu/issues/586
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A relay clock, in milliseconds since the Unix epoch.
+#[derive(Clone, Debug)]
+pub struct Clock {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    /// `Some` for a frozen clock: the current value, stepped by `advance`.
+    frozen: Option<AtomicU64>,
+    /// Applied to both modes, so a system-time relay can also be nudged.
+    offset_ms: AtomicI64,
+}
+
+impl Clock {
+    /// A clock that follows the host's wall clock.
+    ///
+    /// This is what `f2z-fakerelay` runs on: a client developer pointing a real
+    /// application at the endpoint expects `relay_time_ms` to be the real time,
+    /// because their own `timestamp_ms` will be.
+    #[must_use]
+    pub fn system() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                frozen: None,
+                offset_ms: AtomicI64::new(0),
+            }),
+        }
+    }
+
+    /// A clock frozen at `now_ms`, moved only by [`Clock::advance`] and
+    /// [`Clock::set`].
+    ///
+    /// Frozen is the default for the in-process relay. A test that asserts on a
+    /// timestamp window or a TTL must not also be a test of how long the CI
+    /// runner took to schedule a task.
+    #[must_use]
+    pub fn manual(now_ms: u64) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                frozen: Some(AtomicU64::new(now_ms)),
+                offset_ms: AtomicI64::new(0),
+            }),
+        }
+    }
+
+    /// The current relay time, in milliseconds since the Unix epoch.
+    #[must_use]
+    pub fn now_ms(&self) -> u64 {
+        let base = match &self.inner.frozen {
+            Some(frozen) => frozen.load(Ordering::SeqCst),
+            None => u64::try_from(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_or(0, |since| since.as_millis()),
+            )
+            .unwrap_or(u64::MAX),
+        };
+        let offset = self.inner.offset_ms.load(Ordering::SeqCst);
+        if offset >= 0 {
+            base.saturating_add(u64::try_from(offset).unwrap_or(0))
+        } else {
+            base.saturating_sub(offset.unsigned_abs())
+        }
+    }
+
+    /// Move time forward by `millis`.
+    ///
+    /// Works in both modes: on a frozen clock it steps the value, on a system
+    /// clock it moves the offset, so a test can make a relay's clock disagree
+    /// with its own by a known amount without touching the host.
+    pub fn advance(&self, millis: u64) {
+        match &self.inner.frozen {
+            Some(frozen) => {
+                let _ = frozen.fetch_add(millis, Ordering::SeqCst);
+            }
+            None => {
+                let step = i64::try_from(millis).unwrap_or(i64::MAX);
+                let _ = self.inner.offset_ms.fetch_add(step, Ordering::SeqCst);
+            }
+        }
+    }
+
+    /// Move time backward by `millis`. A relay whose clock went backwards is a
+    /// real operational event, and `ERR_STALE_TIMESTAMP` has a future half.
+    pub fn rewind(&self, millis: u64) {
+        match &self.inner.frozen {
+            Some(frozen) => {
+                let _ = frozen.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                    Some(current.saturating_sub(millis))
+                });
+            }
+            None => {
+                let step = i64::try_from(millis).unwrap_or(i64::MAX);
+                let _ = self.inner.offset_ms.fetch_sub(step, Ordering::SeqCst);
+            }
+        }
+    }
+
+    /// Set a frozen clock to an absolute time. A no-op on a system clock, whose
+    /// base is not ours to set.
+    pub fn set(&self, now_ms: u64) {
+        if let Some(frozen) = &self.inner.frozen {
+            frozen.store(now_ms, Ordering::SeqCst);
+        }
+    }
+
+    /// Whether this clock is frozen.
+    #[must_use]
+    pub fn is_manual(&self) -> bool {
+        self.inner.frozen.is_some()
+    }
+}
+
+impl Default for Clock {
+    /// Frozen at a fixed, arbitrary instant in 2027, so that a default-built
+    /// relay produces the same timestamps on every run and in every timezone.
+    fn default() -> Self {
+        Self::manual(DEFAULT_EPOCH_MS)
+    }
+}
+
+/// The instant [`Clock::default`] freezes at: 2027-01-01T00:00:00Z.
+///
+/// Any fixed value would do. It is in the future rather than the past so that a
+/// test which subtracts a TTL from it does not underflow into 1970.
+pub const DEFAULT_EPOCH_MS: u64 = 1_798_761_600_000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_frozen_clock_does_not_move_on_its_own() {
+        let clock = Clock::manual(1_000);
+        assert_eq!(clock.now_ms(), 1_000);
+        assert_eq!(clock.now_ms(), 1_000);
+        clock.advance(500);
+        assert_eq!(clock.now_ms(), 1_500);
+        clock.rewind(2_000);
+        assert_eq!(clock.now_ms(), 0);
+        clock.set(42);
+        assert_eq!(clock.now_ms(), 42);
+    }
+
+    #[test]
+    fn clones_share_one_clock() {
+        let clock = Clock::manual(0);
+        let other = clock.clone();
+        clock.advance(7);
+        assert_eq!(other.now_ms(), 7);
+    }
+
+    #[test]
+    fn a_system_clock_can_still_be_nudged() {
+        let clock = Clock::system();
+        let before = clock.now_ms();
+        clock.advance(60_000);
+        assert!(clock.now_ms() >= before.saturating_add(60_000));
+        assert!(!clock.is_manual());
+    }
+
+    #[test]
+    fn the_default_is_frozen_and_reproducible() {
+        assert_eq!(Clock::default().now_ms(), DEFAULT_EPOCH_MS);
+        assert!(Clock::default().is_manual());
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/config.rs
+++ b/rs/crates/f2z-relay-testkit/src/config.rs
@@ -1,0 +1,468 @@
+//! What a `FakeRelay` is configured with, and the one place a deliberate
+//! departure from `WIRE.md` can be turned on.
+//!
+//! # The published document is the contract, including here
+//!
+//! Every policy value below ends up in the signed capability document of §11.1,
+//! and the relay then enforces exactly what it published. That is not a detail:
+//! §11.3 has a client *decide whether to talk to a relay at all* from that
+//! document, so a test harness whose behaviour and whose document disagree
+//! would teach clients to ignore it.
+//!
+//! The default document is therefore honest about what a `FakeRelay` is:
+//!
+//! - `transport_security: none` and `channel_binding_mode: none`. It serves
+//!   `ws://`, not `wss://` — it is the §2.3 `--insecure-listen` case, and §2.3
+//!   obligations 1 and 2 require exactly this pair. Clients must set
+//!   [`ClientPolicy::allow_insecure_transport`], which is §2.3 obligation 3
+//!   working as designed rather than a workaround.
+//! - `durability_mode: memory`. Storage is a `BTreeMap` that dies with the
+//!   process. §8.4 says an `APPEND` that returned 0 may not survive a crash in
+//!   this mode, which is true here in the strongest possible sense.
+//! - `queue_creation_mode: open`. §13.1 permits it for "a private relay on a
+//!   closed network", which is what a test double is. [`RelayConfig::with_pow`]
+//!   turns on `pow` mode for a client that wants to exercise stamps, at a
+//!   difficulty a phone would laugh at.
+//! - `antireplay_persistence: volatile`, because it is.
+//!
+//! None of those is a relaxation. Each is a policy `WIRE.md` allows, published
+//! where a client can read it and refuse.
+//!
+//! [`ClientPolicy::allow_insecure_transport`]: f2z_relay_proto::capabilities::ClientPolicy::allow_insecure_transport
+
+use std::time::Duration;
+
+use f2z_codec::commands::Capabilities;
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::pow::{ALGORITHM_BLAKE2B_LEADING_ZERO_BITS, PowParams};
+use f2z_codec::types::{ChannelBinding, ShortBytes};
+use f2z_relay_proto::capabilities::{
+    self, AntiReplayPersistence, ChannelBindingMode, DurabilityMode, QueueCreationMode,
+    TransportSecurity,
+};
+use f2z_relay_proto::key::SigningKey;
+
+use crate::clock::Clock;
+use crate::error::{Result, TestkitError};
+use crate::faults::PolicyFaults;
+
+/// The proof-of-work difficulty a `FakeRelay` demands when it demands any.
+///
+/// Eight leading zero bits is 256 expected hashes — microseconds. §12.4 is
+/// blunt that a difficulty high enough to cost an attacker anything is a
+/// difficulty that makes a cheap phone sit there heating up, and a test suite
+/// is the wrong place to pay that. What the low value still buys is the whole
+/// *shape* of the exchange: `GET_CHALLENGE`, a stamp over a relay-issued,
+/// single-use, expiring challenge, scoped to the target address, consumed on
+/// use. Every one of those is a client obligation and every one is exercised.
+pub const TESTKIT_POW_DIFFICULTY_BITS: u8 = 8;
+
+/// Where the channel binding of §5.3 comes from.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ChannelBindingSource {
+    /// 32 zero bytes, published as `channel_binding_mode: none`.
+    ///
+    /// The only honest choice for a relay with no TLS session, and §5.3's
+    /// stated consequence follows: the restart argument for a volatile
+    /// seen-set does not hold, so the document also says
+    /// `antireplay_persistence: volatile` and a client may refuse.
+    None,
+    /// A fixed value both ends are told, published as
+    /// `channel_binding_mode: tls-exporter`.
+    ///
+    /// **This is a simulation and is not a TLS exporter.** There is no TLS
+    /// session; the value is a constant handed to both ends, so it binds a
+    /// signature to *this configuration*, not to a session. It exists because
+    /// the exporter path is code a client must have and would otherwise be
+    /// unreachable without terminating TLS in a test. A client that treats a
+    /// passing test here as evidence about RFC 8446 §7.5 has misread it.
+    Simulated([u8; 32]),
+}
+
+// A channel binding is what every signature on the connection is bound to
+// (§5.3). It is never transmitted, and it is not printed either.
+impl core::fmt::Debug for ChannelBindingSource {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::None => f.write_str("ChannelBindingSource::None"),
+            Self::Simulated(_) => f.write_str("ChannelBindingSource::Simulated(<redacted>)"),
+        }
+    }
+}
+
+impl ChannelBindingSource {
+    /// The binding value both ends use.
+    #[must_use]
+    pub const fn value(self) -> ChannelBinding {
+        match self {
+            Self::None => ChannelBinding::zero(),
+            Self::Simulated(bytes) => ChannelBinding::new(bytes),
+        }
+    }
+
+    /// The `channel_binding_mode` byte this source publishes.
+    #[must_use]
+    pub const fn mode(self) -> ChannelBindingMode {
+        match self {
+            Self::None => ChannelBindingMode::None,
+            Self::Simulated(_) => ChannelBindingMode::TlsExporter,
+        }
+    }
+}
+
+/// Deliberate departures from `WIRE.md`, all off by default.
+///
+/// **Every field here makes the relay accept something a conforming relay would
+/// reject.** That is the most dangerous thing this crate can do: a fake that
+/// accepts what the real relay refuses teaches a client to write code that
+/// works in tests and fails in production. So each one is opt-in, each one is
+/// named after the rule it suspends, and [`Relaxations::any`] lets a harness
+/// assert that a run used none of them.
+///
+/// If you find yourself turning one on to make a client pass, the client is
+/// wrong. The exception is deliberately narrow: a *relay* implementer bringing
+/// up one layer at a time may want the layers below to stop refusing.
+///
+/// Deliberately **not** `#[non_exhaustive]`: like [`crate::faults::PolicyFaults`]
+/// this is built by the caller, in their own file, with struct-update syntax.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Relaxations {
+    /// Accept a payload whose length is not one of the published
+    /// `padding_sizes` (§9). Suspends `ERR_BAD_SIZE`.
+    pub accept_any_payload_size: bool,
+    /// Accept `timestamp_ms` outside `±clock_skew_ms` (§5.5). Suspends
+    /// `ERR_STALE_TIMESTAMP`. The seen-set still runs.
+    pub accept_any_timestamp: bool,
+    /// Accept `CREATE_QUEUE`, `CREATE_CONTACT_QUEUE` and `CONTACT_APPEND`
+    /// without a valid stamp even while the document demands one (§13.1).
+    /// Suspends `ERR_POW_REQUIRED` and `ERR_POW_INVALID`.
+    pub accept_missing_pow: bool,
+    /// Answer a second `HELLO` on one connection instead of refusing it
+    /// (§2.5, §3.5).
+    pub accept_repeated_hello: bool,
+}
+
+impl Relaxations {
+    /// Whether any rule is suspended.
+    #[must_use]
+    pub const fn any(self) -> bool {
+        self.accept_any_payload_size
+            || self.accept_any_timestamp
+            || self.accept_missing_pow
+            || self.accept_repeated_hello
+    }
+}
+
+/// Everything a [`FakeRelay`] is built from.
+///
+/// [`FakeRelay`]: crate::FakeRelay
+#[derive(Clone)]
+pub struct RelayConfig {
+    /// The 32-byte seed of the relay's long-term Ed25519 identity key. Fixed by
+    /// default so `relay_id` is reproducible across runs and can be written
+    /// into a test's expectations.
+    pub identity_seed: [u8; 32],
+    /// The seed of the address and challenge generator. See [`crate::rng`] for
+    /// why a test harness wants this deterministic and why that means
+    /// `f2z-fakerelay` must never be deployed.
+    pub rng_seed: [u8; 32],
+    /// The relay's clock. Frozen by default (§5.5, §7.7 are unreachable
+    /// otherwise).
+    pub clock: Clock,
+    /// Where §5.3's channel binding comes from.
+    pub channel_binding: ChannelBindingSource,
+    /// §2.5's deadline between accept and a valid `HELLO`.
+    pub handshake_timeout: Duration,
+    /// §2.4's server-side WebSocket Ping interval. Short by default so a test
+    /// does not wait 25 seconds to observe one.
+    pub ping_interval: Duration,
+    /// §2.4: close after this many consecutive missed Pongs.
+    pub missed_pongs_before_close: u32,
+    /// The published policy. Start from [`RelayConfig::default`] and edit; the
+    /// relay enforces what is in here, so an edit is a real policy change.
+    pub capabilities: Capabilities,
+    /// Deliberate departures from the specification. All off by default.
+    pub relaxations: Relaxations,
+    /// Faults that are properties of the relay rather than of a frame. Can also
+    /// be changed at runtime through [`crate::faults::FaultInjector`].
+    pub policy_faults: PolicyFaults,
+}
+
+// The two seeds decide the relay's identity key and every address it will hand
+// out. Neither is printed: the identity seed is genuinely secret key material,
+// and the address seed is §7.1's unpredictability in one value.
+impl core::fmt::Debug for RelayConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RelayConfig")
+            .field("identity_seed", &"<redacted>")
+            .field("rng_seed", &"<redacted>")
+            .field("clock", &self.clock)
+            .field("channel_binding", &self.channel_binding)
+            .field("handshake_timeout", &self.handshake_timeout)
+            .field("ping_interval", &self.ping_interval)
+            .field("relaxations", &self.relaxations)
+            .field("policy_faults", &self.policy_faults)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The default identity seed. A fixed, obviously-fake value: a `relay_id` that
+/// shows up in a production log is a `f2z-fakerelay` that should not be there.
+pub const DEFAULT_IDENTITY_SEED: [u8; 32] = *b"f2z-relay-testkit/fake-identity!";
+
+/// The default address-generator seed.
+pub const DEFAULT_RNG_SEED: [u8; 32] = *b"f2z-relay-testkit/fake-addresses";
+
+impl Default for RelayConfig {
+    fn default() -> Self {
+        let clock = Clock::default();
+        let identity = SigningKey::from_seed(&DEFAULT_IDENTITY_SEED);
+        let capabilities = default_capabilities(&identity, clock.now_ms())
+            // `defaults` is fallible only because its empty operator strings go
+            // through the same length-checked constructor as any other, and the
+            // testkit's strings are short constants. A default that cannot be
+            // built is a bug in this crate, not a condition a caller can act
+            // on, so it degrades to the unedited document rather than panicking
+            // inside `Default`.
+            .unwrap_or_else(|_| fallback_capabilities(&identity, clock.now_ms()));
+        Self {
+            identity_seed: DEFAULT_IDENTITY_SEED,
+            rng_seed: DEFAULT_RNG_SEED,
+            clock,
+            channel_binding: ChannelBindingSource::None,
+            handshake_timeout: Duration::from_millis(10_000),
+            ping_interval: Duration::from_millis(500),
+            missed_pongs_before_close: 2,
+            capabilities,
+            relaxations: Relaxations::default(),
+            policy_faults: PolicyFaults::default(),
+        }
+    }
+}
+
+impl RelayConfig {
+    /// The relay's identity key.
+    #[must_use]
+    pub fn identity(&self) -> SigningKey {
+        SigningKey::from_seed(&self.identity_seed)
+    }
+
+    /// Demand a proof-of-work stamp for queue creation (§13.1's default mode),
+    /// at [`TESTKIT_POW_DIFFICULTY_BITS`].
+    #[must_use]
+    pub fn with_pow(mut self) -> Self {
+        self.capabilities.queue_creation_mode = QueueCreationMode::Pow.code();
+        self.capabilities.queue_creation_pow = testkit_pow();
+        self
+    }
+
+    /// Run on the host's wall clock instead of a frozen one. What
+    /// `f2z-fakerelay` does, so a real client's real `timestamp_ms` lands
+    /// inside the window.
+    #[must_use]
+    pub fn with_system_clock(mut self) -> Self {
+        self.clock = Clock::system();
+        self
+    }
+
+    /// Simulate a TLS exporter binding. Read [`ChannelBindingSource::Simulated`]
+    /// before relying on what this proves.
+    #[must_use]
+    pub fn with_simulated_channel_binding(mut self, value: [u8; 32]) -> Self {
+        self.channel_binding = ChannelBindingSource::Simulated(value);
+        self.capabilities.channel_binding_mode = ChannelBindingMode::TlsExporter.code();
+        self
+    }
+
+    /// Set the published padding buckets, and enforce them.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] if the set is not the strictly ascending,
+    /// non-empty, non-zero set §11.1 declares.
+    pub fn with_padding(mut self, buckets: &PaddingBuckets) -> Result<Self> {
+        self.capabilities.padding_sizes = buckets.sizes().to_vec().into();
+        self.capabilities.max_frame_bytes = self
+            .capabilities
+            .max_frame_bytes
+            .max(buckets.largest().saturating_add(4096));
+        capabilities::validate(&self.capabilities)
+            .map_err(|_| TestkitError::Config("padding set makes the document inconsistent"))?;
+        Ok(self)
+    }
+
+    /// The padding buckets this relay publishes and enforces.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] if the configured document does not carry a
+    /// valid set.
+    pub fn padding(&self) -> Result<PaddingBuckets> {
+        PaddingBuckets::new(self.capabilities.padding_sizes.as_slice().to_vec())
+            .map_err(|_| TestkitError::Config("padding_sizes is not a valid ascending set"))
+    }
+
+    /// The capability document this configuration will actually publish, with
+    /// every policy fault applied.
+    ///
+    /// Separate from [`RelayConfig::capabilities`] because a fault that changes
+    /// behaviour must also change the published document — a relay whose
+    /// document and conduct disagree is the one thing a client cannot defend
+    /// against.
+    #[must_use]
+    pub fn published_capabilities(&self, faults: PolicyFaults) -> Capabilities {
+        let mut published = self.capabilities.clone();
+        published.channel_binding_mode = self.channel_binding.mode().code();
+        if faults.unsound_antireplay_window {
+            // Exactly the document #586 says a relay may publish today while
+            // fully conforming, and exactly the one a client should refuse.
+            published.antireplay_window_ms = published.clock_skew_ms;
+        }
+        if let Some(max) = faults.max_queue_messages {
+            published.max_queue_messages = max;
+        }
+        if let Some(max) = faults.max_queue_bytes {
+            published.max_queue_bytes = max;
+        }
+        published
+    }
+}
+
+/// The proof-of-work parameters a `FakeRelay` publishes when it demands work.
+#[must_use]
+pub fn testkit_pow() -> PowParams {
+    PowParams {
+        algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+        difficulty_bits: TESTKIT_POW_DIFFICULTY_BITS,
+        challenge_ttl_ms: 60_000,
+    }
+}
+
+/// The document a `FakeRelay` publishes by default.
+///
+/// # Errors
+///
+/// [`TestkitError::Config`] if the operator strings do not fit their length
+/// prefixes, which they do.
+pub fn default_capabilities(identity: &SigningKey, published_at_ms: u64) -> Result<Capabilities> {
+    let mut capabilities = capabilities::defaults(&identity.public_key(), published_at_ms)
+        .map_err(|_| TestkitError::Config("could not build the default capability document"))?;
+
+    // §2.3: no TLS, so no exporter, so both bytes say so. A relay that lies
+    // about `transport_security` is lying in its signed document, and the point
+    // of publishing it is that lying becomes an act with evidence.
+    capabilities.transport_security = TransportSecurity::None.code();
+    capabilities.channel_binding_mode = ChannelBindingMode::None.code();
+    capabilities.antireplay_persistence = AntiReplayPersistence::Volatile.code();
+    // §8.4: a BTreeMap that dies with the process.
+    capabilities.durability_mode = DurabilityMode::Memory.code();
+    // §13.1: `open` is permitted for a private relay on a closed network.
+    capabilities.queue_creation_mode = QueueCreationMode::Open.code();
+    capabilities.queue_creation_pow = PowParams::none();
+    // §12.3 requires proof of work whenever contact queues are offered, so the
+    // difficulty is trivial rather than absent.
+    capabilities.contact_append_pow = testkit_pow();
+    // §13.3: nothing here rate-limits by source, and the field says so rather
+    // than claiming a control that is not implemented.
+    capabilities.per_source_limits = 0;
+
+    // §11.1's operator block is "the point of the document". Filling it with
+    // the truth about what this process is beats leaving it empty.
+    capabilities.operator_name = short("f2z-relay-testkit FakeRelay (NOT A RELAY)")?;
+    capabilities.operator_contact = short("https://github.com/free2z/zuu/issues")?;
+    capabilities.operator_abuse_contact = short("https://github.com/free2z/zuu/issues")?;
+    capabilities.operator_jurisdiction = short("none - a test double, running in a test process")?;
+    capabilities.operator_policy_url =
+        short("https://github.com/free2z/zuu/blob/main/rs/crates/f2z-relay-testkit/README.md")?;
+    capabilities.source_repo_url = short("https://github.com/free2z/zuu")?;
+    capabilities.source_commit = short("unversioned - built from a working tree")?;
+    capabilities.build_digest = short("none - this binary is not reproducibly built")?;
+
+    Ok(capabilities)
+}
+
+fn fallback_capabilities(identity: &SigningKey, published_at_ms: u64) -> Capabilities {
+    // Reached only if a short ASCII constant above stops fitting in 255 bytes.
+    // The unedited document is still a valid one; it just answers none of the
+    // questions §11.1 exists to answer.
+    capabilities::defaults(&identity.public_key(), published_at_ms).unwrap_or_else(|_| {
+        // `defaults` itself cannot fail for a well-formed key. Rather than
+        // panic in `Default`, fall through to a document built from the same
+        // call with the same argument; if that is impossible the process has
+        // bigger problems than its capability document.
+        #[expect(
+            clippy::unwrap_used,
+            reason = "unreachable: capabilities::defaults is fallible only on an \
+                      over-long operator string, and this call passes none"
+        )]
+        capabilities::defaults(&identity.public_key(), published_at_ms).unwrap()
+    })
+}
+
+fn short(text: &str) -> Result<ShortBytes> {
+    ShortBytes::new(text.as_bytes().to_vec())
+        .map_err(|_| TestkitError::Config("an operator string exceeds 255 bytes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_relay_proto::capabilities::ClientPolicy;
+
+    #[test]
+    fn the_default_document_is_valid_and_says_what_it_is() {
+        let config = RelayConfig::default();
+        assert!(capabilities::validate(&config.capabilities).is_ok());
+        assert_eq!(
+            config.capabilities.transport_security,
+            TransportSecurity::None.code()
+        );
+        assert_eq!(
+            config.capabilities.durability_mode,
+            DurabilityMode::Memory.code()
+        );
+        assert!(!config.relaxations.any());
+    }
+
+    #[test]
+    fn a_default_client_refuses_the_default_relay_until_it_opts_in() {
+        // §2.3 obligation 3, working. This is the correct behaviour and a
+        // client author should see it fail before they see it pass.
+        let config = RelayConfig::default();
+        let strict = ClientPolicy::default();
+        assert!(strict.accept(&config.capabilities).is_err());
+
+        let opted_in = ClientPolicy {
+            allow_insecure_transport: true,
+            ..ClientPolicy::default()
+        };
+        assert!(opted_in.accept(&config.capabilities).is_ok());
+    }
+
+    #[test]
+    fn the_unsound_antireplay_fault_changes_the_published_document() {
+        let config = RelayConfig::default();
+        let faults = PolicyFaults {
+            unsound_antireplay_window: true,
+            ..PolicyFaults::default()
+        };
+        let published = config.published_capabilities(faults);
+        assert_eq!(published.antireplay_window_ms, published.clock_skew_ms);
+        // Still a *valid* document — that is the whole finding of #586.
+        assert!(capabilities::validate(&published).is_ok());
+        // And still refused by a client that checks the relation.
+        let policy = ClientPolicy {
+            allow_insecure_transport: true,
+            ..ClientPolicy::default()
+        };
+        assert!(policy.accept(&published).is_err());
+    }
+
+    #[test]
+    fn pow_mode_publishes_parameters_a_client_can_satisfy() {
+        let config = RelayConfig::default().with_pow();
+        assert!(capabilities::validate(&config.capabilities).is_ok());
+        assert!(config.capabilities.queue_creation_pow.is_required());
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/connection.rs
+++ b/rs/crates/f2z-relay-testkit/src/connection.rs
@@ -1,0 +1,311 @@
+//! One connection, driven identically over a pipe and over a socket.
+//!
+//! [`drive`] is the only connection loop in this crate. `FakeRelay::connect`
+//! hands it one end of a `tokio::io::duplex`; the `ws://` listener hands it a
+//! WebSocket. Everything below this line — the handshake deadline of §2.5, the
+//! keepalive of §2.4, the fatal-close rule of §1.3, and every fault effect — is
+//! written once and therefore cannot differ between the two.
+//!
+//! # Why the writer is a separate task
+//!
+//! Three of the fault effects are about *time*, not about content: a delay, a
+//! reorder, and a stall. None of them is expressible in a loop that reads a
+//! frame and writes its answer before reading again, because the answer to
+//! request 2 has to be able to overtake the answer to request 1. §4.3 says a
+//! relay "MAY complete a cheap `PING` before an expensive `READ` issued
+//! earlier, and will" — so a fake that could not do that would be a fake that
+//! quietly promised ordering the protocol denies.
+//!
+//! The split also makes the in-flight accounting honest. A dropped response is
+//! one the relay *sent*, so its `request_id` is released; a stalled response is
+//! one the relay never produced, so its id stays outstanding and §4.3's window
+//! fills. That distinction is decided in the engine, before the frame reaches
+//! the writer, and is the reason [`crate::faults::Effect::Stall`] and
+//! [`crate::faults::Effect::Drop`] are two effects rather than one.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{mpsc, watch};
+
+use crate::engine::Relay;
+use crate::faults::{Effect, FaultInjector};
+use crate::outbound::{CLOSE_NORMAL, CLOSE_PROTOCOL_ERROR, OutKind, Outbound};
+use crate::transport::{Transport, TransportSink, WireMessage};
+
+/// Serve one connection until either end closes.
+pub async fn drive(relay: Arc<Relay>, transport: Transport) {
+    let (sink, mut stream) = transport.split();
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<Outbound>();
+    let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+
+    let mut connection = relay.open_connection(outbound_tx.clone());
+    let faults = relay.faults().clone();
+    let writer = tokio::spawn(writer_task(sink, outbound_rx, faults, shutdown_tx));
+
+    let handshake_timeout = relay.config().handshake_timeout;
+    let ping_interval = relay.config().ping_interval;
+    let missed_pongs_before_close = relay.config().missed_pongs_before_close;
+    let mut missed_pongs = 0u32;
+    let mut ping = tokio::time::interval(ping_interval);
+    // The first tick of an `interval` fires immediately; a Ping before the
+    // client has even said HELLO is noise, not keepalive.
+    ping.tick().await;
+
+    loop {
+        let waiting_for_hello = !connection.hello_done;
+        let received = tokio::select! {
+            biased;
+            _ = shutdown_rx.changed() => break,
+            _ = ping.tick(), if !waiting_for_hello => {
+                // §2.4: the relay sends a Ping every `ws_ping_interval_seconds`
+                // and closes after two consecutive missed Pongs. Server-driven
+                // rather than client-driven because the browser WebSocket API
+                // cannot send a Ping frame at all, so a client-side keepalive
+                // would be a second mechanism only one of the two clients has.
+                missed_pongs = missed_pongs.saturating_add(1);
+                if missed_pongs > missed_pongs_before_close {
+                    let _ = outbound_tx.send(close_now(CLOSE_NORMAL));
+                    break;
+                }
+                let _ = outbound_tx.send(Outbound::keepalive());
+                continue;
+            }
+            message = read_with_deadline(&mut stream, waiting_for_hello, handshake_timeout) => message,
+        };
+
+        let message = match received {
+            Ok(Some(message)) => message,
+            // End of stream, a transport error, or §2.5's handshake deadline.
+            Ok(None) | Err(()) => break,
+        };
+
+        match message {
+            WireMessage::Binary(bytes) => {
+                for outbound in relay.handle_binary(&mut connection, &bytes) {
+                    if outbound_tx.send(outbound).is_err() {
+                        break;
+                    }
+                }
+            }
+            WireMessage::Text(_) => {
+                // §4.2, and nothing else: no decode attempt, no UTF-8
+                // validation of our own, no treating it as an accidental
+                // binary frame.
+                for outbound in relay.handle_text() {
+                    let _ = outbound_tx.send(outbound);
+                }
+                break;
+            }
+            WireMessage::Ping(payload) => {
+                let _ = outbound_tx.send(pong(payload));
+            }
+            WireMessage::Pong(_) => {
+                missed_pongs = 0;
+            }
+            WireMessage::Close(_) => break,
+        }
+    }
+
+    relay.close_connection(&connection);
+    drop(outbound_tx);
+    let _ = writer.await;
+}
+
+async fn read_with_deadline(
+    stream: &mut Box<dyn crate::transport::TransportStream>,
+    waiting_for_hello: bool,
+    timeout: Duration,
+) -> Result<Option<WireMessage>, ()> {
+    // §2.5: "A relay MUST cap the time between TCP accept and a valid `HELLO`
+    // (`handshake_timeout_ms`, default 10 000) and close on expiry." The cap
+    // applies only until HELLO; after that a subscribed client on a quiet queue
+    // legitimately sends nothing for hours, and §2.4's keepalive is what
+    // notices a dead one.
+    let read = stream.recv();
+    if waiting_for_hello {
+        match tokio::time::timeout(timeout, read).await {
+            Ok(Ok(message)) => Ok(message),
+            Ok(Err(_)) | Err(_) => Err(()),
+        }
+    } else {
+        read.await.map_err(|_| ())
+    }
+}
+
+fn pong(payload: Vec<u8>) -> Outbound {
+    Outbound {
+        bytes: payload,
+        kind: OutKind::Keepalive,
+        close_after: None,
+    }
+}
+
+fn close_now(status: u16) -> Outbound {
+    Outbound {
+        bytes: Vec::new(),
+        kind: OutKind::Response { effect: None },
+        close_after: Some(status),
+    }
+}
+
+/// The writer: the only place frames are actually put on the wire, and the only
+/// place delivery faults are applied.
+///
+/// It is a small scheduler rather than a loop, because a delay that blocked the
+/// frames behind it would not be a delay — it would be a stall of the whole
+/// connection, and §4.3's "responses may arrive out of order … and will" would
+/// be untestable. A delayed frame is parked with a deadline and the writer goes
+/// back to serving whatever else is ready.
+async fn writer_task(
+    mut sink: Box<dyn TransportSink>,
+    mut outbound: mpsc::UnboundedReceiver<Outbound>,
+    faults: FaultInjector,
+    shutdown: watch::Sender<bool>,
+) {
+    // §4.3's reordering, as a one-frame hold. Held frames are flushed when the
+    // connection ends, so a reorder rule that never sees a second frame
+    // degrades to a delay rather than to a silent drop — a fake that lost a
+    // frame here would be teaching a client the wrong lesson.
+    let mut held: Option<Outbound> = None;
+    let mut parked: Vec<(tokio::time::Instant, Outbound)> = Vec::new();
+    let mut inbound_open = true;
+
+    loop {
+        let due = parked.iter().map(|(deadline, _)| *deadline).min();
+
+        let frame = tokio::select! {
+            biased;
+            () = wait_until(due) => {
+                let Some(index) = earliest(&parked) else { continue };
+                if index >= parked.len() {
+                    continue;
+                }
+                let (_, mut frame) = parked.remove(index);
+                frame.kind = OutKind::Ready;
+                frame
+            }
+            received = outbound.recv(), if inbound_open => {
+                match received {
+                    Some(frame) => frame,
+                    None => {
+                        inbound_open = false;
+                        if parked.is_empty() {
+                            break;
+                        }
+                        continue;
+                    }
+                }
+            }
+        };
+
+        let effect = match frame.kind {
+            OutKind::Response { effect } => effect,
+            OutKind::Push { event } => faults.take_push_effect(event),
+            // Never faulted: a suppressed keepalive presents as a hung relay
+            // rather than as the fault it is. A parked frame has already had
+            // its rule applied.
+            OutKind::Keepalive | OutKind::Ready => None,
+        };
+
+        match effect {
+            Some(Effect::Drop | Effect::Stall) => continue,
+            Some(Effect::Delay(duration)) => {
+                let deadline = tokio::time::Instant::now()
+                    .checked_add(duration)
+                    // A delay longer than the runtime's clock can express is a
+                    // configuration mistake, not a fault worth honouring; the
+                    // frame goes out now rather than never.
+                    .unwrap_or_else(tokio::time::Instant::now);
+                parked.push((deadline, frame));
+                continue;
+            }
+            Some(Effect::Reorder) => {
+                if held.is_none() {
+                    held = Some(frame);
+                    continue;
+                }
+            }
+            Some(Effect::CloseBefore) => {
+                let _ = sink.close(CLOSE_PROTOCOL_ERROR).await;
+                let _ = shutdown.send(true);
+                return;
+            }
+            // A refusal never reaches the writer: it was applied in the engine,
+            // before the command ran, and arrived here as an ordinary error
+            // response.
+            Some(Effect::Close | Effect::Refuse(_)) | None => {}
+        }
+
+        let closing = frame.close_after;
+        let close_after_effect = matches!(effect, Some(Effect::Close));
+        if write(&mut sink, frame).await.is_err() {
+            break;
+        }
+        if let Some(waiting) = held.take()
+            && write(&mut sink, waiting).await.is_err()
+        {
+            break;
+        }
+        if let Some(status) = closing {
+            let _ = sink.close(status).await;
+            let _ = shutdown.send(true);
+            return;
+        }
+        if close_after_effect {
+            let _ = sink.close(CLOSE_NORMAL).await;
+            let _ = shutdown.send(true);
+            return;
+        }
+        if !inbound_open && parked.is_empty() {
+            break;
+        }
+    }
+
+    if let Some(waiting) = held.take() {
+        let _ = write(&mut sink, waiting).await;
+    }
+    let _ = sink.close(CLOSE_NORMAL).await;
+    let _ = shutdown.send(true);
+}
+
+/// Sleep until `deadline`, or forever when there is nothing parked.
+async fn wait_until(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+fn earliest(parked: &[(tokio::time::Instant, Outbound)]) -> Option<usize> {
+    let mut best: Option<(usize, tokio::time::Instant)> = None;
+    for (index, (deadline, _)) in parked.iter().enumerate() {
+        match best {
+            Some((_, current)) if current <= *deadline => {}
+            _ => best = Some((index, *deadline)),
+        }
+    }
+    best.map(|(index, _)| index)
+}
+
+async fn write(sink: &mut Box<dyn TransportSink>, frame: Outbound) -> std::io::Result<()> {
+    match frame.kind {
+        // A keepalive with an empty body is §2.4's Ping; one with a body is the
+        // Pong that answers a client's own Ping.
+        OutKind::Keepalive if frame.bytes.is_empty() => {
+            sink.send(WireMessage::Ping(Vec::new())).await
+        }
+        OutKind::Keepalive => sink.send(WireMessage::Pong(frame.bytes)).await,
+        // An empty-bodied response is not a frame at all: it is the bare close
+        // of a fatal error whose `request_id` could not be recovered (§4.2, and
+        // the unreadable-header case of §4.1).
+        OutKind::Response { .. } | OutKind::Push { .. } | OutKind::Ready
+            if frame.bytes.is_empty() =>
+        {
+            Ok(())
+        }
+        OutKind::Response { .. } | OutKind::Push { .. } | OutKind::Ready => {
+            sink.send(WireMessage::Binary(frame.bytes)).await
+        }
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/engine.rs
+++ b/rs/crates/f2z-relay-testkit/src/engine.rs
@@ -1,0 +1,1190 @@
+//! The relay itself: one frame in, zero or more frames out.
+//!
+//! This is the whole of `WIRE.md` that is not storage and not a socket, and it
+//! is the *only* implementation in this crate. The in-process transport and the
+//! real `ws://` listener both call [`Relay::handle_binary`]; if they did not,
+//! the fake would be two fakes and the in-process one would be lying about the
+//! other.
+//!
+//! # What is reused rather than rewritten
+//!
+//! Almost everything. `f2z-codec` owns re-encode equality (§3.3) and the
+//! framing (§4); `f2z-relay-proto` owns the verification order of §5.1, the
+//! anti-replay of §5.5, the queue rules of §7 and §8, and the capability
+//! document of §11. A relay that re-derived any of those would be a second
+//! opinion about the protocol, and the point of a conformance fake is that
+//! there is only one.
+//!
+//! What is genuinely decided here is the part those crates deliberately leave
+//! to a server: the order of the connection lifecycle (§2.5), the in-flight
+//! window (§4.3), which code answers which refusal, when a push is emitted, and
+//! the anti-abuse layering of §13.1.
+//!
+//! # The refusal codes, and the one rule behind most of them
+//!
+//! §6.3: **every send-side refusal that would distinguish queue state collapses
+//! to `ERR_UNAVAILABLE`.** Absent, deleted, expired, full-by-messages,
+//! full-by-bytes, unbound, wrong key, relay backpressure — one code. If they
+//! differed, a bound sender could learn the queue's depth by filling it, which
+//! is the escalation the two-address split exists to prevent. §10's table
+//! assigns "absent" to code 10 and therefore contradicts §6.3; [#586] tracks
+//! it, #583 resolved it in §6.3's favour, and this engine does the same.
+//!
+//! On the receive side the mirror rule is §10's existence-oracle rule: "no such
+//! queue" and "exists, but your key does not authorize it" return the same code
+//! 10, and the absent path performs a dummy Ed25519 verification first so the
+//! dominant CPU cost is present in both. That narrowing is exactly what §10
+//! says it is — a narrowing, not a closure.
+//!
+//! [#586]: https://github.com/free2z/zuu/issues/586
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+
+use f2z_codec::canonical::{Canonical, decode_canonical};
+use f2z_codec::commands::{
+    AckRequest, AckResponse, AppendRequest, Capabilities, ChallengePurpose, ChallengeRequest,
+    ChallengeResponse, Command, ContactAppendRequest, CreateContactQueueRequest,
+    CreateContactQueueResponse, CreateQueueRequest, CreateQueueResponse, HelloRequest,
+    HelloResponse, PushEvent, ReadRequest, ReadResponse, SubscribeResponse,
+};
+use f2z_codec::frame::{FramePayload, RelayFrame, Request, Response};
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::pow::{PowParams, PowStamp};
+use f2z_codec::transcript::TranscriptBuilder;
+use f2z_codec::types::{Digest, QueueAddress, RelayId};
+use f2z_codec::{ErrorCode, PROTOCOL_VERSION};
+use f2z_relay_proto::capabilities::{
+    self, ChannelBindingMode, QueueCreationMode, TransportSecurity,
+};
+use f2z_relay_proto::command::{CommandVerifier, Empty, RelayCommand, Verified, ops};
+use f2z_relay_proto::hello::{RelayAnnouncement, hello_response};
+use f2z_relay_proto::key::{SigningKey, dummy_verify};
+use f2z_relay_proto::queue::{AppendQuota, QueueKind, TtlPolicy};
+use f2z_relay_proto::replay::{SeenSet, TimestampWindow};
+use f2z_relay_proto::{ProtoError, capabilities::AntiReplayPersistence};
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::clock::Clock;
+use crate::config::{ChannelBindingSource, RelayConfig};
+use crate::error::{Result, TestkitError};
+use crate::faults::{Effect, FaultInjector, PolicyFaults};
+use crate::outbound::{
+    CLOSE_PROTOCOL_ERROR, CLOSE_UNSUPPORTED_DATA, OutKind, Outbound, push as push_frame,
+};
+use crate::state::{NOTICE_CAPABILITIES_CHANGED, RelayState};
+
+/// The default `antireplay_seen_max` of §5.5.
+///
+/// `WIRE.md` publishes the field but no default. 65 536 entries is about 3 MiB
+/// of `(key, nonce)` pairs, which is a bound a test process will never reach by
+/// accident and a fault can shrink deliberately.
+pub const DEFAULT_SEEN_MAX: usize = 65_536;
+
+/// One relay, shared by every connection it serves.
+pub struct Relay {
+    config: RelayConfig,
+    identity: SigningKey,
+    relay_id: RelayId,
+    clock: Clock,
+    faults: FaultInjector,
+    padding: PaddingBuckets,
+    ttl: TtlPolicy,
+    state: Mutex<RelayState>,
+}
+
+impl std::fmt::Debug for Relay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Relay")
+            .field("relay_id", &self.relay_id)
+            .field("armed_faults", &self.faults.armed())
+            .finish_non_exhaustive()
+    }
+}
+
+/// One connection's state.
+///
+/// §6.2: "a subscription is scoped to the connection and dies with it", and
+/// §4.3's in-flight window is per connection too. Everything else a relay knows
+/// is shared.
+#[derive(Debug)]
+pub struct Connection {
+    /// Identifier, so a subscription can be found and dropped.
+    pub id: u64,
+    /// Whether `HELLO` has completed (§2.5 step 2).
+    pub hello_done: bool,
+    /// §4.3's outstanding `request_id`s.
+    pub inflight: BTreeSet<u32>,
+    /// The receive addresses this connection is subscribed to.
+    pub subscriptions: BTreeSet<QueueAddress>,
+    /// Where pushes go.
+    pub pushes: UnboundedSender<Outbound>,
+    /// The transcript builder for this connection: the relay's own `relay_id`
+    /// and its own `channel_binding`, never the frame's (§5.2, §5.3).
+    pub transcripts: TranscriptBuilder,
+}
+
+impl Relay {
+    /// Build a relay from a configuration.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] if the configured capability document is not a
+    /// valid one, if its padding set is malformed, or if it selects
+    /// `queue_creation_mode: token`, which this crate does not implement — a
+    /// bearer token is an operator-issued credential with no protocol shape in
+    /// v1, and faking one would be inventing protocol rather than testing it.
+    pub fn new(config: RelayConfig) -> Result<Self> {
+        capabilities::validate(&config.capabilities)
+            .map_err(|_| TestkitError::Config("the configured capability document is invalid"))?;
+        if config.capabilities.queue_creation_mode == QueueCreationMode::Token.code() {
+            return Err(TestkitError::Config(
+                "queue_creation_mode: token is not implemented; \
+                 a bearer token has no protocol shape in WIRE.md v1",
+            ));
+        }
+        // §2.3 obligations 1 and 2 are a pair. A document that claims TLS while
+        // the process serves ws:// would be the one thing a client cannot
+        // defend against.
+        if config.capabilities.transport_security == TransportSecurity::Tls.code() {
+            return Err(TestkitError::Config(
+                "a FakeRelay serves ws://, so transport_security must be none (WIRE.md §2.3)",
+            ));
+        }
+        if config.capabilities.channel_binding_mode != config.channel_binding.mode().code() {
+            return Err(TestkitError::Config(
+                "channel_binding_mode disagrees with the configured binding source",
+            ));
+        }
+
+        let padding = config.padding()?;
+        let identity = config.identity();
+        let relay_id = f2z_codec::hash::relay_id(&identity.public_key());
+        let ttl = capabilities::ttl_policy(&config.capabilities);
+        let faults = FaultInjector::new();
+        faults.set_policy(config.policy_faults);
+        let clock = config.clock.clone();
+        let seen = Self::seen_set(&config, config.policy_faults);
+        let state = Mutex::new(RelayState::new(config.rng_seed, seen));
+        Ok(Self {
+            config,
+            identity,
+            relay_id,
+            clock,
+            faults,
+            padding,
+            ttl,
+            state,
+        })
+    }
+
+    fn seen_set(config: &RelayConfig, faults: PolicyFaults) -> SeenSet {
+        let published = config.published_capabilities(faults);
+        SeenSet::new(
+            u64::from(published.antireplay_window_ms),
+            faults.seen_set_max.unwrap_or(DEFAULT_SEEN_MAX),
+        )
+    }
+
+    /// The relay's identity binding (§5.2).
+    #[must_use]
+    pub const fn relay_id(&self) -> RelayId {
+        self.relay_id
+    }
+
+    /// The relay's long-term public key.
+    #[must_use]
+    pub fn identity_key(&self) -> f2z_codec::types::PublicKey {
+        self.identity.public_key()
+    }
+
+    /// The relay's clock.
+    #[must_use]
+    pub const fn clock(&self) -> &Clock {
+        &self.clock
+    }
+
+    /// The live fault handle.
+    #[must_use]
+    pub const fn faults(&self) -> &FaultInjector {
+        &self.faults
+    }
+
+    /// The configuration this relay was built from.
+    #[must_use]
+    pub const fn config(&self) -> &RelayConfig {
+        &self.config
+    }
+
+    /// The channel binding both ends use (§5.3).
+    #[must_use]
+    pub const fn channel_binding(&self) -> f2z_codec::types::ChannelBinding {
+        self.config.channel_binding.value()
+    }
+
+    /// The document as it stands right now, with every policy fault applied.
+    ///
+    /// Recomputed rather than cached because a fault armed mid-connection is a
+    /// policy change, and §6.4's `NOTICE(3)` exists precisely so a client can
+    /// find out about one without polling.
+    #[must_use]
+    pub fn published_capabilities(&self) -> Capabilities {
+        self.config.published_capabilities(self.faults.policy())
+    }
+
+    /// The signed document (§11.1).
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] if the document cannot be signed, which needs
+    /// an operator string longer than its length prefix.
+    pub fn signed_capabilities(&self) -> Result<f2z_codec::commands::SignedCapabilities> {
+        capabilities::sign(&self.identity, self.published_capabilities())
+            .map_err(|_| TestkitError::Config("could not sign the capability document"))
+    }
+
+    /// `capabilities_digest` for `HELLO` (§6.1).
+    ///
+    /// # Errors
+    ///
+    /// As [`Relay::signed_capabilities`].
+    pub fn capabilities_digest(&self) -> Result<Digest> {
+        capabilities::digest(&self.published_capabilities())
+            .map_err(|_| TestkitError::Config("could not digest the capability document"))
+    }
+
+    /// Announce a capability change to every subscribed connection — §6.4's
+    /// `NOTICE(3)`.
+    ///
+    /// Arming a policy fault changes the document; calling this afterwards is
+    /// what makes a client's re-fetch path reachable.
+    pub fn announce_capability_change(&self) {
+        let now = self.clock.now_ms();
+        if let Ok(state) = self.state.lock() {
+            state.notify_all(NOTICE_CAPABILITIES_CHANGED, now);
+        }
+    }
+
+    /// Open a connection.
+    pub fn open_connection(&self, pushes: UnboundedSender<Outbound>) -> Connection {
+        let id = self
+            .state
+            .lock()
+            .map_or(0, |mut state| state.next_connection_id());
+        Connection {
+            id,
+            hello_done: false,
+            inflight: BTreeSet::new(),
+            subscriptions: BTreeSet::new(),
+            pushes,
+            transcripts: TranscriptBuilder::new(
+                PROTOCOL_VERSION,
+                self.relay_id,
+                self.channel_binding(),
+            ),
+        }
+    }
+
+    /// Release a connection's subscriptions (§6.2).
+    pub fn close_connection(&self, connection: &Connection) {
+        if let Ok(mut state) = self.state.lock() {
+            state.drop_connection(connection.id, &connection.subscriptions);
+        }
+    }
+
+    /// Whether §13.1 layer 4's global backpressure is on.
+    fn backpressured(&self) -> bool {
+        self.faults.policy().global_backpressure
+    }
+
+    // ---------------------------------------------------------------------
+    // The frame path.
+    // ---------------------------------------------------------------------
+
+    /// §4.2: a text frame is a fatal `ERR_FRAME_TYPE`, closed with status 1003.
+    ///
+    /// The relay MUST NOT attempt to decode it, MUST NOT attempt UTF-8
+    /// validation beyond what the WebSocket layer already did, and MUST NOT
+    /// treat it as an accidental binary frame. All three are the absence of
+    /// code here.
+    #[must_use]
+    pub fn handle_text(&self) -> Vec<Outbound> {
+        // A text frame carries no recoverable `request_id`, so there is no
+        // response frame a conforming relay could build: §4.3 requires a
+        // response's id to be nonzero. The connection closes with 1003, which
+        // is what §4.2 actually names.
+        vec![Outbound {
+            bytes: Vec::new(),
+            kind: OutKind::Response { effect: None },
+            close_after: Some(CLOSE_UNSUPPORTED_DATA),
+        }]
+    }
+
+    /// Handle one binary frame (§4.1).
+    #[must_use]
+    pub fn handle_binary(&self, connection: &mut Connection, bytes: &[u8]) -> Vec<Outbound> {
+        let now = self.clock.now_ms();
+        let published = self.published_capabilities();
+
+        // §4.1: a frame exceeding `max_frame_bytes` is `ERR_MALFORMED`, fatal,
+        // and the relay MUST NOT buffer the remainder to produce a tidy error.
+        if bytes.len() > published.max_frame_bytes as usize {
+            return self.fatal(recover_request_id(bytes), ErrorCode::Malformed);
+        }
+
+        // §3.3 on the frame. Decode, re-encode, byte-compare — and the
+        // *re-encoded* bytes are what any signature covers.
+        let Ok(frame) = decode_canonical::<RelayFrame>(bytes) else {
+            return self.fatal(recover_request_id(bytes), ErrorCode::Malformed);
+        };
+        let frame = frame.into_value();
+        if frame.validate().is_err() {
+            return self.fatal(recover_request_id(bytes), ErrorCode::Malformed);
+        }
+        let request_id = frame.request_id;
+        let FramePayload::Request(request) = &frame.payload else {
+            // A client that sends a response or a push is speaking the wrong
+            // half of the protocol. §10 has no code for it; `ERR_MALFORMED` is
+            // the reading, and it is fatal, which is right for a frame no
+            // conforming client emits.
+            return self.fatal(request_id, ErrorCode::Malformed);
+        };
+
+        // §2.5 step 2: `HELLO` MUST be the first frame; a relay that receives
+        // any other frame first responds `ERR_UNSUPPORTED_VERSION` and closes.
+        let command = request.command();
+        if !connection.hello_done && command != Some(Command::Hello) {
+            return self.fatal(request_id, ErrorCode::UnsupportedVersion);
+        }
+        if connection.hello_done
+            && command == Some(Command::Hello)
+            && !self.config.relaxations.accept_repeated_hello
+        {
+            // §3.5: "version negotiation happens once, in HELLO, and applies to
+            // the whole connection." A second HELLO is a renegotiation attempt
+            // and gets the same code a version failure does. Listed as an
+            // ambiguity call: §10 does not name this case.
+            return self.fatal(request_id, ErrorCode::UnsupportedVersion);
+        }
+
+        // §4.3. A duplicate in-flight id is a fatal `ERR_MALFORMED`; exceeding
+        // the window is a fatal `ERR_TOO_MANY_INFLIGHT`. Both bounds exist so a
+        // single connection cannot make the relay allocate unbounded
+        // per-request state before any quota check has run.
+        if connection.inflight.contains(&request_id) {
+            return self.fatal(request_id, ErrorCode::Malformed);
+        }
+        if connection.inflight.len() >= usize::from(published.max_inflight) {
+            return self.fatal(request_id, ErrorCode::TooManyInflight);
+        }
+        connection.inflight.insert(request_id);
+
+        // A fault may refuse the command outright. Consulted here, before any
+        // state changes, so a refused APPEND really did not append.
+        let outcome = match self.faults.take_refusal(command) {
+            Some(code) => Err(ProtoError::Wire(code)),
+            None => match command {
+                Some(command) => self.dispatch(connection, now, request_id, command, request),
+                // §3.5: an unknown command code is a *non-fatal*
+                // `ERR_UNKNOWN_COMMAND`. The frame was well-formed framing, so
+                // the connection survives.
+                None => Err(ProtoError::Wire(ErrorCode::UnknownCommand)),
+            },
+        };
+
+        let (response, fatal) = match outcome {
+            Ok(body) => (
+                Response::ok(body).unwrap_or_else(|_| Response::error(ErrorCode::Internal)),
+                false,
+            ),
+            Err(error) => {
+                let code = error.wire_code().unwrap_or(ErrorCode::Internal);
+                (Response::error(code), code.is_fatal())
+            }
+        };
+
+        // §4.3's window is released when the relay answers. A stalled response
+        // is never answered, so its id stays outstanding — which is the whole
+        // point of the fault: a client that never times out will fill the
+        // window and earn a fatal `ERR_TOO_MANY_INFLIGHT`.
+        let effect = self.faults.take_response_effect(command);
+        if matches!(effect, Some(Effect::Stall)) {
+            return Vec::new();
+        }
+        connection.inflight.remove(&request_id);
+
+        let close = if fatal {
+            Some(CLOSE_PROTOCOL_ERROR)
+        } else {
+            None
+        };
+        match Outbound::response(request_id, response, effect) {
+            Some(mut outbound) => {
+                outbound.close_after = close;
+                vec![outbound]
+            }
+            None => self.fatal(request_id, ErrorCode::Internal),
+        }
+    }
+
+    fn fatal(&self, request_id: u32, code: ErrorCode) -> Vec<Outbound> {
+        // A frame whose `request_id` could not be recovered has no response a
+        // conforming relay can build (§4.3 forbids a zero id on a response), so
+        // the connection simply closes. Listed as an ambiguity call: §4.1 says
+        // "send the error and close" and does not say what to send when the id
+        // is unreadable.
+        if request_id == 0 {
+            return vec![Outbound {
+                bytes: Vec::new(),
+                kind: OutKind::Response { effect: None },
+                close_after: Some(CLOSE_PROTOCOL_ERROR),
+            }];
+        }
+        Outbound::fatal(request_id, code, CLOSE_PROTOCOL_ERROR)
+            .map_or_else(Vec::new, |outbound| vec![outbound])
+    }
+
+    // ---------------------------------------------------------------------
+    // Command dispatch.
+    // ---------------------------------------------------------------------
+
+    fn dispatch(
+        &self,
+        connection: &mut Connection,
+        now: u64,
+        request_id: u32,
+        command: Command,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        match command {
+            Command::Hello => self.hello(connection, request),
+            Command::GetCapabilities => self.get_capabilities(request),
+            Command::GetChallenge => self.get_challenge(now, request),
+            Command::Ping => self.ping(request),
+            Command::CreateQueue => self.create_queue(connection, now, request_id, request),
+            Command::CreateContactQueue => {
+                self.create_contact_queue(connection, now, request_id, request)
+            }
+            Command::Subscribe => self.subscribe(connection, now, request_id, request),
+            Command::Unsubscribe => self.unsubscribe(connection, now, request_id, request),
+            Command::Read => self.read(connection, now, request_id, request),
+            Command::Ack => self.ack(connection, now, request_id, request),
+            Command::DeleteQueue => self.delete_queue(connection, now, request_id, request),
+            Command::BindSend => self.bind_send(connection, now, request_id, request),
+            Command::Append => self.append(connection, now, request_id, request),
+            Command::ContactAppend => self.contact_append(now, request),
+            // `Command` is `#[non_exhaustive]`: a code added to f2z-codec but
+            // not handled here is a hole in this relay, not in the client that
+            // sent it. §3.5's non-fatal `ERR_UNKNOWN_COMMAND` is the honest
+            // answer — this build genuinely does not implement it.
+            _ => Err(ProtoError::Wire(ErrorCode::UnknownCommand)),
+        }
+    }
+
+    // -- §6.1, unsigned ----------------------------------------------------
+
+    fn hello(
+        &self,
+        connection: &mut Connection,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let offer: HelloRequest = self.accept_unsigned::<ops::Hello>(request)?.into_body();
+        if offer.min_version > offer.max_version
+            || PROTOCOL_VERSION < offer.min_version
+            || PROTOCOL_VERSION > offer.max_version
+        {
+            return Err(ProtoError::Wire(ErrorCode::UnsupportedVersion));
+        }
+        let digest = self
+            .capabilities_digest()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+        let announcement = RelayAnnouncement {
+            protocol_version: PROTOCOL_VERSION,
+            relay_time_ms: self.clock.now_ms(),
+            channel_binding_mode: match self.config.channel_binding {
+                ChannelBindingSource::None => ChannelBindingMode::None,
+                ChannelBindingSource::Simulated(_) => ChannelBindingMode::TlsExporter,
+            },
+            transport_security: TransportSecurity::None,
+            capabilities_digest: digest,
+        };
+        let response: HelloResponse = hello_response(
+            &self.identity,
+            &announcement,
+            &self.channel_binding(),
+            &offer.client_nonce,
+        );
+        connection.hello_done = true;
+        Ok(response.encode_canonical()?)
+    }
+
+    fn get_capabilities(&self, request: &Request) -> std::result::Result<Vec<u8>, ProtoError> {
+        let _: Empty = self
+            .accept_unsigned::<ops::GetCapabilities>(request)?
+            .into_body();
+        let signed = self
+            .signed_capabilities()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+        Ok(signed.encode_canonical()?)
+    }
+
+    fn ping(&self, request: &Request) -> std::result::Result<Vec<u8>, ProtoError> {
+        let _: Empty = self.accept_unsigned::<ops::Ping>(request)?.into_body();
+        Ok(Vec::new())
+    }
+
+    fn get_challenge(
+        &self,
+        now: u64,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let body: ChallengeRequest = self
+            .accept_unsigned::<ops::GetChallenge>(request)?
+            .into_body();
+        // `purpose` is a raw byte so an unknown value round-trips through §3.3
+        // rather than failing to decode. §10 has no code for "an enum value in
+        // a body that this build does not know", so `ERR_MALFORMED` is the
+        // reading here and it is listed as an ambiguity call.
+        let purpose = body
+            .purpose()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Malformed))?;
+        let params = self.pow_params_for(purpose);
+        let ttl = if params.challenge_ttl_ms == 0 {
+            60_000
+        } else {
+            params.challenge_ttl_ms
+        };
+        let expires_at_ms = now.saturating_add(u64::from(ttl));
+
+        let challenge = {
+            let mut state = self.state()?;
+            state.expire_challenges(now);
+            state.issue_challenge(purpose.code(), body.scope.as_slice(), expires_at_ms)
+        };
+
+        let response = ChallengeResponse {
+            relay_time_ms: now,
+            challenge,
+            expires_at_ms,
+            pow: params,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn pow_params_for(&self, purpose: ChallengePurpose) -> PowParams {
+        let published = self.published_capabilities();
+        match purpose {
+            // §6.1: the field is zeroed when no PoW is required, and a clock
+            // read never requires one.
+            ChallengePurpose::Clock => PowParams::none(),
+            ChallengePurpose::QueueCreate => published.queue_creation_pow,
+            ChallengePurpose::ContactAppend => published.contact_append_pow,
+        }
+    }
+
+    // -- §6.2, signed by the receive key -----------------------------------
+
+    fn create_queue(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::CreateQueue>(connection, now, request_id, request)?;
+        let body: CreateQueueRequest = verified.into_body();
+
+        // §13.1 layer 4, in the order the section states it: creation is the
+        // first thing refused.
+        if self.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Backpressure));
+        }
+        self.check_creation_stamp(now, &body.stamp)?;
+
+        let published = self.published_capabilities();
+        let message_ttl = self.ttl.grant_message_ttl(body.req_message_ttl_seconds);
+        let idle_ttl = self.ttl.grant_idle_ttl(body.req_idle_ttl_seconds);
+        let quota = AppendQuota {
+            max_messages: u64::from(published.max_queue_messages),
+            max_bytes: published.max_queue_bytes,
+        };
+
+        let mut state = self.state()?;
+        if let Some(max) = self.faults.policy().max_queues
+            && state.queue_count() >= max
+        {
+            // §10 code 14: a recv-side quota. Unlike the send side, the receive
+            // side is allowed a distinguishable code — the party being refused
+            // is the one that owns the queues.
+            return Err(ProtoError::Wire(ErrorCode::Quota));
+        }
+        let (recv_addr, send_addr) = state.create_queue(
+            QueueKind::Standard,
+            body.recv_key,
+            message_ttl,
+            idle_ttl,
+            quota,
+            now,
+        );
+        drop(state);
+
+        let response = CreateQueueResponse {
+            recv_addr,
+            send_addr,
+            message_ttl_seconds: message_ttl,
+            idle_ttl_seconds: idle_ttl,
+            created_at_ms: now,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn create_contact_queue(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified =
+            self.verify::<ops::CreateContactQueue>(connection, now, request_id, request)?;
+        let body: CreateContactQueueRequest = verified.into_body();
+
+        let published = self.published_capabilities();
+        if published.contact_queues_enabled == 0 {
+            return Err(ProtoError::Wire(ErrorCode::NotPermitted));
+        }
+        if self.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Backpressure));
+        }
+        self.check_creation_stamp(now, &body.stamp)?;
+
+        let message_ttl = self.ttl.grant_message_ttl(body.req_message_ttl_seconds);
+        let idle_ttl = self.ttl.grant_idle_ttl(body.req_idle_ttl_seconds);
+        // §12.3: a contact queue is hard-capped, because point 2 of §12.2 means
+        // the whole internet may write to it.
+        let quota = AppendQuota {
+            max_messages: u64::from(published.contact_max_pending),
+            max_bytes: published.contact_max_bytes,
+        };
+
+        let mut state = self.state()?;
+        if let Some(max) = self.faults.policy().max_queues
+            && state.queue_count() >= max
+        {
+            return Err(ProtoError::Wire(ErrorCode::Quota));
+        }
+        let (recv_addr, contact_addr) = state.create_queue(
+            QueueKind::Contact,
+            body.recv_key,
+            message_ttl,
+            idle_ttl,
+            quota,
+            now,
+        );
+        drop(state);
+
+        let response = CreateContactQueueResponse {
+            recv_addr,
+            contact_addr,
+            message_ttl_seconds: message_ttl,
+            idle_ttl_seconds: idle_ttl,
+            max_pending: published.contact_max_pending,
+            max_bytes: published.contact_max_bytes,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn subscribe(
+        &self,
+        connection: &mut Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::Subscribe>(connection, now, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_recv(&recv_addr) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&signer)?;
+        queue.touch(now);
+        let next_index = queue.state.next_index();
+        let pending = queue.pending();
+        state.subscribe(recv_addr, connection.id, connection.pushes.clone());
+        drop(state);
+        connection.subscriptions.insert(recv_addr);
+
+        let response = SubscribeResponse {
+            next_index,
+            pending,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn unsubscribe(
+        &self,
+        connection: &mut Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::Unsubscribe>(connection, now, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_recv(&recv_addr) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&signer)?;
+        state.unsubscribe(&recv_addr, connection.id);
+        drop(state);
+        connection.subscriptions.remove(&recv_addr);
+        Ok(Vec::new())
+    }
+
+    fn read(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::Read>(connection, now, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+        let body: ReadRequest = verified.into_body();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_recv(&recv_addr) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&signer)?;
+        // §13.1 layer 4: READ is never refused for backpressure. It is one of
+        // the operations that make the relay smaller, and refusing it under
+        // load is a deadlock.
+        let Some((messages, has_more)) = state.read(
+            &recv_addr,
+            body.from_index,
+            body.max_messages,
+            body.max_bytes,
+            now,
+        ) else {
+            return Err(self.absent_recv());
+        };
+        drop(state);
+
+        let response = ReadResponse {
+            messages: messages.into(),
+            has_more: u8::from(has_more),
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn ack(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::Ack>(connection, now, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+        let body: AckRequest = verified.into_body();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_recv(&recv_addr) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&signer)?;
+        let (outcome, pending) = state.ack(&recv_addr, body.up_to_index, now)?;
+        drop(state);
+
+        let response = AckResponse {
+            next_index: outcome.next_index,
+            pending,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn delete_queue(
+        &self,
+        connection: &mut Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::DeleteQueue>(connection, now, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_recv(&recv_addr) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&signer)?;
+        state.delete_queue(&recv_addr);
+        drop(state);
+        connection.subscriptions.remove(&recv_addr);
+        Ok(Vec::new())
+    }
+
+    // -- §6.3, signed by the send key --------------------------------------
+
+    fn bind_send(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::BindSend>(connection, now, request_id, request)?;
+        let send_addr = verified.address();
+        let signer = verified.signer_key();
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_second(&send_addr) else {
+            return Err(self.absent_send());
+        };
+        // §7.3, and §7.4's consequence: the second bind is `ERR_ALREADY_BOUND`
+        // with any key, including the same key. A client that gets this on a
+        // first bind attempt for an address from a fresh advert must treat it
+        // as a loud, non-dismissible failure — the relay operator may have read
+        // `send_addr` out of its own database and bound first.
+        queue.state.bind_send(&signer)?;
+        queue.touch(now);
+        Ok(Vec::new())
+    }
+
+    fn append(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.verify::<ops::Append>(connection, now, request_id, request)?;
+        let send_addr = verified.address();
+        let signer = verified.signer_key();
+        let body: AppendRequest = verified.into_body();
+
+        // §13.1 layer 4 step 2: an append under backpressure is
+        // `ERR_UNAVAILABLE`, never a code that says why.
+        if self.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        }
+
+        let payload_len = u64::try_from(body.payload.len()).unwrap_or(u64::MAX);
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_second(&send_addr) else {
+            return Err(self.absent_send());
+        };
+        // A contact queue's second address takes `CONTACT_APPEND`, not
+        // `APPEND`: its send side is never bound, so `authorize_send` refuses
+        // it with the same `ERR_UNAVAILABLE` everything else on this side gets.
+        queue.state.authorize_send(&signer)?;
+        let recv_addr = queue.recv_addr;
+        state.admit(&recv_addr, payload_len, self.faults.policy())?;
+        state.append(&recv_addr, body.payload, now)?;
+        drop(state);
+
+        // §6.3: the response body is empty. No index, no depth, no timestamp,
+        // no queue state of any kind.
+        Ok(Vec::new())
+    }
+
+    // -- §12.2, contact queues ---------------------------------------------
+
+    fn contact_append(
+        &self,
+        now: u64,
+        request: &Request,
+    ) -> std::result::Result<Vec<u8>, ProtoError> {
+        let verified = self.accept_unsigned::<ops::ContactAppend>(request)?;
+        let body: ContactAppendRequest = verified.into_body();
+
+        if self.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        }
+
+        let published = self.published_capabilities();
+        let params = published.contact_append_pow;
+        let payload_len = u64::try_from(body.payload.len()).unwrap_or(u64::MAX);
+
+        let mut state = self.state()?;
+        let Some(queue) = state.queue_by_second(&body.contact_addr) else {
+            return Err(self.absent_send());
+        };
+        if !matches!(queue.kind, QueueKind::Contact) {
+            // An ordinary send address is not a contact address. Same collapse:
+            // a stranger probing addresses learns nothing about which is which.
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        }
+        let recv_addr = queue.recv_addr;
+
+        // §12.3: the stamp is over a relay-issued, single-use, expiring
+        // challenge **scoped to this contact address**, so stamps cannot be
+        // precomputed in bulk, cannot be reused, and cannot be computed for one
+        // victim and spent on another.
+        self.check_stamp(
+            &mut state,
+            now,
+            &body.stamp,
+            &params,
+            ChallengePurpose::ContactAppend,
+            body.contact_addr.as_bytes(),
+        )?;
+
+        state.admit(&recv_addr, payload_len, self.faults.policy())?;
+        state.append(&recv_addr, body.payload, now)?;
+        drop(state);
+        Ok(Vec::new())
+    }
+
+    // ---------------------------------------------------------------------
+    // Shared helpers.
+    // ---------------------------------------------------------------------
+
+    fn state(&self) -> std::result::Result<std::sync::MutexGuard<'_, RelayState>, ProtoError> {
+        let mut guard = self
+            .state
+            .lock()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+        let now = self.clock.now_ms();
+        // §7.7's two timers are applied on every command rather than on a
+        // timer task, so a test that moves the clock sees the consequence on
+        // its very next request and never has to race a sweep.
+        guard.expire(now, self.faults.policy());
+        Ok(guard)
+    }
+
+    /// §10's existence-oracle rule, receive side.
+    fn absent_recv(&self) -> ProtoError {
+        // "On the absent path, perform a dummy Ed25519 verification against a
+        // fixed key so that the dominant CPU cost is present in both paths",
+        // and do not short-circuit before it. The return value is consumed so
+        // the call cannot be optimized away.
+        if dummy_verify() {
+            return ProtoError::Wire(ErrorCode::Internal);
+        }
+        ProtoError::Wire(ErrorCode::NoAccess)
+    }
+
+    /// §6.3's collapse, send side.
+    fn absent_send(&self) -> ProtoError {
+        if dummy_verify() {
+            return ProtoError::Wire(ErrorCode::Internal);
+        }
+        ProtoError::Wire(ErrorCode::Unavailable)
+    }
+
+    fn check_creation_stamp(
+        &self,
+        now: u64,
+        stamp: &PowStamp,
+    ) -> std::result::Result<(), ProtoError> {
+        let published = self.published_capabilities();
+        if published.queue_creation_mode != QueueCreationMode::Pow.code() {
+            return Ok(());
+        }
+        let params = published.queue_creation_pow;
+        let mut state = self.state()?;
+        self.check_stamp(
+            &mut state,
+            now,
+            stamp,
+            &params,
+            ChallengePurpose::QueueCreate,
+            &[],
+        )
+    }
+
+    fn check_stamp(
+        &self,
+        state: &mut RelayState,
+        now: u64,
+        stamp: &PowStamp,
+        params: &PowParams,
+        purpose: ChallengePurpose,
+        scope: &[u8],
+    ) -> std::result::Result<(), ProtoError> {
+        if !params.is_required() || self.config.relaxations.accept_missing_pow {
+            return Ok(());
+        }
+        if stamp.is_empty() {
+            return Err(ProtoError::Wire(ErrorCode::PowRequired));
+        }
+        // Verification is one hash, and §12.3 chose the function for exactly
+        // that: the relay's own cost under flood is what must stay near zero.
+        // Checked before the challenge is consumed so a garbage flood does not
+        // burn the challenge table.
+        if !stamp.meets_difficulty(params.difficulty_bits) {
+            return Err(ProtoError::Wire(ErrorCode::PowInvalid));
+        }
+        state.consume_challenge(&stamp.challenge, purpose.code(), scope, now)
+    }
+
+    fn window(&self) -> TimestampWindow {
+        if self.config.relaxations.accept_any_timestamp {
+            // A window wide enough that no timestamp is outside it. The
+            // seen-set still runs, so a replay is still a replay.
+            TimestampWindow::new(u64::MAX)
+        } else {
+            TimestampWindow::new(u64::from(self.published_capabilities().clock_skew_ms))
+        }
+    }
+
+    fn verify<C: RelayCommand>(
+        &self,
+        connection: &Connection,
+        now: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> std::result::Result<Verified<C>, ProtoError> {
+        let padding = self.verifier_padding::<C>(request);
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+        let seen = state.take_seen();
+        let mut verifier =
+            CommandVerifier::new(connection.transcripts.clone(), self.window(), seen, padding);
+        let outcome = verifier.verify::<C>(now, request_id, request);
+        let retention = verifier.seen_set().retention_ms();
+        let max_entries = verifier.seen_set().max_entries();
+        let seen = core::mem::replace(
+            verifier.seen_set_mut(),
+            SeenSet::new(retention, max_entries),
+        );
+        state.put_seen(seen);
+        drop(state);
+        outcome
+    }
+
+    fn accept_unsigned<C: RelayCommand>(
+        &self,
+        request: &Request,
+    ) -> std::result::Result<Verified<C>, ProtoError> {
+        let padding = self.verifier_padding::<C>(request);
+        // The seen-set is untouched by an unsigned command — there is no
+        // `(signer_key, nonce)` to record — so a throwaway one is honest here
+        // rather than a shortcut.
+        let verifier = CommandVerifier::new(
+            TranscriptBuilder::new(PROTOCOL_VERSION, self.relay_id, self.channel_binding()),
+            self.window(),
+            SeenSet::new(0, 0),
+            padding,
+        );
+        verifier.accept_unsigned::<C>(request)
+    }
+
+    /// The padding set the verifier enforces (§9).
+    ///
+    /// Normally the published set, exactly. Under
+    /// [`Relaxations::accept_any_payload_size`] the payload's own length is
+    /// merged in, which is the only way to suspend a rule whose enforcement
+    /// lives inside a shared crate — and the reason that relaxation is opt-in
+    /// and off by default.
+    ///
+    /// [`Relaxations::accept_any_payload_size`]: crate::config::Relaxations::accept_any_payload_size
+    fn verifier_padding<C: RelayCommand>(&self, request: &Request) -> PaddingBuckets {
+        if !self.config.relaxations.accept_any_payload_size {
+            return self.padding.clone();
+        }
+        let Ok(body) = decode_canonical::<C::Request>(request.body()) else {
+            return self.padding.clone();
+        };
+        let Some(payload) = C::payload(body.value()) else {
+            return self.padding.clone();
+        };
+        let Ok(len) = u32::try_from(payload.len()) else {
+            return self.padding.clone();
+        };
+        let mut sizes = self.padding.sizes().to_vec();
+        if len > 0 && !sizes.contains(&len) {
+            sizes.push(len);
+            sizes.sort_unstable();
+        }
+        PaddingBuckets::new(sizes).unwrap_or_else(|_| self.padding.clone())
+    }
+
+    /// A `NOTICE` push built for the tests that want one (§6.4).
+    #[must_use]
+    pub fn notice(kind: u8, at_ms: u64) -> Option<Outbound> {
+        push_frame(
+            PushEvent::Notice,
+            &f2z_codec::commands::NoticePush { kind, at_ms },
+        )
+    }
+
+    /// Whether the published document declares a durable seen-set (§5.5).
+    #[must_use]
+    pub fn antireplay_is_durable(&self) -> bool {
+        self.published_capabilities().antireplay_persistence
+            == AntiReplayPersistence::Durable.code()
+    }
+}
+
+/// Recover a `request_id` from a frame whose body did not decode.
+///
+/// The frame header is fixed-width — one kind byte, then a big-endian `u32` —
+/// so almost every malformed frame still carries a readable id, and §1.3's
+/// "send the response, then close" is satisfiable. `0` means it was not
+/// recoverable, which [`Relay::fatal`] turns into a bare close.
+fn recover_request_id(bytes: &[u8]) -> u32 {
+    let Some(kind) = bytes.first() else {
+        return 0;
+    };
+    // Only a request frame has a client-chosen id to answer on.
+    if *kind != 1 {
+        return 0;
+    }
+    bytes
+        .get(1..5)
+        .and_then(|slice| <[u8; 4]>::try_from(slice).ok())
+        .map_or(0, u32::from_be_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_request_id_survives_a_body_that_does_not_decode() {
+        let mut bytes = vec![1u8, 0, 0, 0, 9];
+        bytes.extend_from_slice(&[0xff; 3]);
+        assert_eq!(recover_request_id(&bytes), 9);
+        assert_eq!(recover_request_id(&[]), 0);
+        assert_eq!(recover_request_id(&[2, 0, 0, 0, 9]), 0);
+        assert_eq!(recover_request_id(&[1, 0, 0]), 0);
+    }
+
+    #[test]
+    fn token_mode_is_refused_at_construction_rather_than_faked() {
+        let mut config = RelayConfig::default();
+        config.capabilities.queue_creation_mode = QueueCreationMode::Token.code();
+        assert!(Relay::new(config).is_err());
+    }
+
+    #[test]
+    fn a_document_claiming_tls_is_refused() {
+        let mut config = RelayConfig::default();
+        config.capabilities.transport_security = TransportSecurity::Tls.code();
+        assert!(Relay::new(config).is_err());
+    }
+
+    #[test]
+    fn the_relay_id_is_the_digest_of_the_identity_key() {
+        let relay = Relay::new(RelayConfig::default()).unwrap();
+        assert_eq!(
+            relay.relay_id(),
+            f2z_codec::hash::relay_id(&relay.identity_key())
+        );
+        let published = relay.published_capabilities();
+        assert_eq!(published.relay_id, relay.relay_id());
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/error.rs
+++ b/rs/crates/f2z-relay-testkit/src/error.rs
@@ -1,0 +1,120 @@
+//! What the harness itself can fail at, as opposed to what the protocol can
+//! refuse.
+//!
+//! The distinction matters more here than it looks. `f2z-relay-proto` already
+//! separates a **wire refusal** (a §10 code the relay answers with) from a
+//! **client refusal** (a decision a client makes about a relay). This crate
+//! adds a third thing that is neither: the harness lost the connection, or the
+//! test's own timeout elapsed, or the configuration was nonsense. A test that
+//! collapses those into a protocol error will report "the relay answered
+//! `ERR_INTERNAL`" when what actually happened is that the socket closed, and
+//! the client author will go looking in the wrong place.
+
+use std::fmt;
+
+use f2z_codec::ErrorCode;
+use f2z_relay_proto::ProtoError;
+
+/// Anything this crate can fail at.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum TestkitError {
+    /// The protocol refused — a §10 code from the relay, or a client-side
+    /// refusal of the relay. Carries `f2z-relay-proto`'s own type unchanged, so
+    /// the code and its fatality survive.
+    Protocol(ProtoError),
+    /// The transport failed: the socket closed, the duplex peer went away, the
+    /// WebSocket handshake was rejected.
+    Transport(String),
+    /// The peer closed while a request was outstanding. §2.5: the command's
+    /// status is **unknown**, and the retry rules of §7.3 and §8.3 apply.
+    Closed,
+    /// A read waited longer than the caller allowed. Not a protocol event: the
+    /// relay may still answer.
+    Timeout,
+    /// The configuration cannot produce a conforming relay.
+    Config(&'static str),
+    /// A conformance vector's expectation did not hold.
+    Expectation(String),
+}
+
+impl TestkitError {
+    /// The §10 code, when the failure was a wire refusal.
+    #[must_use]
+    pub fn wire_code(&self) -> Option<ErrorCode> {
+        match self {
+            Self::Protocol(error) => error.wire_code(),
+            _ => None,
+        }
+    }
+
+    /// Whether this is the relay answering `code`.
+    #[must_use]
+    pub fn is_wire(&self, code: ErrorCode) -> bool {
+        self.wire_code() == Some(code)
+    }
+}
+
+impl fmt::Display for TestkitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Protocol(error) => write!(f, "{error}"),
+            Self::Transport(detail) => write!(f, "transport failure: {detail}"),
+            Self::Closed => f.write_str(
+                "the connection closed with a request outstanding; \
+                 its status is unknown (WIRE.md §2.5)",
+            ),
+            Self::Timeout => f.write_str("timed out waiting for the relay"),
+            Self::Config(detail) => write!(f, "invalid relay configuration: {detail}"),
+            Self::Expectation(detail) => write!(f, "expectation not met: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for TestkitError {}
+
+impl From<ProtoError> for TestkitError {
+    fn from(error: ProtoError) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+impl From<f2z_codec::CodecError> for TestkitError {
+    fn from(error: f2z_codec::CodecError) -> Self {
+        Self::Protocol(ProtoError::from(error))
+    }
+}
+
+impl From<ErrorCode> for TestkitError {
+    fn from(code: ErrorCode) -> Self {
+        Self::Protocol(ProtoError::Wire(code))
+    }
+}
+
+impl From<std::io::Error> for TestkitError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Transport(error.to_string())
+    }
+}
+
+/// The result of everything in this crate.
+pub type Result<T> = std::result::Result<T, TestkitError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_wire_refusal_keeps_its_code_and_a_transport_failure_has_none() {
+        let refused = TestkitError::from(ErrorCode::Unavailable);
+        assert!(refused.is_wire(ErrorCode::Unavailable));
+        assert!(!refused.is_wire(ErrorCode::NoAccess));
+        assert_eq!(TestkitError::Closed.wire_code(), None);
+        assert_eq!(TestkitError::Timeout.wire_code(), None);
+    }
+
+    #[test]
+    fn a_lost_connection_says_the_status_is_unknown() {
+        assert!(TestkitError::Closed.to_string().contains("unknown"));
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/fake.rs
+++ b/rs/crates/f2z-relay-testkit/src/fake.rs
@@ -1,0 +1,361 @@
+//! `FakeRelay` — the handle a client developer actually holds.
+//!
+//! One relay, two ways to reach it, and the same [`crate::engine::Relay`]
+//! behind both:
+//!
+//! ```text
+//!                       ┌────────────────────────────┐
+//!   FakeRelay::connect ─┤                            │
+//!    (tokio::io::duplex)│   connection::drive         │
+//!                       │        engine::Relay        │
+//!   ws://127.0.0.1:0 ───┤                            │
+//!    (RelayServer)      └────────────────────────────┘
+//! ```
+//!
+//! The in-process path is for the tests that run in milliseconds. The socket
+//! path is for the framing, ordering and reconnection bugs the in-process path
+//! physically cannot expose. Running the conformance suite against both and
+//! comparing the verdicts is what turns "they share an implementation" from a
+//! claim into a check — `tests/conformance.rs` does exactly that.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use f2z_codec::commands::{Capabilities, SignedCapabilities};
+use f2z_codec::types::{ChannelBinding, PublicKey, RelayId};
+use futures_util::future::BoxFuture;
+
+use crate::client::{Client, ClientConfig};
+use crate::clock::Clock;
+use crate::config::RelayConfig;
+use crate::engine::Relay;
+use crate::error::Result;
+use crate::faults::FaultInjector;
+use crate::transport::{Transport, duplex};
+use crate::websocket::{self, RelayServer};
+
+/// The buffer of an in-process connection, in bytes.
+///
+/// Generous on purpose: a relay writer and a client writer that both block on a
+/// full pipe is a deadlock in the harness, not a finding about the protocol.
+/// §4.1's `max_frame_bytes` is what should refuse an oversize frame.
+const DUPLEX_CAPACITY: usize = 4 * 1024 * 1024;
+
+/// A spec-conforming relay you can break on purpose.
+#[derive(Clone, Debug)]
+pub struct FakeRelay {
+    relay: Arc<Relay>,
+    /// How many client configurations this relay has handed out.
+    ///
+    /// §5.5's seen-set is relay-wide, and on a frozen clock nothing in it ever
+    /// ages out. Two connections drawing nonces from one stream would therefore
+    /// collide on `(signer_key, nonce)` the moment the same queue key signed
+    /// from both, and the second command would be refused as a replay — a
+    /// harness bug that looks exactly like a relay bug and costs an afternoon.
+    /// Each configuration gets its own stream, derived from this counter, so it
+    /// is unique *and* reproducible.
+    connections: Arc<AtomicU64>,
+}
+
+impl FakeRelay {
+    /// Build a relay.
+    ///
+    /// # Errors
+    ///
+    /// As [`Relay::new`].
+    pub fn new(config: RelayConfig) -> Result<Self> {
+        Ok(Self {
+            relay: Arc::new(Relay::new(config)?),
+            connections: Arc::new(AtomicU64::new(0)),
+        })
+    }
+
+    /// A relay on [`RelayConfig::default`]: frozen clock, `ws://`-honest
+    /// capability document, open queue creation, nothing faulted.
+    ///
+    /// # Errors
+    ///
+    /// As [`Relay::new`].
+    pub fn with_defaults() -> Result<Self> {
+        Self::new(RelayConfig::default())
+    }
+
+    /// The live fault handle. Cloneable, and armed rules take effect on the
+    /// next frame — arming is not a restart.
+    #[must_use]
+    pub fn faults(&self) -> FaultInjector {
+        self.relay.faults().clone()
+    }
+
+    /// The relay's clock. Frozen unless the configuration said otherwise.
+    #[must_use]
+    pub fn clock(&self) -> Clock {
+        self.relay.clock().clone()
+    }
+
+    /// §5.2's identity binding.
+    #[must_use]
+    pub fn relay_id(&self) -> RelayId {
+        self.relay.relay_id()
+    }
+
+    /// The relay's long-term public key.
+    #[must_use]
+    pub fn identity_key(&self) -> PublicKey {
+        self.relay.identity_key()
+    }
+
+    /// The channel binding both ends use (§5.3). Zeros in `none` mode.
+    #[must_use]
+    pub fn channel_binding(&self) -> ChannelBinding {
+        self.relay.channel_binding()
+    }
+
+    /// The document as it stands now, policy faults included.
+    #[must_use]
+    pub fn published_capabilities(&self) -> Capabilities {
+        self.relay.published_capabilities()
+    }
+
+    /// The signed document (§11.1).
+    ///
+    /// # Errors
+    ///
+    /// As [`Relay::signed_capabilities`].
+    pub fn signed_capabilities(&self) -> Result<SignedCapabilities> {
+        self.relay.signed_capabilities()
+    }
+
+    /// Send `NOTICE(3)` to every subscribed connection (§6.4).
+    ///
+    /// Arming a policy fault changes the published document; this is how a
+    /// client's re-fetch path gets exercised rather than assumed.
+    pub fn announce_capability_change(&self) {
+        self.relay.announce_capability_change();
+    }
+
+    /// A client configuration that already knows this relay: its channel
+    /// binding, its `relay_id`, and its published padding set.
+    ///
+    /// Supplying `expected_relay_id` mirrors what a real client has — §7.2's
+    /// advert carries `(relay_url, relay_id, send_addr)` together, and §5.2's
+    /// substitution check is only possible because of it.
+    #[must_use]
+    pub fn client_config(&self) -> ClientConfig {
+        let published = self.published_capabilities();
+        let padding =
+            f2z_codec::padding::PaddingBuckets::new(published.padding_sizes.as_slice().to_vec())
+                .unwrap_or_default();
+        ClientConfig {
+            channel_binding: self.channel_binding(),
+            expected_relay_id: Some(self.relay_id()),
+            padding,
+            nonce_seed: self.next_nonce_seed(),
+            ..ClientConfig::default()
+        }
+    }
+
+    /// A nonce stream no other client of this relay has been given.
+    fn next_nonce_seed(&self) -> [u8; 32] {
+        let ordinal = self.connections.fetch_add(1, Ordering::SeqCst);
+        let mut input = [0u8; 40];
+        if let Some(slot) = input.get_mut(..32) {
+            slot.copy_from_slice(&self.relay.config().rng_seed);
+        }
+        if let Some(slot) = input.get_mut(32..) {
+            slot.copy_from_slice(&ordinal.to_be_bytes());
+        }
+        *f2z_codec::hash::hash(b"f2z-relay-testkit/client-nonce-seed/v1", &input).as_bytes()
+    }
+
+    /// Open an in-process connection and spawn the relay side of it.
+    ///
+    /// Needs a Tokio runtime, because the relay half runs as a task.
+    #[must_use]
+    pub fn connect(&self) -> Transport {
+        let (client_side, relay_side) = duplex(DUPLEX_CAPACITY);
+        let relay = Arc::clone(&self.relay);
+        tokio::spawn(crate::connection::drive(relay, relay_side));
+        client_side
+    }
+
+    /// An in-process connection with `HELLO` already completed.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::connect`].
+    pub async fn client(&self) -> Result<Client> {
+        Client::connect(self.connect(), self.client_config()).await
+    }
+
+    /// Listen on `127.0.0.1:0` and return the running server.
+    ///
+    /// # Errors
+    ///
+    /// As [`websocket::bind`] and [`websocket::serve`].
+    pub async fn listen_loopback(&self) -> Result<RelayServer> {
+        let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+        self.listen(addr, false).await
+    }
+
+    /// Listen on `addr`.
+    ///
+    /// §2.3: a non-loopback bind without TLS is refused unless
+    /// `insecure_listen` is set, which is a deliberate act with published
+    /// consequences rather than a warning.
+    ///
+    /// # Errors
+    ///
+    /// As [`websocket::bind`] and [`websocket::serve`].
+    pub async fn listen(&self, addr: SocketAddr, insecure_listen: bool) -> Result<RelayServer> {
+        let listener = websocket::bind(addr, insecure_listen).await?;
+        websocket::serve(Arc::clone(&self.relay), listener)
+    }
+
+    /// This relay as an in-process conformance target.
+    #[must_use]
+    pub fn in_process_endpoint(&self) -> InProcessEndpoint {
+        InProcessEndpoint {
+            relay: self.clone(),
+        }
+    }
+
+    /// This relay as a conformance target reached over a real socket.
+    #[must_use]
+    pub fn websocket_endpoint(&self, server: &RelayServer) -> WebSocketEndpoint {
+        WebSocketEndpoint {
+            url: server.url(),
+            config: self.client_config(),
+            faults: Some(self.faults()),
+            clock: Some(self.clock()),
+        }
+    }
+}
+
+/// Something the conformance suite can be run against.
+///
+/// Two implementations ship here — in-process and WebSocket — and a third is
+/// the whole point: `f2z-relay`, once it exists, is a [`WebSocketEndpoint`]
+/// with a URL and no fault handle. The suite then reports the fault vectors as
+/// skipped rather than failing them, so the same file is a real check of both
+/// relays instead of two files that drift.
+pub trait Endpoint: Send + Sync {
+    /// Open a transport to this relay.
+    fn connect(&self) -> BoxFuture<'_, Result<Transport>>;
+
+    /// A client configuration suited to this relay.
+    fn client_config(&self) -> ClientConfig;
+
+    /// The fault handle, when the target is one we can break on purpose.
+    /// `None` for a real relay, which is not a failure — it is the reason the
+    /// suite reports "skipped" rather than "passed".
+    fn faults(&self) -> Option<FaultInjector> {
+        None
+    }
+
+    /// The clock, when the target's clock can be steered.
+    fn clock(&self) -> Option<Clock> {
+        None
+    }
+
+    /// How to name this target in a report.
+    fn describe(&self) -> String;
+}
+
+/// The in-process target.
+#[derive(Clone, Debug)]
+pub struct InProcessEndpoint {
+    relay: FakeRelay,
+}
+
+impl InProcessEndpoint {
+    /// The relay behind it.
+    #[must_use]
+    pub const fn relay(&self) -> &FakeRelay {
+        &self.relay
+    }
+}
+
+impl Endpoint for InProcessEndpoint {
+    fn connect(&self) -> BoxFuture<'_, Result<Transport>> {
+        Box::pin(async move { Ok(self.relay.connect()) })
+    }
+
+    fn client_config(&self) -> ClientConfig {
+        self.relay.client_config()
+    }
+
+    fn faults(&self) -> Option<FaultInjector> {
+        Some(self.relay.faults())
+    }
+
+    fn clock(&self) -> Option<Clock> {
+        Some(self.relay.clock())
+    }
+
+    fn describe(&self) -> String {
+        "in-process (tokio::io::duplex)".to_owned()
+    }
+}
+
+/// A target reached over a real WebSocket — a `FakeRelay`'s listener, or any
+/// other relay that speaks `WIRE.md` v1.
+#[derive(Clone, Debug)]
+pub struct WebSocketEndpoint {
+    url: String,
+    config: ClientConfig,
+    faults: Option<FaultInjector>,
+    clock: Option<Clock>,
+}
+
+impl WebSocketEndpoint {
+    /// A target at `url`, with default client policy.
+    ///
+    /// This is the constructor `f2z-relay` will be run through. It has no fault
+    /// handle and no clock, which the suite reports honestly.
+    #[must_use]
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            config: ClientConfig::default(),
+            faults: None,
+            clock: None,
+        }
+    }
+
+    /// Use this client configuration instead of the default.
+    #[must_use]
+    pub fn with_client_config(mut self, config: ClientConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// The endpoint URL.
+    #[must_use]
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+impl Endpoint for WebSocketEndpoint {
+    fn connect(&self) -> BoxFuture<'_, Result<Transport>> {
+        Box::pin(async move { websocket::connect(&self.url).await })
+    }
+
+    fn client_config(&self) -> ClientConfig {
+        self.config.clone()
+    }
+
+    fn faults(&self) -> Option<FaultInjector> {
+        self.faults.clone()
+    }
+
+    fn clock(&self) -> Option<Clock> {
+        self.clock.clone()
+    }
+
+    fn describe(&self) -> String {
+        format!("websocket {}", self.url)
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/faults.rs
+++ b/rs/crates/f2z-relay-testkit/src/faults.rs
@@ -1,0 +1,442 @@
+//! Fault injection — the half of the testkit that is worth more than the happy
+//! path.
+//!
+//! Under delete-on-ack the failure paths are where data loss lives. A client
+//! that gets `APPEND` and `READ` right and gets a dropped `ACK` response wrong
+//! will lose messages in production and pass every test that only ever sees a
+//! healthy relay. `WIRE.md` §2.5 states the shape of the problem outright: "an
+//! in-flight command whose response was not received has **unknown** status",
+//! and §8.3 spells out the two halves of the answer — `ACK` is idempotent so a
+//! retry is safe, `APPEND` is not so a retry duplicates. Neither sentence is
+//! testable against a relay that always answers.
+//!
+//! So every fault here exists to make a specific client obligation reachable:
+//!
+//! | Fault | The client rule it tests |
+//! |---|---|
+//! | [`Effect::Drop`] | §2.5 unknown status; §8.3 idempotent `ACK` retry |
+//! | [`Effect::Delay`] | §4.3 correlate by `request_id`, never by arrival order |
+//! | [`Effect::Reorder`] | §4.3 "responses may arrive out of order … and will" |
+//! | [`Effect::Close`] / [`Effect::CloseBefore`] | §2.5 close at any time; reconnect and re-`SUBSCRIBE` |
+//! | [`Effect::Refuse`] | §10, every code, including the ones a healthy relay never emits |
+//! | [`Effect::Stall`] | §4.3 in-flight window: a client that never times out fills it and gets a fatal `ERR_TOO_MANY_INFLIGHT` |
+//! | [`PolicyFaults::expire_messages_after`] | §7.7 TTL expiry, and `QUEUE_EVENT(3)` |
+//! | [`PolicyFaults::max_queue_messages`] | §6.3 `ERR_UNAVAILABLE` collapse: a full queue is indistinguishable from an absent one |
+//! | [`PolicyFaults::unsound_antireplay_window`] | [#586] — the capability document a conforming relay may publish and a client must refuse |
+//!
+//! # These are faults, not relaxations
+//!
+//! Everything here makes the relay behave *worse* than the specification
+//! allows in ways a real relay or a real network can. Nothing here makes it
+//! accept something a conforming relay would reject — that is
+//! [`crate::config::Relaxations`], which is a separate type for exactly this
+//! reason.
+//!
+//! [#586]: https://github.com/free2z/zuu/issues/586
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::commands::{Command, PushEvent};
+
+/// Which outbound frames a rule applies to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Trigger {
+    /// Responses to one command code.
+    Command(Command),
+    /// Every response, whatever the command.
+    AnyResponse,
+    /// Pushes of one event kind (§6.4).
+    Push(PushEvent),
+    /// Every push.
+    AnyPush,
+}
+
+impl Trigger {
+    /// Whether this trigger selects a response to `command`.
+    ///
+    /// `command` is `None` for a response to a code the relay does not know
+    /// (`ERR_UNKNOWN_COMMAND`, §3.5), which [`Trigger::AnyResponse`] still
+    /// selects — a client has to handle a dropped error response too.
+    #[must_use]
+    pub fn matches_response(self, command: Option<Command>) -> bool {
+        match self {
+            Self::AnyResponse => true,
+            Self::Command(wanted) => command == Some(wanted),
+            Self::Push(_) | Self::AnyPush => false,
+        }
+    }
+
+    /// Whether this trigger selects a push of `event`.
+    #[must_use]
+    pub fn matches_push(self, event: Option<PushEvent>) -> bool {
+        match self {
+            Self::AnyPush => true,
+            Self::Push(wanted) => event == Some(wanted),
+            Self::Command(_) | Self::AnyResponse => false,
+        }
+    }
+}
+
+/// What a rule does to the frames it selects.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Effect {
+    /// Silently discard the frame. The command still executed: this is the
+    /// lost-response case of §2.5, not a refusal.
+    Drop,
+    /// Hold the frame for this long before writing it.
+    Delay(Duration),
+    /// Hold the frame until the next outbound frame is ready, then write that
+    /// one first (§4.3).
+    ///
+    /// A held frame is flushed when the connection closes, so a reorder rule
+    /// that never sees a second frame degrades to a delay rather than to a
+    /// silent drop.
+    Reorder,
+    /// Never write the frame and never release the request. The command still
+    /// executed; the client's `request_id` stays outstanding, which is what
+    /// puts pressure on §4.3's in-flight window.
+    Stall,
+    /// Write the frame, then close the connection.
+    Close,
+    /// Close the connection instead of writing the frame — the mid-stream
+    /// disconnect where the client cannot know whether the command applied.
+    CloseBefore,
+    /// Answer the command with this code instead of executing it.
+    ///
+    /// Applied *before* any state changes, so a refused `APPEND` really did not
+    /// append. This is the one effect that is evaluated in the engine rather
+    /// than on the way out.
+    Refuse(ErrorCode),
+}
+
+/// How many times a rule fires.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Times {
+    /// Every matching frame, for as long as the rule is armed.
+    Always,
+    /// The next `n` matching frames, then the rule retires itself.
+    Exactly(u32),
+}
+
+/// One fault rule: what to match, what to do, how often.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Fault {
+    /// Which frames this rule selects.
+    pub trigger: Trigger,
+    /// What happens to them.
+    pub effect: Effect,
+    /// How many times.
+    pub times: Times,
+}
+
+impl Fault {
+    /// A rule that fires on every matching frame.
+    #[must_use]
+    pub const fn always(trigger: Trigger, effect: Effect) -> Self {
+        Self {
+            trigger,
+            effect,
+            times: Times::Always,
+        }
+    }
+
+    /// A rule that fires once and retires.
+    #[must_use]
+    pub const fn once(trigger: Trigger, effect: Effect) -> Self {
+        Self {
+            trigger,
+            effect,
+            times: Times::Exactly(1),
+        }
+    }
+
+    /// A rule that fires `n` times and retires.
+    #[must_use]
+    pub const fn times(trigger: Trigger, effect: Effect, n: u32) -> Self {
+        Self {
+            trigger,
+            effect,
+            times: Times::Exactly(n),
+        }
+    }
+
+    /// Consume one firing. Returns `false` when the rule has retired.
+    fn consume(&mut self) -> bool {
+        match &mut self.times {
+            Times::Always => true,
+            Times::Exactly(remaining) => {
+                if *remaining == 0 {
+                    false
+                } else {
+                    *remaining = remaining.saturating_sub(1);
+                    true
+                }
+            }
+        }
+    }
+
+    fn retired(&self) -> bool {
+        matches!(self.times, Times::Exactly(0))
+    }
+}
+
+/// Faults that are properties of the relay's policy rather than of one frame.
+///
+/// These change what the relay *is*, so they are read on every relevant
+/// decision instead of being consumed. Several of them also change the
+/// published capability document, which is the point: a client that reads
+/// policy from `GET_CAPABILITIES` must see the policy it is about to be held
+/// to.
+///
+/// Deliberately **not** `#[non_exhaustive]`: a client developer builds one of
+/// these with struct-update syntax in their own test file, and a crate whose
+/// test-harness configuration could only be constructed from inside the crate
+/// would be unusable for the thing it exists to do.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PolicyFaults {
+    /// Expire stored messages this long after they were appended, whatever TTL
+    /// the queue was granted (§7.7).
+    ///
+    /// `Some(Duration::ZERO)` expires a message the instant the clock is read
+    /// again, which is the fastest way to reach `QUEUE_EVENT(3)` and to prove a
+    /// client does not assume a `READ` returns what it appended.
+    pub expire_messages_after: Option<Duration>,
+    /// Expire a queue this long after its last activity, whatever idle TTL it
+    /// was granted (§7.7). Reaches `QUEUE_EVENT(2)` and, for the sender,
+    /// `ERR_UNAVAILABLE` on a queue that used to work.
+    pub expire_queue_after: Option<Duration>,
+    /// Override `max_queue_messages` (§13.1 layer 2). Set it to 1 and the
+    /// second `APPEND` is `ERR_UNAVAILABLE` — the §6.3 collapse, reached
+    /// cheaply.
+    pub max_queue_messages: Option<u32>,
+    /// Override `max_queue_bytes` (§13.1 layer 2).
+    pub max_queue_bytes: Option<u64>,
+    /// Refuse `CREATE_QUEUE` with `ERR_QUOTA` once the relay holds this many
+    /// queues (§10 code 14 — a recv-side quota, which unlike the send side is
+    /// allowed to be distinguishable).
+    pub max_queues: Option<usize>,
+    /// §13.1 layer 4. Creation answers `ERR_BACKPRESSURE`, appends answer
+    /// `ERR_UNAVAILABLE`, and `READ` / `ACK` / `DELETE_QUEUE` are **never**
+    /// refused — refusing the operations that make the relay smaller is a
+    /// deadlock, and a client that cannot drain under backpressure will find
+    /// out here.
+    pub global_backpressure: bool,
+    /// Publish, and then actually enforce, `antireplay_window_ms =
+    /// clock_skew_ms` — below the `2 × clock_skew_ms` floor that [#586] says
+    /// `WIRE.md` should state and does not.
+    ///
+    /// Both halves matter. The document is what
+    /// `ClientPolicy::require_sound_antireplay_window` refuses on; the
+    /// enforcement is what makes the refusal *justified*, because with the
+    /// short retention the relay really does age a seen-set entry out while the
+    /// frame it covers is still inside the timestamp window.
+    ///
+    /// [#586]: https://github.com/free2z/zuu/issues/586
+    pub unsound_antireplay_window: bool,
+    /// Shrink the seen-set bound so `ERR_BACKPRESSURE` from §5.5 is reachable
+    /// without sending 65 536 commands.
+    pub seen_set_max: Option<usize>,
+}
+
+/// A live handle to one relay's faults.
+///
+/// Cheap to clone and shared with every connection, so a test can arm a fault
+/// in the middle of a conversation — which is the only way to reach half of
+/// them. Arming is not a restart.
+#[derive(Clone, Debug, Default)]
+pub struct FaultInjector {
+    inner: Arc<Mutex<Faults>>,
+}
+
+#[derive(Debug, Default)]
+struct Faults {
+    rules: Vec<Fault>,
+    policy: PolicyFaults,
+}
+
+impl FaultInjector {
+    /// An injector with nothing armed.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Arm a rule.
+    pub fn arm(&self, fault: Fault) {
+        if let Ok(mut faults) = self.inner.lock() {
+            faults.rules.push(fault);
+        }
+    }
+
+    /// Arm several rules at once.
+    pub fn arm_all(&self, faults: impl IntoIterator<Item = Fault>) {
+        for fault in faults {
+            self.arm(fault);
+        }
+    }
+
+    /// Disarm every rule. Policy faults are left alone; use
+    /// [`FaultInjector::set_policy`] for those.
+    pub fn disarm(&self) {
+        if let Ok(mut faults) = self.inner.lock() {
+            faults.rules.clear();
+        }
+    }
+
+    /// Replace the policy faults.
+    pub fn set_policy(&self, policy: PolicyFaults) {
+        if let Ok(mut faults) = self.inner.lock() {
+            faults.policy = policy;
+        }
+    }
+
+    /// The current policy faults.
+    #[must_use]
+    pub fn policy(&self) -> PolicyFaults {
+        self.inner
+            .lock()
+            .map(|faults| faults.policy)
+            .unwrap_or_default()
+    }
+
+    /// How many rules are armed. Retired rules are removed as they retire.
+    #[must_use]
+    pub fn armed(&self) -> usize {
+        self.inner.lock().map_or(0, |faults| faults.rules.len())
+    }
+
+    /// The refusal a rule demands for `command`, consuming one firing.
+    ///
+    /// Called by the engine before the command runs, so a refusal really does
+    /// prevent the state change.
+    #[must_use]
+    pub fn take_refusal(&self, command: Option<Command>) -> Option<ErrorCode> {
+        match self.take(|fault| match fault.effect {
+            Effect::Refuse(_) if fault.trigger.matches_response(command) => Some(fault.effect),
+            _ => None,
+        }) {
+            Some(Effect::Refuse(code)) => Some(code),
+            _ => None,
+        }
+    }
+
+    /// The delivery effect a rule demands for a response, consuming one firing.
+    #[must_use]
+    pub fn take_response_effect(&self, command: Option<Command>) -> Option<Effect> {
+        self.take(|fault| match fault.effect {
+            Effect::Refuse(_) => None,
+            effect if fault.trigger.matches_response(command) => Some(effect),
+            _ => None,
+        })
+    }
+
+    /// The delivery effect a rule demands for a push, consuming one firing.
+    #[must_use]
+    pub fn take_push_effect(&self, event: Option<PushEvent>) -> Option<Effect> {
+        self.take(|fault| match fault.effect {
+            Effect::Refuse(_) => None,
+            effect if fault.trigger.matches_push(event) => Some(effect),
+            _ => None,
+        })
+    }
+
+    /// First matching rule wins, and firing it may retire it.
+    fn take(&self, select: impl Fn(&Fault) -> Option<Effect>) -> Option<Effect> {
+        let mut faults = self.inner.lock().ok()?;
+        let mut chosen = None;
+        for fault in &mut faults.rules {
+            if let Some(effect) = select(fault)
+                && fault.consume()
+            {
+                chosen = Some(effect);
+                break;
+            }
+        }
+        faults.rules.retain(|fault| !fault.retired());
+        chosen
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_once_rule_fires_once_and_retires() {
+        let injector = FaultInjector::new();
+        injector.arm(Fault::once(Trigger::Command(Command::Ack), Effect::Drop));
+        assert_eq!(injector.armed(), 1);
+        assert_eq!(
+            injector.take_response_effect(Some(Command::Ack)),
+            Some(Effect::Drop)
+        );
+        assert_eq!(injector.take_response_effect(Some(Command::Ack)), None);
+        assert_eq!(injector.armed(), 0);
+    }
+
+    #[test]
+    fn a_command_rule_ignores_other_commands() {
+        let injector = FaultInjector::new();
+        injector.arm(Fault::always(Trigger::Command(Command::Read), Effect::Drop));
+        assert_eq!(injector.take_response_effect(Some(Command::Ack)), None);
+        assert_eq!(
+            injector.take_response_effect(Some(Command::Read)),
+            Some(Effect::Drop)
+        );
+        // Always means always.
+        assert_eq!(
+            injector.take_response_effect(Some(Command::Read)),
+            Some(Effect::Drop)
+        );
+    }
+
+    #[test]
+    fn refusals_and_delivery_effects_do_not_steal_each_others_rules() {
+        let injector = FaultInjector::new();
+        injector.arm(Fault::always(
+            Trigger::Command(Command::Append),
+            Effect::Refuse(ErrorCode::Unavailable),
+        ));
+        assert_eq!(injector.take_response_effect(Some(Command::Append)), None);
+        assert_eq!(
+            injector.take_refusal(Some(Command::Append)),
+            Some(ErrorCode::Unavailable)
+        );
+    }
+
+    #[test]
+    fn push_rules_and_response_rules_are_separate() {
+        let injector = FaultInjector::new();
+        injector.arm(Fault::always(Trigger::AnyPush, Effect::Drop));
+        assert_eq!(injector.take_response_effect(Some(Command::Read)), None);
+        assert_eq!(
+            injector.take_push_effect(Some(PushEvent::Msg)),
+            Some(Effect::Drop)
+        );
+    }
+
+    #[test]
+    fn every_error_code_can_be_demanded() {
+        // §10's codes are stable forever and a client has to handle all of
+        // them, including the ones a healthy relay never emits.
+        let injector = FaultInjector::new();
+        for code in ErrorCode::ALL {
+            injector.arm(Fault::once(
+                Trigger::Command(Command::Append),
+                Effect::Refuse(code),
+            ));
+        }
+        for code in ErrorCode::ALL {
+            assert_eq!(
+                injector.take_refusal(Some(Command::Append)),
+                Some(code),
+                "rules fire in the order they were armed"
+            );
+        }
+        assert_eq!(injector.armed(), 0);
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/lib.rs
+++ b/rs/crates/f2z-relay-testkit/src/lib.rs
@@ -1,0 +1,142 @@
+//! **FakeRelay** — a spec-conforming free2z relay you can break on purpose, so
+//! that a client can be built and tested before `f2z-relay` exists.
+//!
+//! ```no_run
+//! # async fn example() -> Result<(), Box<dyn core::error::Error>> {
+//! use f2z_relay_proto::key::SigningKey;
+//! use f2z_relay_testkit::fake::FakeRelay;
+//!
+//! let relay = FakeRelay::with_defaults()?;
+//! let mut bob = relay.client().await?;              // in-process, no sockets
+//! let bob_key = SigningKey::from_seed(&[1u8; 32]);
+//! let queue = bob.create_queue(&bob_key, 0, 0, None).await?;
+//!
+//! let mut alice = relay.client().await?;
+//! let alice_key = SigningKey::from_seed(&[2u8; 32]);
+//! alice.bind_send(&alice_key, queue.send_addr).await?;
+//! alice.append(&alice_key, queue.send_addr, b"ciphertext").await?;
+//!
+//! let read = bob.read(&bob_key, queue.recv_addr, 0, 0, 0).await?;
+//! // …durable local write happens HERE — WIRE.md §8.4's MUST — and only then:
+//! bob.ack(&bob_key, queue.recv_addr, 0).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # What this crate is for
+//!
+//! [`docs/e2ee/WIRE.md`] specifies a relay that does not exist yet, and
+//! [`docs/e2ee/CLIENT-CONTRACT.md`] describes clients that have to be built
+//! against it now. This crate is the thing in between: a relay that implements
+//! §2 through §13 faithfully, runs in a test process, and can be *told to
+//! misbehave*.
+//!
+//! It reuses rather than reimplements. [`f2z_codec`] owns the canonical
+//! encoding, the framing and re-encode equality (§3.3); [`f2z_relay_proto`]
+//! owns the verification order of §5.1, the anti-replay of §5.5, the queue and
+//! acknowledgement rules of §7 and §8, and the capability document of §11. The
+//! part decided here is what those crates deliberately leave to a server: the
+//! connection lifecycle, the in-flight window, which code answers which
+//! refusal, when a push is emitted, and the anti-abuse layering of §13.
+//!
+//! # The three things worth knowing before you use it
+//!
+//! **1. It serves both an in-process pipe and a real socket, and they are the
+//! same relay.** [`fake::FakeRelay::connect`] gives a
+//! [`tokio::io::duplex`]-backed transport for tests that run in milliseconds;
+//! [`fake::FakeRelay::listen_loopback`] serves `ws://127.0.0.1:0` for the
+//! framing, ordering and reconnection bugs an in-memory pipe physically cannot
+//! expose. Both go through [`connection::drive`] and [`engine::Relay`], and
+//! `tests/conformance.rs` runs the whole vector suite against both and compares
+//! the verdicts — because "they share an implementation" is worth nothing as a
+//! claim and everything as a check.
+//!
+//! **2. Faults are the point.** Under delete-on-ack the failure paths are where
+//! data loss lives. A client that handles `APPEND` and `READ` correctly and
+//! mishandles a dropped `ACK` response loses messages in production and passes
+//! every test that only ever sees a healthy relay. [`faults`] can drop a
+//! response, delay one, reorder two, close mid-stream, refuse a command with
+//! any §10 code, stall a response so §4.3's window fills, expire a TTL, hit a
+//! quota, enter global backpressure, and publish the capability document of
+//! [#586].
+//!
+//! **3. Relaxations are not faults, and are off.** A fault makes the relay
+//! behave *worse* than the specification allows, in ways a real relay or a real
+//! network can. A [`config::Relaxations`] makes it **accept** something a
+//! conforming relay would reject — which is the single most dangerous thing a
+//! test double can do, because it teaches a client to write code that works in
+//! tests and fails against the real thing. Each one is opt-in, each is named
+//! after the rule it suspends, and [`config::Relaxations::any`] lets a harness
+//! assert that a run used none.
+//!
+//! # The conformance suite
+//!
+//! [`vectors`] is a set of `(input, expected output)` cases driven through the
+//! ordinary client API against an [`fake::Endpoint`]. Three targets exist:
+//! in-process, this crate's WebSocket listener, and — later, unchanged —
+//! `f2z-relay` itself as a [`fake::WebSocketEndpoint`] with a URL. Vectors that
+//! need to break the relay declare [`vectors::Needs::Faults`] or
+//! [`vectors::Needs::Clock`] and report **skipped** against a target that
+//! cannot be told to misbehave, never passed.
+//!
+//! # What this crate is not
+//!
+//! **Not a relay.** `f2z-fakerelay` serves `ws://` rather than `wss://` (§2.1),
+//! derives queue addresses from a seed so vectors replay (§7.1 requires them to
+//! be unpredictable), and keeps everything in memory (§8.4's
+//! `durability_mode: memory`). All three are published in the signed capability
+//! document it serves, and a conforming client refuses it without an explicit
+//! per-relay opt-in. See [`rng`] and the `f2z-fakerelay` binary docs.
+//!
+//! **Not the client.** [`client::Client`] is the smallest thing that can drive
+//! every command of §6 correctly, so a vector is a statement about the relay
+//! rather than about a test's ability to build a frame. ZUULI's engine and the
+//! WASM web client are the clients, and neither links this.
+//!
+//! **Native only.** This crate opens sockets, spawns tasks and reads a clock.
+//! It is deliberately absent from the `wasm32` job that
+//! [`f2z_codec`] and [`f2z_relay_proto`] must pass: [ADR 0001] requires one
+//! Rust core shared by ZUULI and the browser, and a test harness must not be
+//! able to leak into it.
+//!
+//! [`docs/e2ee/WIRE.md`]: https://github.com/free2z/zuu/blob/main/docs/e2ee/WIRE.md
+//! [`docs/e2ee/CLIENT-CONTRACT.md`]: https://github.com/free2z/zuu/blob/main/docs/e2ee/CLIENT-CONTRACT.md
+//! [ADR 0001]: https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0001-platform-priority.md
+//! [#586]: https://github.com/free2z/zuu/issues/586
+
+#![forbid(unsafe_code)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects
+    )
+)]
+
+pub mod client;
+pub mod clock;
+pub mod config;
+pub mod connection;
+pub mod engine;
+pub mod error;
+pub mod fake;
+pub mod faults;
+pub mod outbound;
+pub mod rng;
+pub mod state;
+pub mod transport;
+pub mod vectors;
+pub mod websocket;
+
+pub use client::{Client, ClientConfig};
+pub use config::{Relaxations, RelayConfig};
+pub use error::{Result, TestkitError};
+pub use fake::{Endpoint, FakeRelay, InProcessEndpoint, WebSocketEndpoint};
+pub use faults::{Effect, Fault, FaultInjector, PolicyFaults, Trigger};
+pub use vectors::{Report, Status, Vector};
+
+/// The protocol version this harness speaks, restated from [`f2z_codec`].
+pub const PROTOCOL_VERSION: u16 = f2z_codec::PROTOCOL_VERSION;

--- a/rs/crates/f2z-relay-testkit/src/outbound.rs
+++ b/rs/crates/f2z-relay-testkit/src/outbound.rs
@@ -1,0 +1,136 @@
+//! What the engine hands the writer.
+//!
+//! One type for responses, pushes and keepalives, because the writer applies
+//! fault effects uniformly and a second shape would be a second place for them
+//! to be forgotten.
+
+use f2z_codec::canonical::Canonical;
+use f2z_codec::commands::{PushEvent, QueuedMessage};
+use f2z_codec::frame::{Push, RelayFrame, Response};
+use f2z_codec::types::QueueAddress;
+use f2z_codec::{ErrorCode, commands::MsgPush};
+
+use crate::faults::Effect;
+
+/// What kind of frame this is, and what the writer must know about it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutKind {
+    /// A response. The effect was already resolved by the engine, which is
+    /// where [`Effect::Stall`] has to be decided: a stalled response must leave
+    /// its `request_id` outstanding in §4.3's window, and only the engine holds
+    /// that.
+    Response {
+        /// The delivery effect, if a fault selected one.
+        effect: Option<Effect>,
+    },
+    /// An unsolicited push (§6.4). The writer resolves its effect, because a
+    /// push is generated deep inside the state under a lock.
+    Push {
+        /// The event, for the fault lookup. `None` for a code this build does
+        /// not know, which cannot happen from our own engine.
+        event: Option<PushEvent>,
+    },
+    /// §2.4's server-driven keepalive. Never faulted: a fault that could stop
+    /// the keepalive would look like a hung relay rather than like the fault it
+    /// is.
+    Keepalive,
+    /// A frame whose fault has already been applied — a delayed one coming back
+    /// round. Written as-is, so a rule cannot fire twice on one frame.
+    Ready,
+}
+
+/// One frame on its way out.
+#[derive(Clone)]
+pub struct Outbound {
+    /// The canonical frame bytes (§3.3): the relay encodes once, here.
+    pub bytes: Vec<u8>,
+    /// What the writer needs to know about it.
+    pub kind: OutKind,
+    /// Close the connection after writing, with this RFC 6455 status.
+    ///
+    /// `WIRE.md` §1.3 defines a fatal error as "send the response, then close
+    /// the WebSocket connection" and §4.2 fixes status 1003 for a text frame.
+    /// It names no status for the other fatal codes; 1002 (protocol error) is
+    /// the reading used here and is listed as an ambiguity call.
+    pub close_after: Option<u16>,
+}
+
+// `bytes` is an encoded relay frame, and for a `MSG` push that is the whole of
+// somebody's ciphertext. Reported by length, like `f2z-codec`'s `Payload`.
+impl core::fmt::Debug for Outbound {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Outbound")
+            .field(
+                "bytes",
+                &format_args!("<redacted; {} bytes>", self.bytes.len()),
+            )
+            .field("kind", &self.kind)
+            .field("close_after", &self.close_after)
+            .finish()
+    }
+}
+
+impl Outbound {
+    /// A response frame.
+    #[must_use]
+    pub fn response(request_id: u32, response: Response, effect: Option<Effect>) -> Option<Self> {
+        Some(Self {
+            bytes: RelayFrame::response(request_id, response)
+                .encode_canonical()
+                .ok()?,
+            kind: OutKind::Response { effect },
+            close_after: None,
+        })
+    }
+
+    /// A response that closes the connection after it (§1.3).
+    #[must_use]
+    pub fn fatal(request_id: u32, code: ErrorCode, status: u16) -> Option<Self> {
+        let mut outbound = Self::response(request_id, Response::error(code), None)?;
+        outbound.close_after = Some(status);
+        Some(outbound)
+    }
+
+    /// The keepalive of §2.4.
+    #[must_use]
+    pub const fn keepalive() -> Self {
+        Self {
+            bytes: Vec::new(),
+            kind: OutKind::Keepalive,
+            close_after: None,
+        }
+    }
+}
+
+/// Encode a push frame (§6.4).
+#[must_use]
+pub fn push<B: Canonical>(event: PushEvent, body: &B) -> Option<Outbound> {
+    let frame = RelayFrame::push(Push::new(event.code(), body.encode_canonical().ok()?).ok()?);
+    Some(Outbound {
+        bytes: frame.encode_canonical().ok()?,
+        kind: OutKind::Push { event: Some(event) },
+        close_after: None,
+    })
+}
+
+/// The `MSG` push of §6.4, which goes only to the receive side, ever.
+#[must_use]
+pub fn msg_push(recv_addr: QueueAddress, message: &QueuedMessage) -> Option<Outbound> {
+    push(
+        PushEvent::Msg,
+        &MsgPush {
+            recv_addr,
+            msg: message.clone(),
+        },
+    )
+}
+
+/// RFC 6455 status 1002, "protocol error": the close used for every fatal §10
+/// code except §4.2's, which fixes 1003.
+pub const CLOSE_PROTOCOL_ERROR: u16 = 1002;
+
+/// RFC 6455 status 1003, "unsupported data": §4.2's text frame.
+pub const CLOSE_UNSUPPORTED_DATA: u16 = 1003;
+
+/// RFC 6455 status 1000, "normal closure".
+pub const CLOSE_NORMAL: u16 = 1000;

--- a/rs/crates/f2z-relay-testkit/src/rng.rs
+++ b/rs/crates/f2z-relay-testkit/src/rng.rs
@@ -1,0 +1,165 @@
+//! The address and nonce source — deterministic on purpose, and **not**
+//! cryptographically unpredictable.
+//!
+//! `WIRE.md` §7.1 requires a relay to generate both queue addresses "from its
+//! own CSPRNG", and §7.1's whole argument for relay-chosen addresses is that a
+//! client cannot predict or squat them. This type does not provide that
+//! property and does not claim to: it is BLAKE2b in counter mode over a seed
+//! the caller supplies, so a caller who knows the seed knows every address the
+//! relay will ever hand out.
+//!
+//! That is deliberate, it is the right trade for a test harness, and it is the
+//! single clearest reason `f2z-fakerelay` must never be deployed:
+//!
+//! - A conformance vector that produced different addresses on every run could
+//!   not be a vector. Reproducibility is what lets a failure be replayed
+//!   verbatim, in CI, six months later.
+//! - Seeding it from the operating system would need `getrandom`, i.e. a
+//!   dependency added to a crate whose randomness is documented not to matter.
+//!
+//! [`Csprng::from_clock`] exists so the binary does not hand every deployment
+//! the same addresses; it is a *variety* source, not an entropy source, and the
+//! difference is stated rather than blurred.
+
+use f2z_codec::hash::hash;
+use f2z_codec::types::{Challenge, QueueAddress};
+
+/// The domain label for this generator's stream.
+///
+/// It is deliberately not one of `f2z_codec::hash::LABELS`: nothing in the
+/// protocol hashes with it, and adding a testkit label to the protocol's
+/// prefix-free set would put a test harness inside the domain separation
+/// argument of `WIRE.md` §1.3.
+const LABEL: &[u8] = b"f2z-relay-testkit/rng/v1";
+
+/// A reproducible byte source for relay-generated addresses and challenges.
+#[derive(Clone)]
+pub struct Csprng {
+    seed: [u8; 32],
+    counter: u64,
+}
+
+// The seed is not secret in the sense a signing key is — the default is a
+// constant in this repository — but printing it hands a reader every address
+// the relay will ever produce, which is the one thing §7.1 wants withheld.
+// Same rule as `f2z-codec`'s newtypes, and for the same reason: `--log-level
+// trace` must not become a capability archive.
+impl core::fmt::Debug for Csprng {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Csprng")
+            .field("seed", &"<redacted>")
+            .field("counter", &self.counter)
+            .finish()
+    }
+}
+
+impl Csprng {
+    /// A stream fixed by `seed`. Two relays with the same seed hand out the
+    /// same addresses in the same order.
+    #[must_use]
+    pub const fn from_seed(seed: [u8; 32]) -> Self {
+        Self { seed, counter: 0 }
+    }
+
+    /// A stream varied by the wall clock.
+    ///
+    /// Read the module note before using this for anything: it is a variety
+    /// source so two runs of `f2z-fakerelay` do not collide, not an entropy
+    /// source, and the addresses it produces are guessable by anyone who knows
+    /// roughly when the process started.
+    #[must_use]
+    pub fn from_clock() -> Self {
+        let millis = core::time::Duration::from_secs(0);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or(millis);
+        let mut seed = [0u8; 32];
+        let stamp = hash(LABEL, &now.as_nanos().to_be_bytes());
+        seed.copy_from_slice(stamp.as_bytes());
+        Self::from_seed(seed)
+    }
+
+    /// The next 32 bytes of the stream.
+    #[must_use]
+    pub fn next_block(&mut self) -> [u8; 32] {
+        let mut input = [0u8; 40];
+        let (seed, counter) = input.split_at_mut(32);
+        seed.copy_from_slice(&self.seed);
+        counter.copy_from_slice(&self.counter.to_be_bytes());
+        self.counter = self.counter.wrapping_add(1);
+        *hash(LABEL, &input).as_bytes()
+    }
+
+    /// The next `N` bytes, for the fixed-width newtypes of `f2z-codec`.
+    #[must_use]
+    pub fn next_bytes<const N: usize>(&mut self) -> [u8; N] {
+        let mut out = [0u8; N];
+        let mut written = 0usize;
+        while written < N {
+            let block = self.next_block();
+            let take = core::cmp::min(32, N.saturating_sub(written));
+            let end = written.saturating_add(take);
+            match (out.get_mut(written..end), block.get(..take)) {
+                (Some(slot), Some(source)) => slot.copy_from_slice(source),
+                // Unreachable by the loop bound; the workspace forbids
+                // indexing, so the impossible branch is written out rather
+                // than asserted away.
+                _ => break,
+            }
+            written = end;
+        }
+        out
+    }
+
+    /// A fresh 32-byte queue address (§7.1).
+    #[must_use]
+    pub fn next_address(&mut self) -> QueueAddress {
+        QueueAddress::new(self.next_block())
+    }
+
+    /// A fresh 32-byte challenge (§6.1).
+    #[must_use]
+    pub fn next_challenge(&mut self) -> Challenge {
+        Challenge::new(self.next_block())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_same_seed_yields_the_same_stream() {
+        let mut left = Csprng::from_seed([7u8; 32]);
+        let mut right = Csprng::from_seed([7u8; 32]);
+        for _ in 0..8 {
+            assert_eq!(left.next_block(), right.next_block());
+        }
+    }
+
+    #[test]
+    fn different_seeds_diverge_immediately() {
+        let mut left = Csprng::from_seed([7u8; 32]);
+        let mut right = Csprng::from_seed([8u8; 32]);
+        assert_ne!(left.next_block(), right.next_block());
+    }
+
+    #[test]
+    fn successive_addresses_differ() {
+        let mut rng = Csprng::from_seed([1u8; 32]);
+        let first = rng.next_address();
+        let second = rng.next_address();
+        assert_ne!(first, second);
+        assert!(!first.is_zero());
+    }
+
+    #[test]
+    fn odd_widths_are_filled_completely() {
+        let mut rng = Csprng::from_seed([2u8; 32]);
+        let short: [u8; 16] = rng.next_bytes();
+        let long: [u8; 48] = rng.next_bytes();
+        assert!(short.iter().any(|byte| *byte != 0));
+        assert!(long.iter().any(|byte| *byte != 0));
+        assert!(long.iter().skip(32).any(|byte| *byte != 0));
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/state.rs
+++ b/rs/crates/f2z-relay-testkit/src/state.rs
@@ -1,0 +1,868 @@
+//! The relay's storage, and the parts of `WIRE.md` §7, §8 and §12 that are
+//! about *holding* things rather than about rules.
+//!
+//! `f2z-relay-proto::queue` already owns every rule that can lose a message:
+//! bind-once, cumulative-monotone-idempotent acknowledgement, and the anti-
+//! pre-ack bound. None of it is re-implemented here. What is here is the state
+//! those rules are applied to — a `BTreeMap` of ciphertext, a subscriber list,
+//! and the challenge table — plus the two behaviours that only exist once
+//! something is stored: TTL expiry (§7.7) and the quota admission of §13.1
+//! layer 2.
+//!
+//! # In-memory, and that is published
+//!
+//! §11.1's `durability_mode` has three values and this is `memory`: an `APPEND`
+//! that returned 0 does not survive the process. §8.4 says no end-to-end
+//! contract breaks in the weaker modes because `accepted` never promised
+//! anything — which is true, and is also exactly why a client must not treat
+//! `accepted` as delivery. A test harness that silently offered durability
+//! would hide that.
+//!
+//! # The one rule that is *not* here, restated because it is the important one
+//!
+//! §13.2: **under no circumstance does a relay delete an unacknowledged message
+//! to free space.** Not the oldest, not the largest, not from the fullest
+//! queue. When it runs out of room it refuses new writes. There is no eviction
+//! path in this module, and the absence is deliberate rather than an omission:
+//! the only deletions are acknowledgement (§8), TTL expiry (§7.7) and
+//! `DELETE_QUEUE` (§7.6).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use f2z_codec::ErrorCode;
+use f2z_codec::commands::{NoticePush, PushEvent, QueueEventPush, QueuedMessage};
+use f2z_codec::types::{Challenge, Payload, PublicKey, QueueAddress};
+use f2z_relay_proto::ProtoError;
+use f2z_relay_proto::queue::{AckOutcome, AppendQuota, QueueKind, QueueState};
+use f2z_relay_proto::replay::SeenSet;
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::error::Result;
+use crate::faults::PolicyFaults;
+use crate::outbound::Outbound;
+use crate::rng::Csprng;
+
+/// `QUEUE_EVENT` reason 1 (§6.4): the queue was deleted.
+pub const QUEUE_EVENT_DELETED: u8 = 1;
+/// `QUEUE_EVENT` reason 2 (§6.4): the queue's idle TTL elapsed.
+pub const QUEUE_EVENT_IDLE_EXPIRED: u8 = 2;
+/// `QUEUE_EVENT` reason 3 (§6.4): stored messages hit their TTL.
+pub const QUEUE_EVENT_MESSAGES_EXPIRED: u8 = 3;
+/// `QUEUE_EVENT` reason 4 (§6.4): a quota was reached.
+pub const QUEUE_EVENT_QUOTA: u8 = 4;
+
+/// `NOTICE` kind 3 (§6.4): the capability document changed.
+pub const NOTICE_CAPABILITIES_CHANGED: u8 = 3;
+
+/// One stored ciphertext.
+#[derive(Clone, Debug)]
+pub struct Stored {
+    /// The index it was appended at.
+    pub index: u64,
+    /// The opaque payload. The relay never looks inside one.
+    pub payload: Payload,
+    /// Relay clock at acceptance — `QueuedMessage.received_at_ms`.
+    pub received_at_ms: u64,
+    /// When §7.7's message TTL drops it.
+    pub expires_at_ms: u64,
+}
+
+impl Stored {
+    fn as_message(&self) -> QueuedMessage {
+        QueuedMessage {
+            index: self.index,
+            received_at_ms: self.received_at_ms,
+            payload: self.payload.clone(),
+        }
+    }
+}
+
+/// One queue: the rules from `f2z-relay-proto`, plus what it holds.
+#[derive(Clone, Debug)]
+pub struct Queue {
+    /// Standard or contact (§12.2).
+    pub kind: QueueKind,
+    /// Authorization and acknowledgement state — the rules, not re-derived.
+    pub state: QueueState,
+    /// The receive address: `SUBSCRIBE`, `READ`, `ACK`, `DELETE_QUEUE`.
+    pub recv_addr: QueueAddress,
+    /// The second address: bindable `send_addr` for a standard queue, published
+    /// and never bindable `contact_addr` for a contact queue.
+    pub second_addr: QueueAddress,
+    /// Stored ciphertext, by index.
+    pub messages: BTreeMap<u64, Stored>,
+    /// Bytes currently held, for §13.1 layer 2's byte cap.
+    pub bytes: u64,
+    /// The granted message TTL (§7.7), after clamping.
+    pub message_ttl_seconds: u32,
+    /// The granted idle TTL (§7.7), after clamping.
+    pub idle_ttl_seconds: u32,
+    /// Relay clock at creation.
+    pub created_at_ms: u64,
+    /// Last successful `APPEND`, `READ`, `ACK` or `SUBSCRIBE` — §7.7's idle
+    /// reset list, exactly as written.
+    pub last_activity_ms: u64,
+    /// The per-queue caps this queue is admitted against.
+    pub quota: AppendQuota,
+}
+
+impl Queue {
+    /// Messages present and not yet acknowledged — §6.2's `pending`.
+    ///
+    /// Counted from storage rather than from the index arithmetic, because TTL
+    /// expiry removes messages without moving the watermark and the index-space
+    /// count is only an upper bound. `f2z-relay-proto::queue` says so and hands
+    /// the decision here, which is where the storage is.
+    #[must_use]
+    pub fn pending(&self) -> u64 {
+        u64::try_from(self.messages.len()).unwrap_or(u64::MAX)
+    }
+
+    /// Touch §7.7's idle timer.
+    pub fn touch(&mut self, now_ms: u64) {
+        self.last_activity_ms = now_ms;
+    }
+
+    fn idle_deadline(&self, faults: PolicyFaults) -> u64 {
+        match faults.expire_queue_after {
+            Some(after) => self
+                .last_activity_ms
+                .saturating_add(u64::try_from(after.as_millis()).unwrap_or(u64::MAX)),
+            None => self
+                .last_activity_ms
+                .saturating_add(u64::from(self.idle_ttl_seconds).saturating_mul(1_000)),
+        }
+    }
+
+    fn message_deadline(&self, stored: &Stored, faults: PolicyFaults) -> u64 {
+        match faults.expire_messages_after {
+            Some(after) => stored
+                .received_at_ms
+                .saturating_add(u64::try_from(after.as_millis()).unwrap_or(u64::MAX)),
+            None => stored.expires_at_ms,
+        }
+    }
+
+    fn effective_quota(&self, faults: PolicyFaults) -> AppendQuota {
+        AppendQuota {
+            max_messages: faults
+                .max_queue_messages
+                .map_or(self.quota.max_messages, u64::from),
+            max_bytes: faults.max_queue_bytes.unwrap_or(self.quota.max_bytes),
+        }
+    }
+}
+
+/// A connection that asked for `MSG` pushes on a queue (§6.2, §6.4).
+#[derive(Clone, Debug)]
+struct Subscriber {
+    connection: u64,
+    sender: UnboundedSender<Outbound>,
+}
+
+/// A challenge the relay issued and has not yet consumed (§6.1, §12.3).
+#[derive(Clone)]
+struct Issued {
+    purpose: u8,
+    scope: Vec<u8>,
+    expires_at_ms: u64,
+}
+
+// `scope` is a published contact address for a `contact_append` challenge —
+// public by design, but still a capability, and §12.2 point 3 makes it the one
+// address in the system meant to be looked up rather than logged.
+impl core::fmt::Debug for Issued {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Issued")
+            .field("purpose", &self.purpose)
+            .field(
+                "scope",
+                &format_args!("<redacted; {} bytes>", self.scope.len()),
+            )
+            .field("expires_at_ms", &self.expires_at_ms)
+            .finish()
+    }
+}
+
+/// Everything one relay holds.
+#[derive(Debug)]
+pub struct RelayState {
+    rng: Csprng,
+    queues: BTreeMap<QueueAddress, Queue>,
+    /// `send_addr` or `contact_addr` → `recv_addr`.
+    second_index: BTreeMap<QueueAddress, QueueAddress>,
+    challenges: BTreeMap<Challenge, Issued>,
+    subscribers: BTreeMap<QueueAddress, Vec<Subscriber>>,
+    /// §5.5's seen-set, relay-wide rather than per connection. In
+    /// `channel_binding_mode: none` — which is what a `ws://` test double
+    /// publishes — the binding is a constant, so a frame captured on one
+    /// connection verifies on another and a per-connection set would not close
+    /// the window at all.
+    seen: SeenSet,
+    next_connection_id: u64,
+}
+
+impl RelayState {
+    /// A fresh, empty relay.
+    #[must_use]
+    pub fn new(rng_seed: [u8; 32], seen: SeenSet) -> Self {
+        Self {
+            rng: Csprng::from_seed(rng_seed),
+            queues: BTreeMap::new(),
+            second_index: BTreeMap::new(),
+            challenges: BTreeMap::new(),
+            subscribers: BTreeMap::new(),
+            seen,
+            next_connection_id: 1,
+        }
+    }
+
+    /// Take the seen-set out for one verification, leaving a placeholder.
+    ///
+    /// `CommandVerifier` owns its seen-set because §5.1's ordering — window,
+    /// then seen-set, then signature — has to live in one function. Moving the
+    /// real set in and out per command is what lets that single implementation
+    /// be reused while the set stays relay-wide.
+    pub fn take_seen(&mut self) -> SeenSet {
+        let placeholder = SeenSet::new(self.seen.retention_ms(), self.seen.max_entries());
+        core::mem::replace(&mut self.seen, placeholder)
+    }
+
+    /// Put the seen-set back after a verification.
+    pub fn put_seen(&mut self, seen: SeenSet) {
+        self.seen = seen;
+    }
+
+    /// The seen-set, for assertions.
+    #[must_use]
+    pub const fn seen(&self) -> &SeenSet {
+        &self.seen
+    }
+
+    /// A connection identifier, so a subscription can be dropped when its
+    /// connection goes (§6.2: "a subscription is scoped to the connection and
+    /// dies with it").
+    pub fn next_connection_id(&mut self) -> u64 {
+        let id = self.next_connection_id;
+        self.next_connection_id = self.next_connection_id.saturating_add(1);
+        id
+    }
+
+    /// How many queues exist, for §13.1's creation quota.
+    #[must_use]
+    pub fn queue_count(&self) -> usize {
+        self.queues.len()
+    }
+
+    /// The relay's own CSPRNG (§7.1). See [`crate::rng`] for what it is not.
+    pub const fn rng(&mut self) -> &mut Csprng {
+        &mut self.rng
+    }
+
+    // -- queues ------------------------------------------------------------
+
+    /// Create a queue, generating both addresses from the relay's own generator
+    /// (§7.1).
+    pub fn create_queue(
+        &mut self,
+        kind: QueueKind,
+        recv_key: PublicKey,
+        message_ttl_seconds: u32,
+        idle_ttl_seconds: u32,
+        quota: AppendQuota,
+        now_ms: u64,
+    ) -> (QueueAddress, QueueAddress) {
+        // §7.1: 32 uniformly random bytes each, independent of one another and
+        // of any key, retried on collision — which at 32 bytes never happens,
+        // but the retry is what makes that a fact rather than a hope.
+        let recv_addr = self.fresh_address();
+        let second_addr = self.fresh_address();
+        let queue = Queue {
+            kind,
+            state: QueueState::create(kind, recv_key),
+            recv_addr,
+            second_addr,
+            messages: BTreeMap::new(),
+            bytes: 0,
+            message_ttl_seconds,
+            idle_ttl_seconds,
+            created_at_ms: now_ms,
+            last_activity_ms: now_ms,
+            quota,
+        };
+        self.queues.insert(recv_addr, queue);
+        self.second_index.insert(second_addr, recv_addr);
+        (recv_addr, second_addr)
+    }
+
+    fn fresh_address(&mut self) -> QueueAddress {
+        loop {
+            let candidate = self.rng.next_address();
+            if candidate.is_zero() {
+                continue;
+            }
+            if !self.queues.contains_key(&candidate) && !self.second_index.contains_key(&candidate)
+            {
+                return candidate;
+            }
+        }
+    }
+
+    /// The queue a receive address names, if any.
+    #[must_use]
+    pub fn queue_by_recv(&mut self, recv_addr: &QueueAddress) -> Option<&mut Queue> {
+        self.queues.get_mut(recv_addr)
+    }
+
+    /// The queue a send or contact address names, if any.
+    #[must_use]
+    pub fn queue_by_second(&mut self, second_addr: &QueueAddress) -> Option<&mut Queue> {
+        let recv = self.second_index.get(second_addr).copied()?;
+        self.queues.get_mut(&recv)
+    }
+
+    /// Whether an address is a queue's second address at all.
+    #[must_use]
+    pub fn is_second_address(&self, address: &QueueAddress) -> bool {
+        self.second_index.contains_key(address)
+    }
+
+    /// Delete a queue, its addresses and every message it holds (§7.6).
+    ///
+    /// Leaves no tombstone: §7.6 forbids retaining anything that distinguishes
+    /// "deleted" from "never existed" in an externally observable way, so the
+    /// record is dropped rather than flagged.
+    pub fn delete_queue(&mut self, recv_addr: &QueueAddress) -> bool {
+        let Some(queue) = self.queues.remove(recv_addr) else {
+            return false;
+        };
+        self.second_index.remove(&queue.second_addr);
+        self.notify_queue_event(recv_addr, QUEUE_EVENT_DELETED);
+        self.subscribers.remove(recv_addr);
+        true
+    }
+
+    /// Append a payload, after the caller has authorized it and admitted it
+    /// against the quota.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::Unavailable`] if the index space is exhausted — a send-side
+    /// refusal like every other (§6.3).
+    pub fn append(
+        &mut self,
+        recv_addr: &QueueAddress,
+        payload: Payload,
+        now_ms: u64,
+    ) -> std::result::Result<u64, ProtoError> {
+        let Some(queue) = self.queues.get_mut(recv_addr) else {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        };
+        let index = queue.state.append()?;
+        let expires_at_ms =
+            now_ms.saturating_add(u64::from(queue.message_ttl_seconds).saturating_mul(1_000));
+        let stored = Stored {
+            index,
+            payload,
+            received_at_ms: now_ms,
+            expires_at_ms,
+        };
+        queue.bytes = queue
+            .bytes
+            .saturating_add(u64::try_from(stored.payload.len()).unwrap_or(u64::MAX));
+        let message = stored.as_message();
+        queue.messages.insert(index, stored);
+        queue.touch(now_ms);
+        self.notify_message(recv_addr, &message);
+        Ok(index)
+    }
+
+    /// Admit one payload against a queue's caps (§13.1 layer 2, §12.3).
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::Unavailable`], never a code that says which cap was hit.
+    pub fn admit(
+        &mut self,
+        recv_addr: &QueueAddress,
+        payload_bytes: u64,
+        faults: PolicyFaults,
+    ) -> std::result::Result<(), ProtoError> {
+        let Some(queue) = self.queues.get(recv_addr) else {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        };
+        let quota = queue.effective_quota(faults);
+        let admitted = quota.admit(queue.pending(), queue.bytes, payload_bytes);
+        if admitted.is_err() {
+            self.notify_queue_event(recv_addr, QUEUE_EVENT_QUOTA);
+        }
+        admitted
+    }
+
+    /// Read from `from_index`, clamped to the acked watermark (§6.2).
+    ///
+    /// Returns the messages and whether more remain past the last one.
+    #[must_use]
+    pub fn read(
+        &mut self,
+        recv_addr: &QueueAddress,
+        from_index: u64,
+        max_messages: u16,
+        max_bytes: u32,
+        now_ms: u64,
+    ) -> Option<(Vec<QueuedMessage>, bool)> {
+        let queue = self.queues.get_mut(recv_addr)?;
+        queue.touch(now_ms);
+        let start = queue.state.read_from(from_index);
+
+        // §6.2 gives no meaning to a zero limit, and the reading that keeps a
+        // queue drainable is "no client-side limit" — the same reading
+        // f2z-relay-proto takes for a zero TTL. A zero that meant "return
+        // nothing" would make a client that forgot to set the field loop
+        // forever against a queue it can never empty.
+        let message_limit = if max_messages == 0 {
+            usize::MAX
+        } else {
+            usize::from(max_messages)
+        };
+        let byte_limit = if max_bytes == 0 {
+            u64::MAX
+        } else {
+            u64::from(max_bytes)
+        };
+
+        let mut messages = Vec::new();
+        let mut bytes = 0u64;
+        let mut has_more = false;
+        for stored in queue.messages.range(start..).map(|(_, stored)| stored) {
+            let size = u64::try_from(stored.payload.len()).unwrap_or(u64::MAX);
+            if !messages.is_empty()
+                && (messages.len() >= message_limit || bytes.saturating_add(size) > byte_limit)
+            {
+                has_more = true;
+                break;
+            }
+            bytes = bytes.saturating_add(size);
+            messages.push(stored.as_message());
+        }
+        Some((messages, has_more))
+    }
+
+    /// Apply an `ACK` and delete what it acknowledges (§8).
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::AckTooHigh`] from §8.2's anti-pre-ack rule, or
+    /// [`ErrorCode::NoAccess`] if the queue is gone.
+    pub fn ack(
+        &mut self,
+        recv_addr: &QueueAddress,
+        up_to_index: u64,
+        now_ms: u64,
+    ) -> std::result::Result<(AckOutcome, u64), ProtoError> {
+        let Some(queue) = self.queues.get_mut(recv_addr) else {
+            return Err(ProtoError::Wire(ErrorCode::NoAccess));
+        };
+        let outcome = queue.state.ack(up_to_index)?;
+        // The watermark moved (or did not, idempotently). Either way the
+        // messages at or below it are gone: §8.1, "the relay deletes them and
+        // advances the queue's acked watermark".
+        let acknowledged: Vec<u64> = queue
+            .messages
+            .range(..=up_to_index)
+            .map(|(index, _)| *index)
+            .collect();
+        for index in acknowledged {
+            if let Some(stored) = queue.messages.remove(&index) {
+                queue.bytes = queue
+                    .bytes
+                    .saturating_sub(u64::try_from(stored.payload.len()).unwrap_or(0));
+            }
+        }
+        queue.touch(now_ms);
+        Ok((outcome, queue.pending()))
+    }
+
+    // -- subscriptions -----------------------------------------------------
+
+    /// Register a connection for `MSG` pushes on a receive address (§6.2).
+    pub fn subscribe(
+        &mut self,
+        recv_addr: QueueAddress,
+        connection: u64,
+        sender: UnboundedSender<Outbound>,
+    ) {
+        let entries = self.subscribers.entry(recv_addr).or_default();
+        if entries
+            .iter()
+            .any(|subscriber| subscriber.connection == connection)
+        {
+            return;
+        }
+        entries.push(Subscriber { connection, sender });
+    }
+
+    /// Drop one connection's subscription to one address.
+    pub fn unsubscribe(&mut self, recv_addr: &QueueAddress, connection: u64) {
+        if let Some(entries) = self.subscribers.get_mut(recv_addr) {
+            entries.retain(|subscriber| subscriber.connection != connection);
+            if entries.is_empty() {
+                self.subscribers.remove(recv_addr);
+            }
+        }
+    }
+
+    /// Drop every subscription a connection holds — §6.2's "dies with it".
+    pub fn drop_connection(&mut self, connection: u64, addresses: &BTreeSet<QueueAddress>) {
+        for address in addresses {
+            self.unsubscribe(address, connection);
+        }
+    }
+
+    fn notify_message(&self, recv_addr: &QueueAddress, message: &QueuedMessage) {
+        let Some(entries) = self.subscribers.get(recv_addr) else {
+            return;
+        };
+        for subscriber in entries {
+            let push = crate::outbound::msg_push(*recv_addr, message);
+            if let Some(outbound) = push {
+                let _ = subscriber.sender.send(outbound);
+            }
+        }
+    }
+
+    fn notify_queue_event(&self, recv_addr: &QueueAddress, reason: u8) {
+        let Some(entries) = self.subscribers.get(recv_addr) else {
+            return;
+        };
+        let body = QueueEventPush {
+            recv_addr: *recv_addr,
+            reason,
+        };
+        for subscriber in entries {
+            if let Some(outbound) = crate::outbound::push(PushEvent::QueueEvent, &body) {
+                let _ = subscriber.sender.send(outbound);
+            }
+        }
+    }
+
+    /// Send a `NOTICE` to every subscribed connection (§6.4).
+    pub fn notify_all(&self, kind: u8, at_ms: u64) {
+        let body = NoticePush { kind, at_ms };
+        for entries in self.subscribers.values() {
+            for subscriber in entries {
+                if let Some(outbound) = crate::outbound::push(PushEvent::Notice, &body) {
+                    let _ = subscriber.sender.send(outbound);
+                }
+            }
+        }
+    }
+
+    // -- expiry ------------------------------------------------------------
+
+    /// Apply §7.7's two timers. Called before every command, so a test that
+    /// moves the clock sees the consequence on its next request.
+    pub fn expire(&mut self, now_ms: u64, faults: PolicyFaults) {
+        let mut messages_expired: Vec<QueueAddress> = Vec::new();
+        let mut idle_expired: Vec<QueueAddress> = Vec::new();
+
+        for (recv_addr, queue) in &mut self.queues {
+            if queue.idle_deadline(faults) <= now_ms {
+                idle_expired.push(*recv_addr);
+                continue;
+            }
+            let expired: Vec<u64> = queue
+                .messages
+                .iter()
+                .filter(|(_, stored)| queue.message_deadline(stored, faults) <= now_ms)
+                .map(|(index, _)| *index)
+                .collect();
+            if expired.is_empty() {
+                continue;
+            }
+            for index in expired {
+                if let Some(stored) = queue.messages.remove(&index) {
+                    queue.bytes = queue
+                        .bytes
+                        .saturating_sub(u64::try_from(stored.payload.len()).unwrap_or(0));
+                }
+            }
+            messages_expired.push(*recv_addr);
+        }
+
+        for recv_addr in messages_expired {
+            self.notify_queue_event(&recv_addr, QUEUE_EVENT_MESSAGES_EXPIRED);
+        }
+        for recv_addr in idle_expired {
+            if let Some(queue) = self.queues.remove(&recv_addr) {
+                self.second_index.remove(&queue.second_addr);
+            }
+            self.notify_queue_event(&recv_addr, QUEUE_EVENT_IDLE_EXPIRED);
+            self.subscribers.remove(&recv_addr);
+        }
+    }
+
+    // -- challenges --------------------------------------------------------
+
+    /// Issue a single-use, expiring challenge (§6.1, §12.3).
+    pub fn issue_challenge(&mut self, purpose: u8, scope: &[u8], expires_at_ms: u64) -> Challenge {
+        let challenge = self.rng.next_challenge();
+        self.challenges.insert(
+            challenge,
+            Issued {
+                purpose,
+                scope: scope.to_vec(),
+                expires_at_ms,
+            },
+        );
+        challenge
+    }
+
+    /// Consume a challenge, checking purpose, scope and expiry (§12.3).
+    ///
+    /// Binding the stamp to the target address and to a relay-issued challenge
+    /// is what means stamps cannot be precomputed before a campaign, cannot be
+    /// reused, and cannot be computed for one victim and spent on another. All
+    /// three properties are this one function.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorCode::PowInvalid`] — §10 code 17 covers "invalid, expired, for
+    /// the wrong challenge, or already consumed" with one code, so none of the
+    /// four is distinguishable from outside.
+    pub fn consume_challenge(
+        &mut self,
+        challenge: &Challenge,
+        purpose: u8,
+        scope: &[u8],
+        now_ms: u64,
+    ) -> std::result::Result<(), ProtoError> {
+        let Some(issued) = self.challenges.remove(challenge) else {
+            return Err(ProtoError::Wire(ErrorCode::PowInvalid));
+        };
+        if issued.purpose != purpose
+            || issued.expires_at_ms <= now_ms
+            || (!scope.is_empty() && issued.scope != scope)
+        {
+            return Err(ProtoError::Wire(ErrorCode::PowInvalid));
+        }
+        Ok(())
+    }
+
+    /// Drop expired challenges. Cheap, and keeps a long-lived relay's table
+    /// from growing without bound.
+    pub fn expire_challenges(&mut self, now_ms: u64) {
+        self.challenges
+            .retain(|_, issued| issued.expires_at_ms > now_ms);
+    }
+}
+
+/// A convenience for callers that want the whole state guarded.
+pub type SharedResult<T> = Result<T>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_codec::types::Payload;
+
+    fn state() -> RelayState {
+        RelayState::new([3u8; 32], SeenSet::new(240_000, 1024))
+    }
+
+    fn quota() -> AppendQuota {
+        AppendQuota {
+            max_messages: 8,
+            max_bytes: 64 * 1024,
+        }
+    }
+
+    #[test]
+    fn a_created_queue_has_two_distinct_nonzero_addresses() {
+        let mut state = state();
+        let (recv, send) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            600,
+            3_600,
+            quota(),
+            1_000,
+        );
+        assert_ne!(recv, send);
+        assert!(!recv.is_zero());
+        assert!(!send.is_zero());
+        assert!(state.queue_by_recv(&recv).is_some());
+        assert!(state.queue_by_second(&send).is_some());
+    }
+
+    #[test]
+    fn deleting_a_queue_leaves_no_tombstone() {
+        let mut state = state();
+        let (recv, send) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            600,
+            3_600,
+            quota(),
+            1_000,
+        );
+        assert!(state.delete_queue(&recv));
+        assert!(state.queue_by_recv(&recv).is_none());
+        assert!(state.queue_by_second(&send).is_none());
+        assert!(!state.is_second_address(&send));
+        // A second delete is indistinguishable from deleting one that never
+        // existed, which is exactly §7.6.
+        assert!(!state.delete_queue(&recv));
+    }
+
+    #[test]
+    fn acking_deletes_and_read_never_resurrects() {
+        let mut state = state();
+        let (recv, _) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            600,
+            3_600,
+            quota(),
+            1_000,
+        );
+        for _ in 0..3 {
+            state
+                .append(&recv, Payload::new(vec![0u8; 1024]).unwrap(), 1_000)
+                .unwrap();
+        }
+        let (outcome, pending) = state.ack(&recv, 1, 1_000).unwrap();
+        assert_eq!(outcome.acknowledged, 2);
+        assert_eq!(pending, 1);
+
+        // §6.2: a READ from below the watermark starts at the watermark and
+        // does not error.
+        let (messages, has_more) = state.read(&recv, 0, 0, 0, 1_000).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages.first().map(|m| m.index), Some(2));
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn a_read_always_returns_at_least_one_message() {
+        // A byte limit below the first message must not stall the queue
+        // forever: the client would never be able to drain it, and there is no
+        // other way out because READ never mutates.
+        let mut state = state();
+        let (recv, _) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            600,
+            3_600,
+            quota(),
+            1_000,
+        );
+        state
+            .append(&recv, Payload::new(vec![0u8; 4096]).unwrap(), 1_000)
+            .unwrap();
+        state
+            .append(&recv, Payload::new(vec![0u8; 4096]).unwrap(), 1_000)
+            .unwrap();
+        let (messages, has_more) = state.read(&recv, 0, 0, 1, 1_000).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn ttl_expiry_removes_messages_without_moving_the_watermark() {
+        let mut state = state();
+        let (recv, _) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            60,
+            3_600,
+            quota(),
+            1_000,
+        );
+        state
+            .append(&recv, Payload::new(vec![0u8; 1024]).unwrap(), 1_000)
+            .unwrap();
+        state.expire(1_000 + 60_001, PolicyFaults::default());
+        let queue = state.queue_by_recv(&recv).unwrap();
+        assert_eq!(queue.messages.len(), 0);
+        assert_eq!(queue.state.acked_through(), None);
+        assert_eq!(queue.state.next_index(), 1);
+        // And the reader can still not pre-ack past what was appended.
+        assert!(state.ack(&recv, 5, 1_000).is_err());
+    }
+
+    #[test]
+    fn an_idle_queue_disappears_with_both_its_addresses() {
+        let mut state = state();
+        let (recv, send) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            60,
+            3_600,
+            quota(),
+            1_000,
+        );
+        state.expire(1_000 + 3_600_001, PolicyFaults::default());
+        assert!(state.queue_by_recv(&recv).is_none());
+        assert!(!state.is_second_address(&send));
+    }
+
+    #[test]
+    fn a_challenge_is_single_use_and_scoped() {
+        let mut state = state();
+        let scope = [9u8; 32];
+        let challenge = state.issue_challenge(2, &scope, 10_000);
+        assert!(
+            state
+                .consume_challenge(&challenge, 2, &[8u8; 32], 1_000)
+                .is_err(),
+            "a stamp computed for one victim must not be spendable on another"
+        );
+        // …and the wrong-scope attempt still consumed it, which is what makes
+        // a challenge single-use rather than single-*success*.
+        let challenge = state.issue_challenge(2, &scope, 10_000);
+        assert!(
+            state
+                .consume_challenge(&challenge, 2, &scope, 1_000)
+                .is_ok()
+        );
+        assert!(
+            state
+                .consume_challenge(&challenge, 2, &scope, 1_000)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn an_expired_challenge_is_refused() {
+        let mut state = state();
+        let challenge = state.issue_challenge(1, &[], 10_000);
+        assert!(state.consume_challenge(&challenge, 1, &[], 10_001).is_err());
+    }
+
+    #[test]
+    fn there_is_no_eviction_path() {
+        // §13.2: the relay refuses new writes rather than deleting an
+        // unacknowledged message. Asserted by admitting past the cap and
+        // checking that nothing already stored moved.
+        let mut state = state();
+        let (recv, _) = state.create_queue(
+            QueueKind::Standard,
+            PublicKey::new([1u8; 32]),
+            600,
+            3_600,
+            AppendQuota {
+                max_messages: 1,
+                max_bytes: 64 * 1024,
+            },
+            1_000,
+        );
+        state
+            .append(&recv, Payload::new(vec![0u8; 1024]).unwrap(), 1_000)
+            .unwrap();
+        assert!(state.admit(&recv, 1024, PolicyFaults::default()).is_err());
+        assert_eq!(
+            state.queue_by_recv(&recv).map(|queue| queue.messages.len()),
+            Some(1)
+        );
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/transport.rs
+++ b/rs/crates/f2z-relay-testkit/src/transport.rs
@@ -1,0 +1,373 @@
+//! The one seam between "a relay" and "how its bytes travel".
+//!
+//! `WIRE.md` §2.1 admits exactly one transport, and §2.2 gives the reason: a
+//! second transport is a second parser and a second fuzz target. This crate
+//! does not add one. What it adds is a *seam*, so that the identical relay can
+//! be driven either over a real WebSocket or over an in-memory pipe.
+//!
+//! # Why both, and why they must be the same code
+//!
+//! An in-process transport is fast, deterministic and has no sockets, which
+//! makes it the right thing for a unit test. It is also a liar: it cannot
+//! reorder, cannot fragment, cannot drop a connection at a TCP boundary, and
+//! cannot tell you that your frame writer forgot to set the binary opcode. A
+//! client that only ever runs against it will ship framing bugs.
+//!
+//! So [`crate::FakeRelay`] serves both, and both go through
+//! [`crate::connection::drive`] — one function, one engine, one set of rules. If
+//! the two ever diverge the fake is lying about the thing it exists to prove,
+//! which is why `tests/conformance.rs` runs the whole vector suite twice and
+//! compares the verdicts rather than trusting that they agree.
+//!
+//! # The in-process framing is not protocol
+//!
+//! A WebSocket message is self-delimiting and typed; a byte pipe is neither. So
+//! [`duplex`] frames each message as `opcode || length || payload`, mirroring
+//! RFC 6455's opcodes closely enough that §4.2's "a text frame is a fatal
+//! `ERR_FRAME_TYPE`" is reachable in-process. **This framing exists nowhere in
+//! `WIRE.md` and no client should implement it.** It is the moral equivalent of
+//! a test double's constructor.
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::future::BoxFuture;
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
+
+/// One protocol unit as it crosses the seam.
+///
+/// The variants are RFC 6455's, restricted to what `WIRE.md` uses: §4.1's
+/// binary frames, §4.2's rejected text frames, and §2.4's server-driven
+/// keepalive.
+#[derive(Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum WireMessage {
+    /// A relay frame (§4.1). The only kind that carries protocol.
+    Binary(Vec<u8>),
+    /// A text frame. §4.2: fatal `ERR_FRAME_TYPE`, close with status 1003. The
+    /// relay MUST NOT try to decode it, and this crate MUST be able to send
+    /// one, or that rule is untested.
+    Text(Vec<u8>),
+    /// §2.4's server-side Ping. A browser cannot send one, which is why the
+    /// relay drives the keepalive.
+    Ping(Vec<u8>),
+    /// The answer to a Ping. Clients MUST send it; the browser runtime does.
+    Pong(Vec<u8>),
+    /// A close, carrying RFC 6455's status code.
+    Close(u16),
+}
+
+// A binary message is a whole relay frame — an `APPEND` payload included — and
+// a derived `Debug` would render it as a list of decimal integers. 1 KiB of
+// ciphertext becomes 5 KiB of log, written by the operator, at rest, for as
+// long as rotation keeps it. The length is public; the bytes are not.
+impl std::fmt::Debug for WireMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Binary(bytes) => write!(f, "Binary(<redacted; {} bytes>)", bytes.len()),
+            Self::Text(bytes) => write!(f, "Text(<redacted; {} bytes>)", bytes.len()),
+            Self::Ping(bytes) => write!(f, "Ping(<{} bytes>)", bytes.len()),
+            Self::Pong(bytes) => write!(f, "Pong(<{} bytes>)", bytes.len()),
+            Self::Close(code) => write!(f, "Close({code})"),
+        }
+    }
+}
+
+impl WireMessage {
+    /// The relay-frame bytes, if this is one.
+    #[must_use]
+    pub fn binary(&self) -> Option<&[u8]> {
+        match self {
+            Self::Binary(bytes) => Some(bytes),
+            _ => None,
+        }
+    }
+
+    /// The RFC 6455 opcode, as the in-process framing writes it.
+    #[must_use]
+    pub const fn opcode(&self) -> u8 {
+        match self {
+            Self::Text(_) => 0x1,
+            Self::Binary(_) => 0x2,
+            Self::Close(_) => 0x8,
+            Self::Ping(_) => 0x9,
+            Self::Pong(_) => 0xa,
+        }
+    }
+}
+
+/// The write half of a connection.
+///
+/// Object-safe rather than `async fn` in a trait, because the relay's writer
+/// task holds one behind a `Box<dyn …>` and must not care which transport it
+/// got.
+pub trait TransportSink: Send {
+    /// Write one message.
+    fn send(&mut self, message: WireMessage) -> BoxFuture<'_, io::Result<()>>;
+
+    /// Close the connection with an RFC 6455 status code.
+    fn close(&mut self, code: u16) -> BoxFuture<'_, io::Result<()>>;
+}
+
+/// The read half of a connection.
+pub trait TransportStream: Send {
+    /// Read the next message, or `None` at end of stream.
+    fn recv(&mut self) -> BoxFuture<'_, io::Result<Option<WireMessage>>>;
+}
+
+/// A connection, split so a writer task and a reader loop can hold one half
+/// each.
+pub struct Transport {
+    /// The write half.
+    pub sink: Box<dyn TransportSink>,
+    /// The read half.
+    pub stream: Box<dyn TransportStream>,
+}
+
+impl Transport {
+    /// Pair a sink and a stream.
+    #[must_use]
+    pub fn new(sink: Box<dyn TransportSink>, stream: Box<dyn TransportStream>) -> Self {
+        Self { sink, stream }
+    }
+
+    /// Split into the two halves.
+    #[must_use]
+    pub fn split(self) -> (Box<dyn TransportSink>, Box<dyn TransportStream>) {
+        (self.sink, self.stream)
+    }
+}
+
+impl std::fmt::Debug for Transport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Transport { .. }")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The in-process framing.
+// ---------------------------------------------------------------------------
+
+/// The in-process frame header: one opcode byte, then a big-endian `u32`
+/// length. Testkit-only; see the module note.
+const HEADER_LEN: usize = 5;
+
+/// The largest in-process message, so a corrupt length prefix cannot ask for an
+/// unbounded allocation. Well above §4.1's 1 MiB default `max_frame_bytes`, so
+/// the relay's own limit is what a test observes rather than this one.
+const MAX_IN_PROCESS_MESSAGE: usize = 16 * 1024 * 1024;
+
+/// The write half of an in-process connection.
+pub struct DuplexSink<W> {
+    writer: W,
+}
+
+impl<W: AsyncWrite + Unpin + Send> DuplexSink<W> {
+    /// Wrap a writer.
+    pub const fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    async fn write_message(&mut self, message: WireMessage) -> io::Result<()> {
+        let (opcode, payload) = match message {
+            WireMessage::Binary(bytes) => (0x2u8, bytes),
+            WireMessage::Text(bytes) => (0x1, bytes),
+            WireMessage::Ping(bytes) => (0x9, bytes),
+            WireMessage::Pong(bytes) => (0xa, bytes),
+            WireMessage::Close(code) => (0x8, code.to_be_bytes().to_vec()),
+        };
+        let len = u32::try_from(payload.len())
+            .map_err(|_| io::Error::other("message longer than the in-process framing allows"))?;
+        let mut header = [0u8; HEADER_LEN];
+        if let Some(first) = header.first_mut() {
+            *first = opcode;
+        }
+        if let Some(slot) = header.get_mut(1..HEADER_LEN) {
+            slot.copy_from_slice(&len.to_be_bytes());
+        }
+        self.writer.write_all(&header).await?;
+        self.writer.write_all(&payload).await?;
+        self.writer.flush().await
+    }
+}
+
+impl<W: AsyncWrite + Unpin + Send> TransportSink for DuplexSink<W> {
+    fn send(&mut self, message: WireMessage) -> BoxFuture<'_, io::Result<()>> {
+        Box::pin(self.write_message(message))
+    }
+
+    fn close(&mut self, code: u16) -> BoxFuture<'_, io::Result<()>> {
+        Box::pin(async move {
+            // A best-effort close frame, then a real shutdown. The frame is
+            // what carries §4.2's status 1003; the shutdown is what makes the
+            // peer's read return `None`.
+            let _ = self.write_message(WireMessage::Close(code)).await;
+            self.writer.shutdown().await
+        })
+    }
+}
+
+/// The read half of an in-process connection.
+pub struct DuplexStream<R> {
+    reader: R,
+}
+
+impl<R: AsyncRead + Unpin + Send> DuplexStream<R> {
+    /// Wrap a reader.
+    pub const fn new(reader: R) -> Self {
+        Self { reader }
+    }
+
+    async fn read_message(&mut self) -> io::Result<Option<WireMessage>> {
+        let mut header = [0u8; HEADER_LEN];
+        match self.reader.read_exact(&mut header).await {
+            Ok(_) => {}
+            Err(error) if is_eof(&error) => return Ok(None),
+            Err(error) => return Err(error),
+        }
+        let opcode = header.first().copied().unwrap_or(0);
+        let mut length = [0u8; 4];
+        match header.get(1..HEADER_LEN) {
+            Some(slice) => length.copy_from_slice(slice),
+            None => return Err(io::Error::other("short in-process header")),
+        }
+        let len = usize::try_from(u32::from_be_bytes(length))
+            .map_err(|_| io::Error::other("in-process length does not fit in usize"))?;
+        if len > MAX_IN_PROCESS_MESSAGE {
+            return Err(io::Error::other("in-process message length is implausible"));
+        }
+        let mut payload = vec![0u8; len];
+        match self.reader.read_exact(&mut payload).await {
+            Ok(_) => {}
+            Err(error) if is_eof(&error) => return Ok(None),
+            Err(error) => return Err(error),
+        }
+        Ok(Some(match opcode {
+            0x1 => WireMessage::Text(payload),
+            0x2 => WireMessage::Binary(payload),
+            0x8 => {
+                let code = payload
+                    .get(..2)
+                    .and_then(|bytes| <[u8; 2]>::try_from(bytes).ok())
+                    .map_or(1000, u16::from_be_bytes);
+                WireMessage::Close(code)
+            }
+            0x9 => WireMessage::Ping(payload),
+            0xa => WireMessage::Pong(payload),
+            other => {
+                return Err(io::Error::other(format!(
+                    "unknown in-process opcode {other:#x}"
+                )));
+            }
+        }))
+    }
+}
+
+impl<R: AsyncRead + Unpin + Send> TransportStream for DuplexStream<R> {
+    fn recv(&mut self) -> BoxFuture<'_, io::Result<Option<WireMessage>>> {
+        Box::pin(self.read_message())
+    }
+}
+
+fn is_eof(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::UnexpectedEof
+            | io::ErrorKind::BrokenPipe
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::ConnectionAborted
+    )
+}
+
+/// A bidirectional in-memory pipe: the two ends of one connection.
+///
+/// `capacity` is the pipe's buffer. It is deliberately generous so a test does
+/// not deadlock on backpressure it did not mean to test — a relay writer and a
+/// client writer that both block on a full pipe is a bug in the test, not a
+/// finding about the protocol.
+#[must_use]
+pub fn duplex(capacity: usize) -> (Transport, Transport) {
+    let (left, right) = tokio::io::duplex(capacity);
+    (wrap_duplex(left), wrap_duplex(right))
+}
+
+fn wrap_duplex(stream: tokio::io::DuplexStream) -> Transport {
+    let (reader, writer) = tokio::io::split(stream);
+    Transport::new(
+        Box::new(DuplexSink::new(writer)),
+        Box::new(DuplexStream::new(reader)),
+    )
+}
+
+/// A stream that yields nothing and never ends, for a half that is not used.
+pub struct PendingStream;
+
+impl TransportStream for PendingStream {
+    fn recv(&mut self) -> BoxFuture<'_, io::Result<Option<WireMessage>>> {
+        Box::pin(Pending)
+    }
+}
+
+struct Pending;
+
+impl std::future::Future for Pending {
+    type Output = io::Result<Option<WireMessage>>;
+
+    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn every_message_kind_round_trips_in_process() {
+        let (mut left, mut right) = duplex(64 * 1024);
+        let sent = [
+            WireMessage::Binary(vec![1, 2, 3]),
+            WireMessage::Text(b"not protocol".to_vec()),
+            WireMessage::Ping(vec![]),
+            WireMessage::Pong(vec![7]),
+        ];
+        for message in &sent {
+            left.sink.send(message.clone()).await.unwrap();
+        }
+        for message in &sent {
+            assert_eq!(right.stream.recv().await.unwrap(), Some(message.clone()));
+        }
+    }
+
+    #[tokio::test]
+    async fn a_closed_peer_reads_as_end_of_stream() {
+        let (mut left, mut right) = duplex(1024);
+        left.sink.send(WireMessage::Binary(vec![9])).await.unwrap();
+        left.sink.close(1000).await.unwrap();
+        assert_eq!(
+            right.stream.recv().await.unwrap(),
+            Some(WireMessage::Binary(vec![9]))
+        );
+        assert_eq!(
+            right.stream.recv().await.unwrap(),
+            Some(WireMessage::Close(1000))
+        );
+        assert_eq!(right.stream.recv().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn a_large_frame_survives_the_pipe_buffer() {
+        // The relay's own `max_frame_bytes` must be what refuses an oversize
+        // frame (§4.1), not the harness's pipe.
+        let (mut left, mut right) = duplex(8 * 1024);
+        let big = WireMessage::Binary(vec![0u8; 512 * 1024]);
+        let writer = tokio::spawn(async move { left.sink.send(big).await });
+        let received = right.stream.recv().await.unwrap();
+        writer.await.unwrap().unwrap();
+        assert_eq!(
+            received.and_then(|m| m.binary().map(<[u8]>::len)),
+            Some(524_288)
+        );
+    }
+}

--- a/rs/crates/f2z-relay-testkit/src/vectors.rs
+++ b/rs/crates/f2z-relay-testkit/src/vectors.rs
@@ -1,0 +1,1784 @@
+//! The conformance suite: `(input, expected output)` for every rule of
+//! `WIRE.md` this crate can reach.
+//!
+//! # Why this file is the deliverable
+//!
+//! A fake relay that nobody checks is an untested claim about the protocol,
+//! and a client built against an untested claim inherits every mistake in it.
+//! So the rules are not asserted in the engine's own unit tests, where they
+//! would only ever prove that the engine agrees with itself. They are stated
+//! here, as inputs and expected outputs, driven through the ordinary client
+//! API, over a transport — which is exactly how `f2z-relay` will be driven when
+//! it exists.
+//!
+//! [`run`] takes an [`Endpoint`]. `FakeRelay` provides two, and the real relay
+//! will be a third:
+//!
+//! ```text
+//!   run(InProcessEndpoint)  ─┐
+//!   run(WebSocketEndpoint)  ─┼─→ the same Vec<Vector>, the same verdicts
+//!   run(WebSocketEndpoint::new("wss://relay.example/relay/v1"))
+//! ```
+//!
+//! A vector that needs to *break* the relay — drop a response, expire a TTL,
+//! publish the [#586] capability document — declares [`Needs::Faults`] or
+//! [`Needs::Clock`]. Against a relay with no such handle it is reported
+//! **skipped**, never passed. A suite that silently counted an unrunnable
+//! vector as green would be worse than not having it.
+//!
+//! # What a vector may assume
+//!
+//! Only what `WIRE.md` guarantees. In particular no vector asserts a queue
+//! address, an index origin beyond what §8.2 forces, or a message ordering the
+//! relay never promised — a test that pinned one of those would fail a
+//! conforming relay, which is the failure mode that makes conformance suites
+//! get deleted.
+//!
+//! [#586]: https://github.com/free2z/zuu/issues/586
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::canonical::Canonical;
+use f2z_codec::commands::{AckRequest, ChallengePurpose, Command, PushEvent};
+use f2z_codec::types::QueueAddress;
+use f2z_relay_proto::capabilities::{self, ClientPolicy};
+use f2z_relay_proto::command::ops;
+use f2z_relay_proto::key::SigningKey;
+use futures_util::future::BoxFuture;
+
+use crate::client::{Client, solve};
+use crate::clock::Clock;
+use crate::error::{Result, TestkitError};
+use crate::fake::Endpoint;
+use crate::faults::{Effect, Fault, FaultInjector, PolicyFaults, Trigger};
+use crate::rng::Csprng;
+use crate::state::{QUEUE_EVENT_DELETED, QUEUE_EVENT_MESSAGES_EXPIRED};
+use crate::transport::Transport;
+
+/// What a vector needs from the target before it can mean anything.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Needs {
+    /// Nothing but a conforming relay. Every one of these runs against
+    /// `f2z-relay` unchanged.
+    Nothing,
+    /// A fault handle. Skipped against a relay that cannot be told to
+    /// misbehave.
+    Faults,
+    /// A steerable clock. Skipped against a relay whose clock is the world's.
+    Clock,
+}
+
+/// One `(input, expected output)` case.
+pub struct Vector {
+    /// The case's name, stable so a failure can be searched for.
+    pub name: &'static str,
+    /// The `WIRE.md` section it pins.
+    pub section: &'static str,
+    /// What the target must provide.
+    pub needs: Needs,
+    /// The case itself.
+    pub run: VectorFn,
+}
+
+/// A vector body.
+pub type VectorFn = for<'a> fn(&'a mut Context) -> BoxFuture<'a, Result<()>>;
+
+/// What a vector is handed.
+pub struct Context {
+    endpoint: Arc<dyn Endpoint>,
+    /// A connection with `HELLO` already completed.
+    pub client: Client,
+    /// The target's fault handle, when it has one.
+    pub faults: Option<FaultInjector>,
+    /// The target's clock, when it can be steered.
+    pub clock: Option<Clock>,
+    keys: Csprng,
+    nonces: Csprng,
+}
+
+impl Context {
+    /// Open a second connection, `HELLO` completed.
+    ///
+    /// # Errors
+    ///
+    /// As [`Client::connect`].
+    pub async fn open(&mut self) -> Result<Client> {
+        let transport = self.endpoint.connect().await?;
+        Client::connect(transport, self.client_config()).await
+    }
+
+    /// A client configuration whose nonce stream has never been used.
+    ///
+    /// §5.5's seen-set is relay-wide and, on a frozen clock, nothing in it ever
+    /// ages out. Two connections drawing from one nonce stream would therefore
+    /// collide on `(signer_key, nonce)` and the second would be refused as a
+    /// replay — a harness bug that would look exactly like a relay bug. Each
+    /// connection gets its own stream, and each vector's streams are derived
+    /// from its own name, so a vector is reproducible in isolation and cannot
+    /// collide with any other.
+    fn client_config(&mut self) -> crate::client::ClientConfig {
+        let mut config = self.endpoint.client_config();
+        config.nonce_seed = self.nonces.next_block();
+        config
+    }
+
+    /// Open a raw transport with **no** `HELLO`, for the vectors that test what
+    /// happens before one.
+    ///
+    /// # Errors
+    ///
+    /// As [`Endpoint::connect`].
+    pub async fn raw(&mut self) -> Result<Transport> {
+        self.endpoint.connect().await
+    }
+
+    /// A fresh queue key. Deterministic, so a failing vector replays.
+    pub fn key(&mut self) -> SigningKey {
+        SigningKey::from_seed(&self.keys.next_block())
+    }
+
+    /// The fault handle, or a skip.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] when the target has none.
+    pub fn require_faults(&self) -> Result<FaultInjector> {
+        self.faults
+            .clone()
+            .ok_or(TestkitError::Config("this target has no fault handle"))
+    }
+
+    /// The clock, or a skip.
+    ///
+    /// # Errors
+    ///
+    /// [`TestkitError::Config`] when the target has none.
+    pub fn require_clock(&self) -> Result<Clock> {
+        self.clock
+            .clone()
+            .ok_or(TestkitError::Config("this target has no steerable clock"))
+    }
+}
+
+/// How a vector ended.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Status {
+    /// The expected output was observed.
+    Passed,
+    /// The target could not provide what the vector needs. Never a pass.
+    Skipped(String),
+    /// The expected output was not observed.
+    Failed(String),
+}
+
+/// One vector's result.
+#[derive(Clone, Debug)]
+pub struct Outcome {
+    /// The vector's name.
+    pub name: &'static str,
+    /// The section it pins.
+    pub section: &'static str,
+    /// What happened.
+    pub status: Status,
+}
+
+/// A whole run.
+#[derive(Clone, Debug)]
+pub struct Report {
+    /// How the target was reached.
+    pub target: String,
+    /// Every vector, in suite order.
+    pub outcomes: Vec<Outcome>,
+}
+
+impl Report {
+    /// How many passed.
+    #[must_use]
+    pub fn passed(&self) -> usize {
+        self.count(|status| matches!(status, Status::Passed))
+    }
+
+    /// How many were skipped for want of a handle.
+    #[must_use]
+    pub fn skipped(&self) -> usize {
+        self.count(|status| matches!(status, Status::Skipped(_)))
+    }
+
+    /// How many failed.
+    #[must_use]
+    pub fn failed(&self) -> usize {
+        self.count(|status| matches!(status, Status::Failed(_)))
+    }
+
+    fn count(&self, predicate: impl Fn(&Status) -> bool) -> usize {
+        self.outcomes
+            .iter()
+            .filter(|outcome| predicate(&outcome.status))
+            .count()
+    }
+
+    /// The names and reasons of every failure.
+    #[must_use]
+    pub fn failures(&self) -> Vec<String> {
+        self.outcomes
+            .iter()
+            .filter_map(|outcome| match &outcome.status {
+                Status::Failed(reason) => {
+                    Some(format!("{} ({}): {reason}", outcome.name, outcome.section))
+                }
+                Status::Passed | Status::Skipped(_) => None,
+            })
+            .collect()
+    }
+
+    /// A one-line summary.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        format!(
+            "{}: {} passed, {} skipped, {} failed, of {}",
+            self.target,
+            self.passed(),
+            self.skipped(),
+            self.failed(),
+            self.outcomes.len()
+        )
+    }
+
+    /// The pass/skip/fail verdict of each vector, by name, for comparing two
+    /// runs of the same suite against two targets.
+    #[must_use]
+    pub fn verdicts(&self) -> Vec<(&'static str, Status)> {
+        self.outcomes
+            .iter()
+            .map(|outcome| (outcome.name, outcome.status.clone()))
+            .collect()
+    }
+}
+
+/// Run the whole suite against a target.
+///
+/// Each vector gets its own connection, and any fault it armed is disarmed
+/// afterwards — a vector that leaked a fault into the next one would produce a
+/// failure nobody could reproduce in isolation.
+pub async fn run(endpoint: Arc<dyn Endpoint>) -> Report {
+    run_selected(endpoint, &suite()).await
+}
+
+/// Run a chosen subset.
+pub async fn run_selected(endpoint: Arc<dyn Endpoint>, vectors: &[Vector]) -> Report {
+    let target = endpoint.describe();
+    let mut outcomes = Vec::with_capacity(vectors.len());
+
+    for vector in vectors {
+        let faults = endpoint.faults();
+        let clock = endpoint.clock();
+        let status = match (vector.needs, faults.is_some(), clock.is_some()) {
+            (Needs::Faults, false, _) => {
+                Status::Skipped("the target has no fault handle".to_owned())
+            }
+            (Needs::Clock, _, false) => {
+                Status::Skipped("the target has no steerable clock".to_owned())
+            }
+            _ => run_one(&endpoint, vector, faults.clone(), clock).await,
+        };
+
+        if let Some(faults) = faults {
+            faults.disarm();
+            faults.set_policy(PolicyFaults::default());
+        }
+        outcomes.push(Outcome {
+            name: vector.name,
+            section: vector.section,
+            status,
+        });
+    }
+
+    Report { target, outcomes }
+}
+
+fn seed_for(name: &str, purpose: &[u8]) -> [u8; 32] {
+    let mut input = Vec::with_capacity(name.len().saturating_add(purpose.len()).saturating_add(1));
+    input.extend_from_slice(purpose);
+    input.push(b'/');
+    input.extend_from_slice(name.as_bytes());
+    *f2z_codec::hash::hash(b"f2z-relay-testkit/vector-seed/v1", &input).as_bytes()
+}
+
+async fn run_one(
+    endpoint: &Arc<dyn Endpoint>,
+    vector: &Vector,
+    faults: Option<FaultInjector>,
+    clock: Option<Clock>,
+) -> Status {
+    let transport = match endpoint.connect().await {
+        Ok(transport) => transport,
+        Err(error) => return Status::Failed(format!("could not connect: {error}")),
+    };
+    // Both streams are derived from the vector's own name rather than from its
+    // position in the suite, so running one vector alone produces exactly the
+    // keys and nonces it produces in a full run.
+    let mut nonces = Csprng::from_seed(seed_for(vector.name, b"nonces"));
+    let mut config = endpoint.client_config();
+    config.nonce_seed = nonces.next_block();
+    let client = match Client::connect(transport, config).await {
+        Ok(client) => client,
+        Err(error) => return Status::Failed(format!("HELLO failed: {error}")),
+    };
+    let mut context = Context {
+        endpoint: Arc::clone(endpoint),
+        client,
+        faults,
+        clock,
+        keys: Csprng::from_seed(seed_for(vector.name, b"keys")),
+        nonces,
+    };
+    match (vector.run)(&mut context).await {
+        Ok(()) => Status::Passed,
+        Err(error) => Status::Failed(error.to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Assertions.
+// ---------------------------------------------------------------------------
+
+/// Assert that a call was refused with exactly this §10 code.
+///
+/// # Errors
+///
+/// [`TestkitError::Expectation`] when it was not.
+pub fn expect_code<T>(result: Result<T>, expected: ErrorCode) -> Result<()> {
+    match result {
+        Ok(_) => Err(TestkitError::Expectation(format!(
+            "expected {} and the relay accepted the command",
+            expected.name()
+        ))),
+        Err(error) => match error.wire_code() {
+            Some(code) if code == expected => Ok(()),
+            Some(code) => Err(TestkitError::Expectation(format!(
+                "expected {}, got {}",
+                expected.name(),
+                code.name()
+            ))),
+            None => Err(TestkitError::Expectation(format!(
+                "expected {}, got {error}",
+                expected.name()
+            ))),
+        },
+    }
+}
+
+/// Assert a boolean, with a reason.
+///
+/// # Errors
+///
+/// [`TestkitError::Expectation`] when it does not hold.
+pub fn expect(condition: bool, reason: &str) -> Result<()> {
+    if condition {
+        Ok(())
+    } else {
+        Err(TestkitError::Expectation(reason.to_owned()))
+    }
+}
+
+/// Assert equality of two values that can be shown.
+///
+/// # Errors
+///
+/// [`TestkitError::Expectation`] when they differ.
+pub fn expect_eq<T: PartialEq + std::fmt::Debug>(left: T, right: T, reason: &str) -> Result<()> {
+    if left == right {
+        Ok(())
+    } else {
+        Err(TestkitError::Expectation(format!(
+            "{reason}: {left:?} != {right:?}"
+        )))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The suite.
+// ---------------------------------------------------------------------------
+
+macro_rules! suite {
+    ($( $needs:ident, $section:literal, $name:ident );* $(;)?) => {
+        /// Every vector, in the order `WIRE.md` states the rules.
+        #[must_use]
+        pub fn suite() -> Vec<Vector> {
+            vec![$(
+                Vector {
+                    name: stringify!($name),
+                    section: $section,
+                    needs: Needs::$needs,
+                    run: |context| Box::pin($name(context)),
+                }
+            ),*]
+        }
+    };
+}
+
+suite! {
+    // §2 — transport and lifecycle
+    Nothing, "§2.5", hello_must_be_the_first_frame;
+    Nothing, "§2.5", a_second_hello_is_refused;
+    Nothing, "§3.5", an_unofferable_version_is_refused;
+    Nothing, "§5.2", relay_id_is_the_digest_of_the_proven_key;
+
+    // §3, §4 — serialization and framing
+    Nothing, "§3.3", trailing_bytes_in_a_frame_are_fatally_malformed;
+    Nothing, "§3.3", a_non_canonical_body_is_fatally_malformed;
+    Nothing, "§4.1", an_oversize_frame_is_fatally_malformed;
+    Nothing, "§4.2", a_text_frame_closes_the_connection;
+    Nothing, "§3.5", an_unknown_command_is_not_fatal;
+    Faults,  "§4.3", a_duplicate_inflight_request_id_is_fatal;
+    Faults,  "§4.3", exceeding_the_inflight_window_is_fatal;
+
+    // §5 — the signing transcript
+    Nothing, "§5.1", a_tampered_signature_is_refused;
+    Nothing, "§5.1", the_transcript_binds_the_request_id;
+    Nothing, "§5.5", a_stale_timestamp_is_refused;
+    Nothing, "§5.5", a_replayed_frame_is_refused;
+    Nothing, "§5.1", a_key_that_does_not_authorize_the_address_is_refused;
+
+    // §6, §7 — queue lifecycle
+    Nothing, "§7.1", create_queue_returns_two_distinct_addresses;
+    Nothing, "§7.7", requested_ttls_are_clamped_and_reported;
+    Nothing, "§7.3", bind_send_is_once_only;
+    Nothing, "§6.3", append_requires_the_bound_key;
+    Nothing, "§6.3", append_before_bind_is_unavailable;
+    Nothing, "§6.3", an_append_response_carries_no_queue_state;
+    Nothing, "§10",  an_absent_recv_address_is_no_access;
+    Nothing, "§6.3", an_absent_send_address_is_unavailable;
+    Nothing, "§7.6", a_deleted_queue_looks_like_one_that_never_existed;
+    Nothing, "§6.2", read_never_mutates;
+    Nothing, "§6.2", reading_below_the_watermark_starts_at_the_watermark;
+
+    // §8 — acknowledgement
+    Nothing, "§8.1", ack_is_cumulative_monotone_and_idempotent;
+    Nothing, "§8.2", acking_beyond_the_highest_index_is_refused;
+    Nothing, "§8.1", acking_deletes_the_ciphertext;
+
+    // §6.4 — pushes
+    Nothing, "§6.4", a_subscriber_is_pushed_the_message;
+    Nothing, "§6.4", unsubscribing_stops_the_pushes;
+    Nothing, "§6.4", deleting_a_queue_pushes_queue_event_one;
+
+    // §9 — padding
+    Nothing, "§9",   a_payload_outside_the_buckets_is_bad_size;
+
+    // §11 — the capability document
+    Nothing, "§11.1", the_capability_document_verifies_and_is_valid;
+    Nothing, "§6.1",  the_hello_digest_matches_the_document;
+    Faults,  "§5.5",  an_unsound_antireplay_window_is_published_and_refused;
+
+    // §12 — first contact
+    Nothing, "§12.2", bind_send_on_a_contact_address_is_not_permitted;
+    Nothing, "§12.3", contact_append_requires_a_stamp;
+    Nothing, "§12.3", a_contact_stamp_is_single_use;
+    Nothing, "§12.3", a_contact_stamp_is_scoped_to_its_target;
+    Nothing, "§12.5", first_contact_reaches_the_recipient;
+
+    // §13 — anti-abuse
+    Faults,  "§13.1", a_full_queue_is_indistinguishable_from_an_absent_one;
+    Faults,  "§13.1", backpressure_never_refuses_read_ack_or_delete;
+    Faults,  "§13.1", the_queue_creation_quota_is_a_distinguishable_code;
+    Faults,  "§10",   every_error_code_can_reach_a_client;
+
+    // §7.7 — TTLs
+    Faults,  "§7.7",  an_expired_message_is_gone_and_announced;
+    Clock,   "§7.7",  an_idle_queue_disappears;
+
+    // Failure paths — the ones delete-on-ack makes expensive to get wrong
+    Faults,  "§8.3",  a_lost_ack_response_is_safe_to_retry;
+    Faults,  "§4.3",  a_delayed_response_still_correlates;
+    Faults,  "§4.3",  reordered_responses_still_correlate;
+    Faults,  "§2.5",  a_mid_stream_close_leaves_the_status_unknown;
+}
+
+// ---------------------------------------------------------------------------
+// §2, §3, §4.
+// ---------------------------------------------------------------------------
+
+async fn hello_must_be_the_first_frame(context: &mut Context) -> Result<()> {
+    // A fresh transport with no HELLO. §2.5: "A relay that receives any other
+    // frame first responds ERR_UNSUPPORTED_VERSION and closes."
+    let transport = context.raw().await?;
+    let (mut sink, mut stream) = transport.split();
+    let frame = f2z_relay_proto::command::unsigned_request::<ops::Ping>(1, &Default::default())?;
+    sink.send(crate::transport::WireMessage::Binary(
+        frame.encode_canonical()?,
+    ))
+    .await?;
+    let code = read_response_code(&mut stream).await?;
+    expect_eq(
+        code,
+        Some(ErrorCode::UnsupportedVersion),
+        "a frame before HELLO must be ERR_UNSUPPORTED_VERSION",
+    )
+}
+
+async fn a_second_hello_is_refused(context: &mut Context) -> Result<()> {
+    let result = context
+        .client
+        .call_unsigned::<ops::Hello>(&f2z_codec::commands::HelloRequest {
+            min_version: f2z_codec::PROTOCOL_VERSION,
+            max_version: f2z_codec::PROTOCOL_VERSION,
+            client_nonce: f2z_codec::types::Challenge::new([9u8; 32]),
+        })
+        .await;
+    // §3.5: negotiation happens once and applies to the whole connection.
+    expect_code(result, ErrorCode::UnsupportedVersion)
+}
+
+async fn an_unofferable_version_is_refused(context: &mut Context) -> Result<()> {
+    let transport = context.raw().await?;
+    let (mut sink, mut stream) = transport.split();
+    let offer = f2z_codec::commands::HelloRequest {
+        // A range this build cannot be inside.
+        min_version: 2,
+        max_version: 3,
+        client_nonce: f2z_codec::types::Challenge::new([1u8; 32]),
+    };
+    let frame = f2z_relay_proto::command::unsigned_request::<ops::Hello>(1, &offer)?;
+    sink.send(crate::transport::WireMessage::Binary(
+        frame.encode_canonical()?,
+    ))
+    .await?;
+    let code = read_response_code(&mut stream).await?;
+    expect_eq(
+        code,
+        Some(ErrorCode::UnsupportedVersion),
+        "no common version must be ERR_UNSUPPORTED_VERSION",
+    )
+}
+
+async fn relay_id_is_the_digest_of_the_proven_key(context: &mut Context) -> Result<()> {
+    // The client already refused to open a session unless this held; asserting
+    // it here makes the property a vector rather than an implementation detail
+    // of the harness.
+    let session = context.client.session();
+    expect_eq(
+        session.relay_id(),
+        f2z_codec::hash::relay_id(&session.relay_identity_pk()),
+        "relay_id must be H(\"free2z/relay/v1/relay-id\", relay_identity_pk)",
+    )
+}
+
+async fn trailing_bytes_in_a_frame_are_fatally_malformed(context: &mut Context) -> Result<()> {
+    let mut client = context.open().await?;
+    let key = context.key();
+    let mut bytes = client.encode_signed::<ops::Ack>(
+        &key,
+        QueueAddress::new([1u8; 32]),
+        &AckRequest { up_to_index: 0 },
+    )?;
+    bytes.push(0);
+    client.send_raw(bytes).await?;
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::Malformed),
+        "a trailing byte must fail re-encode equality",
+    )?;
+    // §1.3: fatal means send the response, then close.
+    client.expect_closed().await
+}
+
+async fn a_non_canonical_body_is_fatally_malformed(context: &mut Context) -> Result<()> {
+    let mut client = context.open().await?;
+    let key = context.key();
+    // A frame that is canonical at the framing layer and carries one trailing
+    // byte inside its opaque body. §3.3 has to be applied twice, and a relay
+    // that applies it once accepts this.
+    let timestamp = client.relay_time_ms();
+    let nonce = client.nonce();
+    let signed = f2z_relay_proto::command::SignedCommand::<ops::Ack>::create(
+        client.session().transcripts(),
+        4_242,
+        QueueAddress::new([2u8; 32]),
+        timestamp,
+        nonce,
+        &key,
+        &AckRequest { up_to_index: 0 },
+    )?;
+    let mut body = signed.body().to_vec();
+    body.push(0);
+    let request = f2z_codec::frame::Request::new(
+        Command::Ack.code(),
+        f2z_codec::frame::CommandAuth::Signed(signed.auth().clone()),
+        body,
+    )?;
+    let frame = f2z_codec::frame::RelayFrame::request(4_242, request);
+    client.send_raw(frame.encode_canonical()?).await?;
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::Malformed),
+        "a non-canonical body inside a canonical frame must still be refused",
+    )
+}
+
+async fn an_oversize_frame_is_fatally_malformed(context: &mut Context) -> Result<()> {
+    let mut client = context.open().await?;
+    let capabilities = client.capabilities().await?.capabilities;
+    let size = usize::try_from(capabilities.max_frame_bytes)
+        .unwrap_or(usize::MAX)
+        .saturating_add(1);
+    let mut probe = context.open().await?;
+    probe.send_raw(vec![0u8; size]).await?;
+    // §4.1: `ERR_MALFORMED`, and the relay MUST NOT buffer the remainder to
+    // produce a tidy error. The bytes are not a decodable frame, so the id is
+    // unrecoverable and the connection simply closes.
+    probe.expect_closed().await
+}
+
+async fn a_text_frame_closes_the_connection(context: &mut Context) -> Result<()> {
+    let mut client = context.open().await?;
+    client.send_text("this is not protocol").await?;
+    // §4.2: fatal ERR_FRAME_TYPE, WebSocket status 1003. A text frame carries
+    // no `request_id`, so what a client observes is the close.
+    client.expect_closed().await
+}
+
+async fn an_unknown_command_is_not_fatal(context: &mut Context) -> Result<()> {
+    let request = f2z_codec::frame::Request::new(
+        0xbeef,
+        f2z_codec::frame::CommandAuth::Unsigned,
+        Vec::new(),
+    )?;
+    let frame = f2z_codec::frame::RelayFrame::request(7, request);
+    context.client.send_raw(frame.encode_canonical()?).await?;
+    let (_, response) = context.client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::UnknownCommand),
+        "an unknown command code must be ERR_UNKNOWN_COMMAND",
+    )?;
+    // Non-fatal: the connection still works.
+    context.client.ping().await
+}
+
+async fn a_duplicate_inflight_request_id_is_fatal(context: &mut Context) -> Result<()> {
+    // §4.3's duplicate rule is about ids that are *currently* in flight, and a
+    // relay releases an id the moment it answers. So the rule is only
+    // observable while a response is being held — which is why this vector
+    // needs a fault handle and is reported as skipped against a relay that has
+    // none, rather than being made into a race that passes by luck.
+    let faults = context.require_faults()?;
+    let mut client = context.open().await?;
+    faults.arm(Fault::once(Trigger::Command(Command::Ping), Effect::Stall));
+
+    let ping = f2z_relay_proto::command::unsigned_request::<ops::Ping>(9_000, &Default::default())?;
+    let bytes = ping.encode_canonical()?;
+    client.send_raw(bytes.clone()).await?;
+    client.send_raw(bytes).await?;
+
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::Malformed),
+        "a duplicate in-flight request_id must be ERR_MALFORMED",
+    )?;
+    // §1.3: fatal means send the response, then close.
+    client.expect_closed().await
+}
+
+async fn exceeding_the_inflight_window_is_fatal(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let mut client = context.open().await?;
+    let capabilities = client.capabilities().await?.capabilities;
+    let window = usize::from(capabilities.max_inflight);
+
+    // Stall every PING so nothing is ever released.
+    faults.arm(Fault::always(
+        Trigger::Command(Command::Ping),
+        Effect::Stall,
+    ));
+    for _ in 0..window {
+        client
+            .send_unsigned::<ops::Ping>(&Default::default())
+            .await?;
+    }
+    client
+        .send_unsigned::<ops::Ping>(&Default::default())
+        .await?;
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::TooManyInflight),
+        "the in-flight window must be enforced with ERR_TOO_MANY_INFLIGHT",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// §5.
+// ---------------------------------------------------------------------------
+
+async fn a_tampered_signature_is_refused(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 0, None).await?;
+    let mut client = context.open().await?;
+    let timestamp = client.relay_time_ms();
+    let nonce = client.nonce();
+    let signed = f2z_relay_proto::command::SignedCommand::<ops::Ack>::create(
+        client.session().transcripts(),
+        11,
+        created.recv_addr,
+        timestamp,
+        nonce,
+        &key,
+        &AckRequest { up_to_index: 0 },
+    )?;
+    let mut auth = signed.auth().clone();
+    let mut signature = *auth.signature.as_bytes();
+    signature[0] ^= 0xff;
+    auth.signature = f2z_codec::types::Signature::new(signature);
+    let request = f2z_codec::frame::Request::new(
+        Command::Ack.code(),
+        f2z_codec::frame::CommandAuth::Signed(auth),
+        signed.body().to_vec(),
+    )?;
+    client
+        .send_raw(f2z_codec::frame::RelayFrame::request(11, request).encode_canonical()?)
+        .await?;
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::BadSignature),
+        "a tampered signature must be ERR_BAD_SIGNATURE",
+    )
+}
+
+async fn the_transcript_binds_the_request_id(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 0, None).await?;
+    let mut client = context.open().await?;
+    // Sign for one `request_id`, then present the frame under another. §5.1
+    // puts `request_id` in the transcript, so this cannot verify — and it is a
+    // *fresh* nonce, so the refusal is the signature check and not the replay
+    // check.
+    let mut bytes = client.encode_signed::<ops::Ack>(
+        &key,
+        created.recv_addr,
+        &AckRequest { up_to_index: 0 },
+    )?;
+    let original = bytes
+        .get(1..5)
+        .and_then(|slice| <[u8; 4]>::try_from(slice).ok())
+        .map_or(0, u32::from_be_bytes);
+    let replacement = original.wrapping_add(1).max(1).to_be_bytes();
+    if let Some(slot) = bytes.get_mut(1..5) {
+        slot.copy_from_slice(&replacement);
+    }
+    client.send_raw(bytes).await?;
+    let (_, response) = client.next_response().await?;
+    expect_eq(
+        response.error_code(),
+        Some(ErrorCode::BadSignature),
+        "the transcript covers request_id, so moving it must break the signature",
+    )
+}
+
+async fn a_stale_timestamp_is_refused(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 0, None).await?;
+    let capabilities = context.client.capabilities().await?.capabilities;
+    let mut client = context.open().await?;
+    let now = client.relay_time_ms();
+    // Outside ±clock_skew_ms in the past. §5.5 gives the same code for the
+    // future half, deliberately: splitting them would tell a caller which way
+    // its clock is wrong, which fingerprints the caller.
+    client.set_timestamp(Some(now.saturating_sub(
+        u64::from(capabilities.clock_skew_ms).saturating_add(60_000),
+    )));
+    let result = client.ack(&key, created.recv_addr, 0).await;
+    expect_code(result, ErrorCode::StaleTimestamp)
+}
+
+async fn a_replayed_frame_is_refused(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 0, None).await?;
+    let mut client = context.open().await?;
+    // A queue with nothing appended: ACK 0 is ERR_ACK_TOO_HIGH, which proves
+    // the frame was *verified* the first time. The second presentation must
+    // stop earlier, at the seen-set.
+    let bytes = client.encode_signed::<ops::Ack>(
+        &key,
+        created.recv_addr,
+        &AckRequest { up_to_index: 0 },
+    )?;
+    client.send_raw(bytes.clone()).await?;
+    let (_, first) = client.next_response().await?;
+    expect_eq(
+        first.error_code(),
+        Some(ErrorCode::AckTooHigh),
+        "the first presentation must be verified and then refused on its merits",
+    )?;
+    client.send_raw(bytes).await?;
+    let (_, second) = client.next_response().await?;
+    expect_eq(
+        second.error_code(),
+        Some(ErrorCode::Replay),
+        "the same (signer_key, nonce) twice must be ERR_REPLAY",
+    )
+}
+
+async fn a_key_that_does_not_authorize_the_address_is_refused(context: &mut Context) -> Result<()> {
+    let owner = context.key();
+    let stranger = context.key();
+    let created = context.client.create_queue(&owner, 0, 0, None).await?;
+    let mut client = context.open().await?;
+    let result = client.read(&stranger, created.recv_addr, 0, 0, 0).await;
+    // §10's existence-oracle rule: the same code an address that never existed
+    // gets.
+    expect_code(result, ErrorCode::NoAccess)
+}
+
+// ---------------------------------------------------------------------------
+// §6, §7.
+// ---------------------------------------------------------------------------
+
+async fn create_queue_returns_two_distinct_addresses(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 0, None).await?;
+    expect(!created.recv_addr.is_zero(), "recv_addr must not be zero")?;
+    expect(!created.send_addr.is_zero(), "send_addr must not be zero")?;
+    expect(
+        created.recv_addr != created.send_addr,
+        "the two addresses must differ; they are two capabilities",
+    )
+}
+
+async fn requested_ttls_are_clamped_and_reported(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    // A century. §7.7 caps the message TTL at 30 days and a relay MUST NOT
+    // grant more, whatever its own configured maximum says.
+    let created = context
+        .client
+        .create_queue(&key, u32::MAX, u32::MAX, None)
+        .await?;
+    expect(
+        created.message_ttl_seconds <= f2z_codec::MAX_MESSAGE_TTL_SECONDS,
+        "message_ttl_seconds must be clamped to the 30-day ceiling",
+    )?;
+    expect(
+        created.idle_ttl_seconds <= f2z_relay_proto::queue::MAX_IDLE_TTL_SECONDS,
+        "idle_ttl_seconds must be clamped to the published ceiling",
+    )
+}
+
+async fn bind_send_is_once_only(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let other_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    // §7.3: with any key, including the same key.
+    let again = sender.bind_send(&send_key, created.send_addr).await;
+    expect_code(again, ErrorCode::AlreadyBound)?;
+    let stolen = sender.bind_send(&other_key, created.send_addr).await;
+    expect_code(stolen, ErrorCode::AlreadyBound)
+}
+
+async fn append_requires_the_bound_key(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let impostor = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    let result = sender
+        .append(&impostor, created.send_addr, b"not yours")
+        .await;
+    // §6.3: never a distinguishable code.
+    expect_code(result, ErrorCode::Unavailable)
+}
+
+async fn append_before_bind_is_unavailable(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    let result = sender.append(&send_key, created.send_addr, b"early").await;
+    expect_code(result, ErrorCode::Unavailable)
+}
+
+async fn an_append_response_carries_no_queue_state(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    let request_id = sender
+        .send_signed::<ops::Append>(
+            &send_key,
+            created.send_addr,
+            &f2z_codec::commands::AppendRequest {
+                payload: sender.pad(b"one")?,
+            },
+        )
+        .await?;
+    let (id, response) = sender.next_response().await?;
+    expect_eq(id, request_id, "the response must answer the request")?;
+    expect(response.is_ok(), "the append must be accepted")?;
+    // The requirement, literally: no index, no depth, no timestamp, no queue
+    // state of any kind. Each of those would convert the send capability into a
+    // weak read capability.
+    expect_eq(
+        response.body().len(),
+        0,
+        "an APPEND response body must be empty",
+    )
+}
+
+async fn an_absent_recv_address_is_no_access(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let result = context
+        .client
+        .read(&key, QueueAddress::new([0x5a; 32]), 0, 0, 0)
+        .await;
+    expect_code(result, ErrorCode::NoAccess)
+}
+
+async fn an_absent_send_address_is_unavailable(context: &mut Context) -> Result<()> {
+    let key = context.key();
+    let result = context
+        .client
+        .append(&key, QueueAddress::new([0x5b; 32]), b"nowhere")
+        .await;
+    expect_code(result, ErrorCode::Unavailable)
+}
+
+async fn a_deleted_queue_looks_like_one_that_never_existed(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    context
+        .client
+        .delete_queue(&recv_key, created.recv_addr)
+        .await?;
+
+    // §7.6: no tombstone distinguishable from outside. The recv side gets the
+    // same code an address that never existed gets…
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await;
+    expect_code(read, ErrorCode::NoAccess)?;
+    // …and the sender learns nothing except that its next APPEND fails.
+    let append = sender.append(&send_key, created.send_addr, b"gone").await;
+    expect_code(append, ErrorCode::Unavailable)
+}
+
+async fn read_never_mutates(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender.append(&send_key, created.send_addr, b"once").await?;
+
+    let first = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    let second = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(
+        first.messages.len(),
+        second.messages.len(),
+        "READ must not consume",
+    )?;
+    expect_eq(
+        first.messages.len(),
+        1,
+        "the appended message must be there",
+    )
+}
+
+async fn reading_below_the_watermark_starts_at_the_watermark(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    for _ in 0..3 {
+        sender.append(&send_key, created.send_addr, b"m").await?;
+    }
+    let all = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(all.messages.len(), 3, "three appends, three messages")?;
+    let first_index = all.messages.as_slice().first().map_or(0, |m| m.index);
+    context
+        .client
+        .ack(&recv_key, created.recv_addr, first_index)
+        .await?;
+
+    // §6.2: below the watermark returns from the watermark, does not error, and
+    // does not resurrect. A client recovering from a crash simply asks for
+    // everything it might have missed.
+    let again = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(
+        again.messages.len(),
+        2,
+        "the acked message must not come back",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// §8.
+// ---------------------------------------------------------------------------
+
+async fn ack_is_cumulative_monotone_and_idempotent(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    for _ in 0..3 {
+        sender.append(&send_key, created.send_addr, b"m").await?;
+    }
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    let last = read.messages.as_slice().last().map_or(0, |m| m.index);
+
+    let first = context
+        .client
+        .ack(&recv_key, created.recv_addr, last)
+        .await?;
+    expect_eq(
+        first.pending,
+        0,
+        "a cumulative ACK clears everything below it",
+    )?;
+    // Idempotent: the retry after a lost response is safe, which is what makes
+    // the connection-loss case tractable at all (§8.3).
+    let repeat = context
+        .client
+        .ack(&recv_key, created.recv_addr, last)
+        .await?;
+    expect_eq(repeat.pending, 0, "a repeated ACK is a no-op")?;
+    // Monotone: below the watermark is accepted and does nothing.
+    let below = context.client.ack(&recv_key, created.recv_addr, 0).await?;
+    expect_eq(
+        below.pending,
+        0,
+        "an ACK below the watermark must not move it",
+    )?;
+    expect_eq(
+        below.next_index,
+        first.next_index,
+        "next_index must not move backwards",
+    )
+}
+
+async fn acking_beyond_the_highest_index_is_refused(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender.append(&send_key, created.send_addr, b"m").await?;
+
+    // §8.2 exists to stop a reader pre-acking: with the watermark set high,
+    // every future APPEND would be deleted the instant it landed while the
+    // sender kept receiving successful, empty responses.
+    let result = context
+        .client
+        .ack(&recv_key, created.recv_addr, u64::MAX)
+        .await;
+    expect_code(result, ErrorCode::AckTooHigh)?;
+    // …and the watermark did not move.
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(read.messages.len(), 1, "a refused ACK must not delete")
+}
+
+async fn acking_deletes_the_ciphertext(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender.append(&send_key, created.send_addr, b"m").await?;
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    let index = read.messages.as_slice().first().map_or(0, |m| m.index);
+    context
+        .client
+        .ack(&recv_key, created.recv_addr, index)
+        .await?;
+    let after = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(
+        after.messages.len(),
+        0,
+        "ACK is queue-delivered: the relay deletes at that instant",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// §6.4.
+// ---------------------------------------------------------------------------
+
+async fn a_subscriber_is_pushed_the_message(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let subscribed = context
+        .client
+        .subscribe(&recv_key, created.recv_addr)
+        .await?;
+    expect_eq(subscribed.pending, 0, "a fresh queue holds nothing")?;
+
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender
+        .append(&send_key, created.send_addr, b"push me")
+        .await?;
+
+    let push = context.client.next_message().await?;
+    expect_eq(
+        push.recv_addr,
+        created.recv_addr,
+        "a MSG push names the subscribed receive address",
+    )
+}
+
+async fn unsubscribing_stops_the_pushes(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    context
+        .client
+        .subscribe(&recv_key, created.recv_addr)
+        .await?;
+    context
+        .client
+        .unsubscribe(&recv_key, created.recv_addr)
+        .await?;
+
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender
+        .append(&send_key, created.send_addr, b"silent")
+        .await?;
+
+    // A PING round-trips after the append, so the absence of a push is an
+    // observation rather than a race, and the wait is short because what is
+    // being proved is a negative.
+    context.client.ping().await?;
+    context.client.set_read_timeout(Duration::from_millis(250));
+    match context.client.next_push().await {
+        Err(TestkitError::Timeout) => Ok(()),
+        Ok(_) => Err(TestkitError::Expectation(
+            "a push arrived after UNSUBSCRIBE".to_owned(),
+        )),
+        Err(error) => Err(error),
+    }
+}
+
+async fn deleting_a_queue_pushes_queue_event_one(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    context
+        .client
+        .subscribe(&recv_key, created.recv_addr)
+        .await?;
+    context
+        .client
+        .delete_queue(&recv_key, created.recv_addr)
+        .await?;
+    let event = context.client.next_queue_event().await?;
+    expect_eq(event.reason, QUEUE_EVENT_DELETED, "reason 1 is 'deleted'")
+}
+
+// ---------------------------------------------------------------------------
+// §9.
+// ---------------------------------------------------------------------------
+
+async fn a_payload_outside_the_buckets_is_bad_size(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    let bucket = sender.padding().sizes().first().copied().unwrap_or(1024);
+    let odd = usize::try_from(bucket).unwrap_or(1024).saturating_sub(1);
+    let result = sender
+        .append_raw_size(&send_key, created.send_addr, odd)
+        .await;
+    expect_code(result, ErrorCode::BadSize)
+}
+
+// ---------------------------------------------------------------------------
+// §11.
+// ---------------------------------------------------------------------------
+
+async fn the_capability_document_verifies_and_is_valid(context: &mut Context) -> Result<()> {
+    let signed = context.client.capabilities().await?;
+    let proven = context.client.session().relay_identity_pk();
+    // §11.3 step 1: verify against the key proved in HELLO, not against the
+    // key the document names — a document is self-signed, so verifying it
+    // against its own embedded key proves only that one hand wrote both.
+    capabilities::verify(&signed, &proven)?;
+    capabilities::validate(&signed.capabilities)?;
+    // §11.3's checklist, under a policy that has opted into the insecure
+    // transport a ws:// relay publishes.
+    let policy = ClientPolicy {
+        allow_insecure_transport: true,
+        ..ClientPolicy::default()
+    };
+    policy.accept(&signed.capabilities)?;
+    Ok(())
+}
+
+async fn the_hello_digest_matches_the_document(context: &mut Context) -> Result<()> {
+    let signed = context.client.capabilities().await?;
+    let expected = context.client.session().capabilities_digest();
+    capabilities::check_digest(&signed.capabilities, &expected)?;
+    Ok(())
+}
+
+async fn an_unsound_antireplay_window_is_published_and_refused(
+    context: &mut Context,
+) -> Result<()> {
+    let faults = context.require_faults()?;
+    faults.set_policy(PolicyFaults {
+        unsound_antireplay_window: true,
+        ..PolicyFaults::default()
+    });
+
+    let mut client = context.open().await?;
+    let signed = client.capabilities().await?;
+    let published = &signed.capabilities;
+    expect(
+        u64::from(published.antireplay_window_ms)
+            < u64::from(published.clock_skew_ms).saturating_mul(2),
+        "the fault must actually publish a window below 2 x clock_skew_ms",
+    )?;
+    // The finding of #586, in two halves. First: the document is *valid*. The
+    // specification as written permits it, which is exactly why the defect is
+    // a defect and not an implementation bug.
+    capabilities::validate(published)?;
+    // Second: a client that checks the relation refuses it, and the check is
+    // on by default in `f2z-relay-proto`.
+    let policy = ClientPolicy {
+        allow_insecure_transport: true,
+        ..ClientPolicy::default()
+    };
+    match policy.accept(published) {
+        Err(f2z_relay_proto::ProtoError::Refused(
+            f2z_relay_proto::Refusal::AntiReplayWindowTooShort,
+        )) => Ok(()),
+        Err(other) => Err(TestkitError::Expectation(format!(
+            "expected AntiReplayWindowTooShort, got {other}"
+        ))),
+        Ok(()) => Err(TestkitError::Expectation(
+            "a client must refuse a relay whose seen-set ages out inside the timestamp window"
+                .to_owned(),
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// §12.
+// ---------------------------------------------------------------------------
+
+async fn bind_send_on_a_contact_address_is_not_permitted(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let binder = context.key();
+    let created = context
+        .client
+        .create_contact_queue(&recv_key, 0, 0, None)
+        .await?;
+    let mut client = context.open().await?;
+    let result = client.bind_send(&binder, created.contact_addr).await;
+    // §12.2 point 1: always, for everyone. There is no key that authorizes
+    // writing to it, which means there is no key that can be stolen.
+    expect_code(result, ErrorCode::NotPermitted)
+}
+
+async fn contact_append_requires_a_stamp(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let created = context
+        .client
+        .create_contact_queue(&recv_key, 0, 0, None)
+        .await?;
+    let mut stranger = context.open().await?;
+    let body = f2z_codec::commands::ContactAppendRequest {
+        contact_addr: created.contact_addr,
+        payload: stranger.pad(b"hello bob")?,
+        stamp: f2z_codec::pow::PowStamp::empty(),
+    };
+    let result = stranger
+        .call_unsigned::<ops::ContactAppend>(&body)
+        .await
+        .map(|_| ());
+    expect_code(result, ErrorCode::PowRequired)
+}
+
+async fn a_contact_stamp_is_single_use(context: &mut Context) -> Result<()> {
+    let recv_key = context.key();
+    let created = context
+        .client
+        .create_contact_queue(&recv_key, 0, 0, None)
+        .await?;
+    let mut stranger = context.open().await?;
+    let capabilities = stranger.capabilities().await?.capabilities;
+    let params = capabilities.contact_append_pow;
+    let issued = stranger
+        .challenge(
+            ChallengePurpose::ContactAppend,
+            created.contact_addr.as_bytes(),
+        )
+        .await?;
+    let mut rng = Csprng::from_seed([0x33; 32]);
+    let stamp = solve(issued.challenge, &mut rng, params.difficulty_bits);
+    let body = f2z_codec::commands::ContactAppendRequest {
+        contact_addr: created.contact_addr,
+        payload: stranger.pad(b"hello bob")?,
+        stamp,
+    };
+    stranger.call_unsigned::<ops::ContactAppend>(&body).await?;
+    // §12.3: the challenge is consumed on use, so stamps cannot be replayed.
+    let again = stranger
+        .call_unsigned::<ops::ContactAppend>(&body)
+        .await
+        .map(|_| ());
+    expect_code(again, ErrorCode::PowInvalid)
+}
+
+async fn a_contact_stamp_is_scoped_to_its_target(context: &mut Context) -> Result<()> {
+    let first_key = context.key();
+    let second_key = context.key();
+    let victim = context
+        .client
+        .create_contact_queue(&first_key, 0, 0, None)
+        .await?;
+    let other = context
+        .client
+        .create_contact_queue(&second_key, 0, 0, None)
+        .await?;
+
+    let mut stranger = context.open().await?;
+    let capabilities = stranger.capabilities().await?.capabilities;
+    let params = capabilities.contact_append_pow;
+    let issued = stranger
+        .challenge(
+            ChallengePurpose::ContactAppend,
+            victim.contact_addr.as_bytes(),
+        )
+        .await?;
+    let mut rng = Csprng::from_seed([0x44; 32]);
+    let stamp = solve(issued.challenge, &mut rng, params.difficulty_bits);
+    // Computed for one victim, spent on another. §12.3 binds the challenge to
+    // the target address precisely so this cannot work.
+    let body = f2z_codec::commands::ContactAppendRequest {
+        contact_addr: other.contact_addr,
+        payload: stranger.pad(b"misdirected")?,
+        stamp,
+    };
+    let result = stranger
+        .call_unsigned::<ops::ContactAppend>(&body)
+        .await
+        .map(|_| ());
+    expect_code(result, ErrorCode::PowInvalid)
+}
+
+async fn first_contact_reaches_the_recipient(context: &mut Context) -> Result<()> {
+    // §12.5, steps 1 to 8, minus the directory: Alice writes to Bob's published
+    // contact address with a stamp, Bob reads it from the ordinary receive side
+    // of the same queue and acknowledges.
+    let bob = context.key();
+    let created = context
+        .client
+        .create_contact_queue(&bob, 0, 0, None)
+        .await?;
+    let capabilities = context.client.capabilities().await?.capabilities;
+
+    let mut alice = context.open().await?;
+    alice
+        .contact_append(
+            created.contact_addr,
+            b"welcome",
+            Some(capabilities.contact_append_pow),
+        )
+        .await?;
+
+    let read = context
+        .client
+        .read(&bob, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(read.messages.len(), 1, "the contact message must arrive")?;
+    let index = read.messages.as_slice().first().map_or(0, |m| m.index);
+    // The §8.4 MUST is Bob's: durable write *first*, then ACK. Here the "write"
+    // is the assertion above.
+    let acked = context.client.ack(&bob, created.recv_addr, index).await?;
+    expect_eq(acked.pending, 0, "the contact queue drains like any other")
+}
+
+// ---------------------------------------------------------------------------
+// §13.
+// ---------------------------------------------------------------------------
+
+async fn a_full_queue_is_indistinguishable_from_an_absent_one(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+
+    faults.set_policy(PolicyFaults {
+        max_queue_messages: Some(1),
+        ..PolicyFaults::default()
+    });
+    sender
+        .append(&send_key, created.send_addr, b"first")
+        .await?;
+    let full = sender.append(&send_key, created.send_addr, b"second").await;
+    expect_code(full, ErrorCode::Unavailable)?;
+
+    // The same code an absent address gets. If they differed, a bound sender
+    // could learn the queue's depth by filling it.
+    let absent = sender
+        .append(&send_key, QueueAddress::new([0x77; 32]), b"nowhere")
+        .await;
+    expect_code(absent, ErrorCode::Unavailable)
+}
+
+async fn backpressure_never_refuses_read_ack_or_delete(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender
+        .append(&send_key, created.send_addr, b"stored")
+        .await?;
+
+    faults.set_policy(PolicyFaults {
+        global_backpressure: true,
+        ..PolicyFaults::default()
+    });
+
+    // §13.1 layer 4, in order: creation refuses with ERR_BACKPRESSURE…
+    let creation = context.client.create_queue(&recv_key, 0, 0, None).await;
+    expect_code(creation, ErrorCode::Backpressure)?;
+    // …appends refuse with ERR_UNAVAILABLE…
+    let append = sender.append(&send_key, created.send_addr, b"more").await;
+    expect_code(append, ErrorCode::Unavailable)?;
+    // …and READ, ACK and DELETE_QUEUE are never refused, because they are the
+    // operations that make the relay smaller and refusing them is a deadlock.
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    let index = read.messages.as_slice().first().map_or(0, |m| m.index);
+    context
+        .client
+        .ack(&recv_key, created.recv_addr, index)
+        .await?;
+    context
+        .client
+        .delete_queue(&recv_key, created.recv_addr)
+        .await
+}
+
+async fn the_queue_creation_quota_is_a_distinguishable_code(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let key = context.key();
+    faults.set_policy(PolicyFaults {
+        max_queues: Some(0),
+        ..PolicyFaults::default()
+    });
+    let result = context.client.create_queue(&key, 0, 0, None).await;
+    // §10 code 14. The receive side is allowed a code that says what happened:
+    // the party being refused is the one that owns the queues, so there is no
+    // state to leak to a stranger.
+    expect_code(result, ErrorCode::Quota)
+}
+
+async fn every_error_code_can_reach_a_client(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    // §10's codes are stable forever and a client has to handle all of them,
+    // including the ones a healthy relay never emits. A client that panics on
+    // an unexpected code finds out here rather than in production.
+    for code in ErrorCode::ALL {
+        if code.is_fatal() {
+            // A fatal code closes the connection, so each one needs its own.
+            let mut client = context.open().await?;
+            faults.arm(Fault::once(
+                Trigger::Command(Command::Ping),
+                Effect::Refuse(code),
+            ));
+            let result = client.ping().await;
+            expect_code(result, code)?;
+            client.expect_closed().await?;
+        } else {
+            faults.arm(Fault::once(
+                Trigger::Command(Command::Ping),
+                Effect::Refuse(code),
+            ));
+            let result = context.client.ping().await;
+            expect_code(result, code)?;
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// §7.7.
+// ---------------------------------------------------------------------------
+
+async fn an_expired_message_is_gone_and_announced(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    context
+        .client
+        .subscribe(&recv_key, created.recv_addr)
+        .await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender
+        .append(&send_key, created.send_addr, b"perishable")
+        .await?;
+    let _ = context.client.next_message().await?;
+
+    faults.set_policy(PolicyFaults {
+        expire_messages_after: Some(Duration::ZERO),
+        ..PolicyFaults::default()
+    });
+    // Any command re-runs the sweep.
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(read.messages.len(), 0, "an expired message must be gone")?;
+    let event = context.client.next_queue_event().await?;
+    expect_eq(
+        event.reason,
+        QUEUE_EVENT_MESSAGES_EXPIRED,
+        "reason 3 is 'messages TTL-expired'",
+    )?;
+    // §8.2 still holds afterwards: expiry does not move the watermark, so the
+    // reader still cannot pre-ack.
+    let ack = context
+        .client
+        .ack(&recv_key, created.recv_addr, u64::MAX)
+        .await;
+    expect_code(ack, ErrorCode::AckTooHigh)
+}
+
+async fn an_idle_queue_disappears(context: &mut Context) -> Result<()> {
+    let clock = context.require_clock()?;
+    let key = context.key();
+    let created = context.client.create_queue(&key, 0, 60, None).await?;
+    // Past the granted idle TTL. §7.7 is explicit about the cost: a user whose
+    // device is offline longer than this loses their queues, and their peers'
+    // adverts become dead addresses.
+    clock.advance(
+        u64::from(created.idle_ttl_seconds)
+            .saturating_mul(1_000)
+            .saturating_add(1_000),
+    );
+    context.client.resync_clock().await?;
+    let result = context.client.read(&key, created.recv_addr, 0, 0, 0).await;
+    expect_code(result, ErrorCode::NoAccess)
+}
+
+// ---------------------------------------------------------------------------
+// The failure paths.
+// ---------------------------------------------------------------------------
+
+async fn a_lost_ack_response_is_safe_to_retry(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+    sender.append(&send_key, created.send_addr, b"m").await?;
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    let index = read.messages.as_slice().first().map_or(0, |m| m.index);
+
+    // Drop exactly one ACK response. The command *ran*; the answer never
+    // arrived. §2.5: the status is unknown. §8.3: the retry is safe, and a
+    // client must not try to find out by reading — the messages may
+    // legitimately be gone.
+    faults.arm(Fault::once(Trigger::Command(Command::Ack), Effect::Drop));
+    context.client.set_read_timeout(Duration::from_millis(250));
+    let lost = context
+        .client
+        .ack(&recv_key, created.recv_addr, index)
+        .await;
+    expect(
+        matches!(lost, Err(TestkitError::Timeout | TestkitError::Closed)),
+        "a dropped response must present as an unknown outcome, not as a refusal",
+    )?;
+
+    let mut retry = context.open().await?;
+    let outcome = retry.ack(&recv_key, created.recv_addr, index).await?;
+    expect_eq(
+        outcome.pending,
+        0,
+        "the retry must be a no-op that reports the same state",
+    )
+}
+
+async fn a_delayed_response_still_correlates(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let mut client = context.open().await?;
+    faults.arm(Fault::once(
+        Trigger::Command(Command::GetCapabilities),
+        Effect::Delay(Duration::from_millis(120)),
+    ));
+    let slow = client
+        .send_unsigned::<ops::GetCapabilities>(&Default::default())
+        .await?;
+    let quick = client
+        .send_unsigned::<ops::Ping>(&Default::default())
+        .await?;
+
+    // §4.3: "A relay MAY complete a cheap PING before an expensive READ issued
+    // earlier, and will." A client that assumed order would mis-decode here.
+    let (first_id, _) = client.next_response().await?;
+    let (second_id, _) = client.next_response().await?;
+    expect_eq(first_id, quick, "the cheap command answered first")?;
+    expect_eq(second_id, slow, "the delayed command answered second")
+}
+
+async fn reordered_responses_still_correlate(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let mut client = context.open().await?;
+    faults.arm(Fault::once(
+        Trigger::Command(Command::GetCapabilities),
+        Effect::Reorder,
+    ));
+    let held = client
+        .send_unsigned::<ops::GetCapabilities>(&Default::default())
+        .await?;
+    let overtaking = client
+        .send_unsigned::<ops::Ping>(&Default::default())
+        .await?;
+
+    let (first_id, first) = client.next_response().await?;
+    let (second_id, second) = client.next_response().await?;
+    expect_eq(first_id, overtaking, "the second request answered first")?;
+    expect_eq(second_id, held, "the held response arrived after it")?;
+    expect(
+        first.is_ok() && second.is_ok(),
+        "both answers are successes",
+    )
+}
+
+async fn a_mid_stream_close_leaves_the_status_unknown(context: &mut Context) -> Result<()> {
+    let faults = context.require_faults()?;
+    let recv_key = context.key();
+    let send_key = context.key();
+    let created = context.client.create_queue(&recv_key, 0, 0, None).await?;
+    let mut sender = context.open().await?;
+    sender.bind_send(&send_key, created.send_addr).await?;
+
+    // Close before the APPEND's answer is written. The append *happened*; the
+    // sender cannot know that. §8.3: APPEND is not idempotent at the relay, so
+    // a retry produces a duplicate — which is why deduplication lives
+    // end-to-end at `msg_id` and not here.
+    faults.arm(Fault::once(
+        Trigger::Command(Command::Append),
+        Effect::CloseBefore,
+    ));
+    sender.set_read_timeout(Duration::from_millis(250));
+    let outcome = sender
+        .append(&send_key, created.send_addr, b"unknown")
+        .await;
+    expect(
+        matches!(outcome, Err(TestkitError::Closed | TestkitError::Timeout)),
+        "a mid-stream close must present as an unknown outcome",
+    )?;
+
+    let read = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(
+        read.messages.len(),
+        1,
+        "the command applied even though its answer was never delivered",
+    )?;
+
+    let mut retry = context.open().await?;
+    retry
+        .append(&send_key, created.send_addr, b"unknown")
+        .await?;
+    let after = context
+        .client
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await?;
+    expect_eq(
+        after.messages.len(),
+        2,
+        "retrying an APPEND duplicates, by design",
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Shared plumbing.
+// ---------------------------------------------------------------------------
+
+async fn read_response_code(
+    stream: &mut Box<dyn crate::transport::TransportStream>,
+) -> Result<Option<ErrorCode>> {
+    loop {
+        let message = match tokio::time::timeout(Duration::from_secs(5), stream.recv()).await {
+            Ok(Ok(Some(message))) => message,
+            Ok(Ok(None)) => return Err(TestkitError::Closed),
+            Ok(Err(error)) => return Err(TestkitError::from(error)),
+            Err(_) => return Err(TestkitError::Timeout),
+        };
+        match message {
+            crate::transport::WireMessage::Binary(bytes) => {
+                let frame =
+                    f2z_codec::canonical::decode_canonical::<f2z_codec::frame::RelayFrame>(&bytes)?
+                        .into_value();
+                if let f2z_codec::frame::FramePayload::Response(response) = frame.payload {
+                    return Ok(response.error_code());
+                }
+            }
+            crate::transport::WireMessage::Close(_) => return Err(TestkitError::Closed),
+            _ => {}
+        }
+    }
+}
+
+/// Every push event this suite knows how to name, so a reader can see the set
+/// without opening `f2z-codec`.
+pub const OBSERVED_PUSH_EVENTS: [PushEvent; 3] =
+    [PushEvent::Msg, PushEvent::QueueEvent, PushEvent::Notice];

--- a/rs/crates/f2z-relay-testkit/src/websocket.rs
+++ b/rs/crates/f2z-relay-testkit/src/websocket.rs
@@ -1,0 +1,405 @@
+//! The real transport — `WIRE.md` §2.1 — minus the TLS.
+//!
+//! # Why a real socket exists at all
+//!
+//! An in-process transport cannot fragment, cannot reorder at a TCP boundary,
+//! cannot half-close, and cannot tell a client that it forgot to set the binary
+//! opcode. Every one of those is a bug a client can ship. So the same relay is
+//! served over a real `ws://127.0.0.1:0` listener and the conformance suite is
+//! run against both, which is the only way to know the fast path is not lying.
+//!
+//! # `ws://`, not `wss://`, and that is published
+//!
+//! §2.1 admits `wss://` only. A test double that terminated TLS would need a
+//! certificate, a trust decision, and a story about what the client should do
+//! with a self-signed one — and it would still not be able to compute the §5.3
+//! exporter through the abstraction this crate uses. So it serves `ws://` and
+//! takes §2.3's `--insecure-listen` path honestly: `transport_security: none`,
+//! `channel_binding_mode: none`, both in the signed capability document, and a
+//! client that must explicitly opt in.
+//!
+//! §2.3's binding rule is enforced rather than described: [`bind`] refuses a
+//! non-loopback address unless the caller passes `insecure_listen`, and
+//! `f2z-fakerelay` makes the operator type the flag.
+//!
+//! # What *is* faithful here
+//!
+//! The path (`/relay/v1`), the mandatory subprotocol (`free2z-relay.v1`) in
+//! both directions, binary versus text framing, Ping/Pong, and close codes. A
+//! client that gets any of those wrong fails against this listener, which is
+//! the point.
+
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt as _, StreamExt as _};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tokio_tungstenite::tungstenite::handshake::server::{
+    ErrorResponse, Request as HandshakeRequest, Response as HandshakeResponse,
+};
+use tokio_tungstenite::tungstenite::http::{HeaderValue, StatusCode};
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::{Bytes, Message};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+use crate::engine::Relay;
+use crate::error::{Result, TestkitError};
+use crate::transport::{Transport, TransportSink, TransportStream, WireMessage};
+
+/// §2.1's path.
+pub const RELAY_PATH: &str = "/relay/v1";
+
+/// §2.1's mandatory subprotocol, in both directions. "A relay that does not
+/// echo `free2z-relay.v1` MUST be treated by the client as not speaking this
+/// protocol, and the client MUST close rather than guess."
+pub const SUBPROTOCOL: &str = "free2z-relay.v1";
+
+const HEADER_SUBPROTOCOL: &str = "sec-websocket-protocol";
+
+// ---------------------------------------------------------------------------
+// The WebSocket half of the transport seam.
+// ---------------------------------------------------------------------------
+
+/// A WebSocket write half.
+pub struct WsSink<S> {
+    inner: SplitSink<WebSocketStream<S>, Message>,
+}
+
+impl<S> WsSink<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    async fn write(&mut self, message: WireMessage) -> io::Result<()> {
+        let message = match message {
+            WireMessage::Binary(bytes) => Message::Binary(Bytes::from(bytes)),
+            WireMessage::Text(bytes) => Message::Text(
+                String::from_utf8(bytes)
+                    .map_err(|_| io::Error::other("text frame is not UTF-8"))?
+                    .into(),
+            ),
+            WireMessage::Ping(bytes) => Message::Ping(Bytes::from(bytes)),
+            WireMessage::Pong(bytes) => Message::Pong(Bytes::from(bytes)),
+            WireMessage::Close(code) => Message::Close(Some(CloseFrame {
+                code: CloseCode::from(code),
+                reason: String::new().into(),
+            })),
+        };
+        self.inner.send(message).await.map_err(io::Error::other)
+    }
+}
+
+impl<S> TransportSink for WsSink<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    fn send(
+        &mut self,
+        message: WireMessage,
+    ) -> futures_util::future::BoxFuture<'_, io::Result<()>> {
+        Box::pin(self.write(message))
+    }
+
+    fn close(&mut self, code: u16) -> futures_util::future::BoxFuture<'_, io::Result<()>> {
+        Box::pin(async move {
+            let _ = self.write(WireMessage::Close(code)).await;
+            self.inner.close().await.map_err(io::Error::other)
+        })
+    }
+}
+
+/// A WebSocket read half.
+pub struct WsStream<S> {
+    inner: SplitStream<WebSocketStream<S>>,
+}
+
+impl<S> WsStream<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    async fn read(&mut self) -> io::Result<Option<WireMessage>> {
+        loop {
+            let Some(next) = self.inner.next().await else {
+                return Ok(None);
+            };
+            let message = next.map_err(io::Error::other)?;
+            return Ok(Some(match message {
+                Message::Binary(bytes) => WireMessage::Binary(bytes.to_vec()),
+                Message::Text(text) => WireMessage::Text(text.as_bytes().to_vec()),
+                Message::Ping(bytes) => WireMessage::Ping(bytes.to_vec()),
+                Message::Pong(bytes) => WireMessage::Pong(bytes.to_vec()),
+                Message::Close(frame) => {
+                    WireMessage::Close(frame.map_or(1000, |frame| frame.code.into()))
+                }
+                // A raw frame never surfaces from a `WebSocketStream` in read
+                // mode; skip rather than invent a protocol event for it.
+                Message::Frame(_) => continue,
+            }));
+        }
+    }
+}
+
+impl<S> TransportStream for WsStream<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    fn recv(&mut self) -> futures_util::future::BoxFuture<'_, io::Result<Option<WireMessage>>> {
+        Box::pin(self.read())
+    }
+}
+
+/// Wrap a negotiated WebSocket as a [`Transport`].
+pub fn wrap<S>(socket: WebSocketStream<S>) -> Transport
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let (sink, stream) = socket.split();
+    Transport::new(
+        Box::new(WsSink { inner: sink }),
+        Box::new(WsStream { inner: stream }),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The listener.
+// ---------------------------------------------------------------------------
+
+/// A running `ws://` listener.
+pub struct RelayServer {
+    addr: SocketAddr,
+    shutdown: watch::Sender<bool>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl std::fmt::Debug for RelayServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RelayServer")
+            .field("addr", &self.addr)
+            .finish()
+    }
+}
+
+impl RelayServer {
+    /// The bound address. With port 0 this is the port the OS chose.
+    #[must_use]
+    pub const fn local_addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// The endpoint URL, path included.
+    #[must_use]
+    pub fn url(&self) -> String {
+        format!("ws://{}{RELAY_PATH}", self.addr)
+    }
+
+    /// Stop accepting and wait for the accept loop to finish.
+    ///
+    /// Connections already open are not torn down: a client that is mid-request
+    /// when a test ends should see the request finish, not a truncated stream
+    /// that looks like a fault it did not arm.
+    pub async fn shutdown(self) {
+        let _ = self.shutdown.send(true);
+        let _ = self.handle.await;
+    }
+}
+
+/// Bind a listener, refusing a non-loopback address without an explicit
+/// override (§2.3).
+///
+/// # Errors
+///
+/// [`TestkitError::Config`] for a non-loopback address without
+/// `insecure_listen`, or [`TestkitError::Transport`] if the bind fails.
+pub async fn bind(addr: SocketAddr, insecure_listen: bool) -> Result<TcpListener> {
+    // §2.3: "A relay MUST refuse to bind a non-loopback address without TLS.
+    // This is a startup check, not a warning: the process exits." This process
+    // has no TLS at all, so the check is unconditional on the address.
+    if !is_loopback(addr.ip()) && !insecure_listen {
+        return Err(TestkitError::Config(
+            "refusing to bind a non-loopback address without TLS (WIRE.md §2.3); \
+             pass --insecure-listen if you really mean it",
+        ));
+    }
+    TcpListener::bind(addr).await.map_err(TestkitError::from)
+}
+
+fn is_loopback(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_loopback(),
+        IpAddr::V6(v6) => v6.is_loopback(),
+    }
+}
+
+/// Serve `relay` on `listener` until the returned handle is shut down.
+///
+/// # Errors
+///
+/// [`TestkitError::Transport`] if the listener cannot report its own address.
+pub fn serve(relay: Arc<Relay>, listener: TcpListener) -> Result<RelayServer> {
+    let addr = listener.local_addr()?;
+    let (shutdown, mut shutdown_rx) = watch::channel(false);
+    let handle = tokio::spawn(async move {
+        loop {
+            let accepted = tokio::select! {
+                _ = shutdown_rx.changed() => break,
+                accepted = listener.accept() => accepted,
+            };
+            let Ok((stream, _peer)) = accepted else {
+                break;
+            };
+            let relay = Arc::clone(&relay);
+            tokio::spawn(async move {
+                if let Some(transport) = handshake(stream).await {
+                    crate::connection::drive(relay, transport).await;
+                }
+            });
+        }
+    });
+    Ok(RelayServer {
+        addr,
+        shutdown,
+        handle,
+    })
+}
+
+async fn handshake(stream: TcpStream) -> Option<Transport> {
+    let socket = tokio_tungstenite::accept_hdr_async(stream, check_upgrade)
+        .await
+        .ok()?;
+    Some(wrap(socket))
+}
+
+/// §2.1's two mandatory properties of the upgrade, enforced.
+///
+/// The `Err` variant is `tungstenite`'s own `http::Response`, whose size is not
+/// ours to change, and this is a handshake callback rather than a hot path: one
+/// oversized `Result` per TCP accept costs nothing measurable. Boxing it would
+/// mean converting at the one call site `tungstenite` allows, for no benefit.
+#[allow(
+    clippy::result_large_err,
+    reason = "the error type is tungstenite's Callback contract, once per accept"
+)]
+fn check_upgrade(
+    request: &HandshakeRequest,
+    mut response: HandshakeResponse,
+) -> std::result::Result<HandshakeResponse, ErrorResponse> {
+    if request.uri().path() != RELAY_PATH {
+        return Err(reject("the relay serves only /relay/v1 (WIRE.md §2.1)"));
+    }
+    let offered = request
+        .headers()
+        .get(HEADER_SUBPROTOCOL)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    if !offered
+        .split(',')
+        .map(str::trim)
+        .any(|value| value == SUBPROTOCOL)
+    {
+        return Err(reject(
+            "the subprotocol header is mandatory in both directions (WIRE.md §2.1)",
+        ));
+    }
+    // Echo it. A relay that does not is one the client must refuse.
+    response
+        .headers_mut()
+        .insert(HEADER_SUBPROTOCOL, HeaderValue::from_static(SUBPROTOCOL));
+    Ok(response)
+}
+
+fn reject(reason: &'static str) -> ErrorResponse {
+    let mut response = ErrorResponse::new(Some(reason.to_owned()));
+    *response.status_mut() = StatusCode::BAD_REQUEST;
+    response
+}
+
+// ---------------------------------------------------------------------------
+// The client side.
+// ---------------------------------------------------------------------------
+
+/// Open a client connection to a `ws://` or `wss://` relay endpoint.
+///
+/// Enforces §2.1's client obligation: the relay MUST echo `free2z-relay.v1`,
+/// and a client that does not check has no way to tell this protocol from
+/// something else answering on the same path.
+///
+/// # Errors
+///
+/// [`TestkitError::Transport`] if the URL is unusable, the handshake fails, or
+/// the relay did not echo the subprotocol.
+pub async fn connect(url: &str) -> Result<Transport> {
+    let request = tokio_tungstenite::tungstenite::http::Request::builder()
+        .method("GET")
+        .uri(url)
+        .header("Host", host_of(url)?)
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Key", generate_key())
+        .header(HEADER_SUBPROTOCOL, SUBPROTOCOL)
+        .body(())
+        .map_err(|error| TestkitError::Transport(error.to_string()))?;
+
+    let (socket, response) = tokio_tungstenite::connect_async(request)
+        .await
+        .map_err(|error| TestkitError::Transport(error.to_string()))?;
+
+    let echoed = response
+        .headers()
+        .get(HEADER_SUBPROTOCOL)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    if echoed != SUBPROTOCOL {
+        return Err(TestkitError::Transport(format!(
+            "the relay did not echo {SUBPROTOCOL}; it is not speaking this protocol (WIRE.md §2.1)"
+        )));
+    }
+
+    Ok(wrap::<MaybeTlsStream<TcpStream>>(socket))
+}
+
+fn generate_key() -> String {
+    tokio_tungstenite::tungstenite::handshake::client::generate_key()
+}
+
+fn host_of(url: &str) -> Result<String> {
+    let rest = url
+        .strip_prefix("ws://")
+        .or_else(|| url.strip_prefix("wss://"))
+        .ok_or(TestkitError::Config("a relay URL must be ws:// or wss://"))?;
+    let authority = rest.split('/').next().unwrap_or(rest);
+    if authority.is_empty() {
+        return Err(TestkitError::Config("a relay URL must name a host"));
+    }
+    Ok(authority.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_host_header_comes_from_the_url() {
+        assert_eq!(
+            host_of("ws://127.0.0.1:9000/relay/v1").unwrap(),
+            "127.0.0.1:9000"
+        );
+        assert_eq!(
+            host_of("wss://relay.example/relay/v1").unwrap(),
+            "relay.example"
+        );
+        assert!(host_of("http://relay.example/relay/v1").is_err());
+    }
+
+    #[tokio::test]
+    async fn a_non_loopback_bind_is_refused_without_the_override() {
+        let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        assert!(bind(addr, false).await.is_err());
+        // And with the override it is allowed, because §2.3 says an operator
+        // may take that path deliberately and publish that they did.
+        assert!(bind(addr, true).await.is_ok());
+    }
+}

--- a/rs/crates/f2z-relay-testkit/tests/conformance.rs
+++ b/rs/crates/f2z-relay-testkit/tests/conformance.rs
@@ -1,0 +1,140 @@
+//! The conformance suite, run twice, and the two runs compared.
+//!
+//! Running it in-process proves the rules. Running it over a real
+//! `ws://127.0.0.1:0` listener proves that the in-process path is not lying:
+//! the framing, the ordering, the close codes and the keepalive all exist on
+//! only one of the two, and a divergence would mean the fast transport is a
+//! second implementation wearing the first one's tests.
+//!
+//! The third assertion is the one that will matter later. `f2z-relay` will be a
+//! `WebSocketEndpoint` with a URL and no fault handle, and this same file will
+//! run against it unchanged — the fault-driven vectors reporting *skipped*
+//! rather than passing, which is the honest verdict for a relay nobody can tell
+//! to misbehave.
+
+// An integration test is its own crate, so the workspace's `panic`/`unwrap`/
+// `expect` denials — written for a relay's unauthenticated request path — apply
+// here too. A test that cannot assert is not a test, so they are lifted for
+// this file and nowhere else.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+use std::sync::Arc;
+
+use f2z_relay_testkit::config::RelayConfig;
+use f2z_relay_testkit::fake::{Endpoint, FakeRelay, WebSocketEndpoint};
+use f2z_relay_testkit::vectors::{self, Needs, Status};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_suite_passes_in_process() {
+    let relay = FakeRelay::with_defaults().expect("a default relay is configurable");
+    let endpoint: Arc<dyn Endpoint> = Arc::new(relay.in_process_endpoint());
+    let report = vectors::run(endpoint).await;
+
+    println!("{}", report.summary());
+    assert_eq!(report.failed(), 0, "{:#?}", report.failures());
+    assert_eq!(
+        report.skipped(),
+        0,
+        "the in-process endpoint has both a fault handle and a clock, \
+         so nothing should be skipped"
+    );
+    assert!(report.passed() >= 40, "the suite should be substantial");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_suite_passes_over_a_real_socket() {
+    // A wall-clock relay would make the clock vectors untestable, so the socket
+    // relay is frozen like the in-process one. The socket is what differs; the
+    // relay must not.
+    let relay = FakeRelay::new(RelayConfig::default()).expect("a default relay is configurable");
+    let server = relay
+        .listen_loopback()
+        .await
+        .expect("binding 127.0.0.1:0 succeeds");
+    let endpoint: Arc<dyn Endpoint> = Arc::new(relay.websocket_endpoint(&server));
+
+    let report = vectors::run(endpoint).await;
+    println!("{}", report.summary());
+    assert_eq!(report.failed(), 0, "{:#?}", report.failures());
+    assert_eq!(report.skipped(), 0);
+
+    server.shutdown().await;
+}
+
+/// The check that makes "both transports run the same implementation" a fact.
+#[tokio::test(flavor = "multi_thread")]
+async fn both_transports_reach_the_same_verdicts() {
+    let in_process_relay = FakeRelay::with_defaults().expect("configurable");
+    let in_process: Arc<dyn Endpoint> = Arc::new(in_process_relay.in_process_endpoint());
+    let in_process_report = vectors::run(in_process).await;
+
+    let socket_relay = FakeRelay::with_defaults().expect("configurable");
+    let server = socket_relay.listen_loopback().await.expect("binds");
+    let socket: Arc<dyn Endpoint> = Arc::new(socket_relay.websocket_endpoint(&server));
+    let socket_report = vectors::run(socket).await;
+
+    assert_eq!(
+        in_process_report.verdicts(),
+        socket_report.verdicts(),
+        "the in-process transport and the WebSocket transport disagreed; \
+         one of them is not running the relay the other is"
+    );
+    server.shutdown().await;
+}
+
+/// A target with no fault handle — the shape `f2z-relay` will arrive in.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_target_without_a_fault_handle_skips_rather_than_passes() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let server = relay.listen_loopback().await.expect("binds");
+
+    // Constructed the way a third-party relay would be: a URL, and nothing
+    // else. Same suite, same file, no fault handle, no clock.
+    let endpoint: Arc<dyn Endpoint> =
+        Arc::new(WebSocketEndpoint::new(server.url()).with_client_config(relay.client_config()));
+    let report = vectors::run(endpoint).await;
+    println!("{}", report.summary());
+
+    let expected_skips = vectors::suite()
+        .iter()
+        .filter(|vector| !matches!(vector.needs, Needs::Nothing))
+        .count();
+    assert_eq!(
+        report.skipped(),
+        expected_skips,
+        "every fault- or clock-driven vector must report Skipped, never Passed"
+    );
+    assert_eq!(report.failed(), 0, "{:#?}", report.failures());
+    assert!(
+        report
+            .outcomes
+            .iter()
+            .any(|outcome| matches!(outcome.status, Status::Skipped(_))),
+        "at least one vector must be skipped for this test to mean anything"
+    );
+
+    server.shutdown().await;
+}
+
+/// The suite is stable in composition, so a vector cannot silently disappear.
+#[test]
+fn every_vector_declares_a_section_and_a_unique_name() {
+    let suite = vectors::suite();
+    let mut names: Vec<&str> = suite.iter().map(|vector| vector.name).collect();
+    names.sort_unstable();
+    let before = names.len();
+    names.dedup();
+    assert_eq!(before, names.len(), "vector names must be unique");
+    for vector in &suite {
+        assert!(
+            vector.section.starts_with('§'),
+            "{} does not name the WIRE.md section it pins",
+            vector.name
+        );
+    }
+}

--- a/rs/crates/f2z-relay-testkit/tests/faults.rs
+++ b/rs/crates/f2z-relay-testkit/tests/faults.rs
@@ -1,0 +1,378 @@
+//! Every fault mode, fired on demand, in one place.
+//!
+//! The conformance suite exercises these as *rules*; this file exercises them
+//! as *controls*, so a client developer can see what each one does before
+//! reaching for it. Under delete-on-ack the failure paths are where data loss
+//! lives, and a client that has never seen a dropped `ACK` response has never
+//! been tested on the case that costs a user their messages.
+
+// An integration test is its own crate, so the workspace's `panic`/`unwrap`/
+// `expect` denials — written for a relay's unauthenticated request path — apply
+// here too. A test that cannot assert is not a test, so they are lifted for
+// this file and nowhere else.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+use std::time::Duration;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::commands::Command;
+use f2z_relay_proto::capabilities::ClientPolicy;
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_testkit::client::Client;
+use f2z_relay_testkit::error::TestkitError;
+use f2z_relay_testkit::fake::FakeRelay;
+use f2z_relay_testkit::faults::{Effect, Fault, PolicyFaults, Trigger};
+
+async fn queue(
+    relay: &FakeRelay,
+    seed: u8,
+) -> (
+    Client,
+    SigningKey,
+    Client,
+    SigningKey,
+    f2z_codec::commands::CreateQueueResponse,
+) {
+    let mut recv = relay.client().await.expect("connects");
+    let recv_key = SigningKey::from_seed(&[seed; 32]);
+    let created = recv
+        .create_queue(&recv_key, 0, 0, None)
+        .await
+        .expect("CREATE_QUEUE");
+    let mut send = relay.client().await.expect("connects");
+    let send_key = SigningKey::from_seed(&[seed.wrapping_add(1); 32]);
+    send.bind_send(&send_key, created.send_addr)
+        .await
+        .expect("BIND_SEND");
+    (recv, recv_key, send, send_key, created)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_a_response() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let (mut recv, recv_key, mut send, send_key, created) = queue(&relay, 0x10).await;
+    send.append(&send_key, created.send_addr, b"m")
+        .await
+        .expect("APPEND");
+
+    relay
+        .faults()
+        .arm(Fault::once(Trigger::Command(Command::Ack), Effect::Drop));
+    recv.set_read_timeout(Duration::from_millis(200));
+    let lost = recv.ack(&recv_key, created.recv_addr, 0).await;
+    assert!(
+        matches!(lost, Err(TestkitError::Timeout)),
+        "a dropped response is an unknown outcome (§2.5), not a refusal"
+    );
+
+    // The command ran. §8.3: the retry is a safe no-op, which is what makes the
+    // connection-loss case tractable at all.
+    let mut again = relay.client().await.expect("connects");
+    let outcome = again
+        .ack(&recv_key, created.recv_addr, 0)
+        .await
+        .expect("the retry is safe");
+    assert_eq!(outcome.pending, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delay_a_response_without_blocking_the_ones_behind_it() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let mut client = relay.client().await.expect("connects");
+    relay.faults().arm(Fault::once(
+        Trigger::Command(Command::GetCapabilities),
+        Effect::Delay(Duration::from_millis(150)),
+    ));
+    let slow = client
+        .send_unsigned::<f2z_relay_proto::command::ops::GetCapabilities>(&Default::default())
+        .await
+        .expect("send");
+    let quick = client
+        .send_unsigned::<f2z_relay_proto::command::ops::Ping>(&Default::default())
+        .await
+        .expect("send");
+
+    let (first, _) = client.next_response().await.expect("a response");
+    let (second, _) = client.next_response().await.expect("a response");
+    assert_eq!(first, quick, "§4.3: a cheap command may overtake, and will");
+    assert_eq!(second, slow);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reorder_two_responses() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let mut client = relay.client().await.expect("connects");
+    relay.faults().arm(Fault::once(
+        Trigger::Command(Command::GetCapabilities),
+        Effect::Reorder,
+    ));
+    let held = client
+        .send_unsigned::<f2z_relay_proto::command::ops::GetCapabilities>(&Default::default())
+        .await
+        .expect("send");
+    let overtaking = client
+        .send_unsigned::<f2z_relay_proto::command::ops::Ping>(&Default::default())
+        .await
+        .expect("send");
+    let (first, _) = client.next_response().await.expect("a response");
+    let (second, _) = client.next_response().await.expect("a response");
+    assert_eq!(first, overtaking);
+    assert_eq!(second, held);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn close_the_connection_mid_stream() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let (recv, recv_key, mut send, send_key, created) = queue(&relay, 0x20).await;
+    drop(recv);
+
+    relay.faults().arm(Fault::once(
+        Trigger::Command(Command::Append),
+        Effect::CloseBefore,
+    ));
+    send.set_read_timeout(Duration::from_millis(250));
+    let outcome = send.append(&send_key, created.send_addr, b"m").await;
+    assert!(matches!(
+        outcome,
+        Err(TestkitError::Closed | TestkitError::Timeout)
+    ));
+
+    // The append applied even though its answer was never delivered. §8.3:
+    // APPEND is not idempotent at the relay, which is why deduplication lives
+    // end-to-end at `msg_id`.
+    let mut reader = relay.client().await.expect("connects");
+    let read = reader
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ");
+    assert_eq!(read.messages.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stall_an_ack_forever() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let (mut recv, recv_key, mut send, send_key, created) = queue(&relay, 0x30).await;
+    send.append(&send_key, created.send_addr, b"m")
+        .await
+        .expect("APPEND");
+
+    relay
+        .faults()
+        .arm(Fault::always(Trigger::Command(Command::Ack), Effect::Stall));
+    recv.set_read_timeout(Duration::from_millis(200));
+    let stalled = recv.ack(&recv_key, created.recv_addr, 0).await;
+    assert!(matches!(stalled, Err(TestkitError::Timeout)));
+
+    // A stalled response keeps its `request_id` outstanding, so a client that
+    // never gives up fills §4.3's window and earns a fatal
+    // ERR_TOO_MANY_INFLIGHT rather than hanging forever.
+    let capabilities = relay.published_capabilities();
+    for _ in 0..capabilities.max_inflight {
+        let _ = recv.ack(&recv_key, created.recv_addr, 0).await;
+    }
+    let overflow = recv.ack(&recv_key, created.recv_addr, 0).await;
+    assert!(
+        overflow.is_err(),
+        "the in-flight window must eventually refuse"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn refuse_an_append_with_every_error_code() {
+    // §10's codes are stable forever and a client has to handle all of them,
+    // including the ones a healthy relay never emits on this command.
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    for code in ErrorCode::ALL {
+        let (_recv, _recv_key, mut send, send_key, created) = queue(&relay, 0x40).await;
+        relay.faults().arm(Fault::once(
+            Trigger::Command(Command::Append),
+            Effect::Refuse(code),
+        ));
+        let refused = send.append(&send_key, created.send_addr, b"m").await;
+        assert_eq!(
+            refused.as_ref().err().and_then(TestkitError::wire_code),
+            Some(code),
+            "the injector must be able to produce {}",
+            code.name()
+        );
+        if code.is_fatal() {
+            send.expect_closed().await.expect("§1.3: then close");
+        }
+        relay.faults().disarm();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_refused_append_did_not_append() {
+    // The refusal is applied before the command runs, which is the only reading
+    // that makes `Effect::Refuse` usable: a fake that refused *after* mutating
+    // would teach a client that ERR_UNAVAILABLE means "not stored" when it did
+    // not.
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let (mut recv, recv_key, mut send, send_key, created) = queue(&relay, 0x50).await;
+    relay.faults().arm(Fault::once(
+        Trigger::Command(Command::Append),
+        Effect::Refuse(ErrorCode::Unavailable),
+    ));
+    let _ = send.append(&send_key, created.send_addr, b"m").await;
+    let read = recv
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ");
+    assert_eq!(read.messages.len(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expire_a_ttl_early() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let (mut recv, recv_key, mut send, send_key, created) = queue(&relay, 0x60).await;
+    recv.subscribe(&recv_key, created.recv_addr)
+        .await
+        .expect("SUBSCRIBE");
+    send.append(&send_key, created.send_addr, b"perishable")
+        .await
+        .expect("APPEND");
+    let _ = recv.next_message().await.expect("MSG push");
+
+    relay.faults().set_policy(PolicyFaults {
+        expire_messages_after: Some(Duration::ZERO),
+        ..PolicyFaults::default()
+    });
+    let read = recv
+        .read(&recv_key, created.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ");
+    assert_eq!(read.messages.len(), 0, "§7.7: the message TTL fired");
+    let event = recv.next_queue_event().await.expect("QUEUE_EVENT push");
+    assert_eq!(event.reason, 3, "reason 3 is 'messages TTL-expired'");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expire_a_queue_by_moving_the_clock() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let mut client = relay.client().await.expect("connects");
+    let key = SigningKey::from_seed(&[0x70; 32]);
+    let created = client
+        .create_queue(&key, 0, 3_600, None)
+        .await
+        .expect("CREATE_QUEUE");
+
+    // §7.7's honest cost: a device offline longer than the idle TTL loses its
+    // queues, and its peers' adverts become dead addresses.
+    relay
+        .clock()
+        .advance(u64::from(created.idle_ttl_seconds).saturating_mul(1_000) + 1_000);
+    client.resync_clock().await.expect("§5.5's clock read");
+    let gone = client.read(&key, created.recv_addr, 0, 0, 0).await;
+    assert_eq!(
+        gone.err().and_then(|error| error.wire_code()),
+        Some(ErrorCode::NoAccess)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn hit_a_quota() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+
+    // The send-side cap collapses to ERR_UNAVAILABLE (§6.3): if a full queue
+    // and an absent one differed, a bound sender could learn the depth by
+    // filling it.
+    let (_recv, _recv_key, mut send, send_key, created) = queue(&relay, 0x80).await;
+    relay.faults().set_policy(PolicyFaults {
+        max_queue_messages: Some(1),
+        ..PolicyFaults::default()
+    });
+    send.append(&send_key, created.send_addr, b"first")
+        .await
+        .expect("the first fits");
+    let full = send.append(&send_key, created.send_addr, b"second").await;
+    assert_eq!(
+        full.err().and_then(|error| error.wire_code()),
+        Some(ErrorCode::Unavailable)
+    );
+
+    // The recv-side creation quota is allowed to say what happened: the party
+    // refused is the one that owns the queues.
+    relay.faults().set_policy(PolicyFaults {
+        max_queues: Some(0),
+        ..PolicyFaults::default()
+    });
+    let mut creator = relay.client().await.expect("connects");
+    let key = SigningKey::from_seed(&[0x81; 32]);
+    let refused = creator.create_queue(&key, 0, 0, None).await;
+    assert_eq!(
+        refused.err().and_then(|error| error.wire_code()),
+        Some(ErrorCode::Quota)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn force_the_capability_document_violation_from_586() {
+    // https://github.com/free2z/zuu/issues/586 §1: `WIRE.md` §11.1 publishes
+    // `antireplay_window_ms` and `clock_skew_ms` as independent fields and
+    // relates them nowhere, so a relay may publish a seen-set retention shorter
+    // than the replay window its own timestamp policy creates — and be fully
+    // conforming while it does.
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    relay.faults().set_policy(PolicyFaults {
+        unsound_antireplay_window: true,
+        ..PolicyFaults::default()
+    });
+
+    let mut client = relay.client().await.expect("connects");
+    let signed = client.capabilities().await.expect("GET_CAPABILITIES");
+    let published = &signed.capabilities;
+    assert!(
+        u64::from(published.antireplay_window_ms)
+            < u64::from(published.clock_skew_ms).saturating_mul(2),
+        "the fault must publish the violating relation, not just behave badly"
+    );
+
+    // Half one: the document is *valid*. That is the defect.
+    f2z_relay_proto::capabilities::validate(published).expect("the spec permits this document");
+
+    // Half two: a client that checks the relation refuses, and the check is on
+    // by default.
+    let policy = ClientPolicy {
+        allow_insecure_transport: true,
+        ..ClientPolicy::default()
+    };
+    let refusal = policy.accept(published).expect_err("a client must refuse");
+    assert!(
+        matches!(
+            refusal,
+            f2z_relay_proto::ProtoError::Refused(
+                f2z_relay_proto::Refusal::AntiReplayWindowTooShort
+            )
+        ),
+        "expected AntiReplayWindowTooShort, got {refusal}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_fault_can_be_armed_mid_conversation_and_disarmed_again() {
+    let relay = FakeRelay::with_defaults().expect("configurable");
+    let mut client = relay.client().await.expect("connects");
+    client.ping().await.expect("healthy");
+
+    relay.faults().arm(Fault::times(
+        Trigger::Command(Command::Ping),
+        Effect::Refuse(ErrorCode::RateLimited),
+        2,
+    ));
+    for _ in 0..2 {
+        let refused = client.ping().await;
+        assert_eq!(
+            refused.err().and_then(|error| error.wire_code()),
+            Some(ErrorCode::RateLimited)
+        );
+    }
+    // The rule retired itself after its two firings.
+    client.ping().await.expect("healthy again");
+    assert_eq!(relay.faults().armed(), 0);
+}

--- a/rs/crates/f2z-relay-testkit/tests/worked_example.rs
+++ b/rs/crates/f2z-relay-testkit/tests/worked_example.rs
@@ -1,0 +1,207 @@
+//! The worked example: two clients, one real socket, and the delete observed.
+//!
+//! This is the flow a client developer has to get right before anything else
+//! works, driven end to end over `ws://127.0.0.1:0` — a real TCP accept, a real
+//! RFC 6455 upgrade with the mandatory subprotocol, real binary frames:
+//!
+//! ```text
+//!   Bob   CREATE_QUEUE                       → (recv_addr, send_addr)
+//!   Bob   SUBSCRIBE   recv_addr
+//!   Alice BIND_SEND   send_addr  (fresh key) → empty, once and forever
+//!   Alice APPEND      send_addr              → empty; no index, no depth
+//!   Bob   ← MSG push
+//!   Bob   READ        recv_addr              → the ciphertext, unchanged
+//!   Bob   (durable write)                    ← the §8.4 MUST happens here
+//!   Bob   ACK         recv_addr, index
+//!   Bob   READ        recv_addr              → empty: the relay deleted it
+//!   Bob   DELETE_QUEUE
+//!   Alice APPEND                             → ERR_UNAVAILABLE
+//! ```
+//!
+//! Run it with `cargo test -p f2z-relay-testkit --test worked_example -- --nocapture`
+//! to watch it narrate.
+
+// An integration test is its own crate, so the workspace's `panic`/`unwrap`/
+// `expect` denials — written for a relay's unauthenticated request path — apply
+// here too. A test that cannot assert is not a test, so they are lifted for
+// this file and nowhere else.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+use f2z_codec::ErrorCode;
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_testkit::client::Client;
+use f2z_relay_testkit::config::RelayConfig;
+use f2z_relay_testkit::fake::FakeRelay;
+use f2z_relay_testkit::websocket;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_bind_append_read_ack_delete_over_a_real_socket() {
+    // A wall-clock relay, as `f2z-fakerelay` runs, so nothing about this
+    // example depends on a frozen clock.
+    let relay = FakeRelay::new(RelayConfig::default().with_system_clock())
+        .expect("a default relay is configurable");
+    let server = relay.listen_loopback().await.expect("binds 127.0.0.1:0");
+    let url = server.url();
+    println!("relay listening at {url}");
+    println!("  relay_id      {:?}", relay.relay_id());
+    println!(
+        "  transport     ws:// — transport_security: none, channel_binding_mode: none (WIRE.md §2.3)"
+    );
+
+    // -- Bob creates the queue. §7.1: the recipient creates it, and the relay
+    //    generates both addresses from its own CSPRNG.
+    let mut bob = connect(&url, &relay).await;
+    let bob_key = SigningKey::from_seed(&[0xb0; 32]);
+    let queue = bob
+        .create_queue(&bob_key, 0, 0, None)
+        .await
+        .expect("CREATE_QUEUE");
+    println!(
+        "CREATE_QUEUE  → message_ttl {}s, idle_ttl {}s (granted after clamping, §7.7)",
+        queue.message_ttl_seconds, queue.idle_ttl_seconds
+    );
+    assert_ne!(queue.recv_addr, queue.send_addr);
+
+    let subscribed = bob
+        .subscribe(&bob_key, queue.recv_addr)
+        .await
+        .expect("SUBSCRIBE");
+    println!(
+        "SUBSCRIBE     → next_index {}, pending {}",
+        subscribed.next_index, subscribed.pending
+    );
+
+    // -- Alice binds the send side. §7.2 has `send_addr` reach her in-band,
+    //    inside the MLS group; the relay never sees that advert.
+    let mut alice = connect(&url, &relay).await;
+    let alice_key = SigningKey::from_seed(&[0xa1; 32]);
+    alice
+        .bind_send(&alice_key, queue.send_addr)
+        .await
+        .expect("BIND_SEND");
+    println!("BIND_SEND     → empty response, once and forever (§7.3)");
+
+    // §7.4: a second bind is ERR_ALREADY_BOUND, and on a *first* attempt for a
+    // fresh advert that is a loud, non-dismissible failure — the relay operator
+    // may have read `send_addr` out of its own database and bound first.
+    let stolen = alice.bind_send(&alice_key, queue.send_addr).await;
+    assert_eq!(
+        stolen.err().and_then(|e| e.wire_code()),
+        Some(ErrorCode::AlreadyBound)
+    );
+    println!("BIND_SEND #2  → ERR_ALREADY_BOUND (§7.4: noisy, not prevented)");
+
+    // -- Alice appends. §6.3: the response carries no index, no depth, no
+    //    timestamp and no queue state of any kind.
+    alice
+        .append(&alice_key, queue.send_addr, b"ciphertext")
+        .await
+        .expect("APPEND");
+    println!("APPEND        → empty response: no index, no depth, no timestamp (§6.3)");
+
+    // -- Bob gets the push, then reads.
+    let push = bob.next_message().await.expect("MSG push");
+    assert_eq!(push.recv_addr, queue.recv_addr);
+    println!(
+        "← MSG push    → index {} (§6.4, receive side only)",
+        push.msg.index
+    );
+
+    let read = bob
+        .read(&bob_key, queue.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ");
+    assert_eq!(read.messages.len(), 1);
+    let index = read.messages.as_slice().first().expect("one message").index;
+    println!(
+        "READ          → 1 message at index {index}, has_more {}",
+        read.has_more
+    );
+
+    // READ never mutates: the same read twice returns the same thing.
+    let again = bob
+        .read(&bob_key, queue.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ again");
+    assert_eq!(again.messages.len(), 1, "READ must not consume (§6.2)");
+
+    // -- The durable write goes HERE. §8.4 and CLIENT-CONTRACT.md §9 rule 1: a
+    //    device MUST NOT send ACK before its durable local write has completed,
+    //    because the relay deletes on ACK and ACK-on-read plus a crash is
+    //    permanent message loss.
+    let durably_written = read.messages.as_slice().first().map(|m| m.payload.len());
+    assert_eq!(durably_written, Some(1024), "padded to a bucket (§9)");
+    println!("(durable write completes — the §8.4 MUST)");
+
+    let acked = bob
+        .ack(&bob_key, queue.recv_addr, index)
+        .await
+        .expect("ACK");
+    println!(
+        "ACK           → next_index {}, pending {}",
+        acked.next_index, acked.pending
+    );
+    assert_eq!(acked.pending, 0);
+
+    // -- The delete, observed.
+    let after = bob
+        .read(&bob_key, queue.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ after ACK");
+    assert_eq!(
+        after.messages.len(),
+        0,
+        "the relay deletes at the instant of ACK (§8.1, §8.4 queue-delivered)"
+    );
+    println!("READ          → 0 messages: the ciphertext is gone (§8.1)");
+
+    // §8.2: and the reader still cannot pre-ack the queue it just drained.
+    let preack = bob.ack(&bob_key, queue.recv_addr, u64::MAX).await;
+    assert_eq!(
+        preack.err().and_then(|e| e.wire_code()),
+        Some(ErrorCode::AckTooHigh)
+    );
+    println!("ACK u64::MAX  → ERR_ACK_TOO_HIGH (§8.2: no pre-acking)");
+
+    // -- Bob retires the queue. §7.6: no observable tombstone.
+    bob.delete_queue(&bob_key, queue.recv_addr)
+        .await
+        .expect("DELETE_QUEUE");
+    println!("DELETE_QUEUE  → empty response, irreversible (§7.6)");
+
+    let event = bob.next_queue_event().await.expect("QUEUE_EVENT push");
+    assert_eq!(event.reason, 1, "reason 1 is 'deleted' (§6.4)");
+    println!("← QUEUE_EVENT → reason 1 (deleted)");
+
+    // The sender learns nothing except that its next APPEND fails.
+    let orphaned = alice.append(&alice_key, queue.send_addr, b"too late").await;
+    assert_eq!(
+        orphaned.err().and_then(|e| e.wire_code()),
+        Some(ErrorCode::Unavailable)
+    );
+    println!("APPEND        → ERR_UNAVAILABLE (§6.3: the collapse, so no state leaks)");
+
+    // And the receive side is indistinguishable from an address that never was.
+    let gone = bob.read(&bob_key, queue.recv_addr, 0, 0, 0).await;
+    assert_eq!(
+        gone.err().and_then(|e| e.wire_code()),
+        Some(ErrorCode::NoAccess)
+    );
+    println!("READ          → ERR_NO_ACCESS, same as an address that never existed (§10)");
+
+    server.shutdown().await;
+}
+
+async fn connect(url: &str, relay: &FakeRelay) -> Client {
+    let transport = websocket::connect(url)
+        .await
+        .expect("the WebSocket upgrade");
+    Client::connect(transport, relay.client_config())
+        .await
+        .expect("HELLO, relay_proof, and the relay_id comparison")
+}

--- a/rs/crates/f2z-relay/Cargo.toml
+++ b/rs/crates/f2z-relay/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "f2z-relay"
+version = "0.1.0"
+description = "The free2z relay daemon: WIRE.md v1 over WebSocket, backed by f2z-relay-store"
+edition.workspace = true
+rust-version = "1.97"
+license = "AGPL-3.0"
+repository.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+f2z-codec = { path = "../f2z-codec", version = "0.1.0" }
+f2z-relay-proto = { path = "../f2z-relay-proto", version = "0.1.0" }
+f2z-relay-store = { path = "../f2z-relay-store", version = "0.1.0" }
+tls_codec = { workspace = true }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-tungstenite = "0.30"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging"] }
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+rand = { version = "0.9", default-features = false, features = ["os_rng"] }
+serde = { version = "1", features = ["derive"] }
+toml = { version = "0.9", default-features = false, features = ["parse", "serde"] }
+
+[dev-dependencies]
+f2z-relay-testkit = { path = "../f2z-relay-testkit", version = "0.1.0" }
+tokio = { version = "1", features = ["test-util"] }

--- a/rs/crates/f2z-relay/README.md
+++ b/rs/crates/f2z-relay/README.md
@@ -1,0 +1,140 @@
+# `f2z-relay` — the relay daemon
+
+The server that runs in production. It implements
+[`docs/e2ee/WIRE.md`](../../../docs/e2ee/WIRE.md) v1 §2 through §13 on top of
+`f2z-codec` (canonical encoding, framing, re-encode equality),
+`f2z-relay-proto` (the signing transcript, anti-replay, queue and ACK rules,
+the capability document) and `f2z-relay-store` (durability, quota admission,
+the acknowledgement watermark).
+
+**Nothing in those three is reimplemented here.** What this crate decides is
+the part they deliberately leave to a server: the socket, the connection
+lifecycle, the group-commit schedule, the anti-abuse layering, and which
+refusal answers which failure.
+
+## Run one
+
+```sh
+# Loopback, ephemeral store, nothing to configure. §2.3 permits a loopback
+# bind without TLS, so this needs no override.
+cargo run -p f2z-relay -- --store memory
+
+# A real one.
+f2z-relay --config /etc/f2z-relay/relay.toml
+```
+
+```sh
+f2z-relay --help                  # the flags, and where each lands in the file
+f2z-relay --version               # crate version and protocol version
+f2z-relay --check-config          # validate and exit
+f2z-relay --print-config          # the merged configuration, secrets redacted
+f2z-relay --print-capabilities    # §11.2's JSON document, for you to publish
+```
+
+Configuration is **flags > environment > file > default**. Every file key is
+settable as `F2Z_RELAY_<SECTION>_<KEY>`: the file's `[limits] max_inflight` is
+`F2Z_RELAY_LIMITS_MAX_INFLIGHT`. An unknown key in the file is an error, not a
+warning — a mistyped `max_queue_byes` that silently kept the default would be a
+quota you believe you set.
+
+## The four properties this crate is responsible for
+
+1. **`accepted` is never written to the socket before the commit is durable.**
+   `f2z-relay-store`'s `Committed<T>` has a crate-private constructor, so the
+   only value that can exist is one a completed transaction minted. It is
+   unwrapped on the commit thread, after `append_batch` returns, in the same
+   statement that sends the reply. There is no path by which a connection task
+   holds an `Appended` before the disk does — not because the code is careful,
+   but because there is nothing to hold until the commit has happened.
+
+2. **Group commit, because `synchronous = FULL` makes the fsync rate the
+   ceiling.** A commodity VPS does 50–200 fsyncs a second; one transaction per
+   `APPEND` would cap the relay there, and
+   [ADR 0005](../../../docs/e2ee/decisions/0005-federation.md)'s economics do
+   not survive it. `tests/group_commit.rs` measures the amortization against
+   `SqliteStore::commits` rather than asserting it — **100 concurrent appends
+   cost 1 durable transaction.** This does not weaken §11.1's published
+   `durability_mode`: §8.4 draws the line at *deferring* the fsync past the
+   response, and every append in a batch waits for the same one.
+
+3. **No payload, queue address, key or peer address in any log line, at any
+   level.** `log::line` takes a `&'static str` and `(&'static str, u64)` pairs
+   and nothing else, so `log_trace!("frame", "payload" = payload)` does not
+   compile. `tests/redaction.rs` checks base16 (both cases), base64url **and**
+   the decimal byte-list form — the trap `f2z-codec` documents, where
+   `#[derive(Debug)]` on a byte vector prints `[222, 173, 190, 239, …]` and a
+   hex-only check sails past a complete dump.
+
+4. **Refusing rather than deleting.** §13.2: under no circumstance does the
+   relay delete an unacknowledged message to make room. Backpressure refuses
+   `CREATE_QUEUE`, then `APPEND`, then new connections, and **never** refuses
+   `READ`, `ACK` or `DELETE_QUEUE` — those are the operations that make the
+   relay smaller.
+
+## Deployment shapes
+
+| | `listen.tls_cert` / `tls_key` | `--insecure-listen` | Published |
+|---|---|---|---|
+| **TLS here** | set | no | `transport_security: tls`, `channel_binding_mode: tls-exporter` |
+| **Behind a terminating proxy** | unset | yes | `transport_security: none`, `channel_binding_mode: none` |
+| **Loopback development** | unset | not needed | as above |
+
+§2.3's rule is a **startup check, not a warning**: a non-loopback bind without
+TLS exits unless the override is typed, and the override is published in the
+signed capability document. §5.3 is honest about the cost of the middle row —
+a relay behind a TLS-terminating proxy has no exporter, so every transcript
+carries 32 zero bytes and clients may refuse it.
+
+## The admin listener is loopback-only, and refuses to be anything else
+
+`/healthz` is constant, cheap, carries **no numbers**, and touches no storage: a
+health check that queried the disk would fail during exactly the backpressure it
+exists to survive. `/metrics` carries **no labels at all** — a `{queue="…"}`
+series is a per-conversation activity trace that outlives the ciphertext in the
+scraper's storage, and a `{remote="…"}` series is a connection log.
+
+## `.well-known` is deliberately not served
+
+§11.2 asks for the capability document over plain HTTPS as JSON, so a human, a
+journalist or a researcher can read a relay's policy without a client. This
+relay does not serve it, and the reason is §2.2's own:
+
+> a second transport is a second parser and a second fuzz target … The relay is
+> an unauthenticated network listener that anyone on the internet may speak to
+> before any signature is checked. Its attack surface is its parser.
+
+Serving that URL means an HTTP request parser on the public port. The WebSocket
+upgrade's own parse does not help: it runs only for requests already carrying
+`Upgrade: websocket` and `Sec-WebSocket-Key`, so a plain `GET` is rejected
+before any route callback sees it.
+
+What is kept is the *property* §11.2 exists for. `--print-capabilities` emits
+exactly the document served over the protocol — same values, same signature,
+same `capabilities_digest` — for you to publish from whatever already serves
+your website. A policy change stays publicly diffable at a URL anyone can poll;
+what you lose is the relay hosting it. A JSON **encoder** is not a JSON parser:
+it writes our own values and consumes nothing from the network, which is why one
+is here and the other is not.
+
+## Testing
+
+```sh
+cargo test -p f2z-relay
+```
+
+`tests/conformance.rs` runs `f2z-relay-testkit`'s 52-vector suite **unchanged**
+against a real listener and against the FakeRelay, and asserts that every vector
+both can run reaches the same verdict. Thirteen vectors need a fault handle or a
+steerable clock; a real relay has neither and must not, so they report
+`Skipped` — never a pass. `tests/configured_equivalents.rs` covers eleven of
+those thirteen through published configuration or ordinary client behaviour, and
+names the two that remain.
+
+## Licence
+
+**AGPL-3.0**, per the owner decision on
+[#305](https://github.com/free2z/zuu/issues/305). The crates it links stay
+permissive so that the ZUULI client, the WASM web client and third-party
+implementations can use them; the boundary starts at this binary, and
+`rs/deny.toml` names this crate in `exceptions` so crossing it is impossible by
+accident.

--- a/rs/crates/f2z-relay/src/abuse.rs
+++ b/rs/crates/f2z-relay/src/abuse.rs
@@ -1,0 +1,512 @@
+//! §13.1's four layers, in the order the section states them.
+//!
+//! | Layer | What it bounds | Where it lives |
+//! |---|---|---|
+//! | 1 — connections | concurrent and new connections per source, per-connection command rate, `GET_CHALLENGE` rate | here |
+//! | 2 — per-queue quotas | `max_queue_messages`, `max_queue_bytes` | `f2z-relay-store`, inside the append transaction |
+//! | 3 — queue creation | `open` / `pow`, and the queue-count ceiling | here and [`crate::challenge`] |
+//! | 4 — global backpressure | storage against a high-water mark | here |
+//!
+//! # The source address is counted and never stored
+//!
+//! Per-source limits need to count what an address has done recently. What they
+//! must not do is give the relay a record of who connected: a table keyed by IP
+//! that outlives the window is a connection log, which is precisely the metadata
+//! `THREAT-MODEL.md` §3.3 assumes an operator has and the rest of the design
+//! spends its effort not adding to.
+//!
+//! So the counters here are keyed by a **BLAKE2b digest of the address under a
+//! per-process random salt**, the salt never leaves the process, and an entry
+//! whose window has passed is dropped rather than retained. The digest is not a
+//! privacy claim against the operator — the kernel knows the peer address and so
+//! does the socket — it is a claim about *this* data structure and about what
+//! ends up in a core dump, a heap profile, or a `Debug` rendering.
+//!
+//! §13.3 is honest that the whole layer harms the people who most need the
+//! system: a Tor exit, a CGNAT block, a university NAT and a shared VPN egress
+//! all present as one source carrying many legitimate users. There is no good
+//! answer without an identity the relay deliberately lacks. What an operator can
+//! do is turn the layer off and publish that they did, which is what
+//! `per_source_limits` in the capability document is for.
+//!
+//! # Order matters in layer 4
+//!
+//! §13.1: on crossing a high-water mark the relay refuses **creation first**,
+//! then **appends**, then **new connections** — and `READ`, `ACK` and
+//! `DELETE_QUEUE` are *never* refused, "because they are the operations that
+//! make the relay smaller, and refusing them under load is a deadlock".
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::config::Limits;
+
+/// A source address, reduced to something that is not an address.
+///
+/// 16 bytes of a keyed digest: enough that two live sources will not collide,
+/// short enough that the table is small, and not invertible without the salt.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SourceKey([u8; 16]);
+
+// Even the digest is not printed. It is a stable per-process identifier for a
+// peer, and a log line carrying one is a log line that can be correlated across
+// connections.
+impl core::fmt::Debug for SourceKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("SourceKey(<redacted>)")
+    }
+}
+
+/// What a source has been doing lately.
+#[derive(Clone, Copy, Debug, Default)]
+struct SourceState {
+    /// Currently open connections.
+    open: u32,
+    /// Connections accepted in the current one-second bucket.
+    accepted: u32,
+    /// The bucket, in whole seconds.
+    accept_second: u64,
+    /// Challenges issued in the current one-minute bucket.
+    challenges: u32,
+    /// The bucket, in whole minutes.
+    challenge_minute: u64,
+}
+
+impl SourceState {
+    const fn is_idle(&self) -> bool {
+        self.open == 0 && self.accepted == 0 && self.challenges == 0
+    }
+}
+
+/// Why an accept was refused.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Refusal {
+    /// §13.1 layer 1: the relay is at `max_connections`.
+    TooManyConnections,
+    /// §13.1 layer 1: this source is at `max_connections_per_source`.
+    TooManyFromSource,
+    /// §13.1 layer 1: this source is opening connections too fast.
+    ConnectingTooFast,
+    /// §13.1 layer 4 step 3: new connections are refused at accept.
+    Backpressure,
+}
+
+/// The per-relay anti-abuse state.
+pub struct AbuseGuard {
+    limits: Limits,
+    per_source: bool,
+    salt: [u8; 32],
+    sources: Mutex<HashMap<SourceKey, SourceState>>,
+    connections: AtomicU64,
+    /// §13.1 layer 4. Recomputed by the expiry tick from the store's own
+    /// numbers, so it follows what is actually on the disk rather than what the
+    /// relay believes it wrote.
+    backpressure: AtomicBool,
+}
+
+// `salt` is what makes a [`SourceKey`] not an address: it never leaves the
+// process, and a derived `Debug` would render it as a decimal byte dump —
+// after which every key in the table is invertible by anyone holding the log.
+// The counters are reported as totals, exactly as `/metrics` reports them.
+impl core::fmt::Debug for AbuseGuard {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AbuseGuard")
+            .field("per_source", &self.per_source)
+            .field("salt", &"<redacted>")
+            .field("connections", &self.open_connections())
+            .field("backpressure", &self.backpressured())
+            .finish_non_exhaustive()
+    }
+}
+
+impl AbuseGuard {
+    /// Build a guard.
+    ///
+    /// `salt` should come from [`crate::rng::seed`]; it never leaves the
+    /// process and is what makes [`SourceKey`] not an address.
+    #[must_use]
+    pub fn new(limits: Limits, per_source: bool, salt: [u8; 32]) -> Self {
+        Self {
+            limits,
+            per_source,
+            salt,
+            sources: Mutex::new(HashMap::new()),
+            connections: AtomicU64::new(0),
+            backpressure: AtomicBool::new(false),
+        }
+    }
+
+    /// Reduce a peer address to a counter key.
+    #[must_use]
+    pub fn key_for(&self, peer: &std::net::SocketAddr) -> SourceKey {
+        // The **address only**, never the port: two connections from one host
+        // are the thing being counted, and a port would make every connection
+        // its own source.
+        let bytes = match peer.ip() {
+            std::net::IpAddr::V4(v4) => v4.octets().to_vec(),
+            std::net::IpAddr::V6(v6) => v6.octets().to_vec(),
+        };
+        let digest = f2z_codec::hash::hash2(b"f2z-relay/v1/source", &self.salt, &bytes);
+        let mut key = [0u8; 16];
+        if let Some(slice) = digest.as_bytes().get(..16) {
+            key.copy_from_slice(slice);
+        }
+        SourceKey(key)
+    }
+
+    /// Whether §13.1 layer 4 is currently on.
+    #[must_use]
+    pub fn backpressured(&self) -> bool {
+        self.backpressure.load(Ordering::Relaxed)
+    }
+
+    /// Set layer 4 from a fresh measurement of the store.
+    ///
+    /// Returns whether the state changed, so the caller can log the transition
+    /// rather than the level.
+    pub fn set_backpressure(&self, on: bool) -> bool {
+        self.backpressure.swap(on, Ordering::Relaxed) != on
+    }
+
+    /// How many connections are open. `/metrics` publishes this as a total.
+    #[must_use]
+    pub fn open_connections(&self) -> u64 {
+        self.connections.load(Ordering::Relaxed)
+    }
+
+    /// Admit a connection, or say why not (§13.1 layer 1, and layer 4 step 3).
+    ///
+    /// # Errors
+    ///
+    /// A [`Refusal`]. The caller closes the socket without speaking protocol:
+    /// there is no `HELLO` yet, so there is no frame to answer with.
+    pub fn accept(
+        self: &Arc<Self>,
+        key: SourceKey,
+        now_ms: u64,
+    ) -> Result<ConnectionPermit, Refusal> {
+        // Layer 4 refuses new connections *last*, after creation and appends,
+        // because an open connection that is only reading is helping.
+        if self.backpressured() {
+            return Err(Refusal::Backpressure);
+        }
+        if self.connections.load(Ordering::Relaxed) >= u64::from(self.limits.max_connections) {
+            return Err(Refusal::TooManyConnections);
+        }
+        if self.per_source {
+            let mut sources = self.lock();
+            let second = now_ms / 1_000;
+            let state = sources.entry(key).or_default();
+            if state.accept_second != second {
+                state.accept_second = second;
+                state.accepted = 0;
+            }
+            if state.open >= self.limits.max_connections_per_source {
+                return Err(Refusal::TooManyFromSource);
+            }
+            if state.accepted >= self.limits.new_connections_per_source_per_second {
+                return Err(Refusal::ConnectingTooFast);
+            }
+            state.open = state.open.saturating_add(1);
+            state.accepted = state.accepted.saturating_add(1);
+        }
+        self.connections.fetch_add(1, Ordering::Relaxed);
+        Ok(ConnectionPermit {
+            guard: Arc::clone(self),
+            key,
+        })
+    }
+
+    /// Take one `GET_CHALLENGE` from this source's minute budget (§6.1).
+    ///
+    /// Returns `false` when the budget is spent; the caller answers
+    /// `ERR_RATE_LIMITED`.
+    #[must_use]
+    pub fn take_challenge(&self, key: SourceKey, now_ms: u64) -> bool {
+        if !self.per_source {
+            return true;
+        }
+        let minute = now_ms / 60_000;
+        let mut sources = self.lock();
+        let state = sources.entry(key).or_default();
+        if state.challenge_minute != minute {
+            state.challenge_minute = minute;
+            state.challenges = 0;
+        }
+        if state.challenges >= self.limits.challenges_per_source_per_minute {
+            return false;
+        }
+        state.challenges = state.challenges.saturating_add(1);
+        true
+    }
+
+    fn release(&self, key: SourceKey) {
+        self.connections.fetch_sub(1, Ordering::Relaxed);
+        if !self.per_source {
+            return;
+        }
+        let mut sources = self.lock();
+        if let Some(state) = sources.get_mut(&key) {
+            state.open = state.open.saturating_sub(1);
+            // A source with nothing outstanding leaves no row behind. The table
+            // is a rate limiter, not a connection log.
+            if state.is_idle() {
+                sources.remove(&key);
+            }
+        }
+    }
+
+    /// Drop rows whose windows have passed. Called by the expiry tick.
+    ///
+    /// Returns how many rows went.
+    pub fn sweep(&self, now_ms: u64) -> usize {
+        if !self.per_source {
+            return 0;
+        }
+        let second = now_ms / 1_000;
+        let minute = now_ms / 60_000;
+        let mut sources = self.lock();
+        let before = sources.len();
+        sources.retain(|_, state| {
+            if state.accept_second != second {
+                state.accepted = 0;
+            }
+            if state.challenge_minute != minute {
+                state.challenges = 0;
+            }
+            !state.is_idle()
+        });
+        before.saturating_sub(sources.len())
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<SourceKey, SourceState>> {
+        self.sources
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+/// A connection's claim on the connection budget, released on drop.
+///
+/// Dropping is the only way to release it, so a path that returns early — a
+/// failed TLS handshake, a refused upgrade, a panic in a task — cannot leak a
+/// slot. A counter that only goes up is a relay that stops accepting after an
+/// uptime rather than under a load.
+#[derive(Debug)]
+pub struct ConnectionPermit {
+    guard: Arc<AbuseGuard>,
+    key: SourceKey,
+}
+
+impl Drop for ConnectionPermit {
+    fn drop(&mut self) {
+        self.guard.release(self.key);
+    }
+}
+
+/// A per-connection command rate limiter (§13.1 layer 1).
+///
+/// One second of budget, refilled on the second. Deliberately not a token
+/// bucket with a burst allowance: §4.3's in-flight window is already the burst
+/// control, and two overlapping burst policies are two numbers an operator has
+/// to reason about together.
+#[derive(Debug)]
+pub struct CommandRate {
+    per_second: u32,
+    used: u32,
+    second: u64,
+}
+
+impl CommandRate {
+    /// A limiter at `per_second` commands. Zero means unlimited.
+    #[must_use]
+    pub const fn new(per_second: u32) -> Self {
+        Self {
+            per_second,
+            used: 0,
+            second: 0,
+        }
+    }
+
+    /// Take one command's budget. `false` means `ERR_RATE_LIMITED`.
+    #[must_use]
+    pub const fn take(&mut self, now_ms: u64) -> bool {
+        if self.per_second == 0 {
+            return true;
+        }
+        let second = now_ms / 1_000;
+        if self.second != second {
+            self.second = second;
+            self.used = 0;
+        }
+        if self.used >= self.per_second {
+            return false;
+        }
+        self.used = self.used.saturating_add(1);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn limits() -> Limits {
+        Limits {
+            max_connections: 4,
+            max_connections_per_source: 2,
+            new_connections_per_source_per_second: 3,
+            challenges_per_source_per_minute: 2,
+            ..Limits::default()
+        }
+    }
+
+    fn peer(last: u8) -> std::net::SocketAddr {
+        std::net::SocketAddr::from(([10, 0, 0, last], 4000))
+    }
+
+    #[test]
+    fn a_source_key_is_the_address_and_not_the_port() {
+        let guard = Arc::new(AbuseGuard::new(limits(), true, [1u8; 32]));
+        let first = guard.key_for(&std::net::SocketAddr::from(([10, 0, 0, 1], 1)));
+        let second = guard.key_for(&std::net::SocketAddr::from(([10, 0, 0, 1], 2)));
+        assert_eq!(first, second);
+        assert_ne!(first, guard.key_for(&peer(2)));
+    }
+
+    #[test]
+    fn a_source_key_is_not_the_address() {
+        let guard = Arc::new(AbuseGuard::new(limits(), true, [2u8; 32]));
+        let key = guard.key_for(&peer(1));
+        let rendered = format!("{key:?}");
+        assert_eq!(rendered, "SourceKey(<redacted>)");
+        // And two relays with different salts do not agree on it, so a key is
+        // not a stable identifier anyone can precompute.
+        let other = Arc::new(AbuseGuard::new(limits(), true, [3u8; 32]));
+        assert_ne!(key, other.key_for(&peer(1)));
+    }
+
+    #[test]
+    fn concurrent_connections_from_one_source_are_capped() {
+        let guard = Arc::new(AbuseGuard::new(limits(), true, [4u8; 32]));
+        let key = guard.key_for(&peer(1));
+        let first = guard.accept(key, 0).unwrap();
+        let second = guard.accept(key, 0).unwrap();
+        assert_eq!(
+            guard.accept(key, 0).unwrap_err(),
+            Refusal::TooManyFromSource
+        );
+        drop(first);
+        drop(second);
+        assert!(guard.accept(key, 0).is_ok());
+    }
+
+    #[test]
+    fn a_permit_releases_on_drop_even_from_an_early_return() {
+        let guard = Arc::new(AbuseGuard::new(limits(), true, [5u8; 32]));
+        let key = guard.key_for(&peer(1));
+        // A second apart, so the per-second accept budget is not what this test
+        // is measuring; the relay-wide counter is.
+        for second in 0..100u64 {
+            let permit = guard.accept(key, second.saturating_mul(1_000)).unwrap();
+            drop(permit);
+        }
+        assert_eq!(guard.open_connections(), 0);
+    }
+
+    #[test]
+    fn the_relay_wide_cap_holds_across_sources() {
+        let guard = Arc::new(AbuseGuard::new(limits(), true, [6u8; 32]));
+        let mut held = Vec::new();
+        for source in 1..=2u8 {
+            for _ in 0..2 {
+                held.push(guard.accept(guard.key_for(&peer(source)), 0).unwrap());
+            }
+        }
+        assert_eq!(
+            guard.accept(guard.key_for(&peer(9)), 0).unwrap_err(),
+            Refusal::TooManyConnections
+        );
+    }
+
+    #[test]
+    fn connecting_too_fast_is_refused_and_the_bucket_rolls() {
+        let guard = Arc::new(AbuseGuard::new(limits(), true, [7u8; 32]));
+        let key = guard.key_for(&peer(1));
+        let a = guard.accept(key, 0).unwrap();
+        let b = guard.accept(key, 0).unwrap();
+        drop(a);
+        drop(b);
+        let c = guard.accept(key, 0).unwrap();
+        drop(c);
+        assert_eq!(
+            guard.accept(key, 0).unwrap_err(),
+            Refusal::ConnectingTooFast
+        );
+        assert!(guard.accept(key, 1_000).is_ok());
+    }
+
+    #[test]
+    fn backpressure_refuses_new_connections_last() {
+        let guard = Arc::new(AbuseGuard::new(limits(), true, [8u8; 32]));
+        assert!(!guard.backpressured());
+        assert!(guard.set_backpressure(true));
+        assert!(!guard.set_backpressure(true));
+        assert_eq!(
+            guard.accept(guard.key_for(&peer(1)), 0).unwrap_err(),
+            Refusal::Backpressure
+        );
+    }
+
+    #[test]
+    fn challenge_issuance_is_rate_limited_per_source() {
+        let guard = Arc::new(AbuseGuard::new(limits(), true, [9u8; 32]));
+        let key = guard.key_for(&peer(1));
+        assert!(guard.take_challenge(key, 0));
+        assert!(guard.take_challenge(key, 0));
+        assert!(!guard.take_challenge(key, 0));
+        assert!(guard.take_challenge(key, 60_000));
+    }
+
+    #[test]
+    fn turning_per_source_limits_off_turns_them_off() {
+        let guard = Arc::new(AbuseGuard::new(limits(), false, [10u8; 32]));
+        let key = guard.key_for(&peer(1));
+        let mut held = Vec::new();
+        for _ in 0..4 {
+            held.push(guard.accept(key, 0).unwrap());
+        }
+        // The relay-wide cap still holds; only the per-source layer is off.
+        assert!(guard.accept(key, 0).is_err());
+        assert!(guard.take_challenge(key, 0));
+        assert!(guard.take_challenge(key, 0));
+        assert!(guard.take_challenge(key, 0));
+    }
+
+    #[test]
+    fn an_idle_source_leaves_no_row_behind() {
+        let guard = Arc::new(AbuseGuard::new(limits(), true, [11u8; 32]));
+        let key = guard.key_for(&peer(1));
+        drop(guard.accept(key, 0).unwrap());
+        assert_eq!(guard.sweep(1_000), 1);
+        assert_eq!(guard.sweep(1_000), 0);
+    }
+
+    #[test]
+    fn the_command_rate_refills_on_the_second() {
+        let mut rate = CommandRate::new(2);
+        assert!(rate.take(0));
+        assert!(rate.take(500));
+        assert!(!rate.take(999));
+        assert!(rate.take(1_000));
+    }
+
+    #[test]
+    fn a_zero_command_rate_is_unlimited() {
+        let mut rate = CommandRate::new(0);
+        for _ in 0..1_000 {
+            assert!(rate.take(0));
+        }
+    }
+}

--- a/rs/crates/f2z-relay/src/admin.rs
+++ b/rs/crates/f2z-relay/src/admin.rs
@@ -1,0 +1,197 @@
+//! The loopback-only operational listener: `/healthz` and `/metrics`.
+//!
+//! # Why this is a second parser and the `.well-known` document is not
+//!
+//! [`crate::caps`] declines to serve §11.2's HTTP copy on the public port,
+//! because §2.2's argument — *"a second transport is a second parser and a
+//! second fuzz target … The relay is an unauthenticated network listener that
+//! anyone on the internet may speak to before any signature is checked"* — is
+//! about the **unauthenticated** surface.
+//!
+//! This listener is bound to loopback and refuses to be anything else
+//! ([`crate::config::Config::check`]). Its reachable population is processes on
+//! the same host, which is not the population §2.2 is about. The parser is also
+//! deliberately the smallest thing that can answer: it reads a bounded prefix,
+//! takes the first line, matches the method and path as whole strings, and
+//! interprets **no headers at all**. There is no chunked encoding, no
+//! `Content-Length`, no keep-alive, no request body.
+//!
+//! # `/healthz` says nothing
+//!
+//! Constant, cheap, and carrying **no numbers**. Reporting queue depth or
+//! connection counts here would put an aggregate on an endpoint whose whole
+//! purpose is to be polled every few seconds by something that keeps history —
+//! and a load balancer's health-check log is not a place anyone reviews for
+//! metadata. It also touches no storage: a health check that queried the disk
+//! would fail during exactly the backpressure it is meant to survive, and would
+//! take the relay out of rotation at the moment `READ` and `ACK` are the things
+//! keeping it alive.
+//!
+//! # `/metrics` has no labels
+//!
+//! See [`crate::metrics`]. No per-queue series, no per-IP series, no exceptions.
+
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+
+use crate::config::is_loopback;
+use crate::engine::Relay;
+
+/// The most of a request this listener will read.
+///
+/// A request line plus whatever headers arrived in the same segment. Nothing
+/// past the first line is interpreted, so this is a bound on the read rather
+/// than a protocol limit.
+const MAX_REQUEST: usize = 2048;
+
+/// The health check's body. Constant, and it is meant to be.
+const HEALTHZ_BODY: &str = "ok\n";
+
+/// Why the admin listener could not start.
+#[derive(Debug)]
+pub enum AdminError {
+    /// The address is not loopback. `/metrics` off-host is a metadata leak, so
+    /// this is refused rather than warned about.
+    NotLoopback,
+    /// The socket could not be bound.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for AdminError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotLoopback => f.write_str(
+                "the admin listener serves /healthz and /metrics and must be loopback-only",
+            ),
+            Self::Io(error) => write!(f, "admin bind: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for AdminError {}
+
+/// Bind the admin listener.
+///
+/// # Errors
+///
+/// [`AdminError::NotLoopback`] for a non-loopback address, or
+/// [`AdminError::Io`] if the socket cannot be bound.
+pub async fn bind(addr: std::net::SocketAddr) -> Result<TcpListener, AdminError> {
+    if !is_loopback(&addr) {
+        return Err(AdminError::NotLoopback);
+    }
+    TcpListener::bind(addr).await.map_err(AdminError::Io)
+}
+
+/// Serve until `shutdown` flips.
+pub async fn serve(relay: Arc<Relay>, listener: TcpListener, mut shutdown: watch::Receiver<bool>) {
+    loop {
+        let accepted = tokio::select! {
+            biased;
+            _ = shutdown.changed() => break,
+            accepted = listener.accept() => accepted,
+        };
+        let Ok((stream, _peer)) = accepted else {
+            continue;
+        };
+        let relay = Arc::clone(&relay);
+        tokio::spawn(async move {
+            let _ = answer(relay, stream).await;
+        });
+    }
+}
+
+async fn answer(relay: Arc<Relay>, mut stream: TcpStream) -> std::io::Result<()> {
+    let mut buffer = [0u8; MAX_REQUEST];
+    let read = stream.read(&mut buffer).await?;
+    let request = buffer.get(..read).unwrap_or_default();
+    let response = route(&relay, request);
+    stream.write_all(response.as_bytes()).await?;
+    stream.flush().await?;
+    // No keep-alive. One request per connection is all an operator's scraper
+    // needs, and it is one fewer state machine on a listener whose whole appeal
+    // is that it barely has one.
+    stream.shutdown().await
+}
+
+/// The whole of the routing. Split out so it is testable without a socket.
+fn route(relay: &Arc<Relay>, request: &[u8]) -> String {
+    let Some(line) = first_line(request) else {
+        return response(400, "text/plain; charset=utf-8", "bad request\n");
+    };
+    let mut parts = line.split(' ');
+    let method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or_default();
+    // The query string is ignored rather than parsed: neither endpoint takes a
+    // parameter, and a parser for parameters that do not exist is a parser.
+    let path = target.split('?').next().unwrap_or_default();
+
+    match (method, path) {
+        ("GET" | "HEAD", "/healthz") => {
+            // Constant and cheap: no store query, no counter read, no lock.
+            response(200, "text/plain; charset=utf-8", HEALTHZ_BODY)
+        }
+        ("GET" | "HEAD", "/metrics") => response(
+            200,
+            "text/plain; version=0.0.4; charset=utf-8",
+            &relay.metrics().render(),
+        ),
+        ("GET" | "HEAD", _) => response(404, "text/plain; charset=utf-8", "not found\n"),
+        _ => response(405, "text/plain; charset=utf-8", "method not allowed\n"),
+    }
+}
+
+fn first_line(request: &[u8]) -> Option<&str> {
+    // Only ASCII, only the first line, and a hard bound already applied by the
+    // caller's buffer. A request line that is not UTF-8 is not one this
+    // listener has any reason to understand.
+    let text = core::str::from_utf8(request).ok()?;
+    let line = text.split("\r\n").next().unwrap_or_default();
+    if line.is_empty() { None } else { Some(line) }
+}
+
+fn response(status: u16, content_type: &str, body: &str) -> String {
+    let reason = match status {
+        200 => "OK",
+        400 => "Bad Request",
+        404 => "Not Found",
+        _ => "Method Not Allowed",
+    };
+    format!(
+        "HTTP/1.1 {status} {reason}\r\n\
+         Content-Type: {content_type}\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         Cache-Control: no-store\r\n\
+         \r\n\
+         {body}",
+        body.len()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_non_loopback_admin_bind_is_refused() {
+        let addr: std::net::SocketAddr = "0.0.0.0:0".parse().unwrap();
+        assert!(matches!(bind(addr).await, Err(AdminError::NotLoopback)));
+    }
+
+    #[test]
+    fn healthz_is_constant_and_carries_no_numbers() {
+        // The body is a fixed string with no digit in it. A health check that
+        // reported queue depth or connection counts would be the metadata the
+        // protocol refuses, arriving on the endpoint that is polled most often.
+        assert!(
+            !HEALTHZ_BODY
+                .chars()
+                .any(|character| character.is_ascii_digit())
+        );
+        assert_eq!(HEALTHZ_BODY, "ok\n");
+    }
+}

--- a/rs/crates/f2z-relay/src/caps.rs
+++ b/rs/crates/f2z-relay/src/caps.rs
@@ -1,0 +1,674 @@
+//! The capability document (§11.1): what this relay publishes about itself.
+//!
+//! # The document is the configuration, not a description of it
+//!
+//! §11.3 has a client *decide whether to talk to a relay at all* from this
+//! structure, so every field here is read out of [`crate::config::Config`] and
+//! the same values are what the engine enforces. There is no second copy of a
+//! policy number anywhere in this crate: `max_queue_messages` is published from
+//! `limits.max_queue_messages` and admitted against `limits.max_queue_messages`.
+//! A relay whose document and conduct disagree is the one thing a client cannot
+//! defend against, and the cheapest way to guarantee they agree is to have one
+//! value.
+//!
+//! # `.well-known` is deliberately not served here
+//!
+//! §11.2 asks for a second representation — the same document, as JSON, over
+//! plain HTTPS at `/.well-known/free2z-relay/v1/capabilities` — so that a human,
+//! a journalist or a researcher can read a relay's policy without a client. The
+//! affordance is worth having and this relay does **not** serve it. The reason
+//! is §2.2's, applied honestly:
+//!
+//! > *a second transport is a second parser and a second fuzz target … The relay
+//! > is an unauthenticated network listener that anyone on the internet may
+//! > speak to before any signature is checked. Its attack surface is its
+//! > parser.*
+//!
+//! Serving that URL from this process means an HTTP request parser on the
+//! public port. The WebSocket upgrade's own HTTP parse does not help: it runs
+//! only for requests that already carry `Upgrade: websocket` and
+//! `Sec-WebSocket-Key`, so a plain `GET` is rejected before any route callback
+//! sees it. Reaching it needs a request-line reader of our own, on the
+//! unauthenticated path, for an affordance aimed at humans rather than at
+//! clients.
+//!
+//! What is kept instead is the *property* §11.2 exists for. [`to_json`] renders
+//! exactly the document this relay serves over the protocol, signature and
+//! digest included, and `f2z-relay --print-capabilities` writes it to stdout. An
+//! operator publishes that file from whatever already serves their website, and
+//! §11.2's substance survives intact: the same values, the same signature, the
+//! same `capabilities_digest`, at a URL anyone can poll and diff, so a quiet
+//! policy change stays an observable one. What does not survive is the
+//! convenience of the relay hosting it, and that is the trade being made.
+//!
+//! A JSON **encoder** is not a JSON parser: it turns our own values into text
+//! and never consumes attacker input. That asymmetry is the whole argument, and
+//! it is why the encoder is here while a parser is not.
+
+use f2z_codec::commands::{Capabilities, SignedCapabilities};
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::pow::{ALGORITHM_BLAKE2B_LEADING_ZERO_BITS, PowParams};
+use f2z_codec::types::{Digest, PublicKey, ShortBytes};
+use f2z_relay_proto::capabilities::{
+    self, AntiReplayPersistence, ChannelBindingMode, DurabilityMode, QueueCreationMode,
+    TransportSecurity,
+};
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_store::Durability;
+
+use crate::config::{Config, CreationMode};
+
+/// Why a document could not be built or signed.
+#[derive(Debug)]
+pub enum CapabilitiesError {
+    /// A configured value cannot be represented in the document.
+    Field(&'static str),
+    /// The assembled document does not satisfy §11.1's own consistency rules.
+    Invalid(f2z_relay_proto::ProtoError),
+    /// The document could not be encoded for signing.
+    Encode,
+}
+
+impl std::fmt::Display for CapabilitiesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Field(key) => write!(f, "{key} cannot be published as configured"),
+            Self::Invalid(error) => write!(f, "the capability document is not valid: {error}"),
+            Self::Encode => f.write_str("the capability document could not be encoded"),
+        }
+    }
+}
+
+impl std::error::Error for CapabilitiesError {}
+
+/// The published policy, plus the signature and digest a client checks.
+#[derive(Clone)]
+pub struct Published {
+    /// The signed document `GET_CAPABILITIES` returns.
+    pub signed: SignedCapabilities,
+    /// `H("free2z/relay/v1/caps", tls_codec(Capabilities))`, which `HELLO`
+    /// carries so a client can detect a policy change without refetching.
+    pub digest: Digest,
+    /// The canonical bytes, encoded once.
+    pub encoded: Vec<u8>,
+}
+
+// `encoded` is the canonical document, and a derived `Debug` would render a
+// kilobyte of it as a decimal byte list. The bytes are public — that is the
+// point of the document — but a log line is still not where they belong, and
+// the rule this workspace enforces is that no type derives `Debug` over raw
+// bytes, without an exception for the ones that happen to be harmless.
+impl core::fmt::Debug for Published {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Published")
+            .field("digest", &self.digest)
+            .field("encoded", &format_args!("<{} bytes>", self.encoded.len()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl Published {
+    /// The document itself.
+    #[must_use]
+    pub const fn capabilities(&self) -> &Capabilities {
+        &self.signed.capabilities
+    }
+}
+
+/// Build the document this configuration describes.
+///
+/// # Errors
+///
+/// [`CapabilitiesError`] if a field does not fit, or if the assembled document
+/// fails §11.1's consistency rules — which is a configuration bug caught at
+/// startup rather than a document served to a client that will refuse it.
+pub fn build(
+    config: &Config,
+    identity: &PublicKey,
+    durability: Durability,
+    published_at_ms: u64,
+) -> Result<Capabilities, CapabilitiesError> {
+    let mode = config
+        .creation_mode()
+        .map_err(|_| CapabilitiesError::Field("antiabuse.queue_creation_mode"))?;
+
+    // §2.3 obligations 1 and 2 travel together: no TLS session means no
+    // exporter to derive a binding from, and a document that claimed otherwise
+    // would be lying in a signed structure.
+    let (transport, binding) = if config.tls_enabled() {
+        (TransportSecurity::Tls, ChannelBindingMode::TlsExporter)
+    } else {
+        (TransportSecurity::None, ChannelBindingMode::None)
+    };
+
+    let padding = PaddingBuckets::new(config.padding.sizes.clone())
+        .map_err(|_| CapabilitiesError::Field("padding.sizes"))?;
+
+    let creation_pow = match mode {
+        CreationMode::Open | CreationMode::Token => PowParams::none(),
+        CreationMode::Pow => PowParams {
+            algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+            difficulty_bits: config.antiabuse.queue_creation_pow_bits,
+            challenge_ttl_ms: config.antiabuse.challenge_ttl_ms,
+        },
+    };
+    let contact_pow = if config.antiabuse.contact_queues_enabled {
+        PowParams {
+            algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+            difficulty_bits: config.antiabuse.contact_append_pow_bits,
+            challenge_ttl_ms: config.antiabuse.challenge_ttl_ms,
+        }
+    } else {
+        PowParams::none()
+    };
+
+    let capabilities = Capabilities {
+        protocol_versions: alloc_versions(),
+
+        relay_identity_pk: *identity,
+        relay_id: f2z_codec::hash::relay_id(identity),
+
+        transport_security: transport.code(),
+        channel_binding_mode: binding.code(),
+        max_frame_bytes: config.limits.max_frame_bytes,
+        max_inflight: config.limits.max_inflight,
+        ws_ping_interval_seconds: config.listen.ping_interval_seconds,
+        handshake_timeout_ms: config.listen.handshake_timeout_ms,
+
+        clock_skew_ms: config.limits.clock_skew_ms,
+        antireplay_window_ms: config.limits.antireplay_window_ms,
+        // §5.5: the seen-set lives in memory, because a restart destroys every
+        // TLS session and the channel binding has already invalidated the whole
+        // pre-restart corpus. §5.3's exception is why this is *published*: in
+        // `channel_binding_mode: none` the argument does not hold, and a client
+        // reads this field and may refuse.
+        antireplay_persistence: AntiReplayPersistence::Volatile.code(),
+
+        padding_sizes: padding.sizes().to_vec().into(),
+        max_chunk_bytes: config.padding.max_chunk_bytes,
+
+        min_message_ttl_seconds: config.queues.min_message_ttl_seconds,
+        max_message_ttl_seconds: config.queues.max_message_ttl_seconds,
+        default_message_ttl_seconds: config.queues.default_message_ttl_seconds,
+        min_idle_ttl_seconds: config.queues.min_idle_ttl_seconds,
+        max_idle_ttl_seconds: config.queues.max_idle_ttl_seconds,
+        default_idle_ttl_seconds: config.queues.default_idle_ttl_seconds,
+        max_queue_messages: config.limits.max_queue_messages,
+        max_queue_bytes: config.limits.max_queue_bytes,
+
+        queue_creation_mode: match mode {
+            CreationMode::Open => QueueCreationMode::Open.code(),
+            CreationMode::Pow => QueueCreationMode::Pow.code(),
+            CreationMode::Token => QueueCreationMode::Token.code(),
+        },
+        queue_creation_pow: creation_pow,
+        contact_queues_enabled: u8::from(config.antiabuse.contact_queues_enabled),
+        contact_max_pending: config.antiabuse.contact_max_pending,
+        contact_max_bytes: config.antiabuse.contact_max_bytes,
+        contact_append_pow: contact_pow,
+        per_source_limits: u8::from(config.antiabuse.per_source_limits),
+        durability_mode: match durability {
+            Durability::Memory => DurabilityMode::Memory.code(),
+            Durability::Batched => DurabilityMode::Batched.code(),
+            // Group commit is **not** `batched`: it amortizes one fsync across
+            // many responses that all wait for it. Deferring the fsync past the
+            // response is what would make this weaker.
+            Durability::FsyncPerAppend => DurabilityMode::FsyncPerAppend.code(),
+        },
+
+        operator_name: short("operator.name", &config.operator.name)?,
+        operator_contact: short("operator.contact", &config.operator.contact)?,
+        operator_abuse_contact: short("operator.abuse_contact", &config.operator.abuse_contact)?,
+        operator_jurisdiction: short("operator.jurisdiction", &config.operator.jurisdiction)?,
+        operator_policy_url: short("operator.policy_url", &config.operator.policy_url)?,
+
+        source_repo_url: short(
+            "provenance.source_repo_url",
+            &config.provenance.source_repo_url,
+        )?,
+        source_commit: short("provenance.source_commit", &config.provenance.source_commit)?,
+        build_digest: short("provenance.build_digest", &config.provenance.build_digest)?,
+
+        published_at_ms,
+    };
+
+    capabilities::validate(&capabilities).map_err(CapabilitiesError::Invalid)?;
+    Ok(capabilities)
+}
+
+/// Sign a document and precompute what `HELLO` and `GET_CAPABILITIES` need.
+///
+/// # Errors
+///
+/// [`CapabilitiesError::Encode`] if the document cannot be encoded.
+pub fn publish(
+    identity: &SigningKey,
+    capabilities: Capabilities,
+) -> Result<Published, CapabilitiesError> {
+    let encoded =
+        capabilities::signing_bytes(&capabilities).map_err(|_| CapabilitiesError::Encode)?;
+    let digest = capabilities::digest(&capabilities).map_err(|_| CapabilitiesError::Encode)?;
+    let signed =
+        capabilities::sign(identity, capabilities).map_err(|_| CapabilitiesError::Encode)?;
+    Ok(Published {
+        signed,
+        digest,
+        encoded,
+    })
+}
+
+fn alloc_versions() -> f2z_codec::vec::VecU8<u16> {
+    vec![f2z_codec::PROTOCOL_VERSION].into()
+}
+
+fn short(key: &'static str, text: &str) -> Result<ShortBytes, CapabilitiesError> {
+    ShortBytes::new(text.as_bytes().to_vec()).map_err(|_| CapabilitiesError::Field(key))
+}
+
+// ---------------------------------------------------------------------------
+// §11.2's representation, for an operator to publish.
+// ---------------------------------------------------------------------------
+
+/// The document as the JSON of §11.2 — the same values, the same signature
+/// (base64url, unpadded), the same digest.
+///
+/// This is an **encoder**. It writes our own values and consumes nothing from
+/// the network, which is the entire reason it is acceptable here while an HTTP
+/// parser on the public port is not (see the module documentation).
+#[must_use]
+pub fn to_json(published: &Published) -> String {
+    use std::fmt::Write as _;
+    let capabilities = published.capabilities();
+    let mut out = String::with_capacity(2048);
+    out.push_str("{\n");
+    let _ = writeln!(
+        out,
+        "  \"protocol_versions\": {:?},",
+        versions(capabilities)
+    );
+    let _ = writeln!(
+        out,
+        "  \"relay_identity_pk\": \"{}\",",
+        base64url(capabilities.relay_identity_pk.as_bytes())
+    );
+    let _ = writeln!(
+        out,
+        "  \"relay_id\": \"{}\",",
+        base64url(capabilities.relay_id.as_bytes())
+    );
+    let _ = writeln!(
+        out,
+        "  \"transport_security\": {},",
+        capabilities.transport_security
+    );
+    let _ = writeln!(
+        out,
+        "  \"channel_binding_mode\": {},",
+        capabilities.channel_binding_mode
+    );
+    let _ = writeln!(
+        out,
+        "  \"max_frame_bytes\": {},",
+        capabilities.max_frame_bytes
+    );
+    let _ = writeln!(out, "  \"max_inflight\": {},", capabilities.max_inflight);
+    let _ = writeln!(
+        out,
+        "  \"ws_ping_interval_seconds\": {},",
+        capabilities.ws_ping_interval_seconds
+    );
+    let _ = writeln!(
+        out,
+        "  \"handshake_timeout_ms\": {},",
+        capabilities.handshake_timeout_ms
+    );
+    let _ = writeln!(out, "  \"clock_skew_ms\": {},", capabilities.clock_skew_ms);
+    let _ = writeln!(
+        out,
+        "  \"antireplay_window_ms\": {},",
+        capabilities.antireplay_window_ms
+    );
+    let _ = writeln!(
+        out,
+        "  \"antireplay_persistence\": {},",
+        capabilities.antireplay_persistence
+    );
+    let _ = writeln!(
+        out,
+        "  \"padding_sizes\": {:?},",
+        capabilities.padding_sizes.as_slice()
+    );
+    let _ = writeln!(
+        out,
+        "  \"max_chunk_bytes\": {},",
+        capabilities.max_chunk_bytes
+    );
+    let _ = writeln!(
+        out,
+        "  \"min_message_ttl_seconds\": {},",
+        capabilities.min_message_ttl_seconds
+    );
+    let _ = writeln!(
+        out,
+        "  \"max_message_ttl_seconds\": {},",
+        capabilities.max_message_ttl_seconds
+    );
+    let _ = writeln!(
+        out,
+        "  \"default_message_ttl_seconds\": {},",
+        capabilities.default_message_ttl_seconds
+    );
+    let _ = writeln!(
+        out,
+        "  \"min_idle_ttl_seconds\": {},",
+        capabilities.min_idle_ttl_seconds
+    );
+    let _ = writeln!(
+        out,
+        "  \"max_idle_ttl_seconds\": {},",
+        capabilities.max_idle_ttl_seconds
+    );
+    let _ = writeln!(
+        out,
+        "  \"default_idle_ttl_seconds\": {},",
+        capabilities.default_idle_ttl_seconds
+    );
+    let _ = writeln!(
+        out,
+        "  \"max_queue_messages\": {},",
+        capabilities.max_queue_messages
+    );
+    let _ = writeln!(
+        out,
+        "  \"max_queue_bytes\": {},",
+        capabilities.max_queue_bytes
+    );
+    let _ = writeln!(
+        out,
+        "  \"queue_creation_mode\": {},",
+        capabilities.queue_creation_mode
+    );
+    let _ = writeln!(
+        out,
+        "  \"queue_creation_pow\": {},",
+        pow_json(&capabilities.queue_creation_pow)
+    );
+    let _ = writeln!(
+        out,
+        "  \"contact_queues_enabled\": {},",
+        capabilities.contact_queues_enabled
+    );
+    let _ = writeln!(
+        out,
+        "  \"contact_max_pending\": {},",
+        capabilities.contact_max_pending
+    );
+    let _ = writeln!(
+        out,
+        "  \"contact_max_bytes\": {},",
+        capabilities.contact_max_bytes
+    );
+    let _ = writeln!(
+        out,
+        "  \"contact_append_pow\": {},",
+        pow_json(&capabilities.contact_append_pow)
+    );
+    let _ = writeln!(
+        out,
+        "  \"per_source_limits\": {},",
+        capabilities.per_source_limits
+    );
+    let _ = writeln!(
+        out,
+        "  \"durability_mode\": {},",
+        capabilities.durability_mode
+    );
+    let _ = writeln!(
+        out,
+        "  \"operator_name\": {},",
+        json_string(capabilities.operator_name.as_slice())
+    );
+    let _ = writeln!(
+        out,
+        "  \"operator_contact\": {},",
+        json_string(capabilities.operator_contact.as_slice())
+    );
+    let _ = writeln!(
+        out,
+        "  \"operator_abuse_contact\": {},",
+        json_string(capabilities.operator_abuse_contact.as_slice())
+    );
+    let _ = writeln!(
+        out,
+        "  \"operator_jurisdiction\": {},",
+        json_string(capabilities.operator_jurisdiction.as_slice())
+    );
+    let _ = writeln!(
+        out,
+        "  \"operator_policy_url\": {},",
+        json_string(capabilities.operator_policy_url.as_slice())
+    );
+    let _ = writeln!(
+        out,
+        "  \"source_repo_url\": {},",
+        json_string(capabilities.source_repo_url.as_slice())
+    );
+    let _ = writeln!(
+        out,
+        "  \"source_commit\": {},",
+        json_string(capabilities.source_commit.as_slice())
+    );
+    let _ = writeln!(
+        out,
+        "  \"build_digest\": {},",
+        json_string(capabilities.build_digest.as_slice())
+    );
+    let _ = writeln!(
+        out,
+        "  \"published_at_ms\": {},",
+        capabilities.published_at_ms
+    );
+    let _ = writeln!(
+        out,
+        "  \"capabilities_digest\": \"{}\",",
+        base64url(published.digest.as_bytes())
+    );
+    let _ = writeln!(
+        out,
+        "  \"signature\": \"{}\"",
+        base64url(published.signed.signature.as_bytes())
+    );
+    out.push_str("}\n");
+    out
+}
+
+fn versions(capabilities: &Capabilities) -> Vec<u16> {
+    capabilities.protocol_versions.as_slice().to_vec()
+}
+
+fn pow_json(params: &PowParams) -> String {
+    format!(
+        "{{ \"algorithm\": {}, \"difficulty_bits\": {}, \"challenge_ttl_ms\": {} }}",
+        params.algorithm, params.difficulty_bits, params.challenge_ttl_ms
+    )
+}
+
+/// An operator string as JSON. The bytes are operator-authored ASCII from a
+/// configuration file, but they are still escaped, because a document a third
+/// party is meant to fetch and diff must not be breakable by a quotation mark.
+fn json_string(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len().saturating_add(2));
+    out.push('"');
+    for byte in bytes {
+        match *byte {
+            b'"' => out.push_str("\\\""),
+            b'\\' => out.push_str("\\\\"),
+            b'\n' => out.push_str("\\n"),
+            b'\r' => out.push_str("\\r"),
+            b'\t' => out.push_str("\\t"),
+            0x20..=0x7e => out.push(char::from(*byte)),
+            other => {
+                use std::fmt::Write as _;
+                let _ = write!(out, "\\u{:04x}", u32::from(other));
+            }
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// base64url without padding — §3.4's representation for bytes in documents.
+#[must_use]
+pub fn base64url(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::with_capacity(
+        bytes
+            .len()
+            .saturating_mul(4)
+            .saturating_div(3)
+            .saturating_add(4),
+    );
+    for chunk in bytes.chunks(3) {
+        let first = chunk.first().copied().unwrap_or(0);
+        let second = chunk.get(1).copied().unwrap_or(0);
+        let third = chunk.get(2).copied().unwrap_or(0);
+        let bits = (u32::from(first) << 16) | (u32::from(second) << 8) | u32::from(third);
+        let indices = [
+            (bits >> 18) & 0x3f,
+            (bits >> 12) & 0x3f,
+            (bits >> 6) & 0x3f,
+            bits & 0x3f,
+        ];
+        let keep = chunk.len().saturating_add(1);
+        for index in indices.iter().take(keep) {
+            let position = usize::try_from(*index).unwrap_or(0);
+            if let Some(byte) = ALPHABET.get(position) {
+                out.push(char::from(*byte));
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_relay_proto::capabilities::ClientPolicy;
+
+    fn identity() -> SigningKey {
+        SigningKey::from_seed(&[7u8; 32])
+    }
+
+    fn document(config: &Config) -> Capabilities {
+        build(
+            config,
+            &identity().public_key(),
+            Durability::FsyncPerAppend,
+            1_800_000_000_000,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn the_default_configuration_publishes_a_document_a_strict_client_accepts() {
+        let capabilities = document(&Config::default());
+        assert!(capabilities::validate(&capabilities).is_ok());
+        // Defaults bind loopback with no TLS, so a client still has to opt in
+        // to the insecure transport — §2.3 obligation 3, working.
+        let policy = ClientPolicy {
+            allow_insecure_transport: true,
+            ..ClientPolicy::default()
+        };
+        assert!(policy.accept(&capabilities).is_ok());
+    }
+
+    #[test]
+    fn tls_publishes_the_exporter_binding_and_nothing_else_does() {
+        let mut config = Config::default();
+        assert_eq!(
+            document(&config).channel_binding_mode,
+            ChannelBindingMode::None.code()
+        );
+        config.listen.tls_cert = "cert.pem".to_owned();
+        config.listen.tls_key = "key.pem".to_owned();
+        let capabilities = document(&config);
+        assert_eq!(
+            capabilities.transport_security,
+            TransportSecurity::Tls.code()
+        );
+        assert_eq!(
+            capabilities.channel_binding_mode,
+            ChannelBindingMode::TlsExporter.code()
+        );
+    }
+
+    #[test]
+    fn the_document_restates_the_limits_the_engine_enforces() {
+        let mut config = Config::default();
+        config.limits.max_queue_messages = 7;
+        config.limits.max_queue_bytes = 4_096;
+        config.limits.max_inflight = 3;
+        let capabilities = document(&config);
+        assert_eq!(capabilities.max_queue_messages, 7);
+        assert_eq!(capabilities.max_queue_bytes, 4_096);
+        assert_eq!(capabilities.max_inflight, 3);
+    }
+
+    #[test]
+    fn the_durability_mode_is_the_stores_and_not_a_claim() {
+        let config = Config::default();
+        let volatile = build(
+            &config,
+            &identity().public_key(),
+            Durability::Memory,
+            1_800_000_000_000,
+        )
+        .unwrap();
+        assert_eq!(volatile.durability_mode, DurabilityMode::Memory.code());
+    }
+
+    #[test]
+    fn open_mode_publishes_no_proof_of_work_parameters() {
+        let mut config = Config::default();
+        config.antiabuse.queue_creation_mode = "open".to_owned();
+        let capabilities = document(&config);
+        assert!(!capabilities.queue_creation_pow.is_required());
+        // Contact queues still demand one — §12.3 requires all four caps.
+        assert!(capabilities.contact_append_pow.is_required());
+    }
+
+    #[test]
+    fn the_signature_verifies_against_the_key_hello_proves() {
+        let published = publish(&identity(), document(&Config::default())).unwrap();
+        assert!(capabilities::verify(&published.signed, &identity().public_key()).is_ok());
+        assert!(capabilities::check_digest(published.capabilities(), &published.digest).is_ok());
+    }
+
+    #[test]
+    fn the_json_carries_the_same_digest_and_signature_as_the_protocol_copy() {
+        let published = publish(&identity(), document(&Config::default())).unwrap();
+        let json = to_json(&published);
+        assert!(json.contains(&base64url(published.digest.as_bytes())));
+        assert!(json.contains(&base64url(published.signed.signature.as_bytes())));
+        assert!(json.contains("\"max_queue_messages\": 4096"));
+    }
+
+    #[test]
+    fn base64url_matches_rfc_4648_section_5_without_padding() {
+        assert_eq!(base64url(b""), "");
+        assert_eq!(base64url(b"f"), "Zg");
+        assert_eq!(base64url(b"fo"), "Zm8");
+        assert_eq!(base64url(b"foo"), "Zm9v");
+        assert_eq!(base64url(b"foob"), "Zm9vYg");
+        assert_eq!(base64url(&[0xfb, 0xff]), "-_8");
+    }
+
+    #[test]
+    fn an_operator_string_cannot_break_the_document_it_appears_in() {
+        let mut config = Config::default();
+        config.operator.name = "a \"quoted\" name\nwith a newline".to_owned();
+        let published = publish(&identity(), document(&config)).unwrap();
+        let json = to_json(&published);
+        assert!(json.contains("a \\\"quoted\\\" name\\nwith a newline"));
+    }
+}

--- a/rs/crates/f2z-relay/src/challenge.rs
+++ b/rs/crates/f2z-relay/src/challenge.rs
@@ -1,0 +1,268 @@
+//! Relay-issued, single-use, expiring challenges (§6.1, §12.3, §13.1).
+//!
+//! # What the challenge is actually for
+//!
+//! A proof-of-work stamp that a client could compute at leisure is not a cost;
+//! it is a one-off purchase. §12.3 is explicit about the three properties the
+//! challenge has to deliver:
+//!
+//! > *Binding the stamp to the target address and to a relay-issued challenge
+//! > means stamps cannot be precomputed at leisure before a campaign, cannot be
+//! > reused, and cannot be computed for one victim and spent on another.*
+//!
+//! So a challenge is drawn from the relay's CSPRNG ([`crate::rng`]), carries a
+//! purpose and — for `contact_append` — the target address as its scope, and is
+//! **removed from the table when it is spent**, whether or not the stamp that
+//! spent it turned out to be valid for its purpose.
+//!
+//! # Bounded, and refusing rather than evicting
+//!
+//! The table is the one structure an unauthenticated caller can make the relay
+//! allocate: `GET_CHALLENGE` needs no signature. So it is capped, and on
+//! reaching the cap the relay answers `ERR_BACKPRESSURE` rather than dropping
+//! an existing entry. Evicting would invalidate a stamp a client had *already
+//! paid for*, at exactly the moment the relay is under load — the same shape of
+//! mistake §5.5 forbids for the seen-set, for the same reason.
+//!
+//! Issuance is additionally rate-limited per source ([`crate::abuse`]), because
+//! §6.1 says so plainly: *"Challenge issuance is itself rate-limited per source,
+//! or it becomes the cheapest way to make the relay do work."*
+
+use std::collections::HashMap;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::types::Challenge;
+use f2z_relay_proto::ProtoError;
+
+/// One issued challenge.
+#[derive(Clone)]
+struct Issued {
+    /// `ChallengePurpose::code()` — a stamp for one purpose is not a stamp for
+    /// another.
+    purpose: u8,
+    /// The target address for `contact_append`, empty otherwise.
+    scope: Vec<u8>,
+    /// When it stops being spendable.
+    expires_at_ms: u64,
+}
+
+// The scope is a `contact_addr`: a published address, but an address. Nothing
+// here renders it.
+impl core::fmt::Debug for Issued {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Issued")
+            .field("purpose", &self.purpose)
+            .field(
+                "scope",
+                &format_args!("<redacted; {} bytes>", self.scope.len()),
+            )
+            .field("expires_at_ms", &self.expires_at_ms)
+            .finish()
+    }
+}
+
+/// The relay's challenge table.
+#[derive(Debug)]
+pub struct Challenges {
+    issued: HashMap<Challenge, Issued>,
+    max_entries: usize,
+}
+
+impl Challenges {
+    /// An empty table bounded at `max_entries`.
+    #[must_use]
+    pub fn new(max_entries: usize) -> Self {
+        Self {
+            issued: HashMap::new(),
+            max_entries,
+        }
+    }
+
+    /// How many challenges are outstanding. `/metrics` publishes this as a
+    /// total, never per source.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.issued.len()
+    }
+
+    /// Whether nothing is outstanding.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.issued.is_empty()
+    }
+
+    /// Drop everything past its expiry.
+    ///
+    /// Returns how many went, so a sweep can be reported as a count.
+    pub fn expire(&mut self, now_ms: u64) -> usize {
+        let before = self.issued.len();
+        self.issued
+            .retain(|_, issued| issued.expires_at_ms > now_ms);
+        before.saturating_sub(self.issued.len())
+    }
+
+    /// Record a freshly drawn challenge.
+    ///
+    /// # Errors
+    ///
+    /// `ERR_BACKPRESSURE` when the table is full. Never an eviction: see the
+    /// module documentation.
+    pub fn issue(
+        &mut self,
+        challenge: Challenge,
+        purpose: u8,
+        scope: &[u8],
+        expires_at_ms: u64,
+        now_ms: u64,
+    ) -> Result<(), ProtoError> {
+        if self.issued.len() >= self.max_entries {
+            // One sweep before refusing, so a table full of dead entries is not
+            // reported as load.
+            self.expire(now_ms);
+        }
+        if self.issued.len() >= self.max_entries {
+            return Err(ProtoError::Wire(ErrorCode::Backpressure));
+        }
+        self.issued.insert(
+            challenge,
+            Issued {
+                purpose,
+                scope: scope.to_vec(),
+                expires_at_ms,
+            },
+        );
+        Ok(())
+    }
+
+    /// Spend a challenge, once.
+    ///
+    /// The entry is removed **before** its purpose and scope are judged: a
+    /// challenge presented for the wrong purpose has still been presented, and
+    /// leaving it spendable would let an attacker probe the table without
+    /// consuming anything.
+    ///
+    /// # Errors
+    ///
+    /// `ERR_POW_INVALID` if it was never issued, has expired, was issued for a
+    /// different purpose, or was issued for a different target (§12.3).
+    pub fn consume(
+        &mut self,
+        challenge: &Challenge,
+        purpose: u8,
+        scope: &[u8],
+        now_ms: u64,
+    ) -> Result<(), ProtoError> {
+        let Some(issued) = self.issued.remove(challenge) else {
+            return Err(ProtoError::Wire(ErrorCode::PowInvalid));
+        };
+        if issued.purpose != purpose
+            || issued.expires_at_ms <= now_ms
+            || (!scope.is_empty() && issued.scope != scope)
+        {
+            return Err(ProtoError::Wire(ErrorCode::PowInvalid));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_codec::commands::ChallengePurpose;
+
+    fn challenge(byte: u8) -> Challenge {
+        Challenge::new([byte; 32])
+    }
+
+    #[test]
+    fn a_challenge_is_spendable_exactly_once() {
+        let mut table = Challenges::new(8);
+        let purpose = ChallengePurpose::QueueCreate.code();
+        table.issue(challenge(1), purpose, &[], 1_000, 0).unwrap();
+        assert!(table.consume(&challenge(1), purpose, &[], 0).is_ok());
+        assert!(table.consume(&challenge(1), purpose, &[], 0).is_err());
+    }
+
+    #[test]
+    fn a_challenge_is_scoped_to_its_target() {
+        let mut table = Challenges::new(8);
+        let purpose = ChallengePurpose::ContactAppend.code();
+        table
+            .issue(challenge(2), purpose, b"victim", 1_000, 0)
+            .unwrap();
+        assert!(table.consume(&challenge(2), purpose, b"other", 0).is_err());
+    }
+
+    #[test]
+    fn a_challenge_is_bound_to_its_purpose() {
+        let mut table = Challenges::new(8);
+        table
+            .issue(challenge(3), ChallengePurpose::Clock.code(), &[], 1_000, 0)
+            .unwrap();
+        assert!(
+            table
+                .consume(&challenge(3), ChallengePurpose::QueueCreate.code(), &[], 0)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn an_expired_challenge_is_refused_and_swept() {
+        let mut table = Challenges::new(8);
+        let purpose = ChallengePurpose::QueueCreate.code();
+        table.issue(challenge(4), purpose, &[], 1_000, 0).unwrap();
+        assert!(table.consume(&challenge(4), purpose, &[], 2_000).is_err());
+        table.issue(challenge(5), purpose, &[], 1_000, 0).unwrap();
+        assert_eq!(table.expire(2_000), 1);
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn a_full_table_refuses_and_never_evicts() {
+        let mut table = Challenges::new(2);
+        let purpose = ChallengePurpose::QueueCreate.code();
+        table.issue(challenge(6), purpose, &[], 10_000, 0).unwrap();
+        table.issue(challenge(7), purpose, &[], 10_000, 0).unwrap();
+        let error = table
+            .issue(challenge(8), purpose, &[], 10_000, 0)
+            .unwrap_err();
+        assert_eq!(error.wire_code(), Some(ErrorCode::Backpressure));
+        // The two a client may already have paid for are still spendable, which
+        // is the whole point of refusing rather than making room.
+        assert!(table.consume(&challenge(6), purpose, &[], 0).is_ok());
+        assert!(table.consume(&challenge(7), purpose, &[], 0).is_ok());
+    }
+
+    #[test]
+    fn a_full_table_of_dead_entries_sweeps_before_it_refuses() {
+        let mut table = Challenges::new(2);
+        let purpose = ChallengePurpose::QueueCreate.code();
+        table.issue(challenge(9), purpose, &[], 1_000, 0).unwrap();
+        table.issue(challenge(10), purpose, &[], 1_000, 0).unwrap();
+        assert!(
+            table
+                .issue(challenge(11), purpose, &[], 9_000, 5_000)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn nothing_in_the_table_renders_its_scope() {
+        let mut table = Challenges::new(4);
+        table
+            .issue(
+                challenge(12),
+                ChallengePurpose::ContactAppend.code(),
+                &[0xde, 0xad, 0xbe, 0xef],
+                1_000,
+                0,
+            )
+            .unwrap();
+        let rendered = format!("{table:?}");
+        assert!(
+            !rendered.contains("222"),
+            "decimal byte list leaked: {rendered}"
+        );
+        assert!(!rendered.contains("deadbeef"));
+    }
+}

--- a/rs/crates/f2z-relay/src/cli.rs
+++ b/rs/crates/f2z-relay/src/cli.rs
@@ -1,0 +1,302 @@
+//! The command line: flags over environment over file over default.
+//!
+//! Hand-rolled rather than delegated to an argument parser, for the reason
+//! §2.2 gives about transports and this crate applies to its whole dependency
+//! graph: every crate in a server binary is attack surface and audit scope, and
+//! the whole of what is needed here is fifteen flags with no subcommands, no
+//! completions and no colour.
+//!
+//! The four inspection modes exist because a relay's configuration decides
+//! things a client can see and refuse — §2.3's transport, §5.5's window, §9's
+//! buckets, §13.1's gate — so "what am I actually running" has to be answerable
+//! without starting anything:
+//!
+//! | Flag | What it does |
+//! |---|---|
+//! | `--help` | The flags, and where each one lands in the file |
+//! | `--version` | The crate version and the protocol version |
+//! | `--print-config` | The merged configuration as TOML, **key material redacted** |
+//! | `--check-config` | Everything [`Config::check`] decides, then exit |
+//! | `--print-capabilities` | §11.2's JSON document, for an operator to publish |
+
+use crate::config::{Config, ConfigError};
+
+/// What the process was asked to do.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Mode {
+    /// Run the relay.
+    Run,
+    /// Print the flags.
+    Help,
+    /// Print the versions.
+    Version,
+    /// Print the merged configuration, redacted.
+    PrintConfig,
+    /// Check the configuration and exit.
+    CheckConfig,
+    /// Print the signed capability document as §11.2's JSON.
+    PrintCapabilities,
+}
+
+/// A parsed command line.
+#[derive(Debug)]
+pub struct Invocation {
+    /// What to do.
+    pub mode: Mode,
+    /// The merged configuration.
+    pub config: Config,
+}
+
+/// The `--help` text.
+pub const HELP: &str = "\
+f2z-relay — the free2z relay daemon (docs/e2ee/WIRE.md v1)
+
+USAGE:
+    f2z-relay [OPTIONS]
+
+OPTIONS:
+    -c, --config <PATH>        TOML configuration file
+        --listen <ADDR>        Protocol listener            [listen.address]
+        --insecure-listen      Bind non-loopback without TLS, and publish
+                               transport_security: none     [listen.insecure]
+        --tls-cert <PATH>      PEM certificate chain        [listen.tls_cert]
+        --tls-key <PATH>       PEM private key              [listen.tls_key]
+        --admin-listen <ADDR>  Loopback /healthz + /metrics [admin.address]
+        --no-admin             Do not serve them at all     [admin.enabled]
+        --store <BACKEND>      sqlite | memory              [store.backend]
+        --store-path <PATH>    SQLite file                  [store.path]
+        --identity <PATH>      Ed25519 identity key file    [identity.path]
+        --no-generate-identity Fail if the key is missing   [identity.generate]
+        --log-level <LEVEL>    off|error|warn|info|debug|trace  [log.level]
+
+    -h, --help                 Print this and exit
+    -V, --version              Print versions and exit
+        --print-config         Print the merged configuration, secrets redacted
+        --check-config         Validate the configuration and exit
+        --print-capabilities   Print the signed capability document as JSON
+
+ENVIRONMENT:
+    Every file key is settable as F2Z_RELAY_<SECTION>_<KEY>; the file's
+    [limits] max_inflight is F2Z_RELAY_LIMITS_MAX_INFLIGHT. Flags win over the
+    environment, the environment wins over the file, the file wins over the
+    defaults.
+
+    F2Z_RELAY_IDENTITY_SEED is key material: 64 hexadecimal characters, for a
+    container with no persistent volume. --print-config redacts it.
+";
+
+/// Parse a command line and merge every source.
+///
+/// # Errors
+///
+/// [`ConfigError`] for an unknown flag, a flag with no value, an unreadable or
+/// invalid file, or an environment variable that does not parse.
+pub fn parse<A, E>(arguments: A, environment: E) -> Result<Invocation, ConfigError>
+where
+    A: IntoIterator<Item = String>,
+    E: IntoIterator<Item = (String, String)>,
+{
+    let arguments: Vec<String> = arguments.into_iter().collect();
+    let mut mode = Mode::Run;
+
+    // The file is read first, because the flags that follow have to win over
+    // it — and `--config` itself has to be found before anything is read.
+    let mut config_path: Option<String> = None;
+    let mut index = 0usize;
+    while let Some(argument) = arguments.get(index) {
+        if argument == "--config" || argument == "-c" {
+            config_path = Some(
+                arguments
+                    .get(index.saturating_add(1))
+                    .cloned()
+                    .ok_or(ConfigError::MissingValue("--config"))?,
+            );
+        }
+        index = index.saturating_add(1);
+    }
+
+    let mut config = match &config_path {
+        Some(path) => Config::from_toml_path(std::path::Path::new(path))?,
+        None => Config::default(),
+    };
+    config.apply_env(environment)?;
+
+    let mut index = 0usize;
+    while let Some(argument) = arguments.get(index) {
+        let take = |flag: &'static str| -> Result<String, ConfigError> {
+            arguments
+                .get(index.saturating_add(1))
+                .cloned()
+                .ok_or(ConfigError::MissingValue(flag))
+        };
+        match argument.as_str() {
+            "-h" | "--help" => mode = Mode::Help,
+            "-V" | "--version" => mode = Mode::Version,
+            "--print-config" => mode = Mode::PrintConfig,
+            "--check-config" => mode = Mode::CheckConfig,
+            "--print-capabilities" => mode = Mode::PrintCapabilities,
+            "-c" | "--config" => {
+                take("--config")?;
+                index = index.saturating_add(1);
+            }
+            "--listen" => {
+                config.listen.address = take("--listen")?;
+                index = index.saturating_add(1);
+            }
+            "--insecure-listen" => config.listen.insecure = true,
+            "--tls-cert" => {
+                config.listen.tls_cert = take("--tls-cert")?;
+                index = index.saturating_add(1);
+            }
+            "--tls-key" => {
+                config.listen.tls_key = take("--tls-key")?;
+                index = index.saturating_add(1);
+            }
+            "--admin-listen" => {
+                config.admin.address = take("--admin-listen")?;
+                config.admin.enabled = true;
+                index = index.saturating_add(1);
+            }
+            "--no-admin" => config.admin.enabled = false,
+            "--store" => {
+                config.store.backend = take("--store")?;
+                index = index.saturating_add(1);
+            }
+            "--store-path" => {
+                config.store.path = take("--store-path")?;
+                index = index.saturating_add(1);
+            }
+            "--identity" => {
+                config.identity.path = take("--identity")?;
+                index = index.saturating_add(1);
+            }
+            "--no-generate-identity" => config.identity.generate = false,
+            "--log-level" => {
+                config.log.level = take("--log-level")?;
+                index = index.saturating_add(1);
+            }
+            other => return Err(ConfigError::UnknownFlag(other.to_owned())),
+        }
+        index = index.saturating_add(1);
+    }
+
+    Ok(Invocation { mode, config })
+}
+
+/// The `--version` text.
+#[must_use]
+pub fn version() -> String {
+    format!(
+        "f2z-relay {}\nWIRE.md protocol version {}\n",
+        env!("CARGO_PKG_VERSION"),
+        f2z_codec::PROTOCOL_VERSION,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|item| (*item).to_owned()).collect()
+    }
+
+    #[test]
+    fn no_arguments_runs_on_the_defaults() {
+        let invocation = parse(args(&[]), []).unwrap();
+        assert_eq!(invocation.mode, Mode::Run);
+        assert_eq!(invocation.config, Config::default());
+    }
+
+    #[test]
+    fn a_flag_wins_over_the_environment() {
+        let invocation = parse(
+            args(&["--listen", "127.0.0.1:1"]),
+            [(
+                "F2Z_RELAY_LISTEN_ADDRESS".to_owned(),
+                "127.0.0.1:2".to_owned(),
+            )],
+        )
+        .unwrap();
+        assert_eq!(invocation.config.listen.address, "127.0.0.1:1");
+    }
+
+    #[test]
+    fn the_environment_wins_over_the_defaults() {
+        let invocation = parse(
+            args(&[]),
+            [("F2Z_RELAY_LIMITS_MAX_INFLIGHT".to_owned(), "7".to_owned())],
+        )
+        .unwrap();
+        assert_eq!(invocation.config.limits.max_inflight, 7);
+    }
+
+    #[test]
+    fn every_inspection_mode_is_reachable() {
+        for (flag, expected) in [
+            ("--help", Mode::Help),
+            ("-h", Mode::Help),
+            ("--version", Mode::Version),
+            ("-V", Mode::Version),
+            ("--print-config", Mode::PrintConfig),
+            ("--check-config", Mode::CheckConfig),
+            ("--print-capabilities", Mode::PrintCapabilities),
+        ] {
+            assert_eq!(parse(args(&[flag]), []).unwrap().mode, expected);
+        }
+    }
+
+    #[test]
+    fn an_unknown_flag_is_named_rather_than_ignored() {
+        let error = parse(args(&["--lisen", "x"]), []).unwrap_err();
+        assert!(format!("{error}").contains("--lisen"));
+    }
+
+    #[test]
+    fn a_flag_with_no_value_says_so() {
+        let error = parse(args(&["--listen"]), []).unwrap_err();
+        assert!(format!("{error}").contains("--listen"));
+    }
+
+    #[test]
+    fn the_insecure_override_is_a_flag_and_not_a_default() {
+        assert!(!parse(args(&[]), []).unwrap().config.listen.insecure);
+        assert!(
+            parse(args(&["--insecure-listen"]), [])
+                .unwrap()
+                .config
+                .listen
+                .insecure
+        );
+    }
+
+    #[test]
+    fn help_names_every_flag_the_parser_accepts() {
+        for flag in [
+            "--config",
+            "--listen",
+            "--insecure-listen",
+            "--tls-cert",
+            "--tls-key",
+            "--admin-listen",
+            "--no-admin",
+            "--store",
+            "--store-path",
+            "--identity",
+            "--no-generate-identity",
+            "--log-level",
+            "--print-config",
+            "--check-config",
+            "--print-capabilities",
+        ] {
+            assert!(HELP.contains(flag), "--help does not mention {flag}");
+        }
+    }
+
+    #[test]
+    fn version_names_both_versions() {
+        let text = version();
+        assert!(text.contains(env!("CARGO_PKG_VERSION")));
+        assert!(text.contains("protocol version 1"));
+    }
+}

--- a/rs/crates/f2z-relay/src/commit.rs
+++ b/rs/crates/f2z-relay/src/commit.rs
@@ -1,0 +1,440 @@
+//! The group-commit writer, and why it is not an optimization.
+//!
+//! # The arithmetic
+//!
+//! `f2z-relay-store` runs `synchronous = FULL` over WAL, so **a transaction
+//! costs an fsync**, and a cheap VPS's disk does on the order of 50-200 of those
+//! a second. One transaction per `APPEND` therefore caps the whole relay at
+//! roughly one append per fsync — a ceiling low enough that
+//! [ADR 0005](https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0005-federation.md)'s
+//! "$5/month VPS" economics do not work. Batching N appends arriving within a
+//! few milliseconds into **one** transaction costs one fsync for all N, and the
+//! ceiling becomes N times higher for the same disk.
+//!
+//! `f2z-relay-store` exposes exactly the two things this needs:
+//! [`RelayStore::append_batch`], which is the *primitive* rather than a
+//! convenience wrapper, and `SqliteStore::commits`, which counts fsyncs so the
+//! amortization is checkable rather than asserted. `tests/group_commit.rs`
+//! checks it: a hundred concurrent appends must move the commit counter by a
+//! small number, not by a hundred.
+//!
+//! # Batching does not weaken durability, and the distinction is published
+//!
+//! §11.1 has three `durability_mode` values and this relay publishes
+//! `fsync-per-append`. That is not a stretch:
+//!
+//! > *deferring the fsync past the response is `batched`; amortizing one fsync
+//! > across many responses that all wait for it is still `fsync-per-append`.*
+//!
+//! Every append in a batch waits for the same commit, and no reply is sent
+//! before it. Which is the second reason this module exists at all:
+//!
+//! # `accepted` is never written to the socket before the commit is durable
+//!
+//! `Committed<T>` has a crate-private constructor in `f2z-relay-store`, so the
+//! only value that can exist is one the completed transaction minted. In this
+//! module that type is unwrapped **on the writer thread, after
+//! `append_batch` returned**, and the `oneshot` reply is sent in the same
+//! statement. There is no path by which a connection task holds an
+//! `Appended` before the disk does — not because the code is careful, but
+//! because there is nothing to hold until the commit has happened.
+//!
+//! # Why a thread and not a task
+//!
+//! An fsync is a blocking syscall of unbounded duration. Running it on a Tokio
+//! worker parks that worker, and on a 1 GB VPS there are not many workers. So
+//! the writer owns an OS thread and takes work over a channel; the window is a
+//! `recv_timeout`, which is the one place a blocking receive is exactly the
+//! right primitive.
+//!
+//! The other store operations — `create_queue`, `read`, `ack`, `delete_queue` —
+//! are called inline from the connection tasks. They contend on the same
+//! connection mutex, so they queue behind a batch rather than racing it, and
+//! none of them is on the path this module exists to widen. `ACK` does commit,
+//! and batching it would be the obvious next step; it is deliberately not done
+//! in v1 because an `ACK` is one row-range delete per reader rather than one per
+//! message, and adding a second batcher before the first one has been measured
+//! in production is how a relay acquires two schedulers nobody can reason about.
+//!
+//! [`RelayStore::append_batch`]: f2z_relay_store::RelayStore::append_batch
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::time::{Duration, Instant};
+
+use f2z_codec::types::{Payload, QueueAddress};
+use f2z_relay_store::{Append, Appended, Durability, RelayStore, SendAuth, StoreError};
+
+use crate::metrics::Metrics;
+
+/// One append, waiting for a transaction.
+struct Job {
+    send_addr: QueueAddress,
+    auth: SendAuth,
+    payload: Payload,
+    received_at_ms: u64,
+    reply: tokio::sync::oneshot::Sender<Reply>,
+}
+
+// The payload is somebody's ciphertext.
+impl core::fmt::Debug for Job {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Job")
+            .field("payload", &self.payload)
+            .field("received_at_ms", &self.received_at_ms)
+            .finish_non_exhaustive()
+    }
+}
+
+/// What the writer sends back.
+///
+/// The `Ok` variant exists **only** downstream of a `Committed<Appended>` that
+/// the store minted, so holding one is holding the fact that the write is
+/// durable at [`Durability`].
+#[derive(Debug)]
+pub struct Accepted {
+    /// The reader's address, for the `MSG` push of §6.4.
+    pub recv_addr: QueueAddress,
+    /// The index assigned. **Never sent to the writer** (§6.3).
+    pub index: u64,
+    /// The stamp recorded. Also never sent to the writer.
+    pub received_at_ms: u64,
+    /// What the store's commit actually promised.
+    pub durability: Durability,
+}
+
+type Reply = Result<Accepted, StoreError>;
+
+/// Why an append could not even be queued.
+#[derive(Debug)]
+pub enum CommitError {
+    /// The writer thread is gone. A relay in this state cannot accept anything,
+    /// and the caller answers `ERR_UNAVAILABLE` — §6.3 collapses every
+    /// send-side refusal to one code, and "the relay is broken" is one of them.
+    WriterStopped,
+}
+
+/// A handle on the writer.
+#[derive(Clone, Debug)]
+pub struct CommitWriter {
+    sender: std::sync::mpsc::Sender<Job>,
+    durability: Durability,
+}
+
+impl CommitWriter {
+    /// Start the writer thread.
+    ///
+    /// `window` is how long a batch gathers after its first job; `max_batch` is
+    /// the most appends one transaction takes.
+    ///
+    /// # Errors
+    ///
+    /// The thread could not be spawned.
+    pub fn start(
+        store: Arc<dyn RelayStore + Send + Sync>,
+        metrics: Arc<Metrics>,
+        window: Duration,
+        max_batch: usize,
+    ) -> std::io::Result<Self> {
+        let durability = store.durability();
+        let (sender, receiver) = std::sync::mpsc::channel::<Job>();
+        std::thread::Builder::new()
+            .name("f2z-relay-commit".to_owned())
+            .spawn(move || run(&store, &metrics, &receiver, window, max_batch.max(1)))?;
+        Ok(Self { sender, durability })
+    }
+
+    /// What this writer's commits promise — §11.1's `durability_mode`.
+    #[must_use]
+    pub const fn durability(&self) -> Durability {
+        self.durability
+    }
+
+    /// Submit an append and wait for its commit.
+    ///
+    /// # Errors
+    ///
+    /// [`CommitError::WriterStopped`] if the writer is gone. A per-append
+    /// refusal — unknown address, wrong key, quota exhausted — comes back as
+    /// the inner `Err`, because one writer hitting its cap must not undo an
+    /// unrelated queue's durable write.
+    pub async fn append(
+        &self,
+        send_addr: QueueAddress,
+        auth: SendAuth,
+        payload: Payload,
+        received_at_ms: u64,
+    ) -> Result<Reply, CommitError> {
+        let (reply, answer) = tokio::sync::oneshot::channel();
+        self.sender
+            .send(Job {
+                send_addr,
+                auth,
+                payload,
+                received_at_ms,
+                reply,
+            })
+            .map_err(|_| CommitError::WriterStopped)?;
+        answer.await.map_err(|_| CommitError::WriterStopped)
+    }
+}
+
+fn run(
+    store: &Arc<dyn RelayStore + Send + Sync>,
+    metrics: &Arc<Metrics>,
+    receiver: &std::sync::mpsc::Receiver<Job>,
+    window: Duration,
+    max_batch: usize,
+) {
+    let durability = store.durability();
+    loop {
+        // Block until there is anything to do. A relay with no traffic costs no
+        // wakeups, which on a shared VPS is a real number.
+        let Ok(first) = receiver.recv() else {
+            return;
+        };
+        let deadline = Instant::now().checked_add(window);
+        let mut batch = vec![first];
+
+        // Gather. The window starts at the *first* job rather than being a
+        // fixed tick, so a lone append waits at most `window` and a burst
+        // waits less.
+        while batch.len() < max_batch {
+            let Some(deadline) = deadline else {
+                break;
+            };
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match receiver.recv_timeout(remaining) {
+                Ok(job) => batch.push(job),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+                // The last sender went away. Commit what is in hand — those
+                // clients are gone, but their queues' readers are not, and a
+                // message thrown away here is a message §13.2 says must not be.
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        commit(store, metrics, durability, batch);
+    }
+}
+
+fn commit(
+    store: &Arc<dyn RelayStore + Send + Sync>,
+    metrics: &Arc<Metrics>,
+    durability: Durability,
+    batch: Vec<Job>,
+) {
+    let appends: Vec<Append<'_>> = batch
+        .iter()
+        .map(|job| Append {
+            send_addr: job.send_addr,
+            auth: job.auth,
+            payload: &job.payload,
+            received_at_ms: job.received_at_ms,
+        })
+        .collect();
+
+    Metrics::inc(&metrics.commit_transactions);
+    let outcome = store.append_batch(&appends);
+
+    match outcome {
+        Ok(committed) => {
+            // `Committed<T>` is unwrapped **here**, after the transaction, and
+            // the replies go out in the same statement. That ordering is what
+            // §8.4's `accepted` means, and it is not a convention: the value
+            // did not exist a line earlier.
+            let mut results = committed.into_inner().into_iter();
+            for job in batch {
+                let reply = match results.next() {
+                    Some(Ok(appended)) => {
+                        Metrics::inc(&metrics.appends_committed);
+                        Ok(accepted(&appended, durability))
+                    }
+                    Some(Err(error)) => Err(error),
+                    None => Err(StoreError::Corrupt(
+                        "append_batch returned fewer results than it was given appends",
+                    )),
+                };
+                // A client that hung up between sending and committing loses
+                // its answer, and the message stays: §2.5 says an in-flight
+                // command whose response was not received has *unknown* status,
+                // and §8.3 says APPEND is deliberately not idempotent.
+                let _ = job.reply.send(reply);
+            }
+        }
+        Err(error) => {
+            // The transaction itself failed, so nothing in the batch was
+            // written. Every job learns that, and §6.3 collapses it to
+            // `ERR_UNAVAILABLE` on the wire.
+            crate::log_error!(
+                "commit transaction failed",
+                "appends" = u32::try_from(batch.len()).unwrap_or(u32::MAX)
+            );
+            let mut first = Some(error);
+            for job in batch {
+                let reply = first.take().map_or_else(
+                    || Err(StoreError::Corrupt("the commit transaction failed")),
+                    Err,
+                );
+                let _ = job.reply.send(reply);
+            }
+        }
+    }
+}
+
+fn accepted(appended: &Appended, durability: Durability) -> Accepted {
+    Accepted {
+        recv_addr: appended.recv_addr,
+        index: appended.index,
+        received_at_ms: appended.received_at_ms,
+        durability,
+    }
+}
+
+/// A counter the tests use to prove the amortization. Not wired into the relay:
+/// the real number is `SqliteStore::commits`, and this exists so a store that
+/// is not SQLite can still be asked.
+#[derive(Debug, Default)]
+pub struct CommitCounter(pub AtomicU64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_codec::types::PublicKey;
+    use f2z_relay_proto::queue::{AppendQuota, QueueKind};
+    use f2z_relay_store::{MemoryStore, QueueSpec};
+
+    fn store_with_queue() -> (Arc<dyn RelayStore + Send + Sync>, QueueAddress, PublicKey) {
+        let store = MemoryStore::new();
+        let recv_addr = QueueAddress::new([1u8; 32]);
+        let send_addr = QueueAddress::new([2u8; 32]);
+        let recv_key = PublicKey::new([3u8; 32]);
+        let send_key = PublicKey::new([4u8; 32]);
+        let _created = store
+            .create_queue(&QueueSpec {
+                kind: QueueKind::Standard,
+                recv_addr,
+                send_addr,
+                recv_key,
+                message_ttl_seconds: 600,
+                idle_ttl_seconds: 6_000,
+                quota: AppendQuota {
+                    max_messages: 1_000,
+                    max_bytes: 1 << 20,
+                },
+                created_at_ms: 0,
+            })
+            .unwrap();
+        let _bound = store.bind_send(&send_addr, &send_key, 0).unwrap();
+        (Arc::new(store), send_addr, send_key)
+    }
+
+    #[tokio::test]
+    async fn an_append_is_answered_only_after_its_transaction() {
+        let (store, send_addr, send_key) = store_with_queue();
+        let metrics = Arc::new(Metrics::new());
+        let writer =
+            CommitWriter::start(store, Arc::clone(&metrics), Duration::from_millis(1), 16).unwrap();
+        let payload = Payload::new(vec![0u8; 1024]).unwrap();
+        let accepted = writer
+            .append(send_addr, SendAuth::Signed(send_key), payload, 1_000)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(accepted.index, 0);
+        assert_eq!(accepted.durability, Durability::Memory);
+        assert_eq!(
+            metrics
+                .appends_committed
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn many_concurrent_appends_share_transactions() {
+        let (store, send_addr, send_key) = store_with_queue();
+        let metrics = Arc::new(Metrics::new());
+        let writer = CommitWriter::start(
+            Arc::clone(&store),
+            Arc::clone(&metrics),
+            Duration::from_millis(20),
+            64,
+        )
+        .unwrap();
+
+        let mut tasks = Vec::new();
+        for _ in 0..64u32 {
+            let writer = writer.clone();
+            tasks.push(tokio::spawn(async move {
+                let payload = Payload::new(vec![0u8; 1024]).unwrap();
+                writer
+                    .append(send_addr, SendAuth::Signed(send_key), payload, 1_000)
+                    .await
+                    .unwrap()
+                    .unwrap()
+            }));
+        }
+        let mut indices = Vec::new();
+        for task in tasks {
+            indices.push(task.await.unwrap().index);
+        }
+        indices.sort_unstable();
+        assert_eq!(indices, (0..64u64).collect::<Vec<_>>());
+
+        // The amortization, as a number rather than a claim. 64 appends into a
+        // 20 ms window must not have cost 64 transactions.
+        let transactions = metrics
+            .commit_transactions
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            transactions < 64,
+            "64 concurrent appends took {transactions} transactions; group commit did nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_writers_refusal_does_not_undo_the_batch() {
+        let (store, send_addr, send_key) = store_with_queue();
+        let metrics = Arc::new(Metrics::new());
+        let writer =
+            CommitWriter::start(store, Arc::clone(&metrics), Duration::from_millis(20), 8).unwrap();
+
+        let good = writer.append(
+            send_addr,
+            SendAuth::Signed(send_key),
+            Payload::new(vec![0u8; 1024]).unwrap(),
+            1_000,
+        );
+        let absent = writer.append(
+            QueueAddress::new([0x5b; 32]),
+            SendAuth::Signed(send_key),
+            Payload::new(vec![0u8; 1024]).unwrap(),
+            1_000,
+        );
+        let (good, absent) = tokio::join!(good, absent);
+        assert!(good.unwrap().is_ok());
+        assert!(absent.unwrap().is_err());
+    }
+
+    #[test]
+    fn a_job_never_renders_its_payload() {
+        let (reply, _answer) = tokio::sync::oneshot::channel();
+        let job = Job {
+            send_addr: QueueAddress::new([9u8; 32]),
+            auth: SendAuth::ContactStamp,
+            payload: Payload::new(vec![0xde, 0xad, 0xbe, 0xef]).unwrap(),
+            received_at_ms: 1,
+            reply,
+        };
+        let rendered = format!("{job:?}");
+        assert!(
+            !rendered.contains("222"),
+            "decimal byte list leaked: {rendered}"
+        );
+        assert!(!rendered.contains("deadbeef"));
+    }
+}

--- a/rs/crates/f2z-relay/src/config.rs
+++ b/rs/crates/f2z-relay/src/config.rs
@@ -1,0 +1,1495 @@
+//! What an operator configures, where the values come from, and what the
+//! defaults assume about the machine.
+//!
+//! # Three sources, one precedence
+//!
+//! **flags > environment > file > default.** A file is optional; a relay with
+//! no file at all starts on the defaults below, which is what makes
+//! `docker run f2z-relay` a sentence rather than a project.
+//!
+//! Every key is spellable in all three, and the mapping is mechanical: the
+//! file's `[limits] max_inflight` is `F2Z_RELAY_LIMITS_MAX_INFLIGHT` in the
+//! environment. Unknown keys in the file are an **error**, not a warning: a
+//! mistyped `max_queue_byes` that silently kept the default would be a quota an
+//! operator believes they set.
+//!
+//! # The defaults are sized for a 1 GB VPS, and that is a decision
+//!
+//! [ADR 0005](https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0005-federation.md)
+//! puts the economics of the whole federation on a cheap box, so the defaults
+//! are what that box can actually hold rather than what a benchmark likes:
+//!
+//! | Knob | Default | Why that number |
+//! |---|---|---|
+//! | `limits.max_connections` | 512 | Each connection is a task, two buffers and a subscription set. 512 is a few MB and leaves the page cache the rest. |
+//! | `limits.antireplay_seen_max` | 65 536 | ~3 MB of `(key, nonce)` pairs. §5.5 refuses rather than evicts, so this is a hard ceiling on a *bounded* structure. |
+//! | `limits.storage_high_water_bytes` | 8 GiB | §13.1 layer 4 turns on here. The point is to hit backpressure before the filesystem does, because a full disk is not a graceful refusal. |
+//! | `limits.max_queues` | 50 000 | Bounds the row count the idle sweep walks, which is the one periodic cost proportional to queues rather than to traffic. |
+//! | `commit.window_ms` | 5 | See [`crate::commit`]. Long enough to gather a batch at any rate worth batching, short enough to be invisible next to a WAN round trip. |
+//!
+//! # Secrets
+//!
+//! One value here is key material: `identity.seed`, which exists so a container
+//! with no persistent volume can be handed its identity through the
+//! environment. `--print-config` renders it as `"<redacted>"`, and
+//! `tests/redaction.rs` proves it.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use crate::log::Level;
+
+/// Why a configuration could not be built.
+#[derive(Debug)]
+pub enum ConfigError {
+    /// The file could not be read.
+    Read(PathBuf, std::io::Error),
+    /// The file is not valid TOML, or carries a key this build does not know.
+    Parse(String),
+    /// A value is present but unusable, naming the key and what is wrong.
+    Invalid(&'static str, String),
+    /// A flag was given that this build does not know.
+    UnknownFlag(String),
+    /// A flag that takes a value was given none.
+    MissingValue(&'static str),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read(path, error) => write!(f, "cannot read {}: {error}", path.display()),
+            Self::Parse(detail) => write!(f, "configuration file: {detail}"),
+            Self::Invalid(key, detail) => write!(f, "{key}: {detail}"),
+            Self::UnknownFlag(flag) => write!(f, "unknown flag {flag}; try --help"),
+            Self::MissingValue(flag) => write!(f, "{flag} needs a value"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+type Result<T> = core::result::Result<T, ConfigError>;
+
+// ---------------------------------------------------------------------------
+// The shape.
+// ---------------------------------------------------------------------------
+
+/// Everything a relay is configured with.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Config {
+    /// The public WebSocket listener (§2.1, §2.3).
+    pub listen: Listen,
+    /// The loopback-only operational listener.
+    pub admin: Admin,
+    /// Where queues live.
+    pub store: Store,
+    /// The relay's long-term Ed25519 identity (§5.2).
+    pub identity: Identity,
+    /// The group-commit writer.
+    pub commit: Commit,
+    /// The numbers §13.1 layers 1 and 4 are made of.
+    pub limits: Limits,
+    /// §7.7's TTL bands.
+    pub queues: Queues,
+    /// §9's bucket set.
+    pub padding: Padding,
+    /// §13.1 layers 2 and 3, and §12.3.
+    pub antiabuse: AntiAbuse,
+    /// §11.1's operator block — "the point of the document".
+    pub operator: Operator,
+    /// §11.1's provenance block.
+    pub provenance: Provenance,
+    /// How much the relay says. See [`crate::log`] for what it may not say.
+    pub log: Log,
+}
+
+/// The public listener.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Listen {
+    /// The address to bind.
+    pub address: String,
+    /// §2.3's override. Binding a non-loopback address without TLS is a startup
+    /// **failure** unless this is set, and setting it is published in the
+    /// capability document as `transport_security: none`.
+    pub insecure: bool,
+    /// PEM certificate chain. Both this and `tls_key` present means TLS.
+    pub tls_cert: String,
+    /// PEM private key.
+    pub tls_key: String,
+    /// §2.5's cap between accept and a valid `HELLO`.
+    pub handshake_timeout_ms: u32,
+    /// §2.4's server-driven Ping interval.
+    pub ping_interval_seconds: u16,
+    /// §2.4: close after this many consecutive missed Pongs.
+    pub missed_pongs_before_close: u32,
+}
+
+/// The loopback-only operational listener.
+///
+/// **Deliberately not the public port.** `/healthz` and `/metrics` are an
+/// operator interface; exposing them is how a relay ends up publishing queue
+/// depth and connection counts to anyone who asks, which is metadata the whole
+/// design refuses to disclose over the protocol.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Admin {
+    /// Whether to serve it at all.
+    pub enabled: bool,
+    /// The address. Refused at startup if it is not loopback.
+    pub address: String,
+}
+
+/// Storage.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Store {
+    /// `sqlite` (durable, §11.1's `fsync-per-append`) or `memory` (volatile).
+    pub backend: String,
+    /// The SQLite file. Ignored by the memory backend.
+    pub path: String,
+}
+
+/// The identity key.
+#[derive(Clone, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Identity {
+    /// Where the 32-byte seed lives.
+    pub path: String,
+    /// Create the file if it is missing. Off in production deployments that
+    /// provision keys out of band, so a lost volume fails loudly instead of
+    /// silently becoming a different relay.
+    pub generate: bool,
+    /// The seed itself, 64 hex characters, for a container with no volume.
+    ///
+    /// **Key material.** Overrides `path` when set, and is what
+    /// `--print-config` redacts.
+    pub seed: String,
+}
+
+// The seed is the relay's long-term private key. A derived `Debug` would put it
+// in any error that ever formats a Config.
+impl std::fmt::Debug for Identity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Identity")
+            .field("path", &self.path)
+            .field("generate", &self.generate)
+            .field(
+                "seed",
+                if self.seed.is_empty() {
+                    &"<unset>"
+                } else {
+                    &"<redacted>"
+                },
+            )
+            .finish()
+    }
+}
+
+/// The group-commit writer (§8.4, and [`crate::commit`]).
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Commit {
+    /// How long a batch gathers before it commits.
+    pub window_ms: u32,
+    /// The most appends one transaction takes.
+    pub max_batch: u32,
+}
+
+/// §13.1's numbers.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Limits {
+    /// §4.1's published frame cap.
+    pub max_frame_bytes: u32,
+    /// §4.3's published in-flight window.
+    pub max_inflight: u16,
+    /// §5.5's published timestamp window.
+    pub clock_skew_ms: u32,
+    /// §5.5's published seen-set retention. MUST be at least twice
+    /// `clock_skew_ms` — see [`Config::check`] and issue #586.
+    pub antireplay_window_ms: u32,
+    /// §5.5's published seen-set bound. On reaching it the relay refuses new
+    /// signed commands with `ERR_BACKPRESSURE`; it never evicts.
+    pub antireplay_seen_max: u32,
+    /// §13.1 layer 1: concurrent connections, all sources.
+    pub max_connections: u32,
+    /// §13.1 layer 1: concurrent connections from one source address.
+    pub max_connections_per_source: u32,
+    /// §13.1 layer 1: new connections per second from one source address.
+    pub new_connections_per_source_per_second: u32,
+    /// §13.1 layer 1: commands per second on one connection.
+    pub commands_per_connection_per_second: u32,
+    /// §6.1: `GET_CHALLENGE` per minute per source, "or it becomes the cheapest
+    /// way to make the relay do work".
+    pub challenges_per_source_per_minute: u32,
+    /// §13.1 layer 3: how many queues may exist at once.
+    pub max_queues: u64,
+    /// §13.1 layer 2's published per-queue message cap.
+    pub max_queue_messages: u32,
+    /// §13.1 layer 2's published per-queue byte cap.
+    pub max_queue_bytes: u64,
+    /// §13.1 layer 4: storage above this turns backpressure on.
+    pub storage_high_water_bytes: u64,
+    /// How many outbound frames one connection may have queued before the relay
+    /// stops producing for it (§13.1's "not to unbounded server-side
+    /// buffering").
+    pub max_outbound_queue: u32,
+}
+
+/// §7.7's TTL bands, and how often they are swept.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Queues {
+    /// The floor a request is clamped up to.
+    pub min_message_ttl_seconds: u32,
+    /// The ceiling. MUST NOT exceed 30 days (§7.7, §11.3 step 5).
+    pub max_message_ttl_seconds: u32,
+    /// What `req_message_ttl_seconds = 0` ("no preference") is granted.
+    pub default_message_ttl_seconds: u32,
+    /// The idle floor.
+    pub min_idle_ttl_seconds: u32,
+    /// The idle ceiling.
+    pub max_idle_ttl_seconds: u32,
+    /// What `req_idle_ttl_seconds = 0` is granted.
+    pub default_idle_ttl_seconds: u32,
+    /// How often the expiry tick runs.
+    pub expiry_tick_seconds: u32,
+}
+
+/// §9's published bucket set.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Padding {
+    /// Strictly ascending, non-empty, no zero.
+    pub sizes: Vec<u32>,
+    /// §9's client-side chunk size.
+    pub max_chunk_bytes: u32,
+}
+
+/// §13.1 layer 3 and §12.3.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct AntiAbuse {
+    /// `open`, `pow` (the default) or `token`.
+    pub queue_creation_mode: String,
+    /// Leading zero bits a queue-creation stamp must show.
+    pub queue_creation_pow_bits: u8,
+    /// Leading zero bits a `CONTACT_APPEND` stamp must show.
+    pub contact_append_pow_bits: u8,
+    /// How long a `GET_CHALLENGE` challenge stays spendable.
+    pub challenge_ttl_ms: u32,
+    /// The most challenges the relay will hold at once. Reaching it is
+    /// `ERR_BACKPRESSURE` on `GET_CHALLENGE`, never an eviction: an evicted
+    /// challenge is a client whose stamp becomes invalid after it paid for it.
+    pub max_challenges: u32,
+    /// §12: whether first contact is offered here at all.
+    pub contact_queues_enabled: bool,
+    /// §12.3's pending cap.
+    pub contact_max_pending: u32,
+    /// §12.3's byte cap.
+    pub contact_max_bytes: u64,
+    /// §13.3: published so a user behind shared egress can choose a relay that
+    /// does not use them.
+    pub per_source_limits: bool,
+}
+
+/// §11.1's operator block.
+///
+/// Every field defaults to empty, and §11.1 is explicit that a relay publishing
+/// this unedited "is publishing a document that answers none of the questions it
+/// exists to answer". The emptiness is deliberate — inventing an operator name
+/// would be worse — and it is what an operator is expected to fill in.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Operator {
+    /// Who runs it.
+    pub name: String,
+    /// How to reach a human.
+    pub contact: String,
+    /// Where abuse reports go.
+    pub abuse_contact: String,
+    /// Where the operator and the hardware sit. §11.1: a user choosing among
+    /// *k* relays is making a jurisdictional choice whether or not anyone tells
+    /// them so.
+    pub jurisdiction: String,
+    /// The published policy.
+    pub policy_url: String,
+}
+
+/// §11.1's provenance block — what turns "open source and self-hostable" into
+/// something a third party can check.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Provenance {
+    /// Where the source is.
+    pub source_repo_url: String,
+    /// The commit this binary was built from.
+    pub source_commit: String,
+    /// A reproducible-build digest of the running binary.
+    pub build_digest: String,
+}
+
+/// Logging.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Log {
+    /// `off`, `error`, `warn`, `info`, `debug`, `trace`.
+    pub level: String,
+}
+
+// ---------------------------------------------------------------------------
+// Defaults.
+// ---------------------------------------------------------------------------
+
+impl Default for Listen {
+    fn default() -> Self {
+        Self {
+            // Loopback, so the out-of-the-box relay is one §2.3 permits without
+            // an override. An operator who wants the internet says so.
+            address: "127.0.0.1:8443".to_owned(),
+            insecure: false,
+            tls_cert: String::new(),
+            tls_key: String::new(),
+            handshake_timeout_ms: 10_000,
+            ping_interval_seconds: 25,
+            missed_pongs_before_close: 2,
+        }
+    }
+}
+
+impl Default for Admin {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            address: "127.0.0.1:9101".to_owned(),
+        }
+    }
+}
+
+impl Default for Store {
+    fn default() -> Self {
+        Self {
+            backend: "sqlite".to_owned(),
+            path: "relay.sqlite".to_owned(),
+        }
+    }
+}
+
+impl Default for Identity {
+    fn default() -> Self {
+        Self {
+            path: "relay-identity.key".to_owned(),
+            generate: true,
+            seed: String::new(),
+        }
+    }
+}
+
+impl Default for Commit {
+    fn default() -> Self {
+        Self {
+            window_ms: 5,
+            max_batch: 256,
+        }
+    }
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_frame_bytes: 1024 * 1024,
+            max_inflight: 32,
+            clock_skew_ms: 120_000,
+            antireplay_window_ms: 240_000,
+            antireplay_seen_max: 65_536,
+            max_connections: 512,
+            max_connections_per_source: 16,
+            new_connections_per_source_per_second: 8,
+            commands_per_connection_per_second: 64,
+            challenges_per_source_per_minute: 60,
+            max_queues: 50_000,
+            max_queue_messages: 4_096,
+            max_queue_bytes: 64 * 1024 * 1024,
+            storage_high_water_bytes: 8 * 1024 * 1024 * 1024,
+            max_outbound_queue: 256,
+        }
+    }
+}
+
+impl Default for Queues {
+    fn default() -> Self {
+        Self {
+            min_message_ttl_seconds: 60,
+            max_message_ttl_seconds: f2z_codec::MAX_MESSAGE_TTL_SECONDS,
+            default_message_ttl_seconds: 604_800,
+            min_idle_ttl_seconds: 3_600,
+            max_idle_ttl_seconds: 31_536_000,
+            default_idle_ttl_seconds: 7_776_000,
+            expiry_tick_seconds: 60,
+        }
+    }
+}
+
+impl Default for Padding {
+    fn default() -> Self {
+        Self {
+            sizes: f2z_codec::padding::PROPOSED_BUCKETS.to_vec(),
+            max_chunk_bytes: f2z_codec::padding::DEFAULT_MAX_CHUNK_BYTES,
+        }
+    }
+}
+
+impl Default for AntiAbuse {
+    fn default() -> Self {
+        Self {
+            // §13.1: "`pow` — **the default.**"
+            queue_creation_mode: "pow".to_owned(),
+            queue_creation_pow_bits: 20,
+            contact_append_pow_bits: 20,
+            challenge_ttl_ms: 60_000,
+            max_challenges: 65_536,
+            contact_queues_enabled: true,
+            contact_max_pending: 64,
+            contact_max_bytes: 256 * 1024,
+            per_source_limits: true,
+        }
+    }
+}
+
+impl Default for Provenance {
+    fn default() -> Self {
+        Self {
+            source_repo_url: "https://github.com/free2z/zuu".to_owned(),
+            source_commit: String::new(),
+            build_digest: String::new(),
+        }
+    }
+}
+
+impl Default for Log {
+    fn default() -> Self {
+        Self {
+            level: "info".to_owned(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Loading.
+// ---------------------------------------------------------------------------
+
+/// How the queue-creation gate is set (§13.1 layer 3).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CreationMode {
+    /// No gate. §13.1: "Appropriate only for a private relay on a closed
+    /// network."
+    Open,
+    /// A `PowStamp` over a relay-issued challenge. The default.
+    Pow,
+    /// An operator-issued bearer token. **Refused at startup** — see
+    /// [`Config::check`].
+    Token,
+}
+
+impl Config {
+    /// Read a TOML file.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfigError::Read`] or [`ConfigError::Parse`]. An unknown key is a
+    /// parse error, deliberately.
+    pub fn from_toml_path(path: &std::path::Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .map_err(|error| ConfigError::Read(path.to_path_buf(), error))?;
+        Self::from_toml_str(&text)
+    }
+
+    /// Parse TOML text.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfigError::Parse`], naming the key when the key is what is wrong.
+    pub fn from_toml_str(text: &str) -> Result<Self> {
+        toml::from_str(text).map_err(|error| ConfigError::Parse(error.to_string()))
+    }
+
+    /// Apply `F2Z_RELAY_*` over whatever is already here.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfigError::Invalid`] for a variable whose value does not parse.
+    pub fn apply_env<I>(&mut self, variables: I) -> Result<()>
+    where
+        I: IntoIterator<Item = (String, String)>,
+    {
+        let mut sorted = BTreeMap::new();
+        for (name, value) in variables {
+            if let Some(key) = name.strip_prefix("F2Z_RELAY_") {
+                sorted.insert(key.to_ascii_lowercase(), value);
+            }
+        }
+        for (key, value) in sorted {
+            self.set(&key, &value)?;
+        }
+        Ok(())
+    }
+
+    /// Set one `section_key` value, as the environment spells it.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfigError::Invalid`] when the value does not parse, or the key is not
+    /// one this build knows.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one match arm per configuration key; splitting it would hide \
+                  the one place a reader can see the whole surface"
+    )]
+    pub fn set(&mut self, key: &str, value: &str) -> Result<()> {
+        match key {
+            "listen_address" => self.listen.address = value.to_owned(),
+            "listen_insecure" => self.listen.insecure = boolean("listen_insecure", value)?,
+            "listen_tls_cert" => self.listen.tls_cert = value.to_owned(),
+            "listen_tls_key" => self.listen.tls_key = value.to_owned(),
+            "listen_handshake_timeout_ms" => {
+                self.listen.handshake_timeout_ms = number("listen_handshake_timeout_ms", value)?;
+            }
+            "listen_ping_interval_seconds" => {
+                self.listen.ping_interval_seconds = number("listen_ping_interval_seconds", value)?;
+            }
+            "listen_missed_pongs_before_close" => {
+                self.listen.missed_pongs_before_close =
+                    number("listen_missed_pongs_before_close", value)?;
+            }
+            "admin_enabled" => self.admin.enabled = boolean("admin_enabled", value)?,
+            "admin_address" => self.admin.address = value.to_owned(),
+            "store_backend" => self.store.backend = value.to_owned(),
+            "store_path" => self.store.path = value.to_owned(),
+            "identity_path" => self.identity.path = value.to_owned(),
+            "identity_generate" => self.identity.generate = boolean("identity_generate", value)?,
+            "identity_seed" => self.identity.seed = value.to_owned(),
+            "commit_window_ms" => self.commit.window_ms = number("commit_window_ms", value)?,
+            "commit_max_batch" => self.commit.max_batch = number("commit_max_batch", value)?,
+            "limits_max_frame_bytes" => {
+                self.limits.max_frame_bytes = number("limits_max_frame_bytes", value)?;
+            }
+            "limits_max_inflight" => {
+                self.limits.max_inflight = number("limits_max_inflight", value)?;
+            }
+            "limits_clock_skew_ms" => {
+                self.limits.clock_skew_ms = number("limits_clock_skew_ms", value)?;
+            }
+            "limits_antireplay_window_ms" => {
+                self.limits.antireplay_window_ms = number("limits_antireplay_window_ms", value)?;
+            }
+            "limits_antireplay_seen_max" => {
+                self.limits.antireplay_seen_max = number("limits_antireplay_seen_max", value)?;
+            }
+            "limits_max_connections" => {
+                self.limits.max_connections = number("limits_max_connections", value)?;
+            }
+            "limits_max_connections_per_source" => {
+                self.limits.max_connections_per_source =
+                    number("limits_max_connections_per_source", value)?;
+            }
+            "limits_new_connections_per_source_per_second" => {
+                self.limits.new_connections_per_source_per_second =
+                    number("limits_new_connections_per_source_per_second", value)?;
+            }
+            "limits_commands_per_connection_per_second" => {
+                self.limits.commands_per_connection_per_second =
+                    number("limits_commands_per_connection_per_second", value)?;
+            }
+            "limits_challenges_per_source_per_minute" => {
+                self.limits.challenges_per_source_per_minute =
+                    number("limits_challenges_per_source_per_minute", value)?;
+            }
+            "limits_max_queues" => self.limits.max_queues = number("limits_max_queues", value)?,
+            "limits_max_queue_messages" => {
+                self.limits.max_queue_messages = number("limits_max_queue_messages", value)?;
+            }
+            "limits_max_queue_bytes" => {
+                self.limits.max_queue_bytes = number("limits_max_queue_bytes", value)?;
+            }
+            "limits_storage_high_water_bytes" => {
+                self.limits.storage_high_water_bytes =
+                    number("limits_storage_high_water_bytes", value)?;
+            }
+            "limits_max_outbound_queue" => {
+                self.limits.max_outbound_queue = number("limits_max_outbound_queue", value)?;
+            }
+            "queues_min_message_ttl_seconds" => {
+                self.queues.min_message_ttl_seconds =
+                    number("queues_min_message_ttl_seconds", value)?;
+            }
+            "queues_max_message_ttl_seconds" => {
+                self.queues.max_message_ttl_seconds =
+                    number("queues_max_message_ttl_seconds", value)?;
+            }
+            "queues_default_message_ttl_seconds" => {
+                self.queues.default_message_ttl_seconds =
+                    number("queues_default_message_ttl_seconds", value)?;
+            }
+            "queues_min_idle_ttl_seconds" => {
+                self.queues.min_idle_ttl_seconds = number("queues_min_idle_ttl_seconds", value)?;
+            }
+            "queues_max_idle_ttl_seconds" => {
+                self.queues.max_idle_ttl_seconds = number("queues_max_idle_ttl_seconds", value)?;
+            }
+            "queues_default_idle_ttl_seconds" => {
+                self.queues.default_idle_ttl_seconds =
+                    number("queues_default_idle_ttl_seconds", value)?;
+            }
+            "queues_expiry_tick_seconds" => {
+                self.queues.expiry_tick_seconds = number("queues_expiry_tick_seconds", value)?;
+            }
+            "padding_sizes" => self.padding.sizes = number_list("padding_sizes", value)?,
+            "padding_max_chunk_bytes" => {
+                self.padding.max_chunk_bytes = number("padding_max_chunk_bytes", value)?;
+            }
+            "antiabuse_queue_creation_mode" => {
+                self.antiabuse.queue_creation_mode = value.to_owned();
+            }
+            "antiabuse_queue_creation_pow_bits" => {
+                self.antiabuse.queue_creation_pow_bits =
+                    number("antiabuse_queue_creation_pow_bits", value)?;
+            }
+            "antiabuse_contact_append_pow_bits" => {
+                self.antiabuse.contact_append_pow_bits =
+                    number("antiabuse_contact_append_pow_bits", value)?;
+            }
+            "antiabuse_challenge_ttl_ms" => {
+                self.antiabuse.challenge_ttl_ms = number("antiabuse_challenge_ttl_ms", value)?;
+            }
+            "antiabuse_max_challenges" => {
+                self.antiabuse.max_challenges = number("antiabuse_max_challenges", value)?;
+            }
+            "antiabuse_contact_queues_enabled" => {
+                self.antiabuse.contact_queues_enabled =
+                    boolean("antiabuse_contact_queues_enabled", value)?;
+            }
+            "antiabuse_contact_max_pending" => {
+                self.antiabuse.contact_max_pending =
+                    number("antiabuse_contact_max_pending", value)?;
+            }
+            "antiabuse_contact_max_bytes" => {
+                self.antiabuse.contact_max_bytes = number("antiabuse_contact_max_bytes", value)?;
+            }
+            "antiabuse_per_source_limits" => {
+                self.antiabuse.per_source_limits = boolean("antiabuse_per_source_limits", value)?;
+            }
+            "operator_name" => self.operator.name = value.to_owned(),
+            "operator_contact" => self.operator.contact = value.to_owned(),
+            "operator_abuse_contact" => self.operator.abuse_contact = value.to_owned(),
+            "operator_jurisdiction" => self.operator.jurisdiction = value.to_owned(),
+            "operator_policy_url" => self.operator.policy_url = value.to_owned(),
+            "provenance_source_repo_url" => self.provenance.source_repo_url = value.to_owned(),
+            "provenance_source_commit" => self.provenance.source_commit = value.to_owned(),
+            "provenance_build_digest" => self.provenance.build_digest = value.to_owned(),
+            "log_level" => self.log.level = value.to_owned(),
+            other => {
+                return Err(ConfigError::Invalid(
+                    "environment",
+                    format!(
+                        "F2Z_RELAY_{} names no configuration key",
+                        other.to_uppercase()
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// The parsed listen address.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfigError::Invalid`] if it is not `host:port`.
+    pub fn listen_addr(&self) -> Result<SocketAddr> {
+        self.listen
+            .address
+            .parse()
+            .map_err(|_| ConfigError::Invalid("listen.address", self.listen.address.clone()))
+    }
+
+    /// The parsed admin address.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfigError::Invalid`] if it is not `host:port`.
+    pub fn admin_addr(&self) -> Result<SocketAddr> {
+        self.admin
+            .address
+            .parse()
+            .map_err(|_| ConfigError::Invalid("admin.address", self.admin.address.clone()))
+    }
+
+    /// Whether the listener terminates TLS itself.
+    #[must_use]
+    pub fn tls_enabled(&self) -> bool {
+        !self.listen.tls_cert.is_empty() && !self.listen.tls_key.is_empty()
+    }
+
+    /// §13.1 layer 3's mode.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfigError::Invalid`] for a value that is not one of the three.
+    pub fn creation_mode(&self) -> Result<CreationMode> {
+        match self.antiabuse.queue_creation_mode.as_str() {
+            "open" => Ok(CreationMode::Open),
+            "pow" => Ok(CreationMode::Pow),
+            "token" => Ok(CreationMode::Token),
+            other => Err(ConfigError::Invalid(
+                "antiabuse.queue_creation_mode",
+                format!("{other} is not one of open, pow, token"),
+            )),
+        }
+    }
+
+    /// The log level.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfigError::Invalid`] for an unrecognized name.
+    pub fn log_level(&self) -> Result<Level> {
+        Level::parse(&self.log.level)
+            .map_err(|other| ConfigError::Invalid("log.level", other.to_owned()))
+    }
+
+    /// Everything `--check-config` checks, and everything startup checks.
+    ///
+    /// This is where the rules that a *pair* of values must satisfy live —
+    /// the ones no single field can enforce and no client can see until it is
+    /// too late.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfigError::Invalid`], naming the key that is wrong.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the cross-field rules of WIRE.md, each with the section it \
+                  comes from; a reader needs them in one list"
+    )]
+    pub fn check(&self) -> Result<()> {
+        let listen = self.listen_addr()?;
+        self.log_level()?;
+        let mode = self.creation_mode()?;
+
+        // §13.1 defines `token` as an operator-issued bearer credential and
+        // gives it **no wire shape at all** in v1: `CreateQueueRequest` carries
+        // a `PowStamp` and a reserved `flags` field that MUST be 0, and nothing
+        // else. There is no conforming way for a client to present a token, so
+        // a relay that published this mode would be publishing a gate no client
+        // can pass. Refused here rather than faked, which is the same call
+        // `f2z-relay-testkit` made. Reported as a spec defect.
+        if matches!(mode, CreationMode::Token) {
+            return Err(ConfigError::Invalid(
+                "antiabuse.queue_creation_mode",
+                "token mode has no wire representation in WIRE.md v1: CREATE_QUEUE \
+                 carries only a PowStamp and a reserved flags field, so a client \
+                 has no conforming way to present a token"
+                    .to_owned(),
+            ));
+        }
+
+        // §2.3, and it is a startup check rather than a warning: the process
+        // exits. A non-loopback bind with no TLS is the one configuration that
+        // silently downgrades every connection metadata property the design
+        // has, so it takes an explicit act to reach.
+        if !self.tls_enabled() && !is_loopback(&listen) && !self.listen.insecure {
+            return Err(ConfigError::Invalid(
+                "listen.address",
+                "refusing to bind a non-loopback address without TLS (WIRE.md §2.3); \
+                 configure listen.tls_cert and listen.tls_key, or pass \
+                 --insecure-listen to publish transport_security: none and \
+                 channel_binding_mode: none"
+                    .to_owned(),
+            ));
+        }
+        if self.tls_enabled() && self.listen.insecure {
+            return Err(ConfigError::Invalid(
+                "listen.insecure",
+                "--insecure-listen contradicts a configured certificate; a relay \
+                 that terminates TLS must publish transport_security: tls"
+                    .to_owned(),
+            ));
+        }
+
+        if self.admin.enabled {
+            let admin = self.admin_addr()?;
+            // §11.1 publishes nothing about connection counts or queue depth,
+            // and `/metrics` carries both. A metrics endpoint reachable from
+            // the network is the metadata disclosure the protocol refuses,
+            // arriving through the side door.
+            if !is_loopback(&admin) {
+                return Err(ConfigError::Invalid(
+                    "admin.address",
+                    "the admin listener serves /healthz and /metrics and must be \
+                     loopback-only; put a reverse proxy in front of it if a \
+                     scraper needs it"
+                        .to_owned(),
+                ));
+            }
+            // Port 0 asks the OS to choose, so two zeros are not a collision —
+            // they are two different ports the kernel has not picked yet. Only a
+            // concrete pair can actually clash.
+            if admin.port() != 0 && admin.port() == listen.port() && admin.ip() == listen.ip() {
+                return Err(ConfigError::Invalid(
+                    "admin.address",
+                    "the admin listener must not share the protocol listener's address".to_owned(),
+                ));
+            }
+        }
+
+        match self.store.backend.as_str() {
+            "sqlite" | "memory" => {}
+            other => {
+                return Err(ConfigError::Invalid(
+                    "store.backend",
+                    format!("{other} is not one of sqlite, memory"),
+                ));
+            }
+        }
+        if self.store.backend == "sqlite" && self.store.path.is_empty() {
+            return Err(ConfigError::Invalid(
+                "store.path",
+                "the sqlite backend needs a file".to_owned(),
+            ));
+        }
+        if self.identity.seed.is_empty() && self.identity.path.is_empty() {
+            return Err(ConfigError::Invalid(
+                "identity.path",
+                "a relay needs an identity: set identity.path or identity.seed".to_owned(),
+            ));
+        }
+        if !self.identity.seed.is_empty() && decode_seed(&self.identity.seed).is_none() {
+            return Err(ConfigError::Invalid(
+                "identity.seed",
+                "must be exactly 64 hexadecimal characters".to_owned(),
+            ));
+        }
+
+        // #586's finding, enforced rather than published. A frame is acceptable
+        // anywhere in `ts ± clock_skew_ms`, so a seen-set entry must be
+        // retained for `2 × clock_skew_ms` from first observation or §5.5's
+        // replay protection has a hole exactly the width of the shortfall. The
+        // specification permits the hole; this relay refuses to open it, which
+        // is why the corresponding conformance vector is one it cannot satisfy
+        // by construction rather than one it fails.
+        if u64::from(self.limits.antireplay_window_ms)
+            < u64::from(self.limits.clock_skew_ms).saturating_mul(2)
+        {
+            return Err(ConfigError::Invalid(
+                "limits.antireplay_window_ms",
+                "must be at least 2 x limits.clock_skew_ms, or the seen-set has no \
+                 coverage for frames in the gap (WIRE.md §5.5, issue #586)"
+                    .to_owned(),
+            ));
+        }
+        if self.limits.clock_skew_ms == 0 {
+            return Err(ConfigError::Invalid(
+                "limits.clock_skew_ms",
+                "a zero window rejects every client whose clock is not the relay's".to_owned(),
+            ));
+        }
+        if self.limits.max_inflight == 0 {
+            return Err(ConfigError::Invalid(
+                "limits.max_inflight",
+                "a zero window admits no commands at all".to_owned(),
+            ));
+        }
+        if self.limits.antireplay_seen_max == 0 {
+            return Err(ConfigError::Invalid(
+                "limits.antireplay_seen_max",
+                "a zero seen-set refuses every signed command (WIRE.md §5.5 is \
+                 fail-closed)"
+                    .to_owned(),
+            ));
+        }
+        if self.limits.max_connections == 0 {
+            return Err(ConfigError::Invalid(
+                "limits.max_connections",
+                "a relay that accepts no connections is not a relay".to_owned(),
+            ));
+        }
+        if self.commit.max_batch == 0 {
+            return Err(ConfigError::Invalid(
+                "commit.max_batch",
+                "a zero batch commits nothing".to_owned(),
+            ));
+        }
+        if self.limits.max_outbound_queue == 0 {
+            return Err(ConfigError::Invalid(
+                "limits.max_outbound_queue",
+                "a zero outbound queue cannot carry a response".to_owned(),
+            ));
+        }
+        if self.queues.expiry_tick_seconds == 0 {
+            return Err(ConfigError::Invalid(
+                "queues.expiry_tick_seconds",
+                "the TTL sweep needs a period".to_owned(),
+            ));
+        }
+
+        // §7.7 and §11.3 step 5. A relay claiming more than 30 days is claiming
+        // a policy the architecture forbids, and a conforming client refuses it
+        // — so refusing to start is strictly kinder than starting and being
+        // refused by everyone.
+        if self.queues.max_message_ttl_seconds > f2z_codec::MAX_MESSAGE_TTL_SECONDS {
+            return Err(ConfigError::Invalid(
+                "queues.max_message_ttl_seconds",
+                "WIRE.md §7.7 caps the message TTL at 2592000 seconds (30 days)".to_owned(),
+            ));
+        }
+
+        let buckets =
+            f2z_codec::padding::PaddingBuckets::new(self.padding.sizes.clone()).map_err(|_| {
+                ConfigError::Invalid(
+                    "padding.sizes",
+                    "must be a non-empty, strictly ascending set of non-zero sizes".to_owned(),
+                )
+            })?;
+        if u64::from(self.limits.max_frame_bytes) < u64::from(buckets.largest()) {
+            return Err(ConfigError::Invalid(
+                "limits.max_frame_bytes",
+                "is below this relay's own largest padding bucket, so the set it \
+                 publishes is one no client can use"
+                    .to_owned(),
+            ));
+        }
+        if !buckets.is_plausible() {
+            return Err(ConfigError::Invalid(
+                "padding.sizes",
+                "§9: a set with more than 16 entries, or a spacing below 512 bytes, \
+                 is indistinguishable from an attempt to let a colluding client \
+                 leak length through size, and a conforming client refuses it"
+                    .to_owned(),
+            ));
+        }
+
+        if matches!(mode, CreationMode::Pow) && self.antiabuse.queue_creation_pow_bits == 0 {
+            return Err(ConfigError::Invalid(
+                "antiabuse.queue_creation_pow_bits",
+                "pow mode with zero difficulty is a gate with nothing behind it".to_owned(),
+            ));
+        }
+        // §12.3 lists proof of work as one of four caps a relay MUST enforce.
+        if self.antiabuse.contact_queues_enabled && self.antiabuse.contact_append_pow_bits == 0 {
+            return Err(ConfigError::Invalid(
+                "antiabuse.contact_append_pow_bits",
+                "§12.3: offering contact queues without proof of work is offering \
+                 an unsigned, unmetered write endpoint to the whole internet"
+                    .to_owned(),
+            ));
+        }
+        if self.antiabuse.queue_creation_pow_bits > 64
+            || self.antiabuse.contact_append_pow_bits > 64
+        {
+            return Err(ConfigError::Invalid(
+                "antiabuse.queue_creation_pow_bits",
+                "a difficulty above 64 bits is not solvable by any client".to_owned(),
+            ));
+        }
+        if self.antiabuse.max_challenges == 0 {
+            return Err(ConfigError::Invalid(
+                "antiabuse.max_challenges",
+                "a zero challenge table refuses every stamp the relay demands".to_owned(),
+            ));
+        }
+
+        for (key, text) in [
+            ("operator.name", &self.operator.name),
+            ("operator.contact", &self.operator.contact),
+            ("operator.abuse_contact", &self.operator.abuse_contact),
+            ("operator.jurisdiction", &self.operator.jurisdiction),
+            ("operator.policy_url", &self.operator.policy_url),
+            (
+                "provenance.source_repo_url",
+                &self.provenance.source_repo_url,
+            ),
+            ("provenance.source_commit", &self.provenance.source_commit),
+            ("provenance.build_digest", &self.provenance.build_digest),
+        ] {
+            if text.len() > 255 {
+                return Err(ConfigError::Invalid(
+                    key,
+                    "§11.1 gives this field a one-byte length prefix; 255 bytes is \
+                     the ceiling"
+                        .to_owned(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// The configuration as TOML, with key material redacted.
+    ///
+    /// What `--print-config` prints. Re-parsing the output yields the same
+    /// configuration **except** for `identity.seed`, which is the point: the
+    /// output is for a bug report and a bug report is a place secrets go to
+    /// live forever.
+    #[must_use]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "a printer with one line per key; the alternative is a macro \
+                  that makes the redaction harder to see"
+    )]
+    pub fn to_redacted_toml(&self) -> String {
+        let mut out = String::with_capacity(2048);
+        let _ = writeln!(out, "[listen]");
+        let _ = writeln!(out, "address = {:?}", self.listen.address);
+        let _ = writeln!(out, "insecure = {}", self.listen.insecure);
+        let _ = writeln!(out, "tls_cert = {:?}", self.listen.tls_cert);
+        let _ = writeln!(out, "tls_key = {:?}", self.listen.tls_key);
+        let _ = writeln!(
+            out,
+            "handshake_timeout_ms = {}",
+            self.listen.handshake_timeout_ms
+        );
+        let _ = writeln!(
+            out,
+            "ping_interval_seconds = {}",
+            self.listen.ping_interval_seconds
+        );
+        let _ = writeln!(
+            out,
+            "missed_pongs_before_close = {}",
+            self.listen.missed_pongs_before_close
+        );
+
+        let _ = writeln!(out, "\n[admin]");
+        let _ = writeln!(out, "enabled = {}", self.admin.enabled);
+        let _ = writeln!(out, "address = {:?}", self.admin.address);
+
+        let _ = writeln!(out, "\n[store]");
+        let _ = writeln!(out, "backend = {:?}", self.store.backend);
+        let _ = writeln!(out, "path = {:?}", self.store.path);
+
+        let _ = writeln!(out, "\n[identity]");
+        let _ = writeln!(out, "path = {:?}", self.identity.path);
+        let _ = writeln!(out, "generate = {}", self.identity.generate);
+        // The one secret in the file. Never printed, present or absent.
+        let _ = writeln!(
+            out,
+            "seed = {:?}",
+            if self.identity.seed.is_empty() {
+                "<unset>"
+            } else {
+                "<redacted>"
+            }
+        );
+
+        let _ = writeln!(out, "\n[commit]");
+        let _ = writeln!(out, "window_ms = {}", self.commit.window_ms);
+        let _ = writeln!(out, "max_batch = {}", self.commit.max_batch);
+
+        let _ = writeln!(out, "\n[limits]");
+        let _ = writeln!(out, "max_frame_bytes = {}", self.limits.max_frame_bytes);
+        let _ = writeln!(out, "max_inflight = {}", self.limits.max_inflight);
+        let _ = writeln!(out, "clock_skew_ms = {}", self.limits.clock_skew_ms);
+        let _ = writeln!(
+            out,
+            "antireplay_window_ms = {}",
+            self.limits.antireplay_window_ms
+        );
+        let _ = writeln!(
+            out,
+            "antireplay_seen_max = {}",
+            self.limits.antireplay_seen_max
+        );
+        let _ = writeln!(out, "max_connections = {}", self.limits.max_connections);
+        let _ = writeln!(
+            out,
+            "max_connections_per_source = {}",
+            self.limits.max_connections_per_source
+        );
+        let _ = writeln!(
+            out,
+            "new_connections_per_source_per_second = {}",
+            self.limits.new_connections_per_source_per_second
+        );
+        let _ = writeln!(
+            out,
+            "commands_per_connection_per_second = {}",
+            self.limits.commands_per_connection_per_second
+        );
+        let _ = writeln!(
+            out,
+            "challenges_per_source_per_minute = {}",
+            self.limits.challenges_per_source_per_minute
+        );
+        let _ = writeln!(out, "max_queues = {}", self.limits.max_queues);
+        let _ = writeln!(
+            out,
+            "max_queue_messages = {}",
+            self.limits.max_queue_messages
+        );
+        let _ = writeln!(out, "max_queue_bytes = {}", self.limits.max_queue_bytes);
+        let _ = writeln!(
+            out,
+            "storage_high_water_bytes = {}",
+            self.limits.storage_high_water_bytes
+        );
+        let _ = writeln!(
+            out,
+            "max_outbound_queue = {}",
+            self.limits.max_outbound_queue
+        );
+
+        let _ = writeln!(out, "\n[queues]");
+        let _ = writeln!(
+            out,
+            "min_message_ttl_seconds = {}",
+            self.queues.min_message_ttl_seconds
+        );
+        let _ = writeln!(
+            out,
+            "max_message_ttl_seconds = {}",
+            self.queues.max_message_ttl_seconds
+        );
+        let _ = writeln!(
+            out,
+            "default_message_ttl_seconds = {}",
+            self.queues.default_message_ttl_seconds
+        );
+        let _ = writeln!(
+            out,
+            "min_idle_ttl_seconds = {}",
+            self.queues.min_idle_ttl_seconds
+        );
+        let _ = writeln!(
+            out,
+            "max_idle_ttl_seconds = {}",
+            self.queues.max_idle_ttl_seconds
+        );
+        let _ = writeln!(
+            out,
+            "default_idle_ttl_seconds = {}",
+            self.queues.default_idle_ttl_seconds
+        );
+        let _ = writeln!(
+            out,
+            "expiry_tick_seconds = {}",
+            self.queues.expiry_tick_seconds
+        );
+
+        let _ = writeln!(out, "\n[padding]");
+        let _ = writeln!(out, "sizes = {:?}", self.padding.sizes);
+        let _ = writeln!(out, "max_chunk_bytes = {}", self.padding.max_chunk_bytes);
+
+        let _ = writeln!(out, "\n[antiabuse]");
+        let _ = writeln!(
+            out,
+            "queue_creation_mode = {:?}",
+            self.antiabuse.queue_creation_mode
+        );
+        let _ = writeln!(
+            out,
+            "queue_creation_pow_bits = {}",
+            self.antiabuse.queue_creation_pow_bits
+        );
+        let _ = writeln!(
+            out,
+            "contact_append_pow_bits = {}",
+            self.antiabuse.contact_append_pow_bits
+        );
+        let _ = writeln!(
+            out,
+            "challenge_ttl_ms = {}",
+            self.antiabuse.challenge_ttl_ms
+        );
+        let _ = writeln!(out, "max_challenges = {}", self.antiabuse.max_challenges);
+        let _ = writeln!(
+            out,
+            "contact_queues_enabled = {}",
+            self.antiabuse.contact_queues_enabled
+        );
+        let _ = writeln!(
+            out,
+            "contact_max_pending = {}",
+            self.antiabuse.contact_max_pending
+        );
+        let _ = writeln!(
+            out,
+            "contact_max_bytes = {}",
+            self.antiabuse.contact_max_bytes
+        );
+        let _ = writeln!(
+            out,
+            "per_source_limits = {}",
+            self.antiabuse.per_source_limits
+        );
+
+        let _ = writeln!(out, "\n[operator]");
+        let _ = writeln!(out, "name = {:?}", self.operator.name);
+        let _ = writeln!(out, "contact = {:?}", self.operator.contact);
+        let _ = writeln!(out, "abuse_contact = {:?}", self.operator.abuse_contact);
+        let _ = writeln!(out, "jurisdiction = {:?}", self.operator.jurisdiction);
+        let _ = writeln!(out, "policy_url = {:?}", self.operator.policy_url);
+
+        let _ = writeln!(out, "\n[provenance]");
+        let _ = writeln!(
+            out,
+            "source_repo_url = {:?}",
+            self.provenance.source_repo_url
+        );
+        let _ = writeln!(out, "source_commit = {:?}", self.provenance.source_commit);
+        let _ = writeln!(out, "build_digest = {:?}", self.provenance.build_digest);
+
+        let _ = writeln!(out, "\n[log]");
+        let _ = writeln!(out, "level = {:?}", self.log.level);
+        out
+    }
+}
+
+/// Whether an address is one §2.3 lets a relay serve without TLS.
+#[must_use]
+pub fn is_loopback(addr: &SocketAddr) -> bool {
+    match addr.ip() {
+        std::net::IpAddr::V4(v4) => v4.is_loopback(),
+        std::net::IpAddr::V6(v6) => v6.is_loopback(),
+    }
+}
+
+/// Decode a 64-character hex seed.
+#[must_use]
+pub fn decode_seed(text: &str) -> Option<[u8; 32]> {
+    if text.len() != 64 {
+        return None;
+    }
+    let bytes = text.as_bytes();
+    let mut seed = [0u8; 32];
+    for index in 0usize..32 {
+        let high = nibble(*bytes.get(index.checked_mul(2)?)?)?;
+        let low = nibble(*bytes.get(index.checked_mul(2)?.checked_add(1)?)?)?;
+        *seed.get_mut(index)? = (high << 4) | low;
+    }
+    Some(seed)
+}
+
+const fn nibble(byte: u8) -> Option<u8> {
+    // `checked_*` rather than `-` and `+`: the workspace denies the arithmetic
+    // families outright, because this crate's parser is the unauthenticated
+    // attack surface and a panic there is a remote denial of service. The range
+    // patterns already make every subtraction safe; saying so with the checked
+    // form is what makes that reviewable rather than argued.
+    match byte {
+        b'0'..=b'9' => byte.checked_sub(b'0'),
+        b'a'..=b'f' => match byte.checked_sub(b'a') {
+            Some(offset) => offset.checked_add(10),
+            None => None,
+        },
+        b'A'..=b'F' => match byte.checked_sub(b'A') {
+            Some(offset) => offset.checked_add(10),
+            None => None,
+        },
+        _ => None,
+    }
+}
+
+fn boolean(key: &'static str, value: &str) -> Result<bool> {
+    match value {
+        "true" | "1" | "yes" | "on" => Ok(true),
+        "false" | "0" | "no" | "off" => Ok(false),
+        other => Err(ConfigError::Invalid(
+            key,
+            format!("{other} is not a boolean"),
+        )),
+    }
+}
+
+fn number<T: std::str::FromStr>(key: &'static str, value: &str) -> Result<T> {
+    value
+        .parse()
+        .map_err(|_| ConfigError::Invalid(key, format!("{value} is not a number this field takes")))
+}
+
+fn number_list(key: &'static str, value: &str) -> Result<Vec<u32>> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| number(key, part))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_defaults_pass_their_own_check() {
+        assert!(Config::default().check().is_ok());
+    }
+
+    #[test]
+    fn the_default_creation_mode_is_proof_of_work() {
+        assert_eq!(
+            Config::default().creation_mode().unwrap(),
+            CreationMode::Pow
+        );
+    }
+
+    #[test]
+    fn a_short_antireplay_window_is_refused_rather_than_published() {
+        // Issue #586: the specification as written *permits* this document, and
+        // a client that checks refuses it. This relay declines to be that
+        // relay, which is why the corresponding conformance vector is
+        // unsatisfiable here by construction.
+        let mut config = Config::default();
+        config.limits.antireplay_window_ms = config.limits.clock_skew_ms;
+        let error = config.check().unwrap_err();
+        assert!(format!("{error}").contains("antireplay_window_ms"));
+    }
+
+    #[test]
+    fn a_public_bind_without_tls_needs_the_override() {
+        let mut config = Config::default();
+        config.listen.address = "0.0.0.0:8443".to_owned();
+        assert!(config.check().is_err());
+        config.listen.insecure = true;
+        assert!(config.check().is_ok());
+    }
+
+    #[test]
+    fn tls_and_the_insecure_override_are_mutually_exclusive() {
+        let mut config = Config::default();
+        config.listen.address = "0.0.0.0:8443".to_owned();
+        config.listen.tls_cert = "cert.pem".to_owned();
+        config.listen.tls_key = "key.pem".to_owned();
+        assert!(config.check().is_ok());
+        config.listen.insecure = true;
+        assert!(config.check().is_err());
+    }
+
+    #[test]
+    fn the_admin_listener_may_not_leave_the_host() {
+        let mut config = Config::default();
+        config.admin.address = "0.0.0.0:9101".to_owned();
+        let error = config.check().unwrap_err();
+        assert!(format!("{error}").contains("loopback-only"));
+    }
+
+    #[test]
+    fn token_mode_is_refused_because_it_has_no_wire_shape() {
+        let mut config = Config::default();
+        config.antiabuse.queue_creation_mode = "token".to_owned();
+        let error = config.check().unwrap_err();
+        assert!(format!("{error}").contains("no wire representation"));
+    }
+
+    #[test]
+    fn a_ttl_above_the_architectures_ceiling_is_refused() {
+        let mut config = Config::default();
+        config.queues.max_message_ttl_seconds = f2z_codec::MAX_MESSAGE_TTL_SECONDS + 1;
+        assert!(config.check().is_err());
+    }
+
+    #[test]
+    fn contact_queues_without_proof_of_work_are_refused() {
+        let mut config = Config::default();
+        config.antiabuse.contact_append_pow_bits = 0;
+        assert!(config.check().is_err());
+        config.antiabuse.contact_queues_enabled = false;
+        assert!(config.check().is_ok());
+    }
+
+    #[test]
+    fn an_unknown_file_key_is_an_error_rather_than_a_default() {
+        let error = Config::from_toml_str("[limits]\nmax_queue_byes = 10\n").unwrap_err();
+        assert!(format!("{error}").contains("max_queue_byes"));
+    }
+
+    #[test]
+    fn a_file_sets_only_what_it_names() {
+        let config = Config::from_toml_str("[limits]\nmax_inflight = 8\n").unwrap();
+        assert_eq!(config.limits.max_inflight, 8);
+        assert_eq!(
+            config.limits.max_frame_bytes,
+            Limits::default().max_frame_bytes
+        );
+    }
+
+    #[test]
+    fn the_environment_spells_every_key_the_file_does() {
+        let mut config = Config::default();
+        config
+            .apply_env([
+                ("F2Z_RELAY_LIMITS_MAX_INFLIGHT".to_owned(), "4".to_owned()),
+                ("F2Z_RELAY_PADDING_SIZES".to_owned(), "512,1024".to_owned()),
+                ("F2Z_RELAY_ADMIN_ENABLED".to_owned(), "false".to_owned()),
+                ("PATH".to_owned(), "/ignored".to_owned()),
+            ])
+            .unwrap();
+        assert_eq!(config.limits.max_inflight, 4);
+        assert_eq!(config.padding.sizes, vec![512, 1024]);
+        assert!(!config.admin.enabled);
+    }
+
+    #[test]
+    fn an_unknown_environment_key_is_named_rather_than_ignored() {
+        let mut config = Config::default();
+        let error = config
+            .apply_env([("F2Z_RELAY_LIMITS_MAX_INFLITE".to_owned(), "4".to_owned())])
+            .unwrap_err();
+        assert!(format!("{error}").contains("LIMITS_MAX_INFLITE"));
+    }
+
+    #[test]
+    fn print_config_never_prints_the_seed() {
+        let mut config = Config::default();
+        config.identity.seed = "ab".repeat(32);
+        let printed = config.to_redacted_toml();
+        assert!(printed.contains("<redacted>"));
+        assert!(!printed.contains("abab"));
+        // And the debug rendering does not leak it either, which matters
+        // because a Config lands in a startup error message.
+        assert!(!format!("{config:?}").contains("abab"));
+    }
+
+    #[test]
+    fn everything_print_config_prints_parses_back() {
+        let config = Config::default();
+        let round = Config::from_toml_str(&config.to_redacted_toml()).unwrap();
+        // Every field except the redacted one.
+        assert_eq!(round.limits, config.limits);
+        assert_eq!(round.queues, config.queues);
+        assert_eq!(round.antiabuse, config.antiabuse);
+        assert_eq!(round.padding, config.padding);
+    }
+
+    #[test]
+    fn a_seed_decodes_only_from_sixty_four_hex_characters() {
+        assert_eq!(decode_seed(&"00".repeat(32)), Some([0u8; 32]));
+        assert_eq!(decode_seed(&"ff".repeat(32)), Some([0xffu8; 32]));
+        assert_eq!(decode_seed("00"), None);
+        assert_eq!(decode_seed(&"zz".repeat(32)), None);
+    }
+
+    #[test]
+    fn two_ephemeral_ports_are_not_a_collision() {
+        let mut config = Config::default();
+        config.listen.address = "127.0.0.1:0".to_owned();
+        config.admin.address = "127.0.0.1:0".to_owned();
+        assert!(config.check().is_ok());
+        // A concrete shared address still is one.
+        config.listen.address = "127.0.0.1:9101".to_owned();
+        config.admin.address = "127.0.0.1:9101".to_owned();
+        assert!(config.check().is_err());
+    }
+
+    #[test]
+    fn an_implausible_padding_set_is_refused_at_startup() {
+        let mut config = Config::default();
+        config.padding.sizes = (1..=20u32).map(|n| n * 8).collect();
+        assert!(config.check().is_err());
+    }
+}

--- a/rs/crates/f2z-relay/src/connection.rs
+++ b/rs/crates/f2z-relay/src/connection.rs
@@ -1,0 +1,173 @@
+//! One connection, from accept to close (§2.4, §2.5, §1.3).
+//!
+//! # Why the writer is a separate task
+//!
+//! §4.3 says a relay *"MAY complete a cheap `PING` before an expensive `READ`
+//! issued earlier, and will"*, and §6.4 lets a push arrive at any moment. A loop
+//! that read a frame and wrote its answer before reading again could do neither:
+//! a push would have to wait for the next request, and a slow `APPEND` would
+//! hold up every response behind it. So frames leave through a bounded channel
+//! that one writer task drains, and the read loop never blocks on the socket's
+//! write half.
+//!
+//! The channel is **bounded** on purpose. §13.1 subjects a subscriber that
+//! cannot keep up to backpressure "not to unbounded server-side buffering"; a
+//! full channel drops the *push* ([`crate::subscriptions`]) and never the
+//! message, which is still in the queue for the reader's next `READ`.
+//!
+//! # The two deadlines
+//!
+//! - §2.5: the time between accept and a valid `HELLO` is capped
+//!   (`handshake_timeout_ms`, default 10 000) and the connection closes on
+//!   expiry. After `HELLO` there is no read deadline at all, because a
+//!   subscribed client on a quiet queue legitimately sends nothing for hours.
+//! - §2.4: the relay sends a Ping every `ws_ping_interval_seconds` and closes
+//!   after two consecutive missed Pongs. Server-driven rather than
+//!   client-driven, because the browser WebSocket API cannot send a Ping frame
+//!   at all — a client-side keepalive would be a second mechanism only one of
+//!   the two clients has.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{mpsc, watch};
+
+use crate::abuse::SourceKey;
+use crate::engine::Relay;
+use crate::outbound::Outbound;
+use crate::transport::{CLOSE_GOING_AWAY, Transport, TransportSink, WireMessage};
+
+/// Serve one connection until either end closes.
+pub async fn drive(
+    relay: Arc<Relay>,
+    transport: Transport,
+    binding: f2z_codec::types::ChannelBinding,
+    source: SourceKey,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    let (sink, mut stream) = transport.split();
+    let capacity = usize::try_from(relay.config().limits.max_outbound_queue).unwrap_or(256);
+    let (outbound_tx, outbound_rx) = mpsc::channel::<Outbound>(capacity.max(1));
+    let (closed_tx, mut closed_rx) = watch::channel(false);
+
+    let mut connection = relay.open_connection(outbound_tx.clone(), binding, source);
+    let writer = tokio::spawn(writer_task(sink, outbound_rx, closed_tx));
+
+    let handshake_timeout =
+        Duration::from_millis(u64::from(relay.config().listen.handshake_timeout_ms));
+    let ping_interval = Duration::from_secs(u64::from(
+        relay.config().listen.ping_interval_seconds.max(1),
+    ));
+    let missed_pongs_before_close = relay.config().listen.missed_pongs_before_close;
+    let mut missed_pongs = 0u32;
+    let mut ping = tokio::time::interval(ping_interval);
+    // An `interval`'s first tick fires immediately; a Ping before the client has
+    // even said HELLO is noise, not keepalive.
+    ping.tick().await;
+
+    loop {
+        let waiting_for_hello = !connection.hello_done;
+        let received = tokio::select! {
+            biased;
+            _ = closed_rx.changed() => break,
+            _ = shutdown.changed() => {
+                let _ = outbound_tx.send(Outbound::close(CLOSE_GOING_AWAY)).await;
+                break;
+            }
+            _ = ping.tick(), if !waiting_for_hello => {
+                missed_pongs = missed_pongs.saturating_add(1);
+                if missed_pongs > missed_pongs_before_close {
+                    let _ = outbound_tx.send(Outbound::close(CLOSE_GOING_AWAY)).await;
+                    break;
+                }
+                if outbound_tx.send(Outbound::ping()).await.is_err() {
+                    break;
+                }
+                continue;
+            }
+            message = read_with_deadline(&mut stream, waiting_for_hello, handshake_timeout) => message,
+        };
+
+        let message = match received {
+            Ok(Some(message)) => message,
+            // End of stream, a transport error, or §2.5's handshake deadline.
+            Ok(None) | Err(()) => break,
+        };
+
+        match message {
+            WireMessage::Binary(bytes) => {
+                let now = crate::now_ms();
+                let mut broken = false;
+                for outbound in relay.handle_binary(&mut connection, now, &bytes).await {
+                    if outbound_tx.send(outbound).await.is_err() {
+                        broken = true;
+                        break;
+                    }
+                }
+                if broken {
+                    break;
+                }
+            }
+            WireMessage::Text => {
+                // §4.2, and nothing else: no decode attempt, no UTF-8
+                // validation of our own, no treating it as an accidental binary
+                // frame. The transport does not even hand the bytes over.
+                for outbound in Relay::handle_text() {
+                    let _ = outbound_tx.send(outbound).await;
+                }
+                break;
+            }
+            WireMessage::Ping(payload) => {
+                let _ = outbound_tx.send(Outbound::pong(payload)).await;
+            }
+            WireMessage::Pong(_) => missed_pongs = 0,
+            WireMessage::Close(_) => break,
+        }
+    }
+
+    relay.close_connection(&connection);
+    drop(outbound_tx);
+    let _ = writer.await;
+}
+
+async fn read_with_deadline(
+    stream: &mut Box<dyn crate::transport::TransportStream>,
+    waiting_for_hello: bool,
+    timeout: Duration,
+) -> Result<Option<WireMessage>, ()> {
+    let read = stream.recv();
+    if waiting_for_hello {
+        match tokio::time::timeout(timeout, read).await {
+            Ok(Ok(message)) => Ok(message),
+            Ok(Err(_)) | Err(_) => Err(()),
+        }
+    } else {
+        read.await.map_err(|_| ())
+    }
+}
+
+/// The only place frames are put on the wire.
+///
+/// §1.3's "send the response, then close" is this function's `close_after`
+/// branch, and it is the only close path for a fatal error — so the ordering
+/// cannot be got wrong in one command handler and right in another.
+async fn writer_task(
+    mut sink: Box<dyn TransportSink>,
+    mut outbound: mpsc::Receiver<Outbound>,
+    closed: watch::Sender<bool>,
+) {
+    while let Some(frame) = outbound.recv().await {
+        if let Some(message) = frame.message
+            && sink.send(message).await.is_err()
+        {
+            break;
+        }
+        if let Some(status) = frame.close_after {
+            let _ = sink.close(status).await;
+            let _ = closed.send(true);
+            return;
+        }
+    }
+    let _ = sink.close(crate::transport::CLOSE_NORMAL).await;
+    let _ = closed.send(true);
+}

--- a/rs/crates/f2z-relay/src/engine.rs
+++ b/rs/crates/f2z-relay/src/engine.rs
@@ -1,0 +1,1428 @@
+//! The relay: one frame in, zero or more frames out.
+//!
+//! # What is reused rather than rewritten
+//!
+//! Almost everything. `f2z-codec` owns re-encode equality (§3.3) and the framing
+//! (§4); `f2z-relay-proto` owns §5.1's verification order, §5.5's anti-replay,
+//! §7 and §8's queue and acknowledgement rules and §11's capability document;
+//! `f2z-relay-store` owns authorization-inside-the-transaction, quota admission
+//! and the acknowledgement watermark. A relay that re-derived any of those would
+//! be a second opinion about the protocol, and a second opinion is how ciphertext
+//! gets deleted before it is read.
+//!
+//! What is genuinely decided here is the part those crates leave to a server:
+//! the connection lifecycle of §2.5, the in-flight window of §4.3, which code
+//! answers which refusal, when a push is emitted, and §13.1's layering.
+//!
+//! # The refusal codes, and the one rule behind most of them
+//!
+//! §6.3: **every send-side refusal that would distinguish queue state collapses
+//! to `ERR_UNAVAILABLE`.** Absent, deleted, expired, full-by-messages,
+//! full-by-bytes, unbound, wrong key, backpressure — one code. §10's table
+//! assigns "absent" to code 10 and therefore contradicts §6.3;
+//! [#586](https://github.com/free2z/zuu/issues/586) tracks it, #583 resolved it
+//! in §6.3's favour, `f2z-relay-testkit` did the same, and so does this.
+//!
+//! On the receive side the mirror rule is §10's existence-oracle rule: "no such
+//! queue" and "exists, but your key does not authorize it" are one code, and the
+//! absent path performs a dummy Ed25519 verification first so the dominant CPU
+//! cost is present in both. §10 is explicit that this narrows the timing channel
+//! rather than closing it, and so is this implementation.
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+
+use f2z_codec::canonical::{Canonical, decode_canonical};
+use f2z_codec::commands::{
+    AckRequest, AckResponse, AppendRequest, ChallengePurpose, ChallengeRequest, ChallengeResponse,
+    Command, ContactAppendRequest, CreateContactQueueRequest, CreateContactQueueResponse,
+    CreateQueueRequest, CreateQueueResponse, HelloRequest, HelloResponse, QueuedMessage,
+    ReadRequest, ReadResponse, SubscribeResponse,
+};
+use f2z_codec::frame::{FramePayload, RelayFrame, Request, Response};
+use f2z_codec::padding::PaddingBuckets;
+use f2z_codec::pow::{PowParams, PowStamp};
+use f2z_codec::transcript::TranscriptBuilder;
+use f2z_codec::types::{ChannelBinding, Payload, QueueAddress, RelayId};
+use f2z_codec::{ErrorCode, PROTOCOL_VERSION};
+use f2z_relay_proto::capabilities::{ChannelBindingMode, TransportSecurity};
+use f2z_relay_proto::command::{CommandVerifier, Empty, RelayCommand, Verified, ops};
+use f2z_relay_proto::hello::{RelayAnnouncement, hello_response};
+use f2z_relay_proto::key::{SigningKey, dummy_verify};
+use f2z_relay_proto::queue::{AppendQuota, QueueKind, TtlPolicy};
+use f2z_relay_proto::replay::{SeenSet, TimestampWindow};
+use f2z_relay_proto::{ProtoError, capabilities};
+use f2z_relay_store::{QueueSpec, RelayStore, SendAuth, StoreError};
+
+use crate::abuse::{AbuseGuard, CommandRate, SourceKey};
+use crate::caps::Published;
+use crate::challenge::Challenges;
+use crate::commit::CommitWriter;
+use crate::config::{Config, CreationMode};
+use crate::metrics::Metrics;
+use crate::outbound::Outbound;
+use crate::subscriptions::{QUEUE_EVENT_DELETED, QUEUE_EVENT_QUOTA, Subscriptions};
+use crate::transport::{CLOSE_PROTOCOL_ERROR, CLOSE_UNSUPPORTED_DATA};
+
+/// How many times §7.1's "draw again on collision" is attempted before the
+/// relay gives up and answers `ERR_INTERNAL`.
+///
+/// §7.1 says a relay "can simply retry on collision, which it will never have to
+/// do at 32 bytes". A bound is still needed, because the *other* thing this loop
+/// catches is a broken CSPRNG handing out a constant — and an unbounded retry
+/// against one is a hang rather than an alert.
+const ADDRESS_DRAWS: usize = 8;
+
+/// Room reserved inside `max_frame_bytes` for a `READ` response's own framing:
+/// the frame header, the response header, the vector prefixes and one
+/// `QueuedMessage` header per message.
+const READ_FRAME_OVERHEAD: u32 = 4096;
+
+/// One relay, shared by every connection it serves.
+pub struct Relay {
+    config: Config,
+    identity: SigningKey,
+    relay_id: RelayId,
+    published: Published,
+    padding: PaddingBuckets,
+    ttl: TtlPolicy,
+    quota: AppendQuota,
+    contact_quota: AppendQuota,
+    creation_mode: CreationMode,
+    store: Arc<dyn RelayStore + Send + Sync>,
+    writer: CommitWriter,
+    seen: Mutex<SeenSet>,
+    challenges: Mutex<Challenges>,
+    subscriptions: Arc<Subscriptions>,
+    abuse: Arc<AbuseGuard>,
+    metrics: Arc<Metrics>,
+    next_connection: std::sync::atomic::AtomicU64,
+}
+
+impl std::fmt::Debug for Relay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Relay")
+            .field("relay_id", &self.relay_id)
+            .field("durability", &self.writer.durability())
+            .finish_non_exhaustive()
+    }
+}
+
+/// One connection's state.
+///
+/// §6.2: *"a subscription is scoped to the connection and dies with it"*, and
+/// §4.3's in-flight window is per connection too. Everything else a relay knows
+/// is shared.
+#[derive(Debug)]
+pub struct Connection {
+    /// Identifier, so a subscription can be found and dropped.
+    pub id: u64,
+    /// Whether `HELLO` has completed (§2.5 step 2).
+    pub hello_done: bool,
+    /// §4.3's outstanding `request_id`s.
+    ///
+    /// Shared, because an `APPEND` is answered from a spawned task: §4.3
+    /// requires a client to be able to fetch, acknowledge and append
+    /// concurrently on one connection "without head-of-line blocking", and a
+    /// read loop that awaited each commit before reading the next frame would
+    /// deny exactly that.
+    pub inflight: Arc<Mutex<BTreeSet<u32>>>,
+    /// The receive addresses this connection is subscribed to.
+    pub subscriptions: BTreeSet<QueueAddress>,
+    /// Where responses and pushes go.
+    pub pushes: tokio::sync::mpsc::Sender<Outbound>,
+    /// This connection's transcript builder: the relay's own `relay_id` and
+    /// **this session's** channel binding, never the frame's (§5.2, §5.3).
+    pub transcripts: TranscriptBuilder,
+    /// §13.1 layer 1's counter key. Not an address — see [`SourceKey`].
+    pub source: SourceKey,
+    /// §13.1 layer 1's per-connection command rate.
+    pub rate: CommandRate,
+}
+
+impl Relay {
+    /// Assemble a relay.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "every collaborator is shared with a task outside this type; \
+                  hiding them in a builder would hide what the relay owns"
+    )]
+    #[must_use]
+    pub fn new(
+        config: Config,
+        identity: SigningKey,
+        published: Published,
+        padding: PaddingBuckets,
+        store: Arc<dyn RelayStore + Send + Sync>,
+        writer: CommitWriter,
+        subscriptions: Arc<Subscriptions>,
+        abuse: Arc<AbuseGuard>,
+        metrics: Arc<Metrics>,
+    ) -> Self {
+        let relay_id = f2z_codec::hash::relay_id(&identity.public_key());
+        let ttl = capabilities::ttl_policy(published.capabilities());
+        let quota = AppendQuota {
+            max_messages: u64::from(config.limits.max_queue_messages),
+            max_bytes: config.limits.max_queue_bytes,
+        };
+        let contact_quota = AppendQuota {
+            max_messages: u64::from(config.antiabuse.contact_max_pending),
+            max_bytes: config.antiabuse.contact_max_bytes,
+        };
+        let creation_mode = config.creation_mode().unwrap_or(CreationMode::Pow);
+        let seen = SeenSet::new(
+            u64::from(config.limits.antireplay_window_ms),
+            usize::try_from(config.limits.antireplay_seen_max).unwrap_or(usize::MAX),
+        );
+        let challenges =
+            Challenges::new(usize::try_from(config.antiabuse.max_challenges).unwrap_or(usize::MAX));
+        Self {
+            config,
+            identity,
+            relay_id,
+            published,
+            padding,
+            ttl,
+            quota,
+            contact_quota,
+            creation_mode,
+            store,
+            writer,
+            seen: Mutex::new(seen),
+            challenges: Mutex::new(challenges),
+            subscriptions,
+            abuse,
+            metrics,
+            next_connection: std::sync::atomic::AtomicU64::new(1),
+        }
+    }
+
+    /// §5.2's identity binding.
+    #[must_use]
+    pub const fn relay_id(&self) -> RelayId {
+        self.relay_id
+    }
+
+    /// The published policy, signed.
+    #[must_use]
+    pub const fn published(&self) -> &Published {
+        &self.published
+    }
+
+    /// The relay's configuration.
+    #[must_use]
+    pub const fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// The subscription table.
+    #[must_use]
+    pub fn subscriptions(&self) -> &Arc<Subscriptions> {
+        &self.subscriptions
+    }
+
+    /// The store, for the expiry tick and the admin listener.
+    #[must_use]
+    pub fn store(&self) -> &Arc<dyn RelayStore + Send + Sync> {
+        &self.store
+    }
+
+    /// The counters.
+    #[must_use]
+    pub fn metrics(&self) -> &Arc<Metrics> {
+        &self.metrics
+    }
+
+    /// The anti-abuse state.
+    #[must_use]
+    pub fn abuse(&self) -> &Arc<AbuseGuard> {
+        &self.abuse
+    }
+
+    /// Age out anti-replay entries and expired challenges. Called by the tick.
+    ///
+    /// Returns `(seen_set_entries, challenges_outstanding)`.
+    pub fn sweep_memory(&self, now_ms: u64) -> (usize, usize) {
+        let entries = {
+            let mut seen = self.lock_seen();
+            seen.expire(now_ms);
+            seen.len()
+        };
+        let outstanding = {
+            let mut challenges = self.lock_challenges();
+            challenges.expire(now_ms);
+            challenges.len()
+        };
+        (entries, outstanding)
+    }
+
+    /// Open a connection.
+    pub fn open_connection(
+        &self,
+        pushes: tokio::sync::mpsc::Sender<Outbound>,
+        binding: ChannelBinding,
+        source: SourceKey,
+    ) -> Connection {
+        let id = self
+            .next_connection
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Connection {
+            id,
+            hello_done: false,
+            inflight: Arc::new(Mutex::new(BTreeSet::new())),
+            subscriptions: BTreeSet::new(),
+            pushes,
+            transcripts: TranscriptBuilder::new(PROTOCOL_VERSION, self.relay_id, binding),
+            source,
+            rate: CommandRate::new(self.config.limits.commands_per_connection_per_second),
+        }
+    }
+
+    /// Release a connection's subscriptions (§6.2).
+    pub fn close_connection(&self, connection: &Connection) {
+        let addresses: Vec<QueueAddress> = connection.subscriptions.iter().copied().collect();
+        self.subscriptions
+            .drop_connection(connection.id, &addresses);
+    }
+
+    // ---------------------------------------------------------------------
+    // The frame path.
+    // ---------------------------------------------------------------------
+
+    /// §4.2: a text frame is a fatal `ERR_FRAME_TYPE`, closed with status 1003.
+    ///
+    /// The relay MUST NOT attempt to decode it, MUST NOT attempt UTF-8
+    /// validation beyond what the WebSocket layer already did, and MUST NOT
+    /// treat it as an accidental binary frame. All three are the absence of code
+    /// here — `WireMessage::Text` does not even carry the bytes.
+    #[must_use]
+    pub fn handle_text() -> Vec<Outbound> {
+        vec![Outbound::close(CLOSE_UNSUPPORTED_DATA)]
+    }
+
+    /// Handle one binary frame (§4.1).
+    ///
+    /// Returns the frames to write **now**. An `APPEND` returns nothing here
+    /// and answers from a spawned task once its commit is durable, which is
+    /// what makes §4.3's out-of-order, non-blocking pipeline real rather than
+    /// stated.
+    pub async fn handle_binary(
+        self: &Arc<Self>,
+        connection: &mut Connection,
+        now_ms: u64,
+        bytes: &[u8],
+    ) -> Vec<Outbound> {
+        Metrics::inc(&self.metrics.frames_received);
+        let caps = self.published.capabilities();
+
+        // §4.1: a frame over `max_frame_bytes` is a fatal `ERR_MALFORMED`, and
+        // the relay MUST NOT buffer the remainder to produce a tidy error.
+        if bytes.len() > caps.max_frame_bytes as usize {
+            return self.fatal(recover_request_id(bytes), ErrorCode::Malformed);
+        }
+
+        // §3.3 on the frame: decode, re-encode, byte-compare — and the
+        // re-encoded bytes are what any signature covers.
+        let Ok(frame) = decode_canonical::<RelayFrame>(bytes) else {
+            return self.fatal(recover_request_id(bytes), ErrorCode::Malformed);
+        };
+        let frame = frame.into_value();
+        if frame.validate().is_err() {
+            return self.fatal(recover_request_id(bytes), ErrorCode::Malformed);
+        }
+        let request_id = frame.request_id;
+        let FramePayload::Request(request) = &frame.payload else {
+            // A client that sends a response or a push is speaking the wrong
+            // half of the protocol. §10 has no code for it; `ERR_MALFORMED` is
+            // the reading, and it is fatal, which is right for a frame no
+            // conforming client emits.
+            return self.fatal(request_id, ErrorCode::Malformed);
+        };
+
+        let command = request.command();
+
+        // §2.5 step 2: `HELLO` MUST be the first frame.
+        if !connection.hello_done && command != Some(Command::Hello) {
+            return self.fatal(request_id, ErrorCode::UnsupportedVersion);
+        }
+        // §3.5: "version negotiation happens once, in HELLO, and applies to the
+        // whole connection." A second HELLO is a renegotiation attempt and gets
+        // the same code a version failure does. An ambiguity call: §10 does not
+        // name this case, and this is the reading `f2z-relay-testkit` takes.
+        if connection.hello_done && command == Some(Command::Hello) {
+            return self.fatal(request_id, ErrorCode::UnsupportedVersion);
+        }
+
+        // §4.3. A duplicate in-flight id is a fatal `ERR_MALFORMED`; exceeding
+        // the window is a fatal `ERR_TOO_MANY_INFLIGHT`. Both bounds exist so a
+        // single connection cannot make the relay allocate unbounded
+        // per-request state before any quota check has run.
+        {
+            let mut inflight = lock_inflight(&connection.inflight);
+            if inflight.contains(&request_id) {
+                drop(inflight);
+                return self.fatal(request_id, ErrorCode::Malformed);
+            }
+            if inflight.len() >= usize::from(caps.max_inflight) {
+                drop(inflight);
+                return self.fatal(request_id, ErrorCode::TooManyInflight);
+            }
+            inflight.insert(request_id);
+        }
+
+        // §13.1 layer 1's per-connection command rate. Taken once, before the
+        // fork below, so a deferred append pays for itself exactly like an
+        // inline command does.
+        let allowed = connection.rate.take(now_ms);
+
+        // The two commands that reach the disk are answered off the read loop.
+        // Everything else is a lookup or an in-memory update and is answered
+        // inline, where it needs no task and no clone.
+        if allowed
+            && let Some(deferred) =
+                command.filter(|code| matches!(code, Command::Append | Command::ContactAppend))
+        {
+            self.defer(connection, now_ms, request_id, deferred, request.clone());
+            return Vec::new();
+        }
+
+        let outcome = if allowed {
+            match command {
+                Some(command) => {
+                    self.dispatch(connection, now_ms, request_id, command, request)
+                        .await
+                }
+                // §3.5: an unknown command code is a *non-fatal*
+                // `ERR_UNKNOWN_COMMAND`. The framing was well-formed, so the
+                // connection survives.
+                None => Err(ProtoError::Wire(ErrorCode::UnknownCommand)),
+            }
+        } else {
+            // Non-fatal: a client that slows down is welcome back.
+            Err(ProtoError::Wire(ErrorCode::RateLimited))
+        };
+
+        lock_inflight(&connection.inflight).remove(&request_id);
+
+        let (response, fatal) = match outcome {
+            Ok(body) => {
+                Metrics::inc(&self.metrics.commands_ok);
+                (
+                    Response::ok(body).unwrap_or_else(|_| Response::error(ErrorCode::Internal)),
+                    false,
+                )
+            }
+            Err(error) => {
+                Metrics::inc(&self.metrics.commands_refused);
+                let code = error.wire_code().unwrap_or(ErrorCode::Internal);
+                (Response::error(code), code.is_fatal())
+            }
+        };
+
+        let close = if fatal {
+            Some(CLOSE_PROTOCOL_ERROR)
+        } else {
+            None
+        };
+        match Outbound::response(request_id, response) {
+            Some(mut outbound) => {
+                outbound.close_after = close;
+                vec![outbound]
+            }
+            None => self.fatal(request_id, ErrorCode::Internal),
+        }
+    }
+
+    fn fatal(&self, request_id: u32, code: ErrorCode) -> Vec<Outbound> {
+        Metrics::inc(&self.metrics.commands_refused);
+        // A frame whose `request_id` could not be recovered has no response a
+        // conforming relay can build — §4.3 forbids a zero id on a response —
+        // so the connection simply closes. §1.3 says "send the response, then
+        // close" and does not say what to send when the id is unreadable; this
+        // is the ambiguity call, and it matches `f2z-relay-testkit`'s.
+        if request_id == 0 {
+            return vec![Outbound::close(CLOSE_PROTOCOL_ERROR)];
+        }
+        Outbound::fatal(request_id, code, CLOSE_PROTOCOL_ERROR)
+            .map_or_else(Vec::new, |outbound| vec![outbound])
+    }
+
+    // ---------------------------------------------------------------------
+    // Command dispatch.
+    // ---------------------------------------------------------------------
+
+    async fn dispatch(
+        &self,
+        connection: &mut Connection,
+        now_ms: u64,
+        request_id: u32,
+        command: Command,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        match command {
+            Command::Hello => self.hello(connection, now_ms, request),
+            Command::GetCapabilities => self.get_capabilities(request),
+            Command::GetChallenge => self.get_challenge(connection, now_ms, request),
+            Command::Ping => Self::ping(request),
+            Command::CreateQueue => self.create_queue(connection, now_ms, request_id, request),
+            Command::CreateContactQueue => {
+                self.create_contact_queue(connection, now_ms, request_id, request)
+            }
+            Command::Subscribe => self.subscribe(connection, now_ms, request_id, request),
+            Command::Unsubscribe => self.unsubscribe(connection, now_ms, request_id, request),
+            Command::Read => self.read(connection, now_ms, request_id, request),
+            Command::Ack => self.ack(connection, now_ms, request_id, request),
+            Command::DeleteQueue => self.delete_queue(connection, now_ms, request_id, request),
+            Command::BindSend => self.bind_send(connection, now_ms, request_id, request),
+            Command::Append => {
+                self.append(&connection.transcripts, now_ms, request_id, request)
+                    .await
+            }
+            Command::ContactAppend => self.contact_append(now_ms, request).await,
+            // `Command` is `#[non_exhaustive]`: a code added to `f2z-codec` but
+            // not handled here is a hole in this relay, not in the client that
+            // sent it, and §3.5's non-fatal `ERR_UNKNOWN_COMMAND` is the honest
+            // answer — this build genuinely does not implement it.
+            _ => Err(ProtoError::Wire(ErrorCode::UnknownCommand)),
+        }
+    }
+
+    // -- §6.1, unsigned ----------------------------------------------------
+
+    fn hello(
+        &self,
+        connection: &mut Connection,
+        now_ms: u64,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let offer: HelloRequest = self.accept_unsigned::<ops::Hello>(request)?.into_body();
+        if offer.min_version > offer.max_version
+            || PROTOCOL_VERSION < offer.min_version
+            || PROTOCOL_VERSION > offer.max_version
+        {
+            return Err(ProtoError::Wire(ErrorCode::UnsupportedVersion));
+        }
+        let caps = self.published.capabilities();
+        let announcement = RelayAnnouncement {
+            protocol_version: PROTOCOL_VERSION,
+            relay_time_ms: now_ms,
+            channel_binding_mode: if caps.channel_binding_mode
+                == ChannelBindingMode::TlsExporter.code()
+            {
+                ChannelBindingMode::TlsExporter
+            } else {
+                ChannelBindingMode::None
+            },
+            transport_security: if caps.transport_security == TransportSecurity::Tls.code() {
+                TransportSecurity::Tls
+            } else {
+                TransportSecurity::None
+            },
+            capabilities_digest: self.published.digest,
+        };
+        // The proof is over **this connection's** binding, which is what makes
+        // §5.2's possession check a statement about this TLS session and not a
+        // value an intermediary can forward.
+        let response: HelloResponse = hello_response(
+            &self.identity,
+            &announcement,
+            &connection.transcripts.channel_binding(),
+            &offer.client_nonce,
+        );
+        connection.hello_done = true;
+        Ok(response.encode_canonical()?)
+    }
+
+    fn get_capabilities(&self, request: &Request) -> Result<Vec<u8>, ProtoError> {
+        let _: Empty = self
+            .accept_unsigned::<ops::GetCapabilities>(request)?
+            .into_body();
+        // Encoded once at startup and handed out unchanged, so the bytes a
+        // client verifies are byte-identical to the ones the digest in `HELLO`
+        // was taken over.
+        Ok(self.published.signed.encode_canonical()?)
+    }
+
+    fn ping(request: &Request) -> Result<Vec<u8>, ProtoError> {
+        // `PING` needs no relay state at all, which is the point of it: §6.1
+        // calls it an application-level liveness probe, distinct from §2.4's
+        // WebSocket Ping that a browser cannot send.
+        let verifier = CommandVerifier::new(
+            TranscriptBuilder::new(PROTOCOL_VERSION, RelayId::zero(), ChannelBinding::zero()),
+            TimestampWindow::new(0),
+            SeenSet::new(0, 0),
+            PaddingBuckets::default(),
+        );
+        let _: Empty = verifier.accept_unsigned::<ops::Ping>(request)?.into_body();
+        Ok(Vec::new())
+    }
+
+    fn get_challenge(
+        &self,
+        connection: &Connection,
+        now_ms: u64,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let body: ChallengeRequest = self
+            .accept_unsigned::<ops::GetChallenge>(request)?
+            .into_body();
+        // §6.1: "Challenge issuance is itself rate-limited per source, or it
+        // becomes the cheapest way to make the relay do work."
+        if !self.abuse.take_challenge(connection.source, now_ms) {
+            return Err(ProtoError::Wire(ErrorCode::RateLimited));
+        }
+        // `purpose` is a raw byte so an unknown value round-trips through §3.3
+        // rather than failing to decode. §10 has no code for "an enum value in
+        // a body that this build does not know"; `ERR_MALFORMED` is the reading
+        // here, it is fatal, and it is listed as an ambiguity call — the same
+        // one `f2z-relay-testkit` flagged, and the weakest in the set.
+        let purpose = body
+            .purpose()
+            .map_err(|_| ProtoError::Wire(ErrorCode::Malformed))?;
+        let params = self.pow_params_for(purpose);
+        let ttl = if params.challenge_ttl_ms == 0 {
+            self.config.antiabuse.challenge_ttl_ms
+        } else {
+            params.challenge_ttl_ms
+        };
+        let expires_at_ms = now_ms.saturating_add(u64::from(ttl));
+
+        let challenge =
+            crate::rng::challenge().map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+        self.lock_challenges().issue(
+            challenge,
+            purpose.code(),
+            body.scope.as_slice(),
+            expires_at_ms,
+            now_ms,
+        )?;
+        Metrics::inc(&self.metrics.challenges_issued);
+
+        let response = ChallengeResponse {
+            relay_time_ms: now_ms,
+            challenge,
+            expires_at_ms,
+            pow: params,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn pow_params_for(&self, purpose: ChallengePurpose) -> PowParams {
+        let caps = self.published.capabilities();
+        match purpose {
+            // §6.1: the field is zeroed when no PoW is required, and a clock
+            // read never requires one.
+            ChallengePurpose::Clock => PowParams::none(),
+            ChallengePurpose::QueueCreate => caps.queue_creation_pow,
+            ChallengePurpose::ContactAppend => caps.contact_append_pow,
+        }
+    }
+
+    // -- §6.2, signed by the receive key -----------------------------------
+
+    fn create_queue(
+        &self,
+        connection: &Connection,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let verified = self.verify_with::<ops::CreateQueue>(
+            &connection.transcripts,
+            now_ms,
+            request_id,
+            request,
+        )?;
+        let body: CreateQueueRequest = verified.into_body();
+        body.validate()?;
+
+        // §13.1 layer 4, in the order the section states it: creation is the
+        // first thing refused.
+        if self.abuse.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Backpressure));
+        }
+        self.check_creation_stamp(now_ms, &body.stamp)?;
+        self.check_queue_ceiling()?;
+
+        let message_ttl = self.ttl.grant_message_ttl(body.req_message_ttl_seconds);
+        let idle_ttl = self.ttl.grant_idle_ttl(body.req_idle_ttl_seconds);
+        let record = self.create(
+            QueueKind::Standard,
+            body.recv_key,
+            message_ttl,
+            idle_ttl,
+            self.quota,
+            now_ms,
+        )?;
+
+        let response = CreateQueueResponse {
+            recv_addr: record.0,
+            send_addr: record.1,
+            message_ttl_seconds: message_ttl,
+            idle_ttl_seconds: idle_ttl,
+            created_at_ms: now_ms,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn create_contact_queue(
+        &self,
+        connection: &Connection,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let verified = self.verify_with::<ops::CreateContactQueue>(
+            &connection.transcripts,
+            now_ms,
+            request_id,
+            request,
+        )?;
+        let body: CreateContactQueueRequest = verified.into_body();
+
+        let caps = self.published.capabilities();
+        if caps.contact_queues_enabled == 0 {
+            return Err(ProtoError::Wire(ErrorCode::NotPermitted));
+        }
+        if self.abuse.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Backpressure));
+        }
+        self.check_creation_stamp(now_ms, &body.stamp)?;
+        self.check_queue_ceiling()?;
+
+        let message_ttl = self.ttl.grant_message_ttl(body.req_message_ttl_seconds);
+        let idle_ttl = self.ttl.grant_idle_ttl(body.req_idle_ttl_seconds);
+        // §12.3: a contact queue is hard-capped, because §12.2 point 2 means the
+        // whole internet may write to it.
+        let record = self.create(
+            QueueKind::Contact,
+            body.recv_key,
+            message_ttl,
+            idle_ttl,
+            self.contact_quota,
+            now_ms,
+        )?;
+
+        let response = CreateContactQueueResponse {
+            recv_addr: record.0,
+            contact_addr: record.1,
+            message_ttl_seconds: message_ttl,
+            idle_ttl_seconds: idle_ttl,
+            max_pending: caps.contact_max_pending,
+            max_bytes: caps.contact_max_bytes,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    /// §7.1: both addresses from the relay's own CSPRNG, redrawn on collision.
+    fn create(
+        &self,
+        kind: QueueKind,
+        recv_key: f2z_codec::types::PublicKey,
+        message_ttl_seconds: u32,
+        idle_ttl_seconds: u32,
+        quota: AppendQuota,
+        now_ms: u64,
+    ) -> Result<(QueueAddress, QueueAddress), ProtoError> {
+        for _ in 0..ADDRESS_DRAWS {
+            let recv_addr =
+                crate::rng::queue_address().map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+            let send_addr =
+                crate::rng::queue_address().map_err(|_| ProtoError::Wire(ErrorCode::Internal))?;
+            match self.store.create_queue(&QueueSpec {
+                kind,
+                recv_addr,
+                send_addr,
+                recv_key,
+                message_ttl_seconds,
+                idle_ttl_seconds,
+                quota,
+                created_at_ms: now_ms,
+            }) {
+                Ok(_committed) => return Ok((recv_addr, send_addr)),
+                Err(StoreError::AddressCollision) => {}
+                Err(error) => return Err(store_error(&error)),
+            }
+        }
+        // Eight consecutive collisions at 32 bytes does not happen; a CSPRNG
+        // returning a constant does. §10's code 21 carries no detail, so the
+        // operator's log is where this is said.
+        crate::log_error!("queue address generator produced repeated collisions");
+        Err(ProtoError::Wire(ErrorCode::Internal))
+    }
+
+    fn subscribe(
+        &self,
+        connection: &mut Connection,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let verified = self.verify_with::<ops::Subscribe>(
+            &connection.transcripts,
+            now_ms,
+            request_id,
+            request,
+        )?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+
+        let record = self
+            .store
+            .queue_by_recv(&recv_addr, &signer)
+            .map_err(|error| self.recv_error(&error))?;
+        // §7.7: the idle TTL resets on SUBSCRIBE too, and this is the one
+        // command for which that is the only durable consequence — hence
+        // `touch`, which is best-effort on purpose.
+        let _ = self.store.touch(&recv_addr, &signer, now_ms);
+
+        self.subscriptions
+            .subscribe(recv_addr, connection.id, connection.pushes.clone());
+        connection.subscriptions.insert(recv_addr);
+
+        let response = SubscribeResponse {
+            next_index: record.state.next_index(),
+            // §6.2: `pending` is disclosed to the **reader** only. There is no
+            // equivalent anywhere on the send side.
+            pending: record.state.pending(),
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn unsubscribe(
+        &self,
+        connection: &mut Connection,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let verified = self.verify_with::<ops::Unsubscribe>(
+            &connection.transcripts,
+            now_ms,
+            request_id,
+            request,
+        )?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+        self.store
+            .queue_by_recv(&recv_addr, &signer)
+            .map_err(|error| self.recv_error(&error))?;
+        self.subscriptions.unsubscribe(&recv_addr, connection.id);
+        connection.subscriptions.remove(&recv_addr);
+        Ok(Vec::new())
+    }
+
+    fn read(
+        &self,
+        connection: &Connection,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let verified =
+            self.verify_with::<ops::Read>(&connection.transcripts, now_ms, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+        let body: ReadRequest = verified.into_body();
+
+        // §6.2 gives no meaning to a zero limit. The reading that keeps a queue
+        // drainable is "no client-side limit" — a zero that meant "return
+        // nothing" would make a client that forgot to set the field loop forever
+        // against a queue it can never empty. Unstated in the specification, and
+        // this is the same call `f2z-relay-testkit` made.
+        let max_messages = if body.max_messages == 0 {
+            u16::MAX
+        } else {
+            body.max_messages
+        };
+        // The byte limit is additionally clamped to what a response frame can
+        // carry: a relay that honoured `max_bytes = u32::MAX` would build a
+        // frame its own §4.1 cap forbids and answer `ERR_INTERNAL` instead of
+        // the page the client asked for.
+        let ceiling = self
+            .published
+            .capabilities()
+            .max_frame_bytes
+            .saturating_sub(READ_FRAME_OVERHEAD)
+            .max(1);
+        let max_bytes = if body.max_bytes == 0 {
+            ceiling
+        } else {
+            body.max_bytes.min(ceiling)
+        };
+
+        // §13.1 layer 4: `READ` is never refused for backpressure. It is one of
+        // the operations that make the relay smaller, and refusing it under load
+        // is a deadlock.
+        let page = self
+            .store
+            .read(
+                &recv_addr,
+                &signer,
+                f2z_relay_store::ReadWindow {
+                    from_index: body.from_index,
+                    max_messages,
+                    max_bytes,
+                },
+                now_ms,
+            )
+            .map_err(|error| self.recv_error(&error))?;
+
+        let messages: Vec<QueuedMessage> = page
+            .messages
+            .into_iter()
+            .map(|stored| QueuedMessage {
+                index: stored.index,
+                received_at_ms: stored.received_at_ms,
+                payload: stored.payload,
+            })
+            .collect();
+        let response = ReadResponse {
+            messages: messages.into(),
+            has_more: u8::from(page.has_more),
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn ack(
+        &self,
+        connection: &Connection,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let verified =
+            self.verify_with::<ops::Ack>(&connection.transcripts, now_ms, request_id, request)?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+        let body: AckRequest = verified.into_body();
+
+        // The watermark advance and the range delete are one transaction inside
+        // the store. That is the crash-safety invariant `f2z-relay-store` is
+        // tested against, and it is why this is not two calls.
+        let committed = self
+            .store
+            .ack(&recv_addr, &signer, body.up_to_index, now_ms)
+            .map_err(|error| self.recv_error(&error))?;
+        let outcome = committed.into_inner();
+        Metrics::add(&self.metrics.messages_acked, outcome.acknowledged);
+
+        let response = AckResponse {
+            next_index: outcome.next_index,
+            pending: outcome.pending,
+        };
+        Ok(response.encode_canonical()?)
+    }
+
+    fn delete_queue(
+        &self,
+        connection: &mut Connection,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let verified = self.verify_with::<ops::DeleteQueue>(
+            &connection.transcripts,
+            now_ms,
+            request_id,
+            request,
+        )?;
+        let recv_addr = verified.address();
+        let signer = verified.signer_key();
+
+        // The `Committed` receipt is taken and named rather than dropped: the
+        // deletion is durable before the empty response is built, which is the
+        // same ordering `commit_append` keeps for `accepted`.
+        let _deleted = self
+            .store
+            .delete_queue(&recv_addr, &signer)
+            .map_err(|error| self.recv_error(&error))?
+            .into_inner();
+
+        // §6.4: `QUEUE_EVENT` reason 1. Pushed **before** the subscription is
+        // torn down, so the connection that asked for the deletion is told about
+        // it like any other reader.
+        self.subscriptions
+            .notify_queue_event(recv_addr, QUEUE_EVENT_DELETED, &self.metrics);
+        self.subscriptions.unsubscribe(&recv_addr, connection.id);
+        connection.subscriptions.remove(&recv_addr);
+        Ok(Vec::new())
+    }
+
+    // -- §6.3, signed by the send key --------------------------------------
+
+    fn bind_send(
+        &self,
+        connection: &Connection,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let verified = self.verify_with::<ops::BindSend>(
+            &connection.transcripts,
+            now_ms,
+            request_id,
+            request,
+        )?;
+        let send_addr = verified.address();
+        // `ops::BindSend::check` has already required `signer_key == send_key`:
+        // §5.1 step 5 has nothing to compare against on an unbound address, so
+        // possession of the key in the body is the only thing the signature can
+        // prove, and without that requirement §7.4's bind-once theft protection
+        // costs an attacker nothing.
+        let signer = verified.signer_key();
+
+        // §7.3, and §7.4's consequence: a second bind with **any** key,
+        // including the same key, is `ERR_ALREADY_BOUND`. To a client that just
+        // received a fresh advert this is a loud, non-dismissible failure, not a
+        // retry — the relay operator may have read `send_addr` out of its own
+        // database and bound first.
+        // Taken rather than dropped: §7.3's bind is irreversible, so the empty
+        // response must not precede the write that makes it so.
+        // The `Committed` receipt is consumed here rather than dropped: §7.3's
+        // bind is irreversible, so the empty response must not precede the
+        // write that makes it so.
+        let _receipt = self
+            .store
+            .bind_send(&send_addr, &signer, now_ms)
+            .map_err(|error| send_error(&error))?;
+        Ok(Vec::new())
+    }
+
+    async fn append(
+        &self,
+        transcripts: &TranscriptBuilder,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let verified = self.verify_with::<ops::Append>(transcripts, now_ms, request_id, request)?;
+        let send_addr = verified.address();
+        let signer = verified.signer_key();
+        let body: AppendRequest = verified.into_body();
+
+        // §13.1 layer 4 step 2: an append under backpressure is
+        // `ERR_UNAVAILABLE`, never a code that says why.
+        if self.abuse.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        }
+
+        self.commit_append(send_addr, SendAuth::Signed(signer), body.payload, now_ms)
+            .await
+    }
+
+    // -- §12.2, contact queues ---------------------------------------------
+
+    async fn contact_append(&self, now_ms: u64, request: &Request) -> Result<Vec<u8>, ProtoError> {
+        let verified = self.accept_unsigned::<ops::ContactAppend>(request)?;
+        let body: ContactAppendRequest = verified.into_body();
+
+        if self.abuse.backpressured() {
+            return Err(ProtoError::Wire(ErrorCode::Unavailable));
+        }
+
+        // The lookup comes first so that a stamp is only demanded for an address
+        // that could take one — and it is `queue_by_send` with `ContactStamp`,
+        // so an ordinary send address answers the same `ERR_UNAVAILABLE` a
+        // nonexistent one does. A stranger probing addresses learns nothing
+        // about which is which.
+        self.store
+            .queue_by_send(&body.contact_addr, &SendAuth::ContactStamp)
+            .map_err(|error| send_error(&error))?;
+
+        // §12.3: the stamp is over a relay-issued, single-use, expiring
+        // challenge **scoped to this contact address**, so stamps cannot be
+        // precomputed in bulk, cannot be reused, and cannot be computed for one
+        // victim and spent on another.
+        let params = self.published.capabilities().contact_append_pow;
+        self.check_stamp(
+            now_ms,
+            &body.stamp,
+            &params,
+            ChallengePurpose::ContactAppend,
+            body.contact_addr.as_bytes(),
+        )?;
+
+        self.commit_append(
+            body.contact_addr,
+            SendAuth::ContactStamp,
+            body.payload,
+            now_ms,
+        )
+        .await
+    }
+
+    /// The one path by which anything reaches the disk, and the one place
+    /// `accepted` is decided.
+    ///
+    /// §6.3: the response body is empty. No index, no depth, no timestamp, no
+    /// queue state of any kind — an index would tell the sender how many
+    /// messages the queue has ever held, and a timestamp would give it a clock
+    /// to correlate against.
+    async fn commit_append(
+        &self,
+        send_addr: QueueAddress,
+        auth: SendAuth,
+        payload: Payload,
+        now_ms: u64,
+    ) -> Result<Vec<u8>, ProtoError> {
+        let payload_bytes = u64::try_from(payload.len()).unwrap_or(u64::MAX);
+        let accepted = match self
+            .writer
+            .append(send_addr, auth, payload.clone(), now_ms)
+            .await
+            .map_err(|_| ProtoError::Wire(ErrorCode::Unavailable))?
+        {
+            Ok(accepted) => accepted,
+            Err(error) => {
+                // §6.4's `QUEUE_EVENT` reason 4. The *writer* is told nothing
+                // but `ERR_UNAVAILABLE` — §6.3 collapses every send-side
+                // refusal so a bound sender cannot learn the queue's state by
+                // filling it — but the **reader** is the party that can act,
+                // and §6.4 gives it a push saying so.
+                self.announce_quota(send_addr, auth, payload_bytes);
+                return Err(send_error(&error));
+            }
+        };
+
+        // Only now. The `Accepted` above exists only downstream of the store's
+        // `Committed`, which the commit thread unwrapped after its transaction —
+        // so this line is unreachable before the write is durable, and not
+        // because anyone remembered to put it here.
+        if self.subscriptions.has_subscriber(&accepted.recv_addr) {
+            let message = QueuedMessage {
+                index: accepted.index,
+                received_at_ms: accepted.received_at_ms,
+                payload,
+            };
+            self.subscriptions
+                .notify_message(accepted.recv_addr, &message, &self.metrics);
+        }
+        Ok(Vec::new())
+    }
+
+    /// Answer an `APPEND` or `CONTACT_APPEND` from its own task.
+    ///
+    /// The task holds only what it needs: the relay, this connection's
+    /// transcript builder (§5.2, §5.3 — never a shared one), the outbound
+    /// channel and the in-flight set. It cannot touch subscriptions or the
+    /// `HELLO` flag, so the read loop remains the only writer of those.
+    fn defer(
+        self: &Arc<Self>,
+        connection: &Connection,
+        now_ms: u64,
+        request_id: u32,
+        command: Command,
+        request: Request,
+    ) {
+        let relay = Arc::clone(self);
+        let transcripts = connection.transcripts.clone();
+        let inflight = Arc::clone(&connection.inflight);
+        let pushes = connection.pushes.clone();
+        tokio::spawn(async move {
+            let outcome = match command {
+                Command::Append => {
+                    relay
+                        .append(&transcripts, now_ms, request_id, &request)
+                        .await
+                }
+                Command::ContactAppend => relay.contact_append(now_ms, &request).await,
+                // `defer` is called with exactly the two codes above.
+                _ => Err(ProtoError::Wire(ErrorCode::Internal)),
+            };
+            // §4.3: the window is released when the relay answers.
+            lock_inflight(&inflight).remove(&request_id);
+
+            let (response, fatal) = match outcome {
+                Ok(body) => {
+                    Metrics::inc(&relay.metrics.commands_ok);
+                    (
+                        Response::ok(body).unwrap_or_else(|_| Response::error(ErrorCode::Internal)),
+                        false,
+                    )
+                }
+                Err(error) => {
+                    Metrics::inc(&relay.metrics.commands_refused);
+                    let code = error.wire_code().unwrap_or(ErrorCode::Internal);
+                    (Response::error(code), code.is_fatal())
+                }
+            };
+            if let Some(mut outbound) = Outbound::response(request_id, response) {
+                if fatal {
+                    outbound.close_after = Some(CLOSE_PROTOCOL_ERROR);
+                }
+                // The client hung up. §2.5: an in-flight command whose response
+                // was not received has *unknown* status, and the append stays —
+                // §8.3 is explicit that APPEND is not idempotent at the relay.
+                let _ = pushes.send(outbound).await;
+            }
+        });
+    }
+
+    /// Tell a subscribed reader that its queue is at a cap (§6.4, reason 4).
+    ///
+    /// Called only on a refusal, so the hot path never pays for it, and only
+    /// when somebody is actually listening. The authoritative admission test is
+    /// the one `f2z-relay-store` runs **inside** the append transaction; this
+    /// re-runs the same arithmetic afterwards purely to decide whether the
+    /// refusal was a quota refusal rather than an absent or unbound address.
+    /// Being occasionally wrong about that race costs a hint, not a message:
+    /// §13.2's rule is about ciphertext, and a push is not ciphertext.
+    fn announce_quota(&self, send_addr: QueueAddress, auth: SendAuth, payload_bytes: u64) {
+        let Ok(record) = self.store.queue_by_send(&send_addr, &auth) else {
+            // Absent, unbound, wrong key, or the wrong kind of queue. All of
+            // them are `ERR_UNAVAILABLE` to the writer and none of them is a
+            // reader's business.
+            return;
+        };
+        if record
+            .quota
+            .admit(record.stored_messages, record.stored_bytes, payload_bytes)
+            .is_ok()
+        {
+            return;
+        }
+        if !self.subscriptions.has_subscriber(&record.recv_addr) {
+            return;
+        }
+        self.subscriptions
+            .notify_queue_event(record.recv_addr, QUEUE_EVENT_QUOTA, &self.metrics);
+    }
+
+    // ---------------------------------------------------------------------
+    // Shared helpers.
+    // ---------------------------------------------------------------------
+
+    /// §13.1 layer 3's ceiling on how many queues may exist.
+    ///
+    /// Distinguishable (`ERR_QUOTA`, code 14) on purpose: unlike the send side,
+    /// the party being refused here is the one that owns the queues, so telling
+    /// it discloses nothing it does not already know.
+    fn check_queue_ceiling(&self) -> Result<(), ProtoError> {
+        let stats = self
+            .store
+            .stats()
+            .map_err(|error| ProtoError::Wire(error.error_code()))?;
+        let total = stats.queues.saturating_add(stats.contact_queues);
+        if total >= self.config.limits.max_queues {
+            return Err(ProtoError::Wire(ErrorCode::Quota));
+        }
+        Ok(())
+    }
+
+    fn check_creation_stamp(&self, now_ms: u64, stamp: &PowStamp) -> Result<(), ProtoError> {
+        if !matches!(self.creation_mode, CreationMode::Pow) {
+            return Ok(());
+        }
+        let params = self.published.capabilities().queue_creation_pow;
+        self.check_stamp(now_ms, stamp, &params, ChallengePurpose::QueueCreate, &[])
+    }
+
+    fn check_stamp(
+        &self,
+        now_ms: u64,
+        stamp: &PowStamp,
+        params: &PowParams,
+        purpose: ChallengePurpose,
+        scope: &[u8],
+    ) -> Result<(), ProtoError> {
+        if !params.is_required() {
+            return Ok(());
+        }
+        if stamp.is_empty() {
+            Metrics::inc(&self.metrics.stamps_refused);
+            return Err(ProtoError::Wire(ErrorCode::PowRequired));
+        }
+        // Verification is one hash, and §12.3 chose the function for exactly
+        // that: the relay's own cost under flood is what must stay near zero.
+        // Checked **before** the challenge is consumed, so a garbage flood
+        // cannot burn the challenge table.
+        if !stamp.meets_difficulty(params.difficulty_bits) {
+            Metrics::inc(&self.metrics.stamps_refused);
+            return Err(ProtoError::Wire(ErrorCode::PowInvalid));
+        }
+        let result =
+            self.lock_challenges()
+                .consume(&stamp.challenge, purpose.code(), scope, now_ms);
+        if result.is_err() {
+            Metrics::inc(&self.metrics.stamps_refused);
+        }
+        result
+    }
+
+    /// §5.1's verification, against **this connection's** transcript builder.
+    ///
+    /// There is deliberately no `verify(&Connection, …)` convenience wrapper
+    /// beside this. A second function whose name begins with `verify` would be
+    /// a second thing the workspace's strict-verification scan has to be told
+    /// about (#612), for the sake of saving one field access at five call
+    /// sites — and the field it saves is exactly the one that must not be
+    /// wrong: a transcript builder from anywhere but this connection would bind
+    /// the signature to another session's channel binding.
+    fn verify_with<C: RelayCommand>(
+        &self,
+        transcripts: &TranscriptBuilder,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+    ) -> Result<Verified<C>, ProtoError> {
+        // §5.5's seen-set is relay-wide, so it is taken out of the shared slot
+        // for the duration of one verification and put back. A per-connection
+        // seen-set would let a replay succeed simply by opening a second
+        // connection.
+        let mut seen = self.take_seen();
+        let mut verifier = CommandVerifier::new(
+            transcripts.clone(),
+            TimestampWindow::new(u64::from(self.config.limits.clock_skew_ms)),
+            seen,
+            self.padding.clone(),
+        );
+        let outcome = verifier.verify::<C>(now_ms, request_id, request);
+        seen = std::mem::replace(
+            verifier.seen_set_mut(),
+            SeenSet::new(
+                u64::from(self.config.limits.antireplay_window_ms),
+                usize::try_from(self.config.limits.antireplay_seen_max).unwrap_or(usize::MAX),
+            ),
+        );
+        self.put_seen(seen);
+        outcome
+    }
+
+    fn accept_unsigned<C: RelayCommand>(
+        &self,
+        request: &Request,
+    ) -> Result<Verified<C>, ProtoError> {
+        // The seen-set is untouched by an unsigned command — there is no
+        // `(signer_key, nonce)` to record — so a throwaway one is honest here
+        // rather than a shortcut.
+        let verifier = CommandVerifier::new(
+            TranscriptBuilder::new(PROTOCOL_VERSION, self.relay_id, ChannelBinding::zero()),
+            TimestampWindow::new(u64::from(self.config.limits.clock_skew_ms)),
+            SeenSet::new(0, 0),
+            self.padding.clone(),
+        );
+        verifier.accept_unsigned::<C>(request)
+    }
+
+    /// §10's existence-oracle rule, receive side.
+    fn recv_error(&self, error: &StoreError) -> ProtoError {
+        if matches!(error.error_code(), ErrorCode::NoAccess) {
+            // "On the absent path, perform a dummy Ed25519 verification against
+            // a fixed key so that the dominant CPU cost is present in both
+            // paths", and do not short-circuit before it. The return value is
+            // consumed so the call cannot be optimized away. §10 is explicit
+            // that what remains — cache residency, page faults, index depth —
+            // is a real residual timing channel, and this narrows it rather
+            // than claiming to close it.
+            if dummy_verify() {
+                return ProtoError::Wire(ErrorCode::Internal);
+            }
+        }
+        store_error(error)
+    }
+
+    fn take_seen(&self) -> SeenSet {
+        let mut slot = self.lock_seen();
+        std::mem::replace(
+            &mut slot,
+            SeenSet::new(
+                u64::from(self.config.limits.antireplay_window_ms),
+                usize::try_from(self.config.limits.antireplay_seen_max).unwrap_or(usize::MAX),
+            ),
+        )
+    }
+
+    fn put_seen(&self, seen: SeenSet) {
+        *self.lock_seen() = seen;
+    }
+
+    fn lock_seen(&self) -> std::sync::MutexGuard<'_, SeenSet> {
+        // A poisoned lock is not a reason to stop serving: the guarded value is
+        // a bounded set whose worst case after a panic is a missing entry, and
+        // refusing every later command would turn one fault into an outage of
+        // `READ` and `ACK`, which §13.1 says must never be refused.
+        self.seen
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn lock_challenges(&self) -> std::sync::MutexGuard<'_, Challenges> {
+        self.challenges
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+/// A poisoned in-flight set is not a reason to drop a connection: the guarded
+/// value is a set of `u32`, and the worst case after a panic is one stale id
+/// occupying a slot in §4.3's window until the connection ends.
+fn lock_inflight(inflight: &Mutex<BTreeSet<u32>>) -> std::sync::MutexGuard<'_, BTreeSet<u32>> {
+    inflight
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// §6.3's collapse, send side, for a store refusal.
+fn send_error(error: &StoreError) -> ProtoError {
+    // The store already answers `ERR_UNAVAILABLE` for every send-side refusal
+    // and `ERR_NOT_PERMITTED` for `BIND_SEND` on a contact address, which §12.2
+    // deliberately does *not* collapse: a contact address is published in a
+    // directory entry, so refusing it distinctly leaks no queue state its finder
+    // did not already have.
+    store_error(error)
+}
+
+fn store_error(error: &StoreError) -> ProtoError {
+    ProtoError::Wire(error.error_code())
+}
+
+/// Recover a `request_id` from a frame whose body did not decode.
+///
+/// The frame header is fixed-width — one kind byte, then a big-endian `u32` —
+/// so almost every malformed frame still carries a readable id and §1.3's "send
+/// the response, then close" is satisfiable. `0` means it was not recoverable,
+/// which [`Relay::fatal`] turns into a bare close.
+fn recover_request_id(bytes: &[u8]) -> u32 {
+    let Some(kind) = bytes.first() else {
+        return 0;
+    };
+    // Only a request frame has a client-chosen id to answer on.
+    if *kind != 1 {
+        return 0;
+    }
+    bytes
+        .get(1..5)
+        .and_then(|slice| <[u8; 4]>::try_from(slice).ok())
+        .map_or(0, u32::from_be_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_request_id_survives_a_body_that_does_not_decode() {
+        let mut bytes = vec![1u8, 0, 0, 0, 9];
+        bytes.extend_from_slice(&[0xff; 3]);
+        assert_eq!(recover_request_id(&bytes), 9);
+        assert_eq!(recover_request_id(&[]), 0);
+        assert_eq!(recover_request_id(&[2, 0, 0, 0, 9]), 0);
+        assert_eq!(recover_request_id(&[1, 0, 0]), 0);
+    }
+
+    #[test]
+    fn a_text_frame_closes_with_the_status_section_4_2_names() {
+        let outbound = Relay::handle_text();
+        assert_eq!(outbound.len(), 1);
+        assert!(
+            outbound
+                .first()
+                .is_some_and(|frame| frame.message.is_none())
+        );
+        assert_eq!(
+            outbound.first().and_then(|frame| frame.close_after),
+            Some(CLOSE_UNSUPPORTED_DATA)
+        );
+    }
+}

--- a/rs/crates/f2z-relay/src/expiry.rs
+++ b/rs/crates/f2z-relay/src/expiry.rs
@@ -1,0 +1,142 @@
+//! The tick: §7.7's two timers, §5.5's seen-set, and §13.1 layer 4's
+//! measurement.
+//!
+//! # Why expiry is a timer and not a lazy check
+//!
+//! A relay could sweep on every command, as `f2z-relay-testkit` does — that is
+//! the right choice for a harness whose clock a test steers, because it makes
+//! the consequence of moving time visible on the very next request. It is the
+//! wrong choice for a server: the sweep is a range scan over an index, and
+//! paying for it on every `READ` puts a cost proportional to the *whole store*
+//! on the path of an operation §13.1 says must never be refused.
+//!
+//! So it runs on a period, and the honest consequence is that a message lives
+//! for up to `expiry_tick_seconds` past its TTL. That is a policy statement
+//! about a seven-day timer, not a correctness one: §7.7's guarantee is that
+//! undelivered ciphertext is dropped after the TTL, and dropping it a minute
+//! late does not break anything the TTL protects.
+//!
+//! # What the tick also does
+//!
+//! - **Ages the seen-set** (§5.5). It is bounded and fail-closed — on reaching
+//!   `antireplay_seen_max` the relay refuses new signed commands rather than
+//!   evicting — so a relay that never aged entries out would be a relay that
+//!   stopped accepting signatures after a while. Aging is what keeps the bound
+//!   a bound rather than a ceiling.
+//! - **Drops expired challenges**, for the same reason.
+//! - **Measures the store and sets §13.1 layer 4.** The high-water mark is
+//!   compared against what the storage engine has actually allocated, not
+//!   against what the relay believes it wrote: page overhead, free pages and the
+//!   write-ahead log are all real disk, and an operator's disk fills with all
+//!   three.
+//! - **Announces expiry to subscribed readers** as `QUEUE_EVENT` (§6.4). Expiry
+//!   is silent to a writer, always.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use f2z_relay_store::ExpiryReason;
+use tokio::sync::watch;
+
+use crate::engine::Relay;
+use crate::metrics::Metrics;
+
+/// Run the tick until `shutdown` flips.
+pub async fn run(relay: Arc<Relay>, mut shutdown: watch::Receiver<bool>) {
+    let period = Duration::from_secs(u64::from(relay.config().queues.expiry_tick_seconds.max(1)));
+    let mut ticker = tokio::time::interval(period);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // The first tick fires immediately, which is what we want: a relay that has
+    // just restarted after an outage may be holding a great deal that expired
+    // while it was down.
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.changed() => return,
+            _ = ticker.tick() => {}
+        }
+        tick(&relay);
+    }
+}
+
+/// One sweep. Public so a test can run it without waiting for a period.
+pub fn tick(relay: &Arc<Relay>) {
+    let now = crate::now_ms();
+    let metrics = relay.metrics();
+
+    match relay.store().expire(now) {
+        Ok(committed) => {
+            let report = committed.into_inner();
+            if !report.is_empty() {
+                Metrics::add(&metrics.messages_expired, report.messages_expired);
+                Metrics::add(&metrics.queues_expired, report.queues_expired);
+                crate::log_debug!(
+                    "expiry sweep",
+                    "queues" = u32::try_from(report.queues_expired).unwrap_or(u32::MAX),
+                    "messages" = u32::try_from(report.messages_expired).unwrap_or(u32::MAX),
+                );
+            }
+            for expired in report.expired {
+                // §6.4: reason 2 for an idle-expired queue, reason 3 for
+                // TTL-expired messages. Both go to a subscribed **reader**;
+                // §7.7 makes expiry silent to a writer.
+                relay.subscriptions().notify_queue_event(
+                    expired.recv_addr,
+                    match expired.reason {
+                        ExpiryReason::IdleTtl => 2,
+                        ExpiryReason::MessageTtl => 3,
+                    },
+                    metrics,
+                );
+            }
+        }
+        Err(_) => {
+            // §10's code 21 carries no detail on the wire; the operator's log is
+            // where a failing sweep is said, and it is said without the error's
+            // own text, which could name a value.
+            crate::log_error!("expiry sweep failed");
+        }
+    }
+
+    let (seen_entries, challenges) = relay.sweep_memory(now);
+    Metrics::set(
+        &metrics.antireplay_entries,
+        u64::try_from(seen_entries).unwrap_or(u64::MAX),
+    );
+    Metrics::set(
+        &metrics.challenges_outstanding,
+        u64::try_from(challenges).unwrap_or(u64::MAX),
+    );
+    let dropped = relay.abuse().sweep(now);
+    if dropped > 0 {
+        crate::log_trace!(
+            "rate-limiter rows dropped",
+            "rows" = u32::try_from(dropped).unwrap_or(u32::MAX)
+        );
+    }
+
+    // §13.1 layer 4, measured rather than assumed.
+    if let Ok(stats) = relay.store().stats() {
+        Metrics::set(&metrics.stored_messages, stats.messages);
+        Metrics::set(&metrics.stored_payload_bytes, stats.payload_bytes);
+        Metrics::set(&metrics.storage_bytes, stats.storage_bytes);
+        Metrics::set(
+            &metrics.queues,
+            stats.queues.saturating_add(stats.contact_queues),
+        );
+
+        let high_water = relay.config().limits.storage_high_water_bytes;
+        let over = high_water > 0 && stats.storage_bytes >= high_water;
+        if relay.abuse().set_backpressure(over) {
+            // Logged on the transition, not on the level: a relay that has been
+            // backpressured for an hour should not have written 3,600 lines
+            // saying so.
+            if over {
+                crate::log_warn!("backpressure on: storage at or above the high-water mark");
+            } else {
+                crate::log_info!("backpressure off");
+            }
+        }
+        Metrics::set(&metrics.backpressure, u64::from(over));
+    }
+}

--- a/rs/crates/f2z-relay/src/identity.rs
+++ b/rs/crates/f2z-relay/src/identity.rs
@@ -1,0 +1,265 @@
+//! The relay's long-term Ed25519 identity (§5.2), and where it lives.
+//!
+//! # Why losing it is not a small thing
+//!
+//! `relay_id = H("free2z/relay/v1/relay-id", relay_identity_pk)`, and §7.2 puts
+//! that value inside every `queue_advert` that ever named this relay — inside
+//! the MLS group, where the relay cannot reach it. A relay that comes back with
+//! a new identity key is, to every client that ever spoke to it, **a different
+//! relay that has taken over the address**: §5.2's substitution check fires,
+//! the mismatch is fatal, and the client is told the relay it names behaved
+//! incorrectly.
+//!
+//! So the key file is the one piece of state whose loss is not recoverable by
+//! restoring a backup of the queues, and `identity.generate` defaults to `true`
+//! only because a first run has to be able to happen at all. A deployment that
+//! provisions keys out of band should set it to `false`, so a lost volume fails
+//! loudly instead of quietly becoming somebody else.
+//!
+//! # The file
+//!
+//! 64 hexadecimal characters and a newline: the 32-byte Ed25519 seed. Written
+//! with mode `0600` on Unix, and refused on load if the mode is wider — a
+//! world-readable identity key is the relay's whole authenticity, and a warning
+//! is not enough.
+
+use std::path::Path;
+
+use f2z_relay_proto::key::SigningKey;
+
+/// Why an identity could not be established.
+#[derive(Debug)]
+pub enum IdentityError {
+    /// The file could not be read or written.
+    Io(std::io::Error),
+    /// The file is not 64 hexadecimal characters.
+    Malformed,
+    /// The file is readable by somebody other than its owner.
+    Permissions(u32),
+    /// The file is missing and `identity.generate` is off.
+    Missing,
+    /// The operating system refused to provide randomness.
+    NoRandomness,
+}
+
+impl std::fmt::Display for IdentityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "identity key file: {error}"),
+            Self::Malformed => f.write_str(
+                "identity key file must be exactly 64 hexadecimal characters (a 32-byte seed)",
+            ),
+            Self::Permissions(mode) => write!(
+                f,
+                "identity key file is readable beyond its owner (mode {mode:o}); \
+                 chmod 600 it"
+            ),
+            Self::Missing => f.write_str(
+                "no identity key file and identity.generate is false; provision one, \
+                 or accept that a new key makes this a different relay to every \
+                 client that ever held a queue advert naming it (WIRE.md §5.2)",
+            ),
+            Self::NoRandomness => f.write_str("the operating system refused to provide randomness"),
+        }
+    }
+}
+
+impl std::error::Error for IdentityError {}
+
+impl From<std::io::Error> for IdentityError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// Load the identity from `path`, creating it when `generate` allows.
+///
+/// # Errors
+///
+/// [`IdentityError`], every variant of which is a startup failure rather than a
+/// warning.
+pub fn load_or_create(path: &Path, generate: bool) -> Result<SigningKey, IdentityError> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => {
+            check_permissions(path)?;
+            let seed = crate::config::decode_seed(text.trim()).ok_or(IdentityError::Malformed)?;
+            Ok(SigningKey::from_seed(&seed))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if !generate {
+                return Err(IdentityError::Missing);
+            }
+            let seed = crate::rng::seed().map_err(|_| IdentityError::NoRandomness)?;
+            write_seed(path, &seed)?;
+            Ok(SigningKey::from_seed(&seed))
+        }
+        Err(error) => Err(IdentityError::Io(error)),
+    }
+}
+
+/// Take the identity from a configured hex seed.
+///
+/// For a container with no persistent volume. The seed is key material; see
+/// [`crate::config::Identity`] for what `--print-config` does with it.
+///
+/// # Errors
+///
+/// [`IdentityError::Malformed`] if it is not 64 hexadecimal characters.
+pub fn from_hex(text: &str) -> Result<SigningKey, IdentityError> {
+    let seed = crate::config::decode_seed(text.trim()).ok_or(IdentityError::Malformed)?;
+    Ok(SigningKey::from_seed(&seed))
+}
+
+fn write_seed(path: &Path, seed: &[u8; 32]) -> Result<(), IdentityError> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut text = String::with_capacity(65);
+    for byte in seed {
+        // `{:02x}` on a `u8`, without pulling in a formatting helper.
+        text.push(hex_digit(byte >> 4));
+        text.push(hex_digit(byte & 0x0f));
+    }
+    text.push('\n');
+
+    #[cfg(unix)]
+    {
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(text.as_bytes())?;
+        file.sync_all()?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, text.as_bytes())?;
+    }
+    Ok(())
+}
+
+fn check_permissions(path: &Path) -> Result<(), IdentityError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            return Err(IdentityError::Permissions(mode));
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+/// The digit for a nibble, in checked arithmetic.
+///
+/// The workspace denies `arithmetic_side_effects` for every crate under `rs/`,
+/// and this file writes a private key: an out-of-range value here would be a
+/// key file that does not decode back to the key in memory.
+const fn hex_digit(nibble: u8) -> char {
+    let digit = match nibble {
+        0..=9 => b'0'.checked_add(nibble),
+        10..=15 => match nibble.checked_sub(10) {
+            Some(offset) => b'a'.checked_add(offset),
+            None => None,
+        },
+        _ => None,
+    };
+    match digit {
+        Some(byte) => byte as char,
+        // Unreachable: every caller masks to four bits. `'?'` rather than a
+        // panic, because a panic in a key writer is the worst possible failure
+        // mode and a malformed file is caught on the next load.
+        None => '?',
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(name: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("f2z-relay-identity-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_generated_key_is_stable_across_loads() {
+        let dir = temp_dir("stable");
+        let path = dir.join("identity.key");
+        let first = load_or_create(&path, true).unwrap();
+        let second = load_or_create(&path, true).unwrap();
+        assert_eq!(first.public_key(), second.public_key());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_missing_key_without_generate_is_a_startup_failure() {
+        let dir = temp_dir("missing");
+        let path = dir.join("identity.key");
+        assert!(matches!(
+            load_or_create(&path, false),
+            Err(IdentityError::Missing)
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_malformed_key_is_refused_rather_than_hashed_into_something() {
+        let dir = temp_dir("malformed");
+        let path = dir.join("identity.key");
+        std::fs::write(&path, "not a key\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        assert!(matches!(
+            load_or_create(&path, true),
+            Err(IdentityError::Malformed)
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_world_readable_key_is_refused() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = temp_dir("perms");
+        let path = dir.join("identity.key");
+        load_or_create(&path, true).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(matches!(
+            load_or_create(&path, true),
+            Err(IdentityError::Permissions(_))
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_hex_seed_and_a_key_file_produce_the_same_key() {
+        let key = from_hex(&"11".repeat(32)).unwrap();
+        assert_eq!(
+            key.public_key(),
+            SigningKey::from_seed(&[0x11; 32]).public_key()
+        );
+        assert!(from_hex("nope").is_err());
+    }
+
+    #[test]
+    fn the_error_display_never_carries_the_seed() {
+        let rendered = format!("{}", IdentityError::Malformed);
+        assert!(!rendered.contains("1111"));
+    }
+}

--- a/rs/crates/f2z-relay/src/lib.rs
+++ b/rs/crates/f2z-relay/src/lib.rs
@@ -1,0 +1,134 @@
+//! The free2z relay daemon — the server that runs in production.
+//!
+//! This crate implements [`docs/e2ee/WIRE.md`] v1 §2 through §13 on top of three
+//! crates that already own the parts a relay and a client must agree on
+//! exactly:
+//!
+//! | Crate | What it owns |
+//! |---|---|
+//! | [`f2z_codec`] | Canonical encoding, the framing of §4, re-encode equality (§3.3), the redaction newtypes |
+//! | [`f2z_relay_proto`] | §5.1's verification order, §5.5's anti-replay, §7/§8's queue and ACK rules, §11's document |
+//! | [`f2z_relay_store`] | Authorization inside the transaction, quota admission, the acknowledgement watermark, durability |
+//!
+//! **Nothing in those three is reimplemented here.** A relay that held a second
+//! opinion about the protocol would be a relay that deletes ciphertext before it
+//! is read. What this crate decides is the part they deliberately leave to a
+//! server: the socket, the connection lifecycle, the group-commit schedule, the
+//! anti-abuse layering, and which refusal answers which failure.
+//!
+//! # Licence
+//!
+//! **AGPL-3.0**, per the owner decision recorded on
+//! [#305](https://github.com/free2z/zuu/issues/305). The crates above stay
+//! permissive so that the ZUULI client, the WASM web client and third-party
+//! implementations can link them; the boundary starts at this binary.
+//! `rs/deny.toml` makes it mechanical — this crate is named in `exceptions`, and
+//! adding `AGPL-3.0` to the shared `allow` list instead would permit it for
+//! every crate in the tree.
+//!
+//! # The four properties this crate is responsible for
+//!
+//! 1. **`accepted` is never written to the socket before the commit is
+//!    durable.** [`commit`] is the only path to the disk, and the value that
+//!    lets a caller answer `accepted` does not exist until the transaction has
+//!    returned. Not a convention — a type.
+//! 2. **Group commit, because `synchronous = FULL` makes the fsync rate the
+//!    ceiling.** N appends inside a few milliseconds cost one fsync, and
+//!    `tests/group_commit.rs` proves the amortization against the store's own
+//!    commit counter rather than asserting it.
+//! 3. **No payload, queue address, key or peer address in any log line at any
+//!    level.** [`log`] has no parameter through which one could travel, and
+//!    `tests/redaction.rs` checks base16, base64url **and** the decimal byte-list
+//!    form that a hex-only test would sail past.
+//! 4. **Refusing rather than deleting.** §13.2: under no circumstance does the
+//!    relay delete an unacknowledged message to make room. Backpressure refuses
+//!    creation, then appends, then new connections, and never refuses `READ`,
+//!    `ACK` or `DELETE_QUEUE`.
+//!
+//! # Running one
+//!
+//! ```no_run
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! use f2z_relay::{config::Config, server::Server};
+//!
+//! let mut config = Config::default();
+//! config.store.backend = "memory".to_owned();
+//! config.listen.address = "127.0.0.1:0".to_owned();
+//!
+//! let server = Server::start(config).await?;
+//! println!("{}", server.url());
+//! server.shutdown().await;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`docs/e2ee/WIRE.md`]: https://github.com/free2z/zuu/blob/main/docs/e2ee/WIRE.md
+
+#![forbid(unsafe_code)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects
+    )
+)]
+
+pub mod abuse;
+pub mod admin;
+pub mod caps;
+pub mod challenge;
+pub mod cli;
+pub mod commit;
+pub mod config;
+pub mod connection;
+pub mod engine;
+pub mod expiry;
+pub mod identity;
+pub mod listener;
+pub mod log;
+pub mod metrics;
+pub mod outbound;
+pub mod rng;
+pub mod server;
+pub mod subscriptions;
+pub mod tls;
+pub mod transport;
+
+pub use config::Config;
+pub use engine::Relay;
+pub use server::{Server, StartError};
+
+/// The relay's clock, in milliseconds since the Unix epoch.
+///
+/// `f2z-relay-proto` is deliberately clock-free — every rule that needs the time
+/// takes it as an argument, because the same code runs in a browser — which
+/// leaves somebody holding the clock, and in a server that somebody is here.
+///
+/// §5.5's timestamp window is `±clock_skew_ms` of *this* value, so an operator
+/// whose clock is wrong will refuse correct clients. Running NTP is not
+/// optional; the relay does not attempt to detect it, because a relay that
+/// second-guessed its own clock would have two.
+#[must_use]
+pub fn now_ms() -> u64 {
+    u64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |since| since.as_millis()),
+    )
+    .unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn the_clock_is_milliseconds_since_the_epoch() {
+        // Any time after 2020 and before 2200, which is the only thing worth
+        // asserting about a wall clock.
+        let now = super::now_ms();
+        assert!(now > 1_577_836_800_000);
+        assert!(now < 7_258_118_400_000);
+    }
+}

--- a/rs/crates/f2z-relay/src/listener.rs
+++ b/rs/crates/f2z-relay/src/listener.rs
@@ -1,0 +1,243 @@
+//! The public listener: accept, upgrade, hand over (§2.1, §2.3, §13.1 layer 1).
+//!
+//! # §2.3 is enforced at bind, not warned about
+//!
+//! > *A relay **MUST refuse to bind a non-loopback address without TLS.** This
+//! > is a startup check, not a warning: the process exits.*
+//!
+//! [`crate::config::Config::check`] is where that decision is made, so it is
+//! reachable from `--check-config` without opening a socket. This module is
+//! where it is *acted on*: [`bind`] refuses the same case again, because a
+//! listener that could be constructed by a caller who skipped the check is a
+//! listener that will eventually be constructed that way.
+//!
+//! The override is published, not private: `--insecure-listen` makes the
+//! capability document say `transport_security: none` and
+//! `channel_binding_mode: none`, and [`crate::caps`] derives both from the same
+//! question the listener asks, so they cannot disagree.
+//!
+//! # What the upgrade checks
+//!
+//! §2.1 makes two things mandatory and this enforces both: the path
+//! `/relay/v1`, and the `free2z-relay.v1` subprotocol **echoed back**. A relay
+//! that does not echo it is one the client must refuse, so a relay that forgets
+//! to is a relay nobody can talk to — which is a bug worth failing loudly rather
+//! than a nicety.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tokio_rustls::TlsAcceptor;
+use tokio_tungstenite::tungstenite::handshake::server::{
+    ErrorResponse, Request as HandshakeRequest, Response as HandshakeResponse,
+};
+use tokio_tungstenite::tungstenite::http::{HeaderValue, StatusCode};
+
+use crate::abuse::Refusal;
+use crate::config::is_loopback;
+use crate::engine::Relay;
+use crate::metrics::Metrics;
+use crate::transport::{RELAY_PATH, SUBPROTOCOL, Transport, wrap};
+
+const HEADER_SUBPROTOCOL: &str = "sec-websocket-protocol";
+
+/// Why a listener could not be created.
+#[derive(Debug)]
+pub enum ListenError {
+    /// §2.3: a non-loopback bind without TLS and without the override.
+    InsecureBind,
+    /// The socket could not be bound.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for ListenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InsecureBind => f.write_str(
+                "refusing to bind a non-loopback address without TLS (WIRE.md §2.3); \
+                 configure listen.tls_cert and listen.tls_key, or pass --insecure-listen",
+            ),
+            Self::Io(error) => write!(f, "bind: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ListenError {}
+
+/// Bind the protocol listener.
+///
+/// # Errors
+///
+/// [`ListenError::InsecureBind`] for §2.3's refused case, or
+/// [`ListenError::Io`] if the socket cannot be bound.
+pub async fn bind(
+    addr: SocketAddr,
+    tls: bool,
+    insecure_override: bool,
+) -> Result<TcpListener, ListenError> {
+    if !tls && !is_loopback(&addr) && !insecure_override {
+        return Err(ListenError::InsecureBind);
+    }
+    TcpListener::bind(addr).await.map_err(ListenError::Io)
+}
+
+/// Accept connections until `shutdown` flips.
+pub async fn serve(
+    relay: Arc<Relay>,
+    listener: TcpListener,
+    acceptor: Option<TlsAcceptor>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    loop {
+        let accepted = tokio::select! {
+            biased;
+            _ = shutdown.changed() => break,
+            accepted = listener.accept() => accepted,
+        };
+        let Ok((stream, peer)) = accepted else {
+            // A transient accept failure (a descriptor limit, a peer that reset
+            // between the SYN and the accept) must not end the listener: the
+            // relay would then be a process that is running and serving nobody.
+            crate::log_warn!("accept failed");
+            continue;
+        };
+
+        let metrics = Arc::clone(relay.metrics());
+        let abuse = Arc::clone(relay.abuse());
+        let source = abuse.key_for(&peer);
+        // §13.1 layer 1, applied **before** any protocol is spoken. There is no
+        // HELLO yet, so there is no frame to answer with; the socket closes.
+        let permit = match abuse.accept(source, crate::now_ms()) {
+            Ok(permit) => permit,
+            Err(reason) => {
+                Metrics::inc(&metrics.connections_refused);
+                crate::log_debug!("connection refused", "reason" = refusal_code(reason));
+                drop(stream);
+                continue;
+            }
+        };
+        Metrics::inc(&metrics.connections_accepted);
+        Metrics::inc(&metrics.connections_open);
+
+        let relay = Arc::clone(&relay);
+        let acceptor = acceptor.clone();
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move {
+            let outcome = handshake(stream, acceptor.as_ref()).await;
+            if let Some((transport, binding)) = outcome {
+                crate::connection::drive(relay, transport, binding, source, shutdown).await;
+            }
+            Metrics::dec(&metrics.connections_open);
+            // The permit is released here, whatever path the task took — a
+            // failed TLS handshake, a refused upgrade, or a full session.
+            drop(permit);
+        });
+    }
+}
+
+const fn refusal_code(reason: Refusal) -> u32 {
+    match reason {
+        Refusal::TooManyConnections => 1,
+        Refusal::TooManyFromSource => 2,
+        Refusal::ConnectingTooFast => 3,
+        Refusal::Backpressure => 4,
+    }
+}
+
+async fn handshake(
+    stream: TcpStream,
+    acceptor: Option<&TlsAcceptor>,
+) -> Option<(Transport, f2z_codec::types::ChannelBinding)> {
+    // Nagle costs a relay latency and buys it nothing: every frame is written
+    // whole by the writer task.
+    let _ = stream.set_nodelay(true);
+
+    match acceptor {
+        Some(acceptor) => {
+            let tls = acceptor.accept(stream).await.ok()?;
+            // §5.3: the exporter is taken from the completed handshake, before
+            // the WebSocket upgrade consumes the stream.
+            let binding = {
+                let (_io, connection) = tls.get_ref();
+                crate::tls::export(connection)
+            };
+            let socket = tokio_tungstenite::accept_hdr_async(tls, check_upgrade)
+                .await
+                .ok()?;
+            Some((wrap(socket), binding))
+        }
+        None => {
+            let socket = tokio_tungstenite::accept_hdr_async(stream, check_upgrade)
+                .await
+                .ok()?;
+            // §5.3: "MUST use **32 zero bytes** in the transcript".
+            Some((wrap(socket), f2z_codec::types::ChannelBinding::zero()))
+        }
+    }
+}
+
+/// §2.1's two mandatory properties of the upgrade.
+///
+/// The `Err` variant is `tungstenite`'s own `http::Response`, whose size is not
+/// ours to change, and this runs once per accept rather than on a hot path.
+#[allow(
+    clippy::result_large_err,
+    reason = "the error type is tungstenite's Callback contract, once per accept"
+)]
+fn check_upgrade(
+    request: &HandshakeRequest,
+    mut response: HandshakeResponse,
+) -> Result<HandshakeResponse, ErrorResponse> {
+    if request.uri().path() != RELAY_PATH {
+        return Err(reject("the relay serves only /relay/v1 (WIRE.md §2.1)"));
+    }
+    let offered = request
+        .headers()
+        .get(HEADER_SUBPROTOCOL)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    if !offered
+        .split(',')
+        .map(str::trim)
+        .any(|value| value == SUBPROTOCOL)
+    {
+        return Err(reject(
+            "the subprotocol header is mandatory in both directions (WIRE.md §2.1)",
+        ));
+    }
+    response
+        .headers_mut()
+        .insert(HEADER_SUBPROTOCOL, HeaderValue::from_static(SUBPROTOCOL));
+    Ok(response)
+}
+
+fn reject(reason: &'static str) -> ErrorResponse {
+    let mut response = ErrorResponse::new(Some(reason.to_owned()));
+    *response.status_mut() = StatusCode::BAD_REQUEST;
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_non_loopback_bind_without_tls_is_refused() {
+        let addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        assert!(matches!(
+            bind(addr, false, false).await,
+            Err(ListenError::InsecureBind)
+        ));
+        // With TLS, or with the published override, §2.3 permits it.
+        assert!(bind(addr, true, false).await.is_ok());
+        assert!(bind(addr, false, true).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn loopback_without_tls_needs_no_override() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        assert!(bind(addr, false, false).await.is_ok());
+    }
+}

--- a/rs/crates/f2z-relay/src/log.rs
+++ b/rs/crates/f2z-relay/src/log.rs
@@ -1,0 +1,250 @@
+//! The relay's log, and the one rule it exists to keep.
+//!
+//! # No payload, no queue address, no key, no IP — at any level
+//!
+//! A relay is the one component that sees every ciphertext and every address in
+//! the system. Its log is therefore the cheapest possible way to undo the whole
+//! design: an operator who turns on `--log-level trace` while debugging must not
+//! thereby create the metadata archive that [ADR 0004] exists to prevent, and
+//! `THREAT-MODEL.md` §3.3's "compromised operator" must not be reachable by
+//! accident from a rotated log file.
+//!
+//! So this module has no `Display` for anything protocol-shaped, no `{:?}` of a
+//! frame, and no formatting of a socket address. What a log line may carry is a
+//! *count*, a *duration*, a *code*, and a fixed string. `tests/redaction.rs`
+//! scans every line this crate can emit for base16, base64url and — the trap —
+//! the **decimal** byte-list form.
+//!
+//! ## The decimal trap, restated because it is the reason this is not obvious
+//!
+//! `f2z-codec`'s redaction tests document it: `tls_codec`'s byte vectors derive
+//! `Debug` and render as `[222, 173, 190, 239, …]`, a complete dump of the bytes
+//! that contains **no hex characters at all**. A leak check written to look for
+//! `deadbeef` passes against that string while every byte is on the page. Every
+//! type that crosses this crate's boundary is an `f2z-codec` newtype with a
+//! redacting `Debug` for exactly that reason, and the test checks the decimal
+//! run as well as the hex.
+//!
+//! # Why not `tracing` or `log`
+//!
+//! Two reasons, and the first is the rule above. A facade invites
+//! `tracing::debug!(?frame)`, and the moment one exists somebody writes it. A
+//! logger with no way to pass a value that is not a number or a `&'static str`
+//! makes the leak a compile error rather than a review finding. The second is
+//! plainer: this binary's dependency graph is its attack surface, and a leveled
+//! writer to stderr is forty lines.
+//!
+//! [ADR 0004]: https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0004-metadata-ambition.md
+
+use std::fmt;
+use std::io::Write as _;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// How much the relay says.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Level {
+    /// Nothing at all. For an operator who ships logs some other way.
+    Off,
+    /// Only what stopped working.
+    Error,
+    /// Degradation an operator should see: backpressure on, a listener retrying.
+    Warn,
+    /// Lifecycle: bound, serving, sweeping, shutting down.
+    #[default]
+    Info,
+    /// Per-connection lifecycle and per-sweep counts.
+    Debug,
+    /// Per-command counts. **Still no payloads, addresses, keys or peers.**
+    Trace,
+}
+
+impl Level {
+    /// Parse `--log-level`.
+    ///
+    /// # Errors
+    ///
+    /// The unrecognized text, so the caller can name it.
+    pub fn parse(text: &str) -> Result<Self, &str> {
+        match text {
+            "off" => Ok(Self::Off),
+            "error" => Ok(Self::Error),
+            "warn" => Ok(Self::Warn),
+            "info" => Ok(Self::Info),
+            "debug" => Ok(Self::Debug),
+            "trace" => Ok(Self::Trace),
+            other => Err(other),
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Trace => "trace",
+        }
+    }
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// The process-wide level. `Info` until [`set_level`] says otherwise.
+static LEVEL: AtomicU8 = AtomicU8::new(Level::Info as u8);
+
+/// Set the level for the process.
+pub fn set_level(level: Level) {
+    LEVEL.store(level as u8, Ordering::Relaxed);
+}
+
+/// The level the process is at.
+#[must_use]
+pub fn level() -> Level {
+    match LEVEL.load(Ordering::Relaxed) {
+        0 => Level::Off,
+        1 => Level::Error,
+        2 => Level::Warn,
+        3 => Level::Info,
+        4 => Level::Debug,
+        _ => Level::Trace,
+    }
+}
+
+/// Whether a line at `level` would be written.
+#[must_use]
+pub fn enabled(target: Level) -> bool {
+    target != Level::Off && target <= level()
+}
+
+/// Write one line. Called only through the macros below.
+///
+/// `message` is a `&'static str` and `fields` are `(name, integer)` pairs, and
+/// that signature *is* the redaction rule: there is no parameter through which
+/// a payload, an address, a key or a peer address could travel.
+pub fn line(target: Level, message: &'static str, fields: &[(&'static str, u64)]) {
+    if !enabled(target) {
+        return;
+    }
+    let mut out = String::with_capacity(64);
+    out.push_str(target.label());
+    out.push(' ');
+    out.push_str(message);
+    for (name, value) in fields {
+        out.push(' ');
+        out.push_str(name);
+        out.push('=');
+        // `u64` renders as digits and nothing else, which is the point: a
+        // formatter that could take `impl Debug` is a formatter that will one
+        // day take a `Payload`.
+        let mut buffer = itoa(*value);
+        out.push_str(buffer.as_str());
+        buffer.clear();
+    }
+    out.push('\n');
+    let mut stderr = std::io::stderr().lock();
+    let _ = stderr.write_all(out.as_bytes());
+    let _ = stderr.flush();
+}
+
+fn itoa(value: u64) -> String {
+    let mut text = String::with_capacity(20);
+    let mut digits = [0u8; 20];
+    let mut length = 0usize;
+    let mut remaining = value;
+    loop {
+        let digit = u8::try_from(remaining % 10).unwrap_or(0);
+        if let Some(slot) = digits.get_mut(length) {
+            *slot = b'0'.saturating_add(digit);
+        }
+        length = length.saturating_add(1);
+        remaining /= 10;
+        if remaining == 0 {
+            break;
+        }
+    }
+    for index in (0..length).rev() {
+        let byte = digits.get(index).copied().unwrap_or(b'0');
+        text.push(char::from(byte));
+    }
+    text
+}
+
+/// An error line.
+#[macro_export]
+macro_rules! log_error {
+    ($message:literal $(, $name:literal = $value:expr)* $(,)?) => {
+        $crate::log::line($crate::log::Level::Error, $message, &[$(($name, u64::from($value))),*])
+    };
+}
+
+/// A warning line.
+#[macro_export]
+macro_rules! log_warn {
+    ($message:literal $(, $name:literal = $value:expr)* $(,)?) => {
+        $crate::log::line($crate::log::Level::Warn, $message, &[$(($name, u64::from($value))),*])
+    };
+}
+
+/// An informational line.
+#[macro_export]
+macro_rules! log_info {
+    ($message:literal $(, $name:literal = $value:expr)* $(,)?) => {
+        $crate::log::line($crate::log::Level::Info, $message, &[$(($name, u64::from($value))),*])
+    };
+}
+
+/// A debug line.
+#[macro_export]
+macro_rules! log_debug {
+    ($message:literal $(, $name:literal = $value:expr)* $(,)?) => {
+        $crate::log::line($crate::log::Level::Debug, $message, &[$(($name, u64::from($value))),*])
+    };
+}
+
+/// A trace line. Still carries no payload, address, key or peer.
+#[macro_export]
+macro_rules! log_trace {
+    ($message:literal $(, $name:literal = $value:expr)* $(,)?) => {
+        $crate::log::line($crate::log::Level::Trace, $message, &[$(($name, u64::from($value))),*])
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn levels_order_from_quiet_to_loud() {
+        assert!(Level::Off < Level::Error);
+        assert!(Level::Error < Level::Warn);
+        assert!(Level::Warn < Level::Info);
+        assert!(Level::Info < Level::Debug);
+        assert!(Level::Debug < Level::Trace);
+    }
+
+    #[test]
+    fn off_enables_nothing_including_itself() {
+        set_level(Level::Off);
+        assert!(!enabled(Level::Error));
+        assert!(!enabled(Level::Off));
+        set_level(Level::Info);
+    }
+
+    #[test]
+    fn parsing_names_what_it_did_not_recognize() {
+        assert_eq!(Level::parse("trace"), Ok(Level::Trace));
+        assert_eq!(Level::parse("verbose"), Err("verbose"));
+    }
+
+    #[test]
+    fn integers_render_as_digits() {
+        assert_eq!(itoa(0), "0");
+        assert_eq!(itoa(1), "1");
+        assert_eq!(itoa(u64::MAX), "18446744073709551615");
+    }
+}

--- a/rs/crates/f2z-relay/src/main.rs
+++ b/rs/crates/f2z-relay/src/main.rs
@@ -1,0 +1,164 @@
+//! `f2z-relay` — the relay daemon's entry point.
+//!
+//! Everything here is argument handling, the five inspection modes, and a
+//! shutdown that is a signal rather than a `SIGKILL`. The relay itself is
+//! [`f2z_relay::server::Server`].
+
+#![forbid(unsafe_code)]
+
+use std::process::ExitCode;
+
+use f2z_relay::caps;
+use f2z_relay::cli::{self, Mode};
+use f2z_relay::config::Config;
+use f2z_relay::server::Server;
+
+fn main() -> ExitCode {
+    let invocation = match cli::parse(std::env::args().skip(1), std::env::vars()) {
+        Ok(invocation) => invocation,
+        Err(error) => {
+            eprintln!("f2z-relay: {error}");
+            return ExitCode::from(2);
+        }
+    };
+
+    match invocation.mode {
+        Mode::Help => {
+            print!("{}", cli::HELP);
+            ExitCode::SUCCESS
+        }
+        Mode::Version => {
+            print!("{}", cli::version());
+            ExitCode::SUCCESS
+        }
+        Mode::PrintConfig => {
+            // Printed **before** `check`, so a configuration that does not
+            // start can still be shown — which is when a reader most wants it.
+            print!("{}", invocation.config.to_redacted_toml());
+            ExitCode::SUCCESS
+        }
+        Mode::CheckConfig => match invocation.config.check() {
+            Ok(()) => {
+                println!("configuration is valid");
+                ExitCode::SUCCESS
+            }
+            Err(error) => {
+                eprintln!("f2z-relay: {error}");
+                ExitCode::from(2)
+            }
+        },
+        Mode::PrintCapabilities => print_capabilities(&invocation.config),
+        Mode::Run => run(invocation.config),
+    }
+}
+
+/// §11.2's representation, for an operator to publish.
+///
+/// This relay does not serve `/.well-known/free2z-relay/v1/capabilities`
+/// itself — [`caps`] explains why, and the short version is that it would put
+/// an HTTP request parser on the unauthenticated public port for an affordance
+/// aimed at humans. What it does instead is hand the operator the exact bytes,
+/// signature and digest included, to publish from whatever already serves their
+/// website. §11.2's property survives: same values, same signature, same
+/// digest, at a URL anyone can poll and diff.
+fn print_capabilities(config: &Config) -> ExitCode {
+    if let Err(error) = config.check() {
+        eprintln!("f2z-relay: {error}");
+        return ExitCode::from(2);
+    }
+    let identity = if config.identity.seed.is_empty() {
+        f2z_relay::identity::load_or_create(
+            std::path::Path::new(&config.identity.path),
+            config.identity.generate,
+        )
+    } else {
+        f2z_relay::identity::from_hex(&config.identity.seed)
+    };
+    let identity = match identity {
+        Ok(identity) => identity,
+        Err(error) => {
+            eprintln!("f2z-relay: {error}");
+            return ExitCode::from(2);
+        }
+    };
+    // The mode the store *would* report. Opening the store to ask would create
+    // the database as a side effect of a print, which is not what a print does.
+    let durability = if config.store.backend == "memory" {
+        f2z_relay_store::Durability::Memory
+    } else {
+        f2z_relay_store::Durability::FsyncPerAppend
+    };
+    let built = caps::build(
+        config,
+        &identity.public_key(),
+        durability,
+        f2z_relay::now_ms(),
+    )
+    .and_then(|capabilities| caps::publish(&identity, capabilities));
+    match built {
+        Ok(published) => {
+            print!("{}", caps::to_json(&published));
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("f2z-relay: {error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run(config: Config) -> ExitCode {
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("f2z-relay: cannot start the runtime: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    runtime.block_on(async {
+        let server = match Server::start(config).await {
+            Ok(server) => server,
+            Err(error) => {
+                eprintln!("f2z-relay: {error}");
+                return ExitCode::from(2);
+            }
+        };
+        eprintln!("f2z-relay: serving {}", server.url());
+        if let Some(admin) = server.admin_addr() {
+            eprintln!("f2z-relay: admin on http://{admin}/healthz and /metrics");
+        }
+
+        wait_for_signal().await;
+        // §6.4's NOTICE(2) goes out here, before the sockets close: a client
+        // that learns the relay is going away can reconnect elsewhere rather
+        // than treating a closed socket as a fault.
+        server.shutdown().await;
+        ExitCode::SUCCESS
+    })
+}
+
+async fn wait_for_signal() {
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(signal) => signal,
+                Err(_) => {
+                    let _ = tokio::signal::ctrl_c().await;
+                    return;
+                }
+            };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = terminate.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}

--- a/rs/crates/f2z-relay/src/metrics.rs
+++ b/rs/crates/f2z-relay/src/metrics.rs
@@ -1,0 +1,322 @@
+//! Counters, and the labels they deliberately do not carry.
+//!
+//! # An unconsidered metrics endpoint is a metadata leak
+//!
+//! The obvious Prometheus design for a relay is
+//! `f2z_relay_queue_messages{queue="…"}` and
+//! `f2z_relay_connections{remote="…"}`, and both are the whole threat model
+//! walking out of the side door. A per-queue series is a per-conversation
+//! activity trace with timestamps — exactly what [ADR 0004] refuses to let the
+//! protocol disclose — and it survives in the scraper's storage long after the
+//! relay has deleted the ciphertext. A per-IP series is a connection log.
+//!
+//! So there are **no labels here at all**. Every series is a single number about
+//! the relay as a whole, and the type system helps: [`Metrics`] has no method
+//! that takes a queue address, a peer address or a key, so a per-queue series is
+//! not something a future edit forgets to avoid — it is something that does not
+//! compile.
+//!
+//! `/metrics` is also loopback-only ([`crate::config::Admin`]), because "no
+//! labels" bounds what one scrape says and does not make totals public.
+//!
+//! # What `/healthz` may not say
+//!
+//! `/healthz` is constant, cheap and carries **no numbers**. Reporting queue
+//! depth or connection counts there would put the same aggregate on an endpoint
+//! whose whole purpose is to be polled every few seconds by something that keeps
+//! history — and a load balancer's health-check log is not a place anyone
+//! reviews for metadata.
+//!
+//! [ADR 0004]: https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0004-metadata-ambition.md
+
+use std::fmt::Write as _;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Every counter the relay keeps.
+#[derive(Debug, Default)]
+pub struct Metrics {
+    /// Connections accepted since start.
+    pub connections_accepted: AtomicU64,
+    /// Connections refused by §13.1 layer 1 or layer 4.
+    pub connections_refused: AtomicU64,
+    /// Connections currently open.
+    pub connections_open: AtomicU64,
+    /// Frames decoded, whatever they turned out to be.
+    pub frames_received: AtomicU64,
+    /// Frames written.
+    pub frames_sent: AtomicU64,
+    /// Commands that returned status 0.
+    pub commands_ok: AtomicU64,
+    /// Commands that returned a §10 code.
+    pub commands_refused: AtomicU64,
+    /// Appends admitted and made durable.
+    pub appends_committed: AtomicU64,
+    /// Store transactions the group-commit writer ran. The ratio of
+    /// `appends_committed` to this is the amortization §8.4 is about.
+    pub commit_transactions: AtomicU64,
+    /// Messages deleted by an `ACK`.
+    pub messages_acked: AtomicU64,
+    /// Messages dropped by the message TTL (§7.7).
+    pub messages_expired: AtomicU64,
+    /// Queues removed by the idle TTL (§7.7).
+    pub queues_expired: AtomicU64,
+    /// Challenges issued (§6.1).
+    pub challenges_issued: AtomicU64,
+    /// Stamps refused as invalid, expired, misscoped or already spent.
+    pub stamps_refused: AtomicU64,
+    /// Pushes dropped because a connection's outbound queue was full.
+    pub pushes_dropped: AtomicU64,
+    /// 1 while §13.1 layer 4 is on.
+    pub backpressure: AtomicU64,
+    /// Messages currently stored, as of the last expiry tick.
+    pub stored_messages: AtomicU64,
+    /// Payload bytes currently stored, as of the last expiry tick.
+    pub stored_payload_bytes: AtomicU64,
+    /// Bytes the storage engine has allocated, as of the last expiry tick.
+    pub storage_bytes: AtomicU64,
+    /// Queues that exist, as of the last expiry tick.
+    pub queues: AtomicU64,
+    /// Entries in the anti-replay seen-set (§5.5).
+    pub antireplay_entries: AtomicU64,
+    /// Outstanding challenges.
+    pub challenges_outstanding: AtomicU64,
+}
+
+impl Metrics {
+    /// A fresh set.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add to a counter.
+    pub fn add(counter: &AtomicU64, delta: u64) {
+        counter.fetch_add(delta, Ordering::Relaxed);
+    }
+
+    /// Add one.
+    pub fn inc(counter: &AtomicU64) {
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Subtract one, saturating at zero.
+    pub fn dec(counter: &AtomicU64) {
+        let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+            Some(value.saturating_sub(1))
+        });
+    }
+
+    /// Overwrite a gauge.
+    pub fn set(counter: &AtomicU64, value: u64) {
+        counter.store(value, Ordering::Relaxed);
+    }
+
+    /// The Prometheus text exposition of every series.
+    ///
+    /// One `HELP`, one `TYPE` and one unlabelled sample each. There is no code
+    /// path here that emits a label, and adding one would need a different
+    /// function.
+    #[must_use]
+    pub fn render(&self) -> String {
+        const SERIES: [(&str, &str, &str); 22] = [
+            (
+                "f2z_relay_connections_accepted_total",
+                "counter",
+                "Connections accepted since start.",
+            ),
+            (
+                "f2z_relay_connections_refused_total",
+                "counter",
+                "Connections refused by anti-abuse.",
+            ),
+            (
+                "f2z_relay_connections_open",
+                "gauge",
+                "Connections currently open.",
+            ),
+            (
+                "f2z_relay_frames_received_total",
+                "counter",
+                "Binary frames received.",
+            ),
+            ("f2z_relay_frames_sent_total", "counter", "Frames written."),
+            (
+                "f2z_relay_commands_ok_total",
+                "counter",
+                "Commands that returned status 0.",
+            ),
+            (
+                "f2z_relay_commands_refused_total",
+                "counter",
+                "Commands that returned an error code.",
+            ),
+            (
+                "f2z_relay_appends_committed_total",
+                "counter",
+                "Appends made durable.",
+            ),
+            (
+                "f2z_relay_commit_transactions_total",
+                "counter",
+                "Store transactions run by the group-commit writer.",
+            ),
+            (
+                "f2z_relay_messages_acked_total",
+                "counter",
+                "Messages deleted by an ACK.",
+            ),
+            (
+                "f2z_relay_messages_expired_total",
+                "counter",
+                "Messages dropped by the message TTL.",
+            ),
+            (
+                "f2z_relay_queues_expired_total",
+                "counter",
+                "Queues removed by the idle TTL.",
+            ),
+            (
+                "f2z_relay_challenges_issued_total",
+                "counter",
+                "Challenges issued.",
+            ),
+            (
+                "f2z_relay_stamps_refused_total",
+                "counter",
+                "Proof-of-work stamps refused.",
+            ),
+            (
+                "f2z_relay_pushes_dropped_total",
+                "counter",
+                "Pushes dropped for a full outbound queue.",
+            ),
+            (
+                "f2z_relay_backpressure",
+                "gauge",
+                "1 while global backpressure is on.",
+            ),
+            (
+                "f2z_relay_stored_messages",
+                "gauge",
+                "Messages stored, at the last sweep.",
+            ),
+            (
+                "f2z_relay_stored_payload_bytes",
+                "gauge",
+                "Payload bytes stored, at the last sweep.",
+            ),
+            (
+                "f2z_relay_storage_bytes",
+                "gauge",
+                "Bytes the storage engine has allocated.",
+            ),
+            (
+                "f2z_relay_queues",
+                "gauge",
+                "Queues that exist, at the last sweep.",
+            ),
+            (
+                "f2z_relay_antireplay_entries",
+                "gauge",
+                "Entries in the anti-replay seen-set.",
+            ),
+            (
+                "f2z_relay_challenges_outstanding",
+                "gauge",
+                "Challenges not yet spent or expired.",
+            ),
+        ];
+        let values = [
+            &self.connections_accepted,
+            &self.connections_refused,
+            &self.connections_open,
+            &self.frames_received,
+            &self.frames_sent,
+            &self.commands_ok,
+            &self.commands_refused,
+            &self.appends_committed,
+            &self.commit_transactions,
+            &self.messages_acked,
+            &self.messages_expired,
+            &self.queues_expired,
+            &self.challenges_issued,
+            &self.stamps_refused,
+            &self.pushes_dropped,
+            &self.backpressure,
+            &self.stored_messages,
+            &self.stored_payload_bytes,
+            &self.storage_bytes,
+            &self.queues,
+            &self.antireplay_entries,
+            &self.challenges_outstanding,
+        ];
+
+        let mut out = String::with_capacity(2048);
+        for (index, (name, kind, help)) in SERIES.iter().enumerate() {
+            let Some(counter) = values.get(index) else {
+                continue;
+            };
+            let _ = writeln!(out, "# HELP {name} {help}");
+            let _ = writeln!(out, "# TYPE {name} {kind}");
+            let _ = writeln!(out, "{name} {}", counter.load(Ordering::Relaxed));
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_series_carries_a_label() {
+        let metrics = Metrics::new();
+        let rendered = metrics.render();
+        for line in rendered.lines() {
+            if line.starts_with('#') {
+                continue;
+            }
+            assert!(
+                !line.contains('{'),
+                "a labelled series would be a metadata leak: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_series_is_declared_and_sampled_exactly_once() {
+        let rendered = Metrics::new().render();
+        let helps = rendered
+            .lines()
+            .filter(|line| line.starts_with("# HELP"))
+            .count();
+        let types = rendered
+            .lines()
+            .filter(|line| line.starts_with("# TYPE"))
+            .count();
+        let samples = rendered
+            .lines()
+            .filter(|line| !line.starts_with('#') && !line.is_empty())
+            .count();
+        assert_eq!(helps, 22);
+        assert_eq!(types, 22);
+        assert_eq!(samples, 22);
+    }
+
+    #[test]
+    fn counters_move_and_gauges_saturate() {
+        let metrics = Metrics::new();
+        Metrics::inc(&metrics.connections_open);
+        Metrics::dec(&metrics.connections_open);
+        Metrics::dec(&metrics.connections_open);
+        assert!(metrics.render().contains("f2z_relay_connections_open 0"));
+        Metrics::add(&metrics.appends_committed, 7);
+        assert!(
+            metrics
+                .render()
+                .contains("f2z_relay_appends_committed_total 7")
+        );
+        Metrics::set(&metrics.storage_bytes, 4_096);
+        assert!(metrics.render().contains("f2z_relay_storage_bytes 4096"));
+    }
+}

--- a/rs/crates/f2z-relay/src/outbound.rs
+++ b/rs/crates/f2z-relay/src/outbound.rs
@@ -1,0 +1,177 @@
+//! What the engine hands the writer task.
+//!
+//! One type for responses, pushes and keepalives, because the writer's rules —
+//! write it, then close if the frame said to — should exist once.
+
+use f2z_codec::ErrorCode;
+use f2z_codec::canonical::Canonical;
+use f2z_codec::commands::{MsgPush, PushEvent, QueuedMessage};
+use f2z_codec::frame::{Push, RelayFrame, Response};
+use f2z_codec::types::QueueAddress;
+
+use crate::transport::WireMessage;
+
+/// One frame on its way out.
+#[derive(Clone)]
+pub struct Outbound {
+    /// What to write. `None` for a frame that is only a close — see
+    /// [`Outbound::close`].
+    pub message: Option<WireMessage>,
+    /// Close the connection after writing, with this RFC 6455 status (§1.3).
+    pub close_after: Option<u16>,
+}
+
+// `message` is an encoded frame, and for a `MSG` push that is the whole of
+// somebody's ciphertext. `WireMessage`'s own `Debug` redacts it; this delegates.
+impl core::fmt::Debug for Outbound {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Outbound")
+            .field("message", &self.message)
+            .field("close_after", &self.close_after)
+            .finish()
+    }
+}
+
+impl Outbound {
+    /// A response frame.
+    #[must_use]
+    pub fn response(request_id: u32, response: Response) -> Option<Self> {
+        Some(Self {
+            message: Some(WireMessage::Binary(
+                RelayFrame::response(request_id, response)
+                    .encode_canonical()
+                    .ok()?,
+            )),
+            close_after: None,
+        })
+    }
+
+    /// A response that closes the connection after it (§1.3).
+    #[must_use]
+    pub fn fatal(request_id: u32, code: ErrorCode, status: u16) -> Option<Self> {
+        let mut outbound = Self::response(request_id, Response::error(code))?;
+        outbound.close_after = Some(status);
+        Some(outbound)
+    }
+
+    /// A bare close, for a frame whose `request_id` could not be recovered.
+    ///
+    /// §1.3 says a fatal error sends the response and then closes; §4.3 forbids
+    /// a zero `request_id` on a response frame. For a frame under five bytes,
+    /// or a text frame, there is no value satisfying both. This relay closes
+    /// with no response frame, which is the reading `f2z-relay-testkit` also
+    /// took — recorded as an ambiguity call, and tracked in
+    /// [#586](https://github.com/free2z/zuu/issues/586).
+    #[must_use]
+    pub const fn close(status: u16) -> Self {
+        Self {
+            message: None,
+            close_after: Some(status),
+        }
+    }
+
+    /// §2.4's keepalive.
+    #[must_use]
+    pub const fn ping() -> Self {
+        Self {
+            message: Some(WireMessage::Ping(Vec::new())),
+            close_after: None,
+        }
+    }
+
+    /// The answer to a client's own Ping.
+    #[must_use]
+    pub const fn pong(payload: Vec<u8>) -> Self {
+        Self {
+            message: Some(WireMessage::Pong(payload)),
+            close_after: None,
+        }
+    }
+}
+
+/// Encode a push frame (§6.4).
+#[must_use]
+pub fn push<B: Canonical>(event: PushEvent, body: &B) -> Option<Outbound> {
+    let frame = RelayFrame::push(Push::new(event.code(), body.encode_canonical().ok()?).ok()?);
+    Some(Outbound {
+        message: Some(WireMessage::Binary(frame.encode_canonical().ok()?)),
+        close_after: None,
+    })
+}
+
+/// The `MSG` push of §6.4, which goes only to the receive side, ever.
+///
+/// §6.4: *"There is no push to a sender, ever — a push to a sender would be a
+/// channel that tells it something about queue state, which §6.3 forbids."*
+/// This function takes a `recv_addr` and there is no sender-side counterpart to
+/// call by mistake.
+#[must_use]
+pub fn msg_push(recv_addr: QueueAddress, message: &QueuedMessage) -> Option<Outbound> {
+    push(
+        PushEvent::Msg,
+        &MsgPush {
+            recv_addr,
+            msg: message.clone(),
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_codec::canonical::decode_canonical;
+    use f2z_codec::frame::FramePayload;
+    use f2z_codec::types::Payload;
+
+    #[test]
+    fn a_fatal_response_carries_the_code_and_then_closes() {
+        let outbound = Outbound::fatal(7, ErrorCode::Malformed, 1002).unwrap();
+        assert_eq!(outbound.close_after, Some(1002));
+        let Some(WireMessage::Binary(bytes)) = &outbound.message else {
+            panic!("expected a binary frame");
+        };
+        let frame = decode_canonical::<RelayFrame>(bytes).unwrap().into_value();
+        assert_eq!(frame.request_id, 7);
+        let FramePayload::Response(response) = frame.payload else {
+            panic!("expected a response");
+        };
+        assert_eq!(response.error_code(), Some(ErrorCode::Malformed));
+        // §4.1: an error response carries a code and nothing else.
+        assert!(response.body().is_empty());
+    }
+
+    #[test]
+    fn an_unrecoverable_frame_closes_without_a_response() {
+        let outbound = Outbound::close(1003);
+        assert!(outbound.message.is_none());
+        assert_eq!(outbound.close_after, Some(1003));
+    }
+
+    #[test]
+    fn a_message_push_never_renders_the_ciphertext() {
+        let message = QueuedMessage {
+            index: 0,
+            received_at_ms: 1,
+            payload: Payload::new(vec![0xde, 0xad, 0xbe, 0xef]).unwrap(),
+        };
+        let outbound = msg_push(QueueAddress::new([1u8; 32]), &message).unwrap();
+        let rendered = format!("{outbound:?}");
+        assert!(rendered.contains("<redacted"));
+        assert!(!rendered.contains("222"));
+    }
+
+    #[test]
+    fn a_push_frame_uses_request_id_zero() {
+        let outbound = push(
+            PushEvent::Notice,
+            &f2z_codec::commands::NoticePush { kind: 3, at_ms: 9 },
+        )
+        .unwrap();
+        let Some(WireMessage::Binary(bytes)) = &outbound.message else {
+            panic!("expected a binary frame");
+        };
+        let frame = decode_canonical::<RelayFrame>(bytes).unwrap().into_value();
+        assert_eq!(frame.request_id, 0);
+        assert!(frame.validate().is_ok());
+    }
+}

--- a/rs/crates/f2z-relay/src/rng.rs
+++ b/rs/crates/f2z-relay/src/rng.rs
@@ -1,0 +1,84 @@
+//! The relay's randomness: queue addresses (§7.1) and challenges (§6.1).
+//!
+//! §7.1 requires **both** queue addresses to come from the relay's own CSPRNG,
+//! 32 uniformly random bytes each, independent of one another and of any key.
+//! The reason is squatting: a client that names its own address lets an
+//! adversary create queues at addresses it predicts a victim will want. So this
+//! module has exactly one source — the operating system's — and no seedable
+//! constructor at all.
+//!
+//! That absence is deliberate and it is the difference between this crate and
+//! `f2z-relay-testkit`, whose addresses are a deterministic stream so that a
+//! conformance vector can be a vector. Its README says plainly that this makes
+//! `f2z-fakerelay` unsafe to deploy. A seeded constructor here, even behind a
+//! test feature, would be a way for the same property to arrive in a real
+//! relay by a build-flag mistake.
+
+use f2z_codec::types::{Challenge, QueueAddress};
+use rand::TryRngCore as _;
+
+/// Fill a buffer from the operating system's CSPRNG.
+///
+/// # Errors
+///
+/// The OS refused to provide randomness. A relay that cannot draw an
+/// unpredictable address must not invent one, so every caller propagates this
+/// rather than falling back.
+fn fill(buffer: &mut [u8; 32]) -> Result<(), rand::rand_core::OsError> {
+    rand::rngs::OsRng.try_fill_bytes(buffer)
+}
+
+/// A fresh queue address (§7.1).
+///
+/// # Errors
+///
+/// [`rand::rand_core::OsError`] if the operating system refused. The caller
+/// answers `ERR_INTERNAL`; §10 says that code carries no detail, ever.
+pub fn queue_address() -> Result<QueueAddress, rand::rand_core::OsError> {
+    let mut bytes = [0u8; 32];
+    fill(&mut bytes)?;
+    Ok(QueueAddress::new(bytes))
+}
+
+/// A fresh single-use challenge (§6.1, §13.1).
+///
+/// # Errors
+///
+/// As [`queue_address`].
+pub fn challenge() -> Result<Challenge, rand::rand_core::OsError> {
+    let mut bytes = [0u8; 32];
+    fill(&mut bytes)?;
+    Ok(Challenge::new(bytes))
+}
+
+/// A fresh 32-byte Ed25519 seed, for [`crate::identity`].
+///
+/// # Errors
+///
+/// As [`queue_address`].
+pub fn seed() -> Result<[u8; 32], rand::rand_core::OsError> {
+    let mut bytes = [0u8; 32];
+    fill(&mut bytes)?;
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn addresses_do_not_repeat_and_are_not_zero() {
+        let mut seen = BTreeSet::new();
+        for _ in 0..256 {
+            let address = queue_address().unwrap();
+            assert!(!address.is_zero());
+            assert!(seen.insert(*address.as_bytes()));
+        }
+    }
+
+    #[test]
+    fn a_challenge_is_drawn_from_the_same_source() {
+        assert_ne!(challenge().unwrap(), challenge().unwrap());
+    }
+}

--- a/rs/crates/f2z-relay/src/server.rs
+++ b/rs/crates/f2z-relay/src/server.rs
@@ -1,0 +1,290 @@
+//! Wiring: a [`Config`] in, a running relay out.
+//!
+//! Startup order is the order in which failure is cheapest to explain:
+//!
+//! 1. **Check the configuration.** Everything [`Config::check`] can decide
+//!    without touching the world — §2.3's bind rule, §5.5's retention
+//!    invariant, §7.7's 30-day ceiling, §12.3's contact-queue caps.
+//! 2. **Establish the identity** (§5.2). Losing it makes this a *different
+//!    relay* to every client holding a queue advert that names it, so it
+//!    happens before anything is bound and it fails loudly.
+//! 3. **Open the store**, which is where `synchronous = FULL` and
+//!    `secure_delete = ON` are verified rather than assumed.
+//! 4. **Build and sign the capability document** from the same values the
+//!    engine will enforce. A document that fails §11.1's own validity rules
+//!    fails here, rather than being served to clients that will refuse it.
+//! 5. **Start the commit writer**, then the listeners, then the tick.
+//!
+//! Shutdown is a `watch` flag every task selects on, plus a `NOTICE(2)` to
+//! subscribed readers (§6.4) so a client learns the relay is going away rather
+//! than inferring it from a closed socket.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+
+use crate::abuse::AbuseGuard;
+use crate::caps;
+use crate::commit::CommitWriter;
+use crate::config::Config;
+use crate::engine::Relay;
+use crate::metrics::Metrics;
+use crate::subscriptions::{NOTICE_SHUTDOWN, Subscriptions};
+
+/// Why a relay could not start.
+#[derive(Debug)]
+pub enum StartError {
+    /// The configuration is not usable.
+    Config(crate::config::ConfigError),
+    /// The identity key could not be established.
+    Identity(crate::identity::IdentityError),
+    /// The store could not be opened.
+    Store(f2z_relay_store::StoreError),
+    /// The capability document could not be built or signed.
+    Capabilities(crate::caps::CapabilitiesError),
+    /// TLS could not be configured.
+    Tls(crate::tls::TlsError),
+    /// The protocol listener could not be bound.
+    Listen(crate::listener::ListenError),
+    /// The admin listener could not be bound.
+    Admin(crate::admin::AdminError),
+    /// A background thread could not be spawned.
+    Spawn(std::io::Error),
+    /// The operating system refused to provide randomness.
+    NoRandomness,
+}
+
+impl std::fmt::Display for StartError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Config(error) => write!(f, "{error}"),
+            Self::Identity(error) => write!(f, "{error}"),
+            Self::Store(error) => write!(f, "store: {error}"),
+            Self::Capabilities(error) => write!(f, "{error}"),
+            Self::Tls(error) => write!(f, "{error}"),
+            Self::Listen(error) => write!(f, "{error}"),
+            Self::Admin(error) => write!(f, "{error}"),
+            Self::Spawn(error) => write!(f, "cannot start the commit writer: {error}"),
+            Self::NoRandomness => f.write_str("the operating system refused to provide randomness"),
+        }
+    }
+}
+
+impl std::error::Error for StartError {}
+
+/// A running relay.
+pub struct Server {
+    relay: Arc<Relay>,
+    protocol_addr: std::net::SocketAddr,
+    admin_addr: Option<std::net::SocketAddr>,
+    shutdown: watch::Sender<bool>,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for Server {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Server")
+            .field("protocol_addr", &self.protocol_addr)
+            .field("admin_addr", &self.admin_addr)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Server {
+    /// Start a relay.
+    ///
+    /// # Errors
+    ///
+    /// [`StartError`], every variant of which is fatal. Nothing here degrades:
+    /// a relay that cannot serve TLS must not silently serve plaintext, and a
+    /// relay that cannot open its store must not serve from memory.
+    pub async fn start(config: Config) -> Result<Self, StartError> {
+        config.check().map_err(StartError::Config)?;
+        if let Ok(level) = config.log_level() {
+            crate::log::set_level(level);
+        }
+
+        let identity = if config.identity.seed.is_empty() {
+            crate::identity::load_or_create(
+                std::path::Path::new(&config.identity.path),
+                config.identity.generate,
+            )
+        } else {
+            crate::identity::from_hex(&config.identity.seed)
+        }
+        .map_err(StartError::Identity)?;
+
+        let store: Arc<dyn f2z_relay_store::RelayStore + Send + Sync> =
+            match config.store.backend.as_str() {
+                "memory" => Arc::new(f2z_relay_store::MemoryStore::new()),
+                // Anything else was rejected by `check`; `sqlite` is the only
+                // remaining value.
+                _ => Arc::new(
+                    f2z_relay_store::SqliteStore::open(&config.store.path)
+                        .map_err(StartError::Store)?,
+                ),
+            };
+        let durability = store.durability();
+
+        let now = crate::now_ms();
+        let capabilities = caps::build(&config, &identity.public_key(), durability, now)
+            .map_err(StartError::Capabilities)?;
+        let padding = f2z_codec::padding::PaddingBuckets::new(config.padding.sizes.clone())
+            .map_err(|_| {
+                StartError::Config(crate::config::ConfigError::Invalid(
+                    "padding.sizes",
+                    "is not a valid ascending set".to_owned(),
+                ))
+            })?;
+        let published = caps::publish(&identity, capabilities).map_err(StartError::Capabilities)?;
+
+        let metrics = Arc::new(Metrics::new());
+        let subscriptions = Arc::new(Subscriptions::new());
+        let abuse = Arc::new(AbuseGuard::new(
+            config.limits.clone(),
+            config.antiabuse.per_source_limits,
+            crate::rng::seed().map_err(|_| StartError::NoRandomness)?,
+        ));
+
+        let writer = CommitWriter::start(
+            Arc::clone(&store),
+            Arc::clone(&metrics),
+            Duration::from_millis(u64::from(config.commit.window_ms)),
+            usize::try_from(config.commit.max_batch).unwrap_or(256),
+        )
+        .map_err(StartError::Spawn)?;
+
+        let acceptor = if config.tls_enabled() {
+            Some(
+                crate::tls::acceptor(
+                    std::path::Path::new(&config.listen.tls_cert),
+                    std::path::Path::new(&config.listen.tls_key),
+                )
+                .map_err(StartError::Tls)?,
+            )
+        } else {
+            None
+        };
+
+        let listen_addr = config.listen_addr().map_err(StartError::Config)?;
+        let admin_enabled = config.admin.enabled;
+        let admin_configured = config.admin_addr().map_err(StartError::Config)?;
+
+        let listener =
+            crate::listener::bind(listen_addr, acceptor.is_some(), config.listen.insecure)
+                .await
+                .map_err(StartError::Listen)?;
+        let protocol_addr = listener
+            .local_addr()
+            .map_err(|error| StartError::Listen(crate::listener::ListenError::Io(error)))?;
+
+        let admin_listener = if admin_enabled {
+            Some(
+                crate::admin::bind(admin_configured)
+                    .await
+                    .map_err(StartError::Admin)?,
+            )
+        } else {
+            None
+        };
+        let admin_addr = admin_listener
+            .as_ref()
+            .and_then(|listener| listener.local_addr().ok());
+
+        let relay = Arc::new(Relay::new(
+            config,
+            identity,
+            published,
+            padding,
+            Arc::clone(&store),
+            writer,
+            Arc::clone(&subscriptions),
+            Arc::clone(&abuse),
+            Arc::clone(&metrics),
+        ));
+
+        let (shutdown, watcher) = watch::channel(false);
+        let mut tasks = Vec::with_capacity(3);
+        tasks.push(tokio::spawn(crate::listener::serve(
+            Arc::clone(&relay),
+            listener,
+            acceptor,
+            watcher.clone(),
+        )));
+        if let Some(admin_listener) = admin_listener {
+            tasks.push(tokio::spawn(crate::admin::serve(
+                Arc::clone(&relay),
+                admin_listener,
+                watcher.clone(),
+            )));
+        }
+        tasks.push(tokio::spawn(crate::expiry::run(
+            Arc::clone(&relay),
+            watcher,
+        )));
+
+        crate::log_info!("relay listening", "port" = protocol_addr.port());
+        Ok(Self {
+            relay,
+            protocol_addr,
+            admin_addr,
+            shutdown,
+            tasks,
+        })
+    }
+
+    /// The bound protocol address. With port 0 this is the port the OS chose.
+    #[must_use]
+    pub const fn protocol_addr(&self) -> std::net::SocketAddr {
+        self.protocol_addr
+    }
+
+    /// The bound admin address, if the admin listener is enabled.
+    #[must_use]
+    pub const fn admin_addr(&self) -> Option<std::net::SocketAddr> {
+        self.admin_addr
+    }
+
+    /// The relay itself, for a test that wants to read its published document.
+    #[must_use]
+    pub const fn relay(&self) -> &Arc<Relay> {
+        &self.relay
+    }
+
+    /// The `ws://` or `wss://` endpoint URL, path included (§2.1).
+    #[must_use]
+    pub fn url(&self) -> String {
+        let scheme = if self.relay.config().tls_enabled() {
+            "wss"
+        } else {
+            "ws"
+        };
+        format!(
+            "{scheme}://{}{}",
+            self.protocol_addr,
+            crate::transport::RELAY_PATH
+        )
+    }
+
+    /// Stop accepting, tell subscribed readers, and wait for the tasks.
+    ///
+    /// §6.4's `NOTICE(2)` is sent first: a client that learns the relay is
+    /// going away can stop sending and reconnect elsewhere, rather than
+    /// discovering it from a closed socket and treating it as a fault.
+    pub async fn shutdown(self) {
+        self.relay.subscriptions().notify_all(
+            NOTICE_SHUTDOWN,
+            crate::now_ms(),
+            self.relay.metrics(),
+        );
+        // A moment for the writers to drain that notice before the same flag
+        // closes their connections.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let _ = self.shutdown.send(true);
+        for task in self.tasks {
+            let _ = task.await;
+        }
+        crate::log_info!("relay stopped");
+    }
+}

--- a/rs/crates/f2z-relay/src/subscriptions.rs
+++ b/rs/crates/f2z-relay/src/subscriptions.rs
@@ -1,0 +1,261 @@
+//! Who is listening on which receive address (§6.2, §6.4).
+//!
+//! A subscription is **scoped to the connection and dies with it** — §6.2 says
+//! so, and it is the reason this table is keyed by receive address and holds a
+//! connection id beside every sender: dropping a connection has to be able to
+//! find and remove every entry it owns without walking the whole table.
+//!
+//! # Only the receive side, ever
+//!
+//! §6.4: *"There is no push to a sender, ever — a push to a sender would be a
+//! channel that tells it something about queue state, which §6.3 forbids."*
+//! There is no send-address index here, so there is nothing to push to.
+//!
+//! # Bounded, and dropping rather than buffering
+//!
+//! §13.1 makes a subscriber that cannot keep up subject to backpressure "not to
+//! unbounded server-side buffering". The channel is bounded; when it is full the
+//! push is **dropped** and counted. That is safe in a way that dropping a
+//! message would not be: the ciphertext is still in the queue, the reader's
+//! `READ` still returns it, and the push was only ever a hint that a `READ` is
+//! worth doing. §13.2's rule is about *messages*, and a push is not one.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use f2z_codec::commands::{NoticePush, PushEvent, QueueEventPush, QueuedMessage};
+use f2z_codec::types::QueueAddress;
+
+use crate::metrics::Metrics;
+use crate::outbound::{Outbound, msg_push, push};
+
+/// `QUEUE_EVENT` reason 1 (§6.4): the queue was deleted.
+pub const QUEUE_EVENT_DELETED: u8 = 1;
+/// `QUEUE_EVENT` reason 4 (§6.4): a quota was reached.
+pub const QUEUE_EVENT_QUOTA: u8 = 4;
+/// `NOTICE` kind 2 (§6.4): the relay is shutting down at `at_ms`.
+pub const NOTICE_SHUTDOWN: u8 = 2;
+
+/// One connection's registration on one address.
+struct Subscriber {
+    connection: u64,
+    sender: tokio::sync::mpsc::Sender<Outbound>,
+}
+
+impl core::fmt::Debug for Subscriber {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Subscriber")
+            .field("connection", &self.connection)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The relay's subscription table.
+#[derive(Debug, Default)]
+pub struct Subscriptions {
+    // The key is a queue address. `QueueAddress`'s `Debug` redacts, so the
+    // derived `Debug` on this map does too.
+    by_recv: Mutex<HashMap<QueueAddress, Vec<Subscriber>>>,
+}
+
+impl Subscriptions {
+    /// An empty table.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a connection for pushes on `recv_addr`. Idempotent.
+    pub fn subscribe(
+        &self,
+        recv_addr: QueueAddress,
+        connection: u64,
+        sender: tokio::sync::mpsc::Sender<Outbound>,
+    ) {
+        let mut table = self.lock();
+        let entries = table.entry(recv_addr).or_default();
+        if entries
+            .iter()
+            .any(|subscriber| subscriber.connection == connection)
+        {
+            return;
+        }
+        entries.push(Subscriber { connection, sender });
+    }
+
+    /// Drop one connection's registration on one address.
+    pub fn unsubscribe(&self, recv_addr: &QueueAddress, connection: u64) {
+        let mut table = self.lock();
+        if let Some(entries) = table.get_mut(recv_addr) {
+            entries.retain(|subscriber| subscriber.connection != connection);
+            if entries.is_empty() {
+                table.remove(recv_addr);
+            }
+        }
+    }
+
+    /// Drop every registration a connection holds — §6.2's "dies with it".
+    pub fn drop_connection(&self, connection: u64, addresses: &[QueueAddress]) {
+        for address in addresses {
+            self.unsubscribe(address, connection);
+        }
+    }
+
+    /// Whether anybody is listening. Lets the engine skip encoding a push
+    /// nobody will receive, which on a relay with few subscribers is most of
+    /// them.
+    #[must_use]
+    pub fn has_subscriber(&self, recv_addr: &QueueAddress) -> bool {
+        self.lock().contains_key(recv_addr)
+    }
+
+    /// Push a `MSG` to whoever is reading this queue (§6.4).
+    pub fn notify_message(
+        &self,
+        recv_addr: QueueAddress,
+        message: &QueuedMessage,
+        metrics: &Metrics,
+    ) {
+        self.deliver(&recv_addr, metrics, || msg_push(recv_addr, message));
+    }
+
+    /// Push a `QUEUE_EVENT` (§6.4). Silent to a writer, always.
+    pub fn notify_queue_event(&self, recv_addr: QueueAddress, reason: u8, metrics: &Metrics) {
+        let body = QueueEventPush { recv_addr, reason };
+        self.deliver(&recv_addr, metrics, || push(PushEvent::QueueEvent, &body));
+    }
+
+    /// Push a `NOTICE` to every subscribed connection (§6.4).
+    pub fn notify_all(&self, kind: u8, at_ms: u64, metrics: &Metrics) {
+        let body = NoticePush { kind, at_ms };
+        let table = self.lock();
+        for entries in table.values() {
+            for subscriber in entries {
+                let Some(outbound) = push(PushEvent::Notice, &body) else {
+                    continue;
+                };
+                if subscriber.sender.try_send(outbound).is_err() {
+                    Metrics::inc(&metrics.pushes_dropped);
+                }
+            }
+        }
+    }
+
+    fn deliver<F: Fn() -> Option<Outbound>>(
+        &self,
+        recv_addr: &QueueAddress,
+        metrics: &Metrics,
+        build: F,
+    ) {
+        let table = self.lock();
+        let Some(entries) = table.get(recv_addr) else {
+            return;
+        };
+        for subscriber in entries {
+            let Some(outbound) = build() else {
+                continue;
+            };
+            // `try_send`, never `send`: a slow reader must not be able to stall
+            // the task that just committed somebody else's append.
+            if subscriber.sender.try_send(outbound).is_err() {
+                Metrics::inc(&metrics.pushes_dropped);
+            }
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<QueueAddress, Vec<Subscriber>>> {
+        self.by_recv
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use f2z_codec::types::Payload;
+
+    fn message() -> QueuedMessage {
+        QueuedMessage {
+            index: 0,
+            received_at_ms: 1,
+            payload: Payload::new(vec![0xde, 0xad, 0xbe, 0xef]).unwrap(),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_subscriber_receives_and_an_unsubscriber_does_not() {
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let address = QueueAddress::new([1u8; 32]);
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(4);
+        table.subscribe(address, 1, sender);
+        table.notify_message(address, &message(), &metrics);
+        assert!(receiver.try_recv().is_ok());
+
+        table.unsubscribe(&address, 1);
+        table.notify_message(address, &message(), &metrics);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn subscribing_twice_registers_once() {
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let address = QueueAddress::new([2u8; 32]);
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(4);
+        table.subscribe(address, 1, sender.clone());
+        table.subscribe(address, 1, sender);
+        table.notify_message(address, &message(), &metrics);
+        assert!(receiver.try_recv().is_ok());
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn a_dropped_connection_takes_every_subscription_with_it() {
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let first = QueueAddress::new([3u8; 32]);
+        let second = QueueAddress::new([4u8; 32]);
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(4);
+        table.subscribe(first, 9, sender.clone());
+        table.subscribe(second, 9, sender);
+        table.drop_connection(9, &[first, second]);
+        assert!(!table.has_subscriber(&first));
+        assert!(!table.has_subscriber(&second));
+        table.notify_message(first, &message(), &metrics);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn a_full_outbound_queue_drops_the_push_and_counts_it() {
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let address = QueueAddress::new([5u8; 32]);
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+        table.subscribe(address, 1, sender);
+        for _ in 0..4 {
+            table.notify_message(address, &message(), &metrics);
+        }
+        assert!(
+            metrics
+                .pushes_dropped
+                .load(std::sync::atomic::Ordering::Relaxed)
+                > 0
+        );
+    }
+
+    #[tokio::test]
+    async fn the_table_never_renders_an_address_or_a_payload() {
+        let table = Subscriptions::new();
+        let address = QueueAddress::new([0xde; 32]);
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+        table.subscribe(address, 1, sender);
+        let rendered = format!("{table:?}");
+        assert!(
+            !rendered.contains("222"),
+            "decimal byte list leaked: {rendered}"
+        );
+        assert!(!rendered.contains("dede"));
+    }
+}

--- a/rs/crates/f2z-relay/src/tls.rs
+++ b/rs/crates/f2z-relay/src/tls.rs
@@ -1,0 +1,182 @@
+//! TLS 1.3, and the exporter §5.3 binds every signature to.
+//!
+//! # TLS 1.3 is a floor, not a preference
+//!
+//! §2.1: *"A relay MUST NOT negotiate TLS 1.2 or below."* The reason is §5.3 —
+//! the channel binding is the TLS 1.3 exporter of
+//! [RFC 8446 §7.5](https://datatracker.ietf.org/doc/html/rfc8446#section-7.5),
+//! and there is no defined binding for this protocol over TLS 1.2. So the
+//! `rustls` configuration names TLS 1.3 as the only version rather than as a
+//! minimum, and a client that cannot reach it fails the handshake instead of
+//! reaching a relay whose transcripts would have to carry zeros.
+//!
+//! # The exporter, and the honest caveat
+//!
+//! ```text
+//! channel_binding = TLS-Exporter("EXPORTER-free2z-relay-v1", "", 32)
+//! ```
+//!
+//! Both ends compute it from their own TLS state and it is never transmitted.
+//! The relay reconstructs every transcript with **its own** value, so a
+//! signature made on a different TLS session simply fails to verify — which,
+//! with §5.2's `relay_id`, is what makes a captured frame useless anywhere
+//! except the connection it was captured from.
+//!
+//! §5.3 states the caveat and this module cannot remove it: **a relay behind a
+//! TLS-terminating proxy cannot compute it.** There is no exporter without a TLS
+//! session, no standardized way for a proxy to forward one, and trusting a
+//! proxy-supplied value would defeat the point. Such a deployment runs this
+//! relay with no certificate, behind the proxy, and publishes
+//! `channel_binding_mode: none` and `transport_security: none` — which
+//! [`crate::caps`] does automatically, because both come from the same
+//! `tls_enabled()` question.
+
+use std::io;
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio_rustls::TlsAcceptor;
+use tokio_rustls::rustls::pki_types::pem::PemObject as _;
+use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio_rustls::rustls::{ServerConfig, SupportedProtocolVersion};
+
+/// §5.3's exporter label.
+pub const EXPORTER_LABEL: &[u8] = b"EXPORTER-free2z-relay-v1";
+
+/// §5.3's exporter length.
+pub const EXPORTER_LEN: usize = 32;
+
+/// TLS 1.3 and nothing else (§2.1).
+const VERSIONS: &[&SupportedProtocolVersion] = &[&tokio_rustls::rustls::version::TLS13];
+
+/// Why TLS could not be configured.
+#[derive(Debug)]
+pub enum TlsError {
+    /// A file could not be read or parsed.
+    ///
+    /// The PEM reader is `rustls-pki-types`' own rather than `rustls-pemfile`:
+    /// that crate was archived in August 2025 (RUSTSEC-2025-0134) and its own
+    /// advisory says its latest version is a thin wrapper around exactly this
+    /// code. One fewer crate on the path that reads an operator's private key.
+    Pem(&'static str, String),
+    /// A file could not be read.
+    Io(&'static str, io::Error),
+    /// The certificate file holds no certificate.
+    NoCertificate,
+    /// The key file holds no private key this build can use.
+    ///
+    /// Retained as a distinct variant because the message names the three forms
+    /// that are accepted, which is the thing an operator with a failing
+    /// certificate actually needs to read.
+    NoPrivateKey,
+    /// `rustls` refused the pair.
+    Rustls(tokio_rustls::rustls::Error),
+}
+
+impl std::fmt::Display for TlsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pem(what, detail) => write!(f, "{what}: {detail}"),
+            Self::Io(what, error) => write!(f, "{what}: {error}"),
+            Self::NoCertificate => f.write_str("listen.tls_cert holds no PEM certificate"),
+            Self::NoPrivateKey => f.write_str(
+                "listen.tls_key holds no PKCS#8, PKCS#1 or SEC1 private key in PEM form",
+            ),
+            Self::Rustls(error) => write!(f, "TLS configuration: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for TlsError {}
+
+/// Build an acceptor that negotiates TLS 1.3 only.
+///
+/// # Errors
+///
+/// [`TlsError`], every variant of which is a startup failure. A relay
+/// configured for TLS that cannot serve it must not silently fall back to
+/// plaintext: §2.3's insecure path is an explicit act with published
+/// consequences, not a degradation.
+pub fn acceptor(cert_path: &Path, key_path: &Path) -> Result<TlsAcceptor, TlsError> {
+    let certs = load_certificates(cert_path)?;
+    let key = load_private_key(key_path)?;
+
+    let config = ServerConfig::builder_with_protocol_versions(VERSIONS)
+        // A relay authenticates itself with §5.2's Ed25519 identity key inside
+        // the protocol, and its clients are anonymous by construction (ADR
+        // 0004). There is no client certificate to want.
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(TlsError::Rustls)?;
+
+    Ok(TlsAcceptor::from(Arc::new(config)))
+}
+
+fn load_certificates(path: &Path) -> Result<Vec<CertificateDer<'static>>, TlsError> {
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_file_iter(path)
+        .map_err(|error| TlsError::Pem("listen.tls_cert", error.to_string()))?
+        .collect::<Result<_, _>>()
+        .map_err(|error| TlsError::Pem("listen.tls_cert", error.to_string()))?;
+    if certs.is_empty() {
+        return Err(TlsError::NoCertificate);
+    }
+    Ok(certs)
+}
+
+fn load_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, TlsError> {
+    PrivateKeyDer::from_pem_file(path)
+        .map_err(|error| TlsError::Pem("listen.tls_key", error.to_string()))
+}
+
+/// §5.3's exporter, taken from a completed handshake.
+///
+/// Returns 32 zero bytes when there is no TLS session, which is the value §5.3
+/// requires in `channel_binding_mode: none` — the same constant both ends use,
+/// so the transcript still verifies and the binding simply provides nothing.
+#[must_use]
+pub fn export(
+    connection: &tokio_rustls::rustls::ServerConnection,
+) -> f2z_codec::types::ChannelBinding {
+    let mut output = [0u8; EXPORTER_LEN];
+    match connection.export_keying_material(output, EXPORTER_LABEL, None) {
+        Ok(bytes) => f2z_codec::types::ChannelBinding::new(bytes),
+        // An exporter that cannot be derived from a completed TLS 1.3 handshake
+        // is a `rustls` state this code has no way to repair. Zeros are the
+        // value §5.3 defines for "no binding", so the connection degrades to the
+        // documented weaker mode rather than to a value only one end knows.
+        Err(_) => {
+            crate::log_warn!("TLS exporter unavailable; this connection has no channel binding");
+            output = [0u8; EXPORTER_LEN];
+            f2z_codec::types::ChannelBinding::new(output)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_exporter_label_and_length_are_section_5_3s() {
+        assert_eq!(EXPORTER_LABEL, b"EXPORTER-free2z-relay-v1");
+        assert_eq!(EXPORTER_LEN, 32);
+    }
+
+    #[test]
+    fn only_tls_1_3_is_offered() {
+        assert_eq!(VERSIONS.len(), 1);
+    }
+
+    #[test]
+    fn a_missing_certificate_is_a_startup_failure_and_names_the_key() {
+        // `TlsAcceptor` has no `Debug`, so the error is taken by matching
+        // rather than by `unwrap_err`.
+        let Err(error) = acceptor(
+            Path::new("/nonexistent/cert.pem"),
+            Path::new("/nonexistent/key.pem"),
+        ) else {
+            panic!("a missing certificate must not configure TLS");
+        };
+        assert!(format!("{error}").contains("listen.tls_cert"));
+    }
+}

--- a/rs/crates/f2z-relay/src/transport.rs
+++ b/rs/crates/f2z-relay/src/transport.rs
@@ -1,0 +1,246 @@
+//! The one transport (§2.1), over plaintext TCP or over TLS 1.3.
+//!
+//! §2.2 admits exactly one transport and gives the reason: *"a second transport
+//! is a second parser and a second fuzz target."* So there is one WebSocket
+//! implementation here and one framing, and the only thing that varies is
+//! whether the bytes underneath it went through `rustls`.
+//!
+//! The seam is a pair of boxed traits rather than a generic parameter, because
+//! the connection loop must not be duplicated per stream type: a monomorphized
+//! `drive::<TcpStream>` and `drive::<TlsStream<TcpStream>>` are two copies of
+//! the code that decides when to close a connection, and they would be two
+//! copies that can drift.
+//!
+//! # What is faithful here
+//!
+//! §2.1's path (`/relay/v1`), the mandatory `free2z-relay.v1` subprotocol in
+//! both directions, binary versus text framing, §2.4's Ping/Pong, and the close
+//! codes of §1.3 and §4.2.
+
+use std::io;
+
+use futures_util::future::BoxFuture;
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt as _, StreamExt as _};
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::{Bytes, Message};
+
+/// §2.1's path.
+pub const RELAY_PATH: &str = "/relay/v1";
+
+/// §2.1's mandatory subprotocol.
+///
+/// *"A relay that does not echo `free2z-relay.v1` MUST be treated by the client
+/// as not speaking this protocol, and the client MUST close rather than
+/// guess."*
+pub const SUBPROTOCOL: &str = "free2z-relay.v1";
+
+/// RFC 6455 status 1002, "protocol error": every fatal §10 code except §4.2's.
+///
+/// §1.3 defines a fatal error as "send the response, then close the WebSocket
+/// connection" and names no status. 1002 is the reading used here, and it is an
+/// ambiguity call — the same one `f2z-relay-testkit` made, so the two agree.
+pub const CLOSE_PROTOCOL_ERROR: u16 = 1002;
+
+/// RFC 6455 status 1003, "unsupported data": §4.2's text frame, which the
+/// specification does name.
+pub const CLOSE_UNSUPPORTED_DATA: u16 = 1003;
+
+/// RFC 6455 status 1000.
+pub const CLOSE_NORMAL: u16 = 1000;
+
+/// RFC 6455 status 1001, "going away": a clean shutdown.
+pub const CLOSE_GOING_AWAY: u16 = 1001;
+
+/// One protocol unit, as it crosses the seam.
+#[derive(Clone, PartialEq, Eq)]
+pub enum WireMessage {
+    /// A relay frame (§4.1) — the only kind that carries protocol.
+    Binary(Vec<u8>),
+    /// §4.2: a fatal `ERR_FRAME_TYPE` and a close with status 1003.
+    Text,
+    /// §2.4's server-driven Ping.
+    Ping(Vec<u8>),
+    /// A Pong, whether ours or the client's.
+    Pong(Vec<u8>),
+    /// A close, with its RFC 6455 status.
+    Close(u16),
+}
+
+// A binary message is a whole frame — an APPEND payload included — and a
+// derived `Debug` would render it as a list of decimal integers. See
+// `crate::log` for why decimal is the trap and hex is not the check.
+impl core::fmt::Debug for WireMessage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Binary(bytes) => write!(f, "Binary(<redacted; {} bytes>)", bytes.len()),
+            Self::Text => f.write_str("Text"),
+            Self::Ping(bytes) => write!(f, "Ping(<{} bytes>)", bytes.len()),
+            Self::Pong(bytes) => write!(f, "Pong(<{} bytes>)", bytes.len()),
+            Self::Close(code) => write!(f, "Close({code})"),
+        }
+    }
+}
+
+/// The write half.
+pub trait TransportSink: Send {
+    /// Write one message.
+    fn send(&mut self, message: WireMessage) -> BoxFuture<'_, io::Result<()>>;
+    /// Close with an RFC 6455 status.
+    fn close(&mut self, code: u16) -> BoxFuture<'_, io::Result<()>>;
+}
+
+/// The read half.
+pub trait TransportStream: Send {
+    /// The next message, or `None` at end of stream.
+    fn recv(&mut self) -> BoxFuture<'_, io::Result<Option<WireMessage>>>;
+}
+
+/// A connection, split so a writer task and a reader loop hold one half each.
+pub struct Transport {
+    /// The write half.
+    pub sink: Box<dyn TransportSink>,
+    /// The read half.
+    pub stream: Box<dyn TransportStream>,
+}
+
+impl core::fmt::Debug for Transport {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("Transport { .. }")
+    }
+}
+
+impl Transport {
+    /// Split into the two halves.
+    #[must_use]
+    pub fn split(self) -> (Box<dyn TransportSink>, Box<dyn TransportStream>) {
+        (self.sink, self.stream)
+    }
+}
+
+struct WsSink<S> {
+    inner: SplitSink<WebSocketStream<S>, Message>,
+}
+
+impl<S> WsSink<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    async fn write(&mut self, message: WireMessage) -> io::Result<()> {
+        let message = match message {
+            WireMessage::Binary(bytes) => Message::Binary(Bytes::from(bytes)),
+            // A relay never sends a text frame. §4.2 is a rule about what it
+            // receives, and the absence of a construction here is what makes
+            // the rule symmetrical.
+            WireMessage::Text => return Ok(()),
+            WireMessage::Ping(bytes) => Message::Ping(Bytes::from(bytes)),
+            WireMessage::Pong(bytes) => Message::Pong(Bytes::from(bytes)),
+            WireMessage::Close(code) => Message::Close(Some(CloseFrame {
+                code: CloseCode::from(code),
+                reason: String::new().into(),
+            })),
+        };
+        self.inner.send(message).await.map_err(io::Error::other)
+    }
+}
+
+impl<S> TransportSink for WsSink<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    fn send(&mut self, message: WireMessage) -> BoxFuture<'_, io::Result<()>> {
+        Box::pin(self.write(message))
+    }
+
+    fn close(&mut self, code: u16) -> BoxFuture<'_, io::Result<()>> {
+        Box::pin(async move {
+            let _ = self.write(WireMessage::Close(code)).await;
+            self.inner.close().await.map_err(io::Error::other)
+        })
+    }
+}
+
+struct WsStream<S> {
+    inner: SplitStream<WebSocketStream<S>>,
+}
+
+impl<S> WsStream<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    async fn read(&mut self) -> io::Result<Option<WireMessage>> {
+        loop {
+            let Some(next) = self.inner.next().await else {
+                return Ok(None);
+            };
+            let message = next.map_err(io::Error::other)?;
+            return Ok(Some(match message {
+                Message::Binary(bytes) => WireMessage::Binary(bytes.to_vec()),
+                // §4.2: the relay MUST NOT attempt to decode it and MUST NOT
+                // attempt UTF-8 validation of its own. Dropping the payload
+                // here rather than carrying it is that rule as an absence.
+                Message::Text(_) => WireMessage::Text,
+                Message::Ping(bytes) => WireMessage::Ping(bytes.to_vec()),
+                Message::Pong(bytes) => WireMessage::Pong(bytes.to_vec()),
+                Message::Close(frame) => {
+                    WireMessage::Close(frame.map_or(CLOSE_NORMAL, |frame| frame.code.into()))
+                }
+                // A raw frame never surfaces from a `WebSocketStream` in read
+                // mode; skip rather than invent a protocol event for it.
+                Message::Frame(_) => continue,
+            }));
+        }
+    }
+}
+
+impl<S> TransportStream for WsStream<S>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    fn recv(&mut self) -> BoxFuture<'_, io::Result<Option<WireMessage>>> {
+        Box::pin(self.read())
+    }
+}
+
+/// Wrap a negotiated WebSocket as a [`Transport`].
+pub fn wrap<S>(socket: WebSocketStream<S>) -> Transport
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let (sink, stream) = socket.split();
+    Transport {
+        sink: Box::new(WsSink { inner: sink }),
+        stream: Box::new(WsStream { inner: stream }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_binary_message_never_renders_its_bytes() {
+        let message = WireMessage::Binary(vec![0xde, 0xad, 0xbe, 0xef]);
+        let rendered = format!("{message:?}");
+        assert_eq!(rendered, "Binary(<redacted; 4 bytes>)");
+        assert!(!rendered.contains("222"));
+        assert!(!rendered.contains("de"));
+    }
+
+    #[test]
+    fn a_text_frame_carries_nothing_into_the_relay() {
+        // §4.2's "MUST NOT attempt to decode it", as a type: there is no
+        // payload on the variant to decode.
+        assert_eq!(format!("{:?}", WireMessage::Text), "Text");
+    }
+
+    #[test]
+    fn the_close_codes_are_the_ones_the_sections_name() {
+        assert_eq!(CLOSE_UNSUPPORTED_DATA, 1003);
+        assert_eq!(CLOSE_PROTOCOL_ERROR, 1002);
+        assert_eq!(CLOSE_NORMAL, 1000);
+        assert_eq!(CLOSE_GOING_AWAY, 1001);
+    }
+}

--- a/rs/crates/f2z-relay/tests/admin.rs
+++ b/rs/crates/f2z-relay/tests/admin.rs
@@ -1,0 +1,215 @@
+//! The loopback-only admin listener, and the two things it must not say.
+//!
+//! # `/healthz` must be constant and cheap
+//!
+//! It is polled every few seconds by a load balancer that keeps a log. So it
+//! must not report queue depth or connection counts — that would put a
+//! per-relay activity trace into a place nobody reviews for metadata — and it
+//! must not touch storage, because a health check that queried the disk would
+//! fail during exactly the backpressure it exists to survive, and would pull the
+//! relay out of rotation at the moment `READ` and `ACK` are keeping it alive.
+//!
+//! # `/metrics` must carry no labels
+//!
+//! A `{queue="…"}` series is a per-conversation activity trace with timestamps
+//! that outlives the ciphertext in the scraper's storage; a `{remote="…"}`
+//! series is a connection log. Neither is something the protocol will disclose,
+//! and neither may arrive through the side door.
+//!
+//! # And neither may leave the host
+//!
+//! Both are refused a non-loopback bind at startup rather than warned about.
+
+// An integration test is its own crate, so the workspace's denials of the
+// panicking families do not reach it through `lib.rs`'s `cfg_attr(test, ...)`.
+// They are relaxed here for the reason `rs/README.md` gives: a test that has to
+// thread a `Result` through every assertion is a test nobody reads, and a panic
+// in a test is a failing test rather than a remote denial of service.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::time::Duration;
+
+use f2z_relay::config::Config;
+use f2z_relay::server::Server;
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_testkit::client::{Client, ClientConfig};
+use f2z_relay_testkit::websocket;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+async fn get(addr: std::net::SocketAddr, path: &str) -> String {
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("the admin listener accepts");
+    stream
+        .write_all(format!("GET {path} HTTP/1.1\r\nHost: localhost\r\n\r\n").as_bytes())
+        .await
+        .expect("the request is written");
+    let mut response = String::new();
+    let _ =
+        tokio::time::timeout(Duration::from_secs(5), stream.read_to_string(&mut response)).await;
+    response
+}
+
+async fn relay_with_admin() -> Server {
+    let mut config = Config::default();
+    config.listen.address = "127.0.0.1:0".to_owned();
+    config.admin.address = "127.0.0.1:0".to_owned();
+    config.store.backend = "memory".to_owned();
+    config.identity.seed = "9f".repeat(32);
+    config.antiabuse.queue_creation_mode = "open".to_owned();
+    config.antiabuse.per_source_limits = false;
+    config.queues.expiry_tick_seconds = 3_600;
+    Server::start(config).await.expect("the relay starts")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn healthz_is_constant_and_reports_no_state() {
+    let server = relay_with_admin().await;
+    let admin = server.admin_addr().expect("the admin listener is bound");
+
+    let first = get(admin, "/healthz").await;
+    assert!(first.starts_with("HTTP/1.1 200 OK"));
+
+    // Do something the relay could be tempted to report.
+    let transport = websocket::connect(&server.url()).await.expect("connects");
+    let mut alice = Client::connect(transport, ClientConfig::default())
+        .await
+        .expect("HELLO completes");
+    let recv = SigningKey::from_seed(&[0xe1; 32]);
+    let send = SigningKey::from_seed(&[0xe2; 32]);
+    let queue = alice.create_queue(&recv, 0, 0, None).await.expect("create");
+    alice.bind_send(&send, queue.send_addr).await.expect("bind");
+    alice
+        .append(&send, queue.send_addr, b"ciphertext")
+        .await
+        .expect("append");
+
+    let second = get(admin, "/healthz").await;
+    let body_of = |response: &str| {
+        response
+            .split("\r\n\r\n")
+            .nth(1)
+            .unwrap_or_default()
+            .to_owned()
+    };
+    // Byte-identical across a queue, a connection and a message. That is the
+    // property: `/healthz` is not an information channel.
+    assert_eq!(body_of(&first), body_of(&second));
+    assert_eq!(body_of(&second), "ok\n");
+    assert!(
+        !body_of(&second).chars().any(|c| c.is_ascii_digit()),
+        "the health check reported a number"
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_carry_totals_and_never_a_label() {
+    let server = relay_with_admin().await;
+    let admin = server.admin_addr().expect("the admin listener is bound");
+
+    let transport = websocket::connect(&server.url()).await.expect("connects");
+    let mut alice = Client::connect(transport, ClientConfig::default())
+        .await
+        .expect("HELLO completes");
+    let recv = SigningKey::from_seed(&[0xf1; 32]);
+    let send = SigningKey::from_seed(&[0xf2; 32]);
+    let queue = alice.create_queue(&recv, 0, 0, None).await.expect("create");
+    alice.bind_send(&send, queue.send_addr).await.expect("bind");
+    alice
+        .append(&send, queue.send_addr, b"ciphertext")
+        .await
+        .expect("append");
+
+    let response = get(admin, "/metrics").await;
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    assert!(response.contains("text/plain; version=0.0.4"));
+    let body = response.split("\r\n\r\n").nth(1).unwrap_or_default();
+
+    // The counters moved, so this is a live endpoint rather than a stub.
+    assert!(body.contains("f2z_relay_connections_accepted_total"));
+    assert!(body.contains("f2z_relay_appends_committed_total 1"));
+    assert!(body.contains("f2z_relay_commit_transactions_total"));
+
+    // And not one series carries a label. A per-queue or per-IP series is the
+    // metadata the protocol refuses, arriving through the operator's scraper.
+    for line in body.lines() {
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+        assert!(!line.contains('{'), "a labelled series: {line}");
+    }
+    // Nor does the body contain either address in any rendering.
+    let recv_hex: String = queue
+        .recv_addr
+        .as_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    assert!(!body.contains(&recv_hex));
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_admin_listener_answers_nothing_else() {
+    let server = relay_with_admin().await;
+    let admin = server.admin_addr().expect("the admin listener is bound");
+    assert!(get(admin, "/").await.starts_with("HTTP/1.1 404"));
+    // §11.2's document is deliberately not served here either: it belongs at a
+    // public URL an operator publishes, and `--print-capabilities` emits it.
+    assert!(
+        get(admin, "/.well-known/free2z-relay/v1/capabilities")
+            .await
+            .starts_with("HTTP/1.1 404")
+    );
+    // A query string is ignored rather than parsed.
+    assert!(
+        get(admin, "/healthz?verbose=1")
+            .await
+            .starts_with("HTTP/1.1 200")
+    );
+
+    let mut stream = tokio::net::TcpStream::connect(admin)
+        .await
+        .expect("connects");
+    stream
+        .write_all(b"POST /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .await
+        .expect("written");
+    let mut response = String::new();
+    let _ =
+        tokio::time::timeout(Duration::from_secs(5), stream.read_to_string(&mut response)).await;
+    assert!(response.starts_with("HTTP/1.1 405"));
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_relay_can_run_with_no_admin_listener_at_all() {
+    let mut config = Config::default();
+    config.listen.address = "127.0.0.1:0".to_owned();
+    config.admin.enabled = false;
+    config.store.backend = "memory".to_owned();
+    config.identity.seed = "a7".repeat(32);
+    let server = Server::start(config).await.expect("the relay starts");
+    assert!(server.admin_addr().is_none());
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_non_loopback_admin_address_refuses_to_start() {
+    let mut config = Config::default();
+    config.listen.address = "127.0.0.1:0".to_owned();
+    config.admin.address = "0.0.0.0:0".to_owned();
+    config.store.backend = "memory".to_owned();
+    config.identity.seed = "b8".repeat(32);
+    // Refused by `check`, before a socket is opened, so `--check-config`
+    // catches it too.
+    assert!(config.check().is_err());
+    assert!(Server::start(config).await.is_err());
+}

--- a/rs/crates/f2z-relay/tests/configured_equivalents.rs
+++ b/rs/crates/f2z-relay/tests/configured_equivalents.rs
@@ -1,0 +1,691 @@
+//! What the real relay can honestly satisfy of the thirteen vectors the
+//! conformance suite reports as `Skipped`.
+//!
+//! # Why this file exists
+//!
+//! `conformance.rs` runs `f2z-relay-testkit`'s suite unchanged and thirteen
+//! vectors report `Skipped`, because they declare `Needs::Faults` or
+//! `Needs::Clock` and a real relay has neither handle. **A skip is not a pass**,
+//! and leaving it there would mean thirteen rules of `WIRE.md` are untested
+//! against the implementation that has to keep them.
+//!
+//! It would be easy and wrong to close that gap by compiling a fault-injection
+//! hook into the relay. A hook that can drop a response, refuse an arbitrary
+//! command or move the clock is a hook an attacker can reach, and a
+//! `#[cfg(test)]` one is a hook that a build-flag mistake ships. So the gap is
+//! closed the other way: **eleven of the thirteen rules are reachable on an
+//! unmodified production binary**, either through published configuration —
+//! which is a policy `WIRE.md` permits, not a relaxation — or through ordinary
+//! client behaviour that the specification already describes.
+//!
+//! | Skipped vector | How this file reaches it |
+//! |---|---|
+//! | `a_duplicate_inflight_request_id_is_fatal` | An `APPEND` is answered from its own task, so its id is genuinely outstanding while a second frame reuses it |
+//! | `exceeding_the_inflight_window_is_fatal` | The same, with `limits.max_inflight` configured low |
+//! | `a_full_queue_is_indistinguishable_from_an_absent_one` | `limits.max_queue_messages = 1` |
+//! | `the_queue_creation_quota_is_a_distinguishable_code` | `limits.max_queues = 1` |
+//! | `backpressure_never_refuses_read_ack_or_delete` | `limits.storage_high_water_bytes = 1` |
+//! | `an_expired_message_is_gone_and_announced` | A one-second message TTL and a one-second sweep |
+//! | `an_idle_queue_disappears` | A one-second idle TTL and a one-second sweep |
+//! | `a_lost_ack_response_is_safe_to_retry` | The client closes before reading the answer — §8.3's actual case |
+//! | `a_delayed_response_still_correlates` | A cheap `PING` overtakes an `APPEND` waiting on a commit window |
+//! | `reordered_responses_still_correlate` | The same exchange, correlated by `request_id` |
+//! | `a_mid_stream_close_leaves_the_status_unknown` | The client closes mid-command |
+//!
+//! The two that remain, stated rather than papered over:
+//!
+//! - **`an_unsound_antireplay_window_is_published_and_refused`** is satisfied in
+//!   a *stronger* sense than the vector asks for: the vector has the relay
+//!   publish `antireplay_window_ms == clock_skew_ms` and a client refuse it,
+//!   and this relay **refuses to be configured that way at all**
+//!   ([`Config::check`], and issue #586). There is no way to make a running
+//!   `f2z-relay` publish that document, so the vector is unrunnable here
+//!   because the defect it demonstrates cannot exist.
+//! - **`every_error_code_can_reach_a_client`** is only partly reachable, and the
+//!   part that is not is honest: code 9 `ERR_CHANNEL_BINDING` is *reserved and
+//!   unused in v1* by §10's own table, so no conforming relay emits it, and code
+//!   21 `ERR_INTERNAL` is a relay fault that cannot be provoked from outside
+//!   without one. Every other code in §10 is reached below or by the suite.
+
+// An integration test is its own crate, so the workspace's denials of the
+// panicking families do not reach it through `lib.rs`'s `cfg_attr(test, ...)`.
+// They are relaxed here for the reason `rs/README.md` gives: a test that has to
+// thread a `Result` through every assertion is a test nobody reads, and a panic
+// in a test is a failing test rather than a remote denial of service.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::time::Duration;
+
+use f2z_codec::ErrorCode;
+use f2z_codec::commands::{AppendRequest, Command};
+use f2z_relay::config::Config;
+use f2z_relay::server::Server;
+use f2z_relay_proto::command::ops;
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_testkit::client::{Client, ClientConfig};
+use f2z_relay_testkit::vectors::{expect, expect_code, expect_eq};
+use f2z_relay_testkit::websocket;
+
+/// A relay on the conformance configuration, with one edit.
+async fn relay(edit: impl FnOnce(&mut Config)) -> Server {
+    let mut config = Config::default();
+    config.listen.address = "127.0.0.1:0".to_owned();
+    config.admin.enabled = false;
+    config.store.backend = "memory".to_owned();
+    config.identity.seed = "3c".repeat(32);
+    config.antiabuse.queue_creation_mode = "open".to_owned();
+    config.antiabuse.contact_append_pow_bits = 8;
+    config.antiabuse.per_source_limits = false;
+    config.commit.window_ms = 1;
+    config.queues.expiry_tick_seconds = 3_600;
+    edit(&mut config);
+    Server::start(config).await.expect("the relay starts")
+}
+
+/// A client on a fresh connection, with a nonce stream no other client shares.
+async fn client(server: &Server, stream: u8) -> Client {
+    let transport = websocket::connect(&server.url())
+        .await
+        .expect("the relay accepts a connection");
+    let config = ClientConfig {
+        // Its own nonce stream: §5.5's seen-set is relay-wide, so two clients
+        // drawing from one stream would collide on `(signer_key, nonce)` and
+        // the second command would be refused as a replay.
+        nonce_seed: [stream; 32],
+        ..ClientConfig::default()
+    };
+    Client::connect(transport, config)
+        .await
+        .expect("HELLO completes")
+}
+
+fn key(seed: u8) -> SigningKey {
+    SigningKey::from_seed(&[seed; 32])
+}
+
+// ---------------------------------------------------------------------------
+// §4.3 — the in-flight window, reachable because an APPEND really is in flight.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_duplicate_inflight_request_id_is_fatal() {
+    // A long gather window makes the first APPEND genuinely outstanding while
+    // the second frame is written. This needs no fault handle precisely because
+    // the relay answers an APPEND from its own task: the request id is released
+    // when the commit returns, not when the frame is read.
+    let server = relay(|config| config.commit.window_ms = 400).await;
+    let mut alice = client(&server, 1).await;
+    let recv = key(0x11);
+    let send = key(0x12);
+    let queue = alice.create_queue(&recv, 0, 0, None).await.unwrap();
+    alice.bind_send(&send, queue.send_addr).await.unwrap();
+
+    let body = AppendRequest {
+        payload: alice.pad(b"ciphertext").unwrap(),
+    };
+    let frame = alice
+        .encode_signed::<ops::Append>(&send, queue.send_addr, &body)
+        .unwrap();
+    alice.send_raw(frame.clone()).await.unwrap();
+    // The same bytes again: the same `request_id`, while the first is still
+    // outstanding. §4.3: "A duplicate `request_id` among in-flight requests is
+    // a fatal `ERR_MALFORMED`."
+    alice.send_raw(frame).await.unwrap();
+
+    let mut saw_malformed = false;
+    for _ in 0..2 {
+        let Ok((_, response)) = alice.next_response().await else {
+            break;
+        };
+        if response.error_code() == Some(ErrorCode::Malformed) {
+            saw_malformed = true;
+        }
+    }
+    assert!(saw_malformed, "the duplicate id was not refused");
+    alice.expect_closed().await.expect("the connection closes");
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn exceeding_the_inflight_window_is_fatal() {
+    let server = relay(|config| {
+        config.commit.window_ms = 400;
+        config.limits.max_inflight = 2;
+    })
+    .await;
+    let mut alice = client(&server, 2).await;
+    let recv = key(0x21);
+    let send = key(0x22);
+    let queue = alice.create_queue(&recv, 0, 0, None).await.unwrap();
+    alice.bind_send(&send, queue.send_addr).await.unwrap();
+
+    // Three distinct requests against a window of two. The first two park in
+    // the commit thread's gather window; the third is refused.
+    for _ in 0..3u8 {
+        let body = AppendRequest {
+            payload: alice.pad(b"ciphertext").unwrap(),
+        };
+        alice
+            .send_signed::<ops::Append>(&send, queue.send_addr, &body)
+            .await
+            .unwrap();
+    }
+
+    let mut saw_too_many = false;
+    for _ in 0..3 {
+        let Ok((_, response)) = alice.next_response().await else {
+            break;
+        };
+        if response.error_code() == Some(ErrorCode::TooManyInflight) {
+            saw_too_many = true;
+        }
+    }
+    assert!(saw_too_many, "the window was not enforced");
+    server.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// §13.1 — quotas and backpressure, reachable by published policy.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_full_queue_is_indistinguishable_from_an_absent_one() {
+    let server = relay(|config| config.limits.max_queue_messages = 1).await;
+    let mut alice = client(&server, 3).await;
+    let recv = key(0x31);
+    let send = key(0x32);
+    let queue = alice.create_queue(&recv, 0, 0, None).await.unwrap();
+    alice.bind_send(&send, queue.send_addr).await.unwrap();
+
+    alice.append(&send, queue.send_addr, b"one").await.unwrap();
+    // §6.3: "every send-side refusal that would distinguish queue state
+    // collapses to the single code `ERR_UNAVAILABLE`" — full-by-messages
+    // included.
+    expect_code(
+        alice.append(&send, queue.send_addr, b"two").await,
+        ErrorCode::Unavailable,
+    )
+    .unwrap();
+    // And the same code an address that never existed gets, which is the
+    // property: a bound sender cannot learn the queue's state by filling it.
+    expect_code(
+        alice
+            .append(&send, f2z_codec::types::QueueAddress::new([0x9e; 32]), b"x")
+            .await,
+        ErrorCode::Unavailable,
+    )
+    .unwrap();
+    server.shutdown().await;
+}
+
+/// A difference the FakeRelay comparison surfaced, which **no vector covers**.
+///
+/// §6.4 defines `QUEUE_EVENT` reason 4 as "quota reached", pushed to a
+/// subscribed reader. `f2z-relay-testkit` emits it when an append is refused
+/// for quota; the first version of this relay did not, because §6.3 collapses
+/// every send-side refusal to one code and the collapse had been applied one
+/// layer too early — the *writer* must not learn which cap was hit, but the
+/// **reader** is the party that can drain the queue and §6.4 exists to tell it.
+///
+/// The FakeRelay was right. This is the regression test for the fix.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_reader_is_told_when_its_queue_hits_a_cap() {
+    let server = relay(|config| config.limits.max_queue_messages = 1).await;
+    let mut bob = client(&server, 20).await;
+    let recv = key(0xd1);
+    let send = key(0xd2);
+    let queue = bob.create_queue(&recv, 0, 0, None).await.unwrap();
+    bob.subscribe(&recv, queue.recv_addr).await.unwrap();
+    bob.bind_send(&send, queue.send_addr).await.unwrap();
+
+    bob.append(&send, queue.send_addr, b"one").await.unwrap();
+    bob.next_message().await.unwrap();
+
+    // The writer learns only `ERR_UNAVAILABLE` (§6.3) …
+    expect_code(
+        bob.append(&send, queue.send_addr, b"two").await,
+        ErrorCode::Unavailable,
+    )
+    .unwrap();
+    // … and the reader learns that it should drain (§6.4, reason 4).
+    let event = bob.next_queue_event().await.unwrap();
+    expect_eq(
+        event.reason,
+        4,
+        "expected QUEUE_EVENT reason 4, quota reached",
+    )
+    .unwrap();
+    expect_eq(
+        event.recv_addr,
+        queue.recv_addr,
+        "the event named a different queue",
+    )
+    .unwrap();
+    server.shutdown().await;
+}
+
+/// And the mirror: an absent address must not produce a push, or the push
+/// itself becomes the existence oracle §10 forbids.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_absent_address_produces_no_queue_event() {
+    let server = relay(|config| config.limits.max_queue_messages = 1).await;
+    let mut bob = client(&server, 21).await;
+    let recv = key(0xe1);
+    let send = key(0xe2);
+    let queue = bob.create_queue(&recv, 0, 0, None).await.unwrap();
+    bob.subscribe(&recv, queue.recv_addr).await.unwrap();
+    bob.bind_send(&send, queue.send_addr).await.unwrap();
+
+    expect_code(
+        bob.append(&send, f2z_codec::types::QueueAddress::new([0x77; 32]), b"x")
+            .await,
+        ErrorCode::Unavailable,
+    )
+    .unwrap();
+    // Nothing arrives. A push here would tell a stranger that some queue
+    // exists, which is exactly what the collapse exists to withhold.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(400), bob.next_push())
+            .await
+            .is_err(),
+        "an absent address produced a push"
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_queue_creation_quota_is_a_distinguishable_code() {
+    let server = relay(|config| config.limits.max_queues = 1).await;
+    let mut alice = client(&server, 4).await;
+    alice.create_queue(&key(0x41), 0, 0, None).await.unwrap();
+    // §10 code 14. Unlike the send side, the receive side is allowed a
+    // distinguishable code: the party being refused is the one that owns the
+    // queues, so telling it discloses nothing it does not already know.
+    expect_code(
+        alice.create_queue(&key(0x42), 0, 0, None).await,
+        ErrorCode::Quota,
+    )
+    .unwrap();
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backpressure_never_refuses_read_ack_or_delete() {
+    let server = relay(|config| {
+        config.limits.storage_high_water_bytes = 1;
+        config.queues.expiry_tick_seconds = 1;
+    })
+    .await;
+    let mut alice = client(&server, 5).await;
+    let recv = key(0x51);
+    let send = key(0x52);
+    // The first sweep ran against an empty store, so creation is still open.
+    let queue = alice.create_queue(&recv, 0, 0, None).await.unwrap();
+    alice.bind_send(&send, queue.send_addr).await.unwrap();
+    alice.append(&send, queue.send_addr, b"one").await.unwrap();
+
+    // Now the store is over the mark and the next sweep turns layer 4 on.
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+    // §13.1 layer 4, in the order the section states it.
+    expect_code(
+        alice.create_queue(&key(0x53), 0, 0, None).await,
+        ErrorCode::Backpressure,
+    )
+    .unwrap();
+    expect_code(
+        alice.append(&send, queue.send_addr, b"two").await,
+        ErrorCode::Unavailable,
+    )
+    .unwrap();
+
+    // "READ, ACK and DELETE_QUEUE are **never** refused for backpressure. They
+    // are the operations that make the relay smaller, and refusing them under
+    // load is a deadlock."
+    let page = alice.read(&recv, queue.recv_addr, 0, 0, 0).await.unwrap();
+    expect_eq(
+        page.messages.len(),
+        1,
+        "READ was refused under backpressure",
+    )
+    .unwrap();
+    alice.ack(&recv, queue.recv_addr, 0).await.unwrap();
+    alice.delete_queue(&recv, queue.recv_addr).await.unwrap();
+    server.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// §7.7 — the two timers, reachable by shortening them.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn an_expired_message_is_gone_and_announced() {
+    let server = relay(|config| {
+        config.queues.min_message_ttl_seconds = 1;
+        config.queues.default_message_ttl_seconds = 1;
+        config.queues.expiry_tick_seconds = 1;
+    })
+    .await;
+    let mut alice = client(&server, 6).await;
+    let recv = key(0x61);
+    let send = key(0x62);
+    let queue = alice.create_queue(&recv, 1, 0, None).await.unwrap();
+    expect_eq(queue.message_ttl_seconds, 1, "the TTL was not granted").unwrap();
+    alice.subscribe(&recv, queue.recv_addr).await.unwrap();
+    alice.bind_send(&send, queue.send_addr).await.unwrap();
+    alice
+        .append(&send, queue.send_addr, b"ciphertext")
+        .await
+        .unwrap();
+    // The MSG push for the append we just made.
+    alice.next_message().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(2_500)).await;
+
+    // §6.4 `QUEUE_EVENT` reason 3: the queue survives, its messages did not.
+    let event = alice.next_queue_event().await.unwrap();
+    expect_eq(event.reason, 3, "expected reason 3, messages TTL-expired").unwrap();
+    let page = alice.read(&recv, queue.recv_addr, 0, 0, 0).await.unwrap();
+    expect(
+        page.messages.is_empty(),
+        "an expired message was still readable",
+    )
+    .unwrap();
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn an_idle_queue_disappears() {
+    let server = relay(|config| {
+        config.queues.min_idle_ttl_seconds = 1;
+        config.queues.default_idle_ttl_seconds = 1;
+        config.queues.expiry_tick_seconds = 1;
+    })
+    .await;
+    let mut alice = client(&server, 7).await;
+    let recv = key(0x71);
+    let queue = alice.create_queue(&recv, 0, 1, None).await.unwrap();
+    expect_eq(queue.idle_ttl_seconds, 1, "the idle TTL was not granted").unwrap();
+    alice.subscribe(&recv, queue.recv_addr).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(2_500)).await;
+
+    // §6.4 `QUEUE_EVENT` reason 2, then §7.7's stated cost: the queue is gone,
+    // and both its addresses answer as if they never existed.
+    let event = alice.next_queue_event().await.unwrap();
+    expect_eq(event.reason, 2, "expected reason 2, idle-expired").unwrap();
+    expect_code(
+        alice.read(&recv, queue.recv_addr, 0, 0, 0).await,
+        ErrorCode::NoAccess,
+    )
+    .unwrap();
+    server.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// The failure paths delete-on-ack makes expensive to get wrong.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_lost_ack_response_is_safe_to_retry() {
+    let server = relay(|_| {}).await;
+    let mut alice = client(&server, 8).await;
+    let recv = key(0x81);
+    let send = key(0x82);
+    let queue = alice.create_queue(&recv, 0, 0, None).await.unwrap();
+    alice.bind_send(&send, queue.send_addr).await.unwrap();
+    alice
+        .append(&send, queue.send_addr, b"ciphertext")
+        .await
+        .unwrap();
+    let page = alice.read(&recv, queue.recv_addr, 0, 0, 0).await.unwrap();
+    let index = page.messages.as_slice().first().map(|m| m.index).unwrap();
+
+    // The durable local write happens here — §8.4's MUST — and only then the
+    // ACK. Which is sent and then abandoned: the client never sees the answer,
+    // so §2.5 leaves the command's status *unknown*.
+    alice
+        .send_signed::<ops::Ack>(
+            &recv,
+            queue.recv_addr,
+            &f2z_codec::commands::AckRequest { up_to_index: index },
+        )
+        .await
+        .unwrap();
+    alice.close().await.unwrap();
+
+    // §8.3: "a client that sent an `ACK` and never saw the response simply
+    // sends it again after reconnecting. It does not need to know whether the
+    // first one arrived, and it must not try to find out by reading."
+    let mut bob = client(&server, 9).await;
+    let outcome = bob.ack(&recv, queue.recv_addr, index).await.unwrap();
+    expect_eq(
+        outcome.pending,
+        0,
+        "the retried ACK did not leave the queue drained",
+    )
+    .unwrap();
+    // Idempotent a third time, and monotone below the watermark.
+    bob.ack(&recv, queue.recv_addr, index).await.unwrap();
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_cheap_command_overtakes_an_expensive_one_and_both_correlate() {
+    // §4.3: "A relay MAY complete a cheap `PING` before an expensive `READ`
+    // issued earlier, and will." Reachable without a fault handle because an
+    // APPEND waits on the group-commit window while a PING does not.
+    let server = relay(|config| config.commit.window_ms = 300).await;
+    let mut alice = client(&server, 10).await;
+    let recv = key(0x91);
+    let send = key(0x92);
+    let queue = alice.create_queue(&recv, 0, 0, None).await.unwrap();
+    alice.bind_send(&send, queue.send_addr).await.unwrap();
+
+    let body = AppendRequest {
+        payload: alice.pad(b"ciphertext").unwrap(),
+    };
+    let append_id = alice
+        .send_signed::<ops::Append>(&send, queue.send_addr, &body)
+        .await
+        .unwrap();
+    let ping_id = alice
+        .send_unsigned::<ops::Ping>(&f2z_relay_proto::command::Empty)
+        .await
+        .unwrap();
+
+    let (first_id, first) = alice.next_response().await.unwrap();
+    let (second_id, second) = alice.next_response().await.unwrap();
+    expect(first.is_ok() && second.is_ok(), "a response was an error").unwrap();
+    expect_eq(first_id, ping_id, "the cheap command did not answer first").unwrap();
+    expect_eq(second_id, append_id, "the append answered out of turn").unwrap();
+    // And both were correlated by id rather than by arrival order, which is the
+    // rule §4.3 states and the reason a client MUST NOT assume ordering.
+    expect(first_id != second_id, "two responses shared an id").unwrap();
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_mid_stream_close_leaves_the_status_unknown_and_the_relay_serving() {
+    let server = relay(|config| config.commit.window_ms = 300).await;
+    let mut alice = client(&server, 11).await;
+    let recv = key(0xa1);
+    let send = key(0xa2);
+    let queue = alice.create_queue(&recv, 0, 0, None).await.unwrap();
+    alice.bind_send(&send, queue.send_addr).await.unwrap();
+
+    let body = AppendRequest {
+        payload: alice.pad(b"ciphertext").unwrap(),
+    };
+    alice
+        .send_signed::<ops::Append>(&send, queue.send_addr, &body)
+        .await
+        .unwrap();
+    // §2.5: "an in-flight command whose response was not received has
+    // **unknown** status". The client cannot tell whether it landed.
+    alice.close().await.unwrap();
+    drop(alice);
+
+    // What must hold is that the relay is unharmed and that whatever it did
+    // with the append, it did durably or not at all — §13.2 forbids it from
+    // discarding an accepted message later to make room.
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    let mut bob = client(&server, 12).await;
+    let page = bob.read(&recv, queue.recv_addr, 0, 0, 0).await.unwrap();
+    expect(
+        page.messages.len() <= 1,
+        "a single append produced more than one message",
+    )
+    .unwrap();
+    // The connection that closed took its subscription with it (§6.2) and left
+    // the relay serving.
+    bob.ping().await.unwrap();
+    server.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// §10 — which codes a real relay can actually emit.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_error_codes_a_real_relay_can_emit_are_the_ones_it_should() {
+    // The two §10 codes no conforming relay produces on demand, stated rather
+    // than skipped: 9 is reserved and unused in v1 by §10's own table, and 21
+    // is a relay fault. Everything else is reached by the conformance suite or
+    // by this file.
+    let unreachable = [ErrorCode::ChannelBinding, ErrorCode::Internal];
+    let reached_here = [
+        ErrorCode::Malformed,
+        ErrorCode::TooManyInflight,
+        ErrorCode::Unavailable,
+        ErrorCode::Quota,
+        ErrorCode::Backpressure,
+        ErrorCode::NoAccess,
+    ];
+    for code in reached_here {
+        assert!(
+            !unreachable.contains(&code),
+            "{} is claimed both reachable and not",
+            code.name()
+        );
+    }
+
+    // `ERR_RATE_LIMITED` (19) needs its own relay, because the conformance
+    // configuration turns per-connection limits off so the suite is not
+    // throttled by them.
+    let server = relay(|config| config.limits.commands_per_connection_per_second = 2).await;
+    let mut alice = client(&server, 13).await;
+    let mut refused = None;
+    for _ in 0..8u8 {
+        if let Err(error) = alice.ping().await {
+            refused = error.wire_code();
+            break;
+        }
+    }
+    assert_eq!(
+        refused,
+        Some(ErrorCode::RateLimited),
+        "the per-connection command rate did not refuse"
+    );
+    server.shutdown().await;
+
+    // `ERR_POW_REQUIRED` (16) on queue creation, which the conformance
+    // configuration deliberately does not exercise: it runs `open` mode, and
+    // the shipped default is `pow`.
+    let server = relay(|config| {
+        config.antiabuse.queue_creation_mode = "pow".to_owned();
+        config.antiabuse.queue_creation_pow_bits = 8;
+    })
+    .await;
+    let mut alice = client(&server, 14).await;
+    expect_code(
+        alice.create_queue(&key(0xb1), 0, 0, None).await,
+        ErrorCode::PowRequired,
+    )
+    .unwrap();
+    // And with a stamp over a relay-issued challenge it succeeds, so the gate
+    // is a gate rather than a wall.
+    let pow = alice
+        .capabilities()
+        .await
+        .unwrap()
+        .capabilities
+        .queue_creation_pow;
+    alice
+        .create_queue(&key(0xb2), 0, 0, Some(pow))
+        .await
+        .unwrap();
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_relay_refuses_to_publish_the_unsound_antireplay_window_at_all() {
+    // The stronger form of `an_unsound_antireplay_window_is_published_and_refused`:
+    // the vector has a relay publish `antireplay_window_ms == clock_skew_ms` and
+    // a client refuse the document. This relay cannot be made to publish it.
+    // Issue #586's finding, enforced rather than demonstrated.
+    let mut config = Config::default();
+    config.limits.antireplay_window_ms = config.limits.clock_skew_ms;
+    assert!(config.check().is_err());
+
+    // And what it does publish satisfies the client-side check the vector's
+    // conforming half performs.
+    let server = relay(|_| {}).await;
+    let mut alice = client(&server, 15).await;
+    let signed = alice.capabilities().await.unwrap();
+    let published = &signed.capabilities;
+    assert!(
+        u64::from(published.antireplay_window_ms)
+            >= u64::from(published.clock_skew_ms).saturating_mul(2)
+    );
+    assert!(
+        f2z_relay_proto::capabilities::ClientPolicy {
+            allow_insecure_transport: true,
+            ..f2z_relay_proto::capabilities::ClientPolicy::default()
+        }
+        .accept(published)
+        .is_ok()
+    );
+    server.shutdown().await;
+}
+
+/// A guard against the suite's `Needs` changing under this file: every vector
+/// named in the module table must still be one the real relay skips.
+#[test]
+fn the_thirteen_skipped_vectors_are_the_ones_this_file_accounts_for() {
+    let skipped: Vec<&'static str> = f2z_relay_testkit::vectors::suite()
+        .into_iter()
+        .filter(|vector| !matches!(vector.needs, f2z_relay_testkit::vectors::Needs::Nothing))
+        .map(|vector| vector.name)
+        .collect();
+    assert_eq!(
+        skipped.len(),
+        13,
+        "the suite's handle-needing set changed: {skipped:?}"
+    );
+    for name in [
+        "a_duplicate_inflight_request_id_is_fatal",
+        "exceeding_the_inflight_window_is_fatal",
+        "an_unsound_antireplay_window_is_published_and_refused",
+        "a_full_queue_is_indistinguishable_from_an_absent_one",
+        "backpressure_never_refuses_read_ack_or_delete",
+        "the_queue_creation_quota_is_a_distinguishable_code",
+        "every_error_code_can_reach_a_client",
+        "an_expired_message_is_gone_and_announced",
+        "an_idle_queue_disappears",
+        "a_lost_ack_response_is_safe_to_retry",
+        "a_delayed_response_still_correlates",
+        "reordered_responses_still_correlate",
+        "a_mid_stream_close_leaves_the_status_unknown",
+    ] {
+        assert!(skipped.contains(&name), "{name} is no longer skipped");
+    }
+    // Command is imported for the table above; keep the reference honest.
+    assert_eq!(Command::Append.code(), 0x0021);
+}

--- a/rs/crates/f2z-relay/tests/conformance.rs
+++ b/rs/crates/f2z-relay/tests/conformance.rs
@@ -1,0 +1,235 @@
+//! The acceptance test: `f2z-relay-testkit`'s conformance suite, run against the
+//! real relay and against the FakeRelay, with the verdicts compared.
+//!
+//! # Why the comparison is the test and the pass count is not
+//!
+//! `f2z-relay-testkit` was written before this crate for exactly this moment.
+//! Its 52 vectors are `(input, expected output)` cases driven through the
+//! ordinary client API against an [`Endpoint`], and its README says what the
+//! third implementation of that trait is for:
+//!
+//! > *`f2z-relay`, once it exists, is a `WebSocketEndpoint` with a URL and no
+//! > fault handle. The suite then reports the fault vectors as skipped rather
+//! > than failing them, so the same file is a real check of both relays instead
+//! > of two files that drift.*
+//!
+//! So this file runs the **same unmodified suite** twice and asserts that every
+//! vector both targets can run reaches the same verdict. A vector that passes
+//! against the FakeRelay and fails here is a defect in this relay; one that
+//! fails there and passes here is a defect in the FakeRelay. Either way the
+//! disagreement is the finding, and a suite that only counted passes would
+//! report neither.
+//!
+//! # A `Skipped` is never a pass
+//!
+//! Thirteen vectors declare [`Needs::Faults`] or [`Needs::Clock`] — they need to
+//! make the relay misbehave, or to move its clock. A real relay has neither
+//! handle and must not: a fault-injection hook compiled into a production binary
+//! is a fault-injection hook an attacker can reach. Those vectors report
+//! `Skipped` here, this file asserts that they are *skipped and not failed*, and
+//! `configured_equivalents.rs` covers the subset that is reachable by
+//! **configuration** instead — which is the honest way for a real relay to
+//! satisfy a rule it cannot be told to break.
+
+// An integration test is its own crate, so the workspace's denials of the
+// panicking families do not reach it through `lib.rs`'s `cfg_attr(test, ...)`.
+// They are relaxed here for the reason `rs/README.md` gives: a test that has to
+// thread a `Result` through every assertion is a test nobody reads, and a panic
+// in a test is a failing test rather than a remote denial of service.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::sync::Arc;
+
+use f2z_relay::config::Config;
+use f2z_relay::server::Server;
+use f2z_relay_testkit::config::{RelayConfig, TESTKIT_POW_DIFFICULTY_BITS};
+use f2z_relay_testkit::fake::{FakeRelay, WebSocketEndpoint};
+use f2z_relay_testkit::vectors::{self, Needs, Report, Status};
+
+/// A configuration that matches the FakeRelay's published policy wherever the
+/// policy is what a vector observes.
+///
+/// Two values differ from this crate's own defaults, and both are *published
+/// policy* rather than a relaxation:
+///
+/// - `queue_creation_mode = open`. §13.1 permits it "for a private relay on a
+///   closed network", which a loopback test relay is, and the FakeRelay
+///   defaults to it for the same reason. The shipped default stays `pow`.
+/// - `contact_append_pow_bits = 8`. §12.3 requires proof of work whenever
+///   contact queues are offered; the difficulty is a policy number, and 8 bits
+///   is what the testkit picked so a suite does not spend a minute hashing. The
+///   shipped default stays 20.
+///
+/// Nothing else is loosened. In particular the padding set, the TTL bands, the
+/// frame cap, the in-flight window and the anti-replay window are this crate's
+/// own defaults.
+pub fn conformance_config() -> Config {
+    let mut config = Config::default();
+    config.listen.address = "127.0.0.1:0".to_owned();
+    config.admin.enabled = false;
+    config.store.backend = "memory".to_owned();
+    // A fixed seed rather than a key file: a test must not write one into
+    // whatever directory it happens to run in.
+    config.identity.seed = "5a".repeat(32);
+    config.antiabuse.queue_creation_mode = "open".to_owned();
+    config.antiabuse.contact_append_pow_bits = TESTKIT_POW_DIFFICULTY_BITS;
+    // The suite opens a connection per vector from one address, and several
+    // vectors open a second. §13.1's per-source caps are real and tested in
+    // their own file; here they would only throttle the harness.
+    config.antiabuse.per_source_limits = false;
+    // A short window, because the suite's appends are sequential and every one
+    // of them would otherwise wait the full gather.
+    config.commit.window_ms = 1;
+    // Long enough that no sweep runs during a suite. §7.7's timers get their
+    // own test, where the wait is the point.
+    config.queues.expiry_tick_seconds = 3_600;
+    config
+}
+
+/// The FakeRelay on its own defaults, over its own `ws://` listener.
+///
+/// The socket path rather than the in-process one, so both reports are of a
+/// relay reached the same way and a difference cannot be a transport artefact.
+async fn fake_report() -> Report {
+    let relay = FakeRelay::new(RelayConfig::default().with_system_clock())
+        .expect("the FakeRelay's default configuration is valid");
+    let server = relay
+        .listen_loopback()
+        .await
+        .expect("a loopback listener binds");
+    let report = vectors::run(Arc::new(relay.websocket_endpoint(&server))).await;
+    server.shutdown().await;
+    report
+}
+
+/// The real relay, reached exactly as a third-party client would reach it.
+async fn real_report() -> (Report, Server) {
+    let server = Server::start(conformance_config())
+        .await
+        .expect("the relay starts");
+    // `WebSocketEndpoint::new` is the constructor the testkit's README names as
+    // the one `f2z-relay` will be run through: a URL, no fault handle, no
+    // steerable clock.
+    let report = vectors::run(Arc::new(WebSocketEndpoint::new(server.url()))).await;
+    (report, server)
+}
+
+fn needs_of(name: &str) -> Needs {
+    vectors::suite()
+        .into_iter()
+        .find(|vector| vector.name == name)
+        .map_or(Needs::Nothing, |vector| vector.needs)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_real_relay_and_the_fakerelay_agree_on_every_vector_both_can_run() {
+    let fake = fake_report().await;
+    let (real, server) = real_report().await;
+
+    println!("\n=== f2z-relay-testkit conformance suite ===");
+    println!("FakeRelay   {}", fake.summary());
+    println!("f2z-relay   {}", real.summary());
+    for (name, status) in real.verdicts() {
+        let fake_status = fake
+            .verdicts()
+            .into_iter()
+            .find(|(other, _)| *other == name)
+            .map(|(_, status)| status);
+        println!(
+            "  {name:<58} fake={:<9} real={}",
+            render(fake_status.as_ref()),
+            render(Some(&status))
+        );
+    }
+    println!();
+
+    let mut disagreements = Vec::new();
+    let mut wrongly_skipped = Vec::new();
+    for (name, real_status) in real.verdicts() {
+        let Some((_, fake_status)) = fake
+            .verdicts()
+            .into_iter()
+            .find(|(other, _)| *other == name)
+        else {
+            disagreements.push(format!("{name}: absent from the FakeRelay's report"));
+            continue;
+        };
+        match needs_of(name) {
+            // Both targets can run it, so both must reach the same verdict.
+            // This is the comparison the suite exists for.
+            Needs::Nothing => {
+                if real_status != fake_status {
+                    disagreements.push(format!(
+                        "{name}: FakeRelay {}, f2z-relay {}",
+                        render(Some(&fake_status)),
+                        render(Some(&real_status))
+                    ));
+                }
+            }
+            // The real relay has no handle, so it must report *skipped* — never
+            // failed, and never a pass it did not earn.
+            Needs::Faults | Needs::Clock => {
+                if !matches!(real_status, Status::Skipped(_)) {
+                    wrongly_skipped.push(format!(
+                        "{name}: expected Skipped against a relay with no handle, got {}",
+                        render(Some(&real_status))
+                    ));
+                }
+            }
+        }
+    }
+
+    server.shutdown().await;
+
+    assert!(
+        disagreements.is_empty(),
+        "the two relays disagree, which is a defect in one of them:\n  {}",
+        disagreements.join("\n  ")
+    );
+    assert!(
+        wrongly_skipped.is_empty(),
+        "a fault-driven vector did not report Skipped:\n  {}",
+        wrongly_skipped.join("\n  ")
+    );
+    assert_eq!(
+        real.failed(),
+        0,
+        "the real relay failed vectors:\n  {}",
+        real.failures().join("\n  ")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn every_vector_that_needs_no_handle_passes_against_the_real_relay() {
+    let (real, server) = real_report().await;
+    let runnable = vectors::suite()
+        .into_iter()
+        .filter(|vector| matches!(vector.needs, Needs::Nothing))
+        .count();
+    server.shutdown().await;
+
+    assert_eq!(
+        real.passed(),
+        runnable,
+        "{} of {runnable} handle-free vectors passed; failures:\n  {}",
+        real.passed(),
+        real.failures().join("\n  ")
+    );
+    // Stated as a number so a vector silently changing its `Needs` is visible.
+    assert_eq!(real.skipped(), real.outcomes.len() - runnable);
+}
+
+fn render(status: Option<&Status>) -> String {
+    match status {
+        Some(Status::Passed) => "passed".to_owned(),
+        Some(Status::Skipped(_)) => "skipped".to_owned(),
+        Some(Status::Failed(reason)) => format!("FAILED({reason})"),
+        None => "absent".to_owned(),
+    }
+}

--- a/rs/crates/f2z-relay/tests/group_commit.rs
+++ b/rs/crates/f2z-relay/tests/group_commit.rs
@@ -1,0 +1,291 @@
+//! Group commit, measured against the disk rather than asserted.
+//!
+//! # The claim
+//!
+//! `f2z-relay-store` runs `synchronous = FULL` over WAL, so **a transaction is
+//! an fsync**, and `SqliteStore::commits` counts them. Its documentation names
+//! the check this file performs:
+//!
+//! > *a batch of a hundred appends must move it by one, not by a hundred.*
+//!
+//! That is the whole of why [`f2z_relay::commit`] exists. A cheap VPS's disk
+//! does on the order of 50-200 fsyncs a second; one transaction per `APPEND`
+//! would cap the relay there, and
+//! [ADR 0005](https://github.com/free2z/zuu/blob/main/docs/e2ee/decisions/0005-federation.md)'s
+//! economics do not survive that ceiling.
+//!
+//! # And the claim it must not weaken
+//!
+//! §11.1's `durability_mode` has three values and this relay publishes
+//! `fsync-per-append`. §8.4 draws the line:
+//!
+//! > *deferring the fsync past the response is `batched`; amortizing one fsync
+//! > across many responses that all wait for it is still `fsync-per-append`.*
+//!
+//! So the amortization test is paired with a loss test: after N concurrent
+//! appends every one of them must be readable, with a distinct index, and the
+//! relay must have answered none of them before its commit.
+
+// An integration test is its own crate, so the workspace's denials of the
+// panicking families do not reach it through `lib.rs`'s `cfg_attr(test, ...)`.
+// They are relaxed here for the reason `rs/README.md` gives: a test that has to
+// thread a `Result` through every assertion is a test nobody reads, and a panic
+// in a test is a failing test rather than a remote denial of service.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use f2z_codec::types::{Payload, PublicKey, QueueAddress};
+use f2z_relay::commit::CommitWriter;
+use f2z_relay::config::Config;
+use f2z_relay::metrics::Metrics;
+use f2z_relay::server::Server;
+use f2z_relay_proto::key::SigningKey;
+use f2z_relay_proto::queue::{AppendQuota, QueueKind};
+use f2z_relay_store::{Durability, QueueSpec, RelayStore, SendAuth, SqliteStore};
+use f2z_relay_testkit::client::{Client, ClientConfig};
+use f2z_relay_testkit::websocket;
+
+/// A scratch directory that removes itself.
+struct Scratch(std::path::PathBuf);
+
+impl Scratch {
+    fn new(name: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "f2z-relay-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).expect("a scratch directory");
+        Self(path)
+    }
+
+    fn join(&self, name: &str) -> std::path::PathBuf {
+        self.0.join(name)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn sqlite_with_queue(path: &std::path::Path) -> (Arc<SqliteStore>, QueueAddress, PublicKey) {
+    let store = SqliteStore::open(path).expect("the store opens");
+    let recv_addr = QueueAddress::new([1u8; 32]);
+    let send_addr = QueueAddress::new([2u8; 32]);
+    let send_key = PublicKey::new([4u8; 32]);
+    let _created = store
+        .create_queue(&QueueSpec {
+            kind: QueueKind::Standard,
+            recv_addr,
+            send_addr,
+            recv_key: PublicKey::new([3u8; 32]),
+            message_ttl_seconds: 600,
+            idle_ttl_seconds: 600_000,
+            quota: AppendQuota {
+                max_messages: 100_000,
+                max_bytes: 1 << 30,
+            },
+            created_at_ms: 0,
+        })
+        .expect("a queue is created");
+    let _bound = store
+        .bind_send(&send_addr, &send_key, 0)
+        .expect("the send side binds");
+    (Arc::new(store), send_addr, send_key)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_hundred_concurrent_appends_do_not_cost_a_hundred_fsyncs() {
+    let scratch = Scratch::new("group-commit");
+    let (store, send_addr, send_key) = sqlite_with_queue(&scratch.join("relay.sqlite"));
+    assert_eq!(store.durability(), Durability::FsyncPerAppend);
+
+    let baseline = store.commits();
+    let metrics = Arc::new(Metrics::new());
+    let writer = CommitWriter::start(
+        Arc::clone(&store) as Arc<dyn RelayStore + Send + Sync>,
+        Arc::clone(&metrics),
+        Duration::from_millis(25),
+        256,
+    )
+    .expect("the writer thread starts");
+
+    const APPENDS: usize = 100;
+    let mut tasks = Vec::with_capacity(APPENDS);
+    for _ in 0..APPENDS {
+        let writer = writer.clone();
+        tasks.push(tokio::spawn(async move {
+            let payload = Payload::new(vec![0u8; 1024]).expect("a payload");
+            writer
+                .append(send_addr, SendAuth::Signed(send_key), payload, 1_000)
+                .await
+                .expect("the writer is alive")
+                .expect("the append is admitted")
+        }));
+    }
+    let mut indices = Vec::with_capacity(APPENDS);
+    for task in tasks {
+        let accepted = task.await.expect("the task completes");
+        // Every reply carries the store's own durability, and it exists only
+        // downstream of a `Committed` the transaction minted.
+        assert_eq!(accepted.durability, Durability::FsyncPerAppend);
+        indices.push(accepted.index);
+    }
+
+    let fsyncs = store.commits().saturating_sub(baseline);
+    assert!(
+        fsyncs < APPENDS as u64,
+        "{APPENDS} concurrent appends cost {fsyncs} fsyncs; group commit did nothing"
+    );
+    // Not merely "fewer": the point is an order of magnitude. A window of 25 ms
+    // against appends submitted as fast as tasks can be spawned should gather
+    // them into a handful of transactions.
+    assert!(
+        fsyncs <= 20,
+        "{APPENDS} appends took {fsyncs} transactions; the window is not gathering"
+    );
+    println!("group commit: {APPENDS} appends in {fsyncs} durable transactions");
+
+    // And nothing was lost or duplicated: §13.2 forbids the relay from
+    // discarding an accepted message, and the indices §8 hands out are dense.
+    indices.sort_unstable();
+    assert_eq!(indices, (0..APPENDS as u64).collect::<Vec<_>>());
+    assert_eq!(
+        metrics.appends_committed.load(Ordering::Relaxed),
+        APPENDS as u64
+    );
+    assert!(metrics.commit_transactions.load(Ordering::Relaxed) < APPENDS as u64);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_lone_append_still_costs_its_own_fsync() {
+    // The other half: batching must not make a single append wait for company
+    // that never comes, and it must still be durable when it returns.
+    let scratch = Scratch::new("lone-append");
+    let (store, send_addr, send_key) = sqlite_with_queue(&scratch.join("relay.sqlite"));
+    let baseline = store.commits();
+    let writer = CommitWriter::start(
+        Arc::clone(&store) as Arc<dyn RelayStore + Send + Sync>,
+        Arc::new(Metrics::new()),
+        Duration::from_millis(10),
+        256,
+    )
+    .expect("the writer thread starts");
+
+    let started = std::time::Instant::now();
+    let accepted = writer
+        .append(
+            send_addr,
+            SendAuth::Signed(send_key),
+            Payload::new(vec![0u8; 1024]).expect("a payload"),
+            1_000,
+        )
+        .await
+        .expect("the writer is alive")
+        .expect("the append is admitted");
+    assert_eq!(accepted.index, 0);
+    assert_eq!(store.commits().saturating_sub(baseline), 1);
+    // The gather window bounds the wait; it does not become the wait.
+    assert!(
+        started.elapsed() < Duration::from_millis(2_000),
+        "a lone append waited {:?}",
+        started.elapsed()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_relay_publishes_fsync_per_append_over_a_real_file() {
+    let scratch = Scratch::new("published-durability");
+    let mut config = Config::default();
+    config.listen.address = "127.0.0.1:0".to_owned();
+    config.admin.enabled = false;
+    config.identity.seed = "7e".repeat(32);
+    config.antiabuse.queue_creation_mode = "open".to_owned();
+    config.antiabuse.per_source_limits = false;
+    config.store.backend = "sqlite".to_owned();
+    config.store.path = scratch.join("relay.sqlite").display().to_string();
+    config.queues.expiry_tick_seconds = 3_600;
+
+    let server = Server::start(config).await.expect("the relay starts");
+    let transport = websocket::connect(&server.url()).await.expect("connects");
+    let mut alice = Client::connect(transport, ClientConfig::default())
+        .await
+        .expect("HELLO completes");
+
+    // §11.1's field, as the relay actually publishes it. Group commit does not
+    // weaken it — every append in a batch waits for the same fsync.
+    let signed = alice.capabilities().await.expect("GET_CAPABILITIES");
+    assert_eq!(
+        signed.capabilities.durability_mode,
+        f2z_relay_proto::capabilities::DurabilityMode::FsyncPerAppend.code()
+    );
+
+    // Fifty appends across five connections, all readable afterwards.
+    let recv = SigningKey::from_seed(&[0xc1; 32]);
+    let send = SigningKey::from_seed(&[0xc2; 32]);
+    let queue = alice
+        .create_queue(&recv, 0, 0, None)
+        .await
+        .expect("CREATE_QUEUE");
+    alice
+        .bind_send(&send, queue.send_addr)
+        .await
+        .expect("BIND_SEND");
+
+    let mut senders = Vec::new();
+    for stream in 0..5u8 {
+        let transport = websocket::connect(&server.url()).await.expect("connects");
+        let config = ClientConfig {
+            nonce_seed: [0xd0 | stream; 32],
+            ..ClientConfig::default()
+        };
+        senders.push(
+            Client::connect(transport, config)
+                .await
+                .expect("HELLO completes"),
+        );
+    }
+    let mut tasks = Vec::new();
+    for mut sender in senders {
+        let send = SigningKey::from_seed(&[0xc2; 32]);
+        let address = queue.send_addr;
+        tasks.push(tokio::spawn(async move {
+            for _ in 0..10u8 {
+                sender
+                    .append(&send, address, b"ciphertext")
+                    .await
+                    .expect("APPEND is accepted");
+            }
+        }));
+    }
+    for task in tasks {
+        task.await.expect("the task completes");
+    }
+
+    let page = alice
+        .read(&recv, queue.recv_addr, 0, 0, 0)
+        .await
+        .expect("READ");
+    assert_eq!(
+        page.messages.len(),
+        50,
+        "an accepted append did not survive to the read"
+    );
+    let mut indices: Vec<u64> = page.messages.as_slice().iter().map(|m| m.index).collect();
+    indices.sort_unstable();
+    assert_eq!(indices, (0..50u64).collect::<Vec<_>>());
+
+    server.shutdown().await;
+}

--- a/rs/crates/f2z-relay/tests/redaction.rs
+++ b/rs/crates/f2z-relay/tests/redaction.rs
@@ -1,0 +1,212 @@
+//! **No payload, queue address, key or peer address in any log line, at any
+//! level.**
+//!
+//! # The trap this file is written around
+//!
+//! `f2z-codec`'s own redaction tests document it and it is worth restating,
+//! because a test that misses it *passes while everything leaks*: `tls_codec`'s
+//! byte vectors derive `Debug` and render as a **decimal** list —
+//! `[222, 173, 190, 239, …]` — which contains no hexadecimal characters at all.
+//! A leak check looking for `deadbeef` sails straight past a complete dump of
+//! the bytes.
+//!
+//! So every assertion below checks four renderings of the same secret: base16
+//! lower, base16 upper, base64url, and the decimal run. The decimal check is the
+//! one that would have caught the bug.
+//!
+//! # What is scanned
+//!
+//! 1. Every type in this crate that holds protocol material and derives or
+//!    implements `Debug` — a `Debug` reaches a log line the first time anyone
+//!    writes `{:?}` in a diagnostic, and every error type here can end up in a
+//!    startup message.
+//! 2. [`f2z_relay::log`]'s own output, which is checked structurally rather than
+//!    by scanning: the writer takes `&'static str` and `u64` and nothing else,
+//!    so there is no parameter through which a payload could travel. The test
+//!    that matters is that the signature has not grown one.
+//! 3. `--print-config`, because a bug report is where a redacted secret goes to
+//!    live forever.
+
+// An integration test is its own crate, so the workspace's denials of the
+// panicking families do not reach it through `lib.rs`'s `cfg_attr(test, ...)`.
+// They are relaxed here for the reason `rs/README.md` gives: a test that has to
+// thread a `Result` through every assertion is a test nobody reads, and a panic
+// in a test is a failing test rather than a remote denial of service.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_codec::types::{Challenge, Payload, PublicKey, QueueAddress};
+use f2z_relay::config::Config;
+
+/// A byte string chosen so every rendering of it is searchable.
+const SECRET: [u8; 8] = [0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe];
+
+/// The four ways these bytes could reach a log line.
+fn leak_forms() -> Vec<(&'static str, String)> {
+    let hex_lower: String = SECRET.iter().map(|byte| format!("{byte:02x}")).collect();
+    let hex_upper: String = SECRET.iter().map(|byte| format!("{byte:02X}")).collect();
+    let base64 = f2z_relay::caps::base64url(&SECRET);
+    // The one a hex-only check misses: `#[derive(Debug)]` on a byte vector.
+    let decimal: String = SECRET
+        .iter()
+        .map(|byte| byte.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    vec![
+        ("base16 lower", hex_lower),
+        ("base16 upper", hex_upper),
+        ("base64url", base64),
+        ("decimal byte list", decimal),
+    ]
+}
+
+#[track_caller]
+fn assert_no_leak(what: &str, rendered: &str) {
+    for (form, needle) in leak_forms() {
+        assert!(
+            !rendered.contains(&needle),
+            "{what} leaked its bytes as a {form}: {rendered}"
+        );
+    }
+}
+
+#[test]
+fn the_decimal_form_is_actually_what_an_underived_debug_prints() {
+    // The premise of every other test in this file. If this ever stops holding,
+    // the checks above are looking for the wrong string.
+    let raw = format!("{:?}", SECRET.to_vec());
+    assert!(raw.contains("222, 173, 190, 239"));
+    assert!(!raw.contains("deadbeef"));
+}
+
+#[test]
+fn an_outbound_frame_never_renders_its_ciphertext() {
+    let message = f2z_codec::commands::QueuedMessage {
+        index: 0,
+        received_at_ms: 1,
+        payload: Payload::new(SECRET.to_vec()).unwrap(),
+    };
+    let outbound = f2z_relay::outbound::msg_push(QueueAddress::new([0xde; 32]), &message).unwrap();
+    assert_no_leak("Outbound", &format!("{outbound:?}"));
+}
+
+#[test]
+fn a_wire_message_never_renders_its_bytes() {
+    let binary = f2z_relay::transport::WireMessage::Binary(SECRET.to_vec());
+    assert_no_leak("WireMessage::Binary", &format!("{binary:?}"));
+    // §4.2's text frame does not even carry the bytes into the relay.
+    assert_eq!(
+        format!("{:?}", f2z_relay::transport::WireMessage::Text),
+        "Text"
+    );
+}
+
+#[test]
+fn the_challenge_table_never_renders_a_scope() {
+    let mut table = f2z_relay::challenge::Challenges::new(4);
+    table
+        .issue(Challenge::new([0xaa; 32]), 2, &SECRET, 10_000, 0)
+        .unwrap();
+    assert_no_leak("Challenges", &format!("{table:?}"));
+}
+
+#[test]
+fn the_subscription_table_never_renders_an_address() {
+    let table = f2z_relay::subscriptions::Subscriptions::new();
+    let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+    let mut address = [0u8; 32];
+    address[..SECRET.len()].copy_from_slice(&SECRET);
+    table.subscribe(QueueAddress::new(address), 1, sender);
+    assert_no_leak("Subscriptions", &format!("{table:?}"));
+}
+
+#[test]
+fn a_source_key_is_not_an_address_and_does_not_render() {
+    let guard =
+        f2z_relay::abuse::AbuseGuard::new(f2z_relay::config::Limits::default(), true, [0x5a; 32]);
+    let peer = std::net::SocketAddr::from(([203, 0, 113, 7], 44_000));
+    let key = guard.key_for(&peer);
+    let rendered = format!("{key:?}");
+    assert_eq!(rendered, "SourceKey(<redacted>)");
+    // Not the address in any form either — including the decimal octets, which
+    // is how a derived `Debug` on `[u8; 4]` would have printed it.
+    for needle in ["203.0.113.7", "203, 0, 113, 7", "cb00", "44000"] {
+        assert!(!rendered.contains(needle), "the peer leaked: {rendered}");
+    }
+}
+
+#[test]
+fn the_config_debug_and_print_config_both_redact_the_identity_seed() {
+    let mut config = Config::default();
+    config.identity.seed = "de".repeat(32);
+    let printed = config.to_redacted_toml();
+    assert!(printed.contains("<redacted>"));
+    assert!(!printed.contains("dede"));
+    // A `Config` lands in a startup error message, so its `Debug` matters as
+    // much as its printer.
+    let debugged = format!("{config:?}");
+    assert!(!debugged.contains("dede"));
+    assert!(debugged.contains("<redacted>"));
+}
+
+#[test]
+fn a_store_error_never_carries_a_value() {
+    // The relay formats store errors nowhere on the wire — §10's ERR_INTERNAL
+    // "carries no detail, ever" — but it does log that a sweep failed, so the
+    // rendering is checked here as well as in `f2z-relay-store`'s own suite.
+    let error = f2z_relay_store::StoreError::Corrupt("a fixed string");
+    assert_no_leak("StoreError", &format!("{error}"));
+    assert_no_leak("StoreError", &format!("{error:?}"));
+}
+
+#[test]
+fn the_logger_has_no_parameter_a_secret_could_travel_through() {
+    // The structural half of the property. `line` takes a `&'static str` and
+    // `(&'static str, u64)` pairs; there is no `impl Debug` parameter, so
+    // `log_trace!("frame", "payload" = payload)` does not compile.
+    //
+    // This test is the compile check itself: it exercises every macro at the
+    // loudest level and asserts the output is digits and fixed text.
+    f2z_relay::log::set_level(f2z_relay::log::Level::Trace);
+    assert!(f2z_relay::log::enabled(f2z_relay::log::Level::Trace));
+    f2z_relay::log_trace!("a fixed message", "count" = 7u32);
+    f2z_relay::log_debug!("a fixed message", "count" = 7u32);
+    f2z_relay::log_info!("a fixed message");
+    f2z_relay::log_warn!("a fixed message");
+    f2z_relay::log_error!("a fixed message");
+    f2z_relay::log::set_level(f2z_relay::log::Level::Info);
+}
+
+#[test]
+fn metrics_carry_no_per_queue_and_no_per_ip_label() {
+    // The other half of the same rule: an unconsidered metrics endpoint is a
+    // metadata leak, and a per-queue series is a per-conversation activity
+    // trace that outlives the ciphertext in the scraper's storage.
+    let rendered = f2z_relay::metrics::Metrics::new().render();
+    for line in rendered.lines() {
+        if line.starts_with('#') {
+            continue;
+        }
+        assert!(!line.contains('{'), "a labelled series: {line}");
+    }
+    assert_no_leak("metrics", &rendered);
+}
+
+#[test]
+fn a_public_key_renders_nothing() {
+    // Inherited from `f2z-codec`'s newtypes rather than implemented here, and
+    // asserted so that a future local wrapper cannot quietly lose it.
+    let mut bytes = [0u8; 32];
+    bytes[..SECRET.len()].copy_from_slice(&SECRET);
+    assert_no_leak("PublicKey", &format!("{:?}", PublicKey::new(bytes)));
+    assert_no_leak("QueueAddress", &format!("{:?}", QueueAddress::new(bytes)));
+    assert_no_leak(
+        "Payload",
+        &format!("{:?}", Payload::new(SECRET.to_vec()).unwrap()),
+    );
+}

--- a/rs/deny.toml
+++ b/rs/deny.toml
@@ -105,16 +105,34 @@ allow = [
   # (the objc2 family, bytemuck, miniz_oxide, tinyvec); this entry is judged
   # against ours and names the crate that needs it.
   "Zlib",
+  # ISC arrives with TLS, and only with TLS: `rustls-webpki` and `untrusted`
+  # are ISC, and `ring` is `Apache-2.0 AND ISC`. None of them is reached by any
+  # crate a client links — the wasm32 job builds `f2z-codec` and
+  # `f2z-relay-proto` and neither pulls rustls — so this entry widens the
+  # policy for the server side of the tree only.
+  #
+  # ISC is the two-clause BSD licence with the redundant words removed:
+  # OSI-approved, FSF Free/Libre, permissive, no copyleft, no
+  # attribution-in-binary requirement. It sits on the same side of the boundary
+  # this section polices — permissive crates versus AGPL server binaries — as
+  # MIT and Apache-2.0 do, and it is added because a dependency needs it rather
+  # than in anticipation of one. `f2z-relay` needs TLS 1.3 because WIRE.md §5.3
+  # binds every signature to the TLS exporter and §2.1 forbids TLS 1.2.
+  "ISC",
 ]
 
-# Per-crate escapes. Empty today.
+# Per-crate escapes.
 #
-# This is where an AGPL-3.0 server binary goes when one lands — as
-# `{ name = "f2z-relay", allow = ["AGPL-3.0"] }`, and nowhere else. Adding
+# This is where an AGPL-3.0 server binary goes, and nowhere else. Adding
 # "AGPL-3.0" to `allow` above instead would silently permit it for every crate
 # in the tree, including the ones the ZUULI client links, which is exactly the
 # drift this section exists to prevent.
-exceptions = []
+#
+# `f2z-relay` is the first one to land. It is a server binary by every test the
+# boundary applies: it opens a listening socket, it links tokio and SQLite, it
+# is deliberately absent from rs.yml's wasm32 line, and no client links it.
+# Adding this entry was the reviewed, one-line act the section above describes.
+exceptions = [{ name = "f2z-relay", allow = ["AGPL-3.0"] }]
 
 # =============================================================================
 # Bans.

--- a/rs/deploy/Dockerfile
+++ b/rs/deploy/Dockerfile
@@ -1,0 +1,36 @@
+# f2z-fakerelay — a TEST DOUBLE for client development. NOT a relay.
+#
+# WIRE.md §2.1 admits `wss://` only and §7.1 requires unpredictable queue
+# addresses from the relay's own CSPRNG. This image provides neither: it serves
+# `ws://`, and its addresses come from a seeded BLAKE2b counter so that a
+# conformance vector can be replayed byte for byte. Both facts are published in
+# the capability document it serves, and a conforming client refuses it without
+# an explicit per-relay opt-in (§2.3 obligation 3).
+#
+# Build it, run it on a developer's machine, point a client at it. Do not put it
+# on a network anyone else can reach.
+
+# The compiler is pinned by rs/rust-toolchain.toml, which restates
+# wallet/rust-toolchain.toml and is held to it by
+# scripts/check-rust-toolchain.sh. `rust:1-slim` ships rustup, which reads that
+# file and fetches the pinned channel — so the version lives in one place here
+# too, rather than being restated in a FROM line nothing checks.
+FROM docker.io/library/rust:1-slim AS build
+WORKDIR /src
+# The whole rs/ workspace: one [workspace], one Cargo.lock, and `--locked` below
+# only means something if the lockfile is the one in the repository.
+COPY . /src
+RUN cargo build --locked --release -p f2z-relay-testkit --bin f2z-fakerelay
+
+FROM docker.io/library/debian:stable-slim
+# Nothing here writes to disk — durability_mode is `memory` (§8.4) — so the
+# runtime image needs no volume, no user data directory and no root.
+RUN useradd --create-home --uid 10001 fakerelay
+COPY --from=build /src/target/release/f2z-fakerelay /usr/local/bin/f2z-fakerelay
+USER fakerelay
+EXPOSE 9944
+ENTRYPOINT ["/usr/local/bin/f2z-fakerelay"]
+# --insecure-listen is required because the container binds 0.0.0.0, which
+# WIRE.md §2.3 refuses without an explicit override. Typing it here rather than
+# defaulting it away is the point: the override is meant to be visible.
+CMD ["--listen", "0.0.0.0:9944", "--insecure-listen"]

--- a/rs/deploy/docker-compose.dev.yml
+++ b/rs/deploy/docker-compose.dev.yml
@@ -1,0 +1,60 @@
+# A relay endpoint in one command, for client development.
+#
+#   cd rs/deploy && docker compose -f docker-compose.dev.yml up
+#   # → ws://127.0.0.1:9944/relay/v1
+#
+# WHAT THIS IS NOT: a relay. `f2z-fakerelay` serves `ws://` (WIRE.md §2.1 admits
+# `wss://` only), derives queue addresses from a fixed seed so vectors replay
+# (§7.1 requires them to be unpredictable), and keeps everything in memory
+# (§8.4's `durability_mode: memory`). All three are published in its signed
+# capability document, and a conforming client refuses it unless the developer
+# opts in per relay (§2.3 obligation 3):
+#
+#   ClientPolicy { allow_insecure_transport: true, .. }
+#
+# The `faulty` service is the same relay with the capability document of
+# https://github.com/free2z/zuu/issues/586 — `antireplay_window_ms` below
+# `2 x clock_skew_ms`, which the specification as written permits and a
+# conforming client must refuse. Point a client at it and watch the refusal;
+# if the client connects anyway, that is the bug the issue is about.
+
+name: f2z-fakerelay
+
+services:
+  fakerelay:
+    build:
+      # rs/ — the workspace root, because the build needs one Cargo.lock.
+      context: ..
+      dockerfile: deploy/Dockerfile
+    # Loopback-only by default. Change this and you are exposing a relay whose
+    # queue addresses anyone can predict.
+    ports:
+      - "127.0.0.1:9944:9944"
+    command:
+      - "--listen"
+      - "0.0.0.0:9944"
+      - "--insecure-listen"
+    read_only: true
+    healthcheck:
+      # A TCP accept is the whole health signal: the process holds no state to
+      # be unhealthy about.
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/9944 || exit 1"]
+      interval: 10s
+      timeout: 2s
+      retries: 3
+
+  # Optional: the same relay, publishing the capability document of #586.
+  # `docker compose -f docker-compose.dev.yml --profile faults up faulty`
+  faulty:
+    profiles: ["faults"]
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    ports:
+      - "127.0.0.1:9945:9945"
+    command:
+      - "--listen"
+      - "0.0.0.0:9945"
+      - "--insecure-listen"
+      - "--unsound-antireplay"
+    read_only: true

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -63,6 +63,7 @@ MANIFESTS=(
   rs/crates/f2z-authority/Cargo.toml
   rs/crates/f2z-relay-store/Cargo.toml
   rs/crates/f2z-relay-testkit/Cargo.toml
+  rs/crates/f2z-relay/Cargo.toml
 )
 
 # Other rust-toolchain.toml files. Cargo picks the toolchain from the directory


### PR DESCRIPTION
Builds **`rs/crates/f2z-relay`** — the relay daemon `WIRE.md` describes, the one that has to run in production. ~8,200 lines of source and ~1,700 of integration tests, on top of `f2z-codec`, `f2z-relay-proto` and `f2z-relay-store`, with **nothing in those three reimplemented**.

## Stacked on one unmerged branch

Rebuilt on **`2ced6e4`** — `main` with the reviewed `f2z-relay-store` (#632). The superseded store commits this branch was originally cut from are **gone**; the merged crate is used unchanged.

Still stacked on **`feature/relay-testkit`**, which is open, because `f2z-relay`'s acceptance test *is* its conformance suite.

| Commit | What |
|---|---|
| `0806212` | `f2z-relay-testkit` — someone else's PR (#607) |
| `d862ec5` | merge of that branch into current `main`; three conflicts, all "both sides added a crate to the same list" |
| `841d8eb` | **this work** — the whole crate |

Review `d862ec5..HEAD`.

### The reviewed store needed no adaptation

Worth stating precisely, since the instruction was to adapt to it rather than reintroduce mine. #632 changed `sqlite.rs` internals, made one `MemoryStore` read fix (an oversized message now `break`s rather than `continue`s, so a page cannot skip a row a cumulative ACK would then destroy — #605/#606), and shortened one `#[must_use]` string. **`store.rs`, `record.rs` and `lib.rs` are byte-identical**, `SqliteStore::commits` survives, and `f2z-relay` compiled against it with **zero source changes**. Nothing the relay needs was lost.

Both properties a rebase onto a different storage layer would silently break were re-measured on the merged crate:

- **Group commit: `100 appends in 1 durable transaction`**, against `SqliteStore::commits`.
- **Conformance: 39/13/0 versus 52/0/0, verdict equality intact** on all 39 comparable vectors.

#631 (anti-replay expiration boundary) and #623 (replay-key commitment after authentication) both land inside `f2z-relay-proto`'s `CommandVerifier`, which this relay calls rather than reimplements, so it inherits both.

---

## Acceptance: the conformance suite, run against both relays

`f2z-relay-testkit`'s 52 vectors, **unchanged**, driven through `WebSocketEndpoint::new(url)` — the constructor its README names as the one `f2z-relay` would be run through — against a real `ws://` listener, and against the FakeRelay over its own listener so a difference cannot be a transport artefact.

```
FakeRelay   52 passed,  0 skipped, 0 failed, of 52
f2z-relay   39 passed, 13 skipped, 0 failed, of 52
```

**Every one of the 39 vectors both relays can run reaches the same verdict.** `tests/conformance.rs` asserts that as an equality rather than counting passes, and separately asserts that each of the 13 is *skipped* and never failed. A skip is not a pass.

The 13 declare `Needs::Faults` or `Needs::Clock`. A real relay has neither handle **and must not**: a fault-injection hook compiled into a production binary is one an attacker can reach, and a `#[cfg(test)]` one is a hook a build-flag mistake ships. So `tests/configured_equivalents.rs` closes the gap the other way — **eleven of the thirteen are reachable on an unmodified binary**, through published configuration (a policy `WIRE.md` permits, not a relaxation) or through ordinary client behaviour the spec already describes:

| Skipped vector | Reached by |
|---|---|
| `a_duplicate_inflight_request_id_is_fatal` | an `APPEND` answered from its own task, so its id is genuinely outstanding |
| `exceeding_the_inflight_window_is_fatal` | the same, with `limits.max_inflight = 2` |
| `a_full_queue_is_indistinguishable_from_an_absent_one` | `limits.max_queue_messages = 1` |
| `the_queue_creation_quota_is_a_distinguishable_code` | `limits.max_queues = 1` |
| `backpressure_never_refuses_read_ack_or_delete` | `limits.storage_high_water_bytes = 1` |
| `an_expired_message_is_gone_and_announced` | a one-second message TTL and sweep |
| `an_idle_queue_disappears` | a one-second idle TTL and sweep |
| `a_lost_ack_response_is_safe_to_retry` | the client closes before reading the answer — §8.3's actual case |
| `a_delayed_response_still_correlates` | a cheap `PING` overtakes an `APPEND` waiting on a commit window |
| `reordered_responses_still_correlate` | the same exchange, correlated by `request_id` |
| `a_mid_stream_close_leaves_the_status_unknown` | the client closes mid-command |

The two that remain, stated rather than papered over:

- **`an_unsound_antireplay_window_is_published_and_refused`** is satisfied in a *stronger* sense than the vector asks. It has a relay publish `antireplay_window_ms == clock_skew_ms` and a client refuse it; `f2z-relay` **refuses to be configured that way at all** (`Config::check`, #586's finding enforced rather than demonstrated). The vector is unrunnable here because the defect it demonstrates cannot exist.
- **`every_error_code_can_reach_a_client`** is partly reachable. Code 9 `ERR_CHANNEL_BINDING` is *reserved and unused in v1* by §10's own table, so no conforming relay emits it, and code 21 `ERR_INTERNAL` is a relay fault. Every other §10 code is reached by the suite or by `configured_equivalents.rs`, which additionally provokes `ERR_RATE_LIMITED` and `ERR_POW_REQUIRED` on relays configured to use them.

### The comparison found a real defect — in this relay

`a_reader_is_told_when_its_queue_hits_a_cap` is a **difference no vector covers**. §6.4 defines `QUEUE_EVENT` reason 4 as "quota reached", pushed to a subscribed reader. The FakeRelay emits it; the first version of this relay did not, because §6.3's send-side collapse had been applied one layer too early — the *writer* must not learn which cap was hit, but the **reader** is the party who can drain the queue and §6.4 exists to tell it. **The FakeRelay was right**; fixed, with the regression test plus its mirror (an absent address must produce no push, or the push becomes §10's existence oracle).

That is the whole reason the testkit was written first, and it paid for itself.

### One behavioural difference that is not a defect in either

The FakeRelay sweeps §7.7's timers on **every command**, which is right for a harness whose clock a test steers. `f2z-relay` sweeps on a timer (`queues.expiry_tick_seconds`, default 60), because the sweep is a range scan and paying for it on every `READ` puts a cost proportional to the whole store on an operation §13.1 says must never be refused. The consequence — a message can outlive its TTL by up to one tick — is a policy statement about a seven-day timer, not a correctness one. Documented in `expiry.rs`.

---

## What is in the crate

- **Listener** (`listener.rs`, `tls.rs`, `transport.rs`) — `wss://` over rustls with **TLS 1.3 as the only version**, because §5.3's binding is the TLS 1.3 exporter and §2.1 forbids 1.2. §2.1's path and mandatory subprotocol, echoed. §2.3's non-loopback-without-TLS refusal is a **startup check** in `Config::check`, enforced again at `bind`, and the `--insecure-listen` override is published as `transport_security: none` + `channel_binding_mode: none` — both derived from the same `tls_enabled()` question so they cannot disagree.
- **Engine** (`engine.rs`) — §4 framing, §5.1's verification order via `CommandVerifier` with a **relay-wide** seen-set, §5.5's window, the full §6 command set over `RelayStore`, §10's existence-oracle collapse with the dummy Ed25519 verification on the absent path.
- **Group commit** (`commit.rs`) — an OS thread, because an fsync is a blocking syscall of unbounded duration and a 1 GB VPS has few workers. `Committed<T>` is unwrapped **on the writer thread after `append_batch` returns**, in the same statement that sends the reply.
- **Expiry tick** (`expiry.rs`) — both §7.7 timers, the seen-set, the challenge table, the rate-limiter rows, and §13.1 layer 4 measured against `storage_bytes` rather than assumed.
- **Anti-abuse** (`abuse.rs`, `challenge.rs`) — §13.1's four layers. Per-source counters are keyed by a **BLAKE2b digest under a per-process random salt** that never leaves the process, and an idle row is dropped rather than retained: a table keyed by IP that outlives its window is a connection log.
- **Admin listener** (`admin.rs`) — loopback-only and refused otherwise. `/healthz` is byte-identical across a queue, a connection and a message, and touches no storage. `/metrics` has **no labels at all**, enforced by `Metrics` having no method that takes an address or a key.
- **Config** (`config.rs`, `cli.rs`) — TOML + env + flags, `--help` / `--version` / `--print-config` (seed redacted) / `--check-config` / `--print-capabilities`. Unknown file keys are errors.

### Proofs, not claims

| Property | Evidence |
|---|---|
| `accepted` never precedes durability | `Committed<T>`'s constructor is crate-private; it is unwrapped on the commit thread and the reply is sent in the same statement |
| Group commit amortizes | `tests/group_commit.rs`: **100 concurrent appends → 1 durable transaction**, measured against `SqliteStore::commits` |
| Batching is still `fsync-per-append` | Same file: 50 appends across 5 connections, all 50 readable, indices dense |
| No secrets in logs | `tests/redaction.rs`: base16 both cases, base64url, **and the decimal byte-list form** |
| No per-queue or per-IP metrics | `tests/admin.rs` + `metrics.rs` unit tests |
| §13.2 refuses, never evicts | `a_full_queue_is_indistinguishable_from_an_absent_one`; the store's own suite covers the transaction |

`log::line` takes a `&'static str` and `(&'static str, u64)` pairs and nothing else, so `log_trace!("frame", "payload" = payload)` **does not compile**.

---

## Spec findings

### One new defect

**`queue_creation_mode: token` has no wire representation in v1.** §13.1 defines it as an operator-issued bearer credential, and `CREATE_QUEUE` carries only a `PowStamp` and a `flags` field that MUST be 0. There is no conforming way for a client to present a token, so a relay publishing that mode publishes a gate no client can pass. `f2z-relay` **refuses to start** in that mode rather than inventing a field. `f2z-relay-testkit`'s README observed the same thing from its own side and recorded it as a testkit gap; it is a spec-level gap, and it is not in #586.

### #586's three known contradictions

Read the issue and its comments. All three are implemented as #586/#583/the testkit resolved them, and **not re-reported**: the §6.3-versus-§10 send-side collapse resolved in §6.3's favour; the §1.3-versus-§4.3 unrecoverable-`request_id` case, closed with no response frame; the unknown `ChallengePurpose` byte answered `ERR_MALFORMED`, and `READ`'s zero limits read as "no limit". The anti-replay retention invariant is **enforced** here rather than left publishable.

### Every ambiguity call

1. **A second `HELLO`** → fatal `ERR_UNSUPPORTED_VERSION`. §3.5 says negotiation happens once; §10 names no code. Matches the testkit.
2. **Close status for a fatal error other than §4.2's** → 1002. §1.3 names none. Matches the testkit.
3. **A client sending a `response` or `push` frame** → fatal `ERR_MALFORMED`. §10 has no code for the wrong half of the protocol.
4. **Unknown `ChallengePurpose`** → fatal `ERR_MALFORMED`. #586's comment; the weakest call in the set, and the testkit's.
5. **`READ` zero limits** → no limit. #586's comment; the testkit's.
6. **`READ`'s byte limit is additionally clamped to `max_frame_bytes - 4096`.** *New, and small.* §6.2 lets a client ask for more bytes than §4.1 lets the relay send; without a clamp the relay builds a frame its own cap forbids and answers `ERR_INTERNAL` instead of the page. Unstated.
7. **A full challenge table** → `ERR_BACKPRESSURE`, and it **refuses rather than evicts**. §5.5 gives that code to the seen-set bound for the same reason; evicting would invalidate a stamp a client already paid for.
8. **`GET_CHALLENGE` over its per-source budget** → `ERR_RATE_LIMITED`. §6.1 requires the limit and names no code.
9. **A `Ping` from a client** → `Pong`. §2.4 only specifies the server-driven direction.
10. **Group commit is published as `fsync-per-append`**, on §8.4's own distinction. Stated because it is the field an auditor will question.

---

## Licence boundary

**AGPL-3.0** for this crate, per #305. `rs/deny.toml` gains exactly the entry its own comment anticipated — `{ name = "f2z-relay", allow = ["AGPL-3.0"] }` — and *not* `"AGPL-3.0"` in the shared `allow` list.

Two supply-chain changes need review:

- **`ISC` added to `allow`.** It arrives only with TLS: `rustls-webpki` and `untrusted` are ISC, `ring` is `Apache-2.0 AND ISC`. None is reached by any crate a client links — the wasm32 job builds `f2z-codec`, `f2z-relay-proto` and `f2z-authority`, and none pulls rustls. ISC is the two-clause BSD licence with the redundant words removed: OSI-approved, FSF Free/Libre, no copyleft, no attribution-in-binary requirement. Added because a dependency needs it, as the file's own instructions describe.
- **`rustls-pemfile` avoided** in favour of `rustls-pki-types`' own `PemObject`. It was archived in August 2025 (**RUSTSEC-2025-0134**) and its advisory says the latest version is a thin wrapper around exactly that code. One fewer crate on the path that reads an operator's private key.

`multiple-versions = "warn"` reports duplicates (`winnow`, `rand`, `getrandom`, `syn`, …); most predate this branch and none fails the gate.

---

## Two workspace scans

**#612's strictness scan.** It registers every `fn verify…` under `rs/crates/*/src/`, not only call sites. Three were unregistered: this relay's `verify`/`verify_with` and `f2z-relay-testkit`'s `verify`. Rather than register three, the thin `verify(&Connection, …)` wrapper is **deleted** — a second name beginning with `verify` is a second thing the scan must be told about, to save one field access at six call sites, and the field it saves is the one that must not be wrong: a transcript builder from anywhere but this connection binds the signature to another session's channel binding (§5.3). Neither relay verifies a signature itself; both reach `key.rs::verify`'s `verify_strict` through `CommandVerifier`, and both registry rows say so.

**`workspace_debug_scan` is hardened against a wrapped attribute.** Its attribute-skipping loop stopped at the first line not starting with `#`, took an attribute's continuation line for the item declaration, and aborted the entire scan on an assert. That is a *hole*, not a failure: one `#[must_use = "…"]` spanning two lines anywhere under `rs/crates/*/src/` silently disables every leak check in the file. `f2z-relay-store` carried exactly that shape until #632 happened to shorten the string — the bug is still on `main`, merely unexercised. Now attributes are consumed until their brackets balance.

**With that fix it immediately caught two real leaks in this crate**: `AbuseGuard` derived `Debug` over the per-process salt that makes `SourceKey` non-invertible, and `Published` derived it over the encoded capability document. Both now hand-write `Debug`.

## Gates

`fmt`, `clippy -D warnings`, `cargo-deny` (advisories, bans, licences, sources) and `check-rust-toolchain.sh` are green locally on the pinned **1.97.1**, plus `cargo test --locked --all-targets`, `--doc`, and the store's `crash-injection` suite. All three new crates are registered in #625's `MANIFESTS` census, and `rs.yml` keeps them **off** the wasm32 line, where its own comment already anticipated "a future server binary — which will be AGPL, will pull tokio, and will never reach a browser".

## Not done, deliberately

- **`.well-known` is not served.** §11.2 asks for the document over plain HTTPS; serving it means an HTTP request parser on the unauthenticated public port, which is precisely what §2.2 argues against, for an affordance aimed at humans rather than clients. The upgrade's own HTTP parse does not help — it runs only for requests already carrying `Upgrade: websocket`. `--print-capabilities` emits the identical document, signature and digest included, for an operator to publish from whatever already serves their website: §11.2's *property* — same values, same signature, publicly diffable — survives; the relay hosting it does not. A JSON **encoder** consumes nothing from the network, which is why one is here and a parser is not. Reviewers who disagree should say so; it is the most arguable call in the PR.
- **`ACK` is not batched.** It commits, so it is the obvious next batcher; deliberately deferred because an `ACK` is one range delete per *reader* rather than one per message, and adding a second scheduler before the first is measured in production is how a relay acquires two nobody can reason about.
- **Push notifications, federation, anonymous credentials** — §16 leaves them open and so does this.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
