### PR TITLE
fix(zuuli): use authoritative ppv stream kind

### DIFF
--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -193,7 +193,7 @@ interface RawDyteMeeting {
   id: number;
   creator: RawCreator;
   meeting_id: string;
-  meeting_type: string; // broadcast | ppv | subscribers-only | private
+  meeting_type: unknown;
   live_now: boolean;
   price_per_minute?: string;
 }
@@ -623,21 +623,51 @@ export function parseCreatorPagesPage(
   };
 }
 
-/** free2z meeting_type → ZUULI StreamKind (and back). */
-const KIND_FROM_TYPE: Record<string, StreamKind> = {
+/** The exact free2z `meeting_type` wire enum. Never add client aliases here. */
+type DyteMeetingType = "broadcast" | "ppv" | "subscribers-only" | "private";
+
+const KIND_FROM_TYPE = {
   broadcast: "broadcast",
   ppv: "ppv",
-  "pay-per-view": "ppv",
   "subscribers-only": "subscriber",
-  subscriber: "subscriber",
   private: "private",
-};
-const TYPE_FROM_KIND: Record<StreamKind, string> = {
+} as const satisfies Record<DyteMeetingType, StreamKind>;
+
+const TYPE_FROM_KIND = {
   broadcast: "broadcast",
-  ppv: "pay-per-view",
+  ppv: "ppv",
   subscriber: "subscribers-only",
   private: "private",
-};
+} as const satisfies Record<StreamKind, DyteMeetingType>;
+
+export class LivestreamKindContractError extends Error {
+  constructor() {
+    super("Unsupported livestream kind in the free2z API contract.");
+    this.name = "LivestreamKindContractError";
+  }
+}
+
+/** Parse an untrusted wire value without silently making a stream free or paid. */
+function streamKindFromType(value: unknown): StreamKind {
+  if (
+    typeof value !== "string" ||
+    !Object.prototype.hasOwnProperty.call(KIND_FROM_TYPE, value)
+  ) {
+    throw new LivestreamKindContractError();
+  }
+  return KIND_FROM_TYPE[value as DyteMeetingType];
+}
+
+/** Serialize a runtime value through the same strict contract boundary. */
+function typeFromStreamKind(value: StreamKind): DyteMeetingType {
+  if (
+    typeof value !== "string" ||
+    !Object.prototype.hasOwnProperty.call(TYPE_FROM_KIND, value)
+  ) {
+    throw new LivestreamKindContractError();
+  }
+  return TYPE_FROM_KIND[value];
+}
 
 /** PPV entry cost the backend enforces: ceil(price_per_minute*30) + 15 fee. */
 function ppvPrice(pricePerMinute?: string): number {
@@ -646,7 +676,7 @@ function ppvPrice(pricePerMinute?: string): number {
 }
 
 function mapLivestream(m: RawDyteMeeting): Livestream {
-  const kind = KIND_FROM_TYPE[m.meeting_type] ?? "broadcast";
+  const kind = streamKindFromType(m.meeting_type);
   const creator = mapCreator(m.creator);
   return {
     id: String(m.id),
@@ -1769,6 +1799,7 @@ export const live = {
     username: string,
     kind?: StreamKind,
   ): Promise<{ live: boolean; participants: number }> {
+    const expectedType = kind ? typeFromStreamKind(kind) : undefined;
     if (useMock()) {
       await delay(120);
       const s = mockLivestreams.find((l) => l.username === username);
@@ -1781,7 +1812,6 @@ export const live = {
         `/api/dyte/${username}/live-status`,
         { anonymous: true, cache: "no-store" },
       );
-      const expectedType = kind ? TYPE_FROM_KIND[kind] : undefined;
       const entries = Object.entries(s || {})
         .filter(
           ([key, entry]) =>
@@ -1799,6 +1829,7 @@ export const live = {
 
   /** Creator starts/ensures their stream and receives its host ticket. */
   async start(kind: StreamKind): Promise<LiveStartResult> {
+    const meetingType = typeFromStreamKind(kind);
     if (useMock()) {
       await delay(500);
       return {
@@ -1828,7 +1859,7 @@ export const live = {
       return { ticket, inviteSecret: secret };
     }
     const r = await request<{ meeting_id: string; auth_token: string }>(
-      `/api/dyte/${me.username}/${TYPE_FROM_KIND[kind]}`,
+      `/api/dyte/${me.username}/${meetingType}`,
       { method: "POST" },
     );
     // A new public meeting changed discovery; private rooms never touch it.
@@ -1858,6 +1889,7 @@ export const live = {
     secret?: string,
     as: "host" | "participant" = "participant",
   ): Promise<DyteJoinTicket> {
+    const meetingType = typeFromStreamKind(kind);
     if (useMock()) {
       await delay(600);
       if (kind === "private" && !mockSecretUnlocks(secret)) {
@@ -1878,7 +1910,7 @@ export const live = {
     const path =
       kind === "private"
         ? `/api/dyte/${encodeURIComponent(username)}/private/${encodeURIComponent(privateSecret!)}`
-        : `/api/dyte/${encodeURIComponent(username)}/${TYPE_FROM_KIND[kind]}`;
+        : `/api/dyte/${encodeURIComponent(username)}/${meetingType}`;
     // The private-join response omits meeting_id (returns { e2ee, auth_token }).
     try {
       const r = await request<{ meeting_id?: string; auth_token: string }>(path, {

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -195,7 +195,7 @@ interface RawDyteMeeting {
   meeting_id: string;
   meeting_type: unknown;
   live_now: boolean;
-  price_per_minute?: string;
+  price_per_minute?: unknown;
 }
 
 // ─── Mappers ────────────────────────────────────────────────────────────────
@@ -647,6 +647,13 @@ export class LivestreamKindContractError extends Error {
   }
 }
 
+export class LivestreamPriceContractError extends Error {
+  constructor() {
+    super("Invalid PPV price in the free2z API contract.");
+    this.name = "LivestreamPriceContractError";
+  }
+}
+
 /** Parse an untrusted wire value without silently making a stream free or paid. */
 function streamKindFromType(value: unknown): StreamKind {
   if (
@@ -670,9 +677,21 @@ function typeFromStreamKind(value: StreamKind): DyteMeetingType {
 }
 
 /** PPV entry cost the backend enforces: ceil(price_per_minute*30) + 15 fee. */
-function ppvPrice(pricePerMinute?: string): number {
-  const ppm = Number(pricePerMinute || 0);
-  return Math.ceil(ppm * 30) + 15;
+function ppvPrice(pricePerMinute: unknown): number {
+  // CreatorMeeting.price_per_minute is Decimal(6, 2). Parse its wire form into
+  // hundredths so values such as 8.30 do not become 8.300000000000001 in JS
+  // and incorrectly round the 30-minute charge up by one.
+  if (typeof pricePerMinute !== "string") {
+    throw new LivestreamPriceContractError();
+  }
+  const match = /^(\d{1,4})(?:\.(\d{1,2}))?$/.exec(pricePerMinute);
+  if (!match) throw new LivestreamPriceContractError();
+
+  const hundredths =
+    BigInt(match[1]) * 100n + BigInt((match[2] ?? "").padEnd(2, "0") || "0");
+  if (hundredths <= 0n) throw new LivestreamPriceContractError();
+
+  return Number((hundredths * 30n + 99n) / 100n + 15n);
 }
 
 function mapLivestream(m: RawDyteMeeting): Livestream {
@@ -1807,22 +1826,27 @@ export const live = {
     }
     try {
       const s = await request<
-        Record<string, { meeting_type?: string; participants?: number }>
-      >(
-        `/api/dyte/${username}/live-status`,
-        { anonymous: true, cache: "no-store" },
-      );
+        Record<string, { meeting_type?: unknown; participants?: number }>
+      >(`/api/dyte/${username}/live-status`, {
+        anonymous: true,
+        cache: "no-store",
+      });
       const entries = Object.entries(s || {})
-        .filter(
-          ([key, entry]) =>
-            !expectedType ||
-            key === expectedType ||
-            entry.meeting_type === expectedType,
-        )
-        .map(([, entry]) => entry);
-      const participants = entries.reduce((n, e) => n + (e.participants ?? 0), 0);
+        .map(([key, entry]) => {
+          const keyKind = streamKindFromType(key);
+          const entryKind = streamKindFromType(entry?.meeting_type);
+          if (keyKind !== entryKind) throw new LivestreamKindContractError();
+          return { key, entry };
+        })
+        .filter(({ key }) => !expectedType || key === expectedType)
+        .map(({ entry }) => entry);
+      const participants = entries.reduce(
+        (n, e) => n + (e.participants ?? 0),
+        0,
+      );
       return { live: entries.length > 0, participants };
-    } catch {
+    } catch (error) {
+      if (error instanceof LivestreamKindContractError) throw error;
       return { live: false, participants: 0 };
     }
   },

--- a/wallet/zuuli/src/lib/api/live-ppv-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/live-ppv-contract.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./http", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./http")>();
+  return { ...original, request: vi.fn() };
+});
+
+import { live, LivestreamKindContractError } from "./free2z";
+import { request } from "./http";
+import type { StreamKind } from "./types";
+
+const requestMock = vi.mocked(request);
+
+function meeting(meetingType: unknown, pricePerMinute = "2") {
+  return {
+    id: 814,
+    creator: { username: "alice", full_name: "Alice" },
+    meeting_id: "authoritative-meeting",
+    meeting_type: meetingType,
+    live_now: true,
+    price_per_minute: pricePerMinute,
+  };
+}
+
+describe("PPV livestream HTTP contract", () => {
+  beforeEach(() => requestMock.mockReset());
+
+  it("round-trips the authoritative ppv kind through listing, pricing, join, and host start", async () => {
+    requestMock
+      .mockResolvedValueOnce({ results: [meeting("ppv")] })
+      .mockResolvedValueOnce({
+        meeting_id: "authoritative-meeting",
+        auth_token: "participant-ticket",
+      })
+      .mockResolvedValueOnce({ username: "alice", tuzis: "500" })
+      .mockResolvedValueOnce({
+        meeting_id: "authoritative-meeting",
+        auth_token: "host-ticket",
+      });
+
+    const [stream] = await live.listPublic({ force: true });
+    expect(stream).toMatchObject({
+      id: "814",
+      username: "alice",
+      kind: "ppv",
+      price_tuzis: 75,
+    });
+
+    await expect(live.join("alice", stream!.kind)).resolves.toMatchObject({
+      authToken: "participant-ticket",
+      meetingId: "authoritative-meeting",
+      as: "participant",
+    });
+    await expect(live.start(stream!.kind)).resolves.toMatchObject({
+      ticket: {
+        authToken: "host-ticket",
+        meetingId: "authoritative-meeting",
+        as: "host",
+      },
+    });
+
+    expect(requestMock.mock.calls.map(([path]) => path)).toEqual([
+      "/api/dyte/public/",
+      "/api/dyte/alice/ppv",
+      "/api/auth/user/",
+      "/api/dyte/alice/ppv",
+    ]);
+  });
+
+  it.each(["pay-per-view", "subscriber", "unknown", null])(
+    "rejects the non-contract listing kind %j instead of classifying it as free or paid",
+    async (meetingType) => {
+      requestMock.mockResolvedValueOnce({ results: [meeting(meetingType)] });
+
+      await expect(live.listPublic({ force: true })).rejects.toBeInstanceOf(
+        LivestreamKindContractError,
+      );
+    },
+  );
+
+  it("rejects the invented pay-per-view alias before join or host requests", async () => {
+    const invalidAlias = "pay-per-view" as StreamKind;
+
+    await expect(live.join("alice", invalidAlias)).rejects.toBeInstanceOf(
+      LivestreamKindContractError,
+    );
+    await expect(live.start(invalidAlias)).rejects.toBeInstanceOf(
+      LivestreamKindContractError,
+    );
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+});

--- a/wallet/zuuli/src/lib/api/live-ppv-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/live-ppv-contract.test.ts
@@ -25,9 +25,16 @@ function meeting(meetingType: unknown, pricePerMinute = "2") {
 describe("PPV livestream HTTP contract", () => {
   beforeEach(() => requestMock.mockReset());
 
-  it("round-trips the authoritative ppv kind through listing, pricing, join, and host start", async () => {
+  it("round-trips the authoritative ppv kind through listing, status, pricing, join, and host start", async () => {
     requestMock
       .mockResolvedValueOnce({ results: [meeting("ppv")] })
+      .mockResolvedValueOnce({
+        ppv: { meeting_type: "ppv", participants: 3 },
+        "pay-per-view": {
+          meeting_type: "pay-per-view",
+          participants: 99,
+        },
+      })
       .mockResolvedValueOnce({
         meeting_id: "authoritative-meeting",
         auth_token: "participant-ticket",
@@ -45,6 +52,10 @@ describe("PPV livestream HTTP contract", () => {
       kind: "ppv",
       price_tuzis: 75,
     });
+    await expect(live.status("alice", stream!.kind)).resolves.toEqual({
+      live: true,
+      participants: 3,
+    });
 
     await expect(live.join("alice", stream!.kind)).resolves.toMatchObject({
       authToken: "participant-ticket",
@@ -61,6 +72,7 @@ describe("PPV livestream HTTP contract", () => {
 
     expect(requestMock.mock.calls.map(([path]) => path)).toEqual([
       "/api/dyte/public/",
+      "/api/dyte/alice/live-status",
       "/api/dyte/alice/ppv",
       "/api/auth/user/",
       "/api/dyte/alice/ppv",

--- a/wallet/zuuli/src/lib/api/live-ppv-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/live-ppv-contract.test.ts
@@ -5,44 +5,39 @@ vi.mock("./http", async (importOriginal) => {
   return { ...original, request: vi.fn() };
 });
 
-import { live, LivestreamKindContractError } from "./free2z";
+import {
+  live,
+  LivestreamKindContractError,
+  LivestreamPriceContractError,
+} from "./free2z";
 import { request } from "./http";
 import type { StreamKind } from "./types";
 
 const requestMock = vi.mocked(request);
 
-function meeting(meetingType: unknown, pricePerMinute = "2") {
+function meeting(meetingType: unknown, ...pricePerMinute: [unknown?]) {
   return {
     id: 814,
     creator: { username: "alice", full_name: "Alice" },
     meeting_id: "authoritative-meeting",
     meeting_type: meetingType,
     live_now: true,
-    price_per_minute: pricePerMinute,
+    price_per_minute: pricePerMinute.length ? pricePerMinute[0] : "2",
   };
 }
 
 describe("PPV livestream HTTP contract", () => {
   beforeEach(() => requestMock.mockReset());
 
-  it("round-trips the authoritative ppv kind through listing, status, pricing, join, and host start", async () => {
+  it("round-trips the authoritative ppv kind through listing, status, and participant join", async () => {
     requestMock
       .mockResolvedValueOnce({ results: [meeting("ppv")] })
       .mockResolvedValueOnce({
         ppv: { meeting_type: "ppv", participants: 3 },
-        "pay-per-view": {
-          meeting_type: "pay-per-view",
-          participants: 99,
-        },
       })
       .mockResolvedValueOnce({
         meeting_id: "authoritative-meeting",
         auth_token: "participant-ticket",
-      })
-      .mockResolvedValueOnce({ username: "alice", tuzis: "500" })
-      .mockResolvedValueOnce({
-        meeting_id: "authoritative-meeting",
-        auth_token: "host-ticket",
       });
 
     const [stream] = await live.listPublic({ force: true });
@@ -62,22 +57,60 @@ describe("PPV livestream HTTP contract", () => {
       meetingId: "authoritative-meeting",
       as: "participant",
     });
-    await expect(live.start(stream!.kind)).resolves.toMatchObject({
+    expect(requestMock.mock.calls.map(([path]) => path)).toEqual([
+      "/api/dyte/public/",
+      "/api/dyte/alice/live-status",
+      "/api/dyte/alice/ppv",
+    ]);
+  });
+
+  it("uses the ppv wire enum for the existing host-start endpoint", async () => {
+    requestMock
+      .mockResolvedValueOnce({ username: "alice", tuzis: "500" })
+      .mockResolvedValueOnce({
+        meeting_id: "authoritative-meeting",
+        auth_token: "host-ticket",
+      });
+
+    await expect(live.start("ppv")).resolves.toMatchObject({
       ticket: {
         authToken: "host-ticket",
         meetingId: "authoritative-meeting",
         as: "host",
       },
     });
-
     expect(requestMock.mock.calls.map(([path]) => path)).toEqual([
-      "/api/dyte/public/",
-      "/api/dyte/alice/live-status",
-      "/api/dyte/alice/ppv",
       "/api/auth/user/",
       "/api/dyte/alice/ppv",
     ]);
   });
+
+  it.each([
+    ["0.01", 16],
+    ["2.00", 75],
+    ["8.30", 264],
+    ["9999.99", 300_015],
+  ])(
+    "computes the exact backend PPV entry price for %s",
+    async (rate, price) => {
+      requestMock.mockResolvedValueOnce({ results: [meeting("ppv", rate)] });
+
+      const [stream] = await live.listPublic({ force: true });
+
+      expect(stream?.price_tuzis).toBe(price);
+    },
+  );
+
+  it.each([undefined, null, 2, "", "0", "0.00", "-1", "1e2", "1.234", "nope"])(
+    "rejects the invalid PPV rate %j",
+    async (rate) => {
+      requestMock.mockResolvedValueOnce({ results: [meeting("ppv", rate)] });
+
+      await expect(live.listPublic({ force: true })).rejects.toBeInstanceOf(
+        LivestreamPriceContractError,
+      );
+    },
+  );
 
   it.each(["pay-per-view", "subscriber", "unknown", null])(
     "rejects the non-contract listing kind %j instead of classifying it as free or paid",
@@ -100,5 +133,33 @@ describe("PPV livestream HTTP contract", () => {
       LivestreamKindContractError,
     );
     expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid status kind before making a request", async () => {
+    const invalidAlias = "pay-per-view" as StreamKind;
+
+    await expect(live.status("alice", invalidAlias)).rejects.toBeInstanceOf(
+      LivestreamKindContractError,
+    );
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["unknown key", { legacy: { meeting_type: "ppv", participants: 3 } }],
+    [
+      "unknown entry kind",
+      { ppv: { meeting_type: "legacy", participants: 3 } },
+    ],
+    ["missing entry kind", { ppv: { participants: 3 } }],
+    [
+      "mismatched key and entry",
+      { ppv: { meeting_type: "broadcast", participants: 3 } },
+    ],
+  ])("rejects a status response with %s", async (_description, response) => {
+    requestMock.mockResolvedValueOnce(response);
+
+    await expect(live.status("alice", "ppv")).rejects.toBeInstanceOf(
+      LivestreamKindContractError,
+    );
   });
 });


### PR DESCRIPTION
Closes #814

## Summary
- serialize paid livestreams with the authoritative `ppv` wire value across listing, status, participant join, and the existing host-start route
- strictly validate listing and status kinds so unknown, missing, or mismatched wire entries fail closed
- compute PPV entry prices with Decimal-equivalent integer arithmetic and reject missing, zero, negative, or malformed backend rates
- keep host scope honest: the current start endpoint accepts a kind but no price, so this PR verifies its `ppv` route only and does not claim price round-tripping
- add mutation-sensitive coverage for varying prices (including `8.30 -> 264`), invalid rates, constant-price substitutions, and invalid status kinds before network I/O

## Verification
- `npm run typecheck`
- `npm run typecheck:tests`
- `npx vitest run src/lib/api/live-ppv-contract.test.ts` (26 passed)
- `npx vitest run` (872 passed, 5 skipped)
- `npm run build`
- `git diff --check`

Merged current `origin/main` normally at `73b14ff4` (no rebase or force-push). 