### PR TITLE
test(kt): pin published epoch bounds

### DIFF
--- a/rs/crates/f2z-authority/src/authority.rs
+++ b/rs/crates/f2z-authority/src/authority.rs
@@ -979,6 +979,15 @@ fn check_account_epoch(account_epoch: u32, previous: Option<u32>) -> Result<()> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_published_bounds_are_the_ones_this_crate_applies() {
+        // KT.md §4.5.4 states these to clients as fixed constants. A client
+        // that hard-codes the specification and a log that applies something
+        // else disagree about admissibility, not merely about an encoding.
+        assert_eq!(ACCOUNT_EPOCH_CEILING, 1 << 20, "KT.md §4.5.4 A18a");
+        assert_eq!(MAX_ACCOUNT_EPOCH_STEP, 16, "KT.md §4.5.4 A18b");
+    }
     use crate::assertion::HandleAssertionTBS;
     use crate::key::SigningKey;
     use crate::nonce::NonceLedger;

--- a/rs/crates/f2z-authority/src/bin/f2z-assert.rs
+++ b/rs/crates/f2z-authority/src/bin/f2z-assert.rs
@@ -33,8 +33,8 @@ use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use f2z_authority::{
-    AssertionNonce, DEFAULT_MAX_VALIDITY_MS, Handle, HandleAssertionTBS, Intent, LogId, SigningKey,
-    authority_id,
+    ACCOUNT_EPOCH_CEILING, AssertionNonce, DEFAULT_MAX_VALIDITY_MS, Handle, HandleAssertionTBS,
+    Intent, LogId, SigningKey, authority_id,
 };
 use f2z_codec::canonical::Canonical as _;
 use f2z_codec::types::PublicKey;
@@ -69,7 +69,8 @@ NOTES:
   last-one forever, which deletes the rule that stops a reset assertion being
   spent twice on one account-ownership event. It defaults to 0 for --intent
   bind, which is the baseline a handle's first reset must exceed, and is
-  REQUIRED for --intent reset. A value at or above 1048576 is refused outright
+  REQUIRED for --intent reset. A value at or above \
+  {account_epoch_ceiling} is refused outright
   as a clock.
 
   --validity-ms defaults to 900000 (15 minutes) and is ignored when --expires-ms
@@ -77,9 +78,18 @@ NOTES:
   the log's own cap is refused however it was signed.
 ";
 
