### PR TITLE
fix(zuuli): permit RealtimeKit endpoints in packaged CSP

### DIFF
--- a/wallet/zuuli/package.json
+++ b/wallet/zuuli/package.json
@@ -16,6 +16,7 @@
     "test:mermaid-security": "node scripts/check-mermaid-security.mjs && node --test scripts/mermaid-security.node-test.mjs && playwright test tests/mermaid-security.pw.ts",
     "test:send-review": "node --test scripts/send-review-boundary.node-test.mjs && playwright test tests/send-review.pw.ts",
     "test:mobile-webview-authority": "node scripts/mobile-webview-authority.mjs && node --test scripts/mobile-webview-authority.node-test.mjs && playwright test tests/mobile-webview-authority.pw.ts",
+    "test:realtimekit-csp": "playwright test tests/realtimekit-csp.pw.ts",
     "test:apple-credential-boundary": "node --test scripts/apple-credential-boundary.node-test.mjs && node scripts/apple-credential-boundary.mjs",
     "test:artifact-sbom": "node --test scripts/artifact-sbom.node-test.mjs",
     "test:viewport": "playwright test tests/viewport.pw.ts",

--- a/wallet/zuuli/src-tauri/tauri.conf.json
+++ b/wallet/zuuli/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: https:; media-src 'self' https:; frame-src 'none'; connect-src 'self' https://free2z.com https://*.free2z.com https://*.zec.rocks https://*.dyte.io wss://*.dyte.io https://*.stripe.com https://checkout.stripe.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'"
+      "csp": "default-src 'self'; img-src 'self' data: https:; media-src 'self' https:; frame-src 'none'; connect-src 'self' https://free2z.com https://*.free2z.com https://*.zec.rocks https://*.dyte.io wss://*.dyte.io https://api.realtime.cloudflare.com https://api-silos.realtime.cloudflare.com https://da-collector.realtime.cloudflare.com https://location.realtime.cloudflare.com https://location-legacy.realtime.cloudflare.com https://r2.cloudflarestorage.com https://rtk-assets.realtime.cloudflare.com wss://socket-edge.realtime.cloudflare.com https://*.stripe.com https://checkout.stripe.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'"
     }
   },
   "bundle": {

--- a/wallet/zuuli/tests/realtimekit-csp.pw.ts
+++ b/wallet/zuuli/tests/realtimekit-csp.pw.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Page } from "@playwright/test";
+
+const appRoot = fileURLToPath(new URL("..", import.meta.url));
+const tauriConfig = JSON.parse(
+  readFileSync(new URL("../src-tauri/tauri.conf.json", import.meta.url), "utf8"),
+) as { app?: { security?: { csp?: unknown } } };
+const productionCsp = tauriConfig.app?.security?.csp;
+
+const apiOrigin = "https://api.realtime.cloudflare.com";
+const participantDetailsUrl = `${apiOrigin}/v2/internals/participant-details`;
+const requiredRealtimeKitSources = [
+  apiOrigin,
+  "https://api-silos.realtime.cloudflare.com",
+  "https://da-collector.realtime.cloudflare.com",
+  "https://location.realtime.cloudflare.com",
+  "https://location-legacy.realtime.cloudflare.com",
+  "https://r2.cloudflarestorage.com",
+  "https://rtk-assets.realtime.cloudflare.com",
+  "wss://socket-edge.realtime.cloudflare.com",
+] as const;
+const expectedConnectSources = [
+  "'self'",
+  "https://free2z.com",
+  "https://*.free2z.com",
+  "https://*.zec.rocks",
+  "https://*.dyte.io",
+  "wss://*.dyte.io",
+  ...requiredRealtimeKitSources,
+  "https://*.stripe.com",
+  "https://checkout.stripe.com",
+];
+
+function directiveSources(csp: string, name: string): string[] {
+  const directive = csp
+    .split(";")
+    .map((entry) => entry.trim().split(/\s+/u))
+    .find(([candidate]) => candidate === name);
+  return directive?.slice(1) ?? [];
+}
+
+function withoutRealtimeKitSources(csp: string): string {
+  return csp
+    .split(";")
+    .map((entry) => {
+      const tokens = entry.trim().split(/\s+/u);
+      return tokens[0] === "connect-src"
+        ? tokens
+            .filter(
+              (token) =>
+                !requiredRealtimeKitSources.some((source) => source === token),
+            )
+            .join(" ")
+        : tokens.join(" ");
+    })
+    .join("; ");
+}
+
+async function initializeWithCsp(page: Page, csp: string) {
+  let requestCount = 0;
+  await page.route(participantDetailsUrl, async (route) => {
+    requestCount += 1;
+    await route.fulfill({ status: 401, body: "" });
+  });
+
+  await page.goto("/");
+  const bundlePath = `${appRoot}/node_modules/@cloudflare/realtimekit/dist/browser.js`;
+  await page.setContent(`
+    <!doctype html>
+    <html>
+      <head>
+        <meta http-equiv="Content-Security-Policy" content="${csp}">
+        <script src="/@fs/${bundlePath}"></script>
+      </head>
+      <body></body>
+    </html>
+  `);
+
+  const result = await page.evaluate(async () => {
+    const violations: Array<{
+      blockedURI: string;
+      violatedDirective: string;
+    }> = [];
+    document.addEventListener("securitypolicyviolation", (event) => {
+      violations.push({
+        blockedURI: event.blockedURI,
+        violatedDirective: event.violatedDirective,
+      });
+    });
+
+    const encode = (value: object) =>
+      btoa(JSON.stringify(value))
+        .replaceAll("=", "")
+        .replaceAll("+", "-")
+        .replaceAll("/", "_");
+    const authToken = [
+      encode({ alg: "none", typ: "JWT" }),
+      encode({
+        meetingId: crypto.randomUUID(),
+        orgId: crypto.randomUUID(),
+        participantId: crypto.randomUUID(),
+      }),
+      "synthetic",
+    ].join(".");
+
+    try {
+      await RealtimeKitClient.init({ authToken });
+      return { error: null, violations };
+    } catch (error) {
+      const candidate = error as {
+        code?: unknown;
+        message?: unknown;
+        name?: unknown;
+      };
+      return {
+        error: {
+          code: typeof candidate.code === "string" ? candidate.code : null,
+          message: typeof candidate.message === "string" ? candidate.message : String(error),
+          name: typeof candidate.name === "string" ? candidate.name : null,
+        },
+        violations,
+      };
+    }
+  });
+
+  return { ...result, requestCount };
+}
+
+test("production CSP admits the bundled RealtimeKit initialization request", async ({
+  page,
+}) => {
+  expect(typeof productionCsp).toBe("string");
+  const csp = productionCsp as string;
+  expect(directiveSources(csp, "connect-src")).toEqual(
+    expectedConnectSources,
+  );
+
+  const result = await initializeWithCsp(page, csp);
+
+  expect(result.requestCount).toBe(1);
+  expect(result.violations).toEqual([]);
+  expect(result.error?.code).toBe("0004");
+  expect(result.error?.message).toContain("Unauthorized");
+});
+
+test("removing the RealtimeKit sources reproduces the ERR0001 CSP boundary", async ({
+  page,
+}) => {
+  expect(typeof productionCsp).toBe("string");
+  const csp = withoutRealtimeKitSources(productionCsp as string);
+  expect(directiveSources(csp, "connect-src")).not.toEqual(
+    expect.arrayContaining([...requiredRealtimeKitSources]),
+  );
+
+  const result = await initializeWithCsp(page, csp);
+
+  expect(result.requestCount).toBe(0);
+  expect(result.violations).toContainEqual({
+    blockedURI: participantDetailsUrl,
+    violatedDirective: "connect-src",
+  });
+  expect(result.error?.code).toBe("0001");
+  expect(result.error?.message).toBe(
+    "[ERR0001]: {Client} Failed to initialize.\nUnable to connect to the server. Check the internet connection.",
+  );
+});
+
+declare global {
+  const RealtimeKitClient: {
+    init(options: { authToken: string }): Promise<unknown>;
+  };
+}


### PR DESCRIPTION
## Summary

- permit only the audited RealtimeKit HTTPS services and `wss://socket-edge.realtime.cloudflare.com` in the packaged `connect-src`
- preserve the existing Free2Z, wallet, media, legacy Dyte, and Stripe source inventory without adding generic `https:` or `wss:` authority
- load the committed production CSP and installed `@cloudflare/realtimekit@1.5.1` browser bundle in Chromium
- prove the production policy reaches `/v2/internals/participant-details`, while deleting only the new sources blocks the request and reproduces the exact `ERR0001`
- generate only ephemeral synthetic token-shaped values in browser memory; no real participant token, meeting secret, or private claim is logged or committed

The endpoint inventory was cross-checked against the bundled SDK and the current [Cloudflare RealtimeKit network allowlist](https://developers.cloudflare.com/realtime/realtimekit/network-allowlist/). The older pinned SDK still contains a `location-legacy` fallback, so that exact origin remains admitted until the SDK is upgraded and re-audited.

## Verification

- `ZUULI_PW_PORT=1485 npm run test:realtimekit-csp` — 2 passed
- `npm run typecheck` — passed
- `npm run typecheck:tests` — passed
- `npm test` — 846 unit tests passed, 375 contract/mutation tests passed, 135 browser tests passed
- `npm run test:mobile-webview-authority` — 8 node tests and 1 browser test passed
- `npm run build` — passed, including fresh WASM verification
- `npm run release:verify` — passed for `0.1.0+17`
- `npm audit --audit-level=high` — passed; existing findings are moderate only

## Signed-device evidence still required

This PR is source and browser-policy evidence, not a claim that a signed mobile build joined a real room. Release acceptance still requires one active authoritative room joined concurrently from web, signed Android, and signed iOS; background/foreground and network transition; a fresh install; and credential-safe recording of the WebSocket hostname actually returned for that room.

Closes #816
Part of #813