### PR TITLE
fix(msg-identity): CKDh must hash the parent key (ARCHITECTURE.md §4.2)

### DIFF
--- a/docs/e2ee/ARCHITECTURE.md
+++ b/docs/e2ee/ARCHITECTURE.md
@@ -193,14 +193,73 @@ MSK  = (msk, cc_msk)  = BLAKE2b-512(personal = "Free2zMsg_MSTRv1", S)
                            or Orchard key trees even at identical indices.
 
 CKDh(node, i)         = BLAKE2b-512(personal = "Free2zMsg_CKDv1_",
-                                    cc_node || 0x11 || I2LEOSP32(i))
+                                    cc_node || 0x11 || ik_node || I2LEOSP32(i))
                         ── hardened only; there is no non-hardened variant and
                            no extended public key at any level of this tree.
+                        ── BOTH halves of the parent are in the preimage. See
+                           the correction below: an earlier revision omitted
+                           ik_node, which is not what ZIP 32 does.
+                        ── I2LEOSP32(i) encodes the HARDENED index, i + 2^31,
+                           as ZIP 32 serializes one: 32' is 0x80000020 and
+                           encodes as 20 00 00 80.
 
 account_node          = CKDh(CKDh(CKDh(MSK, 32'), 133'), account')
                            purpose' = 32'   (ZIP 32 idiom)
                            coin'    = 133'  (SLIP-44 Zcash)
 ```
+
+> **Correction (2026-08-25) — `CKDh` did not hash the parent key, and now it
+> does. This changes every key this tree derives.**
+>
+> The revision of `CKDh` above that shipped in
+> [#694](https://github.com/free2z/zuu/pull/694) read
+>
+> ```
+> CKDh(node, i) = BLAKE2b-512(personal = "Free2zMsg_CKDv1_",
+>                             cc_node || 0x11 || I2LEOSP32(i))     ← superseded
+> ```
+>
+> with `ik_node` absent from the preimage. That is **not** ZIP 32's shape, and
+> this section's whole justification is that it is written in ZIP 32's idiom
+> "because ZUULI already implements that shape and auditors already know it."
+> ZIP 32's Sapling hardened derivation is
+>
+> ```
+> I = PRF^expand(c_par, [0x11] || sk_par || I2LEOSP_32(i))
+>   = BLAKE2b-512(personal = "Zcash_ExpandSeed",
+>                 c_par || 0x11 || sk_par || I2LEOSP_32(i))
+> ```
+>
+> — the parent **spending key** is in the message. The corrected `CKDh` above is
+> that construction with the personalization changed and nothing else, so a
+> reader who knows [ZIP 32](https://zips.z.cash/zip-0032) §5.2 is reading a
+> function they already know. The dropped term is restored; no third
+> construction is invented.
+>
+> **What the omission cost, stated plainly.** It was not directly exploitable —
+> `cc_msk` is exactly as secret as `S` and is never published — but:
+>
+> - the key half of **every** node above the account level was dead weight;
+>   `msk` was never read by anything;
+> - all of the hierarchy's secret entropy below `MSK` reached `ik_account`
+>   through `cc_msk` **alone**, collapsing a two-part secret into a one-part
+>   secret;
+> - a bare chain code derived its **entire subtree**, so any future construct
+>   that treated a chain code as the less-sensitive half of a node would have
+>   been catastrophically wrong.
+>
+> **This changes every key derived from every seed.** It is safe only because
+> nothing has shipped: no user has a messaging identity, no directory entry
+> exists, and no peer has pinned a safety number. The cost of this correction is
+> zero today and unbounded after the first user; that asymmetry is the entire
+> reason it is being made now rather than filed.
+>
+> The implementation and its known-answer vectors move with it —
+> `rs/crates/f2z-msg-identity`, whose `tests/derivation_vectors.rs` pins the
+> corrected hierarchy from BIP-39's published all-`abandon` seed. **Every vector
+> in that file changed.** Found while implementing §4.2 for
+> [#311](https://github.com/free2z/zuu/issues/311); reported rather than coded
+> around.
 
 From `account_node`, every leaf is an HKDF-SHA256 expansion under a distinct
 versioned label (`HKDF-Expand(PRK = ik_account, info = label, L)`):

--- a/rs/crates/f2z-msg-identity/src/node.rs
+++ b/rs/crates/f2z-msg-identity/src/node.rs
@@ -5,7 +5,7 @@
 //! S                     = BIP-39 seed
 //! MSK  = (msk, cc_msk)  = BLAKE2b-512(personal = "Free2zMsg_MSTRv1", S)
 //! CKDh(node, i)         = BLAKE2b-512(personal = "Free2zMsg_CKDv1_",
-//!                                     cc_node || 0x11 || I2LEOSP32(i))
+//!                                     cc_node || 0x11 || ik_node || I2LEOSP32(i))
 //! account_node          = CKDh(CKDh(CKDh(MSK, 32'), 133'), account')
 //! ```
 //!
@@ -13,26 +13,39 @@
 //! at any level, which is why [`ExtendedNode`] has no `public()` and why
 //! nothing in this module returns a chain code to a caller.
 //!
-//! # Two things a reader of §4.2 should notice, because they are decisions
+//! # Two things a reader of §4.2 should notice
 //!
-//! **1. `CKDh` does not consume the parent key.** ZIP 32's hardened derivation
-//! is `PRF^expand(c_par, [0x11] || sk_par || I2LEOSP_32(i))` — the parent
-//! *spending key* is inside the hash. §4.2's is
-//! `BLAKE2b-512(personal, cc_node || 0x11 || I2LEOSP32(i))`, and `msk` /
-//! `ik_node` appear nowhere in it. It is implemented exactly as written,
-//! because implementing something else would mean this crate and the
-//! specification disagree about what a user's identity *is*.
+//! **1. `CKDh` hashes *both* halves of the parent — and it did not always.**
+//! The revision of §4.2 that #694 implemented had a preimage of
+//! `cc_node || 0x11 || I2LEOSP32(i)`, with `ik_node` absent. `ARCHITECTURE.md`
+//! §4.2 now carries a dated correction restoring it, and this module implements
+//! the corrected form.
 //!
-//! The consequence, stated so nobody has to rediscover it: the key half of
-//! every node above the account level is dead — `msk` itself is never read by
-//! anything — and the entire hierarchy's secret entropy reaches `ik_account`
-//! through `cc_msk` alone. That is 256 bits of a BLAKE2b-512 output, which is
-//! not a weakness; it does mean the tree carries half the state ZIP 32's does,
-//! and it means anyone holding an intermediate *chain code* can derive that
-//! node's whole subtree without its key. Since a chain code is only ever held
-//! alongside its key, no practical capability separates. Raised on the pull
-//! request rather than coded around. See `Cargo.toml`'s sibling note and the
-//! PR body for #311.
+//! The corrected preimage is **ZIP 32 §5.2's Sapling hardened derivation with
+//! the personalization changed and nothing else**:
+//!
+//! ```text
+//! ZIP 32:  I = PRF^expand(c_par, [0x11] || sk_par || I2LEOSP_32(i))
+//!            = BLAKE2b-512("Zcash_ExpandSeed", c_par || 0x11 || sk_par || I2LEOSP_32(i))
+//! here:    I = BLAKE2b-512("Free2zMsg_CKDv1_", cc_node || 0x11 || ik_node || I2LEOSP32(i))
+//! ```
+//!
+//! That was the point of the idiom — §4.2 chose it "because ZUULI already
+//! implements that shape and auditors already know it" — so the fix is to
+//! restore the dropped term rather than to invent a third construction. All
+//! four fields are fixed-width (32, 1, 32, 4 = 69 bytes), so the concatenation
+//! is unambiguous without a separator.
+//!
+//! What the omission would have cost, kept here because the *reason* a
+//! derivation looks the way it does is the part that stops someone
+//! "simplifying" it back: with `ik_node` out of the preimage, the key half of
+//! every node above the account level was dead weight, all secret entropy below
+//! `MSK` reached `ik_account` through `cc_msk` **alone** — a two-part secret
+//! collapsed into a one-part secret — and a bare chain code derived its entire
+//! subtree, so any later construct treating a chain code as the
+//! less-sensitive half of a node would have been catastrophically wrong.
+//! `ckd_reads_both_halves_of_the_parent` asserts the corrected behaviour from
+//! both directions.
 //!
 //! **2. `I2LEOSP32(i)` encodes the hardened index, not the ordinal.** §4.2
 //! writes `32'`, `133'`, `account'` in ZIP 32's notation and says the tree is
@@ -215,24 +228,40 @@ pub fn master_node(seed: &[u8]) -> Result<ExtendedNode, IdentityError> {
     )))
 }
 
