### PR TITLE
kt: make three unexercised security checks fail when deleted (#692, #708, #746)

### DIFF
--- a/rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs
+++ b/rs/crates/f2z-codec/tests/workspace_strict_verification_scan.rs
@@ -454,6 +454,19 @@ const WORKSPACE_VERIFY_FNS: &[VerifyFn] = &[
             call: "sig::verify",
         },
     },
+    // §7.2's evidence document, and the check a third party runs on it. Its
+    // `verified()` call is what re-establishes both enclosed signatures, so the
+    // chain to `verify_strict` runs through `WitnessCosignature::verify`.
+    VerifyFn {
+        file: "f2z-kt-core/src/cosign.rs",
+        name: "verify_evidence",
+        occurrence: 0,
+        strictness: Strictness::DelegatesTo {
+            target: "f2z-kt-core/src/cosign.rs::verify",
+            receiver: "first",
+            method: "verified",
+        },
+    },
     VerifyFn {
         file: "f2z-kt-core/src/descriptor.rs",
         name: "verify",

--- a/rs/crates/f2z-kt-client/src/client.rs
+++ b/rs/crates/f2z-kt-client/src/client.rs
@@ -45,7 +45,6 @@ use f2z_kt_core::entry::EntryKind;
 use f2z_kt_core::sth::{LogView, SignedTreeHead};
 use f2z_kt_core::submit::{LogPolicy, PublishedEntry, SubmissionContext};
 use f2z_kt_core::types::{Handle, LogId};
-use f2z_kt_core::verify::HistoryVerificationParams;
 use f2z_kt_core::{AcceptedRoot, KtError, WitnessSet, verify, verify_threshold};
 
 use crate::alarm::{AlarmKind, AlarmLog, RaiseAlarm};
@@ -398,22 +397,19 @@ impl<T: Transport> KtClient<T> {
             Ok(root) => {
                 let standing = WitnessStanding::of(&root, &self.config.witnesses);
                 let epoch = root.epoch();
+                // `wire::history_request` asks for the **complete** history and
+                // `verify_key_history` verifies one — §8.2's `Complete` is
+                // fixed inside it rather than passed, so this call cannot ask
+                // for a weaker proof. The pin is deliberately not handed over
+                // as a predecessor: a complete history begins at version 1, and
+                // the pin is checked separately below and more strictly than a
+                // predecessor argument would have — the entry at the pinned
+                // version must be byte-for-byte the one that was pinned.
                 let verified = verify::verify_key_history(
                     &root,
                     handle,
                     &entry_bytes,
                     response.proof.as_slice(),
-                    // `None`, and NOT the pin: `wire::history_request` asks for
-                    // the **complete** history, so the run begins at version 1
-                    // and `f2z-kt-core` requires that. Handing it the pin as a
-                    // predecessor would demand that every entry shown come
-                    // *after* the pin, which is the opposite of what a complete
-                    // history is. The pin is checked separately, below, and it
-                    // is checked more strictly than passing it here would have:
-                    // the entry at the pinned version must be byte-for-byte the
-                    // one that was pinned.
-                    None,
-                    HistoryVerificationParams::default(),
                 )
                 .map_err(|error| self.on_protocol_error(error, now_ms))?;
                 let entries = verified
@@ -536,16 +532,8 @@ impl<T: Transport> KtClient<T> {
             .iter()
             .map(f2z_codec::types::Payload::as_slice)
             .collect();
-        let verified = verify::verify_key_history(
-            &root,
-            handle,
-            &entry_bytes,
-            response.proof.as_slice(),
-            // `None` for the same reason `self_audit` passes `None`: this asks
-            // for the complete history, which starts at version 1.
-            None,
-            HistoryVerificationParams::default(),
-        )
+        let verified =
+            verify::verify_key_history(&root, handle, &entry_bytes, response.proof.as_slice())
         .map_err(|error| self.on_protocol_error(error, now_ms))?;
         let entries: Vec<_> = verified
             .iter()

--- a/rs/crates/f2z-kt-client/src/client.rs
+++ b/rs/crates/f2z-kt-client/src/client.rs
@@ -534,7 +534,7 @@ impl<T: Transport> KtClient<T> {
             .collect();
         let verified =
             verify::verify_key_history(&root, handle, &entry_bytes, response.proof.as_slice())
-        .map_err(|error| self.on_protocol_error(error, now_ms))?;
+                .map_err(|error| self.on_protocol_error(error, now_ms))?;
         let entries: Vec<_> = verified
             .iter()
             .map(|entry| entry.entry().clone())

--- a/rs/crates/f2z-kt-client/tests/acceptance.rs
+++ b/rs/crates/f2z-kt-client/tests/acceptance.rs
@@ -57,7 +57,7 @@ use f2z_kt_client::{
 };
 use f2z_kt_core::entry::{DirectoryEntry, EntryKind};
 use f2z_kt_core::types::Handle;
-use f2z_kt_core::{ConfiguredWitness, WitnessSet, labels};
+use f2z_kt_core::{ConfiguredWitness, KtError, WitnessSet, labels};
 use f2z_witness::witness::{Outcome, Settings, Witness};
 
 const NOW: u64 = 1_700_000_100_000;
@@ -88,6 +88,11 @@ struct DirectTransport {
     entry_override: Mutex<Option<Vec<u8>>>,
     drop_cosignatures: Mutex<bool>,
     claim_absent: Mutex<bool>,
+    /// Serve a history with the entry at this index removed — the **truthful
+    /// subset** of `KT.md` §8.2. Everything still served is real.
+    omit_history_entry: Mutex<Option<usize>>,
+    /// Serve these bytes in place of the history entry at this index.
+    swap_history_entry: Mutex<Option<(usize, Vec<u8>)>>,
 }
 
 impl DirectTransport {
@@ -103,7 +108,21 @@ impl DirectTransport {
             entry_override: Mutex::new(None),
             drop_cosignatures: Mutex::new(false),
             claim_absent: Mutex::new(false),
+            omit_history_entry: Mutex::new(None),
+            swap_history_entry: Mutex::new(None),
         }
+    }
+
+    /// Drop one entry from every history response — the omission §8.2 step 4
+    /// exists to catch. The index is into the response's own order, which is
+    /// `akd`'s decreasing version order.
+    fn omit_history_entry(&self, index: Option<usize>) {
+        *self.omit_history_entry.lock().unwrap() = index;
+    }
+
+    /// Serve `bytes` in place of the history entry at `index`.
+    fn swap_history_entry(&self, swap: Option<(usize, Vec<u8>)>) {
+        *self.swap_history_entry.lock().unwrap() = swap;
     }
 
     fn tamper_next_proof(&self) {
@@ -198,6 +217,16 @@ impl Transport for DirectTransport {
         if *self.drop_cosignatures.lock().unwrap() {
             response.bundle =
                 f2z_kt_core::api::TreeHeadBundle::new(response.bundle.head, Vec::new()).unwrap();
+        }
+        if let Some((index, bytes)) = self.swap_history_entry.lock().unwrap().as_ref() {
+            let mut entries = response.entries.as_slice().to_vec();
+            entries[*index] = f2z_codec::types::Payload::new(bytes.clone()).unwrap();
+            response.entries = f2z_codec::vec::VecU24::new(entries);
+        }
+        if let Some(index) = *self.omit_history_entry.lock().unwrap() {
+            let mut entries = response.entries.as_slice().to_vec();
+            entries.remove(index);
+            response.entries = f2z_codec::vec::VecU24::new(entries);
         }
         Ok(response.encode_canonical().unwrap())
     }
@@ -347,7 +376,13 @@ impl Deployment {
     /// without the old key, and what a user who rotates legitimately does. From
     /// the victim's client the two are indistinguishable, which is precisely
     /// why §8.2 requires the alarm rather than a silent update.
-    fn rotate(&self, handle: &str, old_seed: u8, new_seed: u8, previous: &DirectoryEntry) {
+    fn rotate(
+        &self,
+        handle: &str,
+        old_seed: u8,
+        new_seed: u8,
+        previous: &DirectoryEntry,
+    ) -> DirectoryEntry {
         let old = Identity::from_byte(old_seed);
         let new = Identity::from_byte(new_seed);
         let prev_hash = labels::prev_entry_hash(&previous.encode_canonical().unwrap());
@@ -368,6 +403,7 @@ impl Deployment {
                 .unwrap();
             self.harness.log.publish_epoch(NOW).await.unwrap();
         });
+        entry
     }
 
     /// Bring the witness up to the log's head, so the client has a cosigned
@@ -833,6 +869,140 @@ fn self_audit_continues_and_reports_under_an_unwitnessed_root() {
         report.alarms()[0].kind(),
         AlarmKind::SelfAuditUnexpectedEntry
     );
+}
+
+// ---------------------------------------------------------------------------
+// 6b. §8.2 step 4 — the truthful subset, and the chain that catches it.
+//
+// zuu#708. `key_history_verify` proves the versions it was shown are in the
+// tree; it does not prove the client was shown **all** of them, and it does not
+// look at `prev_entry_hash` at all. Step 4 is the only thing that does, and
+// under §8.3's self-audit row — *continues, and reports* — it is the only check
+// the client has left.
+// ---------------------------------------------------------------------------
+
+/// A history with one version omitted is refused, not audited.
+///
+/// The log serves nothing false here. Every entry it returns is real, signed
+/// and published; it simply does not return one of them. That is the whole
+/// truthful-subset attack: omit the entry that added the attacker's device and
+/// the entry that removed it, and what remains is a history in which nothing is
+/// wrong.
+#[test]
+fn a_history_with_a_version_omitted_is_refused_under_an_unwitnessed_root() {
+    let mut deployment = Deployment::new("client-history-omission");
+    deployment.cosign(NOW);
+    let first = deployment.register("alice", 1);
+    let second = deployment.rotate("alice", 1, 9, &first);
+    let third = deployment.rotate("alice", 9, 10, &second);
+    deployment.cosign(NOW + 1);
+
+    let submitted: Vec<Digest> = [&first, &second, &third]
+        .iter()
+        .map(|entry| labels::prev_entry_hash(&entry.encode_canonical().unwrap()))
+        .collect();
+
+    let mut client = deployment.client(1);
+    // §8.3's table: the threshold is unmet, so self-audit is reduced to step 4
+    // alone. `key_history_verify` does not run, which is exactly the state this
+    // check has to hold up in.
+    deployment.transport.withhold_cosignatures(true);
+
+    // The positive control, first: three versions, chain intact, nothing
+    // unexpected. Without it the refusal below would prove only that this
+    // deployment refuses everything.
+    let clean = client
+        .self_audit(&handle("alice"), &submitted, NOW + 2)
+        .unwrap();
+    assert!(!clean.root_witnessed());
+    assert!(clean.chain_intact());
+    assert_eq!(clean.versions_seen(), 3);
+    assert_eq!(clean.unexpected().len(), 0);
+
+    // Now the log drops the middle version from the response. Index 1 in
+    // `akd`'s decreasing order is version 2.
+    deployment.transport.omit_history_entry(Some(1));
+    assert_eq!(
+        client
+            .self_audit(&handle("alice"), &submitted, NOW + 3)
+            .unwrap_err(),
+        ClientError::Protocol(KtError::HistoryIncomplete),
+        "a version omitted from a history response is a truthful subset, and \
+         the entry_version sequence is what makes it visible",
+    );
+}
+
+/// A history whose `prev_entry_hash` chain does not link is refused — and the
+/// version sequence alone would not have noticed.
+///
+/// This is the half of step 4 that nothing else in the system covers.
+/// `key_history_verify` proves inclusion and, under `HistoryParams::Complete`,
+/// version contiguity; **it never reads `prev_entry_hash`.** A log that answers
+/// with contiguous versions whose contents do not chain has substituted one of
+/// them, and only the hash walk says so.
+#[test]
+fn a_history_whose_prev_entry_hash_chain_does_not_link_is_refused() {
+    let mut deployment = Deployment::new("client-history-chainbreak");
+    deployment.cosign(NOW);
+    let first = deployment.register("alice", 1);
+    let second = deployment.rotate("alice", 1, 9, &first);
+    let third = deployment.rotate("alice", 9, 10, &second);
+    deployment.cosign(NOW + 1);
+
+    let submitted: Vec<Digest> = [&first, &second, &third]
+        .iter()
+        .map(|entry| labels::prev_entry_hash(&entry.encode_canonical().unwrap()))
+        .collect();
+
+    // A substituted version 2. Well-formed in every way a decoder can see: the
+    // right log, the right handle, version 2, a non-zero `prev_entry_hash` (§4.2
+    // requires exactly that of a non-genesis entry), a valid self-signature. The
+    // only thing wrong with it is that its predecessor hash is not version 1's.
+    let impostor = Identity::from_byte(0x71);
+    let substituted = EntryBuilder::first(deployment.harness.log_id, "alice", &impostor)
+        .version(2)
+        .prev_entry_hash(Digest::new([0x5a; 32]))
+        .device(0x72, &impostor.isk)
+        .endpoint(0x73)
+        .same_key(&impostor.dak);
+    let substituted = substituted.encode_canonical().unwrap();
+
+    let mut client = deployment.client(1);
+    deployment
+        .transport
+        .swap_history_entry(Some((1, substituted.clone())));
+
+    // Under a **witnessed** root the substitution never reaches step 4: the
+    // value the proof commits to is recomputed from the served bytes, so these
+    // bytes are not the ones the tree holds. Asserted so the test below cannot
+    // be mistaken for the only thing standing here.
+    assert_eq!(
+        client
+            .self_audit(&handle("alice"), &submitted, NOW + 2)
+            .unwrap_err(),
+        ClientError::Protocol(KtError::ValueMismatch),
+    );
+
+    // Under an unwitnessed root there is no proof and no commitment to compare
+    // against. §8.3 says the client keeps auditing anyway, and step 4 is what it
+    // has: contiguous versions, a chain that does not link.
+    deployment.transport.withhold_cosignatures(true);
+    assert_eq!(
+        client
+            .self_audit(&handle("alice"), &submitted, NOW + 3)
+            .unwrap_err(),
+        ClientError::Protocol(KtError::HistoryIncomplete),
+        "version contiguity holds here; only the prev_entry_hash walk catches it",
+    );
+
+    // And the control on the same client and the same log: served honestly, the
+    // very same audit passes.
+    deployment.transport.swap_history_entry(None);
+    let clean = client
+        .self_audit(&handle("alice"), &submitted, NOW + 4)
+        .unwrap();
+    assert!(clean.chain_intact());
+    assert_eq!(clean.versions_seen(), 3);
 }
 
 // ---------------------------------------------------------------------------

--- a/rs/crates/f2z-kt-client/tests/acceptance.rs
+++ b/rs/crates/f2z-kt-client/tests/acceptance.rs
@@ -34,6 +34,9 @@
 //! | a key change the user did not initiate raises the alarm | §8.2 step 5 |
 //! | a pinned handle asserted absent fails closed and alarms | §8.1's correction |
 //! | self-audit continues, and reports, under an unwitnessed root | §8.3's table |
+//! | a history with a version omitted is refused | §8.2 step 4 |
+//! | a history whose `prev_entry_hash` chain does not link is refused | §8.2 step 4 |
+//! | a history that chains by hash and renumbers a version is refused | §8.2 step 4 |
 
 // Test code, run on the host by a person reading the failure. The workspace
 // denies these because a panic in a parser is a remote denial of service, and
@@ -1003,6 +1006,55 @@ fn a_history_whose_prev_entry_hash_chain_does_not_link_is_refused() {
         .unwrap();
     assert!(clean.chain_intact());
     assert_eq!(clean.versions_seen(), 3);
+}
+
+/// A history that chains by hash and skips a version is refused.
+///
+/// §8.2 step 4 is two checks — *"an unbroken `entry_version` sequence **and** an
+/// unbroken `prev_entry_hash` chain"* — and this is the one case only the first
+/// catches: the served entry really does chain to version 1, and calls itself
+/// version 5. Without it the version half could be deleted and the hash half
+/// would cover every other case in this file.
+#[test]
+fn a_history_that_chains_by_hash_but_renumbers_a_version_is_refused() {
+    let mut deployment = Deployment::new("client-history-versionjump");
+    deployment.cosign(NOW);
+    let first = deployment.register("alice", 1);
+    let second = deployment.rotate("alice", 1, 9, &first);
+    deployment.cosign(NOW + 1);
+
+    let submitted: Vec<Digest> = [&first, &second]
+        .iter()
+        .map(|entry| labels::prev_entry_hash(&entry.encode_canonical().unwrap()))
+        .collect();
+
+    let impostor = Identity::from_byte(0x74);
+    let renumbered = EntryBuilder::first(deployment.harness.log_id, "alice", &impostor)
+        .version(5)
+        .prev_entry_hash(labels::prev_entry_hash(&first.encode_canonical().unwrap()))
+        .device(0x75, &impostor.isk)
+        .endpoint(0x76)
+        .same_key(&impostor.dak);
+
+    let mut client = deployment.client(1);
+    deployment.transport.withhold_cosignatures(true);
+    deployment
+        .transport
+        .swap_history_entry(Some((0, renumbered.encode_canonical().unwrap())));
+
+    assert_eq!(
+        client
+            .self_audit(&handle("alice"), &submitted, NOW + 2)
+            .unwrap_err(),
+        ClientError::Protocol(KtError::HistoryIncomplete),
+        "the prev_entry_hash walk is satisfied here; the version sequence is not",
+    );
+
+    deployment.transport.swap_history_entry(None);
+    let clean = client
+        .self_audit(&handle("alice"), &submitted, NOW + 3)
+        .unwrap();
+    assert_eq!(clean.versions_seen(), 2);
 }
 
 // ---------------------------------------------------------------------------

--- a/rs/crates/f2z-kt-core/src/cosign.rs
+++ b/rs/crates/f2z-kt-core/src/cosign.rs
@@ -226,6 +226,103 @@ impl VerifiedCosignature {
     }
 }
 
+/// **The evidence** two contradicting cosignatures make (§7.2).
+///
+/// §7.2's claim is that a witness's self-contradiction is *non-repudiable*:
+/// *"No third document is needed to establish it: the two cosignatures and the
+/// witness's own public key are the whole proof."* A check whose only output is
+/// a rejection throws that away — the pair is exactly the artifact that makes
+/// the property useful, and it has to be able to leave the process.
+///
+/// So this is the pair, verbatim, in a form anyone can carry and check.
+///
+/// # It cannot be built around the check
+///
+/// [`WitnessEquivocation::new`] takes two [`VerifiedCosignature`]s — neither
+/// constructible without a passing signature check — and refuses unless
+/// [`VerifiedCosignature::contradicts`] holds. There is no other constructor and
+/// no `From`, so holding one *is* the claim, in the same shape as
+/// [`crate::witness::AcceptedRoot`] and [`crate::submit::AcceptedSubmission`].
+///
+/// # It is not a [`crate::witness::FaultReport`]
+///
+/// §7.3's report is a **witness accusing a log**, and its `log_id` field is
+/// named "the log accused". This is the opposite direction and needs no
+/// accuser: the two enclosed cosignatures are self-authenticating under a key
+/// they both name, so there is nothing for a third party to take on trust and
+/// nothing for the finder to sign. Putting it in §7.3's enum would have said
+/// the log is at fault.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct WitnessEquivocation {
+    /// The statement the witness made first.
+    pub a: WitnessCosignature,
+    /// The statement that contradicts it.
+    pub b: WitnessCosignature,
+}
+
+impl WitnessEquivocation {
+    /// Pair two verified cosignatures that contradict each other.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::BadAuthorization`] if they do not contradict — different
+    /// witnesses, different logs, different epochs, or the same
+    /// `(tree_size, root_hash)`. Refusing rather than storing an
+    /// unsubstantiated pair is the point: this type is an accusation, and an
+    /// accusation that does not hold on its own bytes is worse than none.
+    pub fn new(a: &VerifiedCosignature, b: &VerifiedCosignature) -> Result<Self, KtError> {
+        if !a.contradicts(b) {
+            return Err(KtError::BadAuthorization);
+        }
+        Ok(Self {
+            a: a.as_cosignature().clone(),
+            b: b.as_cosignature().clone(),
+        })
+    }
+
+    /// The witness both statements name — the party this is evidence against.
+    #[must_use]
+    pub const fn witness_pk(&self) -> &PublicKey {
+        &self.a.statement.witness_pk
+    }
+
+    /// The log both statements are about. Evidence against the **witness**, not
+    /// against this log.
+    #[must_use]
+    pub const fn log_id(&self) -> &LogId {
+        &self.a.statement.log_id
+    }
+
+    /// The epoch the two statements disagree about.
+    #[must_use]
+    pub const fn epoch(&self) -> u64 {
+        self.a.statement.epoch
+    }
+
+    /// **Re-establish the whole claim from these bytes alone.**
+    ///
+    /// What a third party runs. It verifies both signatures under the
+    /// `witness_pk` inside each — which is why it needs no key parameter and no
+    /// other document — and re-checks the contradiction. A decoded
+    /// [`WitnessEquivocation`] has not been through
+    /// [`WitnessEquivocation::new`], so this is not redundant with it: bytes off
+    /// a wire are a document anyone can author.
+    ///
+    /// # Errors
+    ///
+    /// [`KtError::WrongLabel`], [`KtError::UnsupportedVersion`] or
+    /// [`KtError::BadSignature`] if either cosignature does not verify, and
+    /// [`KtError::BadAuthorization`] if the two do not contradict.
+    pub fn verify(&self) -> Result<(), KtError> {
+        let a = self.a.clone().verified()?;
+        let b = self.b.clone().verified()?;
+        if !a.contradicts(&b) {
+            return Err(KtError::BadAuthorization);
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -380,6 +477,79 @@ mod tests {
         assert!(
             !a.contradicts(&b),
             "observed_at_ms is excluded from the test on purpose",
+        );
+    }
+
+    /// The evidence survives being written down and read back by someone who
+    /// was not there.
+    #[test]
+    fn the_evidence_pair_re_establishes_itself_from_its_own_bytes() {
+        let log = TestLog::new();
+        let head = log.head(4);
+        let mut forked = head.clone();
+        forked.sth.root_hash = Digest::new([0xaa; 32]);
+        let forked = log.resign(forked);
+
+        let a = log.cosign(&head, 1, 1_700_000_000_000).verified().unwrap();
+        let b = log
+            .cosign(&forked, 1, 1_700_000_100_000)
+            .verified()
+            .unwrap();
+
+        let evidence = WitnessEquivocation::new(&a, &b).expect("they contradict");
+        assert_eq!(evidence.witness_pk(), &log.witness_pk(1));
+        assert_eq!(evidence.log_id(), &head.sth.log_id);
+        assert_eq!(evidence.epoch(), 4);
+        assert_eq!(evidence.verify(), Ok(()));
+
+        // Serialized, handed to a stranger, checked with nothing but these
+        // bytes. That is what §7.2 means by non-repudiable.
+        let bytes = evidence.encode_canonical().unwrap();
+        let decoded = decode_canonical::<WitnessEquivocation>(&bytes)
+            .unwrap()
+            .into_value();
+        assert_eq!(decoded, evidence);
+        assert_eq!(decoded.verify(), Ok(()));
+    }
+
+    /// A forged pair cannot be built, and cannot be checked if someone encodes
+    /// one by hand.
+    #[test]
+    fn an_accusation_cannot_be_assembled_from_bytes_the_witness_never_signed() {
+        let log = TestLog::new();
+        let head = log.head(4);
+        let genuine = log.cosign(&head, 1, 1_700_000_000_000).verified().unwrap();
+
+        // The two that do not contradict: the same statement twice.
+        assert_eq!(
+            WitnessEquivocation::new(&genuine, &genuine).err(),
+            Some(KtError::BadAuthorization),
+            "an accusation that does not hold on its own bytes is worse than none",
+        );
+
+        // And two different witnesses, which is the log's problem and not
+        // either witness's.
+        let mut forked = head.clone();
+        forked.sth.root_hash = Digest::new([0xbb; 32]);
+        let forked = log.resign(forked);
+        let other = log.cosign(&forked, 2, 1).verified().unwrap();
+        assert_eq!(
+            WitnessEquivocation::new(&genuine, &other).err(),
+            Some(KtError::BadAuthorization),
+        );
+
+        // The constructor is not the only door: bytes off a wire have not been
+        // through it. `verify` re-establishes both signatures.
+        let mut forged = genuine.as_cosignature().clone();
+        forged.statement.root_hash = Digest::new([0xcc; 32]);
+        let fabricated = WitnessEquivocation {
+            a: genuine.as_cosignature().clone(),
+            b: forged,
+        };
+        assert_eq!(
+            fabricated.verify(),
+            Err(KtError::BadSignature),
+            "the second half was authored by the accuser, not the witness",
         );
     }
 

--- a/rs/crates/f2z-kt-core/src/cosign.rs
+++ b/rs/crates/f2z-kt-core/src/cosign.rs
@@ -313,10 +313,18 @@ impl WitnessEquivocation {
     /// [`KtError::WrongLabel`], [`KtError::UnsupportedVersion`] or
     /// [`KtError::BadSignature`] if either cosignature does not verify, and
     /// [`KtError::BadAuthorization`] if the two do not contradict.
-    pub fn verify(&self) -> Result<(), KtError> {
-        let a = self.a.clone().verified()?;
-        let b = self.b.clone().verified()?;
-        if !a.contradicts(&b) {
+    pub fn verify_evidence(&self) -> Result<(), KtError> {
+        // Named `verify_evidence` rather than `verify` so that
+        // `f2z-codec`'s workspace strict-verification scan can still name
+        // `cosign.rs::verify` unambiguously as this one's delegation target: a
+        // second `fn verify` in this file would make every row pointing at the
+        // first one resolve to two definitions, and the scan refuses ambiguity
+        // rather than picking one.
+        let first = self.a.clone();
+        let second = self.b.clone();
+        let first = first.verified()?;
+        let second = second.verified()?;
+        if !first.contradicts(&second) {
             return Err(KtError::BadAuthorization);
         }
         Ok(())
@@ -500,7 +508,7 @@ mod tests {
         assert_eq!(evidence.witness_pk(), &log.witness_pk(1));
         assert_eq!(evidence.log_id(), &head.sth.log_id);
         assert_eq!(evidence.epoch(), 4);
-        assert_eq!(evidence.verify(), Ok(()));
+        assert_eq!(evidence.verify_evidence(), Ok(()));
 
         // Serialized, handed to a stranger, checked with nothing but these
         // bytes. That is what §7.2 means by non-repudiable.
@@ -509,7 +517,7 @@ mod tests {
             .unwrap()
             .into_value();
         assert_eq!(decoded, evidence);
-        assert_eq!(decoded.verify(), Ok(()));
+        assert_eq!(decoded.verify_evidence(), Ok(()));
     }
 
     /// A forged pair cannot be built, and cannot be checked if someone encodes
@@ -547,7 +555,7 @@ mod tests {
             b: forged,
         };
         assert_eq!(
-            fabricated.verify(),
+            fabricated.verify_evidence(),
             Err(KtError::BadSignature),
             "the second half was authored by the accuser, not the witness",
         );

--- a/rs/crates/f2z-kt-core/src/error.rs
+++ b/rs/crates/f2z-kt-core/src/error.rs
@@ -182,6 +182,20 @@ pub enum KtError {
     /// §6.3 rule 8: the same epoch with a different root, size or timestamp.
     /// Fatal, and it is fork evidence.
     Fork,
+    /// §7.2: **one witness signed two contradictory statements** about one
+    /// `(log_id, epoch)`.
+    ///
+    /// Distinct from [`KtError::Fork`] on purpose, and the distinction is the
+    /// whole of §7.2's accountability claim. `Fork` is evidence against the
+    /// **log** — it is what the log returns when a cosignature endorses a root
+    /// the log did not publish, and what a client returns when two *different*
+    /// witnesses disagree. This is a fault of the **witness**, it needs no third
+    /// document to establish, and it stands even if the log is honest. Reporting
+    /// it as `Fork` would file evidence against the wrong party.
+    ///
+    /// The pair itself is [`crate::cosign::WitnessEquivocation`]; this is the
+    /// verdict that accompanies it.
+    WitnessEquivocation,
     /// §6.3 rule 7: `prev_sth_hash` does not connect to the last accepted head.
     ChainBreak,
     /// §6.3 rule 7: the new head skips epochs. The verifier MUST fetch every
@@ -231,6 +245,7 @@ impl KtError {
             // inventing a code §9.5 does not have.
             Self::Rollback
             | Self::Fork
+            | Self::WitnessEquivocation
             | Self::ChainBreak
             | Self::EpochGap
             | Self::VrfKeyChange
@@ -258,6 +273,9 @@ impl fmt::Display for KtError {
             Self::Cooldown => "platform_reset before effective_at_ms (KT.md §4.4)",
             Self::Rollback => "tree head moved backwards (KT.md §6.3)",
             Self::Fork => "two different tree heads for one epoch (KT.md §6.3 rule 8)",
+            Self::WitnessEquivocation => {
+                "one witness signed two contradictory statements for one epoch (KT.md §7.2)"
+            }
             Self::ChainBreak => "prev_sth_hash does not connect (KT.md §6.3 rule 7)",
             Self::EpochGap => "tree head skips epochs; fetch every intervening head (KT.md §6.3)",
             Self::VrfKeyChange => "vrf_public_key changed within a log_id (KT.md §6.1)",
@@ -349,6 +367,7 @@ mod tests {
             KtError::Cooldown,
             KtError::Rollback,
             KtError::Fork,
+            KtError::WitnessEquivocation,
             KtError::ChainBreak,
             KtError::EpochGap,
             KtError::VrfKeyChange,

--- a/rs/crates/f2z-kt-core/src/submit.rs
+++ b/rs/crates/f2z-kt-core/src/submit.rs
@@ -771,6 +771,110 @@ mod tests {
     }
 
     #[test]
+    fn a_same_key_update_signed_by_anything_but_the_current_directory_key_is_refused() {
+        // zuu#692. §4.4's `same_key` row is the ONLY thing standing between an
+        // ordinary entry — adding a device, removing a device, changing an
+        // endpoint, rotating a KEM key — and the directory, and it is the
+        // most-travelled rule in §4.4. Every other `BadSignature` test in this
+        // file targets an *exceptional* authorization path.
+        //
+        // The signature here is genuine: a real Ed25519 signature over the real
+        // entry bytes, by a key that is simply not the one the previous entry
+        // published. A corrupted-bytes fixture would be refused by the same
+        // call for a weaker reason.
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+
+        let update = directory.same_key_update(&genesis);
+        let impostor = signing_key(0x9a);
+        let signed_by_a_stranger = DirectoryEntry {
+            authorization: EntryAuthorization::SameKey {
+                auth_signature: crate::testing::sign(
+                    &impostor,
+                    &update.entry.signing_bytes().unwrap(),
+                ),
+            },
+            entry: update.entry.clone(),
+        };
+        assert_eq!(
+            accept(&directory, &signed_by_a_stranger, Some(&published), 0),
+            Err(KtError::BadSignature),
+            "the previous entry's directory_auth_pk is what authorizes an ordinary update",
+        );
+
+        // The positive control, in the same test so a fix that broke ordinary
+        // submissions could not hide behind the refusal above.
+        assert!(accept(&directory, &update, Some(&published), 0).is_ok());
+    }
+
+    #[test]
+    fn a_registration_not_self_signed_by_the_key_it_publishes_is_refused() {
+        // The version-1 half of the same call site, and the AMBIGUITY CALL
+        // §4.4's table has no row for: a registration is self-signed by the
+        // `directory_auth_pk` it publishes. Nothing weaker is possible, and
+        // "nothing weaker" is only true if the self-signature is checked.
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let impostor = signing_key(0x9b);
+        let not_self_signed = DirectoryEntry {
+            authorization: EntryAuthorization::SameKey {
+                auth_signature: crate::testing::sign(
+                    &impostor,
+                    &genesis.entry.signing_bytes().unwrap(),
+                ),
+            },
+            entry: genesis.entry.clone(),
+        };
+        assert_eq!(
+            accept(&directory, &not_self_signed, None, 0),
+            Err(KtError::BadSignature),
+            "trust-on-first-registration still requires the registration to be signed",
+        );
+        assert!(accept(&directory, &genesis, None, 0).is_ok());
+    }
+
+    #[test]
+    fn a_reset_entry_not_signed_by_its_own_directory_key_is_refused() {
+        // zuu#692. §4.4 rule 5 for `platform_reset`: the entry's OWN
+        // `directory_auth_pk` signs it. The reset authority's signature (rule 7)
+        // covers the `ResetAuthorization`, which names the incoming *identity*
+        // key and says nothing at all about the incoming directory-auth key —
+        // so without this signature the platform authority's approval of a
+        // recovery would install a directory-auth key nobody proved possession
+        // of. `a_reset_signed_by_anything_but_the_pinned_authority_is_refused`
+        // covers rule 7 and cannot cover this.
+        let directory = TestDirectory::new();
+        let genesis = directory.genesis();
+        let published = PublishedEntry::from_entry(&genesis).unwrap();
+        let new_isk = signing_key(0x80);
+        let new_auth = signing_key(0x81);
+        let cooldown_ms = directory.policy().reset_cooldown_ms();
+
+        let reset = directory.platform_reset(&genesis, &new_isk, &new_auth, 0);
+        // Genuine signature, wrong key: neither the directory-auth key this
+        // entry publishes nor any key the entry mentions.
+        let stranger_signed = directory.reauthorize_reset(reset.clone(), &signing_key(0x9c));
+        assert_eq!(
+            accept(&directory, &stranger_signed, Some(&published), cooldown_ms),
+            Err(KtError::BadSignature),
+        );
+
+        // And specifically not the *outgoing* directory-auth key either: a
+        // reset exists because that key is gone.
+        let old_auth_signed = directory.reauthorize_reset(reset.clone(), &signing_key(0x42));
+        assert_eq!(
+            accept(&directory, &old_auth_signed, Some(&published), cooldown_ms),
+            Err(KtError::BadSignature),
+        );
+
+        assert!(
+            accept(&directory, &reset, Some(&published), cooldown_ms).is_ok(),
+            "the correctly signed reset is still accepted",
+        );
+    }
+
+    #[test]
     fn a_reset_before_its_cooldown_is_refused() {
         let directory = TestDirectory::new();
         let genesis = directory.genesis();

--- a/rs/crates/f2z-kt-core/src/verify.rs
+++ b/rs/crates/f2z-kt-core/src/verify.rs
@@ -305,21 +305,38 @@ pub fn verify_lookup(
     })
 }
 
-/// §8.2 — verify a handle's key history at a witnessed root.
+/// §8.2 — verify a handle's **complete** key history at a witnessed root.
 ///
 /// `entries` are the full `DirectoryEntry` byte strings served alongside the
 /// proof, in the **same order as the proof's update proofs**, which `akd` emits
 /// in **decreasing** version order.
 ///
-/// `pinned` is the client's last known published entry for this handle, or
-/// `None` when it is starting from a complete history.
+/// # The verification parameters are §8.2's, not the caller's
+///
+/// This used to take `akd_core`'s `HistoryVerificationParams` and a `pinned`
+/// predecessor, and neither could be chosen. §8.2 is a proof about a
+/// **complete** history — step 4 checks "an unbroken `entry_version` sequence"
+/// which begins at the registration — so the only sound value is
+/// `Default { history_params: Complete }`, and a caller passing
+/// `MostRecent(n)` would have relaxed `key_history_verify`'s own start-version
+/// check while leaving step 4 to catch a partial history on its own. `pinned`
+/// was worse than unused: under `Complete` the oldest entry shown is always
+/// version 1, so any `Some(previous)` demanded that version 1 be a successor
+/// of an entry at version 0, which [`DirectoryEntry::validate`] makes
+/// impossible. It could only ever produce [`KtError::HistoryIncomplete`].
+///
+/// A caller doing an **incremental** check against a pin calls
+/// [`check_entry_chain`] directly, which is what that function is public for.
+/// A caller that could weaken the proof is the thing this signature removes.
 ///
 /// # Step 4 is not redundant with step 3
 ///
-/// `key_history_verify` proves the versions returned are in the tree. The
-/// `entry_version` sequence and the `prev_entry_hash` chain prove the client was
-/// shown **all** of them: a log that omits a version from a history response is
-/// otherwise serving a truthful subset, and every proof in it verifies.
+/// `key_history_verify` proves the versions returned are in the tree, and under
+/// `Complete` it proves they are a contiguous run starting at 1. **It never
+/// reads `prev_entry_hash`.** The chain walk is the only thing that does, and
+/// it is what stands between a client and a log that answers with contiguous,
+/// genuinely-included versions whose contents do not chain — a substitution
+/// every proof in the response verifies for.
 ///
 /// # Errors
 ///
@@ -329,17 +346,20 @@ pub fn verify_lookup(
 /// - [`KtError::ValueMismatch`] if any proved value is not the hash of the entry
 ///   served for it.
 /// - [`KtError::HistoryIncomplete`] if the versions are not contiguous, if the
-///   `prev_entry_hash` chain breaks, or if the oldest entry shown is neither
-///   version 1 nor a successor of `pinned`.
+///   `prev_entry_hash` chain breaks, or if the oldest entry shown is not
+///   version 1 with an all-zero `prev_entry_hash`.
 /// - [`KtError::WrongLog`] / [`KtError::BadHandle`] as [`verify_lookup`].
 pub fn verify_key_history(
     root: &AcceptedRoot,
     handle: &Handle,
     entries: &[&[u8]],
     history_proof: &[u8],
-    pinned: Option<&PublishedEntry>,
-    params: HistoryVerificationParams,
 ) -> Result<Vec<VerifiedEntry>, KtError> {
+    // §8.2's terms, fixed here so no caller has to choose them and none can
+    // choose weaker ones.
+    let params = HistoryVerificationParams::Default {
+        history_params: HistoryParams::Complete,
+    };
     handle.validate()?;
     if entries.is_empty() {
         return Err(KtError::HistoryIncomplete);
@@ -390,19 +410,16 @@ pub fn verify_key_history(
         .iter()
         .map(|entry| entry.entry.clone())
         .collect::<Vec<_>>();
-    check_entry_chain(&entries, pinned)?;
+    check_entry_chain(&entries, None)?;
 
     Ok(verified)
 }
 
 /// Re-export so a caller does not have to depend on `akd_core` to name the
-/// history parameters `KT.md` §8.2 hands to the verifier.
+/// history parameters `KT.md` §8.2 hands to the *log* when asking for a
+/// history. [`verify_key_history`] no longer takes one: it fixes §8.2's
+/// `Complete`, because a verifier whose strictness is a caller's argument is a
+/// verifier nobody is holding to §8.2.
 pub use akd_core::verify::history::HistoryParams;
 
-/// The same, for the type [`verify_key_history`] actually takes.
-///
-/// Without this a caller outside this crate cannot **call** the function: the
-/// parameter type is `akd_core`'s and naming it would mean depending on
-/// `akd_core` directly, which is the coupling `KT.md` §11.4's single-crate rule
-/// exists to avoid. Found while writing `f2z-kt-client`.
-pub use akd_core::verify::HistoryVerificationParams;
+use akd_core::verify::HistoryVerificationParams;

--- a/rs/crates/f2z-kt/src/log.rs
+++ b/rs/crates/f2z-kt/src/log.rs
@@ -66,6 +66,7 @@ use f2z_authority::authority::AuthorityConfig;
 use f2z_authority::nonce::NonceLedger;
 use f2z_codec::hash::hash;
 use f2z_codec::types::{Digest, Payload, PublicKey};
+use f2z_kt_core::cosign::WitnessEquivocation;
 use f2z_kt_core::sth::{SignedTreeHead, SignedTreeHeadTBS};
 use f2z_kt_core::submit::{LogPolicy, PublishedEntry, SubmissionContext};
 use f2z_kt_core::types::{Handle, LogId, label_field};
@@ -219,6 +220,9 @@ struct State {
     heads: Vec<SignedTreeHead>,
     /// Epoch → the cosignatures collected for it.
     cosignatures: BTreeMap<u64, Vec<WitnessCosignature>>,
+    /// §7.2 self-equivocations found, in the order they were found. Retained,
+    /// never pruned: the pair is the evidence.
+    equivocations: Vec<WitnessEquivocation>,
     /// How many submission records each epoch covered.
     submissions_upto: u64,
     /// Replay protection for handle assertions.
@@ -303,6 +307,7 @@ impl LogService {
             pending_handles: BTreeSet::new(),
             heads: Vec::new(),
             cosignatures: BTreeMap::new(),
+            equivocations: journal.equivocations.clone(),
             submissions_upto: 0,
             nonces: NonceLedger::new(settings.nonce_ledger_capacity, authority.clock_skew_ms()),
             tree_size: 0,
@@ -943,13 +948,41 @@ impl LogService {
     /// as there are configured witnesses. No input grows the journal without
     /// bound, in either configuration, without a magic number to tune.
     ///
+    /// # §7.2 self-equivocation, and why it is checked before `covers`
+    ///
+    /// A witness that has already cosigned this epoch and now sends a different
+    /// `(tree_size, root_hash)` for it has contradicted **itself**, and the two
+    /// signatures are the whole proof. This log holds both at that moment, so it
+    /// is the party in a position to notice.
+    ///
+    /// The order matters. The `covers` check below would refuse the second
+    /// cosignature as [`KtError::Fork`] — evidence against the **log** — before
+    /// the pair was ever compared, which files the finding against the wrong
+    /// party and discards the evidence. `Fork` is still right when the witness
+    /// has sent nothing else for the epoch: one statement disagreeing with the
+    /// log's head is a disagreement between two parties, not a witness
+    /// contradicting itself, and it needs the log's own head to state at all.
+    ///
+    /// **What the log does with a self-equivocating witness, stated as policy:**
+    /// it retains both cosignatures verbatim in `equivocations.log`, keeps
+    /// serving the earlier one, refuses the new one, and says so at `error`
+    /// level. It does **not** drop the witness. §8.3 and §9.5 are explicit that
+    /// the log's opinion of who is a witness has no bearing on a client's
+    /// configured set, so a log that quietly stopped serving a genuine,
+    /// covering cosignature would be degrading a client's threshold on its own
+    /// authority while destroying nothing an equivocating witness cares about.
+    /// The accountability is the evidence, and the evidence is durable — see
+    /// [`LogService::witness_equivocations`].
+    ///
     /// # Errors
     ///
     /// [`LogError::NotAWitness`] if the log does not recognise the key —
     /// checked **first**, so an unrecognised key costs a set lookup rather than
-    /// a signature verification and an `fsync`. [`LogError::Kt`] if it does not
-    /// verify or does not cover a known head, [`LogError::Storage`] if it could
-    /// not be journalled.
+    /// a signature verification and an `fsync`. [`LogError::Kt`] with
+    /// [`KtError::WitnessEquivocation`] if this witness has already made a
+    /// contradictory statement about this epoch, [`LogError::Kt`] if it does
+    /// not verify or does not cover a known head, [`LogError::Storage`] if it
+    /// could not be journalled.
     pub async fn accept_cosignature(&self, cosignature: &WitnessCosignature) -> Result<()> {
         // Recognition first. `witness_pk` is inside the signed bytes (§7.2), so
         // a claim to be a listed witness is refused here or refused by the
@@ -959,36 +992,82 @@ impl LogService {
         if !self.recognises_witness(&cosignature.statement.witness_pk) {
             return Err(LogError::NotAWitness);
         }
-        cosignature.verify().map_err(LogError::Kt)?;
+        // `verified()` rather than `verify()`: the token is what
+        // `VerifiedCosignature::contradicts` takes, so the comparison below
+        // cannot be reached on a statement whose signature was not checked.
+        let incoming = cosignature.clone().verified().map_err(LogError::Kt)?;
         if cosignature.statement.log_id != self.log_id {
             return Err(LogError::Kt(KtError::WrongLog));
         }
 
         let mut state = self.state.lock().await;
+        let epoch = cosignature.statement.epoch;
+        let held = state
+            .cosignatures
+            .get(&epoch)
+            .and_then(|held| {
+                held.iter()
+                    .find(|other| other.statement.witness_pk == cosignature.statement.witness_pk)
+            })
+            .cloned();
+
+        if let Some(held) = held {
+            // Everything in `state.cosignatures` verified on the way in, so this
+            // cannot fail on stored data; it is written as a check rather than
+            // an assumption because the token is the argument the comparison
+            // needs.
+            let held = held.verified().map_err(LogError::Kt)?;
+            match WitnessEquivocation::new(&held, &incoming) {
+                Ok(evidence) => {
+                    state.store.append_equivocation(&evidence)?;
+                    state.equivocations.push(evidence);
+                    log::error!(
+                        "WITNESS SELF-EQUIVOCATION at epoch {epoch}: one witness signed two \
+                         different roots for one epoch. Both cosignatures are retained verbatim \
+                         in equivocations.log and are non-repudiable against that witness under \
+                         its own key (KT.md §7.2). The earlier one is still served; this one is \
+                         refused."
+                    );
+                    return Err(LogError::Kt(KtError::WitnessEquivocation));
+                }
+                // Not a contradiction: the same statement again, or the same
+                // root observed at a different time. Idempotent, as before — a
+                // witness that retries after a timeout must not appear twice
+                // and inflate the count a client applies a threshold to.
+                Err(_) => return Ok(()),
+            }
+        }
+
         let head =
             head_at(&state, cosignature.statement.epoch).ok_or(LogError::EpochUnavailable)?;
         if !cosignature.covers(&head) {
             // The witness signed a different root for an epoch this log
-            // published. That is the witness's business to explain, and it is
-            // not something to file away as if it agreed with us.
+            // published, and has sent nothing else for that epoch. That is a
+            // disagreement between the witness and the log — not a witness
+            // contradicting itself — and it is the witness's business to
+            // explain. It is not something to file away as if it agreed with us.
             return Err(LogError::Kt(KtError::Fork));
         }
 
-        let epoch = cosignature.statement.epoch;
-        let existing = state.cosignatures.entry(epoch).or_default();
-        if existing
-            .iter()
-            .any(|held| held.statement.witness_pk == cosignature.statement.witness_pk)
-        {
-            // Idempotent: a witness that retries after a timeout must not
-            // appear twice and inflate the count a client applies a threshold
-            // to.
-            return Ok(());
-        }
-        existing.push(cosignature.clone());
+        state
+            .cosignatures
+            .entry(epoch)
+            .or_default()
+            .push(cosignature.clone());
         state.store.append_cosignature(cosignature)?;
         log::info!("cosignature accepted for epoch {epoch}");
         Ok(())
+    }
+
+    /// The witness self-equivocations this log has found (§7.2).
+    ///
+    /// Each is the conflicting pair verbatim, and each re-establishes itself
+    /// from its own bytes under a key it names — so an operator, an auditor or
+    /// anyone else can be handed one and check it without trusting this log.
+    /// That portability is the point: a check whose only output is a rejection
+    /// throws away exactly the artifact that makes §7.2's claim non-repudiable.
+    pub async fn witness_equivocations(&self) -> Vec<WitnessEquivocation> {
+        self.state.lock().await.equivocations.clone()
     }
 
     /// How many submissions are admitted but not yet published.

--- a/rs/crates/f2z-kt/src/store.rs
+++ b/rs/crates/f2z-kt/src/store.rs
@@ -16,6 +16,7 @@
 //! | `submissions.log` | every [`AdmittedSubmission`]'s canonical entry bytes, in admission order | a submission the log accepted and then forgot is a broken §5.2 merge promise, and the client is holding a signed receipt that says so |
 //! | `epochs.log` | every published `SignedTreeHead`, plus how many submissions it covers | §6.3's chain is only checkable if the log can still produce every head it signed |
 //! | `cosignatures.log` | every `WitnessCosignature` accepted at `/kt/v1/cosign` | §9.2 has the log serve them; a log that forgets them looks like a log with fewer witnesses |
+//! | `equivocations.log` | every `WitnessEquivocation` a witness produced against itself (§7.2) | the pair **is** the evidence; a check whose only output is a rejection throws away the one artifact that makes the property non-repudiable |
 //!
 //! The `akd` tree is rebuilt at startup by replaying `publish()` epoch by
 //! epoch, in the recorded order, against an in-memory database — and **the
@@ -49,6 +50,7 @@ use std::path::{Path, PathBuf};
 use f2z_codec::Canonical as _;
 use f2z_codec::decode_canonical;
 use f2z_codec::types::{Payload, ShortBytes};
+use f2z_kt_core::cosign::WitnessEquivocation;
 use f2z_kt_core::sth::SignedTreeHead;
 use f2z_kt_core::types::{check_label, label_field};
 use f2z_kt_core::{KT_VERSION, WitnessCosignature};
@@ -125,15 +127,18 @@ pub struct Journal {
     pub epochs: Vec<StoredEpoch>,
     /// Cosignatures, in arrival order.
     pub cosignatures: Vec<WitnessCosignature>,
+    /// Witness self-equivocations, in the order they were found (§7.2).
+    pub equivocations: Vec<WitnessEquivocation>,
 }
 
-/// The three append-only journals.
+/// The four append-only journals.
 #[derive(Debug)]
 pub struct Store {
     dir: PathBuf,
     submissions: File,
     epochs: File,
     cosignatures: File,
+    equivocations: File,
     next_sequence: u64,
 }
 
@@ -151,10 +156,12 @@ impl Store {
         let mut submissions = open_append(&dir.join("submissions.log"))?;
         let mut epochs = open_append(&dir.join("epochs.log"))?;
         let mut cosignatures = open_append(&dir.join("cosignatures.log"))?;
+        let mut equivocations = open_append(&dir.join("equivocations.log"))?;
 
         let submissions_raw = read_records(&mut submissions, dir)?;
         let epochs_raw = read_records(&mut epochs, dir)?;
         let cosignatures_raw = read_records(&mut cosignatures, dir)?;
+        let equivocations_raw = read_records(&mut equivocations, dir)?;
 
         let mut journal = Journal::default();
         for (index, bytes) in submissions_raw.iter().enumerate() {
@@ -187,6 +194,18 @@ impl Store {
                 .into_value();
             journal.cosignatures.push(record);
         }
+        for (index, bytes) in equivocations_raw.iter().enumerate() {
+            let record = decode_canonical::<WitnessEquivocation>(bytes)
+                .map_err(|_| corrupt("equivocations.log", index))?
+                .into_value();
+            // Re-established from the record's own bytes at every startup. A
+            // stored accusation that no longer checks out is corruption, and
+            // the log must not serve one it cannot itself substantiate.
+            record
+                .verify()
+                .map_err(|_| corrupt("equivocations.log", index))?;
+            journal.equivocations.push(record);
+        }
 
         let next_sequence = u64::try_from(journal.submissions.len()).unwrap_or(u64::MAX);
         Ok((
@@ -195,6 +214,7 @@ impl Store {
                 submissions,
                 epochs,
                 cosignatures,
+                equivocations,
                 next_sequence,
             },
             journal,
@@ -262,6 +282,24 @@ impl Store {
             .encode_canonical()
             .map_err(|_| LogError::Malformed)?;
         append_record(&mut self.cosignatures, &bytes, &self.dir)
+    }
+
+    /// Append a witness self-equivocation and `fsync` (§7.2).
+    ///
+    /// Both cosignatures verbatim, because the pair is the evidence. §7.2:
+    /// *"No third document is needed to establish it: the two cosignatures and
+    /// the witness's own public key are the whole proof."* Storing a summary,
+    /// a flag or a log line would leave the log asserting a fault it could no
+    /// longer prove.
+    ///
+    /// # Errors
+    ///
+    /// [`LogError::Storage`] on any write or sync failure.
+    pub fn append_equivocation(&mut self, evidence: &WitnessEquivocation) -> Result<()> {
+        let bytes = evidence
+            .encode_canonical()
+            .map_err(|_| LogError::Malformed)?;
+        append_record(&mut self.equivocations, &bytes, &self.dir)
     }
 }
 

--- a/rs/crates/f2z-kt/src/store.rs
+++ b/rs/crates/f2z-kt/src/store.rs
@@ -202,7 +202,7 @@ impl Store {
             // stored accusation that no longer checks out is corruption, and
             // the log must not serve one it cannot itself substantiate.
             record
-                .verify()
+                .verify_evidence()
                 .map_err(|_| corrupt("equivocations.log", index))?;
             journal.equivocations.push(record);
         }

--- a/rs/crates/f2z-kt/tests/cosign.rs
+++ b/rs/crates/f2z-kt/tests/cosign.rs
@@ -443,12 +443,12 @@ async fn a_witness_that_signs_two_roots_for_one_epoch_is_caught_and_the_pair_is_
     // 3. And it is non-repudiable with no third document: the two cosignatures
     //    and the key they both name are the whole proof (§7.2). Checked here
     //    the way a stranger would check it — from the encoded bytes alone.
-    assert_eq!(pair.verify(), Ok(()));
+    assert_eq!(pair.verify_evidence(), Ok(()));
     let bytes = pair.encode_canonical().unwrap();
     let decoded = decode_canonical::<f2z_kt_core::cosign::WitnessEquivocation>(&bytes)
         .unwrap()
         .into_value();
-    assert_eq!(decoded.verify(), Ok(()));
+    assert_eq!(decoded.verify_evidence(), Ok(()));
 
     // 4. The earlier, covering cosignature is still served. §8.3 and §9.5 are
     //    explicit that the log's opinion of who is a witness has no bearing on
@@ -488,7 +488,7 @@ async fn a_journalled_equivocation_is_replayed_and_re_verified() {
     let reopened = reopen(&harness, vec![witness.public]).await;
     let evidence = reopened.witness_equivocations().await;
     assert_eq!(evidence.len(), 1);
-    assert_eq!(evidence[0].verify(), Ok(()));
+    assert_eq!(evidence[0].verify_evidence(), Ok(()));
     assert_eq!(evidence[0].witness_pk(), &witness.public);
 }
 

--- a/rs/crates/f2z-kt/tests/cosign.rs
+++ b/rs/crates/f2z-kt/tests/cosign.rs
@@ -54,6 +54,7 @@ use f2z_kt::FileSigner;
 use f2z_kt::api::AppState;
 use f2z_kt::ratelimit::RateLimiter;
 use f2z_kt::testing::{Harness, Key};
+use f2z_kt_core::KtError;
 use f2z_kt_core::api::ErrorBody;
 use f2z_kt_core::cosign::{WitnessCosignature, WitnessCosignatureTBS};
 use f2z_kt_core::sth::SignedTreeHead;
@@ -348,4 +349,203 @@ async fn reopen(harness: &Harness, witnesses: Vec<PublicKey>) -> f2z_kt::LogServ
     )
     .await
     .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// §7.2 — a witness that contradicts itself, and the evidence that survives it.
+//
+// zuu#746. `VerifiedCosignature::contradicts` was made sound by #704 and given
+// no caller, so the accountability §7.2 claims was correctly implemented and
+// never exercised:
+//
+// > Two conflicting statements are directly non-repudiable against the witness
+// > … **That is what makes a witness accountable rather than merely helpful.**
+//
+// A witness that signs two different roots for one epoch was detected by
+// nothing — the second cosignature was refused as `ERR_INTERNAL`/`Fork`, which
+// is evidence against the *log*, and the pair was thrown away.
+// ---------------------------------------------------------------------------
+
+/// A cosignature by `key` over an epoch the log published, but naming a root it
+/// did not.
+///
+/// A **genuine** signature over genuinely different contents — not a corrupted
+/// byte. That is what self-equivocation is: the witness really did sign both.
+fn cosignature_over_another_root(head: &SignedTreeHead, key: &Key) -> WitnessCosignature {
+    let statement = WitnessCosignatureTBS {
+        label: WitnessCosignatureTBS::label_bytes().unwrap(),
+        kt_version: f2z_kt_core::KT_VERSION,
+        log_id: head.sth.log_id,
+        epoch: head.sth.epoch,
+        tree_size: head.sth.tree_size,
+        root_hash: f2z_codec::types::Digest::new([0xaa; 32]),
+        witness_pk: key.public,
+        observed_at_ms: NOW + 60_000,
+    };
+    assert_ne!(statement.root_hash, head.sth.root_hash);
+    let signature = key.sign(&statement.signing_bytes().unwrap());
+    let cosignature = WitnessCosignature {
+        statement,
+        signature,
+    };
+    cosignature
+        .verify()
+        .expect("the witness really did sign this one too");
+    cosignature
+}
+
+/// **zuu#746.** One witness, two genuine cosignatures, one epoch, two roots.
+///
+/// The finding is named as the witness's fault, both statements are retained
+/// verbatim, and the evidence re-establishes itself from its own bytes.
+#[tokio::test]
+async fn a_witness_that_signs_two_roots_for_one_epoch_is_caught_and_the_pair_is_kept() {
+    let witness = Key::from_byte(0xc1);
+    let harness =
+        Harness::vouched_with_witnesses("cosign-equivocation", vec![witness.public]).await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let head = harness.log.latest_bundle().await.unwrap().head;
+
+    // The honest half, first: this is the statement the log and every client
+    // will keep counting.
+    let honest = cosignature_over(&head, &witness);
+    harness.log.accept_cosignature(&honest).await.unwrap();
+    assert_eq!(served(&harness).await, 1);
+    assert!(harness.log.witness_equivocations().await.is_empty());
+
+    // The same witness now signs a different root for the same epoch.
+    let dishonest = cosignature_over_another_root(&head, &witness);
+    let error = harness
+        .log
+        .accept_cosignature(&dishonest)
+        .await
+        .expect_err("a witness contradicting itself is not accepted");
+
+    // 1. A named fault, distinct from `Fork`. `Fork` is evidence against the
+    //    log; this is a fault of the witness and stands even if the log is
+    //    honest, so reporting it as `Fork` would file it against the wrong
+    //    party.
+    assert!(
+        matches!(error, f2z_kt::LogError::Kt(KtError::WitnessEquivocation)),
+        "expected KtError::WitnessEquivocation, got {error:?}",
+    );
+
+    // 2. Both cosignatures retained, verbatim, so the pair can be handed to
+    //    anyone.
+    let evidence = harness.log.witness_equivocations().await;
+    assert_eq!(evidence.len(), 1);
+    let pair = &evidence[0];
+    assert_eq!(pair.witness_pk(), &witness.public);
+    assert_eq!(pair.epoch(), head.sth.epoch);
+    assert_eq!(&pair.a, &honest);
+    assert_eq!(&pair.b, &dishonest);
+
+    // 3. And it is non-repudiable with no third document: the two cosignatures
+    //    and the key they both name are the whole proof (§7.2). Checked here
+    //    the way a stranger would check it — from the encoded bytes alone.
+    assert_eq!(pair.verify(), Ok(()));
+    let bytes = pair.encode_canonical().unwrap();
+    let decoded = decode_canonical::<f2z_kt_core::cosign::WitnessEquivocation>(&bytes)
+        .unwrap()
+        .into_value();
+    assert_eq!(decoded.verify(), Ok(()));
+
+    // 4. The earlier, covering cosignature is still served. §8.3 and §9.5 are
+    //    explicit that the log's opinion of who is a witness has no bearing on
+    //    a client's configured set, so dropping a genuine cosignature would
+    //    degrade a client's threshold on the log's own authority.
+    assert_eq!(served(&harness).await, 1);
+}
+
+/// The evidence survives a restart, and is re-checked on the way back in.
+#[tokio::test]
+async fn a_journalled_equivocation_is_replayed_and_re_verified() {
+    let witness = Key::from_byte(0xc1);
+    let harness =
+        Harness::vouched_with_witnesses("cosign-equivocation-replay", vec![witness.public]).await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let head = harness.log.latest_bundle().await.unwrap().head;
+
+    harness
+        .log
+        .accept_cosignature(&cosignature_over(&head, &witness))
+        .await
+        .unwrap();
+    harness
+        .log
+        .accept_cosignature(&cosignature_over_another_root(&head, &witness))
+        .await
+        .unwrap_err();
+
+    assert!(
+        std::fs::metadata(harness.dir.join("equivocations.log"))
+            .unwrap()
+            .len()
+            > 0,
+        "the pair was fsynced, not held in memory until the process died",
+    );
+
+    let reopened = reopen(&harness, vec![witness.public]).await;
+    let evidence = reopened.witness_equivocations().await;
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(evidence[0].verify(), Ok(()));
+    assert_eq!(evidence[0].witness_pk(), &witness.public);
+}
+
+/// A retry is still a retry. `contradicts` excludes `observed_at_ms` on purpose
+/// — the same root seen at two times is normal, not a conflict — and the
+/// idempotency the fix must not break is exactly that case.
+#[tokio::test]
+async fn re_sending_the_same_root_at_a_later_time_is_not_an_equivocation() {
+    let witness = Key::from_byte(0xc1);
+    let harness =
+        Harness::vouched_with_witnesses("cosign-equivocation-retry", vec![witness.public]).await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let head = harness.log.latest_bundle().await.unwrap().head;
+
+    harness
+        .log
+        .accept_cosignature(&cosignature_over(&head, &witness))
+        .await
+        .unwrap();
+
+    // Same four fields, later clock, fresh genuine signature.
+    let mut later = cosignature_over(&head, &witness);
+    later.statement.observed_at_ms = NOW + 120_000;
+    later.signature = witness.sign(&later.statement.signing_bytes().unwrap());
+    assert_ne!(later, cosignature_over(&head, &witness));
+
+    harness
+        .log
+        .accept_cosignature(&later)
+        .await
+        .expect("a retry is idempotent, not an accusation");
+    assert_eq!(served(&harness).await, 1);
+    assert!(harness.log.witness_equivocations().await.is_empty());
+}
+
+/// A witness that has sent **nothing else** for the epoch and signs a root the
+/// log did not publish is still `Fork`, not equivocation.
+///
+/// One statement disagreeing with the log's head is a disagreement between two
+/// parties. It needs the log's own head to state at all, and the log is one of
+/// the two — so it is not the self-contradiction §7.2 makes non-repudiable, and
+/// calling it one would be an accusation with only one signature behind it.
+#[tokio::test]
+async fn a_first_cosignature_over_an_unpublished_root_is_still_a_fork() {
+    let witness = Key::from_byte(0xc1);
+    let harness = Harness::vouched_with_witnesses("cosign-first-fork", vec![witness.public]).await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let head = harness.log.latest_bundle().await.unwrap().head;
+
+    let error = harness
+        .log
+        .accept_cosignature(&cosignature_over_another_root(&head, &witness))
+        .await
+        .expect_err("the log did not publish that root");
+    assert!(
+        matches!(error, f2z_kt::LogError::Kt(KtError::Fork)),
+        "expected KtError::Fork, got {error:?}",
+    );
+    assert!(harness.log.witness_equivocations().await.is_empty());
 }

--- a/rs/crates/f2z-kt/tests/dishonest_history.rs
+++ b/rs/crates/f2z-kt/tests/dishonest_history.rs
@@ -191,7 +191,9 @@ fn audit(
     let head = log.head();
     let cosignature = log.cosignature(&head);
     let set = WitnessSet::new(
-        vec![ConfiguredWitness::dependent(Key::from_byte(WITNESS_SEED).public)],
+        vec![ConfiguredWitness::dependent(
+            Key::from_byte(WITNESS_SEED).public,
+        )],
         1,
     )
     .unwrap();

--- a/rs/crates/f2z-kt/tests/dishonest_history.rs
+++ b/rs/crates/f2z-kt/tests/dishonest_history.rs
@@ -1,0 +1,337 @@
+//! **A log that publishes a chain its own §4.4 forbids** — `KT.md` §8.2 step 4,
+//! zuu#708.
+//!
+//! # Why this file exists, when `f2z-kt-client`'s acceptance suite already runs
+//!
+//! That suite drives a real [`LogService`], and a real `LogService` cannot
+//! produce the answer step 4 is for. `validate_submission` refuses an entry
+//! whose `prev_entry_hash` does not chain, so every history it can serve chains
+//! by construction — which means the chain walk inside
+//! `f2z_kt_core::verify::verify_key_history` could be deleted with that suite
+//! green. Measured: it was.
+//!
+//! But the threat model is a **dishonest log**, and a dishonest log runs
+//! modified code. So this file builds one: a real `akd` tree, over a real ECVRF
+//! key, publishing two genuinely-included versions of one handle whose entries
+//! do not chain, and answering with a real `HistoryProof`. Nothing here is a
+//! fixture of a proof — `akd::Directory::key_history` produces it, and
+//! `akd_core`'s verifier accepts it, exactly as the issue predicted it would:
+//!
+//! > a log that omits a version from a history response is otherwise serving a
+//! > truthful subset, and **every proof in it verifies**.
+//!
+//! This is `f2z-witness`'s "two real logs sharing one signing key" shape, one
+//! layer down: real cryptography, adversarial content. The only thing that
+//! catches it is §8.2 step 4, and this file is what fails if step 4 stops
+//! running.
+//!
+//! # What is *not* being tested here
+//!
+//! Not `akd`. The control at the end of every test publishes the same handle
+//! with a **correct** chain through the same tree and the same proof machinery,
+//! and asserts it verifies. A refusal that fired on both would prove nothing.
+
+// An integration test is its own crate, so the workspace's denials of the
+// panicking families do not reach it. A `.unwrap()` here is a failing test.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use akd::storage::StorageManager;
+use akd::storage::memory::AsyncInMemoryDatabase;
+use akd::{AkdLabel, AkdValue, AzksParallelismConfig, Directory};
+use f2z_codec::Canonical as _;
+use f2z_codec::types::{Digest, PublicKey};
+use f2z_kt::testing::{EntryBuilder, Identity, Key};
+use f2z_kt::vrf::FileVrf;
+use f2z_kt_core::cosign::{WitnessCosignature, WitnessCosignatureTBS};
+use f2z_kt_core::entry::DirectoryEntry;
+use f2z_kt_core::labels;
+use f2z_kt_core::sth::{SignedTreeHead, SignedTreeHeadTBS};
+use f2z_kt_core::types::{Handle, LogId, label_field};
+use f2z_kt_core::verify::{Configuration, HistoryParams, verify_key_history};
+use f2z_kt_core::{ConfiguredWitness, KT_VERSION, KtError, WitnessSet, verify_threshold};
+use protobuf::Message as _;
+
+const NOW: u64 = 1_700_000_100_000;
+const LOG_SEED: u8 = 0xa1;
+const WITNESS_SEED: u8 = 0xc1;
+
+/// A log with a real `akd` tree that publishes **whatever it is handed**.
+///
+/// The one difference from [`f2z_kt::LogService`], and it is the whole point:
+/// there is no `validate_submission` between `publish` and the tree.
+struct DishonestLog {
+    tree: Directory<Configuration, AsyncInMemoryDatabase, FileVrf>,
+    log_key: Key,
+    log_id: LogId,
+    vrf_public_key: PublicKey,
+    epochs: Vec<(u64, Digest, u64)>,
+    tree_size: u64,
+}
+
+impl DishonestLog {
+    async fn new() -> Self {
+        let log_key = Key::from_byte(LOG_SEED);
+        let vrf = FileVrf::from_seed([0xb7; 32]).unwrap();
+        let vrf_public_key = vrf.public_key().await.unwrap();
+        let tree = Directory::<Configuration, _, _>::new(
+            StorageManager::new_no_cache(AsyncInMemoryDatabase::new()),
+            vrf.clone(),
+            AzksParallelismConfig::default(),
+        )
+        .await
+        .unwrap();
+        Self {
+            tree,
+            log_id: labels::log_id(&log_key.public),
+            log_key,
+            vrf_public_key,
+            epochs: Vec::new(),
+            tree_size: 0,
+        }
+    }
+
+    /// Insert one entry's committed value at the handle's label and close an
+    /// epoch. The bytes are never checked against anything.
+    async fn publish(&mut self, entry: &DirectoryEntry) {
+        let canonical = entry.encode_canonical().unwrap();
+        let label = AkdLabel(labels::akd_label(&entry.entry.handle));
+        let value = AkdValue(labels::entry_value(&canonical).as_bytes().to_vec());
+        let epoch_hash = self.tree.publish(vec![(label, value)]).await.unwrap();
+        self.tree_size += 1;
+        self.epochs.push((
+            epoch_hash.epoch(),
+            Digest::new(epoch_hash.hash()),
+            self.tree_size,
+        ));
+    }
+
+    /// The latest head, signed by the log's own key exactly as `publish_epoch`
+    /// signs one.
+    fn head(&self) -> SignedTreeHead {
+        let mut prev_sth_hash = Digest::zero();
+        let mut head = None;
+        for (epoch, root_hash, tree_size) in &self.epochs {
+            let sth = SignedTreeHeadTBS {
+                label: label_field(labels::LABEL_STH).unwrap(),
+                kt_version: KT_VERSION,
+                log_id: self.log_id,
+                epoch: *epoch,
+                tree_size: *tree_size,
+                root_hash: *root_hash,
+                prev_sth_hash,
+                vrf_public_key: self.vrf_public_key,
+                published_at_ms: NOW + epoch,
+                reset_count: 0,
+                epoch_interval_seconds: 600,
+                max_merge_delay_seconds: 3_600,
+                successor_log_pk: PublicKey::zero(),
+            };
+            prev_sth_hash = sth.chain_hash().unwrap();
+            let signature = self.log_key.sign(&sth.signing_bytes().unwrap());
+            head = Some(SignedTreeHead { sth, signature });
+        }
+        head.expect("at least one epoch was published")
+    }
+
+    /// A genuine cosignature over the latest head by the configured witness.
+    ///
+    /// The witness is honest here: it is signing exactly the root this log
+    /// published. §7.2's cosignature says the witness *saw* the root, never that
+    /// the root's contents are authorized — and this file is about a log whose
+    /// contents are not.
+    fn cosignature(&self, head: &SignedTreeHead) -> WitnessCosignature {
+        let witness = Key::from_byte(WITNESS_SEED);
+        let statement = WitnessCosignatureTBS {
+            label: WitnessCosignatureTBS::label_bytes().unwrap(),
+            kt_version: KT_VERSION,
+            log_id: head.sth.log_id,
+            epoch: head.sth.epoch,
+            tree_size: head.sth.tree_size,
+            root_hash: head.sth.root_hash,
+            witness_pk: witness.public,
+            observed_at_ms: NOW,
+        };
+        let signature = witness.sign(&statement.signing_bytes().unwrap());
+        let cosignature = WitnessCosignature {
+            statement,
+            signature,
+        };
+        cosignature.verify().expect("the fixture is well formed");
+        cosignature
+    }
+
+    /// A real complete-history proof for `handle`, with the entry bytes in
+    /// `akd`'s decreasing-version order.
+    async fn history(&self, handle: &Handle) -> Vec<u8> {
+        let label = AkdLabel(labels::akd_label(handle));
+        let (proof, _) = self
+            .tree
+            .key_history(&label, HistoryParams::Complete)
+            .await
+            .unwrap();
+        akd_core::proto::specs::types::HistoryProof::from(&proof)
+            .write_to_bytes()
+            .unwrap()
+    }
+}
+
+/// The client's side: threshold, then §8.2.
+fn audit(
+    log: &DishonestLog,
+    handle: &Handle,
+    entries: &[Vec<u8>],
+    proof: &[u8],
+) -> Result<usize, KtError> {
+    let head = log.head();
+    let cosignature = log.cosignature(&head);
+    let set = WitnessSet::new(
+        vec![ConfiguredWitness::dependent(Key::from_byte(WITNESS_SEED).public)],
+        1,
+    )
+    .unwrap();
+    // §8.3 first, and the type carries the proof that it ran.
+    let root = verify_threshold(&head, &[cosignature], &set, &log.log_id)?;
+    let borrowed: Vec<&[u8]> = entries.iter().map(Vec::as_slice).collect();
+    verify_key_history(&root, handle, &borrowed, proof).map(|verified| verified.len())
+}
+
+fn handle() -> Handle {
+    Handle::new(b"alice".to_vec()).unwrap()
+}
+
+/// A version-1 registration for `@alice`.
+fn genesis(log_id: LogId, identity: &Identity) -> DirectoryEntry {
+    EntryBuilder::first(log_id, "alice", identity)
+        .device(0x51, &identity.isk)
+        .endpoint(0x52)
+        .same_key(&identity.dak)
+}
+
+/// A version-2 `same_key` successor whose `prev_entry_hash` is `prev`.
+///
+/// Every field a decoder or `DirectoryEntry::validate` can check is correct: the
+/// right log, the right handle, version 2, a non-zero predecessor hash (§4.2
+/// requires exactly that of a non-genesis entry), a valid self-signature.
+fn successor(log_id: LogId, identity: &Identity, prev: Digest) -> DirectoryEntry {
+    EntryBuilder::first(log_id, "alice", identity)
+        .version(2)
+        .prev_entry_hash(prev)
+        .device(0x53, &identity.isk)
+        .endpoint(0x54)
+        .same_key(&identity.dak)
+}
+
+// ---------------------------------------------------------------------------
+// The defect.
+// ---------------------------------------------------------------------------
+
+/// **zuu#708.** A history whose versions are contiguous, whose every entry is
+/// genuinely in the tree, and whose `prev_entry_hash` chain does not link.
+///
+/// `key_history_verify` accepts it. It has no reason not to: both versions are
+/// in the tree, they are a contiguous run starting at 1, and the values match
+/// the entries served. **`akd` never reads `prev_entry_hash`.** Step 4 is the
+/// only thing in the system that does.
+#[tokio::test]
+async fn a_history_the_akd_proof_verifies_but_whose_entries_do_not_chain_is_refused() {
+    let mut log = DishonestLog::new().await;
+    let identity = Identity::from_byte(0x31);
+    let first = genesis(log.log_id, &identity);
+    // The substitution: version 2 chains to something that is not version 1.
+    let second = successor(log.log_id, &identity, Digest::new([0x5a; 32]));
+
+    log.publish(&first).await;
+    log.publish(&second).await;
+
+    let proof = log.history(&handle()).await;
+    let entries = vec![
+        second.encode_canonical().unwrap(),
+        first.encode_canonical().unwrap(),
+    ];
+
+    assert_eq!(
+        audit(&log, &handle(), &entries, &proof),
+        Err(KtError::HistoryIncomplete),
+        "the proof verifies; the chain does not link, and only §8.2 step 4 looks",
+    );
+}
+
+/// The control, and it is not optional: the same tree, the same proof
+/// machinery, the same client, a **correct** chain — and it verifies.
+///
+/// Without this the refusal above would be evidence that this file cannot build
+/// a working log rather than evidence that the check works.
+#[tokio::test]
+async fn the_same_log_serving_a_chain_that_links_is_accepted() {
+    let mut log = DishonestLog::new().await;
+    let identity = Identity::from_byte(0x31);
+    let first = genesis(log.log_id, &identity);
+    let second = successor(log.log_id, &identity, first.chain_hash().unwrap());
+
+    log.publish(&first).await;
+    log.publish(&second).await;
+
+    let proof = log.history(&handle()).await;
+    let entries = vec![
+        second.encode_canonical().unwrap(),
+        first.encode_canonical().unwrap(),
+    ];
+
+    assert_eq!(
+        audit(&log, &handle(), &entries, &proof),
+        Ok(2),
+        "two versions, in the tree, chained — §8.2 is satisfied",
+    );
+}
+
+/// A history that skips versions while still chaining by hash.
+///
+/// This is the case the `entry_version` half of step 4 catches on its own: the
+/// `prev_entry_hash` walk is satisfied — the served version-5 entry really does
+/// chain to version 1 — and §8.2's *"unbroken `entry_version` sequence"* is not.
+///
+/// It is refused here by `akd` rather than by step 4, and that is worth
+/// asserting rather than glossing: under `HistoryParams::Complete`
+/// `key_history_verify` checks its own update proofs are a contiguous
+/// decreasing run, so on the witnessed path the version half of step 4 is a
+/// second opinion. On the **unwitnessed** path (§8.3's self-audit row) there is
+/// no `akd` and step 4 is alone, which is what `f2z-kt-client`'s
+/// `a_history_with_a_version_omitted_is_refused_under_an_unwitnessed_root`
+/// covers.
+#[tokio::test]
+async fn a_history_that_chains_by_hash_but_skips_a_version_is_refused() {
+    let mut log = DishonestLog::new().await;
+    let identity = Identity::from_byte(0x31);
+    let first = genesis(log.log_id, &identity);
+    let jumped = EntryBuilder::first(log.log_id, "alice", &identity)
+        .version(5)
+        .prev_entry_hash(first.chain_hash().unwrap())
+        .device(0x55, &identity.isk)
+        .endpoint(0x56)
+        .same_key(&identity.dak);
+
+    log.publish(&first).await;
+    log.publish(&jumped).await;
+
+    let proof = log.history(&handle()).await;
+    let entries = vec![
+        jumped.encode_canonical().unwrap(),
+        first.encode_canonical().unwrap(),
+    ];
+
+    // `akd` assigns versions itself — the tree holds versions 1 and 2 — so the
+    // entry claiming version 5 does not match the version the proof carries.
+    // §8.1 step 4's binding catches it before step 4 does, and a client that
+    // trusted the entry's own claim would not have noticed.
+    assert_eq!(
+        audit(&log, &handle(), &entries, &proof),
+        Err(KtError::ValueMismatch),
+        "an entry's claimed version is bound to the version the proof proves",
+    );
+}


### PR DESCRIPTION
Closes #692. Closes #708. Closes #746.

Three instances of one defect class: **a security check that exists, is correct, and is never exercised — so deleting it changes nothing.** The deliverable is not the checks. It is, for each one, a test that goes red when the check is removed.

Every claim below was measured, not reasoned about: the mutation was applied to the working tree, the suite was run, and the named tests are the ones that failed. Baseline before this PR was `cargo test --workspace` **EXIT=0, 1073 passed**.

---

## #692 — `validate_submission`'s six `sig::verify` call sites

Two could be deleted with the whole workspace green. Three tests added, and then **all six sites were neutered one at a time** (`sig::verify(…)?;` → `let _mutated = (…);`) and the workspace re-run.

| site | authorization case | what the signature proves | test that goes red |
|---|---|---|---|
| `submit.rs:401` | `SameKey` | the previous entry's `directory_auth_pk` signed it | **NEW** `a_same_key_update_signed_by_anything_but_the_current_directory_key_is_refused` + **NEW** `a_registration_not_self_signed_by_the_key_it_publishes_is_refused` |
| `:451` | `KeyChange` | the outgoing identity key signed the `RotationProof` | `a_key_change_signed_by_only_the_new_key_is_rejected`, `adversarial::a_key_change_carrying_only_one_of_the_two_signatures_is_refused` |
| `:461` | `KeyChange` | the **new** `directory_auth_pk` signed it (ADR 0014's proof of possession) | `a_key_change_signed_by_only_the_old_key_is_rejected` |
| `:510` | `PlatformReset` | the pinned reset authority signed the `ResetAuthorization` | `a_reset_signed_by_anything_but_the_pinned_authority_is_refused`, `adversarial::a_reset_signed_by_anyone_but_the_pinned_authority_is_refused` |
| `:534` | `PlatformReset` | **this** entry's `directory_auth_pk` signed it | **NEW** `a_reset_entry_not_signed_by_its_own_directory_key_is_refused` |
| `:553` | rule 8 | the device credential under this entry's `identity_pk` | `a_device_credential_signed_by_the_wrong_identity_key_is_refused` |

`:401` is the most-travelled rule in §4.4 — adding a device, removing a device, changing an endpoint, rotating a KEM key — and was the only one of the six with no negative test at all. It is one call site covering two cases (a `same_key` successor, and a version-1 registration self-signed by the key it publishes), so it gets two tests.

**No site is redundant.** `:461` and `:534` both check "this entry's `directory_auth_pk` signed the entry bytes", but they are different match arms of `EntryAuthorization` reached under different rules, and each has a mutation that only its own test catches. Nothing was removed and no test was added to make a count look right.

Every staged signature is a **genuine Ed25519 signature over the real entry bytes by the wrong key**, never a corrupted buffer, so the refusal is owed to the rule rather than to a decode failure. Each new test carries its positive control in the same function.

---

## #708 — `verify_key_history` and §8.2 step 4

### The "nothing calls it" half is already closed, by #756

Measured on current `main`: `f2z-kt-client`'s `self_audit` (`client.rs:401`) and `accept_key_change` (`client.rs:539`) both call it, and `check_entry_chain` has since been extracted so the unwitnessed self-audit path can run step 4 on its own. That part of the issue is stale and is not re-fixed here.

### The step-4 walk could still be deleted with the workspace green

Four tests added. Five mutations applied, each independently:

| mutation | tests that go red |
|---|---|
| the entire §8.2 step-4 walk deleted (`check_entry_chain` returns `Ok(())`) | all four below |
| only the `entry_version` contiguity check deleted | `a_history_that_chains_by_hash_but_renumbers_a_version_is_refused` |
| only the `prev_entry_hash` chain check deleted | `a_history_whose_prev_entry_hash_chain_does_not_link_is_refused`, `a_history_the_akd_proof_verifies_but_whose_entries_do_not_chain_is_refused` |
| the call deleted from the client's **unwitnessed** branch | the three `f2z-kt-client` tests |
| the call deleted from `verify_key_history` (the **witnessed** path) | `a_history_the_akd_proof_verifies_but_whose_entries_do_not_chain_is_refused` |

Before this PR the last mutation stayed green, and adding client-side tests alone did not fix it. The reason is structural and worth stating: **a real `LogService` cannot produce the answer step 4 exists to catch.** `validate_submission` refuses an entry whose `prev_entry_hash` does not chain, so every history it can serve chains by construction.

But the threat model is a dishonest log, and a dishonest log runs modified code. `rs/crates/f2z-kt/tests/dishonest_history.rs` builds one: **a real `akd` tree over a real ECVRF key**, publishing two genuinely-included versions of one handle whose entries do not chain, answering with a real `HistoryProof` that `akd_core` accepts — because `akd` never reads `prev_entry_hash`. This is `f2z-witness`'s "two real logs sharing one signing key" shape one layer down: real cryptography, adversarial content. Every test in the file carries a control that publishes a *correct* chain through the same tree and asserts it verifies.

The client-side cases are staged under §8.3's self-audit row (*continues, and reports*), where the threshold is unmet, `key_history_verify` does not run, and step 4 is the only check the client has left:

- **the truthful subset** — one version omitted; every entry still served is real;
- **a broken chain** — contiguous versions whose contents do not link. Asserted both ways: under a witnessed root the §8.1 step-4 value binding refuses it first (`ValueMismatch`); under an unwitnessed one only step 4 does;
- **a renumbered version** — a served entry that really does chain to version 1 and calls itself version 5. This is the case only the `entry_version` half catches.

### Two arguments removed, because neither could be given a meaningful value

Raised in the issue's closing note, and it is the same defect class one level down — a check whose strictness is a caller's argument is a check nobody is holding to §8.2.

- `params: HistoryVerificationParams` let a caller pass `MostRecent(n)` and relax `key_history_verify`'s own start-version check, leaving step 4 to backstop a partial history alone. §8.2 is a proof about a **complete** history, so `Default { history_params: Complete }` is now fixed inside the function and cannot be weakened from outside.
- `pinned` could only ever return `HistoryIncomplete`. Under `Complete` the oldest entry shown is always version 1, so any `Some(previous)` demanded that version 1 be a successor of an entry at version 0 — which `DirectoryEntry::validate` makes impossible. A **strictly broken** parameter, removed. A caller doing an incremental check against a pin calls `check_entry_chain` directly, which is what that function is public for.

Both in-tree callers already passed exactly these values and are unchanged in behaviour.

---

## #746 — §7.2's witness self-equivocation

`VerifiedCosignature::contradicts` was made sound by #704 and given no caller, so a witness signing two different roots for one epoch was detected by nothing.

The seam is `Log::accept_cosignature`, which already held the prior cosignature per epoch keyed by `witness_pk`. What ran instead was the `covers` check, returning `KtError::Fork` — evidence against the **log** — before the pair was ever compared. So the finding was filed against the wrong party and the evidence was discarded.

Six mutations, each independently:

| mutation | tests that go red |
|---|---|
| the `WitnessEquivocation::new` call deleted from `accept_cosignature` | `a_witness_that_signs_two_roots_for_one_epoch_is_caught_and_the_pair_is_kept`, `a_journalled_equivocation_is_replayed_and_re_verified` |
| **the pre-fix ordering restored** (`covers`/`Fork` before the contradiction check) | the same two |
| the evidence discarded instead of journalled and retained | the same two |
| `contradicts` loses its `root_hash` comparison | those two plus `the_evidence_pair_re_establishes_itself_from_its_own_bytes`, `two_roots_for_one_epoch_by_one_witness_are_non_repudiable` |
| `contradicts` loses its `witness_pk` equality | `an_accusation_cannot_be_assembled_from_bytes_the_witness_never_signed`, `two_witnesses_disagreeing_is_not_one_witness_contradicting_itself` |
| `WitnessEquivocation::verify_evidence` stops re-verifying | `an_accusation_cannot_be_assembled_from_bytes_the_witness_never_signed` |

The test stages a real self-equivocating witness: **two genuine cosignatures, one key, one epoch, two roots** — the witness really did sign both.

Against the issue's stated acceptance:

1. **A named fault distinct from `Fork`.** `KtError::WitnessEquivocation`. `Fork` is a disagreement between the witness and the log and needs the log's own head to state at all; this is a fault of the witness, needs no third document, and stands even if the log is honest. `Fork` remains correct for a *first* cosignature over an unpublished root, and `a_first_cosignature_over_an_unpublished_root_is_still_a_fork` holds that line. **No `KT.md` §9.5 wire code is added** — the variant collapses to `ERR_INTERNAL` like every other client- or witness-side verdict, so the stable table is untouched.
2. **Both cosignatures retained.** `WitnessEquivocation` in `f2z-kt-core` carries the pair verbatim. Its only constructor takes two `VerifiedCosignature`s and refuses unless they contradict, so holding one *is* the claim — the same shape as `AcceptedRoot` and `AcceptedSubmission`. `verify_evidence` re-establishes both signatures and the contradiction from the encoded bytes alone, which is what a stranger runs. A fourth journal, `equivocations.log`, makes it durable with an `fsync`, and the startup replay re-verifies every record on the way back in.
3. **A policy call, stated in the code.** The log **retains, flags and refuses**; it does not drop the witness. §8.3 and §9.5 are explicit that the log's opinion of who is a witness has no bearing on a client's configured set, so silently withdrawing a genuine covering cosignature would degrade a client's threshold on the log's own authority while costing an equivocating witness nothing. Idempotency is preserved exactly — `contradicts` excludes `observed_at_ms`, and `re_sending_the_same_root_at_a_later_time_is_not_an_equivocation` proves a retry is still a retry.

`WitnessEquivocation` is deliberately **not** a §7.3 `FaultKind`: that enum is a witness accusing a log, and its `log_id` field is named "the log accused". This is the opposite direction and needs no accuser.

---

## One more instance of the class, caught in flight

`f2z-codec`'s `workspace_strict_verification_scan` failed on the first full-workspace run with the new `fn verify` in `cosign.rs` unregistered — the registry doing exactly what it exists to do, unprompted. Registered as delegating to `WitnessCosignature::verify`, and renamed `verify_evidence` because the scan refuses an ambiguous delegation target: a second `fn verify` in that file would make every row naming `cosign.rs::verify` resolve to two definitions.

## Verified locally

`cargo test --locked --all-targets`, `cargo test --locked --doc`, `check-rust-fmt.sh --root rs`, `check-rust-clippy.sh --root rs`, `check-rust-deny.sh --root rs --config rs/deny.toml`, `check-hash-domain-labels.mjs`, `check-workflow-gates.mjs`, and both wasm32 browser builds (`f2z-kt-core` and `f2z-kt-client`, `--no-default-features --features verifier`) — all green.

`#![forbid(unsafe_code)]` untouched; the AGPL/permissive boundary is unchanged (`WitnessEquivocation` is in MIT `f2z-kt-core`, the journal and the policy are in AGPL `f2z-kt`). No `KeyPackage` publication work was touched.

https://claude.ai/code/session_01EF5qmzNm91R75ujoFuaTku
