### PR TITLE
fix(kt): make long-offline catch-up resumable

### DIFF
--- a/docs/e2ee/KT.md
+++ b/docs/e2ee/KT.md
@@ -1704,7 +1704,24 @@ below against the last one it accepted for this `log_id`:
    `prev_sth_hash == H("free2z/kt/v1/tree-head-hash", tls_codec(last.sth))` directly.
    If `epoch > last.epoch + 1`, the verifier MUST fetch every intervening tree
    head and check the chain link by link. **It MUST NOT skip.** A gap accepted on
-   trust is a branch accepted on trust.
+   trust is a branch accepted on trust. Clients paginate that work as follows:
+   the durable checkpoint is the last accepted `SignedTreeHead`; a page starts
+   at `last.epoch + 1`, ends at `min(last.epoch + 256, target.epoch)`, and fetches
+   `GET /kt/v1/sth/{epoch}` once for every epoch in that inclusive range, in
+   ascending order. Each response MUST contain exactly the requested epoch.
+   After each head verifies, the client advances its in-memory checkpoint; if
+   the page ends before `target.epoch`, it returns an explicit incomplete
+   result, the caller persists the advanced checkpoint, and a later call
+   resumes at the next epoch. The caller also persists the verified prefix
+   exposed after a network or decoding failure. A process interruption before
+   that write may repeat part of the page from an older checkpoint, which is
+   safe because every head is reverified; it MUST NOT resume from an unsigned
+   request counter. A missing, duplicate, reordered, truncated, or stalled
+   response fails closed at that response and cannot consume its epoch. The
+   page is therefore bounded to 256 one-head responses (257 round trips
+   including the initial latest-head or lookup response), while repeated calls
+   converge from an arbitrarily old checkpoint without accepting the target
+   across a gap.
 8. For `epoch == last.epoch`, the complete `SignedTreeHead` — every field of
    `SignedTreeHeadTBS` and `signature` — MUST be identical to the last accepted
    value. An identical re-presentation is an idempotent no-op. Any difference is
