### PR TITLE
test(zcash): mutation-prove send path gaps

### DIFF
--- a/scripts/check-librustzcash-compat.mjs
+++ b/scripts/check-librustzcash-compat.mjs
@@ -399,6 +399,8 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     "pub(super) fn create_transactions<",
     "pub(super) fn propose_fixed_validated<",
     "pub(super) fn propose_send_all_validated<",
+    "pub(super) fn standard_minimum_fee(",
+    "pub(super) fn wallet_summary_with_policy<",
   ];
   // Comments are whitespace in Rust and are already masked above. Canonicalize
   // visibility token spacing before counting so `pub(super /* comment */)`
@@ -418,18 +420,48 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     occurrences(visibilityCanonical, "pub ") !== 0
   ) {
     errors.push(
-      "private native send policy module must expose only its three audited safe boundaries",
+      "private native send policy module must expose only its five audited safe boundaries",
     );
   }
   const lockHelper =
     "fn proposal_lock_request() -> Option<LockRequest> { None }";
   const versionHelper =
     "fn proposed_transaction_version() -> Option<TxVersion> { None }";
+  const confirmationsPolicyBody = rustFunctionBody(
+    send,
+    "confirmations_policy",
+  );
+  const walletSummaryPolicyBody = rustFunctionBody(
+    send,
+    "wallet_summary_with_policy",
+  );
+  const minimumFeeBody = rustFunctionBody(send, "standard_minimum_fee");
   if (
     occurrences(send, "fn proposal_lock_request()") !== 1 ||
     occurrences(send, lockHelper) !== 1
   ) {
     errors.push("proposal lock decision must remain one exact audited None helper");
+  }
+  if (confirmationsPolicyBody !== "ConfirmationsPolicy::default()") {
+    errors.push(
+      "confirmation depth must remain one shared native-send policy decision",
+    );
+  }
+  if (
+    walletSummaryPolicyBody !==
+    "db.get_wallet_summary(confirmations_policy())"
+  ) {
+    errors.push(
+      "send-all wallet summary must remain routed through the shared confirmation policy",
+    );
+  }
+  if (
+    minimumFeeBody !==
+    "let rule = Zip317FeeRule::standard(); (rule.marginal_fee() * rule.grace_actions()).map(u64::from)"
+  ) {
+    errors.push(
+      "send-all minimum fee must remain derived from the standard ZIP-317 fee rule",
+    );
   }
   if (
     occurrences(send, "fn proposed_transaction_version()") !== 1 ||
@@ -460,7 +492,7 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     "&input_selector,",
     "&change_strategy,",
     "request,",
-    "ConfirmationsPolicy::default(),",
+    "confirmations_policy(),",
     "spend_policy,",
     "proposal_lock_request(),",
     "proposed_transaction_version(),",
@@ -522,6 +554,39 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     orchestration,
     "create_production_recovery_route",
   );
