### PR TITLE
fix(kt): compare complete repeated tree heads

### DIFF
--- a/.github/workflows/rs.yml
+++ b/.github/workflows/rs.yml
@@ -144,7 +144,7 @@ jobs:
           rs=false
           while IFS= read -r -d '' file; do
             case "$file" in
-              rs/*|docs/e2ee/*|scripts/check-akd-doc-evidence.mjs|scripts/check-rust-fmt.sh|scripts/check-rust-clippy.sh|scripts/check-rust-deny.sh|scripts/check-rust-toolchain.sh|.github/workflows/rs.yml)
+              rs/*|docs/e2ee/*|scripts/check-akd-doc-evidence.mjs|scripts/check-kt-sth-repeat-agreement.mjs|scripts/check-rust-fmt.sh|scripts/check-rust-clippy.sh|scripts/check-rust-deny.sh|scripts/check-rust-toolchain.sh|.github/workflows/rs.yml)
                 rs=true
                 ;;
             esac
@@ -306,6 +306,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/check-akd-doc-evidence.mjs
+
+      # KT.md §6.3 and LogView share one repeated-head rule: exact complete
+      # equality is a no-op and every same-epoch alternative is a fork. This
+      # check binds the normative branch, the structural runtime comparison,
+      # every TBS field mutant, and the witness/client steady-state coverage.
+      - name: Mutation-test repeated tree-head agreement
+        run: node scripts/check-kt-sth-repeat-agreement.mjs --self-test
+
+      - name: Verify repeated tree-head spec and runtime agreement
+        run: node scripts/check-kt-sth-repeat-agreement.mjs
 
       # `crash-injection` is off by default because it compiles an `abort()`
       # into f2z-relay-store's commit path, so the default run above skips

--- a/docs/e2ee/KT.md
+++ b/docs/e2ee/KT.md
@@ -1685,12 +1685,18 @@ costs a few bytes an epoch.
 
 ### 6.3 Monotonicity
 
-A `SignedTreeHead` is acceptable to a client or witness **only if all of the
-following hold** against the last one it accepted for this `log_id`:
+A `SignedTreeHead` is acceptable to a client or witness only under the branch
+below against the last one it accepted for this `log_id`:
 
 1. `signature` verifies under the log key currently accepted for `log_id` (§6.4).
 2. `label`, `kt_version`, `log_id` are exact.
-3. `epoch > last.epoch`.
+
+<!-- kt-sth-repeat-contract:start -->
+3. Branch on `epoch`:
+   - If `epoch < last.epoch`, the head is a rollback and is fatal.
+   - If `epoch == last.epoch`, apply rule 8 and stop; rules 4–7 are
+     advancement-only.
+   - Only if `epoch > last.epoch`, continue with rules 4–7.
 4. `tree_size >= last.tree_size`.
 5. `published_at_ms > last.published_at_ms`.
 6. `vrf_public_key == last.vrf_public_key`.
@@ -1699,10 +1705,15 @@ following hold** against the last one it accepted for this `log_id`:
    If `epoch > last.epoch + 1`, the verifier MUST fetch every intervening tree
    head and check the chain link by link. **It MUST NOT skip.** A gap accepted on
    trust is a branch accepted on trust.
-8. If `epoch == last.epoch`: `root_hash`, `tree_size` and `published_at_ms` must
-   all be **identical**. Anything else is a fork and is fatal (§7.3).
+8. For `epoch == last.epoch`, the complete `SignedTreeHead` — every field of
+   `SignedTreeHeadTBS` and `signature` — MUST be identical to the last accepted
+   value. An identical re-presentation is an idempotent no-op. Any difference is
+   fork evidence and is fatal (§7.3). Equality is over the canonical protocol
+   structure; implementations MUST NOT define a second encoding or compare a
+   selected field subset.
+<!-- kt-sth-repeat-contract:end -->
 
-Rules 3 and 8 together are the rollback and fork tests. A client MUST apply them
+Rules 3 and 8 together are the rollback and fork test. A client MUST apply them
 too, not only a witness — they are cheap, they need no proof, and they are the
 only part of the log's honesty a client can check unaided.
 
@@ -1861,7 +1872,7 @@ evidence**.
 ```
 enum {
     rollback(1),               /* epoch or root moved backwards           */
-    fork(2),                   /* same epoch, different root or size      */
+    fork(2),                   /* same epoch, different complete STH      */
     chain_break(3),            /* prev_sth_hash does not connect          */
     bad_signature(4),          /* STH or key-transition signature invalid */
     append_only_failure(5),    /* audit_verify rejected                   */

--- a/rs/crates/f2z-kt-client/tests/acceptance.rs
+++ b/rs/crates/f2z-kt-client/tests/acceptance.rs
@@ -509,6 +509,30 @@ fn a_valid_lookup_verifies_against_a_witness_cosigned_root_and_pins() {
     assert!(!client.alarms().has_outstanding_critical());
 }
 
+#[test]
+fn two_handle_lookups_accept_the_same_complete_head_as_a_no_op() {
+    let mut deployment = Deployment::new("client-same-head-two-handles");
+    deployment.cosign(NOW);
+    deployment.register("alice", 1);
+    deployment.register("bob", 2);
+    deployment.cosign(NOW + 1);
+
+    let mut client = deployment.client(1);
+    let epoch = client.view().epoch();
+    let alice = client.resolve(&handle("alice"), NOW + 2).unwrap();
+    assert_eq!(alice.resolved().unwrap().handle().as_slice(), b"alice");
+    assert_eq!(client.view().epoch(), epoch);
+
+    // The real log serves the same latest SignedTreeHead with this other
+    // handle's proof. The repeat is a no-op at the log view while the proof and
+    // per-handle pin remain independently verified.
+    let bob = client.resolve(&handle("bob"), NOW + 3).unwrap();
+    assert_eq!(bob.resolved().unwrap().handle().as_slice(), b"bob");
+    assert_eq!(client.view().epoch(), epoch);
+    assert!(client.pins().get(&handle("alice")).is_some());
+    assert!(client.pins().get(&handle("bob")).is_some());
+}
+
 // ---------------------------------------------------------------------------
 // 2. A tampered proof.
 // ---------------------------------------------------------------------------

