### PR TITLE
fix(kt-core): §7.2's contradiction test may only compare verified cosignatures

### DIFF
--- a/rs/crates/f2z-kt-core/src/cosign.rs
+++ b/rs/crates/f2z-kt-core/src/cosign.rs
@@ -12,9 +12,19 @@
 //!    without first obtaining the log's signature *and* its key, from the very
 //!    party under suspicion.
 //! 2. **Two conflicting statements are directly non-repudiable against the
-//!    witness** — see [`WitnessCosignature::contradicts`]. No third document is
-//!    needed to establish the contradiction. That is what makes a witness
+//!    witness** — see [`VerifiedCosignature::contradicts`]. No third document is
+//!    needed to establish the contradiction: the two cosignatures and the
+//!    witness's own public key are the whole proof. That is what makes a witness
 //!    accountable rather than merely helpful.
+//!
+//!    Non-repudiation is a property of *signatures*, so the contradiction test
+//!    lives on [`VerifiedCosignature`] and not on [`WitnessCosignature`].
+//!    Unverified cosignature bytes are a document anyone can author — flip a
+//!    byte of a genuine `root_hash` and you hold a "second statement" the
+//!    witness never made. A predicate that compared only the statement fields
+//!    would call that a contradiction and hand its caller an accusation with no
+//!    authentication behind it, which is the one direction this crate must never
+//!    let a caller get wrong.
 //! 3. **`witness_pk` is inside the signed bytes**, so a cosignature cannot be
 //!    re-attributed to another witness, and a witness cannot later claim a
 //!    cosignature was someone else's.
@@ -56,7 +66,7 @@ pub struct WitnessCosignatureTBS {
     /// statement cannot be re-attributed.
     pub witness_pk: PublicKey,
     /// When the witness saw it. Deliberately **excluded** from the
-    /// contradiction test — see [`WitnessCosignature::contradicts`].
+    /// contradiction test — see [`VerifiedCosignature::contradicts`].
     pub observed_at_ms: u64,
 }
 
@@ -138,6 +148,55 @@ impl WitnessCosignature {
             && self.statement.root_hash == head.sth.root_hash
     }
 
+    /// Verify the signature and **carry the proof in the type**.
+    ///
+    /// The only way to obtain a [`VerifiedCosignature`], and therefore the only
+    /// way to reach [`VerifiedCosignature::contradicts`]. Takes `self` so the
+    /// unverified value is consumed rather than left beside the verified one.
+    ///
+    /// # Errors
+    ///
+    /// Exactly [`WitnessCosignature::verify`]'s: [`KtError::WrongLabel`],
+    /// [`KtError::UnsupportedVersion`] or [`KtError::BadSignature`].
+    pub fn verified(self) -> Result<VerifiedCosignature, KtError> {
+        self.verify()?;
+        Ok(VerifiedCosignature { cosignature: self })
+    }
+}
+
+/// A cosignature whose signature has been checked under the `witness_pk` inside
+/// its own signed bytes — a statement the witness provably made.
+///
+/// It has no public constructor and no `From`.
+/// [`WitnessCosignature::verified`] is the only thing that builds one, and it
+/// builds one only after [`WitnessCosignature::verify`] has passed, so holding
+/// this type *is* the proof that the check ran. That is the same shape as
+/// [`crate::witness::AcceptedRoot`] and [`crate::auditor::AppendOnlyVerified`]
+/// elsewhere in this crate: the rule is not a step a caller can forget, because
+/// the token is the argument the next step needs.
+///
+/// §7.2's accountability claim is what forces it here. "Verify both, then
+/// compare" as a documented precondition is a rule review has to notice; making
+/// the compare take two verified values is a rule the compiler notices instead.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedCosignature {
+    cosignature: WitnessCosignature,
+}
+
+impl VerifiedCosignature {
+    /// The statement whose signature checked out.
+    #[must_use]
+    pub const fn statement(&self) -> &WitnessCosignatureTBS {
+        &self.cosignature.statement
+    }
+
+    /// The cosignature itself — to re-serve, to store, or to publish as the
+    /// evidence half of a fault report.
+    #[must_use]
+    pub const fn as_cosignature(&self) -> &WitnessCosignature {
+        &self.cosignature
+    }
+
     /// Whether these two cosignatures are a contradiction on their face (§7.2).
     ///
     /// The test is exactly `(log_id, epoch)` equal and `(tree_size, root_hash)`
@@ -152,13 +211,18 @@ impl WitnessCosignature {
     /// non-repudiation §7.2 claims is specifically that *one* witness signed two
     /// contradictory statements, which is a fault of that witness and needs no
     /// third document to establish.
+    ///
+    /// Both sides are [`VerifiedCosignature`]s and neither can be built without
+    /// a passing signature check, so "the witness signed this" is not something
+    /// this predicate assumes about its arguments — it is something their type
+    /// already proved.
     #[must_use]
     pub fn contradicts(&self, other: &Self) -> bool {
-        self.statement.witness_pk == other.statement.witness_pk
-            && self.statement.log_id == other.statement.log_id
-            && self.statement.epoch == other.statement.epoch
-            && (self.statement.tree_size != other.statement.tree_size
-                || self.statement.root_hash != other.statement.root_hash)
+        let (this, that) = (self.statement(), other.statement());
+        this.witness_pk == that.witness_pk
+            && this.log_id == that.log_id
+            && this.epoch == that.epoch
+            && (this.tree_size != that.tree_size || this.root_hash != that.root_hash)
     }
 }
 
@@ -226,22 +290,93 @@ mod tests {
         forked.sth.root_hash = Digest::new([0xaa; 32]);
         let forked = log.resign(forked);
 
-        let a = log.cosign(&head, 1, 1_700_000_000_000);
-        let b = log.cosign(&forked, 1, 1_700_000_100_000);
+        // Both verify, and saying so is not a separate assertion beside the
+        // comparison any more: `verified()` is the only way to reach
+        // `contradicts`, so the contradiction below cannot be established on
+        // anything the witness did not sign.
+        let a = log
+            .cosign(&head, 1, 1_700_000_000_000)
+            .verified()
+            .expect("a genuine cosignature verifies");
+        let b = log
+            .cosign(&forked, 1, 1_700_000_100_000)
+            .verified()
+            .expect("a genuine cosignature verifies");
         assert!(a.contradicts(&b));
         assert!(b.contradicts(&a));
-        // Both verify. That is the point: the contradiction needs no third
-        // document, only the two cosignatures and the witness's public key.
-        assert_eq!(a.verify(), Ok(()));
-        assert_eq!(b.verify(), Ok(()));
+        // The contradiction needs no third document, only the two cosignatures
+        // and the witness's public key — which is inside them.
+        assert_eq!(a.statement().witness_pk, log.witness_pk(1));
+    }
+
+    #[test]
+    fn an_unsigned_forgery_never_becomes_a_verified_cosignature() {
+        let log = TestLog::new();
+        let head = log.head(4);
+        let genuine = log.cosign(&head, 1, 1_700_000_000_000);
+        assert_eq!(genuine.verify(), Ok(()));
+
+        // Anyone holding one genuine cosignature can author this: flip a byte
+        // of the root and you have a second "statement" by that witness.
+        let mut forged = genuine.clone();
+        forged.statement.root_hash = Digest::new([0xcc; 32]);
+
+        assert_eq!(
+            forged.verified().err(),
+            Some(KtError::BadSignature),
+            "the forgery cannot acquire the proof `contradicts` requires",
+        );
+        // So the accusation is unreachable rather than merely discouraged:
+        // `contradicts` exists only on `VerifiedCosignature`, the forgery can
+        // never become one, and calling it on two `WitnessCosignature`s does
+        // not compile.
+        let genuine = genuine.verified().expect("the genuine one verifies");
+        assert_eq!(genuine.statement().root_hash, head.sth.root_hash);
+    }
+
+    #[test]
+    fn a_forged_second_statement_cannot_be_paired_with_a_genuine_one() {
+        let log = TestLog::new();
+        let head = log.head(4);
+        let genuine = log
+            .cosign(&head, 1, 1_700_000_000_000)
+            .verified()
+            .expect("a genuine cosignature verifies");
+
+        // Every field a forger controls, one at a time — each would satisfy
+        // `contradicts`'s field test, and none of them can be verified into a
+        // value `contradicts` accepts.
+        let mut wrong_root = genuine.as_cosignature().clone();
+        wrong_root.statement.root_hash = Digest::new([0xcc; 32]);
+        let mut wrong_size = genuine.as_cosignature().clone();
+        wrong_size.statement.tree_size = head.sth.tree_size.saturating_add(1);
+
+        for forgery in [wrong_root, wrong_size] {
+            assert_eq!(
+                forgery.verified().err(),
+                Some(KtError::BadSignature),
+                "an accusation may not rest on bytes the witness never signed",
+            );
+        }
     }
 
     #[test]
     fn the_same_root_at_two_times_is_not_a_contradiction() {
         let log = TestLog::new();
         let head = log.head(4);
-        let a = log.cosign(&head, 1, 1_700_000_000_000);
-        let b = log.cosign(&head, 1, 1_700_009_999_999);
+        let a = log
+            .cosign(&head, 1, 1_700_000_000_000)
+            .verified()
+            .expect("a genuine cosignature verifies");
+        let b = log
+            .cosign(&head, 1, 1_700_009_999_999)
+            .verified()
+            .expect("a genuine cosignature verifies");
+        assert_ne!(
+            a.statement().observed_at_ms,
+            b.statement().observed_at_ms,
+            "the two really were observed at different times",
+        );
         assert!(
             !a.contradicts(&b),
             "observed_at_ms is excluded from the test on purpose",
@@ -256,8 +391,19 @@ mod tests {
         forked.sth.root_hash = Digest::new([0xbb; 32]);
         let forked = log.resign(forked);
 
-        let a = log.cosign(&head, 1, 1);
-        let b = log.cosign(&forked, 2, 1);
+        let a = log
+            .cosign(&head, 1, 1)
+            .verified()
+            .expect("a genuine cosignature verifies");
+        let b = log
+            .cosign(&forked, 2, 1)
+            .verified()
+            .expect("a genuine cosignature verifies");
+        assert_ne!(
+            a.statement().witness_pk,
+            b.statement().witness_pk,
+            "two different witnesses, both genuine",
+        );
         assert!(!a.contradicts(&b), "that is evidence against the log");
     }
 }

--- a/rs/crates/f2z-kt-core/src/lib.rs
+++ b/rs/crates/f2z-kt-core/src/lib.rs
@@ -34,6 +34,7 @@
 //! |---|---|---|
 //! | [`submit::AcceptedSubmission`] — the only carrier of an `AkdLabel`/`AkdValue` pair | [`submit::validate_submission`] | every rule in §4.4, in order |
 //! | [`witness::AcceptedRoot`] — the only root a proof may be verified against | [`witness::verify_threshold`] | ≥ *t* cosignatures from the caller's **own** witness set (§8.3) |
+//! | [`cosign::VerifiedCosignature`] — the only value §7.2's contradiction test compares | [`cosign::WitnessCosignature::verified`] | the witness's signature over its own statement, checked |
 //! | an advanced [`sth::LogView`] | [`sth::LogView::accept`] | all eight of §6.3's monotonicity rules, with no skipping over an epoch gap |
 //! | an advanced [`auditor::WitnessState`] | [`auditor::verify_append_only`] | `akd`'s auditor actually having run (§7.4) |
 //! | a successor log signing key | [`sth::LogView::accept_log_key_transition`] | a **cosigned** announcement plus both signatures (§6.4) |
@@ -127,7 +128,7 @@ pub use api::{
     AuditResponse, ErrorBody, HistoryRequest, HistoryResponse, LookupRequest, LookupResponse,
     Presence, SubmissionEnvelope, TreeHeadBundle,
 };
-pub use cosign::{WitnessCosignature, WitnessCosignatureTBS};
+pub use cosign::{VerifiedCosignature, WitnessCosignature, WitnessCosignatureTBS};
 pub use descriptor::{LogDescriptor, SignedLogDescriptor};
 pub use entry::{
     ContactEndpoint, DeviceCredential, DeviceCredentialTBS, DeviceRevocation, DirectoryEntry,


### PR DESCRIPTION
## What §7.2 claims

`cosign.rs`'s own module header names the contradiction test as the reason a
witness is a witness rather than a helper:

> 2. **Two conflicting statements are directly non-repudiable against the
>    witness** — see [`WitnessCosignature::contradicts`]. No third document is
>    needed to establish the contradiction. **That is what makes a witness
>    accountable rather than merely helpful.**

## The two defects

1. **It accused on bytes nobody signed.** `contradicts` compared
   `witness_pk`, `log_id`, `epoch`, `tree_size`, `root_hash` and never touched
   `self.signature`, and its doc comment did not state a precondition. Take a
   genuine cosignature, flip one byte of `root_hash`, and you hold a pair that
   `verify()` rejects and `contradicts()` calls a contradiction — an accusation
   with no authentication behind it, against a witness that signed one
   statement, not two. Non-repudiation is a property of signatures; that
   predicate never looked at one.
2. **It has no callers.** Log equivocation is caught elsewhere (`sth.rs`
   `LogView::accept` → `KtError::Fork`, `f2z-kt/src/log.rs`,
   `f2z-witness/src/state.rs`); those catch *the log* showing two heads for one
   epoch. Nothing catches *a witness* cosigning two roots for one epoch. This
   PR does not fix that half — see “Deliberately not done”.

## The design: make the precondition unrepresentable

Preferred option from the issue, and it worked cleanly.

```rust
pub fn verified(self) -> Result<VerifiedCosignature, KtError> {
    self.verify()?;
    Ok(VerifiedCosignature { cosignature: self })
}
```

`VerifiedCosignature` has a private field, **no public constructor and no
`From`**. `WitnessCosignature::verified` is the only thing that builds one, and
it builds one only after `verify()` passes, so holding the type *is* the proof
the check ran. `contradicts` moved onto it and takes `&VerifiedCosignature` on
both sides.

**Why enforcement by type beats a documented precondition here.** Every other
choke point in this crate is already shaped this way — `AcceptedRoot`
(`witness.rs`), `AppendOnlyVerified` (`auditor.rs`), `AcceptedSubmission`
(`submit.rs`) — and `lib.rs`'s own table says why: *“Forgetting a rule is not a
state a caller can reach by omission; it takes deleting a call, not failing to
write one.”* A doc line saying “verify both first” is a rule review has to
notice; a signature saying `&VerifiedCosignature` is a rule the compiler
notices. That matters more here than anywhere else in the module, because
`contradicts`'s output is an *accusation* rather than an acceptance —
`verify_threshold` already refuses to let “it verified” be read as “it agreed”
(`witness.rs:285-289`); this was the same confusion running the other way.
`VerifiedCosignature` is added to the `lib.rs` choke-point table alongside the
other three.

`verify()` itself is **unchanged**, deliberately: `verify_threshold`,
`Log::accept_cosignature` and the `f2z-kt` fixture all want “check this by
reference” and none of them wants the token. Adding `verified(self)` beside it
cost zero call-site churn — no fallout to fix anywhere in the workspace.

**What was kept.** Both semantics the old doc argued for are preserved verbatim,
with their explanations: `observed_at_ms` is excluded (a witness re-serving its
history is not a conflict) and two *different* witnesses return `false` (that is
evidence against the **log**, and `KtError::Fork`'s business).

## Falsification

Every new assertion was proved to fail before the fix. Method: inverse string
replacement into the source (never `git checkout`), asserting the replacement
matched **exactly once**, run, restore.

| Mutation applied | Test that failed | Result |
|---|---|---|
| M1 — `verified()` drops its `self.verify()?` | `an_unsigned_forgery_never_becomes_a_verified_cosignature`, `a_forged_second_statement_cannot_be_paired_with_a_genuine_one` | 2 FAILED, exit 101 |
| M2 — `contradicts` drops the `witness_pk` term | `two_witnesses_disagreeing_is_not_one_witness_contradicting_itself` | FAILED, exit 101 |
| M3 — `contradicts` adds an `observed_at_ms` term | `the_same_root_at_two_times_is_not_a_contradiction` | FAILED, exit 101 |
| M4 — `contradicts` inverted (`==`/`&&` for `!=`/`\|\|`) | `two_roots_for_one_epoch_by_one_witness_are_non_repudiable` (positive control), `the_same_root_at_two_times_...` | 2 FAILED, exit 101 |
| none (restored) | — | 8 passed, exit 0 |

**The misuse is now a compile error, not a failing test.** Issue #704's reviewer
test, pasted in verbatim and unmodified, no longer builds — this is the
falsification for defect 1, in the form the fix makes available:

```
error[E0599]: no method named `contradicts` found for struct `cosign::WitnessCosignature` in the current scope
   --> crates/f2z-kt-core/src/cosign.rs:387:21
    |
108 | pub struct WitnessCosignature {
    | ----------------------------- method `contradicts` not found for this struct
...
387 |             genuine.contradicts(&forged),
    |                     ^^^^^^^^^^^ method not found in `cosign::WitnessCosignature`

error[E0599]: no method named `contradicts` found for struct `cosign::WitnessCosignature` in the current scope
   --> crates/f2z-kt-core/src/cosign.rs:390:24
...
390 |         assert!(forged.contradicts(&genuine));
    |                        ^^^^^^^^^^^ method not found in `cosign::WitnessCosignature`

error: could not compile `f2z-kt-core` (lib test) due to 2 previous errors
```

That temporary test was removed after the demonstration; the committed suite
asserts the runtime half instead — verification *refuses* the forgery, on both
fields a forger controls (`root_hash`, `tree_size`), so the token the accusation
requires cannot be obtained.

## Verification, measured here, before and after

`cargo test --workspace --no-fail-fast`, backgrounded and polled:

| | `EXIT=` | `test result: ok` suites | assertions |
|---|---|---|---|
| before (`e2b228d`, this worktree) | `EXIT=0` | 81 | 1033 passed, 0 failed |
| after | `EXIT=0` | 81 | 1035 passed, 0 failed |

+2 is exactly the two new tests. From `rs/`:

- `cargo fmt --check` → `FMT_EXIT=0`
- `cargo clippy --workspace --all-targets -- -D warnings` → `CLIPPY_EXIT=0`
- `cargo test --workspace --no-fail-fast` → `EXIT=0`, 1035 passed / 0 failed

Also checked, since CI builds the client half for wasm32:
`cargo check --locked --lib -p f2z-kt-core --no-default-features --features verifier`
→ exit 0. `cargo doc --no-deps -p f2z-kt-core` adds **no** new warnings
(3 pre-existing, none in `cosign.rs`).

**Fallout: none.** The three `verify()` call sites — `witness.rs:301`,
`f2z-kt/src/log.rs:962`, `f2z-kt/tests/cosign.rs:92` — are untouched, because
`verify()`'s signature did not change. `contradicts` had no callers to migrate.

## Deliberately not done

**Wiring a caller.** §7.2's witness-equivocation detection still has no
production caller, which is the issue's second half and a different change.
The obvious seam is `f2z-kt`'s `Log::accept_cosignature`
(`f2z-kt/src/log.rs:953-985`): it already holds every previously accepted
cosignature for the epoch (`state.cosignatures`), already de-duplicates on
`witness_pk`, and today returns `KtError::Fork` when a cosignature does not
cover the head — which is the *log's* verdict about its own head, not the
non-repudiable witness-against-itself finding §7.2 describes. Comparing the
incoming cosignature against the stored one for the same `witness_pk` with
`VerifiedCosignature::contradicts` would produce that finding, and would want a
`FaultKind` to file it under and a decision about what the log publishes. That
is a design question with a storage and API surface, so it belongs in its own
PR rather than being wired speculatively here. This PR makes the primitive
sound so that whoever wires it cannot wire it wrong.

Closes #704

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
