### PR TITLE
fix(zuuli): middle-truncate About commit SHA; scope BIP-39 detection to English

### DIFF
--- a/wallet/zuuli/src/features/about/FeedbackComposer.test.tsx
+++ b/wallet/zuuli/src/features/about/FeedbackComposer.test.tsx
@@ -30,7 +30,18 @@ describe("FeedbackComposer", () => {
     );
     expect(
       ABOUT_MESSAGE_KEYS.filter((key) => key.startsWith("feedback")),
-    ).toHaveLength(30);
+    ).toHaveLength(31);
+  });
+
+  it("states plainly that recovery-phrase screening is English-only (#830)", () => {
+    const markup = renderToStaticMarkup(
+      <FeedbackComposer minimalBuildBlock="ZUULI\nVersion: 0.1.0\nBuild: 17" />,
+    );
+    expect(markup).toContain("recognizes the English BIP-39 wordlist");
+    expect(markup).toContain('id="feedback-mnemonic-scope-hint"');
+    expect(markup).toContain(
+      'aria-describedby="feedback-description-hint feedback-mnemonic-scope-hint"',
+    );
   });
 
   it("accepts deliberately expanded locale copy without truncation classes", () => {

--- a/wallet/zuuli/src/features/about/FeedbackComposer.tsx
+++ b/wallet/zuuli/src/features/about/FeedbackComposer.tsx
@@ -360,11 +360,14 @@ export function FeedbackComposer({
           className="min-h-36 min-w-0 max-w-full resize-y"
           maxLength={FEEDBACK_DESCRIPTION_LIMIT}
           value={description}
-          aria-describedby="feedback-description-hint"
+          aria-describedby="feedback-description-hint feedback-mnemonic-scope-hint"
           onChange={(event) => setDescription(event.target.value)}
         />
         <p id="feedback-description-hint" className="max-w-full break-words text-xs text-muted-foreground [overflow-wrap:anywhere]">
           {messages.feedbackDescriptionHint}
+        </p>
+        <p id="feedback-mnemonic-scope-hint" className="max-w-full break-words text-xs text-muted-foreground [overflow-wrap:anywhere]">
+          {messages.feedbackMnemonicLanguageScope}
         </p>
       </div>
 

--- a/wallet/zuuli/src/features/about/about.test.tsx
+++ b/wallet/zuuli/src/features/about/about.test.tsx
@@ -29,7 +29,10 @@ describe("About build identity", () => {
     expect(markup).toContain("<dl");
     expect(markup).toContain("<details");
     expect(markup).toContain("Build provenance");
-    expect(markup).toContain("abcdef012345");
+    // Middle, tail-weighted truncation (see #829) — not a head-only prefix.
+    // (The full, untruncated commit is legitimately shown in full further
+    // down under "Build provenance", so it is not asserted absent here.)
+    expect(markup).toContain("abcdef01…89abcdef01");
     expect(markup).toContain(INFO.sourceCommit);
     expect(markup.match(/Copy build info/g)).toHaveLength(1);
     expect(markup).toContain('role="status"');

--- a/wallet/zuuli/src/lib/about-copy.ts
+++ b/wallet/zuuli/src/lib/about-copy.ts
@@ -42,6 +42,8 @@ export const ABOUT_MESSAGES = Object.freeze({
   feedbackDescriptionLabel: "What happened?",
   feedbackDescriptionHint:
     "Do not include wallet secrets, passwords, tokens, addresses, transaction details, balances, device details, or local files.",
+  feedbackMnemonicLanguageScope:
+    "Automatic screening for recovery phrases only recognizes the English BIP-39 wordlist. A recovery phrase in another language (for example Japanese, Spanish, French, Italian, Korean, Czech, or Portuguese) will not be detected or removed automatically — never paste a recovery phrase here yourself, in any language.",
   feedbackDiagnosticsLabel: "Include sanitized diagnostics",
   feedbackDiagnosticsUnavailable:
     "Off. This build does not collect logs or tracebacks for feedback because their privacy safety is not proven.",

--- a/wallet/zuuli/src/lib/build-info.test.ts
+++ b/wallet/zuuli/src/lib/build-info.test.ts
@@ -5,8 +5,10 @@ import {
   BUILD_INFO,
   formatBuildInfoMinimal,
   formatBuildInfoProvenance,
+  shortSourceCommit,
   type BuildInfo,
 } from "./build-info";
+import { truncateAddress } from "./format";
 
 const INFO: BuildInfo = {
   productName: "ZUULI",
@@ -42,7 +44,7 @@ describe("immutable build info", () => {
     const text = formatBuildInfoMinimal(hostile);
 
     expect(text).toBe(
-      "ZUULI\nVersion: 1.2.3\nBuild: 45\nRelease channel: Internal\nPlatform: iOS\nSource commit: abcdef012345",
+      "ZUULI\nVersion: 1.2.3\nBuild: 45\nRelease channel: Internal\nPlatform: iOS\nSource commit: abcdef01…89abcdef01",
     );
     for (const secret of [
       hostile.account,
@@ -55,6 +57,16 @@ describe("immutable build info", () => {
     ]) {
       expect(text).not.toContain(secret);
     }
+  });
+
+  it("shortens the source commit in the middle, tail-weighted, not by head prefix (#829)", () => {
+    // Pin the exact format so it cannot regress back to a head-only prefix.
+    expect(shortSourceCommit(INFO.sourceCommit)).toBe("abcdef01…89abcdef01");
+    // Reuses the shared opaque-identifier helper rather than reimplementing it.
+    expect(shortSourceCommit(INFO.sourceCommit)).toBe(
+      truncateAddress(INFO.sourceCommit as string),
+    );
+    expect(shortSourceCommit(null)).toBeNull();
   });
 
   it("labels absent optional provenance honestly", () => {

--- a/wallet/zuuli/src/lib/build-info.ts
+++ b/wallet/zuuli/src/lib/build-info.ts
@@ -2,6 +2,7 @@ import {
   resolveAboutMessages,
   type AboutMessages,
 } from "./about-copy";
+import { truncateAddress } from "./format";
 
 export type BuildInfo = Readonly<{
   productName: "ZUULI";
@@ -42,8 +43,16 @@ export function buildPlatformLabel(
   }[platform];
 }
 
+/**
+ * Shorten a full source commit SHA for display.
+ *
+ * Reuses `truncateAddress`'s middle, tail-weighted truncation — the same
+ * convention used for every other opaque identifier in the app — rather
+ * than a head-only prefix, which would discard exactly the trailing bytes
+ * that disambiguate two nearby commits. See #829.
+ */
 export function shortSourceCommit(sourceCommit: string | null) {
-  return sourceCommit ? sourceCommit.slice(0, 12) : null;
+  return sourceCommit ? truncateAddress(sourceCommit) : null;
 }
 
 type MinimalBuildInfo = Pick<

--- a/wallet/zuuli/src/lib/feedback.test.ts
+++ b/wallet/zuuli/src/lib/feedback.test.ts
@@ -356,6 +356,40 @@ describe("feedback privacy boundary", () => {
     },
   );
 
+  // #830: detection is checksum-based against the shipping *English* BIP-39
+  // wordlist only (see `isValidEnglishBip39Mnemonic`/bip39-english.ts) — the
+  // Rust backend only ever generates and accepts English mnemonics, but a
+  // user could bring one home from another wallet in another language. This
+  // is a real, bounded gap, not a regression: it is documented in the
+  // composer's copy (`feedbackMnemonicLanguageScope`) rather than silently
+  // assumed away. These tests pin the current (English-only) boundary.
+  it.each([
+    // French wordlist words with no ASCII-diacritic overlap onto the shipping
+    // English dictionary.
+    "abaisser abdiquer abeille abolir aborder aboutir aboyer abrasif abreuver abriter abroger absence",
+    // Japanese wordlist words: non-Latin script never matches the `[a-z]+`
+    // scan at all, regardless of dictionary contents.
+    "あいこくしん あいさつ あいだ あおぞら あかちゃん あきる あけがた あける あこがれる あさい あさひ あしあと",
+  ])(
+    "does not recognize a bare non-English mnemonic-shaped phrase (documented scope, #830): %s",
+    (phrase) => {
+      const draft = { subject: DEFAULT_SUBJECT, body: phrase };
+      const reviewed = reviewFeedbackDraft(draft, REDACTED_VALUE);
+      expect(reviewed.findings).toHaveLength(0);
+      expect(reviewed.draft.body).toBe(phrase);
+    },
+  );
+
+  it("still removes a non-English phrase once English recovery-phrase context labels it (#830)", () => {
+    const draft = {
+      subject: DEFAULT_SUBJECT,
+      body: "my recovery phrase: abaisser abdiquer abeille abolir aborder aboutir aboyer abrasif abreuver abriter abroger absence",
+    };
+    const reviewed = reviewFeedbackDraft(draft, REDACTED_VALUE);
+    expect(reviewed.findings.length).toBeGreaterThan(0);
+    expect(reviewed.draft.body).toBe(REDACTED_VALUE);
+  });
+
   it.each([
     "Saved in /opt/zuuli/wallet.dat",
     "Read \\\\server\\share\\wallet.bin",

--- a/wallet/zuuli/src/lib/feedback.test.ts
+++ b/wallet/zuuli/src/lib/feedback.test.ts
@@ -12,6 +12,7 @@ import {
   type FeedbackDraft,
 } from "./feedback";
 import { isValidEnglishBip39Mnemonic } from "./bip39";
+import { truncateAddress } from "./format";
 
 const BUILD_BLOCK =
   "ZUULI\nVersion: 0.1.0\nBuild: 17\nChannel: Internal\nPlatform: iOS\nSource commit: 0123456789ab";
@@ -468,6 +469,43 @@ describe("feedback privacy boundary", () => {
       }
     },
   );
+
+  it("does not mistake a middle-truncated opaque identifier for a filename (#829 regression)", () => {
+    // #829 switched the embedded "Source commit" line from a head-only
+    // prefix to truncateAddress's middle, tail-weighted "head…tail" form.
+    // NFKC-normalizing "…" expands it to three literal dots, which used to
+    // read as a `word...ext`-shaped filename and wipe the whole report —
+    // including the app's own auto-attached, pre-vetted build info, on
+    // every single submission. A single dot still separates a real
+    // filename from its extension; three consecutive dots must not.
+    const shortCommit = truncateAddress(
+      "6dc7d6fe1fe6bcbc02d4bf83486ebaf66a419a8a",
+    );
+    expect(shortCommit).toContain("…");
+    const block = `ZUULI\nVersion: 0.1.0\nBuild: 19\nRelease channel: Internal\nPlatform: Web\nSource commit: ${shortCommit}`;
+    const reviewed = createFeedbackDraft(
+      "The save action stopped responding.",
+      block,
+      DEFAULT_SUBJECT,
+      REDACTED_VALUE,
+    );
+    expect(reviewed.findings).toEqual([]);
+    // The pipeline NFKC-normalizes all text (including the app's own
+    // build-info block), which expands "…" to "..." — that normalized form
+    // is what should survive review, not the original glyph.
+    expect(reviewed.draft.body).toContain(shortCommit.normalize("NFKC"));
+  });
+
+  it("still removes a real bare filename with a single dot (crash.log)", () => {
+    const reviewed = createFeedbackDraft(
+      "The app failed. crash.log",
+      BUILD_BLOCK,
+      DEFAULT_SUBJECT,
+      REDACTED_VALUE,
+    );
+    expect(reviewed.findings.length).toBeGreaterThan(0);
+    expect(reviewed.draft.body).toBe(REDACTED_VALUE);
+  });
 
   it("allows a username or email only when the user explicitly enters it", () => {
     const result = createFeedbackDraft(

--- a/wallet/zuuli/src/lib/feedback.ts
+++ b/wallet/zuuli/src/lib/feedback.ts
@@ -99,7 +99,12 @@ const PATH_PATTERNS: readonly RegExp[] = [
   /(?:^|\s)(?:[A-Za-z]:[\\/]|\\\\|~[\\/]|\.{1,2}[\\/])[^\n]+/gmu,
   /\b(?:file|filename|path)\s*(?:=|:|is\b)\s*[^\n]+/giu,
   /\b(?:rust_backtrace|backtrace|traceback|stack\s+trace|TauriInvokeError|JavaScriptError)\b[^\n]*/giu,
-  /\b[^\s/\\]+\.[A-Za-z][A-Za-z0-9]{0,11}(?::\d+(?::\d+)?)?\b/gu,
+  // A single dot separates a real filename from its extension. Three
+  // consecutive dots are an ellipsis (NFKC-normalized from "…", e.g. inside
+  // a middle-truncated opaque identifier like a shortened commit SHA), not
+  // an extension separator, so the dot immediately preceding this one must
+  // not itself be a dot.
+  /\b[^\s/\\]+(?<!\.)\.[A-Za-z][A-Za-z0-9]{0,11}(?::\d+(?::\d+)?)?\b/gu,
   /(?:^|\s)\.[A-Za-z_][A-Za-z0-9_-]*(?=\s|$)/gmu,
 ];
 

--- a/wallet/zuuli/tests/about.pw.ts
+++ b/wallet/zuuli/tests/about.pw.ts
@@ -43,8 +43,10 @@ test("copy uses the complete stable minimal block and announces completion", asy
   await page.getByRole("button", { name: "Copy build info" }).click();
   await expect(page.getByRole("status")).toHaveText("Build info copied.");
   const copied = await page.evaluate(() => navigator.clipboard.readText());
+  // Middle, tail-weighted truncation (see #829) — reuses truncateAddress's
+  // default 8-head/10-tail split rather than a head-only prefix.
   expect(copied).toMatch(
-    /^ZUULI\nVersion: 0\.1\.0\nBuild: 19\nRelease channel: Internal\nPlatform: Web\nSource commit: [0-9a-f]{12}$/,
+    /^ZUULI\nVersion: 0\.1\.0\nBuild: 19\nRelease channel: Internal\nPlatform: Web\nSource commit: [0-9a-f]{8}…[0-9a-f]{10}$/,
   );
   expect(copied).not.toMatch(/wallet|balance|device|address|\/Users\//i);
 });


### PR DESCRIPTION
## Summary

Two related ZUULI About/Feedback fixes, same feature area, one PR.

### #829 — About commit SHA truncated head-first

`shortSourceCommit()` in `wallet/zuuli/src/lib/build-info.ts` used
`sourceCommit.slice(0, 12)` — a head-only prefix, which discards exactly the
trailing bytes that disambiguate two nearby commits. It now reuses the
existing `truncateAddress()` helper (`src/lib/format.ts`) — the same
middle, tail-weighted convention already used for every other opaque
identifier in the app — instead of reimplementing truncation.

This value is shared by the on-screen About row *and* the "Copy build
info" / feedback auto-attached block, so the fix (and its fallout, below)
touches both.

Pinned by:
- `src/lib/build-info.test.ts` — new test asserting the exact
  `"abcdef01…89abcdef01"`-shaped output and that it equals
  `truncateAddress(...)` directly.
- `src/features/about/about.test.tsx` — updated markup assertion.
- `tests/about.pw.ts` — updated "Copy build info" clipboard regex.

### #830 — feedback composer's BIP-39 detection is English-only

Per the issue, the composer's mnemonic scrubber is checksum-verified
against the shipping **English** BIP-39 wordlist only (matches the Rust
backend, which only ever generates/accepts English mnemonics). A user
bringing a mnemonic from another wallet in Japanese/Spanish/French/
Italian/Korean/Czech/Portuguese would not be detected.

**Decision: scope detection to English explicitly, and say so plainly in
the composer's copy**, rather than bundling the other 7 standard BIP-39
wordlists.

Why: each additional wordlist is a full 2048-word, checksum-verified
dictionary (`bip39-english.ts` alone is ~20KB raw) — 7 more languages is
real bundle-size cost, and non-trivial correctness risk for wordlists
(and, for CJK/Korean, normalization/joining conventions) this codebase
has no existing way to verify as rigorously as the shipping English list
is verified against the native Rust crate. An honest, explicit scope
statement is safer than a partially-verified expansion that silently
under- or over-claims coverage.

Change:
- New catalog key `feedbackMnemonicLanguageScope` in
  `src/lib/about-copy.ts` (`ABOUT_MESSAGES`), rendered in
  `FeedbackComposer.tsx` under the description field and wired into its
  `aria-describedby` alongside the existing hint.
- Tests in `src/lib/feedback.test.ts` document the boundary: a bare
  non-English mnemonic-shaped phrase (French wordlist words; Japanese
  script) passes through unscrubbed, but the same phrase is still removed
  once accompanied by an English recovery-phrase context label (existing
  heuristic already covers that case).
- `src/features/about/FeedbackComposer.test.tsx` asserts the new copy
  renders and is wired for accessibility.

**On the i18n kernel**: `wallet/zuuli`'s About/Feedback feature has its
own bounded, key-parity-enforced catalog (`ABOUT_MESSAGES` /
`ABOUT_MESSAGE_KEYS` / `ABOUT_CATALOGS` in `about-copy.ts`, validated by
`validateAboutMessages`) — it does not go through the separate global
`src/i18n` kernel (`MESSAGE_KEYS` / `t()` / `en.json`/`es.json`/`fr.json`),
which is scoped to shell/navigation strings only and has no About/Feedback
entries today. The new string was added to About's own catalog, which is
the kernel this feature actually uses; `src/i18n/locales/{en,es,fr}.json`
were intentionally left untouched.

### Regression found and fixed along the way

Embedding the new ellipsis-truncated commit SHA into the feedback
composer's auto-attached build-info block broke the feedback flow
completely: the scrubber NFKC-normalizes all text up front, which expands
"…" (U+2026) into three literal ASCII dots, and the path/filename
heuristic in `src/lib/feedback.ts` treated the last of those three dots
followed by a letter as a `name.ext`-shaped match — redacting the entire
report (including the user's own description) on **every** submission,
since the build-info block is unconditionally appended to every draft.

Fixed by tightening that pattern so a dot preceded by another dot (i.e.
part of an ellipsis, never a real extension separator) doesn't count;
bare single-dot filenames (e.g. `crash.log`) are still caught. Covered by
a new regression test in `feedback.test.ts`.

## Test plan

All run from `wallet/zuuli` via `npm ci`:
- [x] `npm run typecheck` — pass
- [x] `npx vitest run` — 1506 passed / 5 skipped (100 files)
- [x] `node scripts/ui-copy-truncation.node-test.mjs` — 4/4 pass
- [x] `npx playwright test` — 185/185 pass (full suite, foreground)

Closes #829
Closes #830

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH