### PR TITLE
test(zuuli-release): prove a real DMG canary reaches the artifact SBOM

### DIFF
--- a/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
+++ b/wallet/zuuli/scripts/artifact-sbom.node-test.mjs
@@ -2746,6 +2746,88 @@ test("verification re-extracts the artifact instead of trusting a mutated scan r
 });
 
 test(
+  "an undeclared canary shipped inside a real DMG payload is inventoried and bound",
+  { skip: process.platform !== "darwin" },
+  () => {
+    // The zip-based canary test above proves this for the AAB/IPA/mac-ZIP
+    // `unzip` code path. DMG payloads take an entirely different path
+    // (`hdiutil attach` + `cloneMountedTree`), so acceptance criterion #1 of
+    // #379 ("a test injects an undeclared canary library/file into a package
+    // and the artifact SBOM reports it") needs its own proof for that path:
+    // the canary here is baked into the source folder handed to `hdiutil
+    // create`, so it ships inside the real DMG bytes, not into a scan root
+    // some other step already trusts.
+    const temporary = mkdtempSync(
+      resolve(tmpdir(), "zuuli-artifact-dmg-canary-"),
+    );
+    try {
+      const source = resolve(temporary, "source");
+      const executable = resolve(source, "ZUULI.app/Contents/MacOS/ZUULI");
+      const canary = resolve(
+        source,
+        "ZUULI.app/Contents/Frameworks/libundeclared-canary.dylib",
+      );
+      mkdirSync(dirname(executable), { recursive: true });
+      mkdirSync(dirname(canary), { recursive: true });
+      writeFileSync(executable, "signed macOS executable fixture\n");
+      writeFileSync(canary, "undeclared native macOS library bytes\n");
+      const canaryPath =
+        "ZUULI.app/Contents/Frameworks/libundeclared-canary.dylib";
+      const artifact = resolve(temporary, "ZUULI-test-canary.dmg");
+      execFileSync(
+        "hdiutil",
+        [
+          "create",
+          "-quiet",
+          "-ov",
+          "-format",
+          "UDZO",
+          "-volname",
+          "ZUULI canary test",
+          "-srcfolder",
+          source,
+          artifact,
+        ],
+        { timeout: 120_000 },
+      );
+      const root = resolve(temporary, "unpacked");
+      const rawSbom = resolve(temporary, "raw.cdx.json");
+      const sbom = resolve(temporary, "artifact.sbom.cdx.json");
+      const binding = resolve(temporary, "artifact.sbom-binding.json");
+      writeJson(rawSbom, minimalCycloneDx());
+
+      const inventory = prepareArtifact({ artifact, root });
+      assert.ok(
+        inventory.some((entry) => entry.path === canaryPath),
+        "the real DMG mount must surface a file nobody declared anywhere",
+      );
+      finalizeArtifactSbom({ artifact, root, rawSbom, sbom, binding });
+      assert.doesNotThrow(() =>
+        verifyArtifactSbom({ artifact, sbom, binding }),
+      );
+
+      const document = JSON.parse(readFileSync(sbom, "utf8"));
+      assert.equal(
+        property(document.metadata.properties, "free2z:inventory-scope"),
+        "shipped-artifact",
+      );
+      const canaryComponent = document.components.find(
+        (component) =>
+          property(component.properties ?? [], "free2z:artifact:path") ===
+          canaryPath,
+      );
+      assert.equal(canaryComponent?.type, "file");
+      assert.equal(
+        canaryComponent?.hashes?.[0]?.content,
+        sha256File(resolve(root, canaryPath)),
+      );
+    } finally {
+      rmSync(temporary, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
   "macOS DMG inventory is copied without following its Applications link",
   { skip: process.platform !== "darwin" },
   () => {


### PR DESCRIPTION
## Summary

Refs #379. This is a small, safe, fully-verified slice of the issue's first
acceptance criterion ("a test injects an undeclared canary library/file into
a package and the artifact SBOM reports it"), not a fix for the remaining
architectural gap (see "What remains" below).

`wallet/zuuli/syft.yaml` / `syft-artifact.yaml` and the release workflow
already implement shipped-artifact scanning, digest binding, and independent
fresh re-extraction for every platform (landed via #524, #527, #529, #533,
#695). Every artifact format already has a canary test proving its own
extraction code path faithfully inventories an undeclared file:

- AAB / IPA / mac-ZIP share one `unzip`-based extractor, proven by the
  existing IPA canary test.
- AppImage / deb / rpm each have their own canary fixture via
  `writeCanaryPayload`.
- **DMG did not.** It has its own extraction path (`hdiutil attach` +
  `cloneMountedTree`), and the existing DMG test only proved that a
  *post-hoc* scan-root mutation is caught by independent re-verification —
  not that a file shipped inside the *real* DMG bytes is inventoried at all.

This PR adds that missing positive-path test: it builds a real DMG with
`hdiutil create` from a source folder containing an undeclared
`libundeclared-canary.dylib`, then asserts the finalized artifact SBOM
contains that exact file with the correct SHA-256, closing the one format
gap in that acceptance criterion.

## What remains on #379

The issue's own thread (after #695) documents the real remaining gap:
build-evidence-backed dependency reconciliation — embedding and recovering
a linked Cargo runtime graph from every shipped **native** binary (currently
only Linux has this, via `linux-cargo-runtime.mjs` + `cargo-auditable`),
plus the analogous Gradle `runtimeClasspath` reconciliation for Android and
Rollup/Vite bundle-graph reconciliation for the embedded web payload.

I scoped this PR down to *not* attempt the macOS/iOS Cargo-runtime slice
here, on purpose:

- It requires changing the macOS/iOS **unsigned build step** in the
  protected release workflow (wrapping `tauri build`/`tauri ios build` with
  the `cargo-auditable` instrumentation), which precedes signing/notarization
  that I have no credentials to dry-run end-to-end.
- macOS ships a *universal* (lipo'd arm64+x86_64) binary, so the extraction
  side needs new Mach-O fat-binary parsing — meaningfully new, security
  sensitive code with no existing local test harness to lean on (unlike this
  DMG test, which reuses the fully generic, already-hardened
  `finalizeArtifactSbom`/`verifyArtifactSbom` machinery).
- Precedent (`8437bcb`, the Linux slice) shows this class of change needed
  several CI-driven follow-up fixes even for the simpler single-arch ELF
  case. This task is scoped to a single push with no reruns, which is the
  wrong way to land a first attempt at new binary-format extraction logic on
  the protected release path.

Given that, a correctly-scoped "first phase" here is real, verified test
coverage rather than an unvalidated attempt at the native-runtime-graph
feature. The Cargo-runtime-evidence work for macOS/iOS/Android, and the
Gradle/Vite bundle reconciliation, remain open follow-ups on #379.

## Test plan

- [x] `node --test --test-name-pattern="canary shipped inside a real DMG"
      scripts/artifact-sbom.node-test.mjs` (macOS, real `hdiutil`)
- [x] `npm run test:artifact-sbom` — 19 pass, 5 skipped (Linux-only fixtures
      on this Darwin runner), 0 fail
- [x] `node wallet/zuuli/scripts/verify-ci-cache-policy.mjs [--self-test]`
- [x] `node scripts/check-github-actions-pins.mjs [--self-test]`
- [x] `node scripts/check-workflow-gates.mjs [--self-test]`
- [x] `node scripts/check-zuuli-android-gate.mjs [--self-test]`
- [x] No changes to `.github/workflows/zuuli-release.yml`, signing,
      provenance, the `zuuli-mobile-store` concurrency lane, or the
      credential boundary.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH