### PR TITLE
feat(rs): migrate to the OpenMLS 0.9 train, clearing nine advisories

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -331,16 +331,21 @@ jobs:
         working-directory: rs
         run: cargo test --locked -p f2z-msg-store --features crash-injection --test crash_safety
 
-      # `openmls 0.8.1` runs `debug_assert!(false)` on the AEAD-open failure
-      # path (`private_message_in.rs:136`), which any peer or relay can reach by
-      # flipping one byte. It compiles out in release, so the engine's
-      # corrupted-ciphertext case — "refuse, do not crash" — is a property only a
-      # release build can assert, and `tests/two_instances.rs` gates that case on
-      # `not(debug_assertions)`. This step is what runs it. See #385 and the
-      # note on that test.
-      - name: Run the MLS engine's release-only refusal cases
-        working-directory: rs
-        run: cargo test --release --locked -p f2z-msg-mls --test two_instances
+      # There is deliberately NO extra `--release` step for f2z-msg-mls here.
+      #
+      # There used to be one, and this note is why it is gone rather than
+      # missing. `openmls 0.8.1` ran `debug_assert!(false)` on the AEAD-open
+      # failure path (`private_message_in.rs:136`) — reachable by any peer or
+      # relay that flips one byte — which aborted the process in a debug build
+      # and compiled out in release. The engine's corrupted-ciphertext case
+      # ("refuse, do not crash") was therefore a property only a release build
+      # could assert, `tests/two_instances.rs` gated it on
+      # `not(debug_assertions)`, and this step existed to run it.
+      #
+      # `openmls 0.9.0` replaced that path with `log::error!` plus a returned
+      # `MessageDecryptionError::AeadError`, so the case now runs in the
+      # ordinary `cargo test --all-targets` above and this step would be a
+      # second full compile of the same crate for nothing. See #723 and #701.
 
   rs_wasm:
     name: rs / wasm32
@@ -434,25 +439,26 @@ jobs:
       # and the web client, so this reaching wasm32 is a protocol-level
       # requirement rather than a nice property.
       #
-      # Two things are needed and neither is optional:
+      # `--features js` is not optional: OpenMLS emits a `compile_error!` for
+      # wasm32 without it, because it needs JavaScript APIs for secure
+      # randomness and for the current time. It refuses to build rather than
+      # producing a binary that traps at runtime, which is the right choice and
+      # is why the feature exists.
       #
-      #   * `--features js` — OpenMLS emits a `compile_error!` for wasm32
-      #     without it, because it needs JavaScript APIs for secure randomness
-      #     and for the current time. It refuses to build rather than producing
-      #     a binary that traps at runtime, which is the right choice and is why
-      #     the feature exists.
-      #   * `--cfg getrandom_backend="wasm_js"` — `getrandom` refuses to compile
-      #     for wasm32-unknown-unknown until a backend is named, and this graph
-      #     carries **two** major versions of it (0.3 via `rand_core 0.9`, 0.4
-      #     via `rand 0.10` inside `hpke-rs-libcrux`). `f2z-msg-mls`'s manifest
-      #     names both under a `cfg(target_arch = "wasm32")` target table purely
-      #     to turn their `wasm_js` features on; this flag is the other half.
-      #     RUSTFLAGS rather than `.cargo/config.toml` so it applies to this job
-      #     and cannot silently change a native build.
+      # There is deliberately **no** `RUSTFLAGS: --cfg getrandom_backend="wasm_js"`
+      # here any more. Against `openmls 0.8.1` this graph carried two major
+      # versions of `getrandom` — 0.3 via `rand_core 0.9`, 0.4 via `rand 0.10`
+      # inside `hpke-rs-libcrux` — and **0.3 needs the cfg as well as the
+      # feature**. On the 0.9 train nothing in this crate's wasm graph reaches
+      # `rand_core 0.9`, and getrandom **0.4** selects its wasm backend from the
+      # `wasm_js` feature alone, which `f2z-msg-mls`'s target table declares.
+      # See that manifest's note; #723 removed both halves together.
+      #
+      # This cannot regress silently: if getrandom 0.3 re-enters the graph, this
+      # step fails with getrandom's own `compile_error!` naming the missing
+      # backend.
       - name: Build the MLS engine for the browser target
         working-directory: rs
-        env:
-          RUSTFLAGS: --cfg getrandom_backend="wasm_js"
         run: |
           set -euo pipefail
           cargo build --locked --lib \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,11 +144,15 @@ integrate, and move it forward alongside everything else.
   `wallet/zuuli/src-tauri` links that plugin together with the rest of the app,
   so **rusqlite 0.37 is a repo-wide singleton**: any new crate that needs SQLite
   must resolve to it. All three lockfiles currently agree on `rusqlite 0.37.0` /
-  `libsqlite3-sys 0.35.0`. Worked example: `openmls_sqlite_storage` 0.2.0 — the
-  latest *release* — requires `rusqlite ^0.32` and is therefore unusable here;
-  its `0.3.0-rc` line moved to `^0.37` and would fit. Check the requirement
-  before adopting, because the conflict appears only once the app links both: a
-  crate that builds fine on its own can still be off-limits.
+  `libsqlite3-sys 0.35.0`. Worked example, **and note how it ended**:
+  `openmls_sqlite_storage` 0.2.0 required `rusqlite ^0.32` and was therefore
+  unusable here, which is part of why `rs/crates/f2z-msg-store` exists; its
+  0.3.0 release (2026-08-25) moved to `rusqlite = "0.37"` and now fits. The
+  singleton did not change — upstream moved. Check the requirement before
+  adopting *and* re-check it when the upstream releases, because the conflict
+  appears only once the app links both: a crate that builds fine on its own can
+  still be off-limits, and one that was off-limits can stop being so without
+  anyone noticing.
 
 ## Guardrails that keep us honest
 

--- a/docs/e2ee/ARCHITECTURE.md
+++ b/docs/e2ee/ARCHITECTURE.md
@@ -143,12 +143,27 @@ Eight findings, one of them **High severity — "improper authentication of
 MACs."** The High finding and all but one of the rest are fixed in **0.8.1** (and
 0.7.3 on the previous line).
 
-**Floor: `openmls >= 0.8.1`.** Any earlier version contains a High-severity
-authentication defect and MUST NOT be shipped. One Low-severity finding was still
-open at publication; **review its status before release** rather than assuming the
-audit closed everything. Note also that the version floor interacts with the
-crypto provider: `openmls_rust_crypto` does not implement X-Wing, so the PQ
-ciphersuite (§5.2) requires the libcrux provider.
+**Floor: `openmls >= 0.9.0`**, raised from `>= 0.8.1` by
+[#723](https://github.com/free2z/zuu/issues/723) and carrying two defects rather
+than one. Any version before 0.8.1 contains the High-severity authentication
+defect above. Any version before **0.9.0** resolves, through
+`openmls_libcrux_crypto <= 0.3.1`, to a `libcrux-secrets 0.0.5` carrying
+**RUSTSEC-2026-0212** — a constant-time swap/select that can return incorrect
+results on **aarch64**, underneath the AEAD of §5.2's ciphersuite. aarch64 is
+every phone we ship to and every Apple Silicon desktop.
+[#701](https://github.com/free2z/zuu/issues/701) established that the fix could
+not be applied without forking the libcrux release train; `openmls 0.9.0` and
+`openmls_libcrux_crypto 0.4.0` apply it upstream, and taking them cleared nine
+accepted advisories from `rs/deny.toml` at once. Neither floor may be shipped
+under.
+
+One Low-severity finding from the audit was still open at publication; **review
+its status before release** rather than assuming the audit closed everything.
+Note also that the version floor interacts with the crypto provider:
+`openmls_rust_crypto` does not implement X-Wing, so the PQ ciphersuite (§5.2)
+requires the libcrux provider — and on `openmls 0.9.0` the X-Wing codepoint
+additionally sits behind the `draft-ietf-mls-pq-ciphersuites` feature, which
+`rs/Cargo.toml` enables by name.
 
 This closes §13-A. It does not remove the case for our own review — an audit of
 the library is not an audit of how we use it — but it does mean "widely used" has
@@ -1359,7 +1374,9 @@ finds the answer instead of a hole.
   SRLabs, sponsored by the Sovereign Tech Agency, was published
   [2026-05-27](https://blog.openmls.tech/posts/2026-05-27-independent-audit/):
   eight findings, one High ("improper authentication of MACs"), fixed in 0.8.1
-  and 0.7.3. **We adopt the floor `openmls >= 0.8.1`.** One Low-severity finding
+  and 0.7.3. **We adopt the floor `openmls >= 0.9.0`** — 0.8.1 for the audit
+  finding, and 0.9.0 for RUSTSEC-2026-0212 in the libcrux provider beneath it
+  (#701, #723). One Low-severity finding
   was still open at publication and must be re-checked before release. See §3.1.
   This closes the question of whether the library has been audited; it does not
   close the question of auditing *our* use of it, which per #305's economics

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -80,15 +80,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +190,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,12 +223,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -284,7 +289,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -340,6 +354,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,13 +416,13 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-models"
-version = "0.0.5"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
+checksum = "ee3344d349528f449816cfa85e558c439bdca5a6d8a738cfb21e69f0b2b1952f"
 dependencies = [
  "hax-lib",
  "pastey",
- "rand 0.9.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -410,6 +441,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crabgrind"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7459e07732f6de74001fcf73a3fdfbb0f368e4fd8e2392f4a2206a065e6e95"
+dependencies = [
+ "bindgen",
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -466,6 +508,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
@@ -477,6 +520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -533,7 +585,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.12",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -551,6 +603,25 @@ dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -574,6 +645,18 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -582,12 +665,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature 2.2.0",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -596,7 +679,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature 2.2.0",
 ]
 
@@ -658,9 +741,9 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -689,7 +772,7 @@ version = "0.1.0"
 dependencies = [
  "ed25519-dalek 3.0.0",
  "f2z-codec",
- "tls_codec",
+ "tls_codec 0.4.2",
 ]
 
 [[package]]
@@ -698,7 +781,7 @@ version = "0.1.0"
 dependencies = [
  "blake2",
  "proptest",
- "tls_codec",
+ "tls_codec 0.4.2",
 ]
 
 [[package]]
@@ -716,7 +799,7 @@ dependencies = [
  "f2z-kt-core",
  "log",
  "protobuf",
- "tls_codec",
+ "tls_codec 0.4.2",
  "tokio",
  "tower",
 ]
@@ -731,7 +814,7 @@ dependencies = [
  "f2z-codec",
  "proptest",
  "protobuf",
- "tls_codec",
+ "tls_codec 0.4.2",
 ]
 
 [[package]]
@@ -742,11 +825,11 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "f2z-codec",
  "f2z-kt-core",
- "hkdf",
+ "hkdf 0.12.4",
  "proptest",
  "rand_core 0.10.1",
  "sha2 0.10.9",
- "tls_codec",
+ "tls_codec 0.4.2",
  "zeroize",
 ]
 
@@ -758,23 +841,21 @@ dependencies = [
  "f2z-kt-core",
  "f2z-msg-identity",
  "f2z-msg-store",
- "getrandom 0.3.4",
  "getrandom 0.4.3",
  "libcrux-ed25519",
  "openmls",
- "openmls_libcrux_crypto 0.3.1",
- "openmls_traits 0.5.0",
+ "openmls_libcrux_crypto",
+ "openmls_traits",
  "serde",
  "serde_json",
  "tempfile",
- "tls_codec",
 ]
 
 [[package]]
 name = "f2z-msg-store"
 version = "0.1.0"
 dependencies = [
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "proptest",
  "rusqlite",
  "serde",
@@ -794,11 +875,11 @@ dependencies = [
  "futures-util",
  "rand 0.9.5",
  "serde",
- "tls_codec",
+ "tls_codec 0.4.2",
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -809,7 +890,7 @@ dependencies = [
  "f2z-codec",
  "proptest",
  "subtle",
- "tls_codec",
+ "tls_codec 0.4.2",
 ]
 
 [[package]]
@@ -830,7 +911,7 @@ dependencies = [
  "f2z-codec",
  "f2z-relay-proto",
  "futures-util",
- "tls_codec",
+ "tls_codec 0.4.2",
  "tokio",
  "tokio-tungstenite",
 ]
@@ -846,7 +927,7 @@ dependencies = [
  "f2z-kt",
  "f2z-kt-core",
  "log",
- "tls_codec",
+ "tls_codec 0.4.2",
  "tokio",
  "ureq",
 ]
@@ -898,21 +979,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
-name = "fluvio-wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b768c170dc045fa587a8f948c91f9bcfb87f774930477c6215addf54317f137f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,18 +991,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "futures"
-version = "0.3.34"
+name = "form_urlencoded"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -946,7 +1006,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -954,34 +1013,6 @@ name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.4",
-]
 
 [[package]]
 name = "futures-sink"
@@ -996,24 +1027,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
-
-[[package]]
 name = "futures-util"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1047,11 +1068,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1127,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543f93241d32b3f00569201bfce9d7a93c92c6421b23c77864ac929dc947b9fc"
+checksum = "01a33cb227f97ee5c419064c31d7c55a7d895f28d8019ccdadc311cc036500c4"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -1138,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8755751e760b11021765bb04cb4a6c4e24742688d9f3aa14c2079638f537b0f"
+checksum = "28da835a5f153e9f3d0cc1f42ee605a1cfa9093c93348193793d60a1b0908b51"
 dependencies = [
  "hax-lib-macros-types",
  "proc-macro-error2",
@@ -1151,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros-types"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f177c9ae8ea456e2f71ff3c1ea47bf4464f772a05133fcbba56cd5ba169035a2"
+checksum = "eed327e9a28d6ee018a4a9ba842d4ee27e378c8a591d2beb6f42f32b24a02fcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1163,10 +1182,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hkdf"
@@ -1174,7 +1202,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1184,6 +1221,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1197,40 +1243,39 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ad6a58eb3e0ee30be8bfc7a9770ae98adcfa1d9bc820a5847732ce84f70837"
+checksum = "812de62ab573b876c6c40d7553bae9402ae3bad95b64af06f964388eecb9b7b1"
 dependencies = [
  "hpke-rs-crypto",
  "hpke-rs-libcrux",
  "hpke-rs-rust-crypto",
  "libcrux-sha3",
  "log",
- "rand_core 0.9.5",
  "serde",
  "subtle",
- "tls_codec",
+ "tls_codec 0.5.0",
  "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-crypto"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a73a99d9008010d73289f41335a3f6e14fb8c04eaf60e9111b450463b1bbc7f"
+checksum = "d2c461da2e0c9c93d875b597f0c78214fb0d2d5c57834b2ef2a2fa057fa20e24"
 dependencies = [
- "rand_core 0.9.5",
+ "rand 0.10.2",
  "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-libcrux"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ce6b7e54aebe540faee869c67ee253bede44ea6cb67c6e72c7847d6c59f1df"
+checksum = "4c1ace95ef11fbbd84527eada5fc1304f66720fc4c008db30d888d62d3c52613"
 dependencies = [
  "hpke-rs-crypto",
- "libcrux-aead 0.0.7",
+ "libcrux-aead",
  "libcrux-ecdh",
  "libcrux-hkdf",
  "libcrux-kem",
@@ -1243,24 +1288,25 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs-rust-crypto"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b28be6cba9081c7feda2651d51c2a900029798e78b4c1e093e792f4571a870"
+checksum = "3a606ac19851da841862ef5f39d26d6227bfcfb4047417801a66c1f6e6652d71"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
- "hkdf",
+ "hkdf 0.13.0",
  "hpke-rs-crypto",
  "k256",
+ "ml-kem",
  "p256",
  "p384",
- "rand 0.8.7",
- "rand_chacha 0.3.1",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
  "rand_core 0.10.1",
- "rand_core 0.6.4",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
- "x25519-dalek",
+ "x-wing",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -1315,6 +1361,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
+ "ctutils",
  "typenum",
 ]
 
@@ -1354,6 +1401,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,15 +1524,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
+name = "itertools"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
+ "either",
 ]
 
 [[package]]
@@ -1461,6 +1609,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,33 +1636,21 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libcrux-aead"
-version = "0.0.6"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44098a02cdfd8f41cffe672e1d449538a75fd77a9a8093b3d6d77c4b43a7363"
+checksum = "22acbe68be84b7b41aaba6e39b87036fc4324dee628d94773750bf3d7e906d69"
 dependencies = [
- "libcrux-aesgcm",
- "libcrux-chacha20poly1305 0.0.6",
+ "libcrux-aes",
+ "libcrux-chacha20poly1305",
  "libcrux-secrets",
  "libcrux-traits",
 ]
 
 [[package]]
-name = "libcrux-aead"
-version = "0.0.7"
+name = "libcrux-aes"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13297ce29869a5c0edab0378837b0fc5f88bf99a843712d9201c3b1150b3b476"
-dependencies = [
- "libcrux-aesgcm",
- "libcrux-chacha20poly1305 0.0.7",
- "libcrux-secrets",
- "libcrux-traits",
-]
-
-[[package]]
-name = "libcrux-aesgcm"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f2a019dab4097585a7d4f5b9deebe46cd1e628b16a5bc4cb0ce35e1da334e6"
+checksum = "57cc95b11dbc797b1e169467b1fc4205c4e6ee2ce516a035ad7342ce5f6ae971"
 dependencies = [
  "libcrux-intrinsics",
  "libcrux-platform",
@@ -1504,35 +1660,22 @@ dependencies = [
 
 [[package]]
 name = "libcrux-chacha20poly1305"
-version = "0.0.6"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627fca7f9cb4cedaa9667670de8f591859dd2417ce4006c4f0ebbe5626f5e0a"
+checksum = "537e6eee5cdc9a980014d058784b0be09614f0596df789b114f7833aa9f35d75"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-poly1305 0.0.4",
- "libcrux-secrets",
- "libcrux-traits",
-]
-
-[[package]]
-name = "libcrux-chacha20poly1305"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc08d044676af21343b32b988411fa98dbb5cf65a03c9df478ced221bbdfdb1b"
-dependencies = [
- "libcrux-hacl-rs",
- "libcrux-macros",
- "libcrux-poly1305 0.0.5",
+ "libcrux-poly1305",
  "libcrux-secrets",
  "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-curve25519"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1e5fd8476a6ed609d24ef42aee5ab6f99f7c65d054f92412da9f499e423299"
+checksum = "e4f3cfd5e31cb9745e290ee061222c380ec42884654b09fc7d12a5b0ed63e028"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1542,41 +1685,42 @@ dependencies = [
 
 [[package]]
 name = "libcrux-ecdh"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65f73ce79337c762eb38bbac91e4c9b9e60cf318e8501b812750c640814d45e"
+checksum = "4a227590b89ff55ce7cd97b5a7468c82d231db8f3b890bb4d4fb6d271e7524d7"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
- "rand 0.9.5",
+ "rand 0.10.2",
+ "tls_codec 0.5.0",
 ]
 
 [[package]]
 name = "libcrux-ed25519"
-version = "0.0.6"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3970fc899de0a430a4bd04acdbbfb5236057a895759bea42d36b0f52afb3e418"
+checksum = "cc463d32f41c47e03dc664547596928a13cb3d79c03453a9b3fe654649313982"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
  "libcrux-sha2",
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "libcrux-hacl-rs"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2637dc87d158e1f1b550fd9b226443e84153fded4de69028d897b534d16d22e6"
+checksum = "66106db376ae249af86911aee048cf73ea1f394d6653026fc988dd22cf2a4ace"
 dependencies = [
  "libcrux-macros",
 ]
 
 [[package]]
 name = "libcrux-hkdf"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1a89ca0c89be3a268a921e47105fb7873badf7267f5e3ebf4ea46baedd73ef"
+checksum = "dc94e651dca4d47edbcdd88bb2428ce16a2bd86b7a4e7170da87b505478f9839"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-hmac",
@@ -1585,20 +1729,31 @@ dependencies = [
 
 [[package]]
 name = "libcrux-hmac"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7a242707d65960770bd7e14e4f18a92bdf0b967777dd404887db8d087a643b"
+checksum = "500ad9b32c715161b594172ca1fb11503a1c033b393ff4c0c33505ce51c1943c"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
  "libcrux-sha2",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-hmac-drbg"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860985647c344b7357ce950bf8e13f076db47df36132d49b48a6fff30abe5be6"
+dependencies = [
+ "libcrux-hmac",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "libcrux-intrinsics"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b5db005ff8001e026b73a6842ee81bbef8ec5ff0e1915a67ae65fd2a9fafa5"
+checksum = "98a0c574d4eb81d0814bc2b91e4a433d7e0b35851b1d62eb5dd95c064f1f76d0"
 dependencies = [
  "core-models",
  "hax-lib",
@@ -1606,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-kem"
-version = "0.0.7"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12631592f491d22fd1a176d32b2c6edfb673998fd3987e9d95f8fa79ad2a737b"
+checksum = "541a7377fb35060892e0620982e224e47419f10da8c212453bf642dafe529691"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-ecdh",
@@ -1616,7 +1771,7 @@ dependencies = [
  "libcrux-p256",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1631,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-ml-kem"
-version = "0.0.8"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14ab3e477de9df6ee1273a114018ff62c4996ca9220070c4e5cb1743f94a67d"
+checksum = "1d8160f7d64fd2716b4fd05cc886a042f8dcda18d9206c0d506e2c67bdf97daa"
 dependencies = [
  "hax-lib",
  "libcrux-intrinsics",
@@ -1641,15 +1796,15 @@ dependencies = [
  "libcrux-secrets",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.5",
- "tls_codec",
+ "rand 0.10.2",
+ "tls_codec 0.5.0",
 ]
 
 [[package]]
 name = "libcrux-p256"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4778ba25cb08bb8a96bd100e19ed9aecf78337198fd176036e21042b2dd99bc"
+checksum = "3400732702d578be622257b98cec85e9b0cd34a67f1f06d3ebe9ae34963cdf02"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1669,19 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-poly1305"
-version = "0.0.4"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfb6399682b2dee13b728c779ab5dcc51afbe982b63508ca524806994336134"
-dependencies = [
- "libcrux-hacl-rs",
- "libcrux-macros",
-]
-
-[[package]]
-name = "libcrux-poly1305"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02491808ee5b9db8cb65fad64ae0be812db64beef179d945c00c7787dc7dfcf9"
+checksum = "76a9144949845813a0b8787d08cbba47baabe59c83f3043e558e6e92385c40cc"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1689,18 +1834,19 @@ dependencies = [
 
 [[package]]
 name = "libcrux-secrets"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce650f3041b44ba40d4263852347d007cd2cd9d1cc856a6f6c8b2e10c3fd40b"
+checksum = "79054fc9037cb70d6a546cf094cea7d7df06af5e49d230ba24103d27ccc886f1"
 dependencies = [
+ "crabgrind",
  "hax-lib",
 ]
 
 [[package]]
 name = "libcrux-sha2"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d253473f259fc74a280c43f29c464f7e374abdf28b4942234dc707f529d4b7"
+checksum = "960e46e1be0b77098cc6ce82137864936ecad3a1b9fd4303dd51202ca140dd1e"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -1709,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-sha3"
-version = "0.0.8"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ae0b7d0e1cc4793a609fd0ff2ca3b3a3fabae523770c619a3d4bc86417b0d7"
+checksum = "c09f5c39afae0528e1f70a3c1e3c6ee649ec1f19dda26fc9b6ea91108fb879ef"
 dependencies = [
  "hax-lib",
  "libcrux-intrinsics",
@@ -1721,12 +1867,22 @@ dependencies = [
 
 [[package]]
 name = "libcrux-traits"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
+checksum = "3fa7a21e8c2e8baa8b40f0b176740f2ca4baadd79d1b00e48d6b1e363c42085a"
 dependencies = [
  "libcrux-secrets",
- "rand 0.9.5",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -1751,6 +1907,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1789,6 +1951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,6 +1968,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-dsa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "shake",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +2026,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1841,89 +2065,77 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openmls"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb512bfe6a55777518853ea535c6241f069cb0e8984678c117151d2a1e7e903"
+checksum = "b6b08d90fc020cb5354d5f08ca17711b84c82e2bcc7331753fd94f000d99a8c8"
 dependencies = [
- "fluvio-wasm-timer",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "log",
- "openmls_libcrux_crypto 0.3.1",
+ "openmls_basic_credential",
+ "openmls_libcrux_crypto",
+ "openmls_memory_storage",
+ "openmls_rust_crypto",
+ "openmls_serialization_helpers",
+ "openmls_sqlite_storage",
  "openmls_test",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "rayon",
  "serde",
  "serde_bytes",
  "thiserror 2.0.20",
- "tls_codec",
+ "tls_codec 0.5.0",
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "openmls_basic_credential"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd3f0c3422e7c7a8496f042b547b0c28d0793f8ba97feb401966e58196a1e40"
+dependencies = [
+ "ed25519-dalek 2.2.0",
+ "ml-dsa",
+ "openmls_traits",
+ "p256",
+ "p384",
+ "rand_core 0.6.4",
+ "serde",
+ "tls_codec 0.5.0",
  "zeroize",
 ]
 
 [[package]]
 name = "openmls_libcrux_crypto"
-version = "0.2.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38e425025fcd0caa0f2852bcf825a937ee80d0fa35803d0b5c248a1522190b8"
+checksum = "41e6367fb30f91f21e4d30f4f58a8d3b41f96f55c3e4b5acfa1d6d18c9dd4855"
 dependencies = [
  "hpke-rs",
  "hpke-rs-crypto",
  "hpke-rs-libcrux",
- "libcrux-aead 0.0.6",
+ "libcrux-aead",
  "libcrux-ed25519",
  "libcrux-hkdf",
  "libcrux-hmac",
+ "libcrux-hmac-drbg",
  "libcrux-sha2",
  "libcrux-traits",
- "openmls_memory_storage 0.4.1",
- "openmls_traits 0.4.1",
- "rand 0.9.5",
- "rand_chacha 0.9.0",
- "tls_codec",
-]
-
-[[package]]
-name = "openmls_libcrux_crypto"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82db6d14bcea364a2f078353cf081ead79950c57dcb307a865fe1eb05d390204"
-dependencies = [
- "hpke-rs",
- "hpke-rs-crypto",
- "hpke-rs-libcrux",
- "libcrux-aead 0.0.6",
- "libcrux-ed25519",
- "libcrux-hkdf",
- "libcrux-hmac",
- "libcrux-sha2",
- "libcrux-traits",
- "openmls_memory_storage 0.5.0",
- "openmls_traits 0.5.0",
- "rand 0.9.5",
- "rand_chacha 0.9.0",
- "tls_codec",
+ "openmls_memory_storage",
+ "openmls_traits",
+ "rand 0.10.2",
+ "tls_codec 0.5.0",
 ]
 
 [[package]]
 name = "openmls_memory_storage"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7b071ea5573a97efaa72b7c53e81cebc644b62ef0fe992bad685cc0f7dd4ea"
+checksum = "ce927945a16eaa19302ed5ccef052f01ba68f2ba7ae67e4ac4ff2fc661445364"
 dependencies = [
+ "hex",
  "log",
- "openmls_traits 0.4.1",
- "serde",
- "serde_json",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "openmls_memory_storage"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a52c927ddb9940acb96d51aebd54b8b9c601c7119e6609622fb3f2cbe16abe3"
-dependencies = [
- "log",
- "openmls_traits 0.5.0",
+ "openmls_traits",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -1931,64 +2143,77 @@ dependencies = [
 
 [[package]]
 name = "openmls_rust_crypto"
-version = "0.4.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e864b90d4b297b84a46ada993142a72392737248050100533ae063586c7f433f"
+checksum = "36bf3fe824ead6e81d22f49a9cd7feffca3494979fac14c1248e19516e3625f1"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "ed25519-dalek 2.2.0",
- "hkdf",
- "hmac",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "hpke-rs",
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
- "openmls_memory_storage 0.4.1",
- "openmls_traits 0.4.1",
+ "ml-dsa",
+ "openmls_memory_storage",
+ "openmls_traits",
  "p256",
- "rand 0.8.7",
+ "p384",
  "rand_chacha 0.3.1",
- "serde",
- "sha2 0.10.9",
+ "rand_core 0.10.1",
+ "rand_core 0.6.4",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
- "tls_codec",
+ "tls_codec 0.5.0",
+]
+
+[[package]]
+name = "openmls_serialization_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2cf2193541e83ce1a89aaa44c2fd4783abd54853823075a32b60ef032284c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "openmls_sqlite_storage"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a48acaffbed1bbed61c5030193e374ff4914331ed5f4a604bd5a4692c0a713"
+dependencies = [
+ "openmls_traits",
+ "refinery",
+ "rusqlite",
+ "serde",
 ]
 
 [[package]]
 name = "openmls_test"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5984361586c8ef56108664ffec909fa78126be8eef1983723f0aed80a9266"
+checksum = "b8b4f925203b593f1ac9b5155d71f74355ef6a3ef34a081a4749bbc92288c761"
 dependencies = [
- "ansi_term",
- "openmls_libcrux_crypto 0.2.4",
+ "openmls_libcrux_crypto",
  "openmls_rust_crypto",
- "openmls_traits 0.4.1",
- "proc-macro2",
+ "openmls_sqlite_storage",
+ "openmls_traits",
  "quote",
- "rstest",
- "rstest_reuse",
  "syn 2.0.119",
 ]
 
 [[package]]
 name = "openmls_traits"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21d8877bacdbc407060df29bf59b145bb886a8fa0099b87ae8067a34b902a13"
+checksum = "ac13edad8698eb1917cbc1dab99591fa1594d84320904fe3fc5121854f95831c"
 dependencies = [
  "serde",
- "tls_codec",
-]
-
-[[package]]
-name = "openmls_traits"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f88ccdd53448dfdbfa5b8da8ba4e527c418fdb966418172bace2e3b41eedd56"
-dependencies = [
- "serde",
- "tls_codec",
+ "tls_codec 0.5.0",
 ]
 
 [[package]]
@@ -2015,33 +2240,10 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2052,7 +2254,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2085,19 +2287,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2130,6 +2336,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,21 +2360,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -2195,7 +2417,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.13.1",
+ "bitflags",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
@@ -2283,17 +2505,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
 
 [[package]]
 name = "rand"
@@ -2401,20 +2612,55 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
+]
+
+[[package]]
+name = "refinery"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2a344cdb48871e27addeafbbaffab8828cc12cec2b9041119e9bea0c0f551a"
+dependencies = [
+ "refinery-core",
+ "refinery-macros",
+]
+
+[[package]]
+name = "refinery-core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eeafd893124f29183dd6afa9137a27e7bef59250223b8b660005279c60aea4"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "log",
+ "regex",
+ "rusqlite",
+ "serde",
+ "siphasher",
+ "thiserror 2.0.20",
+ "time",
+ "toml 1.1.4+spec-1.1.0",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "refinery-macros"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90cea6d11a9a4e8a85a884b6305461004101b28ca65dd35ec028e009a898e16"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "refinery-core",
+ "regex",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2447,18 +2693,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -2477,59 +2717,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "rstest"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
-dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.119",
- "unicode-ident",
-]
-
-[[package]]
-name = "rstest_reuse"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
-dependencies = [
- "quote",
- "rand 0.8.7",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2546,7 +2751,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2559,7 +2764,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2689,9 +2894,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -2702,7 +2907,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2821,6 +3026,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,6 +3095,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
+ "digest 0.11.3",
  "rand_core 0.10.1",
 ]
 
@@ -2870,6 +3114,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2900,8 +3150,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "subtle"
@@ -2936,6 +3208,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "tempfile"
@@ -2991,13 +3274,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tls_codec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
 dependencies = [
+ "tls_codec_derive 0.4.2",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18cc98286004cea38f717e2b03d990fc774fbfd38a82720de40e5c94365067c8"
+dependencies = [
  "serde",
- "tls_codec_derive",
+ "serde_bytes",
+ "tls_codec_derive 0.5.0",
  "zeroize",
 ]
 
@@ -3006,6 +3340,17 @@ name = "tls_codec_derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674f41dd95f76cdeb005c83f9444e20cf43daebef37cde9e49a9ca6f4e87b423"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3075,6 +3420,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,18 +3453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.25.13+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
-dependencies = [
- "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.4",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3460,12 @@ checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3220,10 +3574,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -3302,16 +3674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3344,12 +3706,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.104"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -3384,22 +3747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,12 +3754,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -3513,15 +3854,31 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "x-wing"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51507b887016c3925c84591108dadb8c099f776eb04fec6a60ae3519fee856f"
+dependencies = [
+ "kem",
+ "ml-kem",
+ "sha3 0.12.0",
+ "shake",
+ "x25519-dalek 3.0.0",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -3533,6 +3890,39 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -3556,6 +3946,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3573,6 +3984,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -86,10 +86,20 @@ zeroize = { version = "1", default-features = false, features = ["derive"] }
 f2z-codec = { path = "crates/f2z-codec", version = "0.1.0" }
 
 # ---------------------------------------------------------------------------
-# MLS (RFC 9420), ARCHITECTURE.md §5. Every version here is the one #385
-# measured on real hardware across all nine shipping triples; none of them is
-# free to move on a whim, and the floor beneath `openmls` is enforced by
-# `[[bans.deny]]` in rs/deny.toml rather than by these lines.
+# MLS (RFC 9420), ARCHITECTURE.md §5.
+#
+# The 0.9 train (`openmls 0.9.0`, `openmls_traits 0.6.0`,
+# `openmls_libcrux_crypto 0.4.0`), taken for a **security** reason and not for
+# freshness: 0.4.0 of the provider moves to `libcrux-aead 0.0.9` /
+# `libcrux-ed25519 0.0.9`, which is the first libcrux release train whose
+# `libcrux-secrets` requirement admits `0.0.6` — the fix for RUSTSEC-2026-0212,
+# the aarch64 constant-time swap/select defect that #701 could not patch around
+# without forking libcrux. Ten `ignore` entries came out of `rs/deny.toml` with
+# this bump; see #723.
+#
+# None of these is free to move on a whim, and the floor beneath `openmls` and
+# `openmls_traits` is enforced by `[[bans.deny]]` in rs/deny.toml rather than by
+# these lines.
 # ---------------------------------------------------------------------------
 
 # The storage trait, and nothing else. `f2z-msg-store` implements
@@ -97,32 +107,62 @@ f2z-codec = { path = "crates/f2z-codec", version = "0.1.0" }
 # depend on `openmls`: the storage layer is defined entirely by the trait, and
 # keeping the engine out of that crate's graph is what lets a browser build the
 # store without the crypto core.
-openmls_traits = { version = "0.5", default-features = false }
-# 0.8.1 is a HARD FLOOR: every earlier release carries the High-severity MAC
-# authentication defect (GHSA-3wpg-h9qc-hjwj / RUSTSEC-2025-0069), and a floor
-# nobody enforces is a comment. rs/deny.toml holds it with `[[bans.deny]]`,
-# because a `[patch.crates-io]`, a path dependency or a vendored copy all walk
-# under a manifest requirement without a word.
 #
-# `default-features = false` and then `libcrux-provider` by name: the default
-# provider is `openmls_rust_crypto`, which is a *second* crypto core, and
-# ADR 0001 has exactly one. `test-utils` is deliberately absent — it pulls
-# `openmls_memory_storage` and `openmls_basic_credential` back in, which are
-# the two crates this tree replaces.
-openmls = { version = "0.8.1", default-features = false, features = [
+# 0.6.0's `StorageProvider` is byte-for-byte the same trait as 0.5.0's on the
+# surface this tree implements: every method 0.6.0 adds is behind
+# `virtual-clients-draft`, which nothing here enables. The one break that
+# reached us is a **feature rename** — `extensions-draft-08` became
+# `extensions-draft` — and `f2z-msg-store`'s forwarding feature is renamed with
+# it.
+openmls_traits = { version = "0.6", default-features = false }
+# 0.9.0 is a HARD FLOOR, and it subsumes the 0.8.1 one. Every release before
+# 0.8.1 carries the High-severity MAC authentication defect
+# (GHSA-3wpg-h9qc-hjwj / RUSTSEC-2025-0069); every release before 0.9.0 resolves
+# to a `libcrux-secrets 0.0.5` carrying RUSTSEC-2026-0212. A floor nobody
+# enforces is a comment, so rs/deny.toml holds this one with `[[bans.deny]]`:
+# a `[patch.crates-io]`, a path dependency or a vendored copy all walk under a
+# manifest requirement without a word.
+#
+# `default-features = false` and then features by name:
+#
+#   * `libcrux-provider` — the default provider is `openmls_rust_crypto`, which
+#     is a *second* crypto core, and ADR 0001 has exactly one.
+#   * `draft-ietf-mls-pq-ciphersuites` — **newly required in 0.9.0, and it is
+#     not optional for us.** 0.9.0 moved every post-quantum codepoint, X-Wing
+#     included, behind this feature; without it
+#     `Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519` and
+#     `HpkeKemType::XWingKemDraft6` do not exist and §5.2's hybrid ciphersuite
+#     cannot be named. It gates a set of codepoints, not an alternative
+#     implementation: `engine::CIPHERSUITE` is unchanged and
+#     `the_ciphersuite_uses_chacha20poly1305_and_not_aes_gcm` still checks it.
+#
+# `test-utils` is deliberately absent — it pulls `openmls_memory_storage` and
+# `openmls_basic_credential` back in, which are the two crates this tree
+# replaces.
+openmls = { version = "0.9.0", default-features = false, features = [
   "libcrux-provider",
+  "draft-ietf-mls-pq-ciphersuites",
 ] }
 # Cryspen's formally verified core, and the only one this tree links.
 # #385 proved `MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519` on it against the
 # NIST ACVP ML-KEM vectors, RFC 7748, RFC 8032 and draft-connolly-cfrg-xwing-06
-# Appendix C, on nine targets.
-openmls_libcrux_crypto = { version = "0.3.1", default-features = false }
+# Appendix C, on nine targets — against 0.3.1. #723 re-ran the two-instance
+# exchange, the crash suite and the cross-compilation matrix against 0.4.0;
+# what it could not re-run is recorded on that issue.
+openmls_libcrux_crypto = { version = "0.4.0", default-features = false }
 # Ed25519, straight from the libcrux core. This is the *same* crate and the same
 # functions `openmls_libcrux_crypto`'s `CryptoProvider::sign` /
 # `verify_signature` call, so naming it here adds nothing to the graph — it lets
 # `f2z-msg-mls` implement `openmls_traits::signatures::Signer` itself instead of
 # taking `openmls_basic_credential`, which is #693.
-libcrux-ed25519 = { version = "0.0.6", default-features = false }
+#
+# 0.0.9 rather than 0.0.6 because `openmls_libcrux_crypto 0.4.0` requires it,
+# and unifying is the point — a second copy would mean MLS framing signed by one
+# build of the primitive and verified by another. It is also the release that
+# fixes RUSTSEC-2026-0075: `generate_key_pair` now returns `Error::KeyGen`
+# instead of an all-zero secret key when the CSPRNG fails 100 times running.
+# `sign` is unchanged, which is the only function this tree calls.
+libcrux-ed25519 = { version = "0.0.9", default-features = false }
 # `openmls_basic_credential` is NOT here and must not be added. It signs with
 # `ed25519-dalek` and `p256` outside the libcrux provider (#693), which
 # contradicts ADR 0001's single crypto core; `f2z-msg-mls` implements

--- a/rs/crates/f2z-msg-mls/Cargo.toml
+++ b/rs/crates/f2z-msg-mls/Cargo.toml
@@ -61,7 +61,11 @@ openmls_libcrux_crypto = { workspace = true }
 # uses (`openmls_libcrux_crypto`'s `crypto.rs` calls exactly these functions),
 # so naming it here adds no crate to the graph and removes two.
 libcrux-ed25519 = { workspace = true }
-tls_codec = { workspace = true }
+# `tls_codec` is deliberately NOT a dependency of this crate. `openmls 0.9` is
+# on `tls_codec 0.5` and `f2z-codec`/`f2z-kt-core` are on `0.4`; the only two
+# `tls_codec` calls here are on OpenMLS's own types, and `src/engine.rs` reaches
+# them through `openmls::prelude::tls_codec` so they cannot resolve to the other
+# version. See the note at that import.
 serde = { workspace = true }
 
 [dev-dependencies]
@@ -85,14 +89,35 @@ libcrux-ed25519 = { workspace = true }
 # store uses.
 serde_json = { workspace = true }
 
-# wasm32 only, and only to turn a feature on. See `src/lib.rs`'s note on the
-# browser build: `getrandom` refuses to compile for wasm32-unknown-unknown
-# unless a backend is selected, and neither of the two versions in this graph is
-# reachable through a feature of `openmls` or `openmls_libcrux_crypto`
-# (getrandom 0.3 arrives via `rand_core 0.9`, getrandom 0.4 via `rand 0.10`
-# inside `hpke-rs-libcrux`). Naming both here unifies the feature across the
-# graph; the matching `--cfg getrandom_backend="wasm_js"` is set by the wasm
-# job. Target-gated so a native build gains nothing.
+# wasm32 only, and only to turn a feature on. `getrandom` refuses to compile for
+# wasm32-unknown-unknown until a backend is selected — a `compile_error!`, not a
+# binary that traps — and the browser build (ADR 0001) needs one.
+#
+# **There used to be two entries here and now there is one**, which is a real
+# change in the graph rather than a tidy-up. Against `openmls 0.8.1` this crate
+# pulled getrandom 0.3 (through `rand_core 0.9`) *and* getrandom 0.4 (through
+# `rand 0.10` inside `hpke-rs-libcrux`), so both had to be named. On the 0.9
+# train nothing in this crate's wasm graph reaches `rand_core 0.9` any more:
+# getrandom 0.3 survives in this workspace's lockfile only under `proptest` and
+# `f2z-relay`'s dev-dependencies, neither of which the `--lib` browser build
+# compiles. Declaring it here would put a crate in the browser bundle that
+# nothing in the browser bundle uses. Verified with
+# `cargo tree --target wasm32-unknown-unknown -p f2z-msg-mls
+# --no-default-features --features js -i getrandom@0.3`, which now matches
+# nothing.
+#
+# **The `--cfg getrandom_backend="wasm_js"` RUSTFLAG went with it**, and that is
+# a version difference rather than an oversight: getrandom **0.3** required the
+# feature *and* the cfg, while **0.4** selects its wasm backend from the
+# `wasm_js` feature alone (`src/backends.rs`, the
+# `target_family = "wasm"` arm). `.github/workflows/rs.yml` no longer sets it.
+#
+# The entry below is kept even though `openmls/js` also turns `getrandom/wasm_js`
+# on by unification, per `AGENTS.md`: a feature enabled only because some other
+# crate happens to enable it is a feature we do not actually have. Target-gated,
+# so a native build gains nothing.
+#
+# If getrandom 0.3 ever re-enters this graph the wasm job fails at compile time
+# with getrandom's own `compile_error!`. It cannot fail quietly.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom_v03 = { package = "getrandom", version = "0.3", default-features = false, features = ["wasm_js"] }
 getrandom_v04 = { package = "getrandom", version = "0.4", default-features = false, features = ["wasm_js"] }

--- a/rs/crates/f2z-msg-mls/src/engine.rs
+++ b/rs/crates/f2z-msg-mls/src/engine.rs
@@ -55,7 +55,24 @@
 
 use f2z_msg_store::{Durability, StorageBackend};
 use openmls::prelude::*;
-use tls_codec::{Deserialize as _, Serialize as _};
+// **Through the prelude, deliberately, and not as a dependency of this crate.**
+//
+// `openmls 0.9` moved to `tls_codec 0.5`, while `f2z-codec` and `f2z-kt-core`
+// — the crates that define free2z's own wire structures — are on `tls_codec
+// 0.4`. Both live in this graph. The two `tls_codec` traits below are used on
+// **OpenMLS's** types (`MlsMessageOut`, `MlsMessageIn`) and on nothing else, so
+// they must be the version OpenMLS derived them with; naming the crate directly
+// would let a future workspace bump resolve them to the other one and produce a
+// trait-not-implemented error whose cause is invisible. `openmls::prelude`
+// re-exports `tls_codec::{self, *}`, so this import cannot drift from what
+// OpenMLS itself uses.
+//
+// Nothing crosses the seam. A `DeviceCredential` reaches MLS as the opaque
+// identity bytes of a `BasicCredential` (`credential::encode`, which is
+// `f2z-codec`'s canonical encoding), so no `tls_codec` *type* from either
+// version appears in an interface between the two halves — the same shape as
+// the two `ed25519-dalek` majors this workspace already carries.
+use openmls::prelude::tls_codec::{Deserialize as _, Serialize as _};
 
 use crate::credential::{DeviceCredential, encode as encode_credential, validate_for_leaf};
 use crate::error::{CredentialError, EngineError, Result};
@@ -120,6 +137,27 @@ pub enum Received {
     },
     /// A proposal was queued. It changes nothing until a commit covers it.
     ProposalQueued,
+    /// A message **this device authored**, handed back by the relay.
+    ///
+    /// New in the `openmls 0.9` migration (#723) and it is a behaviour change
+    /// worth knowing about. Under 0.8.1 a `PrivateMessage` whose sender data
+    /// named our own leaf failed to decrypt — the own sender ratchet is
+    /// encryption-only — and [`MlsEngine::receive`] returned
+    /// [`EngineError::Mls`]. 0.9 surfaces it as a distinct outcome instead
+    /// (`ProcessedMessageContent::OwnPrivateMessage`), because "I cannot
+    /// decrypt this" and "this is mine and there is nothing to decrypt" are
+    /// different facts and only the first is an error.
+    ///
+    /// The content is **not** available and never will be: the plaintext of
+    /// our own message is the caller's, not the engine's. What the engine does
+    /// do is write the durable "handled" record for it in the same
+    /// transaction, so the caller may `ACK` and the relay may drop its copy —
+    /// which is the whole point of surfacing it rather than failing.
+    ///
+    /// `ARCHITECTURE.md` §9.4 makes this routine rather than exotic: a device
+    /// may publish queue addresses on *k* relays and a sender sends to all *k*,
+    /// so a device that is also a member sees its own traffic come back.
+    Own,
 }
 
 impl core::fmt::Debug for Received {
@@ -146,6 +184,7 @@ impl core::fmt::Debug for Received {
                 .field("epoch", epoch)
                 .finish(),
             Self::ProposalQueued => f.write_str("ProposalQueued"),
+            Self::Own => f.write_str("Own"),
         }
     }
 }
@@ -476,6 +515,39 @@ impl<B: StorageBackend> MlsEngine<B> {
                 self.validate_members(group, now_ms)?;
                 Received::EpochChanged {
                     epoch: group.epoch().as_u64(),
+                }
+            }
+            // Both of these are **new in openmls 0.9** and both mean "this
+            // device authored it and the delivery service handed it back".
+            ProcessedMessageContent::OwnPrivateMessage => Received::Own,
+            ProcessedMessageContent::OwnPendingCommit => {
+                // 0.9 returns this when an incoming Commit's confirmation tag
+                // matches a commit *this* device has pending, so that the
+                // caller merges the pending commit rather than staging the
+                // echo. This engine never leaves one pending: `update` and
+                // `add_member` call `merge_pending_commit` before their bytes
+                // leave the method, precisely so that the device is in the new
+                // epoch the moment the caller has something to send. So the
+                // `Some` arm is not reachable today.
+                //
+                // It is written anyway, and it is not defensive padding: the
+                // alternative — assuming the invariant and returning
+                // `Received::Own` — would silently *skip an epoch change* if
+                // anyone ever split those two steps, and a group whose tree is
+                // one epoch behind its peers' is exactly the failure the
+                // transaction in this method exists to prevent. Merging is the
+                // only correct action when a pending commit exists, and doing
+                // nothing is the only correct action when none does.
+                if group.pending_commit().is_some() {
+                    group
+                        .merge_pending_commit(&self.provider)
+                        .map_err(|_| EngineError::Mls("merge pending commit"))?;
+                    self.validate_members(group, now_ms)?;
+                    Received::EpochChanged {
+                        epoch: group.epoch().as_u64(),
+                    }
+                } else {
+                    Received::Own
                 }
             }
         };

--- a/rs/crates/f2z-msg-mls/src/lib.rs
+++ b/rs/crates/f2z-msg-mls/src/lib.rs
@@ -7,16 +7,22 @@
 //! # What is settled, and why it is not re-litigated here
 //!
 //! [#385](https://github.com/free2z/zuu/issues/385) proved, on real hardware,
-//! that `openmls 0.8.1` with `openmls_libcrux_crypto 0.3.1` on
+//! that OpenMLS with the libcrux provider on
 //! `MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519` builds for all nine shipping
 //! triples and runs green on Android API-29 against NIST ACVP ML-KEM vectors,
 //! RFC 7748, RFC 8032 and draft-connolly-cfrg-xwing-06 Appendix C. KeyPackage
-//! generation is 0.20 ms; the first commit is 1.35 ms. Those versions are the
-//! ones this crate pins and the choice is not open.
+//! generation is 0.20 ms; the first commit is 1.35 ms. **That measurement was
+//! against `openmls 0.8.1` / `openmls_libcrux_crypto 0.3.1`**, and this crate
+//! is now on the 0.9 train; #723 re-ran what it could and recorded what it
+//! could not. The *library choice* is what #385 settled, and that is not open.
 //!
-//! **`openmls >= 0.8.1` is a hard floor**: every earlier release carries the
-//! High-severity MAC authentication defect. `rs/deny.toml` holds the floor with
-//! a `[[bans.deny]]` entry, because a version floor nobody enforces is a
+//! **`openmls >= 0.9.0` is a hard floor**, and it carries two defects rather
+//! than one: every release before 0.8.1 has the High-severity MAC
+//! authentication defect, and every release before 0.9.0 resolves to a
+//! `libcrux-secrets 0.0.5` carrying RUSTSEC-2026-0212 — a constant-time
+//! swap/select that can return **incorrect results on aarch64**, which is every
+//! phone we ship to, underneath the AEAD we use. `rs/deny.toml` holds the floor
+//! with `[[bans.deny]]` entries, because a version floor nobody enforces is a
 //! comment — a `[patch.crates-io]`, a path dependency or a vendored copy all
 //! walk under a manifest requirement without a word.
 //!

--- a/rs/crates/f2z-msg-mls/src/version.rs
+++ b/rs/crates/f2z-msg-mls/src/version.rs
@@ -34,11 +34,18 @@
 
 use serde::{Deserialize, Serialize};
 
-/// The ciphersuite codepoint this engine builds groups on, as OpenMLS 0.8.1 and
+/// The ciphersuite codepoint this engine builds groups on, as OpenMLS 0.9.0 and
 /// libcrux ship it today.
 ///
 /// Named rather than left implicit so that the number a future migration has to
 /// look for is written down in one place, with the paragraph above next to it.
+///
+/// `openmls 0.9.0` moved this codepoint — and every other post-quantum one —
+/// behind the `draft-ietf-mls-pq-ciphersuites` feature, which
+/// `rs/Cargo.toml` therefore enables. The **number is unchanged**; what moved
+/// is whether the name compiles. That is the shape of relabelling this module
+/// exists to survive, and it arrived one minor version after the module was
+/// written.
 pub const XWING_CIPHERSUITE_CODEPOINT: u16 = 0x004D;
 
 /// The revision of *our* MLS profile that produced a group's stored state.

--- a/rs/crates/f2z-msg-mls/tests/two_instances.rs
+++ b/rs/crates/f2z-msg-mls/tests/two_instances.rs
@@ -226,6 +226,69 @@ fn both_sides_record_the_protocol_version_beside_the_group() {
 
 /// A device may publish queue addresses on *k* relays and senders send to all
 /// *k* (`ARCHITECTURE.md` §9.4), so the same message arriving twice is routine.
+/// A device's own `PrivateMessage`, handed back by the relay, is an outcome and
+/// not an error.
+///
+/// # This is a behaviour change the 0.9 migration brought with it
+///
+/// `ARCHITECTURE.md` §9.4 makes it routine rather than exotic: a device may
+/// publish queue addresses on *k* relays and a sender sends to all *k*, so a
+/// device that is also a member sees its own traffic come back. Under
+/// `openmls 0.8.1` that failed to decrypt — the own sender ratchet is
+/// encryption-only — and [`MlsEngine::receive`] returned `EngineError::Mls`,
+/// which put the caller in the position of having to distinguish "the relay
+/// echoed me" from "something is wrong with this group" by guessing.
+///
+/// `openmls 0.9` surfaces it as `ProcessedMessageContent::OwnPrivateMessage`,
+/// and this engine maps it to [`Received::Own`]. The consequences the test
+/// pins are the ones that matter under delete-on-ack (§6.4):
+///
+/// * the plaintext is **not** returned — `payload()` is `None`, because the
+///   content of our own message is the caller's and the engine has nothing to
+///   decrypt;
+/// * the durable "handled" record **is** written, so the caller may `ACK` and
+///   the relay may drop its copy. That is the whole reason for surfacing it
+///   rather than failing: an echo that always errored would be an echo that
+///   could never be acknowledged, and the relay would keep redelivering it.
+#[test]
+fn a_devices_own_message_handed_back_is_an_outcome_and_not_an_error() {
+    let (alice, mut alice_group, bob, mut bob_group) = paired();
+
+    let wire = alice.send(&mut alice_group, b"hello, bob").expect("send");
+
+    // The relay hands Alice her own message back.
+    let received = alice
+        .receive(&mut alice_group, &wire, b"echo-1", NOW)
+        .expect("an echo is not an error");
+    assert_eq!(received, Received::Own);
+    assert_eq!(received.payload(), None);
+
+    // The record was written in the same transaction, so a second delivery of
+    // the same echo is a duplicate rather than a second `Own`. This is what
+    // makes the `ACK` safe.
+    assert!(matches!(
+        alice.receive(&mut alice_group, &wire, b"echo-1", NOW),
+        Err(EngineError::Duplicate)
+    ));
+
+    // Neither side moved, and the group still works in both directions.
+    assert_eq!(alice_group.epoch(), bob_group.epoch());
+    assert_eq!(
+        bob.receive(&mut bob_group, &wire, b"msg-1", NOW)
+            .expect("bob still decrypts it")
+            .payload(),
+        Some(b"hello, bob".as_slice())
+    );
+    let reply = bob.send(&mut bob_group, b"hello, alice").expect("send");
+    assert_eq!(
+        alice
+            .receive(&mut alice_group, &reply, b"msg-2", NOW)
+            .expect("receive")
+            .payload(),
+        Some(b"hello, alice".as_slice())
+    );
+}
+
 #[test]
 fn a_duplicate_delivery_is_refused_and_changes_nothing() {
     let (alice, mut alice_group, bob, mut bob_group) = paired();
@@ -331,22 +394,28 @@ fn a_truncated_message_is_refused_and_leaves_the_group_usable() {
 
 /// A flipped ciphertext byte must be a refusal, not a crash.
 ///
-/// # Why this is gated on `not(debug_assertions)`
+/// # This used to be gated on `not(debug_assertions)`, and no longer is
 ///
-/// **This is an upstream defect, and it is worth stating rather than working
-/// around silently.** `openmls 0.8.1`'s
-/// `private_message_in.rs:136` runs `debug_assert!(false, "Ciphertext
-/// decryption failed")` on the AEAD-open failure path — a path any peer, or any
-/// relay that flips one byte, can reach at will. In a release build the
-/// `debug_assert` compiles out and the function correctly returns
-/// `MessageDecryptionError::AeadError`; in a **debug** build, which is what
-/// `cargo test` produces, the process aborts.
+/// `openmls 0.8.1`'s `private_message_in.rs:136` ran
+/// `debug_assert!(false, "Ciphertext decryption failed")` on the AEAD-open
+/// failure path — a path any peer, or any relay that flips one byte, can reach
+/// at will. The assertion compiled out in release and the function correctly
+/// returned `MessageDecryptionError::AeadError`, but in a **debug** build,
+/// which is what `cargo test` produces, the process aborted. The property was
+/// therefore true of what shipped and unassertable by the suite CI ran, so the
+/// case was gated and CI ran it in a separate `--release` step.
 ///
-/// So the property below is true of what ships, and cannot be asserted by the
-/// suite that CI runs. Gating it is the honest option: the alternative is
-/// deleting the test and losing the record that the release behaviour was ever
-/// checked. Run it with `cargo test --release -p f2z-msg-mls`.
-#[cfg(not(debug_assertions))]
+/// **0.9.0 removed that path**: both AEAD-open failures in
+/// `private_message_in.rs` are now `log::error!` followed by a returned
+/// `MessageDecryptionError::AeadError`, with no `debug_assert` anywhere in
+/// `src/framing/` except an unrelated key-package version check. The gate and
+/// the extra CI step both came off with #723 — verified by running this case in
+/// an ordinary debug `cargo test`, not by reading the changelog.
+///
+/// It is left as its own named case rather than folded into
+/// `a_truncated_message_is_refused_…` because the two exercise different
+/// refusals: a truncation fails to parse, and this one parses and fails to
+/// open.
 #[test]
 fn a_corrupted_ciphertext_is_refused_and_leaves_the_group_usable() {
     let (alice, mut alice_group, bob, mut bob_group) = paired();

--- a/rs/crates/f2z-msg-store/Cargo.toml
+++ b/rs/crates/f2z-msg-store/Cargo.toml
@@ -33,7 +33,13 @@ sqlite = ["dep:rusqlite"]
 # code does not exist in a dependency build. Mirrors `f2z-relay-store`.
 crash-injection = []
 
-# Forwarded, never decided here. `openmls_traits`'s `extensions-draft-08`
+# Forwarded, never decided here. **Renamed in `openmls_traits 0.6.0`** — it was
+# `extensions-draft-08` against 0.5.0, and the "-08" went away when the draft
+# moved on. The feature this crate exposes is renamed with it rather than kept
+# as an alias: an alias would let a consumer name a draft revision that no
+# longer exists anywhere in the graph.
+#
+# `openmls_traits`'s `extensions-draft`
 # feature adds three methods to the trait this crate implements
 # (`write_application_export_tree`, `application_export_tree`,
 # `delete_application_export_tree`). They are implemented under the same gate,
@@ -48,13 +54,13 @@ crash-injection = []
 # dependency of `openmls_libcrux_crypto` — would then also have to implement, so
 # turning it on for `openmls_traits` without turning it on for `openmls` (which
 # forwards to that crate) is a compile error in someone else's code. Enabling it
-# for real means enabling `openmls/extensions-draft-08` at the same time.
+# for real means enabling `openmls/extensions-draft` at the same time.
 # `rs/deny.toml` already sets `all-features = false`, and
 # `scripts/check-rust-clippy.sh` lints with `--all-targets` and not
 # `--all-features`, so no gate builds the broken combination — but a person
 # running `cargo build --all-features` out of habit will meet it, and this is
 # where they find out why.
-extensions-draft-08 = ["openmls_traits/extensions-draft-08"]
+extensions-draft = ["openmls_traits/extensions-draft"]
 
 [lints]
 workspace = true

--- a/rs/crates/f2z-msg-store/src/keys.rs
+++ b/rs/crates/f2z-msg-store/src/keys.rs
@@ -44,7 +44,7 @@ pub(crate) const EPOCH_KEY_PAIRS_LABEL: &[u8] = b"EpochKeyPairs";
 
 pub(crate) const TREE_LABEL: &[u8] = b"Tree";
 pub(crate) const GROUP_CONTEXT_LABEL: &[u8] = b"GroupContext";
-#[cfg(feature = "extensions-draft-08")]
+#[cfg(feature = "extensions-draft")]
 pub(crate) const APPLICATION_EXPORT_TREE_LABEL: &[u8] = b"ApplicationExportTree";
 pub(crate) const INTERIM_TRANSCRIPT_HASH_LABEL: &[u8] = b"InterimTranscriptHash";
 pub(crate) const CONFIRMATION_TAG_LABEL: &[u8] = b"ConfirmationTag";
@@ -98,7 +98,7 @@ pub(crate) const LABELS: &[&[u8]] = &[
     EPOCH_KEY_PAIRS_LABEL,
     TREE_LABEL,
     GROUP_CONTEXT_LABEL,
-    #[cfg(feature = "extensions-draft-08")]
+    #[cfg(feature = "extensions-draft")]
     APPLICATION_EXPORT_TREE_LABEL,
     INTERIM_TRANSCRIPT_HASH_LABEL,
     CONFIRMATION_TAG_LABEL,

--- a/rs/crates/f2z-msg-store/src/lib.rs
+++ b/rs/crates/f2z-msg-store/src/lib.rs
@@ -3,21 +3,62 @@
 //!
 //! # Why this crate exists at all
 //!
-//! OpenMLS ships a SQLite storage provider. We cannot use it, and the reason is
-//! not a preference:
+//! OpenMLS ships a SQLite storage provider. This crate is a deliberate
+//! alternative to it, and the reasons below are the current ones —
+//! **re-established against `openmls_sqlite_storage 0.3.0`, not inherited.**
 //!
-//! - `openmls_sqlite_storage 0.2.0`, the newest **release** compatible with the
-//!   audited `openmls 0.8.1`, requires `rusqlite ^0.32`.
-//! - `libsqlite3-sys` declares `links = "sqlite3"`, and Cargo **hard-errors**
-//!   on a graph containing two versions of a `links` package.
-//! - Everything under `wallet/` reaches SQLite through `tauri-plugin-zcash`'s
-//!   `rusqlite = "0.37"`, so **0.37 is a repository-wide singleton**
-//!   (`AGENTS.md`, "What NOT to do").
-//! - The `0.3.0-rc` line does fit `^0.37` — and drags in `openmls 0.9.0-rc`, an
-//!   unreleased OpenMLS.
+//! ## The reason that used to be first, and has expired
 //!
-//! [#385](https://github.com/free2z/zuu/issues/385) reproduced the resolver
-//! error rather than trusting the note. So: implement it.
+//! It was, until 2026-08-25, that the upstream provider **could not resolve**:
+//! `openmls_sqlite_storage 0.2.0` — the newest release compatible with the
+//! audited `openmls 0.8.1` — required `rusqlite ^0.32`; `libsqlite3-sys`
+//! declares `links = "sqlite3"` and Cargo hard-errors on two versions of a
+//! `links` package; everything under `wallet/` reaches SQLite through
+//! `tauri-plugin-zcash`'s `rusqlite = "0.37"`, making **0.37 a
+//! repository-wide singleton** (`AGENTS.md`); and the only line that fit
+//! `^0.37` was a `0.3.0-rc` needing an unreleased `openmls 0.9.0-rc`.
+//! [#385](https://github.com/free2z/zuu/issues/385) reproduced that resolver
+//! error rather than trusting the note.
+//!
+//! **`openmls_sqlite_storage 0.3.0` requires `rusqlite = "0.37"` with
+//! `features = ["bundled"]` — exactly our singleton — and `openmls 0.9.0` is
+//! released.** The blocker is gone. It is written down as gone because a
+//! justification whose leading clause is false is worse than no justification:
+//! it invites the next reader to accept the rest of the argument on the
+//! strength of a premise that has stopped being true.
+//!
+//! ## Why the answer is still "keep this crate"
+//!
+//! Three reasons, each checked against 0.3.0's actual source rather than its
+//! README, and the first is decisive on its own.
+//!
+//! **1. The transaction.** `openmls_sqlite_storage 0.3.0`'s entire public
+//! surface is `new`, `initialize`, `run_migrations` and the `StorageProvider`
+//! impl. There is no transaction API — there cannot be, because
+//! `openmls_traits::storage::StorageProvider` has none — so it commits each of
+//! the many calls in a `process_message` → `merge_staged_commit` run
+//! independently. Nor can one be supplied from outside: the provider is
+//! generic over `ConnectionRef: Borrow<Connection>`, and `rusqlite::Transaction`
+//! reaches `Connection` through `Deref`, not `Borrow`. Atomicity is the whole
+//! point of this crate (see below), and under delete-on-ack a half-applied
+//! epoch change is data loss.
+//!
+//! **2. The backend seam.** ADR 0001 needs one core shared with the browser.
+//! `openmls_sqlite_storage` is native by construction — `rusqlite`'s `bundled`
+//! feature links SQLite's C amalgamation — so a web client would need a second
+//! implementation of all 57 methods, and the second implementation is the one
+//! that ends up with the bug in it. [`StorageBackend`] is three methods with no
+//! generics; an IndexedDB backend is a new type behind it.
+//!
+//! **3. The application namespace.** The durable "handled" record that makes an
+//! `ACK` safe ([`ARCHITECTURE.md` §6.4][s64]) has to land in the **same atomic
+//! write** as the epoch change it accompanies. `StorageProvider` has no notion
+//! of application data, so no implementation of it alone can offer that; this
+//! crate's app namespace shares the journal with the MLS writes.
+//!
+//! A fourth, smaller: [`Durability`] is reported by the backend, so
+//! `f2z-msg-mls` can refuse to let a caller `ACK` on a store that survives
+//! nothing. That is a property of the seam, not of SQLite.
 //!
 //! # The shape
 //!
@@ -32,7 +73,7 @@
 //! is generic over serde, and nothing in the trait is specific to a storage
 //! engine. They are implemented **once**, in [`storage_impl`], in the upstream
 //! trait's declaration order so a reviewer can diff them against
-//! `openmls_traits::storage` and against `openmls_memory_storage 0.5.0` side by
+//! `openmls_traits::storage` and against `openmls_memory_storage 0.6.0` side by
 //! side. The backend seam is three methods with no generics.
 //!
 //! The seam exists now, before the browser needs it, because ADR 0001 requires

--- a/rs/crates/f2z-msg-store/src/sqlite.rs
+++ b/rs/crates/f2z-msg-store/src/sqlite.rs
@@ -39,12 +39,22 @@
 //! SQLite through `tauri-plugin-zcash`'s `rusqlite = "0.37"`, so 0.37 is a
 //! repository-wide singleton.
 //!
+//! **That constraint no longer excludes the upstream provider, and this note
+//! says so rather than repeating an argument that has expired.**
 //! `openmls_sqlite_storage 0.2.0` — the newest *release* compatible with the
-//! audited `openmls 0.8.1` — requires `rusqlite ^0.32` and is therefore
-//! unusable here; #385 reproduced the exact resolver error rather than trusting
-//! the note. Its `0.3.0-rc` line moved to `^0.37` and would fit, but it
-//! requires `openmls_traits ^0.6.0-rc`, i.e. an unreleased `openmls 0.9.0-rc`.
-//! That is the whole reason this crate exists.
+//! then-audited `openmls 0.8.1` — required `rusqlite ^0.32` and was unusable
+//! here; #385 reproduced the exact resolver error rather than trusting the
+//! note. **`openmls_sqlite_storage 0.3.0` requires `rusqlite = "0.37"` with
+//! `features = ["bundled"]`, which is our singleton exactly**, and the
+//! `openmls 0.9.0` it needs is released.
+//!
+//! This crate is kept anyway, and for reasons that have nothing to do with
+//! resolution: 0.3.0 still exposes no transaction (`StorageProvider` has none
+//! to expose, and its `ConnectionRef: Borrow<Connection>` cannot be handed a
+//! `rusqlite::Transaction`, which reaches `Connection` through `Deref`), it is
+//! native by construction so it cannot serve ADR 0001's browser half, and it
+//! has no application namespace for the durable "handled" record. See the
+//! crate root; #723 re-examined it and wrote the conclusion down there.
 //!
 //! # Schema
 //!

--- a/rs/crates/f2z-msg-store/src/storage_impl.rs
+++ b/rs/crates/f2z-msg-store/src/storage_impl.rs
@@ -5,7 +5,7 @@
 //! There is no cleverness here and there must not be any. Every method reduces
 //! to one of six helpers on [`F2zStorageProvider`] — `write`, `append`,
 //! `remove_item`, `read`, `read_list`, `delete` — named after
-//! `openmls_memory_storage 0.5.0`'s and doing the same thing to the same bytes.
+//! `openmls_memory_storage 0.6.0`'s and doing the same thing to the same bytes.
 //! The order is the **trait's** order, not the reference implementation's,
 //! because the trait is the specification and a reviewer checking that all 57
 //! are present and correctly wired should be able to read this file and
@@ -23,7 +23,7 @@
 //! | deleters for crypto objects | 6 |
 //!
 //! Three of those (`write_application_export_tree`, `application_export_tree`,
-//! `delete_application_export_tree`) exist only under `extensions-draft-08`,
+//! `delete_application_export_tree`) exist only under `extensions-draft`,
 //! which the trait gates and this crate forwards.
 //!
 //! # Where this deliberately differs from the reference
@@ -51,6 +51,18 @@
 //! fix is one line: go through the same `delete` helper every other deleter
 //! uses. `tests/provider.rs` pins it.
 //!
+//! **It is reported and it is still not fixed.** [openmls/openmls#2188][2188]
+//! carries a self-contained reproduction; the defect is present unchanged in
+//! `openmls_memory_storage` **0.6.0**, which this tree re-read line by line
+//! during the 0.9 migration (#723) rather than assuming the port still applied.
+//! Both differences above still stand against 0.6.0 — `clear_proposal_queue`
+//! still calls `values.remove(&serde_json::to_vec(&(group_id, proposal_ref))?)`
+//! against entries written through `write::<CURRENT_VERSION>(…)`, and
+//! `queued_proposals` still `unwrap()`s a dangling reference. **Do not "resync
+//! with upstream" by copying either of them back.**
+//!
+//! [2188]: https://github.com/openmls/openmls/issues/2188
+//!
 //! [`F2zStorageProvider`]: crate::F2zStorageProvider
 //! [`StoreError`]: crate::StoreError
 
@@ -58,7 +70,7 @@ use openmls_traits::storage::{CURRENT_VERSION, StorageProvider, traits};
 
 use crate::backend::StorageBackend;
 use crate::error::{Result, StoreError};
-#[cfg(feature = "extensions-draft-08")]
+#[cfg(feature = "extensions-draft")]
 use crate::keys::APPLICATION_EXPORT_TREE_LABEL;
 use crate::keys::{
     CONFIRMATION_TAG_LABEL, ENCRYPTION_KEY_PAIR_LABEL, EPOCH_KEY_PAIRS_LABEL, EPOCH_SECRETS_LABEL,
@@ -276,7 +288,7 @@ impl<B: StorageBackend> StorageProvider<CURRENT_VERSION> for F2zStorageProvider<
         )
     }
 
-    #[cfg(feature = "extensions-draft-08")]
+    #[cfg(feature = "extensions-draft")]
     fn write_application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
@@ -617,7 +629,7 @@ impl<B: StorageBackend> StorageProvider<CURRENT_VERSION> for F2zStorageProvider<
         self.read::<CURRENT_VERSION, _>(PSK_LABEL, &encode(psk_id, PSK_LABEL)?)
     }
 
-    #[cfg(feature = "extensions-draft-08")]
+    #[cfg(feature = "extensions-draft")]
     fn application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,
@@ -823,7 +835,7 @@ impl<B: StorageBackend> StorageProvider<CURRENT_VERSION> for F2zStorageProvider<
         self.delete::<CURRENT_VERSION>(PSK_LABEL, &encode(psk_id, PSK_LABEL)?)
     }
 
-    #[cfg(feature = "extensions-draft-08")]
+    #[cfg(feature = "extensions-draft")]
     fn delete_application_export_tree<
         GroupId: traits::GroupId<CURRENT_VERSION>,
         ApplicationExportTree: traits::ApplicationExportTree<CURRENT_VERSION>,

--- a/rs/deny.toml
+++ b/rs/deny.toml
@@ -59,187 +59,61 @@ yanked = "warn"
 # finding the crate in `cargo tree`, and deciding whether this tree's code can
 # reach the affected function — not by copying an id out of a red CI log.
 #
-# All eleven arrive with **one** dependency: `openmls_libcrux_crypto 0.3.1`, the
-# libcrux-backed crypto provider #385 measured and ADR 0001 requires. libcrux
-# publishes as `0.0.x`, so every one of those releases is semver-incompatible
-# with the next and `cargo update` cannot move any of them: the fix has to come
-# from `openmls_libcrux_crypto` and `hpke-rs-libcrux` bumping their own
-# requirements. That single sentence is the "why we are not on that version yet"
-# for every entry, and each entry adds what is specific to it.
+# **It has one entry.** It had ten until #723, and the nine that went were the
+# whole libcrux family that arrived with `openmls_libcrux_crypto 0.3.1`:
 #
-# **Read this before treating the list as settled:** #385 evaluated this
-# provider on nine targets against real NIST/RFC vectors and did *not* run
-# cargo-deny, so none of the eleven was visible when the library choice was
-# made. The reachability arguments below are the agent's, made from the advisory
-# text and the dependency graph; the two marked NEEDS AN OWNER DECISION are the
-# ones reasoning cannot close.
+#   RUSTSEC-2026-0073  libcrux-poly1305           standalone MAC panic
+#   RUSTSEC-2026-0075  libcrux-ed25519            all-zero key on RNG failure
+#   RUSTSEC-2026-0124  libcrux-chacha20poly1305   encrypt panics on a long buffer
+#   RUSTSEC-2026-0207  libcrux-sha3               incremental SHAKE squeeze
+#   RUSTSEC-2026-0208  libcrux-sha3               AVX2 SHAKE-256 panic
+#   RUSTSEC-2026-0209  libcrux-aesgcm             AES-GCM AAD length limit
+#   RUSTSEC-2026-0210  libcrux-aesgcm             unmaintained (renamed)
+#   RUSTSEC-2026-0211  libcrux-aesgcm             non-constant-time tag check
+#   RUSTSEC-2026-0212  libcrux-secrets            aarch64 constant-time defect
+#
+# They are **fixed, not re-argued**. The 0.9 train resolves to
+# `libcrux-secrets 0.0.6`, `libcrux-sha3 0.0.10`, `libcrux-ed25519 0.0.9`,
+# `libcrux-poly1305 0.0.6`, `libcrux-chacha20poly1305 0.0.9` and
+# `libcrux-aes 0.0.9`, none of which is affected. The per-advisory reachability
+# reasoning that stood here — which of them our ciphersuite could reach, and why
+# — has been **deleted rather than kept as history**: a justification for a risk
+# that no longer exists teaches the next reader that the risk is still being
+# accepted, which is worse than saying nothing. #701 and #723 hold the record.
+#
+# The one that mattered was RUSTSEC-2026-0212. `libcrux-secrets 0.0.5`'s
+# constant-time swap/select returned incorrect results on **aarch64** — every
+# phone we ship to and every Apple Silicon desktop — underneath the AEAD we
+# actually use, and #701 established that it could not be patched around
+# without forking the libcrux release train. It was carried as an accepted risk
+# for one day. It is now simply fixed.
+#
+# =============================================================================
+# THE `[patch.crates-io]` WARNING, AND IT OUTLIVES THIS MIGRATION.
+# =============================================================================
+#
+# #701 tried to force `libcrux-secrets 0.0.6` under the old graph with a
+# `[patch.crates-io]` entry. **The build went green and linked 0.0.5.** Cargo's
+# `[patch]` replaces a package's *source*, not its version, so a 0.0.6 patch
+# cannot satisfy `libcrux-aead`'s `=0.0.5`; cargo emits
+#
+#     warning: patch `libcrux-secrets v0.0.6 (...)` was not used in the crate graph
+#
+# and carries on. Trusting the exit code would have meant reporting the advisory
+# fixed while the vulnerable code was still in the binary.
+#
+# **Anyone patching a pinned transitive dependency must check
+# `cargo tree -i <crate>`, not the build result.** That is a fact about cargo,
+# not about libcrux, and it will be true again the next time someone tries this.
 ignore = [
   # ---------------------------------------------------------------------------
-  # NOT REACHED: AES-GCM. Our ciphersuite is
-  # MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519 — ChaCha20-Poly1305 for the
-  # MLS AEAD *and* for the HPKE AEAD (`openmls_libcrux_crypto`'s `supports()`
-  # accepts only `HpkeAeadType::ChaCha20Poly1305`). `libcrux-aesgcm` is linked
-  # because `libcrux-aead` offers every algorithm; nothing in this tree selects
-  # it. `f2z-msg-mls`'s `the_ciphersuite_uses_chacha20poly1305_and_not_aes_gcm`
-  # is what makes that a checked fact rather than a claim.
-  # Fixed in libcrux-aes 0.0.9 (the crate was renamed).
-  { id = "RUSTSEC-2026-0209", reason = "AES-GCM AAD length limit; AES-GCM is not in our ciphersuite" },
-  { id = "RUSTSEC-2026-0211", reason = "non-constant-time AES-GCM tag check; AES-GCM is not in our ciphersuite" },
-  { id = "RUSTSEC-2026-0210", reason = "libcrux-aesgcm renamed to libcrux-aes; unmaintained-by-rename, and not on our path" },
-
-  # ---------------------------------------------------------------------------
-  # NOT REACHED: the standalone Poly1305 MAC. The advisory says so explicitly —
-  # "The use of libcrux-poly1305 in libcrux-chacha20poly1305 is unaffected" —
-  # and libcrux-chacha20poly1305 is the only caller in this graph.
-  # Fixed in libcrux-poly1305 0.0.5.
-  { id = "RUSTSEC-2026-0073", reason = "panic in the standalone MAC API; the AEAD path the advisory names as unaffected is the only one we use" },
-
-  # ---------------------------------------------------------------------------
-  # NOT REACHED: SHAKE. Both advisories state their own scope, and both exclude
-  # ML-KEM — which is the only consumer of SHAKE in this graph, via X-Wing.
-  # 0207 affects multi-call incremental `squeeze` with a non-RATE-divisible
-  # length ("does not impact the use of libcrux-sha3 in libcrux-ml-kem"); 0208
-  # affects `avx2::x4::shake256` with an output length > 32 not divisible by 8
-  # ("does not impact the use in ML-KEM or ML-DSA"). Nothing here calls the SHAKE
-  # API directly.
-  # Both fixed in libcrux-sha3 0.0.10.
-  { id = "RUSTSEC-2026-0207", reason = "incremental SHAKE squeeze; the advisory excludes ML-KEM, our only SHAKE consumer" },
-  { id = "RUSTSEC-2026-0208", reason = "AVX2 SHAKE-256 panic; the advisory excludes ML-KEM, our only SHAKE consumer" },
-
-  # ---------------------------------------------------------------------------
-  # NOT REACHED: libcrux Ed25519 *key generation*. The defect is in
-  # `generate_key_pair`, which silently returns an all-zero secret key if the
-  # supplied CSPRNG fails 100 times in a row. This tree never calls it:
-  # `f2z-msg-mls::DeviceSigner::from_private_key` takes the key from its caller,
-  # and `ARCHITECTURE.md` §4.2 makes `DeviceSignatureKey` a value the *device*
-  # generates from the OS CSPRNG. `openmls_libcrux_crypto::signature_key_gen`
-  # does call it, and nothing in this tree calls `signature_key_gen`.
-  # Fixed in libcrux-ed25519 0.0.7.
-  #
-  # Worth a reviewer's attention anyway: whoever writes `f2z-msg-identity` must
-  # not reach for `libcrux_ed25519::generate_key_pair` while this version is
-  # pinned, and this comment is where they will find out.
-  { id = "RUSTSEC-2026-0075", reason = "all-zero Ed25519 key on catastrophic RNG failure; we never call generate_key_pair" },
-
-  # ---------------------------------------------------------------------------
-  # REACHED, AND ACCEPTED. NEEDS AN OWNER DECISION.
-  #
-  # `libcrux-chacha20poly1305` panics if `encrypt` is handed an output buffer
-  # LONGER than `ptxt.len() + TAG_LEN`. This is our AEAD, so the crate is very
-  # much on our path. What is not on our path is the *trigger*: the buffer is
-  # sized by `hpke-rs-libcrux` and `openmls_libcrux_crypto`, never by a peer or
-  # a relay, so "the length of the ciphertext buffer under attacker control" —
-  # the advisory's own impact statement — does not describe this caller. A
-  # remote attacker would have to first change how OpenMLS sizes its own
-  # buffers.
-  #
-  # It is still a panic reachable by a caller bug in a crypto core, in a tree
-  # whose clippy policy denies `panic` for exactly that reason. Fixed upstream;
-  # unreachable from here until `libcrux-aead` bumps.
-  { id = "RUSTSEC-2026-0124", reason = "ChaCha20-Poly1305 encrypt panics on an overlong output buffer; the buffer is sized by OpenMLS, not by any peer" },
-
-  # ---------------------------------------------------------------------------
-  # REACHED. NEEDS AN OWNER DECISION. This is the one that cannot be reasoned
-  # away, and it should not be buried.
-  #
-  # `libcrux-secrets 0.0.5`'s constant-time swap/select on **aarch64** compares
-  # an 8-bit selector with a 32-bit `cmp`, including 24 bits of unspecified
-  # register content, so "in certain circumstances the swap and select
-  # instructions on aarch64 platforms returned incorrect results". aarch64 is
-  # every phone we ship to and every Apple Silicon desktop, and `libcrux-secrets`
-  # sits under `libcrux-aead` — the AEAD we do use.
-  #
-  # What we have on the other side is evidence rather than proof: #385 ran the
-  # full NIST ACVP ML-KEM, RFC 7748, RFC 8032 and X-Wing Appendix C known-answer
-  # suite green on `aarch64-apple-darwin` and on a real Android API-29 arm64
-  # device, and a swap/select returning the wrong branch would show up as a
-  # wrong answer. That is a strong negative result on two aarch64 environments;
-  # it is not a proof of absence, because the advisory says the fault depends on
-  # the execution environment.
-  #
-  # ## The fix exists and CANNOT be applied from here. This was measured, not
-  # ## assumed — do not spend the afternoon rediscovering it.
-  #
-  # `libcrux-secrets 0.0.6` is published and is the fix. Three things were tried
-  # against the graph in this lockfile, in increasing force:
-  #
-  #   1. `cargo update -p libcrux-secrets --precise 0.0.6` — **refused.**
-  #      `libcrux-aead 0.0.6` *and* `0.0.7` both require `libcrux-secrets`
-  #      `"=0.0.5"`, an exact pin, not a caret.
-  #
-  #   2. `[patch.crates-io]` pointing `libcrux-secrets` at a 0.0.6 source —
-  #      **silently ignored.** Cargo's `[patch]` replaces a package's *source*,
-  #      not its version, so a 0.0.6 patch cannot satisfy `=0.0.5`; cargo emits
-  #      `warning: patch ... was not used in the crate graph` and carries on.
-  #      **The build goes green on 0.0.5.** That is the dangerous shape here: a
-  #      patch that appears to work, changes nothing, and would have let us
-  #      report the advisory fixed while the vulnerable code was still linked.
-  #      Anyone repeating this must check `cargo tree -i libcrux-secrets`, not
-  #      the exit code.
-  #
-  #   3. Forcing it — a vendored 0.0.6 whose manifest claims `version = "0.0.5"`
-  #      — **fails to resolve, and not over anything to do with this crate's
-  #      API.** `libcrux-secrets 0.0.6` requires `hax-lib "0.3.7"`, while
-  #      `libcrux-intrinsics 0.0.6`, `libcrux-ml-kem 0.0.8` and `libcrux-sha3
-  #      0.0.8` each require `hax-lib "=0.3.6"`. `hax-lib` is libcrux's
-  #      formal-verification annotation crate and every one of those pins is
-  #      exact, so the two constraints are unsatisfiable together.
-  #
-  # So this is not a one-crate override. Taking `libcrux-secrets 0.0.6` means
-  # simultaneously forking `libcrux-intrinsics`, `libcrux-ml-kem` and
-  # `libcrux-sha3` off `hax-lib =0.3.6` — and those are in turn exactly pinned
-  # by `libcrux-aead`, `libcrux-kem` and `hpke-rs`, so the fork propagates all
-  # the way up to `openmls_libcrux_crypto`. It is forking the libcrux release
-  # train, not patching a dependency.
-  #
-  # Two further facts a decision should have. `libcrux-secrets 0.0.6` carries
-  # deliberate **API breaks** (upstream #1499 replaced the `IntOps`/`EncodeOps`
-  # traits with inherent methods on `Secret`, #1446 removed the const
-  # qualifier from the secret constructors, #1484 sealed the scalar trait), so
-  # `libcrux-aead`'s `=0.0.5` is a considered pin rather than an oversight —
-  # even a resolvable patch would have had to survive those. And libcrux has
-  # moved organisation: the advisory's fix PR is `celabshq/libcrux#1461`, while
-  # the crates still name `cryspen/libcrux`.
-  #
-  # **Remove this entry when `openmls_libcrux_crypto` ships against a
-  # `libcrux-aead` whose `libcrux-secrets` requirement admits `>= 0.0.6`.** That
-  # is the only condition under which it goes away without a fork. See #701.
-  #
-  # ## UPDATE 2026-08-25: that condition is already met. Do not re-run the
-  # ## experiment above — upgrade instead. See #723.
-  #
-  # The whole OpenMLS 0.9 train shipped on 2026-08-25, one day after the analysis
-  # above was written: `openmls 0.9.0`, `openmls_traits 0.6.0`,
-  # `openmls_libcrux_crypto 0.4.0`. That provider requires `libcrux-aead 0.0.9`,
-  # which requires `libcrux-secrets = "=0.0.6"` — the fixed version.
-  #
-  # Resolved and measured, not inferred: `cargo deny check advisories` over a
-  # crate depending only on `openmls 0.9.0` + `openmls_libcrux_crypto 0.4.0`,
-  # with an **empty** ignore list, reports exactly one finding —
-  # RUSTSEC-2026-0173, the build-host-only `proc-macro-error2` below. The 0.9
-  # train pulls `libcrux-secrets 0.0.6`, `libcrux-sha3 0.0.10`,
-  # `libcrux-ed25519 0.0.9`, `libcrux-poly1305 0.0.6`,
-  # `libcrux-chacha20poly1305 0.0.9` and `libcrux-aes 0.0.9`, which between them
-  # clear **every libcrux advisory in this list**.
-  #
-  # These entries stay until that migration lands, because they are accurate
-  # about the graph this repository actually ships — `openmls 0.8.1`, the version
-  # #385 validated on nine triples with real NIST/RFC vectors on Android
-  # hardware. What has changed is their status: they are a **migration backlog
-  # item with a known fix**, not a standing risk anyone has to keep accepting.
-  # #723 tracks it and takes "these ten entries come out" as its acceptance
-  # criterion.
-  { id = "RUSTSEC-2026-0212", reason = "aarch64 constant-time swap/select may return incorrect results; #385's aarch64 KATs are green but this is evidence, not proof — owner decision required" },
-
-  # ---------------------------------------------------------------------------
-  # BUILD-TIME ONLY. `proc-macro-error2` is unmaintained (a fork of an already
-  # unmaintained crate). It reaches this graph as a proc-macro dependency of
-  # `hax-lib-macros`, which libcrux uses for its formal-verification
-  # annotations: `proc-macro-error2 -> hax-lib-macros -> hax-lib -> core-models
-  # -> libcrux-intrinsics -> libcrux-aesgcm -> libcrux-aead`. It runs on the
-  # build host and no code from it is linked into any shipped artifact, so
-  # "unmaintained" here is a supply-chain-of-the-build concern and not a
-  # runtime one. Nothing we control can drop it while libcrux is in the graph.
+  # BUILD-TIME ONLY, and the only entry left. `proc-macro-error2` is
+  # unmaintained (a fork of an already unmaintained crate). It reaches this
+  # graph as a proc-macro dependency of `hax-lib-macros`, which libcrux uses for
+  # its formal-verification annotations. It runs on the build host and no code
+  # from it is linked into any shipped artifact, so "unmaintained" here is a
+  # supply-chain-of-the-build concern and not a runtime one. Nothing we control
+  # can drop it while libcrux is in the graph.
   { id = "RUSTSEC-2026-0173", reason = "unmaintained proc-macro; build-host only, nothing from it is linked into a shipped artifact" },
 ]
 
@@ -331,7 +205,7 @@ exceptions = [
   # ---------------------------------------------------------------------------
   # MPL-2.0, arriving with HPKE, and **this one needs an owner's eye**.
   #
-  # `openmls_libcrux_crypto 0.3.1` reaches HPKE (RFC 9180) through Cryspen's
+  # `openmls_libcrux_crypto 0.4.0` reaches HPKE (RFC 9180) through Cryspen's
   # `hpke-rs` family, and all three of those crates are MPL-2.0. There is no
   # alternative inside the decision #385 settled: HPKE is how MLS does its
   # asymmetric encryption, and this is the HPKE the libcrux provider uses.
@@ -406,28 +280,43 @@ version = "<0.13.0"
 name = "akd_mysql"
 
 [[bans.deny]]
-# openmls < 0.8.1 carries a High-severity MAC authentication defect. 0.8.1 is
-# the floor `ARCHITECTURE.md` §5 and #385 are written against, and it is the
-# version whose X-Wing behaviour was measured on all nine shipping triples.
+# The floor carries **two** defects now, and it is raised rather than replaced.
+#
+#   * openmls < 0.8.1 carries a High-severity MAC authentication defect
+#     (GHSA-3wpg-h9qc-hjwj / RUSTSEC-2025-0069).
+#   * openmls < 0.9.0 resolves, through `openmls_libcrux_crypto <= 0.3.1`, to a
+#     `libcrux-aead` pinned at `libcrux-secrets =0.0.5` — RUSTSEC-2026-0212,
+#     the aarch64 constant-time swap/select defect. `openmls_libcrux_crypto` is
+#     the crate that actually carries that, but a floor on the provider alone
+#     would leave `openmls 0.8.1` free to select it, and 0.9.0 is the release
+#     that requires 0.4.0.
 #
 # The same reasoning as the `akd` floor above applies and is the reason this is
 # an entry rather than a comment: a `[patch.crates-io]`, a path dependency or a
-# vendored copy all satisfy a manifest requirement of `"0.8.1"` without a word,
+# vendored copy all satisfy a manifest requirement of `"0.9.0"` without a word,
 # and a floor nobody enforces is a wish. This is the mechanism.
-#
-# It is deliberately `<0.8.1` and not `<0.8`: the defect is fixed *in* the 0.8
-# line, so the dangerous versions and the required one share a minor.
 name = "openmls"
-version = "<0.8.1"
+version = "<0.9.0"
+
+[[bans.deny]]
+# The provider, floored in its own right. `openmls 0.9.0` requires
+# `openmls_libcrux_crypto 0.4.0` today, so this is redundant with the entry
+# above *given today's manifests* — which is exactly why it is written down: it
+# is the crate that resolves `libcrux-secrets`, and a future `openmls` that
+# widened its provider requirement back across the 0.3 line would otherwise
+# reintroduce RUSTSEC-2026-0212 without changing a single version this file
+# names.
+name = "openmls_libcrux_crypto"
+version = "<0.4.0"
 
 [[bans.deny]]
 # The trait crate that ships with it. Held at the release matching the audited
-# `openmls 0.8.1` for the same reason: `f2z-msg-store` implements
+# `openmls 0.9.0` for the same reason: `f2z-msg-store` implements
 # `StorageProvider` against this trait, and an older trait would silently mean
 # fewer methods — a storage provider that compiles while never being asked to
 # persist something OpenMLS now persists.
 name = "openmls_traits"
-version = "<0.5.0"
+version = "<0.6.0"
 
 [[bans.deny]]
 # `openmls_basic_credential` must not enter this graph. It signs with
@@ -452,7 +341,7 @@ name = "openmls_rust_crypto"
 # `openmls_memory_storage` is deliberately NOT banned, and the reason is worth
 # recording because banning it was the first instinct. It is the reference
 # implementation `f2z-msg-store` is a port of, and it is also a **hard,
-# non-optional dependency of `openmls_libcrux_crypto 0.3.1`**, whose `Provider`
+# non-optional dependency of `openmls_libcrux_crypto 0.4.0`**, whose `Provider`
 # struct owns a `MemoryStorage` field. A ban would therefore be unsatisfiable
 # without forking the provider. What matters is that nothing in this tree
 # *hands it to OpenMLS*: `f2z-msg-mls::F2zProvider` implements `OpenMlsProvider`


### PR DESCRIPTION
Closes #723.

`openmls 0.9.0` / `openmls_traits 0.6.0` / `openmls_libcrux_crypto 0.4.0`, taken
for a security reason and not for freshness: **it removes a real aarch64
cryptographic defect from the shipping graph.**

## The acceptance criterion, measured

`rs/deny.toml`'s `ignore` list goes from **ten entries to one**. Every entry
that came out is *fixed upstream*, not re-argued.

Measured rather than inferred — `cargo deny check advisories` over each graph
with an **empty** `ignore` list, via `scripts/check-rust-deny.sh --root rs`:

| | `origin/main` (`openmls 0.8.1`) | this branch (`openmls 0.9.0`) |
|---|---|---|
| advisories firing with an empty ignore list | **10** | **1** |

The nine that cleared, and what each is:

| advisory | crate | defect |
|---|---|---|
| **RUSTSEC-2026-0212** | `libcrux-secrets` | **aarch64 constant-time swap/select may return incorrect results** |
| RUSTSEC-2026-0124 | `libcrux-chacha20poly1305` | encrypt panics on an overlong output buffer |
| RUSTSEC-2026-0073 | `libcrux-poly1305` | panic in the standalone MAC API |
| RUSTSEC-2026-0075 | `libcrux-ed25519` | all-zero key on catastrophic RNG failure |
| RUSTSEC-2026-0207 | `libcrux-sha3` | incorrect incremental SHAKE squeeze |
| RUSTSEC-2026-0208 | `libcrux-sha3` | panic in AVX2 SHAKE-256 |
| RUSTSEC-2026-0209 | `libcrux-aesgcm` | AES-GCM AAD length limit not enforced |
| RUSTSEC-2026-0210 | `libcrux-aesgcm` | unmaintained (renamed to `libcrux-aes`) |
| RUSTSEC-2026-0211 | `libcrux-aesgcm` | non-constant-time AES-GCM tag check |

`RUSTSEC-2026-0173` (`proc-macro-error2`, unmaintained, build-host only) stays,
and it is the only entry left.

**A correction to #723's arithmetic, since the acceptance criterion was written
in terms of it.** The issue and the old `deny.toml` header both say "eleven
advisories, ten of them libcrux". The file had **ten** `ignore` entries and
**nine** of them were libcrux. Ten came out of the *count* only if you include
the one that stays. The substantive claim is unaffected and is fully met:
**every libcrux advisory is gone, RUSTSEC-2026-0212 included, and the only thing
left is the build-host proc macro.**

Resolved versions, from `rs/Cargo.lock`: `libcrux-secrets 0.0.6`,
`libcrux-sha3 0.0.10`, `libcrux-ed25519 0.0.9`, `libcrux-poly1305 0.0.6`,
`libcrux-chacha20poly1305 0.0.9`, `libcrux-aes 0.0.9`, `libcrux-aead 0.0.9`.

The per-advisory reachability reasoning has been **deleted, not archived**: a
justification for a risk that no longer exists teaches the next reader that the
risk is still being accepted. #701 and #723 hold the record. The
`[patch.crates-io]` warning is **kept** — it is a fact about cargo (a patch that
cannot satisfy an exact pin is skipped with a warning and the build goes green
on the vulnerable version), and that lesson outlives this migration.

Floors raised in `rs/deny.toml`: `openmls < 0.9.0`, `openmls_traits < 0.6.0`,
and a **new** `openmls_libcrux_crypto < 0.4.0` — redundant against today's
manifests, and written down precisely because it is the crate that resolves
`libcrux-secrets`.

## The API breaks, and the three that needed judgement

**`openmls_traits 0.6.0` did not move `StorageProvider` out from under us.**
Every method 0.6.0 adds is behind `virtual-clients-draft`, which nothing here
enables; the base trait is unchanged. `f2z-msg-store`'s 57 methods compiled
against 0.6.0 **without a single edit**. The one break was a feature rename,
`extensions-draft-08` → `extensions-draft`, renamed rather than aliased.

**The X-Wing ciphersuite moved behind a feature.** 0.9.0 gates every
post-quantum codepoint on `draft-ietf-mls-pq-ciphersuites`; without it
`Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519` does not exist.
`rs/Cargo.toml` enables it by name. The **codepoint is unchanged** (`0x004D`) —
what moved is whether the name compiles, which is exactly the relabelling risk
`version.rs` was written to survive.

**`openmls` moved to `tls_codec 0.5`** while `f2z-codec` and `f2z-kt-core` stay
on 0.4. The two `tls_codec` calls in `f2z-msg-mls` are on OpenMLS's own types,
so `tls_codec` was **dropped as a dependency of that crate** and the traits now
come through `openmls::prelude::tls_codec` — which cannot drift from what
OpenMLS derived them with. Nothing crosses the seam: a `DeviceCredential`
reaches MLS as opaque `BasicCredential` bytes via `f2z-codec`'s canonical
encoding. Same shape as the two `ed25519-dalek` majors this workspace already
carries. **The wire codec crates are deliberately untouched** — a `tls_codec`
major bump under `f2z-codec` is a wire-format change and does not belong in a
security migration.

**Two new `ProcessedMessageContent` variants, and one is a behaviour change
callers can see.** 0.9 added `OwnPrivateMessage` and `OwnPendingCommit`. Under
0.8.1, a device's own `PrivateMessage` handed back by a relay failed to decrypt
and `receive` returned `EngineError::Mls`; 0.9 surfaces it as a distinct
outcome. The engine now returns a new `Received::Own`, **writes the durable
"handled" record**, and returns no payload. That matters under delete-on-ack
(§9.4 makes relay echoes routine): an echo that always errored could never be
acknowledged, so the relay would redeliver it forever.
`a_devices_own_message_handed_back_is_an_outcome_and_not_an_error` pins all of
it. `OwnPendingCommit` is unreachable in this engine — `update`/`add_member`
merge before returning — and is handled by merging if a pending commit exists,
because assuming the invariant would silently *skip an epoch change* if anyone
ever split those two steps.

### 1. `f2z-msg-store`: keep it, and the reason has changed

**The blocker #385 measured has genuinely expired**, and the crate docs said so
in their first clause. `openmls_sqlite_storage 0.3.0` requires
`rusqlite = "0.37"` with `features = ["bundled"]` — our repo-wide singleton
exactly — and the `openmls 0.9.0` it needs is released.

The decision is still **keep**, on three reasons checked against 0.3.0's source
rather than its README:

1. **The transaction.** 0.3.0's entire public surface is `new`, `initialize`,
   `run_migrations` and the `StorageProvider` impl. No transaction API — there
   cannot be one, `StorageProvider` has none — and one cannot be supplied from
   outside either: it is generic over `ConnectionRef: Borrow<Connection>`, and
   `rusqlite::Transaction` reaches `Connection` through `Deref`, not `Borrow`.
2. **The backend seam.** `rusqlite`'s `bundled` feature links SQLite's C
   amalgamation, so it is native by construction and cannot serve ADR 0001's
   browser half.
3. **The application namespace.** `StorageProvider` has no notion of
   application data, so no implementation of it alone can put the durable
   "handled" record in the *same* atomic write as the epoch change.

The crate root, `sqlite.rs`'s note and `AGENTS.md`'s worked example were all
rewritten to say the blocker expired rather than to keep repeating it.

### 2. The `openmls_memory_storage` defect is still there

`clear_proposal_queue` still removes `serde_json::to_vec(&(group_id,
proposal_ref))` while `queue_proposal` writes through
`write::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, …)` — a key nothing was ever
stored under, leaking every serialised proposal body. **Verified present
unchanged in `openmls_memory_storage 0.6.0`**, filed as
[openmls/openmls#2188](https://github.com/openmls/openmls/issues/2188). Our fix
and `clearing_the_queue_removes_the_proposal_bodies_and_not_only_the_references`
both survive; `storage_impl.rs`'s note now names the version it was re-checked
against and says **do not resync with upstream**.

### 3. The `debug_assert!(false)` workaround is gone — verified, not assumed

`openmls 0.9.0`'s `private_message_in.rs` has no `debug_assert` on either
AEAD-open path; both are `log::error!` + a returned
`MessageDecryptionError::AeadError`. The whole of `src/framing/` contains one
`debug_assert`, on an unrelated key-package version check.

So `a_corrupted_ciphertext_is_refused_and_leaves_the_group_usable` lost its
`#[cfg(not(debug_assertions))]` gate and **now runs in the ordinary debug
`cargo test`** — confirmed by running it, not by reading the changelog. The
extra `--release` step in `rs.yml` is removed, replaced by a comment saying why
it is gone rather than leaving a silent hole.

## Re-validation

#385's nine-triple validation was against 0.8.1, so it was re-run.

**Green, on this branch, on aarch64-apple-darwin:**

- **The two-instance exchange** — `f2z-msg-mls/tests/two_instances.rs`, 18/18.
  Separate storage, separate identities, real `Welcome`, decrypted payload in
  both directions, `Update` with both sides agreeing on the epoch, exporter
  material changing with the epoch.
- **The crash-safety suite** with its real child-process abort —
  `cargo test -p f2z-msg-store --features crash-injection --test crash_safety`,
  4/4, including "a crash before the commit leaves no trace" and "a crash after
  it leaves the whole operation".
- **The full `rs/` suite** — `cargo test --locked --all-targets` and
  `--locked --doc`, everything green.
- **rustfmt**, **clippy at `-D warnings`**, and **`cargo-deny`** (advisories,
  bans, licences, sources) over all 13 crates, plus the four workflow-policy
  scripts and the toolchain-pin check.
- **Cross-compilation for all nine shipping triples**
  (`cargo check --locked --lib -p f2z-msg-mls --no-default-features`):
  `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-apple-darwin`,
  `x86_64-pc-windows-msvc`, `aarch64-apple-ios`, `aarch64-linux-android`,
  `armv7-linux-androideabi`, `i686-linux-android`, `x86_64-linux-android`.
- **`wasm32-unknown-unknown`** for `f2z-msg-store --no-default-features` and for
  `f2z-msg-mls --no-default-features --features js`.

### The wasm plumbing got simpler, and that is a graph change

`--features js` is still required. **`--cfg getrandom_backend="wasm_js"` is
not, and `getrandom 0.3` is no longer declared.** Against 0.8.1 this crate's
wasm graph carried getrandom 0.3 (via `rand_core 0.9`) *and* 0.4 (via
`rand 0.10` inside `hpke-rs-libcrux`), and **0.3 needs the cfg as well as the
feature**. On the 0.9 train nothing in that graph reaches `rand_core 0.9` —
getrandom 0.3 survives in the lockfile only under `proptest` and `f2z-relay`'s
dev-dependencies — and getrandom **0.4** selects its wasm backend from the
`wasm_js` feature alone (`src/backends.rs`, the `target_family = "wasm"` arm).
Both halves came off together. If getrandom 0.3 ever re-enters, the wasm job
fails with getrandom's own `compile_error!`; it cannot regress quietly.

### What could NOT be re-validated — stated plainly

- **The KATs were not re-run.** #385's NIST ACVP ML-KEM, RFC 7748, RFC 8032 and
  draft-connolly-cfrg-xwing-06 Appendix C harness **does not exist in this
  repository** — `wallet/zuuli/crypto-target-spike` is a compile-target probe
  over `libcrux-ml-kem`, not a known-answer suite — so there was nothing to run.
  This is a gap worth its own issue rather than a line in a PR body.
- **What was run on real aarch64 is the functional suite, not KATs.** This work
  was done on Apple Silicon (`arm64`), so the two-instance exchange, the crash
  suite and the whole `rs/` suite executed the libcrux code paths natively on
  aarch64 — a real X-Wing key schedule, a real ChaCha20-Poly1305 AEAD, real
  Ed25519 framing signatures. That is meaningful evidence and it is **not** a
  known-answer test.
- **No physical Android or iOS device.** The Android and iOS triples were
  **compile-checked only**. Nothing here was run on a phone, and no simulator
  result is being reported as a device result.
- **The eight non-host triples are `cargo check`, not link-and-run.**
  `--no-default-features` (no `rusqlite`) so no cross C toolchain is needed.
  CI's own matrix is the authority on the link step.

## Also updated

- `docs/e2ee/ARCHITECTURE.md` §3.1 and §13-A: the floor is now
  `openmls >= 0.9.0`, carrying two defects rather than one.
- `AGENTS.md`'s `rusqlite` singleton worked example, which cited the expired
  `openmls_sqlite_storage 0.2.0` situation as if it were current.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
