### PR TITLE
test(relay): cover authorization-before-commit ordering for all 6 relay-state commands

### DIFF
--- a/rs/crates/f2z-relay/tests/configured_equivalents.rs
+++ b/rs/crates/f2z-relay/tests/configured_equivalents.rs
@@ -114,6 +114,11 @@ fn key(seed: u8) -> SigningKey {
 /// relay has authorized the signed queue identity. This goes through the
 /// production WebSocket listener and the production `RelayStore` lookup; the
 /// count is the live relay-wide seen-set, not a verifier fixture.
+///
+/// This is one of six `RelayState`-authorized commands wired through
+/// `f2z-relay/src/engine.rs`'s `verify_with` (§5's ordering added by #658):
+/// `SUBSCRIBE` (here), `UNSUBSCRIBE`, `READ`, `ACK`, `DELETE_QUEUE` and
+/// `APPEND` (below). Issue #659 found this guarantee tested for only this one.
 #[tokio::test(flavor = "multi_thread")]
 async fn denied_queue_authorization_does_not_commit_the_replay_key() {
     let server = relay(|_| {}).await;
@@ -131,6 +136,151 @@ async fn denied_queue_authorization_does_not_commit_the_replay_key() {
 
     let after = server.relay().sweep_memory(0).0;
     assert_eq!(after, before, "denied command entered the relay seen-set");
+    server.shutdown().await;
+}
+
+/// `UNSUBSCRIBE`'s share of the same guarantee: a signed-but-unauthorized
+/// `UNSUBSCRIBE` must not consume the seen-set either.
+#[tokio::test(flavor = "multi_thread")]
+async fn denied_unsubscribe_authorization_does_not_commit_the_replay_key() {
+    let server = relay(|_| {}).await;
+    let mut alice = client(&server, 0x61).await;
+    let owner = key(0x62);
+    let intruder = key(0x63);
+    let queue = alice.create_queue(&owner, 0, 0, None).await.unwrap();
+    let before = server.relay().sweep_memory(0).0;
+
+    expect_code(
+        alice.unsubscribe(&intruder, queue.recv_addr).await,
+        ErrorCode::NoAccess,
+    )
+    .unwrap();
+
+    let after = server.relay().sweep_memory(0).0;
+    assert_eq!(after, before, "denied command entered the relay seen-set");
+    server.shutdown().await;
+}
+
+/// `READ`'s share of the same guarantee.
+#[tokio::test(flavor = "multi_thread")]
+async fn denied_read_authorization_does_not_commit_the_replay_key() {
+    let server = relay(|_| {}).await;
+    let mut alice = client(&server, 0x64).await;
+    let owner = key(0x65);
+    let intruder = key(0x66);
+    let queue = alice.create_queue(&owner, 0, 0, None).await.unwrap();
+    let before = server.relay().sweep_memory(0).0;
+
+    expect_code(
+        alice.read(&intruder, queue.recv_addr, 0, 0, 0).await,
+        ErrorCode::NoAccess,
+    )
+    .unwrap();
+
+    let after = server.relay().sweep_memory(0).0;
+    assert_eq!(after, before, "denied command entered the relay seen-set");
+    server.shutdown().await;
+}
+
+/// `ACK`'s share of the same guarantee.
+#[tokio::test(flavor = "multi_thread")]
+async fn denied_ack_authorization_does_not_commit_the_replay_key() {
+    let server = relay(|_| {}).await;
+    let mut alice = client(&server, 0x67).await;
+    let owner = key(0x68);
+    let intruder = key(0x69);
+    let queue = alice.create_queue(&owner, 0, 0, None).await.unwrap();
+    let before = server.relay().sweep_memory(0).0;
+
+    expect_code(
+        alice.ack(&intruder, queue.recv_addr, 0).await,
+        ErrorCode::NoAccess,
+    )
+    .unwrap();
+
+    let after = server.relay().sweep_memory(0).0;
+    assert_eq!(after, before, "denied command entered the relay seen-set");
+    server.shutdown().await;
+}
+
+/// `DELETE_QUEUE`'s share of the same guarantee.
+#[tokio::test(flavor = "multi_thread")]
+async fn denied_delete_queue_authorization_does_not_commit_the_replay_key() {
+    let server = relay(|_| {}).await;
+    let mut alice = client(&server, 0x6a).await;
+    let owner = key(0x6b);
+    let intruder = key(0x6c);
+    let queue = alice.create_queue(&owner, 0, 0, None).await.unwrap();
+    let before = server.relay().sweep_memory(0).0;
+
+    expect_code(
+        alice.delete_queue(&intruder, queue.recv_addr).await,
+        ErrorCode::NoAccess,
+    )
+    .unwrap();
+
+    let after = server.relay().sweep_memory(0).0;
+    assert_eq!(after, before, "denied command entered the relay seen-set");
+    server.shutdown().await;
+}
+
+/// `APPEND`'s share of the same guarantee, send side. A signer that never
+/// bound `send_addr` gets §6.3's collapsed `ERR_UNAVAILABLE`, not
+/// `ERR_NO_ACCESS` — the send-side lookup gives every refusal one code so a
+/// bound sender cannot learn queue state by filling it — but it must still not
+/// touch the seen-set before that refusal is decided.
+#[tokio::test(flavor = "multi_thread")]
+async fn denied_append_authorization_does_not_commit_the_replay_key() {
+    let server = relay(|_| {}).await;
+    let mut alice = client(&server, 0x6d).await;
+    let recv = key(0x6e);
+    let send = key(0x6f);
+    let intruder = key(0x70);
+    let queue = alice.create_queue(&recv, 0, 0, None).await.unwrap();
+    alice.bind_send(&send, queue.send_addr).await.unwrap();
+    let before = server.relay().sweep_memory(0).0;
+
+    expect_code(
+        alice
+            .append(&intruder, queue.send_addr, b"ciphertext")
+            .await,
+        ErrorCode::Unavailable,
+    )
+    .unwrap();
+
+    let after = server.relay().sweep_memory(0).0;
+    assert_eq!(after, before, "denied command entered the relay seen-set");
+    server.shutdown().await;
+}
+
+/// The padding-policy oracle #658 closed, named the way the issue asked: a
+/// correctly signed `APPEND` under an unrelated (never-bound) key, carrying a
+/// payload that is not one of the published padding buckets, must answer the
+/// same collapsed `ERR_UNAVAILABLE` an authorized-but-otherwise-identical
+/// refusal would — never `ERR_BAD_SIZE`, which would tell an attacker holding
+/// no relationship to this queue that their signature and framing were fine
+/// and only the padding was wrong, i.e. that the queue exists and is
+/// reachable at all.
+#[tokio::test(flavor = "multi_thread")]
+async fn unauthorized_append_with_bad_padding_gets_collapsed_refusal_not_bad_size() {
+    let server = relay(|_| {}).await;
+    let mut alice = client(&server, 0x71).await;
+    let recv = key(0x72);
+    let send = key(0x73);
+    let intruder = key(0x74);
+    let queue = alice.create_queue(&recv, 0, 0, None).await.unwrap();
+    alice.bind_send(&send, queue.send_addr).await.unwrap();
+
+    let bucket = alice.padding().sizes().first().copied().unwrap_or(1024);
+    let odd_size = usize::try_from(bucket).unwrap_or(1024).saturating_sub(1);
+
+    expect_code(
+        alice
+            .append_raw_size(&intruder, queue.send_addr, odd_size)
+            .await,
+        ErrorCode::Unavailable,
+    )
+    .unwrap();
     server.shutdown().await;
 }
 


### PR DESCRIPTION
## What

#658 bound relay-state authorization to run *before* replay-key commitment
and padding validation (`CommandVerifier::verify_authorized` in
`rs/crates/f2z-relay-proto/src/command.rs`), for a good reason: "a correctly
signed request under an unrelated key is authenticated but unauthorized, and
must not consume the bounded seen-set."

#659 found that guarantee was tested for only 1 of the 6 relay-state
commands wired through it. This PR extends coverage to all 6.

## The 6 relay-state commands

Identified from `f2z-relay/src/engine.rs`, each wiring a real
`preauthorize_recv`/`preauthorize_send` closure into `verify_with` (as
opposed to `|_| Ok(())`, which is the correct, legitimate argument at the
three `SelfAuthenticating` call sites: `CREATE_QUEUE`,
`CREATE_CONTACT_QUEUE`, `BIND_SEND`):

| Command | engine.rs call site | Authorization closure | Coverage before this PR |
|---|---|---|---|
| `SUBSCRIBE` | `subscribe` (~line 762) | `preauthorize_recv` | Covered (`denied_queue_authorization_does_not_commit_the_replay_key`) |
| `UNSUBSCRIBE` | `unsubscribe` (~line 801) | `preauthorize_recv` | **Not covered** |
| `READ` | `read` (~line 824) | `preauthorize_recv` | **Not covered** |
| `ACK` | `ack` (~line 901) | `preauthorize_recv` | **Not covered** |
| `DELETE_QUEUE` | `delete_queue` (~line 936) | `preauthorize_recv` | **Not covered** |
| `APPEND` | `append` (~line 1012) | `preauthorize_send` | **Not covered** |

## What was added

In `rs/crates/f2z-relay/tests/configured_equivalents.rs`, following the
existing `denied_queue_authorization_does_not_commit_the_replay_key` test's
exact pattern (real production `Server` + WebSocket `Client`, live
`RelayStore`, seen-set size read via `server.relay().sweep_memory(0).0`
before/after a signed-but-unauthorized command):

- `denied_unsubscribe_authorization_does_not_commit_the_replay_key`
- `denied_read_authorization_does_not_commit_the_replay_key`
- `denied_ack_authorization_does_not_commit_the_replay_key`
- `denied_delete_queue_authorization_does_not_commit_the_replay_key`
- `denied_append_authorization_does_not_commit_the_replay_key` (send-side:
  a never-bound signer gets the collapsed `ERR_UNAVAILABLE`, per §6.3, and
  must still not touch the seen-set)
- `unauthorized_append_with_bad_padding_gets_collapsed_refusal_not_bad_size`
  — the padding-policy-oracle case #658's own PR description named
  specifically: a correctly signed `APPEND` under an unrelated key, with a
  payload that is not a published padding bucket, must answer
  `ERR_UNAVAILABLE`, never `ERR_BAD_SIZE`.

No genuine ordering defect was found — `verify_authorized`'s
authorize-then-commit/validate ordering is correctly applied at all 6 call
sites today. This PR is coverage, not a fix.

## Proof each new test is a real regression test, not a tautology

For each of the 5 new `denied_*` tests, I temporarily replaced that
command's real closure with `|_| Ok(())` in `engine.rs` (the exact mutation
#658/#659 used), ran only the corresponding new test, observed it fail, then
restored the source (confirmed identical via `diff` against the original —
no lasting change to `engine.rs`, only the test file changed):

- **UNSUBSCRIBE** (line 801 neutered): `denied_unsubscribe_authorization_does_not_commit_the_replay_key` FAILED — `assertion left == right failed: denied command entered the relay seen-set / left: 2, right: 1`
- **READ** (line 824 neutered): `denied_read_authorization_does_not_commit_the_replay_key` FAILED — same assertion, `left: 2, right: 1`
- **ACK** (line 901 neutered): `denied_ack_authorization_does_not_commit_the_replay_key` FAILED — same assertion, `left: 2, right: 1`
- **DELETE_QUEUE** (line 936 neutered): `denied_delete_queue_authorization_does_not_commit_the_replay_key` FAILED — same assertion, `left: 3, right: 2` (queue create + bind_send precede it)
- **APPEND** (line 1012 neutered): `denied_append_authorization_does_not_commit_the_replay_key` FAILED — same assertion, `left: 3, right: 2`
- **APPEND padding oracle**, same mutation still in place: `unauthorized_append_with_bad_padding_gets_collapsed_refusal_not_bad_size` FAILED — `Expectation("expected ERR_UNAVAILABLE, got ERR_BAD_SIZE")`, exactly the leak #658 closed

Each mutation was reverted before moving to the next, and the full suite
was confirmed green again after every revert.

## Verification

- `scripts/check-rust-fmt.sh --root rs` — pass (15 crates)
- `cargo clippy -p f2z-relay --tests --all-targets -- -D warnings` — pass, no warnings
- `cargo test -p f2z-codec -p f2z-relay-proto -p f2z-relay-store -p f2z-relay-testkit -p f2z-relay` — all targets pass, 0 failed

Closes #659