### PR TITLE
docs(msg-store): openmls#2188 is fixed upstream but not released

### DIFF
--- a/rs/crates/f2z-msg-store/src/storage_impl.rs
+++ b/rs/crates/f2z-msg-store/src/storage_impl.rs
@@ -41,9 +41,10 @@
 //! store*, and upstream turns it into a panic in the middle of message
 //! processing.
 //!
-//! **2. `clear_proposal_queue` actually clears the queue.** Upstream builds the
-//! per-proposal key as `serde_json::to_vec(&(group_id, proposal_ref))` and
-//! removes *that* from the map — but every write goes in under
+//! **2. `clear_proposal_queue` actually clears the queue.** The released
+//! reference builds the per-proposal key as
+//! `serde_json::to_vec(&(group_id, proposal_ref))` and removes *that* from the
+//! map — but every write goes in under
 //! `build_key_from_vec(label, key, version)`, so the key it removes is one no
 //! entry was ever stored at. The refs list is deleted and the proposal bodies
 //! are left behind forever. Ported faithfully that would be a slow leak of
@@ -51,17 +52,38 @@
 //! fix is one line: go through the same `delete` helper every other deleter
 //! uses. `tests/provider.rs` pins it.
 //!
-//! **It is reported and it is still not fixed.** [openmls/openmls#2188][2188]
-//! carries a self-contained reproduction; the defect is present unchanged in
-//! `openmls_memory_storage` **0.6.0**, which this tree re-read line by line
-//! during the 0.9 migration (#723) rather than assuming the port still applied.
-//! Both differences above still stand against 0.6.0 — `clear_proposal_queue`
-//! still calls `values.remove(&serde_json::to_vec(&(group_id, proposal_ref))?)`
-//! against entries written through `write::<CURRENT_VERSION>(…)`, and
-//! `queued_proposals` still `unwrap()`s a dangling reference. **Do not "resync
-//! with upstream" by copying either of them back.**
+//! **It is reported, it is fixed upstream, and the fix is not released.**
+//! [openmls/openmls#2188][2188] carried a self-contained reproduction and was
+//! closed as fixed by [openmls/openmls#2163][2163], merged to `main` on
+//! 2026-08-31: upstream's `clear_proposal_queue` now wraps each per-proposal
+//! key in `build_key_from_vec::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, key)`
+//! before removing it, which is the correction difference 2 makes. **No
+//! release carries it.** `openmls_memory_storage` **0.6.0** was published
+//! 2026-08-25, six days before that merge, and is still the newest version and
+//! the one this graph resolves; it still calls
+//! `values.remove(&serde_json::to_vec(&(group_id, proposal_ref))?)` against
+//! entries written through `write::<CURRENT_VERSION>(…)`. This tree re-read it
+//! line by line during the 0.9 migration (#723) rather than assuming the port
+//! still applied.
+//!
+//! **Difference 1 stands against upstream `main` as well.** #2163 changed one
+//! line inside `clear_proposal_queue` and nothing else, so `main`'s
+//! `queued_proposals` still `unwrap()`s the `read` that returns `None`, and
+//! `main` still `unwrap()`s serialisation throughout. So **do not "resync with
+//! upstream" by copying either difference back** — difference 1 for that
+//! reason, difference 2 until an `openmls_memory_storage` release **newer than
+//! 0.6.0** carries #2163, which is the one event that retires it. `rs/deny.toml`
+//! records the same exit condition beside the dependency.
+//!
+//! None of this changes what is built here. The `MemoryStorage` #2163 fixes is
+//! linked only as `openmls_libcrux_crypto`'s own field and is never handed to
+//! OpenMLS — `rs/deny.toml` records why it is therefore not banned — and the
+//! reasons this crate exists (see [`crate`]: the transaction, the backend seam,
+//! the application namespace) are untouched by a fix to the reference
+//! implementation.
 //!
 //! [2188]: https://github.com/openmls/openmls/issues/2188
+//! [2163]: https://github.com/openmls/openmls/pull/2163
 //!
 //! [`F2zStorageProvider`]: crate::F2zStorageProvider
 //! [`StoreError`]: crate::StoreError

--- a/rs/crates/f2z-msg-store/tests/provider.rs
+++ b/rs/crates/f2z-msg-store/tests/provider.rs
@@ -327,15 +327,20 @@ fn removing_one_proposal_leaves_the_other() {
     );
 }
 
-/// The defect this crate fixes relative to `openmls_memory_storage 0.5.0`.
+/// The defect this crate fixes relative to every released
+/// `openmls_memory_storage`, 0.6.0 included.
 ///
-/// Upstream's `clear_proposal_queue` removes a map key that nothing was ever
+/// The released `clear_proposal_queue` removes a map key that nothing was ever
 /// stored under — `serde_json::to_vec(&(group_id, proposal_ref))` with no label
 /// prefix and no version suffix — so the reference list is deleted and every
 /// serialised proposal body is left in the store forever. Ported faithfully
 /// that is an unbounded leak in every client's local database.
 ///
