### PR TITLE
fix(zuuli): bind the About identity test to canonical release.json

### DIFF
--- a/wallet/zuuli/tests/about.pw.ts
+++ b/wallet/zuuli/tests/about.pw.ts
@@ -1,5 +1,21 @@
+import { readFileSync } from "node:fs";
+
 import { expect, test } from "@playwright/test";
 import { PSEUDO_ABOUT_MESSAGES } from "../src/lib/about-copy";
+
+// The identity the About card must display is the canonical one, so read it
+// from release.json rather than restating it. A literal here is only ever
+// right by coincidence of the current build: `release-bump.mjs` regenerates
+// the four generated identity surfaces on every bump but cannot reach into a
+// test, so a pinned number turns each release into a gate failure while
+// proving nothing about the binding (#822). Reading the canonical file is
+// also the stronger assertion — it fails if the UI and release.json ever
+// disagree, which a literal cannot detect. Same source as
+// `src/lib/build-info.test.ts`, and the same file-reading convention as
+// `tests/realtimekit-csp.pw.ts`.
+const RELEASE = JSON.parse(
+  readFileSync(new URL("../release.json", import.meta.url), "utf8"),
+) as { version: string; build: number };
 
 test.beforeEach(async ({ page }) => {
   await page.setViewportSize({ width: 320, height: 760 });
@@ -10,8 +26,10 @@ test.beforeEach(async ({ page }) => {
 test("About is keyboard and screen-reader usable at 320px", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "About & Feedback" })).toBeVisible();
   const card = page.locator("[data-about-build-card]");
-  await expect(card.getByText("0.1.0", { exact: true })).toBeVisible();
-  await expect(card.getByText("19", { exact: true })).toBeVisible();
+  await expect(card.getByText(RELEASE.version, { exact: true })).toBeVisible();
+  await expect(
+    card.getByText(String(RELEASE.build), { exact: true }),
+  ).toBeVisible();
   await expect(card.getByText("Internal", { exact: true })).toBeVisible();
   await expect(card.getByText("Web", { exact: true })).toBeVisible();
 
@@ -46,7 +64,12 @@ test("copy uses the complete stable minimal block and announces completion", asy
   // Middle, tail-weighted truncation (see #829) — reuses truncateAddress's
   // default 8-head/10-tail split rather than a head-only prefix.
   expect(copied).toMatch(
-    /^ZUULI\nVersion: 0\.1\.0\nBuild: 19\nRelease channel: Internal\nPlatform: Web\nSource commit: [0-9a-f]{8}…[0-9a-f]{10}$/,
+    new RegExp(
+      `^ZUULI\\nVersion: ${RELEASE.version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}` +
+        `\\nBuild: ${RELEASE.build}` +
+        "\\nRelease channel: Internal\\nPlatform: Web" +
+        "\\nSource commit: [0-9a-f]{8}…[0-9a-f]{10}$",
+    ),
   );
   expect(copied).not.toMatch(/wallet|balance|device|address|\/Users\//i);
 });


### PR DESCRIPTION
## The bug

`wallet/zuuli/tests/about.pw.ts` pinned the release identity as literals — the
build number as `getByText("19")` and the whole copied block as a regex
containing `Build: 19`. **That makes every ZUULI release bump fail the required
gate.**

Caught for real by the build-20 bump (#871), where `zuuli / frontend` failed:

```
Expected pattern: /^ZUULI\nVersion: 0\.1\.0\nBuild: 19\nRelease channel: Internal\n.../
Received string:  "ZUULI
Version: 0.1.0
Build: 20
Release channel: Internal
..."
```

This is the **first bump since #822 added the About build-identity binding** —
#822 landed at `3b0b796`, after build 19 was cut at `cafa488` — so build 20 is
the first release to hit it. It is not a one-off: `release-bump.mjs`
regenerates the four generated identity surfaces it owns but cannot reach into
a test, and `status-freshness.mjs` correctly refuses to let a release source
commit carry a non-ceremony source change. So the literal is a hard stop on
*every* future release until it is removed, which is why this is a separate PR
ahead of the bump rather than folded into it.

## The fix

Read `release.json` — the same canonical source `src/lib/build-info.test.ts`
already uses — with the file-reading convention of
`tests/realtimekit-csp.pw.ts`.

This is also the **stronger** assertion, not merely a looser one: it fails if
the rendered identity and canonical `release.json` ever disagree, which is the
binding #822 actually claims. A frozen literal cannot detect that — it only
matches by coincidence of whatever build happens to be current.

## Deliberately not touched

`src/lib/feedback.test.ts`'s `Build: 19` string is a synthetic fixture fed into
the scrubber to test how it treats the block's *shape* (#829's `…` regression).
It never reads the real identity, and a literal is correct there.

## Verification

Each run on a clean checkout — a dirty tree makes `build-identity.mjs` null the
source commit by design, which is a separate, expected failure mode:

- `npx playwright test tests/about.pw.ts` at build 19 → **3/3 pass**, so the fix
  does not regress the current identity.
- The same with `release.json` temporarily committed at build 20 → **3/3 pass**,
  where the unfixed test fails deterministically (reproduced locally and in
  #871's CI).
- `npx playwright test` (full suite) → **185/185 pass**.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH