### PR TITLE
test(f2z-relay): hold §2.4's keepalive and §2.5's handshake deadline to account — and release the permit they were supposed to

### DIFF
--- a/rs/crates/f2z-relay-testkit/src/connection.rs
+++ b/rs/crates/f2z-relay-testkit/src/connection.rs
@@ -30,7 +30,7 @@ use tokio::sync::{mpsc, watch};
 
 use crate::engine::Relay;
 use crate::faults::{Effect, FaultInjector};
-use crate::outbound::{CLOSE_NORMAL, CLOSE_PROTOCOL_ERROR, OutKind, Outbound};
+use crate::outbound::{CLOSE_GOING_AWAY, CLOSE_NORMAL, CLOSE_PROTOCOL_ERROR, OutKind, Outbound};
 use crate::transport::{Transport, TransportSink, WireMessage};
 
 /// Serve one connection until either end closes.
@@ -65,7 +65,11 @@ pub async fn drive(relay: Arc<Relay>, transport: Transport) {
                 // would be a second mechanism only one of the two clients has.
                 missed_pongs = missed_pongs.saturating_add(1);
                 if missed_pongs > missed_pongs_before_close {
-                    let _ = outbound_tx.send(close_now(CLOSE_NORMAL));
+                    // 1001, "going away", the same status `f2z-relay` sends.
+                    // Issue #678: this said 1000 while production said 1001, and
+                    // nothing could notice, because the constant did not exist
+                    // in this crate.
+                    let _ = outbound_tx.send(close_now(CLOSE_GOING_AWAY));
                     break;
                 }
                 let _ = outbound_tx.send(Outbound::keepalive());
@@ -108,6 +112,15 @@ pub async fn drive(relay: Arc<Relay>, transport: Transport) {
     }
 
     relay.close_connection(&connection);
+    // Both senders, or the writer never ends. `Connection` carries its own
+    // clone of `outbound_tx` (`Connection::pushes`), so dropping only the local
+    // one leaves `outbound.recv()` with a live sender and it parks forever.
+    // `f2z-relay`'s loop had the identical shape and the identical bug, found
+    // by issue #678's tests: every path that ends in silence rather than in a
+    // close frame — §2.5's handshake deadline, a client hanging up, a transport
+    // error — leaked its writer task. Fixed in both, because this loop exists
+    // to be the same loop.
+    drop(connection);
     drop(outbound_tx);
     let _ = writer.await;
 }

--- a/rs/crates/f2z-relay-testkit/src/outbound.rs
+++ b/rs/crates/f2z-relay-testkit/src/outbound.rs
@@ -134,3 +134,30 @@ pub const CLOSE_UNSUPPORTED_DATA: u16 = 1003;
 
 /// RFC 6455 status 1000, "normal closure".
 pub const CLOSE_NORMAL: u16 = 1000;
+
+/// RFC 6455 status 1001, "going away": §2.4's keepalive giving up on a
+/// connection that stopped answering.
+///
+/// `WIRE.md` names no status for this, so neither value is non-conforming —
+/// but this crate is the second implementation the conformance vectors exist to
+/// hold in step with `f2z-relay`, and until issue #678 the constant was not
+/// defined here at all. A double that cannot express what production does is a
+/// gap in the double, not a difference of opinion, so it is pinned to
+/// `f2z_relay::transport::CLOSE_GOING_AWAY`'s value.
+pub const CLOSE_GOING_AWAY: u16 = 1001;
+
+#[cfg(test)]
+mod tests {
+    use super::{CLOSE_GOING_AWAY, CLOSE_NORMAL, CLOSE_PROTOCOL_ERROR, CLOSE_UNSUPPORTED_DATA};
+
+    // `f2z-relay`'s `transport.rs` pins the same four values in the same way.
+    // Two crates asserting the numbers separately is the point: neither can be
+    // renumbered without the other's test noticing.
+    #[test]
+    fn the_close_codes_are_the_ones_the_sections_name() {
+        assert_eq!(CLOSE_UNSUPPORTED_DATA, 1003);
+        assert_eq!(CLOSE_PROTOCOL_ERROR, 1002);
+        assert_eq!(CLOSE_NORMAL, 1000);
+        assert_eq!(CLOSE_GOING_AWAY, 1001);
+    }
+}

