### PR TITLE
fix(e2ee): authenticate the complete relay hello

### DIFF
--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -545,9 +545,7 @@ Two consequences follow, and both are requirements:
 
 - **The relay MUST prove possession of the identity key**, otherwise any relay
   could simply claim another's `relay_id` and the binding would be decoration.
-  The `HELLO` response carries
-  `relay_proof = Sign(relay_identity_sk, "free2z/relay/v1/hello" || channel_binding || client_nonce)`,
-  and the client MUST verify it before sending any signed command.
+  The client MUST verify `relay_proof` before sending any signed command.
 - **The client must know which `relay_id` to expect.** It does: a queue advert
   (§7.2) travels inside the MLS group and carries `(relay_url, relay_id,
   send_addr)` together, authenticated by the peer. A relay substituted at the DNS
@@ -556,6 +554,42 @@ Two consequences follow, and both are requirements:
   [`ARCHITECTURE.md` §10](./ARCHITECTURE.md#10-p2p-webrtc--an-optimization-not-a-dependency):
   the identifying material comes from inside the authenticated channel, never
   from the infrastructure being authenticated.
+
+The proof is an Ed25519 signature over a canonical TLS structure, not an ad hoc
+concatenation:
+
+```
+struct {
+    opaque label<0..255>;             /* exactly "free2z/relay/v1/hello" */
+    opaque channel_binding[32];       /* this connection's §5.3 value */
+    opaque client_nonce[32];          /* from the corresponding HelloRequest */
+    uint16 protocol_version;
+    opaque relay_identity_pk[32];
+    opaque relay_id[32];
+    uint64 relay_time_ms;
+    uint8  channel_binding_mode;
+    uint8  transport_security;
+    opaque capabilities_digest[32];
+} HelloProofTranscript;
+
+relay_proof = Sign(relay_identity_sk, tls_codec(HelloProofTranscript))
+```
+
+The fields after `client_nonce` are every `HelloResponse` field in wire order
+except `relay_proof`, which cannot include itself. The client reconstructs the
+transcript with the channel binding it computed locally and the nonce it sent;
+every other value comes from the response. Therefore the proof authenticates
+the negotiated version, relay clock, binding and transport modes, and capability
+digest as well as possession of `relay_identity_sk`.
+
+> **Security correction (2026-09-03).** The original v1 proof signed only
+> `"free2z/relay/v1/hello" || channel_binding || client_nonce`. It proved key
+> possession on this session but authenticated none of the response's policy or
+> negotiation fields. In `transport_security: none`, an active intermediary
+> could therefore rewrite those fields — including a binding-mode downgrade and
+> `capabilities_digest` — without invalidating the proof. The canonical
+> transcript above replaces that construction; implementations of the earlier
+> signing rule are not conforming v1 implementations.
 
 ### 5.3 TLS exporter channel binding — with the caveat stated
 
@@ -604,9 +638,11 @@ Therefore:
   [`ARCHITECTURE.md` §7](./ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering)'s
   hash-linked DAG, precisely so that ordering survives a hostile relay. Stated
   here so nobody looks for it in the wrong layer.
-- **The relay's response.** Responses are unsigned. A relay can lie about a
-  response and no signature detects it. This is deliberate: every response that
-  matters end-to-end is verified by other means (a `READ` result is MLS
+- **Command responses after `HELLO`.** These responses are unsigned. (`HELLO`
+  is the deliberate exception: its proof authenticates every field except the
+  proof itself.) A relay can lie about a later response and no signature detects
+  it. This is deliberate: every response that matters end-to-end is verified by
+  other means (a `READ` result is MLS
   ciphertext that authenticates itself; a claimed deletion is unverifiable in any
   case per
   [`THREAT-MODEL.md` §4.5](./THREAT-MODEL.md#45-server-side-deletion-is-auditable-not-verifiable)),
@@ -781,8 +817,10 @@ struct {
 
 MUST be the first frame. If no version in `[min_version, max_version]` is
 supported → `ERR_UNSUPPORTED_VERSION`, fatal. The client MUST verify
-`relay_proof`, MUST recompute `relay_id` from `relay_identity_pk`, and MUST
-compare `relay_id` against any value it obtained from an in-band advert (§7.2).
+`relay_proof` over the §5.2 `HelloProofTranscript`, MUST recompute `relay_id`
+from `relay_identity_pk`, and MUST compare `relay_id` against any value it
+obtained from an in-band advert (§7.2). Every response field except the proof
+itself is authenticated by that transcript.
 
 #### `GET_CAPABILITIES` — `0x0002`
 

--- a/docs/e2ee/decisions/0010-signing-transcript-and-ack-semantics.md
+++ b/docs/e2ee/decisions/0010-signing-transcript-and-ack-semantics.md
@@ -66,9 +66,13 @@ the highest appended index is an error.
   verification; a captured frame replayed on a new connection fails on the channel
   binding; a frame replayed on the same connection fails on the seen-set.
 - **The relay MUST prove possession of its identity key**, or `relay_id` is
-  decoration that any relay can claim. `HELLO` returns
-  `Sign(relay_identity_sk, "free2z/relay/v1/hello" || channel_binding || client_nonce)`
-  and the client verifies it before sending any signed command.
+  decoration that any relay can claim. `HELLO` returns an Ed25519 signature over
+  the canonical `HelloProofTranscript`: its domain label, the locally computed
+  channel binding, the client's nonce, and every `HelloResponse` field except
+  the proof itself. The client verifies it before interpreting the announcement
+  or sending any signed command. This is the 2026-09-03 security correction to
+  the original partial proof, which authenticated only the binding and nonce and
+  left the version, clock, policy modes, and capability digest rewritable.
 - **The channel binding cannot be computed behind a TLS-terminating proxy, and we
   say so.** Such a relay declares `channel_binding_mode: "none"`, uses 32 zero
   bytes, and a client may refuse it. There is no fix at this layer: no
@@ -95,9 +99,10 @@ the highest appended index is an error.
   this design; it is the hash-linked DAG of
   [`../ARCHITECTURE.md` §7](../ARCHITECTURE.md#7-application-framing--hash-linked-causal-ordering),
   precisely so it survives a hostile relay.
-- **Responses are unsigned.** Every response that matters end-to-end is verified
-  by other means, and signing responses would buy an audit trail against an
-  adversary who can simply refuse to answer.
+- **Command responses after `HELLO` are unsigned.** `HELLO` is the exception:
+  its proof authenticates the complete announcement. Every later response that
+  matters end-to-end is verified by other means, and signing those responses
+  would buy an audit trail against an adversary who can simply refuse to answer.
 - **Cumulative ACK keeps relay state to one integer per queue.** Selective
   acknowledgement would need a per-message bitmap — state proportional to the
   queue rather than constant — and would let a reader hold one message

--- a/rs/crates/f2z-codec/src/commands.rs
+++ b/rs/crates/f2z-codec/src/commands.rs
@@ -276,9 +276,11 @@ pub struct HelloRequest {
 
 /// `HELLO` response (§6.1).
 ///
-/// The client MUST verify `relay_proof`, MUST recompute `relay_id` from
-/// `relay_identity_pk` ([`crate::hash::relay_id`]), and MUST compare `relay_id`
-/// against any value it obtained from an in-band advert (§7.2).
+/// `relay_proof` authenticates every other field plus the connection's channel
+/// binding and the request's client nonce. The client MUST verify it, MUST
+/// recompute `relay_id` from `relay_identity_pk` ([`crate::hash::relay_id`]),
+/// and MUST compare `relay_id` against any value it obtained from an in-band
+/// advert (§7.2).
 #[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
 pub struct HelloResponse {
     /// The version selected for this connection.
@@ -287,7 +289,8 @@ pub struct HelloResponse {
     pub relay_identity_pk: PublicKey,
     /// MUST equal `H("free2z/relay/v1/relay-id", relay_identity_pk)`.
     pub relay_id: crate::types::RelayId,
-    /// Proof of possession of `relay_identity_pk` (§5.2).
+    /// Proof of possession of `relay_identity_pk` over the complete
+    /// [`crate::transcript::HelloProofTranscript`] (§5.2).
     pub relay_proof: Signature,
     /// The relay's clock, for clients whose own clock is unreliable (§5.5).
     pub relay_time_ms: u64,

--- a/rs/crates/f2z-codec/src/hash.rs
+++ b/rs/crates/f2z-codec/src/hash.rs
@@ -40,11 +40,9 @@ pub const LABEL_RELAY_ID: &[u8] = b"free2z/relay/v1/relay-id";
 /// (`WIRE.md` §6.1).
 pub const LABEL_CAPS: &[u8] = b"free2z/relay/v1/caps";
 
-/// The `HELLO` proof-of-possession prefix. `WIRE.md` §5.2:
-/// `relay_proof = Sign(relay_identity_sk, "free2z/relay/v1/hello" || channel_binding || client_nonce)`.
+/// The first-field label of `HelloProofTranscript` (`WIRE.md` §5.2).
 ///
-/// Note that this one is a signing *prefix*, not an argument to `H` — the proof
-/// is signed over the concatenation directly.
+/// This one is a signing-transcript label, not an argument to `H`.
 pub const LABEL_HELLO: &[u8] = b"free2z/relay/v1/hello";
 
 /// The proof-of-work label. `WIRE.md` §13.1: a stamp is valid iff
@@ -108,29 +106,6 @@ pub fn capabilities_digest(encoded_capabilities: &[u8]) -> Digest {
     hash(LABEL_CAPS, encoded_capabilities)
 }
 
-/// The exact bytes a relay signs to prove possession of its identity key
-/// (`WIRE.md` §5.2): `"free2z/relay/v1/hello" || channel_binding || client_nonce`.
-///
-/// The client MUST verify this before sending any signed command; without it
-/// the `relay_id` binding of §5.2 is decoration, because any relay could claim
-/// another's identity.
-#[must_use]
-pub fn hello_proof_message(
-    channel_binding: &crate::types::ChannelBinding,
-    client_nonce: &crate::types::Challenge,
-) -> alloc::vec::Vec<u8> {
-    let mut message = alloc::vec::Vec::with_capacity(
-        LABEL_HELLO
-            .len()
-            .saturating_add(crate::types::ChannelBinding::LEN)
-            .saturating_add(crate::types::Challenge::LEN),
-    );
-    message.extend_from_slice(LABEL_HELLO);
-    message.extend_from_slice(channel_binding.as_bytes());
-    message.extend_from_slice(client_nonce.as_bytes());
-    message
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,15 +158,5 @@ mod tests {
             relay_id(&key).as_bytes(),
             hash(LABEL_RELAY_ID, key.as_bytes()).as_bytes()
         );
-    }
-
-    #[test]
-    fn hello_proof_message_is_label_binding_nonce() {
-        let binding = crate::types::ChannelBinding::new([1u8; 32]);
-        let nonce = crate::types::Challenge::new([2u8; 32]);
-        let message = hello_proof_message(&binding, &nonce);
-        assert_eq!(message.len(), LABEL_HELLO.len() + 64);
-        assert!(message.starts_with(LABEL_HELLO));
-        assert!(message.ends_with(&[2u8; 32]));
     }
 }

--- a/rs/crates/f2z-codec/src/transcript.rs
+++ b/rs/crates/f2z-codec/src/transcript.rs
@@ -43,10 +43,117 @@ use alloc::vec::Vec;
 use tls_codec::{TlsDeserializeBytes, TlsSerializeBytes, TlsSize};
 
 use crate::canonical::encode;
+use crate::commands::HelloResponse;
 use crate::error::CodecError;
 use crate::frame::SignedAuth;
-use crate::hash::{LABEL_COMMAND, body_hash};
-use crate::types::{ChannelBinding, Digest, Nonce, PublicKey, QueueAddress, RelayId, ShortBytes};
+use crate::hash::{LABEL_COMMAND, LABEL_HELLO, body_hash};
+use crate::types::{
+    Challenge, ChannelBinding, Digest, Nonce, PublicKey, QueueAddress, RelayId, ShortBytes,
+};
+
+/// The canonical structure authenticated by `HelloResponse.relay_proof`
+/// (`WIRE.md` §5.2).
+///
+/// The signature itself is necessarily absent. Every other response field is
+/// copied verbatim, while `channel_binding` and `client_nonce` bind the proof
+/// to the transport session and the client's request. Keeping this as a typed
+/// `tls_codec` structure prevents a new announcement field from silently being
+/// left outside the proof.
+#[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
+pub struct HelloProofTranscript {
+    /// Exactly `"free2z/relay/v1/hello"`.
+    pub label: ShortBytes,
+    /// The TLS exporter, or 32 zero bytes in `none` mode (§5.3).
+    pub channel_binding: ChannelBinding,
+    /// Fresh randomness from the corresponding [`crate::commands::HelloRequest`].
+    pub client_nonce: Challenge,
+    /// The version selected for this connection.
+    pub protocol_version: u16,
+    /// The relay's long-term Ed25519 public key.
+    pub relay_identity_pk: PublicKey,
+    /// `H("free2z/relay/v1/relay-id", relay_identity_pk)`.
+    pub relay_id: RelayId,
+    /// The relay's clock at the instant it answered.
+    pub relay_time_ms: u64,
+    /// Whether commands are bound to the TLS session.
+    pub channel_binding_mode: u8,
+    /// Whether the connection itself is carried by TLS.
+    pub transport_security: u8,
+    /// The capability document in force for this connection.
+    pub capabilities_digest: Digest,
+}
+
+impl HelloProofTranscript {
+    /// Build the transcript for one response and one client session.
+    ///
+    /// `response.relay_proof` is deliberately ignored: a signature cannot
+    /// include itself. All other response fields are copied explicitly.
+    ///
+    /// # Errors
+    ///
+    /// [`CodecError::Overflow`] can only arise from the fixed label, so in
+    /// practice this does not fail.
+    pub fn from_response(
+        response: &HelloResponse,
+        channel_binding: ChannelBinding,
+        client_nonce: Challenge,
+    ) -> Result<Self, CodecError> {
+        // Deliberately exhaustive: adding a field to HelloResponse must break
+        // this build until the field is consciously included in the proof (or,
+        // for the self-referential proof field alone, consciously excluded).
+        let HelloResponse {
+            protocol_version,
+            relay_identity_pk,
+            relay_id,
+            relay_proof: _,
+            relay_time_ms,
+            channel_binding_mode,
+            transport_security,
+            capabilities_digest,
+        } = response;
+        Ok(Self {
+            label: ShortBytes::new(LABEL_HELLO)?,
+            channel_binding,
+            client_nonce,
+            protocol_version: *protocol_version,
+            relay_identity_pk: *relay_identity_pk,
+            relay_id: *relay_id,
+            relay_time_ms: *relay_time_ms,
+            channel_binding_mode: *channel_binding_mode,
+            transport_security: *transport_security,
+            capabilities_digest: *capabilities_digest,
+        })
+    }
+
+    /// The exact canonical bytes the relay signs and the client verifies.
+    ///
+    /// # Errors
+    ///
+    /// [`CodecError`] if the structure cannot be encoded.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, CodecError> {
+        encode(self)
+    }
+
+    /// Check the semantic invariant a decoder cannot: the exact label.
+    ///
+    /// # Errors
+    ///
+    /// [`CodecError::InvalidValue`] for any other label.
+    pub fn validate(&self) -> Result<(), CodecError> {
+        if self.label.as_slice() == LABEL_HELLO {
+            Ok(())
+        } else {
+            Err(CodecError::InvalidValue)
+        }
+    }
+}
+
+/// The canonical byte length of [`HelloProofTranscript`].
+///
+/// `1 + 21` label, `32` channel binding, `32` nonce, `2` version, `32`
+/// identity key, `32` relay id, `8` relay time, `1` binding mode, `1`
+/// transport mode, and `32` capability digest.
+pub const HELLO_PROOF_TRANSCRIPT_LEN: usize = 1 + 21 + 32 + 32 + 2 + 32 + 32 + 8 + 1 + 1 + 32;
 
 /// The fixed-shape structure every signed command is authenticated over
 /// (`WIRE.md` §5.1).
@@ -298,9 +405,70 @@ pub const TRANSCRIPT_LEN: usize = 1 + 19 + 2 + 32 + 32 + 2 + 4 + 32 + 32 + 8 + 1
 mod tests {
     use super::*;
     use crate::canonical::decode_canonical;
-    use crate::commands::Command;
+    use crate::commands::{Command, HelloResponse};
     use crate::types::Signature;
     use alloc::vec;
+
+    fn hello_response() -> HelloResponse {
+        HelloResponse {
+            protocol_version: 1,
+            relay_identity_pk: PublicKey::new([0x31; 32]),
+            relay_id: RelayId::new([0x32; 32]),
+            relay_proof: Signature::new([0x33; 64]),
+            relay_time_ms: 1_800_000_000_000,
+            channel_binding_mode: 1,
+            transport_security: 1,
+            capabilities_digest: Digest::new([0x34; 32]),
+        }
+    }
+
+    #[test]
+    fn hello_proof_transcript_is_canonical_and_excludes_only_the_proof() {
+        let response = hello_response();
+        let transcript = HelloProofTranscript::from_response(
+            &response,
+            ChannelBinding::new([0x41; 32]),
+            Challenge::new([0x42; 32]),
+        )
+        .unwrap();
+        let bytes = transcript.signing_bytes().unwrap();
+
+        assert_eq!(bytes.len(), HELLO_PROOF_TRANSCRIPT_LEN);
+        assert_eq!(bytes[0], LABEL_HELLO.len() as u8);
+        assert_eq!(&bytes[1..1 + LABEL_HELLO.len()], LABEL_HELLO);
+        assert!(transcript.validate().is_ok());
+        assert_eq!(
+            decode_canonical::<HelloProofTranscript>(&bytes)
+                .unwrap()
+                .value(),
+            &transcript
+        );
+
+        let mut different_proof = response;
+        different_proof.relay_proof = Signature::new([0xff; 64]);
+        assert_eq!(
+            HelloProofTranscript::from_response(
+                &different_proof,
+                ChannelBinding::new([0x41; 32]),
+                Challenge::new([0x42; 32]),
+            )
+            .unwrap(),
+            transcript,
+            "relay_proof is the one response field that cannot cover itself"
+        );
+    }
+
+    #[test]
+    fn hello_proof_transcript_rejects_the_wrong_label() {
+        let mut transcript = HelloProofTranscript::from_response(
+            &hello_response(),
+            ChannelBinding::new([0x41; 32]),
+            Challenge::new([0x42; 32]),
+        )
+        .unwrap();
+        transcript.label = ShortBytes::new(b"not-the-hello-label".to_vec()).unwrap();
+        assert_eq!(transcript.validate(), Err(CodecError::InvalidValue));
+    }
 
     fn builder() -> TranscriptBuilder {
         TranscriptBuilder::new(

--- a/rs/crates/f2z-codec/tests/wire_vectors.rs
+++ b/rs/crates/f2z-codec/tests/wire_vectors.rs
@@ -72,10 +72,13 @@ use f2z_codec::commands::{
 use f2z_codec::frame::{CommandAuth, FrameKind, Push, RelayFrame, Request, Response, SignedAuth};
 use f2z_codec::hash::{
     LABEL_BODY, LABEL_CAPS, LABEL_COMMAND, LABEL_HELLO, LABEL_POW, LABEL_RELAY_ID, LABELS,
-    body_hash, capabilities_digest, hash, hash2, hello_proof_message, relay_id,
+    body_hash, capabilities_digest, hash, hash2, relay_id,
 };
 use f2z_codec::pow::{PowParams, PowStamp};
-use f2z_codec::transcript::{AuthContext, TRANSCRIPT_LEN, TranscriptBuilder};
+use f2z_codec::transcript::{
+    AuthContext, HELLO_PROOF_TRANSCRIPT_LEN, HelloProofTranscript, TRANSCRIPT_LEN,
+    TranscriptBuilder,
+};
 use f2z_codec::types::{
     Body, Challenge, ChannelBinding, Digest, Nonce, Payload, PublicKey, QueueAddress, RelayId,
     Salt, ShortBytes, Signature,
@@ -380,24 +383,40 @@ fn capabilities_digest_is_a_known_answer() {
 }
 
 #[test]
-fn the_hello_proof_message_is_the_label_then_binding_then_nonce() {
-    // WIRE.md:473 —
-    // `relay_proof = Sign(relay_identity_sk, "free2z/relay/v1/hello" || channel_binding || client_nonce)`.
-    // Not an argument to `H`: a signing prefix over a plain concatenation.
-    let message = hello_proof_message(
-        &ChannelBinding::new([0xa1; 32]),
-        &Challenge::new([0xb2; 32]),
-    );
+fn hello_proof_transcript_covers_the_complete_announcement_in_spec_order() {
+    // WIRE.md §5.2. Derived field-by-field from the printed TLS structure,
+    // independently of the derive implementation this test judges.
+    let transcript = HelloProofTranscript {
+        label: ShortBytes::new(LABEL_HELLO).unwrap(),
+        channel_binding: ChannelBinding::new([0xa1; 32]),
+        client_nonce: Challenge::new([0xb2; 32]),
+        protocol_version: 1,
+        relay_identity_pk: PublicKey::new([0xc3; 32]),
+        relay_id: RelayId::new([0xd4; 32]),
+        relay_time_ms: 0x0102_0304_0506_0708,
+        channel_binding_mode: 1,
+        transport_security: 0,
+        capabilities_digest: Digest::new([0xe5; 32]),
+    };
+    let message = transcript.signing_bytes().unwrap();
     assert_wire(
-        "hello_proof_message",
+        "HelloProofTranscript",
         &message,
         &[
-            f("\"free2z/relay/v1/hello\"", 21, b"free2z/relay/v1/hello"),
+            f("uint8 label length = 21", 1, [21]),
+            f("label", 21, b"free2z/relay/v1/hello"),
             f("channel_binding[32]", 32, fill(0xa1, 32)),
             f("client_nonce[32]", 32, fill(0xb2, 32)),
+            f("protocol_version", 2, [0, 1]),
+            f("relay_identity_pk[32]", 32, fill(0xc3, 32)),
+            f("relay_id[32]", 32, fill(0xd4, 32)),
+            f("relay_time_ms", 8, [1, 2, 3, 4, 5, 6, 7, 8]),
+            f("channel_binding_mode", 1, [1]),
+            f("transport_security", 1, [0]),
+            f("capabilities_digest[32]", 32, fill(0xe5, 32)),
         ],
     );
-    assert_eq!(message.len(), 21 + 32 + 32);
+    assert_eq!(message.len(), HELLO_PROOF_TRANSCRIPT_LEN);
 }
 
 #[test]

--- a/rs/crates/f2z-relay-proto/src/hello.rs
+++ b/rs/crates/f2z-relay-proto/src/hello.rs
@@ -24,25 +24,31 @@
 
 use f2z_codec::commands::{HelloRequest, HelloResponse};
 use f2z_codec::hash;
-use f2z_codec::transcript::TranscriptBuilder;
+use f2z_codec::transcript::{HelloProofTranscript, TranscriptBuilder};
 use f2z_codec::types::{Challenge, ChannelBinding, Digest, PublicKey, RelayId, Signature};
 
 use crate::capabilities::{ChannelBindingMode, ClientPolicy, TransportSecurity};
 use crate::error::{ProtoError, Refusal, Result};
 use crate::key::{SigningKey, VerifyingKey};
 
-/// The bytes a relay signs to prove possession of its identity key (§5.2):
-/// `"free2z/relay/v1/hello" || channel_binding || client_nonce`.
+/// Sign the canonical `HelloProofTranscript` that proves possession of the
+/// relay identity key (§5.2).
 ///
-/// Note that this is a signing *prefix*, not an argument to `H` — the proof is
-/// over the concatenation directly.
-#[must_use]
+/// The transcript covers every `HelloResponse` field except the proof itself,
+/// plus this session's channel binding and the client's nonce.
+///
+/// # Errors
+///
+/// [`f2z_codec::CodecError`] if the transcript cannot be encoded.
 pub fn relay_proof(
     identity: &SigningKey,
+    response: &HelloResponse,
     channel_binding: &ChannelBinding,
     client_nonce: &Challenge,
-) -> Signature {
-    identity.sign(&hash::hello_proof_message(channel_binding, client_nonce))
+) -> Result<Signature> {
+    let transcript =
+        HelloProofTranscript::from_response(response, *channel_binding, *client_nonce)?;
+    Ok(identity.sign(&transcript.signing_bytes()?))
 }
 
 /// What a relay announces about itself in `HELLO` (§6.1).
@@ -69,24 +75,29 @@ pub struct RelayAnnouncement {
 ///
 /// `relay_id` is recomputed here rather than taken as an argument so that a
 /// relay cannot publish one that is not the digest of its own key.
-#[must_use]
+///
+/// # Errors
+///
+/// [`f2z_codec::CodecError`] if the proof transcript cannot be encoded.
 pub fn hello_response(
     identity: &SigningKey,
     announcement: &RelayAnnouncement,
     channel_binding: &ChannelBinding,
     client_nonce: &Challenge,
-) -> HelloResponse {
+) -> Result<HelloResponse> {
     let relay_identity_pk = identity.public_key();
-    HelloResponse {
+    let mut response = HelloResponse {
         protocol_version: announcement.protocol_version,
         relay_identity_pk,
         relay_id: hash::relay_id(&relay_identity_pk),
-        relay_proof: relay_proof(identity, channel_binding, client_nonce),
+        relay_proof: Signature::new([0; Signature::LEN]),
         relay_time_ms: announcement.relay_time_ms,
         channel_binding_mode: announcement.channel_binding_mode.code(),
         transport_security: announcement.transport_security.code(),
         capabilities_digest: announcement.capabilities_digest,
-    }
+    };
+    response.relay_proof = relay_proof(identity, &response, channel_binding, client_nonce)?;
+    Ok(response)
 }
 
 /// A connection whose relay has proved who it is.
@@ -209,6 +220,18 @@ pub fn verify_hello_response(
     expected_relay_id: Option<&RelayId>,
     policy: &ClientPolicy,
 ) -> Result<RelaySession> {
+    // §5.2: authenticate the complete announcement before interpreting any
+    // of its policy or negotiation fields. A substituted relay still gets the
+    // more specific RelayIdMismatch below: it can sign its own internally
+    // consistent response, but its derived id is not the peer-advertised one.
+    let identity = VerifyingKey::from_public_key(&response.relay_identity_pk)
+        .map_err(|_| ProtoError::Refused(Refusal::RelayKeyInvalid))?;
+    let proof =
+        HelloProofTranscript::from_response(response, *channel_binding, offer.client_nonce)?;
+    identity
+        .verify(&proof.signing_bytes()?, &response.relay_proof)
+        .map_err(|_| ProtoError::Refused(Refusal::RelayProofInvalid))?;
+
     // §3.5: one version, selected once, for the whole connection.
     if response.protocol_version < offer.min_version
         || response.protocol_version > offer.max_version
@@ -223,9 +246,10 @@ pub fn verify_hello_response(
     if hash::relay_id(&response.relay_identity_pk) != response.relay_id {
         return Err(ProtoError::Refused(Refusal::RelayIdNotDerived));
     }
-    // §2.5 step 3 and §5.2. Checked before the proof so that a substituted
-    // relay is reported as a substitution rather than as a bad signature — the
-    // two failures call for very different things from a user.
+    // §2.5 step 3 and §5.2. A substituted relay can still be reported as a
+    // substitution after proof verification: it signs an internally
+    // consistent announcement under its own key, then fails this comparison
+    // against the identity the peer advertised in-band.
     if let Some(expected) = expected_relay_id
         && *expected != response.relay_id
     {
@@ -261,17 +285,6 @@ pub fn verify_hello_response(
     if matches!(binding_mode, ChannelBindingMode::None) && policy.require_channel_binding {
         return Err(ProtoError::Refused(Refusal::NoChannelBinding));
     }
-
-    // §5.2: proof of possession, over this session's binding and this client's
-    // nonce, so it cannot be replayed from another connection.
-    let identity = VerifyingKey::from_public_key(&response.relay_identity_pk)
-        .map_err(|_| ProtoError::Refused(Refusal::RelayKeyInvalid))?;
-    identity
-        .verify(
-            &hash::hello_proof_message(channel_binding, &offer.client_nonce),
-            &response.relay_proof,
-        )
-        .map_err(|_| ProtoError::Refused(Refusal::RelayProofInvalid))?;
 
     Ok(RelaySession {
         transcripts: TranscriptBuilder::new(
@@ -336,6 +349,7 @@ mod tests {
             binding,
             &offer().client_nonce,
         )
+        .unwrap()
     }
 
     #[test]
@@ -354,6 +368,43 @@ mod tests {
         assert_eq!(session.relay_identity_pk(), identity.public_key());
         assert_eq!(session.relay_time_after(1_500), NOW + 1_500);
         assert_eq!(session.transcripts().channel_binding(), binding());
+    }
+
+    #[test]
+    fn every_hello_response_field_is_authenticated_before_it_is_used() {
+        let identity = relay();
+        let response = response(&identity, &binding());
+
+        macro_rules! assert_tamper_fails {
+            ($field:ident, $replacement:expr) => {{
+                let mut tampered = response.clone();
+                tampered.$field = $replacement;
+                assert_eq!(
+                    verify_hello_response(
+                        &tampered,
+                        &offer(),
+                        &binding(),
+                        None,
+                        &ClientPolicy::default(),
+                    )
+                    .map(|_| ()),
+                    Err(ProtoError::Refused(Refusal::RelayProofInvalid)),
+                    "{} was not bound to relay_proof",
+                    stringify!($field),
+                );
+            }};
+        }
+
+        assert_tamper_fails!(protocol_version, 2);
+        assert_tamper_fails!(
+            relay_identity_pk,
+            SigningKey::from_seed(&[0x45; 32]).public_key()
+        );
+        assert_tamper_fails!(relay_id, RelayId::new([0x46; 32]));
+        assert_tamper_fails!(relay_time_ms, NOW + 1);
+        assert_tamper_fails!(channel_binding_mode, ChannelBindingMode::None.code());
+        assert_tamper_fails!(transport_security, TransportSecurity::None.code());
+        assert_tamper_fails!(capabilities_digest, Digest::new([0x47; 32]));
     }
 
     #[test]
@@ -378,6 +429,8 @@ mod tests {
         let identity = relay();
         let mut response = response(&identity, &binding());
         response.relay_id = RelayId::new([1u8; 32]);
+        response.relay_proof =
+            relay_proof(&identity, &response, &binding(), &offer().client_nonce).unwrap();
         assert_eq!(
             verify_hello_response(
                 &response,
@@ -456,7 +509,8 @@ mod tests {
             &announcement(&identity, ChannelBindingMode::None, TransportSecurity::Tls),
             &zero,
             &offer().client_nonce,
-        );
+        )
+        .unwrap();
         let session =
             verify_hello_response(&response, &offer(), &zero, None, &ClientPolicy::default())
                 .unwrap();
@@ -475,8 +529,20 @@ mod tests {
     #[test]
     fn a_version_outside_the_offer_is_refused() {
         let identity = relay();
-        let mut response = response(&identity, &binding());
-        response.protocol_version = 2;
+        let response = hello_response(
+            &identity,
+            &RelayAnnouncement {
+                protocol_version: 2,
+                ..announcement(
+                    &identity,
+                    ChannelBindingMode::TlsExporter,
+                    TransportSecurity::Tls,
+                )
+            },
+            &binding(),
+            &offer().client_nonce,
+        )
+        .unwrap();
         assert_eq!(
             verify_hello_response(
                 &response,
@@ -499,7 +565,8 @@ mod tests {
             &announcement(&identity, ChannelBindingMode::None, TransportSecurity::None),
             &zero,
             &offer().client_nonce,
-        );
+        )
+        .unwrap();
         assert_eq!(
             verify_hello_response(&response, &offer(), &zero, None, &ClientPolicy::default())
                 .map(|_| ()),

--- a/rs/crates/f2z-relay-proto/src/lib.rs
+++ b/rs/crates/f2z-relay-proto/src/lib.rs
@@ -75,7 +75,7 @@
 //!     },
 //!     &binding,
 //!     &offer.client_nonce,
-//! );
+//! )?;
 //!
 //! // The client verifies the proof before signing anything. A session is the
 //! // only way to obtain a transcript builder.

--- a/rs/crates/f2z-relay-proto/tests/redaction.rs
+++ b/rs/crates/f2z-relay-proto/tests/redaction.rs
@@ -302,7 +302,8 @@ fn a_relay_session_does_not_render_its_binding_or_its_identity() {
         },
         &binding,
         &offer.client_nonce,
-    );
+    )
+    .unwrap();
     let session =
         verify_hello_response(&response, &offer, &binding, None, &ClientPolicy::default()).unwrap();
 

--- a/rs/crates/f2z-relay-testkit/src/engine.rs
+++ b/rs/crates/f2z-relay-testkit/src/engine.rs
@@ -527,7 +527,7 @@ impl Relay {
             &announcement,
             &self.channel_binding(),
             &offer.client_nonce,
-        );
+        )?;
         connection.hello_done = true;
         Ok(response.encode_canonical()?)
     }

--- a/rs/crates/f2z-relay/src/engine.rs
+++ b/rs/crates/f2z-relay/src/engine.rs
@@ -533,7 +533,7 @@ impl Relay {
             &announcement,
             &connection.transcripts.channel_binding(),
             &offer.client_nonce,
-        );
+        )?;
         connection.hello_done = true;
         Ok(response.encode_canonical()?)
     }


### PR DESCRIPTION
## Summary

- replace the partial HELLO possession proof with a canonical TLS transcript covering the session binding, client nonce, and every HelloResponse field except the proof itself
- sign that transcript in both relay implementations and verify it before interpreting the relay announcement
- pin the byte layout and reject independent tampering of every covered response field; exhaustive construction makes future response fields a compile-time review point
- document the corrected v1 security rule and the compatibility boundary

## Verification

- cargo +1.97.1 test --locked --all-targets (rs/)
- cargo +1.97.1 test --locked --doc (rs/)
- cargo +1.97.1 build --locked --lib --target wasm32-unknown-unknown -p f2z-codec -p f2z-relay-proto
- scripts/check-rust-clippy.sh --self-test macos
- scripts/check-rust-clippy.sh --root rs
- scripts/check-rust-fmt.sh --self-test
- scripts/check-rust-fmt.sh --root rs
- node scripts/check-hash-domain-labels.mjs --self-test
- node scripts/check-hash-domain-labels.mjs
- scripts/check-rust-toolchain.sh
- git diff --check

Refs #552