### PR TITLE
docs(zuuli): re-derive STATUS at the build-20 anchor

### DIFF
--- a/wallet/zuuli/STATUS.md
+++ b/wallet/zuuli/STATUS.md
@@ -8,74 +8,96 @@ back from the named store. Authenticated, money-moving, wallet, KYC, and media
 operations are not called working without recorded evidence from that path.
 
 Last re-derived from `origin/main` at
-`e2be49c8e7b319c383b449d4ea1747c9a162c726` on 2026-08-31. Before a release,
+`9c78e90fda7aa4c886411164b4f490c2e522f46c` on 2026-09-01. Before a release,
 update the evidence and disposition for every non-ready row; do not carry this
 commit or date forward mechanically.
 
-This anchor is the first one since build 18 to carry application changes.
-Thirteen PRs landed between `73b14ff` (the build-18 anchor) and this commit:
-the i18n kernel ([#797](https://github.com/free2z/zuu/pull/797)), the wallet
-identity store foundation ([#805](https://github.com/free2z/zuu/pull/805)),
-locked creator ZEC tip intents ([#799](https://github.com/free2z/zuu/pull/799)),
-the authoritative `ppv` stream kind
-([#817](https://github.com/free2z/zuu/pull/817)), trusted first-party image
-auto-load ([#801](https://github.com/free2z/zuu/pull/801)), camera/microphone
-preflight ([#804](https://github.com/free2z/zuu/pull/804)), MLS `KeyPackage`
-publication ([#769](https://github.com/free2z/zuu/pull/769)), and six `rs/`
-changes ([#836](https://github.com/free2z/zuu/pull/836),
-[#833](https://github.com/free2z/zuu/pull/833),
-[#835](https://github.com/free2z/zuu/pull/835),
-[#839](https://github.com/free2z/zuu/pull/839),
-[#840](https://github.com/free2z/zuu/pull/840),
-[#834](https://github.com/free2z/zuu/pull/834)).
+This is the widest anchor since build 14. Thirty-three commits landed between
+`e2be49c8` (the build-19 anchor) and this one; two of them are build 19's own
+ceremony ([#842](https://github.com/free2z/zuu/pull/842) and
+[#843](https://github.com/free2z/zuu/pull/843)), so **thirty-one PRs reach a
+build for the first time in `0.1.0+20`**:
+
+- **ZUULI application and UI** — the off-screen mobile More sheet
+  ([#869](https://github.com/free2z/zuu/pull/869)), About commit-SHA
+  middle-truncation and English-scoped BIP-39 detection
+  ([#868](https://github.com/free2z/zuu/pull/868)), safe-area-aware snackbars
+  ([#863](https://github.com/free2z/zuu/pull/863)), RTL layout mirroring and
+  bidi identifier isolation ([#861](https://github.com/free2z/zuu/pull/861)),
+  autocomplete-first discovery
+  ([#803](https://github.com/free2z/zuu/pull/803)), the privacy-safe feedback
+  composer ([#823](https://github.com/free2z/zuu/pull/823)), exact About build
+  identity ([#822](https://github.com/free2z/zuu/pull/822)), truthful
+  participant counts ([#798](https://github.com/free2z/zuu/pull/798)), live
+  join tickets bound to meetings
+  ([#819](https://github.com/free2z/zuu/pull/819)), and mock/`handle.rs`
+  handle-eligibility parity
+  ([#864](https://github.com/free2z/zuu/pull/864)).
+- **Build, boundary, and release tooling** — real wallet project boundaries
+  ([#862](https://github.com/free2z/zuu/pull/862)), the DMG shipped-artifact
+  SBOM canary ([#866](https://github.com/free2z/zuu/pull/866)), the
+  store-capture toolchain image
+  ([#857](https://github.com/free2z/zuu/pull/857)), Playwright in documented
+  local verification ([#845](https://github.com/free2z/zuu/pull/845)), the
+  Actions cache ceiling ([#846](https://github.com/free2z/zuu/pull/846)), and
+  the markdown-only Rust-matrix skip
+  ([#848](https://github.com/free2z/zuu/pull/848)).
+- **`rs/` and messaging** — rejecting a `same_key` entry that rotates
+  `directory_auth_pk` ([#841](https://github.com/free2z/zuu/pull/841)), MLS
+  group restore after a receive rollback
+  ([#781](https://github.com/free2z/zuu/pull/781)), fail-closed relay error
+  contexts ([#800](https://github.com/free2z/zuu/pull/800)), a discriminating
+  test for the relay `MAX_CONCURRENT` cap
+  ([#867](https://github.com/free2z/zuu/pull/867)), reserved queue-creation
+  coverage ([#860](https://github.com/free2z/zuu/pull/860)), the
+  `cfg_attr(derive(Debug))` scanner blind spot
+  ([#858](https://github.com/free2z/zuu/pull/858)), and the withdrawn PoW
+  calibration claim ([#859](https://github.com/free2z/zuu/pull/859)).
+- **Dependency and documentation hygiene** —
+  [#855](https://github.com/free2z/zuu/pull/855),
+  [#856](https://github.com/free2z/zuu/pull/856),
+  [#853](https://github.com/free2z/zuu/pull/853),
+  [#854](https://github.com/free2z/zuu/pull/854),
+  [#849](https://github.com/free2z/zuu/pull/849),
+  [#850](https://github.com/free2z/zuu/pull/850),
+  [#852](https://github.com/free2z/zuu/pull/852), and
+  [#847](https://github.com/free2z/zuu/pull/847).
 
 At the anchor SHA itself the push-triggered
-[rs gate](https://github.com/free2z/zuu/actions/runs/33362593695) and
-[f2z servers / images](https://github.com/free2z/zuu/actions/runs/33362593719)
-runs both completed successfully. The anchor's own required
-[wallet/zuuli gate](https://github.com/free2z/zuu/actions/runs/33362593912) was
-still queued behind a saturated runner pool when this was re-derived and is
-therefore **not** counted as evidence here. Unlike the build-18 re-derive, the
-merged PR's own green gate cannot stand in for it: `#834`'s head
-`47c357c2ab504e059b2c74af3426ed09925ae658` carries tree
-`a7d4bb073112ad6b91b6b04a4d935a470c422c0d`, which is not this anchor's tree
-(`f60a154c6cc525308c98e01c13973ca67f92efcc`), so its
-[wallet/zuuli](https://github.com/free2z/zuu/actions/runs/33351312164) and
-[rs](https://github.com/free2z/zuu/actions/runs/33351312169) runs are evidence
-for a near neighbour and not for this source. The nearest **completed** required
-`wallet/zuuli` gate on this anchor's first-parent history is
-[33360519208](https://github.com/free2z/zuu/actions/runs/33360519208) at
-`f4bca187`, the anchor's parent. Every release-impacting path in this snapshot
-except `#834`'s `rs/crates/f2z-relay-testkit` change is therefore gate-covered
-at exactly the shipped content, and that one change is covered by the anchor's
-own successful `rs` run.
+[rs gate](https://github.com/free2z/zuu/actions/runs/33479067721) completed
+successfully. The anchor's own required
+[wallet/zuuli gate](https://github.com/free2z/zuu/actions/runs/33479067797) and
+its [packaging smoke](https://github.com/free2z/zuu/actions/runs/33479067766)
+had not concluded when this was re-derived — the gate still queued behind a
+saturated runner pool, the smoke in flight — and are therefore **not** counted
+as evidence here. As at the build-19 anchor, the
+merged PRs' own green gates cannot stand in for them, because none of their
+heads carries this anchor's tree (`dd78fd26`): `#869`'s head `b6290fd3` carries
+tree `15a74971`
+([wallet/zuuli](https://github.com/free2z/zuu/actions/runs/33472459527)),
+`#868`'s head `e9c33e62` carries tree `c3f0ae54`
+([wallet/zuuli](https://github.com/free2z/zuu/actions/runs/33471808539)), and
+`#864`'s head `ea6bf084` carries tree `ecc4c442`
+([wallet/zuuli](https://github.com/free2z/zuu/actions/runs/33472198284)). Those
+three runs are evidence for three near neighbours, not for this source.
 
-The four-target packaging smoke did not run at this anchor: none of the seven
-commits after `87b1e65` touches a path in its trigger set, which covers
-`wallet/zuuli/**` and `wallet/plugins/tauri-plugin-zcash/**` but neither `rs/**`
-nor `wallet/plugins/tauri-plugin-f2zmsg/**`. The most recent smoke over the
-ZUULI application surface,
-[33355838136](https://github.com/free2z/zuu/actions/runs/33355838136) at
-`87b1e65e` (`#804`), was still queued when this was re-derived. The one before
-it, [33355831108](https://github.com/free2z/zuu/actions/runs/33355831108) at
-`a048fcbc` (`#801`), **failed** — not on the build, which succeeded on all four
-targets, but on `Scan macOS DMG shipped artifact`, where `anchore/sbom-action`
-could not download the syft installer
-(`Request timeout: /anchore/syft/main/install.sh`, three attempts). That is an
-infrastructure fault in SBOM tooling rather than a source defect, but the
-consequence stands: **no completed four-target packaging smoke covers the last
-two ZUULI application changes at this anchor.** The most recent green one is
-[33355822526](https://github.com/free2z/zuu/actions/runs/33355822526) at
-`9658cf84` (`#817`). Both changes did pass a four-target smoke at their exact
-merged PR heads before merge —
-[33348843793](https://github.com/free2z/zuu/actions/runs/33348843793) at
-`33ed5101` for `#801` and
-[33350104681](https://github.com/free2z/zuu/actions/runs/33350104681) at
-`16737c2e` for `#804` — which is package-build evidence for that content on a
-different base, not for the anchor's tree.
+The nearest **completed** required `wallet/zuuli` gate on this anchor's
+first-parent history is
+[33474816218](https://github.com/free2z/zuu/actions/runs/33474816218) at
+`9ebf39d` (`#866`), three commits back, and the four-target packaging smoke
+[33474816193](https://github.com/free2z/zuu/actions/runs/33474816193) succeeded
+at that same commit across the macOS universal app, the iOS unsigned target
+app, the Linux packages, and the unsigned Android AAB. Every release-impacting
+path in this snapshot is therefore gate-covered at exactly the shipped content
+**except** the three commits after it — `#864`'s
+`wallet/plugins/tauri-plugin-f2zmsg/src/handle.rs` and mock fixture, `#868`'s
+About, feedback, and build-info sources, and `#869`'s `Sidebar.tsx` — whose
+release-impacting content is covered only at their own PR heads.
 
 These are source, test, and package-build evidence only. They add no
-product-operation or physical-device evidence.
+product-operation or physical-device evidence. Nothing in this anchor was
+exercised on a physical device, and no store readback has been taken since
+build 17.
 
 ## Evidence boundaries
 
@@ -102,14 +124,16 @@ product-operation or physical-device evidence.
 
 | Surface | Real API/backend dependency | Native integration | Automated evidence | Production/native evidence | Current status and linked gaps |
 |---|---|---|---|---|---|
-| Runtime transport | Production bundle → `free2z.cash`; development proxy → staging | `tauri-plugin-http` is registered and selected for packaged non-dev Tauri. [#801](https://github.com/free2z/zuu/pull/801) added `https://*.free2z.cash/*` to both capability HTTP allowlists and put `https://free2z.cash` and `https://*.free2z.cash` into the packaged `connect-src`, plus `blob:` in `img-src` | The required frontend/Rust gate passes at the anchor's **parent**, which covers every release-impacting path here except the anchor's own relay-testkit change; the anchor's own gate and the newest packaging smoke were still queued at re-derivation | Signed-store and unsigned packages exist; no per-surface native HTTP success is recorded here | **Wired, not runtime-proven.** The former claim that packaged HTTP registration was missing was false. |
-| Public Articles, creator listing, search, Live discovery, AI models, and pricing | Public `zpage`, `creator`, `dyte/public`, `ai/models`, `pricing`, and `pricing/quote` endpoints | Shared native HTTP transport in packaged builds | Parser/component tests cover selected article, remote-data, and media contracts. [#797](https://github.com/free2z/zuu/pull/797) routes this surface's copy through a repo-wide message catalog (`en`/`es`/`fr`) with build-boundary and copy-policy tests; that is a source and test change to presentation only, and it adds no backend evidence | Unfiltered collection/model/pricing production GETs returned HTTP 200 on 2026-08-31; Live returned a valid empty page. Filtered creator/article search was not probed | **Collection reads production-observed; search wired, not runtime-proven.** Signed-native rendering remains unrecorded. The source/test fixes for articles ([#337](https://github.com/free2z/zuu/issues/337), [#374](https://github.com/free2z/zuu/issues/374), [#250](https://github.com/free2z/zuu/issues/250), [#251](https://github.com/free2z/zuu/issues/251)) and pagination ([#252](https://github.com/free2z/zuu/issues/252), [#253](https://github.com/free2z/zuu/issues/253)) do not create signed-native or filtered-search runtime evidence. |
+| Runtime transport | Production bundle → `free2z.cash`; development proxy → staging | `tauri-plugin-http` is registered and selected for packaged non-dev Tauri. [#801](https://github.com/free2z/zuu/pull/801) added `https://*.free2z.cash/*` to both capability HTTP allowlists and put `https://free2z.cash` and `https://*.free2z.cash` into the packaged `connect-src`, plus `blob:` in `img-src` | The required frontend/Rust gate and the four-target packaging smoke both pass three commits back at `9ebf39d`, which covers every release-impacting path here except the last three application commits; the anchor's own gate and smoke were still queued at re-derivation. [#862](https://github.com/free2z/zuu/pull/862) additionally makes `wallet/shared/` a real `@free2z/wallet-shared` package and adds a required boundary scanner so neither app can reach into the other's source | Signed-store and unsigned packages exist; no per-surface native HTTP success is recorded here | **Wired, not runtime-proven.** The former claim that packaged HTTP registration was missing was false. |
+| App shell, mobile navigation, and localization | None | Safe-area insets and the mobile tab bar are native-surface concerns | Playwright geometry suites at 320/360px cover the five-item primary nav and the More sheet. [#869](https://github.com/free2z/zuu/pull/869) fixes a real defect: `DialogContent`'s variant-scoped `ltr:-translate-x-1/2` was not dropped by tailwind-merge when the sheet overrode it with an unprefixed `translate-x-0`, so the instant the entrance animation's effect was removed the base utility won and the sheet snapped to `translateX(-50%)`. Reverting only that class change reproduced it deterministically — dialog `left` at **-160 at 320px and -180 at 360px**, exactly `-width/2` — on every run, not intermittently. The same PR makes `navigation.pw.ts` wait on the dialog's own `getAnimations()` instead of measuring mid-tween. [#863](https://github.com/free2z/zuu/pull/863) gives Sonner toasts safe-area-aware offsets that clear the whole mobile tab bar; [#861](https://github.com/free2z/zuu/pull/861) mirrors layout for RTL locales, isolates bidi identifiers, and adds a source-policy gate against physical-direction utilities | No signed build has been observed on a physical device at any viewport. All geometry evidence is headless browser measurement | **A user-facing mobile-navigation defect shipped in builds 18 and 19 and is first fixed in build 20.** On a narrow viewport the More sheet — the only route to Articles, Messages, Profile, Revenue share, and About — rendered fully off-screen at rest once its entrance animation ended. It is fixed in source and covered by a test that was proven to fail without the fix; it has **not** been confirmed on a device. RTL and inset behaviour are likewise source and browser-test evidence only. Physical-device acceptance for the shell: [#331](https://github.com/free2z/zuu/issues/331), [#238](https://github.com/free2z/zuu/issues/238). |
+| About & Feedback | None for the About row; the feedback handoff opens an external mail client or GitHub | Build identity is injected at bundle time from canonical `release.json`, the checked-out full source SHA, and the Tauri build platform; the OS opener performs the handoff | [#822](https://github.com/free2z/zuu/pull/822) binds version/build/channel/platform/source identity through release verification and artifact provenance, with drift, offline, clipboard, keyboard, screen-reader, and enlarged-text tests. [#823](https://github.com/free2z/zuu/pull/823) shows the complete outgoing subject and body before any handoff, fails closed with **no** diagnostic, log, stack, or runtime capture because traceback safety is not proven, and scrubs wallet/auth/network/path/encoded-secret shapes at review and again before copy. [#868](https://github.com/free2z/zuu/pull/868) middle-truncates the commit SHA through the shared `truncateAddress()` helper instead of a head-only `slice(0, 12)`, scopes BIP-39 mnemonic detection explicitly to English and surfaces that limit in the composer copy, and fixes the regression where the new ellipsis matched the scrubber's own path shape and redacted every report | No feedback report has been composed or sent from a signed build, and no build has been observed displaying its own identity on a device | **New visible surface in build 20; source and test evidence only.** The scrubber is a best-effort redactor over text the user can still edit before sending; it is not a guarantee, and non-English mnemonics are explicitly out of its detection scope and said so in the UI. Nothing here is device-proven. |
+| Public Articles, creator listing, search, Live discovery, AI models, and pricing | Public `zpage`, `creator`, `dyte/public`, `ai/models`, `pricing`, and `pricing/quote` endpoints | Shared native HTTP transport in packaged builds | Parser/component tests cover selected article, remote-data, and media contracts. [#797](https://github.com/free2z/zuu/pull/797) routes this surface's copy through a repo-wide message catalog (`en`/`es`/`fr`) with build-boundary and copy-policy tests; that is a source and test change to presentation only, and it adds no backend evidence. [#803](https://github.com/free2z/zuu/pull/803) replaces the Articles topic-pill wall with a topic autocomplete and adds mixed topic/creator/page suggestions to global Search, with tests for stale-response rejection, identity dedupe, and distinguishing a transport failure from an empty corpus — client contract only | Unfiltered collection/model/pricing production GETs returned HTTP 200 on 2026-09-01; Live returned a valid empty page. Filtered creator/article search and the new autocomplete endpoints were not probed against production | **Collection reads production-observed; search wired, not runtime-proven.** Signed-native rendering remains unrecorded. The source/test fixes for articles ([#337](https://github.com/free2z/zuu/issues/337), [#374](https://github.com/free2z/zuu/issues/374), [#250](https://github.com/free2z/zuu/issues/250), [#251](https://github.com/free2z/zuu/issues/251)) and pagination ([#252](https://github.com/free2z/zuu/issues/252), [#253](https://github.com/free2z/zuu/issues/253)) do not create signed-native or filtered-search runtime evidence. |
 | Username/password and TOTP sign-in | Knox Basic login, OTP status/login, and authenticated user endpoints | Token-backed HTTP; no special native plugin | Session-boundary, login-destination, component, and browser lifecycle tests | Anonymous protected reads returned HTTP 403; no successful production login is recorded | **Wired, not runtime-proven; not release-ready.** Server-side TOTP enforcement: [#369](https://github.com/free2z/zuu/issues/369). Token custody: [#377](https://github.com/free2z/zuu/issues/377). |
 | Login/link with Zcash | `auth/zcash/challenge` and `auth/zcash/login` | The shared plugin supports local recovery-phrase restore and transparent-address Zcash Signed Message signing | Native atomic-restore/signing tests and frontend restore/challenge lifecycle tests exercise local contracts | No production restore → native signature → Knox session round trip is recorded | **Restore is implemented and contract-tested, but the login path is not runtime-proven.** Recovery-phrase restore landed in [#428](https://github.com/free2z/zuu/pull/428); external-wallet signing remains unsupported. Physical recovery ceremony: [#246](https://github.com/free2z/zuu/issues/246). Wallet/login identity choice: [#329](https://github.com/free2z/zuu/issues/329). This is not ZIP-304. |
-| Social login/link | Provider discovery, authorization start, callback exchange, and authenticated user endpoints | Desktop loopback and mobile private-scheme transports exist | Strict discovery parsing, transport selection, attempt fencing, error/retry UI, and 320/360 browser tests cover the client contract; the live preflight fails closed before opening provider URLs | Both discovery endpoints answered anonymously with HTTP 200 on 2026-08-31. The web/desktop endpoint reports `x` with `configured: true`, `google` and `github` `configured: false`; the mobile endpoint returns all three `configured: false`. No OAuth round trip is recorded on any platform | **Client contract fixed; backend-dependent and not runtime-proven.** A provider is selectable on desktop/web; none is on mobile. A `configured` flag is not a login — no authorization start, callback exchange, or resulting session has been performed on any platform, so signed-device login/link proof remains blocked. Public client follow-up: [#403](https://github.com/free2z/zuu/issues/403). Claimed-HTTPS release proof: [#242](https://github.com/free2z/zuu/issues/242). Association binding: [#380](https://github.com/free2z/zuu/issues/380). |
+| Social login/link | Provider discovery, authorization start, callback exchange, and authenticated user endpoints | Desktop loopback and mobile private-scheme transports exist | Strict discovery parsing, transport selection, attempt fencing, error/retry UI, and 320/360 browser tests cover the client contract; the live preflight fails closed before opening provider URLs | Both discovery endpoints answered anonymously with HTTP 200 on 2026-09-01. The web/desktop endpoint reports `x` with `configured: true`, `google` and `github` `configured: false`; the mobile endpoint returns all three `configured: false`. No OAuth round trip is recorded on any platform | **Client contract fixed; backend-dependent and not runtime-proven.** A provider is selectable on desktop/web; none is on mobile. A `configured` flag is not a login — no authorization start, callback exchange, or resulting session has been performed on any platform, so signed-device login/link proof remains blocked. Public client follow-up: [#403](https://github.com/free2z/zuu/issues/403). Claimed-HTTPS release proof: [#242](https://github.com/free2z/zuu/issues/242). Association binding: [#380](https://github.com/free2z/zuu/issues/380). |
 | Wallet create/restore/sync/receive/send/history | Lightwalletd and librustzcash through the shared plugin | Real Tauri Zcash plugin is registered. [#805](https://github.com/free2z/zuu/pull/805) adds typed multi-wallet listing and switching through the ZUULI bridge and a new mobile capability, publishing inventory, active identity, and account-scoped data atomically and serializing concurrent switches | Plugin Rust tests, frontend wallet tests, and backend compilation run in CI. `#805` adds identity-store, bridge, lifecycle, concurrency, and fail-closed suites; the deterministic mock is what those exercise | Packages have built, but no signed-device create/restore/sync/receive/send record is checked into this repository. `#805` adds no device or lightwalletd evidence | **Wired, not runtime-proven; release stop until kick-the-tires evidence exists.** The identity store is a **foundation**: a switchable wallet inventory now exists in source and under test, and it has never selected a real account on a real device. Send confirmation integrity: [#368](https://github.com/free2z/zuu/issues/368). Preserved-wallet import: [#272](https://github.com/free2z/zuu/issues/272). |
 | AI conversations and billing | Model/personality APIs plus model-bound `ai/conversations/.../promptresponses` metering and authoritative balance refresh | Native HTTP | Component/state tests do not exercise a real metered conversation | Public model discovery returned HTTP 200; no authenticated production prompt and charge is recorded | **Wired, not runtime-proven.** The active UI uses the metered conversation path; the old flat-1-2Z description referred to legacy code. Conversation/model state: [#266](https://github.com/free2z/zuu/issues/266). |
-| Livestream room/media | Public listing plus authenticated start/join and membership endpoints | Cloudflare RealtimeKit provider and meeting UI are mounted; camera/mic are native permissions. [#804](https://github.com/free2z/zuu/pull/804) adds an explicit-intent camera/microphone preflight with device enumeration and a confirmed preview before provisioning, and locks the exact Android/iOS/macOS capture manifests — macOS `Entitlements.plist` capture entitlements and `Info.macos.plist` usage strings now exist where they did not | Membership reconciliation tests cover selected money-boundary races. [#818](https://github.com/free2z/zuu/pull/818) adds a browser test that loads the exact packaged `src-tauri/tauri.conf.json` CSP, proves the bundled SDK's first `api.realtime.cloudflare.com/v2/internals/participant-details` request is permitted, and uses a negative control that removes the added sources to reproduce the blocked-request boundary. [#817](https://github.com/free2z/zuu/pull/817) adds a strict `meeting_type` contract suite, and `#804` adds mutation-sensitive preflight and permission-manifest suites | Public listing returned HTTP 200 with zero active rooms; no native host/join/camera/mic session is recorded, and the preflight has never run against a real camera or microphone on a device. Founder QA on a Play-distributed build reported `ERR0001` when tapping Join Free on an active stream ([#813](https://github.com/free2z/zuu/issues/813)); `0.1.0+18` is the first build to carry the packaged-CSP fix, and it has been signed and uploaded to Play Internal but has **not** yet been read back from either store, so it is not yet confirmed available to a tester on either platform | **Wired, not end-to-end proven.** The former missing-SDK claim was false. The packaged CSP allowed only legacy Dyte origins and blocked RealtimeKit's first Cloudflare request, which deterministically produced that `ERR0001`; [#816](https://github.com/free2z/zuu/issues/816) is closed by `#818`, which permits only the audited RealtimeKit HTTPS/WSS origins and no blanket `https:`/`wss:`. `#817` additionally corrects the paid-stream wire value the client sent — it serialized `pay-per-view` where the free2z contract's enum is `ppv` — and now fails closed on an unknown, missing, or mismatched kind and on a missing, zero, negative, or malformed PPV rate instead of silently making a stream free or paid; that fix is likewise in no read-back build. All of this remains source and browser-test evidence: **[#813](https://github.com/free2z/zuu/issues/813) stays open and unproven until a real active room is actually joined from signed Android and iOS builds** alongside the web viewer. Metadata/PPV: [#262](https://github.com/free2z/zuu/issues/262). Private streams: [#264](https://github.com/free2z/zuu/issues/264). Participant counts: [#265](https://github.com/free2z/zuu/issues/265). Purchase integrity: [#336](https://github.com/free2z/zuu/issues/336). |
+| Livestream room/media | Public listing plus authenticated start/join and membership endpoints | Cloudflare RealtimeKit provider and meeting UI are mounted; camera/mic are native permissions. [#804](https://github.com/free2z/zuu/pull/804) adds an explicit-intent camera/microphone preflight with device enumeration and a confirmed preview before provisioning, and locks the exact Android/iOS/macOS capture manifests — macOS `Entitlements.plist` capture entitlements and `Info.macos.plist` usage strings now exist where they did not | Membership reconciliation tests cover selected money-boundary races. [#818](https://github.com/free2z/zuu/pull/818) adds a browser test that loads the exact packaged `src-tauri/tauri.conf.json` CSP, proves the bundled SDK's first `api.realtime.cloudflare.com/v2/internals/participant-details` request is permitted, and uses a negative control that removes the added sources to reproduce the blocked-request boundary. [#817](https://github.com/free2z/zuu/pull/817) adds a strict `meeting_type` contract suite, and `#804` adds mutation-sensitive preflight and permission-manifest suites. [#819](https://github.com/free2z/zuu/pull/819) strictly parses the RealtimeKit participant JWT and binds token, authoritative join response, discovery meeting, provider environment, role, and expiry before SDK initialization, replaces same-token retry with a fresh participant-only join that rejects replay/room-rotation/environment drift, and classifies CSP, offline, transport, timeout, malformed/expired ticket, provider-rejection, and ended-room faults into actionable copy emitting only allowlisted diagnostics. [#798](https://github.com/free2z/zuu/pull/798) removes local host/viewer count synthesis and represents counts as `number \| null` so absent or failed hydration renders as unknown rather than fabricated | Public listing returned HTTP 200 with zero active rooms on 2026-09-01; no native host/join/camera/mic session is recorded, and the preflight has never run against a real camera or microphone on a device. Founder QA on a Play-distributed build reported `ERR0001` when tapping Join Free on an active stream ([#813](https://github.com/free2z/zuu/issues/813)); `0.1.0+18` was the first build to carry the packaged-CSP fix and `0.1.0+19` also carries it, and per their own release runs both were signed and uploaded to Play Internal *and* TestFlight — but **neither has been read back from either store**, so neither is confirmed available to a tester on either platform, and no tester has joined a room from either | **Wired, not end-to-end proven.** The former missing-SDK claim was false. The packaged CSP allowed only legacy Dyte origins and blocked RealtimeKit's first Cloudflare request, which deterministically produced that `ERR0001`; [#816](https://github.com/free2z/zuu/issues/816) is closed by `#818`, which permits only the audited RealtimeKit HTTPS/WSS origins and no blanket `https:`/`wss:`. `#817` additionally corrects the paid-stream wire value the client sent — it serialized `pay-per-view` where the free2z contract's enum is `ppv` — and now fails closed on an unknown, missing, or mismatched kind and on a missing, zero, negative, or malformed PPV rate instead of silently making a stream free or paid; that fix is likewise in no read-back build. `#819` closes [#815](https://github.com/free2z/zuu/issues/815) and removes a second class of join failure — an unbound or replayed ticket — but it is source and browser-test evidence only and reaches a build for the first time in `0.1.0+20`. All of this remains source and browser-test evidence: **[#813](https://github.com/free2z/zuu/issues/813) stays open and unproven. No real active room has been joined from signed Android and iOS builds.** Builds 18 and 19 both shipped the CSP fix and neither has been read back, so nobody has verified the join on either platform. Metadata/PPV: [#262](https://github.com/free2z/zuu/issues/262). Private streams: [#264](https://github.com/free2z/zuu/issues/264). Participant counts: `#798` stops the client fabricating and sorting by synthesized counts, but [#265](https://github.com/free2z/zuu/issues/265) stays **open** — no populated production room has been observed rendering a real count. Purchase integrity: [#336](https://github.com/free2z/zuu/issues/336). |
 | Articles read/write/comments/tips | Public zpage reads; authenticated create/update/comment/donation APIs | Native HTTP; markdown/media render inside the privileged webview. [#801](https://github.com/free2z/zuu/pull/801) auto-loads validated raster images from `free2z.cash` and its HTTPS subdomains, inspects every redirect before requesting the next hop, renders only local `blob:` URLs, and keeps per-item consent for third-party media behind a persistent Strict image-privacy switch | Markdown safety/media and donation idempotency/response tests, plus `#801`'s remote-media policy, redirect, native media-authority, and first-party image browser suites | Public feed returned HTTP 200; authenticated publishing, commenting, and tipping are not production-proven. No packaged build has been observed rendering a real first-party image | **Reads production-observed; writes and charges not runtime-proven.** The image change narrows what the reader will fetch without consent to an audited first-party scope; it is a source and test change and is in no read-back build. Remote-content boundaries: [#367](https://github.com/free2z/zuu/issues/367), [#374](https://github.com/free2z/zuu/issues/374). Authoring: [#250](https://github.com/free2z/zuu/issues/250), [#251](https://github.com/free2z/zuu/issues/251). |
 | Creator public profile and self-edit | Public creator detail/zpage reads; authenticated user mutation | Native HTTP | UI and remote-data tests do not prove a production profile read or mutation | The creator collection returned HTTP 200; no creator-detail read, authenticated edit, or media upload is recorded | **Detail and self-edit wired, not runtime-proven.** Avatar/banner upload remains absent. Linked identities are not authoritative across reloads: [#256](https://github.com/free2z/zuu/issues/256). |
 | KYC application | Authenticated KYC profile, document, tax-form, signature, and submit endpoints | Native HTTP and file picker; no live-camera capture flow | UI tests do not exercise the production KYC contract | No production application or signed-device capture/upload is recorded | **Wired, not runtime-proven; incomplete.** “Live photo” is a file upload: [#257](https://github.com/free2z/zuu/issues/257). Tax-form invalidation: [#258](https://github.com/free2z/zuu/issues/258). This is an application flow, not payout/cash-out. |
@@ -117,23 +141,20 @@ product-operation or physical-device evidence.
 | Buy 2Z with card | Authenticated Stripe Checkout creation, hosted Checkout, signed webhook credit, and a server-controlled return bridge | Native OS opener is used in packaged apps; the exact `cash.free2z.zuuli://checkout/return` route is registered on iOS/Android and claimed through the authenticated server bridge | #400 added signed-out gating, exact HTTPS host validation, actionable failures, and opener tests | Anonymous production checkout returned HTTP 403; no signed-in staging/live charge or signed-build return is recorded | **Wired, not runtime-proven.** Native return is blocked on an unshipped backend dependency tracked internally, so no native return has been exercised against a live charge. Track the end-to-end path in [#388](https://github.com/free2z/zuu/issues/388) and exact charge/credit integrity in [#399](https://github.com/free2z/zuu/issues/399). |
 | Buy 2Z with ZEC | Public pricing/quote plus wallet spend and backend settlement/credit | Wallet bridge exists; production settlement is intentionally disabled | Quote parsing and explicit browser-only demo-boundary tests | Pricing and an exact 100-2Z quote returned HTTP 200; no spend/settlement exists | **Mock/demo only for settlement; unavailable in release builds:** [#155](https://github.com/free2z/zuu/issues/155). A price quote is not a top-up. |
 | 2Z Activity | Authenticated Stripe purchase ledger | Native HTTP | Parsing/UI tests do not prove a complete ledger | Protected endpoint returned HTTP 403 anonymously; authenticated ledger not exercised | **Known incomplete:** the endpoint is purchases-only and cannot substantiate tips/AI/PPV totals ([#172](https://github.com/free2z/zuu/issues/172)). |
-| E2EE messaging | Relay, key-transparency, and MLS services under `rs/` | `wallet/plugins/tauri-plugin-f2zmsg` builds, its two-instance integration test drives two engines over a real relay, and since [#750](https://github.com/free2z/zuu/pull/750) `wallet/zuuli/src-tauri` links it: `Cargo.toml` and its lock carry the plugin, `src/lib.rs` registers it, `src/messaging.rs` serves the enrollment trio, and both capability files grant it | The plugin's own crate gate runs in `zuuli.yml`; the app's gate additionally builds it into ZUULI for desktop, iOS and Android, and compiler-bound IPC probes assert the shipping routers route `plugin:f2zmsg|…` and the unprefixed enrollment commands. [#774](https://github.com/free2z/zuu/pull/774) adds frontend contract tests for exact-handle initiation, inbound decisions, witness-threshold refusal, single-flight proof of work, and authoritative event re-reads. [#767](https://github.com/free2z/zuu/pull/767), [#764](https://github.com/free2z/zuu/pull/764), and [#802](https://github.com/free2z/zuu/pull/802) add mutation-backed key-transparency and relay lifecycle coverage. Since the build-18 anchor, [#833](https://github.com/free2z/zuu/pull/833) covers authorization-before-commit ordering for all six relay-state commands, [#836](https://github.com/free2z/zuu/pull/836) reparses Rust with `syn` in `workspace_debug_scan` and redacts `Finding`'s `Debug`, [#835](https://github.com/free2z/zuu/pull/835) encodes a push once and fans it out with an encode-failure test, [#840](https://github.com/free2z/zuu/pull/840) binds handle-candidate eligibility to shipping parity, and [#834](https://github.com/free2z/zuu/pull/834) retires `with_simulated_channel_binding` from the relay testkit | **None.** Linking, routing, authorization, UI controls, and automated contracts are proven; no enrollment or message has been performed in a running ZUULI. The **`KeyPackage` blocker is now closed in source**: [#769](https://github.com/free2z/zuu/pull/769) merged at `127e600` and **is** part of this snapshot — the previous snapshot's claim that it was not is corrected here. It adds `PUBLISH_KEY_PACKAGES` (`0x0032`, signed by the contact queue's receive key) and `CLAIM_KEY_PACKAGE` (`0x0033`, unsigned behind a proof-of-work stamp), stores the pool at the relay hosting the device's contact queue under the `contact_addr` its directory entry already publishes, and makes `MlsEngine::add_member` take a `VerifiedKeyPackage` whose only constructor is the verifying one, so no relay-supplied bytes can join a group without the directory check. What still blocks first contact is one layer up: [#756](https://github.com/free2z/zuu/pull/756) landed the `f2z-kt-client` crate and `directory.rs` ships a real `KtDirectory` — `/kt/v1/lookup` over HTTPS with §6.3 monotonicity, §8.3's threshold over the client's own witness set, `f2z_kt_core::verify` inclusion proofs, §4.4 re-authorization, and pinning — but **the shipping default is still `directory::NoDirectory`**, which fails closed, because `KT.md` §12 has not decided the log identity, signing key, shipped witness list, or default *t*. `start_conversation` on the shipped configuration therefore still refuses with `witness-threshold-unmet` | **Linked and reachable; still not usable.** The blocker moved but did not clear: a `KeyPackage` can now be published and claimed, and **a user still cannot start a conversation with anyone in a shipped build**, because the default directory resolves nothing. There is no physical-device evidence. Spec and code also disagree at this anchor: [#839](https://github.com/free2z/zuu/pull/839) added `KT.md` rule 13 — a `same_key` entry at `entry_version >= 2` MUST NOT rotate `directory_auth_pk`, and the log MUST reject one that does with `ERR_BAD_AUTHORIZATION` — but `f2z-kt-core`'s `submit.rs` `same_key` branch verifies `auth_signature` against the previous entry's `directory_auth_pk` without comparing the value the new entry publishes, so a validly signed entry can still take over directory writes. That is filed as [#837](https://github.com/free2z/zuu/issues/837); [#841](https://github.com/free2z/zuu/pull/841) fixes it and **did not merge before this anchor**, so build 19 ships the spec/code divergence. [#753](https://github.com/free2z/zuu/issues/753) is closed: since [#759](https://github.com/free2z/zuu/pull/759) a messaging store that will not open no longer takes ZUULI down at launch. [#782](https://github.com/free2z/zuu/pull/782) additionally keeps pure `check_handle_eligibility` available in that faulted state while every engine- or storage-dependent command and the enrollment trio refuses with the same §8 code. Epic: [#305](https://github.com/free2z/zuu/issues/305). Do not describe ZUULI as having usable messaging because the plugin or UI is present. |
-| Internal distribution and store presentation | GitHub release train, App Store Connect, and Google Play | Signed mobile bundles plus generated platform/store icons | Release identity, icon/store validators, protected state machines, and all-target packaging are gated | The last **read-back** evidence is still build 17: a read-only readback at 19:44Z on 2026-08-30 reported TestFlight `0.1.0+17` `uploaded`, `processed`, and `availableToInternalTesters` all true, `VALID`/`IN_BETA_TESTING`, related to the one internal-only group, and the store audit at the same source reported the exact Play release 17 `present: true`. Build 18's release run had, at this re-derivation, signed the Android bundle and completed `Android / protected sign and Play upload` plus its shipped-artifact provenance, and had completed `iOS / system export and signing`; its `iOS / credential-free signed artifact verification`, `iOS / App Store validation and TestFlight`, iOS provenance, and the immutable release index had **not yet run**. No readback or store audit has been run for build 18 on either platform. No physical-device acceptance is recorded. The audits still find canonical listing copy unmatched and every declared screenshot set absent remotely | **Android internal delivery is uploaded at build 18 but not read back; iOS internal delivery is still confirmed only at build 17.** `0.1.0+18` is the first build carrying the [#818](https://github.com/free2z/zuu/pull/818) RealtimeKit CSP fix, and it is the *only* build carrying it — it has none of this anchor's thirteen PRs. `0.1.0+19` is the first build carrying them. Publication presentation and device acceptance remain incomplete. Store media: [#387](https://github.com/free2z/zuu/issues/387). Physical installs: [#238](https://github.com/free2z/zuu/issues/238). Play remains owner-selected Console email-list mode: [#296](https://github.com/free2z/zuu/issues/296). |
+| E2EE messaging | Relay, key-transparency, and MLS services under `rs/` | `wallet/plugins/tauri-plugin-f2zmsg` builds, its two-instance integration test drives two engines over a real relay, and since [#750](https://github.com/free2z/zuu/pull/750) `wallet/zuuli/src-tauri` links it: `Cargo.toml` and its lock carry the plugin, `src/lib.rs` registers it, `src/messaging.rs` serves the enrollment trio, and both capability files grant it | The plugin's own crate gate runs in `zuuli.yml`; the app's gate additionally builds it into ZUULI for desktop, iOS and Android, and compiler-bound IPC probes assert the shipping routers route `plugin:f2zmsg|…` and the unprefixed enrollment commands. [#774](https://github.com/free2z/zuu/pull/774) adds frontend contract tests for exact-handle initiation, inbound decisions, witness-threshold refusal, single-flight proof of work, and authoritative event re-reads. [#767](https://github.com/free2z/zuu/pull/767), [#764](https://github.com/free2z/zuu/pull/764), and [#802](https://github.com/free2z/zuu/pull/802) add mutation-backed key-transparency and relay lifecycle coverage. Since the build-18 anchor, [#833](https://github.com/free2z/zuu/pull/833) covers authorization-before-commit ordering for all six relay-state commands, [#836](https://github.com/free2z/zuu/pull/836) reparses Rust with `syn` in `workspace_debug_scan` and redacts `Finding`'s `Debug`, [#835](https://github.com/free2z/zuu/pull/835) encodes a push once and fans it out with an encode-failure test, [#840](https://github.com/free2z/zuu/pull/840) binds handle-candidate eligibility to shipping parity, and [#834](https://github.com/free2z/zuu/pull/834) retires `with_simulated_channel_binding` from the relay testkit. Since the build-19 anchor, [#781](https://github.com/free2z/zuu/pull/781) restores MLS group state after a receive rollback, [#800](https://github.com/free2z/zuu/pull/800) makes the plugin fail closed on relay error contexts, [#864](https://github.com/free2z/zuu/pull/864) puts `mock.ts::evaluateHandle` and `handle.rs::eligibility` on one shared `docs/e2ee/fixtures/handle-eligibility.json` table — the mock previously answered `not-signed-in` where the authoritative Rust answers `punctuation` for the empty username, proven by running the new parity test against the unmodified mock first — [#867](https://github.com/free2z/zuu/pull/867) replaces a relay `MAX_CONCURRENT` test that passed with the cap removed with one that fails, and pins `REQUEST_TIMEOUT`'s floor at compile time against tuzi's k8s probe timeouts, [#860](https://github.com/free2z/zuu/pull/860) covers the reserved queue-creation mode through `Server::start`, and [#858](https://github.com/free2z/zuu/pull/858) closes a `cfg_attr(derive(Debug))` blind spot in `workspace_debug_scan` | **None.** Linking, routing, authorization, UI controls, and automated contracts are proven; no enrollment or message has been performed in a running ZUULI. The **`KeyPackage` blocker is now closed in source**: [#769](https://github.com/free2z/zuu/pull/769) merged at `127e600` and **is** part of this snapshot — the previous snapshot's claim that it was not is corrected here. It adds `PUBLISH_KEY_PACKAGES` (`0x0032`, signed by the contact queue's receive key) and `CLAIM_KEY_PACKAGE` (`0x0033`, unsigned behind a proof-of-work stamp), stores the pool at the relay hosting the device's contact queue under the `contact_addr` its directory entry already publishes, and makes `MlsEngine::add_member` take a `VerifiedKeyPackage` whose only constructor is the verifying one, so no relay-supplied bytes can join a group without the directory check. What still blocks first contact is one layer up: [#756](https://github.com/free2z/zuu/pull/756) landed the `f2z-kt-client` crate and `directory.rs` ships a real `KtDirectory` — `/kt/v1/lookup` over HTTPS with §6.3 monotonicity, §8.3's threshold over the client's own witness set, `f2z_kt_core::verify` inclusion proofs, §4.4 re-authorization, and pinning — but **the shipping default is still `directory::NoDirectory`**, which fails closed, because `KT.md` §12 has not decided the log identity, signing key, shipped witness list, or default *t*. `start_conversation` on the shipped configuration therefore still refuses with `witness-threshold-unmet` | **Linked and reachable; still not usable.** The blocker moved but did not clear: a `KeyPackage` can now be published and claimed, and **a user still cannot start a conversation with anyone in a shipped build**, because the default directory resolves nothing. There is no physical-device evidence. The spec/code divergence recorded at the build-19 anchor is now closed: [#839](https://github.com/free2z/zuu/pull/839) added `KT.md` rule 13 — a `same_key` entry at `entry_version >= 2` MUST NOT rotate `directory_auth_pk`, and the log MUST reject one that does with `ERR_BAD_AUTHORIZATION` — while `f2z-kt-core`'s `submit.rs` verified `auth_signature` against the previous entry's key without comparing the value the new entry published, so a validly signed entry could take over directory writes. [#841](https://github.com/free2z/zuu/pull/841) fixes that and closes [#837](https://github.com/free2z/zuu/issues/837); it landed **after** build 19 was cut, so `0.1.0+19` ships the divergence and `0.1.0+20` is the first build without it. That is a source fix to an unreachable surface — the shipping directory still resolves nothing, so nothing in a shipped build exercises the submission path either way. [#753](https://github.com/free2z/zuu/issues/753) is closed: since [#759](https://github.com/free2z/zuu/pull/759) a messaging store that will not open no longer takes ZUULI down at launch. [#782](https://github.com/free2z/zuu/pull/782) additionally keeps pure `check_handle_eligibility` available in that faulted state while every engine- or storage-dependent command and the enrollment trio refuses with the same §8 code. Epic: [#305](https://github.com/free2z/zuu/issues/305). Do not describe ZUULI as having usable messaging because the plugin or UI is present. |
+| Internal distribution and store presentation | GitHub release train, App Store Connect, and Google Play | Signed mobile bundles plus generated platform/store icons | Release identity, icon/store validators, protected state machines, and all-target packaging are gated. [#866](https://github.com/free2z/zuu/pull/866) adds the missing DMG canary: a real `hdiutil`-built DMG containing an undeclared `libundeclared-canary.dylib` is proven to reach the finalized artifact SBOM with the correct SHA-256, closing the last artifact-format gap in [#379](https://github.com/free2z/zuu/issues/379)'s first acceptance criterion. [#857](https://github.com/free2z/zuu/pull/857) publishes a pinned store-capture toolchain image | The last **read-back** evidence is still build 17: a read-only readback at 19:44Z on 2026-08-30 reported TestFlight `0.1.0+17` `uploaded`, `processed`, and `availableToInternalTesters` all true, `VALID`/`IN_BETA_TESTING`, related to the one internal-only group, and the store audit at the same source reported the exact Play release 17 `present: true`. Build 18's and build 19's release runs have since both **concluded successfully end to end** — Play upload, iOS signing, App Store validation and TestFlight, both shipped-artifact provenance jobs, and the immutable release index — but **no readback and no store audit has been run for build 18 or build 19 on either platform**, so nothing store-side confirms either build. No physical-device acceptance is recorded. The audits at build 17 still found canonical listing copy unmatched and every declared screenshot set absent remotely | **Builds 18 and 19 are uploaded to TestFlight and Play Internal per their own CI, and confirmed by neither store; the newest store-side confirmation is still build 17.** A green upload job is CI evidence, not a readback. `0.1.0+18` carries the [#818](https://github.com/free2z/zuu/pull/818) RealtimeKit CSP fix alone; `0.1.0+19` adds the build-19 anchor's thirteen PRs; `0.1.0+20` is the first build carrying this anchor's thirty-one. Publication presentation and device acceptance remain incomplete. Store media: [#387](https://github.com/free2z/zuu/issues/387) stays **open** — `#857` is Phase A toolchain only and publishes no listing media. Shipped-artifact SBOMs: [#379](https://github.com/free2z/zuu/issues/379) stays **open** — `#866` closed one format gap and left build-evidence-backed dependency reconciliation for macOS/iOS Cargo runtimes, Android Gradle `runtimeClasspath`, and the Rollup/Vite bundle graph unaddressed. Physical installs: [#238](https://github.com/free2z/zuu/issues/238). Play remains owner-selected Console email-list mode: [#296](https://github.com/free2z/zuu/issues/296). |
 
 ## Current production and distribution evidence
 
-Safe unauthenticated requests on 2026-08-31 returned the following status and
-top-level contracts. These were taken at the build-18 re-derivation earlier the
-same UTC day and were **not** re-run for this anchor; nothing in this anchor's
-thirteen PRs changes a server, so they still describe the same backend, but they
-are not a fresh probe:
+Safe unauthenticated requests were **re-run fresh for this anchor** on
+2026-09-01 and returned the following status and top-level contracts:
 
 ```text
-GET  /api/zpage/?page_size=1                 200  count,next,previous,results (count: 3900)
-GET  /api/creator/?page_size=1               200  count,next,previous,results (count: 77)
+GET  /api/zpage/?page_size=1                 200  count,next,previous,results (count: 3901)
+GET  /api/creator/?page_size=1               200  count,next,previous,results (count: 76)
 GET  /api/ai/models/?page_size=1             200  count,next,previous,results (count: 9)
 GET  /api/dyte/public/?page_size=1           200  count,next,previous,results (count: 0)
-GET  /api/pricing/                           200  pricing snapshot
+GET  /api/pricing/                           200  pricing snapshot (7 sources)
 GET  /api/pricing/quote/?tuzis=100           200  exact quote
 GET  /api/auth/social/providers/             200  providers array (`x` `configured: true`)
 GET  /api/auth/social/mobile/providers/      200  providers array (all `configured: false`)
@@ -144,7 +165,8 @@ Safe anonymous probes of `/api/auth/user/`, `/api/openai/prompt`,
 `/api/stripe/create-checkout-session/` returned HTTP 403. That proves only the
 anonymous access boundary; it does not prove any authenticated success path.
 
-The social-provider configuration is unchanged from the 2026-08-26 audit.
+The social-provider configuration is unchanged from the 2026-08-26 audit and
+was re-confirmed by this probe.
 `/api/auth/social/providers/`, the web/desktop endpoint, reports `x` with
 `configured: true`; `google` and `github` remain `configured: false` there, and
 the mobile endpoint `/api/auth/social/mobile/providers/` still returns all
@@ -157,22 +179,25 @@ again observed against an empty collection rather than a populated one.
 
 Distribution evidence is narrower and explicit:
 
-- [Protected release run 33355762719](https://github.com/free2z/zuu/actions/runs/33355762719)
-  is building and delivering `0.1.0+18` from
-  `992bf2f5` and **had not concluded** when this was re-derived. Pinned
-  immutable source, the credential-free unsigned universal AAB, the
-  credential-free unsigned iOS archive, `iOS / system export and signing`,
-  `Android / protected sign and Play upload`, and
-  `Android / credential-free shipped-artifact provenance` all succeeded; the
-  three macOS jobs and the Linux packages were skipped by the `mobile` target.
-  `iOS / credential-free signed artifact verification` has been queued since
-  05:10Z waiting on a macOS runner, and the jobs behind it —
+- [Protected release run 33369623712](https://github.com/free2z/zuu/actions/runs/33369623712)
+  built, signed, and delivered `0.1.0+19` on 2026-08-31 from
+  `cafa48855d06c6eb3225e3c4c4264e99b8c46142` and **succeeded overall**. Pinned
+  immutable source, the credential-free unsigned iOS archive and universal AAB,
+  `iOS / system export and signing`,
+  `iOS / credential-free signed artifact verification`,
   `iOS / App Store validation and TestFlight`,
-  `iOS / credential-free shipped-artifact provenance`, and
-  `Immutable GitHub release index` — have not started. So build 18 is **on Play
-  Internal and not yet on TestFlight**, and neither track has been read back at
-  18. Do not record build 18 as delivered on iOS until that run concludes and a
-  readback confirms it.
+  `Android / protected sign and Play upload`, both shipped-artifact provenance
+  jobs, and the immutable GitHub release index all succeeded; the three macOS
+  jobs and the Linux packages were skipped by the `mobile` target. **No
+  readback and no store audit has been run at build 19.**
+- [Protected release run 33355762719](https://github.com/free2z/zuu/actions/runs/33355762719)
+  delivered `0.1.0+18` from `992bf2f5` and has since **concluded
+  successfully**, correcting the build-19 re-derive's in-flight snapshot: the
+  iOS lane completed through `iOS / App Store validation and TestFlight`,
+  alongside the Play upload it had already finished, and the immutable release
+  index succeeded. So build 18 reached **both** tracks. **No readback and no
+  store audit has been run at build 18 either**, so a green upload job remains
+  the only evidence for both 18 and 19, on both platforms.
 - [Protected release run 33330274664](https://github.com/free2z/zuu/actions/runs/33330274664)
   built, signed, and delivered `0.1.0+17` on 2026-08-30 from
   `a4478fb1e920bc022a9ab49518d4f26264442837` and **succeeded overall**. Pinned
@@ -195,6 +220,9 @@ Distribution evidence is narrower and explicit:
   failed the same lane for build 15 on a different fault
   ([#738](https://github.com/free2z/zuu/issues/738), fixed by
   [#739](https://github.com/free2z/zuu/pull/739)).
+- The newest TestFlight readback and the newest store audit both still sit at
+  build 17's source; nothing has been read back from either store since
+  2026-08-30, across two further shipped builds.
 - [TestFlight read-only recovery 33331705268](https://github.com/free2z/zuu/actions/runs/33331705268)
   read back `0.1.0+17` at 19:44Z on 2026-08-30, from source
   `a4478fb1e920bc022a9ab49518d4f26264442837` in read-only mode, with
@@ -225,14 +253,14 @@ These runs prove package/store state, not product operations. No repository
 record yet demonstrates the full physical-device checklist for wallet
 recovery/sync/spend, OAuth, AI charging, Live media, KYC capture, card checkout,
 or ZEC top-up. That checklist was re-derived for this audit and is still unmet:
-as of 2026-08-31, neither the repository nor the physical-device tracking issues
+as of 2026-09-01, neither the repository nor the physical-device tracking issues
 record a signed-device wallet operation.
 
 Read the "release stop" dispositions above for what they say. They bar calling
 a surface **ready** and bar a public release; they have never barred an
-internal build: builds 2 through 14 and build 17 all reached TestFlight and
-Play internal carrying them, 15 and 16 reached TestFlight carrying them, and 18
-reached Play Internal carrying them with its iOS lane still in flight. Internal
+internal build: builds 2 through 14 and builds 17, 18, and 19 all reached
+TestFlight and Play Internal carrying them, and 15 and 16 reached TestFlight
+carrying them. Internal
 distribution is the mechanism by which the
 missing device evidence gets collected — see [#234](https://github.com/free2z/zuu/issues/234)
 and [#238](https://github.com/free2z/zuu/issues/238) — so shipping a further


### PR DESCRIPTION
Docs-only. Re-derives `wallet/zuuli/STATUS.md` at `9c78e90`, the current
`origin/main` tip, ahead of internal build `0.1.0+20`. Bump PR is stacked on
this branch.

## Why now

`node wallet/zuuli/scripts/status-freshness.mjs` fails at `main` because
release-impacting paths changed after the build-19 re-derive (including
`z/zcash/librustzcash` via #852). This is the fix.

## Anchor and scope

Thirty-three commits landed between `e2be49c8` (the build-19 anchor) and this
one. Two are build 19's own ceremony (#842, #843), so **thirty-one PRs reach a
build for the first time in `0.1.0+20`** — the header groups them by
application/UI, build and release tooling, `rs/`/messaging, and dependency
hygiene.

## Gate evidence, stated as it stands

- The anchor's own `rs` run [33479067721](https://github.com/free2z/zuu/actions/runs/33479067721) **concluded successfully**.
- The anchor's own required `wallet/zuuli` gate [33479067797](https://github.com/free2z/zuu/actions/runs/33479067797) was still **queued** and its packaging smoke [33479067766](https://github.com/free2z/zuu/actions/runs/33479067766) still **in flight** at re-derivation. Neither is counted, following the build-18 and build-19 precedent.
- None of #864/#868/#869's PR heads carries the anchor's tree `dd78fd26`, so their green runs are evidence for near neighbours, not for this source. Trees are named explicitly.
- The nearest **completed** required gate on first-parent history is [33474816218](https://github.com/free2z/zuu/actions/runs/33474816218) at `9ebf39d`, with a successful four-target packaging smoke [33474816193](https://github.com/free2z/zuu/actions/runs/33474816193) at the same commit. The three uncovered commits after it are named.

## Dispositions that genuinely changed

- **#869 recorded as a shipped defect.** The mobile More sheet — the only route
  to Articles, Messages, Profile, Revenue share, and About — rendered *fully
  off-screen at rest* on narrow viewports once its entrance animation ended.
  Measured `left` of -160 at 320px and -180 at 360px, exactly `-width/2`,
  deterministically. Present in builds 18 and 19; first fixed in build 20. A
  new app-shell row carries this.
- **#813 stays OPEN and unproven.** Builds 18 and 19 both carry the CSP fix and
  both reached TestFlight *and* Play Internal per their own release runs, but
  neither has been read back from either store, and **no real active room has
  been joined from signed Android and iOS builds**.
- **Build 18's release run has since concluded successfully**, correcting the
  build-19 snapshot that recorded its iOS lane in flight. The newest store-side
  confirmation is nevertheless **still build 17** — no readback and no store
  audit exists at 18 or 19. A green upload job is CI evidence, not a readback.
- **Messaging.** #841 closes #837, so `0.1.0+19` ships the KT spec/code
  divergence and `0.1.0+20` is the first build without it. KeyPackage
  publication (#769) exists, but **the shipping directory default is still
  `NoDirectory`** pending KT.md §12, so a user still cannot start a
  conversation. Unchanged and unsoftened.
- **#691 and #379 both stay OPEN** — #862 and #866 delivered partial scope
  only, and the remaining gaps are named.
- **#387 stays OPEN** — #857 is Phase A toolchain and publishes no listing
  media. **#265 stays OPEN** — #798 stops the client fabricating counts, but no
  populated production room has been observed.
- New **About & Feedback** row for #822/#823/#868, source and test evidence
  only, including the scrubber's explicit English-only mnemonic scope.

## Probes

Unauthenticated production probes were **re-run fresh** for this anchor on
2026-09-01 rather than carried forward: zpage 3901, creator 76, ai/models 9,
dyte/public 0, pricing and exact quote 200; protected endpoints 403; social
providers unchanged (`x` configured on web/desktop, nothing on mobile).

## What this does not add

No device evidence, no store-publication evidence, no product-operation
evidence.

## Verification

- `node --test wallet/zuuli/scripts/status-freshness.node-test.mjs` — 31/31 pass
- The re-derivation marker parses at `9c78e90fda7aa4c886411164b4f490c2e522f46c` / `2026-09-01`
- The live `status-freshness.mjs` check passes on the stacked bump commit (verified in the build-20 bump PR, which is where a release source commit exists)

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH