### PR TITLE
fix(zuuli): make Android artifact stdout explicit

### DIFF
--- a/wallet/zuuli/scripts/android-release-artifact.node-test.mjs
+++ b/wallet/zuuli/scripts/android-release-artifact.node-test.mjs
@@ -33,44 +33,93 @@ async function fixture() {
   return { root, aab, output, verifier, verifierSha };
 }
 
-test("records and verifies a checksum-closed four-ABI AAB", async (t) => {
+test("record, seal-verifier, and verify honor their success stdout contracts", async (t) => {
   const { root, aab, output, verifier, verifierSha } = await fixture();
   t.after(() => rm(root, { recursive: true, force: true }));
+
+  // Release workflows capture digest-producing commands in shell variables,
+  // while verify is status-only. Each helper owns that boundary itself.
   const recorded = run(["record", aab, "0.1.0+14", "a".repeat(40), "b".repeat(40), output]);
   assert.equal(recorded.status, 0, recorded.stderr);
+  assert.match(recorded.stdout, /^[0-9a-f]{64}\n$/);
   const sealed = run(["seal-verifier", output, verifier, verifierSha]);
   assert.equal(sealed.status, 0, sealed.stderr);
-  assert.equal(run(["verify", output]).status, 0);
+  assert.match(sealed.stdout, /^[0-9a-f]{64}\n$/);
+  const verified = run(["verify", output]);
+  assert.equal(verified.status, 0, verified.stderr);
+  assert.equal(verified.stdout, "");
   const source = JSON.parse(await readFile(join(output, "source-record.json"), "utf8"));
   assert.deepEqual(source.abis, ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]);
   assert.equal(source.verifier.sha256, verifierSha);
 });
 
-test("record and seal-verifier print one bare digest and nothing else", async (t) => {
-  const { root, aab, output, verifier, verifierSha } = await fixture();
+test("record keeps unsafe archive names off stdout and diagnoses the failure on stderr", async (t) => {
+  const { root, aab, output } = await fixture();
   t.after(() => rm(root, { recursive: true, force: true }));
 
-  // $GITHUB_OUTPUT takes one key=value per line, so every extra stdout line
-  // from a helper (`sha256sum -c` names each member) breaks the release job.
-  const recorded = run(["record", aab, "0.1.0+14", "a".repeat(40), "b".repeat(40), output]);
-  assert.equal(recorded.status, 0, recorded.stderr);
-  assert.match(recorded.stdout, /^[0-9a-f]{64}\n$/);
+  const unsafe = join(root, "-unsafe-member");
+  await writeFile(unsafe, "unsafe");
+  const appended = spawnSync("zip", ["-q", aab, "../-unsafe-member"], {
+    cwd: join(root, "payload"),
+  });
+  assert.equal(appended.status, 0, appended.stderr?.toString());
 
-  const sealed = run(["seal-verifier", output, verifier, verifierSha]);
-  assert.equal(sealed.status, 0, sealed.stderr);
-  assert.match(sealed.stdout, /^[0-9a-f]{64}\n$/);
-  assert.equal(sealed.stdout.trimEnd().split("\n").length, 1, sealed.stdout);
+  const recorded = run(["record", aab, "0.1.0+14", "a".repeat(40), "b".repeat(40), output]);
+  assert.notEqual(recorded.status, 0);
+  assert.equal(recorded.stdout, "");
+  assert.match(recorded.stderr, /AAB contains an unsafe member name/);
 });
 
-test("seal-verifier still refuses a recorded member that drifted", async (t) => {
+test("seal-verifier keeps checksum status off stdout but preserves failure diagnostics", async (t) => {
   const { root, aab, output, verifier, verifierSha } = await fixture();
   t.after(() => rm(root, { recursive: true, force: true }));
   assert.equal(run(["record", aab, "0.1.0+14", "a".repeat(40), "b".repeat(40), output]).status, 0);
-  // Silencing the pre-seal checksum check must not disable it.
   await writeFile(join(output, "aab-members.txt"), "drifted\n");
   const sealed = run(["seal-verifier", output, verifier, verifierSha]);
   assert.notEqual(sealed.status, 0);
+  assert.equal(sealed.stdout, "");
+  assert.match(sealed.stderr, /WARNING: 1 computed checksum did NOT match/);
   assert.match(sealed.stderr, /unsigned artifact is not ready to seal/);
+});
+
+test("verify keeps checksum status off stdout but preserves failure diagnostics", async (t) => {
+  const { root, aab, output, verifier, verifierSha } = await fixture();
+  t.after(() => rm(root, { recursive: true, force: true }));
+  assert.equal(run(["record", aab, "0.1.0+14", "a".repeat(40), "b".repeat(40), output]).status, 0);
+  assert.equal(run(["seal-verifier", output, verifier, verifierSha]).status, 0);
+  await writeFile(join(output, "bundletool-all-1.18.3.jar"), "mutated verifier");
+
+  const verified = run(["verify", output]);
+  assert.notEqual(verified.status, 0);
+  assert.equal(verified.stdout, "");
+  assert.match(verified.stderr, /WARNING: 1 computed checksum did NOT match/);
+  assert.match(verified.stderr, /artifact inventory or checksum verification failed/);
+});
+
+test("verify keeps member-inventory differences off stdout and diagnoses them on stderr", async (t) => {
+  const { root, aab, output, verifier, verifierSha } = await fixture();
+  t.after(() => rm(root, { recursive: true, force: true }));
+  assert.equal(run(["record", aab, "0.1.0+14", "a".repeat(40), "b".repeat(40), output]).status, 0);
+  assert.equal(run(["seal-verifier", output, verifier, verifierSha]).status, 0);
+
+  const extra = join(root, "extra");
+  await writeFile(extra, "extra");
+  const appended = spawnSync("zip", ["-q", join(output, "ZUULI-android-unsigned.aab"), "extra"], {
+    cwd: root,
+  });
+  assert.equal(appended.status, 0, appended.stderr?.toString());
+  const checksums = spawnSync(
+    "sha256sum",
+    ["ZUULI-android-unsigned.aab", "aab-members.txt", "bundletool-all-1.18.3.jar", "source-record.json"],
+    { cwd: output, encoding: "utf8" },
+  );
+  assert.equal(checksums.status, 0, checksums.stderr);
+  await writeFile(join(output, "CHECKSUMS.sha256"), checksums.stdout);
+
+  const verified = run(["verify", output]);
+  assert.notEqual(verified.status, 0);
+  assert.equal(verified.stdout, "");
+  assert.match(verified.stderr, /AAB member inventory changed/);
 });
 
 test("rejects missing ABIs and checksum drift", async (t) => {

--- a/wallet/zuuli/scripts/android-release-artifact.sh
+++ b/wallet/zuuli/scripts/android-release-artifact.sh
@@ -16,13 +16,15 @@ validate_identity() {
 
 validate_archive() {
   local artifact=$1 listing=$2
+  # This validator is shared by stdout-producing and stdout-silent commands.
+  # Keep its stdout empty on both success and failure; diagnostics go to stderr.
   unzip -Z1 "$artifact" | LC_ALL=C sort > "$listing" || return 1
   [[ -s "$listing" ]] || { echo "AAB member inventory is empty" >&2; return 1; }
   if LC_ALL=C sort "$listing" | uniq -d | grep -q .; then
     echo "AAB contains duplicate member names" >&2
     return 1
   fi
-  if grep -E '(^/|(^|/)\.\.?(/|$)|(^|/)-|\\|[[:cntrl:]])' "$listing"; then
+  if grep -qE '(^/|(^|/)\.\.?(/|$)|(^|/)-|\\|[[:cntrl:]])' "$listing"; then
     echo "AAB contains an unsafe member name" >&2
     return 1
   fi
@@ -38,6 +40,8 @@ validate_archive() {
 }
 
 record() {
+  # Stdout contract: exactly one bare CHECKSUMS.sha256 digest on success and
+  # nothing on failure. All diagnostics belong on stderr.
   [[ $# -eq 5 ]] || usage
   local artifact=$1 identity=$2 source_sha=$3 source_tree=$4 output=$5
   validate_identity "$identity" || { echo "invalid release identity" >&2; return 1; }
@@ -64,6 +68,8 @@ record() {
 }
 
 seal_verifier() {
+  # Stdout contract: exactly one bare sealed CHECKSUMS.sha256 digest on success
+  # and nothing on failure. All diagnostics belong on stderr.
   [[ $# -eq 3 ]] || usage
   local directory=$1 verifier=$2 expected_sha=$3
   [[ "$expected_sha" =~ ^[0-9a-f]{64}$ ]] || { echo "invalid verifier digest" >&2; return 1; }
@@ -94,6 +100,8 @@ seal_verifier() {
 }
 
 verify() {
+  # Stdout contract: always empty. Verification detail and failures belong on
+  # stderr so callers may safely use stdout as a machine-readable channel.
   [[ $# -eq 1 ]] || usage
   local directory=$1
   [[ -d "$directory" && ! -L "$directory" ]] || { echo "unsafe artifact directory" >&2; return 1; }
@@ -102,11 +110,17 @@ verify() {
     actual_inventory=$({ for path in ./*; do [[ -f "$path" && ! -L "$path" ]] || exit 1; printf '%s\n' "${path#./}"; done; } | LC_ALL=C sort | tr '\n' ' ') || exit 1
     [[ "$actual_inventory" == \
       "CHECKSUMS.sha256 ZUULI-android-unsigned.aab aab-members.txt bundletool-all-1.18.3.jar source-record.json " ]] || exit 1
-    sha256sum -c CHECKSUMS.sha256
+    # Keep sha256sum's mismatch warning and read errors on stderr without
+    # leaking its per-member status lines to stdout.
+    sha256sum -c CHECKSUMS.sha256 >/dev/null
     [[ "$(sha256_file bundletool-all-1.18.3.jar)" == "$(jq -er .verifier.sha256 source-record.json)" ]] || exit 1
   ) || { echo "artifact inventory or checksum verification failed" >&2; return 1; }
   validate_archive "$directory/ZUULI-android-unsigned.aab" "$directory/current-members.txt" || return 1
-  cmp "$directory/aab-members.txt" "$directory/current-members.txt" || { rm -f "$directory/current-members.txt"; return 1; }
+  cmp -s "$directory/aab-members.txt" "$directory/current-members.txt" || {
+    rm -f "$directory/current-members.txt"
+    echo "AAB member inventory changed" >&2
+    return 1
+  }
   rm "$directory/current-members.txt" || return 1
   jq -e '.schemaVersion == 1 and .kind == "android-unsigned-universal-aab" and .applicationId == "cash.free2z.zuuli" and .abis == ["arm64-v8a","armeabi-v7a","x86","x86_64"] and .verifier.name == "bundletool-all-1.18.3.jar" and .verifier.version == "1.18.3" and (.verifier.sha256 | test("^[0-9a-f]{64}$"))' \
     "$directory/source-record.json" >/dev/null


### PR DESCRIPTION
## Summary
- define stdout contracts for every Android release artifact subcommand
- silence archive-validation, checksum, and inventory comparison status output while retaining stderr diagnostics
- add regression coverage for success output and checksum/archive/inventory failure streams

## Tests
- `node --test scripts/android-release-artifact.node-test.mjs`
- `shellcheck wallet/zuuli/scripts/android-release-artifact.sh`
- `ZUULI_PW_PORT=1441 npm test` (846 Vitest passed; 370 Node passed, 5 skipped; 133 Playwright passed)
- `git diff --check`

Closes #741