### PR TITLE
feat(rs): f2z-msg-dag — §7 hash-linked causal ordering, gap detection and repair

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -407,6 +407,13 @@ jobs:
       # no clock and no generator — the CSPRNG is a `rand_core::CryptoRng`
       # parameter precisely so the crate can compile here — so this step is what
       # keeps that promise honest.
+      #
+      # `f2z-msg-dag` is on it for the neighbouring reason: it is the ordering
+      # rule (ARCHITECTURE.md §7), and a browser client that could not compute
+      # the same transcript as a native one would make "every client that
+      # applies this rule produces the same transcript" a claim about one
+      # platform. It reads no clock either — every time-dependent decision is a
+      # `now_ms` parameter — which is the property this step keeps honest.
       - name: Build the client-linked crates for the browser target
         working-directory: rs
         run: |
@@ -416,7 +423,8 @@ jobs:
             -p f2z-codec \
             -p f2z-relay-proto \
             -p f2z-authority \
-            -p f2z-msg-identity
+            -p f2z-msg-identity \
+            -p f2z-msg-dag
 
       # The messaging store, without its SQLite backend.
       #

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -818,6 +818,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "f2z-msg-dag"
+version = "0.1.0"
+dependencies = [
+ "blake2",
+ "f2z-codec",
+ "f2z-kt-core",
+ "f2z-msg-identity",
+ "f2z-msg-mls",
+ "f2z-msg-store",
+ "proptest",
+ "tls_codec 0.4.2",
+]
+
+[[package]]
 name = "f2z-msg-identity"
 version = "0.1.0"
 dependencies = [

--- a/rs/README.md
+++ b/rs/README.md
@@ -118,6 +118,7 @@ prevent.
 | [`crates/f2z-authority`](./crates/f2z-authority) | An **experimental candidate** for the directory's non-cryptographic trust-root layer: the proposed `HandleAssertion`, a partial assertion-layer check, `AuthoritySet`, and `f2z-assert`. `KT.md` does not yet ratify these structures or first-entry/no-authority semantics (#594), and its result is not §4.4 directory authorization. Same portability constraints. |
 | [`crates/f2z-kt-core`](./crates/f2z-kt-core) | Key transparency, [`docs/e2ee/KT.md`](../docs/e2ee/KT.md) v1: `DirectoryEntry` and the §4.4 authorization rules, `SignedTreeHead` and its monotonicity checks, log-key rotation, `WitnessCosignature` and the threshold rule, and the client verifier over `akd_core`. Built on `f2z-codec`, `#![forbid(unsafe_code)]`, no I/O, no clock, no keys. |
 | [`crates/f2z-msg-identity`](./crates/f2z-msg-identity) | The messaging key hierarchy, [`docs/e2ee/ARCHITECTURE.md`](../docs/e2ee/ARCHITECTURE.md) §4.2: the ZIP-32-idiom seed-derived tree (`MSK`, hardened-only `CKDh`, `account_node`), the four HKDF account leaves, the per-device keys the OS CSPRNG generates, and `DeviceCredential` issuance. **The one crate here that holds a user's secret keys.** `no_std` + `alloc`, `#![forbid(unsafe_code)]`, no I/O, no clock, and its randomness is a `rand_core::CryptoRng` parameter so it reaches `wasm32-unknown-unknown`. |
+| [`crates/f2z-msg-dag`](./crates/f2z-msg-dag) | The hash-linked application framing, [`docs/e2ee/ARCHITECTURE.md`](../docs/e2ee/ARCHITECTURE.md) §7: the `AppMessage`, its `msg_id` commitment, causal ordering with `(epoch, sender_leaf_index, msg_id)` as the tie-break, gap detection from a dangling `parents` hash, and the bounded-window plaintext outbox §7's repair needs. `sent_at` is a newtype with **no `Ord`**, so ordering by the sender's clock does not compile. `no_std` + `alloc`, `#![forbid(unsafe_code)]`, no I/O and no clock — every time-dependent decision is a `now_ms` parameter — so it reaches `wasm32-unknown-unknown`. |
 
 `f2z-msg-identity` is the **only** crate in this tree that holds secrets. Every
 other crate here verifies, encodes or stores; this one derives an identity from a
@@ -202,8 +203,8 @@ boundary in practice: every crate above is MIT because a third-party relay, ZUUL
 and the WASM web client all compile the same rules, and a rule that two implementations
 disagree about is how ciphertext gets deleted before it is read.
 
-**The clients link `f2z-codec`, `f2z-relay-proto`, `f2z-kt-core`'s verifier and
-`f2z-msg-identity`; the relay links the first two
+**The clients link `f2z-codec`, `f2z-relay-proto`, `f2z-kt-core`'s verifier,
+`f2z-msg-identity` and `f2z-msg-dag`; the relay links the first two
 plus `f2z-relay-store`.** That is the licence boundary in practice: the shared
 crates are MIT because a third-party relay, ZUULI and the WASM web client all
 compile the same rules, and a rule that two implementations disagree about is how
@@ -377,7 +378,7 @@ cargo test
 # The client-linked crates only. `f2z-kt` and `f2z-witness` are native server
 # binaries and are deliberately absent from this line.
 cargo build --target wasm32-unknown-unknown --lib \
-  -p f2z-codec -p f2z-relay-proto -p f2z-authority -p f2z-msg-identity
+  -p f2z-codec -p f2z-relay-proto -p f2z-authority -p f2z-msg-identity -p f2z-msg-dag
 cargo build --target wasm32-unknown-unknown --lib -p f2z-kt-core \
             --no-default-features --features verifier
 

--- a/rs/crates/f2z-msg-dag/Cargo.toml
+++ b/rs/crates/f2z-msg-dag/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "f2z-msg-dag"
+version = "0.1.0"
+description = "Hash-linked application framing for free2z messaging (docs/e2ee/ARCHITECTURE.md §7): the AppMessage, its msg_id commitment, causal ordering, gap detection and bounded-window gap repair"
+edition.workspace = true
+# A restatement of wallet/rust-toolchain.toml's channel in Cargo's MSRV form,
+# registered with `scripts/check-rust-toolchain.sh --manifest` so it cannot
+# drift. Not inherited from the workspace: that check reads this literal line.
+rust-version = "1.97"
+# Permissive, deliberately and explicitly. Every client links this — ZUULI
+# native, the WASM web client, and any third-party implementation that wants to
+# produce a transcript another client agrees with. The AGPL-3.0 boundary starts
+# at the server binaries, not here, and an ordering rule that only one licence
+# may implement is an ordering rule nobody can check against a second
+# implementation. Stated literally rather than inherited so it is visible to
+# anyone opening the crate. rs/deny.toml enforces it.
+license = "MIT"
+repository.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# BLAKE2b-256 for `msg_id`. `ARCHITECTURE.md` §7's construction is the same
+# `H(label, x)` shape as `WIRE.md` §1.3's — label bytes, then the message, no
+# separator — so the label set is held to prefix-freeness with everyone else's
+# by `scripts/check-hash-domain-labels.mjs`.
+blake2 = { workspace = true }
+# The canonical encoding, and the `Body` newtype whose `Debug` is already
+# redacted. `canonical(rest)` in §7 has to mean *something* concrete, and the
+# only concrete canonical encoding in this tree is `f2z-codec`'s: a second one
+# would be a second chance for two clients to compute different `msg_id`s for
+# the same message, which is the one thing a content-addressed identifier
+# cannot survive.
+f2z-codec = { workspace = true }
+tls_codec = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+# `tests/repair_reencrypts.rs` performs the §7 repair against a **real** MLS
+# group rather than a stand-in cipher: two engines, a `Welcome`, an epoch
+# advance, and then the original plaintext re-encrypted under the new epoch.
+# The property being asserted — "the ciphertext differs and still decrypts" —
+# is a property of MLS, and a fake cipher would have proved it about the fake.
+#
+# `default-features = false` drops `f2z-msg-store`'s `sqlite` feature: these
+# tests run on `MemoryBackend`, and pulling SQLite's C amalgamation into a
+# dev-dependency graph would cost every `cargo test` in the workspace.
+f2z-msg-mls = { path = "../f2z-msg-mls", version = "0.1.0", default-features = false }
+f2z-msg-store = { path = "../f2z-msg-store", version = "0.1.0", default-features = false }
+# Credentials in those tests come from the real issuer, exactly as
+# `f2z-msg-mls`'s own tests do, so this file is a coordination test rather than
+# a test against this crate's idea of a credential.
+f2z-msg-identity = { path = "../f2z-msg-identity", version = "0.1.0" }
+f2z-kt-core = { path = "../f2z-kt-core", version = "0.1.0", default-features = false }

--- a/rs/crates/f2z-msg-dag/src/dag.rs
+++ b/rs/crates/f2z-msg-dag/src/dag.rs
@@ -1,0 +1,545 @@
+//! The receiver's view: dedup, gap detection, heads, and the display order.
+//!
+//! # What a gap is, and what it is not
+//!
+//! §7: "a receiver that sees a `parents` hash it does not hold knows, with
+//! certainty and without any server assistance, that it is missing a message."
+//! That is the whole mechanism, and its two properties are worth separating:
+//!
+//! - **It is certain.** A dangling parent is not a heuristic about latency or a
+//!   suspicion about a relay. The sender committed to that hash, inside MLS, in
+//!   an authenticated message. Either the receiver holds it or it does not.
+//! - **It is incomplete.** Hash links detect a *dropped middle*, and nothing
+//!   else. If a relay drops the last `k` messages from a sender and nothing
+//!   later arrives, no message ever references them and there is no dangling
+//!   parent to notice. `tests/tail_truncation.rs` asserts that limit as a
+//!   limit; `THREAT-MODEL.md` §4.4 and §7 both state it; no protocol fixes it.
+//!
+//! So [`MessageDag::has_detected_gaps`] returning `false` means "no detected
+//! gap", never "nothing is missing", and `CLIENT-CONTRACT.md` §3.5 forbids any
+//! string that implies the latter.
+//!
+//! # Dedup is by `msg_id` and by nothing else
+//!
+//! `ARCHITECTURE.md` §9.4: a device may publish queue addresses on *k* relays
+//! and a sender sends to all *k*, so receiving the identical message *k* times
+//! is the normal case rather than an anomaly. `msg_id` is a hash commitment
+//! over the content, so two arrivals of one message are byte-identical by
+//! construction. Deduplicating on anything else — a client reference, a
+//! `(sender, sent_at)` tuple — would either miss real duplicates or collapse
+//! two genuinely distinct messages, and `sent_at` in particular is
+//! attacker-chosen.
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::vec::Vec;
+
+use crate::error::DagError;
+use crate::message::{AppMessage, MsgId, RetentionClass, SentAt};
+use crate::order::{OrderNode, SortKey, linearise};
+
+/// Where a message came from, which decides how its sort key was obtained.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum Provenance {
+    /// Delivered inside its own MLS framing. `epoch` and `sender_leaf_index`
+    /// are the framing's, and the framing authenticated the sender.
+    Delivered,
+    /// Reconstructed from a `gap_response` (§7's repair). The message content
+    /// is verified against the `msg_id` that was requested — a hash commitment
+    /// — but the framing that carried it was the *repairing* peer's.
+    Repaired,
+}
+
+/// A message as the DAG holds it: its name, its edges, and its sort key.
+///
+/// Deliberately not the whole [`AppMessage`]: the body is the application's
+/// business and the store's, not the ordering layer's. Keeping the plaintext
+/// out of this structure also keeps it out of every `Debug` line the ordering
+/// layer could produce.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DagEntry {
+    key: SortKey,
+    parents: Vec<MsgId>,
+    retention_class: RetentionClass,
+    sent_at: SentAt,
+    provenance: Provenance,
+}
+
+impl DagEntry {
+    /// Admit a message that arrived inside its own MLS framing.
+    ///
+    /// `epoch` and `sender_leaf_index` are the **framing's** — they come from
+    /// `f2z_msg_mls::Received::Application`, are authenticated by MLS, and are
+    /// the only trustworthy source for them.
+    ///
+    /// The message's own `epoch` field must agree with the framing's. §7 does
+    /// not say what to do when they disagree; refusing is the safe reading,
+    /// because the field is inside the hash and the framing is not, so a
+    /// disagreement is a sender claiming to have authored in an epoch it did
+    /// not encrypt under. Accepting it would let a sender place its message
+    /// anywhere in the transcript it liked, which is precisely the power §7
+    /// takes away from the clock.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::EpochMismatch`] if the two epochs disagree.
+    pub fn from_delivered(
+        message: &AppMessage,
+        epoch: u64,
+        sender_leaf_index: u32,
+    ) -> Result<Self, DagError> {
+        if message.tbs().epoch != epoch {
+            return Err(DagError::EpochMismatch);
+        }
+        Ok(Self {
+            key: SortKey {
+                epoch,
+                sender_leaf_index,
+                msg_id: message.msg_id(),
+            },
+            parents: message.tbs().parents.as_slice().to_vec(),
+            retention_class: message.tbs().retention_class,
+            sent_at: message.tbs().sent_at,
+            provenance: Provenance::Delivered,
+        })
+    }
+
+    /// Admit a message reconstructed from a `gap_response`.
+    ///
+    /// The epoch is the message's **own** field, not the framing's: §7's repair
+    /// re-encrypts the original plaintext under the *current* epoch, so the
+    /// framing epoch of a repair is later than the message's by construction
+    /// and using it would move the message in the transcript.
+    ///
+    /// # `sender_leaf_index` is the open question §7 leaves, stated plainly
+    ///
+    /// The sort key needs a `sender_leaf_index`, and a repaired message does
+    /// not carry one it can prove: `sender_leaf_index` lives in MLS framing,
+    /// `msg_id` does not commit to it, and the framing that arrives with a
+    /// repair belongs to the repairing peer. §7 says "**the sender**
+    /// re-encrypts the original plaintext", so this function takes the
+    /// repairing peer's own authenticated leaf index and is correct exactly
+    /// when that sentence holds — the peer repairing is the peer that
+    /// originally sent.
+    ///
+    /// If repair is ever generalised so a third member may answer a
+    /// `gap_request` — which §7 does not forbid, and which is the obvious
+    /// optimisation once a group is larger than two — then two receivers who
+    /// learned the same message by different routes will compute **different
+    /// sort keys for the same `msg_id`**, and §7's "every client that applies
+    /// this rule to the same set of messages produces the same transcript"
+    /// stops being true. The fix is to move `sender_leaf_index` inside the
+    /// hashed message so the commitment covers it. That is a specification
+    /// change, so it is reported rather than made here.
+    #[must_use]
+    pub fn from_repair(message: &AppMessage, original_sender_leaf_index: u32) -> Self {
+        Self {
+            key: SortKey {
+                epoch: message.tbs().epoch,
+                sender_leaf_index: original_sender_leaf_index,
+                msg_id: message.msg_id(),
+            },
+            parents: message.tbs().parents.as_slice().to_vec(),
+            retention_class: message.tbs().retention_class,
+            sent_at: message.tbs().sent_at,
+            provenance: Provenance::Repaired,
+        }
+    }
+
+    /// The message's name.
+    #[must_use]
+    pub const fn msg_id(&self) -> MsgId {
+        self.key.msg_id
+    }
+
+    /// §7's sort key for this message.
+    #[must_use]
+    pub const fn sort_key(&self) -> SortKey {
+        self.key
+    }
+
+    /// The `msg_id`s this message referenced.
+    #[must_use]
+    pub fn parents(&self) -> &[MsgId] {
+        &self.parents
+    }
+
+    /// §8's retention class.
+    #[must_use]
+    pub const fn retention_class(&self) -> RetentionClass {
+        self.retention_class
+    }
+
+    /// The sender's claim about when it sent. Advisory; see [`SentAt`].
+    #[must_use]
+    pub const fn sent_at(&self) -> SentAt {
+        self.sent_at
+    }
+
+    /// How this message reached the receiver.
+    #[must_use]
+    pub const fn provenance(&self) -> Provenance {
+        self.provenance
+    }
+}
+
+/// What one gap is doing, mirroring `CLIENT-CONTRACT.md`'s `GapState`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum GapState {
+    /// A dangling parent has been seen; no repair has been asked for yet.
+    Detected,
+    /// A `gap_request` naming this hash has been emitted.
+    RepairRequested,
+    /// The sender no longer holds the plaintext, or said so.
+    ///
+    /// §8.4: this is surfaced to the user as an explicit "this message could
+    /// not be recovered" marker rather than a silent hole. It is terminal, and
+    /// it is deliberately *not* removed from the gap set — a hole the user was
+    /// told about is the whole point.
+    Unrecoverable,
+}
+
+/// The result of admitting a message.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Insertion {
+    /// The message is new to this device.
+    Accepted {
+        /// Parents this message referenced that the receiver has never held.
+        ///
+        /// Newly discovered only: a hash already in the gap set is not repeated,
+        /// so *n* messages all referencing one missing parent produce one gap.
+        newly_missing: Vec<MsgId>,
+    },
+    /// Already held. §9.4 makes this routine — the same message arrives once
+    /// per relay the recipient publishes a queue address on.
+    Duplicate,
+}
+
+/// A device's view of one conversation's message graph.
+///
+/// No clock, no I/O, no storage: every time-dependent decision in this crate is
+/// a parameter. That is what makes the ordering testable and what lets the same
+/// code run in a browser.
+#[derive(Clone, Debug, Default)]
+pub struct MessageDag {
+    entries: BTreeMap<MsgId, DagEntry>,
+    /// Parent -> children, including parents not held. This is what makes a
+    /// repaired message able to close the gap it was fetched for.
+    referenced_by: BTreeMap<MsgId, BTreeSet<MsgId>>,
+    gaps: BTreeMap<MsgId, GapState>,
+}
+
+impl MessageDag {
+    /// An empty conversation.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// How many messages are held.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether nothing is held.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Whether this `msg_id` is held.
+    #[must_use]
+    pub fn contains(&self, msg_id: &MsgId) -> bool {
+        self.entries.contains_key(msg_id)
+    }
+
+    /// Look one up.
+    #[must_use]
+    pub fn get(&self, msg_id: &MsgId) -> Option<&DagEntry> {
+        self.entries.get(msg_id)
+    }
+
+    /// Admit a message, deduplicating on `msg_id` and reporting new gaps.
+    ///
+    /// Idempotent: inserting the same `msg_id` again is a [`Insertion::Duplicate`]
+    /// and changes nothing, including the gap set. That is the property
+    /// `ARCHITECTURE.md` §9.4's *k*-relay fan-out depends on.
+    pub fn insert(&mut self, entry: DagEntry) -> Insertion {
+        let id = entry.msg_id();
+        if self.entries.contains_key(&id) {
+            return Insertion::Duplicate;
+        }
+
+        let mut newly_missing = Vec::new();
+        for parent in entry.parents() {
+            self.referenced_by.entry(*parent).or_default().insert(id);
+            if self.entries.contains_key(parent) {
+                continue;
+            }
+            // Already known missing — one gap, however many messages point at
+            // it. `Unrecoverable` is terminal and is not reopened by a later
+            // reference either.
+            if self.gaps.contains_key(parent) {
+                continue;
+            }
+            self.gaps.insert(*parent, GapState::Detected);
+            newly_missing.push(*parent);
+        }
+
+        // This message may itself be one somebody was missing.
+        self.gaps.remove(&id);
+        self.entries.insert(id, entry);
+
+        Insertion::Accepted { newly_missing }
+    }
+
+    /// The hashes of every message known to be missing and not yet resolved.
+    ///
+    /// Ascending by `msg_id`, so the list is stable across runs.
+    #[must_use]
+    pub fn detected_gaps(&self) -> Vec<MsgId> {
+        self.gaps
+            .iter()
+            .filter(|(_, state)| **state != GapState::Unrecoverable)
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    /// Whether any gap has been **detected**.
+    ///
+    /// Never "whether anything is missing" — see the module note on tail
+    /// truncation. `CLIENT-CONTRACT.md` §3.5 requires the distinction to
+    /// survive into the UI copy.
+    #[must_use]
+    pub fn has_detected_gaps(&self) -> bool {
+        self.gaps
+            .values()
+            .any(|state| *state != GapState::Unrecoverable)
+    }
+
+    /// The state of one gap, if there is one.
+    #[must_use]
+    pub fn gap_state(&self, msg_id: &MsgId) -> Option<GapState> {
+        self.gaps.get(msg_id).copied()
+    }
+
+    /// Every gap that has been given up on, ascending.
+    ///
+    /// §8.4's explicit "this message could not be recovered" set. A caller that
+    /// renders a transcript must render these; dropping them is the silent hole
+    /// §8.4 forbids.
+    #[must_use]
+    pub fn unrecoverable_gaps(&self) -> Vec<MsgId> {
+        self.gaps
+            .iter()
+            .filter(|(_, state)| **state == GapState::Unrecoverable)
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    /// Take the gaps that have not yet been asked about, marking them asked.
+    ///
+    /// This is the body of §7's `gap_request{hashes}`. Emptying the *detected*
+    /// set as it emits is what makes "every dropped middle message produces
+    /// exactly one gap signal" true — a caller that polls this in a loop does
+    /// not re-ask, and a message that keeps arriving with the same dangling
+    /// parent does not re-trigger.
+    ///
+    /// Returns an empty vector when there is nothing new to ask for.
+    pub fn take_gap_request(&mut self) -> Vec<MsgId> {
+        let pending: Vec<MsgId> = self
+            .gaps
+            .iter()
+            .filter(|(_, state)| **state == GapState::Detected)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in &pending {
+            self.gaps.insert(*id, GapState::RepairRequested);
+        }
+        pending
+    }
+
+    /// Record that a gap can never be filled (§8.4).
+    ///
+    /// Called when the sender answers that its plaintext outbox no longer holds
+    /// the message — see [`crate::outbox::RepairOutcome`] — or when the caller
+    /// gives up. Terminal.
+    pub fn mark_unrecoverable(&mut self, msg_id: &MsgId) {
+        if self.entries.contains_key(msg_id) {
+            return;
+        }
+        self.gaps.insert(*msg_id, GapState::Unrecoverable);
+    }
+
+    /// The current heads: held messages nothing held references.
+    ///
+    /// This is §7's "every message this sender had delivered and not yet
+    /// referenced, at send time" — the `parents` of the next message this
+    /// device sends. Ascending by `msg_id`, so two devices with the same view
+    /// build the same list and therefore, given the same content, the same
+    /// `msg_id`.
+    #[must_use]
+    pub fn heads(&self) -> Vec<MsgId> {
+        self.entries
+            .keys()
+            .filter(|id| {
+                self.referenced_by
+                    .get(*id)
+                    .is_none_or(alloc::collections::BTreeSet::is_empty)
+            })
+            .copied()
+            .collect()
+    }
+
+    /// §7's display order over everything held.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::Cycle`] — see [`linearise`].
+    pub fn display_order(&self) -> Result<Vec<MsgId>, DagError> {
+        let nodes: Vec<OrderNode> = self
+            .entries
+            .values()
+            .map(|entry| OrderNode {
+                key: entry.sort_key(),
+                parents: entry.parents().to_vec(),
+            })
+            .collect();
+        linearise(&nodes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{AppMessageTbs, MessageType, Parents};
+    use alloc::vec;
+    use f2z_codec::types::Body;
+
+    fn message(parents: Vec<MsgId>, epoch: u64, body: &[u8]) -> AppMessage {
+        AppMessage::seal(AppMessageTbs {
+            message_type: MessageType::CHAT,
+            parents: Parents::new(parents).unwrap(),
+            epoch,
+            sent_at: SentAt::new(0),
+            retention_class: RetentionClass::Chat,
+            body: Body::new(body.to_vec()).unwrap(),
+        })
+        .unwrap()
+    }
+
+    fn delivered(message: &AppMessage, leaf: u32) -> DagEntry {
+        DagEntry::from_delivered(message, message.tbs().epoch, leaf).unwrap()
+    }
+
+    #[test]
+    fn the_same_message_arriving_k_times_is_held_once() {
+        let mut dag = MessageDag::new();
+        let one = message(vec![], 7, b"hello");
+        assert!(matches!(
+            dag.insert(delivered(&one, 0)),
+            Insertion::Accepted { .. }
+        ));
+        for _ in 0..4 {
+            assert_eq!(dag.insert(delivered(&one, 0)), Insertion::Duplicate);
+        }
+        assert_eq!(dag.len(), 1);
+    }
+
+    #[test]
+    fn a_dangling_parent_is_one_gap_however_many_messages_point_at_it() {
+        let missing = message(vec![], 7, b"missing").msg_id();
+        let mut dag = MessageDag::new();
+
+        let first = message(vec![missing], 7, b"a");
+        let Insertion::Accepted { newly_missing } = dag.insert(delivered(&first, 0)) else {
+            panic!("expected acceptance");
+        };
+        assert_eq!(newly_missing, vec![missing]);
+
+        let second = message(vec![missing], 7, b"b");
+        let Insertion::Accepted { newly_missing } = dag.insert(delivered(&second, 0)) else {
+            panic!("expected acceptance");
+        };
+        assert!(newly_missing.is_empty(), "one hole is one gap");
+        assert_eq!(dag.detected_gaps(), vec![missing]);
+    }
+
+    #[test]
+    fn a_gap_request_is_emitted_once() {
+        let missing = message(vec![], 7, b"missing").msg_id();
+        let mut dag = MessageDag::new();
+        dag.insert(delivered(&message(vec![missing], 7, b"a"), 0));
+
+        assert_eq!(dag.take_gap_request(), vec![missing]);
+        assert!(
+            dag.take_gap_request().is_empty(),
+            "a gap already asked about must not be re-asked"
+        );
+        assert_eq!(dag.gap_state(&missing), Some(GapState::RepairRequested));
+    }
+
+    #[test]
+    fn the_missing_message_arriving_closes_the_gap() {
+        let missing = message(vec![], 7, b"missing");
+        let mut dag = MessageDag::new();
+        dag.insert(delivered(&message(vec![missing.msg_id()], 7, b"a"), 0));
+        assert!(dag.has_detected_gaps());
+
+        dag.insert(delivered(&missing, 1));
+        assert!(!dag.has_detected_gaps());
+        assert!(dag.detected_gaps().is_empty());
+    }
+
+    #[test]
+    fn an_unrecoverable_gap_stays_visible_and_is_not_reopened() {
+        let missing = message(vec![], 7, b"missing").msg_id();
+        let mut dag = MessageDag::new();
+        dag.insert(delivered(&message(vec![missing], 7, b"a"), 0));
+        dag.take_gap_request();
+        dag.mark_unrecoverable(&missing);
+
+        assert_eq!(dag.unrecoverable_gaps(), vec![missing]);
+        assert!(!dag.has_detected_gaps(), "it is no longer outstanding");
+
+        // Another message pointing at the same hole must not resurrect it as a
+        // fresh gap: the user has already been told it cannot be recovered.
+        let Insertion::Accepted { newly_missing } =
+            dag.insert(delivered(&message(vec![missing], 7, b"b"), 0))
+        else {
+            panic!("expected acceptance");
+        };
+        assert!(newly_missing.is_empty());
+        assert_eq!(dag.unrecoverable_gaps(), vec![missing]);
+    }
+
+    #[test]
+    fn heads_are_the_messages_nothing_references() {
+        let root = message(vec![], 7, b"root");
+        let child = message(vec![root.msg_id()], 7, b"child");
+        let sibling = message(vec![root.msg_id()], 7, b"sibling");
+
+        let mut dag = MessageDag::new();
+        dag.insert(delivered(&root, 0));
+        dag.insert(delivered(&child, 1));
+        dag.insert(delivered(&sibling, 1));
+
+        let mut heads = dag.heads();
+        heads.sort_unstable();
+        let mut expected = vec![child.msg_id(), sibling.msg_id()];
+        expected.sort_unstable();
+        assert_eq!(heads, expected);
+    }
+
+    #[test]
+    fn the_framing_epoch_and_the_claimed_epoch_must_agree() {
+        let one = message(vec![], 7, b"hello");
+        assert_eq!(
+            DagEntry::from_delivered(&one, 8, 0),
+            Err(DagError::EpochMismatch)
+        );
+    }
+}

--- a/rs/crates/f2z-msg-dag/src/error.rs
+++ b/rs/crates/f2z-msg-dag/src/error.rs
@@ -1,0 +1,96 @@
+//! This crate's failure type.
+
+use core::fmt;
+
+use f2z_codec::CodecError;
+
+/// Everything that can go wrong framing, admitting or ordering a message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DagError {
+    /// The bytes did not decode, did not re-encode to themselves, or carried a
+    /// value no version-1 structure may hold. `WIRE.md` §3.3's rule applies to
+    /// application framing for the same reason it applies to relay framing:
+    /// `msg_id` covers the canonical bytes, so a decoder that is more
+    /// permissive than its encoder is a parse-versus-verify gap.
+    Codec(CodecError),
+
+    /// `parents` was not strictly ascending, or repeated a `msg_id`.
+    ///
+    /// See [`crate::message::Parents`]. Without this rule two senders holding
+    /// the *same* set of heads can mint two different `msg_id`s for the same
+    /// message, and a content-addressed identifier that depends on the order
+    /// somebody happened to iterate a set is not content-addressed.
+    ParentsNotCanonical,
+
+    /// `parents` exceeded [`crate::message::Parents::MAX`].
+    TooManyParents,
+
+    /// The `msg_id` on the message is not the hash of the rest of it.
+    ///
+    /// Fatal and never retried. `msg_id` is a commitment; a message whose
+    /// commitment does not check is not a corrupted message, it is a different
+    /// message wearing a name.
+    MsgIdMismatch,
+
+    /// The `epoch` field disagrees with the MLS epoch the message was framed
+    /// in.
+    ///
+    /// See [`crate::dag::DagEntry::from_delivered`]. Only a directly delivered
+    /// message is held to this; a repaired one carries its *original* epoch by
+    /// construction (§7's repair re-encrypts under the current epoch, which
+    /// changes the framing and must not change the message).
+    EpochMismatch,
+
+    /// A `gap_response` carried a message that is not the one that was asked
+    /// for.
+    ///
+    /// The requester knows the `msg_id` it is missing — that is what a dangling
+    /// parent *is* — and `msg_id` is a hash commitment, so a repairing peer
+    /// cannot substitute content for it. This is the check that makes repair
+    /// safe to accept from a peer whose framing does not authenticate the
+    /// original sender.
+    UnsolicitedRepair,
+
+    /// The held graph contains a cycle.
+    ///
+    /// Cryptographically infeasible: a child's `msg_id` commits to its
+    /// parents' `msg_id`s, so a cycle is a hash preimage cycle. Reported
+    /// rather than ignored because the alternative is an ordering routine that
+    /// silently drops messages.
+    Cycle,
+}
+
+impl From<CodecError> for DagError {
+    fn from(error: CodecError) -> Self {
+        Self::Codec(error)
+    }
+}
+
+impl From<tls_codec::Error> for DagError {
+    fn from(_: tls_codec::Error) -> Self {
+        Self::Codec(CodecError::Decode)
+    }
+}
+
+impl fmt::Display for DagError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Codec(inner) => write!(f, "{inner}"),
+            Self::ParentsNotCanonical => {
+                f.write_str("parents must be strictly ascending msg_ids (ARCHITECTURE.md §7)")
+            }
+            Self::TooManyParents => f.write_str("parents exceeds the maximum this framing admits"),
+            Self::MsgIdMismatch => f.write_str("msg_id is not the hash of the rest of the message"),
+            Self::EpochMismatch => {
+                f.write_str("the epoch field disagrees with the MLS epoch of the framing")
+            }
+            Self::UnsolicitedRepair => {
+                f.write_str("a gap_response carried a message that was not requested")
+            }
+            Self::Cycle => f.write_str("the message graph contains a cycle"),
+        }
+    }
+}
+
+impl core::error::Error for DagError {}

--- a/rs/crates/f2z-msg-dag/src/error.rs
+++ b/rs/crates/f2z-msg-dag/src/error.rs
@@ -52,6 +52,15 @@ pub enum DagError {
     /// original sender.
     UnsolicitedRepair,
 
+    /// The responder answered, and the answer was "I cannot supply it".
+    ///
+    /// Distinct from [`DagError::UnsolicitedRepair`] because it is not a
+    /// protocol violation and not an attack — it is §8.4 working: the
+    /// responder's plaintext outbox window elapsed, and saying so is the
+    /// behaviour the specification asks for. The caller's next step is
+    /// [`crate::dag::MessageDag::mark_unrecoverable`], not a retry.
+    RepairRefused(crate::repair::RepairRefusal),
+
     /// The held graph contains a cycle.
     ///
     /// Cryptographically infeasible: a child's `msg_id` commits to its
@@ -87,6 +96,9 @@ impl fmt::Display for DagError {
             }
             Self::UnsolicitedRepair => {
                 f.write_str("a gap_response carried a message that was not requested")
+            }
+            Self::RepairRefused(reason) => {
+                write!(f, "the responder cannot supply that message: {reason:?}")
             }
             Self::Cycle => f.write_str("the message graph contains a cycle"),
         }

--- a/rs/crates/f2z-msg-dag/src/labels.rs
+++ b/rs/crates/f2z-msg-dag/src/labels.rs
@@ -1,0 +1,74 @@
+//! The one domain-separation label this crate mints.
+//!
+//! `ARCHITECTURE.md` §7:
+//!
+//! ```text
+//! msg_id = BLAKE2b-256("free2z/msg/v1/msgid" || canonical(rest))
+//! ```
+//!
+//! That is `WIRE.md` §1.3's `H(label, x)` construction — label bytes, then the
+//! message, **no separator and no terminator** — so the same rule applies to
+//! this label as to every other one in the tree: the *set* of labels must be
+//! prefix-free, because without a separator a label that is a proper prefix of
+//! another is a cross-domain collision waiting for an attacker-chosen message.
+//!
+//! Prefix-freeness is a property of the union, not of any one crate's array.
+//! `scripts/check-hash-domain-labels.mjs` holds this label against every other
+//! `free2z/` label in every tracked file — `f2z-msg-identity`'s four
+//! `free2z/msg/v1/…` leaves included, which is the set this one is most likely
+//! to collide with. The test below is the cheap local half and is deliberately
+//! not the load-bearing one; [zuu#602] is what happens when a check covers a
+//! subset of the namespace.
+//!
+//! [zuu#602]: https://github.com/free2z/zuu/issues/602
+
+/// `msg_id = BLAKE2b-256("free2z/msg/v1/msgid" || canonical(rest))`
+/// (`ARCHITECTURE.md` §7).
+///
+/// `rest` is every field of the message **except** `msg_id` itself — see
+/// [`crate::message::AppMessageTbs`], which is exactly that set and nothing
+/// else, so "the rest" is a type rather than a convention somebody has to
+/// remember to apply.
+pub const LABEL_MSG_ID: &[u8] = b"free2z/msg/v1/msgid";
+
+/// Every label this crate defines.
+///
+/// One entry, and it stays a closed array anyway: a second construction added
+/// under an unregistered label is a domain nobody checked, and the array is
+/// what the repository-wide script and the test below both range over.
+pub const LABELS: [&[u8]; 1] = [LABEL_MSG_ID];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The four `free2z/msg/v1/…` labels `f2z-msg-identity` mints.
+    ///
+    /// Restated here rather than imported, deliberately: this crate does not
+    /// depend on `f2z-msg-identity` and must not gain a dependency on it just
+    /// to run a test. The restatement can rot, which is exactly why it is not
+    /// the load-bearing check — `scripts/check-hash-domain-labels.mjs` reads
+    /// the real constants out of the tracked tree and is what CI gates on.
+    const NEIGHBOURING_LABELS: [&[u8]; 4] = [
+        b"free2z/msg/v1/identity-sig",
+        b"free2z/msg/v1/ceremony-sig",
+        b"free2z/msg/v1/directory-auth",
+        b"free2z/msg/v1/backup-wrap",
+    ];
+
+    #[test]
+    fn the_label_is_prefix_free_against_its_namespace_neighbours() {
+        for ours in LABELS {
+            assert!(ours.is_ascii(), "a label must be exact ASCII bytes");
+            assert!(
+                ours.starts_with(b"free2z/msg/v1/"),
+                "an unversioned label cannot be rotated"
+            );
+            for theirs in NEIGHBOURING_LABELS {
+                assert_ne!(ours, theirs);
+                assert!(!theirs.starts_with(ours), "{ours:?} is a prefix of another");
+                assert!(!ours.starts_with(theirs), "another label is a prefix of us");
+            }
+        }
+    }
+}

--- a/rs/crates/f2z-msg-dag/src/lib.rs
+++ b/rs/crates/f2z-msg-dag/src/lib.rs
@@ -1,0 +1,161 @@
+//! Hash-linked application framing — `docs/e2ee/ARCHITECTURE.md` §7.
+//!
+//! Every application payload carries the hashes of its predecessors. That one
+//! choice makes ordering and gap detection **transport-independent**: it works
+//! identically whether a message arrived over the relay, over WebRTC or over
+//! anything added later, so the transports can interleave freely and no
+//! sequencing authority exists to be trusted, subpoenaed or wrong.
+//!
+//! ```text
+//! AppMessage = { type, msg_id, parents, epoch, sent_at, retention_class, body }
+//! msg_id     = BLAKE2b-256("free2z/msg/v1/msgid" || canonical(rest))
+//! ```
+//!
+//! # What this crate is
+//!
+//! The framing, the commitment, the order, the gap signal and the repair
+//! bookkeeping — and nothing else. There is no MLS here, no relay, no storage,
+//! no clock and no randomness. [`PlaintextOutbox::repair`] hands back a
+//! *plaintext* for the caller's MLS engine to re-encrypt; it never produces a
+//! ciphertext, because §7's forward-secrecy argument depends on repair going
+//! through the current epoch's keys and a crate that could return a stored
+//! ciphertext would be one refactor away from replaying it.
+//!
+//! Every time-dependent decision takes `now_ms` as a parameter. That is what
+//! makes an expiry test a test instead of a wait, and it is why this crate
+//! reaches `wasm32-unknown-unknown` for the browser client (ADR 0001).
+//!
+//! # The four properties, and where each is asserted
+//!
+//! 1. **Causal order first, sort key second.** [`order`] linearises the DAG and
+//!    breaks ties between *concurrent* messages by
+//!    `(epoch, sender_leaf_index, msg_id)`. Applying the tie-break alone puts
+//!    replies above the messages they answer; the module note carries the
+//!    two-line counterexample and `tests/typescript_parity.rs` pins the
+//!    disagreement with the shipped TypeScript comparator.
+//!
+//! 2. **`sent_at` cannot order anything.** [`SentAt`] implements neither `Ord`
+//!    nor `PartialOrd`. §7 calls the field advisory; a doc comment saying so is
+//!    a convention, and a missing trait is a compile error.
+//!
+//! 3. **A gap is certain, and incomplete.** A `parents` hash the receiver does
+//!    not hold is proof — server-independent, authenticated inside MLS — that
+//!    something is missing. It detects a dropped *middle* and nothing else:
+//!    tail truncation leaves no dangling parent and is undetectable, which
+//!    `tests/tail_truncation.rs` asserts as a limit rather than papering over.
+//!
+//! 4. **Dedup is by `msg_id`.** §9.4's *k*-relay fan-out means receiving one
+//!    message *k* times is the normal case.
+//!
+//! # Where this crate had to decide something §7 does not say
+//!
+//! Written down because the alternative is a second implementation quietly
+//! deciding differently:
+//!
+//! - **The wire encoding.** §7 gives a structure, not a serialization.
+//!   [`AppMessage::encode`] is `msg_id || canonical(rest)`, so the hashed bytes
+//!   are a contiguous suffix. See [`message`].
+//! - **`parents` is strictly ascending.** A head *set* has to encode one way or
+//!   `msg_id` is not a function of the content. See [`Parents`].
+//! - **`type` is open, `retention_class` is closed.** See [`RetentionClass`].
+//! - **The framing epoch and the claimed epoch must agree** for a directly
+//!   delivered message. See [`DagEntry::from_delivered`].
+//! - **A repaired message's `sender_leaf_index` is the repairing peer's.** §7's
+//!   total order needs a leaf index; `msg_id` does not commit to one. See
+//!   [`DagEntry::from_repair`], which states the consequence in full.
+//!
+//! # Example
+//!
+//! ```
+//! use f2z_codec::types::Body;
+//! use f2z_msg_dag::{
+//!     AppMessage, AppMessageTbs, DagEntry, Insertion, MessageDag, MessageType, Parents,
+//!     RetentionClass, SentAt,
+//! };
+//!
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
+//! let mut dag = MessageDag::new();
+//!
+//! // The first message a peer sends: no parents.
+//! let first = AppMessage::seal(AppMessageTbs {
+//!     message_type: MessageType::CHAT,
+//!     parents: Parents::empty(),
+//!     epoch: 7,
+//!     sent_at: SentAt::new(1_700_000_000_000), // advisory; orders nothing
+//!     retention_class: RetentionClass::Chat,
+//!     body: Body::new(b"hello".to_vec())?,
+//! })?;
+//!
+//! // A second message referencing it — which never arrives.
+//! let dropped = AppMessage::seal(AppMessageTbs {
+//!     message_type: MessageType::CHAT,
+//!     parents: Parents::new(vec![first.msg_id()])?,
+//!     epoch: 7,
+//!     sent_at: SentAt::new(1_700_000_001_000),
+//!     retention_class: RetentionClass::Chat,
+//!     body: Body::new(b"are you there?".to_vec())?,
+//! })?;
+//!
+//! // A third, referencing the second.
+//! let third = AppMessage::seal(AppMessageTbs {
+//!     message_type: MessageType::CHAT,
+//!     parents: Parents::new(vec![dropped.msg_id()])?,
+//!     epoch: 7,
+//!     sent_at: SentAt::new(1_700_000_002_000),
+//!     retention_class: RetentionClass::Chat,
+//!     body: Body::new(b"still here".to_vec())?,
+//! })?;
+//!
+//! // `epoch` and the leaf index come from the MLS framing, authenticated.
+//! dag.insert(DagEntry::from_delivered(&first, 7, 1)?);
+//! let outcome = dag.insert(DagEntry::from_delivered(&third, 7, 1)?);
+//!
+//! // The hole is certain, and it names itself.
+//! assert_eq!(
+//!     outcome,
+//!     Insertion::Accepted { newly_missing: vec![dropped.msg_id()] }
+//! );
+//! assert_eq!(dag.take_gap_request(), vec![dropped.msg_id()]);
+//! assert!(dag.take_gap_request().is_empty(), "one gap, one signal");
+//! # Ok(())
+//! # }
+//! ```
+
+#![no_std]
+#![forbid(unsafe_code)]
+// The workspace denies these because a panic in a client's message pipeline is
+// a crash of the client. Neither hazard exists in a test harness run on the
+// host by a person reading the failure, and the same `cfg_attr` sits at the
+// root of `f2z-codec` and `f2z-msg-mls`.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects
+    )
+)]
+
+extern crate alloc;
+
+pub mod dag;
+pub mod error;
+pub mod labels;
+pub mod message;
+pub mod order;
+pub mod outbox;
+pub mod repair;
+
+pub use dag::{DagEntry, GapState, Insertion, MessageDag, Provenance};
+pub use error::DagError;
+pub use labels::{LABEL_MSG_ID, LABELS};
+pub use message::{
+    AppMessage, AppMessageTbs, MessageType, MsgId, Parents, RetentionClass, SentAt, msg_id_of,
+};
+pub use order::{OrderNode, SortKey, compare_sort_keys, linearise};
+pub use outbox::{PlaintextOutbox, RepairOutcome, Unrecoverable};
+pub use repair::{
+    GAP_REQUEST_TYPE, GAP_RESPONSE_TYPE, GapRequest, GapResponse, RepairEntry, RepairRefusal,
+};

