### PR TITLE
spec(e2ee): withdraw the unsubstantiated PoW calibration claim

### DIFF
--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -1797,6 +1797,13 @@ a flood, when the relay is the resource under pressure. The calibration is
 unresolved and is recorded as
 [`ARCHITECTURE.md` §13-N](./ARCHITECTURE.md#13-open-questions).
 
+> **Correction (2026-08-31) — the phone-tolerability claim above was not
+> measured and is withdrawn.** No phone benchmark was recorded for the v1
+> contact-append proof of work, so this document has no evidence that any
+> difficulty is tolerable to the supported phones or imposes a particular cost
+> on attackers. `ARCHITECTURE.md` §13-N remains the required benchmark and
+> adjustment work before either claim can be made.
+
 **Disk exhaustion by mass queue creation is made expensive, not closed.** Nothing
 here prevents an adversary with real resources from creating a very large number
 of legitimate-looking queues, each with a valid stamp, from a large number of

--- a/wallet/zuuli/src/lib/messaging/mock.handle-eligibility.test.ts
+++ b/wallet/zuuli/src/lib/messaging/mock.handle-eligibility.test.ts
@@ -1,0 +1,28 @@
+// `evaluateHandle`'s doc comment (mock.ts §11.3) already states the rule: the
+// raw-ASCII check runs before `toLowerCase()`, because `toLowerCase()` can
+// turn a non-ASCII string into an ASCII one. U+212A KELVIN SIGN is the
+// concrete case that ordering exists for — `"K".toLowerCase()` is `"k"`,
+// so a check that lower-cased first and then tested for ASCII would let it
+// through as a plain ASCII handle. Nothing exercised that ordering as a
+// regression test before this file, so a future edit could restore the
+// case-fold-then-check order without any test failing.
+import { describe, expect, it } from "vitest";
+import { evaluateHandle } from "./mock";
+
+describe("handle eligibility uses raw ASCII before case mapping", () => {
+  it("rejects Unicode characters that a Unicode lowercase could map to ASCII", () => {
+    expect(evaluateHandle("K")).toEqual({
+      eligible: false,
+      candidate: null,
+      reason: "non-ascii",
+    });
+  });
+
+  it("maps ASCII uppercase only after the raw ASCII check", () => {
+    expect(evaluateHandle("Alice_1")).toEqual({
+      eligible: true,
+      candidate: "alice_1",
+      reason: null,
+    });
+  });
+});


### PR DESCRIPTION
## What

`docs/e2ee/WIRE.md` §12.4 still asserted:

> We have chosen a difficulty that is a nuisance to attackers and tolerable
> to phones, which means it is *only* a nuisance.

immediately before the very next sentence in the same paragraph calls the
calibration "unresolved" and points at `ARCHITECTURE.md` §13-N for it — a
direct contradiction within one paragraph.

**Correction to the source-branch premise, checked against current main:**
`ARCHITECTURE.md` §13-N itself was already corrected by #800 — it currently
reads "What difficulty is simultaneously a real cost to an attacker and
tolerable on a cheap Android device is **unmeasured**, and whether a
memory-hard function is affordable at relay scale is undecided," with no
calibration claim to withdraw. So **only the `WIRE.md` paragraph** carried
the leftover, uncorrected claim; `ARCHITECTURE.md` needed no edit, and this
PR does not touch it. (git blame: `f629de4` / #800 introduced the
"unmeasured"/"undecided" wording in `ARCHITECTURE.md` but never touched this
`WIRE.md` paragraph.)

No phone benchmark for the v1 contact-append proof of work exists anywhere
in this repository, so the claim is withdrawn — not replaced with a new
claim — via a dated correction blockquote, following the doc's own
established pattern for this (see e.g. `WIRE.md` §14.3, "the earlier answer
... is withdrawn — see the correction in...").

## Also included

`wallet/zuuli/src/lib/messaging/mock.handle-eligibility.test.ts` (absent
from main): covers the raw-ASCII-before-case-folding ordering that
`mock.ts`'s `evaluateHandle` already documents and implements (§11.3
comment: *"non-ASCII is checked before length because `toLowerCase()` can
change a non-ASCII string's length"*). U+212A KELVIN SIGN is the concrete
case — `"K".toLowerCase()` is ASCII `"k"` — so a check that folded case
before testing for ASCII would silently admit it as a plain handle. Verified
the implementation is already correct (both new assertions pass against
main's `mock.ts` unmodified); nothing previously locked that ordering in as
a regression test, and this directly answers still-open #838.

## Verification

- `wallet/zuuli`: `npm ci`, `npm run typecheck` (clean), `npx vitest run`
  (97 files / 1410 passed, 5 skipped — including the 2 new tests)
- Manually re-read `docs/e2ee/ARCHITECTURE.md` §13-N and confirmed it does
  not restate the withdrawn claim (no edit made there)

Refs #550, #821, #838.