### PR TITLE
fix(mls): restore group after receive rollback

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -615,15 +615,28 @@ jobs:
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          workspaces: wallet/plugins/tauri-plugin-f2zmsg
+          workspaces: |
+            wallet/plugins/tauri-plugin-f2zmsg
+            rs
           key: zuuli-msg-plugin
 
-      # The acceptance criterion. `--features relay-harness` builds the
-      # `f2zmsg-peer` binary the integration test spawns twice against a real
-      # `ws://` listener; without it the test compiles to nothing and passes by
-      # not existing.
+      # The client crate cannot link the AGPL relay daemon. Build its actual
+      # production binary separately so the rollback/cursor regression can
+      # spawn it across that licence boundary rather than substituting the MIT
+      # FakeRelay behind a WebSocket.
+      - name: Build the production relay daemon for integration tests
+        run: |
+          cargo build --locked --manifest-path rs/Cargo.toml \
+            -p f2z-relay --bin f2z-relay
+
+      # The acceptance criteria. `--features relay-harness` builds the
+      # `f2zmsg-peer` binary for the two-process exchange and enables the exact
+      # two-record rollback regression against the production relay binary.
+      # Without it both integration tests compile to nothing and pass by not
+      # existing.
       - name: Build and test the messaging plugin
         env:
+          F2Z_RELAY_BIN: ${{ github.workspace }}/rs/target/debug/f2z-relay
           TAURI_PERMISSION_GENERATION_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           cargo test --locked --all-targets --features relay-harness \

--- a/rs/crates/f2z-msg-mls/src/engine.rs
+++ b/rs/crates/f2z-msg-mls/src/engine.rs
@@ -22,10 +22,13 @@
 //! relay, un-acknowledged, and is redelivered — which is recoverable, and a
 //! half-applied epoch change is not.
 //!
-//! Rolling back storage is only half of that invariant after OpenMLS has merged
-//! a commit into the caller's [`MlsGroup`]. [`MlsEngine::receive`] reloads the
-//! durable pre-transaction group into that same handle before returning a
-//! post-merge error, so redelivery sees the epoch the store actually holds.
+//! Rolling back storage is only half of that invariant after OpenMLS has
+//! advanced a private-message receive ratchet or merged a commit into the
+//! caller's [`MlsGroup`]. [`MlsEngine::receive`] reloads the durable
+//! pre-transaction group into that same handle before returning an error, so
+//! redelivery sees the state the store actually holds. If that reload itself
+//! fails, [`EngineError::GroupStateUnavailable`] tells the caller to discard
+//! the possibly advanced handle and attempt a fresh durable load.
 //!
 //! # Delete-on-ack, and what `record_key` is for
 //!
