### PR TITLE
fix(zuuli): preserve unknown participant counts

### DIFF
--- a/wallet/zuuli/src/features/home/LiveRail.tsx
+++ b/wallet/zuuli/src/features/home/LiveRail.tsx
@@ -10,6 +10,7 @@ import { useAsync } from "@/hooks/useAsync";
 import type { Livestream, StreamKind } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import { coverTone } from "@/lib/cover";
+import { participantCountCopy } from "@/lib/participant-count";
 import { SectionHeader } from "./parts";
 
 const KIND_META: Record<
@@ -24,10 +25,11 @@ const KIND_META: Record<
 
 function StreamCard({ stream }: { stream: Livestream }) {
   const kind = KIND_META[stream.kind] ?? KIND_META.broadcast;
+  const participants = participantCountCopy(stream.participants);
   return (
     <Link
       to={`/live/${stream.username}`}
-      aria-label={`${stream.title} — live now, ${stream.participants} watching`}
+      aria-label={`${stream.title} — live now, ${participants.watching}`}
       className="group flex w-[280px] shrink-0 snap-start flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-all hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:w-auto"
     >
       <div
@@ -47,9 +49,7 @@ function StreamCard({ stream }: { stream: Livestream }) {
         </div>
         <div className="absolute bottom-3 right-3 flex items-center gap-1 rounded-full bg-black/55 px-2 py-1 text-xs font-medium text-white backdrop-blur">
           <Users className="h-3.5 w-3.5" aria-hidden />
-          <span className="tabular-nums">
-            {stream.participants.toLocaleString()}
-          </span>
+          <span className="tabular-nums">{participants.value}</span>
         </div>
         <div className="absolute inset-0 grid place-items-center opacity-70 transition-opacity group-hover:opacity-100">
           <RadioTower className="h-8 w-8 text-white/90" aria-hidden />

--- a/wallet/zuuli/src/features/live/Discovery.tsx
+++ b/wallet/zuuli/src/features/live/Discovery.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { live } from "@/lib/api/free2z";
 import { useAsync } from "@/hooks/useAsync";
 import type { StreamKind } from "@/lib/api/types";
+import { compareParticipantCountsDescending } from "@/lib/participant-count";
 import { StreamCard, StreamCardSkeleton } from "./StreamCard";
 import { GoLiveDialog } from "./GoLiveDialog";
 
@@ -51,7 +52,7 @@ export function Discovery() {
     // Live first, then most-watched.
     return [...filtered].sort((a, b) => {
       if (a.live !== b.live) return a.live ? -1 : 1;
-      return b.participants - a.participants;
+      return compareParticipantCountsDescending(a.participants, b.participants);
     });
   }, [data, filter]);
 

--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -41,6 +41,7 @@ import { useSession } from "@/store/session";
 import { formatTuzis, timeAgo, initials, truncateAddress } from "@/lib/format";
 import type { DyteJoinTicket, Livestream, StreamKind } from "@/lib/api/types";
 import { coverTone } from "@/lib/cover";
+import { participantCountCopy } from "@/lib/participant-count";
 import {
   parsePrivateInviteHash,
   privateInviteDisplayUrl,
@@ -136,7 +137,9 @@ export function Room() {
         title: resolved.title,
         kind: resolved.kind,
         live: true,
-        participants: 1,
+        // Starting or joining locally does not reveal an authoritative room
+        // count. Never synthesize the host/viewer into this value.
+        participants: null,
         price_tuzis: resolved.price_tuzis,
         thumbnail: null,
         started_at: new Date().toISOString(),
@@ -228,6 +231,7 @@ export function Room() {
     creatorUsername: stream.username,
     kind: stream.kind,
   });
+  const participants = participantCountCopy(stream.participants);
 
   return (
     <div className="space-y-6 animate-slide-up">
@@ -284,10 +288,7 @@ export function Room() {
             {stream.live ? (
               <div className="absolute right-4 top-4 flex items-center gap-1 rounded-full bg-black/55 px-2.5 py-1 text-xs font-medium text-white backdrop-blur">
                 <Users className="h-3.5 w-3.5" aria-hidden />
-                <span className="tabular-nums">
-                  {(stream.participants + (ticket ? 1 : 0)).toLocaleString()}
-                </span>{" "}
-                watching
+                <span className="tabular-nums">{participants.watching}</span>
               </div>
             ) : null}
 
@@ -1109,7 +1110,7 @@ function ConnectedDetails({
         </div>
       </dl>
       <Separator className="my-3" />
-      <ParticipantStrip count={stream.participants + 1} />
+      <ParticipantStrip count={stream.participants} />
       <Button variant="outline" className="mt-4 w-full gap-2" onClick={onLeave}>
         <LogOut className="h-4 w-4" aria-hidden />
         Leave
@@ -1128,6 +1129,7 @@ function HostControls({
   onEnd: () => void;
 }) {
   const inviteInput = useRef<HTMLInputElement>(null);
+  const participants = participantCountCopy(stream.participants);
   const inviteUrl =
     inviteSecret && typeof window !== "undefined"
       ? privateInviteDisplayUrl({
@@ -1164,10 +1166,7 @@ function HostControls({
         </Badge>
         <span className="flex items-center gap-1 text-xs text-muted-foreground">
           <Users className="h-3.5 w-3.5" aria-hidden />
-          <span className="tabular-nums">
-            {(stream.participants + 1).toLocaleString()}
-          </span>{" "}
-          watching
+          <span className="tabular-nums">{participants.watching}</span>
         </span>
       </div>
       <p className="mt-3 text-xs text-muted-foreground">
@@ -1201,7 +1200,7 @@ function HostControls({
           </p>
         </div>
       ) : null}
-      <ParticipantStrip count={stream.participants + 1} />
+      <ParticipantStrip count={stream.participants} />
       <Button
         variant="destructive"
         className="mt-4 w-full gap-2"
@@ -1216,9 +1215,10 @@ function HostControls({
 
 // The real participant roster, active-speaker highlighting, and chat all
 // live inside the mounted `<Stage>` (RealtimeKit's own meeting UI) — this
-// strip is just a lightweight, always-real count for the ZUULI chrome
-// around it.
-function ParticipantStrip({ count }: { count: number }) {
+// strip is just lightweight ZUULI chrome around it. Its count stays explicitly
+// unavailable until authoritative hydration exists.
+function ParticipantStrip({ count }: { count: number | null }) {
+  const copy = participantCountCopy(count);
   return (
     <div>
       <div className="mb-2 eyebrow text-muted-foreground">
@@ -1227,9 +1227,8 @@ function ParticipantStrip({ count }: { count: number }) {
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
         <Users className="h-3.5 w-3.5" aria-hidden />
         <span className="tabular-nums font-medium text-foreground">
-          {count.toLocaleString()}
+          {copy.watching}
         </span>
-        {count === 1 ? "person watching" : "people watching"}
       </div>
     </div>
   );

--- a/wallet/zuuli/src/features/live/StreamCard.test.tsx
+++ b/wallet/zuuli/src/features/live/StreamCard.test.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { Livestream } from "@/lib/api/types";
+import { StreamCard } from "./StreamCard";
+
+function stream(participants: number | null): Livestream {
+  return {
+    id: "stream",
+    username: "alice",
+    creator: {
+      username: "alice",
+      free2zaddr: "alice",
+      display_name: "Alice",
+    },
+    title: "Truthful stream",
+    kind: "broadcast",
+    live: true,
+    participants,
+    price_tuzis: 0,
+  };
+}
+
+function render(participants: number | null): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <StreamCard stream={stream(participants)} />
+    </MemoryRouter>,
+  );
+}
+
+describe("StreamCard participant count accessibility", () => {
+  it("renders and announces an unavailable count without zero-like copy", () => {
+    const markup = render(null);
+    expect(markup).toContain("Unavailable");
+    expect(markup).toContain(
+      'aria-label="Truthful stream by Alice — live now, Participant count unavailable"',
+    );
+    expect(markup).not.toContain("0 watching");
+    expect(markup).not.toContain("1 watching");
+  });
+
+  it("keeps a real zero visibly and accessibly distinct from unknown", () => {
+    const markup = render(0);
+    expect(markup).toContain(
+      'aria-label="Truthful stream by Alice — live now, 0 people watching"',
+    );
+    expect(markup).toMatch(/<span class="tabular-nums">0<\/span>/);
+    expect(markup).not.toContain("Unavailable");
+  });
+});

--- a/wallet/zuuli/src/features/live/StreamCard.tsx
+++ b/wallet/zuuli/src/features/live/StreamCard.tsx
@@ -7,19 +7,21 @@ import { formatTuzis, timeAgo, initials } from "@/lib/format";
 import type { Livestream } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 import { coverTone } from "@/lib/cover";
+import { participantCountCopy } from "@/lib/participant-count";
 import { KIND_META } from "./lib";
 
 export function StreamCard({ stream }: { stream: Livestream }) {
   const kind = KIND_META[stream.kind] ?? KIND_META.broadcast;
   const creatorName = stream.creator.display_name ?? stream.creator.username;
   const isPaid = stream.kind === "ppv" && stream.price_tuzis > 0;
+  const participants = participantCountCopy(stream.participants);
 
   return (
     <Link
       to={`/live/${stream.username}`}
       aria-label={
         stream.live
-          ? `${stream.title} by ${creatorName} — live now, ${stream.participants} watching`
+          ? `${stream.title} by ${creatorName} — live now, ${participants.watching}`
           : `${stream.title} by ${creatorName} — offline`
       }
       className={cn(
@@ -74,9 +76,7 @@ export function StreamCard({ stream }: { stream: Livestream }) {
         {stream.live ? (
           <div className="absolute bottom-3 right-3 flex items-center gap-1 rounded-full bg-black/55 px-2 py-1 text-xs font-medium text-white backdrop-blur">
             <Users className="h-3.5 w-3.5" aria-hidden />
-            <span className="tabular-nums">
-              {stream.participants.toLocaleString()}
-            </span>
+            <span className="tabular-nums">{participants.value}</span>
           </div>
         ) : null}
 

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -11,6 +11,10 @@ import { usdToTuzis } from "../format";
 import { normalizeArticleTags, sanitizeArticleTags } from "../article-tags";
 import { normalizePrivateSecret } from "../private-live";
 import {
+  normalizeParticipantCount,
+  sumParticipantCounts,
+} from "../participant-count";
+import {
   cancelMobileOAuth,
   captureOAuthCode,
   finishMobileOAuth,
@@ -706,7 +710,9 @@ function mapLivestream(m: RawDyteMeeting): Livestream {
     title: `${creator.display_name} is live`,
     kind,
     live: !!m.live_now,
-    participants: 0,
+    // The public meeting listing does not carry an authoritative count. #265
+    // will hydrate one; until then the only truthful client value is unknown.
+    participants: null,
     price_tuzis: kind === "ppv" ? ppvPrice(m.price_per_minute) : 0,
     thumbnail: creator.image ?? null,
     started_at: undefined,
@@ -1819,12 +1825,15 @@ export const live = {
   async status(
     username: string,
     kind?: StreamKind,
-  ): Promise<{ live: boolean; participants: number }> {
+  ): Promise<{ live: boolean; participants: number | null }> {
     const expectedType = kind ? typeFromStreamKind(kind) : undefined;
     if (useMock()) {
       await delay(120);
       const s = mockLivestreams.find((l) => l.username === username);
-      return { live: s?.live ?? false, participants: s?.participants ?? 0 };
+      return {
+        live: s?.live ?? false,
+        participants: normalizeParticipantCount(s?.participants),
+      };
     }
     try {
       const s = await request<
@@ -1842,14 +1851,13 @@ export const live = {
         })
         .filter(({ key }) => !expectedType || key === expectedType)
         .map(({ entry }) => entry);
-      const participants = entries.reduce(
-        (n, e) => n + (e.participants ?? 0),
-        0,
+      const participants = sumParticipantCounts(
+        entries.map((entry) => entry.participants),
       );
       return { live: entries.length > 0, participants };
     } catch (error) {
       if (error instanceof LivestreamKindContractError) throw error;
-      return { live: false, participants: 0 };
+      return { live: false, participants: null };
     }
   },
 

--- a/wallet/zuuli/src/lib/api/mock-data.ts
+++ b/wallet/zuuli/src/lib/api/mock-data.ts
@@ -394,7 +394,8 @@ export const mockLivestreams: Livestream[] = [
       "PPV: Deep dive — writing a Halo2 circuit from scratch without copying anybody's gadgets",
     kind: "ppv",
     live: true,
-    participants: 38,
+    // Count hydration can be unavailable independently of live status.
+    participants: null,
     price_tuzis: 250,
     thumbnail: null,
     started_at: new Date(Date.now() - 12 * 60000).toISOString(),

--- a/wallet/zuuli/src/lib/api/participant-count-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/participant-count-contract.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./http", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./http")>();
+  return { ...original, request: vi.fn() };
+});
+
+import { live } from "./free2z";
+import { request } from "./http";
+
+const requestMock = vi.mocked(request);
+const creator = {
+  username: "alice",
+  full_name: "Alice",
+  free2zaddr: "alice",
+};
+
+describe("participant count hydration contract", () => {
+  beforeEach(() => requestMock.mockReset());
+
+  it("coalesces concurrent listing reads and never invents a count absent from that endpoint", async () => {
+    requestMock.mockResolvedValue({
+      results: [
+        {
+          id: 1,
+          creator,
+          meeting_id: "broadcast-id",
+          meeting_type: "broadcast",
+          live_now: true,
+        },
+      ],
+    });
+
+    const first = live.listPublic({ force: true });
+    const second = live.listPublic({ force: true });
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(requestMock).toHaveBeenCalledOnce();
+    expect(firstResult).toEqual(secondResult);
+    expect(firstResult).toHaveLength(1);
+    expect(firstResult[0]?.participants).toBeNull();
+  });
+
+  it("preserves an authoritative zero and complete multi-room total", async () => {
+    requestMock
+      .mockResolvedValueOnce({ broadcast: { participants: 0 } })
+      .mockResolvedValueOnce({
+        broadcast: { participants: 9 },
+        "pay-per-view": { participants: 4 },
+      });
+
+    await expect(live.status("alice", "broadcast")).resolves.toEqual({
+      live: true,
+      participants: 0,
+    });
+    await expect(live.status("alice")).resolves.toEqual({
+      live: true,
+      participants: 13,
+    });
+  });
+
+  it("makes missing or malformed partial hydration explicitly unavailable", async () => {
+    requestMock
+      .mockResolvedValueOnce({ broadcast: {} })
+      .mockResolvedValueOnce({
+        broadcast: { participants: 9 },
+        "pay-per-view": {},
+      })
+      .mockResolvedValueOnce({ broadcast: { participants: "9" } });
+
+    await expect(live.status("alice")).resolves.toEqual({
+      live: true,
+      participants: null,
+    });
+    await expect(live.status("alice")).resolves.toEqual({
+      live: true,
+      participants: null,
+    });
+    await expect(live.status("alice")).resolves.toEqual({
+      live: true,
+      participants: null,
+    });
+  });
+
+  it("returns unavailable on empty and failed hydration instead of fabricated zero", async () => {
+    requestMock
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("offline"));
+
+    await expect(live.status("alice")).resolves.toEqual({
+      live: false,
+      participants: null,
+    });
+    await expect(live.status("alice")).resolves.toEqual({
+      live: false,
+      participants: null,
+    });
+  });
+});

--- a/wallet/zuuli/src/lib/api/participant-count-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/participant-count-contract.test.ts
@@ -43,10 +43,12 @@ describe("participant count hydration contract", () => {
 
   it("preserves an authoritative zero and complete multi-room total", async () => {
     requestMock
-      .mockResolvedValueOnce({ broadcast: { participants: 0 } })
       .mockResolvedValueOnce({
-        broadcast: { participants: 9 },
-        "pay-per-view": { participants: 4 },
+        broadcast: { meeting_type: "broadcast", participants: 0 },
+      })
+      .mockResolvedValueOnce({
+        broadcast: { meeting_type: "broadcast", participants: 9 },
+        ppv: { meeting_type: "ppv", participants: 4 },
       });
 
     await expect(live.status("alice", "broadcast")).resolves.toEqual({
@@ -61,12 +63,14 @@ describe("participant count hydration contract", () => {
 
   it("makes missing or malformed partial hydration explicitly unavailable", async () => {
     requestMock
-      .mockResolvedValueOnce({ broadcast: {} })
+      .mockResolvedValueOnce({ broadcast: { meeting_type: "broadcast" } })
       .mockResolvedValueOnce({
-        broadcast: { participants: 9 },
-        "pay-per-view": {},
+        broadcast: { meeting_type: "broadcast", participants: 9 },
+        ppv: { meeting_type: "ppv" },
       })
-      .mockResolvedValueOnce({ broadcast: { participants: "9" } });
+      .mockResolvedValueOnce({
+        broadcast: { meeting_type: "broadcast", participants: "9" },
+      });
 
     await expect(live.status("alice")).resolves.toEqual({
       live: true,

--- a/wallet/zuuli/src/lib/api/participant-count-mock-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/participant-count-mock-contract.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../platform", () => ({ useMock: () => true }));
+
+import { live } from "./free2z";
+
+describe("mock participant count hydration", () => {
+  it("keeps a missing creator unavailable instead of coercing it to zero", async () => {
+    await expect(live.status("missing-creator")).resolves.toEqual({
+      live: false,
+      participants: null,
+    });
+  });
+});

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -356,7 +356,8 @@ export type StreamKind = "broadcast" | "subscriber" | "ppv" | "private";
 export interface LiveStatus {
   username: string;
   live: boolean;
-  participants: number;
+  /** Authoritative hydrated count, or null while the count is unavailable. */
+  participants: number | null;
   kind: StreamKind;
 }
 
@@ -369,7 +370,8 @@ export interface Livestream {
   title: string;
   kind: StreamKind;
   live: boolean;
-  participants: number;
+  /** Authoritative hydrated count, or null while the count is unavailable. */
+  participants: number | null;
   /** 2Z price to join (0 for free broadcast). */
   price_tuzis: number;
   thumbnail?: string | null;

--- a/wallet/zuuli/src/lib/participant-count.test.ts
+++ b/wallet/zuuli/src/lib/participant-count.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareParticipantCountsDescending,
+  normalizeParticipantCount,
+  participantCountCopy,
+  sumParticipantCounts,
+  type ParticipantCount,
+} from "./participant-count";
+
+describe("participant count truthfulness", () => {
+  it("preserves exact non-negative integers without coercing missing or malformed values", () => {
+    expect(normalizeParticipantCount(0)).toBe(0);
+    expect(normalizeParticipantCount(37)).toBe(37);
+
+    for (const unavailable of [
+      null,
+      undefined,
+      "0",
+      "37",
+      -1,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      expect(normalizeParticipantCount(unavailable)).toBeNull();
+    }
+  });
+
+  it("rejects partial and unsafe aggregates instead of adding fallback zeroes", () => {
+    expect(sumParticipantCounts([0])).toBe(0);
+    expect(sumParticipantCounts([12, 5, 0])).toBe(17);
+    expect(sumParticipantCounts([])).toBeNull();
+    expect(sumParticipantCounts([12, undefined, 5])).toBeNull();
+    expect(sumParticipantCounts([12, "5"])).toBeNull();
+    expect(sumParticipantCounts([Number.MAX_SAFE_INTEGER, 1])).toBeNull();
+  });
+
+  it("sorts known positive counts, then known zero, then stable unknowns", () => {
+    const rows: { id: string; count: ParticipantCount }[] = [
+      { id: "unknown-first", count: null },
+      { id: "zero", count: 0 },
+      { id: "eight", count: 8 },
+      { id: "unknown-second", count: null },
+      { id: "three", count: 3 },
+    ];
+
+    expect(
+      rows
+        .sort((left, right) =>
+          compareParticipantCountsDescending(left.count, right.count),
+        )
+        .map(({ id }) => id),
+    ).toEqual(["eight", "three", "zero", "unknown-first", "unknown-second"]);
+    expect(compareParticipantCountsDescending(null, null)).toBe(0);
+    expect(compareParticipantCountsDescending(0, null)).toBeLessThan(0);
+    expect(compareParticipantCountsDescending(null, 0)).toBeGreaterThan(0);
+  });
+
+  it("keeps unavailable, zero, singular, and plural copy distinct", () => {
+    expect(participantCountCopy(null)).toEqual({
+      value: "Unavailable",
+      watching: "Participant count unavailable",
+    });
+    expect(participantCountCopy(0)).toEqual({
+      value: "0",
+      watching: "0 people watching",
+    });
+    expect(participantCountCopy(1)).toEqual({
+      value: "1",
+      watching: "1 person watching",
+    });
+    expect(participantCountCopy(12_345)).toEqual({
+      value: "12,345",
+      watching: "12,345 people watching",
+    });
+  });
+});

--- a/wallet/zuuli/src/lib/participant-count.ts
+++ b/wallet/zuuli/src/lib/participant-count.ts
@@ -1,0 +1,61 @@
+export type ParticipantCount = number | null;
+
+/** Accept only complete, non-negative integer counts from hydration. */
+export function normalizeParticipantCount(value: unknown): ParticipantCount {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : null;
+}
+
+/**
+ * Aggregate only complete hydration. A missing or malformed member makes the
+ * whole total unknown instead of silently contributing a fabricated zero.
+ */
+export function sumParticipantCounts(
+  values: readonly unknown[],
+): ParticipantCount {
+  if (values.length === 0) return null;
+
+  let total = 0;
+  for (const value of values) {
+    const count = normalizeParticipantCount(value);
+    if (count === null) return null;
+    total += count;
+    if (!Number.isSafeInteger(total)) return null;
+  }
+  return total;
+}
+
+/** Most-watched ordering: every known count, including zero, precedes unknown. */
+export function compareParticipantCountsDescending(
+  left: ParticipantCount,
+  right: ParticipantCount,
+): number {
+  if (left === null) return right === null ? 0 : 1;
+  if (right === null) return -1;
+  return right - left;
+}
+
+export interface ParticipantCountCopy {
+  /** Compact value used where the surrounding UI already names the metric. */
+  value: string;
+  /** Complete truthful phrase for visible prose and accessible names. */
+  watching: string;
+}
+
+export function participantCountCopy(
+  count: ParticipantCount,
+): ParticipantCountCopy {
+  if (count === null) {
+    return {
+      value: "Unavailable",
+      watching: "Participant count unavailable",
+    };
+  }
+
+  const value = count.toLocaleString();
+  return {
+    value,
+    watching: `${value} ${count === 1 ? "person" : "people"} watching`,
+  };
+}

--- a/wallet/zuuli/tests/participant-counts.pw.ts
+++ b/wallet/zuuli/tests/participant-counts.pw.ts
@@ -1,0 +1,69 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const privateSecret = "123e4567-e89b-42d3-a456-426614174000";
+
+async function signIn(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+  });
+}
+
+test("known and unavailable counts stay truthful in home and discovery cards", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const homeKnown = page.locator('a[href="/live/nine"]');
+  await expect(homeKnown).toHaveAccessibleName(/214 people watching/);
+  await expect(homeKnown.getByText("214", { exact: true })).toBeVisible();
+
+  const homeUnknown = page.locator('a[href="/live/mining_maya"]');
+  await expect(homeUnknown).toHaveAccessibleName(
+    /Participant count unavailable/,
+  );
+  await expect(
+    homeUnknown.getByText("Unavailable", { exact: true }),
+  ).toBeVisible();
+  await expect(homeUnknown).not.toContainText("0 watching");
+
+  await page.goto("/live");
+
+  const discoveryKnown = page.locator('a[href="/live/nine"]');
+  await expect(discoveryKnown).toHaveAccessibleName(/214 people watching/);
+  await expect(discoveryKnown.getByText("214", { exact: true })).toBeVisible();
+
+  const discoveryUnknown = page.locator('a[href="/live/mining_maya"]');
+  await expect(discoveryUnknown).toHaveAccessibleName(
+    /Participant count unavailable/,
+  );
+  await expect(
+    discoveryUnknown.getByText("Unavailable", { exact: true }),
+  ).toBeVisible();
+});
+
+test("local host and guest tickets never synthesize themselves into the count", async ({
+  page,
+}) => {
+  await signIn(page);
+  await page.goto("/live");
+  await page.getByRole("button", { name: "Go Live" }).click();
+  await page.getByRole("radio", { name: /Private/ }).click();
+  await page.getByLabel("Title").fill("Count-safe private room");
+  await page.getByRole("button", { name: "Start stream" }).click();
+
+  await expect(
+    page.getByText("Participant count unavailable", { exact: true }).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByText("1 person watching", { exact: true }),
+  ).toHaveCount(0);
+
+  await page.goto(`/live/alice#private=${privateSecret}`);
+  await expect(page.getByText("participant", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Participant count unavailable", { exact: true }).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByText("1 person watching", { exact: true }),
+  ).toHaveCount(0);
+});

--- a/wallet/zuuli/tests/participant-counts.pw.ts
+++ b/wallet/zuuli/tests/participant-counts.pw.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
+import { installMockCapture } from "./helpers/mock-capture";
 
 const privateSecret = "123e4567-e89b-42d3-a456-426614174000";
 
@@ -45,11 +46,14 @@ test("local host and guest tickets never synthesize themselves into the count", 
   page,
 }) => {
   await signIn(page);
+  await installMockCapture(page);
   await page.goto("/live");
   await page.getByRole("button", { name: "Go Live" }).click();
   await page.getByRole("radio", { name: /Private/ }).click();
   await page.getByLabel("Title").fill("Count-safe private room");
-  await page.getByRole("button", { name: "Start stream" }).click();
+  await page.getByRole("button", { name: "Set up camera and microphone" }).click();
+  await expect(page.getByRole("heading", { name: "Preview ready" })).toBeVisible();
+  await page.getByRole("button", { name: "Confirm and start" }).click();
 
   await expect(
     page.getByText("Participant count unavailable", { exact: true }).first(),

--- a/wallet/zuuli/tests/participant-counts.pw.ts
+++ b/wallet/zuuli/tests/participant-counts.pw.ts
@@ -67,3 +67,21 @@ test("local host and guest tickets never synthesize themselves into the count", 
     page.getByText("1 person watching", { exact: true }),
   ).toHaveCount(0);
 });
+
+test("joining a public room leaves its known count unchanged", async ({
+  page,
+}) => {
+  await page.goto("/live/nine");
+  await expect(page.getByText("214 people watching", { exact: true })).toHaveCount(
+    1,
+  );
+
+  await page.getByRole("button", { name: "Join free" }).click();
+  await expect(page.getByText("Connected", { exact: true })).toBeVisible();
+  await expect(page.getByText("214 people watching", { exact: true })).toHaveCount(
+    2,
+  );
+  await expect(page.getByText("215 people watching", { exact: true })).toHaveCount(
+    0,
+  );
+});


### PR DESCRIPTION
Closes #794

## Summary
- represent participant counts as explicit `number | null` values and keep absent/failed hydration unavailable
- remove local host/viewer count synthesis and sort known zero ahead of stable unknown values
- render truthful visible and accessible count copy across Live cards, rails, and rooms

## Tests
- `npm run typecheck`
- `npm run typecheck:tests`
- `npx vitest run` (856 passed, 5 skipped)
- `ZUULI_PW_PORT=14794 npx playwright test tests/participant-counts.pw.ts tests/private-live.pw.ts` (5 passed)
- `node --test scripts/ui-copy-truncation.node-test.mjs`
- `npm run build`