### PR TITLE
feat(zuuli): make discovery autocomplete-first

### DIFF
--- a/wallet/zuuli/src/components/layout/TopBar.tsx
+++ b/wallet/zuuli/src/components/layout/TopBar.tsx
@@ -19,11 +19,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -57,8 +53,7 @@ export function TopBar() {
   // link starts at 0). Reading it during render keyed on `location` keeps it
   // reactive. Hidden on the root/home route, where "back" is meaningless, so
   // it never dead-ends the user out of the app.
-  const historyIdx =
-    (window.history.state?.idx as number | undefined) ?? 0;
+  const historyIdx = (window.history.state?.idx as number | undefined) ?? 0;
   const canGoBack = historyIdx > 0 && location.pathname !== "/";
 
   return (

--- a/wallet/zuuli/src/features/articles/components/TopicFilterAutocomplete.tsx
+++ b/wallet/zuuli/src/features/articles/components/TopicFilterAutocomplete.tsx
@@ -172,7 +172,7 @@ export function TopicFilterAutocomplete({
             onClick={() => onChange([])}
             className="min-tap inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
-            Clear tags
+            Clear topics
           </button>
         </div>
       ) : null}

--- a/wallet/zuuli/src/features/articles/components/TopicFilterAutocomplete.tsx
+++ b/wallet/zuuli/src/features/articles/components/TopicFilterAutocomplete.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { Loader2, Search, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { articles } from "@/lib/api/free2z";
+import { rankTopicSuggestions } from "@/lib/discovery-autocomplete";
+import type { ArticleTagSuggestion } from "@/lib/api/types";
+import { MAX_ARTICLE_TAGS } from "@/lib/article-tags";
+
+interface TopicFilterAutocompleteProps {
+  selected: string[];
+  onChange: (topics: string[]) => void;
+}
+
+const DEBOUNCE_MS = 180;
+
+export function TopicFilterAutocomplete({
+  selected,
+  onChange,
+}: TopicFilterAutocompleteProps) {
+  const listId = useId();
+  const statusId = useId();
+  const requestRef = useRef(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [draft, setDraft] = useState("");
+  const [focused, setFocused] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [initialized, setInitialized] = useState(false);
+  const [error, setError] = useState(false);
+  const [retryNonce, setRetryNonce] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [rawSuggestions, setRawSuggestions] = useState<ArticleTagSuggestion[]>(
+    [],
+  );
+  const selectedKey = selected.join("\u0000");
+  const locale =
+    typeof navigator === "undefined" ? undefined : navigator.language;
+  const suggestions = useMemo(
+    () => rankTopicSuggestions(rawSuggestions, draft, selected, locale),
+    // selectedKey intentionally tracks semantic selection without treating a
+    // newly allocated equivalent array as a changed request.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [draft, locale, rawSuggestions, selectedKey],
+  );
+  const hasDraft = draft.trim().length > 0;
+  const full = selected.length >= MAX_ARTICLE_TAGS;
+  const open = focused && !dismissed && hasDraft && !full;
+
+  useEffect(() => {
+    const request = ++requestRef.current;
+    setActiveIndex(-1);
+    if (!focused || !hasDraft || full) {
+      setLoading(false);
+      setInitialized(false);
+      setRawSuggestions([]);
+      return;
+    }
+
+    setLoading(true);
+    setInitialized(false);
+    setError(false);
+    const timer = window.setTimeout(() => {
+      void articles
+        .suggestTags(draft, selected)
+        .then((next) => {
+          if (requestRef.current !== request) return;
+          setRawSuggestions(next);
+          setInitialized(true);
+        })
+        .catch(() => {
+          if (requestRef.current !== request) return;
+          setRawSuggestions([]);
+          setError(true);
+          setInitialized(true);
+        })
+        .finally(() => {
+          if (requestRef.current === request) setLoading(false);
+        });
+    }, DEBOUNCE_MS);
+
+    return () => {
+      requestRef.current += 1;
+      window.clearTimeout(timer);
+    };
+    // selectedKey captures selected without firing for an equivalent array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draft, focused, full, hasDraft, retryNonce, selectedKey]);
+
+  useEffect(() => {
+    setActiveIndex((current) =>
+      current >= suggestions.length ? suggestions.length - 1 : current,
+    );
+  }, [suggestions.length]);
+
+  function addTopic(name: string) {
+    if (full) return;
+    onChange([...selected, name]);
+    setDraft("");
+    setDismissed(false);
+    setRawSuggestions([]);
+    inputRef.current?.focus();
+  }
+
+  function removeTopic(name: string) {
+    onChange(selected.filter((topic) => topic !== name));
+    inputRef.current?.focus();
+  }
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setDismissed(false);
+      setActiveIndex((current) =>
+        suggestions.length === 0
+          ? -1
+          : Math.min(current + 1, suggestions.length - 1),
+      );
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((current) =>
+        suggestions.length === 0
+          ? -1
+          : current <= 0
+            ? suggestions.length - 1
+            : current - 1,
+      );
+    } else if (
+      event.key === "Enter" &&
+      activeIndex >= 0 &&
+      activeIndex < suggestions.length
+    ) {
+      event.preventDefault();
+      addTopic(suggestions[activeIndex].name);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      setDismissed(true);
+      setActiveIndex(-1);
+    } else if (event.key === "Backspace" && !draft && selected.length > 0) {
+      removeTopic(selected[selected.length - 1]);
+    }
+  }
+
+  const status = loading
+    ? "Loading topics"
+    : error
+      ? "Topics unavailable"
+      : initialized && suggestions.length === 0
+        ? "No topics"
+        : suggestions.length > 0
+          ? `${suggestions.length} topics`
+          : "";
+
+  return (
+    <div className="mb-6 max-w-md" data-topic-filter-autocomplete>
+      {selected.length > 0 ? (
+        <div className="mb-2 flex flex-wrap gap-2" aria-label="Selected topics">
+          {selected.map((topic) => (
+            <button
+              key={topic}
+              type="button"
+              onClick={() => removeTopic(topic)}
+              aria-label={`Remove topic ${topic}`}
+              className="min-tap inline-flex max-w-full items-center gap-1.5 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-left text-xs font-medium text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <span className="min-w-0 break-words">#{topic}</span>
+              <X className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => onChange([])}
+            className="min-tap inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Clear tags
+          </button>
+        </div>
+      ) : null}
+
+      <div
+        className="relative"
+        onFocus={() => setFocused(true)}
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget)) {
+            setFocused(false);
+            setActiveIndex(-1);
+          }
+        }}
+      >
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          aria-hidden
+        />
+        <Input
+          ref={inputRef}
+          type="text"
+          value={draft}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setDismissed(false);
+          }}
+          onKeyDown={onKeyDown}
+          placeholder={full ? "Maximum topics selected" : "Filter by topic"}
+          aria-label="Filter by topic"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={open && suggestions.length > 0}
+          aria-controls={open && suggestions.length > 0 ? listId : undefined}
+          aria-activedescendant={
+            open && activeIndex >= 0 && activeIndex < suggestions.length
+              ? `${listId}-${activeIndex}`
+              : undefined
+          }
+          aria-describedby={statusId}
+          autoComplete="off"
+          disabled={full}
+          className="pl-9 pr-10"
+        />
+        {loading ? (
+          <Loader2
+            className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground"
+            aria-hidden
+          />
+        ) : null}
+
+        {open && suggestions.length > 0 ? (
+          <div
+            id={listId}
+            role="listbox"
+            aria-label="Topic suggestions"
+            className="absolute inset-x-0 top-full z-30 mt-1 overflow-hidden rounded-xl border border-border bg-card shadow-lg"
+          >
+            {suggestions.map((suggestion, index) => (
+              <button
+                id={`${listId}-${index}`}
+                key={suggestion.name}
+                type="button"
+                role="option"
+                aria-selected={activeIndex === index}
+                onPointerDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => addTopic(suggestion.name)}
+                className="flex min-h-11 w-full items-center justify-between gap-3 border-b border-border px-3 py-2 text-left last:border-b-0 hover:bg-secondary aria-selected:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+              >
+                <span className="min-w-0 break-words text-sm">
+                  #{suggestion.name}
+                </span>
+                <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                  {suggestion.count.toLocaleString(locale)}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : open && error ? (
+          <div className="absolute inset-x-0 top-full z-30 mt-1 flex min-h-11 items-center justify-between gap-3 rounded-xl border border-border bg-card px-3 py-2 shadow-lg">
+            <span className="text-sm text-muted-foreground">
+              Topics unavailable
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setRetryNonce((current) => current + 1)}
+            >
+              Try again
+            </Button>
+          </div>
+        ) : open && !loading && initialized ? (
+          <p className="absolute inset-x-0 top-full z-30 mt-1 rounded-xl border border-border bg-card px-3 py-3 text-sm text-muted-foreground shadow-lg">
+            No topics
+          </p>
+        ) : null}
+      </div>
+      <span id={statusId} className="sr-only" aria-live="polite">
+        {status}
+      </span>
+    </div>
+  );
+}

--- a/wallet/zuuli/src/features/articles/pages/Feed.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Feed.tsx
@@ -10,13 +10,13 @@ import { useRouteScroll } from "@/hooks/useRouteScroll";
 import { cn } from "@/lib/utils";
 import { MESSAGE_KEYS } from "@/i18n/messages";
 import {
-  isArticleTagFilterable,
   MAX_ARTICLE_TAGS,
   parseArticleTagsParam,
   sanitizeArticleTags,
 } from "@/lib/article-tags";
 import type { ArticleSort } from "@/lib/api/types";
 import { ArticleCard, ArticleCardSkeleton } from "../components/ArticleCard";
+import { TopicFilterAutocomplete } from "../components/TopicFilterAutocomplete";
 import { useArticleFeed } from "../useArticleFeed";
 
 /** The user-facing ranking options (backend `homeSort` values). */
@@ -45,25 +45,16 @@ export function Feed() {
     return () => clearTimeout(id);
   }, [searchInput]);
 
-  const { items, count, loading, loadingMore, error, hasMore, loadMore, reload } =
-    useArticleFeed({ sort, tags: selectedTags, search });
-
-  // Accumulate tags seen across pages so the filter chips grow as you scroll,
-  // and never drop a tag the user has already selected.
-  const [knownTags, setKnownTags] = useState<string[]>([]);
-  useEffect(() => {
-    setKnownTags((prev) => {
-      const set = new Set(prev);
-      for (const article of items) {
-        for (const tag of sanitizeArticleTags(article.tags ?? [])) set.add(tag);
-      }
-      for (const t of selectedTags) set.add(t);
-      const merged = Array.from(set).sort();
-      return merged.length === prev.length && merged.every((t, i) => t === prev[i])
-        ? prev
-        : merged;
-    });
-  }, [items, selectedTags]);
+  const {
+    items,
+    count,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    loadMore,
+    reload,
+  } = useArticleFeed({ sort, tags: selectedTags, search });
 
   function updateSelectedTags(tags: string[]) {
     const canonical = sanitizeArticleTags(tags).slice(0, MAX_ARTICLE_TAGS);
@@ -71,14 +62,6 @@ export function Feed() {
     if (canonical.length > 0) next.set("tags", canonical.join(","));
     else next.delete("tags");
     setParams(next);
-  }
-
-  function toggleTag(tag: string) {
-    updateSelectedTags(
-      selectedTags.includes(tag)
-        ? selectedTags.filter((candidate) => candidate !== tag)
-        : [...selectedTags, tag],
-    );
   }
 
   // Infinite scroll: fire loadMore when the sentinel scrolls into view.
@@ -96,8 +79,6 @@ export function Feed() {
   }, [loadMore, sentinel, viewport]);
 
   const hasFilters = selectedTags.length > 0 || search.length > 0;
-  const showTagBar = knownTags.length > 0;
-
   const grid = useMemo(
     () => (
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -181,58 +162,16 @@ export function Feed() {
         </div>
       </div>
 
-      {/* Tag filter (AND semantics) */}
-      {showTagBar ? (
-        <div className="mb-6 flex flex-wrap items-center gap-2" aria-label="Filter by tag">
-          {knownTags.map((tag) => {
-            const on = selectedTags.includes(tag);
-            if (!isArticleTagFilterable(tag)) {
-              return (
-                <span
-                  key={tag}
-                  className="min-tap inline-flex max-w-full items-center rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground"
-                >
-                  <span className="min-w-0 break-words">{tag}</span>
-                </span>
-              );
-            }
-            return (
-              <button
-                key={tag}
-                type="button"
-                aria-pressed={on}
-                onClick={() => toggleTag(tag)}
-                className={cn(
-                  "min-tap max-w-full break-words rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  on
-                    ? "border-primary bg-primary/15 text-primary"
-                    : "border-border bg-transparent text-muted-foreground hover:bg-secondary hover:text-foreground",
-                )}
-              >
-                {tag}
-              </button>
-            );
-          })}
-          {selectedTags.length > 0 ? (
-            <button
-              type="button"
-              onClick={() => updateSelectedTags([])}
-              className="min-tap inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              <X className="h-3 w-3" aria-hidden />
-              Clear tags
-            </button>
-          ) : null}
-        </div>
-      ) : null}
+      <TopicFilterAutocomplete
+        selected={selectedTags}
+        onChange={updateSelectedTags}
+      />
 
       {/* Result count */}
       {!loading && !error && items.length > 0 ? (
         <p className="mb-4 text-sm text-muted-foreground tabular-nums">
           {count.toLocaleString()} {count === 1 ? "article" : "articles"}
-          {selectedTags.length > 0
-            ? ` tagged ${selectedTags.join(" + ")}`
-            : ""}
+          {selectedTags.length > 0 ? ` tagged ${selectedTags.join(" + ")}` : ""}
         </p>
       ) : null}
 
@@ -257,9 +196,7 @@ export function Feed() {
       ) : items.length === 0 ? (
         <EmptyState
           icon={search ? Search : Newspaper}
-          title={
-            hasFilters ? "No matching articles" : "No articles yet"
-          }
+          title={hasFilters ? "No matching articles" : "No articles yet"}
           description={
             hasFilters
               ? "Nothing matched your search and filters. Try broadening them."
@@ -306,7 +243,10 @@ export function Feed() {
             </div>
           ) : hasMore ? (
             <div className="flex justify-center py-8 text-muted-foreground">
-              <Loader2 className="h-5 w-5 animate-spin" aria-label="Loading more" />
+              <Loader2
+                className="h-5 w-5 animate-spin"
+                aria-label="Loading more"
+              />
             </div>
           ) : (
             <p className="py-8 text-center text-sm text-muted-foreground">

--- a/wallet/zuuli/src/features/articles/pages/Feed.tsx
+++ b/wallet/zuuli/src/features/articles/pages/Feed.tsx
@@ -10,6 +10,7 @@ import { useRouteScroll } from "@/hooks/useRouteScroll";
 import { cn } from "@/lib/utils";
 import { MESSAGE_KEYS } from "@/i18n/messages";
 import {
+  isArticleTagFilterable,
   MAX_ARTICLE_TAGS,
   parseArticleTagsParam,
   sanitizeArticleTags,
@@ -57,7 +58,9 @@ export function Feed() {
   } = useArticleFeed({ sort, tags: selectedTags, search });
 
   function updateSelectedTags(tags: string[]) {
-    const canonical = sanitizeArticleTags(tags).slice(0, MAX_ARTICLE_TAGS);
+    const canonical = sanitizeArticleTags(tags)
+      .filter(isArticleTagFilterable)
+      .slice(0, MAX_ARTICLE_TAGS);
     const next = new URLSearchParams(params);
     if (canonical.length > 0) next.set("tags", canonical.join(","));
     else next.delete("tags");

--- a/wallet/zuuli/src/features/search/index.tsx
+++ b/wallet/zuuli/src/features/search/index.tsx
@@ -1,22 +1,19 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import {
   BadgeCheck,
   BookOpen,
   Clock,
   FileText,
+  Hash,
   Loader2,
   Radio,
   Search as SearchIcon,
   Users,
   X,
 } from "lucide-react";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -28,7 +25,12 @@ import { SectionLoadError } from "@/components/common/SectionLoadError";
 import { RemoteMedia } from "@/components/common/RemoteMedia";
 import { formatTuzis, initials, timeAgo } from "@/lib/format";
 import type { Article, SimpleCreator } from "@/lib/api/types";
-import { withSearchQuery } from "@/lib/search-route";
+import {
+  buildDiscoverySuggestions,
+  type DiscoverySuggestion,
+} from "@/lib/discovery-autocomplete";
+import { MAX_ARTICLE_TAGS, sanitizeArticleTags } from "@/lib/article-tags";
+import { SEARCH_INPUT_LABEL, withSearchQuery } from "@/lib/search-route";
 import { MESSAGE_KEYS } from "@/i18n/messages";
 import { useCreatorSearch, usePageSearch } from "./pagination";
 
@@ -46,12 +48,49 @@ function excerpt(text: string, max = 160): string {
 export default function SearchFeature() {
   const { t } = useTranslation();
   const [params, setParams] = useSearchParams();
+  const navigate = useNavigate();
   const query = params.get("q") ?? "";
   const debounced = useDebounced(query, DEBOUNCE_MS);
   const inputRef = useRef<HTMLInputElement>(null);
-  const searchKey = debounced.trim();
+  const listId = useId();
+  const statusId = useId();
+  const [focused, setFocused] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const selectedTopics = useMemo(
+    () =>
+      sanitizeArticleTags(params.getAll("topic")).slice(0, MAX_ARTICLE_TAGS),
+    [params],
+  );
+  const debouncedInput = debounced.trim();
+  const inputSettled = query.trim() === debouncedInput;
+  const searchKey = [debouncedInput, ...selectedTopics]
+    .filter(Boolean)
+    .join(" ");
   const creators = useCreatorSearch(searchKey);
   const pages = usePageSearch(searchKey);
+  const locale =
+    typeof navigator === "undefined" ? undefined : navigator.language;
+  const suggestions = useMemo(() => {
+    if (!inputSettled) return [];
+    const next = buildDiscoverySuggestions({
+      query,
+      creators: creators.items,
+      pages: pages.items,
+      selectedTopics,
+      locale,
+    });
+    return selectedTopics.length >= MAX_ARTICLE_TAGS
+      ? next.filter((suggestion) => suggestion.kind !== "topic")
+      : next;
+  }, [
+    creators.items,
+    inputSettled,
+    locale,
+    pages.items,
+    query,
+    selectedTopics,
+  ]);
 
   // Focus the box on mount for a keyboard-first feel.
   useEffect(() => {
@@ -60,7 +99,28 @@ export default function SearchFeature() {
 
   // The route, not the debounce timer, owns visible empty-vs-results state.
   // Clearing `?q=` must clear the screen in the same render.
-  const hasQuery = query.trim().length > 0;
+  const hasQuery = query.trim().length > 0 || selectedTopics.length > 0;
+  const loadingSuggestions =
+    !inputSettled ||
+    creators.loading ||
+    pages.loading ||
+    (!creators.initialized && !creators.error) ||
+    (!pages.initialized && !pages.error);
+  const suggestionsInitialized =
+    inputSettled &&
+    (creators.initialized || Boolean(creators.error)) &&
+    (pages.initialized || Boolean(pages.error));
+  const suggestionError = Boolean(
+    (creators.error || pages.error) && suggestions.length === 0,
+  );
+  const popupOpen =
+    focused &&
+    !dismissed &&
+    query.trim().length > 0 &&
+    (loadingSuggestions ||
+      suggestionsInitialized ||
+      suggestionError ||
+      suggestions.length > 0);
   const creatorCount = creators.count ?? 0;
   const pageCount = pages.count ?? 0;
 
@@ -81,57 +141,282 @@ export default function SearchFeature() {
     params,
   ]);
 
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [query, searchKey]);
+
+  useEffect(() => {
+    setActiveIndex((current) =>
+      current >= suggestions.length ? suggestions.length - 1 : current,
+    );
+  }, [suggestions.length]);
+
+  function updateTopics(topics: string[]) {
+    setParams(
+      (current) => {
+        return withSelectedTopics(current, topics);
+      },
+      { replace: true },
+    );
+  }
+
+  function withSelectedTopics(current: URLSearchParams, topics: string[]) {
+    const next = new URLSearchParams(current);
+    next.delete("topic");
+    for (const topic of sanitizeArticleTags(topics).slice(
+      0,
+      MAX_ARTICLE_TAGS,
+    )) {
+      next.append("topic", topic);
+    }
+    return next;
+  }
+
+  function chooseSuggestion(suggestion: DiscoverySuggestion) {
+    if (suggestion.kind === "topic") {
+      setParams(
+        (current) => {
+          return withSelectedTopics(withSearchQuery(current, ""), [
+            ...selectedTopics,
+            suggestion.label,
+          ]);
+        },
+        { replace: true },
+      );
+      setDismissed(false);
+      inputRef.current?.focus();
+      return;
+    }
+    if (suggestion.kind === "creator") {
+      navigate(`/creator/${suggestion.creator.username}`);
+      return;
+    }
+    navigate(`/articles/${suggestion.article.slug ?? suggestion.article.id}`);
+  }
+
+  function onSearchKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setDismissed(false);
+      setActiveIndex((current) =>
+        suggestions.length === 0
+          ? -1
+          : Math.min(current + 1, suggestions.length - 1),
+      );
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setDismissed(false);
+      setActiveIndex((current) =>
+        suggestions.length === 0
+          ? -1
+          : current <= 0
+            ? suggestions.length - 1
+            : current - 1,
+      );
+    } else if (
+      event.key === "Enter" &&
+      activeIndex >= 0 &&
+      activeIndex < suggestions.length
+    ) {
+      event.preventDefault();
+      chooseSuggestion(suggestions[activeIndex]);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      setDismissed(true);
+      setActiveIndex(-1);
+    }
+  }
+
   return (
     <div className="animate-slide-up">
       <PageHeader title={t(MESSAGE_KEYS.navSearchAction)} />
 
-      {/* Search box */}
-      <div className="relative mb-6 max-w-2xl">
-        <SearchIcon
-          className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-          aria-hidden
-        />
-        <Input
-          ref={inputRef}
-          type="text"
-          role="searchbox"
-          inputMode="search"
-          enterKeyHint="search"
-          value={query}
-          onChange={(e) => {
-            const value = e.target.value;
-            setParams((current) => withSearchQuery(current, value), {
-              replace: true,
-            });
-          }}
-          placeholder={t(MESSAGE_KEYS.navSearchAction)}
-          aria-label={t(MESSAGE_KEYS.navSearch)}
-          data-custom-search-clear
-          className="h-12 pl-10 pr-14 text-base"
-        />
-        {query ? (
-          <button
-            type="button"
-            onClick={() => {
-              setParams((current) => withSearchQuery(current, ""), {
-                replace: true,
-              });
-              inputRef.current?.focus();
-            }}
-            aria-label={t(MESSAGE_KEYS.searchClear)}
-            className="min-tap absolute right-1.5 top-1/2 grid h-12 w-12 min-h-12 min-w-12 -translate-y-1/2 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      <div className="mb-6 max-w-2xl">
+        {selectedTopics.length > 0 ? (
+          <div
+            className="mb-2 flex flex-wrap gap-2"
+            aria-label="Selected topics"
           >
-            <X className="h-4 w-4" aria-hidden />
-          </button>
+            {selectedTopics.map((topic) => (
+              <button
+                key={topic}
+                type="button"
+                onClick={() =>
+                  updateTopics(
+                    selectedTopics.filter((candidate) => candidate !== topic),
+                  )
+                }
+                aria-label={`Remove topic ${topic}`}
+                className="min-tap inline-flex max-w-full items-center gap-1.5 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-left text-xs font-medium text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <span className="min-w-0 break-words">#{topic}</span>
+                <X className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              </button>
+            ))}
+          </div>
         ) : null}
+
+        <div
+          className="relative"
+          onFocus={() => setFocused(true)}
+          onBlur={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget)) {
+              setFocused(false);
+              setActiveIndex(-1);
+            }
+          }}
+        >
+          <SearchIcon
+            className="pointer-events-none absolute left-3.5 top-6 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <Input
+            ref={inputRef}
+            type="text"
+            role="combobox"
+            inputMode="search"
+            enterKeyHint="search"
+            value={query}
+            onChange={(event) => {
+              setDismissed(false);
+              setParams(
+                (current) => withSearchQuery(current, event.target.value),
+                { replace: true },
+              );
+            }}
+            onKeyDown={onSearchKeyDown}
+            placeholder="Search creators, pages, topics"
+            aria-label={SEARCH_INPUT_LABEL}
+            aria-autocomplete="list"
+            aria-expanded={popupOpen && suggestions.length > 0}
+            aria-controls={
+              popupOpen && suggestions.length > 0 ? listId : undefined
+            }
+            aria-activedescendant={
+              popupOpen && activeIndex >= 0 && activeIndex < suggestions.length
+                ? `${listId}-${activeIndex}`
+                : undefined
+            }
+            aria-describedby={statusId}
+            autoComplete="off"
+            data-custom-search-clear
+            className="h-12 pl-10 pr-14 text-base"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={() => {
+                setParams((current) => withSearchQuery(current, ""), {
+                  replace: true,
+                });
+                setDismissed(false);
+                inputRef.current?.focus();
+              }}
+              aria-label={t(MESSAGE_KEYS.searchClear)}
+              className="min-tap absolute right-1.5 top-6 grid h-12 w-12 min-h-12 min-w-12 -translate-y-1/2 place-items-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <X className="h-4 w-4" aria-hidden />
+            </button>
+          ) : null}
+
+          {popupOpen ? (
+            suggestions.length > 0 ? (
+              <div
+                id={listId}
+                role="listbox"
+                aria-label="Search suggestions"
+                className="absolute inset-x-0 top-full z-30 mt-1 overflow-hidden rounded-xl border border-border bg-card shadow-lg"
+              >
+                {suggestions.map((suggestion, index) => (
+                  <button
+                    id={`${listId}-${index}`}
+                    key={suggestion.key}
+                    type="button"
+                    role="option"
+                    data-suggestion-kind={suggestion.kind}
+                    aria-selected={activeIndex === index}
+                    onPointerDown={(event) => event.preventDefault()}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onClick={() => chooseSuggestion(suggestion)}
+                    className="flex min-h-11 w-full items-center gap-3 border-b border-border px-3 py-2 text-left last:border-b-0 hover:bg-secondary aria-selected:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                  >
+                    {suggestion.kind === "topic" ? (
+                      <Hash
+                        className="h-4 w-4 shrink-0 text-muted-foreground"
+                        aria-hidden
+                      />
+                    ) : suggestion.kind === "creator" ? (
+                      <Users
+                        className="h-4 w-4 shrink-0 text-muted-foreground"
+                        aria-hidden
+                      />
+                    ) : (
+                      <FileText
+                        className="h-4 w-4 shrink-0 text-muted-foreground"
+                        aria-hidden
+                      />
+                    )}
+                    <span className="min-w-0 flex-1">
+                      <span className="block break-words text-sm font-medium">
+                        {suggestion.kind === "topic" ? "#" : ""}
+                        {suggestion.label}
+                      </span>
+                      <span className="block break-words text-xs text-muted-foreground">
+                        {suggestion.kind === "topic"
+                          ? "Topic"
+                          : suggestion.kind === "creator"
+                            ? suggestion.detail
+                            : `Page · ${suggestion.detail}`}
+                      </span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : suggestionError ? (
+              <div className="absolute inset-x-0 top-full z-30 mt-1 flex min-h-11 items-center justify-between gap-3 rounded-xl border border-border bg-card px-3 py-2 shadow-lg">
+                <span className="text-sm text-muted-foreground">
+                  Search unavailable
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    creators.retry();
+                    pages.retry();
+                  }}
+                >
+                  Try again
+                </Button>
+              </div>
+            ) : suggestionsInitialized && !loadingSuggestions ? (
+              <p className="absolute inset-x-0 top-full z-30 mt-1 rounded-xl border border-border bg-card px-3 py-3 text-sm text-muted-foreground shadow-lg">
+                No matches
+              </p>
+            ) : (
+              <p className="absolute inset-x-0 top-full z-30 mt-1 flex min-h-11 items-center gap-2 rounded-xl border border-border bg-card px-3 py-3 text-sm text-muted-foreground shadow-lg">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Searching
+              </p>
+            )
+          ) : null}
+          <span id={statusId} className="sr-only" aria-live="polite">
+            {loadingSuggestions && query.trim()
+              ? "Searching"
+              : suggestionError
+                ? "Search unavailable"
+                : suggestionsInitialized && query.trim()
+                  ? `${suggestions.length} suggestions`
+                  : ""}
+          </span>
+        </div>
       </div>
 
       {!hasQuery ? (
-        <EmptyState
-          icon={SearchIcon}
-          title={t(MESSAGE_KEYS.searchAll)}
-        />
-      ) : (
+        <p className="text-sm text-muted-foreground">
+          {t(MESSAGE_KEYS.searchAll)}
+        </p>
+      ) : !inputSettled ? null : (
         <Tabs
           value={selectedTab}
           onValueChange={(tab) => {
@@ -193,6 +478,7 @@ export default function SearchFeature() {
               <EmptyState
                 icon={Users}
                 title="No creators found"
+                description={`No creators match “${searchKey}”. Creators are matched by username and name.`}
               />
             ) : creators.items.length > 0 ? (
               <>
@@ -241,7 +527,7 @@ export default function SearchFeature() {
               <EmptyState
                 icon={BookOpen}
                 title="No pages found"
-                description={`No pages match “${debounced.trim()}”. Try different or broader terms.`}
+                description={`No pages match “${searchKey}”. Try different or broader terms.`}
               />
             ) : pages.items.length > 0 ? (
               <>

--- a/wallet/zuuli/src/features/search/index.tsx
+++ b/wallet/zuuli/src/features/search/index.tsx
@@ -30,7 +30,7 @@ import {
   type DiscoverySuggestion,
 } from "@/lib/discovery-autocomplete";
 import { MAX_ARTICLE_TAGS, sanitizeArticleTags } from "@/lib/article-tags";
-import { SEARCH_INPUT_LABEL, withSearchQuery } from "@/lib/search-route";
+import { withSearchQuery } from "@/lib/search-route";
 import { MESSAGE_KEYS } from "@/i18n/messages";
 import { useCreatorSearch, usePageSearch } from "./pagination";
 
@@ -359,8 +359,8 @@ export default function SearchFeature() {
               );
             }}
             onKeyDown={onSearchKeyDown}
-            placeholder="Search"
-            aria-label={SEARCH_INPUT_LABEL}
+            placeholder={t(MESSAGE_KEYS.navSearchAction)}
+            aria-label={t(MESSAGE_KEYS.navSearch)}
             aria-autocomplete="list"
             aria-expanded={popupOpen && suggestions.length > 0}
             aria-controls={

--- a/wallet/zuuli/src/features/search/index.tsx
+++ b/wallet/zuuli/src/features/search/index.tsx
@@ -52,6 +52,9 @@ export default function SearchFeature() {
   const query = params.get("q") ?? "";
   const debounced = useDebounced(query, DEBOUNCE_MS);
   const inputRef = useRef<HTMLInputElement>(null);
+  const autocompleteRef = useRef<HTMLDivElement>(null);
+  const pointerInteractionRef = useRef(false);
+  const pointerReleaseTimerRef = useRef<number | null>(null);
   const listId = useId();
   const statusId = useId();
   const [focused, setFocused] = useState(false);
@@ -95,6 +98,45 @@ export default function SearchFeature() {
   // Focus the box on mount for a keyboard-first feel.
   useEffect(() => {
     inputRef.current?.focus();
+    const finishReleasedPointer = (event: PointerEvent) => {
+      if (!pointerInteractionRef.current) return;
+      if (pointerReleaseTimerRef.current !== null) {
+        window.clearTimeout(pointerReleaseTimerRef.current);
+      }
+      const target = event.target;
+      pointerReleaseTimerRef.current = window.setTimeout(() => {
+        pointerReleaseTimerRef.current = null;
+        if (!pointerInteractionRef.current) return;
+        pointerInteractionRef.current = false;
+        if (
+          target instanceof Node &&
+          autocompleteRef.current?.contains(target)
+        ) {
+          return;
+        }
+        setFocused(false);
+        setActiveIndex(-1);
+      }, 0);
+    };
+    const cancelPointer = () => {
+      if (!pointerInteractionRef.current) return;
+      pointerInteractionRef.current = false;
+      if (pointerReleaseTimerRef.current !== null) {
+        window.clearTimeout(pointerReleaseTimerRef.current);
+        pointerReleaseTimerRef.current = null;
+      }
+      setFocused(false);
+      setActiveIndex(-1);
+    };
+    window.addEventListener("pointerup", finishReleasedPointer);
+    window.addEventListener("pointercancel", cancelPointer);
+    return () => {
+      window.removeEventListener("pointerup", finishReleasedPointer);
+      window.removeEventListener("pointercancel", cancelPointer);
+      if (pointerReleaseTimerRef.current !== null) {
+        window.clearTimeout(pointerReleaseTimerRef.current);
+      }
+    };
   }, []);
 
   // The route, not the debounce timer, owns visible empty-vs-results state.
@@ -227,8 +269,37 @@ export default function SearchFeature() {
     }
   }
 
+  function dismissAutocomplete() {
+    setFocused(false);
+    setActiveIndex(-1);
+  }
+
+  function finishPointerInteraction(target: EventTarget | null) {
+    pointerInteractionRef.current = false;
+    if (pointerReleaseTimerRef.current !== null) {
+      window.clearTimeout(pointerReleaseTimerRef.current);
+      pointerReleaseTimerRef.current = null;
+    }
+    if (target instanceof Node && autocompleteRef.current?.contains(target)) {
+      return;
+    }
+    dismissAutocomplete();
+  }
+
   return (
-    <div className="animate-slide-up">
+    <div
+      className="animate-slide-up"
+      onPointerDownCapture={() => {
+        pointerInteractionRef.current = true;
+        if (pointerReleaseTimerRef.current !== null) {
+          window.clearTimeout(pointerReleaseTimerRef.current);
+          pointerReleaseTimerRef.current = null;
+        }
+      }}
+      onClickCapture={(event) => {
+        finishPointerInteraction(event.target);
+      }}
+    >
       <PageHeader title={t(MESSAGE_KEYS.navSearchAction)} />
 
       <div className="mb-6 max-w-2xl">
@@ -257,12 +328,15 @@ export default function SearchFeature() {
         ) : null}
 
         <div
+          ref={autocompleteRef}
           className="relative"
           onFocus={() => setFocused(true)}
           onBlur={(event) => {
             if (!event.currentTarget.contains(event.relatedTarget)) {
-              setFocused(false);
-              setActiveIndex(-1);
+              // A pointer click elsewhere in Search must finish against a
+              // stable target before this in-flow panel is removed. Otherwise
+              // blur shifts cards and tabs between pointer-down and click.
+              if (!pointerInteractionRef.current) dismissAutocomplete();
             }
           }}
         >
@@ -285,7 +359,7 @@ export default function SearchFeature() {
               );
             }}
             onKeyDown={onSearchKeyDown}
-            placeholder="Search creators, pages, topics"
+            placeholder="Search"
             aria-label={SEARCH_INPUT_LABEL}
             aria-autocomplete="list"
             aria-expanded={popupOpen && suggestions.length > 0}
@@ -325,7 +399,7 @@ export default function SearchFeature() {
                 id={listId}
                 role="listbox"
                 aria-label="Search suggestions"
-                className="absolute inset-x-0 top-full z-30 mt-1 overflow-hidden rounded-xl border border-border bg-card shadow-lg"
+                className="mt-1 overflow-hidden rounded-xl border border-border bg-card shadow-lg"
               >
                 {suggestions.map((suggestion, index) => (
                   <button
@@ -373,7 +447,7 @@ export default function SearchFeature() {
                 ))}
               </div>
             ) : suggestionError ? (
-              <div className="absolute inset-x-0 top-full z-30 mt-1 flex min-h-11 items-center justify-between gap-3 rounded-xl border border-border bg-card px-3 py-2 shadow-lg">
+              <div className="mt-1 flex min-h-11 items-center justify-between gap-3 rounded-xl border border-border bg-card px-3 py-2 shadow-lg">
                 <span className="text-sm text-muted-foreground">
                   Search unavailable
                 </span>
@@ -390,11 +464,11 @@ export default function SearchFeature() {
                 </Button>
               </div>
             ) : suggestionsInitialized && !loadingSuggestions ? (
-              <p className="absolute inset-x-0 top-full z-30 mt-1 rounded-xl border border-border bg-card px-3 py-3 text-sm text-muted-foreground shadow-lg">
+              <p className="mt-1 rounded-xl border border-border bg-card px-3 py-3 text-sm text-muted-foreground shadow-lg">
                 No matches
               </p>
             ) : (
-              <p className="absolute inset-x-0 top-full z-30 mt-1 flex min-h-11 items-center gap-2 rounded-xl border border-border bg-card px-3 py-3 text-sm text-muted-foreground shadow-lg">
+              <p className="mt-1 flex min-h-11 items-center gap-2 rounded-xl border border-border bg-card px-3 py-3 text-sm text-muted-foreground shadow-lg">
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
                 Searching
               </p>
@@ -420,6 +494,8 @@ export default function SearchFeature() {
         <Tabs
           value={selectedTab}
           onValueChange={(tab) => {
+            setDismissed(true);
+            setActiveIndex(-1);
             setParams(
               (current) => {
                 const next = new URLSearchParams(current);
@@ -478,7 +554,7 @@ export default function SearchFeature() {
               <EmptyState
                 icon={Users}
                 title="No creators found"
-                description={`No creators match “${searchKey}”. Creators are matched by username and name.`}
+                description={`No creators match “${searchKey}”.`}
               />
             ) : creators.items.length > 0 ? (
               <>

--- a/wallet/zuuli/src/features/search/pagination.test.ts
+++ b/wallet/zuuli/src/features/search/pagination.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { SearchResultPage } from "@/lib/api/types";
+import type { SearchResultPage, SimpleCreator } from "@/lib/api/types";
 import {
+  creatorSearchIdentity,
   mergeSearchPage,
   SearchSnapshotCache,
   type SearchSnapshot,
@@ -63,7 +64,9 @@ describe("global Search result pagination", () => {
   });
 
   it("advances past a fully duplicated nonterminal page to later rows", () => {
-    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
     const first = mergeSearchPage(
       initial(),
       page([result("a"), result("b")], 2, 3),
@@ -96,7 +99,9 @@ describe("global Search result pagination", () => {
   });
 
   it("keeps valid rows when advisory counts drift or a tied row is skipped", () => {
-    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
     const first = mergeSearchPage(
       initial(),
       page([result("a")], 2, 2),
@@ -137,5 +142,35 @@ describe("global Search result pagination", () => {
     expect(cache.restore("two")).toBeNull();
     expect(cache.restore("one")?.key).toBe("one");
     expect(cache.restore("three")?.key).toBe("three");
+  });
+
+  it("keeps case-variant creator accounts distinct by stable address", () => {
+    const creator = (username: string, free2zaddr: string): SimpleCreator => ({
+      username,
+      free2zaddr,
+    });
+    const merged = mergeSearchPage(
+      {
+        key: "shared",
+        items: [],
+        next: 1,
+        count: null,
+        initialized: false,
+      },
+      {
+        items: [
+          creator("Shared", "t-addr-one"),
+          creator("shared", "t-addr-two"),
+        ],
+        next: null,
+        count: 2,
+      },
+      1,
+      creatorSearchIdentity,
+    );
+    expect(merged.items.map(({ free2zaddr }) => free2zaddr)).toEqual([
+      "t-addr-one",
+      "t-addr-two",
+    ]);
   });
 });

--- a/wallet/zuuli/src/features/search/pagination.ts
+++ b/wallet/zuuli/src/features/search/pagination.ts
@@ -208,8 +208,9 @@ const loadCreatorPage = (query: string, page: number) =>
   discover.searchCreatorPage(query, page);
 const loadPagePage = (query: string, page: number) =>
   discover.searchPagePage(query, page);
-const creatorIdentity = (creator: SimpleCreator) =>
-  creator.username.toLowerCase();
+/** The immutable creator address, not a locale/case-folded display handle. */
+export const creatorSearchIdentity = (creator: SimpleCreator) =>
+  creator.free2zaddr;
 const pageIdentity = (article: Article) => String(article.id);
 
 export function useCreatorSearch(query: string) {
@@ -217,7 +218,7 @@ export function useCreatorSearch(query: string) {
     query,
     creatorCache,
     loadCreatorPage,
-    creatorIdentity,
+    creatorSearchIdentity,
   );
 }
 

--- a/wallet/zuuli/src/i18n/locales/en.json
+++ b/wallet/zuuli/src/i18n/locales/en.json
@@ -44,7 +44,7 @@
     "profile": "Profile",
     "profileAccessible": "Edit profile",
     "revenueShare": "Revenue share",
-    "search": "Search creators and pages",
+    "search": "Search creators, pages, and topics",
     "searchAction": "Search",
     "searchPlaceholder": "Search creators and pages…",
     "signOut": "Sign out",

--- a/wallet/zuuli/src/i18n/locales/es.json
+++ b/wallet/zuuli/src/i18n/locales/es.json
@@ -44,7 +44,7 @@
     "profile": "Perfil",
     "profileAccessible": "Editar perfil",
     "revenueShare": "Reparto de ingresos",
-    "search": "Buscar creadores y páginas",
+    "search": "Buscar creadores, páginas y temas",
     "searchAction": "Buscar",
     "searchPlaceholder": "Buscar creadores y páginas…",
     "signOut": "Cerrar sesión",

--- a/wallet/zuuli/src/i18n/locales/fr.json
+++ b/wallet/zuuli/src/i18n/locales/fr.json
@@ -44,7 +44,7 @@
     "profile": "Profil",
     "profileAccessible": "Modifier le profil",
     "revenueShare": "Partage des revenus",
-    "search": "Rechercher des créateurs et des pages",
+    "search": "Rechercher des créateurs, des pages et des sujets",
     "searchAction": "Rechercher",
     "searchPlaceholder": "Rechercher des créateurs et des pages…",
     "signOut": "Se déconnecter",

--- a/wallet/zuuli/src/lib/api/article-tags-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/article-tags-contract.test.ts
@@ -78,8 +78,6 @@ describe("article tag HTTP contract", () => {
       { name: "Privacy", count: 12 },
       { name: "privacy", count: "11" },
       { name: "C++", count: null },
-      { nope: true },
-      { name: "bad\u0000tag", count: 3 },
     ]);
     await expect(articles.suggestTags("pri", ["zcash"])).resolves.toEqual([
       { name: "Privacy", count: 12 },
@@ -127,11 +125,18 @@ describe("article tag HTTP contract", () => {
     });
   });
 
-  it("fails soft when optional autocomplete is unavailable or malformed", async () => {
+  it("exposes autocomplete transport and schema failures to its UI boundary", async () => {
     requestMock.mockRejectedValueOnce(new Error("offline"));
-    await expect(articles.suggestTags("privacy")).resolves.toEqual([]);
+    await expect(articles.suggestTags("privacy")).rejects.toThrow("offline");
 
     requestMock.mockResolvedValueOnce({ results: [] });
-    await expect(articles.suggestTags("privacy")).resolves.toEqual([]);
+    await expect(articles.suggestTags("privacy")).rejects.toThrow(
+      "Malformed topic autocomplete response",
+    );
+
+    requestMock.mockResolvedValueOnce([{ nope: true }]);
+    await expect(articles.suggestTags("privacy")).rejects.toThrow(
+      "Malformed topic autocomplete suggestion",
+    );
   });
 });

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -1538,67 +1538,67 @@ export const articles = {
     query: string,
     selected: string[] = [],
   ): Promise<ArticleTagSuggestion[]> {
-    try {
-      const selectedTags = normalizeArticleTags(selected);
-      if (useMock()) {
-        await delay(80);
-        const counts = new Map<string, number>();
-        for (const article of mockArticles) {
-          for (const tag of sanitizeArticleTags(article.tags ?? [])) {
-            counts.set(tag, (counts.get(tag) ?? 0) + 1);
-          }
+    const selectedTags = normalizeArticleTags(selected);
+    if (useMock()) {
+      await delay(80);
+      const scenario =
+        typeof window === "undefined"
+          ? null
+          : window.sessionStorage.getItem("zuuli.mock.article-topics");
+      if (scenario === "unavailable" || scenario === "unavailable-once") {
+        if (scenario === "unavailable-once") {
+          window.sessionStorage.removeItem("zuuli.mock.article-topics");
         }
-        const needle = query
-          .normalize("NFKC")
-          .trim()
-          .toLocaleLowerCase("en-US");
-        return [...counts]
-          .filter(
-            ([name]) =>
-              !selectedTags.includes(name) &&
-              (!needle || name.includes(needle)),
-          )
-          .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-          .slice(0, 10)
-          .map(([name, count]) => ({ name, count }));
+        throw new Error("Mock topic autocomplete unavailable");
       }
-      const response = await request<unknown>("/api/tagging/autocomplete", {
-        query: {
-          query: query.trim(),
-          type: "zpage",
-          selected_tags: selectedTags.join(","),
-          num_results: 10,
-        },
-        anonymous: true,
-      });
-      if (!Array.isArray(response)) return [];
-      return response
-        .flatMap((value): ArticleTagSuggestion[] => {
-          if (!isRecord(value) || typeof value.name !== "string") return [];
-          const [name] = sanitizeArticleTags([value.name]);
-          if (!name) return [];
-          const count = Number(value.count);
-          return [
-            {
-              name,
-              count: Number.isFinite(count)
-                ? Math.max(0, Math.round(count))
-                : 0,
-            },
-          ];
-        })
+      const counts = new Map<string, number>();
+      for (const article of mockArticles) {
+        for (const tag of sanitizeArticleTags(article.tags ?? [])) {
+          counts.set(tag, (counts.get(tag) ?? 0) + 1);
+        }
+      }
+      const needle = query.normalize("NFKC").trim().toLocaleLowerCase("en-US");
+      return [...counts]
         .filter(
-          (suggestion, index, all) =>
-            !selectedTags.includes(suggestion.name) &&
-            all.findIndex((candidate) => candidate.name === suggestion.name) ===
-              index,
+          ([name]) =>
+            !selectedTags.includes(name) && (!needle || name.includes(needle)),
         )
-        .slice(0, 10);
-    } catch {
-      // Autocomplete is an optional authoring aid. Network/schema failures
-      // must never prevent a valid open-vocabulary tag from being entered.
-      return [];
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .slice(0, 10)
+        .map(([name, count]) => ({ name, count }));
     }
+    const response = await request<unknown>("/api/tagging/autocomplete", {
+      query: {
+        query: query.trim(),
+        type: "zpage",
+        selected_tags: selectedTags.join(","),
+        num_results: 10,
+      },
+      anonymous: true,
+    });
+    if (!Array.isArray(response)) {
+      throw new Error("Malformed topic autocomplete response.");
+    }
+    const suggestions = response.map((value): ArticleTagSuggestion => {
+      if (!isRecord(value) || typeof value.name !== "string") {
+        throw new Error("Malformed topic autocomplete suggestion.");
+      }
+      const [name] = sanitizeArticleTags([value.name]);
+      if (!name) throw new Error("Malformed topic autocomplete name.");
+      const count = Number(value.count);
+      if (!Number.isFinite(count)) {
+        throw new Error("Malformed topic autocomplete count.");
+      }
+      return { name, count: Math.max(0, Math.round(count)) };
+    });
+    return suggestions
+      .filter(
+        (suggestion, index, all) =>
+          !selectedTags.includes(suggestion.name) &&
+          all.findIndex((candidate) => candidate.name === suggestion.name) ===
+            index,
+      )
+      .slice(0, 10);
   },
 };
 

--- a/wallet/zuuli/src/lib/discovery-autocomplete.test.ts
+++ b/wallet/zuuli/src/lib/discovery-autocomplete.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { Article, SimpleCreator } from "@/lib/api/types";
+import {
+  buildDiscoverySuggestions,
+  localeSearchKey,
+  rankTopicSuggestions,
+} from "./discovery-autocomplete";
+
+const creator = (username: string, display_name?: string): SimpleCreator => ({
+  username,
+  display_name,
+  free2zaddr: username,
+});
+
+const page = (
+  id: string,
+  title: string,
+  tags: string[],
+  author = creator("author", "Author"),
+): Article => ({ id, title, tags, author, content: "" });
+
+describe("discovery autocomplete", () => {
+  it("coalesces case, width, and accent variants using the active locale", () => {
+    expect(localeSearchKey("ＰＲÍＶＡＣＹ", "es")).toBe("privacy");
+    expect(localeSearchKey("İSTANBUL", "tr")).toBe("istanbul");
+    expect(localeSearchKey("I", "tr")).toBe("ı");
+    expect(
+      rankTopicSuggestions(
+        [
+          { name: "Privacidad", count: 2 },
+          { name: "PRIVACIDAD", count: 8 },
+          { name: "Privacy", count: 20 },
+        ],
+        "pri",
+        [],
+        "es",
+      ),
+    ).toEqual([
+      { name: "Privacy", count: 20 },
+      { name: "PRIVACIDAD", count: 8 },
+    ]);
+  });
+
+  it("ranks mixed topics, creators, and pages while preserving backend order", () => {
+    const suggestions = buildDiscoverySuggestions({
+      query: "privacy",
+      locale: "en-US",
+      creators: [creator("privacy_lab", "Privacy Lab"), creator("alice")],
+      pages: [
+        page("1", "Privacy in practice", ["Privacy", "Zcash"]),
+        page("2", "A second view", ["PRÍVACY"]),
+      ],
+    });
+
+    expect(suggestions.map(({ kind, label }) => [kind, label])).toEqual([
+      ["topic", "Privacy"],
+      ["page", "Privacy in practice"],
+      ["page", "A second view"],
+      ["creator", "Privacy Lab"],
+      ["creator", "alice"],
+    ]);
+    expect(suggestions.filter(({ kind }) => kind === "topic")).toHaveLength(1);
+  });
+
+  it("omits locale-equivalent selected topics and bounds every suggestion kind", () => {
+    const suggestions = buildDiscoverySuggestions({
+      query: "z",
+      locale: "de",
+      selectedTopics: ["Zéro"],
+      creators: Array.from({ length: 5 }, (_, index) => creator(`z-${index}`)),
+      pages: Array.from({ length: 5 }, (_, index) =>
+        page(String(index), `Z page ${index}`, [
+          index === 0 ? "ZERO" : `z${index}`,
+        ]),
+      ),
+      limit: 8,
+    });
+
+    expect(suggestions).toHaveLength(8);
+    expect(
+      suggestions.filter(({ kind }) => kind === "creator").length,
+    ).toBeLessThanOrEqual(3);
+    expect(
+      suggestions.filter(({ kind }) => kind === "page").length,
+    ).toBeLessThanOrEqual(3);
+    expect(
+      suggestions.some(
+        ({ kind, label }) => kind === "topic" && label === "ZERO",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns no default vocabulary before the user types", () => {
+    expect(
+      buildDiscoverySuggestions({
+        query: "  ",
+        creators: [creator("alice")],
+        pages: [page("1", "Hello", ["privacy"])],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/wallet/zuuli/src/lib/discovery-autocomplete.test.ts
+++ b/wallet/zuuli/src/lib/discovery-autocomplete.test.ts
@@ -6,10 +6,14 @@ import {
   rankTopicSuggestions,
 } from "./discovery-autocomplete";
 
-const creator = (username: string, display_name?: string): SimpleCreator => ({
+const creator = (
+  username: string,
+  display_name?: string,
+  free2zaddr = username,
+): SimpleCreator => ({
   username,
   display_name,
-  free2zaddr: username,
+  free2zaddr,
 });
 
 const page = (
@@ -88,6 +92,47 @@ describe("discovery autocomplete", () => {
         ({ kind, label }) => kind === "topic" && label === "ZERO",
       ),
     ).toBe(false);
+  });
+
+  it("deduplicates entities by stable identity, not normalized visible text", () => {
+    const suggestions = buildDiscoverySuggestions({
+      query: "shared",
+      locale: "en-US",
+      creators: [
+        creator("Shared", "Shared", "t-addr-one"),
+        creator("shared", "Shared", "t-addr-two"),
+      ],
+      pages: [page("one", "Shared title", []), page("two", "Shared title", [])],
+    });
+
+    expect(
+      suggestions
+        .filter(({ kind }) => kind === "creator")
+        .map(({ key }) => key),
+    ).toEqual(["creator:t-addr-one", "creator:t-addr-two"]);
+    expect(
+      suggestions.filter(({ kind }) => kind === "page").map(({ key }) => key),
+    ).toEqual(["page:one", "page:two"]);
+  });
+
+  it("never offers stored comma-bearing tags as selectable filters", () => {
+    expect(
+      buildDiscoverySuggestions({
+        query: "machine",
+        creators: [],
+        pages: [page("one", "Machine learning", ["machine, learning"])],
+      }).filter(({ kind }) => kind === "topic"),
+    ).toEqual([]);
+    expect(
+      rankTopicSuggestions(
+        [
+          { name: "machine, learning", count: 9 },
+          { name: "machine learning", count: 2 },
+        ],
+        "machine",
+        [],
+      ),
+    ).toEqual([{ name: "machine learning", count: 2 }]);
   });
 
   it("returns no default vocabulary before the user types", () => {

--- a/wallet/zuuli/src/lib/discovery-autocomplete.ts
+++ b/wallet/zuuli/src/lib/discovery-autocomplete.ts
@@ -1,0 +1,242 @@
+import type { Article, ArticleTagSuggestion, SimpleCreator } from "./api/types";
+import { sanitizeArticleTags } from "./article-tags";
+
+export type DiscoverySuggestion =
+  | {
+      kind: "topic";
+      key: string;
+      label: string;
+      count: number;
+    }
+  | {
+      kind: "creator";
+      key: string;
+      label: string;
+      detail: string;
+      creator: SimpleCreator;
+    }
+  | {
+      kind: "page";
+      key: string;
+      label: string;
+      detail: string;
+      article: Article;
+    };
+
+interface RankedSuggestion {
+  suggestion: DiscoverySuggestion;
+  match: number;
+  sourceOrder: number;
+}
+
+/** A locale-aware comparison key for case, width, and accent variants. */
+export function localeSearchKey(value: string, locale?: string): string {
+  return value
+    .toLocaleLowerCase(locale)
+    .normalize("NFKD")
+    .replace(/\p{M}+/gu, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function matchRank(value: string, query: string, locale?: string): number {
+  const candidate = localeSearchKey(value, locale);
+  const needle = localeSearchKey(query, locale);
+  if (!needle) return 0;
+  if (candidate === needle) return 0;
+  if (candidate.startsWith(needle)) return 1;
+  if (
+    candidate.split(/[\s\p{P}\p{S}]+/u).some((word) => word.startsWith(needle))
+  ) {
+    return 2;
+  }
+  if (candidate.includes(needle)) return 3;
+  return Number.POSITIVE_INFINITY;
+}
+
+function bestMatch(
+  values: Array<string | null | undefined>,
+  query: string,
+  locale?: string,
+) {
+  return Math.min(
+    ...values.filter(Boolean).map((value) => matchRank(value!, query, locale)),
+  );
+}
+
+function collator(locale?: string) {
+  return new Intl.Collator(locale, {
+    sensitivity: "base",
+    usage: "search",
+    numeric: true,
+  });
+}
+
+/**
+ * Build a small, mixed discovery list from the already-requested result sets.
+ * Backend order remains the relevance tiebreaker; local matching only promotes
+ * direct textual matches and coalesces locale-equivalent labels.
+ */
+export function buildDiscoverySuggestions({
+  query,
+  creators,
+  pages,
+  selectedTopics = [],
+  locale,
+  limit = 8,
+}: {
+  query: string;
+  creators: readonly SimpleCreator[];
+  pages: readonly Article[];
+  selectedTopics?: readonly string[];
+  locale?: string;
+  limit?: number;
+}): DiscoverySuggestion[] {
+  const needle = localeSearchKey(query, locale);
+  if (!needle || limit < 1) return [];
+
+  const selected = new Set(
+    selectedTopics.map((topic) => localeSearchKey(topic, locale)),
+  );
+  const topicCounts = new Map<
+    string,
+    { label: string; count: number; sourceOrder: number }
+  >();
+
+  pages.forEach((page, pageIndex) => {
+    for (const tag of sanitizeArticleTags(page.tags ?? [])) {
+      const key = localeSearchKey(tag, locale);
+      if (!key || selected.has(key)) continue;
+      const existing = topicCounts.get(key);
+      if (existing) existing.count += 1;
+      else
+        topicCounts.set(key, { label: tag, count: 1, sourceOrder: pageIndex });
+    }
+  });
+
+  const ranked: RankedSuggestion[] = [];
+  for (const [key, topic] of topicCounts) {
+    const match = matchRank(topic.label, query, locale);
+    if (Number.isFinite(match)) {
+      ranked.push({
+        suggestion: {
+          kind: "topic",
+          key: `topic:${key}`,
+          label: topic.label,
+          count: topic.count,
+        },
+        match,
+        sourceOrder: topic.sourceOrder,
+      });
+    }
+  }
+
+  const seenCreators = new Set<string>();
+  creators.forEach((creator, sourceOrder) => {
+    const displayName = creator.display_name || creator.username;
+    const key = localeSearchKey(creator.username, locale);
+    if (!key || seenCreators.has(key)) return;
+    seenCreators.add(key);
+    const match = bestMatch([displayName, creator.username], query, locale);
+    // The server may return semantic/popularity matches whose visible text does
+    // not contain the query. Keep them after direct local matches.
+    ranked.push({
+      suggestion: {
+        kind: "creator",
+        key: `creator:${key}`,
+        label: displayName,
+        detail: `@${creator.username}`,
+        creator,
+      },
+      match: Number.isFinite(match) ? match : 10,
+      sourceOrder,
+    });
+  });
+
+  const seenPages = new Set<string>();
+  pages.forEach((article, sourceOrder) => {
+    const titleKey = localeSearchKey(article.title, locale);
+    if (!titleKey || seenPages.has(titleKey)) return;
+    seenPages.add(titleKey);
+    const author = article.author.display_name || article.author.username;
+    const match = bestMatch(
+      [
+        article.title,
+        article.subtitle,
+        article.category,
+        ...(article.tags ?? []),
+      ],
+      query,
+      locale,
+    );
+    ranked.push({
+      suggestion: {
+        kind: "page",
+        key: `page:${String(article.id)}`,
+        label: article.title,
+        detail: author,
+        article,
+      },
+      match: Number.isFinite(match) ? match : 10,
+      sourceOrder,
+    });
+  });
+
+  const kindOrder: Record<DiscoverySuggestion["kind"], number> = {
+    topic: 0,
+    creator: 1,
+    page: 2,
+  };
+  const compare = collator(locale);
+  const perKind = new Map<DiscoverySuggestion["kind"], number>();
+
+  return ranked
+    .sort(
+      (a, b) =>
+        a.match - b.match ||
+        a.sourceOrder - b.sourceOrder ||
+        kindOrder[a.suggestion.kind] - kindOrder[b.suggestion.kind] ||
+        compare.compare(a.suggestion.label, b.suggestion.label),
+    )
+    .filter(({ suggestion }) => {
+      const count = perKind.get(suggestion.kind) ?? 0;
+      if (count >= 3) return false;
+      perKind.set(suggestion.kind, count + 1);
+      return true;
+    })
+    .slice(0, limit)
+    .map(({ suggestion }) => suggestion);
+}
+
+/** Locale-aware ranking and dedupe for the standalone topic filter. */
+export function rankTopicSuggestions(
+  suggestions: readonly ArticleTagSuggestion[],
+  query: string,
+  selected: readonly string[],
+  locale?: string,
+  limit = 6,
+): ArticleTagSuggestion[] {
+  const selectedKeys = new Set(
+    selected.map((tag) => localeSearchKey(tag, locale)),
+  );
+  const unique = new Map<string, ArticleTagSuggestion>();
+  for (const suggestion of suggestions) {
+    const key = localeSearchKey(suggestion.name, locale);
+    if (!key || selectedKeys.has(key)) continue;
+    const previous = unique.get(key);
+    if (!previous || suggestion.count > previous.count)
+      unique.set(key, suggestion);
+  }
+  const compare = collator(locale);
+  return [...unique.values()]
+    .filter((suggestion) =>
+      Number.isFinite(matchRank(suggestion.name, query, locale)),
+    )
+    .sort(
+      (a, b) =>
+        matchRank(a.name, query, locale) - matchRank(b.name, query, locale) ||
+        b.count - a.count ||
+        compare.compare(a.name, b.name),
+    )
+    .slice(0, Math.max(0, limit));
+}

--- a/wallet/zuuli/src/lib/discovery-autocomplete.ts
+++ b/wallet/zuuli/src/lib/discovery-autocomplete.ts
@@ -1,5 +1,5 @@
 import type { Article, ArticleTagSuggestion, SimpleCreator } from "./api/types";
-import { sanitizeArticleTags } from "./article-tags";
+import { isArticleTagFilterable, sanitizeArticleTags } from "./article-tags";
 
 export type DiscoverySuggestion =
   | {
@@ -105,6 +105,10 @@ export function buildDiscoverySuggestions({
 
   pages.forEach((page, pageIndex) => {
     for (const tag of sanitizeArticleTags(page.tags ?? [])) {
+      // The feed API serializes selected topics as one comma-delimited value
+      // and has no escaping. Stored legacy tags containing commas remain
+      // displayable, but must never become selectable filters.
+      if (!isArticleTagFilterable(tag)) continue;
       const key = localeSearchKey(tag, locale);
       if (!key || selected.has(key)) continue;
       const existing = topicCounts.get(key);
@@ -134,7 +138,7 @@ export function buildDiscoverySuggestions({
   const seenCreators = new Set<string>();
   creators.forEach((creator, sourceOrder) => {
     const displayName = creator.display_name || creator.username;
-    const key = localeSearchKey(creator.username, locale);
+    const key = creator.free2zaddr;
     if (!key || seenCreators.has(key)) return;
     seenCreators.add(key);
     const match = bestMatch([displayName, creator.username], query, locale);
@@ -155,9 +159,9 @@ export function buildDiscoverySuggestions({
 
   const seenPages = new Set<string>();
   pages.forEach((article, sourceOrder) => {
-    const titleKey = localeSearchKey(article.title, locale);
-    if (!titleKey || seenPages.has(titleKey)) return;
-    seenPages.add(titleKey);
+    const key = String(article.id);
+    if (!key || seenPages.has(key)) return;
+    seenPages.add(key);
     const author = article.author.display_name || article.author.username;
     const match = bestMatch(
       [
@@ -172,7 +176,7 @@ export function buildDiscoverySuggestions({
     ranked.push({
       suggestion: {
         kind: "page",
-        key: `page:${String(article.id)}`,
+        key: `page:${key}`,
         label: article.title,
         detail: author,
         article,
@@ -221,6 +225,7 @@ export function rankTopicSuggestions(
   );
   const unique = new Map<string, ArticleTagSuggestion>();
   for (const suggestion of suggestions) {
+    if (!isArticleTagFilterable(suggestion.name)) continue;
     const key = localeSearchKey(suggestion.name, locale);
     if (!key || selectedKeys.has(key)) continue;
     const previous = unique.get(key);

--- a/wallet/zuuli/src/lib/search-route.ts
+++ b/wallet/zuuli/src/lib/search-route.ts
@@ -1,4 +1,4 @@
-export const SEARCH_INPUT_LABEL = "Search creators and pages";
+export const SEARCH_INPUT_LABEL = "Search creators, pages, and topics";
 
 /** Search owns the chrome for every route mounted below `/search/*`. */
 export function isSearchRoute(pathname: string): boolean {
@@ -8,9 +8,7 @@ export function isSearchRoute(pathname: string): boolean {
 /** TopBar submissions enter the canonical Search route with a trimmed query. */
 export function searchHref(query: string): string {
   const canonical = query.trim();
-  return canonical
-    ? `/search?q=${encodeURIComponent(canonical)}`
-    : "/search";
+  return canonical ? `/search?q=${encodeURIComponent(canonical)}` : "/search";
 }
 
 /**

--- a/wallet/zuuli/src/lib/search-route.ts
+++ b/wallet/zuuli/src/lib/search-route.ts
@@ -1,5 +1,3 @@
-export const SEARCH_INPUT_LABEL = "Search creators, pages, and topics";
-
 /** Search owns the chrome for every route mounted below `/search/*`. */
 export function isSearchRoute(pathname: string): boolean {
   return pathname === "/search" || pathname.startsWith("/search/");

--- a/wallet/zuuli/tests/article-tags.pw.ts
+++ b/wallet/zuuli/tests/article-tags.pw.ts
@@ -60,7 +60,9 @@ test("authored tags autocomplete and round-trip into reader filter links", async
     page.getByText("1 article tagged c++", { exact: true }),
   ).toBeVisible();
 
-  await page.getByRole("button", { name: "privacy" }).click();
+  const topicFilter = page.getByRole("combobox", { name: "Filter by topic" });
+  await topicFilter.fill("privacy");
+  await page.getByRole("option", { name: /#privacy/ }).click();
   expect(new URL(page.url()).searchParams.get("tags")).toBe("c++,privacy");
   await expect(
     page.getByText("1 article tagged c++ + privacy", { exact: true }),

--- a/wallet/zuuli/tests/article-tags.pw.ts
+++ b/wallet/zuuli/tests/article-tags.pw.ts
@@ -85,6 +85,6 @@ test("a direct multi-tag Articles URL remains filtered across reload", async ({
   await expect(resultCount).toHaveText(expected ?? "");
   expect(new URL(page.url()).searchParams.get("tags")).toBe("Privacy,zcash");
 
-  await page.getByRole("button", { name: "Clear tags" }).click();
+  await page.getByRole("button", { name: "Clear topics" }).click();
   expect(new URL(page.url()).searchParams.has("tags")).toBe(false);
 });

--- a/wallet/zuuli/tests/search-autocomplete.pw.ts
+++ b/wallet/zuuli/tests/search-autocomplete.pw.ts
@@ -172,6 +172,93 @@ test("Articles replaces the topic wall with a quiet removable autocomplete", asy
   expect(viewport.scroll).toBeLessThanOrEqual(viewport.client);
 });
 
+test("Articles exposes a retryable topic failure instead of misreporting an empty corpus", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    sessionStorage.setItem("zuuli.mock.article-topics", "unavailable-once");
+  });
+  await page.goto("/articles");
+
+  const input = page.getByRole("combobox", { name: "Filter by topic" });
+  await input.fill("pri");
+  await expect(
+    page.getByText("Topics unavailable", { exact: true }).first(),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Try again" }).first().click();
+  await expect(
+    page.getByRole("listbox", { name: "Topic suggestions" }),
+  ).toContainText("privacy");
+});
+
+for (const width of [320, 360] as const) {
+  for (const signedIn of [false, true]) {
+    test(`${signedIn ? "signed-in" : "signed-out"} Search tabs remain operable while autocomplete loads and is empty at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 720 });
+      await page.addInitScript((authenticated) => {
+        const key = "zuuli.knox.token";
+        if (authenticated) localStorage.setItem(key, "mock-knox-token");
+        else localStorage.removeItem(key);
+      }, signedIn);
+      await page.goto("/search?q=no-results-for-this-query");
+
+      const pagesTab = page.getByRole("tab", { name: /Pages/ });
+      await pagesTab.click();
+      await expect(pagesTab).toHaveAttribute("aria-selected", "true");
+      await globalSearch(page).fill("still-no-results-for-this-query");
+      await expect(page.getByText("No matches", { exact: true })).toBeVisible();
+
+      const creatorsTab = page.getByRole("tab", { name: /Creators/ });
+      await creatorsTab.click();
+      await expect(creatorsTab).toHaveAttribute("aria-selected", "true");
+      await expect(page.getByText("No matches", { exact: true })).toHaveCount(
+        0,
+      );
+    });
+  }
+}
+
+test("Search clears a pointer transaction released outside the route", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 800, height: 720 });
+  await page.goto("/search?q=no-results-for-this-query");
+
+  const input = globalSearch(page);
+  const noMatches = page.getByText("No matches", { exact: true });
+  await expect(noMatches).toBeVisible();
+
+  const clearSearch = page.getByRole("button", { name: "Clear search" });
+  const clearBounds = await clearSearch.boundingBox();
+  const topBarBounds = await page.locator("[data-app-top-bar]").boundingBox();
+  expect(clearBounds).not.toBeNull();
+  expect(topBarBounds).not.toBeNull();
+  await page.mouse.move(
+    clearBounds!.x + clearBounds!.width / 2,
+    clearBounds!.y + clearBounds!.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    topBarBounds!.x + topBarBounds!.width / 2,
+    topBarBounds!.y + topBarBounds!.height / 2,
+  );
+  await page.mouse.up();
+  await expect(noMatches).toHaveCount(0);
+
+  // Force a new keyboard focus transition even on browsers that keep the
+  // pressed clear button from taking focus when released elsewhere.
+  await page.getByRole("button", { name: "Log in" }).focus();
+  await input.focus();
+  await expect(noMatches).toBeVisible();
+  await input.press("Tab");
+  await expect(clearSearch).toBeFocused();
+  await expect(noMatches).toBeVisible();
+  await page.keyboard.press("Tab");
+  await expect(noMatches).toHaveCount(0);
+});
+
 test.describe("locale-aware Search", () => {
   test.use({ locale: "es-ES" });
 

--- a/wallet/zuuli/tests/search-autocomplete.pw.ts
+++ b/wallet/zuuli/tests/search-autocomplete.pw.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
 const SEARCH_NAME = "Search creators, pages, and topics";
+const SEARCH_NAME_ES = "Buscar creadores, páginas y temas";
 
 function globalSearch(page: Page) {
   return page.getByRole("combobox", { name: SEARCH_NAME });
@@ -266,7 +267,7 @@ test.describe("locale-aware Search", () => {
     page,
   }) => {
     await page.goto("/search");
-    const input = globalSearch(page);
+    const input = page.getByRole("combobox", { name: SEARCH_NAME_ES });
     await input.fill("privacy");
     const options = page.getByRole("option");
     await expect(options.first()).toBeVisible();

--- a/wallet/zuuli/tests/search-autocomplete.pw.ts
+++ b/wallet/zuuli/tests/search-autocomplete.pw.ts
@@ -1,0 +1,161 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const SEARCH_NAME = "Search creators, pages, and topics";
+
+function globalSearch(page: Page) {
+  return page.getByRole("combobox", { name: SEARCH_NAME });
+}
+
+test("global Search offers mixed keyboard and screen-reader suggestions", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 640 });
+  await page.goto("/search");
+
+  const input = globalSearch(page);
+  await expect(input).toBeFocused();
+  await expect(input).toHaveAttribute("aria-expanded", "false");
+  await expect(
+    page.getByRole("listbox", { name: "Search suggestions" }),
+  ).toHaveCount(0);
+  await expect(page.locator("[data-suggestion-kind]")).toHaveCount(0);
+
+  await input.fill("z");
+  const listbox = page.getByRole("listbox", { name: "Search suggestions" });
+  await expect(listbox).toBeVisible();
+  await expect(input).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator('[data-suggestion-kind="topic"]')).not.toHaveCount(
+    0,
+  );
+  await expect(
+    page.locator('[data-suggestion-kind="creator"]'),
+  ).not.toHaveCount(0);
+  await expect(page.locator('[data-suggestion-kind="page"]')).not.toHaveCount(
+    0,
+  );
+
+  await input.press("ArrowDown");
+  const activeId = await input.getAttribute("aria-activedescendant");
+  expect(activeId).toBeTruthy();
+  await expect(page.locator(`[id="${activeId}"]`)).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+
+  await input.press("Escape");
+  await expect(input).toHaveValue("z");
+  await expect(input).toHaveAttribute("aria-expanded", "false");
+  await expect(listbox).toHaveCount(0);
+
+  await input.press("ArrowDown");
+  await expect(listbox).toBeVisible();
+  await input.press("Enter");
+  await expect(page.getByLabel("Selected topics")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /^Remove topic / }),
+  ).toBeVisible();
+  expect(new URL(page.url()).searchParams.getAll("topic")).toHaveLength(1);
+  await expect(input).toHaveValue("");
+
+  const viewport = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth,
+  }));
+  expect(viewport.scroll).toBeLessThanOrEqual(viewport.client);
+});
+
+test("global Search cancels stale suggestions and exposes a retryable error", async ({
+  page,
+}) => {
+  await page.goto("/search");
+  const input = globalSearch(page);
+
+  await input.fill("z");
+  await expect(
+    page.getByRole("listbox", { name: "Search suggestions" }),
+  ).toBeVisible();
+  await input.fill("not-a-result");
+  await expect(page.locator("[data-suggestion-kind]")).toHaveCount(0);
+  await expect(page.getByText("No matches", { exact: true })).toBeVisible();
+
+  await page.evaluate(() => {
+    sessionStorage.setItem("zuuli.mock.search-creators", "unavailable");
+    sessionStorage.setItem("zuuli.mock.search-pages", "unavailable");
+  });
+  await input.fill("error-state");
+  await expect(
+    page.getByText("Search unavailable", { exact: true }).first(),
+  ).toBeVisible();
+  const retry = page.getByRole("button", { name: "Try again" }).first();
+  await expect(retry).toBeVisible();
+
+  await page.evaluate(() => {
+    sessionStorage.removeItem("zuuli.mock.search-creators");
+    sessionStorage.removeItem("zuuli.mock.search-pages");
+  });
+  await retry.click();
+  await expect(page.getByText("No matches", { exact: true })).toBeVisible();
+});
+
+test("Articles replaces the topic wall with a quiet removable autocomplete", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 360, height: 720 });
+  await page.goto("/articles");
+
+  await expect(page.locator('[aria-label="Filter by tag"]')).toHaveCount(0);
+  const input = page.getByRole("combobox", { name: "Filter by topic" });
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("aria-expanded", "false");
+  await expect(
+    page.getByRole("listbox", { name: "Topic suggestions" }),
+  ).toHaveCount(0);
+
+  await input.fill("pri");
+  const listbox = page.getByRole("listbox", { name: "Topic suggestions" });
+  await expect(listbox.getByRole("option").first()).toBeVisible();
+  await input.press("ArrowDown");
+  await input.press("Enter");
+  await expect(page).toHaveURL(/\/articles\?tags=privacy$/);
+
+  const remove = page.getByRole("button", { name: "Remove topic privacy" });
+  await expect(remove).toBeVisible();
+  const box = await remove.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.height).toBeGreaterThanOrEqual(44);
+  await remove.click();
+  expect(new URL(page.url()).searchParams.has("tags")).toBe(false);
+
+  await input.fill("pri");
+  await expect(listbox).toBeVisible();
+  await input.press("Escape");
+  await expect(input).toHaveValue("pri");
+  await expect(input).toHaveAttribute("aria-expanded", "false");
+
+  await input.fill("zc");
+  await expect(listbox).toBeVisible();
+  await expect(listbox.getByRole("option")).toHaveCount(1);
+  await expect(listbox.getByRole("option")).toContainText("zcash");
+
+  const viewport = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth,
+  }));
+  expect(viewport.scroll).toBeLessThanOrEqual(viewport.client);
+});
+
+test.describe("locale-aware Search", () => {
+  test.use({ locale: "es-ES" });
+
+  test("keeps mixed suggestions bounded and selectable outside en-US", async ({
+    page,
+  }) => {
+    await page.goto("/search");
+    const input = globalSearch(page);
+    await input.fill("privacy");
+    const options = page.getByRole("option");
+    await expect(options.first()).toBeVisible();
+    expect(await options.count()).toBeLessThanOrEqual(8);
+    await expect(input).toHaveAttribute("aria-autocomplete", "list");
+  });
+});

--- a/wallet/zuuli/tests/search-autocomplete.pw.ts
+++ b/wallet/zuuli/tests/search-autocomplete.pw.ts
@@ -64,19 +64,47 @@ test("global Search offers mixed keyboard and screen-reader suggestions", async 
   expect(viewport.scroll).toBeLessThanOrEqual(viewport.client);
 });
 
-test("global Search cancels stale suggestions and exposes a retryable error", async ({
+test("global Search rejects an older response that resolves last and exposes a retryable error", async ({
   page,
 }) => {
   await page.goto("/search");
   const input = globalSearch(page);
 
+  // Invert the two search generations deterministically: the first creator
+  // and page calls take 1.2s, while the second pair takes 10ms. This exercises
+  // the production request-generation guard instead of merely clearing an
+  // already-rendered list between sequential searches.
+  await page.evaluate(() => {
+    const nativeSetTimeout = window.setTimeout.bind(window);
+    let searchCalls = 0;
+    window.setTimeout = ((
+      handler: TimerHandler,
+      timeout?: number,
+      ...args: unknown[]
+    ) => {
+      if (timeout === 200 || timeout === 220) {
+        const delay = searchCalls < 2 ? 1_200 : 10;
+        searchCalls += 1;
+        return nativeSetTimeout(handler, delay, ...args);
+      }
+      return nativeSetTimeout(handler, timeout, ...args);
+    }) as typeof window.setTimeout;
+  });
+
   await input.fill("z");
-  await expect(
-    page.getByRole("listbox", { name: "Search suggestions" }),
-  ).toBeVisible();
-  await input.fill("not-a-result");
-  await expect(page.locator("[data-suggestion-kind]")).toHaveCount(0);
-  await expect(page.getByText("No matches", { exact: true })).toBeVisible();
+  await page.waitForTimeout(350);
+  await input.fill("privacy");
+  const listbox = page.getByRole("listbox", { name: "Search suggestions" });
+  await expect(listbox.getByRole("option").first()).toBeVisible();
+  await expect(input).toHaveValue("privacy");
+  await expect(listbox).toContainText("#privacy");
+
+  // The delayed `z` response has resolved by now. It must not replace the
+  // newer privacy generation or resurrect its topic suggestions.
+  await page.waitForTimeout(1_000);
+  await expect(input).toHaveValue("privacy");
+  await expect(listbox).toContainText("#privacy");
+  await expect(listbox).not.toContainText("#zcash");
 
   await page.evaluate(() => {
     sessionStorage.setItem("zuuli.mock.search-creators", "unavailable");

--- a/wallet/zuuli/tests/search-pagination.pw.ts
+++ b/wallet/zuuli/tests/search-pagination.pw.ts
@@ -4,6 +4,14 @@ function viewport(page: Page) {
   return page.locator("[data-scroll-area-viewport]");
 }
 
+async function dismissAutocomplete(page: Page) {
+  const input = page.getByRole("combobox", {
+    name: "Search creators, pages, and topics",
+  });
+  await input.press("Escape");
+  await expect(input).toHaveAttribute("aria-expanded", "false");
+}
+
 async function useSearchScenarios(page: Page, creators: string, pages: string) {
   await page.addInitScript(
     ({ creatorScenario, pageScenario }) => {
@@ -23,6 +31,7 @@ test("every result remains loaded with its tab and scroll position across back n
 
   const creatorResults = page.locator("[data-search-creator-result]");
   await expect(creatorResults).toHaveCount(2);
+  await dismissAutocomplete(page);
   await expect(page.getByRole("tab", { name: /Creators/ })).toContainText("4");
   await page.getByRole("button", { name: "Load more creators" }).click();
   await expect(creatorResults).toHaveCount(4);
@@ -66,7 +75,7 @@ test("every result remains loaded with its tab and scroll position across back n
 
   await page.getByRole("tab", { name: /Creators/ }).click();
   await expect(creatorResults).toHaveCount(4);
-  await expect(page.getByRole("searchbox")).toHaveValue("a");
+  await expect(page.getByRole("combobox")).toHaveValue("a");
 });
 
 test("a fully duplicated page advances to later unique results", async ({
@@ -77,6 +86,7 @@ test("a fully duplicated page advances to later unique results", async ({
 
   const creators = page.locator("[data-search-creator-result]");
   await expect(creators).toHaveCount(2);
+  await dismissAutocomplete(page);
   await page.getByRole("button", { name: "Load more creators" }).click();
   await expect(creators).toHaveCount(2);
   await page.getByRole("button", { name: "Load more creators" }).click();
@@ -94,10 +104,13 @@ test("count drift and tied-row skips retain the valid terminal results", async (
 
   const creators = page.locator("[data-search-creator-result]");
   await expect(creators).toHaveCount(2);
+  await dismissAutocomplete(page);
   await page.getByRole("button", { name: "Load more creators" }).click();
   await expect(creators).toHaveCount(4);
   await expect(page.getByRole("alert")).toHaveCount(0);
-  await expect(page.getByText("4 of 5 creators", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("4 of 5 creators", { exact: true }),
+  ).toBeVisible();
 
   await page.getByRole("tab", { name: /Pages/ }).click();
   const pages = page.locator("[data-search-page-result]");
@@ -129,6 +142,7 @@ test("overlapping backend pages are deduplicated without losing order", async ({
 
   const creators = page.locator("[data-search-creator-result]");
   await expect(creators).toHaveCount(2);
+  await dismissAutocomplete(page);
   await page.getByRole("button", { name: "Load more creators" }).click();
   await expect(creators).toHaveCount(3);
   await page.getByRole("button", { name: "Load more creators" }).click();

--- a/wallet/zuuli/tests/search.pw.ts
+++ b/wallet/zuuli/tests/search.pw.ts
@@ -108,7 +108,7 @@ for (const viewport of VIEWPORTS) {
       await expect(input).toBeFocused();
       await expect(clear).toHaveCount(0);
       await expect(
-        page.getByText("Start typing.", { exact: true }),
+        page.getByText("Search all of free2z", { exact: true }),
       ).toBeVisible();
 
       await page.goBack();

--- a/wallet/zuuli/tests/search.pw.ts
+++ b/wallet/zuuli/tests/search.pw.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-const SEARCH_NAME = "Search creators and pages";
+const SEARCH_NAME = "Search creators, pages, and topics";
 const VIEWPORTS = [
   { name: "phone", width: 320, height: 568 },
   { name: "tablet", width: 768, height: 1024 },
@@ -25,7 +25,7 @@ async function enterSearch(page: Page, width: number) {
 }
 
 async function expectSingleRouteSearch(page: Page) {
-  const input = page.getByRole("searchbox", { name: SEARCH_NAME });
+  const input = page.getByRole("combobox", { name: SEARCH_NAME });
   const topBar = page.locator("[data-app-top-bar]");
 
   await expect(input).toHaveCount(1);
@@ -36,6 +36,7 @@ async function expectSingleRouteSearch(page: Page) {
   await expect(topBar.getByLabel("Search", { exact: true })).toHaveCount(0);
   await expect(input).toHaveAttribute("data-custom-search-clear", "true");
   await expect(input).toHaveAttribute("type", "text");
+  await expect(input).toHaveAttribute("aria-autocomplete", "list");
   await expect(input).toHaveAttribute("inputmode", "search");
   return input;
 }
@@ -106,7 +107,9 @@ for (const viewport of VIEWPORTS) {
       await expect(input).toHaveValue("");
       await expect(input).toBeFocused();
       await expect(clear).toHaveCount(0);
-      await expect(page.getByText("Search all of free2z")).toBeVisible();
+      await expect(
+        page.getByText("Start typing.", { exact: true }),
+      ).toBeVisible();
 
       await page.goBack();
       await expect(page).toHaveURL(/\/$/);

--- a/wallet/zuuli/tests/touch-targets.pw.ts
+++ b/wallet/zuuli/tests/touch-targets.pw.ts
@@ -43,8 +43,12 @@ async function setSession(page: Page, signedIn: boolean) {
   }, signedIn);
 }
 
-async function expectEditableTextClearsButton(page: Page, inputName: string) {
-  const input = page.getByRole("searchbox", { name: inputName });
+async function expectEditableTextClearsButton(
+  page: Page,
+  inputName: string,
+  role: "searchbox" | "combobox" = "searchbox",
+) {
+  const input = page.getByRole(role, { name: inputName });
   const clear = page.getByRole("button", { name: "Clear search" });
   const [inputBox, clearBox, inset] = await Promise.all([
     input.boundingBox(),
@@ -272,9 +276,15 @@ for (const signedIn of [false, true]) {
 
       await page.goto("/search?q=zcash");
       await page
-        .getByRole("searchbox", { name: "Search creators and pages" })
+        .getByRole("combobox", {
+          name: "Search creators, pages, and topics",
+        })
         .fill("a long creator and page query that reaches the trailing control");
-      await expectEditableTextClearsButton(page, "Search creators and pages");
+      await expectEditableTextClearsButton(
+        page,
+        "Search creators, pages, and topics",
+        "combobox",
+      );
       await page.getByRole("tab", { name: /Pages/ }).click();
       routeFailures.push(
         ...(await auditTouchTargets(page)).failures.map(

--- a/wallet/zuuli/tests/ui-copy.pw.ts
+++ b/wallet/zuuli/tests/ui-copy.pw.ts
@@ -86,13 +86,15 @@ for (const width of WIDTHS) {
     await page.goto("/search");
     await expect(page.getByRole("heading", { name: "Search" })).toBeVisible();
     await expect(
-      page.getByRole("searchbox", { name: "Search creators and pages" }),
+      page.getByRole("combobox", {
+        name: "Search creators, pages, and topics",
+      }),
     ).toBeVisible();
     await expect(page.getByText(REMOVED_EXPLAINERS)).toHaveCount(0);
     await expect(page.locator("h1").locator("xpath=..").locator("p")).toHaveCount(0);
 
     await expandText(page);
-    await expectCopyFits(page, "Search creators and pages");
+    await expectCopyFits(page, "Search creators, pages, and topics");
 
     await page.goto("/articles");
     const articleSearch = page.getByRole("searchbox", {
@@ -117,8 +119,8 @@ test("changed Search copy resolves through the accepted locale catalog", async (
   await page.goto("/search");
 
   await expect(page.getByRole("heading", { name: "Buscar" })).toBeVisible();
-  const search = page.getByRole("searchbox", {
-    name: "Buscar creadores y páginas",
+  const search = page.getByRole("combobox", {
+    name: "Buscar creadores, páginas y temas",
   });
   await expect(search).toHaveAttribute("placeholder", "Buscar");
   await expect(page.getByText("Buscar en todo free2z")).toBeVisible();


### PR DESCRIPTION
Closes #788

## Summary
- replace the Articles topic-pill wall with a quiet topic autocomplete and compact removable selections
- add mixed topic, creator, and page suggestions to global Search with locale-aware ranking and stable-identity dedupe
- preserve keyboard-first selection, screen-reader status, touch access, cancellation, stale-response rejection, explicit retryable errors, and paginated result safety
- keep legacy comma-bearing tags displayable but never selectable as ambiguous feed filters

## Remediation
- expose article-topic transport/schema failures so the filter can distinguish unavailable data from an empty corpus
- keep case-variant creators and same-title pages distinct by immutable backend identity
- keep autocomplete panels in normal flow so loading/empty states cannot intercept mobile tabs
- defer click-away collapse through the complete pointer transaction so controls below the in-flow panel do not shift before their click; globally settle pointer releases/cancellation
- use concise Search and Articles copy without reintroducing a topic pill wall

## Exact-head verification
Verified at `00c583aa552a92313d7e24a2f23ee5830ef12c2c`:
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run build` with fresh 116-byte WASM verification
- focused discovery Vitest: 6/6
- copy policy Node: 2/2
- full Vitest: 853 passed, 5 skipped
- full Node policy: 370 passed, 5 skipped
- full Playwright: 145/145, including all autocomplete, pagination, remote-media consent, mobile tab, locale, pointer-release, and current-main RealtimeKit CSP cases
- prior repair stress remains green: pagination 15/15, media consent 5/5, lost pointer release 5/5

## Integration
This branch is self-contained and normally merged current `origin/main` at `73b14ff4b7922b7577ac0ac5ed0129aaa5fcabb7` in merge commit `00c583aa552a92313d7e24a2f23ee5830ef12c2c`. It does not depend on #786 or #797 and requires no rebase.

## Review
Fresh adversarial exact-head review is in progress for `00c583aa552a92313d7e24a2f23ee5830ef12c2c`; the earlier `6011bb` verdict is superseded.
