### PR TITLE
chore(deps): rebase librustzcash fork onto upstream main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	# AGENTS.md "It's a real upstream regression -> branch, PR, pin, resume".
 	#
 	# free2z/librustzcash `f2z/drop-stale-rustcrypto-rc-pins` is upstream
-	# `main` at 330e4c0 plus one 4-line deletion (and its lockfile): the workspace's
+	# `main` at 91f448b plus one 4-line deletion (and its lockfile): the workspace's
 	# `block-buffer = "=0.11.0-rc.3"` / `crypto-common = "=0.2.0-rc.1"` pins
 	# and the two `zcash_primitives` lines that consume them. Both carry
 	# upstream's own comment "later RCs require edition2024" / "remove after
@@ -38,7 +38,8 @@
 	# link `tauri-plugin-f2zmsg` at all.
 	#
 	# Move this back to https://github.com/zcash/librustzcash + `main` the
-	# moment the upstream PR merges.
+	# moment the upstream PR (zcash/librustzcash#3010) merges. Until then the
+	# branch is rebased forward onto upstream `main` rather than left behind.
 	url = https://github.com/free2z/librustzcash
 	branch = f2z/drop-stale-rustcrypto-rc-pins
 [submodule "z/zcash/orchard"]

--- a/scripts/check-librustzcash-compat.mjs
+++ b/scripts/check-librustzcash-compat.mjs
@@ -12,7 +12,8 @@ const SUBMODULE_PATH = "z/zcash/librustzcash";
 // the index or working tree: doing so would make a stale pin self-approving.
 //
 // TRANSIENT FORK. This commit is upstream `main` at
-// 330e4c0aa9e25199acdb93a56bf70126d0d3f2b9 — the previously reviewed pin — plus
+// 91f448b5b1eacba09607faefd39e2204e4bb342d — the fork branch rebased forward
+// from its previous base 330e4c0aa9e25199acdb93a56bf70126d0d3f2b9 — plus
 // one 4-line deletion, and `.gitmodules` points at free2z/librustzcash for as
 // long as that deletion is unmerged. It removes the workspace's
 // `block-buffer = "=0.11.0-rc.3"` / `crypto-common = "=0.2.0-rc.1"` pins and
@@ -25,10 +26,14 @@ const SUBMODULE_PATH = "z/zcash/librustzcash";
 //
 // Because the delta is a dependency-requirement deletion and not a version
 // bump, EXPECTED_PACKAGES below is unchanged and so is REVIEWED_SCOPE_DIGEST.
-// Move both this literal and `.gitmodules` back to upstream the moment the PR
-// merges.
+// The ten upstream commits this rebase pulls in (NuTachyon/V7 behind
+// `cfg(zcash_unstable)`, transparent-output persistence, a P2PKH
+// `finalize_spends` fix) published no new crate versions and changed no
+// workspace dependency requirement, so all three shipping locks re-resolved
+// byte-identically. Move both this literal and `.gitmodules` back to upstream
+// the moment the PR merges.
 const EXPECTED_LIBRUSTZCASH_SHA =
-  "d63d44b27e9de276a3bab2ea2ec6430871faef22";
+  "a2b8c95210046eb59ee71dd10fd2ad1e9329b238";
 const SEND_SOURCE =
   "wallet/plugins/tauri-plugin-zcash/src/wallet/send.rs";
 const NATIVE_SEND_POLICY_SOURCE =

--- a/wallet/plugins/tauri-plugin-f2zmsg/README.md
+++ b/wallet/plugins/tauri-plugin-f2zmsg/README.md
@@ -216,8 +216,9 @@ crate is referenced in `zcash_primitives`' source at all.
 So, per `AGENTS.md`'s "branch, PR, pin, resume", **two transient pins**:
 
 * `z/zcash/librustzcash` → **free2z/librustzcash**
-  `f2z/drop-stale-rustcrypto-rc-pins`: upstream `main` at the previously
-  reviewed `330e4c0` plus that 4-line deletion.
+  `f2z/drop-stale-rustcrypto-rc-pins`: upstream `main` at the currently
+  reviewed `91f448b` plus that 4-line deletion, offered upstream as
+  zcash/librustzcash#3010 and rebased forward as upstream `main` moves.
 * `[patch.crates-io] bip32` → **free2z/crates** `f2z/bip32-secp256k1-0.29`,
   pinned by `rev`. iqlusioninc/crates `main` already moved bip32 onto the
   released RustCrypto lines — but the same branch bumped `secp256k1-ffi`


### PR DESCRIPTION
Keeps the transient librustzcash fork a bridge instead of a parking spot: it
had fallen 10 commits behind upstream `main`, so rebase it forward and move
the submodule pointer.

## The pin

| | |
|---|---|
| Old fork SHA | `d63d44b27e9de276a3bab2ea2ec6430871faef22` |
| New fork SHA | `a2b8c95210046eb59ee71dd10fd2ad1e9329b238` |
| Old upstream base | `330e4c0aa9e25199acdb93a56bf70126d0d3f2b9` |
| New upstream base | `91f448b5b1eacba09607faefd39e2204e4bb342d` (zcash/librustzcash `main`) |
| Fork branch | free2z/librustzcash `f2z/drop-stale-rustcrypto-rc-pins` (force-pushed with lease) |

**The delta is still the minimal deletion.** `git diff upstream/main` on the
rebased branch is exactly:

* `Cargo.toml` — drop `block-buffer = "=0.11.0-rc.3"` and
  `crypto-common = "=0.2.0-rc.1"`
* `zcash_primitives/Cargo.toml` — drop the two `.workspace = true` lines that
  consume them
* `Cargo.lock` — the two rows those produced

Four manifest lines plus two lockfile rows. Nothing else. The fork is still
required: upstream `main` at `91f448b` still carries both `=` pins, and
`=0.2.0-rc.1` cannot coexist with the `^0.2` that `digest 0.11` requires, so
`wallet/zuuli/src-tauri` still could not link `tauri-plugin-f2zmsg` without it.

## Upstream PR zcash/librustzcash#3010

Still **OPEN** and **MERGEABLE**; `mergeStateStatus` is `BLOCKED` (awaiting
maintainer review). Head updated to `a2b8c95210` by this rebase.

Two corrections to what we believed about it:

1. The PR is **not** opened from the branch `.gitmodules` tracks. Its head is
   free2z/librustzcash `f2z/upstream-drop-stale-rustcrypto-rc-pins`, a second
   branch that was sitting on `d475e5244d` — a *different* base from the
   submodule pin. Pushing the submodule branch therefore did **not** update the
   PR. I pushed the same rebased commit to both branches, so they are now the
   same SHA and cannot drift apart again.
2. **No CI has ever run on this PR.** `gh pr checks 3010` reports
   "no checks reported", and the check-runs API returns `total_count: 0` for
   both the old head `0db04b6746` and the new one. Upstream requires maintainer
   approval to run workflows for fork PRs and that approval has not been given.
   So "checks green" was not accurate before this change and is not accurate
   now — there is nothing to be green.

## What upstream changed, and whether it broke us

Nothing broke; no fix-forward was needed.

* `zcash_protocol` / `zcash_primitives` / `pczt` — experimental NuTachyon
  network upgrade and `TxVersion::V7`, all behind `zcash_unstable="nutachyon"`,
  which we do not set. The only root `Cargo.toml` edit in the whole range is
  adding `"nutachyon"` to the `check-cfg` list.
* `zcash_client_backend` / `zcash_client_sqlite` — `WalletWrite::put_blocks` is
  now documented as atomic and now records the transparent outputs of scanned
  transactions that pay a wallet account, queueing each outpoint for spend
  detection. This is a behavioural fix in upstream's own `WalletDb` impl; we
  have no first-party `WalletWrite` implementation, so it needs no adaptation
  from us. Worth knowing when reasoning about sync: transparent outputs are now
  persisted at scan time rather than only via
  `decrypt_and_store_transaction`.
* No workspace dependency requirement moved — not `rusqlite`, `secp256k1`,
  `bip32`, `secrecy`, `nonempty` or `rand` — so none of the wallet manifests
  that deliberately mirror them had to move, and no comment there went stale.

## Lockfiles

`cargo update -w` on all four Cargo roots (`tauri-plugin-zcash`,
`tauri-plugin-f2zmsg`, `zuuallet/src-tauri`, `zuuli/src-tauri`) produced **zero
changes** — the upstream range published no new crate versions. The two
`wallet/zuuli` spike lockfiles and `rs/Cargo.lock` contain no `zcash_*` package
at all and are untouched. So this PR moves the gitlink, the reviewed SHA and
three prose sites, and no lockfile.

Because no package version moved, `EXPECTED_PACKAGES` and
`REVIEWED_SCOPE_DIGEST` in `scripts/check-librustzcash-compat.mjs` are
unchanged, and `scripts/check-github-actions-pins.mjs` needed no edit.

## Verification (macOS host, pinned toolchain 1.97.1)

| Check | Result |
|---|---|
| `cargo build --locked` `wallet/plugins/tauri-plugin-zcash` | ok |
| `cargo build --locked` `wallet/plugins/tauri-plugin-f2zmsg` | ok |
| `cargo build --locked` `wallet/zuuallet/src-tauri` | ok |
| `cargo build --locked` `wallet/zuuli/src-tauri` | ok |
| `cargo test --locked --all-targets --features production-route-probe` (zcash plugin) | 150 + 1 passed |
| `cargo test --locked` `wallet/zuuli/src-tauri` | 22 passed |
| `cargo test --locked` `wallet/plugins/tauri-plugin-f2zmsg` | 85 passed |
| `node scripts/check-librustzcash-compat.mjs` | passed — gitlink `a2b8c95210`, 11 packages, 3 locks |
| `node scripts/check-librustzcash-compat.mjs --self-test` | killed 114 mutants |
| `node scripts/check-github-actions-pins.mjs` | passed |
| `scripts/check-rust-toolchain.sh` | passed |
| `scripts/check-rust-fmt.sh` | all 6 crates formatted |
| `scripts/check-rust-clippy.sh --root wallet` | all 6 crates clippy-clean |
| `scripts/check-rust-deny.sh --root wallet --config wallet/deny.toml` | advisories/bans/licenses/sources ok |
| `cargo tree --target x86_64-unknown-linux-gnu` | zcash stack resolves on Linux; `rusqlite 0.37.0` still a singleton |

## Not verified locally

* No clean-Linux-container build was run (dev host is macOS); CI's Linux jobs
  are the check for that. `cargo tree --target x86_64-unknown-linux-gnu` was
  run as the cheap stand-in, per AGENTS.md.
* The f2zmsg `relay-harness` integration tests were not run (they need the
  `f2z-relay` binary); only the default `cargo test` for that crate. That crate
  does not consume librustzcash — its lockfile contains no `zcash_*` package —
  so this change cannot reach it.
* Upstream PR #3010's CI, because upstream has never run any.

https://claude.ai/code/session_017MAbZDMgXsUqr1CVe6VnWF
