### PR TITLE
docs: describe the three-app architecture, honestly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -492,9 +492,17 @@ once.
 
 ## Practical notes
 
-- The three first-party Cargo roots and lockfiles are deliberately independent.
-  The release-train boundary, new-crate rules, and explicit triggers for
-  reconsidering a wallet-wide workspace are recorded in
+- **We ship three Tauri apps, not one.** `cash.free2z.zuuli` holds the seed and
+  renders nothing untrusted; `cash.free2z.free2z` renders untrusted content and
+  has no privileged capability; `cash.free2z.e2e2z` holds device keys only. The
+  threat that forced it (#367), what enforces the boundary, and what is not yet
+  built are in [docs/architecture.md](docs/architecture.md) and
+  [docs/status.md](docs/status.md). Before adding a capability, a plugin, or an
+  `invoke_handler` entry to any of them, read the first.
+- The first-party Cargo roots and lockfiles are deliberately independent — six
+  of them under `wallet/` since the split. The release-train boundary,
+  new-crate rules, and explicit triggers for reconsidering a wallet-wide
+  workspace are recorded in
   [docs/architecture/CARGO-WORKSPACE.md](docs/architecture/CARGO-WORKSPACE.md).
 - Submodules live at `z/{github-org}/{repo}` and track a branch (see
   `.gitmodules`). Update to latest with `git submodule update --remote`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,14 @@ owner, not a person.
 
 Per-project specifics:
 
+- `docs/architecture.md` — **we ship three Tauri apps, not one.**
+  `cash.free2z.zuuli` (wallet authority, holds the seed, renders nothing
+  untrusted), `cash.free2z.free2z` (content, zero privileged capability),
+  `cash.free2z.e2e2z` (messaging, device keys only). Read it before adding a
+  capability, a plugin, or an `invoke_handler` entry to any of them.
+  `docs/status.md` says what is actually working — the cross-app bridge has no
+  transport yet.
+- `wallet/zuuli/CLAUDE.md` — ZUULI, the wallet authority.
 - `wallet/zuuallet/CLAUDE.md` — Zuuallet desktop app (Tauri v2 + React).
 - `wallet/plugins/tauri-plugin-zcash/CLAUDE.md` — Rust plugin, build commands,
   librustzcash API gotchas.

--- a/README.md
+++ b/README.md
@@ -1,80 +1,95 @@
 # ZUU
 
-**The Zcash User Universe**
+**The Zcash User Universe** — a synthetic monorepo where Free2Z's applications
+are built against the Zcash ecosystem *from source*.
 
-ZUU is a synthetic monorepo for building Free2Z products against the Zcash
-ecosystem from source. It brings our applications, shared wallet code,
-documentation, and upstream Zcash projects into one integration tree.
+Thirty upstream repositories are vendored as Git submodules under [`z/`](z/), so
+our apps compile against real upstream HEAD instead of published packages. We
+stay on HEAD and contribute fixes upstream rather than pinning to old commits —
+[AGENTS.md](AGENTS.md) is the doctrine.
 
-Our flagship app is [ZUULI](wallet/zuuli/): a Zcash-native desktop and mobile
-app that combines a self-custody wallet with the free2z platform's AI,
-livestreaming, articles, and 2Z economy. ZUULI is experimental; its implemented
-surfaces and known release gaps are tracked in
-[its status document](wallet/zuuli/STATUS.md).
+## Three apps, one seed, no shared privilege
+
+ZUULI used to be one Tauri app that held the Zcash seed **and** rendered
+third-party content. [#367](https://github.com/free2z/zuu/issues/367) showed
+that cannot hold: Wry injects Tauri's IPC bridge into *every* iframe, and
+Android's IPC reports the top-level URL as the origin — so a remote subframe
+resolves as the trusted main window and can invoke privileged commands. The
+generalisation is that any embed policy permissive enough to be useful is too
+permissive to sit next to seed access.
+
+So it is three apps ([#904](https://github.com/free2z/zuu/issues/904)):
+
+| App | Role | Holds | Renders remote content | Privileged plugins |
+| --- | --- | --- | --- | --- |
+| [`cash.free2z.zuuli`](wallet/zuuli/) | wallet authority | master seed, spending keys, account-level messaging keys | **never** | `zcash` |
+| [`cash.free2z.free2z`](wallet/free2z/) | content — articles, creator, live, AI, search | Knox token, 2Z balance | **yes** | **none** |
+| [`cash.free2z.e2e2z`](wallet/e2e2z/) | messaging | device keys + device credential | **never** | `f2zmsg` |
+
+**The argument, in two sentences.** The app that holds the seed renders nothing
+we do not control, and the app that renders untrusted content registers no
+`invoke_handler`, links no privileged plugin, and grants no `zcash:*` or
+`f2zmsg:*` capability — so a hostile subframe there finds nothing privileged to
+reach. That is mechanical rather than customary:
+[`surface-capability-authority.mjs`](wallet/zuuli/scripts/surface-capability-authority.mjs)
+runs inside the required CI gate and fails if either delegated surface gains
+one.
+
+Ongoing messaging never needs the seed, only enrollment does — account keys and
+device keys are already separated by
+[`docs/e2ee/ARCHITECTURE.md`](docs/e2ee/ARCHITECTURE.md) §4.2, which is what
+makes a third app possible instead of a compromise.
+
+### How they talk
+
+Over a versioned [**intent bridge**](docs/intent-bridge/PROTOCOL.md): one-shot,
+expiring, single-use requests in three defined families — `execute-payment`,
+`issue-device-credential`, `sign-challenge`. ZUULI is the only signing
+authority: for `execute-payment`, the one family it implements today, it
+re-derives its own review from its own wallet state, confirms natively, and
+acts. No other app can spend or sign. The other two families are refused with
+`INTENT_UNKNOWN_INTENT`, which is not a lie — this build does not implement
+them.
 
 > [!IMPORTANT]
-> Local `main` is read-only. Every change starts from `origin/main` in a new
-> branch and isolated worktree, goes through an issue and pull request, and is
-> squash-merged on GitHub. Local `main` moves only with
-> `git pull --ff-only origin main`. Read [AGENTS.md](AGENTS.md) before changing
-> anything.
+> **The bridge has no transport.** Both caller sides build real, validated
+> requests and then fail closed at one named seam, because verified App Links /
+> Universal Links ([#461](https://github.com/free2z/zuu/issues/461)) are not
+> wired. **Nothing crosses between apps today.** ZUULI's hardening
+> ([#904](https://github.com/free2z/zuu/issues/904) phase 4) is also still in
+> progress. [**docs/status.md**](docs/status.md) is the honest ledger: what
+> works, what fails closed by design, and what is blocked.
 
-## What makes this a synthetic monorepo?
+## Read next
 
-The [`z/`](z/) tree vendors 30 Zcash-ecosystem repositories as Git submodules,
-organized as `z/{github-owner}/{repository}`. Our applications can therefore
-build and test against real upstream source instead of waiting for published
-packages. The complete, authoritative list of submodule URLs and tracked
-branches is [`.gitmodules`](.gitmodules).
-
-This repository tracks upstream HEAD and fixes forward. If a dependency update
-exposes a bug in our code, we port our code. If it exposes a genuine upstream
-regression, we contribute the fix upstream and use a reachable fork commit only
-as a temporary bridge. [AGENTS.md](AGENTS.md) documents that contribution
-doctrine and the repository's dependency guardrails.
-
-Submodules are intentionally not initialized in a fresh worktree. Initialize
-only what your project needs; initializing the entire ecosystem is expensive.
-ZUULI and Zuuallet currently require `librustzcash`:
-
-```bash
-git submodule update --init --recursive z/zcash/librustzcash
-```
+| | |
+| --- | --- |
+| [docs/architecture.md](docs/architecture.md) | The three-app split in depth — the threat, the target, what enforces it |
+| [docs/status.md](docs/status.md) | What works, what fails closed, what is blocked |
+| [docs/development.md](docs/development.md) | Build, test, and the CI gate model |
+| [docs/intent-bridge/](docs/intent-bridge/PROTOCOL.md) | The cross-app protocol: wire format, authority side, caller authentication, conformance |
+| [docs/e2ee/](docs/e2ee/README.md) | The E2EE messaging design and key transparency |
+| [AGENTS.md](AGENTS.md) · [docs/PARALLEL-AGENTS.md](docs/PARALLEL-AGENTS.md) | Contribution doctrine and the parallel-agent workflow |
 
 ## Repository map
 
-| Path | Purpose | Start here |
-| --- | --- | --- |
-| [`wallet/zuuli/`](wallet/zuuli/) | Flagship ZUULI desktop/mobile app (React, TypeScript, Tauri, Rust) | [README](wallet/zuuli/README.md), [status](wallet/zuuli/STATUS.md), [contributor instructions](wallet/zuuli/CLAUDE.md) |
-| [`wallet/plugins/tauri-plugin-zcash/`](wallet/plugins/tauri-plugin-zcash/) | Shared native wallet engine over `librustzcash` | [README](wallet/plugins/tauri-plugin-zcash/README.md), [contributor instructions](wallet/plugins/tauri-plugin-zcash/CLAUDE.md) |
-| [`wallet/zuuallet/`](wallet/zuuallet/) | Focused reference wallet using the shared plugin | [README](wallet/zuuallet/README.md), [contributor instructions](wallet/zuuallet/CLAUDE.md) |
-| [`ts/react/free2z/`](ts/react/free2z/) | Free2Z React frontend | [README](ts/react/free2z/README.md) |
-| [`ts/svelte/free2z/`](ts/svelte/free2z/) | Free2Z Svelte frontend | [README](ts/svelte/free2z/README.md) |
-| [`py/dj/proj/zuu/`](py/dj/proj/zuu/) | Open-source Free2Z Django backend components | [README](py/dj/proj/zuu/README.md) |
-| [`docs/`](docs/) | Product, architecture, operations, and contributor documentation | [parallel-agent workflow](docs/PARALLEL-AGENTS.md) |
-| [`z/`](z/) | Upstream Zcash ecosystem Git submodules | [submodule manifest](.gitmodules) |
-| [`scripts/`](scripts/) | Repository-wide Rust, dependency, and CI policy checks | [Rust guardrails](AGENTS.md#guardrails-that-keep-us-honest) |
+| Path | Purpose |
+| --- | --- |
+| [`wallet/zuuli/`](wallet/zuuli/) | ZUULI, the wallet authority ([status](wallet/zuuli/STATUS.md)) |
+| [`wallet/free2z/`](wallet/free2z/) | free2z, the content surface |
+| [`wallet/e2e2z/`](wallet/e2e2z/) | e2e2z, the messaging surface |
+| [`wallet/shared/`](wallet/shared/) | `@free2z/wallet-shared` — the one client-side intent implementation |
+| [`wallet/plugins/`](wallet/plugins/) | [`tauri-plugin-zcash`](wallet/plugins/tauri-plugin-zcash/README.md), [`tauri-plugin-f2zmsg`](wallet/plugins/tauri-plugin-f2zmsg/README.md) |
+| [`wallet/zuuallet/`](wallet/zuuallet/) | Focused reference wallet over the shared plugin |
+| [`rs/crates/`](rs/README.md) | Protocol crates — `f2z-intent`, `f2z-codec`, messaging, key transparency |
+| [`ts/react/free2z/`](ts/react/free2z/README.md) · [`ts/svelte/free2z/`](ts/svelte/free2z/README.md) | Free2Z web frontends |
+| [`py/dj/proj/zuu/`](py/dj/proj/zuu/README.md) | Open-source Free2Z Django backend components |
+| [`z/`](z/) | Upstream Zcash submodules — [`.gitmodules`](.gitmodules) is authoritative |
+| [`scripts/`](scripts/) | Repository-wide policy checks run by CI |
 
-## Prerequisites
+## Quick start
 
-Install only the toolchains needed by the project you choose:
-
-- Git is required; the GitHub CLI (`gh`) is used for the issue/PR workflow.
-- ZUULI frontend development uses Node.js 24, matching CI, and `npm`.
-- Native wallet work uses `rustup`; [`wallet/rust-toolchain.toml`](wallet/rust-toolchain.toml)
-  selects the exact Rust compiler for every wallet crate.
-- Tauri builds need platform-specific
-  [system dependencies](https://v2.tauri.app/start/prerequisites/). iOS and
-  Android builds also need their respective Xcode or Android SDK/NDK tooling;
-  [the ZUULI README](wallet/zuuli/README.md#run-it) lists the project commands.
-- [`.devcontainer/`](.devcontainer/) is an optional general-purpose development
-  container. Project READMEs and CI remain authoritative for current build
-  commands and versions.
-
-## Quick start: explore ZUULI in a browser
-
-The fixture-backed browser mode is the lightest way to explore the flagship UI;
-it does not require Rust, native SDKs, or submodules:
+The fixture-backed browser mode needs no Rust, native SDKs, or submodules:
 
 ```bash
 git clone https://github.com/free2z/zuu.git
@@ -83,65 +98,25 @@ npm ci
 VITE_MOCK=1 npm run dev
 ```
 
-Mock mode is UI/demo evidence, not an end-to-end wallet or production proof.
-For the real staging API, native wallet, tests, release state, and mobile
-commands, continue with the [ZUULI README](wallet/zuuli/README.md) and
-[`wallet/zuuli/CLAUDE.md`](wallet/zuuli/CLAUDE.md).
+Mock mode is UI evidence, not an end-to-end wallet. For real builds, tests, and
+mobile commands see [docs/development.md](docs/development.md) and the per-app
+READMEs.
 
-## Find work
+## Contributing
 
-- Start with open issues labeled
-  [`agent-ready`](https://github.com/free2z/zuu/issues?q=is%3Aissue%20is%3Aopen%20label%3Aagent-ready).
-- [`good first issue`](https://github.com/free2z/zuu/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
-  identifies narrower entry points; `help wanted` marks work where another
-  contributor is especially useful.
-- Read the issue, its linked code, and the closest `CLAUDE.md` before claiming
-  it. Comment on the issue so parallel contributors do not duplicate work.
-- If the work is not already tracked, open an issue with a bounded scope and
-  acceptance criteria before writing code.
+Start from an open issue — [`agent-ready`](https://github.com/free2z/zuu/issues?q=is%3Aissue%20is%3Aopen%20label%3Aagent-ready)
+and [`good first issue`](https://github.com/free2z/zuu/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
+are the entry points.
 
-## Contribution workflow
-
-The full process, including review, CI, merge, and safe cleanup, is in
-[docs/PARALLEL-AGENTS.md](docs/PARALLEL-AGENTS.md). The short version for a
-repository collaborator is:
-
-1. Create or claim one issue and mark it `in-progress`.
-2. Fetch the remote, then create one isolated worktree and branch from
-   `origin/main` (never from local `main`):
-
-   ```bash
-   git fetch origin
-   git worktree add -b <type>/<issue>-<slug> <worktree-path> origin/main
-   ```
-
-3. Make one focused change, follow the nearest project instructions, and run
-   the relevant checks in that worktree.
-4. Push the branch and open one pull request against `main`; include
-   `Closes #<issue>` in its body.
-5. Wait for required CI and an approving review. A red gate never merges.
-6. Squash-merge on the remote. Only then fast-forward the primary checkout's
-   local `main` from `origin/main` and perform the audited worktree cleanup.
-
-Contributors without repository push access should still start from an issue,
-keep local `main` clean, branch from the upstream `main`, and open the pull
-request from a fork.
-
-## Zcash ecosystem sources
-
-The submodules currently span:
-
-- **Core protocol and nodes:** Zcash, Zcash Foundation, and Zakura projects,
-  including `librustzcash`, Orchard, Zebra, Zallet, Zcash, and Zakura.
-- **Wallets and SDKs:** Zcash mobile SDKs, ZODL wallets, Warp, and ZWallet.
-- **Community implementations:** ChainSafe WebZjs, Zingo Labs, Nozy Wallet,
-  and QED-it's ZSA work.
-
-Always use [`.gitmodules`](.gitmodules) rather than this summary when deciding
-which upstream repository and branch a path tracks.
+> [!IMPORTANT]
+> **Local `main` is read-only.** Every change branches from `origin/main` in its
+> own worktree, goes through an issue and a pull request, and is squash-merged
+> on GitHub. Local `main` moves only with `git pull --ff-only origin main`. Read
+> [AGENTS.md](AGENTS.md) before changing anything; the full loop is in
+> [docs/PARALLEL-AGENTS.md](docs/PARALLEL-AGENTS.md).
 
 ## License
 
-ZUU's own source is available under the [MIT License](LICENSE). Each Git
-submodule is an independent upstream repository with its own license and
+ZUU's own source is available under the [MIT License](LICENSE). Each submodule
+under `z/` is an independent upstream repository with its own license and
 contribution rules.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,196 @@
+# The three-app architecture
+
+How `cash.free2z.zuuli`, `cash.free2z.free2z` and `cash.free2z.e2e2z` divide
+authority, why the division exists, and what mechanically enforces it.
+
+Issues: [#904](https://github.com/free2z/zuu/issues/904) (the split),
+[#367](https://github.com/free2z/zuu/issues/367) (the driver),
+[#905](https://github.com/free2z/zuu/issues/905) (the bridge),
+[#461](https://github.com/free2z/zuu/issues/461) (the blocking prerequisite).
+
+Companion documents. This page deliberately does **not** restate them:
+
+- [`intent-bridge/PROTOCOL.md`](./intent-bridge/PROTOCOL.md) — the wire format
+  and both implementations.
+- [`intent-bridge/AUTHORITY.md`](./intent-bridge/AUTHORITY.md) — what ZUULI does
+  with an admitted intent.
+- [`intent-bridge/CALLER-AUTHENTICATION.md`](./intent-bridge/CALLER-AUTHENTICATION.md)
+  — who is calling, per platform, and what cannot be established.
+- [`intent-bridge/CONFORMANCE.md`](./intent-bridge/CONFORMANCE.md) — every guard
+  and the mutation that proves its test is not inert.
+- [`e2ee/ARCHITECTURE.md`](./e2ee/ARCHITECTURE.md) — the account-key /
+  device-key separation this split rests on.
+- [`status.md`](./status.md) — what is actually working today.
+
+---
+
+## 1. The driver
+
+ZUULI was one Tauri app, one window, one WebView, holding the Zcash seed and
+rendering third-party content: article embeds, the Cloudflare RealtimeKit
+livestream SDK, remote images, AI output.
+
+**[#367](https://github.com/free2z/zuu/issues/367).** Wry injects Tauri's bridge
+scripts into **every** frame (`setOf("*")`, ignoring the `main_only` flag), and
+its Android IPC reports the *top-level* URL rather than the requesting frame. A
+remote subframe therefore resolves as the trusted main window and can invoke
+privileged commands. Reported upstream separately.
+
+**[#816](https://github.com/free2z/zuu/issues/816) /
+[#818](https://github.com/free2z/zuu/issues/818).** The packaged CSP blocked
+RealtimeKit's first request and broke Join Free — a runtime failure mode that
+exists only because a privileged WebView renders third-party code.
+
+The generalisation: **any embed policy permissive enough to be useful is too
+permissive to sit next to seed access.** `frame-src 'none'` works today
+precisely because the feature was given up.
+
+### Why not sandbox inside one app
+
+This was the preferred option and it does not hold where the threat is:
+
+- [tauri#11528](https://github.com/tauri-apps/tauri/issues/11528) — multiple
+  webviews are desktop-only, behind an unstable feature flag.
+  [tauri#11794](https://github.com/tauri-apps/tauri/issues/11794) (`add_child`
+  on mobile) is also open.
+- Multi-*window* on mobile needs Android 12L / API 32; our `minSdk` is 29.
+- Even at API 32, Android launches a separate activity onto the back stack and
+  iPhone replaces the UI. On a phone the UX cost of another window already
+  equals another app — so the single-app argument evaporates exactly where the
+  vulnerability lives.
+
+## 2. The principle
+
+**The wallet is a signing authority. Every other surface holds only delegated,
+scoped, revocable credentials — never the seed.**
+
+This was already our design.
+[`e2ee/ARCHITECTURE.md`](./e2ee/ARCHITECTURE.md) §4.2 separates **account keys**
+(seed-derived, restorable: `CeremonySigningKey`, `DirectoryAuthKey`,
+`BackupWrapKey`) from **device keys** (OS CSPRNG, never seed-derived, never
+exported: `DeviceSignatureKey`, `DeviceInitKey`, `QueueKey_{q}`), bound by a
+`DeviceCredential` implemented in
+`rs/crates/f2z-msg-identity/src/credential.rs`.
+
+The consequence is what makes a third app cheap rather than a compromise:
+**ongoing messaging never needs the seed — only enrollment does.** The same
+shape generalises; signing a login challenge is an attestation, not a spend.
+
+One seed root stays fine — one backup phrase, one identity — **provided the root
+never leaves the wallet app.**
+
+Three surfaces and not two, so that the dangerous one holds **neither** spending
+authority **nor** messaging keys.
+
+## 3. The three surfaces
+
+| | [`cash.free2z.zuuli`](../wallet/zuuli/) | [`cash.free2z.free2z`](../wallet/free2z/) | [`cash.free2z.e2e2z`](../wallet/e2e2z/) |
+| --- | --- | --- | --- |
+| Role | wallet authority | content | messaging |
+| Holds | master seed, spending keys, account-level messaging keys | Knox token, 2Z balance | device keys + device credential |
+| Renders remote content | never | **yes** — articles, creator, live, AI, search | never |
+| Privileged plugins | `zcash` | **none** | `f2zmsg` |
+| Bundle `active` | `true` | `false` (native layer unwired, [#918](https://github.com/free2z/zuu/issues/918)) | `true` |
+
+### 3.1 What makes the content surface safe
+
+Not its CSP. **Its dependency list, and its empty IPC surface.**
+
+`wallet/free2z/src-tauri/src/lib.rs` registers **no `invoke_handler` at all**
+and links neither `tauri-plugin-zcash` nor `tauri-plugin-f2zmsg`; its capability
+files carry no `zcash:*` and no `f2zmsg:*` entry. Under #367 a remote subframe
+in that process resolves as the trusted main window — and finds nothing
+privileged to call. A CSP is a policy that can be relaxed under product
+pressure; an absent command cannot be invoked.
+
+### 3.2 What the messaging surface holds
+
+`wallet/e2e2z/src-tauri/Cargo.lock` contains **zero Zcash crates** — no
+`zcash_*`, no `orchard`, no `sapling`. It registers `tauri-plugin-f2zmsg` and
+exactly one app command, `e2e2z_device_credential_keys`, which returns the
+**public** halves of an OS-CSPRNG device key set and grants nothing.
+
+ZUULI's three app-crate enrollment commands — `f2zmsg_enrollment_status`,
+`f2zmsg_enroll`, `f2zmsg_unenroll` — are deliberately absent here. In ZUULI they
+borrow the seed from `tauri-plugin-zcash`'s managed state in-process
+([`e2ee/CLIENT-CONTRACT.md`](./e2ee/CLIENT-CONTRACT.md) §2.2). There is no seed
+here to borrow, so enrollment becomes a bridge call — and until that lands the
+frontend refuses with a typed error rather than synthesising an
+`EnrollmentStatus` nobody published.
+
+### 3.3 What the wallet authority does not have
+
+`wallet/zuuli/src-tauri/src/intent.rs` handles intents, and `receive_intent` is
+**not** a `#[tauri::command]` and appears in no capability. #367 is precisely
+that the WebView's frames are not separated from one another, so a command
+turning caller-supplied bytes into a payment confirmation would be the deputy
+that issue is about. A test reads `lib.rs` and fails if anything from the module
+reaches the invoke handler.
+
+## 4. What enforces the boundary
+
+The split is worth nothing if it is a convention. "free2z has no wallet
+capability" is a property a one-line edit can quietly reverse, and the edit
+looks like every other capability edit. Three checks run inside the **required**
+`gate` in [`.github/workflows/zuuli.yml`](../.github/workflows/zuuli.yml), whose
+change detector selects `wallet/free2z/**` and `wallet/e2e2z/**`:
+
+| Check | What it refuses |
+| --- | --- |
+| [`wallet/zuuli/scripts/surface-capability-authority.mjs`](../wallet/zuuli/scripts/surface-capability-authority.mjs) | any `zcash:*`/`f2zmsg:*` entry in free2z, any `zcash:*` entry or blanket `f2zmsg:default` in e2e2z, and linking a forbidden plugin. Capability files are enumerated off the filesystem, so a new one cannot escape by being added |
+| [`wallet/zuuli/scripts/project-boundary.mjs`](../wallet/zuuli/scripts/project-boundary.mjs) | an import crossing between wallet applications in either direction, and a second client-side implementation of the intent guards outside `wallet/shared/src/intent` |
+| `rust_fmt` / `rust_clippy` / `rust_deny` | crate **discovery**, not a list — both new `src-tauri` crates were gated from their first commit |
+
+Each app's Rust crate also asserts its own manifest in a unit test, so the
+property is stated where the violation would be written as well as centrally.
+
+Build coverage for the two delegated surfaces lives in
+[`.github/workflows/wallet-surfaces.yml`](../.github/workflows/wallet-surfaces.yml),
+which publishes no gate — deliberately. What keeps those surfaces unprivileged
+is the required gate above, not their own build.
+
+## 5. How the surfaces talk
+
+Over the versioned [intent bridge](./intent-bridge/PROTOCOL.md). Three families
+are defined; **one is implemented on the authority side.**
+
+| Intent | The request carries | ZUULI does | Returns | Authority side |
+| --- | --- | --- | --- | --- |
+| `execute-payment` | recipient, amount, memo, fee | re-derives and shows its **own** payment review | txid or refusal | **implemented** |
+| `issue-device-credential` | device **public** keys, handle, validity window | *(designed)* derive account keys, confirm natively | `DeviceCredential` | refused, `INTENT_UNKNOWN_INTENT` |
+| `sign-challenge` | challenge bytes, purpose, claimed caller | *(designed)* confirm natively | signature | refused, `INTENT_UNKNOWN_INTENT` |
+
+The two refusals are deliberate and the status is not a lie: this build
+genuinely does not implement them.
+
+Two invariants the format itself enforces: **the seed never appears in a
+message** — there is no field it could occupy — and **device private keys never
+leave their app**. One the pipeline enforces: **nothing here is a continuous
+grant**; every intent is one-shot, expires on two clocks within five minutes,
+and is bound to one approval of one rendering.
+
+Where the code lives:
+
+| Half | Path |
+| --- | --- |
+| the rules | `rs/crates/f2z-intent` |
+| the authority | `wallet/zuuli/src-tauri/src/intent.rs` |
+| the one client implementation | `wallet/shared/src/intent` (`@free2z/wallet-shared`) |
+| callers | `wallet/free2z/src/lib/bridge/`, `wallet/e2e2z/src/lib/enrollment/` |
+
+**Ordering was a decision, not an accident.** Strength runs strong for
+`execute-payment`, medium for `issue-device-credential`, weak for
+`sign-challenge` — a challenge is an opaque nonce that confirms nothing to the
+person approving it, so shipping it first because it "only signs" is backwards.
+[`AUTHORITY.md`](./intent-bridge/AUTHORITY.md) §3 has the full argument.
+
+## 6. What is not built yet
+
+Read [`status.md`](./status.md) rather than inferring from this page. In short:
+there is **no transport** ([#461](https://github.com/free2z/zuu/issues/461)),
+`sign-challenge` has neither a caller nor an authority-side implementation, and
+`issue-device-credential` has a caller but no authority-side implementation —
+enrollment could not complete even with a transport
+([#928](https://github.com/free2z/zuu/issues/928)), free2z's native layer is
+unwired ([#918](https://github.com/free2z/zuu/issues/918)), and ZUULI's phase-4
+hardening is in progress.

--- a/docs/architecture/CARGO-WORKSPACE.md
+++ b/docs/architecture/CARGO-WORKSPACE.md
@@ -3,16 +3,30 @@
 Status: accepted on 2026-08-23. This records the decision for
 [issue #341](https://github.com/free2z/zuu/issues/341).
 
+> [!NOTE]
+> **Amended 2026-09-04 — the count changed, the decision did not.** The
+> three-app split ([#904](https://github.com/free2z/zuu/issues/904), see
+> [`../architecture.md`](../architecture.md)) added
+> `wallet/free2z/src-tauri/` and `wallet/e2e2z/src-tauri/`, and
+> `wallet/plugins/tauri-plugin-f2zmsg/` is a fourth plugin root, so there are
+> now **six** shipping package roots under `wallet/` rather than three. Each was
+> created as an independent root under exactly the reasoning below, and each was
+> gated from its first commit because the fmt/clippy/deny checks **discover**
+> crates rather than listing them. Read "three" below as "the roots that existed
+> when this was written"; nothing else in this document changes. The revisit
+> triggers are unchanged and none has fired.
+
 ## Decision
 
-Keep the three existing Rust package roots independent:
+Keep the existing Rust package roots independent. At the time of writing they
+were:
 
 - `wallet/plugins/tauri-plugin-zcash/`
 - `wallet/zuuli/src-tauri/`
 - `wallet/zuuallet/src-tauri/`
 
 Each remains the root of its own Cargo resolution, lockfile, profiles, and
-target directory. Do not add a virtual workspace above all three merely to
+target directory. Do not add a virtual workspace above them merely to
 deduplicate configuration.
 
 The durable boundary is the **release train**, not the repository. ZUULI and

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,151 @@
+# Development
+
+Getting the apps built and tested, and how CI decides whether a change may
+merge. This page orients; [AGENTS.md](../AGENTS.md) is the authority on
+doctrine, guardrails, and the traps that make a warm local build lie to you.
+
+---
+
+## Prerequisites
+
+Install only what the project you picked needs.
+
+| For | You need |
+| --- | --- |
+| Anything | Git, and the GitHub CLI (`gh`) for the issue/PR workflow |
+| Any frontend | Node.js **24**, matching CI, and `npm` |
+| Any native build | `rustup`; [`wallet/rust-toolchain.toml`](../wallet/rust-toolchain.toml) selects the exact compiler for every wallet crate |
+| A Tauri bundle | Platform [system dependencies](https://v2.tauri.app/start/prerequisites/); iOS and Android also need Xcode or the Android SDK/NDK |
+
+[`.devcontainer/`](../.devcontainer/) is an optional general-purpose container.
+Project READMEs and CI remain authoritative for current commands and versions.
+
+## Submodules
+
+Submodules are intentionally **not** initialized in a fresh clone; initializing
+the whole ecosystem is expensive. Take what your project needs. ZUULI and
+Zuuallet need `librustzcash`:
+
+```bash
+git submodule update --init --recursive z/zcash/librustzcash
+```
+
+The delegated surfaces — free2z and e2e2z — need **no** submodule, because
+neither links a Zcash crate.
+
+## Running an app
+
+Each app is an independent npm project under `wallet/`.
+
+```bash
+cd wallet/zuuli && npm ci && VITE_MOCK=1 npm run dev   # fixture-backed, no Rust
+cd wallet/free2z && npm ci && npm run dev
+cd wallet/e2e2z  && npm ci && npm run dev
+```
+
+Mock mode is UI evidence, not an end-to-end wallet or a production proof. For
+the real staging API, native wallet, and mobile commands, continue with
+[`wallet/zuuli/README.md`](../wallet/zuuli/README.md).
+
+Native builds run through the app-local Tauri CLI, e.g.:
+
+```bash
+cargo build --locked --manifest-path wallet/zuuli/src-tauri/Cargo.toml
+```
+
+## Testing
+
+`npm run verify` in any app is typecheck + typecheck of tests + `npm test`.
+That is the command to run before pushing.
+
+**`wallet/zuuli` has two independent JS suites and only one is easy to reach
+for.** Vitest is separate from Playwright (`tests/*.pw.ts`, `npm run test:e2e`),
+and the `zuuli / frontend` CI job requires both. Vitest green is **not** evidence
+Playwright is green — the `.pw.ts` specs assert rendered copy, so any change
+touching user-visible text, navigation, or component structure needs
+`npm run test:e2e` (or `npm run verify`) before push. #822 and #803 both learned
+this the expensive way.
+
+Repository-wide policy checks live in [`scripts/`](../scripts/) and each carries
+a `--self-test` that proves it still fails on the thing it exists to catch. Run
+the check *and* its self-test; a check that has quietly become vacuous reports
+green.
+
+## Verify at the real conditions
+
+A warm local build reuses artifacts and resolves Cargo **features** and npm
+**optional-dependency trees** differently from a clean checkout, so a green
+local build can be red in CI for reasons your machine will never show you.
+Development is macOS-heavy; CI is Linux.
+
+[AGENTS.md § *Verifying before you push*](../AGENTS.md#verifying-before-you-push)
+documents the specific traps we have actually been bitten by — feature
+unification masking, toolchain skew, platform-gated dependencies silently
+landing inside a `cfg(target_os = "macos")` table, and integer widths that
+differ per target while clippy sees only one. Read it before bumping a Rust
+dependency. The short version: for anything touching Rust deps or features,
+verify in a clean Linux container on CI's pinned toolchain and **let it
+finish**.
+
+## The CI gate model
+
+There is exactly one **required** check, `gate`, and it lives in
+[`.github/workflows/zuuli.yml`](../.github/workflows/zuuli.yml). Everything that
+must be true before a merge is decided inside it or awaited by it.
+
+| Workflow | Publishes a gate? | Covers |
+| --- | --- | --- |
+| `zuuli.yml` | **yes — the required `gate`** | ZUULI frontend + Playwright, Rust fmt/clippy/deny across every crate under `wallet/`, target-native clippy on macOS and Windows, and the repository policy scripts |
+| `wallet-surfaces.yml` | no | build coverage for free2z and e2e2z — typecheck, tests, bundle, `cargo build` per backend |
+| `zuuallet.yml` | no | Zuuallet frontend + backend, and the weekly `upstream-canary` against latest librustzcash `main` |
+
+Two consequences worth internalising:
+
+- **The delegated surfaces are gated by `zuuli.yml`, not by their own
+  workflow.** Its change detector selects `wallet/free2z/**` and
+  `wallet/e2e2z/**`, so the capability and boundary checks in
+  [`docs/architecture.md` §4](./architecture.md#4-what-enforces-the-boundary)
+  run on every pull request that touches either tree. `wallet-surfaces.yml`
+  publishes no gate and is registered in `check-workflow-gates.mjs`'s
+  `UNGATED_WORKFLOWS`.
+- **`rust_fmt` / `rust_clippy` / `rust_deny` discover crates** by finding
+  `Cargo.toml` under `wallet/` rather than listing them, so a new crate is gated
+  from its first commit and cannot escape the MSRV check by never being
+  registered.
+
+A green gate is necessary and not sufficient — see
+[`docs/PARALLEL-AGENTS.md`](./PARALLEL-AGENTS.md) for the merge mechanics.
+
+## Rust package layout
+
+Six shipping Cargo package roots under `wallet/`, each the root of its own
+resolution, lockfile, profiles and target directory:
+
+```
+wallet/plugins/tauri-plugin-zcash/    wallet/zuuli/src-tauri/     wallet/free2z/src-tauri/
+wallet/plugins/tauri-plugin-f2zmsg/   wallet/zuuallet/src-tauri/  wallet/e2e2z/src-tauri/
+```
+
+(`wallet/zuuli/wasm-spike/` and `wallet/zuuli/crypto-target-spike/` are
+investigation roots, not shipped.) Plus the protocol crates under
+[`rs/crates/`](../rs/README.md). The reasoning,
+and the conditions under which consolidating into a workspace would be
+revisited, is [`architecture/CARGO-WORKSPACE.md`](./architecture/CARGO-WORKSPACE.md).
+Read it before adding a crate.
+
+## Contributing
+
+The full loop — issue, worktree, branch, PR, review, merge, cleanup — is
+[`docs/PARALLEL-AGENTS.md`](./PARALLEL-AGENTS.md). The rule that admits no
+exception:
+
+> **Local `main` is read-only.** Branch from `origin/main` in an isolated
+> worktree, never from local `main`; squash-merge on the remote; move local
+> `main` only with `git pull --ff-only origin main`.
+
+```bash
+git fetch origin
+git worktree add -b <type>/<issue>-<slug> <worktree-path> origin/main
+```
+
+Contributors without push access follow the same shape from a fork.

--- a/docs/status.md
+++ b/docs/status.md
@@ -8,9 +8,9 @@ contradicts a claim elsewhere in the repository, this page is the one that was
 checked against the tree — and the other page is a bug.
 
 > **The one-line summary.** The three apps exist, build, and are held apart by
-> the required CI gate. **No intent has ever crossed between them**, because
-> there is no transport. Every cross-app feature you can see in the UI stops at
-> a single named seam and says so.
+> the required CI gate. **No intent can cross between them**, because there is
+> no transport. Every cross-app feature you can see in the UI stops at a single
+> named seam and says so.
 
 Per-app detail stays in the per-app documents:
 [`wallet/zuuli/STATUS.md`](../wallet/zuuli/STATUS.md),

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,157 @@
+# Status of the three-app split
+
+What works, what fails closed on purpose, and what is blocked. Last derived
+against `main` on **2026-09-04**.
+
+This page exists so that no other page has to hedge. If something here
+contradicts a claim elsewhere in the repository, this page is the one that was
+checked against the tree — and the other page is a bug.
+
+> **The one-line summary.** The three apps exist, build, and are held apart by
+> the required CI gate. **No intent has ever crossed between them**, because
+> there is no transport. Every cross-app feature you can see in the UI stops at
+> a single named seam and says so.
+
+Per-app detail stays in the per-app documents:
+[`wallet/zuuli/STATUS.md`](../wallet/zuuli/STATUS.md),
+[`wallet/free2z/README.md`](../wallet/free2z/README.md),
+[`wallet/e2e2z/README.md`](../wallet/e2e2z/README.md).
+
+---
+
+## 1. What works
+
+| | Evidence |
+| --- | --- |
+| Three apps exist as buildable Tauri projects with distinct identifiers | `wallet/{zuuli,free2z,e2e2z}/src-tauri/tauri.conf.json` |
+| free2z has **no** privileged capability and **no** IPC surface at all | `wallet/free2z/src-tauri/src/lib.rs` registers no `invoke_handler`; its `Cargo.toml` links neither wallet plugin |
+| e2e2z holds **no** Zcash code | `wallet/e2e2z/src-tauri/Cargo.lock` contains zero `zcash_*`/`orchard`/`sapling` crates |
+| Those two properties are enforced, not asserted | `wallet/zuuli/scripts/surface-capability-authority.mjs`, run by `npm run test` inside the required `zuuli / frontend` gate job |
+| No import crosses between wallet applications | `wallet/zuuli/scripts/project-boundary.mjs`, same gate |
+| One versioned wire format, agreed byte-for-byte by two implementations | the same 130-byte vector pinned by hand in `rs/crates/f2z-intent/tests/wire_vectors.rs` **and** `wallet/zuuli/src/lib/intent-bridge.test.ts` |
+| Every bridge guard has a mutation-verified test | [`intent-bridge/CONFORMANCE.md`](./intent-bridge/CONFORMANCE.md) |
+| `execute-payment` is implemented end-to-end **on ZUULI's side of the seam** | `wallet/zuuli/src-tauri/src/intent.rs` — admit, propose, re-derive the review, confirm natively, bind, execute |
+| Content surfaces are ported to free2z: articles, creator, live, AI, search | `wallet/free2z/src/features/` |
+| The messaging surface is ported to e2e2z | `wallet/e2e2z/src/features/messages/` |
+| Both delegated surfaces have CI build coverage | `.github/workflows/wallet-surfaces.yml` |
+
+Merged for the split, in order: [#909](https://github.com/free2z/zuu/pull/909)
+scaffolds · [#911](https://github.com/free2z/zuu/pull/911) intent protocol ·
+[#919](https://github.com/free2z/zuu/pull/919) CI gate ·
+[#914](https://github.com/free2z/zuu/pull/914) ZUULI authority side ·
+[#913](https://github.com/free2z/zuu/pull/913) messaging → e2e2z ·
+[#912](https://github.com/free2z/zuu/pull/912) articles/creator → free2z ·
+[#920](https://github.com/free2z/zuu/pull/920) live/AI/search → free2z ·
+[#926](https://github.com/free2z/zuu/pull/926) e2e2z caller ·
+[#924](https://github.com/free2z/zuu/pull/924) free2z caller.
+
+## 2. What fails closed, by design
+
+These are built, validated, tested — and then refuse. That is the intended
+behaviour today, not an outage.
+
+### 2.1 There is no transport
+
+**Nothing can cross between the apps.** Verified App Links / Universal Links
+([#461](https://github.com/free2z/zuu/issues/461)) are not wired, and a
+custom-scheme deep link is not an authenticated channel — any app can register
+`zuuli://`, so shipping on one would recreate
+[#367](https://github.com/free2z/zuu/issues/367)'s confused deputy at the OS
+layer instead of the frame layer.
+
+Both callers build a real, validated request and then stop at **one named
+seam**:
+
+| Caller | The seam | Behaviour |
+| --- | --- | --- |
+| `wallet/free2z/src/lib/bridge/intent-transport.ts` | `installedIntentTransport` | rejects with `IntentTransportUnavailableError`, code `INTENT_TRANSPORT_UNAVAILABLE`, reason naming #461 |
+| `wallet/e2e2z/src/lib/enrollment/transport.ts` | the single `IntentTransport` implementation | rejects before device keys are sampled, and again unconditionally inside `dispatch` |
+
+Neither seam has a flag, an environment check, or an "if a wallet is installed"
+branch — those are the shapes that decay into a channel nobody reviewed.
+`rs/crates/f2z-intent` contains no URL parsing, no intent filter and no scheme,
+for the same reason. When #461 lands, the work is to write an `IntentTransport`
+and register it; nothing else on either path changes.
+
+The creator-tip UI is honest about this: only three outcomes may tell a payer
+that nothing was sent — no transport, a request that could not be built, and an
+explicit `INTENT_NOT_CONFIRMED` from the wallet. A lost answer or an
+`INTENT_UNAVAILABLE` sends the payer to ZUULI to look instead of reassuring
+them.
+
+### 2.2 `sign-challenge` has no caller and no implementation
+
+ZUULI refuses it with `INTENT_UNKNOWN_INTENT`, and that status is not a lie:
+this build genuinely does not implement it. The ordering is deliberate —
+[`AUTHORITY.md`](./intent-bridge/AUTHORITY.md) §3: a challenge is an opaque
+nonce that confirms nothing to the person approving it, so absent caller
+attestation both "who is asking" and "why" are attacker-chosen. Shipping it
+first because it "only signs" is backwards.
+
+The visible consequence today: free2z's **Login with Zcash** is *absent rather
+than stubbed behind a button that cannot work*. Password and linked accounts
+work; the Zcash method is missing and the login screen says so
+(`wallet/free2z/src/features/auth/`).
+
+Anything else that would depend on `sign-challenge` should be expected to be
+absent for the same reason. The Profile and revenue-share surfaces have not
+been ported yet — that is [#927](https://github.com/free2z/zuu/pull/927), still
+open at the time of writing.
+
+### 2.3 e2e2z shows no enrolled state
+
+Every enrollment call refuses with a typed
+`EnrollmentUnavailableError { reason: "enrollment-requires-wallet-app" }`
+without reaching Tauri IPC, and the screen renders a standing "enrollment
+happens in the wallet app" state: no claim control, no conversation list, no
+engine start/stop. Nothing synthesises an `EnrollmentStatus` — every field of
+one is a claim about the key transparency directory, and a fabricated
+`enrolled: true` would show a handle nobody published.
+
+## 3. What is blocked
+
+| Issue | What it blocks |
+| --- | --- |
+| [**#461**](https://github.com/free2z/zuu/issues/461) | *Everything cross-app.* Verified App Links / Universal Links need `assetlinks.json` and `apple-app-site-association` served from a domain we control |
+| [**#928**](https://github.com/free2z/zuu/issues/928) | Enrollment could not complete **even with a transport**: `IssueDeviceCredentialResultV1` carries no `identity_pk` and no `BackupWrapKey`, both of which `install_identity` requires, and e2e2z registers no install command. The obvious fix would ship a seed-derived key into e2e2z, breaching the account/device split — so this is a design question, not a wire-format patch |
+| [**#918**](https://github.com/free2z/zuu/issues/918) | free2z's native layer is unwired — the HTTP plugin, the OAuth transport, and its own deep-link scheme. Its bundle is `"active": false` |
+| [**#904**](https://github.com/free2z/zuu/issues/904) phase 4 | ZUULI's hardening. See §4 |
+
+**Therefore: no user can claim a messaging handle in any shipped build** until
+#461 and #928 both resolve. That is the plainest consequence of the two rows
+above and it is stated here so nobody has to derive it.
+
+Also open against the bridge, and worth reading before building on it:
+[#929](https://github.com/free2z/zuu/issues/929) (correlation is not
+authentication, and two clients now depend on it) and
+[#930](https://github.com/free2z/zuu/issues/930) (`INTENT_UNAVAILABLE` does not
+mean "nothing happened").
+
+## 4. In progress: hardening ZUULI
+
+[#904](https://github.com/free2z/zuu/issues/904) phase 4. The ports were
+**copies**, so removing the content surfaces from ZUULI is a separate step and
+is being worked now — do not infer ZUULI's current feature set from this page.
+
+The target state:
+
+- ZUULI renders no third-party content, so it needs no permissive CSP and can
+  drop the markdown and embed dependency tree.
+- Its capabilities are re-scoped to what a wallet authority actually needs.
+- The known hazard recorded on #904 is addressed: the Zcash plugin's seed lock
+  is **label-blind** — `WindowEvent::Focused(false)` ignores the label, which is
+  harmless with one window and wrong with two.
+
+Until that lands, ZUULI still contains the surfaces that were copied out of it.
+
+## 5. Keeping this page true
+
+This is the page most likely to go stale, which is why the root
+[`README.md`](../README.md) points at it rather than restating it. When you
+change any of the following, update the corresponding row here in the same pull
+request:
+
+- a transport seam stops rejecting;
+- an intent family gains an authority-side implementation;
+- a delegated surface gains or loses a capability or a plugin;
+- an issue in §3 closes.


### PR DESCRIPTION
Closes #931. Also closes the documentation half of #904 phase 0 — the root docs described a single ZUULI app and were materially wrong after tonight's split.

## What changed

| File | |
| --- | --- |
| `README.md` | Rewritten. 119 lines, reads in under a minute: the three apps as a table, the security argument in two sentences, everything else linked out |
| `docs/architecture.md` | **New.** The split in depth — the #367 threat, why sandboxing inside one app does not hold, the account/device key principle, what each surface holds, and the three gate checks that enforce it |
| `docs/status.md` | **New.** The honest ledger: what works, what fails closed by design, what is blocked |
| `docs/development.md` | **New.** Build, test, and the CI gate model |
| `AGENTS.md`, `CLAUDE.md` | "The three first-party Cargo roots" was stale — there are six under `wallet/`. Both now point at `docs/architecture.md` before you add a capability, a plugin, or an `invoke_handler` entry |
| `docs/architecture/CARGO-WORKSPACE.md` | Annotated, not rewritten. The count changed; the decision did not, and no revisit trigger has fired |

`docs/architecture.md` deliberately does **not** restate `docs/intent-bridge/PROTOCOL.md` — it links to it and to `AUTHORITY.md`, `CALLER-AUTHENTICATION.md`, `CONFORMANCE.md`.

## The honesty is the point

`docs/status.md` §2 and §3 state, with issue numbers:

- **There is no transport.** Both callers build real, validated requests and stop at one named seam — `wallet/free2z/src/lib/bridge/intent-transport.ts` and `wallet/e2e2z/src/lib/enrollment/transport.ts`. Nothing crosses between apps (#461).
- **`sign-challenge` has no caller and no authority-side implementation.** Refused with `INTENT_UNKNOWN_INTENT`. Hence free2z's Zcash login is absent rather than stubbed.
- **`issue-device-credential` has a caller but no authority side either** — correcting the original brief, which said only `sign-challenge`. `AUTHORITY.md` line 4 is explicit that both are deliberately unimplemented.
- **Enrollment could not complete even with a transport** (#928) — a design question, not a wire-format patch.
- **No user can claim a messaging handle in any shipped build** until #461 and #928 resolve. Stated outright so nobody has to derive it.
- **free2z's native layer is unwired** (#918); its bundle is `"active": false`.
- **ZUULI phase-4 hardening is in progress.** Target state described, marked in progress, and the page says explicitly not to infer ZUULI's current feature set from it — a parallel PR is deleting the ported surfaces.

## Verification

Every security property cites the file that enforces it, and each was read:

- `wallet/free2z/src-tauri/src/lib.rs` registers no `invoke_handler` at all.
- `wallet/e2e2z/src-tauri/Cargo.lock` — `grep -ic zcash` and `grep -ic orchard` both return **0**.
- `wallet/zuuli/scripts/surface-capability-authority.mjs` runs via `npm run test` inside the protected `zuuli / frontend` job, and `zuuli.yml`'s change detector selects `wallet/free2z/**` and `wallet/e2e2z/**`.
- `wallet-surfaces.yml` publishes no gate and is registered in `check-workflow-gates.mjs`'s `UNGATED_WORKFLOWS` (line 234).
- Merged PRs confirmed with `gh pr list`: #909 #911 #919 #914 #913 #912 #920 #926 #924. **#927 is still open**, so nothing is claimed about Profile or the revenue-share surfaces.

Ran:

- **Every relative link in all 7 touched files resolves** — scripted check, 0 broken. No link points at a moved or deleted path, and nothing in the repo links to a root-README anchor.
- `scripts/check-public-repo-boundary.sh` — clean
- `scripts/check-workflow-gates.mjs` — clean
- `scripts/check-hash-domain-labels.mjs` — clean
- `scripts/check-github-actions-pins.mjs`, `check-zuuli-linux-image.mjs`, `check-zuuli-store-capture-image.mjs`, `check-zuuli-android-gate.mjs` — clean
- `node --test wallet/zuuli/scripts/ui-copy-truncation.node-test.mjs` — 4/4 pass (this text does not feed UI; run for completeness)

The repo has no markdown linter or link checker in CI, so the link check above was scripted for this PR.

## Scope

Stayed entirely out of `wallet/free2z/**`, `wallet/e2e2z/**` and `wallet/zuuli/**`.

**Found stale, not fixed — out of scope:**

- `wallet/zuuli/CLAUDE.md:3` still calls ZUULI "the flagship Zcash-native app: a native Zcash wallet…" combining wallet and content surfaces. After phase 4 that sentence is wrong. It belongs to whoever is doing the hardening.
- `.github/workflows/wallet-surfaces.yml`'s header comment says e2e2z "is still a placeholder screen" in one place while the file's own later comment records that phase 3 moved the messaging surface there. Currently true (e2e2z still ships no `vite.config.*`), but it will read as stale the moment one is added.
- `docs/e2ee/CLIENT-CONTRACT.md` carries a superseded-by-#904 banner rather than fully re-derived text. Correct as an annotation; a real pass is a separate job.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
