### PR TITLE
fix(zuuli): keep snackbars inside native insets

### DIFF
--- a/wallet/zuuli/scripts/safe-area-contract.node-test.mjs
+++ b/wallet/zuuli/scripts/safe-area-contract.node-test.mjs
@@ -25,6 +25,7 @@ const androidGradle = source("../src-tauri/gen/android/app/build.gradle.kts");
 const androidActivity = source(
   "../src-tauri/gen/android/app/src/main/java/cash/free2z/zuuli/MainActivity.kt",
 );
+const executableCss = css.replace(/\/\*[\s\S]*?\*\//g, "");
 
 function cssRule(className) {
   const match = css.match(new RegExp(`\\.${className}\\s*\\{([^}]+)\\}`));
@@ -67,6 +68,22 @@ test("cover is enabled only together with four authoritative inset fallbacks", (
   assert.match(sidebar, /data-app-bottom-nav/);
   assert.match(sidebar, /className="app-mobile-more-dialog /);
   assert.match(sidebar, /closeClassName="app-mobile-more-close /);
+});
+
+test("the global toast host clears native insets and mobile navigation", () => {
+  assert.match(executableCss, /--toast-edge-gap: 1rem;/);
+  assert.match(
+    executableCss,
+    /--toast-horizontal-offset:[^;]*max\(var\(--safe-area-left\), var\(--safe-area-right\)\)/s,
+  );
+  assert.match(
+    executableCss,
+    /--toast-bottom-offset:[^;]*var\(--safe-area-bottom\)/s,
+  );
+  assert.match(
+    executableCss,
+    /@media \(max-width: 767px\)[\s\S]*?--toast-bottom-offset:[^;]*var\(--mobile-tab-bar-height\)/,
+  );
 });
 
 test("the document and app are bounded to one dynamic viewport frame", () => {

--- a/wallet/zuuli/src/components/ui/sonner.test.tsx
+++ b/wallet/zuuli/src/components/ui/sonner.test.tsx
@@ -1,0 +1,32 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+const sonner = vi.hoisted(() => ({
+  host: vi.fn((_props: Record<string, unknown>) => null),
+}));
+
+vi.mock("sonner", () => ({ Toaster: sonner.host }));
+
+import { Toaster } from "./sonner";
+
+describe("Toaster viewport geometry", () => {
+  it("binds every Sonner edge to the centralized safe-area offsets", () => {
+    renderToStaticMarkup(<Toaster />);
+
+    expect(sonner.host).toHaveBeenCalledOnce();
+    expect(sonner.host.mock.calls[0]?.[0]).toMatchObject({
+      className: "app-toaster toaster group",
+      position: "bottom-right",
+      offset: {
+        right: "var(--toast-horizontal-offset)",
+        bottom: "var(--toast-bottom-offset)",
+        left: "var(--toast-horizontal-offset)",
+      },
+      mobileOffset: {
+        right: "var(--toast-horizontal-offset)",
+        bottom: "var(--toast-bottom-offset)",
+        left: "var(--toast-horizontal-offset)",
+      },
+    });
+  });
+});

--- a/wallet/zuuli/src/components/ui/sonner.tsx
+++ b/wallet/zuuli/src/components/ui/sonner.tsx
@@ -2,13 +2,21 @@ import { Toaster as Sonner } from "sonner";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
+const viewportOffsets = {
+  right: "var(--toast-horizontal-offset)",
+  bottom: "var(--toast-bottom-offset)",
+  left: "var(--toast-horizontal-offset)",
+} as const;
+
 /** App-wide toast host. Import { toast } from "sonner" to fire toasts. */
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme="dark"
-      className="toaster group"
+      className="app-toaster toaster group"
       position="bottom-right"
+      offset={viewportOffsets}
+      mobileOffset={viewportOffsets}
       toastOptions={{
         classNames: {
           toast:

--- a/wallet/zuuli/src/index.css
+++ b/wallet/zuuli/src/index.css
@@ -19,6 +19,14 @@
     --mobile-tab-bar-height: calc(
       var(--mobile-tab-content-height) + var(--safe-area-bottom)
     );
+    --toast-edge-gap: 1rem;
+    --toast-horizontal-offset: calc(
+      var(--toast-edge-gap) +
+        max(var(--safe-area-left), var(--safe-area-right))
+    );
+    --toast-bottom-offset: calc(
+      var(--toast-edge-gap) + var(--safe-area-bottom)
+    );
 
     --font-sans: "IBM Plex Sans Variable", ui-sans-serif, system-ui, sans-serif;
     --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -205,6 +213,19 @@
     padding-right: var(--safe-area-right);
     padding-bottom: var(--safe-area-bottom);
     padding-left: var(--safe-area-left);
+  }
+
+  /* Sonner renders outside the app frame, so it cannot inherit that frame's
+     inset padding. On mobile, clear the complete fixed tab bar (which already
+     includes the native bottom inset); elsewhere clear only the native edge.
+     The shared horizontal maximum keeps Sonner's symmetric mobile width inside
+     asymmetric landscape/notch insets without counting either inset twice. */
+  @media (max-width: 767px) {
+    :root {
+      --toast-bottom-offset: calc(
+        var(--toast-edge-gap) + var(--mobile-tab-bar-height)
+      );
+    }
   }
 
   .app-mobile-more-dialog {

--- a/wallet/zuuli/tests/send-review.pw.ts
+++ b/wallet/zuuli/tests/send-review.pw.ts
@@ -80,6 +80,99 @@ test("a multi-payment URI never selects its first payment or preserves stale int
   await expect(page.getByRole("button", { name: "Review payment" })).toBeDisabled();
 });
 
+test("a snackbar clears native insets, mobile navigation, and viewport resizes", async ({
+  page,
+}) => {
+  await openSend(page);
+  await page.addStyleTag({
+    content: `:root {
+      --safe-area-top: 23px !important;
+      --safe-area-right: 9px !important;
+      --safe-area-bottom: 31px !important;
+      --safe-area-left: 13px !important;
+    }
+    /* Freeze Sonner's mount-in transform transition so the geometry
+       assertions below measure the toast's settled position instead of an
+       arbitrary animation frame. */
+    [data-sonner-toast] {
+      transition: none !important;
+    }`,
+  });
+
+  await page
+    .getByLabel("Recipient address")
+    .fill("zcash:?address=u1first&amount=1&address.1=u1second&amount.1=2");
+  const toast = page.locator("[data-sonner-toast]").filter({
+    hasText: "Couldn't read that payment link",
+  });
+  const toaster = page.locator("[data-sonner-toaster]");
+  const bottomNav = page.locator("[data-app-bottom-nav]");
+  await expect(toast).toBeVisible();
+
+  async function geometry() {
+    const [toastRect, navRect, toasterStyle, viewport] = await Promise.all([
+      toast.boundingBox(),
+      bottomNav.boundingBox(),
+      toaster.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return {
+          bottom: Number.parseFloat(style.bottom),
+          left: Number.parseFloat(style.left),
+          right: Number.parseFloat(style.right),
+        };
+      }),
+      page.evaluate(() => ({
+        width: document.documentElement.clientWidth,
+        height:
+          window.visualViewport?.height ?? document.documentElement.clientHeight,
+      })),
+    ]);
+    if (!toastRect || !navRect) {
+      throw new Error("toast geometry fixtures are not mounted");
+    }
+    return {
+      toast: {
+        top: toastRect.y,
+        right: toastRect.x + toastRect.width,
+        bottom: toastRect.y + toastRect.height,
+        left: toastRect.x,
+      },
+      navTop: navRect.y,
+      viewportWidth: viewport.width,
+      visualViewportHeight: viewport.height,
+      toasterBottom: toasterStyle.bottom,
+      toasterLeft: toasterStyle.left,
+      toasterRight: toasterStyle.right,
+    };
+  }
+
+  async function expectInsetGeometry() {
+    // The toaster host itself is intentionally zero-height: every
+    // `[data-sonner-toast]` child is absolutely positioned within it (see
+    // sonner's own stylesheet), so an in-flow visibility/bounding-box check
+    // on the host never succeeds. Assert it is mounted and read its computed
+    // offsets instead; the toast's own visibility and position below are the
+    // real inset assertions.
+    await expect(toaster).toBeAttached();
+    await expect(bottomNav).toBeVisible();
+    const measured = await geometry();
+    expect(measured.toasterBottom).toBe(103);
+    expect(measured.toasterLeft).toBe(29);
+    expect(measured.toasterRight).toBe(29);
+    expect(measured.toast.left).toBeGreaterThanOrEqual(29);
+    expect(measured.toast.right).toBeLessThanOrEqual(measured.viewportWidth - 29);
+    expect(measured.toast.bottom).toBeLessThanOrEqual(measured.navTop - 16);
+    expect(measured.toast.top).toBeGreaterThanOrEqual(23);
+    expect(measured.toast.bottom).toBeLessThanOrEqual(
+      measured.visualViewportHeight,
+    );
+  }
+
+  await expectInsetGeometry();
+  await page.setViewportSize({ width: 320, height: 420 });
+  await expectInsetGeometry();
+});
+
 test("the 320px dialog renders only the immutable native review and locks editing", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

Sonner toasts (used for errors like "Couldn't read that payment link") currently render flush against the device edges and behind the mobile tab bar on ZUULI, ignoring the safe-area insets that every other piece of chrome already respects (see #331's top/bottom-bar safe-area work, already landed via #356).

This adds a centralized `--toast-horizontal-offset` / `--toast-bottom-offset` pair in `wallet/zuuli/src/index.css`, wired into Sonner's `offset`/`mobileOffset` props in `wallet/zuuli/src/components/ui/sonner.tsx`. On mobile the bottom offset clears the *entire* fixed tab bar (which already folds in the native bottom inset), not just the raw inset, since Sonner renders outside the app shell and can't inherit its padding. The horizontal offset takes the max of the left/right insets so the toast width stays symmetric on mobile without double-counting an asymmetric notch/landscape inset.

## Relationship to #331

I confirmed via `gh issue view 331` that its own listed defects (`/login` escaping the app shell, missing `viewport-fit=cover`, missing top/bottom insets) were fixed by PR #356 and merged to main; #331 stays open only pending physical-device acceptance evidence, not further code. This PR does not touch any of that — it fixes a separate, still-live safe-area gap (toast notifications ignoring insets) found in the same area during QA. I'm referencing #331 as the closest tracking issue since there's no dedicated issue number for the snackbar defect; happy to move this under a new issue if preferred.

I checked whether `main` had already fixed this independently (given how much has landed since, including #797's i18n kernel and #804's preflight): it has not — `wallet/zuuli/src/components/ui/sonner.tsx` on current `main` still has no `offset`/`mobileOffset` props and no safe-area-aware CSS variables, so this fix is still needed.

## Judgment call / bug found during verification

The stranded branch's own new Playwright test (`tests/send-review.pw.ts`, "a snackbar clears native insets...") had two real bugs I fixed while verifying against current `main`, without weakening any of the actual geometry assertions:

1. It asserted `await expect(toaster).toBeVisible()` on Sonner's `<ol data-sonner-toaster>` host. That element is *always* zero-height by design — every `[data-sonner-toast]` child is `position: absolute` per Sonner's own stylesheet, so an in-flow container with only absolutely-positioned children has zero intrinsic height, and Playwright's `toBeVisible()` requires a non-empty bounding box. This assertion could never pass. Changed it to `toBeAttached()` — the real safety checks (the toast's own visibility, and the numeric offset/position assertions below, unchanged) still fully verify the inset behavior.
2. The geometry assertions raced Sonner's 400ms mount-in transform transition — measuring the toast's position before it settled produced flaky/wrong numbers depending on timing. Added `[data-sonner-toast] { transition: none !important; }` via `page.addStyleTag` so the test measures the toast's final settled position deterministically instead of an arbitrary animation frame.

Root-caused both by bisecting with instrumented copies of the test (confirmed the un-fixed original fails deterministically, not flakily, on current `main`); confirmed the fix is stable across a `--repeat-each=3` run and the full suite.

## Verified

From `wallet/zuuli` after `npm ci`, rebased onto current `origin/main` (rebase applied cleanly, zero conflicts):

- `npm run typecheck` — clean
- `npx vitest run` — 97 test files / 1409 passed, 5 skipped
- `node scripts/ui-copy-truncation.node-test.mjs` — 4/4 pass
- `node --test scripts/safe-area-contract.node-test.mjs` — 6/6 pass (including this branch's new toast-host assertion)
- `npx playwright test` — **183/183 passed** (full suite, after the two test fixes above; confirmed `tests/send-review.pw.ts` stable under `--repeat-each=3`)

No merge performed; ready for the QA gate + adversarial review per repo doctrine.