### PR TITLE
fix(e2ee): close residual wire contract gaps

### DIFF
--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -1544,6 +1544,11 @@ struct {
 } SignedCapabilities;
 ```
 
+The five operator fields and three provenance fields are inert human-readable
+text, not markup. Each byte MUST be printable ASCII (`0x20..0x7e`); the empty
+value remains valid. A renderer MUST display the bytes as text and MUST NOT
+interpret HTML, Markdown, terminal escapes, or any other embedded language.
+
 > **Correction (2026-08-24) — the two anti-replay fields were published as
 > independent values, but they are not.** Section 5.5 derives the required
 > relation and retention origin. A relay MUST publish
@@ -1950,6 +1955,8 @@ A stamp is valid iff
 `H("free2z/relay/v1/pow", challenge || salt || counter)` has at least
 `difficulty_bits` leading zero bits, the challenge is unconsumed and unexpired,
 and (for `contact_append`) the challenge was issued for that `contact_addr`.
+At this point of use, `counter` is exactly an eight-byte unsigned `uint64` in
+network (big-endian) order, concatenated directly with no length prefix.
 Verification is one hash; the relay marks the challenge consumed. The choice of a
 verify-cheap, GPU-friendly function and its consequences are argued in §12.4.
 

--- a/rs/crates/f2z-codec/src/commands.rs
+++ b/rs/crates/f2z-codec/src/commands.rs
@@ -14,7 +14,9 @@
 use alloc::format;
 use alloc::vec::Vec;
 
-use tls_codec::{TlsDeserializeBytes, TlsSerializeBytes, TlsSize};
+use tls_codec::{
+    DeserializeBytes, Error as TlsError, TlsDeserializeBytes, TlsSerializeBytes, TlsSize,
+};
 
 use crate::error::CodecError;
 use crate::pow::{PowParams, PowStamp};
@@ -434,12 +436,23 @@ pub struct QueuedMessage {
 }
 
 /// `READ` response (§6.2). `READ` never mutates.
-#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes)]
 pub struct ReadResponse {
     /// The messages, `<0..2^24-1>` bytes of them.
     pub messages: VecU24<QueuedMessage>,
-    /// Nonzero when more messages remain past the last one returned.
+    /// 1 when more messages remain past the last one returned; 0 otherwise.
     pub has_more: u8,
+}
+
+impl DeserializeBytes for ReadResponse {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (messages, rest) = VecU24::<QueuedMessage>::tls_deserialize_bytes(bytes)?;
+        let (has_more, rest) = u8::tls_deserialize_bytes(rest)?;
+        if has_more > 1 {
+            return Err(TlsError::UnknownValue(u64::from(has_more)));
+        }
+        Ok((Self { messages, has_more }, rest))
+    }
 }
 
 /// `ACK` request (§6.2). Cumulative, monotone, idempotent, never selective
@@ -772,6 +785,30 @@ mod tests {
             decode_canonical::<ReadResponse>(&bytes).unwrap().value(),
             &response
         );
+    }
+
+    #[test]
+    fn read_response_rejects_non_boolean_has_more_bytes() {
+        // An empty `VecU24` is three zero length bytes. Keep these bodies
+        // hand-authored so the expected value does not come from the encoder
+        // under test.
+        for valid in [0x00, 0x01] {
+            let body = [0x00, 0x00, 0x00, valid];
+            assert_eq!(
+                decode_canonical::<ReadResponse>(&body)
+                    .unwrap()
+                    .value()
+                    .has_more,
+                valid
+            );
+        }
+        for invalid in [0x02, 0xff] {
+            let body = [0x00, 0x00, 0x00, invalid];
+            assert_eq!(
+                decode_canonical::<ReadResponse>(&body).unwrap_err(),
+                CodecError::Decode
+            );
+        }
     }
 
     #[test]

--- a/rs/crates/f2z-relay-proto/src/capabilities.rs
+++ b/rs/crates/f2z-relay-proto/src/capabilities.rs
@@ -247,7 +247,7 @@ pub fn check_digest(capabilities: &Capabilities, expected: &Digest) -> Result<()
 ///   a frame cap below the relay's own largest padding bucket, a `none`
 ///   transport that still claims a channel binding, a `pow` creation mode with
 ///   no parameters, or contact queues offered without the proof of work §12.3
-///   requires.
+///   requires, or operator/provenance text outside printable ASCII.
 pub fn validate(capabilities: &Capabilities) -> Result<()> {
     let inconsistent = ProtoError::Refused(Refusal::CapabilitiesInconsistent);
 
@@ -308,6 +308,30 @@ pub fn validate(capabilities: &Capabilities) -> Result<()> {
     // work is one of them. Offering contact queues without it is offering an
     // unsigned, unmetered write endpoint to the whole internet.
     if contact_queues && !capabilities.contact_append_pow.is_required() {
+        return Err(inconsistent);
+    }
+
+    // §11.1: these are the eight human-facing strings a client surfaces. They
+    // are inert text, not markup, and arbitrary control/non-ASCII bytes are not
+    // a conforming capability document. Keep this scoped here: `ShortBytes`
+    // also carries challenge scopes, whose 32 address bytes are intentionally
+    // arbitrary.
+    let human_text = [
+        &capabilities.operator_name,
+        &capabilities.operator_contact,
+        &capabilities.operator_abuse_contact,
+        &capabilities.operator_jurisdiction,
+        &capabilities.operator_policy_url,
+        &capabilities.source_repo_url,
+        &capabilities.source_commit,
+        &capabilities.build_digest,
+    ];
+    if human_text.iter().any(|text| {
+        !text
+            .as_slice()
+            .iter()
+            .all(|byte| (0x20..=0x7e).contains(byte))
+    }) {
         return Err(inconsistent);
     }
 
@@ -548,6 +572,77 @@ mod tests {
 
     fn document() -> Capabilities {
         defaults(&identity().public_key(), 1_800_000_000_000).unwrap()
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum HumanTextField {
+        OperatorName,
+        OperatorContact,
+        OperatorAbuseContact,
+        OperatorJurisdiction,
+        OperatorPolicyUrl,
+        SourceRepoUrl,
+        SourceCommit,
+        BuildDigest,
+    }
+
+    const HUMAN_TEXT_FIELDS: [HumanTextField; 8] = [
+        HumanTextField::OperatorName,
+        HumanTextField::OperatorContact,
+        HumanTextField::OperatorAbuseContact,
+        HumanTextField::OperatorJurisdiction,
+        HumanTextField::OperatorPolicyUrl,
+        HumanTextField::SourceRepoUrl,
+        HumanTextField::SourceCommit,
+        HumanTextField::BuildDigest,
+    ];
+
+    fn set_human_text(capabilities: &mut Capabilities, field: HumanTextField, bytes: &[u8]) {
+        let value = ShortBytes::new(bytes.to_vec()).unwrap();
+        match field {
+            HumanTextField::OperatorName => capabilities.operator_name = value,
+            HumanTextField::OperatorContact => capabilities.operator_contact = value,
+            HumanTextField::OperatorAbuseContact => capabilities.operator_abuse_contact = value,
+            HumanTextField::OperatorJurisdiction => capabilities.operator_jurisdiction = value,
+            HumanTextField::OperatorPolicyUrl => capabilities.operator_policy_url = value,
+            HumanTextField::SourceRepoUrl => capabilities.source_repo_url = value,
+            HumanTextField::SourceCommit => capabilities.source_commit = value,
+            HumanTextField::BuildDigest => capabilities.build_digest = value,
+        }
+    }
+
+    #[test]
+    fn all_operator_and_provenance_fields_are_printable_ascii() {
+        for field in HUMAN_TEXT_FIELDS {
+            for accepted in [b"".as_slice(), b" ", b"~", b"\"", b"\\"] {
+                let mut capabilities = document();
+                set_human_text(&mut capabilities, field, accepted);
+                assert_eq!(validate(&capabilities), Ok(()), "{field:?}: {accepted:?}");
+            }
+            for rejected in [b"\x1f".as_slice(), b"\x7f", b"\x80"] {
+                let mut capabilities = document();
+                set_human_text(&mut capabilities, field, rejected);
+                assert_eq!(
+                    validate(&capabilities),
+                    Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent)),
+                    "{field:?}: {rejected:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_valid_signature_does_not_make_invalid_operator_text_acceptable() {
+        let key = identity();
+        let mut capabilities = document();
+        capabilities.operator_name = ShortBytes::new(b"line\x1fbreak".to_vec()).unwrap();
+        let signed = sign(&key, capabilities).unwrap();
+
+        assert_eq!(verify(&signed, &key.public_key()), Ok(()));
+        assert_eq!(
+            ClientPolicy::default().accept(&signed.capabilities),
+            Err(ProtoError::Refused(Refusal::CapabilitiesInconsistent))
+        );
     }
 
     #[test]

--- a/rs/crates/f2z-relay/src/caps.rs
+++ b/rs/crates/f2z-relay/src/caps.rs
@@ -583,6 +583,25 @@ mod tests {
     }
 
     #[test]
+    fn configured_control_bytes_fail_before_the_relay_can_publish_them() {
+        let mut config = Config::default();
+        config.operator.name = "line\u{001f}break".to_owned();
+        assert!(matches!(
+            build(
+                &config,
+                &identity().public_key(),
+                Durability::FsyncPerAppend,
+                1_800_000_000_000,
+            ),
+            Err(CapabilitiesError::Invalid(
+                f2z_relay_proto::ProtoError::Refused(
+                    f2z_relay_proto::Refusal::CapabilitiesInconsistent
+                )
+            ))
+        ));
+    }
+
+    #[test]
     fn tls_publishes_the_exporter_binding_and_nothing_else_does() {
         let mut config = Config::default();
         assert_eq!(
@@ -666,9 +685,9 @@ mod tests {
     #[test]
     fn an_operator_string_cannot_break_the_document_it_appears_in() {
         let mut config = Config::default();
-        config.operator.name = "a \"quoted\" name\nwith a newline".to_owned();
+        config.operator.name = "a \"quoted\" name\\with a slash".to_owned();
         let published = publish(&identity(), document(&config)).unwrap();
         let json = to_json(&published);
-        assert!(json.contains("a \\\"quoted\\\" name\\nwith a newline"));
+        assert!(json.contains("a \\\"quoted\\\" name\\\\with a slash"));
     }
 }


### PR DESCRIPTION
Closes #585.

## What changed

- Restates the PoW counter at point of use as exactly eight-byte unsigned big-endian with no length prefix.
- Restricts exactly the five operator and three provenance capability text fields to printable ASCII `0x20..=0x7e`, with empty allowed; binary `ShortBytes` values such as challenge scopes remain unrestricted.
- Makes `ReadResponse.has_more` decode canonically: only literal `0` and `1` are accepted.
- Proves semantic attachment through both signed client policy and production relay capability construction.

## Verification

- full locked workspace tests, all targets — pass
- full locked workspace Clippy with `-D warnings` — pass
- repository fmt/Clippy gates across all 10 `rs` crates — pass

Compiled mutation controls, independently replayed on exact head `82938cdd`:

- omit each of the eight text fields from validation — all eight RED;
- widen to arbitrary bytes — RED;
- narrow to alphanumeric — RED on valid space/quote/backslash boundaries;
- remove strict `has_more` check — RED;
- normalize nonzero as true — RED (`NotCanonical` instead of required decode refusal);
- remove `ClientPolicy::accept` validation — RED after cryptographic verification;
- remove production `caps::build` validation — RED before publication;
- change PoW counter BE to LE — RED against the independent known-answer vector.

Independent exact-head review: APPROVE. Stable patch ID: `d4e531495c6bc410d2f74efa0e86d3c6405456c4`.