### PR TITLE
fix(relay-testkit): retire with_simulated_channel_binding

### DIFF
--- a/rs/crates/f2z-relay-testkit/README.md
+++ b/rs/crates/f2z-relay-testkit/README.md
@@ -175,10 +175,14 @@ see it fail before they see it pass.
 - **`queue_creation_mode: token` is not implemented.** §13.1 defines it as an
   operator-issued bearer credential and gives it no protocol shape in v1;
   configuring it is refused at construction rather than faked.
-- **The channel binding is not a TLS exporter.** `ChannelBindingSource::Simulated`
-  hands both ends a constant so the §5.3 exporter code path is reachable, but it
-  binds a signature to *this configuration*, not to a TLS session. A passing test
-  there is not evidence about RFC 8446 §7.5.
+- **`channel_binding_mode: tls-exporter` is not reachable here.** A `FakeRelay`
+  always serves `ws://`, and `capabilities::validate` requires
+  `transport_security: none` to pair with `channel_binding_mode: none` (§2.3
+  obligation 2), so no channel-binding value this harness could publish makes
+  a startable relay. (An earlier `ChannelBindingSource::Simulated` tried to
+  fake the pairing with a constant instead of a real TLS exporter; #740 found
+  it could never construct a valid `FakeRelay` and removed it.) Exercise
+  `tls-exporter` against the real relay instead.
 
 ## Licence
 

--- a/rs/crates/f2z-relay-testkit/src/config.rs
+++ b/rs/crates/f2z-relay-testkit/src/config.rs
@@ -58,7 +58,19 @@ use crate::faults::PolicyFaults;
 pub const TESTKIT_POW_DIFFICULTY_BITS: u8 = 8;
 
 /// Where the channel binding of §5.3 comes from.
-#[derive(Clone, Copy, PartialEq, Eq)]
+///
+/// A `FakeRelay` always serves `ws://` (see [`Relay::new`]'s §2.3 obligation-2
+/// check), so `None` — `transport_security: none` paired with
+/// `channel_binding_mode: none` — is the only value that can ever produce a
+/// startable relay. There used to be a second variant, `Simulated([u8; 32])`,
+/// that published `channel_binding_mode: tls-exporter` from a constant instead
+/// of a real TLS exporter; #740 found it could not be paired with any
+/// `transport_security` a `FakeRelay` can honestly publish and removed it. See
+/// the "Known gaps" section of the crate README for how to exercise
+/// `tls-exporter` instead: against the real relay.
+///
+/// [`Relay::new`]: crate::engine::Relay::new
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[non_exhaustive]
 pub enum ChannelBindingSource {
     /// 32 zero bytes, published as `channel_binding_mode: none`.
@@ -68,27 +80,6 @@ pub enum ChannelBindingSource {
     /// seen-set does not hold, so the document also says
     /// `antireplay_persistence: volatile` and a client may refuse.
     None,
-    /// A fixed value both ends are told, published as
-    /// `channel_binding_mode: tls-exporter`.
-    ///
-    /// **This is a simulation and is not a TLS exporter.** There is no TLS
-    /// session; the value is a constant handed to both ends, so it binds a
-    /// signature to *this configuration*, not to a session. It exists because
-    /// the exporter path is code a client must have and would otherwise be
-    /// unreachable without terminating TLS in a test. A client that treats a
-    /// passing test here as evidence about RFC 8446 §7.5 has misread it.
-    Simulated([u8; 32]),
-}
-
-// A channel binding is what every signature on the connection is bound to
-// (§5.3). It is never transmitted, and it is not printed either.
-impl core::fmt::Debug for ChannelBindingSource {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::None => f.write_str("ChannelBindingSource::None"),
-            Self::Simulated(_) => f.write_str("ChannelBindingSource::Simulated(<redacted>)"),
-        }
-    }
 }
 
 impl ChannelBindingSource {
@@ -97,7 +88,6 @@ impl ChannelBindingSource {
     pub const fn value(self) -> ChannelBinding {
         match self {
             Self::None => ChannelBinding::zero(),
-            Self::Simulated(bytes) => ChannelBinding::new(bytes),
         }
     }
 
@@ -106,7 +96,6 @@ impl ChannelBindingSource {
     pub const fn mode(self) -> ChannelBindingMode {
         match self {
             Self::None => ChannelBindingMode::None,
-            Self::Simulated(_) => ChannelBindingMode::TlsExporter,
         }
     }
 }
@@ -263,15 +252,6 @@ impl RelayConfig {
     #[must_use]
     pub fn with_system_clock(mut self) -> Self {
         self.clock = Clock::system();
-        self
-    }
-
-    /// Simulate a TLS exporter binding. Read [`ChannelBindingSource::Simulated`]
-    /// before relying on what this proves.
-    #[must_use]
-    pub fn with_simulated_channel_binding(mut self, value: [u8; 32]) -> Self {
-        self.channel_binding = ChannelBindingSource::Simulated(value);
-        self.capabilities.channel_binding_mode = ChannelBindingMode::TlsExporter.code();
         self
     }
 

--- a/rs/crates/f2z-relay-testkit/src/engine.rs
+++ b/rs/crates/f2z-relay-testkit/src/engine.rs
@@ -54,9 +54,7 @@ use f2z_codec::pow::{PowParams, PowStamp};
 use f2z_codec::transcript::TranscriptBuilder;
 use f2z_codec::types::{Digest, QueueAddress, RelayId};
 use f2z_codec::{ErrorCode, PROTOCOL_VERSION};
-use f2z_relay_proto::capabilities::{
-    self, ChannelBindingMode, QueueCreationMode, TransportSecurity,
-};
+use f2z_relay_proto::capabilities::{self, QueueCreationMode, TransportSecurity};
 use f2z_relay_proto::command::{CommandVerifier, Empty, RelayCommand, Verified, ops};
 use f2z_relay_proto::hello::{RelayAnnouncement, hello_response};
 use f2z_relay_proto::key::{SigningKey, dummy_verify};
@@ -66,7 +64,7 @@ use f2z_relay_proto::{ProtoError, capabilities::AntiReplayPersistence};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::clock::Clock;
-use crate::config::{ChannelBindingSource, RelayConfig};
+use crate::config::RelayConfig;
 use crate::error::{Result, TestkitError};
 use crate::faults::{Effect, FaultInjector, PolicyFaults};
 use crate::outbound::{
@@ -501,10 +499,7 @@ impl Relay {
         let announcement = RelayAnnouncement {
             protocol_version: PROTOCOL_VERSION,
             relay_time_ms: self.clock.now_ms(),
-            channel_binding_mode: match self.config.channel_binding {
-                ChannelBindingSource::None => ChannelBindingMode::None,
-                ChannelBindingSource::Simulated(_) => ChannelBindingMode::TlsExporter,
-            },
+            channel_binding_mode: self.config.channel_binding.mode(),
             transport_security: TransportSecurity::None,
             capabilities_digest: digest,
         };
@@ -1213,6 +1208,8 @@ fn recover_request_id(bytes: &[u8]) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use f2z_relay_proto::capabilities::ChannelBindingMode;
+
     use super::*;
 
     #[test]
@@ -1237,6 +1234,27 @@ mod tests {
         let mut config = RelayConfig::default();
         config.capabilities.transport_security = TransportSecurity::Tls.code();
         assert!(Relay::new(config).is_err());
+    }
+
+    // #740: `tls-exporter` cannot be published by a startable `FakeRelay`
+    // under either `transport_security` value, which is why the crate no
+    // longer offers a way to configure it. `transport_security: tls` is
+    // refused above because a `FakeRelay` serves `ws://`; this covers the
+    // other side, `transport_security: none`, which `capabilities::validate`
+    // refuses under §2.3 obligation 2 regardless of what claims `tls-exporter`
+    // channel binding.
+    #[test]
+    fn tls_exporter_channel_binding_cannot_produce_a_startable_relay() {
+        for transport in [TransportSecurity::None, TransportSecurity::Tls] {
+            let mut config = RelayConfig::default();
+            config.capabilities.transport_security = transport.code();
+            config.capabilities.channel_binding_mode = ChannelBindingMode::TlsExporter.code();
+            assert!(
+                Relay::new(config).is_err(),
+                "transport_security={transport:?} paired with channel_binding_mode: \
+                 tls-exporter must not start a FakeRelay"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Observed defect

`RelayConfig::with_simulated_channel_binding` could not produce a startable
`FakeRelay` for any input, and had zero callers in the workspace.

Proved it before touching anything, with a throwaway test in
`f2z-relay-testkit/tests/`:

```rust
for value in [[0u8; 32], [7u8; 32]] {
    let config = RelayConfig::default().with_simulated_channel_binding(value);
    let result = FakeRelay::new(config);
    // result = Err(Config("the configured capability document is invalid"))
}
```

Both values fail identically. The cause is two constraints that can never
both be satisfied by a `FakeRelay`:

- `Relay::new` refuses `transport_security: tls` outright, because a
  `FakeRelay` only ever serves `ws://` (WIRE.md §2.3).
- `capabilities::validate` refuses `transport_security: none` paired with a
  non-`none` `channel_binding_mode` (§2.3 obligation 2).

`with_simulated_channel_binding` sets `channel_binding_mode: tls-exporter`
but leaves `transport_security` wherever it already was — `none` by default,
and `Relay::new` bans `tls` regardless. There is no third option: every value
of `transport_security` a `FakeRelay` can honestly publish makes the document
invalid the moment `channel_binding_mode` says `tls-exporter`.

## Resolution: retire it (option 2 from #740)

#740 laid out two honest options: make the testkit publish
`transport_security: tls` for a simulated binding (option 1), or delete the
constructor and document that `tls-exporter` is only reachable against the
real relay (option 2).

I went with option 2. Option 1 would mean a `FakeRelay` publishing
`transport_security: tls` while still serving plain `ws://` — exactly the
"document and conduct disagree" failure mode `Relay::new`'s existing check
and this crate's whole design philosophy (see `config.rs`'s module doc) exist
to prevent. Making that pairing legitimate would require the `FakeRelay` to
actually terminate TLS, which is a real feature addition (cert generation, a
`wss://` listener, wiring `listen_loopback` or a new variant of it) well
beyond a #740-scoped fix, and it cuts against the very reason
`ChannelBindingSource::Simulated` existed: to reach the `tls-exporter` code
path *without* paying for a real TLS session in tests. Retiring the dead
constructor is the honest, cheap option, and it removes untested surface area
rather than adding a bigger untested feature under time pressure.

## What changed

- `f2z-relay-testkit/src/config.rs`: removed
  `RelayConfig::with_simulated_channel_binding` and the
  `ChannelBindingSource::Simulated([u8; 32])` variant it was the only
  constructor for (with no in-crate way to build it, the variant was
  permanently dead too). `ChannelBindingSource` is now a single-variant
  `#[non_exhaustive]` enum with an expanded doc comment explaining why `None`
  is the only value that can ever start a `FakeRelay`, and pointing at the
  real relay for exercising `tls-exporter`.
- `f2z-relay-testkit/src/engine.rs`: the `HELLO` response's
  `channel_binding_mode` match collapses to `self.config.channel_binding.mode()`
  (the match had exactly one meaningful arm left); dropped the now-unused
  `ChannelBindingSource`/`ChannelBindingMode` imports at file scope. Added a
  regression test, `tls_exporter_channel_binding_cannot_produce_a_startable_relay`,
  which asserts `Relay::new` rejects `channel_binding_mode: tls-exporter`
  under both `transport_security: none` and `transport_security: tls` —
  turning the exact defect from #740 into a permanent, real test rather than
  documentation.
- `f2z-relay-testkit/README.md`: rewrote the "Known gaps" bullet about the
  channel binding to describe the real constraint (no reachable pairing) and
  point at the real relay for `tls-exporter` coverage.

## Verification

- `cargo build -p f2z-relay-testkit`
- `cargo test -p f2z-relay-testkit` — 39 unit tests + all integration suites
  (`conformance`, `faults`, `server_shutdown`, `worked_example`) pass,
  including the new regression test.
- `cargo test -p f2z-relay` — 118+ tests pass across all suites, including
  `tests/conformance.rs`'s real-relay-vs-FakeRelay comparison.
- `cargo fmt --check -p f2z-relay-testkit` — clean.
- `./scripts/check-rust-fmt.sh --root rs` — all 15 crates under `rs/` formatted.
- `cargo clippy -p f2z-relay-testkit -p f2z-relay --all-targets -- -D warnings` — clean.
- No `Cargo.toml`/`Cargo.lock` changes, so `check-rust-deny.sh` is not
  applicable here.

Scope: only the three files above changed, all within `f2z-relay-testkit`
(plus its own README). No dependency bumps, no unrelated formatting.

Closes #740