### PR TITLE
release(zuuli): prepare internal build 0.1.0+15

### DIFF
--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.zuuli",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 14,
+  "build": 15,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "14").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "15").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "14"
+        CFBundleVersion: "15"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -37,14 +37,14 @@
       "entitlements": "./Entitlements.plist"
     },
     "iOS": {
-      "bundleVersion": "14",
+      "bundleVersion": "15",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 14
+      "versionCode": 15
     }
   },
   "plugins": {


### PR DESCRIPTION
Generated by `npm run release:bump -- --version=0.1.0 --build=15`. The diff is
exactly the identity surfaces that script owns — `release.json`, the generated
Gradle `versionCode`, the generated Xcode `CFBundleVersion` in both
`project.yml` and `Info.plist`, and `tauri.conf.json`'s iOS `bundleVersion` and
Android `versionCode` — all 14 to 15, and nothing else.

`npm run release:verify` agrees across every representation:

    {"applicationId":"cash.free2z.zuuli","version":"0.1.0","build":15,
     "identity":"0.1.0+15","tag":"zuuli-v0.1.0+15"}

The audit this release consumes was re-derived in #726 against `66aebd12`,
which is on this commit's first-parent history with nothing release-impacting
between them.

**This is an internal build.** It goes to TestFlight and the Play internal
track and nowhere else. The wallet, authentication, KYC, media, and money rows
in STATUS.md remain "wired, not runtime-proven", and nothing here changes that
— internal distribution is the mechanism by which #234 and #238 collect the
signed-device evidence those rows need. Do not describe this build as ready or
promote it beyond the internal tracks.

Claude-Session: https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD