### PR TITLE
docs(e2ee): close relay wire contract gaps

### DIFF
--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -14,6 +14,11 @@
 [0012](./decisions/0012-anti-abuse-v1.md),
 [0014](./decisions/0014-directory-key-rotation.md).
 
+> **Correction (2026-08-24) — the implementation claim above is no longer
+> true.** `f2z-codec` and `f2z-relay-proto` now implement the canonical wire
+> structures and the shared, side-effect-free protocol rules. There is still no
+> relay or client binary and no deployment; this remains a Phase 1 specification.
+
 This document is written to be read by a third-party security auditor and by an
 independent implementer. It fixes the wire encodings that
 [`ARCHITECTURE.md`](./ARCHITECTURE.md) deliberately left as *proposed*
@@ -106,6 +111,14 @@ construction #544 selects.
   ([ADR 0001](./decisions/0001-platform-priority.md)).
 - A **fatal** error means: send the response, then close the WebSocket
   connection. A non-fatal error means: send the response, keep the connection.
+
+> **Correction (2026-08-24) — a response is possible only when a request id is
+> recoverable.** The rule above assumes that the relay can recover a nonzero
+> `request_id` from the fixed five-byte binary header. When it can, it MUST send
+> the fatal error on that id and then close. When it cannot — including a binary
+> message shorter than five bytes, a zero id, and every text message that §4.2
+> forbids the relay to decode — it MUST close without a protocol response. It
+> MUST NOT invent id zero for a response, because §4.3 reserves zero for pushes.
 
 ---
 
@@ -469,6 +482,27 @@ Steps 2 and 3 precede signature verification because they are cheap and they are
 the flood-resistant filters; step 5 follows verification so that an unsigned
 guess cannot probe the address space.
 
+> **Correction (2026-08-24) — step 5 is not one rule for every signed
+> command.** It applies literally only to `SUBSCRIBE`, `UNSUBSCRIBE`, `READ`,
+> `ACK`, and `DELETE_QUEUE`: `signer_key` MUST equal the queue's registered
+> `recv_key`, and failure is `ERR_NO_ACCESS`. The other signed commands use these
+> rules:
+>
+> - `CREATE_QUEUE` and `CREATE_CONTACT_QUEUE` have no address yet. Their
+>   transcript address is zero, and `signer_key` MUST equal the `recv_key` in
+>   the body. Failure is `ERR_NO_ACCESS`.
+> - `BIND_SEND` acts on an unbound side, so there is no registered send key to
+>   compare. `signer_key` MUST equal the `send_key` in the body. Failure is
+>   `ERR_NO_ACCESS`. This frame-internal check reveals no relay state.
+> - `APPEND` requires `signer_key` to equal the bound `send_key`, but every
+>   state-dependent failure, including a missing address and a wrong or absent
+>   bound key, is `ERR_UNAVAILABLE` (§6.3 and §10's correction).
+>
+> Requiring the `BIND_SEND` self-check is security-significant. Without it, a
+> caller that learned `send_addr` could sign with a disposable key while binding
+> an unrelated key it does not possess. The bind-once theft described by §7.4
+> would cost the caller no write capability at all.
+
 ### 5.2 Relay identity binding — the attack it closes
 
 ```
@@ -537,6 +571,10 @@ Therefore:
 
 - Such a relay MUST set `channel_binding_mode: "none"` in its capability
   document and MUST use **32 zero bytes** in the transcript.
+- A relay in `tls-exporter` mode whose exporter output is 32 zero bytes MUST
+  treat that as failure to obtain a binding and refuse the connection. Zero is
+  the `none` sentinel; accepting it in both modes would make them identical in
+  the signed transcript.
 - A client MAY refuse such a relay outright, and the reference client SHOULD make
   this a user-visible setting with a strict mode that refuses.
 - **In `none` mode the restart argument of §5.5 does not hold**, so the relay
@@ -585,6 +623,42 @@ Two mechanisms, together:
    `timestamp_ms + clock_skew_ms`. A half-open seen-set would forget it at that
    same instant when the two published windows are equal.
 
+> **Correction (2026-08-24) — “observed within the window” did not define a
+> retention origin, duration, or client check.** For a frame stamped `t`, let
+> `skew = clock_skew_ms`. The inclusive timestamp rule accepts it throughout
+>
+> ```text
+> [t - skew, t + skew]
+> ```
+>
+> whose earliest-to-latest span is `2 * skew`. An attacker may first present the
+> frame at the left endpoint and replay it at the right endpoint. Therefore the
+> relay MUST record an authenticated `(signer_key, nonce)` using its own clock,
+> only after the signature, frame-internal checks, and relay-state
+> authorization succeed. Quota and operational policy remain step 6 above and
+> may refuse after replay commitment without mutating queue state. The shared
+> verifier's `verify_authorized` path binds the relay-state authorization
+> callback before replay commitment; its narrower `verify` method proves only
+> the frame-local half and MUST NOT be used by itself to admit a stateful relay
+> command. The relay MUST retain the recorded entry through the inclusive instant
+> `recorded_at_ms + antireplay_window_ms`. The duration is measured from this
+> relay-controlled recording time, never from attacker-chosen `timestamp_ms`.
+>
+> Consequently, after widening before multiplication so overflow cannot make an
+> unsafe pair look small:
+>
+> ```text
+> antireplay_window_ms >= 2 * clock_skew_ms
+> ```
+>
+> A relay MUST NOT publish values that violate this invariant. A client MUST
+> compare the two signed capability fields and MUST refuse such a relay by
+> default (§11.3). This is a client policy refusal, not a decode or signature
+> failure: the client retains the validly signed document as evidence of the
+> operator's nonconforming policy. An override MAY exist only as an explicit,
+> surfaced, per-relay choice; it MUST NOT be a global “ignore relay policy”
+> switch.
+
 **The seen-set is fail-closed.** It is bounded (`antireplay_seen_max`, published)
 and when the bound is reached the relay returns `ERR_BACKPRESSURE` and refuses new
 signed commands until entries age out. It MUST NOT evict live entries to make
@@ -606,6 +680,11 @@ does not hold, because the binding is a constant. Such a relay MUST persist the
 seen-set or declare `antireplay_persistence: "volatile"` and accept that a
 restart reopens a replay window of `clock_skew_ms` for any frame an adversary
 captured. Clients read that field and may refuse.
+
+> **Correction (2026-08-24) — the restart exposure above used the half-width.**
+> With the inclusive two-sided timestamp window, a captured frame may remain
+> acceptable for up to `2 * clock_skew_ms` between its earliest and latest valid
+> presentations. The persist-or-declare requirement is unchanged.
 
 ### 5.6 The residual, stated
 
@@ -652,6 +731,13 @@ to error codes.
 | `0x0021` | `APPEND` | send key | `send_addr` |
 | `0x0030` | `CREATE_CONTACT_QUEUE` | recv key | zeros |
 | `0x0031` | `CONTACT_APPEND` | none (PoW) | — |
+
+The last two columns are normative. A command listed as signed that arrives
+without `SignedAuth` is non-fatal `ERR_BAD_SIGNATURE`; a command listed as
+unsigned that arrives with `SignedAuth` is fatal `ERR_MALFORMED`, because v1 has
+no transcript with which to verify it. A creation command with a nonzero
+transcript address, or any other signed command with a zero transcript address,
+is fatal `ERR_MALFORMED`.
 
 ### 6.1 Unsigned commands
 
@@ -706,6 +792,12 @@ struct {
 } ChallengeResponse;
 ```
 
+For `clock` and `queue_create`, `scope` MUST be empty. For `contact_append`, it
+MUST be exactly the target `contact_addr`. A purpose byte not defined by the
+negotiated protocol version is fatal `ERR_MALFORMED`; a later version can assign
+new values only after negotiating that version. A challenge is spendable only by
+a command matching its purpose and, for `contact_append`, its scope.
+
 Three jobs, and each is a real reason for the command to exist:
 
 1. It gives a client with an unreliable clock the relay's current time, so it can
@@ -752,6 +844,10 @@ The transcript's `address` field is 32 zero bytes (no address exists yet) and
 `signer_key` MUST equal `recv_key`, so the request is self-authenticating: it
 proves possession of the key that the new queue will be bound to.
 
+> **Correction (2026-08-24) — `PowStamp` is fixed-width, so “empty” had no
+> encoding.** In `open` mode every field of `stamp` is zero; the field is never
+> omitted.
+
 **Both addresses are generated by the relay from its own CSPRNG** (§7.1).
 
 `flags` is reserved and is **not** a credential hook: it is a `uint16` that MUST
@@ -761,10 +857,10 @@ correction there.
 
 #### `SUBSCRIBE` — `0x0011` / `UNSUBSCRIBE` — `0x0012`
 
-Empty bodies. `SUBSCRIBE` registers the connection to receive `MSG` pushes (§6.4)
-for `recv_addr` and returns the current `next_index` so the client can decide
-whether to `READ` first. A subscription is scoped to the connection and dies with
-it.
+Both request bodies are empty. `SUBSCRIBE` registers the connection to receive
+`MSG` pushes (§6.4) for `recv_addr` and returns the current `next_index` so the
+client can decide whether to `READ` first. `UNSUBSCRIBE` has an empty response.
+A subscription is scoped to the connection and dies with it.
 
 ```
 struct {
@@ -773,9 +869,22 @@ struct {
 } SubscribeResponse;
 ```
 
+Queue indices start at **0**. An empty queue has `next_index = 0`; the first
+accepted append receives index 0, and each later accepted append increments it.
+Expiry and acknowledgement never reuse an index.
+
 `pending` is disclosed to the **reader** only. The reader is the recipient; it is
 about to learn this by reading. No equivalent is ever disclosed to a sender
 (§6.3).
+
+> **Correction (2026-08-24) — the field comment above is too strong.** In v1,
+> `pending` is the number of assigned, unacknowledged indices:
+> `next_index - first_unacked`, where `first_unacked` is zero before any ACK and
+> one greater than the ACK watermark afterward. TTL expiry can remove stored
+> messages without changing either value, so `pending` is an upper bound on
+> messages actually present, not an exact storage count. A client MAY use it as
+> a conservative backlog hint, but MUST NOT treat it as an index or derive a
+> `READ.from_index` from it.
 
 #### `READ` — `0x0013`
 
@@ -804,6 +913,14 @@ watermark; the relay MUST NOT resurrect deleted messages and MUST NOT error, so
 that a client recovering from a crash can simply ask for everything it might have
 missed.
 
+`max_messages` and `max_bytes` are pagination preferences; zero means “no
+preference” for that dimension. The relay returns messages in increasing index
+order and MUST set `has_more` to 1 exactly when another matching stored message
+remains after the page (0 otherwise). If a positive `max_bytes` is smaller than
+the first eligible encoded message, the relay returns that one message anyway:
+returning an empty page would make the queue impossible to drain. The hard
+`max_frame_bytes` limit still applies to every response.
+
 #### `ACK` — `0x0014`
 
 ```
@@ -826,6 +943,12 @@ Empty request, empty response. Deletes the queue, both addresses, and every
 message it holds, acknowledged or not. Irreversible. The relay MUST subsequently
 answer both addresses with `ERR_NO_ACCESS` — the same code an address that never
 existed gets (§10).
+
+> **Correction (2026-08-24) — “both addresses” assigns the send address the
+> wrong code.** After deletion, recv-side commands return `ERR_NO_ACCESS`, while
+> `BIND_SEND` and `APPEND` on the former send address return
+> `ERR_UNAVAILABLE`. That is the same collapsed answer as an absent, expired,
+> full, or backpressured send side (§6.3), so deletion reveals no extra state.
 
 The sender, if any, learns nothing except that its next `APPEND` fails with
 `ERR_UNAVAILABLE` (§6.3). Telling the peer that a queue was retired is the
@@ -874,6 +997,15 @@ queue's state by filling it. Therefore **every send-side refusal that would
 distinguish queue state collapses to the single code `ERR_UNAVAILABLE`**: absent
 queue, deleted queue, expired queue, queue at its message cap, queue at its byte
 cap, relay in global backpressure. See §10.
+
+> **Correction (2026-08-24) — the collapse list omitted authorization and bind
+> lookup failures.** `APPEND` also returns `ERR_UNAVAILABLE` when `signer_key`
+> is not the bound `send_key`, when the send side is unbound, and when the
+> address lookup fails. A distinguishable wrong-key result would itself reveal
+> that the address exists. `BIND_SEND` uses `ERR_UNAVAILABLE` for an absent,
+> deleted, or expired ordinary send address; `ERR_ALREADY_BOUND` remains the
+> deliberate loud signal from §7.4, and `ERR_NOT_PERMITTED` remains the answer
+> for a published contact address (§12.2).
 
 Two honest consequences:
 
@@ -966,6 +1098,10 @@ chose.
 
 A relay never sees a `queue_advert`; it sees an opaque MLS `PrivateMessage` like
 every other payload.
+
+The object above deliberately has no `tls_codec` encoding in this document. Its
+application-layer encoding belongs to the MLS message schema; inventing a relay
+wire encoding for an object no relay parses would create a second contract.
 
 ### 7.3 `BIND_SEND` — once-only and irreversible
 
@@ -1083,6 +1219,11 @@ Two independent timers. Both are per-queue, both are requested at creation, both
 are clamped by relay policy, and both granted values are returned in
 `CreateQueueResponse` so the client knows what it actually got.
 
+A requested TTL of `0` means “no preference” and selects the relay's published
+default. A nonzero request is clamped to the published minimum and maximum. The
+message-TTL ceiling of 2 592 000 seconds applies last and unconditionally: no
+operator default, maximum, or client request may grant more.
+
 | Timer | Field | Default | Ceiling | Resets on |
 |---|---|---|---|---|
 | Message TTL | `message_ttl_seconds` | 604 800 (7 days) | **2 592 000 (30 days)** | — (per message, from append) |
@@ -1137,6 +1278,10 @@ relay deletes them and advances the queue's acked watermark.
 
 `up_to_index` greater than the highest index the relay has ever appended to that
 queue is `ERR_ACK_TOO_HIGH`, and the watermark does not move.
+
+Precisely, an ACK is in range iff `up_to_index < next_index`. Therefore every ACK
+on a never-written queue (`next_index = 0`) is `ERR_ACK_TOO_HIGH`; a drained queue
+still accepts an idempotent ACK only for an index that was previously assigned.
 
 The reason is specific and it is not tidiness. Without this rule a reader could
 **pre-ack** — set the watermark to a very large value — after which every future
@@ -1269,6 +1414,21 @@ a bug report from two years ago must all still mean the same thing.
 | 20 | `ERR_NOT_PERMITTED` | | The command is not valid for this queue kind — e.g. `BIND_SEND` on a contact queue (§12.2). |
 | 21 | `ERR_INTERNAL` | | Relay fault. Carries no detail, ever. |
 
+> **Correction (2026-08-24) — rows 10 and 15 both assigned the send-side
+> “absent” case.** Section 6.3's security rule governs: state-dependent
+> send-side refusals collapse to `ERR_UNAVAILABLE` (15). In particular:
+>
+> - `APPEND` never returns code 10. An absent, deleted, expired, unbound, full,
+>   backpressured, or wrong-key send side returns code 15.
+> - `BIND_SEND` returns code 15 for an absent, deleted, or expired ordinary send
+>   address. Its frame-internal `signer_key == send_key` failure remains code 10
+>   because it is decidable from the request without looking up relay state.
+> - `ERR_ALREADY_BOUND` (11) remains §7.4's deliberate signal that a first bind
+>   lost the race. `ERR_NOT_PERMITTED` (20) remains the answer for `BIND_SEND`
+>   on a contact address, which is public by design.
+> - `CONTACT_APPEND` is unsigned, but its absent, full, expired, or
+>   backpressured cases likewise collapse to code 15.
+
 ### The existence-oracle rule
 
 **"No such queue" and "exists, but your key does not authorize it" MUST return
@@ -1280,6 +1440,12 @@ space is not sweepable by brute force, but an oracle is also useful against
 addresses obtained by other means — a leaked log line, a partially-observed
 advert, a database from a decommissioned relay — and there is no reason to
 provide it.
+
+> **Correction (2026-08-24) — the MUST above is receive-side only.** For a
+> recv-key-signed command, “no such receive address” and “wrong receive key” are
+> both `ERR_NO_ACCESS` (10), and the timing mitigations below apply. Send-side
+> commands follow the code-15 collapse above; applying code 10 to them would
+> recreate the state oracle §6.3 forbids.
 
 **And the honest limit: this is not constant time, and we do not claim it is.**
 The two paths do different amounts of work. The absent path is an index miss. The
@@ -1326,9 +1492,9 @@ struct {
     uint16   ws_ping_interval_seconds;
     uint32   handshake_timeout_ms;
 
-    /* anti-replay */
-    uint32   clock_skew_ms;
-    uint32   antireplay_window_ms;
+    /* anti-replay — these values are related by §5.5 */
+    uint32   clock_skew_ms;                /* default 120000 */
+    uint32   antireplay_window_ms;         /* >= 2 * clock_skew_ms; default 240000 */
     uint8    antireplay_persistence;      /* 0 = volatile, 1 = durable (§5.3, §5.5) */
 
     /* padding */
@@ -1378,6 +1544,12 @@ struct {
 } SignedCapabilities;
 ```
 
+> **Correction (2026-08-24) — the two anti-replay fields were published as
+> independent values, but they are not.** Section 5.5 derives the required
+> relation and retention origin. A relay MUST publish
+> `antireplay_window_ms >= 2 * clock_skew_ms`, with entries live through their
+> inclusive expiration instant. The defaults are `120000` and `240000`.
+
 Note what the last two blocks are for. `operator_jurisdiction` and the contact
 fields are not decoration: a user choosing among *k* relays
 ([ADR 0005](./decisions/0005-federation.md)) is making a jurisdictional choice
@@ -1417,13 +1589,24 @@ On first use of a relay, and on `NOTICE(3)`:
 1. Fetch, verify the signature against the `relay_identity_pk` proven in `HELLO`.
 2. Refuse if `transport_security = none` without explicit user opt-in (§2.3).
 3. Refuse if `channel_binding_mode = none` and the user's policy is strict
-   (§5.3).
-4. Refuse if `padding_sizes` is not a superset of what this client emits, or is
+   (§5.3), and apply the user's durable-seen-set policy (§5.5).
+4. Compare `antireplay_window_ms` with twice `clock_skew_ms` in a wider integer
+   type and refuse by default if the anti-replay window is shorter (§5.5).
+5. Refuse if `padding_sizes` is not a superset of what this client emits, or is
    implausibly fine-grained (§9).
-5. Refuse if `max_message_ttl_seconds > 2592000` — the relay is claiming a policy
+6. Refuse if `max_message_ttl_seconds > 2592000` — the relay is claiming a policy
    the architecture forbids.
-6. Record `queue_creation_mode`, quotas and PoW parameters for §13.
-7. Surface operator name, jurisdiction and contact in the relay-picker UI.
+7. Refuse an internally unusable document: `contact_queues_enabled = 1`
+   requires nonzero `contact_append_pow`, and `max_frame_bytes` must be large
+   enough for the largest advertised padding bucket. The latter is necessary,
+   not sufficient: framing and authentication add overhead beyond the payload.
+8. Record `queue_creation_mode`, quotas and PoW parameters for §13.
+9. Surface operator name, jurisdiction and contact in the relay-picker UI.
+
+Step 4 is a client policy refusal, not a capability decoding or signature
+failure. The client retains the signed document so the policy violation remains
+attributable to that relay and publication time. An override, if offered, must
+be explicit, surfaced, and scoped to one relay (§5.5's correction).
 
 ---
 
@@ -1485,6 +1668,11 @@ struct {
     PowStamp  stamp;                /* over a relay-issued challenge (§6.1) */
 } ContactAppendRequest;
 ```
+
+Like `CREATE_QUEUE`, `CREATE_CONTACT_QUEUE` is self-authenticating: its
+transcript address MUST be 32 zero bytes and `signer_key` MUST equal the
+`recv_key` in the request body. A mismatch is `ERR_NO_ACCESS` and is decided
+without consulting relay state.
 
 `CONTACT_APPEND`'s response is **empty**, for the same reason `APPEND`'s is
 (§6.3): a stranger writing to Bob's contact queue must learn nothing about how

--- a/rs/crates/f2z-codec/src/commands.rs
+++ b/rs/crates/f2z-codec/src/commands.rs
@@ -306,14 +306,15 @@ impl ChallengePurpose {
 /// `GET_CHALLENGE` request (§6.1).
 ///
 /// `purpose` is a raw `u8` for the same reason command codes are raw: `(255)`
-/// fixes the width, and a purpose this build does not know is the relay's to
-/// refuse with a code, not the decoder's to reject as malformed. Resolve it
+/// fixes the width, and preserving the value lets the relay answer an unknown
+/// purpose with §6.1's fatal `ERR_MALFORMED` on the request's id. Resolve it
 /// with [`ChallengeRequest::purpose`].
 #[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
 pub struct ChallengeRequest {
     /// The `ChallengePurpose` byte.
     pub purpose: u8,
-    /// For `contact_append`: the target `contact_addr`. Empty otherwise.
+    /// For `contact_append`: exactly the 32-byte target `contact_addr`. Empty
+    /// for `clock` and `queue_create`.
     pub scope: ShortBytes,
 }
 

--- a/rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs
+++ b/rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs
@@ -287,6 +287,8 @@ enum Strictness {
         target: &'static str,
         /// The local binding on which the wrapper method must be called.
         receiver: &'static str,
+        /// The method name called on `receiver`.
+        method: &'static str,
     },
     /// Its body calls a registered strict verifier as a **free function**
     /// rather than as a method — `sig::verify(key, message, signature)`.
@@ -359,6 +361,7 @@ const WORKSPACE_VERIFY_FNS: &[VerifyFn] = &[
         strictness: Strictness::DelegatesTo {
             target: "f2z-relay-proto/src/key.rs::verify",
             receiver: "key",
+            method: "verify",
         },
     },
     VerifyFn {
@@ -366,8 +369,19 @@ const WORKSPACE_VERIFY_FNS: &[VerifyFn] = &[
         name: "verify",
         occurrence: 0,
         strictness: Strictness::DelegatesTo {
+            target: "f2z-relay-proto/src/command.rs::verify_authorized",
+            receiver: "self",
+            method: "verify_authorized",
+        },
+    },
+    VerifyFn {
+        file: "f2z-relay-proto/src/command.rs",
+        name: "verify_authorized",
+        occurrence: 0,
+        strictness: Strictness::DelegatesTo {
             target: "f2z-relay-proto/src/key.rs::verify",
             receiver: "verifying_key",
+            method: "verify",
         },
     },
     VerifyFn {
@@ -377,22 +391,23 @@ const WORKSPACE_VERIFY_FNS: &[VerifyFn] = &[
         strictness: Strictness::DelegatesTo {
             target: "f2z-relay-proto/src/key.rs::verify",
             receiver: "identity",
+            method: "verify",
         },
     },
     // The two relays. Neither verifies a signature itself: each builds a
     // `CommandVerifier` from `f2z-relay-proto` and hands it the frame, so what
-    // they reach is `command.rs::verify`, which reaches `key.rs::verify`'s
-    // `verify_strict`. `target` names the terminal strict verifier and
-    // `receiver` names the local call, exactly as `command.rs::verify`'s own
-    // row does. Registered rather than exempted, because "it only delegates" is
-    // the claim this scan exists to check rather than accept.
+    // they reach is `command.rs::verify_authorized`, which reaches
+    // `key.rs::verify`'s `verify_strict`. Registered rather than exempted,
+    // because "it only delegates" is the claim this scan exists to check
+    // rather than accept.
     VerifyFn {
         file: "f2z-relay/src/engine.rs",
         name: "verify_with",
         occurrence: 0,
         strictness: Strictness::DelegatesTo {
-            target: "f2z-relay-proto/src/key.rs::verify",
+            target: "f2z-relay-proto/src/command.rs::verify_authorized",
             receiver: "verifier",
+            method: "verify_authorized",
         },
     },
     VerifyFn {
@@ -400,8 +415,9 @@ const WORKSPACE_VERIFY_FNS: &[VerifyFn] = &[
         name: "verify",
         occurrence: 0,
         strictness: Strictness::DelegatesTo {
-            target: "f2z-relay-proto/src/key.rs::verify",
+            target: "f2z-relay-proto/src/command.rs::verify_authorized",
             receiver: "verifier",
+            method: "verify_authorized",
         },
     },
     VerifyFn {
@@ -417,6 +433,7 @@ const WORKSPACE_VERIFY_FNS: &[VerifyFn] = &[
         strictness: Strictness::DelegatesTo {
             target: "f2z-authority/src/key.rs::verify",
             receiver: "identity_key",
+            method: "verify",
         },
     },
     // ---- f2z-kt-core -------------------------------------------------------
@@ -903,6 +920,33 @@ fn registration_matches(entry: &VerifyFn, file: &str, name: &str, occurrence: us
     entry.file == file && entry.name == name && entry.occurrence == occurrence
 }
 
+fn delegation_reaches_strict_base(mut target: &str) -> bool {
+    for _ in 0..WORKSPACE_VERIFY_FNS.len() {
+        let Some((target_file, target_name)) = target.rsplit_once("::") else {
+            return false;
+        };
+        let Some(entry) = WORKSPACE_VERIFY_FNS
+            .iter()
+            .find(|entry| entry.file == target_file && entry.name == target_name)
+        else {
+            return false;
+        };
+        match entry.strictness {
+            Strictness::CallsVerifyStrict { .. } => return true,
+            Strictness::DelegatesTo {
+                target: next_target,
+                ..
+            }
+            | Strictness::DelegatesToFn {
+                target: next_target,
+                ..
+            } => target = next_target,
+            Strictness::NotASignatureCheck { .. } => return false,
+        }
+    }
+    false
+}
+
 fn calls_method(body: &str, name: &str) -> bool {
     identifier_positions(body, name).any(|at| {
         let before = body[..at].trim_end();
@@ -938,7 +982,9 @@ fn registered_body_has_required_call(strictness: &Strictness, body: &str) -> boo
         Strictness::CallsVerifyStrict { receiver } => {
             calls_method_on(body, receiver, "verify_strict")
         }
-        Strictness::DelegatesTo { receiver, .. } => calls_method_on(body, receiver, "verify"),
+        Strictness::DelegatesTo {
+            receiver, method, ..
+        } => calls_method_on(body, receiver, method),
         Strictness::DelegatesToFn { call, .. } | Strictness::NotASignatureCheck { via: call } => {
             calls_path(body, call)
         }
@@ -1041,6 +1087,7 @@ fn the_live_registry_contract_rejects_the_right_method_on_the_wrong_receiver() {
     let delegated = Strictness::DelegatesTo {
         target: "f2z-authority/src/key.rs::verify",
         receiver: "identity_key",
+        method: "verify",
     };
     let delegated_body = function_body(
         "fn verify_binding() { identity_key.verify(message, signature); }",
@@ -1265,15 +1312,10 @@ fn every_verify_function_in_the_workspace_is_registered_as_strict() {
                 );
             }
             Strictness::DelegatesTo { target, .. } => {
-                let (target_file, target_name) = target.rsplit_once("::").unwrap();
                 assert!(
-                    WORKSPACE_VERIFY_FNS
-                        .iter()
-                        .any(|other| other.file == target_file
-                            && other.name == target_name
-                            && matches!(other.strictness, Strictness::CallsVerifyStrict { .. })),
-                    "{}::{} delegates to {target}, which is not registered as a strict \
-                     verifier",
+                    delegation_reaches_strict_base(target),
+                    "{}::{} delegates to {target}, whose registered chain does not terminate in \
+                     a strict verifier",
                     entry.file,
                     entry.name
                 );

--- a/rs/crates/f2z-relay-proto/src/capabilities.rs
+++ b/rs/crates/f2z-relay-proto/src/capabilities.rs
@@ -238,7 +238,7 @@ pub fn check_digest(capabilities: &Capabilities, expected: &Digest) -> Result<()
 /// - [`Refusal::RelayIdNotDerived`] if `relay_id` is not the digest of
 ///   `relay_identity_pk` (§5.2).
 /// - [`Refusal::TtlCeilingExceeded`] if `max_message_ttl_seconds` is above the
-///   architecture's 30-day ceiling (§11.3 step 5).
+///   architecture's 30-day ceiling (§11.3 step 6).
 /// - [`Refusal::PowAlgorithmUnknown`] if a `PowParams` names an algorithm v1
 ///   does not define (§13.1).
 /// - [`Refusal::CapabilitiesInconsistent`] for everything else: an undefined
@@ -362,15 +362,13 @@ pub struct ClientPolicy {
     /// §5.5: refuse `antireplay_persistence: volatile`.
     pub require_durable_antireplay: bool,
     /// Refuse a relay whose seen-set retention is shorter than twice its own
-    /// clock skew. See [`Refusal::AntiReplayWindowTooShort`] — this is a check
-    /// `WIRE.md` does not state and, on the reading in that variant's
-    /// documentation, should.
+    /// clock skew. See [`Refusal::AntiReplayWindowTooShort`] and `WIRE.md` §5.5.
     pub require_sound_antireplay_window: bool,
     /// §9: refuse an implausibly fine-grained padding set.
     pub require_plausible_padding: bool,
     /// §13.1: refuse `queue_creation_mode: token`, which is linkable.
     pub allow_token_queue_creation: bool,
-    /// §11.3 step 4: the sizes this client will emit. The relay's set MUST be a
+    /// §11.3 step 5: the sizes this client will emit. The relay's set MUST be a
     /// superset.
     pub emitted_padding: PaddingBuckets,
 }
@@ -423,13 +421,14 @@ impl ClientPolicy {
         {
             return Err(ProtoError::Refused(Refusal::VolatileAntiReplay));
         }
+        // Step 4.
         if self.require_sound_antireplay_window
             && u64::from(capabilities.antireplay_window_ms)
                 < u64::from(capabilities.clock_skew_ms).saturating_mul(2)
         {
             return Err(ProtoError::Refused(Refusal::AntiReplayWindowTooShort));
         }
-        // Step 4.
+        // Step 5.
         let buckets = PaddingBuckets::new(capabilities.padding_sizes.as_slice().to_vec())
             .map_err(|_| ProtoError::Refused(Refusal::CapabilitiesInconsistent))?;
         if !buckets.is_superset_of(&self.emitted_padding) {
@@ -438,7 +437,7 @@ impl ClientPolicy {
         if self.require_plausible_padding && !buckets.is_plausible() {
             return Err(ProtoError::Refused(Refusal::PaddingImplausible));
         }
-        // Step 6.
+        // Step 8.
         if matches!(
             QueueCreationMode::from_code(capabilities.queue_creation_mode)?,
             QueueCreationMode::Token
@@ -794,7 +793,7 @@ mod tests {
         capabilities.antireplay_window_ms = capabilities.clock_skew_ms;
         assert!(
             validate(&capabilities).is_ok(),
-            "WIRE.md permits this; that is the defect"
+            "policy refusal must preserve the signed document as a valid artifact"
         );
         assert_eq!(
             ClientPolicy::default().accept(&capabilities),

--- a/rs/crates/f2z-relay-proto/src/command.rs
+++ b/rs/crates/f2z-relay-proto/src/command.rs
@@ -6,8 +6,9 @@
 //!
 //! # The verification order is the security argument
 //!
-//! §5.1 fixes an order and says "it matters". [`CommandVerifier::verify`]
-//! implements exactly it:
+//! §5.1 fixes an order and says "it matters".
+//! [`CommandVerifier::verify_authorized`] implements authenticated admission
+//! through relay-state authorization:
 //!
 //! 1. Decode and re-encode-compare (§3.3). The frame half is `f2z-codec`'s and
 //!    has already happened by the time a [`Request`] exists; the *body* half
@@ -19,7 +20,8 @@
 //!    `ERR_REPLAY`, without inserting it.
 //! 4. Rebuild the transcript **from the relay's own `relay_id` and its own
 //!    `channel_binding`** and verify the signature → `ERR_BAD_SIGNATURE`.
-//! 5. Address and self-authentication rules (§6.2, §6.3) → `ERR_NO_ACCESS`.
+//! 5. Address, self-authentication, and caller-supplied relay-state
+//!    authorization rules (§6.2, §6.3).
 //! 6. Policy — the payload's padding bucket (§9).
 //! 7. Commit the authenticated `(signer_key, nonce)` with insert-if-absent
 //!    semantics. A competing commit loses as `ERR_REPLAY`.
@@ -30,9 +32,13 @@
 //! which is why the whole sequence lives in one function instead of being
 //! composed by each call site.
 //!
-//! What this module does **not** do is look anything up. Steps 5's *second*
+//! What this module does **not** do is look anything up. Step 5's relay-state
 //! half — "the address exists and `signer_key` is the key registered for it" —
-//! and step 6's quotas are relay state; they live in [`crate::queue`] and above.
+//! lives in [`crate::queue`] and above. The caller supplies that lookup as the
+//! authorization closure, and the verifier commits the replay key only after
+//! it succeeds. [`CommandVerifier::verify`] is the narrower frame-local path;
+//! it is not complete admission for a command whose authorization depends on
+//! relay state.
 
 use core::fmt;
 use core::marker::PhantomData;
@@ -41,8 +47,8 @@ use alloc::vec::Vec;
 
 use f2z_codec::canonical::{Canonical, decode_canonical};
 use f2z_codec::commands::{
-    AckRequest, AckResponse, AppendRequest, Auth, BindSendRequest, ChallengeRequest,
-    ChallengeResponse, Command, ContactAppendRequest, CreateContactQueueRequest,
+    AckRequest, AckResponse, AppendRequest, Auth, BindSendRequest, ChallengePurpose,
+    ChallengeRequest, ChallengeResponse, Command, ContactAppendRequest, CreateContactQueueRequest,
     CreateContactQueueResponse, CreateQueueRequest, CreateQueueResponse, HelloRequest,
     HelloResponse, ReadRequest, ReadResponse, SignedCapabilities, SubscribeResponse,
     TranscriptAddress,
@@ -152,11 +158,12 @@ pub trait RelayCommand: Sized {
 /// is ever constructed.
 pub mod ops {
     use super::{
-        AckRequest, AckResponse, AppendRequest, BindSendRequest, ChallengeRequest,
-        ChallengeResponse, Command, ContactAppendRequest, CreateContactQueueRequest,
-        CreateContactQueueResponse, CreateQueueRequest, CreateQueueResponse, Empty, ErrorCode,
-        HelloRequest, HelloResponse, Payload, ProtoError, ReadRequest, ReadResponse, RelayCommand,
-        Result, SignedAuth, SignedCapabilities, SubscribeResponse, keys_equal,
+        AckRequest, AckResponse, AppendRequest, BindSendRequest, ChallengePurpose,
+        ChallengeRequest, ChallengeResponse, Command, ContactAppendRequest,
+        CreateContactQueueRequest, CreateContactQueueResponse, CreateQueueRequest,
+        CreateQueueResponse, Empty, ErrorCode, HelloRequest, HelloResponse, Payload, ProtoError,
+        QueueAddress, ReadRequest, ReadResponse, RelayCommand, Result, SignedAuth,
+        SignedCapabilities, SubscribeResponse, keys_equal,
     };
 
     macro_rules! command {
@@ -191,14 +198,29 @@ pub mod ops {
         Empty,
         SignedCapabilities
     );
-    command!(
-        /// `0x0003` (§6.1). Clock, single-use challenge, and current PoW
-        /// parameters.
-        GetChallenge,
-        GetChallenge,
-        ChallengeRequest,
-        ChallengeResponse
-    );
+    /// `0x0003` (§6.1). Clock, single-use challenge, and current PoW
+    /// parameters.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct GetChallenge;
+
+    impl RelayCommand for GetChallenge {
+        const COMMAND: Command = Command::GetChallenge;
+        type Request = ChallengeRequest;
+        type Response = ChallengeResponse;
+
+        fn check(request: &Self::Request, auth: Option<&SignedAuth>) -> Result<()> {
+            let _ = auth;
+            let scope_is_valid = match request.purpose()? {
+                ChallengePurpose::Clock | ChallengePurpose::QueueCreate => request.scope.is_empty(),
+                ChallengePurpose::ContactAppend => request.scope.len() == QueueAddress::LEN,
+            };
+            if scope_is_valid {
+                Ok(())
+            } else {
+                Err(ProtoError::Wire(ErrorCode::Malformed))
+            }
+        }
+    }
     command!(
         /// `0x0004` (§6.1). Application-level liveness, distinct from §2.4's
         /// WebSocket Ping, which a browser client cannot send.
@@ -290,12 +312,10 @@ pub mod ops {
         type Request = CreateContactQueueRequest;
         type Response = CreateContactQueueResponse;
 
-        /// §12.2 does not restate `CREATE_QUEUE`'s self-authentication rule,
-        /// but the command has the same shape — a `recv_key` in the body, a
-        /// zero address in the transcript, and no existing queue to look the
-        /// signer up against — so the same rule is the only one that
-        /// authenticates it at all. Applied here, and listed as an
-        /// interpretation.
+        /// §12.2 applies `CREATE_QUEUE`'s self-authentication rule: a `recv_key`
+        /// in the body, a zero address in the transcript, and no existing queue
+        /// to look the signer up against. Requiring the signer to own that key is
+        /// the only thing that authenticates the request.
         fn check(request: &Self::Request, auth: Option<&SignedAuth>) -> Result<()> {
             let auth = auth.ok_or(ProtoError::Wire(ErrorCode::BadSignature))?;
             if keys_equal(&auth.signer_key, &request.recv_key) {
@@ -490,14 +510,16 @@ impl<C: RelayCommand> SignedCommand<C> {
 /// A command accepted through every check prescribed for `C`.
 ///
 /// There is no public constructor. The only way to hold one is to have run
-/// [`CommandVerifier::verify`] for a signed command, or
-/// [`CommandVerifier::accept_unsigned`] for an unsigned command. The signed
-/// path proves §5.1, including the timestamp window, signature, command policy,
-/// and a replay key committed to that verifier's process-local [`SeenSet`]. It
-/// does not attest that a relay also committed external, durable, or
-/// cross-worker state. The unsigned path has no authenticator, timestamp, or
-/// replay key to verify; it proves canonical encoding plus that command's own
-/// rules and stores zero values in the authentication-only accessors below.
+/// [`CommandVerifier::verify`] or [`CommandVerifier::verify_authorized`] for a
+/// signed command, or [`CommandVerifier::accept_unsigned`] for an unsigned
+/// command. The signed path proves §5.1, including the timestamp window,
+/// signature, command policy, and a replay key committed to that verifier's
+/// process-local [`SeenSet`]. Only `verify_authorized` also proves the caller's
+/// relay-state authorization closure. Neither path attests that a relay
+/// committed external, durable, or cross-worker state. The unsigned path has
+/// no authenticator, timestamp, or replay key to verify; it proves canonical
+/// encoding plus that command's own rules and stores zero values in the
+/// authentication-only accessors below.
 /// Holding this type therefore proves the checks for `C`'s prescribed path,
 /// not that an arbitrary `Verified<C>` was authenticated.
 #[derive(Debug)]
@@ -562,8 +584,10 @@ impl<C: RelayCommand> Verified<C> {
     }
 
     /// For a signed command, its nonce after the corresponding replay key was
-    /// committed to the seen-set. [`Nonce::zero`] for an unsigned command,
-    /// which carries no nonce and does not touch the seen-set.
+    /// committed to the seen-set. While a candidate is borrowed by
+    /// `verify_authorized`'s authorization closure, commitment has not happened
+    /// yet; the returned value has passed it. [`Nonce::zero`] for an unsigned
+    /// command, which carries no nonce and does not touch the seen-set.
     #[must_use]
     pub const fn nonce(&self) -> Nonce {
         self.nonce
@@ -632,7 +656,13 @@ impl CommandVerifier {
         &self.padding
     }
 
-    /// Verify a signed command, in §5.1's order.
+    /// Verify only the frame-local half of a signed command.
+    ///
+    /// This compatibility path does not perform a queue lookup or any other
+    /// relay-state authorization. A relay admitting a command MUST use
+    /// [`Self::verify_authorized`] so the replay key is not committed before
+    /// that authorization succeeds. This method remains useful for clients,
+    /// tests, and frame-local protocol checks that have no admission decision.
     ///
     /// `now_ms` is the relay's clock. `request_id` is the frame's, not the
     /// body's — it is covered by the transcript, so a relay that passes a
@@ -662,6 +692,36 @@ impl CommandVerifier {
         request_id: u32,
         request: &Request,
     ) -> Result<Verified<C>> {
+        self.verify_authorized(now_ms, request_id, request, |_| Ok(()))
+    }
+
+    /// Verify a signed command and its relay-state authorization as one
+    /// admission path.
+    ///
+    /// The closure runs after the signature and frame-internal command checks
+    /// but before the replay key is committed. It receives the authenticated
+    /// address and signer through [`Verified`], so a relay can perform the
+    /// exact queue lookup and [`crate::queue::QueueState`] authorization the
+    /// command requires. If it refuses, the seen-set is unchanged. The closure
+    /// MUST be a read-only authorization/policy check: replay commitment can
+    /// still lose a race, so durable command state is mutated only after this
+    /// method returns `Ok`.
+    ///
+    /// # Errors
+    ///
+    /// The errors documented on [`Self::verify`], or the closure's
+    /// relay-state refusal.
+    pub fn verify_authorized<C, F>(
+        &mut self,
+        now_ms: u64,
+        request_id: u32,
+        request: &Request,
+        authorize: F,
+    ) -> Result<Verified<C>>
+    where
+        C: RelayCommand,
+        F: FnOnce(&Verified<C>) -> Result<()>,
+    {
         if request.command != C::COMMAND.code() {
             return Err(ProtoError::Wire(ErrorCode::Internal));
         }
@@ -702,8 +762,23 @@ impl CommandVerifier {
         check_transcript_address(C::COMMAND, &auth.address)?;
         C::check(body.value(), Some(auth))?;
 
-        // Step 6.
-        if let Some(payload) = C::payload(body.value()) {
+        let verified = Verified {
+            address: auth.address,
+            signer_key: auth.signer_key,
+            timestamp_ms: auth.timestamp_ms,
+            nonce: auth.nonce,
+            body: body.into_value(),
+        };
+
+        // Step 5's relay-state half. This must precede replay commitment: a
+        // correctly signed request under an unrelated key is authenticated but
+        // unauthorized, and must not consume the bounded seen-set.
+        authorize(&verified)?;
+
+        // Step 6. Policy follows relay-state authorization: otherwise a
+        // correctly signed APPEND under an unrelated key could distinguish an
+        // invalid padding size from the collapsed send-side refusal.
+        if let Some(payload) = C::payload(verified.body()) {
             self.padding.validate_payload(payload)?;
         }
 
@@ -712,13 +787,7 @@ impl CommandVerifier {
         // that both won preflight cannot both accept the same pair.
         self.seen.commit(now_ms, replay_key)?;
 
-        Ok(Verified {
-            address: auth.address,
-            signer_key: auth.signer_key,
-            timestamp_ms: auth.timestamp_ms,
-            nonce: auth.nonce,
-            body: body.into_value(),
-        })
+        Ok(verified)
     }
 
     /// Accept an unsigned command (§6.1, §12.2).
@@ -829,7 +898,9 @@ mod tests {
     use super::*;
     use alloc::vec;
     use f2z_codec::pow::PowStamp;
-    use f2z_codec::types::{ChannelBinding, RelayId};
+    use f2z_codec::types::{ChannelBinding, RelayId, ShortBytes};
+
+    use crate::queue::{QueueKind, QueueState};
 
     fn transcripts() -> TranscriptBuilder {
         TranscriptBuilder::new(
@@ -976,6 +1047,192 @@ mod tests {
                 .map(|_| ()),
             Err(ProtoError::Wire(ErrorCode::NoAccess))
         );
+    }
+
+    #[test]
+    fn verify_refuses_a_contact_queue_whose_signer_is_not_the_key_it_registers() {
+        let caller = SigningKey::from_seed(&[0x28; 32]);
+        let stranger = SigningKey::from_seed(&[0x29; 32]);
+        let body = |recv_key| CreateContactQueueRequest {
+            recv_key,
+            req_message_ttl_seconds: 0,
+            req_idle_ttl_seconds: 0,
+            stamp: PowStamp::empty(),
+        };
+
+        let honest = hostile_request::<ops::CreateContactQueue>(
+            5,
+            QueueAddress::zero(),
+            nonce(0x28),
+            &caller,
+            &body(caller.public_key()),
+        );
+        assert!(
+            verifier()
+                .verify::<ops::CreateContactQueue>(NOW, 5, &honest)
+                .is_ok()
+        );
+
+        let hijacked = hostile_request::<ops::CreateContactQueue>(
+            5,
+            QueueAddress::zero(),
+            nonce(0x29),
+            &caller,
+            &body(stranger.public_key()),
+        );
+        assert_eq!(
+            verifier()
+                .verify::<ops::CreateContactQueue>(NOW, 5, &hijacked)
+                .map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::NoAccess))
+        );
+    }
+
+    #[test]
+    fn relay_state_authorization_precedes_replay_commit() {
+        let owner = SigningKey::from_seed(&[0x31; 32]);
+        let stranger = SigningKey::from_seed(&[0x32; 32]);
+        let address = QueueAddress::new([0x33; 32]);
+        let queue = QueueState::create(QueueKind::Standard, owner.public_key());
+
+        let honest = hostile_request::<ops::Subscribe>(6, address, nonce(0x31), &owner, &Empty);
+        let mut accepted = verifier();
+        assert!(
+            accepted
+                .verify_authorized::<ops::Subscribe, _>(NOW, 6, &honest, |candidate| {
+                    queue.authorize_recv(&candidate.signer_key())
+                })
+                .is_ok()
+        );
+        assert_eq!(accepted.seen_set().len(), 1);
+
+        let hostile = hostile_request::<ops::Subscribe>(7, address, nonce(0x32), &stranger, &Empty);
+        let mut refused = verifier();
+        assert_eq!(
+            refused
+                .verify_authorized::<ops::Subscribe, _>(NOW, 7, &hostile, |candidate| {
+                    queue.authorize_recv(&candidate.signer_key())
+                })
+                .map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::NoAccess))
+        );
+        assert!(
+            refused.seen_set().is_empty(),
+            "an authenticated but unauthorized command must not consume replay capacity"
+        );
+    }
+
+    #[test]
+    fn relay_state_authorization_precedes_padding_policy() {
+        let receiver = SigningKey::from_seed(&[0x34; 32]);
+        let sender = SigningKey::from_seed(&[0x35; 32]);
+        let stranger = SigningKey::from_seed(&[0x36; 32]);
+        let address = QueueAddress::new([0x37; 32]);
+        let mut queue = QueueState::create(QueueKind::Standard, receiver.public_key());
+        queue.bind_send(&sender.public_key()).unwrap();
+
+        let body = AppendRequest {
+            // One byte below the default 1024-byte bucket. This reaches
+            // padding policy only after the signed queue identity is accepted.
+            payload: Payload::new(vec![0u8; 1023]).unwrap(),
+        };
+
+        let unauthorized =
+            hostile_request::<ops::Append>(8, address, nonce(0x36), &stranger, &body);
+        let mut refused = verifier();
+        assert_eq!(
+            refused
+                .verify_authorized::<ops::Append, _>(NOW, 8, &unauthorized, |candidate| {
+                    queue.authorize_send(&candidate.signer_key())
+                })
+                .map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::Unavailable)),
+            "step 5 must collapse the send-side refusal before step 6 reveals padding policy"
+        );
+        assert!(refused.seen_set().is_empty());
+
+        let authorized = hostile_request::<ops::Append>(9, address, nonce(0x35), &sender, &body);
+        let mut accepted_identity = verifier();
+        assert_eq!(
+            accepted_identity
+                .verify_authorized::<ops::Append, _>(NOW, 9, &authorized, |candidate| {
+                    queue.authorize_send(&candidate.signer_key())
+                })
+                .map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::BadSize)),
+            "an authorized sender must still reach the padding policy"
+        );
+        assert!(accepted_identity.seen_set().is_empty());
+    }
+
+    fn challenge(body: &ChallengeRequest) -> Request {
+        Request::new(
+            Command::GetChallenge.code(),
+            CommandAuth::Unsigned,
+            body.encode_canonical().unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn get_challenge_rejects_an_unknown_purpose() {
+        let request = challenge(&ChallengeRequest {
+            purpose: 3,
+            scope: ShortBytes::default(),
+        });
+        assert_eq!(
+            verifier()
+                .accept_unsigned::<ops::GetChallenge>(&request)
+                .map(|_| ()),
+            Err(ProtoError::Wire(ErrorCode::Malformed))
+        );
+    }
+
+    #[test]
+    fn get_challenge_enforces_the_purposes_scope_shape() {
+        let empty = ShortBytes::default();
+        for purpose in [ChallengePurpose::Clock, ChallengePurpose::QueueCreate] {
+            let valid = challenge(&ChallengeRequest {
+                purpose: purpose.code(),
+                scope: empty.clone(),
+            });
+            assert!(
+                verifier()
+                    .accept_unsigned::<ops::GetChallenge>(&valid)
+                    .is_ok()
+            );
+
+            let invalid = challenge(&ChallengeRequest {
+                purpose: purpose.code(),
+                scope: ShortBytes::new(vec![0x41; QueueAddress::LEN]).unwrap(),
+            });
+            assert_eq!(
+                verifier()
+                    .accept_unsigned::<ops::GetChallenge>(&invalid)
+                    .map(|_| ()),
+                Err(ProtoError::Wire(ErrorCode::Malformed))
+            );
+        }
+
+        let contact = |length| {
+            challenge(&ChallengeRequest {
+                purpose: ChallengePurpose::ContactAppend.code(),
+                scope: ShortBytes::new(vec![0x42; length]).unwrap(),
+            })
+        };
+        assert!(
+            verifier()
+                .accept_unsigned::<ops::GetChallenge>(&contact(QueueAddress::LEN))
+                .is_ok()
+        );
+        for wrong_length in [0, QueueAddress::LEN - 1, QueueAddress::LEN + 1] {
+            assert_eq!(
+                verifier()
+                    .accept_unsigned::<ops::GetChallenge>(&contact(wrong_length))
+                    .map(|_| ()),
+                Err(ProtoError::Wire(ErrorCode::Malformed))
+            );
+        }
     }
 
     #[test]

--- a/rs/crates/f2z-relay-proto/src/error.rs
+++ b/rs/crates/f2z-relay-proto/src/error.rs
@@ -136,27 +136,25 @@ pub enum Refusal {
     /// client policy.
     NoChannelBinding,
     /// §5.5: `antireplay_persistence = volatile` under a strict client policy —
-    /// a restart reopens a replay window of `clock_skew_ms`.
+    /// a restart reopens a replay window of up to `2 * clock_skew_ms`.
     VolatileAntiReplay,
     /// §5.5 / §11.1: `antireplay_window_ms` is shorter than `2 ×
     /// clock_skew_ms`, so seen-set entries age out while the frames they cover
     /// are still inside the timestamp window.
     ///
-    /// **`WIRE.md` does not state this relation and it should** — see
-    /// [`SeenSet::retention_is_sound`]. Reported as a client-side refusal
-    /// rather than as a document-validity failure, because the document is
-    /// exactly what the specification permits; it is the specification that is
-    /// missing the constraint.
+    /// See [`SeenSet::retention_is_sound`]. Reported as a client-side policy
+    /// refusal rather than as a decoding or signature failure so the validly
+    /// signed, nonconforming policy remains available as evidence.
     ///
     /// [`SeenSet::retention_is_sound`]: crate::replay::SeenSet::retention_is_sound
     AntiReplayWindowTooShort,
-    /// §11.3 step 4: the relay's `padding_sizes` is not a superset of the
+    /// §11.3 step 5: the relay's `padding_sizes` is not a superset of the
     /// sizes this client emits.
     PaddingNotSuperset,
-    /// §9 / §11.3 step 4: the relay's `padding_sizes` is fine-grained enough
+    /// §9 / §11.3 step 5: the relay's `padding_sizes` is fine-grained enough
     /// to be indistinguishable from a covert length channel.
     PaddingImplausible,
-    /// §11.3 step 5: `max_message_ttl_seconds` exceeds the architecture's
+    /// §11.3 step 6: `max_message_ttl_seconds` exceeds the architecture's
     /// 30-day ceiling. The relay is claiming a policy the architecture forbids.
     TtlCeilingExceeded,
     /// §11.1: the capability document is internally inconsistent — a mode byte

--- a/rs/crates/f2z-relay-proto/src/lib.rs
+++ b/rs/crates/f2z-relay-proto/src/lib.rs
@@ -51,6 +51,7 @@
 //! use f2z_relay_proto::command::{CommandVerifier, SignedCommand, ops};
 //! use f2z_relay_proto::hello::{RelayAnnouncement, hello_response, verify_hello_response};
 //! use f2z_relay_proto::key::SigningKey;
+//! use f2z_relay_proto::queue::{QueueKind, QueueState};
 //! use f2z_relay_proto::replay::{SeenSet, TimestampWindow};
 //!
 //! # fn main() -> Result<(), Box<dyn core::error::Error>> {
@@ -100,11 +101,18 @@
 //!     SeenSet::new(240_000, 65_536),
 //!     PaddingBuckets::default(),
 //! );
-//! let verified = verifier.verify::<ops::Append>(now, 1, &signed.request()?)?;
+//! let mut queue = QueueState::create(QueueKind::Standard, send_key.public_key());
+//! queue.bind_send(&send_key.public_key())?;
+//! let request = signed.request()?;
+//! let verified = verifier.verify_authorized::<ops::Append, _>(now, 1, &request, |candidate| {
+//!     queue.authorize_send(&candidate.signer_key())
+//! })?;
 //! assert_eq!(verified.signer_key(), send_key.public_key());
 //!
 //! // The same frame a second time is a replay, whatever it was the first time.
-//! assert!(verifier.verify::<ops::Append>(now, 1, &signed.request()?).is_err());
+//! assert!(verifier.verify_authorized::<ops::Append, _>(now, 1, &request, |candidate| {
+//!     queue.authorize_send(&candidate.signer_key())
+//! }).is_err());
 //! # Ok(())
 //! # }
 //! ```

--- a/rs/crates/f2z-relay-proto/src/queue.rs
+++ b/rs/crates/f2z-relay-proto/src/queue.rs
@@ -172,11 +172,9 @@ impl QueueState {
 
     /// The index the next appended message will receive.
     ///
-    /// Indices start at zero and only ever increase. `WIRE.md` does not name a
-    /// first index; zero is chosen because §8.2's rule is stated as "greater
-    /// than the highest index the relay has **ever** appended", which is a
-    /// clean total order from zero and needs no sentinel for "nothing yet" —
-    /// `next_index == 0` says it.
+    /// Indices start at zero and only ever increase, as `WIRE.md` §6.2 now
+    /// states. `next_index == 0` is the unambiguous sentinel for “nothing has
+    /// ever been appended”.
     #[must_use]
     pub const fn next_index(&self) -> u64 {
         self.next_index
@@ -338,11 +336,12 @@ impl QueueState {
 ///
 /// `acknowledged` is zero for the idempotent case — a retry after a lost
 /// response, or a replay (§5.6 lists `ACK` as a no-op for exactly this reason).
-/// A relay deletes `acknowledged` messages and nothing else.
+/// It counts index-space advancement, not stored rows: TTL expiry may already
+/// have removed some of those rows. A relay deletes every stored message at or
+/// below the accepted watermark and nothing above it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AckOutcome {
-    /// How many indices the watermark advanced by, i.e. how many messages this
-    /// `ACK` authorizes the relay to delete.
+    /// How many indices the watermark advanced by.
     pub acknowledged: u64,
     /// `AckResponse.next_index`.
     pub next_index: u64,

--- a/rs/crates/f2z-relay-proto/src/replay.rs
+++ b/rs/crates/f2z-relay-proto/src/replay.rs
@@ -35,8 +35,8 @@
 //! **In `channel_binding_mode: none` that argument fails**, because the binding
 //! is a constant: such a relay MUST persist the set or publish
 //! `antireplay_persistence: volatile` and accept a replay window of
-//! `clock_skew_ms` across a restart. This type is in-memory either way; the
-//! persistence decision belongs to the relay that owns it.
+//! up to `2 * clock_skew_ms` across a restart. This type is in-memory either
+//! way; the persistence decision belongs to the relay that owns it.
 
 use alloc::collections::BTreeMap;
 use core::fmt;
@@ -181,17 +181,11 @@ impl SeenSet {
     /// Whether the published `(antireplay_window_ms, clock_skew_ms)` pair
     /// actually closes the window.
     ///
-    /// **This is a check `WIRE.md` does not state, and it should.** §11.1
-    /// publishes the two values independently and nothing relates them, but a
-    /// frame is replayable for as long as its timestamp stays inside the
-    /// window: a command stamped `clock_skew_ms` in the future is still
-    /// acceptable `clock_skew_ms` *after* the relay first saw it, so an entry
-    /// must be retained for `2 × clock_skew_ms` from the moment it was
-    /// observed. A relay publishing `antireplay_window_ms < 2 ×
-    /// clock_skew_ms` ages entries out while their frames are still valid and
-    /// has no seen-set at all for the gap, which is §5.5's stated protection
-    /// silently absent. Reported as a specification defect rather than
-    /// implemented around.
+    /// `WIRE.md` §5.5 derives the relation: a frame can remain acceptable over
+    /// the inclusive interval from `timestamp_ms - clock_skew_ms` through
+    /// `timestamp_ms + clock_skew_ms`. A relay publishing
+    /// `antireplay_window_ms < 2 × clock_skew_ms` ages entries out while their
+    /// frames are still valid and has no seen-set at all for the gap.
     #[must_use]
     pub const fn retention_is_sound(&self, clock_skew_ms: u64) -> bool {
         match clock_skew_ms.checked_mul(2) {

--- a/rs/crates/f2z-relay-proto/tests/properties.rs
+++ b/rs/crates/f2z-relay-proto/tests/properties.rs
@@ -99,7 +99,9 @@ proptest! {
                             let repeat = queue.ack(up_to).unwrap();
                             prop_assert_eq!(repeat.acknowledged, 0);
                             prop_assert_eq!(queue.acked_through(), watermark);
-                            // Cumulative: `pending` is exactly what is left.
+                            // Cumulative: `pending` is exactly the remaining
+                            // unacknowledged index span (an upper bound after
+                            // TTL expiry removes stored rows).
                             prop_assert_eq!(
                                 outcome.pending,
                                 queue.next_index() - queue.first_unacked()

--- a/rs/crates/f2z-relay-store/tests/properties.rs
+++ b/rs/crates/f2z-relay-store/tests/properties.rs
@@ -456,6 +456,26 @@ proptest! {
 }
 
 #[test]
+fn pending_remains_an_index_span_after_ttl_expiry() {
+    both(|store, name| {
+        let _ = store
+            .create_queue(&spec(QueueKind::Standard, generous(), 1, 31_536_000))
+            .unwrap();
+        let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+        let payload = Payload::new(vec![0x5a; 64]).unwrap();
+        append_at(store, &payload, 10_000).unwrap();
+
+        let _ = store.expire(11_000).unwrap();
+        let record = store.queue_by_recv(&RECV, &RECV_KEY).unwrap();
+        assert_eq!(record.state.next_index(), 1, "{name}");
+        assert_eq!(record.state.acked_through(), None, "{name}");
+        assert_eq!(record.state.pending(), 1, "{name}");
+        assert_eq!(record.stored_messages, 0, "{name}");
+        let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+    });
+}
+
+#[test]
 fn the_idle_timer_retires_the_queue_and_activity_resets_it() {
     both(|store, name| {
         // 60-second idle TTL, created at 1_000 ms.

--- a/rs/crates/f2z-relay-testkit/src/engine.rs
+++ b/rs/crates/f2z-relay-testkit/src/engine.rs
@@ -591,7 +591,8 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> std::result::Result<Vec<u8>, ProtoError> {
-        let verified = self.verify::<ops::CreateQueue>(connection, now, request_id, request)?;
+        let verified =
+            self.verify::<ops::CreateQueue>(connection, now, request_id, request, |_, _| Ok(()))?;
         let body: CreateQueueRequest = verified.into_body();
 
         // §13.1 layer 4, in the order the section states it: creation is the
@@ -645,8 +646,13 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> std::result::Result<Vec<u8>, ProtoError> {
-        let verified =
-            self.verify::<ops::CreateContactQueue>(connection, now, request_id, request)?;
+        let verified = self.verify::<ops::CreateContactQueue>(
+            connection,
+            now,
+            request_id,
+            request,
+            |_, _| Ok(()),
+        )?;
         let body: CreateContactQueueRequest = verified.into_body();
 
         let published = self.published_capabilities();
@@ -701,7 +707,13 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> std::result::Result<Vec<u8>, ProtoError> {
-        let verified = self.verify::<ops::Subscribe>(connection, now, request_id, request)?;
+        let verified = self.verify::<ops::Subscribe>(
+            connection,
+            now,
+            request_id,
+            request,
+            |state, candidate| self.preauthorize_recv(state, candidate),
+        )?;
         let recv_addr = verified.address();
         let signer = verified.signer_key();
 
@@ -731,7 +743,13 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> std::result::Result<Vec<u8>, ProtoError> {
-        let verified = self.verify::<ops::Unsubscribe>(connection, now, request_id, request)?;
+        let verified = self.verify::<ops::Unsubscribe>(
+            connection,
+            now,
+            request_id,
+            request,
+            |state, candidate| self.preauthorize_recv(state, candidate),
+        )?;
         let recv_addr = verified.address();
         let signer = verified.signer_key();
 
@@ -753,7 +771,10 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> std::result::Result<Vec<u8>, ProtoError> {
-        let verified = self.verify::<ops::Read>(connection, now, request_id, request)?;
+        let verified =
+            self.verify::<ops::Read>(connection, now, request_id, request, |state, candidate| {
+                self.preauthorize_recv(state, candidate)
+            })?;
         let recv_addr = verified.address();
         let signer = verified.signer_key();
         let body: ReadRequest = verified.into_body();
@@ -791,7 +812,10 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> std::result::Result<Vec<u8>, ProtoError> {
-        let verified = self.verify::<ops::Ack>(connection, now, request_id, request)?;
+        let verified =
+            self.verify::<ops::Ack>(connection, now, request_id, request, |state, candidate| {
+                self.preauthorize_recv(state, candidate)
+            })?;
         let recv_addr = verified.address();
         let signer = verified.signer_key();
         let body: AckRequest = verified.into_body();
@@ -818,7 +842,13 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> std::result::Result<Vec<u8>, ProtoError> {
-        let verified = self.verify::<ops::DeleteQueue>(connection, now, request_id, request)?;
+        let verified = self.verify::<ops::DeleteQueue>(
+            connection,
+            now,
+            request_id,
+            request,
+            |state, candidate| self.preauthorize_recv(state, candidate),
+        )?;
         let recv_addr = verified.address();
         let signer = verified.signer_key();
 
@@ -842,7 +872,8 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> std::result::Result<Vec<u8>, ProtoError> {
-        let verified = self.verify::<ops::BindSend>(connection, now, request_id, request)?;
+        let verified =
+            self.verify::<ops::BindSend>(connection, now, request_id, request, |_, _| Ok(()))?;
         let send_addr = verified.address();
         let signer = verified.signer_key();
 
@@ -867,7 +898,13 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> std::result::Result<Vec<u8>, ProtoError> {
-        let verified = self.verify::<ops::Append>(connection, now, request_id, request)?;
+        let verified = self.verify::<ops::Append>(
+            connection,
+            now,
+            request_id,
+            request,
+            |state, candidate| self.preauthorize_send(state, candidate),
+        )?;
         let send_addr = verified.address();
         let signer = verified.signer_key();
         let body: AppendRequest = verified.into_body();
@@ -1044,6 +1081,7 @@ impl Relay {
         now: u64,
         request_id: u32,
         request: &Request,
+        authorize: impl FnOnce(&mut RelayState, &Verified<C>) -> std::result::Result<(), ProtoError>,
     ) -> std::result::Result<Verified<C>, ProtoError> {
         let padding = self.verifier_padding::<C>(request);
         let mut state = self
@@ -1053,7 +1091,9 @@ impl Relay {
         let seen = state.take_seen();
         let mut verifier =
             CommandVerifier::new(connection.transcripts.clone(), self.window(), seen, padding);
-        let outcome = verifier.verify::<C>(now, request_id, request);
+        let outcome = verifier.verify_authorized::<C, _>(now, request_id, request, |candidate| {
+            authorize(&mut state, candidate)
+        });
         let retention = verifier.seen_set().retention_ms();
         let max_entries = verifier.seen_set().max_entries();
         let seen = core::mem::replace(
@@ -1063,6 +1103,28 @@ impl Relay {
         state.put_seen(seen);
         drop(state);
         outcome
+    }
+
+    fn preauthorize_recv<C: RelayCommand>(
+        &self,
+        state: &mut RelayState,
+        candidate: &Verified<C>,
+    ) -> std::result::Result<(), ProtoError> {
+        let Some(queue) = state.queue_by_recv(&candidate.address()) else {
+            return Err(self.absent_recv());
+        };
+        queue.state.authorize_recv(&candidate.signer_key())
+    }
+
+    fn preauthorize_send<C: RelayCommand>(
+        &self,
+        state: &mut RelayState,
+        candidate: &Verified<C>,
+    ) -> std::result::Result<(), ProtoError> {
+        let Some(queue) = state.queue_by_second(&candidate.address()) else {
+            return Err(self.absent_send());
+        };
+        queue.state.authorize_send(&candidate.signer_key())
     }
 
     fn accept_unsigned<C: RelayCommand>(

--- a/rs/crates/f2z-relay-testkit/src/state.rs
+++ b/rs/crates/f2z-relay-testkit/src/state.rs
@@ -107,14 +107,20 @@ pub struct Queue {
 }
 
 impl Queue {
-    /// Messages present and not yet acknowledged — §6.2's `pending`.
+    /// Assigned indices not yet acknowledged — §6.2's `pending`.
     ///
-    /// Counted from storage rather than from the index arithmetic, because TTL
-    /// expiry removes messages without moving the watermark and the index-space
-    /// count is only an upper bound. `f2z-relay-proto::queue` says so and hands
-    /// the decision here, which is where the storage is.
+    /// This deliberately delegates to the shared queue state rather than
+    /// counting stored messages. TTL expiry removes ciphertext without moving
+    /// `next_index` or the ACK watermark, so the wire value remains an
+    /// index-span upper bound after expiry.
     #[must_use]
-    pub fn pending(&self) -> u64 {
+    pub const fn pending(&self) -> u64 {
+        self.state.pending()
+    }
+
+    /// Ciphertexts currently occupying storage and quota.
+    #[must_use]
+    fn stored_messages(&self) -> u64 {
         u64::try_from(self.messages.len()).unwrap_or(u64::MAX)
     }
 
@@ -392,7 +398,7 @@ impl RelayState {
             return Err(ProtoError::Wire(ErrorCode::Unavailable));
         };
         let quota = queue.effective_quota(faults);
-        let admitted = quota.admit(queue.pending(), queue.bytes, payload_bytes);
+        let admitted = quota.admit(queue.stored_messages(), queue.bytes, payload_bytes);
         if admitted.is_err() {
             self.notify_queue_event(recv_addr, QUEUE_EVENT_QUOTA);
         }

--- a/rs/crates/f2z-relay-testkit/tests/faults.rs
+++ b/rs/crates/f2z-relay-testkit/tests/faults.rs
@@ -241,6 +241,7 @@ async fn expire_a_ttl_early() {
 
     relay.faults().set_policy(PolicyFaults {
         expire_messages_after: Some(Duration::ZERO),
+        max_queue_messages: Some(1),
         ..PolicyFaults::default()
     });
     let read = recv
@@ -250,6 +251,24 @@ async fn expire_a_ttl_early() {
     assert_eq!(read.messages.len(), 0, "§7.7: the message TTL fired");
     let event = recv.next_queue_event().await.expect("QUEUE_EVENT push");
     assert_eq!(event.reason, 3, "reason 3 is 'messages TTL-expired'");
+
+    // Expiry removed storage, not queue history. A fresh subscription sees the
+    // next assigned index and the unacknowledged index span, exactly as the
+    // production relay does; neither value is derived from the now-empty read.
+    let mut again = relay.client().await.expect("reconnects");
+    let state = again
+        .subscribe(&recv_key, created.recv_addr)
+        .await
+        .expect("re-SUBSCRIBE");
+    assert_eq!(state.next_index, 1);
+    assert_eq!(state.pending, 1);
+
+    // The wire backlog is an index span, but storage quota is not. Expiring
+    // the only stored ciphertext frees the one-message cap even though the
+    // unacknowledged historical index remains pending.
+    send.append(&send_key, created.send_addr, b"replacement")
+        .await
+        .expect("TTL expiry frees stored-message quota");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/rs/crates/f2z-relay/src/engine.rs
+++ b/rs/crates/f2z-relay/src/engine.rs
@@ -632,6 +632,7 @@ impl Relay {
             now_ms,
             request_id,
             request,
+            |_| Ok(()),
         )?;
         let body: CreateQueueRequest = verified.into_body();
         body.validate()?;
@@ -677,6 +678,7 @@ impl Relay {
             now_ms,
             request_id,
             request,
+            |_| Ok(()),
         )?;
         let body: CreateContactQueueRequest = verified.into_body();
 
@@ -763,6 +765,7 @@ impl Relay {
             now_ms,
             request_id,
             request,
+            |candidate| self.preauthorize_recv(candidate),
         )?;
         let recv_addr = verified.address();
         let signer = verified.signer_key();
@@ -801,6 +804,7 @@ impl Relay {
             now_ms,
             request_id,
             request,
+            |candidate| self.preauthorize_recv(candidate),
         )?;
         let recv_addr = verified.address();
         let signer = verified.signer_key();
@@ -819,8 +823,13 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> Result<Vec<u8>, ProtoError> {
-        let verified =
-            self.verify_with::<ops::Read>(&connection.transcripts, now_ms, request_id, request)?;
+        let verified = self.verify_with::<ops::Read>(
+            &connection.transcripts,
+            now_ms,
+            request_id,
+            request,
+            |candidate| self.preauthorize_recv(candidate),
+        )?;
         let recv_addr = verified.address();
         let signer = verified.signer_key();
         let body: ReadRequest = verified.into_body();
@@ -891,8 +900,13 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> Result<Vec<u8>, ProtoError> {
-        let verified =
-            self.verify_with::<ops::Ack>(&connection.transcripts, now_ms, request_id, request)?;
+        let verified = self.verify_with::<ops::Ack>(
+            &connection.transcripts,
+            now_ms,
+            request_id,
+            request,
+            |candidate| self.preauthorize_recv(candidate),
+        )?;
         let recv_addr = verified.address();
         let signer = verified.signer_key();
         let body: AckRequest = verified.into_body();
@@ -926,6 +940,7 @@ impl Relay {
             now_ms,
             request_id,
             request,
+            |candidate| self.preauthorize_recv(candidate),
         )?;
         let recv_addr = verified.address();
         let signer = verified.signer_key();
@@ -963,6 +978,7 @@ impl Relay {
             now_ms,
             request_id,
             request,
+            |_| Ok(()),
         )?;
         let send_addr = verified.address();
         // `ops::BindSend::check` has already required `signer_key == send_key`:
@@ -996,7 +1012,13 @@ impl Relay {
         request_id: u32,
         request: &Request,
     ) -> Result<Vec<u8>, ProtoError> {
-        let verified = self.verify_with::<ops::Append>(transcripts, now_ms, request_id, request)?;
+        let verified = self.verify_with::<ops::Append>(
+            transcripts,
+            now_ms,
+            request_id,
+            request,
+            |candidate| self.preauthorize_send(candidate),
+        )?;
         let send_addr = verified.address();
         let signer = verified.signer_key();
         let body: AppendRequest = verified.into_body();
@@ -1265,6 +1287,7 @@ impl Relay {
         now_ms: u64,
         request_id: u32,
         request: &Request,
+        authorize: impl FnOnce(&Verified<C>) -> Result<(), ProtoError>,
     ) -> Result<Verified<C>, ProtoError> {
         // §5.5's seen-set is relay-wide, so it is taken out of the shared slot
         // for the duration of one verification and put back. A per-connection
@@ -1277,7 +1300,7 @@ impl Relay {
             seen,
             self.padding.clone(),
         );
-        let outcome = verifier.verify::<C>(now_ms, request_id, request);
+        let outcome = verifier.verify_authorized::<C, _>(now_ms, request_id, request, authorize);
         seen = std::mem::replace(
             verifier.seen_set_mut(),
             SeenSet::new(
@@ -1287,6 +1310,29 @@ impl Relay {
         );
         self.put_seen(seen);
         outcome
+    }
+
+    fn preauthorize_recv<C: RelayCommand>(
+        &self,
+        candidate: &Verified<C>,
+    ) -> Result<(), ProtoError> {
+        self.store
+            .queue_by_recv(&candidate.address(), &candidate.signer_key())
+            .map(|_| ())
+            .map_err(|error| self.recv_error(&error))
+    }
+
+    fn preauthorize_send<C: RelayCommand>(
+        &self,
+        candidate: &Verified<C>,
+    ) -> Result<(), ProtoError> {
+        self.store
+            .queue_by_send(
+                &candidate.address(),
+                &SendAuth::Signed(candidate.signer_key()),
+            )
+            .map(|_| ())
+            .map_err(|error| send_error(&error))
     }
 
     fn accept_unsigned<C: RelayCommand>(

--- a/rs/crates/f2z-relay/tests/configured_equivalents.rs
+++ b/rs/crates/f2z-relay/tests/configured_equivalents.rs
@@ -63,7 +63,8 @@
 use std::time::Duration;
 
 use f2z_codec::ErrorCode;
-use f2z_codec::commands::{AppendRequest, Command};
+use f2z_codec::commands::{AppendRequest, ChallengePurpose, ChallengeRequest, Command};
+use f2z_codec::types::{QueueAddress, ShortBytes};
 use f2z_relay::config::Config;
 use f2z_relay::server::Server;
 use f2z_relay_proto::command::ops;
@@ -107,6 +108,66 @@ async fn client(server: &Server, stream: u8) -> Client {
 
 fn key(seed: u8) -> SigningKey {
     SigningKey::from_seed(&[seed; 32])
+}
+
+/// A fully valid hostile command must not consume its replay key before the
+/// relay has authorized the signed queue identity. This goes through the
+/// production WebSocket listener and the production `RelayStore` lookup; the
+/// count is the live relay-wide seen-set, not a verifier fixture.
+#[tokio::test(flavor = "multi_thread")]
+async fn denied_queue_authorization_does_not_commit_the_replay_key() {
+    let server = relay(|_| {}).await;
+    let mut alice = client(&server, 0x51).await;
+    let owner = key(0x52);
+    let intruder = key(0x53);
+    let queue = alice.create_queue(&owner, 0, 0, None).await.unwrap();
+    let before = server.relay().sweep_memory(0).0;
+
+    expect_code(
+        alice.subscribe(&intruder, queue.recv_addr).await,
+        ErrorCode::NoAccess,
+    )
+    .unwrap();
+
+    let after = server.relay().sweep_memory(0).0;
+    assert_eq!(after, before, "denied command entered the relay seen-set");
+    server.shutdown().await;
+}
+
+/// The generic unsigned-command checker is on the production challenge path,
+/// including values the typed convenience method cannot construct.
+#[tokio::test(flavor = "multi_thread")]
+async fn get_challenge_rejects_unknown_purposes_and_wrong_scope_shapes() {
+    let server = relay(|_| {}).await;
+    let mut valid = client(&server, 0x54).await;
+    valid.challenge(ChallengePurpose::Clock, &[]).await.unwrap();
+    valid
+        .challenge(ChallengePurpose::ContactAppend, &[0x55; QueueAddress::LEN])
+        .await
+        .unwrap();
+
+    let mut unknown = client(&server, 0x56).await;
+    let body = ChallengeRequest {
+        purpose: 3,
+        scope: ShortBytes::default(),
+    };
+    expect_code(
+        unknown.call_unsigned::<ops::GetChallenge>(&body).await,
+        ErrorCode::Malformed,
+    )
+    .unwrap();
+
+    let mut wrong_scope = client(&server, 0x57).await;
+    let body = ChallengeRequest {
+        purpose: ChallengePurpose::ContactAppend.code(),
+        scope: ShortBytes::new(vec![0x58; QueueAddress::LEN - 1]).unwrap(),
+    };
+    expect_code(
+        wrong_scope.call_unsigned::<ops::GetChallenge>(&body).await,
+        ErrorCode::Malformed,
+    )
+    .unwrap();
+    server.shutdown().await;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #586.

## What changed

Closes the remaining relay/WIRE implementation gaps with shared, executable protocol rules:

- binds relay-state authorization before replay commitment and before padding-policy disclosure;
- validates challenge purpose/scope centrally;
- defines `pending` as the unacknowledged index span while keeping storage quotas tied to live stored rows;
- aligns production relay, FakeRelay, store backends, capability policy, error mapping, and WIRE corrections;
- exercises TTL expiry, resubscribe, capacity replacement, and malformed challenge behavior over real sockets.

## Verification

- pinned rustfmt for all 10 `rs/` crates — pass
- all targets for `f2z-codec`, `f2z-relay-proto`, `f2z-relay-store`, `f2z-relay-testkit`, and `f2z-relay` — pass
- pinned Clippy with `-D warnings` across those five crates — pass
- real relay/FakeRelay socket and dual-backend store suites — pass

Compiled mutation controls, independently replayed on exact head `9488debf`:

- bypass production `SUBSCRIBE` authorization — RED: unauthorized replay key commits;
- neutralize challenge purpose/scope validation — RED: malformed request is accepted over a production socket;
- derive `pending` from stored rows — RED: TTL/resubscribe reports 0 instead of the required index span 1;
- derive quota from pending span — RED: replacement append is refused after TTL frees live storage;
- move padding before relay-state authorization — RED: unauthorized malformed APPEND leaks `ERR_BAD_SIZE` instead of collapsed `ERR_UNAVAILABLE`.

Independent exact-head review: APPROVE. Stable patch ID: `4dd24d96939007bf6d1a30a511ef9dd59ca38ff9`.