### PR TITLE
fix(relay): bound the operational listener in time and concurrency

### DIFF
--- a/rs/crates/f2z-relay/README.md
+++ b/rs/crates/f2z-relay/README.md
@@ -121,8 +121,18 @@ Two things this deliberately is **not**:
   fail the kubelet's liveness probe and restart the only replica. A separate
   listener cannot do that.
 
-`scripts/check-f2z-images.mjs --probe-relay IMAGE` asserts all three properties
-against a running container after every build.
+It is also **bounded in time and concurrency**, which the loopback listener
+never needed to be: a two-second deadline per request and sixteen in flight, so
+a peer that connects and never speaks costs an accept and a close rather than a
+task, a buffer and a descriptor held indefinitely. Be precise about what that
+buys — it bounds *resources*, not *availability*. A determined flood from inside
+the cluster can still occupy the permits and make a probe time out, and no
+in-process constant fixes that; a NetworkPolicy on the port is the answer to a
+hostile pod.
+
+`scripts/check-f2z-images.mjs --probe-relay IMAGE` asserts the three surface
+properties against a running container after every build, and
+`tests/health.rs` covers the slow-client case.
 
 ## `.well-known` is deliberately not served
 

--- a/rs/crates/f2z-relay/src/admin.rs
+++ b/rs/crates/f2z-relay/src/admin.rs
@@ -51,10 +51,11 @@
 //! relay's existence at that address is not a secret; its queue depth is.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::watch;
+use tokio::sync::{Semaphore, watch};
 
 use crate::config::is_loopback;
 use crate::engine::Relay;
@@ -65,6 +66,41 @@ use crate::engine::Relay;
 /// past the first line is interpreted, so this is a bound on the read rather
 /// than a protocol limit.
 const MAX_REQUEST: usize = 2048;
+
+/// How long one request may take, from accept to written response.
+///
+/// A bound on BYTES is not a bound on TIME: a client that connects and sends
+/// nothing holds a task and a descriptor for as long as it likes, and
+/// [`Scope::HealthOnly`] is reachable from the whole cluster rather than from
+/// loopback. Two seconds is chosen to be SHORTER than the probe's own
+/// `timeoutSeconds` (3-5s in the manifests): the server should give up before
+/// the client does, so a stuck peer is the server's descriptor to reclaim
+/// rather than the probe's deadline to miss.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// How many requests this listener will have in flight at once.
+///
+/// The whole population is a kubelet and a load-balancer health checker, which
+/// together produce a handful of requests per ten seconds; anything above this
+/// is not a scraper. A refused connection is closed immediately, before any
+/// read, so the cost of a flood is an accept and a close rather than a task, a
+/// buffer and a descriptor held for the timeout above.
+///
+/// This is deliberately NOT §13.1 layer 1's connection guard: that one lives on
+/// the protocol listener and can refuse under backpressure, which is exactly
+/// why the health check must not be answered there — a probe that fails during
+/// a traffic spike restarts the only replica.
+///
+/// **BE PRECISE ABOUT WHAT THIS BUYS.** It bounds RESOURCES — descriptors,
+/// tasks, buffers — so a peer that opens connections and never speaks cannot
+/// grow this process without limit, and the listener recovers within
+/// [`REQUEST_TIMEOUT`] once the flood stops. It does **not** guarantee
+/// AVAILABILITY: a determined flood from inside the cluster can still occupy
+/// the permits and make a probe time out, and no in-process number fixes that
+/// — an attacker who can do this can also fill the accept backlog. The answer
+/// to a hostile pod on the cluster network is a NetworkPolicy on this port, not
+/// a bigger constant here.
+const MAX_CONCURRENT: usize = 16;
 
 /// The health check's body. Constant, and it is meant to be.
 const HEALTHZ_BODY: &str = "ok\n";