--- a/rs/crates/f2z-msg-dag/src/message.rs
+++ b/rs/crates/f2z-msg-dag/src/message.rs
@@ -1,0 +1,739 @@
+//! The `AppMessage` of `ARCHITECTURE.md` §7, and the hash that names it.
+//!
+//! ```text
+//! AppMessage = {
+//!   type, msg_id, parents, epoch, sent_at, retention_class, body
+//! }
+//! msg_id = BLAKE2b-256("free2z/msg/v1/msgid" || canonical(rest))
+//! ```
+//!
+//! # `rest` is a type, not a comment
+//!
+//! `canonical(rest)` means "every field except `msg_id`", and getting that set
+//! wrong is a silent interoperability break rather than a crash: two clients
+//! that disagree about which bytes are hashed simply compute two different
+//! names for one message and never dedup it. So `rest` is [`AppMessageTbs`] —
+//! a type that *is* the hashed set — and [`AppMessage`] is that type plus its
+//! digest. There is no path that hashes a hand-assembled byte string.
+//!
+//! # The wire order, and why `msg_id` comes first
+//!
+//! §7 lists `type` first. That listing is a **structure**, not a wire encoding:
+//! §7 defines no concrete serialization, because the message travels as the
+//! opaque payload of an MLS `PrivateMessage` and MLS does not care what is
+//! inside it. Some concrete encoding still has to exist for `canonical(rest)`
+//! to be a byte string, and this crate defines it:
+//!
+//! ```text
+//! encode(AppMessage) == msg_id || encode(AppMessageTbs)
+//! ```
+//!
+//! `msg_id` first buys one property worth having: the hashed bytes are a
+//! **contiguous suffix** of the encoded message, so verifying the commitment
+//! needs no re-assembly and cannot pick up a field the encoder placed
+//! somewhere else. [`AppMessage::decode`] verifies against that suffix
+//! directly.
+//!
+//! This is an ambiguity in §7 that had to be resolved to write any code at all,
+//! and it is resolved *here*, which means it has to be reflected back into §7
+//! before a second implementation exists. It is listed in the pull request.
+//!
+//! # `sent_at` has no `Ord`, and that is the point
+//!
+//! [`SentAt`] deliberately implements neither `Ord` nor `PartialOrd`. §7 says
+//! the field is advisory and never orders anything; a comment saying so is a
+//! convention, and a missing trait is a compile error. Sorting a transcript by
+//! `sent_at` does not produce a subtly wrong transcript in this crate — it
+//! produces `error[E0277]: the trait bound `SentAt: Ord` is not satisfied`.
+
+// `tls_codec`'s derive macros build their error strings with `format!` and
+// return `Vec<u8>`; both need to be in scope in a `no_std` crate.
+use alloc::format;
+use alloc::vec::Vec;
+use core::fmt;
+
+use blake2::digest::consts::U32;
+use blake2::{Blake2b, Digest as _};
+use f2z_codec::CodecError;
+use f2z_codec::canonical::Canonical;
+use f2z_codec::types::Body;
+use f2z_codec::vec::VecU16;
+use tls_codec::{
+    DeserializeBytes, Error as TlsError, SerializeBytes, Size, TlsDeserializeBytes,
+    TlsSerializeBytes, TlsSize,
+};
+
+use crate::error::DagError;
+use crate::labels::LABEL_MSG_ID;
+
+type Blake2b256 = Blake2b<U32>;
+
+// ---------------------------------------------------------------------------
+// msg_id
+// ---------------------------------------------------------------------------
+
+/// A message's name: `BLAKE2b-256("free2z/msg/v1/msgid" || canonical(rest))`.
+///
+/// This is the protocol's dedup key and the third component of §7's total
+/// order. `Ord` is derived over the raw bytes, which is the ordering
+/// `CLIENT-CONTRACT.md` §7's `msgId` string comparison reproduces exactly as
+/// long as the string is base16 in a **single** case — see
+/// [`MsgId::to_lower_hex`].
+///
+/// `Debug` is hand-written. A `msg_id` is not secret in the sense a key is —
+/// anyone holding the message can recompute it — but it is a stable,
+/// conversation-linkable identifier that survives forever in a log file, and
+/// the derived `Debug` over `[u8; 32]` would render it as a decimal byte list
+/// that no hex-shaped leak check would ever notice.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MsgId([u8; MsgId::LEN]);
+
+impl MsgId {
+    /// The width of a `msg_id`, in bytes. BLAKE2b-**256**.
+    pub const LEN: usize = 32;
+
+    /// Wrap 32 bytes.
+    #[must_use]
+    pub const fn new(bytes: [u8; Self::LEN]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; Self::LEN] {
+        &self.0
+    }
+
+    /// Wrap a slice of exactly 32 bytes.
+    ///
+    /// # Errors
+    ///
+    /// [`CodecError::InvalidValue`] if the slice is a different length.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, CodecError> {
+        let array: [u8; Self::LEN] = bytes.try_into().map_err(|_| CodecError::InvalidValue)?;
+        Ok(Self(array))
+    }
+
+    /// Lowercase base16, which is the spelling `CLIENT-CONTRACT.md` §7's
+    /// `msgId` carries across the FFI boundary.
+    ///
+    /// The case matters and the *consistency* of the case matters more. Base16
+    /// is order-preserving in either case on its own — ASCII `0`..`9` precedes
+    /// both `A`..`F` and `a`..`f` — so a client that lexicographically compares
+    /// all-lowercase hex strings, as `compareMessages` in
+    /// `wallet/zuuli/src/lib/messaging/types.ts` does, reproduces this type's
+    /// byte ordering exactly. **Mixed** case does not, and base64 does not
+    /// either: `+` and `/` sort below the digits and the alphabet is not
+    /// monotone in the underlying bytes. This function exists so the FFI has
+    /// one spelling to use and no reason to invent another.
+    #[must_use]
+    pub fn to_lower_hex(&self) -> alloc::string::String {
+        let mut out = alloc::string::String::with_capacity(Self::LEN.saturating_mul(2));
+        for byte in &self.0 {
+            const DIGITS: &[u8; 16] = b"0123456789abcdef";
+            let high = usize::from(byte >> 4);
+            let low = usize::from(byte & 0x0f);
+            out.push(char::from(*DIGITS.get(high).unwrap_or(&b'0')));
+            out.push(char::from(*DIGITS.get(low).unwrap_or(&b'0')));
+        }
+        out
+    }
+}
+
+impl fmt::Debug for MsgId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("MsgId(<redacted>)")
+    }
+}
+
+impl Size for MsgId {
+    fn tls_serialized_len(&self) -> usize {
+        Self::LEN
+    }
+}
+
+impl SerializeBytes for MsgId {
+    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        self.0.tls_serialize()
+    }
+}
+
+impl DeserializeBytes for MsgId {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (array, rest) = <[u8; MsgId::LEN]>::tls_deserialize_bytes(bytes)?;
+        Ok((Self(array), rest))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// type
+// ---------------------------------------------------------------------------
+
+/// The `type` field of §7.
+///
+/// A transparent `u8` rather than a closed enum, because §7's list ends in
+/// `...` — the set is open by specification. A closed enum would have to map
+/// an unrecognised byte to something, and mapping an unknown variant to a
+/// default is the silent-variant hazard `WIRE.md` §3.3 exists to forbid: the
+/// message would re-encode to a *different* byte and fail re-encode equality,
+/// or, worse, be silently reinterpreted. `CLIENT-CONTRACT.md`'s `MessageBody`
+/// already has an `unsupported` arm carrying a `typeTag`, which is the
+/// behaviour this admits.
+///
+/// **The codepoints are this crate's assignment.** §7 names the types and gives
+/// no numbers; these are allocated in the order §7 lists them, starting at 1,
+/// with 0 left unassigned so that an all-zero buffer is not a valid `chat`.
+/// Listed in the pull request as an ambiguity that has to go back into §7.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct MessageType(u8);
+
+impl MessageType {
+    /// A user-visible chat message.
+    pub const CHAT: Self = Self(1);
+    /// A `DeliveryReceipt` (`CLIENT-CONTRACT.md` §6.2's `device-delivered`).
+    pub const RECEIPT: Self = Self(2);
+    /// `gap_request{hashes}` — §7's gap signal.
+    pub const GAP_REQUEST: Self = Self(3);
+    /// `gap_response` — the repair, re-encrypted under the current epoch.
+    pub const GAP_RESPONSE: Self = Self(4);
+    /// A FROST/DKG ceremony payload (§11), which carries its own signature in
+    /// addition to MLS framing.
+    pub const CEREMONY: Self = Self(5);
+    /// A queue advert (`WIRE.md` §12.2).
+    pub const QUEUE_ADVERT: Self = Self(6);
+    /// A WebRTC offer (§10).
+    pub const WEBRTC_OFFER: Self = Self(7);
+
+    /// Wrap a raw codepoint, including one this build has never heard of.
+    #[must_use]
+    pub const fn new(code: u8) -> Self {
+        Self(code)
+    }
+
+    /// The raw codepoint.
+    #[must_use]
+    pub const fn code(self) -> u8 {
+        self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// retention_class
+// ---------------------------------------------------------------------------
+
+/// §8's retention class, and a **closed** set.
+///
+/// The asymmetry with [`MessageType`] is deliberate and is the interesting
+/// decision in this file. `type` drives dispatch, and a client that does not
+/// recognise a type can honestly render "unsupported message". `retention_class`
+/// drives a *retention decision* — §8.5 retains `CEREMONY` by default and §8.2's
+/// ephemeral hint expires `CHAT` — and there is no honest default for a value
+/// nobody recognises. Silently treating an unknown class as `CHAT` would expire
+/// a ceremony transcript the participant is keeping as their own evidence;
+/// silently treating it as `CEREMONY` would retain something a user asked to be
+/// ephemeral. So an unknown value is a decode error, loudly, at the boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum RetentionClass {
+    /// §8.2's ephemeral-hint-eligible class.
+    Chat,
+    /// §8.5: retained by default, because the participant wants the evidence.
+    Ceremony,
+}
+
+impl RetentionClass {
+    /// The wire codepoint.
+    #[must_use]
+    pub const fn code(self) -> u8 {
+        match self {
+            Self::Chat => 1,
+            Self::Ceremony => 2,
+        }
+    }
+
+    /// Resolve a codepoint this build knows.
+    #[must_use]
+    pub const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::Chat),
+            2 => Some(Self::Ceremony),
+            _ => None,
+        }
+    }
+}
+
+impl Size for RetentionClass {
+    fn tls_serialized_len(&self) -> usize {
+        1
+    }
+}
+
+impl SerializeBytes for RetentionClass {
+    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        self.code().tls_serialize()
+    }
+}
+
+impl DeserializeBytes for RetentionClass {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (code, rest) = u8::tls_deserialize_bytes(bytes)?;
+        let class = Self::from_code(code).ok_or(TlsError::UnknownValue(u64::from(code)))?;
+        Ok((class, rest))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// sent_at
+// ---------------------------------------------------------------------------
+
+/// The sender's claimed wall clock, in milliseconds. **Advisory only.**
+///
+/// §7: "sender-claimed; ADVISORY ONLY, never used for ordering or security
+/// decisions". `CLIENT-CONTRACT.md` §7 enumerates the prohibition: it must not
+/// order, filter, deduplicate, bound a query, decide whether something is
+/// "new", drive a day separator that changes ordering, or feed any security
+/// decision.
+///
+/// **This type implements neither `Ord` nor `PartialOrd`, and that is load
+/// bearing.** Every messaging client that has ever got this wrong got it wrong
+/// by sorting on a field that happened to be comparable. Here the mistake does
+/// not compile. `PartialEq` is kept — a re-encode-equality test has to compare
+/// whole messages — but equality is not ordering and cannot be used to place
+/// anything in a transcript.
+///
+/// It is also not usable for dedup even where it would appear to work:
+/// [`crate::dag::MessageDag`] dedups on [`MsgId`] only.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct SentAt(u64);
+
+impl SentAt {
+    /// Wrap a sender-claimed millisecond timestamp.
+    #[must_use]
+    pub const fn new(millis: u64) -> Self {
+        Self(millis)
+    }
+
+    /// The claimed value, for **rendering** beside a message and nothing else.
+    ///
+    /// The name says "claimed" because that is all it is: an attacker-supplied
+    /// integer. Anything that takes this and compares it to another one has
+    /// re-created the ordering hazard this type exists to prevent.
+    #[must_use]
+    pub const fn claimed_millis(self) -> u64 {
+        self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// parents
+// ---------------------------------------------------------------------------
+
+/// §7's `parents`: every message this sender had delivered and not yet
+/// referenced, at send time.
+///
+/// # Strictly ascending, and why that is not tidiness
+///
+/// A sender's heads are a *set*. Any encoding of a set has to pick an order,
+/// and `msg_id` hashes the encoding — so if the order were free, two senders
+/// holding the identical head set would mint two different names for the
+/// identical message. Content addressing that depends on iteration order is not
+/// content addressing. So this type admits only strictly ascending sequences:
+/// sorted, and therefore also duplicate-free.
+///
+/// Rejecting duplicates has a second effect worth naming: a `parents` list of
+/// the same hash repeated 2000 times would otherwise be a cheap way to make a
+/// receiver do 2000 lookups per message.
+///
+/// §7 does not state this rule. It is this crate's canonicalisation decision
+/// and it is listed in the pull request.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes)]
+pub struct Parents(VecU16<MsgId>);
+
+impl Parents {
+    /// The most parents one message may reference.
+    ///
+    /// The `<0..2^16-1>` length prefix already caps this at 2047 whole
+    /// `msg_id`s; the constant is spelled out so the limit is a decision rather
+    /// than an artefact of a prefix width.
+    pub const MAX: usize = 2047;
+
+    /// Wrap a head set, sorting and validating it.
+    ///
+    /// The input need not already be sorted — sorting is this constructor's
+    /// job, because a caller assembling its heads from a `BTreeSet` should not
+    /// have to know the rule. Duplicates are an error rather than something to
+    /// quietly collapse: a caller that produced one has a bug in its head
+    /// tracking and should hear about it.
+    ///
+    /// # Errors
+    ///
+    /// - [`DagError::TooManyParents`] above [`Parents::MAX`].
+    /// - [`DagError::ParentsNotCanonical`] if the same `msg_id` appears twice.
+    pub fn new(mut ids: Vec<MsgId>) -> Result<Self, DagError> {
+        if ids.len() > Self::MAX {
+            return Err(DagError::TooManyParents);
+        }
+        ids.sort_unstable();
+        if ids.windows(2).any(|pair| pair.first() == pair.get(1)) {
+            return Err(DagError::ParentsNotCanonical);
+        }
+        Ok(Self(VecU16::new(ids)))
+    }
+
+    /// The empty head set — a conversation's first message.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self(VecU16::new(Vec::new()))
+    }
+
+    /// The parent ids, ascending.
+    #[must_use]
+    pub fn as_slice(&self) -> &[MsgId] {
+        self.0.as_slice()
+    }
+
+    /// How many parents.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether there are none.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn validate(&self) -> Result<(), DagError> {
+        let ids = self.0.as_slice();
+        if ids.len() > Self::MAX {
+            return Err(DagError::TooManyParents);
+        }
+        let ascending = ids.windows(2).all(|pair| match (pair.first(), pair.get(1)) {
+            (Some(low), Some(high)) => low < high,
+            _ => true,
+        });
+        if !ascending {
+            return Err(DagError::ParentsNotCanonical);
+        }
+        Ok(())
+    }
+}
+
+impl DeserializeBytes for Parents {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (inner, rest) = VecU16::<MsgId>::tls_deserialize_bytes(bytes)?;
+        let parents = Self(inner);
+        // A received list that is not strictly ascending is refused here rather
+        // than sorted, because sorting it would change the bytes `msg_id`
+        // commits to. §3.3's rule again: the decoder must not be more
+        // permissive than the encoder.
+        parents
+            .validate()
+            .map_err(|_| TlsError::InvalidVectorLength)?;
+        Ok((parents, rest))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// the message
+// ---------------------------------------------------------------------------
+
+/// `rest`: every field of §7's `AppMessage` except `msg_id`.
+///
+/// This is the exact input to the hash, as a type. See the module note.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct AppMessageTbs {
+    /// §7's `type`.
+    pub message_type: MessageType,
+    /// §7's `parents`.
+    pub parents: Parents,
+    /// §7's `epoch`: the MLS epoch this message was authored in.
+    pub epoch: u64,
+    /// §7's `sent_at`. Advisory. See [`SentAt`].
+    pub sent_at: SentAt,
+    /// §7's `retention_class`.
+    pub retention_class: RetentionClass,
+    /// §7's `body`, opaque at this layer.
+    pub body: Body,
+}
+
+/// A framed application message: §7's structure, with its commitment.
+///
+/// Construct one with [`AppMessage::seal`], which computes `msg_id`, or decode
+/// one with [`AppMessage::decode`], which verifies it. There is no constructor
+/// that takes both halves without checking they agree, because a message whose
+/// name does not match its content is the one thing this framing exists to make
+/// impossible.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AppMessage {
+    msg_id: MsgId,
+    tbs: AppMessageTbs,
+}
+
+impl AppMessage {
+    /// Compute `msg_id` over `tbs` and bind the two together.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::Codec`] if `tbs` cannot be encoded — in practice a `parents`
+    /// list or `body` longer than its length prefix can describe.
+    pub fn seal(tbs: AppMessageTbs) -> Result<Self, DagError> {
+        let encoded = tbs.encode_canonical()?;
+        Ok(Self {
+            msg_id: msg_id_of(&encoded),
+            tbs,
+        })
+    }
+
+    /// The message's name, and the protocol's dedup key.
+    #[must_use]
+    pub const fn msg_id(&self) -> MsgId {
+        self.msg_id
+    }
+
+    /// The hashed fields.
+    #[must_use]
+    pub const fn tbs(&self) -> &AppMessageTbs {
+        &self.tbs
+    }
+
+    /// `msg_id || encode(tbs)`. See the module note on the field order.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::Codec`] if the structure exceeds a length prefix.
+    pub fn encode(&self) -> Result<Vec<u8>, DagError> {
+        let tbs = self.tbs.encode_canonical()?;
+        let mut out = Vec::with_capacity(MsgId::LEN.saturating_add(tbs.len()));
+        out.extend_from_slice(self.msg_id.as_bytes());
+        out.extend_from_slice(&tbs);
+        Ok(out)
+    }
+
+    /// Decode a message and verify its commitment.
+    ///
+    /// Three checks, in this order, and all three are fatal:
+    ///
+    /// 1. the bytes decode as a version-1 `AppMessage`;
+    /// 2. they re-encode to themselves (`WIRE.md` §3.3);
+    /// 3. `msg_id` is the hash of the remaining bytes.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::Codec`] for 1 and 2, [`DagError::MsgIdMismatch`] for 3.
+    pub fn decode(bytes: &[u8]) -> Result<Self, DagError> {
+        let claimed = bytes
+            .get(..MsgId::LEN)
+            .ok_or(DagError::Codec(CodecError::Decode))?;
+        let rest = bytes
+            .get(MsgId::LEN..)
+            .ok_or(DagError::Codec(CodecError::Decode))?;
+        let claimed = MsgId::from_slice(claimed)?;
+
+        // Re-encode equality on the hashed suffix. `decode_canonical` is the
+        // only place in this tree that performs it, and the bytes it hands back
+        // are the *re-encoded* ones — so step 3 below cannot be fed the
+        // received bytes by accident.
+        let canonical = f2z_codec::decode_canonical::<AppMessageTbs>(rest)?;
+        if msg_id_of(canonical.bytes()) != claimed {
+            return Err(DagError::MsgIdMismatch);
+        }
+
+        Ok(Self {
+            msg_id: claimed,
+            tbs: canonical.into_value(),
+        })
+    }
+}
+
+/// `BLAKE2b-256("free2z/msg/v1/msgid" || canonical_rest)` — §7's construction,
+/// with the label applied exactly as `WIRE.md` §1.3's `H(label, x)` does: label
+/// bytes, then the message, no separator and no terminator.
+#[must_use]
+pub fn msg_id_of(canonical_rest: &[u8]) -> MsgId {
+    let mut hasher = Blake2b256::new();
+    hasher.update(LABEL_MSG_ID);
+    hasher.update(canonical_rest);
+    MsgId::new(hasher.finalize().into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn tbs(parents: Parents, epoch: u64, body: &[u8]) -> AppMessageTbs {
+        AppMessageTbs {
+            message_type: MessageType::CHAT,
+            parents,
+            epoch,
+            sent_at: SentAt::new(1_700_000_000_000),
+            retention_class: RetentionClass::Chat,
+            body: Body::new(body.to_vec()).unwrap(),
+        }
+    }
+
+    fn id(byte: u8) -> MsgId {
+        MsgId::new([byte; MsgId::LEN])
+    }
+
+    #[test]
+    fn a_sealed_message_round_trips_and_its_commitment_verifies() {
+        let message = AppMessage::seal(tbs(Parents::empty(), 7, b"hello")).unwrap();
+        let wire = message.encode().unwrap();
+        assert_eq!(AppMessage::decode(&wire).unwrap(), message);
+        assert_eq!(
+            wire.get(..MsgId::LEN).unwrap(),
+            message.msg_id().as_bytes(),
+            "the hashed bytes must be the suffix after msg_id"
+        );
+    }
+
+    #[test]
+    fn the_hashed_bytes_are_exactly_the_suffix_of_the_encoding() {
+        let message = AppMessage::seal(tbs(Parents::empty(), 7, b"hello")).unwrap();
+        let wire = message.encode().unwrap();
+        let suffix = wire.get(MsgId::LEN..).unwrap();
+        assert_eq!(msg_id_of(suffix), message.msg_id());
+    }
+
+    #[test]
+    fn editing_any_hashed_field_changes_the_name() {
+        let base = AppMessage::seal(tbs(Parents::empty(), 7, b"hello")).unwrap();
+
+        let other_epoch = AppMessage::seal(tbs(Parents::empty(), 8, b"hello")).unwrap();
+        assert_ne!(base.msg_id(), other_epoch.msg_id());
+
+        let other_body = AppMessage::seal(tbs(Parents::empty(), 7, b"hellp")).unwrap();
+        assert_ne!(base.msg_id(), other_body.msg_id());
+
+        let mut ceremony = tbs(Parents::empty(), 7, b"hello");
+        ceremony.retention_class = RetentionClass::Ceremony;
+        assert_ne!(base.msg_id(), AppMessage::seal(ceremony).unwrap().msg_id());
+
+        // `sent_at` is advisory, but it is still *hashed* — §7 puts it inside
+        // `rest`. Advisory means "never ordered by", not "not committed to".
+        let mut later = tbs(Parents::empty(), 7, b"hello");
+        later.sent_at = SentAt::new(0);
+        assert_ne!(base.msg_id(), AppMessage::seal(later).unwrap().msg_id());
+    }
+
+    #[test]
+    fn a_tampered_body_fails_the_commitment_rather_than_decoding() {
+        let message = AppMessage::seal(tbs(Parents::empty(), 7, b"hello")).unwrap();
+        let mut wire = message.encode().unwrap();
+        let last = wire.len().checked_sub(1).unwrap();
+        *wire.get_mut(last).unwrap() ^= 0xff;
+        assert_eq!(AppMessage::decode(&wire), Err(DagError::MsgIdMismatch));
+    }
+
+    #[test]
+    fn trailing_bytes_are_rejected() {
+        let message = AppMessage::seal(tbs(Parents::empty(), 7, b"hello")).unwrap();
+        let mut wire = message.encode().unwrap();
+        wire.push(0);
+        assert_eq!(
+            AppMessage::decode(&wire),
+            Err(DagError::Codec(CodecError::Decode))
+        );
+    }
+
+    #[test]
+    fn parents_are_sorted_by_the_constructor_so_a_head_set_has_one_name() {
+        let one = Parents::new(vec![id(3), id(1), id(2)]).unwrap();
+        let other = Parents::new(vec![id(1), id(2), id(3)]).unwrap();
+        assert_eq!(one, other);
+        assert_eq!(
+            AppMessage::seal(tbs(one, 7, b"x")).unwrap().msg_id(),
+            AppMessage::seal(tbs(other, 7, b"x")).unwrap().msg_id(),
+            "the same head set must mint the same msg_id"
+        );
+    }
+
+    #[test]
+    fn a_repeated_parent_is_refused() {
+        assert_eq!(
+            Parents::new(vec![id(1), id(1)]),
+            Err(DagError::ParentsNotCanonical)
+        );
+    }
+
+    #[test]
+    fn a_descending_parents_list_on_the_wire_is_refused_rather_than_sorted() {
+        // Hand-assemble the encoding with the parents out of order. Sorting on
+        // receipt would change the bytes msg_id commits to, so this must be an
+        // error and not a repair.
+        let ascending = AppMessage::seal(tbs(
+            Parents::new(vec![id(1), id(2)]).unwrap(),
+            7,
+            b"x",
+        ))
+        .unwrap();
+        let wire = ascending.encode().unwrap();
+
+        // Swap the two 32-byte parent ids in place. They sit after msg_id, the
+        // one-byte type and the two-byte vector prefix.
+        let at = MsgId::LEN + 1 + 2;
+        let mut swapped = wire.clone();
+        for offset in 0..MsgId::LEN {
+            let low = at + offset;
+            let high = at + MsgId::LEN + offset;
+            swapped.swap(low, high);
+        }
+        assert_ne!(swapped, wire);
+        assert!(matches!(
+            AppMessage::decode(&swapped),
+            Err(DagError::Codec(_) | DagError::MsgIdMismatch)
+        ));
+    }
+
+    #[test]
+    fn an_unknown_retention_class_is_a_decode_error_and_not_a_default() {
+        let message = AppMessage::seal(tbs(Parents::empty(), 7, b"hello")).unwrap();
+        let wire = message.encode().unwrap();
+        // retention_class sits after msg_id, type, the empty parents prefix,
+        // epoch and sent_at.
+        let at = MsgId::LEN + 1 + 2 + 8 + 8;
+        assert_eq!(*wire.get(at).unwrap(), RetentionClass::Chat.code());
+        let mut unknown = wire;
+        *unknown.get_mut(at).unwrap() = 0x7f;
+        assert_eq!(
+            AppMessage::decode(&unknown),
+            Err(DagError::Codec(CodecError::Decode)),
+            "an unrecognised retention class must not silently become CHAT"
+        );
+    }
+
+    #[test]
+    fn an_unknown_message_type_round_trips_because_the_set_is_open() {
+        let mut open = tbs(Parents::empty(), 7, b"hello");
+        open.message_type = MessageType::new(0xfe);
+        let message = AppMessage::seal(open).unwrap();
+        let decoded = AppMessage::decode(&message.encode().unwrap()).unwrap();
+        assert_eq!(decoded.tbs().message_type.code(), 0xfe);
+    }
+
+    #[test]
+    fn lower_hex_is_order_preserving_over_the_bytes() {
+        // The property `CLIENT-CONTRACT.md` §7's string comparison depends on.
+        let low = MsgId::new([0x09; MsgId::LEN]);
+        let high = MsgId::new([0xa0; MsgId::LEN]);
+        assert!(low < high);
+        assert!(low.to_lower_hex() < high.to_lower_hex());
+        assert_eq!(low.to_lower_hex().len(), 64);
+    }
+
+    #[test]
+    fn the_label_is_applied_with_no_separator() {
+        // §7's construction spelled out by hand, so the code below cannot
+        // silently start framing the label.
+        let tbs = tbs(Parents::empty(), 7, b"hello");
+        let encoded = tbs.encode_canonical().unwrap();
+        let mut hasher = Blake2b256::new();
+        hasher.update(b"free2z/msg/v1/msgid");
+        hasher.update(&encoded);
+        let expected: [u8; 32] = hasher.finalize().into();
+        assert_eq!(AppMessage::seal(tbs).unwrap().msg_id().as_bytes(), &expected);
+    }
+}

--- a/rs/crates/f2z-msg-dag/src/message.rs
+++ b/rs/crates/f2z-msg-dag/src/message.rs
@@ -184,7 +184,19 @@ impl DeserializeBytes for MsgId {
 /// no numbers; these are allocated in the order §7 lists them, starting at 1,
 /// with 0 left unassigned so that an all-zero buffer is not a valid `chat`.
 /// Listed in the pull request as an ambiguity that has to go back into §7.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    TlsSize,
+    TlsSerializeBytes,
+    TlsDeserializeBytes,
+)]
 pub struct MessageType(u8);
 
 impl MessageType {
@@ -303,7 +315,9 @@ impl DeserializeBytes for RetentionClass {
 ///
 /// It is also not usable for dedup even where it would appear to work:
 /// [`crate::dag::MessageDag`] dedups on [`MsgId`] only.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, TlsSize, TlsSerializeBytes, TlsDeserializeBytes,
+)]
 pub struct SentAt(u64);
 
 impl SentAt {
@@ -409,10 +423,12 @@ impl Parents {
         if ids.len() > Self::MAX {
             return Err(DagError::TooManyParents);
         }
-        let ascending = ids.windows(2).all(|pair| match (pair.first(), pair.get(1)) {
-            (Some(low), Some(high)) => low < high,
-            _ => true,
-        });
+        let ascending = ids
+            .windows(2)
+            .all(|pair| match (pair.first(), pair.get(1)) {
+                (Some(low), Some(high)) => low < high,
+                _ => true,
+            });
         if !ascending {
             return Err(DagError::ParentsNotCanonical);
         }
@@ -664,12 +680,8 @@ mod tests {
         // Hand-assemble the encoding with the parents out of order. Sorting on
         // receipt would change the bytes msg_id commits to, so this must be an
         // error and not a repair.
-        let ascending = AppMessage::seal(tbs(
-            Parents::new(vec![id(1), id(2)]).unwrap(),
-            7,
-            b"x",
-        ))
-        .unwrap();
+        let ascending =
+            AppMessage::seal(tbs(Parents::new(vec![id(1), id(2)]).unwrap(), 7, b"x")).unwrap();
         let wire = ascending.encode().unwrap();
 
         // Swap the two 32-byte parent ids in place. They sit after msg_id, the
@@ -734,6 +746,9 @@ mod tests {
         hasher.update(b"free2z/msg/v1/msgid");
         hasher.update(&encoded);
         let expected: [u8; 32] = hasher.finalize().into();
-        assert_eq!(AppMessage::seal(tbs).unwrap().msg_id().as_bytes(), &expected);
+        assert_eq!(
+            AppMessage::seal(tbs).unwrap().msg_id().as_bytes(),
+            &expected
+        );
     }
 }

--- a/rs/crates/f2z-msg-dag/src/order.rs
+++ b/rs/crates/f2z-msg-dag/src/order.rs
@@ -162,10 +162,10 @@ pub fn linearise(nodes: &[OrderNode]) -> Result<Vec<MsgId>, DagError> {
                 continue;
             };
             *degree = degree.saturating_sub(1);
-            if *degree == 0 {
-                if let Some(child_key) = held.get(child) {
-                    ready.push(Reverse(*child_key));
-                }
+            if *degree == 0
+                && let Some(child_key) = held.get(child)
+            {
+                ready.push(Reverse(*child_key));
             }
         }
     }

--- a/rs/crates/f2z-msg-dag/src/order.rs
+++ b/rs/crates/f2z-msg-dag/src/order.rs
@@ -1,0 +1,251 @@
+//! §7's ordering: a causal partial order, linearised deterministically.
+//!
+//! # The rule, quoted, because the two halves get conflated
+//!
+//! > **Causal ordering:** the DAG's partial order. For display, a deterministic
+//! > total order breaks ties by `(epoch, sender_leaf_index, msg_id)`.
+//! > Wall-clock timestamps are never used to order, because a clock is an
+//! > attacker-controlled input.
+//!
+//! Two rules, and the first one is primary. The DAG's partial order decides
+//! every pair of messages that are causally related. `(epoch,
+//! sender_leaf_index, msg_id)` decides the pairs that are **concurrent** — the
+//! ones the partial order leaves incomparable. It is the *tie*-break, and a
+//! tie is exactly the case where neither message is an ancestor of the other.
+//!
+//! # Why the tie-break alone is not the order
+//!
+//! Applying the sort key on its own — sorting the message set by the triple and
+//! nothing else — puts replies above the messages they reply to. The
+//! counterexample is two lines long and it is not exotic:
+//!
+//! - Bob is leaf 1. At epoch 7 he sends `A`.
+//! - Alice is leaf 0. She receives `A` and replies with `B`, `parents = [A]`,
+//!   still at epoch 7.
+//!
+//! Sort keys: `A = (7, 1, …)`, `B = (7, 0, …)`. `B` sorts first, so the reply
+//! renders above the message it answers, in every one-to-one conversation where
+//! the replier holds the lower leaf index — which is half of them. `A → B` is a
+//! causal edge, and the causal edge is what §7 says decides.
+//!
+//! This matters beyond aesthetics: [`crate::dag::MessageDag`] detects a gap
+//! from a `parents` hash it does not hold, and a transcript that can place a
+//! child before its parent makes "the hole is here" unanswerable.
+//!
+//! **`compareMessages` in `wallet/zuuli/src/lib/messaging/types.ts` implements
+//! the tie-break only**, which is what a JavaScript comparator can express — a
+//! `.sort()` comparator cannot see the graph. The two implementations therefore
+//! disagree on exactly the pairs above, and [`compare_sort_keys`] exists so the
+//! disagreement is a testable thing in this tree rather than a discovery
+//! somebody makes from a screenshot. See `tests/typescript_parity.rs`.
+//!
+//! # Determinism
+//!
+//! [`linearise`] is Kahn's algorithm with a min-heap keyed on [`SortKey`]. At
+//! every step the set of ready nodes is fully ordered by the sort key, so the
+//! output depends on the *graph and the keys* and on nothing else — not on
+//! insertion order, not on iteration order, not on a clock. That is what makes
+//! "every client that applies this rule to the same set of messages produces
+//! the same transcript" true rather than aspirational, and
+//! `tests/properties.rs` asserts it over random shuffles.
+//!
+//! A parent the receiver does not hold contributes **no** constraint: it is not
+//! in the graph, so it cannot be ordered against. The hole is reported
+//! separately, by [`crate::dag::MessageDag::detected_gaps`], and
+//! `CLIENT-CONTRACT.md` §7 is explicit that "a hole in the sort order is not a
+//! hole in the conversation and vice versa".
+
+use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap};
+use alloc::vec::Vec;
+use core::cmp::Reverse;
+
+use crate::error::DagError;
+use crate::message::MsgId;
+
+/// §7's tie-break key: `(epoch, sender_leaf_index, msg_id)`.
+///
+/// All three components are protocol-authenticated — `epoch` and
+/// `sender_leaf_index` come from MLS framing, `msg_id` is a hash commitment
+/// over the content. The sender's wall clock is not here and cannot be added:
+/// [`crate::message::SentAt`] has no `Ord`.
+///
+/// The derived `Ord` is field order, which is the specified order. Do not
+/// reorder the fields.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SortKey {
+    /// The MLS epoch the message was authored in.
+    pub epoch: u64,
+    /// The sender's MLS leaf index.
+    ///
+    /// **Not covered by `msg_id`.** It comes from the framing, not from the
+    /// hashed message, so a message learned through gap repair carries the
+    /// repairing peer's framing rather than the original sender's. See
+    /// [`crate::dag::DagEntry::from_repair`].
+    pub sender_leaf_index: u32,
+    /// The message's name.
+    pub msg_id: MsgId,
+}
+
+/// §7's tie-break, applied on its own.
+///
+/// This is `compareMessages` from `wallet/zuuli/src/lib/messaging/types.ts`,
+/// transcribed. It is **not** the display order — see the module note — and it
+/// is public for exactly two reasons: [`linearise`] needs it to break ties
+/// between concurrent messages, and a test needs to be able to show where the
+/// two implementations part company.
+#[must_use]
+pub fn compare_sort_keys(a: &SortKey, b: &SortKey) -> core::cmp::Ordering {
+    a.cmp(b)
+}
+
+/// One node of the graph to be ordered.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OrderNode {
+    /// The node's sort key.
+    pub key: SortKey,
+    /// The `msg_id`s this message referenced. Parents not present among the
+    /// nodes are ignored, because an absent message cannot be ordered against.
+    pub parents: Vec<MsgId>,
+}
+
+/// Linearise a set of messages into §7's display order.
+///
+/// A topological order of the causal DAG, with concurrent messages ordered by
+/// [`SortKey`]. Deterministic: the same set produces the same sequence on every
+/// client, in any delivery order.
+///
+/// # Errors
+///
+/// [`DagError::Cycle`] if the held messages contain a cycle. That requires a
+/// BLAKE2b-256 preimage cycle, so in practice it means the caller has fed this
+/// function something that is not a message graph. It is an error rather than a
+/// silent truncation because dropping messages from a transcript is worse than
+/// refusing to render one.
+pub fn linearise(nodes: &[OrderNode]) -> Result<Vec<MsgId>, DagError> {
+    let held: BTreeMap<MsgId, SortKey> = nodes
+        .iter()
+        .map(|node| (node.key.msg_id, node.key))
+        .collect();
+
+    // parent -> children, and the in-degree counted over *held* parents only.
+    let mut children: BTreeMap<MsgId, BTreeSet<MsgId>> = BTreeMap::new();
+    let mut indegree: BTreeMap<MsgId, usize> = BTreeMap::new();
+
+    for node in nodes {
+        let id = node.key.msg_id;
+        let mut degree = 0usize;
+        for parent in &node.parents {
+            if !held.contains_key(parent) {
+                continue;
+            }
+            if children.entry(*parent).or_default().insert(id) {
+                degree = degree.saturating_add(1);
+            }
+        }
+        indegree.insert(id, degree);
+    }
+
+    let mut ready: BinaryHeap<Reverse<SortKey>> = indegree
+        .iter()
+        .filter(|(_, degree)| **degree == 0)
+        .filter_map(|(id, _)| held.get(id).map(|key| Reverse(*key)))
+        .collect();
+
+    let mut out = Vec::with_capacity(held.len());
+    while let Some(Reverse(key)) = ready.pop() {
+        out.push(key.msg_id);
+        let Some(dependents) = children.get(&key.msg_id) else {
+            continue;
+        };
+        for child in dependents {
+            let Some(degree) = indegree.get_mut(child) else {
+                continue;
+            };
+            *degree = degree.saturating_sub(1);
+            if *degree == 0 {
+                if let Some(child_key) = held.get(child) {
+                    ready.push(Reverse(*child_key));
+                }
+            }
+        }
+    }
+
+    if out.len() != held.len() {
+        return Err(DagError::Cycle);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn id(byte: u8) -> MsgId {
+        MsgId::new([byte; MsgId::LEN])
+    }
+
+    fn node(byte: u8, epoch: u64, leaf: u32, parents: &[u8]) -> OrderNode {
+        OrderNode {
+            key: SortKey {
+                epoch,
+                sender_leaf_index: leaf,
+                msg_id: id(byte),
+            },
+            parents: parents.iter().copied().map(id).collect(),
+        }
+    }
+
+    /// The counterexample from the module note, as a test.
+    #[test]
+    fn a_reply_never_precedes_the_message_it_replies_to() {
+        // Bob (leaf 1) sends A; Alice (leaf 0) replies with B, same epoch.
+        let a = node(0xaa, 7, 1, &[]);
+        let b = node(0xbb, 7, 0, &[0xaa]);
+
+        // The tie-break alone would place the reply first.
+        assert!(compare_sort_keys(&b.key, &a.key).is_lt());
+
+        // The causal order does not.
+        let order = linearise(&[a.clone(), b.clone()]).unwrap();
+        assert_eq!(order, vec![id(0xaa), id(0xbb)]);
+    }
+
+    #[test]
+    fn concurrent_messages_fall_back_to_the_sort_key() {
+        // No edges between them: epoch, then leaf index, then msg_id.
+        let older_epoch = node(0xff, 6, 9, &[]);
+        let lower_leaf = node(0x01, 7, 0, &[]);
+        let higher_leaf = node(0x00, 7, 1, &[]);
+        let order = linearise(&[higher_leaf, lower_leaf, older_epoch]).unwrap();
+        assert_eq!(order, vec![id(0xff), id(0x01), id(0x00)]);
+    }
+
+    #[test]
+    fn a_parent_the_receiver_does_not_hold_imposes_no_constraint() {
+        let orphan = node(0x01, 7, 0, &[0xee]);
+        assert_eq!(linearise(&[orphan]).unwrap(), vec![id(0x01)]);
+    }
+
+    #[test]
+    fn a_cycle_is_reported_rather_than_truncating_the_transcript() {
+        let a = node(0x01, 7, 0, &[0x02]);
+        let b = node(0x02, 7, 0, &[0x01]);
+        assert_eq!(linearise(&[a, b]), Err(DagError::Cycle));
+    }
+
+    #[test]
+    fn the_order_is_a_linear_extension_of_a_deep_chain() {
+        // A chain built so that every sort key points the *wrong* way: each
+        // child has a strictly lower leaf index than its parent, so a
+        // key-only sort would reverse the whole conversation.
+        let mut nodes = Vec::new();
+        for step in 0u8..8 {
+            let leaf = u32::from(8u8.saturating_sub(step));
+            let parents: Vec<u8> = if step == 0 { vec![] } else { vec![step - 1] };
+            nodes.push(node(step, 7, leaf, &parents));
+        }
+        let expected: Vec<MsgId> = (0u8..8).map(id).collect();
+        assert_eq!(linearise(&nodes).unwrap(), expected);
+    }
+}

--- a/rs/crates/f2z-msg-dag/src/outbox.rs
+++ b/rs/crates/f2z-msg-dag/src/outbox.rs
@@ -1,0 +1,339 @@
+//! The bounded-window plaintext outbox that makes §7's repair possible.
+//!
+//! # Why the sender has to keep the plaintext
+//!
+//! §7: "the sender re-encrypts the original plaintext under the *current* epoch
+//! and replies `gap_response`. It does not replay old ciphertext, so repair
+//! does not undermine forward secrecy."
+//!
+//! That sentence is the whole design and it is worth reading twice. Replaying
+//! the original ciphertext would be trivial to implement and would quietly undo
+//! MLS's forward secrecy: an old ciphertext is decryptable by whoever holds the
+//! old epoch secrets, and the point of ratcheting is that nobody should still
+//! be able to use them. Re-encrypting means the repaired copy is protected by
+//! the *current* epoch's keys, exactly like a message sent today.
+//!
+//! The cost is that the sender must still have the plaintext. That is what this
+//! type is, and it is bounded on both axes: a time window and a count.
+//!
+//! # The interaction with §8, which is a trade-off and not a bug
+//!
+//! §8.1 makes retention a per-user local choice, and §8.4 states the
+//! consequence: "a short local TTL shortens the plaintext outbox window used
+//! for gap repair (§7), which means some detected gaps become unrecoverable.
+//! That is surfaced to the user as an explicit 'this message could not be
+//! recovered' marker rather than a silent hole."
+//!
+//! So [`RepairOutcome::Unrecoverable`] is a first-class answer here, not an
+//! error path. It carries *why*, because "I deleted it" and "I never had it"
+//! are different facts about a peer and only one of them is about retention.
+//! [`crate::dag::MessageDag::mark_unrecoverable`] is where it lands on the
+//! requester's side.
+//!
+//! # No clock
+//!
+//! Every method that depends on time takes `now_ms`. The crate reads no clock,
+//! which is what makes an expiry test a test rather than a wait, and what lets
+//! this compile for `wasm32-unknown-unknown`.
+
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+use core::fmt;
+
+use crate::message::MsgId;
+
+/// Why a message cannot be repaired.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum Unrecoverable {
+    /// The outbox window elapsed and the plaintext was dropped. §8.4's case:
+    /// the person who chose the short TTL made this trade-off.
+    WindowExpired,
+    /// The outbox was full and this entry was evicted to make room for newer
+    /// ones.
+    Evicted,
+    /// This device never held that message. Either it was not the sender, or
+    /// the requester is asking for something that does not exist.
+    NeverHeld,
+}
+
+impl fmt::Display for Unrecoverable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::WindowExpired => "the plaintext outbox window elapsed (ARCHITECTURE.md §8.4)",
+            Self::Evicted => "the plaintext was evicted when the outbox filled",
+            Self::NeverHeld => "this device never held that message",
+        })
+    }
+}
+
+/// The answer to one `gap_request` hash.
+///
+/// `Reencrypt` hands back the **plaintext**, not a ciphertext, and that is the
+/// point: the caller must put it through the MLS engine's current-epoch send
+/// path. There is deliberately no variant carrying stored ciphertext, so a
+/// future contributor cannot implement replay without first adding one and
+/// having to explain why.
+#[derive(Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RepairOutcome<'a> {
+    /// Re-encrypt these bytes under the current epoch and send them as a
+    /// `gap_response`.
+    Reencrypt(&'a [u8]),
+    /// §8.4: tell the requester, explicitly, that this one is gone.
+    Unrecoverable(Unrecoverable),
+}
+
+/// Hand-written: the `Reencrypt` arm holds a user's plaintext, and a derived
+/// `Debug` would render it as a list of decimal integers — which contains no
+/// hex, so a leak check that greps for hex would walk straight past a complete
+/// dump of the message. That is `f2z-codec`'s stated trap, and this is the one
+/// type in this crate that holds the message itself.
+impl fmt::Debug for RepairOutcome<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Reencrypt(plaintext) => {
+                write!(f, "Reencrypt(<redacted; {} bytes>)", plaintext.len())
+            }
+            Self::Unrecoverable(reason) => f.debug_tuple("Unrecoverable").field(reason).finish(),
+        }
+    }
+}
+
+/// One stored plaintext and when it was stored.
+#[derive(Clone, PartialEq, Eq)]
+struct OutboxEntry {
+    plaintext: Vec<u8>,
+    stored_at_ms: u64,
+}
+
+/// Hand-written for the same reason as [`RepairOutcome`]'s.
+impl fmt::Debug for OutboxEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OutboxEntry")
+            .field(
+                "plaintext",
+                &format_args!("<redacted; {} bytes>", self.plaintext.len()),
+            )
+            .field("stored_at_ms", &self.stored_at_ms)
+            .finish()
+    }
+}
+
+/// The sender's bounded-window store of plaintexts it may be asked to repair.
+///
+/// Bounded twice, on purpose:
+///
+/// - **In time**, by `window_ms`, which is the retention decision of §8.4. A
+///   window of `0` is legitimate and means "never repairable"; that is what a
+///   user who chose an aggressive local TTL has asked for.
+/// - **In count**, by `capacity`. Without it a chatty conversation is an
+///   unbounded plaintext buffer, which is a poor thing to leave on a phone
+///   whatever the TTL says. Eviction is oldest-first, and it is
+///   [`Unrecoverable::Evicted`] rather than a silent drop so the requester
+///   still gets a definite answer.
+#[derive(Clone, Debug)]
+pub struct PlaintextOutbox {
+    window_ms: u64,
+    capacity: usize,
+    entries: BTreeMap<MsgId, OutboxEntry>,
+    /// Everything this device has stored and no longer holds, with why. The
+    /// requester is owed an answer, and "I do not have it" without a reason is
+    /// how a silent hole starts.
+    forgotten: BTreeMap<MsgId, Unrecoverable>,
+}
+
+impl PlaintextOutbox {
+    /// A new outbox with a repair window and a capacity.
+    #[must_use]
+    pub fn new(window_ms: u64, capacity: usize) -> Self {
+        Self {
+            window_ms,
+            capacity,
+            entries: BTreeMap::new(),
+            forgotten: BTreeMap::new(),
+        }
+    }
+
+    /// The repair window, in milliseconds.
+    #[must_use]
+    pub const fn window_ms(&self) -> u64 {
+        self.window_ms
+    }
+
+    /// How many plaintexts are held.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether nothing is held.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Keep a plaintext against a possible repair request.
+    ///
+    /// Called by the sender for every message it sends. Storing also expires
+    /// anything already past the window, so a caller that never calls
+    /// [`PlaintextOutbox::expire`] still does not grow without bound.
+    pub fn store(&mut self, msg_id: MsgId, plaintext: Vec<u8>, now_ms: u64) {
+        self.expire(now_ms);
+        self.entries.insert(
+            msg_id,
+            OutboxEntry {
+                plaintext,
+                stored_at_ms: now_ms,
+            },
+        );
+        self.evict_to_capacity();
+    }
+
+    /// Drop everything stored more than `window_ms` before `now_ms`.
+    ///
+    /// Returns how many entries were dropped. The boundary is inclusive of the
+    /// window: an entry stored at `t` survives until `t + window_ms` and is
+    /// dropped at `t + window_ms + 1`, so a window of `0` keeps a message only
+    /// for the instant it was stored in.
+    pub fn expire(&mut self, now_ms: u64) -> usize {
+        let cutoff = now_ms.saturating_sub(self.window_ms);
+        let stale: Vec<MsgId> = self
+            .entries
+            .iter()
+            .filter(|(_, entry)| entry.stored_at_ms < cutoff)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in &stale {
+            self.entries.remove(id);
+            self.forgotten.insert(*id, Unrecoverable::WindowExpired);
+        }
+        stale.len()
+    }
+
+    /// Answer one `gap_request` hash (§7's repair).
+    ///
+    /// Expiry is applied first, so a caller cannot repair from a window that
+    /// has already elapsed merely by not having called [`PlaintextOutbox::expire`].
+    #[must_use]
+    pub fn repair(&mut self, msg_id: &MsgId, now_ms: u64) -> RepairOutcome<'_> {
+        self.expire(now_ms);
+        // Resolved before the entry lookup so the returned borrow of
+        // `self.entries` is the last thing this function touches.
+        let reason = self
+            .forgotten
+            .get(msg_id)
+            .copied()
+            .unwrap_or(Unrecoverable::NeverHeld);
+        match self.entries.get(msg_id) {
+            Some(entry) => RepairOutcome::Reencrypt(&entry.plaintext),
+            None => RepairOutcome::Unrecoverable(reason),
+        }
+    }
+
+    fn evict_to_capacity(&mut self) {
+        while self.entries.len() > self.capacity {
+            // Oldest first, ties broken by `msg_id` so eviction is
+            // deterministic rather than dependent on map iteration luck.
+            let Some(oldest) = self
+                .entries
+                .iter()
+                .min_by(|left, right| {
+                    left.1
+                        .stored_at_ms
+                        .cmp(&right.1.stored_at_ms)
+                        .then_with(|| left.0.cmp(right.0))
+                })
+                .map(|(id, _)| *id)
+            else {
+                break;
+            };
+            self.entries.remove(&oldest);
+            self.forgotten.insert(oldest, Unrecoverable::Evicted);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn id(byte: u8) -> MsgId {
+        MsgId::new([byte; MsgId::LEN])
+    }
+
+    #[test]
+    fn a_message_inside_the_window_is_repairable() {
+        let mut outbox = PlaintextOutbox::new(60_000, 8);
+        outbox.store(id(1), b"hello".to_vec(), 1_000);
+        assert_eq!(
+            outbox.repair(&id(1), 60_000),
+            RepairOutcome::Reencrypt(b"hello")
+        );
+    }
+
+    #[test]
+    fn an_expired_window_is_an_explicit_unrecoverable_state() {
+        let mut outbox = PlaintextOutbox::new(60_000, 8);
+        outbox.store(id(1), b"hello".to_vec(), 1_000);
+        assert_eq!(
+            outbox.repair(&id(1), 61_002),
+            RepairOutcome::Unrecoverable(Unrecoverable::WindowExpired),
+            "§8.4 requires the requester to be told, not left with a hole"
+        );
+    }
+
+    #[test]
+    fn a_message_this_device_never_sent_is_distinguished_from_an_expired_one() {
+        let mut outbox = PlaintextOutbox::new(60_000, 8);
+        assert_eq!(
+            outbox.repair(&id(9), 1_000),
+            RepairOutcome::Unrecoverable(Unrecoverable::NeverHeld)
+        );
+    }
+
+    #[test]
+    fn a_zero_window_means_nothing_is_repairable_after_the_instant_it_was_sent() {
+        let mut outbox = PlaintextOutbox::new(0, 8);
+        outbox.store(id(1), b"hello".to_vec(), 1_000);
+        assert_eq!(
+            outbox.repair(&id(1), 1_001),
+            RepairOutcome::Unrecoverable(Unrecoverable::WindowExpired)
+        );
+    }
+
+    #[test]
+    fn the_outbox_is_bounded_by_count_as_well_as_by_time() {
+        let mut outbox = PlaintextOutbox::new(u64::MAX, 2);
+        outbox.store(id(1), b"one".to_vec(), 10);
+        outbox.store(id(2), b"two".to_vec(), 20);
+        outbox.store(id(3), b"three".to_vec(), 30);
+        assert_eq!(outbox.len(), 2);
+        assert_eq!(
+            outbox.repair(&id(1), 30),
+            RepairOutcome::Unrecoverable(Unrecoverable::Evicted)
+        );
+        assert_eq!(outbox.repair(&id(3), 30), RepairOutcome::Reencrypt(b"three"));
+    }
+
+    #[test]
+    fn debug_never_renders_the_plaintext_in_any_base() {
+        let secret = vec![0xdeu8; 16];
+        let mut outbox = PlaintextOutbox::new(u64::MAX, 4);
+        outbox.store(id(1), secret.clone(), 0);
+
+        let rendered = alloc::format!("{outbox:?}");
+        let hex: alloc::string::String =
+            secret.iter().map(|b| alloc::format!("{b:02x}")).collect();
+        let decimal = "222, 222, 222, 222";
+        assert!(!rendered.contains(&hex));
+        assert!(!rendered.contains(decimal), "a decimal dump is a dump");
+
+        let outcome = outbox.repair(&id(1), 0);
+        let rendered = alloc::format!("{outcome:?}");
+        assert!(!rendered.contains(&hex));
+        assert!(!rendered.contains(decimal));
+        assert!(rendered.contains("16 bytes"));
+    }
+}

--- a/rs/crates/f2z-msg-dag/src/outbox.rs
+++ b/rs/crates/f2z-msg-dag/src/outbox.rs
@@ -314,7 +314,10 @@ mod tests {
             outbox.repair(&id(1), 30),
             RepairOutcome::Unrecoverable(Unrecoverable::Evicted)
         );
-        assert_eq!(outbox.repair(&id(3), 30), RepairOutcome::Reencrypt(b"three"));
+        assert_eq!(
+            outbox.repair(&id(3), 30),
+            RepairOutcome::Reencrypt(b"three")
+        );
     }
 
     #[test]