--- a/rs/crates/f2z-relay/src/connection.rs
+++ b/rs/crates/f2z-relay/src/connection.rs
@@ -26,6 +26,11 @@
 //!   client-driven, because the browser WebSocket API cannot send a Ping frame
 //!   at all — a client-side keepalive would be a second mechanism only one of
 //!   the two clients has.
+//!
+//! Both are the only mechanisms that **release** a §13.1 layer 1 connection
+//! permit, and until issue #678 both could be deleted with the whole suite
+//! green. `tests/connection_deadlines.rs` drives each one over a real socket
+//! and asserts the permit goes back.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -126,6 +131,20 @@ pub async fn drive(
     }
 
     relay.close_connection(&connection);
+    // Both senders, or the writer never ends. `Connection` carries its own
+    // clone of `outbound_tx` (`Connection::pushes`, which is what a subscription
+    // and a spawned `APPEND` are handed), so dropping only the local one leaves
+    // `outbound.recv()` with a live sender and it parks forever. The writer then
+    // never returns, `writer.await` never returns, `drive` never returns — and
+    // the §13.1 layer 1 permit the listener drops after `drive` is never
+    // released. That is invisible on every path that ends by *sending* a close
+    // (§1.3's fatal errors, §4.2's text frame, §2.4's keepalive close), because
+    // the frame itself wakes the writer; it is the whole story on every path
+    // that ends in silence — §2.5's handshake deadline, a client hanging up, a
+    // transport error. Dropping the connection here rather than at the end of
+    // scope also keeps §1.3's ordering: a task still answering an `APPEND` holds
+    // its own clone, so its response is written before the writer sees `None`.
+    drop(connection);
     drop(outbound_tx);
     let _ = writer.await;
 }

--- a/rs/crates/f2z-relay/tests/connection_deadlines.rs
+++ b/rs/crates/f2z-relay/tests/connection_deadlines.rs
@@ -1,0 +1,355 @@
+//! §2.4's keepalive and §2.5's handshake deadline, against a real socket.
+//!
+//! # Why this file exists
+//!
+//! `connection.rs` has a section headed "The two deadlines". Until this file
+//! existed, **both could be deleted outright and `cargo test -p f2z-relay -p
+//! f2z-relay-testkit` stayed green** (issue #678): replacing
+//! `if missed_pongs > missed_pongs_before_close` with `if false`, or
+//! `if waiting_for_hello` with `if false`, changed no verdict anywhere. Nothing
+//! in either crate named a Pong, a missed pong, or the handshake timeout.
+//!
+//! That is not a hygiene problem. §13.1 layer 1 caps concurrent connections per
+//! source and relay-wide, and a connection permit is the only structure an
+//! unauthenticated caller can make the relay allocate. These two deadlines are
+//! the only mechanisms that **release** one. A cap that is measured and tested,
+//! guarding a release path that is neither, is a cap with a hole in it.
+//!
+//! # Why the `PING` command is not this
+//!
+//! `f2z-relay-testkit`'s vector suite mentions `Ping` six times, and every one
+//! of them is §6.1's application-level `PING` **command** — a request frame with
+//! a response frame, which is what [`Client::ping`] sends. §2.4's keepalive is a
+//! WebSocket **control frame**, which a browser client cannot send at all, which
+//! is why the relay drives it. A grep for "ping" makes the keepalive look
+//! covered; it was not.
+//!
+//! # Why real sockets and real seconds
+//!
+//! `tokio::time::pause`/`advance` needs a `current_thread` runtime and a clock
+//! nothing else is waiting on. These tests drive a production [`Server`] — its
+//! own listener, commit thread and expiry tick — over loopback TCP, so a paused
+//! clock would stop the relay it is meant to observe. `ping_interval_seconds` is
+//! a `u16` of **seconds** with a floor of 1, so the shortest honest keepalive
+//! test is a few real seconds; `handshake_timeout_ms` is milliseconds and costs
+//! far less.
+//!
+//! # What a "client that does not answer" has to be
+//!
+//! `tokio-tungstenite` answers a Ping with a Pong from inside its own read path
+//! (`WebSocket::read` flushes `additional_send` before it parses), so a client
+//! that *reads* is a client that *pongs*, whatever the layer above it does. The
+//! only faithful unresponsive client is one that does not read, which is why
+//! [`an_unanswered_ping_closes_the_connection_going_away`] speaks `HELLO`
+//! through the raw transport rather than through [`Client`], sleeps past the
+//! deadline, and only then drains what the relay left on the wire.
+
+// An integration test is its own crate, so the workspace's denials of the
+// panicking families do not reach it through `lib.rs`'s `cfg_attr(test, ...)`.
+// They are relaxed here for the reason `rs/README.md` gives: a test that has to
+// thread a `Result` through every assertion is a test nobody reads, and a panic
+// in a test is a failing test rather than a remote denial of service.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::time::{Duration, Instant};
+
+use f2z_codec::PROTOCOL_VERSION;
+use f2z_codec::canonical::Canonical;
+use f2z_codec::commands::HelloRequest;
+use f2z_codec::types::Challenge;
+use f2z_relay::config::Config;
+use f2z_relay::server::Server;
+use f2z_relay::transport::{CLOSE_GOING_AWAY, CLOSE_NORMAL};
+use f2z_relay_proto::command::{ops, unsigned_request};
+use f2z_relay_testkit::client::{Client, ClientConfig};
+use f2z_relay_testkit::transport::{TransportSink, TransportStream, WireMessage};
+use f2z_relay_testkit::websocket;
+
+/// A relay on the conformance configuration, with one edit.
+///
+/// The same shape `configured_equivalents.rs` uses, and for the same reason: a
+/// deadline is published policy, so reaching it needs configuration rather than
+/// a fault handle compiled into the relay.
+async fn relay(edit: impl FnOnce(&mut Config)) -> Server {
+    let mut config = Config::default();
+    config.listen.address = "127.0.0.1:0".to_owned();
+    config.admin.enabled = false;
+    config.store.backend = "memory".to_owned();
+    config.identity.seed = "3c".repeat(32);
+    config.antiabuse.queue_creation_mode = "open".to_owned();
+    config.antiabuse.contact_append_pow_bits = 8;
+    config.antiabuse.per_source_limits = false;
+    config.commit.window_ms = 1;
+    config.queues.expiry_tick_seconds = 3_600;
+    edit(&mut config);
+    Server::start(config).await.expect("the relay starts")
+}
+
+/// A client on a fresh connection, with a nonce stream no other client shares.
+async fn client(server: &Server, stream: u8) -> Client {
+    let transport = websocket::connect(&server.url())
+        .await
+        .expect("the relay accepts a connection");
+    let config = ClientConfig {
+        // Its own nonce stream: §5.5's seen-set is relay-wide.
+        nonce_seed: [stream; 32],
+        ..ClientConfig::default()
+    };
+    Client::connect(transport, config)
+        .await
+        .expect("HELLO completes")
+}
+
+/// A connection that has completed §2.5's `HELLO` but is **not** a [`Client`].
+///
+/// The halves come back raw, so the caller decides when — or whether — to read.
+/// A [`Client`] cannot be unresponsive: every one of its paths reads, and both
+/// it and `tungstenite` beneath it answer a Ping with a Pong.
+async fn hello_only(
+    server: &Server,
+    nonce: u8,
+) -> (Box<dyn TransportSink>, Box<dyn TransportStream>) {
+    let transport = websocket::connect(&server.url())
+        .await
+        .expect("the relay accepts a connection");
+    let (mut sink, mut stream) = transport.split();
+    let offer = HelloRequest {
+        min_version: PROTOCOL_VERSION,
+        max_version: PROTOCOL_VERSION,
+        client_nonce: Challenge::new([nonce; 32]),
+    };
+    let frame = unsigned_request::<ops::Hello>(1, &offer).expect("HELLO encodes");
+    sink.send(WireMessage::Binary(
+        frame.encode_canonical().expect("the frame is canonical"),
+    ))
+    .await
+    .expect("the relay takes the HELLO");
+    // The response is not verified here — `Client::connect` is what proves
+    // §5.2, and this connection exists to be silent, not to be a client. It is
+    // read so that the wire is empty of everything but what §2.4 puts there.
+    match tokio::time::timeout(Duration::from_secs(5), stream.recv()).await {
+        Ok(Ok(Some(WireMessage::Binary(_)))) => {}
+        other => panic!("expected a HELLO response, got {other:?}"),
+    }
+    (sink, stream)
+}
+
+/// What the relay left on the wire, and when it stopped.
+#[derive(Debug)]
+struct Drained {
+    /// §2.4 Ping control frames seen.
+    pings: usize,
+    /// The RFC 6455 status the relay closed with, if it closed.
+    close: Option<u16>,
+    /// How long the drain took to reach that verdict.
+    elapsed: Duration,
+}
+
+/// Read control frames until the relay closes, or `within` elapses.
+///
+/// A relay that never closes is the failure this file exists to catch, so the
+/// bound is on the whole drain rather than on each read: pings arriving forever
+/// must not keep the loop alive forever.
+async fn drain_until_close(stream: &mut Box<dyn TransportStream>, within: Duration) -> Drained {
+    let started = Instant::now();
+    let deadline = tokio::time::Instant::now() + within;
+    let mut pings = 0usize;
+    loop {
+        let received = match tokio::time::timeout_at(deadline, stream.recv()).await {
+            Err(_) => {
+                return Drained {
+                    pings,
+                    close: None,
+                    elapsed: started.elapsed(),
+                };
+            }
+            Ok(received) => received,
+        };
+        match received {
+            Ok(Some(WireMessage::Ping(_))) => pings += 1,
+            Ok(Some(WireMessage::Close(code))) => {
+                return Drained {
+                    pings,
+                    close: Some(code),
+                    elapsed: started.elapsed(),
+                };
+            }
+            // An end of stream without a close frame is still a closed
+            // connection, and reported as one so the assertion can say which it
+            // was. `Ok(None)` is the peer going away; `Err` is the socket.
+            Ok(None) | Err(_) => {
+                return Drained {
+                    pings,
+                    close: None,
+                    elapsed: started.elapsed(),
+                };
+            }
+            Ok(Some(_)) => {}
+        }
+    }
+}
+
+/// Wait for §13.1 layer 1's relay-wide counter to reach `want`.
+///
+/// The permit is dropped by the listener *after* `connection::drive` returns,
+/// which is after the close frame is on the wire, so the client can observe the
+/// close a moment before the counter moves.
+async fn settled_connections(server: &Server, want: u64) -> u64 {
+    for _ in 0..200u32 {
+        let open = server.relay().abuse().open_connections();
+        if open == want {
+            return open;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    server.relay().abuse().open_connections()
+}
+
+// ---------------------------------------------------------------------------
+// §2.4 — the keepalive.
+// ---------------------------------------------------------------------------
+
+/// **The positive control.** Without it, the two closing tests below would pass
+/// against a relay that closed every connection the moment it opened.
+///
+/// A client that answers §2.4's Pings survives several ping intervals and is
+/// still able to command the relay afterwards.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_client_that_answers_pongs_is_never_closed_by_the_keepalive() {
+    let server = relay(|config| {
+        config.listen.ping_interval_seconds = 1;
+        config.listen.missed_pongs_before_close = 1;
+    })
+    .await;
+    let mut alice = client(&server, 0x60).await;
+
+    // Four ping intervals. Every `PING` command is a round trip, and a round
+    // trip reads, and a read answers the pending keepalive Ping — which is
+    // exactly what a real client does and the reason `missed_pongs` resets.
+    let until = Instant::now() + Duration::from_millis(4_200);
+    while Instant::now() < until {
+        alice
+            .ping()
+            .await
+            .expect("the relay answers a PING command");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    assert!(
+        !alice.is_closed(),
+        "a responsive client was closed by the keepalive"
+    );
+    alice
+        .ping()
+        .await
+        .expect("a responsive client is still connected after four ping intervals");
+    assert_eq!(
+        server.relay().abuse().open_connections(),
+        1,
+        "the connection permit was released while the client was still using it"
+    );
+    server.shutdown().await;
+}
+
+/// A client that never answers is closed after `missed_pongs_before_close`
+/// intervals, with the status production means to send — and its §13.1 layer 1
+/// permit goes back.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unanswered_ping_closes_the_connection_going_away() {
+    let server = relay(|config| {
+        config.listen.ping_interval_seconds = 1;
+        config.listen.missed_pongs_before_close = 1;
+    })
+    .await;
+    let (_sink, mut stream) = hello_only(&server, 0x61).await;
+
+    // One interval sends the Ping; the next finds it unanswered and closes. The
+    // sleep is what makes the client unresponsive: reading would pong.
+    tokio::time::sleep(Duration::from_millis(2_600)).await;
+
+    let drained = drain_until_close(&mut stream, Duration::from_secs(4)).await;
+    assert_eq!(
+        drained.close,
+        Some(CLOSE_GOING_AWAY),
+        "an unanswered Ping did not close the connection with 1001: {drained:?}"
+    );
+    assert_eq!(
+        drained.pings, 1,
+        "the relay closed without first sending §2.4's Ping: {drained:?}"
+    );
+    assert_eq!(
+        settled_connections(&server, 0).await,
+        0,
+        "the connection permit outlived the connection (§13.1 layer 1)"
+    );
+    server.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// §2.5 — the handshake deadline.
+// ---------------------------------------------------------------------------
+
+/// A connection that completes the WebSocket upgrade and then says nothing is
+/// closed at `handshake_timeout_ms`, and its permit is released.
+///
+/// This is the case that needs no credentials at all: the upgrade is free, and
+/// before this test the relay held the permit until the process restarted.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_connection_that_never_says_hello_is_closed_at_the_deadline() {
+    let server = relay(|config| config.listen.handshake_timeout_ms = 700).await;
+    let transport = websocket::connect(&server.url())
+        .await
+        .expect("the relay accepts a connection");
+    // The sink is held, not dropped: a client that hung up would be a different
+    // test, and would close the connection for a reason that is not the
+    // deadline.
+    let (_sink, mut stream) = transport.split();
+
+    let drained = drain_until_close(&mut stream, Duration::from_secs(6)).await;
+    assert_eq!(
+        drained.close,
+        Some(CLOSE_NORMAL),
+        "a silent connection was not closed at §2.5's deadline: {drained:?}"
+    );
+    assert!(
+        drained.elapsed >= Duration::from_millis(350),
+        "the connection was closed far too early to be the deadline: {drained:?}"
+    );
+    assert_eq!(
+        settled_connections(&server, 0).await,
+        0,
+        "an unauthenticated silent connection kept its permit (§13.1 layer 1)"
+    );
+    server.shutdown().await;
+}
+
+/// The other half of §2.5: the cap is on the time **to** `HELLO`, not a read
+/// deadline on the session. A subscribed client on a quiet queue legitimately
+/// sends nothing for hours.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_connection_that_says_hello_in_time_outlives_the_deadline() {
+    let server = relay(|config| config.listen.handshake_timeout_ms = 700).await;
+    let mut alice = client(&server, 0x62).await;
+
+    // Three times the deadline, silent. The default 25 s keepalive cannot reach
+    // in here, so the only thing that could close this connection is §2.5 being
+    // applied where it must not be.
+    tokio::time::sleep(Duration::from_millis(2_100)).await;
+
+    alice
+        .ping()
+        .await
+        .expect("a connection that said HELLO in time is not subject to the deadline");
+    assert_eq!(
+        server.relay().abuse().open_connections(),
+        1,
+        "the connection was released while it was still open"
+    );
+    server.shutdown().await;
+}


### PR DESCRIPTION
Closes #678.

## What the issue said, and what re-measuring found

The issue is correct on both counts, and understates one of them. Everything
below is a measurement I ran in this worktree; nothing is quoted from the issue.

### Baseline (re-measured on current `origin/main`, `fdc3280` — *not* the issue's `0e705d6`)

```
cd rs && cargo test -p f2z-relay -p f2z-relay-testkit
EXIT=0    219 passed, across 16 `test result: ok` suites
```

The issue's 200 was on `0e705d6`; 219 is the number on the commit this branch
is based on.

### Reproducing §2.4 — the keepalive close

```rust
 missed_pongs = missed_pongs.saturating_add(1);
-if missed_pongs > missed_pongs_before_close {
+if false {
```

```
cargo test -p f2z-relay -p f2z-relay-testkit
EXIT=0    219 passed, 16 ok suites
```

### Reproducing §2.5 — the handshake deadline

```rust
 let read = stream.recv();
-if waiting_for_hello {
+if false {
```

```
cargo test -p f2z-relay -p f2z-relay-testkit
EXIT=0    219 passed, 16 ok suites
```

Both mutations were reverted by inverse string replacement with an asserted
match count (a `python3` replace that `assert`s `count(old) == 1` before
writing), never by `git checkout --`. `git status --porcelain` was empty after
each revert.

## The part the issue did not know: §2.5's deadline released nothing at all

Writing the prescribed test made it fail on unmodified `main`. A connection that
completes the upgrade and says nothing gets **no close frame, no EOF, and keeps
its permit** — the deadline fires, breaks the read loop, and then the whole task
parks forever:

```
SILENT drain (handshake_timeout_ms = 400): timeout at 1.50s, no frame, no EOF
SILENT open_connections() after the deadline: 1
```

The cause is in `drive`'s tail. `Connection` carries its own clone of
`outbound_tx` (`Connection::pushes` — the sender a subscription and a spawned
`APPEND` are handed), and `connection` was dropped at end of scope, *after*
`writer.await`. So `outbound.recv()` still saw a live sender, returned `Pending`
forever, `writer_task` never returned, `drive` never returned, and
`listener.rs`'s `drop(permit)` after `drive(...).await` never ran.

This is invisible on every path that ends by *sending* a close — §1.3's fatal
errors, §4.2's text frame, §2.4's keepalive close — because the frame itself
wakes the writer. It is the whole story on every path that ends in silence. I
measured the client-hangup case too:

```
EOF open_connections() while open:                1
EOF open_connections() 500 ms after client hangup: 1
```

So it was not only the unauthenticated silent connection; **every normally
closed connection leaked its task and its permit until process restart.**

Fix, in `f2z-relay/src/connection.rs`:

```rust
 relay.close_connection(&connection);
+drop(connection);
 drop(outbound_tx);
 let _ = writer.await;
```

Dropping the connection *here* rather than at end of scope also preserves §1.3's
ordering: a task still answering an `APPEND` holds its own clone, so its
response is written before the writer sees `None`.

I treated this as in scope rather than as an adjacent defect, because it is the
exact claim the issue makes ("both mechanisms that *release* a connection are
unenforced") and because the issue's own prescribed test 3 cannot pass without
it.

## The tests

`rs/crates/f2z-relay/tests/connection_deadlines.rs` — a sibling of
`configured_equivalents.rs`, using the same `relay(|config| …)` /
`client(&server, stream)` idiom. Four tests, split so each mutation reddens
exactly one:

1. `a_client_that_answers_pongs_is_never_closed_by_the_keepalive` — **the
   positive control.** A client answering Pongs survives four ping intervals and
   still commands the relay afterwards. Without it the two closing tests would
   pass against a relay that closed everything immediately.
2. `an_unanswered_ping_closes_the_connection_going_away` — closed after
   `missed_pongs_before_close` intervals, with `CLOSE_GOING_AWAY` (1001), having
   sent exactly one Ping first, and the permit goes back to 0.
3. `a_connection_that_never_says_hello_is_closed_at_the_deadline` — closed at
   `handshake_timeout_ms` with `CLOSE_NORMAL` (1000), not before ~half the
   deadline, and the permit goes back to 0.
4. `a_connection_that_says_hello_in_time_outlives_the_deadline` — the other half
   of §2.5, and the second positive control: the cap is on the time *to* `HELLO`,
   not a read deadline on the session.

Tests 2 and 3 also assert `abuse().open_connections()` returns to 0. That is the
§13.1 layer 1 property the issue is actually about, and it is what caught the
bug above.

### Real sockets and real seconds, not `tokio::time` pause/advance

`pause`/`advance` needs a `current_thread` runtime and a clock nothing else is
waiting on. These tests drive a production `Server` — its own listener, commit
thread and expiry tick — over loopback TCP, so a paused clock would stop the
relay they exist to observe. `ping_interval_seconds` is a `u16` of **seconds**
with a floor of 1, so the shortest honest keepalive test is a few real seconds.
The suite runs in ~4.3 s. `handshake_timeout_ms` is milliseconds and costs far
less. **The testkit's own 500 ms `ping_interval` default is not reachable here**
— that is `f2z_relay_testkit::config`, and these tests configure the production
`f2z_relay::config::Config`, whose field is whole seconds.

### Why the unresponsive client does not use `Client`

`tokio-tungstenite` answers a Ping with a Pong from inside its own read path
(`WebSocket::read` flushes `additional_send` before it parses a frame), so *any*
client that reads is a client that pongs, whatever the layer above it does. Test
2 therefore speaks `HELLO` through the raw transport (`websocket::connect` +
`unsigned_request::<ops::Hello>`), sleeps past the deadline without reading, and
only then drains what the relay left on the wire.

## Falsification — each mutation, and the counts

Full `cargo test -p f2z-relay -p f2z-relay-testkit --no-fail-fast` for each.

| mutation | EXIT | red test(s) | ok suites | passed in ok suites | failed suite |
|---|---|---|---|---|---|
| **none** (this branch) | **0** | — | **17** | **224** | — |
| §2.4 `if missed_pongs > … ` → `if false` | **101** | `an_unanswered_ping_closes_the_connection_going_away` **only** | 16 | 220 | `connection_deadlines`: 3 passed, 1 failed |
| §2.5 `if waiting_for_hello` → `if false` | **101** | `a_connection_that_never_says_hello_is_closed_at_the_deadline` **only** | 16 | 220 | `connection_deadlines`: 3 passed, 1 failed |
| the fix itself: remove `drop(connection)` | **101** | `a_connection_that_never_says_hello_is_closed_at_the_deadline` **only** | 16 | 220 | `connection_deadlines`: 3 passed, 1 failed |

Exactly the orthogonality asked for: the keepalive mutation reddens the
keepalive test and **not** the handshake test, and vice versa. Both positive
controls stay green under both mutations, which is what makes them controls.

The failure messages, verbatim:

```
§2.4:  assertion `left == right` failed: an unanswered Ping did not close the
       connection with 1001: Drained { pings: 6, close: None, elapsed: 4.002807167s }
         left: None
        right: Some(1001)

§2.5:  assertion `left == right` failed: a silent connection was not closed at
       §2.5's deadline: Drained { pings: 0, close: None, elapsed: 6.001761541s }
         left: None
        right: Some(1000)
```

Under §2.4's mutation the relay pings six times over four seconds and never
closes, which is the leak stated as a number.

One disclosure about how that §2.4 row was obtained. My first §2.4 run asserted
the ping count before the close status, so it failed on the *ping* assertion
(`pings: 6, right: 1`) rather than on the close. I reordered the assertions so
the close is checked first — a closer relay is the point, the ping count is the
corroboration — and **re-ran the §2.4 mutation from scratch**. The message and
counts in the table and above are from that re-run, not from the earlier one.

All three mutations were reverted by asserted inverse replacement,
`git status --porcelain` confirmed empty, and the suite re-confirmed green:

```
cargo test -p f2z-relay -p f2z-relay-testkit
EXIT=0    224 passed, 17 ok suites
```

## Closing the testkit gap

Per the issue's table, and stated plainly: **`WIRE.md` names no close code for
either case, so neither implementation was non-conforming.** This closes a gap in
the double, it does not fix a conformance violation. Nothing in
`f2z-relay-testkit/src/vectors.rs` asserts a keepalive close code, so no
conformance vector had to be weakened — the whole vector suite is still green
under both the pipe and the `ws://` listener.

- `f2z-relay-testkit/src/outbound.rs`: defines `CLOSE_GOING_AWAY = 1001`, which
  the crate did not have at all, plus a unit test pinning all four codes the way
  `f2z-relay/src/transport.rs` pins its own. Two crates asserting the numbers
  separately is the point: neither can be renumbered without the other noticing.
- `f2z-relay-testkit/src/connection.rs`: keepalive-failure close 1000 → 1001.
- `f2z-relay-testkit/src/connection.rs`: the same `drop(connection)` fix. The
  testkit's loop had the identical shape and the identical latent hang.

### One correction to the issue's table

The "shutdown" row reads `Outbound::close(CLOSE_GOING_AWAY)` vs `break`, no
close frame. Those are not the same arm. Production has **two** watch channels:
`closed_rx` (the writer telling the reader it has already closed — `break`, no
frame, correctly) and `shutdown` (the server going away — sends
`Outbound::close(CLOSE_GOING_AWAY)`). The testkit's single `shutdown_rx` is the
*former*: `writer_task` signals it after `sink.close(...)`. The testkit has **no
server-shutdown path at all** — `RelayServer::shutdown` only stops the accept
loop and documents that open connections are not torn down. So there is nothing
to align on that row without adding a shutdown channel to `drive`, changing its
signature and both its callers. I did not do that; it is a real difference, but
a design one rather than drift, and out of scope here.

## Verification

Run from `rs/`.

```
cargo fmt --check                                  EXIT=0
cargo clippy --workspace --all-targets -- -D warnings   EXIT=0
cargo test -p f2z-relay -p f2z-relay-testkit       EXIT=0   224 passed, 17 ok suites
cargo test --workspace --no-fail-fast              EXIT=0   1078 passed,
                                                            85 `test result: ok` suites,
                                                            0 FAILED suites
```

224 = the 219 baseline + 4 new integration tests + 1 new testkit unit test.
17 suites = 16 + the new `connection_deadlines` test binary.

## Scope

`rs/` only — four files, three modified and one added. Nothing under `wallet/`,
`.github/workflows/zuuli*` or `z/` is touched, so the release audit anchor is
intact. Nothing in the issue's "Reviewed in the same pass, no findings" section
was changed.

## Honest caveats

- The keepalive tests spend real seconds because production's ping interval is
  configured in whole seconds with a floor of 1. `connection_deadlines` runs in
  ~4.3 s; it is the slowest test binary in `f2z-relay` after `conformance`.
- Test 3 asserts `elapsed >= 350 ms` against a 700 ms deadline rather than a
  tight window, and test 4 sleeps 3× a 700 ms deadline. Both are one-sided on
  purpose: a loaded CI box can be late, and a late close still proves the
  deadline exists, whereas an early one would not.
- The `open_connections()` assertions in tests 2 and 3 poll (up to 4 s) rather
  than reading once, because the listener drops the permit after `drive`
  returns, which is after the close frame is already on the wire.
- I did not add a testkit-side test for the keepalive close code itself; the
  testkit's `drive` has no server-shutdown handle and its `FakeRelay` clock is
  the same real clock, so such a test would cost the same real seconds for a
  second copy of the same assertion. The constant is pinned by a unit test in
  both crates instead.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
