### PR TITLE
fix(relay): close anti-replay expiration boundary

### DIFF
--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -578,7 +578,12 @@ Two mechanisms, together:
    within the window and rejects a repeat with `ERR_REPLAY`. `nonce` is 16 bytes
    from the client's CSPRNG, fresh per command; the birthday bound is 2^64 per
    key, which is not reachable inside a two-minute window at any rate a relay
-   would serve.
+   would serve. `antireplay_window_ms` MUST be at least `2 × clock_skew_ms`, and
+   an entry MUST remain live through the instant at which that retention period
+   ends. Both boundaries matter: the timestamp window is inclusive, so a frame
+   first accepted at `timestamp_ms - clock_skew_ms` remains valid at
+   `timestamp_ms + clock_skew_ms`. A half-open seen-set would forget it at that
+   same instant when the two published windows are equal.
 
 **The seen-set is fail-closed.** It is bounded (`antireplay_seen_max`, published)
 and when the bound is reached the relay returns `ERR_BACKPRESSURE` and refuses new

--- a/rs/crates/f2z-relay-proto/src/capabilities.rs
+++ b/rs/crates/f2z-relay-proto/src/capabilities.rs
@@ -488,8 +488,8 @@ pub fn defaults(relay_identity_pk: &PublicKey, published_at_ms: u64) -> Result<C
 
         // §5.5 default: ±2 minutes.
         clock_skew_ms: 120_000,
-        // Twice the skew, for the reason `Refusal::AntiReplayWindowTooShort`
-        // gives. `WIRE.md` publishes no default for this field.
+        // Twice the skew. Equality is sound because §5.5 requires seen-set
+        // entries to remain live through their expiration instant.
         antireplay_window_ms: 240_000,
         antireplay_persistence: AntiReplayPersistence::Volatile.code(),
 

--- a/rs/crates/f2z-relay-proto/src/command.rs
+++ b/rs/crates/f2z-relay-proto/src/command.rs
@@ -1201,6 +1201,34 @@ mod tests {
     }
 
     #[test]
