### PR TITLE
fix(deps): clear yanked spin release

### DIFF
--- a/wallet/deny.toml
+++ b/wallet/deny.toml
@@ -38,8 +38,6 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # upstream between two runs of CI with no commit of ours in between, which would
 # turn an unrelated pull request red for reasons its author cannot act on. It is
 # reported on every run and triaged deliberately instead.
-# Currently reported: spin 0.9.8 (via flume -> zcash_client_backend, and via
-# lazy_static -> bellman/orchard/tao).
 yanked = "warn"
 
 ignore = [

--- a/wallet/plugins/tauri-plugin-zcash/Cargo.lock
+++ b/wallet/plugins/tauri-plugin-zcash/Cargo.lock
@@ -4965,9 +4965,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/wallet/zuuallet/src-tauri/Cargo.lock
+++ b/wallet/zuuallet/src-tauri/Cargo.lock
@@ -4912,9 +4912,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
Refs #351

## Summary
- update the two stale wallet lockfiles from spin 0.9.8 to 0.9.9
- remove the obsolete yanked-spin allowance comment from wallet/deny.toml
- leave the advisory-backlog umbrella open for its remaining upstream items

## Verification
- scripts/check-rust-deny.sh advisories: all five wallet Cargo roots pass under the repository policy
- plugin, classic Zuuallet, and ZUULI locked builds/tests and Rust fmt/clippy passed on the candidate
- cargo tree resolves spin 0.9.9 in every affected shipping graph

## Mutation proof
The repository deliberately keeps yanked = warn so a registry-side yank cannot break unrelated PRs. Therefore the normal policy command reports an old yanked lock but exits zero. For the mutation proof only, I used the same pinned cargo-deny binary, real lockfiles, registry advisory data, and deny.toml with the CLI lint override -D yanked:

- candidate plugin and classic lockfiles at spin 0.9.9: both strict invocations exit 0
- restoring only the plugin lock to spin 0.9.8: strict invocation exits 1 with error[yanked] naming spin 0.9.8
- restoring only the classic Zuuallet lock to spin 0.9.8: strict invocation exits 1 with the same exact yanked finding
- restoring both candidate lockfiles returns both strict invocations to exit 0; the tracked tree and patch ID are unchanged

The CLI override is verification-only and does not change the repository warning policy.