+fn usage_with_account_epoch_ceiling(account_epoch_ceiling: u32) -> String {
+    USAGE.replace(
+        "{account_epoch_ceiling}",
+        &account_epoch_ceiling.to_string(),
+    )
+}
+
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().skip(1).collect();
-    match run(&args) {
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    match run_published(&args, &mut stdout) {
         Ok(()) => ExitCode::SUCCESS,
         Err(message) => {
             eprintln!("f2z-assert: {message}");
@@ -88,9 +98,17 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(args: &[String]) -> Result<(), String> {
+fn run_published(args: &[String], stdout: &mut impl std::io::Write) -> Result<(), String> {
+    run(args, ACCOUNT_EPOCH_CEILING, stdout)
+}
+
+fn run(
+    args: &[String],
+    account_epoch_ceiling: u32,
+    stdout: &mut impl std::io::Write,
+) -> Result<(), String> {
     let Some(command) = args.first() else {
-        print!("{USAGE}");
+        write_usage(stdout, account_epoch_ceiling)?;
         return Err("no subcommand given".into());
     };
     let rest = args.get(1..).unwrap_or_default();
@@ -99,11 +117,17 @@ fn run(args: &[String]) -> Result<(), String> {
         "authority" => authority(rest),
         "issue" => issue(rest),
         "-h" | "--help" | "help" => {
-            print!("{USAGE}");
+            write_usage(stdout, account_epoch_ceiling)?;
             Ok(())
         }
         other => Err(format!("unknown subcommand `{other}`; try --help")),
     }
+}
+
+fn write_usage(stdout: &mut impl std::io::Write, account_epoch_ceiling: u32) -> Result<(), String> {
+    stdout
+        .write_all(usage_with_account_epoch_ceiling(account_epoch_ceiling).as_bytes())
+        .map_err(|error| format!("writing usage: {error}"))
 }
 
 // ---------------------------------------------------------------- subcommands
@@ -454,6 +478,66 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
+
+    #[test]
+    fn usage_formats_the_supplied_epoch_ceiling() {
+        let rendered = usage_with_account_epoch_ceiling(42);
+        assert!(rendered.contains("A value at or above 42 is refused outright"));
+        assert!(!rendered.contains("{account_epoch_ceiling}"));
+    }
+
+    #[test]
+    fn every_dispatch_usage_path_formats_the_supplied_epoch_ceiling() {
+        let help = ["--help".to_owned()];
+        let no_args: [String; 0] = [];
+
+        for ceiling in [42, 2_000_000] {
+            let expected = usage_with_account_epoch_ceiling(ceiling);
+            let expected_threshold = format!(
+                "  REQUIRED for --intent reset. A value at or above {ceiling} is refused outright"
+            );
+            for (args, succeeds) in [(&help[..], true), (&no_args[..], false)] {
+                let mut stdout = Vec::new();
+                let result = run(args, ceiling, &mut stdout);
+                assert_eq!(result.is_ok(), succeeds);
+                let rendered = String::from_utf8(stdout).unwrap();
+                let threshold_lines: Vec<&str> = rendered
+                    .lines()
+                    .filter(|line| line.contains("A value at or above"))
+                    .collect();
+                assert_eq!(threshold_lines, [expected_threshold.as_str()]);
+                assert_eq!(rendered, expected);
+            }
+        }
+    }
+
+    struct RefusingWriter;
+
+    impl std::io::Write for RefusingWriter {
+        fn write(&mut self, _buffer: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("refused"))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn every_usage_path_propagates_write_failure() {
+        let help = ["--help".to_owned()];
+        let no_args: [String; 0] = [];
+        for args in [&help[..], &no_args[..]] {
+            assert_eq!(
+                run(args, 42, &mut RefusingWriter).unwrap_err(),
+                "writing usage: refused"
+            );
+            assert_eq!(
+                run_published(args, &mut RefusingWriter).unwrap_err(),
+                "writing usage: refused"
+            );
+        }
+    }
 
     fn unused_path(name: &str) -> std::path::PathBuf {
         let unique = SystemTime::now()

--- a/rs/crates/f2z-authority/tests/cli.rs
+++ b/rs/crates/f2z-authority/tests/cli.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use f2z_authority::{HandleAssertion, Intent, SigningKey, authority_id};
+use f2z_authority::{ACCOUNT_EPOCH_CEILING, HandleAssertion, Intent, SigningKey, authority_id};
 use f2z_codec::canonical::{Canonical as _, decode_canonical};
 
 const FIXED_KEY_SEED: [u8; 32] = [
@@ -42,6 +42,7 @@ const RAW_ISSUE_SEED: [u8; 32] = [
     0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
     0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf,
 ];
+const EXPECTED_HELP: &str = include_str!("fixtures/f2z-assert-help.txt");
 
 struct TestDirectory(PathBuf);
 
@@ -86,6 +87,51 @@ fn command_strings(args: &[String]) -> Output {
         .args(args)
         .output()
         .unwrap()
+}
+
+fn ascii_numbers(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut numbers = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index].is_ascii_digit() {
+            let start = index;
+            while index < bytes.len() && bytes[index].is_ascii_digit() {
+                index += 1;
+            }
+            numbers.push(&text[start..index]);
+        } else {
+            index += 1;
+        }
+    }
+    numbers
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf2_9ce4_8422_2325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x0000_0100_0000_01b3)
+    })
+}
+
+#[test]
+fn every_usage_path_publishes_the_library_epoch_ceiling() {
+    assert_eq!(fnv1a64(b""), 0xcbf2_9ce4_8422_2325);
+    assert_eq!(fnv1a64(b"a"), 0xaf63_dc4c_8601_ec8c);
+    for args in [&["--help"][..], &[][..]] {
+        let output = command(args);
+        assert_eq!(output.status.success(), !args.is_empty());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(stdout, EXPECTED_HELP);
+        assert_eq!(fnv1a64(stdout.as_bytes()), 0xd869_f92d_9457_63b0);
+        assert!(stdout.contains(&ACCOUNT_EPOCH_CEILING.to_string()));
+        assert_eq!(
+            ascii_numbers(&stdout),
+            [
+                "2", "2", "2", "2", "25519", "64", "2", "2", "64", "32", "0600", "0014", "4", "5",
+                "4", "0", "1048576", "900000", "15",
+            ]
+        );
+    }
 }
 
 #[cfg(unix)]

--- a/rs/crates/f2z-authority/tests/fixtures/f2z-assert-help.txt
+++ b/rs/crates/f2z-authority/tests/fixtures/f2z-assert-help.txt
@@ -1,0 +1,35 @@
+f2z-assert — issue a free2z handle-ownership assertion (docs/e2ee/KT.md)
+
+USAGE:
+  f2z-assert keygen [--out FILE]
+      Generate an Ed25519 issuing key. Writes 64 hex characters.
+
+  f2z-assert authority --key FILE
+      Print the authority_id and public key for a key file, in the form an
+      AuthoritySet entry takes.
+
+  f2z-assert issue --key FILE --log-id HEX --handle NAME --identity-pk HEX
+                   [--intent bind|reset] [--account-epoch N]
+                   [--issued-ms N] [--expires-ms N] [--validity-ms N]
+                   [--nonce HEX] [--out FILE]
+      Sign an assertion. Writes hex to stdout, or raw bytes with --out.
+
+NOTES:
+  A key file holds 64 hex characters or 32 raw bytes. Surrounding whitespace is
+  ignored. It is a private key: mode 0600, and never in a repository.
+
+  --intent defaults to bind. Use reset only for ADR 0014's platform-reset path,
+  where an account has changed hands; the log refuses a reset on a handle's
+  first entry and refuses a bind on any later one.
+
+  --account-epoch is the authority's DURABLE PER-ACCOUNT COUNTER (KT.md
+  §4.5.4). It is not a timestamp: a clock satisfies strictly-greater-than-the-
+  last-one forever, which deletes the rule that stops a reset assertion being
+  spent twice on one account-ownership event. It defaults to 0 for --intent
+  bind, which is the baseline a handle's first reset must exceed, and is
+  REQUIRED for --intent reset. A value at or above 1048576 is refused outright
+  as a clock.
+
+  --validity-ms defaults to 900000 (15 minutes) and is ignored when --expires-ms
+  is given. The LOG caps this independently: an assertion whose window exceeds
+  the log's own cap is refused however it was signed.


### PR DESCRIPTION
Closes #657

Pins the account-epoch ceiling to an independent literal contract, renders the CLI help from the production constant, and verifies the real process output against an exact golden, numeric census, and independently checked FNV-1a checksum. Both help and no-argument paths share the same fallible writer path, including the shipping wrapper.

Validation:
- `cargo test -p f2z-authority -p f2z-kt --all-targets`
- `cargo test -p f2z-authority -p f2z-kt --doc`
- rustfmt and all-target clippy
- independent exact-head review on `b6e56b337b8d47a539d78065c6d7bb549e3b05e6`

Mutation evidence (compiled and RED): production constant drift; step constant drift; formatter bypass; hard-coded template/wrapper branches; help/no-args routing divergence; swallowed writer errors; coordinated production+golden contradictions; split-line/spelled-out alternate limits; the prior numeric-reallocation survivor; FNV helper-prime corruption; and checksum-literal corruption.