-/// This test is what would fail if someone "restored fidelity" with upstream.
+/// openmls/openmls#2163 fixed it on upstream `main` on 2026-08-31, after 0.6.0
+/// was published; `storage_impl.rs` carries the full status. The test stays
+/// either way — it guards this crate's own behaviour, and until a release
+/// newer than 0.6.0 carries that fix it is also what would fail if someone
+/// "restored fidelity" with the reference.
 #[test]
 fn clearing_the_queue_removes_the_proposal_bodies_and_not_only_the_references() {
     let store = provider();

--- a/rs/deny.toml
+++ b/rs/deny.toml
@@ -347,6 +347,18 @@ name = "openmls_rust_crypto"
 # *hands it to OpenMLS*: `f2z-msg-mls::F2zProvider` implements `OpenMlsProvider`
 # itself and never constructs `openmls_libcrux_crypto::Provider`, so the
 # transaction-free store is linked and unreachable.
+#
+# The version matters to a reader for one reason, and it is worth stating so it
+# does not have to be rediscovered: the resolved **0.6.0** (published
+# 2026-08-25) still carries the `clear_proposal_queue` proposal-body leak that
+# `f2z-msg-store` fixes. openmls/openmls#2163 fixed it on upstream `main` on
+# 2026-08-31 — after that publish — so **no release contains the fix**. The exit
+# condition for the corresponding note in
+# `crates/f2z-msg-store/src/storage_impl.rs` is an `openmls_memory_storage`
+# release **newer than 0.6.0** whose `clear_proposal_queue` carries #2163 —
+# read the release's source rather than its version number, since nothing else
+# retires the note. Being unreachable here, the leak is not a supply-chain
+# finding: this is a pointer, not a ban.
 
 # =============================================================================
 # Sources. Everything resolves to crates.io. Making that a rule rather than a


### PR DESCRIPTION
`rs/crates/f2z-msg-store/src/storage_impl.rs` asserted that the
`openmls_memory_storage::clear_proposal_queue` proposal-body leak "**is reported
and it is still not fixed**". That claim expired today.

## What changed upstream (re-verified, not taken on report)

| Fact | Evidence |
|---|---|
| `openmls/openmls#2188` closed as **completed** 2026-08-31T07:40:31Z, comment "Fixed by #2163." | `gh api repos/openmls/openmls/issues/2188` |
| `openmls/openmls#2163` **merged to `main`** 2026-08-31T07:18:26Z | `gh api repos/openmls/openmls/pulls/2163` |
| #2163 is **+2/-1 in `memory_storage/src/lib.rs`** (plus 3 test lines) — one line, inside `clear_proposal_queue` | `gh api .../pulls/2163/files` |
| `openmls_memory_storage` **0.6.0 published 2026-08-25**, six days *before* the merge, and is still the newest version | crates.io versions API |
| 0.6.0's `clear_proposal_queue` line 877 still `values.remove(&key)` on a raw `serde_json::to_vec(&(group_id, proposal_ref))` | vendored registry source read directly |
| `main`'s now wraps it: `build_key_from_vec::<CURRENT_VERSION>(QUEUED_PROPOSAL_LABEL, key)` | `main`'s `memory_storage/src/lib.rs` lines 884-886 |

So: **fixed upstream, in no release.** The note was wrong about `main` and right
about everything a consumer can actually depend on.

## What I measured about the other documented difference

Documented difference **1** ("nothing panics") **stands against upstream `main`
unchanged**, and this was measured rather than assumed. #2163 touched one line
inside `clear_proposal_queue` and nothing else, so on current `main`:

- `queued_proposals` (line 428) is still
  `let proposal = self.read(QUEUED_PROPOSAL_LABEL, &key)?.unwrap();` — a
  dangling queue reference is still a panic in the middle of message processing.
- Serialisation is still `unwrap()`ed throughout: ~50 non-lock `.unwrap()` call
  sites across `write_tree`, `write_group_context`, `write_signature_key_pair`,
  every `serde_json::from_slice` reader, and `build_key` itself.

## What this does *not* change

Nothing about the build. `openmls_memory_storage 0.6.0` **is** in `rs/Cargo.lock`
— `cargo tree -i` shows it reached only through `openmls_libcrux_crypto 0.4.0`,
whose `Provider` owns a `MemoryStorage` field — but `f2z-msg-mls::F2zProvider`
implements `OpenMlsProvider` itself and never constructs it, so the defective
store is linked and unreachable (already recorded in `rs/deny.toml`). And the
upstream fix does **not** obsolete this crate: the reasons in `lib.rs` — the
transaction, the backend seam, the application namespace — are untouched by a
one-line correction to the reference implementation.

## The diff

- **`storage_impl.rs`** — the status paragraph is replaced with the accurate
  one: reported, fixed by #2163 on `main`, not in any release, 0.6.0 is what we
  resolve. Difference 2's opening sentence is narrowed from "Upstream builds…"
  to "The released reference builds…", which is the only other now-false tense.
  Adds the exit condition and the cross-reference to `deny.toml`.
- **`tests/provider.rs`** — test kept as-is; only its doc comment is corrected.
  It named 0.5.0 and claimed the fidelity-restoring edit fails against
  "upstream" without qualification.
- **`rs/deny.toml`** — the durable pointer, beside the dependency it is about:
  the exit condition is an `openmls_memory_storage` release newer than 0.6.0
  whose `clear_proposal_queue` carries #2163, read from the source rather than
  inferred from the version number. This is the file `AGENTS.md` names as the
  one whose justifications rot.

No behaviour change; no `Cargo.lock` change.

## Gates run locally (pinned 1.97.1)

- `scripts/check-rust-fmt.sh --root rs` — 15 crates formatted
- `scripts/check-rust-clippy.sh --root rs` — 15 crates clippy-clean
- `scripts/check-rust-deny.sh --root rs --config rs/deny.toml` — advisories/bans/licenses/sources ok
- `cargo test --workspace` in `rs/` — all green, including
  `clearing_the_queue_removes_the_proposal_bodies_and_not_only_the_references`
- `cargo doc -p f2z-msg-store --no-deps` — no new rustdoc warning from this change

https://claude.ai/code/session_017MAbZDMgXsUqr1CVe6VnWF