### PR TITLE
fix(zuuli): make the More sheet's translate override direction-aware

### DIFF
--- a/wallet/zuuli/src/components/layout/Sidebar.tsx
+++ b/wallet/zuuli/src/components/layout/Sidebar.tsx
@@ -236,8 +236,20 @@ export function MobileTabBar() {
                 </span>
               </button>
             </DialogTrigger>
+            {/* DialogContent's base classes position a *centered* dialog via
+                `ltr:-translate-x-1/2 rtl:translate-x-1/2` (a direction-aware
+                utility pair, both variant-scoped). This bottom sheet needs
+                zero horizontal translate instead, but `translate-x-0` alone
+                does not override either of those — tailwind-merge treats a
+                variant-scoped utility and an unprefixed one as non-competing,
+                so both stayed in the class list. While `animate-slide-up` is
+                running it sets `transform` on every frame and hides this;
+                the instant that animation's effect is removed on completion,
+                the base utility wins the cascade and the sheet snaps to
+                translateX(-50%) — fully off-screen. Override both directions
+                explicitly so tailwind-merge actually drops the base ones. */}
             <DialogContent
-              className="app-mobile-more-dialog bottom-0 start-0 top-auto w-full max-w-none translate-x-0 translate-y-0 gap-2 overflow-y-auto rounded-b-none rounded-t-2xl border-x-0 border-b-0 p-4 data-[state=open]:animate-slide-up sm:bottom-0 sm:start-0 sm:top-auto sm:max-w-none sm:translate-x-0 sm:translate-y-0 sm:rounded-b-none sm:rounded-t-2xl"
+              className="app-mobile-more-dialog bottom-0 start-0 top-auto w-full max-w-none ltr:translate-x-0 rtl:translate-x-0 translate-y-0 gap-2 overflow-y-auto rounded-b-none rounded-t-2xl border-x-0 border-b-0 p-4 data-[state=open]:animate-slide-up sm:bottom-0 sm:start-0 sm:top-auto sm:max-w-none sm:ltr:translate-x-0 sm:rtl:translate-x-0 sm:translate-y-0 sm:rounded-b-none sm:rounded-t-2xl"
               closeClassName="app-mobile-more-close min-tap top-2 grid place-items-center rounded-md"
               data-mobile-more-dialog
             >

--- a/wallet/zuuli/tests/navigation.pw.ts
+++ b/wallet/zuuli/tests/navigation.pw.ts
@@ -19,6 +19,22 @@ async function primaryNavigation(page: Page) {
   return navigation;
 }
 
+// The More dialog enters with `animate-slide-up` (a 0.24s translateY/opacity
+// tween — see tailwind.config.cjs). Reading its geometry while that
+// animation is still running is a real race: (1) its rows sit exactly at
+// the 44px `min-tap` floor with zero margin, so a mid-tween frame can read a
+// sub-pixel value just under 44px, and (2) while the CSS animation's own
+// per-frame transform is active it can paper over a resting-position bug —
+// see the `ltr:`/`rtl:` translate fix in Sidebar.tsx — that only becomes
+// visible once the animation's effect is removed. Wait for the dialog's own
+// entrance animations to actually finish (a real condition) before measuring
+// anything inside it, rather than racing the tween or padding with a sleep.
+async function waitForEntranceAnimations(element: Locator) {
+  await element.evaluate((node) =>
+    Promise.all(node.getAnimations().map((animation) => animation.finished)),
+  );
+}
+
 async function expectFiveItemGeometry(
   navigation: Locator,
   expectedLabels: readonly string[] = PRIMARY_LABELS,
@@ -111,6 +127,7 @@ for (const signedIn of [false, true]) {
 
       const dialog = page.getByRole("dialog", { name: "More" });
       await expect(dialog).toBeVisible();
+      await waitForEntranceAnimations(dialog);
       const dialogGeometry = await dialog.evaluate((element) => {
         const rect = element.getBoundingClientRect();
         return {


### PR DESCRIPTION
## Summary

#851 turned out to be **two real problems**, not a flake:

**1. A genuine layout bug.** `DialogContent`'s base classes position a centered dialog via `ltr:-translate-x-1/2 rtl:translate-x-1/2` (`wallet/zuuli/src/components/ui/dialog.tsx`) — a *variant-scoped* utility pair. The mobile More bottom sheet overrode it with plain `translate-x-0`, but tailwind-merge treats a variant-scoped utility and an unprefixed one as non-competing, so **both stayed in the class list**. While `animate-slide-up` runs it sets `transform` on every frame and masks this; the instant that animation's effect is removed on completion, the base utility wins the cascade and the sheet snaps to `translateX(-50%)` — fully off-screen. Fix: override both directions explicitly (`ltr:translate-x-0 rtl:translate-x-0`, and the `sm:` variants) so tailwind-merge actually drops the base utilities.

**2. A measurement race.** The More sheet's rows sit exactly at the 44px `min-tap` floor with zero margin, so reading geometry mid-tween could read a sub-pixel value just under 44px. Fix: `navigation.pw.ts` now waits on the dialog's own `getAnimations()` promises to settle before measuring anything inside it — a real condition, not a sleep.

## Reproduction evidence (layout bug confirmed, not just diagnosed)

Reverted only the `Sidebar.tsx` class change (kept the animation-wait fix) and reran `navigation.pw.ts`. All four "five-item navigation" tests failed identically:

```
Expected: >= 0
Received:    -160   (at 320px viewport)
Received:    -180   (at 360px viewport)
```

`-160` and `-180` are exactly `-width/2` of the full-width sheet at each viewport (320/2, 360/2) — the sheet was centered off the left edge by half its own width, i.e. entirely off-screen, at rest, every time (not intermittently). Restoring the fix made all 10 `navigation.pw.ts` tests pass again.

## Measured touch targets at 320px, five items (post-fix)

| Control | width × height |
|---|---|
| Primary nav: Home / Live / AI / Wallet / More | 64 × 55 (each) |
| More sheet row: Articles / Messages / Profile / Revenue share / About & Feedback | 288 × 44 (each) |

All meet the 44px minimum. The More sheet rows sit exactly at the floor (44px, zero margin) — which is why mid-animation measurement could intermittently read sub-pixel under it. This is the number #851 asked for and nobody had supplied yet.

## Local verification (from `wallet/zuuli`)

- `npm ci`
- `npm run typecheck` — clean
- `npx vitest run` — 100 files, 1499 passed / 5 skipped, 0 failed (includes `BidiIdentifier.test.tsx`, the second flake tracked in #865 — passed here)
- `node scripts/ui-copy-truncation.node-test.mjs` — 4/4 pass
- `node scripts/rtl-source-policy.mjs` — OK; `rtl-source-policy.node-test.mjs` — 17/17 pass (this fix is direction-aware by construction, and doesn't trip the RTL policy check added in #861)
- `npx playwright test` — 184 passed, 1 unrelated pre-existing failure (`about.pw.ts` expected a real source-commit SHA but got "Unavailable in this build" — traced to `scripts/build-identity.mjs` intentionally nulling the source commit while the git checkout is dirty; confirmed the same test passes once the fix is committed and the tree is clean again)
- `npx playwright test tests/navigation.pw.ts --repeat-each=5` — 50/50 passed, no flake

## Related

Part of #865 (this navigation flake, plus a separate `BidiIdentifier.test.tsx` parallel-vitest-load timeout). This PR addresses only the navigation half; the `BidiIdentifier.test.tsx` timing issue is untouched here.

Closes #851

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH