### PR TITLE
fix(relay-store): make the fsync counter's population closed by type, not by comment

### DIFF
--- a/rs/crates/f2z-relay-store/src/sqlite.rs
+++ b/rs/crates/f2z-relay-store/src/sqlite.rs
@@ -76,6 +76,113 @@ use crate::record::{
 };
 use crate::store::RelayStore;
 
+use self::counted::{CountedTransaction, WriteConnection};
+
+/// Making the fsync counter's population closed, by type rather than by care.
+///
+/// # What is being protected
+///
+/// [`SqliteStore::commits`] counts durable commits, and that number is not
+/// decoration: `f2z-relay`'s group-commit writer (`f2z-relay/src/commit.rs`)
+/// rests its entire argument on it — "`SqliteStore::commits`, which counts
+/// fsyncs so the amortization is checkable rather than asserted" — and
+/// `f2z-relay/tests/group_commit.rs`'s
+/// `a_hundred_concurrent_appends_do_not_cost_a_hundred_fsyncs` asserts
+/// `fsyncs < APPENDS`. A commit that happened without being counted therefore
+/// makes that assertion *easier* to satisfy: the evidence for group commit
+/// would weaken in the direction that still looks green.
+///
+/// # Why a type and not a comment
+///
+/// The counter used to be defended by a sentence saying every commit goes
+/// through one helper. That was true, and nothing enforced it — a
+/// `tx.commit()?` written next to any transaction site compiled, passed, and
+/// silently stopped incrementing the counter. These two newtypes remove the
+/// expression rather than warn about it:
+///
+/// * [`WriteConnection`] derefs to `&Connection` and **never** to
+///   `&mut Connection`. `rusqlite::Connection::transaction` needs `&mut self`,
+///   so the only way to begin a write transaction is [`WriteConnection::begin`].
+///   Reads are unaffected — they only ever needed `&Connection`.
+/// * [`CountedTransaction`] owns the `rusqlite::Transaction` in a private field
+///   and derefs to `&Transaction`, so the transaction can never be moved back
+///   out. `Transaction::commit` consumes `self`, which a shared deref cannot
+///   provide. The one reachable commit is
+///   [`CountedTransaction::commit`], which increments the counter.
+///
+/// The pleasant consequence is that the mistake the old comment warned about —
+/// writing `tx.commit()?` at a call site — now resolves to the inherent method
+/// and *counts*. There is no spelling of "commit without counting" left inside
+/// `sqlite.rs`; the only remaining way to add one is to add a method to this
+/// module, whose entire purpose is stated above.
+mod counted {
+    use std::ops::Deref;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use rusqlite::{Connection, Transaction};
+
+    /// The store's connection, handed out by shared reference only.
+    #[derive(Debug)]
+    pub(super) struct WriteConnection(Connection);
+
+    impl WriteConnection {
+        pub(super) fn new(connection: Connection) -> Self {
+            Self(connection)
+        }
+
+        /// Begin the only kind of write transaction this file can express.
+        ///
+        /// `commits` is the counter the returned transaction will bump, so a
+        /// transaction cannot be started without naming what will account for
+        /// it.
+        pub(super) fn begin<'conn>(
+            &'conn mut self,
+            commits: &'conn AtomicU64,
+        ) -> rusqlite::Result<CountedTransaction<'conn>> {
+            Ok(CountedTransaction {
+                tx: self.0.transaction()?,
+                commits,
+            })
+        }
+    }
+
+    impl Deref for WriteConnection {
+        type Target = Connection;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    /// A write transaction whose only commit path increments the fsync counter.
+    #[derive(Debug)]
+    pub(super) struct CountedTransaction<'conn> {
+        tx: Transaction<'conn>,
+        commits: &'conn AtomicU64,
+    }
+
+    impl CountedTransaction<'_> {
+        /// Commit, and count the fsync it cost.
+        ///
+        /// Dropping without calling this rolls back, as with any
+        /// `rusqlite::Transaction`, and correctly counts nothing.
+        pub(super) fn commit(self) -> rusqlite::Result<()> {
+            let Self { tx, commits } = self;
+            tx.commit()?;
+            commits.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    impl<'conn> Deref for CountedTransaction<'conn> {
+        type Target = Transaction<'conn>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.tx
+        }
+    }
+}
+
 /// The schema version stamped into `PRAGMA user_version`.
 const SCHEMA_VERSION: i32 = 1;
 
@@ -126,7 +233,7 @@ const QUEUE_COLUMNS: &str = "recv_addr, send_addr, kind, recv_key, send_key, nex
 /// where the batching driver can see it.
 #[derive(Debug)]
 pub struct SqliteStore {
-    connection: Mutex<Connection>,
+    connection: Mutex<WriteConnection>,
     /// §7.7 idle-timer activity that has not been written yet. See
     /// [`RelayStore::touch`] for why this is deliberately not durable.
     activity: Mutex<HashMap<QueueAddress, u64>>,
@@ -198,7 +305,7 @@ impl SqliteStore {
         }
 
         Ok(Self {
-            connection: Mutex::new(connection),
+            connection: Mutex::new(WriteConnection::new(connection)),
             activity: Mutex::new(HashMap::new()),
             commits: AtomicU64::new(0),
         })
@@ -237,13 +344,17 @@ impl SqliteStore {
         self.commits.load(Ordering::Relaxed)
     }
 
-    /// Commit, and count it.
+    /// Commit, and release the activity buffer the commit made durable.
     ///
-    /// Every commit in this file goes through here, so the counter cannot drift
-    /// from reality by someone adding a `tx.commit()` next to it.
+    /// The counting itself lives one level down, in
+    /// [`CountedTransaction::commit`], because that is the only place a
+    /// `rusqlite::Transaction` can be committed from — see the [`counted`]
+    /// module for why the counter's population is closed by type rather than
+    /// by this comment. What is left here is the part that is genuinely a
+    /// policy of the store: when the staged touches may be dropped.
     fn commit(
         &self,
-        tx: Transaction<'_>,
+        tx: CountedTransaction<'_>,
         mut activity: std::sync::MutexGuard<'_, HashMap<QueueAddress, u64>>,
     ) -> Result<()> {
         tx.commit()?;
@@ -252,7 +363,6 @@ impl SqliteStore {
         // also drops this guard without clearing the buffer, so the next
         // transaction retries the activity instead of silently losing it.
         activity.clear();
-        self.commits.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 
@@ -263,7 +373,7 @@ impl SqliteStore {
     /// next `BEGIN` starts from committed state. Refusing every subsequent
     /// request would convert one fault into a permanent outage of `READ` and
     /// `ACK`, which are the two operations §13.1 says must never be refused.
-    fn lock_connection(&self) -> std::sync::MutexGuard<'_, Connection> {
+    fn lock_connection(&self) -> std::sync::MutexGuard<'_, WriteConnection> {
         self.connection
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
@@ -554,7 +664,7 @@ impl RelayStore for SqliteStore {
             return Err(StoreError::AddressCollision);
         }
         let mut connection = self.lock_connection();
-        let tx = connection.transaction()?;
+        let tx = connection.begin(&self.commits)?;
         let activity = self.flush_activity(&tx)?;
 
         // Both addresses are drawn from one 32-byte space, and a lookup by
@@ -615,7 +725,7 @@ impl RelayStore for SqliteStore {
         now_ms: u64,
     ) -> Result<Committed<()>> {
         let mut connection = self.lock_connection();
-        let tx = connection.transaction()?;
+        let tx = connection.begin(&self.commits)?;
         let activity = self.flush_activity(&tx)?;
 
         let Some(mut record) = load_by_send(&tx, send_addr)? else {
@@ -657,7 +767,7 @@ impl RelayStore for SqliteStore {
 
     fn append_batch(&self, appends: &[Append<'_>]) -> Result<Committed<Vec<Result<Appended>>>> {
         let mut connection = self.lock_connection();
-        let tx = connection.transaction()?;
+        let tx = connection.begin(&self.commits)?;
         let activity = self.flush_activity(&tx)?;
 
         let mut results: Vec<Result<Appended>> = Vec::with_capacity(appends.len());
@@ -709,7 +819,7 @@ impl RelayStore for SqliteStore {
         now_ms: u64,
     ) -> Result<Committed<AckOutcome>> {
         let mut connection = self.lock_connection();
-        let tx = connection.transaction()?;
+        let tx = connection.begin(&self.commits)?;
         let activity = self.flush_activity(&tx)?;
 
         let mut record = load_by_recv(&tx, recv_addr)?.ok_or_else(StoreError::no_access)?;
@@ -765,7 +875,7 @@ impl RelayStore for SqliteStore {
         signer: &PublicKey,
     ) -> Result<Committed<Deleted>> {
         let mut connection = self.lock_connection();
-        let tx = connection.transaction()?;
+        let tx = connection.begin(&self.commits)?;
         let activity = self.flush_activity(&tx)?;
 
         let record = load_by_recv(&tx, recv_addr)?.ok_or_else(StoreError::no_access)?;
@@ -805,7 +915,7 @@ impl RelayStore for SqliteStore {
 
     fn expire(&self, now_ms: u64) -> Result<Committed<ExpiryReport>> {
         let mut connection = self.lock_connection();
-        let tx = connection.transaction()?;
+        let tx = connection.begin(&self.commits)?;
         // Before the sweep, so a touch that has not been written down yet still
         // saves its queue. This is what bounds `touch`'s best-effort window to
         // the sweep period.
@@ -1245,7 +1355,7 @@ mod tests {
         let commits_before_failure = store.commits();
         {
             let mut connection = store.lock_connection();
-            let tx = connection.transaction().unwrap();
+            let tx = connection.begin(&store.commits).unwrap();
             let activity = store.flush_activity(&tx).unwrap();
             tx.execute("INSERT INTO commit_failure (parent_id) VALUES (7)", [])
                 .unwrap();


### PR DESCRIPTION
## The claim, and what was behind it

`SqliteStore::commit` documented a structural guarantee:

> Every commit in this file goes through here, so the counter cannot drift from reality by someone adding a `tx.commit()` next to it.

**Verified on the current tree** (`origin/main`, not the `0e705d6` the issue was filed against — the numbers have moved, so here are the measured ones):

| | issue said | measured on `origin/main` |
|---|---|---|
| `tx.commit()` on a `rusqlite::Transaction` in the whole crate | 1 | **1** (`sqlite.rs:249`, inside the helper) |
| transaction-creation sites | 8 | **6** in the impl (`create_queue`, `bind_send`, `append_batch`, `ack`, `delete_queue`, `expire`) + **1** in `mod tests` = 7 |
| files in the crate that touch `Transaction` at all | — | **1** (`sqlite.rs`; `grep` over `src/` and `tests/` finds nothing elsewhere) |

So the claim was true — and enforced by nothing.

## What it cost downstream

The counter is not local bookkeeping. `f2z-relay/src/commit.rs` rests its whole group-commit argument on it — *"`SqliteStore::commits`, which counts fsyncs so the amortization is checkable rather than asserted"* — and `f2z-relay/tests/group_commit.rs`'s `a_hundred_concurrent_appends_do_not_cost_a_hundred_fsyncs` asserts `fsyncs < APPENDS`. An uncounted commit makes that assertion **easier** to satisfy. The evidence weakens in the direction that still looks green.

Worth noting which sites were actually exposed: `append_batch`'s commit *is* pinned by `a_batch_of_a_hundred_appends_is_one_fsync` (`assert_eq!(store.commits() - before, 1)`), so a bypass there would have been caught. The other five — `create_queue`, `bind_send`, `ack`, `delete_queue`, `expire` — had no counter assertion anywhere, and a bypass at any of them was entirely silent. The falsification below uses `create_queue`.

## Route taken: enforcement by type

The issue proposed the text-scan test (the `f2z-codec/tests/workspace_strict_verification_scan.rs` idiom). I went for the type instead, because it turned out to be clean and because the repo's own standard is that enforcement by type beats a test. A new private `counted` module holds two newtypes:

* **`WriteConnection`** derefs to `&Connection` and **never** to `&mut Connection`. `rusqlite::Connection::transaction` needs `&mut self`, so the only way to begin a write transaction is `WriteConnection::begin(&mut self, commits: &AtomicU64)` — which takes the counter it will bump, so a transaction cannot be started without naming what accounts for it. Every read path only ever needed `&Connection` and goes through the deref unchanged.
* **`CountedTransaction`** owns the `rusqlite::Transaction` in a private field and derefs to `&Transaction`. The transaction can never be moved back out, and `Transaction::commit` consumes `self`, which a shared deref cannot supply. Its own `commit` is the one reachable commit, and it does `fetch_add`.

The pleasant part: the exact mistake the old comment warned about — writing `tx.commit()?` at a call site — now resolves to the *inherent* method and **counts**. `SqliteStore::commit` keeps only what is genuinely store policy: when the staged activity buffer may be dropped.

The doc comment on the module names what it protects (`f2z-relay`'s group-commit evidence, by file and by test name), so the next reader knows it is not merely tidy.

**Cost:** six call sites change `connection.transaction()?` → `connection.begin(&self.commits)?`, one field type, one signature. That is the whole diff besides the module and its doc.

**Why not the scan:** the scan pins a count of `.commit(` occurrences; it cannot stop a *new* transaction site from committing uncounted, only make the count change visible at review. The type makes both spellings of the bypass fail to compile. I did not add the scan on top, since it would only re-cover ground the compiler now holds.

**Residual surface, stated plainly:** the hole is not gone from the universe, it is reduced to one ~50-line module — someone could add a method there that leaks the inner `Transaction`, or add `impl DerefMut for WriteConnection`. Both are deliberate, visible edits inside the module whose doc says why not, which is a different class of act from writing `tx.commit()?` next to a transaction.

## Falsification

Injected at `create_queue`; each replacement asserted to match **exactly once** before being applied.

| # | tree | edit at `create_queue` | result |
|---|---|---|---|
| 0 | `origin/main` (pre-change) | `self.commit(tx, activity)?` → `tx.commit()?; drop(activity);` | **compiles, zero warnings, `cargo test -p f2z-relay-store -p f2z-relay` → `EXIT=0`, 201 passed, 0 failed.** Completely silent. A probe asserting `store.commits() - before == 1` after `create_queue` fails: `left: 0, right: 1`. The hole is real. |
| 1 | this PR | same edit (`tx` is now a `CountedTransaction`) | compiles, and the same probe **passes** — the accidental spelling counts. |
| 2 | this PR | `connection.begin(&self.commits)?` → `connection.transaction()?` | **compile error** `E0308: mismatched types … expected CountedTransaction<'_>, found Transaction<'_>` |
| 3 | this PR | `connection.transaction()?` **and** `tx.commit()?` (the full old-style bypass) | **compile error** `E0596: cannot borrow data in dereference of WriteConnection as mutable … trait DerefMut is required` |

Case 0's silence is the point: on `origin/main` the bypass passed every test in both crates. Cases 2 and 3 are the guard, and it is the compiler, not a test. All injections were reverted; the probe test was temporary and is not in the diff.

<details>
<summary>Case 3 verbatim</summary>

```
error[E0596]: cannot borrow data in dereference of `WriteConnection` as mutable
   --> crates/f2z-relay-store/src/sqlite.rs:667:18
    |
667 |         let tx = connection.transaction()?;
    |                  ^^^^^^^^^^ cannot borrow as mutable
    |
    = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `WriteConnection`
```
</details>

## Verification, from `rs/`

Measured on this machine, before and after, not carried over from the issue.

| command | before (pre-edit, `origin/main`) | after (this PR) |
|---|---|---|
| `cargo test --workspace --no-fail-fast` | `EXIT=0` — 81 `test result: ok` sections, **1038 passed, 0 failed** | `EXIT=0` — 81 sections, **1038 passed, 0 failed** |
| `cargo test -p f2z-relay-store --features crash-injection --test crash_safety` | `EXIT=0` — 5 passed, 1 ignored | `EXIT=0` — 5 passed, 1 ignored |
| `cargo fmt --check` | — | `EXIT=0` |
| `cargo clippy --workspace --all-targets -- -D warnings` | — | `EXIT=0` |

The before-run started at 21:58:57 and completed before the first edit to `sqlite.rs`.

Crash-injection re-run in full, since the change is adjacent to the commit sites (the injection points themselves are untouched — they sit in the callers, around `self.commit(...)`, exactly as before):

```
test crash_child_worker ... ignored, spawned by the parent cases below; not a test on its own
test the_reopened_store_still_refuses_a_pre_ack ... ok
test a_crash_before_the_ack_commit_deletes_nothing ... ok
test a_crash_after_the_append_commit_loses_nothing_that_was_accepted ... ok
test a_crash_after_the_ack_commit_leaves_nothing_acked_but_undeleted ... ok
test a_crash_before_the_append_commit_leaves_no_trace_of_it ... ok
test result: ok. 5 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```

Nothing the issue lists as load-bearing is weakened: the four `CrashPoint` variants are still all driven by name, `arm_from_env` still has exactly its two callers in `crash_safety.rs`, and `tests/properties.rs` is unchanged.

<sub>One caveat on process, recorded rather than hidden: my first "after" run was polluted by my running the crash-injection suite concurrently against the same target dir, which exhausted the disk and produced a cascade of `SQLITE_IOERR_SHMSIZE` ("disk I/O error") failures plus a stray `properties.proptest-regressions` file. That file was deleted and the workspace suite re-run alone; the numbers in the table are from the clean serial run, and the working tree contains nothing but the one changed file.</sub>

Closes #679

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
