### PR TITLE
test(store): bind creator catalog page contract

### DIFF
--- a/wallet/zuuli/scripts/store-screenshot-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/store-screenshot-contract.node-test.mjs
@@ -244,7 +244,7 @@ test("feed capture scroll is geometry-derived and keeps a required control unobs
   assert.equal(computeFeedCaptureScroll({ currentScroll: 0, visibleTop: 60, visibleBottom: 580, controlTop: 240, contentBottom: 820, requireControl: false }), 240);
 });
 
-test("creator capture pins the authoritative first catalog page and rejects pagination drift", () => {
+test("creator capture pins the authoritative first catalog page and rejects decorative pagination", () => {
   const creatorDetail = "GET https://free2z.cash/api/creator/example_editorial/";
   const firstPage = "GET https://free2z.cash/api/zpage/?ordering=-created_at&page=1&page_size=12&username=example_editorial";
   assert.deepEqual(CAPTURE_PUBLIC_REQUESTS["creator-profile"], [creatorDetail, firstPage]);
@@ -252,7 +252,8 @@ test("creator capture pins the authoritative first catalog page and rejects pagi
   for (const drifted of [
     "GET https://free2z.cash/api/zpage/?ordering=-created_at&page_size=12&username=example_editorial",
     "GET https://free2z.cash/api/zpage/?ordering=-created_at&page=2&page_size=12&username=example_editorial",
-    "GET https://free2z.cash/api/zpage/?ordering=-created_at&page=1&page_size=24&username=example_editorial",
+    "GET https://free2z.cash/api/zpage/?note=page%3D1&ordering=-created_at&page_size=12&username=example_editorial",
+    "GET https://free2z.cash/api/creator/example_editorial/?page=1",
   ]) {
     assert.equal(capturePublicRequestAllowed("creator-profile", drifted), false);
   }

--- a/wallet/zuuli/scripts/store-screenshot-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/store-screenshot-contract.node-test.mjs
@@ -252,6 +252,7 @@ test("creator capture pins the authoritative first catalog page and rejects deco
   for (const drifted of [
     "GET https://free2z.cash/api/zpage/?ordering=-created_at&page_size=12&username=example_editorial",
     "GET https://free2z.cash/api/zpage/?ordering=-created_at&page=2&page_size=12&username=example_editorial",
+    "GET https://free2z.cash/api/zpage/?ordering=-created_at&page=1&page_size=24&username=example_editorial",
     "GET https://free2z.cash/api/zpage/?note=page%3D1&ordering=-created_at&page_size=12&username=example_editorial",
     "GET https://free2z.cash/api/creator/example_editorial/?page=1",
   ]) {


### PR DESCRIPTION
Refs #387

Harden the deterministic store-capture request contract against ordinary and decorative query drift for the explicit creator-catalog `page=1` request. This is a test-only slice; it does not claim the screenshots were recaptured and does not close the store-media umbrella.

Independent mutation review: APPROVE, zero survivors. Missing page, `page=2`, ignored `page_size`, a decorative `page=1` on the note or creator-detail request, and a broad `includes("page=1")` membership bypass all turn red. The restored exact request passes an independent literal oracle. All 60 store-listing tests, `store:validate`, and diff checks are green.

The attempted two-pass recapture replaced no artifacts. Current capture tooling still needs a separately reviewed digest-pinned Playwright + Rust 1.97.1/wasm32 composition and corrected wallet-root mount before the mandatory production WASM build can run reproducibly.
