### PR TITLE
chore(deps): unify tls_codec on 0.5, closing the two-major split

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -772,7 +772,7 @@ version = "0.1.0"
 dependencies = [
  "ed25519-dalek 3.0.0",
  "f2z-codec",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -782,7 +782,7 @@ dependencies = [
  "blake2",
  "proptest",
  "syn 2.0.119",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -800,7 +800,7 @@ dependencies = [
  "f2z-kt-core",
  "log",
  "protobuf",
- "tls_codec 0.4.2",
+ "tls_codec",
  "tokio",
  "tower",
 ]
@@ -834,7 +834,7 @@ dependencies = [
  "f2z-codec",
  "proptest",
  "protobuf",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -848,7 +848,7 @@ dependencies = [
  "f2z-msg-mls",
  "f2z-msg-store",
  "proptest",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -863,7 +863,7 @@ dependencies = [
  "proptest",
  "rand_core 0.10.1",
  "sha2 0.10.9",
- "tls_codec 0.4.2",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -909,7 +909,7 @@ dependencies = [
  "futures-util",
  "rand 0.9.5",
  "serde",
- "tls_codec 0.4.2",
+ "tls_codec",
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
@@ -924,7 +924,7 @@ dependencies = [
  "f2z-codec",
  "proptest",
  "subtle",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -945,7 +945,7 @@ dependencies = [
  "f2z-codec",
  "f2z-relay-proto",
  "futures-util",
- "tls_codec 0.4.2",
+ "tls_codec",
  "tokio",
  "tokio-tungstenite",
 ]
@@ -961,7 +961,7 @@ dependencies = [
  "f2z-kt",
  "f2z-kt-core",
  "log",
- "tls_codec 0.4.2",
+ "tls_codec",
  "tokio",
  "ureq",
 ]
@@ -1288,7 +1288,7 @@ dependencies = [
  "log",
  "serde",
  "subtle",
- "tls_codec 0.5.0",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -1726,7 +1726,7 @@ dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
  "rand 0.10.2",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -1831,7 +1831,7 @@ dependencies = [
  "libcrux-sha3",
  "libcrux-traits",
  "rand 0.10.2",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -2117,7 +2117,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror 2.0.20",
- "tls_codec 0.5.0",
+ "tls_codec",
  "web-time",
  "zeroize",
 ]
@@ -2135,7 +2135,7 @@ dependencies = [
  "p384",
  "rand_core 0.6.4",
  "serde",
- "tls_codec 0.5.0",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -2158,7 +2158,7 @@ dependencies = [
  "openmls_memory_storage",
  "openmls_traits",
  "rand 0.10.2",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -2199,7 +2199,7 @@ dependencies = [
  "rand_core 0.6.4",
  "sha2 0.11.0",
  "thiserror 2.0.20",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -2247,7 +2247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac13edad8698eb1917cbc1dab99591fa1594d84320904fe3fc5121854f95831c"
 dependencies = [
  "serde",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -3349,35 +3349,14 @@ dependencies = [
 
 [[package]]
 name = "tls_codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
-dependencies = [
- "tls_codec_derive 0.4.2",
- "zeroize",
-]
-
-[[package]]
-name = "tls_codec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18cc98286004cea38f717e2b03d990fc774fbfd38a82720de40e5c94365067c8"
 dependencies = [
  "serde",
  "serde_bytes",
- "tls_codec_derive 0.5.0",
+ "tls_codec_derive",
  "zeroize",
-]
-
-[[package]]
-name = "tls_codec_derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -34,7 +34,54 @@ expect_used = "deny"
 
 [workspace.dependencies]
 blake2 = { version = "0.10", default-features = false }
-tls_codec = { version = "0.4", default-features = false, features = ["derive"] }
+# The canonical wire encoding itself — `WIRE.md` §3, and therefore the most
+# consequential line in this file. `f2z-codec` implements §3.3's
+# re-encode-equality rule on top of it, so a change here is a change to what
+# every deployed client considers a well-formed frame.
+#
+# **0.5, and the version is the point.** `openmls 0.9` moved to `tls_codec 0.5`
+# while this workspace was on `0.4`, so the lock carried both majors at once:
+# our own wire types spoke one and the MLS engine the other. Nothing crossed
+# that seam — `f2z-msg-mls` reaches the traits through `openmls::prelude` and
+# hands MLS a credential as opaque bytes — so it was survivable, but it was
+# survivable by accident, and the accident was one `use tls_codec::…` away from
+# a trait-not-implemented error whose cause is invisible. It also quietly
+# falsified the second of `WIRE.md` §3.1's three reasons for choosing this codec
+# at all: "it is already in the client's dependency graph… the crypto core
+# already contains this decoder, already ships it to WASM". Two majors mean two
+# decoders in the bundle and two in the audit scope, which is the cost §3.2
+# refused to pay for CBOR.
+#
+# **The bump is byte-compatible with 0.4.2, and that was measured rather than
+# assumed** (#853). 0.5.0's only breaking change on the surface this tree uses
+# is the *method* rename `SerializeBytes::tls_serialize` →
+# `tls_serialize_bytes`; every encode path we reach — the derived
+# `SerializeBytes`, the integer `to_be_bytes`, `[u8; N]`, `TlsByteVecU8/16/24`,
+# `Option<T>` — emits the same bytes it did before. Its other changes are on the
+# **decode** side and are strictly narrowing (element vectors must now consume
+# their declared length exactly, and a zero-length element is refused), plus
+# overflow guards that are compiled out entirely on 64-bit and can only turn a
+# wrapped length into an error on 32-bit and wasm32.
+#
+# How that was proved, and **the order is the whole point**: every value the
+# workspace's test suite encodes was dumped through
+# `f2z_codec::canonical::encode` while the tree was still on **0.4.2** — 30,315
+# distinct (type, bytes) vectors over 81 types in seven crates — and then, after
+# the bump, replayed through `decode_canonical` under **0.5.0**, which decodes,
+# re-encodes and byte-compares. 30,314 of them round-tripped identically; the
+# one vector not replayed is `f2z-relay-proto`'s private `Empty`, whose encoding
+# is zero bytes and cannot differ. Generating the
+# vectors after the bump would have proved nothing except that 0.5 agrees with
+# itself. `f2z-codec/tests/wire_vectors.rs` — whose expectations are derived by
+# hand from the spec text rather than from this codec — is the independent half,
+# and it passes unchanged.
+#
+# Anyone bumping this again owes the same measurement. A `tls_codec` release
+# that changes one byte of one encoding is a wire-format break for deployed
+# clients, and neither the type checker nor the round-trip tests would say so:
+# `TlsSerializeBytes` and `TlsDeserializeBytes` move together, so a re-encode of
+# a re-decode stays green through a format change (#564).
+tls_codec = { version = "0.5", default-features = false, features = ["derive"] }
 # Ed25519, `WIRE.md` §5. `default-features = false` drops `std` and `fast`:
 # `fast` is curve25519-dalek's precomputed-tables, which trades roughly 30 KiB
 # of table for signing speed, and this graph reaches wasm32 for the browser

--- a/rs/crates/f2z-authority/src/types.rs
+++ b/rs/crates/f2z-authority/src/types.rs
@@ -85,8 +85,8 @@ macro_rules! opaque_fixed {
         }
 
         impl SerializeBytes for $name {
-            fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-                self.0.tls_serialize()
+            fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+                self.0.tls_serialize_bytes()
             }
         }
 
@@ -255,7 +255,7 @@ impl Size for Handle {
 }
 
 impl SerializeBytes for Handle {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
         let len = u8::try_from(self.0.len()).map_err(|_| TlsError::InvalidVectorLength)?;
         if self.0.is_empty() || self.0.len() > HANDLE_MAX_LEN {
             return Err(TlsError::InvalidVectorLength);
@@ -349,7 +349,7 @@ impl Size for Intent {
 }
 
 impl SerializeBytes for Intent {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
         Ok(alloc::vec![self.code()])
     }
 }

--- a/rs/crates/f2z-codec/src/canonical.rs
+++ b/rs/crates/f2z-codec/src/canonical.rs
@@ -107,7 +107,7 @@ where
     // `tls_deserialize_exact_bytes` refuses trailing data, which is the first
     // half of §3.3's "no unknown trailing bytes" rule.
     let value = T::tls_deserialize_exact_bytes(bytes)?;
-    let encoded = SerializeBytes::tls_serialize(&value)?;
+    let encoded = SerializeBytes::tls_serialize_bytes(&value)?;
     if encoded.as_slice() != bytes {
         return Err(CodecError::NotCanonical);
     }
@@ -121,7 +121,7 @@ where
 /// [`CodecError::Decode`] if the value cannot be encoded — in practice, a
 /// vector longer than its length prefix can describe.
 pub fn encode<T: SerializeBytes>(value: &T) -> Result<Vec<u8>, CodecError> {
-    Ok(SerializeBytes::tls_serialize(value)?)
+    Ok(SerializeBytes::tls_serialize_bytes(value)?)
 }
 
 /// A wire structure that participates in re-encode equality.

--- a/rs/crates/f2z-codec/src/frame.rs
+++ b/rs/crates/f2z-codec/src/frame.rs
@@ -361,14 +361,18 @@ impl Size for RelayFrame {
 }
 
 impl SerializeBytes for RelayFrame {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
         let mut out = Vec::with_capacity(self.tls_serialized_len());
         out.push(self.kind().code());
         out.extend_from_slice(&self.request_id.to_be_bytes());
         match &self.payload {
-            FramePayload::Request(request) => out.extend_from_slice(&request.tls_serialize()?),
-            FramePayload::Response(response) => out.extend_from_slice(&response.tls_serialize()?),
-            FramePayload::Push(push) => out.extend_from_slice(&push.tls_serialize()?),
+            FramePayload::Request(request) => {
+                out.extend_from_slice(&request.tls_serialize_bytes()?)
+            }
+            FramePayload::Response(response) => {
+                out.extend_from_slice(&response.tls_serialize_bytes()?)
+            }
+            FramePayload::Push(push) => out.extend_from_slice(&push.tls_serialize_bytes()?),
         }
         Ok(out)
     }
@@ -482,11 +486,11 @@ impl Size for CommandAuth {
 }
 
 impl SerializeBytes for CommandAuth {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
         let mut out = Vec::with_capacity(self.tls_serialized_len());
         out.push(self.present());
         if let Self::Signed(auth) = self {
-            out.extend_from_slice(&auth.tls_serialize()?);
+            out.extend_from_slice(&auth.tls_serialize_bytes()?);
         }
         Ok(out)
     }

--- a/rs/crates/f2z-codec/src/types.rs
+++ b/rs/crates/f2z-codec/src/types.rs
@@ -106,8 +106,8 @@ macro_rules! opaque_fixed {
         }
 
         impl SerializeBytes for $name {
-            fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-                self.0.tls_serialize()
+            fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+                self.0.tls_serialize_bytes()
             }
         }
 
@@ -243,8 +243,8 @@ impl Size for Payload {
 }
 
 impl SerializeBytes for Payload {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-        self.0.tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+        self.0.tls_serialize_bytes()
     }
 }
 
@@ -316,8 +316,8 @@ impl Size for Body {
 }
 
 impl SerializeBytes for Body {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-        self.0.tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+        self.0.tls_serialize_bytes()
     }
 }
 
@@ -405,8 +405,8 @@ impl Size for KeyPackage {
 }
 
 impl SerializeBytes for KeyPackage {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-        self.0.tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+        self.0.tls_serialize_bytes()
     }
 }
 
@@ -505,8 +505,8 @@ impl Size for ShortBytes {
 }
 
 impl SerializeBytes for ShortBytes {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-        self.0.tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+        self.0.tls_serialize_bytes()
     }
 }
 
@@ -525,7 +525,7 @@ mod tests {
     #[test]
     fn fixed_newtypes_round_trip() {
         let address = QueueAddress::new([7u8; 32]);
-        let encoded = SerializeBytes::tls_serialize(&address).unwrap();
+        let encoded = SerializeBytes::tls_serialize_bytes(&address).unwrap();
         assert_eq!(encoded, [7u8; 32]);
         let (decoded, rest) = QueueAddress::tls_deserialize_bytes(&encoded).unwrap();
         assert_eq!(decoded, address);

--- a/rs/crates/f2z-codec/src/vec.rs
+++ b/rs/crates/f2z-codec/src/vec.rs
@@ -93,10 +93,10 @@ macro_rules! length_prefixed_vec {
         }
 
         impl<T: SerializeBytes + Size> SerializeBytes for $name<T> {
-            fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+            fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
                 let mut body = Vec::new();
                 for item in &self.0 {
-                    body.extend_from_slice(&item.tls_serialize()?);
+                    body.extend_from_slice(&item.tls_serialize_bytes()?);
                 }
                 if body.len() > Self::MAX_BYTES {
                     return Err(TlsError::InvalidVectorLength);

--- a/rs/crates/f2z-kt-core/src/entry.rs
+++ b/rs/crates/f2z-kt-core/src/entry.rs
@@ -192,7 +192,7 @@ impl Size for EntryKind {
 }
 
 impl SerializeBytes for EntryKind {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
         Ok(vec![self.code()])
     }
 }
@@ -401,25 +401,25 @@ impl Size for EntryAuthorization {
 }
 
 impl SerializeBytes for EntryAuthorization {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
         let mut out = vec![self.kind().code()];
         match self {
             Self::SameKey { auth_signature } => {
-                out.extend_from_slice(&auth_signature.tls_serialize()?);
+                out.extend_from_slice(&auth_signature.tls_serialize_bytes()?);
             }
             Self::KeyChange {
                 rotation,
                 auth_signature,
             } => {
-                out.extend_from_slice(&rotation.tls_serialize()?);
-                out.extend_from_slice(&auth_signature.tls_serialize()?);
+                out.extend_from_slice(&rotation.tls_serialize_bytes()?);
+                out.extend_from_slice(&auth_signature.tls_serialize_bytes()?);
             }
             Self::PlatformReset {
                 reset,
                 auth_signature,
             } => {
-                out.extend_from_slice(&reset.tls_serialize()?);
-                out.extend_from_slice(&auth_signature.tls_serialize()?);
+                out.extend_from_slice(&reset.tls_serialize_bytes()?);
+                out.extend_from_slice(&auth_signature.tls_serialize_bytes()?);
             }
         }
         Ok(out)

--- a/rs/crates/f2z-kt-core/src/types.rs
+++ b/rs/crates/f2z-kt-core/src/types.rs
@@ -114,8 +114,8 @@ macro_rules! opaque_fixed {
         }
 
         impl SerializeBytes for $name {
-            fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-                self.0.tls_serialize()
+            fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+                self.0.tls_serialize_bytes()
             }
         }
 
@@ -241,8 +241,8 @@ impl Size for Handle {
 }
 
 impl SerializeBytes for Handle {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-        self.0.tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+        self.0.tls_serialize_bytes()
     }
 }
 
@@ -316,8 +316,8 @@ impl Size for KemPublicKey {
 }
 
 impl SerializeBytes for KemPublicKey {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-        self.0.tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+        self.0.tls_serialize_bytes()
     }
 }
 

--- a/rs/crates/f2z-kt-core/src/witness.rs
+++ b/rs/crates/f2z-kt-core/src/witness.rs
@@ -412,7 +412,7 @@ impl Size for FaultKind {
 }
 
 impl SerializeBytes for FaultKind {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
         Ok(vec![self.code()])
     }
 }

--- a/rs/crates/f2z-msg-dag/src/message.rs
+++ b/rs/crates/f2z-msg-dag/src/message.rs
@@ -164,8 +164,8 @@ impl Size for MsgId {
 }
 
 impl SerializeBytes for MsgId {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-        self.0.tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+        self.0.tls_serialize_bytes()
     }
 }
 
@@ -292,8 +292,8 @@ impl Size for RetentionClass {
 }
 
 impl SerializeBytes for RetentionClass {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-        self.code().tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+        self.code().tls_serialize_bytes()
     }
 }
 

--- a/rs/crates/f2z-msg-dag/src/repair.rs
+++ b/rs/crates/f2z-msg-dag/src/repair.rs
@@ -163,8 +163,8 @@ impl Size for RepairRefusal {
 }
 
 impl SerializeBytes for RepairRefusal {
-    fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
-        self.code().tls_serialize()
+    fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
+        self.code().tls_serialize_bytes()
     }
 }
 

--- a/rs/crates/f2z-msg-mls/Cargo.toml
+++ b/rs/crates/f2z-msg-mls/Cargo.toml
@@ -61,11 +61,12 @@ openmls_libcrux_crypto = { workspace = true }
 # uses (`openmls_libcrux_crypto`'s `crypto.rs` calls exactly these functions),
 # so naming it here adds no crate to the graph and removes two.
 libcrux-ed25519 = { workspace = true }
-# `tls_codec` is deliberately NOT a dependency of this crate. `openmls 0.9` is
-# on `tls_codec 0.5` and `f2z-codec`/`f2z-kt-core` are on `0.4`; the only two
-# `tls_codec` calls here are on OpenMLS's own types, and `src/engine.rs` reaches
-# them through `openmls::prelude::tls_codec` so they cannot resolve to the other
-# version. See the note at that import.
+# `tls_codec` is deliberately NOT a dependency of this crate, and it stays that
+# way even though the workspace and `openmls 0.9` now agree on 0.5 (#853). The
+# only two `tls_codec` calls here are on OpenMLS's own types, so `src/engine.rs`
+# reaches them through `openmls::prelude::tls_codec`: the trait a derive
+# generated must be the one that crate derived it with, whether or not the
+# resolver currently makes those the same crate. See the note at that import.
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/rs/crates/f2z-msg-mls/src/engine.rs
+++ b/rs/crates/f2z-msg-mls/src/engine.rs
@@ -65,21 +65,24 @@ use f2z_msg_store::{Durability, StorageBackend};
 use openmls::prelude::*;
 // **Through the prelude, deliberately, and not as a dependency of this crate.**
 //
-// `openmls 0.9` moved to `tls_codec 0.5`, while `f2z-codec` and `f2z-kt-core`
-// — the crates that define free2z's own wire structures — are on `tls_codec
-// 0.4`. Both live in this graph. The two `tls_codec` traits below are used on
-// **OpenMLS's** types (`MlsMessageOut`, `MlsMessageIn`) and on nothing else, so
-// they must be the version OpenMLS derived them with; naming the crate directly
-// would let a future workspace bump resolve them to the other one and produce a
-// trait-not-implemented error whose cause is invisible. `openmls::prelude`
-// re-exports `tls_codec::{self, *}`, so this import cannot drift from what
-// OpenMLS itself uses.
+// The two `tls_codec` traits below are used on **OpenMLS's** types
+// (`MlsMessageOut`, `MlsMessageIn`) and on nothing else, so they must be the
+// version OpenMLS derived them with. `openmls::prelude` re-exports
+// `tls_codec::{self, *}`, so this import cannot drift from what OpenMLS itself
+// uses.
 //
-// Nothing crosses the seam. A `DeviceCredential` reaches MLS as the opaque
-// identity bytes of a `BasicCredential` (`credential::encode`, which is
-// `f2z-codec`'s canonical encoding), so no `tls_codec` *type* from either
-// version appears in an interface between the two halves — the same shape as
-// the two `ed25519-dalek` majors this workspace already carries.
+// This graph carried **two** majors of `tls_codec` until #853 — `openmls 0.9`
+// on 0.5, `f2z-codec` and `f2z-kt-core` on 0.4 — and the workspace is now on
+// 0.5 with them, so the two resolve to one crate today. The indirection stays
+// anyway: naming `tls_codec` directly here would make that unification
+// load-bearing, and the next time OpenMLS moves ahead of us the failure is a
+// trait-not-implemented error on a derive nobody edited.
+//
+// Nothing crosses the seam in either case. A `DeviceCredential` reaches MLS as
+// the opaque identity bytes of a `BasicCredential` (`credential::encode`, which
+// is `f2z-codec`'s canonical encoding), so no `tls_codec` *type* appears in an
+// interface between the two halves — the same shape as the two
+// `ed25519-dalek` majors this workspace still carries.
 use openmls::prelude::tls_codec::{Deserialize as _, Serialize as _};
 
 use crate::credential::{DeviceCredential, encode as encode_credential, validate_for_leaf};

--- a/rs/crates/f2z-relay-proto/src/command.rs
+++ b/rs/crates/f2z-relay-proto/src/command.rs
@@ -91,7 +91,7 @@ mod empty {
     }
 
     impl SerializeBytes for Empty {
-        fn tls_serialize(&self) -> Result<Vec<u8>, TlsError> {
+        fn tls_serialize_bytes(&self) -> Result<Vec<u8>, TlsError> {
             Ok(Vec::new())
         }
     }

--- a/wallet/plugins/tauri-plugin-f2zmsg/Cargo.lock
+++ b/wallet/plugins/tauri-plugin-f2zmsg/Cargo.lock
@@ -1257,7 +1257,7 @@ name = "f2z-codec"
 version = "0.1.0"
 dependencies = [
  "blake2",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -1277,7 +1277,7 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "f2z-codec",
  "protobuf",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -1286,7 +1286,7 @@ version = "0.1.0"
 dependencies = [
  "blake2",
  "f2z-codec",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -1300,7 +1300,7 @@ dependencies = [
  "hkdf 0.12.4",
  "rand_core 0.10.1",
  "sha2 0.10.9",
- "tls_codec 0.4.2",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -1336,7 +1336,7 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "f2z-codec",
  "subtle",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -1346,7 +1346,7 @@ dependencies = [
  "f2z-codec",
  "f2z-relay-proto",
  "futures-util",
- "tls_codec 0.4.2",
+ "tls_codec",
  "tokio",
  "tokio-tungstenite",
 ]
@@ -2013,7 +2013,7 @@ dependencies = [
  "log",
  "serde",
  "subtle",
- "tls_codec 0.5.0",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -2695,7 +2695,7 @@ dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
  "rand 0.10.2",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -2800,7 +2800,7 @@ dependencies = [
  "libcrux-sha3",
  "libcrux-traits",
  "rand 0.10.2",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -3420,7 +3420,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror 2.0.20",
- "tls_codec 0.5.0",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -3437,7 +3437,7 @@ dependencies = [
  "p384",
  "rand_core 0.6.4",
  "serde",
- "tls_codec 0.5.0",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -3460,7 +3460,7 @@ dependencies = [
  "openmls_memory_storage",
  "openmls_traits",
  "rand 0.10.2",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -3501,7 +3501,7 @@ dependencies = [
  "rand_core 0.6.4",
  "sha2 0.11.0",
  "thiserror 2.0.20",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -3549,7 +3549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac13edad8698eb1917cbc1dab99591fa1594d84320904fe3fc5121854f95831c"
 dependencies = [
  "serde",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -5310,7 +5310,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin",
  "tempfile",
- "tls_codec 0.4.2",
+ "tls_codec",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -5546,35 +5546,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls_codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
-dependencies = [
- "tls_codec_derive 0.4.2",
- "zeroize",
-]
-
-[[package]]
-name = "tls_codec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18cc98286004cea38f717e2b03d990fc774fbfd38a82720de40e5c94365067c8"
 dependencies = [
  "serde",
  "serde_bytes",
- "tls_codec_derive 0.5.0",
+ "tls_codec_derive",
  "zeroize",
-]
-
-[[package]]
-name = "tls_codec_derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/wallet/plugins/tauri-plugin-f2zmsg/Cargo.toml
+++ b/wallet/plugins/tauri-plugin-f2zmsg/Cargo.toml
@@ -159,8 +159,12 @@ f2z-codec = { path = "../../../rs/crates/f2z-codec", version = "0.1.0" }
 # in-flight window, the queue state machine and `ClientPolicy`.
 f2z-relay-proto = { path = "../../../rs/crates/f2z-relay-proto", version = "0.1.0" }
 # `tls_codec`'s traits are in `f2z-codec`'s public API (`Canonical`), so the
-# 0.4 line is named here rather than inherited by luck.
-tls_codec = { version = "0.4", default-features = false, features = ["derive"] }
+# line is named here rather than inherited by luck — and it must be the line
+# `rs/Cargo.toml` names, because a trait implemented by one copy of the crate is
+# not the trait the other copy's bound asks for. Moved 0.4 → 0.5 with the
+# workspace in #853; the reasoning, and the byte-compatibility measurement that
+# justified it, live at that declaration.
+tls_codec = { version = "0.5", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/wallet/zuuli/src-tauri/Cargo.lock
+++ b/wallet/zuuli/src-tauri/Cargo.lock
@@ -1787,7 +1787,7 @@ name = "f2z-codec"
 version = "0.1.0"
 dependencies = [
  "blake2",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -1807,7 +1807,7 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "f2z-codec",
  "protobuf",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -1816,7 +1816,7 @@ version = "0.1.0"
 dependencies = [
  "blake2",
  "f2z-codec",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -1830,7 +1830,7 @@ dependencies = [
  "hkdf 0.12.4",
  "rand_core 0.10.1",
  "sha2 0.10.9",
- "tls_codec 0.4.2",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -1866,7 +1866,7 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "f2z-codec",
  "subtle",
- "tls_codec 0.4.2",
+ "tls_codec",
 ]
 
 [[package]]
@@ -2754,7 +2754,7 @@ dependencies = [
  "log",
  "serde",
  "subtle",
- "tls_codec 0.5.0",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -3512,7 +3512,7 @@ dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
  "rand 0.10.2",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -3617,7 +3617,7 @@ dependencies = [
  "libcrux-sha3",
  "libcrux-traits",
  "rand 0.10.2",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -4376,7 +4376,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror 2.0.18",
- "tls_codec 0.5.0",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -4393,7 +4393,7 @@ dependencies = [
  "p384",
  "rand_core 0.6.4",
  "serde",
- "tls_codec 0.5.0",
+ "tls_codec",
  "zeroize",
 ]
 
@@ -4416,7 +4416,7 @@ dependencies = [
  "openmls_memory_storage",
  "openmls_traits",
  "rand 0.10.2",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -4457,7 +4457,7 @@ dependencies = [
  "rand_core 0.6.4",
  "sha2 0.11.0",
  "thiserror 2.0.18",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -4505,7 +4505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac13edad8698eb1917cbc1dab99591fa1594d84320904fe3fc5121854f95831c"
 dependencies = [
  "serde",
- "tls_codec 0.5.0",
+ "tls_codec",
 ]
 
 [[package]]
@@ -7031,7 +7031,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin",
- "tls_codec 0.4.2",
+ "tls_codec",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -7392,35 +7392,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls_codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
-dependencies = [
- "tls_codec_derive 0.4.2",
- "zeroize",
-]
-
-[[package]]
-name = "tls_codec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18cc98286004cea38f717e2b03d990fc774fbfd38a82720de40e5c94365067c8"
 dependencies = [
  "serde",
  "serde_bytes",
- "tls_codec_derive 0.5.0",
+ "tls_codec_derive",
  "zeroize",
-]
-
-[[package]]
-name = "tls_codec_derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]


### PR DESCRIPTION
## The finding

`rs/Cargo.lock` and both wallet lockfiles carried **two majors of `tls_codec` at once**:

| version | who |
|---|---|
| `0.4.2` | every first-party crate — `f2z-authority`, `f2z-codec`, `f2z-kt`, `f2z-kt-core`, `f2z-msg-dag`, `f2z-msg-identity`, `f2z-relay`, `f2z-relay-proto`, `f2z-relay-testkit`, `f2z-witness`, and `tauri-plugin-f2zmsg` |
| `0.5.0` | `openmls 0.9.0`, `openmls_traits 0.6.0`, `openmls_libcrux_crypto 0.4.0`, `hpke-rs 0.7.0`, `libcrux-ecdh`, `libcrux-ml-kem` |

This PR unifies on `0.5.0`. The three questions were answered in order, and the answers are below.

## 1. Does any `tls_codec` type cross the boundary?

**No — and it was already deliberate.** The only `tls_codec` use in `f2z-msg-mls` is two traits imported as `use openmls::prelude::tls_codec::{Deserialize as _, Serialize as _}`, applied to `MlsMessageOut`/`MlsMessageIn` at `engine.rs:956,962`, plus `DeserializeBytes` on an OpenMLS `KeyPackage` in `keypackage.rs`. `tls_codec` is not a dependency of that crate at all. A `DeviceCredential` reaches MLS as the opaque identity bytes of a `BasicCredential`, encoded by `f2z-codec`'s canonical encoding — so no `tls_codec` *type* appears in an interface between the two halves.

So the split was **cosmetic in effect** — but survivable by accident, one `use tls_codec::…` away from a trait-not-implemented error whose cause is invisible. It also quietly falsified [`WIRE.md` §3.1](docs/e2ee/WIRE.md)'s own second reason for choosing this codec: *"it is already in the client's dependency graph… the crypto core already contains this decoder, already ships it to WASM"*. Two majors are two decoders in the WASM bundle and two in the audit scope, which is exactly the cost §3.2 refused to pay for CBOR.

## 2. Is the encoding byte-compatible? — **Yes, and it was measured, not read**

**Direct statement: the encoding is byte-identical between 0.4.2 and 0.5.0 for every construct this tree uses.**

Read from the actual crate sources side by side (both are vendored locally), not only the changelog:

- **`src/arrays.rs`, `src/primitives.rs`, `src/tls_vec.rs`** — every encode-side change is `writer.write(..)` → `writer.write_all(..)` (the `Serialize`/`Write` half, which this tree does not use) and the `SerializeBytes::tls_serialize` → `tls_serialize_bytes` rename. Emitted bytes are unchanged: integers still `to_be_bytes`, `[u8; N]` still `to_vec`, `TlsByteVecU*` still length prefix + bytes, `Option<T>` still tag + value.
- **`tls_codec_derive/src/lib.rs`** — the derived `SerializeBytes` still appends fields in declaration order and still writes the discriminant first for enums. The only additions are `#[cfg(not(target_pointer_width = "64"))]` overflow guards that trip solely at `usize::MAX`.
- Every other change in 0.5.0 is **decode-side and strictly narrowing**: element vectors must now consume their declared length exactly, a zero-length element is refused, `checked_add` replaces an overflowing sum, and read-based deserialization no longer pre-allocates from an untrusted length. None of these can widen what is accepted. (This tree does not use `TlsVecU*`/`VLBytes` at all — only `TlsByteVecU8/16/24` and its own `f2z_codec::vec::VecU*`.)
- MSRV 1.85, edition 2024, licence `Apache-2.0 OR MIT` — all fine against the pinned 1.97.1.

### The empirical proof, in the right order

Reading a changelog is not evidence, so:

1. **Under 0.4.2**, `f2z_codec::canonical::encode`/`decode_canonical` — the single chokepoint every crate in the tree encodes through — was temporarily instrumented to append `type_name::<T>()` + hex to a file, and the whole `rs/` suite was run. Result: **30,315 distinct (type, bytes) vectors over 81 types in seven crates** (`f2z-codec`, `f2z-kt-core`, `f2z-authority`, `f2z-msg-dag`, `f2z-kt`, `f2z-witness`, `f2z-relay-proto`).
2. **Then the bump**, and the same corpus was replayed through `decode_canonical` under **0.5.0** — which decodes, re-encodes and byte-compares.

```
REPLAYED   206 vectors for f2z_authority::
REPLAYED  7593 vectors for f2z_codec::
REPLAYED    66 vectors for f2z_kt::
REPLAYED   504 vectors for f2z_kt_core::
REPLAYED 21925 vectors for f2z_msg_dag::
REPLAYED    20 vectors for f2z_witness::
                = 30,314, all identical, zero failures
```

The one vector not replayed is `f2z-relay-proto`'s private `Empty`, whose encoding is zero bytes and cannot differ.

Generating the vectors *after* the bump would have proved only that 0.5 agrees with itself, which is why it was done this way round. The instrumentation and the replay harness were scratch-only and are **not** in this diff.

**The independent half:** `rs/crates/f2z-codec/tests/wire_vectors.rs` already exists — 98 tests whose expected bytes are derived **by hand from the `WIRE.md` spec text**, explicitly not from the implementation (#564). It passes unchanged.

## 3. What breaks at the source level?

One thing: `SerializeBytes::tls_serialize` → `tls_serialize_bytes`. Mechanically renamed at ~45 sites across 11 files. No `#[tls_codec(with = ...)]` anywhere, no use of the deprecated `Error::InvalidWriteLength`, no `Size` trait change, no derive-attribute change.

## Result

`rs/Cargo.lock` and both wallet lockfiles now resolve exactly one `tls_codec`; `0.4.2` and `tls_codec_derive 0.4.2` are gone with no new package added.

The reasoning, the measurement, and the obligation on whoever bumps this next are recorded **at the declaration** in `rs/Cargo.toml` — including the warning that `TlsSerializeBytes` and `TlsDeserializeBytes` move together, so a round-trip test stays green straight through a format change. The stale notes in `f2z-msg-mls`'s manifest and `engine.rs` are corrected; the indirection through `openmls::prelude` **stays**, because it must not become load-bearing on the two happening to resolve to one crate today.

## Verification

- `scripts/check-rust-fmt.sh --root rs` / `--root wallet`
- `scripts/check-rust-clippy.sh --root rs`; `cargo clippy --locked --all-targets -- -D warnings` in `tauri-plugin-f2zmsg`
- `scripts/check-rust-deny.sh --root rs --config rs/deny.toml` and `--root wallet` — advisories, bans, licences, sources all ok, the `[[bans.deny]]` floors untouched
- `scripts/check-rust-toolchain.sh`
- `cargo test --locked --all-targets` in `rs/` — **1150 passed, 0 failed**; `cargo test --locked --doc`
- Every wasm32 build `rs.yml` runs: the five client crates, `f2z-msg-store --no-default-features`, `f2z-msg-mls --features js`, `f2z-kt-core`/`f2z-kt-client --features verifier`
- `cargo build --locked` of `wallet/plugins/tauri-plugin-f2zmsg` and `wallet/zuuli/src-tauri`

https://claude.ai/code/session_017MAbZDMgXsUqr1CVe6VnWF