@@ -133,6 +169,7 @@ pub async fn serve(
     scope: Scope,
     mut shutdown: watch::Receiver<bool>,
 ) {
+    let permits = Arc::new(Semaphore::new(MAX_CONCURRENT));
     loop {
         let accepted = tokio::select! {
             biased;
@@ -142,9 +179,19 @@ pub async fn serve(
         let Ok((stream, _peer)) = accepted else {
             continue;
         };
+        // `try_acquire`, not `acquire`: waiting here would move the queue from
+        // the semaphore to the accept backlog and hold the connection open,
+        // which is the thing being bounded. Over the limit, close.
+        let Ok(permit) = Arc::clone(&permits).try_acquire_owned() else {
+            drop(stream);
+            continue;
+        };
         let relay = Arc::clone(&relay);
         tokio::spawn(async move {
-            let _ = answer(relay, scope, stream).await;
+            // The timeout wraps the whole exchange, so a peer that connects and
+            // never sends cannot hold the permit either.
+            let _ = tokio::time::timeout(REQUEST_TIMEOUT, answer(relay, scope, stream)).await;
+            drop(permit);
         });
     }
 }

--- a/rs/crates/f2z-relay/tests/health.rs
+++ b/rs/crates/f2z-relay/tests/health.rs
@@ -113,6 +113,54 @@ async fn the_health_listener_does_not_serve_metrics() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn a_client_that_connects_and_says_nothing_is_disconnected_and_the_listener_recovers() {
+    // The health surface is the one that may answer off loopback, so its
+    // population is the whole cluster rather than processes on this host. A
+    // bound on request BYTES is not a bound on TIME: without a timeout and a
+    // concurrency cap, a peer that connects and sends nothing holds a task, a
+    // buffer and a descriptor indefinitely, and enough of them grow the process
+    // until the memory limit kills the only replica.
+    //
+    // What is asserted here is what the bound actually buys: the peers are
+    // disconnected on the server's own deadline, and the listener is serving
+    // again afterwards. It is NOT an availability guarantee — see the note on
+    // MAX_CONCURRENT; a determined flood can still make a probe time out, and
+    // a NetworkPolicy is the answer to that, not a bigger constant.
+    let mut config = base();
+    config.health.enabled = true;
+    config.health.address = "127.0.0.1:0".to_owned();
+    let server = Server::start(config).await.expect("the relay starts");
+    let health = server.health_addr().expect("bound");
+
+    let mut silent = Vec::new();
+    for _ in 0..64 {
+        if let Ok(stream) = tokio::net::TcpStream::connect(health).await {
+            silent.push(stream);
+        }
+    }
+    assert!(silent.len() > 16, "the listener accepted {}", silent.len());
+
+    // Every one of them is dropped by the server without ever being spoken to.
+    // Reading returns 0 bytes at EOF rather than hanging, which is the property:
+    // the connection is the server's to reclaim, not the peer's to hold.
+    let mut closed = 0usize;
+    for mut stream in silent {
+        let mut byte = [0u8; 1];
+        if let Ok(Ok(0)) =
+            tokio::time::timeout(Duration::from_secs(10), stream.read(&mut byte)).await
+        {
+            closed += 1;
+        }
+    }
+    assert_eq!(closed, 64, "the server held connections open indefinitely");
+
+    // And it is serving again.
+    let response = get(health, "/healthz").await;
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn the_health_listener_is_off_unless_asked_for() {
     let server = Server::start(base()).await.expect("the relay starts");
     assert!(server.health_addr().is_none());


### PR DESCRIPTION
Follow-up to #665, which merged while this was being written. It is the fourth finding of the codex adversarial review on the companion manifest PR (free2z/tuzi#1399) — the review noticing that a listener written for loopback had just been pointed at the cluster.

## The defect

#665 added a health-only listener that may bind off loopback, because the kubelet and the GCE health checker both dial the pod IP. That made a listener written for a loopback population reachable from **every pod in the cluster** — and `admin::answer` has a bound on request **bytes** with no bound on **time**, inside an accept loop that spawns a task per connection with no cap:

```rust
let Ok((stream, _peer)) = accepted else { continue; };
tokio::spawn(async move { let _ = answer(relay, scope, stream).await; });
```

```rust
let read = stream.read(&mut buffer).await?;   // no deadline
```

A peer that connects and never speaks holds a task, a 2 KiB buffer and a descriptor indefinitely. Enough of them grow this process until the memory limit kills it — and the deployment is `replicas: 1` on a ReadWriteOnce volume, so there is no second pod.

On loopback that population was "processes on this host" and none of it mattered. Off loopback it does.

## The fix

Two seconds per request, sixteen in flight.

`try_acquire`, not `acquire`: waiting would move the queue from the semaphore to the accept backlog and keep the connection open, which is the thing being bounded. Over the limit, the socket is closed before any read.

Two seconds is chosen to be **shorter than the probe's own `timeoutSeconds`** (3–5s in the manifests): the server should give up before the client does, so a stuck peer is the server's descriptor to reclaim rather than the probe's deadline to miss.

## Be precise about what this buys

The code says this where somebody will read it, because the overclaim is the tempting part:

> It bounds **resources** — descriptors, tasks, buffers — so a peer that opens connections and never speaks cannot grow this process without limit, and the listener recovers within `REQUEST_TIMEOUT` once the flood stops. It does **not** guarantee **availability**: a determined flood from inside the cluster can still occupy the permits and make a probe time out, and no in-process number fixes that — an attacker who can do this can also fill the accept backlog. The answer to a hostile pod on the cluster network is a NetworkPolicy on this port, not a bigger constant here.

The first version of the test asserted the availability property and **failed**, which is how that came to be written down instead of assumed.

## The test asserts exactly that and no more

64 silent peers are all disconnected on the server's own deadline — a read returning `0` at EOF rather than hanging, which is the property: the connection is the server's to reclaim, not the peer's to hold — and the listener is serving `/healthz` again afterwards.

```
test a_client_that_connects_and_says_nothing_is_disconnected_and_the_listener_recovers ... ok
```

## Gate

`check-rust-fmt.sh` (10 crates), `cargo test --locked -p f2z-relay --test health --test admin` (12 passed, 0 failed).

## Related

* free2z/tuzi#1399 — the manifest side, whose review found this.
* #669 — `/kt/v1/cosign` fail-open with no `witness_pk`, plus the global rate limiter that lets the same endpoint be starved.
* #671 — `Server::start`'s tasks are unsupervised: a panic in the protocol listener leaves a process that still answers `/healthz`, which is the *other* way this listener can lie now that the load balancer believes it.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku