### PR TITLE
fix(wallet): redact legacy preview identity

### DIFF
--- a/wallet/plugins/tauri-plugin-zcash/src/legacy_import_preview.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/legacy_import_preview.rs
@@ -1085,19 +1085,45 @@ mod tests {
         connection
             .execute_batch("CREATE TABLE accounts (id INTEGER PRIMARY KEY, name TEXT, ufvk TEXT);")
             .expect("accounts schema");
+        let raw_ufvk_a = valid_ufvk(0);
+        let raw_ufvk_b = valid_ufvk(1);
         connection
             .execute(
                 "INSERT INTO accounts (id, name, ufvk) VALUES (0, 'private', ?1)",
-                [valid_ufvk(0)],
+                [&raw_ufvk_a],
             )
             .expect("uncheckpointed account");
+        connection
+            .execute(
+                "INSERT INTO accounts (id, name, ufvk) VALUES (1, 'private too', ?1)",
+                [&raw_ufvk_b],
+            )
+            .expect("second uncheckpointed account");
         assert!(db.with_extension("sqlite-wal").exists());
         assert!(db.with_extension("sqlite-shm").exists());
         let before = tree_bytes(&tree.root);
 
         let preview = preview(&tree.canonical(), CANONICAL_IDENTIFIER);
+        let serialized = serde_json::to_string(&preview).expect("serialize WAL preview");
+        let fingerprint = |ufvk: &str| {
+            let mut hasher = Sha256::new();
+            hasher.update(b"ZUULI legacy UFVK fingerprint v1\0");
+            hasher.update(ufvk.as_bytes());
+            to_hex(&hasher.finalize())
+        };
+        let fingerprint_a = fingerprint(&raw_ufvk_a);
+        let fingerprint_b = fingerprint(&raw_ufvk_b);
         assert_eq!(preview.state, LegacyImportPreviewState::Ready);
-        assert_eq!(preview.wallets[0].account_count, 1);
+        assert_eq!(preview.wallets[0].account_count, 2);
+        assert_eq!(preview.wallets[0].db_filename, REDACTED);
+        assert_eq!(preview.wallets[0].ufvk_fingerprints, [REDACTED, REDACTED]);
+        for secret in [
+            "wallet.sqlite",
+            fingerprint_a.as_str(),
+            fingerprint_b.as_str(),
+        ] {
+            assert!(!serialized.contains(secret), "WAL preview leaked {secret}");
+        }
         assert!(preview.wallets[0].wal_present);
         assert!(preview.wallets[0].shm_present);
         assert_eq!(tree_bytes(&tree.root), before);

--- a/wallet/plugins/tauri-plugin-zcash/src/legacy_import_preview.rs
+++ b/wallet/plugins/tauri-plugin-zcash/src/legacy_import_preview.rs
@@ -333,9 +333,9 @@ where
     Ok(LegacyWalletPreview {
         wallet_id: REDACTED.to_owned(),
         wallet_name: REDACTED.to_owned(),
-        db_filename: entry.db_filename.clone(),
+        db_filename: REDACTED.to_owned(),
         account_count,
-        ufvk_fingerprints,
+        ufvk_fingerprints: vec![REDACTED.to_owned(); ufvk_fingerprints.len()],
         wal_present,
         shm_present,
         encrypted_custody_present,
@@ -770,9 +770,9 @@ mod tests {
         assert_eq!(preview.wallets.len(), 1);
         assert_eq!(preview.wallets[0].wallet_id, REDACTED);
         assert_eq!(preview.wallets[0].wallet_name, REDACTED);
-        assert_eq!(preview.wallets[0].db_filename, "wallet.sqlite");
+        assert_eq!(preview.wallets[0].db_filename, REDACTED);
         assert_eq!(preview.wallets[0].account_count, 1);
-        assert_eq!(preview.wallets[0].ufvk_fingerprints[0].len(), 64);
+        assert_eq!(preview.wallets[0].ufvk_fingerprints, [REDACTED]);
         assert!(preview.wallets[0].encrypted_custody_present);
         for secret in [
             raw_ufvk.as_str(),
@@ -780,6 +780,7 @@ mod tests {
             "unpublished-id",
             "private encrypted phrase",
             "private salt",
+            "wallet.sqlite",
         ] {
             assert!(!serialized.contains(secret), "preview leaked {secret}");
         }
@@ -791,7 +792,7 @@ mod tests {
     }
 
     #[test]
-    fn multi_layout_preserves_exact_db_names_but_redacts_manifest_identity() {
+    fn multi_layout_redacts_all_bridge_identity() {
         let tree = TestTree::new();
         fs::create_dir(tree.canonical()).expect("canonical");
         fs::create_dir(tree.legacy()).expect("legacy");
@@ -822,8 +823,16 @@ mod tests {
             serde_json::to_vec(&manifest).expect("manifest"),
         )
         .expect("write manifest");
-        create_db(&tree.legacy().join("wallet_a.sqlite"), &[valid_ufvk(0)]);
-        create_db(&tree.legacy().join("wallet_b.sqlite"), &[valid_ufvk(1)]);
+        let raw_ufvk_a = valid_ufvk(0);
+        let raw_ufvk_b = valid_ufvk(1);
+        create_db(
+            &tree.legacy().join("wallet_a.sqlite"),
+            std::slice::from_ref(&raw_ufvk_a),
+        );
+        create_db(
+            &tree.legacy().join("wallet_b.sqlite"),
+            std::slice::from_ref(&raw_ufvk_b),
+        );
 
         let preview = preview(&tree.canonical(), CANONICAL_IDENTIFIER);
         let serialized = serde_json::to_string(&preview).expect("serialize preview");
@@ -835,13 +844,23 @@ mod tests {
                 .iter()
                 .map(|wallet| wallet.db_filename.as_str())
                 .collect::<Vec<_>>(),
-            ["wallet_a.sqlite", "wallet_b.sqlite"]
+            [REDACTED, REDACTED]
+        );
+        assert!(
+            preview
+                .wallets
+                .iter()
+                .all(|wallet| { wallet.ufvk_fingerprints == [REDACTED] })
         );
         for secret in [
             "very-secret-wallet-a",
             "very-secret-wallet-b",
             "Alice private wallet",
             "Bob private wallet",
+            "wallet_a.sqlite",
+            "wallet_b.sqlite",
+            raw_ufvk_a.as_str(),
+            raw_ufvk_b.as_str(),
         ] {
             assert!(!serialized.contains(secret));
         }


### PR DESCRIPTION
Closes #714

Redacts legacy wallet database filenames and UFVK fingerprints at the native preview boundary while preserving account/fingerprint cardinality for the existing UI. Strengthens the WAL-backed regression with two distinct accounts and independently derived fingerprint canaries.

Mutation evidence before opening:
- restoring the raw database filename makes the exact WAL test fail
- restoring the two raw UFVK fingerprints makes the exact WAL test fail
- collapsing the two redaction markers to one makes the exact WAL test fail

Verification:
- cargo +1.97.1 fmt --all -- --check
- cargo +1.97.1 test --locked --all-targets (150/150)
- cargo +1.97.1 clippy --locked --all-targets -- -D warnings
- independent adversarial review of exact fe5207b0cbd3b42f7039cf997b9cff3aaa1cbe69: APPROVE