### PR TITLE
fix(rs): align relay and KT runtime with corrected specs

### DIFF
--- a/rs/crates/f2z-kt-client/tests/acceptance.rs
+++ b/rs/crates/f2z-kt-client/tests/acceptance.rs
@@ -91,6 +91,7 @@ struct DirectTransport {
     entry_override: Mutex<Option<Vec<u8>>>,
     drop_cosignatures: Mutex<bool>,
     claim_absent: Mutex<bool>,
+    claim_absent_with_proof: Mutex<bool>,
     /// Serve a history with the entry at this index removed — the **truthful
     /// subset** of `KT.md` §8.2. Everything still served is real.
     omit_history_entry: Mutex<Option<usize>>,
@@ -111,6 +112,7 @@ impl DirectTransport {
             entry_override: Mutex::new(None),
             drop_cosignatures: Mutex::new(false),
             claim_absent: Mutex::new(false),
+            claim_absent_with_proof: Mutex::new(false),
             omit_history_entry: Mutex::new(None),
             swap_history_entry: Mutex::new(None),
         }
@@ -145,6 +147,10 @@ impl DirectTransport {
 
     fn assert_absent(&self, value: bool) {
         *self.claim_absent.lock().unwrap() = value;
+    }
+
+    fn assert_absent_but_retain_proof(&self) {
+        *self.claim_absent_with_proof.lock().unwrap() = true;
     }
 
     fn bundle_bytes(&self, mut bundle: f2z_kt_core::api::TreeHeadBundle) -> Vec<u8> {
@@ -185,6 +191,10 @@ impl Transport for DirectTransport {
             response.presence = f2z_kt_core::api::Presence::AbsentUnproved.code();
             response.entry = f2z_codec::types::Payload::new(Vec::new()).unwrap();
             response.proof = f2z_codec::types::Payload::new(Vec::new()).unwrap();
+        }
+        if *self.claim_absent_with_proof.lock().unwrap() {
+            response.presence = f2z_kt_core::api::Presence::AbsentUnproved.code();
+            response.entry = f2z_codec::types::Payload::new(Vec::new()).unwrap();
         }
         if *self.tamper_proof.lock().unwrap() {
             // One byte of a real `akd` `LookupProof`. Not a garbage buffer: the
@@ -579,6 +589,29 @@ fn an_unregistered_handle_is_an_answer_and_it_is_labelled_unproved() {
     // cannot produce one. The variant's name is the whole disclosure.
     assert!(answer.standing().threshold_met());
     assert!(client.pins().get(&handle("nobody")).is_none());
+}
+
+#[test]
+fn an_absent_discriminant_cannot_smuggle_a_populated_proof_to_the_client() {
+    let mut deployment = Deployment::new("client-absent-with-proof");
+    deployment.cosign(NOW);
+    deployment.register("alice", 1);
+    deployment.cosign(NOW + 1);
+
+    // Start from f2z-kt's real present response, then make only the two edits a
+    // dishonest server needs for §9.2's malformed shape: claim absence and
+    // hide the entry while retaining the genuine populated proof.
+    deployment.transport.assert_absent_but_retain_proof();
+    let mut client = deployment.client(1);
+    let error = client.resolve(&handle("alice"), NOW + 2).unwrap_err();
+    assert_eq!(
+        error,
+        ClientError::Protocol(f2z_kt_core::KtError::Malformed)
+    );
+    assert!(
+        client.pins().get(&handle("alice")).is_none(),
+        "a malformed absent response must not establish or weaken a pin"
+    );
 }
 
 #[test]

--- a/rs/crates/f2z-kt-core/src/api.rs
+++ b/rs/crates/f2z-kt-core/src/api.rs
@@ -262,11 +262,10 @@ impl LookupRequest {
 
 /// Whether a lookup found a registered handle.
 ///
-/// # This field is an admission, and it should not have to exist
-///
-/// `KT.md` §8.1 and §9.5 require that an unregistered handle be answered with a
-/// **proof of non-membership** — *"'No such user' is a claim the log must
-/// prove"* — and that is why §9.5 has no unknown-handle error code.
+/// `KT.md` §8.1 normatively requires this discriminant and requires the absent
+/// case to say that it is unproved. §9.2 requires a response whose fields agree
+/// with it: both `entry` and `proof` are populated for [`Presence::Present`],
+/// and both are empty for [`Presence::AbsentUnproved`].
 ///
 /// **`akd` 0.13 cannot produce that proof.** `akd::Directory::lookup` returns
 /// `StorageError::NotFound` for a label with no user state; the
@@ -275,10 +274,10 @@ impl LookupRequest {
 /// registered. There is no public API in the adopted library that answers "this
 /// handle is not in the tree" with anything a client can check.
 ///
-/// So this log tells the truth about what it can prove: [`Presence::Absent`]
-/// is an **assertion**, carries no proof, and is labelled as unproved on the
-/// wire so that no client mistakes it for one. Reported as a spec defect rather
-/// than papered over.
+/// So this conforming wire shape tells the truth about what the log can prove:
+/// [`Presence::AbsentUnproved`] is an **assertion**, carries no proof, and is
+/// labelled as unproved so no client mistakes it for one. `KT.md` §11.5 records
+/// the missing upstream capability and when this limitation can be revisited.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Presence {
@@ -592,10 +591,10 @@ mod tests {
     }
 
     #[test]
-    fn a_lookup_response_cannot_claim_presence_with_no_entry() {
-        // The shape check exists so that a client cannot be handed
-        // `presence = Present` with nothing to verify and quietly treat the
-        // handle as resolved.
+    fn lookup_presence_and_payloads_must_agree_in_both_directions() {
+        // §9.2 names both malformed directions explicitly. Exercise each
+        // payload independently so changing the validator to check only
+        // `entry` or only `proof` cannot leave the other as a smuggling field.
         let bundle = TreeHeadBundle::new(
             SignedTreeHead {
                 sth: SignedTreeHeadTBS {
@@ -626,15 +625,44 @@ mod tests {
             proof: f2z_codec::types::Payload::new(Vec::new()).unwrap(),
             bundle,
         };
-        assert!(response.validate().is_err());
-
-        response.presence = Presence::AbsentUnproved.code();
-        assert!(response.validate().is_ok());
+        assert_eq!(response.validate(), Err(crate::KtError::Malformed));
 
         response.entry = f2z_codec::types::Payload::new(b"entry".to_vec()).unwrap();
-        assert!(
-            response.validate().is_err(),
-            "an absent verdict carrying an entry is incoherent and must not decode as either"
+        assert_eq!(
+            response.validate(),
+            Err(crate::KtError::Malformed),
+            "presence requires a proof as well as an entry"
         );
+        response.entry = f2z_codec::types::Payload::new(Vec::new()).unwrap();
+        response.proof = f2z_codec::types::Payload::new(b"proof".to_vec()).unwrap();
+        assert_eq!(
+            response.validate(),
+            Err(crate::KtError::Malformed),
+            "presence requires an entry as well as a proof"
+        );
+        response.entry = f2z_codec::types::Payload::new(b"entry".to_vec()).unwrap();
+        assert!(response.validate().is_ok());
+
+        response.presence = Presence::AbsentUnproved.code();
+        assert_eq!(
+            response.validate(),
+            Err(crate::KtError::Malformed),
+            "absence cannot carry an entry and proof"
+        );
+        response.proof = f2z_codec::types::Payload::new(Vec::new()).unwrap();
+        assert_eq!(
+            response.validate(),
+            Err(crate::KtError::Malformed),
+            "absence cannot carry an entry"
+        );
+        response.entry = f2z_codec::types::Payload::new(Vec::new()).unwrap();
+        response.proof = f2z_codec::types::Payload::new(b"proof".to_vec()).unwrap();
+        assert_eq!(
+            response.validate(),
+            Err(crate::KtError::Malformed),
+            "absence cannot carry a proof"
+        );
+        response.proof = f2z_codec::types::Payload::new(Vec::new()).unwrap();
+        assert!(response.validate().is_ok());
     }
 }

--- a/rs/crates/f2z-kt/src/log.rs
+++ b/rs/crates/f2z-kt/src/log.rs
@@ -40,10 +40,11 @@
 //!   The cost is one leaf per epoch: about 52,000 a year at the proposed 600 s
 //!   cadence, against a directory sized in millions.
 //!
-//! The heartbeat label cannot collide with a handle label: `KT.md` §3.3's
-//! handle labels are `"free2z/kt/v1/handle:" || handle` and this is not that
-//! prefix. Reported as a specification defect rather than coded around
-//! silently — see the pull request.
+//! `KT.md` §5.1 specifies the heartbeat label, the epoch-derived value, its
+//! exclusion from the handle-label space, and its contribution to `tree_size`.
+//! In particular, the label cannot collide with `KT.md` §3.3's handle labels:
+//! those are `"free2z/kt/v1/handle:" || handle`, while this fixed label is not
+//! in that prefix space.
 //!
 //! # `tree_size`
 //!

--- a/rs/crates/f2z-relay-proto/src/capabilities.rs
+++ b/rs/crates/f2z-relay-proto/src/capabilities.rs
@@ -12,8 +12,8 @@
 //!   contradicts itself or claims a policy the architecture forbids. Every
 //!   check in it is a MUST that `WIRE.md` states.
 //! - [`ClientPolicy::accept`] asks whether *this* client will use *this* relay.
-//!   Every check in it is a client-side decision — §11.3's numbered list — and
-//!   a relay that fails one is not misbehaving, it is merely unsuitable.
+//!   Its checks are the client-side decisions in §11.3's numbered list, after
+//!   [`validate`] has rejected documents that no conforming relay may publish.
 //!
 //! Collapsing the two would mean a client's strictness setting deciding what
 //! counts as a conforming relay, which is exactly backwards.
@@ -86,9 +86,9 @@ pub enum QueueCreationMode {
     Open,
     /// `1` — the default: a `PowStamp` over a relay-issued challenge.
     Pow,
-    /// `2` — an operator-issued bearer token. **A token is an identifier**: it
-    /// lets the operator link every queue created with it, which reintroduces
-    /// the linkability that opaque per-pair addresses exist to remove.
+    /// `2` — reserved. The name is retained so a client can identify and report
+    /// the formerly specified token mode, but §13.1 forbids a relay from
+    /// publishing it and forbids a client override.
     Token,
 }
 
@@ -241,6 +241,8 @@ pub fn check_digest(capabilities: &Capabilities, expected: &Digest) -> Result<()
 ///   architecture's 30-day ceiling (§11.3 step 6).
 /// - [`Refusal::PowAlgorithmUnknown`] if a `PowParams` names an algorithm v1
 ///   does not define (§13.1).
+/// - [`Refusal::QueueCreationTokenGated`] if `queue_creation_mode` is reserved
+///   value 2 (§13.1).
 /// - [`Refusal::CapabilitiesInconsistent`] for everything else: an undefined
 ///   mode byte, an empty version or padding list, a padding set that is not
 ///   strictly ascending, a TTL band whose default sits outside its own clamps,
@@ -265,6 +267,12 @@ pub fn validate(capabilities: &Capabilities) -> Result<()> {
     let binding = ChannelBindingMode::from_code(capabilities.channel_binding_mode)?;
     AntiReplayPersistence::from_code(capabilities.antireplay_persistence)?;
     let creation = QueueCreationMode::from_code(capabilities.queue_creation_mode)?;
+    // §13.1's 2026-08-24 correction: value 2 is permanently reserved because
+    // v1 has no field in which a client could present the token. This is a
+    // document-conformance failure, not a preference a client may relax.
+    if matches!(creation, QueueCreationMode::Token) {
+        return Err(ProtoError::Refused(Refusal::QueueCreationTokenGated));
+    }
     DurabilityMode::from_code(capabilities.durability_mode)?;
     let contact_queues = flag(capabilities.contact_queues_enabled)?;
     flag(capabilities.per_source_limits)?;
@@ -367,13 +375,13 @@ fn flag(byte: u8) -> Result<bool> {
 
 /// What *this* client requires of a relay (§11.3).
 ///
-/// Defaults are the conservative reading of §11.3: refuse a plaintext relay,
-/// refuse an implausible padding set, refuse a token-gated one. The two that
-/// §5.3 and §5.5 describe as a *strict mode* — requiring a channel binding and
-/// requiring a durable seen-set — default to off, because a relay behind a
-/// TLS-terminating proxy is "a common and legitimate deployment" and refusing
-/// every one of them by default would be a stricter policy than the
-/// specification's.
+/// Defaults are the conservative reading of §11.3: refuse a plaintext relay
+/// and refuse an implausible padding set. Reserved capability values are
+/// rejected unconditionally by [`validate`]. The two that §5.3 and §5.5
+/// describe as a *strict mode* — requiring a channel binding and requiring a
+/// durable seen-set — default to off, because a relay behind a TLS-terminating
+/// proxy is "a common and legitimate deployment" and refusing every one of
+/// them by default would be a stricter policy than the specification's.
 #[derive(Clone, Debug)]
 pub struct ClientPolicy {
     /// §2.3: connect to a relay serving without TLS. MUST be an explicit,
@@ -390,8 +398,6 @@ pub struct ClientPolicy {
     pub require_sound_antireplay_window: bool,
     /// §9: refuse an implausibly fine-grained padding set.
     pub require_plausible_padding: bool,
-    /// §13.1: refuse `queue_creation_mode: token`, which is linkable.
-    pub allow_token_queue_creation: bool,
     /// §11.3 step 5: the sizes this client will emit. The relay's set MUST be a
     /// superset.
     pub emitted_padding: PaddingBuckets,
@@ -405,7 +411,6 @@ impl Default for ClientPolicy {
             require_durable_antireplay: false,
             require_sound_antireplay_window: true,
             require_plausible_padding: true,
-            allow_token_queue_creation: false,
             emitted_padding: PaddingBuckets::default(),
         }
     }
@@ -461,15 +466,6 @@ impl ClientPolicy {
         if self.require_plausible_padding && !buckets.is_plausible() {
             return Err(ProtoError::Refused(Refusal::PaddingImplausible));
         }
-        // Step 8.
-        if matches!(
-            QueueCreationMode::from_code(capabilities.queue_creation_mode)?,
-            QueueCreationMode::Token
-        ) && !self.allow_token_queue_creation
-        {
-            return Err(ProtoError::Refused(Refusal::QueueCreationTokenGated));
-        }
-
         Ok(())
     }
 }
@@ -834,19 +830,26 @@ mod tests {
     }
 
     #[test]
-    fn a_token_gated_relay_is_refused_unless_the_user_accepts_the_linkability() {
+    fn reserved_token_mode_is_unconditionally_refused() {
         let mut capabilities = document();
         capabilities.queue_creation_mode = QueueCreationMode::Token.code();
-        assert!(validate(&capabilities).is_ok());
         assert_eq!(
-            ClientPolicy::default().accept(&capabilities),
+            validate(&capabilities),
             Err(ProtoError::Refused(Refusal::QueueCreationTokenGated))
         );
-        let permissive = ClientPolicy {
-            allow_token_queue_creation: true,
+        let otherwise_lenient = ClientPolicy {
+            allow_insecure_transport: true,
+            require_channel_binding: false,
+            require_durable_antireplay: false,
+            require_sound_antireplay_window: false,
+            require_plausible_padding: false,
             ..ClientPolicy::default()
         };
-        assert!(permissive.accept(&capabilities).is_ok());
+        assert_eq!(
+            otherwise_lenient.accept(&capabilities),
+            Err(ProtoError::Refused(Refusal::QueueCreationTokenGated)),
+            "a reserved wire value is not a user-overridable policy choice"
+        );
     }
 
     #[test]

--- a/rs/crates/f2z-relay-proto/src/error.rs
+++ b/rs/crates/f2z-relay-proto/src/error.rs
@@ -171,10 +171,9 @@ pub enum Refusal {
     /// §13.1: the relay demands a proof-of-work algorithm v1 does not define,
     /// so no conforming client can create a queue on it.
     PowAlgorithmUnknown,
-    /// §13.1: `queue_creation_mode = token`. Not invalid — a token is an
-    /// operator-issued bearer credential and a closed deployment may want one —
-    /// but it is an identifier that links every queue created with it, so a
-    /// client whose policy is unlinkability refuses.
+    /// §13.1: `queue_creation_mode = 2`, the reserved former token mode. V1 has
+    /// no wire field in which a client can present a token, so every client
+    /// refuses and no user override is conforming.
     QueueCreationTokenGated,
 }
 
@@ -220,7 +219,9 @@ impl fmt::Display for Refusal {
             Self::CapabilitiesSignatureInvalid => "the capability document's signature is invalid",
             Self::CapabilitiesDigestMismatch => "capabilities_digest does not match the document",
             Self::PowAlgorithmUnknown => "the relay demands a proof-of-work v1 does not define",
-            Self::QueueCreationTokenGated => "the relay gates queue creation on a linkable token",
+            Self::QueueCreationTokenGated => {
+                "the relay publishes reserved token-gated queue creation"
+            }
         };
         write!(f, "refused the relay ({}): {text}", self.section())
     }

--- a/rs/crates/f2z-relay-testkit/README.md
+++ b/rs/crates/f2z-relay-testkit/README.md
@@ -172,9 +172,10 @@ see it fail before they see it pass.
   affordance aimed at humans rather than at clients. A client's "fetch the
   well-known copy and compare digests" path therefore cannot be exercised
   against this harness.
-- **`queue_creation_mode: token` is not implemented.** §13.1 defines it as an
-  operator-issued bearer credential and gives it no protocol shape in v1;
-  configuring it is refused at construction rather than faked.
+- **`queue_creation_mode: token` is reserved.** §13.1 gives v1 no field in
+  which a client could present that credential, so a relay MUST NOT publish
+  value 2 and MUST refuse startup if configured with it. `FakeRelay` therefore
+  refuses it at construction.
 - **`channel_binding_mode: tls-exporter` is not reachable here.** A `FakeRelay`
   always serves `ws://`, and `capabilities::validate` requires
   `transport_security: none` to pair with `channel_binding_mode: none` (§2.3

--- a/rs/crates/f2z-relay-testkit/src/engine.rs
+++ b/rs/crates/f2z-relay-testkit/src/engine.rs
@@ -130,11 +130,16 @@ impl Relay {
     /// # Errors
     ///
     /// [`TestkitError::Config`] if the configured capability document is not a
-    /// valid one, if its padding set is malformed, or if it selects
-    /// `queue_creation_mode: token`, which this crate does not implement — a
-    /// bearer token is an operator-issued credential with no protocol shape in
-    /// v1, and faking one would be inventing protocol rather than testing it.
+    /// valid one, if its padding set is malformed, or if it selects reserved
+    /// `queue_creation_mode: token`. `WIRE.md` §13.1 requires every relay that
+    /// names that unsatisfiable v1 mode to refuse startup.
     pub fn new(config: RelayConfig) -> Result<Self> {
+        if config.capabilities.queue_creation_mode == QueueCreationMode::Token.code() {
+            return Err(TestkitError::Config(
+                "queue_creation_mode: token is reserved by WIRE.md v1; \
+                 a relay that names it must refuse startup",
+            ));
+        }
         capabilities::validate(&config.capabilities)
             .map_err(|_| TestkitError::Config("the configured capability document is invalid"))?;
         config
@@ -145,12 +150,6 @@ impl Relay {
         {
             return Err(TestkitError::Config(
                 "key packages require contact queues to provide their published address",
-            ));
-        }
-        if config.capabilities.queue_creation_mode == QueueCreationMode::Token.code() {
-            return Err(TestkitError::Config(
-                "queue_creation_mode: token is not implemented; \
-                 a bearer token has no protocol shape in WIRE.md v1",
             ));
         }
         // §2.3 obligations 1 and 2 are a pair. A document that claims TLS while
@@ -1399,7 +1398,7 @@ mod tests {
     }
 
     #[test]
-    fn token_mode_is_refused_at_construction_rather_than_faked() {
+    fn reserved_token_mode_is_refused_at_construction() {
         let mut config = RelayConfig::default();
         config.capabilities.queue_creation_mode = QueueCreationMode::Token.code();
         assert!(Relay::new(config).is_err());

--- a/rs/crates/f2z-relay/src/config.rs
+++ b/rs/crates/f2z-relay/src/config.rs
@@ -871,13 +871,11 @@ impl Config {
         self.log_level()?;
         let mode = self.creation_mode()?;
 
-        // §13.1 defines `token` as an operator-issued bearer credential and
-        // gives it **no wire shape at all** in v1: `CreateQueueRequest` carries
-        // a `PowStamp` and a reserved `flags` field that MUST be 0, and nothing
-        // else. There is no conforming way for a client to present a token, so
-        // a relay that published this mode would be publishing a gate no client
-        // can pass. Refused here rather than faked, which is the same call
-        // `f2z-relay-testkit` made. Reported as a spec defect.
+        // §13.1's 2026-08-24 correction reserves `token` because it has no wire
+        // shape in v1: `CreateQueueRequest` carries a `PowStamp` and a reserved
+        // `flags` field that MUST be 0, and nothing else. The specification now
+        // requires a relay naming this mode to refuse startup, so the operator
+        // sees the unusable configuration before it can be published.
         if matches!(mode, CreationMode::Token) {
             return Err(ConfigError::Invalid(
                 "antiabuse.queue_creation_mode",


### PR DESCRIPTION
Closes #646

## Summary

- remove the client policy override for reserved `queue_creation_mode = 2` and reject it as `QueueCreationTokenGated` during capability validation
- align relay, testkit, heartbeat, and `Presence` documentation with the 2026-08-24 WIRE/KT corrections
- cover the complete present/absent lookup-response shape matrix and prove the client rejects an absent discriminant carrying a real populated proof

## Verification

- `cargo test --locked -p f2z-relay-proto -p f2z-relay-testkit -p f2z-relay -p f2z-kt-core -p f2z-kt-client -p f2z-kt` (from `rs/`, Rust 1.97.1)
- `scripts/check-rust-fmt.sh --root rs`
- pinned Rust 1.97.1 workspace `cargo clippy --locked --all-targets -- -D warnings` pass (via `scripts/check-rust-clippy.sh --root rs`; per-crate repetitions left to CI after the workspace verdict)
- `git diff --check`