### PR TITLE
docs(e2ee): distinguish bulk KT download from enumeration

### DIFF
--- a/docs/e2ee/KT.md
+++ b/docs/e2ee/KT.md
@@ -237,6 +237,18 @@ public by design — it is how `@alice` is discoverable — and the zero-knowled
 property protects the entries you did *not* ask for, not the one you did. See
 [`THREAT-MODEL.md` §4.1](./THREAT-MODEL.md#41-directory-lookup-reveals-interest-in-a-handle).
 
+<!-- akd-claim:enumeration_boundary_kt:start -->
+That protection is against a bulk directory download, not against
+handle-by-handle reconstruction. `/kt/v1/lookup` is available to anyone (§9.2),
+and a public-username platform gives an observer a public list of candidate
+handles. Each successful lookup reveals that handle's full `DirectoryEntry`,
+including its device credentials and contact endpoints. Rate limiting can make
+enumeration slower and more expensive; it does not make membership or the
+returned metadata for known or guessed handles cryptographically private. The
+zero-knowledge benefit remains concrete: there is no one-shot corpus, and
+unqueried or unguessed handles remain hidden.
+<!-- akd-claim:enumeration_boundary_kt:end -->
+
 ---
 
 ## 4. `DirectoryEntry`

--- a/docs/e2ee/decisions/0013-key-transparency-log.md
+++ b/docs/e2ee/decisions/0013-key-transparency-log.md
@@ -285,6 +285,24 @@ is [`../KT.md`](../KT.md).
   meant. Note that the leak comes from publishing entries in the clear, not from
   RFC 6962, which is why the fallback above pairs it with a VRF and a commitment.
 
+  <!-- akd-claim:enumeration_boundary_adr:start -->
+  **Correction (2026-09-03) — “the full membership ... as a downloadable
+  file” distinguishes bulk publication from enumeration; it does not make
+  public handles non-enumerable.** The rejection above remains sound: a
+  cleartext log exposes one permanent corpus that can be copied without first
+  knowing or guessing any handle. The adopted zero-knowledge set prevents that
+  one-shot download and keeps an entry hidden from an observer who does not
+  query or guess its handle.
+
+  It does not prevent handle-by-handle reconstruction. `/kt/v1/lookup` is
+  available to anyone, a successful response carries the full
+  `DirectoryEntry`, and on a public-username platform the public username list
+  supplies candidate handles. Server rate limits can raise the time and request
+  cost of that reconstruction, but they are an operational bound, not a
+  cryptographic claim that membership, device count, credential and entry
+  timestamps, or contact endpoints for queried handles are non-enumerable.
+  <!-- akd-claim:enumeration_boundary_adr:end -->
+
 - **Full hand-rolled SEEMless.** Rejected as the worst of both: it keeps the
   privacy property and therefore keeps the expensive append-only proof, so it
   gives up nothing `akd` costs us, while taking on the entire soundness burden of

--- a/scripts/check-akd-doc-evidence.mjs
+++ b/scripts/check-akd-doc-evidence.mjs
@@ -117,6 +117,46 @@ const claimInventory = new Map([
   ["audit_scope", "docs/e2ee/decisions/0013-key-transparency-log.md"],
   ["history_proof_type", "docs/e2ee/KT.md"],
   ["history_request_wire", "docs/e2ee/KT.md"],
+  ["enumeration_boundary_kt", "docs/e2ee/KT.md"],
+  ["enumeration_boundary_adr", "docs/e2ee/decisions/0013-key-transparency-log.md"],
+]);
+
+const requiredClaimInventory = new Map([
+  ["audit_scope", "docs/e2ee/decisions/0013-key-transparency-log.md"],
+  ["history_proof_type", "docs/e2ee/KT.md"],
+  ["history_request_wire", "docs/e2ee/KT.md"],
+  ["enumeration_boundary_kt", "docs/e2ee/KT.md"],
+  ["enumeration_boundary_adr", "docs/e2ee/decisions/0013-key-transparency-log.md"],
+]);
+
+const enumerationClaimContexts = new Map([
+  [
+    "enumeration_boundary_kt",
+    Object.freeze({
+      before:
+        "[`THREAT-MODEL.md` §4.1](./THREAT-MODEL.md#41-directory-lookup-reveals-interest-in-a-handle).\n\n",
+      after: "\n\n---\n\n## 4. `DirectoryEntry`",
+      markerIndent: "",
+      outerHeading: "3. What `akd` provides, and what we add",
+      outerHeadingOrdinal: 2,
+      sectionHeading: "3.3 Label and value",
+      sectionHeadingOrdinal: 2,
+      followingHeading: "4. `DirectoryEntry`",
+    }),
+  ],
+  [
+    "enumeration_boundary_adr",
+    Object.freeze({
+      before:
+        "RFC 6962, which is why the fallback above pairs it with a VRF and a commitment.\n\n  ",
+      after: "\n\n- **Full hand-rolled SEEMless.**",
+      markerIndent: "  ",
+      outerHeading: "Alternatives rejected",
+      outerHeadingOrdinal: 3,
+      itemStart: "- **A plain cleartext RFC 6962 log.**",
+      itemEnd: "- **Full hand-rolled SEEMless.**",
+    }),
+  ],
 ]);
 
 function sha256(value) {
@@ -215,7 +255,7 @@ function validateMetricClaims(files, benchmark) {
   }
 }
 
-function claimBlock(source, key) {
+function claimBounds(source, key) {
   const start = `<!-- akd-claim:${key}:start -->`;
   const end = `<!-- akd-claim:${key}:end -->`;
   const startIndex = source.indexOf(start);
@@ -223,12 +263,670 @@ function claimBlock(source, key) {
   assert(startIndex >= 0 && endIndex > startIndex, `missing complete ${key} claim block`);
   assert.equal(source.indexOf(start, startIndex + 1), -1, `duplicate ${key} claim start`);
   assert.equal(source.indexOf(end, endIndex + 1), -1, `duplicate ${key} claim end`);
+  return { start, end, startIndex, endIndex };
+}
+
+function claimBlock(source, key) {
+  const { start, endIndex, startIndex } = claimBounds(source, key);
   return source
     .slice(startIndex + start.length, endIndex)
     .trim()
     .split("\n")
     .map((line) => line.trimStart())
     .join("\n");
+}
+
+function markdownLines(source) {
+  return [...source.matchAll(/[^\n]*(?:\n|$)/g)]
+    .filter((match) => match[0] !== "")
+    .map((match) => ({
+      index: match.index,
+      line: match[0].endsWith("\n") ? match[0].slice(0, -1) : match[0],
+      hasNewline: match[0].endsWith("\n"),
+    }));
+}
+
+function markdownContainerAt(containers, index) {
+  return containers.find(({ start, end }) => index >= start && index < end) ?? null;
+}
+
+function markdownLineInContainer(line, container) {
+  if (container === null || container.indent === 0 || line.trim() === "") return line;
+  const prefix = " ".repeat(container.indent);
+  return line.startsWith(prefix) ? line.slice(container.indent) : line;
+}
+
+function markdownFenceCandidate(line) {
+  const match = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+  if (!match) return null;
+  return {
+    character: match[1][0],
+    length: match[1].length,
+    rest: match[2],
+  };
+}
+
+function nextMarkdownFence(fence, line, container = null) {
+  // A block nested in a list item cannot consume the next sibling item. Reset
+  // an unterminated fence when its reviewed container ends, just as CommonMark
+  // does after removing the list's content indentation.
+  if (fence !== null && fence.container !== container) fence = null;
+  const candidate = markdownFenceCandidate(line);
+  if (!candidate) return fence;
+  if (fence === null) {
+    // CommonMark forbids backticks in a backtick fence's info string. Tilde
+    // fences have no corresponding restriction.
+    if (candidate.character === "`" && candidate.rest.includes("`")) return null;
+    return { character: candidate.character, length: candidate.length, container };
+  }
+  // A closing fence uses the same character, is at least as long as its opener,
+  // and has no info string: only spaces or tabs may follow it.
+  if (
+    candidate.character === fence.character
+    && candidate.length >= fence.length
+    && /^[ \t]*$/.test(candidate.rest)
+  ) {
+    return null;
+  }
+  return fence;
+}
+
+function markdownFenceAt(source, index, containers = []) {
+  let fence = null;
+  for (const entry of markdownLines(source)) {
+    if (entry.index >= index) break;
+    const container = markdownContainerAt(containers, entry.index);
+    fence = nextMarkdownFence(
+      fence,
+      markdownLineInContainer(entry.line, container),
+      container,
+    );
+  }
+  return fence !== null && fence.container === markdownContainerAt(containers, index)
+    ? fence
+    : null;
+}
+
+function insideMarkdownFence(source, index, containers = []) {
+  return markdownFenceAt(source, index, containers) !== null;
+}
+
+function maskMarkdownFences(source, containers = []) {
+  let fence = null;
+  let masked = "";
+  for (const entry of markdownLines(source)) {
+    const { hasNewline, index, line } = entry;
+    const container = markdownContainerAt(containers, index);
+    const effectiveLine = markdownLineInContainer(line, container);
+    const wasInside = fence !== null && fence.container === container;
+    fence = nextMarkdownFence(fence, effectiveLine, container);
+    const isFenceLine = markdownFenceCandidate(effectiveLine) !== null && (wasInside || fence !== null);
+    masked += wasInside || isFenceLine ? " ".repeat(line.length) : line;
+    if (hasNewline) masked += "\n";
+  }
+  return masked;
+}
+
+function markdownHeadings(source, containers = []) {
+  const headings = [];
+  // CommonMark permits up to three leading spaces before an ATX heading. A
+  // structural census that recognises only column zero lets an ordinary
+  // one-space H2 move a claim while remaining invisible to its ordinal check.
+  const atxPattern = /^ {0,3}(#{1,6})(?:[ \t]+(.*?))?[ \t]*$/;
+  const lines = markdownLines(source);
+  for (const entry of lines) {
+    const container = markdownContainerAt(containers, entry.index);
+    const match = atxPattern.exec(markdownLineInContainer(entry.line, container));
+    if (match === null) continue;
+    if (
+      !insideMarkdownFence(source, entry.index, containers)
+      && !insideSpecialRawHtmlBlock(source, entry.index, containers)
+      && openRawHtmlContainers(source, entry.index, containers).length === 0
+    ) {
+      const text = (match[2] ?? "")
+        .replace(/(?:^|[ \t]+)#+[ \t]*$/, "")
+        .trimEnd();
+      headings.push({ index: entry.index, level: match[1].length, text });
+    }
+  }
+  // Setext headings are normative section boundaries too. Ignoring them lets
+  // an unrelated rendered H2 sit between the reviewed ATX heading and claim
+  // while the raw-source census still reports the older section as preceding.
+  const setextUnderlinePattern = /^ {0,3}(=+|-+)[ \t]*$/;
+  for (let lineIndex = 1; lineIndex < lines.length; lineIndex += 1) {
+    const entry = lines[lineIndex];
+    const previous = lines[lineIndex - 1];
+    const container = markdownContainerAt(containers, entry.index);
+    if (container !== markdownContainerAt(containers, previous.index)) continue;
+    const underline = setextUnderlinePattern.exec(markdownLineInContainer(entry.line, container));
+    const textLine = markdownLineInContainer(previous.line, container);
+    if (underline === null || !/^ {0,3}\S/.test(textLine)) continue;
+    if (
+      !insideMarkdownFence(source, previous.index, containers)
+      && !insideSpecialRawHtmlBlock(source, previous.index, containers)
+      && openRawHtmlContainers(source, previous.index, containers).length === 0
+    ) {
+      headings.push({
+        index: previous.index,
+        level: underline[1][0] === "=" ? 1 : 2,
+        text: textLine.trimStart().trimEnd(),
+      });
+    }
+  }
+  return headings.sort((left, right) => left.index - right.index);
+}
+
+function markdownListItemStarts(source, fromIndex = 0) {
+  const region = source.slice(fromIndex);
+  const candidates = [...region.matchAll(/^( *)([-+*]|\d{1,9}[.)])(?:([ \t]+)([^\n]*))?$/gm)]
+    .filter((match) => {
+      const index = fromIndex + match.index;
+      return !insideMarkdownFence(source, index)
+        && !insideSpecialRawHtmlBlock(source, index)
+        && openRawHtmlContainers(source, index).length === 0;
+    })
+    .map((match) => ({
+      index: fromIndex + match.index,
+      indent: match[1].length,
+      contentIndent: match[1].length + match[2].length
+        + (match[3] && match[3].length <= 4 ? match[3].length : 1),
+      marker: match[2],
+      text: match[0].slice(match[1].length),
+    }));
+
+  // This document's alternatives form one root list. Once its first item fixes
+  // the content column, another marker before that column is a sibling/root
+  // boundary; a marker at or beyond it is nested content and must not displace
+  // the containing alternative.
+  const firstRoot = candidates.find(({ indent }) => indent <= 3);
+  if (!firstRoot) return [];
+  return candidates.filter(({ indent }) => indent < firstRoot.contentIndent);
+}
+
+function insideRawHtmlComment(source, index, containers = []) {
+  const prefix = maskMarkdownFences(source, containers).slice(0, index);
+  return prefix.lastIndexOf("<!--") > prefix.lastIndexOf("-->");
+}
+
+function unclosedDelimitedRawBlock(prefix, opening, closing) {
+  const start = prefix.lastIndexOf(opening);
+  return start >= 0 && prefix.indexOf(closing, start + opening.length) < 0;
+}
+
+function insideSpecialRawHtmlBlock(source, index, containers = []) {
+  const prefix = maskMarkdownFences(source, containers).slice(0, index);
+  if (
+    unclosedDelimitedRawBlock(prefix, "<!--", "-->")
+    || unclosedDelimitedRawBlock(prefix, "<?", "?>")
+    || unclosedDelimitedRawBlock(prefix, "<![CDATA[", "]]>")
+  ) {
+    return true;
+  }
+  const declarations = [...prefix.matchAll(/<![A-Z]/g)];
+  const declaration = declarations.at(-1);
+  return declaration !== undefined && prefix.indexOf(">", declaration.index + 3) < 0;
+}
+
+// CommonMark 0.31.2 §4.6 type-1 containers plus the complete type-6 block-tag
+// inventory. Extra semantic containers used by GitHub Markdown remain included
+// fail-closed: a reviewed normative claim must be ordinary rendered Markdown,
+// never raw HTML whose display or hierarchy depends on a sanitizer/browser.
+const rawHtmlBlockTags = new Set([
+  "address",
+  "article",
+  "aside",
+  "base",
+  "basefont",
+  "body",
+  "blockquote",
+  "caption",
+  "center",
+  "code",
+  "col",
+  "colgroup",
+  "dd",
+  "details",
+  "dialog",
+  "dir",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "frame",
+  "frameset",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "head",
+  "header",
+  "hr",
+  "html",
+  "iframe",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "menu",
+  "menuitem",
+  "nav",
+  "noframes",
+  "noscript",
+  "object",
+  "ol",
+  "optgroup",
+  "option",
+  "p",
+  "param",
+  "pre",
+  "script",
+  "search",
+  "section",
+  "span",
+  "style",
+  "summary",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "tfoot",
+  "th",
+  "thead",
+  "title",
+  "track",
+  "tr",
+  "ul",
+  "textarea",
+]);
+const rawHtmlVoidTags = new Set([
+  "base",
+  "basefont",
+  "col",
+  "frame",
+  "hr",
+  "link",
+  "menuitem",
+  "param",
+  "track",
+]);
+const rawHtmlContainerPattern = new RegExp(
+  `<\\s*\\/?\\s*(?:${[...rawHtmlBlockTags].join("|")})\\b`,
+  "i",
+);
+
+function rawHtmlTagTokens(source) {
+  const tokens = [];
+  for (let start = 0; start < source.length; start += 1) {
+    if (source[start] !== "<") continue;
+    let cursor = start + 1;
+    let closing = false;
+    if (source[cursor] === "/") {
+      closing = true;
+      cursor += 1;
+    }
+    // HTML tag names begin immediately after `<` or `</`. Accepting whitespace
+    // here lets a browser-visible malformed close such as `</ details>` pop a
+    // container in the policy parser even though it does not close the element.
+    if (!/[A-Za-z]/.test(source[cursor] ?? "")) continue;
+    const nameStart = cursor;
+    cursor += 1;
+    while (/[A-Za-z0-9-]/.test(source[cursor] ?? "")) cursor += 1;
+    const name = source.slice(nameStart, cursor).toLowerCase();
+    if (!/[\s/>]/.test(source[cursor] ?? "")) continue;
+
+    let quote = null;
+    let end = -1;
+    for (; cursor < source.length; cursor += 1) {
+      const character = source[cursor];
+      if (quote !== null) {
+        if (character === quote) quote = null;
+      } else if (character === '"' || character === "'") {
+        quote = character;
+      } else if (character === ">") {
+        end = cursor;
+        break;
+      }
+    }
+    if (end < 0) continue;
+    const tail = source.slice(nameStart + name.length, end);
+    if (closing && !/^\s*$/.test(tail)) {
+      // End tags have no attributes or self-closing slash. Fail closed: do not
+      // let a malformed spelling alter the reviewed container stack.
+      continue;
+    }
+    tokens.push({
+      start,
+      end: end + 1,
+      name,
+      closing,
+      selfClosing: !closing && /\/\s*$/.test(tail),
+    });
+    start = end;
+  }
+  return tokens;
+}
+
+function openRawHtmlContainers(source, index, containers = []) {
+  const stack = [];
+  const prefix = maskMarkdownFences(source, containers)
+    .slice(0, index)
+    .replace(/<!--[\s\S]*?-->/g, "");
+  for (const token of rawHtmlTagTokens(prefix)) {
+    const { closing, name, selfClosing } = token;
+    if (!rawHtmlBlockTags.has(name)) continue;
+    if (closing) {
+      const position = stack.lastIndexOf(name);
+      if (position >= 0) stack.splice(position, 1);
+    } else if (!rawHtmlVoidTags.has(name) && !selfClosing) {
+      stack.push(name);
+    }
+  }
+  return stack;
+}
+
+function stripClosedSpecialRawMarkup(line) {
+  return line
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<\?[\s\S]*?\?>/g, " ")
+    .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, " ")
+    .replace(/<![A-Z][^>]*>/g, " ");
+}
+
+function visibleMarkdownBlocks(source, key, protectedContext) {
+  const { containers, protectedEnd, protectedStart } = protectedContext;
+  const { end, endIndex, start, startIndex } = claimBounds(source, key);
+  const ignoredStart = source.lastIndexOf("\n", startIndex - 1) + 1;
+  const ignoredEndLine = source.indexOf("\n", endIndex + end.length);
+  const ignoredEnd = ignoredEndLine < 0 ? source.length : ignoredEndLine + 1;
+  const blocks = [];
+  let block = [];
+  const finishBlock = () => {
+    if (block.length > 0) blocks.push(block.join(" ").replace(/\s+/g, " ").trim());
+    block = [];
+  };
+
+  for (const entry of markdownLines(source)) {
+    if (entry.index < protectedStart || entry.index >= protectedEnd) continue;
+    if (entry.index >= ignoredStart && entry.index < ignoredEnd) {
+      finishBlock();
+      continue;
+    }
+    const container = markdownContainerAt(containers, entry.index);
+    const effectiveLine = markdownLineInContainer(entry.line, container);
+    const fenced = insideMarkdownFence(source, entry.index, containers);
+    if (fenced || markdownFenceCandidate(effectiveLine) !== null) {
+      finishBlock();
+      continue;
+    }
+    if (insideSpecialRawHtmlBlock(source, entry.index, containers)) {
+      finishBlock();
+      continue;
+    }
+    if (openRawHtmlContainers(source, entry.index, containers).length > 0) {
+      finishBlock();
+      continue;
+    }
+    const withoutSpecial = stripClosedSpecialRawMarkup(effectiveLine);
+    const htmlTokens = rawHtmlTagTokens(withoutSpecial);
+    if (htmlTokens.length > 0) {
+      assert.equal(
+        htmlTokens.length,
+        0,
+        `${key} contains raw HTML in its protected rendered section`,
+      );
+    }
+    const visible = withoutSpecial.trim();
+    if (visible === "") {
+      finishBlock();
+    } else {
+      block.push(visible);
+    }
+  }
+  finishBlock();
+  return blocks;
+}
+
+const enumerationLanguage = String.raw`(?:enumerat(?:e|ed|es|ing|ion)|reconstruct(?:s|ed|ing|ion)?|per[- ]handle\s+discover(?:y|ability)|handle[- ]by[- ]handle|lookups?)`;
+const privacyTargets = String.raw`(?:membership|device(?:\s+count|\s+metadata|\s+credentials?)?|credentials?|contact\s+endpoints?|metadata|(?:queried|known|guessed|public)\s+(?:handles?|entries|users?))`;
+const preventionLanguage = String.raw`(?:prevent(?:s|ed|ing)?|block(?:s|ed|ing)?|stop(?:s|ped|ping)?|preclud(?:e|es|ed|ing)|defeat(?:s|ed|ing)?|eliminat(?:e|es|ed|ing)|thwart(?:s|ed|ing)?)`;
+const strongPrivacyLanguage = String.raw`(?:cryptograph(?:ic|ically)\s+(?:private|hidden|protected|concealed|confidential)|non[- ]enumerable|unobservable|undiscoverable|guarantee(?:s|d)?\s+(?:privacy|confidentiality)|conceal(?:s|ed|ing)?|keep(?:s|ing)?\s+secret)`;
+const enumerationOverclaimPatterns = [
+  new RegExp(`\\b${preventionLanguage}\\b.{0,140}\\b${enumerationLanguage}\\b`, "i"),
+  new RegExp(`\\b${enumerationLanguage}\\b.{0,140}\\b${preventionLanguage}\\b`, "i"),
+  new RegExp(`\\b${privacyTargets}\\b.{0,140}\\b${strongPrivacyLanguage}\\b`, "i"),
+  new RegExp(`\\b${strongPrivacyLanguage}\\b.{0,140}\\b${privacyTargets}\\b`, "i"),
+  /\brate\s+limit(?:s|ing)?\b.{0,140}\b(?:cryptographic\s+guarantee|guarantee(?:s|d)?\s+privacy|prevent(?:s|ed|ing)?\s+(?:enumeration|reconstruction))\b/i,
+];
+const visibleEnumerationContextDigests = new Map([
+  ["enumeration_boundary_kt", "2c518de6d0ad6031e7e5e3a36647f0206d8ec9e341f1f032763792ed234a0225"],
+  ["enumeration_boundary_adr", "4786e1b13446163cece6656daa6aaa8273da23eb284edd588189e0396ec376be"],
+]);
+
+function validateNoVisibleEnumerationContradictions(source, key, protectedContext) {
+  const blocks = visibleMarkdownBlocks(source, key, protectedContext);
+  for (const block of blocks) {
+    for (const pattern of enumerationOverclaimPatterns) {
+      const match = pattern.exec(block);
+      if (match === null) continue;
+      const prefix = block.slice(Math.max(0, match.index - 32), match.index + 32);
+      if (/\b(?:does?|do|is|are|can|will|would)\s+not\b|\b(?:never|cannot|can't|doesn't)\b/i.test(prefix)) {
+        continue;
+      }
+      assert.fail(`${key} contains a visible enumeration-privacy overclaim: ${match[0]}`);
+    }
+  }
+  assert.equal(
+    sha256(JSON.stringify(blocks)),
+    visibleEnumerationContextDigests.get(key),
+    `${key} visible surrounding prose changed; review it for enumeration-privacy contradictions`,
+  );
+}
+
+function validateEnumerationSection(source, key, startIndex, endIndex) {
+  const context = enumerationClaimContexts.get(key);
+  let containers = [];
+  let headings = markdownHeadings(source);
+  let bullets = null;
+  let precedingItem = null;
+  let followingItem = null;
+
+  if (key === "enumeration_boundary_adr") {
+    const baseOuterHeading = headings.filter(
+      ({ level, text }) => level === 2 && text === context.outerHeading,
+    ).at(0);
+    assert(baseOuterHeading, `${key} lacks its outer section`);
+    bullets = markdownListItemStarts(source, baseOuterHeading.index);
+    precedingItem = bullets.filter(({ index }) => index < startIndex).at(-1);
+    followingItem = bullets.find(({ index }) => index > endIndex);
+    assert(
+      precedingItem?.text.startsWith(context.itemStart),
+      `${key} is outside the cleartext-log alternative`,
+    );
+    assert(
+      followingItem?.text.startsWith(context.itemEnd),
+      `${key} crossed the cleartext-log alternative boundary`,
+    );
+    containers = bullets.map((item, itemIndex) => {
+      const bodyStart = source.indexOf("\n", item.index);
+      assert(bodyStart >= 0, `${key} alternative lacks a body`);
+      return {
+        start: bodyStart + 1,
+        end: bullets[itemIndex + 1]?.index ?? source.length,
+        indent: item.contentIndent,
+      };
+    });
+    // CommonMark removes a list item's content indentation before parsing its
+    // child blocks. Re-run the heading census through that container view so a
+    // raw 4/5-space ATX or Setext heading cannot become rendered structure that
+    // the policy mistakes for ordinary indented text.
+    headings = markdownHeadings(source, containers);
+  }
+
+  const h2s = headings.filter(({ level }) => level === 2);
+  assert.equal(
+    h2s.filter(({ text }) => text === context.outerHeading).length,
+    1,
+    `${key} outer section heading must be unique`,
+  );
+  assert.equal(
+    h2s[context.outerHeadingOrdinal]?.text,
+    context.outerHeading,
+    `${key} outer section moved from its reviewed document ordinal`,
+  );
+  const precedingH2 = h2s.filter(({ index }) => index < startIndex).at(-1);
+  assert.equal(
+    precedingH2?.text,
+    context.outerHeading,
+    `${key} is outside its required outer section`,
+  );
+
+  if (key === "enumeration_boundary_kt") {
+    assert.equal(
+      h2s.filter(({ text }) => text === context.followingHeading).length,
+      1,
+      `${key} following section boundary must be unique`,
+    );
+    const followingH2 = h2s.find(({ index }) => index > endIndex);
+    assert.equal(
+      followingH2?.text,
+      context.followingHeading,
+      `${key} crossed its outer section boundary`,
+    );
+    const h3s = headings.filter(
+      ({ level, index }) => level === 3 && index > precedingH2.index && index < followingH2.index,
+    );
+    assert.equal(
+      h3s.filter(({ text }) => text === context.sectionHeading).length,
+      1,
+      `${key} subsection heading must be unique`,
+    );
+    assert.equal(
+      h3s[context.sectionHeadingOrdinal]?.text,
+      context.sectionHeading,
+      `${key} subsection moved from its reviewed ordinal`,
+    );
+    assert.equal(
+      h3s.filter(({ index }) => index < startIndex).at(-1)?.text,
+      context.sectionHeading,
+      `${key} is outside its required subsection`,
+    );
+    assert.equal(
+      headings.find(({ index }) => index > endIndex)?.text,
+      context.followingHeading,
+      `${key} is not the final normative paragraph of its subsection`,
+    );
+    return {
+      containers,
+      protectedStart: h3s.find(({ text }) => text === context.sectionHeading).index,
+      protectedEnd: followingH2.index,
+    };
+  }
+
+  assert.equal(
+    h2s.at(-1)?.text,
+    context.outerHeading,
+    `${key} outer section must retain its document boundary`,
+  );
+  assert(bullets !== null, `${key} list structure was not initialized`);
+  assert.equal(
+    bullets.filter(({ text }) => text.startsWith(context.itemStart)).length,
+    1,
+    `${key} cleartext-log alternative must be unique`,
+  );
+  assert.equal(
+    bullets.filter(({ text }) => text.startsWith(context.itemEnd)).length,
+    1,
+    `${key} following alternative boundary must be unique`,
+  );
+  assert(
+    precedingItem?.text.startsWith(context.itemStart),
+    `${key} is outside the cleartext-log alternative`,
+  );
+  assert(
+    followingItem?.text.startsWith(context.itemEnd),
+    `${key} crossed the cleartext-log alternative boundary`,
+  );
+  return {
+    containers,
+    protectedStart: h2s.at(-1).index,
+    protectedEnd: source.length,
+  };
+}
+
+function validateEnumerationClaimContext(source, key) {
+  const context = enumerationClaimContexts.get(key);
+  assert(context, `missing structural context for ${key}`);
+  const { start, end, startIndex, endIndex } = claimBounds(source, key);
+
+  assert.equal(
+    source.split(context.before).length - 1,
+    1,
+    `${key} preceding structural anchor must be unique`,
+  );
+  assert.equal(
+    source.split(context.after).length - 1,
+    1,
+    `${key} following structural anchor must be unique`,
+  );
+
+  assert.equal(
+    source.slice(startIndex - context.before.length, startIndex),
+    context.before,
+    `${key} moved away from its reviewed preceding context`,
+  );
+  assert.equal(
+    source.slice(endIndex + end.length, endIndex + end.length + context.after.length),
+    context.after,
+    `${key} moved away from its reviewed following context`,
+  );
+  const protectedContext = validateEnumerationSection(source, key, startIndex, endIndex);
+  const { containers } = protectedContext;
+
+  const markerLineStart = source.lastIndexOf("\n", startIndex - 1) + 1;
+  assert.equal(
+    source.slice(markerLineStart, startIndex),
+    context.markerIndent,
+    `${key} marker is indented into a quote or code/example context`,
+  );
+  assert(!insideMarkdownFence(source, startIndex, containers), `${key} is inside a fenced code/example block`);
+  assert(!insideMarkdownFence(source, endIndex, containers), `${key} ends inside a fenced code/example block`);
+  assert(!insideSpecialRawHtmlBlock(source, startIndex, containers), `${key} is inside a raw HTML block`);
+  assert(!insideSpecialRawHtmlBlock(source, endIndex, containers), `${key} ends inside a raw HTML block`);
+  assert.deepEqual(
+    openRawHtmlContainers(source, startIndex, containers),
+    [],
+    `${key} is inside a raw HTML disclosure or container`,
+  );
+  assert.deepEqual(
+    openRawHtmlContainers(source, endIndex, containers),
+    [],
+    `${key} ends inside a raw HTML disclosure or container`,
+  );
+
+  const rawClaim = source.slice(startIndex + start.length, endIndex);
+  assert(
+    !rawHtmlContainerPattern.test(rawClaim),
+    `${key} contains a raw HTML disclosure or container`,
+  );
+  for (const line of rawClaim.split("\n")) {
+    if (line.trim() === "") continue;
+    assert(
+      line.startsWith(context.markerIndent),
+      `${key} prose escaped its containing structural indentation`,
+    );
+    const prose = line.slice(context.markerIndent.length);
+    assert(
+      !/^ {0,3}>|^ {0,3}(?:`{3,}|~{3,})|^ {4}|^\t/.test(prose),
+      `${key} is quoted or rendered as code/example text`,
+    );
+  }
+  validateNoVisibleEnumerationContradictions(source, key, protectedContext);
 }
 
 function replaceClaimBlock(source, key, replacement) {
@@ -238,6 +936,180 @@ function replaceClaimBlock(source, key, replacement) {
   const endIndex = source.indexOf(end, startIndex + start.length);
   assert(startIndex >= 0 && endIndex > startIndex, `cannot replace incomplete ${key} claim block`);
   return `${source.slice(0, startIndex + start.length)}\n${replacement}\n${source.slice(endIndex)}`;
+}
+
+function removeClaimBlock(source, key) {
+  const start = `<!-- akd-claim:${key}:start -->`;
+  const end = `<!-- akd-claim:${key}:end -->`;
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert(startIndex >= 0 && endIndex > startIndex, `cannot remove incomplete ${key} claim block`);
+  return `${source.slice(0, startIndex)}${source.slice(endIndex + end.length)}`;
+}
+
+function fenceClaimInPlace(source, key) {
+  const context = enumerationClaimContexts.get(key);
+  assert(context, `missing structural context for ${key}`);
+  const { end, endIndex, startIndex } = claimBounds(source, key);
+  const beforeStart = startIndex - context.before.length;
+  const fenceStart = source.lastIndexOf("\n", beforeStart - 1) + 1;
+  const afterEnd = endIndex + end.length + context.after.length;
+  const followingNewline = source.indexOf("\n", afterEnd);
+  const fenceEnd = followingNewline < 0 ? source.length : followingNewline + 1;
+  const fence = `${context.markerIndent}\`\`\`markdown`;
+  return `${source.slice(0, fenceStart)}${fence}\n${source.slice(fenceStart, fenceEnd)}${fence}\n${source.slice(fenceEnd)}`;
+}
+
+function claimTrioBounds(source, key) {
+  const context = enumerationClaimContexts.get(key);
+  assert(context, `missing structural context for ${key}`);
+  const { end, endIndex, startIndex } = claimBounds(source, key);
+  return {
+    startIndex: startIndex - context.before.length,
+    endIndex: endIndex + end.length + context.after.length,
+  };
+}
+
+function wrapClaimTrio(source, key, opening, closing) {
+  const bounds = claimTrioBounds(source, key);
+  return `${source.slice(0, bounds.startIndex)}${opening}\n${source.slice(bounds.startIndex, bounds.endIndex)}\n${closing}${source.slice(bounds.endIndex)}`;
+}
+
+function relocateClaimTrio(source, key, wrapper = null, replacement = "") {
+  const bounds = claimTrioBounds(source, key);
+  const trio = source.slice(bounds.startIndex, bounds.endIndex);
+  const relocated = wrapper === null ? trio : `${wrapper.opening}\n${trio}\n${wrapper.closing}`;
+  return `${source.slice(0, bounds.startIndex)}${replacement}${source.slice(bounds.endIndex)}\n\n${relocated}\n`;
+}
+
+function hideClaimTrioBehindMalformedFence(source, key) {
+  const bounds = claimTrioBounds(source, key);
+  const start = source.lastIndexOf("\n", bounds.startIndex - 1) + 1;
+  const followingNewline = source.indexOf("\n", bounds.endIndex);
+  const end = followingNewline < 0 ? source.length : followingNewline;
+  const indent = enumerationClaimContexts.get(key).markerIndent;
+  const contradiction = key === "enumeration_boundary_kt"
+    ? "The zero-knowledge set prevents handle-by-handle reconstruction and makes queried membership and device metadata cryptographically private."
+    : "  The zero-knowledge set prevents reconstruction and cryptographically conceals membership and metadata for every queried public handle.";
+  return [
+    source.slice(0, start),
+    `${indent}\`\`\`markdown\n`,
+    `${indent}\`\`\` this is literal code, not a closing fence\n`,
+    source.slice(start, end),
+    `\n${indent}\`\`\`\n\n`,
+    `${contradiction}\n`,
+    source.slice(end + (followingNewline < 0 ? 0 : 1)),
+  ].join("");
+}
+
+function spoofClaimStructureWithHiddenTokens(source, key) {
+  if (key === "enumeration_boundary_kt") {
+    return source.replace(
+      "### 3.3 Label and value",
+      "#### 3.4 Unrelated implementation note\n\n<!--\n### 3.3 Label and value\n-->",
+    );
+  }
+  return source
+    .replace(
+      "## Alternatives rejected",
+      "### Unrelated implementation appendix\n\n<!--\n## Alternatives rejected\n-->",
+    )
+    .replace(
+      "- **A plain cleartext RFC 6962 log.**",
+      "- **An unrelated storage alternative.**",
+    )
+    .replace(
+      "  meant. Note that the leak comes from publishing entries in the clear, not from",
+      [
+        "  meant.",
+        "",
+        "  <!--",
+        "- **A plain cleartext RFC 6962 log.**",
+        "  -->",
+        "",
+        "  Note that the leak comes from publishing entries in the clear, not from",
+      ].join("\n"),
+    );
+}
+
+function spoofAdrItemWithFencedToken(source) {
+  return source
+    .replace(
+      "- **A plain cleartext RFC 6962 log.**",
+      "- **An unrelated storage alternative.**",
+    )
+    .replace(
+      "  meant. Note that the leak comes from publishing entries in the clear, not from",
+      [
+        "  meant.",
+        "",
+        "  ```markdown",
+        "- **A plain cleartext RFC 6962 log.**",
+        "  ```",
+        "",
+        "  Note that the leak comes from publishing entries in the clear, not from",
+      ].join("\n"),
+    );
+}
+
+function insertSetextSectionBeforeClaim(source, key) {
+  const bounds = claimTrioBounds(source, key);
+  const paragraphStart = source.lastIndexOf("\n\n", bounds.startIndex - 1);
+  assert(paragraphStart >= 0, `${key} lacks a paragraph boundary for the setext mutant`);
+  return `${source.slice(0, paragraphStart + 2)}Unrelated normative section\n` +
+    `---------------------------\n\n${source.slice(paragraphStart + 2)}`;
+}
+
+function insertAtxSectionBeforeClaim(source, key) {
+  const bounds = claimTrioBounds(source, key);
+  const paragraphStart = source.lastIndexOf("\n\n", bounds.startIndex - 1);
+  assert(paragraphStart >= 0, `${key} lacks a paragraph boundary for the ATX mutant`);
+  return `${source.slice(0, paragraphStart + 2)} ## Unrelated normative section\n\n` +
+    source.slice(paragraphStart + 2);
+}
+
+function insertEmptyAtxSectionBeforeClaim(source, key) {
+  const bounds = claimTrioBounds(source, key);
+  const paragraphStart = source.lastIndexOf("\n\n", bounds.startIndex - 1);
+  assert(paragraphStart >= 0, `${key} lacks a paragraph boundary for the empty ATX mutant`);
+  return `${source.slice(0, paragraphStart + 2)}##\n\n${source.slice(paragraphStart + 2)}`;
+}
+
+function insertAdrContainerBlock(source, block) {
+  const target = "  RFC 6962, which is why the fallback above pairs it with a VRF and a commitment.";
+  assert.equal(source.split(target).length - 1, 1, "ADR container mutant target must occur once");
+  return source.replace(target, `${block}\n${target}`);
+}
+
+function insertBeforeAdrCleartextItem(source, block) {
+  const target = "- **A plain cleartext RFC 6962 log.**";
+  assert.equal(source.split(target).length - 1, 1, "ADR pre-item mutant target must occur once");
+  return source.replace(target, `${block}\n\n${target}`);
+}
+
+function insertAfterAdrCleartextItem(source, block) {
+  const target = "- **A second, simpler verifier for the web client**";
+  assert.equal(source.split(target).length - 1, 1, "ADR post-item mutant target must occur once");
+  return source.replace(target, `${block}\n\n${target}`);
+}
+
+function insertKtVisibleOverclaim(source, overclaim) {
+  const target = "What it does **not** buy is confidentiality of the entry.";
+  assert.equal(source.split(target).length - 1, 1, "KT contradiction mutant target must occur once");
+  return source.replace(target, `${overclaim}\n\n${target}`);
+}
+
+function insertListBoundaryBeforeClaim(source, key, marker) {
+  const bounds = claimTrioBounds(source, key);
+  const context = enumerationClaimContexts.get(key);
+  const lineStart = source.lastIndexOf("\n", bounds.startIndex - 1) + 1;
+  assert.equal(
+    source.slice(lineStart, bounds.startIndex),
+    context.markerIndent,
+    `${key} lacks the reviewed list indentation for the list mutant`,
+  );
+  return `${source.slice(0, lineStart)}${marker} **Unrelated alternative.**\n\n` +
+    `${context.markerIndent}${source.slice(bounds.startIndex)}`;
 }
 
 function expectedAuditClaim(audit) {
@@ -287,9 +1159,51 @@ function expectedHistoryRequestWireClaim() {
   ].join("\n");
 }
 
-function validateClaimBlocks(files, audit) {
+function expectedEnumerationKtClaim() {
+  return [
+    "That protection is against a bulk directory download, not against",
+    "handle-by-handle reconstruction. `/kt/v1/lookup` is available to anyone (§9.2),",
+    "and a public-username platform gives an observer a public list of candidate",
+    "handles. Each successful lookup reveals that handle's full `DirectoryEntry`,",
+    "including its device credentials and contact endpoints. Rate limiting can make",
+    "enumeration slower and more expensive; it does not make membership or the",
+    "returned metadata for known or guessed handles cryptographically private. The",
+    "zero-knowledge benefit remains concrete: there is no one-shot corpus, and",
+    "unqueried or unguessed handles remain hidden.",
+  ].join("\n");
+}
+
+function expectedEnumerationAdrClaim() {
+  return [
+    "**Correction (2026-09-03) — “the full membership ... as a downloadable",
+    "file” distinguishes bulk publication from enumeration; it does not make",
+    "public handles non-enumerable.** The rejection above remains sound: a",
+    "cleartext log exposes one permanent corpus that can be copied without first",
+    "knowing or guessing any handle. The adopted zero-knowledge set prevents that",
+    "one-shot download and keeps an entry hidden from an observer who does not",
+    "query or guess its handle.",
+    "",
+    "It does not prevent handle-by-handle reconstruction. `/kt/v1/lookup` is",
+    "available to anyone, a successful response carries the full",
+    "`DirectoryEntry`, and on a public-username platform the public username list",
+    "supplies candidate handles. Server rate limits can raise the time and request",
+    "cost of that reconstruction, but they are an operational bound, not a",
+    "cryptographic claim that membership, device count, credential and entry",
+    "timestamps, or contact endpoints for queried handles are non-enumerable.",
+  ].join("\n");
+}
+
+function validateClaimInventory(inventory) {
+  assert.equal(inventory.size, requiredClaimInventory.size, "claim inventory row count drifted");
+  for (const [key, path] of requiredClaimInventory) {
+    assert.equal(inventory.get(key), path, `${key} is missing or points at the wrong documentation file`);
+  }
+}
+
+function validateClaimBlocks(files, audit, inventory = claimInventory) {
+  validateClaimInventory(inventory);
   const byPath = new Map(files);
-  for (const [key, relativePath] of claimInventory) {
+  for (const [key, relativePath] of inventory) {
     assert(byPath.has(relativePath), `missing documentation file ${relativePath}`);
     const source = byPath.get(relativePath);
     if (key === "history_proof_type") {
@@ -302,8 +1216,18 @@ function validateClaimBlocks(files, audit) {
         expectedHistoryRequestWireClaim(),
         `${relativePath}: ${key} claim drifted from the implemented wire contract`,
       );
-    } else {
+    } else if (key === "audit_scope") {
       assert.equal(claimBlock(source, key), expectedAuditClaim(audit), `${relativePath}: ${key} claim drifted from executable evidence`);
+    } else if (key === "enumeration_boundary_kt") {
+      const expected = expectedEnumerationKtClaim();
+      assert.equal(claimBlock(source, key), expected, `${relativePath}: ${key} claim drifted from the reviewed privacy boundary`);
+      validateEnumerationClaimContext(source, key);
+    } else if (key === "enumeration_boundary_adr") {
+      const expected = expectedEnumerationAdrClaim();
+      assert.equal(claimBlock(source, key), expected, `${relativePath}: ${key} claim drifted from the reviewed privacy boundary`);
+      validateEnumerationClaimContext(source, key);
+    } else {
+      assert.fail(`unrecognized claim inventory key ${key}`);
     }
   }
 }
@@ -1092,7 +2016,8 @@ async function selfTest() {
   );
   killed.coordinatedEvidence += 1;
 
-  for (const [key, relativePath] of claimInventory) {
+  for (const key of ["audit_scope", "history_proof_type", "history_request_wire"]) {
+    const relativePath = claimInventory.get(key);
     const end = key === "audit_scope" || key === "history_request_wire"
       ? `<!-- akd-claim:${key}:end -->`
       : expectedHistoryClaim();
@@ -1145,6 +2070,361 @@ async function selfTest() {
     );
     killed.claims += 1;
   }
+
+  for (const tag of ['<details title=">">', '<details title="/>">', "<details title='/>' >"]) {
+    const tokens = rawHtmlTagTokens(tag);
+    assert.equal(tokens.length, 1, `quoted HTML tag was not tokenized as one element: ${tag}`);
+    assert.equal(tokens[0].name, "details", `quoted HTML tag name drifted: ${tag}`);
+    assert.equal(tokens[0].selfClosing, false, `quoted attribute text became a self-closing slash: ${tag}`);
+  }
+  assert.deepEqual(rawHtmlTagTokens("</ details>"), [], "spaced malformed close became an HTML end tag");
+
+  for (const key of ["enumeration_boundary_kt", "enumeration_boundary_adr"]) {
+    const relativePath = claimInventory.get(key);
+    const expected = key === "enumeration_boundary_kt"
+      ? expectedEnumerationKtClaim()
+      : expectedEnumerationAdrClaim();
+    const mutateFiles = (mutation) => files.map(([path, source]) => [
+      path,
+      path === relativePath ? mutation(source) : source,
+    ]);
+    const reject = (name, mutation) => {
+      assert.throws(
+        () => validateClaimBlocks(mutateFiles(mutation), audit),
+        `${key} ${name} mutant survived`,
+      );
+      killed.claims += 1;
+    };
+    const rejectWith = (name, mutation, expectedError) => {
+      assert.throws(
+        () => validateClaimBlocks(mutateFiles(mutation), audit),
+        expectedError,
+        `${key} ${name} mutant failed for the wrong reason or survived`,
+      );
+      killed.claims += 1;
+    };
+
+    const missingInventoryRow = new Map(claimInventory);
+    missingInventoryRow.delete(key);
+    assert.throws(
+      () => validateClaimBlocks(files, audit, missingInventoryRow),
+      `${key} inventory-row deletion mutant survived`,
+    );
+    killed.claims += 1;
+
+    reject("complete-deletion", (source) => removeClaimBlock(source, key));
+    reject("whole-trio-relocation", (source) => relocateClaimTrio(source, key));
+    reject("fenced-context", (source) => fenceClaimInPlace(source, key));
+    reject("raw-html-comment-context", (source) => wrapClaimTrio(source, key, "<!--", "-->"));
+    reject("collapsed-details-context", (source) => wrapClaimTrio(
+      source,
+      key,
+      "<details><summary>Non-normative note</summary>",
+      "</details>",
+    ));
+    reject("hidden-container-context", (source) =>
+      wrapClaimTrio(source, key, '<div hidden="hidden">', "</div>"));
+    reject("one-space-atx-section-boundary", (source) =>
+      insertAtxSectionBeforeClaim(source, key));
+    reject("empty-atx-section-boundary", (source) =>
+      insertEmptyAtxSectionBeforeClaim(source, key));
+    reject("textarea-raw-html-context", (source) =>
+      wrapClaimTrio(source, key, "<textarea>", "</textarea>"));
+    reject("address-raw-html-context", (source) =>
+      wrapClaimTrio(source, key, "<address>", "</address>"));
+    reject("processing-instruction-raw-html-context", (source) =>
+      wrapClaimTrio(source, key, "<?f2z", "?>"));
+    reject("declaration-raw-html-context", (source) =>
+      wrapClaimTrio(source, key, "<!F2Z", ">"));
+    reject("cdata-raw-html-context", (source) =>
+      wrapClaimTrio(source, key, "<![CDATA[", "]]>"));
+    reject("hidden-canonical-visible-contradiction", (source) => {
+      const visibleContradiction = key === "enumeration_boundary_kt"
+        ? "That protection prevents handle-by-handle reconstruction and makes membership and device metadata cryptographically non-enumerable."
+        : "  The adopted zero-knowledge set prevents handle-by-handle reconstruction and makes queried membership and device metadata cryptographically non-enumerable.";
+      return relocateClaimTrio(
+        source,
+        key,
+        { opening: "<details><summary>Archived wording</summary>", closing: "</details>" },
+        visibleContradiction,
+      );
+    });
+    reject("quoted marker context", (source) =>
+      source.replace(
+        `<!-- akd-claim:${key}:start -->`,
+        `> <!-- akd-claim:${key}:start -->`,
+      ),
+    );
+    for (const [name, opening, closing] of [
+      ["visible-span-container", "<span>", "</span>"],
+      ["visible-open-details-container", "<details open>", "</details>"],
+    ]) {
+      const contradiction = "The zero-knowledge set prevents handle-by-handle reconstruction and makes queried membership cryptographically non-enumerable.";
+      rejectWith(
+        name,
+        (source) => key === "enumeration_boundary_kt"
+          ? insertKtVisibleOverclaim(source, `${opening}\n${contradiction}\n${closing}`)
+          : insertAdrContainerBlock(
+              source,
+              `  ${opening}\n  ${contradiction}\n  ${closing}`,
+            ),
+        /contains raw HTML in its protected rendered section/,
+      );
+    }
+    if (key === "enumeration_boundary_adr") {
+      for (const [name, block] of [
+        ["four-space-container-fence", "    ```markdown"],
+        ["five-space-container-fence", "     ~~~markdown"],
+        ["four-space-container-atx", "    ## Unrelated normative section"],
+        ["five-space-container-atx", "     ## Unrelated normative section"],
+        ["four-space-container-empty-atx", "    ##"],
+        ["five-space-container-empty-atx", "     ##"],
+        ["four-space-container-setext", "    Unrelated normative section\n    ---------------------------"],
+        ["five-space-container-setext", "     Unrelated normative section\n     ---------------------------"],
+      ]) {
+        reject(name, (source) => insertAdrContainerBlock(source, block));
+      }
+      const rootMarkers = ["-", "+", "*", "1.", "1)", "2.", "2)", "123456789.", "123456789)"];
+      for (const marker of rootMarkers) {
+        reject(`${marker}-list-boundary`, (source) =>
+          insertListBoundaryBeforeClaim(source, key, marker));
+      }
+      for (const marker of rootMarkers) {
+        reject(`${marker}-empty-list-boundary`, (source) =>
+          insertListBoundaryBeforeClaim(source, key, marker).replace(
+            `${marker} **Unrelated alternative.**`,
+            marker,
+          ));
+      }
+      const nestedItems = [
+        "- **Root alternative.**",
+        "  - Nested unordered dash detail",
+        "  + Nested unordered detail",
+        "  * Nested unordered star detail",
+        "  1. Nested ordered detail",
+        "  1) Nested parenthesized ordered detail",
+        "  123456789. Nested maximum-width ordered detail",
+        "  123456789) Nested maximum-width parenthesized detail",
+        "* **Sibling alternative.**",
+      ].join("\n");
+      assert.deepEqual(
+        markdownListItemStarts(nestedItems).map(({ marker, text }) => ({ marker, text })),
+        [
+          { marker: "-", text: "- **Root alternative.**" },
+          { marker: "*", text: "* **Sibling alternative.**" },
+        ],
+        "nested list items were mistaken for top-level alternative boundaries",
+      );
+      reject("prevention-inversion", (source) => {
+        const mutated = expected.replace("does not prevent", "prevents");
+        assert.notEqual(mutated, expected, `${key} lacks the reconstruction-refusal boundary`);
+        return replaceClaimBlock(source, key, mutated);
+      });
+      reject("standalone-visible-contradiction", (source) => insertAdrContainerBlock(
+        source,
+        "  The ZKS stops handle-by-handle reconstruction and makes public membership non-enumerable.",
+      ));
+      for (const [name, overclaim] of [
+        [
+          "pre-item-standalone-visible-contradiction",
+          "The ZKS blocks enumeration of public handles and keeps queried device metadata cryptographically private.",
+        ],
+        [
+          "pre-item-root-bullet-visible-contradiction",
+          "- The directory guarantees known-user membership confidentiality.",
+        ],
+        [
+          "pre-item-table-visible-contradiction",
+          "| Scope | Guarantee |\n|---|---|\n| Public-handle membership | non-enumerable |",
+        ],
+        [
+          "pre-item-mixed-html-visible-contradiction",
+          "<hr> The ZKS blocks enumeration of public handles and keeps queried device metadata cryptographically private.",
+        ],
+        [
+          "pre-item-mixed-html-root-bullet-visible-contradiction",
+          "- <hr> The directory guarantees known-user membership confidentiality.",
+        ],
+        [
+          "pre-item-mixed-html-table-visible-contradiction",
+          "| Scope | Guarantee |\n|---|---|\n| Public-handle membership | <hr> non-enumerable |",
+        ],
+      ]) {
+        const expectedError = name.includes("mixed-html")
+          ? /contains raw HTML in its protected rendered section/
+          : name === "pre-item-root-bullet-visible-contradiction"
+            ? /visible surrounding prose changed/
+            : /visible enumeration-privacy overclaim/;
+        rejectWith(name, (source) => insertBeforeAdrCleartextItem(source, overclaim), expectedError);
+      }
+      rejectWith(
+        "pre-item-open-vocabulary-visible-contradiction",
+        (source) => insertBeforeAdrCleartextItem(
+          source,
+          "The adopted directory ensures an attacker cannot learn the user roster one name at a time.",
+        ),
+        /visible surrounding prose changed/,
+      );
+      rejectWith(
+        "post-item-visible-contradiction",
+        (source) => insertAfterAdrCleartextItem(
+          source,
+          "The ZKS blocks enumeration of public handles and keeps queried device metadata cryptographically private.",
+        ),
+        /visible enumeration-privacy overclaim/,
+      );
+    } else {
+      reject("quoted-greater-than-details-context", (source) => wrapClaimTrio(
+        source,
+        key,
+        '<details title="/>">',
+        "</details>",
+      ));
+      reject("malformed-spaced-close-details-context", (source) => wrapClaimTrio(
+        source,
+        key,
+        "<details>\n</ details>",
+        "</details>",
+      ));
+      for (const [name, overclaim] of [
+        [
+          "standalone-visible-contradiction",
+          "The zero-knowledge set prevents handle-by-handle reconstruction and makes\nqueried membership and device metadata cryptographically non-enumerable.",
+        ],
+        ["bullet-visible-contradiction", "- ZKS blocks enumeration of public handles."],
+        [
+          "table-visible-contradiction",
+          "| Scope | Guarantee |\n|---|---|\n| Queried device metadata | cryptographically concealed |",
+        ],
+        [
+          "synonym-visible-contradiction",
+          "AKD thwarts per-handle discovery and keeps contact endpoints secret for known users.",
+        ],
+        [
+          "rate-limit-visible-contradiction",
+          "Rate limiting guarantees privacy for known-handle membership.",
+        ],
+        [
+          "open-vocabulary-visible-contradiction",
+          "The adopted directory ensures an attacker cannot learn the user roster one name at a time.",
+        ],
+        [
+          "mixed-html-standalone-visible-contradiction",
+          "<hr> The ZKS blocks enumeration of public handles and keeps queried device metadata cryptographically private.",
+        ],
+        [
+          "mixed-html-bullet-visible-contradiction",
+          "- <hr> ZKS blocks enumeration of public handles.",
+        ],
+        [
+          "mixed-html-table-visible-contradiction",
+          "| Scope | Guarantee |\n|---|---|\n| Queried device metadata | <hr> cryptographically concealed |",
+        ],
+      ]) {
+        if (name.includes("mixed-html")) {
+          rejectWith(
+            name,
+            (source) => insertKtVisibleOverclaim(source, overclaim),
+            /contains raw HTML in its protected rendered section/,
+          );
+        } else {
+          reject(name, (source) => insertKtVisibleOverclaim(source, overclaim));
+        }
+      }
+      rejectWith(
+        "mixed-html-suffix-visible-contradiction",
+        (source) => insertKtVisibleOverclaim(
+          source,
+          "The ZKS blocks enumeration of public handles and keeps queried device metadata cryptographically private. <hr>",
+        ),
+        /contains raw HTML in its protected rendered section/,
+      );
+    }
+    reject("rate-limit-cryptographic-guarantee", (source) => {
+      const rateBoundary = key === "enumeration_boundary_kt"
+        ? "Rate limiting can make\nenumeration slower and more expensive; it does not make membership or the\nreturned metadata for known or guessed handles cryptographically private."
+        : "Server rate limits can raise the time and request\ncost of that reconstruction, but they are an operational bound, not a\ncryptographic claim that membership, device count, credential and entry\ntimestamps, or contact endpoints for queried handles are non-enumerable.";
+      const mutated = expected.replace(rateBoundary, "Rate limiting is a cryptographic guarantee.");
+      assert.notEqual(mutated, expected, `${key} lacks the operational rate-limit boundary`);
+      return replaceClaimBlock(source, key, mutated);
+    });
+    reject("queried-entry-unqueried-label-collapse", (source) => {
+      const lookup = key === "enumeration_boundary_kt"
+        ? "handle-by-handle reconstruction. `/kt/v1/lookup` is available to anyone (§9.2),\nand a public-username platform gives an observer a public list of candidate\nhandles. Each successful lookup reveals that handle's full `DirectoryEntry`,\nincluding its device credentials and contact endpoints."
+        : "It does not prevent handle-by-handle reconstruction. `/kt/v1/lookup` is\navailable to anyone, a successful response carries the full\n`DirectoryEntry`, and on a public-username platform the public username list\nsupplies candidate handles.";
+      const hidden = key === "enumeration_boundary_kt"
+        ? "unqueried or unguessed handles remain hidden."
+        : "keeps an entry hidden from an observer who does not\nquery or guess its handle.";
+      const replacement = key === "enumeration_boundary_kt"
+        ? "Per-handle lookup details are omitted."
+        : "Per-handle lookup details are omitted.";
+      let mutated = expected.replace(lookup, replacement);
+      assert.notEqual(mutated, expected, `${key} lacks the full-entry disclosure boundary`);
+      const withoutHidden = mutated.replace(hidden, "Unqueried-label privacy is omitted.");
+      assert.notEqual(withoutHidden, mutated, `${key} lacks the unqueried-label privacy boundary`);
+      return replaceClaimBlock(source, key, withoutHidden);
+    });
+  }
+
+  const hiddenOverclaim = "The zero-knowledge set prevents handle-by-handle reconstruction and makes queried membership cryptographically non-enumerable.";
+  const ktPath = claimInventory.get("enumeration_boundary_kt");
+  const hiddenOverclaimFiles = (wrapper) => files.map(([path, source]) => [
+    path,
+    path === ktPath
+      ? insertKtVisibleOverclaim(source, wrapper(hiddenOverclaim))
+      : source,
+  ]);
+  for (const [name, wrapper] of [
+    ["comment", (text) => `<!-- ${text} -->`],
+    ["fence", (text) => `\`\`\`markdown\n${text}\n\`\`\``],
+  ]) {
+    assert.doesNotThrow(
+      () => validateClaimBlocks(hiddenOverclaimFiles(wrapper), audit),
+      `${name}-hidden overclaim was mistaken for rendered normative prose`,
+    );
+  }
+
+  const coordinatedEnumerationMutation = (mutation) => files.map(([path, source]) => {
+    for (const key of ["enumeration_boundary_kt", "enumeration_boundary_adr"]) {
+      if (path === claimInventory.get(key)) return [path, mutation(source, key)];
+    }
+    return [path, source];
+  });
+  assert.throws(
+    () => validateClaimBlocks(
+      coordinatedEnumerationMutation(hideClaimTrioBehindMalformedFence),
+      audit,
+    ),
+    "simultaneous malformed-fence hiding and visible-contradiction mutant survived",
+  );
+  killed.claims += 1;
+  assert.throws(
+    () => validateClaimBlocks(
+      coordinatedEnumerationMutation(spoofClaimStructureWithHiddenTokens),
+      audit,
+    ),
+    "simultaneous hidden-heading and hidden-list-boundary mutant survived",
+  );
+  killed.claims += 1;
+  assert.throws(
+    () => validateClaimBlocks(
+      coordinatedEnumerationMutation(insertSetextSectionBeforeClaim),
+      audit,
+    ),
+    "simultaneous setext section-boundary mutant survived",
+  );
+  killed.claims += 1;
+  const fencedItemFiles = files.map(([path, source]) => [
+    path,
+    path === claimInventory.get("enumeration_boundary_adr")
+      ? spoofAdrItemWithFencedToken(source)
+      : source,
+  ]);
+  assert.throws(
+    () => validateClaimBlocks(fencedItemFiles, audit),
+    "fenced fake cleartext-log item boundary mutant survived",
+  );
+  killed.claims += 1;
 
   const reportMutant = structuredClone(audit);
   reportMutant.report.finding = "NCC-E008327-NONEXISTENT";


### PR DESCRIPTION
## Summary

- preserve the zero-knowledge privacy rationale in ADR 0013 while scoping it to prevention of a one-shot bulk directory corpus
- state that public or guessed handles can still be reconstructed one lookup at a time and that rate limiting is operational rather than cryptographic privacy
- put the same boundary beside the KT.md §3.3 explanation of public `DirectoryEntry` responses
- structurally bind both correction sites into the AKD evidence checker without changing their reviewed prose
- parse protected list-item Markdown after its reviewed content indentation, recognizing 4/5-space ATX (including empty headings), Setext headings, and backtick/tilde fences that GitHub renders inside the item; retain exact root/empty-marker versus nesting coverage
- tokenize raw HTML quote-aware with strict closing-tag syntax so quoted `>`/`/>` text and malformed spaced closes cannot hide canonical prose in collapsed containers
- fail closed on every HTML element tag in the protected rendered regions, including visible multiline `<span>` and `<details open>` containers, while preserving structural exclusion for comments and fenced examples
- protect the complete rendered ADR `## Alternatives rejected` section, with list-relative parsing for every root alternative, so contradictions before or after the canonical cleartext-log item cannot escape review
- reject independently added visible enumeration-privacy overclaims across the protected rendered sections, including prose, root-list, table, HTML, and open-vocabulary variants
- mutation-test complete deletion, relocation/hiding, visible contradiction, semantic inversion, cryptographic-rate-limit overclaim, collapse of successful public full-entry disclosure versus unqueried-label privacy, container-relative fences/headings, quote-bearing HTML tags, malformed closes, hidden structural tokens, intervening sections, and exact visible-container/pre-item/post-item bypasses

## Verification

- `git diff --check`
- `node --check scripts/check-akd-doc-evidence.mjs`
- `node scripts/check-akd-doc-evidence.mjs --self-test` — all 160 integrated mutants failed as required, including 99 claim mutants and exact visible `<span>`/`<details open>` contradictions in both protected documents
- `node scripts/check-akd-doc-evidence.mjs`
- `node scripts/check-github-actions-pins.mjs`
- `node scripts/check-github-actions-pins.mjs --self-test`
- `cargo +1.97.1 test --locked --manifest-path rs/Cargo.toml -p f2z-kt --test akd_doc_api`
- `scripts/check-public-repo-boundary.sh`
- `scripts/check-public-repo-boundary.sh --self-test`

Adversarial review found and repaired the visible raw-container parser bypass at `9dd8b2406371918ab6f31b83d3928b5578791358`; that repair still requires an independent reviewer.

No reset, witness, encoding, runtime, or release behavior changes.

Closes #890
Refs #558.
