### PR TITLE
fix(kt): enforce credential lifetime and revocations

### DIFF
--- a/docs/e2ee/KT.md
+++ b/docs/e2ee/KT.md
@@ -267,6 +267,17 @@ struct {
 validated by peers who have no directory access at all, so it cannot depend on
 its envelope for meaning.
 
+The interval MUST be non-empty: `not_before_ms < not_after_ms`. The v1
+credential-clock tolerance is a fixed protocol constant,
+`credential_clock_skew_ms = 120000`; it is not log policy and a log cannot
+increase it. At verifier-local Unix time `t`, a credential is valid exactly
+when both `not_before_ms <= saturating_add(t, credential_clock_skew_ms)` and
+`t <= saturating_add(not_after_ms, credential_clock_skew_ms)` hold. Both outer
+boundaries are inclusive. Before the first boundary the result is
+**not-yet-valid**; after the second it is **expired**. Either result excludes the
+credential from lookup-driven first contact and causes an MLS peer validating
+the self-contained credential to reject it.
+
 ```
 struct {
     opaque device_pk[32];
@@ -304,6 +315,26 @@ struct {
     EntryAuthorization authorization;     /* §4.4 */
 } DirectoryEntry;
 ```
+
+`revocations` is an append-only cumulative history per handle. A single entry
+MUST NOT contain two records for one `device_pk`, whether identical or
+contradictory. Every successor MUST carry its predecessor's complete vector as
+an exact prefix: existing records cannot be omitted, reordered or edited, and
+new records are appended. This rule crosses identity-key changes and does not
+grant `platform_reset` an un-revocation power. A revocation takes effect when
+the entry containing it is published; `revoked_at_ms` and `reason` are audit and
+display metadata, not a future activation switch. The log MUST apply the
+interval, uniqueness and cumulative-prefix checks during admission, before it
+persists the submission or issues a `SubmissionReceipt`.
+
+A fresh verified lookup therefore teaches a client every revocation published
+for the handle, and first-contact selection MUST exclude both revoked and
+out-of-window credentials. An offline MLS peer has only the credential already
+carried in the group: it can enforce the same time interval from its local
+clock, but it cannot learn a later directory revocation until it performs or
+receives the result of a fresh verified lookup. Publishing a KT revocation does
+not itself remove an existing MLS member or retroactively invalidate messages;
+that requires an MLS state change delivered through the group.
 
 Note what is **not** in it: no display name, no avatar, no profile field, no
 relay list beyond contact endpoints, and no `KeyPackage`. A directory entry is
@@ -517,7 +548,11 @@ Verification rules the log MUST apply, in order, before an entry enters a batch:
    authority key, `effective_at_ms - created_at_ms` is at least the published
    cooldown, and the log MUST NOT publish the entry before `effective_at_ms`.
 9. Every `DeviceCredential` signature verifies under this entry's `identity_pk`,
-   and no two credentials share a `device_pk`.
+   every interval is non-empty, and no two credentials share a `device_pk`.
+   No two revocations share a `device_pk`; for `entry_version >= 2`, the
+   predecessor's complete revocation vector is an exact prefix of this entry's
+   vector. A submission that drops, reorders or changes a prior record is an
+   un-revocation attempt and MUST be rejected with `ERR_BAD_AUTHORIZATION`.
 10. §4.3's uniqueness rule.
 11. **§4.5 applies, in full, and the entry MUST NOT be published unless it
     passes.** Three cases, and an implementer applies all three:
@@ -2014,6 +2049,11 @@ To resolve `@alice`:
    surface that — §4.6, and §8.3's rule about not displaying a reassuring number
    for a property the system does not have.
 8. Pin `(handle, identity_pk, entry_version, prev_entry_hash, epoch)`.
+9. For lookup-driven first contact, select only `devices` whose credential is
+   valid at verifier-local time under §4.1's fixed skew rule and whose
+   `device_pk` does not occur in cumulative `revocations`. The raw entry remains
+   available for proof and audit, but a caller MUST NOT use an excluded device
+   for a new `KeyPackage` or routing advert.
 
 **A handle that is not registered returns a proof of non-membership, not an
 error.** **That is the requirement and not the shipped property — read the

--- a/docs/e2ee/WIRE.md
+++ b/docs/e2ee/WIRE.md
@@ -2142,22 +2142,27 @@ these hold:
 | 3 | The credential parses as a `free2z/device-credential/v1`, not as a bare handle in a `BasicCredential`. |
 | 4 | The credential's signature verifies under the **entry's** `identity_pk` — not under the key inside the credential. |
 | 5 | The credential's `handle` is the entry's `handle`. |
-| 6 | The credential's `device_pk` appears in the entry's `devices`. |
-| 7 | The credential's `device_pk` does **not** appear in the entry's `revocations`. |
-| 8 | The leaf's `signature_key` is the credential's `device_pk` — the identity→device binding of `ARCHITECTURE.md` §4.2. |
+| 6 | The complete signed `DeviceCredential` exactly equals the credential the entry publishes in `devices` for that `device_pk`; matching the key alone is insufficient. |
+| 7 | At verifier-local time, that published credential is `Valid` under `KT.md` §4.1's exact shared inclusive fixed-skew rule; **not-yet-valid** and **expired** credentials are refused. |
+| 8 | The credential's `device_pk` does **not** appear in the entry's cumulative `revocations`. |
+| 9 | The leaf's `signature_key` is the credential's `device_pk` — the identity→device binding of `ARCHITECTURE.md` §4.2. |
 
 Check 4 is the one the section exists for. A relay that invents an identity key,
 issues itself a credential under it and signs a key package with the matching
-device key passes 1, 2, 3 and 8; only the directory's `identity_pk` stops it.
-Checks 6 and 7 are what make a *withdrawn* or *revoked* device unreachable for
-first contact, which a credential-only check cannot see.
+device key passes 1, 2, 3 and 9; only the directory's `identity_pk` stops it.
+Checks 6–8 make a replaced, withdrawn, not-yet-valid, expired, or revoked
+device unreachable for first contact. In particular, accepting a matching
+`device_pk` instead of the complete published credential would preserve the
+longer lifetime of a stale package after the owner replaced that credential.
 
-The reference implementation makes this structural rather than remembered:
+The reference implementation's safe first-party route makes this structural:
 `f2z_msg_mls::VerifiedKeyPackage` has no constructor but the verifying one, and
-`MlsEngine::add_member` takes that type instead of bytes. That is a suggestion
-about how to build it, not a wire requirement — but the requirement that the
-check happen is normative, and an implementation that leaves it to a comment has
-not met it.
+`MlsEngine::add_member` takes that type instead of bytes. Its crate-level public
+API still exposes enough raw OpenMLS capabilities for an external caller to go
+around that wrapper; [#903](https://github.com/free2z/zuu/issues/903) tracks
+sealing that escape. This is an implementation status disclosure, not a
+weakening of the wire requirement: every client MUST perform all nine checks
+before proposing the Add.
 
 #### 12.6.6 Exhaustion, and the package of last resort
 

--- a/rs/crates/f2z-kt-client/src/client.rs
+++ b/rs/crates/f2z-kt-client/src/client.rs
@@ -1,4 +1,6 @@
-//! `KtClient` — `KT.md` §8.1's eight steps, in order, with no way to skip one.
+//! `KtClient` — `KT.md` §8.1's verification and pinning steps, in order, with
+//! no way to skip one. Device selection is exposed on the verified result so
+//! callers apply §8.1 step 9 without reimplementing its policy.
 //!
 //! # The order is the security property
 //!

--- a/rs/crates/f2z-kt-client/src/resolve.rs
+++ b/rs/crates/f2z-kt-client/src/resolve.rs
@@ -34,7 +34,7 @@
 //! rendering it cannot mistake it for a check that passed.
 
 use f2z_codec::types::PublicKey;
-use f2z_kt_core::entry::{DirectoryEntry, EntryKind};
+use f2z_kt_core::entry::{DeviceCredential, DirectoryEntry, EntryKind};
 use f2z_kt_core::types::Handle;
 
 use crate::standing::WitnessStanding;
@@ -127,6 +127,29 @@ impl ResolvedHandle {
     #[must_use]
     pub const fn identity_pk(&self) -> &PublicKey {
         &self.entry.entry.identity_pk
+    }
+
+    /// Credentials eligible for lookup-driven first contact at the verifier's
+    /// local time: published, inside the common skew-aware interval, and not
+    /// present in the entry's cumulative revocation history.
+    pub fn active_devices_at(
+        &self,
+        verifier_time_ms: u64,
+    ) -> impl Iterator<Item = &DeviceCredential> {
+        self.entry.entry.active_devices_at(verifier_time_ms)
+    }
+
+    /// Select one published device only if it is currently eligible for first
+    /// contact under the same rule.
+    #[must_use]
+    pub fn active_device_at(
+        &self,
+        device_pk: &PublicKey,
+        verifier_time_ms: u64,
+    ) -> Option<&DeviceCredential> {
+        self.entry
+            .entry
+            .active_device_at(device_pk, verifier_time_ms)
     }
 
     /// `entry_version` (§4.2).

--- a/rs/crates/f2z-kt-client/tests/acceptance.rs
+++ b/rs/crates/f2z-kt-client/tests/acceptance.rs
@@ -533,6 +533,47 @@ fn two_handle_lookups_accept_the_same_complete_head_as_a_no_op() {
     assert!(client.pins().get(&handle("bob")).is_some());
 }
 
+#[test]
+fn lookup_selects_only_unrevoked_credentials_inside_the_shared_window() {
+    let mut deployment = Deployment::new("client-active-devices");
+    let identity = Identity::from_byte(1);
+    let skew = f2z_kt_core::entry::DEVICE_CREDENTIAL_CLOCK_SKEW_MS;
+    let active = Key::from_byte(0x20).public;
+    let future = Key::from_byte(0x21).public;
+    let expired = Key::from_byte(0x22).public;
+    let revoked = Key::from_byte(0x23).public;
+    let entry = EntryBuilder::first(deployment.harness.log_id, "alice", &identity)
+        .device_window(0x20, &identity.isk, NOW - 1, NOW + 1)
+        .device_window(0x21, &identity.isk, NOW + skew + 1, NOW + skew + 2)
+        .device_window(0x22, &identity.isk, NOW - skew - 2, NOW - skew - 1)
+        .device_window(0x23, &identity.isk, NOW - 1, NOW + 1)
+        .revocation(revoked, NOW, b"lost")
+        .same_key(&identity.dak);
+    deployment.setup.block_on(async {
+        deployment
+            .harness
+            .log
+            .submit(&deployment.harness.envelope(&entry, &identity, NOW), NOW)
+            .await
+            .unwrap();
+        deployment.harness.log.publish_epoch(NOW).await.unwrap();
+    });
+    deployment.cosign(NOW + 1);
+
+    let mut client = deployment.client(1);
+    let resolution = client.resolve(&handle("alice"), NOW).unwrap();
+    let resolved = resolution.resolved().unwrap();
+    let selected: Vec<_> = resolved
+        .active_devices_at(NOW)
+        .map(|credential| credential.credential.device_pk)
+        .collect();
+    assert_eq!(selected, vec![active]);
+    assert!(resolved.active_device_at(&active, NOW).is_some());
+    assert!(resolved.active_device_at(&future, NOW).is_none());
+    assert!(resolved.active_device_at(&expired, NOW).is_none());
+    assert!(resolved.active_device_at(&revoked, NOW).is_none());
+}
+
 // ---------------------------------------------------------------------------
 // 2. A tampered proof.
 // ---------------------------------------------------------------------------

--- a/rs/crates/f2z-kt-core/src/entry.rs
+++ b/rs/crates/f2z-kt-core/src/entry.rs
@@ -35,6 +35,28 @@ use crate::labels::{
 };
 use crate::types::{Handle, KemPublicKey, LogId, check_label, label_field};
 
+/// The fixed v1 tolerance for verifier-clock disagreement: two minutes.
+///
+/// This is deliberately a protocol constant rather than log-published policy.
+/// A log must not be able to extend the useful lifetime of a credential, and
+/// an offline MLS peer must be able to apply the same rule without consulting
+/// the directory.
+pub const DEVICE_CREDENTIAL_CLOCK_SKEW_MS: u64 = 120_000;
+
+/// A device credential's status under the common v1 verifier-time rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CredentialValidity {
+    /// The verifier is earlier than `not_before_ms`, even after the fixed skew
+    /// allowance.
+    NotYetValid,
+    /// The verifier's clock falls inside the skew-expanded inclusive interval.
+    Valid,
+    /// The verifier is later than `not_after_ms`, even after the fixed skew
+    /// allowance.
+    Expired,
+}
+
 /// The `DeviceCredentialTBS` of §4.1 — what the user's `IdentitySigningKey`
 /// signs.
 #[derive(Clone, Debug, PartialEq, Eq, TlsSize, TlsSerializeBytes, TlsDeserializeBytes)]
@@ -70,11 +92,8 @@ impl DeviceCredentialTBS {
         if self.device_kem_pk.is_empty() {
             return Err(KtError::Malformed);
         }
-        // Invented here: §4.1 gives the two fields and no ordering rule. A
-        // credential whose window is empty or inverted can never be valid at any
-        // instant, so accepting one would put a permanently-dead credential in an
-        // append-only record. `not_after_ms == not_before_ms` is refused too: an
-        // instantaneous credential is not a credential.
+        // §4.1: an empty or inverted interval has no valid instant and is
+        // malformed rather than merely inactive.
         if self.not_after_ms <= self.not_before_ms {
             return Err(KtError::Malformed);
         }
@@ -88,6 +107,26 @@ impl DeviceCredentialTBS {
     /// [`KtError::Malformed`] if the structure cannot be encoded.
     pub fn signing_bytes(&self) -> Result<Vec<u8>, KtError> {
         encode(self).map_err(KtError::from)
+    }
+
+    /// Classify this credential at a verifier's local Unix time.
+    ///
+    /// Both interval endpoints and both skew boundaries are inclusive. The
+    /// additions saturate so values near the Unix-time representation's ends
+    /// fail safely without wrapping into the opposite side of the interval.
+    #[must_use]
+    pub const fn validity_at(&self, verifier_time_ms: u64) -> CredentialValidity {
+        if verifier_time_ms.saturating_add(DEVICE_CREDENTIAL_CLOCK_SKEW_MS) < self.not_before_ms {
+            CredentialValidity::NotYetValid
+        } else if verifier_time_ms
+            > self
+                .not_after_ms
+                .saturating_add(DEVICE_CREDENTIAL_CLOCK_SKEW_MS)
+        {
+            CredentialValidity::Expired
+        } else {
+            CredentialValidity::Valid
+        }
     }
 }
 
@@ -571,10 +610,66 @@ impl DirectoryEntryTBS {
             }
         }
 
+        // §4.4: one immutable revocation record per device key. Two records for
+        // one key either repeat an event or disagree about its time/reason; in
+        // both cases there is no canonical cumulative history to carry forward.
+        for (index, revocation) in self.revocations.as_slice().iter().enumerate() {
+            for other in self
+                .revocations
+                .as_slice()
+                .iter()
+                .skip(index.saturating_add(1))
+            {
+                if revocation.device_pk == other.device_pk {
+                    return Err(KtError::Malformed);
+                }
+            }
+        }
+
         for endpoint in self.contact_endpoints.as_slice() {
             endpoint.validate()?;
         }
         Ok(())
+    }
+
+    /// Whether this entry records `device_pk` as permanently revoked.
+    #[must_use]
+    pub fn is_revoked(&self, device_pk: &PublicKey) -> bool {
+        self.revocations
+            .as_slice()
+            .iter()
+            .any(|revocation| &revocation.device_pk == device_pk)
+    }
+
+    /// The published credential for `device_pk`, only when it is usable now.
+    ///
+    /// This is the shared selection rule for directory lookup and first
+    /// contact: the credential must be present, inside the common validity
+    /// window, and absent from the cumulative revocation set.
+    #[must_use]
+    pub fn active_device_at(
+        &self,
+        device_pk: &PublicKey,
+        verifier_time_ms: u64,
+    ) -> Option<&DeviceCredential> {
+        if self.is_revoked(device_pk) {
+            return None;
+        }
+        self.devices.as_slice().iter().find(|credential| {
+            &credential.credential.device_pk == device_pk
+                && credential.credential.validity_at(verifier_time_ms) == CredentialValidity::Valid
+        })
+    }
+
+    /// Every published credential usable at `verifier_time_ms`.
+    pub fn active_devices_at(
+        &self,
+        verifier_time_ms: u64,
+    ) -> impl Iterator<Item = &DeviceCredential> {
+        self.devices.as_slice().iter().filter(move |credential| {
+            self.active_device_at(&credential.credential.device_pk, verifier_time_ms)
+                .is_some()
+        })
     }
 
     /// The exact bytes the `DirectoryAuthKey` signs (§4.4).
@@ -743,6 +838,100 @@ mod tests {
             .clone();
         entry.entry.devices = VecU16::new(vec![credential.clone(), credential]);
         assert_eq!(entry.entry.validate(), Err(KtError::Malformed));
+    }
+
+    #[test]
+    fn credential_time_boundaries_include_exactly_the_fixed_skew() {
+        let directory = TestDirectory::new();
+        let entry = directory.genesis();
+        let mut credential = entry.entry.devices.as_slice()[0].credential.clone();
+        credential.not_before_ms = 1_000_000;
+        credential.not_after_ms = 2_000_000;
+        let skew = DEVICE_CREDENTIAL_CLOCK_SKEW_MS;
+
+        assert_eq!(
+            credential.validity_at(credential.not_before_ms - skew - 1),
+            CredentialValidity::NotYetValid
+        );
+        assert_eq!(
+            credential.validity_at(credential.not_before_ms - skew),
+            CredentialValidity::Valid
+        );
+        assert_eq!(
+            credential.validity_at(credential.not_before_ms),
+            CredentialValidity::Valid
+        );
+        assert_eq!(
+            credential.validity_at(credential.not_after_ms),
+            CredentialValidity::Valid
+        );
+        assert_eq!(
+            credential.validity_at(credential.not_after_ms + skew),
+            CredentialValidity::Valid
+        );
+        assert_eq!(
+            credential.validity_at(credential.not_after_ms + skew + 1),
+            CredentialValidity::Expired
+        );
+    }
+
+    #[test]
+    fn empty_or_inverted_credential_intervals_are_malformed() {
+        let directory = TestDirectory::new();
+        let mut entry = directory.genesis();
+        let mut devices = entry.entry.devices.clone().into_vec();
+        devices[0].credential.not_after_ms = devices[0].credential.not_before_ms;
+        entry.entry.devices = VecU16::new(devices.clone());
+        assert_eq!(entry.entry.validate(), Err(KtError::Malformed));
+
+        devices[0].credential.not_after_ms = devices[0].credential.not_before_ms.saturating_sub(1);
+        entry.entry.devices = VecU16::new(devices);
+        assert_eq!(entry.entry.validate(), Err(KtError::Malformed));
+    }
+
+    #[test]
+    fn duplicate_or_contradictory_revocations_are_malformed() {
+        let directory = TestDirectory::new();
+        let mut entry = directory.genesis();
+        let device_pk = entry.entry.devices.as_slice()[0].credential.device_pk;
+        let first = DeviceRevocation {
+            device_pk,
+            revoked_at_ms: 1_700_000_000_000,
+            reason: ShortBytes::new(b"lost".to_vec()).unwrap(),
+        };
+        let contradictory = DeviceRevocation {
+            device_pk,
+            revoked_at_ms: first.revoked_at_ms + 1,
+            reason: ShortBytes::new(b"stolen".to_vec()).unwrap(),
+        };
+        entry.entry.revocations = VecU16::new(vec![first, contradictory]);
+        assert_eq!(entry.entry.validate(), Err(KtError::Malformed));
+    }
+
+    #[test]
+    fn active_device_selection_combines_lifetime_and_revocation() {
+        let directory = TestDirectory::new();
+        let mut entry = directory.genesis();
+        let device_pk = entry.entry.devices.as_slice()[0].credential.device_pk;
+        let inside = entry.entry.devices.as_slice()[0].credential.not_before_ms;
+        assert!(entry.entry.active_device_at(&device_pk, inside).is_some());
+        assert_eq!(entry.entry.active_devices_at(inside).count(), 1);
+
+        entry.entry.revocations = VecU16::new(vec![DeviceRevocation {
+            device_pk,
+            revoked_at_ms: inside,
+            reason: ShortBytes::new(b"compromised".to_vec()).unwrap(),
+        }]);
+        assert!(entry.entry.active_device_at(&device_pk, inside).is_none());
+        assert_eq!(entry.entry.active_devices_at(inside).count(), 0);
+
+        entry.entry.revocations = VecU16::new(Vec::new());
+        let expired = entry.entry.devices.as_slice()[0]
+            .credential
+            .not_after_ms
+            .saturating_add(DEVICE_CREDENTIAL_CLOCK_SKEW_MS)
+            .saturating_add(1);
+        assert!(entry.entry.active_device_at(&device_pk, expired).is_none());
     }
 
     #[test]

--- a/rs/crates/f2z-kt-core/src/submit.rs
+++ b/rs/crates/f2z-kt-core/src/submit.rs
@@ -61,7 +61,7 @@
 use f2z_codec::canonical::decode_canonical;
 use f2z_codec::types::{Digest, PublicKey};
 
-use crate::entry::{DirectoryEntry, EntryAuthorization};
+use crate::entry::{DeviceRevocation, DirectoryEntry, EntryAuthorization};
 use crate::error::KtError;
 use crate::labels::{akd_label, entry_value, prev_entry_hash};
 use crate::sig;
@@ -135,6 +135,7 @@ pub struct PublishedEntry {
     chain_hash: Digest,
     identity_pk: PublicKey,
     directory_auth_pk: PublicKey,
+    revocations: Vec<DeviceRevocation>,
     no_reset: bool,
 }
 
@@ -154,6 +155,7 @@ impl PublishedEntry {
             chain_hash: entry.chain_hash()?,
             identity_pk: entry.entry.identity_pk,
             directory_auth_pk: entry.entry.directory_auth_pk,
+            revocations: entry.entry.revocations.as_slice().to_vec(),
             no_reset: entry.entry.no_reset != 0,
         })
     }
