### PR TITLE
fix(f2z-relay): refuse a connection whose TLS exporter yields no binding (WIRE.md §5.3)

### DIFF
--- a/rs/crates/f2z-relay/src/listener.rs
+++ b/rs/crates/f2z-relay/src/listener.rs
@@ -158,10 +158,13 @@ async fn handshake(
         Some(acceptor) => {
             let tls = acceptor.accept(stream).await.ok()?;
             // §5.3: the exporter is taken from the completed handshake, before
-            // the WebSocket upgrade consumes the stream.
+            // the WebSocket upgrade consumes the stream. No binding is a
+            // refusal, not a degradation to `none` — this relay publishes
+            // `channel_binding_mode: tls-exporter`, and §5.3 requires the
+            // connection to be refused rather than carry the `none` sentinel.
             let binding = {
                 let (_io, connection) = tls.get_ref();
-                crate::tls::export(connection)
+                crate::tls::export(connection)?
             };
             let socket = tokio_tungstenite::accept_hdr_async(tls, check_upgrade)
                 .await

--- a/rs/crates/f2z-relay/src/tls.rs
+++ b/rs/crates/f2z-relay/src/tls.rs
@@ -130,26 +130,44 @@ fn load_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, TlsError> {
 
 /// §5.3's exporter, taken from a completed handshake.
 ///
-/// Returns 32 zero bytes when there is no TLS session, which is the value §5.3
-/// requires in `channel_binding_mode: none` — the same constant both ends use,
-/// so the transcript still verifies and the binding simply provides nothing.
-#[must_use]
+/// Returns `None` when there is no binding to be had, and the caller drops the
+/// connection. Anything that reaches this function has a TLS session, so
+/// [`crate::caps`] publishes `channel_binding_mode: tls-exporter`, and §5.3 is
+/// explicit about what that costs:
+///
+/// > A relay in `tls-exporter` mode whose exporter output is 32 zero bytes MUST
+/// > treat that as failure to obtain a binding and refuse the connection. Zero
+/// > is the `none` sentinel; accepting it in both modes would make them
+/// > identical in the signed transcript.
+///
+/// So neither a failing exporter nor an exporter that returns the sentinel may
+/// degrade this connection into the `none` mode it does not publish. It is
+/// [`acceptor`]'s stance one layer up, for the same reason: §2.3's insecure
+/// path is an explicit act with published consequences, not a degradation.
 pub fn export(
     connection: &tokio_rustls::rustls::ServerConnection,
-) -> f2z_codec::types::ChannelBinding {
-    let mut output = [0u8; EXPORTER_LEN];
-    match connection.export_keying_material(output, EXPORTER_LABEL, None) {
-        Ok(bytes) => f2z_codec::types::ChannelBinding::new(bytes),
-        // An exporter that cannot be derived from a completed TLS 1.3 handshake
-        // is a `rustls` state this code has no way to repair. Zeros are the
-        // value §5.3 defines for "no binding", so the connection degrades to the
-        // documented weaker mode rather than to a value only one end knows.
-        Err(_) => {
-            crate::log_warn!("TLS exporter unavailable; this connection has no channel binding");
-            output = [0u8; EXPORTER_LEN];
-            f2z_codec::types::ChannelBinding::new(output)
-        }
+) -> Option<f2z_codec::types::ChannelBinding> {
+    let output = [0u8; EXPORTER_LEN];
+    // An exporter that cannot be derived from a completed TLS 1.3 handshake is
+    // a `rustls` state this code has no way to repair.
+    let Ok(bytes) = connection.export_keying_material(output, EXPORTER_LABEL, None) else {
+        crate::log_warn!("TLS exporter unavailable; refusing the connection (WIRE.md §5.3)");
+        return None;
+    };
+    binding_from_exporter(bytes)
+}
+
+/// §5.3's rule about the exporter's **output**, kept separate from the
+/// exporter's *error* so it can be exercised without terminating TLS.
+fn binding_from_exporter(bytes: [u8; EXPORTER_LEN]) -> Option<f2z_codec::types::ChannelBinding> {
+    let binding = f2z_codec::types::ChannelBinding::new(bytes);
+    if binding.is_zero() {
+        crate::log_warn!(
+            "TLS exporter returned the `none` sentinel; refusing the connection (WIRE.md §5.3)"
+        );
+        return None;
     }
+    Some(binding)
 }
 
 #[cfg(test)]
@@ -165,6 +183,25 @@ mod tests {
     #[test]
     fn only_tls_1_3_is_offered() {
         assert_eq!(VERSIONS.len(), 1);
+    }
+
+    #[test]
+    fn a_zero_exporter_output_yields_no_binding() {
+        // §5.3: "A relay in `tls-exporter` mode whose exporter output is 32
+        // zero bytes MUST treat that as failure to obtain a binding and refuse
+        // the connection." `export` returns `None` and `listener::handshake`
+        // drops the connection on it.
+        assert!(binding_from_exporter([0u8; EXPORTER_LEN]).is_none());
+    }
+
+    #[test]
+    fn a_real_exporter_output_yields_that_binding() {
+        // The positive control, so the refusal above is attributable to the
+        // sentinel and not to the guard refusing everything.
+        let mut bytes = [0u8; EXPORTER_LEN];
+        bytes[EXPORTER_LEN - 1] = 1;
+        let binding = binding_from_exporter(bytes).expect("a non-zero exporter output binds");
+        assert_eq!(binding.as_bytes(), &bytes);
     }
 
     #[test]


### PR DESCRIPTION
## What §5.3 requires

`WIRE.md` §5.3 (lines 574-577):

> A relay in `tls-exporter` mode whose exporter output is 32 zero bytes MUST
> treat that as failure to obtain a binding and refuse the connection. Zero is
> the `none` sentinel; accepting it in both modes would make them identical in
> the signed transcript.

## What the code did

`f2z-relay/src/tls.rs`'s `export()` returned the sentinel and let the connection
proceed:

```rust
Err(_) => {
    crate::log_warn!("TLS exporter unavailable; this connection has no channel binding");
    output = [0u8; EXPORTER_LEN];
    f2z_codec::types::ChannelBinding::new(output)
}
```

`listener.rs` took whatever came back and completed the WebSocket upgrade with
it. A relay on that path has a TLS acceptor, so `caps.rs` publishes
`channel_binding_mode: tls-exporter` — and the connection then signed exactly
what a `none`-mode relay signs, which is the state that sentence exists to
forbid. The `Ok` branch was unchecked too: §5.3's rule is about the exporter's
**output**, not about the error, so a successful all-zero return would also have
passed through.

The doc comment on `export()` asserted the opposite of the spec ("Returns 32
zero bytes when there is no TLS session, which is the value §5.3 requires in
`channel_binding_mode: none` — the same constant both ends use"). It does not
hold here: the peer is a TLS client whose own exporter succeeded, so it derives
a real binding, not zeros.

**Severity, stated plainly:** this is fail-closed in practice. A relay signing
against zeros while the client signs against a real exporter fails every
signature with `ERR_BAD_SIGNATURE`; the connection is useless rather than
unprotected. The value of the fix is conformance, and a clear refusal instead of
an obscure signature failure — the same trade `f2z-relay-proto/src/hello.rs`
already makes on the client side ("a signature made under that disagreement
fails later, obscurely. Fail now, clearly.").

## The fix

`export()` returns `Option<ChannelBinding>`. Both the failing exporter and a
zero output return `None`, each with a warning that names §5.3. The zero check
lives in a small `binding_from_exporter` helper so §5.3's rule about the
*output* can be exercised without terminating TLS.

`listener.rs` refuses with `?`, which is already how `handshake` reports "no
connection" — the `accept_hdr_async(...).ok()?` two lines below takes the same
path, the `connections_open` gauge is decremented and the abuse permit released
by the existing code in `serve`.

The plaintext branch is untouched: a relay in `channel_binding_mode: none` still
carries `ChannelBinding::zero()` exactly as §5.3 requires.

## Falsification

The guard was reverted by string replacement (`if binding.is_zero()` →
`if false`), not by `git checkout`, so only the guard changed and the new tests
stayed in place.

| Mutation | Command | Result |
| --- | --- | --- |
| none (the fix as committed) | `cargo test -p f2z-relay --lib tls::` | `EXIT=0` — `test result: ok. 5 passed; 0 failed` |
| `if binding.is_zero()` → `if false` | `cargo test -p f2z-relay --lib tls::` | `EXIT=101` — `a_zero_exporter_output_yields_no_binding ... FAILED`, `assertion failed: binding_from_exporter([0u8; EXPORTER_LEN]).is_none()`, `test result: FAILED. 4 passed; 1 failed` |
| guard restored | `cargo test -p f2z-relay --lib tls::` | `EXIT=0` — `test result: ok. 5 passed; 0 failed` |

Under the mutation the positive control (`a_real_exporter_output_yields_that_binding`)
still passed, so the failure is attributable to the sentinel and not to the test
refusing everything.

## Verification

Run from `rs/` in the worktree, on the committed tree:

- `cargo fmt --check` → **exit 0**, no output.
- `cargo clippy --workspace --all-targets -- -D warnings` → **exit 0**
  (`Finished \`dev\` profile [unoptimized + debuginfo] target(s)`).
- `cargo test --workspace --no-fail-fast` → **`EXIT=0`**, 80 `^test result: ok`
  lines, 0 non-ok `test result` lines. (`error …` lines in the log are the
  relay's own log output from tests, not compile errors.)

Baseline, measured in the same worktree with `tls.rs` and `listener.rs` restored
to `origin/main` and everything else identical: **`EXIT=0`, 80 `^test result: ok`
lines** — the same, so the change adds two tests to an existing target and
regresses nothing. (The 73 figure from an earlier session was taken on an older
`main`; the base here is 5bc785b.)

## `f2z-relay-testkit`: checked, and it does **not** share the gap

`ChannelBindingSource::Simulated([0u8; 32])` would look like the same hole —
`tls-exporter` published over a zero binding — but it is already unreachable,
and for a reason one layer up. `Relay::new` calls
`f2z_relay_proto::capabilities::validate`, which refuses
`transport_security: none` together with any `channel_binding_mode` other than
`none` (§2.3 obligation 2), and a `FakeRelay` serves `ws://` so its transport is
always `none`. Measured with a temporary probe: both
`with_simulated_channel_binding([0u8; 32])` and
`with_simulated_channel_binding([7u8; 32])` fail with
`Config("the configured capability document is invalid")`. So no fix is included
here — a guard for the zero case would be dead code.

That measurement did surface a separate, smaller thing worth its own issue:
**`RelayConfig::with_simulated_channel_binding` cannot produce a startable
`FakeRelay` at all**, for any value, and has no callers in the workspace. Either
it needs a way to publish `tls-exporter` honestly or it should go. Out of scope
for a §5.3 conformance fix; noting it rather than folding it in.

## Not verified

- No test exercises `export()` against a real `rustls` `ServerConnection`: the
  crate has no certificate-generation dev-dependency, so a live TLS 1.3
  handshake cannot be stood up here. The tests cover §5.3's rule about the
  exporter's output; the `Err` arm's refusal is verified by reading, not by
  execution.
- CI has not run at the time of writing.

Closes #670

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
