### PR TITLE
docs(deps): a fork & pin register, enforced, and fix the canary's blind spot

### DIFF
--- a/.github/workflows/dependency-register.yml
+++ b/.github/workflows/dependency-register.yml
@@ -1,0 +1,163 @@
+name: dependency-register
+
+# Enforces docs/DEPENDENCIES.md — the fork & pin register.
+#
+# AGENTS.md says a fork is "a bridge, never a parking spot", and until this
+# workflow existed nothing enforced the last step of that policy. The two
+# failures it is built from were both found by a human going looking: the
+# librustzcash fork sitting ten commits behind upstream, and z3's `.gitmodules`
+# `branch` naming a ref upstream had deleted months earlier.
+#
+# TWO JOBS, AND THE SPLIT IS THE DESIGN.
+#
+#   `offline` runs on pull requests. It reads only files in this repository —
+#   the register, `.gitmodules`, the `[patch.crates-io]` sites and
+#   z/zcash/librustzcash's own `[workspace.dependencies]` — so its verdict
+#   depends on nothing outside the tree and it is safe to run on a contributor's
+#   change.
+#
+#   `upstream` runs weekly and on dispatch, and files an issue rather than
+#   failing a check. Every verdict it renders is a statement about someone
+#   else's repository: whether zcash/librustzcash merged a PR, how far upstream
+#   `main` has moved, whether a remote still publishes a branch. Making that a
+#   required context would hand a third party's merge queue — or an
+#   api.github.com outage — the ability to redden `main` for a contributor who
+#   touched none of it. Upstream merging zcash/librustzcash#3010 is *good news*
+#   and must not be an incident for whoever happens to open a pull request that
+#   hour. So the action item lands in the tracker, where retiring a fork belongs.
+#
+# Neither job publishes a gate; the file is registered in
+# `UNGATED_WORKFLOWS` in scripts/check-workflow-gates.mjs with that reasoning.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/DEPENDENCIES.md'
+      - 'scripts/check-dependency-register.mjs'
+      - '.gitmodules'
+      - '**/Cargo.toml'
+      - '.github/workflows/dependency-register.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/DEPENDENCIES.md'
+      - 'scripts/check-dependency-register.mjs'
+      - '.gitmodules'
+      - '**/Cargo.toml'
+      - '.github/workflows/dependency-register.yml'
+  schedule:
+    # Mondays 08:00 UTC — the `upstream` job only, an hour after zuuallet.yml's
+    # upstream-canary so the two upstream watchers do not report at once.
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-register-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Deterministic half. No network, so a red here is always our own doing.
+  # ---------------------------------------------------------------------------
+  offline:
+    name: dependency-register / offline
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      # The register claims six version holds are *upstream librustzcash's*
+      # requirement rather than ours. The check re-reads that claim out of
+      # upstream's own manifest, so the submodule has to be here.
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      # Self-test first, so the verdict that follows comes from a check that has
+      # just been watched fail — the same shape as every other policy step here.
+      - name: Verify the fork & pin register
+        run: |
+          node scripts/check-dependency-register.mjs --self-test
+          node scripts/check-dependency-register.mjs
+
+  # ---------------------------------------------------------------------------
+  # Network half. Advisory by construction; it files an issue, never a red gate.
+  # ---------------------------------------------------------------------------
+  upstream:
+    name: dependency-register / upstream
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Fetch librustzcash submodule
+        run: git submodule update --init z/zcash/librustzcash
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - name: Verify the checker before trusting its verdict
+        run: node scripts/check-dependency-register.mjs --self-test
+
+      # `continue-on-error` is not used: a non-zero exit here is a *finding*,
+      # not a failure, and the next step needs to see it. The step captures the
+      # status explicitly so an infrastructure error (a crash, a bad token)
+      # still surfaces as a red step rather than being swallowed.
+      - name: Ask upstream whether an exit condition has fired
+        id: upstream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          node scripts/check-dependency-register.mjs --upstream > findings.txt 2>&1
+          status=$?
+          set -e
+          cat findings.txt
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" -gt 1 ]; then
+            echo "::error::dependency-register --upstream crashed (exit $status)"
+            exit "$status"
+          fi
+
+      # One issue, reused. A weekly job that opens a fresh issue every Monday
+      # trains people to close them unread, which is the failure mode this
+      # whole workflow exists to fix.
+      - name: File or update the tracking issue
+        if: steps.upstream.outputs.status != '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: 'chore(deps): fork & pin register needs attention'
+        run: |
+          set -euo pipefail
+          {
+            echo "\`scripts/check-dependency-register.mjs --upstream\` reported findings on $(date -u +%Y-%m-%d)."
+            echo
+            echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+            echo '```'
+            cat findings.txt
+            echo '```'
+            echo
+            echo "A \`[exit]\` line means an exit condition has fired and the fork or pin"
+            echo "should be retired — see \`docs/DEPENDENCIES.md\` for the row it belongs to."
+          } > body.md
+          existing=$(gh issue list --state open --limit 100 --json number,title \
+            --jq "[.[] | select(.title == env.TITLE) | .number] | first // empty")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file body.md
+            echo "Updated issue #$existing"
+          else
+            gh issue create --title "$TITLE" --body-file body.md
+          fi

--- a/.github/workflows/dependency-register.yml
+++ b/.github/workflows/dependency-register.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The register claims six version holds are *upstream librustzcash's*
       # requirement rather than ours. The check re-reads that claim out of
@@ -99,7 +99,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Fetch librustzcash submodule
         run: git submodule update --init z/zcash/librustzcash

--- a/.github/workflows/zuuallet.yml
+++ b/.github/workflows/zuuallet.yml
@@ -13,6 +13,14 @@ name: wallet/zuuallet
 # It runs on PRs/pushes that touch the app or its dependency inputs, and a
 # weekly `upstream-canary` job proactively rebuilds against the *latest*
 # librustzcash + refreshed crates to catch upstream drift before we bump.
+#
+# The canary also answers a question that is not about Zuuallet at all: is the
+# free2z/librustzcash fork still needed? Zuuallet does not depend on
+# tauri-plugin-f2zmsg, so it builds happily against pristine upstream while the
+# pins that force the fork are fully present — the canary's blind spot. It now
+# also resolves wallet/zuuli/src-tauri against pristine upstream and asserts
+# that this *fails* for the documented reason. See the last step of
+# `upstream-canary`, and docs/DEPENDENCIES.md.
 
 on:
   pull_request:
@@ -357,10 +365,68 @@ jobs:
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          workspaces: wallet/zuuallet/src-tauri
+          workspaces: |
+            wallet/zuuallet/src-tauri
+            wallet/zuuli/src-tauri
 
       - name: Refresh crates.io deps to latest compatible
         run: cargo update --manifest-path wallet/zuuallet/src-tauri/Cargo.toml
 
       - name: Build against latest upstream
         run: cargo build --manifest-path wallet/zuuallet/src-tauri/Cargo.toml
+
+      # -----------------------------------------------------------------------
+      # The blind spot this job had until this step existed, and why its
+      # polarity is inverted.
+      #
+      # Everything above builds wallet/zuuallet/src-tauri, and Zuuallet does not
+      # depend on tauri-plugin-f2zmsg. But the entire reason the librustzcash
+      # fork exists is that upstream's `block-buffer = "=0.11.0-rc.3"` /
+      # `crypto-common = "=0.2.0-rc.1"` workspace pins make **ZUULI** unable to
+      # link f2zmsg: `=0.2.0-rc.1` and the `^0.2` that `digest 0.11` requires
+      # cannot both be satisfied. So this canary was passing against pristine
+      # upstream while the exact condition that forces the fork was fully
+      # present — a green that meant nothing about the thing it was watching.
+      #
+      # Adding `cargo build` for zuuli would just be a mystery red every Monday,
+      # and a job that is always red teaches people to stop reading it. So the
+      # assertion is inverted: **failing to resolve, for the documented reason,
+      # is the expected and passing outcome** — it is this job confirming the
+      # fork is still required. Three verdicts:
+      #
+      #   * resolution fails naming crypto-common/block-buffer  -> PASS, the
+      #     fork is still needed; nothing to do.
+      #   * resolution fails for any other reason               -> FAIL, real
+      #     upstream breakage, which is what a canary is for.
+      #   * resolution SUCCEEDS                                 -> FAIL loudly.
+      #     Upstream has dropped the pins; the fork's premise is gone and it
+      #     should be retired. docs/DEPENDENCIES.md §1 is the exit checklist.
+      #
+      # Resolution, not compilation, because that is where the conflict lives:
+      # Cargo rejects the graph before a single crate is built, so this costs
+      # seconds and is the exact failure the fork removes.
+      # -----------------------------------------------------------------------
+      - name: Assert the librustzcash fork is still required (ZUULI vs pristine upstream)
+        run: |
+          set -uo pipefail
+          if cargo metadata --format-version 1 \
+              --manifest-path wallet/zuuli/src-tauri/Cargo.toml \
+              > /dev/null 2> zuuli-upstream-resolve.log; then
+            echo "::error::ZUULI now RESOLVES against pristine upstream librustzcash."
+            echo "The block-buffer / crypto-common pins that forced free2z/librustzcash"
+            echo "appear to be gone. Retire the fork: see docs/DEPENDENCIES.md section 1"
+            echo "and zcash/librustzcash#3010."
+            exit 1
+          fi
+          cat zuuli-upstream-resolve.log
+          if grep -q 'crypto-common' zuuli-upstream-resolve.log \
+            && grep -q '0.2.0-rc.1' zuuli-upstream-resolve.log; then
+            echo "Expected: ZUULI cannot resolve against pristine upstream librustzcash."
+            echo "This is the conflict free2z/librustzcash's one 4-line deletion removes,"
+            echo "so the fork is still required. Nothing to do."
+            exit 0
+          fi
+          echo "::error::ZUULI failed to resolve against pristine upstream for an"
+          echo "UNEXPECTED reason — not the known crypto-common conflict. Read the log"
+          echo "above: this is genuine upstream breakage, which is what this canary is for."
+          exit 1

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,6 +40,10 @@
 	# Move this back to https://github.com/zcash/librustzcash + `main` the
 	# moment the upstream PR (zcash/librustzcash#3010) merges. Until then the
 	# branch is rebased forward onto upstream `main` rather than left behind.
