### PR TITLE
test(zuuli): remove gate timing races

### DIFF
--- a/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
@@ -4974,6 +4974,7 @@ fn capabilities_view(capabilities: &f2z_codec::commands::Capabilities) -> RelayC
 mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use f2z_codec::commands::Command;
     use f2z_codec::types::{Digest, PublicKey, RelayId, ShortBytes};
@@ -4982,6 +4983,7 @@ mod tests {
     use f2z_msg_identity::{AccountKeys, DeviceCredentialRequest};
     use f2z_msg_mls::{DeviceSigner, MlsEngine};
     use f2z_msg_store::{Durability, MemoryBackend, Op, SqliteBackend, StorageBackend, StoreError};
+    use f2z_relay_testkit::config::RelayConfig as FakeRelayConfig;
     use f2z_relay_testkit::fake::FakeRelay;
     use f2z_relay_testkit::faults::{Effect, Fault, Trigger};
     use openmls::prelude::{GroupId, MlsGroup};
@@ -6655,7 +6657,16 @@ mod tests {
 
     #[tokio::test]
     async fn failed_atomic_theft_commit_uses_loud_in_memory_fallback_without_partial_state() {
-        let relay = FakeRelay::with_defaults().expect("fake relay");
+        // This test deliberately parks the client socket while it opens and
+        // primes a real SQLite store. The FakeRelay's 500 ms keepalive is for
+        // keepalive tests, not representative of the shipping relay's 25 s
+        // interval; under a contended gate it could close this otherwise-ready
+        // fixture before the storage-failure assertion even began.
+        let relay_config = FakeRelayConfig {
+            ping_interval: Duration::from_secs(25),
+            ..FakeRelayConfig::default()
+        };
+        let relay = FakeRelay::new(relay_config).expect("fake relay");
         let server = relay.listen_loopback().await.expect("relay listener");
         let url = server.url();
         let root = tempfile::tempdir().expect("tempdir");
@@ -6689,6 +6700,10 @@ mod tests {
             .records()
             .commit(|records| records.put_conversation(&stored))
             .expect("initial conversation");
+        connection
+            .capabilities()
+            .await
+            .expect("storage-fault fixture relay is ready before the theft assertion");
         inner.connections.insert(url.clone(), connection);
         // One successful preflight apply, then fail the single atomic
         // conversation+alarm transition.

--- a/wallet/zuuli/src/components/common/BidiIdentifier.test.tsx
+++ b/wallet/zuuli/src/components/common/BidiIdentifier.test.tsx
@@ -146,7 +146,10 @@ describe("BidiIdentifier", () => {
   });
 });
 
-describe("opaque identifier production inventory", () => {
+// These are compiler-backed source-policy tests, not ordinary unit assertions.
+// Keep their budget local to this suite so a saturated parallel worker cannot
+// turn legitimate AST analysis into a global retry or timeout increase.
+describe("opaque identifier production inventory", { timeout: 30_000 }, () => {
   it("binds all 13 wallet/auth displays, both live IDs, and both editable addresses", () => {
     expect(() => assertBidiIdentifierPolicy(productionSources())).not.toThrow();
   });

--- a/wallet/zuuli/src/components/common/bidi-identifier-policy.ts
+++ b/wallet/zuuli/src/components/common/bidi-identifier-policy.ts
@@ -65,7 +65,16 @@ const EXPECTED_LTR_INPUTS: Readonly<Record<string, readonly string[]>> = {
   "src/features/profile/index.tsx": ["profile-p2paddr"],
 };
 
+// Most policy mutants change one of the eight audited files. Keep the other
+// seven parsed trees and their symbol tables instead of rebuilding a complete
+// TypeScript program for them in every assertion. The source text is the cache
+// identity, so a mutant can never inherit the verdict for the production file.
+const parsedSources = new Map<string, Map<string, ts.SourceFile>>();
+const sourceCheckers = new WeakMap<ts.SourceFile, ts.TypeChecker>();
+
 function parse(fileName: string, source: string): ts.SourceFile {
+  const cached = parsedSources.get(fileName)?.get(source);
+  if (cached) return cached;
   const file = ts.createSourceFile(
     fileName,
     source,
@@ -79,6 +88,12 @@ function parse(fileName: string, source: string): ts.SourceFile {
   if (diagnostics.length > 0) {
     throw new Error(`bidi identifier policy cannot parse ${fileName}`);
   }
+  let bySource = parsedSources.get(fileName);
+  if (!bySource) {
+    bySource = new Map();
+    parsedSources.set(fileName, bySource);
+  }
+  bySource.set(source, file);
   return file;
 }
 
@@ -216,6 +231,8 @@ function exactImportBinding(file: ts.SourceFile): ts.Identifier | null {
 }
 
 function checkerFor(fileName: string, file: ts.SourceFile): ts.TypeChecker {
+  const cached = sourceCheckers.get(file);
+  if (cached) return cached;
   const options: ts.CompilerOptions = {
     jsx: ts.JsxEmit.ReactJSX,
     module: ts.ModuleKind.ESNext,
@@ -230,7 +247,9 @@ function checkerFor(fileName: string, file: ts.SourceFile): ts.TypeChecker {
       ? file
       : getSourceFile(candidate, languageVersion, onError, shouldCreateNewSourceFile);
   const program = ts.createProgram([fileName], options, host);
-  return program.getTypeChecker();
+  const checker = program.getTypeChecker();
+  sourceCheckers.set(file, checker);
+  return checker;
 }
 
 function isImportedBidiTag(


### PR DESCRIPTION
Closes #865

## What changed

- Cache BidiIdentifier policy `SourceFile`s and type checkers by exact file/source identity, so each mutant recompiles only the file it changes instead of rebuilding all eight audited programs.
- Give only the compiler-backed opaque-identifier suite a realistic 30-second budget; global Vitest retries and timeouts are unchanged.
- Run the SQLite theft-fallback test's FakeRelay at the shipping 25-second ping cadence instead of the harness's keepalive-test-oriented 500 ms cadence.
- Prove the established relay transport is still ready with a signed capabilities round trip immediately before the definitive theft assertion. The `SendAddressStolen` assertion and all atomic/no-partial-state checks remain exact.

## Verification

- Full parallel `npx vitest run`: 5/5 stress runs green, 99 files / 1,506 active tests each; post-rebase run also green.
- `BidiIdentifier.test.tsx`: all 76 tests green under concurrent cold Rust clippy load; initial inventory completed in 2.8 s.
- Exact Rust regression: 50/50 stress runs green on Rust 1.97.1; post-rebase focused run green.
- CI-equivalent messaging command green: `cargo test --locked --all-targets --features relay-harness` (74 lib tests plus all integration/two-process harness tests).
- `cargo +1.97.1 clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.97.1 fmt -- --check`
- `npm run typecheck:tests`
- `npm run test:rtl` (17 source-policy tests, 88 Vitest tests, 2 Playwright tests)
- Tauri plugin permission self-test and live parity check.
