### PR TITLE
fix(rs): close three relay coverage gaps, and remove the duplicate that caused one

### DIFF
--- a/rs/crates/f2z-relay-store/tests/properties.rs
+++ b/rs/crates/f2z-relay-store/tests/properties.rs
@@ -760,6 +760,86 @@ fn indices_are_dense_and_ascending_across_batch_boundaries() {
     });
 }
 
+#[test]
+fn a_batch_result_belongs_to_the_append_that_earned_it() {
+    // zuu#721. `append_batch`'s contract is that the vector is the same length
+    // as `appends` and in the same order, and the relay consumes it purely by
+    // position: `commit.rs` zips results onto jobs and routes §6.4's `MSG` push
+    // to `Appended::recv_addr`. Every other batch test here is single-queue, so
+    // reversing the queue each success belonged to — while leaving the indices
+    // dense and ascending — used to pass the whole workspace. Group commit
+    // exists to batch appends from *different* connections to *different*
+    // queues, so the mixed batch is the shape production actually runs.
+    let second_recv = QueueAddress::new([0x66; 32]);
+    let second_send = QueueAddress::new([0x77; 32]);
+    let second_recv_key = PublicKey::new([0x88; 32]);
+    let second_send_key = PublicKey::new([0xaa; 32]);
+
+    both(|store, name| {
+        let _ = store
+            .create_queue(&spec(QueueKind::Standard, generous(), 86_400, 86_400))
+            .unwrap();
+        let _ = store.bind_send(&SEND, &SEND_KEY, 1_000).unwrap();
+        let _ = store
+            .create_queue(&QueueSpec {
+                kind: QueueKind::Standard,
+                recv_addr: second_recv,
+                send_addr: second_send,
+                recv_key: second_recv_key,
+                message_ttl_seconds: 86_400,
+                idle_ttl_seconds: 86_400,
+                quota: generous(),
+                created_at_ms: 1_000,
+            })
+            .unwrap();
+        let _ = store
+            .bind_send(&second_send, &second_send_key, 1_000)
+            .unwrap();
+
+        let payload = Payload::new(vec![9u8; 32]).unwrap();
+        // Interleaved on purpose: A, B, A, B. A batch grouped by address would
+        // still satisfy "same length", and a `HashMap`-keyed implementation
+        // returning `into_values()` would still return four results.
+        let batch: Vec<Append<'_>> = [
+            (SEND, SEND_KEY),
+            (second_send, second_send_key),
+            (SEND, SEND_KEY),
+            (second_send, second_send_key),
+        ]
+        .into_iter()
+        .map(|(send_addr, key)| Append {
+            send_addr,
+            auth: SendAuth::Signed(key),
+            payload: &payload,
+            received_at_ms: 2_000,
+        })
+        .collect();
+
+        let results = store.append_batch(&batch).unwrap().into_inner();
+        assert_eq!(results.len(), batch.len(), "{name}");
+
+        // Reviewed literals rather than values derived from the results: each
+        // position's queue and the index that position earned within it.
+        let expected = [(RECV, 0u64), (second_recv, 0), (RECV, 1), (second_recv, 1)];
+        for (position, (result, (recv_addr, index))) in
+            results.into_iter().zip(expected).enumerate()
+        {
+            let appended = result.unwrap();
+            assert_eq!(
+                appended.recv_addr, recv_addr,
+                "{name}: position {position} came back with another queue's receive address"
+            );
+            assert_eq!(
+                appended.index, index,
+                "{name}: position {position} came back with another append's index"
+            );
+        }
+
+        let _ = store.delete_queue(&RECV, &RECV_KEY).unwrap();
+        let _ = store.delete_queue(&second_recv, &second_recv_key).unwrap();
+    });
+}
+
 // ---------------------------------------------------------------------------
 // Durability, as a published fact.
 // ---------------------------------------------------------------------------

--- a/rs/crates/f2z-relay/src/engine.rs
+++ b/rs/crates/f2z-relay/src/engine.rs
@@ -127,8 +127,6 @@ pub struct Connection {
     /// read loop that awaited each commit before reading the next frame would
     /// deny exactly that.
     pub inflight: Arc<Mutex<BTreeSet<u32>>>,
-    /// The receive addresses this connection is subscribed to.
-    pub subscriptions: BTreeSet<QueueAddress>,
     /// Where responses and pushes go.
     pub pushes: tokio::sync::mpsc::Sender<Outbound>,
     /// This connection's transcript builder: the relay's own `relay_id` and
@@ -270,7 +268,6 @@ impl Relay {
             id,
             hello_done: false,
             inflight: Arc::new(Mutex::new(BTreeSet::new())),
-            subscriptions: BTreeSet::new(),
             pushes,
             transcripts: TranscriptBuilder::new(PROTOCOL_VERSION, self.relay_id, binding),
             source,
@@ -280,9 +277,7 @@ impl Relay {
 
     /// Release a connection's subscriptions (§6.2).
     pub fn close_connection(&self, connection: &Connection) {
-        let addresses: Vec<QueueAddress> = connection.subscriptions.iter().copied().collect();
-        self.subscriptions
-            .drop_connection(connection.id, &addresses);
+        self.subscriptions.drop_connection(connection.id);
     }
 
     // ---------------------------------------------------------------------
@@ -781,7 +776,6 @@ impl Relay {
 
         self.subscriptions
             .subscribe(recv_addr, connection.id, connection.pushes.clone());
-        connection.subscriptions.insert(recv_addr);
 
         let response = SubscribeResponse {
             next_index: record.state.next_index(),
@@ -812,7 +806,6 @@ impl Relay {
             .queue_by_recv(&recv_addr, &signer)
             .map_err(|error| self.recv_error(&error))?;
         self.subscriptions.unsubscribe(&recv_addr, connection.id);
-        connection.subscriptions.remove(&recv_addr);
         Ok(Vec::new())
     }
 
@@ -960,7 +953,6 @@ impl Relay {
         self.subscriptions
             .notify_queue_event(recv_addr, QUEUE_EVENT_DELETED, &self.metrics);
         self.subscriptions.unsubscribe(&recv_addr, connection.id);
-        connection.subscriptions.remove(&recv_addr);
         Ok(Vec::new())
     }
 

--- a/rs/crates/f2z-relay/src/subscriptions.rs
+++ b/rs/crates/f2z-relay/src/subscriptions.rs
@@ -20,7 +20,7 @@
 //! `READ` still returns it, and the push was only ever a hint that a `READ` is
 //! worth doing. §13.2's rule is about *messages*, and a push is not one.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Mutex;
 
 use f2z_codec::commands::{NoticePush, PushEvent, QueueEventPush, QueuedMessage};
@@ -51,11 +51,27 @@ impl core::fmt::Debug for Subscriber {
 }
 
 /// The relay's subscription table.
+///
+/// Both directions are held here, under one lock, because §6.2's "dies with it"
+/// is only as good as the list teardown is given. When the connection kept that
+/// list itself, a `SUBSCRIBE` path that forgot to record an address left a row
+/// nothing would ever remove — and nothing prunes an orphan, because a failed
+/// `try_send` is counted and the subscriber is left in place. Owning the reverse
+/// index means [`Subscriptions::drop_connection`] needs no caller-supplied list,
+/// so there is no second place to forget (zuu#722).
 #[derive(Debug, Default)]
 pub struct Subscriptions {
-    // The key is a queue address. `QueueAddress`'s `Debug` redacts, so the
-    // derived `Debug` on this map does too.
-    by_recv: Mutex<HashMap<QueueAddress, Vec<Subscriber>>>,
+    inner: Mutex<Tables>,
+}
+
+/// The two indexes, kept consistent by every method that touches either.
+///
+/// The address map's key is a `QueueAddress`, whose `Debug` redacts, so the
+/// derived `Debug` here does too.
+#[derive(Debug, Default)]
+struct Tables {
+    by_recv: HashMap<QueueAddress, Vec<Subscriber>>,
+    by_connection: HashMap<u64, BTreeSet<QueueAddress>>,
 }
 
 impl Subscriptions {
@@ -72,8 +88,8 @@ impl Subscriptions {
         connection: u64,
         sender: tokio::sync::mpsc::Sender<Outbound>,
     ) {
-        let mut table = self.lock();
-        let entries = table.entry(recv_addr).or_default();
+        let mut tables = self.lock();
+        let entries = tables.by_recv.entry(recv_addr).or_default();
         if entries
             .iter()
             .any(|subscriber| subscriber.connection == connection)
@@ -81,23 +97,46 @@ impl Subscriptions {
             return;
         }
         entries.push(Subscriber { connection, sender });
+        tables
+            .by_connection
+            .entry(connection)
+            .or_default()
+            .insert(recv_addr);
     }
 
     /// Drop one connection's registration on one address.
     pub fn unsubscribe(&self, recv_addr: &QueueAddress, connection: u64) {
-        let mut table = self.lock();
-        if let Some(entries) = table.get_mut(recv_addr) {
-            entries.retain(|subscriber| subscriber.connection != connection);
-            if entries.is_empty() {
-                table.remove(recv_addr);
-            }
-        }
+        let mut tables = self.lock();
+        Self::remove_one(&mut tables, recv_addr, connection);
     }
 
     /// Drop every registration a connection holds — §6.2's "dies with it".
-    pub fn drop_connection(&self, connection: u64, addresses: &[QueueAddress]) {
+    ///
+    /// The addresses come from this table's own reverse index, so a caller
+    /// cannot pass an incomplete list.
+    pub fn drop_connection(&self, connection: u64) {
+        let mut tables = self.lock();
+        let Some(addresses) = tables.by_connection.remove(&connection) else {
+            return;
+        };
         for address in addresses {
-            self.unsubscribe(address, connection);
+            Self::remove_one(&mut tables, &address, connection);
+        }
+    }
+
+    /// Remove one (address, connection) pair from both indexes.
+    fn remove_one(tables: &mut Tables, recv_addr: &QueueAddress, connection: u64) {
+        if let Some(entries) = tables.by_recv.get_mut(recv_addr) {
+            entries.retain(|subscriber| subscriber.connection != connection);
+            if entries.is_empty() {
+                tables.by_recv.remove(recv_addr);
+            }
+        }
+        if let Some(addresses) = tables.by_connection.get_mut(&connection) {
+            addresses.remove(recv_addr);
+            if addresses.is_empty() {
+                tables.by_connection.remove(&connection);
+            }
         }
     }
 
@@ -106,7 +145,7 @@ impl Subscriptions {
     /// them.
     #[must_use]
     pub fn has_subscriber(&self, recv_addr: &QueueAddress) -> bool {
-        self.lock().contains_key(recv_addr)
+        self.lock().by_recv.contains_key(recv_addr)
     }
 
     /// Push a `MSG` to whoever is reading this queue (§6.4).
@@ -128,8 +167,8 @@ impl Subscriptions {
     /// Push a `NOTICE` to every subscribed connection (§6.4).
     pub fn notify_all(&self, kind: u8, at_ms: u64, metrics: &Metrics) {
         let body = NoticePush { kind, at_ms };
-        let table = self.lock();
-        for entries in table.values() {
+        let tables = self.lock();
+        for entries in tables.by_recv.values() {
             for subscriber in entries {
                 let Some(outbound) = push(PushEvent::Notice, &body) else {
                     continue;
@@ -147,8 +186,8 @@ impl Subscriptions {
         metrics: &Metrics,
         build: F,
     ) {
-        let table = self.lock();
-        let Some(entries) = table.get(recv_addr) else {
+        let tables = self.lock();
+        let Some(entries) = tables.by_recv.get(recv_addr) else {
             return;
         };
         for subscriber in entries {
@@ -163,8 +202,8 @@ impl Subscriptions {
         }
     }
 
-    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<QueueAddress, Vec<Subscriber>>> {
-        self.by_recv
+    fn lock(&self) -> std::sync::MutexGuard<'_, Tables> {
+        self.inner
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
@@ -220,11 +259,55 @@ mod tests {
         let (sender, mut receiver) = tokio::sync::mpsc::channel(4);
         table.subscribe(first, 9, sender.clone());
         table.subscribe(second, 9, sender);
-        table.drop_connection(9, &[first, second]);
+        // No address list: the table knows what this connection holds, which is
+        // the whole point — a caller cannot hand teardown a short list.
+        table.drop_connection(9);
         assert!(!table.has_subscriber(&first));
         assert!(!table.has_subscriber(&second));
         table.notify_message(first, &message(), &metrics);
         assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn teardown_needs_nothing_the_caller_has_to_remember() {
+        // zuu#722. The rule used to be kept in two places: this table, and a
+        // `BTreeSet` on the connection that the `SUBSCRIBE` handler had to
+        // remember to update. Deleting that one line left every workspace test
+        // green while every subscription outlived its connection. There is now
+        // no second place, and this asserts the reverse index really is what
+        // teardown reads.
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let first = QueueAddress::new([5u8; 32]);
+        let second = QueueAddress::new([6u8; 32]);
+        let other = QueueAddress::new([7u8; 32]);
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(4);
+        let (survivor, mut survivor_receiver) = tokio::sync::mpsc::channel(4);
+
+        table.subscribe(first, 11, sender.clone());
+        table.subscribe(second, 11, sender);
+        table.subscribe(other, 12, survivor);
+
+        table.drop_connection(11);
+
+        // Everything connection 11 held is gone, including the address it
+        // subscribed to second — the one a partial list would have missed.
+        assert!(!table.has_subscriber(&first));
+        assert!(!table.has_subscriber(&second));
+        table.notify_message(second, &message(), &metrics);
+        assert!(receiver.try_recv().is_err());
+
+        // …and only that connection's rows went.
+        assert!(table.has_subscriber(&other));
+        table.notify_message(other, &message(), &metrics);
+        assert!(survivor_receiver.try_recv().is_ok());
+
+        // Dropping a connection that holds nothing is not an error, and an
+        // explicit unsubscribe leaves no empty row for a later teardown to walk.
+        table.drop_connection(11);
+        table.unsubscribe(&other, 12);
+        assert!(!table.has_subscriber(&other));
+        table.drop_connection(12);
     }
 
     #[tokio::test]

--- a/rs/crates/f2z-relay/tests/redaction.rs
+++ b/rs/crates/f2z-relay/tests/redaction.rs
@@ -141,6 +141,19 @@ fn a_source_key_is_not_an_address_and_does_not_render() {
 }
 
 #[test]
+fn the_abuse_guard_never_renders_its_per_source_salt() {
+    // The salt is what makes a `SourceKey` not an address: hold it and every
+    // key in the table is invertible by trying candidate peers. `AbuseGuard`
+    // hand-writes its `Debug` to keep it out, and this is what proves that impl
+    // still does its job — the other two relay tables are covered above, and
+    // this is the only one carrying a secret of its own.
+    let mut salt = [0u8; 32];
+    salt[..SECRET.len()].copy_from_slice(&SECRET);
+    let guard = f2z_relay::abuse::AbuseGuard::new(Config::default().limits, true, salt);
+    assert_no_leak("AbuseGuard", &format!("{guard:?}"));
+}
+
+#[test]
 fn the_config_debug_and_print_config_both_redact_the_identity_seed() {
     let mut config = Config::default();
     config.identity.seed = "de".repeat(32);


### PR DESCRIPTION
Three findings from the relay review, each with a mutation that used to leave
the whole workspace green.

**#720 — the per-source salt was never asserted.** `AbuseGuard` hand-writes its
`Debug` solely to keep the salt out of a rendering, because holding the salt
makes every `SourceKey` in the table invertible by trying candidate peers.
`tests/redaction.rs` already renders `Challenges`, `Subscriptions` and
`SourceKey`; `AbuseGuard` was the third relay table and the only one carrying a
secret of its own, and the only one absent. Adds that case using the existing
`assert_no_leak` helper, which checks all four encodings including the decimal
byte list a derived `Debug` would emit.

**#721 — `append_batch`'s "same order" was tested on one axis of two.**
`RelayStore::append_batch` promises the result vector is the same length as
`appends` and in the same order, and `commit.rs` consumes it purely by position,
routing SS6.4's `MSG` push to `Appended::recv_addr`. Refusal position and index
density were pinned; *which queue a success belonged to* was not, because every
batch in the suite was single-queue. Group commit exists to batch appends from
different connections to different queues, so the mixed batch is the shape
production runs. Adds an interleaved two-queue batch asserting each position's
queue and index against reviewed literals.

**#722 — SS6.2's "a subscription dies with its connection" was kept in two
places by hand.** The table held addresses; the connection separately held a
`BTreeSet` that teardown read to drive it. Deleting the one line in the
`SUBSCRIBE` handler that filled that set left all 64 targets green while every
subscription outlived its connection — and nothing prunes an orphan, since a
failed `try_send` is counted and the subscriber left in place. Rather than test
the duplicate, this removes it: `Subscriptions` now owns a
`connection -> addresses` reverse index, `drop_connection` takes only a
connection id, and `Connection.subscriptions` is gone. There is no second place
to forget.

Each new assertion was falsified before landing:

| mutation | result |
|---|---|
| `.field("salt", &"<redacted>")` -> `&self.salt` | `the_abuse_guard_never_renders_its_per_source_salt` fails, printing the salt |
| swap `recv_addr` between successful batch results | `a_batch_result_belongs_to_the_append_that_earned_it` fails at position 0 |
| `drop_connection` removes only the first address | `teardown_needs_nothing_the_caller_has_to_remember` fails on the second |

`cargo clippy --workspace --all-targets -- -D warnings` exits 0;
`cargo test --workspace --no-fail-fast` exits 0 over 64 targets.

Closes #720
Closes #721
Closes #722

Claude-Session: https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD