### PR TITLE
fix(f2zmsg): a messaging store that will not open must not stop ZUULI from starting

### DIFF
--- a/docs/e2ee/CLIENT-CONTRACT.md
+++ b/docs/e2ee/CLIENT-CONTRACT.md
@@ -1323,6 +1323,20 @@ Leaving `faulted` takes an explicit `start_engine` after the user has acted on
 `lastError`; nothing retries out of it on a timer, because the codes that reach it
 are the ones §8 marks non-retryable.
 
+There is one entry into `faulted` that is not a transition at all: **the client
+can come up with no engine.** `SqliteBackend::open` verifies WAL,
+`synchronous = FULL` and `secure_delete` and *refuses* otherwise, because §11.2
+says a client that cannot promise durability must not ACK — and the data
+directory can also be full, read-only, or hold an `f2zmsg.sqlite` left
+half-written by a killed process. In every one of those the correct product
+behaviour is that **messaging is unavailable and the rest of the application
+works**: the store failing to open must never stop the host application from
+starting. The client reports `faulted` with the `lastError` that stopped it
+(`storage-full`, `durability-unavailable`, or `internal`), and every command
+other than `get_engine_status` — `start_engine` and the §3.2 enrollment trio
+included — refuses with that same code. This is the one `faulted` that
+`start_engine` cannot leave; only fixing the storage and restarting can.
+
 `locked` exists because the local encrypted history is wrapped under a
 seed-derived key
 ([`ARCHITECTURE.md` §4.2](./ARCHITECTURE.md#42-derivation-proposed)). Note what
@@ -1637,7 +1651,7 @@ type ErrorCode =
 | `engine-locked` | | The seed is unavailable, so local history cannot be decrypted. Prompt to unlock. Never auto-unlock. |
 | `engine-not-running` | ● | Call `start_engine` once, then retry once. |
 | `device-clock-skew` | ● | **This device's clock is wrong**, not the relay's: `timestamp_ms` fell outside the relay's published `clock_skew_ms` window ([`WIRE.md` §5.5](./WIRE.md#55-anti-replay-a-bounded-window-plus-a-seen-set)). Re-learn the relay's time from `HELLO` / `GET_CHALLENGE`, apply the offset **locally**, retry once. If it persists, say plainly that the device clock is off and by roughly how much — never that the relay misbehaved, and never a defect-report affordance. **Never set the system clock from a relay-supplied time**: `WIRE.md` §5.5 forbids it, and a relay that could move this device's clock could move the anti-replay window with it. |
-| `durability-unavailable` | | Browser only: storage durability was refused. Enter **no-ACK mode** (§11.2) and say what is degraded. **Do not ACK.** |
+| `durability-unavailable` | | Storage durability was refused, so nothing may be ACKed. In a browser this is the storage API declining, and the client enters **no-ACK mode** (§11.2) and says what is degraded. On ZUULI it is the durable store failing to open at all — a filesystem that will not give WAL, a read-only or permission-denied data directory — and there is no degraded mode to enter: messaging is unavailable for the life of the process (§6.1). Either way, **do not ACK.** |
 | `storage-full` | | Local storage exhausted. Inbound stops being acknowledged — which is correct, because an un-ACKed message is still on the relay. Offer to reduce retention. |
 | `gap-unrecoverable` | | The sender no longer holds the plaintext. Render the `{ kind: "unrecoverable" }` marker in place ([`ARCHITECTURE.md` §8.4](./ARCHITECTURE.md#84-short-local-retention-and-gap-repair)). Never a silent hole. |
 | `not-supported-in-browser` | | A ZUULI-only operation was attempted in a browser (§10, §11.1). State the reason — it is a trust-model boundary, not a missing feature. |

--- a/wallet/plugins/tauri-plugin-f2zmsg/Cargo.lock
+++ b/wallet/plugins/tauri-plugin-f2zmsg/Cargo.lock
@@ -5303,6 +5303,7 @@ dependencies = [
  "openmls",
  "openmls_traits",
  "rand 0.9.5",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",

--- a/wallet/plugins/tauri-plugin-f2zmsg/Cargo.toml
+++ b/wallet/plugins/tauri-plugin-f2zmsg/Cargo.toml
@@ -122,6 +122,17 @@ chacha20poly1305 = "0.10"
 # The OpenMLS `StorageProvider`. `sqlite` is the default and is what makes
 # `Durability::Durable` — and therefore ACKing at all — reachable (§11.2).
 f2z-msg-store = { path = "../../../rs/crates/f2z-msg-store", version = "0.1.0" }
+# Named only to *classify* a store that would not open: `StoreError::Sqlite`
+# carries a `rusqlite::Error` in `f2z-msg-store`'s public API, and #753 needs
+# `SQLITE_FULL` to reach the frontend as §8's `storage-full` rather than as a
+# flattened `internal`. Nothing here opens a connection.
+#
+# **rusqlite 0.37 is a repo-wide singleton** (root `AGENTS.md`): `libsqlite3-sys`
+# declares `links = "sqlite3"`, so a second major line anywhere in this graph is
+# a hard Cargo failure rather than a duplicate. This is the same 0.37 `rs/`'s
+# workspace and `tauri-plugin-zcash` already resolve, and `default-features =
+# false` so the feature set stays whatever `f2z-msg-store` asked for.
+rusqlite = { version = "0.37", default-features = false }
 # `Handle`, `KemPublicKey` and `DeviceCredential` itself live here; issuing a
 # credential needs them, so this is a direct dependency rather than something
 # reached through `f2z-msg-identity`'s re-exports.

--- a/wallet/plugins/tauri-plugin-f2zmsg/README.md
+++ b/wallet/plugins/tauri-plugin-f2zmsg/README.md
@@ -249,15 +249,24 @@ What that unblocked, all of it now present:
   `wallet/zuuli/scripts/mobile-webview-authority.mjs`'s reviewed allowlist —
   mobile authority is granted by review, not by registration.
 
-**One consequence of linking, recorded as #753 rather than fixed here.** This
-crate's `setup` hook is fallible end to end, and an `Err` from a plugin's setup
-makes `tauri::Builder::build()` fail — so a messaging store that cannot be
-opened now takes the whole ZUULI wallet down at launch. `SqliteBackend::open`'s
-strictness is right (§11.2: a client that cannot promise durability must not
-ACK); its blast radius is not. Failing soft is not a one-line change, because
-`F2zMsgExt::f2zmsg` unwraps the managed state and all 43 commands would panic
-instead of refusing — `EngineState::Faulted` is the answer, and #753 carries the
-shape.
+**A store that will not open makes messaging unavailable, not the wallet (#753).**
+This crate's `setup` hook used to be fallible end to end, and an `Err` from a
+plugin's setup makes `tauri::Builder::build()` fail — which ZUULI's `run()` ends
+by `.expect(..)`ing, so an unopenable `f2zmsg.sqlite` took the whole wallet down
+at launch. `SqliteBackend::open`'s strictness was never the problem and is
+unchanged (§11.2: a client that cannot promise durability must not ACK); its
+blast radius was. `setup` now always registers its state and never returns
+`Err`, because failing soft is *not* skipping `app.manage(..)`:
+`F2zMsgExt::f2zmsg` is `state::<F2zMsg<R>>().inner()`, which panics on an
+unmanaged type, so all 43 commands would have panicked instead of refusing.
+`F2zMsg` holds the engine **or** the §8 code that stopped it being built,
+`F2zMsg::engine` returns a `Result` — so the compiler, not a convention, is what
+makes every command handle it — `get_engine_status` answers §6.1's `faulted`
+carrying that code, and everything else refuses with it.
+`wallet/zuuli/src-tauri/src/lib.rs`'s
+`an_unopenable_messaging_store_leaves_zuuli_running_and_every_command_refusing`
+drives the census off `COMMANDS`, so a forty-fourth command cannot be added
+without stating how it behaves in that state.
 
 ## What is still not wired, and exactly why
 

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/commands.rs
@@ -15,6 +15,20 @@
 //! * **Commands with no arguments take no `args` key at all**, so they have no
 //!   second parameter.
 //!
+//! # `engine()` is a `Result`, and every command here takes it with `?`
+//!
+//! The plugin's `setup` can finish without an engine: a durable store that will
+//! not open must make messaging unavailable, not the wallet (#753). The managed
+//! state is registered either way — it has to be, because
+//! [`crate::state::F2zMsgExt::f2zmsg`] panics on an unmanaged type — and
+//! [`crate::state::F2zMsg::engine`] hands back the §8 code that stopped the
+//! engine from being built. Returning that *by type* is what makes the refusal
+//! total: there is no way to reach the engine that skips it, so a command that
+//! compiles is a command that cannot panic in the faulted state.
+//!
+//! `get_engine_status` is the one exception, and it answers rather than
+//! refusing. Everything else refuses.
+//!
 //! Enrollment is **not** here. `f2zmsg_enroll`, `f2zmsg_enrollment_status` and
 //! `f2zmsg_unenroll` need the wallet seed, and putting them behind a plugin
 //! would mean the mnemonic reaching the webview's JavaScript heap. They live in
@@ -31,24 +45,36 @@ use crate::state::F2zMsgExt as _;
 // §3.1 — engine lifecycle
 // ---------------------------------------------------------------------------
 
+/// The one command that **answers** instead of refusing when the plugin has no
+/// engine (#753).
+///
+/// A store that would not open leaves §6.1's `faulted` and the §8 code that
+/// caused it, because a UI told only "internal" on every command has nothing to
+/// render but an empty screen; told `faulted` with `lastError`, it can say that
+/// messaging is unavailable and why. Every *other* command refuses with the
+/// same code.
 #[command]
 pub(crate) async fn get_engine_status<R: Runtime>(app: AppHandle<R>) -> Result<EngineStatus> {
-    app.f2zmsg().engine().status().await
+    let state = app.f2zmsg();
+    match state.faulted_status() {
+        Some(faulted) => Ok(faulted),
+        None => state.engine()?.status().await,
+    }
 }
 
 #[command]
 pub(crate) async fn start_engine<R: Runtime>(app: AppHandle<R>) -> Result<EngineStatus> {
-    app.f2zmsg().engine().start().await
+    app.f2zmsg().engine()?.start().await
 }
 
 #[command]
 pub(crate) async fn stop_engine<R: Runtime>(app: AppHandle<R>) -> Result<EngineStatus> {
-    app.f2zmsg().engine().stop().await
+    app.f2zmsg().engine()?.stop().await
 }
 
 #[command]
 pub(crate) async fn get_device_info<R: Runtime>(app: AppHandle<R>) -> Result<DeviceInfo> {
-    app.f2zmsg().engine().device_info().await
+    app.f2zmsg().engine()?.device_info().await
 }
 
 // ---------------------------------------------------------------------------
@@ -61,7 +87,7 @@ pub(crate) async fn list_conversations<R: Runtime>(
     args: ListConversationsArgs,
 ) -> Result<ConversationPage> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .list_conversations(args.limit, args.cursor)
         .await
 }
@@ -72,7 +98,7 @@ pub(crate) async fn get_conversation<R: Runtime>(
     args: ConversationIdArgs,
 ) -> Result<Conversation> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .get_conversation(&args.conversation_id)
         .await
 }
@@ -84,14 +110,17 @@ pub(crate) async fn start_conversation<R: Runtime>(
     app: AppHandle<R>,
     args: HandleArgs,
 ) -> Result<Conversation> {
-    app.f2zmsg().engine().start_conversation(&args.handle).await
+    app.f2zmsg()
+        .engine()?
+        .start_conversation(&args.handle)
+        .await
 }
 
 #[command]
 pub(crate) async fn list_contact_requests<R: Runtime>(
     app: AppHandle<R>,
 ) -> Result<Vec<ContactRequest>> {
-    app.f2zmsg().engine().list_contact_requests().await
+    app.f2zmsg().engine()?.list_contact_requests().await
 }
 
 #[command]
@@ -100,7 +129,7 @@ pub(crate) async fn accept_contact_request<R: Runtime>(
     args: RequestIdArgs,
 ) -> Result<Conversation> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .accept_contact_request(&args.request_id)
         .await
 }
@@ -111,7 +140,7 @@ pub(crate) async fn reject_contact_request<R: Runtime>(
     args: RejectContactRequestArgs,
 ) -> Result<()> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .reject_contact_request(&args.request_id, args.block)
         .await
 }
@@ -122,7 +151,7 @@ pub(crate) async fn leave_conversation<R: Runtime>(
     args: ConversationIdArgs,
 ) -> Result<()> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .leave_conversation(&args.conversation_id)
         .await
 }
@@ -137,7 +166,7 @@ pub(crate) async fn send_message<R: Runtime>(
     args: SendMessageArgs,
 ) -> Result<SendAccepted> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .send_message(&args.conversation_id, &args.body, &args.client_ref)
         .await
 }
@@ -150,12 +179,12 @@ pub(crate) async fn retry_send<R: Runtime>(
     app: AppHandle<R>,
     args: MsgIdArgs,
 ) -> Result<SendAccepted> {
-    app.f2zmsg().engine().retry_send(&args.msg_id).await
+    app.f2zmsg().engine()?.retry_send(&args.msg_id).await
 }
 
 #[command]
 pub(crate) async fn cancel_send<R: Runtime>(app: AppHandle<R>, args: MsgIdArgs) -> Result<()> {
-    app.f2zmsg().engine().cancel_send(&args.msg_id).await
+    app.f2zmsg().engine()?.cancel_send(&args.msg_id).await
 }
 
 #[command]
@@ -164,14 +193,14 @@ pub(crate) async fn list_messages<R: Runtime>(
     args: ListMessagesArgs,
 ) -> Result<MessagePage> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .list_messages(&args.conversation_id, args.limit, args.before, args.after)
         .await
 }
 
 #[command]
 pub(crate) async fn get_message<R: Runtime>(app: AppHandle<R>, args: MsgIdArgs) -> Result<Message> {
-    app.f2zmsg().engine().get_message(&args.msg_id).await
+    app.f2zmsg().engine()?.get_message(&args.msg_id).await
 }
 
 // ---------------------------------------------------------------------------
@@ -183,13 +212,13 @@ pub(crate) async fn get_delivery_state<R: Runtime>(
     app: AppHandle<R>,
     args: MsgIdArgs,
 ) -> Result<DeliveryStatus> {
-    app.f2zmsg().engine().delivery_state(&args.msg_id).await
+    app.f2zmsg().engine()?.delivery_state(&args.msg_id).await
 }
 
 #[command]
 pub(crate) async fn mark_read<R: Runtime>(app: AppHandle<R>, args: MarkReadArgs) -> Result<()> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .mark_read(&args.conversation_id, &args.up_to_msg_id)
         .await
 }
@@ -200,7 +229,7 @@ pub(crate) async fn get_receipt_policy<R: Runtime>(
     args: ConversationIdArgs,
 ) -> Result<ReceiptPolicy> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .receipt_policy(&args.conversation_id)
         .await
 }
@@ -211,7 +240,7 @@ pub(crate) async fn set_receipt_policy<R: Runtime>(
     args: SetReceiptPolicyArgs,
 ) -> Result<ReceiptPolicy> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .set_receipt_policy(
             &args.conversation_id,
             args.delivery_receipts,
@@ -229,7 +258,10 @@ pub(crate) async fn list_gaps<R: Runtime>(
     app: AppHandle<R>,
     args: ConversationIdArgs,
 ) -> Result<Vec<Gap>> {
-    app.f2zmsg().engine().list_gaps(&args.conversation_id).await
+    app.f2zmsg()
+        .engine()?
+        .list_gaps(&args.conversation_id)
+        .await
 }
 
 #[command]
@@ -238,7 +270,7 @@ pub(crate) async fn request_gap_repair<R: Runtime>(
     args: RequestGapRepairArgs,
 ) -> Result<Vec<GapRepairStatus>> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .request_gap_repair(&args.conversation_id, &args.gap_ids)
         .await
 }
@@ -253,7 +285,7 @@ pub(crate) async fn get_retention_policy<R: Runtime>(
     args: GetRetentionPolicyArgs,
 ) -> Result<RetentionPolicy> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .retention_policy(args.conversation_id.as_deref())
         .await
 }
@@ -264,7 +296,7 @@ pub(crate) async fn set_retention_policy<R: Runtime>(
     args: SetRetentionPolicyArgs,
 ) -> Result<RetentionPolicy> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .set_retention_policy(
             args.scope,
             args.mode,
@@ -284,7 +316,7 @@ pub(crate) async fn send_ephemeral_hint<R: Runtime>(
     args: SendEphemeralHintArgs,
 ) -> Result<EphemeralHintState> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .send_ephemeral_hint(&args.conversation_id, args.mode, args.ttl_seconds)
         .await
 }
@@ -295,7 +327,7 @@ pub(crate) async fn get_ephemeral_hint<R: Runtime>(
     args: ConversationIdArgs,
 ) -> Result<Option<EphemeralHintState>> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .ephemeral_hint(&args.conversation_id)
         .await
 }
@@ -310,7 +342,7 @@ pub(crate) async fn send_purge_request<R: Runtime>(
     args: SendPurgeRequestArgs,
 ) -> Result<PurgeRequestStatus> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .send_purge_request(&args.conversation_id, args.before_epoch)
         .await
 }
@@ -321,7 +353,7 @@ pub(crate) async fn list_purge_requests<R: Runtime>(
     args: ConversationIdArgs,
 ) -> Result<Vec<PurgeRequestStatus>> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .list_purge_requests(&args.conversation_id)
         .await
 }
@@ -338,11 +370,17 @@ pub(crate) async fn resolve_handle<R: Runtime>(
     app: AppHandle<R>,
     args: HandleArgs,
 ) -> Result<DirectoryResolution> {
-    app.f2zmsg().engine().resolve_handle(&args.handle).await
+    app.f2zmsg().engine()?.resolve_handle(&args.handle).await
 }
 
 /// Callable **before** enrollment and before the engine runs, so the UI can
 /// decide what to render without provoking a failure (§11.3).
