### PR TITLE
fix(kt): restore nonce ledger across restart

### DIFF
--- a/rs/crates/f2z-kt/src/log.rs
+++ b/rs/crates/f2z-kt/src/log.rs
@@ -154,19 +154,46 @@ impl core::fmt::Debug for Pending {
 /// first restart — the nonces were checked when they were first admitted, and
 /// the record of that decision *is* the journal.
 ///
+/// It does capture the nonce observation produced by that successful check.
+/// [`readmit`] moves the captured values into the separate live ledger only
+/// after admission succeeds, so startup both verifies its history without
+/// rejecting it and closes the replay window that history already spent.
+///
 /// It is a distinct type rather than a flag so that it cannot be reached from
 /// the live path: [`LogService::submit`] names [`NonceLedger`] and nothing
 /// else.
-struct ReplayLedger;
+struct ReplayedNonce {
+    now_ms: u64,
+    authority_id: f2z_authority::types::AuthorityId,
+    nonce: f2z_authority::types::AssertionNonce,
+    expires_ms: u64,
+}
+
+#[derive(Default)]
+struct ReplayLedger {
+    observed: Option<ReplayedNonce>,
+}
+
+impl ReplayLedger {
+    fn take_observed(&mut self) -> Option<ReplayedNonce> {
+        self.observed.take()
+    }
+}
 
 impl f2z_authority::nonce::NonceSeen for ReplayLedger {
     fn observe(
         &mut self,
-        _now_ms: u64,
-        _authority_id: f2z_authority::types::AuthorityId,
-        _nonce: f2z_authority::types::AssertionNonce,
-        _expires_ms: u64,
+        now_ms: u64,
+        authority_id: f2z_authority::types::AuthorityId,
+        nonce: f2z_authority::types::AssertionNonce,
+        expires_ms: u64,
     ) -> core::result::Result<(), f2z_authority::AuthorityError> {
+        self.observed = Some(ReplayedNonce {
+            now_ms,
+            authority_id,
+            nonce,
+            expires_ms,
+        });
         Ok(())
     }
 }
@@ -309,7 +336,7 @@ impl LogService {
     ///   rather than a log serving proofs against a root nobody cosigned.
     async fn replay(&self, journal: Journal) -> Result<()> {
         let mut state = self.state.lock().await;
-        let mut ledger = ReplayLedger;
+        let mut ledger = ReplayLedger::default();
 
         let mut cursor = 0usize;
         for stored in &journal.epochs {
@@ -922,11 +949,11 @@ impl core::fmt::Debug for LogService {
 /// It takes the same route a network submission takes — the journal holds the
 /// envelope exactly as it was canonicalised, so there is one admission path and
 /// not a second, laxer one for startup.
-fn readmit<S: f2z_authority::nonce::NonceSeen + ?Sized>(
+fn readmit(
     state: &mut State,
     service: &LogService,
     record: &crate::store::StoredSubmission,
-    ledger: &mut S,
+    replay: &mut ReplayLedger,
 ) -> Result<AdmittedSubmission> {
     let handle = peek_handle(record.envelope.as_slice())?;
     let previous = state.published.get(&handle).cloned();
@@ -945,9 +972,39 @@ fn readmit<S: f2z_authority::nonce::NonceSeen + ?Sized>(
         authority: &service.authority,
         retained,
     };
-    admit_submission(record.envelope.as_slice(), &context, ledger).map_err(|error| {
+    let admitted =
+        admit_submission(record.envelope.as_slice(), &context, replay).map_err(|error| {
+            LogError::Storage(format!(
+                "submissions.log: record {} no longer admits ({error})",
+                record.sequence
+            ))
+        })?;
+    restore_replayed_nonce(&mut state.nonces, record, replay)?;
+    Ok(admitted)
+}
+
+/// Restore a nonce that the canonical stored assertion presented while the
+/// replay ledger re-ran admission. Replay itself must accept the log's own
+/// history, but the separate live ledger must remember that history after
+/// startup.
+fn restore_replayed_nonce(
+    live: &mut NonceLedger,
+    record: &crate::store::StoredSubmission,
+    replay: &mut ReplayLedger,
+) -> Result<()> {
+    let Some(observed) = replay.take_observed() else {
+        return Ok(());
+    };
+    f2z_authority::nonce::NonceSeen::observe(
+        live,
+        observed.now_ms,
+        observed.authority_id,
+        observed.nonce,
+        observed.expires_ms,
+    )
+    .map_err(|error| {
         LogError::Storage(format!(
-            "submissions.log: record {} no longer admits ({error})",
+            "submissions.log: record {} cannot restore the nonce ledger ({error})",
             record.sequence
         ))
     })

--- a/rs/crates/f2z-kt/tests/durability.rs
+++ b/rs/crates/f2z-kt/tests/durability.rs
@@ -27,7 +27,12 @@
 
 use std::sync::Arc;
 
-use f2z_kt::testing::{EntryBuilder, Harness, Identity};
+use f2z_authority::types::{AssertionNonce, Handle as AuthorityHandle, Intent, LogId};
+use f2z_codec::Canonical as _;
+use f2z_kt::testing::{EntryBuilder, Harness, Identity, entry_bytes};
+use f2z_kt::wire::SubmissionEnvelope;
+use f2z_kt_core::entry::DirectoryEntry;
+use f2z_kt_core::labels;
 use f2z_kt_core::types::Handle;
 
 const NOW: u64 = 1_700_000_100_000;
@@ -48,6 +53,82 @@ async fn reopen(harness: &Harness) -> f2z_kt::Result<f2z_kt::LogService> {
         Vec::new(),
     )
     .await
+}
+
+/// Build a fully valid first-entry envelope whose assertion uses an explicit
+/// nonce. Each call constructs and signs a new assertion, so two returned
+/// envelopes sharing a nonce are not copies of one another.
+fn envelope_with_nonce(
+    harness: &Harness,
+    entry: &DirectoryEntry,
+    identity: &Identity,
+    nonce: AssertionNonce,
+) -> Vec<u8> {
+    let bytes = entry_bytes(entry);
+    let digest = labels::entry_value(&bytes);
+    let handle = AuthorityHandle::parse(entry.entry.handle.as_slice()).unwrap();
+    let issuer = harness.issuer.as_ref().unwrap();
+    let assertion = f2z_authority::HandleAssertionTBS::new(
+        &issuer.public_key(),
+        LogId::new(*harness.log_id.as_bytes()),
+        handle.clone(),
+        entry.entry.identity_pk,
+        Intent::Bind,
+        0,
+        NOW,
+        NOW + 60_000,
+        nonce,
+    )
+    .unwrap()
+    .sign(issuer)
+    .unwrap();
+    let binding = harness
+        .log
+        .authority()
+        .binding(&handle, &entry.entry.identity_pk, Some(&assertion), &digest)
+        .unwrap();
+    let identity_signature = identity.isk.sign(&binding.signing_bytes().unwrap());
+    SubmissionEnvelope::new(
+        &bytes,
+        Some(&assertion.encode_canonical().unwrap()),
+        identity_signature,
+    )
+    .unwrap()
+    .encode_canonical()
+    .unwrap()
+}
+
+#[tokio::test]
+async fn a_restart_does_not_reopen_an_admitted_assertion_nonce() {
+    let harness = Harness::vouched("dur-nonce-restart").await;
+    let alice = Identity::from_byte(1);
+    let bob = Identity::from_byte(2);
+    let nonce = AssertionNonce::new([0x77; 16]);
+
+    let alice_entry = EntryBuilder::first(harness.log_id, "alice", &alice).same_key(&alice.dak);
+    let bob_entry = EntryBuilder::first(harness.log_id, "bob", &bob).same_key(&bob.dak);
+    let alice_envelope = envelope_with_nonce(&harness, &alice_entry, &alice, nonce);
+    let bob_envelope = envelope_with_nonce(&harness, &bob_entry, &bob, nonce);
+
+    // The second assertion is independently signed for another handle and
+    // identity. On a fresh log it passes every chain, assertion and binding
+    // rule; the reused (authority_id, nonce) pair is its only defect.
+    let control = Harness::vouched("dur-nonce-control").await;
+    let control_bob = envelope_with_nonce(&control, &bob_entry, &bob, nonce);
+    control.log.submit(&control_bob, NOW).await.unwrap();
+
+    harness.log.submit(&alice_envelope, NOW).await.unwrap();
+    harness.log.publish_epoch(NOW).await.unwrap();
+
+    let reopened = reopen(&harness).await.unwrap();
+    let error = reopened
+        .submit(&bob_envelope, NOW + 1_000)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        f2z_kt::LogError::Authority(f2z_authority::AuthorityError::ReplayedNonce)
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #650.

## What changed

Reconstructs the live A17 `NonceLedger` while replaying canonical stored assertions after restart. The existing `ReplayLedger` still reruns full admission; only successfully admitted records restore their `(authority_id, nonce, expiry)` into the production ledger before published/tail state is installed. Both epoch and tail loops share the same `readmit` path.

The decisive restart test uses independently signed first-entry assertions for Alice and Bob with different handles, identities, entries, bindings, and signatures. Bob succeeds on a fresh control log, then is rejected only for reusing Alice's `(authority_id, nonce)` after Alice is journaled and the log is reopened.

## Verification

- `scripts/check-rust-fmt.sh --root rs` — pass
- `cargo +1.97.1 test --locked -p f2z-kt --all-targets` — 61 tests pass
- `cargo +1.97.1 test --locked -p f2z-authority nonce::tests` — 6 tests pass
- `cargo +1.97.1 clippy --locked -p f2z-kt --all-targets --all-features -- -D warnings` — pass

Mutation controls, independently replayed on exact head `50a76fa6`:

- Remove restore call — RED: restart accepts Bob.
- Key by nonce only — RED: distinct authority is falsely rejected.
- Key by authority only — RED: distinct nonce is falsely rejected.
- Change expiry release `>` to `>=` — RED at the exact boundary.
- Evict on capacity instead of refusing — RED: third insertion returns `Ok` instead of `LedgerFull`.

Independent exact-head review: APPROVE. Stable patch ID: `9ebcb1f4a744da23462f86de10be08e6b038ce1a`.