### PR TITLE
perf(relay): encode a push once and fan it out

### DIFF
--- a/rs/crates/f2z-relay/src/subscriptions.rs
+++ b/rs/crates/f2z-relay/src/subscriptions.rs
@@ -166,20 +166,69 @@ impl Subscriptions {
     }
 
     /// Push a `NOTICE` to every subscribed connection (§6.4).
+    ///
+    /// The frame is identical for every recipient — a `NOTICE` carries no
+    /// per-subscriber field (§4.3 fixes `request_id` at 0 for every push, and
+    /// [`NoticePush`] is just `kind` and `at_ms`) — so it is built **once**,
+    /// before the table lock is even taken, and the encoded [`Outbound`] is
+    /// cloned to each subscriber of each address. Building it per subscriber,
+    /// under the lock, used to pay one encode per recipient for bytes that
+    /// were always going to come out the same (zuu#749).
+    ///
+    /// If the encode itself fails, that failure is not a function of *which*
+    /// subscriber is being served — it is a function of `kind`/`at_ms` alone —
+    /// so nobody receives the push. See [`Subscriptions::deliver`]'s doc
+    /// comment for why "fail closed for everyone" is the right call and not
+    /// merely a side effect of hoisting.
     pub fn notify_all(&self, kind: u8, at_ms: u64, metrics: &Metrics) {
         let body = NoticePush { kind, at_ms };
+        let Some(outbound) = push(PushEvent::Notice, &body) else {
+            return;
+        };
         let tables = self.lock();
         for entries in tables.by_recv.values() {
             for subscriber in entries {
-                let Some(outbound) = push(PushEvent::Notice, &body) else {
-                    continue;
-                };
-                count_push(subscriber.sender.try_send(outbound), metrics);
+                count_push(subscriber.sender.try_send(outbound.clone()), metrics);
             }
         }
     }
 
-    fn deliver<F: Fn() -> Option<Outbound>>(
+    /// Encode `build()` once and fan the result out to every subscriber of
+    /// `recv_addr` (zuu#749).
+    ///
+    /// # Why one encode is safe to share
+    ///
+    /// Every caller of `deliver` closes over data that does not change across
+    /// the loop — a `recv_addr`, a `QueuedMessage`, a `QueueEventPush` body —
+    /// and none of that encodes any per-subscriber field: a push's
+    /// `request_id` is always 0 (§4.3), and none of `MsgPush`, `QueueEventPush`
+    /// carries a connection id, a sequence number or a nonce that would differ
+    /// between two subscribers of the same address. `Outbound` is `Clone`, so
+    /// building it once and cloning per subscriber produces the exact bytes
+    /// the old per-subscriber loop did — this is a pure fan-out, not a change
+    /// to what goes over the wire.
+    ///
+    /// # The encode-failure decision, made on purpose
+    ///
+    /// `build()` is a pure function of that same closed-over data — encoding
+    /// has no dependency on which subscriber is being served — so if it fails
+    /// for one subscriber it fails identically for all of them. The old
+    /// per-subscriber loop called `build()` fresh for every subscriber and
+    /// skipped just that one on `None`, which *looked* like a subscriber-scoped
+    /// failure but, for any real encode failure (the body does not fit under
+    /// `Body::MAX_LEN`; see the `encode_failure` tests), was never anything
+    /// but the same failure repeated once per subscriber.
+    ///
+    /// Given that, failing the whole address once `build()` returns `None` is
+    /// not a behaviour change hiding in a refactor — it is the behaviour the
+    /// old code already had, made explicit and paid for once instead of N
+    /// times. It also matches this module's doctrine on backpressure (top of
+    /// file): a push is only ever a hint that a `READ` is worth doing, the
+    /// message stays in the queue, and dropping the hint is safe in a way that
+    /// dropping the message would not be. Nobody is unsubscribed, nothing
+    /// partial or corrupt goes out, and no success is reported — the caller
+    /// gets silence, exactly as it does today when `build()` fails.
+    fn deliver<F: FnOnce() -> Option<Outbound>>(
         &self,
         recv_addr: &QueueAddress,
         metrics: &Metrics,
@@ -189,13 +238,13 @@ impl Subscriptions {
         let Some(entries) = tables.by_recv.get(recv_addr) else {
             return;
         };
+        let Some(outbound) = build() else {
+            return;
+        };
         for subscriber in entries {
-            let Some(outbound) = build() else {
-                continue;
-            };
             // `try_send`, never `send`: a slow reader must not be able to stall
             // the task that just committed somebody else's append.
-            count_push(subscriber.sender.try_send(outbound), metrics);
+            count_push(subscriber.sender.try_send(outbound.clone()), metrics);
         }
     }
 
@@ -419,6 +468,88 @@ mod tests {
         table.notify_message(address, &message(), &metrics);
         table.notify_all(NOTICE_SHUTDOWN, 1_000, &metrics);
         assert!(receiver.try_recv().is_ok());
+        assert_eq!(dropped(&metrics), 0);
+        assert_eq!(to_closed(&metrics), 0);
+    }
+
+    #[tokio::test]
+    async fn deliver_encodes_once_and_shares_it_across_every_subscriber() {
+        // zuu#749: an identical push must be encoded once, then fanned out —
+        // not rebuilt fresh for every subscriber on the address. This drives
+        // `deliver` directly with a counting build so the encode count is
+        // asserted, not just inferred from timing.
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let address = QueueAddress::new([12u8; 32]);
+        let mut receivers = Vec::new();
+        for connection in 0..5u64 {
+            let (sender, receiver) = tokio::sync::mpsc::channel(4);
+            table.subscribe(address, connection, sender);
+            receivers.push(receiver);
+        }
+
+        let encodes = std::sync::atomic::AtomicUsize::new(0);
+        let outbound = push(PushEvent::Notice, &NoticePush { kind: 1, at_ms: 0 }).unwrap();
+        table.deliver(&address, &metrics, || {
+            encodes.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Some(outbound.clone())
+        });
+
+        assert_eq!(
+            encodes.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "5 subscribers on one address must share a single encode"
+        );
+        for mut receiver in receivers {
+            assert!(
+                receiver.try_recv().is_ok(),
+                "every subscriber still gets the (shared) frame"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn an_oversized_message_fails_the_encode_closed_not_partial() {
+        // §6.4's `MSG` push wraps a `QueuedMessage` inside a `Push` whose body
+        // is bounded by `Body::MAX_LEN` (2^24-1, the same cap `Payload::MAX_LEN`
+        // uses). A payload sitting at that cap adds `MsgPush`'s own framing on
+        // top of it — a 32-byte `recv_addr`, an 8-byte index, an 8-byte
+        // timestamp and a 3-byte length prefix — so the encoded push can never
+        // fit. That is a real encode failure driven by real production code
+        // (`msg_push`/`push`), not a mocked `build()`.
+        let table = Subscriptions::new();
+        let metrics = Metrics::new();
+        let address = QueueAddress::new([13u8; 32]);
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(4);
+        table.subscribe(address, 1, sender);
+
+        let oversized = QueuedMessage {
+            index: 0,
+            received_at_ms: 1,
+            payload: Payload::new(vec![0u8; Payload::MAX_LEN]).unwrap(),
+        };
+        // Confirm the premise before trusting what follows: this input really
+        // does fail to encode, so the assertions below exercise the failure
+        // path and not a payload that happened to succeed.
+        assert!(
+            msg_push(address, &oversized).is_none(),
+            "test setup must actually overflow Body::MAX_LEN"
+        );
+
+        table.notify_message(address, &oversized, &metrics);
+
+        // Fails closed: no partial or garbage frame reaches the subscriber…
+        assert!(
+            receiver.try_recv().is_err(),
+            "an encode failure must not deliver a partial/corrupt frame"
+        );
+        // …the subscriber is not silently dropped from the table…
+        assert!(
+            table.has_subscriber(&address),
+            "an encode failure must not silently unsubscribe anyone"
+        );
+        // …and nothing is miscounted as ordinary backpressure or a closed
+        // receiver — both would misreport what actually happened.
         assert_eq!(dropped(&metrics), 0);
         assert_eq!(to_closed(&metrics), 0);
     }


### PR DESCRIPTION
# perf(relay): encode a push once and fan it out; test the encode-failure path

Closes #749.

## Part 1 — encode once, fan out

`Subscriptions::deliver` (used by `notify_message` and `notify_queue_event`)
and `Subscriptions::notify_all` each called their `build()` closure once per
subscriber, even though every subscriber on a given address gets byte-for-byte
the same frame.

**Verified the premise before changing anything**, per the task: is the push
genuinely subscriber-invariant, or does something per-subscriber (a sequence
number, a connection id, a nonce) leak into the encoding?

- Push frames always carry `request_id = 0` (WIRE.md §4.3: *"Push frames use
  `request_id = 0`"*) — never anything connection-specific.
- `MsgPush { recv_addr, msg }`, `QueueEventPush { recv_addr, reason }`, and
  `NoticePush { kind, at_ms }` (WIRE.md §6.4) carry only queue/event data, never
  a connection id or per-recipient field.
- `push()`/`msg_push()` in `outbound.rs` are pure functions of that data — no
  RNG, no clock read, no counter.

So the encoded bytes **are** identical per subscriber, and hoisting the build
above the loop and cloning `Outbound` (already `Clone`) per subscriber is
behaviourally equivalent to the old code, just paid for once instead of N
times.

Changed:
- `deliver`: takes the table lock, looks up the subscriber list (unchanged —
  still skips encoding for an address nobody is on), builds the frame **once**,
  then clones it into each subscriber's channel.
- `notify_all`: builds the `NOTICE` frame **once**, *before* taking the table
  lock at all (previously it re-encoded per subscriber *under* the lock), then
  fans the clone out across every address's subscriber list.

**Verified the reduction, not just asserted it.** `deliver_encodes_once_and_shares_it_across_every_subscriber`
drives `deliver` directly with a build closure that counts its own calls: 5
subscribers on one address, 1 encode. Ran this test against the *old*
per-subscriber-loop code (temporarily reverted, not part of this diff) and
confirmed it fails there with `left: 5, right: 1` — so it is a real
regression guard, not a tautology.

## Part 2 — the encode-failure path, tested

The issue flagged a real semantic question: hoisting means an encode failure
skips *everyone* on the address, where before it (looked like it) skipped
subscribers one at a time. I checked whether that is actually a behaviour
change:

`build()` is a **pure** function of the data closed over (the message, the
recv_addr, the event body) — nothing about *which subscriber's turn it is*
feeds into the encode. So if `build()` fails for the first subscriber it fails
identically for the second, third, ... Nth. The old loop's apparent
"skip-one-then-keep-going" behaviour never actually happened for a real
encode failure — every subscriber on that address would already have been
skipped, just at the cost of one repeated, doomed encode per subscriber. The
hoist makes explicit and cheap what was already true; it does not change what
goes out over the wire.

**What "correct" means here, from WIRE.md:** the relay's own doctrine (§13
padding, "the correct direction for the failure"; and the general theme
throughout — silent partial delivery is called out repeatedly as the wrong
failure mode, e.g. "silently dropping an accepted message is quiet, delayed,
and lands on someone who cannot [do anything about it]. Refusal is the
correct failure mode.") plus this module's own existing doc comment on
backpressure ("the push was only ever a hint that a READ is worth doing")
together fix the answer: on an encode failure, **fail closed** — no partial
or corrupt frame, no subscriber silently dropped from the table, no success
reported. The underlying message is untouched in the queue and a `READ` still
returns it; only the push *hint* is lost, which is exactly the existing
contract for a full outbound channel.

**Drove a real encode failure**, not a mocked `build()`: `MsgPush` wraps
`recv_addr[32] + QueuedMessage{index:u64, received_at_ms:u64, payload}` and the
whole thing is bounded by `Body::MAX_LEN` (`2^24 - 1`), the same bound
`Payload::MAX_LEN` uses for the payload alone. A `QueuedMessage` built with a
payload *at* `Payload::MAX_LEN` adds 51 bytes of `MsgPush` framing on top of
that same ceiling, so `push()`/`Body::new()` genuinely returns `None` — this
is production code (`msg_push`, `push`, `Body::new`) hitting a real overflow,
not a stand-in. The test asserts the premise (`msg_push(...).is_none()`)
before trusting anything downstream of it.

`an_oversized_message_fails_the_encode_closed_not_partial` then drives that
through `notify_message` end to end and asserts all three fail-closed
properties:
- the subscriber's channel receives nothing (`try_recv().is_err()`) — no
  partial/corrupt frame,
- `has_subscriber` is still `true` — nobody is silently unsubscribed,
- `pushes_dropped` and `pushes_to_closed` are both still 0 — the failure is
  not miscounted as ordinary backpressure or a closed receiver, which would
  misreport what happened.

**Confirmed this is a real test, not a tautology**, by temporarily breaking
the implementation two different ways and watching the test fail each time
(neither change is part of this diff):
1. Reverted `deliver` to the old per-subscriber loop → the encode-count test
   fails (`left: 5, right: 1`), as above.
2. Made the (hoisted) `deliver` fall back to a bogus non-empty `Outbound` when
   `build()` returns `None`, instead of returning early → the encode-failure
   test fails on the "must not deliver a partial/corrupt frame" assertion.

`notify_all`'s own body (`NoticePush { kind: u8, at_ms: u64 }`) is fixed-size
and can never overflow `Body::MAX_LEN`, so there is no way to drive a genuine
encode failure through it the same way — its `None` arm exists for symmetry
with `deliver` and to keep the two call sites' failure semantics visibly the
same, not because it is reachable today.

## Testing

- `scripts/check-rust-fmt.sh --root rs` — clean.
- `scripts/check-rust-clippy.sh --root rs` — clean.
- `cargo test -p f2z-relay` — 120 lib tests + integration suites, all green.
- `cargo test -p f2z-relay-store -p f2z-relay-proto -p f2z-relay-testkit -p f2z-codec` — all green.

No unrelated changes. Scope is `rs/crates/f2z-relay/src/subscriptions.rs` only.
EOF