+	#
+	# Tracked as section 1 of docs/DEPENDENCIES.md; #3010's head is a
+	# *different* branch on the same fork, and the register says why that
+	# matters. scripts/check-dependency-register.mjs enforces both.
 	url = https://github.com/free2z/librustzcash
 	branch = f2z/drop-stale-rustcrypto-rc-pins
 [submodule "z/zcash/orchard"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,14 @@ First decide **whose bug it is**:
 The point of pinning our own commit is never to park there. It's a bridge that
 keeps the synthetic monorepo building **while** the fix is in flight upstream.
 
+Every bridge currently standing — and the event that retires each one — is
+listed in **[docs/DEPENDENCIES.md](./docs/DEPENDENCIES.md)**, the fork & pin
+register. Step 5 above is what nothing enforced until that page existed;
+`scripts/check-dependency-register.mjs` and
+`.github/workflows/dependency-register.yml` now watch it. Add a row when you add
+a fork or a `[patch.crates-io]`, and delete the row when you retire it — the
+check fails in both directions.
+
 ### Branching a dep is a signal to vendor it
 
 If we need to branch something to make it work, that's a strong candidate to

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -27,7 +27,7 @@ worse than no register.
 
 | | |
 |---|---|
-| **Kind** | Submodule fork (the *only* one in `z/`) |
+| **Kind** | Submodule fork — the only one in `z/` pointing at a repository **we control**. (`z/QED-it/librustzcash` is also a librustzcash fork, but a third party's, vendored reference-only like the rest of `z/`.) |
 | **Points at** | `https://github.com/free2z/librustzcash`, branch `f2z/drop-stale-rustcrypto-rc-pins` |
 | **Upstream** | `zcash/librustzcash`, `main` |
 | **Delta** | one 4-line deletion (the `block-buffer = "=0.11.0-rc.3"` / `crypto-common = "=0.2.0-rc.1"` workspace pins and the two `zcash_primitives` lines consuming them), plus the lockfile |

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,206 @@
+# Fork & pin register
+
+<!-- verified: 2026-08-31 -->
+
+What this repository carries that is **not stock upstream**, and **what event
+retires each one**.
+
+This page is an index and an exit-condition tracker. It deliberately does *not*
+restate the justifications — those live next to the declaration they justify,
+which is where someone editing the declaration will actually read them. Every
+row links out to its real home.
+
+`scripts/check-dependency-register.mjs` enforces this page. Its offline half
+runs on every pull request that touches the inputs; its network half runs weekly
+from `.github/workflows/dependency-register.yml` and opens an issue when an exit
+condition has fired, a fork has drifted behind its upstream, or a `.gitmodules`
+`branch` names a ref that no longer exists. See
+[Why a scheduled issue and not a gate](#why-a-scheduled-issue-and-not-a-gate).
+
+Everything below was verified against the live sources on the date in the
+marker above. Re-verify when you edit; a register of unverified restatements is
+worse than no register.
+
+---
+
+## 1. `z/zcash/librustzcash` → `free2z/librustzcash`
+
+| | |
+|---|---|
+| **Kind** | Submodule fork (the *only* one in `z/`) |
+| **Points at** | `https://github.com/free2z/librustzcash`, branch `f2z/drop-stale-rustcrypto-rc-pins` |
+| **Upstream** | `zcash/librustzcash`, `main` |
+| **Delta** | one 4-line deletion (the `block-buffer = "=0.11.0-rc.3"` / `crypto-common = "=0.2.0-rc.1"` workspace pins and the two `zcash_primitives` lines consuming them), plus the lockfile |
+| **Exit condition** | **`zcash/librustzcash#3010` merges** → move `.gitmodules` back to `https://github.com/zcash/librustzcash` + `main`, drop the pin |
+| **Why** | [`.gitmodules`](../.gitmodules) and the header of [`scripts/check-librustzcash-compat.mjs`](../scripts/check-librustzcash-compat.mjs) |
+
+**State on 2026-08-31:** #3010 open, not merged. Fork branch head
+`a2b8c95210`, 1 ahead of and 2 behind `zcash/librustzcash@main` (`aed0fdda`).
+Upstream still carries both pins on `main`.
+
+### Two traps this entry exists to remember
+
+**Two branches on the same fork.** #3010's head is
+`f2z/upstream-drop-stale-rustcrypto-rc-pins`, a *different* branch from the
+`f2z/drop-stale-rustcrypto-rc-pins` that `.gitmodules` tracks. They are both at
+`a2b8c95210` today, and nothing but this check keeps them that way: rebasing one
+and not the other means the thing we build is not the thing under review
+upstream. `--upstream` compares the two heads and fails when they differ.
+
+**Upstream has never run CI on #3010.** `check-runs` for `a2b8c95210` in
+`zcash/librustzcash` reports `total_count: 0` — upstream gates fork-PR workflows
+behind maintainer approval, so no workflow has ever started. "Wait for green
+upstream" is not a signal that exists here; our own `gate` and `rs / gate` are
+the only evidence the deletion is safe.
+
+---
+
+## 2. `[patch.crates-io] bip32` → `free2z/crates`
+
+| | |
+|---|---|
+| **Kind** | Cargo `[patch.crates-io]`, pinned by `rev` |
+| **Declared in** | [`wallet/zuuli/src-tauri/Cargo.toml`](../wallet/zuuli/src-tauri/Cargo.toml) |
+| **Points at** | `https://github.com/free2z/crates` @ `131d490ef75ccd23111cc7f3df91e4a88fc971ae` (branch `f2z/bip32-secp256k1-0.29`) |
+| **Upstream** | `iqlusioninc/crates`, `main` |
+| **Delta** | upstream `main` (`eb57d494`) with `bip32`'s `secp256k1-ffi` requirement held at 0.29 — one requirement, nothing else |
+| **Exit condition** | a real **`bip32 0.6.0`** release **and** the Zcash stack on **secp256k1 0.31** |
+| **Why** | the `[patch.crates-io]` comment block at the foot of `wallet/zuuli/src-tauri/Cargo.toml` |
+
+**Both halves of the exit condition are still unmet on 2026-08-31.**
+
+* crates.io `bip32`: `max_version` is `0.6.0-pre.1` (published 2025-01-27);
+  `max_stable_version` is `0.5.3`. No 0.6.0.
+* `z/zcash/librustzcash/Cargo.toml` still declares
+  `secp256k1 = { version = "0.29", ... }` and
+  `bip32 = { version = "=0.6.0-pre.1", ... }`. The stack has not moved to 0.31.
+  (crates.io's own `secp256k1` is at 0.33.1 — the constraint is librustzcash's
+  requirement, not the registry's ceiling.)
+
+The fork is **not** drifting: `131d490e` is 1 ahead of, 0 behind,
+`iqlusioninc/crates@main`. This is the only `[patch.crates-io]` in the
+repository, and the check fails if a second appears unregistered, or if any
+patch is pinned by `branch` instead of `rev`.
+
+---
+
+## 3. Deliberate version holds that look stale but are not
+
+Every version below is **verified against
+[`z/zcash/librustzcash/Cargo.toml`](../z/zcash/librustzcash/Cargo.toml)'s
+`[workspace.dependencies]`**, not against a summary. The check re-reads that
+file, so upstream bumping any of them turns this table red rather than leaving
+it quietly wrong.
+
+| Crate | Held at | Who forces it | Where the reason lives |
+|---|---|---|---|
+| `rusqlite` | 0.37 | **Upstream librustzcash** *and* a repository-wide singleton: `libsqlite3-sys` declares `links = "sqlite3"` and Cargo hard-errors on two versions of a `links` package | [`rs/Cargo.toml`](../rs/Cargo.toml) (`rusqlite` entry), `wallet/plugins/tauri-plugin-zcash/Cargo.toml`, upstream's own CocoaPods note |
+| `secrecy` | 0.8 | **Upstream librustzcash** workspace (`secrecy = "0.8"`). `wallet/zuuli/src-tauri` names it only to match what `tauri-plugin-zcash` already resolves | `wallet/zuuli/src-tauri/Cargo.toml` |
+| `secp256k1` | 0.29 | **Upstream librustzcash** workspace. Also the second half of row 2's exit condition | `z/zcash/librustzcash/Cargo.toml`; `wallet/zuuli/src-tauri/Cargo.toml` `[patch.crates-io]` block |
+| `rand` | 0.8 | **Upstream librustzcash** workspace (`rand = "0.8"`, `rand_core = "0.6"`). Not a repository-wide hold — `rs/` is on `rand_core 0.10` and the shipping wallet lock legitimately carries 0.8, 0.9 and 0.10 | `z/zcash/librustzcash/Cargo.toml`; `rs/Cargo.toml` (`rand_core` entry) |
+| `sha2` | 0.10 | **Upstream librustzcash** workspace (`sha2 = "0.10"`) — see the correction below | [`rs/Cargo.toml`](../rs/Cargo.toml) (`sha2` entry) |
+| `hkdf` | 0.12 | **Our own choice.** `hkdf` appears nowhere in librustzcash. 0.12 is the line that pairs with `sha2` 0.10 (both on `digest` 0.10), so it moves only when `sha2` does | [`rs/Cargo.toml`](../rs/Cargo.toml) (`hkdf` entry) |
+
+### Correction: the `sha2` hold's stated reason was wrong
+
+`rs/Cargo.toml` used to justify `sha2 = "0.10"` as resolving "to the copy
+`akd_core`'s graph already carries". **`akd_core` 0.13.0 does not depend on
+`sha2` at all** — its digest is `blake3`, and it reaches `sha2 0.10.9` only
+transitively through `ed25519-dalek 2`. The hold is still right; the reason was
+not. The real one, read off the shipping lock:
+
+`f2z-msg-identity` is linked into **`wallet/zuuli/src-tauri`**, and in that
+binary `sha2 0.10.9` is what `zcash_primitives`, `zcash_transparent`,
+`zcash_script`, `tauri-plugin-zcash`, `bip0039`, `bs58`, `tauri-codegen` and
+`wry` all resolve to — because librustzcash's workspace declares `sha2 = "0.10"`.
+Moving `f2z-msg-identity` to 0.11 would add a second SHA-256 to the shipped
+wallet. That is the constraint, and it is upstream's, not `akd_core`'s.
+
+The comment in `rs/Cargo.toml` has been corrected to say so.
+
+---
+
+## 4. `openmls_memory_storage`
+
+| | |
+|---|---|
+| **Kind** | Not a fork and not a pin — a **linked-but-unreachable** dependency with an open upstream defect |
+| **How it gets here** | a hard, non-optional dependency of `openmls_libcrux_crypto 0.4.0`, whose `Provider` owns a `MemoryStorage` field. Nothing in this tree ever hands it to OpenMLS |
+| **Exit condition** | an `openmls_memory_storage` release **newer than 0.6.0** whose `clear_proposal_queue` carries [openmls/openmls#2163](https://github.com/openmls/openmls/pull/2163) |
+| **Why, in full** | the `openmls_memory_storage` block in [`rs/deny.toml`](../rs/deny.toml), and the module header of `rs/crates/f2z-msg-store/src/storage_impl.rs` |
+
+Recorded here only because it is an exit condition and exit conditions belong in
+one place. Do not duplicate the prose — `rs/deny.toml` explains why it is
+deliberately *not* banned, and #850 is the PR that wrote it down.
+
+**State on 2026-08-31:** #2163 merged upstream 2026-08-31; latest
+`openmls_memory_storage` release is 0.6.0, published 2026-08-25 — before the
+fix. No release carries it. Read the release's source, not its version number.
+
+> Note for whoever follows the trail: PR #850's *title* cites
+> "openmls#2188", which does not exist. The body and `rs/deny.toml` both cite
+> **#2163**, which is the real PR. Trust the code comment.
+
+---
+
+## 5. `z/` submodule policy
+
+`z/` vendors Zcash-ecosystem repositories so we can depend on them **in source**
+and move the ecosystem forward (`AGENTS.md`, "The prime directive"). The build
+consequence is narrow:
+
+**Only `z/zcash/librustzcash` is a Cargo path dependency.** It is named by
+`wallet/plugins/tauri-plugin-zcash/Cargo.toml` (nine path deps) and reaches
+`wallet/zuuli/src-tauri` and `wallet/zuuallet/src-tauri` through that plugin. No
+other manifest in the tree points into `z/`. Bumping any other submodule cannot
+break a build.
+
+Two nuances that make "nothing else consumes `z/`" not strictly true, and one
+piece of housekeeping:
+
+* **`langchain/zcash/store.py` reads two submodules as document corpora.** It
+  loads `../../z/ZcashFoundation/zebra/` (`.rs`, `.toml`, `.yaml`, `.md`,
+  `.json`, `.proto`) and `../../z/zcash/zips/` (`.rst`) into a Chroma vector
+  store. Not a build input, but a consumer: emptying or moving either path
+  changes what the retriever indexes.
+* **`z/zcash/zcash` is archived upstream** (`archived: true`, last push
+  2026-07-19, the zcashd EOL merge). It is a **frozen artifact, not a tracked
+  upstream** — "stay on HEAD" does not apply, and `git submodule update
+  --remote` will never move it again.
+* **`z/hhanh00/warp` is dormant**: last push 2024-12-22, ~20 months ago, not
+  archived. Reference-only, and nobody should expect it to move.
+
+One claim worth correcting: **`z/hhanh00/zwallet` is *not* dormant** — last
+push 2026-08-23, eight days before this verification. Only `warp` is.
+
+### `.gitmodules` `branch` fields
+
+Every submodule declares a `branch`, and `git submodule update --remote`
+resolves it against the remote. A `branch` naming a ref that no longer exists on
+the remote makes that submodule un-updatable, silently, forever — which is
+exactly what happened to `z/ZcashFoundation/z3` when upstream renamed `dev` to
+`main` on 2026-05-30 and nobody noticed for months (fixed in #847). The check's
+`--upstream` mode `git ls-remote`s every `branch` in `.gitmodules`; it is the
+cheapest of the three rules and the one that would have caught that.
+
+---
+
+## Why a scheduled issue and not a gate
+
+The offline half of `scripts/check-dependency-register.mjs` — this page agreeing
+with `.gitmodules`, the `[patch.crates-io]` set, and librustzcash's declared
+versions — depends on nothing outside this repository, so it is safe to run on a
+pull request and it does.
+
+The network half is deliberately **not** a required check. Every one of its
+verdicts is a statement about somebody else's repository: whether `zcash/librustzcash`
+merged a PR, how many commits upstream `main` has gained, whether a remote still
+publishes a branch. Wiring that into branch protection hands a third party's
+merge queue — or an api.github.com outage — the ability to redden `main` for a
+contributor who touched none of it. Upstream merging #3010 is *good news*; it
+must not be an incident for whoever happens to open a PR that hour.
+
+So it runs weekly and on `workflow_dispatch`, and files (or updates) a single
+issue. The action item lands in the tracker where fork retirement belongs,
+nobody is blocked, and the thing that failed for months — nobody looking — is
+the thing that is now automated.

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -133,13 +133,20 @@ Recorded here only because it is an exit condition and exit conditions belong in
 one place. Do not duplicate the prose — `rs/deny.toml` explains why it is
 deliberately *not* banned, and #850 is the PR that wrote it down.
 
-**State on 2026-08-31:** #2163 merged upstream 2026-08-31; latest
+**State on 2026-08-31:** #2163 merged upstream 2026-08-31T07:18:26Z; latest
 `openmls_memory_storage` release is 0.6.0, published 2026-08-25 — before the
 fix. No release carries it. Read the release's source, not its version number.
 
-> Note for whoever follows the trail: PR #850's *title* cites
-> "openmls#2188", which does not exist. The body and `rs/deny.toml` both cite
-> **#2163**, which is the real PR. Trust the code comment.
+> Two upstream numbers, and they are not alternatives:
+> [openmls/openmls#2188](https://github.com/openmls/openmls/issues/2188) is the
+> **issue** — ours, "`clear_proposal_queue` removes a key nothing was stored
+> under, leaking every proposal body", closed as completed 2026-08-31 with
+> "Fixed by #2163" — and
+> [openmls/openmls#2163](https://github.com/openmls/openmls/pull/2163) is the
+> **pull request** that fixed it. PR #850's title cites the issue and
+> `rs/deny.toml` cites the PR; both are correct. The exit condition is keyed to
+> **#2163**, because a release either contains that commit or does not, whereas
+> a closed issue says nothing about what was published.
 
 ---
 
@@ -169,9 +176,15 @@ piece of housekeeping:
   --remote` will never move it again.
 * **`z/hhanh00/warp` is dormant**: last push 2024-12-22, ~20 months ago, not
   archived. Reference-only, and nobody should expect it to move.
+* **`z/hhanh00/zwallet` is recently touched, but the touch was a deprecation
+  notice.** Its last commit is 2026-08-23, `Update README to reflect Zcash
+  deprecation (#274)`; the one before it is 2026-06-04, a release chore. So
+  neither "dormant" nor "actively maintained" is the useful word — the fact a
+  reader needs when deciding whether to keep vendoring it is that its most
+  recent act upstream was to announce it is winding down.
 
-One claim worth correcting: **`z/hhanh00/zwallet` is *not* dormant** — last
-push 2026-08-23, eight days before this verification. Only `warp` is.
+Both are reference-only, so neither can break a build; the distinction matters
+only to whether we keep carrying them.
 
 ### `.gitmodules` `branch` fields
 

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -53,10 +53,23 @@ subtle = { version = "2", default-features = false }
 # four account leaves out of one account key with
 # `HKDF-Expand(PRK = ik_account, info = label, L)`; only the Expand half is
 # used, because the PRK is already a uniformly random BLAKE2b output and an
-# Extract over it would buy nothing. `sha2` is pinned to the 0.10 line so that
-# it resolves to the copy `akd_core`'s graph already carries rather than adding
-# a third: 0.11 is in this lock only because `ed25519-dalek` 3 uses it
-# internally, and a hash this crate names should be one a reader can find.
+# Extract over it would buy nothing.
+#
+# `sha2` is pinned to the 0.10 line, and the reason is the SHIPPING WALLET, not
+# this workspace. An earlier version of this comment said 0.10 "resolves to the
+# copy `akd_core`'s graph already carries"; that was wrong. `akd_core` 0.13.0
+# does not depend on `sha2` at all — its digest is `blake3` — and reaches
+# `sha2 0.10.9` only transitively through `ed25519-dalek` 2. The real
+# constraint: `f2z-msg-identity` is linked into `wallet/zuuli/src-tauri`, and in
+# that binary `sha2 0.10.9` is what `zcash_primitives`, `zcash_transparent`,
+# `zcash_script`, `tauri-plugin-zcash`, `bip0039`, `bs58`, `tauri-codegen` and
+# `wry` all resolve to, because librustzcash's workspace declares
+# `sha2 = "0.10"`. Moving to 0.11 would put a second SHA-256 in the shipped
+# wallet. `hkdf` 0.12 is the line that pairs with it (both on `digest` 0.10), so
+# the two move together and only when upstream librustzcash moves.
+# `docs/DEPENDENCIES.md` section 3 tracks that, and
+# `scripts/check-dependency-register.mjs` re-reads upstream's manifest so this
+# paragraph cannot go stale unnoticed a second time.
 hkdf = { version = "0.12", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 # The CSPRNG **boundary** for `ARCHITECTURE.md` §4.1's device keys, and not a

--- a/scripts/check-dependency-register.mjs
+++ b/scripts/check-dependency-register.mjs
@@ -160,12 +160,19 @@ const HOLD_TOKENS = [
 const NARRATIVE_TOKENS = [
   // 4. openmls_memory_storage — cross-referenced, never duplicated.
   "openmls_memory_storage",
+  // BOTH numbers, deliberately. #2188 is the issue and #2163 is the pull
+  // request that fixed it; an earlier draft of the register asserted that
+  // #2188 "does not exist" because `/pulls/2188` 404s for an issue number.
+  // Requiring both here means the register cannot lose the half that makes
+  // the other half unambiguous.
   "openmls/openmls#2163",
+  "openmls/openmls#2188",
   "rs/deny.toml",
   // 5. z/ submodule policy.
   "langchain/zcash/store.py",
   "z/zcash/zcash",
   "z/hhanh00/warp",
+  "z/hhanh00/zwallet",
 ];
 
 const VERIFIED_MARKER = /<!--\s*verified:\s*(\d{4}-\d{2}-\d{2})\s*-->/;
@@ -551,35 +558,69 @@ export async function upstreamFindings(snapshot, deps = {}) {
   for (const tracked of TRACKED) {
     // 2. Exit conditions.
     if (tracked.exitPr) {
-      const pull = await api(
-        `repos/${tracked.upstreamRepo}/pulls/${tracked.exitPr}`,
+      // RESOLVE VIA `/issues/{n}`, NEVER `/pulls/{n}`.
+      //
+      // On GitHub every pull request is also an issue, but not every issue is
+      // a pull request — and `/pulls/{n}` returns a bare 404 for an issue
+      // number. That 404 would surface here as a thrown error and exit 2,
+      // which dependency-register.yml reads as "the script or the network
+      // broke" rather than "someone registered an issue number". A wrong
+      // registration would then look exactly like an api.github.com outage.
+      //
+      // This is not hypothetical: the openmls defect tracked in section 4 of
+      // the register is issue #2188, fixed by pull request #2163, and
+      // confusing the two is what `/pulls/2188` 404ing already caused once.
+      // `/issues/{n}` resolves both shapes, and the `pull_request` key is what
+      // distinguishes them.
+      const reference = `${tracked.upstreamRepo}#${tracked.exitPr}`;
+      const issue = await api(
+        `repos/${tracked.upstreamRepo}/issues/${tracked.exitPr}`,
       );
-      if (pull.merged) {
+      const isPullRequest = issue.pull_request != null;
+      if (!isPullRequest) {
+        // An issue closing says the maintainers consider it handled; it does
+        // not say a release carries the fix, which is what retires a pin. So
+        // this is a finding about the *registration*, not about upstream.
+        note(
+          "drift",
+          `${tracked.id}: registered exit reference ${reference} is an issue, not a pull request`,
+          "An issue's state does not tell you whether the fix shipped. Register the pull " +
+            "request that closes it, so `merged` is the signal.",
+        );
+      } else if (issue.pull_request.merged_at) {
         note(
           "exit",
-          `${tracked.id}: ${tracked.upstreamRepo}#${tracked.exitPr} MERGED (${pull.merged_at}) — drop the fork`,
+          `${tracked.id}: ${reference} MERGED (${issue.pull_request.merged_at}) — drop the fork`,
           `Move the submodule back to https://github.com/${tracked.upstreamRepo} + \`${tracked.upstreamBranch}\`, ` +
             `drop the pin, and retire section for \`${tracked.id}\` in ${REGISTER_PATH}.`,
         );
-      } else if (pull.state === "closed") {
+      } else if (issue.state === "closed") {
         note(
           "drift",
-          `${tracked.id}: ${tracked.upstreamRepo}#${tracked.exitPr} was CLOSED without merging`,
+          `${tracked.id}: ${reference} was CLOSED without merging`,
           "The exit condition can never fire. Either reopen it upstream or the fork needs a new plan.",
         );
       }
+
       // Upstream gates fork-PR workflows behind maintainer approval, so this
       // is expected to be zero. It is recorded rather than asserted: the point
       // is that "wait for green upstream" is not a signal available here.
-      const checks = await api(
-        `repos/${tracked.upstreamRepo}/commits/${pull.head.sha}/check-runs`,
-      );
-      if (checks.total_count === 0) {
-        note(
-          "info",
-          `${tracked.id}: upstream has still run no CI on ${tracked.upstreamRepo}#${tracked.exitPr}`,
-          "`check-runs` total_count is 0. Our own `gate` / `rs / gate` remain the only evidence.",
+      //
+      // Only a pull request has a head commit to ask about.
+      if (isPullRequest) {
+        const pull = await api(
+          `repos/${tracked.upstreamRepo}/pulls/${tracked.exitPr}`,
         );
+        const checks = await api(
+          `repos/${tracked.upstreamRepo}/commits/${pull.head.sha}/check-runs`,
+        );
+        if (checks.total_count === 0) {
+          note(
+            "info",
+            `${tracked.id}: upstream has still run no CI on ${reference}`,
+            "`check-runs` total_count is 0. Our own `gate` / `rs / gate` remain the only evidence.",
+          );
+        }
       }
     }
     if (tracked.exitCrate) {
@@ -891,15 +932,20 @@ async function runUpstreamSelfTest() {
   /// Every reply an unremarkable week produces: PR open, no upstream CI, fork
   /// level with its base, both fork branches at one commit, every remote branch
   /// present.
+  ///
+  /// `/issues/{n}` carries a `pull_request` object, which is how GitHub marks
+  /// an issue that is also a pull request — the distinction the resolution
+  /// above depends on, so the fake has to reproduce it rather than flatten it.
   const quiet = () => ({
     githubJson: async (route) => {
-      if (/\/pulls\/\d+$/.test(route)) {
+      if (/\/issues\/\d+$/.test(route)) {
         return {
-          merged: false,
-          merged_at: null,
           state: "open",
-          head: { sha: "a".repeat(40) },
+          pull_request: { merged_at: null },
         };
+      }
+      if (/\/pulls\/\d+$/.test(route)) {
+        return { head: { sha: "a".repeat(40) } };
       }
       if (route.endsWith("/check-runs")) return { total_count: 4 };
       if (route.includes("/compare/")) {
@@ -930,12 +976,10 @@ async function runUpstreamSelfTest() {
       {
         ...quiet(),
         githubJson: async (route) => {
-          if (/\/pulls\/\d+$/.test(route)) {
+          if (/\/issues\/\d+$/.test(route)) {
             return {
-              merged: true,
-              merged_at: "2026-09-01T00:00:00Z",
               state: "closed",
-              head: { sha: "a".repeat(40) },
+              pull_request: { merged_at: "2026-09-01T00:00:00Z" },
             };
           }
           return quiet().githubJson(route);
@@ -949,19 +993,35 @@ async function runUpstreamSelfTest() {
       {
         ...quiet(),
         githubJson: async (route) => {
-          if (/\/pulls\/\d+$/.test(route)) {
-            return {
-              merged: false,
-              merged_at: null,
-              state: "closed",
-              head: { sha: "a".repeat(40) },
-            };
+          if (/\/issues\/\d+$/.test(route)) {
+            return { state: "closed", pull_request: { merged_at: null } };
           }
           return quiet().githubJson(route);
         },
       },
       baseline,
       "CLOSED without merging",
+    ],
+    [
+      // The defect the coordinator caught in review: `/pulls/{n}` 404s on an
+      // issue number, so registering an issue used to crash the run and read
+      // as an outage. It must now be a named finding instead.
+      "the registered exit reference is an issue, not a pull request",
+      {
+        ...quiet(),
+        githubJson: async (route) => {
+          if (/\/issues\/\d+$/.test(route)) {
+            // No `pull_request` key: this is what a plain issue looks like.
+            return { state: "closed", state_reason: "completed" };
+          }
+          if (/\/pulls\/\d+$/.test(route)) {
+            throw new Error("GET pulls -> 404 Not Found");
+          }
+          return quiet().githubJson(route);
+        },
+      },
+      baseline,
+      "is an issue, not a pull request",
     ],
     [
       "the fork falls behind its upstream base",

--- a/scripts/check-dependency-register.mjs
+++ b/scripts/check-dependency-register.mjs
@@ -1,0 +1,1105 @@
+#!/usr/bin/env node
+//
+// Enforce `docs/DEPENDENCIES.md` — the fork & pin register.
+//
+// `AGENTS.md` says a fork is "a bridge, never a parking spot": branch, PR, pin
+// transiently, and move the submodule back to upstream `main` the moment the PR
+// merges. That policy is right and nothing enforced step 5. Two things went
+// wrong before this script existed, and both were found only because a human
+// went looking:
+//
+//   * the librustzcash fork sat ten commits behind upstream `main`, so the
+//     thing we built was not the thing under review upstream; and
+//   * `z/ZcashFoundation/z3`'s `.gitmodules` `branch` named `dev` for months
+//     after upstream deleted it, which made `git submodule update --remote`
+//     unable to resolve that submodule at all — silently, and forever (#847).
+//
+// Neither is a code change, so no build could go red for either. This script is
+// what goes red instead.
+//
+// TWO HALVES, ON PURPOSE.
+//
+//   OFFLINE (default). Reads only files in this repository: `.gitmodules`, the
+//   manifests carrying `[patch.crates-io]`, `z/zcash/librustzcash/Cargo.toml`
+//   and the register itself. Deterministic, so it is safe on a pull request and
+//   runs on one.
+//
+//   UPSTREAM (`--upstream`). Asks github.com and crates.io whether an exit
+//   condition has fired, how far a fork has drifted, and whether every
+//   `.gitmodules` `branch` still exists on its remote. Every verdict here is a
+//   statement about someone else's repository, so this is deliberately NOT a
+//   required check: upstream merging zcash/librustzcash#3010 is good news and
+//   must not redden `main` for a contributor who touched none of it. It runs
+//   weekly from `.github/workflows/dependency-register.yml` and files an issue.
+//
+// The registry below is a set of reviewed literals, not values derived from the
+// files under judgement — deriving them would make a stale pin self-approving,
+// the same reason `scripts/check-librustzcash-compat.mjs` holds its gitlink as
+// a literal.
+//
+// Usage:
+//   node scripts/check-dependency-register.mjs              offline verdict
+//   node scripts/check-dependency-register.mjs --self-test   negative controls
+//   node scripts/check-dependency-register.mjs --upstream    network verdict
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const REGISTER_PATH = "docs/DEPENDENCIES.md";
+const GITMODULES_PATH = ".gitmodules";
+const LIBRUSTZCASH_MANIFEST = "z/zcash/librustzcash/Cargo.toml";
+
+/// Manifests allowed to carry a `[patch.crates-io]` section. A patch anywhere
+/// else is a fork nobody registered, so the enumeration is the point: the
+/// offline check reads every tracked `Cargo.toml` and fails on a patch section
+/// in a file that is not on this list.
+const PATCHABLE_MANIFESTS = ["wallet/zuuli/src-tauri/Cargo.toml"];
+
+/// GitHub owners whose repositories are *ours*. A `.gitmodules` `url` under one
+/// of these is by definition a fork we are carrying, and must be registered.
+const FORK_OWNERS = new Set(["free2z"]);
+
+/// How far behind its upstream base a fork branch may fall before this is a
+/// finding. Ten is the drift that was discovered by hand — rebasing a one-commit
+/// fork forward is cheap and scripted, so the threshold is set where the failure
+/// actually happened rather than somewhere comfortable.
+const DEFAULT_DRIFT_LIMIT = 10;
+
+/// How stale the register's `<!-- verified: -->` marker may get before the
+/// weekly run says so. Offline runs only parse the date; letting time alone
+/// fail a pull request would be a gate on the calendar.
+const REGISTER_MAX_AGE_DAYS = 90;
+
+/// Every fork and pin this repository carries, with the event that retires it.
+///
+/// `registerTokens` are strings `docs/DEPENDENCIES.md` must contain. They are
+/// what stops the register from being edited into vagueness while the pin stays:
+/// deleting the exit condition from the page fails here.
+const TRACKED = [
+  {
+    id: "z/zcash/librustzcash",
+    kind: "submodule",
+    forkUrl: "https://github.com/free2z/librustzcash",
+    forkBranch: "f2z/drop-stale-rustcrypto-rc-pins",
+    /// #3010's head is a DIFFERENT branch on the same fork. Both must stay at
+    /// the same commit or we are building something upstream is not reviewing.
+    prHeadBranch: "f2z/upstream-drop-stale-rustcrypto-rc-pins",
+    upstreamRepo: "zcash/librustzcash",
+    upstreamBranch: "main",
+    exitPr: 3010,
+    driftLimit: DEFAULT_DRIFT_LIMIT,
+    registerTokens: [
+      "https://github.com/free2z/librustzcash",
+      "f2z/drop-stale-rustcrypto-rc-pins",
+      "f2z/upstream-drop-stale-rustcrypto-rc-pins",
+      "zcash/librustzcash#3010",
+    ],
+  },
+  {
+    id: "bip32",
+    kind: "patch",
+    manifest: "wallet/zuuli/src-tauri/Cargo.toml",
+    forkUrl: "https://github.com/free2z/crates",
+    forkRev: "131d490ef75ccd23111cc7f3df91e4a88fc971ae",
+    upstreamRepo: "iqlusioninc/crates",
+    upstreamBranch: "main",
+    /// Not a PR. This one retires on a registry event plus an upstream version
+    /// move, both of which `--upstream` checks by name.
+    exitCrate: { name: "bip32", stableAtLeast: "0.6.0" },
+    exitDependencyMove: { crate: "secp256k1", awayFrom: "0.29" },
+    driftLimit: DEFAULT_DRIFT_LIMIT,
+    registerTokens: [
+      "https://github.com/free2z/crates",
+      "131d490ef75ccd23111cc7f3df91e4a88fc971ae",
+      "0.6.0-pre.1",
+    ],
+  },
+];
+
+/// Version requirements that are UPSTREAM librustzcash's, not ours, read back
+/// out of `z/zcash/librustzcash/Cargo.toml`'s `[workspace.dependencies]`.
+///
+/// This is the rule that keeps section 3 of the register honest. Each entry is
+/// a claim the register makes about who forces a hold; if upstream bumps
+/// `rusqlite` to 0.38, the register's row becomes false and this goes red
+/// instead of the page quietly lying.
+const UPSTREAM_HOLDS = new Map([
+  ["rusqlite", "0.37"],
+  ["secrecy", "0.8"],
+  ["secp256k1", "0.29"],
+  ["rand", "0.8"],
+  ["sha2", "0.10"],
+  ["bip32", "=0.6.0-pre.1"],
+]);
+
+/// Holds the register attributes to *us*. The claim being checked is the
+/// negative one — that librustzcash does not declare these at all — because
+/// "our own choice" stops being true the moment upstream takes a position.
+const OUR_OWN_HOLDS = new Set(["hkdf"]);
+
+/// Strings section 3 of the register must contain, so a hold cannot be dropped
+/// from the page while the version is still pinned in the tree.
+const HOLD_TOKENS = [
+  "`rusqlite` | 0.37",
+  "`secrecy` | 0.8",
+  "`secp256k1` | 0.29",
+  "`rand` | 0.8",
+  "`sha2` | 0.10",
+  "`hkdf` | 0.12",
+];
+
+/// The remaining register sections that are not a fork or a hold, each with the
+/// token that proves the section survived an edit.
+const NARRATIVE_TOKENS = [
+  // 4. openmls_memory_storage — cross-referenced, never duplicated.
+  "openmls_memory_storage",
+  "openmls/openmls#2163",
+  "rs/deny.toml",
+  // 5. z/ submodule policy.
+  "langchain/zcash/store.py",
+  "z/zcash/zcash",
+  "z/hhanh00/warp",
+];
+
+const VERIFIED_MARKER = /<!--\s*verified:\s*(\d{4}-\d{2}-\d{2})\s*-->/;
+
+// ---------------------------------------------------------------------------
+// Parsing. Line-oriented, matching the other check scripts in this repository:
+// the alternative is a dependency, and these files are written in a plain
+// subset that this reads exactly.
+// ---------------------------------------------------------------------------
+
+/// `.gitmodules` as `[{ name, path, url, branch }]`.
+export function parseGitmodules(text) {
+  const entries = [];
+  let current = null;
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    const header = /^\[submodule "(.+)"\]$/.exec(line);
+    if (header) {
+      current = { name: header[1], path: null, url: null, branch: null };
+      entries.push(current);
+      continue;
+    }
+    if (!current || line.startsWith("#")) continue;
+    const pair = /^([a-zA-Z]+)\s*=\s*(.+)$/.exec(line);
+    if (!pair) continue;
+    const [, key, value] = pair;
+    if (key in current) current[key] = value.trim();
+  }
+  return entries;
+}
+
+/// The `[patch.crates-io]` entries of one manifest, as
+/// `[{ crate, git, rev, branch }]`. Absent section yields `[]`.
+export function parsePatchSection(text) {
+  const lines = text.split("\n");
+  const start = lines.findIndex((line) => line.trim() === "[patch.crates-io]");
+  if (start < 0) return [];
+  const patches = [];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index].trim();
+    if (line.startsWith("[")) break;
+    if (!line || line.startsWith("#")) continue;
+    const pair = /^([A-Za-z0-9_-]+)\s*=\s*(.+)$/.exec(line);
+    if (!pair) continue;
+    const [, crate, value] = pair;
+    patches.push({
+      crate,
+      git: /git\s*=\s*"([^"]+)"/.exec(value)?.[1] ?? null,
+      rev: /rev\s*=\s*"([^"]+)"/.exec(value)?.[1] ?? null,
+      branch: /branch\s*=\s*"([^"]+)"/.exec(value)?.[1] ?? null,
+    });
+  }
+  return patches;
+}
+
+/// The version requirement each crate carries in one `[workspace.dependencies]`
+/// table. Continuation lines are joined on brace balance so a multi-line entry
+/// is read whole rather than half.
+export function parseWorkspaceDependencies(text) {
+  const lines = text.split("\n");
+  const start = lines.findIndex(
+    (line) => line.trim() === "[workspace.dependencies]",
+  );
+  if (start < 0) return new Map();
+  const versions = new Map();
+  let buffer = "";
+  let depth = 0;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (depth === 0 && line.trimStart().startsWith("[")) break;
+    const code = withoutComment(line);
+    buffer += (buffer ? "\n" : "") + code;
+    for (const character of code) {
+      if (character === "{" || character === "[") depth += 1;
+      if (character === "}" || character === "]") depth -= 1;
+    }
+    if (depth > 0) continue;
+    const pair = /^([A-Za-z0-9_-]+)\s*=\s*([\s\S]+)$/.exec(buffer.trim());
+    buffer = "";
+    depth = 0;
+    if (!pair) continue;
+    const [, crate, value] = pair;
+    const inline = /^"([^"]+)"\s*$/.exec(value.trim());
+    versions.set(
+      crate,
+      inline ? inline[1] : (/version\s*=\s*"([^"]+)"/.exec(value)?.[1] ?? null),
+    );
+  }
+  return versions;
+}
+
+function ownerOf(url) {
+  return /github\.com[/:]([^/]+)\//.exec(url)?.[1] ?? null;
+}
+
+/// Strip a TOML line comment without eating a `#` that lives inside a string.
+function withoutComment(line) {
+  let quoted = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (character === '"' && line[index - 1] !== "\\") quoted = !quoted;
+    if (character === "#" && !quoted) return line.slice(0, index);
+  }
+  return line;
+}
+
+/// Compare two dotted version requirements numerically, ignoring any `=`/`^`
+/// operator and treating a pre-release suffix as lower than the release. Enough
+/// for "is the published stable version at least X", which is all it is used for.
+export function atLeast(candidate, floor) {
+  const parse = (value) => {
+    const [core, pre] = String(value).replace(/^[=^~><]+/, "").split("-");
+    return {
+      parts: core.split(".").map((piece) => Number.parseInt(piece, 10) || 0),
+      pre: pre ?? null,
+    };
+  };
+  const left = parse(candidate);
+  const right = parse(floor);
+  for (let index = 0; index < 3; index += 1) {
+    const a = left.parts[index] ?? 0;
+    const b = right.parts[index] ?? 0;
+    if (a !== b) return a > b;
+  }
+  if (left.pre && !right.pre) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Offline verdict.
+// ---------------------------------------------------------------------------
+
+/// `snapshot` is `{ gitmodules, librustzcash, register, manifests }`, where
+/// `manifests` maps every tracked `Cargo.toml` path to its contents. Taking a
+/// snapshot rather than reading files here is what lets the self-test mutate
+/// one input at a time and watch this fail.
+export function offlineFailures(snapshot) {
+  const failures = [];
+  const submodules = parseGitmodules(snapshot.gitmodules);
+
+  if (submodules.length === 0) {
+    failures.push(".gitmodules declares no submodules");
+  }
+  for (const submodule of submodules) {
+    if (!submodule.url) {
+      failures.push(`${submodule.name}: .gitmodules entry has no url`);
+    }
+    // The z3 failure mode starts here: an entry with no `branch` cannot be
+    // resolved by `git submodule update --remote` either.
+    if (!submodule.branch) {
+      failures.push(
+        `${submodule.name}: .gitmodules entry declares no branch, so ` +
+          "`git submodule update --remote` cannot resolve it",
+      );
+    }
+  }
+
+  // Forks must be registered, in both directions.
+  const registeredSubmodules = new Map(
+    TRACKED.filter((entry) => entry.kind === "submodule").map((entry) => [
+      entry.id,
+      entry,
+    ]),
+  );
+  for (const submodule of submodules) {
+    if (!submodule.url || !FORK_OWNERS.has(ownerOf(submodule.url))) continue;
+    const tracked = registeredSubmodules.get(submodule.path ?? submodule.name);
+    if (!tracked) {
+      failures.push(
+        `${submodule.path ?? submodule.name}: points at a fork we control ` +
+          `(${submodule.url}) and is not in ${REGISTER_PATH}'s registry`,
+      );
+      continue;
+    }
+    if (submodule.url !== tracked.forkUrl) {
+      failures.push(
+        `${tracked.id}: registered fork url ${tracked.forkUrl}, .gitmodules says ${submodule.url}`,
+      );
+    }
+    if (submodule.branch !== tracked.forkBranch) {
+      failures.push(
+        `${tracked.id}: registered fork branch ${tracked.forkBranch}, .gitmodules says ${submodule.branch}`,
+      );
+    }
+  }
+  for (const tracked of registeredSubmodules.values()) {
+    const present = submodules.some(
+      (submodule) => (submodule.path ?? submodule.name) === tracked.id,
+    );
+    if (!present) {
+      failures.push(
+        `${tracked.id}: registered as a fork but absent from .gitmodules — ` +
+          "retire the register entry when the fork goes",
+      );
+    }
+  }
+
+  // `[patch.crates-io]` must be registered, pinned by rev, and confined to the
+  // manifests that are allowed one.
+  const registeredPatches = new Map(
+    TRACKED.filter((entry) => entry.kind === "patch").map((entry) => [
+      `${entry.manifest}#${entry.id}`,
+      entry,
+    ]),
+  );
+  const seenPatches = new Set();
+  for (const [manifestPath, contents] of Object.entries(snapshot.manifests)) {
+    const patches = parsePatchSection(contents);
+    if (patches.length && !PATCHABLE_MANIFESTS.includes(manifestPath)) {
+      failures.push(
+        `${manifestPath}: carries [patch.crates-io] and is not a registered patch site`,
+      );
+      continue;
+    }
+    for (const patch of patches) {
+      const key = `${manifestPath}#${patch.crate}`;
+      seenPatches.add(key);
+      const tracked = registeredPatches.get(key);
+      if (!tracked) {
+        failures.push(
+          `${key}: [patch.crates-io] entry is not in ${REGISTER_PATH}'s registry`,
+        );
+        continue;
+      }
+      // A moving branch is not a reproducible build and `--locked` has to mean
+      // something, so `rev` is the only accepted pin.
+      if (patch.branch || !patch.rev) {
+        failures.push(
+          `${key}: [patch.crates-io] must be pinned by rev, never by branch`,
+        );
+      }
+      if (patch.rev && patch.rev !== tracked.forkRev) {
+        failures.push(
+          `${key}: registered rev ${tracked.forkRev}, manifest says ${patch.rev}`,
+        );
+      }
+      if (patch.git && patch.git !== tracked.forkUrl) {
+        failures.push(
+          `${key}: registered fork url ${tracked.forkUrl}, manifest says ${patch.git}`,
+        );
+      }
+    }
+  }
+  for (const [key, tracked] of registeredPatches) {
+    if (!seenPatches.has(key)) {
+      failures.push(
+        `${key}: registered as a patch but absent from ${tracked.manifest} — ` +
+          "retire the register entry when the patch goes",
+      );
+    }
+  }
+
+  // Section 3: every "upstream forces it" claim, re-read from upstream.
+  const workspace = parseWorkspaceDependencies(snapshot.librustzcash);
+  if (workspace.size === 0) {
+    failures.push(
+      `${LIBRUSTZCASH_MANIFEST}: no [workspace.dependencies] found — ` +
+        "is the submodule checked out? (git submodule update --init z/zcash/librustzcash)",
+    );
+  } else {
+    for (const [crate, expected] of UPSTREAM_HOLDS) {
+      const actual = workspace.get(crate);
+      if (actual === undefined) {
+        failures.push(
+          `${crate}: register says upstream librustzcash forces ${expected}, ` +
+            "but it declares no such workspace dependency any more",
+        );
+      } else if (actual !== expected) {
+        failures.push(
+          `${crate}: register says upstream librustzcash forces ${expected}, ` +
+            `it now declares ${actual} — the hold's stated justification is stale`,
+        );
+      }
+    }
+    for (const crate of OUR_OWN_HOLDS) {
+      if (workspace.has(crate)) {
+        failures.push(
+          `${crate}: register calls this hold our own choice, but upstream ` +
+            `librustzcash now declares ${workspace.get(crate)} — re-attribute it`,
+        );
+      }
+    }
+  }
+
+  // The register itself.
+  const register = snapshot.register;
+  const marker = VERIFIED_MARKER.exec(register);
+  if (!marker) {
+    failures.push(
+      `${REGISTER_PATH}: missing its <!-- verified: YYYY-MM-DD --> marker`,
+    );
+  } else if (Number.isNaN(Date.parse(`${marker[1]}T00:00:00Z`))) {
+    failures.push(`${REGISTER_PATH}: verified marker ${marker[1]} is not a date`);
+  }
+  const requiredTokens = [
+    ...TRACKED.flatMap((entry) => [entry.id, ...entry.registerTokens]),
+    ...HOLD_TOKENS,
+    ...NARRATIVE_TOKENS,
+  ];
+  for (const token of requiredTokens) {
+    if (!register.includes(token)) {
+      failures.push(`${REGISTER_PATH}: does not mention \`${token}\``);
+    }
+  }
+
+  return failures;
+}
+
+// ---------------------------------------------------------------------------
+// Upstream verdict. Network, and therefore never a required check.
+// ---------------------------------------------------------------------------
+
+async function githubJson(route) {
+  const headers = {
+    accept: "application/vnd.github+json",
+    "user-agent": "free2z-zuu-dependency-register",
+  };
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  if (token) headers.authorization = `Bearer ${token}`;
+  const response = await fetch(`https://api.github.com/${route}`, { headers });
+  if (!response.ok) {
+    throw new Error(`GET ${route} -> ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+async function cratesIo(name) {
+  const response = await fetch(`https://crates.io/api/v1/crates/${name}`, {
+    headers: { "user-agent": "free2z-zuu-dependency-register" },
+  });
+  if (!response.ok) {
+    throw new Error(`crates.io ${name} -> ${response.status}`);
+  }
+  return response.json();
+}
+
+function remoteHasBranch(url, branch) {
+  const output = execFileSync(
+    "git",
+    ["ls-remote", "--heads", url, `refs/heads/${branch}`],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  return output.trim().length > 0;
+}
+
+/// Findings are `{ severity, headline, detail }`. `severity: "exit"` means an
+/// exit condition has fired and the fork should be retired — the good outcome,
+/// reported loudly rather than as a failure of ours.
+export async function upstreamFindings(snapshot, deps = {}) {
+  const api = deps.githubJson ?? githubJson;
+  const registry = deps.cratesIo ?? cratesIo;
+  const lsRemote = deps.remoteHasBranch ?? remoteHasBranch;
+  const today = deps.today ?? new Date();
+  const findings = [];
+  const note = (severity, headline, detail) =>
+    findings.push({ severity, headline, detail });
+
+  // 1. `.gitmodules` branches that do not exist on their remote. The cheapest
+  //    of the three rules, and the one that would have caught z3.
+  for (const submodule of parseGitmodules(snapshot.gitmodules)) {
+    if (!submodule.url || !submodule.branch) continue;
+    let exists;
+    try {
+      exists = lsRemote(submodule.url, submodule.branch);
+    } catch (error) {
+      note(
+        "unknown",
+        `${submodule.path ?? submodule.name}: could not reach ${submodule.url}`,
+        String(error.message ?? error),
+      );
+      continue;
+    }
+    if (!exists) {
+      note(
+        "drift",
+        `${submodule.path ?? submodule.name}: .gitmodules branch \`${submodule.branch}\` does not exist on ${submodule.url}`,
+        "`git submodule update --remote` cannot resolve this submodule at all. " +
+          "Upstream probably renamed or deleted the branch; point `.gitmodules` at the new one.",
+      );
+    }
+  }
+
+  for (const tracked of TRACKED) {
+    // 2. Exit conditions.
+    if (tracked.exitPr) {
+      const pull = await api(
+        `repos/${tracked.upstreamRepo}/pulls/${tracked.exitPr}`,
+      );
+      if (pull.merged) {
+        note(
+          "exit",
+          `${tracked.id}: ${tracked.upstreamRepo}#${tracked.exitPr} MERGED (${pull.merged_at}) — drop the fork`,
+          `Move the submodule back to https://github.com/${tracked.upstreamRepo} + \`${tracked.upstreamBranch}\`, ` +
+            `drop the pin, and retire section for \`${tracked.id}\` in ${REGISTER_PATH}.`,
+        );
+      } else if (pull.state === "closed") {
+        note(
+          "drift",
+          `${tracked.id}: ${tracked.upstreamRepo}#${tracked.exitPr} was CLOSED without merging`,
+          "The exit condition can never fire. Either reopen it upstream or the fork needs a new plan.",
+        );
+      }
+      // Upstream gates fork-PR workflows behind maintainer approval, so this
+      // is expected to be zero. It is recorded rather than asserted: the point
+      // is that "wait for green upstream" is not a signal available here.
+      const checks = await api(
+        `repos/${tracked.upstreamRepo}/commits/${pull.head.sha}/check-runs`,
+      );
+      if (checks.total_count === 0) {
+        note(
+          "info",
+          `${tracked.id}: upstream has still run no CI on ${tracked.upstreamRepo}#${tracked.exitPr}`,
+          "`check-runs` total_count is 0. Our own `gate` / `rs / gate` remain the only evidence.",
+        );
+      }
+    }
+    if (tracked.exitCrate) {
+      const crate = await registry(tracked.exitCrate.name);
+      const stable = crate.crate.max_stable_version;
+      if (stable && atLeast(stable, tracked.exitCrate.stableAtLeast)) {
+        note(
+          "exit",
+          `${tracked.id}: crates.io now publishes ${tracked.exitCrate.name} ${stable}`,
+          `The register expects the patch to retire once a real ${tracked.exitCrate.name} ` +
+            `${tracked.exitCrate.stableAtLeast} exists. Re-read the second half of the exit ` +
+            "condition (the Zcash stack's secp256k1 version) before dropping the patch.",
+        );
+      }
+    }
+    if (tracked.exitDependencyMove) {
+      const workspace = parseWorkspaceDependencies(snapshot.librustzcash);
+      const actual = workspace.get(tracked.exitDependencyMove.crate);
+      if (actual && actual !== tracked.exitDependencyMove.awayFrom) {
+        note(
+          "exit",
+          `${tracked.id}: librustzcash moved ${tracked.exitDependencyMove.crate} to ${actual}`,
+          "That is the second half of this patch's exit condition. Check the first half " +
+            "(a real bip32 0.6.0 on crates.io) and drop the patch when both hold.",
+        );
+      }
+    }
+
+    // 3. Drift behind the upstream base.
+    const head = tracked.forkRev ?? tracked.forkBranch;
+    const forkRepo = tracked.forkUrl.replace("https://github.com/", "");
+    const [forkOwner, forkName] = forkRepo.split("/");
+    const comparison = await api(
+      `repos/${tracked.upstreamRepo}/compare/${encodeURIComponent(tracked.upstreamBranch)}...${forkOwner}:${forkName}:${encodeURIComponent(head)}`,
+    );
+    if (comparison.behind_by > tracked.driftLimit) {
+      note(
+        "drift",
+        `${tracked.id}: fork is ${comparison.behind_by} commits behind ${tracked.upstreamRepo}@${tracked.upstreamBranch} (limit ${tracked.driftLimit})`,
+        "Rebase the fork forward onto upstream `main` — a bridge that stops moving is a parking spot.",
+      );
+    }
+
+    // 4. A fork whose PR head is a different branch can silently diverge from
+    //    the branch we actually build. This is exactly the trap #852 hit.
+    if (tracked.prHeadBranch) {
+      const built = await api(
+        `repos/${forkRepo}/branches/${encodeURIComponent(tracked.forkBranch)}`,
+      );
+      const reviewed = await api(
+        `repos/${forkRepo}/branches/${encodeURIComponent(tracked.prHeadBranch)}`,
+      );
+      if (built.commit.sha !== reviewed.commit.sha) {
+        note(
+          "drift",
+          `${tracked.id}: the branch we build and the branch upstream reviews have diverged`,
+          `\`${tracked.forkBranch}\` is at ${built.commit.sha.slice(0, 10)}, ` +
+            `\`${tracked.prHeadBranch}\` (the head of ${tracked.upstreamRepo}#${tracked.exitPr}) ` +
+            `is at ${reviewed.commit.sha.slice(0, 10)}. Rebase both or upstream is reviewing something else.`,
+        );
+      }
+    }
+  }
+
+  // 5. Register staleness. Time alone must never fail a pull request, so this
+  //    lives only in the scheduled half.
+  const marker = VERIFIED_MARKER.exec(snapshot.register);
+  if (marker) {
+    const age = Math.floor(
+      (today.getTime() - Date.parse(`${marker[1]}T00:00:00Z`)) / 86_400_000,
+    );
+    if (age > REGISTER_MAX_AGE_DAYS) {
+      note(
+        "drift",
+        `${REGISTER_PATH}: last verified ${marker[1]}, ${age} days ago`,
+        `Re-verify every row against its live source and move the marker. ` +
+          `A register of unverified restatements is worse than no register.`,
+      );
+    }
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshots and CLI.
+// ---------------------------------------------------------------------------
+
+function read(relative) {
+  const absolute = path.join(REPO_ROOT, relative);
+  return fs.existsSync(absolute) ? fs.readFileSync(absolute, "utf8") : "";
+}
+
+function trackedManifests() {
+  const output = execFileSync("git", ["ls-files", "--", "*Cargo.toml"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+  return output.split("\n").filter(Boolean);
+}
+
+export function liveSnapshot() {
+  const manifests = {};
+  for (const manifest of trackedManifests()) {
+    manifests[manifest] = read(manifest);
+  }
+  return {
+    gitmodules: read(GITMODULES_PATH),
+    librustzcash: read(LIBRUSTZCASH_MANIFEST),
+    register: read(REGISTER_PATH),
+    manifests,
+  };
+}
+
+function requireFailure(name, snapshot, expected) {
+  const failures = offlineFailures(snapshot);
+  if (!failures.some((failure) => failure.includes(expected))) {
+    throw new Error(
+      `mutation escaped policy: ${name}\n  expected a failure containing: ${expected}\n  got: ${JSON.stringify(failures, null, 2)}`,
+    );
+  }
+}
+
+function runSelfTest() {
+  const baseline = liveSnapshot();
+  const clean = offlineFailures(baseline);
+  if (clean.length) {
+    throw new Error(
+      `self-test needs a passing baseline, got:\n${clean.map((f) => `  - ${f}`).join("\n")}`,
+    );
+  }
+
+  const withGitmodules = (text) => ({ ...baseline, gitmodules: text });
+  const withRegister = (text) => ({ ...baseline, register: text });
+  const withLibrustzcash = (text) => ({ ...baseline, librustzcash: text });
+  const withManifest = (relative, text) => ({
+    ...baseline,
+    manifests: { ...baseline.manifests, [relative]: text },
+  });
+
+  const cases = [
+    [
+      "a .gitmodules branch field is deleted (the z3 failure mode's precursor)",
+      withGitmodules(
+        baseline.gitmodules.replace("\tbranch = main\n", "", 1),
+      ),
+      "declares no branch",
+    ],
+    [
+      "the fork submodule quietly moves to another branch",
+      withGitmodules(
+        baseline.gitmodules.replace(
+          "branch = f2z/drop-stale-rustcrypto-rc-pins",
+          "branch = f2z/some-other-branch",
+        ),
+      ),
+      "registered fork branch f2z/drop-stale-rustcrypto-rc-pins",
+    ],
+    [
+      "a second, unregistered fork appears in z/",
+      withGitmodules(
+        `${baseline.gitmodules}\n[submodule "z/zcash/orchard-fork"]\n\tpath = z/zcash/orchard-fork\n\turl = https://github.com/free2z/orchard\n\tbranch = main\n`,
+      ),
+      "is not in docs/DEPENDENCIES.md's registry",
+    ],
+    [
+      "the fork submodule is dropped but the register entry stays",
+      withGitmodules(
+        baseline.gitmodules.replace(
+          'path = z/zcash/librustzcash',
+          'path = z/zcash/librustzcash-renamed',
+        ),
+      ),
+      "registered as a fork but absent from .gitmodules",
+    ],
+    [
+      "the bip32 patch is re-pinned to a moving branch",
+      withManifest(
+        "wallet/zuuli/src-tauri/Cargo.toml",
+        baseline.manifests["wallet/zuuli/src-tauri/Cargo.toml"].replace(
+          'rev = "131d490ef75ccd23111cc7f3df91e4a88fc971ae"',
+          'branch = "f2z/bip32-secp256k1-0.29"',
+        ),
+      ),
+      "must be pinned by rev, never by branch",
+    ],
+    [
+      "the bip32 patch rev drifts from the reviewed one",
+      withManifest(
+        "wallet/zuuli/src-tauri/Cargo.toml",
+        baseline.manifests["wallet/zuuli/src-tauri/Cargo.toml"].replace(
+          "131d490ef75ccd23111cc7f3df91e4a88fc971ae",
+          "0000000000000000000000000000000000000000",
+        ),
+      ),
+      "registered rev 131d490ef75ccd23111cc7f3df91e4a88fc971ae",
+    ],
+    [
+      "the bip32 patch is deleted while the register still claims it",
+      withManifest(
+        "wallet/zuuli/src-tauri/Cargo.toml",
+        baseline.manifests["wallet/zuuli/src-tauri/Cargo.toml"].replace(
+          "[patch.crates-io]",
+          "[patch.crates-io-disabled]",
+        ),
+      ),
+      "registered as a patch but absent from",
+    ],
+    [
+      "a patch section appears in a manifest that is not a registered patch site",
+      withManifest(
+        "wallet/zuuallet/src-tauri/Cargo.toml",
+        `${baseline.manifests["wallet/zuuallet/src-tauri/Cargo.toml"]}\n[patch.crates-io]\nfoo = { git = "https://github.com/free2z/foo", rev = "deadbeef" }\n`,
+      ),
+      "is not a registered patch site",
+    ],
+    [
+      "upstream librustzcash bumps a hold the register says it forces",
+      withLibrustzcash(
+        baseline.librustzcash.replace(
+          'rusqlite = { version = "0.37"',
+          'rusqlite = { version = "0.38"',
+        ),
+      ),
+      "it now declares 0.38",
+    ],
+    [
+      "upstream librustzcash drops a hold the register says it forces",
+      withLibrustzcash(
+        baseline.librustzcash.replace(/^secrecy = "0\.8"$/m, "# secrecy gone"),
+      ),
+      "declares no such workspace dependency any more",
+    ],
+    [
+      "upstream takes a position on a hold the register calls our own",
+      withLibrustzcash(
+        baseline.librustzcash.replace(
+          'sha2 = { version = "0.10", default-features = false }',
+          'sha2 = { version = "0.10", default-features = false }\nhkdf = { version = "0.13", default-features = false }',
+        ),
+      ),
+      "register calls this hold our own choice",
+    ],
+    [
+      "the librustzcash submodule is not checked out",
+      withLibrustzcash(""),
+      "is the submodule checked out?",
+    ],
+    [
+      "the register loses its verification marker",
+      withRegister(baseline.register.replace(VERIFIED_MARKER, "")),
+      "missing its <!-- verified:",
+    ],
+    [
+      "the register's verification marker is not a date",
+      withRegister(
+        baseline.register.replace(VERIFIED_MARKER, "<!-- verified: 2026-13-45 -->"),
+      ),
+      "is not a date",
+    ],
+    [
+      "the register loses the exit condition for the librustzcash fork",
+      withRegister(baseline.register.replaceAll("zcash/librustzcash#3010", "the PR")),
+      "does not mention `zcash/librustzcash#3010`",
+    ],
+    [
+      "the register forgets that #3010's head is a different branch",
+      withRegister(
+        baseline.register.replaceAll(
+          "f2z/upstream-drop-stale-rustcrypto-rc-pins",
+          "the other branch",
+        ),
+      ),
+      "does not mention `f2z/upstream-drop-stale-rustcrypto-rc-pins`",
+    ],
+    [
+      "the register drops a deliberate hold from section 3",
+      withRegister(baseline.register.replace("`hkdf` | 0.12", "")),
+      "does not mention ``hkdf` | 0.12`",
+    ],
+    [
+      "the register drops the openmls_memory_storage cross-reference",
+      withRegister(baseline.register.replaceAll("openmls/openmls#2163", "an upstream PR")),
+      "does not mention `openmls/openmls#2163`",
+    ],
+    [
+      "the register drops the langchain consumer of z/",
+      withRegister(baseline.register.replaceAll("langchain/zcash/store.py", "a script")),
+      "does not mention `langchain/zcash/store.py`",
+    ],
+  ];
+
+  for (const [name, snapshot, expected] of cases) {
+    requireFailure(name, snapshot, expected);
+  }
+  process.stdout.write(
+    `self-test: killed ${cases.length} offline dependency-register mutants.\n`,
+  );
+  return cases.length;
+}
+
+/// Negative controls for the network half, with github.com and crates.io
+/// injected. Without these the three rules that actually matter — an exit
+/// condition firing, a fork drifting, a `.gitmodules` branch vanishing — would
+/// be untested code that only ever runs weekly, which is the same class of
+/// unwatched thing this script exists to catch.
+async function runUpstreamSelfTest() {
+  const baseline = liveSnapshot();
+  /// Every reply an unremarkable week produces: PR open, no upstream CI, fork
+  /// level with its base, both fork branches at one commit, every remote branch
+  /// present.
+  const quiet = () => ({
+    githubJson: async (route) => {
+      if (/\/pulls\/\d+$/.test(route)) {
+        return {
+          merged: false,
+          merged_at: null,
+          state: "open",
+          head: { sha: "a".repeat(40) },
+        };
+      }
+      if (route.endsWith("/check-runs")) return { total_count: 4 };
+      if (route.includes("/compare/")) {
+        return { status: "ahead", ahead_by: 1, behind_by: 0 };
+      }
+      if (route.includes("/branches/")) return { commit: { sha: "b".repeat(40) } };
+      throw new Error(`unexpected route ${route}`);
+    },
+    cratesIo: async () => ({ crate: { max_stable_version: "0.5.3" } }),
+    remoteHasBranch: () => true,
+    today: new Date("2026-08-31T00:00:00Z"),
+  });
+
+  const expectQuiet = async () => {
+    const findings = await upstreamFindings(baseline, quiet());
+    const actionable = findings.filter((finding) => finding.severity !== "info");
+    if (actionable.length) {
+      throw new Error(
+        `upstream self-test needs a quiet baseline, got ${JSON.stringify(actionable, null, 2)}`,
+      );
+    }
+  };
+  await expectQuiet();
+
+  const cases = [
+    [
+      "the upstream PR merges — time to drop the fork",
+      {
+        ...quiet(),
+        githubJson: async (route) => {
+          if (/\/pulls\/\d+$/.test(route)) {
+            return {
+              merged: true,
+              merged_at: "2026-09-01T00:00:00Z",
+              state: "closed",
+              head: { sha: "a".repeat(40) },
+            };
+          }
+          return quiet().githubJson(route);
+        },
+      },
+      baseline,
+      "MERGED",
+    ],
+    [
+      "the upstream PR is closed without merging",
+      {
+        ...quiet(),
+        githubJson: async (route) => {
+          if (/\/pulls\/\d+$/.test(route)) {
+            return {
+              merged: false,
+              merged_at: null,
+              state: "closed",
+              head: { sha: "a".repeat(40) },
+            };
+          }
+          return quiet().githubJson(route);
+        },
+      },
+      baseline,
+      "CLOSED without merging",
+    ],
+    [
+      "the fork falls behind its upstream base",
+      {
+        ...quiet(),
+        githubJson: async (route) => {
+          if (route.includes("/compare/")) {
+            return { status: "diverged", ahead_by: 1, behind_by: 11 };
+          }
+          return quiet().githubJson(route);
+        },
+      },
+      baseline,
+      "commits behind",
+    ],
+    [
+      "the branch we build and the branch upstream reviews diverge",
+      {
+        ...quiet(),
+        githubJson: async (route) => {
+          if (route.includes("/branches/")) {
+            return {
+              commit: {
+                sha: route.includes("upstream-drop") ? "c".repeat(40) : "b".repeat(40),
+              },
+            };
+          }
+          return quiet().githubJson(route);
+        },
+      },
+      baseline,
+      "have diverged",
+    ],
+    [
+      "a .gitmodules branch no longer exists on its remote (the z3 failure mode)",
+      { ...quiet(), remoteHasBranch: () => false },
+      baseline,
+      "does not exist on",
+    ],
+    [
+      "crates.io publishes the release the patch was waiting for",
+      { ...quiet(), cratesIo: async () => ({ crate: { max_stable_version: "0.6.0" } }) },
+      baseline,
+      "crates.io now publishes bip32 0.6.0",
+    ],
+    [
+      "librustzcash moves off the secp256k1 version the patch is held to",
+      quiet(),
+      {
+        ...baseline,
+        librustzcash: baseline.librustzcash.replace(
+          'secp256k1 = { version = "0.29"',
+          'secp256k1 = { version = "0.31"',
+        ),
+      },
+      "moved secp256k1 to 0.31",
+    ],
+    [
+      "the register goes unverified for too long",
+      { ...quiet(), today: new Date("2027-01-01T00:00:00Z") },
+      baseline,
+      "last verified",
+    ],
+  ];
+
+  for (const [name, deps, snapshot, expected] of cases) {
+    const findings = await upstreamFindings(snapshot, deps);
+    if (!findings.some((finding) => finding.headline.includes(expected))) {
+      throw new Error(
+        `mutation escaped policy: ${name}\n  expected a finding containing: ${expected}\n  got: ${JSON.stringify(findings, null, 2)}`,
+      );
+    }
+  }
+  process.stdout.write(
+    `self-test: killed ${cases.length} upstream dependency-register mutants.\n`,
+  );
+  return cases.length;
+}
+
+async function runUpstream() {
+  const findings = await upstreamFindings(liveSnapshot());
+  const actionable = findings.filter((finding) => finding.severity !== "info");
+  for (const finding of findings) {
+    const stream = finding.severity === "info" ? process.stdout : process.stderr;
+    stream.write(`[${finding.severity}] ${finding.headline}\n    ${finding.detail}\n`);
+  }
+  if (actionable.length) {
+    process.stderr.write(
+      `\n${actionable.length} dependency-register finding(s) need an owner. See ${REGISTER_PATH}.\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(
+    `Upstream check passed: every tracked fork is unmerged, within its drift limit, ` +
+      `and every .gitmodules branch exists on its remote.\n`,
+  );
+}
+
+async function runCli(args) {
+  if (args.length === 1 && args[0] === "--self-test") {
+    const offline = runSelfTest();
+    const upstream = await runUpstreamSelfTest();
+    process.stdout.write(
+      `self-test passed: ${offline + upstream} mutants killed across both halves.\n`,
+    );
+    return;
+  }
+  if (args.length === 1 && args[0] === "--upstream") {
+    await runUpstream();
+    return;
+  }
+  if (args.length === 0) {
+    const failures = offlineFailures(liveSnapshot());
+    if (failures.length) {
+      for (const failure of failures) process.stderr.write(`drift: ${failure}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(
+      `${REGISTER_PATH} agrees with .gitmodules, ${PATCHABLE_MANIFESTS.length} patch site(s), ` +
+        `and ${UPSTREAM_HOLDS.size} upstream-forced version holds.\n`,
+    );
+    return;
+  }
+  process.stderr.write(
+    "usage: scripts/check-dependency-register.mjs [--self-test|--upstream]\n",
+  );
+  process.exit(2);
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  // Exit 1 means "findings" and exit 2 means "this script or the network broke".
+  // Node exits 1 on an uncaught throw, which would make an api.github.com
+  // outage read as a merged upstream PR — the two must not share a code, since
+  // dependency-register.yml opens an issue on 1 and goes red on 2.
+  try {
+    await runCli(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`check-dependency-register failed: ${error?.stack ?? error}\n`);
+    process.exit(2);
+  }
+}

--- a/scripts/check-workflow-gates.mjs
+++ b/scripts/check-workflow-gates.mjs
@@ -197,6 +197,16 @@ const UNGATED_WORKFLOWS = new Map([
       "while a pull request is still open, so a required context from it could never report.",
   ],
   [
+    ".github/workflows/dependency-register.yml",
+    "Enforces docs/DEPENDENCIES.md. Its `offline` job is deterministic and could be gated, but its " +
+      "`upstream` job renders verdicts about third-party repositories — whether zcash/librustzcash " +
+      "merged a PR, how far upstream main has moved, whether a remote still publishes a branch — and " +
+      "a required context carrying those would let someone else's merge queue or an api.github.com " +
+      "outage redden main for a contributor who touched none of it. It runs weekly and files an issue " +
+      "instead. Gating the offline half alone means first splitting it behind a change detector, and " +
+      "its `on: pull_request: paths:` filter would otherwise leave a required context pending.",
+  ],
+  [
     ".github/workflows/docs-about-free2z.yml",
     "Advisory build of docs/about-free2z/**, selected by an `on: pull_request: paths:` filter; " +
       "gating it means first moving that filter into a change-detector job.",


### PR DESCRIPTION
## Why

`AGENTS.md` says a fork is **a bridge, never a parking spot** — branch, PR, pin
transiently, then move the submodule back to upstream `main` the moment the PR
merges. The policy is right. **Nothing enforced step 5, and nothing noticed
drift.** Both recent failures were found only because a human went looking:

* the librustzcash fork had silently fallen ten commits behind upstream, so what
  we built was not what upstream was reviewing; and
* `z/ZcashFoundation/z3`'s `.gitmodules` `branch` named `dev` for months after
  upstream deleted it, which made `git submodule update --remote` unable to
  resolve that submodule at all (#847).

Neither is a code change, so nothing could go red for either.

## What lands

### 1. `docs/DEPENDENCIES.md` — the fork & pin register

One page answering "what do we carry that isn't stock upstream, and when does it
go away?" It is an **index and exit-condition tracker**, not a second copy of the
reasoning: this repo deliberately keeps the *why* beside the declaration, so
every row links out. Five sections: the librustzcash fork, the `bip32`
`[patch.crates-io]`, the deliberate version holds, `openmls_memory_storage`, and
`z/` submodule policy.

**Every fact was verified against its live source on 2026-08-31**, with the date
recorded in a `<!-- verified: -->` marker the check parses.

### 2. `scripts/check-dependency-register.mjs` — enforcement, split in two

**Offline** (default, runs on pull requests). Reads only files in this tree:

* every `.gitmodules` entry declares a `branch`;
* every submodule pointing at a `free2z/` fork is registered, and every
  registered fork is still in `.gitmodules` — both directions;
* every `[patch.crates-io]` is registered, pinned by `rev` (never a branch), and
  confined to a manifest allowed to have one;
* **each "upstream forces this hold" claim is re-read out of
  `z/zcash/librustzcash/Cargo.toml`.** If upstream bumps `rusqlite` to 0.38 the
  register goes red instead of quietly lying. `hkdf` is checked the other way —
  the register calls it *our* choice, so upstream declaring it at all is a
  finding;
* the register still names every tracked entry and exit condition.

**Upstream** (`--upstream`, weekly). Whether a tracked PR has merged, how far a
fork has drifted behind its base (limit 10 — the drift that was found by hand),
whether the two fork branches have diverged, and `git ls-remote` for every
`.gitmodules` `branch`.

27 mutants killed across both halves; the network half is self-tested with
github.com and crates.io injected, so those rules are not untested code that only
runs on Mondays.

**Why a scheduled issue and not a gate.** Every verdict the network half renders
is a statement about somebody else's repository. Wiring that into branch
protection hands a third party's merge queue — or an api.github.com outage — the
ability to redden `main` for a contributor who touched none of it. Upstream
merging zcash/librustzcash#3010 is *good news*; it must not be an incident for
whoever opens a PR that hour. `.github/workflows/dependency-register.yml` runs it
weekly and files (or updates) **one** reusable issue. Exit 1 means findings, exit
2 means the script or the network broke, so an outage cannot read as a merged PR.

### 3. The canary's blind spot — fixed, and the answer is "the fork is still needed"

`zuuallet.yml`'s weekly `upstream-canary` builds only
`wallet/zuuallet/src-tauri`, and **zuuallet does not depend on
`tauri-plugin-f2zmsg`**. But the entire reason the librustzcash fork exists is
that upstream's `block-buffer` / `crypto-common` RC pins make **zuuli** unable to
link f2zmsg. So the canary passed against pristine upstream while the exact
condition that forces the fork was fully present.

**Verified empirically before writing the assertion**, both directions:

```
# submodule at zcash/librustzcash@aed0fdda (pristine upstream main)
$ cargo metadata --manifest-path wallet/zuuli/src-tauri/Cargo.toml
error: failed to select a version for `crypto-common`.
    ... required by package `digest v0.11.2`
    ... which satisfies dependency `sha2 = "^0.11"` of package `ed25519-dalek v3.0.0`
    ... which satisfies dependency `ed25519-dalek = "^3"` of package `f2z-kt-core`
  previously selected package `crypto-common v0.2.0-rc.1`
    ... which satisfies dependency `crypto-common = "=0.2.0-rc.1"` of `zcash_primitives`
exit 101

$ cargo metadata --manifest-path wallet/zuuallet/src-tauri/Cargo.toml
exit 0          # <- the blind spot, exactly
```

**It fails, for the documented reason. The fork is still required.** So the
canary's polarity is inverted rather than adding a permanent red that trains
people to ignore the job:

| outcome | verdict |
|---|---|
| resolution fails naming `crypto-common` / `0.2.0-rc.1` | **pass** — the fork is still needed |
| resolution fails for any other reason | **fail** — real upstream breakage |
| resolution **succeeds** | **fail loudly** — the fork's premise is gone, retire it |

Resolution rather than compilation because that is where the conflict lives:
Cargo rejects the graph before building a crate, so the assertion costs seconds.
Both branches of that shell were run locally and produce the intended exit codes.

## One register entry whose justification was wrong

`rs/Cargo.toml` held `sha2` at 0.10 because it "resolves to the copy
`akd_core`'s graph already carries". **`akd_core` 0.13.0 does not depend on
`sha2` at all** — its digest is `blake3`, and it reaches `sha2 0.10.9` only
transitively through `ed25519-dalek` 2. The hold is still right; the reason was
not.

The real one, read off the shipping lock: `f2z-msg-identity` is linked into
`wallet/zuuli/src-tauri`, and in that binary `sha2 0.10.9` is what
`zcash_primitives`, `zcash_transparent`, `zcash_script`, `tauri-plugin-zcash`,
`bip0039`, `bs58`, `tauri-codegen` and `wry` all resolve to — because
librustzcash's workspace declares `sha2 = "0.10"`. Comment corrected, and the new
check now re-reads that upstream requirement so it cannot go stale unnoticed
again.

Two smaller corrections recorded in the register: PR #850's *title* cites
`openmls#2188`, which does not exist (the body and `rs/deny.toml` correctly cite
**#2163**); and `z/hhanh00/zwallet` is **not** dormant — last push 2026-08-23.
Only `z/hhanh00/warp` is (2024-12-22).

## Diff scope

`docs/`, `scripts/`, `.github/workflows/`, plus **comment-only** edits to
`rs/Cargo.toml`, `.gitmodules` and `AGENTS.md`. No lockfile, no dependency, no
code change.

## Checks run locally

```
check-dependency-register --self-test   27 mutants killed
check-dependency-register               register agrees with the tree
check-dependency-register --upstream    passed against live github.com
check-workflow-gates                    39 self-test cases, 16 workflow files
check-github-actions-pins               195 external refs, 17 files
check-librustzcash-compat               gitlink + 3 shipping locks
```

https://claude.ai/code/session_017MAbZDMgXsUqr1CVe6VnWF