@@ -324,8 +327,7 @@ mod tests {
         outbox.store(id(1), secret.clone(), 0);
 
         let rendered = alloc::format!("{outbox:?}");
-        let hex: alloc::string::String =
-            secret.iter().map(|b| alloc::format!("{b:02x}")).collect();
+        let hex: alloc::string::String = secret.iter().map(|b| alloc::format!("{b:02x}")).collect();
         let decimal = "222, 222, 222, 222";
         assert!(!rendered.contains(&hex));
         assert!(!rendered.contains(decimal), "a decimal dump is a dump");

--- a/rs/crates/f2z-msg-dag/src/repair.rs
+++ b/rs/crates/f2z-msg-dag/src/repair.rs
@@ -352,8 +352,7 @@ mod tests {
 
     #[test]
     fn a_gap_request_round_trips_through_a_body() {
-        let request =
-            GapRequest::new(vec![MsgId::new([2; 32]), MsgId::new([1; 32])]).unwrap();
+        let request = GapRequest::new(vec![MsgId::new([2; 32]), MsgId::new([1; 32])]).unwrap();
         assert_eq!(
             request.hashes(),
             &[MsgId::new([1; 32]), MsgId::new([2; 32])],

--- a/rs/crates/f2z-msg-dag/src/repair.rs
+++ b/rs/crates/f2z-msg-dag/src/repair.rs
@@ -257,13 +257,21 @@ impl RepairEntry {
     ///
     /// - [`DagError::UnsolicitedRepair`] if this entry answers a hash that was
     ///   not requested.
+    /// - [`DagError::RepairRefused`] if the responder said it cannot supply it.
+    ///   That is §8.4 working, not a violation: the caller's next step is
+    ///   [`crate::dag::MessageDag::mark_unrecoverable`], not a retry.
     /// - [`DagError::MsgIdMismatch`] if the supplied bytes do not hash to it.
     /// - [`DagError::Codec`] if they are not a canonical `AppMessage`.
     pub fn accept(&self, requested: &MsgId) -> Result<AppMessage, DagError> {
         if self.msg_id != *requested {
             return Err(DagError::UnsolicitedRepair);
         }
+        if let Some(refusal) = self.refusal() {
+            return Err(DagError::RepairRefused(refusal));
+        }
         if self.refusal != 0 {
+            // A refusal code this build does not recognise. Not a message, and
+            // not something to guess at.
             return Err(DagError::UnsolicitedRepair);
         }
         // `AppMessage::decode` re-checks the commitment against the bytes, so
@@ -406,7 +414,11 @@ mod tests {
         let id = MsgId::new([4; 32]);
         let entry = RepairEntry::unrecoverable(id, RepairRefusal::NoLongerHeld).unwrap();
         assert_eq!(entry.refusal(), Some(RepairRefusal::NoLongerHeld));
-        assert_eq!(entry.accept(&id), Err(DagError::UnsolicitedRepair));
+        assert_eq!(
+            entry.accept(&id),
+            Err(DagError::RepairRefused(RepairRefusal::NoLongerHeld)),
+            "§8.4's answer is an answer, not a protocol violation"
+        );
 
         let response = GapResponse::new(vec![entry]);
         let body = response.to_body().unwrap();

--- a/rs/crates/f2z-msg-dag/src/repair.rs
+++ b/rs/crates/f2z-msg-dag/src/repair.rs
@@ -1,0 +1,432 @@
+//! `gap_request` and `gap_response` — the bodies of §7's repair exchange.
+//!
+//! These are the `body` of an [`AppMessage`] whose `type` is
+//! [`MessageType::GAP_REQUEST`] or [`MessageType::GAP_RESPONSE`]. They travel
+//! inside MLS like everything else, so they are confidential and authenticated
+//! by the sender's leaf key.
+//!
+//! # The check that makes repair safe to accept
+//!
+//! A repaired message arrives outside its original framing: MLS authenticated
+//! the `gap_response`, not the message inside it. What stops a peer answering
+//! "here is the message you missed" with something the original sender never
+//! wrote is not the framing — it is that the requester **already knows the
+//! name** of what it is missing. A dangling parent *is* a `msg_id`, `msg_id` is
+//! a BLAKE2b-256 commitment over the content, and
+//! [`GapResponse::accept`] refuses anything that does not hash to the id that
+//! was asked for.
+//!
+//! That is a real property and it is worth stating precisely, because it is
+//! narrower than it first looks. It proves the **content** is the content the
+//! original sender committed to. It does not prove who is repairing, and it
+//! does not recover the original `sender_leaf_index` — see
+//! [`crate::dag::DagEntry::from_repair`] for the ordering consequence, which is
+//! the one open question §7 leaves here.
+//!
+//! # Every hash gets an answer
+//!
+//! §8.4 requires an unrecoverable gap to become an explicit marker rather than
+//! a silent hole, so a [`GapResponse`] answers *every* requested hash: either
+//! with the original message or with [`RepairEntry::Unrecoverable`]. A
+//! responder that simply omits what it cannot supply leaves the requester
+//! unable to distinguish "gone" from "still in flight", which is the
+//! distinction §8.4 exists to preserve.
+
+use alloc::vec::Vec;
+use core::fmt;
+
+use f2z_codec::canonical::Canonical;
+use f2z_codec::types::Body;
+use f2z_codec::vec::VecU16;
+use tls_codec::{
+    DeserializeBytes, Error as TlsError, SerializeBytes, Size, TlsDeserializeBytes,
+    TlsSerializeBytes, TlsSize,
+};
+
+use crate::error::DagError;
+use crate::message::{AppMessage, MessageType, MsgId};
+use crate::outbox::Unrecoverable;
+
+// `tls_codec`'s derive macros build their error strings with `format!`.
+use alloc::format;
+
+/// §7's `gap_request{hashes}`.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct GapRequest {
+    hashes: VecU16<MsgId>,
+}
+
+impl GapRequest {
+    /// The most hashes one request may carry, capped by the length prefix.
+    pub const MAX: usize = 2047;
+
+    /// Build a request over a set of missing hashes.
+    ///
+    /// Sorted and deduplicated, for the same reason
+    /// [`crate::message::Parents`] is: this is the body of a message whose
+    /// `msg_id` hashes it, so the same missing set must produce the same bytes.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::TooManyParents`] above [`GapRequest::MAX`].
+    pub fn new(mut hashes: Vec<MsgId>) -> Result<Self, DagError> {
+        hashes.sort_unstable();
+        hashes.dedup();
+        if hashes.len() > Self::MAX {
+            return Err(DagError::TooManyParents);
+        }
+        Ok(Self {
+            hashes: VecU16::new(hashes),
+        })
+    }
+
+    /// The requested hashes, ascending.
+    #[must_use]
+    pub fn hashes(&self) -> &[MsgId] {
+        self.hashes.as_slice()
+    }
+
+    /// Encode as the `body` of a `gap_request` message.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::Codec`] if the structure exceeds a length prefix.
+    pub fn to_body(&self) -> Result<Body, DagError> {
+        Ok(Body::new(self.encode_canonical()?)?)
+    }
+
+    /// Decode from a `gap_request` body, with re-encode equality.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::Codec`] if the bytes are not a canonical `GapRequest`.
+    pub fn from_body(body: &Body) -> Result<Self, DagError> {
+        Ok(f2z_codec::decode_canonical::<Self>(body.as_slice())?.into_value())
+    }
+}
+
+/// Why a responder could not supply a message, on the wire.
+///
+/// A separate type from [`Unrecoverable`] on purpose: that one is the local
+/// outbox's private bookkeeping and includes `Evicted`, which tells a requester
+/// something about the responder's memory pressure that it has no business
+/// knowing. This is the reduced set that goes over the wire.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum RepairRefusal {
+    /// The responder no longer holds the plaintext (§8.4).
+    NoLongerHeld,
+    /// The responder never held it — it was not the sender.
+    NotMine,
+}
+
+impl RepairRefusal {
+    /// The wire codepoint.
+    #[must_use]
+    pub const fn code(self) -> u8 {
+        match self {
+            Self::NoLongerHeld => 1,
+            Self::NotMine => 2,
+        }
+    }
+
+    /// Resolve a codepoint.
+    #[must_use]
+    pub const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::NoLongerHeld),
+            2 => Some(Self::NotMine),
+            _ => None,
+        }
+    }
+
+    /// The refusal a local [`Unrecoverable`] becomes on the wire.
+    ///
+    /// `Evicted` and `WindowExpired` collapse to one code deliberately. Both
+    /// mean "gone"; telling a peer *which* leaks the responder's local
+    /// retention setting and its buffer pressure, and `THREAT-MODEL.md`'s
+    /// metadata ambition does not spend anything on distinctions the requester
+    /// cannot act on.
+    #[must_use]
+    pub const fn from_local(reason: Unrecoverable) -> Self {
+        match reason {
+            Unrecoverable::WindowExpired | Unrecoverable::Evicted => Self::NoLongerHeld,
+            Unrecoverable::NeverHeld => Self::NotMine,
+        }
+    }
+}
+
+impl Size for RepairRefusal {
+    fn tls_serialized_len(&self) -> usize {
+        1
+    }
+}
+
+impl SerializeBytes for RepairRefusal {
+    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        self.code().tls_serialize()
+    }
+}
+
+impl DeserializeBytes for RepairRefusal {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), TlsError> {
+        let (code, rest) = u8::tls_deserialize_bytes(bytes)?;
+        let refusal = Self::from_code(code).ok_or(TlsError::UnknownValue(u64::from(code)))?;
+        Ok((refusal, rest))
+    }
+}
+
+/// One answer inside a [`GapResponse`].
+#[derive(Clone, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct RepairEntry {
+    msg_id: MsgId,
+    /// The re-encoded original message, or empty when `refusal` is set.
+    original: Body,
+    /// `0` for "supplied", otherwise a [`RepairRefusal`] code.
+    ///
+    /// Spelled as a raw `u8` rather than an `Option<RepairRefusal>` because
+    /// `tls_codec`'s derive has no optional; `0` is not a valid refusal code,
+    /// so the two states cannot be confused.
+    refusal: u8,
+}
+
+/// Hand-written: `original` is a `Body`, which redacts itself, but this type
+/// would otherwise be one field edit away from a derived `Debug` over raw
+/// bytes. Stated explicitly so the redaction is a decision.
+impl fmt::Debug for RepairEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RepairEntry")
+            .field("msg_id", &self.msg_id)
+            .field(
+                "original",
+                &format_args!("<redacted; {} bytes>", self.original.len()),
+            )
+            .field("refusal", &RepairRefusal::from_code(self.refusal))
+            .finish()
+    }
+}
+
+impl RepairEntry {
+    /// The message this entry answers for.
+    #[must_use]
+    pub const fn msg_id(&self) -> MsgId {
+        self.msg_id
+    }
+
+    /// A supplied message: the **re-encoded original**, which the responder
+    /// has just re-encrypted under the current epoch by sending this at all.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::Codec`] if the message exceeds a length prefix.
+    pub fn supplied(message: &AppMessage) -> Result<Self, DagError> {
+        Ok(Self {
+            msg_id: message.msg_id(),
+            original: Body::new(message.encode()?)?,
+            refusal: 0,
+        })
+    }
+
+    /// A refusal (§8.4).
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::Codec`] never, in practice; the empty body cannot overflow.
+    pub fn unrecoverable(msg_id: MsgId, refusal: RepairRefusal) -> Result<Self, DagError> {
+        Ok(Self {
+            msg_id,
+            original: Body::new(Vec::new())?,
+            refusal: refusal.code(),
+        })
+    }
+
+    /// The refusal, if this entry is one.
+    #[must_use]
+    pub const fn refusal(&self) -> Option<RepairRefusal> {
+        RepairRefusal::from_code(self.refusal)
+    }
+
+    /// Verify and take the repaired message.
+    ///
+    /// The `msg_id` the entry claims must be the one that was requested, and
+    /// the bytes must hash to it. Both checks, in that order, because the
+    /// second is the expensive one and the first is what makes the response
+    /// *solicited*.
+    ///
+    /// # Errors
+    ///
+    /// - [`DagError::UnsolicitedRepair`] if this entry answers a hash that was
+    ///   not requested.
+    /// - [`DagError::MsgIdMismatch`] if the supplied bytes do not hash to it.
+    /// - [`DagError::Codec`] if they are not a canonical `AppMessage`.
+    pub fn accept(&self, requested: &MsgId) -> Result<AppMessage, DagError> {
+        if self.msg_id != *requested {
+            return Err(DagError::UnsolicitedRepair);
+        }
+        if self.refusal != 0 {
+            return Err(DagError::UnsolicitedRepair);
+        }
+        // `AppMessage::decode` re-checks the commitment against the bytes, so
+        // the equality below is what binds it to the *requested* id rather than
+        // to whatever id the responder chose to put in the entry.
+        let message = AppMessage::decode(self.original.as_slice())?;
+        if message.msg_id() != *requested {
+            return Err(DagError::MsgIdMismatch);
+        }
+        Ok(message)
+    }
+}
+
+/// §7's `gap_response`: one entry per requested hash.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct GapResponse {
+    entries: VecU16<RepairEntry>,
+}
+
+impl GapResponse {
+    /// Build a response.
+    #[must_use]
+    pub fn new(entries: Vec<RepairEntry>) -> Self {
+        Self {
+            entries: VecU16::new(entries),
+        }
+    }
+
+    /// The entries.
+    #[must_use]
+    pub fn entries(&self) -> &[RepairEntry] {
+        self.entries.as_slice()
+    }
+
+    /// Encode as the `body` of a `gap_response` message.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::Codec`] if the structure exceeds a length prefix.
+    pub fn to_body(&self) -> Result<Body, DagError> {
+        Ok(Body::new(self.encode_canonical()?)?)
+    }
+
+    /// Decode from a `gap_response` body, with re-encode equality.
+    ///
+    /// # Errors
+    ///
+    /// [`DagError::Codec`] if the bytes are not a canonical `GapResponse`.
+    pub fn from_body(body: &Body) -> Result<Self, DagError> {
+        Ok(f2z_codec::decode_canonical::<Self>(body.as_slice())?.into_value())
+    }
+
+    /// Find the entry answering one requested hash.
+    #[must_use]
+    pub fn entry_for(&self, msg_id: &MsgId) -> Option<&RepairEntry> {
+        self.entries
+            .as_slice()
+            .iter()
+            .find(|entry| entry.msg_id() == *msg_id)
+    }
+}
+
+/// Which [`MessageType`] carries a [`GapRequest`].
+pub const GAP_REQUEST_TYPE: MessageType = MessageType::GAP_REQUEST;
+
+/// Which [`MessageType`] carries a [`GapResponse`].
+pub const GAP_RESPONSE_TYPE: MessageType = MessageType::GAP_RESPONSE;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{AppMessageTbs, Parents, RetentionClass, SentAt};
+    use alloc::vec;
+
+    fn message(body: &[u8]) -> AppMessage {
+        AppMessage::seal(AppMessageTbs {
+            message_type: MessageType::CHAT,
+            parents: Parents::empty(),
+            epoch: 7,
+            sent_at: SentAt::new(0),
+            retention_class: RetentionClass::Chat,
+            body: Body::new(body.to_vec()).unwrap(),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn a_gap_request_round_trips_through_a_body() {
+        let request =
+            GapRequest::new(vec![MsgId::new([2; 32]), MsgId::new([1; 32])]).unwrap();
+        assert_eq!(
+            request.hashes(),
+            &[MsgId::new([1; 32]), MsgId::new([2; 32])],
+            "sorted, so the same missing set produces the same bytes"
+        );
+        let body = request.to_body().unwrap();
+        assert_eq!(GapRequest::from_body(&body).unwrap(), request);
+    }
+
+    #[test]
+    fn a_repeated_hash_is_collapsed_rather_than_asked_for_twice() {
+        let id = MsgId::new([3; 32]);
+        assert_eq!(GapRequest::new(vec![id, id, id]).unwrap().hashes(), &[id]);
+    }
+
+    #[test]
+    fn a_supplied_entry_verifies_against_the_requested_hash() {
+        let original = message(b"the missing one");
+        let entry = RepairEntry::supplied(&original).unwrap();
+        assert_eq!(entry.accept(&original.msg_id()).unwrap(), original);
+    }
+
+    #[test]
+    fn a_substituted_message_is_refused_even_though_it_is_well_formed() {
+        // The whole point of the commitment: a peer answering with a *valid*
+        // message that is not the one asked for gets nowhere.
+        let asked_for = message(b"the missing one");
+        let substituted = message(b"something else entirely");
+
+        let mut entry = RepairEntry::supplied(&substituted).unwrap();
+        // Pretend the responder relabelled it with the requested id.
+        entry.msg_id = asked_for.msg_id();
+        assert_eq!(
+            entry.accept(&asked_for.msg_id()),
+            Err(DagError::MsgIdMismatch)
+        );
+    }
+
+    #[test]
+    fn an_answer_to_a_hash_nobody_asked_about_is_refused() {
+        let original = message(b"unsolicited");
+        let entry = RepairEntry::supplied(&original).unwrap();
+        assert_eq!(
+            entry.accept(&MsgId::new([9; 32])),
+            Err(DagError::UnsolicitedRepair)
+        );
+    }
+
+    #[test]
+    fn a_refusal_round_trips_and_never_yields_a_message() {
+        let id = MsgId::new([4; 32]);
+        let entry = RepairEntry::unrecoverable(id, RepairRefusal::NoLongerHeld).unwrap();
+        assert_eq!(entry.refusal(), Some(RepairRefusal::NoLongerHeld));
+        assert_eq!(entry.accept(&id), Err(DagError::UnsolicitedRepair));
+
+        let response = GapResponse::new(vec![entry]);
+        let body = response.to_body().unwrap();
+        let decoded = GapResponse::from_body(&body).unwrap();
+        assert_eq!(
+            decoded.entry_for(&id).unwrap().refusal(),
+            Some(RepairRefusal::NoLongerHeld)
+        );
+    }
+
+    #[test]
+    fn the_wire_refusal_does_not_distinguish_expiry_from_eviction() {
+        assert_eq!(
+            RepairRefusal::from_local(Unrecoverable::WindowExpired),
+            RepairRefusal::from_local(Unrecoverable::Evicted)
+        );
+        assert_eq!(
+            RepairRefusal::from_local(Unrecoverable::NeverHeld),
+            RepairRefusal::NotMine
+        );
+    }
+}

--- a/rs/crates/f2z-msg-dag/tests/properties.rs
+++ b/rs/crates/f2z-msg-dag/tests/properties.rs
@@ -1,0 +1,438 @@
+//! Properties over random interleavings, not worked examples.
+//!
+//! A worked example proves the code does the right thing on the graph its
+//! author drew. The interesting failures in a causal-ordering layer are the
+//! graphs nobody would draw: a message whose parents span three senders and two
+//! epochs, delivered fifth, after the message that depends on it, twice, from
+//! two relays. So every property below is generated — a random DAG, a random
+//! delivery order, a random set of drops — and asserted over the whole space.
+//!
+//! Each `proptest!` block below is one of the acceptance criteria for
+//! `ARCHITECTURE.md` §7.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use f2z_codec::types::Body;
+use f2z_msg_dag::{
+    AppMessage, AppMessageTbs, DagEntry, Insertion, MessageDag, MessageType, MsgId, Parents,
+    RetentionClass, SentAt,
+};
+use proptest::prelude::*;
+
+/// One authored message plus the framing facts a receiver would learn from MLS.
+#[derive(Clone, Debug)]
+struct Authored {
+    message: AppMessage,
+    epoch: u64,
+    leaf: u32,
+}
+
+impl Authored {
+    fn entry(&self) -> DagEntry {
+        DagEntry::from_delivered(&self.message, self.epoch, self.leaf).unwrap()
+    }
+
+    fn msg_id(&self) -> MsgId {
+        self.message.msg_id()
+    }
+}
+
+/// Build a random causal DAG.
+///
+/// Each message picks its parents from *earlier* messages only, which is what
+/// causality means and is what a real sender's head set produces. Epochs are
+/// non-decreasing along the authoring order for the same reason: a sender
+/// cannot author in an epoch it has not reached.
+///
+/// The leaf indices are deliberately drawn to make the sort key fight the
+/// causal order as often as possible — a reply from a low leaf index to a high
+/// one is the case where the tie-break alone gets the transcript wrong.
+fn authored_dag(count: usize) -> impl Strategy<Value = Vec<Authored>> {
+    let plan = proptest::collection::vec((0u32..4, 0u64..3, any::<u64>(), 0u8..100), count);
+    plan.prop_map(|rows| {
+        let mut out: Vec<Authored> = Vec::new();
+        let mut epoch = 0u64;
+        for (index, (leaf, epoch_step, sent_at, parent_dice)) in rows.into_iter().enumerate() {
+            epoch = epoch.saturating_add(epoch_step);
+
+            // Parents: a subset of the messages authored so far, chosen so that
+            // roughly a third of messages fork and the rest chain.
+            let mut parents: Vec<MsgId> = Vec::new();
+            if !out.is_empty() {
+                let take = usize::from(parent_dice % 3)
+                    .saturating_add(1)
+                    .min(out.len());
+                for step in 0..take {
+                    let at = out
+                        .len()
+                        .saturating_sub(1)
+                        .saturating_sub(step.saturating_mul(usize::from(parent_dice % 2) + 1));
+                    if let Some(candidate) = out.get(at)
+                        && !parents.contains(&candidate.msg_id())
+                    {
+                        parents.push(candidate.msg_id());
+                    }
+                }
+            }
+
+            let message = AppMessage::seal(AppMessageTbs {
+                message_type: MessageType::CHAT,
+                parents: Parents::new(parents).unwrap(),
+                epoch,
+                // Deliberately random and deliberately unordered. If anything
+                // in this crate started ordering by it, these properties would
+                // fail — which is the second line of defence behind `SentAt`
+                // having no `Ord` at all.
+                sent_at: SentAt::new(sent_at),
+                retention_class: RetentionClass::Chat,
+                body: Body::new(format!("m{index}").into_bytes()).unwrap(),
+            })
+            .unwrap();
+
+            out.push(Authored {
+                message,
+                epoch,
+                leaf,
+            });
+        }
+        out
+    })
+}
+
+/// A permutation of `0..len`, for shuffling the delivery order.
+fn permutation(len: usize) -> impl Strategy<Value = Vec<usize>> {
+    Just((0..len).collect::<Vec<usize>>()).prop_shuffle()
+}
+
+fn ancestors(authored: &[Authored]) -> BTreeMap<MsgId, BTreeSet<MsgId>> {
+    let mut out: BTreeMap<MsgId, BTreeSet<MsgId>> = BTreeMap::new();
+    for item in authored {
+        let mut set: BTreeSet<MsgId> = BTreeSet::new();
+        for parent in item.message.tbs().parents.as_slice() {
+            set.insert(*parent);
+            if let Some(grand) = out.get(parent) {
+                set.extend(grand.iter().copied());
+            }
+        }
+        out.insert(item.msg_id(), set);
+    }
+    out
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// **Ordering is deterministic and total across shuffled delivery orders.**
+    ///
+    /// The same set of messages, delivered in any order, produces the same
+    /// transcript. This is §7's "every client that applies this rule to the
+    /// same set of messages produces the same transcript" — the property that
+    /// makes the DAG an ordering rule rather than a suggestion.
+    #[test]
+    fn the_display_order_does_not_depend_on_the_delivery_order(
+        authored in authored_dag(12),
+        first in permutation(12),
+        second in permutation(12),
+    ) {
+        let mut one = MessageDag::new();
+        for at in &first {
+            one.insert(authored[*at].entry());
+        }
+        let mut other = MessageDag::new();
+        for at in &second {
+            other.insert(authored[*at].entry());
+        }
+
+        let left = one.display_order().unwrap();
+        let right = other.display_order().unwrap();
+        prop_assert_eq!(&left, &right);
+        prop_assert_eq!(left.len(), authored.len());
+
+        // Total: no repeats, everything present.
+        let unique: BTreeSet<MsgId> = left.iter().copied().collect();
+        prop_assert_eq!(unique.len(), left.len());
+    }
+
+    /// **The display order is a linear extension of the causal order.**
+    ///
+    /// Every ancestor precedes every descendant. This is the half of §7 that a
+    /// sort-key-only comparator does not have — see `typescript_parity.rs`.
+    #[test]
+    fn every_ancestor_precedes_every_descendant(
+        authored in authored_dag(12),
+        order in permutation(12),
+    ) {
+        let mut dag = MessageDag::new();
+        for at in &order {
+            dag.insert(authored[*at].entry());
+        }
+
+        let transcript = dag.display_order().unwrap();
+        let position: BTreeMap<MsgId, usize> = transcript
+            .iter()
+            .enumerate()
+            .map(|(at, id)| (*id, at))
+            .collect();
+
+        for (id, forebears) in ancestors(&authored) {
+            for forebear in forebears {
+                prop_assert!(
+                    position[&forebear] < position[&id],
+                    "a descendant rendered above its ancestor"
+                );
+            }
+        }
+    }
+
+    /// **Every dropped middle message produces exactly one gap signal.**
+    ///
+    /// One dropped message, however many later messages reference it, and
+    /// however many times each of those arrives, yields one hash in one
+    /// `gap_request` — and never a second one.
+    #[test]
+    fn a_dropped_middle_message_produces_exactly_one_gap_signal(
+        authored in authored_dag(12),
+        order in permutation(12),
+        drop_at in 0usize..12,
+        repeats in 1usize..4,
+    ) {
+        let dropped = authored[drop_at].msg_id();
+        let mut dag = MessageDag::new();
+
+        let mut signalled: Vec<MsgId> = Vec::new();
+        for at in &order {
+            if *at == drop_at {
+                continue;
+            }
+            for _ in 0..repeats {
+                if let Insertion::Accepted { newly_missing } = dag.insert(authored[*at].entry()) {
+                    signalled.extend(newly_missing);
+                }
+            }
+        }
+
+        let referenced = authored
+            .iter()
+            .enumerate()
+            .any(|(at, item)| {
+                at != drop_at && item.message.tbs().parents.as_slice().contains(&dropped)
+            });
+
+        if referenced {
+            prop_assert_eq!(
+                signalled.iter().filter(|id| **id == dropped).count(),
+                1,
+                "one hole must produce one signal, not one per referrer"
+            );
+            // A shuffled delivery order also produces *transient* gaps — a
+            // child arriving before its parent — and those close by themselves
+            // when the parent lands. What must survive to the end is exactly
+            // the one message that never arrives.
+            prop_assert_eq!(dag.detected_gaps(), vec![dropped]);
+            prop_assert_eq!(dag.take_gap_request(), vec![dropped]);
+            prop_assert!(
+                dag.take_gap_request().is_empty(),
+                "a gap already asked about must never be asked about twice"
+            );
+        } else {
+            // Nothing references it: this is the tail-truncation case, and it
+            // is undetectable. See `tail_truncation.rs`.
+            prop_assert!(!signalled.contains(&dropped));
+            prop_assert!(dag.detected_gaps().is_empty());
+        }
+    }
+
+    /// **Dedup holds when the same `msg_id` arrives *k* times.**
+    ///
+    /// §9.4's *k*-relay fan-out. The transcript, the gap set and the head set
+    /// must all be identical to the single-delivery case.
+    #[test]
+    fn k_deliveries_of_the_same_message_are_indistinguishable_from_one(
+        authored in authored_dag(10),
+        order in permutation(10),
+        k in 2usize..6,
+    ) {
+        let mut once = MessageDag::new();
+        for at in &order {
+            once.insert(authored[*at].entry());
+        }
+
+        let mut many = MessageDag::new();
+        let mut duplicates = 0usize;
+        for at in &order {
+            for round in 0..k {
+                let outcome = many.insert(authored[*at].entry());
+                if round > 0 {
+                    prop_assert_eq!(outcome, Insertion::Duplicate);
+                    duplicates += 1;
+                }
+            }
+        }
+
+        prop_assert_eq!(duplicates, authored.len() * (k - 1));
+        prop_assert_eq!(many.len(), once.len());
+        prop_assert_eq!(many.display_order().unwrap(), once.display_order().unwrap());
+        prop_assert_eq!(many.heads(), once.heads());
+        prop_assert_eq!(many.detected_gaps(), once.detected_gaps());
+    }
+
+    /// **A repaired message closes the gap and lands in the right place.**
+    ///
+    /// The message the receiver missed, admitted through the repair path, must
+    /// produce the same transcript as if it had never been dropped — because
+    /// the repairing peer here *is* the original sender, which is the case §7
+    /// specifies.
+    #[test]
+    fn a_repaired_message_restores_the_transcript_exactly(
+        authored in authored_dag(10),
+        order in permutation(10),
+        drop_at in 0usize..10,
+    ) {
+        let mut complete = MessageDag::new();
+        for at in &order {
+            complete.insert(authored[*at].entry());
+        }
+
+        let mut repaired = MessageDag::new();
+        for at in &order {
+            if *at != drop_at {
+                repaired.insert(authored[*at].entry());
+            }
+        }
+        // Repair arrives last, out of order, as it would in practice.
+        repaired.insert(DagEntry::from_repair(
+            &authored[drop_at].message,
+            authored[drop_at].leaf,
+        ));
+
+        prop_assert!(!repaired.has_detected_gaps());
+        prop_assert_eq!(
+            repaired.display_order().unwrap(),
+            complete.display_order().unwrap()
+        );
+    }
+
+    /// **An adversarial clock cannot reorder a causally ordered conversation.**
+    ///
+    /// The sharpest thing a lying `sent_at` could buy an attacker is a message
+    /// of theirs rendered above one it actually answers. Here the conversation
+    /// is a chain — every message references the one before it — so causality
+    /// decides every pair, and the claimed clock is drawn adversarially:
+    /// ascending, descending, all-identical, and uniformly random. The
+    /// transcript is the chain in all four cases.
+    ///
+    /// The ids differ between the four runs, because `sent_at` is *inside* the
+    /// hash — advisory means "never ordered by", not "not committed to" — so
+    /// the assertion is over authoring positions rather than over ids.
+    #[test]
+    fn an_adversarial_clock_cannot_reorder_a_causal_chain(
+        leaves in proptest::collection::vec(0u32..4, 8),
+        epoch_steps in proptest::collection::vec(0u64..3, 8),
+        noise in proptest::collection::vec(any::<u64>(), 8),
+        order in permutation(8),
+    ) {
+        let chain = |clock: &dyn Fn(usize) -> u64| -> Vec<Authored> {
+            let mut out: Vec<Authored> = Vec::new();
+            let mut epoch = 0u64;
+            for index in 0..8usize {
+                epoch = epoch.saturating_add(epoch_steps[index]);
+                let parents = match out.last() {
+                    None => Parents::empty(),
+                    Some(previous) => Parents::new(vec![previous.msg_id()]).unwrap(),
+                };
+                let message = AppMessage::seal(AppMessageTbs {
+                    message_type: MessageType::CHAT,
+                    parents,
+                    epoch,
+                    sent_at: SentAt::new(clock(index)),
+                    retention_class: RetentionClass::Chat,
+                    body: Body::new(format!("m{index}").into_bytes()).unwrap(),
+                })
+                .unwrap();
+                out.push(Authored { message, epoch, leaf: leaves[index] });
+            }
+            out
+        };
+
+        let transcript = |set: &[Authored]| -> Vec<usize> {
+            let mut dag = MessageDag::new();
+            for at in &order {
+                dag.insert(set[*at].entry());
+            }
+            dag.display_order()
+                .unwrap()
+                .iter()
+                .map(|id| set.iter().position(|item| item.msg_id() == *id).unwrap())
+                .collect()
+        };
+
+        let authoring_order: Vec<usize> = (0..8).collect();
+
+        let ascending: &dyn Fn(usize) -> u64 = &|index| 1_000u64.saturating_add(index as u64);
+        let descending: &dyn Fn(usize) -> u64 = &|index| 1_000_000u64.saturating_sub(index as u64);
+        let frozen: &dyn Fn(usize) -> u64 = &|_| 0;
+        let random: &dyn Fn(usize) -> u64 = &|index| noise[index];
+
+        prop_assert_eq!(transcript(&chain(ascending)), authoring_order.clone());
+        prop_assert_eq!(transcript(&chain(descending)), authoring_order.clone());
+        prop_assert_eq!(transcript(&chain(frozen)), authoring_order.clone());
+        prop_assert_eq!(transcript(&chain(random)), authoring_order.clone());
+    }
+
+    /// **Two concurrent messages are separated by the sort key, never by the
+    /// clock.**
+    ///
+    /// The other half of the previous property. With no causal edge between
+    /// them, §7 says `(epoch, sender_leaf_index, msg_id)` decides — and the
+    /// claimed clock, however it is drawn, does not appear in that tuple.
+    #[test]
+    fn two_concurrent_messages_are_separated_by_the_sort_key(
+        left_leaf in 0u32..4,
+        right_leaf in 0u32..4,
+        left_epoch in 0u64..3,
+        right_epoch in 0u64..3,
+        left_clock in any::<u64>(),
+        right_clock in any::<u64>(),
+        swap in any::<bool>(),
+    ) {
+        let make = |epoch: u64, clock: u64, tag: &str| {
+            AppMessage::seal(AppMessageTbs {
+                message_type: MessageType::CHAT,
+                parents: Parents::empty(),
+                epoch,
+                sent_at: SentAt::new(clock),
+                retention_class: RetentionClass::Chat,
+                body: Body::new(tag.as_bytes().to_vec()).unwrap(),
+            })
+            .unwrap()
+        };
+
+        let left = Authored { message: make(left_epoch, left_clock, "left"), epoch: left_epoch, leaf: left_leaf };
+        let right = Authored { message: make(right_epoch, right_clock, "right"), epoch: right_epoch, leaf: right_leaf };
+
+        let mut dag = MessageDag::new();
+        if swap {
+            dag.insert(right.entry());
+            dag.insert(left.entry());
+        } else {
+            dag.insert(left.entry());
+            dag.insert(right.entry());
+        }
+
+        let transcript = dag.display_order().unwrap();
+        let expected_first = if left.entry().sort_key() < right.entry().sort_key() {
+            left.msg_id()
+        } else {
+            right.msg_id()
+        };
+        prop_assert_eq!(transcript[0], expected_first);
+    }
+}

--- a/rs/crates/f2z-msg-dag/tests/redaction.rs
+++ b/rs/crates/f2z-msg-dag/tests/redaction.rs
@@ -1,0 +1,164 @@
+//! Nothing in this crate renders a message's bytes through `Debug`.
+//!
+//! # The trap, restated because it produces a *passing* test over a leaking type
+//!
+//! `f2z-codec`'s `tests/redaction.rs` documents it and `f2z-msg-mls`'s repeats
+//! it: a derived `Debug` over `Vec<u8>` or `[u8; N]` prints a list of **decimal**
+//! integers. `[171, 205, 239, 18]` contains no hex at all, so a redaction check
+//! that greps for `abcdef12` sees a clean string while the whole secret sits in
+//! the log line.
+//!
+//! Every assertion below therefore checks base16 in both cases **and** the
+//! decimal run, and the decimal one is the one doing the work. The decimal
+//! pattern is deliberately unbracketed: a real dump very often starts partway
+//! through a buffer — a length prefix comes first — so anchoring on `[` misses
+//! exactly the shape the check exists to catch.
+//!
+//! # Why it matters in this crate specifically
+//!
+//! This is the layer that holds the **message**. `f2z-codec` redacts
+//! ciphertext; `f2z-msg-mls` redacts keys and the decrypted payload; here the
+//! plaintext sits in a [`PlaintextOutbox`] for the entire repair window, by
+//! design, on the sender's device. An FFI boundary that formats an error, or a
+//! client run with tracing on, produces exactly these strings.
+//!
+//! The source-level half of this — no type in `rs/crates/*/src/` may *derive*
+//! `Debug` while holding raw bytes — is `f2z-codec`'s
+//! `tests/workspace_debug_scan.rs`, which reaches this crate automatically. The
+//! two are complementary: that one fires on a type nobody wrote a fixture for,
+//! this one fires on a hand-written `Debug` that renders the bytes anyway.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_codec::types::Body;
+use f2z_msg_dag::{
+    AppMessage, AppMessageTbs, DagEntry, MessageDag, MessageType, MsgId, Parents, PlaintextOutbox,
+    RepairEntry, RetentionClass, SentAt,
+};
+
+/// A byte pattern that is unmistakable in any encoding a leak might use.
+const SECRET: u8 = 0xde;
+
+fn lower_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn upper_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02X}")).collect()
+}
+
+/// `222, 222, 222, 222` — a derived `Debug` over a byte slice, unbracketed. See
+/// the module note for why the brackets are left off.
+fn decimal_run(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(alloc_to_string)
+        .collect::<Vec<String>>()
+        .join(", ")
+}
+
+fn alloc_to_string(byte: &u8) -> String {
+    byte.to_string()
+}
+
+fn assert_no_leak(rendered: &str, secret: &[u8], what: &str) {
+    assert!(
+        !rendered.contains(&lower_hex(secret)),
+        "{what} leaked its bytes as lowercase hex: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&upper_hex(secret)),
+        "{what} leaked its bytes as uppercase hex: {rendered}"
+    );
+    assert!(
+        !rendered.contains(&decimal_run(secret)),
+        "{what} leaked its bytes as a decimal list — which contains no hex at all, \
+         so a hex-shaped check would have passed: {rendered}"
+    );
+}
+
+fn secret_message() -> AppMessage {
+    AppMessage::seal(AppMessageTbs {
+        message_type: MessageType::CHAT,
+        parents: Parents::new(vec![MsgId::new([SECRET; 32])]).unwrap(),
+        epoch: 7,
+        sent_at: SentAt::new(1_700_000_000_000),
+        retention_class: RetentionClass::Chat,
+        body: Body::new(vec![SECRET; 64]).unwrap(),
+    })
+    .unwrap()
+}
+
+#[test]
+fn a_msg_id_does_not_render_its_bytes() {
+    let id = MsgId::new([SECRET; 32]);
+    let rendered = format!("{id:?}");
+    assert_eq!(rendered, "MsgId(<redacted>)");
+    assert_no_leak(&rendered, id.as_bytes(), "MsgId");
+}
+
+#[test]
+fn an_app_message_does_not_render_its_body_or_its_parents() {
+    let message = secret_message();
+    let rendered = format!("{message:?}");
+    assert_no_leak(&rendered, &[SECRET; 64], "AppMessage");
+    // The fields that are safe — and useful — are still there.
+    assert!(rendered.contains("epoch: 7"));
+    assert!(rendered.contains("64 bytes"));
+}
+
+#[test]
+fn a_repair_entry_does_not_render_the_message_it_carries() {
+    let message = secret_message();
+    let entry = RepairEntry::supplied(&message).unwrap();
+    let rendered = format!("{entry:?}");
+    assert_no_leak(&rendered, &[SECRET; 64], "RepairEntry");
+    assert_no_leak(&rendered, message.msg_id().as_bytes(), "RepairEntry");
+}
+
+#[test]
+fn the_outbox_and_its_repair_outcome_do_not_render_the_plaintext() {
+    let message = secret_message();
+    let plaintext = message.encode().unwrap();
+
+    let mut outbox = PlaintextOutbox::new(60_000, 8);
+    outbox.store(message.msg_id(), plaintext, 0);
+    assert_no_leak(&format!("{outbox:?}"), &[SECRET; 64], "PlaintextOutbox");
+
+    let outcome = outbox.repair(&message.msg_id(), 0);
+    let rendered = format!("{outcome:?}");
+    assert_no_leak(&rendered, &[SECRET; 64], "RepairOutcome");
+    assert!(
+        rendered.contains("bytes"),
+        "the length is public and useful; the bytes are not"
+    );
+}
+
+#[test]
+fn the_dag_does_not_render_message_bytes() {
+    let message = secret_message();
+    let mut dag = MessageDag::new();
+    dag.insert(DagEntry::from_delivered(&message, 7, 1).unwrap());
+    assert_no_leak(&format!("{dag:?}"), &[SECRET; 32], "MessageDag");
+}
+
+/// The negative control. If this ever stops failing, the checks above are
+/// checking nothing — which is how a redaction suite rots into decoration.
+#[test]
+fn the_decimal_check_would_catch_a_real_dump() {
+    let leaked = format!("Payload {{ bytes: {:?} }}", vec![SECRET; 8]);
+    assert!(
+        leaked.contains(&decimal_run(&[SECRET; 8])),
+        "the decimal pattern no longer matches a derived Debug over bytes"
+    );
+    assert!(
+        !leaked.contains(&lower_hex(&[SECRET; 8])),
+        "and a hex-only check would have passed over it — that is the trap"
+    );
+}

--- a/rs/crates/f2z-msg-dag/tests/repair_reencrypts.rs
+++ b/rs/crates/f2z-msg-dag/tests/repair_reencrypts.rs
@@ -1,0 +1,341 @@
+//! §7's repair, against a real MLS group.
+//!
+//! # Why this is not a stub cipher
+//!
+//! The claim being tested is a claim about **forward secrecy**:
+//!
+//! > the sender re-encrypts the original plaintext under the *current* epoch
+//! > and replies `gap_response`. It does not replay old ciphertext, so repair
+//! > does not undermine forward secrecy.
+//!
+//! A fake cipher would have proved that a fake cipher produces different bytes
+//! under a different key. What has to be true is that *MLS* does — that the
+//! epoch really advanced, that the repaired ciphertext really is not the
+//! original, and that it really decrypts on the other side under the new epoch.
+//! So this file drives two `f2z_msg_mls::MlsEngine`s that share nothing but
+//! byte strings, exactly as `f2z-msg-mls`'s own `two_instances.rs` does, with
+//! credentials issued by the real `f2z-msg-identity` issuer.
+//!
+//! That makes this the coordination test between §7's framing and §5's engine.
+//! If the two ever stop composing — an epoch that does not advance, a payload
+//! the engine will not carry — it fails here rather than on a phone.
+//!
+//! # What each test asserts
+//!
+//! - `a_repair_is_re_encrypted_under_the_current_epoch_and_is_not_a_replay`:
+//!   the epoch advanced, the repaired ciphertext differs byte for byte from the
+//!   original, and Bob decrypts it in the new epoch.
+//! - `the_original_ciphertext_no_longer_decrypts_after_the_epoch_advanced`:
+//!   the reason replay would be wrong, made concrete.
+//! - `a_repaired_message_carries_its_original_msg_id_unchanged`: the repair is
+//!   the same message, not a new one — which is what lets it close a gap.
+//! - `an_expired_outbox_window_produces_an_explicit_unrecoverable_state`: §8.4,
+//!   end to end, from an outbox that has forgotten to a `MessageDag` that says
+//!   so.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_codec::types::{Body, PublicKey};
+use f2z_kt_core::types::{Handle, KemPublicKey};
+use f2z_msg_dag::{
+    AppMessage, AppMessageTbs, DagEntry, GapRequest, GapResponse, MessageDag, MessageType, MsgId,
+    Parents, PlaintextOutbox, RepairEntry, RepairOutcome, RepairRefusal, RetentionClass, SentAt,
+};
+use f2z_msg_identity::{AccountKeys, DeviceCredentialRequest};
+use f2z_msg_mls::{DeviceSigner, MlsEngine, Received};
+use f2z_msg_store::MemoryBackend;
+
+const NOW: u64 = 1_700_000_000_000;
+const GROUP_ID: &[u8] = b"conversation-alice-bob";
+
+/// One device, built the way enrollment builds one.
+fn device(handle: &str, account_seed: u8, device_seed: u8) -> MlsEngine<MemoryBackend> {
+    let seed = [account_seed; 64];
+    let account = AccountKeys::from_seed(&seed, 0).unwrap();
+    let signer = DeviceSigner::from_private_key([device_seed; 32]);
+    let credential = account
+        .identity
+        .issue_device_credential(&DeviceCredentialRequest {
+            handle: Handle::new(handle.as_bytes().to_vec()).unwrap(),
+            device_pk: PublicKey::new(*signer.public_key()),
+            device_kem_pk: KemPublicKey::new(vec![device_seed; 1216]).unwrap(),
+            not_before_ms: NOW - 1_000_000,
+            not_after_ms: NOW + 1_000_000,
+        })
+        .unwrap();
+    MlsEngine::new(MemoryBackend::new(), signer, credential, NOW).unwrap()
+}
+
+/// Alice creates the group and adds Bob; Bob joins from the `Welcome`.
+///
+/// A macro rather than a function so this crate does not have to declare
+/// `openmls` as a dependency merely to name `MlsGroup` in a return type. The
+/// engines and groups are two devices that share nothing but the byte strings
+/// a relay would carry — a `KeyPackage`, a `Welcome`, a commit, a
+/// `PrivateMessage` — which is what makes the assertions below about two
+/// parties rather than about one process talking to itself.
+macro_rules! paired {
+    ($alice:ident, $alice_group:ident, $bob:ident, $bob_group:ident) => {
+        let $alice = device("alice", 11, 111);
+        let $bob = device("bob", 22, 222);
+        let bob_key_package = $bob.generate_key_package().unwrap();
+        let mut $alice_group = $alice.create_group(GROUP_ID).unwrap();
+        let (_commit, welcome) = $alice
+            .add_member(&mut $alice_group, &bob_key_package, NOW)
+            .unwrap();
+        let mut $bob_group = $bob.join_from_welcome(&welcome, NOW).unwrap();
+    };
+}
+
+fn chat(parents: Parents, epoch: u64, body: &[u8]) -> AppMessage {
+    AppMessage::seal(AppMessageTbs {
+        message_type: MessageType::CHAT,
+        parents,
+        epoch,
+        sent_at: SentAt::new(NOW),
+        retention_class: RetentionClass::Chat,
+        body: Body::new(body.to_vec()).unwrap(),
+    })
+    .unwrap()
+}
+
+/// The acceptance criterion.
+#[test]
+fn a_repair_is_re_encrypted_under_the_current_epoch_and_is_not_a_replay() {
+    paired!(alice, alice_group, bob, bob_group);
+    let original_epoch = alice_group.epoch().as_u64();
+
+    // Alice authors a message and keeps the plaintext against a repair request.
+    let message = chat(Parents::empty(), original_epoch, b"the one that got lost");
+    let plaintext = message.encode().unwrap();
+    let mut outbox = PlaintextOutbox::new(60_000, 32);
+    outbox.store(message.msg_id(), plaintext.clone(), NOW);
+
+    // She sends it. Bob never receives this ciphertext — the relay dropped it.
+    let original_ciphertext = alice.send(&mut alice_group, &plaintext).unwrap();
+
+    // Time passes and the group ratchets forward.
+    let commit = alice.update(&mut alice_group).unwrap();
+    let processed = bob
+        .receive(&mut bob_group, &commit, b"commit-1", NOW)
+        .unwrap();
+    let current_epoch = bob_group.epoch().as_u64();
+    assert_eq!(
+        processed,
+        Received::EpochChanged {
+            epoch: current_epoch
+        }
+    );
+    assert!(
+        current_epoch > original_epoch,
+        "the epoch must actually advance or this test proves nothing"
+    );
+
+    // Bob notices the hole and asks for it.
+    let later = chat(
+        Parents::new(vec![message.msg_id()]).unwrap(),
+        current_epoch,
+        b"did you say something?",
+    );
+    let mut bob_dag = MessageDag::new();
+    bob_dag.insert(DagEntry::from_delivered(&later, current_epoch, 0).unwrap());
+    let missing = bob_dag.take_gap_request();
+    assert_eq!(missing, vec![message.msg_id()]);
+    let request = GapRequest::new(missing).unwrap();
+
+    // Alice repairs: the outbox hands back the **plaintext**, and she puts it
+    // through the ordinary current-epoch send path. There is no API here that
+    // could hand back the stored ciphertext.
+    let requested = request.hashes()[0];
+    let RepairOutcome::Reencrypt(recovered) = outbox.repair(&requested, NOW + 1_000) else {
+        panic!("the window has not elapsed; this must be repairable");
+    };
+    assert_eq!(recovered, plaintext.as_slice());
+
+    let entry = RepairEntry::supplied(&AppMessage::decode(recovered).unwrap()).unwrap();
+    let response = GapResponse::new(vec![entry]);
+    let envelope = AppMessage::seal(AppMessageTbs {
+        message_type: MessageType::GAP_RESPONSE,
+        parents: Parents::empty(),
+        epoch: current_epoch,
+        sent_at: SentAt::new(NOW + 1_000),
+        retention_class: RetentionClass::Chat,
+        body: response.to_body().unwrap(),
+    })
+    .unwrap();
+    let repair_ciphertext = alice
+        .send(&mut alice_group, &envelope.encode().unwrap())
+        .unwrap();
+
+    // ---- the two assertions this test exists for --------------------------
+
+    assert_ne!(
+        repair_ciphertext, original_ciphertext,
+        "the repair must be a fresh encryption, not the stored ciphertext replayed"
+    );
+
+    let received = bob
+        .receive(&mut bob_group, &repair_ciphertext, b"repair-1", NOW)
+        .unwrap();
+    let Received::Application {
+        payload,
+        sender,
+        epoch,
+    } = received
+    else {
+        panic!("expected an application message");
+    };
+    assert_eq!(
+        epoch, current_epoch,
+        "the repair must decrypt under the CURRENT epoch key"
+    );
+
+    // ---- and the repaired message closes the gap --------------------------
+
+    let envelope = AppMessage::decode(&payload).unwrap();
+    assert_eq!(envelope.tbs().message_type, MessageType::GAP_RESPONSE);
+    let response = GapResponse::from_body(&envelope.tbs().body).unwrap();
+    let repaired = response
+        .entry_for(&requested)
+        .unwrap()
+        .accept(&requested)
+        .unwrap();
+
+    assert_eq!(repaired, message, "the repair is the same message");
+    assert_eq!(
+        repaired.tbs().epoch,
+        original_epoch,
+        "the message keeps the epoch it was authored in; only the framing moved"
+    );
+
+    bob_dag.insert(DagEntry::from_repair(&repaired, sender));
+    assert!(!bob_dag.has_detected_gaps());
+    assert_eq!(
+        bob_dag.display_order().unwrap(),
+        vec![message.msg_id(), later.msg_id()],
+        "and it lands before the message that referenced it"
+    );
+}
+
+/// The reason replay would be wrong, made concrete rather than asserted in
+/// prose: once the group has ratcheted, the old ciphertext is not something
+/// this engine will accept any more. A repair that replayed it would be asking
+/// the recipient to keep — and to use — key material the ratchet exists to
+/// destroy.
+#[test]
+fn the_original_ciphertext_no_longer_decrypts_after_the_epoch_advanced() {
+    paired!(alice, alice_group, bob, bob_group);
+    let epoch = alice_group.epoch().as_u64();
+
+    let message = chat(Parents::empty(), epoch, b"the one that got lost");
+    let original_ciphertext = alice
+        .send(&mut alice_group, &message.encode().unwrap())
+        .unwrap();
+
+    let commit = alice.update(&mut alice_group).unwrap();
+    bob.receive(&mut bob_group, &commit, b"commit-1", NOW)
+        .unwrap();
+
+    assert!(
+        bob.receive(&mut bob_group, &original_ciphertext, b"replay", NOW)
+            .is_err(),
+        "an old-epoch ciphertext delivered after the ratchet is not a repair path"
+    );
+}
+
+#[test]
+fn a_repaired_message_carries_its_original_msg_id_unchanged() {
+    paired!(alice, alice_group, bob, bob_group);
+    let epoch = alice_group.epoch().as_u64();
+    let message = chat(Parents::empty(), epoch, b"stable identity");
+    let bytes = message.encode().unwrap();
+
+    // Send it twice, under two different epochs. The framing differs; the name
+    // does not, because `msg_id` commits to the message and not to the framing.
+    let first = alice.send(&mut alice_group, &bytes).unwrap();
+    let commit = alice.update(&mut alice_group).unwrap();
+    bob.receive(&mut bob_group, &commit, b"commit-1", NOW)
+        .unwrap();
+    let second = alice.send(&mut alice_group, &bytes).unwrap();
+
+    assert_ne!(first, second);
+    let Received::Application { payload, .. } = bob
+        .receive(&mut bob_group, &second, b"repair", NOW)
+        .unwrap()
+    else {
+        panic!("expected an application message");
+    };
+    assert_eq!(
+        AppMessage::decode(&payload).unwrap().msg_id(),
+        message.msg_id()
+    );
+}
+
+/// §8.4, end to end. A short local TTL is a legitimate per-user choice (§8.1),
+/// and its consequence must reach the requester as a statement rather than as
+/// silence.
+#[test]
+fn an_expired_outbox_window_produces_an_explicit_unrecoverable_state() {
+    paired!(alice, alice_group, bob, bob_group);
+    let epoch = alice_group.epoch().as_u64();
+
+    let message = chat(Parents::empty(), epoch, b"gone forever");
+    let mut outbox = PlaintextOutbox::new(5_000, 32);
+    outbox.store(message.msg_id(), message.encode().unwrap(), NOW);
+
+    // Bob asks, well after Alice's window elapsed.
+    let later = chat(
+        Parents::new(vec![message.msg_id()]).unwrap(),
+        epoch,
+        b"and then?",
+    );
+    let mut bob_dag = MessageDag::new();
+    bob_dag.insert(DagEntry::from_delivered(&later, epoch, 0).unwrap());
+    let requested: MsgId = bob_dag.take_gap_request()[0];
+
+    let RepairOutcome::Unrecoverable(reason) = outbox.repair(&requested, NOW + 60_000) else {
+        panic!("the window elapsed; the plaintext must be gone");
+    };
+
+    // Alice says so, in band, rather than saying nothing.
+    let refusal = RepairEntry::unrecoverable(requested, RepairRefusal::from_local(reason)).unwrap();
+    let envelope = AppMessage::seal(AppMessageTbs {
+        message_type: MessageType::GAP_RESPONSE,
+        parents: Parents::empty(),
+        epoch,
+        sent_at: SentAt::new(NOW + 60_000),
+        retention_class: RetentionClass::Chat,
+        body: GapResponse::new(vec![refusal]).to_body().unwrap(),
+    })
+    .unwrap();
+    let wire = alice
+        .send(&mut alice_group, &envelope.encode().unwrap())
+        .unwrap();
+
+    let Received::Application { payload, .. } =
+        bob.receive(&mut bob_group, &wire, b"refusal", NOW).unwrap()
+    else {
+        panic!("expected an application message");
+    };
+    let response =
+        GapResponse::from_body(&AppMessage::decode(&payload).unwrap().tbs().body).unwrap();
+    let entry = response.entry_for(&requested).unwrap();
+    assert_eq!(entry.refusal(), Some(RepairRefusal::NoLongerHeld));
+
+    bob_dag.mark_unrecoverable(&requested);
+    assert_eq!(
+        bob_dag.unrecoverable_gaps(),
+        vec![requested],
+        "§8.4: an explicit 'could not be recovered' marker, never a silent hole"
+    );
+    assert!(
+        !bob_dag.has_detected_gaps(),
+        "it is answered, not outstanding — but it is still visible"
+    );
+}

