### PR TITLE
docs(agents): a merged worktree is reclaimed on sight, not on judgement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,15 +413,22 @@ for w in .worktrees/*/* ; do
 done
 ```
 
-A `MERGED` row is reclaimable. `OPEN` is live work. `(no PR)` and `CLOSED` are
-judgement calls that belong to whoever created them — **never sweep those
-without asking the owner.**
+**A `MERGED` row is reclaimed on sight — always, and without asking.** The
+branch is on `main`; the worktree holds nothing that is not already in the
+repository, so there is no judgement to exercise and no owner to consult. Do
+not leave one standing because it is not yours.
+
+`OPEN` is live work. `(no PR)` and `CLOSED` are the judgement calls, and those
+**do** belong to whoever created them — never sweep those without asking.
 
 ### Check for uncommitted work first, and never force past it
 
 `git worktree remove --force` will discard a dirty tree. That is fine for a
 worktree you created minutes ago to run a mutation in; it is not fine for
-somebody else's in-progress branch. Before removing anything you did not create
+somebody else's in-progress branch. **This is the one condition that overrides
+"reclaim every merged worktree":** a merged branch with uncommitted changes on
+top is somebody's work-in-progress, and the sweep refuses it rather than
+deciding for them. Before removing anything you did not create
 this session:
 
 ```bash
@@ -442,7 +449,15 @@ refuses for a good reason has not already cost you the rebuild:
 rm -rf "$w"/rs/target "$w"/wallet/*/target "$w"/wallet/*/node_modules
 git worktree remove --force "$w"
 git worktree prune
+git branch -D "$b"        # merged; the remote branch is already gone
 ```
+
+Two things that will bite in `zsh`: an unmatched glob is a hard error rather
+than a silent no-op, so give `rm -rf` a `2>/dev/null` or the loop aborts on the
+first worktree that has no `wallet/*/target`; and `gh pr list` needs repository
+context, so a loop that `cd`s to the directory *containing* the checkouts must
+pass `-R <owner>/<repo>` or every query silently returns empty and every
+worktree looks unmerged.
 
 Reclaiming build output **without** removing the worktree is the conservative
 middle option for a branch somebody still wants: it costs a cold rebuild and


### PR DESCRIPTION
#758 described the sweep but left "reclaim" reading like a decision. It is not
one. A merged branch is on `main`; its worktree holds nothing that is not
already in the repository, so there is no owner to consult and no reason to
leave one standing because it is somebody else's. Says so plainly now:
**always, and without asking.**

The distinction that remains is narrower and worth keeping sharp. `OPEN` is
live work. `(no PR)` and `CLOSED` are genuine judgement calls belonging to
whoever created them. And uncommitted changes are the one condition that
overrides the rule — a merged branch with work on top is somebody's
work-in-progress, so the sweep refuses it rather than deciding for them.

Also records two traps that made today's sweep report nonsense before it
reported anything useful:

- **`gh pr list` needs repository context.** A loop that `cd`s to the directory
  *containing* the checkouts is outside any repo, so every query returns empty
  and every worktree looks unmerged. Pass `-R <owner>/<repo>`.
- **`zsh` treats an unmatched glob as a hard error**, so `rm -rf "$w"/wallet/*/target`
  aborts the loop on the first worktree without that path. Needs `2>/dev/null`.

Adds `git branch -D "$b"` to the removal sequence, since a reclaimed merged
worktree otherwise leaves its local branch behind.

Measured on the sweep this documents: 27 GiB free before, 121 GiB after.

Claude-Session: https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD