### PR TITLE
fix(kt,relay,witness): fail closed on the rest of the supervision cluster

### DIFF
--- a/docs/e2ee/KT.md
+++ b/docs/e2ee/KT.md
@@ -1308,6 +1308,45 @@ O(entries added) (§10) and an empty epoch adds none.
 > `AppendOnlyProof` segment containing no insertions, with `audit_verify`
 > accepting it. Neither exists in `akd` 0.13. See §11.5.
 
+> **Correction (2026-08-24, later the same day) — the cadence rule binds the
+> log's *process*, not only its publishing code: a conforming log MUST NOT keep
+> serving after whatever emits epochs has stopped.** Found while fixing
+> [#684](https://github.com/free2z/zuu/issues/684). Nothing above is withdrawn;
+> what is added is the half a reader could otherwise implement around.
+>
+> §5.1's whole argument is that a heartbeat converts silence from an ambiguity
+> into a detectable fault. **That argument assumes something is still emitting
+> heartbeats.** A log whose scheduler has died — panicked, cancelled, or never
+> restarted after a transient — does not *fail* the cadence rule in a way any
+> client can see: it goes on serving §9.2's endpoints correctly, `/kt/v1/sth`
+> keeps returning the last valid signed tree head, every inclusion and
+> consistency proof still verifies, and nothing errors. The detection mechanism
+> is not tripped, it is **removed**, because there are no heartbeats left to
+> miss.
+>
+> A witness following the log does eventually see it (§7: no new head for
+> longer than the cadence), and the log's own operator sees it in
+> `KT.md`-derived monitoring — but both are *external* observers on a delay, and
+> a process-local probe answers `200` throughout. So the rule at the process
+> level is:
+>
+> - **The epoch scheduler is supervised.** If it ends for any reason before an
+>   orderly shutdown was requested, the log stops serving and the process exits
+>   non-zero, within a bounded grace period so that a wedged scheduler cannot
+>   hold the listening socket.
+> - **A tick that fails is not that**, and is unchanged: an epoch the log could
+>   not sign because a signer was briefly unreachable is logged and retried on
+>   the next tick. Publishing late is within §5.2's `max_merge_delay_seconds`
+>   promise; not publishing at all, silently and forever, is not.
+>
+> At `replicas: 1` this makes a dead scheduler a short, **visible** outage
+> instead of a `Ready` pod serving a directory that has silently frozen. This is
+> the same trade `WIRE.md`'s relay made for its listener and expiry tasks
+> ([#671](https://github.com/free2z/zuu/issues/671),
+> [#683](https://github.com/free2z/zuu/issues/683)), and it is the reason that
+> trade generalises: an availability signal that stays green over a component
+> that has stopped doing its job is worse than the outage it is hiding.
+
 ### 5.2 Maximum merge delay
 
 **`max_merge_delay_seconds` — proposed 3600, six epochs — is the log's published

--- a/rs/README.md
+++ b/rs/README.md
@@ -317,8 +317,9 @@ answers from process state and nothing else, deliberately — a probe that queri
 the store would fail during exactly the backpressure it exists to survive. That
 makes it a true statement about a relay only if the process cannot outlive the
 tasks that do its work, so `f2z-relay` supervises the protocol listener, the
-admin and health listeners and the expiry tick: if any of them ends before a
-shutdown was asked for, the relay closes its listeners, prints
+admin and health listeners, the expiry tick and — since [#685] — the
+**group-commit writer**: if any of them ends before a shutdown was asked for,
+the relay closes its listeners, prints
 `the <task> stopped while the relay was running` to stderr and **exits 1**. A
 crash-looping pod is the correct outcome. At `replicas: 1` with
 `strategy: Recreate` that is a brief, visible outage, and the alternative — a
@@ -327,7 +328,26 @@ crash-looping pod is the correct outcome. At `replicas: 1` with
 `accepted` and a relay that then loses the message have between them destroyed
 it.
 
+The commit writer is the one that is not a task. It is an **OS thread**, because
+an fsync is a blocking syscall of unbounded duration and parking a Tokio worker
+on a 1 GB VPS is worse; `Supervised` holds `JoinHandle`s, so the thread could not
+be in it, and a dead writer used to leave every listener open and every probe
+green over a relay answering `ERR_UNAVAILABLE` to every `APPEND`. It is covered
+by supervising a task that waits on the thread's liveness signal — a task
+registered in the same list as the other four, so the watchdog is not itself
+the unsupervised thing.
+
+**`f2z-kt` has the same rule and a quieter failure** ([#684]). Its epoch
+scheduler is what publishes `KT.md` §5.1's epochs, heartbeats included, and a
+log that has stopped publishing errors on *nothing*: clients keep verifying
+against the last signed tree head, lookups keep succeeding, and heartbeats
+cannot be missed because there is nothing left to emit them. So the scheduler
+and the HTTP listener are supervised the same way, and `f2z-kt serve` exits
+non-zero when either ends.
+
 [#671]: https://github.com/free2z/zuu/issues/671
+[#684]: https://github.com/free2z/zuu/issues/684
+[#685]: https://github.com/free2z/zuu/issues/685
 
 ## Working in this tree
 

--- a/rs/crates/f2z-kt/Cargo.toml
+++ b/rs/crates/f2z-kt/Cargo.toml
@@ -76,7 +76,15 @@ async-trait = { workspace = true }
 # on itself. This is the supported way to say "build my `testing` feature for
 # `tests/`, and never for the binary".
 f2z-kt = { path = ".", version = "0.1.0", features = ["testing"] }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+# `net` and `io-util` for `tests/supervision.rs`, which dials the bound listener
+# rather than asserting on an in-process flag (zuu#684).
+tokio = { workspace = true, features = [
+  "rt-multi-thread",
+  "macros",
+  "time",
+  "net",
+  "io-util",
+] }
 tower = { version = "0.5.3", default-features = false, features = ["util"] }
 
 [[bin]]

--- a/rs/crates/f2z-kt/src/main.rs
+++ b/rs/crates/f2z-kt/src/main.rs
@@ -115,12 +115,26 @@ fn serve(args: &[String]) -> Result<(), String> {
         .enable_all()
         .build()
         .map_err(|error| error.to_string())?;
-    runtime.block_on(async {
+    let stopped = runtime.block_on(async {
         let state = server::build(&config).await.map_err(|e| e.to_string())?;
         server::serve(state, &config.listen)
             .await
             .map_err(|e| e.to_string())
-    })
+    })?;
+    // Exhaustive on purpose (zuu#684). `Stopped` is not `#[non_exhaustive]`, so
+    // a future stop reason is a compile error here rather than a wildcard arm
+    // that silently exits zero — the same shape zuu#666 fixed in the witness's
+    // liveness predicate.
+    match stopped {
+        server::Stopped::Requested => Ok(()),
+        // Non-zero, and loud. The pod restarts and is visibly not `Ready` while
+        // it does; a log that stays up with a dead scheduler publishes nothing
+        // and reports nothing, and no client can tell.
+        server::Stopped::TaskEnded(name) => Err(format!(
+            "the {name} ended while the log was running; the log cannot publish epochs and is \
+             stopping rather than serving a directory that has silently frozen"
+        )),
+    }
 }
 
 fn check(args: &[String]) -> Result<(), String> {

--- a/rs/crates/f2z-kt/src/server.rs
+++ b/rs/crates/f2z-kt/src/server.rs
@@ -13,8 +13,41 @@
 //! not fatal: an epoch the log could not sign because a KMS was briefly
 //! unreachable is better published late than not at all, and a process that
 //! exits on it takes the whole directory down for a transient.
+//!
+//! # Every task started here is supervised (zuu#684)
+//!
+//! A tick that *fails* is a transient. The scheduler **task** ending is not:
+//! it panicked, or it was cancelled, and from that moment the log publishes
+//! nothing at all. The listener does not care — `/healthz` answers from process
+//! state, so the pod stays `Ready`, stays in rotation, and serves §9.2's
+//! endpoints correctly forever, over a directory that has stopped moving.
+//!
+//! **That failure is silent in a way `f2z-relay`'s was not.** A relay that has
+//! stopped accepting is loud: senders fail immediately. A key-transparency log
+//! that has stopped publishing epochs errors on nothing. Clients keep verifying
+//! against the last signed tree head, which stays valid; lookups keep
+//! succeeding; and no client can distinguish "no directory changes happened"
+//! from "the log stopped incorporating them".
+//!
+//! §5.1's heartbeat epochs exist precisely so that silence is detectable — an
+//! epoch published on cadence even with nothing to add, so a client that sees
+//! none knows something is wrong. A dead scheduler defeats that mechanism
+//! rather than tripping it: **there are no heartbeats to miss, because there is
+//! nothing left to emit them.**
+//!
+//! So [`Server::run_until_stopped`] selects over the join handles alongside the
+//! caller's signal, and a supervised task that ends before shutdown was asked
+//! for takes the whole process down with a non-zero exit — bounded by
+//! [`SHUTDOWN_GRACE`], so a wedged task cannot keep the listener open by
+//! refusing to finish. This is `f2z-relay`'s supervision idiom (zuu#671,
+//! zuu#683) applied unchanged; there is deliberately not a second one.
 
+use std::future::Future;
+use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
 
 use crate::api::{AppState, router};
 use crate::config::Config;
@@ -24,6 +57,18 @@ use crate::ratelimit::RateLimiter;
 use crate::signer::{FileSigner, LogSigner};
 use crate::vrf::FileVrf;
 use crate::{descriptor, now_ms, policy};
+
+/// §5.1's cadence, heartbeat epochs included. The task the log exists to run.
+pub const EPOCH_TASK: &str = "epoch scheduler";
+/// §9.2's endpoints and `/healthz` — the surface every probe reads.
+pub const HTTP_TASK: &str = "http listener";
+
+/// How long a failing log is given to close its listener politely.
+///
+/// A bound and not a promise: the point of the failure path is that the process
+/// stops, and a task that will not finish must not be able to hold the port by
+/// refusing to.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 
 /// Build every part of a running log from a configuration.
 ///
@@ -140,49 +185,237 @@ fn build_signer(config: &Config) -> Result<Arc<dyn LogSigner>> {
     Ok(Arc::new(FileSigner::load(&config.signing_key_file)?))
 }
 
+/// Why a log stopped serving.
+///
+/// Deliberately **not** `#[non_exhaustive]`, for the reason
+/// `f2z_relay::server::Stopped` is not: the binary is a separate crate, so that
+/// attribute would force a wildcard arm in `main`, and a wildcard arm is how a
+/// future stop reason silently becomes a zero exit. A new variant here should
+/// break every caller until each has decided what it means.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Stopped {
+    /// The caller's signal fired. An ordinary shutdown; exit zero.
+    Requested,
+    /// A supervised task ended before shutdown was asked for — it panicked, or
+    /// it was cancelled. The log cannot do its job and the process must not go
+    /// on passing health checks; exit non-zero.
+    TaskEnded(&'static str),
+}
+
+/// A task the log cannot serve without, and the name an operator sees when it
+/// is the one that ended.
+struct Supervised {
+    name: &'static str,
+    /// `None` once it has been observed to finish, so it is never polled twice.
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+/// A running log: the epoch scheduler, the HTTP listener, and the supervision
+/// that makes either one's death the process's death.
+pub struct Server {
+    addr: SocketAddr,
+    shutdown: watch::Sender<bool>,
+    tasks: Vec<Supervised>,
+}
+
+impl std::fmt::Debug for Server {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Server")
+            .field("addr", &self.addr)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Server {
+    /// Start the epoch scheduler and bind the listener.
+    ///
+    /// # Errors
+    ///
+    /// [`LogError::Config`] if the listen address will not bind.
+    pub async fn start(state: Arc<AppState>, listen: &str) -> Result<Self> {
+        let listener = tokio::net::TcpListener::bind(listen)
+            .await
+            .map_err(|error| LogError::Config(format!("{listen}: {error}")))?;
+        let addr = listener
+            .local_addr()
+            .map_err(|error| LogError::Config(format!("{listen}: {error}")))?;
+
+        let (shutdown, watcher) = watch::channel(false);
+        let mut tasks = Vec::with_capacity(2);
+
+        let interval = u64::from(state.log.settings().epoch_interval_seconds).max(1);
+        let log = Arc::clone(&state.log);
+        let scheduler_watcher = watcher.clone();
+        tasks.push(Supervised {
+            name: EPOCH_TASK,
+            handle: Some(tokio::spawn(async move {
+                let stop = changed(scheduler_watcher);
+                let mut stop = core::pin::pin!(stop);
+                let mut ticker = tokio::time::interval(Duration::from_secs(interval));
+                // `Delay` rather than `Burst`: a process that was descheduled
+                // must not then publish four epochs back to back, which would
+                // spend four signatures to say nothing and make the cadence a
+                // client observes meaningless.
+                ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                // The first tick completes immediately; genesis has already
+                // been published, so skip it.
+                ticker.tick().await;
+                loop {
+                    tokio::select! {
+                        _ = ticker.tick() => {
+                            if let Err(error) = log.publish_epoch(now_ms()).await {
+                                log::error!("epoch not published: {error}; retrying next tick");
+                            }
+                        }
+                        // A requested shutdown ends this task on purpose, which
+                        // is why the supervisor asks *whether shutdown was
+                        // requested* rather than treating every ending as a
+                        // fault. Without it the scheduler would be aborted mid
+                        // `publish_epoch`, which is the one operation in this
+                        // process that writes.
+                        () = &mut stop => return,
+                    }
+                }
+            })),
+        });
+
+        log::info!("listening on {addr} (plain HTTP; terminate TLS in front of this process)");
+        tasks.push(Supervised {
+            name: HTTP_TASK,
+            handle: Some(tokio::spawn(async move {
+                if let Err(error) = axum::serve(listener, router(state))
+                    .with_graceful_shutdown(changed(watcher))
+                    .await
+                {
+                    log::error!("serve: {error}");
+                }
+            })),
+        });
+
+        Ok(Self {
+            addr,
+            shutdown,
+            tasks,
+        })
+    }
+
+    /// The bound address. With port 0 this is the port the OS chose.
+    #[must_use]
+    pub const fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Serve until `signal` fires **or a supervised task ends**, then stop.
+    ///
+    /// This is the whole of zuu#684's fix and it is deliberately the only
+    /// supported way to run a log: awaiting the listener alone leaves the
+    /// scheduler's join handle unobserved, and an unobserved scheduler that
+    /// panics is a log that answers every request correctly and never publishes
+    /// another epoch.
+    ///
+    /// The listener is closed before this returns either way, bounded by
+    /// [`SHUTDOWN_GRACE`]. A [`Stopped::TaskEnded`] result is the caller's
+    /// instruction to exit **non-zero**: at `replicas: 1` a crash-loop is a
+    /// short, visible outage, and the alternative is a `Ready` pod serving a
+    /// frozen directory that nothing in the system reports as frozen.
+    pub async fn run_until_stopped(mut self, signal: impl Future<Output = ()>) -> Stopped {
+        let stopped = {
+            let mut signal = core::pin::pin!(signal);
+            tokio::select! {
+                biased;
+                name = self.supervise() => Stopped::TaskEnded(name),
+                () = &mut signal => Stopped::Requested,
+            }
+        };
+        if let Stopped::TaskEnded(name) = stopped {
+            log::error!("{name} ended; stopping the log");
+        }
+        if tokio::time::timeout(SHUTDOWN_GRACE, self.stop())
+            .await
+            .is_err()
+        {
+            log::error!("shutdown did not finish in time; exiting anyway");
+        }
+        stopped
+    }
+
+    /// Resolve when any supervised task ends. Pending while all are alive.
+    ///
+    /// Each handle is polled at most to completion once — a `JoinHandle` polled
+    /// after it has finished panics, and this runs inside a `select!` that may
+    /// poll it many times.
+    async fn supervise(&mut self) -> &'static str {
+        let tasks = &mut self.tasks;
+        core::future::poll_fn(move |cx| {
+            for task in tasks.iter_mut() {
+                let Some(handle) = task.handle.as_mut() else {
+                    continue;
+                };
+                if core::pin::Pin::new(handle).poll(cx).is_ready() {
+                    task.handle = None;
+                    return core::task::Poll::Ready(task.name);
+                }
+            }
+            core::task::Poll::Pending
+        })
+        .await
+    }
+
+    /// Abort a supervised task by name, so that a test can produce the failure
+    /// this supervision exists for. Returns whether one was found.
+    ///
+    /// There is no other way to write that test. The failure it stands in for
+    /// is a **panic**, which comes from a bug rather than from an input, and a
+    /// fault-injection hook inside the shipped scheduler would be a far worse
+    /// thing to carry than a method behind a feature that never reaches the
+    /// binary. An aborted task and a panicked one are the same shape here: the
+    /// handle completes, and nothing else in the process notices.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn abort_task(&mut self, name: &str) -> bool {
+        self.tasks
+            .iter()
+            .find(|task| task.name == name)
+            .and_then(|task| task.handle.as_ref())
+            .is_some_and(|handle| {
+                handle.abort();
+                true
+            })
+    }
+
+    /// Tell every task to stop and wait for it.
+    async fn stop(self) {
+        let _ = self.shutdown.send(true);
+        for task in self.tasks {
+            if let Some(handle) = task.handle {
+                let _ = handle.await;
+            }
+        }
+        log::info!("log stopped");
+    }
+}
+
+/// Resolve once the shutdown flag is set.
+async fn changed(mut watcher: watch::Receiver<bool>) {
+    // `*borrow()` first: the flag may already be set by the time a task gets
+    // here, and `changed()` only reports transitions after this point.
+    while !*watcher.borrow_and_update() {
+        if watcher.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
 /// Run the epoch scheduler and the HTTP listener until the process is asked to
-/// stop.
+/// stop, or until one of them ends on its own.
 ///
 /// # Errors
 ///
 /// [`LogError::Config`] if the listen address will not bind.
-pub async fn serve(state: Arc<AppState>, listen: &str) -> Result<()> {
-    let interval = u64::from(state.log.settings().epoch_interval_seconds).max(1);
-    let scheduler = {
-        let log = Arc::clone(&state.log);
-        tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(tokio::time::Duration::from_secs(interval));
-            // `Delay` rather than `Burst`: a process that was descheduled must
-            // not then publish four epochs back to back, which would spend four
-            // signatures to say nothing and make the cadence a client observes
-            // meaningless.
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            // The first tick completes immediately; genesis has already been
-            // published, so skip it.
-            ticker.tick().await;
-            loop {
-                ticker.tick().await;
-                if let Err(error) = log.publish_epoch(now_ms()).await {
-                    log::error!("epoch not published: {error}; retrying next tick");
-                }
-            }
-        })
-    };
-
-    let listener = tokio::net::TcpListener::bind(listen)
-        .await
-        .map_err(|error| LogError::Config(format!("{listen}: {error}")))?;
-    log::info!(
-        "listening on {} (plain HTTP; terminate TLS in front of this process)",
-        listen
-    );
-
-    let result = axum::serve(listener, router(state))
-        .with_graceful_shutdown(shutdown())
-        .await
-        .map_err(|error| LogError::Config(format!("serve: {error}")));
-    scheduler.abort();
-    result
+pub async fn serve(state: Arc<AppState>, listen: &str) -> Result<Stopped> {
+    Ok(Server::start(state, listen)
+        .await?
+        .run_until_stopped(shutdown())
+        .await)
 }
 
 async fn shutdown() {

--- a/rs/crates/f2z-kt/tests/supervision.rs
+++ b/rs/crates/f2z-kt/tests/supervision.rs
@@ -1,0 +1,290 @@
+//! **A dead epoch scheduler must take the process with it** — zuu#684.
+//!
+//! `server::serve` spawned the scheduler as a detached task and then awaited
+//! the listener. Nothing observed the scheduler's join handle, so a **panic**
+//! in it ended that task and left the rest of the process running: `/healthz`
+//! answering `200`, the pod `Ready`, §9.2's endpoints all correct — over a
+//! directory that had stopped moving.
+//!
+//! # Why this is worse than the relay case it is copied from
+//!
+//! zuu#671 fixed this shape in `f2z-relay`, where the failure is at least
+//! *loud*: a relay that has stopped accepting fails its senders immediately.
+//! **A key-transparency log that has stopped publishing epochs errors on
+//! nothing.** Clients keep verifying against the last signed tree head, which
+//! stays valid. Lookups keep succeeding. Submissions are still accepted into
+//! the pending journal. Nothing in the protocol distinguishes "no directory
+//! changes happened this hour" from "the log stopped incorporating them".
+//!
+//! `KT.md` §5.1's heartbeat epochs exist precisely so that silence is
+//! detectable — an epoch on cadence even with nothing to add, so that a client
+//! seeing none knows. A dead scheduler does not *trip* that mechanism, it
+//! **removes** it: there are no heartbeats to miss, because there is nothing
+//! left to emit them.
+//!
+//! # These tests drive a real listener on purpose
+//!
+//! zuu#683 measured the correction that applies directly here: ending a task
+//! drops the future that owns **its own** listener, so the port that task was
+//! serving stops accepting immediately with or without supervision. The part
+//! that keeps lying is the **health surface**, which belongs to a different
+//! task and goes on answering `200`. In `f2z-kt` the health surface and the
+//! protocol surface are the same axum router, so the scheduler owns neither —
+//! which makes the point sharper, not softer: killing the scheduler changes
+//! *nothing* an outside observer can see, and the assertion below is that after
+//! the fix it changes everything, because the process stops.
+//!
+//! So each test dials the bound address, reads `/healthz` before the failure,
+//! and asserts the socket is refused afterwards. That is the property the
+//! kubelet, the load balancer and a client all observe, and no in-process flag
+//! can stand in for it.
+//!
+//! The failure is injected with `Server::abort_task` because the real cause is
+//! a panic, which comes from a bug rather than from an input: there is no
+//! request that makes the scheduler panic on demand, and a fault-injection hook
+//! inside the shipped scheduler would be a far worse thing to carry. An aborted
+//! task and a panicked one are the same shape to the supervisor — the handle
+//! completes and nothing else in the process notices.
+
+// An integration test is its own crate, so the workspace's denials of the
+// panicking families do not reach it. A `.unwrap()` here is a failing test.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use f2z_authority::authority::{AuthorityConfig, AuthoritySet};
+use f2z_kt::api::AppState;
+use f2z_kt::config::LogSettings;
+use f2z_kt::log::LogService;
+use f2z_kt::ratelimit::RateLimiter;
+use f2z_kt::server::{EPOCH_TASK, HTTP_TASK, Server, Stopped};
+use f2z_kt::signer::FileSigner;
+use f2z_kt::testing::{Key, temp_dir};
+use f2z_kt::vrf::FileVrf;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+const NOW: u64 = 1_700_000_100_000;
+
+/// A whole log, in a temporary directory, publishing on `interval` seconds.
+///
+/// Built here rather than from `testing::Harness` because the cadence is the
+/// thing under test in [`the_scheduler_really_is_what_publishes_epochs`], and a
+/// fixture that hard-coded §5.1's proposed 600 s would make that test take ten
+/// minutes or, worse, quietly become a test of nothing.
+async fn log_serving_every(name: &str, interval: u32) -> Arc<AppState> {
+    let dir = temp_dir(name);
+    let log_key = Key::from_byte(0xa1);
+    let reset_authority = Key::from_byte(0xa2);
+    let issuer = f2z_authority::key::SigningKey::from_seed(&[0xa3; 32]);
+
+    let log_id = f2z_kt_core::labels::log_id(&log_key.public);
+    let mut settings = LogSettings::defaults(log_key.public, reset_authority.public).unwrap();
+    settings.epoch_interval_seconds = interval;
+
+    let authority = AuthorityConfig::with_defaults(
+        f2z_authority::types::LogId::new(*log_id.as_bytes()),
+        AuthoritySet::single(issuer.public_key()).unwrap(),
+    )
+    .unwrap();
+
+    let signer = Arc::new(FileSigner::from_seed(&[0xa1; 32]));
+    let vrf = FileVrf::from_seed([0xb0; 32]).unwrap();
+    let log = LogService::open(
+        &dir,
+        settings.clone(),
+        Arc::clone(&signer) as Arc<dyn f2z_kt::signer::LogSigner>,
+        vrf,
+        authority.clone(),
+        Vec::new(),
+    )
+    .await
+    .unwrap();
+    // §6.3's chain has to start somewhere, exactly as `server::build` does it.
+    if log.current_epoch().await == 0 {
+        log.publish_epoch(NOW).await.unwrap();
+    }
+    let vrf_public_key = *log.vrf_public_key();
+    let log = Arc::new(log);
+
+    Arc::new(AppState {
+        descriptor: f2z_kt::descriptor::sign_descriptor(
+            &settings,
+            log_id,
+            vrf_public_key,
+            signer.as_ref(),
+            NOW,
+        )
+        .unwrap(),
+        policy: f2z_kt::sign_policy(&authority, log_id, signer.as_ref(), NOW).unwrap(),
+        log,
+        limits: RateLimiter::defaults(),
+        clock: Arc::new(f2z_kt::now_ms),
+    })
+}
+
+/// `GET /healthz`, which is what every probe and the load balancer do.
+///
+/// `Connection: close` so the response ends at EOF and no keep-alive socket is
+/// left for the graceful shutdown to wait on — the test is about whether the
+/// listener is *there*, not about how long a spare connection lingers.
+async fn healthz(addr: SocketAddr) -> String {
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    stream
+        .write_all(b"GET /healthz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .await
+        .unwrap();
+    let mut response = String::new();
+    let _ =
+        tokio::time::timeout(Duration::from_secs(5), stream.read_to_string(&mut response)).await;
+    response
+}
+
+/// Assert that connecting is refused, allowing a moment for the socket to
+/// close. A closed listener answers with a reset rather than a timeout, so this
+/// converges immediately in practice; the loop is here so that a slow runner
+/// reports the real failure rather than a scheduling artefact.
+async fn refuses(addr: SocketAddr, what: &str) {
+    for _ in 0..100u32 {
+        match tokio::time::timeout(
+            Duration::from_millis(200),
+            tokio::net::TcpStream::connect(addr),
+        )
+        .await
+        {
+            Ok(Err(_)) => return,
+            _ => tokio::time::sleep(Duration::from_millis(20)).await,
+        }
+    }
+    panic!("the {what} at {addr} is still accepting connections");
+}
+
+/// **zuu#684.** A dead epoch scheduler takes the whole process down, including
+/// the surface that would otherwise keep the pod `Ready` over a frozen log.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_dead_epoch_scheduler_stops_the_process_instead_of_staying_ready() {
+    let state = log_serving_every("supervision-scheduler", 3_600).await;
+    let mut server = Server::start(state, "127.0.0.1:0")
+        .await
+        .expect("it starts");
+    let addr = server.addr();
+
+    assert!(
+        healthz(addr).await.starts_with("HTTP/1.1 200"),
+        "the probe surface is green before the failure"
+    );
+
+    assert!(server.abort_task(EPOCH_TASK), "the scheduler is supervised");
+
+    // The signal never fires: this is the case where nobody asked the log to
+    // stop and it must stop anyway.
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.run_until_stopped(std::future::pending()),
+    )
+    .await
+    .expect("supervision notices a dead scheduler without waiting for a signal");
+    assert_eq!(stopped, Stopped::TaskEnded(EPOCH_TASK));
+
+    // The load-bearing assertion. Without the fix this address answers `200`
+    // forever: the listener has no idea the scheduler is gone, `/healthz` reads
+    // process state only, and every probe and the load balancer are satisfied
+    // by a log that will never publish another epoch.
+    refuses(addr, "http listener").await;
+}
+
+/// The listener is supervised too. A log whose HTTP surface has died is
+/// unreachable to every probe, and the process should not sit there publishing
+/// epochs nobody can fetch until something else kills it.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_dead_http_listener_stops_the_process() {
+    let state = log_serving_every("supervision-listener", 3_600).await;
+    let mut server = Server::start(state, "127.0.0.1:0")
+        .await
+        .expect("it starts");
+    let addr = server.addr();
+    assert!(healthz(addr).await.starts_with("HTTP/1.1 200"));
+
+    assert!(server.abort_task(HTTP_TASK), "the listener is supervised");
+
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.run_until_stopped(std::future::pending()),
+    )
+    .await
+    .expect("supervision notices the listener");
+    assert_eq!(stopped, Stopped::TaskEnded(HTTP_TASK));
+    refuses(addr, "http listener").await;
+}
+
+/// The control: an ordinary signal is still an ordinary, zero-exit shutdown,
+/// and it is **not** reported as a task failure.
+///
+/// Without this, a supervisor that called every stop a failure would pass the
+/// two tests above and crash-loop every deliberate restart. It is also the test
+/// that catches the specific mistake this fix could make: the scheduler now
+/// selects on the shutdown flag, so it *ends* on a requested shutdown, and a
+/// supervisor that did not race the signal first would report that ending as
+/// `TaskEnded(EPOCH_TASK)` and exit non-zero on every `SIGTERM`.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_requested_shutdown_is_not_a_failure() {
+    let state = log_serving_every("supervision-signal", 3_600).await;
+    let server = Server::start(state, "127.0.0.1:0")
+        .await
+        .expect("it starts");
+    let addr = server.addr();
+    assert!(healthz(addr).await.starts_with("HTTP/1.1 200"));
+
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.run_until_stopped(std::future::ready(())),
+    )
+    .await
+    .expect("a signalled shutdown finishes");
+    assert_eq!(stopped, Stopped::Requested);
+    refuses(addr, "http listener").await;
+}
+
+/// The positive control, and the reason the three tests above mean anything: on
+/// a one-second cadence the log really does publish §5.1's heartbeat epochs on
+/// its own, with nothing submitted to it.
+///
+/// Supervision of a task that published nothing would be supervision of a
+/// no-op, and every assertion above would still pass. This is the test that
+/// says the thing being supervised is the thing the log exists to do.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_scheduler_really_is_what_publishes_epochs() {
+    let state = log_serving_every("supervision-cadence", 1).await;
+    let before = state.log.current_epoch().await;
+    let server = Server::start(Arc::clone(&state), "127.0.0.1:0")
+        .await
+        .expect("it starts");
+
+    let mut after = before;
+    for _ in 0..60u32 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        after = state.log.current_epoch().await;
+        if after > before {
+            break;
+        }
+    }
+    assert!(
+        after > before,
+        "the scheduler published nothing in 15s at a 1s cadence: {before} -> {after}"
+    );
+
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.run_until_stopped(std::future::ready(())),
+    )
+    .await
+    .expect("a signalled shutdown finishes");
+    assert_eq!(stopped, Stopped::Requested);
+}

--- a/rs/crates/f2z-relay/src/commit.rs
+++ b/rs/crates/f2z-relay/src/commit.rs
@@ -47,6 +47,37 @@
 //! `recv_timeout`, which is the one place a blocking receive is exactly the
 //! right primitive.
 //!
+//! # …and why that thread is nevertheless supervised (zuu#685)
+//!
+//! Being a thread put this worker **outside** zuu#683's supervision, which
+//! holds `tokio::task::JoinHandle`s and polls them. That is a type boundary and
+//! not an oversight in a list of names, and it left the relay with the worst
+//! shape in the system: when this thread died, [`CommitWriter::append`] began
+//! returning [`CommitError::WriterStopped`], `engine.rs` turned that into a
+//! per-request `ERR_UNAVAILABLE`, and the process went on answering `/healthz`
+//! with `200` while it could not store a single message. Under delete-on-ack
+//! that is not downtime; a sender told `accepted` by a relay that never wrote
+//! the message has had data destroyed between them.
+//!
+//! So [`CommitWriter::start`] hands back a [`WriterStopped`] alongside the
+//! handle: the thread owns a `oneshot::Sender` it never sends on, and dropping
+//! it — by returning, or by unwinding out of a panic — resolves the receiver.
+//! `server.rs` supervises a task that awaits exactly that, so the writer's
+//! death arrives at [`crate::server::Server::run_until_stopped`] in the same
+//! shape every other task's does.
+//!
+//! **The bridging task is itself supervised**, which is the point: it is
+//! registered in the same `Vec<Supervised>` as the four tokio tasks, so a
+//! watchdog that is itself killed is reported exactly as the thing it watches
+//! would be. Solving a supervision gap by adding an unsupervised supervisor
+//! would move the hole rather than close it.
+//!
+//! The alternative — `spawn_blocking`, whose handle is pollable — was
+//! considered and rejected: an aborted blocking task cannot be cancelled once
+//! it is running, so the shutdown path would have to wait out
+//! `SHUTDOWN_GRACE` on **every** ordinary stop, and the test that proves the
+//! supervision works could not produce the failure at all.
+//!
 //! The other store operations — `create_queue`, `read`, `ack`, `delete_queue` —
 //! are called inline from the connection tasks. They contend on the same
 //! connection mutex, so they queue behind a batch rather than racing it, and
@@ -66,6 +97,23 @@ use f2z_codec::types::{Payload, QueueAddress};
 use f2z_relay_store::{Append, Appended, Durability, RelayStore, SendAuth, StoreError};
 
 use crate::metrics::Metrics;
+
+/// What the writer takes over the channel.
+///
+/// An enum with one shipped variant, so that the testing-only way to kill the
+/// thread is a *message* rather than a magic value inside a real [`Job`]. The
+/// shipped binary contains `Append` and nothing else.
+enum Message {
+    /// One append, waiting for a transaction.
+    Append(Job),
+    /// Die here, exactly where a panic inside the writer would leave the
+    /// relay. Behind the `testing` feature, like `Server::abort_task`, and for
+    /// the same reason: the real cause is a bug rather than an input, and a
+    /// fault-injection hook that reached the shipped binary would be a far
+    /// worse thing to carry than one that cannot.
+    #[cfg(any(test, feature = "testing"))]
+    Stop,
+}
 
 /// One append, waiting for a transaction.
 struct Job {
@@ -114,10 +162,30 @@ pub enum CommitError {
     WriterStopped,
 }
 
+/// Resolves when the group-commit writer thread has ended, for any reason.
+///
+/// The thread holds the matching `oneshot::Sender` and never sends on it, so
+/// the only thing that can complete this is the sender being **dropped** —
+/// which happens when `run` returns and when a panic unwinds out of it. There
+/// is nothing for the writer to remember to do, which is the property that
+/// makes this trustworthy: a liveness signal the worker has to publish is a
+/// liveness signal a panicking worker does not publish.
+#[derive(Debug)]
+pub struct WriterStopped(tokio::sync::oneshot::Receiver<core::convert::Infallible>);
+
+impl WriterStopped {
+    /// Wait for the writer thread to end.
+    pub async fn wait(self) {
+        // `Ok` is unreachable — `Infallible` has no values — so this resolves
+        // only on the sender's drop.
+        let Err(_dropped) = self.0.await;
+    }
+}
+
 /// A handle on the writer.
 #[derive(Clone, Debug)]
 pub struct CommitWriter {
-    sender: std::sync::mpsc::Sender<Job>,
+    sender: std::sync::mpsc::Sender<Message>,
     durability: Durability,
 }
 
@@ -127,6 +195,10 @@ impl CommitWriter {
     /// `window` is how long a batch gathers after its first job; `max_batch` is
     /// the most appends one transaction takes.
     ///
+    /// Returns the handle **and** a [`WriterStopped`] that resolves when the
+    /// thread ends (zuu#685). The caller is expected to supervise it: a relay
+    /// whose write path is gone must stop, not answer probes.
+    ///
     /// # Errors
     ///
     /// The thread could not be spawned.
@@ -135,13 +207,28 @@ impl CommitWriter {
         metrics: Arc<Metrics>,
         window: Duration,
         max_batch: usize,
-    ) -> std::io::Result<Self> {
+    ) -> std::io::Result<(Self, WriterStopped)> {
         let durability = store.durability();
-        let (sender, receiver) = std::sync::mpsc::channel::<Job>();
+        let (sender, receiver) = std::sync::mpsc::channel::<Message>();
+        let (alive, stopped) = tokio::sync::oneshot::channel();
         std::thread::Builder::new()
             .name("f2z-relay-commit".to_owned())
-            .spawn(move || run(&store, &metrics, &receiver, window, max_batch.max(1)))?;
-        Ok(Self { sender, durability })
+            .spawn(move || {
+                // Moved in and never used: it exists to be dropped when this
+                // closure ends, however it ends.
+                let _alive = alive;
+                run(&store, &metrics, &receiver, window, max_batch.max(1));
+            })?;
+        Ok((Self { sender, durability }, WriterStopped(stopped)))
+    }
+
+    /// Make the writer thread exit, exactly where a panic inside it would.
+    ///
+    /// Returns whether the message could be delivered. See [`Message::Stop`]
+    /// for why this is behind a feature that never reaches the binary.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn stop_for_test(&self) -> bool {
+        self.sender.send(Message::Stop).is_ok()
     }
 
     /// What this writer's commits promise — §11.1's `durability_mode`.
@@ -167,13 +254,13 @@ impl CommitWriter {
     ) -> Result<Reply, CommitError> {
         let (reply, answer) = tokio::sync::oneshot::channel();
         self.sender
-            .send(Job {
+            .send(Message::Append(Job {
                 send_addr,
                 auth,
                 payload,
                 received_at_ms,
                 reply,
-            })
+            }))
             .map_err(|_| CommitError::WriterStopped)?;
         answer.await.map_err(|_| CommitError::WriterStopped)
     }
@@ -182,7 +269,7 @@ impl CommitWriter {
 fn run(
     store: &Arc<dyn RelayStore + Send + Sync>,
     metrics: &Arc<Metrics>,
-    receiver: &std::sync::mpsc::Receiver<Job>,
+    receiver: &std::sync::mpsc::Receiver<Message>,
     window: Duration,
     max_batch: usize,
 ) {
@@ -190,11 +277,18 @@ fn run(
     loop {
         // Block until there is anything to do. A relay with no traffic costs no
         // wakeups, which on a shared VPS is a real number.
-        let Ok(first) = receiver.recv() else {
+        let Ok(message) = receiver.recv() else {
             return;
+        };
+        let first = match message {
+            Message::Append(job) => job,
+            #[cfg(any(test, feature = "testing"))]
+            Message::Stop => return,
         };
         let deadline = Instant::now().checked_add(window);
         let mut batch = vec![first];
+        #[cfg(any(test, feature = "testing"))]
+        let mut stopping = false;
 
         // Gather. The window starts at the *first* job rather than being a
         // fixed tick, so a lone append waits at most `window` and a burst
@@ -208,7 +302,15 @@ fn run(
                 break;
             }
             match receiver.recv_timeout(remaining) {
-                Ok(job) => batch.push(job),
+                Ok(Message::Append(job)) => batch.push(job),
+                // Commit what is in hand first: those jobs' senders are waiting
+                // on a durable answer, and §13.2 says a message accepted into
+                // this batch must not be thrown away.
+                #[cfg(any(test, feature = "testing"))]
+                Ok(Message::Stop) => {
+                    stopping = true;
+                    break;
+                }
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
                 // The last sender went away. Commit what is in hand — those
                 // clients are gone, but their queues' readers are not, and a
@@ -218,6 +320,11 @@ fn run(
         }
 
         commit(store, metrics, durability, batch);
+
+        #[cfg(any(test, feature = "testing"))]
+        if stopping {
+            return;
+        }
     }
 }
 
@@ -336,7 +443,7 @@ mod tests {
     async fn an_append_is_answered_only_after_its_transaction() {
         let (store, send_addr, send_key) = store_with_queue();
         let metrics = Arc::new(Metrics::new());
-        let writer =
+        let (writer, _stopped) =
             CommitWriter::start(store, Arc::clone(&metrics), Duration::from_millis(1), 16).unwrap();
         let payload = Payload::new(vec![0u8; 1024]).unwrap();
         let accepted = writer
@@ -358,7 +465,7 @@ mod tests {
     async fn many_concurrent_appends_share_transactions() {
         let (store, send_addr, send_key) = store_with_queue();
         let metrics = Arc::new(Metrics::new());
-        let writer = CommitWriter::start(
+        let (writer, _stopped) = CommitWriter::start(
             Arc::clone(&store),
             Arc::clone(&metrics),
             Duration::from_millis(20),
@@ -400,7 +507,7 @@ mod tests {
     async fn one_writers_refusal_does_not_undo_the_batch() {
         let (store, send_addr, send_key) = store_with_queue();
         let metrics = Arc::new(Metrics::new());
-        let writer =
+        let (writer, _stopped) =
             CommitWriter::start(store, Arc::clone(&metrics), Duration::from_millis(20), 8).unwrap();
 
         let good = writer.append(
@@ -418,6 +525,26 @@ mod tests {
         let (good, absent) = tokio::join!(good, absent);
         assert!(good.unwrap().is_ok());
         assert!(absent.unwrap().is_err());
+    }
+
+    /// zuu#685's mechanism, with **no injection hook involved at all**.
+    ///
+    /// Dropping the last `Sender` makes `receiver.recv()` fail and `run`
+    /// return, which is a genuine end of the writer thread. The signal has to
+    /// arrive from the thread unwinding its own locals — there is nothing the
+    /// writer remembers to do — and that is exactly why a panic inside it is
+    /// covered too. Without this, `stop_for_test` could be proving only that
+    /// one testing path works.
+    #[tokio::test]
+    async fn the_liveness_signal_fires_when_the_writer_thread_really_ends() {
+        let (store, _send_addr, _send_key) = store_with_queue();
+        let (writer, stopped) =
+            CommitWriter::start(store, Arc::new(Metrics::new()), Duration::from_millis(1), 8)
+                .unwrap();
+        drop(writer);
+        tokio::time::timeout(Duration::from_secs(5), stopped.wait())
+            .await
+            .expect("the writer thread's death is observable to a supervisor");
     }
 
     #[test]

--- a/rs/crates/f2z-relay/src/server.rs
+++ b/rs/crates/f2z-relay/src/server.rs
@@ -38,6 +38,24 @@
 //! leaves the load balancer with no endpoint to send traffic to. That is the
 //! correct trade under delete-on-ack, and it is the one the health-probe work
 //! of #665 assumed was already true.
+//!
+//! # The write path is supervised too, and it is not a task (zuu#685)
+//!
+//! The four tasks above were the whole of #683's supervision, and the relay has
+//! a **fifth** long-lived worker that owns the entire write path: the
+//! group-commit writer, which is an OS thread because an fsync is a blocking
+//! syscall of unbounded duration. `Supervised` holds `JoinHandle`s, so a thread
+//! could not be in it — a type boundary, not a missed name — and a dead writer
+//! left the relay returning `ERR_UNAVAILABLE` for every `APPEND` and
+//! `CONTACT_APPEND` while `/healthz` answered `200` and every probe passed.
+//! Under delete-on-ack that is the worst failure in the system: `accepted` for
+//! messages that never became durable.
+//!
+//! It is covered by supervising a **task that waits on the writer thread's
+//! liveness signal** ([`crate::commit::WriterStopped`]) and registering that
+//! task in the same list as the other four. The watchdog is therefore itself
+//! supervised: it cannot be the unsupervised thing that closes a supervision
+//! gap.
 
 use std::future::Future;
 use std::sync::Arc;
@@ -105,6 +123,14 @@ pub const ADMIN_TASK: &str = "admin listener";
 pub const HEALTH_TASK: &str = "health listener";
 /// §7.7's TTL sweep and §5.5's seen-set aging.
 pub const EXPIRY_TASK: &str = "queue expiry tick";
+/// The group-commit writer — **the entire write path** (zuu#685).
+///
+/// The worker is an OS thread rather than a tokio task, for the reason
+/// `commit.rs` argues at length: an fsync is a blocking syscall of unbounded
+/// duration. Supervision reaches it anyway through a task that waits on the
+/// thread's liveness signal, and that task is registered here like every other,
+/// so the watchdog is supervised by the same mechanism it feeds.
+pub const COMMIT_TASK: &str = "group-commit writer";
 
 /// How long a failing relay is given to close its sockets politely.
 ///
@@ -121,6 +147,10 @@ pub struct Server {
     health_addr: Option<std::net::SocketAddr>,
     shutdown: watch::Sender<bool>,
     tasks: Vec<Supervised>,
+    /// A second handle on the group-commit writer, so that a test can kill it.
+    /// See [`Server::stop_commit_writer`].
+    #[cfg(any(test, feature = "testing"))]
+    writer: CommitWriter,
 }
 
 /// A task the relay cannot serve without, and the name an operator sees when it
@@ -213,7 +243,7 @@ impl Server {
             crate::rng::seed().map_err(|_| StartError::NoRandomness)?,
         ));
 
-        let writer = CommitWriter::start(
+        let (writer, writer_stopped) = CommitWriter::start(
             Arc::clone(&store),
             Arc::clone(&metrics),
             Duration::from_millis(u64::from(config.commit.window_ms)),
@@ -275,6 +305,9 @@ impl Server {
             .as_ref()
             .and_then(|listener| listener.local_addr().ok());
 
+        #[cfg(any(test, feature = "testing"))]
+        let writer_handle = writer.clone();
+
         let relay = Arc::new(Relay::new(
             config,
             identity,
@@ -288,13 +321,36 @@ impl Server {
         ));
 
         let (shutdown, watcher) = watch::channel(false);
-        let mut tasks = Vec::with_capacity(4);
+        let mut tasks = Vec::with_capacity(5);
         let mut supervise = |name, handle| {
             tasks.push(Supervised {
                 name,
                 handle: Some(handle),
             })
         };
+        // zuu#685. The write path is an OS thread, so what is supervised here
+        // is a **task that waits for that thread to end**. It is in the same
+        // list as everything else on purpose: a watchdog outside the mechanism
+        // would move the fail-open rather than close it, and this one's own
+        // death is reported exactly as the writer's would be.
+        //
+        // It ends on an ordinary shutdown too, like every other task here —
+        // the writer thread is left to be reaped with the process, which is
+        // what it did before this fix. Waiting for it would mean waiting for a
+        // `recv` that only returns when the last `Sender` is dropped, and the
+        // connection tasks hold those.
+        {
+            let mut shutting_down = watcher.clone();
+            supervise(
+                COMMIT_TASK,
+                tokio::spawn(async move {
+                    tokio::select! {
+                        () = writer_stopped.wait() => {}
+                        _ = shutting_down.changed() => {}
+                    }
+                }),
+            );
+        }
         supervise(
             PROTOCOL_TASK,
             tokio::spawn(crate::listener::serve(
@@ -342,6 +398,8 @@ impl Server {
             health_addr,
             shutdown,
             tasks,
+            #[cfg(any(test, feature = "testing"))]
+            writer: writer_handle,
         })
     }
 
@@ -443,6 +501,20 @@ impl Server {
             core::task::Poll::Pending
         })
         .await
+    }
+
+    /// Kill the group-commit writer **thread**, so that a test can produce the
+    /// failure [`COMMIT_TASK`]'s supervision exists for. Returns whether the
+    /// message could be delivered.
+    ///
+    /// Not [`Self::abort_task`]: aborting the watchdog would prove only that
+    /// the watchdog is in the supervised list, and would pass identically if
+    /// nothing connected it to the writer. This kills the thread that owns the
+    /// write path, and the assertion is that the process stops — which is the
+    /// chain the defect broke.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn stop_commit_writer(&self) -> bool {
+        self.writer.stop_for_test()
     }
 
     /// Abort a supervised task by name, so that a test can produce the failure

--- a/rs/crates/f2z-relay/tests/group_commit.rs
+++ b/rs/crates/f2z-relay/tests/group_commit.rs
@@ -114,7 +114,9 @@ async fn a_hundred_concurrent_appends_do_not_cost_a_hundred_fsyncs() {
 
     let baseline = store.commits();
     let metrics = Arc::new(Metrics::new());
-    let writer = CommitWriter::start(
+    // `_stopped` is the writer's liveness signal (zuu#685); `server.rs`
+    // supervises it, and this test only needs the handle.
+    let (writer, _stopped) = CommitWriter::start(
         Arc::clone(&store) as Arc<dyn RelayStore + Send + Sync>,
         Arc::clone(&metrics),
         Duration::from_millis(25),
@@ -176,7 +178,7 @@ async fn a_lone_append_still_costs_its_own_fsync() {
     let scratch = Scratch::new("lone-append");
     let (store, send_addr, send_key) = sqlite_with_queue(&scratch.join("relay.sqlite"));
     let baseline = store.commits();
-    let writer = CommitWriter::start(
+    let (writer, _stopped) = CommitWriter::start(
         Arc::clone(&store) as Arc<dyn RelayStore + Send + Sync>,
         Arc::new(Metrics::new()),
         Duration::from_millis(10),

--- a/rs/crates/f2z-relay/tests/supervision.rs
+++ b/rs/crates/f2z-relay/tests/supervision.rs
@@ -69,7 +69,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use f2z_relay::config::Config;
-use f2z_relay::server::{EXPIRY_TASK, HEALTH_TASK, PROTOCOL_TASK, Server, Stopped};
+use f2z_relay::server::{COMMIT_TASK, EXPIRY_TASK, HEALTH_TASK, PROTOCOL_TASK, Server, Stopped};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
 /// A relay that binds everything on loopback, with nothing durable behind it.
@@ -222,5 +222,84 @@ async fn a_requested_shutdown_is_not_a_failure() {
     .await
     .expect("a signalled shutdown finishes");
     assert_eq!(stopped, Stopped::Requested);
+    refuses(protocol, "protocol listener").await;
+}
+
+/// **zuu#685.** The group-commit writer is an **OS thread**, so #683's
+/// supervision — which holds `JoinHandle`s — could not reach it. A dead writer
+/// left every listener open and every probe green over a relay that could not
+/// store a single message: `CommitWriter::append` returned `WriterStopped`,
+/// `engine.rs` collapsed that to a per-request `ERR_UNAVAILABLE`, and nothing
+/// above it ever concluded that the relay was finished.
+///
+/// Under delete-on-ack that is the worst failure in the system. A sender is
+/// told `accepted` by a relay whose write path is gone, deletes its only copy,
+/// and the message never existed. `replicas: 1` on a ReadWriteOnce volume means
+/// there is no second pod to take over from one that has quietly stopped
+/// accepting.
+///
+/// The failure is injected by killing **the thread**, not by aborting the
+/// watchdog task: aborting the watchdog would pass identically on a build where
+/// nothing connected it to the writer, which is precisely the defect.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_dead_commit_writer_stops_the_process_instead_of_answering_unavailable() {
+    let server = Server::start(base()).await.expect("the relay starts");
+    let protocol = server.protocol_addr();
+    let health = server.health_addr().expect("the health listener is bound");
+
+    accepts(protocol, "protocol listener").await;
+    assert!(
+        healthz(health).await.starts_with("HTTP/1.1 200"),
+        "the probe surface is green before the failure"
+    );
+
+    assert!(
+        server.stop_commit_writer(),
+        "the commit writer is running and reachable"
+    );
+
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.run_until_stopped(std::future::pending()),
+    )
+    .await
+    .expect("supervision notices a dead commit writer without waiting for a signal");
+    assert_eq!(stopped, Stopped::TaskEnded(COMMIT_TASK));
+
+    // The load-bearing assertion, for #683's measured reason: the writer thread
+    // owns no socket at all, so *nothing* an outside observer can see changes
+    // when it dies. Without the fix both of these keep answering forever.
+    refuses(health, "health listener").await;
+    refuses(protocol, "protocol listener").await;
+}
+
+/// The watchdog is not a way to fake the above: killing the **watchdog task**
+/// is reported too, under the same name.
+///
+/// A supervisor that watched the write path from outside the supervised set
+/// would move the fail-open rather than close it — the relay would then have a
+/// process whose commit-writer watchdog had died and which nobody was watching.
+/// This asserts the watchdog is in the same `Vec<Supervised>` as the four tokio
+/// tasks and is covered by the same mechanism.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_commit_watchdog_is_itself_supervised() {
+    let mut server = Server::start(base()).await.expect("the relay starts");
+    let protocol = server.protocol_addr();
+    let health = server.health_addr().expect("the health listener is bound");
+    accepts(protocol, "protocol listener").await;
+
+    assert!(
+        server.abort_task(COMMIT_TASK),
+        "the commit watchdog is a supervised task like any other"
+    );
+
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(10),
+        server.run_until_stopped(std::future::pending()),
+    )
+    .await
+    .expect("supervision notices its own watchdog");
+    assert_eq!(stopped, Stopped::TaskEnded(COMMIT_TASK));
+    refuses(health, "health listener").await;
     refuses(protocol, "protocol listener").await;
 }

--- a/rs/crates/f2z-witness/src/health.rs
+++ b/rs/crates/f2z-witness/src/health.rs
@@ -49,8 +49,14 @@ use crate::state;
 pub const DEFAULT_STALE_AFTER_MS: u64 = 3_600_000;
 
 /// What a probe found.
+///
+/// Deliberately **not** `#[non_exhaustive]` (zuu#666), for the reason
+/// `f2z_relay::server::Stopped` is not: the binary is a separate crate from
+/// this library, so that attribute would force a wildcard arm on every match
+/// in `main`, and a wildcard arm is how a future verdict silently inherits
+/// somebody else's exit code. A new variant here should break every caller
+/// until each has decided what it means.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum Health {
     /// Following a log, last updated recently.
     Following {
@@ -80,9 +86,18 @@ pub enum Health {
 
 impl Health {
     /// Whether the probe should pass.
+    ///
+    /// Exhaustive rather than `matches!`, for [`Self::is_alive`]'s reason
+    /// (zuu#666). This one happens to be fail-*closed* today — anything new is
+    /// not `Following`, so it would fail readiness — but two predicates over
+    /// one enum written in two different styles is how the asymmetry arose in
+    /// the first place, and the fail-closed one is the cheap half to fix.
     #[must_use]
     pub const fn is_healthy(&self) -> bool {
-        matches!(self, Self::Following { .. })
+        match self {
+            Self::Following { .. } => true,
+            Self::Stale { .. } | Self::Halted { .. } | Self::Unpinned => false,
+        }
     }
 
     /// Whether a **liveness** probe should pass: `healthz --liveness yes`.
@@ -114,9 +129,34 @@ impl Health {
     /// halted witness is never reported as fine by the one check an operator
     /// looks at first. A `0/1` pod with `HALTED` in its probe output is the
     /// correct thing for a human to find.
+    ///
+    /// # Why this is a `match` and not `!matches!(self, Self::Halted { .. })`
+    ///
+    /// zuu#666. Written as a negation, this predicate **defaults a variant that
+    /// does not exist yet to "alive"**: a fifth local fault — a state file that
+    /// exists but cannot be read, a signature that does not verify, a second
+    /// halt-like condition — is not `Halted`, so the liveness probe passes and
+    /// the pod shows `1/1` while the witness sits in a fault it cannot leave.
+    /// The compiler said nothing, because the only exhaustive match on this
+    /// enum was [`Self::message`] — so adding a variant asked the author for a
+    /// **display string** and never for a verdict.
+    ///
+    /// An exhaustive match moves that question to the one place it belongs:
+    /// a new variant is a compile error *here*, where the author has to answer
+    /// "could a restart repair this?" — which the doc comment above frames
+    /// better than any test could, and which no test can ask on behalf of a
+    /// variant nobody has written yet.
     #[must_use]
     pub const fn is_alive(&self) -> bool {
-        !matches!(self, Self::Halted { .. })
+        match self {
+            // Statements about the upstream LOG. A restart cannot repair
+            // either, and restarting on a schedule during someone else's
+            // outage destroys the state file that is the evidence a human
+            // needs.
+            Self::Following { .. } | Self::Stale { .. } | Self::Unpinned => true,
+            // Local and permanent. Visible as `0/1` with HALTED in the output.
+            Self::Halted { .. } => false,
+        }
     }
 
     /// The process exit code for a readiness/startup probe.


### PR DESCRIPTION
Three fail-open defects of one shape, finished in **#683's** idiom rather than
in three new ones. Every rule fixed here is a rule that **could not fail**
before this PR — which is how all three survived review — so each lands with the
test that fails without it, and each was watched fail on unfixed code before the
fix was written.

Closes #684
Closes #685
Closes #666

---

## #684 — `f2z-kt`'s epoch scheduler was unsupervised

`server::serve` spawned the scheduler detached and then awaited the listener.
Nothing observed its join handle, so a panic ended that task and left the
process serving §9.2's endpoints correctly over a directory that had stopped
moving.

**Worse than the relay case, and measured rather than argued.** On the unfixed
shape — scheduler aborted, then a real `GET /healthz` on the bound port:

```
MEASURED after scheduler death: healthz=Some("HTTP/1.1 200 OK") epoch 1 -> 1
```

That is three seconds at a **one-second** cadence. Nothing errors. Clients keep
verifying against the last signed tree head, which stays valid; lookups keep
succeeding; and no client can distinguish *"no directory changes happened"* from
*"the log stopped incorporating them"*. `KT.md` §5.1's heartbeat epochs exist
precisely so silence is detectable — a dead scheduler does not **trip** that
mechanism, it **removes** it: there are no heartbeats to miss because nothing is
left to emit them.

### The fix

`Server::{start, run_until_stopped, supervise, abort_task}` in
`f2z-kt/src/server.rs`, the same shape as `f2z-relay`'s and deliberately not a
second idiom. `serve` now returns `Stopped`; `main` matches it **exhaustively**
(`Stopped` is not `#[non_exhaustive]`, for #683's reason) and exits non-zero on
`TaskEnded`. Shutdown is bounded by `SHUTDOWN_GRACE` so a wedged task cannot
hold the port. The scheduler also selects on the shutdown flag rather than being
`abort()`ed, so it can no longer be cancelled mid-`publish_epoch` — the one
operation in that process that writes.

### The test, and the evidence it can fail

`rs/crates/f2z-kt/tests/supervision.rs`, driven through the bound listener
because the property is what a kubelet and a load balancer observe. With
supervision removed (join handles not polled, exactly as before the fix):

```
running 4 tests
test a_requested_shutdown_is_not_a_failure ... ok
test the_scheduler_really_is_what_publishes_epochs ... ok
test a_dead_epoch_scheduler_stops_the_process_instead_of_staying_ready ... FAILED
test a_dead_http_listener_stops_the_process ... FAILED

supervision notices a dead scheduler without waiting for a signal: Elapsed(())
```

#683's measured correction applies directly and is why the assertion is on the
**health surface**: ending a task drops its own listener, so a test that only
checked the protocol port would pass on the defect. In `f2z-kt` the scheduler
owns *no* socket, which makes the point sharper — killing it changes nothing an
outside observer can see, and the assertion is that after the fix the process
stops.

`the_scheduler_really_is_what_publishes_epochs` is the positive control:
supervision of a task that published nothing would be supervision of a no-op,
and the other three tests would still pass.

### Spec

`KT.md` §5.1 carries a dated correction in `ARCHITECTURE.md` §4.9's style: the
cadence rule binds the log's **process**, not only its publishing code. Nothing
above it is withdrawn; what is added is that a conforming log MUST NOT keep
serving after whatever emits epochs has stopped, and that a *tick* that fails is
still a transient to be retried.

---

## #685 — the group-commit writer was outside #683's supervision

Not a missed name: a **type boundary**. `Supervised` holds
`tokio::task::JoinHandle`s, and the writer is an OS thread — for the reason
`commit.rs` argues at length, an fsync is a blocking syscall of unbounded
duration. Measured on the unfixed shape:

```
MEASURED after commit-writer death: healthz=Some("HTTP/1.1 200 OK") protocol_accepts=true
```

Every listener open, every probe green, and `APPEND` answering
`ERR_UNAVAILABLE`. Under delete-on-ack that is **data loss, not downtime**.

### The fix, and the trap it avoids

`CommitWriter::start` returns a `WriterStopped` alongside the handle: the thread
owns a `oneshot::Sender<Infallible>` it never sends on, so the **only** thing
that can complete the receiver is the sender being dropped — when `run` returns,
and when a panic unwinds out of it. There is nothing the writer has to remember
to do, which is the property that makes it trustworthy under a panic.

`server.rs` supervises a task that awaits exactly that, registered in the
**same** `Vec<Supervised>` as the other four. The instruction was not to solve a
supervision gap by adding an unsupervised supervisor, and this is how that is
satisfied: the watchdog's own death is reported identically, which
`the_commit_watchdog_is_itself_supervised` asserts.

**`spawn_blocking` was considered and rejected.** Its handle is pollable, but an
aborted blocking task cannot be cancelled once running: `shutdown()` awaits every
handle, so every ordinary stop would wait out `SHUTDOWN_GRACE`, and the test
that proves the supervision works could not produce the failure at all.

### The tests, and the evidence they can fail

The injection kills **the thread**, not the watchdog — aborting the watchdog
would pass identically on a build where nothing connected it to the writer,
which is precisely the defect. `Message::Stop` is behind `testing`, like
`abort_task`, and never reaches the binary. With the watchdog not registered
(`drop(writer_stopped)`, i.e. the pre-fix wiring):

```
cargo test -p f2z-relay --test supervision --test health
  supervision:  4 passed; 2 FAILED
    a_dead_commit_writer_stops_the_process_instead_of_answering_unavailable  FAILED
    the_commit_watchdog_is_itself_supervised                                 FAILED
  health:       7 passed; 0 failed        <- the issue's whole point
```

`commit.rs` also gains
`the_liveness_signal_fires_when_the_writer_thread_really_ends`, which uses **no
injection hook at all** — dropping the last `Sender` ends `run` for real — so
`stop_for_test` cannot be proving only that one testing path works.

---

## #666 — `Health::is_alive` was fail-open on a new variant

Reproduced exactly as the issue described, by adding a fifth variant to the
**unfixed** predicates:

```
cargo build -p f2z-witness   =>  one error, at message() only
PROBE is_healthy (readiness) => false  exit_code=1
PROBE is_alive   (liveness)  => true   liveness_exit_code=0
```

A brand-new local fault fails readiness for free and **passes liveness**: the
kubelet is satisfied and the pod shows `1/1` while the witness sits in a fault
it cannot leave. The compiler asked the author for a display string and never
for a verdict.

### The fix, and why the "test" is the compiler

Both predicates are now exhaustive matches, so the question — *could a restart
repair this?* — is forced at the decision point, where the doc comment already
frames it better than any test could. `Health` also loses `#[non_exhaustive]`,
for the reason #683's `Stopped` never had it: the binary is a separate crate, so
that attribute forces a wildcard arm in `main`, and a wildcard arm is how this
class recurs. Same experiment against the fixed tree:

```
error[E0004]: non-exhaustive patterns: `&Health::EvidenceUnreadable` not covered
   --> crates/f2z-witness/src/health.rs:99   (is_healthy)
   --> crates/f2z-witness/src/health.rs:153  (is_alive)
   --> crates/f2z-witness/src/health.rs:179  (message)
```

One error became three, and the two new ones are the ones that decide whether a
pod lives. No runtime test can ask this on behalf of a variant nobody has
written yet; the existing four-variant test stays as the runtime control.

---

## The audit, which is the part that was not filed

Every long-lived task and thread in the three binaries, not just the three
instances:

- **`f2z-relay`** — the four `Server::start` spawns (#683) plus the commit
  writer (this PR) are now the complete set. `listener.rs:127`, `admin.rs:190`,
  `connection.rs:54` and `engine.rs:1144` are per-connection or per-request:
  one of those dying is that connection's problem, and they are correctly
  outside the scheme.
- **`f2z-kt`** — `server.rs` was the only file with a `tokio::spawn`; both sites
  are now supervised. `signer.rs:217` is a per-signature KMS subprocess behind
  the `kms` feature, not long-lived.
- **`f2z-witness` — the obvious candidate, and not the same shape.** The poll
  loop is `main`'s own loop, not a task: every way out of it (`Halted`, a
  non-retryable error, `poll` mode) **returns from `main`**, so it cannot stop
  while the process lives, and there is no `/healthz` for a stalled loop to keep
  answering — the probe is `exec` on a separate invocation. The one wedge that
  could have made it fail open is a hung request, and `transport.rs` sets
  `timeout_global`, so a poll cannot block forever. A witness that is slow or
  cut off is `Health::Stale`, which fails readiness and deliberately passes
  liveness (§7.1: killing the observer does not fix the observed). **No fix, and
  nothing to file.**

## Gates

`check-rust-fmt.sh`, `check-rust-clippy.sh` (`-D warnings`, all 10 crates),
`check-rust-deny.sh`, `check-hash-domain-labels.mjs`,
`check-akd-doc-evidence.mjs`, `check-f2z-images.mjs`,
`check-public-repo-boundary.sh`, and `cargo test --locked --all-targets` +
`--doc` all pass locally. `#![forbid(unsafe_code)]` and the AGPL/permissive
boundary are unchanged; #649 is untouched.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
