### PR TITLE
fix(zuuli): bind live join tickets to meetings

### DIFF
--- a/wallet/zuuli/src/features/live/Room.tsx
+++ b/wallet/zuuli/src/features/live/Room.tsx
@@ -55,6 +55,8 @@ import {
   runSingleFlight,
 } from "./membership";
 import { Stage } from "./Stage";
+import { viewerEntryState } from "./viewer-safety";
+import { classifyLiveFailure, safeLiveDiagnostic } from "./connection-failure";
 
 interface JustStarted {
   ticket: DyteJoinTicket;
@@ -76,6 +78,7 @@ export function Room() {
   const tuzis = useSession((s) => s.tuzis);
   const adjustTuzis = useSession((s) => s.adjustTuzis);
   const user = useSession((s) => s.user);
+  const sessionLoading = useSession((s) => s.loading);
 
   // A host who just went live already has their stream + ticket in navigation
   // state, so we can render the room immediately and skip the public listing
@@ -146,6 +149,12 @@ export function Room() {
   const [ticket, setTicket] = useState<DyteJoinTicket | null>(
     justStarted?.ticket ?? null,
   );
+  // Private invites remain memory-only. Keeping the active secret here lets a
+  // failed viewer request obtain a fresh ticket without putting it in storage,
+  // diagnostics, query parameters, or the ticket itself.
+  const [activeJoinSecret, setActiveJoinSecret] = useState<string | undefined>(
+    inviteSecret ?? undefined,
+  );
 
   useEffect(() => {
     if (!data?.inviteTicket) return;
@@ -213,6 +222,12 @@ export function Room() {
   const kind = KIND_META[stream.kind] ?? KIND_META.broadcast;
   const creatorName = stream.creator.display_name ?? stream.creator.username;
   const seed = stream.username + stream.title;
+  const entryState = viewerEntryState({
+    sessionLoading,
+    viewerUsername: user?.username,
+    creatorUsername: stream.username,
+    kind: stream.kind,
+  });
 
   return (
     <div className="space-y-6 animate-slide-up">
@@ -278,7 +293,21 @@ export function Room() {
 
             {/* Stage center: either the "off-air" identity or the real meeting */}
             {ticket ? (
-              <Stage ticket={ticket} />
+              <Stage
+                ticket={ticket}
+                {...(ticket.as === "participant"
+                  ? {
+                      refreshTicket: (previous: DyteJoinTicket) =>
+                        live.refreshParticipant(
+                          stream.username,
+                          stream.kind,
+                          previous,
+                          activeJoinSecret,
+                        ),
+                      onTicketRefreshed: setTicket,
+                    }
+                  : {})}
+              />
             ) : (
               <div className="absolute inset-0 grid place-items-center">
                 <div className="flex flex-col items-center gap-3 text-center">
@@ -349,16 +378,23 @@ export function Room() {
               />
             )
           ) : (
-            <JoinPanel
-              stream={stream}
-              tuzis={tuzis}
-              onJoined={(t) => {
-                setTicket(t);
-                if (stream.kind === "ppv" && stream.price_tuzis > 0) {
-                  adjustTuzis(-stream.price_tuzis);
-                }
-              }}
-            />
+            entryState === "checking-session" ? (
+              <ViewerIdentityCheck />
+            ) : entryState === "creator-blocked" ? (
+              <CreatorViewerGuard />
+            ) : (
+              <JoinPanel
+                stream={stream}
+                tuzis={tuzis}
+                onJoined={(t, secret) => {
+                  setActiveJoinSecret(secret);
+                  setTicket(t);
+                  if (stream.kind === "ppv" && stream.price_tuzis > 0) {
+                    adjustTuzis(-stream.price_tuzis);
+                  }
+                }}
+              />
+            )
           )}
         </div>
       </div>
@@ -395,7 +431,7 @@ function JoinPanel({
 }: {
   stream: Livestream;
   tuzis: number;
-  onJoined: (ticket: DyteJoinTicket) => void;
+  onJoined: (ticket: DyteJoinTicket, secret?: string) => void;
 }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -503,14 +539,22 @@ function JoinPanel({
     try {
       const ticket = await runExclusive(async () => {
         if (action) await action();
-        return live.join(stream.username, stream.kind, joinSecret);
+        return live.join(
+          stream.username,
+          stream.kind,
+          joinSecret,
+          "participant",
+          { expectedMeetingId: stream.meetingId },
+        );
       });
       if (!ticket) return false;
-      onJoined(ticket);
+      onJoined(ticket, joinSecret);
       return true;
     } catch (e) {
+      const failure = classifyLiveFailure(e, "ticket-request");
+      console.warn("Livestream join failed", safeLiveDiagnostic(failure));
       toast.error("Could not join", {
-        description: e instanceof Error ? e.message : "Please try again.",
+        description: failure.message,
       });
       return false;
     }
@@ -568,7 +612,10 @@ function JoinPanel({
             // does not expose while replacing all authoritative account data.
             setUser({ ...useSession.getState().user, ...authoritative });
           },
-          join: () => live.join(stream.username, stream.kind),
+          join: () =>
+            live.join(stream.username, stream.kind, undefined, "participant", {
+              expectedMeetingId: stream.meetingId,
+            }),
         }),
       );
       if (!result) return;
@@ -978,6 +1025,40 @@ function JoinPanel({
           chat all run in the room once you join.
         </p>
       </div>
+    </div>
+  );
+}
+
+function CreatorViewerGuard() {
+  return (
+    <div className="rounded-xl border border-info/30 bg-info/[0.06] p-4">
+      <div className="flex items-center gap-2">
+        <Badge variant="sub" className="gap-1.5">
+          <ShieldCheck className="h-3 w-3" aria-hidden />
+          Creator-safe viewer link
+        </Badge>
+      </div>
+      <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
+        This public viewer page will never start, replace, or rotate your active
+        room. Open the stream from your Live creator controls instead.
+      </p>
+      <Button asChild variant="outline" className="mt-4 w-full">
+        <Link to="/live">Open Live controls</Link>
+      </Button>
+    </div>
+  );
+}
+
+function ViewerIdentityCheck() {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <Button className="w-full gap-2" size="lg" disabled>
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+        Checking viewer session
+      </Button>
+      <p className="mt-3 text-center text-xs text-muted-foreground">
+        Verifying that this viewer action cannot affect creator controls.
+      </p>
     </div>
   );
 }

--- a/wallet/zuuli/src/features/live/Stage.test.tsx
+++ b/wallet/zuuli/src/features/live/Stage.test.tsx
@@ -1,0 +1,199 @@
+import { act, useState } from "react";
+import type { Root } from "react-dom/client";
+import { parseHTML } from "linkedom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DyteJoinTicket } from "@/lib/api/types";
+
+const controls = vi.hoisted(() => ({
+  initMeeting: vi.fn(),
+}));
+
+vi.mock("@cloudflare/realtimekit-react", () => ({
+  RealtimeKitProvider: ({ children }: { children: unknown }) => children,
+  useRealtimeKitClient: () => [null, controls.initMeeting],
+}));
+vi.mock("@cloudflare/realtimekit-react-ui", () => ({
+  RtkMeeting: () => null,
+}));
+
+import { Stage } from "./Stage";
+
+let root: Root;
+let container: HTMLElement;
+let restoreGlobals: () => void;
+
+const firstTicket: DyteJoinTicket = {
+  authToken: "first-private-token",
+  meetingId: "selected-meeting",
+  environmentId: "production-org",
+  as: "participant",
+};
+const freshTicket: DyteJoinTicket = {
+  ...firstTicket,
+  authToken: "fresh-private-token",
+};
+
+async function installDom(online: boolean) {
+  const { window, document } = parseHTML(
+    "<!doctype html><html><body><div id='root'></div></body></html>",
+  );
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { protocol: "http:" },
+  });
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    writable: true,
+    value: online,
+  });
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    writable: true,
+    value: "visible",
+  });
+  const saved = new Map<string, PropertyDescriptor | undefined>();
+  for (const [name, value] of Object.entries({
+    window,
+    document,
+    navigator: window.navigator,
+    HTMLElement: window.HTMLElement,
+    Event: window.Event,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  })) {
+    saved.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+  restoreGlobals = () => {
+    for (const [name, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else delete (globalThis as Record<string, unknown>)[name];
+    }
+  };
+  container = document.getElementById("root") as unknown as HTMLElement;
+  const { createRoot } = await import("react-dom/client");
+  root = createRoot(container);
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(async () => {
+  controls.initMeeting.mockReset();
+  await installDom(true);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (root) await act(async () => root.unmount());
+  restoreGlobals?.();
+});
+
+describe("RealtimeKit stage retry lifecycle", () => {
+  it("discards raw provider errors and retries only with a fresh authoritative ticket", async () => {
+    const rawSecret = "eyJ.private-identity.signature";
+    controls.initMeeting
+      .mockRejectedValueOnce(
+        new Error(`[ERR0004] rejected ${rawSecret} at https://private.invalid/join`),
+      )
+      .mockResolvedValueOnce({});
+    const refresh = vi.fn().mockResolvedValue(freshTicket);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    function Harness() {
+      const [ticket, setTicket] = useState(firstTicket);
+      return (
+        <Stage
+          ticket={ticket}
+          refreshTicket={refresh}
+          onTicketRefreshed={setTicket}
+        />
+      );
+    }
+
+    await act(async () => root.render(<Harness />));
+    await flush();
+    expect(container.textContent).toContain("rejected this join ticket");
+    expect(container.textContent).not.toContain(rawSecret);
+
+    const button = container.querySelector("button");
+    expect(button?.textContent).toBe("Try again");
+    await act(async () => {
+      button?.dispatchEvent(new window.Event("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledWith(firstTicket);
+    expect(controls.initMeeting.mock.calls.map(([options]) => options.authToken)).toEqual([
+      "first-private-token",
+      "fresh-private-token",
+    ]);
+    const diagnostics = JSON.stringify(warn.mock.calls);
+    expect(diagnostics).not.toContain(rawSecret);
+    expect(diagnostics).not.toContain("private.invalid");
+  });
+
+  it("waits through an offline background and enables fresh-ticket retry after resume", async () => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      writable: true,
+      value: false,
+    });
+    controls.initMeeting.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const refresh = vi.fn().mockResolvedValue(freshTicket);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await act(async () =>
+      root.render(
+        <Stage
+          ticket={firstTicket}
+          refreshTicket={refresh}
+          onTicketRefreshed={() => {}}
+        />,
+      ),
+    );
+    await flush();
+    const button = container.querySelector("button");
+    expect(button?.textContent).toBe("Waiting for connection");
+    expect(button?.disabled).toBe(true);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      writable: true,
+      value: "hidden",
+    });
+    document.dispatchEvent(new window.Event("visibilitychange"));
+    expect(refresh).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      writable: true,
+      value: "visible",
+    });
+    document.dispatchEvent(new window.Event("visibilitychange"));
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      writable: true,
+      value: true,
+    });
+    await act(async () => window.dispatchEvent(new window.Event("online")));
+    expect(button?.disabled).toBe(false);
+    expect(button?.textContent).toBe("Try again");
+
+    await act(async () => {
+      button?.dispatchEvent(new window.Event("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledWith(firstTicket);
+  });
+});

--- a/wallet/zuuli/src/features/live/Stage.tsx
+++ b/wallet/zuuli/src/features/live/Stage.tsx
@@ -7,6 +7,11 @@ import {
 import { RtkMeeting } from "@cloudflare/realtimekit-react-ui";
 import { Button } from "@/components/ui/button";
 import type { DyteJoinTicket } from "@/lib/api/types";
+import {
+  classifyLiveFailure,
+  safeLiveDiagnostic,
+  type LiveConnectionFailure,
+} from "./connection-failure";
 
 type StageStatus = "connecting" | "connected" | "failed" | "ended";
 
@@ -19,16 +24,38 @@ type StageStatus = "connecting" | "connected" | "failed" | "ended";
  * controls, and chat — is rendered as-is. No custom media plumbing needed;
  * RealtimeKit owns the whole stage.
  */
-export function Stage({ ticket }: { ticket: DyteJoinTicket }) {
+export function Stage({
+  ticket,
+  refreshTicket,
+  onTicketRefreshed,
+}: {
+  ticket: DyteJoinTicket;
+  refreshTicket?: (previous: DyteJoinTicket) => Promise<DyteJoinTicket>;
+  onTicketRefreshed?: (fresh: DyteJoinTicket) => void;
+}) {
   const [meeting, initMeeting] = useRealtimeKitClient();
   const [status, setStatus] = useState<StageStatus>("connecting");
-  const [error, setError] = useState<string | null>(null);
-  const [attempt, setAttempt] = useState(0);
+  const [failure, setFailure] = useState<LiveConnectionFailure | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [online, setOnline] = useState(
+    typeof navigator === "undefined" ? true : navigator.onLine !== false,
+  );
+
+  useEffect(() => {
+    const markOnline = () => setOnline(true);
+    const markOffline = () => setOnline(false);
+    window.addEventListener("online", markOnline);
+    window.addEventListener("offline", markOffline);
+    return () => {
+      window.removeEventListener("online", markOnline);
+      window.removeEventListener("offline", markOffline);
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
     setStatus("connecting");
-    setError(null);
+    setFailure(null);
 
     initMeeting({
       authToken: ticket.authToken,
@@ -42,36 +69,47 @@ export function Stage({ ticket }: { ticket: DyteJoinTicket }) {
         if (cancelled || client) return;
         // A falsy resolution (no thrown error) still means we never got a
         // connected client — surface it rather than rendering a blank stage.
-        setError("Failed to connect to meeting.");
+        const classified = classifyLiveFailure(
+          new Error("RealtimeKit returned no client"),
+          "sdk-init",
+        );
+        console.warn("RealtimeKit connection failed", safeLiveDiagnostic(classified));
+        setFailure(classified);
         setStatus("failed");
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        console.error("Failed to initialize RealtimeKit meeting:", err);
-        const e = err as { message?: string; name?: string };
-        const message =
-          e.name === "NotAllowedError" ||
-          e.message?.includes("Permission denied")
-            ? "Microphone or camera permission denied. Please allow access in your browser/app settings and try again."
-            : e.message || "Failed to connect to meeting.";
-        setError(message);
+        const classified = classifyLiveFailure(err, "sdk-init");
+        // Never log the raw SDK error: provider errors can echo credentials or
+        // private endpoints. The allowlisted boundary/category is sufficient.
+        console.warn("RealtimeKit connection failed", safeLiveDiagnostic(classified));
+        setFailure(classified);
         setStatus("failed");
       });
 
     return () => {
       cancelled = true;
     };
-  }, [ticket.authToken, ticket.as, attempt, initMeeting]);
+  }, [ticket.authToken, ticket.as, initMeeting]);
 
   useEffect(() => {
     if (!meeting) return;
 
-    const onJoined = () => setStatus("connected");
+    const onJoined = () => {
+      setFailure(null);
+      setStatus("connected");
+    };
     const onLeft = ({ state }: { state: string }) => {
       if (state === "ended") {
+        setFailure(null);
         setStatus("ended");
       } else if (state === "failed") {
-        setError("Connection to the meeting failed.");
+        const classified = classifyLiveFailure(
+          new TypeError("room transport failed"),
+          "room-session",
+        );
+        console.warn("RealtimeKit connection failed", safeLiveDiagnostic(classified));
+        setFailure(classified);
         setStatus("failed");
       }
     };
@@ -85,22 +123,47 @@ export function Stage({ ticket }: { ticket: DyteJoinTicket }) {
     };
   }, [meeting]);
 
-  if (error) {
+  async function retryWithFreshTicket() {
+    if (!refreshTicket || !onTicketRefreshed || refreshing) return;
+    setRefreshing(true);
+    setFailure(null);
+    setStatus("connecting");
+    try {
+      const fresh = await refreshTicket(ticket);
+      onTicketRefreshed(fresh);
+    } catch (error) {
+      const classified = classifyLiveFailure(error, "ticket-refresh");
+      console.warn("RealtimeKit connection failed", safeLiveDiagnostic(classified));
+      setFailure(classified);
+      setStatus("failed");
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  if (failure) {
     return (
       <div className="absolute inset-0 grid place-items-center px-6">
         <div className="flex flex-col items-center gap-3 text-center">
           <div className="grid h-14 w-14 place-items-center rounded-full bg-destructive/20 ring-2 ring-destructive/40">
             <AlertCircle className="h-7 w-7 text-destructive-foreground" aria-hidden />
           </div>
-          <p className="max-w-xs text-sm text-white/80">{error}</p>
-          <Button
-            size="sm"
-            variant="outline"
-            className="mt-1 border-white/20 bg-white/5 text-white hover:bg-white/10"
-            onClick={() => setAttempt((n) => n + 1)}
-          >
-            Try again
-          </Button>
+          <p className="max-w-xs text-sm text-white/80">{failure.message}</p>
+          {failure.retryable && refreshTicket && onTicketRefreshed ? (
+            <Button
+              size="sm"
+              variant="outline"
+              className="mt-1 border-white/20 bg-white/5 text-white hover:bg-white/10"
+              disabled={refreshing || !online}
+              onClick={() => void retryWithFreshTicket()}
+            >
+              {refreshing
+                ? "Getting a fresh ticket…"
+                : !online
+                  ? "Waiting for connection"
+                  : "Try again"}
+            </Button>
+          ) : null}
         </div>
       </div>
     );

--- a/wallet/zuuli/src/features/live/connection-failure.test.ts
+++ b/wallet/zuuli/src/features/live/connection-failure.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/api/http";
+import { LiveTicketError } from "@/lib/api/live-ticket";
+import { classifyLiveFailure, safeLiveDiagnostic } from "./connection-failure";
+
+describe("live connection failure classification", () => {
+  it.each([
+    [new DOMException("blocked", "SecurityError"), true, "policy"],
+    [new TypeError("Failed to fetch https://private.invalid/ticket"), false, "offline"],
+    [new TypeError("Failed to fetch https://private.invalid/ticket"), true, "transport"],
+    [new DOMException("request stopped", "AbortError"), true, "timeout"],
+    [new ApiError(410, "meeting secret ended"), true, "ended-room"],
+    [new ApiError(412, "creator lifecycle details"), true, "ended-room"],
+    [new ApiError(409, "meeting rotated"), true, "lifecycle-race"],
+    [new LiveTicketError("malformed-ticket"), true, "malformed-ticket"],
+    [new LiveTicketError("meeting-mismatch"), true, "lifecycle-race"],
+    [new LiveTicketError("environment-mismatch"), true, "lifecycle-race"],
+    [new LiveTicketError("expired-ticket"), true, "expired-ticket"],
+    [new LiveTicketError("replayed-ticket"), true, "replayed-ticket"],
+    [new Error("ERR0004 participant token revoked"), true, "token-rejected"],
+    [new Error("auth token belongs to wrong environment"), true, "token-rejected"],
+    [new Error("[ERR0001] Unable to connect to the server"), true, "transport"],
+  ])("classifies %s as %s", (error, online, expected) => {
+    expect(classifyLiveFailure(error, "sdk-init", online).kind).toBe(expected);
+  });
+
+  it("emits only an allowlisted boundary, category, and provider code", () => {
+    const token = "eyJ.private-identity-and-url.signature";
+    const failure = classifyLiveFailure(
+      new Error(`[ERR0004] rejected ${token} at https://private.invalid/join`),
+      "sdk-init",
+      true,
+    );
+    const diagnostic = JSON.stringify(safeLiveDiagnostic(failure));
+
+    expect(JSON.parse(diagnostic)).toEqual({
+      boundary: "sdk-init",
+      category: "token-rejected",
+      providerCode: "ERR0004",
+    });
+    expect(diagnostic).not.toContain(token);
+    expect(diagnostic).not.toContain("private.invalid");
+    expect(diagnostic).not.toContain("identity");
+  });
+});

--- a/wallet/zuuli/src/features/live/connection-failure.ts
+++ b/wallet/zuuli/src/features/live/connection-failure.ts
@@ -1,0 +1,207 @@
+import { ApiError } from "@/lib/api/http";
+import { LiveTicketError } from "@/lib/api/live-ticket";
+
+export type LiveFailureBoundary =
+  | "ticket-request"
+  | "ticket-refresh"
+  | "sdk-init"
+  | "room-session";
+
+export type LiveFailureKind =
+  | "policy"
+  | "offline"
+  | "transport"
+  | "timeout"
+  | "malformed-ticket"
+  | "expired-ticket"
+  | "replayed-ticket"
+  | "token-rejected"
+  | "ended-room"
+  | "lifecycle-race"
+  | "unknown";
+
+export interface LiveConnectionFailure {
+  kind: LiveFailureKind;
+  boundary: LiveFailureBoundary;
+  message: string;
+  retryable: boolean;
+  /** Allowlisted provider code only; never the provider's raw message. */
+  providerCode?: "ERR0001" | "ERR0004";
+}
+
+const COPY: Record<LiveFailureKind, { message: string; retryable: boolean }> = {
+  policy: {
+    message:
+      "The app blocked the live connection. Check app permissions or network security settings, then try again.",
+    retryable: true,
+  },
+  offline: {
+    message:
+      "You're offline. Reconnect, then try again for a fresh join ticket.",
+    retryable: true,
+  },
+  transport: {
+    message:
+      "The live service couldn't be reached. Switch networks or try again.",
+    retryable: true,
+  },
+  timeout: {
+    message: "The live connection timed out. Try again for a fresh join ticket.",
+    retryable: true,
+  },
+  "malformed-ticket": {
+    message:
+      "The stream server returned an invalid join ticket. Try again in a moment.",
+    retryable: true,
+  },
+  "expired-ticket": {
+    message:
+      "The join ticket expired before the connection started. Try again for a fresh one.",
+    retryable: true,
+  },
+  "replayed-ticket": {
+    message:
+      "The stream server did not issue a fresh join ticket. Try again in a moment.",
+    retryable: true,
+  },
+  "token-rejected": {
+    message:
+      "The live service rejected this join ticket. Try again for a fresh one.",
+    retryable: true,
+  },
+  "ended-room": {
+    message: "This stream has ended or is no longer accepting viewers.",
+    retryable: false,
+  },
+  "lifecycle-race": {
+    message:
+      "The stream changed while you were joining. Return to livestreams and open it again.",
+    retryable: false,
+  },
+  unknown: {
+    message: "The live connection failed. Try again for a fresh join ticket.",
+    retryable: true,
+  },
+};
+
+function errorName(error: unknown): string {
+  return error instanceof Error
+    ? error.name
+    : typeof error === "object" && error !== null && "name" in error
+      ? String((error as { name?: unknown }).name ?? "")
+      : "";
+}
+
+function errorText(error: unknown): string {
+  if (error instanceof Error) return error.message.toLowerCase();
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String((error as { message?: unknown }).message ?? "").toLowerCase();
+  }
+  return "";
+}
+
+function providerCode(text: string): LiveConnectionFailure["providerCode"] {
+  if (/\b(?:err)?0004\b/i.test(text)) return "ERR0004";
+  if (/\b(?:err)?0001\b/i.test(text)) return "ERR0001";
+  return undefined;
+}
+
+function makeFailure(
+  kind: LiveFailureKind,
+  boundary: LiveFailureBoundary,
+  code?: LiveConnectionFailure["providerCode"],
+): LiveConnectionFailure {
+  return { kind, boundary, ...COPY[kind], ...(code ? { providerCode: code } : {}) };
+}
+
+/** Classify raw failures once, then discard their potentially sensitive text. */
+export function classifyLiveFailure(
+  error: unknown,
+  boundary: LiveFailureBoundary,
+  online = typeof navigator === "undefined" ? true : navigator.onLine !== false,
+): LiveConnectionFailure {
+  if (error instanceof LiveTicketError) {
+    const kind: LiveFailureKind =
+      error.code === "meeting-mismatch" ||
+      error.code === "environment-mismatch"
+        ? "lifecycle-race"
+        : error.code === "malformed-ticket"
+          ? "malformed-ticket"
+          : error.code === "expired-ticket"
+            ? "expired-ticket"
+            : error.code === "replayed-ticket"
+              ? "replayed-ticket"
+            : "unknown";
+    return makeFailure(kind, boundary);
+  }
+
+  if (error instanceof ApiError) {
+    if ([404, 410, 412].includes(error.status)) {
+      return makeFailure("ended-room", boundary);
+    }
+    if (error.status === 409) return makeFailure("lifecycle-race", boundary);
+    if ([408, 504].includes(error.status)) return makeFailure("timeout", boundary);
+    if ([401, 403].includes(error.status)) {
+      return makeFailure("token-rejected", boundary);
+    }
+  }
+
+  const name = errorName(error);
+  const text = errorText(error);
+  const code = providerCode(text);
+  if (name === "PrivateRoomUnavailableError") {
+    return makeFailure("ended-room", boundary, code);
+  }
+  if (
+    name === "SecurityError" ||
+    name === "NotAllowedError" ||
+    /content security policy|blocked by (?:client|policy)|permission denied|not allowed/.test(
+      text,
+    )
+  ) {
+    return makeFailure("policy", boundary, code);
+  }
+  if (!online) return makeFailure("offline", boundary, code);
+  if (
+    name === "AbortError" ||
+    name === "TimeoutError" ||
+    /timed? out|timeout/.test(text)
+  ) {
+    return makeFailure("timeout", boundary, code);
+  }
+  if (
+    code === "ERR0004" ||
+    /auth(?:entication)? token|unauthori[sz]ed|token (?:expired|revoked|rejected)|wrong environment|invalid participant/.test(
+      text,
+    )
+  ) {
+    return makeFailure("token-rejected", boundary, code);
+  }
+  if (/meeting (?:ended|inactive)|room (?:ended|closed)/.test(text)) {
+    return makeFailure("ended-room", boundary, code);
+  }
+  if (
+    error instanceof TypeError ||
+    /failed to fetch|networkerror|network request|websocket|unable to connect/.test(
+      text,
+    )
+  ) {
+    return makeFailure("transport", boundary, code);
+  }
+  return makeFailure("unknown", boundary, code);
+}
+
+/** Safe for telemetry/console/feedback: no raw error, credential, URL or ID. */
+export function safeLiveDiagnostic(failure: LiveConnectionFailure): {
+  boundary: LiveFailureBoundary;
+  category: LiveFailureKind;
+  providerCode?: "ERR0001" | "ERR0004";
+} {
+  return {
+    boundary: failure.boundary,
+    category: failure.kind,
+    ...(failure.providerCode
+      ? { providerCode: failure.providerCode }
+      : {}),
+  };
+}

--- a/wallet/zuuli/src/features/live/viewer-safety.test.ts
+++ b/wallet/zuuli/src/features/live/viewer-safety.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { viewerEntryState } from "./viewer-safety";
+
+describe("creator-safe viewer entry", () => {
+  it("cannot issue a public join while identity hydration is unresolved", () => {
+    expect(
+      viewerEntryState({
+        sessionLoading: true,
+        creatorUsername: "alice",
+        kind: "broadcast",
+      }),
+    ).toBe("checking-session");
+  });
+
+  it("blocks the authenticated creator case-insensitively from the overloaded public route", () => {
+    expect(
+      viewerEntryState({
+        sessionLoading: false,
+        viewerUsername: "ALICE",
+        creatorUsername: "alice",
+        kind: "broadcast",
+      }),
+    ).toBe("creator-blocked");
+  });
+
+  it("allows guests, other viewers, and the dedicated non-management private invite route", () => {
+    expect(
+      viewerEntryState({
+        sessionLoading: false,
+        creatorUsername: "alice",
+        kind: "broadcast",
+      }),
+    ).toBe("allowed");
+    expect(
+      viewerEntryState({
+        sessionLoading: false,
+        viewerUsername: "bob",
+        creatorUsername: "alice",
+        kind: "subscriber",
+      }),
+    ).toBe("allowed");
+    expect(
+      viewerEntryState({
+        sessionLoading: false,
+        viewerUsername: "alice",
+        creatorUsername: "alice",
+        kind: "private",
+      }),
+    ).toBe("allowed");
+  });
+});

--- a/wallet/zuuli/src/features/live/viewer-safety.ts
+++ b/wallet/zuuli/src/features/live/viewer-safety.ts
@@ -1,0 +1,25 @@
+import type { StreamKind } from "@/lib/api/types";
+
+export type ViewerEntryState = "checking-session" | "creator-blocked" | "allowed";
+
+/**
+ * The public backend route is intentionally overloaded for host start and
+ * viewer join. Until session hydration proves who is clicking, issuing its
+ * POST would risk treating the creator's viewer-page click as host authority.
+ */
+export function viewerEntryState(options: {
+  sessionLoading: boolean;
+  viewerUsername?: string;
+  creatorUsername: string;
+  kind: StreamKind;
+}): ViewerEntryState {
+  if (options.sessionLoading) return "checking-session";
+  if (
+    options.kind !== "private" &&
+    options.viewerUsername?.toLowerCase() ===
+      options.creatorUsername.toLowerCase()
+  ) {
+    return "creator-blocked";
+  }
+  return "allowed";
+}

--- a/wallet/zuuli/src/lib/api/free2z.ts
+++ b/wallet/zuuli/src/lib/api/free2z.ts
@@ -103,6 +103,7 @@ import type {
   TuziTransaction,
 } from "./types";
 import { validateStripeCheckoutUrl } from "./checkout";
+import { parseJoinTicketResponse } from "./live-ticket";
 import { parseSocialProvidersStatus } from "./social-providers";
 import {
   parseCheckoutPaymentStatus,
@@ -699,6 +700,7 @@ function mapLivestream(m: RawDyteMeeting): Livestream {
   const creator = mapCreator(m.creator);
   return {
     id: String(m.id),
+    meetingId: m.meeting_id,
     username: m.creator.username,
     creator,
     title: `${creator.display_name} is live`,
@@ -1882,18 +1884,17 @@ export const live = {
       const ticket = await live.join(me.username, "private", secret, "host");
       return { ticket, inviteSecret: secret };
     }
-    const r = await request<{ meeting_id: string; auth_token: string }>(
+    const r = await request<unknown>(
       `/api/dyte/${me.username}/${meetingType}`,
       { method: "POST" },
     );
     // A new public meeting changed discovery; private rooms never touch it.
     listingCache = null;
     return {
-      ticket: {
-        authToken: r.auth_token,
-        meetingId: r.meeting_id,
+      ticket: parseJoinTicketResponse(r, {
         as: "host",
-      },
+        responseMeetingIdRequired: true,
+      }),
     };
   },
 
@@ -1912,6 +1913,11 @@ export const live = {
     kind: StreamKind,
     secret?: string,
     as: "host" | "participant" = "participant",
+    constraints: {
+      expectedMeetingId?: string;
+      expectedEnvironmentId?: string;
+      previousAuthToken?: string;
+    } = {},
   ): Promise<DyteJoinTicket> {
     const meetingType = typeFromStreamKind(kind);
     if (useMock()) {
@@ -1937,13 +1943,14 @@ export const live = {
         : `/api/dyte/${encodeURIComponent(username)}/${meetingType}`;
     // The private-join response omits meeting_id (returns { e2ee, auth_token }).
     try {
-      const r = await request<{ meeting_id?: string; auth_token: string }>(path, {
+      const r = await request<unknown>(path, {
         method: "POST",
       });
-      if (!r || typeof r.auth_token !== "string" || !r.auth_token) {
-        throw new Error("Livestream join returned no authentication ticket");
-      }
-      return { authToken: r.auth_token, meetingId: r.meeting_id ?? "", as };
+      return parseJoinTicketResponse(r, {
+        as,
+        responseMeetingIdRequired: kind !== "private",
+        ...constraints,
+      });
     } catch (error) {
       if (
         kind === "private" &&
@@ -1954,6 +1961,27 @@ export const live = {
       }
       throw error;
     }
+  },
+
+  /**
+   * Refresh a viewer credential by repeating only the authoritative join
+   * operation. This never calls `start` or either creator management endpoint,
+   * remains bound to the selected meeting/environment, and rejects a replay.
+   */
+  async refreshParticipant(
+    username: string,
+    kind: StreamKind,
+    previous: DyteJoinTicket,
+    secret?: string,
+  ): Promise<DyteJoinTicket> {
+    if (previous.as !== "participant") {
+      throw new Error("Only participant join tickets can be refreshed here.");
+    }
+    return live.join(username, kind, secret, "participant", {
+      expectedMeetingId: previous.meetingId,
+      expectedEnvironmentId: previous.environmentId,
+      previousAuthToken: previous.authToken,
+    });
   },
 };
 

--- a/wallet/zuuli/src/lib/api/live-join-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/live-join-contract.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./http", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./http")>();
+  return { ...original, request: vi.fn() };
+});
+
+import { live } from "./free2z";
+import { request } from "./http";
+import { LiveTicketError } from "./live-ticket";
+
+const requestMock = vi.mocked(request);
+
+function token(
+  participantId: string,
+  meetingId = "selected-meeting",
+  orgId = "production-org",
+): string {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value))
+      .replace(/=/g, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+  return `${encode({ alg: "RS256" })}.${encode({
+    meetingId,
+    participantId,
+    orgId,
+    exp: 4_102_444_800,
+  })}.signature`;
+}
+
+describe("authoritative public live join and refresh", () => {
+  beforeEach(() => requestMock.mockReset());
+
+  it("binds the initial ticket to the exact meeting selected in discovery", async () => {
+    const authToken = token("viewer-one");
+    requestMock.mockResolvedValueOnce({
+      auth_token: authToken,
+      meeting_id: "selected-meeting",
+    });
+
+    await expect(
+      live.join("alice", "broadcast", undefined, "participant", {
+        expectedMeetingId: "selected-meeting",
+      }),
+    ).resolves.toMatchObject({
+      authToken,
+      meetingId: "selected-meeting",
+      environmentId: "production-org",
+      as: "participant",
+    });
+    expect(requestMock).toHaveBeenCalledWith("/api/dyte/alice/broadcast", {
+      method: "POST",
+    });
+  });
+
+  it("refreshes through one join request and never calls a creator management route", async () => {
+    const previous = {
+      authToken: token("viewer-one"),
+      meetingId: "selected-meeting",
+      environmentId: "production-org",
+      as: "participant" as const,
+    };
+    const fresh = token("viewer-two");
+    requestMock.mockResolvedValueOnce({
+      auth_token: fresh,
+      meeting_id: "selected-meeting",
+    });
+
+    await expect(
+      live.refreshParticipant("alice", "broadcast", previous),
+    ).resolves.toMatchObject({ authToken: fresh, meetingId: "selected-meeting" });
+    expect(requestMock.mock.calls).toEqual([
+      ["/api/dyte/alice/broadcast", { method: "POST" }],
+    ]);
+    expect(requestMock.mock.calls.flat().join(" ")).not.toContain("/private");
+  });
+
+  it("fails closed when retry replays, rotates rooms, or changes environment", async () => {
+    const previous = {
+      authToken: token("viewer-one"),
+      meetingId: "selected-meeting",
+      environmentId: "production-org",
+      as: "participant" as const,
+    };
+
+    requestMock.mockResolvedValueOnce({
+      auth_token: previous.authToken,
+      meeting_id: "selected-meeting",
+    });
+    await expect(
+      live.refreshParticipant("alice", "broadcast", previous),
+    ).rejects.toMatchObject({
+      code: "replayed-ticket",
+    } satisfies Partial<LiveTicketError>);
+
+    requestMock.mockResolvedValueOnce({
+      auth_token: token("viewer-two", "rotated-meeting"),
+      meeting_id: "rotated-meeting",
+    });
+    await expect(
+      live.refreshParticipant("alice", "broadcast", previous),
+    ).rejects.toMatchObject({
+      code: "meeting-mismatch",
+    } satisfies Partial<LiveTicketError>);
+
+    requestMock.mockResolvedValueOnce({
+      auth_token: token("viewer-three", "selected-meeting", "staging-org"),
+      meeting_id: "selected-meeting",
+    });
+    await expect(
+      live.refreshParticipant("alice", "broadcast", previous),
+    ).rejects.toMatchObject({
+      code: "environment-mismatch",
+    } satisfies Partial<LiveTicketError>);
+  });
+
+  it("refuses to turn host recovery into a participant or room mutation", async () => {
+    await expect(
+      live.refreshParticipant("alice", "broadcast", {
+        authToken: token("host"),
+        meetingId: "selected-meeting",
+        environmentId: "production-org",
+        as: "host",
+      }),
+    ).rejects.toThrow("Only participant join tickets");
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the non-management secret join route for private viewer refresh", async () => {
+    const inviteId = "123e4567-e89b-42d3-a456-426614174000";
+    const previous = {
+      authToken: token("private-viewer-one", "private-meeting"),
+      meetingId: "private-meeting",
+      environmentId: "production-org",
+      as: "participant" as const,
+    };
+    requestMock.mockResolvedValueOnce({
+      auth_token: token("private-viewer-two", "private-meeting"),
+    });
+
+    await live.refreshParticipant("alice", "private", previous, inviteId);
+    expect(requestMock).toHaveBeenCalledWith(
+      `/api/dyte/alice/private/${inviteId}`,
+      { method: "POST" },
+    );
+    expect(requestMock.mock.calls[0]?.[0]).not.toBe("/api/dyte/alice/private");
+  });
+});

--- a/wallet/zuuli/src/lib/api/live-ppv-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/live-ppv-contract.test.ts
@@ -15,6 +15,29 @@ import type { StreamKind } from "./types";
 
 const requestMock = vi.mocked(request);
 
+/**
+ * A minimally valid RealtimeKit-shaped auth token: three base64url segments
+ * whose payload carries the claims `live-ticket.ts` requires before it will
+ * bind a ticket to a meeting.
+ */
+function fakeAuthToken(
+  claims: Record<string, unknown> = {},
+  header: Record<string, unknown> = { alg: "RS256" },
+): string {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value))
+      .replace(/=/g, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+  return `${encode(header)}.${encode({
+    meetingId: "authoritative-meeting",
+    orgId: "production-org",
+    participantId: "viewer-participant",
+    exp: 2_100_000_000,
+    ...claims,
+  })}.signature`;
+}
+
 function meeting(meetingType: unknown, ...pricePerMinute: [unknown?]) {
   return {
     id: 814,
@@ -30,6 +53,7 @@ describe("PPV livestream HTTP contract", () => {
   beforeEach(() => requestMock.mockReset());
 
   it("round-trips the authoritative ppv kind through listing, status, and participant join", async () => {
+    const participantToken = fakeAuthToken({ participantId: "participant-ticket" });
     requestMock
       .mockResolvedValueOnce({ results: [meeting("ppv")] })
       .mockResolvedValueOnce({
@@ -37,7 +61,7 @@ describe("PPV livestream HTTP contract", () => {
       })
       .mockResolvedValueOnce({
         meeting_id: "authoritative-meeting",
-        auth_token: "participant-ticket",
+        auth_token: participantToken,
       });
 
     const [stream] = await live.listPublic({ force: true });
@@ -53,7 +77,7 @@ describe("PPV livestream HTTP contract", () => {
     });
 
     await expect(live.join("alice", stream!.kind)).resolves.toMatchObject({
-      authToken: "participant-ticket",
+      authToken: participantToken,
       meetingId: "authoritative-meeting",
       as: "participant",
     });
@@ -65,16 +89,17 @@ describe("PPV livestream HTTP contract", () => {
   });
 
   it("uses the ppv wire enum for the existing host-start endpoint", async () => {
+    const hostToken = fakeAuthToken({ participantId: "host-ticket" });
     requestMock
       .mockResolvedValueOnce({ username: "alice", tuzis: "500" })
       .mockResolvedValueOnce({
         meeting_id: "authoritative-meeting",
-        auth_token: "host-ticket",
+        auth_token: hostToken,
       });
 
     await expect(live.start("ppv")).resolves.toMatchObject({
       ticket: {
-        authToken: "host-ticket",
+        authToken: hostToken,
         meetingId: "authoritative-meeting",
         as: "host",
       },

--- a/wallet/zuuli/src/lib/api/live-ticket.test.ts
+++ b/wallet/zuuli/src/lib/api/live-ticket.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  LiveTicketError,
+  parseJoinTicketResponse,
+} from "./live-ticket";
+
+const NOW = 2_000_000_000_000;
+
+function token(
+  claims: Record<string, unknown> = {},
+  header: Record<string, unknown> = { alg: "RS256" },
+): string {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value))
+      .replace(/=/g, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+  return `${encode(header)}.${encode({
+    meetingId: "meeting-one",
+    orgId: "production-org",
+    participantId: "viewer-participant",
+    exp: 2_100_000_000,
+    ...claims,
+  })}.signature`;
+}
+
+function parse(
+  response: unknown,
+  overrides: Partial<Parameters<typeof parseJoinTicketResponse>[1]> = {},
+) {
+  return parseJoinTicketResponse(response, {
+    as: "participant",
+    responseMeetingIdRequired: true,
+    nowMs: NOW,
+    ...overrides,
+  });
+}
+
+async function failure(operation: () => unknown): Promise<LiveTicketError> {
+  try {
+    operation();
+  } catch (error) {
+    expect(error).toBeInstanceOf(LiveTicketError);
+    return error as LiveTicketError;
+  }
+  throw new Error("Expected ticket parsing to fail");
+}
+
+describe("strict RealtimeKit join ticket parsing", () => {
+  it("returns only the bounded provider data needed by the meeting stage", () => {
+    const authToken = token({
+      email: "must-not-escape@example.test",
+      private_url: "https://private.invalid/secret",
+      nested: { identity: "must-not-escape" },
+    });
+
+    expect(parse({ auth_token: authToken, meeting_id: "meeting-one" })).toEqual({
+      authToken,
+      meetingId: "meeting-one",
+      environmentId: "production-org",
+      expiresAt: 2_100_000_000,
+      as: "participant",
+    });
+  });
+
+  it.each([
+    null,
+    {},
+    { auth_token: "" },
+    { auth_token: "not-a-participant-token", meeting_id: "meeting-one" },
+    { auth_token: "a.b.c", meeting_id: "meeting-one" },
+    { auth_token: token({ meetingId: "" }), meeting_id: "meeting-one" },
+    { auth_token: token({ orgId: null }), meeting_id: "meeting-one" },
+    { auth_token: token({ participantId: [] }), meeting_id: "meeting-one" },
+    { auth_token: token({ exp: "2100000000" }), meeting_id: "meeting-one" },
+    { auth_token: token(), meeting_id: " meeting-one" },
+  ])("fails closed on a malformed response without echoing it: %#", async (value) => {
+    const error = await failure(() => parse(value));
+    expect(error.code).toBe("malformed-ticket");
+    expect(error.message).not.toContain("participant");
+    expect(error.message).not.toContain("meeting-one");
+  });
+
+  it("requires meeting_id on the public contract but derives it for private joins", async () => {
+    const authToken = token();
+    const publicError = await failure(() => parse({ auth_token: authToken }));
+    expect(publicError.code).toBe("malformed-ticket");
+
+    expect(
+      parse(
+        { auth_token: authToken },
+        { responseMeetingIdRequired: false },
+      ).meetingId,
+    ).toBe("meeting-one");
+  });
+
+  it("rejects an expired credential before RealtimeKit sees it", async () => {
+    const error = await failure(() =>
+      parse({
+        auth_token: token({ exp: NOW / 1_000 }),
+        meeting_id: "meeting-one",
+      }),
+    );
+    expect(error.code).toBe("expired-ticket");
+  });
+
+  it("binds the response, token, and selected listing to one meeting", async () => {
+    const responseMismatch = await failure(() =>
+      parse({ auth_token: token(), meeting_id: "meeting-two" }),
+    );
+    expect(responseMismatch.code).toBe("meeting-mismatch");
+
+    const rotatedListing = await failure(() =>
+      parse(
+        { auth_token: token(), meeting_id: "meeting-one" },
+        { expectedMeetingId: "meeting-before-rotation" },
+      ),
+    );
+    expect(rotatedListing.code).toBe("meeting-mismatch");
+  });
+
+  it("rejects environment changes and credential replay during refresh", async () => {
+    const first = token();
+    const wrongEnvironment = await failure(() =>
+      parse(
+        {
+          auth_token: token({ orgId: "staging-org", participantId: "new-viewer" }),
+          meeting_id: "meeting-one",
+        },
+        { expectedEnvironmentId: "production-org" },
+      ),
+    );
+    expect(wrongEnvironment.code).toBe("environment-mismatch");
+
+    const replay = await failure(() =>
+      parse(
+        { auth_token: first, meeting_id: "meeting-one" },
+        { previousAuthToken: first },
+      ),
+    );
+    expect(replay.code).toBe("replayed-ticket");
+  });
+});

--- a/wallet/zuuli/src/lib/api/live-ticket.ts
+++ b/wallet/zuuli/src/lib/api/live-ticket.ts
@@ -1,0 +1,203 @@
+import type { DyteJoinTicket } from "./types";
+
+export type LiveTicketFailureCode =
+  | "malformed-ticket"
+  | "expired-ticket"
+  | "meeting-mismatch"
+  | "environment-mismatch"
+  | "replayed-ticket";
+
+const SAFE_MESSAGES: Record<LiveTicketFailureCode, string> = {
+  "malformed-ticket":
+    "The stream server returned an invalid join ticket. Try again.",
+  "expired-ticket":
+    "The join ticket expired before the connection started. Try again for a fresh ticket.",
+  "meeting-mismatch":
+    "The stream changed while you were joining. Return to livestreams and open it again.",
+  "environment-mismatch":
+    "The stream service changed while you were joining. Return to livestreams and open it again.",
+  "replayed-ticket":
+    "The stream server did not issue a fresh join ticket. Try again in a moment.",
+};
+
+/**
+ * A deliberately content-free failure. The raw response, token, decoded
+ * claims, meeting identifiers, and participant identity must never cross this
+ * boundary into UI copy or diagnostics.
+ */
+export class LiveTicketError extends Error {
+  readonly code: LiveTicketFailureCode;
+
+  constructor(code: LiveTicketFailureCode) {
+    super(SAFE_MESSAGES[code]);
+    this.name = "LiveTicketError";
+    this.code = code;
+  }
+}
+
+interface ParticipantTokenBinding {
+  meetingId: string;
+  environmentId: string;
+  expiresAt?: number;
+}
+
+export interface JoinTicketConstraints {
+  as: "host" | "participant";
+  /** Public join/start responses are contractually required to carry this. */
+  responseMeetingIdRequired: boolean;
+  /** The listing/previous ticket the user explicitly chose to join. */
+  expectedMeetingId?: string;
+  /** A refresh must stay on the same provider tenant/environment. */
+  expectedEnvironmentId?: string;
+  /** A refresh must never silently replay the credential that just failed. */
+  previousAuthToken?: string;
+  nowMs?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function opaqueId(value: unknown): string | null {
+  if (typeof value !== "string" || value !== value.trim()) return null;
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(value)) return null;
+  return value;
+}
+
+function decodeBase64UrlJson(segment: string): unknown {
+  if (
+    segment.length === 0 ||
+    segment.length > 12_000 ||
+    !/^[A-Za-z0-9_-]+$/.test(segment)
+  ) {
+    throw new LiveTicketError("malformed-ticket");
+  }
+  const padding = "=".repeat((4 - (segment.length % 4)) % 4);
+  try {
+    const binary = atob(segment.replace(/-/g, "+").replace(/_/g, "/") + padding);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+    ) as unknown;
+  } catch {
+    throw new LiveTicketError("malformed-ticket");
+  }
+}
+
+/**
+ * Decode only the provider binding and expiry claims required before handing a
+ * credential to RealtimeKit. This does not verify JWT authenticity; TLS and
+ * the authoritative Free2Z response provide that boundary. It only fails
+ * closed when the response and provider token disagree.
+ */
+function participantTokenBinding(
+  authToken: string,
+  nowMs: number,
+): ParticipantTokenBinding {
+  if (
+    authToken.length === 0 ||
+    authToken.length > 16_384 ||
+    authToken !== authToken.trim()
+  ) {
+    throw new LiveTicketError("malformed-ticket");
+  }
+  const segments = authToken.split(".");
+  if (
+    segments.length !== 3 ||
+    segments.some(
+      (segment) => segment.length === 0 || !/^[A-Za-z0-9_-]+$/.test(segment),
+    )
+  ) {
+    throw new LiveTicketError("malformed-ticket");
+  }
+
+  const payload = decodeBase64UrlJson(segments[1]!);
+  if (!isRecord(payload)) throw new LiveTicketError("malformed-ticket");
+
+  // These are the exact camelCase claims consumed by RealtimeKit 1.x.
+  const meetingId = opaqueId(payload.meetingId);
+  const environmentId = opaqueId(payload.orgId);
+  if (!meetingId || !environmentId || !opaqueId(payload.participantId)) {
+    throw new LiveTicketError("malformed-ticket");
+  }
+
+  let expiresAt: number | undefined;
+  if (payload.exp !== undefined) {
+    if (
+      typeof payload.exp !== "number" ||
+      !Number.isSafeInteger(payload.exp) ||
+      payload.exp <= 0 ||
+      payload.exp > Math.floor(Number.MAX_SAFE_INTEGER / 1_000)
+    ) {
+      throw new LiveTicketError("malformed-ticket");
+    }
+    expiresAt = payload.exp;
+    if (expiresAt * 1_000 <= nowMs) {
+      throw new LiveTicketError("expired-ticket");
+    }
+  }
+
+  return { meetingId, environmentId, expiresAt };
+}
+
+function optionalOpaqueId(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  const parsed = opaqueId(value);
+  if (!parsed) throw new LiveTicketError("malformed-ticket");
+  return parsed;
+}
+
+/** Strictly convert the untrusted HTTP response into the only ticket shape UI accepts. */
+export function parseJoinTicketResponse(
+  value: unknown,
+  constraints: JoinTicketConstraints,
+): DyteJoinTicket {
+  if (!isRecord(value)) throw new LiveTicketError("malformed-ticket");
+  if (typeof value.auth_token !== "string") {
+    throw new LiveTicketError("malformed-ticket");
+  }
+
+  const binding = participantTokenBinding(
+    value.auth_token,
+    constraints.nowMs ?? Date.now(),
+  );
+  const responseMeetingId = optionalOpaqueId(value.meeting_id);
+  if (constraints.responseMeetingIdRequired && !responseMeetingId) {
+    throw new LiveTicketError("malformed-ticket");
+  }
+  if (responseMeetingId && responseMeetingId !== binding.meetingId) {
+    throw new LiveTicketError("meeting-mismatch");
+  }
+
+  const meetingId = responseMeetingId ?? binding.meetingId;
+  if (
+    constraints.expectedMeetingId &&
+    meetingId !== constraints.expectedMeetingId
+  ) {
+    throw new LiveTicketError("meeting-mismatch");
+  }
+  if (
+    constraints.expectedEnvironmentId &&
+    binding.environmentId !== constraints.expectedEnvironmentId
+  ) {
+    throw new LiveTicketError("environment-mismatch");
+  }
+  if (
+    constraints.previousAuthToken &&
+    value.auth_token === constraints.previousAuthToken
+  ) {
+    throw new LiveTicketError("replayed-ticket");
+  }
+
+  const roomName = optionalOpaqueId(value.room_name);
+  return {
+    authToken: value.auth_token,
+    meetingId,
+    environmentId: binding.environmentId,
+    ...(binding.expiresAt === undefined
+      ? {}
+      : { expiresAt: binding.expiresAt }),
+    ...(roomName === undefined ? {} : { roomName }),
+    as: constraints.as,
+  };
+}

--- a/wallet/zuuli/src/lib/api/private-live-contract.test.ts
+++ b/wallet/zuuli/src/lib/api/private-live-contract.test.ts
@@ -10,21 +10,41 @@ import { ApiError, request } from "./http";
 
 const requestMock = vi.mocked(request);
 const secret = "123e4567-e89b-42d3-a456-426614174000";
+function participantToken(
+  meetingId: string,
+  participantId: string,
+  orgId = "production-org",
+): string {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value))
+      .replace(/=/g, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+  return `${encode({ alg: "RS256" })}.${encode({
+    meetingId,
+    participantId,
+    orgId,
+    exp: 4_102_444_800,
+  })}.signature`;
+}
 
 describe("private livestream HTTP contract", () => {
   beforeEach(() => requestMock.mockReset());
 
   it("creates the secret and then joins the same private room as host", async () => {
+    const hostToken = participantToken("private-room", "host-participant");
     requestMock
       .mockResolvedValueOnce({ username: "alice", tuzis: "500" })
       .mockResolvedValueOnce({ secret, e2ee: true, meeting_id: "not-a-ticket" })
-      .mockResolvedValueOnce({ auth_token: "host-ticket", e2ee: true });
+      .mockResolvedValueOnce({ auth_token: hostToken, e2ee: true });
 
     await expect(live.start("private")).resolves.toEqual({
       inviteSecret: secret,
       ticket: {
-        authToken: "host-ticket",
-        meetingId: "",
+        authToken: hostToken,
+        meetingId: "private-room",
+        environmentId: "production-org",
+        expiresAt: 4_102_444_800,
         as: "host",
       },
     });
@@ -66,17 +86,21 @@ describe("private livestream HTTP contract", () => {
   });
 
   it("uses the secret join endpoint for cold guests and refreshed hosts", async () => {
+    const guestToken = participantToken("private-room", "guest-participant");
+    const hostToken = participantToken("private-room", "host-participant");
     requestMock
-      .mockResolvedValueOnce({ auth_token: "guest-ticket" })
-      .mockResolvedValueOnce({ auth_token: "refreshed-host-ticket" });
+      .mockResolvedValueOnce({ auth_token: guestToken })
+      .mockResolvedValueOnce({ auth_token: hostToken });
     await expect(live.join("alice", "private", secret)).resolves.toMatchObject({
-      authToken: "guest-ticket",
+      authToken: guestToken,
+      meetingId: "private-room",
       as: "participant",
     });
     await expect(
       live.join("alice", "private", secret, "host"),
     ).resolves.toMatchObject({
-      authToken: "refreshed-host-ticket",
+      authToken: hostToken,
+      meetingId: "private-room",
       as: "host",
     });
     expect(requestMock.mock.calls.map(([path]) => path)).toEqual([

--- a/wallet/zuuli/src/lib/api/types.ts
+++ b/wallet/zuuli/src/lib/api/types.ts
@@ -362,6 +362,8 @@ export interface LiveStatus {
 
 export interface Livestream {
   id: string;
+  /** Provider meeting selected by discovery; binds the subsequent join ticket. */
+  meetingId?: string;
   username: string;
   creator: SimpleCreator;
   title: string;
@@ -379,6 +381,10 @@ export interface Livestream {
 export interface DyteJoinTicket {
   authToken: string;
   meetingId: string;
+  /** Provider tenant binding. Never render or include in diagnostics. */
+  environmentId?: string;
+  /** JWT expiry in seconds since Unix epoch, when the provider supplies it. */
+  expiresAt?: number;
   roomName?: string;
   as: "host" | "participant";
 }


### PR DESCRIPTION
Closes #815
Part of #813

## Summary
- strictly parse RealtimeKit participant JWTs and bind the token, authoritative join response, discovery meeting, provider environment, role, and expiry before SDK initialization
- replace same-token SDK retry with a fresh participant-only authoritative join, rejecting replay, room rotation, environment drift, and host-role refresh
- prevent an unresolved or creator-owned public viewer page from invoking the overloaded host/join route
- classify policy/CSP, offline, transport, timeout, malformed/expired/replayed tickets, provider rejection, ended rooms, and lifecycle races into safe actionable copy
- emit allowlisted boundary/category/provider-code diagnostics only; never raw SDK errors, token claims, meeting IDs, identities, or private URLs

## Verification
- npm run typecheck:tests
- npm run build
- npx vitest run (68 files; 887 passed, 5 skipped)
- focused live suite (58 passed)
- gitleaks git --staged --redact --no-banner .

## Backend boundary
The client blocks the known creator-viewer trigger and its retry path never calls start or private room management. The backend must still enforce the second-layer creator-safe public-route invariant tracked in free2z/tuzi#1514; this PR does not claim that server guard or signed-device end-to-end evidence.