### PR TITLE
fix(msg-identity): remove alternate MLS signing seam

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "rand_core 0.10.1",
  "sha2 0.10.9",
  "tls_codec",
+ "trybuild",
  "zeroize",
 ]
 
@@ -3255,6 +3256,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3265,6 +3272,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3506,6 +3522,21 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "trybuild"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.4+spec-1.1.0",
+]
 
 [[package]]
 name = "tungstenite"

--- a/rs/crates/f2z-msg-identity/Cargo.toml
+++ b/rs/crates/f2z-msg-identity/Cargo.toml
@@ -58,3 +58,6 @@ tls_codec = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+# Compile the removed public method from an external consumer's perspective
+# and pin the expected E0599 diagnostic on the repository's Rust toolchain.
+trybuild = "1"

--- a/rs/crates/f2z-msg-identity/src/device.rs
+++ b/rs/crates/f2z-msg-identity/src/device.rs
@@ -108,10 +108,11 @@ device_key!(
     /// `DeviceSignatureKey` (DSK) — the MLS leaf `signature_key`
     /// (RFC 9420 §7.2), bound to the account by a `DeviceCredential`.
     ///
-    /// It signs MLS handshake and application framing, which is why it is
-    /// **not** the [`crate::account::IdentitySigningKey`]: §4.1 requires that
-    /// the key which signs message content and the key a peer pins as an
-    /// identity are different keys.
+    /// It is **not** the [`crate::account::IdentitySigningKey`]: §4.1 requires
+    /// that the key which signs message content and the key a peer pins as an
+    /// identity are different keys. The former ed25519-dalek
+    /// `sign_mls_content(&[u8])` path was removed; MLS framing is signed by the
+    /// MLS engine's libcrux-backed signer.
     DeviceSignatureKey
 );
 
@@ -125,19 +126,6 @@ device_key!(
     /// provide. `ADR 0009` fixes the addressing that goes with it.
     QueueKey
 );
-
-impl DeviceSignatureKey {
-    /// Sign MLS framing with the device's leaf signature key.
-    ///
-    /// The bytes are MLS's — RFC 9420 fixes what a `FramedContentTBS` is — so
-    /// this method does no framing of its own. It exists so the *key choice* is
-    /// explicit: message content is signed by the device key and never by the
-    /// identity key (§4.1).
-    #[must_use]
-    pub fn sign_mls_content(&self, framed_content_tbs: &[u8]) -> Signature {
-        Signature::new(self.0.sign(framed_content_tbs).to_bytes())
-    }
-}
 
 impl QueueKey {
     /// Sign a relay command transcript (`WIRE.md` §5.1).
@@ -244,18 +232,5 @@ mod tests {
                 );
             }
         }
-    }
-
-    #[test]
-    fn a_signature_is_over_the_bytes_it_was_given() {
-        // Not a verification test — this crate does not verify — but a
-        // signature over a different message must be different bytes, which is
-        // enough to catch a method signing a constant.
-        let mut rng = CountingRng(2);
-        let key = DeviceSignatureKey::generate(&mut rng);
-        assert_ne!(
-            key.sign_mls_content(b"one message"),
-            key.sign_mls_content(b"another message")
-        );
     }
 }

--- a/rs/crates/f2z-msg-identity/tests/removed_mls_signing_api.rs
+++ b/rs/crates/f2z-msg-identity/tests/removed_mls_signing_api.rs
@@ -1,0 +1,18 @@
+//! External-consumer regression test for the API removed by #700.
+//!
+//! This deliberately makes one narrow claim: the former
+//! `DeviceSignatureKey::sign_mls_content(&[u8])` API does not compile. It is
+//! not a census of every name or wrapper by which a future signing oracle
+//! could be exposed. A complete public-API policy needs compiler-derived data;
+//! stable Rust 1.97.1 does not expose rustdoc JSON.
+//!
+//! Follow-up proposal: once rustdoc JSON is stable, snapshot the compiler's
+//! externally reachable API for every supported target/feature combination,
+//! normalize resolved type identities and re-exports, and mutation-test macro-
+//! and cfg-generated signing surfaces. Until then this test must stay narrow.
+
+#[test]
+fn removed_mls_signing_method_is_not_callable_by_a_consumer() {
+    let cases = trybuild::TestCases::new();
+    cases.compile_fail("tests/ui/device_signature_key_has_no_mls_signing_method.rs");
+}

--- a/rs/crates/f2z-msg-identity/tests/ui/device_signature_key_has_no_mls_signing_method.rs
+++ b/rs/crates/f2z-msg-identity/tests/ui/device_signature_key_has_no_mls_signing_method.rs
@@ -1,0 +1,7 @@
+use f2z_msg_identity::DeviceSignatureKey;
+
+fn caller_chosen_mls_bytes(key: &DeviceSignatureKey) {
+    let _ = key.sign_mls_content(b"caller-chosen MLS bytes");
+}
+
+fn main() {}

--- a/rs/crates/f2z-msg-identity/tests/ui/device_signature_key_has_no_mls_signing_method.stderr
+++ b/rs/crates/f2z-msg-identity/tests/ui/device_signature_key_has_no_mls_signing_method.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `sign_mls_content` found for reference `&DeviceSignatureKey` in the current scope
+ --> tests/ui/device_signature_key_has_no_mls_signing_method.rs:4:17
+  |
+4 |     let _ = key.sign_mls_content(b"caller-chosen MLS bytes");
+  |                 ^^^^^^^^^^^^^^^^ method not found in `&DeviceSignatureKey`

--- a/rs/crates/f2z-msg-mls/tests/common/mod.rs
+++ b/rs/crates/f2z-msg-mls/tests/common/mod.rs
@@ -10,20 +10,14 @@
 //! structure of a credential, the engine stops accepting credentials the
 //! identity crate issues — here, in CI, rather than on somebody's phone.
 //!
-//! # The one place the two crates do not meet, stated
+//! # Why the device signer belongs to this crate
 //!
-//! `f2z-msg-identity::DeviceSignatureKey` signs MLS framing with
-//! **`ed25519-dalek`** (`sign_mls_content`), and this engine signs it with
-//! **libcrux** ([`f2z_msg_mls::DeviceSigner`]) — which is what closes
-//! [#693](https://github.com/free2z/zuu/issues/693) and what ADR 0001's single
-//! crypto core requires. `DeviceSignatureKey` does not expose its private bytes
-//! (correctly), so the two cannot be bridged from outside, and these tests
-//! therefore use the identity crate for the **account** half of §4.2 and
-//! `DeviceSigner` for the **device** half.
-//!
-//! That is a real seam and it needs reconciling: either `DeviceSignatureKey`
-//! signs through libcrux, or it stops offering `sign_mls_content`. It is called
-//! out in the pull request rather than papered over here.
+//! MLS framing is signed only by **libcrux** through
+//! [`f2z_msg_mls::DeviceSigner`], as ADR 0001's single crypto core requires.
+//! `f2z-msg-identity` owns the account hierarchy and credential issuer, but it
+//! exposes no `ed25519-dalek` MLS-signing path. These tests therefore use the
+//! identity crate for the **account** half of §4.2 and `DeviceSigner` for the
+//! **device** half.
 
 #![allow(
     clippy::unwrap_used,


### PR DESCRIPTION
## Summary

- remove the unused `DeviceSignatureKey::sign_mls_content` ed25519-dalek path so MLS framing uses the libcrux-backed engine signer
- replace the stale MLS coordination-test seam with the resolved ownership boundary
- reject restoration of that exact public API from an external consumer using a pinned `trybuild` E0599 compile-fail fixture
- remove the source-text public-surface census and its broad assurance: pinned stable Rust 1.97.1 does not expose rustdoc JSON, and the unstable format represents only each invocation's active cfg/feature expansion

The compile-fail test deliberately makes no claim that it discovers renamed methods, wrappers, re-exports, traits, macros, or raw-key exposure. A follow-up compiler-derived API policy should wait for stable rustdoc JSON, snapshot every supported target/feature combination, normalize resolved type identities and re-exports, and mutation-test cfg- and macro-generated surfaces.

## Verification

- `cargo +1.97.1 test --locked -p f2z-msg-identity --all-features --all-targets`
- `cargo +1.97.1 test --locked -p f2z-msg-identity --doc`
- `cargo +1.97.1 test --workspace --all-targets --locked`
- `cargo +1.97.1 test --workspace --doc --locked`
- `cargo +1.97.1 clippy --workspace --all-targets --locked -- -D warnings`
- `scripts/check-rust-fmt.sh --root rs` and self-test
- `scripts/check-rust-clippy.sh --root rs` and macOS target-native self-test
- `scripts/check-rust-deny.sh --root rs --config rs/deny.toml` and self-test
- `scripts/check-rust-toolchain.sh` and self-test
- `cargo +1.97.1 build --locked -p f2z-msg-identity --target wasm32-unknown-unknown`
- exact restoration mutation: adding back `sign_mls_content(&[u8])` makes the compile-fail fixture compile and the test fail

Closes #700
