### PR TITLE
fix(kt,relay): fail closed on cosigning and on a dead supervised task

### DIFF
--- a/docs/e2ee/KT.md
+++ b/docs/e2ee/KT.md
@@ -2136,6 +2136,48 @@ port, no certificate and no domain. The log then serves the cosignatures it
 collected. §7.5 states the conflict of interest that creates and what a client
 should do about it.
 
+> **Correction (2026-08-24) — a log that recognises no witnesses accepts no
+> cosignatures.** §9.5's `ERR_NOT_A_WITNESS` row calls the log's witness list
+> *"advisory only"*, and the first implementation read that as licence to skip
+> the check entirely when the list was empty. It was measured, not inferred:
+> four freshly generated keys, named nowhere in a real log's configuration, were
+> all accepted, `fsync`ed to the append-only journal, replayed at every startup,
+> and served inside every `/kt/v1/sth` bundle
+> ([#669](https://github.com/free2z/zuu/issues/669)).
+>
+> **A log MUST refuse a cosignature whose `witness_pk` is not one it has been
+> configured to recognise, and an empty configured set recognises nobody.** A
+> log MAY be run with no witnesses; what it may not do is collect cosignatures
+> from strangers on their behalf.
+>
+> "Advisory" was and remains true of the *client*: §8.3's threshold is applied
+> over the client's own configured set, and the log's list has no cryptographic
+> bearing on it. It was never true of the *log*, which is where the list decides
+> what gets an `fsync` on an append-only journal with no backup, what is held in
+> memory for the life of the process, and what number a client sees in a
+> tree-head bundle. A count inflated by anonymous keys is worse than a count of
+> zero, because
+> [`ARCHITECTURE.md` §9.3](./ARCHITECTURE.md#93-anti-equivocation-without-a-blockchain)
+> already requires the UI to stop displaying a reassuring witness count that
+> nothing independent stands behind — and this made the number reassuring and
+> unfounded at the same time.
+>
+> Two consequences worth stating, because both are properties an implementation
+> can be checked against:
+>
+> - **The bound is structural, not a tuned number.** Storage is idempotent per
+>   `witness_pk` and every accepted key is on the configured list, so one epoch
+>   holds at most as many cosignatures as there are configured witnesses. No
+>   input grows the journal without bound.
+> - **The configuration is re-applied at every startup.** A record already in
+>   the journal from a key the log does not recognise MUST NOT be replayed into
+>   what the log serves. The journal is append-only and keeps the evidence;
+>   recovery from a period of fail-open operation is a configuration change and
+>   a restart, never hand-editing a security-sensitive append-only file.
+>
+> `ERR_NOT_A_WITNESS`'s meaning is unchanged — it is still "from a key the log
+> does not recognise" — and a log with no configured witnesses recognises none.
+
 `/kt/v1/lookup` and `/kt/v1/history` are `POST` with a body rather than `GET`
 with the handle in the path, so that the queried handle does not land in the
 log's access logs, any intermediary's logs, or a `Referer` header by default.
@@ -2199,7 +2241,7 @@ is never reused** — [`WIRE.md` §10](./WIRE.md#10-error-codes)'s rule, for
 | 7 | `ERR_EPOCH_UNAVAILABLE` | The requested epoch or audit range is outside the served horizon (§9.3). |
 | 8 | `ERR_RANGE_TOO_WIDE` | An audit range above the published maximum. |
 | 9 | `ERR_RATE_LIMITED` | Retry later. |
-| 10 | `ERR_NOT_A_WITNESS` | `/kt/v1/cosign` from a key the log does not recognise. Advisory only — the log's opinion of who is a witness has **no bearing** on a client's configured set (§8.3). |
+| 10 | `ERR_NOT_A_WITNESS` | `/kt/v1/cosign` from a key the log does not recognise, **including every key when the log recognises none** (§9.2's correction). Advisory to the *client* — the log's opinion of who is a witness has **no bearing** on a client's configured set (§8.3) — and binding on the *log*. |
 | 11 | `ERR_INTERNAL` | Log fault. Carries no detail, ever. |
 
 **There is no "unknown handle" code**, deliberately: an unregistered handle is

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -546,6 +546,7 @@ name = "f2z-relay"
 version = "0.1.0"
 dependencies = [
  "f2z-codec",
+ "f2z-relay",
  "f2z-relay-proto",
  "f2z-relay-store",
  "f2z-relay-testkit",

--- a/rs/README.md
+++ b/rs/README.md
@@ -312,6 +312,23 @@ it is invoked unconditionally from `rs.yml` — not from the image workflow —
 because the image workflow's own `paths:` filter is one of the things it checks,
 and a drifted filter is a workflow that has silently stopped publishing.
 
+**A shallow probe is only safe over a supervised process** ([#671]). `/healthz`
+answers from process state and nothing else, deliberately — a probe that queried
+the store would fail during exactly the backpressure it exists to survive. That
+makes it a true statement about a relay only if the process cannot outlive the
+tasks that do its work, so `f2z-relay` supervises the protocol listener, the
+admin and health listeners and the expiry tick: if any of them ends before a
+shutdown was asked for, the relay closes its listeners, prints
+`the <task> stopped while the relay was running` to stderr and **exits 1**. A
+crash-looping pod is the correct outcome. At `replicas: 1` with
+`strategy: Recreate` that is a brief, visible outage, and the alternative — a
+`Ready` endpoint in the load balancer's rotation over a relay that serves nobody
+— is data loss under delete-on-ack rather than downtime: a sender that was told
+`accepted` and a relay that then loses the message have between them destroyed
+it.
+
+[#671]: https://github.com/free2z/zuu/issues/671
+
 ## Working in this tree
 
 ```bash

--- a/rs/crates/f2z-kt/src/api.rs
+++ b/rs/crates/f2z-kt/src/api.rs
@@ -207,6 +207,12 @@ async fn cosign(headers: HeaderMap, State(state): State<Arc<AppState>>, body: By
     if !state.limits.allow(Class::Cosign, (state.clock)()) {
         return error_response(&headers, &LogError::RateLimited);
     }
+    // A log with no configured witnesses recognises nobody (zuu#669), and that
+    // is a complete answer before the body is decoded — a cheap refusal for the
+    // one configuration in which every request on this endpoint is refused.
+    if !state.log.cosigning_enabled() {
+        return error_response(&headers, &LogError::NotAWitness);
+    }
     if body.len() > state.log.settings().max_request_bytes {
         return error_response(&headers, &LogError::Malformed);
     }

--- a/rs/crates/f2z-kt/src/config.rs
+++ b/rs/crates/f2z-kt/src/config.rs
@@ -16,7 +16,7 @@
 //! vrf_key_file = /etc/f2z-kt/vrf.key
 //! reset_authority_pk = <64 hex>
 //! authority_pk = <64 hex>        # repeatable; omit entirely for no-authority
-//! witness_pk = <64 hex>          # repeatable, advisory only
+//! witness_pk = <64 hex>          # repeatable; NO line means no cosigning
 //! ```
 //!
 //! Every numeric knob has a default drawn from `KT.md`'s proposed placeholders,
@@ -133,7 +133,9 @@ pub struct Config {
     pub authority_max_validity_ms: u64,
     /// The clock skew allowed an issuer, in milliseconds.
     pub authority_clock_skew_ms: u64,
-    /// Cosigning keys this log recognises. Advisory only (`KT.md` §9.5).
+    /// Cosigning keys this log recognises. **Empty means nobody**: a log with
+    /// no `witness_pk` line refuses every `/kt/v1/cosign` request rather than
+    /// accepting one from anybody (zuu#669), and says so at startup.
     pub witnesses: Vec<PublicKey>,
     /// The published numbers.
     pub settings: LogSettings,

--- a/rs/crates/f2z-kt/src/log.rs
+++ b/rs/crates/f2z-kt/src/log.rs
@@ -237,10 +237,15 @@ pub struct LogService {
     log_id: LogId,
     kt_policy: LogPolicy,
     authority: AuthorityConfig,
-    /// Cosigning keys this log recognises. Advisory only: `KT.md` §9.5 is
-    /// explicit that the log's opinion of who is a witness has **no bearing**
-    /// on a client's configured set, so this decides one thing — whether
-    /// `/kt/v1/cosign` answers `ERR_NOT_A_WITNESS` — and nothing else.
+    /// Cosigning keys this log recognises.
+    ///
+    /// **Empty means nobody** (zuu#669). `KT.md` §9.5 is right that this list
+    /// has no *cryptographic* bearing — a client applies its own threshold over
+    /// keys it trusts, and nothing here can change that. It has an
+    /// **operational** bearing, and treating "advisory" as "therefore
+    /// unenforced" is what made `/kt/v1/cosign` an unauthenticated,
+    /// permanently-journalled amplification vector on every log whose operator
+    /// had not written a `witness_pk` line.
     known_witnesses: Vec<PublicKey>,
     state: tokio::sync::Mutex<State>,
 }
@@ -412,13 +417,40 @@ impl LogService {
             enqueue_pending(&mut state, &admitted)?;
         }
 
+        // The journal is append-only and nothing rewrites it, so the replay is
+        // where a configuration change actually takes effect (zuu#669). A log
+        // that ran fail-open has records in here from keys it never recognised;
+        // serving them again after the operator fixed the configuration would
+        // make the fix cosmetic and leave "hand-edit a security-sensitive
+        // append-only file" as the only recovery. Configuration decides what
+        // the log serves, at every startup; the journal keeps the evidence of
+        // what it was sent.
+        let mut unrecognised = 0usize;
         for cosignature in journal.cosignatures {
+            if !self.recognises_witness(&cosignature.statement.witness_pk) {
+                unrecognised = unrecognised.saturating_add(1);
+                continue;
+            }
             let epoch = cosignature.statement.epoch;
-            state
-                .cosignatures
-                .entry(epoch)
-                .or_default()
-                .push(cosignature);
+            let held = state.cosignatures.entry(epoch).or_default();
+            // The live path is idempotent per witness; the replay is too, so a
+            // journal that somehow holds two records for one witness at one
+            // epoch cannot inflate the count a client applies a threshold to.
+            if held
+                .iter()
+                .any(|other| other.statement.witness_pk == cosignature.statement.witness_pk)
+            {
+                continue;
+            }
+            held.push(cosignature);
+        }
+        if unrecognised > 0 {
+            log::warn!(
+                "IGNORED {unrecognised} JOURNALLED COSIGNATURES from keys this log does not \
+                 recognise: they are not served and not counted. A log that was running with no \
+                 `witness_pk` configured accepted cosignatures from anyone (zuu#669); the records \
+                 stay in cosignatures.log as evidence and nothing needs to be edited by hand."
+            );
         }
 
         log::info!(
@@ -859,29 +891,77 @@ impl LogService {
         })
     }
 
+    /// Whether this log recognises `witness_pk` as a cosigner.
+    ///
+    /// A log with no configured witnesses recognises nobody, so this is `false`
+    /// for every key. See [`LogService::accept_cosignature`].
+    #[must_use]
+    pub fn recognises_witness(&self, witness_pk: &PublicKey) -> bool {
+        self.known_witnesses.contains(witness_pk)
+    }
+
+    /// Whether `/kt/v1/cosign` can accept anything at all.
+    ///
+    /// `false` on a log with no `witness_pk` configured, which is a complete
+    /// answer to the endpoint before a body is decoded.
+    #[must_use]
+    pub fn cosigning_enabled(&self) -> bool {
+        !self.known_witnesses.is_empty()
+    }
+
     /// **`POST /kt/v1/cosign`.** Accept a witness cosignature.
     ///
     /// Verified before it is stored — a cosignature the log cannot check is a
     /// cosignature the log would be publishing on a witness's behalf — and
     /// checked to cover a head this log actually signed.
     ///
+    /// # An unconfigured log accepts nothing (zuu#669)
+    ///
+    /// This check used to be skipped entirely when no `witness_pk` was
+    /// configured — "empty means everyone" — which made a public,
+    /// unauthenticated endpoint on a log with a perfectly ordinary
+    /// configuration accept a correctly self-signed cosignature from any key at
+    /// all, `fsync` it to an append-only journal with no backup, replay it at
+    /// every startup, and serve it inside every tree-head bundle. Four
+    /// unrelated keys were accepted by a real log that way.
+    ///
+    /// **Empty now means nobody.** The alternative — a numeric cap on what one
+    /// epoch may accumulate — bounds the disk but not the lie: a client that
+    /// counts cosignatures would still be handed a reassuring number produced
+    /// by strangers, and a reassuring number that means nothing is worse than
+    /// no cosignatures at all, which is at least true.
+    ///
+    /// A log legitimately run with no witnesses is not broken by this. It has
+    /// no witnesses, so there are no cosignatures for it to collect; what it
+    /// loses is the ability to collect *somebody else's*, and
+    /// [`crate::server::build`] says so in capitals at startup.
+    ///
+    /// # The bound is now structural
+    ///
+    /// Storage is idempotent per `witness_pk` and every accepted key must be on
+    /// the configured list, so one epoch can hold at most as many cosignatures
+    /// as there are configured witnesses. No input grows the journal without
+    /// bound, in either configuration, without a magic number to tune.
+    ///
     /// # Errors
     ///
-    /// [`LogError::Kt`] if it does not verify or does not cover a known head,
-    /// [`LogError::NotAWitness`] if the log does not recognise the key
-    /// (advisory only; §9.5), [`LogError::Storage`] if it could not be
-    /// journalled.
+    /// [`LogError::NotAWitness`] if the log does not recognise the key —
+    /// checked **first**, so an unrecognised key costs a set lookup rather than
+    /// a signature verification and an `fsync`. [`LogError::Kt`] if it does not
+    /// verify or does not cover a known head, [`LogError::Storage`] if it could
+    /// not be journalled.
     pub async fn accept_cosignature(&self, cosignature: &WitnessCosignature) -> Result<()> {
+        // Recognition first. `witness_pk` is inside the signed bytes (§7.2), so
+        // a claim to be a listed witness is refused here or refused by the
+        // signature check below — checking it first cannot admit anything, and
+        // it keeps a flood of valid-but-unrecognised cosignatures away from the
+        // verification and the journal.
+        if !self.recognises_witness(&cosignature.statement.witness_pk) {
+            return Err(LogError::NotAWitness);
+        }
         cosignature.verify().map_err(LogError::Kt)?;
         if cosignature.statement.log_id != self.log_id {
             return Err(LogError::Kt(KtError::WrongLog));
-        }
-        if !self.known_witnesses.is_empty()
-            && !self
-                .known_witnesses
-                .contains(&cosignature.statement.witness_pk)
-        {
-            return Err(LogError::NotAWitness);
         }
 
         let mut state = self.state.lock().await;

--- a/rs/crates/f2z-kt/src/main.rs
+++ b/rs/crates/f2z-kt/src/main.rs
@@ -157,6 +157,13 @@ fn check(args: &[String]) -> Result<(), String> {
         "handles          {}",
         state.log.authority().authorities().status()
     );
+    // zuu#669: an operator reading this needs to see that a log with no
+    // `witness_pk` collects nothing, because the previous behaviour — collecting
+    // from everyone — looked identical from the outside except that it was worse.
+    match config.witnesses.len() {
+        0 => println!("witnesses        NONE CONFIGURED — /kt/v1/cosign refuses every request"),
+        count => println!("witnesses        {count} configured"),
+    }
     Ok(())
 }
 

--- a/rs/crates/f2z-kt/src/server.rs
+++ b/rs/crates/f2z-kt/src/server.rs
@@ -59,6 +59,19 @@ pub async fn build(config: &Config) -> Result<Arc<AppState>> {
         );
     }
 
+    if config.witnesses.is_empty() {
+        // Loud, once, at startup, in the shape zuu#594's warning above uses.
+        // zuu#669: this configuration used to make `/kt/v1/cosign` accept a
+        // cosignature from **any** key, permanently. It now accepts none, and an
+        // operator who meant to collect cosignatures should find that out here
+        // rather than from a witness whose polls have been refused all week.
+        log::warn!(
+            "NO WITNESS KEYS CONFIGURED: /kt/v1/cosign will refuse every cosignature with \
+             ERR_NOT_A_WITNESS, and this log will serve zero cosignatures in every tree-head \
+             bundle. Set one `witness_pk` line per witness you actually run."
+        );
+    }
+
     let log = LogService::open(
         &config.data_dir,
         settings.clone(),

--- a/rs/crates/f2z-kt/src/testing.rs
+++ b/rs/crates/f2z-kt/src/testing.rs
@@ -506,7 +506,7 @@ impl Harness {
     ///
     /// If the log will not start, which is a bug in the fixture.
     pub async fn vouched(name: &str) -> Self {
-        Self::build(name, true).await
+        Self::build(name, true, Vec::new()).await
     }
 
     /// Stand up a log in the explicit no-authority mode (zuu#594).
@@ -515,10 +515,24 @@ impl Harness {
     ///
     /// If the log will not start.
     pub async fn unvouched(name: &str) -> Self {
-        Self::build(name, false).await
+        Self::build(name, false, Vec::new()).await
     }
 
-    async fn build(name: &str, vouched: bool) -> Self {
+    /// Stand up a log that **recognises** `witnesses` as cosigners.
+    ///
+    /// Separate from [`Harness::vouched`] on purpose: a log with no configured
+    /// witness keys accepts no cosignatures at all (zuu#669), so a fixture that
+    /// quietly configured one would hide the very rule that issue is about.
+    /// A test that wants a cosignature stored has to say whose.
+    ///
+    /// # Panics
+    ///
+    /// If the log will not start.
+    pub async fn vouched_with_witnesses(name: &str, witnesses: Vec<PublicKey>) -> Self {
+        Self::build(name, true, witnesses).await
+    }
+
+    async fn build(name: &str, vouched: bool, witnesses: Vec<PublicKey>) -> Self {
         let dir = temp_dir(name);
         let log_key = Key::from_byte(0xa1);
         let reset_authority = Key::from_byte(0xa2);
@@ -541,7 +555,7 @@ impl Harness {
 
         let signer = Arc::new(crate::signer::FileSigner::from_seed(&[0xa1; 32]));
         let vrf = crate::vrf::FileVrf::from_seed([0xb0; 32]).unwrap();
-        let log = crate::log::LogService::open(&dir, settings, signer, vrf, authority, Vec::new())
+        let log = crate::log::LogService::open(&dir, settings, signer, vrf, authority, witnesses)
             .await
             .unwrap();
 

--- a/rs/crates/f2z-kt/tests/cosign.rs
+++ b/rs/crates/f2z-kt/tests/cosign.rs
@@ -1,0 +1,351 @@
+//! **`/kt/v1/cosign` must fail closed** — zuu#669.
+//!
+//! A log that accepts a cosignature from anybody does not merely fail to add
+//! security. It **manufactures the appearance of it**: `/kt/v1/sth` hands every
+//! client a bundle with a reassuring number of cosignatures in it, and the
+//! number means nothing. Anti-equivocation is the one property cosigning
+//! exists to provide, and
+//! [`ARCHITECTURE.md` §9.3](../../../docs/e2ee/ARCHITECTURE.md) already says
+//! plainly that witnesses free2z operates are not independent witnesses — a
+//! count inflated by four strangers is strictly worse than a count of zero,
+//! because zero is true.
+//!
+//! The defect was measured, not theorised: four `f2z-witness` instances with
+//! four freshly generated keys, none of them named anywhere in the log's
+//! configuration, were all accepted by a real log, journalled with an `fsync`,
+//! and replayed into memory at every subsequent startup. The condition
+//!
+//! ```text
+//! if !self.known_witnesses.is_empty() && !self.known_witnesses.contains(...)
+//! ```
+//!
+//! never ran its second half, because `witness_pk` is optional and the shipped
+//! deployment had none.
+//!
+//! # Why these tests are written against the HTTP endpoint
+//!
+//! `/kt/v1/cosign` is public and unauthenticated. The rule is a property of
+//! **what a stranger with a socket can make the log store**, so the test is a
+//! request through the router rather than a call to a method — the same route
+//! the four witnesses took.
+//!
+//! Every assertion here is a rule that, before this file existed, could not
+//! fail. That is exactly how the defect survived review: a happy-path test with
+//! one configured witness passes identically on a log that accepts everyone.
+
+// An integration test is its own crate, so the workspace's denials of the
+// panicking families do not reach it. A `.unwrap()` here is a failing test.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use f2z_codec::Canonical as _;
+use f2z_codec::decode_canonical;
+use f2z_codec::types::PublicKey;
+use f2z_kt::FileSigner;
+use f2z_kt::api::AppState;
+use f2z_kt::ratelimit::RateLimiter;
+use f2z_kt::testing::{Harness, Key};
+use f2z_kt_core::api::ErrorBody;
+use f2z_kt_core::cosign::{WitnessCosignature, WitnessCosignatureTBS};
+use f2z_kt_core::sth::SignedTreeHead;
+use tower::ServiceExt as _;
+
+const NOW: u64 = 1_700_000_100_000;
+
+/// `ERR_NOT_A_WITNESS`, `KT.md` §9.5. Written as a literal: the point of that
+/// table is that a code's number never changes.
+const ERR_NOT_A_WITNESS: u16 = 10;
+
+/// A cosignature over `head`, signed by `key`.
+///
+/// Correctly formed in every way — the label, the version, the log id, the
+/// epoch, the size, the root and the signature all check out. The *only* thing
+/// wrong with it is whose key it is, which is the whole point: a log that
+/// refuses it for any other reason is not testing zuu#669.
+fn cosignature_over(head: &SignedTreeHead, key: &Key) -> WitnessCosignature {
+    let statement = WitnessCosignatureTBS {
+        label: WitnessCosignatureTBS::label_bytes().unwrap(),
+        kt_version: f2z_kt_core::KT_VERSION,
+        log_id: head.sth.log_id,
+        epoch: head.sth.epoch,
+        tree_size: head.sth.tree_size,
+        root_hash: head.sth.root_hash,
+        witness_pk: key.public,
+        observed_at_ms: NOW,
+    };
+    let signature = key.sign(&statement.signing_bytes().unwrap());
+    let cosignature = WitnessCosignature {
+        statement,
+        signature,
+    };
+    // The fixture is not the thing under test: if this ever fails, the test
+    // below would be asserting a refusal the log owes to a bad signature.
+    cosignature.verify().expect("the fixture is well formed");
+    assert!(cosignature.covers(head), "the fixture covers the head");
+    cosignature
+}
+
+async fn app_state(harness: &Harness) -> Arc<AppState> {
+    let signer = FileSigner::from_seed(&[0xa1; 32]);
+    Arc::new(AppState {
+        descriptor: f2z_kt::descriptor::sign_descriptor(
+            harness.log.settings(),
+            harness.log_id,
+            *harness.log.vrf_public_key(),
+            &signer,
+            NOW,
+        )
+        .unwrap(),
+        policy: f2z_kt::sign_policy(harness.log.authority(), harness.log_id, &signer, NOW).unwrap(),
+        log: Arc::clone(&harness.log),
+        limits: RateLimiter::defaults(),
+        clock: Arc::new(|| NOW),
+    })
+}
+
+/// `POST /kt/v1/cosign`, returning the status and the §9.5 code in the body.
+///
+/// `None` for the code on a `204`, which carries no body by design.
+async fn post_cosign(
+    state: &Arc<AppState>,
+    cosignature: &WitnessCosignature,
+) -> (StatusCode, Option<u16>) {
+    let body = cosignature.encode_canonical().unwrap();
+    let response = f2z_kt::api::router(Arc::clone(state))
+        .oneshot(
+            Request::post("/kt/v1/cosign")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 16)
+        .await
+        .unwrap();
+    let code = decode_canonical::<ErrorBody>(&bytes)
+        .ok()
+        .map(|body| body.into_value().code);
+    (status, code)
+}
+
+/// How many cosignatures the log serves for its latest head, which is what a
+/// client counts a threshold against.
+async fn served(harness: &Harness) -> usize {
+    harness
+        .log
+        .latest_bundle()
+        .await
+        .unwrap()
+        .cosignatures
+        .len()
+}
+
+/// The size of the append-only cosignature journal, in bytes.
+///
+/// Asserted separately from what the log serves because the two failures are
+/// different: serving a stranger's cosignature is this epoch's problem, and
+/// `fsync`ing it is every future startup's problem. §9.2's journal is
+/// append-only with no backup, on a `replicas: 1` ReadWriteOnce volume, and the
+/// documented recovery for junk in it is hand-editing a security-sensitive
+/// file.
+fn journal_bytes(harness: &Harness) -> u64 {
+    std::fs::metadata(harness.dir.join("cosignatures.log")).map_or(0, |meta| meta.len())
+}
+
+// ---------------------------------------------------------------------------
+// The defect.
+// ---------------------------------------------------------------------------
+
+/// **zuu#669.** With no `witness_pk` configured, four unrelated keys are
+/// refused — and nothing about them reaches memory or the journal.
+#[tokio::test]
+async fn a_log_with_no_configured_witnesses_refuses_every_cosignature() {
+    let harness = Harness::vouched("cosign-fail-open").await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let state = app_state(&harness).await;
+    let head = harness.log.latest_bundle().await.unwrap().head;
+
+    // Four unrelated keys, as in the reproduction on the issue. None of them is
+    // named anywhere in this log's configuration, because this log's
+    // configuration names no witness at all.
+    for seed in [0xd1_u8, 0xd2, 0xd3, 0xd4] {
+        let stranger = Key::from_byte(seed);
+        let cosignature = cosignature_over(&head, &stranger);
+        let (status, code) = post_cosign(&state, &cosignature).await;
+        assert_eq!(
+            (status, code),
+            (StatusCode::BAD_REQUEST, Some(ERR_NOT_A_WITNESS)),
+            "a log that recognises nobody must recognise nobody, key {seed:#x}"
+        );
+    }
+
+    assert_eq!(
+        served(&harness).await,
+        0,
+        "a client counting cosignatures on this log must count zero, which is the truth"
+    );
+    assert_eq!(
+        journal_bytes(&harness),
+        0,
+        "nothing a stranger sent was fsynced into the append-only journal"
+    );
+}
+
+/// The same rule where it is cheapest to get wrong: an empty configured list is
+/// **nobody**, not everybody, on the service as well as through the router.
+#[tokio::test]
+async fn an_empty_witness_list_is_nobody_not_everybody() {
+    let harness = Harness::vouched("cosign-empty-means-nobody").await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let head = harness.log.latest_bundle().await.unwrap().head;
+
+    let error = harness
+        .log
+        .accept_cosignature(&cosignature_over(&head, &Key::from_byte(0xd5)))
+        .await
+        .expect_err("an unrecognised key is refused");
+    assert_eq!(error.wire_code().code(), ERR_NOT_A_WITNESS);
+}
+
+// ---------------------------------------------------------------------------
+// The control: the fix must not break the configuration it exists to serve.
+// ---------------------------------------------------------------------------
+
+/// A configured witness is still accepted, still exactly once, and a stranger
+/// is still refused on the same log.
+///
+/// The second half is the bound the issue asked for and it needs no magic
+/// number: storage is idempotent per `witness_pk` and every accepted key must
+/// be on the configured list, so one epoch can accumulate at most as many
+/// cosignatures as there are configured witnesses. There is no longer any input
+/// that grows the journal without bound.
+#[tokio::test]
+async fn a_configured_witness_is_accepted_exactly_once_and_a_stranger_is_not() {
+    let witness = Key::from_byte(0xc1);
+    let stranger = Key::from_byte(0xc2);
+    let harness = Harness::vouched_with_witnesses("cosign-configured", vec![witness.public]).await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let state = app_state(&harness).await;
+    let head = harness.log.latest_bundle().await.unwrap().head;
+
+    let theirs = cosignature_over(&head, &witness);
+    assert_eq!(
+        post_cosign(&state, &theirs).await,
+        (StatusCode::NO_CONTENT, None),
+        "the configured witness is accepted"
+    );
+    assert_eq!(served(&harness).await, 1);
+    let after_first = journal_bytes(&harness);
+    assert!(after_first > 0, "an accepted cosignature is journalled");
+
+    // A retry after a timeout is ordinary and must not inflate the count a
+    // client applies a threshold to, nor grow the journal.
+    assert_eq!(
+        post_cosign(&state, &theirs).await,
+        (StatusCode::NO_CONTENT, None),
+        "a retry is idempotent"
+    );
+    assert_eq!(served(&harness).await, 1);
+    assert_eq!(journal_bytes(&harness), after_first);
+
+    let (status, code) = post_cosign(&state, &cosignature_over(&head, &stranger)).await;
+    assert_eq!(
+        (status, code),
+        (StatusCode::BAD_REQUEST, Some(ERR_NOT_A_WITNESS)),
+        "a key that is not on the list is refused on a log that has a list"
+    );
+    assert_eq!(served(&harness).await, 1);
+    assert_eq!(journal_bytes(&harness), after_first);
+}
+
+// ---------------------------------------------------------------------------
+// "every accepted record is permanent" — the other half of the issue's title.
+// ---------------------------------------------------------------------------
+
+/// A cosignature already in the journal from a key the log no longer recognises
+/// is **not replayed** into what the log serves.
+///
+/// Without this, the fix above would close the door and leave whatever came
+/// through it while it was open: the journal is `fsync`ed and append-only, it is
+/// replayed at every startup, and the issue's stated recovery — hand-editing a
+/// security-sensitive append-only file — is not a recovery anyone should be
+/// asked to perform. Configuration decides what the log serves, at every
+/// startup, and the journal keeps the evidence of what it was sent.
+#[tokio::test]
+async fn a_journalled_cosignature_from_an_unrecognised_key_is_not_served_after_a_restart() {
+    let kept = Key::from_byte(0xc1);
+    let dropped = Key::from_byte(0xc2);
+    let harness =
+        Harness::vouched_with_witnesses("cosign-replay", vec![kept.public, dropped.public]).await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let head = harness.log.latest_bundle().await.unwrap().head;
+    for key in [&kept, &dropped] {
+        harness
+            .log
+            .accept_cosignature(&cosignature_over(&head, key))
+            .await
+            .unwrap();
+    }
+    assert_eq!(
+        served(&harness).await,
+        2,
+        "both were configured, both stored"
+    );
+
+    // The operator removes one `witness_pk` line and restarts. Both records are
+    // still in the journal — it is append-only and nothing rewrites it.
+    let reopened = reopen(&harness, vec![kept.public]).await;
+    let bundle = reopened.latest_bundle().await.unwrap();
+    let keys: Vec<PublicKey> = bundle
+        .cosignatures
+        .as_slice()
+        .iter()
+        .map(|cosignature| cosignature.statement.witness_pk)
+        .collect();
+    assert_eq!(
+        keys,
+        vec![kept.public],
+        "the log serves what it is configured to recognise, not what it once accepted"
+    );
+
+    // And a restart with no `witness_pk` at all serves none of them.
+    let unconfigured = reopen(&harness, Vec::new()).await;
+    assert_eq!(
+        unconfigured
+            .latest_bundle()
+            .await
+            .unwrap()
+            .cosignatures
+            .len(),
+        0
+    );
+}
+
+/// Reopen the log at the same data directory with the same keys and a possibly
+/// different witness list.
+async fn reopen(harness: &Harness, witnesses: Vec<PublicKey>) -> f2z_kt::LogService {
+    let mut settings =
+        f2z_kt::LogSettings::defaults(harness.log_key.public, harness.reset_authority.public)
+            .unwrap();
+    settings.reset_cooldown_seconds = 60;
+    f2z_kt::LogService::open(
+        &harness.dir,
+        settings,
+        Arc::new(FileSigner::from_seed(&[0xa1; 32])),
+        f2z_kt::vrf::FileVrf::from_seed([0xb0; 32]).unwrap(),
+        harness.log.authority().clone(),
+        witnesses,
+    )
+    .await
+    .unwrap()
+}

--- a/rs/crates/f2z-relay/Cargo.toml
+++ b/rs/crates/f2z-relay/Cargo.toml
@@ -11,6 +11,15 @@ publish.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+# `Server::abort_task`, and nothing else. A feature rather than `#[cfg(test)]`
+# because the supervision test in `tests/` is its own crate and cannot see one,
+# and a feature rather than an unconditional method because a way to kill the
+# protocol listener has no business existing in the shipped binary. See
+# `server::Server::abort_task`.
+testing = []
+
 [dependencies]
 f2z-codec = { path = "../f2z-codec", version = "0.1.0" }
 f2z-relay-proto = { path = "../f2z-relay-proto", version = "0.1.0" }
@@ -26,4 +35,8 @@ toml = { version = "0.9", default-features = false, features = ["parse", "serde"
 
 [dev-dependencies]
 f2z-relay-testkit = { path = "../f2z-relay-testkit", version = "0.1.0" }
+# A crate's own integration tests do not see its `[features]` unless it depends
+# on itself. This is the supported way to say "build my `testing` feature for
+# `tests/`, and never for the binary" — the same shape `f2z-kt` uses.
+f2z-relay = { path = ".", version = "0.1.0", features = ["testing"] }
 tokio = { version = "1", features = ["test-util"] }

--- a/rs/crates/f2z-relay/src/main.rs
+++ b/rs/crates/f2z-relay/src/main.rs
@@ -11,7 +11,7 @@ use std::process::ExitCode;
 use f2z_relay::caps;
 use f2z_relay::cli::{self, Mode};
 use f2z_relay::config::Config;
-use f2z_relay::server::Server;
+use f2z_relay::server::{Server, Stopped};
 
 fn main() -> ExitCode {
     let invocation = match cli::parse(std::env::args().skip(1), std::env::vars()) {
@@ -135,12 +135,31 @@ fn run(config: Config) -> ExitCode {
             eprintln!("f2z-relay: health on http://{health}/healthz (no /metrics)");
         }
 
-        wait_for_signal().await;
-        // §6.4's NOTICE(2) goes out here, before the sockets close: a client
-        // that learns the relay is going away can reconnect elsewhere rather
-        // than treating a closed socket as a fault.
-        server.shutdown().await;
-        ExitCode::SUCCESS
+        // Not `wait_for_signal().await; server.shutdown().await;` — that leaves
+        // the join handles unobserved, which is zuu#671: a panicking protocol
+        // task ends silently and the process goes on answering `/healthz` with
+        // `200` while completing nothing for a single client. Every probe and
+        // the load balancer's health check stay green over a relay that cannot
+        // serve, and under delete-on-ack a relay that accepts and then loses is
+        // data loss rather than an outage.
+        //
+        // §6.4's NOTICE(2) goes out inside `run_until_stopped` on both paths,
+        // before the sockets close: a client that learns the relay is going away
+        // can reconnect elsewhere rather than treating a closed socket as a
+        // fault.
+        match server.run_until_stopped(wait_for_signal()).await {
+            Stopped::Requested => ExitCode::SUCCESS,
+            Stopped::TaskEnded(name) => {
+                // Non-zero, and loud. A crash-looping pod is the correct
+                // outcome: `replicas: 1` with `strategy: Recreate` makes it a
+                // brief, visible outage, and the alternative is a `Ready`
+                // endpoint in the load balancer's rotation that serves nobody.
+                eprintln!(
+                    "f2z-relay: the {name} stopped while the relay was running; this process                      cannot serve and is exiting"
+                );
+                ExitCode::FAILURE
+            }
+        }
     })
 }
 

--- a/rs/crates/f2z-relay/src/server.rs
+++ b/rs/crates/f2z-relay/src/server.rs
@@ -18,7 +18,28 @@
 //! Shutdown is a `watch` flag every task selects on, plus a `NOTICE(2)` to
 //! subscribed readers (§6.4) so a client learns the relay is going away rather
 //! than inferring it from a closed socket.
+//!
+//! # Every task started here is supervised (zuu#671)
+//!
+//! The tasks below are spawned detached, and a panic in one of them ends that
+//! task and nothing else. That produced the worst shape available: a process
+//! whose protocol listener had died, whose health listener was still answering
+//! `/healthz` with `200`, and which therefore passed the startup, readiness and
+//! liveness probes *and* the load balancer's health check while completing
+//! nothing for a single client. Under delete-on-ack that is not a degraded
+//! service — a sender that is told `accepted` by a relay that then loses the
+//! message has had data destroyed between them.
+//!
+//! So [`Server::run_until_stopped`] selects over the join handles alongside the
+//! caller's signal, and **a supervised task that ends before shutdown was asked
+//! for takes the whole process down**. The deployment is `replicas: 1` with
+//! `strategy: Recreate`, so this is a brief outage rather than a silent wrong
+//! answer: a crash-looping pod fails its probes, is visibly not `Ready`, and
+//! leaves the load balancer with no endpoint to send traffic to. That is the
+//! correct trade under delete-on-ack, and it is the one the health-probe work
+//! of #665 assumed was already true.
 
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -76,6 +97,22 @@ impl std::fmt::Display for StartError {
 
 impl std::error::Error for StartError {}
 
+/// The protocol listener — the only task that serves clients (§2.1).
+pub const PROTOCOL_TASK: &str = "protocol listener";
+/// The loopback-only operator surface: `/healthz` and `/metrics`.
+pub const ADMIN_TASK: &str = "admin listener";
+/// The health-only surface the kubelet and the load balancer probe (#665).
+pub const HEALTH_TASK: &str = "health listener";
+/// §7.7's TTL sweep and §5.5's seen-set aging.
+pub const EXPIRY_TASK: &str = "queue expiry tick";
+
+/// How long a failing relay is given to close its sockets politely.
+///
+/// It is a bound and not a promise: the point of the failure path is that the
+/// process stops, and a task that will not finish must not be able to keep the
+/// listener open by refusing to.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
 /// A running relay.
 pub struct Server {
     relay: Arc<Relay>,
@@ -83,7 +120,31 @@ pub struct Server {
     admin_addr: Option<std::net::SocketAddr>,
     health_addr: Option<std::net::SocketAddr>,
     shutdown: watch::Sender<bool>,
-    tasks: Vec<tokio::task::JoinHandle<()>>,
+    tasks: Vec<Supervised>,
+}
+
+/// A task the relay cannot serve without, and the name an operator sees when it
+/// is the one that ended.
+struct Supervised {
+    name: &'static str,
+    /// `None` once it has been observed to finish, so it is never polled twice.
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+/// Why a relay stopped serving.
+///
+/// Deliberately **not** `#[non_exhaustive]`: the binary is a separate crate, so
+/// that attribute would force a wildcard arm in `main`, and a wildcard arm is
+/// how a future stop reason silently becomes a zero exit. A new variant here
+/// should break every caller until each has decided what it means.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Stopped {
+    /// The caller's signal fired. An ordinary shutdown; exit zero.
+    Requested,
+    /// A supervised task ended before shutdown was asked for — it panicked, or
+    /// it was cancelled. The relay cannot do its job and the process must not
+    /// go on passing health checks; exit non-zero.
+    TaskEnded(&'static str),
 }
 
 impl std::fmt::Debug for Server {
@@ -228,32 +289,50 @@ impl Server {
 
         let (shutdown, watcher) = watch::channel(false);
         let mut tasks = Vec::with_capacity(4);
-        tasks.push(tokio::spawn(crate::listener::serve(
-            Arc::clone(&relay),
-            listener,
-            acceptor,
-            watcher.clone(),
-        )));
-        if let Some(admin_listener) = admin_listener {
-            tasks.push(tokio::spawn(crate::admin::serve(
+        let mut supervise = |name, handle| {
+            tasks.push(Supervised {
+                name,
+                handle: Some(handle),
+            })
+        };
+        supervise(
+            PROTOCOL_TASK,
+            tokio::spawn(crate::listener::serve(
                 Arc::clone(&relay),
-                admin_listener,
-                crate::admin::Scope::Operator,
+                listener,
+                acceptor,
                 watcher.clone(),
-            )));
+            )),
+        );
+        if let Some(admin_listener) = admin_listener {
+            supervise(
+                ADMIN_TASK,
+                tokio::spawn(crate::admin::serve(
+                    Arc::clone(&relay),
+                    admin_listener,
+                    crate::admin::Scope::Operator,
+                    watcher.clone(),
+                )),
+            );
         }
         if let Some(health_listener) = health_listener {
-            tasks.push(tokio::spawn(crate::admin::serve(
-                Arc::clone(&relay),
-                health_listener,
-                crate::admin::Scope::HealthOnly,
-                watcher.clone(),
-            )));
+            supervise(
+                HEALTH_TASK,
+                tokio::spawn(crate::admin::serve(
+                    Arc::clone(&relay),
+                    health_listener,
+                    crate::admin::Scope::HealthOnly,
+                    watcher.clone(),
+                )),
+            );
         }
-        tasks.push(tokio::spawn(crate::expiry::run(
-            Arc::clone(&relay),
-            watcher,
-        )));
+        // Supervised for a correctness reason rather than an availability one:
+        // §7.7's TTLs stop being enforced the moment this task is gone, and
+        // nothing a client can observe says so.
+        supervise(
+            EXPIRY_TASK,
+            tokio::spawn(crate::expiry::run(Arc::clone(&relay), watcher)),
+        );
 
         crate::log_info!("relay listening", "port" = protocol_addr.port());
         Ok(Self {
@@ -305,6 +384,88 @@ impl Server {
         )
     }
 
+    /// Serve until `signal` fires **or a supervised task ends**, then stop.
+    ///
+    /// This is the whole of zuu#671's fix and it is deliberately the only
+    /// supported way to run a relay: `Server::start` followed by an `await` on
+    /// a signal leaves the join handles unobserved, and an unobserved task that
+    /// panics is a relay that answers `/healthz` with `200` and serves nobody.
+    ///
+    /// Either way the listeners are closed before this returns — bounded by
+    /// [`SHUTDOWN_GRACE`], because on the failure path a wedged task must not be
+    /// able to hold the protocol port open. A [`Stopped::TaskEnded`] result is
+    /// the caller's instruction to exit **non-zero**: under `replicas: 1` and
+    /// `strategy: Recreate` a crash-loop is a short, visible outage, and the
+    /// alternative is a `Ready` pod in the load balancer's rotation that
+    /// silently drops what senders were told was accepted.
+    pub async fn run_until_stopped(mut self, signal: impl Future<Output = ()>) -> Stopped {
+        let stopped = {
+            let mut signal = core::pin::pin!(signal);
+            tokio::select! {
+                biased;
+                name = self.supervise() => Stopped::TaskEnded(name),
+                () = &mut signal => Stopped::Requested,
+            }
+        };
+        if matches!(stopped, Stopped::TaskEnded(_)) {
+            // The name is not in this line on purpose: `log::line` takes a
+            // literal message and numeric fields only, which is what keeps
+            // payloads, addresses and keys out of the operator log. `main`
+            // prints the name to stderr, where an operator reads a fatal.
+            crate::log_error!("a supervised task ended; stopping the relay");
+        }
+        if tokio::time::timeout(SHUTDOWN_GRACE, self.shutdown())
+            .await
+            .is_err()
+        {
+            crate::log_error!("shutdown did not finish in time; exiting anyway");
+        }
+        stopped
+    }
+
+    /// Resolve when any supervised task ends. Pending while all are alive.
+    ///
+    /// Each handle is polled at most to completion once — a `JoinHandle` polled
+    /// after it has finished panics, and this runs inside a `select!` that may
+    /// poll it many times.
+    async fn supervise(&mut self) -> &'static str {
+        let tasks = &mut self.tasks;
+        core::future::poll_fn(move |cx| {
+            for task in tasks.iter_mut() {
+                let Some(handle) = task.handle.as_mut() else {
+                    continue;
+                };
+                if core::pin::Pin::new(handle).poll(cx).is_ready() {
+                    task.handle = None;
+                    return core::task::Poll::Ready(task.name);
+                }
+            }
+            core::task::Poll::Pending
+        })
+        .await
+    }
+
+    /// Abort a supervised task by name, so that a test can produce the failure
+    /// this supervision exists for. Returns whether one was found.
+    ///
+    /// There is no other way to write that test. The failure it stands in for
+    /// is a **panic**, which comes from a bug rather than from an input, and a
+    /// fault-injection hook inside the shipped listener would be a far worse
+    /// thing to carry than a method behind a feature that never reaches the
+    /// binary. An aborted task and a panicked one are the same shape here:
+    /// the handle completes, and nothing else in the process notices.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn abort_task(&mut self, name: &str) -> bool {
+        self.tasks
+            .iter()
+            .find(|task| task.name == name)
+            .and_then(|task| task.handle.as_ref())
+            .is_some_and(|handle| {
+                handle.abort();
+                true
+            })
+    }
+
     /// Stop accepting, tell subscribed readers, and wait for the tasks.
     ///
     /// §6.4's `NOTICE(2)` is sent first: a client that learns the relay is
@@ -321,7 +482,9 @@ impl Server {
         tokio::time::sleep(Duration::from_millis(50)).await;
         let _ = self.shutdown.send(true);
         for task in self.tasks {
-            let _ = task.await;
+            if let Some(handle) = task.handle {
+                let _ = handle.await;
+            }
         }
         crate::log_info!("relay stopped");
     }

--- a/rs/crates/f2z-relay/tests/supervision.rs
+++ b/rs/crates/f2z-relay/tests/supervision.rs
@@ -1,0 +1,226 @@
+//! **A task the relay cannot serve without must take the process with it** —
+//! zuu#671.
+//!
+//! `Server::start` spawns the protocol listener, the health listener and the
+//! expiry tick as detached tasks. Nothing observed their join handles, so a
+//! **panic** in one of them ended that task silently and left the rest of the
+//! process running. For the protocol listener that is the worst shape
+//! available:
+//!
+//! * `/healthz` answers from process state only — deliberately, because a probe
+//!   that queried the store would fail during exactly the backpressure it exists
+//!   to survive — so the startup, readiness and liveness probes all pass;
+//! * the GCE health check passes too, so the load balancer keeps the NEG
+//!   endpoint in rotation;
+//! * and no new client can be served — see the measurement below for the exact
+//!   shape of that, which is sharper than the issue's description.
+//!
+//! Every availability signal is green over a relay that cannot serve a single
+//! client, at `replicas: 1`, with no second pod to compare against. Under
+//! delete-on-ack that is not a degraded service: a sender that was told
+//! `accepted` and a relay that then loses the message have between them
+//! destroyed it.
+//!
+//! # Measured while writing these tests, and worth recording
+//!
+//! The issue describes the surviving process as one that *"accepts TCP and
+//! completes nothing"*. What was measured is sharper: ending the protocol task
+//! drops the future that owns the `TcpListener`, so the protocol port stops
+//! accepting immediately. **The health listener is the part that keeps lying.**
+//! With supervision removed, `/healthz` still answers `HTTP/1.1 200 OK` after
+//! the protocol task is gone — so the pod stays `Ready`, the NEG endpoint stays
+//! in rotation, and the load balancer goes on sending clients to a process whose
+//! only client-facing port is refusing connections. Connections accepted before
+//! the failure are handled by their own spawned tasks and do carry on, which is
+//! the "completes nothing" observation from the other side.
+//!
+//! That is why the assertion each test below turns on is that **the health
+//! surface is gone**, not merely that the protocol port is: the second is true
+//! with or without the fix, and a test that only checked it would pass on the
+//! defect.
+//!
+//! # These tests drive real listeners on purpose
+//!
+//! An in-process assertion that a flag flipped would prove nothing about the
+//! thing that actually failed — a probe surface that was still answering `200`.
+//! So each test connects to the bound protocol and health addresses **before**
+//! killing a task, and then asserts that connecting to them is refused
+//! afterwards. That is the property the kubelet, the load balancer and a client
+//! all observe, and it is the one a flag cannot stand in for.
+//!
+//! The failure is injected with [`Server::abort_task`] because the real cause is
+//! a panic, which comes from a bug rather than from an input: there is no
+//! request that makes `listener::serve` panic on demand, and a fault-injection
+//! hook inside the shipped listener would be a worse thing to carry. An aborted
+//! task and a panicked one are the same shape to the supervisor — the handle
+//! completes and nothing else in the process notices.
+
+// An integration test is its own crate, so the workspace's denials of the
+// panicking families do not reach it. A `.unwrap()` here is a failing test.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use f2z_relay::config::Config;
+use f2z_relay::server::{EXPIRY_TASK, HEALTH_TASK, PROTOCOL_TASK, Server, Stopped};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+/// A relay that binds everything on loopback, with nothing durable behind it.
+fn base() -> Config {
+    let mut config = Config::default();
+    config.listen.address = "127.0.0.1:0".to_owned();
+    config.admin.address = "127.0.0.1:0".to_owned();
+    config.health.enabled = true;
+    config.health.address = "127.0.0.1:0".to_owned();
+    config.store.backend = "memory".to_owned();
+    config.identity.seed = "5e".repeat(32);
+    config.antiabuse.per_source_limits = false;
+    config.queues.expiry_tick_seconds = 3_600;
+    config
+}
+
+/// Assert that a TCP connection is accepted right now.
+async fn accepts(addr: SocketAddr, what: &str) {
+    tokio::net::TcpStream::connect(addr)
+        .await
+        .unwrap_or_else(|error| panic!("the {what} accepts before the failure: {error}"));
+}
+
+/// `GET /healthz`, which is what every probe and the load balancer do.
+async fn healthz(addr: SocketAddr) -> String {
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    stream
+        .write_all(b"GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .await
+        .unwrap();
+    let mut response = String::new();
+    let _ =
+        tokio::time::timeout(Duration::from_secs(5), stream.read_to_string(&mut response)).await;
+    response
+}
+
+/// Assert that connecting is refused, allowing a moment for the socket to close.
+///
+/// A closed listener answers with a reset rather than a timeout, so this
+/// converges immediately in practice; the loop is here so that a slow runner
+/// reports the real failure rather than a scheduling artefact.
+async fn refuses(addr: SocketAddr, what: &str) {
+    for _ in 0..100u32 {
+        match tokio::time::timeout(
+            Duration::from_millis(200),
+            tokio::net::TcpStream::connect(addr),
+        )
+        .await
+        {
+            Ok(Err(_)) => return,
+            _ => tokio::time::sleep(Duration::from_millis(20)).await,
+        }
+    }
+    panic!("the {what} at {addr} is still accepting connections");
+}
+
+/// **zuu#671.** A dead protocol task takes the whole process down — including
+/// the health listener that would otherwise keep the pod `Ready`.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_dead_protocol_task_stops_the_process_instead_of_staying_ready() {
+    let mut server = Server::start(base()).await.expect("the relay starts");
+    let protocol = server.protocol_addr();
+    let health = server.health_addr().expect("the health listener is bound");
+
+    accepts(protocol, "protocol listener").await;
+    assert!(
+        healthz(health).await.starts_with("HTTP/1.1 200"),
+        "the probe surface is green before the failure"
+    );
+
+    assert!(server.abort_task(PROTOCOL_TASK), "the task is supervised");
+
+    // The signal never fires: this is the case where nobody asked the relay to
+    // stop and it must stop anyway.
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.run_until_stopped(std::future::pending()),
+    )
+    .await
+    .expect("supervision notices a dead task without waiting for a signal");
+    assert_eq!(stopped, Stopped::TaskEnded(PROTOCOL_TASK));
+
+    // The properties an operator, a kubelet and a client actually observe.
+    // The health surface is the load-bearing one: without the fix it answers
+    // `200` here, which is the whole defect — a `Ready` pod in the load
+    // balancer's rotation over a relay that cannot serve.
+    refuses(health, "health listener").await;
+    refuses(protocol, "protocol listener").await;
+}
+
+/// The expiry tick is supervised for a **correctness** reason, not an
+/// availability one: §7.7's TTLs stop being enforced the moment it is gone, and
+/// nothing a client can see says so.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_dead_expiry_tick_stops_the_process_too() {
+    let mut server = Server::start(base()).await.expect("the relay starts");
+    let protocol = server.protocol_addr();
+    let health = server.health_addr().expect("the health listener is bound");
+    accepts(protocol, "protocol listener").await;
+
+    assert!(server.abort_task(EXPIRY_TASK), "the tick is supervised");
+
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.run_until_stopped(std::future::pending()),
+    )
+    .await
+    .expect("supervision notices the tick");
+    assert_eq!(stopped, Stopped::TaskEnded(EXPIRY_TASK));
+
+    refuses(protocol, "protocol listener").await;
+    refuses(health, "health listener").await;
+}
+
+/// The listener a probe reaches is supervised as well: a relay whose health
+/// surface has died is unreachable to the kubelet, which would restart it — the
+/// process should not wait to be killed to stop serving.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_dead_health_listener_stops_the_process() {
+    let mut server = Server::start(base()).await.expect("the relay starts");
+    let protocol = server.protocol_addr();
+
+    assert!(server.abort_task(HEALTH_TASK), "the listener is supervised");
+
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.run_until_stopped(std::future::pending()),
+    )
+    .await
+    .expect("supervision notices the health listener");
+    assert_eq!(stopped, Stopped::TaskEnded(HEALTH_TASK));
+    refuses(protocol, "protocol listener").await;
+}
+
+/// The control: an ordinary signal is still an ordinary, zero-exit shutdown, and
+/// it is **not** reported as a task failure.
+///
+/// Without this, a supervisor that reported every stop as a failure would pass
+/// the three tests above and crash-loop every deliberate restart.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_requested_shutdown_is_not_a_failure() {
+    let server = Server::start(base()).await.expect("the relay starts");
+    let protocol = server.protocol_addr();
+    accepts(protocol, "protocol listener").await;
+
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.run_until_stopped(std::future::ready(())),
+    )
+    .await
+    .expect("a signalled shutdown finishes");
+    assert_eq!(stopped, Stopped::Requested);
+    refuses(protocol, "protocol listener").await;
+}

--- a/rs/crates/f2z-witness/tests/acceptance.rs
+++ b/rs/crates/f2z-witness/tests/acceptance.rs
@@ -41,7 +41,7 @@ use std::sync::{Arc, Mutex};
 
 use f2z_codec::Canonical as _;
 use f2z_kt::LogService;
-use f2z_kt::testing::{EntryBuilder, Harness, Identity};
+use f2z_kt::testing::{EntryBuilder, Harness, Identity, Key};
 use f2z_kt_core::api::TreeHeadBundle;
 use f2z_kt_core::types::Handle;
 use f2z_kt_core::{ConfiguredWitness, FaultKind, WitnessSet, verify_threshold};
@@ -49,6 +49,19 @@ use f2z_witness::witness::{Outcome, Settings, Witness};
 use f2z_witness::{Transport, WitnessError};
 
 const NOW: u64 = 1_700_000_100_000;
+
+/// The seed every witness in this file is built from.
+///
+/// Named rather than repeated because the **log** has to be configured with the
+/// matching public key: a log with no `witness_pk` accepts no cosignatures at
+/// all (zuu#669), so a fixture that stood up a log without naming its witness
+/// would be testing the refusal path and calling it a happy path.
+const WITNESS_SEED: u8 = 0xc1;
+
+/// A log that recognises this file's witness.
+fn log_for(name: &str) -> impl std::future::Future<Output = Harness> + use<'_> {
+    Harness::vouched_with_witnesses(name, vec![Key::from_byte(WITNESS_SEED).public])
+}
 
 /// A transport that reaches a real [`LogService`] in this process.
 ///
@@ -138,7 +151,7 @@ fn witness_for(harness: &Harness, transport: Box<dyn Transport>, name: &str) -> 
             evidence_dir: dir.join("evidence"),
             max_audit_span: 64,
         },
-        &[0xc1; 32],
+        &[WITNESS_SEED; 32],
         transport,
     )
     .unwrap()
@@ -168,7 +181,7 @@ fn register(runtime: &tokio::runtime::Runtime, harness: &Harness, handle: &str, 
 #[test]
 fn a_witness_verifies_real_proofs_and_the_log_serves_its_cosignature() {
     let setup = tokio::runtime::Runtime::new().unwrap();
-    let harness = setup.block_on(Harness::vouched("accept-happy"));
+    let harness = setup.block_on(log_for("accept-happy"));
     setup.block_on(harness.log.publish_epoch(NOW)).unwrap();
 
     let transport = Arc::new(DirectTransport::new(Arc::clone(&harness.log)));
@@ -260,8 +273,8 @@ fn a_witness_verifies_real_proofs_and_the_log_serves_its_cosignature() {
 /// bytes, but a server that has committed to two different roots for one epoch
 /// and shows each party one of them, with a perfectly valid signature on both.
 fn equivocating_pair(setup: &tokio::runtime::Runtime, name: &str) -> (Harness, Harness) {
-    let left = setup.block_on(Harness::vouched(&format!("{name}-left")));
-    let right = setup.block_on(Harness::vouched(&format!("{name}-right")));
+    let left = setup.block_on(log_for(&format!("{name}-left")));
+    let right = setup.block_on(log_for(&format!("{name}-right")));
     // `Harness` derives both logs from the same fixed seeds, so they share a
     // `log_id`, a signing key and a VRF key — and differ only in what they
     // published.


### PR DESCRIPTION
Two fail-open defects in shipped servers. Both are rules that **could not fail**
before this PR — which is exactly how both survived review — so each fix lands
with the test that fails without it, and each test was watched fail on unfixed
code before the fix was written.

Closes #669
Closes #671

---

## #669 — `/kt/v1/cosign` accepted anyone's cosignature

`accept_cosignature` short-circuited the witness check when the configured list
was empty, so a public unauthenticated endpoint accepted a correctly self-signed
cosignature from **any** key, `fsync`ed it to an append-only journal with no
backup, replayed it at every startup, and served it inside every
`/kt/v1/sth` bundle.

### The decision: empty means **nobody**, not everybody

The issue proposed a per-epoch cap instead, on the grounds that a semantic flip
would break a log legitimately run with no configured witnesses. It does not: a
log with no witnesses has no cosignatures to collect. What it loses is the
ability to collect *somebody else's*.

And a cap bounds the disk without touching the lie. A client applying a
threshold would still be handed a reassuring number produced by strangers, and
`ARCHITECTURE.md` §9.3 already requires the UI to stop displaying a witness count
that nothing independent stands behind — *"witnesses we operate are not
independent witnesses… the UI must say so rather than display a reassuring
witness count."* A count inflated by anonymous keys is strictly worse than zero,
because zero is true. Refusing is the only answer that leaves the number
meaning what it says.

**The bound the issue asked for now falls out structurally**, with no magic
number to tune: storage is idempotent per `witness_pk` and every accepted key
must be on the configured list, so one epoch holds at most as many cosignatures
as there are configured witnesses. There is no input that grows the journal
without bound in either configuration.

### Also in this fix

- **Recognition is checked first** — before the signature verification and
  before anything touches the lock or the journal. `witness_pk` is inside the
  signed bytes, so checking membership first cannot admit anything; it makes an
  unrecognised key cost a set lookup rather than an Ed25519 verification and an
  `fsync`. (The starvation comment on #669 asked for a cheaper rejection path;
  this is that half. The **per-source bucket** half is deliberately *not* here —
  `ratelimit.rs` argues at length that this process cannot key on client
  identity because it sits behind a TLS terminator and the only identity
  available is spoofable. A reserved per-witness budget keyed on a *proved*
  identity is a real design with real trade-offs and it deserves its own issue
  rather than a rider on a fail-closed fix.)
- **The replay applies the configured list.** The journal is append-only and
  nothing rewrites it, so without this the fix would be cosmetic for any log
  that already ran fail-open. Recovery is now a configuration change and a
  restart; the issue's stated recovery — hand-editing a security-sensitive
  append-only file — is no longer required, and the records stay as evidence.
  Replay also dedupes per `(epoch, witness_pk)`, so it is exactly as strict as
  the live path.
- **Loud when unconfigured.** `NO WITNESS KEYS CONFIGURED: …` at startup, in the
  shape of zuu#594's no-authority warning, and a `witnesses  NONE CONFIGURED`
  line in `f2z-kt check`. `IGNORED n JOURNALLED COSIGNATURES …` when a replay
  drops records.
- **Spec.** `KT.md` §9.2 carries a dated correction in §4.9's style, and §9.5's
  `ERR_NOT_A_WITNESS` row now separates *advisory to the client* (still true,
  §8.3) from *binding on the log* (which it always was). The code's meaning is
  unchanged: "from a key the log does not recognise", and a log with no
  configured witnesses recognises none.

### The test, and the evidence it can fail

`rs/crates/f2z-kt/tests/cosign.rs`, driven through the router rather than the
service, because the rule is about what a stranger with a socket can make the log
store. On **unfixed** code, with only the test fixtures added:

```
running 4 tests
test an_empty_witness_list_is_nobody_not_everybody ... FAILED
test a_log_with_no_configured_witnesses_refuses_every_cosignature ... FAILED
test a_configured_witness_is_accepted_exactly_once_and_a_stranger_is_not ... ok
test a_journalled_cosignature_from_an_unrecognised_key_is_not_served_after_a_restart ... FAILED

---- a_log_with_no_configured_witnesses_refuses_every_cosignature stdout ----
assertion `left == right` failed: a log that recognises nobody must recognise nobody, key 0xd1
  left: (204, None)
 right: (400, Some(10))

---- a_journalled_cosignature_from_an_unrecognised_key_is_not_served_after_a_restart stdout ----
assertion `left == right` failed: the log serves what it is configured to recognise, not what it once accepted
  left: [PublicKey(<redacted>), PublicKey(<redacted>)]
 right: [PublicKey(<redacted>)]

test result: FAILED. 1 passed; 3 failed
```

`left: (204, None)` is the defect itself: an unrelated key's cosignature
**accepted**, exactly as the four `f2z-witness` instances on the issue were. The
one test that passed before the fix is the control — a configured witness is
still accepted, still exactly once, and a stranger on the same log is still
refused — which is what stops this from being a fix that simply breaks cosigning.

`f2z-witness`'s acceptance test now has to name the witness key in the log's
configuration, which is the semantic change made visible in the diff.

---

## #671 — a panicking task left a process that still passed every probe

`Server::start` spawned the protocol listener, the admin and health listeners and
the expiry tick detached, and nothing observed their join handles.

**The decision: the process goes down.** Not a deeper probe — that trades this
for the failure mode the shallow probe was chosen to avoid, and the deployment
repo has a `probe-path-is-root` kube-linter rule because of an outage caused by a
probe on an expensive path. `Server::run_until_stopped` selects over the join
handles alongside the caller's signal; a task that ends before shutdown was asked
for closes every listener and returns `Stopped::TaskEnded(name)`, and `main`
exits non-zero.

**The deployment interaction, stated:** the relay is `replicas: 1` with
`strategy: Recreate`, so terminating is a brief, *visible* outage — a
crash-looping pod fails its probes, is not `Ready`, and leaves the load balancer
with no endpoint. The alternative is a `Ready` endpoint in rotation over a relay
that serves nobody, and under delete-on-ack that is not downtime but **data
loss**: a sender that was told `accepted` and a relay that then loses the message
have between them destroyed it. The brief outage is the correct trade.

Shutdown on the failure path is bounded (5 s) so a wedged task cannot hold the
protocol port open, and the expiry tick is supervised for a correctness reason
rather than an availability one — §7.7's TTLs stop being enforced the moment it
is gone.

`Stopped` is deliberately **not** `#[non_exhaustive]`: the binary is a separate
crate, so that attribute would force a wildcard arm in `main`, and a wildcard arm
is how a future stop reason silently becomes a zero exit.

### Sharper than the issue, and measured

The issue describes a process that *"accepts TCP and completes nothing"*. What
was measured while writing the test: ending the protocol task drops the future
that owns the `TcpListener`, so the protocol port stops accepting immediately.
**It is the health listener that keeps lying** — with supervision removed,
`/healthz` still answers `HTTP/1.1 200 OK` after the protocol task is gone, so
the pod stays `Ready`, the NEG endpoint stays in rotation, and the load balancer
keeps sending clients to a process whose only client-facing port is refusing
them. (Connections accepted before the failure are handled by their own spawned
tasks and do carry on, which is "completes nothing" seen from the other side.)

So the tests turn on **the health surface going away**, not on the protocol port
closing — the latter is true with or without the fix, and a test that checked
only that would pass on the defect.

### The test, and the evidence it can fail

`rs/crates/f2z-relay/tests/supervision.rs`, driven through real listeners: each
test connects to the bound protocol and health addresses before killing a task
and asserts they refuse afterwards. The failure is injected with
`Server::abort_task`, behind a `testing` feature that never reaches the binary,
because the real cause is a panic — there is no request that makes
`listener::serve` panic on demand, and a fault-injection hook inside the shipped
listener would be a far worse thing to carry. An aborted task and a panicked one
are the same shape to the supervisor: the handle completes and nothing else
notices.

With supervision neutered to the pre-fix behaviour (nothing observes the
handles):

```
running 4 tests
test a_requested_shutdown_is_not_a_failure ... ok
test a_dead_health_listener_stops_the_process ... FAILED
test a_dead_protocol_task_stops_the_process_instead_of_staying_ready ... FAILED
test a_dead_expiry_tick_stops_the_process_too ... FAILED

---- a_dead_protocol_task_stops_the_process_instead_of_staying_ready stdout ----
supervision notices a dead task without waiting for a signal: Elapsed(())

test result: FAILED. 1 passed; 3 failed; finished in 10.02s
```

and a throwaway probe in the same neutered tree printed the defect directly:

```
NEGATIVE CONTROL: after the protocol task died, /healthz said: Some("HTTP/1.1 200 OK")
```

The one test that passes both before and after is the control: an ordinary
signalled shutdown is still `Stopped::Requested` and still exits zero. Without
it, a supervisor that called every stop a failure would pass the other three and
crash-loop every deliberate restart.

---

## Scope

- `#![forbid(unsafe_code)]` unchanged; AGPL/permissive boundary unchanged
  (`f2z-kt` and `f2z-relay` are both already AGPL, and nothing moved).
- **#649 is untouched** — first-entry client-verifiability is a different layer
  and nothing here contradicts it.
- Not fixed here, and worth an issue each rather than a rider: the per-source
  rate-limit bucket for `Class::Cosign` (see above), and `f2z-kt`'s own epoch
  scheduler, which is the same unsupervised-task shape as #671 in a different
  binary — a dead scheduler stops publishing epochs while `/healthz` stays 200.

## Gates run locally

`cargo fmt --check`, `scripts/check-rust-clippy.sh --root rs` (10 crates clean),
`scripts/check-rust-deny.sh --root rs --config rs/deny.toml`,
`cargo test --locked --all-targets`, `cargo test --locked --doc`, and the four
Node policy checks including `check-hash-domain-labels.mjs` and
`check-akd-doc-evidence.mjs` — all green.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
