### PR TITLE
test(release): make Cargo fixture checks falsifiable

### DIFF
--- a/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
+++ b/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
@@ -119,6 +119,16 @@ const linuxFixtureTools = [
   "rpmbuild",
   "unsquashfs",
 ];
+const cargoRuntimeFixtureTools = [
+  "cargo",
+  "cargo-auditable",
+  "dpkg-deb",
+  "objcopy",
+  "rustc",
+];
+const requiredLinuxFixtureTools = [
+  ...new Set([...linuxFixtureTools, ...cargoRuntimeFixtureTools]),
+].sort();
 
 function commandExists(command) {
   return (process.env.PATH ?? "")
@@ -130,7 +140,7 @@ const canBuildLinuxFixtures =
   process.platform === "linux" && linuxFixtureTools.every(commandExists);
 const requireLinuxFixtures =
   process.env[REQUIRE_LINUX_ARTIFACT_FIXTURES] === "1";
-const missingLinuxFixtureTools = linuxFixtureTools.filter(
+const missingLinuxFixtureTools = requiredLinuxFixtureTools.filter(
   (command) => !commandExists(command),
 );
 if (
@@ -244,8 +254,52 @@ test("Linux packaging runner binds every selected fixture to a real passing test
   assert.notEqual(missingToolProbe.status, 0);
   assert.match(
     `${missingToolProbe.stdout}${missingToolProbe.stderr}`,
-    /required Linux artifact fixtures cannot run: .*missing tools=cc,dpkg-deb,mksquashfs,readelf,rpm2archive,rpmbuild,unsquashfs/,
+    /required Linux artifact fixtures cannot run: .*missing tools=cargo,cargo-auditable,cc,dpkg-deb,mksquashfs,objcopy,readelf,rpm2archive,rpmbuild,rustc,unsquashfs/,
   );
+  const incompleteToolDirectory = mkdtempSync(
+    resolve(tmpdir(), "zuuli-linux-fixture-tools-"),
+  );
+  try {
+    for (const command of [
+      "cargo",
+      "cc",
+      "dpkg-deb",
+      "mksquashfs",
+      "objcopy",
+      "readelf",
+      "rpm2archive",
+      "rpmbuild",
+      "rustc",
+      "unsquashfs",
+    ]) {
+      symlinkSync(process.execPath, resolve(incompleteToolDirectory, command));
+    }
+    const missingCargoAuditableEnvironment = {
+      ...process.env,
+      PATH: incompleteToolDirectory,
+      [REQUIRE_LINUX_ARTIFACT_FIXTURES]: "1",
+    };
+    delete missingCargoAuditableEnvironment.NODE_TEST_CONTEXT;
+    const missingCargoAuditableProbe = spawnSync(
+      process.execPath,
+      [
+        "--test",
+        "--test-name-pattern=nonexistent",
+        resolve(scriptDirectory, "artifact-sbom.node-test.mjs"),
+      ],
+      {
+        encoding: "utf8",
+        env: missingCargoAuditableEnvironment,
+      },
+    );
+    assert.notEqual(missingCargoAuditableProbe.status, 0);
+    assert.match(
+      `${missingCargoAuditableProbe.stdout}${missingCargoAuditableProbe.stderr}`,
+      /required Linux artifact fixtures cannot run: .*missing tools=cargo-auditable(?:\s|$)/,
+    );
+  } finally {
+    rmSync(incompleteToolDirectory, { recursive: true, force: true });
+  }
   assert.throws(
     () =>
       runLinuxArtifactFixtures({
@@ -594,13 +648,6 @@ linuxArtifactFixture(
   },
 );
 
-const cargoRuntimeFixtureTools = [
-  "cargo",
-  "cargo-auditable",
-  "dpkg-deb",
-  "objcopy",
-  "rustc",
-];
 const canBuildCargoRuntimeFixture =
   process.platform === "linux" && cargoRuntimeFixtureTools.every(commandExists);
 
@@ -935,11 +982,13 @@ test("real cargo-auditable executable evidence installer is exact and fail-close
         '  if (args[0] === "install" && args[1] !== "--list") {',
         '    requireState("patch");',
         '    if (process.env.ZUULI_INSTALLER_FAILURE === "install") fail("install", 101);',
+        '    writeFileSync(resolve(state, "installed-source"), args[args.indexOf("--path") + 1]);',
         '    writeFileSync(resolve(state, "install"), "ok\\n");',
         '  } else if (args[0] === "install" && args[1] === "--list") {',
         '    requireState("install");',
         '    const version = process.env.ZUULI_INSTALLER_FAILURE === "version" ? "9.9.9" : "0.7.5";',
-        "    process.stdout.write(`cargo-auditable v${version} (/mock/source):\\n    cargo-auditable\\n`);",
+        '    const source = process.env.ZUULI_INSTALLER_FAILURE === "source" ? "" : ` (${readFileSync(resolve(state, "installed-source"), "utf8")})`;',
+        "    process.stdout.write(`cargo-auditable v${version}${source}:\\n    cargo-auditable\\n`);",
         '    if (process.env.ZUULI_INSTALLER_FAILURE === "list-exit") fail("list", 17);',
         "  } else process.exit(94);",
         "} else process.exit(95);",
@@ -1136,6 +1185,14 @@ test("real cargo-auditable executable evidence installer is exact and fail-close
       wrongVersion.commands,
       expectedCommandsFor(wrongVersionArchive),
     );
+
+    const missingSource = invoke("failure-source", "source");
+    assert.ok(
+      missingSource.error,
+      "a crates.io-style listing must not verify the patched path install",
+    );
+    assert.equal(missingSource.status, 1);
+    assert.equal(missingSource.stderr, "");
   } finally {
     rmSync(temporary, { recursive: true, force: true });
   }

--- a/wallet/zuuli/scripts/install-cargo-auditable.sh
+++ b/wallet/zuuli/scripts/install-cargo-auditable.sh
@@ -17,4 +17,5 @@ patch --fuzz=0 --batch --forward -d "$temporary" -p0 \
   --input="$script_directory/cargo-auditable-0.7.5-root.patch"
 cargo install --force --locked --path "$temporary/cargo-auditable-$version"
 installed=$(cargo install --list)
-printf '%s\n' "$installed" | grep -Eq "^cargo-auditable v${version}( \\([^)]*\\))?:$"
+expected="cargo-auditable v${version} ($temporary/cargo-auditable-$version):"
+printf '%s\n' "$installed" | grep -Fx -- "$expected"


### PR DESCRIPTION
Closes #711

## What changed
- require `cargo install --list` to identify the exact temporary path build, so a registry install cannot satisfy the post-install check
- make the required Linux fixture precondition cover the union of every selected fixture tool, including cargo-auditable
- add isolated registry-style output and cargo-auditable-only missing-tool controls

## Verification
- artifact SBOM suite: 22 tests, 17 passed / 5 host-skipped on macOS
- shell syntax check
- Actions policy live: 187 references / 16 workflows
- Actions policy self-test: 334 cases
- real Cargo probe confirmed `cargo install --list` preserves the exact absolute `--path` source, including a symlink path

## Mutation evidence
- restoring the optional registry/path regex makes the focused installer test red at `a crates.io-style listing must not verify the patched path install`
- narrowing the precondition back to the old Linux-only list makes the focused runner test red because cargo, cargo-auditable, objcopy, and rustc disappear from the diagnostic

Independent adversarial review approved exact head 375029c52c9a7a9a75070cdb40a7665d7b31bb9e and stable patch 749489af837c98b8b2eb792195f8260826b5f71d.