### PR TITLE
test(kt): bind rejected VRF seed to akd_core

### DIFF
--- a/rs/crates/f2z-kt/src/vrf.rs
+++ b/rs/crates/f2z-kt/src/vrf.rs
@@ -124,7 +124,23 @@ impl core::fmt::Debug for FileVrf {
 
 #[cfg(test)]
 mod tests {
+    use akd_core::ecvrf::VRFKeyStorage as _;
+
     use super::{FileVrf, HARDCODED_TEST_VRF_SEED};
+
+    #[tokio::test]
+    async fn the_copied_seed_still_matches_akd_cores_own() {
+        let library = akd_core::ecvrf::HardCodedAkdVRF
+            .retrieve()
+            .await
+            .expect("akd_core's hardcoded VRF key is retrievable");
+        assert_eq!(
+            library.as_slice(),
+            &HARDCODED_TEST_VRF_SEED,
+            "akd_core changed its hardcoded test key; forbid_hardcoded is now refusing a key \
+             nobody ships and permitting the one that makes every label public",
+        );
+    }
 
     #[test]
     fn the_libraries_hardcoded_test_key_is_refused_at_startup() {


### PR DESCRIPTION
Closes #644.

## What changed

Adds an async `f2z-kt` test that retrieves `akd_core::ecvrf::HardCodedAkdVRF` through the public `VRFKeyStorage` API and compares that independent library value with the copied production refusal seed. This binds the refusal guard to the real upstream registry without a source-shape or locally duplicated fixture.

## Verification

- `cargo +1.97.1 test --locked -p f2z-kt --all-targets` — 61 tests pass
- `cargo +1.97.1 test --locked -p f2z-kt --doc` — pass
- `cargo +1.97.1 fmt --all -- --check` — pass
- `cargo +1.97.1 clippy --locked -p f2z-kt --all-targets -- -D warnings` — pass

Mutation controls, replayed independently on exact head `0bc5d4f1`:

- Corrupt one production seed byte (`0xc9 -> 0xc8`) — RED: independent retrieval remains `201`, copied seed becomes `200`.
- Delete the refusal body — RED: hardcoded key unexpectedly loads.
- Invert the equality predicate — RED: forbidden seed is accepted and both ordinary-key tests reject valid seeds.

Independent exact-head review: APPROVE. Stable patch ID: `d75a96a631d5050c27acc9350ad3dc615c535ca1`.