### PR TITLE
ci(zuuli): skip the Rust matrix for markdown-only changes (Windows natives stay on the gate)

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -123,6 +123,25 @@ jobs:
           zuuli=false
           zuuallet_schema=false
           while IFS= read -r -d '' file; do
+            # Prose under wallet/zuuli/ — STATUS.md, README.md, CLAUDE.md,
+            # docs/**.md — describes the app; it is not compiled into it and no
+            # job below reads it. Without this guard the broad `wallet/zuuli/*`
+            # pattern in the arm below matches it, so a STATUS re-derivation —
+            # which every release needs at least once — pays the full ~40-minute
+            # native matrix.
+            #
+            # `==` inside `[[ ]]` is a glob match, not a string compare, and a
+            # glob `*` spans `/`, so this one pattern covers every depth:
+            # wallet/zuuli/STATUS.md and wallet/zuuli/docs/e2ee/notes.md alike.
+            #
+            # It is scoped to the wallet/zuuli/ prefix and so cannot reach the
+            # markdown that genuinely gates behaviour: docs/e2ee/CLIENT-CONTRACT.md,
+            # docs/e2ee/WIRE.md and docs/ZUULI-LINUX-BUILD-IMAGE.md all live
+            # outside that prefix and still select the full gate. It also runs
+            # only per-file, so it cannot affect the fail-open paths above.
+            if [[ "$file" == wallet/zuuli/*.md ]]; then
+              continue
+            fi
             case "$file" in
               Cargo.toml|Cargo.lock|.cargo/*|clippy.toml|.clippy.toml|wallet/Cargo.toml|wallet/Cargo.lock|wallet/.cargo/*|wallet/clippy.toml|wallet/.clippy.toml|wallet/*.rs|wallet/*/Cargo.toml|wallet/*/Cargo.lock|wallet/*/.cargo/*|wallet/*/clippy.toml|wallet/*/.clippy.toml|wallet/shared/sensitive-entry-session.ts|wallet/zuuli/*|wallet/plugins/*|rs/crates/f2z-codec/*|rs/crates/f2z-kt-client/*|rs/crates/f2z-kt-core/*|rs/crates/f2z-msg-dag/*|rs/crates/f2z-msg-identity/*|rs/crates/f2z-msg-mls/*|rs/crates/f2z-msg-store/*|rs/crates/f2z-relay-proto/*|rs/crates/f2z-relay-testkit/*|rs/rust-toolchain.toml|wallet/zuuallet/package.json|wallet/zuuallet/package-lock.json|wallet/zuuallet/src/hooks/useWallet.ts|wallet/zuuallet/src/lib/mnemonic.ts|wallet/zuuallet/src/lib/sensitive-entry.ts|wallet/zuuallet/src/lib/sensitive-seed-session.ts|wallet/zuuallet/src/lib/sensitive-seed.ts|wallet/zuuallet/src/lib/tauri.ts|wallet/zuuallet/src/pages/CreateWallet.tsx|wallet/zuuallet/src/pages/RestoreWallet.tsx|wallet/zuuallet/src/pages/Settings.tsx|wallet/zuuallet/src/pages/Welcome.tsx|wallet/zuuallet/src/pages/sensitive-entry-routes.test.tsx|wallet/zuuallet/src/types/index.ts|wallet/rust-toolchain.toml|wallet/deny.toml|docs/e2ee/CLIENT-CONTRACT.md|docs/e2ee/WIRE.md|scripts/check-github-actions-pins.mjs|scripts/check-librustzcash-compat.mjs|scripts/check-rust-toolchain.sh|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-tauri-plugin-permissions.mjs|scripts/check-zuuli-linux-image.mjs|scripts/check-zuuli-android-gate.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-store-audit.yml|.github/workflows/zuuli-store-publish.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md)
                 zuuli=true

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -70,6 +70,13 @@ const RUST_ROOT_CONTRACTS = [
       "wallet/README.md",
       "wallet/docs/architecture.md",
       "rs/crates/f2z-relay/src/lib.rs",
+      // Markdown under wallet/zuuli/ is prose about the app, not an input to
+      // any job the gate awaits, and `wallet/zuuli/*` would otherwise select
+      // the whole native matrix for a STATUS re-derivation. Probed at the root
+      // and at depth because the guard is a glob whose `*` spans `/`.
+      "wallet/zuuli/STATUS.md",
+      "wallet/zuuli/CLAUDE.md",
+      "wallet/zuuli/docs/e2ee/notes.md",
     ],
     jobs: [
       [
@@ -3397,6 +3404,38 @@ function runRustRootWorkflowMutationTests(repoRoot) {
           'must actively select "docs/e2ee/WIRE.md"',
         ],
       ];
+      // The markdown-only guard is a *negative* selector: it exists to keep
+      // `wallet/zuuli/*` from dragging prose into the native matrix. Its two
+      // failure directions are deleting it and narrowing it to the top level,
+      // so both are exercised against the live workflow.
+      assertWorkflowFailure(
+        contract,
+        source,
+        "wallet/ rejects deleting the ZUULI markdown-only guard",
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            '            if [[ "$file" == wallet/zuuli/*.md ]]; then\n' +
+              "              continue\n" +
+              "            fi\n",
+            "",
+          ),
+        'must leave zuuli false for unrelated input "wallet/zuuli/STATUS.md"',
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        "wallet/ rejects a ZUULI markdown-only guard that misses nested prose",
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            '"$file" == wallet/zuuli/*.md',
+            '"$file" == wallet/zuuli/STATUS.md',
+          ),
+        'must leave zuuli false for unrelated input "wallet/zuuli/docs/e2ee/notes.md"',
+      );
       for (const [guard, target, replacement, needle] of
         selectorPatternMutations) {
         const action = replacement ? "broadened" : "removed";

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -14,7 +14,7 @@ const target = "armv7-linux-androideabi";
 const ndk = "27.0.12077973";
 const cacheKey = `zuuli-plugin-android-armv7-ndk${ndk}-api29`;
 const changeDetectorDigest =
-  "cee5084c20352f861f17f989b3ffad8d8f15d3dd58b0845f7a1d54f270ce8bc2";
+  "640396c8de1263a2cf89f1263cd980c26cb7d1ceaa90bf1b8a5ae954d481f180";
 const toolchainEnvDigest =
   "403f59c58bca0a37b98a3bb0ea0ae7f1c289b3531d6e1eec8496643866ee2013";
 const requiredMessagingSelector = "wallet/zuuli/*";


### PR DESCRIPTION
## What this does

**CHANGE 1 (shipped).** `wallet/zuuli/*` in the release-impacting selector matches *every* file under the app directory — `STATUS.md`, `README.md`, `CLAUDE.md`, `docs/*.md` included — so a docs-only STATUS re-derivation ran the entire ~40-minute Rust matrix. We paid that on builds 18 and 19, and every release needs a STATUS re-derive.

The per-file loop now short-circuits on markdown under that prefix:

```bash
if [[ "$file" == wallet/zuuli/*.md ]]; then
  continue
fi
```

`==` inside `[[ ]]` is a glob match and a glob `*` spans `/`, so the one pattern covers every depth. It runs per-file, so it cannot touch the fail-open paths for manual runs, first pushes or unusable base SHAs.

**CHANGE 2 (not shipped — see below).** Moving the two Windows native jobs off the per-PR gate is not implementable without weakening the guard that exists specifically to prevent it. Detail at the bottom.

## Observed filter output

The selector body was extracted from `.github/workflows/zuuli.yml` verbatim and executed with `/bin/bash` against a real Git fixture (the same harness `check-github-actions-pins.mjs` uses), one commit per case:

```
wallet/zuuli/STATUS.md                   -> zuuli=false zuuallet_schema=false
wallet/zuuli/README.md                   -> zuuli=false zuuallet_schema=false
wallet/zuuli/CLAUDE.md                   -> zuuli=false zuuallet_schema=false
wallet/zuuli/docs/e2ee/notes.md          -> zuuli=false zuuallet_schema=false
wallet/zuuli/src/App.tsx                 -> zuuli=true  zuuallet_schema=false
docs/e2ee/WIRE.md                        -> zuuli=true  zuuallet_schema=false
docs/e2ee/CLIENT-CONTRACT.md             -> zuuli=true  zuuallet_schema=false
docs/ZUULI-LINUX-BUILD-IMAGE.md          -> zuuli=true  zuuallet_schema=false
wallet/zuuallet/src-tauri/main.rs        -> zuuli=true  zuuallet_schema=true
wallet/README.md                         -> zuuli=false zuuallet_schema=false
```

The three contract documents that deliberately gate behaviour — `docs/e2ee/CLIENT-CONTRACT.md`, `docs/e2ee/WIRE.md`, `docs/ZUULI-LINUX-BUILD-IMAGE.md` — live outside the `wallet/zuuli/` prefix and still select the full gate.

Edge cases, same harness:

```
STATUS.md + src/App.tsx together                     -> zuuli=true  zuuallet_schema=false
STATUS.md + docs/e2ee/WIRE.md together               -> zuuli=true  zuuallet_schema=false
STATUS.md, unusable BASE_SHA (fail open)             -> zuuli=true  zuuallet_schema=true
STATUS.md, BASE_SHA empty (fail open)                -> zuuli=true  zuuallet_schema=true
STATUS.md, BASE_SHA unknown 40-hex (fail open)       -> zuuli=true  zuuallet_schema=true
wallet/zuuli/notes.mdx (not a .md suffix)            -> zuuli=true  zuuallet_schema=false
```

A mixed PR still runs the full gate; fail-open is unchanged and never fails open into a skip.

## No gated coverage is lost

Of the 11 tracked markdown files under `wallet/zuuli/`, exactly one is read by a checker: `wallet/zuuli/docs/wasm-spike.md`, by `wallet/zuuli/scripts/wasm-boundary.mjs` — which runs **unconditionally** in the `changes` job, before any selector output exists. Everything else (`status-freshness`, `seed-capture-boundary`, `store-*`, `ui-copy-truncation`) is fixture-driven or does not read repo markdown at all.

`wallet/zuuli/scripts/status-freshness.mjs` keeps its own broader release-impacting list, which still treats `wallet/zuuli/**` markdown as release-impacting. That is the fail-safe direction — STATUS freshness stays strict at release time — so it is deliberately left alone.

## The behaviour is pinned, not merely asserted

`check-github-actions-pins.mjs` already executes the selector body against a real Git fixture and asserts outputs. This PR extends that:

- `excludedProbePaths` gains `wallet/zuuli/STATUS.md`, `wallet/zuuli/CLAUDE.md` and `wallet/zuuli/docs/e2ee/notes.md` (root and depth), so the live check fails if the guard regresses.
- Two new mutation controls prove that check can go red:
  - `wallet/ rejects deleting the ZUULI markdown-only guard: passed`
  - `wallet/ rejects a ZUULI markdown-only guard that misses nested prose: passed`

`scripts/check-zuuli-android-gate.mjs` digest-pins the detector step; the digest was re-derived with its own `--print-change-detector-digest` (`cee5084c…` → `640396c8…`).

## Verification run locally

```
node scripts/check-workflow-gates.mjs --self-test   -> 39 case(s) passed
node scripts/check-workflow-gates.mjs               -> pass (2 gates, 60 jobs, 15 workflow files)
node scripts/check-github-actions-pins.mjs --self-test
    -> 74 source-policy, 10 gate-verdict, 139 current-workflow, 14 frontend-build,
       103 Rust-root ownership mutation case(s) passed
node scripts/check-github-actions-pins.mjs          -> pass (191 external refs, 16 files)
node scripts/check-zuuli-android-gate.mjs --self-test -> 44 mutations passed
node scripts/check-zuuli-android-gate.mjs           -> pass
node scripts/check-zuuli-linux-image.mjs (+ --self-test)   -> pass
node scripts/check-librustzcash-compat.mjs (+ --self-test) -> pass
node wallet/zuuli/scripts/wasm-boundary.mjs         -> pass
scripts/check-rust-toolchain.sh                     -> pass
scripts/check-public-repo-boundary.sh               -> pass
```

## CHANGE 2 — Windows natives stay on the per-PR gate. Here is why.

`Rust / native tests (windows)` (23 min) and `Rust / native lints (windows)` (13 min) do cost 36 min on every PR, and moving them to `push: main` is a reasonable *shape*. It is not implementable here without dismantling the guard that was built to forbid exactly this move.

1. **They are not separate jobs.** Windows is a matrix leg of `rust_native_clippy` / `rust_native_tests`, shared with macOS. A matrix leg cannot carry its own `if:`, so deferring Windows means a dynamic matrix computed in `changes` — i.e. changing the matrix.

2. **The matrix is hard-pinned, line for line.** `scripts/check-github-actions-pins.mjs` holds both jobs to their exact current source (`REQUIRED_NATIVE_CLIPPY_JOB_LINES` at :137, `REQUIRED_NATIVE_TESTS_JOB_LINES` at :186), *and* independently asserts `target_os` is exactly `["macos","windows"]` on runners `["macos-latest","windows-latest"]` (:2529), *and* pins the `if:` string. Its own comment states the purpose:

   > this is the only required job that runs Win32 and Darwin code paths, so weakening the command, the matrix or the selector silently restores the #610 state where Windows execution could not fail a merge.

   There are live mutation controls asserting each of those rejections (`real workflow rejects a non-native target matrix`, `real workflow rejects a weakened native clippy selector`).

3. **Deferring to `push: main` *is* the #610 state.** A PR would merge green with Windows never having run; Windows would only fail *after* the merge. That is precisely "Windows execution cannot fail a merge", which #610 moved this suite here to end. Implementing it means editing those constants and deleting their mutation controls — weakening the checker, which the brief forbids.

4. **There is no canary lane to move them into.** `zuuli.yml` has no `schedule:` trigger (`pull_request`, `merge_group`, `push: main`, `workflow_dispatch`). And `check-workflow-gates.mjs`'s `GATE_EXEMPT_JOBS` is deliberately empty, with the comment naming "a scheduled canary that is not part of a PR verdict" as the foreseeable first entry — so a canary lane is a designed-but-unbuilt path, not a config toggle.

Doing CHANGE 2 properly is a separate PR that: adds a scheduled/canary lane, registers the exemption in `GATE_EXEMPT_JOBS` with a written reason, and re-reviews the `REQUIRED_NATIVE_*_JOB_LINES` contract as a deliberate #610 policy reversal. **The tradeoff being accepted, plainly: PRs keep paying 36 minutes of Windows time, and in exchange a Windows-only regression still cannot reach `main`.** That is worth someone deciding on purpose rather than a checker being quietly relaxed in a throughput PR.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
