### PR TITLE
docs(zuuli): re-derive the release-readiness audit for 0.1.0+16

### DIFF
--- a/wallet/zuuli/STATUS.md
+++ b/wallet/zuuli/STATUS.md
@@ -8,7 +8,7 @@ back from the named store. Authenticated, money-moving, wallet, KYC, and media
 operations are not called working without recorded evidence from that path.
 
 Last re-derived from `origin/main` at
-`66aebd12e2af75692c8ca0ddf4ee0cfba8463434` on 2026-08-25. Before a release,
+`4bbbf277bf20c2a2e97d440c3a2e2e04e1d4c997` on 2026-08-25. Before a release,
 update the evidence and disposition for every non-ready row; do not carry this
 commit or date forward mechanically.
 
@@ -52,7 +52,7 @@ commit or date forward mechanically.
 | Buy 2Z with card | Authenticated Stripe Checkout creation, hosted Checkout, signed webhook credit, and a server-controlled return bridge | Native OS opener is used in packaged apps; the exact `cash.free2z.zuuli://checkout/return` route is registered on iOS/Android and claimed through the authenticated server bridge | #400 added signed-out gating, exact HTTPS host validation, actionable failures, and opener tests | Anonymous production checkout returned HTTP 403; no signed-in staging/live charge or signed-build return is recorded | **Wired, not runtime-proven.** Native return is blocked on an unshipped backend dependency tracked internally, so no native return has been exercised against a live charge. Track the end-to-end path in [#388](https://github.com/free2z/zuu/issues/388) and exact charge/credit integrity in [#399](https://github.com/free2z/zuu/issues/399). |
 | Buy 2Z with ZEC | Public pricing/quote plus wallet spend and backend settlement/credit | Wallet bridge exists; production settlement is intentionally disabled | Quote parsing and explicit browser-only demo-boundary tests | Pricing and an exact 100-2Z quote returned HTTP 200; no spend/settlement exists | **Mock/demo only for settlement; unavailable in release builds:** [#155](https://github.com/free2z/zuu/issues/155). A price quote is not a top-up. |
 | 2Z Activity | Authenticated Stripe purchase ledger | Native HTTP | Parsing/UI tests do not prove a complete ledger | Protected endpoint returned HTTP 403 anonymously; authenticated ledger not exercised | **Known incomplete:** the endpoint is purchases-only and cannot substantiate tips/AI/PPV totals ([#172](https://github.com/free2z/zuu/issues/172)). |
-| Internal distribution and store presentation | GitHub release train, App Store Connect, and Google Play | Signed mobile bundles plus generated platform/store icons | Release identity, icon/store validators, protected state machines, and all-target packaging are gated | A fresh read-only readback on 2026-08-25 reports TestFlight `0.1.0+14` `uploaded`, `processed` and `availableToInternalTesters` all true, `VALID`/`IN_BETA_TESTING`, related to the one internal-only group; Play build 14 is present on the internal track. No physical-device acceptance is recorded. The same-day Apple/Play audits found canonical listing copy unmatched and every declared screenshot set absent remotely | **Internal delivery exists; publication presentation and device acceptance are incomplete.** Store media: [#387](https://github.com/free2z/zuu/issues/387). Physical installs: [#238](https://github.com/free2z/zuu/issues/238). Play remains owner-selected Console email-list mode: [#296](https://github.com/free2z/zuu/issues/296). |
+| Internal distribution and store presentation | GitHub release train, App Store Connect, and Google Play | Signed mobile bundles plus generated platform/store icons | Release identity, icon/store validators, protected state machines, and all-target packaging are gated | A read-only readback at 21:19Z on 2026-08-25 reports TestFlight `0.1.0+15` `uploaded`, `processed` and `availableToInternalTesters` all true, `VALID`/`IN_BETA_TESTING`, related to the one internal-only group. **Play is a build behind: the same-hour audit reports the exact release 15 `present: false`**, because build 15's Android job died before packaging ([#738](https://github.com/free2z/zuu/issues/738)); 14 remains the latest Play internal build. No physical-device acceptance is recorded. The audits found canonical listing copy unmatched and every declared screenshot set absent remotely | **iOS internal delivery is current; Android is one build behind; publication presentation and device acceptance are incomplete.** Store media: [#387](https://github.com/free2z/zuu/issues/387). Physical installs: [#238](https://github.com/free2z/zuu/issues/238). Play remains owner-selected Console email-list mode: [#296](https://github.com/free2z/zuu/issues/296). |
 
 ## Current production and distribution evidence
 
@@ -87,29 +87,39 @@ one.
 
 Distribution evidence is narrower and explicit:
 
+- [Protected release run 32885179531](https://github.com/free2z/zuu/actions/runs/32885179531)
+  delivered `0.1.0+15` to TestFlight on 2026-08-25 — iOS unsigned archive,
+  system export and signing, credential-free signed artifact verification, App
+  Store validation and TestFlight, and shipped-artifact provenance all
+  succeeded. **Its Android job failed** in `seal_verifier`, before packaging,
+  so no Play internal release exists for build 15
+  ([#738](https://github.com/free2z/zuu/issues/738), fixed after that run).
+  The run's first attempt failed earlier still, at `Set up job`, because
+  GitHub began validating an allowed action's own internal sub-action
+  reference against the repository Actions allowlist; the allowlist now
+  carries `actions/attest-build-provenance/*@*` and remains closed to
+  GitHub-owned and verified-creator actions.
 - [Protected release run 32624780318](https://github.com/free2z/zuu/actions/runs/32624780318)
-  built, signed, and delivered `0.1.0+14` on 2026-08-23: Play internal, iOS
-  export/signing, App Store validation and TestFlight, and the credential-free
-  shipped-artifact provenance jobs all succeeded.
-- [Packaging run 32856592558](https://github.com/free2z/zuu/actions/runs/32856592558)
-  built the Linux AppImage/deb/rpm, macOS, unsigned iOS, and unsigned Android
-  targets from `6aeff5dc`, the immediate parent of this audit's source.
-- [TestFlight read-only recovery 32875338031](https://github.com/free2z/zuu/actions/runs/32875338031)
-  read back `0.1.0+14` on 2026-08-25 with `uploaded`, `processed`, and
-  `availableToInternalTesters` all true, `processingState: VALID`,
+  built, signed, and delivered `0.1.0+14` on 2026-08-23, including Play
+  internal. That is the newest build on the Play internal track.
+- [TestFlight read-only recovery 32900398788](https://github.com/free2z/zuu/actions/runs/32900398788)
+  read back `0.1.0+15` at 21:19Z on 2026-08-25 with `uploaded`, `processed`,
+  and `availableToInternalTesters` all true, `processingState: VALID`,
   `internalBuildState: IN_BETA_TESTING`, `usesNonExemptEncryption: false`, and
   the exact build relationship to the single internal-only group verified. It
   did not read or log tester identities.
-- [Store listing audit 32875367578](https://github.com/free2z/zuu/actions/runs/32875367578)
+- [Store listing audit 32900401023](https://github.com/free2z/zuu/actions/runs/32900401023)
   audited both providers against this audit's source with no provider failure
   and `publicationReady: false`. Apple matched the app identity but no `en-US`
   app-info, beta-info, or exact-version metadata, and both declared screenshot
   sets — four candidates each for iPhone 6.9-inch and iPad 13-inch — have a
-  remote count of zero. Play matched the identity and found exact build 14 on
-  the internal track, with listing, details, and release notes unmatched and
-  icon, feature graphic, phone, 7-inch, and 10-inch counts all zero. Play
-  tester eligibility remains the owner-declared Console email-list mode with no
-  API-visible Google Groups, which the API cannot enumerate either way. The
+  remote count of zero. Play matched the identity and reported the exact
+  release 15 **`present: false`**, which is the store-side confirmation of the
+  Android gap above rather than an inference from a CI log; listing, details,
+  and release notes are unmatched and icon, feature graphic, phone, 7-inch,
+  and 10-inch counts are all zero. Play tester eligibility remains the
+  owner-declared Console email-list mode with no API-visible Google Groups,
+  which the API cannot enumerate either way. The
   temporary read-only Play edit was deleted without commit.
 
 These runs prove package/store state, not product operations. No repository


### PR DESCRIPTION
Re-derived against `4bbbf277`, ahead of an Android-only follow-up release. The
probes were re-run, not restated.

**Nothing moved on the API side.** All eight anonymous GETs returned the same
statuses and top-level contracts as this morning's audit, the five protected
probes are still 403, and `/api/dyte/public/` still reports `count: 0`.
`/api/auth/social/mobile/providers/` is still 200 with all three providers
`configured: false`.

**The distribution rows did move, in both directions.** iOS is current: a
read-only readback at 21:19Z reports `0.1.0+15` `uploaded`, `processed` and
`availableToInternalTesters` all true, `VALID` / `IN_BETA_TESTING`, exact build
relationship to the one internal-only group verified.

Android is a build behind, and the audit says so from the store rather than
from a log: the Play provider reports exact release 15 **`present: false`**.
Build 15's Android job died in `seal_verifier` before packaging (#738, fixed in
#739 after that run), so 14 remains the newest build on the Play internal
track. That is now the disposition — "iOS internal delivery is current;
Android is one build behind" — instead of the flat "internal delivery exists".

Also recorded, because it is release-relevant and was not visible anywhere:
build 15's first attempt failed at `Set up job`, before building anything,
when GitHub began validating an allowed action's own internal sub-action
reference against the repository Actions allowlist. The allowlist now carries
`actions/attest-build-provenance/*@*` and still admits neither GitHub-owned
nor verified-creator actions.

The device checklist is unchanged and still unmet; no signed-device wallet
operation has been recorded in this repository.

`npm run test:status-freshness`: 31 tests, 31 pass.

Claude-Session: https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD