### PR TITLE
fix(e2ee): bound signed PoW work policy

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -52,6 +52,8 @@ jobs:
           node scripts/check-workflow-gates.mjs
           node scripts/check-librustzcash-compat.mjs --self-test
           node scripts/check-librustzcash-compat.mjs
+          node scripts/check-pow-policy.mjs --self-test
+          node scripts/check-pow-policy.mjs
 
       # Runs on every event, including changes this job would otherwise skip,
       # because a toolchain pin can drift from any workflow or manifest. The

--- a/docs/e2ee/CLIENT-CONTRACT.md
+++ b/docs/e2ee/CLIENT-CONTRACT.md
@@ -467,12 +467,14 @@ against that entry**, build the group, obtain a second challenge, compute a
 second proof-of-work stamp, and `CONTACT_APPEND` the `Welcome`. Four
 consequences for the UI:
 
-- **It can take seconds, and the delay is proof-of-work on the user's device —
-  now twice.** §12.6 gives the claim its own challenge purpose, so first contact
-  pays two stamps rather than one. On a cheap phone that is meaningfully slow and
-  the reason is unfixable by tuning
-  ([`WIRE.md` §12.4](./WIRE.md#124-the-honest-limits)). Show progress; do not
-  present it as a network wait.
+- **The delay includes proof-of-work on the user's device — now twice.** §12.6
+  gives the claim its own challenge purpose, so first contact pays two stamps
+  rather than one. No supported-phone duration has been measured. Show progress;
+  do not present computation as a network wait. Each search follows the finite
+  [`WIRE.md` §13.1](./WIRE.md#131-the-layers) client policy: reject signed work
+  above 20 bits before starting, run off the async executor, and stop at the
+  16,777,216-candidate, 30,000 ms, challenge-expiry, cancellation, or `uint64`
+  counter boundary without wrapping.
 - **It fails closed when the witness threshold is unmet.** Resolving a *new*
   handle is refused, not degraded
   ([`KT.md` §8.3](./KT.md#83-the-threshold-rule-and-failing-closed)). See rule 5
@@ -1696,11 +1698,11 @@ type ErrorCode =
 | `relay-protocol-violation` | | The relay sent something malformed, or rejected us as malformed. **This is a bug in one of the two implementations.** Surface it as a defect with a report affordance; never silently retry. |
 | `relay-identity-mismatch` | | **Fatal and loud.** The relay's proven identity does not match the `relay_id` the peer advertised in-band — a substituted relay ([`WIRE.md` §5.2](./WIRE.md#52-relay-identity-binding--the-attack-it-closes)). Raise an alarm, stop using this relay for this conversation, do not retry against it. |
 | `relay-refused-insecure` | | The relay declares `transport_security: "none"` or `channel_binding_mode: "none"` and the user has not opted in. Offer the opt-in with copy stating that ciphertext is protected by MLS but connection metadata, queue addresses and commands travel in the clear ([`WIRE.md` §2.3](./WIRE.md#23-listener-rules-and-the-insecure-override)). |
-| `relay-capability-mismatch` | | Its padding set, TTL ceiling, or `.well-known` digest disagrees with what it serves. Refuse the relay and say which check failed ([`WIRE.md` §11.2](./WIRE.md#112-served-two-ways-on-purpose), [§11.3](./WIRE.md#113-what-a-client-does-with-it)). |
+| `relay-capability-mismatch` | | Its padding set, TTL ceiling, PoW work policy, or `.well-known` digest disagrees with what this client accepts or what it serves. Refuse the relay and say which check failed before beginning PoW ([`WIRE.md` §11.2](./WIRE.md#112-served-two-ways-on-purpose), [§11.3](./WIRE.md#113-what-a-client-does-with-it)). |
 | `send-unavailable` | ● | The single collapsed send-side refusal: absent, deleted, expired, full, or backpressure — the relay is forbidden from distinguishing them ([`WIRE.md` §6.3](./WIRE.md#63-commands-signed-by-the-send-side-queue-key)). Exponential backoff to the retry budget, then ask the peer in-band for a fresh queue advert. **The UI cannot tell the user why, and must not guess.** |
 | `send-address-stolen` | | **Fatal, loud, non-dismissible.** `ERR_ALREADY_BOUND` on a first bind for a freshly advertised address means the address was already bound to another or unknown key ([`WIRE.md` §7.4](./WIRE.md#74-the-consequence-said-plainly)). Mark `transportHealth: "compromised"`, abandon the queue, and name the relay that returned the result. The result does not identify who bound it. Not a warning toast. Not a log line. |
 | `pow-required` | ● | Obtain a challenge and compute a stamp. Show it as work, not as a network wait. |
-| `pow-failed` | ● | The challenge expired or was consumed. Get a fresh one and retry once. |
+| `pow-failed` | ● | The challenge expired or was consumed, or the finite local search hit its attempt/deadline/cancellation/counter bound. Get a fresh challenge and retry once; never continue or wrap an exhausted search. |
 | `directory-unreachable` | ● | Existing conversations continue. New-handle resolution is unavailable — say that, do not fall back. |
 | `directory-rate-limited` | ● | Back off. |
 | `directory-proof-invalid` | | **Fatal.** An inclusion proof, a monotonicity check, or an entry authorization failed. This is **fork evidence**, not a network glitch ([`KT.md` §8.1](./KT.md#81-lookup), [§6.3](./KT.md#63-monotonicity)). Raise `directory-fork-evidence`; do not retry, do not "try another server". |
@@ -2203,6 +2205,7 @@ files) are settled.
 | `SafetyNumber.zcashMemoPayload` | Verification over a shielded Zcash memo is described in [`ARCHITECTURE.md` §9.2](./ARCHITECTURE.md#92-the-directory) and has no specified payload format. |
 | Retry budgets and backoff constants | Not specified anywhere yet; `send_retry_max` is named in [`WIRE.md` §6.3](./WIRE.md#63-commands-signed-by-the-send-side-queue-key) without a value. |
 | Enrollment merge latency | Depends on the KT epoch cadence, whose values are placeholders ([§13-P](./ARCHITECTURE.md#13-open-questions)). |
+| PoW algorithm 1 / 20-bit / 60000 ms default | An interoperability value, not calibration evidence. The 20-bit acceptance ceiling, 16,777,216-candidate budget and 30000 ms search deadline are safety bounds pending §13-N's supported-device and attacker measurements. |
 
 ### 12.2 Open questions this document inherits
 

--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -1565,11 +1565,12 @@ struct {
     uint8    queue_creation_mode;         /* 0 = open, 1 = pow, 2 = token — reserved
                                              and MUST NOT be published; see §13.1's
                                              correction */
-    PowParams queue_creation_pow;
+    PowParams queue_creation_pow;         /* provisional v1 default: algorithm 1,
+                                             20 bits, challenge_ttl_ms 60000 */
     uint8    contact_queues_enabled;
     uint32   contact_max_pending;
     uint64   contact_max_bytes;
-    PowParams contact_append_pow;
+    PowParams contact_append_pow;         /* same bounded v1 policy */
     uint8    per_source_limits;           /* 0 = off, 1 = on (§13.3) */
     uint8    durability_mode;             /* 0 = memory, 1 = batched, 2 = fsync-per-append */
 
@@ -1659,9 +1660,13 @@ On first use of a relay, and on `NOTICE(3)`:
 6. Refuse if `max_message_ttl_seconds > 2592000` — the relay is claiming a policy
    the architecture forbids.
 7. Refuse an internally unusable document: `contact_queues_enabled = 1`
-   requires nonzero `contact_append_pow`, and `max_frame_bytes` must be large
-   enough for the largest advertised padding bucket. The latter is necessary,
-   not sufficient: framing and authentication add overhead beyond the payload.
+   requires nonzero `contact_append_pow`; every named PoW policy MUST use
+   algorithm 1, `difficulty_bits` in 1..=20, and `challenge_ttl_ms` in
+   1..=60000; and `max_frame_bytes` must be large enough for the largest
+   advertised padding bucket. These checks happen on the verified signed
+   document before the client obtains a challenge or starts work. The frame-size
+   condition is necessary, not sufficient: framing and authentication add
+   overhead beyond the payload.
 8. Record `queue_creation_mode`, quotas and PoW parameters for §13.
 9. Surface operator name, jurisdiction and contact in the relay-picker UI.
 
@@ -1782,23 +1787,18 @@ thing that must stay near zero.
 
 ### 12.4 The honest limits
 
-**Proof of work taxes phones far more than it taxes rented GPUs.** This is the
-central weakness and it is not fixable by tuning. A leading-zero-bit search is
-precisely the workload that commodity parallel hardware accelerates best; the
-ratio between a rented GPU-hour and a mid-range phone's battery-constrained
-budget is orders of magnitude. Any difficulty high enough to meaningfully cost an
-attacker is a difficulty that makes a cheap Android device sit there heating up
-before it can say hello. We have chosen a difficulty that is a nuisance to
-attackers and tolerable to phones, which means it is *only* a nuisance. A
-memory-hard function (Argon2id and relatives) would narrow the hardware gap, and
-it was rejected for v1 because it multiplies the *relay's* verification cost by
-the same factor that it raises the attacker's — the wrong trade at the moment of
-a flood, when the relay is the resource under pressure. The calibration is
-unresolved and is recorded as
+**Proof of work taxes general-purpose clients while commodity parallel hardware
+can accelerate a leading-zero-bit search.** This is the central weakness and it
+is not fixed by choosing a larger unmeasured number. A memory-hard function
+(Argon2id and relatives) could narrow the hardware gap, and it was rejected for
+v1 because it multiplies the *relay's* verification cost by the same factor that
+it raises the attacker's — the wrong trade at the moment of a flood, when the
+relay is the resource under pressure. Client and attacker timings on supported
+hardware are unmeasured; calibration remains open in
 [`ARCHITECTURE.md` §13-N](./ARCHITECTURE.md#13-open-questions).
 
-> **Correction (2026-08-31) — the phone-tolerability claim above was not
-> measured and is withdrawn.** No phone benchmark was recorded for the v1
+> **Correction (2026-08-31) — the earlier phone-tolerability claim was not
+> measured and remains withdrawn.** No phone benchmark was recorded for the v1
 > contact-append proof of work, so this document has no evidence that any
 > difficulty is tolerable to the supported phones or imposes a particular cost
 > on attackers. `ARCHITECTURE.md` §13-N remains the required benchmark and
@@ -2365,8 +2365,8 @@ allocates durable state out of nothing, so it is the one that needs a gate.
 ```
 struct {
     uint8  algorithm;        /* 1 = blake2b-leading-zero-bits; no other value in v1 */
-    uint8  difficulty_bits;
-    uint32 challenge_ttl_ms;
+    uint8  difficulty_bits;  /* required range: 1..=20 */
+    uint32 challenge_ttl_ms; /* required range: 1..=60000 */
 } PowParams;
 
 struct {
@@ -2384,6 +2384,26 @@ At this point of use, `counter` is exactly an eight-byte unsigned `uint64` in
 network (big-endian) order, concatenated directly with no length prefix.
 Verification is one hash; the relay marks the challenge consumed. The choice of a
 verify-cheap, GPU-friendly function and its consequences are argued in §12.4.
+
+**The v1 interoperability default is provisionally algorithm 1,
+`difficulty_bits = 20`, and `challenge_ttl_ms = 60000`.** It is not a benchmark
+result and makes no claim about phone duration, battery cost, or attacker cost.
+Until §13-N records measurements and this policy is revised, 20 bits is also the
+maximum a v1 client accepts and 60000 ms is the maximum challenge lifetime a v1
+client accepts. Relays MUST reject configuration above either bound; clients MUST
+refuse a signed capability document above either bound before requesting a
+challenge or beginning a search. There is no override for attacker-selected
+work.
+
+A client search is finite independently of the probabilistic target. For each
+stamp it tries at most **16,777,216** candidates and at most **30,000 ms**, with
+the challenge's remaining lifetime as an earlier deadline. The search MUST run
+off the async executor, MUST observe caller cancellation cooperatively, and MUST
+stop when any limit is reached. Advancing the fixed-salt `uint64 counter` uses a
+checked increment: exhausting it fails the search and MUST NOT wrap to zero and
+repeat the same search space. Exhaustion, deadline, cancellation, or challenge
+expiry is `pow-failed`; a caller may obtain one fresh challenge and retry once as
+specified by the client contract.
 
 **Layer 4 — global backpressure.** The relay tracks storage and memory against
 published high-water marks. On crossing them it refuses work in this order:

--- a/docs/e2ee/decisions/0011-first-contact-contact-queues.md
+++ b/docs/e2ee/decisions/0011-first-contact-contact-queues.md
@@ -69,14 +69,13 @@ contact queue plays no further part for that pair.
   than as messages.
 - **`CONTACT_APPEND` returns nothing**, on the same rule as `APPEND`: a stranger
   must learn neither how full the queue is nor whether Bob has read it.
-- **Proof of work taxes phones far more than rented GPUs. This is the central
-  weakness and it is not fixable by tuning.** A leading-zero-bit search is
-  precisely the workload commodity parallel hardware accelerates best; the ratio
-  between a rented GPU-hour and a battery-constrained mid-range phone is orders of
-  magnitude. A difficulty high enough to meaningfully cost an attacker is a
-  difficulty that makes a cheap Android device heat up before it can say hello. We
-  have chosen a difficulty that is a nuisance to attackers and tolerable to
-  phones, which means it is *only* a nuisance.
+- **Proof of work taxes general-purpose clients while commodity parallel
+  hardware can accelerate the chosen leading-zero-bit search.** This is the
+  central weakness and it is not fixed by choosing a larger unmeasured number.
+  The provisional algorithm-1 / 20-bit / 60000 ms interoperability default is
+  not evidence of a supported-phone duration or an attacker cost; those
+  measurements remain open in §13-N. The finite client work policy in WIRE.md
+  §13.1 bounds the denial a hostile signed capability can demand.
 - **Disk exhaustion via mass queue creation is made expensive, not closed.**
   Nothing prevents an adversary with real resources from creating very many
   legitimate-looking queues with valid stamps from many sources. The caps bound
@@ -125,7 +124,8 @@ contact queue plays no further part for that pair.
   [ADR 0004](./0004-metadata-ambition.md) removed it from, and it would tell the
   relay who contacted whom.
 - **A memory-hard proof of work (Argon2id and relatives).** Rejected for v1 with
-  regret. It would genuinely narrow the phone-versus-GPU gap. It also multiplies
+  regret. It is intended to narrow the general-purpose-versus-parallel-hardware
+  gap. It also multiplies
   the **relay's own verification cost** by the same factor it raises the
   attacker's, which is the wrong trade at the moment of a flood, when the relay is
   the resource under pressure. Verification must stay a single hash. Recorded as

--- a/rs/crates/f2z-codec/src/pow.rs
+++ b/rs/crates/f2z-codec/src/pow.rs
@@ -24,10 +24,11 @@
 //! explicit that binding the stamp to a relay-issued, single-use challenge is
 //! what stops precomputation, and none of that is expressible here.
 //!
-//! §12.4 states the honest limit plainly: a leading-zero-bit search taxes phones
-//! far more than it taxes rented GPUs, and that is not fixable by tuning. The
-//! function is chosen so that **verification is a single hash** — the relay's
-//! own cost under flood is the thing that must stay near zero.
+//! §12.4 states the honest limit plainly: commodity parallel hardware can
+//! accelerate this leading-zero-bit search, and no supported-device or attacker
+//! calibration has been recorded. The function is chosen so that
+//! **verification is a single hash** — the relay's own cost under flood is the
+//! thing that must stay near zero.
 
 // `tls_codec`'s derive macros build their error strings with `format!` and
 // return `Vec<u8>`; both need to be in scope in a `no_std` crate.
@@ -42,6 +43,34 @@ use crate::types::{Challenge, Salt};
 
 /// The only PoW algorithm in v1: BLAKE2b with a leading-zero-bit target.
 pub const ALGORITHM_BLAKE2B_LEADING_ZERO_BITS: u8 = 1;
+
+/// The provisional v1 interoperability difficulty (§13.1).
+///
+/// This is a wire default, not a phone or attacker calibration result. Until
+/// the measurements in `ARCHITECTURE.md` §13-N exist, v1 clients and relays do
+/// not accept a harder advertised search.
+pub const DEFAULT_POW_DIFFICULTY_BITS: u8 = 20;
+
+/// The hardest proof-of-work search a v1 client will accept (§13.1).
+pub const MAX_POW_DIFFICULTY_BITS: u8 = DEFAULT_POW_DIFFICULTY_BITS;
+
+/// The provisional v1 challenge lifetime, in milliseconds (§13.1).
+pub const DEFAULT_POW_CHALLENGE_TTL_MS: u32 = 60_000;
+
+/// The longest challenge lifetime a v1 client accepts (§13.1).
+pub const MAX_POW_CHALLENGE_TTL_MS: u32 = DEFAULT_POW_CHALLENGE_TTL_MS;
+
+/// The most candidates a v1 client searches for one stamp.
+///
+/// At the maximum accepted difficulty this is sixteen expected search lengths.
+/// The independent wall-clock deadline remains authoritative on a slow device.
+pub const MAX_POW_ATTEMPTS: u64 = 1 << 24;
+
+/// The wall-clock ceiling for one client-side search, in milliseconds.
+///
+/// This is a denial-of-service bound, not a claim that any supported device
+/// finishes the provisional default within it.
+pub const MAX_POW_SOLVE_MS: u64 = 30_000;
 
 /// The relay's current proof-of-work parameters.
 ///
@@ -85,11 +114,12 @@ impl PowParams {
 
     /// Check that the parameters are ones a v1 client can satisfy.
     ///
-    /// `difficulty_bits` needs no *upper* bound: it is a `u8`, the digest is
-    /// 256 bits, so every representable value is satisfiable. Whether it is
-    /// *reachable* on a phone is §12.4's problem, not this function's.
+    /// `difficulty_bits` is bounded by [`MAX_POW_DIFFICULTY_BITS`]. A hash
+    /// target can be mathematically satisfiable and still be hostile work for
+    /// a client; accepting the signed capability is what authorizes the work,
+    /// so the bound belongs here rather than only in the solver.
     ///
-    /// It does need a lower one. `is_required` reads `algorithm` alone, so a
+    /// It also needs a lower bound. `is_required` reads `algorithm` alone, so a
     /// relay publishing `algorithm: 1, difficulty_bits: 0` passes §13.1's
     /// "pow mode must name a PoW" and §12.3's "contact queues must be gated"
     /// checks while demanding no work at all — `meets_difficulty(0)` holds for
@@ -99,16 +129,24 @@ impl PowParams {
     ///
     /// # Errors
     ///
-    /// [`CodecError::InvalidValue`] if `algorithm` is neither 0 ("not
-    /// required") nor 1, or if a named algorithm carries zero difficulty.
+    /// [`CodecError::InvalidValue`] if the no-work form is not all-zero, if
+    /// `algorithm` is not 1, if the difficulty is outside the v1 client range,
+    /// or if its challenge lifetime is zero or above the v1 ceiling.
     pub const fn validate(&self) -> Result<(), CodecError> {
         if self.algorithm == 0 {
-            return Ok(());
+            return if self.difficulty_bits == 0 && self.challenge_ttl_ms == 0 {
+                Ok(())
+            } else {
+                Err(CodecError::InvalidValue)
+            };
         }
         if self.algorithm != ALGORITHM_BLAKE2B_LEADING_ZERO_BITS {
             return Err(CodecError::InvalidValue);
         }
-        if self.difficulty_bits == 0 {
+        if self.difficulty_bits == 0 || self.difficulty_bits > MAX_POW_DIFFICULTY_BITS {
+            return Err(CodecError::InvalidValue);
+        }
+        if self.challenge_ttl_ms == 0 || self.challenge_ttl_ms > MAX_POW_CHALLENGE_TTL_MS {
             return Err(CodecError::InvalidValue);
         }
         Ok(())
@@ -246,7 +284,7 @@ mod tests {
     }
 
     #[test]
-    fn params_reject_an_algorithm_v1_does_not_define() {
+    fn params_enforce_the_bounded_v1_work_policy() {
         assert!(PowParams::none().validate().is_ok());
         // zuu#715: a named algorithm with zero difficulty is a published gate
         // that demands nothing. `is_required` reads `algorithm` alone, so both
@@ -256,7 +294,7 @@ mod tests {
             PowParams {
                 algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
                 difficulty_bits: 0,
-                challenge_ttl_ms: 60_000,
+                challenge_ttl_ms: DEFAULT_POW_CHALLENGE_TTL_MS,
             }
             .validate(),
             Err(CodecError::InvalidValue)
@@ -266,7 +304,7 @@ mod tests {
             PowParams {
                 algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
                 difficulty_bits: 1,
-                challenge_ttl_ms: 60_000,
+                challenge_ttl_ms: DEFAULT_POW_CHALLENGE_TTL_MS,
             }
             .validate()
             .is_ok()
@@ -275,17 +313,44 @@ mod tests {
         assert!(
             PowParams {
                 algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
-                difficulty_bits: 20,
-                challenge_ttl_ms: 60_000,
+                difficulty_bits: MAX_POW_DIFFICULTY_BITS,
+                challenge_ttl_ms: MAX_POW_CHALLENGE_TTL_MS,
             }
             .validate()
             .is_ok()
         );
         assert_eq!(
             PowParams {
+                algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+                difficulty_bits: MAX_POW_DIFFICULTY_BITS + 1,
+                challenge_ttl_ms: DEFAULT_POW_CHALLENGE_TTL_MS,
+            }
+            .validate(),
+            Err(CodecError::InvalidValue)
+        );
+        assert_eq!(
+            PowParams {
+                algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+                difficulty_bits: DEFAULT_POW_DIFFICULTY_BITS,
+                challenge_ttl_ms: MAX_POW_CHALLENGE_TTL_MS + 1,
+            }
+            .validate(),
+            Err(CodecError::InvalidValue)
+        );
+        assert_eq!(
+            PowParams {
+                algorithm: 0,
+                difficulty_bits: 1,
+                challenge_ttl_ms: 0,
+            }
+            .validate(),
+            Err(CodecError::InvalidValue)
+        );
+        assert_eq!(
+            PowParams {
                 algorithm: 2,
-                difficulty_bits: 20,
-                challenge_ttl_ms: 60_000,
+                difficulty_bits: DEFAULT_POW_DIFFICULTY_BITS,
+                challenge_ttl_ms: DEFAULT_POW_CHALLENGE_TTL_MS,
             }
             .validate(),
             Err(CodecError::InvalidValue)

--- a/rs/crates/f2z-relay-proto/src/capabilities.rs
+++ b/rs/crates/f2z-relay-proto/src/capabilities.rs
@@ -35,7 +35,10 @@ use f2z_codec::canonical::Canonical;
 use f2z_codec::commands::{Capabilities, SignedCapabilities};
 use f2z_codec::hash;
 use f2z_codec::padding::PaddingBuckets;
-use f2z_codec::pow::{ALGORITHM_BLAKE2B_LEADING_ZERO_BITS, PowParams};
+use f2z_codec::pow::{
+    ALGORITHM_BLAKE2B_LEADING_ZERO_BITS, DEFAULT_POW_CHALLENGE_TTL_MS, DEFAULT_POW_DIFFICULTY_BITS,
+    MAX_POW_CHALLENGE_TTL_MS, MAX_POW_DIFFICULTY_BITS, PowParams,
+};
 use f2z_codec::types::{Digest, PublicKey, ShortBytes};
 
 use crate::error::{ProtoError, Refusal, Result};
@@ -241,6 +244,8 @@ pub fn check_digest(capabilities: &Capabilities, expected: &Digest) -> Result<()
 ///   architecture's 30-day ceiling (§11.3 step 6).
 /// - [`Refusal::PowAlgorithmUnknown`] if a `PowParams` names an algorithm v1
 ///   does not define (§13.1).
+/// - [`Refusal::PowWorkPolicyExceeded`] if signed parameters exceed v1's
+///   bounded client work policy (§13.1).
 /// - [`Refusal::QueueCreationTokenGated`] if `queue_creation_mode` is reserved
 ///   value 2 (§13.1).
 /// - [`Refusal::CapabilitiesInconsistent`] for everything else: an undefined
@@ -360,9 +365,17 @@ pub fn ttl_policy(capabilities: &Capabilities) -> TtlPolicy {
 }
 
 fn validate_pow(params: &PowParams) -> Result<()> {
+    if params.algorithm != 0 && params.algorithm != ALGORITHM_BLAKE2B_LEADING_ZERO_BITS {
+        return Err(ProtoError::Refused(Refusal::PowAlgorithmUnknown));
+    }
+    if params.difficulty_bits > MAX_POW_DIFFICULTY_BITS
+        || params.challenge_ttl_ms > MAX_POW_CHALLENGE_TTL_MS
+    {
+        return Err(ProtoError::Refused(Refusal::PowWorkPolicyExceeded));
+    }
     params
         .validate()
-        .map_err(|_| ProtoError::Refused(Refusal::PowAlgorithmUnknown))
+        .map_err(|_| ProtoError::Refused(Refusal::CapabilitiesInconsistent))
 }
 
 fn flag(byte: u8) -> Result<bool> {
@@ -529,16 +542,16 @@ pub fn defaults(relay_identity_pk: &PublicKey, published_at_ms: u64) -> Result<C
         queue_creation_mode: QueueCreationMode::Pow.code(),
         queue_creation_pow: PowParams {
             algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
-            difficulty_bits: 20,
-            challenge_ttl_ms: 60_000,
+            difficulty_bits: DEFAULT_POW_DIFFICULTY_BITS,
+            challenge_ttl_ms: DEFAULT_POW_CHALLENGE_TTL_MS,
         },
         contact_queues_enabled: 1,
         contact_max_pending: 64,
         contact_max_bytes: 256 * 1024,
         contact_append_pow: PowParams {
             algorithm: ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
-            difficulty_bits: 20,
-            challenge_ttl_ms: 60_000,
+            difficulty_bits: DEFAULT_POW_DIFFICULTY_BITS,
+            challenge_ttl_ms: DEFAULT_POW_CHALLENGE_TTL_MS,
         },
         per_source_limits: 1,
         durability_mode: DurabilityMode::FsyncPerAppend.code(),
@@ -882,6 +895,20 @@ mod tests {
         assert_eq!(
             validate(&capabilities),
             Err(ProtoError::Refused(Refusal::PowAlgorithmUnknown))
+        );
+    }
+
+    #[test]
+    fn signed_pow_at_the_client_maximum_is_accepted_and_maximum_plus_one_is_refused() {
+        let mut capabilities = document();
+        capabilities.queue_creation_pow.difficulty_bits = MAX_POW_DIFFICULTY_BITS;
+        capabilities.contact_append_pow.difficulty_bits = MAX_POW_DIFFICULTY_BITS;
+        assert!(ClientPolicy::default().accept(&capabilities).is_ok());
+
+        capabilities.contact_append_pow.difficulty_bits = MAX_POW_DIFFICULTY_BITS + 1;
+        assert_eq!(
+            ClientPolicy::default().accept(&capabilities),
+            Err(ProtoError::Refused(Refusal::PowWorkPolicyExceeded))
         );
     }
 

--- a/rs/crates/f2z-relay-proto/src/error.rs
+++ b/rs/crates/f2z-relay-proto/src/error.rs
@@ -171,6 +171,9 @@ pub enum Refusal {
     /// §13.1: the relay demands a proof-of-work algorithm v1 does not define,
     /// so no conforming client can create a queue on it.
     PowAlgorithmUnknown,
+    /// §13.1: signed proof-of-work parameters exceed v1's finite client work
+    /// policy. Refused before a challenge is requested or work begins.
+    PowWorkPolicyExceeded,
     /// §13.1: `queue_creation_mode = 2`, the reserved former token mode. V1 has
     /// no wire field in which a client can present a token, so every client
     /// refuses and no user override is conforming.
@@ -192,7 +195,9 @@ impl Refusal {
             Self::PaddingNotSuperset | Self::PaddingImplausible => "§9",
             Self::TtlCeilingExceeded => "§11.3",
             Self::CapabilitiesInconsistent | Self::CapabilitiesSignatureInvalid => "§11.1",
-            Self::PowAlgorithmUnknown | Self::QueueCreationTokenGated => "§13.1",
+            Self::PowAlgorithmUnknown
+            | Self::PowWorkPolicyExceeded
+            | Self::QueueCreationTokenGated => "§13.1",
         }
     }
 }
@@ -219,6 +224,9 @@ impl fmt::Display for Refusal {
             Self::CapabilitiesSignatureInvalid => "the capability document's signature is invalid",
             Self::CapabilitiesDigestMismatch => "capabilities_digest does not match the document",
             Self::PowAlgorithmUnknown => "the relay demands a proof-of-work v1 does not define",
+            Self::PowWorkPolicyExceeded => {
+                "the relay demands proof of work above the v1 client bound"
+            }
             Self::QueueCreationTokenGated => {
                 "the relay publishes reserved token-gated queue creation"
             }

--- a/rs/crates/f2z-relay/src/config.rs
+++ b/rs/crates/f2z-relay/src/config.rs
@@ -510,16 +510,16 @@ impl Default for AntiAbuse {
         Self {
             // §13.1: "`pow` — **the default.**"
             queue_creation_mode: "pow".to_owned(),
-            queue_creation_pow_bits: 20,
-            contact_append_pow_bits: 20,
-            challenge_ttl_ms: 60_000,
+            queue_creation_pow_bits: f2z_codec::pow::DEFAULT_POW_DIFFICULTY_BITS,
+            contact_append_pow_bits: f2z_codec::pow::DEFAULT_POW_DIFFICULTY_BITS,
+            challenge_ttl_ms: f2z_codec::pow::DEFAULT_POW_CHALLENGE_TTL_MS,
             max_challenges: 65_536,
             contact_queues_enabled: true,
             contact_max_pending: 64,
             contact_max_bytes: 256 * 1024,
             key_packages_enabled: true,
             contact_max_key_packages: 64,
-            claim_key_package_pow_bits: 20,
+            claim_key_package_pow_bits: f2z_codec::pow::DEFAULT_POW_DIFFICULTY_BITS,
             per_source_limits: true,
         }
     }
@@ -1135,13 +1135,39 @@ impl Config {
                     .to_owned(),
             ));
         }
-        if self.antiabuse.queue_creation_pow_bits > 64
-            || self.antiabuse.contact_append_pow_bits > 64
-            || self.antiabuse.claim_key_package_pow_bits > 64
+        for (key, difficulty) in [
+            (
+                "antiabuse.queue_creation_pow_bits",
+                self.antiabuse.queue_creation_pow_bits,
+            ),
+            (
+                "antiabuse.contact_append_pow_bits",
+                self.antiabuse.contact_append_pow_bits,
+            ),
+            (
+                "antiabuse.claim_key_package_pow_bits",
+                self.antiabuse.claim_key_package_pow_bits,
+            ),
+        ] {
+            if difficulty > f2z_codec::pow::MAX_POW_DIFFICULTY_BITS {
+                return Err(ConfigError::Invalid(
+                    key,
+                    format!(
+                        "exceeds the v1 client work-policy maximum of {} bits",
+                        f2z_codec::pow::MAX_POW_DIFFICULTY_BITS
+                    ),
+                ));
+            }
+        }
+        if self.antiabuse.challenge_ttl_ms == 0
+            || self.antiabuse.challenge_ttl_ms > f2z_codec::pow::MAX_POW_CHALLENGE_TTL_MS
         {
             return Err(ConfigError::Invalid(
-                "antiabuse.queue_creation_pow_bits",
-                "a difficulty above 64 bits is not solvable by any client".to_owned(),
+                "antiabuse.challenge_ttl_ms",
+                format!(
+                    "must be between 1 and the v1 client maximum of {} ms",
+                    f2z_codec::pow::MAX_POW_CHALLENGE_TTL_MS
+                ),
             ));
         }
         if self.antiabuse.max_challenges == 0 {
@@ -1585,6 +1611,19 @@ mod tests {
         let mut config = Config::default();
         config.antiabuse.contact_queues_enabled = false;
         assert!(config.check().is_err());
+    }
+
+    #[test]
+    fn proof_of_work_maximum_is_accepted_and_maximum_plus_one_is_refused() {
+        let mut config = Config::default();
+        config.antiabuse.queue_creation_pow_bits = f2z_codec::pow::MAX_POW_DIFFICULTY_BITS;
+        config.antiabuse.contact_append_pow_bits = f2z_codec::pow::MAX_POW_DIFFICULTY_BITS;
+        config.antiabuse.claim_key_package_pow_bits = f2z_codec::pow::MAX_POW_DIFFICULTY_BITS;
+        assert!(config.check().is_ok());
+
+        config.antiabuse.claim_key_package_pow_bits = f2z_codec::pow::MAX_POW_DIFFICULTY_BITS + 1;
+        let error = config.check().unwrap_err();
+        assert!(format!("{error}").contains("claim_key_package_pow_bits"));
     }
 
     #[test]

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -31,6 +31,9 @@ const LIBRUSTZCASH_POLICY_SELF_TEST_COMMAND =
   "node scripts/check-librustzcash-compat.mjs --self-test";
 const LIBRUSTZCASH_POLICY_COMMAND =
   "node scripts/check-librustzcash-compat.mjs";
+const POW_POLICY_SELF_TEST_COMMAND =
+  "node scripts/check-pow-policy.mjs --self-test";
+const POW_POLICY_COMMAND = "node scripts/check-pow-policy.mjs";
 const REQUIRED_LIBRUSTZCASH_LOCKFILE_COUNT = 3;
 const REQUIRED_LIBRUSTZCASH_PACKAGE_COUNT = 11;
 const REQUIRED_LIBRUSTZCASH_SCOPE_DIGEST =
@@ -1345,13 +1348,15 @@ function requiredChangesControlFailures(relativeFile, lines, changes) {
   if (
     !hasExactKeys(policy.properties, ["name", "run"]) ||
     policy.properties.get("run")?.value !== "|" ||
-    commands.length !== 6 ||
+    commands.length !== 8 ||
     commands[0] !== GATE_POLICY_SELF_TEST_COMMAND ||
     commands[1] !== GATE_POLICY_COMMAND ||
     commands[2] !== WORKFLOW_GATES_SELF_TEST_COMMAND ||
     commands[3] !== WORKFLOW_GATES_COMMAND ||
     commands[4] !== LIBRUSTZCASH_POLICY_SELF_TEST_COMMAND ||
-    commands[5] !== LIBRUSTZCASH_POLICY_COMMAND
+    commands[5] !== LIBRUSTZCASH_POLICY_COMMAND ||
+    commands[6] !== POW_POLICY_SELF_TEST_COMMAND ||
+    commands[7] !== POW_POLICY_COMMAND
   ) {
     failures.push(
       `${relativeFile}:${policy.start + 1}: changes policy step must exactly self-test and enforce the current-source policy`,
@@ -4202,6 +4207,8 @@ function runCurrentWorkflowMutationTests(repoRoot) {
           `          ${WORKFLOW_GATES_COMMAND}`,
           `          ${LIBRUSTZCASH_POLICY_SELF_TEST_COMMAND}`,
           `          ${LIBRUSTZCASH_POLICY_COMMAND}`,
+          `          ${POW_POLICY_SELF_TEST_COMMAND}`,
+          `          ${POW_POLICY_COMMAND}`,
         ].join("\n"),
         [
           "      - name: Verify immutable actions and fail-closed required jobs",
@@ -4247,6 +4254,18 @@ function runCurrentWorkflowMutationTests(repoRoot) {
       needle:
         "changes policy step must exactly self-test and enforce the current-source policy",
       source: source.replace(`          ${LIBRUSTZCASH_POLICY_COMMAND}\n`, ""),
+    },
+    {
+      name: "real workflow rejects a missing bounded PoW policy self-test",
+      needle:
+        "changes policy step must exactly self-test and enforce the current-source policy",
+      source: source.replace(`          ${POW_POLICY_SELF_TEST_COMMAND}\n`, ""),
+    },
+    {
+      name: "real workflow rejects a missing bounded PoW policy verdict",
+      needle:
+        "changes policy step must exactly self-test and enforce the current-source policy",
+      source: source.replace(`          ${POW_POLICY_COMMAND}\n`, ""),
     },
     {
       name: "real workflow rejects a missing WASM boundary policy",
@@ -5124,6 +5143,8 @@ function runSelfTest(repoRoot) {
     `          ${WORKFLOW_GATES_COMMAND}`,
     `          ${LIBRUSTZCASH_POLICY_SELF_TEST_COMMAND}`,
     `          ${LIBRUSTZCASH_POLICY_COMMAND}`,
+    `          ${POW_POLICY_SELF_TEST_COMMAND}`,
+    `          ${POW_POLICY_COMMAND}`,
     "      - name: Verify the required Rust/WASM build boundary",
     "        run: |",
     `          ${WASM_POLICY_SELF_TEST_COMMAND}`,
@@ -5502,7 +5523,7 @@ function runSelfTest(repoRoot) {
         "changes policy step must exactly self-test and enforce the current-source policy",
       files: gateFixture(
         validGateWorkflow.replace(
-          `        run: |\n          ${GATE_POLICY_SELF_TEST_COMMAND}\n          ${GATE_POLICY_COMMAND}\n          ${WORKFLOW_GATES_SELF_TEST_COMMAND}\n          ${WORKFLOW_GATES_COMMAND}\n          ${LIBRUSTZCASH_POLICY_SELF_TEST_COMMAND}\n          ${LIBRUSTZCASH_POLICY_COMMAND}\n`,
+          `        run: |\n          ${GATE_POLICY_SELF_TEST_COMMAND}\n          ${GATE_POLICY_COMMAND}\n          ${WORKFLOW_GATES_SELF_TEST_COMMAND}\n          ${WORKFLOW_GATES_COMMAND}\n          ${LIBRUSTZCASH_POLICY_SELF_TEST_COMMAND}\n          ${LIBRUSTZCASH_POLICY_COMMAND}\n          ${POW_POLICY_SELF_TEST_COMMAND}\n          ${POW_POLICY_COMMAND}\n`,
           "        run: true\n",
         ),
       ),

--- a/scripts/check-pow-policy.mjs
+++ b/scripts/check-pow-policy.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+// One bounded proof-of-work policy across the public contract and shipping
+// Rust. This source check is deliberately independent of the Rust tests: a
+// coordinated edit that changes both runtime constants and their unit-test
+// expectations must still fail until the public policy is reviewed too.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const paths = {
+  wire: "docs/e2ee/WIRE.md",
+  contract: "docs/e2ee/CLIENT-CONTRACT.md",
+  decision: "docs/e2ee/decisions/0011-first-contact-contact-queues.md",
+  codec: "rs/crates/f2z-codec/src/pow.rs",
+  proto: "rs/crates/f2z-relay-proto/src/capabilities.rs",
+  config: "rs/crates/f2z-relay/src/config.rs",
+  relay: "wallet/plugins/tauri-plugin-f2zmsg/src/relay.rs",
+  ui: "wallet/zuuli/src/features/messages/FirstContact.tsx",
+};
+
+function liveSources() {
+  return Object.fromEntries(
+    Object.entries(paths).map(([name, relative]) => [
+      name,
+      fs.readFileSync(path.join(root, relative), "utf8"),
+    ]),
+  );
+}
+
+function required(source, needle, label, failures) {
+  if (!source.includes(needle)) failures.push(`${label}: missing ${JSON.stringify(needle)}`);
+}
+
+export function powPolicyFailures(sources) {
+  const failures = [];
+  const { wire, contract, decision, codec, proto, config, relay, ui } = sources;
+
+  for (const [needle, label] of [
+    ["pub const DEFAULT_POW_DIFFICULTY_BITS: u8 = 20;", "codec default difficulty"],
+    ["pub const MAX_POW_DIFFICULTY_BITS: u8 = DEFAULT_POW_DIFFICULTY_BITS;", "codec difficulty ceiling"],
+    ["pub const DEFAULT_POW_CHALLENGE_TTL_MS: u32 = 60_000;", "codec default challenge lifetime"],
+    ["pub const MAX_POW_CHALLENGE_TTL_MS: u32 = DEFAULT_POW_CHALLENGE_TTL_MS;", "codec challenge-lifetime ceiling"],
+    ["pub const MAX_POW_ATTEMPTS: u64 = 1 << 24;", "codec candidate budget"],
+    ["pub const MAX_POW_SOLVE_MS: u64 = 30_000;", "codec wall-clock budget"],
+    ["self.difficulty_bits > MAX_POW_DIFFICULTY_BITS", "codec validates difficulty ceiling"],
+    ["self.challenge_ttl_ms > MAX_POW_CHALLENGE_TTL_MS", "codec validates lifetime ceiling"],
+  ]) required(codec, needle, label, failures);
+
+  for (const [needle, label] of [
+    ["`difficulty_bits` in 1..=20", "WIRE signed-capability difficulty range"],
+    ["challenge_ttl_ms` in\n   1..=60000", "WIRE signed-capability lifetime range"],
+    ["16,777,216", "WIRE candidate budget"],
+    ["30,000 ms", "WIRE wall-clock budget"],
+    ["MUST NOT wrap to zero", "WIRE counter exhaustion"],
+    ["cooperatively", "WIRE cancellation"],
+    ["not a benchmark\nresult", "WIRE provisional default"],
+    ["before requesting a\nchallenge or beginning a search", "WIRE pre-work refusal"],
+  ]) required(wire, needle, label, failures);
+
+  for (const [needle, label] of [
+    ["reject signed work\n  above 20 bits before starting", "client pre-work refusal"],
+    ["16,777,216-candidate, 30,000 ms", "client finite work policy"],
+    ["No supported-phone duration has been measured", "client calibration honesty"],
+    ["never continue or wrap an exhausted search", "client failure behavior"],
+    ["algorithm 1 / 20-bit / 60000 ms default", "client provisional tuple"],
+  ]) required(contract, needle, label, failures);
+
+  required(
+    decision,
+    "not evidence of a supported-phone duration or an attacker cost",
+    "ADR calibration honesty",
+    failures,
+  );
+
+  for (const [needle, label] of [
+    ["difficulty_bits > MAX_POW_DIFFICULTY_BITS", "protocol signed difficulty refusal"],
+    ["challenge_ttl_ms > MAX_POW_CHALLENGE_TTL_MS", "protocol signed lifetime refusal"],
+    ["Refusal::PowWorkPolicyExceeded", "protocol named work-policy refusal"],
+    ["difficulty_bits: DEFAULT_POW_DIFFICULTY_BITS", "protocol shared default difficulty"],
+    ["challenge_ttl_ms: DEFAULT_POW_CHALLENGE_TTL_MS", "protocol shared default lifetime"],
+  ]) required(proto, needle, label, failures);
+
+  for (const [needle, label] of [
+    ["queue_creation_pow_bits: f2z_codec::pow::DEFAULT_POW_DIFFICULTY_BITS", "relay shared queue default"],
+    ["contact_append_pow_bits: f2z_codec::pow::DEFAULT_POW_DIFFICULTY_BITS", "relay shared contact default"],
+    ["claim_key_package_pow_bits: f2z_codec::pow::DEFAULT_POW_DIFFICULTY_BITS", "relay shared claim default"],
+    ["challenge_ttl_ms: f2z_codec::pow::DEFAULT_POW_CHALLENGE_TTL_MS", "relay shared lifetime default"],
+    ["difficulty > f2z_codec::pow::MAX_POW_DIFFICULTY_BITS", "relay configuration difficulty ceiling"],
+    ["challenge_ttl_ms > f2z_codec::pow::MAX_POW_CHALLENGE_TTL_MS", "relay configuration lifetime ceiling"],
+  ]) required(config, needle, label, failures);
+  if (config.includes("pow_bits > 64")) failures.push("relay retains the divergent 64-bit ceiling");
+
+  for (const [needle, label] of [
+    ["tokio::task::spawn_blocking", "shipping solver leaves async executor"],
+    ["tokio::time::timeout(valid_for, worker)", "shipping solver deadline"],
+    ["struct CancelPowOnDrop", "shipping caller cancellation"],
+    ["MAX_POW_ATTEMPTS", "shipping candidate budget"],
+    ["checked_add(1)", "shipping checked counter"],
+    ["PowSolveError::CounterExhausted", "shipping counter-exhaustion result"],
+    ["cancelled.load(Ordering::Acquire)", "shipping cooperative cancellation poll"],
+    ["self.policy.accept(&signed.capabilities)", "shipping signed policy acceptance"],
+    ["capabilities::check_digest", "shipping HELLO digest binding"],
+    ["if issued.pow != params", "shipping challenge/capability agreement"],
+  ]) required(relay, needle, label, failures);
+  if (relay.includes("wrapping_add(1)")) failures.push("shipping solver can wrap its counter");
+
+  for (const unsupported of ["can take several seconds", "This can take several"]) {
+    if (ui.includes(unsupported)) failures.push(`shipping UI retains unsupported timing claim ${JSON.stringify(unsupported)}`);
+  }
+
+  return failures;
+}
+
+function checkLive() {
+  const failures = powPolicyFailures(liveSources());
+  if (failures.length) throw new Error(`bounded PoW policy drift:\n- ${failures.join("\n- ")}`);
+  console.log("bounded PoW spec/runtime policy: passed");
+}
+
+function selfTest() {
+  const original = liveSources();
+  const mutations = [
+    ["codec maximum", "codec", "MAX_POW_DIFFICULTY_BITS: u8 = DEFAULT_POW_DIFFICULTY_BITS", "MAX_POW_DIFFICULTY_BITS: u8 = 21"],
+    ["WIRE maximum", "wire", "`difficulty_bits` in 1..=20", "`difficulty_bits` in 1..=21"],
+    ["client candidate budget", "contract", "16,777,216-candidate", "unbounded-candidate"],
+    ["relay shared default", "config", "queue_creation_pow_bits: f2z_codec::pow::DEFAULT_POW_DIFFICULTY_BITS", "queue_creation_pow_bits: 20"],
+    ["signed policy check", "proto", "difficulty_bits > MAX_POW_DIFFICULTY_BITS", "difficulty_bits < MAX_POW_DIFFICULTY_BITS"],
+    ["blocking isolation", "relay", "tokio::task::spawn_blocking", "tokio::spawn"],
+    ["counter wrap", "relay", "checked_add(1)", "wrapping_add(1)"],
+    ["caller cancellation", "relay", "struct CancelPowOnDrop", "struct IgnorePowOnDrop"],
+    ["unsupported UI timing", "ui", "Duration varies by device.", "This can take several seconds."],
+  ];
+
+  for (const [name, key, needle, replacement] of mutations) {
+    const changed = original[key].replace(needle, replacement);
+    assert.notEqual(changed, original[key], `${name}: mutation did not apply`);
+    assert.notDeepEqual(
+      powPolicyFailures({ ...original, [key]: changed }),
+      [],
+      `${name}: mutation escaped`,
+    );
+    console.log(`self-test: ${name}: passed`);
+  }
+}
+
+const mode = process.argv[2];
+if (mode === "--self-test") selfTest();
+else if (mode === undefined) checkLive();
+else {
+  console.error("usage: scripts/check-pow-policy.mjs [--self-test]");
+  process.exitCode = 2;
+}

--- a/scripts/check-pow-policy.mjs
+++ b/scripts/check-pow-policy.mjs
@@ -100,12 +100,19 @@ export function powPolicyFailures(sources) {
     ["struct CancelPowOnDrop", "shipping caller cancellation"],
     ["MAX_POW_ATTEMPTS", "shipping candidate budget"],
     ["checked_add(1)", "shipping checked counter"],
+    [".checked_sub(current_relay_time_ms)", "shipping challenge deadline uses current relay time"],
     ["PowSolveError::CounterExhausted", "shipping counter-exhaustion result"],
     ["cancelled.load(Ordering::Acquire)", "shipping cooperative cancellation poll"],
     ["self.policy.accept(&signed.capabilities)", "shipping signed policy acceptance"],
     ["capabilities::check_digest", "shipping HELLO digest binding"],
     ["if issued.pow != params", "shipping challenge/capability agreement"],
   ]) required(relay, needle, label, failures);
+  const currentLifetimeCalls = relay.match(
+    /challenge_lifetime\(&issued, self\.relay_time_ms\(\)\)\?/g,
+  );
+  if (currentLifetimeCalls?.length !== 2) {
+    failures.push("both shipping challenge paths must derive lifetime from current relay time");
+  }
   if (relay.includes("wrapping_add(1)")) failures.push("shipping solver can wrap its counter");
 
   for (const unsupported of ["can take several seconds", "This can take several"]) {
@@ -131,6 +138,8 @@ function selfTest() {
     ["signed policy check", "proto", "difficulty_bits > MAX_POW_DIFFICULTY_BITS", "difficulty_bits < MAX_POW_DIFFICULTY_BITS"],
     ["blocking isolation", "relay", "tokio::task::spawn_blocking", "tokio::spawn"],
     ["counter wrap", "relay", "checked_add(1)", "wrapping_add(1)"],
+    ["current challenge deadline", "relay", ".checked_sub(current_relay_time_ms)", ".checked_sub(issued.relay_time_ms)"],
+    ["both challenge paths", "relay", "challenge_lifetime(&issued, self.relay_time_ms())?", "challenge_lifetime(&issued, issued.relay_time_ms)?"],
     ["caller cancellation", "relay", "struct CancelPowOnDrop", "struct IgnorePowOnDrop"],
     ["unsupported UI timing", "ui", "Duration varies by device.", "This can take several seconds."],
   ];

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/commands.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/commands.rs
@@ -107,8 +107,9 @@ pub(crate) async fn get_conversation<R: Runtime>(
         .await
 }
 
-/// Runs the whole first-contact handshake, proof of work included. It can take
-/// seconds and the delay is computation, not network — the UI shows it as work.
+/// Runs the whole first-contact handshake, bounded proof of work included. The
+/// duration is uncalibrated; the UI identifies computation rather than calling
+/// it a network wait.
 #[command]
 pub(crate) async fn start_conversation<R: Runtime>(
     app: AppHandle<R>,

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
@@ -3782,9 +3782,9 @@ impl<B: StorageBackend> Inner<B> {
     /// (§12.2).
     ///
     /// Unsigned at the relay and gated by a proof-of-work stamp: that is the
-    /// whole design — a stranger can reach you exactly once, expensively — and
-    /// §12.4 is honest that the cost lands far harder on a phone than on rented
-    /// hardware. The search runs on a blocking thread — see
+    /// whole design — a stranger can reach you exactly once after presenting a
+    /// stamp — and §12.4 is honest that client and attacker costs are not yet
+    /// measured. The search runs on a bounded blocking thread — see
     /// `RelayConnection::stamp_for`, which is where that is arranged and where
     /// the residual it does *not* close is written down — and §3.3 tells the UI
     /// to show it as work, not as a network wait.

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/relay.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/relay.rs
@@ -40,6 +40,8 @@
 //!   the engine's, taken only after the durable local write commits (§9 rule
 //!   1). See [`RelayConnection::ack`]'s documentation.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use f2z_codec::canonical::{Canonical as _, decode_canonical};
@@ -53,7 +55,7 @@ use f2z_codec::commands::{
 };
 use f2z_codec::frame::{FramePayload, Push, RelayFrame, Response};
 use f2z_codec::padding::PaddingBuckets;
-use f2z_codec::pow::{PowParams, PowStamp};
+use f2z_codec::pow::{MAX_POW_ATTEMPTS, MAX_POW_SOLVE_MS, PowParams, PowStamp};
 use f2z_codec::types::{ChannelBinding, KeyPackage, Nonce, Payload, QueueAddress, RelayId, Salt};
 use f2z_codec::{Challenge, PROTOCOL_VERSION};
 use f2z_relay_proto::capabilities::ClientPolicy;
@@ -163,6 +165,7 @@ pub struct RelayConnection {
     padding: PaddingBuckets,
     relay_time_ms: u64,
     relay_time_taken: Instant,
+    policy: ClientPolicy,
     /// Set once the peer closes, so a caller stops trying.
     closed: bool,
 }
@@ -247,6 +250,7 @@ impl RelayConnection {
             padding: policy.padding.clone(),
             relay_time_ms,
             relay_time_taken: Instant::now(),
+            policy: policy.policy.clone(),
             closed: false,
         })
     }
@@ -282,9 +286,26 @@ impl RelayConnection {
     ///
     /// # Errors
     ///
-    /// As [`RelayConnection::call_unsigned`].
+    /// As [`RelayConnection::call_unsigned`], plus a signature, HELLO-digest,
+    /// or client-policy refusal. Validation completes before a caller can use
+    /// any advertised PoW value.
     pub async fn capabilities(&mut self) -> Result<SignedCapabilities> {
-        self.call_unsigned::<ops::GetCapabilities>(&Empty).await
+        let signed = self.call_unsigned::<ops::GetCapabilities>(&Empty).await?;
+        f2z_relay_proto::capabilities::verify(&signed, &self.session.relay_identity_pk())
+            .and_then(|()| {
+                f2z_relay_proto::capabilities::check_digest(
+                    &signed.capabilities,
+                    &self.session.capabilities_digest(),
+                )
+            })
+            .and_then(|()| self.policy.accept(&signed.capabilities))
+            .map_err(|error| {
+                Error::new(
+                    from_proto(error, Command::GetCapabilities, BindAttempt::Later),
+                    format!("the relay's signed capabilities are refused: {error:?}"),
+                )
+            })?;
+        Ok(signed)
     }
 
     /// Additive §12.6 key-package policy discovery.
@@ -526,9 +547,9 @@ impl RelayConnection {
 
     /// `CONTACT_APPEND` (§12.2), with a stamp scoped to `contact_addr`.
     ///
-    /// This is the proof-of-work first contact pays. §12.4 is honest that it
-    /// taxes phones far more than rented hardware and that no tuning fixes
-    /// that; the UI's job is to show it as work rather than as a network wait.
+    /// This is the proof-of-work first contact pays. §12.4 records that its
+    /// supported-device and attacker costs are unmeasured; the UI's job is to
+    /// show it as work rather than as a network wait.
     ///
     /// # Errors
     ///
@@ -640,13 +661,12 @@ impl RelayConnection {
                 "relay issued an unmetered key-package claim challenge",
             ));
         }
-        let challenge = issued.challenge;
-        let difficulty_bits = issued.pow.difficulty_bits;
-        let stamp = tokio::task::spawn_blocking(move || solve(challenge, difficulty_bits))
-            .await
-            .map_err(|error| {
-                Error::internal(format!("the stamp search did not finish: {error}"))
-            })?;
+        let stamp = solve_bounded(
+            issued.challenge,
+            issued.pow.difficulty_bits,
+            challenge_lifetime(&issued)?,
+        )
+        .await?;
         let body = ClaimKeyPackageRequest {
             contact_addr,
             stamp,
@@ -836,15 +856,19 @@ impl RelayConnection {
     /// Obtain a challenge and solve a stamp, when and only when the relay's
     /// published parameters require one (§13.1).
     ///
-    /// # The search runs on a blocking thread, and that is not a nicety
+    /// # The search runs on a bounded blocking thread, and that is not a nicety
     ///
-    /// [`solve`] is an unbounded synchronous loop — a leading-zero-bit search
-    /// that takes seconds on a phone at the shipped difficulty, and §12.4 is
-    /// blunt that no tuning fixes that. Run inline on the async task it would
+    /// [`solve_bounded`] is a leading-zero-bit search. Run inline on the async task it would
     /// hold a runtime worker for the whole search, stalling **every other task
     /// in the process**: the inbound pump that must ACK, the other relay
     /// connections, and every Tauri command. Since `WIRE.md` §12.6 first
     /// contact pays **two** stamps rather than one, so the window doubled.
+    ///
+    /// The blocking worker cooperatively observes cancellation if this future
+    /// is dropped, and independently stops at the earliest of the challenge
+    /// expiry, the client wall-clock ceiling, the candidate budget, or `u64`
+    /// counter exhaustion. A timeout therefore returns promptly without
+    /// leaving an unbounded blocking task behind.
     ///
     /// # The residual, stated rather than implied
     ///
@@ -853,9 +877,9 @@ impl RelayConnection {
     /// is polled only from inside its own methods, so nothing answers §2.4's
     /// server-driven Ping until this call returns, and a relay whose keepalive
     /// is shorter than the search will close — correctly. The shipping relay's
-    /// interval is 25 s with two missed Pongs, so this is bounded well above a
-    /// realistic solve; a relay that published a tighter one would break first
-    /// contact here. Closing it for real needs a reader task owning the socket,
+    /// interval is 25 s with two missed Pongs, while the client work deadline is
+    /// 30 s. A relay that published a tighter one could break first contact here.
+    /// Closing it for real needs a reader task owning the socket,
     /// which is a change to this file's ownership model and not a line.
     async fn stamp_for(
         &mut self,
@@ -863,20 +887,42 @@ impl RelayConnection {
         scope: &[u8],
         pow: Option<PowParams>,
     ) -> Result<PowStamp> {
-        let Some(params) = pow.filter(PowParams::is_required) else {
+        let Some(params) = pow else {
             return Ok(PowStamp::empty());
         };
+        params.validate().map_err(|_| {
+            Error::new(
+                ErrorCode::RelayCapabilityMismatch,
+                "proof-of-work parameters exceed the bounded v1 client policy",
+            )
+        })?;
+        if !params.is_required() {
+            return Ok(PowStamp::empty());
+        }
         let body = ChallengeRequest {
             purpose: purpose.code(),
             scope: f2z_codec::types::ShortBytes::new(scope.to_vec())
                 .map_err(|error| Error::internal(format!("challenge scope: {error:?}")))?,
         };
         let issued = self.call_unsigned::<ops::GetChallenge>(&body).await?;
-        let challenge = issued.challenge;
-        let difficulty_bits = params.difficulty_bits;
-        tokio::task::spawn_blocking(move || solve(challenge, difficulty_bits))
-            .await
-            .map_err(|error| Error::internal(format!("the stamp search did not finish: {error}")))
+        issued.pow.validate().map_err(|_| {
+            Error::new(
+                ErrorCode::RelayCapabilityMismatch,
+                "relay issued proof-of-work parameters outside the bounded v1 client policy",
+            )
+        })?;
+        if issued.pow != params {
+            return Err(Error::new(
+                ErrorCode::RelayCapabilityMismatch,
+                "relay challenge proof-of-work parameters differ from its signed capabilities",
+            ));
+        }
+        solve_bounded(
+            issued.challenge,
+            params.difficulty_bits,
+            challenge_lifetime(&issued)?,
+        )
+        .await
     }
 
     fn take_request_id(&mut self) -> u32 {
@@ -982,26 +1028,124 @@ impl RelayConnection {
     }
 }
 
-/// §13.1's stamp search: leading zero bits over BLAKE2b, chosen so verification
-/// is a single hash.
-///
-/// Synchronous and unbounded on purpose. It is the reason `start_conversation`
-/// can take seconds, and §3.3 tells the UI to show that as *work on this
-/// device* rather than as a network wait. The caller runs it on a blocking task.
-#[must_use]
-pub fn solve(challenge: Challenge, difficulty_bits: u8) -> PowStamp {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PowSolveError {
+    Cancelled,
+    Deadline,
+    AttemptLimit,
+    CounterExhausted,
+}
+
+impl core::fmt::Display for PowSolveError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Cancelled => f.write_str("cancelled"),
+            Self::Deadline => f.write_str("deadline reached"),
+            Self::AttemptLimit => f.write_str("candidate budget exhausted"),
+            Self::CounterExhausted => f.write_str("counter exhausted"),
+        }
+    }
+}
+
+/// Sets the cooperative flag on every exit, including caller cancellation.
+struct CancelPowOnDrop(Arc<AtomicBool>);
+
+impl Drop for CancelPowOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Release);
+    }
+}
+
+fn challenge_lifetime(issued: &f2z_codec::commands::ChallengeResponse) -> Result<Duration> {
+    let remaining_ms = issued
+        .expires_at_ms
+        .checked_sub(issued.relay_time_ms)
+        .filter(|remaining| *remaining > 0)
+        .ok_or_else(|| Error::new(ErrorCode::PowFailed, "relay issued an expired challenge"))?;
+    Ok(Duration::from_millis(remaining_ms).min(Duration::from_millis(MAX_POW_SOLVE_MS)))
+}
+
+async fn solve_bounded(
+    challenge: Challenge,
+    difficulty_bits: u8,
+    valid_for: Duration,
+) -> Result<PowStamp> {
     let mut salt_bytes = [0u8; 16];
     rand::rng().fill_bytes(&mut salt_bytes);
-    let mut stamp = PowStamp {
-        challenge,
-        salt: Salt::from(salt_bytes),
-        counter: 0,
-    };
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancel_on_drop = CancelPowOnDrop(Arc::clone(&cancelled));
+    let deadline = Instant::now()
+        .checked_add(valid_for)
+        .ok_or_else(|| Error::internal("proof-of-work deadline overflow"))?;
+    let worker = tokio::task::spawn_blocking(move || {
+        solve_search(
+            challenge,
+            difficulty_bits,
+            Salt::from(salt_bytes),
+            0,
+            MAX_POW_ATTEMPTS,
+            deadline,
+            &cancelled,
+        )
+    });
+
+    let outcome = tokio::time::timeout(valid_for, worker).await;
+    drop(cancel_on_drop);
+    match outcome {
+        Ok(Ok(Ok(stamp))) => Ok(stamp),
+        Ok(Ok(Err(error))) => Err(Error::new(
+            ErrorCode::PowFailed,
+            format!("proof-of-work search stopped: {error}"),
+        )),
+        Ok(Err(error)) => Err(Error::internal(format!(
+            "the proof-of-work worker did not finish: {error}"
+        ))),
+        Err(_) => Err(Error::new(
+            ErrorCode::PowFailed,
+            "proof-of-work search reached the client deadline",
+        )),
+    }
+}
+
+/// §13.1's bounded stamp search. `counter` is advanced with `checked_add` so
+/// exhausting the fixed `(challenge, salt, uint64)` search space is terminal,
+/// never a wrap back to work already performed.
+fn solve_search(
+    challenge: Challenge,
+    difficulty_bits: u8,
+    salt: Salt,
+    first_counter: u64,
+    max_attempts: u64,
+    deadline: Instant,
+    cancelled: &AtomicBool,
+) -> core::result::Result<PowStamp, PowSolveError> {
+    if max_attempts == 0 {
+        return Err(PowSolveError::AttemptLimit);
+    }
+    let mut counter = first_counter;
+    let mut attempts = 0u64;
     loop {
-        if stamp.meets_difficulty(difficulty_bits) {
-            return stamp;
+        if cancelled.load(Ordering::Acquire) {
+            return Err(PowSolveError::Cancelled);
         }
-        stamp.counter = stamp.counter.wrapping_add(1);
+        if Instant::now() >= deadline {
+            return Err(PowSolveError::Deadline);
+        }
+        let stamp = PowStamp {
+            challenge,
+            salt,
+            counter,
+        };
+        if stamp.meets_difficulty(difficulty_bits) {
+            return Ok(stamp);
+        }
+        counter = counter
+            .checked_add(1)
+            .ok_or(PowSolveError::CounterExhausted)?;
+        attempts = attempts.saturating_add(1);
+        if attempts >= max_attempts {
+            return Err(PowSolveError::AttemptLimit);
+        }
     }
 }
 
@@ -1138,4 +1282,107 @@ async fn hello(
         &policy.policy,
     )
     .map_err(|error| proto(error, Command::Hello, BindAttempt::Later))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn future_deadline() -> Instant {
+        Instant::now()
+            .checked_add(Duration::from_secs(2))
+            .expect("short test deadline")
+    }
+
+    #[test]
+    fn deterministic_low_cost_search_finds_a_verifiable_stamp() {
+        let cancelled = AtomicBool::new(false);
+        let stamp = solve_search(
+            Challenge::new([0x5a; 32]),
+            8,
+            Salt::new([0x0f; 16]),
+            0,
+            100_000,
+            future_deadline(),
+            &cancelled,
+        )
+        .expect("8-bit deterministic search");
+        assert!(stamp.meets_difficulty(8));
+    }
+
+    #[test]
+    fn a_fixed_search_space_ends_instead_of_wrapping_its_counter() {
+        let cancelled = AtomicBool::new(false);
+        let challenge = Challenge::new([0xa5; 32]);
+        let salt = Salt::new([0x33; 16]);
+        let last = PowStamp {
+            challenge,
+            salt,
+            counter: u64::MAX,
+        };
+        assert!(
+            !last.meets_difficulty(255),
+            "fixture must not solve the hostile target"
+        );
+        assert_eq!(
+            solve_search(
+                challenge,
+                255,
+                salt,
+                u64::MAX,
+                2,
+                future_deadline(),
+                &cancelled,
+            ),
+            Err(PowSolveError::CounterExhausted)
+        );
+    }
+
+    #[test]
+    fn cancellation_stops_hostile_work_promptly() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let worker_cancelled = Arc::clone(&cancelled);
+        let started = Instant::now();
+        let worker = std::thread::spawn(move || {
+            solve_search(
+                Challenge::new([0x77; 32]),
+                255,
+                Salt::new([0x88; 16]),
+                0,
+                u64::MAX,
+                Instant::now()
+                    .checked_add(Duration::from_secs(10))
+                    .expect("short test deadline"),
+                &worker_cancelled,
+            )
+        });
+        std::thread::sleep(Duration::from_millis(10));
+        cancelled.store(true, Ordering::Release);
+        assert_eq!(
+            worker.join().expect("worker joins"),
+            Err(PowSolveError::Cancelled)
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "cooperative cancellation must not wait for the work/deadline bounds"
+        );
+    }
+
+    #[test]
+    fn an_expired_challenge_is_refused_before_work() {
+        let issued = f2z_codec::commands::ChallengeResponse {
+            relay_time_ms: 100,
+            challenge: Challenge::new([0x11; 32]),
+            expires_at_ms: 100,
+            pow: PowParams {
+                algorithm: f2z_codec::pow::ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
+                difficulty_bits: f2z_codec::pow::DEFAULT_POW_DIFFICULTY_BITS,
+                challenge_ttl_ms: f2z_codec::pow::DEFAULT_POW_CHALLENGE_TTL_MS,
+            },
+        };
+        assert_eq!(
+            challenge_lifetime(&issued).unwrap_err().code(),
+            ErrorCode::PowFailed
+        );
+    }
 }

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/relay.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/relay.rs
@@ -664,7 +664,7 @@ impl RelayConnection {
         let stamp = solve_bounded(
             issued.challenge,
             issued.pow.difficulty_bits,
-            challenge_lifetime(&issued)?,
+            challenge_lifetime(&issued, self.relay_time_ms())?,
         )
         .await?;
         let body = ClaimKeyPackageRequest {
@@ -920,7 +920,7 @@ impl RelayConnection {
         solve_bounded(
             issued.challenge,
             params.difficulty_bits,
-            challenge_lifetime(&issued)?,
+            challenge_lifetime(&issued, self.relay_time_ms())?,
         )
         .await
     }
@@ -1056,12 +1056,20 @@ impl Drop for CancelPowOnDrop {
     }
 }
 
-fn challenge_lifetime(issued: &f2z_codec::commands::ChallengeResponse) -> Result<Duration> {
+fn challenge_lifetime(
+    issued: &f2z_codec::commands::ChallengeResponse,
+    current_relay_time_ms: u64,
+) -> Result<Duration> {
     let remaining_ms = issued
         .expires_at_ms
-        .checked_sub(issued.relay_time_ms)
+        .checked_sub(current_relay_time_ms)
         .filter(|remaining| *remaining > 0)
-        .ok_or_else(|| Error::new(ErrorCode::PowFailed, "relay issued an expired challenge"))?;
+        .ok_or_else(|| {
+            Error::new(
+                ErrorCode::PowFailed,
+                "relay challenge expired before proof-of-work could begin",
+            )
+        })?;
     Ok(Duration::from_millis(remaining_ms).min(Duration::from_millis(MAX_POW_SOLVE_MS)))
 }
 
@@ -1369,11 +1377,11 @@ mod tests {
     }
 
     #[test]
-    fn an_expired_challenge_is_refused_before_work() {
+    fn a_delayed_response_that_is_now_expired_is_refused_before_work() {
         let issued = f2z_codec::commands::ChallengeResponse {
             relay_time_ms: 100,
             challenge: Challenge::new([0x11; 32]),
-            expires_at_ms: 100,
+            expires_at_ms: 150,
             pow: PowParams {
                 algorithm: f2z_codec::pow::ALGORITHM_BLAKE2B_LEADING_ZERO_BITS,
                 difficulty_bits: f2z_codec::pow::DEFAULT_POW_DIFFICULTY_BITS,
@@ -1381,7 +1389,11 @@ mod tests {
             },
         };
         assert_eq!(
-            challenge_lifetime(&issued).unwrap_err().code(),
+            challenge_lifetime(&issued, issued.relay_time_ms).expect("fresh at issuance"),
+            Duration::from_millis(50)
+        );
+        assert_eq!(
+            challenge_lifetime(&issued, 151).unwrap_err().code(),
             ErrorCode::PowFailed
         );
     }

--- a/wallet/zuuli/src/features/messages/FirstContact.tsx
+++ b/wallet/zuuli/src/features/messages/FirstContact.tsx
@@ -265,7 +265,7 @@ export function FirstContact({
           </h2>
           <p className="mt-1 text-sm text-muted-foreground">
             Enter an exact messaging handle. Establishing first contact computes
-            proof of work on this device and can take several seconds.
+            bounded proof of work on this device; its duration varies by device.
           </p>
         </div>
 
@@ -309,8 +309,8 @@ export function FirstContact({
             role="status"
             aria-live="polite"
           >
-            Computing proof of work on this device. This can take several
-            seconds.
+            Computing proof of work on this device within a bounded work policy.
+            Duration varies by device.
           </p>
         ) : null}
 


### PR DESCRIPTION
## Summary
- define one provisional v1 PoW policy across WIRE, CLIENT-CONTRACT, codec, relay configuration, and the shipping client
- refuse hostile signed capabilities before work and solve on a bounded blocking worker with deadline, cancellation, attempt, and counter-exhaustion limits
- add boundary/refusal/cancellation/low-cost tests plus a mutation-sensitive spec/runtime policy checker wired into the required workflow

## Verification
- `cargo +1.97.1 test --locked -p f2z-codec -p f2z-relay-proto -p f2z-relay`
- `cargo +1.97.1 test --locked --lib` (tauri-plugin-f2zmsg)
- `cargo +1.97.1 fmt --all -- --check` (rs)
- `cargo +1.97.1 fmt --manifest-path Cargo.toml -- --check` (tauri-plugin-f2zmsg)
- `node scripts/check-pow-policy.mjs --self-test`
- `node scripts/check-pow-policy.mjs`
- `node scripts/check-github-actions-pins.mjs --self-test`
- `node scripts/check-github-actions-pins.mjs`
- `scripts/check-rust-toolchain.sh`

Closes #821