### PR TITLE
fix(kt): A15 could not fail — `account_epoch` must move like a counter

### DIFF
--- a/docs/e2ee/KT.md
+++ b/docs/e2ee/KT.md
@@ -676,6 +676,27 @@ this paragraph be restated without its scope.
 > must survive a restart. Each is a case where the weaker behaviour leaves a
 > field or a rule in place that looks like it is doing work it is not.
 
+> **Correction (2026-08-24) — neither of those two is still a gap between this
+> document and the Rust log, and the `account_epoch` rule has grown a rule a
+> verifier can actually apply.**
+> [#650](https://github.com/free2z/zuu/issues/650),
+> [#651](https://github.com/free2z/zuu/issues/651).
+>
+> - **A17's ledger durability was a code defect, not a specification one**, and
+>   is fixed: the log rebuilt an empty ledger on startup, so every restart
+>   reopened the replay window for every assertion still inside its validity cap,
+>   while the trait it wrote through said in its own documentation that a restart
+>   must not do that. It now restores each admitted
+>   `(authority_id, nonce, expires_ms)` into the live ledger during journal
+>   replay. §4.5.5's sentence is unchanged because it was right.
+> - **`account_epoch`'s rule is now checkable, within a stated limit.** §4.5.4
+>   carries **A18** and says exactly which clocks it still cannot see and what the
+>   issuer must therefore guarantee. The issuing endpoint operated by the party
+>   that runs the user directory still derives the value from Unix seconds where
+>   no counter is supplied and remains **non-conforming**; that is tracked on
+>   their side, and A18 means a log now refuses those assertions rather than
+>   publishing entries authorized by a rule that could not fail.
+
 An assertion is a short-lived, single-use, log-pinned statement by a configured
 authority that a named handle belongs to a named identity key. It is **not** part
 of the `DirectoryEntry`; it accompanies one, in the submission envelope of §9.2,
@@ -837,6 +858,56 @@ baseline the handle's first `reset` must exceed.
 > event. A `u32` seconds counter also exhausts the field in 2106, which is a
 > second reason not to put a clock in it.
 
+> **Correction (2026-08-24) — the MUST above is now a rule a log applies, and
+> the honest limit of that rule is stated with it.**
+> [#651](https://github.com/free2z/zuu/issues/651). As first published this
+> section stated the issuer's obligation and stopped there, which left A15 in the
+> position the paragraph above describes: a rule that **cannot fail** against a
+> clock-derived value, in a document that says so. A requirement no verifier
+> checks is a requirement, not a rule, and this one had already been disregarded
+> by a shipped issuer.
+>
+> A log therefore now applies **A18** (§4.5.5), and it has two halves because one
+> is not enough:
+>
+> - **A18a — a ceiling.** `account_epoch` **MUST** be less than `2^20`
+>   (1,048,576). This is what a count of account-ownership events can plausibly
+>   reach: an account that changed hands or was recovered a million times is not
+>   an account. Unix time in whole seconds has exceeded it since 1970-01-13, and
+>   Unix milliseconds do not fit `uint32` at all, so the exact non-conformance
+>   named above is refused **on the value's face** — including at a first `bind`,
+>   where there is no retained value and A15 has nothing to compare against at
+>   all.
+> - **A18b — a step bound.** Where a value is retained for the handle,
+>   `account_epoch` **MUST NOT** exceed it by more than **16**. A counter
+>   increments once per ownership event, and only events whose assertion never
+>   reached the log accumulate slack, so the gap between two admitted assertions
+>   is a handful. A clock's gap is however much time passed. This is what catches
+>   a clock too coarse to trip the ceiling — days since the epoch is about
+>   20,700.
+>
+> Both are **fixed constants, not published policy numbers**, unlike A9's
+> validity cap: the same bound on every log is one a client can apply without
+> first fetching §4.6's document, and there is no operational reason for two logs
+> to disagree about a counter's shape.
+>
+> **What A18 cannot do, said plainly.** No check on a single `uint32` can prove
+> the value came from durable storage. A clock fine enough to tick between two
+> issuances but coarse enough to tick at most sixteen times, and small enough in
+> absolute terms to stay under the ceiling, is indistinguishable from a counter
+> in the value alone. A18 is therefore **necessary and not sufficient**, and the
+> MUST above is not weakened to match what a verifier can see. What the issuer
+> must guarantee instead, and what this document requires of it:
+>
+> - `account_epoch` is read from and written to a **per-account column that
+>   survives a process restart**;
+> - it is incremented **only** on the events that justify invalidating
+>   outstanding assertions — account recovery and account transfer — and once per
+>   such event, not once per assertion issued;
+> - an issuer that cannot read that column **MUST refuse to issue**
+>   `intent = reset` rather than substitute a clock, a timestamp, or any other
+>   value that happens to be increasing.
+
 #### 4.5.5 The rules, in the order a log applies them
 
 These are §4.4 rule 11, expanded. They run **after** §4.4's rules 1–10, for the
@@ -907,6 +978,13 @@ a log MUST apply all of them.
     replay, while the pair also catches an issuer that reused a nonce across two
     *different* assertions — an issuer bug, or a compromised issuer trying to
     make two claims look like one, which is the case worth failing on.
+18. **A18 — `account_epoch` moved like a counter, not like a clock.** It is
+    below `2^20`, and where a value is retained for this handle it exceeds that
+    value by at most 16. §4.5.4 states both bounds, why they are fixed rather
+    than published, and exactly what they cannot prove. Applied **with A15**
+    rather than after A17: it costs nothing, and a submission that fails it must
+    not burn a nonce. Numbered last because it was added last
+    ([#651](https://github.com/free2z/zuu/issues/651)); it is not run last.
 
 **On A17's ledger.** A log MUST refuse rather than evict: discarding an unexpired
 entry to make room silently reopens the replay window at exactly the moment the
@@ -928,7 +1006,7 @@ There is no new error code. §9.5's table is unchanged and the mapping is:
 | A2 decode, re-encode mismatch, charset | `ERR_MALFORMED` (1) |
 | A4 wrong `log_id` | `ERR_UNSUPPORTED_VERSION` (2) — "a `log_id` this server does not serve" |
 | A13, A16 signature failures | `ERR_BAD_SIGNATURE` (3) |
-| A1, A3, A5–A12, A14, A15, and A17 **as a replay** | `ERR_BAD_AUTHORIZATION` (4) |
+| A1, A3, A5–A12, A14, A15, A18, and A17 **as a replay** | `ERR_BAD_AUTHORIZATION` (4) |
 | A17 refused because the ledger is **full of unexpired entries** | `ERR_RATE_LIMITED` (9) |
 | the log's own authority set is misconfigured | `ERR_INTERNAL` (11) |
 
@@ -2312,9 +2390,13 @@ Deliberately, and listed rather than invented.
   session theft the first step of a handle takeover (§4.7). This is an
   account-security decision rather than a wire encoding, which is why §4.5 does
   not invent one, and it is a real gap rather than a tidy deferral. The two
-  conformance rules §4.5 states more strictly than a shipped implementation are
+  conformance rules §4.5 states more strictly than a shipped implementation were
   tracked as [#651](https://github.com/free2z/zuu/issues/651) (`account_epoch`)
-  and [#650](https://github.com/free2z/zuu/issues/650) (A17's ledger).
+  and [#650](https://github.com/free2z/zuu/issues/650) (A17's ledger); **both
+  are closed on the log side** — A17's ledger now survives a restart, and A18
+  refuses a clock-shaped `account_epoch`. What is left is not a specification
+  gap but an issuer that must hold a durable per-account counter, which A18 can
+  bound but cannot verify (§4.5.4).
 - **The authority key's own distribution and rotation.** §4.6 publishes the
   authority set in a document signed by the log, which is not a trust root —
   exactly the caveat §9.1 states for `reset_authority_pk`, and the same

--- a/rs/crates/f2z-authority/src/assertion.rs
+++ b/rs/crates/f2z-authority/src/assertion.rs
@@ -128,11 +128,21 @@ impl HandleAssertionTBS {
     /// authority while being signed by another, and naming one handle while
     /// being indexed under another.
     ///
+    /// It also refuses to *mint* what the log would refuse to admit: an
+    /// `account_epoch` at or above [`ACCOUNT_EPOCH_CEILING`] is a clock rather
+    /// than the durable counter `KT.md` §4.5.4 requires, and the failure this
+    /// crate exists to prevent is an issuer that reaches for `now / 1000`
+    /// because a counter was inconvenient. Refusing here means the issuer finds
+    /// out at its own keyboard rather than at somebody else's log.
+    ///
     /// # Errors
     ///
     /// [`AuthorityError::Malformed`] if the label does not fit `<0..255>`,
     /// which it always does — the check is there so the constructor has no
-    /// unwrap in it.
+    /// unwrap in it. [`AuthorityError::AccountEpochNotACounter`] for a
+    /// clock-shaped `account_epoch`.
+    ///
+    /// [`ACCOUNT_EPOCH_CEILING`]: crate::authority::ACCOUNT_EPOCH_CEILING
     // Nine arguments, and deliberately not a builder. Every one of them is a
     // field of a structure that is about to be signed, and a builder would make
     // each one omissible: forgetting `expires_ms` on a builder yields a
@@ -151,6 +161,9 @@ impl HandleAssertionTBS {
         expires_ms: u64,
         nonce: AssertionNonce,
     ) -> Result<Self> {
+        if account_epoch >= crate::authority::ACCOUNT_EPOCH_CEILING {
+            return Err(AuthorityError::AccountEpochNotACounter);
+        }
         let handle_id = handle.handle_id();
         Ok(Self {
             label: ShortBytes::new(LABEL_ASSERTION_TBS).map_err(AuthorityError::from)?,

--- a/rs/crates/f2z-authority/src/authority.rs
+++ b/rs/crates/f2z-authority/src/authority.rs
@@ -65,6 +65,51 @@ use crate::types::{AuthorityId, Handle, Intent, LogId, authority_id};
 /// > it can be carried anywhere. Measure it before shipping.
 pub const DEFAULT_MAX_VALIDITY_MS: u64 = 900_000;
 
+/// The exclusive upper bound on `account_epoch`: 2^20.
+///
+/// `KT.md` §4.5.4 requires `account_epoch` to be a **durable per-account
+/// counter** and forbids deriving it from a clock, because a monotonic clock
+/// satisfies A15's "strictly greater than the last one" unconditionally and
+/// forever — which does not weaken A15, it deletes it while leaving a field in
+/// place that looks like it is doing the work.
+///
+/// A15 alone cannot notice, so A18 refuses the value on its face. The ceiling
+/// is what an account-ownership counter can plausibly reach: an account that
+/// changed hands or was recovered a million times is not an account. Unix time
+/// in whole seconds has exceeded this since 1970-01-13, and Unix milliseconds
+/// do not fit a `uint32` at all, so the specific non-conformance §4.5.4 names
+/// is refused at the first assertion an issuer mints — before any predecessor
+/// exists to compare against.
+///
+/// **This is necessary, not sufficient, and the gap is stated rather than
+/// papered over.** A clock at a coarse granularity — days since the epoch is
+/// about 20,700 — passes the ceiling, and no check on a single `u32` can prove
+/// the value came from durable storage. [`MAX_ACCOUNT_EPOCH_STEP`] closes most
+/// of what is left; what remains is the issuer's obligation, stated in §4.5.4
+/// and in this crate's module documentation.
+pub const ACCOUNT_EPOCH_CEILING: u32 = 1 << 20;
+
+/// The largest advance in `account_epoch` between two assertions admitted for
+/// one handle: 16.
+///
+/// A counter increments once per account-ownership event, and only events whose
+/// assertion never reached the log accumulate slack, so the gap between two
+/// *admitted* assertions is a handful at most. A clock's gap is however much
+/// time passed between the two issuances, at whatever granularity the clock
+/// runs.
+///
+/// Together with [`ACCOUNT_EPOCH_CEILING`] this leaves a clock only one narrow
+/// band to hide in — fine enough to tick between two issuances, coarse enough
+/// that it ticks at most 16 times, and small enough in absolute terms to stay
+/// under the ceiling. It is a fixed constant rather than a published policy
+/// number deliberately: the same bound on every log is one a client can apply
+/// without first fetching a policy document, and unlike
+/// [`AuthorityConfig::max_validity_ms`] there is no operational reason for two
+/// logs to disagree about it.
+///
+/// [`AuthorityConfig::max_validity_ms`]: AuthorityConfig::max_validity_ms
+pub const MAX_ACCOUNT_EPOCH_STEP: u32 = 16;
+
 /// The default clock skew allowed on `issued_ms`, in milliseconds: 2 minutes.
 ///
 /// The same value `WIRE.md` §5.5 publishes for the relay's timestamp window,
@@ -635,8 +680,15 @@ impl AuthorityConfig {
     /// 16. **The identity key signed the binding.** Without this a stolen
     ///     assertion is usable by the thief; with it, it is useless.
     /// 17. `(authority_id, nonce)` has not been admitted before.
+    /// 18. **`account_epoch` moved like a counter, not like a clock** — it is
+    ///     below [`ACCOUNT_EPOCH_CEILING`] and, where there is a predecessor,
+    ///     advanced by at most [`MAX_ACCOUNT_EPOCH_STEP`]. Rule 15 is
+    ///     satisfiable *unconditionally* by any monotonic clock, so without
+    ///     this rule the field is present and enforcing nothing. Run with rule
+    ///     15 rather than after rule 17, because it costs nothing and a
+    ///     submission that fails it must not burn a nonce.
     ///
-    /// On a path without an assertion, rules 2–15 and 17 have nothing to run
+    /// On a path without an assertion, rules 2–15, 17 and 18 have nothing to run
     /// against and rule 16 is the whole check in this layer — the submitter
     /// proves it holds the identity key. The caller remains responsible for
     /// `KT.md` §4.4's directory signature and rotation proof on routine entries.
@@ -739,14 +791,9 @@ impl AuthorityConfig {
             return Err(AuthorityError::IntentMismatch);
         }
 
-        // 15. Account-epoch monotonicity. Strict: a reset is a distinct
-        //     account-ownership event, so an assertion for an epoch already
-        //     seen is one that has already been spent.
-        if let Some(previous) = previous_account_epoch
-            && body.account_epoch <= previous
-        {
-            return Err(AuthorityError::AccountEpochRegression);
-        }
+        // 15, 18. Account-epoch monotonicity, and the rule that keeps rule 15
+        //     from being satisfiable unconditionally by a clock.
+        check_account_epoch(body.account_epoch, previous_account_epoch)?;
 
         // 16. The rule that makes the whole thing sound.
         self.verify_binding(submission, Some(assertion))?;
@@ -877,6 +924,56 @@ impl AuthorityConfig {
             AuthorityError::BadIdentitySignature,
         )
     }
+}
+
+/// Rules 15 and 18: `account_epoch` advanced, **and it moved like a counter**.
+///
+/// Free rather than a method because it takes no policy: both bounds are fixed
+/// constants ([`ACCOUNT_EPOCH_CEILING`], [`MAX_ACCOUNT_EPOCH_STEP`]), so a
+/// client applying them needs nothing from the log.
+///
+/// # What each half catches, and what neither can
+///
+/// | | Rule 15 alone | With rule 18 |
+/// |---|---|---|
+/// | a durable counter, replayed | refused | refused |
+/// | Unix **seconds** in a `uint32` | **accepted, always** | refused on its face — over the ceiling |
+/// | a coarser clock (days, hours) | **accepted, always** | refused as soon as two issuances are more than [`MAX_ACCOUNT_EPOCH_STEP`] ticks apart |
+/// | a clock ticking 1–16 times between two issuances, under the ceiling | accepted | **accepted** |
+///
+/// The last row is the residue, and it is stated rather than hidden: **no check
+/// on a single `u32` can prove the value came from durable storage.** What the
+/// issuer must guarantee, and what `KT.md` §4.5.4 requires of it, is that
+/// `account_epoch` is read from and written to a per-account column that
+/// survives a process restart, and is incremented **only** on the events that
+/// justify invalidating outstanding assertions — account recovery and account
+/// transfer. An issuer that cannot read that column MUST refuse to issue
+/// `intent = reset` rather than substitute a clock.
+fn check_account_epoch(account_epoch: u32, previous: Option<u32>) -> Result<()> {
+    // 18a. Before anything relative: a value this large is not a count of what
+    //      one account did. Checked on every path — including a first `bind`,
+    //      which has no predecessor and is therefore the only place a
+    //      clock-derived epoch can be caught the first time an issuer mints
+    //      one.
+    if account_epoch >= ACCOUNT_EPOCH_CEILING {
+        return Err(AuthorityError::AccountEpochNotACounter);
+    }
+    let Some(previous) = previous else {
+        return Ok(());
+    };
+    // 15. Strict: a reset is a distinct account-ownership event, so an
+    //     assertion for an epoch already seen is one that has already been
+    //     spent.
+    if account_epoch <= previous {
+        return Err(AuthorityError::AccountEpochRegression);
+    }
+    // 18b. …and it advanced by an amount a counter could have advanced by.
+    //      `previous` is below the ceiling because it was admitted under 18a,
+    //      so this cannot overflow.
+    if account_epoch > previous.saturating_add(MAX_ACCOUNT_EPOCH_STEP) {
+        return Err(AuthorityError::AccountEpochStepTooLarge);
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/rs/crates/f2z-authority/src/bin/f2z-assert.rs
+++ b/rs/crates/f2z-authority/src/bin/f2z-assert.rs
@@ -64,6 +64,14 @@ NOTES:
   where an account has changed hands; the log refuses a reset on a handle's
   first entry and refuses a bind on any later one.
 
+  --account-epoch is the authority's DURABLE PER-ACCOUNT COUNTER (KT.md
+  §4.5.4). It is not a timestamp: a clock satisfies strictly-greater-than-the-
+  last-one forever, which deletes the rule that stops a reset assertion being
+  spent twice on one account-ownership event. It defaults to 0 for --intent
+  bind, which is the baseline a handle's first reset must exceed, and is
+  REQUIRED for --intent reset. A value at or above 1048576 is refused outright
+  as a clock.
+
   --validity-ms defaults to 900000 (15 minutes) and is ignored when --expires-ms
   is given. The LOG caps this independently: an assertion whose window exceeds
   the log's own cap is refused however it was signed.
@@ -184,9 +192,24 @@ fn issue(args: &[String]) -> Result<(), String> {
         Some("reset") => Intent::Reset,
         Some(other) => return Err(format!("--intent must be bind or reset, not `{other}`")),
     };
-    let account_epoch = match options.get("account-epoch") {
-        Some(value) => parse_u32(value, "--account-epoch")?,
-        None => 0,
+    // `bind` establishes the baseline a handle's first reset must exceed, and 0
+    // is the honest baseline for an account nothing has happened to yet. A
+    // `reset` is the opposite: its whole job is to be a *different* value from
+    // the last one, and a default there would be this tool inventing the number
+    // the authority is supposed to hold. KT.md §4.5.4 requires a durable
+    // per-account counter; this binary has no storage, so on the one path where
+    // the value carries the security property it asks rather than guesses.
+    let account_epoch = match (options.get("account-epoch"), intent) {
+        (Some(value), _) => parse_u32(value, "--account-epoch")?,
+        (None, Intent::Bind) => 0,
+        (None, Intent::Reset) => {
+            return Err(
+                "--account-epoch is required for --intent reset: it must be the \
+                        authority's durable per-account counter, read after the account-ownership \
+                        event that justifies the reset, and never a clock (KT.md §4.5.4)"
+                    .into(),
+            );
+        }
     };
 
     let issued_ms = match options.get("issued-ms") {

--- a/rs/crates/f2z-authority/src/error.rs
+++ b/rs/crates/f2z-authority/src/error.rs
@@ -103,6 +103,25 @@ pub enum AuthorityError {
     /// `account_epoch` did not advance past the last admitted assertion for
     /// this handle.
     AccountEpochRegression,
+    /// `account_epoch` is too large to be a count of account-ownership events,
+    /// so it is a clock rather than the counter `KT.md` §4.5.4 requires.
+    ///
+    /// See [`ACCOUNT_EPOCH_CEILING`]. This is a *necessary* condition, not a
+    /// sufficient one: it refuses the specific non-conformance §4.5.4 names —
+    /// Unix time in a `uint32` — and cannot prove that a value below the
+    /// ceiling came from a durable counter.
+    ///
+    /// [`ACCOUNT_EPOCH_CEILING`]: crate::authority::ACCOUNT_EPOCH_CEILING
+    AccountEpochNotACounter,
+    /// `account_epoch` advanced past the predecessor's by more than one
+    /// assertion can account for.
+    ///
+    /// A counter increments once per account-ownership event, so the gap
+    /// between two admitted assertions for one handle is small. A clock's gap
+    /// is however much time passed. See [`MAX_ACCOUNT_EPOCH_STEP`].
+    ///
+    /// [`MAX_ACCOUNT_EPOCH_STEP`]: crate::authority::MAX_ACCOUNT_EPOCH_STEP
+    AccountEpochStepTooLarge,
     /// An initial bind or platform reset on a vouched log arrived without its
     /// platform assertion.
     MissingAssertion,
@@ -173,6 +192,8 @@ impl AuthorityError {
             | Self::UnexpectedPriorAccountEpoch
             | Self::IdentityUnchanged
             | Self::AccountEpochRegression
+            | Self::AccountEpochNotACounter
+            | Self::AccountEpochStepTooLarge
             | Self::MissingAssertion
             | Self::UnexpectedAssertion => ERR_BAD_AUTHORIZATION,
         }
@@ -219,6 +240,8 @@ impl AuthorityError {
             }
             Self::IdentityUnchanged => "a reset assertion was spent on an unchanged identity key",
             Self::AccountEpochRegression => "account_epoch did not advance",
+            Self::AccountEpochNotACounter => "account_epoch is a clock, not a counter",
+            Self::AccountEpochStepTooLarge => "account_epoch advanced by more than a counter can",
             Self::MissingAssertion => "this log requires an assertion and none was presented",
             Self::UnexpectedAssertion => "this entry kind must not carry a platform assertion",
             Self::EmptyAuthoritySet => "an authority set needs at least one key",

--- a/rs/crates/f2z-authority/src/lib.rs
+++ b/rs/crates/f2z-authority/src/lib.rs
@@ -58,9 +58,33 @@
 //! Authority membership and signature, `log_id`, timestamps, **a validity cap
 //! the log holds rather than the issuer**, nonce freshness, `handle_id`
 //! agreement, the `[a-z0-9_]{1,30}` charset, entry-kind shape, assertion intent,
-//! and `account_epoch` monotonicity. [`AuthorityConfig::check_assertion_layer`]'s documentation
-//! lists all seventeen asserted-path rules in the order they run, and names the
+//! and `account_epoch` monotonicity — together with the rule that keeps that
+//! last one from being satisfiable unconditionally, which is the whole of the
+//! next paragraph. [`AuthorityConfig::check_assertion_layer`]'s documentation
+//! lists all eighteen asserted-path rules in the order they run, and names the
 //! smaller routine assertion-layer path explicitly.
+//!
+//! # The rule that could not fail, and what was done about it
+//!
+//! `account_epoch` (`KT.md` §4.5.4) is the authority's counter for the account
+//! behind a handle, and A15 requires each assertion's value to be strictly
+//! greater than the last one admitted for that handle. That is a real rule
+//! **only if the value is a counter.** Derived from a clock — Unix seconds, say
+//! — "strictly greater than the last one" holds unconditionally and forever, so
+//! the field is present, the check runs, and it enforces nothing. A control
+//! that is visibly present and functionally absent is worse than a missing one,
+//! because it stops anybody looking.
+//!
+//! [`ACCOUNT_EPOCH_CEILING`] and [`MAX_ACCOUNT_EPOCH_STEP`] are what this crate
+//! can check from the bytes it holds, and [`check_assertion_layer`]'s rule 18
+//! applies them. Neither proves the value came from durable storage, and rule
+//! 18's own documentation says exactly which clocks still slip through and what
+//! the issuer must therefore guarantee instead. The issuing
+//! side of this crate — `f2z-assert` — refuses to mint a clock-shaped value at
+//! all, and requires the counter explicitly rather than defaulting it on the
+//! one path where the value carries the security property.
+//!
+//! [`check_assertion_layer`]: crate::authority::AuthorityConfig::check_assertion_layer
 //!
 //! # What it deliberately does not do
 //!
@@ -167,8 +191,9 @@ pub mod types;
 
 pub use assertion::{AssertionBindingTBS, HandleAssertion, HandleAssertionTBS};
 pub use authority::{
-    AssertionLayerCheck, AuthorityConfig, AuthorityKey, AuthoritySet, DEFAULT_CLOCK_SKEW_MS,
-    DEFAULT_MAX_VALIDITY_MS, EntryKind, Submission, Vouch, VouchingStatus,
+    ACCOUNT_EPOCH_CEILING, AssertionLayerCheck, AuthorityConfig, AuthorityKey, AuthoritySet,
+    DEFAULT_CLOCK_SKEW_MS, DEFAULT_MAX_VALIDITY_MS, EntryKind, MAX_ACCOUNT_EPOCH_STEP, Submission,
+    Vouch, VouchingStatus,
 };
 pub use error::{AuthorityError, Result};
 pub use key::{SigningKey, VerifyingKey};

--- a/rs/crates/f2z-authority/tests/adversarial.rs
+++ b/rs/crates/f2z-authority/tests/adversarial.rs
@@ -249,7 +249,7 @@ fn asserted_bind_and_reset_preserve_each_signed_epoch_and_kind() {
         assert_eq!(checked.account_epoch(), account_epoch);
     }
 
-    for (previous_account_epoch, asserted_account_epoch) in [(5, 19), (53, 89)] {
+    for (previous_account_epoch, asserted_account_epoch) in [(5, 19), (53, 61)] {
         let mut asserted = body();
         asserted.intent = Intent::Reset;
         asserted.account_epoch = asserted_account_epoch;
@@ -1479,4 +1479,197 @@ fn the_ledger_trait_is_what_a_durable_log_implements() {
             .is_ok()
     );
     assert_eq!(counting.writes, 1);
+}
+
+// ------------------------------------------------ zuu#651: A15 could not fail
+//
+// A15 requires `account_epoch` to be strictly greater than the value retained
+// for the handle, and `KT.md` §4.5.4 requires the value to be a **durable
+// per-account counter, never a clock**. The rule is only a rule if the value is
+// a counter: a monotonic clock satisfies "strictly greater than the last one"
+// unconditionally and forever, which does not weaken A15 — it deletes it, while
+// leaving a field in place that looks like it is doing the work.
+//
+// Everything above tests the rule. Nothing above tested the *supply* of the
+// value, which is where it goes wrong, and that is precisely why a clock-derived
+// epoch survived review: the happy path is indistinguishable.
+
+/// Exactly what a non-conforming issuer reaches for when no counter is at hand:
+/// Unix time in whole seconds.
+fn clock_derived_epoch(now_ms: u64) -> u32 {
+    u32::try_from(now_ms / 1_000).expect("Unix seconds fit a u32 until 2106 — see zuu#651")
+}
+
+/// Present a `platform_reset` assertion carrying `asserted` against a handle for
+/// which the log retains `previous`, and report what the log decided.
+fn spend_reset(previous: u32, asserted: u32, now_ms: u64) -> Result<u32, AuthorityError> {
+    let mut value = HandleAssertionTBS {
+        label: body().label,
+        authority_id: f2z_authority::authority_id(&authority().public_key()),
+        log_id: log_id(),
+        handle: handle(),
+        handle_id: handle().handle_id(),
+        identity_pk: identity().public_key(),
+        intent: Intent::Reset,
+        account_epoch: asserted,
+        issued_ms: now_ms - 1_000,
+        expires_ms: now_ms + 60_000,
+        nonce: AssertionNonce::new([0x55; 16]),
+    };
+    // A distinct nonce per issuance, so nothing here can be mistaken for A17.
+    value.nonce = AssertionNonce::new([u8::try_from(asserted % 251).unwrap_or(0); 16]);
+
+    let (bytes, signature) = present(value);
+    let identity_pk = identity().public_key();
+    let handle = handle();
+    let outgoing = PublicKey::new([0x66; 32]);
+    let mut reset = submission(&bytes, &signature, &identity_pk, &handle);
+    reset.kind = EntryKind::PlatformReset;
+    reset.entry_version = 9;
+    reset.previous_identity_pk = Some(&outgoing);
+    reset.previous_vouch = Some(historical_vouch(0xf6));
+    reset.previous_account_epoch = Some(previous);
+
+    config()
+        .check_assertion_layer(&reset, now_ms, &mut ledger())
+        .map(|checked| checked.account_epoch())
+}
+
+#[test]
+fn two_reset_assertions_from_one_ownership_event_cannot_both_be_spent() {
+    // ONE account recovery, asked about twice a minute apart.
+    let retained = 4u32;
+    let first_ms = NOW_MS;
+    let second_ms = NOW_MS + 60_000;
+
+    // A conforming issuer increments its durable counter **once**, because one
+    // thing happened, so both assertions carry the same value and the second is
+    // a spent assertion. That is A15 working, and it is what A15 is for.
+    assert_eq!(
+        spend_reset(retained, retained + 1, first_ms),
+        Ok(retained + 1)
+    );
+    assert_eq!(
+        spend_reset(retained + 1, retained + 1, second_ms).unwrap_err(),
+        AuthorityError::AccountEpochRegression,
+    );
+
+    // The clock-derived issuer, at the same two moments. The second value is
+    // larger than the first for no reason other than that time passed, so there
+    // is nothing left for A15 to refuse — one ownership event, two spendable
+    // assertions. A18 is what refuses, and it refuses on the value's face,
+    // before any predecessor exists to compare against.
+    let first = clock_derived_epoch(first_ms);
+    let second = clock_derived_epoch(second_ms);
+    assert!(
+        second > first,
+        "the fixture is only interesting because the clock moved: {first} -> {second}",
+    );
+    assert!(
+        second > first && first > f2z_authority::ACCOUNT_EPOCH_CEILING,
+        "and because Unix seconds are nowhere near a count of account events",
+    );
+    assert_eq!(
+        spend_reset(retained, first, first_ms).unwrap_err(),
+        AuthorityError::AccountEpochNotACounter,
+    );
+    assert_eq!(
+        spend_reset(first, second, second_ms).unwrap_err(),
+        AuthorityError::AccountEpochNotACounter,
+    );
+}
+
+#[test]
+fn a_clock_coarse_enough_to_clear_the_ceiling_is_caught_by_the_step_bound() {
+    // Days since the Unix epoch is about 20,700 — comfortably under the
+    // ceiling, so rule 18a cannot see it. It is still a clock, and it still
+    // makes every instant a distinct ownership event.
+    let day = 20_700u32;
+    assert!(day < f2z_authority::ACCOUNT_EPOCH_CEILING);
+    assert_eq!(
+        spend_reset(day, day + 30, NOW_MS).unwrap_err(),
+        AuthorityError::AccountEpochStepTooLarge,
+        "a month between two resets is not thirty account-ownership events",
+    );
+
+    // And the residue, stated rather than hidden. Inside the step bound a clock
+    // is indistinguishable from a counter *in the value alone*, which is why
+    // §4.5.4 states the issuer's obligation as a normative MUST instead of
+    // leaving the log to infer it: what a log can check is necessary, not
+    // sufficient.
+    assert_eq!(
+        spend_reset(day, day + 1, NOW_MS),
+        Ok(day + 1),
+        "no check on a single u32 can prove the value came from durable storage",
+    );
+    assert_eq!(
+        spend_reset(day, day + f2z_authority::MAX_ACCOUNT_EPOCH_STEP, NOW_MS),
+        Ok(day + f2z_authority::MAX_ACCOUNT_EPOCH_STEP),
+    );
+    assert_eq!(
+        spend_reset(day, day + f2z_authority::MAX_ACCOUNT_EPOCH_STEP + 1, NOW_MS).unwrap_err(),
+        AuthorityError::AccountEpochStepTooLarge,
+    );
+}
+
+#[test]
+fn a_clock_derived_epoch_is_refused_at_a_first_bind_too() {
+    // The first entry is where every handle starts and where a clock-derived
+    // issuer shows itself first — there is no retained value, so A15 has
+    // nothing to compare and cannot refuse anything at all.
+    assert_eq!(
+        check_assertion_with(|body| body.account_epoch = clock_derived_epoch(NOW_MS)).unwrap_err(),
+        AuthorityError::AccountEpochNotACounter,
+    );
+    assert_eq!(
+        check_assertion_with(|body| body.account_epoch = f2z_authority::ACCOUNT_EPOCH_CEILING)
+            .unwrap_err(),
+        AuthorityError::AccountEpochNotACounter,
+    );
+    // The bound is exclusive at the top and permissive everywhere a counter
+    // lives, including the zero baseline `intent = bind` normally carries.
+    assert!(
+        check_assertion_with(|body| {
+            body.account_epoch = f2z_authority::ACCOUNT_EPOCH_CEILING - 1;
+        })
+        .is_ok()
+    );
+    assert!(check_assertion_with(|body| body.account_epoch = 0).is_ok());
+}
+
+#[test]
+fn the_issuing_constructor_refuses_to_mint_a_clock() {
+    // The verifying side is the last place this can be caught; the issuing side
+    // is the first. A tool that will not mint the value is a tool whose
+    // operator finds out at their own keyboard.
+    let error = HandleAssertionTBS::new(
+        &authority().public_key(),
+        log_id(),
+        handle(),
+        identity().public_key(),
+        Intent::Reset,
+        clock_derived_epoch(NOW_MS),
+        ISSUED_MS,
+        EXPIRES_MS,
+        AssertionNonce::new([0x55; 16]),
+    )
+    .unwrap_err();
+    assert_eq!(error, AuthorityError::AccountEpochNotACounter);
+    assert_eq!(error.kt_error_code(), 4, "ERR_BAD_AUTHORIZATION");
+    assert!(!error.is_configuration_fault());
+
+    assert!(
+        HandleAssertionTBS::new(
+            &authority().public_key(),
+            log_id(),
+            handle(),
+            identity().public_key(),
+            Intent::Reset,
+            f2z_authority::ACCOUNT_EPOCH_CEILING - 1,
+            ISSUED_MS,
+            EXPIRES_MS,
+            AssertionNonce::new([0x55; 16]),
+        )
+        .is_ok()
+    );
 }

--- a/rs/crates/f2z-authority/tests/cli.rs
+++ b/rs/crates/f2z-authority/tests/cli.rs
@@ -525,3 +525,124 @@ fn every_subcommand_rejects_positional_arguments_before_doing_work() {
     );
     assert!(issue.stdout.is_empty());
 }
+
+// ------------------------------------------------------------------- zuu#651
+
+#[test]
+fn issue_refuses_a_reset_without_an_explicit_account_epoch() {
+    // `--account-epoch` defaults to 0 for a bind, which is the honest baseline
+    // for an account nothing has happened to yet. On a reset the value carries
+    // the whole of A15: it must be the authority's durable per-account counter,
+    // read after the ownership event, and this binary holds no such counter. So
+    // it asks. Defaulting here — or, worse, reaching for a clock — is what
+    // zuu#651 is about.
+    let directory = TestDirectory::new("issue-reset-epoch");
+    let (key_path, _) = fixed_key_file(&directory);
+    let output = command(&[
+        "issue",
+        "--key",
+        path_text(&key_path),
+        "--log-id",
+        &independent_hex(&LOG_ID_BYTES),
+        "--handle",
+        "alice",
+        "--identity-pk",
+        &independent_hex(&IDENTITY_PK_BYTES),
+        "--intent",
+        "reset",
+        "--issued-ms",
+        "1000",
+        "--expires-ms",
+        "2000",
+        "--nonce",
+        &independent_hex(&EXPLICIT_NONCE_BYTES),
+    ]);
+    assert!(
+        !output.status.success(),
+        "a reset was issued with no counter"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--account-epoch is required for --intent reset"),
+        "refused for an unrelated reason: {stderr}"
+    );
+    assert!(
+        stderr.contains("never a clock"),
+        "the reason is not stated: {stderr}"
+    );
+    assert!(output.stdout.is_empty(), "an assertion was written anyway");
+
+    // The same command with the counter supplied is fine, and a bind with no
+    // counter at all is still fine.
+    let with_counter = command(&[
+        "issue",
+        "--key",
+        path_text(&key_path),
+        "--log-id",
+        &independent_hex(&LOG_ID_BYTES),
+        "--handle",
+        "alice",
+        "--identity-pk",
+        &independent_hex(&IDENTITY_PK_BYTES),
+        "--intent",
+        "reset",
+        "--account-epoch",
+        "3",
+        "--issued-ms",
+        "1000",
+        "--expires-ms",
+        "2000",
+        "--nonce",
+        &independent_hex(&EXPLICIT_NONCE_BYTES),
+    ]);
+    assert!(
+        with_counter.status.success(),
+        "issue failed: {}",
+        String::from_utf8_lossy(&with_counter.stderr)
+    );
+    let assertion = decode_assertion(&independent_unhex(
+        with_counter.stdout.strip_suffix(b"\n").unwrap(),
+    ));
+    assert_eq!(assertion.assertion.intent, Intent::Reset);
+    assert_eq!(assertion.assertion.account_epoch, 3);
+}
+
+#[test]
+fn issue_refuses_a_clock_shaped_account_epoch() {
+    // Unix time in whole seconds is the exact value a non-conforming issuer
+    // substitutes when the counter is unavailable. It is refused at the
+    // keyboard rather than at somebody else's log.
+    let directory = TestDirectory::new("issue-clock-epoch");
+    let (key_path, _) = fixed_key_file(&directory);
+    let output = command(&[
+        "issue",
+        "--key",
+        path_text(&key_path),
+        "--log-id",
+        &independent_hex(&LOG_ID_BYTES),
+        "--handle",
+        "alice",
+        "--identity-pk",
+        &independent_hex(&IDENTITY_PK_BYTES),
+        "--intent",
+        "reset",
+        "--account-epoch",
+        "1787000000",
+        "--issued-ms",
+        "1000",
+        "--expires-ms",
+        "2000",
+        "--nonce",
+        &independent_hex(&EXPLICIT_NONCE_BYTES),
+    ]);
+    assert!(
+        !output.status.success(),
+        "a clock was minted into an assertion"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("account_epoch is a clock, not a counter"),
+        "refused for an unrelated reason: {stderr}"
+    );
+    assert!(output.stdout.is_empty());
+}

--- a/rs/crates/f2z-kt/src/testing.rs
+++ b/rs/crates/f2z-kt/src/testing.rs
@@ -415,6 +415,73 @@ pub fn empty_bundle() -> TreeHeadBundle {
     .unwrap()
 }
 
+/// What a test wants to say instead of the fixture's defaults, when the
+/// assertion's own fields are the thing under test.
+///
+/// [`Harness::envelope`] derives every field from the entry so that a test
+/// about §4.4 never accidentally trips over the assertion layer. The two rules
+/// that only a *badly issued* assertion can exercise — A17's
+/// `(authority_id, nonce)` ledger and §4.5.4's `account_epoch` — need the
+/// opposite, so they get this.
+#[derive(Clone, Copy, Default)]
+pub struct AssertionOverrides {
+    /// The 16-byte assertion nonce. Reusing one across two assertions is what
+    /// A17 exists to refuse, and it is not otherwise producible.
+    pub nonce: Option<[u8; 16]>,
+    /// `account_epoch`, so a test can supply the clock-derived value `KT.md`
+    /// §4.5.4 forbids.
+    pub account_epoch: Option<u32>,
+    /// `issued_ms`; defaults to the submission's `now_ms`.
+    pub issued_ms: Option<u64>,
+    /// `expires_ms`; defaults to `issued_ms + 60_000`.
+    pub expires_ms: Option<u64>,
+}
+
+/// Hand-written, and the workspace `Debug` scan is what insists on it: a
+/// derived `Debug` over `Option<[u8; 16]>` renders the nonce as a decimal byte
+/// dump, which is a dump.
+impl core::fmt::Debug for AssertionOverrides {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AssertionOverrides")
+            .field("nonce", &self.nonce.map(|_| "<redacted; 16 bytes>"))
+            .field("account_epoch", &self.account_epoch)
+            .field("issued_ms", &self.issued_ms)
+            .field("expires_ms", &self.expires_ms)
+            .finish()
+    }
+}
+
+impl AssertionOverrides {
+    /// Override only the nonce.
+    #[must_use]
+    pub const fn nonce(nonce: [u8; 16]) -> Self {
+        Self {
+            nonce: Some(nonce),
+            account_epoch: None,
+            issued_ms: None,
+            expires_ms: None,
+        }
+    }
+
+    /// Override only `account_epoch`.
+    #[must_use]
+    pub const fn account_epoch(epoch: u32) -> Self {
+        Self {
+            nonce: None,
+            account_epoch: Some(epoch),
+            issued_ms: None,
+            expires_ms: None,
+        }
+    }
+
+    /// Also override the nonce.
+    #[must_use]
+    pub const fn with_nonce(mut self, nonce: [u8; 16]) -> Self {
+        self.nonce = Some(nonce);
+        self
+    }
+}
+
 /// A whole log, in-process, with everything the acceptance tests need to drive
 /// it: keys, an authority, and a clock they control.
 pub struct Harness {
@@ -566,6 +633,29 @@ impl Harness {
         .unwrap()
     }
 
+    /// As [`Harness::envelope`], but with the assertion's own fields chosen by
+    /// the caller.
+    ///
+    /// The one way to produce a **badly issued** assertion: a reused nonce
+    /// (A17) or a clock-derived `account_epoch` (§4.5.4). Both rules are about
+    /// what the issuer *supplied*, and a fixture that always supplies a
+    /// conforming value cannot exercise either — which is exactly how both
+    /// defects survived review.
+    ///
+    /// # Panics
+    ///
+    /// If any part will not encode, or if the harness has no issuer.
+    #[must_use]
+    pub fn envelope_overriding(
+        &self,
+        entry: &DirectoryEntry,
+        identity: &Identity,
+        now_ms: u64,
+        overrides: AssertionOverrides,
+    ) -> Vec<u8> {
+        self.build_envelope(entry, identity, now_ms, true, overrides)
+    }
+
     /// As [`Harness::envelope`], but optionally omitting the assertion — the
     /// adversarial case zuu#594 is about.
     ///
@@ -578,6 +668,23 @@ impl Harness {
         identity: &Identity,
         now_ms: u64,
         with_assertion: bool,
+    ) -> Vec<u8> {
+        self.build_envelope(
+            entry,
+            identity,
+            now_ms,
+            with_assertion,
+            AssertionOverrides::default(),
+        )
+    }
+
+    fn build_envelope(
+        &self,
+        entry: &DirectoryEntry,
+        identity: &Identity,
+        now_ms: u64,
+        with_assertion: bool,
+        overrides: AssertionOverrides,
     ) -> Vec<u8> {
         let bytes = entry_bytes(entry);
         let digest = labels::entry_value(&bytes);
@@ -592,28 +699,41 @@ impl Harness {
                 } else {
                     f2z_authority::types::Intent::Reset
                 };
-                let tbs = f2z_authority::HandleAssertionTBS::new(
-                    &issuer.public_key(),
-                    f2z_authority::types::LogId::new(*self.log_id.as_bytes()),
-                    handle.clone(),
-                    entry.entry.identity_pk,
+                let issued_ms = overrides.issued_ms.unwrap_or(now_ms);
+                // Built field by field rather than through
+                // `HandleAssertionTBS::new`, which refuses a clock-shaped
+                // `account_epoch` outright — a real issuer should, and a test
+                // standing in for a non-conforming one must be able to mint
+                // what that issuer mints.
+                let tbs = f2z_authority::HandleAssertionTBS {
+                    label: ShortBytes::new(f2z_authority::labels::LABEL_ASSERTION_TBS.to_vec())
+                        .unwrap(),
+                    authority_id: f2z_authority::authority_id(&issuer.public_key()),
+                    log_id: f2z_authority::types::LogId::new(*self.log_id.as_bytes()),
+                    handle_id: handle.handle_id(),
+                    handle: handle.clone(),
+                    identity_pk: entry.entry.identity_pk,
                     intent,
                     // Strictly greater than the predecessor's retained epoch;
                     // a reset is a distinct account-ownership event.
-                    u32::from(entry.entry.entry_version > 1),
-                    now_ms,
-                    now_ms.saturating_add(60_000),
+                    account_epoch: overrides
+                        .account_epoch
+                        .unwrap_or_else(|| u32::from(entry.entry.entry_version > 1)),
+                    issued_ms,
+                    expires_ms: overrides
+                        .expires_ms
+                        .unwrap_or_else(|| issued_ms.saturating_add(60_000)),
                     // Derived from the handle and the identity key rather than
                     // from the clock: two registrations in one millisecond are
                     // ordinary, and a fixture that reused a nonce would be
                     // testing the nonce ledger instead of whatever the test is
                     // about. (It caught exactly that the first time.)
-                    f2z_authority::types::AssertionNonce::new(nonce_for(
-                        entry.entry.handle.as_slice(),
-                        &entry.entry.identity_pk,
-                    )),
-                )
-                .unwrap();
+                    nonce: f2z_authority::types::AssertionNonce::new(
+                        overrides.nonce.unwrap_or_else(|| {
+                            nonce_for(entry.entry.handle.as_slice(), &entry.entry.identity_pk)
+                        }),
+                    ),
+                };
                 Some(tbs.sign(issuer).unwrap())
             }
             _ => None,

--- a/rs/crates/f2z-kt/tests/durability.rs
+++ b/rs/crates/f2z-kt/tests/durability.rs
@@ -325,3 +325,111 @@ async fn a_journal_signed_by_another_key_refuses_to_start() {
     .unwrap_err();
     assert!(format!("{error}").contains("does not verify"));
 }
+
+// ------------------------------- the ledger's retention, at the log's own cap
+//
+// `a_restart_does_not_reopen_an_admitted_assertion_nonce` (#650) proves the
+// ledger survives a restart at all. This is the neighbouring property, and it
+// is the one an attacker would aim at: **retention must cover the longest
+// assertion the log will accept, not the typical one.**
+
+#[tokio::test]
+async fn the_recovered_ledger_covers_the_longest_assertion_the_log_will_accept() {
+    // Retention is derived from the *assertion's* own `expires_ms` plus the
+    // clock skew, not from a fixed window, and `expires_ms - issued_ms` is
+    // capped at `max_validity_ms` on admission — so raising the cap widens the
+    // ledger's retention automatically and cannot leave it short. A ledger
+    // sized to the fixture's usual minute would come back from a restart
+    // already having forgotten the atypical assertion, which is exactly the one
+    // worth stealing.
+    use f2z_kt::testing::AssertionOverrides;
+
+    let harness = Harness::vouched("dur-nonce-cap").await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+
+    let cap = harness.log.authority().max_validity_ms();
+    let at_the_cap = AssertionOverrides {
+        nonce: Some([0x5a; 16]),
+        account_epoch: None,
+        issued_ms: Some(NOW),
+        expires_ms: Some(NOW + cap),
+    };
+
+    let alice = Identity::from_byte(1);
+    let alice_entry = EntryBuilder::first(harness.log_id, "alice", &alice).same_key(&alice.dak);
+    harness
+        .log
+        .submit(
+            &harness.envelope_overriding(&alice_entry, &alice, NOW, at_the_cap),
+            NOW,
+        )
+        .await
+        .unwrap();
+    harness.log.publish_epoch(NOW).await.unwrap();
+
+    // A second, independently signed assertion for another handle and identity,
+    // whose only defect is the reused `(authority_id, nonce)` pair.
+    let bob = Identity::from_byte(2);
+    let bob_entry = EntryBuilder::first(harness.log_id, "bob", &bob).same_key(&bob.dak);
+    let replay = harness.envelope_overriding(&bob_entry, &bob, NOW, at_the_cap);
+
+    // Restart, then present it at the last instant the stolen assertion is
+    // still inside its own window.
+    let reopened = reopen(&harness).await.unwrap();
+    let error = reopened.submit(&replay, NOW + cap - 1).await.unwrap_err();
+    assert!(
+        matches!(
+            error,
+            f2z_kt::LogError::Authority(f2z_authority::AuthorityError::ReplayedNonce)
+        ),
+        "the ledger aged the entry out while the assertion it covers was still acceptable: {error}",
+    );
+}
+
+// ------------------------------------------- zuu#651: an epoch that is a clock
+
+#[tokio::test]
+async fn the_log_refuses_a_clock_derived_account_epoch_end_to_end() {
+    // The whole pipeline, not just the crate that owns the rule: a submission
+    // whose assertion carries Unix seconds where §4.5.4 requires a durable
+    // counter never reaches the tree. Under the old behaviour it was admitted
+    // and published, because "strictly greater than the last one" is what a
+    // clock is best at.
+    use f2z_kt::testing::AssertionOverrides;
+
+    let harness = Harness::vouched("dur-clock-epoch").await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+
+    let clock_seconds = u32::try_from(NOW / 1_000).unwrap();
+    let alice = Identity::from_byte(1);
+    let entry = EntryBuilder::first(harness.log_id, "alice", &alice).same_key(&alice.dak);
+    let error = harness
+        .log
+        .submit(
+            &harness.envelope_overriding(
+                &entry,
+                &alice,
+                NOW,
+                AssertionOverrides::account_epoch(clock_seconds),
+            ),
+            NOW,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        f2z_kt::LogError::Authority(f2z_authority::AuthorityError::AccountEpochNotACounter)
+    ));
+    assert_eq!(harness.log.pending_count().await, 0);
+
+    // The same submission with a counter is admitted, so the refusal is about
+    // the value and nothing else.
+    harness
+        .log
+        .submit(
+            &harness.envelope_overriding(&entry, &alice, NOW, AssertionOverrides::account_epoch(0)),
+            NOW,
+        )
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
Closes #651.

> **Rebased.** This branch also carried a fix for #650, which [#653](https://github.com/free2z/zuu/pull/653) landed first with an equivalent design. That work is dropped; what survives from it is one test #653 does not have — see *The ledger's retention* below.

## The rule that could not fail

`KT.md` §4.5.5 **A15** requires an assertion's `account_epoch` to be strictly
greater than the value retained for the handle, so a `reset` assertion cannot be
spent twice on one account-ownership event. **That is only a rule if the value is
a counter.** Derived from a clock — Unix seconds, which is what one shipped
issuer does — "strictly greater than the last one" holds unconditionally and
forever. The field is present, the check runs, and it enforces nothing.

§4.5.4 already said the value **MUST** be a durable per-account counter and
**MUST NOT** come from a clock. No verifier applied it. A requirement no verifier
checks is a requirement, not a rule — and a security control that is visibly
present and functionally absent is worse than a missing one, because it stops
anybody looking.

## A18, in two halves because one is not enough

Run **with A15**, before A17, so a submission that fails it never burns a nonce.

| | catches | misses |
|---|---|---|
| **A18a — ceiling.** `account_epoch < 2^20` | Unix seconds (over the ceiling since 1970-01-13); Unix ms does not fit `uint32` at all. Fires **on the value's face at a first `bind`**, where A15 has nothing to compare against | a coarser clock — days since the epoch is ~20,700 |
| **A18b — step bound.** at most `previous + 16` | a coarser clock: two resets a month apart differ by 30, and that is not thirty ownership events | a clock ticking 1–16 times between two issuances |

Both are **fixed constants, not published policy numbers** (unlike A9's validity
cap): the same bound on every log is one a client can apply without first
fetching §4.6's document, and there is no operational reason for two logs to
disagree about a counter's shape. No wire change — `AuthorityPolicyTBS` is
untouched, and the encoding vectors shared with the second implementation are
unaffected.

### What A18 cannot do is stated, not papered over

No check on a single `uint32` can prove the value came from durable storage.
§4.5.4 and `check_account_epoch`'s own documentation name the residual band
explicitly and state what the issuer **MUST** guarantee instead: a per-account
column that survives a restart, incremented **once per ownership event** (not
once per assertion issued), and a refusal to issue `intent = reset` rather than a
substituted clock. The MUST is not weakened to match what a verifier can see.

### Issuing side

`HandleAssertionTBS::new` refuses to *mint* a clock-shaped value, and
`f2z-assert` requires `--account-epoch` explicitly for `--intent reset` instead
of defaulting it to `0` (issue #651 item 3). A tool that will not mint the value
is a tool whose operator finds out at their own keyboard rather than at somebody
else's log.

## The tests are the point

**Every new test was run against the unfixed source first**, and each fails
there. That discipline matters more than usual: a rule that cannot fail is
invisible to a test that only checks the happy path, which is precisely how this
survived review.

| test | without the fix |
|---|---|
| `two_reset_assertions_from_one_ownership_event_cannot_both_be_spent` | `unwrap_err()` on `Ok(1700000000)` — **one recovery, two spendable assertions** |
| `a_clock_coarse_enough_to_clear_the_ceiling_is_caught_by_the_step_bound` | `Ok(20730)` |
| `a_clock_derived_epoch_is_refused_at_a_first_bind_too` | `Ok(By(AuthorityId(…)))` |
| `the_issuing_constructor_refuses_to_mint_a_clock` | `Ok(HandleAssertionTBS { … account_epoch: 1700000000 … })` |
| `the_log_refuses_a_clock_derived_account_epoch_end_to_end` | a signed receipt for `alice` |
| `issue_refuses_a_reset_without_an_explicit_account_epoch` | "a reset was issued with no counter" |
| `issue_refuses_a_clock_shaped_account_epoch` | "a clock was minted into an assertion" |

The first test is the shape the issue asks for: a conforming issuer increments
once, both assertions carry the same value, and A15 refuses the second — that is
A15 working. The clock-derived issuer, at the same two moments, hands out a
larger second value for no reason but the passage of time, and there is nothing
left for A15 to refuse. `a_clock_coarse_enough…` then asserts the **residue**
too: inside the step bound the value is still accepted, so the test states the
limit rather than overclaiming it.

`AssertionOverrides` in `f2z-kt::testing` is what makes a *badly issued*
assertion producible at all. The existing harness derives every assertion field
from the entry so a §4.4 test never trips over the assertion layer — which means
it cannot express the two rules that are about what the issuer *supplied*.

## The ledger's retention (kept from the #650 work)

`the_recovered_ledger_covers_the_longest_assertion_the_log_will_accept` is the
property neighbouring #653's restart test. A17's retention is derived from the
**assertion's own** `expires_ms + clock_skew_ms`, and `expires_ms - issued_ms` is
capped at `max_validity_ms` on admission — so it must cover the *longest*
assertion the log will admit, not the typical one. A ledger sized to the
fixture's usual minute would come back from a restart already having forgotten
the atypical assertion, which is exactly the one worth stealing. Verified capable
of failing: removing #653's `restore_replayed_nonce` call turns it RED alongside
`a_restart_does_not_reopen_an_admitted_assertion_nonce`.

## Spec

`KT.md` §4.5 carries dated corrections in `ARCHITECTURE.md` §4.9's style: §4.5's
preamble (neither of the two "stricter than a shipped implementation" notes is
still a gap against the Rust log), §4.5.4 (A18, its two halves, why the bounds
are fixed, and what it cannot prove), §4.5.5 (rule A18 in the numbered list),
§4.5.6 (the wire-code row), and the §12 open-questions bullet.

## Not fixed here, reported instead

The private Django issuer still does `account_epoch = now_ms // 1000` when no
counter is supplied, and the endpoint never supplies one — so **every** assertion
it issues, `bind` and `reset` alike, carries a clock. It is **non-conforming** by
§4.5.4, and per the workspace boundary the fix is not made in this PR. Its
docstring reasons carefully about the two ways a clock *under*-delivers (two
assertions in one second, a backwards correction) and concludes "both failures
are refusals, never acceptances" — which misses the case the rule exists for:
**two assertions minted more than a second apart for one ownership event are both
spendable**, and that is an acceptance.

**Ordering note:** once A18 is deployed, that issuer's assertions are refused
outright (its epoch of ~1.79e9 is far over the ceiling). The issuer needs its
durable counter before a log carrying A18 is put in front of it.

## Not touched

#649 — that a handle's first-entry authorization is not client-verifiable — is a
wire change to `EntryAuthorization` and is deliberately untouched. Nothing here
contradicts it: A18 is log-side admission control, which is exactly the layer
#649 observes no client can check.

`#![forbid(unsafe_code)]` intact; the AGPL/permissive boundary is unchanged
(`f2z-kt` AGPL, `f2z-authority` permissive, and A18 lives in the permissive crate
where every other assertion rule lives).

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
