### PR TITLE
feat(zuuli): add fail-closed first-contact messaging UI

### DIFF
--- a/wallet/zuuli/src/features/messages/FirstContact.test.tsx
+++ b/wallet/zuuli/src/features/messages/FirstContact.test.tsx
@@ -1,0 +1,301 @@
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { Simulate } from "react-dom/test-utils";
+import { parseHTML } from "linkedom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ContactRequest,
+  Conversation,
+} from "@/lib/messaging/types";
+
+const controls = vi.hoisted(() => ({
+  startConversation: vi.fn(),
+  listContactRequests: vi.fn(),
+  acceptContactRequest: vi.fn(),
+  rejectContactRequest: vi.fn(),
+  listen: vi.fn(),
+}));
+
+vi.mock("@/lib/messaging/bridge", () => ({
+  messaging: {
+    startConversation: controls.startConversation,
+    listContactRequests: controls.listContactRequests,
+    acceptContactRequest: controls.acceptContactRequest,
+    rejectContactRequest: controls.rejectContactRequest,
+  },
+}));
+vi.mock("@/lib/messaging/events", () => ({
+  listenMessaging: controls.listen,
+}));
+
+import { FirstContact } from "./FirstContact";
+
+const REQUEST: ContactRequest = {
+  requestId: "req-1",
+  peerHandle: "newcomer",
+  peerIdentityFingerprint: "2B8F 60C1 D4A7 39E5",
+  receivedAt: 1,
+  bodyPreview: null,
+};
+
+const CONVERSATION: Conversation = {
+  conversationId: "conv-newcomer",
+  peerHandle: "newcomer",
+  peerIdentityFingerprint: REQUEST.peerIdentityFingerprint,
+  verification: { state: "unverified" },
+  epoch: 1,
+  createdAt: 1,
+  lastMessageAt: null,
+  unreadCount: 0,
+  retention: {
+    scope: "global",
+    mode: "keep",
+    ttlSeconds: null,
+    effectiveFrom: 1,
+  },
+  ephemeralHint: null,
+  receiptPolicy: { deliveryReceipts: true, readReceipts: false },
+  hasGaps: false,
+  transportHealth: "ok",
+};
+
+let root: Root;
+let container: HTMLElement;
+let restoreGlobals: () => void;
+let listeners: Map<string, () => void>;
+let unlisteners: Map<string, ReturnType<typeof vi.fn>>;
+
+async function installDom() {
+  const { window, document } = parseHTML(
+    "<!doctype html><html><body><div id='root'></div></body></html>",
+  );
+  const saved = new Map<string, PropertyDescriptor | undefined>();
+  for (const [name, value] of Object.entries({
+    window,
+    document,
+    navigator: window.navigator,
+    HTMLElement: window.HTMLElement,
+    Event: window.Event,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })) {
+    saved.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+  restoreGlobals = () => {
+    for (const [name, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else delete (globalThis as Record<string, unknown>)[name];
+    }
+  };
+  container = document.getElementById("root") as unknown as HTMLElement;
+  const { createRoot } = await import("react-dom/client");
+  root = createRoot(container);
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = Array.from(container.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!found) throw new Error(`button not found: ${label}`);
+  return found;
+}
+
+async function enterHandle(value: string) {
+  const input = container.querySelector("input")!;
+  await act(async () => {
+    Simulate.change(input, { target: { value } } as never);
+  });
+}
+
+function submit() {
+  container
+    .querySelector("form")!
+    .dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+}
+
+async function renderFirstContact(
+  overrides: Partial<React.ComponentProps<typeof FirstContact>> = {},
+) {
+  const props: React.ComponentProps<typeof FirstContact> = {
+    engineRunning: true,
+    witnessThresholdMet: true,
+    onConversation: vi.fn(),
+    onStateChanged: vi.fn(async () => {}),
+    ...overrides,
+  };
+  await act(async () => root.render(<FirstContact {...props} />));
+  await vi.waitFor(() =>
+    expect(controls.listContactRequests).toHaveBeenCalled(),
+  );
+  return props;
+}
+
+beforeEach(async () => {
+  listeners = new Map();
+  unlisteners = new Map();
+  controls.startConversation.mockReset().mockResolvedValue(CONVERSATION);
+  controls.listContactRequests.mockReset().mockResolvedValue([]);
+  controls.acceptContactRequest.mockReset().mockResolvedValue(CONVERSATION);
+  controls.rejectContactRequest.mockReset().mockResolvedValue(undefined);
+  controls.listen.mockReset().mockImplementation(async (event, handler) => {
+    const unlisten = vi.fn();
+    listeners.set(event, handler);
+    unlisteners.set(event, unlisten);
+    return unlisten;
+  });
+  await installDom();
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root.unmount());
+  restoreGlobals?.();
+});
+
+describe("ZUULI first contact", () => {
+  it.each([
+    "",
+    "Alice",
+    " alice",
+    "alice ",
+    "@alice",
+    "álîce",
+    "a".repeat(31),
+    "alice-bob",
+  ])("rejects %j locally without rewriting or invoking it", async (value) => {
+    await renderFirstContact();
+    await enterHandle(value);
+    expect(button("Start chat").disabled).toBe(true);
+    await act(async () => button("Start chat").click());
+    expect(controls.startConversation).not.toHaveBeenCalled();
+  });
+
+  it("passes an exact valid handle once and selects the returned conversation", async () => {
+    const onConversation = vi.fn();
+    const onStateChanged = vi.fn(async () => {});
+    await renderFirstContact({ onConversation, onStateChanged });
+    await enterHandle("alice_123");
+    await act(async () => submit());
+    await vi.waitFor(() =>
+      expect(controls.startConversation).toHaveBeenCalledWith("alice_123"),
+    );
+    expect(controls.startConversation).toHaveBeenCalledTimes(1);
+    expect(onConversation).toHaveBeenCalledWith(CONVERSATION);
+    expect(onStateChanged).toHaveBeenCalled();
+  });
+
+  it("keeps proof-of-work single-flight even across two clicks in one turn", async () => {
+    let resolveStart: (conversation: Conversation) => void = () => {};
+    controls.startConversation.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    await renderFirstContact();
+    await enterHandle("alice");
+    await act(async () => {
+      submit();
+      submit();
+    });
+    expect(controls.startConversation).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("Computing on this device…");
+    expect(container.textContent).toContain("proof of work on this device");
+    await act(async () => resolveStart(CONVERSATION));
+  });
+
+  it("fails closed below the witness threshold while preserving local rejection", async () => {
+    controls.listContactRequests.mockResolvedValue([REQUEST]);
+    await renderFirstContact({ witnessThresholdMet: false });
+    await enterHandle("alice");
+    expect(button("Start chat").disabled).toBe(true);
+    expect(button("Accept").disabled).toBe(true);
+    expect(button("Reject").disabled).toBe(false);
+    expect(container.textContent).toContain(
+      "Existing conversations remain available.",
+    );
+    await act(async () => {
+      button("Start chat").click();
+      button("Accept").click();
+    });
+    expect(controls.startConversation).not.toHaveBeenCalled();
+    expect(controls.acceptContactRequest).not.toHaveBeenCalled();
+  });
+
+  it("shows request identity, accepts it, and selects only the command result", async () => {
+    controls.listContactRequests.mockResolvedValue([REQUEST]);
+    const onConversation = vi.fn();
+    await renderFirstContact({ onConversation });
+    expect(container.textContent).toContain("@newcomer");
+    expect(container.textContent).toContain(REQUEST.peerIdentityFingerprint);
+    await act(async () => button("Accept").click());
+    await vi.waitFor(() =>
+      expect(controls.acceptContactRequest).toHaveBeenCalledWith("req-1"),
+    );
+    expect(onConversation).toHaveBeenCalledWith(CONVERSATION);
+  });
+
+  it("keeps rejection and device-local blocking as distinct bridge calls", async () => {
+    controls.listContactRequests.mockResolvedValue([REQUEST]);
+    await renderFirstContact();
+    expect(container.textContent).toContain("Block on this device");
+    await act(async () => button("Reject").click());
+    await vi.waitFor(() =>
+      expect(controls.rejectContactRequest).toHaveBeenCalledWith("req-1", false),
+    );
+    await act(async () => button("Block on this device").click());
+    await vi.waitFor(() =>
+      expect(controls.rejectContactRequest).toHaveBeenCalledWith("req-1", true),
+    );
+  });
+
+  it.each(["f2zmsg://contact-request", "f2zmsg://conversation-updated"])(
+    "treats %s as a signal and re-reads both authoritative views",
+    async (event) => {
+      const onStateChanged = vi.fn(async () => {});
+      await renderFirstContact({ onStateChanged });
+      controls.listContactRequests.mockClear().mockResolvedValue([REQUEST]);
+      onStateChanged.mockClear();
+
+      await act(async () => listeners.get(event)?.());
+      await vi.waitFor(() =>
+        expect(controls.listContactRequests).toHaveBeenCalledTimes(1),
+      );
+      expect(onStateChanged).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("@newcomer");
+    },
+  );
+
+  it("cleans up listeners that finish attaching after unmount", async () => {
+    const resolvers: Array<(unlisten: () => void) => void> = [];
+    controls.listen.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    await renderFirstContact();
+    await act(async () => root.unmount());
+    const late = [vi.fn(), vi.fn()];
+    await act(async () => {
+      resolvers.forEach((resolve, index) => resolve(late[index]));
+      await Promise.resolve();
+    });
+    expect(late[0]).toHaveBeenCalledTimes(1);
+    expect(late[1]).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps request state visible when a bare bridge error is refused", async () => {
+    controls.listContactRequests.mockResolvedValue([REQUEST]);
+    controls.startConversation.mockRejectedValue("directory-unreachable");
+    await renderFirstContact();
+    await enterHandle("alice");
+    await act(async () => submit());
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain("directory-unreachable"),
+    );
+    expect(container.textContent).toContain("@newcomer");
+  });
+});

--- a/wallet/zuuli/src/features/messages/FirstContact.test.tsx
+++ b/wallet/zuuli/src/features/messages/FirstContact.test.tsx
@@ -33,7 +33,8 @@ import { FirstContact } from "./FirstContact";
 const REQUEST: ContactRequest = {
   requestId: "req-1",
   peerHandle: "newcomer",
-  peerIdentityFingerprint: "2B8F 60C1 D4A7 39E5",
+  peerIdentityFingerprint:
+    "2b8f60c1d4a739e50f2687bd4c319a0e9123a456b789c012d345e678f9012345",
   receivedAt: 1,
   bodyPreview: null,
 };
@@ -229,7 +230,13 @@ describe("ZUULI first contact", () => {
     const onConversation = vi.fn();
     await renderFirstContact({ onConversation });
     expect(container.textContent).toContain("@newcomer");
-    expect(container.textContent).toContain(REQUEST.peerIdentityFingerprint);
+    expect(container.textContent).toContain(
+      "2B8F6 0C1D4 A739E 50F26 87BD4 C319A 0E912 3A456 B789C 012D3 45E67 8F901 2345",
+    );
+    expect(container.textContent).toContain("Unverified identity key claimed");
+    expect(container.textContent).toContain(
+      "Directory confirmation happens only if you accept",
+    );
     await act(async () => button("Accept").click());
     await vi.waitFor(() =>
       expect(controls.acceptContactRequest).toHaveBeenCalledWith("req-1"),
@@ -276,7 +283,14 @@ describe("ZUULI first contact", () => {
           resolvers.push(resolve);
         }),
     );
-    await renderFirstContact();
+    await act(async () => root.render(
+      <FirstContact
+        engineRunning
+        witnessThresholdMet
+        onConversation={vi.fn()}
+        onStateChanged={vi.fn(async () => {})}
+      />,
+    ));
     await act(async () => root.unmount());
     const late = [vi.fn(), vi.fn()];
     await act(async () => {
@@ -285,6 +299,121 @@ describe("ZUULI first contact", () => {
     });
     expect(late[0]).toHaveBeenCalledTimes(1);
     expect(late[1]).toHaveBeenCalledTimes(1);
+  });
+
+  it("attaches both event listeners before the initial authoritative read", async () => {
+    const listenerResolvers: Array<(unlisten: () => void) => void> = [];
+    controls.listen.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          listenerResolvers.push(resolve);
+        }),
+    );
+    controls.listContactRequests.mockClear();
+    await act(async () => root.render(
+      <FirstContact
+        engineRunning
+        witnessThresholdMet
+        onConversation={vi.fn()}
+        onStateChanged={vi.fn(async () => {})}
+      />,
+    ));
+    expect(controls.listContactRequests).not.toHaveBeenCalled();
+    controls.listContactRequests.mockResolvedValue([REQUEST]);
+    await act(async () => {
+      listenerResolvers.forEach((resolve) => resolve(vi.fn()));
+      await Promise.resolve();
+    });
+    await vi.waitFor(() =>
+      expect(controls.listContactRequests).toHaveBeenCalledTimes(1),
+    );
+    expect(container.textContent).toContain("@newcomer");
+  });
+
+  it("does not let an older contact-request read resurrect stale state", async () => {
+    const reads: Array<(requests: ContactRequest[]) => void> = [];
+    controls.listContactRequests.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          reads.push(resolve);
+        }),
+    );
+    await act(async () => root.render(
+      <FirstContact
+        engineRunning
+        witnessThresholdMet
+        onConversation={vi.fn()}
+        onStateChanged={vi.fn(async () => {})}
+      />,
+    ));
+    await vi.waitFor(() => expect(reads).toHaveLength(1));
+    await act(async () =>
+      window.dispatchEvent(new window.Event("focus")),
+    );
+    await vi.waitFor(() => expect(reads).toHaveLength(2));
+    await act(async () => reads[1]([]));
+    expect(container.textContent).not.toContain("@newcomer");
+    await act(async () => reads[0]([REQUEST]));
+    expect(container.textContent).not.toContain("@newcomer");
+  });
+
+  it.each([
+    [
+      "directory-proof-invalid",
+      "Directory proof failed",
+      "cryptographic verification failed",
+    ],
+    [
+      "witness-threshold-unmet",
+      "Independent witness threshold not met",
+      "compare safety numbers",
+    ],
+    [
+      "directory-protocol-violation",
+      "Messaging defect",
+      "report this error code",
+    ],
+    [
+      "directory-unreachable",
+      "First contact can be retried",
+      "directory could not be reached",
+    ],
+  ])("renders the actionable security meaning of %s", async (code, title, copy) => {
+    controls.startConversation.mockRejectedValue(code);
+    await renderFirstContact();
+    await enterHandle("alice");
+    await act(async () => submit());
+    await vi.waitFor(() => expect(container.textContent).toContain(title));
+    expect(container.textContent?.toLowerCase()).toContain(copy.toLowerCase());
+    expect(container.textContent).toContain(code);
+  });
+
+  it("clears a stale load refusal after a later authoritative read succeeds", async () => {
+    controls.listContactRequests
+      .mockRejectedValueOnce("directory-unreachable")
+      .mockResolvedValueOnce([REQUEST]);
+    await renderFirstContact();
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain("directory-unreachable"),
+    );
+    await act(async () =>
+      window.dispatchEvent(new window.Event("focus")),
+    );
+    await vi.waitFor(() => expect(container.textContent).toContain("@newcomer"));
+    expect(container.textContent).not.toContain("directory-unreachable");
+  });
+
+  it("announces multi-second proof-of-work progress accessibly", async () => {
+    controls.startConversation.mockReturnValue(new Promise(() => {}));
+    await renderFirstContact();
+    await enterHandle("alice");
+    await act(async () => submit());
+    const status = container.querySelector('[role="status"]');
+    expect(status?.getAttribute("aria-live")).toBe("polite");
+    expect(status?.textContent).toContain("Computing proof of work on this device");
+    expect(container.querySelector("form")?.getAttribute("aria-busy")).toBe(
+      "true",
+    );
   });
 
   it("keeps request state visible when a bare bridge error is refused", async () => {

--- a/wallet/zuuli/src/features/messages/FirstContact.tsx
+++ b/wallet/zuuli/src/features/messages/FirstContact.tsx
@@ -10,6 +10,7 @@ import {
   HANDLE_PATTERN,
   type ContactRequest,
   type Conversation,
+  type ErrorCode,
 } from "@/lib/messaging/types";
 
 interface FirstContactProps {
@@ -19,9 +20,87 @@ interface FirstContactProps {
   onStateChanged: () => Promise<void>;
 }
 
-function refusalCode(error: unknown): string {
+function refusalCode(error: unknown): ErrorCode {
   const parsed = ErrorCodeSchema.safeParse(error);
   return parsed.success ? parsed.data : "internal";
+}
+
+function errorPresentation(code: ErrorCode): {
+  title: string;
+  body: string;
+  tone: "warning" | "destructive";
+} {
+  if (code === "directory-proof-invalid") {
+    return {
+      title: "Directory proof failed",
+      body:
+        "Cryptographic verification failed. First contact stopped; do not retry through another directory. Review the security alarms before proceeding.",
+      tone: "destructive",
+    };
+  }
+  if (code === "witness-threshold-unmet") {
+    return {
+      title: "Independent witness threshold not met",
+      body:
+        "First contact remains blocked. You can compare safety numbers over a channel you already trust; existing conversations continue.",
+      tone: "warning",
+    };
+  }
+  if (
+    code === "directory-protocol-violation" ||
+    code === "relay-protocol-violation" ||
+    code === "internal"
+  ) {
+    return {
+      title: "Messaging defect",
+      body:
+        "ZUULI or a service returned an invalid result. Update ZUULI and report this error code; do not retry it automatically.",
+      tone: "destructive",
+    };
+  }
+  if (code === "directory-unreachable") {
+    return {
+      title: "First contact can be retried",
+      body:
+        "The directory could not be reached. Existing conversations are unaffected; try first contact again after connectivity returns.",
+      tone: "warning",
+    };
+  }
+  if (
+    code === "directory-rate-limited" ||
+    code === "directory-version-conflict" ||
+    code === "relay-unreachable" ||
+    code === "relay-rate-limited" ||
+    code === "relay-backpressure" ||
+    code === "send-unavailable" ||
+    code === "pow-required" ||
+    code === "pow-failed"
+  ) {
+    return {
+      title: "First contact can be retried",
+      body:
+        "The temporary attempt did not complete. Wait before trying again; established conversations are unaffected.",
+      tone: "warning",
+    };
+  }
+  if (code === "engine-not-running") {
+    return {
+      title: "Messaging engine stopped",
+      body: "Start the messaging engine, then try first contact once more.",
+      tone: "warning",
+    };
+  }
+  return {
+    title: "First contact stopped",
+    body:
+      "ZUULI did not establish or accept this contact. Resolve the condition named by the error code before trying again.",
+    tone: "destructive",
+  };
+}
+
+function formatClaimedIdentityKey(value: string): string {
+  if (!/^[0-9a-f]{64}$/i.test(value)) return "Invalid key encoding";
+  return value.toUpperCase().match(/.{1,5}/g)?.join(" ") ?? value;
 }
 
 /**
@@ -40,32 +119,44 @@ export function FirstContact({
   const [handle, setHandle] = useState("");
   const [requests, setRequests] = useState<ContactRequest[] | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<ErrorCode | null>(null);
+  const [requestLoadError, setRequestLoadError] = useState<ErrorCode | null>(
+    null,
+  );
+  const [conversationLoadError, setConversationLoadError] =
+    useState<ErrorCode | null>(null);
   const busyRef = useRef<string | null>(null);
+  const requestReadGeneration = useRef(0);
+  const conversationReadGeneration = useRef(0);
 
   const loadRequests = useCallback(async () => {
+    const generation = ++requestReadGeneration.current;
     try {
-      setRequests(await messaging.listContactRequests());
+      const next = await messaging.listContactRequests();
+      if (generation !== requestReadGeneration.current) return;
+      setRequests(next);
+      setRequestLoadError(null);
     } catch (cause) {
-      setError(refusalCode(cause));
+      if (generation !== requestReadGeneration.current) return;
+      setRequestLoadError(refusalCode(cause));
     }
   }, []);
 
-  const reconcileAfterSignal = useCallback(async () => {
+  const loadConversations = useCallback(async () => {
+    const generation = ++conversationReadGeneration.current;
     try {
-      const [nextRequests] = await Promise.all([
-        messaging.listContactRequests(),
-        onStateChanged(),
-      ]);
-      setRequests(nextRequests);
+      await onStateChanged();
+      if (generation !== conversationReadGeneration.current) return;
+      setConversationLoadError(null);
     } catch (cause) {
-      setError(refusalCode(cause));
+      if (generation !== conversationReadGeneration.current) return;
+      setConversationLoadError(refusalCode(cause));
     }
   }, [onStateChanged]);
 
-  useEffect(() => {
-    void loadRequests();
-  }, [loadRequests]);
+  const reconcileAfterSignal = useCallback(async () => {
+    await Promise.all([loadRequests(), loadConversations()]);
+  }, [loadConversations, loadRequests]);
 
   // Events are only signals. Their payloads are deliberately ignored and both
   // authoritative views are re-read (§5.2); appending either payload directly
@@ -74,16 +165,24 @@ export function FirstContact({
     let disposed = false;
     const unlisteners: Array<() => void> = [];
 
-    const attach = (promise: Promise<() => void>) => {
-      void promise.then((unlisten) => {
-        if (disposed) unlisten();
-        else unlisteners.push(unlisten);
-      });
-    };
-
     const reread = () => void reconcileAfterSignal();
-    attach(listenMessaging("f2zmsg://contact-request", reread));
-    attach(listenMessaging("f2zmsg://conversation-updated", reread));
+    void Promise.all([
+      listenMessaging("f2zmsg://contact-request", reread),
+      listenMessaging("f2zmsg://conversation-updated", reread),
+    ])
+      .then((attached) => {
+        if (disposed) {
+          for (const unlisten of attached) unlisten();
+          return;
+        }
+        unlisteners.push(...attached);
+        // The read starts only after both subscriptions exist. Anything that
+        // landed during async attachment is therefore included here.
+        void reconcileAfterSignal();
+      })
+      .catch((cause) => {
+        if (!disposed) setConversationLoadError(refusalCode(cause));
+      });
 
     const onFocus = () => void loadRequests();
     const onVisibility = () => {
@@ -94,6 +193,8 @@ export function FirstContact({
 
     return () => {
       disposed = true;
+      requestReadGeneration.current += 1;
+      conversationReadGeneration.current += 1;
       for (const unlisten of unlisteners) unlisten();
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onVisibility);
@@ -108,12 +209,12 @@ export function FirstContact({
       if (busyRef.current !== null) return;
       busyRef.current = key;
       setBusy(key);
-      setError(null);
+      setActionError(null);
       try {
         await action();
         await reconcileAfterSignal();
       } catch (cause) {
-        setError(refusalCode(cause));
+        setActionError(refusalCode(cause));
       } finally {
         busyRef.current = null;
         setBusy(null);
@@ -152,6 +253,9 @@ export function FirstContact({
     [run],
   );
 
+  const error = actionError ?? conversationLoadError ?? requestLoadError;
+  const presentedError = error ? errorPresentation(error) : null;
+
   return (
     <section className="space-y-4" aria-labelledby="first-contact-title">
       <div className="rounded-xl border border-border bg-card p-5">
@@ -167,6 +271,7 @@ export function FirstContact({
 
         <form
           className="flex flex-col gap-2 sm:flex-row"
+          aria-busy={busy === "start"}
           onSubmit={(event) => {
             event.preventDefault();
             void start();
@@ -198,6 +303,17 @@ export function FirstContact({
           </Button>
         </form>
 
+        {busy === "start" ? (
+          <p
+            className="mt-2 text-sm text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
+            Computing proof of work on this device. This can take several
+            seconds.
+          </p>
+        ) : null}
+
         {handle.length > 0 && !validHandle ? (
           <p className="mt-2 text-sm text-destructive" role="alert">
             Use 1–30 lowercase letters, numbers, or underscores, without an @.
@@ -216,9 +332,14 @@ export function FirstContact({
         ) : null}
       </div>
 
-      {error ? (
-        <Callout tone="destructive" title="First contact was refused" role="alert">
-          Messaging error: <span className="mono-id">{error}</span>
+      {error && presentedError ? (
+        <Callout
+          tone={presentedError.tone}
+          title={presentedError.title}
+          role="alert"
+        >
+          {presentedError.body} Error code:{" "}
+          <span className="mono-id">{error}</span>
         </Callout>
       ) : null}
 
@@ -237,10 +358,14 @@ export function FirstContact({
                     @{request.peerHandle}
                   </p>
                   <p className="mt-1 text-xs text-muted-foreground">
-                    Identity fingerprint
+                    Unverified identity key claimed by this request
                   </p>
                   <p className="mono-id break-all text-sm text-foreground">
-                    {request.peerIdentityFingerprint}
+                    {formatClaimedIdentityKey(request.peerIdentityFingerprint)}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Directory confirmation happens only if you accept. Compare
+                    safety numbers afterward over a channel you already trust.
                   </p>
                   <div className="mt-4 flex flex-wrap gap-2">
                     <Button

--- a/wallet/zuuli/src/features/messages/FirstContact.tsx
+++ b/wallet/zuuli/src/features/messages/FirstContact.tsx
@@ -1,0 +1,290 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Ban, Loader2, MessageCirclePlus, UserPlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
+import { Input } from "@/components/ui/input";
+import { messaging } from "@/lib/messaging/bridge";
+import { listenMessaging } from "@/lib/messaging/events";
+import {
+  ErrorCodeSchema,
+  HANDLE_PATTERN,
+  type ContactRequest,
+  type Conversation,
+} from "@/lib/messaging/types";
+
+interface FirstContactProps {
+  engineRunning: boolean;
+  witnessThresholdMet: boolean;
+  onConversation: (conversation: Conversation) => void;
+  onStateChanged: () => Promise<void>;
+}
+
+function refusalCode(error: unknown): string {
+  const parsed = ErrorCodeSchema.safeParse(error);
+  return parsed.success ? parsed.data : "internal";
+}
+
+/**
+ * The first-contact surface from CLIENT-CONTRACT.md §3.3.
+ *
+ * Handles are passed byte-for-byte. In particular, this component never trims,
+ * case-folds, normalizes, or strips an `@`: the directory's exact ASCII
+ * predicate is the security boundary, not a suggestion for presentation.
+ */
+export function FirstContact({
+  engineRunning,
+  witnessThresholdMet,
+  onConversation,
+  onStateChanged,
+}: FirstContactProps) {
+  const [handle, setHandle] = useState("");
+  const [requests, setRequests] = useState<ContactRequest[] | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const busyRef = useRef<string | null>(null);
+
+  const loadRequests = useCallback(async () => {
+    try {
+      setRequests(await messaging.listContactRequests());
+    } catch (cause) {
+      setError(refusalCode(cause));
+    }
+  }, []);
+
+  const reconcileAfterSignal = useCallback(async () => {
+    try {
+      const [nextRequests] = await Promise.all([
+        messaging.listContactRequests(),
+        onStateChanged(),
+      ]);
+      setRequests(nextRequests);
+    } catch (cause) {
+      setError(refusalCode(cause));
+    }
+  }, [onStateChanged]);
+
+  useEffect(() => {
+    void loadRequests();
+  }, [loadRequests]);
+
+  // Events are only signals. Their payloads are deliberately ignored and both
+  // authoritative views are re-read (§5.2); appending either payload directly
+  // would lose coalesced events and duplicate later reconciliation reads.
+  useEffect(() => {
+    let disposed = false;
+    const unlisteners: Array<() => void> = [];
+
+    const attach = (promise: Promise<() => void>) => {
+      void promise.then((unlisten) => {
+        if (disposed) unlisten();
+        else unlisteners.push(unlisten);
+      });
+    };
+
+    const reread = () => void reconcileAfterSignal();
+    attach(listenMessaging("f2zmsg://contact-request", reread));
+    attach(listenMessaging("f2zmsg://conversation-updated", reread));
+
+    const onFocus = () => void loadRequests();
+    const onVisibility = () => {
+      if (document.visibilityState !== "hidden") void loadRequests();
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      disposed = true;
+      for (const unlisten of unlisteners) unlisten();
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [loadRequests, reconcileAfterSignal]);
+
+  const canEstablish = engineRunning && witnessThresholdMet;
+  const validHandle = HANDLE_PATTERN.test(handle);
+
+  const run = useCallback(
+    async (key: string, action: () => Promise<void>) => {
+      if (busyRef.current !== null) return;
+      busyRef.current = key;
+      setBusy(key);
+      setError(null);
+      try {
+        await action();
+        await reconcileAfterSignal();
+      } catch (cause) {
+        setError(refusalCode(cause));
+      } finally {
+        busyRef.current = null;
+        setBusy(null);
+      }
+    },
+    [reconcileAfterSignal],
+  );
+
+  const start = useCallback(async () => {
+    // Repeat both gates at the action boundary. Disabled controls are UX, not
+    // authority, and a stale event must not let a click proceed silently.
+    if (!canEstablish || !validHandle) return;
+    await run("start", async () => {
+      const conversation = await messaging.startConversation(handle);
+      onConversation(conversation);
+      setHandle("");
+    });
+  }, [canEstablish, handle, onConversation, run, validHandle]);
+
+  const accept = useCallback(
+    async (requestId: string) => {
+      if (!canEstablish) return;
+      await run(`accept:${requestId}`, async () => {
+        onConversation(await messaging.acceptContactRequest(requestId));
+      });
+    },
+    [canEstablish, onConversation, run],
+  );
+
+  const reject = useCallback(
+    async (requestId: string, block: boolean) => {
+      await run(`${block ? "block" : "reject"}:${requestId}`, () =>
+        messaging.rejectContactRequest(requestId, block),
+      );
+    },
+    [run],
+  );
+
+  return (
+    <section className="space-y-4" aria-labelledby="first-contact-title">
+      <div className="rounded-xl border border-border bg-card p-5">
+        <div className="mb-4">
+          <h2 id="first-contact-title" className="font-medium text-foreground">
+            Start a conversation
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Enter an exact messaging handle. Establishing first contact computes
+            proof of work on this device and can take several seconds.
+          </p>
+        </div>
+
+        <form
+          className="flex flex-col gap-2 sm:flex-row"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void start();
+          }}
+        >
+          <label className="sr-only" htmlFor="first-contact-handle">
+            Messaging handle
+          </label>
+          <Input
+            id="first-contact-handle"
+            value={handle}
+            onChange={(event) => setHandle(event.target.value)}
+            placeholder="alice_123"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            aria-invalid={handle.length > 0 && !validHandle}
+          />
+          <Button
+            type="submit"
+            disabled={!canEstablish || !validHandle || busy !== null}
+          >
+            {busy === "start" ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+            ) : (
+              <MessageCirclePlus className="size-4" aria-hidden />
+            )}
+            {busy === "start" ? "Computing on this device…" : "Start chat"}
+          </Button>
+        </form>
+
+        {handle.length > 0 && !validHandle ? (
+          <p className="mt-2 text-sm text-destructive" role="alert">
+            Use 1–30 lowercase letters, numbers, or underscores, without an @.
+          </p>
+        ) : null}
+
+        {!engineRunning ? (
+          <p className="mt-2 text-sm text-muted-foreground">
+            Start the messaging engine before establishing first contact.
+          </p>
+        ) : !witnessThresholdMet ? (
+          <p className="mt-2 text-sm text-muted-foreground">
+            First contact is unavailable until the independent witness threshold
+            is met. Existing conversations remain available.
+          </p>
+        ) : null}
+      </div>
+
+      {error ? (
+        <Callout tone="destructive" title="First contact was refused" role="alert">
+          Messaging error: <span className="mono-id">{error}</span>
+        </Callout>
+      ) : null}
+
+      {requests && requests.length > 0 ? (
+        <div className="space-y-3">
+          <h2 className="font-medium text-foreground">Contact requests</h2>
+          <ul className="space-y-3">
+            {requests.map((request) => {
+              const requestBusy = busy?.endsWith(`:${request.requestId}`) ?? false;
+              return (
+                <li
+                  key={request.requestId}
+                  className="rounded-xl border border-border bg-card p-4"
+                >
+                  <p className="mono-id font-medium text-foreground">
+                    @{request.peerHandle}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Identity fingerprint
+                  </p>
+                  <p className="mono-id break-all text-sm text-foreground">
+                    {request.peerIdentityFingerprint}
+                  </p>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      disabled={!canEstablish || busy !== null}
+                      onClick={() => void accept(request.requestId)}
+                    >
+                      {requestBusy && busy?.startsWith("accept:") ? (
+                        <Loader2 className="size-4 animate-spin" aria-hidden />
+                      ) : (
+                        <UserPlus className="size-4" aria-hidden />
+                      )}
+                      Accept
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={busy !== null}
+                      onClick={() => void reject(request.requestId, false)}
+                    >
+                      Reject
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={busy !== null}
+                      onClick={() => void reject(request.requestId, true)}
+                    >
+                      <Ban className="size-4" aria-hidden />
+                      Block on this device
+                    </Button>
+                  </div>
+                  {!witnessThresholdMet ? (
+                    <p className="mt-3 text-sm text-muted-foreground">
+                      Acceptance waits for the independent witness threshold;
+                      rejecting or blocking locally is still available.
+                    </p>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/wallet/zuuli/src/features/messages/index.reconciliation.test.tsx
+++ b/wallet/zuuli/src/features/messages/index.reconciliation.test.tsx
@@ -1,0 +1,163 @@
+import { act } from "react";
+import type { Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Conversation,
+  DeviceInfo,
+  EngineStatus,
+  EnrollmentStatus,
+} from "@/lib/messaging/types";
+
+const controls = vi.hoisted(() => ({
+  getEngineStatus: vi.fn(),
+  getEnrollmentStatus: vi.fn(),
+  getDeviceInfo: vi.fn(),
+  listConversations: vi.fn(),
+  listen: vi.fn(async () => vi.fn()),
+}));
+
+vi.mock("@/lib/messaging/bridge", () => ({
+  messaging: {
+    getEngineStatus: controls.getEngineStatus,
+    getDeviceInfo: controls.getDeviceInfo,
+    listConversations: controls.listConversations,
+  },
+  enrollment: { getEnrollmentStatus: controls.getEnrollmentStatus },
+}));
+vi.mock("@/lib/messaging/events", () => ({ listenMessaging: controls.listen }));
+vi.mock("./BrowserGuarantee", () => ({ BrowserGuarantee: () => null }));
+vi.mock("./FirstContact", () => ({ FirstContact: () => null }));
+vi.mock("./Transcript", () => ({
+  Transcript: ({ conversation }: { conversation: Conversation }) => (
+    <p data-transcript>{conversation.peerHandle}</p>
+  ),
+}));
+
+import MessagesFeature from "./index";
+
+const STATUS: EngineStatus = {
+  state: "running",
+  enrolled: true,
+  handle: "self",
+  relaysConnected: 1,
+  relaysConfigured: 1,
+  witnessThresholdMet: true,
+  independentWitnesses: 2,
+  pendingInbound: 0,
+  unacknowledgedAlarms: 0,
+  lastError: null,
+};
+const ENROLLMENT: EnrollmentStatus = {
+  enrolled: true,
+  handle: "self",
+  eligibility: { eligible: true, candidate: "self", reason: null },
+  directoryEntryVersion: 1,
+  submittedAt: 1,
+  mergedAtEpoch: 1,
+  blocked: null,
+};
+const DEVICE: DeviceInfo = {
+  deviceId: "device",
+  deviceFingerprint: "AAAAA",
+  identityFingerprint: "BBBBB",
+  createdAt: 1,
+  platform: "zuuli-desktop",
+  durability: "durable",
+};
+
+function conversation(peerHandle: string): Conversation {
+  return {
+    conversationId: `conv-${peerHandle}`,
+    peerHandle,
+    peerIdentityFingerprint: "CCCCC",
+    verification: { state: "unverified" },
+    epoch: 1,
+    createdAt: 1,
+    lastMessageAt: null,
+    unreadCount: 0,
+    retention: {
+      scope: "global",
+      mode: "keep",
+      ttlSeconds: null,
+      effectiveFrom: 1,
+    },
+    ephemeralHint: null,
+    receiptPolicy: { deliveryReceipts: true, readReceipts: false },
+    hasGaps: false,
+    transportHealth: "ok",
+  };
+}
+
+let root: Root;
+let container: HTMLElement;
+let restoreGlobals: () => void;
+
+beforeEach(async () => {
+  const { window, document } = parseHTML(
+    "<!doctype html><html><body><div id='root'></div></body></html>",
+  );
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { protocol: "http:" },
+  });
+  const saved = new Map<string, PropertyDescriptor | undefined>();
+  for (const [name, value] of Object.entries({
+    window,
+    document,
+    navigator: window.navigator,
+    HTMLElement: window.HTMLElement,
+    Event: window.Event,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })) {
+    saved.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+  restoreGlobals = () => {
+    for (const [name, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else delete (globalThis as Record<string, unknown>)[name];
+    }
+  };
+  container = document.getElementById("root") as unknown as HTMLElement;
+  const { createRoot } = await import("react-dom/client");
+  root = createRoot(container);
+  controls.getEngineStatus.mockReset().mockResolvedValue(STATUS);
+  controls.getEnrollmentStatus.mockReset().mockResolvedValue(ENROLLMENT);
+  controls.getDeviceInfo.mockReset().mockResolvedValue(DEVICE);
+  controls.listConversations.mockReset();
+  controls.listen.mockClear();
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root.unmount());
+  restoreGlobals?.();
+});
+
+describe("messages reconciliation", () => {
+  it("does not let an older conversation read overwrite a newer focus read", async () => {
+    const reads: Array<(page: { conversations: Conversation[]; cursor: null }) => void> = [];
+    controls.listConversations.mockImplementation(
+      () => new Promise((resolve) => reads.push(resolve)),
+    );
+    await act(async () => root.render(<MessagesFeature />));
+    await vi.waitFor(() => expect(reads).toHaveLength(1));
+    await act(async () =>
+      window.dispatchEvent(new window.Event("focus")),
+    );
+    await vi.waitFor(() => expect(reads).toHaveLength(2));
+    await act(async () =>
+      reads[1]({ conversations: [conversation("new")], cursor: null }),
+    );
+    expect(container.textContent).toContain("@new");
+    await act(async () =>
+      reads[0]({ conversations: [conversation("old")], cursor: null }),
+    );
+    expect(container.textContent).toContain("@new");
+    expect(container.textContent).not.toContain("@old");
+  });
+});

--- a/wallet/zuuli/src/features/messages/index.tsx
+++ b/wallet/zuuli/src/features/messages/index.tsx
@@ -1,7 +1,4 @@
 // Encrypted messages — mounted at /messages/*.
-//
-// This slice covers enrollment and engine lifecycle only; the conversation
-// surface arrives with the rest of the command set.
 
 import { useCallback, useEffect, useState } from "react";
 import {

--- a/wallet/zuuli/src/features/messages/index.tsx
+++ b/wallet/zuuli/src/features/messages/index.tsx
@@ -27,6 +27,7 @@ import type {
   IneligibilityReason,
 } from "@/lib/messaging/types";
 import { BrowserGuarantee } from "./BrowserGuarantee";
+import { FirstContact } from "./FirstContact";
 import { Transcript } from "./Transcript";
 
 const STATE_COPY: Record<EngineState, string> = {
@@ -171,6 +172,16 @@ export default function MessagesFeature() {
     [reconcile],
   );
 
+  const selectConversation = useCallback((conversation: Conversation) => {
+    setConversations((current) => {
+      const withoutSelected = (current ?? []).filter(
+        (candidate) => candidate.conversationId !== conversation.conversationId,
+      );
+      return [conversation, ...withoutSelected];
+    });
+    setSelectedId(conversation.conversationId);
+  }, []);
+
   if (!status || !enrolled) {
     return (
       <div className="animate-slide-up space-y-6">
@@ -281,6 +292,15 @@ export default function MessagesFeature() {
           is not resolvable by other people until that happens. There is no
           deadline to show you here, and nothing to retry.
         </Callout>
+      )}
+
+      {enrolled.enrolled && enrolled.mergedAtEpoch !== null && (
+        <FirstContact
+          engineRunning={isRunning(status.state)}
+          witnessThresholdMet={status.witnessThresholdMet}
+          onConversation={selectConversation}
+          onStateChanged={reconcile}
+        />
       )}
 
       {conversations !== null && conversations.length > 0 && (

--- a/wallet/zuuli/src/features/messages/index.tsx
+++ b/wallet/zuuli/src/features/messages/index.tsx
@@ -1,6 +1,6 @@
 // Encrypted messages — mounted at /messages/*.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   KeyRound,
   Loader2,
@@ -99,25 +99,31 @@ export default function MessagesFeature() {
   );
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const reconcileGeneration = useRef(0);
 
   const reconcile = useCallback(async () => {
+    const generation = ++reconcileGeneration.current;
     const [engine, enrollmentState, deviceInfo] = await Promise.all([
       messaging.getEngineStatus(),
       enrollment.getEnrollmentStatus(),
       messaging.getDeviceInfo(),
     ]);
+    const nextConversations = enrollmentState.enrolled
+      ? (await messaging.listConversations()).conversations
+      : [];
+    if (generation !== reconcileGeneration.current) return;
+
     setStatus(engine);
     setEnrolled(enrollmentState);
     setDevice(deviceInfo);
-
-    if (!enrollmentState.enrolled) {
-      setConversations([]);
-      return;
-    }
-    const page = await messaging.listConversations();
-    setConversations(page.conversations);
+    setConversations(nextConversations);
     setSelectedId(
-      (current) => current ?? page.conversations[0]?.conversationId ?? null,
+      (current) =>
+        nextConversations.some(
+          (conversation) => conversation.conversationId === current,
+        )
+          ? current
+          : (nextConversations[0]?.conversationId ?? null),
     );
   }, []);
 


### PR DESCRIPTION
## Summary

- add ZUULI's missing first-contact surface for exact-handle initiation and inbound requests
- keep initiation and acceptance fail-closed below the independent witness threshold while established chats and local reject/block remain available
- re-read authoritative conversation/request state after messaging events, with late-listener cleanup
- make proof-of-work, identity fingerprints, and device-local blocking explicit in the UI

## Tests

- `npx vitest run src/features/messages/FirstContact.test.tsx` — 17 passed
- `npx vitest run` — 837 passed, 5 skipped
- `npm run typecheck` — passed
- `npm run typecheck:tests` — passed
- `npm run build` — passed, including fresh WASM build/dist verification
- `node --test scripts/messaging-contract.node-test.mjs scripts/mobile-webview-authority.node-test.mjs` — 14 passed
- `node scripts/mobile-webview-authority.mjs` — passed
- five mutation probes each turned the focused suite red: witness gate, exact-handle rewrite, single-flight guard, authoritative event re-read, and block-local boolean

## Boundaries

Frontend only: no Rust, bridge, type, capability, or contract changes. Live first contact still depends on #769 and the owner witness decision in #770; this PR does not bypass or simulate either.

Closes #771
Refs #305
Refs #312