### PR TITLE
fix(relay-testkit): close established connections on shutdown

### DIFF
--- a/rs/crates/f2z-relay-testkit/src/connection.rs
+++ b/rs/crates/f2z-relay-testkit/src/connection.rs
@@ -33,15 +33,19 @@ use crate::faults::{Effect, FaultInjector};
 use crate::outbound::{CLOSE_GOING_AWAY, CLOSE_NORMAL, CLOSE_PROTOCOL_ERROR, OutKind, Outbound};
 use crate::transport::{Transport, TransportSink, WireMessage};
 
-/// Serve one connection until either end closes.
-pub async fn drive(relay: Arc<Relay>, transport: Transport) {
+/// Serve one connection until either end closes or the server shuts down.
+pub async fn drive(
+    relay: Arc<Relay>,
+    transport: Transport,
+    mut server_shutdown: watch::Receiver<bool>,
+) {
     let (sink, mut stream) = transport.split();
     let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<Outbound>();
-    let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+    let (writer_finished_tx, mut writer_finished_rx) = watch::channel(false);
 
     let mut connection = relay.open_connection(outbound_tx.clone());
     let faults = relay.faults().clone();
-    let writer = tokio::spawn(writer_task(sink, outbound_rx, faults, shutdown_tx));
+    let writer = tokio::spawn(writer_task(sink, outbound_rx, faults, writer_finished_tx));
 
     let handshake_timeout = relay.config().handshake_timeout;
     let ping_interval = relay.config().ping_interval;
@@ -56,7 +60,16 @@ pub async fn drive(relay: Arc<Relay>, transport: Transport) {
         let waiting_for_hello = !connection.hello_done;
         let received = tokio::select! {
             biased;
-            _ = shutdown_rx.changed() => break,
+            // The writer has already sent any close frame for this path.
+            _ = writer_finished_rx.changed() => break,
+            // Server shutdown is a different event: production sends 1001
+            // before it winds an established connection down, so the test
+            // double must make that observable too. This is alignment with
+            // production rather than a `WIRE.md` conformance requirement.
+            _ = server_shutdown.changed() => {
+                let _ = outbound_tx.send(close_now(CLOSE_GOING_AWAY));
+                break;
+            }
             _ = ping.tick(), if !waiting_for_hello => {
                 // §2.4: the relay sends a Ping every `ws_ping_interval_seconds`
                 // and closes after two consecutive missed Pongs. Server-driven
@@ -174,7 +187,7 @@ async fn writer_task(
     mut sink: Box<dyn TransportSink>,
     mut outbound: mpsc::UnboundedReceiver<Outbound>,
     faults: FaultInjector,
-    shutdown: watch::Sender<bool>,
+    writer_finished: watch::Sender<bool>,
 ) {
     // §4.3's reordering, as a one-frame hold. Held frames are flushed when the
     // connection ends, so a reorder rule that never sees a second frame
@@ -241,7 +254,7 @@ async fn writer_task(
             }
             Some(Effect::CloseBefore) => {
                 let _ = sink.close(CLOSE_PROTOCOL_ERROR).await;
-                let _ = shutdown.send(true);
+                let _ = writer_finished.send(true);
                 return;
             }
             // A refusal never reaches the writer: it was applied in the engine,
@@ -262,12 +275,12 @@ async fn writer_task(
         }
         if let Some(status) = closing {
             let _ = sink.close(status).await;
-            let _ = shutdown.send(true);
+            let _ = writer_finished.send(true);
             return;
         }
         if close_after_effect {
             let _ = sink.close(CLOSE_NORMAL).await;
-            let _ = shutdown.send(true);
+            let _ = writer_finished.send(true);
             return;
         }
         if !inbound_open && parked.is_empty() {
@@ -279,7 +292,7 @@ async fn writer_task(
         let _ = write(&mut sink, waiting).await;
     }
     let _ = sink.close(CLOSE_NORMAL).await;
-    let _ = shutdown.send(true);
+    let _ = writer_finished.send(true);
 }
 
 /// Sleep until `deadline`, or forever when there is nothing parked.

--- a/rs/crates/f2z-relay-testkit/src/fake.rs
+++ b/rs/crates/f2z-relay-testkit/src/fake.rs
@@ -176,7 +176,14 @@ impl FakeRelay {
     pub fn connect(&self) -> Transport {
         let (client_side, relay_side) = duplex(DUPLEX_CAPACITY);
         let relay = Arc::clone(&self.relay);
-        tokio::spawn(crate::connection::drive(relay, relay_side));
+        // An in-process connection has no owning server to shut down. Keep its
+        // sender alive for exactly as long as `drive`, so the new server-
+        // shutdown watch remains distinct from the writer-finished watch.
+        let (server_lifetime, server_shutdown) = tokio::sync::watch::channel(false);
+        tokio::spawn(async move {
+            crate::connection::drive(relay, relay_side, server_shutdown).await;
+            drop(server_lifetime);
+        });
         client_side
     }
 

--- a/rs/crates/f2z-relay-testkit/src/websocket.rs
+++ b/rs/crates/f2z-relay-testkit/src/websocket.rs
@@ -37,6 +37,7 @@ use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt as _, StreamExt as _};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
+use tokio::task::JoinSet;
 use tokio_tungstenite::tungstenite::handshake::server::{
     ErrorResponse, Request as HandshakeRequest, Response as HandshakeResponse,
 };
@@ -195,11 +196,8 @@ impl RelayServer {
         format!("ws://{}{RELAY_PATH}", self.addr)
     }
 
-    /// Stop accepting and wait for the accept loop to finish.
-    ///
-    /// Connections already open are not torn down: a client that is mid-request
-    /// when a test ends should see the request finish, not a truncated stream
-    /// that looks like a fault it did not arm.
+    /// Stop accepting, close established connections with status 1001, and
+    /// wait for the listener and connection tasks to finish.
     pub async fn shutdown(self) {
         let _ = self.shutdown.send(true);
         let _ = self.handle.await;
@@ -242,21 +240,37 @@ pub fn serve(relay: Arc<Relay>, listener: TcpListener) -> Result<RelayServer> {
     let addr = listener.local_addr()?;
     let (shutdown, mut shutdown_rx) = watch::channel(false);
     let handle = tokio::spawn(async move {
+        let mut connections = JoinSet::new();
         loop {
             let accepted = tokio::select! {
+                biased;
                 _ = shutdown_rx.changed() => break,
+                completed = connections.join_next(), if !connections.is_empty() => {
+                    let _ = completed;
+                    continue;
+                }
                 accepted = listener.accept() => accepted,
             };
             let Ok((stream, _peer)) = accepted else {
                 break;
             };
             let relay = Arc::clone(&relay);
-            tokio::spawn(async move {
-                if let Some(transport) = handshake(stream).await {
-                    crate::connection::drive(relay, transport).await;
+            let mut connection_shutdown = shutdown_rx.clone();
+            connections.spawn(async move {
+                let transport = tokio::select! {
+                    biased;
+                    transport = handshake(stream) => transport,
+                    _ = connection_shutdown.changed() => return,
+                };
+                if let Some(transport) = transport {
+                    crate::connection::drive(relay, transport, connection_shutdown).await;
                 }
             });
         }
+        // `drive` sends the close before it returns. Waiting here makes
+        // `RelayServer::shutdown().await` a proof that every established
+        // connection has had the chance to put status 1001 on the wire.
+        while connections.join_next().await.is_some() {}
     });
     Ok(RelayServer {
         addr,

--- a/rs/crates/f2z-relay-testkit/tests/server_shutdown.rs
+++ b/rs/crates/f2z-relay-testkit/tests/server_shutdown.rs
@@ -1,0 +1,62 @@
+//! Alignment checks for the testkit server's graceful-shutdown path.
+//!
+//! `WIRE.md` does not prescribe a WebSocket close status for server shutdown,
+//! so this is deliberately a crate-level comparison with `f2z-relay`, not a
+//! conformance vector.
+
+// An integration test is its own crate, so the workspace's panic/unwrap/expect
+// denials for the unauthenticated relay path are lifted only here.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::arithmetic_side_effects
+)]
+
+use std::time::Duration;
+
+use f2z_relay_testkit::fake::FakeRelay;
+use f2z_relay_testkit::outbound::CLOSE_GOING_AWAY;
+use f2z_relay_testkit::transport::WireMessage;
+use f2z_relay_testkit::websocket;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn shutdown_closes_only_the_target_servers_established_connections() {
+    let stopping_relay = FakeRelay::with_defaults().expect("configurable stopping relay");
+    let stopping_server = stopping_relay
+        .listen_loopback()
+        .await
+        .expect("stopping server binds");
+    let stopping_transport = websocket::connect(&stopping_server.url())
+        .await
+        .expect("stopping server accepts a WebSocket");
+    let (_stopping_sink, mut stopping_stream) = stopping_transport.split();
+
+    let live_relay = FakeRelay::with_defaults().expect("configurable live relay");
+    let live_server = live_relay
+        .listen_loopback()
+        .await
+        .expect("live server binds");
+    let live_transport = websocket::connect(&live_server.url())
+        .await
+        .expect("live server accepts a WebSocket");
+    let (_live_sink, mut live_stream) = live_transport.split();
+
+    stopping_server.shutdown().await;
+
+    let close = tokio::time::timeout(Duration::from_secs(1), stopping_stream.recv())
+        .await
+        .expect("shutdown produces a frame before the socket disappears")
+        .expect("reading the shutdown close succeeds")
+        .expect("shutdown produces a close frame");
+    assert_eq!(close, WireMessage::Close(CLOSE_GOING_AWAY));
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), live_stream.recv())
+            .await
+            .is_err(),
+        "a connection to an independently running server must not receive a close frame"
+    );
+
+    live_server.shutdown().await;
+}


### PR DESCRIPTION
Closes #766

## Summary
- give `connection::drive` a server-shutdown watch distinct from its writer-finished watch
- send WebSocket status 1001 before an established testkit connection winds down, matching production
- track listener-owned connection tasks so `RelayServer::shutdown().await` waits until their close path finishes
- keep in-process connections independent of the listener shutdown lifecycle

## Test rationale
`WIRE.md` names no shutdown close status, so this stays a crate-level production-alignment test rather than a conformance vector.

The new real-WebSocket test was first run against the pre-fix implementation and failed red by timing out while waiting for the shutdown frame. With the implementation present it asserts the target server sends `CLOSE_GOING_AWAY`, and its positive control proves a connection to an independently running server receives no frame.

## Verification
- `cargo +1.97.1 test --locked -p f2z-relay-testkit --test server_shutdown`
- `cargo +1.97.1 test --locked --all-targets`
- `cargo +1.97.1 test --locked --doc`
- `scripts/check-rust-fmt.sh --root rs`
- `scripts/check-rust-clippy.sh --root rs`
- `scripts/check-rust-deny.sh --root rs --config rs/deny.toml`
- `scripts/check-rust-toolchain.sh`
- `git diff --check`