@@ -2176,6 +2193,20 @@ Stated at the point of use, and it is the correction
 | Whether the log **claims** to vouch for handles at all (§4.6's signed policy) | That a handle's **first** entry came from whoever is entitled to the handle. §4.5 now says what authorizes `entry_version == 1`, and the log checks it; it is not committed to the tree and not served, so there is nothing for a client to verify (§4.7) |
 | — | That a log which reports itself vouched actually applied §4.5 — or that a handle registered while it was unvouched was later re-vouched. The policy is log-wide, not per-handle (§4.6) |
 | That a `SubmissionReceipt`'s deadline was met, for its own submissions | That a log which met the deadline did so on the branch everyone else sees |
+
+Long dormancy makes the cheap check latency-heavy rather than proof-heavy. At
+the ten-minute cadence, 256 epochs are about 42 hours 40 minutes. A client one
+year behind has about 52,560 heads to verify: 206 bounded calls, 52,560
+exact-epoch response round trips, plus one latest/lookup round trip per call.
+The canonical TLS encoding of a one-head bundle is 314 bytes before
+cosignatures and each cosignature adds 205 bytes, so the response bodies alone
+are about 15.7 MiB with no cosignatures or 26.0 MiB with one per head for the
+exact-epoch responses; the 206 latest/lookup responses and HTTP/TLS headers add
+deployment-dependent overhead. This pagination prevents one API call from
+monopolising a client and makes progress durable, but it does not turn one-head
+HTTP catch-up into an efficient bulk protocol. An implementation claiming
+materially fewer round trips needs a separately specified range response and
+cannot silently replace the chain walk with the latest head.
 
 **A client cannot substitute its own consistency check for a witness's.** There
 is no cheap check available to it, so there is no fallback when the witness set

--- a/rs/crates/f2z-kt-client/src/client.rs
+++ b/rs/crates/f2z-kt-client/src/client.rs
@@ -38,6 +38,16 @@
 //! explicit that the protocol which exchanges them *"is not specified here"*.
 //! Inventing one would be worse than listing it, so it is listed:
 //! [§13-R](https://github.com/free2z/zuu/issues/311).
+//!
+//! # Catch-up state is progress even when the operation is incomplete
+//!
+//! A call that observes an epoch gap advances [`KtClient::view`] through at
+//! most [`MAX_EPOCH_CATCHUP`] consecutively verified heads. The caller must
+//! persist [`KtClient::checkpoint_bytes`] after **every** return, including an
+//! error: a transport or decoding failure can happen after a valid prefix.
+//! Persisting less is safe — the prefix is verified again after restart — but
+//! loses progress. [`KtClient::resume`] canonically decodes and verifies those
+//! signed checkpoint bytes, then resumes at exactly the first unverified epoch.
 
 use f2z_codec::types::PublicKey;
 use f2z_kt_core::api::{Presence, TreeHeadBundle};
@@ -58,14 +68,15 @@ use crate::standing::WitnessStanding;
 use crate::transport::Transport;
 use crate::wire;
 
-/// How many tree heads a client will fetch to close a §6.3 rule 7 gap in one
-/// call.
+/// How many tree heads a client will fetch and verify to close a §6.3 rule 7
+/// gap in one call.
 ///
 /// A number rather than "as many as it takes", because each one is a round
 /// trip and a client that has been offline for a year would otherwise open
 /// tens of thousands of them before answering a single lookup. Beyond it the
-/// client fails with [`KtError::EpochGap`] rather than skipping: *a gap
-/// accepted on trust is a branch accepted on trust*, so the fallback is a
+/// client returns [`ClientError::CatchUpIncomplete`] after advancing its
+/// [`LogView`] through the verified prefix. Persist that view and retry: *a
+/// gap accepted on trust is a branch accepted on trust*, so resumability is a
 /// slower catch-up and never a shortcut.
 pub const MAX_EPOCH_CATCHUP: u64 = 256;
 
@@ -103,9 +114,10 @@ pub struct ClientConfig {
 /// A key-transparency client for one log.
 ///
 /// Holds the two pieces of state that make §8.1 step 2 and step 8 mean
-/// anything: the pinned [`LogView`], and the [`PinStore`]. Both are readable
-/// for persistence and neither is settable except through a constructor, so a
-/// caller cannot rewind either by assignment.
+/// anything: the pinned [`LogView`], and the [`PinStore`]. The corresponding
+/// signed head is exposed by [`KtClient::checkpoint`] for canonical persistence;
+/// none of this state is settable except through a constructor, so a caller
+/// cannot rewind it by assignment.
 pub struct KtClient<T> {
     transport: T,
     config: ClientConfig,
@@ -160,29 +172,63 @@ impl<T: Transport> KtClient<T> {
         })
     }
 
-    /// Resume from persisted state.
-    #[must_use]
-    pub const fn resume(
+    /// Resume from canonically encoded, persisted signed-head checkpoint bytes.
+    ///
+    /// Reconstructing [`LogView`] through [`LogView::pin`] is deliberate: a
+    /// caller cannot deserialize private view fields and install unchecked
+    /// state. Persist [`KtClient::checkpoint_bytes`] after every operation and
+    /// supply those bytes here with the separately persisted pins and alarms.
+    ///
+    /// # Errors
+    ///
+    /// [`ClientError::Protocol`] if the checkpoint does not verify under the
+    /// configured log id and key.
+    pub fn resume(
         transport: T,
         config: ClientConfig,
-        view: LogView,
+        checkpoint: &[u8],
         pins: PinStore,
         alarms: AlarmLog,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        let checkpoint = f2z_codec::decode_canonical::<SignedTreeHead>(checkpoint)?.into_value();
+        let view = LogView::pin(config.log_id, config.accepted_log_pk, &checkpoint)?;
+        Ok(Self {
             transport,
             config,
             view,
             pins,
             alarms,
             vouching: Vouching::Unknown,
-        }
+        })
     }
 
-    /// The pinned view of the log — persist this.
+    /// The pinned view of the log, for inspection.
     #[must_use]
     pub const fn view(&self) -> &LogView {
         &self.view
+    }
+
+    /// The last accepted signed head — canonically encode and persist this.
+    ///
+    /// Unlike [`KtClient::view`], this is a protocol object with a canonical
+    /// `tls_codec` representation. [`KtClient::resume`] verifies it rather than
+    /// trusting caller-constructed checkpoint fields.
+    #[must_use]
+    pub const fn checkpoint(&self) -> &SignedTreeHead {
+        self.view.last_head()
+    }
+
+    /// Canonically encode the signed-head checkpoint for durable storage.
+    ///
+    /// These are the exact bytes [`KtClient::resume`] accepts. Keeping the
+    /// codec inside this crate prevents each application from inventing a
+    /// serialization for [`LogView`]'s private fields.
+    ///
+    /// # Errors
+    ///
+    /// [`ClientError::Protocol`] if canonical encoding fails.
+    pub fn checkpoint_bytes(&self) -> Result<Vec<u8>> {
+        f2z_codec::canonical::encode(self.checkpoint()).map_err(ClientError::from)
     }
 
     /// The pins — persist these.
@@ -227,6 +273,14 @@ impl<T: Transport> KtClient<T> {
     /// caller that only resolves is not skipping it.
     ///
     /// # Errors
+    ///
+    /// [`ClientError::CatchUpIncomplete`] after one bounded, verified prefix;
+    /// persist [`KtClient::checkpoint_bytes`] even though this operation did not
+    /// reach its target, then retry to resume from the next epoch.
+    ///
+    /// Any other error can also follow an accepted prefix. Persist
+    /// [`KtClient::checkpoint_bytes`] after every return; see the module-level
+    /// catch-up contract.
     ///
     /// [`ClientError::WitnessThresholdUnmet`] when §8.3's threshold is not met.
     /// Anything for which [`ClientError::is_fork_evidence`] holds has also
@@ -594,7 +648,7 @@ impl<T: Transport> KtClient<T> {
     /// §8.1 step 2, plus §6.3 rule 7's *"fetch every intervening tree head and
     /// check the chain link by link"*.
     fn advance_to(&mut self, head: &SignedTreeHead, now_ms: u64) -> Result<()> {
-        match self.view.accept(head) {
+        match self.accept_head(head) {
             Ok(()) => Ok(()),
             Err(KtError::EpochGap) => self.close_gap(head, now_ms),
             Err(error) => Err(self.on_protocol_error(error, now_ms)),
@@ -604,20 +658,49 @@ impl<T: Transport> KtClient<T> {
     fn close_gap(&mut self, head: &SignedTreeHead, now_ms: u64) -> Result<()> {
         let from = self.view.epoch().saturating_add(1);
         let to = head.sth.epoch;
-        if to < from || to.saturating_sub(from) > MAX_EPOCH_CATCHUP {
-            // Fail closed rather than skip. The remedy is more round trips, and
-            // a caller that wants them calls again.
+        if to < from {
             return Err(self.on_protocol_error(KtError::EpochGap, now_ms));
         }
-        for epoch in from..to {
+
+        // The checkpoint is the signed head already held by `LogView`; no
+        // unsigned page token exists for the server to roll back or reorder.
+        // The target is deliberately excluded when it lies beyond this page:
+        // accepting it would replace contiguous verification with latest-head
+        // trust, which is exactly §6.3 rule 7's forbidden shortcut.
+        let batch_end = to.min(self.view.epoch().saturating_add(MAX_EPOCH_CATCHUP));
+        for epoch in from..=batch_end {
             let bundle = wire::decode_bundle(&self.transport.sth_at(epoch)?)?;
-            self.view
-                .accept(&bundle.head)
+            if bundle.head.sth.epoch != epoch {
+                // `LogView::accept` treats an identical repeat of its current
+                // head as idempotent. That is correct for a direct observation
+                // and wrong for an exact-epoch page: here it would let a
+                // duplicate response consume an index and conceal a gap. Bind
+                // every response to the requested epoch before acceptance.
+                return Err(self.on_protocol_error(KtError::EpochGap, now_ms));
+            }
+            self.accept_head(&bundle.head)
                 .map_err(|error| self.on_protocol_error(error, now_ms))?;
         }
-        self.view
-            .accept(head)
+
+        if batch_end < to {
+            return Err(ClientError::CatchUpIncomplete {
+                accepted_epoch: self.view.epoch(),
+                target_epoch: to,
+            });
+        }
+
+        // The exact target was fetched through `/sth/{epoch}` above. Verify
+        // that the bundle carried by lookup/latest is the same signed head
+        // before its cosignatures or proof can be used; a different head at
+        // this epoch is a fork and `LogView` names it as such.
+        self.accept_head(head)
             .map_err(|error| self.on_protocol_error(error, now_ms))
+    }
+
+    /// Advance the checked view and its retained complete signed-head checkpoint
+    /// as one state transition. An error changes neither.
+    fn accept_head(&mut self, head: &SignedTreeHead) -> core::result::Result<(), KtError> {
+        self.view.accept(head)
     }
 
     /// §8.1 step 3 — §8.3's threshold, over the client's **own** set.

--- a/rs/crates/f2z-kt-client/src/error.rs
+++ b/rs/crates/f2z-kt-client/src/error.rs
@@ -30,6 +30,20 @@ pub enum ClientError {
     /// this crate implements none of them a second time.
     Protocol(KtError),
 
+    /// A verified catch-up prefix reached `accepted_epoch`, but the latest
+    /// head observed for this operation is still `target_epoch`.
+    ///
+    /// This is an expected, retryable checkpoint rather than a protocol
+    /// failure. Persist [`crate::KtClient::checkpoint_bytes`] before retrying:
+    /// the next call resumes at `accepted_epoch + 1` and never trusts the
+    /// target across the unverified gap (`KT.md` §6.3).
+    CatchUpIncomplete {
+        /// The last consecutively verified epoch, now held by the client.
+        accepted_epoch: u64,
+        /// The target epoch the operation has not accepted yet.
+        target_epoch: u64,
+    },
+
     /// §8.3, and it is **the fail-closed path**.
     ///
     /// Fewer than *t* distinct witnesses from the client's **own** configured
@@ -102,13 +116,13 @@ impl ClientError {
     /// Whether retrying later could plausibly succeed with nothing else
     /// changing.
     ///
-    /// Only the transport. A threshold that is unmet because the client
-    /// configured witnesses that are not cosigning is not transient in any
-    /// sense a retry loop should act on, and a UI that spun on it would turn a
-    /// deliberate refusal into a hang.
+    /// The transport, or a bounded catch-up checkpoint. A threshold that is
+    /// unmet because the client configured witnesses that are not cosigning is
+    /// not transient in any sense a retry loop should act on, and a UI that
+    /// spun on it would turn a deliberate refusal into a hang.
     #[must_use]
     pub const fn is_transient(&self) -> bool {
-        matches!(self, Self::Unreachable(_))
+        matches!(self, Self::Unreachable(_) | Self::CatchUpIncomplete { .. })
     }
 }
 
@@ -118,6 +132,14 @@ impl fmt::Display for ClientError {
             Self::Unreachable(detail) => write!(f, "the log could not be reached: {detail}"),
             Self::Refused(code) => write!(f, "the log refused: {code}"),
             Self::Protocol(error) => write!(f, "{error}"),
+            Self::CatchUpIncomplete {
+                accepted_epoch,
+                target_epoch,
+            } => write!(
+                f,
+                "verified catch-up checkpoint {accepted_epoch} of {target_epoch}; persist the \
+                 signed-head checkpoint and retry (KT.md §6.3)"
+            ),
             Self::WitnessThresholdUnmet => f.write_str(
                 "fewer than t of this client's own configured witnesses cosigned this root \
                  (KT.md §8.3); refusing rather than proceeding on an unwitnessed answer",

--- a/rs/crates/f2z-kt-client/src/transport.rs
+++ b/rs/crates/f2z-kt-client/src/transport.rs
@@ -76,7 +76,11 @@ pub trait Transport {
     /// Needed for §6.3 rule 7: a head that skips epochs is not accepted, and
     /// the only correct response is to fetch every intervening head and check
     /// the chain link by link. *A gap accepted on trust is a branch accepted on
-    /// trust.*
+    /// trust.* [`crate::KtClient`] binds the decoded head back to this exact
+    /// `epoch` before acceptance, so a duplicate or reordered response cannot
+    /// consume a page position. One catch-up operation calls this at most
+    /// [`crate::MAX_EPOCH_CATCHUP`] times and persists the last accepted signed
+    /// head as its checkpoint.
     ///
     /// # Errors
     ///

--- a/rs/crates/f2z-kt-client/src/transport.rs
+++ b/rs/crates/f2z-kt-client/src/transport.rs
@@ -197,6 +197,10 @@ impl HttpTransport {
     fn build(base: &str, timeout: core::time::Duration) -> Self {
         let config = ureq::Agent::config_builder()
             .timeout_global(Some(timeout))
+            // A §9.5 refusal is carried in the response body. Keep non-2xx
+            // responses readable so `response_bytes` can distinguish a
+            // canonical protocol refusal from a network failure.
+            .http_status_as_error(false)
             .build();
         Self {
             base: base.trim_end_matches('/').to_owned(),
@@ -206,31 +210,41 @@ impl HttpTransport {
 
     fn get(&self, path: &str) -> Result<Vec<u8>, ClientError> {
         let url = format!("{}{path}", self.base);
-        let mut response = self
+        let response = self
             .agent
             .get(&url)
             .header("accept", "application/octet-stream")
             .call()
             .map_err(|error| ClientError::Unreachable(format!("{url}: {error}")))?;
-        response
-            .body_mut()
-            .read_to_vec()
-            .map_err(|error| ClientError::Unreachable(format!("{url}: {error}")))
+        Self::response_bytes(&url, response)
     }
 
     fn post(&self, path: &str, body: &[u8]) -> Result<Vec<u8>, ClientError> {
         let url = format!("{}{path}", self.base);
-        let mut response = self
+        let response = self
             .agent
             .post(&url)
             .header("content-type", "application/octet-stream")
             .header("accept", "application/octet-stream")
             .send(body)
             .map_err(|error| ClientError::Unreachable(format!("{url}: {error}")))?;
-        response
+        Self::response_bytes(&url, response)
+    }
+
+    fn response_bytes(
+        url: &str,
+        mut response: ureq::http::Response<ureq::Body>,
+    ) -> Result<Vec<u8>, ClientError> {
+        let status = response.status();
+        let body = response
             .body_mut()
             .read_to_vec()
-            .map_err(|error| ClientError::Unreachable(format!("{url}: {error}")))
+            .map_err(|error| ClientError::Unreachable(format!("{url}: {error}")))?;
+        if status.is_success() {
+            Ok(body)
+        } else {
+            Err(crate::wire::status_error(url, status.as_u16(), &body))
+        }
     }
 }
 
@@ -263,7 +277,50 @@ impl Transport for HttpTransport {
 
 #[cfg(all(test, feature = "http"))]
 mod tests {
-    use super::HttpTransport;
+    use std::io::{Read as _, Write as _};
+    use std::net::TcpListener;
+    use std::thread::JoinHandle;
+
+    use f2z_codec::Canonical as _;
+    use f2z_kt_core::ErrorCode;
+    use f2z_kt_core::api::ErrorBody;
+
+    use super::{HttpTransport, Transport};
+
+    fn loopback_response(status: &str, body: Vec<u8>) -> (String, JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let status = status.to_owned();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 1_024];
+            while !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                let read = stream.read(&mut chunk).unwrap();
+                assert_ne!(read, 0, "client closed before completing its request");
+                request.extend_from_slice(&chunk[..read]);
+            }
+            write!(
+                stream,
+                "HTTP/1.1 {status}\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .unwrap();
+            stream.write_all(&body).unwrap();
+            String::from_utf8(request).unwrap()
+        });
+        (format!("http://{address}"), server)
+    }
+
+    fn loopback_disconnect() -> (String, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            drop(stream);
+        });
+        (format!("http://{address}"), server)
+    }
 
     #[test]
     fn a_cleartext_log_url_is_refused_by_default() {
@@ -295,6 +352,50 @@ mod tests {
             format!("{transport:?}"),
             "HttpTransport { base: \"https://kt.example\", .. }"
         );
+    }
+
+    #[test]
+    fn a_real_http_epoch_unavailable_body_is_a_non_transient_refusal() {
+        let body = ErrorBody::new(ErrorCode::EpochUnavailable.code())
+            .unwrap()
+            .encode_canonical()
+            .unwrap();
+        let (base, server) = loopback_response("404 Not Found", body);
+        let transport =
+            HttpTransport::insecure_loopback(&base, core::time::Duration::from_secs(5)).unwrap();
+
+        let error = transport.sth_at(77).unwrap_err();
+        assert_eq!(
+            error,
+            crate::ClientError::Refused(ErrorCode::EpochUnavailable)
+        );
+        assert!(!error.is_transient());
+        assert!(server.join().unwrap().starts_with("GET /kt/v1/sth/77 "));
+    }
+
+    #[test]
+    fn a_noncanonical_http_error_body_remains_an_unreachable_response() {
+        let (base, server) = loopback_response("404 Not Found", b"not canonical".to_vec());
+        let transport =
+            HttpTransport::insecure_loopback(&base, core::time::Duration::from_secs(5)).unwrap();
+
+        let error = transport.sth_at(77).unwrap_err();
+        assert!(matches!(error, crate::ClientError::Unreachable(_)));
+        assert!(error.is_transient());
+        assert!(format!("{error}").contains("HTTP 404 with no usable error body"));
+        assert!(server.join().unwrap().starts_with("GET /kt/v1/sth/77 "));
+    }
+
+    #[test]
+    fn a_socket_failure_remains_an_unreachable_transport_error() {
+        let (base, server) = loopback_disconnect();
+        let transport =
+            HttpTransport::insecure_loopback(&base, core::time::Duration::from_secs(5)).unwrap();
+
+        let error = transport.sth_at(77).unwrap_err();
+        assert!(matches!(error, crate::ClientError::Unreachable(_)));
+        assert!(error.is_transient());
+        server.join().unwrap();
     }
 }
 

--- a/rs/crates/f2z-kt-client/tests/catchup.rs
+++ b/rs/crates/f2z-kt-client/tests/catchup.rs
@@ -1,0 +1,491 @@
+//! Bounded, resumable `KT.md` §6.3 catch-up over the exact-epoch transport.
+//!
+//! These fixtures do not imitate a tree or an append-only proof. They generate
+//! real Ed25519-signed `SignedTreeHead`s and witness cosignatures, then stand in
+//! only for the socket so failures can be placed at exact page boundaries. The
+//! real-log acceptance suite separately proves that `Transport::sth_at` serves
+//! the production log's bundles.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use f2z_authority::SigningKey;
+use f2z_codec::Canonical as _;
+use f2z_codec::types::{Digest, PublicKey};
+use f2z_kt_client::{AlarmLog, PinStore};
+use f2z_kt_client::{ClientConfig, ClientError, KtClient, MAX_EPOCH_CATCHUP, Transport};
+use f2z_kt_core::api::TreeHeadBundle;
+use f2z_kt_core::cosign::{WitnessCosignature, WitnessCosignatureTBS};
+use f2z_kt_core::sth::{SignedTreeHead, SignedTreeHeadTBS};
+use f2z_kt_core::{ConfiguredWitness, ErrorCode, KT_VERSION, KtError, WitnessSet, labels};
+
+const TARGET: u64 = 600;
+
+#[derive(Clone)]
+enum Reply {
+    Bytes(Vec<u8>),
+    Error(ClientError),
+}
+
+struct State {
+    bundles: Vec<Vec<u8>>,
+    latest_epoch: u64,
+    latest_override: Option<Reply>,
+    exact_overrides: BTreeMap<u64, Reply>,
+    requested: Vec<u64>,
+}
+
+#[derive(Clone)]
+struct FixtureTransport(Arc<Mutex<State>>);
+
+impl FixtureTransport {
+    fn set_latest(&self, epoch: u64) {
+        self.0.lock().unwrap().latest_epoch = epoch;
+    }
+
+    fn override_latest(&self, reply: Reply) {
+        self.0.lock().unwrap().latest_override = Some(reply);
+    }
+
+    fn clear_latest_override(&self) {
+        self.0.lock().unwrap().latest_override = None;
+    }
+
+    fn override_epoch(&self, epoch: u64, reply: Reply) {
+        self.0.lock().unwrap().exact_overrides.insert(epoch, reply);
+    }
+
+    fn clear_epoch_override(&self, epoch: u64) {
+        self.0.lock().unwrap().exact_overrides.remove(&epoch);
+    }
+
+    fn requested(&self) -> Vec<u64> {
+        self.0.lock().unwrap().requested.clone()
+    }
+
+    fn clear_requests(&self) {
+        self.0.lock().unwrap().requested.clear();
+    }
+
+    fn bytes_at(&self, epoch: u64) -> Vec<u8> {
+        self.0.lock().unwrap().bundles[usize::try_from(epoch).unwrap()].clone()
+    }
+}
+
+impl Transport for FixtureTransport {
+    fn latest_sth(&self) -> f2z_kt_client::Result<Vec<u8>> {
+        let state = self.0.lock().unwrap();
+        match state.latest_override.as_ref() {
+            Some(Reply::Bytes(bytes)) => Ok(bytes.clone()),
+            Some(Reply::Error(error)) => Err(error.clone()),
+            None => Ok(state.bundles[usize::try_from(state.latest_epoch).unwrap()].clone()),
+        }
+    }
+
+    fn sth_at(&self, epoch: u64) -> f2z_kt_client::Result<Vec<u8>> {
+        let mut state = self.0.lock().unwrap();
+        state.requested.push(epoch);
+        match state.exact_overrides.get(&epoch) {
+            Some(Reply::Bytes(bytes)) => Ok(bytes.clone()),
+            Some(Reply::Error(error)) => Err(error.clone()),
+            None => Ok(state.bundles[usize::try_from(epoch).unwrap()].clone()),
+        }
+    }
+
+    fn lookup(&self, _request: &[u8]) -> f2z_kt_client::Result<Vec<u8>> {
+        Err(ClientError::Unreachable("fixture has no lookup".into()))
+    }
+
+    fn history(&self, _request: &[u8]) -> f2z_kt_client::Result<Vec<u8>> {
+        Err(ClientError::Unreachable("fixture has no history".into()))
+    }
+
+    fn authority_policy(&self) -> f2z_kt_client::Result<Vec<u8>> {
+        Err(ClientError::Unreachable("fixture has no policy".into()))
+    }
+
+    fn descriptor(&self) -> f2z_kt_client::Result<Vec<u8>> {
+        Err(ClientError::Unreachable("fixture has no descriptor".into()))
+    }
+}
+
+struct Fixture {
+    transport: FixtureTransport,
+    config: ClientConfig,
+    heads: Vec<SignedTreeHead>,
+    log_key: SigningKey,
+}
+
+impl Fixture {
+    fn new(last_epoch: u64) -> Self {
+        let log_key = SigningKey::from_seed(&[0x31; 32]);
+        let witness_key = SigningKey::from_seed(&[0x32; 32]);
+        let log_id = labels::log_id(&log_key.public_key());
+        let vrf_public_key = SigningKey::from_seed(&[0x33; 32]).public_key();
+        let mut heads = Vec::new();
+        let mut bundles = Vec::new();
+        let mut previous_hash = Digest::zero();
+
+        for epoch in 0..=last_epoch {
+            let mut root = [0u8; 32];
+            root[..8].copy_from_slice(&epoch.to_be_bytes());
+            root[8..].fill(0x44);
+            let sth = SignedTreeHeadTBS {
+                label: SignedTreeHeadTBS::label_bytes().unwrap(),
+                kt_version: KT_VERSION,
+                log_id,
+                epoch,
+                tree_size: epoch,
+                root_hash: Digest::new(root),
+                prev_sth_hash: previous_hash,
+                vrf_public_key,
+                published_at_ms: 1_700_000_000_000 + epoch,
+                reset_count: 0,
+                epoch_interval_seconds: 600,
+                max_merge_delay_seconds: 3_600,
+                successor_log_pk: PublicKey::zero(),
+            };
+            let head = SignedTreeHead {
+                signature: log_key.sign(&sth.signing_bytes().unwrap()),
+                sth,
+            };
+            previous_hash = head.sth.chain_hash().unwrap();
+            let statement = WitnessCosignatureTBS {
+                label: WitnessCosignatureTBS::label_bytes().unwrap(),
+                kt_version: KT_VERSION,
+                log_id,
+                epoch,
+                tree_size: epoch,
+                root_hash: head.sth.root_hash,
+                witness_pk: witness_key.public_key(),
+                observed_at_ms: 1_700_000_000_500 + epoch,
+            };
+            let cosignature = WitnessCosignature {
+                signature: witness_key.sign(&statement.signing_bytes().unwrap()),
+                statement,
+            };
+            bundles.push(
+                TreeHeadBundle::new(head.clone(), vec![cosignature])
+                    .unwrap()
+                    .encode_canonical()
+                    .unwrap(),
+            );
+            heads.push(head);
+        }
+
+        let transport = FixtureTransport(Arc::new(Mutex::new(State {
+            bundles,
+            latest_epoch: 0,
+            latest_override: None,
+            exact_overrides: BTreeMap::new(),
+            requested: Vec::new(),
+        })));
+        let config = ClientConfig {
+            log_id,
+            accepted_log_pk: log_key.public_key(),
+            witnesses: WitnessSet::new(
+                vec![ConfiguredWitness::independent(witness_key.public_key())],
+                1,
+            )
+            .unwrap(),
+            reset_authority_pk: SigningKey::from_seed(&[0x34; 32]).public_key(),
+            reset_cooldown_seconds: 86_400,
+        };
+        Self {
+            transport,
+            config,
+            heads,
+            log_key,
+        }
+    }
+
+    fn bootstrap(&self) -> KtClient<FixtureTransport> {
+        KtClient::bootstrap(self.transport.clone(), self.config.clone()).unwrap()
+    }
+
+    fn resume(&self, client: &KtClient<FixtureTransport>) -> KtClient<FixtureTransport> {
+        // This byte boundary is the persistence seam: the new client gets no
+        // clone of the old private `LogView`, only a canonical protocol object
+        // decoded as a process after restart would decode it.
+        let bytes = client.checkpoint_bytes().unwrap();
+        KtClient::resume(
+            self.transport.clone(),
+            self.config.clone(),
+            &bytes,
+            PinStore::new(),
+            AlarmLog::new(),
+        )
+        .unwrap()
+    }
+
+    fn resign(&self, mut head: SignedTreeHead) -> Vec<u8> {
+        head.signature = self.log_key.sign(&head.sth.signing_bytes().unwrap());
+        TreeHeadBundle::new(head, Vec::new())
+            .unwrap()
+            .encode_canonical()
+            .unwrap()
+    }
+}
+
+fn assert_checkpoint(error: ClientError, accepted_epoch: u64, target_epoch: u64) {
+    assert_eq!(
+        error,
+        ClientError::CatchUpIncomplete {
+            accepted_epoch,
+            target_epoch,
+        }
+    );
+    assert!(error.is_transient());
+    assert!(!error.is_fork_evidence());
+}
+
+#[test]
+fn a_six_hundred_epoch_gap_converges_in_three_persisted_batches() {
+    let fixture = Fixture::new(TARGET);
+    let mut client = fixture.bootstrap();
+    fixture.transport.set_latest(TARGET);
+
+    let error = client.sync(1).unwrap_err();
+    assert_checkpoint(error, MAX_EPOCH_CATCHUP, TARGET);
+    assert_eq!(client.view().epoch(), 256);
+    assert_eq!(fixture.transport.requested(), (1..=256).collect::<Vec<_>>());
+
+    // A process restart: only the documented durable state crosses this seam.
+    let mut client = fixture.resume(&client);
+    fixture.transport.clear_requests();
+    let error = client.sync(2).unwrap_err();
+    assert_checkpoint(error, 512, TARGET);
+    assert_eq!(client.view().epoch(), 512);
+    assert_eq!(
+        fixture.transport.requested(),
+        (257..=512).collect::<Vec<_>>()
+    );
+
+    let mut client = fixture.resume(&client);
+    fixture.transport.clear_requests();
+    let accepted = client.sync(3).unwrap();
+    assert_eq!(accepted.epoch(), TARGET);
+    assert_eq!(client.view().epoch(), TARGET);
+    assert_eq!(
+        fixture.transport.requested(),
+        (513..=TARGET).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn latest_head_trust_mutation_cannot_satisfy_a_catch_up_page() {
+    // Mutation control: replacing `advance_to`'s EpochGap branch with a fresh
+    // `LogView::pin(..., target)` turns the expected incomplete result below
+    // into `Ok(AcceptedRoot { epoch: 300, .. })` and makes this test fail. That
+    // is the tempting shortcut §6.3 specifically forbids.
+    let fixture = Fixture::new(300);
+    let mut client = fixture.bootstrap();
+    fixture.transport.set_latest(300);
+
+    let error = client.sync(1).unwrap_err();
+    assert_checkpoint(error, 256, 300);
+    assert_eq!(
+        client.view().epoch(),
+        256,
+        "the target must remain untrusted"
+    );
+    assert_eq!(
+        fixture.transport.requested(),
+        (1..=256).collect::<Vec<_>>(),
+        "every epoch in the bounded contiguous prefix must be requested"
+    );
+}
+
+#[test]
+fn an_interrupted_page_persists_only_its_verified_prefix_and_resumes() {
+    let fixture = Fixture::new(300);
+    let mut client = fixture.bootstrap();
+    fixture.transport.set_latest(300);
+    fixture.transport.override_epoch(
+        100,
+        Reply::Error(ClientError::Unreachable("server stalled".into())),
+    );
+
+    assert!(matches!(client.sync(1), Err(ClientError::Unreachable(_))));
+    assert_eq!(client.view().epoch(), 99);
+
+    let mut client = fixture.resume(&client);
+    fixture.transport.clear_epoch_override(100);
+    fixture.transport.clear_requests();
+    let accepted = client.sync(2).unwrap();
+    assert_eq!(accepted.epoch(), 300);
+    assert_eq!(client.view().epoch(), 300);
+    assert_eq!(
+        fixture.transport.requested(),
+        (100..=300).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn catch_up_target_uses_complete_repeat_equality_and_persists_the_exact_epoch_head() {
+    let fixture = Fixture::new(8);
+    let mut client = fixture.bootstrap();
+
+    // The exact-epoch page serves the canonical epoch-8 head. The latest
+    // response keeps the old subset (epoch/root/size/time) identical but changes
+    // a different signed TBS field. Before #898, subset equality accepted this
+    // as an idempotent repeat after catch-up; complete protocol equality must
+    // instead report fork evidence.
+    let mut alternative = fixture.heads[8].clone();
+    alternative.sth.reset_count = alternative.sth.reset_count.saturating_add(1);
+    fixture
+        .transport
+        .override_latest(Reply::Bytes(fixture.resign(alternative)));
+
+    let error = client.sync(1).unwrap_err();
+    assert_eq!(error, ClientError::Protocol(KtError::Fork));
+    assert!(error.is_fork_evidence());
+    assert_eq!(client.view().epoch(), 8);
+    assert_eq!(client.checkpoint(), &fixture.heads[8]);
+    assert_eq!(fixture.transport.requested(), (1..=8).collect::<Vec<_>>());
+
+    // Persisting after that error retains the consecutively verified canonical
+    // exact-epoch head, never the conflicting latest response. On restart, the
+    // same complete canonical head is an idempotent no-op and needs no page.
+    let checkpoint = client.checkpoint_bytes().unwrap();
+    let mut client = fixture.resume(&client);
+    fixture.transport.clear_latest_override();
+    fixture.transport.set_latest(8);
+    fixture.transport.clear_requests();
+    let accepted = client.sync(2).unwrap();
+    assert_eq!(accepted.epoch(), 8);
+    assert_eq!(client.checkpoint_bytes().unwrap(), checkpoint);
+    assert!(fixture.transport.requested().is_empty());
+}
+
+#[test]
+fn a_corrupted_persisted_checkpoint_is_refused_before_resume() {
+    let fixture = Fixture::new(300);
+    let mut client = fixture.bootstrap();
+    fixture.transport.set_latest(300);
+    assert!(matches!(
+        client.sync(1),
+        Err(ClientError::CatchUpIncomplete { .. })
+    ));
+
+    let mut checkpoint = client.checkpoint_bytes().unwrap();
+    *checkpoint.last_mut().unwrap() ^= 0x01;
+    assert!(matches!(
+        KtClient::resume(
+            fixture.transport.clone(),
+            fixture.config.clone(),
+            &checkpoint,
+            PinStore::new(),
+            AlarmLog::new(),
+        ),
+        Err(ClientError::Protocol(KtError::BadSignature))
+    ));
+}
+
+#[test]
+fn missing_duplicate_reordered_truncated_and_stalled_pages_never_skip() {
+    let cases = [
+        (
+            "missing",
+            Reply::Error(ClientError::Refused(ErrorCode::EpochUnavailable)),
+            ClientError::Refused(ErrorCode::EpochUnavailable),
+        ),
+        (
+            "duplicate",
+            Reply::Bytes(Fixture::new(8).transport.bytes_at(4)),
+            ClientError::Protocol(KtError::EpochGap),
+        ),
+        (
+            "reordered",
+            Reply::Bytes(Fixture::new(8).transport.bytes_at(6)),
+            ClientError::Protocol(KtError::EpochGap),
+        ),
+        (
+            "truncated",
+            Reply::Bytes({
+                let fixture = Fixture::new(8);
+                let mut bytes = fixture.transport.bytes_at(5);
+                bytes.pop();
+                bytes
+            }),
+            ClientError::Protocol(KtError::Malformed),
+        ),
+        (
+            "stalled",
+            Reply::Error(ClientError::Unreachable("server stalled".into())),
+            ClientError::Unreachable("server stalled".into()),
+        ),
+    ];
+
+    for (name, reply, expected) in cases {
+        let fixture = Fixture::new(8);
+        let mut client = fixture.bootstrap();
+        fixture.transport.set_latest(8);
+        fixture.transport.override_epoch(5, reply);
+        assert_eq!(client.sync(1), Err(expected), "{name} response must fail");
+        assert_eq!(client.view().epoch(), 4, "{name} response skipped an epoch");
+        assert_eq!(fixture.transport.requested(), (1..=5).collect::<Vec<_>>());
+    }
+}
+
+#[test]
+fn fork_rollback_and_broken_chain_fail_at_the_last_verified_checkpoint() {
+    let fixture = Fixture::new(12);
+    fixture.transport.set_latest(10);
+    let mut client = fixture.bootstrap();
+
+    fixture
+        .transport
+        .override_latest(Reply::Bytes(fixture.transport.bytes_at(9)));
+    assert_eq!(
+        client.sync(1),
+        Err(ClientError::Protocol(KtError::Rollback))
+    );
+    assert_eq!(client.view().epoch(), 10);
+
+    let mut fork = fixture.heads[10].clone();
+    fork.sth.root_hash = Digest::new([0xf0; 32]);
+    fixture
+        .transport
+        .override_latest(Reply::Bytes(fixture.resign(fork)));
+    let fork_error = client.sync(2).unwrap_err();
+    assert_eq!(fork_error, ClientError::Protocol(KtError::Fork));
+    assert!(fork_error.is_fork_evidence());
+    assert_eq!(client.view().epoch(), 10);
+
+    let fixture = Fixture::new(12);
+    let mut client = fixture.bootstrap();
+    fixture.transport.set_latest(12);
+    let mut broken = fixture.heads[5].clone();
+    broken.sth.prev_sth_hash = Digest::new([0xb0; 32]);
+    fixture
+        .transport
+        .override_epoch(5, Reply::Bytes(fixture.resign(broken)));
+    assert_eq!(
+        client.sync(3),
+        Err(ClientError::Protocol(KtError::ChainBreak))
+    );
+    assert_eq!(client.view().epoch(), 4);
+}
+
+#[test]
+fn documented_one_head_wire_costs_are_executable_constants() {
+    let fixture = Fixture::new(0);
+    let with_one_cosignature = fixture.transport.bytes_at(0).len();
+    let without_cosignatures = TreeHeadBundle::new(fixture.heads[0].clone(), Vec::new())
+        .unwrap()
+        .encode_canonical()
+        .unwrap()
+        .len();
+
+    assert_eq!(without_cosignatures, 314);
+    assert_eq!(with_one_cosignature - without_cosignatures, 205);
+}

--- a/rs/crates/f2z-kt-core/src/sth.rs
+++ b/rs/crates/f2z-kt-core/src/sth.rs
@@ -229,6 +229,16 @@ impl LogView {
         &self.sth_hash
     }
 
+    /// The complete signed head most recently accepted by this view.
+    ///
+    /// This is the canonical durable checkpoint for a resumable client. It is
+    /// the same protocol value §6.3 rule 8 compares for an idempotent repeat,
+    /// so callers do not need to maintain a second head alongside the view.
+    #[must_use]
+    pub const fn last_head(&self) -> &SignedTreeHead {
+        &self.last_head
+    }
+
     /// The VRF key every label in the tree is derived under.
     #[must_use]
     pub const fn vrf_public_key(&self) -> &PublicKey {

--- a/scripts/check-kt-sth-repeat-agreement.mjs
+++ b/scripts/check-kt-sth-repeat-agreement.mjs
@@ -47,7 +47,24 @@ const EXPECTED_DOC = `3. Branch on \`epoch\`:
    \`prev_sth_hash == H("free2z/kt/v1/tree-head-hash", tls_codec(last.sth))\` directly.
    If \`epoch > last.epoch + 1\`, the verifier MUST fetch every intervening tree
    head and check the chain link by link. **It MUST NOT skip.** A gap accepted on
-   trust is a branch accepted on trust.
+   trust is a branch accepted on trust. Clients paginate that work as follows:
+   the durable checkpoint is the last accepted \`SignedTreeHead\`; a page starts
+   at \`last.epoch + 1\`, ends at \`min(last.epoch + 256, target.epoch)\`, and fetches
+   \`GET /kt/v1/sth/{epoch}\` once for every epoch in that inclusive range, in
+   ascending order. Each response MUST contain exactly the requested epoch.
+   After each head verifies, the client advances its in-memory checkpoint; if
+   the page ends before \`target.epoch\`, it returns an explicit incomplete
+   result, the caller persists the advanced checkpoint, and a later call
+   resumes at the next epoch. The caller also persists the verified prefix
+   exposed after a network or decoding failure. A process interruption before
+   that write may repeat part of the page from an older checkpoint, which is
+   safe because every head is reverified; it MUST NOT resume from an unsigned
+   request counter. A missing, duplicate, reordered, truncated, or stalled
+   response fails closed at that response and cannot consume its epoch. The
+   page is therefore bounded to 256 one-head responses (257 round trips
+   including the initial latest-head or lookup response), while repeated calls
+   converge from an arbitrarily old checkpoint without accepting the target
+   across a gap.
 8. For \`epoch == last.epoch\`, the complete \`SignedTreeHead\` — every field of
    \`SignedTreeHeadTBS\` and \`signature\` — MUST be identical to the last accepted
    value. An identical re-presentation is an idempotent no-op. Any difference is


### PR DESCRIPTION
Closes #893

## Summary

- specify checkpointed pagination over the existing exact-epoch endpoint: an ascending inclusive prefix of at most 256 signed heads, with exact response-epoch binding and an explicit incomplete outcome
- retain the last accepted complete `SignedTreeHead` inside `LogView` as the single canonical durable checkpoint; `checkpoint_bytes()` encodes it and `resume()` canonically decodes, signature-checks, and re-pins it
- integrate #898 without duplicating or weakening its repeated-head semantics: the catch-up target is re-accepted through complete protocol equality, and failed same-epoch alternatives leave the verified exact-epoch checkpoint unchanged
- advance the checkpoint after every consecutively verified head, including prefixes preceding transport or decode failures, while never accepting the target across an unverified gap
- document the honest long-dormancy cost: a year at the ten-minute cadence is about 52,560 exact-epoch round trips and 15.7 MiB without cosignatures / 26.0 MiB with one cosignature per head, before latest requests and HTTP/TLS overhead
- add signed runtime fixtures covering a 600-epoch three-batch recovery, persisted byte-level restart, corrupt-checkpoint refusal, complete repeated-head equality, fork, rollback, chain break, missing, duplicate, reorder, truncation, and server stall

## Compatibility

`KtClient::resume` now accepts canonical signed-head checkpoint bytes and returns `Result<Self>` instead of accepting an in-memory `LogView`. There were no repository callers. This makes the documented restart seam persistable and ensures resumed state is signature-checked.

## Integration with #898

This branch is rebased onto `ba72c7ef5944c9ef9730f7e263c13016a2a6282e`. `LogView::last_head()` exposes the exact complete head already retained by #898; `KtClient` no longer carries a second checkpoint that could drift. The interaction test changes only `reset_count` in a re-signed same-epoch latest head, proves it is fork evidence after the exact page reaches that epoch, proves the canonical page head remains durable, then resumes and accepts the exact canonical repeat as an idempotent no-op.

## Verification

- `cargo +1.97.1 test --locked --manifest-path rs/Cargo.toml -p f2z-kt-client -p f2z-kt-core -p f2z-kt --all-targets`
- `cargo +1.97.1 test --locked --manifest-path rs/Cargo.toml -p f2z-kt-client -p f2z-kt-core -p f2z-kt --doc`
- `cargo +1.97.1 clippy --locked --manifest-path rs/Cargo.toml -p f2z-kt-client -p f2z-kt-core -p f2z-kt --all-targets -- -D warnings`
- `cargo +1.97.1 check --locked --manifest-path rs/Cargo.toml -p f2z-kt-client --target wasm32-unknown-unknown --no-default-features --features verifier`
- Rust fmt, native-clippy, deny, and toolchain self-tests plus live `rs/` checks
- repeated-STH, workflow-gate, hash-domain, bounded-PoW, GitHub Actions, and AKD evidence self-tests plus live checks
- `git diff --check`

## Mutation controls

- replacing the `EpochGap` branch with a fresh `LogView::pin(..., target)` makes `latest_head_trust_mutation_cannot_satisfy_a_catch_up_page` return success instead of the required incomplete checkpoint
- the #898 interaction fixture changes only `reset_count` while keeping the former epoch/root/size/time subset identical; subset equality would accept it, while the complete comparison returns `KtError::Fork` and preserves the exact page checkpoint
- the repeated-STH agreement self-test killed all six spec/runtime/field/coverage mutants

Exact pushed head: `300bc2c2c0f0d1ed0ab166b24bd58c86035ba051`