### PR TITLE
test(relay): restore coverage of json_string's control-byte escapes

### DIFF
--- a/rs/crates/f2z-relay/src/caps.rs
+++ b/rs/crates/f2z-relay/src/caps.rs
@@ -690,4 +690,80 @@ mod tests {
         let json = to_json(&published);
         assert!(json.contains("a \\\"quoted\\\" name\\\\with a slash"));
     }
+
+    // -----------------------------------------------------------------------
+    // `json_string`'s own coverage.
+    //
+    // §11.1 restricts the eight operator and provenance strings to printable
+    // ASCII and `build` ends in `capabilities::validate`, so a control byte is
+    // refused before `to_json` can render one — which is why the test above
+    // reaches the escaper with a backslash rather than the newline it used to
+    // use. Those eight fields are `json_string`'s only callers, so its `\n`,
+    // `\r`, `\t` and `\u{04x}` arms are unreachable from a capability document
+    // and nothing above this line can exercise them.
+    //
+    // They are still the layer that has to hold if the restriction is ever
+    // relaxed, bypassed, or this renderer reused, so they are tested here
+    // directly: `json_string` is a private free function over `&[u8]`, so it
+    // needs no config, no signing and no document, and the restriction is not
+    // weakened to make a test possible.
+    //
+    // One byte class per test, so that a break in one arm cannot be hidden by
+    // another arm's bytes in the same assertion. Each assertion is the whole
+    // rendered token — the string a JSON reader must accept per RFC 8259 §7 —
+    // rather than a substring of a document. `f2z-relay` deliberately carries
+    // no JSON parser (hand-rendering §11.2 is the point of this module), so
+    // these are reviewed literals rather than a parse.
+
+    #[test]
+    fn the_json_escaper_renders_empty_bytes_as_an_empty_string() {
+        assert_eq!(json_string(b""), "\"\"");
+    }
+
+    #[test]
+    fn the_json_escaper_escapes_a_quotation_mark() {
+        assert_eq!(json_string(b"a\"b"), "\"a\\\"b\"");
+    }
+
+    #[test]
+    fn the_json_escaper_escapes_a_backslash() {
+        assert_eq!(json_string(b"a\\b"), "\"a\\\\b\"");
+    }
+
+    #[test]
+    fn the_json_escaper_escapes_a_newline() {
+        assert_eq!(json_string(b"a\nb"), "\"a\\nb\"");
+    }
+
+    #[test]
+    fn the_json_escaper_escapes_a_carriage_return() {
+        assert_eq!(json_string(b"a\rb"), "\"a\\rb\"");
+    }
+
+    #[test]
+    fn the_json_escaper_escapes_a_tab() {
+        assert_eq!(json_string(b"a\tb"), "\"a\\tb\"");
+    }
+
+    #[test]
+    fn the_json_escaper_escapes_every_byte_no_short_form_covers() {
+        // Everything outside `0x20..=0x7e` without a two-character form: the C0
+        // controls, DEL, and every byte with the high bit set. Each becomes the
+        // code point of the same value, which is a byte-wise reading and not a
+        // UTF-8 one — sound only because §11.1 refuses these bytes upstream,
+        // never a claim that a `0x80` here was part of a character.
+        assert_eq!(
+            json_string(b"\x00\x1f\x7f\x80\xff"),
+            "\"\\u0000\\u001f\\u007f\\u0080\\u00ff\""
+        );
+    }
+
+    #[test]
+    fn the_json_escaper_passes_the_rest_of_printable_ascii_through_unchanged() {
+        let printable: Vec<u8> = (0x20..=0x7e)
+            .filter(|byte| *byte != b'"' && *byte != b'\\')
+            .collect();
+        let expected = String::from_utf8(printable.clone()).unwrap();
+        assert_eq!(json_string(&printable), format!("\"{expected}\""));
+    }
 }


### PR DESCRIPTION
## What `json_string` escapes

`rs/crates/f2z-relay/src/caps.rs:499-518` renders one operator string as a JSON
string token. Seven arms, verified on today's `main` (`b5b6eac`):

| arm | line | output |
|---|---|---|
| `b'"'` | `:504` | `\"` |
| `b'\\'` | `:505` | `\\` |
| `b'\n'` | `:506` | `\n` |
| `b'\r'` | `:507` | `\r` |
| `b'\t'` | `:508` | `\t` |
| `0x20..=0x7e` | `:509` | the byte, unchanged |
| everything else | `:510-513` | `\u{:04x}` |

## Why #661 had to change the test that covered it

`an_operator_string_cannot_break_the_document_it_appears_in` was the only test
that reached the escaper, and it reached it with a **newline**. #661 (`dd67eac6`)
added §11.1's printable-ASCII rule at
`rs/crates/f2z-relay-proto/src/capabilities.rs:314-336`: the eight operator and
provenance strings must be `0x20..=0x7e` or `validate` refuses the document.
`caps::build` ends in `capabilities::validate` (`caps.rs:236`), so a configured
newline now fails at `build`, before there is anything for `to_json` to render.

Measured on this branch with a throwaway test, not assumed:
`config.operator.name = "a\nb"` makes `build` return
`Err(CapabilitiesError::Invalid(ProtoError::Refused(Refusal::CapabilitiesInconsistent)))`.
So #661's swap of that test's input from a newline to a backslash was necessary,
and the test is now asserting the right thing at the right layer. **This PR
leaves it exactly as #661 left it**, and leaves
`configured_control_bytes_fail_before_the_relay_can_publish_them` alone too.

## What lost coverage, and why nothing else reaches it

`json_string` is private to `caps.rs` and has exactly **eight call sites** —
`caps.rs:429`, `:434`, `:439`, `:444`, `:449`, `:454`, `:459`, `:464` — and they
are precisely the eight fields #661 restricts. So after the swap the `\n`, `\r`,
`\t` and `\u{04x}` arms had no coverage anywhere in the workspace, and no
capability document could give them any.

Measured, not argued. Applying the issue's exact mutation to **`origin/main`'s**
`caps.rs`:

```rust
-            b'\n' => out.push_str("\\n"),
+            b'\n' => out.push_str("LITERAL-NEWLINE-BREAKS-JSON"),
```

and running the **whole workspace** suite: `EXIT=0`, **1040 passed, 0 failed** —
byte-identical to the clean baseline. An arm that emits a raw newline into a
signed document a third party fetches and diffs is invisible to the entire suite.

That is a reason to keep the escaper and a bad reason to stop testing it: the
value of a second layer is that it holds when the first is relaxed, bypassed, or
the renderer reused. (`f2z-kt/src/descriptor.rs` renders the same eight fields
through `crate::json::escape` with no equivalent KT.md restriction in front of
it — raised in #662 as a separate question, deliberately not touched here.)

## The fix

Eight unit tests against `json_string` directly. It is a private free function
over `&[u8]` in the same module as `mod tests`, so `use super::*` reaches it the
way the existing `base64url` test reaches its subject — no config, no signing, no
document, and **no weakening of #661's restriction to make a test possible**.

One byte class per test, so a break in one arm cannot be masked by another arm's
bytes in the same assertion. Each assertion is the **whole rendered token**, not
a `contains` on a document:

```rust
assert_eq!(json_string(b"a\nb"), "\"a\\nb\"");
```

**Reviewed literals, not a parse — and why.** `f2z-relay` has no JSON parser in
`[dependencies]` or `[dev-dependencies]`; hand-rendering §11.2 with no
`serde_json` in the daemon is the point of the module, so rather than add a JSON
reader to the one crate that deliberately has none, the expected values are
written out from RFC 8259 §7. To keep them from being a transcription of the
implementation's own output, every expected token was checked out-of-band
against a real JSON reader (CPython `json`) before being committed: each one
parses, and decodes back to exactly the input bytes. The literals are the
artifact a JSON reader accepts, not a substring of one.

One behaviour the fallback test now pins, worth naming: a byte `>= 0x80` renders
as the code point of the same value (`0xff` → `ÿ`), i.e. read byte-wise, not
as UTF-8. Sound only because §11.1 refuses those bytes upstream — not a claim
that the escaper transcodes. (The `\u` literal sketched in #662 was not what the
code emits; this is.)

## Falsification — one mutation per arm

Each mutation applied by inverse string replacement asserted to match **exactly
once**, `cargo test -p f2z-relay --lib caps::tests` after each, file restored
byte-for-byte before the next (verified).

**On this branch:**

| mutated arm | replacement | exit | tests that failed |
|---|---|---|---|
| `b'"'` | `out.push('"')` | 101 | `the_json_escaper_escapes_a_quotation_mark`, `an_operator_string_cannot_break_the_document_it_appears_in` |
| `b'\\'` | `out.push('\\')` | 101 | `the_json_escaper_escapes_a_backslash`, `an_operator_string_cannot_break_the_document_it_appears_in` |
| `b'\n'` | `"LITERAL-NEWLINE-BREAKS-JSON"` | 101 | **`the_json_escaper_escapes_a_newline` — and only that** |
| `b'\r'` | `"LITERAL-CR-BREAKS-JSON"` | 101 | **`the_json_escaper_escapes_a_carriage_return` — and only that** |
| `b'\t'` | `"LITERAL-TAB-BREAKS-JSON"` | 101 | **`the_json_escaper_escapes_a_tab` — and only that** |
| `\u{:04x}` fallback | `write!(out, "{}", char::from(other))` | 101 | **`the_json_escaper_escapes_every_byte_no_short_form_covers` — and only that** |
| `0x20..=0x7e` | `out.push('?')` | 101 | 7 tests (every case containing printable bytes — expected; this arm was never the uncovered one) |

**The same mutations on `origin/main`'s `caps.rs`, for contrast:**

| mutated arm | exit | tests that failed there |
|---|---|---|
| `b'"'` | 101 | `an_operator_string_cannot_break_the_document_it_appears_in` |
| `b'\\'` | 101 | `an_operator_string_cannot_break_the_document_it_appears_in` |
| `b'\n'` | 0 | **NONE** |
| `b'\r'` | 0 | **NONE** |
| `b'\t'` | 0 | **NONE** |
| `\u{:04x}` fallback | 0 | **NONE** |

Four arms that nothing could fail now each have a case that only they can fail.

## Baselines

Measured in this worktree, `-j 5` because the machine is shared:

| run | tree | command | result |
|---|---|---|---|
| before | `origin/main` (`b5b6eac`), `git status --porcelain` empty, run started before any edit | `cargo test --workspace --no-fail-fast` | **EXIT=0**, 1040 passed, 81 suites ok, 0 failed |
| mutant | `origin/main`'s `caps.rs` + the `\n` mutation | `cargo test --workspace --no-fail-fast` | **EXIT=0**, 1040 passed, 0 failed — the regression |
| after | this branch | `cargo test --workspace --no-fail-fast` | **EXIT=0**, 1048 passed, 81 suites ok, 0 failed |

`cargo fmt --check` → exit 0.
`cargo clippy --workspace --all-targets -- -D warnings` → exit 0, zero warnings.

Closes #662

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