@@ -683,7 +686,10 @@ impl<B: StorageBackend> MlsEngine<B> {
     /// [`EngineError::OutOfOrder`] for a message from an epoch this group is
     /// not in; [`EngineError::Credential`] if the sender's credential does not
     /// validate; [`EngineError::Mls`] if OpenMLS refused;
-    /// [`EngineError::Storage`] if the store did.
+    /// [`EngineError::Storage`] if the store did; or
+    /// [`EngineError::GroupStateUnavailable`] if rollback succeeded but its
+    /// durable state could not be reloaded. After that last outcome the caller
+    /// must discard `group` and load a fresh handle from durable storage.
     pub fn receive(
         &self,
         group: &mut MlsGroup,
@@ -702,9 +708,12 @@ impl<B: StorageBackend> MlsEngine<B> {
         let group_id = group.group_id().clone();
         let original_aad = group.aad().to_vec();
         let transaction = self.provider.store().begin()?;
-        let mut restore_group_on_error = false;
 
         let operation = || -> Result<Received> {
+            // Private-message processing advances the receive ratchet before
+            // content dispatch. Restoration therefore has to cover every
+            // failure from this call onward, not only the visibly mutating
+            // commit branches below.
             let processed = group
                 .process_message(&self.provider, protocol_message)
                 .map_err(map_process_error)?;
@@ -744,9 +753,6 @@ impl<B: StorageBackend> MlsEngine<B> {
                     Received::ProposalQueued
                 }
                 ProcessedMessageContent::StagedCommitMessage(staged) => {
-                    // Mark before the merge: OpenMLS is allowed to mutate the
-                    // caller's group before returning an error.
-                    restore_group_on_error = true;
                     group
                         .merge_staged_commit(&self.provider, *staged)
                         .map_err(|_| EngineError::Mls("merge staged commit"))?;
@@ -779,7 +785,6 @@ impl<B: StorageBackend> MlsEngine<B> {
                     // only correct action when a pending commit exists, and doing
                     // nothing is the only correct action when none does.
                     if group.pending_commit().is_some() {
-                        restore_group_on_error = true;
                         group
                             .merge_pending_commit(&self.provider)
                             .map_err(|_| EngineError::Mls("merge pending commit"))?;
@@ -805,8 +810,11 @@ impl<B: StorageBackend> MlsEngine<B> {
 
         let result = operation();
         if let Err(error) = result {
-            if restore_group_on_error {
-                self.restore_group_after_rollback(group, &group_id, original_aad)?;
+            if let Err(reload) = self.restore_group_after_rollback(group, &group_id, original_aad) {
+                return Err(EngineError::GroupStateUnavailable {
+                    operation: Box::new(error),
+                    reload: Box::new(reload),
+                });
             }
             return Err(error);
         }

--- a/rs/crates/f2z-msg-mls/src/engine.rs
+++ b/rs/crates/f2z-msg-mls/src/engine.rs
@@ -22,6 +22,11 @@
 //! relay, un-acknowledged, and is redelivered — which is recoverable, and a
 //! half-applied epoch change is not.
 //!
+//! Rolling back storage is only half of that invariant after OpenMLS has merged
+//! a commit into the caller's [`MlsGroup`]. [`MlsEngine::receive`] reloads the
+//! durable pre-transaction group into that same handle before returning a
+//! post-merge error, so redelivery sees the epoch the store actually holds.
+//!
 //! # Delete-on-ack, and what `record_key` is for
 //!
 //! [`MlsEngine::receive`] takes a `record_key`: the caller's identifier for
@@ -694,101 +699,118 @@ impl<B: StorageBackend> MlsEngine<B> {
         }
 
         let protocol_message = parse_protocol_message(wire)?;
-
+        let group_id = group.group_id().clone();
+        let original_aad = group.aad().to_vec();
         let transaction = self.provider.store().begin()?;
+        let mut restore_group_on_error = false;
 
-        let processed = group
-            .process_message(&self.provider, protocol_message)
-            .map_err(map_process_error)?;
+        let operation = || -> Result<Received> {
+            let processed = group
+                .process_message(&self.provider, protocol_message)
+                .map_err(map_process_error)?;
 
-        // The credential the *sender* presented, validated against the leaf it
-        // came from. `ProcessedMessage::credential` is the leaf's credential and
-        // OpenMLS has already checked the framing signature under that leaf's
-        // signature key, so binding the credential to that key is the remaining
-        // half of §4.2's identity→device binding.
-        let sender_index = match processed.sender() {
-            Sender::Member(index) => Some(*index),
-            _ => None,
-        };
-        let epoch = processed.epoch().as_u64();
-        validate_credential_bytes(
-            basic_credential_identity(processed.credential())?,
-            group_signature_key(group, sender_index)?.as_slice(),
-            now_ms,
-        )?;
+            // The credential the *sender* presented, validated against the leaf it
+            // came from. `ProcessedMessage::credential` is the leaf's credential and
+            // OpenMLS has already checked the framing signature under that leaf's
+            // signature key, so binding the credential to that key is the remaining
+            // half of §4.2's identity→device binding.
+            let sender_index = match processed.sender() {
+                Sender::Member(index) => Some(*index),
+                _ => None,
+            };
+            let epoch = processed.epoch().as_u64();
+            validate_credential_bytes(
+                basic_credential_identity(processed.credential())?,
+                group_signature_key(group, sender_index)?.as_slice(),
+                now_ms,
+            )?;
 
-        let outcome = match processed.into_content() {
-            ProcessedMessageContent::ApplicationMessage(message) => Received::Application {
-                payload: message.into_bytes(),
-                sender: sender_index.map_or(0, |index| index.u32()),
-                epoch,
-            },
-            ProcessedMessageContent::ProposalMessage(proposal) => {
-                group
-                    .store_pending_proposal(self.provider.store(), *proposal)
-                    .map_err(|_| EngineError::Mls("store pending proposal"))?;
-                Received::ProposalQueued
-            }
-            ProcessedMessageContent::ExternalJoinProposalMessage(proposal) => {
-                group
-                    .store_pending_proposal(self.provider.store(), *proposal)
-                    .map_err(|_| EngineError::Mls("store external join proposal"))?;
-                Received::ProposalQueued
-            }
-            ProcessedMessageContent::StagedCommitMessage(staged) => {
-                group
-                    .merge_staged_commit(&self.provider, *staged)
-                    .map_err(|_| EngineError::Mls("merge staged commit"))?;
-                // Re-validated after the merge, because the commit may have
-                // *added* members whose credentials nobody has looked at.
-                self.validate_members(group, now_ms)?;
-                Received::EpochChanged {
-                    epoch: group.epoch().as_u64(),
-                }
-            }
-            // Both of these are **new in openmls 0.9** and both mean "this
-            // device authored it and the delivery service handed it back".
-            ProcessedMessageContent::OwnPrivateMessage => Received::Own,
-            ProcessedMessageContent::OwnPendingCommit => {
-                // 0.9 returns this when an incoming Commit's confirmation tag
-                // matches a commit *this* device has pending, so that the
-                // caller merges the pending commit rather than staging the
-                // echo. This engine never leaves one pending: `update` and
-                // `add_member` call `merge_pending_commit` before their bytes
-                // leave the method, precisely so that the device is in the new
-                // epoch the moment the caller has something to send. So the
-                // `Some` arm is not reachable today.
-                //
-                // It is written anyway, and it is not defensive padding: the
-                // alternative — assuming the invariant and returning
-                // `Received::Own` — would silently *skip an epoch change* if
-                // anyone ever split those two steps, and a group whose tree is
-                // one epoch behind its peers' is exactly the failure the
-                // transaction in this method exists to prevent. Merging is the
-                // only correct action when a pending commit exists, and doing
-                // nothing is the only correct action when none does.
-                if group.pending_commit().is_some() {
+            let outcome = match processed.into_content() {
+                ProcessedMessageContent::ApplicationMessage(message) => Received::Application {
+                    payload: message.into_bytes(),
+                    sender: sender_index.map_or(0, |index| index.u32()),
+                    epoch,
+                },
+                ProcessedMessageContent::ProposalMessage(proposal) => {
                     group
-                        .merge_pending_commit(&self.provider)
-                        .map_err(|_| EngineError::Mls("merge pending commit"))?;
+                        .store_pending_proposal(self.provider.store(), *proposal)
+                        .map_err(|_| EngineError::Mls("store pending proposal"))?;
+                    Received::ProposalQueued
+                }
+                ProcessedMessageContent::ExternalJoinProposalMessage(proposal) => {
+                    group
+                        .store_pending_proposal(self.provider.store(), *proposal)
+                        .map_err(|_| EngineError::Mls("store external join proposal"))?;
+                    Received::ProposalQueued
+                }
+                ProcessedMessageContent::StagedCommitMessage(staged) => {
+                    // Mark before the merge: OpenMLS is allowed to mutate the
+                    // caller's group before returning an error.
+                    restore_group_on_error = true;
+                    group
+                        .merge_staged_commit(&self.provider, *staged)
+                        .map_err(|_| EngineError::Mls("merge staged commit"))?;
+                    // Re-validated after the merge, because the commit may have
+                    // *added* members whose credentials nobody has looked at.
                     self.validate_members(group, now_ms)?;
                     Received::EpochChanged {
                         epoch: group.epoch().as_u64(),
                     }
-                } else {
-                    Received::Own
                 }
-            }
+                // Both of these are **new in openmls 0.9** and both mean "this
+                // device authored it and the delivery service handed it back".
+                ProcessedMessageContent::OwnPrivateMessage => Received::Own,
+                ProcessedMessageContent::OwnPendingCommit => {
+                    // 0.9 returns this when an incoming Commit's confirmation tag
+                    // matches a commit *this* device has pending, so that the
+                    // caller merges the pending commit rather than staging the
+                    // echo. This engine never leaves one pending: `update` and
+                    // `add_member` call `merge_pending_commit` before their bytes
+                    // leave the method, precisely so that the device is in the new
+                    // epoch the moment the caller has something to send. So the
+                    // `Some` arm is not reachable today.
+                    //
+                    // It is written anyway, and it is not defensive padding: the
+                    // alternative — assuming the invariant and returning
+                    // `Received::Own` — would silently *skip an epoch change* if
+                    // anyone ever split those two steps, and a group whose tree is
+                    // one epoch behind its peers' is exactly the failure the
+                    // transaction in this method exists to prevent. Merging is the
+                    // only correct action when a pending commit exists, and doing
+                    // nothing is the only correct action when none does.
+                    if group.pending_commit().is_some() {
+                        restore_group_on_error = true;
+                        group
+                            .merge_pending_commit(&self.provider)
+                            .map_err(|_| EngineError::Mls("merge pending commit"))?;
+                        self.validate_members(group, now_ms)?;
+                        Received::EpochChanged {
+                            epoch: group.epoch().as_u64(),
+                        }
+                    } else {
+                        Received::Own
+                    }
+                }
+            };
+
+            // The durable "handled" record, in the same journal as everything
+            // above. This is the line that makes an `ACK` safe.
+            self.provider
+                .store()
+                .put_app(&handled_key(record_key), &[1])?;
+
+            transaction.commit()?;
+            Ok(outcome)
         };
 
-        // The durable "handled" record, in the same journal as everything
-        // above. This is the line that makes an `ACK` safe.
-        self.provider
-            .store()
-            .put_app(&handled_key(record_key), &[1])?;
-
-        transaction.commit()?;
-        Ok(outcome)
+        let result = operation();
+        if let Err(error) = result {
+            if restore_group_on_error {
+                self.restore_group_after_rollback(group, &group_id, original_aad)?;
+            }
+            return Err(error);
+        }
+        result
     }
 
     /// Issue an `Update` commit: fresh leaf key, new epoch.
@@ -877,6 +899,24 @@ impl<B: StorageBackend> MlsEngine<B> {
                 now_ms,
             )?;
         }
+        Ok(())
+    }
+
+    /// Replace a group mutated inside a failed receive transaction with the
+    /// durable pre-transaction state. OpenMLS persists every durable group
+    /// field through the provider; AAD is intentionally ephemeral, so preserve
+    /// it explicitly across the reload.
+    fn restore_group_after_rollback(
+        &self,
+        group: &mut MlsGroup,
+        group_id: &GroupId,
+        aad: Vec<u8>,
+    ) -> Result<()> {
+        let Some(mut restored) = MlsGroup::load(self.provider.store(), group_id)? else {
+            return Err(EngineError::Mls("reload group after rollback"));
+        };
+        restored.set_aad(aad);
+        *group = restored;
         Ok(())
     }
 

--- a/rs/crates/f2z-msg-mls/src/error.rs
+++ b/rs/crates/f2z-msg-mls/src/error.rs
@@ -44,6 +44,21 @@ pub enum EngineError {
     /// contradiction would persist a group that cannot be reloaded by the
     /// conversation identifier after restart.
     GroupIdMismatch,
+    /// A failed receive mutated the caller's group and the durable rollback
+    /// state could not be reloaded into that handle.
+    ///
+    /// The handle passed to [`crate::MlsEngine::receive`] is unusable after
+    /// this outcome and **must be discarded**. The caller may retry only after
+    /// loading a fresh [`openmls::prelude::MlsGroup`] from durable storage and
+    /// reapplying any ephemeral AAD it set on the discarded handle. Both errors
+    /// are retained so a recovery failure does not hide the operation that
+    /// made recovery necessary.
+    GroupStateUnavailable {
+        /// The receive failure that caused the transaction to roll back.
+        operation: Box<EngineError>,
+        /// The failure while reloading the durable pre-transaction group.
+        reload: Box<EngineError>,
+    },
     /// A message arrived for an epoch this device has already moved past, or
     /// has not reached yet.
     ///
@@ -120,6 +135,10 @@ impl fmt::Display for EngineError {
             Self::GroupIdMismatch => {
                 f.write_str("the Welcome group id does not match the conversation id")
             }
+            Self::GroupStateUnavailable { operation, reload } => write!(
+                f,
+                "the caller's MLS group is unusable after {operation}; durable reload also failed: {reload}"
+            ),
             Self::OutOfOrder => f.write_str("the message is for a different epoch"),
             Self::Duplicate => f.write_str("the message has already been processed"),
         }
@@ -131,6 +150,7 @@ impl core::error::Error for EngineError {
         match self {
             Self::Credential(error) => Some(error),
             Self::Storage(error) => Some(error),
+            Self::GroupStateUnavailable { operation, .. } => Some(operation.as_ref()),
             _ => None,
         }
     }
@@ -159,6 +179,10 @@ mod tests {
             EngineError::Credential(CredentialError::DeviceKeyMismatch),
             EngineError::Mls("process_message"),
             EngineError::GroupIdMismatch,
+            EngineError::GroupStateUnavailable {
+                operation: Box::new(EngineError::Mls("process_message")),
+                reload: Box::new(EngineError::Mls("reload group after rollback")),
+            },
             EngineError::OutOfOrder,
             EngineError::Duplicate,
         ];

--- a/rs/crates/f2z-msg-mls/tests/two_instances.rs
+++ b/rs/crates/f2z-msg-mls/tests/two_instances.rs
@@ -31,6 +31,7 @@ mod common;
 use common::{NOW, device, directory_entry, issue_credential};
 
 const GROUP_ID: &[u8] = b"conversation-alice-bob";
+const TEST_AAD: &[u8] = b"free2z/test/non-empty-aad";
 
 /// Alice creates the group and adds Bob; Bob joins from the `Welcome`.
 fn paired() -> (
@@ -64,6 +65,8 @@ fn paired() -> (
 struct FailableBackend {
     inner: Arc<MemoryBackend>,
     fail_apply: Arc<AtomicBool>,
+    fail_restore_get_after_apply: Arc<AtomicBool>,
+    fail_next_get: Arc<AtomicBool>,
 }
 
 impl FailableBackend {
@@ -71,21 +74,38 @@ impl FailableBackend {
         Self {
             inner: Arc::new(MemoryBackend::new()),
             fail_apply: Arc::new(AtomicBool::new(false)),
+            fail_restore_get_after_apply: Arc::new(AtomicBool::new(false)),
+            fail_next_get: Arc::new(AtomicBool::new(false)),
         }
     }
 
     fn set_fail_apply(&self, fail: bool) {
         self.fail_apply.store(fail, Ordering::SeqCst);
     }
+
+    fn fail_apply_and_restore_get_once(&self) {
+        self.fail_restore_get_after_apply
+            .store(true, Ordering::SeqCst);
+        self.fail_apply.store(true, Ordering::SeqCst);
+    }
 }
 
 impl StorageBackend for FailableBackend {
     fn get(&self, key: &[u8]) -> f2z_msg_store::Result<Option<Vec<u8>>> {
+        if self.fail_next_get.swap(false, Ordering::SeqCst) {
+            return Err(StoreError::Backend("injected restore get failure"));
+        }
         self.inner.get(key)
     }
 
     fn apply(&self, ops: &[Op]) -> f2z_msg_store::Result<()> {
         if self.fail_apply.load(Ordering::SeqCst) {
+            if self
+                .fail_restore_get_after_apply
+                .swap(false, Ordering::SeqCst)
+            {
+                self.fail_next_get.store(true, Ordering::SeqCst);
+            }
             return Err(StoreError::Backend("injected apply failure"));
         }
         self.inner.apply(ops)
@@ -446,6 +466,8 @@ fn an_apply_failure_after_merging_restores_memory_and_redelivery_succeeds() {
     let (alice, mut alice_group, bob, mut bob_group) =
         paired_with_bob_backend(bob_backend.clone(), NOW + 1_000_000);
 
+    alice_group.set_aad(TEST_AAD.to_vec());
+    bob_group.set_aad(TEST_AAD.to_vec());
     let commit = alice.update(&mut alice_group).expect("update");
     let epoch_before = bob_group.epoch();
 
@@ -465,6 +487,11 @@ fn an_apply_failure_after_merging_restores_memory_and_redelivery_succeeds() {
         epoch_before,
         "a commit refused after merge must restore the caller's group"
     );
+    assert_eq!(
+        bob_group.aad(),
+        TEST_AAD,
+        "durable MLS state omits ephemeral AAD, so rollback must restore it explicitly"
+    );
 
     bob_backend.set_fail_apply(false);
     let redelivery = bob
@@ -477,6 +504,87 @@ fn an_apply_failure_after_merging_restores_memory_and_redelivery_succeeds() {
         }
     );
     assert_eq!(alice_group.epoch(), bob_group.epoch());
+}
+
+#[test]
+fn an_application_apply_failure_restores_the_receive_ratchet_for_redelivery() {
+    let bob_backend = FailableBackend::new();
+    let (alice, mut alice_group, bob, mut bob_group) =
+        paired_with_bob_backend(bob_backend.clone(), NOW + 1_000_000);
+    alice_group.set_aad(TEST_AAD.to_vec());
+    bob_group.set_aad(TEST_AAD.to_vec());
+    let wire = alice
+        .send(&mut alice_group, b"ratchet rollback")
+        .expect("send");
+
+    bob_backend.set_fail_apply(true);
+    let outcome = bob.receive(&mut bob_group, &wire, b"application-apply", NOW);
+    assert!(
+        matches!(
+            outcome,
+            Err(EngineError::Storage(StoreError::Backend(
+                "injected apply failure"
+            )))
+        ),
+        "the injected durable-store failure must be returned, got {outcome:?}"
+    );
+    assert_eq!(
+        bob_group.aad(),
+        TEST_AAD,
+        "application rollback must preserve non-empty AAD"
+    );
+
+    bob_backend.set_fail_apply(false);
+    let redelivery = bob
+        .receive(&mut bob_group, &wire, b"application-apply", NOW)
+        .expect("the restored receive ratchet must accept redelivery");
+    assert_eq!(redelivery.payload(), Some(b"ratchet rollback".as_slice()));
+}
+
+#[test]
+fn a_restore_read_failure_requires_a_fresh_group_before_redelivery() {
+    let bob_backend = FailableBackend::new();
+    let (alice, mut alice_group, bob, mut bob_group) =
+        paired_with_bob_backend(bob_backend.clone(), NOW + 1_000_000);
+    alice_group.set_aad(TEST_AAD.to_vec());
+    bob_group.set_aad(TEST_AAD.to_vec());
+    let commit = alice.update(&mut alice_group).expect("update");
+    let group_id = bob_group.group_id().clone();
+
+    bob_backend.fail_apply_and_restore_get_once();
+    let outcome = bob.receive(&mut bob_group, &commit, b"restore-read", NOW);
+    match outcome {
+        Err(EngineError::GroupStateUnavailable { operation, reload }) => {
+            assert!(matches!(
+                operation.as_ref(),
+                EngineError::Storage(StoreError::Backend("injected apply failure"))
+            ));
+            assert!(matches!(
+                reload.as_ref(),
+                EngineError::Storage(StoreError::Backend("injected restore get failure"))
+            ));
+        }
+        other => panic!("the caller must be told to discard the group, got {other:?}"),
+    }
+
+    // The handle passed above may contain the uncommitted epoch and is never
+    // reused. This is the same fresh durable load the ZUULI caller performs
+    // when it sees GroupStateUnavailable.
+    bob_backend.set_fail_apply(false);
+    let mut restored = openmls::prelude::MlsGroup::load(bob.provider().store(), &group_id)
+        .expect("fresh durable load")
+        .expect("durable pre-transaction group");
+    restored.set_aad(TEST_AAD.to_vec());
+    let redelivery = bob
+        .receive(&mut restored, &commit, b"restore-read", NOW)
+        .expect("redelivery through the freshly loaded group");
+    assert_eq!(
+        redelivery,
+        Received::EpochChanged {
+            epoch: restored.epoch().as_u64()
+        }
+    );
+    assert_eq!(alice_group.epoch(), restored.epoch());
 }
 
 #[test]

--- a/rs/crates/f2z-msg-mls/tests/two_instances.rs
+++ b/rs/crates/f2z-msg-mls/tests/two_instances.rs
@@ -22,7 +22,10 @@
 )]
 
 use f2z_msg_mls::{EngineError, ExportLabel, MlsEngine, ProtocolVersion, Received};
-use f2z_msg_store::MemoryBackend;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use f2z_msg_store::{Durability, MemoryBackend, Op, StorageBackend, StoreError};
 
 mod common;
 use common::{NOW, device, directory_entry, issue_credential};
@@ -52,6 +55,66 @@ fn paired() -> (
         .add_member(&mut alice_group, &bob_key_package, NOW)
         .expect("add member");
 
+    let bob_group = bob.join_from_welcome(&welcome, NOW).expect("join");
+
+    (alice, alice_group, bob, bob_group)
+}
+
+#[derive(Clone, Debug)]
+struct FailableBackend {
+    inner: Arc<MemoryBackend>,
+    fail_apply: Arc<AtomicBool>,
+}
+
+impl FailableBackend {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(MemoryBackend::new()),
+            fail_apply: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn set_fail_apply(&self, fail: bool) {
+        self.fail_apply.store(fail, Ordering::SeqCst);
+    }
+}
+
+impl StorageBackend for FailableBackend {
+    fn get(&self, key: &[u8]) -> f2z_msg_store::Result<Option<Vec<u8>>> {
+        self.inner.get(key)
+    }
+
+    fn apply(&self, ops: &[Op]) -> f2z_msg_store::Result<()> {
+        if self.fail_apply.load(Ordering::SeqCst) {
+            return Err(StoreError::Backend("injected apply failure"));
+        }
+        self.inner.apply(ops)
+    }
+
+    fn durability(&self) -> Durability {
+        self.inner.durability()
+    }
+}
+
+fn paired_with_bob_backend<B: StorageBackend>(
+    bob_backend: B,
+    bob_not_after_ms: u64,
+) -> (
+    MlsEngine<MemoryBackend>,
+    openmls::prelude::MlsGroup,
+    MlsEngine<B>,
+    openmls::prelude::MlsGroup,
+) {
+    let alice = device("alice", 11, 111);
+    let (bob_credential, bob_signer) =
+        issue_credential("bob", 22, 222, NOW - 1_000_000, bob_not_after_ms);
+    let bob = MlsEngine::new(bob_backend, bob_signer, bob_credential, NOW).expect("bob engine");
+
+    let bob_key_package = bob.generate_key_package().expect("key package");
+    let mut alice_group = alice.create_group(GROUP_ID).expect("create group");
+    let (_commit, welcome) = alice
+        .add_member(&mut alice_group, &bob_key_package, NOW)
+        .expect("add member");
     let bob_group = bob.join_from_welcome(&welcome, NOW).expect("join");
 
     (alice, alice_group, bob, bob_group)
@@ -375,6 +438,77 @@ fn a_refused_delivery_leaves_no_handled_record() {
     bob.receive(&mut bob_group, &second, b"commit-2", NOW)
         .expect("the redelivery must not have been swallowed as a duplicate");
     assert_eq!(alice_group.epoch(), bob_group.epoch());
+}
+
+#[test]
+fn an_apply_failure_after_merging_restores_memory_and_redelivery_succeeds() {
+    let bob_backend = FailableBackend::new();
+    let (alice, mut alice_group, bob, mut bob_group) =
+        paired_with_bob_backend(bob_backend.clone(), NOW + 1_000_000);
+
+    let commit = alice.update(&mut alice_group).expect("update");
+    let epoch_before = bob_group.epoch();
+
+    bob_backend.set_fail_apply(true);
+    let outcome = bob.receive(&mut bob_group, &commit, b"commit-apply", NOW);
+    assert!(
+        matches!(
+            outcome,
+            Err(EngineError::Storage(StoreError::Backend(
+                "injected apply failure"
+            )))
+        ),
+        "the injected durable-store failure must be returned, got {outcome:?}"
+    );
+    assert_eq!(
+        bob_group.epoch(),
+        epoch_before,
+        "a commit refused after merge must restore the caller's group"
+    );
+
+    bob_backend.set_fail_apply(false);
+    let redelivery = bob
+        .receive(&mut bob_group, &commit, b"commit-apply", NOW)
+        .expect("the unhandled commit must remain applicable after storage recovers");
+    assert_eq!(
+        redelivery,
+        Received::EpochChanged {
+            epoch: bob_group.epoch().as_u64()
+        }
+    );
+    assert_eq!(alice_group.epoch(), bob_group.epoch());
+}
+
+#[test]
+fn post_merge_credential_failure_restores_memory_for_redelivery() {
+    let (alice, mut alice_group, bob, mut bob_group) =
+        paired_with_bob_backend(MemoryBackend::new(), NOW + 1);
+    let commit = alice.update(&mut alice_group).expect("update");
+    let epoch_before = bob_group.epoch();
+    let after_bob_expired = NOW + 2;
+
+    for attempt in 1..=2 {
+        let outcome = bob.receive(
+            &mut bob_group,
+            &commit,
+            b"commit-expired-member",
+            after_bob_expired,
+        );
+        assert!(
+            matches!(
+                outcome,
+                Err(EngineError::Credential(
+                    f2z_msg_mls::CredentialError::Expired
+                ))
+            ),
+            "redelivery {attempt} must reach post-merge credential validation, got {outcome:?}"
+        );
+        assert_eq!(
+            bob_group.epoch(),
+            epoch_before,
+            "redelivery {attempt} must restore the caller's pre-commit epoch"
+        );
+    }
 }
 
 #[test]

--- a/rs/crates/f2z-msg-mls/tests/two_instances.rs
+++ b/rs/crates/f2z-msg-mls/tests/two_instances.rs
@@ -128,9 +128,16 @@ fn paired_with_bob_backend<B: StorageBackend>(
     let alice = device("alice", 11, 111);
     let (bob_credential, bob_signer) =
         issue_credential("bob", 22, 222, NOW - 1_000_000, bob_not_after_ms);
-    let bob = MlsEngine::new(bob_backend, bob_signer, bob_credential, NOW).expect("bob engine");
+    let bob =
+        MlsEngine::new(bob_backend, bob_signer, bob_credential.clone(), NOW).expect("bob engine");
 
     let bob_key_package = bob.generate_key_package().expect("key package");
+    // §12.6: the package is checked against the directory entry before it can
+    // become an argument to `add_member` at all. There is no other constructor.
+    let bob_entry = directory_entry(&[bob_credential]);
+    let bob_key_package = alice
+        .verify_key_package(&bob_key_package, &bob_entry, NOW)
+        .expect("the directory vouches for this package");
     let mut alice_group = alice.create_group(GROUP_ID).expect("create group");
     let (_commit, welcome) = alice
         .add_member(&mut alice_group, &bob_key_package, NOW)

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -471,12 +471,17 @@ const REQUIRED_STEP_ENVIRONMENTS = new Map([
     ]),
   ],
   [
-    // The messaging plugin's `build.rs` watches this value, so a restored
-    // Cargo cache cannot turn its permission-drift assertion into a no-op.
-    // There is no schema nonce beside it: this plugin has no consuming app in
-    // the tree yet, so nothing generates target schemas from it.
+    // The messaging plugin's `build.rs` watches the nonce, so a restored Cargo
+    // cache cannot turn its permission-drift assertion into a no-op. The relay
+    // path binds the real-daemon regression to the binary built in the prior
+    // step rather than permitting a PATH substitution. There is no schema
+    // nonce: this plugin has no consuming app in the tree yet.
     "rust_msg_plugin\0Build and test the messaging plugin",
     new Map([
+      [
+        "F2Z_RELAY_BIN",
+        "${{ github.workspace }}/rs/target/debug/f2z-relay",
+      ],
       [
         "TAURI_PERMISSION_GENERATION_NONCE",
         "${{ github.run_id }}-${{ github.run_attempt }}",

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
@@ -2500,6 +2500,23 @@ impl<B: StorageBackend> Inner<B> {
         Ok(())
     }
 
+    /// Load one conversation's MLS group from the durable provider.
+    ///
+    /// Used on demand after [`EngineError::GroupStateUnavailable`], where the
+    /// old in-memory handle is deliberately absent. Failure must propagate so
+    /// the queue cursor and ACK boundary remain before the ciphertext.
+    fn reload_group(&self, stored: &StoredConversation) -> Result<MlsGroup> {
+        let group_id = hex::decode(&stored.group_id)
+            .map_err(|_| Error::internal("the stored MLS group id is not hexadecimal"))?;
+        let mls = self.mls_ref("reload_group")?;
+        MlsGroup::load(
+            mls.provider().storage(),
+            &GroupId::from_slice(group_id.as_slice()),
+        )
+        .map_err(|error| Error::internal(format!("reloading an MLS group: {error:?}")))?
+        .ok_or_else(|| Error::internal("the durable MLS group is missing"))
+    }
+
     async fn subscribe_all(&mut self) {
         let Ok(ids) = self.records().conversation_ids() else {
             return;
@@ -3899,8 +3916,14 @@ impl<B: StorageBackend> Inner<B> {
         // rather than double-applied.
         let record_key = format!("{conversation_id}:{index}").into_bytes();
 
-        let Some(mut group) = self.groups.remove(&conversation_id) else {
-            return Ok(Vec::new());
+        let mut group = match self.groups.remove(&conversation_id) {
+            Some(group) => group,
+            // A prior receive can leave its caller handle explicitly
+            // unusable when durable rollback reload itself fails. Do not
+            // silently treat that as a handled delivery: retry the durable
+            // load first, leaving the queue cursor untouched if it still
+            // cannot be read.
+            None => self.reload_group(stored)?,
         };
         let received: Result<core::result::Result<Received, EngineError>> = (|| {
             let mls = self.mls_ref("apply_inbound")?;
@@ -3911,7 +3934,13 @@ impl<B: StorageBackend> Inner<B> {
                 u64::try_from(now).unwrap_or_default(),
             ))
         })();
-        self.groups.insert(conversation_id.clone(), group);
+        let group_state_unavailable = matches!(
+            &received,
+            Ok(Err(EngineError::GroupStateUnavailable { .. }))
+        );
+        if !group_state_unavailable {
+            self.groups.insert(conversation_id.clone(), group);
+        }
         let received = received?;
 
         let (payload, sender, epoch) = match received {
@@ -3933,6 +3962,13 @@ impl<B: StorageBackend> Inner<B> {
                 // it as nothing, so the transcript gets §3.4's marker instead.
                 self.advance(stored, index)?;
                 return self.record_unrecoverable(&conversation_id, index, now);
+            }
+            Err(error @ EngineError::GroupStateUnavailable { .. }) => {
+                // `receive` says this exact handle may be ahead of durable
+                // state. It stays out of the live map, and this index stays at
+                // the head of the queue until `reload_group` succeeds on a
+                // later pass and redelivery can be attempted safely.
+                return Err(Error::internal(format!("decrypting: {error}")));
             }
             Err(error) => {
                 self.advance(stored, index)?;

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
@@ -2266,6 +2266,34 @@ enum Inbound {
     Delivery(DeliveryStatus),
 }
 
+/// Why one ciphertext was not applied.
+///
+/// Most refusals are local to one record: `apply_inbound` advances the durable
+/// cursor past them, and the rest of the relay batch can still be considered.
+/// [`EngineError::GroupStateUnavailable`] is different. Its record deliberately
+/// leaves the cursor untouched and removes the unusable group handle, so trying
+/// a later record from the same `READ` could reload the old durable group and
+/// advance the cursor past the ciphertext that must be retried first.
+enum InboundApplyError {
+    Continue(Error),
+    AbortBatch(Error),
+}
+
+impl From<Error> for InboundApplyError {
+    fn from(error: Error) -> Self {
+        Self::Continue(error)
+    }
+}
+
+impl InboundApplyError {
+    fn into_parts(self) -> (Error, bool) {
+        match self {
+            Self::Continue(error) => (error, false),
+            Self::AbortBatch(error) => (error, true),
+        }
+    }
+}
+
 impl<B: StorageBackend> Inner<B> {
     fn records(&self) -> RecordStore<'_, SharedBackend<B>> {
         RecordStore::new(&self.records)
@@ -2796,9 +2824,11 @@ impl<B: StorageBackend> Inner<B> {
 ///
 /// This is a free function taking outcomes rather than a `bool` threaded
 /// through the read loop, because the property is worth a test and a flag
-/// inside an async loop over a socket is not testable. `pump_conversation`'s
-/// local read cursor still advances past a failure, so the next pass does not
-/// spin on it; what does not advance is the deletion.
+/// inside an async loop over a socket is not testable. `pump_conversation`
+/// advances its local cursor past ordinary per-record failures, so the next
+/// pass does not spin on them; what does not advance is the deletion. An
+/// unusable MLS group instead aborts the batch before any later record can
+/// advance past the ciphertext that must be retried.
 fn acknowledgeable(outcomes: &[(u64, bool)]) -> Option<u64> {
     let mut highest = None;
     for (index, committed) in outcomes {
@@ -3839,8 +3869,11 @@ impl<B: StorageBackend> Inner<B> {
         // failure has to stop the acknowledgement there, or a message this
         // device could not write is deleted at the relay by an `ACK` for a
         // later one — §9 rule 1's failure mode reached by the back door. The
-        // local read cursor still advances past the failure, so the next pass
-        // does not spin on it; what does not advance is the deletion.
+        // An ordinary per-record refusal still advances the local read cursor,
+        // so the next pass does not spin on it; what does not advance is the
+        // deletion. An unusable MLS group is the exception: that batch stops
+        // at the failed ciphertext and keeps the local cursor there, because a
+        // later record must not leapfrog state that needs a fresh durable load.
         //
         // The consequence is the correct one and §8's `storage-full` row says
         // so in as many words: an un-ACKed message stays on the relay until its
@@ -3850,16 +3883,20 @@ impl<B: StorageBackend> Inner<B> {
             let index = queued.index;
             let outcome = match crate::relay::unpad(queued.payload.as_slice()) {
                 Ok(ciphertext) => self.apply_inbound(&mut stored, index, &ciphertext).await,
-                Err(error) => Err(error),
+                Err(error) => Err(InboundApplyError::Continue(error)),
             };
             match outcome {
                 Ok(mut produced) => {
                     events.append(&mut produced);
                     outcomes.push((index, true));
                 }
-                Err(error) => {
+                Err(failure) => {
+                    let (error, abort_batch) = failure.into_parts();
                     outcomes.push((index, false));
                     tracing::info!(conversation = %conversation_id, index, code = %error.code(), "inbound");
+                    if abort_batch {
+                        break;
+                    }
                 }
             }
         }
@@ -3908,7 +3945,7 @@ impl<B: StorageBackend> Inner<B> {
         stored: &mut StoredConversation,
         index: u64,
         ciphertext: &[u8],
-    ) -> Result<Vec<Inbound>> {
+    ) -> core::result::Result<Vec<Inbound>, InboundApplyError> {
         let conversation_id = stored.conversation_id.clone();
         let now = now_ms();
         // The MLS dedup key. Derived from the queue coordinates so a re-read
@@ -3923,7 +3960,9 @@ impl<B: StorageBackend> Inner<B> {
             // silently treat that as a handled delivery: retry the durable
             // load first, leaving the queue cursor untouched if it still
             // cannot be read.
-            None => self.reload_group(stored)?,
+            None => self
+                .reload_group(stored)
+                .map_err(InboundApplyError::AbortBatch)?,
         };
         let received: Result<core::result::Result<Received, EngineError>> = (|| {
             let mls = self.mls_ref("apply_inbound")?;
@@ -3961,18 +4000,24 @@ impl<B: StorageBackend> Inner<B> {
                 // plaintext is genuinely gone — but §9 rule 7 forbids rendering
                 // it as nothing, so the transcript gets §3.4's marker instead.
                 self.advance(stored, index)?;
-                return self.record_unrecoverable(&conversation_id, index, now);
+                return self
+                    .record_unrecoverable(&conversation_id, index, now)
+                    .map_err(InboundApplyError::Continue);
             }
             Err(error @ EngineError::GroupStateUnavailable { .. }) => {
                 // `receive` says this exact handle may be ahead of durable
                 // state. It stays out of the live map, and this index stays at
                 // the head of the queue until `reload_group` succeeds on a
                 // later pass and redelivery can be attempted safely.
-                return Err(Error::internal(format!("decrypting: {error}")));
+                return Err(InboundApplyError::AbortBatch(Error::internal(format!(
+                    "decrypting: {error}"
+                ))));
             }
             Err(error) => {
                 self.advance(stored, index)?;
-                return Err(Error::internal(format!("decrypting: {error}")));
+                return Err(InboundApplyError::Continue(Error::internal(format!(
+                    "decrypting: {error}"
+                ))));
             }
         };
 

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/two_record_rollback_over_a_relay.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/two_record_rollback_over_a_relay.rs
@@ -1,24 +1,35 @@
-//! A failed rollback reload stops a real relay batch at its first ciphertext.
+//! A failed rollback reload stops a production-relay batch at its first ciphertext.
 //!
 //! This is intentionally above the MLS crate's focused rollback tests. Two
-//! application messages cross the plugin's real WebSocket client and occupy one
-//! relay `READ`; the receiver then suffers an apply failure followed by a
-//! one-shot restore read failure. The production pump must leave both records
-//! behind the first failure so a fresh durable group load can process them in
-//! order on the next pass.
+//! application messages cross the plugin's real WebSocket client and the actual
+//! `f2z-relay` daemon, backed by its production SQLite store and group-commit
+//! writer, and occupy one relay `READ`. The receiver then suffers an apply
+//! failure followed by a one-shot restore read failure. The production pump
+//! must leave both records behind the first failure so a fresh durable group
+//! load can process them in order on the next pass.
+//!
+//! The daemon is a separate process on purpose. The client plugin cannot link
+//! the AGPL server crate across `rs/README.md`'s licence boundary, and a
+//! `FakeRelay::listen_loopback` socket still exercises the testkit relay rather
+//! than the server ZUULI will meet in deployment. CI builds `f2z-relay` from the
+//! same checkout and supplies `F2Z_RELAY_BIN`; a local run can use the ordinary
+//! `rs/target/debug/f2z-relay` path after building that package.
 
 #![cfg(feature = "relay-harness")]
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use std::collections::HashMap;
+use std::io::{BufRead as _, BufReader, Read as _};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
 
 use f2z_codec::types::PublicKey;
 use f2z_kt_core::types::{Handle, KemPublicKey};
 use f2z_msg_identity::{AccountKeys, DeviceCredentialRequest};
 use f2z_msg_store::{Durability, MemoryBackend, Op, StorageBackend, StoreError};
-use f2z_relay_testkit::fake::FakeRelay;
 use tauri_plugin_f2zmsg::directory::{Directory, ResolvedIdentity, ResolvedPeer};
 use tauri_plugin_f2zmsg::engine::{Engine, IdentityInstall};
 use tauri_plugin_f2zmsg::error::{Error, Result};
@@ -28,6 +39,99 @@ use tauri_plugin_f2zmsg::models::{
 };
 
 const NOW: i64 = 1_800_000_000_000;
+
+/// The actual `f2z-relay` daemon, kept alive for one plugin integration test.
+struct ProductionRelay {
+    child: Child,
+    stderr: Option<JoinHandle<String>>,
+    _scratch: tempfile::TempDir,
+    url: String,
+}
+
+impl ProductionRelay {
+    fn binary() -> PathBuf {
+        if let Some(path) = std::env::var_os("F2Z_RELAY_BIN") {
+            return PathBuf::from(path);
+        }
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../rs/target/debug")
+            .join(format!("f2z-relay{}", std::env::consts::EXE_SUFFIX))
+    }
+
+    fn start() -> Self {
+        let binary = Self::binary();
+        assert!(
+            binary.is_file(),
+            "production relay binary is absent at {}; build it with `cargo +1.97.1 build \
+             --locked --manifest-path rs/Cargo.toml -p f2z-relay --bin f2z-relay`, or set \
+             F2Z_RELAY_BIN",
+            binary.display()
+        );
+        let scratch = tempfile::tempdir().expect("relay scratch directory");
+        let store = scratch.path().join("relay.sqlite");
+        let mut child = Command::new(&binary)
+            .args(["--listen", "127.0.0.1:0"])
+            .args(["--no-admin", "--no-health"])
+            .args(["--store", "sqlite"])
+            .args(["--store-path", &store.to_string_lossy()])
+            .args(["--log-level", "off"])
+            // This variable selects the child executable for the *test*. The
+            // daemon deliberately rejects every unknown `F2Z_RELAY_*` key, so
+            // it must not inherit the harness-only selector.
+            .env_remove("F2Z_RELAY_BIN")
+            .env("F2Z_RELAY_IDENTITY_SEED", "5a".repeat(32))
+            .env("F2Z_RELAY_ANTIABUSE_QUEUE_CREATION_MODE", "open")
+            .env("F2Z_RELAY_ANTIABUSE_CONTACT_APPEND_POW_BITS", "8")
+            .env("F2Z_RELAY_ANTIABUSE_PER_SOURCE_LIMITS", "false")
+            .env("F2Z_RELAY_COMMIT_WINDOW_MS", "1")
+            .env("F2Z_RELAY_QUEUES_EXPIRY_TICK_SECONDS", "3600")
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("start the production f2z-relay daemon");
+        let stderr = child.stderr.take().expect("capture relay startup");
+        let mut stderr = BufReader::new(stderr);
+        let mut startup = String::new();
+        stderr
+            .read_line(&mut startup)
+            .expect("read production relay startup");
+        let url = startup
+            .trim()
+            .strip_prefix("f2z-relay: serving ")
+            .unwrap_or_else(|| panic!("production relay did not start: {startup:?}"))
+            .to_owned();
+        let stderr = std::thread::spawn(move || {
+            let mut remainder = String::new();
+            let _ = stderr.read_to_string(&mut remainder);
+            remainder
+        });
+        Self {
+            child,
+            stderr: Some(stderr),
+            _scratch: scratch,
+            url,
+        }
+    }
+
+    fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+impl Drop for ProductionRelay {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let status = self.child.wait();
+        let stderr = self
+            .stderr
+            .take()
+            .and_then(|thread| thread.join().ok())
+            .unwrap_or_default();
+        if let Err(error) = status {
+            eprintln!("waiting for production relay failed: {error}; stderr: {stderr}");
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 struct FailOnceBackend {
@@ -275,9 +379,8 @@ async fn publish<B: StorageBackend>(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn two_relay_records_remain_behind_an_unavailable_group() {
-    let relay = FakeRelay::with_defaults().expect("fake relay");
-    let server = relay.listen_loopback().await.expect("WebSocket listener");
-    let url = server.url().to_owned();
+    let relay = ProductionRelay::start();
+    let url = relay.url().to_owned();
 
     let directory = Arc::new(HarnessDirectory::default());
     let alice = engine(MemoryBackend::new(), Arc::clone(&directory));

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/two_record_rollback_over_a_relay.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/two_record_rollback_over_a_relay.rs
@@ -26,8 +26,9 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
-use f2z_codec::types::PublicKey;
-use f2z_kt_core::types::{Handle, KemPublicKey};
+use f2z_codec::types::{Digest, PublicKey, RelayId, ShortBytes};
+use f2z_kt_core::entry::{DeviceCredential, DirectoryEntryTBS, EntryKind};
+use f2z_kt_core::types::{Handle, KemPublicKey, LogId};
 use f2z_msg_identity::{AccountKeys, DeviceCredentialRequest};
 use f2z_msg_store::{Durability, MemoryBackend, Op, StorageBackend, StoreError};
 use tauri_plugin_f2zmsg::directory::{Directory, ResolvedIdentity, ResolvedPeer};
@@ -203,8 +204,14 @@ impl StorageBackend for FailOnceBackend {
 #[derive(Clone, Debug)]
 struct Published {
     identity_pk: String,
-    key_package: Vec<u8>,
+    /// The `DirectoryEntryTBS` a log would commit, real credential and all.
+    ///
+    /// §12.6: since a key package is no longer published in the directory, it
+    /// is claimed from the peer's relay one at a time and authenticated
+    /// against this entry — there is no other constructor.
+    entry: DirectoryEntryTBS,
     contact_relay_url: String,
+    contact_relay_id: RelayId,
     contact_addr: String,
 }
 
@@ -268,7 +275,9 @@ impl Directory for HarnessDirectory {
         Ok(ResolvedIdentity {
             resolution: self.resolution(handle, true),
             identity_pk: published.identity_pk,
+            entry: published.entry,
             contact_relay_url: published.contact_relay_url,
+            contact_relay_id: published.contact_relay_id,
             contact_addr: published.contact_addr,
         })
     }
@@ -278,8 +287,9 @@ impl Directory for HarnessDirectory {
         Ok(ResolvedPeer {
             resolution: self.resolution(handle, true),
             identity_pk: published.identity_pk,
-            key_package: published.key_package,
+            entry: published.entry,
             contact_relay_url: published.contact_relay_url,
+            contact_relay_id: published.contact_relay_id,
             contact_addr: published.contact_addr,
         })
     }
@@ -303,7 +313,11 @@ fn engine<B: StorageBackend>(backend: B, directory: Arc<HarnessDirectory>) -> En
     .with_directory(directory)
 }
 
-async fn enroll<B: StorageBackend>(engine: &Engine<B>, handle: &str, seed: u8) {
+async fn enroll<B: StorageBackend>(
+    engine: &Engine<B>,
+    handle: &str,
+    seed: u8,
+) -> (DeviceCredential, PublicKey) {
     let device = engine.prepare_device().await.expect("device keys");
     let account = AccountKeys::from_seed(&[seed; 64], 0).expect("account keys");
     let credential = account
@@ -330,6 +344,8 @@ async fn enroll<B: StorageBackend>(engine: &Engine<B>, handle: &str, seed: u8) {
         .unlock(account.backup_wrap.as_bytes())
         .await
         .expect("unlock");
+    let directory_auth_pk = PublicKey::new(*account.directory_auth.public().as_bytes());
+    (credential, directory_auth_pk)
 }
 
 async fn configure_relay<B: StorageBackend>(engine: &Engine<B>, url: &str) {
@@ -355,12 +371,32 @@ async fn publish<B: StorageBackend>(
     engine: &Engine<B>,
     directory: &HarnessDirectory,
     handle: &str,
+    credential: &DeviceCredential,
+    directory_auth_pk: PublicKey,
 ) {
-    let (contact_relay_url, contact_addr) = engine
+    let (contact_relay_url, contact_relay_id, contact_addr) = engine
         .contact_advert()
         .await
         .expect("contact advert")
         .expect("contact queue");
+    // §12.6: the real `DirectoryEntryTBS` a log would commit — the same shape
+    // `start_conversation`'s claimed key package is authenticated against.
+    let entry = DirectoryEntryTBS {
+        label: ShortBytes::new(f2z_kt_core::labels::LABEL_ENTRY.to_vec()).expect("entry label"),
+        kt_version: 1,
+        log_id: LogId::new([0x11; 32]),
+        handle: credential.credential.handle.clone(),
+        entry_version: 1,
+        kind: EntryKind::SameKey,
+        identity_pk: credential.credential.identity_pk,
+        directory_auth_pk,
+        devices: vec![credential.clone()].into(),
+        revocations: Vec::new().into(),
+        contact_endpoints: Vec::new().into(),
+        prev_entry_hash: Digest::new([0; 32]),
+        no_reset: 0,
+        created_at_ms: 0,
+    };
     directory.publish(
         handle,
         Published {
@@ -370,8 +406,9 @@ async fn publish<B: StorageBackend>(
                 .expect("device info")
                 .identity_fingerprint
                 .replace(' ', ""),
-            key_package: engine.key_package().await.expect("key package"),
+            entry,
             contact_relay_url,
+            contact_relay_id,
             contact_addr,
         },
     );
@@ -387,14 +424,28 @@ async fn two_relay_records_remain_behind_an_unavailable_group() {
     let bob_backend = FailOnceBackend::new();
     let bob = engine(bob_backend.clone(), Arc::clone(&directory));
 
-    enroll(&alice, "alice", 1).await;
-    enroll(&bob, "bob", 2).await;
+    let (alice_credential, alice_directory_auth_pk) = enroll(&alice, "alice", 1).await;
+    let (bob_credential, bob_directory_auth_pk) = enroll(&bob, "bob", 2).await;
     configure_relay(&alice, &url).await;
     configure_relay(&bob, &url).await;
     alice.start().await.expect("start alice");
     bob.start().await.expect("start bob");
-    publish(&alice, &directory, "alice").await;
-    publish(&bob, &directory, "bob").await;
+    publish(
+        &alice,
+        &directory,
+        "alice",
+        &alice_credential,
+        alice_directory_auth_pk,
+    )
+    .await;
+    publish(
+        &bob,
+        &directory,
+        "bob",
+        &bob_credential,
+        bob_directory_auth_pk,
+    )
+    .await;
 
     let conversation = alice
         .start_conversation("bob")

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/two_record_rollback_over_a_relay.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/two_record_rollback_over_a_relay.rs
@@ -1,0 +1,370 @@
+//! A failed rollback reload stops a real relay batch at its first ciphertext.
+//!
+//! This is intentionally above the MLS crate's focused rollback tests. Two
+//! application messages cross the plugin's real WebSocket client and occupy one
+//! relay `READ`; the receiver then suffers an apply failure followed by a
+//! one-shot restore read failure. The production pump must leave both records
+//! behind the first failure so a fresh durable group load can process them in
+//! order on the next pass.
+
+#![cfg(feature = "relay-harness")]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use f2z_codec::types::PublicKey;
+use f2z_kt_core::types::{Handle, KemPublicKey};
+use f2z_msg_identity::{AccountKeys, DeviceCredentialRequest};
+use f2z_msg_store::{Durability, MemoryBackend, Op, StorageBackend, StoreError};
+use f2z_relay_testkit::fake::FakeRelay;
+use tauri_plugin_f2zmsg::directory::{Directory, ResolvedIdentity, ResolvedPeer};
+use tauri_plugin_f2zmsg::engine::{Engine, IdentityInstall};
+use tauri_plugin_f2zmsg::error::{Error, Result};
+use tauri_plugin_f2zmsg::events::{EventSink, NullSink};
+use tauri_plugin_f2zmsg::models::{
+    DirectoryResolution, ErrorCode, MessageBody, Platform, TransportHealth,
+};
+
+const NOW: i64 = 1_800_000_000_000;
+
+#[derive(Clone, Debug)]
+struct FailOnceBackend {
+    inner: Arc<MemoryBackend>,
+    fail_apply: Arc<AtomicBool>,
+    fail_restore_get_after_apply: Arc<AtomicBool>,
+    fail_next_get: Arc<AtomicBool>,
+    apply_failures: Arc<AtomicUsize>,
+    restore_get_failures: Arc<AtomicUsize>,
+}
+
+impl FailOnceBackend {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(MemoryBackend::new()),
+            fail_apply: Arc::new(AtomicBool::new(false)),
+            fail_restore_get_after_apply: Arc::new(AtomicBool::new(false)),
+            fail_next_get: Arc::new(AtomicBool::new(false)),
+            apply_failures: Arc::new(AtomicUsize::new(0)),
+            restore_get_failures: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn fail_apply_and_restore_get_once(&self) {
+        self.fail_restore_get_after_apply
+            .store(true, Ordering::SeqCst);
+        self.fail_apply.store(true, Ordering::SeqCst);
+    }
+
+    fn failure_counts(&self) -> (usize, usize) {
+        (
+            self.apply_failures.load(Ordering::SeqCst),
+            self.restore_get_failures.load(Ordering::SeqCst),
+        )
+    }
+}
+
+impl StorageBackend for FailOnceBackend {
+    fn get(&self, key: &[u8]) -> f2z_msg_store::Result<Option<Vec<u8>>> {
+        if self.fail_next_get.swap(false, Ordering::SeqCst) {
+            self.restore_get_failures.fetch_add(1, Ordering::SeqCst);
+            return Err(StoreError::Backend("injected restore get failure"));
+        }
+        self.inner.get(key)
+    }
+
+    fn apply(&self, ops: &[Op]) -> f2z_msg_store::Result<()> {
+        if self.fail_apply.swap(false, Ordering::SeqCst) {
+            self.apply_failures.fetch_add(1, Ordering::SeqCst);
+            if self
+                .fail_restore_get_after_apply
+                .swap(false, Ordering::SeqCst)
+            {
+                self.fail_next_get.store(true, Ordering::SeqCst);
+            }
+            return Err(StoreError::Backend("injected apply failure"));
+        }
+        self.inner.apply(ops)
+    }
+
+    fn durability(&self) -> Durability {
+        // This test exercises the shipping ACK path after recovery. Atomicity
+        // comes from MemoryBackend; process durability is intentionally asserted
+        // here only so the plugin is permitted to send that ACK.
+        Durability::Durable
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Published {
+    identity_pk: String,
+    key_package: Vec<u8>,
+    contact_relay_url: String,
+    contact_addr: String,
+}
+
+#[derive(Debug, Default)]
+struct HarnessDirectory {
+    entries: Mutex<HashMap<String, Published>>,
+}
+
+impl HarnessDirectory {
+    fn publish(&self, handle: &str, entry: Published) {
+        self.entries
+            .lock()
+            .expect("directory lock")
+            .insert(handle.to_owned(), entry);
+    }
+
+    fn entry(&self, handle: &str) -> Result<Published> {
+        self.entries
+            .lock()
+            .map_err(|_| Error::internal("the harness directory lock was poisoned"))?
+            .get(handle)
+            .cloned()
+            .ok_or_else(|| Error::new(ErrorCode::DirectoryUnreachable, "peer not published"))
+    }
+
+    fn resolution(&self, handle: &str, found: bool) -> DirectoryResolution {
+        DirectoryResolution {
+            handle: handle.to_owned(),
+            found,
+            identity_fingerprint: found.then(|| {
+                self.entries
+                    .lock()
+                    .expect("directory lock")
+                    .get(handle)
+                    .expect("published entry")
+                    .identity_pk
+                    .clone()
+            }),
+            device_count: u32::from(found),
+            entry_version: found.then_some(1),
+            epoch: 1,
+            witness_cosignatures: 1,
+            independent_witnesses: 1,
+            threshold_met: true,
+        }
+    }
+}
+
+impl Directory for HarnessDirectory {
+    fn resolve(&self, handle: &str) -> Result<DirectoryResolution> {
+        let found = self
+            .entries
+            .lock()
+            .map_err(|_| Error::internal("the harness directory lock was poisoned"))?
+            .contains_key(handle);
+        Ok(self.resolution(handle, found))
+    }
+
+    fn resolve_identity(&self, handle: &str) -> Result<ResolvedIdentity> {
+        let published = self.entry(handle)?;
+        Ok(ResolvedIdentity {
+            resolution: self.resolution(handle, true),
+            identity_pk: published.identity_pk,
+            contact_relay_url: published.contact_relay_url,
+            contact_addr: published.contact_addr,
+        })
+    }
+
+    fn resolve_peer(&self, handle: &str) -> Result<ResolvedPeer> {
+        let published = self.entry(handle)?;
+        Ok(ResolvedPeer {
+            resolution: self.resolution(handle, true),
+            identity_pk: published.identity_pk,
+            key_package: published.key_package,
+            contact_relay_url: published.contact_relay_url,
+            contact_addr: published.contact_addr,
+        })
+    }
+
+    fn independent_witnesses(&self) -> u32 {
+        1
+    }
+
+    fn threshold_met(&self) -> bool {
+        true
+    }
+}
+
+fn engine<B: StorageBackend>(backend: B, directory: Arc<HarnessDirectory>) -> Engine<B> {
+    Engine::new(
+        backend,
+        Arc::new(NullSink) as Arc<dyn EventSink>,
+        Platform::ZuuliDesktop,
+    )
+    .expect("engine")
+    .with_directory(directory)
+}
+
+async fn enroll<B: StorageBackend>(engine: &Engine<B>, handle: &str, seed: u8) {
+    let device = engine.prepare_device().await.expect("device keys");
+    let account = AccountKeys::from_seed(&[seed; 64], 0).expect("account keys");
+    let credential = account
+        .identity
+        .issue_device_credential(&DeviceCredentialRequest {
+            handle: Handle::new(handle.as_bytes().to_vec()).expect("handle"),
+            device_pk: PublicKey::new(device.device_pk),
+            device_kem_pk: KemPublicKey::new(device.device_kem_pk).expect("KEM key"),
+            not_before_ms: 0,
+            not_after_ms: u64::MAX / 2,
+        })
+        .expect("credential");
+    engine
+        .install_identity(IdentityInstall {
+            handle: handle.to_owned(),
+            identity_pk: hex::encode(account.identity.public().as_bytes()),
+            credential: f2z_msg_mls::credential::encode(&credential).expect("encode credential"),
+            wrap_key: *account.backup_wrap.as_bytes(),
+            submitted_at: NOW,
+        })
+        .await
+        .expect("install identity");
+    engine
+        .unlock(account.backup_wrap.as_bytes())
+        .await
+        .expect("unlock");
+}
+
+async fn configure_relay<B: StorageBackend>(engine: &Engine<B>, url: &str) {
+    let refusal = engine
+        .add_relay(url)
+        .await
+        .expect_err("cleartext relay requires explicit consent");
+    assert_eq!(refusal.code(), ErrorCode::RelayRefusedInsecure);
+    let relay = engine
+        .list_relays()
+        .await
+        .expect("relay list")
+        .into_iter()
+        .find(|relay| relay.relay_url == url)
+        .expect("stored refused relay");
+    engine
+        .set_relay_trust(&relay.relay_id, true, true)
+        .await
+        .expect("relay consent");
+}
+
+async fn publish<B: StorageBackend>(
+    engine: &Engine<B>,
+    directory: &HarnessDirectory,
+    handle: &str,
+) {
+    let (contact_relay_url, contact_addr) = engine
+        .contact_advert()
+        .await
+        .expect("contact advert")
+        .expect("contact queue");
+    directory.publish(
+        handle,
+        Published {
+            identity_pk: engine
+                .device_info()
+                .await
+                .expect("device info")
+                .identity_fingerprint
+                .replace(' ', ""),
+            key_package: engine.key_package().await.expect("key package"),
+            contact_relay_url,
+            contact_addr,
+        },
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn two_relay_records_remain_behind_an_unavailable_group() {
+    let relay = FakeRelay::with_defaults().expect("fake relay");
+    let server = relay.listen_loopback().await.expect("WebSocket listener");
+    let url = server.url().to_owned();
+
+    let directory = Arc::new(HarnessDirectory::default());
+    let alice = engine(MemoryBackend::new(), Arc::clone(&directory));
+    let bob_backend = FailOnceBackend::new();
+    let bob = engine(bob_backend.clone(), Arc::clone(&directory));
+
+    enroll(&alice, "alice", 1).await;
+    enroll(&bob, "bob", 2).await;
+    configure_relay(&alice, &url).await;
+    configure_relay(&bob, &url).await;
+    alice.start().await.expect("start alice");
+    bob.start().await.expect("start bob");
+    publish(&alice, &directory, "alice").await;
+    publish(&bob, &directory, "bob").await;
+
+    let conversation = alice
+        .start_conversation("bob")
+        .await
+        .expect("start conversation");
+    bob.pump_inbound().await.expect("contact queue pump");
+    let request = bob
+        .list_contact_requests()
+        .await
+        .expect("contact requests")
+        .into_iter()
+        .next()
+        .expect("contact request");
+    let joined = bob
+        .accept_contact_request(&request.request_id)
+        .await
+        .expect("accept contact request");
+    assert_eq!(conversation.conversation_id, joined.conversation_id);
+
+    // The joiner's queue advert crosses the same socket before Alice can send.
+    alice.pump_inbound().await.expect("queue advert pump");
+    assert_eq!(
+        alice
+            .get_conversation(&conversation.conversation_id)
+            .await
+            .expect("conversation")
+            .transport_health,
+        TransportHealth::Ok
+    );
+
+    let first = alice
+        .send_message(&conversation.conversation_id, "first", "first-ref")
+        .await
+        .expect("first append");
+    let second = alice
+        .send_message(&conversation.conversation_id, "second", "second-ref")
+        .await
+        .expect("second append");
+
+    bob_backend.fail_apply_and_restore_get_once();
+    assert_eq!(bob.pump_inbound().await.expect("failed receive pass"), 0);
+    assert_eq!(bob_backend.failure_counts(), (1, 1));
+    assert!(
+        bob.list_messages(&conversation.conversation_id, 100, None, None)
+            .await
+            .expect("messages after failure")
+            .messages
+            .is_empty(),
+        "neither later ciphertext may be applied after the first group becomes unusable"
+    );
+
+    // The backend recovered after its two one-shot failures. A fresh durable
+    // load must restart at the first relay index and deliver both records from
+    // the same batch; the second may not have advanced the cursor past it.
+    let recovered_events = bob.pump_inbound().await.expect("recovery pass");
+    assert!(
+        recovered_events >= 2,
+        "recovering both messages must emit at least their two receive events"
+    );
+    let messages = bob
+        .list_messages(&conversation.conversation_id, 100, None, None)
+        .await
+        .expect("messages after recovery")
+        .messages;
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].msg_id, first.msg_id);
+    assert_eq!(messages[1].msg_id, second.msg_id);
+    assert!(matches!(
+        &messages[0].body,
+        MessageBody::Text { text } if text == "first"
+    ));
+    assert!(matches!(
+        &messages[1].body,
+        MessageBody::Text { text } if text == "second"
+    ));
+}


### PR DESCRIPTION
Closes #699

## Summary
- reload the durable pre-transaction MLS group into the caller handle after a staged or pending commit merge is rolled back
- preserve ephemeral AAD while restoring all durable group state
- prove injected StorageBackend apply failure restores the epoch and allows same-record redelivery
- prove post-merge credential validation failure can be redelivered without becoming OutOfOrder

## Verification
- cargo test -p f2z-msg-mls
- cargo test --locked --all-targets
- scripts/check-rust-fmt.sh --root rs
- scripts/check-rust-clippy.sh --root rs