@@ -188,6 +190,12 @@ impl PublishedEntry {
     #[must_use]
     pub const fn directory_auth_pk(&self) -> &PublicKey {
         &self.directory_auth_pk
+    }
+
+    /// The immutable revocation prefix every successor must retain.
+    #[must_use]
+    pub fn revocations(&self) -> &[DeviceRevocation] {
+        &self.revocations
     }
 
     /// Whether this handle has foreclosed the platform reset path (ADR 0014).
@@ -315,9 +323,9 @@ impl AcceptedSubmission {
 ///   The wire code is `ERR_BAD_AUTHORIZATION`: *structurally valid but §4.4's
 ///   rules unmet — e.g. a key change with one signature.*
 /// - [`KtError::BadSignature`] — any signature that did not verify, including
-///   rule 6's `RotationProof`, rule 7's reset and rule 8's device credentials.
-/// - [`KtError::Cooldown`] — rule 7's timing half.
-/// - [`KtError::DuplicateInEpoch`] — rule 9.
+///   rule 7's `RotationProof`, rule 8's reset and rule 9's device credentials.
+/// - [`KtError::Cooldown`] — rule 8's timing half.
+/// - [`KtError::DuplicateInEpoch`] — rule 10.
 pub fn validate_submission(
     submitted: &[u8],
     context: &SubmissionContext<'_>,
@@ -332,7 +340,7 @@ pub fn validate_submission(
     let entry = decoded.value().clone();
     let canonical = decoded.bytes().to_vec();
 
-    // ---- Rules 2, 3 (charset), 5 (kind agreement) and 8 (duplicate device
+    // ---- Rules 2, 3 (charset), 5 (kind agreement) and 9 (duplicate device
     // ---- keys), plus the shape checks a decode cannot express. ---------------
     //
     // `DirectoryEntry::validate` checks the label first, per §6.2's "a verifier
@@ -368,6 +376,24 @@ pub fn validate_submission(
                 return Err(KtError::VersionConflict);
             }
         }
+    }
+
+    // ---- Rule 9. Device revocations are cumulative. -------------------------
+    //
+    // `DirectoryEntryTBS::validate` has already required one record per
+    // device key. Requiring the predecessor's whole vector as an exact prefix
+    // makes each record immutable as well as permanent: a successor may only
+    // append, never omit, reorder, change the timestamp/reason, or "un-revoke"
+    // a device. This runs before any authorization signature or assertion
+    // work, so a rejected history earns neither persistence nor a receipt.
+    if let Some(previous) = context.previous
+        && !entry
+            .entry
+            .revocations
+            .as_slice()
+            .starts_with(previous.revocations())
+    {
+        return Err(KtError::BadAuthorization);
     }
 
     // ---- Rule 5. The authorization table of §4.4. ---------------------------
@@ -559,7 +585,7 @@ pub fn validate_submission(
         }
     }
 
-    // ---- Rule 8. Device credentials. ----------------------------------------
+    // ---- Rule 9. Device credentials. ----------------------------------------
     //
     // "Every `DeviceCredential` signature verifies under **this entry's**
     // `identity_pk`" — under the entry's key, not under the key the credential
@@ -581,7 +607,7 @@ pub fn validate_submission(
         )?;
     }
 
-    // ---- Rule 9. §4.3's uniqueness rule. ------------------------------------
+    // ---- Rule 10. §4.3's uniqueness rule. -----------------------------------
     //
     // "The log MUST accept at most one entry per handle per epoch." Last in
     // §4.4's order, and it is not a convenience rule: it is the mitigation for
@@ -615,7 +641,7 @@ mod tests {
     use super::*;
     use crate::testing::{TestDirectory, signing_key};
     use f2z_codec::canonical::Canonical as _;
-    use f2z_codec::types::Signature;
+    use f2z_codec::types::{ShortBytes, Signature};
 
     fn accept(
         directory: &TestDirectory,
@@ -675,6 +701,65 @@ mod tests {
             accept(&directory, &update, Some(&published), 0),
             Err(KtError::VersionConflict),
             "a truncated or substituted history has to break a hash, not merely omit a proof",
+        );
+    }
+
+    #[test]
+    fn revocation_history_is_an_immutable_cumulative_prefix() {
+        let directory = TestDirectory::new();
+        let mut genesis = directory.genesis();
+        let first_device = genesis.entry.devices.as_slice()[0].credential.device_pk;
+        let first = DeviceRevocation {
+            device_pk: first_device,
+            revoked_at_ms: 1_700_000_000_000,
+            reason: ShortBytes::new(b"lost".to_vec()).unwrap(),
+        };
+        genesis.entry.revocations = f2z_codec::vec::VecU16::new(vec![first.clone()]);
+        let genesis = directory.reauthorize_genesis(genesis);
+        let published = accept(&directory, &genesis, None, 0)
+            .unwrap()
+            .published()
+            .unwrap();
+
+        let carried = directory.same_key_update(&genesis);
+        assert!(
+            accept(&directory, &carried, Some(&published), 0).is_ok(),
+            "an exact retained prefix remains admissible"
+        );
+
+        let mut dropped = carried.clone();
+        dropped.entry.revocations = f2z_codec::vec::VecU16::new(Vec::new());
+        let dropped = directory.reauthorize_same_key(dropped, &genesis);
+        assert_eq!(
+            accept(&directory, &dropped, Some(&published), 0),
+            Err(KtError::BadAuthorization),
+            "omitting a prior revocation must not un-revoke its key"
+        );
+
+        let mut changed = carried.clone();
+        let mut records = changed.entry.revocations.clone().into_vec();
+        records[0].reason = ShortBytes::new(b"different".to_vec()).unwrap();
+        changed.entry.revocations = f2z_codec::vec::VecU16::new(records);
+        let changed = directory.reauthorize_same_key(changed, &genesis);
+        assert_eq!(
+            accept(&directory, &changed, Some(&published), 0),
+            Err(KtError::BadAuthorization),
+            "a successor cannot rewrite an accepted revocation"
+        );
+
+        let mut appended = carried;
+        let second = DeviceRevocation {
+            device_pk: PublicKey::new([0x91; 32]),
+            revoked_at_ms: first.revoked_at_ms.saturating_add(1),
+            reason: ShortBytes::new(b"retired".to_vec()).unwrap(),
+        };
+        let mut records = appended.entry.revocations.clone().into_vec();
+        records.push(second);
+        appended.entry.revocations = f2z_codec::vec::VecU16::new(records);
+        let appended = directory.reauthorize_same_key(appended, &genesis);
+        assert!(
+            accept(&directory, &appended, Some(&published), 0).is_ok(),
+            "new unique revocations append after the immutable prefix"
         );
     }
 

--- a/rs/crates/f2z-kt-core/src/testing.rs
+++ b/rs/crates/f2z-kt-core/src/testing.rs
@@ -403,6 +403,7 @@ impl TestDirectory {
         );
         // Something has to differ, or the update is a re-publication. A second
         // contact endpoint is the most boring change §4.1 permits.
+        entry.revocations = previous.entry.revocations.clone();
         entry.contact_endpoints = VecU16::new(vec![
             ContactEndpoint {
                 relay_url: short(b"wss://relay.example/relay/v1"),

--- a/rs/crates/f2z-kt-core/tests/credential_policy_spec.rs
+++ b/rs/crates/f2z-kt-core/tests/credential_policy_spec.rs
@@ -208,6 +208,13 @@ fn credential_policy_is_bound_to_the_normative_spec() {
         "a malformed `</ details>` must not pop the raw HTML container"
     );
 
+    let hidden_by_commonmark_hgroup =
+        KT.replacen("### 4.1 Structure", "<hgroup>\n### 4.1 Structure", 1);
+    assert!(
+        !kt_credential_policy_is_exact(&hidden_by_commonmark_hgroup),
+        "the normative CommonMark hgroup block tag must not hide §4.1"
+    );
+
     for (name, opening, closing) in [
         ("fenced code", "```markdown", "```"),
         ("raw HTML container", "<details>", "</details>"),

--- a/rs/crates/f2z-kt-core/tests/credential_policy_spec.rs
+++ b/rs/crates/f2z-kt-core/tests/credential_policy_spec.rs
@@ -1,0 +1,249 @@
+//! Mutation-sensitive agreement between KT §4.1 and the credential policy.
+
+#![allow(clippy::expect_used)]
+
+use f2z_kt_core::entry::DEVICE_CREDENTIAL_CLOCK_SKEW_MS;
+
+#[path = "../../../tests/support/markdown.rs"]
+mod markdown;
+
+const KT: &str = include_str!("../../../../docs/e2ee/KT.md");
+const DIRECTORY_ENTRY_HEADING: &str = "4. `DirectoryEntry`";
+const STRUCTURE_HEADING: &str = "4.1 Structure";
+const STRUCTURE_POLICY_DIGEST: u64 = 2_518_136_126_776_171_893;
+
+const LIFETIME_POLICY: &str = r#"The interval MUST be non-empty: `not_before_ms < not_after_ms`. The v1
+credential-clock tolerance is a fixed protocol constant,
+`credential_clock_skew_ms = 120000`; it is not log policy and a log cannot
+increase it. At verifier-local Unix time `t`, a credential is valid exactly
+when both `not_before_ms <= saturating_add(t, credential_clock_skew_ms)` and
+`t <= saturating_add(not_after_ms, credential_clock_skew_ms)` hold. Both outer
+boundaries are inclusive. Before the first boundary the result is
+**not-yet-valid**; after the second it is **expired**. Either result excludes the
+credential from lookup-driven first contact and causes an MLS peer validating
+the self-contained credential to reject it."#;
+
+const REVOCATION_POLICY: &str = r#"`revocations` is an append-only cumulative history per handle. A single entry
+MUST NOT contain two records for one `device_pk`, whether identical or
+contradictory. Every successor MUST carry its predecessor's complete vector as
+an exact prefix: existing records cannot be omitted, reordered or edited, and
+new records are appended. This rule crosses identity-key changes and does not
+grant `platform_reset` an un-revocation power. A revocation takes effect when
+the entry containing it is published; `revoked_at_ms` and `reason` are audit and
+display metadata, not a future activation switch. The log MUST apply the
+interval, uniqueness and cumulative-prefix checks during admission, before it
+persists the submission or issues a `SubmissionReceipt`.
+
+A fresh verified lookup therefore teaches a client every revocation published
+for the handle, and first-contact selection MUST exclude both revoked and
+out-of-window credentials. An offline MLS peer has only the credential already
+carried in the group: it can enforce the same time interval from its local
+clock, but it cannot learn a later directory revocation until it performs or
+receives the result of a fresh verified lookup. Publishing a KT revocation does
+not itself remove an existing MLS member or retroactively invalidate messages;
+that requires an MLS state change delivered through the group."#;
+
+fn kt_credential_policy_is_exact(kt: &str) -> bool {
+    let Some(rendered) = markdown::RenderedMarkdown::parse(kt) else {
+        return false;
+    };
+    let expected_children = [
+        "4.1 Structure",
+        "4.2 Versions and the hash chain",
+        "4.3 Uniqueness within an epoch — a MUST that comes from the audit",
+        "4.4 What authorizes an entry",
+        "4.5 `HandleAssertion` — what authorizes a handle's first entry",
+        "4.6 A log with no authority, and why it must say so",
+        "4.7 What a compromised authority can and cannot do",
+    ];
+    let Some(children) = rendered.child_headings(2, DIRECTORY_ENTRY_HEADING, 3) else {
+        return false;
+    };
+    let Some(section) = rendered.section(3, STRUCTURE_HEADING) else {
+        return false;
+    };
+    let lifetime_context = format!(
+        "so it cannot depend on\nits envelope for meaning.\n\n{LIFETIME_POLICY}\n\n```\nstruct {{\n    opaque device_pk[32];"
+    );
+    let revocation_context = format!(
+        "    EntryAuthorization authorization;     /* §4.4 */\n}} DirectoryEntry;\n```\n\n{REVOCATION_POLICY}\n\nNote what is **not** in it:"
+    );
+
+    children == expected_children
+        && kt.matches("### 4.1 Structure").count() == 1
+        && kt.matches(LIFETIME_POLICY).count() == 1
+        && kt.matches(REVOCATION_POLICY).count() == 1
+        && kt.matches(&lifetime_context).count() == 1
+        && kt.matches(&revocation_context).count() == 1
+        && section.contains(LIFETIME_POLICY)
+        && section.contains(REVOCATION_POLICY)
+        && rendered.section_has_raw_html(3, STRUCTURE_HEADING) == Some(false)
+        && markdown::stable_digest(core::iter::once(section)) == STRUCTURE_POLICY_DIGEST
+}
+
+#[test]
+fn credential_policy_is_bound_to_the_normative_spec() {
+    assert_eq!(DEVICE_CREDENTIAL_CLOCK_SKEW_MS, 120_000);
+    let rendered = markdown::RenderedMarkdown::parse(KT).expect("KT must parse fail-closed");
+    let section = rendered
+        .section(3, STRUCTURE_HEADING)
+        .expect("KT §4.1 must be a unique rendered section");
+    assert!(
+        rendered.has_raw_html(),
+        "reviewed AKD claim-marker comments elsewhere in KT remain present"
+    );
+    assert_eq!(
+        rendered.section_has_raw_html(3, STRUCTURE_HEADING),
+        Some(false),
+        "KT §4.1 itself must stay free of raw HTML"
+    );
+    assert_eq!(
+        markdown::stable_digest(core::iter::once(section)),
+        STRUCTURE_POLICY_DIGEST,
+        "the rendered KT §4.1 contract changed"
+    );
+    assert!(kt_credential_policy_is_exact(KT));
+
+    for (name, addition) in [
+        (
+            "advisory",
+            "The interval and revocation requirements above are advisory.",
+        ),
+        (
+            "ignored intervals",
+            "Implementations MAY ignore credential intervals during first contact.",
+        ),
+        (
+            "un-revocation",
+            "A successor MAY remove a prior revocation and re-enable that device.",
+        ),
+    ] {
+        let mutant = KT.replacen(
+            LIFETIME_POLICY,
+            &format!("{LIFETIME_POLICY}\n\n{addition}"),
+            1,
+        );
+        assert!(
+            !kt_credential_policy_is_exact(&mutant),
+            "the exact §4.1 contract survived additive {name} prose"
+        );
+    }
+
+    let indented_visible_continuation = KT.replacen(
+        "Mutable profile data\nbelongs on the platform, where it can be changed and deleted.",
+        "Mutable profile data\nbelongs on the platform, where it can be changed and deleted.\n    Nevertheless, a successor MAY remove a prior revocation and re-enable that device.",
+        1,
+    );
+    assert!(
+        !kt_credential_policy_is_exact(&indented_visible_continuation),
+        "a four-space continuation of §4.1's prose carried a visible un-revocation"
+    );
+
+    for (name, addition) in [
+        (
+            "inline span",
+            "<span>A successor MAY remove a prior revocation and re-enable that device.</span>",
+        ),
+        (
+            "open details container",
+            "<details open>A successor MAY remove a prior revocation and re-enable that device.</details>",
+        ),
+    ] {
+        let visible_html_contradiction = KT.replacen(
+            "Mutable profile data\nbelongs on the platform, where it can be changed and deleted.",
+            &format!(
+                "Mutable profile data\nbelongs on the platform, where it can be changed and deleted.\n\n{addition}"
+            ),
+            1,
+        );
+        assert!(
+            !kt_credential_policy_is_exact(&visible_html_contradiction),
+            "a visible contradiction in {name} escaped the protected §4.1 raw-HTML guard"
+        );
+    }
+
+    let coordinated_hiding = KT
+        .replacen(LIFETIME_POLICY, &format!("<!--\n{LIFETIME_POLICY}"), 1)
+        .replacen(
+            REVOCATION_POLICY,
+            &format!(
+                "{REVOCATION_POLICY}\n-->\n\nImplementations MAY ignore intervals and remove \
+                 prior revocations; the hidden policy is advisory."
+            ),
+            1,
+        );
+    assert!(
+        !kt_credential_policy_is_exact(&coordinated_hiding),
+        "hidden canonical policy plus visible contradictory policy passed"
+    );
+
+    for (name, opening) in [
+        ("quoted greater-than", "<details title=\"a > b\">"),
+        ("quoted self-close token", "<details title=\"/>\">"),
+    ] {
+        let hidden_section = KT
+            .replacen(
+                "### 4.1 Structure",
+                &format!("{opening}\n### 4.1 Structure"),
+                1,
+            )
+            .replacen(
+                "### 4.2 Versions and the hash chain",
+                "</details>\n\n### 4.2 Versions and the hash chain",
+                1,
+            );
+        assert!(
+            !kt_credential_policy_is_exact(&hidden_section),
+            "a {name} must not expose §4.1 hidden in a details container"
+        );
+    }
+
+    let malformed_spaced_close = KT.replacen(
+        "### 4.1 Structure",
+        "<details>\n</ details>\n### 4.1 Structure",
+        1,
+    );
+    assert!(
+        !kt_credential_policy_is_exact(&malformed_spaced_close),
+        "a malformed `</ details>` must not pop the raw HTML container"
+    );
+
+    for (name, opening, closing) in [
+        ("fenced code", "```markdown", "```"),
+        ("raw HTML container", "<details>", "</details>"),
+    ] {
+        let hidden = KT.replacen(
+            LIFETIME_POLICY,
+            &format!("{opening}\n{LIFETIME_POLICY}\n{closing}"),
+            1,
+        );
+        assert!(
+            !kt_credential_policy_is_exact(&hidden),
+            "canonical lifetime policy hidden in {name} passed"
+        );
+    }
+
+    for (name, prefix) in [("blockquote", "> "), ("indented code", "    ")] {
+        let hidden_policy = LIFETIME_POLICY
+            .lines()
+            .map(|line| format!("{prefix}{line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let hidden = KT.replacen(LIFETIME_POLICY, &hidden_policy, 1);
+        assert!(
+            !kt_credential_policy_is_exact(&hidden),
+            "canonical lifetime policy hidden in a {name} passed"
+        );
+    }
+
+    let removed = KT.replacen(&format!("{LIFETIME_POLICY}\n\n"), "", 1);
+    let relocated = removed.replacen(
+        "### 4.2 Versions and the hash chain",
+        &format!("### 4.2 Versions and the hash chain\n\n{LIFETIME_POLICY}"),
+        1,
+    );
+    assert!(
+        !kt_credential_policy_is_exact(&relocated),
+        "canonical lifetime policy relocated outside §4.1 passed"
+    );
+}

--- a/rs/crates/f2z-kt/src/testing.rs
+++ b/rs/crates/f2z-kt/src/testing.rs
@@ -193,7 +193,19 @@ impl EntryBuilder {
     ///
     /// If the KEM key will not fit, which it always will.
     #[must_use]
-    pub fn device(mut self, device_seed: u8, signer: &Key) -> Self {
+    pub fn device(self, device_seed: u8, signer: &Key) -> Self {
+        self.device_window(device_seed, signer, 1_700_000_000_000, 1_900_000_000_000)
+    }
+
+    /// Add a device credential with an explicit validity interval.
+    #[must_use]
+    pub fn device_window(
+        mut self,
+        device_seed: u8,
+        signer: &Key,
+        not_before_ms: u64,
+        not_after_ms: u64,
+    ) -> Self {
         let device = Key::from_byte(device_seed);
         let credential = DeviceCredentialTBS {
             label: label_field(labels::LABEL_DEVICE_CREDENTIAL).unwrap(),
@@ -201,13 +213,24 @@ impl EntryBuilder {
             handle: self.handle.clone(),
             device_pk: device.public,
             device_kem_pk: KemPublicKey::new(vec![device_seed; 1216]).unwrap(),
-            not_before_ms: 1_700_000_000_000,
-            not_after_ms: 1_900_000_000_000,
+            not_before_ms,
+            not_after_ms,
         };
         let signature = signer.sign(&credential.signing_bytes().unwrap());
         self.devices.push(DeviceCredential {
             credential,
             signature,
+        });
+        self
+    }
+
+    /// Append a device revocation record.
+    #[must_use]
+    pub fn revocation(mut self, device_pk: PublicKey, revoked_at_ms: u64, reason: &[u8]) -> Self {
+        self.revocations.push(DeviceRevocation {
+            device_pk,
+            revoked_at_ms,
+            reason: ShortBytes::new(reason.to_vec()).unwrap(),
         });
         self
     }

--- a/rs/crates/f2z-kt/tests/adversarial.rs
+++ b/rs/crates/f2z-kt/tests/adversarial.rs
@@ -63,6 +63,12 @@ async fn publish_and_count(harness: &Harness) -> u64 {
     }
 }
 
+fn submission_journal_bytes(harness: &Harness) -> u64 {
+    std::fs::metadata(harness.dir.join("submissions.log"))
+        .map(|metadata| metadata.len())
+        .unwrap_or(0)
+}
+
 // ---------------------------------------------------------------------------
 // zuu#594 — what authorizes a handle's FIRST entry.
 // ---------------------------------------------------------------------------
@@ -95,6 +101,101 @@ async fn a_first_entry_with_no_authority_assertion_is_refused() {
         0,
         "the tree did not move"
     );
+}
+
+#[tokio::test]
+async fn malformed_credential_or_duplicate_revocation_is_rejected_before_receipt_or_publish() {
+    let harness = Harness::vouched("adv-credential-interval").await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let alice = Identity::from_byte(1);
+    let entry = EntryBuilder::first(harness.log_id, "alice", &alice)
+        .device_window(0x10, &alice.isk, NOW, NOW)
+        .same_key(&alice.dak);
+    let journal_before = submission_journal_bytes(&harness);
+
+    assert_eq!(
+        refusal(
+            harness
+                .log
+                .submit(&harness.envelope(&entry, &alice, NOW), NOW)
+                .await
+        ),
+        ErrorCode::Malformed
+    );
+    assert_eq!(harness.log.pending_count().await, 0);
+    assert_eq!(submission_journal_bytes(&harness), journal_before);
+
+    let device_pk = f2z_kt::testing::Key::from_byte(0x10).public;
+    let contradictory = EntryBuilder::first(harness.log_id, "alice", &alice)
+        .device(0x10, &alice.isk)
+        .revocation(device_pk, NOW, b"lost")
+        .revocation(device_pk, NOW + 1, b"stolen")
+        .same_key(&alice.dak);
+    assert_eq!(
+        refusal(
+            harness
+                .log
+                .submit(&harness.envelope(&contradictory, &alice, NOW), NOW)
+                .await
+        ),
+        ErrorCode::Malformed
+    );
+    assert_eq!(harness.log.pending_count().await, 0);
+    assert_eq!(submission_journal_bytes(&harness), journal_before);
+    assert_eq!(publish_and_count(&harness).await, 0);
+}
+
+#[tokio::test]
+async fn accepted_revocation_cannot_be_dropped_before_receipt_or_publish() {
+    let harness = Harness::vouched("adv-unrevocation").await;
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let alice = Identity::from_byte(1);
+    let device_pk = f2z_kt::testing::Key::from_byte(0x10).public;
+    let first = EntryBuilder::first(harness.log_id, "alice", &alice)
+        .device(0x10, &alice.isk)
+        .same_key(&alice.dak);
+    harness
+        .log
+        .submit(&harness.envelope(&first, &alice, NOW), NOW)
+        .await
+        .unwrap();
+    harness.log.publish_epoch(NOW).await.unwrap();
+
+    let second = EntryBuilder::first(harness.log_id, "alice", &alice)
+        .version(2)
+        .prev_entry_hash(labels::prev_entry_hash(&entry_bytes(&first)))
+        .device(0x10, &alice.isk)
+        .revocation(device_pk, NOW, b"lost")
+        .same_key(&alice.dak);
+    harness
+        .log
+        .submit(&harness.envelope(&second, &alice, NOW), NOW)
+        .await
+        .expect("the first publication of a unique revocation earns a receipt");
+    harness.log.publish_epoch(NOW).await.unwrap();
+    let journal_before_unrevocation = submission_journal_bytes(&harness);
+
+    let unrevoked = EntryBuilder::first(harness.log_id, "alice", &alice)
+        .version(3)
+        .prev_entry_hash(labels::prev_entry_hash(&entry_bytes(&second)))
+        .device(0x10, &alice.isk)
+        .same_key(&alice.dak);
+    assert_eq!(
+        refusal(
+            harness
+                .log
+                .submit(&harness.envelope(&unrevoked, &alice, NOW), NOW)
+                .await
+        ),
+        ErrorCode::BadAuthorization
+    );
+    assert_eq!(harness.log.pending_count().await, 0);
+    assert_eq!(
+        submission_journal_bytes(&harness),
+        journal_before_unrevocation,
+        "a refused un-revocation never reaches durable submission storage"
+    );
+    assert_eq!(publish_and_count(&harness).await, 0);
 }
 
 #[tokio::test]

--- a/rs/crates/f2z-msg-mls/src/credential.rs
+++ b/rs/crates/f2z-msg-mls/src/credential.rs
@@ -75,6 +75,7 @@
 //! `openmls_libcrux_crypto` both do through libcrux.
 
 use f2z_codec::canonical::{decode_canonical, encode as canonical_encode};
+use f2z_kt_core::entry::CredentialValidity;
 
 pub use f2z_kt_core::entry::{DeviceCredential, DeviceCredentialTBS};
 /// The label every `DeviceCredential` carries, re-exported from the one place it
@@ -138,11 +139,14 @@ pub fn validate_at(credential: &DeviceCredential, now_ms: u64) -> Result<(), Cre
         .validate()
         .map_err(|_| CredentialError::Malformed)?;
 
-    // The window, against the caller's clock. `f2z-kt-core` is `no_std` with no
-    // I/O and deliberately has no clock, so "is it valid *now*" is the caller's
-    // question and this is where it is asked.
-    if now_ms < credential.credential.not_before_ms || now_ms > credential.credential.not_after_ms {
-        return Err(CredentialError::Expired);
+    // The caller supplies its clock; the core owns the protocol's one
+    // inclusive, skew-aware classification so directory selection and offline
+    // MLS validation cannot drift apart.
+    match credential.credential.validity_at(now_ms) {
+        CredentialValidity::Valid => {}
+        CredentialValidity::NotYetValid => return Err(CredentialError::NotYetValid),
+        CredentialValidity::Expired => return Err(CredentialError::Expired),
+        _ => return Err(CredentialError::Malformed),
     }
 
     let signing_bytes = credential

--- a/rs/crates/f2z-msg-mls/src/engine.rs
+++ b/rs/crates/f2z-msg-mls/src/engine.rs
@@ -88,7 +88,7 @@ use openmls::prelude::tls_codec::{Deserialize as _, Serialize as _};
 use crate::credential::{DeviceCredential, encode as encode_credential, validate_for_leaf};
 use crate::error::{CredentialError, EngineError, Result};
 use crate::exporter::ExportLabel;
-use crate::keypackage::VerifiedKeyPackage;
+use crate::keypackage::{VerifiedKeyPackage, published_device_for_first_contact};
 use crate::provider::F2zProvider;
 use crate::signer::DeviceSigner;
 use crate::version::ProtocolVersion;
@@ -326,25 +326,16 @@ impl<B: StorageBackend> MlsEngine<B> {
         signature: &[u8],
         now_ms: u64,
     ) -> Result<()> {
-        let credential = entry
-            .devices
-            .as_slice()
-            .iter()
-            .find(|credential| credential.credential.device_pk.as_bytes() == device_pk)
-            .ok_or(EngineError::Credential(CredentialError::DeviceKeyMismatch))?;
-        validate_for_leaf(credential, device_pk, now_ms)?;
-        if credential.credential.identity_pk != entry.identity_pk
-            || credential.credential.handle != entry.handle
-            || entry
-                .revocations
-                .as_slice()
-                .iter()
-                .any(|revoked| revoked.device_pk.as_bytes() == device_pk)
-        {
-            return Err(EngineError::Credential(CredentialError::DeviceKeyMismatch));
-        }
         let public_key = f2z_codec::types::PublicKey::from_slice(device_pk)
-            .map_err(|_| EngineError::Signature)?;
+            .map_err(|_| EngineError::Credential(CredentialError::Malformed))?;
+        let credential = published_device_for_first_contact(entry, &public_key, now_ms)?;
+        validate_for_leaf(credential, device_pk, now_ms)?;
+        if credential.credential.identity_pk != entry.identity_pk {
+            return Err(EngineError::Credential(CredentialError::BadSignature));
+        }
+        if credential.credential.handle != entry.handle {
+            return Err(EngineError::Credential(CredentialError::InvalidHandle));
+        }
         let signature = f2z_codec::types::Signature::from_slice(signature)
             .map_err(|_| EngineError::Signature)?;
         f2z_kt_core::sig::verify(&public_key, payload, &signature)
@@ -547,13 +538,14 @@ impl<B: StorageBackend> MlsEngine<B> {
     /// Add a member from their published `KeyPackage`, returning the commit and
     /// the `Welcome`, both ready for the wire.
     ///
-    /// **The argument is a [`VerifiedKeyPackage`], not bytes**, and that is the
-    /// whole of `WIRE.md` §12.6's authentication requirement expressed as a
+    /// **The argument is a [`VerifiedKeyPackage`], not bytes**, so this safe
+    /// wrapper expresses `WIRE.md` §12.6's authentication requirement as a
     /// type. A key package is fetched from a relay the design assumes is
     /// hostile; one used without being checked against the directory entry the
     /// key-transparency log proved is [#133](https://github.com/free2z/zuu/issues/133)
     /// reintroduced at first contact. There is no constructor for that type
-    /// except the one that performs the check — see [`crate::keypackage`].
+    /// except the one that performs the check — see [`crate::keypackage`]. The
+    /// raw public OpenMLS escape outside this wrapper is tracked in #903.
     ///
     /// The credential is validated again here, against this call's clock, and
     /// **before** the Add is proposed: a device that added a peer and then

--- a/rs/crates/f2z-msg-mls/src/error.rs
+++ b/rs/crates/f2z-msg-mls/src/error.rs
@@ -93,8 +93,24 @@ pub enum CredentialError {
     /// The `IdentitySigningKey` signature over the credential body does not
     /// verify.
     BadSignature,
-    /// `not_before`/`not_after` do not bracket the time it was checked at.
+    /// The verifier is earlier than the credential's skew-adjusted inclusive
+    /// `not_before` boundary.
+    NotYetValid,
+    /// The verifier is later than the credential's skew-adjusted inclusive
+    /// `not_after` boundary.
     Expired,
+    /// The verified directory entry publishes no credential for this device
+    /// key.
+    DeviceNotPublished,
+    /// The verified directory entry permanently revokes this device key.
+    DeviceRevoked,
+    /// A credential with this device key is published, but the presented
+    /// credential is not exactly that complete signed credential.
+    ///
+    /// Credential equality covers every TBS field and the identity signature.
+    /// Comparing only `device_pk` would let a relay keep an older credential's
+    /// longer offline validity after the directory published its replacement.
+    PublishedCredentialMismatch,
     /// The credential's `device_pk` is not the leaf's `signature_key`.
     ///
     /// **This is the binding.** A credential that is internally valid but
@@ -114,7 +130,15 @@ impl fmt::Display for CredentialError {
             Self::Malformed => "the credential could not be parsed",
             Self::WrongType => "the credential is not a free2z/device-credential/v1",
             Self::BadSignature => "the identity signature over the credential does not verify",
-            Self::Expired => "the credential is not valid at this time",
+            Self::NotYetValid => "the credential is not valid yet",
+            Self::Expired => "the credential has expired",
+            Self::DeviceNotPublished => {
+                "the directory does not publish a credential for this device key"
+            }
+            Self::DeviceRevoked => "the directory records this device key as revoked",
+            Self::PublishedCredentialMismatch => {
+                "the presented credential is not the complete credential the directory publishes"
+            }
             Self::DeviceKeyMismatch => "the credential does not describe this leaf's device key",
             Self::InvalidHandle => "the credential's handle is not a valid messaging handle",
         })
@@ -177,6 +201,9 @@ mod tests {
         let errors = [
             EngineError::Signature,
             EngineError::Credential(CredentialError::DeviceKeyMismatch),
+            EngineError::Credential(CredentialError::DeviceNotPublished),
+            EngineError::Credential(CredentialError::DeviceRevoked),
+            EngineError::Credential(CredentialError::PublishedCredentialMismatch),
             EngineError::Mls("process_message"),
             EngineError::GroupIdMismatch,
             EngineError::GroupStateUnavailable {

--- a/rs/crates/f2z-msg-mls/src/keypackage.rs
+++ b/rs/crates/f2z-msg-mls/src/keypackage.rs
@@ -21,14 +21,16 @@
 //! the `Welcome` is encrypted to, which is [#133][i133] reintroduced at the one
 //! moment the whole design is about.
 //!
-//! So there is no way to reach [`MlsEngine::add_member`] without one of these.
+//! [`MlsEngine::add_member`] cannot be called without one of these.
 //! [`VerifiedKeyPackage`] has no public constructor and no public fields; the
 //! only way to obtain one is [`VerifiedKeyPackage::verify`], which takes the
-//! directory entry. That is this repository's *one door and no windows* idiom —
-//! the same shape `f2z-relay-store`'s `Committed` and `f2z-kt`'s
-//! `AdmittedSubmission` use — and it is used here because "remember to check
-//! the credential" is exactly the kind of rule that survives review and does
-//! not survive the next refactor.
+//! directory entry. That makes the safe first-party wrapper structural rather
+//! than remembered. It does not yet seal the crate's entire public API:
+//! external callers can combine its raw OpenMLS group, provider, and signer
+//! capabilities to invoke OpenMLS directly. [#903][i903] tracks replacing that
+//! escape with an opaque capability boundary. Until then, first-party callers
+//! MUST use the wrapper and this structural claim applies to the wrapper, not
+//! to every operation expressible through the public crate API.
 //!
 //! # What is checked, and what each check stops
 //!
@@ -39,7 +41,8 @@
 //! | The credential parses as a `DeviceCredential` | A bare handle in a `BasicCredential`, which binds nothing. |
 //! | The credential's signature verifies under the **directory's** `identity_pk` | **The MITM.** Any relay-chosen package. |
 //! | The credential's `handle` is the entry's handle | A genuine credential for a different person, served for this handle. |
-//! | `device_pk` is a device the entry publishes | A genuine credential the owner has not put in the directory — an old one, or one issued to a device the identity key signed for and then withdrew. |
+//! | The complete signed credential exactly equals the one the entry publishes | A relay retaining an older credential for the same device key can retain its longer offline lifetime after the owner replaces it. |
+//! | The published credential is valid at the verifier's clock under KT's shared inclusive skew rule | A not-yet-valid or expired device remains reachable for first contact. |
 //! | `device_pk` is not in the entry's `revocations` | A stolen device that is still able to receive first contact after the owner published the revocation. |
 //! | The leaf's `signature_key` is the credential's `device_pk` | A genuine credential presented in somebody else's leaf — the substitution the identity→device binding of §4.2 exists to stop. |
 //!
@@ -62,9 +65,10 @@
 //! [tm33]: https://github.com/free2z/zuu/blob/main/docs/e2ee/THREAT-MODEL.md#33-compromised-relay-operator-third-party-or-ours
 //! [tm412]: https://github.com/free2z/zuu/blob/main/docs/e2ee/THREAT-MODEL.md
 //! [i133]: https://github.com/free2z/zuu/issues/133
+//! [i903]: https://github.com/free2z/zuu/issues/903
 //! [`MlsEngine::add_member`]: crate::MlsEngine::add_member
 
-use f2z_kt_core::entry::DirectoryEntryTBS;
+use f2z_kt_core::entry::{CredentialValidity, DeviceCredential, DirectoryEntryTBS};
 use openmls::prelude::tls_codec::DeserializeBytes as _;
 use openmls::prelude::{KeyPackage, MlsMessageBodyIn, MlsMessageIn, ProtocolVersion};
 use openmls_traits::crypto::OpenMlsCrypto;
@@ -78,10 +82,11 @@ use crate::error::{CredentialError, EngineError, Result};
 /// A peer's `KeyPackage`, checked against the directory entry that vouches for
 /// it.
 ///
-/// Constructible only through [`VerifiedKeyPackage::verify`]. That is the
-/// point: [`crate::MlsEngine::add_member`] takes one of these, so there is no
-/// path from *bytes a relay handed us* to *a member of a group* that does not
-/// pass through the directory.
+/// Constructible only through [`VerifiedKeyPackage::verify`]. The safe
+/// [`crate::MlsEngine::add_member`] wrapper takes one of these, so there is no
+/// path through that wrapper from *bytes a relay handed us* to *a member of a
+/// group* that does not pass through the directory. See the module-level
+/// disclosure about the still-public raw OpenMLS escape tracked in #903.
 #[derive(Clone)]
 pub struct VerifiedKeyPackage {
     key_package: KeyPackage,
@@ -117,7 +122,8 @@ impl VerifiedKeyPackage {
     /// under RFC 9420, or use a ciphersuite other than [`CIPHERSUITE`];
     /// [`EngineError::Credential`] if the credential does not parse, does not
     /// verify under the entry's identity key, names a different handle,
-    /// describes a device the entry does not publish, describes a revoked
+    /// describes a device the entry does not publish, differs from the complete
+    /// credential the entry publishes for that device key, describes a revoked
     /// device, or does not bind to the leaf it arrived in.
     pub fn verify(
         wire: &[u8],
@@ -155,25 +161,22 @@ impl VerifiedKeyPackage {
             return Err(EngineError::Credential(CredentialError::InvalidHandle));
         }
 
-        // The entry publishes the device set. A credential the identity key
-        // signed but the owner never published — an old one, or one for a
-        // device since withdrawn — is not a device this handle speaks through.
+        // First contact uses the same publication, validity and cumulative
+        // revocation rule as directory selection, but needs the rejected state
+        // rather than an `Option` so diagnostics do not call every inactive
+        // device a leaf-key mismatch.
         let device_pk = credential.credential.device_pk;
-        if !entry
-            .devices
-            .as_slice()
-            .iter()
-            .any(|published| published.credential.device_pk == device_pk)
-        {
-            return Err(EngineError::Credential(CredentialError::DeviceKeyMismatch));
-        }
-        if entry
-            .revocations
-            .as_slice()
-            .iter()
-            .any(|revoked| revoked.device_pk == device_pk)
-        {
-            return Err(EngineError::Credential(CredentialError::DeviceKeyMismatch));
+        let published = published_device_for_first_contact(entry, &device_pk, now_ms)?;
+
+        // A device key is not a credential identity. Both values came through
+        // canonical decoding, and `DeviceCredential` equality covers the full
+        // TBS plus its signature. Requiring exact equality prevents a hostile
+        // relay from retaining an older credential for the same DSK after the
+        // directory publishes a shorter-lived replacement.
+        if published != &credential {
+            return Err(EngineError::Credential(
+                CredentialError::PublishedCredentialMismatch,
+            ));
         }
 
         Ok(Self {
@@ -220,6 +223,32 @@ impl VerifiedKeyPackage {
 
     pub(crate) const fn inner(&self) -> &KeyPackage {
         &self.key_package
+    }
+}
+
+/// Select one published device for a first-contact proof without erasing why
+/// an inactive device was refused.
+pub(crate) fn published_device_for_first_contact<'a>(
+    entry: &'a DirectoryEntryTBS,
+    device_pk: &f2z_codec::types::PublicKey,
+    now_ms: u64,
+) -> core::result::Result<&'a DeviceCredential, CredentialError> {
+    let published = entry
+        .devices
+        .as_slice()
+        .iter()
+        .find(|credential| &credential.credential.device_pk == device_pk)
+        .ok_or(CredentialError::DeviceNotPublished)?;
+
+    if entry.is_revoked(device_pk) {
+        return Err(CredentialError::DeviceRevoked);
+    }
+
+    match published.credential.validity_at(now_ms) {
+        CredentialValidity::Valid => Ok(published),
+        CredentialValidity::NotYetValid => Err(CredentialError::NotYetValid),
+        CredentialValidity::Expired => Err(CredentialError::Expired),
+        _ => Err(CredentialError::Malformed),
     }
 }
 

--- a/rs/crates/f2z-msg-mls/tests/credential.rs
+++ b/rs/crates/f2z-msg-mls/tests/credential.rs
@@ -17,6 +17,7 @@
 )]
 
 use f2z_codec::types::{PublicKey, ShortBytes};
+use f2z_kt_core::entry::DEVICE_CREDENTIAL_CLOCK_SKEW_MS;
 use f2z_msg_mls::credential::{encode, parse, validate_at, validate_for_leaf};
 use f2z_msg_mls::{CredentialError, DeviceSigner};
 
@@ -73,19 +74,23 @@ fn editing_the_device_key_breaks_the_signature_before_it_breaks_the_binding() {
 }
 
 #[test]
-fn a_credential_outside_its_validity_window_is_rejected_at_both_ends() {
+fn credential_boundaries_apply_the_shared_skew_and_distinguish_too_early() {
     let (credential, device) = issue_credential("alice", 11, 111, NOW - 1000, NOW + 1000);
+    let not_before = credential.credential.not_before_ms;
+    let not_after = credential.credential.not_after_ms;
+    let skew = DEVICE_CREDENTIAL_CLOCK_SKEW_MS;
     assert_eq!(
-        validate_for_leaf(&credential, device.public_key(), NOW - 100_000),
+        validate_for_leaf(&credential, device.public_key(), not_before - skew - 1),
+        Err(CredentialError::NotYetValid)
+    );
+    validate_for_leaf(&credential, device.public_key(), not_before - skew).unwrap();
+    validate_for_leaf(&credential, device.public_key(), not_before).unwrap();
+    validate_for_leaf(&credential, device.public_key(), not_after).unwrap();
+    validate_for_leaf(&credential, device.public_key(), not_after + skew).unwrap();
+    assert_eq!(
+        validate_for_leaf(&credential, device.public_key(), not_after + skew + 1),
         Err(CredentialError::Expired)
     );
-    assert_eq!(
-        validate_for_leaf(&credential, device.public_key(), NOW + 100_000),
-        Err(CredentialError::Expired)
-    );
-    // The boundaries themselves are inside the window.
-    validate_for_leaf(&credential, device.public_key(), NOW - 1000).unwrap();
-    validate_for_leaf(&credential, device.public_key(), NOW + 1000).unwrap();
 }
 
 /// What a peer that put a bare handle in a `BasicCredential` looks like from

--- a/rs/crates/f2z-msg-mls/tests/key_packages.rs
+++ b/rs/crates/f2z-msg-mls/tests/key_packages.rs
@@ -152,6 +152,13 @@ fn wire_rendered_prose_digest(rendered: &markdown::RenderedMarkdown) -> u64 {
 }
 
 fn wire_has_exact_key_package_authentication_table(wire: &str) -> bool {
+    wire_has_exact_key_package_authentication_table_with_digest(wire, WIRE_RENDERED_PROSE_DIGEST)
+}
+
+fn wire_has_exact_key_package_authentication_table_with_digest(
+    wire: &str,
+    expected_rendered_prose_digest: u64,
+) -> bool {
     let Some(rendered) = markdown::RenderedMarkdown::parse(wire) else {
         return false;
     };
@@ -182,7 +189,7 @@ fn wire_has_exact_key_package_authentication_table(wire: &str) -> bool {
             == Some(KEY_PACKAGE_AUTHENTICATION_SECTION)
         && rendered.section(4, KEY_PACKAGE_EXHAUSTION_TEXT).as_deref()
             == Some(KEY_PACKAGE_EXHAUSTION_SECTION)
-        && wire_rendered_prose_digest(&rendered) == WIRE_RENDERED_PROSE_DIGEST
+        && wire_rendered_prose_digest(&rendered) == expected_rendered_prose_digest
 }
 
 #[test]
@@ -382,6 +389,28 @@ fn wire_key_package_authentication_list_is_exhaustive_and_mutation_sensitive() {
     assert!(
         !wire_has_exact_key_package_authentication_table(&malformed_fence_closer),
         "the checker treated a fence with trailing text as a CommonMark closer"
+    );
+
+    let hidden_by_commonmark_hgroup = WIRE
+        .replacen(
+            KEY_PACKAGE_AUTHENTICATION_HEADING,
+            &format!("<hgroup>\n{KEY_PACKAGE_AUTHENTICATION_HEADING}"),
+            1,
+        )
+        .replacen(
+            NEXT_WIRE_HEADING,
+            &format!("</hgroup>\n{NEXT_WIRE_HEADING}"),
+            1,
+        );
+    let mutant_rendered = markdown::RenderedMarkdown::parse(&hidden_by_commonmark_hgroup)
+        .expect("the hgroup mutation must remain syntactically valid");
+    let reanchored_digest = wire_rendered_prose_digest(&mutant_rendered);
+    assert!(
+        !wire_has_exact_key_package_authentication_table_with_digest(
+            &hidden_by_commonmark_hgroup,
+            reanchored_digest,
+        ),
+        "a re-anchored prose digest must not let CommonMark hgroup hide §12.6.5"
     );
 
     for (name, opening, closing) in [

--- a/rs/crates/f2z-msg-mls/tests/key_packages.rs
+++ b/rs/crates/f2z-msg-mls/tests/key_packages.rs
@@ -15,12 +15,425 @@
     clippy::arithmetic_side_effects
 )]
 
-use f2z_msg_mls::{CredentialError, EngineError};
+use f2z_msg_mls::{CredentialError, EngineError, MlsEngine};
 use openmls::prelude::{GroupId, MlsGroup};
 use openmls_traits::OpenMlsProvider as _;
 
 mod common;
-use common::{NOW, device, directory_entry, with_revocation};
+use common::{NOW, device, directory_entry, issue_credential, with_revocation};
+
+#[path = "../../../tests/support/markdown.rs"]
+mod markdown;
+
+const WIRE: &str = include_str!("../../../../docs/e2ee/WIRE.md");
+const KEY_PACKAGE_AUTHENTICATION_HEADING: &str =
+    "#### 12.6.5 Authentication — mandatory, and structural";
+const NEXT_WIRE_HEADING: &str = "#### 12.6.6 Exhaustion, and the package of last resort";
+const KEY_PACKAGE_PARENT_HEADING: &str =
+    "12.6 `KeyPackage` publication — where a consumable key lives";
+const KEY_PACKAGE_AUTHENTICATION_TABLE: &str = r#"| # | Check |
+|---|---|
+| 1 | RFC 9420's own `KeyPackage` validation: the package signature, the leaf-node signature, the lifetime, the extensions, and `init_key != encryption_key`. |
+| 2 | The ciphersuite is `ARCHITECTURE.md` §5.2's, and only that one. A relay that could choose the suite could downgrade the hybrid PQ. |
+| 3 | The credential parses as a `free2z/device-credential/v1`, not as a bare handle in a `BasicCredential`. |
+| 4 | The credential's signature verifies under the **entry's** `identity_pk` — not under the key inside the credential. |
+| 5 | The credential's `handle` is the entry's `handle`. |
+| 6 | The complete signed `DeviceCredential` exactly equals the credential the entry publishes in `devices` for that `device_pk`; matching the key alone is insufficient. |
+| 7 | At verifier-local time, that published credential is `Valid` under `KT.md` §4.1's exact shared inclusive fixed-skew rule; **not-yet-valid** and **expired** credentials are refused. |
+| 8 | The credential's `device_pk` does **not** appear in the entry's cumulative `revocations`. |
+| 9 | The leaf's `signature_key` is the credential's `device_pk` — the identity→device binding of `ARCHITECTURE.md` §4.2. |"#;
+const KEY_PACKAGE_AUTHENTICATION_SECTION: &str = r#"**A fetched key package MUST be verified against the `DirectoryEntry` the
+key-transparency lookup proved, before it is used for anything.** A client that
+skips this has reintroduced [#133](https://github.com/free2z/zuu/issues/133) one
+level down: the relay would choose whose init key the `Welcome` is encrypted to,
+and `ARCHITECTURE.md` §9.1's sentence applies unchanged — *encrypting perfectly
+to the wrong key is not security*.
+
+The check is possible because a `KeyPackage` carries the device's
+`DeviceCredential` as its MLS `Credential` (`KT.md` §4.1,
+`ARCHITECTURE.md` §4.2), and that credential is signed by the identity key the
+directory publishes. In full, a client MUST refuse the package unless **all** of
+these hold:
+
+| # | Check |
+|---|---|
+| 1 | RFC 9420's own `KeyPackage` validation: the package signature, the leaf-node signature, the lifetime, the extensions, and `init_key != encryption_key`. |
+| 2 | The ciphersuite is `ARCHITECTURE.md` §5.2's, and only that one. A relay that could choose the suite could downgrade the hybrid PQ. |
+| 3 | The credential parses as a `free2z/device-credential/v1`, not as a bare handle in a `BasicCredential`. |
+| 4 | The credential's signature verifies under the **entry's** `identity_pk` — not under the key inside the credential. |
+| 5 | The credential's `handle` is the entry's `handle`. |
+| 6 | The complete signed `DeviceCredential` exactly equals the credential the entry publishes in `devices` for that `device_pk`; matching the key alone is insufficient. |
+| 7 | At verifier-local time, that published credential is `Valid` under `KT.md` §4.1's exact shared inclusive fixed-skew rule; **not-yet-valid** and **expired** credentials are refused. |
+| 8 | The credential's `device_pk` does **not** appear in the entry's cumulative `revocations`. |
+| 9 | The leaf's `signature_key` is the credential's `device_pk` — the identity→device binding of `ARCHITECTURE.md` §4.2. |
+
+Check 4 is the one the section exists for. A relay that invents an identity key,
+issues itself a credential under it and signs a key package with the matching
+device key passes 1, 2, 3 and 9; only the directory's `identity_pk` stops it.
+Checks 6–8 make a replaced, withdrawn, not-yet-valid, expired, or revoked
+device unreachable for first contact. In particular, accepting a matching
+`device_pk` instead of the complete published credential would preserve the
+longer lifetime of a stale package after the owner replaced that credential.
+
+The reference implementation's safe first-party route makes this structural:
+`f2z_msg_mls::VerifiedKeyPackage` has no constructor but the verifying one, and
+`MlsEngine::add_member` takes that type instead of bytes. Its crate-level public
+API still exposes enough raw OpenMLS capabilities for an external caller to go
+around that wrapper; [#903](https://github.com/free2z/zuu/issues/903) tracks
+sealing that escape. This is an implementation status disclosure, not a
+weakening of the wire requirement: every client MUST perform all nine checks
+before proposing the Add."#;
+
+const KEY_PACKAGE_EXHAUSTION_SECTION: &str = r#"When the pool is empty a relay serves the **package of last resort** — RFC 9420's
+`last_resort` KeyPackage extension — repeatedly, without deleting it.
+
+**This is a real weakening and it is stated rather than buried.** A reusable
+package means a reused init key: two initiators derive their `Welcome` encryption
+from the same secret, and an attacker who later compromises that secret can open
+every `Welcome` ever addressed to it. The full accounting is
+[`THREAT-MODEL.md` §4.12](./THREAT-MODEL.md#412-a-last-resort-key-package-is-a-reused-init-key).
+
+The alternative is worse and is the reason the trade is taken: **without it,
+exhaustion means a device becomes unreachable to anyone new** for as long as it
+is offline, and an attacker willing to pay `max_pool_size` claim stamps can
+put it in that state deliberately. That is §12.4's contact-queue flood with a
+much smaller bill, and it would make first contact denial-of-service cheap.
+
+Two rules bound the cost:
+
+- A device **SHOULD** publish exactly one last-resort package and **SHOULD** give
+  it a lifetime materially shorter than its device credential's. The only
+  mitigation available against a reusable key is that it stops being usable.
+- A device **SHOULD NOT** replace its last-resort package on every top-up. A
+  `Welcome` may already be in flight against the retired one and the sender has
+  no way to learn it was withdrawn.
+
+A device **MAY** publish no last-resort package at all, accepting unreachability
+over reuse. A relay then answers `ERR_UNAVAILABLE` on an empty pool, and a client
+MUST surface that as *"this person cannot be reached right now"* rather than as
+*"this person does not exist"* — the two are the same wire code, by §10's rule,
+and only the client knows the lookup succeeded.
+
+**Refill, and the trap in it.** A device SHOULD top its pool up to a target on
+every `start_engine` and whenever something arrives on its contact queue.
+
+**A device MUST NOT decide when to refill from its own last-recorded count.**
+Most claims never produce a `Welcome` — a stranger may claim and never write —
+so consumption is *invisible* to the owner. A device that trusted its own number
+would sit at "I published 32" while the relay held zero, fall back to its
+reusable package of last resort on every first contact, and never notice.
+
+The way to ask is a **publish with an empty `packages` vector and an empty
+`last_resort`**: it changes nothing and returns the relay's true `pool_size` and
+`has_last_resort`. That is not a special case bolted on — it is why the response
+carries state at all, and it is safe for the reason §12.6.3 gives: the caller is
+the queue's owner, authenticated by the receive-side key.
+
+The numbers (a target, a low-water mark) are policy and are not fixed here; the
+reference client uses 32 and 8 against a cap of 64, and calls both placeholders.
+
+**Offline for a long time.** The pool drains, the last-resort package carries
+first contact at the cost above, and when *that* expires the device is
+unreachable to new contacts until it comes back. Established conversations are
+entirely unaffected at every stage — they use ordinary queues and no key package
+is ever consulted again."#;
+
+const KEY_PACKAGE_AUTHENTICATION_TEXT: &str = "12.6.5 Authentication — mandatory, and structural";
+const KEY_PACKAGE_EXHAUSTION_TEXT: &str = "12.6.6 Exhaustion, and the package of last resort";
+// This is intentionally the complete ordinary rendered-prose surface, not a
+// vocabulary search for likely weakenings. Otherwise a contradictory paragraph
+// elsewhere in WIRE can evade the guard by choosing one synonym we did not list.
+// Fenced examples and quoted/raw-HTML content cannot establish this normative
+// contract; the exact §12.6 structure and prose are checked separately below.
+const WIRE_RENDERED_PROSE_DIGEST: u64 = 8_772_757_061_631_922_358;
+
+fn wire_rendered_prose_digest(rendered: &markdown::RenderedMarkdown) -> u64 {
+    markdown::stable_digest(rendered.paragraphs())
+}
+
+fn wire_has_exact_key_package_authentication_table(wire: &str) -> bool {
+    let Some(rendered) = markdown::RenderedMarkdown::parse(wire) else {
+        return false;
+    };
+    let expected_children = [
+        "12.6.1 The tension, stated first",
+        "12.6.2 The answer: the relay, at the address the directory already publishes",
+        "12.6.3 `PUBLISH_KEY_PACKAGES` — `0x0032`",
+        "12.6.4 `CLAIM_KEY_PACKAGE` — `0x0033`",
+        KEY_PACKAGE_AUTHENTICATION_TEXT,
+        KEY_PACKAGE_EXHAUSTION_TEXT,
+        "12.6.7 What a client may not conclude from `last_resort`",
+        "12.6.8 Privacy — what this adds, precisely",
+        "12.6.9 Anti-abuse",
+    ];
+    let Some(children) = rendered.child_headings(3, KEY_PACKAGE_PARENT_HEADING, 4) else {
+        return false;
+    };
+
+    children == expected_children
+        && !rendered.has_raw_html()
+        && wire.matches(KEY_PACKAGE_AUTHENTICATION_HEADING).count() == 1
+        && wire.matches(NEXT_WIRE_HEADING).count() == 1
+        && wire.matches(KEY_PACKAGE_AUTHENTICATION_SECTION).count() == 1
+        && wire.matches(KEY_PACKAGE_EXHAUSTION_SECTION).count() == 1
+        && rendered
+            .section(4, KEY_PACKAGE_AUTHENTICATION_TEXT)
+            .as_deref()
+            == Some(KEY_PACKAGE_AUTHENTICATION_SECTION)
+        && rendered.section(4, KEY_PACKAGE_EXHAUSTION_TEXT).as_deref()
+            == Some(KEY_PACKAGE_EXHAUSTION_SECTION)
+        && wire_rendered_prose_digest(&rendered) == WIRE_RENDERED_PROSE_DIGEST
+}
+
+#[test]
+fn wire_key_package_authentication_list_is_exhaustive_and_mutation_sensitive() {
+    let rendered = markdown::RenderedMarkdown::parse(WIRE).expect("WIRE must parse fail-closed");
+    assert_eq!(
+        wire_rendered_prose_digest(&rendered),
+        WIRE_RENDERED_PROSE_DIGEST,
+        "WIRE's ordinary rendered prose changed; review the change before updating the contract"
+    );
+    assert!(
+        wire_has_exact_key_package_authentication_table(WIRE),
+        "WIRE §12.6.5 must carry the exact exhaustive authentication table"
+    );
+
+    for (name, original, replacement) in [
+        (
+            "full credential equality",
+            "The complete signed `DeviceCredential` exactly equals the credential the entry publishes in `devices` for that `device_pk`; matching the key alone is insufficient.",
+            "The credential's `device_pk` appears in the entry's `devices`.",
+        ),
+        (
+            "shared inclusive validity rule",
+            "At verifier-local time, that published credential is `Valid` under `KT.md` §4.1's exact shared inclusive fixed-skew rule; **not-yet-valid** and **expired** credentials are refused.",
+            "The credential lifetime is acceptable.",
+        ),
+        (
+            "cumulative revocation",
+            "The credential's `device_pk` does **not** appear in the entry's cumulative `revocations`.",
+            "The credential has not been revoked recently.",
+        ),
+    ] {
+        assert_eq!(
+            WIRE.matches(original).count(),
+            1,
+            "{name} mutation must target exactly one normative claim"
+        );
+        let mutant = WIRE.replacen(original, replacement, 1);
+        assert!(
+            !wire_has_exact_key_package_authentication_table(&mutant),
+            "the checker survived deletion of {name}"
+        );
+    }
+
+    let extra_rule = WIRE.replacen(
+        KEY_PACKAGE_AUTHENTICATION_TABLE,
+        &format!(
+            "{KEY_PACKAGE_AUTHENTICATION_TABLE}\n\
+             | 10 | Implementations MAY accept a matching device key without full credential equality. |"
+        ),
+        1,
+    );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&extra_rule),
+        "the checker accepted a tenth, contradictory authentication rule"
+    );
+
+    let advisory = WIRE.replacen(
+        KEY_PACKAGE_AUTHENTICATION_TABLE,
+        &format!(
+            "{KEY_PACKAGE_AUTHENTICATION_TABLE}\n\n\
+             The nine checks are advisory; matching the device key alone is sufficient."
+        ),
+        1,
+    );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&advisory),
+        "the checker accepted additive prose making full credential equality optional"
+    );
+
+    let synonymous_weakening = WIRE.replacen(
+        KEY_PACKAGE_AUTHENTICATION_TABLE,
+        &format!(
+            "{KEY_PACKAGE_AUTHENTICATION_TABLE}\n\n\
+             The nine checks are recommendations; a matching device key is adequate."
+        ),
+        1,
+    );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&synonymous_weakening),
+        "the checker accepted a synonymous additive weakening"
+    );
+
+    let adjacent_weakening = WIRE.replacen(
+        NEXT_WIRE_HEADING,
+        &format!(
+            "{NEXT_WIRE_HEADING}\n\n\
+             Despite §12.6.5, clients MAY accept a key package whenever its `device_pk` \
+             matches a published device; exact credential equality is advisory."
+        ),
+        1,
+    );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&adjacent_weakening),
+        "the checker accepted a contradiction in adjacent §12.6.6"
+    );
+
+    for (name, original, addition) in [
+        (
+            "§12.6.5 four-space paragraph continuation",
+            "before proposing the Add.",
+            "Clients MAY match only `device_pk` and skip complete credential equality.",
+        ),
+        (
+            "§12.6.6 four-space paragraph continuation",
+            "is ever consulted again.",
+            "Expired key packages MAY be accepted when the pool is exhausted.",
+        ),
+    ] {
+        assert_eq!(
+            WIRE.matches(original).count(),
+            1,
+            "{name} mutation must target exactly one rendered paragraph ending"
+        );
+        let visible_continuation =
+            WIRE.replacen(original, &format!("{original}\n    {addition}"), 1);
+        assert!(
+            !wire_has_exact_key_package_authentication_table(&visible_continuation),
+            "the checker discarded a visible {name} as indented code"
+        );
+    }
+
+    let elsewhere_weakening = WIRE.replacen(
+        "# free2z E2EE — Relay wire protocol, version 1",
+        "# free2z E2EE — Relay wire protocol, version 1\n\nClients MAY use a matching device key without exact \
+         `DeviceCredential` equality; the §12.6.5 checks are advisory.",
+        1,
+    );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&elsewhere_weakening),
+        "the checker accepted a contradiction elsewhere in WIRE"
+    );
+
+    let html_elsewhere_weakening = WIRE.replacen(
+        "# free2z E2EE — Relay wire protocol, version 1",
+        "# free2z E2EE — Relay wire protocol, version 1\n\n<div>Clients MAY ignore \
+         §12.6.5 and match only the device key.</div>",
+        1,
+    );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&html_elsewhere_weakening),
+        "the checker accepted contradictory prose in a raw HTML container"
+    );
+
+    let hidden_and_contradicted = WIRE
+        .replacen(
+            KEY_PACKAGE_AUTHENTICATION_HEADING,
+            &format!("<!--\n{KEY_PACKAGE_AUTHENTICATION_HEADING}"),
+            1,
+        )
+        .replacen(
+            NEXT_WIRE_HEADING,
+            &format!(
+                "{NEXT_WIRE_HEADING}\n-->\n\nClients MAY accept a package on matching \
+                 `device_pk` alone; the hidden checks above are advisory."
+            ),
+            1,
+        );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&hidden_and_contradicted),
+        "the checker counted comment-hidden canonical policy over visible contradictory prose"
+    );
+
+    let same_line_comment = WIRE.replacen(
+        KEY_PACKAGE_AUTHENTICATION_HEADING,
+        &format!("<!-- hidden raw block -->{KEY_PACKAGE_AUTHENTICATION_HEADING}"),
+        1,
+    );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&same_line_comment),
+        "text after a raw-comment close on the same line counted as a rendered heading"
+    );
+
+    let lazy_blockquote = WIRE.replacen(
+        &format!("{KEY_PACKAGE_AUTHENTICATION_HEADING}\n\n"),
+        &format!(
+            "{KEY_PACKAGE_AUTHENTICATION_HEADING}\n> Quoted non-normative example whose marker is omitted on continuation lines\n"
+        ),
+        1,
+    );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&lazy_blockquote),
+        "unmarked lazy blockquote continuations established the canonical policy"
+    );
+
+    // A CommonMark closer may contain trailing whitespace and nothing else.
+    // Treating the second line as a closer makes the canonical section appear
+    // rendered even though the unclosed fence actually hides it through EOF.
+    let malformed_fence_closer = WIRE.replacen(
+        KEY_PACKAGE_AUTHENTICATION_HEADING,
+        &format!(
+            "```markdown\n``` this is literal fenced content, not a closer\n\
+             {KEY_PACKAGE_AUTHENTICATION_HEADING}"
+        ),
+        1,
+    );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&malformed_fence_closer),
+        "the checker treated a fence with trailing text as a CommonMark closer"
+    );
+
+    for (name, opening, closing) in [
+        ("fenced code", "```markdown", "```"),
+        ("raw HTML container", "<div hidden>", "</div>"),
+        ("raw HTML block", "<textarea>", "</textarea>"),
+    ] {
+        let hidden = WIRE
+            .replacen(
+                KEY_PACKAGE_AUTHENTICATION_HEADING,
+                &format!("{opening}\n{KEY_PACKAGE_AUTHENTICATION_HEADING}"),
+                1,
+            )
+            .replacen(
+                NEXT_WIRE_HEADING,
+                &format!("{NEXT_WIRE_HEADING}\n{closing}"),
+                1,
+            );
+        assert!(
+            !wire_has_exact_key_package_authentication_table(&hidden),
+            "the checker counted canonical policy hidden in {name}"
+        );
+    }
+
+    let authentication_block =
+        format!("{KEY_PACKAGE_AUTHENTICATION_HEADING}\n\n{KEY_PACKAGE_AUTHENTICATION_SECTION}");
+    for (name, prefix) in [("blockquote", "> "), ("indented code", "    ")] {
+        let hidden_block = authentication_block
+            .lines()
+            .map(|line| format!("{prefix}{line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let hidden = WIRE.replacen(&authentication_block, &hidden_block, 1);
+        assert!(
+            !wire_has_exact_key_package_authentication_table(&hidden),
+            "the checker counted canonical policy hidden in a {name}"
+        );
+    }
+
+    let without_authentication = WIRE.replacen(&format!("{authentication_block}\n\n"), "", 1);
+    let relocated = without_authentication.replacen(
+        "#### 12.6.7 What a client may not conclude from `last_resort`",
+        &format!(
+            "{authentication_block}\n\n#### 12.6.7 What a client may not conclude from `last_resort`"
+        ),
+        1,
+    );
+    assert!(
+        !wire_has_exact_key_package_authentication_table(&relocated),
+        "the checker accepted the canonical section at a different structural ordinal"
+    );
+}
 
 #[test]
 fn a_substituted_relay_id_breaks_the_device_authenticated_routing_advert() {
@@ -82,6 +495,71 @@ fn a_swapped_welcome_breaks_the_device_authenticated_routing_transcript() {
         .is_err(),
         "deleting Welcome coverage would make this substitution survive"
     );
+}
+
+#[test]
+fn routing_advert_refusals_name_the_directory_device_state() {
+    let bob = device("bob", 22, 222);
+    let payload = b"conversation|relay-url|relay-id|send-addr";
+    let signature = bob.sign_routing_advert(payload).expect("routing signature");
+    let device_pk = bob.credential().credential.device_pk;
+
+    let unpublished = device("bob", 22, 244);
+    let unpublished_entry = directory_entry(&[unpublished.credential().clone()]);
+    let error = MlsEngine::<f2z_msg_store::MemoryBackend>::authenticate_routing_advert(
+        &unpublished_entry,
+        device_pk.as_bytes(),
+        payload,
+        &signature,
+        NOW,
+    )
+    .expect_err("the routing signer is not published");
+    assert!(
+        matches!(
+            error,
+            EngineError::Credential(CredentialError::DeviceNotPublished)
+        ),
+        "{error:?}"
+    );
+
+    let entry = directory_entry(&[bob.credential().clone()]);
+    let revoked = with_revocation(&entry, device_pk);
+    let error = MlsEngine::<f2z_msg_store::MemoryBackend>::authenticate_routing_advert(
+        &revoked,
+        device_pk.as_bytes(),
+        payload,
+        &signature,
+        NOW,
+    )
+    .expect_err("the routing signer is revoked");
+    assert!(
+        matches!(
+            error,
+            EngineError::Credential(CredentialError::DeviceRevoked)
+        ),
+        "{error:?}"
+    );
+
+    let skew = f2z_kt_core::entry::DEVICE_CREDENTIAL_CLOCK_SKEW_MS;
+    for (not_before, not_after, expected) in [
+        (NOW + skew + 1, NOW + skew + 2, CredentialError::NotYetValid),
+        (NOW - skew - 2, NOW - skew - 1, CredentialError::Expired),
+    ] {
+        let published = issue_credential("bob", 22, 222, not_before, not_after).0;
+        let entry = directory_entry(&[published]);
+        let error = MlsEngine::<f2z_msg_store::MemoryBackend>::authenticate_routing_advert(
+            &entry,
+            device_pk.as_bytes(),
+            payload,
+            &signature,
+            NOW,
+        )
+        .expect_err("the routing signer is outside its published window");
+        assert!(
+            matches!(error, EngineError::Credential(actual) if actual == expected),
+            "expected {expected:?}, got {error:?}"
+        );
+    }
 }
 
 #[test]
@@ -261,7 +739,7 @@ fn a_package_from_a_device_the_entry_does_not_publish_is_refused() {
     assert!(
         matches!(
             error,
-            EngineError::Credential(CredentialError::DeviceKeyMismatch)
+            EngineError::Credential(CredentialError::DeviceNotPublished)
         ),
         "{error:?}"
     );
@@ -287,7 +765,7 @@ fn a_package_from_a_revoked_device_is_refused() {
     assert!(
         matches!(
             error,
-            EngineError::Credential(CredentialError::DeviceKeyMismatch)
+            EngineError::Credential(CredentialError::DeviceRevoked)
         ),
         "{error:?}"
     );
@@ -307,7 +785,68 @@ fn an_expired_package_is_refused() {
         .verify_key_package(&wire, &entry, NOW + 100_000_000_000)
         .expect_err("an expired package is not usable");
     assert!(
-        matches!(error, EngineError::Credential(_) | EngineError::Mls(_)),
+        matches!(error, EngineError::Credential(CredentialError::Expired)),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn first_contact_uses_the_published_credential_window_not_only_the_package_window() {
+    let bob = device("bob", 22, 222);
+    let alice = device("alice", 11, 111);
+    let wire = bob.generate_key_package().expect("package");
+    let skew = f2z_kt_core::entry::DEVICE_CREDENTIAL_CLOCK_SKEW_MS;
+
+    for (not_before, not_after, expected) in [
+        (NOW + skew + 1, NOW + skew + 2, CredentialError::NotYetValid),
+        (NOW - skew - 2, NOW - skew - 1, CredentialError::Expired),
+    ] {
+        // Same identity, handle and device key as the still-valid credential
+        // inside `wire`; only the directory-published lifetime excludes it.
+        let published = issue_credential("bob", 22, 222, not_before, not_after).0;
+        let entry = directory_entry(&[published]);
+        let error = alice
+            .verify_key_package(&wire, &entry, NOW)
+            .expect_err("the published credential is inactive");
+        assert!(
+            matches!(error, EngineError::Credential(actual) if actual == expected),
+            "expected {expected:?}, got {error:?}"
+        );
+    }
+}
+
+#[test]
+fn a_stale_longer_lived_credential_for_the_same_device_key_is_not_published() {
+    let (embedded, signer) = issue_credential("bob", 22, 222, NOW - 1_000_000, NOW + 1_000_000);
+    let bob = MlsEngine::new(
+        f2z_msg_store::MemoryBackend::new(),
+        signer,
+        embedded.clone(),
+        NOW,
+    )
+    .expect("the older credential is currently valid");
+    let wire = bob.generate_key_package().expect("package");
+
+    // The replacement uses the exact same identity, handle and DSK, and is
+    // also valid now. Only full credential equality catches that the relay
+    // retained the older, longer-lived credential embedded in `wire`.
+    let published = issue_credential("bob", 22, 222, NOW - 500, NOW + 500).0;
+    assert_eq!(
+        embedded.credential.device_pk,
+        published.credential.device_pk
+    );
+    assert_ne!(embedded, published);
+
+    let alice = device("alice", 11, 111);
+    let entry = directory_entry(&[published]);
+    let error = alice
+        .verify_key_package(&wire, &entry, NOW)
+        .expect_err("a stale credential is not the credential the directory publishes");
+    assert!(
+        matches!(
+            error,
+            EngineError::Credential(CredentialError::PublishedCredentialMismatch)
+        ),
         "{error:?}"
     );
 }

--- a/rs/crates/f2z-msg-mls/tests/two_instances.rs
+++ b/rs/crates/f2z-msg-mls/tests/two_instances.rs
@@ -600,7 +600,7 @@ fn post_merge_credential_failure_restores_memory_for_redelivery() {
         paired_with_bob_backend(MemoryBackend::new(), NOW + 1);
     let commit = alice.update(&mut alice_group).expect("update");
     let epoch_before = bob_group.epoch();
-    let after_bob_expired = NOW + 2;
+    let after_bob_expired = NOW + f2z_kt_core::entry::DEVICE_CREDENTIAL_CLOCK_SKEW_MS + 2;
 
     for attempt in 1..=2 {
         let outcome = bob.receive(

--- a/rs/tests/support/markdown.rs
+++ b/rs/tests/support/markdown.rs
@@ -59,6 +59,7 @@ const RAW_HTML_TAGS: &[&str] = &[
     "h6",
     "head",
     "header",
+    "hgroup",
     "html",
     "iframe",
     "legend",
@@ -746,6 +747,17 @@ mod tests {
 
         assert!(rendered.section(4, "Hidden").is_none());
         assert_eq!(rendered.section(4, "Visible").as_deref(), Some("kept"));
+    }
+
+    #[test]
+    fn commonmark_hgroup_container_cannot_hide_a_heading() {
+        let rendered =
+            RenderedMarkdown::parse("<hgroup>\n#### Hidden\n</hgroup>\n#### Visible\nkept")
+                .expect("a balanced CommonMark hgroup raw block parses");
+
+        assert!(rendered.section(4, "Hidden").is_none());
+        assert_eq!(rendered.section(4, "Visible").as_deref(), Some("kept"));
+        assert!(rendered.has_raw_html());
     }
 
     #[test]

--- a/rs/tests/support/markdown.rs
+++ b/rs/tests/support/markdown.rs
@@ -1,0 +1,777 @@
+//! Small, fail-closed Markdown structure reader for normative documentation tests.
+//!
+//! This deliberately recognizes only the CommonMark constructs that can turn
+//! source-looking prose into non-rendered/example content. A malformed or
+//! unclosed construct returns `None`; callers must treat that as a failed
+//! contract rather than guessing how a renderer will recover.
+
+#![allow(dead_code, clippy::arithmetic_side_effects, clippy::indexing_slicing)]
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Heading {
+    pub line: usize,
+    pub level: usize,
+    pub text: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct RenderedMarkdown {
+    lines: Vec<Option<String>>,
+    headings: Vec<Heading>,
+    raw_html_lines: Vec<bool>,
+    has_raw_html: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Fence {
+    marker: char,
+    length: usize,
+}
+
+const RAW_HTML_TAGS: &[&str] = &[
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "body",
+    "caption",
+    "center",
+    "code",
+    "colgroup",
+    "dd",
+    "details",
+    "dialog",
+    "dir",
+    "div",
+    "dl",
+    "dt",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "frameset",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "head",
+    "header",
+    "html",
+    "iframe",
+    "legend",
+    "li",
+    "main",
+    "menu",
+    "nav",
+    "noframes",
+    "noscript",
+    "object",
+    "ol",
+    "optgroup",
+    "option",
+    "p",
+    "pre",
+    "script",
+    "search",
+    "section",
+    "span",
+    "style",
+    "summary",
+    "table",
+    "tbody",
+    "td",
+    "template",
+    "textarea",
+    "tfoot",
+    "th",
+    "thead",
+    "title",
+    "tr",
+    "ul",
+];
+
+const VOID_HTML_TAGS: &[&str] = &[
+    "area", "base", "basefont", "br", "col", "embed", "frame", "hr", "img", "input", "link",
+    "menuitem", "meta", "param", "source", "track", "wbr",
+];
+
+fn fence_candidate(line: &str) -> Option<(char, usize, &str)> {
+    let spaces = line.bytes().take_while(|byte| *byte == b' ').count();
+    if spaces > 3 {
+        return None;
+    }
+    let rest = line.get(spaces..)?;
+    let marker = rest.chars().next()?;
+    if marker != '`' && marker != '~' {
+        return None;
+    }
+    let length = rest
+        .chars()
+        .take_while(|character| *character == marker)
+        .count();
+    (length >= 3).then(|| (marker, length, &rest[length..]))
+}
+
+fn update_fence(fence: Option<Fence>, line: &str) -> (Option<Fence>, bool) {
+    let Some((marker, length, trailing)) = fence_candidate(line) else {
+        return (fence, fence.is_some());
+    };
+    match fence {
+        None if marker == '`' && trailing.contains('`') => (None, false),
+        None => (Some(Fence { marker, length }), true),
+        Some(open)
+            if marker == open.marker
+                && length >= open.length
+                && trailing
+                    .chars()
+                    .all(|character| matches!(character, ' ' | '\t')) =>
+        {
+            (None, true)
+        }
+        Some(open) => (Some(open), true),
+    }
+}
+
+fn strip_comments(line: &str, in_comment: &mut bool) -> String {
+    let mut remainder = line;
+    let mut visible = String::new();
+    loop {
+        if *in_comment {
+            let Some(end) = remainder.find("-->") else {
+                return visible;
+            };
+            *in_comment = false;
+            remainder = &remainder[end + 3..];
+            continue;
+        }
+        let Some(start) = remainder.find("<!--") else {
+            visible.push_str(remainder);
+            return visible;
+        };
+        visible.push_str(&remainder[..start]);
+        *in_comment = true;
+        remainder = &remainder[start + 4..];
+    }
+}
+
+fn opening_tag_tail(tail: &str) -> Option<bool> {
+    let bytes = tail.as_bytes();
+    let mut cursor = 0;
+    loop {
+        let before_whitespace = cursor;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor = cursor.saturating_add(1);
+        }
+        let had_whitespace = cursor > before_whitespace;
+        let Some(byte) = bytes.get(cursor).copied() else {
+            return Some(false);
+        };
+        if byte == b'/' {
+            return (cursor.saturating_add(1) == bytes.len()).then_some(true);
+        }
+        // Every attribute must be separated from the tag name or prior
+        // attribute. A terminal slash is the sole exception above.
+        if !had_whitespace || !(byte.is_ascii_alphabetic() || matches!(byte, b'_' | b':')) {
+            return None;
+        }
+        cursor = cursor.saturating_add(1);
+        while bytes.get(cursor).is_some_and(|candidate| {
+            candidate.is_ascii_alphanumeric() || matches!(candidate, b'_' | b'.' | b':' | b'-')
+        }) {
+            cursor = cursor.saturating_add(1);
+        }
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor = cursor.saturating_add(1);
+        }
+        if bytes.get(cursor) != Some(&b'=') {
+            continue;
+        }
+        cursor = cursor.saturating_add(1);
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor = cursor.saturating_add(1);
+        }
+        match bytes.get(cursor).copied()? {
+            quote @ (b'\'' | b'"') => {
+                cursor = cursor.saturating_add(1);
+                while bytes.get(cursor).copied() != Some(quote) {
+                    bytes.get(cursor)?;
+                    cursor = cursor.saturating_add(1);
+                }
+                cursor = cursor.saturating_add(1);
+            }
+            _ => {
+                let value_start = cursor;
+                while bytes.get(cursor).is_some_and(|candidate| {
+                    !candidate.is_ascii_whitespace()
+                        && !matches!(candidate, b'"' | b'\'' | b'=' | b'<' | b'>' | b'`')
+                }) {
+                    cursor = cursor.saturating_add(1);
+                }
+                if cursor == value_start {
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+fn raw_html_tags(line: &str) -> Option<Vec<(bool, bool, String)>> {
+    let mut tags = Vec::new();
+    let bytes = line.as_bytes();
+    let mut cursor = 0;
+    while let Some(relative) = line[cursor..].find('<') {
+        let start = cursor + relative;
+        let mut position = start.saturating_add(1);
+        let closing = bytes.get(position) == Some(&b'/');
+        if closing {
+            position = position.saturating_add(1);
+        }
+
+        // HTML tag names begin immediately after `<` or `</`. In particular,
+        // `</ details>` is text, not a closing tag.
+        if !bytes.get(position).is_some_and(u8::is_ascii_alphabetic) {
+            cursor = start.saturating_add(1);
+            continue;
+        }
+        let name_start = position;
+        while bytes
+            .get(position)
+            .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'-')
+        {
+            position = position.saturating_add(1);
+        }
+        let name_end = position;
+        let name = line[name_start..name_end].to_ascii_lowercase();
+        let recognized =
+            RAW_HTML_TAGS.contains(&name.as_str()) || VOID_HTML_TAGS.contains(&name.as_str());
+        if !bytes
+            .get(position)
+            .is_some_and(|byte| byte.is_ascii_whitespace() || *byte == b'/' || *byte == b'>')
+        {
+            if recognized {
+                return None;
+            }
+            cursor = start.saturating_add(1);
+            continue;
+        }
+
+        // Attribute values may contain `>` or `/>`; only an unquoted `>`
+        // terminates the tag. HTML does not use backslash escapes for quotes.
+        let mut quote = None;
+        let mut end = None;
+        while let Some(byte) = bytes.get(position).copied() {
+            match (quote, byte) {
+                (Some(open), candidate) if candidate == open => quote = None,
+                (None, b'\'' | b'"') => quote = Some(byte),
+                (None, b'>') => {
+                    end = Some(position);
+                    break;
+                }
+                _ => {}
+            }
+            position = position.saturating_add(1);
+        }
+        let Some(end) = end else {
+            return (!recognized).then_some(tags);
+        };
+
+        let trailing = &line[name_end..end];
+        let valid = if closing {
+            trailing
+                .bytes()
+                .all(|byte| byte.is_ascii_whitespace())
+                .then_some(false)
+        } else {
+            opening_tag_tail(trailing)
+        };
+        if recognized {
+            let _syntactically_self_closing = valid?;
+            // HTML browsers ignore the self-closing flag on non-void elements:
+            // `<details />` still opens a container. Treating that spelling as
+            // balanced would let it hide all following normative prose.
+            let self_closing = VOID_HTML_TAGS.contains(&name.as_str());
+            tags.push((closing, self_closing, name));
+        }
+        cursor = end.saturating_add(1);
+        if cursor >= bytes.len() {
+            break;
+        }
+    }
+    Some(tags)
+}
+
+fn update_html_stack(stack: &mut Vec<String>, tags: &[(bool, bool, String)]) {
+    for (closing, self_closing, name) in tags {
+        if *closing {
+            if let Some(position) = stack.iter().rposition(|open| open == name) {
+                stack.truncate(position);
+            }
+        } else if !self_closing {
+            stack.push(name.clone());
+        }
+    }
+}
+
+fn atx_heading(line: &str) -> Option<(usize, String)> {
+    let spaces = line.bytes().take_while(|byte| *byte == b' ').count();
+    if spaces > 3 {
+        return None;
+    }
+    let rest = line.get(spaces..)?;
+    let level = rest.bytes().take_while(|byte| *byte == b'#').count();
+    if !(1..=6).contains(&level) {
+        return None;
+    }
+    let after = rest.get(level..)?;
+    if !after.is_empty() && !after.starts_with([' ', '\t']) {
+        return None;
+    }
+    let mut text = after.trim().to_owned();
+    if let Some(without_closer) = text.strip_suffix('#') {
+        let trimmed = without_closer.trim_end_matches('#').trim_end();
+        if trimmed.len() < without_closer.len() {
+            text = trimmed.to_owned();
+        }
+    }
+    Some((level, text))
+}
+
+fn setext_level(line: &str) -> Option<usize> {
+    let spaces = line.bytes().take_while(|byte| *byte == b' ').count();
+    if spaces > 3 {
+        return None;
+    }
+    let rest = line.get(spaces..)?.trim_end_matches([' ', '\t']);
+    if !rest.is_empty() && rest.bytes().all(|byte| byte == b'=') {
+        Some(1)
+    } else if !rest.is_empty() && rest.bytes().all(|byte| byte == b'-') {
+        Some(2)
+    } else {
+        None
+    }
+}
+
+fn starts_list_item(line: &str) -> bool {
+    let trimmed = line.trim_start_matches([' ', '\t']);
+    if trimmed
+        .strip_prefix(['-', '+', '*'])
+        .is_some_and(|rest| rest.starts_with([' ', '\t']))
+    {
+        return true;
+    }
+    let digits = trimmed.bytes().take_while(u8::is_ascii_digit).count();
+    (1..=9).contains(&digits)
+        && trimmed
+            .get(digits..)
+            .and_then(|rest| rest.strip_prefix(['.', ')']))
+            .is_some_and(|rest| rest.starts_with([' ', '\t']))
+}
+
+fn normalize(lines: impl IntoIterator<Item = String>) -> String {
+    let mut normalized = Vec::new();
+    let mut previous_blank = true;
+    for line in lines {
+        let line = line.trim_end().to_owned();
+        let blank = line.trim().is_empty();
+        if !blank || !previous_blank {
+            normalized.push(line);
+        }
+        previous_blank = blank;
+    }
+    while normalized.last().is_some_and(|line| line.is_empty()) {
+        normalized.pop();
+    }
+    normalized.join("\n")
+}
+
+impl RenderedMarkdown {
+    pub fn parse(source: &str) -> Option<Self> {
+        let mut lines = Vec::new();
+        let mut raw_html_lines = Vec::new();
+        let mut fence = None;
+        let mut in_comment = false;
+        let mut special_raw_end: Option<&str> = None;
+        let mut html_stack = Vec::new();
+        let mut has_raw_html = false;
+        let mut in_indented_code = false;
+        let mut paragraph_open = false;
+        let mut lazy_blockquote_paragraph = false;
+
+        'lines: for raw_line in source.lines() {
+            if let Some(end) = special_raw_end {
+                if raw_line.contains(end) {
+                    special_raw_end = None;
+                }
+                lines.push(None);
+                raw_html_lines.push(true);
+                paragraph_open = false;
+                lazy_blockquote_paragraph = false;
+                continue;
+            }
+
+            // CommonMark's raw comment block consumes both its opening line
+            // and the line containing its closing delimiter. Text after the
+            // delimiter on either line does not become a structural heading.
+            let raw_comment_line = in_comment || raw_line.contains("<!--");
+            let comment_block_line = in_comment || raw_line.trim_start().starts_with("<!--");
+            has_raw_html |= raw_line.contains("<!--");
+            let line = strip_comments(raw_line, &mut in_comment);
+            if comment_block_line {
+                lines.push(None);
+                raw_html_lines.push(true);
+                paragraph_open = false;
+                lazy_blockquote_paragraph = false;
+                continue;
+            }
+
+            let (next_fence, is_fence_content) = update_fence(fence, &line);
+            fence = next_fence;
+            if is_fence_content {
+                lines.push(None);
+                raw_html_lines.push(raw_comment_line);
+                in_indented_code = false;
+                paragraph_open = false;
+                lazy_blockquote_paragraph = false;
+                continue;
+            }
+
+            let trimmed = line.trim_start();
+            for (opening, closing) in [("<?", "?>"), ("<![CDATA[", "]]>")] {
+                if trimmed.starts_with(opening) {
+                    has_raw_html = true;
+                    if !trimmed.contains(closing) {
+                        special_raw_end = Some(closing);
+                    }
+                    lines.push(None);
+                    raw_html_lines.push(true);
+                    paragraph_open = false;
+                    lazy_blockquote_paragraph = false;
+                    continue 'lines;
+                }
+            }
+            if trimmed.starts_with("<!")
+                && !trimmed.starts_with("<!--")
+                && !trimmed.starts_with("<![CDATA[")
+            {
+                has_raw_html = true;
+                if !trimmed.contains('>') {
+                    special_raw_end = Some(">");
+                }
+                lines.push(None);
+                raw_html_lines.push(true);
+                paragraph_open = false;
+                lazy_blockquote_paragraph = false;
+                continue 'lines;
+            }
+
+            let tags = raw_html_tags(&line)?;
+            has_raw_html |= !tags.is_empty();
+            let hidden_by_html = !html_stack.is_empty() || !tags.is_empty();
+            update_html_stack(&mut html_stack, &tags);
+            if hidden_by_html {
+                lines.push(None);
+                raw_html_lines.push(true);
+                paragraph_open = false;
+                lazy_blockquote_paragraph = false;
+                continue;
+            }
+
+            if line.trim().is_empty() {
+                if in_indented_code {
+                    lines.push(None);
+                } else {
+                    lines.push(Some(line));
+                }
+                raw_html_lines.push(raw_comment_line);
+                paragraph_open = false;
+                lazy_blockquote_paragraph = false;
+                continue;
+            }
+
+            let leading_spaces = line.bytes().take_while(|byte| *byte == b' ').count();
+            let content = line.get(leading_spaces..)?;
+            let quoted = content.strip_prefix('>');
+            if lazy_blockquote_paragraph
+                && quoted.is_none()
+                && atx_heading(&line).is_none()
+                && setext_level(&line).is_none()
+                && fence_candidate(&line).is_none()
+                && !starts_list_item(&line)
+            {
+                // A block quote marker may be omitted on paragraph
+                // continuation lines. They remain quoted/example content even
+                // though the source line no longer begins with `>`.
+                lines.push(None);
+                raw_html_lines.push(raw_comment_line);
+                paragraph_open = false;
+                continue;
+            }
+
+            let indented = line.starts_with('\t') || leading_spaces >= 4;
+            if indented {
+                // CommonMark indented code cannot interrupt a paragraph. Four
+                // spaces after an ordinary prose line are therefore a visible
+                // lazy/paragraph continuation; only a block-context indent
+                // starts (or continues) indented code.
+                if in_indented_code || !paragraph_open {
+                    lines.push(None);
+                    in_indented_code = true;
+                    paragraph_open = false;
+                } else {
+                    lines.push(Some(line));
+                    in_indented_code = false;
+                    paragraph_open = true;
+                }
+                raw_html_lines.push(raw_comment_line);
+                continue;
+            }
+
+            in_indented_code = false;
+            if let Some(quoted) = quoted {
+                lines.push(None);
+                raw_html_lines.push(raw_comment_line);
+                paragraph_open = false;
+                let quoted = quoted.strip_prefix([' ', '\t']).unwrap_or(quoted);
+                lazy_blockquote_paragraph = !quoted.is_empty()
+                    && atx_heading(quoted).is_none()
+                    && setext_level(quoted).is_none()
+                    && fence_candidate(quoted).is_none()
+                    && !starts_list_item(quoted);
+                continue;
+            }
+            lazy_blockquote_paragraph = false;
+            paragraph_open = atx_heading(&line).is_none() && setext_level(&line).is_none();
+            lines.push(Some(line));
+            raw_html_lines.push(raw_comment_line);
+        }
+
+        if fence.is_some() || in_comment || special_raw_end.is_some() || !html_stack.is_empty() {
+            return None;
+        }
+
+        let mut headings = Vec::new();
+        for (line_number, line) in lines.iter().enumerate() {
+            let Some(line) = line else { continue };
+            if let Some((level, text)) = atx_heading(line) {
+                headings.push(Heading {
+                    line: line_number,
+                    level,
+                    text,
+                });
+                continue;
+            }
+            if let Some(level) = setext_level(line)
+                && line_number > 0
+                && let Some(Some(previous)) = lines.get(line_number - 1)
+                && !previous.trim().is_empty()
+            {
+                headings.push(Heading {
+                    line: line_number - 1,
+                    level,
+                    text: previous.trim().to_owned(),
+                });
+            }
+        }
+
+        Some(Self {
+            lines,
+            headings,
+            raw_html_lines,
+            has_raw_html,
+        })
+    }
+
+    pub fn section(&self, level: usize, text: &str) -> Option<String> {
+        let matches = self
+            .headings
+            .iter()
+            .filter(|heading| heading.level == level && heading.text == text)
+            .collect::<Vec<_>>();
+        if matches.len() != 1 {
+            return None;
+        }
+        let start = matches[0].line;
+        let end = self
+            .headings
+            .iter()
+            .find(|heading| heading.line > start && heading.level <= level)
+            .map_or(self.lines.len(), |heading| heading.line);
+        Some(normalize(
+            self.lines[start + 1..end].iter().filter_map(Clone::clone),
+        ))
+    }
+
+    pub const fn has_raw_html(&self) -> bool {
+        self.has_raw_html
+    }
+
+    /// Whether a uniquely named rendered section contains raw HTML syntax.
+    ///
+    /// A protected normative section can use this to fail closed without
+    /// rejecting reviewed claim-marker comments elsewhere in the document.
+    pub fn section_has_raw_html(&self, level: usize, text: &str) -> Option<bool> {
+        let matches = self
+            .headings
+            .iter()
+            .filter(|heading| heading.level == level && heading.text == text)
+            .collect::<Vec<_>>();
+        if matches.len() != 1 {
+            return None;
+        }
+        let start = matches[0].line;
+        let end = self
+            .headings
+            .iter()
+            .find(|heading| heading.line > start && heading.level <= level)
+            .map_or(self.lines.len(), |heading| heading.line);
+        Some(self.raw_html_lines[start..end].iter().any(|raw| *raw))
+    }
+
+    pub fn child_headings(
+        &self,
+        level: usize,
+        text: &str,
+        child_level: usize,
+    ) -> Option<Vec<String>> {
+        let parent = self
+            .headings
+            .iter()
+            .filter(|heading| heading.level == level && heading.text == text)
+            .collect::<Vec<_>>();
+        if parent.len() != 1 {
+            return None;
+        }
+        let start = parent[0].line;
+        let end = self
+            .headings
+            .iter()
+            .find(|heading| heading.line > start && heading.level <= level)
+            .map_or(self.lines.len(), |heading| heading.line);
+        Some(
+            self.headings
+                .iter()
+                .filter(|heading| {
+                    heading.line > start && heading.line < end && heading.level == child_level
+                })
+                .map(|heading| heading.text.clone())
+                .collect(),
+        )
+    }
+
+    pub fn paragraphs(&self) -> Vec<String> {
+        normalize(self.lines.iter().filter_map(Clone::clone))
+            .split("\n\n")
+            .map(str::trim)
+            .filter(|paragraph| !paragraph.is_empty())
+            .map(str::to_owned)
+            .collect()
+    }
+}
+
+pub fn stable_digest(texts: impl IntoIterator<Item = String>) -> u64 {
+    // A deterministic change detector, not a cryptographic commitment. The
+    // reviewed expected value lives beside each exact prose contract.
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for text in texts {
+        for byte in text.bytes().chain(core::iter::once(0xff)) {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RenderedMarkdown;
+
+    #[test]
+    fn four_space_indent_cannot_interrupt_a_paragraph() {
+        let rendered = RenderedMarkdown::parse(
+            "#### Policy\nRequired text.\n    Visible contradictory continuation.\n#### Next",
+        )
+        .expect("ordinary paragraph continuation parses");
+
+        assert_eq!(
+            rendered.section(4, "Policy").as_deref(),
+            Some("Required text.\n    Visible contradictory continuation.")
+        );
+    }
+
+    #[test]
+    fn a_blank_line_allows_indented_code_to_start_and_continue() {
+        let rendered = RenderedMarkdown::parse(
+            "#### Policy\nRequired text.\n\n    example one\n\n    example two\n#### Next",
+        )
+        .expect("an indented code block may end at EOF or a non-indented line");
+
+        assert_eq!(
+            rendered.section(4, "Policy").as_deref(),
+            Some("Required text.")
+        );
+    }
+
+    #[test]
+    fn an_unmarked_blockquote_paragraph_continuation_stays_quoted() {
+        let rendered = RenderedMarkdown::parse(
+            "> quoted example\nunmarked continuation\n    four-space continuation\n#### Visible",
+        )
+        .expect("a lazy blockquote continuation parses");
+
+        assert_eq!(rendered.paragraphs(), vec!["#### Visible"]);
+        assert!(rendered.section(4, "Visible").is_some());
+    }
+
+    #[test]
+    fn raw_html_is_scoped_to_the_section_that_contains_it() {
+        let rendered = RenderedMarkdown::parse(
+            "<!-- reviewed marker -->\n### Protected\n<span>visible policy</span>\n### Ordinary\nkept",
+        )
+        .expect("balanced raw HTML parses");
+
+        assert_eq!(rendered.section_has_raw_html(3, "Protected"), Some(true));
+        assert_eq!(rendered.section_has_raw_html(3, "Ordinary"), Some(false));
+        assert!(rendered.has_raw_html());
+    }
+
+    #[test]
+    fn raw_html_attributes_may_contain_greater_than_characters() {
+        let rendered = RenderedMarkdown::parse(
+            "<details title=\"an ordinary a > b label\">\n#### Hidden\n</details>\n#### Visible\nkept",
+        )
+        .expect("a quoted attribute must not leave the raw HTML stack open");
+
+        assert!(rendered.section(4, "Hidden").is_none());
+        assert_eq!(rendered.section(4, "Visible").as_deref(), Some("kept"));
+    }
+
+    #[test]
+    fn quoted_self_close_token_does_not_self_close_a_container() {
+        let rendered = RenderedMarkdown::parse(
+            "<details title=\"/>\">\n#### Hidden\n</details>\n#### Visible\nkept",
+        )
+        .expect("the real closing tag must balance the container");
+
+        assert!(rendered.section(4, "Hidden").is_none());
+        assert_eq!(rendered.section(4, "Visible").as_deref(), Some("kept"));
+    }
+
+    #[test]
+    fn non_void_self_close_syntax_still_opens_an_html_container() {
+        assert!(
+            RenderedMarkdown::parse("<details />\n#### Still hidden").is_none(),
+            "HTML ignores self-close syntax on a non-void container"
+        );
+    }
+
+    #[test]
+    fn whitespace_after_closing_slash_is_not_a_closing_tag() {
+        assert!(
+            RenderedMarkdown::parse("<details>\n</ details>\n#### Still hidden").is_none(),
+            "a malformed spaced close must not pop the raw HTML stack"
+        );
+    }
+}

--- a/wallet/plugins/tauri-plugin-f2zmsg/CLAUDE.md
+++ b/wallet/plugins/tauri-plugin-f2zmsg/CLAUDE.md
@@ -39,10 +39,12 @@ why it is a test binary.
 its directory entry publishes — so a key package arrives from a party the threat
 model assumes is hostile. `Inner::claim_key_package` claims **and verifies** in
 one function on purpose: the verification is what stops the relay choosing whose
-init key the `Welcome` is encrypted to, which is #133 at first contact. The type
-system holds the line one level down — `MlsEngine::add_member` takes a
-`VerifiedKeyPackage`, which has no constructor but the verifying one — so the
-way to break this is to delete the check, not to forget it. Don't.
+init key the `Welcome` is encrypted to, which is #133 at first contact. The
+plugin must use the checked `MlsEngine::add_member` route, which takes a
+`VerifiedKeyPackage` with no constructor but the verifying one. The crate's raw
+OpenMLS capabilities are not yet a complete public API seal; #903 tracks that
+boundary. Until it lands, treating those capabilities as an alternate Add path
+would bypass the first-contact authentication this plugin requires. Don't.
 
 `start_engine` publishes this device's own pool and tops it up whenever
 something lands on the contact queue. A device with no published pool is one


### PR DESCRIPTION
## Summary

- define one fixed, inclusive v1 credential-lifetime rule and reuse it across verified lookup, first-contact key packages/routing adverts, and offline MLS validation
- reject duplicate revocations and require every successor entry to retain the predecessor revocation vector as an immutable prefix before journalling or receipt issuance
- document publication-effective revocations and the limits of what offline MLS peers can learn without a fresh verified lookup
- add mutation-sensitive spec/runtime, skew-boundary, not-yet-valid, expiry, cumulative-history, attempted un-revocation, durable-admission, lookup, and first-contact coverage
- harden the shared Markdown policy parser so no-blank four-space paragraph continuations remain visible, while true indented code and lazy blockquotes remain excluded
- fail closed on raw HTML inside protected KT §4.1 while preserving reviewed AKD claim-marker comments elsewhere; exact WIRE §12.6.5/§12.6.6, KT §4.1, inline-span, and open-details mutants prove the boundaries

Platform-reset policy choices remain out of scope; the per-handle cumulative invariant applies uniformly to every successor entry.

## Verification

- `cargo +1.97.1 fmt --manifest-path rs/Cargo.toml --all --check`
- `cargo +1.97.1 test --locked --manifest-path rs/Cargo.toml -p f2z-kt-core --test credential_policy_spec` (9 passed)
- `cargo +1.97.1 test --locked --manifest-path rs/Cargo.toml -p f2z-msg-mls --test key_packages wire_key_package_authentication_list_is_exhaustive_and_mutation_sensitive -- --exact`
- `cargo +1.97.1 test --workspace --locked --manifest-path rs/Cargo.toml`
- `cargo +1.97.1 clippy --workspace --all-targets --locked --manifest-path rs/Cargo.toml -- -D warnings`
- `scripts/check-rust-fmt.sh --self-test && scripts/check-rust-fmt.sh --root rs`
- `scripts/check-rust-clippy.sh --self-test macos && scripts/check-rust-clippy.sh --root rs`
- `scripts/check-rust-deny.sh --self-test && scripts/check-rust-deny.sh --root rs --config rs/deny.toml`
- `scripts/check-rust-toolchain.sh --self-test && scripts/check-rust-toolchain.sh`
- GitHub Actions pin/gate policy self-test and live check
- hash-domain-label policy self-test and live check
- AKD documentation evidence self-test and live check

Closes #891
Refs #558