### PR TITLE
docs(deny): RUSTSEC-2026-0212's removal condition is already met

### DIFF
--- a/rs/deny.toml
+++ b/rs/deny.toml
@@ -204,6 +204,31 @@ ignore = [
   # **Remove this entry when `openmls_libcrux_crypto` ships against a
   # `libcrux-aead` whose `libcrux-secrets` requirement admits `>= 0.0.6`.** That
   # is the only condition under which it goes away without a fork. See #701.
+  #
+  # ## UPDATE 2026-08-25: that condition is already met. Do not re-run the
+  # ## experiment above — upgrade instead. See #723.
+  #
+  # The whole OpenMLS 0.9 train shipped on 2026-08-25, one day after the analysis
+  # above was written: `openmls 0.9.0`, `openmls_traits 0.6.0`,
+  # `openmls_libcrux_crypto 0.4.0`. That provider requires `libcrux-aead 0.0.9`,
+  # which requires `libcrux-secrets = "=0.0.6"` — the fixed version.
+  #
+  # Resolved and measured, not inferred: `cargo deny check advisories` over a
+  # crate depending only on `openmls 0.9.0` + `openmls_libcrux_crypto 0.4.0`,
+  # with an **empty** ignore list, reports exactly one finding —
+  # RUSTSEC-2026-0173, the build-host-only `proc-macro-error2` below. The 0.9
+  # train pulls `libcrux-secrets 0.0.6`, `libcrux-sha3 0.0.10`,
+  # `libcrux-ed25519 0.0.9`, `libcrux-poly1305 0.0.6`,
+  # `libcrux-chacha20poly1305 0.0.9` and `libcrux-aes 0.0.9`, which between them
+  # clear **every libcrux advisory in this list**.
+  #
+  # These entries stay until that migration lands, because they are accurate
+  # about the graph this repository actually ships — `openmls 0.8.1`, the version
+  # #385 validated on nine triples with real NIST/RFC vectors on Android
+  # hardware. What has changed is their status: they are a **migration backlog
+  # item with a known fix**, not a standing risk anyone has to keep accepting.
+  # #723 tracks it and takes "these ten entries come out" as its acceptance
+  # criterion.
   { id = "RUSTSEC-2026-0212", reason = "aarch64 constant-time swap/select may return incorrect results; #385's aarch64 KATs are green but this is evidence, not proof — owner decision required" },
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
A comment-only change to `rs/deny.toml`. No code, no dependency, no policy verdict changes — `cargo deny` is green before and after.

## Why

#697's entry for RUSTSEC-2026-0212 recorded a removal condition:

> Remove this entry when `openmls_libcrux_crypto` ships against a `libcrux-aead` whose `libcrux-secrets` requirement admits `>= 0.0.6`.

**That happened the next day.** The whole OpenMLS 0.9 train shipped 2026-08-25 — `openmls 0.9.0`, `openmls_traits 0.6.0`, `openmls_libcrux_crypto 0.4.0` — and 0.4.0 requires `libcrux-aead 0.0.9`, which requires `libcrux-secrets = "=0.0.6"`, the fixed version.

Measured, not inferred: `cargo deny check advisories` over a scratch crate depending only on `openmls 0.9.0` + `openmls_libcrux_crypto 0.4.0`, with an **empty** ignore list, reports exactly one finding — `RUSTSEC-2026-0173`, the build-host-only `proc-macro-error2`. The 0.9 train pulls `libcrux-secrets 0.0.6`, `libcrux-sha3 0.0.10`, `libcrux-ed25519 0.0.9`, `libcrux-poly1305 0.0.6`, `libcrux-chacha20poly1305 0.0.9` and `libcrux-aes 0.0.9`, which between them clear **every libcrux advisory in that list**.

## Why the entries stay anyway

They are accurate about the graph this repository ships — `openmls 0.8.1`, the version #385 validated on nine triples against real NIST/RFC vectors on Android hardware. 0.9.0 is a major version released hours ago and deserves its own evaluation, tracked in #723 with "these ten entries come out" as its acceptance criterion.

What changes is their **status**: a migration backlog item with a known fix, rather than a standing risk anyone has to keep accepting.

## Why this is worth a PR of its own

The entry above it carries a hard-won negative result — that `[patch.crates-io]` at 0.0.6 is *silently ignored*, producing a green build that still links the vulnerable version. That warning only does its job if the surrounding text is current. Left as-is, the file reads "wait for upstream" when upstream has already arrived, and the next person spends an afternoon re-running an experiment whose answer expired.

Refs #701, #723, #697.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku