### PR TITLE
fix(zuuli): keep seal_verifier stdout to the sealed digest

### DIFF
--- a/wallet/zuuli/scripts/android-release-artifact.node-test.mjs
+++ b/wallet/zuuli/scripts/android-release-artifact.node-test.mjs
@@ -46,6 +46,33 @@ test("records and verifies a checksum-closed four-ABI AAB", async (t) => {
   assert.equal(source.verifier.sha256, verifierSha);
 });
 
+test("record and seal-verifier print one bare digest and nothing else", async (t) => {
+  const { root, aab, output, verifier, verifierSha } = await fixture();
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  // $GITHUB_OUTPUT takes one key=value per line, so every extra stdout line
+  // from a helper (`sha256sum -c` names each member) breaks the release job.
+  const recorded = run(["record", aab, "0.1.0+14", "a".repeat(40), "b".repeat(40), output]);
+  assert.equal(recorded.status, 0, recorded.stderr);
+  assert.match(recorded.stdout, /^[0-9a-f]{64}\n$/);
+
+  const sealed = run(["seal-verifier", output, verifier, verifierSha]);
+  assert.equal(sealed.status, 0, sealed.stderr);
+  assert.match(sealed.stdout, /^[0-9a-f]{64}\n$/);
+  assert.equal(sealed.stdout.trimEnd().split("\n").length, 1, sealed.stdout);
+});
+
+test("seal-verifier still refuses a recorded member that drifted", async (t) => {
+  const { root, aab, output, verifier, verifierSha } = await fixture();
+  t.after(() => rm(root, { recursive: true, force: true }));
+  assert.equal(run(["record", aab, "0.1.0+14", "a".repeat(40), "b".repeat(40), output]).status, 0);
+  // Silencing the pre-seal checksum check must not disable it.
+  await writeFile(join(output, "aab-members.txt"), "drifted\n");
+  const sealed = run(["seal-verifier", output, verifier, verifierSha]);
+  assert.notEqual(sealed.status, 0);
+  assert.match(sealed.stderr, /unsigned artifact is not ready to seal/);
+});
+
 test("rejects missing ABIs and checksum drift", async (t) => {
   const { root, aab, output, verifier, verifierSha } = await fixture();
   t.after(() => rm(root, { recursive: true, force: true }));

--- a/wallet/zuuli/scripts/android-release-artifact.sh
+++ b/wallet/zuuli/scripts/android-release-artifact.sh
@@ -74,7 +74,11 @@ seal_verifier() {
     actual_inventory=$({ for path in ./*; do [[ -f "$path" && ! -L "$path" ]] || exit 1; printf '%s\n' "${path#./}"; done; } | LC_ALL=C sort | tr '\n' ' ') || exit 1
     [[ "$actual_inventory" == \
       "CHECKSUMS.sha256 ZUULI-android-unsigned.aab aab-members.txt source-record.json " ]] || exit 1
-    sha256sum -c CHECKSUMS.sha256
+    # Stdout of seal_verifier is the sealed digest and nothing else; `-c` reports
+    # every member on stdout, so keep only its exit status. Redirecting rather
+    # than passing --status keeps sha256sum's stderr diagnostics (unreadable
+    # members, the mismatch warning).
+    sha256sum -c CHECKSUMS.sha256 >/dev/null
   ) || { echo "unsigned artifact is not ready to seal" >&2; return 1; }
   cp "$verifier" "$directory/bundletool-all-1.18.3.jar" || return 1
   local source_record_tmp="$directory/source-record.json.tmp"


### PR DESCRIPTION
## What broke

Build `0.1.0+15` built its AAB, then died in output handling three seconds later — it reached TestFlight and **never reached the Play internal track**.

[Run 32885179531](https://github.com/free2z/zuu/actions/runs/32885179531), job `Android / credential-free unsigned universal AAB`, step 14 `Build source-bound unsigned universal AAB`:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format 'aab-members.txt: OK'
```

## Cause (one line)

`sha256sum -c CHECKSUMS.sha256` at `android-release-artifact.sh:77` writes `<member>: OK` for every member **to stdout**, so `seal_verifier` — contracted to print only the sealed digest — printed four lines, and `zuuli-release.yml:290` captured all four into `payload_sha256`; line two has no `=`, so the runner rejected the whole `$GITHUB_OUTPUT` write.

Measured on the mutated (pre-fix) script:

```
ZUULI-android-unsigned.aab: OK
aab-members.txt: OK
source-record.json: OK
5dc737435d3336212a850e86695d3d13009116c3f1fcfb3450d9950788c9155e
```

`seal-verifier` entered the release workflow in #534, after `0.1.0+14`, so build 15 was its first ever execution.

## Fix

```sh
sha256sum -c CHECKSUMS.sha256 >/dev/null
```

Exit status — the only thing `:78` reads — is unchanged. `>/dev/null` rather than `--status` keeps sha256sum's **stderr** diagnostics (unreadable members, `WARNING: N computed checksum did NOT match`). Measured on this platform, the per-member `FAILED` line goes to stdout and is therefore silenced too, while that stderr warning survives; `--status` would silence both. Nothing else about the function changed.

## Falsification

The new test was proved to fail before it was allowed to pass. The `>/dev/null` was removed **by string replacement only** (`perl -0pi -e`), never `git checkout`, so the rest of the change stayed in place.

| Mutation | `node --test --test-name-pattern="one bare digest"` |
| --- | --- |
| `sha256sum -c CHECKSUMS.sha256` (the bug restored) | **FAIL** — `The input did not match the regular expression /^[0-9a-f]{64}\n$/`, actual stdout was the exact four lines the runner choked on |
| `sha256sum -c CHECKSUMS.sha256 >/dev/null` (restored) | **PASS** |

Failing run, verbatim:

```
TAP version 13
# Subtest: record and seal-verifier print one bare digest and nothing else
not ok 1 - record and seal-verifier print one bare digest and nothing else
  ---
  error: |-
    The input did not match the regular expression /^[0-9a-f]{64}\n$/. Input:

    'ZUULI-android-unsigned.aab: OK\n' +
      'aab-members.txt: OK\n' +
      'source-record.json: OK\n' +
      '5dc737435d3336212a850e86695d3d13009116c3f1fcfb3450d9950788c9155e\n'
  ...
# tests 1
# pass 0
# fail 1
```

## Tests added

Both in the existing home, `wallet/zuuli/scripts/android-release-artifact.node-test.mjs` (already listed in `package.json`'s `test` script and in `scripts/check-github-actions-pins.mjs`, so no harness or manifest changes were needed):

- **`record and seal-verifier print one bare digest and nothing else`** — pins the *contract*: stdout matches `^[0-9a-f]{64}\n$` and is exactly one line. Covers `record` too, per the issue's request, so the caller's `>/dev/null` at `zuuli-release.yml:288` stops being load-bearing.
- **`seal-verifier still refuses a recorded member that drifted`** — guards the obvious over-fix: silencing the check must not disable it. A tampered `aab-members.txt` still exits non-zero with `unsigned artifact is not ready to seal` on stderr.

## Audit of `record` and `verify`

Empirically measured, running each subcommand against a fixture artifact and splitting the streams:

| Subcommand | stdout on success | Captured by a caller? | Verdict |
| --- | --- | --- | --- |
| `record` | one bare 64-hex digest | yes — `zuuli-release.yml:288`, with `>/dev/null` | already correct; now pinned by test |
| `seal-verifier` | four lines → **now one bare digest** | yes — `zuuli-release.yml:292`, bare `$(...)` | **the bug; fixed** |
| `verify` | four `<member>: OK` lines | **no caller anywhere in the repo** outside the node tests, which read only its exit status | left alone, noted below |

Two same-class latent leaks found and deliberately **not** changed, because neither can corrupt a captured value today and both are behavior changes outside this fix:

1. **`verify` at `:101`** has the identical `sha256sum -c` stdout spray, plus `cmp` at `:105` which prints diffs to stdout. `verify`'s contract is its exit status, its stdout is unspecified, and no caller captures it — so this is untidiness, not the outage. Its chatty output is also useful when a human runs `verify` by hand, so silencing it is a judgement call rather than an obvious fix.
2. **`validate_archive` at `:25`**, reached from both `record` and `verify`: `grep -E '<unsafe pattern>' "$listing"` prints the offending member names to **stdout** (the human-readable message beside it correctly goes to stderr). This only fires on the failure path, where the function returns 1 and `record` never prints a digest — so no caller can mistake the leak for a value. `grep -qE` plus an explicit stderr diagnostic would be the tidy form.

Both are worth a follow-up issue — "every subcommand guarantees its own stdout instead of trusting the caller to redirect" — rather than scope creep here.

## Verification (verbatim)

`npm ci` first, from `wallet/zuuli/`.

`node --test scripts/android-release-artifact.node-test.mjs`:

```
ok 1 - records and verifies a checksum-closed four-ABI AAB
ok 2 - record and seal-verifier print one bare digest and nothing else
ok 3 - seal-verifier still refuses a recorded member that drifted
ok 4 - rejects missing ABIs and checksum drift
ok 5 - rejects an unpinned or post-seal mutated verifier
ok 6 - Android build canary rejects ambient signing and upload authority
# tests 6
# pass 6
# fail 0
```

`bash -n wallet/zuuli/scripts/android-release-artifact.sh` — exit 0, no output.

`shellcheck` **was** available (`/opt/homebrew/bin/shellcheck`); `shellcheck wallet/zuuli/scripts/android-release-artifact.sh` produced no findings.

Neighbouring checks that read this script's call sites, run to prove nothing regressed:

```
$ node scripts/apple-credential-boundary.mjs
Store-release build, credential, and finalization boundaries verified.

$ node --test scripts/apple-credential-boundary.node-test.mjs
# tests 145
# pass 145
# fail 0
```

`npm run typecheck` — clean (no TypeScript was touched; run for safety). The Rust workspace was not run: this change does not touch `rs/`.

## Not verified

The fix is proved against the script's real behavior on a fixture artifact, not against a live GitHub runner — the actual `$GITHUB_OUTPUT` write can only be observed by a release run. `STATUS.md` and `release.json` are deliberately untouched; because this lands in `wallet/zuuli/`, shipping Android needs a fresh identity (`0.1.0+16`), not a re-run of build 15's pinned source.

Closes #738

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
