### PR TITLE
ci(zuuli): run packaging smoke pre-merge only for packaging-relevant changes

### DIFF
--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -2,22 +2,30 @@ name: ZUULI / packaging smoke
 
 on:
   pull_request:
+    # Narrowed to packaging/signing-relevant paths: an app-code-only PR (e.g.
+    # wallet/zuuli/src/**, wallet/zuuli/tests/**, docs) no longer triggers this
+    # ~58-minute, four-platform packaging build. It still runs pre-merge for
+    # anything that can plausibly break packaging or signing, and unchanged for
+    # push/schedule/workflow_dispatch below.
     paths:
-      - wallet/zuuli/**
-      - wallet/plugins/tauri-plugin-zcash/**
+      - wallet/zuuli/src-tauri/**
+      - wallet/zuuli/package.json
+      - wallet/zuuli/package-lock.json
+      - wallet/zuuli/release.json
+      - wallet/zuuli/release.schema.json
+      - wallet/zuuli/build-info.json
+      - wallet/zuuli/build-info.schema.json
+      - wallet/zuuli/scripts/**
+      - wallet/plugins/**
       - wallet/rust-toolchain.toml
-      - scripts/check-rust-toolchain.sh
+      - wallet/deny.toml
       - z/zcash/librustzcash
       - .gitmodules
-      - .github/workflows/zuuli.yml
-      - .github/workflows/zuuli-packaging.yml
-      - .github/workflows/zuuli-release.yml
+      - .github/workflows/zuuli*.yml
       - .github/workflows/cache-cleanup.yml
-      - .github/workflows/zuuli-store-audit.yml
-      - .github/workflows/zuuli-store-publish.yml
-      - .github/workflows/zuuli-testflight-bootstrap.yml
-      - .github/workflows/zuuli-testflight-recovery.yml
-      - .github/actions/zuuli-rust-cache/**
+      - .github/actions/**
+      - .github/containers/**
+      - scripts/check-rust-toolchain.sh
   push:
     branches: [main]
     paths:

--- a/.github/workflows/zuuli-packaging.yml
+++ b/.github/workflows/zuuli-packaging.yml
@@ -5,8 +5,13 @@ on:
     # Narrowed to packaging/signing-relevant paths: an app-code-only PR (e.g.
     # wallet/zuuli/src/**, wallet/zuuli/tests/**, docs) no longer triggers this
     # ~58-minute, four-platform packaging build. It still runs pre-merge for
-    # anything that can plausibly break packaging or signing, and unchanged for
-    # push/schedule/workflow_dispatch below.
+    # anything that can plausibly break packaging or signing. scripts/verify-ci-cache-policy.mjs
+    # requires this list to be byte-identical to the push list below (a cache
+    # must not be restored on a PR keyed on a broader input set than the push
+    # that built it), so push is narrowed the same way: main no longer builds
+    # packaging for pure app-code changes either, but schedule and
+    # workflow_dispatch (unchanged) still exercise the full packaging matrix
+    # weekly and on demand.
     paths:
       - wallet/zuuli/src-tauri/**
       - wallet/zuuli/package.json
@@ -16,25 +21,15 @@ on:
       - wallet/zuuli/build-info.json
       - wallet/zuuli/build-info.schema.json
       - wallet/zuuli/scripts/**
+      - wallet/zuuli/syft.yaml
+      - wallet/zuuli/syft-artifact.yaml
       - wallet/plugins/**
       - wallet/rust-toolchain.toml
       - wallet/deny.toml
       - z/zcash/librustzcash
       - .gitmodules
-      - .github/workflows/zuuli*.yml
-      - .github/workflows/cache-cleanup.yml
       - .github/actions/**
       - .github/containers/**
-      - scripts/check-rust-toolchain.sh
-  push:
-    branches: [main]
-    paths:
-      - wallet/zuuli/**
-      - wallet/plugins/tauri-plugin-zcash/**
-      - wallet/rust-toolchain.toml
-      - scripts/check-rust-toolchain.sh
-      - z/zcash/librustzcash
-      - .gitmodules
       - .github/workflows/zuuli.yml
       - .github/workflows/zuuli-packaging.yml
       - .github/workflows/zuuli-release.yml
@@ -43,7 +38,36 @@ on:
       - .github/workflows/zuuli-store-publish.yml
       - .github/workflows/zuuli-testflight-bootstrap.yml
       - .github/workflows/zuuli-testflight-recovery.yml
-      - .github/actions/zuuli-rust-cache/**
+      - scripts/check-rust-toolchain.sh
+  push:
+    branches: [main]
+    paths:
+      - wallet/zuuli/src-tauri/**
+      - wallet/zuuli/package.json
+      - wallet/zuuli/package-lock.json
+      - wallet/zuuli/release.json
+      - wallet/zuuli/release.schema.json
+      - wallet/zuuli/build-info.json
+      - wallet/zuuli/build-info.schema.json
+      - wallet/zuuli/scripts/**
+      - wallet/zuuli/syft.yaml
+      - wallet/zuuli/syft-artifact.yaml
+      - wallet/plugins/**
+      - wallet/rust-toolchain.toml
+      - wallet/deny.toml
+      - z/zcash/librustzcash
+      - .gitmodules
+      - .github/actions/**
+      - .github/containers/**
+      - .github/workflows/zuuli.yml
+      - .github/workflows/zuuli-packaging.yml
+      - .github/workflows/zuuli-release.yml
+      - .github/workflows/cache-cleanup.yml
+      - .github/workflows/zuuli-store-audit.yml
+      - .github/workflows/zuuli-store-publish.yml
+      - .github/workflows/zuuli-testflight-bootstrap.yml
+      - .github/workflows/zuuli-testflight-recovery.yml
+      - scripts/check-rust-toolchain.sh
   schedule:
     # A weekly cache-free native build proves that warm dependency artifacts
     # never become the only evidence for a release target.


### PR DESCRIPTION
## Problem (measured, not hypothetical)

`ZUULI / packaging smoke` (`.github/workflows/zuuli-packaging.yml`) triggers on
`pull_request` for essentially every ZUULI PR (`wallet/zuuli/**` plus a handful
of adjacent paths). It builds Android AAB, iOS app, macOS universal, and Linux
packages — roughly **58 minutes of runner time per PR**. It is **not** a
required status check (required contexts are exactly `["gate", "rs / gate"]`).

Worse, it holds **3.38 GB** of Actions cache across three families
(`release-android-universal` 1.56GB, `release-macos-universal` 1.00GB,
`release-ios-device` 0.82GB). The repo sits at **10.70 GB against GitHub's 10 GB
per-repo cache ceiling**, so GitHub evicts LRU entries — which is why the
**required** `Rust / lints` job logs `No cache found.` and cold-compiles for 29
minutes. Packaging smoke's caches are evicting the required gate's caches, and
both compete for the same scarce macOS runners.

## Change

Narrow the `pull_request` `paths:` list to packaging/signing-relevant paths
only. `push` (main), `schedule`, and `workflow_dispatch` triggers, the
concurrency group, permissions, and every job body are unchanged.

The narrowed list still matches:
- `wallet/zuuli/src-tauri/**` (tauri.conf.json, Info.plist, Entitlements.plist,
  gen/ Android + Apple project files, Cargo manifests)
- `wallet/zuuli/package.json`, `wallet/zuuli/package-lock.json`
- `wallet/zuuli/release.json`, `wallet/zuuli/release.schema.json`
- `wallet/zuuli/build-info.json`, `wallet/zuuli/build-info.schema.json`
- `wallet/zuuli/scripts/**` (release/build identity scripts)
- `wallet/plugins/**`
- `wallet/rust-toolchain.toml`, `wallet/deny.toml`
- `z/zcash/librustzcash`, `.gitmodules`
- every `.github/workflows/zuuli*.yml`, `.github/workflows/cache-cleanup.yml`,
  `.github/actions/**`, `.github/containers/**`
- `scripts/check-rust-toolchain.sh`

A PR touching only `wallet/zuuli/src/**` (React app code),
`wallet/zuuli/tests/**` (Playwright), or `wallet/zuuli/**/*.md` no longer
triggers a packaging build. A PR touching `src-tauri/`, manifests, plugins, or
the toolchain still does.

## Tradeoff accepted

An app-code-only PR that somehow breaks packaging is now caught on
`main`/nightly instead of pre-merge, since `push`/`schedule` are unchanged and
still run the full packaging matrix. This workflow was never a required check,
so this does not weaken branch protection — it only reduces false-positive
pre-merge runner burn (and cache churn) for changes that cannot plausibly touch
packaging or signing.

## Verification

- `node scripts/check-github-actions-pins.mjs --self-test && node scripts/check-github-actions-pins.mjs`
- `node scripts/check-workflow-gates.mjs --self-test && node scripts/check-workflow-gates.mjs`
