### PR TITLE
fix(f2z-relay): a closed subscriber is not a full queue

### DIFF
--- a/rs/crates/f2z-relay/src/metrics.rs
+++ b/rs/crates/f2z-relay/src/metrics.rs
@@ -64,8 +64,17 @@ pub struct Metrics {
     pub challenges_issued: AtomicU64,
     /// Stamps refused as invalid, expired, misscoped or already spent.
     pub stamps_refused: AtomicU64,
-    /// Pushes dropped because a connection's outbound queue was full.
+    /// Pushes dropped because a connection's outbound queue was full — the
+    /// backpressure signal, and only that. A push to a subscriber whose
+    /// receiver is gone is counted by `pushes_to_closed` instead, because the
+    /// two call for opposite responses and mixing them made this number lie
+    /// during ordinary disconnect churn (zuu#676).
     pub pushes_dropped: AtomicU64,
+    /// Pushes dropped because the subscriber's receiver was gone: its writer
+    /// task ended and `drop_connection` has not run yet. Not backpressure —
+    /// there is no capacity to raise — but a sustained rise is still a signal,
+    /// about teardown rather than about the queue.
+    pub pushes_to_closed: AtomicU64,
     /// 1 while §13.1 layer 4 is on.
     pub backpressure: AtomicU64,
     /// Messages currently stored, as of the last expiry tick.
@@ -118,7 +127,7 @@ impl Metrics {
     /// function.
     #[must_use]
     pub fn render(&self) -> String {
-        const SERIES: [(&str, &str, &str); 22] = [
+        const SERIES: [(&str, &str, &str); 23] = [
             (
                 "f2z_relay_connections_accepted_total",
                 "counter",
@@ -188,7 +197,12 @@ impl Metrics {
             (
                 "f2z_relay_pushes_dropped_total",
                 "counter",
-                "Pushes dropped for a full outbound queue.",
+                "Pushes dropped for a full outbound queue, not for a gone subscriber.",
+            ),
+            (
+                "f2z_relay_pushes_to_closed_total",
+                "counter",
+                "Pushes dropped because the subscriber's receiver was gone.",
             ),
             (
                 "f2z_relay_backpressure",
@@ -242,6 +256,7 @@ impl Metrics {
             &self.challenges_issued,
             &self.stamps_refused,
             &self.pushes_dropped,
+            &self.pushes_to_closed,
             &self.backpressure,
             &self.stored_messages,
             &self.stored_payload_bytes,
@@ -298,9 +313,9 @@ mod tests {
             .lines()
             .filter(|line| !line.starts_with('#') && !line.is_empty())
             .count();
-        assert_eq!(helps, 22);
-        assert_eq!(types, 22);
-        assert_eq!(samples, 22);
+        assert_eq!(helps, 23);
+        assert_eq!(types, 23);
+        assert_eq!(samples, 23);
     }
 
     #[test]
@@ -318,5 +333,23 @@ mod tests {
         );
         Metrics::set(&metrics.storage_bytes, 4_096);
         assert!(metrics.render().contains("f2z_relay_storage_bytes 4096"));
+    }
+
+    #[test]
+    fn the_two_push_drop_causes_are_separate_series() {
+        // zuu#676. `SERIES` and `values` are parallel arrays, so this also
+        // proves the new name is sampled from the counter it names: a
+        // misaligned insert would print the increment under the wrong series.
+        let metrics = Metrics::new();
+        Metrics::inc(&metrics.pushes_to_closed);
+        let rendered = metrics.render();
+        assert!(
+            rendered.contains("f2z_relay_pushes_to_closed_total 1"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("f2z_relay_pushes_dropped_total 0"),
+            "{rendered}"
+        );
     }
 }

--- a/rs/crates/f2z-relay/src/subscriptions.rs
+++ b/rs/crates/f2z-relay/src/subscriptions.rs
@@ -25,6 +25,7 @@ use std::sync::Mutex;
 
 use f2z_codec::commands::{NoticePush, PushEvent, QueueEventPush, QueuedMessage};
 use f2z_codec::types::QueueAddress;
+use tokio::sync::mpsc::error::TrySendError;
 
 use crate::metrics::Metrics;
 use crate::outbound::{Outbound, msg_push, push};
@@ -173,9 +174,7 @@ impl Subscriptions {
                 let Some(outbound) = push(PushEvent::Notice, &body) else {
                     continue;
                 };
-                if subscriber.sender.try_send(outbound).is_err() {
-                    Metrics::inc(&metrics.pushes_dropped);
-                }
+                count_push(subscriber.sender.try_send(outbound), metrics);
             }
         }
     }
@@ -196,9 +195,7 @@ impl Subscriptions {
             };
             // `try_send`, never `send`: a slow reader must not be able to stall
             // the task that just committed somebody else's append.
-            if subscriber.sender.try_send(outbound).is_err() {
-                Metrics::inc(&metrics.pushes_dropped);
-            }
+            count_push(subscriber.sender.try_send(outbound), metrics);
         }
     }
 
@@ -206,6 +203,25 @@ impl Subscriptions {
         self.inner
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+/// Book one `try_send` outcome to the counter that describes *why* it failed.
+///
+/// `TrySendError` has two variants and they ask an operator for opposite
+/// things, so they cannot share a series: `Full` means the subscriber is not
+/// keeping up — raise `outbound` capacity or slow the producer — while `Closed`
+/// means the subscriber's writer task has ended and [`Subscriptions::drop_connection`]
+/// has not run yet, which is ordinary disconnect churn with nothing to tune.
+/// Counting `Closed` as `pushes_dropped` made the backpressure signal rise with
+/// client churn alone (zuu#676).
+///
+/// Both paths book through here so the two can never drift apart again.
+fn count_push(result: Result<(), TrySendError<Outbound>>, metrics: &Metrics) {
+    match result {
+        Ok(()) => {}
+        Err(TrySendError::Full(_)) => Metrics::inc(&metrics.pushes_dropped),
+        Err(TrySendError::Closed(_)) => Metrics::inc(&metrics.pushes_to_closed),
     }
 }
 
@@ -310,22 +326,101 @@ mod tests {
         table.drop_connection(12);
     }
 
+    fn dropped(metrics: &Metrics) -> u64 {
+        metrics
+            .pushes_dropped
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn to_closed(metrics: &Metrics) -> u64 {
+        metrics
+            .pushes_to_closed
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     #[tokio::test]
     async fn a_full_outbound_queue_drops_the_push_and_counts_it() {
         let table = Subscriptions::new();
         let metrics = Metrics::new();
         let address = QueueAddress::new([5u8; 32]);
+        // The receiver stays bound, so the channel genuinely fills rather than
+        // closing — this is the `Full` half and nothing else.
         let (sender, _receiver) = tokio::sync::mpsc::channel(1);
         table.subscribe(address, 1, sender);
         for _ in 0..4 {
             table.notify_message(address, &message(), &metrics);
         }
-        assert!(
-            metrics
-                .pushes_dropped
-                .load(std::sync::atomic::Ordering::Relaxed)
-                > 0
+        assert!(dropped(&metrics) > 0);
+        // zuu#676: the two causes must not be able to satisfy each other's
+        // assertion, so a full queue has to leave the closed counter alone.
+        assert_eq!(to_closed(&metrics), 0);
+    }
+
+    #[tokio::test]
+    async fn a_full_outbound_queue_counts_full_in_notify_all_too() {
+        // `notify_all` carries its own push, so the classification is asserted
+        // on that path as well and not inferred from `deliver`.
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let address = QueueAddress::new([8u8; 32]);
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+        table.subscribe(address, 1, sender);
+        for _ in 0..4 {
+            table.notify_all(NOTICE_SHUTDOWN, 1_000, &metrics);
+        }
+        assert!(dropped(&metrics) > 0);
+        assert_eq!(to_closed(&metrics), 0);
+    }
+
+    #[tokio::test]
+    async fn a_closed_subscriber_is_not_counted_as_a_full_queue() {
+        // zuu#676. The queue is 64 deep and nothing was ever sent, so there is
+        // no capacity to raise: the receiver is simply gone, which is what
+        // happens between a writer task ending and `drop_connection` running.
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let address = QueueAddress::new([9u8; 32]);
+        let (sender, receiver) = tokio::sync::mpsc::channel(64);
+        table.subscribe(address, 1, sender);
+        drop(receiver);
+
+        table.notify_message(address, &message(), &metrics);
+
+        assert_eq!(to_closed(&metrics), 1);
+        assert_eq!(
+            dropped(&metrics),
+            0,
+            "a gone subscriber is not backpressure and must not inflate it"
         );
+    }
+
+    #[tokio::test]
+    async fn a_closed_subscriber_is_not_counted_as_a_full_queue_in_notify_all() {
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let address = QueueAddress::new([10u8; 32]);
+        let (sender, receiver) = tokio::sync::mpsc::channel(64);
+        table.subscribe(address, 1, sender);
+        drop(receiver);
+
+        table.notify_all(NOTICE_SHUTDOWN, 1_000, &metrics);
+
+        assert_eq!(to_closed(&metrics), 1);
+        assert_eq!(dropped(&metrics), 0);
+    }
+
+    #[tokio::test]
+    async fn a_delivered_push_counts_neither() {
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let address = QueueAddress::new([11u8; 32]);
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(4);
+        table.subscribe(address, 1, sender);
+        table.notify_message(address, &message(), &metrics);
+        table.notify_all(NOTICE_SHUTDOWN, 1_000, &metrics);
+        assert!(receiver.try_recv().is_ok());
+        assert_eq!(dropped(&metrics), 0);
+        assert_eq!(to_closed(&metrics), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What the metric claims

`f2z_relay_pushes_dropped_total` is the operator's backpressure signal, and it said so in both places it was described:

```rust
/// Pushes dropped because a connection's outbound queue was full.
pub pushes_dropped: AtomicU64,
```
```rust
("f2z_relay_pushes_dropped_total", "counter", "Pushes dropped for a full outbound queue.")
```

## What it counted

Any `try_send` failure. `tokio::sync::mpsc::error::TrySendError` has **two** variants, `Full` and `Closed`, and both push paths collapsed them:

```rust
if subscriber.sender.try_send(outbound).is_err() {
    Metrics::inc(&metrics.pushes_dropped);
}
```

A subscriber whose receiver has been dropped was counted as a full queue. The window is ordinary, not exotic: a subscription is removed by `drop_connection`, so any push landing between a writer task ending and that cleanup running hits a closed channel. Normal client churn produces it, and the two causes ask an operator for opposite things — a full queue means raise `outbound` capacity or slow the producer, a closed one means the subscriber left and there is nothing to tune.

## The fix

Match the variant. `Full` keeps `pushes_dropped`; `Closed` gets a new counter:

```rust
fn count_push(result: Result<(), TrySendError<Outbound>>, metrics: &Metrics) {
    match result {
        Ok(()) => {}
        Err(TrySendError::Full(_)) => Metrics::inc(&metrics.pushes_dropped),
        Err(TrySendError::Closed(_)) => Metrics::inc(&metrics.pushes_to_closed),
    }
}
```

Both `deliver` and `notify_all` now book through this one helper. The increment used to be inline in both — which is exactly how one classification came to exist in two places — so the shared helper is the structural half of the fix: the two paths can no longer drift apart. Per-path test coverage is kept anyway (see the falsification table), so a future edit that inlines one of them again is still caught.

### Why a second counter beats discarding the closed case

Dropping the `Closed` branch on the floor would fix the lie and lose information. A sustained rise in pushes to gone subscribers is a real signal — it says connection teardown is lagging, or clients are churning harder than expected — it is just a *different* signal from backpressure. Two counters let an operator answer "is anyone failing to keep up?" and "are subscribers vanishing under me?" separately, which is the whole reason the conflation was a bug.

`f2z_relay_pushes_to_closed_total` is unlabelled like every other series here, so `metrics.rs`'s "no labels at all" rule is intact — see the redaction note below.

### Existing HELP text

Post-fix, "Pushes dropped for a full outbound queue." became literally true. It still under-describes, though, because the *name* `pushes_dropped_total` now reads like the total of all dropped pushes when it is only one of two. The HELP an operator reads on `/metrics` now says what it is **and** what it is not:

> `Pushes dropped for a full outbound queue, not for a gone subscriber.`

## Falsification

Every assertion was proven load-bearing by inverse string replacement (not `git checkout`), each asserting it matched **exactly once**, then restored. No revert was accepted on a match count other than 1.

| # | Inverse replacement | Expected | Result |
|---|---|---|---|
| F1 | `Closed(_) => inc(pushes_to_closed)` → `inc(pushes_dropped)` (the original bug) | both closed tests fail, full tests pass | `EXIT=101`, **8 passed / 2 failed** — exactly `a_closed_subscriber_is_not_counted_as_a_full_queue` and `..._in_notify_all` (`left: 0, right: 1`) |
| F2 | `Full(_) => inc(pushes_dropped)` → `inc(pushes_to_closed)` | both full tests fail, closed tests pass | `EXIT=101`, **8 passed / 2 failed** — exactly `a_full_outbound_queue_drops_the_push_and_counts_it` and `a_full_outbound_queue_counts_full_in_notify_all_too` |
| F3a | `deliver`'s `count_push(...)` → the old inline `is_err()` form | only the `deliver` closed test fails | `EXIT=101`, **9 passed / 1 failed** — only `a_closed_subscriber_is_not_counted_as_a_full_queue` |
| F3b | `notify_all`'s `count_push(...)` → the old inline `is_err()` form | only the `notify_all` closed test fails | `EXIT=101`, **9 passed / 1 failed** — only `a_closed_subscriber_is_not_counted_as_a_full_queue_in_notify_all` |
| F4 | swap `&self.pushes_dropped` / `&self.pushes_to_closed` in `values` | the render alignment test fails | `EXIT=101`, **3 passed / 1 failed** — only `the_two_push_drop_causes_are_separate_series` |

F1 and F2 together are the point the issue asked for: **neither cause can satisfy the other's assertion.** F3a/F3b prove `deliver` and `notify_all` are each covered on their own rather than one standing in for the other. F4 guards the parallel `SERIES`/`values` arrays — a misaligned insert would have printed the increment under the wrong series name and nothing else would have noticed.

## Verification

All from `rs/`, on this branch:

```
cargo fmt --check          →  FMT EXIT=0    (no output)
cargo clippy --workspace --all-targets -- -D warnings
                           →  CLIPPY EXIT=0
cargo test --workspace --no-fail-fast
                           →  EXIT=0
```

Measured before/after baselines, both full `cargo test --workspace --no-fail-fast` runs:

| | before (`origin/main`, pre-edit) | after |
|---|---|---|
| exit | `EXIT=0` | `EXIT=0` |
| `test result: ok` lines | 81 | 81 |
| tests passed | **1033** | **1038** |
| tests failed | 0 | 0 |

+5 is exactly the five tests added (four in `subscriptions`, one in `metrics`). The before-log was confirmed to predate the edits — it contains none of the new test names. `^error` lines in both logs are the relay's own test logging, not compile errors.

### Redaction suite

`rs/crates/f2z-relay/tests/redaction.rs::metrics_carry_no_per_queue_and_no_per_ip_label` **passes** — confirmed green in the after run. The new counter introduces no label: it is a single unlabelled series like every other one, and `metrics.rs`'s own `no_series_carries_a_label` also still passes.

## Testkit finding — not the same bug, no fix needed

Checked `f2z-relay-testkit`'s push path: `RelayState::notify_message`, `notify_queue_event` and `notify_all` in `rs/crates/f2z-relay-testkit/src/state.rs`.

**There is no conflation there, and there structurally cannot be.** Two reasons:

1. The testkit's `Subscriber` holds an `UnboundedSender<Outbound>`, not a bounded `Sender`. An unbounded channel has no `Full` state — `UnboundedSender::send` fails only with `SendError`, which is the closed case and the *only* case. There are no two variants to confuse.
2. The testkit keeps no metrics at all. Every send is `let _ = subscriber.sender.send(outbound);` — the result is deliberately discarded, and there is no counter for it to be booked to incorrectly.

So the fake relay cannot mislead an operator about backpressure, because it neither models backpressure nor reports anything. Nothing to fix and nothing to follow up. Worth noting for the record that this also means the testkit does not exercise the bounded-channel drop behaviour at all — that is by design for a test double, not a defect.

## Also noted, not done here

The issue's secondary observation stands and is untouched: `deliver` calls `build()` **inside** the subscriber loop, so each subscriber re-encodes an identical frame (for `notify_message` that includes a full `message.clone()` of the ciphertext), and `notify_all` re-encodes an identical `NoticePush` per subscriber of every address. `Outbound` is `Clone`, so hoisting the build out of the loop is equivalent. Left out deliberately to keep this PR about the counter — it is a performance change with a different risk profile and deserves its own diff.

Closes #676

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
