### PR TITLE
test(rs): make two guards falsifiable one clause at a time

### DIFF
--- a/rs/crates/f2z-kt-core/src/auditor.rs
+++ b/rs/crates/f2z-kt-core/src/auditor.rs
@@ -327,6 +327,115 @@ mod tests {
     }
 
     #[test]
+    fn each_clause_of_the_token_guard_refuses_on_its_own() {
+        // zuu#709. `advance`'s guard is five clauses, and the test above trips
+        // two of them at once with a token for epoch 9 and a zero root, so
+        // deleting any single clause left the suite green. Each case here
+        // differs from the accepted setup in exactly one clause, so each clause
+        // has a case that only it can refuse.
+        let log = TestLog::new();
+        let pinned = |()| {
+            let view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+            WitnessState::new(view)
+        };
+        let heads = [log.head(0), log.head(1), log.head(2)];
+        let good_token = || AppendOnlyVerified {
+            from_epoch: 0,
+            to_epoch: 2,
+            to_root: log.head(2).sth.root_hash,
+        };
+
+        // 1. The run does not start where this witness is pinned. The first
+        //    head carries the *pinned root* at the wrong epoch, so the root
+        //    clause cannot be what refuses it — only the epoch clause can.
+        let mut ahead = log.head(1);
+        ahead.sth.root_hash = log.head(0).sth.root_hash;
+        let ahead = [log.resign(ahead), log.head(2)];
+        let mut state = pinned(());
+        assert_eq!(
+            state.advance(
+                &ahead,
+                &AppendOnlyVerified {
+                    from_epoch: 1,
+                    to_epoch: 2,
+                    to_root: log.head(2).sth.root_hash,
+                }
+            ),
+            Err(KtError::Malformed),
+            "a run starting past the pinned epoch must be refused"
+        );
+        assert_eq!(state.view().epoch(), 0);
+
+        // 2. Right epoch, different root: a fork at the pinned point.
+        let mut forked = log.head(0);
+        forked.sth.root_hash = Digest::new([0xfe; 32]);
+        let forked = [log.resign(forked), log.head(1), log.head(2)];
+        let mut state = pinned(());
+        assert_eq!(
+            state.advance(&forked, &good_token()),
+            Err(KtError::Malformed),
+            "a run whose first head forks from the pinned root must be refused"
+        );
+        assert_eq!(state.view().epoch(), 0);
+
+        // 3. The token starts somewhere the run does not.
+        let mut state = pinned(());
+        assert_eq!(
+            state.advance(
+                &heads,
+                &AppendOnlyVerified {
+                    from_epoch: 1,
+                    to_epoch: 2,
+                    to_root: log.head(2).sth.root_hash,
+                }
+            ),
+            Err(KtError::Malformed),
+            "a token whose from_epoch is not the run's first epoch must be refused"
+        );
+        assert_eq!(state.view().epoch(), 0);
+
+        // 4. The token ends somewhere the run does not — same root, so only
+        //    the epoch clause can catch it.
+        let mut state = pinned(());
+        assert_eq!(
+            state.advance(
+                &heads,
+                &AppendOnlyVerified {
+                    from_epoch: 0,
+                    to_epoch: 3,
+                    to_root: log.head(2).sth.root_hash,
+                }
+            ),
+            Err(KtError::Malformed),
+            "a token whose to_epoch is not the run's last epoch must be refused"
+        );
+        assert_eq!(state.view().epoch(), 0);
+
+        // 5. The token ends at the right epoch on a different root — the
+        //    substitution the root clause exists for.
+        let mut state = pinned(());
+        assert_eq!(
+            state.advance(
+                &heads,
+                &AppendOnlyVerified {
+                    from_epoch: 0,
+                    to_epoch: 2,
+                    to_root: Digest::new([0xab; 32]),
+                }
+            ),
+            Err(KtError::Malformed),
+            "a token whose to_root is not the run's last root must be refused"
+        );
+        assert_eq!(state.view().epoch(), 0);
+
+        // …and the setup every case above was one edit away from is accepted,
+        // so none of them is refused for an unrelated reason.
+        let mut state = pinned(());
+        assert!(state.advance(&heads, &good_token()).is_ok());
+        assert_eq!(state.view().epoch(), 2);
+    }
+
+    #[test]
     fn a_halted_witness_stays_halted() {
         let log = TestLog::new();
         let view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();

--- a/rs/crates/f2z-kt/src/json.rs
+++ b/rs/crates/f2z-kt/src/json.rs
@@ -145,9 +145,42 @@ mod tests {
 
     #[test]
     fn every_container_says_which_half_is_authoritative() {
-        let body = container(b"abc", "");
-        assert!(body.contains("\"authoritative\":\"tls_codec\""));
-        assert!(body.contains("\"tls_codec\":\"YWJj\""));
+        // Both branches, because production takes both: `api.rs`'s `respond`
+        // is called with an empty rendering once and with a real one twice
+        // (zuu#710). The name claims every container, so it asserts every
+        // container.
+        let bare = container(b"abc", "");
+        assert!(bare.contains("\"authoritative\":\"tls_codec\""));
+        assert!(bare.contains("\"tls_codec\":\"YWJj\""));
+        assert!(
+            !bare.contains("\"rendered\""),
+            "an empty rendering must not produce an empty `rendered` object"
+        );
+
+        let with_rendering = container(b"abc", "\"epoch\":7");
+        assert!(with_rendering.contains("\"authoritative\":\"tls_codec\""));
+        assert!(with_rendering.contains("\"tls_codec\":\"YWJj\""));
+        assert!(with_rendering.contains("\"rendered\":{\"epoch\":7}"));
+
+        // The authoritative half is byte-identical across both branches: the
+        // rendering is added beside the `tls_codec` member, never in place of
+        // it, which is the property the module note is about.
+        assert!(bare.contains("\"tls_codec\":\"YWJj\""));
+        assert_eq!(
+            bare.matches("\"tls_codec\"").count(),
+            with_rendering.matches("\"tls_codec\"").count()
+        );
+
+        // Both are well-formed objects that a JSON reader can actually parse:
+        // balanced braces, and the rendering nested rather than spliced.
+        for body in [&bare, &with_rendering] {
+            assert!(body.starts_with('{') && body.ends_with('}'));
+            assert_eq!(
+                body.matches('{').count(),
+                body.matches('}').count(),
+                "unbalanced container: {body}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
**#709 — the token guard's five clauses.** `WitnessState::advance` refuses a
token that does not describe this run of heads, and it does so in one condition
with five clauses. The only test trips two of them at once — a token for epoch
9 with a zero root — so **deleting any single clause left the whole suite
green**, including the clause that is the actual substitution attack: right
epoch, different root.

Replaced with five cases that each differ from the accepted setup in exactly
one clause. Case 1 needed care: a run starting at epoch 1 is also a run whose
first root differs, so the root clause caught it and the epoch clause stayed
unproven. It now carries the *pinned root* at the wrong epoch, so only the
epoch clause can refuse it. The accepted setup every case is one edit away from
is asserted too, so none of them is passing for an unrelated reason.

Deleting each clause in turn, against the new test:

| clause deleted | caught |
|---|---|
| `first.sth.epoch != self.view.epoch()` | yes |
| `first.sth.root_hash != *self.view.root_hash()` | yes |
| `verified.from_epoch() != first.sth.epoch` | yes |
| `verified.to_epoch() != last.sth.epoch` | yes |
| `verified.to_root() != &last.sth.root_hash` | yes |

All five were green before.

**#710 — the container's other branch.** `json::container` has an empty-fields
branch and a rendered branch, and
`every_container_says_which_half_is_authoritative` only built the empty one.
Now both, with the `rendered` object asserted nested rather than spliced, the
authoritative `tls_codec` member asserted identical across branches, and braces
balanced. Splicing `{fields}` in place of `"rendered":{{fields}}` — the shape a
careless edit produces — fails it.

A correction to that issue while I am here: #710 says the untested branch is
"the one production uses". That is not right, and I have said so on the issue.
Production uses **both** — `api.rs`'s `respond` is called once with an empty
rendering and twice with a real one. The accurate statement is that one of two
reachable branches was never built in a test, which is what this fixes.

`cargo clippy --workspace --all-targets -- -D warnings` exits 0;
`cargo test --workspace --no-fail-fast` exits 0 over 73 targets.

Closes #709
Closes #710

Claude-Session: https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD