### PR TITLE
test(release): bind Linux packaging fixture selection

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -391,7 +391,7 @@ jobs:
       - run: npm ci
       - name: Test Linux artifact inspectors against real packages
         if: runner.os == 'Linux'
-        run: node --test --test-name-pattern='real AppImage, deb, and rpm|AppImage inspection|AppImage listing|real deb with an escaping' scripts/artifact-sbom.node-test.mjs
+        run: node scripts/run-linux-artifact-fixtures.mjs
       - run: npm run release:verify
       - name: Verify Rust compiler
         run: rustc --version | grep -F "rustc $ZUULI_RUST_VERSION "

--- a/wallet/zuuli/scripts/artifact-sbom.mjs
+++ b/wallet/zuuli/scripts/artifact-sbom.mjs
@@ -1572,6 +1572,34 @@ function requireExactRunStep(
   }
 }
 
+function requireExactCommandStep(
+  label,
+  block,
+  stepName,
+  expectedCommand,
+  failures,
+  expectedIf,
+) {
+  const marker = `\n      - name: ${stepName}\n`;
+  const count = block.split(marker).length - 1;
+  if (count !== 1) {
+    failures.push(
+      `${label}: expected one named ${stepName} step, found ${count}`,
+    );
+    return;
+  }
+  const rest = block.slice(block.indexOf(marker) + marker.length);
+  const next = rest.search(/^      - /m);
+  const step = (next === -1 ? rest : rest.slice(0, next)).trimEnd();
+  const expected = [
+    ...(expectedIf ? [`        if: ${expectedIf}`] : []),
+    `        run: ${expectedCommand}`,
+  ].join("\n");
+  if (step !== expected) {
+    failures.push(`${label}: ${stepName} executable step changed`);
+  }
+}
+
 function requireExactActionStep(
   label,
   block,
@@ -1616,6 +1644,14 @@ export function artifactSbomWorkflowFailures(packaging, release) {
   const failures = [];
   const packagingLinux = jobBlock(packaging, "desktop");
   const releaseLinux = jobBlock(release, "linux");
+  requireExactCommandStep(
+    "packaging linux",
+    packagingLinux,
+    "Test Linux artifact inspectors against real packages",
+    "node scripts/run-linux-artifact-fixtures.mjs",
+    failures,
+    "runner.os == 'Linux'",
+  );
   const prepareLinuxLines = [
     "appimages=(release-artifacts/*.AppImage)",
     "debs=(release-artifacts/*.deb)",
@@ -1763,7 +1799,7 @@ export function artifactSbomWorkflowFailures(packaging, release) {
       "packaging linux",
       jobBlock(packaging, "desktop"),
       [
-        "node --test --test-name-pattern='real AppImage, deb, and rpm|AppImage inspection|AppImage listing|real deb with an escaping' scripts/artifact-sbom.node-test.mjs",
+        "node scripts/run-linux-artifact-fixtures.mjs",
         'node scripts/artifact-sbom.mjs prepare --artifact="${appimages[0]}" --root=artifact-sbom-work/linux-appimage/root',
         'node scripts/artifact-sbom.mjs prepare --artifact="${debs[0]}" --root=artifact-sbom-work/linux-deb/root',
         'node scripts/artifact-sbom.mjs prepare --artifact="${rpms[0]}" --root=artifact-sbom-work/linux-rpm/root',

--- a/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
+++ b/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
   appendFileSync,
   copyFileSync,
@@ -14,7 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, resolve } from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -31,6 +31,12 @@ import {
   validateLogicalEntries,
   verifyArtifactSbom,
 } from "./artifact-sbom.mjs";
+import {
+  LINUX_ARTIFACT_FIXTURE_TITLES,
+  linuxArtifactFixturePattern,
+  REQUIRE_LINUX_ARTIFACT_FIXTURES,
+  runLinuxArtifactFixtures,
+} from "./run-linux-artifact-fixtures.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const appRoot = resolve(scriptDirectory, "..");
@@ -119,6 +125,105 @@ function commandExists(command) {
 
 const canBuildLinuxFixtures =
   process.platform === "linux" && linuxFixtureTools.every(commandExists);
+const requireLinuxFixtures =
+  process.env[REQUIRE_LINUX_ARTIFACT_FIXTURES] === "1";
+const missingLinuxFixtureTools = linuxFixtureTools.filter(
+  (command) => !commandExists(command),
+);
+if (
+  requireLinuxFixtures &&
+  (process.platform !== "linux" || missingLinuxFixtureTools.length > 0)
+) {
+  throw new Error(
+    `required Linux artifact fixtures cannot run: platform=${process.platform}; missing tools=${missingLinuxFixtureTools.join(",") || "none"}`,
+  );
+}
+
+const registeredLinuxFixtureTitles = [];
+function linuxArtifactFixture(title, implementation) {
+  assert.ok(
+    LINUX_ARTIFACT_FIXTURE_TITLES.includes(title),
+    `Linux artifact fixture has an unregistered title: ${title}`,
+  );
+  registeredLinuxFixtureTitles.push(title);
+  test(
+    title,
+    { skip: !canBuildLinuxFixtures, timeout: 120_000 },
+    implementation,
+  );
+}
+
+after(() => {
+  assert.deepEqual(
+    [...registeredLinuxFixtureTitles].sort(),
+    [...LINUX_ARTIFACT_FIXTURE_TITLES].sort(),
+    "registered Linux artifact fixtures must exactly equal the shipping selector",
+  );
+});
+
+test("Linux packaging runner binds every selected fixture to a real passing test", () => {
+  const expectedTitles = [
+    "real AppImage, deb, and rpm fixtures expose undeclared shipped canaries",
+    "AppImage inspection fails closed on ELF arithmetic and SquashFS boundary mutations",
+    "AppImage listing rejects a SquashFS member with invalid UTF-8 bytes",
+    "a real deb with an escaping payload symlink fails before extraction",
+  ];
+  assert.deepEqual(LINUX_ARTIFACT_FIXTURE_TITLES, expectedTitles);
+
+  let invocation;
+  assert.doesNotThrow(() =>
+    runLinuxArtifactFixtures({
+      spawn(command, args, options) {
+        invocation = { command, args, options };
+        return { status: 0 };
+      },
+    }),
+  );
+  assert.equal(invocation.command, process.execPath);
+  assert.deepEqual(invocation.args, [
+    "--test",
+    `--test-name-pattern=${linuxArtifactFixturePattern()}`,
+    resolve(scriptDirectory, "artifact-sbom.node-test.mjs"),
+  ]);
+  assert.equal(
+    invocation.options.env[REQUIRE_LINUX_ARTIFACT_FIXTURES],
+    "1",
+  );
+  assert.equal(invocation.options.stdio, "inherit");
+  const missingToolEnvironment = {
+    ...process.env,
+    PATH: "",
+    [REQUIRE_LINUX_ARTIFACT_FIXTURES]: "1",
+  };
+  delete missingToolEnvironment.NODE_TEST_CONTEXT;
+  const missingToolProbe = spawnSync(
+    process.execPath,
+    [
+      "--test",
+      "--test-name-pattern=nonexistent",
+      resolve(scriptDirectory, "artifact-sbom.node-test.mjs"),
+    ],
+    {
+      encoding: "utf8",
+      env: missingToolEnvironment,
+    },
+  );
+  assert.notEqual(missingToolProbe.status, 0);
+  assert.match(
+    `${missingToolProbe.stdout}${missingToolProbe.stderr}`,
+    /required Linux artifact fixtures cannot run: .*missing tools=cc,dpkg-deb,mksquashfs,readelf,rpm2archive,rpmbuild,unsquashfs/,
+  );
+  assert.throws(
+    () =>
+      runLinuxArtifactFixtures({
+        spawn() {
+          return { status: 1 };
+        },
+      }),
+    /test process exited with status 1/,
+    "the shipping runner must propagate fixture failures",
+  );
+});
 
 function writeCanaryPayload(root) {
   const canary = resolve(root, "usr/lib/zuuli/libundeclared-canary.so");
@@ -420,9 +525,8 @@ function assertRealLinuxArtifactBoundary(temporary, label, artifact) {
   }
 }
 
-test(
+linuxArtifactFixture(
   "real AppImage, deb, and rpm fixtures expose undeclared shipped canaries",
-  { skip: !canBuildLinuxFixtures, timeout: 120_000 },
   () => {
     const temporary = mkdtempSync(
       resolve(tmpdir(), "zuuli-linux-artifact-sbom-"),
@@ -449,9 +553,8 @@ test(
   },
 );
 
-test(
+linuxArtifactFixture(
   "AppImage inspection fails closed on ELF arithmetic and SquashFS boundary mutations",
-  { skip: !canBuildLinuxFixtures, timeout: 120_000 },
   () => {
     const temporary = mkdtempSync(
       resolve(tmpdir(), "zuuli-appimage-mutation-"),
@@ -601,9 +704,8 @@ test(
   },
 );
 
-test(
+linuxArtifactFixture(
   "AppImage listing rejects a SquashFS member with invalid UTF-8 bytes",
-  { skip: !canBuildLinuxFixtures, timeout: 120_000 },
   () => {
     const temporary = mkdtempSync(
       resolve(tmpdir(), "zuuli-appimage-utf8-mutation-"),
@@ -624,9 +726,8 @@ test(
   },
 );
 
-test(
+linuxArtifactFixture(
   "a real deb with an escaping payload symlink fails before extraction",
-  { skip: !canBuildLinuxFixtures, timeout: 120_000 },
   () => {
     const temporary = mkdtempSync(resolve(tmpdir(), "zuuli-deb-mutation-"));
     try {
@@ -1463,13 +1564,44 @@ test("workflow contract catches removal or weakening of artifact scans", () => {
     "the policy must keep all Linux scans and bindings before manifest/upload",
   );
   const skippedRealFixtures = packaging.replace(
-    "node --test --test-name-pattern='real AppImage, deb, and rpm|AppImage inspection|AppImage listing|real deb with an escaping' scripts/artifact-sbom.node-test.mjs",
+    "node scripts/run-linux-artifact-fixtures.mjs",
     "node --test --test-name-pattern='nonexistent' scripts/artifact-sbom.node-test.mjs",
   );
+  assert.notEqual(skippedRealFixtures, packaging);
   assert.ok(
     artifactSbomWorkflowFailures(skippedRealFixtures, release).some((failure) =>
-      failure.includes("packaging linux"),
+      failure.includes(
+        "Test Linux artifact inspectors against real packages executable step changed",
+      ),
     ),
+  );
+  const decorativeRealFixtures = packaging.replace(
+    "        run: node scripts/run-linux-artifact-fixtures.mjs",
+    "        run: node --test --test-name-pattern='nonexistent' scripts/artifact-sbom.node-test.mjs\n        # node scripts/run-linux-artifact-fixtures.mjs",
+  );
+  assert.notEqual(decorativeRealFixtures, packaging);
+  assert.ok(
+    artifactSbomWorkflowFailures(decorativeRealFixtures, release).some(
+      (failure) =>
+        failure.includes(
+          "Test Linux artifact inspectors against real packages executable step changed",
+        ),
+    ),
+    "a comment containing the reviewed runner cannot authorize a different command",
+  );
+  const softFailingRealFixtures = packaging.replace(
+    "        run: node scripts/run-linux-artifact-fixtures.mjs",
+    "        continue-on-error: true\n        run: node scripts/run-linux-artifact-fixtures.mjs",
+  );
+  assert.notEqual(softFailingRealFixtures, packaging);
+  assert.ok(
+    artifactSbomWorkflowFailures(softFailingRealFixtures, release).some(
+      (failure) =>
+        failure.includes(
+          "Test Linux artifact inspectors against real packages executable step changed",
+        ),
+    ),
+    "the real fixture runner cannot soft-fail",
   );
   const sourceScanSubstitution = release.replace(
     "path: wallet/zuuli/artifact-sbom-work/linux-deb/root",

--- a/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
+++ b/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
@@ -14,7 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, resolve } from "node:path";
-import test, { after } from "node:test";
+import test, { after, beforeEach } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -140,6 +140,7 @@ if (
 }
 
 const registeredLinuxFixtureTitles = [];
+const completedLinuxFixtureTitles = [];
 function linuxArtifactFixture(title, implementation) {
   assert.ok(
     LINUX_ARTIFACT_FIXTURE_TITLES.includes(title),
@@ -149,9 +150,23 @@ function linuxArtifactFixture(title, implementation) {
   test(
     title,
     { skip: !canBuildLinuxFixtures, timeout: 120_000 },
-    implementation,
+    async () => {
+      await implementation();
+      completedLinuxFixtureTitles.push(title);
+    },
   );
 }
+
+beforeEach((context) => {
+  if (
+    requireLinuxFixtures &&
+    !LINUX_ARTIFACT_FIXTURE_TITLES.includes(context.name)
+  ) {
+    throw new Error(
+      `required Linux artifact selector reached a non-fixture test: ${context.name}`,
+    );
+  }
+});
 
 after(() => {
   assert.deepEqual(
@@ -159,6 +174,13 @@ after(() => {
     [...LINUX_ARTIFACT_FIXTURE_TITLES].sort(),
     "registered Linux artifact fixtures must exactly equal the shipping selector",
   );
+  if (requireLinuxFixtures) {
+    assert.deepEqual(
+      [...completedLinuxFixtureTitles].sort(),
+      [...LINUX_ARTIFACT_FIXTURE_TITLES].sort(),
+      "every required Linux artifact fixture body must complete successfully exactly once",
+    );
+  }
 });
 
 test("Linux packaging runner binds every selected fixture to a real passing test", () => {
@@ -169,6 +191,9 @@ test("Linux packaging runner binds every selected fixture to a real passing test
     "a real deb with an escaping payload symlink fails before extraction",
   ];
   assert.deepEqual(LINUX_ARTIFACT_FIXTURE_TITLES, expectedTitles);
+  const expectedPattern =
+    "^(?:real AppImage, deb, and rpm fixtures expose undeclared shipped canaries|AppImage inspection fails closed on ELF arithmetic and SquashFS boundary mutations|AppImage listing rejects a SquashFS member with invalid UTF-8 bytes|a real deb with an escaping payload symlink fails before extraction)$";
+  assert.equal(linuxArtifactFixturePattern(), expectedPattern);
 
   let invocation;
   assert.doesNotThrow(() =>
@@ -182,7 +207,7 @@ test("Linux packaging runner binds every selected fixture to a real passing test
   assert.equal(invocation.command, process.execPath);
   assert.deepEqual(invocation.args, [
     "--test",
-    `--test-name-pattern=${linuxArtifactFixturePattern()}`,
+    `--test-name-pattern=${expectedPattern}`,
     resolve(scriptDirectory, "artifact-sbom.node-test.mjs"),
   ]);
   assert.equal(

--- a/wallet/zuuli/scripts/run-linux-artifact-fixtures.mjs
+++ b/wallet/zuuli/scripts/run-linux-artifact-fixtures.mjs
@@ -1,0 +1,69 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const EXPECTED_LINUX_ARTIFACT_FIXTURE_COUNT = 4;
+
+export const REQUIRE_LINUX_ARTIFACT_FIXTURES =
+  "ZUULI_REQUIRE_LINUX_ARTIFACT_FIXTURES";
+export const LINUX_ARTIFACT_FIXTURE_TITLES = Object.freeze([
+  "real AppImage, deb, and rpm fixtures expose undeclared shipped canaries",
+  "AppImage inspection fails closed on ELF arithmetic and SquashFS boundary mutations",
+  "AppImage listing rejects a SquashFS member with invalid UTF-8 bytes",
+  "a real deb with an escaping payload symlink fails before extraction",
+]);
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function linuxArtifactFixturePattern() {
+  const uniqueTitles = new Set(LINUX_ARTIFACT_FIXTURE_TITLES);
+  if (
+    LINUX_ARTIFACT_FIXTURE_TITLES.length !==
+      EXPECTED_LINUX_ARTIFACT_FIXTURE_COUNT ||
+    uniqueTitles.size !== EXPECTED_LINUX_ARTIFACT_FIXTURE_COUNT
+  ) {
+    throw new Error(
+      `Linux artifact fixture selector must contain exactly ${EXPECTED_LINUX_ARTIFACT_FIXTURE_COUNT} unique titles`,
+    );
+  }
+  return `^(?:${LINUX_ARTIFACT_FIXTURE_TITLES.map(escapeRegExp).join("|")})$`;
+}
+
+export function runLinuxArtifactFixtures({ spawn = spawnSync } = {}) {
+  const result = spawn(
+    process.execPath,
+    [
+      "--test",
+      `--test-name-pattern=${linuxArtifactFixturePattern()}`,
+      resolve(scriptDirectory, "artifact-sbom.node-test.mjs"),
+    ],
+    {
+      env: {
+        ...process.env,
+        [REQUIRE_LINUX_ARTIFACT_FIXTURES]: "1",
+      },
+      stdio: "inherit",
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `Linux artifact fixture test process exited with status ${result.status}`,
+    );
+  }
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    runLinuxArtifactFixtures();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/wallet/zuuli/scripts/run-linux-artifact-fixtures.mjs
+++ b/wallet/zuuli/scripts/run-linux-artifact-fixtures.mjs
@@ -4,6 +4,8 @@ import { dirname, resolve } from "node:path";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const EXPECTED_LINUX_ARTIFACT_FIXTURE_COUNT = 4;
+const EXPECTED_LINUX_ARTIFACT_FIXTURE_PATTERN =
+  "^(?:real AppImage, deb, and rpm fixtures expose undeclared shipped canaries|AppImage inspection fails closed on ELF arithmetic and SquashFS boundary mutations|AppImage listing rejects a SquashFS member with invalid UTF-8 bytes|a real deb with an escaping payload symlink fails before extraction)$";
 
 export const REQUIRE_LINUX_ARTIFACT_FIXTURES =
   "ZUULI_REQUIRE_LINUX_ARTIFACT_FIXTURES";
@@ -33,11 +35,17 @@ export function linuxArtifactFixturePattern() {
 }
 
 export function runLinuxArtifactFixtures({ spawn = spawnSync } = {}) {
+  const pattern = linuxArtifactFixturePattern();
+  if (pattern !== EXPECTED_LINUX_ARTIFACT_FIXTURE_PATTERN) {
+    throw new Error(
+      "Linux artifact fixture selector does not match its independent exact authority",
+    );
+  }
   const result = spawn(
     process.execPath,
     [
       "--test",
-      `--test-name-pattern=${linuxArtifactFixturePattern()}`,
+      `--test-name-pattern=${pattern}`,
       resolve(scriptDirectory, "artifact-sbom.node-test.mjs"),
     ],
     {


### PR DESCRIPTION
Closes #696

Replace the unbounded English-name regex workflow step with a fail-closed runner that binds the exact current Linux fixture population and proves every selected fixture body completes.

Independent mutation review: APPROVE, zero survivors. On the real Ubuntu/Node 24 runner the restored baseline is exactly 4 tests, 4 passed, 0 skipped. All four selector deletions, selector broadening, coordinated broadening, `skip: true`, completion-record deletion, selected nonfixture execution, required-env/tool/status weakening, and nonexistent/comment-only/soft-fail workflow substitutions turn red.

The fifth cargo-auditable fixture exists only on open #695; after this merges, that PR must raise the independent population to five and replay its fifth-title mutations before merge.
