### PR TITLE
ci(zuuli): skip the Rust matrix for markdown-only free2z/e2e2z changes

### DIFF
--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -130,23 +130,28 @@ jobs:
           zuuli=false
           zuuallet_schema=false
           while IFS= read -r -d '' file; do
-            # Prose under wallet/zuuli/ — STATUS.md, README.md, CLAUDE.md,
-            # docs/**.md — describes the app; it is not compiled into it and no
-            # job below reads it. Without this guard the broad `wallet/zuuli/*`
-            # pattern in the arm below matches it, so a STATUS re-derivation —
-            # which every release needs at least once — pays the full ~40-minute
-            # native matrix.
+            # Prose under an application directory — STATUS.md, README.md,
+            # CLAUDE.md, docs/**.md — describes the app; it is not compiled into
+            # it and no job below reads it. Without this guard the broad
+            # `wallet/zuuli/*`, `wallet/free2z/*` and `wallet/e2e2z/*` patterns
+            # in the arm below match it, so a STATUS re-derivation — which every
+            # release needs at least once — pays the full ~40-minute native
+            # matrix, as does a README edit on either delegated surface.
             #
             # `==` inside `[[ ]]` is a glob match, not a string compare, and a
-            # glob `*` spans `/`, so this one pattern covers every depth:
+            # glob `*` spans `/`, so one pattern per app covers every depth:
             # wallet/zuuli/STATUS.md and wallet/zuuli/docs/e2ee/notes.md alike.
             #
