### PR TITLE
spec(e2ee): bind handle-candidate eligibility to shipping parity

### DIFF
--- a/docs/e2ee/ARCHITECTURE.md
+++ b/docs/e2ee/ARCHITECTURE.md
@@ -1376,6 +1376,15 @@ deliberate.
     end state (a database-level `UniqueConstraint(Lower("username"))`) are in
     [`WIRE.md` §14.3](./WIRE.md#143-the-decision-and-the-cost-accepted). The
     backend work is tracked in the deployment repository.
+  - **Candidate derivation and authoritative binding are two different claims,
+    and only the first ships (2026-08-31, #820).** "What handle would this
+    username become, and is it well-formed" is a pure, already-implemented,
+    already-safe function of the string
+    ([`WIRE.md` §14.1](./WIRE.md#141-proposed-rule),
+    `check_handle_eligibility`). "This account authoritatively owns that handle"
+    is what the census, collision resolution and database invariant above are
+    blocking, and this document does not treat the first as evidence for the
+    second.
 - **P. KT epoch cadence and maximum merge delay.** Opened 2026-08-23 by
   [`KT.md` §5](./KT.md#5-epochs-and-the-merge-promise). The values there — a
   600-second epoch published whether or not there is work, and a 3,600-second

--- a/docs/e2ee/CLIENT-CONTRACT.md
+++ b/docs/e2ee/CLIENT-CONTRACT.md
@@ -375,12 +375,12 @@ interface EnrollmentStatus {
 
 interface HandleEligibility {
   eligible: boolean;
-  candidate: string | null;        // lowercase(username), if it matches
+  candidate: string | null;        // ascii_lower(username), if it matches (§11.3, WIRE.md §14.1)
   reason:
     | null
-    | "punctuation"                // contains . @ + or - — the dominant cause (§11.3)
-    | "non-ascii"                  // contains a non-ASCII character
-    | "too-long"                   // > 30 chars after lowercasing
+    | "punctuation"                // contains . @ + or - — the dominant cause (§11.3); also the empty string
+    | "non-ascii"                  // raw username contains a non-ASCII byte, checked before folding
+    | "too-long"                   // > 30 chars after ascii_lower
     | "not-signed-in";
 }
 ```
@@ -389,7 +389,10 @@ interface HandleEligibility {
 prevalence and the UI should say the true specific thing: punctuation accounts
 for almost the whole of the ineligible population, non-ASCII and over-length for
 very little (§11.3). A single "invalid handle" string would be accurate and
-useless.
+useless. The empty string is `"punctuation"` — one fixed choice among these four
+values, since none of them means "empty" and nothing about that answer follows
+from the pattern alone; every implementation of this predicate, including the
+mock, MUST agree on it (`WIRE.md` §14.1).
 
 `f2zmsg_unenroll` takes a typed confirmation string, in the shape
 `discard_unrecoverable_send` already uses (`"I CHECKED WALLET HISTORY"`), because
@@ -1996,16 +1999,38 @@ against that. Three build rules follow.
   address, not an authentication, and first-contact copy should say so rather
   than implying the handle did the work.
 
-An account is eligible iff `lowercase(username)` matches the pattern. The
-argument originally given for folding case — that platform uniqueness is already
-enforced case-insensitively, so folding *cannot* collide two distinct existing
-accounts — **is false, and was retracted on the record**
+An account is eligible iff `ascii_lower(username)` matches the pattern —
+**`ascii_lower`, never a general "lowercase," and the distinction is load-
+bearing.** Reject the raw username if it is not ASCII, checked before any
+folding; only then fold ASCII `A`–`Z` to `a`–`z` and nothing else
+([`WIRE.md` §14.1](./WIRE.md#141-proposed-rule)). A locale- or Unicode-aware
+`lowercase()` folds some non-ASCII characters *to* ASCII — the Kelvin sign,
+U+212A, folds to `k` — which would let a non-ASCII username slip past this
+charset entirely, defeating the reason the charset exists. Older sentences in
+this document set that say `lowercase(username)` mean `ascii_lower(username)`
+in this exact sense.
+
+The argument originally given for folding case — that platform uniqueness is
+already enforced case-insensitively, so folding *cannot* collide two distinct
+existing accounts — **is false, and was retracted on the record**
 ([`WIRE.md` §14.3](./WIRE.md#143-the-decision-and-the-cost-accepted)).
 Case-insensitive uniqueness is an application convention living in two
 serializers, not a property of the database, and folding case does collide real
 accounts today. The eligibility *rule* is unchanged and uppercase still
 disqualifies nobody; what does not hold is that the mapping is injective, and
 the client consequences of that are spelled out below.
+
+**What this predicate answers, and what it does not.** `ascii_lower(username)
+matches the pattern` is candidate derivation: a pure function of the string,
+implemented and safe to ship as
+`tauri-plugin-f2zmsg`'s `handle.rs::eligibility`, exposed as
+`check_handle_eligibility` below. It asserts nothing about who owns a handle in
+the directory — that is authoritative publication, and it remains blocked on
+backend work this contract does not do (the corrected census below, the
+collision groups §14.3 of `WIRE.md` found in production, and a database-level
+uniqueness invariant that does not exist yet). A client MUST NOT treat
+`check_handle_eligibility` returning `eligible: true` as a reservation or a
+guarantee that enrollment will succeed — only as "this string is well-formed."
 
 free2z usernames are considerably broader — Django's `^[\w.@+-]+$` up to 150
 characters — so **existing accounts containing `.`, `@`, `+`, `-`, any non-ASCII
@@ -2030,14 +2055,21 @@ one is still active**: this is not a set of dead rows, it is roughly a tenth of
 real, current users. Design the ineligible state as a state a tenth of users
 will see, because it is one.
 
-Two things the frontend must not infer from that number:
+Three things the frontend must not infer from that number:
 
+- **It is not a live guarantee about today's account population.** This is a
+  historical figure from one query against production on 2026-08-23, and this
+  repository cannot re-run it: registrations continue, and `WIRE.md` §14.3's
+  collision groups — found by the same query — are expected to be resolved
+  before the mapping ships, which moves the eligible share without updating
+  this table. Treat it as the evidence that motivated the design below, not as
+  a number to cite as current.
 - **It is not a temporary gap awaiting a migration.** Whether that ~10% is
   excluded from messaging discovery in v1 or served by a separate opt-in
   messaging handle is an **undecided product question**
   ([§13-O](./ARCHITECTURE.md#13-open-questions), §13-K). Do not write copy that
   promises either outcome.
-- **`lowercase(username)` is not yet a unique key.** Case-insensitive username
+- **`ascii_lower(username)` is not yet a unique key.** Case-insensitive username
   uniqueness lives in two serializers and **not in the database**, and
   production holds case-variant duplicate accounts today, in more than one
   group ([`WIRE.md` §14.3](./WIRE.md#143-the-decision-and-the-cost-accepted)).

--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -2447,6 +2447,87 @@ document, and are a rendering and verification obligation on the client
 ([`THREAT-MODEL.md` §4.10](./THREAT-MODEL.md#410-the-platform-username-space-contains-homographs-messaging-handles-do-not),
 [`CLIENT-CONTRACT.md` §11.3](./CLIENT-CONTRACT.md#113-the-handle-charset-and-accounts-that-cannot-have-a-handle)).
 
+**Two different operations share the word "no normalization," and conflating
+them is the exact defect this correction closes (#820).** This section states
+one of each kind and they must not be read as the same rule applied twice.
+
+- **Comparison-time matching (this section, and every directory lookup or
+  `DirectoryEntry` comparison downstream of it) never folds anything.** Two
+  handles, or a handle and a lookup key, are equal iff they are byte-identical.
+  There is no case to fold here because a published handle has already been
+  through candidate derivation (next) and is already lowercase; running any
+  fold at comparison time would let two byte-distinct inputs compare equal,
+  which is the one thing this rule exists to prevent.
+- **Candidate derivation (§14.3) runs once, ahead of comparison, turning a
+  platform username into the messaging handle it would become.** It is not
+  "no normalization" at all — it is exactly one normalization step, ASCII case
+  folding, applied in a fixed order relative to the ASCII check, and that order
+  is load-bearing:
+
+  1. **Reject the raw username if it is not ASCII**, checked on the string
+     **as typed, before any folding.** This is not a stylistic ordering choice.
+     Some non-ASCII characters fold *to* ASCII under general Unicode
+     case-folding — the Kelvin sign, U+212A, folds to `k` — so a fold-first
+     implementation could turn a non-ASCII username into a well-formed ASCII
+     handle, exactly the homograph surface this whole section exists to keep
+     out. Checking ASCII-ness first, on the unfolded string, forecloses that
+     regardless of which case-folding function a later implementation reaches
+     for.
+  2. **Fold only ASCII `A`–`Z` to `a`–`z`.** Nothing else is normalized: no
+     Unicode case folding, no NFKC, no confusable mapping. This is why every
+     restatement of the rule in this document set says `ascii_lower`, not
+     `lowercase` — "lowercase" is Unicode-aware by default in most runtimes
+     (JavaScript's `String.prototype.toLowerCase`, Python's `str.lower`), and
+     Unicode-aware case folding is precisely the normalization step 1 already
+     ran to avoid needing. Wherever an older sentence in this document set says
+     `lowercase(username)`, it means `ascii_lower(username)` in this exact
+     sense, never a locale- or Unicode-aware fold.
+  3. **Check the result against `/^[a-z0-9_]{1,30}$/`.**
+
+  This is what ships:
+  [`wallet/plugins/tauri-plugin-f2zmsg/src/handle.rs`](../../wallet/plugins/tauri-plugin-f2zmsg/src/handle.rs)'s
+  `eligibility()` runs these three steps in this order, gates step 2 behind
+  `username.is_ascii()`, and its `#[cfg(test)]` module fixes the Cyrillic-а case
+  as a rejected `non-ascii`, not a folded ASCII string.
+
+**What the regex alone does not say: the empty string.** `{1,30}` requires at
+least one character, but a charset-membership check implemented as "every byte
+of the candidate is in `[a-z0-9_]`" is vacuously true on zero bytes — an
+implementation that checks charset membership and a length *ceiling* without
+also, separately, checking a length *floor* accepts the empty string as a
+"handle" of zero length. The reference implementation closes this with an
+explicit early case rather than by relying on the regex to be applied
+correctly: an empty username is `ineligible`, reason `punctuation` — one fixed,
+if slightly arbitrary, choice among the four `IneligibilityReason` values,
+picked because none of the four means "empty" and the type does not have a
+fifth. **Every restatement of this rule MUST return exactly that pair —
+`eligible: false`, `reason: punctuation` — for the empty string**, because
+nothing about that answer follows from the regex by itself; it has to be
+stated once, here, or two conforming restatements will disagree on it. They
+currently do: [`wallet/zuuli/src/lib/messaging/mock.ts`](../../wallet/zuuli/src/lib/messaging/mock.ts)'s
+`evaluateHandle` treats an empty string the same as no signed-in account
+(`reason: "not-signed-in"`), which this section now states is the wrong
+answer. [#838](https://github.com/free2z/zuu/issues/838) tracks the mock fix;
+this document does not overstate the mock as already conforming.
+
+**A restatement is not proof of agreement, and this document requires one.**
+Three independent restatements of the same three-step rule already exist —
+`handle.rs` (Rust, the shipped backend), `evaluateHandle` (the TypeScript mock),
+and this prose — and prose cannot catch the other two drifting from each other,
+which is exactly how the empty-string disagreement above went unnoticed until
+now. A conforming implementation of this section **MUST** maintain a
+mutation-sensitive test that checks the Rust and TypeScript implementations
+against one shared table of `(input → expected HandleEligibility)` fixtures —
+at minimum: `null`, the empty string, an ASCII-uppercase username, each of
+`.`/`@`/`+`/`-`, a non-ASCII character, the Kelvin sign U+212A specifically
+(because it is the case where fold-then-check and check-then-fold disagree),
+and lengths 30 and 31 — so that an edit to either implementation which drifts
+from the other, or from this table, fails a test rather than shipping unnoticed.
+**This does not exist yet.** [#838](https://github.com/free2z/zuu/issues/838)
+tracks adding it; until it lands, the parity this section specifies is
+maintained by hand, and the empty-string case above is the demonstrated cost of
+that.
+
 ### 14.2 Checked against free2z's real username rules — measured
 
 **This was checked before being written down**, and the answer is that real
@@ -2512,7 +2593,20 @@ Two things follow, and the second is the one that matters most:
 #### Eligibility, measured on production 2026-08-23
 
 Eligibility is evaluated as `lowercase(username) matches /^[a-z0-9_]{1,30}$/`
-(§14.3).
+(§14.3) — read `lowercase` as `ascii_lower` per §14.1.
+
+**These are historical figures from one query, not a live property, and this
+document does not claim they still hold.** Every share below is evidence
+gathered against production on 2026-08-23, under a predicate this repository
+cannot re-run: it required a query against a live database this repository
+does not have access to, at a point in time that has since passed. New
+accounts have registered since, and §14.3's collision groups — found by the
+same query — are expected to be *resolved* by the time the mapping ships,
+which changes the count of eligible accounts without changing this table. Read
+these numbers as what motivated the v1 design decision below, not as a
+guarantee about today's account population; whoever plans the collision-cleanup
+or migration work must re-query production rather than cite this table as
+current.
 
 | Of all existing accounts | Share |
 |---|---:|
@@ -2550,6 +2644,14 @@ for a messaging handle iff:
 ```
 lowercase(username) matches /^[a-z0-9_]{1,30}$/
 ```
+
+**Read `lowercase` here as `ascii_lower`, in the precise sense §14.1 now
+states**: reject a non-ASCII username before folding anything, then fold ASCII
+`A`–`Z` to `a`–`z` and nothing else. This section's `lowercase` was never meant
+to mean general Unicode case-folding — the whole point of §14.1's charset is to
+avoid needing one — but the word alone does not say so, which is the
+terminology #820 corrects. No decision below changes; the two steps described
+here are the one mapping this section has always meant.
 
 The lowercase mapping is included deliberately: because platform uniqueness is
 already enforced case-insensitively, folding case **cannot** introduce a
@@ -2607,6 +2709,23 @@ resolved by hand before the mapping ships.
 > it can be relied on. That constraint and the resolution of the colliding
 > accounts are tracked in the deployment repository; they are backend work and
 > are not specified here.
+
+**Two different claims share the word "eligibility," and this document makes
+only one of them (#820).** "Given this username string, what handle would it
+become, and is it well-formed" is **candidate derivation** — a pure function of
+the string, asking nothing about any account, and it is implemented and safe
+to ship exactly as specified in §14.1:
+`wallet/plugins/tauri-plugin-f2zmsg/src/handle.rs::eligibility`, exposed to the
+client as `check_handle_eligibility` (`CLIENT-CONTRACT.md` §3.2), does this and
+only this — no network call, no account lookup, no ownership claim. "This
+account is the authoritative holder of that handle in the directory" is a
+different claim, and nothing in this document authorizes publishing it yet:
+that requires the corrected census above, resolution of every collision group
+the query already found, and the database-level `UniqueConstraint` becoming
+real, none of which is done. A client MUST NOT read a `true` from
+`check_handle_eligibility` as anything more than "this string could become a
+handle" — it is not a reservation, a claim, or a promise that submitting it
+will succeed, and copy built on top of it must not imply otherwise.
 
 **Accepted product cost, stated plainly.** Existing accounts whose username
 contains `.`, `@`, `+` or `-`, contains any non-ASCII character, or exceeds 30


### PR DESCRIPTION
Closes #820.

## Problem

The public contract used "lowercase(username)" throughout to define handle
eligibility. That word is Unicode-ambiguous — most runtimes' `lowercase()`
is Unicode-aware by default, and Unicode-aware case folding is exactly the
normalization step the whole charset exists to avoid needing (the Kelvin
sign, U+212A, folds to ASCII `k` under general Unicode case-folding). The
shipped Rust implementation never had this bug — it checks
`username.is_ascii()` before folding anything — but the spec's own wording
didn't say that ordering was required, so a from-scratch implementation
reading only the prose could get it wrong.

## Changes

**`docs/e2ee/WIRE.md` §14.1** — replaced the terse "no normalization"
statement with the full two-step rule the code runs, in order: reject raw
non-ASCII first, then fold ASCII `A`-`Z` to `a`-`z` only. Added a paragraph
scoping this (one-time candidate derivation) apart from §14.1's existing
comparison-time rule (byte-exact match between two already-derived handles)
— they're different operations and the doc's wording let them read as the
same "no normalization" rule stated twice.

**§14.1/§14.2/§14.3** — every normative restatement of the rule now says
`ascii_lower`, with `lowercase(username)` in older/historical sentences
glossed inline as meaning the same precise thing (not deleted, per this
document's convention of keeping the record of what was said and
correcting it in place).

**§14.2** — the ~90%/~10% prevalence table now carries an explicit caveat:
it's a historical figure from one 2026-08-23 production query, not
reproducible from this repository, and not a live guarantee (new
registrations, and the collision groups the same query found are expected
to be resolved before the mapping ships). Same caveat added to
`CLIENT-CONTRACT.md` §11.3's copy of the table.

**§14.3 / `CLIENT-CONTRACT.md` §11.3** — added an explicit statement that
*candidate derivation* (a pure, already-implemented, already-safe function
of a username string — `handle.rs::eligibility`, exposed as
`check_handle_eligibility`) and *authoritative handle ownership* (blocked on
the backend census, collision resolution, and the not-yet-real database
uniqueness invariant) are different claims. A client MUST NOT read
`check_handle_eligibility`'s `true` as a reservation or a success guarantee.

**§14.1** — named the empty-string case explicitly: the regex
`{1,30}` implies a length floor the code's charset-membership check doesn't
enforce on its own (vacuously true on zero bytes), so the reference
implementation special-cases it to `ineligible`/`punctuation`. Required
every restatement to agree on that exact pair, and named where they
currently don't (below).

**`docs/e2ee/ARCHITECTURE.md` §13-O** — one bullet added cross-referencing
the candidate-derivation/authoritative-binding split, so the open-questions
ledger doesn't read as though the whole feature is blocked when only
publication is.

## Spec vs. shipped code — found, not papered over

Checking this against both implementations surfaced a real divergence:
`wallet/zuuli/src/lib/messaging/mock.ts`'s `evaluateHandle` answers
`reason: "not-signed-in"` for an empty string, where `handle.rs::eligibility`
(the reference/shipped behavior) answers `reason: "punctuation"`. The mock's
`if (!username)` guard conflates `null` (no signed-in account, correctly
`not-signed-in`) with `""` (a signed-in account with an empty username,
which should run the same pipeline as any other string). There's also a
latent bug in the mock's own punctuation regex (`*` instead of `+`) that
would mislabel the empty case even without that guard.

I did not fix the mock in this PR — it's a `.ts` change outside
`docs/e2ee/`, and this issue's scope is the spec. Filed **#838** with the
exact fix, and the spec now states the required behavior explicitly (§14.1)
rather than silently assuming the mock already matches it.

## What I did not do

- **The mutation-sensitive spec↔Rust↔mock parity self-test** #820's
  acceptance criteria call for does not exist yet. The spec now states it as
  a MUST (WIRE.md §14.1) but does not claim it's implemented — also tracked
  in #838, alongside the mock fix.
- **Updating the Rust/plugin code-comment restatements** of the rule
  (`handle.rs`'s module doc, `f2z-authority`) that the issue also flagged as
  using inconsistent terminology — out of scope for a `docs/e2ee/`-only PR;
  worth a follow-up sweep once #838 lands so code comments and spec don't
  drift again.

Verified `scripts/check-akd-doc-evidence.mjs`,
`scripts/check-hash-domain-labels.mjs`, and
`wallet/zuuli/scripts/messaging-contract.node-test.mjs` all still pass
against the edited files.