--- a/rs/crates/f2z-kt-core/src/error.rs
+++ b/rs/crates/f2z-kt-core/src/error.rs
@@ -179,7 +179,7 @@ pub enum KtError {
     Cooldown,
     /// §6.3: `epoch`, `tree_size` or `published_at_ms` moved backwards.
     Rollback,
-    /// §6.3 rule 8: the same epoch with a different root, size or timestamp.
+    /// §6.3: the same epoch with any difference in the complete signed head.
     /// Fatal, and it is fork evidence.
     Fork,
     /// §7.2: **one witness signed two contradictory statements** about one
@@ -272,7 +272,7 @@ impl fmt::Display for KtError {
             Self::DuplicateInEpoch => "a second entry for this handle in this epoch (KT.md §4.3)",
             Self::Cooldown => "platform_reset before effective_at_ms (KT.md §4.4)",
             Self::Rollback => "tree head moved backwards (KT.md §6.3)",
-            Self::Fork => "two different tree heads for one epoch (KT.md §6.3 rule 8)",
+            Self::Fork => "two different complete tree heads for one epoch (KT.md §6.3)",
             Self::WitnessEquivocation => {
                 "one witness signed two contradictory statements for one epoch (KT.md §7.2)"
             }

--- a/rs/crates/f2z-kt-core/src/sth.rs
+++ b/rs/crates/f2z-kt-core/src/sth.rs
@@ -151,6 +151,10 @@ impl SignedTreeHead {
 pub struct LogView {
     log_id: LogId,
     accepted_log_pk: PublicKey,
+    /// The canonical value that passed verification most recently. Keeping the
+    /// decoded structure means repeat equality uses the protocol type itself,
+    /// not a second encoding or a hand-maintained subset of its fields.
+    last_head: SignedTreeHead,
     epoch: u64,
     tree_size: u64,
     root_hash: Digest,
@@ -179,6 +183,7 @@ impl LogView {
         Ok(Self {
             log_id,
             accepted_log_pk,
+            last_head: head.clone(),
             epoch: head.sth.epoch,
             tree_size: head.sth.tree_size,
             root_hash: head.sth.root_hash,
@@ -230,18 +235,19 @@ impl LogView {
         &self.vrf_public_key
     }
 
-    /// Apply §6.3 in full and advance to `head`.
+    /// Apply §6.3 in full and, for a later epoch, advance to `head`.
     ///
     /// The eight rules, in §6.3's order:
     ///
     /// 1. the signature verifies under the currently accepted log key;
     /// 2. `label`, `kt_version` and `log_id` are exact;
-    /// 3. `epoch > last.epoch`;
+    /// 3. an older epoch is a rollback; at the same epoch only the complete
+    ///    previously accepted [`SignedTreeHead`] is an idempotent no-op;
     /// 4. `tree_size >= last.tree_size`;
     /// 5. `published_at_ms > last.published_at_ms`;
     /// 6. `vrf_public_key == last.vrf_public_key`;
     /// 7. the `prev_sth_hash` chain connects, with **no skipping** over a gap;
-    /// 8. an equal epoch must be byte-identical in root, size and timestamp.
+    /// 8. any other valid head at the same epoch is fork evidence.
     ///
     /// # Errors
     ///
@@ -260,20 +266,18 @@ impl LogView {
         // Rules 1 and 2.
         head.verify(&self.log_id, &self.accepted_log_pk)?;
 
-        // Rule 8 first among the ordering rules, because a repeat of the epoch
-        // we already hold is either a no-op or the single most important thing
-        // this function can detect, and reporting it as a rollback would name
-        // the wrong fault in the evidence a witness publishes.
+        // Rule 8 first among the ordering rules. Equality is over the canonical
+        // protocol value itself: every TBS field and the signature, with no
+        // alternate encoding and no subset that can drift as fields are added.
+        // kt-sth-repeat-runtime:start
         if head.sth.epoch == self.epoch {
-            if head.sth.root_hash == self.root_hash
-                && head.sth.tree_size == self.tree_size
-                && head.sth.published_at_ms == self.published_at_ms
-            {
-                // The same head again. Idempotent, and not an advance.
-                return Ok(());
-            }
-            return Err(KtError::Fork);
+            return if head == &self.last_head {
+                Ok(())
+            } else {
+                Err(KtError::Fork)
+            };
         }
+        // kt-sth-repeat-runtime:end
         // Rule 3.
         if head.sth.epoch < self.epoch {
             return Err(KtError::Rollback);
@@ -299,6 +303,7 @@ impl LogView {
             return Err(KtError::ChainBreak);
         }
 
+        self.last_head = head.clone();
         self.epoch = head.sth.epoch;
         self.tree_size = head.sth.tree_size;
         self.root_hash = head.sth.root_hash;
@@ -502,18 +507,99 @@ mod tests {
     }
 
     #[test]
-    fn the_same_head_twice_is_idempotent_and_a_different_one_is_a_fork() {
+    fn the_same_complete_head_twice_is_idempotent() {
         let log = TestLog::new();
         let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
         view.accept(&log.head(1)).unwrap();
         assert_eq!(view.accept(&log.head(1)), Ok(()));
+    }
 
-        // §6.3 rule 8: same epoch, different root. Fatal, and it is exactly the
-        // evidence §8.4 says two gossiping clients would exchange.
-        let mut forked = log.head(1);
-        forked.sth.root_hash = Digest::new([0xaa; 32]);
-        let forked = log.resign(forked);
-        assert_eq!(view.accept(&forked), Err(KtError::Fork));
+    #[test]
+    fn every_mutable_signed_field_is_part_of_same_epoch_equality() {
+        type Mutation = (&'static str, fn(&mut SignedTreeHeadTBS));
+
+        // kt-sth-repeat-field-tests:start
+        let mutations: [Mutation; 9] = [
+            ("tree_size", |sth| {
+                sth.tree_size = sth.tree_size.saturating_add(1)
+            }),
+            ("root_hash", |sth| sth.root_hash = Digest::new([0xaa; 32])),
+            ("prev_sth_hash", |sth| {
+                sth.prev_sth_hash = Digest::new([0xbb; 32])
+            }),
+            ("vrf_public_key", |sth| {
+                sth.vrf_public_key = PublicKey::new([0xcc; 32])
+            }),
+            ("published_at_ms", |sth| {
+                sth.published_at_ms = sth.published_at_ms.saturating_add(1);
+            }),
+            ("reset_count", |sth| {
+                sth.reset_count = sth.reset_count.saturating_add(1)
+            }),
+            ("epoch_interval_seconds", |sth| {
+                sth.epoch_interval_seconds = sth.epoch_interval_seconds.saturating_add(1);
+            }),
+            ("max_merge_delay_seconds", |sth| {
+                sth.max_merge_delay_seconds = sth.max_merge_delay_seconds.saturating_add(1);
+            }),
+            ("successor_log_pk", |sth| {
+                sth.successor_log_pk = PublicKey::new([0xdd; 32]);
+            }),
+        ];
+        // kt-sth-repeat-field-tests:end
+
+        for (field, mutate) in mutations {
+            let log = TestLog::new();
+            let accepted = log.head(1);
+            let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+            view.accept(&accepted).unwrap();
+
+            let mut alternative = accepted.clone();
+            mutate(&mut alternative.sth);
+            let alternative = log.resign(alternative);
+            assert_eq!(
+                view.accept(&alternative),
+                Err(KtError::Fork),
+                "same-epoch mutation of {field} escaped complete-head equality",
+            );
+            assert_eq!(
+                view.accept(&accepted),
+                Ok(()),
+                "{field} mutation changed the view"
+            );
+        }
+    }
+
+    #[test]
+    fn same_epoch_type_identity_and_signature_are_verified_before_equality() {
+        let log = TestLog::new();
+        let accepted = log.head(1);
+        let mut view = LogView::pin(*log.log_id(), *log.log_pk(), &log.head(0)).unwrap();
+        view.accept(&accepted).unwrap();
+
+        let mut wrong_label = accepted.clone();
+        wrong_label.sth.label = ShortBytes::new(b"free2z/kt/v1/not-sth".to_vec()).unwrap();
+        assert_eq!(
+            view.accept(&log.resign(wrong_label)),
+            Err(KtError::WrongLabel)
+        );
+
+        let mut wrong_version = accepted.clone();
+        wrong_version.sth.kt_version = KT_VERSION.saturating_add(1);
+        assert_eq!(
+            view.accept(&log.resign(wrong_version)),
+            Err(KtError::UnsupportedVersion)
+        );
+
+        let mut wrong_log = accepted.clone();
+        wrong_log.sth.log_id = LogId::new([0xee; 32]);
+        assert_eq!(view.accept(&log.resign(wrong_log)), Err(KtError::WrongLog));
+
+        let mut bad_signature = accepted.clone();
+        bad_signature.signature = Signature::new([0xff; 64]);
+        assert_eq!(view.accept(&bad_signature), Err(KtError::BadSignature));
+
+        assert_eq!(view.accept(&accepted), Ok(()));
     }
 
     #[test]

--- a/rs/crates/f2z-witness/tests/acceptance.rs
+++ b/rs/crates/f2z-witness/tests/acceptance.rs
@@ -317,7 +317,7 @@ fn a_witness_refuses_a_fork_and_records_self_authenticating_evidence() {
     );
 
     // Now the log shows it the other branch for the epoch it already signed.
-    // §6.3 rule 8: same epoch, different root, and that is fatal.
+    // §6.3 rule 8: same epoch, different complete head, and that is fatal.
     transport.serve(&right.log);
     assert_eq!(
         witness.poll_once(NOW + 2).unwrap(),

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -116,6 +116,7 @@ const RUST_ROOT_CONTRACTS = [
           "docs/e2ee/evidence/akd-benchmark.json",
           "docs/e2ee/evidence/akd-audit-scope.json",
           "scripts/check-akd-doc-evidence.mjs",
+          "scripts/check-kt-sth-repeat-agreement.mjs",
         ],
       },
     ],
@@ -2366,16 +2367,22 @@ function rustRootWorkflowFailures(relativeFile, lines, contract) {
     const steps = job
       ? policyJobSteps(relativeFile, lines, job, failures, "rs AKD evidence owner")
       : [];
-    for (const [stepName, command] of [
-      ["Mutation-test AKD documentation evidence", "node scripts/check-akd-doc-evidence.mjs --self-test"],
-      ["Verify AKD documentation against locked executable evidence", "node scripts/check-akd-doc-evidence.mjs"],
+    for (const [stepName, command, needsToken] of [
+      ["Mutation-test AKD documentation evidence", "node scripts/check-akd-doc-evidence.mjs --self-test", true],
+      ["Verify AKD documentation against locked executable evidence", "node scripts/check-akd-doc-evidence.mjs", true],
+      ["Mutation-test repeated tree-head agreement", "node scripts/check-kt-sth-repeat-agreement.mjs --self-test", false],
+      ["Verify repeated tree-head spec and runtime agreement", "node scripts/check-kt-sth-repeat-agreement.mjs", false],
     ]) {
       const matching = steps.filter((step) => step.properties.get("name")?.value === stepName);
       const step = matching[0];
+      const expectedKeys = needsToken ? ["name", "env", "run"] : ["name", "run"];
+      const tokenIsExact = !needsToken ||
+        (step !== undefined &&
+          stepEnvironment(relativeFile, lines, step, failures).get("GITHUB_TOKEN") === "${{ github.token }}");
       if (
         matching.length !== 1 ||
-        !hasExactKeys(step?.properties ?? new Map(), ["name", "env", "run"]) ||
-        stepEnvironment(relativeFile, lines, step, failures).get("GITHUB_TOKEN") !== "${{ github.token }}" ||
+        !hasExactKeys(step?.properties ?? new Map(), expectedKeys) ||
+        !tokenIsExact ||
         step?.properties.get("run")?.value !== command
       ) {
         failures.push(
@@ -3550,7 +3557,7 @@ function runRustRootWorkflowMutationTests(repoRoot) {
               "changes",
               probePath.startsWith("docs/e2ee/")
                 ? "docs/e2ee/*|"
-                : "scripts/check-akd-doc-evidence.mjs|",
+                : `${probePath}|`,
               "",
             ),
           `${ownerPrefix} selector must actively select`,
@@ -3808,9 +3815,11 @@ function runRustRootWorkflowMutationTests(repoRoot) {
       );
     }
     if (contract.root === "rs") {
-      for (const [stepName, command] of [
-        ["Mutation-test AKD documentation evidence", "node scripts/check-akd-doc-evidence.mjs --self-test"],
-        ["Verify AKD documentation against locked executable evidence", "node scripts/check-akd-doc-evidence.mjs"],
+      for (const [stepName, command, needsToken] of [
+        ["Mutation-test AKD documentation evidence", "node scripts/check-akd-doc-evidence.mjs --self-test", true],
+        ["Verify AKD documentation against locked executable evidence", "node scripts/check-akd-doc-evidence.mjs", true],
+        ["Mutation-test repeated tree-head agreement", "node scripts/check-kt-sth-repeat-agreement.mjs --self-test", false],
+        ["Verify repeated tree-head spec and runtime agreement", "node scripts/check-kt-sth-repeat-agreement.mjs", false],
       ]) {
         const needle = "rs owner job rs_test must run exactly one unconditional";
         const stepWithToken = `      - name: ${stepName}\n        env:\n          GITHUB_TOKEN: \${{ github.token }}\n        run: ${command}`;
@@ -3836,25 +3845,35 @@ function runRustRootWorkflowMutationTests(repoRoot) {
           (value) => mutateJob(value, "rs_test", `      - name: ${stepName}`, `      - name: ${stepName}\n        continue-on-error: true`),
           needle,
         );
-        assertWorkflowFailure(
-          contract,
-          source,
-          `rs/rs_test rejects unauthenticated ${stepName}`,
-          (value) => mutateJob(value, "rs_test", stepWithToken, stepWithoutToken),
-          needle,
-        );
-        assertWorkflowFailure(
-          contract,
-          source,
-          `rs/rs_test rejects a substituted token for ${stepName}`,
-          (value) => mutateJob(
-            value,
-            "rs_test",
-            stepWithToken,
-            stepWithToken.replace("\${{ github.token }}", "untrusted"),
-          ),
-          needle,
-        );
+        if (needsToken) {
+          assertWorkflowFailure(
+            contract,
+            source,
+            `rs/rs_test rejects unauthenticated ${stepName}`,
+            (value) => mutateJob(value, "rs_test", stepWithToken, stepWithoutToken),
+            needle,
+          );
+          assertWorkflowFailure(
+            contract,
+            source,
+            `rs/rs_test rejects a substituted token for ${stepName}`,
+            (value) => mutateJob(
+              value,
+              "rs_test",
+              stepWithToken,
+              stepWithToken.replace("\${{ github.token }}", "untrusted"),
+            ),
+            needle,
+          );
+        } else {
+          assertWorkflowFailure(
+            contract,
+            source,
+            `rs/rs_test rejects unnecessary credentials for ${stepName}`,
+            (value) => mutateJob(value, "rs_test", stepWithoutToken, stepWithToken),
+            needle,
+          );
+        }
       }
     }
   }

--- a/scripts/check-kt-sth-repeat-agreement.mjs
+++ b/scripts/check-kt-sth-repeat-agreement.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+// Bind KT.md §6.3's repeated-head rule to the one runtime implementation used
+// by the log client and witness. The runtime deliberately compares the decoded
+// protocol value itself: copying fields into this checker would create the
+// second equality definition #892 removes.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DOC = "docs/e2ee/KT.md";
+const RUNTIME = "rs/crates/f2z-kt-core/src/sth.rs";
+const CLIENT_TEST = "rs/crates/f2z-kt-client/tests/acceptance.rs";
+const WITNESS_TEST = "rs/crates/f2z-witness/tests/acceptance.rs";
+
+const ALL_TBS_FIELDS = [
+  "label",
+  "kt_version",
+  "log_id",
+  "epoch",
+  "tree_size",
+  "root_hash",
+  "prev_sth_hash",
+  "vrf_public_key",
+  "published_at_ms",
+  "reset_count",
+  "epoch_interval_seconds",
+  "max_merge_delay_seconds",
+  "successor_log_pk",
+];
+
+// Constants are rejected before the epoch branch and epoch selects the branch.
+// Every other TBS field must have an independent same-epoch fork mutant.
+const MUTABLE_TBS_FIELDS = ALL_TBS_FIELDS.slice(4);
+
+const EXPECTED_DOC = `3. Branch on \`epoch\`:
+   - If \`epoch < last.epoch\`, the head is a rollback and is fatal.
+   - If \`epoch == last.epoch\`, apply rule 8 and stop; rules 4–7 are
+     advancement-only.
+   - Only if \`epoch > last.epoch\`, continue with rules 4–7.
+4. \`tree_size >= last.tree_size\`.
+5. \`published_at_ms > last.published_at_ms\`.
+6. \`vrf_public_key == last.vrf_public_key\`.
+7. **The \`prev_sth_hash\` chain connects.** If \`epoch == last.epoch + 1\`, then
+   \`prev_sth_hash == H("free2z/kt/v1/tree-head-hash", tls_codec(last.sth))\` directly.
+   If \`epoch > last.epoch + 1\`, the verifier MUST fetch every intervening tree
+   head and check the chain link by link. **It MUST NOT skip.** A gap accepted on
+   trust is a branch accepted on trust.
+8. For \`epoch == last.epoch\`, the complete \`SignedTreeHead\` — every field of
+   \`SignedTreeHeadTBS\` and \`signature\` — MUST be identical to the last accepted
+   value. An identical re-presentation is an idempotent no-op. Any difference is
+   fork evidence and is fatal (§7.3). Equality is over the canonical protocol
+   structure; implementations MUST NOT define a second encoding or compare a
+   selected field subset.`;
+
+const EXPECTED_RUNTIME = `if head.sth.epoch == self.epoch {
+            return if head == &self.last_head {
+                Ok(())
+            } else {
+                Err(KtError::Fork)
+            };
+        }`;
+
+function marked(source, name) {
+  const start = `// ${name}:start`;
+  const end = `// ${name}:end`;
+  assert.equal(source.split(start).length - 1, 1, `${name}: start marker must occur once`);
+  assert.equal(source.split(end).length - 1, 1, `${name}: end marker must occur once`);
+  return source.split(start)[1].split(end)[0].trim();
+}
+
+function markdownMarked(source, name) {
+  const start = `<!-- ${name}:start -->`;
+  const end = `<!-- ${name}:end -->`;
+  assert.equal(source.split(start).length - 1, 1, `${name}: start marker must occur once`);
+  assert.equal(source.split(end).length - 1, 1, `${name}: end marker must occur once`);
+  return source.split(start)[1].split(end)[0].trim();
+}
+
+function fieldNames(source) {
+  const body = source
+    .split("pub struct SignedTreeHeadTBS {")[1]
+    ?.split("\n}")[0];
+  assert(body, `${RUNTIME}: SignedTreeHeadTBS declaration not found`);
+  return [...body.matchAll(/^\s*pub\s+(\w+):/gm)].map((match) => match[1]);
+}
+
+function verify(files) {
+  const docs = files.get(DOC);
+  const runtime = files.get(RUNTIME);
+  const client = files.get(CLIENT_TEST);
+  const witness = files.get(WITNESS_TEST);
+  assert(docs && runtime && client && witness, "required agreement inputs are missing");
+
+  assert.equal(markdownMarked(docs, "kt-sth-repeat-contract"), EXPECTED_DOC, `${DOC}: repeated-head contract drifted`);
+  assert.deepEqual(fieldNames(runtime), ALL_TBS_FIELDS, `${RUNTIME}: TBS field inventory drifted; classify and test the new field`);
+  assert.match(
+    runtime,
+    /#\[derive\([^\]]*PartialEq, Eq[^\]]*\)\]\npub struct SignedTreeHead \{/,
+    `${RUNTIME}: SignedTreeHead must retain structural equality`,
+  );
+  assert.equal(marked(runtime, "kt-sth-repeat-runtime"), EXPECTED_RUNTIME, `${RUNTIME}: same-epoch equality must compare the complete canonical value`);
+  assert.equal(runtime.split("last_head: SignedTreeHead,").length - 1, 1, `${RUNTIME}: LogView must retain exactly one complete head`);
+  assert.equal(runtime.split("last_head: head.clone(),").length - 1, 1, `${RUNTIME}: pin must retain the verified head`);
+  assert.equal(runtime.split("self.last_head = head.clone();").length - 1, 1, `${RUNTIME}: advance must retain the newly verified head`);
+
+  const testedFields = [...marked(runtime, "kt-sth-repeat-field-tests").matchAll(/^\s*\("([a-z_]+)"/gm)].map((match) => match[1]);
+  assert.deepEqual(testedFields, MUTABLE_TBS_FIELDS, `${RUNTIME}: every mutable TBS field needs an independent same-epoch mutant`);
+
+  assert.match(client, /fn two_handle_lookups_accept_the_same_complete_head_as_a_no_op\(\)/, `${CLIENT_TEST}: same-head multi-handle coverage is missing`);
+  assert.match(witness, /Polling again with nothing new is a no-op[\s\S]*Outcome::UpToDate \{ epoch: 3 \}/, `${WITNESS_TEST}: steady repeated-head poll coverage is missing`);
+}
+
+function load(root) {
+  return new Map([DOC, RUNTIME, CLIENT_TEST, WITNESS_TEST].map((relative) => [
+    relative,
+    fs.readFileSync(path.join(root, relative), "utf8"),
+  ]));
+}
+
+function mutated(files, relative, from, to) {
+  const copy = new Map(files);
+  const source = copy.get(relative);
+  assert.equal(source.split(from).length - 1, 1, `self-test target must occur once: ${from}`);
+  copy.set(relative, source.replace(from, to));
+  return copy;
+}
+
+function selfTest(root) {
+  const files = load(root);
+  verify(files);
+  const cases = [
+    ["partial spec equality", DOC, "every field of\n   `SignedTreeHeadTBS` and `signature`", "only `root_hash`, `tree_size`, and `published_at_ms`"],
+    ["partial runtime equality", RUNTIME, "head == &self.last_head", "head.sth.root_hash == self.root_hash"],
+    ["stale retained head", RUNTIME, "self.last_head = head.clone();", "// retained head update deleted"],
+    ["missing VRF mutant", RUNTIME, '"vrf_public_key"', '"vrf_key_not_tested"'],
+    ["missing multi-handle client proof", CLIENT_TEST, "fn two_handle_lookups_accept_the_same_complete_head_as_a_no_op", "fn deleted_same_head_client_proof"],
+    ["missing steady witness proof", WITNESS_TEST, "Polling again with nothing new is a no-op", "Polling coverage deleted"],
+  ];
+  for (const [name, relative, from, to] of cases) {
+    assert.throws(() => verify(mutated(files, relative, from, to)), `${name} mutant survived`);
+    console.log(`self-test: ${name}: killed`);
+  }
+  console.log(`self-test: ${cases.length} KT repeated-head agreement mutants killed`);
+}
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const args = process.argv.slice(2);
+if (args.length > 1 || (args.length === 1 && args[0] !== "--self-test")) {
+  console.error("usage: scripts/check-kt-sth-repeat-agreement.mjs [--self-test]");
+  process.exit(2);
+}
+
+try {
+  if (args[0] === "--self-test") selfTest(repoRoot);
+  else {
+    verify(load(repoRoot));
+    console.log("KT repeated-head spec/runtime agreement is complete.");
+  }
+} catch (error) {
+  console.error(`KT repeated-head agreement check failed: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
Summary:
- make KT section 6.3 explicitly branch on epoch: exact complete SignedTreeHead repeats are no-ops, older heads roll back, and only later heads run advancement checks
- retain the last verified SignedTreeHead in LogView and compare the canonical protocol value directly, covering VRF, cadence/merge policy, reset count, successor key, chain metadata, and signature without a parallel encoding
- add independent field mutants plus real witness steady-poll and same-epoch two-handle client acceptance coverage
- add a mutation-tested spec/runtime agreement checker and bind its exact CI ownership

Verification:
- cargo +1.97.1 test --locked -p f2z-kt-core (94 unit + 8 integration tests)
- cargo +1.97.1 test --locked -p f2z-kt-client --test acceptance (19 passed)
- cargo +1.97.1 test --locked -p f2z-witness --test acceptance (5 passed)
- cargo +1.97.1 clippy --locked -p f2z-kt-core --all-targets -- -D warnings
- scripts/check-rust-fmt.sh --root rs --self-test; scripts/check-rust-fmt.sh --root rs
- node scripts/check-kt-sth-repeat-agreement.mjs --self-test; live check
- node scripts/check-github-actions-pins.mjs --self-test; live check
- node scripts/check-workflow-gates.mjs --self-test; live check
- node scripts/check-hash-domain-labels.mjs --self-test; live check

Closes #892