-            # It is scoped to the wallet/zuuli/ prefix and so cannot reach the
-            # markdown that genuinely gates behaviour: docs/e2ee/CLIENT-CONTRACT.md,
-            # docs/e2ee/WIRE.md and docs/ZUULI-LINUX-BUILD-IMAGE.md all live
-            # outside that prefix and still select the full gate. It also runs
-            # only per-file, so it cannot affect the fail-open paths above.
-            if [[ "$file" == wallet/zuuli/*.md ]]; then
+            # It is scoped to those three application prefixes and so cannot
+            # reach the markdown that genuinely gates behaviour:
+            # docs/e2ee/CLIENT-CONTRACT.md, docs/e2ee/WIRE.md and
+            # docs/ZUULI-LINUX-BUILD-IMAGE.md all live outside them and still
+            # select the full gate. It also runs only per-file, so it cannot
+            # affect the fail-open paths above, and a commit that touches prose
+            # *and* source still selects the full gate on the source file.
+            if [[ "$file" == wallet/zuuli/*.md ||
+                  "$file" == wallet/free2z/*.md ||
+                  "$file" == wallet/e2e2z/*.md ]]; then
               continue
             fi
             case "$file" in

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -63,6 +63,10 @@ const RUST_ROOT_CONTRACTS = [
           "wallet/nested/future/Cargo.toml",
           "docs/e2ee/CLIENT-CONTRACT.md",
           "docs/e2ee/WIRE.md",
+          // The markdown-only guard must exclude prose and nothing else: source
+          // under the same two prefixes still selects the full gate.
+          "wallet/free2z/src/App.tsx",
+          "wallet/e2e2z/src/App.tsx",
         ],
       },
       {
@@ -81,6 +85,14 @@ const RUST_ROOT_CONTRACTS = [
       "wallet/zuuli/STATUS.md",
       "wallet/zuuli/CLAUDE.md",
       "wallet/zuuli/docs/e2ee/notes.md",
+      // The same property for the two delegated surfaces of the three-app
+      // split (#904/#906). `wallet/free2z/*` and `wallet/e2e2z/*` joined the
+      // selector in #909 so the required gate covers them; without the guard a
+      // README edit on either drags the whole native matrix in behind it.
+      "wallet/free2z/README.md",
+      "wallet/free2z/docs/notes.md",
+      "wallet/e2e2z/README.md",
+      "wallet/e2e2z/docs/notes.md",
     ],
     jobs: [
       [
@@ -3661,18 +3673,22 @@ function runRustRootWorkflowMutationTests(repoRoot) {
         ],
       ];
       // The markdown-only guard is a *negative* selector: it exists to keep
-      // `wallet/zuuli/*` from dragging prose into the native matrix. Its two
-      // failure directions are deleting it and narrowing it to the top level,
-      // so both are exercised against the live workflow.
+      // `wallet/zuuli/*`, `wallet/free2z/*` and `wallet/e2e2z/*` from dragging
+      // prose into the native matrix. Its failure directions are deleting the
+      // guard, dropping one application's clause from it, and narrowing a
+      // clause to the top level, so all three are exercised against the live
+      // workflow — once per application clause.
       assertWorkflowFailure(
         contract,
         source,
-        "wallet/ rejects deleting the ZUULI markdown-only guard",
+        "wallet/ rejects deleting the application markdown-only guard",
         (value) =>
           mutateJob(
             value,
             "changes",
-            '            if [[ "$file" == wallet/zuuli/*.md ]]; then\n' +
+            '            if [[ "$file" == wallet/zuuli/*.md ||\n' +
+              '                  "$file" == wallet/free2z/*.md ||\n' +
+              '                  "$file" == wallet/e2e2z/*.md ]]; then\n' +
               "              continue\n" +
               "            fi\n",
             "",
@@ -3682,16 +3698,45 @@ function runRustRootWorkflowMutationTests(repoRoot) {
       assertWorkflowFailure(
         contract,
         source,
-        "wallet/ rejects a ZUULI markdown-only guard that misses nested prose",
+        "wallet/ rejects dropping wallet/free2z from the markdown-only guard",
         (value) =>
           mutateJob(
             value,
             "changes",
-            '"$file" == wallet/zuuli/*.md',
-            '"$file" == wallet/zuuli/STATUS.md',
+            '                  "$file" == wallet/free2z/*.md ||\n',
+            "",
           ),
-        'must leave zuuli false for unrelated input "wallet/zuuli/docs/e2ee/notes.md"',
+        'must leave zuuli false for unrelated input "wallet/free2z/README.md"',
       );
+      assertWorkflowFailure(
+        contract,
+        source,
+        "wallet/ rejects dropping wallet/e2e2z from the markdown-only guard",
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            '                  "$file" == wallet/free2z/*.md ||\n' +
+              '                  "$file" == wallet/e2e2z/*.md ]]; then\n',
+            '                  "$file" == wallet/free2z/*.md ]]; then\n',
+          ),
+        'must leave zuuli false for unrelated input "wallet/e2e2z/README.md"',
+      );
+      for (const app of ["zuuli", "free2z", "e2e2z"]) {
+        assertWorkflowFailure(
+          contract,
+          source,
+          `wallet/ rejects a wallet/${app} markdown-only clause that misses nested prose`,
+          (value) =>
+            mutateJob(
+              value,
+              "changes",
+              `"$file" == wallet/${app}/*.md`,
+              `"$file" == wallet/${app}/${app === "zuuli" ? "STATUS" : "README"}.md`,
+            ),
+          `must leave zuuli false for unrelated input "wallet/${app}/docs/${app === "zuuli" ? "e2ee/" : ""}notes.md"`,
+        );
+      }
       for (const [guard, target, replacement, needle] of
         selectorPatternMutations) {
         const action = replacement ? "broadened" : "removed";

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -14,7 +14,7 @@ const target = "armv7-linux-androideabi";
 const ndk = "27.0.12077973";
 const cacheKey = `zuuli-plugin-android-armv7-ndk${ndk}-api29`;
 const changeDetectorDigest =
-  "12ac7c784e9ce12b3ceb85d5f8dc5482655a8092dd797793b9ba888f3159f1c1";
+  "f75d1b5797cad3446e27bebccb341b2beaadf9f8b9e8ba76db478f3212299d47";
 const toolchainEnvDigest =
   "403f59c58bca0a37b98a3bb0ea0ae7f1c289b3531d6e1eec8496643866ee2013";
 const requiredMessagingSelector = "wallet/zuuli/*";


### PR DESCRIPTION
## What this does

#909 made the required `gate` cover the two new apps by adding `wallet/free2z/*` and `wallet/e2e2z/*` to `zuuli.yml`'s change detector. Those globs match `README.md` too, so a documentation edit on either surface selected the full ZUULI matrix — ~40 minutes for a prose change.

#848 already solved exactly this for `wallet/zuuli/`. This extends that same guard — same mechanism, same place in the loop, one clause per app — to the two new prefixes:

```bash
if [[ "$file" == wallet/zuuli/*.md ||
      "$file" == wallet/free2z/*.md ||
      "$file" == wallet/e2e2z/*.md ]]; then
  continue
fi
```

## What the digest pin protects, and why this change is safe

`scripts/check-zuuli-android-gate.mjs` hashes the entire `Detect release-impacting ZUULI changes` step and compares it to a reviewed constant. Its failure message names the property: *"change detector differs from the reviewed fail-open/fail-closed selector step."* The step is the only thing standing between "a change landed" and "the required native matrix ran", and it contains two structurally different regions:

1. **Fail-open preamble** (before the loop). If `BASE_SHA` is not 40 hex digits, or names a commit that does not exist, or `git diff` itself fails, the step writes `zuuli=true` / `zuuallet_schema=true` and `exit 0`s. Every degenerate event — manual dispatch, first push, incomplete payload — must land here and run everything.
2. **Per-file selection** (inside the loop). Each changed path is matched against a `case` arm.

The digest exists because the *textual* difference between those two regions is small and the *semantic* difference is total. A one-character edit in region 1 turns "we could not tell, so run everything" into "we could not tell, so run nothing", and nothing else in the workflow would notice. #909 stayed purely additive specifically so it never had to touch the constant.

**This change touches only region 2, and only the negative direction of it.** The guard is a `continue` on a single `$file`, evaluated after the preamble has already returned in every fail-open case. It cannot execute on a run where the base SHA is unusable, because such a run never reaches the loop. The observed output below shows both halves of that claim rather than arguing it.

The digest was re-derived only after that confirmation, with the script's own affordance:

```
$ node scripts/check-zuuli-android-gate.mjs --print-change-detector-digest
f75d1b5797cad3446e27bebccb341b2beaadf9f8b9e8ba76db478f3212299d47
```

`12ac7c78…` → `f75d1b57…`.

## Observed filter output

**This is not a workflow run.** The `run:` body of the selector step was extracted verbatim from `.github/workflows/zuuli.yml` and executed with `/bin/bash` against a real single-purpose Git repository — the same technique `scripts/check-github-actions-pins.mjs` uses in `executeRustRootSelector`, extended so one case can commit a *set* of files (the repo harness fixtures one probe path each and so cannot express "both together"). `BASE_SHA`, `GITHUB_SHA` and `GITHUB_OUTPUT` are set the way GitHub sets them; the reported value is the *effective last* write to `$GITHUB_OUTPUT`.

### After this change

```
wallet/free2z/README.md                                     -> zuuli=false zuuallet_schema=false exit=0
wallet/free2z/docs/notes.md                                 -> zuuli=false zuuallet_schema=false exit=0
wallet/free2z/src/App.tsx                                   -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z/README.md + wallet/free2z/src/App.tsx         -> zuuli=true  zuuallet_schema=false exit=0
wallet/e2e2z/README.md                                      -> zuuli=false zuuallet_schema=false exit=0
wallet/e2e2z/docs/notes.md                                  -> zuuli=false zuuallet_schema=false exit=0
wallet/e2e2z/src/App.tsx                                    -> zuuli=true  zuuallet_schema=false exit=0
wallet/e2e2z/README.md + wallet/e2e2z/src/App.tsx           -> zuuli=true  zuuallet_schema=false exit=0
wallet/zuuli/STATUS.md (regression)                         -> zuuli=false zuuallet_schema=false exit=0
wallet/zuuli/src/App.tsx (regression)                       -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z/README.md + wallet/e2e2z/README.md            -> zuuli=false zuuallet_schema=false exit=0
wallet/free2z/README.md + wallet/e2e2z/src-tauri/src/lib.rs -> zuuli=true  zuuallet_schema=true  exit=0
wallet/free2z/README.md + docs/e2ee/WIRE.md                 -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z/notes.mdx (not .md)                           -> zuuli=true  zuuallet_schema=false exit=0
wallet/e2e2z/notes.mdx (not .md)                            -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z-other/README.md (prefix is exact)             -> zuuli=false zuuallet_schema=false exit=0
```

The three acceptance cases, for both apps: README alone → **skip**; source alone → **full**; **both together → full**. The quantifier is right by construction rather than by luck — the guard is a per-file `continue`, i.e. "this path is not release-impacting", never "this commit is documentation". The mixed case still reaches the `case` arm on `src/App.tsx` and sets `zuuli=true`.

`docs/e2ee/WIRE.md` and the other contract markdown live outside the three application prefixes and still select the full gate (row 13). `wallet/free2z-other/README.md` is `false` because nothing selects that path at all, guard or no guard — the glob does not leak past the `/`.

### Fail-open, unchanged

```
BASE_SHA empty + wallet/free2z/README.md              -> zuuli=true  zuuallet_schema=true  exit=0
BASE_SHA empty + wallet/e2e2z/README.md               -> zuuli=true  zuuallet_schema=true  exit=0
BASE_SHA not 40-hex + wallet/free2z/README.md         -> zuuli=true  zuuallet_schema=true  exit=0
BASE_SHA not 40-hex + wallet/e2e2z/README.md          -> zuuli=true  zuuallet_schema=true  exit=0
BASE_SHA unknown 40-hex + wallet/free2z/README.md     -> zuuli=true  zuuallet_schema=true  exit=0
BASE_SHA unknown 40-hex + wallet/e2e2z/README.md      -> zuuli=true  zuuallet_schema=true  exit=0
```

Every degenerate base runs the **full** gate even when the only changed file is markdown the guard would otherwise skip — the dangerous "fail open into a skip" mode does not exist here, because the preamble `exit 0`s before the loop is entered.

### Before this change (`origin/main`, same harness)

```
wallet/free2z/README.md                                     -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z/docs/notes.md                                 -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z/src/App.tsx                                   -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z/README.md + wallet/free2z/src/App.tsx         -> zuuli=true  zuuallet_schema=false exit=0
wallet/e2e2z/README.md                                      -> zuuli=true  zuuallet_schema=false exit=0
wallet/e2e2z/docs/notes.md                                  -> zuuli=true  zuuallet_schema=false exit=0
wallet/e2e2z/src/App.tsx                                    -> zuuli=true  zuuallet_schema=false exit=0
wallet/e2e2z/README.md + wallet/e2e2z/src/App.tsx           -> zuuli=true  zuuallet_schema=false exit=0
wallet/zuuli/STATUS.md (regression)                         -> zuuli=false zuuallet_schema=false exit=0
wallet/zuuli/src/App.tsx (regression)                       -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z/README.md + wallet/e2e2z/README.md            -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z/README.md + wallet/e2e2z/src-tauri/src/lib.rs -> zuuli=true  zuuallet_schema=true  exit=0
wallet/free2z/README.md + docs/e2ee/WIRE.md                 -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z/notes.mdx (not .md)                           -> zuuli=true  zuuallet_schema=false exit=0
wallet/e2e2z/notes.mdx (not .md)                            -> zuuli=true  zuuallet_schema=false exit=0
wallet/free2z-other/README.md (prefix is exact)             -> zuuli=false zuuallet_schema=false exit=0
```

Diffing the two tables row for row: exactly **five** rows flip — `free2z/README.md`, `free2z/docs/notes.md`, `e2e2z/README.md`, `e2e2z/docs/notes.md`, and the two-README commit. Every one is a markdown-only change under one of the two new prefixes. The other eleven rows, and the entire fail-open block, are byte-identical before and after. That is the "semantic change is limited to excluding markdown" claim, observed rather than asserted.

## No gated coverage is lost

`wallet/free2z/README.md` and `wallet/e2e2z/README.md` are the only tracked markdown under either tree. `grep`ing `scripts/`, `.github/` and `wallet/zuuli/scripts/` for those trees turns up `check-rust-toolchain.sh`, `check-tauri-plugin-permissions.mjs`, `check-workflow-gates.mjs` and `project-boundary.node-test.mjs` — every one of them reads `Cargo.toml`, `capabilities/*.json`, or source. **No checker reads markdown under either prefix.**

`.github/workflows/wallet-surfaces.yml` keeps its own `paths: wallet/free2z/**` filter and is deliberately untouched: it is registered as advisory in `check-workflow-gates.mjs`, cannot fail a merge, and is cheap. Its registered rationale ("the ZUULI change detector selects `wallet/free2z/*` and `wallet/e2e2z/*`") remains true for every change that can affect the capability contract or the import boundary — those live in source, not prose.

## The guard is load-bearing — negative controls

A guard that cannot go red is decoration. Each control below tampers with the live workflow, runs the real checker, and restores the tree.

**Digest pin, cosmetic tamper** (rewording `::notice::No usable base commit; running the full ZUULI gate.` inside the pinned step — semantically inert):

```
- change detector differs from the reviewed fail-open/fail-closed selector step
check-zuuli-android-gate.mjs exit=1
```

**Digest pin, the dangerous tamper** (`zuuli=true` → `zuuli=false` in the *fail-open* branch):

```
- change detector differs from the reviewed fail-open/fail-closed selector step
check-zuuli-android-gate.mjs exit=1
```

**Digest pin, guard widened** (`wallet/zuuli/*.md` → `wallet/*.md`, which would swallow prose across the whole tree):

```
- change detector differs from the reviewed fail-open/fail-closed selector step
check-zuuli-android-gate.mjs exit=1
```

That last one matters: `check-github-actions-pins.mjs` would *not* catch it, because no probe path is `wallet/<something>.md`. The digest is the only thing that forces a human to look. Worth knowing it is the backstop, not a formality.

**And the executing checker catches the fail-open flip independently of any digest** — `check-github-actions-pins.mjs` actually runs the selector body against a real Git fixture with an unusable base:

```
--- mutated fail-open branch ---
            echo "::notice::No usable base commit; running the full ZUULI gate."
            echo "zuuli=false" >> "$GITHUB_OUTPUT"
--- check-github-actions-pins.mjs verdict ---
GitHub Actions fail-closed policy failed:
- .github/workflows/zuuli.yml:103: wallet/ owner selector must fail open to its full gate when no usable base commit exists
1 failure(s); scanned 20 workflow/action file(s) and 212 external reference(s).
exit=1
```

So the fail-open property has two independent enforcers, and both were confirmed red before this PR's version was confirmed green.

## The behaviour is pinned, not merely asserted

`scripts/check-github-actions-pins.mjs`:

- `excludedProbePaths` gains `wallet/free2z/README.md`, `wallet/free2z/docs/notes.md`, `wallet/e2e2z/README.md`, `wallet/e2e2z/docs/notes.md` — root and depth, because the guard is a glob whose `*` spans `/`. The live check fails if the guard regresses.
- `additionalProbePaths` gains `wallet/free2z/src/App.tsx` and `wallet/e2e2z/src/App.tsx`, so the guard cannot be widened into source without the live check going red.
- The two #848 mutation controls become six, one failure direction per application clause:

```
self-test: wallet/ rejects deleting the application markdown-only guard: passed
self-test: wallet/ rejects dropping wallet/free2z from the markdown-only guard: passed
self-test: wallet/ rejects dropping wallet/e2e2z from the markdown-only guard: passed
self-test: wallet/ rejects a wallet/zuuli markdown-only clause that misses nested prose: passed
self-test: wallet/ rejects a wallet/free2z markdown-only clause that misses nested prose: passed
self-test: wallet/ rejects a wallet/e2e2z markdown-only clause that misses nested prose: passed
```

`assertWorkflowFailure` throws if its mutation target is not found, so these fixtures cannot silently rot into no-ops.

Rust-root ownership mutation cases: **124 → 128**.

## Verification run locally

```
node scripts/check-zuuli-android-gate.mjs --self-test        -> 34 mutations passed
node scripts/check-zuuli-android-gate.mjs                    -> pass
node scripts/check-github-actions-pins.mjs --self-test       -> 74 source-policy, 11 gate-verdict,
    148 current-workflow, 3 project-discovery, 18 frontend-build, 4 classic-frontend-audit,
    128 Rust-root ownership mutation case(s) passed
node scripts/check-github-actions-pins.mjs                   -> pass (212 external refs, 20 files)
node scripts/check-workflow-gates.mjs --self-test            -> 39 case(s) passed
node scripts/check-workflow-gates.mjs                        -> pass (2 gates, 69 jobs, 19 files)
node scripts/check-librustzcash-compat.mjs --self-test       -> 114 mutants killed
node scripts/check-librustzcash-compat.mjs                   -> pass
node scripts/check-pow-policy.mjs --self-test                -> pass
node scripts/check-pow-policy.mjs                            -> pass
node scripts/check-zuuli-linux-image.mjs --self-test         -> 43 negative cases passed
node scripts/check-zuuli-linux-image.mjs                     -> pass
node scripts/check-zuuli-store-capture-image.mjs --self-test -> 28 mutants killed
node scripts/check-zuuli-store-capture-image.mjs             -> pass
node scripts/check-tauri-plugin-permissions.mjs --self-test  -> pass
node scripts/check-tauri-plugin-permissions.mjs              -> pass
node wallet/zuuli/scripts/wasm-boundary.mjs --self-test      -> 11 mutations rejected
node wallet/zuuli/scripts/wasm-boundary.mjs                  -> pass
scripts/check-rust-toolchain.sh (+ --self-test)              -> pass (channel 1.97.1)
scripts/check-public-repo-boundary.sh (+ --self-test)        -> pass
```

`zuuli.yml` also re-parses as YAML (14 jobs), and the selector body executed cleanly (`exit=0`) in all 22 probe cases above, which is the bash-syntax proof for the multi-line `[[ ... || ... ]]`.

## Known collision — #914, and how to resolve it

**#914** (`feat/zuuli-intent-authority`) is editing the same digest-pinned step concurrently: it must add `rs/crates/f2z-intent/*` to the ZUULI selector because ZUULI's `src-tauri` now depends on that crate in source. Its edit is purely additive; this one is subtractive. Both re-derive `changeDetectorDigest`. Branched from `bd39b14`, before either landed.

**Whichever merges second rebases, and the resolution is not a `git checkout --ours`.** If #914 lands first, take `main`'s version of the change-detection step — the one that already contains `rs/crates/f2z-intent/*` — re-apply *only* the three-clause markdown guard on top, and re-derive the digest with `node scripts/check-zuuli-android-gate.mjs --print-change-detector-digest` against the merged step. **Do not drop `rs/crates/f2z-intent/*` while resolving:** without it, a change to the intent-protocol crate no longer selects the ZUULI gate, and the wallet authority could be rebuilt against modified intent code with nothing running. That is a fail-closed property, not bookkeeping.

The two edits are independent by construction — #914 adds a `case` arm pattern in region 2's `case` list; this adds a `continue` before it — so the merge is mechanical once the digest is re-derived against the combined text. The digest pin is precisely what forces that re-derivation instead of letting a stale constant ride through.

Independent corroboration that the checker's baseline validation is real rather than a rubber stamp: #914 reported hitting `scripts/check-zuuli-android-gate.mjs:407` with

```
Error: cannot self-test an invalid baseline:
wallet/ links rs/crates/f2z-intent in source; the ZUULI selector must name it
```

i.e. the self-test refuses to run at all against a tree whose selector under-covers a linked crate. (That output is from #914's run, not this branch — this branch's own negative controls are the three digest tampers and the fail-open flip above.)

Closes #910