+/// The width of a `CKDh` preimage: `cc_node ‖ 0x11 ‖ ik_node ‖ I2LEOSP32(i)`.
+///
+/// `32 + 1 + 32 + 4`. Every field is fixed-width, which is what makes the
+/// concatenation unambiguous without a separator — and it is why this is a
+/// `const` with the arithmetic written out rather than a magic number.
+const CKD_PREIMAGE_LEN: usize = 32 + 1 + 32 + 4;
+
 /// `CKDh(node, i) = BLAKE2b-512(personal = "Free2zMsg_CKDv1_", cc_node || 0x11
-/// || I2LEOSP32(i))` (§4.2).
+/// || ik_node || I2LEOSP32(i))` (§4.2, as corrected 2026-08-25).
+///
+/// **Both halves of the parent are in the preimage.** See the module note: an
+/// earlier revision of §4.2 omitted `ik_node`, which is not ZIP 32's shape and
+/// left the whole subtree derivable from a chain code alone. This is ZIP 32
+/// §5.2's Sapling hardened derivation with the personalization changed.
 ///
 /// Hardened only. There is no `CKDn`, and there will not be one: a non-hardened
 /// variant would require an extended public key at some level, and §4.2 has
 /// none at any level on purpose.
 #[must_use]
 pub fn ckd_hardened(node: &ExtendedNode, index: HardenedIndex) -> ExtendedNode {
-    // 32 + 1 + 4. A fixed-size buffer rather than a `Vec`: it is secret
-    // material and it is zeroized on the way out.
-    let mut preimage = Zeroizing::new([0u8; 37]);
+    // A fixed-size buffer rather than a `Vec`: it is secret material — it now
+    // carries the parent's key as well as its chain code — and it is zeroized
+    // on the way out.
+    let mut preimage = Zeroizing::new([0u8; CKD_PREIMAGE_LEN]);
     let (chain, rest) = preimage.split_at_mut(32);
     chain.copy_from_slice(node.chain_code());
-    let (tag, index_bytes) = rest.split_at_mut(1);
-    // `rest` is exactly 5 bytes, so both halves are the widths written above.
+    let (tag, rest) = rest.split_at_mut(1);
+    // `rest` is exactly 37 bytes here, so every split below is the width
+    // written in `CKD_PREIMAGE_LEN`.
     if let Some(slot) = tag.first_mut() {
         *slot = HARDENED_TAG;
     }
+    let (key, index_bytes) = rest.split_at_mut(32);
+    key.copy_from_slice(node.key());
     index_bytes.copy_from_slice(&index.to_le_bytes());
 
     ExtendedNode::from_digest(&blake2b512_personal(PERSONAL_CKD, preimage.as_slice()))
@@ -339,22 +368,64 @@ mod tests {
         assert_ne!(a.chain_code(), b.chain_code());
     }
 
-    /// The half of `CKDh` that §4.2 writes and that a reimplementation is most
-    /// likely to get wrong: the parent's *key* is not in the preimage, so two
-    /// nodes with the same chain code and different keys have the same
-    /// children. Asserted rather than described, because it is the property the
-    /// module note raises as a spec observation.
+    /// **The regression test for §4.2's 2026-08-25 correction.**
+    ///
+    /// Both halves of the parent must reach the child. The defect this replaces
+    /// was the exact inverse assertion — that flipping a bit of the parent's
+    /// *key* left the children unchanged — which was true, was what §4.2 then
+    /// said, and meant a bare chain code derived the whole subtree.
+    ///
+    /// Asserted from both directions, because either one alone would pass for a
+    /// `CKDh` that read the wrong single field.
     #[test]
-    fn ckd_reads_only_the_chain_code() {
+    fn ckd_reads_both_halves_of_the_parent() {
         let master = master_node(&SEED).unwrap();
-        let mut twin = master.clone();
-        twin.key[0] ^= 0xff;
         let index = HardenedIndex::new(7).unwrap();
+        let child = ckd_hardened(&master, index);
+
+        // One bit of the parent's key half.
+        let mut key_twin = master.clone();
+        key_twin.key[0] ^= 0x01;
+        assert_ne!(
+            ckd_hardened(&key_twin, index).key(),
+            child.key(),
+            "CKDh is ignoring the parent key — this is the #694 defect returning, \
+             and it means a chain code alone derives the whole subtree"
+        );
+
+        // One bit of the parent's chain code.
+        let mut chain_twin = master.clone();
+        chain_twin.chain_code[0] ^= 0x01;
+        assert_ne!(
+            ckd_hardened(&chain_twin, index).key(),
+            child.key(),
+            "CKDh is ignoring the parent chain code"
+        );
+    }
+
+    /// The preimage is the four fixed-width fields §4.2 names, in order.
+    ///
+    /// Built here a second time, by hand, and compared against the shipped
+    /// derivation. A field-order or width mistake inside `ckd_hardened` would
+    /// otherwise be invisible to every other test in this file — they would all
+    /// still see a deterministic, well-separated tree.
+    #[test]
+    fn the_ckd_preimage_is_chain_code_tag_key_index() {
+        let master = master_node(&SEED).unwrap();
+        let index = HardenedIndex::new(133).unwrap();
+
+        let mut expected = alloc::vec::Vec::with_capacity(CKD_PREIMAGE_LEN);
+        expected.extend_from_slice(master.chain_code());
+        expected.push(0x11);
+        expected.extend_from_slice(master.key());
+        expected.extend_from_slice(&index.to_le_bytes());
+        assert_eq!(expected.len(), CKD_PREIMAGE_LEN);
+
+        let by_hand = ExtendedNode::from_digest(&blake2b512_personal(PERSONAL_CKD, &expected));
+        assert_eq!(ckd_hardened(&master, index).key(), by_hand.key());
         assert_eq!(
-            ckd_hardened(&master, index).key(),
-            ckd_hardened(&twin, index).key(),
-            "if this ever fails, CKDh started reading the parent key and every \
-             identity moved; see the module note"
+            ckd_hardened(&master, index).chain_code(),
+            by_hand.chain_code()
         );
     }
 

--- a/rs/crates/f2z-msg-identity/tests/derivation_vectors.rs
+++ b/rs/crates/f2z-msg-identity/tests/derivation_vectors.rs
@@ -18,6 +18,21 @@
 //! crate note. A pull request that updates a value here is either fixing a
 //! defect found before launch or is wrong.
 //!
+//! # Every value below changed on 2026-08-25, and this is the one that was
+//!
+//! `ARCHITECTURE.md` §4.2 carries a dated correction: `CKDh`'s preimage omitted
+//! the parent key, and now reads `cc_node ‖ 0x11 ‖ ik_node ‖ I2LEOSP32(i)`.
+//! Every node below `MSK` and every leaf therefore has a different value than
+//! the vectors #694 shipped. `MSK` itself is unchanged — the master derivation
+//! never involved `CKDh` — which is a useful thing to notice when reading the
+//! diff: a correction that moved `MSK` too would have been a different and
+//! larger change.
+//!
+//! It was safe to make **only** because nothing had shipped. No user had an
+//! identity, no directory entry existed, no safety number had been pinned. That
+//! is exactly the window this file exists to make it possible to act inside, and
+//! it is now closed for anything further.
+//!
 //! # The rule this file is written under
 //!
 //! The same one `f2z-codec/tests/wire_vectors.rs` states: **every expected
@@ -75,33 +90,33 @@ const MSK: &str = "74f055750feeefebb248b31b88aae0b2b9b0b0db1c0f520eb831d30243c87
                    91d0cc16887876d54b585fa850dd2b2c1aecbe525e4d300b8b15dd7677de373a";
 
 /// `CKDh(MSK, 32')` — the `purpose'` level.
-const NODE_PURPOSE: &str = "2ca48d29539f895d3566a0de26c1ea0274b5c698b0d371836b448aaeaaca8b1c\
-                            21d0e04ea3c254f9619003132a9350756280c4a50e5b11bb656897f925faf733";
+const NODE_PURPOSE: &str = "288530fcef32ace05c9545252ac22fd9d8f070b0961b3bb8e955c0e86922d906\
+                            1f9b549adf14b522e5ab8fe6658282cc5fccc1fdcef7c9f5a8a921e58fad0bd9";
 
 /// `CKDh(CKDh(MSK, 32'), 133')` — the `coin_type'` level, SLIP-44 Zcash.
-const NODE_COIN: &str = "020d1c3484f121f46c06bd68426ce3ceba7a5fd3b6f08665eb06dec300f45073\
-                         a92ebad0cb0c113cf905f5cca3a0fc42ab37ad501eeeda9d0da525293d82a2ad";
+const NODE_COIN: &str = "8b269b6624b43f1794346249cbd4c0cf6f835467f9937f997265805ad8632464\
+                         1f0c258f743e7b01b85ed3c1c4732f66c2784a53b924a28bb74c5806b07285cf";
 
 /// `account_node = CKDh(CKDh(CKDh(MSK, 32'), 133'), 0')`, as
 /// `ik_account || cc_account`.
-const ACCOUNT_NODE: &str = "21e92468197afc2b0b5390f00ae5dcff4a686d1f973bb15d56081d031eb63679\
-                            9b24166797e30a4cad0c4adc0496bc7c0d976a21db9208c821e7151644931dcb";
+const ACCOUNT_NODE: &str = "dbd4245907a1e6e0368d41ad784262d99f52ae7e8f6ce14ab3ef46efb811c627\
+                            1462b713c286891f5298d6e625319fb7b16382c8509b18bffaa928ecd2801102";
 
 /// `IdentitySigningKey.public`, from
 /// `HKDF-Expand(ik_account, "free2z/msg/v1/identity-sig", 32)`.
-const ISK_PUBLIC: &str = "cf7011daaf3200aee965329b1976ab6e3d397402f914fdd8e27e0a4147195cdd";
+const ISK_PUBLIC: &str = "e73fcd0648504865a6a582473c961cab75b3e6b108bff18196ef80aa41955199";
 
 /// `CeremonySigningKey.public`, label `free2z/msg/v1/ceremony-sig`.
-const CSK_PUBLIC: &str = "96c347ec69459beab59e76fa7571e27692da7ae85384a9546e3ef83f822eb902";
+const CSK_PUBLIC: &str = "c5027046f3bb8b8251e060b99b52f9044210791a148c0ebae05c8c2f5e4f4c6c";
 
 /// `DirectoryAuthKey.public`, label `free2z/msg/v1/directory-auth`.
 const DIRECTORY_AUTH_PUBLIC: &str =
-    "9084ebcc6f68eff30bdb3765780714fd49a67f98b0afa14a88f63aa117d44606";
+    "e8a99244307a22722cb61bdac80098c8c826d1fa8c064de5e685bb926cd7130b";
 
 /// `BackupWrapKey`, label `free2z/msg/v1/backup-wrap`. The one leaf whose
 /// secret bytes *are* the key, so the vector is the secret rather than a public
 /// half — which is fine, because this seed's identity is published in BIP-39.
-const BACKUP_WRAP: &str = "13ace59b8f2e13e5f475bc89348328a5e6cde431ecb9dffb1529895aed44f3d7";
+const BACKUP_WRAP: &str = "479083aada9066af10d708d474199ae99416dd80bd3f5bcefa68c65a2c30270e";
 
 // The `DeviceCredential` fixture. Fixed values, chosen so a reviewer can see
 // them in a hex dump: a device key of all `0x07`, a KEM key of all `0xab`, and
@@ -137,8 +152,8 @@ const CREDENTIAL_TBS_LEN: usize = 1332;
 /// Ed25519 signing is deterministic (RFC 8032 §5.1.6), so this is a known
 /// answer rather than one valid answer among many — which is what makes it
 /// usable as a cross-implementation vector at all.
-const CREDENTIAL_SIGNATURE: &str = "6bd3f57d6685b1bdf3ee265783feed76acc8fa89af5b0f8bcc36d2bc30222e32\
-     994b6286fc98bb4e78b31b172110d26970e54022b55366bcc43f2dde0b22780b";
+const CREDENTIAL_SIGNATURE: &str = "24785757ba36d112cb310dd6bad39b027776ca693848c1d56557f011b4bda4ed\
+     196c1a0f59e14d9a100c1d10e1be9f9f779c164492e7e713b1a930080e017806";
 
 // ---------------------------------------------------------------------------
 
@@ -185,10 +200,15 @@ fn transcribed_node_bytes(chain: &[u32]) -> Vec<u8> {
 
     let mut node = blake2b512_personal(b"Free2zMsg_MSTRv1", &seed()).to_vec();
     for ordinal in chain {
-        let mut preimage = Vec::with_capacity(37);
+        // §4.2 as corrected 2026-08-25:
+        //     cc_node || 0x11 || ik_node || I2LEOSP32(i)
+        // Both halves of the parent, four fixed-width fields, 69 bytes.
+        let mut preimage = Vec::with_capacity(69);
         preimage.extend_from_slice(&node[32..]);
         preimage.push(0x11);
+        preimage.extend_from_slice(&node[..32]);
         preimage.extend_from_slice(&(ordinal | 0x8000_0000).to_le_bytes());
+        assert_eq!(preimage.len(), 69);
         node = blake2b512_personal(b"Free2zMsg_CKDv1_", &preimage).to_vec();
     }
     node
@@ -358,9 +378,11 @@ fn the_whole_credential_re_encodes_canonically() {
 /// def b2(personal, data):
 ///     return hashlib.blake2b(data, digest_size=64, person=personal).digest()
 ///
-/// def ckdh(node, ordinal):                       # ARCHITECTURE.md §4.2
-///     return b2(b"Free2zMsg_CKDv1_",
-///               node[32:] + b"\x11" + (ordinal | 0x80000000).to_bytes(4, "little"))
+/// def ckdh(node, ordinal):        # ARCHITECTURE.md §4.2, corrected 2026-08-25
+///     ik, cc = node[:32], node[32:]
+///     pre = cc + b"\x11" + ik + (ordinal | 0x80000000).to_bytes(4, "little")
+///     assert len(pre) == 32 + 1 + 32 + 4 == 69   # both halves of the parent
+///     return b2(b"Free2zMsg_CKDv1_", pre)
 ///
 /// def hkdf_expand(prk, info, length):            # RFC 5869 §2.3
 ///     out, t, counter = b"", b"", 1


### PR DESCRIPTION
# ⚠️ This changes every key the messaging hierarchy derives, from every seed

`ARCHITECTURE.md` §4.2's `CKDh` did not hash the parent key. It does now. **Every
node below `MSK`, every account leaf, and every `DeviceCredential` signature is a
different value than the vectors #694 shipped three hours ago.**

That is safe **only because nothing has shipped**: no user has a messaging
identity, no directory entry exists in any log, and no peer has pinned a safety
number. The cost of this correction is zero today and unbounded after the first
user. That asymmetry is the whole reason it is being made now rather than filed.

> **This is a follow-up, not an amendment.** #694 was squash-merged to `main`
> (`def7687`) before the defect was actioned, so the fix ships as its own PR
> against the merged text. `main` currently contains the defective derivation.

---

## The defect

```
CKDh(node, i) = BLAKE2b-512(personal = "Free2zMsg_CKDv1_",
                            cc_node || 0x11 || I2LEOSP32(i))     ← superseded
```

`ik_node` is absent. ZIP 32 §5.2's Sapling hardened derivation is

```
I = PRF^expand(c_par, [0x11] || sk_par || I2LEOSP_32(i))
  = BLAKE2b-512("Zcash_ExpandSeed", c_par || 0x11 || sk_par || I2LEOSP_32(i))
```

— the parent **spending key** is in the message. §4.2's own justification for the
idiom is that it is written in ZIP 32's shape *"because ZUULI already implements
that shape and auditors already know it."* It was not.

**Not directly exploitable today.** `cc_msk` is exactly as secret as `S` and is
never published. What it cost is structural:

- the key half of **every** node above the account level was dead weight; `msk`
  was never read by anything;
- all secret entropy below `MSK` reached `ik_account` through `cc_msk` **alone**
  — a two-part secret collapsed into a one-part secret;
- a bare chain code derived its **entire subtree**, so any later construct that
  treated a chain code as the less-sensitive half of a node would have been
  catastrophically wrong.

## The fix

```
CKDh(node, i) = BLAKE2b-512(personal = "Free2zMsg_CKDv1_",
                            cc_node || 0x11 || ik_node || I2LEOSP32(i))
```

**ZIP 32 §5.2 with the personalization changed and nothing else.** The dropped
term is restored in the position ZIP 32 puts it; no third construction is
invented, because auditor familiarity was the entire argument for the idiom.
All four fields are fixed-width (`32 + 1 + 32 + 4 = 69`), so the concatenation is
unambiguous with no separator.

`ARCHITECTURE.md` §4.2 carries a **dated correction (2026-08-25)** in the house
style — the superseded form stays visible, struck through in prose rather than
silently rewritten, with the consequence analysis and the "safe only because
nothing has shipped" reasoning recorded next to it.

## Regenerated vectors

Recomputed **independently in Python** again — `hashlib.blake2b(person=…)`, a
hand-written RFC 5869 §2.3 `HKDF-Expand`, `cryptography`'s Ed25519 — never
printed from the implementation. The updated transcript is in the test file's
doc comment.

```
seed (BIP-39, all-`abandon`, unchanged)
             5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc1
             9a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4
MSK          74f055750feeefebb248b31b88aae0b2b9b0b0db1c0f520eb831d30243c87096   ← UNCHANGED
             91d0cc16887876d54b585fa850dd2b2c1aecbe525e4d300b8b15dd7677de373a
  32'        288530fcef32ace05c9545252ac22fd9d8f070b0961b3bb8e955c0e86922d906
             1f9b549adf14b522e5ab8fe6658282cc5fccc1fdcef7c9f5a8a921e58fad0bd9
  133'       8b269b6624b43f1794346249cbd4c0cf6f835467f9937f997265805ad8632464
             1f0c258f743e7b01b85ed3c1c4732f66c2784a53b924a28bb74c5806b07285cf
  0'         dbd4245907a1e6e0368d41ad784262d99f52ae7e8f6ce14ab3ef46efb811c627   ← ik_account
             1462b713c286891f5298d6e625319fb7b16382c8509b18bffaa928ecd2801102
ISK.public   e73fcd0648504865a6a582473c961cab75b3e6b108bff18196ef80aa41955199
CSK.public   c5027046f3bb8b8251e060b99b52f9044210791a148c0ebae05c8c2f5e4f4c6c
DirAuth.pub  e8a99244307a22722cb61bdac80098c8c826d1fa8c064de5e685bb926cd7130b
BackupWrap   479083aada9066af10d708d474199ae99416dd80bd3f5bcefa68c65a2c30270e
DeviceCredentialTBS  1332 bytes (unchanged — the encoding did not move)
signature    24785757ba36d112cb310dd6bad39b027776ca693848c1d56557f011b4bda4ed
             196c1a0f59e14d9a100c1d10e1be9f9f779c164492e7e713b1a930080e017806
```

**`MSK` is unchanged and that is worth noticing while reading the diff** — the
master derivation never involved `CKDh`. A correction that moved `MSK` too would
have been a different and larger change.

The node levels are still asserted twice: once against the shipped
`master_node`/`ckd_hardened`, once against a second in-test transcription of
§4.2 (now updated to the corrected preimage, with a `69` length assertion).

## The test that asserted the defect is gone

`ckd_reads_only_the_chain_code` — which asserted that flipping a bit of the
parent's key left the children unchanged, and *passed*, because that was what
§4.2 then said — is replaced by:

- **`ckd_reads_both_halves_of_the_parent`**, asserting from **both** directions
  that a one-bit change to either half moves the child. Either direction alone
  would pass for a `CKDh` that read the wrong single field.
- **`the_ckd_preimage_is_chain_code_tag_key_index`**, which rebuilds the 69-byte
  preimage by hand and compares. A field-order or width mistake inside
  `ckd_hardened` is otherwise invisible to every other test in the file — they
  would all still see a deterministic, well-separated tree.

## Still true, and re-verified against the new derivation

`tests/kt_core_agreement.rs` (all five cases — the acceptance test that
`f2z_kt_core::validate_submission` accepts what this crate issues),
`tests/zcash_separation.rs` (#311's disjointness criterion),
`tests/no_seed_derived_device_keys.rs`, and `tests/redaction.rs` all pass
unchanged. None of them depends on a derivation *constant*, which is the correct
outcome: they test properties, and the vectors test values.

## The other vector-affecting call — check both in one pass

**`I2LEOSP32(i)` still encodes the hardened index whole**: `32'` is `0x8000_0020`
→ `20 00 00 80` little-endian, as ZIP 32 serializes one. The corrected
construction does not make the other reading (bare ordinal) any more or less
right, so the call stands — but it is the *other* thing that silently changes
every identity, and a reviewer looking at `CKDh` today should confirm this in the
same pass. `HardenedIndex` takes the ordinal and sets the bit itself, so there is
exactly one spelling of a path in the crate.

## Kept as-is, per review

- **The `Blake2bMac512` trap note in `src/blake.rs`.** `blake2 0.10`'s obvious
  spelling for personalized BLAKE2b prepends a padded key block even with an
  empty key: the digest looks right and matches no other implementation on
  earth. That note stays visible for the next person who tries to simplify the
  file.
- **The `DeviceInitKey` scope call.** X-Wing comes from OpenMLS's libcrux
  provider (§3.1); a second combiner here is the divergence ADR 0001 exists to
  prevent.

## Verification

| Check | Result |
|---|---|
| `cargo test --locked --all-targets` (rs workspace) | ✅ exit 0 |
| `cargo test --locked --doc` | ✅ exit 0 |
| `cargo build --locked --lib --target wasm32-unknown-unknown -p f2z-msg-identity` | ✅ |
| `scripts/check-rust-fmt.sh --root rs` | ✅ 11/11 |
| `scripts/check-rust-clippy.sh --root rs` | ✅ 11/11 |
| `scripts/check-hash-domain-labels.mjs` | ✅ 49 labels prefix-free |
| `scripts/check-rust-toolchain.sh` | ✅ |

No dependency, manifest or lockfile change — this is three files: the
specification, `src/node.rs`, and the vectors.

Refs #311, follows up #694.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
