### PR TITLE
test(kt): guard queried-handle log privacy

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -525,6 +525,7 @@ dependencies = [
  "protobuf",
  "tls_codec",
  "tokio",
+ "tower",
 ]
 
 [[package]]

--- a/rs/crates/f2z-kt/Cargo.toml
+++ b/rs/crates/f2z-kt/Cargo.toml
@@ -77,6 +77,7 @@ async-trait = { workspace = true }
 # `tests/`, and never for the binary".
 f2z-kt = { path = ".", version = "0.1.0", features = ["testing"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+tower = { version = "0.5.3", default-features = false, features = ["util"] }
 
 [[bin]]
 name = "f2z-kt"

--- a/rs/crates/f2z-kt/src/log.rs
+++ b/rs/crates/f2z-kt/src/log.rs
@@ -799,6 +799,19 @@ impl LogService {
         })
     }
 
+    /// Remove the stored entry bytes while leaving the authenticated tree
+    /// untouched, so an acceptance test can exercise the production history
+    /// fault path through the HTTP error logger.
+    ///
+    /// This is available only to test builds. A real process can reach the
+    /// same state after storage corruption; it must report that fault without
+    /// turning the queried handle into operator-log data.
+    #[cfg(any(test, feature = "testing"))]
+    pub async fn forget_entry_bytes_for_test(&self, handle: &Handle, version: u32) {
+        let mut state = self.state.lock().await;
+        state.entries.remove(&(handle.as_slice().to_vec(), version));
+    }
+
     /// **`GET /kt/v1/audit?from&to`.**
     ///
     /// Carries every head in `[from, to]` alongside the proof — see

--- a/rs/crates/f2z-kt/tests/redaction.rs
+++ b/rs/crates/f2z-kt/tests/redaction.rs
@@ -1,5 +1,5 @@
 //! **The log is public by construction — so log it normally, but never a
-//! signing key and never an unpublished submission.**
+//! signing key, never an unpublished submission, and never a queried handle.**
 //!
 //! The first half is deliberate: a `DirectoryEntry` is a public record, and a
 //! server that refused to name a handle in its own operator log would be
@@ -30,10 +30,58 @@
     clippy::arithmetic_side_effects
 )]
 
+use std::sync::{Arc, Mutex, Once};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use f2z_codec::Canonical as _;
+use f2z_kt::api::AppState;
+use f2z_kt::ratelimit::RateLimiter;
 use f2z_kt::testing::{EntryBuilder, Harness, Identity, Key};
+use f2z_kt::wire::{HistoryRequest, LookupRequest};
 use f2z_kt::{FileSigner, LogSigner as _};
+use tower::ServiceExt as _;
 
 const NOW: u64 = 1_700_000_100_000;
+
+struct Capture {
+    records: Mutex<Vec<String>>,
+}
+
+impl log::Log for Capture {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        metadata.level() <= log::Level::Trace
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if self.enabled(record.metadata()) {
+            self.records.lock().unwrap().push(record.args().to_string());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static CAPTURE: Capture = Capture {
+    records: Mutex::new(Vec::new()),
+};
+static INSTALL_CAPTURE: Once = Once::new();
+
+fn captured() -> String {
+    CAPTURE.records.lock().unwrap().join("\n")
+}
+
+fn clear_capture() {
+    CAPTURE.records.lock().unwrap().clear();
+}
+
+fn install_capture() {
+    INSTALL_CAPTURE.call_once(|| {
+        log::set_logger(&CAPTURE).unwrap();
+        log::set_max_level(log::LevelFilter::Trace);
+    });
+    clear_capture();
+}
 
 /// Assert that `rendered` contains `bytes` in none of the forms a `Debug`
 /// implementation can leak them in.
@@ -74,6 +122,39 @@ fn assert_absent(rendered: &str, bytes: &[u8], what: &str) {
             "{what} leaked as {form} in: {rendered}"
         );
     }
+
+    if let Ok(utf8) = std::str::from_utf8(bytes) {
+        assert!(
+            !rendered.contains(utf8),
+            "{what} leaked as UTF-8 in: {rendered}"
+        );
+    }
+}
+
+async fn request(state: Arc<AppState>, path: &'static str, body: Vec<u8>) -> StatusCode {
+    f2z_kt::api::router(state)
+        .oneshot(Request::post(path).body(Body::from(body)).unwrap())
+        .await
+        .unwrap()
+        .status()
+}
+
+async fn app_state(harness: &Harness) -> Arc<AppState> {
+    let signer = FileSigner::from_seed(&[0xa1; 32]);
+    Arc::new(AppState {
+        descriptor: f2z_kt::descriptor::sign_descriptor(
+            harness.log.settings(),
+            harness.log_id,
+            *harness.log.vrf_public_key(),
+            &signer,
+            NOW,
+        )
+        .unwrap(),
+        policy: f2z_kt::sign_policy(harness.log.authority(), harness.log_id, &signer, NOW).unwrap(),
+        log: Arc::clone(&harness.log),
+        limits: RateLimiter::defaults(),
+        clock: Arc::new(|| NOW),
+    })
 }
 
 #[test]
@@ -135,6 +216,77 @@ async fn the_log_service_never_renders_a_pending_submission_or_a_key() {
     // And the identifiers an operator actually needs are still there.
     assert!(rendered.contains("log_id"));
     assert!(rendered.contains("vrf_public_key"));
+}
+
+#[tokio::test]
+async fn lookup_and_history_never_put_the_queried_handle_in_the_operator_log() {
+    install_capture();
+    log::trace!("query-log-privacy trace capture control");
+    assert!(
+        captured().contains("query-log-privacy trace capture control"),
+        "the capturing logger did not observe its trace-level control"
+    );
+    clear_capture();
+
+    let harness = Harness::vouched("redaction-query-handle").await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+
+    let alice = Identity::from_byte(0x5d);
+    let handle = f2z_kt_core::types::Handle::new(b"queryhandleprivacy".to_vec()).unwrap();
+    let entry =
+        EntryBuilder::first(harness.log_id, "queryhandleprivacy", &alice).same_key(&alice.dak);
+    harness
+        .log
+        .submit(&harness.envelope(&entry, &alice, NOW), NOW)
+        .await
+        .unwrap();
+
+    let positive = captured();
+    assert!(
+        positive.contains("queryhandleprivacy"),
+        "the capturing logger did not observe the production submission log: {positive}"
+    );
+
+    harness.log.publish_epoch(NOW + 1).await.unwrap();
+    let state = app_state(&harness).await;
+    clear_capture();
+
+    let lookup = LookupRequest::new(handle.clone())
+        .unwrap()
+        .encode_canonical()
+        .unwrap();
+    assert_eq!(
+        request(Arc::clone(&state), "/kt/v1/lookup", lookup).await,
+        StatusCode::OK
+    );
+    assert_absent(&captured(), handle.as_slice(), "the queried lookup handle");
+
+    let history = HistoryRequest::complete(handle.clone())
+        .unwrap()
+        .encode_canonical()
+        .unwrap();
+    assert_eq!(
+        request(Arc::clone(&state), "/kt/v1/history", history.clone()).await,
+        StatusCode::OK
+    );
+    assert_absent(&captured(), handle.as_slice(), "the queried history handle");
+
+    harness.log.forget_entry_bytes_for_test(&handle, 1).await;
+    clear_capture();
+    assert_eq!(
+        request(state, "/kt/v1/history", history).await,
+        StatusCode::INTERNAL_SERVER_ERROR
+    );
+    let fault = captured();
+    assert!(
+        fault.contains("history: no stored entry for version 1"),
+        "the test did not drive the production storage fault into the operator logger: {fault}"
+    );
+    assert_absent(
+        &fault,
+        handle.as_slice(),
+        "the history handle on the storage-fault path",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #655

## What changed
- exercise the real `/lookup` and `/history` router paths under a global capturing logger
- require queried handles to stay absent in UTF-8, hex, decimal-byte, and base64url forms
- cover both successful responses and an authenticated-tree/storage-failure path that reaches production error logging
- retain positive controls for production info logs and trace-level capture so the privacy assertion cannot pass with inert logging

## Verification
- `cargo test --locked -p f2z-kt --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p f2z-kt --all-targets -- -D warnings`
- 20 repeated parallel-thread redaction runs

## Mutation evidence
Each guard was broken on the exact candidate and the focused test went red before restoration:
- add a Debug-level queried-handle leak in `LogService::lookup`
- add a Trace-level queried-handle leak in `LogService::lookup`
- narrow the global max level from Trace to Info
- narrow the capture logger enabled filter from Trace to Info

Exact reviewed head: `3d456c6e9686d1a597c86f87009ee0b80178ca09`
Stable patch: `5f1d8d9b84abe68afd1fbff9b646ec04ca0edfd4`