+///
+/// "Before the engine runs" is not "without an engine": the answer is pure, but
+/// it is reached through the engine, and a plugin whose store never opened has
+/// none. So this refuses in the faulted state like everything else (#753). It
+/// costs nothing the user notices — a device with no messaging store has no
+/// handle to pick either.
 #[command]
 pub(crate) async fn check_handle_eligibility<R: Runtime>(
     app: AppHandle<R>,
@@ -350,7 +388,7 @@ pub(crate) async fn check_handle_eligibility<R: Runtime>(
 ) -> Result<HandleEligibility> {
     Ok(app
         .f2zmsg()
-        .engine()
+        .engine()?
         .check_handle_eligibility(&args.username))
 }
 
@@ -360,7 +398,7 @@ pub(crate) async fn get_safety_number<R: Runtime>(
     args: ConversationIdArgs,
 ) -> Result<SafetyNumber> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .safety_number(&args.conversation_id)
         .await
 }
@@ -371,7 +409,7 @@ pub(crate) async fn set_verification<R: Runtime>(
     args: SetVerificationArgs,
 ) -> Result<VerificationState> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .set_verification(
             &args.conversation_id,
             &args.safety_number_digest,
@@ -382,12 +420,12 @@ pub(crate) async fn set_verification<R: Runtime>(
 
 #[command]
 pub(crate) async fn get_self_audit_state<R: Runtime>(app: AppHandle<R>) -> Result<SelfAuditState> {
-    app.f2zmsg().engine().self_audit_state().await
+    app.f2zmsg().engine()?.self_audit_state().await
 }
 
 #[command]
 pub(crate) async fn list_alarms<R: Runtime>(app: AppHandle<R>) -> Result<Vec<Alarm>> {
-    app.f2zmsg().engine().list_alarms().await
+    app.f2zmsg().engine()?.list_alarms().await
 }
 
 /// Acknowledging is **not** dismissing: the alarm stays in `list_alarms` with
@@ -398,7 +436,7 @@ pub(crate) async fn acknowledge_alarm<R: Runtime>(
     args: AcknowledgeAlarmArgs,
 ) -> Result<Alarm> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .acknowledge_alarm(&args.alarm_id, &args.confirmation)
         .await
 }
@@ -409,7 +447,7 @@ pub(crate) async fn acknowledge_alarm<R: Runtime>(
 
 #[command]
 pub(crate) async fn list_relays<R: Runtime>(app: AppHandle<R>) -> Result<Vec<RelayConfig>> {
-    app.f2zmsg().engine().list_relays().await
+    app.f2zmsg().engine()?.list_relays().await
 }
 
 #[command]
@@ -417,12 +455,12 @@ pub(crate) async fn add_relay<R: Runtime>(
     app: AppHandle<R>,
     args: RelayUrlArgs,
 ) -> Result<RelayConfig> {
-    app.f2zmsg().engine().add_relay(&args.relay_url).await
+    app.f2zmsg().engine()?.add_relay(&args.relay_url).await
 }
 
 #[command]
 pub(crate) async fn remove_relay<R: Runtime>(app: AppHandle<R>, args: RelayIdArgs) -> Result<()> {
-    app.f2zmsg().engine().remove_relay(&args.relay_id).await
+    app.f2zmsg().engine()?.remove_relay(&args.relay_id).await
 }
 
 #[command]
@@ -431,7 +469,7 @@ pub(crate) async fn get_relay_capabilities<R: Runtime>(
     args: RelayIdArgs,
 ) -> Result<RelayCapabilities> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .relay_capabilities(&args.relay_id)
         .await
 }
@@ -446,7 +484,7 @@ pub(crate) async fn set_relay_trust<R: Runtime>(
     args: SetRelayTrustArgs,
 ) -> Result<RelayConfig> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .set_relay_trust(
             &args.relay_id,
             args.allow_insecure_transport,
@@ -457,7 +495,7 @@ pub(crate) async fn set_relay_trust<R: Runtime>(
 
 #[command]
 pub(crate) async fn list_witnesses<R: Runtime>(app: AppHandle<R>) -> Result<Vec<WitnessConfig>> {
-    app.f2zmsg().engine().list_witnesses().await
+    app.f2zmsg().engine()?.list_witnesses().await
 }
 
 #[command]
@@ -466,7 +504,7 @@ pub(crate) async fn set_witness_set<R: Runtime>(
     args: SetWitnessSetArgs,
 ) -> Result<WitnessSetState> {
     app.f2zmsg()
-        .engine()
+        .engine()?
         .set_witness_set(&args.witnesses, args.threshold)
         .await
 }
@@ -475,5 +513,5 @@ pub(crate) async fn set_witness_set<R: Runtime>(
 pub(crate) async fn get_witness_set_state<R: Runtime>(
     app: AppHandle<R>,
 ) -> Result<WitnessSetState> {
-    app.f2zmsg().engine().witness_set_state().await
+    app.f2zmsg().engine()?.witness_set_state().await
 }

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/error.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/error.rs
@@ -72,6 +72,44 @@ impl Error {
             format!("{what} requires a directory entry"),
         )
     }
+
+    /// A messaging store that would not open, as the one §8 code every command
+    /// will then answer with for the life of the process (#753).
+    ///
+    /// Three outcomes, and keeping them apart is the whole point of not
+    /// flattening this to `internal`:
+    ///
+    /// * **`storage-full`** — SQLite said `SQLITE_FULL`. §8 already tells the
+    ///   UI what to do about a full store, and it is the one cause the user can
+    ///   actually clear.
+    /// * **`durability-unavailable`** — either a pragma did not take, or the
+    ///   file cannot be opened for writing at all. `SqliteBackend::open`
+    ///   verifies WAL, `synchronous = FULL` and `secure_delete` and *refuses*
+    ///   rather than fall back, because §11.2 says a client that cannot promise
+    ///   durability must not ACK; a filesystem that will not give those pragmas
+    ///   (a network mount, a read-only or permission-denied data directory) is
+    ///   exactly "this device cannot host a store that may ACK", which is what
+    ///   this code means.
+    /// * **`internal`** — everything else, corruption included. §8: it carries
+    ///   no detail by design, so the cause goes to the log.
+    pub fn store_did_not_open(error: &f2z_msg_store::StoreError) -> Self {
+        let code = match error {
+            // Every `Backend` an *open* can produce is a pragma that did not
+            // take: `journal_mode`, `synchronous`, `secure_delete`.
+            f2z_msg_store::StoreError::Backend(_) => ErrorCode::DurabilityUnavailable,
+            f2z_msg_store::StoreError::Sqlite(sqlite) => match sqlite.sqlite_error_code() {
+                Some(rusqlite::ErrorCode::DiskFull) => ErrorCode::StorageFull,
+                Some(
+                    rusqlite::ErrorCode::CannotOpen
+                    | rusqlite::ErrorCode::ReadOnly
+                    | rusqlite::ErrorCode::PermissionDenied,
+                ) => ErrorCode::DurabilityUnavailable,
+                _ => ErrorCode::Internal,
+            },
+            _ => ErrorCode::Internal,
+        };
+        Self::new(code, format!("opening the messaging store: {error}"))
+    }
 }
 
 impl core::fmt::Display for Error {
@@ -136,6 +174,82 @@ mod tests {
             !json.contains("deadbeef"),
             "context must not cross IPC: {json}"
         );
+    }
+
+    /// #753. `SqliteBackend::open` verifies WAL, `synchronous = FULL` and
+    /// `secure_delete` and refuses rather than fall back, because §11.2 says a
+    /// client that cannot promise durability must not ACK. That refusal is a
+    /// `Backend` error, and it has a §8 code of its own — flattening it to
+    /// `internal` would tell a user on a network mount nothing they can act on.
+    #[test]
+    fn a_pragma_that_did_not_take_is_durability_unavailable() {
+        for operation in [
+            "open: journal_mode did not take",
+            "open: synchronous did not become FULL",
+            "open: secure_delete did not become ON",
+        ] {
+            assert_eq!(
+                Error::store_did_not_open(&f2z_msg_store::StoreError::Backend(operation)).code(),
+                ErrorCode::DurabilityUnavailable,
+                "{operation}",
+            );
+        }
+    }
+
+    /// The one cause the user can actually clear, so it must not arrive as
+    /// `internal`.
+    #[test]
+    fn a_full_disk_reaches_the_frontend_as_storage_full() {
+        let full = f2z_msg_store::StoreError::Sqlite(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_FULL),
+            None,
+        ));
+        assert_eq!(
+            Error::store_did_not_open(&full).code(),
+            ErrorCode::StorageFull
+        );
+    }
+
+    /// A file that cannot be opened for writing at all — a read-only or
+    /// permission-denied data directory, or a `f2zmsg.sqlite` that is not a
+    /// file — is the same statement as a pragma that did not take: this device
+    /// cannot host a store that may ACK.
+    #[test]
+    fn a_store_that_cannot_be_opened_for_writing_is_durability_unavailable() {
+        for code in [
+            rusqlite::ffi::SQLITE_CANTOPEN,
+            rusqlite::ffi::SQLITE_READONLY,
+            rusqlite::ffi::SQLITE_PERM,
+        ] {
+            let error = f2z_msg_store::StoreError::Sqlite(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(code),
+                None,
+            ));
+            assert_eq!(
+                Error::store_did_not_open(&error).code(),
+                ErrorCode::DurabilityUnavailable,
+                "sqlite result code {code}",
+            );
+        }
+    }
+
+    /// Corruption has no §8 member of its own, and `internal` carries no detail
+    /// by design — including the path, which names the user's home directory.
+    #[test]
+    fn a_corrupt_store_is_internal_and_still_leaks_nothing() {
+        let corrupt = f2z_msg_store::StoreError::Sqlite(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_NOTADB),
+            Some("file is not a database: /Users/someone/f2zmsg.sqlite".to_owned()),
+        ));
+        let error = Error::store_did_not_open(&corrupt);
+        assert_eq!(error.code(), ErrorCode::Internal);
+        assert!(
+            error.context().contains("not a database"),
+            "the cause must reach the log: {}",
+            error.context()
+        );
+        let json = serde_json::to_string(&error).expect("serialize");
+        assert_eq!(json, "\"internal\"", "context must not cross IPC: {json}");
     }
 
     #[test]

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/lib.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/lib.rs
@@ -63,6 +63,22 @@ macro_rules! command_handler {
     };
 }
 
+macro_rules! command_names {
+    ($($command:ident),* $(,)?) => {
+        &[$(stringify!($command)),*]
+    };
+}
+
+/// §3's plugin command surface as data.
+///
+/// The same `with_f2zmsg_commands!` expansion that generates the invoke handler
+/// and `build.rs`'s permission manifest, so a command cannot be registered and
+/// left out of this list. It is public because the *app* crate needs it: ZUULI's
+/// census test for #753 drives every command through IPC against a deliberately
+/// unopenable store, and a hand-written list there would go stale the first time
+/// §3 grows.
+pub const COMMANDS: &[&str] = with_f2zmsg_commands!(command_names);
+
 pub mod directory;
 pub mod engine;
 pub mod envelope;
@@ -104,40 +120,96 @@ pub fn command_router<R: Runtime>() -> TauriPlugin<R> {
     command_builder().build()
 }
 
-/// Initialize the plugin.
-pub fn init<R: Runtime>() -> TauriPlugin<R> {
+/// Where the durable store lives.
+enum StoreLocation {
+    /// The app's data directory — what a shipping build uses.
+    AppData,
+    /// An explicit directory. The only reason this exists is that #753 is a
+    /// defect about what happens when the store will *not* open, and a test
+    /// cannot make the app data directory unopenable without wrecking the
+    /// developer's machine.
+    Fixed(std::path::PathBuf),
+}
+
+/// Open the durable store and build the engine over it.
+///
+/// Every failure on this path is a §8 code rather than an opaque io error,
+/// because the code is what the frontend will be told for the rest of the
+/// process's life (#753).
+fn open_engine<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    location: &StoreLocation,
+) -> Result<Arc<engine::Engine<state::Backend>>> {
+    let data_dir = match location {
+        StoreLocation::AppData => app.path().app_data_dir().map_err(|error| {
+            Error::internal(format!("resolving the app data directory: {error}"))
+        })?,
+        StoreLocation::Fixed(dir) => dir.clone(),
+    };
+    // `From<std::io::Error>` is what turns a full or quota-exceeded volume into
+    // §8's `storage-full` here.
+    std::fs::create_dir_all(&data_dir)?;
+    let backend = f2z_msg_store::SqliteBackend::open(&data_dir.join(STORE_FILE))
+        .map_err(|error| Error::store_did_not_open(&error))?;
+
+    let platform = if cfg!(any(target_os = "android", target_os = "ios")) {
+        models::Platform::ZuuliMobile
+    } else {
+        models::Platform::ZuuliDesktop
+    };
+    let sink = Arc::new(events::TauriSink::new(app.clone()));
+    Ok(Arc::new(engine::Engine::new(backend, sink, platform)?))
+}
+
+fn plugin<R: Runtime>(location: StoreLocation) -> TauriPlugin<R> {
     command_builder()
-        .setup(|app, _api| {
-            let data_dir = app.path().app_data_dir()?;
-            std::fs::create_dir_all(&data_dir)?;
-            let backend = f2z_msg_store::SqliteBackend::open(&data_dir.join(STORE_FILE))
-                .map_err(|error| std::io::Error::other(error.to_string()))?;
+        .setup(move |app, _api| {
+            // **This hook must not return `Err`, ever** (#753). A plugin whose
+            // `setup` fails makes `tauri::Builder::build()` fail, and ZUULI's
+            // `run()` ends in `.expect("error while running tauri
+            // application")` — so an unopenable messaging store used to take
+            // the entire wallet down at launch. WAL is unavailable on some
+            // filesystems, a data directory can be full or read-only, and a
+            // half-written `f2zmsg.sqlite` is a state a real device reaches.
+            //
+            // Failing soft is *not* skipping `app.manage(..)`: `f2zmsg()` is
+            // `state::<F2zMsg<R>>().inner()`, which panics on an unmanaged
+            // type, so all forty-three commands would panic instead of
+            // refusing. The state is registered either way and answers either
+            // way.
+            match open_engine(app, &location) {
+                Ok(engine) => {
+                    app.manage(state::F2zMsg::new(app.clone(), Arc::clone(&engine)));
 
-            let platform = if cfg!(any(target_os = "android", target_os = "ios")) {
-                models::Platform::ZuuliMobile
-            } else {
-                models::Platform::ZuuliDesktop
-            };
-            let sink = Arc::new(events::TauriSink::new(app.clone()));
-            let engine = Arc::new(engine::Engine::new(backend, sink, platform).map_err(
-                |error| std::io::Error::other(format!("messaging engine: {}", error.context())),
-            )?);
-
-            app.manage(state::F2zMsg::new(app.clone(), Arc::clone(&engine)));
-
-            // The receive loop. It runs for the life of the process and does
-            // nothing at all until the engine is unlocked and started, which is
-            // why it is spawned here rather than from `start_engine`: a task
-            // started and stopped by a command is a task that can be left
-            // stopped by a command that failed halfway.
-            tauri::async_runtime::spawn(async move {
-                loop {
-                    tokio::time::sleep(POLL_INTERVAL).await;
-                    if let Err(error) = engine.pump_inbound().await {
-                        tracing::debug!(code = %error.code(), "inbound poll");
-                    }
+                    // The receive loop. It runs for the life of the process and
+                    // does nothing at all until the engine is unlocked and
+                    // started, which is why it is spawned here rather than from
+                    // `start_engine`: a task started and stopped by a command is
+                    // a task that can be left stopped by a command that failed
+                    // halfway. There is nothing to poll without an engine, so
+                    // the faulted arm spawns no task at all.
+                    tauri::async_runtime::spawn(async move {
+                        loop {
+                            tokio::time::sleep(POLL_INTERVAL).await;
+                            if let Err(error) = engine.pump_inbound().await {
+                                tracing::debug!(code = %error.code(), "inbound poll");
+                            }
+                        }
+                    });
                 }
-            });
+                Err(fault) => {
+                    // The one place this is recorded. `Error`'s `Serialize`
+                    // logs each refusal that crosses IPC, but the *cause* is
+                    // here and nowhere else, and it is what a support log needs
+                    // to tell a network mount apart from a full disk.
+                    tracing::error!(
+                        code = %fault.code(),
+                        context = %fault.context(),
+                        "messaging is unavailable: the durable store did not open"
+                    );
+                    app.manage(state::F2zMsg::faulted(app.clone(), fault));
+                }
+            }
 
             Ok(())
         })
@@ -148,22 +220,35 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                 event,
                 tauri::RunEvent::Exit | tauri::RunEvent::ExitRequested { .. }
             ) {
-                let engine = app.f2zmsg().engine_handle();
-                tauri::async_runtime::spawn(async move {
-                    engine.shutdown().await;
-                });
+                // A faulted plugin never built an engine, so there is nothing
+                // to shut down and nothing to wait for (#753).
+                if let Ok(engine) = app.f2zmsg().engine_handle() {
+                    tauri::async_runtime::spawn(async move {
+                        engine.shutdown().await;
+                    });
+                }
             }
         })
         .build()
 }
 
+/// Initialize the plugin.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    plugin(StoreLocation::AppData)
+}
+
+/// The shipping plugin with its store forced to `store_dir`.
+///
+/// A test seam, and specifically #753's: it is the only way to build the real
+/// `setup` hook over a store that cannot be opened.
+#[doc(hidden)]
+pub fn init_with_store_dir<R: Runtime>(store_dir: std::path::PathBuf) -> TauriPlugin<R> {
+    plugin(StoreLocation::Fixed(store_dir))
+}
+
 #[cfg(test)]
 mod command_registry_tests {
-    macro_rules! command_names {
-        ($($command:ident),* $(,)?) => {
-            &[$(stringify!($command)),*]
-        };
-    }
+    use super::COMMANDS;
 
     /// `CLIENT-CONTRACT.md` §3's plugin command surface: 46 bridge methods
     /// minus the enrollment trio, which is the app crate's (§2.2).
@@ -171,7 +256,7 @@ mod command_registry_tests {
 
     #[test]
     fn the_registry_is_the_contracts_plugin_surface() {
-        let commands: &[&str] = with_f2zmsg_commands!(command_names);
+        let commands: &[&str] = COMMANDS;
         assert_eq!(
             commands.len(),
             EXPECTED,
@@ -204,7 +289,6 @@ mod command_registry_tests {
         // `build.rs` writes the list it generated permissions from into the
         // environment. If the two ever disagree, a command exists at runtime
         // with no permission, or a permission exists for no command.
-        let commands: &[&str] = with_f2zmsg_commands!(command_names);
-        assert_eq!(env!("F2ZMSG_BUILD_COMMANDS"), commands.join(","));
+        assert_eq!(env!("F2ZMSG_BUILD_COMMANDS"), COMMANDS.join(","));
     }
 }

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/state.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/state.rs
@@ -3,6 +3,27 @@
 //! Mirrors `tauri-plugin-zcash`'s `ZcashExt`: the state is registered with
 //! `app.manage(..)` in `setup`, and every command reaches it through a trait
 //! implemented for anything that is a `Manager<R>`.
+//!
+//! # Why this holds an outcome and not an engine (#753)
+//!
+//! A plugin's `setup` hook is fallible, and an `Err` from it makes
+//! `tauri::Builder::build()` fail — which `wallet/zuuli/src-tauri/src/lib.rs`
+//! ends by `.expect(..)`ing. So for as long as this state was *only* ever
+//! constructed from a successfully opened store, a messaging store that would
+//! not open took the whole wallet down at launch. WAL is unavailable on some
+//! filesystems, a data directory can be full or read-only, and a half-written
+//! `f2zmsg.sqlite` from a killed process is a state a real device reaches; in
+//! every one of those the correct product behaviour is *messaging is
+//! unavailable and the wallet works*.
+//!
+//! Failing soft cannot be done by skipping `app.manage(..)`, because
+//! [`F2zMsgExt::f2zmsg`] is `self.state::<F2zMsg<R>>().inner()` and `state()`
+//! panics on an unmanaged type: all forty-three commands would panic rather
+//! than refuse. **The state has to exist and answer.** So it holds either the
+//! engine or the §8 [`ErrorCode`](crate::models::ErrorCode) that stopped the
+//! engine from being built, and [`F2zMsg::engine`] returns a `Result` — which
+//! makes the refusal the compiler's business rather than a convention: a
+//! command cannot reach the engine without handling the fault.
 
 use std::sync::Arc;
 
@@ -10,6 +31,8 @@ use f2z_msg_store::SqliteBackend;
 use tauri::{Manager, Runtime};
 
 use crate::engine::Engine;
+use crate::error::{Error, Result};
+use crate::models::{EngineState, EngineStatus};
 
 /// The backend the shipping plugin uses.
 ///
@@ -22,29 +45,95 @@ use crate::engine::Engine;
 /// rather than fail.
 pub type Backend = SqliteBackend;
 
-/// What `app.manage` holds.
+/// What `app.manage` holds: the **outcome** of the plugin's setup.
+///
+/// See the module header for why this is an outcome and not an engine.
 pub struct F2zMsg<R: Runtime> {
-    engine: Arc<Engine<Backend>>,
+    engine: core::result::Result<Arc<Engine<Backend>>, Error>,
     _app: tauri::AppHandle<R>,
 }
 
 impl<R: Runtime> F2zMsg<R> {
+    /// The state a `setup` that opened the store leaves behind.
     #[must_use]
     pub const fn new(app: tauri::AppHandle<R>, engine: Arc<Engine<Backend>>) -> Self {
-        Self { engine, _app: app }
+        Self {
+            engine: Ok(engine),
+            _app: app,
+        }
+    }
+
+    /// The state a `setup` that could **not** open the store leaves behind.
+    ///
+    /// `fault` is the §8 code the UI will see on every command, plus the
+    /// context that only reaches the log.
+    #[must_use]
+    pub const fn faulted(app: tauri::AppHandle<R>, fault: Error) -> Self {
+        Self {
+            engine: Err(fault),
+            _app: app,
+        }
     }
 
     /// The engine every command delegates to.
-    #[must_use]
-    pub fn engine(&self) -> &Engine<Backend> {
-        &self.engine
+    ///
+    /// # Errors
+    ///
+    /// The §8 code that stopped the engine from being built, when the store
+    /// did not open. Returning a `Result` here rather than panicking is the
+    /// whole fix for #753, and returning it *by type* is what makes every one
+    /// of the forty-three commands handle it: there is no way to reach the
+    /// engine that does not go through this.
+    pub fn engine(&self) -> Result<&Engine<Backend>> {
+        match &self.engine {
+            Ok(engine) => Ok(engine),
+            Err(fault) => Err(fault.clone()),
+        }
     }
 
     /// A cloned handle, for the receive task and for the app crate's
     /// enrollment commands.
+    ///
+    /// # Errors
+    ///
+    /// As [`F2zMsg::engine`].
+    pub fn engine_handle(&self) -> Result<Arc<Engine<Backend>>> {
+        match &self.engine {
+            Ok(engine) => Ok(Arc::clone(engine)),
+            Err(fault) => Err(fault.clone()),
+        }
+    }
+
+    /// The fault, when there is one — for `get_engine_status`, which answers
+    /// §6.1's `faulted` instead of refusing so the UI can say *why* messaging
+    /// is unavailable rather than render an empty screen.
     #[must_use]
-    pub fn engine_handle(&self) -> Arc<Engine<Backend>> {
-        Arc::clone(&self.engine)
+    pub const fn fault(&self) -> Option<&Error> {
+        match &self.engine {
+            Ok(_) => None,
+            Err(fault) => Some(fault),
+        }
+    }
+
+    /// §6.1's `faulted` status, when setup faulted.
+    ///
+    /// Every count is zero and `enrolled` is false because the store is the
+    /// only thing that knows otherwise and it is precisely what did not open —
+    /// reporting a remembered value here would be an invention.
+    #[must_use]
+    pub fn faulted_status(&self) -> Option<EngineStatus> {
+        self.fault().map(|fault| EngineStatus {
+            state: EngineState::Faulted,
+            enrolled: false,
+            handle: None,
+            relays_connected: 0,
+            relays_configured: 0,
+            witness_threshold_met: false,
+            independent_witnesses: 0,
+            pending_inbound: 0,
+            unacknowledged_alarms: 0,
+            last_error: Some(fault.code()),
+        })
     }
 }
 

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/an_unopenable_store_is_contained.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/an_unopenable_store_is_contained.rs
@@ -1,0 +1,97 @@
+//! #753 — a messaging store that will not open must make *messaging*
+//! unavailable, not the wallet.
+//!
+//! A plugin whose `setup` returns `Err` makes `tauri::Builder::build()` fail,
+//! and `wallet/zuuli/src-tauri/src/lib.rs` ends its `run()` in
+//! `.expect("error while running tauri application")` — so until this landed,
+//! an unopenable `f2zmsg.sqlite` took the whole ZUULI wallet down at launch.
+//! WAL is unavailable on some filesystems, a data directory can be full or
+//! read-only, and a half-written store from a killed process is a state a real
+//! device reaches.
+//!
+//! This file proves the plugin half: the app builds, the managed state exists,
+//! and it says why it has no engine. ZUULI's own
+//! `an_unopenable_messaging_store_leaves_zuuli_running_and_every_command_refusing`
+//! proves the other half — that all forty-three commands and the enrollment
+//! trio refuse over IPC rather than panic — because that needs the shipping
+//! capabilities, which only the app crate has.
+//!
+//! **`SqliteBackend::open`'s strictness is not what changed.** It still
+//! verifies every pragma and refuses otherwise, because §11.2 says a client
+//! that cannot promise durability must not ACK. What changed is the blast
+//! radius of that refusal.
+
+#![cfg(not(target_os = "windows"))]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use tauri_plugin_f2zmsg::models::{EngineState, ErrorCode};
+use tauri_plugin_f2zmsg::state::F2zMsgExt as _;
+
+/// A data directory in which `f2zmsg.sqlite` cannot be opened.
+///
+/// The store path is occupied by a **directory**, so SQLite answers
+/// `SQLITE_CANTOPEN` — the same result code a read-only or permission-denied
+/// data directory produces, and the only way to produce it that needs neither
+/// root nor a filesystem the test machine may not have.
+fn unopenable_store() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("temp data directory");
+    std::fs::create_dir(dir.path().join("f2zmsg.sqlite")).expect("occupy the store path");
+    dir
+}
+
+#[test]
+fn a_store_that_will_not_open_still_lets_the_app_build() {
+    let store = unopenable_store();
+    let app = tauri::test::mock_builder()
+        .plugin(tauri_plugin_f2zmsg::init_with_store_dir(
+            store.path().to_path_buf(),
+        ))
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("an unopenable messaging store must not stop the app from building");
+
+    // The state is registered either way, and that is the whole design:
+    // `F2zMsgExt::f2zmsg` is `state::<F2zMsg<R>>().inner()`, which *panics* on
+    // an unmanaged type, so skipping `app.manage(..)` would turn every command
+    // into a panic instead of a refusal.
+    let state = app.f2zmsg();
+    let fault = state
+        .fault()
+        .expect("the plugin must record why it has no engine");
+    assert_eq!(
+        fault.code(),
+        ErrorCode::DurabilityUnavailable,
+        "a store that cannot be opened for writing is not `internal`: {}",
+        fault.context()
+    );
+
+    assert!(state.engine().is_err(), "there is no engine to hand out");
+    assert!(state.engine_handle().is_err());
+
+    // §6.1's `faulted`, so the UI can say *why* messaging is unavailable
+    // instead of rendering an empty screen.
+    let status = state.faulted_status().expect("a faulted status");
+    assert_eq!(status.state, EngineState::Faulted);
+    assert_eq!(status.last_error, Some(ErrorCode::DurabilityUnavailable));
+}
+
+/// The negative control. Without it the test above would still pass if
+/// `init_with_store_dir` faulted unconditionally, and would prove nothing about
+/// the store path at all.
+#[test]
+fn a_store_that_opens_is_not_faulted() {
+    let store = tempfile::tempdir().expect("temp data directory");
+    let app = tauri::test::mock_builder()
+        .plugin(tauri_plugin_f2zmsg::init_with_store_dir(
+            store.path().to_path_buf(),
+        ))
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("an openable messaging store builds the app");
+
+    let state = app.f2zmsg();
+    assert!(
+        state.fault().is_none(),
+        "a writable directory must produce an engine, not a fault"
+    );
+    assert!(state.faulted_status().is_none());
+    assert!(state.engine().is_ok());
+}

--- a/wallet/zuuli/src-tauri/Cargo.lock
+++ b/wallet/zuuli/src-tauri/Cargo.lock
@@ -7025,6 +7025,7 @@ dependencies = [
  "openmls",
  "openmls_traits",
  "rand 0.9.5",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
@@ -9535,6 +9536,7 @@ dependencies = [
  "tauri-plugin-http",
  "tauri-plugin-opener",
  "tauri-plugin-zcash",
+ "tempfile",
  "tiny_http",
  "url",
 ]

--- a/wallet/zuuli/src-tauri/Cargo.toml
+++ b/wallet/zuuli/src-tauri/Cargo.toml
@@ -69,6 +69,9 @@ hex = "0.4"
 # its behavioral IPC probe runs on macOS/Linux.
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 tauri = { version = "2", features = ["test"] }
+# #753's census needs a data directory it can make *unopenable*. Already in the
+# lock as a transitive dependency, so naming it adds no crate to the graph.
+tempfile = "3"
 
 # ---------------------------------------------------------------------------
 # Build profiles. DO NOT DELETE — this is load-bearing for `tauri dev` usability.

--- a/wallet/zuuli/src-tauri/src/lib.rs
+++ b/wallet/zuuli/src-tauri/src/lib.rs
@@ -203,6 +203,274 @@ mod tests {
         }
     }
 
+    /// #753 — the census.
+    ///
+    /// `tauri_plugin_f2zmsg::init()`'s `setup` hook is fallible end to end, an
+    /// `Err` from a plugin's setup makes `tauri::Builder::build()` fail, and
+    /// `run()` above ends in `.expect("error while running tauri
+    /// application")`. So a messaging store that would not open took the entire
+    /// wallet down at launch — and WAL is unavailable on some filesystems, a
+    /// data directory can be full or read-only, and a half-written
+    /// `f2zmsg.sqlite` is a state a real device reaches.
+    ///
+    /// Three things are asserted here and nothing weaker would do:
+    ///
+    /// 1. **The app still builds.** That single `.expect` on `build()` below is
+    ///    the defect: before the fix it failed, and ZUULI did not start.
+    /// 2. **`get_engine_status` answers** §6.1's `faulted` carrying the §8
+    ///    code, so the UI can say *why* messaging is unavailable rather than
+    ///    render an empty screen.
+    /// 3. **Every other command refuses, and none panics** — driven off
+    ///    `tauri_plugin_f2zmsg::COMMANDS`, the same `with_f2zmsg_commands!`
+    ///    expansion that builds the invoke handler and the permission manifest,
+    ///    so this cannot cover forty of forty-three and look green. The
+    ///    enrollment trio is checked alongside it: those three live in this
+    ///    crate (§2.2) and reach the same engine.
+    ///
+    /// Failing soft could not be done by skipping `app.manage(..)`:
+    /// `F2zMsgExt::f2zmsg` is `state::<F2zMsg<R>>().inner()`, which panics on an
+    /// unmanaged type, so every command would have panicked instead of
+    /// refusing. That is precisely what this test would catch.
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn an_unopenable_messaging_store_leaves_zuuli_running_and_every_command_refusing() {
+        /// The §8 code an occupied store path produces. `SqliteBackend::open`
+        /// answers `SQLITE_CANTOPEN`, which is the same statement as a
+        /// read-only or permission-denied data directory: this device cannot
+        /// host a store that may ACK (§11.2).
+        const FAULT: &str = "durability-unavailable";
+
+        /// A valid payload for each command, so the refusal under test is the
+        /// engine's absence and not argument validation — an "invalid args"
+        /// answer would prove only that the command was routed.
+        ///
+        /// `None` means the command takes no `args` key at all (§3). The final
+        /// `panic!` is the census: a command added to §3 fails here until
+        /// someone states how to call it.
+        fn args_for(command: &str) -> Option<serde_json::Value> {
+            match command {
+                "get_engine_status"
+                | "start_engine"
+                | "stop_engine"
+                | "get_device_info"
+                | "list_contact_requests"
+                | "get_self_audit_state"
+                | "list_alarms"
+                | "list_relays"
+                | "list_witnesses"
+                | "get_witness_set_state" => None,
+                // Every field of these two is optional, and §3 still nests them
+                // under `args`.
+                "list_conversations" | "get_retention_policy" => Some(json!({})),
+                "get_conversation"
+                | "leave_conversation"
+                | "get_receipt_policy"
+                | "list_gaps"
+                | "get_ephemeral_hint"
+                | "list_purge_requests"
+                | "get_safety_number" => Some(json!({ "conversationId": "conversation-1" })),
+                "start_conversation" | "resolve_handle" => Some(json!({ "handle": "alice" })),
+                "check_handle_eligibility" => Some(json!({ "username": "alice" })),
+                "accept_contact_request" => Some(json!({ "requestId": "request-1" })),
+                "reject_contact_request" => {
+                    Some(json!({ "requestId": "request-1", "block": false }))
+                }
+                "send_message" => Some(json!({
+                    "conversationId": "conversation-1",
+                    "body": "hello",
+                    "clientRef": "client-ref-1",
+                })),
+                "retry_send" | "cancel_send" | "get_message" | "get_delivery_state" => {
+                    Some(json!({ "msgId": "message-1" }))
+                }
+                "list_messages" => Some(json!({ "conversationId": "conversation-1", "limit": 20 })),
+                "mark_read" => Some(json!({
+                    "conversationId": "conversation-1",
+                    "upToMsgId": "message-1",
+                })),
+                "set_receipt_policy" => Some(json!({
+                    "conversationId": "conversation-1",
+                    "deliveryReceipts": true,
+                    "readReceipts": false,
+                })),
+                "request_gap_repair" => Some(json!({
+                    "conversationId": "conversation-1",
+                    "gapIds": ["gap-1"],
+                })),
+                "set_retention_policy" => Some(json!({
+                    "scope": "global",
+                    "mode": "expire",
+                    "ttlSeconds": 604_800,
+                })),
+                "send_ephemeral_hint" => Some(json!({
+                    "conversationId": "conversation-1",
+                    "mode": "ephemeral",
+                    "ttlSeconds": 300,
+                })),
+                "send_purge_request" => Some(json!({
+                    "conversationId": "conversation-1",
+                    "beforeEpoch": 7,
+                })),
+                "set_verification" => Some(json!({
+                    "conversationId": "conversation-1",
+                    "safetyNumberDigest": "0011223344556677",
+                    "verified": true,
+                })),
+                "acknowledge_alarm" => Some(json!({
+                    "alarmId": "alarm-1",
+                    "confirmation": "i-have-read-this",
+                })),
+                "add_relay" => Some(json!({ "relayUrl": "wss://relay.invalid/" })),
+                "remove_relay" | "get_relay_capabilities" => Some(json!({ "relayId": "relay-1" })),
+                "set_relay_trust" => Some(json!({
+                    "relayId": "relay-1",
+                    "allowInsecureTransport": false,
+                    "allowNoChannelBinding": false,
+                })),
+                "set_witness_set" => Some(json!({ "witnesses": [], "threshold": 1 })),
+                other => panic!(
+                    "{other} was added to the plugin's command registry; \
+                     state how to call it so #753's census still covers it"
+                ),
+            }
+        }
+
+        // A data directory whose store path is occupied by a *directory*.
+        // SQLite cannot open it, and arranging that needs neither root nor a
+        // filesystem the test machine may not have.
+        let store = tempfile::tempdir().expect("temp data directory");
+        std::fs::create_dir(store.path().join("f2zmsg.sqlite")).expect("occupy the store path");
+
+        // (1) The app builds. This `.expect` is the whole defect.
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_f2zmsg::init_with_store_dir(
+                store.path().to_path_buf(),
+            ))
+            .invoke_handler(tauri::generate_handler![
+                super::messaging::f2zmsg_enrollment_status,
+                super::messaging::f2zmsg_enroll,
+                super::messaging::f2zmsg_unenroll,
+            ])
+            .build(super::app_context())
+            .expect("a messaging store that will not open must not stop ZUULI from starting");
+        let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+            .build()
+            .expect("mock main webview");
+
+        let invoke = |cmd: String, body: serde_json::Value| {
+            tauri::test::get_ipc_response(
+                &webview,
+                tauri::webview::InvokeRequest {
+                    cmd,
+                    callback: tauri::ipc::CallbackFn(0),
+                    error: tauri::ipc::CallbackFn(1),
+                    url: "tauri://localhost".parse().expect("invoke URL"),
+                    body: tauri::ipc::InvokeBody::Json(body),
+                    headers: Default::default(),
+                    invoke_key: tauri::test::INVOKE_KEY.to_owned(),
+                },
+            )
+        };
+        let body_for = |command: &str| match args_for(command) {
+            Some(args) => json!({ "args": args }),
+            None => json!({}),
+        };
+
+        // (2) `get_engine_status` answers instead of refusing.
+        let status = invoke(
+            "plugin:f2zmsg|get_engine_status".to_owned(),
+            body_for("get_engine_status"),
+        )
+        .expect("get_engine_status must report the fault, not refuse")
+        .deserialize::<serde_json::Value>()
+        .expect("an engine status is JSON");
+        assert_eq!(
+            status["state"],
+            json!("faulted"),
+            "the UI has to be able to say messaging is unavailable: {status}"
+        );
+        assert_eq!(status["lastError"], json!(FAULT), "…and why: {status}");
+
+        // (3) Every other command refuses with that same §8 code.
+        assert_eq!(
+            tauri_plugin_f2zmsg::COMMANDS.len(),
+            43,
+            "§3's plugin surface changed; the census below covers whatever it now is"
+        );
+        for command in tauri_plugin_f2zmsg::COMMANDS {
+            if *command == "get_engine_status" {
+                continue;
+            }
+            let refused = invoke(format!("plugin:f2zmsg|{command}"), body_for(command))
+                .expect_err("a command with no engine must refuse, not answer");
+            assert_eq!(
+                refused,
+                json!(FAULT),
+                "plugin:f2zmsg|{command} must refuse with a §8 code"
+            );
+        }
+
+        // …and so does the enrollment trio, which lives in this crate (§2.2)
+        // and reaches the same engine. `f2zmsg_enroll` refuses *before* it
+        // reads the wallet seed.
+        for (command, body) in [
+            ("f2zmsg_enrollment_status", json!({})),
+            ("f2zmsg_enroll", json!({ "args": { "handle": "alice" } })),
+            (
+                "f2zmsg_unenroll",
+                json!({ "args": { "confirmation": "DELETE" } }),
+            ),
+        ] {
+            let refused = invoke(command.to_owned(), body)
+                .expect_err("enrollment with no engine must refuse, not answer");
+            assert_eq!(
+                refused,
+                json!(FAULT),
+                "{command} must refuse with a §8 code"
+            );
+        }
+    }
+
+    /// The negative control for the test above: the same build over a *usable*
+    /// data directory is not faulted. Without it, a plugin that faulted
+    /// unconditionally would pass the census and prove nothing.
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn a_messaging_store_that_opens_leaves_the_engine_reachable() {
+        let store = tempfile::tempdir().expect("temp data directory");
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_f2zmsg::init_with_store_dir(
+                store.path().to_path_buf(),
+            ))
+            .build(super::app_context())
+            .expect("mock ZUULI app over a usable messaging store");
+        let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+            .build()
+            .expect("mock main webview");
+
+        let status = tauri::test::get_ipc_response(
+            &webview,
+            tauri::webview::InvokeRequest {
+                cmd: "plugin:f2zmsg|get_engine_status".to_owned(),
+                callback: tauri::ipc::CallbackFn(0),
+                error: tauri::ipc::CallbackFn(1),
+                url: "tauri://localhost".parse().expect("invoke URL"),
+                body: tauri::ipc::InvokeBody::Json(json!({})),
+                headers: Default::default(),
+                invoke_key: tauri::test::INVOKE_KEY.to_owned(),
+            },
+        )
+        .expect("a usable store answers")
+        .deserialize::<serde_json::Value>()
+        .expect("an engine status is JSON");
+        assert_ne!(
+            status["state"],
+            json!("faulted"),
+            "a writable data directory must produce an engine: {status}"
+        );
+        assert_eq!(status["lastError"], json!(null));
+    }
+
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn shipping_zcash_router_registers_sensitive_entry_commands() {

--- a/wallet/zuuli/src-tauri/src/messaging.rs
+++ b/wallet/zuuli/src-tauri/src/messaging.rs
@@ -51,6 +51,16 @@
 //! that is already enrolled under the requested handle it re-derives the wrap
 //! key and unlocks, rather than refusing. A frontend that calls `enroll` on
 //! launch gets "ready", not an error it has no command to resolve.
+//!
+//! # These three refuse when the plugin has no engine, like the other 43
+//!
+//! `F2zMsgExt::f2zmsg` answers even when `tauri-plugin-f2zmsg`'s `setup` could
+//! not open the durable store, and `F2zMsg::engine` is a `Result` for exactly
+//! that reason (#753). So each command below takes it with `?` and refuses with
+//! the §8 code the store failure produced, rather than panicking on an engine
+//! that was never built. In `f2zmsg_enroll` the `?` is deliberately the *first*
+//! statement: there is no point reading the wallet seed for an enrollment that
+//! has nowhere to be written.
 
 use f2z_codec::types::PublicKey;
 use f2z_kt_core::types::{Handle, KemPublicKey};
@@ -91,7 +101,7 @@ pub struct UnenrollArgs {
 /// §3.2 `f2zmsg_enrollment_status`. Reads the store; needs no seed.
 #[tauri::command]
 pub async fn f2zmsg_enrollment_status<R: Runtime>(app: AppHandle<R>) -> Result<EnrollmentStatus> {
-    app.f2zmsg().engine().enrollment_status().await
+    app.f2zmsg().engine()?.enrollment_status().await
 }
 
 /// §3.2 `f2zmsg_enroll`.
@@ -105,7 +115,7 @@ pub async fn f2zmsg_enroll<R: Runtime>(
     app: AppHandle<R>,
     args: EnrollArgs,
 ) -> Result<EnrollmentStatus> {
-    let engine = app.f2zmsg().engine_handle();
+    let engine = app.f2zmsg().engine_handle()?;
 
     // Derive first, in every branch. Enrolling and unlocking need the same
     // §4.2 account keys, and deriving before the branch keeps the seed's
@@ -186,7 +196,7 @@ pub async fn f2zmsg_unenroll<R: Runtime>(
     app: AppHandle<R>,
     args: UnenrollArgs,
 ) -> Result<EnrollmentStatus> {
-    app.f2zmsg().engine().unenroll(&args.confirmation).await
+    app.f2zmsg().engine()?.unenroll(&args.confirmation).await
 }
 
 /// Read the active wallet's seed **in process** and derive §4.2's account keys.


### PR DESCRIPTION
## The failure chain

`tauri_plugin_f2zmsg::init()`'s `setup` hook was fallible end to end:

```
app.path().app_data_dir()?          ─┐
std::fs::create_dir_all(&data_dir)?  ├─ any Err …
SqliteBackend::open(..)?             │
Engine::new(..)?                    ─┘
        │
        ▼
plugin `setup` returns Err
        │
        ▼
tauri::Builder::build() fails            (Error::PluginInitialization)
        │
        ▼
wallet/zuuli/src-tauri/src/lib.rs: .run(app_context())
                                   .expect("error while running tauri application")
        │
        ▼
ZUULI does not start.
```

WAL is unavailable on some filesystems, a data directory can be full,
read-only or permission-denied, and a half-written `f2zmsg.sqlite` from a killed
process is a state a real device reaches. In every one of those the correct
product behaviour is *messaging is unavailable and the wallet works*.

**`SqliteBackend::open`'s strictness is unchanged and is not the defect.** It
still verifies WAL, `synchronous = FULL` and `secure_delete` at open and refuses
otherwise, because `CLIENT-CONTRACT.md` §11.2 says a client that cannot promise
durability must not ACK, and a silent fallback to a non-durable store would stop
deleting relay copies without telling anyone. What was wrong is the blast
radius.

## Why failing soft cannot just skip `app.manage(..)`

`F2zMsgExt::f2zmsg` is `self.state::<F2zMsg<R>>().inner()`, and Tauri's
`state()` panics on an unmanaged type:

```
state() called before manage() for tauri_plugin_f2zmsg::state::F2zMsg<..>
```

So a `setup` that returned `Ok(())` without managing would turn all 43 commands
from *refusals* into *panics* — a worse failure, not a better one. That is
falsification F2 below, run for real. **The state has to exist and answer.**

## The design

* `F2zMsg` holds the **outcome** — `Result<Arc<Engine<Backend>>, Error>`: either
  the engine, or the §8 code (plus log-only context) that stopped it being
  built. `F2zMsg::new` and the new `F2zMsg::faulted` are the two constructors.
* **`F2zMsg::engine()` returns a `Result`.** That is what makes the refusal
  total: there is no way to reach the engine that does not go through it, so the
  *compiler* — not a convention, and not a reviewer — is what makes every one of
  the 43 commands handle the fault. A command that compiles cannot panic in this
  state.
* `get_engine_status` is the single command that **answers** instead of
  refusing: §6.1's `EngineState::Faulted` with `lastError` set, so the UI can say
  why messaging is unavailable rather than render an empty screen. Every other
  command, and the app-crate enrollment trio (`f2zmsg_enroll`,
  `f2zmsg_unenroll`, `f2zmsg_enrollment_status`), refuses with that code.
  `f2zmsg_enroll` takes the `?` as its *first* statement — there is no point
  reading the wallet seed for an enrollment that has nowhere to be written.
* `setup` never returns `Err` again, logs the cause once at `error!` (the one
  place it is recorded; `Error`'s `Serialize` logs the refusals but not the
  cause), and spawns no receive task when there is no engine. `on_event`'s
  shutdown is `if let Ok(engine) = …engine_handle()`.
* **The open failure is mapped, not flattened** (`Error::store_did_not_open`):
  * `SQLITE_FULL` → `storage-full` (the one cause the user can clear; §8 already
    tells the UI what to do about it), as is a `create_dir_all` that returns
    `StorageFull`/`QuotaExceeded` through the existing `From<std::io::Error>`.
  * `StoreError::Backend(..)` — every `Backend` error an *open* can produce is a
    pragma that did not take — and `SQLITE_CANTOPEN` / `SQLITE_READONLY` /
    `SQLITE_PERM` → `durability-unavailable`. Both say the same thing: this
    device cannot host a store that may ACK.
  * everything else, corruption included → `internal`, which §8 says carries no
    detail by design; the cause goes to the log.
  Classifying needs `rusqlite::ErrorCode`, so `rusqlite = "0.37"` is now a named
  dependency of the plugin — the repo-wide singleton the root `AGENTS.md`
  describes, already in this graph through `f2z-msg-store`, `default-features =
  false`. No crate is added to either lockfile (only a dependency edge).
* `tauri_plugin_f2zmsg::COMMANDS` is now public: the same
  `with_f2zmsg_commands!` expansion that builds the invoke handler and
  `build.rs`'s permission manifest, exported so the app crate's census cannot go
  stale.

## Tests

`wallet/zuuli/src-tauri/src/lib.rs` —
`an_unopenable_messaging_store_leaves_zuuli_running_and_every_command_refusing`
is the **census**, over the real ZUULI context and its shipping capabilities:

1. `tauri::test::mock_builder().plugin(init_with_store_dir(..)).build(app_context())`
   succeeds over a store path that cannot be opened. That single `.expect` is
   the defect.
2. `plugin:f2zmsg|get_engine_status` answers `state: "faulted"`,
   `lastError: "durability-unavailable"`.
3. **All 43 commands** — iterated from `tauri_plugin_f2zmsg::COMMANDS`, not a
   hand-picked sample — plus the enrollment trio, each invoked over IPC with a
   *valid* payload so the refusal under test is the engine's absence and not
   argument validation. Each must refuse with the §8 code; none may panic. The
   per-command payload table ends in `panic!("… state how to call it so #753's
   census still covers it")`, so a 44th command cannot be added without saying
   how it behaves in this state.

`a_messaging_store_that_opens_leaves_the_engine_reachable` is its negative
control: the same build over a writable directory is *not* faulted. Without it a
plugin that faulted unconditionally would pass the census.

`wallet/plugins/tauri-plugin-f2zmsg/tests/an_unopenable_store_is_contained.rs`
proves the plugin half without the app's capabilities: the app builds, the state
is managed, and it reports the fault; plus its own negative control.

`src/error.rs` gains four unit tests for the code mapping, including one that a
corrupt store is `internal` **and** that its context still does not cross IPC.

The store is made unopenable by occupying `f2zmsg.sqlite` with a *directory* —
SQLite answers `SQLITE_CANTOPEN`, the same result code a read-only or
permission-denied data directory gives, and it needs neither root nor a
filesystem the CI runner may not have.

## Falsification

Each revert was an inverse string replacement asserted to match **exactly once**
(never `git checkout`), and each pre-fix failure mode was checked to be the real
one — a build failure or a panic, not a changed message.

| # | Inverse replacement | Test | Result |
|---|---|---|---|
| F1 | `app.manage(state::F2zMsg::faulted(app.clone(), fault));` → `return Err(Box::new(std::io::Error::other(fault.context().to_owned())));` (the pre-fix `setup`) | `a_store_that_will_not_open_still_lets_the_app_build` | **FAILED** — `panicked … an unopenable messaging store must not stop the app from building: PluginInitialization("f2zmsg", "opening the messaging store: the SQLite backend failed: unable to open database file: …")`. A `Builder::build()` failure, exactly the chain above. |
| F2 | same line → `let _ = &fault;` (i.e. "just skip `manage`") | same | **FAILED** — `panicked at tauri-2.11.5/src/lib.rs:734:7: state() called before manage() for tauri_plugin_f2zmsg::state::F2zMsg<..>`. A panic, which is what the issue predicted and why skipping `manage` is not the fix. |
| F3 | `get_engine_status`'s faulted branch → `app.f2zmsg().engine()?.status().await` | `an_unopenable_messaging_store_leaves_zuuli_running_and_every_command_refusing` | **FAILED** — `get_engine_status must report the fault, not refuse` panicked at src/lib.rs:384:10: get_engine_status must report the fault, not refuse: String("durability-unavailable") — the census then never reaches the 43-command loop. |
| — | restored | both | **pass** |

## Verification

BEFORE = `origin/main` @ 8cbcd62 with the branch stashed; AFTER = this branch.
All measured on this machine, macOS, rustup toolchain 1.97.1 (the repo pin).

### `tauri-plugin-f2zmsg` (its own workspace)

`cargo test --locked --all-targets --features relay-harness` — the CI gate's exact command:

| | BEFORE (`origin/main` @ 8cbcd62) | AFTER |
|---|---|---|
| `src/lib.rs` unit tests | `ok. 48 passed; 0 failed` | `ok. 52 passed; 0 failed` |
| `src/bin/peer.rs` | `ok. 0 passed; 0 failed` | `ok. 0 passed; 0 failed` |
| `tests/an_unopenable_store_is_contained.rs` | *(did not exist)* | `ok. 2 passed; 0 failed` |
| `tests/engine_lifecycle.rs` | `ok. 11 passed; 0 failed` | `ok. 11 passed; 0 failed` |
| `tests/two_instances_over_a_relay.rs` | `ok. 1 passed; 0 failed` | `ok. 1 passed; 0 failed` |
| | `EXIT=0` (60 tests) | `EXIT=0` (66 tests) |

```
cargo clippy --all-targets -- -D warnings   BEFORE EXIT=0   AFTER EXIT=0
cargo clippy --all-targets --all-features -- -D warnings    AFTER EXIT=0
cargo fmt --check                           BEFORE EXIT=0   AFTER EXIT=0
cargo build --locked   (the shipping configuration)         AFTER EXIT=0
```

### `wallet/zuuli/src-tauri`

`cargo test --locked`:

| | BEFORE | AFTER |
|---|---|---|
| `unittests src/lib.rs` | `ok. 20 passed; 0 failed` | `ok. 22 passed; 0 failed` |
| `unittests src/main.rs` | `ok. 0 passed; 0 failed` | `ok. 0 passed; 0 failed` |
| doc-tests | `ok. 0 passed; 0 failed` | `ok. 0 passed; 0 failed` |
| | `EXIT=0` | `EXIT=0` |

```
cargo clippy --all-targets -- -D warnings   BEFORE EXIT=0   AFTER EXIT=0
cargo fmt --check                           BEFORE EXIT=0   AFTER EXIT=0
```

`scripts/check-rust-fmt.sh` (all six wallet crates, rustfmt from 1.97.1):
`All 6 Rust crate(s) under wallet/ are formatted (rustfmt from 1.97.1).` `EXIT=0`

### Node

From `wallet/zuuli/` after `npm ci` (`EXIT=0`):

```
npm run test:status-freshness                     # tests 31  pass 31  fail 0   EXIT=0
node --test scripts/messaging-contract.node-test.mjs   # tests 6   pass 6   fail 0   EXIT=0
```

From the repository root:

```
node scripts/check-tauri-plugin-permissions.mjs
  Tauri plugin permission generation matches.
    zcash:  39 commands, 78 permission identifiers, 3 capability grants, 3 tracked target schemas
    f2zmsg: 43 commands, 86 permission identifiers, 2 capability grants, 0 tracked target schemas
  EXIT=0
node scripts/check-tauri-plugin-permissions.mjs --self-test
  Tauri plugin permission parity negative controls passed.
  EXIT=0
```

`git diff --exit-code -- wallet/plugins/tauri-plugin-f2zmsg/permissions` after a
build with `TAURI_PERMISSION_GENERATION_NONCE` set: **no drift**, `EXIT=0`.

Toolchain: rustup `1.97.1` (`wallet/rust-toolchain.toml`), macOS. Every command
was run from the directory holding the toolchain pin, and judged by its `EXIT=`
marker.


## Deliberately left

* **`check_handle_eligibility` refuses too.** Its answer is pure
  (`handle::eligibility(username)`), and §11.3 calls it "callable before
  enrollment and before the engine runs" — but it is *reached through* the
  engine, and a plugin whose store never opened has none. It refuses like
  everything else, which keeps the acceptance criterion literal ("every command
  … refuses") and costs nothing a user notices: a device with no messaging store
  has no handle to pick either. Making it engine-free is a separate change.
* **`faulted` is entered here without passing through `starting`.**
  `CLIENT-CONTRACT.md` §6.1 said `faulted` is reached only from
  `starting`/`running`/`degraded` and is left by `start_engine`. This one is
  entered at plugin setup and cannot be left by `start_engine` — only by fixing
  the storage and restarting. §6.1 now says so, and §8's
  `durability-unavailable` row is no longer "browser only".
* **No UI change.** The contract's job here was to *report* it; rendering the
  faulted state is the frontend's, and `EngineStatusSchema` already carries
  `state: "faulted"` and `lastError`.
* **`STATUS.md` and `release.json` untouched**, as instructed.

Closes #753

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