--- a/rs/crates/f2z-msg-dag/tests/repair_reencrypts.rs
+++ b/rs/crates/f2z-msg-dag/tests/repair_reencrypts.rs
@@ -45,7 +45,8 @@ use f2z_codec::types::{Body, PublicKey};
 use f2z_kt_core::types::{Handle, KemPublicKey};
 use f2z_msg_dag::{
     AppMessage, AppMessageTbs, DagEntry, GapRequest, GapResponse, MessageDag, MessageType, MsgId,
-    Parents, PlaintextOutbox, RepairEntry, RepairOutcome, RepairRefusal, RetentionClass, SentAt,
+    Parents, PlaintextOutbox, Provenance, RepairEntry, RepairOutcome, RepairRefusal,
+    RetentionClass, SentAt,
 };
 use f2z_msg_identity::{AccountKeys, DeviceCredentialRequest};
 use f2z_msg_mls::{DeviceSigner, MlsEngine, Received};
@@ -214,7 +215,14 @@ fn a_repair_is_re_encrypted_under_the_current_epoch_and_is_not_a_replay() {
         "the message keeps the epoch it was authored in; only the framing moved"
     );
 
-    bob_dag.insert(DagEntry::from_repair(&repaired, sender));
+    let entry = DagEntry::from_repair(&repaired, sender);
+    assert_eq!(
+        entry.provenance(),
+        Provenance::Repaired,
+        "the receiver must be able to tell a repaired message from a delivered one: \
+         its sender_leaf_index is the repairing peer's, not a committed value"
+    );
+    bob_dag.insert(entry);
     assert!(!bob_dag.has_detected_gaps());
     assert_eq!(
         bob_dag.display_order().unwrap(),

--- a/rs/crates/f2z-msg-dag/tests/tail_truncation.rs
+++ b/rs/crates/f2z-msg-dag/tests/tail_truncation.rs
@@ -1,0 +1,168 @@
+//! The limit, asserted as a limit.
+//!
+//! # Read this before "fixing" the DAG
+//!
+//! Hash links detect a **dropped middle** and nothing else. If a relay drops
+//! the last *k* messages from a sender and no later message arrives, no message
+//! ever references them, so there is no dangling parent and there is nothing to
+//! notice. This is not an oversight in the implementation below and it is not
+//! something a cleverer traversal recovers.
+//!
+//! `ARCHITECTURE.md` §7:
+//!
+//! > **What hash links do NOT detect: tail truncation.** If a relay drops the
+//! > last *k* messages from a sender and no later message arrives, there is no
+//! > dangling parent to notice. Detecting suppression of the tail requires
+//! > liveness signals — periodic authenticated heartbeats carrying the sender's
+//! > current DAG head — and even then, an adversary that partitions a peer
+//! > entirely is indistinguishable from that peer being offline. […] no
+//! > protocol fixes this.
+//!
+//! `THREAT-MODEL.md` §4.4 says the same thing from the adversary's side.
+//!
+//! So the test below **passes when detection fails**, and it is named for that.
+//! A future contributor who reads `has_detected_gaps() == false` here and takes
+//! it for a bug will find this file instead of a subtle rewrite of
+//! [`MessageDag::insert`], and a change that made the DAG "catch" this case
+//! would break this test loudly — which is the point. The only honest fixes are
+//! outside this crate: a heartbeat carrying the sender's current head, and a UI
+//! that never says "nothing is missing".
+//!
+//! # What *is* enforced here
+//!
+//! Two things, and both are real:
+//!
+//! - `has_detected_gaps()` means "no gap **detected**", and every accessor on
+//!   [`MessageDag`] is named so a caller cannot read it as "nothing missing".
+//! - One message arriving *after* the truncated tail turns the whole thing into
+//!   an ordinary dropped middle, which is detected exactly. The undetectability
+//!   is a property of the tail being the tail, not of the messages.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_codec::types::Body;
+use f2z_msg_dag::{
+    AppMessage, AppMessageTbs, DagEntry, MessageDag, MessageType, MsgId, Parents, RetentionClass,
+    SentAt,
+};
+
+const EPOCH: u64 = 7;
+const SENDER_LEAF: u32 = 1;
+
+/// A linear chain of `count` messages, each referencing the one before it.
+fn chain(count: usize) -> Vec<AppMessage> {
+    let mut out: Vec<AppMessage> = Vec::new();
+    for index in 0..count {
+        let parents = match out.last() {
+            None => Parents::empty(),
+            Some(previous) => Parents::new(vec![previous.msg_id()]).unwrap(),
+        };
+        out.push(
+            AppMessage::seal(AppMessageTbs {
+                message_type: MessageType::CHAT,
+                parents,
+                epoch: EPOCH,
+                sent_at: SentAt::new(1_700_000_000_000 + index as u64),
+                retention_class: RetentionClass::Chat,
+                body: Body::new(format!("message {index}").into_bytes()).unwrap(),
+            })
+            .unwrap(),
+        );
+    }
+    out
+}
+
+fn deliver(dag: &mut MessageDag, message: &AppMessage) {
+    dag.insert(DagEntry::from_delivered(message, EPOCH, SENDER_LEAF).unwrap());
+}
+
+/// **This test asserts that detection FAILS. That is the specification.**
+///
+/// Do not change it to assert a gap is found. If a change to this crate makes
+/// it start finding one, the change is wrong — or the threat model moved, in
+/// which case `ARCHITECTURE.md` §7 and `THREAT-MODEL.md` §4.4 move first.
+#[test]
+fn tail_truncation_is_undetectable_by_design() {
+    let messages = chain(10);
+
+    for dropped in 1..=5usize {
+        let mut dag = MessageDag::new();
+        let kept = messages.len() - dropped;
+        for message in messages.iter().take(kept) {
+            deliver(&mut dag, message);
+        }
+
+        assert_eq!(dag.len(), kept);
+        assert!(
+            !dag.has_detected_gaps(),
+            "dropping the last {dropped} messages left a dangling parent, which cannot \
+             happen: nothing the receiver holds references them"
+        );
+        assert!(dag.detected_gaps().is_empty());
+        assert!(dag.take_gap_request().is_empty());
+        assert!(dag.unrecoverable_gaps().is_empty());
+
+        // And the transcript renders perfectly happily, which is exactly the
+        // failure mode: the receiver has a complete, correctly ordered,
+        // internally consistent view of a conversation that has been censored.
+        let order = dag.display_order().unwrap();
+        assert_eq!(order.len(), kept);
+        let expected: Vec<MsgId> = messages.iter().take(kept).map(AppMessage::msg_id).collect();
+        assert_eq!(order, expected);
+    }
+}
+
+/// The complement, and the reason the limit is about the *tail* rather than
+/// about the messages: the same drop, with one later message, is caught.
+#[test]
+fn the_same_drop_is_detected_the_moment_anything_later_arrives() {
+    let messages = chain(10);
+    let mut dag = MessageDag::new();
+
+    // Everything except messages 7, 8, 9 …
+    for message in messages.iter().take(7) {
+        deliver(&mut dag, message);
+    }
+    assert!(!dag.has_detected_gaps(), "still a tail; still invisible");
+
+    // … then one more message, authored after them, referencing message 9.
+    let later = AppMessage::seal(AppMessageTbs {
+        message_type: MessageType::CHAT,
+        parents: Parents::new(vec![messages[9].msg_id()]).unwrap(),
+        epoch: EPOCH,
+        sent_at: SentAt::new(1_700_000_100_000),
+        retention_class: RetentionClass::Chat,
+        body: Body::new(b"and one more".to_vec()).unwrap(),
+    })
+    .unwrap();
+    deliver(&mut dag, &later);
+
+    assert_eq!(
+        dag.detected_gaps(),
+        vec![messages[9].msg_id()],
+        "the tail stopped being the tail, so the hole became a dangling parent"
+    );
+}
+
+/// The naming half of the guarantee. Nothing on [`MessageDag`] offers a caller
+/// a way to ask "is anything missing?", because the honest answer is not
+/// computable and an API that appeared to answer it would be used.
+#[test]
+fn nothing_on_the_api_claims_to_know_whether_anything_is_missing() {
+    let mut dag = MessageDag::new();
+    for message in chain(3) {
+        deliver(&mut dag, &message);
+    }
+    // `has_detected_gaps` — detected. `detected_gaps` — detected.
+    // `unrecoverable_gaps` — gaps somebody already knows about. There is no
+    // `is_complete`, and there must never be one.
+    assert!(!dag.has_detected_gaps());
+    assert!(dag.detected_gaps().is_empty());
+    assert!(dag.unrecoverable_gaps().is_empty());
+}

--- a/rs/crates/f2z-msg-dag/tests/typescript_parity.rs
+++ b/rs/crates/f2z-msg-dag/tests/typescript_parity.rs
@@ -1,0 +1,236 @@
+//! Where this crate and the shipped TypeScript client agree about §7's order,
+//! and the one place they do not.
+//!
+//! # The other implementation
+//!
+//! `wallet/zuuli/src/lib/messaging/types.ts`:
+//!
+//! ```text
+//! export function compareMessages(a: Message, b: Message): number {
+//!   if (a.epoch !== b.epoch) return a.epoch - b.epoch;
+//!   if (a.senderLeafIndex !== b.senderLeafIndex) {
+//!     return a.senderLeafIndex - b.senderLeafIndex;
+//!   }
+//!   return a.msgId < b.msgId ? -1 : a.msgId > b.msgId ? 1 : 0;
+//! }
+//! ```
+//!
+//! and `wallet/zuuli/src/features/messages/Transcript.tsx` applies it as
+//! `[...messages].sort(compareMessages)` — that is the entire ordering the UI
+//! performs. Nothing there reads `parents`.
+//!
+//! # Where they agree: the tie-break
+//!
+//! [`f2z_msg_dag::compare_sort_keys`] is that function, field for field, and
+//! the tests below check the agreement includes the parts that are easy to get
+//! wrong across a language boundary:
+//!
+//! - `epoch` first, then `senderLeafIndex`, then `msgId` — and `msgId`
+//!   compared as **bytes** here against a **string** there, which agree because
+//!   base16 is order-preserving in a single case (`MsgId::to_lower_hex`).
+//! - `sentAt` appears in neither. In this crate it *cannot*: [`SentAt`] has no
+//!   `Ord`.
+//!
+//! # Where they disagree: the tie-break is not the order
+//!
+//! §7's rule has two halves — "the DAG's partial order", and a total order that
+//! "breaks **ties**". A tie is a pair of *concurrent* messages, the ones the
+//! partial order leaves incomparable. Applying the tie-break to every pair,
+//! including causally related ones, is a different rule, and it produces a
+//! different transcript.
+//!
+//! `causal_order_and_the_typescript_comparator_disagree_on_a_reply` below is
+//! the smallest case, and it is not a corner: it fires in every one-to-one
+//! conversation where the person replying holds the lower MLS leaf index, which
+//! is half of them.
+//!
+//! **This is a defect in the TypeScript client, not a difference of opinion**,
+//! and it is reported on the pull request rather than worked around here. A
+//! JavaScript `Array.prototype.sort` comparator cannot express a topological
+//! order — it only ever sees two elements — so the fix is a pass over the graph
+//! before the sort, not a cleverer comparator.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use core::cmp::Ordering;
+
+use f2z_codec::types::Body;
+use f2z_msg_dag::{
+    AppMessage, AppMessageTbs, DagEntry, MessageDag, MessageType, MsgId, Parents, RetentionClass,
+    SentAt, SortKey, compare_sort_keys,
+};
+
+/// `compareMessages`, transcribed. Kept as a separate function from
+/// [`compare_sort_keys`] so that the transcription is visible rather than
+/// assumed, and so a future change to either one shows up as a failing test
+/// instead of as a silent convergence.
+fn typescript_compare_messages(a: &SortKey, b: &SortKey) -> Ordering {
+    if a.epoch != b.epoch {
+        return a.epoch.cmp(&b.epoch);
+    }
+    if a.sender_leaf_index != b.sender_leaf_index {
+        return a.sender_leaf_index.cmp(&b.sender_leaf_index);
+    }
+    // `msgId` is a hex string there and 32 bytes here. See the module note.
+    a.msg_id.to_lower_hex().cmp(&b.msg_id.to_lower_hex())
+}
+
+fn key(epoch: u64, leaf: u32, msg_id: MsgId) -> SortKey {
+    SortKey {
+        epoch,
+        sender_leaf_index: leaf,
+        msg_id,
+    }
+}
+
+fn id(byte: u8) -> MsgId {
+    MsgId::new([byte; 32])
+}
+
+#[test]
+fn the_tie_break_agrees_field_for_field() {
+    let cases = [
+        (key(1, 0, id(0xff)), key(2, 0, id(0x00))),
+        (key(2, 0, id(0xff)), key(2, 1, id(0x00))),
+        (key(2, 1, id(0x01)), key(2, 1, id(0x02))),
+        (key(0, 0, id(0x00)), key(0, 0, id(0x00))),
+        (
+            key(u64::MAX, u32::MAX, id(0xff)),
+            key(u64::MAX, u32::MAX, id(0xff)),
+        ),
+    ];
+    for (left, right) in cases {
+        assert_eq!(
+            compare_sort_keys(&left, &right),
+            typescript_compare_messages(&left, &right),
+            "the two implementations of §7's tie-break disagree on {left:?} vs {right:?}"
+        );
+        assert_eq!(
+            compare_sort_keys(&right, &left),
+            typescript_compare_messages(&right, &left),
+        );
+    }
+}
+
+/// The byte-versus-string question, isolated.
+///
+/// A hex string comparison and a byte comparison agree because ASCII `0`..`9`
+/// precedes `a`..`f` and the mapping is monotone. They would **not** agree for
+/// base64 — `+` and `/` sort below the digits — and they would not agree for
+/// mixed case. If the FFI ever changes how a `msgId` is spelled, this test is
+/// where it fails.
+#[test]
+fn hex_string_ordering_reproduces_byte_ordering_over_the_whole_range() {
+    for low in 0u8..=254 {
+        let high = low + 1;
+        let a = MsgId::new([low; 32]);
+        let b = MsgId::new([high; 32]);
+        assert!(a < b);
+        assert!(a.to_lower_hex() < b.to_lower_hex(), "{low} vs {high}");
+    }
+    // And a boundary that a naive check would miss: the digit/letter seam.
+    assert!(MsgId::new([0x09; 32]) < MsgId::new([0x0a; 32]));
+    assert!(MsgId::new([0x09; 32]).to_lower_hex() < MsgId::new([0x0a; 32]).to_lower_hex());
+}
+
+/// **The disagreement, executable.**
+///
+/// Bob (leaf 1) sends `A`. Alice (leaf 0) replies with `B`, `parents = [A]`,
+/// in the same epoch. `compareMessages` puts the reply first. The causal order
+/// does not.
+///
+/// This test asserting a disagreement is deliberate: it documents a live defect
+/// in `wallet/zuuli/src/features/messages/Transcript.tsx`. When that is fixed —
+/// a topological pass before the sort — this test should be updated to assert
+/// agreement, and not before.
+#[test]
+fn causal_order_and_the_typescript_comparator_disagree_on_a_reply() {
+    let a = AppMessage::seal(AppMessageTbs {
+        message_type: MessageType::CHAT,
+        parents: Parents::empty(),
+        epoch: 7,
+        sent_at: SentAt::new(1_000),
+        retention_class: RetentionClass::Chat,
+        body: Body::new(b"what do you think?".to_vec()).unwrap(),
+    })
+    .unwrap();
+
+    let b = AppMessage::seal(AppMessageTbs {
+        message_type: MessageType::CHAT,
+        parents: Parents::new(vec![a.msg_id()]).unwrap(),
+        epoch: 7,
+        sent_at: SentAt::new(2_000),
+        retention_class: RetentionClass::Chat,
+        body: Body::new(b"I think yes".to_vec()).unwrap(),
+    })
+    .unwrap();
+
+    // Bob is leaf 1 and sent A; Alice is leaf 0 and replied with B.
+    let a_entry = DagEntry::from_delivered(&a, 7, 1).unwrap();
+    let b_entry = DagEntry::from_delivered(&b, 7, 0).unwrap();
+
+    // The tie-break alone — which is what the TypeScript client applies to
+    // every pair — puts the reply first.
+    assert_eq!(
+        typescript_compare_messages(&b_entry.sort_key(), &a_entry.sort_key()),
+        Ordering::Less,
+        "the transcribed comparator no longer reproduces the shipped one",
+    );
+
+    // The causal order does not, because B references A.
+    let mut dag = MessageDag::new();
+    dag.insert(b_entry);
+    dag.insert(a_entry);
+    assert_eq!(
+        dag.display_order().unwrap(),
+        vec![a.msg_id(), b.msg_id()],
+        "§7 says the DAG's partial order decides; the tie-break only breaks ties"
+    );
+}
+
+/// The complement: with no causal edge, the two agree exactly.
+///
+/// This is what makes the defect above narrow enough to be a real bug rather
+/// than a rewrite — the comparator is the right rule applied in too many
+/// places, not the wrong rule.
+#[test]
+fn with_no_causal_edge_the_two_orders_are_identical() {
+    let mut messages = Vec::new();
+    for (index, (epoch, leaf)) in [(7u64, 1u32), (7, 0), (8, 3), (6, 2), (7, 1)]
+        .into_iter()
+        .enumerate()
+    {
+        let message = AppMessage::seal(AppMessageTbs {
+            message_type: MessageType::CHAT,
+            parents: Parents::empty(),
+            epoch,
+            sent_at: SentAt::new(9_999 - index as u64),
+            retention_class: RetentionClass::Chat,
+            body: Body::new(format!("m{index}").into_bytes()).unwrap(),
+        })
+        .unwrap();
+        messages.push((message, epoch, leaf));
+    }
+
+    let mut dag = MessageDag::new();
+    for (message, epoch, leaf) in &messages {
+        dag.insert(DagEntry::from_delivered(message, *epoch, *leaf).unwrap());
+    }
+
+    let mut expected: Vec<SortKey> = messages
+        .iter()
+        .map(|(message, epoch, leaf)| key(*epoch, *leaf, message.msg_id()))
+        .collect();
+    expected.sort_by(typescript_compare_messages);
+
+    assert_eq!(
+        dag.display_order().unwrap(),
+        expected.iter().map(|k| k.msg_id).collect::<Vec<MsgId>>()
+    );
+}

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -76,6 +76,7 @@ MANIFESTS=(
   # same `rust-version` restatement as every other crate under rs/.
   rs/crates/f2z-msg-store/Cargo.toml
   rs/crates/f2z-msg-mls/Cargo.toml
+  rs/crates/f2z-msg-dag/Cargo.toml
 )
 
 # Other rust-toolchain.toml files. Cargo picks the toolchain from the directory


### PR DESCRIPTION
`rs/crates/f2z-msg-dag` — the hash-linked application framing of
[`ARCHITECTURE.md` §7](https://github.com/free2z/zuu/blob/main/docs/e2ee/ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering).
The `AppMessage`, its `msg_id` commitment, causal ordering, gap detection, and
the bounded-window plaintext outbox §7's repair needs.

`#![forbid(unsafe_code)]`, `no_std` + `alloc`, **no I/O and no clock** — every
time-dependent decision is a `now_ms` parameter — MIT, and on the `rs_wasm` line.
Registered with `scripts/check-rust-toolchain.sh` and swept by
`check-hash-domain-labels.mjs` and `f2z-codec`'s workspace `Debug` scan.

---

## ⚠️ A defect in the shipped TypeScript client, found by writing this

**`compareMessages` implements only the tie-break, so the ZUULI transcript
renders replies above the messages they reply to.**

§7 has two rules and the first one is primary:

> **Causal ordering:** the DAG's partial order. For display, a deterministic
> total order **breaks ties** by `(epoch, sender_leaf_index, msg_id)`.

A *tie* is a pair of **concurrent** messages — the ones the partial order leaves
incomparable. `wallet/zuuli/src/lib/messaging/types.ts` applies the tie-break to
every pair, and `wallet/zuuli/src/features/messages/Transcript.tsx` applies it as
`[...messages].sort(compareMessages)` — nothing there reads `parents`.

The counterexample is two lines and it is not exotic:

- Bob is leaf 1. At epoch 7 he sends `A`.
- Alice is leaf 0. She receives `A` and replies with `B`, `parents = [A]`, still
  at epoch 7.

Sort keys `A = (7, 1, …)` and `B = (7, 0, …)`, so **`B` renders above `A`** — the
reply above the message it answers. Run against the shipped comparator verbatim:

```
Transcript.tsx renders: B then A
Causal edge:            A -> B (B's parents = [A])
RESULT: the reply renders ABOVE the message it replies to.
```

Epochs are non-decreasing along a causal edge, so the inversion is confined to a
single epoch — but within an epoch it fires **whenever the replier holds the
lower MLS leaf index**, which is half of all one-to-one conversations.

Two implementations, written independently, disagreeing — exactly the check this
repo keeps finding real defects with. This PR does **not** change the TypeScript;
`rs/crates/f2z-msg-dag/tests/typescript_parity.rs` pins the disagreement as an
executable fact, agrees with `compareMessages` field for field everywhere the
tie-break *is* the rule, and says in its module note that the test should be
flipped to assert agreement only once the client is fixed. A JS `sort`
comparator cannot express a topological order — it only ever sees two elements —
so the fix there is a pass over the graph before the sort, not a cleverer
comparator. **Worth a follow-up issue against ZUULI.**

## ⚠️ A gap in §7 itself: `sender_leaf_index` is in the sort key but not in the hash

§7's total order needs `sender_leaf_index`. That field lives in **MLS framing**,
not in the `AppMessage`, so `msg_id` does not commit to it. §7's repair delivers
a message *outside its original framing* — the `gap_response` is authenticated as
the **repairing** peer's message.

Today that is sound, because §7 says "**the sender** re-encrypts the original
plaintext", so the repairer is the original sender and its own authenticated leaf
index is the right one. `DagEntry::from_repair` takes exactly that and documents
why.

But §7 does not *forbid* a third member answering a `gap_request`, and that is
the obvious optimisation the moment a group is larger than two. If repair is ever
generalised, **two receivers that learned the same message by different routes
compute different sort keys for the same `msg_id`**, and §7's "every client that
applies this rule to the same set of messages produces the same transcript" stops
holding. The fix is to move `sender_leaf_index` inside the hashed message. That
is a specification change, so it is reported here rather than made in code.

---

## What is in the crate

| Module | What it does |
|---|---|
| `message` | `AppMessage`, `AppMessageTbs` (= §7's `rest`, as a type), `MsgId`, `MessageType`, `RetentionClass`, `SentAt`, `Parents`, and `msg_id = BLAKE2b-256("free2z/msg/v1/msgid" ‖ canonical(rest))`. |
| `order` | `SortKey`, and `linearise` — Kahn's algorithm with a min-heap on the sort key, so the output is a linear extension of the DAG and depends on the graph and the keys and nothing else. |
| `dag` | `MessageDag`: dedup by `msg_id`, gap detection, heads (= the `parents` of the next send), `take_gap_request`, the explicit unrecoverable set. |
| `outbox` | `PlaintextOutbox` — bounded in **time** (§8.4's TTL) and in **count**. `repair()` returns a **plaintext**; there is deliberately no variant that could carry stored ciphertext. |
| `repair` | `GapRequest`, `GapResponse`, `RepairEntry` — and `accept(requested)`, which refuses anything that does not hash to the `msg_id` that was asked for. |

### `sent_at` cannot order anything — structurally

`SentAt` implements **neither `Ord` nor `PartialOrd`**. §7 calls the field
advisory; a doc comment saying so is a convention, a missing trait is a compile
error. Sorting a transcript by the sender's clock produces
`error[E0277]: the trait bound `SentAt: Ord` is not satisfied`, not a subtly
wrong transcript.

### Repair does not replay ciphertext

The outbox hands back plaintext; the caller puts it through the MLS engine's
ordinary current-epoch send path. `tests/repair_reencrypts.rs` proves this
against a **real** two-engine MLS group (credentials from the real
`f2z-msg-identity` issuer, as `f2z-msg-mls`'s own tests do) rather than a stub
cipher — a fake cipher would only have proved something about the fake.

---

## Test evidence

`cargo test --locked --all-targets` from `rs/` is green (exit 0, whole
workspace), `cargo clippy --locked --all-targets -p f2z-msg-dag -- -D warnings`
is clean, `cargo fmt --all -- --check` is clean, and the five gate policy scripts
pass.

**56 tests in this crate: 38 unit + 18 integration, plus 7 proptest properties.**

### The limit, tested as a limit

```
test tail_truncation_is_undetectable_by_design ... ok
```

**This test passes when detection fails, and that is the specification.** If a
relay drops the last *k* messages and nothing later arrives, no message
references them, so there is no dangling parent. It sweeps `k = 1..=5` and
asserts `has_detected_gaps() == false`, an empty `gap_request`, *and* that the
truncated transcript renders perfectly happily — which is the actual failure
mode: a complete, correctly ordered, internally consistent view of a conversation
that has been censored. The file opens with "Read this before 'fixing' the DAG"
and quotes §7 and `THREAT-MODEL.md` §4.4.

Two companions: `the_same_drop_is_detected_the_moment_anything_later_arrives`
(the limit is about the tail, not the messages) and
`nothing_on_the_api_claims_to_know_whether_anything_is_missing` (there is no
`is_complete()`, and there must never be one).

### Properties, over random DAGs and random interleavings (256 cases each)

| Property | Test |
|---|---|
| Ordering is deterministic and total across shuffled delivery orders | `the_display_order_does_not_depend_on_the_delivery_order` |
| The order is a linear extension of the causal order | `every_ancestor_precedes_every_descendant` |
| Every dropped middle message produces **exactly one** gap signal | `a_dropped_middle_message_produces_exactly_one_gap_signal` |
| Dedup holds when the same `msg_id` arrives *k* times | `k_deliveries_of_the_same_message_are_indistinguishable_from_one` |
| A repair restores the transcript exactly | `a_repaired_message_restores_the_transcript_exactly` |
| An adversarial clock cannot reorder a causal chain | `an_adversarial_clock_cannot_reorder_a_causal_chain` |
| Concurrent messages are separated by the sort key, never the clock | `two_concurrent_messages_are_separated_by_the_sort_key` |

The generator draws leaf indices specifically to make the sort key *fight* the
causal order, which is the case a tie-break-only implementation gets wrong.
The one-gap-per-hole property distinguishes the **transient** gaps a shuffled
delivery order produces — a child arriving before its parent — from the one
message that never arrives.

### Repair, against a real MLS group

| Test | Asserts |
|---|---|
| `a_repair_is_re_encrypted_under_the_current_epoch_and_is_not_a_replay` | the epoch actually advanced; the repaired ciphertext **differs byte for byte** from the original; Bob decrypts it and `Received::Application.epoch == current_epoch`; the repaired message closes the gap and lands *before* the message that referenced it |
| `the_original_ciphertext_no_longer_decrypts_after_the_epoch_advanced` | why replay would be wrong, made concrete |
| `a_repaired_message_carries_its_original_msg_id_unchanged` | the framing moved; the name did not |
| `an_expired_outbox_window_produces_an_explicit_unrecoverable_state` | §8.4 end to end: outbox → in-band `RepairRefusal::NoLongerHeld` → `MessageDag::unrecoverable_gaps()`. Never a silent hole |

### Redaction

`tests/redaction.rs` checks lowercase hex, uppercase hex **and an unbracketed
decimal run** for `MsgId`, `AppMessage`, `RepairEntry`, `PlaintextOutbox`,
`RepairOutcome` and `MessageDag` — the decimal one is the one doing the work,
per `f2z-codec`'s documented trap, and
`the_decimal_check_would_catch_a_real_dump` is the negative control proving the
pattern still matches a derived `Debug`. `f2z-codec`'s
`workspace_debug_scan.rs` reaches this crate automatically (its coverage anchor
asserts every crate under `rs/crates/` is scanned) and passes.

---

## Every ambiguity call, enumerated

§7 specifies a structure and a rule, not a serialization. These had to be
decided to write any code; each is documented at the point it is made and each
needs reflecting back into §7 before a second implementation exists.

1. **Wire encoding.** `encode(AppMessage) == msg_id ‖ canonical(AppMessageTbs)`.
   §7 lists `type` first, but that is a *field listing*: §7 defines no
   serialization, because the message rides as the opaque payload of an MLS
   `PrivateMessage`. Putting `msg_id` first makes the hashed bytes a **contiguous
   suffix**, so `decode` verifies the commitment against the received suffix with
   no re-assembly. Everything else is `f2z-codec`'s canonical `tls_codec`
   encoding, with §3.3 re-encode equality applied to application framing for the
   same reason it applies to relay framing.

2. **`parents` MUST be strictly ascending.** A head set is a *set*; `msg_id`
   hashes an encoding of it. Without a canonical order, two senders holding the
   identical head set mint two different names for the identical message.
   `Parents::new` sorts; a descending list *on the wire* is refused rather than
   sorted, because sorting it would change the bytes the commitment covers.
   Duplicates are an error (also removes a cheap 2000-lookups-per-message
   amplification). **§7 does not state this rule.**

3. **`type` is open; `retention_class` is closed.** §7's type list ends in `...`,
   so `MessageType` is a transparent `u8` and an unknown codepoint round-trips
   (matching `CLIENT-CONTRACT.md`'s `unsupported` + `typeTag` arm). But
   `retention_class` drives a *retention decision* and has no honest default: an
   unknown value silently becoming `CHAT` would expire a ceremony transcript a
   participant is keeping as evidence, and silently becoming `CEREMONY` would
   retain something asked to be ephemeral. So it is a closed enum and an unknown
   byte is a decode error.

4. **Codepoint assignment.** §7 names the types and gives no numbers. Allocated
   1..7 in the order §7 lists them; `0` left unassigned so an all-zero buffer is
   not a valid `chat`. `RetentionClass` is 1/2 on the same basis.

5. **The framing epoch and the claimed `epoch` must agree** for a directly
   delivered message (`DagError::EpochMismatch`). §7 does not say what to do when
   they disagree; refusing is the safe reading, because the field is inside the
   hash and the framing is not, so a disagreement is a sender claiming to have
   authored in an epoch it did not encrypt under — which would let it place its
   message anywhere in the transcript, the exact power §7 takes from the clock.
   **A repaired message is exempt**, and must be: §7's repair re-encrypts under
   the *current* epoch, so the framing epoch is later than the message's by
   construction.

6. **A repaired message's `sender_leaf_index`** — the §7 gap above.

7. **A `parents` hash the receiver does not hold imposes no ordering
   constraint.** It is not in the graph and cannot be ordered against; the hole is
   reported separately, per `CLIENT-CONTRACT.md` §7's "a hole in the sort order is
   not a hole in the conversation and vice versa".

8. **Gap-signal semantics.** `take_gap_request()` drains only the *newly
   detected* set, marking them `RepairRequested`. That is what makes "one dropped
   message, one gap signal" true when *n* later messages all reference the same
   hole and each arrives from *k* relays. `Unrecoverable` is terminal and is
   never reopened by a later reference — the user has already been told.

9. **`gap_response` answers every requested hash**, with either the original
   message or an explicit `RepairRefusal`. A responder that simply omits what it
   cannot supply leaves the requester unable to tell "gone" from "still in
   flight", which is the distinction §8.4 exists to preserve. A refusal surfaces
    as its own `DagError::RepairRefused` rather than sharing an error with a peer
    answering a hash nobody asked about — only the second is a violation.
    `WindowExpired` and
   `Evicted` collapse to one wire code (`NoLongerHeld`): both mean "gone", and
   telling a peer *which* leaks the responder's local retention setting and its
   buffer pressure.

10. **The outbox is bounded in count as well as in time.** §7 says
    "bounded-window" and §8.4 gives the time bound. Without a count bound a chatty
    conversation is an unbounded plaintext buffer on a phone. Eviction is
    oldest-first with `msg_id` as a deterministic tie-break, and surfaces as
    `Unrecoverable::Evicted` rather than a silent drop.

11. **A cycle is an error, not a truncation.** `msg_id` commits to `parents`, so a
    cycle is a BLAKE2b-256 preimage cycle. Reported as `DagError::Cycle`, because
    silently dropping messages from a transcript is worse than refusing to render
    one.

12. **`msg_id` spelling across the FFI.** `MsgId::to_lower_hex` exists so there is
    one spelling. Base16 in a *single* case is order-preserving over the bytes, so
    the TypeScript string comparison reproduces the Rust byte ordering exactly;
    **mixed case does not, and base64 does not** (`+` and `/` sort below the
    digits). `hex_string_ordering_reproduces_byte_ordering_over_the_whole_range`
    pins it across all 255 adjacent byte pairs.

---

## Not in this PR, deliberately

No MLS, no relay, no storage, no persistence of the DAG across restarts, no
heartbeat/liveness signal (the only honest mitigation for tail truncation, and it
is a separate protocol decision), and no change to the TypeScript client.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku

