### PR TITLE
feat(e2e2z): build the issue-device-credential intent, still fail closed (#905)

### DIFF
--- a/docs/e2ee/CLIENT-CONTRACT.md
+++ b/docs/e2ee/CLIENT-CONTRACT.md
@@ -294,6 +294,22 @@ what travels in the clear.
 > intent, which does not ship before
 > [#461](https://github.com/free2z/zuu/issues/461): a custom-scheme deep link is
 > not an authenticated channel.
+>
+> **`enroll` is now that intent, and it still refuses.** Since #904's caller
+> half landed, `enrollment.enroll` runs
+> `wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.ts`: it reads this
+> device's **public** keys from the app-crate command
+> `e2e2z_device_credential_keys` (which calls
+> `tauri_plugin_f2zmsg::engine::Engine::prepare_device` in process — OS CSPRNG,
+> never seed-derived, private halves never leaving that process), builds the
+> request through `@free2z/wallet-shared`, and hands it to the single transport
+> seam, which rejects. The refusal is re-wrapped as
+> `EnrollmentUnavailableError` with the cause attached, so the paragraph above
+> stays true in every clause: `enroll` cannot resolve, cannot produce an
+> `EnrollmentStatus`, and cannot install a credential — this app registers no
+> command that could. `e2e2z_device_credential_keys` is an app-crate command
+> (§2.2: no `plugin:` prefix, no capability entry) and is deliberately **not**
+> part of §3's plugin surface: it grants nothing and returns no secret.
 
 Messaging mounts as a new top-level route. In `src/lib/routes.ts`:
 

--- a/docs/intent-bridge/CONFORMANCE.md
+++ b/docs/intent-bridge/CONFORMANCE.md
@@ -123,6 +123,67 @@ what keeps a *future* reader safe if someone adds a decode path that forgets
 `finish()` — and claiming an independent test for each would have been the
 overstatement this document exists to avoid.
 
+## The e2e2z caller — `wallet/e2e2z/src/lib/enrollment`
+
+The first application to build an intent. `#904` splits the messaging surface
+away from the wallet, so e2e2z holds device keys and never anything
+seed-derived, and the one operation it cannot perform alone is enrollment
+(`ARCHITECTURE.md` §4.2). It therefore builds an `issue-device-credential`
+request — really, through the shared implementation, over its own OS-CSPRNG
+device public keys — and fails at the transport, because there is not one.
+
+Baseline: 42 tests green across `transport.test.ts`, `deviceKeys.test.ts` and
+`issueDeviceCredential.test.ts`, plus 3 in
+`wallet/e2e2z/src/lib/messaging/enroll-intent.test.ts`, plus the 4 in
+`wallet/e2e2z/scripts/seed-authority-boundary.node-test.mjs`. Reproduce with
+`cd wallet/e2e2z && npx vitest run && node --test scripts/seed-authority-boundary.node-test.mjs`.
+
+| Guard, as mutated | Test that must fail | Result |
+|---|---|---|
+| `enroll` refuses instead of returning a status, **after** a fulfilled response | `enroll builds a real intent and still cannot enroll > never resolves to an EnrollmentStatus even on a fulfilled response` | FAILS |
+| `enroll` refuses instead of returning a status, **before** the intent path | `the enrollment gap > never resolves to an EnrollmentStatus, however shaped` | FAILS |
+| the shipping transport rejects rather than resolving | `the intent transport > never resolves to bytes a caller could mistake for a response` | FAILS |
+| the shipping transport's refusal is not gated on `available` | `the intent transport > does not gate its refusal on the availability flag` | FAILS |
+| session correlation, seen from the caller | `refuses an answer to a different request`, `refuses an answer whose identifier differs in one byte`, `refuses a replay of an answer it already accepted` | FAILS |
+| `IssueDeviceCredentialResultV1` trailing-byte refusal **and** re-encode equality, together | `the issue-device-credential family result > refuses trailing bytes` | FAILS |
+| `IssueDeviceCredentialResultV1` non-empty credential | `the issue-device-credential family result > refuses a zero-length credential` | FAILS |
+| seed authority: the wallet plugin as a dependency | `e2e2z holds no route to the wallet seed` | FAILS |
+| seed authority: a `plugin:zcash\|` invoke in the renderer | `e2e2z holds no route to the wallet seed` | FAILS |
+| seed authority: `get_seed_phrase` named in executable code | `e2e2z holds no route to the wallet seed` | FAILS |
+
+**10 mutations, 10 failures, 0 survivors.** Every one was applied, watched to
+fail with a named assertion, and restored; the tree ends green.
+
+### What survived, and what that means
+
+Two observations are recorded rather than smoothed over, because each says
+something true about where a guard actually lives:
+
+| Mutation | Result | Why |
+|---|---|---|
+| fabricating a status **after** the transport check | `enrollment-gap.test.ts` **still green** | with no transport, `enroll` refuses before it reaches the fabricated line. #913's negative control is intact — it is simply testing an earlier point on the same path, which is why the *second* row above exists |
+| weakening `decodeIssueDeviceCredentialResult`'s framing | `refuses every truncation` **still green** | `ByteReader.take` bounds-checks before every read, so a truncation refuses without `finish()`. The same redundancy the TypeScript table above documents, in the same format, for the same reason |
+
+The seed-authority scan additionally carries its own coverage anchors — a
+fabricated violation of each of its three routes, an assertion that prose about
+the seed is *not* a violation while executable code is, and an assertion that
+the reader saw a manifest, a capability file and more than twenty sources. A
+boundary scanner that has silently stopped finding files reports success
+forever (`#553`).
+
+### What none of this proves
+
+`CALLER-AUTHENTICATION.md` §5: **there is no signature over responses.** Every
+case in `a response is judged as if the responder were hostile` establishes one
+thing — that whoever answered had seen the request, because `request_id` is 32
+CSPRNG bytes that appeared in exactly one outbound message. Not one of them
+establishes that the responder was ZUULI. An app that *received* the request
+holds the identifier and can answer with a `DeviceCredential` of its own
+choosing, and this client would accept it. Only a transport that authenticates
+the response destination closes that, which is
+[#461](https://github.com/free2z/zuu/issues/461), which is why the transport is
+shut.
+
 ## The boundary scanner
 
 `wallet/zuuli/scripts/project-boundary.node-test.mjs` gains seven cases, and

--- a/docs/intent-bridge/CONFORMANCE.md
+++ b/docs/intent-bridge/CONFORMANCE.md
@@ -133,10 +133,11 @@ request — really, through the shared implementation, over its own OS-CSPRNG
 device public keys — and fails at the transport, because there is not one.
 
 Baseline: 42 tests green across `transport.test.ts`, `deviceKeys.test.ts` and
-`issueDeviceCredential.test.ts`, plus 3 in
-`wallet/e2e2z/src/lib/messaging/enroll-intent.test.ts`, plus the 4 in
-`wallet/e2e2z/scripts/seed-authority-boundary.node-test.mjs`. Reproduce with
-`cd wallet/e2e2z && npx vitest run && node --test scripts/seed-authority-boundary.node-test.mjs`.
+`issueDeviceCredential.test.ts`, plus 5 across
+`wallet/e2e2z/src/lib/messaging/enroll-intent.test.ts` and
+`enroll-chunk-failure.test.ts`, plus the 6 in
+`wallet/e2e2z/scripts/authority-boundary.node-test.mjs`. Reproduce with
+`cd wallet/e2e2z && npx vitest run && node --test scripts/authority-boundary.node-test.mjs`.
 
 | Guard, as mutated | Test that must fail | Result |
 |---|---|---|
@@ -147,12 +148,26 @@ Baseline: 42 tests green across `transport.test.ts`, `deviceKeys.test.ts` and
 | session correlation, seen from the caller | `refuses an answer to a different request`, `refuses an answer whose identifier differs in one byte`, `refuses a replay of an answer it already accepted` | FAILS |
 | `IssueDeviceCredentialResultV1` trailing-byte refusal **and** re-encode equality, together | `the issue-device-credential family result > refuses trailing bytes` | FAILS |
 | `IssueDeviceCredentialResultV1` non-empty credential | `the issue-device-credential family result > refuses a zero-length credential` | FAILS |
-| seed authority: the wallet plugin as a dependency | `e2e2z holds no route to the wallet seed` | FAILS |
-| seed authority: a `plugin:zcash\|` invoke in the renderer | `e2e2z holds no route to the wallet seed` | FAILS |
-| seed authority: `get_seed_phrase` named in executable code | `e2e2z holds no route to the wallet seed` | FAILS |
+| seed authority: the wallet plugin as a dependency | `e2e2z holds neither seed authority nor dispatch authority` | FAILS |
+| seed authority: a `plugin:zcash\|` invoke in the renderer | `e2e2z holds neither seed authority nor dispatch authority` | FAILS |
+| seed authority: `get_seed_phrase` named in executable code | `e2e2z holds neither seed authority nor dispatch authority` | FAILS |
+| `enroll`'s lazy `import()` inside the `try`, so a chunk-load failure still wears the typed refusal | `a chunk that never loads > still refuses with the typed enrollment refusal` | FAILS |
+| dispatch authority: only a test may call `setIntentTransport` | `e2e2z holds neither seed authority nor dispatch authority` | FAILS |
 
-**10 mutations, 10 failures, 0 survivors.** Every one was applied, watched to
+**12 mutations, 12 failures, 0 survivors.** Every one was applied, watched to
 fail with a named assertion, and restored; the tree ends green.
+
+The last two rows came out of adversarial review and are the same objection
+pointed in two directions. `enroll` reaches its client through a lazy
+`import()`; with that statement *outside* the `try`, a chunk that fails to load
+escapes as an untyped error, and the screen — which branches on
+`isEnrollmentUnavailable` — would say "something broke" instead of the one true
+thing this app can say. And `setIntentTransport` is exported so the tests can
+drive the shipping path against a wallet stand-in; a guard defeated by one call
+to it from a renderer module has exactly the shape of the guard defeated by one
+boolean that `transport.ts` argues against. Neither changed what the app can do
+— both were already fail-closed — and both are now pinned rather than true by
+accident.
 
 ### What survived, and what that means
 
@@ -164,12 +179,14 @@ something true about where a guard actually lives:
 | fabricating a status **after** the transport check | `enrollment-gap.test.ts` **still green** | with no transport, `enroll` refuses before it reaches the fabricated line. #913's negative control is intact — it is simply testing an earlier point on the same path, which is why the *second* row above exists |
 | weakening `decodeIssueDeviceCredentialResult`'s framing | `refuses every truncation` **still green** | `ByteReader.take` bounds-checks before every read, so a truncation refuses without `finish()`. The same redundancy the TypeScript table above documents, in the same format, for the same reason |
 
-The seed-authority scan additionally carries its own coverage anchors — a
-fabricated violation of each of its three routes, an assertion that prose about
-the seed is *not* a violation while executable code is, and an assertion that
-the reader saw a manifest, a capability file and more than twenty sources. A
-boundary scanner that has silently stopped finding files reports success
-forever (`#553`).
+The authority scan additionally carries its own coverage anchors — a fabricated
+violation of each of its three seed routes, an assertion that prose about the
+seed is *not* a violation while executable code is, an assertion that
+`setIntentTransport` is permitted from a test and refused from a production
+module, an assertion that the transport rule fails loudly if the export it is
+about is ever renamed away, and an assertion that the reader saw a manifest, a
+capability file and more than twenty sources. A boundary scanner that has
+silently stopped finding files reports success forever (`#553`).
 
 ### What none of this proves
 

--- a/docs/intent-bridge/PROTOCOL.md
+++ b/docs/intent-bridge/PROTOCOL.md
@@ -52,6 +52,7 @@ one rendering.
 | Wallet — the rules | `rs/crates/f2z-intent` | parse, validate, expire, one-use, authorize caller, bind confirmation |
 | Wallet — the authority | `wallet/zuuli/src-tauri/src/intent.rs` | receive, confirm natively, act. `execute-payment` only — see [`AUTHORITY.md`](./AUTHORITY.md) |
 | Clients | `wallet/shared/src/intent` (`@free2z/wallet-shared`) | build requests, remember them, refuse unsolicited answers |
+| First caller | `wallet/e2e2z/src/lib/enrollment` | `issue-device-credential`, built through the client half, with one transport seam that is shut |
 
 There is **one** client implementation and
 `wallet/zuuli/scripts/project-boundary.mjs` enforces that: the guard names may
@@ -393,6 +394,14 @@ Therefore, until #461 lands:
 
 - **No intent carrying authority may be dispatched over a deep link.** Not
   `sign-challenge`, not `issue-device-credential`, not `execute-payment`.
+- The one caller that exists, `wallet/e2e2z/src/lib/enrollment`, holds that line
+  in one file: `transport.ts` declares an `IntentTransport` interface and ships
+  the only implementation there is, which **rejects**. It rejects before the
+  caller samples a device key set — sampling one for a request that cannot leave
+  the process discards the previous secrets for nothing — and it rejects again
+  inside `dispatch`, unconditionally, so flipping the availability flag moves the
+  refusal rather than removing it. When #461 lands, the work is to write an
+  `IntentTransport` and register it; nothing else on that path changes.
 - `f2z-intent` deliberately contains **no transport**: no URL parsing, no intent
   filter, no scheme. Adding one is the work #461 gates, not work this crate
   quietly permits.

--- a/wallet/e2e2z/README.md
+++ b/wallet/e2e2z/README.md
@@ -91,9 +91,12 @@ build with a Tauri IPC host that registers the plugin and not the trio — the
 exact shape `src-tauri/src/lib.rs` ships — and asserts no `f2zmsg_*` command was
 ever invoked. The intent path adds `src/lib/enrollment/*.test.ts`,
 `src/lib/messaging/enroll-intent.test.ts` — which drives a *fulfilled* wallet
-response through the shipping code and asserts `enroll` **still** refuses — and
-`scripts/seed-authority-boundary.node-test.mjs`, which judges all three routes
-seed authority could arrive by. `docs/intent-bridge/CONFORMANCE.md` records the
+response through the shipping code and asserts `enroll` **still** refuses —
+`src/lib/messaging/enroll-chunk-failure.test.ts`, which does the same for a
+lazily imported chunk that never loads, and
+`scripts/authority-boundary.node-test.mjs`, which judges the three routes seed
+authority could arrive by **and** holds `setIntentTransport` to test files, so
+dispatch authority cannot be installed by one call from the renderer. `docs/intent-bridge/CONFORMANCE.md` records the
 mutation matrix, including the two mutations that survive and why.
 
 ## Capabilities: named commands, never the blanket grant

--- a/wallet/e2e2z/README.md
+++ b/wallet/e2e2z/README.md
@@ -35,7 +35,20 @@ no capability entry grants them and none should try.
 Here there is no seed to borrow. Enrollment becomes a bridge call into the
 wallet authority, which issues the `DeviceCredential` (#905). Until that
 protocol lands there is no honest in-process implementation, so this crate
-registers no command at all and no capability addresses one.
+registers none of the trio and no capability addresses one.
+
+The one command this crate *does* register is
+`e2e2z_device_credential_keys` (`src-tauri/src/device.rs`): the **public**
+halves of this device's key set, which are exactly what an
+`issue-device-credential` request carries. It calls
+`tauri_plugin_f2zmsg::engine::Engine::prepare_device`, which samples from the OS
+CSPRNG, keeps the private halves in that process and hands back nothing else. It
+is an app-crate command for §2.2's reason — no `plugin:` prefix, no capability
+entry — and it is deliberately not part of the contract's §3 plugin surface,
+because it grants nothing. Generating that keypair in the renderer instead would
+mean a second cryptographic implementation and a private key in a
+garbage-collected JavaScript heap; `src/lib/enrollment/deviceKeys.ts` says so at
+the top and holds no `crypto.subtle`.
 
 **And the frontend fails closed rather than pretending.** The ported
 `src/lib/messaging/bridge.ts` keeps all three in its declared command
@@ -55,13 +68,33 @@ of one is a claim about the key transparency directory, and a fabricated
 before #461**: a custom-scheme deep link is not an authenticated channel, so no
 transport is invented here.
 
+**The caller half of that intent is built, and it is what `enroll` now runs.**
+`src/lib/enrollment/` reads this device's public keys, builds the request
+through `@free2z/wallet-shared` — the single intent-bridge implementation, the
+one `wallet/zuuli/scripts/project-boundary.mjs` forbids a second of — and hands
+it to `transport.ts`, which is the whole seam and which **rejects**. It rejects
+before a device key set is sampled, and it rejects again inside `dispatch`
+without consulting its own availability flag, so no single edit turns the
+refusal into a success. Response handling is implemented and tested against
+hand-assembled hostile bytes even though nothing can deliver one: correlation,
+family, window, status, framing and the credential's own encoding each get a
+case. What that validation proves is that the responder saw the request; it does
+**not** prove the responder was ZUULI, because
+`docs/intent-bridge/CALLER-AUTHENTICATION.md` §5 records that there is no
+signature over responses. That is #461's job, not this code's.
+
 Proved by `src/lib/messaging/enrollment-gap.test.ts` (the bridge refuses, never
 invokes, never resolves), `src/features/messages/index.enrollment-gap.test.tsx`
 (the screen renders the gap and offers nothing enrolled), and
 `tests/enrollment-gap.pw.ts`, which runs a real browser against the **default**
 build with a Tauri IPC host that registers the plugin and not the trio — the
 exact shape `src-tauri/src/lib.rs` ships — and asserts no `f2zmsg_*` command was
-ever invoked.
+ever invoked. The intent path adds `src/lib/enrollment/*.test.ts`,
+`src/lib/messaging/enroll-intent.test.ts` — which drives a *fulfilled* wallet
+response through the shipping code and asserts `enroll` **still** refuses — and
+`scripts/seed-authority-boundary.node-test.mjs`, which judges all three routes
+seed authority could arrive by. `docs/intent-bridge/CONFORMANCE.md` records the
+mutation matrix, including the two mutations that survive and why.
 
 ## Capabilities: named commands, never the blanket grant
 

--- a/wallet/e2e2z/package-lock.json
+++ b/wallet/e2e2z/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource-variable/ibm-plex-sans": "^5.3.0",
         "@fontsource/ibm-plex-mono": "^5.3.0",
+        "@free2z/wallet-shared": "file:../shared",
         "@radix-ui/react-slot": "^1.1.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-deep-link": "^2.4.9",
@@ -39,6 +40,10 @@
         "vite": "^6.4.3",
         "vitest": "3.2.7"
       }
+    },
+    "../shared": {
+      "name": "@free2z/wallet-shared",
+      "version": "0.1.0"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.3.0",
@@ -671,6 +676,10 @@
       "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
       "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "license": "MIT"
+    },
+    "node_modules/@free2z/wallet-shared": {
+      "resolved": "../shared",
+      "link": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",

--- a/wallet/e2e2z/package.json
+++ b/wallet/e2e2z/package.json
@@ -10,12 +10,12 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "typecheck:tests": "tsc --noEmit",
-    "test": "vitest run && node --test scripts/ui-copy-truncation.node-test.mjs scripts/seed-authority-boundary.node-test.mjs && playwright test",
+    "test": "vitest run && node --test scripts/ui-copy-truncation.node-test.mjs scripts/authority-boundary.node-test.mjs && playwright test",
     "tauri": "tauri",
     "test:e2e": "playwright test",
     "test:ui-copy": "node --test scripts/ui-copy-truncation.node-test.mjs",
-    "test:seed-boundary": "node --test scripts/seed-authority-boundary.node-test.mjs",
-    "verify": "npm run typecheck && npm run typecheck:tests && npm test"
+    "verify": "npm run typecheck && npm run typecheck:tests && npm test",
+    "test:authority-boundary": "node --test scripts/authority-boundary.node-test.mjs"
   },
   "dependencies": {
     "@fontsource-variable/ibm-plex-sans": "^5.3.0",

--- a/wallet/e2e2z/package.json
+++ b/wallet/e2e2z/package.json
@@ -10,15 +10,17 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "typecheck:tests": "tsc --noEmit",
-    "test": "vitest run && node --test scripts/ui-copy-truncation.node-test.mjs && playwright test",
+    "test": "vitest run && node --test scripts/ui-copy-truncation.node-test.mjs scripts/seed-authority-boundary.node-test.mjs && playwright test",
     "tauri": "tauri",
     "test:e2e": "playwright test",
     "test:ui-copy": "node --test scripts/ui-copy-truncation.node-test.mjs",
+    "test:seed-boundary": "node --test scripts/seed-authority-boundary.node-test.mjs",
     "verify": "npm run typecheck && npm run typecheck:tests && npm test"
   },
   "dependencies": {
     "@fontsource-variable/ibm-plex-sans": "^5.3.0",
     "@fontsource/ibm-plex-mono": "^5.3.0",
+    "@free2z/wallet-shared": "file:../shared",
     "@radix-ui/react-slot": "^1.1.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-deep-link": "^2.4.9",

--- a/wallet/e2e2z/scripts/authority-boundary.node-test.mjs
+++ b/wallet/e2e2z/scripts/authority-boundary.node-test.mjs
@@ -1,4 +1,13 @@
-// e2e2z reaches no seed, and this is the check that says so mechanically.
+// Two authorities e2e2z must not hold, checked mechanically.
+//
+// **Seed authority** — it must not be able to reach the Zcash seed.
+// **Dispatch authority** — it must not be able to send an authority-bearing
+// intent, because there is no transport that authenticates either end (#461).
+//
+// Both are enforced elsewhere by design and by review. This file is the part
+// that does not depend on anyone remembering.
+//
+// ## 1. Seed authority
 //
 // #904's premise is a hard one: this app holds device keys and a
 // `DeviceCredential` and **never** anything seed-derived
@@ -26,6 +35,27 @@
 // the way seed authority actually arrives, which is somebody adding the
 // obvious dependency or the obvious permission because a feature needed it.
 //
+// ## 2. Dispatch authority
+//
+// `src/lib/enrollment/transport.ts` ships one `IntentTransport`, and it
+// rejects. Two guards keep it that way and they are deliberately independent:
+// the client checks `available` before it samples a device key set, and
+// `dispatch` refuses anyway without reading that flag. Neither can be defeated
+// by one edit.
+//
+// But `setIntentTransport` is *exported*, because the tests drive the shipping
+// code path against a wallet stand-in rather than proving a parallel one works.
+// So a single call to it from any production module installs a transport and
+// walks straight past both guards — which is the same shape as the objection
+// the module's own comment raises about the availability flag, pointed the
+// other way. The registry is not a guard if anything in the renderer may write
+// to it.
+//
+// So: `setIntentTransport` may be *referenced* only from test files, until
+// #461's transport arrives and this rule is deliberately amended along with it.
+// `resetIntentTransport` is unrestricted — it restores the fail-closed default
+// and can only ever narrow what this app can do.
+//
 // Structured as a pure judge plus a live reader, so that the judge can be
 // handed a fabricated violation. A boundary scanner that has silently stopped
 // finding files reports success forever — #553's lesson — so the last test
@@ -47,6 +77,21 @@ const SEED_COMMANDS = ["get_seed_phrase", "get_backup_seed_phrase"];
 
 /** The IPC prefix of the wallet plugin, as a frontend would write it. */
 const WALLET_PLUGIN_PREFIX = "plugin:zcash|";
+
+/** The registry writer. Installing a transport is dispatch authority. */
+const TRANSPORT_INSTALLER = "setIntentTransport";
+
+/** Where it is declared. Referencing it here is the declaration, not a call. */
+const TRANSPORT_MODULE = "src/lib/enrollment/transport.ts";
+
+/** A file whose references to {@link TRANSPORT_INSTALLER} are permitted. */
+function isTestFile(file) {
+  return (
+    file.endsWith(".test.ts") ||
+    file.endsWith(".test.tsx") ||
+    file.endsWith(".pw.ts")
+  );
+}
 
 /**
  * Strip `//` line comments and `/* *\/` block comments.
@@ -76,7 +121,7 @@ export function withoutComments(source) {
 }
 
 /** Judge already-read inputs, so a fabricated violation can be handed in. */
-export function seedAuthorityFailures({ manifest, capabilities, sources }) {
+export function authorityFailures({ manifest, capabilities, sources }) {
   const failures = [];
 
   if (new RegExp(`(^|\\n)\\s*${FORBIDDEN_CRATE}\\s*=`).test(manifest)) {
@@ -107,6 +152,27 @@ export function seedAuthorityFailures({ manifest, capabilities, sources }) {
     }
     if (/\btauri_plugin_zcash\b/.test(code) || /\bZcashExt\b/.test(code)) {
       failures.push(`${file}: e2e2z must not use the wallet plugin's Rust API`);
+    }
+    if (
+      file !== TRANSPORT_MODULE &&
+      !isTestFile(file) &&
+      new RegExp(`\\b${TRANSPORT_INSTALLER}\\b`).test(code)
+    ) {
+      failures.push(
+        `${file}: only a test may call ${TRANSPORT_INSTALLER}; installing a transport is dispatch authority, and #461 has not landed`,
+      );
+    }
+  }
+
+  // The coverage anchor for the rule above. If the declaring module is renamed
+  // or the export is dropped, the rule silently protects nothing — so its
+  // subject has to be present for the check to mean anything (#553).
+  const transport = sources.get(TRANSPORT_MODULE);
+  if (transport !== undefined) {
+    if (!new RegExp(`export function ${TRANSPORT_INSTALLER}\\b`).test(transport)) {
+      failures.push(
+        `${TRANSPORT_MODULE}: must declare ${TRANSPORT_INSTALLER}; a rule about a name nobody declares is a rule about nothing`,
+      );
     }
   }
 
@@ -153,8 +219,8 @@ function readTree() {
   return { manifest, capabilities, sources };
 }
 
-test("e2e2z holds no route to the wallet seed", () => {
-  assert.deepEqual(seedAuthorityFailures(readTree()), []);
+test("e2e2z holds neither seed authority nor dispatch authority", () => {
+  assert.deepEqual(authorityFailures(readTree()), []);
 });
 
 test("the scan is not blind", () => {
@@ -171,14 +237,14 @@ test("prose about the seed is not a violation, and code is", () => {
     ["src/prose.ts", '// this app never calls get_seed_phrase\nexport const x = 1;'],
   ]);
   assert.deepEqual(
-    seedAuthorityFailures({ manifest: "", capabilities: new Map(), sources: commented }),
+    authorityFailures({ manifest: "", capabilities: new Map(), sources: commented }),
     [],
   );
 
   const executable = new Map([
     ["src/bad.ts", 'export const x = invoke("plugin:zcash|get_seed_phrase");'],
   ]);
-  const failures = seedAuthorityFailures({
+  const failures = authorityFailures({
     manifest: "",
     capabilities: new Map(),
     sources: executable,
@@ -186,15 +252,68 @@ test("prose about the seed is not a violation, and code is", () => {
   assert.equal(failures.length, 2, failures.join("\n"));
 });
 
+test("only a test may install an intent transport", () => {
+  // The rule fires on a production module...
+  const production = authorityFailures({
+    manifest: "",
+    capabilities: new Map(),
+    sources: new Map([
+      ["src/features/messages/index.tsx", "setIntentTransport(appLinkTransport);"],
+    ]),
+  });
+  assert.equal(production.length, 1, production.join("\n"));
+
+  // ...and does not fire on a test, or on the module that declares it.
+  assert.deepEqual(
+    authorityFailures({
+      manifest: "",
+      capabilities: new Map(),
+      sources: new Map([
+        ["src/lib/enrollment/transport.test.ts", "setIntentTransport(stub);"],
+        ["tests/whatever.pw.ts", "setIntentTransport(stub);"],
+        [
+          "src/lib/enrollment/transport.ts",
+          "export function setIntentTransport(transport) { active = transport; }",
+        ],
+      ]),
+    }),
+    [],
+  );
+
+  // Prose that merely names it is not an installation.
+  assert.deepEqual(
+    authorityFailures({
+      manifest: "",
+      capabilities: new Map(),
+      sources: new Map([
+        ["src/lib/messaging/bridge.ts", "// #461's work is to call setIntentTransport.\nexport const x = 1;"],
+      ]),
+    }),
+    [],
+  );
+});
+
+test("the transport rule cannot outlive the export it is about", () => {
+  // A rule whose subject has been renamed away protects nothing and says so.
+  const orphaned = authorityFailures({
+    manifest: "",
+    capabilities: new Map(),
+    sources: new Map([
+      ["src/lib/enrollment/transport.ts", "export function installTransport(t) {}"],
+    ]),
+  });
+  assert.equal(orphaned.length, 1, orphaned.join("\n"));
+});
+
 test("each route is judged, and each fabricated violation is caught", () => {
-  const crate = seedAuthorityFailures({
+  const crate = authorityFailures({
     manifest: '[dependencies]\ntauri-plugin-zcash = { path = "../../plugins/tauri-plugin-zcash" }\n',
     capabilities: new Map(),
     sources: new Map(),
   });
   assert.equal(crate.length, 1, crate.join("\n"));
 
-  const capability = seedAuthorityFailures({
+  const capability = authorityFailures({
     manifest: "",
     capabilities: new Map([
       ["capabilities/default.json", { permissions: ["core:default", "zcash:allow-get-balance"] }],
@@ -203,7 +322,7 @@ test("each route is judged, and each fabricated violation is caught", () => {
   });
   assert.equal(capability.length, 1, capability.join("\n"));
 
-  const rust = seedAuthorityFailures({
+  const rust = authorityFailures({
     manifest: "",
     capabilities: new Map(),
     sources: new Map([["src-tauri/src/bad.rs", "use tauri_plugin_zcash::ZcashExt as _;"]]),

--- a/wallet/e2e2z/scripts/seed-authority-boundary.node-test.mjs
+++ b/wallet/e2e2z/scripts/seed-authority-boundary.node-test.mjs
@@ -1,0 +1,212 @@
+// e2e2z reaches no seed, and this is the check that says so mechanically.
+//
+// #904's premise is a hard one: this app holds device keys and a
+// `DeviceCredential` and **never** anything seed-derived
+// (`docs/e2ee/ARCHITECTURE.md` §4.2). Every other guard in this tree is about
+// what happens when the boundary holds. This one is about the boundary itself.
+//
+// Three routes exist by which seed authority could arrive, and all three are
+// checked, because closing two of them is closing none:
+//
+//   1. **A crate.** Linking `tauri-plugin-zcash` puts the seed in this
+//      process's managed state. `src-tauri/src/lib.rs` asserts this too; it is
+//      repeated here so that a check written in the language of the manifest
+//      exists even if the crate's own test is deleted.
+//   2. **A capability.** A `zcash:*` grant would let the webview call the
+//      wallet plugin directly. `wallet/zuuli/scripts/surface-capability-authority.mjs`
+//      is the repository-wide version; this is the app-local one, and it runs
+//      in this app's own `npm test` rather than only in the ZUULI lane.
+//   3. **An invoke.** A frontend string is all it takes to call a command, and
+//      neither of the checks above sees one. `CLIENT-CONTRACT.md` §2.2 names
+//      the two commands that can reach the phrase — `get_seed_phrase` and
+//      `get_backup_seed_phrase` — so they are named here.
+//
+// Not a substitute for reading the code, and it does not pretend to be: an
+// equivalent route under another name would pass. It is the check that catches
+// the way seed authority actually arrives, which is somebody adding the
+// obvious dependency or the obvious permission because a feature needed it.
+//
+// Structured as a pure judge plus a live reader, so that the judge can be
+// handed a fabricated violation. A boundary scanner that has silently stopped
+// finding files reports success forever — #553's lesson — so the last test
+// asserts the reader saw something.
+
+import { strict as assert } from "node:assert";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { test } from "node:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appRoot = fileURLToPath(new URL("..", import.meta.url));
+
+/** The wallet plugin, by the name a manifest would name it. */
+const FORBIDDEN_CRATE = "tauri-plugin-zcash";
+
+/** The two commands that can reach the recovery phrase (§2.2). */
+const SEED_COMMANDS = ["get_seed_phrase", "get_backup_seed_phrase"];
+
+/** The IPC prefix of the wallet plugin, as a frontend would write it. */
+const WALLET_PLUGIN_PREFIX = "plugin:zcash|";
+
+/**
+ * Strip `//` line comments and `/* *\/` block comments.
+ *
+ * Prose in this tree discusses the seed at length — it has to, since the whole
+ * design is about not having one — so a scan over raw text would either be
+ * inert or would forbid explaining itself. Only executable text is judged.
+ */
+export function withoutComments(source) {
+  let out = "";
+  let index = 0;
+  while (index < source.length) {
+    if (source.startsWith("//", index)) {
+      const end = source.indexOf("\n", index);
+      index = end < 0 ? source.length : end;
+      continue;
+    }
+    if (source.startsWith("/*", index)) {
+      const end = source.indexOf("*/", index + 2);
+      index = end < 0 ? source.length : end + 2;
+      continue;
+    }
+    out += source[index];
+    index += 1;
+  }
+  return out;
+}
+
+/** Judge already-read inputs, so a fabricated violation can be handed in. */
+export function seedAuthorityFailures({ manifest, capabilities, sources }) {
+  const failures = [];
+
+  if (new RegExp(`(^|\\n)\\s*${FORBIDDEN_CRATE}\\s*=`).test(manifest)) {
+    failures.push(
+      `src-tauri/Cargo.toml: e2e2z must not link ${FORBIDDEN_CRATE}; ongoing messaging never needs the seed`,
+    );
+  }
+
+  for (const [file, capability] of capabilities) {
+    for (const permission of capability.permissions ?? []) {
+      const identifier =
+        typeof permission === "string" ? permission : permission?.identifier;
+      if (typeof identifier === "string" && identifier.startsWith("zcash:")) {
+        failures.push(`${file}: e2e2z must grant no zcash:* permission (${identifier})`);
+      }
+    }
+  }
+
+  for (const [file, source] of sources) {
+    const code = withoutComments(source);
+    if (code.includes(WALLET_PLUGIN_PREFIX)) {
+      failures.push(`${file}: e2e2z must not address the wallet plugin (${WALLET_PLUGIN_PREFIX})`);
+    }
+    for (const command of SEED_COMMANDS) {
+      if (code.includes(command)) {
+        failures.push(`${file}: e2e2z must not name the seed command ${command}`);
+      }
+    }
+    if (/\btauri_plugin_zcash\b/.test(code) || /\bZcashExt\b/.test(code)) {
+      failures.push(`${file}: e2e2z must not use the wallet plugin's Rust API`);
+    }
+  }
+
+  return failures;
+}
+
+function filesUnder(directory, extensions) {
+  const found = [];
+  const walk = (current) => {
+    for (const entry of readdirSync(current)) {
+      if (entry === "node_modules" || entry === "target" || entry === "dist") continue;
+      const full = path.join(current, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (extensions.some((extension) => entry.endsWith(extension))) found.push(full);
+    }
+  };
+  walk(directory);
+  return found;
+}
+
+function readTree() {
+  const manifest = readFileSync(path.join(appRoot, "src-tauri/Cargo.toml"), "utf8");
+
+  const capabilityDirectory = path.join(appRoot, "src-tauri/capabilities");
+  const capabilities = new Map();
+  for (const file of filesUnder(capabilityDirectory, [".json"])) {
+    capabilities.set(
+      path.relative(appRoot, file),
+      JSON.parse(readFileSync(file, "utf8")),
+    );
+  }
+
+  const sources = new Map();
+  for (const directory of ["src", "src-tauri/src", "tests"]) {
+    for (const file of filesUnder(path.join(appRoot, directory), [
+      ".ts",
+      ".tsx",
+      ".rs",
+    ])) {
+      sources.set(path.relative(appRoot, file), readFileSync(file, "utf8"));
+    }
+  }
+
+  return { manifest, capabilities, sources };
+}
+
+test("e2e2z holds no route to the wallet seed", () => {
+  assert.deepEqual(seedAuthorityFailures(readTree()), []);
+});
+
+test("the scan is not blind", () => {
+  const tree = readTree();
+  assert.ok(tree.manifest.length > 0, "the Tauri manifest must be read");
+  assert.ok(tree.capabilities.size > 0, "at least one capability file must be read");
+  assert.ok(tree.sources.size > 20, "the source tree must be read");
+});
+
+test("prose about the seed is not a violation, and code is", () => {
+  // The two halves of the comment rule, together. Without the first this file
+  // could not explain itself; without the second it would be decorative.
+  const commented = new Map([
+    ["src/prose.ts", '// this app never calls get_seed_phrase\nexport const x = 1;'],
+  ]);
+  assert.deepEqual(
+    seedAuthorityFailures({ manifest: "", capabilities: new Map(), sources: commented }),
+    [],
+  );
+
+  const executable = new Map([
+    ["src/bad.ts", 'export const x = invoke("plugin:zcash|get_seed_phrase");'],
+  ]);
+  const failures = seedAuthorityFailures({
+    manifest: "",
+    capabilities: new Map(),
+    sources: executable,
+  });
+  assert.equal(failures.length, 2, failures.join("\n"));
+});
+
+test("each route is judged, and each fabricated violation is caught", () => {
+  const crate = seedAuthorityFailures({
+    manifest: '[dependencies]\ntauri-plugin-zcash = { path = "../../plugins/tauri-plugin-zcash" }\n',
+    capabilities: new Map(),
+    sources: new Map(),
+  });
+  assert.equal(crate.length, 1, crate.join("\n"));
+
+  const capability = seedAuthorityFailures({
+    manifest: "",
+    capabilities: new Map([
+      ["capabilities/default.json", { permissions: ["core:default", "zcash:allow-get-balance"] }],
+    ]),
+    sources: new Map(),
+  });
+  assert.equal(capability.length, 1, capability.join("\n"));
+
+  const rust = seedAuthorityFailures({
+    manifest: "",
+    capabilities: new Map(),
+    sources: new Map([["src-tauri/src/bad.rs", "use tauri_plugin_zcash::ZcashExt as _;"]]),
+  });
+  assert.equal(rust.length, 1, rust.join("\n"));
+});

--- a/wallet/e2e2z/src-tauri/Cargo.toml
+++ b/wallet/e2e2z/src-tauri/Cargo.toml
@@ -24,7 +24,9 @@ tauri-build = { version = "2", features = [] }
 # it, and under #904 that becomes a bridge call into the wallet authority
 # rather than an in-process one, so the app-crate enrollment trio
 # (`f2zmsg_enrollment_status`, `f2zmsg_enroll`, `f2zmsg_unenroll`) is not
-# registered here either — see this crate's `src/lib.rs`.
+# registered here either — see this crate's `src/lib.rs`. What IS registered is
+# `e2e2z_device_credential_keys`, which returns this device's public keys and
+# nothing else; `src/device.rs` says why that is not a hole in the same rule.
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-deep-link = "2.4.9"

--- a/wallet/e2e2z/src-tauri/src/device.rs
+++ b/wallet/e2e2z/src-tauri/src/device.rs
@@ -1,0 +1,138 @@
+//! This device's public keys, for the `issue-device-credential` intent (#905).
+//!
+//! `docs/e2ee/ARCHITECTURE.md` §4.2 splits the messaging key material in two:
+//!
+//! - **Account keys** — `IdentitySigningKey`, `DirectoryAuthKey`,
+//!   `BackupWrapKey` — are *seed-derived*, so restoring the mnemonic restores
+//!   the identity. e2e2z never holds the seed and therefore never holds these.
+//! - **Device keys** — `DeviceSignatureKey`, `DeviceInitKey`, `QueueKey_{q}` —
+//!   are generated on-device from the **OS CSPRNG**, are **never
+//!   seed-derived**, and are **never exported**.
+//!
+//! That split is the entire reason this app can exist: ongoing messaging needs
+//! only the second set, so the seed is needed exactly once, at enrollment, to
+//! sign a `DeviceCredential` binding the account to the device. #905's
+//! `issue-device-credential` intent is how that one signature is asked for, and
+//! the request it carries needs this device's **public** halves.
+//!
+//! # Why this is a Rust command and not a few lines of `crypto.subtle`
+//!
+//! The keys already exist here. `tauri_plugin_f2zmsg::engine::Engine`'s
+//! `prepare_device` is the *only* place in the shipping tree that samples a
+//! device key set, it does it from `rand::rng()` (the OS generator), it keeps
+//! the private halves in the plugin's process memory, and `install_identity`
+//! is the only thing that can consume them. Generating a second keypair in the
+//! renderer would mean:
+//!
+//! 1. a second cryptographic implementation, in the least auditable process in
+//!    the system, whose output would then have to be smuggled *back* into the
+//!    engine for the credential to be worth anything, and
+//! 2. a private key in a garbage-collected JavaScript heap — the same exposure
+//!    `docs/e2ee/CLIENT-CONTRACT.md` §2.2 refuses for the wallet seed.
+//!
+//! So this command returns public halves and nothing else. There is no
+//! argument, no secret in the response, and no path from here to a private
+//! key.
+//!
+//! # Why an app-crate command and not a plugin command
+//!
+//! §2.2's rule: app-crate commands carry no `plugin:` prefix and need no
+//! capability entry, and `tauri-plugin-f2zmsg`'s command surface is the
+//! population `docs/e2ee/CLIENT-CONTRACT.md` §3 pins and
+//! `wallet/zuuli/scripts/messaging-contract.node-test.mjs` compares in both
+//! directions. This is not a messaging operation — it is enrollment's
+//! preparation, which is precisely the thing §2.2 keeps out of the plugin's
+//! IPC surface. ZUULI reaches `prepare_device` the same way, in process, from
+//! `wallet/zuuli/src-tauri/src/messaging.rs`.
+//!
+//! # It is not idempotent, and the caller must know that
+//!
+//! Each call samples a **fresh** device key set and replaces the engine's
+//! pending one, discarding the previous secrets. That is `prepare_device`'s
+//! existing contract and it is why the client calls this **after** it has
+//! established that a transport exists: preparing a device for a request that
+//! cannot be sent throws away key material for nothing.
+
+use serde::Serialize;
+use tauri::{AppHandle, Runtime};
+use tauri_plugin_f2zmsg::{F2zMsgExt as _, Result};
+
+/// The public halves of this device's key set, hex-encoded.
+///
+/// Hex rather than bytes because that is what the rest of this surface already
+/// speaks — `DeviceInfo.deviceFingerprint`, `StoredIdentity.device_pk` — and a
+/// JSON array of 32 numbers is the shape nobody can eyeball in a log.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceCredentialKeys {
+    /// `DSK.public` — the MLS leaf `signature_key`, 32 bytes, 64 hex
+    /// characters. `IssueDeviceCredentialRequestV1.device_pk`.
+    pub device_pk: String,
+    /// The X-Wing hybrid KEM public key.
+    /// `IssueDeviceCredentialRequestV1.device_kem_pk`.
+    ///
+    /// `tauri_plugin_f2zmsg::engine::DevicePublicKeys` documents at length why
+    /// this is a placeholder in this build: the HPKE init key MLS actually
+    /// uses is generated inside each OpenMLS `KeyPackage`, and nothing yet
+    /// binds the two. It is carried faithfully rather than being invented
+    /// here, so that when that circularity is broken upstream this path does
+    /// not have to change.
+    pub device_kem_pk: String,
+}
+
+/// Lowercase hex. Four lines, so that this crate does not grow a dependency to
+/// avoid writing them.
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+/// Sample this device's keys and return only their public halves.
+///
+/// # Errors
+///
+/// Whatever `tauri_plugin_f2zmsg` refuses with — the engine failing to open its
+/// store, or `prepare_device` refusing a degenerate sample. As every f2zmsg
+/// error does, it reaches the webview as a bare `ErrorCode` string.
+#[tauri::command]
+pub async fn e2e2z_device_credential_keys<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<DeviceCredentialKeys> {
+    let engine = app.f2zmsg().engine_handle()?;
+    let device = engine.prepare_device().await?;
+    Ok(DeviceCredentialKeys {
+        device_pk: hex(&device.device_pk),
+        device_kem_pk: hex(&device.device_kem_pk),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_is_lowercase_and_zero_padded() {
+        assert_eq!(hex(&[0x00, 0x0f, 0xa0, 0xff]), "000fa0ff");
+        assert_eq!(hex(&[]), "");
+    }
+
+    /// The response type is public keys and nothing else. A private half added
+    /// here would be exported device key material, which `ARCHITECTURE.md`
+    /// §4.2 forbids outright — so the field set is asserted rather than left to
+    /// review.
+    #[test]
+    fn the_response_carries_only_public_halves() {
+        let json = serde_json::to_value(DeviceCredentialKeys {
+            device_pk: hex(&[0x11; 32]),
+            device_kem_pk: hex(&[0x22; 8]),
+        })
+        .expect("the response serializes");
+        let object = json.as_object().expect("a JSON object");
+        let mut names: Vec<&str> = object.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        assert_eq!(names, ["deviceKemPk", "devicePk"]);
+    }
+}

--- a/wallet/e2e2z/src-tauri/src/lib.rs
+++ b/wallet/e2e2z/src-tauri/src/lib.rs
@@ -12,6 +12,14 @@
 //! issues the `DeviceCredential` (#905). Until that protocol lands there is no
 //! honest in-process implementation, so there is no command and no capability
 //! entry addressing one.
+//!
+//! What this crate *does* register is [`device::e2e2z_device_credential_keys`]:
+//! the **public** halves of this device's OS-CSPRNG key set, which are what an
+//! `issue-device-credential` request carries. It grants nothing, reveals no
+//! secret, and is the one piece of enrollment that does not need the seed. See
+//! that module for why it is here rather than in the plugin or in the renderer.
+
+pub mod device;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -19,6 +27,9 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_f2zmsg::init())
+        .invoke_handler(tauri::generate_handler![
+            device::e2e2z_device_credential_keys
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
@@ -35,5 +46,26 @@ mod tests {
             !manifest.contains("\ntauri-plugin-zcash ="),
             "e2e2z must not link tauri-plugin-zcash: ongoing messaging never needs the seed"
         );
+    }
+
+    /// The enrollment trio must stay absent from this crate's IPC surface.
+    ///
+    /// `e2e2z_device_credential_keys` is deliberately *not* one of them: it
+    /// returns public keys and cannot enroll anything. If a command whose name
+    /// starts `f2zmsg_` ever appears here, this app has grown the very surface
+    /// #904 split away, so the source is asserted rather than the doc comment.
+    #[test]
+    fn no_enrollment_command_is_registered() {
+        let source = include_str!("lib.rs");
+        let handler = source
+            .split("invoke_handler(tauri::generate_handler![")
+            .nth(1)
+            .and_then(|rest| rest.split("])").next())
+            .expect("the invoke_handler list");
+        assert!(
+            !handler.contains("f2zmsg_"),
+            "e2e2z must register no f2zmsg_* app-crate command: enrollment needs the seed"
+        );
+        assert!(handler.contains("e2e2z_device_credential_keys"));
     }
 }

--- a/wallet/e2e2z/src/lib/enrollment/deviceKeys.test.ts
+++ b/wallet/e2e2z/src/lib/enrollment/deviceKeys.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+//
+// The renderer's read of this device's public keys.
+//
+// jsdom because `@tauri-apps/api/core` reaches `window.__TAURI_INTERNALS__`,
+// and the point of the last two cases is that the *shipping* path — the real
+// lazy import, the real command name, the real parse — is what runs, rather
+// than an injected stand-in that would prove only that the injection works.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEVICE_CREDENTIAL_KEYS_COMMAND,
+  DEVICE_PUBLIC_KEY_BYTES,
+  DeviceKeysUnavailableError,
+  parseDeviceCredentialKeys,
+  readDeviceCredentialKeys,
+} from "./deviceKeys";
+
+const DEVICE_PK_HEX = "ab".repeat(DEVICE_PUBLIC_KEY_BYTES);
+const KEM_HEX = "22".repeat(1216);
+
+function installTauriHost(answer: (cmd: string) => unknown): string[] {
+  const invoked: string[] = [];
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    writable: true,
+    value: {
+      invoke(cmd: string) {
+        invoked.push(cmd);
+        return Promise.resolve(answer(cmd));
+      },
+    },
+  });
+  return invoked;
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(window as unknown as Record<string, unknown>, "__TAURI_INTERNALS__");
+  vi.restoreAllMocks();
+});
+
+describe("parsing this device's public keys", () => {
+  it("accepts the shape the app-crate command returns", () => {
+    const keys = parseDeviceCredentialKeys({
+      devicePk: DEVICE_PK_HEX,
+      deviceKemPk: KEM_HEX,
+    });
+    expect(keys.devicePublicKey).toHaveLength(DEVICE_PUBLIC_KEY_BYTES);
+    expect(keys.deviceKemPublicKey).toHaveLength(1216);
+  });
+
+  it("refuses every shape a request cannot be built from", () => {
+    const rejected: unknown[] = [
+      null,
+      "not an object",
+      {},
+      { devicePk: DEVICE_PK_HEX },
+      { deviceKemPk: KEM_HEX },
+      { devicePk: 17, deviceKemPk: KEM_HEX },
+      { devicePk: DEVICE_PK_HEX, deviceKemPk: null },
+      // Uppercase and odd-length are not hex the shared parser accepts, and a
+      // local regexp here would be a second answer to "what is hex".
+      { devicePk: DEVICE_PK_HEX.toUpperCase(), deviceKemPk: KEM_HEX },
+      { devicePk: "1".repeat(63), deviceKemPk: KEM_HEX },
+      // Short, long, and empty keys are each a credential bound to the wrong
+      // thing, so none of them may reach the encoder.
+      { devicePk: "ab".repeat(31), deviceKemPk: KEM_HEX },
+      { devicePk: "ab".repeat(33), deviceKemPk: KEM_HEX },
+      { devicePk: DEVICE_PK_HEX, deviceKemPk: "" },
+    ];
+    for (const value of rejected) {
+      expect(() => parseDeviceCredentialKeys(value)).toThrow(DeviceKeysUnavailableError);
+    }
+  });
+
+  it("never invents a key when a field is missing", () => {
+    // The failure that would matter: returning zeroed bytes rather than
+    // throwing, which would enroll a device nobody holds the private half of.
+    let produced: unknown = null;
+    try {
+      produced = parseDeviceCredentialKeys({ deviceKemPk: KEM_HEX });
+    } catch {
+      produced = "refused";
+    }
+    expect(produced).toBe("refused");
+  });
+});
+
+describe("reading them over IPC", () => {
+  it("invokes exactly the app-crate command, with no arguments and no prefix", async () => {
+    const invoked = installTauriHost(() => ({
+      devicePk: DEVICE_PK_HEX,
+      deviceKemPk: KEM_HEX,
+    }));
+    const keys = await readDeviceCredentialKeys();
+    expect(invoked).toEqual([DEVICE_CREDENTIAL_KEYS_COMMAND]);
+    // §2.2: app-crate commands carry no `plugin:` prefix and need no capability
+    // entry. A `plugin:` prefix here would mean this had been moved onto the
+    // messaging plugin's IPC surface, which is the population CLIENT-CONTRACT
+    // §3 pins.
+    expect(DEVICE_CREDENTIAL_KEYS_COMMAND.startsWith("plugin:")).toBe(false);
+    expect(keys.devicePublicKey[0]).toBe(0xab);
+  });
+
+  it("refuses a host that answers with the wrong shape", async () => {
+    installTauriHost(() => ({ devicePk: DEVICE_PK_HEX, secretKey: "oh no" }));
+    await expect(readDeviceCredentialKeys()).rejects.toBeInstanceOf(
+      DeviceKeysUnavailableError,
+    );
+  });
+});

--- a/wallet/e2e2z/src/lib/enrollment/deviceKeys.ts
+++ b/wallet/e2e2z/src/lib/enrollment/deviceKeys.ts
@@ -1,0 +1,117 @@
+/**
+ * This device's public keys, read from the process that owns them.
+ *
+ * `docs/e2ee/ARCHITECTURE.md` §4.2: device keys come from the **OS CSPRNG**,
+ * are **never seed-derived** and are **never exported**. All three clauses are
+ * enforced by where the keys live, not by this file — the sampling happens in
+ * `tauri_plugin_f2zmsg::engine::Engine::prepare_device`, the private halves
+ * stay in that process, and `wallet/e2e2z/src-tauri/src/device.rs` returns only
+ * the public halves. This module is the renderer's read of that result and
+ * nothing more.
+ *
+ * **There is no `crypto.subtle` here and there must never be one.** A second
+ * keypair generated in the renderer would be a second cryptographic
+ * implementation in the least auditable process in the system, holding a
+ * private key in a garbage-collected heap, and it would still have to be
+ * smuggled back into the engine before a credential over it meant anything.
+ * `src-tauri/src/device.rs` carries the long form of that argument.
+ *
+ * What this file *does* own is distrust of the answer. The command is
+ * app-crate, so the response is not covered by the plugin's `ErrorCode`
+ * contract or by any zod schema in `../messaging/types.ts`; it is parsed here,
+ * to the exact shape `IssueDeviceCredentialRequestV1` needs
+ * (`docs/intent-bridge/PROTOCOL.md` §3.3), and refused otherwise.
+ */
+
+import { fromHex } from "@free2z/wallet-shared";
+
+/** The wire name of the app-crate command. No `plugin:` prefix — §2.2. */
+export const DEVICE_CREDENTIAL_KEYS_COMMAND = "e2e2z_device_credential_keys";
+
+/** `IssueDeviceCredentialRequestV1.device_pk` is `opaque[32]`. */
+export const DEVICE_PUBLIC_KEY_BYTES = 32;
+
+/** The public halves an `issue-device-credential` request carries. */
+export interface DeviceCredentialKeys {
+  /** `DSK.public` — the MLS leaf signature key, exactly 32 bytes. */
+  readonly devicePublicKey: Uint8Array;
+  /** The X-Wing hybrid KEM public key, opaque and non-empty. */
+  readonly deviceKemPublicKey: Uint8Array;
+}
+
+/**
+ * The answer was not the shape this app can build a request from.
+ *
+ * Its own class rather than a bare `Error` because the enrollment client has to
+ * tell "the keys are unusable" from "there is nowhere to send them", and the
+ * two want different words in front of a user.
+ */
+export class DeviceKeysUnavailableError extends Error {
+  readonly reason = "device-keys-unavailable" as const;
+
+  constructor(detail: string) {
+    super(`this device's public keys could not be read: ${detail}`);
+    this.name = "DeviceKeysUnavailableError";
+  }
+}
+
+function requireHex(value: unknown, field: string): Uint8Array {
+  if (typeof value !== "string") {
+    throw new DeviceKeysUnavailableError(`${field} is not a string`);
+  }
+  // `fromHex` refuses odd lengths, uppercase and non-hex, and it is the shared
+  // implementation rather than a local regexp so that "what is hex" has one
+  // answer in this app.
+  try {
+    return fromHex(value);
+  } catch {
+    throw new DeviceKeysUnavailableError(`${field} is not lowercase hex`);
+  }
+}
+
+/**
+ * Parse the command's response.
+ *
+ * Separate from the invoke so the hostile shapes can be tested without a Tauri
+ * host: a missing field, a non-string, a short key, an empty KEM key. Each of
+ * those would otherwise reach `encodeIssueDeviceCredentialPayload`, which does
+ * refuse them — but it refuses with `INTENT_INVALID_VALUE`, which tells a user
+ * nothing about *which* side was wrong.
+ *
+ * @throws {@link DeviceKeysUnavailableError}
+ */
+export function parseDeviceCredentialKeys(value: unknown): DeviceCredentialKeys {
+  if (typeof value !== "object" || value === null) {
+    throw new DeviceKeysUnavailableError("the response is not an object");
+  }
+  const record = value as Record<string, unknown>;
+  const devicePublicKey = requireHex(record["devicePk"], "devicePk");
+  const deviceKemPublicKey = requireHex(record["deviceKemPk"], "deviceKemPk");
+  if (devicePublicKey.length !== DEVICE_PUBLIC_KEY_BYTES) {
+    throw new DeviceKeysUnavailableError(
+      `devicePk is ${devicePublicKey.length} bytes, not ${DEVICE_PUBLIC_KEY_BYTES}`,
+    );
+  }
+  if (deviceKemPublicKey.length === 0) {
+    throw new DeviceKeysUnavailableError("deviceKemPk is empty");
+  }
+  return { devicePublicKey, deviceKemPublicKey };
+}
+
+/**
+ * Sample this device's keys and read back their public halves.
+ *
+ * **Not idempotent.** Each call replaces the engine's pending device key set
+ * and discards the previous secrets — `prepare_device`'s existing contract. So
+ * the enrollment client calls this only once it knows a request can actually be
+ * dispatched.
+ *
+ * The `@tauri-apps/api/core` import is lazy, matching `../messaging/bridge.ts`,
+ * so the browser bundle never requires it.
+ *
+ * @throws {@link DeviceKeysUnavailableError}
+ */
+export async function readDeviceCredentialKeys(): Promise<DeviceCredentialKeys> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  return parseDeviceCredentialKeys(await invoke(DEVICE_CREDENTIAL_KEYS_COMMAND));
+}

--- a/wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.test.ts
+++ b/wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.test.ts
@@ -1,0 +1,519 @@
+// `issue-device-credential`, from this app's side, judged as if the responder
+// were hostile.
+//
+// Two halves, and the second is the one that would otherwise be written after a
+// transport exists — which is to say, after it is expensive to be wrong.
+//
+//   1. **The shipping build fails closed.** No transport means no dispatch, no
+//      device key sample, and never an `EnrollmentStatus`.
+//   2. **Response handling is real.** Nothing can deliver a response today, so
+//      every one below is hand-assembled from the bytes `PROTOCOL.md` §3
+//      specifies, the way an attacker would have to assemble one. Correlation,
+//      family, window, status, framing and the credential's own encoding each
+//      get a case, and each case is a shape a responder that saw the request
+//      could actually send.
+//
+// The response builder here is a fixture, not a second implementation: it emits
+// bytes, it validates nothing, and it exists precisely so the assertions are
+// against the shared decoder rather than against an encoder that agrees with it
+// by construction. `wallet/zuuli/src/lib/intent-bridge.test.ts` does the same.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  INTENT_PROTOCOL_VERSION,
+  IntentErrorCode,
+  IntentFamily,
+  MAX_INTENT_LIFETIME_MS,
+  decodeIntentRequest,
+  toHex,
+} from "@free2z/wallet-shared";
+import {
+  CREDENTIAL_BACKDATE_MS,
+  CREDENTIAL_LIFETIME_MS,
+  E2E2Z_CALLER,
+  ISSUE_DEVICE_CREDENTIAL_PURPOSE,
+  IntentRefusedError,
+  REQUEST_LIFETIME_MS,
+  createDeviceCredentialClient,
+  isIntentRefused,
+} from "./issueDeviceCredential";
+import { DeviceKeysUnavailableError } from "./deviceKeys";
+import {
+  IntentTransportUnavailableError,
+  isIntentTransportUnavailable,
+  resetIntentTransport,
+  type IntentDispatchContext,
+  type IntentTransport,
+} from "./transport";
+
+const NOW = 1_700_000_000_000;
+const DEVICE_PK = new Uint8Array(32).fill(0x11);
+const DEVICE_KEM_PK = new Uint8Array(1216).fill(0x22);
+const CREDENTIAL = new Uint8Array(96).fill(0x33);
+
+const keys = () =>
+  Promise.resolve({
+    devicePublicKey: DEVICE_PK,
+    deviceKemPublicKey: DEVICE_KEM_PK,
+  });
+
+/** Big-endian, the only endianness the format has. */
+function be(value: number, width: number): number[] {
+  const out: number[] = [];
+  for (let shift = (width - 1) * 8; shift >= 0; shift -= 8) {
+    out.push((value >>> shift) & 0xff);
+  }
+  return out;
+}
+
+/** `struct { opaque credential<0..2^24-1>; } IssueDeviceCredentialResultV1`. */
+function credentialResult(credential: Uint8Array): Uint8Array {
+  return Uint8Array.from([...be(credential.length, 3), ...credential]);
+}
+
+/**
+ * A response envelope, assembled byte by byte with no validation whatsoever.
+ *
+ * Every field is overridable because every field is somewhere an attacker can
+ * lie.
+ */
+function responseBytes(options: {
+  version?: number;
+  requestId: Uint8Array;
+  intent?: number;
+  status?: number;
+  payload?: Uint8Array;
+  /** Appended after the envelope, to model a padded or spliced frame. */
+  trailer?: Uint8Array;
+}): Uint8Array {
+  const payload = options.payload ?? credentialResult(CREDENTIAL);
+  const body = [
+    ...options.requestId,
+    ...be(options.intent ?? IntentFamily.IssueDeviceCredential, 2),
+    ...be(options.status ?? 0, 2),
+    ...be(payload.length, 3),
+    ...payload,
+  ];
+  return Uint8Array.from([
+    ...be(options.version ?? INTENT_PROTOCOL_VERSION, 2),
+    ...be(body.length, 3),
+    ...body,
+    ...(options.trailer ?? []),
+  ]);
+}
+
+/**
+ * A stand-in for the wallet authority.
+ *
+ * It is `available: true`, which no shipping transport is, and it records what
+ * it was handed so the *request* can be judged as well as the answer. `answer`
+ * receives the request identifier the client actually generated, because a
+ * responder that saw the request knows it — that is exactly the adversary
+ * `PROTOCOL.md` §6 says correlation does not exclude.
+ */
+function walletStandIn(
+  answer: (requestId: Uint8Array, request: Uint8Array) => Uint8Array | Promise<Uint8Array>,
+): IntentTransport & { readonly sent: Uint8Array[]; readonly contexts: IntentDispatchContext[] } {
+  const sent: Uint8Array[] = [];
+  const contexts: IntentDispatchContext[] = [];
+  return {
+    id: "wallet-stand-in",
+    available: true,
+    sent,
+    contexts,
+    async dispatch(request, context) {
+      sent.push(request);
+      contexts.push(context);
+      const decoded = decodeIntentRequest(request);
+      if (!decoded.ok) throw new Error("the stand-in was handed an undecodable request");
+      return answer(decoded.value.requestId, request);
+    },
+  };
+}
+
+function clientWith(transport: IntentTransport, now: () => number = () => NOW) {
+  return createDeviceCredentialClient({
+    transport: () => transport,
+    readKeys: keys,
+    now,
+  });
+}
+
+/** The refusal code, or a failure that says what happened instead. */
+async function refusalCode(promise: Promise<unknown>): Promise<IntentErrorCode> {
+  const caught = await promise.then(
+    (value) => ({ resolved: true as const, value }),
+    (error: unknown) => ({ resolved: false as const, error }),
+  );
+  if (caught.resolved) {
+    throw new Error(`expected a refusal, resolved with ${String(caught.value)}`);
+  }
+  if (!isIntentRefused(caught.error)) {
+    throw new Error(`expected an IntentRefusedError, got ${String(caught.error)}`);
+  }
+  return (caught.error as IntentRefusedError).code;
+}
+
+afterEach(() => {
+  resetIntentTransport();
+  vi.restoreAllMocks();
+});
+
+describe("the shipping build fails closed", () => {
+  it("refuses before it samples a device key set", async () => {
+    const readKeys = vi.fn(keys);
+    // No `transport` override: this is the module registry, in the state every
+    // packaged build ships it in.
+    const client = createDeviceCredentialClient({ readKeys, now: () => NOW });
+
+    await expect(client.requestDeviceCredential("alice")).rejects.toBeInstanceOf(
+      IntentTransportUnavailableError,
+    );
+    // `prepare_device` replaces this device's pending key set and discards the
+    // previous secrets. Sampling one for a request that cannot leave the
+    // process would throw key material away for nothing.
+    expect(readKeys).not.toHaveBeenCalled();
+    expect(client.pending).toBe(0);
+  });
+
+  it("never resolves, however the call is shaped", async () => {
+    const client = createDeviceCredentialClient({ readKeys: keys, now: () => NOW });
+    for (const handle of ["alice", "bob", "a".repeat(30)]) {
+      const settled = await client.requestDeviceCredential(handle).then(
+        (value) => ({ resolved: true as const, value }),
+        () => ({ resolved: false as const }),
+      );
+      expect(settled.resolved).toBe(false);
+    }
+  });
+
+  it("names the transport gap rather than blaming the wallet", async () => {
+    const client = createDeviceCredentialClient({ readKeys: keys, now: () => NOW });
+    const refusal = await client
+      .requestDeviceCredential("alice")
+      .catch((cause: unknown) => cause);
+    expect(isIntentTransportUnavailable(refusal)).toBe(true);
+    expect((refusal as IntentTransportUnavailableError).blockedOn).toBe(461);
+  });
+});
+
+describe("the request this app builds", () => {
+  it("is the structure the wallet parses, with the fields #905 specifies", async () => {
+    const transport = walletStandIn((requestId) => responseBytes({ requestId }));
+    await clientWith(transport).requestDeviceCredential("alice");
+
+    expect(transport.sent).toHaveLength(1);
+    const decoded = decodeIntentRequest(transport.sent[0] as Uint8Array);
+    expect(decoded.ok).toBe(true);
+    if (!decoded.ok) return;
+    const request = decoded.value;
+
+    expect(request.intent).toBe(IntentFamily.IssueDeviceCredential);
+    expect(request.caller).toBe(E2E2Z_CALLER);
+    expect(request.purpose).toBe(ISSUE_DEVICE_CREDENTIAL_PURPOSE);
+    expect(request.issuedAtMs).toBe(NOW);
+    expect(request.expiresAtMs).toBe(NOW + REQUEST_LIFETIME_MS);
+    expect(request.requestId).toHaveLength(32);
+
+    // §3.3's payload: handle, device_pk[32], device_kem_pk<0..2^24-1>,
+    // not_before_ms, not_after_ms. Asserted as bytes, because the point of the
+    // shared encoder is that these are the bytes the wallet's digest covers.
+    const notBefore = NOW - CREDENTIAL_BACKDATE_MS;
+    const notAfter = NOW + CREDENTIAL_LIFETIME_MS;
+    expect(toHex(request.payload)).toBe(
+      "05" +
+        toHex(new TextEncoder().encode("alice")) +
+        toHex(DEVICE_PK) +
+        "0004c0" +
+        toHex(DEVICE_KEM_PK) +
+        BigInt(notBefore).toString(16).padStart(16, "0") +
+        BigInt(notAfter).toString(16).padStart(16, "0"),
+    );
+  });
+
+  it("declares a window inside the protocol's ceiling", async () => {
+    const transport = walletStandIn((requestId) => responseBytes({ requestId }));
+    await clientWith(transport).requestDeviceCredential("alice");
+    const decoded = decodeIntentRequest(transport.sent[0] as Uint8Array);
+    if (!decoded.ok) throw new Error("the request must decode");
+    const lifetime = decoded.value.expiresAtMs - decoded.value.issuedAtMs;
+    expect(lifetime).toBeGreaterThan(0);
+    // "Nothing here is a continuous grant" (#904), enforced on the *declared*
+    // window so it binds even when the verifying clock is wrong.
+    expect(lifetime).toBeLessThanOrEqual(MAX_INTENT_LIFETIME_MS);
+  });
+
+  it("carries a fresh identifier every time", async () => {
+    const seen = new Set<string>();
+    const transport = walletStandIn((requestId) => {
+      seen.add(toHex(requestId));
+      return responseBytes({ requestId });
+    });
+    const client = clientWith(transport);
+    for (let index = 0; index < 8; index += 1) {
+      await client.requestDeviceCredential("alice");
+    }
+    expect(seen.size).toBe(8);
+  });
+
+  it("refuses a handle carrying a bidirectional override, before dispatch", async () => {
+    // `PROTOCOL.md` §3.5: bridge text is refused outright rather than escaped,
+    // because it is written by this app to appear inside ZUULI's confirmation.
+    const transport = walletStandIn((requestId) => responseBytes({ requestId }));
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("ali‮ce"))).toBe(
+      IntentErrorCode.InvalidValue,
+    );
+    expect(transport.sent).toHaveLength(0);
+  });
+
+  it("refuses an empty handle, before dispatch", async () => {
+    const transport = walletStandIn((requestId) => responseBytes({ requestId }));
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential(""))).toBe(
+      IntentErrorCode.InvalidValue,
+    );
+    expect(transport.sent).toHaveLength(0);
+  });
+
+  it("refuses unusable device keys without asking the wallet anything", async () => {
+    const transport = walletStandIn((requestId) => responseBytes({ requestId }));
+    const client = createDeviceCredentialClient({
+      transport: () => transport,
+      now: () => NOW,
+      readKeys: async () => ({
+        devicePublicKey: new Uint8Array(31).fill(0x11),
+        deviceKemPublicKey: DEVICE_KEM_PK,
+      }),
+    });
+    // Not a protocol refusal: the wrong side was wrong, and saying
+    // INTENT_INVALID_VALUE would point a reader at the wallet.
+    await expect(client.requestDeviceCredential("alice")).rejects.toBeInstanceOf(Error);
+    expect(transport.sent).toHaveLength(0);
+  });
+});
+
+describe("a response is judged as if the responder were hostile", () => {
+  it("accepts the one well-formed answer to the question it asked", async () => {
+    const transport = walletStandIn((requestId) => responseBytes({ requestId }));
+    const credential = await clientWith(transport).requestDeviceCredential("alice");
+    expect(toHex(credential)).toBe(toHex(CREDENTIAL));
+    // What this proves: the responder saw the request. What it does not prove:
+    // that the responder was ZUULI. CALLER-AUTHENTICATION.md §5 — there is no
+    // signature over responses, and correlation is not authentication.
+  });
+
+  it("refuses an answer to a different request", async () => {
+    const transport = walletStandIn(() =>
+      responseBytes({ requestId: new Uint8Array(32).fill(0xaa) }),
+    );
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Unsolicited,
+    );
+  });
+
+  it("refuses an answer whose identifier differs in one byte", async () => {
+    const transport = walletStandIn((requestId) => {
+      const near = Uint8Array.from(requestId);
+      near[31] = ((near[31] as number) ^ 0x01) & 0xff;
+      return responseBytes({ requestId: near });
+    });
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Unsolicited,
+    );
+  });
+
+  it("refuses a correlated answer that echoes a different family", async () => {
+    // The dangerous shape: right identifier, wrong family. Accepting it would
+    // route a `sign-challenge` result into a credential.
+    const transport = walletStandIn((requestId) =>
+      responseBytes({
+        requestId,
+        intent: IntentFamily.SignChallenge,
+        payload: credentialResult(CREDENTIAL),
+      }),
+    );
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Unsolicited,
+    );
+  });
+
+  it("refuses a version it does not implement, before reading the body", async () => {
+    const transport = walletStandIn((requestId) => responseBytes({ requestId, version: 2 }));
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.UnsupportedVersion,
+    );
+  });
+
+  it("refuses a truncated envelope rather than reading plausible zeroes", async () => {
+    const transport = walletStandIn((requestId) =>
+      responseBytes({ requestId }).subarray(0, 20),
+    );
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Malformed,
+    );
+  });
+
+  it("refuses trailing bytes after a complete envelope", async () => {
+    const transport = walletStandIn((requestId) =>
+      responseBytes({ requestId, trailer: Uint8Array.from([0x00]) }),
+    );
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Malformed,
+    );
+  });
+
+  it("refuses an empty response", async () => {
+    const transport = walletStandIn(() => new Uint8Array(0));
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Malformed,
+    );
+  });
+
+  it("refuses a family payload with a truncated credential length", async () => {
+    const transport = walletStandIn((requestId) =>
+      responseBytes({ requestId, payload: Uint8Array.from([0x00, 0x00, 0x40, 0x33]) }),
+    );
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Malformed,
+    );
+  });
+
+  it("refuses a family payload with bytes after the credential", async () => {
+    const transport = walletStandIn((requestId) =>
+      responseBytes({
+        requestId,
+        payload: Uint8Array.from([...credentialResult(CREDENTIAL), 0x00]),
+      }),
+    );
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Malformed,
+    );
+  });
+
+  it("refuses a zero-length credential, which frames perfectly and is not one", async () => {
+    const transport = walletStandIn((requestId) =>
+      responseBytes({ requestId, payload: credentialResult(new Uint8Array(0)) }),
+    );
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.InvalidValue,
+    );
+  });
+
+  it("never mistakes a refusal for a success", async () => {
+    for (const status of [
+      IntentErrorCode.CallerNotAuthorized,
+      IntentErrorCode.NotConfirmed,
+      IntentErrorCode.Expired,
+      IntentErrorCode.Replay,
+    ]) {
+      const transport = walletStandIn((requestId) =>
+        // §3.4: a refusal carries an empty payload.
+        responseBytes({ requestId, status, payload: new Uint8Array(0) }),
+      );
+      expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+        status,
+      );
+    }
+  });
+
+  it("refuses a refusal that also carries a payload", async () => {
+    // A payload beside a non-zero status is a channel with no defined meaning —
+    // and the concrete hazard is a client that reads the payload anyway and
+    // installs a credential the wallet said it was refusing.
+    const transport = walletStandIn((requestId) =>
+      responseBytes({
+        requestId,
+        status: IntentErrorCode.NotConfirmed,
+        payload: credentialResult(CREDENTIAL),
+      }),
+    );
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Malformed,
+    );
+  });
+
+  it("refuses an unknown refusal status rather than guessing", async () => {
+    const transport = walletStandIn((requestId) =>
+      responseBytes({ requestId, status: 4242, payload: new Uint8Array(0) }),
+    );
+    expect(await refusalCode(clientWith(transport).requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Malformed,
+    );
+  });
+
+  it("refuses a replay of an answer it already accepted", async () => {
+    let first: Uint8Array | null = null;
+    const transport = walletStandIn((requestId) => {
+      // The second call replays the FIRST response verbatim — the shape a
+      // recorded deep link has.
+      if (first === null) first = responseBytes({ requestId });
+      return first;
+    });
+    const client = clientWith(transport);
+    await expect(client.requestDeviceCredential("alice")).resolves.toBeInstanceOf(Uint8Array);
+    expect(await refusalCode(client.requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Unsolicited,
+    );
+  });
+
+  it("refuses an answer that arrives after the window closed", async () => {
+    let clock = NOW;
+    const transport = walletStandIn((requestId) => {
+      clock = NOW + REQUEST_LIFETIME_MS + 1;
+      return responseBytes({ requestId });
+    });
+    const client = clientWith(transport, () => clock);
+    expect(await refusalCode(client.requestDeviceCredential("alice"))).toBe(
+      IntentErrorCode.Expired,
+    );
+  });
+
+  it("consumes the outstanding question whether the answer is accepted or refused", async () => {
+    const transport = walletStandIn((requestId) =>
+      responseBytes({ requestId, intent: IntentFamily.ExecutePayment }),
+    );
+    const client = clientWith(transport);
+    await client.requestDeviceCredential("alice").catch(() => undefined);
+    // Nothing outstanding: a second delivery of the same bytes finds no
+    // question, which is what makes a recorded response worthless.
+    expect(client.pending).toBe(0);
+  });
+
+  it("does not launder a transport that resolves with a non-response", async () => {
+    const transport: IntentTransport = {
+      id: "broken",
+      available: true,
+      dispatch: async () => "definitely bytes" as unknown as Uint8Array,
+    };
+    await expect(
+      clientWith(transport).requestDeviceCredential("alice"),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("propagates a transport rejection unchanged", async () => {
+    const failure = new Error("the link was never opened");
+    const transport: IntentTransport = {
+      id: "failing",
+      available: true,
+      dispatch: () => Promise.reject(failure),
+    };
+    await expect(clientWith(transport).requestDeviceCredential("alice")).rejects.toBe(
+      failure,
+    );
+  });
+});
+
+describe("the refusal type", () => {
+  it("says which side was wrong", () => {
+    expect(new IntentRefusedError("request", IntentErrorCode.InvalidValue).stage).toBe(
+      "request",
+    );
+    expect(String(new IntentRefusedError("response", IntentErrorCode.Unsolicited))).toContain(
+      "INTENT_UNSOLICITED",
+    );
+  });
+
+  it("is recognizable after losing its prototype", () => {
+    expect(isIntentRefused({ reason: "intent-refused" })).toBe(true);
+    expect(isIntentRefused(new DeviceKeysUnavailableError("nope"))).toBe(false);
+  });
+});

--- a/wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.ts
+++ b/wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.ts
@@ -145,7 +145,8 @@ export function isIntentRefused(error: unknown): error is IntentRefusedError {
   );
 }
 
-function require_<T>(
+/** Unwrap an outcome, or throw the refusal it carries. */
+function orRefuse<T>(
   outcome: IntentOutcome<T>,
   stage: "request" | "response",
 ): T {
@@ -217,7 +218,7 @@ export function createDeviceCredentialClient(
 
       const keys = await readKeys();
       const issuedAtMs = now();
-      const payload = require_(
+      const payload = orRefuse(
         encodeIssueDeviceCredentialPayload({
           handle,
           devicePublicKey: keys.devicePublicKey,
@@ -232,7 +233,7 @@ export function createDeviceCredentialClient(
       const expiresAtMs = issuedAtMs + REQUEST_LIFETIME_MS;
       // `issue` encodes and records in one step, so there is no window in which
       // a request exists on the wire without an outstanding question behind it.
-      const encoded = require_(
+      const encoded = orRefuse(
         session.issue(
           {
             intent: IntentFamily.IssueDeviceCredential,
@@ -270,7 +271,7 @@ export function createDeviceCredentialClient(
       // different family, an expired window, a refusal status, a malformed or
       // truncated envelope, trailing bytes. All of it is the shared session's
       // and the shared decoder's, re-checked against the frozen record.
-      const accepted = require_(session.accept(answer, now()), "response");
+      const accepted = orRefuse(session.accept(answer, now()), "response");
 
       // Defence in depth. `accept` already tags the result from the *pending*
       // record rather than from the reply, and refuses a family mismatch; this
@@ -280,7 +281,7 @@ export function createDeviceCredentialClient(
         throw new IntentRefusedError("response", IntentErrorCode.Unsolicited);
       }
 
-      return require_(
+      return orRefuse(
         decodeIssueDeviceCredentialResult(accepted.payload),
         "response",
       );

--- a/wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.ts
+++ b/wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.ts
@@ -1,0 +1,289 @@
+/**
+ * The caller side of `issue-device-credential` — #905, #904, blocked on #461.
+ *
+ * ZUULI holds the Zcash seed and is therefore the wallet authority. e2e2z holds
+ * device keys and a `DeviceCredential` and never anything seed-derived
+ * (`docs/e2ee/ARCHITECTURE.md` §4.2). The one operation that crosses that line
+ * is enrollment: claiming a handle means signing with the seed-derived
+ * `IdentitySigningKey`, and the signature that binds *this* device to *that*
+ * account is a `DeviceCredential`. So this app asks for one, and asks in the
+ * one format both halves already implement.
+ *
+ * ## Everything here is built through the single implementation
+ *
+ * `@free2z/wallet-shared` is the only intent-bridge implementation in the
+ * repository and `wallet/zuuli/scripts/project-boundary.mjs` enforces that
+ * mechanically: the version gate, the request encoder, the response decoder,
+ * the outstanding-question map and the text validator may only be *declared*
+ * under `wallet/shared/src/intent`. This module declares none of them. It
+ * supplies policy — who is calling, what for, how long the request lives — and
+ * hands every byte decision to the shared code.
+ *
+ * That is not tidiness. The wallet binds the user's approval to a digest over
+ * the re-encoded request (`PROTOCOL.md` §5), so a client that encoded a request
+ * even slightly differently would be asking the user to approve a structure
+ * that means one thing here and another there.
+ *
+ * ## It fails closed, and the closure is one line deep
+ *
+ * There is no transport (`./transport.ts`), so in the shipping build this
+ * function throws before it samples a key. It **never** returns a fabricated
+ * credential and it **never** synthesizes an `EnrollmentStatus`: every field of
+ * one is a claim about the key-transparency directory, and a fabricated
+ * `enrolled: true` would make this app render a handle nobody published.
+ *
+ * ## What the response validation can and cannot prove
+ *
+ * `CALLER-AUTHENTICATION.md` §5 is explicit: **there is no signature over
+ * responses.** So the checks below prove exactly one thing — that whoever
+ * answered had seen this request, because `request_id` is 32 CSPRNG bytes that
+ * appeared in exactly one outbound message. They do **not** prove the responder
+ * was ZUULI. An app that *received* the request holds the identifier and can
+ * answer. Only a transport that authenticates the response destination closes
+ * that, which is #461, which is why nothing dispatches yet.
+ */
+
+import {
+  IntentErrorCode,
+  IntentFamily,
+  createIntentSession,
+  decodeIssueDeviceCredentialResult,
+  encodeIssueDeviceCredentialPayload,
+  intentErrorName,
+  intentFamilyName,
+  newRequestId,
+  toHex,
+  type IntentOutcome,
+  type IntentSession,
+} from "@free2z/wallet-shared";
+import {
+  readDeviceCredentialKeys,
+  type DeviceCredentialKeys,
+} from "./deviceKeys";
+import {
+  intentTransport,
+  IntentTransportUnavailableError,
+  type IntentTransport,
+} from "./transport";
+
+/**
+ * This app's own identifier — the bundle identifier `tauri.conf.json` declares.
+ *
+ * It is a **claim**, and the protocol says so. ZUULI renders the caller's
+ * display name from its own registry and never from this string
+ * (`CALLER-AUTHENTICATION.md` §2), and on iOS there is no attestation that
+ * could make it more than a claim. It is here so the wallet can look the caller
+ * up, not so the wallet can believe it.
+ */
+export const E2E2Z_CALLER = "cash.free2z.e2e2z";
+
+/**
+ * What the wallet renders inside its own confirmation.
+ *
+ * Bridge text (`PROTOCOL.md` §3.5): UTF-8, non-empty, trimmed, at most 255
+ * bytes, and no bidirectional or invisible-formatting control. A constant
+ * rather than something composed at the call site, because a `purpose` is
+ * authored by *this* app specifically to appear inside *ZUULI's* confirmation,
+ * and a string with a runtime-interpolated tail is a string an attacker who
+ * reaches the interpolation gets to write.
+ */
+export const ISSUE_DEVICE_CREDENTIAL_PURPOSE =
+  "Issue this device a messaging credential";
+
+/**
+ * How long the *request* stays answerable, in milliseconds.
+ *
+ * Two minutes, against §3.4's five-minute ceiling. The user has to read a
+ * confirmation in another app, so seconds are too few; the ceiling exists
+ * because "nothing here is a continuous grant" (#904), so the whole window
+ * should be no longer than the task needs.
+ */
+export const REQUEST_LIFETIME_MS = 120_000;
+
+/**
+ * How long the *credential* is requested for.
+ *
+ * The same window `wallet/zuuli/src-tauri/src/messaging.rs` already uses when
+ * it issues one in process — an hour of backdating for clock skew, then a year
+ * — so the bridged path and the in-process path ask for the identical thing.
+ * `KT.md` §4.1 leaves the window to the issuer, and ZUULI is the issuer: these
+ * are a **request**, and it may narrow them.
+ */
+export const CREDENTIAL_BACKDATE_MS = 3_600_000;
+/** See {@link CREDENTIAL_BACKDATE_MS}. */
+export const CREDENTIAL_LIFETIME_MS = 31_536_000_000;
+
+/**
+ * A refusal that came from the protocol rather than from the transport.
+ *
+ * `stage` says which side was wrong, and it matters: `request` means this app
+ * built something unsendable and is a bug here, while `response` means the
+ * answer failed a check and is either a broken responder or a hostile one.
+ */
+export class IntentRefusedError extends Error {
+  readonly reason = "intent-refused" as const;
+  readonly code: IntentErrorCode;
+  readonly stage: "request" | "response";
+
+  constructor(stage: "request" | "response", code: IntentErrorCode) {
+    super(
+      `the issue-device-credential ${stage} was refused: ${intentErrorName(code)}`,
+    );
+    this.name = "IntentRefusedError";
+    this.stage = stage;
+    this.code = code;
+  }
+}
+
+/** Whether a caught value is an {@link IntentRefusedError}, prototype or not. */
+export function isIntentRefused(error: unknown): error is IntentRefusedError {
+  return (
+    error instanceof IntentRefusedError ||
+    (typeof error === "object" &&
+      error !== null &&
+      (error as { reason?: unknown }).reason === "intent-refused")
+  );
+}
+
+function require_<T>(
+  outcome: IntentOutcome<T>,
+  stage: "request" | "response",
+): T {
+  if (!outcome.ok) throw new IntentRefusedError(stage, outcome.error);
+  return outcome.value;
+}
+
+/** The seams a test replaces. Production passes none of them. */
+export interface DeviceCredentialClientOptions {
+  /** The outstanding-question map. One per client, never module-global. */
+  readonly session?: IntentSession;
+  /** Where the bytes go. Defaults to the registry in `./transport.ts`. */
+  readonly transport?: () => IntentTransport;
+  /** How device public keys are read. Defaults to the app-crate command. */
+  readonly readKeys?: () => Promise<DeviceCredentialKeys>;
+  /** The wall clock. */
+  readonly now?: () => number;
+}
+
+/** The client half of `issue-device-credential`. */
+export interface DeviceCredentialClient {
+  /**
+   * Ask the wallet authority to issue this device a credential for `handle`.
+   *
+   * Resolves with the credential's canonical bytes — opaque here on purpose:
+   * it is a `f2z_kt_core::DeviceCredential`, defined once in that crate, and
+   * the layer that installs it is the one that validates it.
+   *
+   * @throws {@link IntentTransportUnavailableError} in every shipping build.
+   * @throws {@link IntentRefusedError} when the protocol refuses either half.
+   * @throws `DeviceKeysUnavailableError` when this device's keys are unusable.
+   */
+  requestDeviceCredential(handle: string): Promise<Uint8Array>;
+  /** How many questions are outstanding, for tests and diagnostics. */
+  readonly pending: number;
+}
+
+/**
+ * A client.
+ *
+ * A factory and not a singleton, for `createIntentSession`'s reason: a module
+ * global would be shared between two independent surfaces in one process, so
+ * one surface's response could be matched against another's question.
+ */
+export function createDeviceCredentialClient(
+  options: DeviceCredentialClientOptions = {},
+): DeviceCredentialClient {
+  const session = options.session ?? createIntentSession();
+  const transportOf = options.transport ?? intentTransport;
+  const readKeys = options.readKeys ?? readDeviceCredentialKeys;
+  const now = options.now ?? (() => Date.now());
+  const family = intentFamilyName(IntentFamily.IssueDeviceCredential);
+
+  return {
+    get pending(): number {
+      return session.size;
+    },
+
+    async requestDeviceCredential(handle: string): Promise<Uint8Array> {
+      const transport = transportOf();
+      // Before anything is sampled. `prepare_device` replaces this device's
+      // pending key set and discards the previous secrets, so preparing a
+      // device for a request that cannot leave the process throws key material
+      // away for nothing. The transport refuses again inside `dispatch`, and
+      // that second refusal does not read this flag — see `./transport.ts`.
+      if (!transport.available) {
+        throw new IntentTransportUnavailableError(family);
+      }
+
+      const keys = await readKeys();
+      const issuedAtMs = now();
+      const payload = require_(
+        encodeIssueDeviceCredentialPayload({
+          handle,
+          devicePublicKey: keys.devicePublicKey,
+          deviceKemPublicKey: keys.deviceKemPublicKey,
+          notBeforeMs: Math.max(0, issuedAtMs - CREDENTIAL_BACKDATE_MS),
+          notAfterMs: issuedAtMs + CREDENTIAL_LIFETIME_MS,
+        }),
+        "request",
+      );
+
+      const requestId = newRequestId();
+      const expiresAtMs = issuedAtMs + REQUEST_LIFETIME_MS;
+      // `issue` encodes and records in one step, so there is no window in which
+      // a request exists on the wire without an outstanding question behind it.
+      const encoded = require_(
+        session.issue(
+          {
+            intent: IntentFamily.IssueDeviceCredential,
+            requestId,
+            caller: E2E2Z_CALLER,
+            purpose: ISSUE_DEVICE_CREDENTIAL_PURPOSE,
+            issuedAtMs,
+            expiresAtMs,
+            payload,
+          },
+          issuedAtMs,
+        ),
+        "request",
+      );
+
+      // The record stays outstanding if this rejects. It is keyed by 32 CSPRNG
+      // bytes and expires on its own; removing it here would mean a response
+      // that crossed a slow dispatch's rejection could never be judged.
+      const answer = await transport.dispatch(encoded, {
+        family,
+        requestId: toHex(requestId),
+        expiresAtMs,
+      });
+
+      // A transport is not trusted to have returned bytes at all. Anything else
+      // is a programming error in the transport, not a message, so it is not
+      // laundered into a protocol refusal.
+      if (!(answer instanceof Uint8Array)) {
+        throw new TypeError(
+          `the ${transport.id} transport resolved with something that is not a response`,
+        );
+      }
+
+      // Every hostile shape is judged here: an unsolicited identifier, a
+      // different family, an expired window, a refusal status, a malformed or
+      // truncated envelope, trailing bytes. All of it is the shared session's
+      // and the shared decoder's, re-checked against the frozen record.
+      const accepted = require_(session.accept(answer, now()), "response");
+
+      // Defence in depth. `accept` already tags the result from the *pending*
+      // record rather than from the reply, and refuses a family mismatch; this
+      // costs nothing and means a future change to that tagging cannot quietly
+      // route another family's payload into a credential.
+      if (accepted.intent !== IntentFamily.IssueDeviceCredential) {
+        throw new IntentRefusedError("response", IntentErrorCode.Unsolicited);
+      }
+
+      return require_(
+        decodeIssueDeviceCredentialResult(accepted.payload),
+        "response",
+      );
+    },
+  };
+}

--- a/wallet/e2e2z/src/lib/enrollment/transport.test.ts
+++ b/wallet/e2e2z/src/lib/enrollment/transport.test.ts
@@ -1,0 +1,95 @@
+// The seam, tested as the thing it is: a refusal that cannot be argued out of.
+//
+// `docs/intent-bridge/PROTOCOL.md` §7 forbids dispatching any authority-bearing
+// intent until #461 lands. The failure mode that matters is not "it errors" —
+// it is a transport that quietly starts answering, because everything upstream
+// of it is finished and would believe the answer.
+
+import { describe, expect, it } from "vitest";
+import {
+  IntentTransportUnavailableError,
+  intentTransport,
+  isIntentTransportUnavailable,
+  resetIntentTransport,
+  setIntentTransport,
+  unavailableIntentTransport,
+  type IntentDispatchContext,
+} from "./transport";
+
+const CONTEXT: IntentDispatchContext = {
+  family: "issue-device-credential",
+  requestId: "77".repeat(32),
+  expiresAtMs: 1_700_000_120_000,
+};
+
+describe("the intent transport", () => {
+  it("is unavailable by default, in every build", () => {
+    resetIntentTransport();
+    expect(intentTransport()).toBe(unavailableIntentTransport);
+    expect(intentTransport().available).toBe(false);
+  });
+
+  it("rejects rather than resolving, with a typed refusal", async () => {
+    await expect(
+      unavailableIntentTransport.dispatch(new Uint8Array(4), CONTEXT),
+    ).rejects.toBeInstanceOf(IntentTransportUnavailableError);
+  });
+
+  it("never resolves to bytes a caller could mistake for a response", async () => {
+    const settled = await unavailableIntentTransport
+      .dispatch(new Uint8Array(4), CONTEXT)
+      .then(
+        (value) => ({ resolved: true as const, value }),
+        () => ({ resolved: false as const }),
+      );
+    expect(settled.resolved).toBe(false);
+  });
+
+  it("names the family, the reason and the blocking issue", async () => {
+    const refusal = await unavailableIntentTransport
+      .dispatch(new Uint8Array(4), CONTEXT)
+      .catch((cause: unknown) => cause);
+    expect(isIntentTransportUnavailable(refusal)).toBe(true);
+    const typed = refusal as IntentTransportUnavailableError;
+    expect(typed.reason).toBe("intent-transport-not-built");
+    expect(typed.blockedOn).toBe(461);
+    expect(typed.family).toBe("issue-device-credential");
+    // A bug report has to be actionable without a debugger.
+    expect(String(typed)).toContain("#461");
+  });
+
+  it("does not gate its refusal on the availability flag", async () => {
+    // The client checks `available` before it samples a device key set, so a
+    // reviewer could reasonably ask whether flipping one boolean is all that
+    // stands between here and a dispatch. It is not: `dispatch` refuses
+    // unconditionally, and this is the assertion that keeps that true.
+    const flipped = { ...unavailableIntentTransport, available: true };
+    expect(flipped.available).toBe(true);
+    await expect(
+      flipped.dispatch(new Uint8Array(4), CONTEXT),
+    ).rejects.toBeInstanceOf(IntentTransportUnavailableError);
+  });
+
+  it("recognizes a refusal that lost its prototype", () => {
+    expect(
+      isIntentTransportUnavailable({ reason: "intent-transport-not-built" }),
+    ).toBe(true);
+    expect(isIntentTransportUnavailable(new Error("something else"))).toBe(false);
+    expect(isIntentTransportUnavailable(null)).toBe(false);
+  });
+
+  it("registers and restores, so a real transport is one registration", () => {
+    const stub = {
+      id: "test",
+      available: true,
+      dispatch: async () => new Uint8Array(0),
+    };
+    try {
+      setIntentTransport(stub);
+      expect(intentTransport()).toBe(stub);
+    } finally {
+      resetIntentTransport();
+    }
+    expect(intentTransport()).toBe(unavailableIntentTransport);
+  });
+});

--- a/wallet/e2e2z/src/lib/enrollment/transport.ts
+++ b/wallet/e2e2z/src/lib/enrollment/transport.ts
@@ -1,0 +1,167 @@
+/**
+ * The one seam where intent bytes would leave this process — and it is shut.
+ *
+ * Everything else in `src/lib/enrollment/` is finished work: this app can
+ * sample its device keys, build a byte-exact `issue-device-credential` request,
+ * remember it, and judge an answer. What it cannot do is **send** one, and this
+ * module is the single place that is true.
+ *
+ * ## Why there is no transport, stated as the docs state it
+ *
+ * `docs/intent-bridge/PROTOCOL.md` §7 and
+ * `docs/intent-bridge/CALLER-AUTHENTICATION.md` §4 draw the same line twice:
+ *
+ * - **A custom scheme is not an authenticated channel.** Any app can register
+ *   `zuuli://`. Shipping the response half over one would let a hostile app
+ *   register the response link and answer with a `DeviceCredential` this app
+ *   would then install — [#367](https://github.com/free2z/zuu/issues/367)'s
+ *   confused deputy, moved from the frame layer to the OS layer.
+ * - **What replaces it is domain-bound.** A verified App Link or Universal Link
+ *   reaches only the app whose package or team owns the domain association,
+ *   which needs `assetlinks.json` and `apple-app-site-association` served from
+ *   a domain we control — [#461](https://github.com/free2z/zuu/issues/461),
+ *   still blocked.
+ *
+ * §7 therefore says, without qualification: *no intent carrying authority may
+ * be dispatched over a deep link* until that lands. `issue-device-credential`
+ * carries authority.
+ *
+ * ## The shape of the seam
+ *
+ * One interface, one method, one fail-closed implementation, and a module-level
+ * registry so that a real transport is a single registration rather than an
+ * edit spread through the enrollment path. When #461 lands, the work is to
+ * write an `IntentTransport` and call {@link setIntentTransport} — not to
+ * unpick a refusal from the middle of a flow.
+ *
+ * ## Two independent guards, on purpose
+ *
+ * {@link IntentTransport.available} is what the enrollment client checks
+ * *before* it samples device keys, because sampling a device key set for a
+ * request that cannot be sent discards the previous one for nothing
+ * (`src-tauri/src/device.rs`). {@link unavailableIntentTransport.dispatch}
+ * refuses **anyway**, and refuses unconditionally — it does not read the flag.
+ * So flipping `available` to `true` does not produce a success; it produces the
+ * same typed refusal one step later. A guard that can be defeated by editing
+ * one boolean is not a guard, and
+ * `src/lib/enrollment/transport.test.ts` pins exactly that.
+ */
+
+/** What a dispatch is for, so a real transport can log and route without parsing. */
+export interface IntentDispatchContext {
+  /** The family name, from `intentFamilyName` — for logs only. */
+  readonly family: string;
+  /** The request identifier, hex. The response correlator; never a secret. */
+  readonly requestId: string;
+  /** Wall-clock expiry of the request, milliseconds since the epoch. */
+  readonly expiresAtMs: number;
+}
+
+/**
+ * Carry a request to the wallet authority and bring back its answer.
+ *
+ * An implementation MUST NOT interpret the bytes. Correlation, family, window
+ * and status are re-checked by the session in
+ * `@free2z/wallet-shared`; a transport that decided anything for itself would
+ * be a second implementation of the guard the boundary scanner exists to
+ * forbid.
+ */
+export interface IntentTransport {
+  /** A stable name for logs and for tests to assert against. */
+  readonly id: string;
+  /**
+   * Whether this transport can both deliver a request **and** receive a
+   * response over a channel that authenticates its destination.
+   *
+   * Both halves, because half of it is worthless: a channel that delivers but
+   * cannot authenticate the answer is exactly the confused deputy §4 describes.
+   */
+  readonly available: boolean;
+  /** The response envelope, verbatim. Rejects rather than resolving on failure. */
+  dispatch(
+    request: Uint8Array,
+    context: IntentDispatchContext,
+  ): Promise<Uint8Array>;
+}
+
+/**
+ * The refusal, thrown wherever an intent would have travelled.
+ *
+ * Typed, with a machine-readable `reason`, so no caller has to match on prose
+ * and no caller can mistake it for a network error worth retrying. There is
+ * nothing to retry: the transport does not exist.
+ */
+export class IntentTransportUnavailableError extends Error {
+  /** Machine-readable, and structured-clone survivable. */
+  readonly reason = "intent-transport-not-built" as const;
+  /** The issue that unblocks this, so a log line carries its own next step. */
+  readonly blockedOn = 461 as const;
+  /** The family that was refused, for logs. */
+  readonly family: string;
+
+  constructor(family: string) {
+    super(
+      `the ${family} intent cannot be dispatched: e2e2z has no authenticated ` +
+        "transport to the wallet authority. A custom-scheme deep link does not " +
+        "authenticate its sender or its receiver, so no intent carrying " +
+        "authority may travel over one (docs/intent-bridge/PROTOCOL.md §7). " +
+        "Verified App Links and Universal Links are issue #461.",
+    );
+    this.name = "IntentTransportUnavailableError";
+    this.family = family;
+  }
+}
+
+/** Whether a caught value is the transport refusal, prototype or not. */
+export function isIntentTransportUnavailable(
+  error: unknown,
+): error is IntentTransportUnavailableError {
+  return (
+    error instanceof IntentTransportUnavailableError ||
+    (typeof error === "object" &&
+      error !== null &&
+      (error as { reason?: unknown }).reason === "intent-transport-not-built")
+  );
+}
+
+/**
+ * The shipping transport: none.
+ *
+ * It **throws**. It never resolves, and in particular it never resolves to
+ * bytes — because a transport that returned a plausible response envelope
+ * would be a transport that fabricated a `DeviceCredential`, and this app would
+ * install it. `docs/e2ee/CLIENT-CONTRACT.md` §2.4's rule is that nothing here
+ * may synthesize an `EnrollmentStatus`; synthesizing the credential that
+ * produces one would be the same defect wearing a hat.
+ */
+export const unavailableIntentTransport: IntentTransport = {
+  id: "unavailable",
+  available: false,
+  dispatch(_request: Uint8Array, context: IntentDispatchContext): Promise<never> {
+    // Deliberately not gated on `available`. See the module note.
+    return Promise.reject(new IntentTransportUnavailableError(context.family));
+  },
+};
+
+let active: IntentTransport = unavailableIntentTransport;
+
+/** The transport the enrollment client will use. */
+export function intentTransport(): IntentTransport {
+  return active;
+}
+
+/**
+ * Install a transport.
+ *
+ * The only production caller this will ever have is #461's App Link surface.
+ * Until then it exists so the tests can drive the *shipping* code path against
+ * a wallet stand-in, rather than proving a parallel one works.
+ */
+export function setIntentTransport(transport: IntentTransport): void {
+  active = transport;
+}
+
+/** Restore the fail-closed default. */
+export function resetIntentTransport(): void {
+  active = unavailableIntentTransport;
+}

--- a/wallet/e2e2z/src/lib/messaging/bridge.ts
+++ b/wallet/e2e2z/src/lib/messaging/bridge.ts
@@ -210,14 +210,30 @@ async function invoke<T>(
  * fabricated `enrolled: true` would make this app render a handle nobody
  * published and offer first contact it cannot complete. Failing closed is the
  * only answer that stays true.
+ *
+ * `enroll` is no longer a bare refusal: it runs `../enrollment`'s real
+ * `issue-device-credential` client, which builds the request the wallet
+ * authority would answer and fails at the one seam that has no implementation.
+ * The refusal it produces is wrapped back into this type, with the underlying
+ * cause attached, so every consumer's branch is unchanged and no shipping build
+ * can reach an `EnrollmentStatus` by that path either.
  */
 export class EnrollmentUnavailableError extends Error {
   /** Machine-readable, so a caller never has to match on the message. */
   readonly reason = "enrollment-requires-wallet-app" as const;
   /** The bridge method that was refused, for logs and tests. */
   readonly method: BridgeMethod;
+  /**
+   * What actually stopped the call, when something did.
+   *
+   * Declared here rather than passed to `Error`'s `options.cause`, which is
+   * ES2022 and this app compiles to ES2020. A boundary that summarised the
+   * failure and discarded it would make every enrollment bug read the same in
+   * a report, which is exactly the state #904 is trying to leave.
+   */
+  readonly cause?: unknown;
 
-  constructor(method: BridgeMethod) {
+  constructor(method: BridgeMethod, options?: { cause?: unknown }) {
     super(
       `${WIRE_COMMANDS[method]} is unavailable in e2e2z: enrollment derives ` +
         "account keys from the wallet seed, which this app never holds. Enroll " +
@@ -225,6 +241,7 @@ export class EnrollmentUnavailableError extends Error {
     );
     this.name = "EnrollmentUnavailableError";
     this.method = method;
+    this.cause = options?.cause;
   }
 }
 
@@ -644,13 +661,36 @@ export const enrollment = {
   },
 
   /**
-   * In ZUULI: a directory submission, not an instant effect. Here: refused —
-   * claiming a handle means signing with the §4.2 `DirectoryAuthKey`, which is
-   * derived from the seed this app does not have.
+   * In ZUULI: a directory submission, not an instant effect. Here: an
+   * `issue-device-credential` intent addressed to the wallet authority, which
+   * holds the seed-derived §4.2 `IdentitySigningKey` this app never will.
+   *
+   * The request is built for real — through `@free2z/wallet-shared`, over this
+   * device's OS-CSPRNG public keys, byte-identical to what `f2z-intent` parses
+   * — and then fails at the transport, because there is no channel that
+   * authenticates either end (`docs/intent-bridge/PROTOCOL.md` §7, #461).
+   *
+   * **It can only reject.** The declared return type is `EnrollmentStatus` and
+   * there is no expression in this function that produces one: even a
+   * successful round trip yields a `DeviceCredential`, which has to be
+   * installed before any status could be read back, and installing it is
+   * `install_identity`'s job in a process this app does not have a command for.
+   * The refusal is re-wrapped so the screen's branch stays the one it was.
    */
   async enroll(handle: string): Promise<EnrollmentStatus> {
     if (useMock()) return mockMessaging.enroll(handle);
-    void handle;
+    const { createDeviceCredentialClient } = await import(
+      "../enrollment/issueDeviceCredential"
+    );
+    try {
+      await createDeviceCredentialClient().requestDeviceCredential(handle);
+    } catch (cause) {
+      throw new EnrollmentUnavailableError("enroll", { cause });
+    }
+    // Unreachable while no transport exists, and it must stay unreachable in
+    // the sense that matters: a credential is not a status, and this app has no
+    // way to install one. Refusing here rather than returning a shape is what
+    // keeps `enrolled: true` unfabricatable.
     return refuseEnrollment("enroll");
   },
 

--- a/wallet/e2e2z/src/lib/messaging/bridge.ts
+++ b/wallet/e2e2z/src/lib/messaging/bridge.ts
@@ -676,13 +676,22 @@ export const enrollment = {
    * installed before any status could be read back, and installing it is
    * `install_identity`'s job in a process this app does not have a command for.
    * The refusal is re-wrapped so the screen's branch stays the one it was.
+   *
+   * The dynamic `import()` is **inside** the `try` deliberately. A chunk that
+   * fails to load — offline, a half-rolled deploy, a stale service worker —
+   * rejects, and outside the `try` that rejection would escape as an untyped
+   * error. It would still fail closed, since nothing about it can produce a
+   * status, but the screen branches on `isEnrollmentUnavailable` and would take
+   * the error path instead of the standing gap path: a user would be told
+   * something broke rather than that enrollment happens in the wallet app. The
+   * typed refusal is the contract, so every way this can fail has to wear it.
    */
   async enroll(handle: string): Promise<EnrollmentStatus> {
     if (useMock()) return mockMessaging.enroll(handle);
-    const { createDeviceCredentialClient } = await import(
-      "../enrollment/issueDeviceCredential"
-    );
     try {
+      const { createDeviceCredentialClient } = await import(
+        "../enrollment/issueDeviceCredential"
+      );
       await createDeviceCredentialClient().requestDeviceCredential(handle);
     } catch (cause) {
       throw new EnrollmentUnavailableError("enroll", { cause });

--- a/wallet/e2e2z/src/lib/messaging/enroll-chunk-failure.test.ts
+++ b/wallet/e2e2z/src/lib/messaging/enroll-chunk-failure.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+//
+// `enroll`'s lazily imported chunk fails to load. It must still refuse in the
+// typed way.
+//
+// `bridge.ts` reaches the intent client through a dynamic `import()`, matching
+// the lazy `@tauri-apps/api/core` import beside it, so the browser bundle never
+// requires either. That import can reject on its own: offline, a half-rolled
+// deploy, a stale service worker holding a manifest whose chunks are gone.
+//
+// It fails closed either way — a rejected import cannot produce an
+// `EnrollmentStatus`. What is at stake is narrower and still worth a test: the
+// screen branches on `isEnrollmentUnavailable`, so an untyped escape would show
+// a user "something went wrong" instead of the standing "enrollment happens in
+// the wallet app" state, which is the one true thing this app can say. The
+// typed refusal is the contract; every way this can fail has to wear it.
+//
+// Its own file because it plays with the module registry — `vi.resetModules()`
+// plus a `vi.doMock` factory that throws — and a reset registry orphans the
+// module instances other tests in a file have already captured. `enroll-intent
+// .test.ts` registers a transport into exactly such an instance.
+//
+// The mutation that proves this is not inert: move the `import()` above the
+// `try` in `bridge.ts` and the first assertion below fails, because the raw
+// chunk-load error escapes `enroll` unwrapped.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EnrollmentUnavailableError } from "./bridge";
+
+const CHUNK_FAILURE = "Failed to fetch dynamically imported module";
+
+afterEach(() => {
+  vi.doUnmock("../enrollment/issueDeviceCredential");
+  vi.resetModules();
+});
+
+describe("a chunk that never loads", () => {
+  it("still refuses with the typed enrollment refusal", async () => {
+    vi.resetModules();
+    vi.doMock("../enrollment/issueDeviceCredential", () => {
+      throw new Error(CHUNK_FAILURE);
+    });
+
+    // A fresh instance, so the mock applies to the import `enroll` performs.
+    const { enrollment, EnrollmentUnavailableError: Refusal } = await import(
+      "./bridge"
+    );
+
+    const refusal = await enrollment
+      .enroll("alice")
+      .catch((cause: unknown) => cause);
+
+    expect(refusal).toBeInstanceOf(Refusal);
+    const typed = refusal as EnrollmentUnavailableError;
+    expect(typed.reason).toBe("enrollment-requires-wallet-app");
+    expect(typed.method).toBe("enroll");
+    // Not summarised away: whatever actually failed is still reachable from the
+    // refusal, so a bug report can say which of the two failure modes this was.
+    expect(typed.cause).toBeDefined();
+  });
+
+  it("never resolves, so the screen cannot read it as enrolled", async () => {
+    vi.resetModules();
+    vi.doMock("../enrollment/issueDeviceCredential", () => {
+      throw new Error(CHUNK_FAILURE);
+    });
+    const { enrollment } = await import("./bridge");
+
+    const settled = await enrollment.enroll("alice").then(
+      (value) => ({ resolved: true as const, value }),
+      () => ({ resolved: false as const }),
+    );
+    expect(settled.resolved).toBe(false);
+  });
+});

--- a/wallet/e2e2z/src/lib/messaging/enroll-intent.test.ts
+++ b/wallet/e2e2z/src/lib/messaging/enroll-intent.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+//
+// The negative control that matters most, run against the *best* case.
+//
+// `enrollment-gap.test.ts` proves `enroll` refuses when there is nowhere to
+// send an intent. This file proves something stronger and less obvious: even
+// when a transport exists, even when it answers with a perfectly framed,
+// correctly correlated `issue-device-credential` response carrying a
+// credential, `enroll` **still** refuses — because a `DeviceCredential` is not
+// an `EnrollmentStatus`, and this app has no command that could install one.
+//
+// That is the shape of the mistake this whole boundary exists to prevent: a
+// client that gets a plausible answer and renders itself enrolled. `docs/e2ee/
+// CLIENT-CONTRACT.md` §2.4 states the rule — nothing in e2e2z may fabricate an
+// `EnrollmentStatus` — and a rule that is only true because the happy path is
+// unreachable is a rule that breaks the day the path opens.
+//
+// jsdom, because this exercises the shipping path end to end: the real lazy
+// `@tauri-apps/api/core` import, the real app-crate command, the real shared
+// encoder, and the real session.
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  INTENT_PROTOCOL_VERSION,
+  IntentFamily,
+  decodeIntentRequest,
+} from "@free2z/wallet-shared";
+import {
+  E2E2Z_CALLER,
+  ISSUE_DEVICE_CREDENTIAL_PURPOSE,
+} from "../enrollment/issueDeviceCredential";
+import {
+  resetIntentTransport,
+  setIntentTransport,
+  type IntentTransport,
+} from "../enrollment/transport";
+import { DEVICE_CREDENTIAL_KEYS_COMMAND } from "../enrollment/deviceKeys";
+import { EnrollmentUnavailableError, enrollment } from "./bridge";
+
+const DEVICE_PK_HEX = "ab".repeat(32);
+const KEM_HEX = "22".repeat(1216);
+const CREDENTIAL = new Uint8Array(96).fill(0x33);
+
+function be(value: number, width: number): number[] {
+  const out: number[] = [];
+  for (let shift = (width - 1) * 8; shift >= 0; shift -= 8) {
+    out.push((value >>> shift) & 0xff);
+  }
+  return out;
+}
+
+/** A response the wallet authority would be entitled to send. */
+function fulfilled(requestId: Uint8Array): Uint8Array {
+  const payload = [...be(CREDENTIAL.length, 3), ...CREDENTIAL];
+  const body = [
+    ...requestId,
+    ...be(IntentFamily.IssueDeviceCredential, 2),
+    ...be(0, 2),
+    ...be(payload.length, 3),
+    ...payload,
+  ];
+  return Uint8Array.from([
+    ...be(INTENT_PROTOCOL_VERSION, 2),
+    ...be(body.length, 3),
+    ...body,
+  ]);
+}
+
+function installTauriHost(): string[] {
+  const invoked: string[] = [];
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    writable: true,
+    value: {
+      invoke(cmd: string) {
+        invoked.push(cmd);
+        if (cmd === DEVICE_CREDENTIAL_KEYS_COMMAND) {
+          return Promise.resolve({
+            devicePk: DEVICE_PK_HEX,
+            deviceKemPk: KEM_HEX,
+          });
+        }
+        return Promise.reject(new Error(`Command ${cmd} not found`));
+      },
+    },
+  });
+  return invoked;
+}
+
+afterEach(() => {
+  resetIntentTransport();
+  Reflect.deleteProperty(
+    window as unknown as Record<string, unknown>,
+    "__TAURI_INTERNALS__",
+  );
+});
+
+describe("enroll builds a real intent and still cannot enroll", () => {
+  it("sends the wallet authority the request #905 specifies", async () => {
+    const invoked = installTauriHost();
+    const sent: Uint8Array[] = [];
+    const transport: IntentTransport = {
+      id: "wallet-stand-in",
+      available: true,
+      async dispatch(request) {
+        sent.push(request);
+        const decoded = decodeIntentRequest(request);
+        if (!decoded.ok) throw new Error("undecodable request");
+        return fulfilled(decoded.value.requestId);
+      },
+    };
+    setIntentTransport(transport);
+
+    // Still a rejection. The whole point.
+    await expect(enrollment.enroll("alice")).rejects.toBeInstanceOf(
+      EnrollmentUnavailableError,
+    );
+
+    // …and it got that far by doing the real work.
+    expect(invoked).toEqual([DEVICE_CREDENTIAL_KEYS_COMMAND]);
+    expect(sent).toHaveLength(1);
+    const decoded = decodeIntentRequest(sent[0] as Uint8Array);
+    expect(decoded.ok).toBe(true);
+    if (!decoded.ok) return;
+    expect(decoded.value.intent).toBe(IntentFamily.IssueDeviceCredential);
+    expect(decoded.value.caller).toBe(E2E2Z_CALLER);
+    expect(decoded.value.purpose).toBe(ISSUE_DEVICE_CREDENTIAL_PURPOSE);
+  });
+
+  it("never resolves to an EnrollmentStatus even on a fulfilled response", async () => {
+    installTauriHost();
+    setIntentTransport({
+      id: "wallet-stand-in",
+      available: true,
+      async dispatch(request) {
+        const decoded = decodeIntentRequest(request);
+        if (!decoded.ok) throw new Error("undecodable request");
+        return fulfilled(decoded.value.requestId);
+      },
+    });
+    const settled = await enrollment.enroll("alice").then(
+      (value) => ({ resolved: true as const, value }),
+      () => ({ resolved: false as const }),
+    );
+    expect(settled.resolved).toBe(false);
+  });
+
+  it("keeps the refusal typed, with the underlying cause attached", async () => {
+    installTauriHost();
+    const failure = new Error("the wallet never answered");
+    setIntentTransport({
+      id: "failing",
+      available: true,
+      dispatch: () => Promise.reject(failure),
+    });
+    const refusal = await enrollment
+      .enroll("alice")
+      .catch((cause: unknown) => cause);
+    expect(refusal).toBeInstanceOf(EnrollmentUnavailableError);
+    // A bug report needs the real reason, not only the boundary's summary.
+    expect((refusal as EnrollmentUnavailableError).cause).toBe(failure);
+  });
+});

--- a/wallet/shared/src/intent/index.ts
+++ b/wallet/shared/src/intent/index.ts
@@ -35,6 +35,7 @@ export {
   REQUEST_ID_BYTES,
   decodeIntentRequest,
   decodeIntentResponse,
+  decodeIssueDeviceCredentialResult,
   encodeExecutePaymentPayload,
   encodeIntentRequest,
   encodeIssueDeviceCredentialPayload,

--- a/wallet/shared/src/intent/wire.ts
+++ b/wallet/shared/src/intent/wire.ts
@@ -293,6 +293,45 @@ export function encodeExecutePaymentPayload(payment: {
   });
 }
 
+/**
+ * Decode an `issue-device-credential` family **result**.
+ *
+ * `struct { opaque credential<0..2^24-1>; } IssueDeviceCredentialResultV1`
+ * (§3.3). The credential stays opaque: it is a
+ * `f2z_kt_core::DeviceCredential`, defined once in that crate, and a second
+ * definition on this side would be a second chance to disagree about the bytes
+ * the whole key-transparency directory is built on. What this function
+ * guarantees is only that the *framing* is exactly one well-formed structure —
+ * the caller must still hand the bytes to the layer that validates them.
+ *
+ * Three refusals, and each is a shape a hostile responder can send:
+ *
+ * - a **truncated** payload, caught by the reader's before-the-read bounds
+ *   check rather than becoming a short array of plausible zeroes;
+ * - **trailing bytes** after the credential, caught by `finish()` and again by
+ *   re-encode equality, because a payload that decodes two ways is a payload
+ *   whose meaning depends on who is reading;
+ * - an **empty** credential, which frames perfectly and is not a credential.
+ *   `KT.md` §4.1 gives no valid zero-length encoding, so accepting it would
+ *   mean returning `ok` for nothing at all.
+ */
+export function decodeIssueDeviceCredentialResult(
+  payload: Uint8Array,
+): IntentOutcome<Uint8Array> {
+  return outcome(() => {
+    const reader = new ByteReader(payload);
+    const credential = reader.opaque24();
+    reader.finish();
+    if (credential.length === 0) refuse(IntentErrorCode.InvalidValue);
+    const writer = new ByteWriter();
+    writer.opaque24(credential);
+    if (!bytesEqual(writer.finish(), payload)) {
+      refuse(IntentErrorCode.Malformed);
+    }
+    return credential;
+  });
+}
+
 /** Encode an `issue-device-credential` family payload. Public keys only. */
 export function encodeIssueDeviceCredentialPayload(device: {
   readonly handle: string;

--- a/wallet/zuuli/src/lib/intent-bridge.test.ts
+++ b/wallet/zuuli/src/lib/intent-bridge.test.ts
@@ -28,6 +28,7 @@ import {
   createIntentSession,
   decodeIntentRequest,
   decodeIntentResponse,
+  decodeIssueDeviceCredentialResult,
   encodeExecutePaymentPayload,
   encodeIntentRequest,
   encodeIssueDeviceCredentialPayload,
@@ -482,5 +483,53 @@ describe("the session refuses answers to questions it did not ask", () => {
     const second = toHex(newRequestId());
     expect(first).toHaveLength(64);
     expect(first).not.toBe(second);
+  });
+});
+
+describe("the issue-device-credential family result", () => {
+  const credential = new Uint8Array(96).fill(0x33);
+
+  /** `struct { opaque credential<0..2^24-1>; }`, assembled by hand. */
+  function result(bytes: Uint8Array): Uint8Array {
+    return Uint8Array.from([
+      (bytes.length >>> 16) & 0xff,
+      (bytes.length >>> 8) & 0xff,
+      bytes.length & 0xff,
+      ...bytes,
+    ]);
+  }
+
+  it("returns the credential bytes untouched", () => {
+    // Opaque on purpose: a `DeviceCredential` is defined once, in
+    // `f2z-kt-core`, and a second definition here would be a second chance to
+    // disagree about the bytes the directory is built on.
+    expect(toHex(unwrap(decodeIssueDeviceCredentialResult(result(credential))))).toBe(
+      toHex(credential),
+    );
+  });
+
+  it("refuses every truncation", () => {
+    const encoded = result(credential);
+    for (let cut = 0; cut < encoded.length; cut += 1) {
+      expect(refusal(decodeIssueDeviceCredentialResult(encoded.subarray(0, cut)))).toBe(
+        IntentErrorCode.Malformed,
+      );
+    }
+  });
+
+  it("refuses trailing bytes", () => {
+    expect(
+      refusal(
+        decodeIssueDeviceCredentialResult(
+          Uint8Array.from([...result(credential), 0x00]),
+        ),
+      ),
+    ).toBe(IntentErrorCode.Malformed);
+  });
+
+  it("refuses a zero-length credential, which frames perfectly", () => {
+    expect(
+      refusal(decodeIssueDeviceCredentialResult(result(new Uint8Array(0)))),
+    ).toBe(IntentErrorCode.InvalidValue);
   });
 });


### PR DESCRIPTION
Closes the caller half of `#905`'s `issue-device-credential` intent in
`cash.free2z.e2e2z`. e2e2z's enrollment stops being a bare refusal and becomes a
**real, validated request built through the single intent-bridge client** — and
still fails closed, because there is no authenticated transport.

> **STACKED ON #913.** Branched from `origin/feat/port-messaging-e2e2z`, which is
> reviewed and green but not merged. #913 will squash-merge, so its commits will
> not be ancestors of `main` and this PR currently re-proposes its files. **Before
> merging this**, run:
>
> ```
> git fetch origin && git rebase --onto origin/main f715f60 feat/e2e2z-intent-client
> ```
>
> and verify by the **shrink** — the diff must drop to only the paths listed under
> "What changed" below (21 files, ~300 net lines). If #913's files still show
> large diffs, **STOP**; a bad rebase can silently revert merged work.

## The architecture this rests on

`docs/e2ee/ARCHITECTURE.md` §4.2 splits messaging key material in two:

- **Account keys** (`CeremonySigningKey`, `DirectoryAuthKey`, `BackupWrapKey`) —
  seed-derived, so restoring the mnemonic restores the identity. ZUULI holds the
  seed; e2e2z never will.
- **Device keys** (`DeviceSignatureKey`, `DeviceInitKey`, `QueueKey_{q}`) — OS
  CSPRNG, **never** seed-derived, **never** exported.

The consequence that makes the split work: **ongoing messaging never needs the
seed — only enrollment does.** So enrollment is one request to the wallet
authority, and everything else stays local.

## What changed

**Device keys come from Rust, not the renderer.**
`wallet/e2e2z/src-tauri/src/device.rs` adds `e2e2z_device_credential_keys`, an
**app-crate** command (§2.2: no `plugin:` prefix, no capability entry, not part
of `CLIENT-CONTRACT.md` §3's plugin surface). It calls
`tauri_plugin_f2zmsg::engine::Engine::prepare_device` — the only place in the
tree that samples a device key set, from `rand::rng()` — and returns the
**public** halves only. There is no `crypto.subtle` anywhere in
`src/lib/enrollment/`, and there must never be: a renderer keypair would be a
second cryptographic implementation holding a private key in a
garbage-collected JS heap, and it would still have to be smuggled back into the
engine before a credential over it meant anything.

**The request is built through `wallet/shared/src/intent`, not hand-rolled.**
`src/lib/enrollment/issueDeviceCredential.ts` supplies policy only — caller,
purpose, window — and hands every byte decision to `createIntentSession`,
`encodeIssueDeviceCredentialPayload` and `encodeIntentRequest`. It declares none
of the five names `project-boundary.mjs` reserves. One new decoder,
`decodeIssueDeviceCredentialResult`, lands **in the shared package** beside the
family encoder it mirrors, rather than as a local parser.

**The transport is ONE seam and it is shut.** `src/lib/enrollment/transport.ts`
declares an `IntentTransport` interface and the only implementation there is,
which rejects with a typed `IntentTransportUnavailableError`
(`reason: "intent-transport-not-built"`, `blockedOn: 461`). Two independent
guards: the client checks `available` **before** sampling a device key set —
`prepare_device` replaces the pending set and discards the previous secrets, so
sampling for an undeliverable request throws key material away for nothing — and
`dispatch` rejects **anyway**, unconditionally, without reading that flag. A
guard defeated by editing one boolean is not a guard, and there is a test for
exactly that. When #461 lands the work is `setIntentTransport(...)`; nothing
else on the path changes.

**`enroll` can only reject.** Even a fulfilled response yields a
`DeviceCredential`, and installing one is `install_identity`'s job in a process
this app registers no command for. The refusal is re-wrapped as #913's
`EnrollmentUnavailableError` with the cause attached, so every consumer branch
and every existing test is unchanged. Nothing synthesizes an `EnrollmentStatus`.

**User-visible copy is untouched.** The screen still says enrollment happens in
the wallet app and that the handover is not built yet.
`CLIENT-CONTRACT.md` §2.4's "Superseded" note is updated so it stays accurate
about what `enroll` now does, and every clause of it is still true.

## What the response validation proves — and what it does not

Implemented and tested even though nothing can deliver a response yet, against
**hand-assembled** bytes rather than an encoder that agrees with the decoder by
construction. Refused: an answer to a different request; an identifier differing
in one byte; a correlated answer echoing a different family; an unsupported
version; a truncated envelope; trailing bytes; an empty response; a truncated
family payload; bytes after the credential; a zero-length credential; a refusal
status (never mistaken for success); a refusal carrying a payload; an unknown
status; a replay; an answer after the window closed; a transport that resolves
with a non-response.

**`CALLER-AUTHENTICATION.md` §5 states plainly that there is no signature over
responses.** So all of the above establishes exactly one thing: *whoever
answered had seen the request*, because `request_id` is 32 CSPRNG bytes that
appeared in exactly one outbound message. **None of it establishes that the
responder was ZUULI.** An app that *received* the request holds the identifier
and can answer with a `DeviceCredential` of its own choosing, and this client
would accept it. Correlation is not authentication. §5 also records that there
is no iOS caller attestation and no per-caller enrollment keys. Closing that is
a transport that authenticates the response destination — #461 — which is why
the transport is shut rather than merely undocumented.

## Verification

| Check | Result |
|---|---|
| `wallet/e2e2z`: `npm run typecheck`, `typecheck:tests` | clean |
| `wallet/e2e2z`: `npx vitest run` | 207 passed (14 files) |
| `wallet/e2e2z`: `npx playwright test` | 4 passed |
| `wallet/e2e2z`: `node --test scripts/seed-authority-boundary.node-test.mjs` | 4 passed |
| `wallet/e2e2z`: `npm run build` | clean |
| `wallet/zuuli`: `npx vitest run` | 1394 passed, 5 skipped (95 files) |
| `wallet/zuuli`: typecheck + `messaging-contract.node-test.mjs` | clean, 9 passed |
| `wallet/zuuallet`, `wallet/free2z`: typecheck | clean |
| `node wallet/zuuli/scripts/project-boundary.mjs` | verified, 5 intent-bridge guards |
| `node wallet/zuuli/scripts/surface-capability-authority.mjs` | **e2e2z: zero `zcash:*`** |
| `cargo fmt --check`, `cargo clippy --locked --all-targets -D warnings` | clean |
| `cargo test --locked` (e2e2z) | 4 passed |

## Mutation matrix — the guards are load-bearing

Recorded in `docs/intent-bridge/CONFORMANCE.md`. **10 mutations, 10 failures, 0
survivors**; every one applied, watched to fail with a named assertion, and
restored. The tree ends green.

Fabricating a successful enrollment (after the transport check):

```
× never resolves to an EnrollmentStatus even on a fulfilled response
  → expected true to be false
× sends the wallet authority the request #905 specifies
  → promise resolved "{ enrolled: true, …(5) }" instead of rejecting
+   "enrolled": true,
+   "handle": "alice",
```

Fabricating it *before* the intent path — #913's negative control, intact:

```
× the enrollment gap > refuses every enrollment call with a typed refusal
  → promise resolved "{ enrolled: true, …(5) }" instead of rejecting
× the enrollment gap > never resolves to an EnrollmentStatus, however shaped
  → expected true to be false
```

Dropping correlation in `session.accept` (match any outstanding question):

```
× refuses an answer to a different request                → expected a refusal, resolved with 51,51,…
× refuses an answer whose identifier differs in one byte  → expected a refusal, resolved with 51,51,…
× refuses a replay of an answer it already accepted       → expected a refusal, resolved with 51,51,…
```

Seed-derived paths into e2e2z:

```
not ok 1 - e2e2z holds no route to the wallet seed
  + 'src-tauri/Cargo.toml: e2e2z must not link tauri-plugin-zcash; ongoing messaging never needs the seed'
  + 'src/lib/enrollment/deviceKeys.ts: e2e2z must not address the wallet plugin (plugin:zcash|)'
  + 'src/lib/enrollment/deviceKeys.ts: e2e2z must not name the seed command get_seed_phrase'
```

and the same crate mutation, caught repo-wide:

```
wallet/e2e2z/src-tauri/Cargo.toml: must not link tauri-plugin-zcash; a capability
can only reach a command the process registers
```

Also mutated to red: the shipping transport resolving instead of rejecting; the
transport's refusal gated on `available`; the family-result decoder's
trailing-byte and empty-credential guards.

**Two mutations survived, and CONFORMANCE.md records both rather than hiding
them.** (1) Fabricating a status *after* the transport check leaves
`enrollment-gap.test.ts` green — because with no transport `enroll` refuses
earlier on the same path; that is why the second row of the matrix exists. (2)
Weakening the family decoder's framing leaves `refuses every truncation` green —
`ByteReader.take` bounds-checks before every read, the same documented
redundancy the existing TypeScript matrix already reports.

## Hard constraints held

- e2e2z links **no** `tauri-plugin-zcash` (manifest test + `lib.rs` test +
  repo-wide surface script + new app-local scanner).
- e2e2z grants **zero** `zcash:*` — `surface-capability-authority.mjs` confirms.
- e2e2z reaches **no** seed. I did not at any point need one: §4.2's split is
  exactly why the design works, and the request carries public keys only.
- The plugin's §3 command population is unchanged, so
  `messaging-contract.node-test.mjs`'s three-way comparison is untouched.

## Still blocked on #461

No intent carrying authority can be dispatched. `sign-challenge` and
`execute-payment` have no caller here at all. There is no iOS caller
attestation, no per-caller enrollment key, and no signature over responses. The
credential round trip cannot complete end to end even in principle: this app
registers no command that installs one, and `IssueDeviceCredentialResultV1`
carries no `identity_pk` or `BackupWrapKey`, which `install_identity` needs.
That is follow-up work for whoever lands the transport, and it is named here
rather than discovered then.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