+    fn a_frame_seen_at_the_earliest_valid_instant_is_still_seen_at_the_latest() {
+        let key = SigningKey::from_seed(&[0x9a; 32]);
+        let signed = SignedCommand::<ops::Subscribe>::create(
+            &transcripts(),
+            2,
+            QueueAddress::new([0x9b; 32]),
+            NOW,
+            nonce(0x9c),
+            &key,
+            &Empty,
+        )
+        .unwrap();
+        let request = signed.request().unwrap();
+        let mut verifier = verifier();
+
+        assert!(
+            verifier
+                .verify::<ops::Subscribe>(NOW - 120_000, 2, &request)
+                .is_ok()
+        );
+        assert_eq!(
+            verifier.verify::<ops::Subscribe>(NOW + 120_000, 2, &request),
+            Err(ProtoError::Wire(ErrorCode::Replay)),
+            "the inclusive timestamp window must not outlive the seen-set entry"
+        );
+    }
+
+    #[test]
     fn the_timestamp_window_is_checked_before_the_signature() {
         let key = SigningKey::from_seed(&[5u8; 32]);
         let signed = SignedCommand::<ops::Subscribe>::create(

--- a/rs/crates/f2z-relay-proto/src/replay.rs
+++ b/rs/crates/f2z-relay-proto/src/replay.rs
@@ -157,7 +157,7 @@ impl fmt::Debug for ReplayKey {
 /// but they are not independent. See [`SeenSet::retention_is_sound`].
 #[derive(Clone, Debug)]
 pub struct SeenSet {
-    /// Value is the instant at which the entry may be dropped.
+    /// Value is the final instant at which the entry must remain live.
     entries: BTreeMap<ReplayKey, u64>,
     retention_ms: u64,
     max_entries: usize,
@@ -226,6 +226,9 @@ impl SeenSet {
     }
 
     /// Drop every entry whose retention has elapsed, and report how many went.
+    /// An entry whose expiration equals `now_ms` is still live: the timestamp
+    /// window is inclusive at both ends, so the seen-set must cover its own
+    /// final millisecond too.
     ///
     /// Called by [`SeenSet::preflight`] and [`SeenSet::commit`] before anything
     /// else, so a relay never
@@ -234,7 +237,7 @@ impl SeenSet {
     /// forever, and an operator may want to reclaim that.
     pub fn expire(&mut self, now_ms: u64) -> usize {
         let before = self.entries.len();
-        self.entries.retain(|_, expires_at| *expires_at > now_ms);
+        self.entries.retain(|_, expires_at| *expires_at >= now_ms);
         before.saturating_sub(self.entries.len())
     }
 
@@ -369,20 +372,46 @@ mod tests {
     }
 
     #[test]
-    fn an_entry_survives_for_exactly_its_retention() {
-        // Half-open: an entry observed at `t` is held over `[t, t +
-        // retention_ms)`. Which end is closed does not matter to the security
-        // property, because soundness comes from `retention_ms >= 2 *
-        // clock_skew_ms` (`SeenSet::retention_is_sound`) and not from a single
-        // millisecond at the boundary; it is pinned by a test so it cannot
-        // change unnoticed.
+    fn an_entry_survives_through_its_expiration_instant() {
+        // Closed: an entry observed at `t` is held over `[t, t +
+        // retention_ms]`. This final instant is security-significant when
+        // retention equals twice the inclusive timestamp skew: the original
+        // frame is still valid there and must still be recognized as a replay.
         let mut seen = SeenSet::new(1_000, 8);
         seen.commit(0, key(1)).unwrap();
         assert_eq!(
             seen.commit(999, key(1)),
             Err(ProtoError::Wire(ErrorCode::Replay))
         );
-        assert!(seen.commit(1_000, key(1)).is_ok());
+        assert_eq!(
+            seen.commit(1_000, key(1)),
+            Err(ProtoError::Wire(ErrorCode::Replay))
+        );
+        assert!(seen.commit(1_001, key(1)).is_ok());
+    }
+
+    #[test]
+    fn zero_retention_still_rejects_a_replay_at_the_same_instant() {
+        let mut seen = SeenSet::new(0, 8);
+        seen.commit(500, key(1)).unwrap();
+        assert_eq!(
+            seen.commit(500, key(1)),
+            Err(ProtoError::Wire(ErrorCode::Replay))
+        );
+        assert!(seen.commit(501, key(1)).is_ok());
+    }
+
+    #[test]
+    fn expiration_overflow_fails_closed() {
+        let mut seen = SeenSet::new(10, 8);
+        let near_end_of_time = u64::MAX - 4;
+        seen.commit(near_end_of_time, key(1)).unwrap();
+        assert_eq!(
+            seen.commit(near_end_of_time, key(1)),
+            Err(ProtoError::Wire(ErrorCode::Replay)),
+            "expiration arithmetic must not wrap behind the observation time"
+        );
+        assert_eq!(seen.expire(u64::MAX), 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #624.

## Fix
- Keep seen-set entries live through their inclusive expiration instant, matching the inclusive timestamp window.
- State the retention relationship and boundary semantics in WIRE.md.
- Exercise the real CommandVerifier from the earliest valid presentation through the latest valid replay.
- Pin zero-retention and overflowing expiration behavior through the public SeenSet API.

## Mutation proof
- The new verifier reproduction failed red against the old half-open production predicate before the fix.
- Production expiration >= changed back to > compiles and fails red.
- Production saturating_add changed to wrapping_add compiles and fails red near u64::MAX.
- Inclusive timestamp <= changed to < compiles and fails red through the verifier boundary.
- Restored candidate passes 88 unit, 6 property, and 8 redaction tests, plus strict clippy and fmt.

Independently reviewed at exact head 63d0ec97d95312cd20243d1667079c8923998d11.