### PR TITLE
test(relay): cover the reserved queue-creation mode through Server::start

### DIFF
--- a/rs/crates/f2z-relay/tests/startup_validation.rs
+++ b/rs/crates/f2z-relay/tests/startup_validation.rs
@@ -1,0 +1,48 @@
+//! External-crate regressions for the public production constructor.
+//!
+//! `Config::check` is already unit-tested from inside the crate (see
+//! `config.rs`'s `token_mode_is_refused_because_it_has_no_wire_shape`), but a
+//! unit test calling a method directly cannot prove anything about whether
+//! the method is actually reached from the one place an operator can start a
+//! relay from. This test deliberately cannot reach the engine's
+//! crate-private assembly function: the only public route from an operator
+//! [`Config`] to a running relay is [`Server::start`], and that route must
+//! apply the full shared configuration validation — including the
+//! permanently-reserved `token` queue-creation mode (§13.1) — before it ever
+//! creates an identity, opens a store, or binds a listener.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use f2z_relay::config::{Config, ConfigError};
+use f2z_relay::server::{Server, StartError};
+
+#[tokio::test]
+async fn public_startup_refuses_the_reserved_token_creation_mode() {
+    let mut config = Config::default();
+    config.antiabuse.queue_creation_mode = "token".to_owned();
+    // Keep the negative control independent of the filesystem and of any
+    // other startup step: if validation were ever bypassed, startup would
+    // reach real identity/store/capability construction rather than failing
+    // incidentally on a missing key file or a disk-backed store path.
+    config.identity.seed = "11".repeat(32);
+    config.store.backend = "memory".to_owned();
+    config.listen.address = "127.0.0.1:0".to_owned();
+
+    match Server::start(config).await {
+        Err(StartError::Config(ConfigError::Invalid(field, reason))) => {
+            assert_eq!(field, "antiabuse.queue_creation_mode");
+            assert!(reason.contains("no wire representation"));
+        }
+        Err(other) => panic!("reserved mode escaped public startup validation: {other}"),
+        Ok(server) => {
+            server.shutdown().await;
+            panic!("a protocol-v1 relay started with the reserved token creation mode");
+        }
+    }
+}


### PR DESCRIPTION
## What

`Config::check` already refuses the permanently-reserved `token`
queue-creation mode (§13.1: token mode has no wire representation in
`WIRE.md` v1 — `CREATE_QUEUE` carries only a `PowStamp` and a reserved
`flags` field), and `config.rs` already unit-tests that directly via
`token_mode_is_refused_because_it_has_no_wire_shape`. Nothing exercised the
same invariant through the **public** boundary an operator actually starts a
relay from: `Server::start`. `rs/crates/f2z-relay/tests/startup_validation.rs`
adds that: a config with `queue_creation_mode = "token"` must be refused by
`Server::start` with `StartError::Config(ConfigError::Invalid(...))` — naming
`antiabuse.queue_creation_mode` and mentioning "no wire representation" —
before any identity, store, or listener is created; it must never silently
start a relay in this mode.

Adapted from `origin/fix/630-reserve-token-mode` onto main's current API.
The source branch's assertion checked for the substring `"permanently
reserved"`, which is not the wording main's `check()` actually uses — the
test here asserts on main's real message, `"no wire representation"`,
verified to actually appear. The branch's broader `CheckedConfig`/
`ActiveCreationMode` type-state redesign is intentionally **not** included —
that's a separate architectural proposal, not a rescue of this one gap.

## Verification

- `scripts/check-rust-fmt.sh --root rs` — all 15 crates formatted
- `cargo clippy -p f2z-relay --all-targets --locked` — clean
- `cargo test -p f2z-relay --locked` — all tests pass, including the new
  `public_startup_refuses_the_reserved_token_creation_mode`

Refs #630.