### PR TITLE
fix(relay): give MAX_CONCURRENT a test that can see it, pin REQUEST_TIMEOUT's floor

### DIFF
--- a/rs/crates/f2z-relay/src/admin.rs
+++ b/rs/crates/f2z-relay/src/admin.rs
@@ -72,11 +72,42 @@ const MAX_REQUEST: usize = 2048;
 /// A bound on BYTES is not a bound on TIME: a client that connects and sends
 /// nothing holds a task and a descriptor for as long as it likes, and
 /// [`Scope::HealthOnly`] is reachable from the whole cluster rather than from
-/// loopback. Two seconds is chosen to be SHORTER than the probe's own
-/// `timeoutSeconds` (3-5s in the manifests): the server should give up before
-/// the client does, so a stuck peer is the server's descriptor to reclaim
-/// rather than the probe's deadline to miss.
+/// loopback. Two seconds is chosen to be SHORTER than the probes' own
+/// `timeoutSeconds` (see [`PROBE_TIMEOUT_FLOOR`]): the server should give up
+/// before the client does, so a stuck peer is the server's descriptor to
+/// reclaim rather than the probe's deadline to miss.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The tightest `timeoutSeconds` among the k8s probes that dial this
+/// listener, pinned so [`REQUEST_TIMEOUT`]'s ordering against it cannot drift
+/// silently (#682).
+///
+/// This value lives half here and half in `k8s/f2z-relay/deployment.yaml` in
+/// the tuzi repo, which — as of the deployment this constant was last checked
+/// against — sets `startupProbe.timeoutSeconds: 5`,
+/// `readinessProbe.timeoutSeconds: 3`, and `livenessProbe.timeoutSeconds: 5`.
+/// Readiness is both the smallest of the three and the one that gates the
+/// Service/NEG, so it is the probe [`REQUEST_TIMEOUT`] has to beat: a relay
+/// that only outraces liveness would still let a stuck peer make the
+/// readiness probe time out first, pulling the pod out of rotation for the
+/// wrong reason.
+///
+/// Same shape as #665's `the_kubernetes_shape_is_valid_configuration`: a
+/// value that is correct today because a human copied it correctly, with
+/// nothing before this that would notice the two repos diverging. If either
+/// side's number moves, update this constant to match and re-derive
+/// `REQUEST_TIMEOUT` against it — the assertion below is what turns that
+/// drift into a build failure instead of a silent inversion.
+const PROBE_TIMEOUT_FLOOR: Duration = Duration::from_secs(3);
+
+/// Pins the ordering at compile time rather than only in a test that has to
+/// be run: if either constant above moves so `REQUEST_TIMEOUT` no longer
+/// beats `PROBE_TIMEOUT_FLOOR`, this fails to build.
+const _: () = assert!(
+    REQUEST_TIMEOUT.as_millis() < PROBE_TIMEOUT_FLOOR.as_millis(),
+    "REQUEST_TIMEOUT must stay shorter than PROBE_TIMEOUT_FLOOR (see its doc \
+     comment) so the relay gives up before the tightest k8s probe does"
+);
 
 /// How many requests this listener will have in flight at once.
 ///
@@ -297,5 +328,20 @@ mod tests {
                 .any(|character| character.is_ascii_digit())
         );
         assert_eq!(HEALTHZ_BODY, "ok\n");
+    }
+
+    #[test]
+    fn request_timeout_stays_shorter_than_the_probe_timeout_floor() {
+        // The invariant REQUEST_TIMEOUT's own doc claims but nothing pinned
+        // before #682: the server must give up before the tightest k8s probe
+        // does. See PROBE_TIMEOUT_FLOOR for where the other half of this
+        // relationship lives and why 3s (readiness) is the one that matters.
+        assert!(
+            REQUEST_TIMEOUT < PROBE_TIMEOUT_FLOOR,
+            "REQUEST_TIMEOUT ({REQUEST_TIMEOUT:?}) must stay below \
+             PROBE_TIMEOUT_FLOOR ({PROBE_TIMEOUT_FLOOR:?}); if you moved \
+             either one, re-check k8s/f2z-relay/deployment.yaml in tuzi and \
+             update whichever side is now wrong"
+        );
     }
 }

--- a/rs/crates/f2z-relay/tests/health.rs
+++ b/rs/crates/f2z-relay/tests/health.rs
@@ -161,6 +161,89 @@ async fn a_client_that_connects_and_says_nothing_is_disconnected_and_the_listene
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn the_concurrency_cap_closes_extra_connections_before_the_timeout_deadline() {
+    // #682: the test above cannot tell a concurrency cap from no cap at all,
+    // because every silent peer reaches EOF within REQUEST_TIMEOUT either
+    // way — with the cap, refused-but-accepted connections are closed before
+    // any read; without one, every connection is merely held open until the
+    // shared timeout fires. `closed == N` is identical in both worlds.
+    //
+    // What distinguishes them is timing, and it is already observable: a
+    // connection over MAX_CONCURRENT is closed promptly, before the deadline,
+    // while a connection that is holding a permit is closed only once
+    // REQUEST_TIMEOUT elapses. So: open more than the cap, measure how long
+    // each one takes to reach EOF, and require that substantially more than
+    // the cap's worth close fast, with roughly the cap's worth riding out the
+    // full deadline as the positive control that the timeout is still doing
+    // its job on the connections that did get a permit.
+    let mut config = base();
+    config.health.enabled = true;
+    config.health.address = "127.0.0.1:0".to_owned();
+    let server = Server::start(config).await.expect("the relay starts");
+    let health = server.health_addr().expect("bound");
+
+    let mut silent = Vec::new();
+    for _ in 0..64 {
+        let opened = std::time::Instant::now();
+        if let Ok(stream) = tokio::net::TcpStream::connect(health).await {
+            silent.push((opened, stream));
+        }
+    }
+    assert!(silent.len() > 16, "the listener accepted {}", silent.len());
+
+    // Read concurrently, not in a sequential loop: a connection refused
+    // immediately at accept time can still sit unread for ~2s if this test
+    // only gets around to polling it after 16 sequential ~2s waits, which
+    // would misclassify it as slow. Spawning means each task's own elapsed
+    // time reflects when the server actually closed *that* connection.
+    let mut tasks = Vec::new();
+    for (opened, mut stream) in silent {
+        tasks.push(tokio::spawn(async move {
+            let mut byte = [0u8; 1];
+            let result =
+                tokio::time::timeout(Duration::from_secs(10), stream.read(&mut byte)).await;
+            (matches!(result, Ok(Ok(0))), opened.elapsed())
+        }));
+    }
+
+    let mut closed = 0usize;
+    let mut fast = 0usize; // closed well before REQUEST_TIMEOUT: a refusal.
+    let mut slow = 0usize; // closed near REQUEST_TIMEOUT: held a permit.
+    let mut elapsed = Vec::new();
+    for task in tasks {
+        let (was_closed, duration) = task.await.expect("the read task did not panic");
+        if was_closed {
+            closed += 1;
+        }
+        if duration < Duration::from_millis(500) {
+            fast += 1;
+        } else if duration >= Duration::from_millis(1000) {
+            slow += 1;
+        }
+        elapsed.push(duration);
+    }
+
+    assert_eq!(
+        closed,
+        elapsed.len(),
+        "the server held connections open indefinitely"
+    );
+    assert!(
+        fast > 16,
+        "too few connections were refused before the deadline for a cap of \
+         16 to be doing anything: fast={fast} slow={slow} elapsed={elapsed:?}"
+    );
+    assert!(
+        (8..=24).contains(&slow),
+        "expected roughly MAX_CONCURRENT (16) connections to ride out the \
+         full REQUEST_TIMEOUT as the positive control: fast={fast} \
+         slow={slow} elapsed={elapsed:?}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn the_health_listener_is_off_unless_asked_for() {
     let server = Server::start(base()).await.expect("the relay starts");
     assert!(server.health_addr().is_none());


### PR DESCRIPTION
Closes #682.

## Proof first: reproduced the issue's claim exactly

Baseline against the merged head of #680: `cargo test -p f2z-relay --test health --test admin` → **EXIT=0, 12 passed**.

Applied the issue's exact mutation — restore `REQUEST_TIMEOUT`, remove only the refusal (`try_acquire_owned()` → `try_acquire_owned().ok()`, permit becomes `Option`, no cap enforced):

```
cargo test -p f2z-relay --test health  =>  EXIT=0, 7 passed
```

`a_client_that_connects_and_says_nothing_is_disconnected_and_the_listener_recovers` passes with **no concurrency bound at all**. The claim is correct.

## Decision: (a) keep the cap, give it a test that can see it

The cap is real load-bearing code — `try_acquire_owned` failing and closing the socket *before any read* is the only thing stopping a cluster-wide flood from holding an unbounded number of tasks, 2 KiB buffers, and descriptors. The existing test just can't distinguish it from having no cap, because every silent peer reaches EOF within `REQUEST_TIMEOUT` either way: `closed == 64` and `silent.len() > 16` hold in both worlds. Removing the cap as "dead weight" because of a blind test would be removing real protection because of a documentation gap in the test, not the code — so (a).

**The fix the issue itself proposed**: timing distinguishes the two mechanisms and is already observable. A connection over `MAX_CONCURRENT` is refused and closed *before any read* — low milliseconds. A connection that got a permit is held open until `REQUEST_TIMEOUT` (2s) elapses. New test `the_concurrency_cap_closes_extra_connections_before_the_timeout_deadline`:

- opens 64 silent connections,
- reads from all of them **concurrently** (spawned tasks, not a sequential loop — sequential polling would misclassify an already-closed "fast" connection as "slow" once earlier ~2s waits have already burned real wall-clock time),
- classifies each by its own measured elapsed time: `fast` (<500ms, refused) vs `slow` (≥1000ms, rode out the deadline as the positive control),
- asserts `fast > 16` (substantially more than the cap were refused promptly) and `slow` is roughly `MAX_CONCURRENT` (8..=24, generous band against scheduler jitter).

**Verified by mutation** (the exact patch from #682, applied then reverted):
```
fast=0 slow=64 elapsed=[2.004520959s, 2.00425525s, 2.00396175s, ...]
thread '...' panicked: too few connections were refused before the deadline for a cap of 16 to be doing anything
test result: FAILED. 0 passed; 1 failed
```
Restoring the refusal: `test result: ok. 8 passed; 0 failed`. Stable across 5 repeated runs (all `2.06s`, no flakiness observed).

## `REQUEST_TIMEOUT`'s cross-repo ordering, pinned

`REQUEST_TIMEOUT`'s doc comment claimed "shorter than the probe's own `timeoutSeconds` (3-5s in the manifests)" but nothing enforced it. Checked `k8s/f2z-relay/deployment.yaml` in the local `tuzi` checkout: `startupProbe.timeoutSeconds: 5`, `readinessProbe.timeoutSeconds: 3`, `livenessProbe.timeoutSeconds: 5`. Readiness is both the tightest and the one that gates the Service/NEG, so it's the one `REQUEST_TIMEOUT` actually has to beat.

Added `PROBE_TIMEOUT_FLOOR: Duration = Duration::from_secs(3)`, documented with the tuzi values and file path, and pinned the ordering with:

```rust
const _: () = assert!(
    REQUEST_TIMEOUT.as_millis() < PROBE_TIMEOUT_FLOOR.as_millis(),
    "REQUEST_TIMEOUT must stay shorter than PROBE_TIMEOUT_FLOOR ..."
);
```

A compile-time assertion rather than only a runtime test (also included, for a friendlier `cargo test` failure message) — this fails the *build*, not just a test someone has to remember to run, the moment either constant moves out of order. Same shape as #665's `the_kubernetes_shape_is_valid_configuration`: it doesn't read tuzi's YAML directly (that's a separate repo), so it's one repo short of catching drift with zero human involvement, but it turns "someone changed one side and the invariant silently inverted" into "the crate does not compile until you look at both."

**Verified by mutation**: bumped `REQUEST_TIMEOUT` to 3s (equal to the floor) —
```
error[E0080]: evaluation panicked: REQUEST_TIMEOUT must stay shorter than PROBE_TIMEOUT_FLOOR ...
error: could not compile `f2z-relay` (lib) due to 1 previous error
```
Reverted, builds clean.

## Gate

- `scripts/check-rust-fmt.sh --root rs` — 15/15 crates formatted.
- `cargo clippy -p f2z-relay --all-targets -- -D warnings` — clean.
- `cargo test -p f2z-relay` — 124 lib + 5+23+2+4+3+8+12+1+6+1 integration tests, all passing (includes the two new tests: 1 unit in `admin.rs`, 1 integration in `tests/health.rs`).