### PR TITLE
fix(rs): enforce two WIRE.md rules where they become bytes, and stop two docs over-claiming

### DIFF
--- a/rs/crates/f2z-codec/src/commands.rs
+++ b/rs/crates/f2z-codec/src/commands.rs
@@ -733,29 +733,65 @@ mod tests {
 
     #[test]
     fn auth_and_transcript_address_match_section_6() {
-        assert_eq!(Command::Hello.auth(), Auth::None);
-        assert_eq!(Command::ContactAppend.auth(), Auth::None);
-        assert_eq!(Command::CreateQueue.auth(), Auth::RecvKey);
-        assert_eq!(Command::Append.auth(), Auth::SendKey);
-        assert_eq!(Command::BindSend.auth(), Auth::SendKey);
-
-        assert_eq!(
-            Command::CreateQueue.transcript_address(),
-            TranscriptAddress::Zeros
-        );
-        assert_eq!(
-            Command::CreateContactQueue.transcript_address(),
-            TranscriptAddress::Zeros
-        );
-        assert_eq!(
-            Command::Read.transcript_address(),
-            TranscriptAddress::RecvAddr
-        );
-        assert_eq!(
-            Command::Append.transcript_address(),
-            TranscriptAddress::SendAddr
-        );
-        assert_eq!(Command::Ping.transcript_address(), TranscriptAddress::None);
+        // The whole table, both columns, as reviewed literals. It used to name
+        // five of fourteen commands for `auth` and five for
+        // `transcript_address` under a name that claims the table (zuu#718).
+        // The `RecvAddr`/`SendAddr` distinction has no consumer — see
+        // `check_transcript_address` — so pinning it here is the only thing
+        // standing between §6's table and a silent edit.
+        let expected = [
+            (Command::Hello, Auth::None, TranscriptAddress::None),
+            (
+                Command::GetCapabilities,
+                Auth::None,
+                TranscriptAddress::None,
+            ),
+            (Command::GetChallenge, Auth::None, TranscriptAddress::None),
+            (Command::Ping, Auth::None, TranscriptAddress::None),
+            (Command::ContactAppend, Auth::None, TranscriptAddress::None),
+            (
+                Command::CreateQueue,
+                Auth::RecvKey,
+                TranscriptAddress::Zeros,
+            ),
+            (
+                Command::CreateContactQueue,
+                Auth::RecvKey,
+                TranscriptAddress::Zeros,
+            ),
+            (
+                Command::Subscribe,
+                Auth::RecvKey,
+                TranscriptAddress::RecvAddr,
+            ),
+            (
+                Command::Unsubscribe,
+                Auth::RecvKey,
+                TranscriptAddress::RecvAddr,
+            ),
+            (Command::Read, Auth::RecvKey, TranscriptAddress::RecvAddr),
+            (Command::Ack, Auth::RecvKey, TranscriptAddress::RecvAddr),
+            (
+                Command::DeleteQueue,
+                Auth::RecvKey,
+                TranscriptAddress::RecvAddr,
+            ),
+            (
+                Command::BindSend,
+                Auth::SendKey,
+                TranscriptAddress::SendAddr,
+            ),
+            (Command::Append, Auth::SendKey, TranscriptAddress::SendAddr),
+        ];
+        assert_eq!(expected.len(), Command::ALL.len());
+        for (command, auth, address) in expected {
+            assert_eq!(command.auth(), auth, "{command:?} auth");
+            assert_eq!(
+                command.transcript_address(),
+                address,
+                "{command:?} transcript address"
+            );
+        }
     }
 
     #[test]

--- a/rs/crates/f2z-codec/src/pow.rs
+++ b/rs/crates/f2z-codec/src/pow.rs
@@ -73,6 +73,11 @@ impl PowParams {
     }
 
     /// Whether these parameters demand any work.
+    ///
+    /// Reads `algorithm` alone, which is only a safe question to ask of
+    /// parameters [`PowParams::validate`] has accepted: it is that function
+    /// which refuses the combination where an algorithm is named and the
+    /// difficulty is zero (zuu#715).
     #[must_use]
     pub const fn is_required(&self) -> bool {
         self.algorithm != 0
@@ -80,16 +85,30 @@ impl PowParams {
 
     /// Check that the parameters are ones a v1 client can satisfy.
     ///
-    /// `difficulty_bits` needs no bound: it is a `u8`, the digest is 256 bits,
-    /// so every representable value is satisfiable. Whether it is *reachable*
-    /// on a phone is §12.4's problem, not this function's.
+    /// `difficulty_bits` needs no *upper* bound: it is a `u8`, the digest is
+    /// 256 bits, so every representable value is satisfiable. Whether it is
+    /// *reachable* on a phone is §12.4's problem, not this function's.
+    ///
+    /// It does need a lower one. `is_required` reads `algorithm` alone, so a
+    /// relay publishing `algorithm: 1, difficulty_bits: 0` passes §13.1's
+    /// "pow mode must name a PoW" and §12.3's "contact queues must be gated"
+    /// checks while demanding no work at all — `meets_difficulty(0)` holds for
+    /// every hash, including the one over `PowStamp::empty()`. That is a gate
+    /// in the capability document and an open door on the wire, so it is
+    /// refused here rather than left for each caller to notice.
     ///
     /// # Errors
     ///
     /// [`CodecError::InvalidValue`] if `algorithm` is neither 0 ("not
-    /// required") nor 1.
+    /// required") nor 1, or if a named algorithm carries zero difficulty.
     pub const fn validate(&self) -> Result<(), CodecError> {
-        if self.algorithm != 0 && self.algorithm != ALGORITHM_BLAKE2B_LEADING_ZERO_BITS {
+        if self.algorithm == 0 {
+            return Ok(());
+        }
+        if self.algorithm != ALGORITHM_BLAKE2B_LEADING_ZERO_BITS {
+            return Err(CodecError::InvalidValue);
+        }
+        if self.difficulty_bits == 0 {
             return Err(CodecError::InvalidValue);
         }
         Ok(())
@@ -229,6 +248,29 @@ mod tests {
     #[test]
     fn params_reject_an_algorithm_v1_does_not_define() {
         assert!(PowParams::none().validate().is_ok());
+        // zuu#715: a named algorithm with zero difficulty is a published gate
+        // that demands nothing. `is_required` reads `algorithm` alone, so both
+        // §13.1's and §12.3's capability guards used to accept it, and
+        // `meets_difficulty(0)` accepts the hash over an empty stamp.
+        assert_eq!(
+            PowParams {
+                algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+                difficulty_bits: 0,
+                challenge_ttl_ms: 60_000,
+            }
+            .validate(),
+            Err(CodecError::InvalidValue)
+        );
+        // One bit is enough to be a real gate, and is accepted.
+        assert!(
+            PowParams {
+                algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+                difficulty_bits: 1,
+                challenge_ttl_ms: 60_000,
+            }
+            .validate()
+            .is_ok()
+        );
         assert!(!PowParams::none().is_required());
         assert!(
             PowParams {

--- a/rs/crates/f2z-relay-proto/src/command.rs
+++ b/rs/crates/f2z-relay-proto/src/command.rs
@@ -836,8 +836,16 @@ impl CommandVerifier {
     }
 }
 
-/// §6's table, as a check: the transcript's `address` is zeros for the creation
-/// commands and a real address for the rest.
+/// One column of §6's table, as a check: the transcript's `address` is zeros for
+/// the creation commands and a real address for the rest.
+///
+/// It deliberately does **not** distinguish `RecvAddr` from `SendAddr`, and no
+/// other consumer of [`Command::transcript_address`] does either (zuu#718).
+/// Which of a queue's two addresses a command is bound to is decided by the
+/// handler's choice of store lookup — `queue_by_recv` for the receive-side
+/// commands, `queue_by_send` for `BIND_SEND` and `APPEND` — and it is that
+/// lookup, not this function, that refuses a command presented against the
+/// wrong address.
 ///
 /// The zero address is the sentinel for "no queue exists yet", so a non-creation
 /// command carrying it is a command about no queue at all. `ERR_MALFORMED` is

--- a/rs/crates/f2z-relay-proto/src/inflight.rs
+++ b/rs/crates/f2z-relay-proto/src/inflight.rs
@@ -66,10 +66,20 @@ impl<C: RelayCommand> Ticket<C> {
 
 /// One connection's outstanding requests.
 ///
-/// Useful in both directions, which is why it is not called a client: a client
-/// uses it to correlate responses, and a relay uses it to enforce §4.3's
-/// duplicate and window rules on what arrives. The relay side ignores
-/// [`Ticket`] and reads [`InFlight::command_for`].
+/// Written for both directions, and currently used by one. A client uses it to
+/// correlate responses, which is what [`Ticket`] is for.
+///
+/// **No relay in this workspace uses it** (zuu#719). `f2z-relay` and
+/// `f2z-relay-testkit` each enforce §4.3's duplicate and window rules
+/// themselves, over a bare `BTreeSet<u32>` on the connection — see
+/// `f2z-relay/src/engine.rs`'s `handle_binary` and the matching block in
+/// `f2z-relay-testkit/src/engine.rs`. The two hand-written copies agree
+/// clause for clause, and the conformance suite compares the relays' verdicts,
+/// so this is duplication rather than divergence; it is recorded here so the
+/// next reader looks for the rule where it is actually enforced.
+///
+/// [`InFlight::command_for`] is the relay-side accessor that arrangement would
+/// need. It has no caller today.
 #[derive(Clone, Debug)]
 pub struct InFlight {
     /// `request_id` → the command code it was issued for.

--- a/rs/crates/f2z-relay/src/outbound.rs
+++ b/rs/crates/f2z-relay/src/outbound.rs
@@ -34,8 +34,19 @@ impl core::fmt::Debug for Outbound {
 
 impl Outbound {
     /// A response frame.
+    ///
+    /// `None` for a zero `request_id`: §4.3 gives zero to pushes and requires a
+    /// response to carry the nonzero id of the request it answers. The guard
+    /// lives here rather than at each caller because this is the one place a
+    /// response becomes bytes — [`Outbound::fatal`] already refused it on the
+    /// error path while the success path passed the client's id straight
+    /// through (zuu#716). Callers that cannot build a response fall back to
+    /// their fatal path, which closes the connection when the id is unusable.
     #[must_use]
     pub fn response(request_id: u32, response: Response) -> Option<Self> {
+        if request_id == 0 {
+            return None;
+        }
         Some(Self {
             message: Some(WireMessage::Binary(
                 RelayFrame::response(request_id, response)
@@ -158,6 +169,27 @@ mod tests {
         let rendered = format!("{outbound:?}");
         assert!(rendered.contains("<redacted"));
         assert!(!rendered.contains("222"));
+    }
+
+    #[test]
+    fn a_response_may_never_carry_a_pushs_request_id() {
+        // zuu#716. §4.3 reserves zero for pushes. `fatal()` refused it on the
+        // error path; the success path handed the client's id straight to
+        // `response`, so a request arriving with `request_id = 0` would have
+        // been answered on a frame `outbound.rs`'s own comment calls forbidden.
+        // Refused where a response becomes bytes, so both paths inherit it.
+        assert!(Outbound::response(0, Response::ok(vec![]).unwrap()).is_none());
+        assert!(
+            Outbound::fatal(
+                0,
+                ErrorCode::Malformed,
+                crate::transport::CLOSE_PROTOCOL_ERROR
+            )
+            .is_none()
+        );
+
+        // …and a real id still works, so the guard is the id and not the frame.
+        assert!(Outbound::response(1, Response::ok(vec![]).unwrap()).is_some());
     }
 
     #[test]


### PR DESCRIPTION
**#716 — SS4.3's nonzero response id, guarded by construction.** SS4.3 reserves
`request_id = 0` for pushes and requires a response to carry the nonzero id of
the request it answers. `Outbound::fatal` refused a zero id on the error path;
the success path handed the client's id straight to `Outbound::response`
(`engine.rs`), so a request arriving with id 0 would be answered on a frame
`outbound.rs`'s own comment calls forbidden. Deleting the one call that
currently catches this — `frame.validate()` in `handle_binary` — left every
workspace target green.

The guard now lives in `Outbound::response`, the single place a response
becomes bytes, so both paths inherit it. It composes with what was already
there: `response` returns `Option`, and the success path's `None` arm already
falls through to `fatal()`, which closes the connection when the id is
unusable. No hang, no new branch.

**#715 — a PoW gate that demands no work.** `PowParams::is_required()` reads
`algorithm` alone, so `algorithm: 1, difficulty_bits: 0` satisfies both
SS13.1's "pow mode must name a PoW" and SS12.3's "contact queues must be gated"
while requiring nothing: `meets_difficulty(0)` holds for every hash, including
the one over `PowStamp::empty()`. `PowParams::validate` now refuses a named
algorithm with zero difficulty, which is where `capabilities.rs` already routes
through `validate_pow`, so such a capability document is rejected rather than
published. `is_required`'s doc now says it is only a safe question to ask of
validated parameters.

**#718 — SS6's table, both columns.** `auth_and_transcript_address_match_section_6`
named five of fourteen commands per column under a name that claims the table.
Now the whole table as reviewed literals. `check_transcript_address`'s doc said
"SS6's table, as a check" while checking one column of it; corrected to say which
column, and to point at the store lookup — `queue_by_recv` versus
`queue_by_send` — that actually binds a command to the right address.

**#719 — inflight.rs described a relay that does not exist.** Its module doc
said a relay uses `InFlight` to enforce SS4.3 and reads `command_for`. No relay
in this workspace does; both engines hand-roll the duplicate and window rules
over a bare `BTreeSet<u32>`. Corrected to say so and to point at where the rule
is really enforced. The rule itself is right — mutating `len() >= max_inflight`
to `>` reddens exactly `exceeding_the_inflight_window_is_fatal` — so this is
duplication, not divergence, and the doc now says that too.

Each change was falsified before landing:

| mutation | result |
|---|---|
| drop the zero-id guard from `Outbound::response` | `a_response_may_never_carry_a_pushs_request_id` fails |
| drop the difficulty check from `PowParams::validate` | `params_reject_an_algorithm_v1_does_not_define` fails |
| move `DeleteQueue` from `RecvAddr` to `SendAddr` | `auth_and_transcript_address_match_section_6` fails, naming the command |

That third mutation left all 64 targets green before this change.

`cargo clippy --workspace --all-targets -- -D warnings` exits 0;
`cargo test --workspace --no-fail-fast` exits 0 over 73 targets.

Closes #715
Closes #716
Closes #718
Closes #719

Claude-Session: https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD