### PR TITLE
test(f2z-kt): cover every arm of `escape`, one byte class per test

### DIFF
--- a/rs/crates/f2z-kt/src/descriptor.rs
+++ b/rs/crates/f2z-kt/src/descriptor.rs
@@ -165,4 +165,50 @@ mod tests {
         let rendered = render(&signed);
         assert!(rendered.contains("ev\\\"il"));
     }
+
+    #[test]
+    fn an_operator_name_ending_in_a_backslash_cannot_escape_its_own_field() {
+        // The assertion whose absence made zuu#763 invisible. `escape`'s
+        // backslash arm was deletable with every test in every dependent
+        // crate still green, because the only test named for this property
+        // exercised the quotation mark and nothing asserted against a
+        // *rendered* field at all.
+        //
+        // It matters here and not only in `crate::json` because `render`
+        // splices the escaped value straight into a hand-built JSON string. A
+        // trailing backslash that reaches the output unescaped escapes the
+        // closing quotation mark instead of standing for itself: the field
+        // reads `"operator_name":"free2z\"` , never terminates, and swallows
+        // the rest of the descriptor — every field after it included.
+        //
+        // Nothing upstream prevents this. `LogDescriptor::validate` places no
+        // restriction on operator string bytes (see `crate::json`'s test note),
+        // so the escaper is the only thing standing here.
+        let signer = FileSigner::from_seed(&[9u8; 32]);
+        let genesis = signer.public_key();
+        let mut settings = LogSettings::defaults(genesis, PublicKey::new([8u8; 32])).unwrap();
+        settings.operator_name = f2z_codec::types::ShortBytes::new(b"free2z\\".to_vec()).unwrap();
+        let signed = sign_descriptor(
+            &settings,
+            labels::log_id(&genesis),
+            PublicKey::new([7u8; 32]),
+            &signer,
+            1,
+        )
+        .unwrap();
+        let rendered = render(&signed);
+
+        // The backslash stands for itself, and the field still ends where it
+        // should: the very next thing is the comma and the next member's key.
+        assert!(
+            rendered.contains("\"operator_name\":\"free2z\\\\\",\"operator_contact\":"),
+            "operator_name did not render as a terminated field: {rendered}"
+        );
+        // And the broken rendering is absent by name, so this fails loudly
+        // rather than by omission if the arm is ever removed.
+        assert!(
+            !rendered.contains("\"operator_name\":\"free2z\\\",\"operator_contact\":"),
+            "a trailing backslash escaped the closing quotation mark: {rendered}"
+        );
+    }
 }

--- a/rs/crates/f2z-kt/src/json.rs
+++ b/rs/crates/f2z-kt/src/json.rs
@@ -136,7 +136,16 @@ mod tests {
     }
 
     #[test]
-    fn an_operator_string_cannot_escape_its_own_field() {
+    fn an_operator_string_cannot_close_its_own_field_with_a_quotation_mark() {
+        // Renamed from `an_operator_string_cannot_escape_its_own_field`
+        // (zuu#763). The old name claimed the general property — that *no*
+        // operator string can escape its field — while the body exercised one
+        // of the two characters that can do it. Three arms of `escape` could
+        // be broken at once with this test, and every other test in every
+        // crate that depends on `f2z-kt`, still green. A name that asserts
+        // more than the body checks is the defect, not a symptom of it; the
+        // rest of the property is now covered below and, for the backslash,
+        // against a rendered descriptor field in `crate::descriptor`.
         let hostile = "free2z\",\"authoritative\":\"json";
         let rendered = escape(hostile);
         assert!(!rendered.contains("\",\""));
@@ -193,5 +202,93 @@ mod tests {
         );
         let named = error_container(b"", 4, Some("ERR_BAD_AUTHORIZATION"));
         assert!(named.contains("ERR_BAD_AUTHORIZATION"));
+    }
+
+    // -----------------------------------------------------------------------
+    // `escape`'s own coverage, one byte class per test (zuu#763).
+    //
+    // Unlike `f2z-relay`'s `json_string` — whose control and `\u` arms are
+    // unreachable because `WIRE.md` §11.1 restricts the eight operator strings
+    // to printable ASCII and `capabilities::validate` refuses anything else
+    // before the renderer sees it — **every arm here is reachable in
+    // production**. `LogDescriptor::validate` constrains `kt_versions`,
+    // `log_id` and `configuration` and places no restriction whatsoever on the
+    // operator string bytes, so all seven of `operator_name`,
+    // `operator_contact`, `operator_jurisdiction`, `operator_policy_url`,
+    // `source_repo_url`, `source_commit` and `build_digest` arrive at `escape`
+    // exactly as an operator configured them, by way of
+    // `String::from_utf8_lossy` in `crate::descriptor::render`.
+    //
+    // One byte class per test, and each payload holds *only* characters of the
+    // class under test, so a break in one arm cannot be masked by another
+    // arm's bytes in the same assertion — which is precisely how the backslash,
+    // newline and `\u{04x}` arms were all deletable with every dependent crate
+    // green. Each assertion is the whole returned string rather than a
+    // substring: `f2z-kt` hand-renders its JSON (that is what this module is
+    // for) and carries no JSON parser, so these are reviewed literals.
+
+    #[test]
+    fn the_json_escaper_escapes_a_quotation_mark() {
+        assert_eq!(escape("\""), "\\\"");
+    }
+
+    #[test]
+    fn the_json_escaper_escapes_a_backslash() {
+        // A lone backslash that survives unescaped is the field-escape of
+        // zuu#763; `crate::descriptor`'s tests assert the same arm against a
+        // real rendered descriptor field, which is where it actually bites.
+        assert_eq!(escape("\\"), "\\\\");
+    }
+
+    #[test]
+    fn the_json_escaper_escapes_a_newline() {
+        assert_eq!(escape("\n"), "\\n");
+    }
+
+    #[test]
+    fn the_json_escaper_escapes_a_carriage_return() {
+        assert_eq!(escape("\r"), "\\r");
+    }
+
+    #[test]
+    fn the_json_escaper_escapes_a_tab() {
+        assert_eq!(escape("\t"), "\\t");
+    }
+
+    #[test]
+    fn the_json_escaper_passes_the_rest_of_printable_ascii_through_unchanged() {
+        // `0x20..=0x7e` minus the two characters with a short form of their
+        // own, which the two tests above already own.
+        let printable: String = (0x20u8..=0x7e)
+            .filter(|byte| *byte != b'"' && *byte != b'\\')
+            .map(char::from)
+            .collect();
+        assert_eq!(escape(&printable), printable);
+    }
+
+    #[test]
+    fn the_json_escaper_renders_everything_else_as_utf16_code_units() {
+        // The C0 controls with no two-character form, DEL, and every
+        // non-ASCII character.
+        assert_eq!(escape("\u{0}"), "\\u0000");
+        assert_eq!(escape("\u{1f}"), "\\u001f");
+        assert_eq!(escape("\u{7f}"), "\\u007f");
+        assert_eq!(escape("\u{e9}"), "\\u00e9");
+        // U+2028 LINE SEPARATOR: legal unescaped in JSON, illegal unescaped in
+        // a JavaScript string literal. Escaping it is why "conservative on
+        // purpose" is worth the width.
+        assert_eq!(escape("\u{2028}"), "\\u2028");
+        // U+1F600 is astral, so `c.encode_utf16` emits a **surrogate pair** —
+        // two `\u` escapes for one character, which is what RFC 8259 §7
+        // requires and what a JSON reader reassembles.
+        //
+        // This is deliberately NOT what `f2z-relay`'s `json_string` does: that
+        // This is deliberately NOT what `f2z-relay`'s `json_string` does:
+        // that one is byte-wise over `&[u8]` and would render the same
+        // character as its four UTF-8 bytes, `\u00f0\u009f\u0098\u0080`.
+        // Both are correct for their own input type — `&str` here, `&[u8]`
+        // there — and the two renderers are meant to differ. Do not
+        // "align" them.
+        assert_eq!(escape("\u{1f600}"), "\\ud83d\\ude00");
     }
 }


### PR DESCRIPTION
Closes #763.

Test-only. `escape` in `rs/crates/f2z-kt/src/json.rs` is **not touched** — every new test passes against the current implementation as written. Diff is `rs/crates/f2z-kt/src/{json,descriptor}.rs` and nothing else.

## 1. Baseline, re-measured here

`cargo test -p f2z-kt -p f2z-kt-client -p f2z-witness --no-fail-fast` from `rs/`, on `origin/main` @ `1deb992`, before any change:

```
EXIT=0   ok suites=16   passed=127
```

Matches the numbers in the issue exactly.

## 2. Defect reproduced here

Broke the same three arms simultaneously — backslash, `\n`, and the `\u{04x}` UTF-16 fallback — by inverse-checked string replacement:

| | EXIT | ok suites | passed |
|---|---|---|---|
| clean baseline | 0 | 16 | 127 |
| **backslash + `\n` + `\u{04x}` all broken** | **0** | **16** | **127** |

Byte-identical. Confirmed independently of the issue's measurement.

Restored by exact inverse string replacement with an assertion that the replacement matched exactly once (`assert text.count(src) == 1`) — not `git checkout --`. `git diff --stat` was empty afterwards.

## 3. What this PR adds

**`json.rs` — seven tests, one byte class each.** Each payload contains *only* characters of the class under test, so a break in one arm cannot be masked by another arm's bytes in the same assertion. Each assertion is the whole returned string, not a substring — `f2z-kt` hand-renders its JSON and carries no parser, so these are reviewed literals, following the idiom `f2z-relay`'s `caps.rs` established in #761.

The header comment states the reachability honestly, and states the *opposite* of `caps.rs`'s: `LogDescriptor::validate` (`f2z-kt-core/src/descriptor.rs:86`) constrains `kt_versions`, `log_id` and `configuration` and places no restriction on operator string bytes, so **all seven arms are reachable in production** via `render`'s `String::from_utf8_lossy`. No restriction was added to `validate()` or to KT.md — per the issue, that is a separate spec question and adding it here would hide what these tests exist to prove.

**`descriptor.rs` — the field-escape assertion.** `an_operator_name_ending_in_a_backslash_cannot_escape_its_own_field` sets `operator_name` to `free2z\`, signs a real descriptor, and asserts against the **rendered field**:

```rust
assert!(rendered.contains("\"operator_name\":\"free2z\\\\\",\"operator_contact\":"));
assert!(!rendered.contains("\"operator_name\":\"free2z\\\",\"operator_contact\":"));
```

Positive *and* negative, so it fails loudly rather than by omission. This is the assertion whose absence made the bug invisible.

**The misleading name is fixed, not deleted.** `an_operator_string_cannot_escape_its_own_field` → `an_operator_string_cannot_close_its_own_field_with_a_quotation_mark`, body unchanged, with a comment recording why. Renamed rather than widened deliberately: widening it to cover the backslash too would have made one test catch two mutations, which is the thing being fixed.

**UTF-16 pinned.** `escape("\u{1f600}") == "\\ud83d\\ude00"` — a surrogate pair, because `c.encode_utf16` is code-point-wise over `&str`. The comment says in so many words that this deliberately differs from `f2z-relay`'s byte-wise `json_string` (which would render the same character as `ð`), that both are correct for their own input type, and not to "align" them. U+2028 is pinned in the same test with the reason escaping it is worth the width.

## 4. Falsification — every arm mutated individually

One arm broken at a time, full run each time, restored and re-confirmed green between every run (each restore returned `EXIT=0 ok=16 passed=135`).

| mutated arm | EXIT | ok suites | passed | tests reddened |
|---|---|---|---|---|
| `'"'` | 101 | 15 | 132 | 3 |
| `'\\'` | 101 | 15 | 133 | 2 |
| `'\n'` | 101 | 15 | 134 | **1** |
| `'\r'` | 101 | 15 | 134 | **1** |
| `'\t'` | 101 | 15 | 134 | **1** |
| printable passthrough | 101 | 15 | 131 | 4 |
| `\u{04x}` fallback | 101 | 15 | 134 | **1** |

Which tests, verbatim:

```
quote:      descriptor::tests::the_json_rendering_escapes_an_operator_supplied_field
            json::tests::an_operator_string_cannot_close_its_own_field_with_a_quotation_mark
            json::tests::the_json_escaper_escapes_a_quotation_mark
backslash:  descriptor::tests::an_operator_name_ending_in_a_backslash_cannot_escape_its_own_field
            json::tests::the_json_escaper_escapes_a_backslash
newline:    json::tests::the_json_escaper_escapes_a_newline
cr:         json::tests::the_json_escaper_escapes_a_carriage_return
tab:        json::tests::the_json_escaper_escapes_a_tab
printable:  descriptor::tests::an_operator_name_ending_in_a_backslash_cannot_escape_its_own_field
            descriptor::tests::the_json_rendering_escapes_an_operator_supplied_field
            json::tests::an_internal_error_renders_its_code_and_nothing_else
            json::tests::the_json_escaper_passes_the_rest_of_printable_ascii_through_unchanged
ufallback:  json::tests::the_json_escaper_renders_everything_else_as_utf16_code_units
```

**Where I did not reach exactly one, and why — read this rather than the table.**

Taken the other way round, per *test* rather than per *mutation*, all seven new byte-class tests in `json.rs` catch **exactly one mutation each, and it is the right one**. That is the narrowness the issue asked for, and it holds without exception.

The counts above 1 come entirely from tests I was required to keep or to add:

- **quote → 3.** One is my new byte-class test. The other two are the renamed test (which #763 says not to delete) and `the_json_rendering_escapes_an_operator_supplied_field`, which already existed and already used `ev"il`. Getting this to 1 would mean deleting pre-existing coverage to make a number look better, so I left it and am reporting it.
- **backslash → 2.** Both required: the byte-class unit test, and the rendered-field test the issue calls the most important single thing in this PR.
- **printable → 4.** Any test that asserts on a *rendered* string necessarily contains printable characters, so all three descriptor/error-rendering tests notice when printable passthrough breaks. Two of those three pre-date this PR. This is not a masking risk — the printable arm has its own dedicated test that reddens too — but it is not 1, and I am not going to claim it is.

I could have driven backslash and printable to exactly 1 by making the descriptor test's `operator_name` a lone `\` with no printable characters around it. I chose `free2z\` instead: it is the exact scenario from the issue, and it reads as the attack rather than as a fixture tuned to make a metric come out even. Flagging the trade-off rather than burying it.

## 5. Final green run

From `rs/`:

| check | result |
|---|---|
| `cargo fmt --check` | `EXIT=0` |
| `cargo clippy --workspace --all-targets -- -D warnings` | `EXIT=0` |
| `cargo test -p f2z-kt -p f2z-kt-client -p f2z-witness --no-fail-fast` | `EXIT=0`, **16** ok suites, **135** passed (was 127; +8 tests) |
| `cargo test --workspace --no-fail-fast` | `EXIT=0`, **84** `test result: ok` suites, **1089** passed |

## Scope compliance

- `rs/` only — nothing under `wallet/`, `.github/workflows/zuuli*`, or `z/` (`git status --porcelain` shows the two files above and nothing else), so the release audit anchor is untouched.
- No `f2z-relay` files changed (#678 is being worked concurrently there).
- No restriction added to `LogDescriptor::validate()` or KT.md.
- No production behaviour change; `escape` is byte-for-byte as it was on `main`. Nothing had to be adjusted to make a test pass, so there is no second finding to report.

https://claude.ai/code/session_01NMwYnLDGotB9Ph4NgDFNeD
