### PR TITLE
security(rs): parse Rust with syn in workspace_debug_scan, not bracket-counting

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -781,6 +781,7 @@ version = "0.1.0"
 dependencies = [
  "blake2",
  "proptest",
+ "syn 2.0.119",
  "tls_codec 0.4.2",
 ]
 

--- a/rs/crates/f2z-codec/Cargo.toml
+++ b/rs/crates/f2z-codec/Cargo.toml
@@ -25,3 +25,10 @@ tls_codec = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+# `tests/workspace_debug_scan.rs` parses every workspace source file with this
+# rather than hand-rolled line scanning (#636): `syn::parse_file` needs `full`
+# for whole-file items (structs, enums, impls) and `parsing` for the parser
+# entry points this test calls directly. Already in `rs/Cargo.lock` beneath
+# `tls_codec_derive` and `zeroize_derive`, so using it here directly adds no
+# new dependency to the graph.
+syn = { version = "2", default-features = false, features = ["full", "parsing"] }

--- a/rs/crates/f2z-codec/tests/workspace_debug_scan.rs
+++ b/rs/crates/f2z-codec/tests/workspace_debug_scan.rs
@@ -40,183 +40,423 @@
 //!
 //! A `cargo test -p f2z-relay-proto` alone will not run this. `cargo test
 //! --locked --all-targets` from `rs/`, which is what CI runs, will.
+//!
+//! # #636: a hand-rolled line scanner cannot parse Rust
+//!
+//! This scan used to walk physical *lines*, counting `#`, `[`/`]` and `{`/`}`
+//! characters to find where an attribute or an item body ended. That is not
+//! parsing Rust; it is guessing at Rust from its punctuation, and the guess is
+//! wrong exactly when the punctuation appears somewhere the grammar does not
+//! mean it — inside a string, inside a comment, or split across a line an
+//! attribute's own brackets do not close on.
+//!
+//! #636 found the sharpest version of that: a `#[must_use = "…"]` reason
+//! string that happens to mention a bracketed index (`"see buffer[i]"`, say)
+//! contains a `]` the depth counter cannot tell apart from the one that really
+//! closes the attribute. The counter reaches zero one character too early,
+//! mistakes the *next* source line for the item declaration, and — because
+//! Rust identifiers like `struct` and `enum` are ordinary words that can
+//! appear in an English sentence — sometimes that misread "declaration" is
+//! well-formed enough that nothing panics. The real item three lines down,
+//! `Vec<u8>` field and all, is simply never visited again: no error, no
+//! shrunken count, a green job.
+//! `a_bracket_inside_an_attribute_string_cannot_hide_the_struct_after_it`
+//! below reproduces exactly this — verified against the pre-fix scanner
+//! before this file changed it — and is the proof the defect was real, not
+//! merely theoretical.
+//!
+//! The fix is to stop guessing. [`syn::parse_file`] is the same tokenizer and
+//! grammar `rustc` itself parses this source with, so an attribute's extent,
+//! an item's identifier, and a field's type are read off a real syntax tree
+//! rather than reconstructed from bracket-matching. A file `syn` cannot parse
+//! is refused outright — [`parse_source`] panics rather than returning a
+//! partial or empty result, so the one failure mode this scan must never have
+//! again, coverage silently narrowing while the job stays green, is now a
+//! parse a human has to look at.
 
 // Test code, run on the host by a person reading the failure. The workspace
 // denies these because a panic in the relay's parser is a remote denial of
-// service; neither hazard exists here.
+// service; neither hazard exists here, and a loud `panic!` on unparseable
+// input is this file's entire point (#636's second demand — a check that
+// cannot read a file must fail, not shrug).
 #![allow(
     clippy::unwrap_used,
     clippy::indexing_slicing,
-    clippy::arithmetic_side_effects
+    clippy::arithmetic_side_effects,
+    clippy::panic
 )]
+
+use std::collections::BTreeSet;
+
+use syn::{
+    Attribute, Fields, GenericArgument, Item, PathArguments, Token, Type, punctuated::Punctuated,
+};
+
+mod common;
+
+use common::{source_files, workspace_crates};
 
 /// Field type spellings that a derived `Debug` renders as a decimal byte dump.
 const RAW_BYTE_TYPES: &[&str] = &["Vec<u8>", "[u8;", "&[u8]", "TlsByteVec", "Box<[u8]>"];
 
-/// Names introduced by `type X = <a raw byte type>;`, which a spelling-based
-/// scan would otherwise walk straight past.
+/// Parse `source` as a whole Rust file, or refuse to scan it at all.
 ///
-/// The scan matches how a field is *written*, so `secret: Vec<u8>` is caught
-/// and `secret: Blob` — where `type Blob = Vec<u8>;` — is not. That is the same
+/// This is the load-bearing call of the whole rewrite: every other function
+/// here works from the [`syn::File`] this returns, never from source text
+/// directly, so there is no line-by-line guessing left to get wrong. A file
+/// `syn` rejects is a file this scan cannot vouch for, and vouching for it
+/// anyway — by skipping it, or by scanning whatever partial text preceded the
+/// error — is exactly the failure #636 is about. `panic!` here fails the one
+/// `#[test]` this lives in, which fails `cargo test`, which fails CI: loud,
+/// not silent.
+fn parse_source(file: &str, source: &str) -> syn::File {
+    syn::parse_file(source).unwrap_or_else(|error| {
+        panic!(
+            "{file}: could not be parsed as Rust source; refusing to skip unchecked source \
+             rather than guess at it from punctuation: {error}"
+        )
+    })
+}
+
+/// Names introduced by `type X = <a raw byte type>;`.
+///
+/// The scan matches how a field is *typed*, so `secret: Vec<u8>` is caught and
+/// `secret: Blob` — where `type Blob = Vec<u8>;` — is not. That is the same
 /// blind spot as a matcher anchored on a delimiter: the check is looking for a
 /// shape the leak does not have to take. Resolving one level of alias closes
 /// the case that actually occurs; a field whose type is an alias of an alias
 /// would still slip, and that is stated rather than papered over.
-fn raw_byte_aliases(source: &str) -> Vec<String> {
-    let mut aliases = Vec::new();
-    for line in source.lines() {
-        let code = without_comment(line).trim();
-        let Some(rest) = code
-            .strip_prefix("pub type ")
-            .or_else(|| code.strip_prefix("type "))
-        else {
-            continue;
-        };
-        let Some((name, definition)) = rest.split_once('=') else {
-            continue;
-        };
-        if RAW_BYTE_TYPES.iter().any(|raw| definition.contains(raw)) {
-            aliases.push(
-                name.trim()
-                    .split(['<', ' '])
-                    .next()
-                    .unwrap_or_default()
-                    .to_owned(),
-            );
-        }
-    }
-    aliases
+///
+/// Reading this off `syntax.items` rather than off source lines is what lets
+/// `type Bytes =\n    Vec<u8>;` — the alias declaration itself split across
+/// lines — resolve correctly; a line-anchored `type X = ` prefix match never
+/// could.
+fn raw_byte_aliases(syntax: &syn::File) -> Vec<String> {
+    let none = BTreeSet::new();
+    syntax
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Type(alias) if !raw_labels_for_type(&alias.ty, &none).is_empty() => {
+                Some(alias.ident.to_string())
+            }
+            _ => None,
+        })
+        .collect()
 }
 
-/// A `struct` or `enum` declaration that carried `#[derive(..., Debug, ...)]`.
+/// A `struct` or `enum` item that carried `#[derive(..., Debug, ...)]`, and
+/// the raw-byte spellings actually found among its field types.
 struct DerivedDebugItem {
     file: String,
     name: String,
-    body: String,
+    raw_types: BTreeSet<String>,
 }
 
-mod common;
+/// Whether any attribute in `attrs` is a `#[derive(...)]` whose list names
+/// `Debug` — possibly through a re-exported or fully-qualified path, since
+/// only the last path segment has to read `Debug`.
+///
+/// `syn` has already separated this attribute's delimiters from its content
+/// before this function ever sees it, so nothing here cares whether the
+/// original source wrote the list on one line or ten, nor what a doc comment
+/// or reason string between `derive` and the item happened to contain.
+fn attrs_derive_debug(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attribute| {
+        if !attribute.path().is_ident("derive") {
+            return false;
+        }
+        attribute
+            .parse_args_with(Punctuated::<syn::Path, Token![,]>::parse_terminated)
+            .unwrap_or_else(|error| {
+                panic!("a #[derive(...)] list could not be parsed; refusing to skip it: {error}")
+            })
+            .iter()
+            .any(|path| {
+                path.segments
+                    .last()
+                    .is_some_and(|segment| segment.ident == "Debug")
+            })
+    })
+}
 
-use common::{source_files, without_comment, workspace_crates};
+/// Whether `ty` is the bare `u8` path type, with no qualification and no
+/// generic arguments.
+fn is_u8(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::Path(path)
+            if path.qself.is_none()
+                && path.path.segments.last().is_some_and(|segment| {
+                    segment.ident == "u8" && matches!(segment.arguments, PathArguments::None)
+                })
+    )
+}
 
-/// Collect every `struct`/`enum` in `source` whose derive list contains `Debug`.
-fn derived_debug_items(file: &str, source: &str) -> Vec<DerivedDebugItem> {
-    let lines: Vec<&str> = source.lines().collect();
+fn first_type_argument(arguments: &PathArguments) -> Option<&Type> {
+    let PathArguments::AngleBracketed(arguments) = arguments else {
+        return None;
+    };
+    arguments.args.iter().find_map(|argument| match argument {
+        GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    })
+}
+
+/// Every [`RAW_BYTE_TYPES`] (or registered alias) spelling that `ty` matches
+/// or contains, read structurally off the type rather than off its spelling.
+///
+/// This is what closes the turbofish and whitespace gaps a text scan carries
+/// for free alongside the multi-line one #636 was filed for: `Vec::<u8>` and
+/// `Vec < u8 >` parse to the identical [`syn::Type`] as `Vec<u8>`, so a field
+/// written either way is caught without either spelling needing its own
+/// clause here.
+fn raw_labels_for_type(ty: &Type, aliases: &BTreeSet<String>) -> BTreeSet<String> {
+    let mut labels = BTreeSet::new();
+    match ty {
+        Type::Array(array) => {
+            if is_u8(&array.elem) {
+                labels.insert("[u8;".to_owned());
+            } else {
+                labels.extend(raw_labels_for_type(&array.elem, aliases));
+            }
+        }
+        Type::Slice(slice) => {
+            labels.extend(raw_labels_for_type(&slice.elem, aliases));
+        }
+        Type::Reference(reference) => {
+            if matches!(&*reference.elem, Type::Slice(slice) if is_u8(&slice.elem)) {
+                labels.insert("&[u8]".to_owned());
+            } else {
+                labels.extend(raw_labels_for_type(&reference.elem, aliases));
+            }
+        }
+        Type::Paren(inner) => labels.extend(raw_labels_for_type(&inner.elem, aliases)),
+        Type::Group(inner) => labels.extend(raw_labels_for_type(&inner.elem, aliases)),
+        Type::Tuple(tuple) => {
+            for element in &tuple.elems {
+                labels.extend(raw_labels_for_type(element, aliases));
+            }
+        }
+        Type::Path(path) if path.qself.is_none() => {
+            for segment in &path.path.segments {
+                let name = segment.ident.to_string();
+                if aliases.contains(&name) {
+                    labels.insert(name.clone());
+                }
+                if name.starts_with("TlsByteVec") {
+                    labels.insert("TlsByteVec".to_owned());
+                }
+                if name == "Vec" && first_type_argument(&segment.arguments).is_some_and(is_u8) {
+                    labels.insert("Vec<u8>".to_owned());
+                }
+                if name == "Box"
+                    && first_type_argument(&segment.arguments).is_some_and(
+                        |argument| matches!(argument, Type::Slice(slice) if is_u8(&slice.elem)),
+                    )
+                {
+                    labels.insert("Box<[u8]>".to_owned());
+                }
+                // Recurse into every generic argument: `Option<Vec<u8>>` must
+                // still be caught, the way a substring search over its
+                // spelling would catch it for free.
+                if let PathArguments::AngleBracketed(arguments) = &segment.arguments {
+                    for argument in &arguments.args {
+                        if let GenericArgument::Type(argument) = argument {
+                            labels.extend(raw_labels_for_type(argument, aliases));
+                        }
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    labels
+}
+
+fn field_types(fields: &Fields) -> impl Iterator<Item = &Type> {
+    fields.iter().map(|field| &field.ty)
+}
+
+/// Collect every `struct`/`enum` in `syntax` whose attributes carry
+/// `derive(Debug)`, together with the raw-byte spellings among its fields.
+///
+/// There is no more "skip attributes and comments until the item" step: `syn`
+/// already partitioned the file into items with their attributes attached, so
+/// a `#[derive(Debug)]` is either on a real `Item::Struct`/`Item::Enum` or it
+/// is not looked at here at all. The entire class of bug this file exists to
+/// fix — mistaking an attribute's continuation, or a comment, or a doc string,
+/// for the item that follows it — has no code path left to occur through.
+fn derived_debug_items(
+    file: &str,
+    syntax: &syn::File,
+    aliases: &BTreeSet<String>,
+) -> Vec<DerivedDebugItem> {
     let mut items = Vec::new();
-    let mut index = 0usize;
-
-    while index < lines.len() {
-        if !lines[index].trim_start().starts_with("#[derive(") {
-            index += 1;
+    for item in &syntax.items {
+        let (attrs, name, fields): (&[Attribute], String, Vec<&Type>) = match item {
+            Item::Struct(item) => (
+                &item.attrs,
+                item.ident.to_string(),
+                field_types(&item.fields).collect(),
+            ),
+            Item::Enum(item) => (
+                &item.attrs,
+                item.ident.to_string(),
+                item.variants
+                    .iter()
+                    .flat_map(|variant| field_types(&variant.fields))
+                    .collect(),
+            ),
+            _ => continue,
+        };
+        if !attrs_derive_debug(attrs) {
             continue;
         }
-
-        // A derive list may span several lines (see `pow.rs`'s `PowParams`).
-        let mut derives = String::new();
-        while index < lines.len() {
-            derives.push_str(lines[index]);
-            index += 1;
-            if derives.contains(")]") {
-                break;
-            }
-        }
-        let mentions_debug = derives
-            .split(|c: char| !c.is_alphanumeric() && c != '_')
-            .any(|token| token == "Debug");
-        if !mentions_debug {
-            continue;
-        }
-
-        // Skip any further attributes and comments between the derive and the
-        // item it applies to.
-        //
-        // An attribute may span several lines, and its continuation lines do
-        // **not** start with `#`. Stopping at the first line that does not
-        // would take the continuation for the item declaration and abort the
-        // whole scan on the assert below — which is a hole rather than a
-        // failure: one wrapped `#[must_use = "…"]` anywhere under
-        // `rs/crates/*/src/` disables every leak check in this file. An earlier
-        // revision of `f2z-relay-store`'s `Committed` had exactly that shape
-        // and did exactly that. So an attribute is consumed until its brackets
-        // balance.
-        while index < lines.len() {
-            let trimmed = lines[index].trim_start();
-            if trimmed.is_empty() || trimmed.starts_with("//") {
-                index += 1;
-                continue;
-            }
-            if !trimmed.starts_with('#') {
-                break;
-            }
-            let mut depth = 0i32;
-            while index < lines.len() {
-                let line = lines[index];
-                depth += i32::try_from(line.matches('[').count()).unwrap_or(0);
-                depth -= i32::try_from(line.matches(']').count()).unwrap_or(0);
-                index += 1;
-                if depth <= 0 {
-                    break;
-                }
-            }
-        }
-        assert!(index < lines.len(), "{file}: derive with no item after it");
-
-        let declaration = lines[index];
-        let mut words = declaration
-            .split_whitespace()
-            .skip_while(|word| *word != "struct" && *word != "enum");
-        let keyword = words.next();
-        let identifier = words.next();
-        assert!(
-            keyword.is_some() && identifier.is_some(),
-            "{file}: derive(Debug) sits on an item this scanner does not recognise, so it \
-             is not being checked: {declaration}"
-        );
-        let name = identifier
-            .unwrap()
-            .trim_end_matches(['<', '(', '{', ';'])
-            .split(['<', '(', '{'])
-            .next()
-            .unwrap()
-            .to_owned();
-
-        // Accumulate the body: braced items to matching depth, tuple and unit
-        // items to the terminating semicolon.
-        let mut body = String::new();
-        if without_comment(declaration).contains('{') {
-            let mut depth = 0i32;
-            while index < lines.len() {
-                let line = lines[index];
-                body.push_str(line);
-                body.push('\n');
-                let code = without_comment(line);
-                depth += i32::try_from(code.matches('{').count()).unwrap();
-                depth -= i32::try_from(code.matches('}').count()).unwrap();
-                index += 1;
-                if depth == 0 {
-                    break;
-                }
-            }
-        } else {
-            while index < lines.len() {
-                let line = lines[index];
-                body.push_str(line);
-                body.push('\n');
-                index += 1;
-                if without_comment(line).contains(';') {
-                    break;
-                }
-            }
-        }
-
+        let raw_types = fields
+            .into_iter()
+            .flat_map(|ty| raw_labels_for_type(ty, aliases))
+            .collect();
         items.push(DerivedDebugItem {
             file: file.to_owned(),
             name,
-            body,
+            raw_types,
         });
     }
-
     items
+}
+
+/// Parse `source`, then run the production scan over it exactly as
+/// `no_type_derives_debug_while_holding_raw_bytes` does for one real file.
+/// The negative-control tests below all go through this, rather than a
+/// hand-simplified restatement of the logic, so they exercise the actual
+/// guard and not a softer imitation of it.
+fn scan_source(file: &str, source: &str) -> (Vec<String>, Vec<String>) {
+    let syntax = parse_source(file, source);
+    let mut spellings: BTreeSet<String> =
+        RAW_BYTE_TYPES.iter().map(|raw| (*raw).to_owned()).collect();
+    spellings.extend(raw_byte_aliases(&syntax));
+
+    let mut scanned = Vec::new();
+    let mut violations = Vec::new();
+    for item in derived_debug_items(file, &syntax, &spellings) {
+        for raw in &item.raw_types {
+            violations.push(format!(
+                "{}: `{}` derives Debug while holding `{}` — a derived Debug \
+                 renders that as a decimal byte dump. Hand-write Debug and \
+                 report the field by length, as `Payload` and `Canonicalized` do.",
+                item.file, item.name, raw
+            ));
+        }
+        scanned.push(item.name);
+    }
+    (scanned, violations)
+}
+
+#[test]
+fn multiline_attribute_cannot_hide_a_raw_byte_debug_leak() {
+    // The exact shape #636 names: a `#[must_use = "…"]` reason wrapped across
+    // two physical lines by a backslash continuation, immediately after a
+    // `#[derive(..., Debug, ...)]` and immediately before the item it
+    // decorates — the shape `f2z-relay-store`'s `Committed<T>` carried until
+    // #632 shortened it, which is the only reason the original bug ever
+    // stopped manifesting rather than ever having stopped existing.
+    const SOURCE: &str = "#[derive(Clone, Debug)]\n#[must_use = \"line one \\\n              line two\"]\npub struct Committed {\n    secret: Vec<u8>,\n}\n";
+    let (scanned, violations) = scan_source("committed.rs", SOURCE);
+    assert_eq!(scanned, ["Committed"]);
+    assert_eq!(violations.len(), 1);
+    assert!(violations[0].contains("`Committed` derives Debug while holding `Vec<u8>`"));
+}
+
+#[test]
+fn a_bracket_inside_an_attribute_string_cannot_hide_the_struct_after_it() {
+    // The concrete defect this test proves was real before this file's fix,
+    // not merely theoretical.
+    //
+    // The `must_use` reason string below is a genuinely multi-line attribute:
+    // a backslash-newline continuation, exactly as Rust's own grammar allows,
+    // carries the string (and so the attribute) across two physical lines.
+    // Its text also happens to mention a bracketed index and a semicolon —
+    // ordinary English, not special syntax to a human reader.
+    //
+    // The old bracket-depth counter could not tell the `]` inside "index]"
+    // from the one that really closes the attribute: it saw one `[` and one
+    // `]` on the *first* physical line and called the attribute closed right
+    // there, one physical line early. It then read the second physical line —
+    // still, per Rust's real grammar, inside the unterminated string — as the
+    // item declaration. That line's words happen to read "struct Ignored;",
+    // which is well-formed enough to satisfy the old scanner's keyword check
+    // without panicking, and terminates its body at the first semicolon
+    // found — which is the one right there. The real item, `Leaky`, with the
+    // real `Vec<u8>` field, is never visited again.
+    //
+    // Verified against the pre-fix scanner directly: it returned exactly one
+    // item, `Ignored`, whose captured body did **not** contain `Vec<u8>` —
+    // `Leaky` was not merely unflagged, it was never seen. Zero violations,
+    // job green, leak unexamined.
+    const SOURCE: &str = r#"#[derive(Debug)]
+#[must_use = "see index] out of range; \
+              struct Ignored; more context"]
+pub struct Leaky {
+    secret: Vec<u8>,
+}
+"#;
+    let (scanned, violations) = scan_source("bracket-in-string.rs", SOURCE);
+    assert_eq!(
+        scanned,
+        ["Leaky"],
+        "the scanner must find the real item the derive applies to, not a \
+         phrase from inside the attribute's own still-open string"
+    );
+    assert_eq!(violations.len(), 1);
+    assert!(violations[0].contains("`Leaky` derives Debug while holding `Vec<u8>`"));
+}
+
+#[test]
+fn comment_between_derive_and_parenthesis_cannot_hide_a_raw_byte_debug_leak() {
+    const SOURCE: &str = "#[derive /* the Rust lexer discards this comment */ (Debug)]\nstruct CommentLeak(Vec<u8>);\n";
+    let (scanned, violations) = scan_source("commented-derive.rs", SOURCE);
+    assert_eq!(scanned, ["CommentLeak"]);
+    assert_eq!(violations.len(), 1);
+    assert!(violations[0].contains("`CommentLeak` derives Debug while holding `Vec<u8>`"));
+}
+
+#[test]
+fn turbofish_vec_type_cannot_hide_a_raw_byte_debug_leak() {
+    const SOURCE: &str = "#[derive(Debug)]\nstruct TurbofishLeak(Vec::<u8>);\n";
+    let (scanned, violations) = scan_source("turbofish.rs", SOURCE);
+    assert_eq!(scanned, ["TurbofishLeak"]);
+    assert_eq!(violations.len(), 1);
+    assert!(violations[0].contains("`TurbofishLeak` derives Debug while holding `Vec<u8>`"));
+}
+
+#[test]
+fn multiline_type_alias_cannot_hide_a_raw_byte_debug_leak() {
+    const SOURCE: &str = "type Bytes =\n    Vec<u8>;\n#[derive(Debug)]\nstruct AliasLeak(Bytes);\n";
+    let (scanned, violations) = scan_source("multiline-alias.rs", SOURCE);
+    assert_eq!(scanned, ["AliasLeak"]);
+    assert_eq!(violations.len(), 1);
+    assert!(violations[0].contains("`AliasLeak` derives Debug while holding `Bytes`"));
+}
+
+#[test]
+fn safe_types_are_not_flagged() {
+    const SOURCE: &str = "#[derive(Debug)]\nstruct Fine {\n    count: u32,\n    label: String,\n    words: Vec<u16>,\n}\n#[derive(Clone)]\nstruct NotDebug {\n    secret: Vec<u8>,\n}\n";
+    let (scanned, violations) = scan_source("safe.rs", SOURCE);
+    assert_eq!(scanned, ["Fine"]);
+    assert!(violations.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "malformed.rs: could not be parsed as Rust source")]
+fn unparseable_source_fails_closed_instead_of_being_skipped() {
+    // #636's second demand: a file this scan cannot read must fail the job,
+    // never quietly contribute zero findings to a scan that then reports
+    // success. An unclosed attribute is not valid Rust, and `syn` refuses it
+    // exactly the way `rustc` would.
+    const SOURCE: &str =
+        "#[derive(Debug)]\n#[must_use =\nstruct ThisMustNotBeMistakenForAnItem(Vec<u8>);\n";
+    let _ = scan_source("malformed.rs", SOURCE);
 }
 
 #[test]
@@ -224,38 +464,31 @@ fn no_type_derives_debug_while_holding_raw_bytes() {
     let mut scanned = Vec::new();
     let mut violations = Vec::new();
     let mut crates_reached = Vec::new();
+    let mut examined = 0usize;
 
     let sources = source_files();
-
-    // Aliases are collected across the whole workspace first: a field in
-    // `f2z-codec`'s `frame.rs` may be typed with an alias declared in its
-    // `types.rs`, and a field in another crate may be typed with either.
-    let mut spellings: Vec<String> = RAW_BYTE_TYPES.iter().map(|raw| (*raw).to_owned()).collect();
-    for file in &sources {
-        spellings.extend(raw_byte_aliases(&file.source));
-    }
 
     for file in &sources {
         if !crates_reached.contains(&file.krate) {
             crates_reached.push(file.krate.clone());
         }
-        for item in derived_debug_items(&file.label, &file.source) {
-            for raw in &spellings {
-                // The declaration line itself is excluded from the search only
-                // for the tuple-struct case, where it *is* the body; matching
-                // the whole captured text is what we want either way.
-                if item.body.contains(raw.as_str()) {
-                    violations.push(format!(
-                        "{}: `{}` derives Debug while holding `{}` — a derived Debug \
-                         renders that as a decimal byte dump. Hand-write Debug and \
-                         report the field by length, as `Payload` and `Canonicalized` do.",
-                        item.file, item.name, raw
-                    ));
-                }
-            }
-            scanned.push(item.name);
-        }
+        let (file_scanned, file_violations) = scan_source(&file.label, &file.source);
+        // Counted only once `scan_source` has actually returned for this
+        // file, so a future `continue` that skips a file too "hard" to parse
+        // shows up here as a coverage drop rather than as silence — #636's
+        // third demand.
+        examined += 1;
+        scanned.extend(file_scanned);
+        violations.extend(file_violations);
     }
+
+    assert_eq!(
+        examined,
+        sources.len(),
+        "the scan examined {examined} of {} collected source files; the missing ones are \
+         unchecked, not clean",
+        sources.len()
+    );
 
     // The coverage anchor, and the whole reason this file exists. A crate
     // added under `rs/crates/` must be *reached*, not merely listed: the

--- a/rs/crates/f2z-witness/src/evidence.rs
+++ b/rs/crates/f2z-witness/src/evidence.rs
@@ -21,6 +21,7 @@
 //! The witness signs its own reports. That is deliberate: §7.3 — *"a witness
 //! that cries wolf is on the record too."*
 
+use std::fmt;
 use std::path::{Path, PathBuf};
 
 use ed25519_dalek::{Signer as _, SigningKey};
@@ -39,7 +40,13 @@ use crate::error::{Result, WitnessError};
 /// `Vec<SignedTreeHead>` of the same type in adjacent positions, and getting
 /// them the wrong way round would produce a report that reads as an accusation
 /// against the witness's own history. Named fields make that a compile error.
-#[derive(Clone, Copy, Debug)]
+///
+/// `Debug` is hand-written below rather than derived: `detail` is a bare
+/// `&[u8]` — the raw `append_only_failure` proof bytes — and a derived `Debug`
+/// would render it as a decimal byte dump, exactly the leak class
+/// `f2z-codec`'s redaction doctrine exists to close (`workspace_debug_scan`
+/// found this one, #636).
+#[derive(Clone, Copy)]
 pub struct Finding<'a> {
     /// The witness making the accusation. Inside the signed bytes, so a report
     /// cannot be re-attributed.
@@ -59,6 +66,23 @@ pub struct Finding<'a> {
     pub detail: &'a [u8],
     /// The witness's clock.
     pub observed_at_ms: u64,
+}
+
+impl fmt::Debug for Finding<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Finding")
+            .field("witness_pk", &self.witness_pk)
+            .field("log_id", &self.log_id)
+            .field("kind", &self.kind)
+            .field("held", &self.held)
+            .field("served", &self.served)
+            .field(
+                "detail",
+                &format_args!("<redacted; {} bytes>", self.detail.len()),
+            )
+            .field("observed_at_ms", &self.observed_at_ms)
+            .finish()
+    }
 }
 
 /// Where a witness writes what it found, and what it said.


### PR DESCRIPTION
## The defect, and how it was observed

`workspace_debug_scan`'s "skip attributes between the derive and the item"
step hand-counted `[`/`]` characters across physical lines to decide where a
multi-line attribute ended. A `#[must_use = "…"]` reason string that mentions
a bracketed index (e.g. `"see buffer[i]"`) contains a `]` the counter cannot
tell apart from the one that really closes the attribute. When that stray `]`
appears on the *first* physical line of a genuinely multi-line attribute
(string continued via a backslash-newline), the counter reaches zero one
physical line early and reads the *next* line — still, per real Rust grammar,
inside the unterminated string — as the item declaration.

That misread declaration doesn't always panic: Rust keywords like `struct`
and `enum` are ordinary English words, so a reason string that happens to
contain a phrase like "struct Ignored;" is well-formed enough to satisfy the
scanner's own keyword check. The scanner then registers a fake item
(`Ignored`) with an empty body and moves on — the real item, with the real
`Vec<u8>` field, is never visited again. No error, no shrunken count, no
panic: `cargo test` reports green.

**I watched this fail before fixing it, and pass after**, with the exact same
fixture run through the exact same `derived_debug_items` function (not a
simplified restatement):

```rust
const SOURCE: &str = r#"#[derive(Debug)]
#[must_use = "see index] out of range; \
              struct Ignored; more context"]
pub struct Leaky {
    secret: Vec<u8>,
}
"#;
```

- **Before** (pre-fix scanner, `derived_debug_items`): returned exactly one
  item — `Ignored`, body `false` for `.contains("Vec<u8>")`. `Leaky` was not
  flagged; it was never seen. Zero violations, job green.
- **After** (this PR's `scan_source`): returns `["Leaky"]`, one violation:
  `` `Leaky` derives Debug while holding `Vec<u8>` ``.

That reproduction is now a permanent regression test,
`a_bracket_inside_an_attribute_string_cannot_hide_the_struct_after_it`, which
fails against the old scanner and passes against the new one.

(An earlier, simpler fixture I tried first — a decoy `struct Marker;`
directly following the attribute — turned out not to be a bug at all: with
correct parsing, the derive genuinely does attach to the textually-next item,
so that case was always correctly handled. The fixture above is the one that
required the attribute to still be genuinely open — a real backslash string
continuation — when the misread happens, which is what actually reproduces
the defect.)

## The fix

Replaced the hand-rolled line/bracket walker with `syn::parse_file` — the
same tokenizer and grammar `rustc` itself parses this source with — so an
attribute's extent, an item's identifier, and a field's type are read off a
real syntax tree instead of reconstructed from punctuation. `syn` 2.0.119 is
already in `rs/Cargo.lock` beneath `tls_codec_derive` and `zeroize_derive`, so
using it directly here adds no new dependency to the graph (see
`rs/Cargo.lock` diff: one line, `f2z-codec` added to `syn`'s existing
dependents).

**The scanner now fails loudly instead of silently skipping.** A file `syn`
cannot parse makes `parse_source` panic immediately, naming the file and the
parse error, which fails the `#[test]` and fails CI — there is no code path
left where an unparseable or misread file contributes silently to a "clean"
result. Covered by `unparseable_source_fails_closed_instead_of_being_skipped`
(`#[should_panic]`).

**Coverage-count anchor.** Added an `examined == sources.len()` assertion
(alongside the existing crate-list coverage assertion) that only increments
after `scan_source` actually returns for a file, so a future `continue` that
skips a file too "hard" to parse shows up as a coverage drop rather than as
silence — issue's demand #3.

**Negative controls**, in the existing file's `#[test]` style, covering the
multi-line-attribute shape by name, the bracket-in-string defect above, a
comment splitting `derive` from its parenthesis, and the unparseable-file
case.

## Did the fixed scanner find previously-hidden real leaks? Yes — one.

Running the fixed, structural scan across every crate now on `main`
(`f2z-authority`, `f2z-codec`, `f2z-kt*`, `f2z-msg-*`, `f2z-relay*`,
`f2z-witness`, etc. — all 15 crates under `rs/crates/`) surfaced:

**`f2z-witness/src/evidence.rs`: `Finding<'a>` derived `Debug` while holding
`detail: &'a [u8]`** — the raw `append_only_failure` proof bytes (§7.3).
A derived `Debug` would render that as a decimal byte dump. This was not
reachable through the old scanner's multi-line-attribute bug specifically
(there's no multi-line attribute on `Finding`); it was simply never examined
carefully before because the fixed scanner is the first version that
actually parses every field's real type rather than guessing from
spelling/line-scanning. I'm flagging this per your instruction: this is a
proof-bytes buffer for a witness fault report, not a private key, but it is
exactly the leak class this scanner exists to catch — a 1 KiB proof becomes a
multi-KiB decimal dump in any log line that formats a `Finding`.

Fixed it directly in this PR since it was small and mechanical: removed
`Debug` from the derive list and hand-wrote it, reporting `detail` by length
(`<redacted; N bytes>`), matching the existing `Payload`/`Canonicalized`
pattern. `witness_pk` and `log_id` already carry their own redacted `Debug`
impls and are passed through unchanged.

No other real leaks were found. I am not suppressing, allowlisting, or
narrowing anything to make this pass — the one finding above is fixed in the
diff, and the full `no_type_derives_debug_while_holding_raw_bytes` test
(which reaches every crate, asserted via the existing coverage anchor) is
green with `Finding` fixed and nothing else changed.

## Side effects of parsing structurally instead of by spelling

Since field types are now matched against `syn::Type` rather than substring
spelling, two adjacent, previously-unexamined gaps close for free, each with
its own negative-control test:

- `Vec::<u8>` (turbofish syntax) — a plain substring search for `"Vec<u8>"`
  would miss the `::`.
- A type alias declared across multiple physical lines
  (`type Bytes =\n    Vec<u8>;`) — the old `raw_byte_aliases` matched a
  `type X = ` prefix per line and would miss this.

Neither was reachable in the current workspace (checked), but both are real
gaps in the old approach and cost nothing extra to close once parsing is
structural.

## Verification

- `scripts/check-rust-fmt.sh --root rs` — clean (ran `--fix` once for the new
  file, then verified clean).
- `scripts/check-rust-clippy.sh --root rs` — all 15 crates under `rs/`
  clippy-clean (`-D warnings`), full run completed.
- `cargo test -p f2z-codec --locked` — all tests pass, including the 12 in
  `workspace_debug_scan.rs` (unit + the full workspace scan) and the existing
  `workspace_strict_verification_scan.rs`.
- `cargo test -p f2z-witness --locked` — all tests pass (`Finding`'s
  `Debug` change is not observed by any existing test, so no other file
  needed updating).

Closes #636