### PR TITLE
fix(relay): §12.3's target check must not be disableable by its caller

### DIFF
--- a/rs/crates/f2z-relay-testkit/src/state.rs
+++ b/rs/crates/f2z-relay-testkit/src/state.rs
@@ -646,10 +646,11 @@ impl RelayState {
         let Some(issued) = self.challenges.remove(challenge) else {
             return Err(ProtoError::Wire(ErrorCode::PowInvalid));
         };
-        if issued.purpose != purpose
-            || issued.expires_at_ms <= now_ms
-            || (!scope.is_empty() && issued.scope != scope)
-        {
+        // Unconditional, for the reason the real relay's `Challenges::consume`
+        // is (#663): a scope comparison skipped when the caller passes an empty
+        // scope is a §12.3 check with an off switch, and the reference relay
+        // must not certify a client against a laxer rule than the real one.
+        if issued.purpose != purpose || issued.expires_at_ms <= now_ms || issued.scope != scope {
             return Err(ProtoError::Wire(ErrorCode::PowInvalid));
         }
         Ok(())
@@ -822,6 +823,12 @@ mod tests {
                 .consume_challenge(&challenge, 2, &[8u8; 32], 1_000)
                 .is_err(),
             "a stamp computed for one victim must not be spendable on another"
+        );
+        // An absent scope is a wrong scope, not a waiver (#663).
+        let challenge = state.issue_challenge(2, &scope, 10_000);
+        assert!(
+            state.consume_challenge(&challenge, 2, &[], 1_000).is_err(),
+            "an empty scope must not switch the §12.3 target check off"
         );
         // …and the wrong-scope attempt still consumed it, which is what makes
         // a challenge single-use rather than single-*success*.

--- a/rs/crates/f2z-relay/src/challenge.rs
+++ b/rs/crates/f2z-relay/src/challenge.rs
@@ -155,10 +155,14 @@ impl Challenges {
         let Some(issued) = self.issued.remove(challenge) else {
             return Err(ProtoError::Wire(ErrorCode::PowInvalid));
         };
-        if issued.purpose != purpose
-            || issued.expires_at_ms <= now_ms
-            || (!scope.is_empty() && issued.scope != scope)
-        {
+        // The scope comparison is unconditional. An earlier form skipped it
+        // when the caller passed an empty `scope`, which made the check that
+        // stops a stamp being spent on another victim disableable by its own
+        // caller (#663). Nothing legitimate needed the exemption: `Clock` and
+        // `QueueCreate` challenges are issued with an empty scope — `check`
+        // for `GET_CHALLENGE` refuses any other — and consumed with an empty
+        // scope, so empty compares equal to empty and they pass unchanged.
+        if issued.purpose != purpose || issued.expires_at_ms <= now_ms || issued.scope != scope {
             return Err(ProtoError::Wire(ErrorCode::PowInvalid));
         }
         Ok(())
@@ -191,6 +195,43 @@ mod tests {
             .issue(challenge(2), purpose, b"victim", 1_000, 0)
             .unwrap();
         assert!(table.consume(&challenge(2), purpose, b"other", 0).is_err());
+
+        // An absent scope is a wrong scope, not a waiver (#663). The check that
+        // stops a stamp being spent on another victim must not be disableable
+        // by the caller who is supposed to be subject to it.
+        table
+            .issue(challenge(22), purpose, b"victim", 1_000, 0)
+            .unwrap();
+        assert!(
+            table.consume(&challenge(22), purpose, b"", 0).is_err(),
+            "an empty scope must not switch the §12.3 target check off"
+        );
+
+        // The control, so the two refusals above are attributable to the scope
+        // and not to a comparison that refuses everything.
+        table
+            .issue(challenge(23), purpose, b"victim", 1_000, 0)
+            .unwrap();
+        assert!(table.consume(&challenge(23), purpose, b"victim", 0).is_ok());
+    }
+
+    #[test]
+    fn an_unscoped_purpose_still_consumes_with_an_empty_scope() {
+        // The other half of the control for #663: making the comparison
+        // unconditional must not break `Clock` and `QueueCreate`, whose
+        // challenges are issued with an empty scope — `GetChallenge::check`
+        // refuses any other — and consumed with an empty one.
+        let mut table = Challenges::new(8);
+        for purpose in [ChallengePurpose::Clock, ChallengePurpose::QueueCreate] {
+            table
+                .issue(challenge(24), purpose.code(), &[], 1_000, 0)
+                .unwrap();
+            assert!(
+                table
+                    .consume(&challenge(24), purpose.code(), &[], 0)
+                    .is_ok()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What §12.3 requires

> *Binding the stamp to the target address and to a relay-issued challenge means
> stamps cannot be precomputed at leisure before a campaign, cannot be reused,
> and **cannot be computed for one victim and spent on another**.*

`challenge.rs` quotes that paragraph in its own module doc as the reason the
module exists. The third clause is `Challenges::consume`'s job alone.

## The guard, and why an empty scope defeats it

```rust
if issued.purpose != purpose
    || issued.expires_at_ms <= now_ms
    || (!scope.is_empty() && issued.scope != scope)
```

`!scope.is_empty() &&` means that when the caller passes an empty `scope`, the
comparison never runs and a challenge issued for `b"victim"` is spent
successfully by a caller who names no victim at all. The check that enforces the
"one victim, another victim" clause has an off switch, and the switch is one of
its own arguments — the caller it is supposed to be judging decides whether it
applies.

This is the same shape as zuu#669 (`/kt/v1/cosign`): `if !known.is_empty() && !known.contains(..)`,
an empty collection silently meaning "accept anything".

## The fix

```diff
-    || (!scope.is_empty() && issued.scope != scope)
+    || issued.scope != scope
```

**Nothing legitimate needed the exemption**, and I checked this on the current
tree rather than taking it from the issue. `GetChallenge::check`
(`rs/crates/f2z-relay-proto/src/command.rs:211-222`) is reached by both consume
paths' issuance via `CommandVerifier::accept_unsigned`, which calls `C::check`
at `command.rs:824`, and it says:

```rust
ChallengePurpose::Clock | ChallengePurpose::QueueCreate => request.scope.is_empty(),
ChallengePurpose::ContactAppend => request.scope.len() == QueueAddress::LEN,
```

So on the issuance side a `Clock`/`QueueCreate` challenge's scope is *forced*
empty. On the consumption side `check_creation_stamp` (`engine.rs:1227-1233`)
passes `&[]`. Empty compares equal to empty, and those paths pass unchanged —
which the new `an_unscoped_purpose_still_consumes_with_an_empty_scope` pins as a
test rather than leaving as an argument. `contact_append` (`engine.rs:1052-1059`)
passes a 32-byte `contact_addr` against a 32-byte issued scope, so it now
actually gets compared.

## Falsification

I did not trust that the new assertions can fail. I restored the guard by string
replacement (not `git checkout`, which would have reverted the tests too),
asserted the replacement matched in both files, and re-ran:

```
$ grep -c '!scope.is_empty() && issued.scope != scope' crates/f2z-relay/src/challenge.rs crates/f2z-relay-testkit/src/state.rs
crates/f2z-relay/src/challenge.rs:1
crates/f2z-relay-testkit/src/state.rs:1
```

| mutation | command | result |
|---|---|---|
| guard restored in `challenge.rs` | `cargo test -p f2z-relay --lib challenge::` | **EXIT=101** — `a_challenge_is_scoped_to_its_target` panicked at `challenge.rs:205`: *"an empty scope must not switch the §12.3 target check off"* (7 passed, 1 failed) |
| guard restored in `state.rs` | `cargo test -p f2z-relay-testkit --lib a_challenge_is_single_use_and_scoped` | **EXIT=101** — `a_challenge_is_single_use_and_scoped` panicked at `state.rs:829`, same message |
| fix restored (both) | `cargo test -p f2z-relay --lib challenge::` | **EXIT=0** — 8 passed |

Both new assertions fail for the intended reason and pass with the fix. Note the
mutated relay run still shows `an_unscoped_purpose_still_consumes_with_an_empty_scope ... ok`:
that test is the positive control and is *supposed* to be insensitive to the
mutation. The correctly-scoped consume in `a_challenge_is_scoped_to_its_target`
is the other control, so the refusals are attributable to the scope rather than
to a comparison that refuses everything.

## Baselines — measured here, not quoted

Full workspace suite from `rs/`, cold before / warm after, same machine:

| | `EXIT=` | `^test result: ok` lines | `^test result: FAILED` | tests passed |
|---|---|---|---|---|
| before (unmodified `origin/main`) | `EXIT=0` | 81 | 0 | 1032 |
| after | `EXIT=0` | 81 | 0 | 1033 |

`+1` is exactly the one new `#[test]` function; the other additions are
assertions inside two existing tests. No test moved.

Gates, all from `rs/`:

- `cargo fmt --check` → `EXIT=0`
- `cargo clippy --workspace --all-targets -- -D warnings` → `EXIT=0`
- `cargo test --workspace --no-fail-fast` → `EXIT=0`

## Reachability — honestly, not remotely exploitable today

I am not claiming a live vulnerability. The two consume sites are the only ones,
and neither can currently deliver an empty scope to a scoped challenge:

- `check_creation_stamp` passes a literal `&[]`, but for `QueueCreate`, whose
  issued scope is empty too — correct before and after.
- `contact_append` passes `body.contact_addr.as_bytes()`, and `QueueAddress` is
  `opaque_fixed!(QueueAddress, 32)` (`f2z-codec/src/types.rs:122-128`), so
  `as_bytes()` returns `&[u8; 32]` and **can never be empty**.

So what stands between the guard and the property it protects is a fixed-length
type two layers away, holding by construction rather than by anything that would
notice if it changed. #661 tightened the *issuance* side; this tightens the
*consumption* side so the invariant is enforced where it is stated instead of
being an emergent consequence of an unrelated type's width.

## Testkit

`f2z-relay-testkit`'s fake relay had **the same bypass**, character for character,
in `RelayState::consume_challenge` (`state.rs:651`), reached from its own
`check_stamp` at `engine.rs:1065`. Fixed in the same commit rather than deferred:
it is the identical bug and the identical one-line fix, and a reference relay
that accepts what the real relay refuses would certify a client against a laxer
rule than the thing it is a model of. Its test
`a_challenge_is_single_use_and_scoped` had the same blind spot — a wrong scope
that was never empty — and got the same extra case.

A workspace-wide `grep -rn 'is_empty() &&'` found no third instance of this
pattern acting as a check-disabler.

Closes #663

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
