### PR TITLE
release(zuuli): prepare internal build 0.1.0+17

### DIFF
--- a/wallet/zuuli/release.json
+++ b/wallet/zuuli/release.json
@@ -4,7 +4,7 @@
   "applicationId": "cash.free2z.zuuli",
   "iosUsesNonExemptEncryption": false,
   "version": "0.1.0",
-  "build": 16,
+  "build": 17,
   "minimums": {
     "ios": "18.0",
     "android": 29

--- a/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
+++ b/wallet/zuuli/src-tauri/gen/android/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "cash.free2z.zuuli"
         minSdk = 29
         targetSdk = 36
-        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "16").toInt()
+        versionCode = tauriProperties.getProperty("tauri.android.versionCode", "17").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "0.1.0")
     }
     val releaseStoreFile = System.getenv("ANDROID_KEYSTORE_PATH")?.takeIf { it.isNotBlank() }

--- a/wallet/zuuli/src-tauri/gen/apple/project.yml
+++ b/wallet/zuuli/src-tauri/gen/apple/project.yml
@@ -69,7 +69,7 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 0.1.0
-        CFBundleVersion: "16"
+        CFBundleVersion: "17"
     entitlements:
       path: zuuli_iOS/zuuli_iOS.entitlements
     scheme:

--- a/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
+++ b/wallet/zuuli/src-tauri/gen/apple/zuuli_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>17</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -37,14 +37,14 @@
       "entitlements": "./Entitlements.plist"
     },
     "iOS": {
-      "bundleVersion": "16",
+      "bundleVersion": "17",
       "developmentTeam": "F9AV5HKF6N",
       "minimumSystemVersion": "18.0",
       "infoPlist": "Info.ios.plist"
     },
     "android": {
       "minSdkVersion": 29,
-      "versionCode": 16
+      "versionCode": 17
     }
   },
   "plugins": {


### PR DESCRIPTION
Closes #807
Parent: #779

Prepare ZUULI 0.1.0+17 for internal delivery to Google Play Internal and TestFlight from the STATUS-audited trunk produced by #806.

Generated with:

    npm ci
    npm run release:bump -- --version=0.1.0 --build=17

The marketing version remains 0.1.0. The focused diff changes only release.json and the four generated/native build-number representations owned by the release bump.

Verified locally:

    npm run release:verify
    npm run test:status-freshness
    node --test scripts/release-tag-identity.node-test.mjs
    node scripts/release-identity.mjs --source-sha=<exact-head> --require-newer-than=<parent>
    node scripts/status-freshness.mjs --source-sha=<exact-head>

This PR does not promote to public store tracks. publicationReady remains false, and STATUS.md does not claim physical-device or product-operation readiness.