+  const sendAllSpendableBody = rustFunctionBody(
+    orchestration,
+    "send_all_spendable_balance",
+  );
+  const sendAllStatefulBody = rustFunctionBody(
+    orchestration,
+    "propose_send_all_stateful_production_caller",
+  );
+  if (
+    occurrences(orchestration, "ConfirmationsPolicy") !== 0 ||
+    occurrences(
+      sendAllSpendableBody ?? "",
+      "self::native::wallet_summary_with_policy(db)",
+    ) !== 1 ||
+    occurrences(
+      orchestration,
+      "self::native::wallet_summary_with_policy(db)",
+    ) !== 1
+  ) {
+    errors.push(
+      "send-all spendable balance must consume the sole native confirmation policy",
+    );
+  }
+  if (
+    occurrences(
+      sendAllStatefulBody ?? "",
+      "let minimum_fee = self::native::standard_minimum_fee()",
+    ) !== 1
+  ) {
+    errors.push(
+      "send-all retry and minimum-balance guard must derive their estimate from the standard ZIP-317 fee authority",
+    );
+  }
   for (const [boundary, body] of [
     ["fixed-send", fixedProductionRouteBody],
     ["send-all", sendAllProductionRouteBody],
@@ -574,10 +639,7 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
     ],
     [
       "send-all stateful caller",
-      rustFunctionBody(
-        orchestration,
-        "propose_send_all_stateful_production_caller",
-      ),
+      sendAllStatefulBody,
       "propose_send_all_production_route(",
     ],
     [
@@ -623,8 +685,9 @@ function validate(snapshot, scope = reviewedCompatibilityScope()) {
       boundary: "send-all WalletState adapter",
       functionName: "propose_send_all_after_recipient_validation",
       transition: "proposal construction and exact pending-state installation",
-      digest: "6240360464b39a53bd5ba965df13861a98cbe9466995926c93fbd4ffdb67ccbf",
+      digest: "1f9d5942f8ec8cfeafa9c1f5bd8c43c64f88c1f97476cda42a5db11bed49fd00",
       orderedAnchors: [
+        "let spendable = { let db_guard = state.read_db.lock().await; let db = db_guard.as_ref().ok_or(Error::WalletNotInitialized)?; send_all_spendable_balance(db)? };",
         "let (pending, public) = propose_send_all_stateful_production_caller( db, &state.network, &recipient, memo_bytes.as_ref(), network_label(&state.network), spendable, &wallet_id, &state.proposal_counter, state.send_session_id, )?;",
         "drop(db_guard);",
         "let mut pending_broadcast = state.pending_broadcast.lock().await;",
@@ -1123,7 +1186,7 @@ function runSelfTest() {
         "pub(super) fn propose_with_policy<",
         "private policy core becomes parent-visible",
       ),
-      "expose only its three audited safe boundaries",
+      "expose only its five audited safe boundaries",
     ],
     [
       "comment spacing cannot hide parent-visible policy core",
@@ -1134,7 +1197,7 @@ function runSelfTest() {
         "pub(super /* visibility mutant */) fn propose_with_policy<",
         "hide parent-visible policy core behind comment spacing",
       ),
-      "expose only its three audited safe boundaries",
+      "expose only its five audited safe boundaries",
     ],
     [
       "fixed safe boundary loses parent visibility",
@@ -1145,7 +1208,7 @@ function runSelfTest() {
         "fn propose_fixed_validated<",
         "fixed safe boundary loses parent visibility",
       ),
-      "expose only its three audited safe boundaries",
+      "expose only its five audited safe boundaries",
     ],
     [
       "policy module re-exports a policy type",
@@ -1156,7 +1219,7 @@ function runSelfTest() {
         "use zcash_client_backend::fees::DustOutputPolicy;\npub(super) use zcash_client_backend::data_api::wallet::input_selection::SpendPolicy as ExposedSpendPolicy;",
         "policy module re-exports a policy type",
       ),
-      "expose only its three audited safe boundaries",
+      "expose only its five audited safe boundaries",
     ],
     [
       "parent imports a forbidden policy type",
@@ -1626,6 +1689,72 @@ function runSelfTest() {
         "TxVersion helper drift",
       ),
       "transaction version decision",
+    ],
+    [
+      "shared confirmation policy drifts to minimum depth",
+      mutated(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "    ConfirmationsPolicy::default()\n",
+        "    ConfirmationsPolicy::MIN\n",
+        "change the shared confirmation policy",
+      ),
+      "one shared native-send policy decision",
+    ],
+    [
+      "wallet summary bypasses the shared confirmation policy",
+      mutated(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "    db.get_wallet_summary(confirmations_policy())\n",
+        "    db.get_wallet_summary(ConfirmationsPolicy::MIN)\n",
+        "bypass shared depth inside the wallet-summary boundary",
+      ),
+      "wallet summary must remain routed through the shared confirmation policy",
+    ],
+    [
+      "standard minimum fee becomes an independent literal",
+      mutated(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "    (rule.marginal_fee() * rule.grace_actions()).map(u64::from)\n",
+        "    Some(10_000)\n",
+        "replace the fee-rule derivation with an independent literal",
+      ),
+      "derived from the standard ZIP-317 fee rule",
+    ],
+    [
+      "proposal construction bypasses the shared confirmation policy",
+      mutated(
+        baseline,
+        NATIVE_SEND_POLICY_SOURCE,
+        "        confirmations_policy(),\n",
+        "        ConfirmationsPolicy::default(),\n",
+        "bypass shared depth in proposal construction",
+      ),
+      "exact audited depth, spend, lock, and version decisions",
+    ],
+    [
+      "send-all balance bypasses the shared confirmation policy",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let summary = self::native::wallet_summary_with_policy(db)\n",
+        "    let summary = db\n        .get_wallet_summary(zcash_client_backend::data_api::wallet::ConfirmationsPolicy::default())\n",
+        "bypass shared depth in send-all balance",
+      ),
+      "sole native confirmation policy",
+    ],
+    [
+      "send-all retry revives the independent fee literal",
+      mutated(
+        baseline,
+        SEND_SOURCE,
+        "    let minimum_fee = self::native::standard_minimum_fee()\n        .ok_or(Error::SendError(\"standard ZIP-317 fee overflow\".into()))?;\n",
+        "    let minimum_fee = 10_000;\n",
+        "replace the send-all fee authority with a literal",
+      ),
+      "standard ZIP-317 fee authority",
     ],
     [
       "shared proposal core is no longer recognizable",

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs
@@ -11,7 +11,7 @@ use std::{
 use rand::{RngCore, rngs::OsRng};
 use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
-use zcash_client_backend::data_api::wallet::{ConfirmationsPolicy, SpendingKeys};
+use zcash_client_backend::data_api::wallet::SpendingKeys;
 use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead, WalletWrite};
 use zcash_client_backend::proto::service::{RawTransaction, TxFilter};
 use zcash_keys::address::Address;
@@ -1466,6 +1466,35 @@ enum SendAllRouteError {
     Other(Error),
 }
 
+/// Read the shielded value send-all may spend under the same confirmation
+/// policy that proposal construction enforces.
+fn send_all_spendable_balance<DbT>(db: &DbT) -> Result<u64>
+where
+    DbT: WalletRead,
+    <DbT as WalletRead>::Error: std::fmt::Display,
+{
+    let summary = self::native::wallet_summary_with_policy(db)
+        .map_err(|error| Error::DatabaseError(format!("{error}")))?
+        .ok_or(Error::SendError("no wallet summary available".into()))?;
+    let account_ids = db
+        .get_account_ids()
+        .map_err(|error| Error::DatabaseError(format!("{error}")))?;
+    let account_id = account_ids
+        .first()
+        .copied()
+        .ok_or(Error::SendError("no accounts found".into()))?;
+    let balance = summary
+        .account_balances()
+        .get(&account_id)
+        .ok_or(Error::SendError("no balance for account".into()))?;
+    let sapling = balance.sapling_balance();
+    let orchard = balance.orchard_balance();
+    let ironwood = balance.ironwood_balance();
+    Ok(u64::from(sapling.spendable_value())
+        + u64::from(orchard.spendable_value())
+        + u64::from(ironwood.spendable_value()))
+}
+
 /// The compiler-bound send-all attempt used by production and behavior tests.
 /// A successful return proves both the ordinary request reached native policy
 /// and the resulting proposal survived native review.
@@ -1543,9 +1572,12 @@ where
         .first()
         .copied()
         .ok_or(Error::SendError("no accounts found".into()))?;
-    let mut amount = spendable
-        .checked_sub(10_000)
-        .ok_or(Error::SendError("insufficient spendable balance".into()))?;
+    let minimum_fee = self::native::standard_minimum_fee()
+        .ok_or(Error::SendError("standard ZIP-317 fee overflow".into()))?;
+    if spendable <= minimum_fee {
+        return Err(Error::SendError("insufficient spendable balance".into()));
+    }
+    let mut amount = spendable - minimum_fee;
 
     for _ in 0..3 {
         match propose_send_all_production_route(
@@ -1702,36 +1734,8 @@ async fn propose_send_all_after_recipient_validation(
     let spendable = {
         let db_guard = state.read_db.lock().await;
         let db = db_guard.as_ref().ok_or(Error::WalletNotInitialized)?;
-        let policy = ConfirmationsPolicy::default();
-        let summary = db
-            .get_wallet_summary(policy)
-            .map_err(|e| Error::DatabaseError(format!("{e}")))?
-            .ok_or(Error::SendError("no wallet summary available".into()))?;
-        let account_ids = db
-            .get_account_ids()
-            .map_err(|e| Error::DatabaseError(format!("{e}")))?;
-        let account_id = account_ids
-            .first()
-            .copied()
-            .ok_or(Error::SendError("no accounts found".into()))?;
-        let balance = summary
-            .account_balances()
-            .get(&account_id)
-            .ok_or(Error::SendError("no balance for account".into()))?;
-        let sapling = balance.sapling_balance();
-        let orchard = balance.orchard_balance();
-        // Ironwood is a third shielded pool (NU6.3); after activation, Orchard
-        // becomes spend-only and new shielded value lands in Ironwood, so it must
-        // be counted or the wallet will report a false "insufficient balance".
-        let ironwood = balance.ironwood_balance();
-        u64::from(sapling.spendable_value())
-            + u64::from(orchard.spendable_value())
-            + u64::from(ironwood.spendable_value())
+        send_all_spendable_balance(db)?
     };
-
-    if spendable <= 10000 {
-        return Err(Error::SendError("insufficient spendable balance".into()));
-    }
 
     let memo_bytes = match memo {
         Some(m) => {
@@ -2469,17 +2473,21 @@ async fn broadcast_record(
 #[doc(hidden)]
 pub mod production_route_probe {
     use super::*;
+    use std::collections::HashMap;
+    use zcash_client_backend::data_api::Account;
     use zcash_client_backend::data_api::testing::{
         orchard::OrchardPoolTester,
         pool::{ShieldedPoolTester, dsl::TestDsl},
     };
+    use zcash_client_backend::decrypt_transaction;
     use zcash_client_sqlite::testing::{BlockCache, db::TestDbFactory};
+    use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
+    use zcash_protocol::memo::Memo;
 
     pub fn assert_ordinary_stateful_shipping_routes() {
-        const NOTE_VALUE: u64 = 60_000;
+        const NOTE_VALUE: u64 = 90_000;
+        const EACH_NOTE_VALUE: u64 = 30_000;
         const FIXED_SEND_VALUE: u64 = 10_000;
-        const SEND_ALL_VALUE: u64 = 50_000;
-        const EXPECTED_FEE: u64 = 10_000;
         const PROPOSAL_ID: u32 = 41;
         const WALLET_ID: &str = "ordinary-route-wallet";
         const REVIEW_NETWORK: &str = "independent-test-network";
@@ -2488,14 +2496,17 @@ pub mod production_route_probe {
         let mut state =
             TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
                 .build::<OrchardPoolTester>();
-        let (_, _, _) =
-            state.add_a_single_note_checking_balance(Zatoshis::const_from_u64(NOTE_VALUE));
+        for _ in 0..3 {
+            let (_, _, _) =
+                state.add_a_single_note_checking_balance(Zatoshis::const_from_u64(EACH_NOTE_VALUE));
+        }
 
         let recipient_key = OrchardPoolTester::sk(&[0xa7; 32]);
         let recipient = OrchardPoolTester::sk_default_address(&recipient_key);
         let network = *state.network();
         let recipient = recipient.to_zcash_address(&network);
         let account = state.get_account();
+        let account_id = account.id();
         let spending_keys = SpendingKeys::from_unified_spending_key(account.usk().clone());
         let proposal_counter = AtomicU32::new(PROPOSAL_ID);
 
@@ -2512,10 +2523,21 @@ pub mod production_route_probe {
         );
         assert!(
             immature.is_err(),
-            "one-confirmation Orchard value must not cross shipping policy"
+            "sub-ten-confirmation Orchard value must not cross shipping policy"
+        );
+        assert_eq!(
+            send_all_spendable_balance(state.wallet())
+                .expect("the shipping balance path must read the test wallet"),
+            0,
+            "the shared confirmation policy must exclude immature value from send-all",
         );
         assert_eq!(proposal_counter.load(Ordering::Relaxed), PROPOSAL_ID);
         state.add_empty_blocks(9);
+        let spendable = send_all_spendable_balance(state.wallet())
+            .expect("the shipping balance path must read mature value");
+        assert_eq!(spendable, NOTE_VALUE);
+        let minimum_fee = self::native::standard_minimum_fee()
+            .expect("the standard ZIP-317 minimum fee must be representable");
 
         let (fixed_pending, fixed_public) = propose_fixed_stateful_production_caller(
             state.wallet_mut(),
@@ -2538,8 +2560,8 @@ pub mod production_route_probe {
             recipient.encode()
         );
         assert_eq!(fixed_public.review.payments[0].amount, FIXED_SEND_VALUE);
-        assert_eq!(fixed_public.review.fee, EXPECTED_FEE);
-        assert_eq!(fixed_public.review.total, FIXED_SEND_VALUE + EXPECTED_FEE);
+        assert_eq!(fixed_public.review.fee, minimum_fee);
+        assert_eq!(fixed_public.review.total, FIXED_SEND_VALUE + minimum_fee);
         assert_eq!(fixed_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
         assert_eq!(fixed_proposal.input_count_in_pool(PoolType::SAPLING), 0);
         assert_eq!(
@@ -2557,13 +2579,32 @@ pub mod production_route_probe {
             0
         );
 
+        let guard_error = propose_send_all_stateful_production_caller(
+            state.wallet_mut(),
+            &network,
+            &recipient,
+            None,
+            REVIEW_NETWORK,
+            minimum_fee,
+            WALLET_ID,
+            &proposal_counter,
+            SESSION_ID,
+        )
+        .err()
+        .expect("a balance equal to the minimum fee must be rejected by the production guard");
+        assert!(
+            matches!(guard_error, Error::SendError(message) if message == "insufficient spendable balance"),
+            "the exact send-all minimum-balance guard must reject before proposal construction",
+        );
+        assert_eq!(proposal_counter.load(Ordering::Relaxed), PROPOSAL_ID + 1);
+
         let (send_all_pending, send_all_public) = propose_send_all_stateful_production_caller(
             state.wallet_mut(),
             &network,
             &recipient,
             None,
             REVIEW_NETWORK,
-            NOTE_VALUE,
+            spendable,
             WALLET_ID,
             &proposal_counter,
             SESSION_ID,
@@ -2571,10 +2612,14 @@ pub mod production_route_probe {
         .expect("ordinary value must cross the stateful send-all shipping caller");
         let send_all_proposal = send_all_pending.native_proposal();
         assert_eq!(send_all_public.proposal_id, PROPOSAL_ID + 1);
-        assert_eq!(send_all_public.review.payments[0].amount, SEND_ALL_VALUE);
-        assert_eq!(send_all_public.review.fee, EXPECTED_FEE);
+        assert!(send_all_public.review.fee > minimum_fee);
+        assert_eq!(
+            send_all_public.review.payments[0].amount + send_all_public.review.fee,
+            spendable,
+            "fee convergence must retry from the minimum estimate to the real multi-input fee",
+        );
         assert_eq!(send_all_public.review.total, NOTE_VALUE);
-        assert_eq!(send_all_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
+        assert_eq!(send_all_proposal.input_count_in_pool(PoolType::ORCHARD), 3);
         assert_eq!(
             send_all_proposal
                 .steps()
@@ -2587,7 +2632,7 @@ pub mod production_route_probe {
             0
         );
 
-        let recovery_height = fixed_proposal.min_target_height().into();
+        let recovery_height: consensus::BlockHeight = fixed_proposal.min_target_height().into();
         let prover = LocalTxProver::bundled();
         let mut broadcast_slot = None;
         execute_send_creation_stateful_production_caller(
@@ -2621,6 +2666,27 @@ pub mod production_route_probe {
             .get_transaction(txid)
             .expect("the stateful creation caller must leave the wallet readable")
             .expect("the stateful creation caller must persist its transaction");
+        assert_eq!(
+            tx.expiry_height(),
+            recovery_height + DEFAULT_TX_EXPIRY_DELTA,
+            "shipping creation must retain the builder-derived expiry height",
+        );
+        let viewing_keys: HashMap<_, _> =
+            [(account_id, account.usk().to_unified_full_viewing_key())]
+                .into_iter()
+                .collect();
+        let decrypted =
+            decrypt_transaction(&network, None, Some(recovery_height), &tx, &viewing_keys);
+        let mut wallet_output_memos = Vec::new();
+        OrchardPoolTester::with_decrypted_pool_memos(&decrypted, |memo| {
+            wallet_output_memos
+                .push(Memo::try_from(memo).expect("shipping creation must encode a valid memo"));
+        });
+        assert_eq!(
+            wallet_output_memos,
+            vec![Memo::Empty, Memo::Empty],
+            "the shipping recipient is memo-free, so the other actual output proves change is empty",
+        );
         let mut persisted_transaction_bytes = Vec::new();
         tx.write(&mut persisted_transaction_bytes)
             .expect("the persisted transaction must serialize");
@@ -2660,10 +2726,9 @@ mod tests {
 
     #[test]
     fn ordinary_values_cross_each_complete_production_money_route() {
-        const NOTE_VALUE: u64 = 60_000;
+        const NOTE_VALUE: u64 = 90_000;
+        const EACH_NOTE_VALUE: u64 = 30_000;
         const FIXED_SEND_VALUE: u64 = 10_000;
-        const SEND_ALL_VALUE: u64 = 50_000;
-        const EXPECTED_FEE: u64 = 10_000;
         const PROPOSAL_ID: u32 = 41;
         const WALLET_ID: &str = "ordinary-route-wallet";
         const REVIEW_NETWORK: &str = "independent-test-network";
@@ -2671,8 +2736,10 @@ mod tests {
         let mut state =
             TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
                 .build::<OrchardPoolTester>();
-        let (_, _, _) =
-            state.add_a_single_note_checking_balance(Zatoshis::const_from_u64(NOTE_VALUE));
+        for _ in 0..3 {
+            let (_, _, _) =
+                state.add_a_single_note_checking_balance(Zatoshis::const_from_u64(EACH_NOTE_VALUE));
+        }
 
         let recipient_key = OrchardPoolTester::sk(&[0xa7; 32]);
         let recipient = OrchardPoolTester::sk_default_address(&recipient_key);
@@ -2695,10 +2762,21 @@ mod tests {
         );
         assert!(
             immature.is_err(),
-            "an externally received Orchard note must not cross production policy after one confirmation"
+            "externally received Orchard notes must not cross production policy below ten confirmations"
+        );
+        assert_eq!(
+            send_all_spendable_balance(state.wallet())
+                .expect("the production balance path must read the test wallet"),
+            0,
+            "the shared confirmation policy must exclude immature value from send-all",
         );
         assert_eq!(proposal_counter.load(Ordering::Relaxed), PROPOSAL_ID);
         state.add_empty_blocks(9);
+        let spendable = send_all_spendable_balance(state.wallet())
+            .expect("the production balance path must read mature value");
+        assert_eq!(spendable, NOTE_VALUE);
+        let minimum_fee = self::native::standard_minimum_fee()
+            .expect("the standard ZIP-317 minimum fee must be representable");
 
         let (fixed_pending, fixed_public) = propose_fixed_stateful_production_caller(
             state.wallet_mut(),
@@ -2719,8 +2797,8 @@ mod tests {
         assert_eq!(fixed_review.payments.len(), 1);
         assert_eq!(fixed_review.payments[0].recipient, recipient.encode());
         assert_eq!(fixed_review.payments[0].amount, FIXED_SEND_VALUE);
-        assert_eq!(fixed_review.fee, EXPECTED_FEE);
-        assert_eq!(fixed_review.total, FIXED_SEND_VALUE + EXPECTED_FEE);
+        assert_eq!(fixed_review.fee, minimum_fee);
+        assert_eq!(fixed_review.total, FIXED_SEND_VALUE + minimum_fee);
         assert_eq!(fixed_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
         assert_eq!(fixed_proposal.input_count_in_pool(PoolType::SAPLING), 0);
         assert_eq!(
@@ -2738,13 +2816,32 @@ mod tests {
             0
         );
 
+        let guard_error = propose_send_all_stateful_production_caller(
+            state.wallet_mut(),
+            &network,
+            &recipient,
+            None,
+            REVIEW_NETWORK,
+            minimum_fee,
+            WALLET_ID,
+            &proposal_counter,
+            SESSION_ID,
+        )
+        .err()
+        .expect("a balance equal to the minimum fee must be rejected by the production guard");
+        assert!(
+            matches!(guard_error, Error::SendError(message) if message == "insufficient spendable balance"),
+            "the exact send-all minimum-balance guard must reject before proposal construction",
+        );
+        assert_eq!(proposal_counter.load(Ordering::Relaxed), PROPOSAL_ID + 1);
+
         let (send_all_pending, send_all_public) = propose_send_all_stateful_production_caller(
             state.wallet_mut(),
             &network,
             &recipient,
             None,
             REVIEW_NETWORK,
-            NOTE_VALUE,
+            spendable,
             WALLET_ID,
             &proposal_counter,
             SESSION_ID,
@@ -2753,10 +2850,14 @@ mod tests {
         let send_all_proposal = send_all_pending.native_proposal();
         let send_all_review = &send_all_public.review;
         assert_eq!(send_all_public.proposal_id, PROPOSAL_ID + 1);
-        assert_eq!(send_all_review.payments[0].amount, SEND_ALL_VALUE);
-        assert_eq!(send_all_review.fee, EXPECTED_FEE);
+        assert!(send_all_review.fee > minimum_fee);
+        assert_eq!(
+            send_all_review.payments[0].amount + send_all_review.fee,
+            spendable,
+            "fee convergence must retry from the minimum estimate to the real multi-input fee",
+        );
         assert_eq!(send_all_review.total, NOTE_VALUE);
-        assert_eq!(send_all_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
+        assert_eq!(send_all_proposal.input_count_in_pool(PoolType::ORCHARD), 3);
         assert_eq!(
             send_all_proposal
                 .steps()

--- a/wallet/plugins/tauri-plugin-zcash/src/wallet/send/native.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/wallet/send/native.rs
@@ -4,7 +4,9 @@ use zcash_client_backend::data_api::wallet::{
     input_selection::{GreedyInputSelector, SpendPolicy},
     propose_transfer,
 };
-use zcash_client_backend::data_api::{InputSource, WalletCommitmentTrees, WalletRead, WalletWrite};
+use zcash_client_backend::data_api::{
+    InputSource, WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite,
+};
 use zcash_client_backend::fees::DustOutputPolicy;
 use zcash_client_backend::fees::zip317::SingleOutputChangeStrategy;
 use zcash_client_backend::proposal::Proposal;
@@ -25,6 +27,34 @@ fn proposed_transaction_version() -> Option<TxVersion> {
     // Let librustzcash select the consensus transaction version for the target
     // height, matching the behavior before this argument was introduced.
     None
+}
+
+/// The one confirmation-depth decision used by proposal construction and the
+/// send-all spendable-balance read.
+fn confirmations_policy() -> ConfirmationsPolicy {
+    ConfirmationsPolicy::default()
+}
+
+/// Apply the shared depth decision without making the policy type or value
+/// available to orchestration.
+pub(super) fn wallet_summary_with_policy<DbT>(
+    db: &DbT,
+) -> std::result::Result<
+    Option<WalletSummary<<DbT as WalletRead>::AccountId>>,
+    <DbT as WalletRead>::Error,
+>
+where
+    DbT: WalletRead,
+{
+    db.get_wallet_summary(confirmations_policy())
+}
+
+/// Derive the minimum standard ZIP-317 fee from the fee rule itself. Returning
+/// `None` keeps an impossible future arithmetic overflow on the ordinary error
+/// path instead of turning a send request into a process panic.
+pub(super) fn standard_minimum_fee() -> Option<u64> {
+    let rule = Zip317FeeRule::standard();
+    (rule.marginal_fee() * rule.grace_actions()).map(u64::from)
 }
 
 type NativeSendChangeStrategy<DbT> = SingleOutputChangeStrategy<Zip317FeeRule, DbT>;
@@ -69,7 +99,7 @@ where
         &input_selector,
         &change_strategy,
         request,
-        ConfirmationsPolicy::default(),
+        confirmations_policy(),
         spend_policy,
         proposal_lock_request(),
         proposed_transaction_version(),
@@ -170,6 +200,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use transparent::{
         bundle::{OutPoint, TxOut},
         keys::TransparentKeyScope,
@@ -180,9 +211,12 @@ mod tests {
         pool::{ShieldedPoolTester, dsl::TestDsl},
     };
     use zcash_client_backend::data_api::wallet::input_selection::TransparentSpendPolicy;
+    use zcash_client_backend::decrypt_transaction;
     use zcash_client_backend::wallet::WalletTransparentOutput;
     use zcash_client_sqlite::testing::{BlockCache, db::TestDbFactory};
+    use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
     use zcash_protocol::PoolType;
+    use zcash_protocol::memo::Memo;
     use zcash_protocol::value::Zatoshis;
 
     fn payment_request(
@@ -197,12 +231,21 @@ mod tests {
         .expect("the independently fixed test payment is valid")
     }
 
+    fn independently_derived_standard_minimum_fee() -> u64 {
+        let rule = Zip317FeeRule::standard();
+        u64::from(
+            (rule.marginal_fee() * rule.grace_actions())
+                .expect("the standard ZIP-317 fee constants fit in the monetary range"),
+        )
+    }
+
     #[test]
     fn production_send_boundaries_preserve_pool_depth_fee_and_sender_recovery() {
         const NOTE_VALUE: u64 = 60_000;
         const FIXED_SEND_VALUE: u64 = 10_000;
         const SEND_ALL_VALUE: u64 = 50_000;
-        const EXPECTED_FEE: u64 = 10_000;
+        let expected_fee = independently_derived_standard_minimum_fee();
+        assert_eq!(standard_minimum_fee(), Some(expected_fee));
 
         let mut st =
             TestDsl::with_sapling_birthday_account(TestDbFactory::default(), BlockCache::new())
@@ -255,7 +298,7 @@ mod tests {
         );
         assert_eq!(
             u64::from(proposal.steps().head.balance().fee_required()),
-            EXPECTED_FEE
+            expected_fee
         );
 
         let send_all_proposal = propose_send_all_validated(
@@ -269,7 +312,7 @@ mod tests {
         assert_eq!(send_all_proposal.input_count_in_pool(PoolType::ORCHARD), 1);
         assert_eq!(
             u64::from(send_all_proposal.steps().head.balance().fee_required()),
-            EXPECTED_FEE
+            expected_fee
         );
         assert_eq!(
             send_all_proposal
@@ -285,7 +328,7 @@ mod tests {
 
         let spending_keys = SpendingKeys::from_unified_spending_key(account.usk().clone());
         let prover = LocalTxProver::bundled();
-        let recovery_height = proposal.min_target_height().into();
+        let recovery_height: consensus::BlockHeight = proposal.min_target_height().into();
         let txids = create_transactions(
             st.wallet_mut(),
             &network,
@@ -299,6 +342,29 @@ mod tests {
             .get_transaction(txids.head)
             .expect("the test wallet database remains readable")
             .expect("the created transaction is persisted");
+        assert_eq!(
+            tx.expiry_height(),
+            recovery_height + DEFAULT_TX_EXPIRY_DELTA,
+            "the created transaction must retain the builder-derived expiry height",
+        );
+
+        let viewing_keys: HashMap<_, _> =
+            [(account_id, account.usk().to_unified_full_viewing_key())]
+                .into_iter()
+                .collect();
+        let decrypted =
+            decrypt_transaction(&network, None, Some(recovery_height), &tx, &viewing_keys);
+        let mut wallet_output_memos = Vec::new();
+        OrchardPoolTester::with_decrypted_pool_memos(&decrypted, |memo| {
+            wallet_output_memos.push(
+                Memo::try_from(memo).expect("a transaction built by the wallet has a valid memo"),
+            );
+        });
+        assert_eq!(
+            wallet_output_memos,
+            vec![Memo::Empty, Memo::Empty],
+            "the recipient fixture is memo-free, so the other decrypted output proves change is empty",
+        );
         let sender_fvk = OrchardPoolTester::test_account_fvk(&st);
         let (_, recovered_recipient, _) =
             OrchardPoolTester::try_output_recovery(&network, recovery_height, &tx, &sender_fvk)


### PR DESCRIPTION
Closes #616

Closes the remaining native send-path verification gaps with behavioral coverage through the exact shipping production callers:

- one private confirmation policy drives both proposal construction and send-all wallet summaries;
- the ZIP-317 minimum is derived from the fee rule rather than copied as a literal;
- the send-all retry test requires more than one fee-convergence iteration and exercises the exact minimum-balance boundary;
- actual created transaction bytes prove builder expiry and empty change memo after decryption.

Mutation evidence (each compiled and went red, then was restored):
- transaction expiry `None -> Some(height)`;
- change memo `None -> Some(probe)`;
- summary confirmation policy `default -> MIN`;
- proposal confirmation policy `default -> MIN`;
- retry range `0..3 -> 0..1`;
- minimum guard `<= -> <`;
- fee-rule derivation replaced with an independent literal.

Verification on exact head `4c08f99e58d6798270c2ab698c4b4acbcf96db6d`:
- 114 compatibility mutants killed + live source contract green;
- 145 unit tests + 1 shipping-feature production-route integration green;
- pinned Rust 1.97.1 fmt and clippy `-D warnings` green;
- independently reviewed exact head; stable patch ID and all resulting blobs match the mutation-approved candidate.