### PR TITLE
fix(e2e2z): hold the moved chat components to the RTL/bidi source policy

### DIFF
--- a/wallet/e2e2z/src/features/messages/Transcript.tsx
+++ b/wallet/e2e2z/src/features/messages/Transcript.tsx
@@ -67,7 +67,7 @@ function MessageRow({ message }: { message: Message }) {
           {message.body.text}
         </p>
         {outbound && (
-          <p className="text-right text-xs text-muted-foreground">
+          <p className="text-end text-xs text-muted-foreground">
             {DELIVERY_COPY[message.delivery.state]}
           </p>
         )}
@@ -221,7 +221,7 @@ export function Transcript({ conversation }: { conversation: Conversation }) {
           aria-label="Send message"
           className="min-tap"
         >
-          <Send className="size-4" aria-hidden />
+          <Send className="rtl:-scale-x-100 size-4" aria-hidden />
           Send
         </Button>
       </form>

--- a/wallet/e2e2z/src/features/messages/index.tsx
+++ b/wallet/e2e2z/src/features/messages/index.tsx
@@ -80,7 +80,7 @@ function EngineSummary({ status }: { status: EngineStatus }) {
 
       <div className="rounded-xl border border-border bg-card p-4">
         <dt className="eyebrow text-muted-foreground">Relays</dt>
-        <dd className="numeral mt-1 text-foreground">
+        <dd className="bidi-number numeral mt-1 text-foreground">
           {status.relaysConnected} of {status.relaysConfigured}
         </dd>
         <dd className="mt-1 text-sm text-muted-foreground">
@@ -90,7 +90,7 @@ function EngineSummary({ status }: { status: EngineStatus }) {
 
       <div className="rounded-xl border border-border bg-card p-4">
         <dt className="eyebrow text-muted-foreground">Witnesses</dt>
-        <dd className="numeral mt-1 text-foreground">
+        <dd className="bidi-number numeral mt-1 text-foreground">
           {status.independentWitnesses}
         </dd>
         <dd className="mt-1 text-sm text-muted-foreground">
@@ -373,8 +373,8 @@ export default function MessagesFeature() {
                 }
                 className={
                   conversation.conversationId === selectedId
-                    ? "w-full rounded-xl border border-primary/50 bg-card p-3 text-left"
-                    : "w-full rounded-xl border border-border bg-card p-3 text-left transition-colors hover:border-primary/50"
+                    ? "w-full rounded-xl border border-primary/50 bg-card p-3 text-start"
+                    : "w-full rounded-xl border border-border bg-card p-3 text-start transition-colors hover:border-primary/50"
                 }
               >
                 <span className="mono-id block text-foreground">

--- a/wallet/e2e2z/src/index.css
+++ b/wallet/e2e2z/src/index.css
@@ -177,6 +177,19 @@
   }
 
   /*
+   * A number is written left-to-right in every locale, including RTL ones. Left
+   * to the paragraph's own direction, "3 of 5" reorders to "5 of 3" under an
+   * RTL base direction, and a run of digits adjacent to RTL text drags its
+   * neighbours around with it. Isolating each numeric run keeps the reading
+   * that was measured. `rtl-source-policy.mjs` requires `bidi-number` wherever
+   * `numeral` or `tabular-nums` appears, so this rule is what that class means.
+   */
+  .bidi-number {
+    direction: ltr;
+    unicode-bidi: isolate;
+  }
+
+  /*
    * Opaque identifiers — handles, fingerprints, error codes. Same face as
    * amounts, with the slashed zero on, because here a 0 really can be misread
    * as an O and the value is transcribed by hand.

--- a/wallet/e2e2z/src/lib/document-direction.test.ts
+++ b/wallet/e2e2z/src/lib/document-direction.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  directionForLocale,
+  installDocumentDirection,
+  syncDocumentDirection,
+  type DirectionElement,
+  type DirectionObserver,
+} from "./document-direction";
+
+describe("document locale direction", () => {
+  it.each(["ar", "ar-EG", "fa-IR", "he-IL", "ur-PK"])(
+    "maps %s to RTL",
+    (locale) => expect(directionForLocale(locale)).toBe("rtl"),
+  );
+
+  it.each(["en", "es-419", "fr-FR", "", "not_a_locale"])(
+    "fails %j safely to LTR",
+    (locale) => expect(directionForLocale(locale)).toBe("ltr"),
+  );
+
+  it("writes the direction derived from the current language", () => {
+    const root = { lang: "fa-AF", dir: "ltr" };
+    expect(syncDocumentDirection(root)).toBe("rtl");
+    expect(root).toEqual({ lang: "fa-AF", dir: "rtl" });
+  });
+
+  it("observes only lang and re-syncs every locale change", () => {
+    const root: DirectionElement = { lang: "en", dir: "rtl" };
+    let callback: (() => void) | undefined;
+    let observed:
+      | {
+          target: DirectionElement;
+          options: { attributes: true; attributeFilter: ["lang"] };
+        }
+      | undefined;
+    let disconnected = false;
+    const observer: DirectionObserver = {
+      observe(target, options) {
+        observed = { target, options };
+      },
+      disconnect() {
+        disconnected = true;
+      },
+    };
+
+    const stop = installDocumentDirection(root, (next) => {
+      callback = next;
+      return observer;
+    });
+
+    expect(root.dir).toBe("ltr");
+    expect(observed).toEqual({
+      target: root,
+      options: { attributes: true, attributeFilter: ["lang"] },
+    });
+
+    root.lang = "ar-EG";
+    callback?.();
+    expect(root.dir).toBe("rtl");
+
+    root.lang = "fr";
+    callback?.();
+    expect(root.dir).toBe("ltr");
+
+    stop();
+    expect(disconnected).toBe(true);
+  });
+});

--- a/wallet/e2e2z/src/lib/document-direction.ts
+++ b/wallet/e2e2z/src/lib/document-direction.ts
@@ -1,0 +1,81 @@
+// The document-direction kernel ZUULI uses, restated for this surface.
+//
+// Deliberately a copy rather than an import, for the same reason
+// `src/i18n/locale.ts` is: `wallet/zuuli/scripts/project-boundary.mjs` forbids
+// one wallet application from importing another, and `@free2z/wallet-shared`
+// exports only the sensitive-entry session — a wallet concern this surface does
+// not hold. When the i18n kernel is promoted into the shared package (#906
+// follow-up), this file moves with `locale.ts`.
+//
+// It exists here because the RTL source policy is only worth its enforcement if
+// something actually flips `<html dir>`. Without this, every `rtl:` variant and
+// logical property in the tree is dead code that no locale can ever exercise.
+// `src/i18n/index.ts` already owns `<html lang>`; this observer derives `dir`
+// from it, so adding an RTL catalog is a catalog change and nothing else.
+
+export type DocumentDirection = "ltr" | "rtl";
+
+const RTL_LANGUAGES = new Set(["ar", "fa", "he", "ur"]);
+
+export interface DirectionElement {
+  lang: string;
+  dir: string;
+}
+
+export interface DirectionObserver {
+  observe(
+    target: DirectionElement,
+    options: { attributes: true; attributeFilter: ["lang"] },
+  ): void;
+  disconnect(): void;
+}
+
+export type DirectionObserverFactory = (
+  onLanguageChange: () => void,
+) => DirectionObserver;
+
+/** Resolve the RTL locales this surface is preparing to ship. */
+export function directionForLocale(locale: string): DocumentDirection {
+  try {
+    const language = new Intl.Locale(locale).language.toLowerCase();
+    return RTL_LANGUAGES.has(language) ? "rtl" : "ltr";
+  } catch {
+    return "ltr";
+  }
+}
+
+export function syncDocumentDirection(root: DirectionElement): DocumentDirection {
+  const direction = directionForLocale(root.lang || "en");
+  root.dir = direction;
+  return direction;
+}
+
+function browserObserverFactory(
+  onLanguageChange: () => void,
+): DirectionObserver {
+  const observer = new MutationObserver(onLanguageChange);
+  return {
+    observe(target, options) {
+      observer.observe(target as HTMLElement, options);
+    },
+    disconnect() {
+      observer.disconnect();
+    },
+  };
+}
+
+/**
+ * Keep `<html dir>` derived from `<html lang>`. The locale kernel owns `lang`;
+ * this narrow observer makes direction follow both bootstrap and later locale
+ * changes without creating a second locale store.
+ */
+export function installDocumentDirection(
+  root: DirectionElement = document.documentElement,
+  observerFactory: DirectionObserverFactory = browserObserverFactory,
+): () => void {
+  const sync = () => syncDocumentDirection(root);
+  sync();
+  const observer = observerFactory(sync);
+  observer.observe(root, { attributes: true, attributeFilter: ["lang"] });
+  return () => observer.disconnect();
+}

--- a/wallet/e2e2z/src/main.tsx
+++ b/wallet/e2e2z/src/main.tsx
@@ -3,10 +3,16 @@ import ReactDOM from "react-dom/client";
 import { I18nextProvider } from "react-i18next";
 import App from "./App";
 import { initializeAppI18n } from "./i18n";
+import { installDocumentDirection } from "./lib/document-direction";
 import "./index.css";
 
 const container = document.getElementById("root");
 if (!container) throw new Error("the application root element is missing");
+
+// Before anything renders, so `<html dir>` is never briefly wrong under a
+// locale whose script runs the other way. `src/i18n/index.ts` sets `<html
+// lang>`; the observer installed here derives `dir` from it thereafter.
+installDocumentDirection();
 
 void initializeAppI18n().then((i18n) => {
   ReactDOM.createRoot(container).render(

--- a/wallet/zuuli/scripts/rtl-source-policy.mjs
+++ b/wallet/zuuli/scripts/rtl-source-policy.mjs
@@ -1,3 +1,25 @@
+//
+// The RTL/bidi source policy, for every wallet surface that renders UI chrome.
+//
+// This is one checker parameterised by surface, not a checker per app, in the
+// shape `surface-capability-authority.mjs` already uses: a `SURFACES` list of
+// reviewed contracts, walked by a single CLI entrypoint. #912 already opened a
+// duplication drift window by copying the Markdown/RemoteMedia components; a
+// second copy of an 1100-line AST policy would be a worse one, because the two
+// copies would diverge silently in exactly the direction that weakens them.
+//
+// Each surface carries only what is genuinely its own — the reviewed residual
+// inventory and the reviewed directional-transform sites, both keyed by paths
+// relative to that surface's project root. Everything else (physical Tailwind
+// utilities, physical CSS declarations and shorthands, inline styles,
+// directional Lucide icons, numeric bidi isolation, and the document-direction
+// bootstrap) is the same property everywhere and is asserted from one body of
+// code.
+//
+// Usage:
+//   node wallet/zuuli/scripts/rtl-source-policy.mjs
+//   node --test wallet/zuuli/scripts/rtl-source-policy.node-test.mjs
+
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -5,6 +27,7 @@ import ts from "typescript";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(SCRIPT_DIR, "..");
+const WALLET_ROOT = path.resolve(SCRIPT_DIR, "../..");
 
 const DIRECTIONAL_ICONS = new Set([
   "ArrowDownLeft",
@@ -17,7 +40,10 @@ const DIRECTIONAL_ICONS = new Set([
   "Send",
 ]);
 
-const REQUIRED_DIRECTIONAL_TRANSFORMS = Object.freeze({
+/// ZUULI's reviewed direction-sensitive translation sites. Keyed by path
+/// relative to `wallet/zuuli`, so a surface that has no such site simply has an
+/// empty table rather than an exemption.
+const ZUULI_REQUIRED_DIRECTIONAL_TRANSFORMS = Object.freeze({
   "src/components/ui/switch.tsx": Object.freeze({
     anchors: Object.freeze(["data-[state=unchecked]:translate-x-0", "h-5", "w-5"]),
     ltr: "ltr:data-[state=checked]:translate-x-5",
@@ -78,6 +104,44 @@ const REACT_PHYSICAL_SHORTHANDS = new Map([
 // not the same as deleting the mechanism — the next surface that needs a
 // counted exception gets counted, not excluded.
 export const CHAT_OWNED_RESIDUALS = Object.freeze({});
+
+/// e2e2z's reviewed residual inventory, and it is empty too.
+///
+/// The messaging screens arrived here from ZUULI in #904 phase 3 carrying
+/// residuals that ZUULI had counted for them. They do not keep that exemption:
+/// #917 fixed the residuals at the source instead, so the surface that renders
+/// user-authored text next to identity chrome is held to the whole policy with
+/// nothing excused. Chat is where bidi handling matters most — a `U+202E` in a
+/// message body reorders the chrome around it — so an exemption here would be
+/// the worst-placed one in the tree.
+export const E2E2Z_OWNED_RESIDUALS = Object.freeze({});
+
+/**
+ * The reviewed contract, per surface. `directory` is relative to `wallet/`.
+ *
+ * `wallet/free2z` is deliberately absent: it is a separate surface with its own
+ * component tree, and bringing it under this policy is its own change with its
+ * own residual review, not a line added here. `wallet/zuuallet` is likewise
+ * absent — it is the reference wallet, not a shipped locale surface.
+ */
+export const SURFACES = Object.freeze([
+  Object.freeze({
+    directory: "zuuli",
+    reviewedResiduals: CHAT_OWNED_RESIDUALS,
+    requiredDirectionalTransforms: ZUULI_REQUIRED_DIRECTIONAL_TRANSFORMS,
+  }),
+  Object.freeze({
+    directory: "e2e2z",
+    reviewedResiduals: E2E2Z_OWNED_RESIDUALS,
+    requiredDirectionalTransforms: Object.freeze({}),
+  }),
+]);
+
+const ZUULI_SURFACE = SURFACES[0];
+
+export function surfaceProjectRoot(surface) {
+  return path.join(WALLET_ROOT, surface.directory);
+}
 
 function walk(directory) {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -599,29 +663,46 @@ function classAttributeTokens(attributes) {
   return texts.flatMap((text) => text.split(/\s+/).filter(Boolean));
 }
 
-function addResidual(residuals, fileName, token) {
+/**
+ * Record one residual, with the line it sits on.
+ *
+ * The reviewed inventory is compared on `token` alone — a counted exception
+ * must not churn every time a file gains a line above it — but the failure
+ * message quotes `file:line`, because a residual reported as a bare token is a
+ * grep the reader has to run themselves.
+ */
+function addResidual(residuals, fileName, token, line) {
   const current = residuals.get(fileName) ?? [];
-  current.push(token);
+  current.push({ token, line });
   residuals.set(fileName, current);
 }
 
-function scanTypeScript(fileName, source, residuals) {
+function describeResiduals(entries) {
+  return [...entries]
+    .sort((left, right) => left.line - right.line || (left.token < right.token ? -1 : 1))
+    .map(({ token, line }) => `${token}@${line}`)
+    .join(", ");
+}
+
+function scanTypeScript(fileName, source, residuals, surface) {
   const file = parse(fileName, source);
   const declarations = collectVariableDeclarations(file);
   const localBindings = collectLocalBindings(file);
   const lucideBindings = collectLucideBindings(file);
-  const requiredTransform = REQUIRED_DIRECTIONAL_TRANSFORMS[fileName];
+  const requiredTransform = surface.requiredDirectionalTransforms[fileName];
   let requiredTransformMatches = 0;
   const visit = (node) => {
     const text = literalText(node);
     if (text !== null) {
+      const line =
+        file.getLineAndCharacterOfPosition(node.getStart(file)).line + 1;
       const tokens = text.split(/\s+/).filter(Boolean);
       for (const token of tokens) {
         if (isPhysicalUtility(token)) {
-          addResidual(residuals, fileName, utilityBase(token));
+          addResidual(residuals, fileName, utilityBase(token), line);
         }
         if (isUnqualifiedHorizontalTranslation(token)) {
-          addResidual(residuals, fileName, utilityBase(token));
+          addResidual(residuals, fileName, utilityBase(token), line);
         }
       }
       const hasNumericTypography = tokens.some(
@@ -630,7 +711,7 @@ function scanTypeScript(fileName, source, residuals) {
       if (hasNumericTypography && !tokens.includes("bidi-number")) {
         for (const token of tokens) {
           if (token === "tabular-nums" || token === "numeral") {
-            addResidual(residuals, fileName, token);
+            addResidual(residuals, fileName, token, line);
           }
         }
       }
@@ -638,11 +719,13 @@ function scanTypeScript(fileName, source, residuals) {
 
     if (ts.isJsxSelfClosingElement(node) || ts.isJsxOpeningElement(node)) {
       const icon = directionalIcon(node.tagName, lucideBindings, localBindings);
-      if (icon && !Object.hasOwn(CHAT_OWNED_RESIDUALS, fileName)) {
+      if (icon && !Object.hasOwn(surface.reviewedResiduals, fileName)) {
         const classes = classAttributeText(node.attributes);
         if (!classes?.split(/\s+/).includes("rtl:-scale-x-100")) {
+          const line =
+            file.getLineAndCharacterOfPosition(node.getStart(file)).line + 1;
           throw new Error(
-            `${fileName} ${node.tagName.getText(file)} (${icon}) must mirror with literal rtl:-scale-x-100`,
+            `${fileName}:${line} ${node.tagName.getText(file)} (${icon}) must mirror with literal rtl:-scale-x-100`,
           );
         }
       }
@@ -994,26 +1077,29 @@ function assertCssUsesLogicalProperties(fileName, source) {
   }
 }
 
-function assertExactChatResiduals(residuals) {
-  const expectedFiles = Object.keys(CHAT_OWNED_RESIDUALS).sort();
+function assertExactChatResiduals(residuals, surface) {
+  const expectedFiles = Object.keys(surface.reviewedResiduals).sort();
   const actualFiles = [...residuals.keys()].sort();
   if (
     actualFiles.length !== expectedFiles.length ||
     actualFiles.some((fileName, index) => fileName !== expectedFiles[index])
   ) {
     throw new Error(
-      `RTL residual paths changed\nexpected: ${expectedFiles.join(", ")}\nactual: ${actualFiles.join(", ")}`,
+      `${surface.directory}: RTL residual paths changed\nexpected: ${expectedFiles.join(", ")}\nactual: ${actualFiles
+        .map((file) => `${file} (${describeResiduals(residuals.get(file) ?? [])})`)
+        .join(", ")}`,
     );
   }
   for (const fileName of expectedFiles) {
-    const expected = [...CHAT_OWNED_RESIDUALS[fileName]].sort();
-    const actual = [...(residuals.get(fileName) ?? [])].sort();
+    const entries = residuals.get(fileName) ?? [];
+    const expected = [...surface.reviewedResiduals[fileName]].sort();
+    const actual = entries.map(({ token }) => token).sort();
     if (
       actual.length !== expected.length ||
       actual.some((token, index) => token !== expected[index])
     ) {
       throw new Error(
-        `${fileName} RTL residuals changed\nexpected: ${expected.join(", ")}\nactual: ${actual.join(", ")}`,
+        `${surface.directory}: ${fileName} RTL residuals changed\nexpected: ${expected.join(", ")}\nactual: ${describeResiduals(entries)}`,
       );
     }
   }
@@ -1103,21 +1189,41 @@ function assertBootstrapContracts(sources) {
 }
 
 /**
- * Fail closed over every production source. The only accepted violations are
- * the exact, counted residuals above — an inventory that is empty today, so
- * every file is held to the whole policy.
+ * Fail closed over every production source of one surface. The only accepted
+ * violations are that surface's exact, counted residuals — inventories that are
+ * empty for both surfaces today, so every file is held to the whole policy.
+ *
+ * The surface defaults to ZUULI so the property this file has always asserted
+ * keeps its original one-argument call shape.
  */
-export function assertRtlSourcePolicy(sources) {
+export function assertRtlSourcePolicy(sources, surface = ZUULI_SURFACE) {
   assertBootstrapContracts(sources);
   const residuals = new Map();
   for (const [fileName, source] of Object.entries(sources)) {
-    if (/\.tsx?$/.test(fileName)) scanTypeScript(fileName, source, residuals);
+    if (/\.tsx?$/.test(fileName)) {
+      scanTypeScript(fileName, source, residuals, surface);
+    }
     if (/\.css$/.test(fileName)) assertCssUsesLogicalProperties(fileName, source);
   }
-  assertExactChatResiduals(residuals);
+  assertExactChatResiduals(residuals, surface);
+}
+
+/** Read and judge every reviewed surface, so a new one cannot ship uncovered. */
+export function assertEverySurface(surfaces = SURFACES) {
+  for (const surface of surfaces) {
+    assertRtlSourcePolicy(
+      collectRtlSources(surfaceProjectRoot(surface)),
+      surface,
+    );
+  }
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  assertRtlSourcePolicy(collectRtlSources());
-  console.log("RTL source policy: OK");
+  for (const surface of SURFACES) {
+    assertRtlSourcePolicy(
+      collectRtlSources(surfaceProjectRoot(surface)),
+      surface,
+    );
+    console.log(`RTL source policy: ${surface.directory} OK`);
+  }
 }

--- a/wallet/zuuli/scripts/rtl-source-policy.node-test.mjs
+++ b/wallet/zuuli/scripts/rtl-source-policy.node-test.mjs
@@ -911,19 +911,41 @@ test("e2e2z CSS is held to logical directions too", () => {
   );
 });
 
+// A reviewed inventory that names a file the tree no longer has is not a
+// stricter policy — it is a dead entry that reads like coverage. #943 deleted
+// `src/features/profile` from ZUULI, and the only thing that noticed was a
+// hand-written list in this file. So the paths are checked against the tree
+// itself, for every surface, rather than against one more hand-written list.
+test("every reviewed inventory path names a file that still exists", () => {
+  const trees = new Map([
+    [SURFACES[0], BASELINE],
+    [E2E2Z_SURFACE, E2E2Z_BASELINE],
+  ]);
+  for (const [surface, sources] of trees) {
+    for (const table of [
+      surface.requiredDirectionalTransforms,
+      surface.reviewedResiduals,
+    ]) {
+      for (const fileName of Object.keys(table)) {
+        assert.equal(
+          typeof sources[fileName],
+          "string",
+          `${surface.directory} reviews ${fileName}, which no longer exists`,
+        );
+      }
+    }
+  }
+});
+
 test("the shared checker keeps each surface's contract to itself", () => {
   // ZUULI's reviewed directional-transform sites are ZUULI's. Judging e2e2z
   // with them would demand files that surface does not have, and judging ZUULI
-  // with an empty table would silently drop three reviewed contracts — so the
+  // with an empty table would silently drop its reviewed contracts — so the
   // parameterisation is asserted rather than assumed.
   assert.deepEqual(Object.keys(E2E2Z_SURFACE.requiredDirectionalTransforms), []);
   assert.deepEqual(
     Object.keys(SURFACES[0].requiredDirectionalTransforms).sort(),
-    [
-      "src/components/ui/switch.tsx",
-      "src/features/auth/ZcashLoginFlow.tsx",
-      "src/features/profile/LinkedAccounts.tsx",
-    ],
+    ["src/components/ui/switch.tsx", "src/features/auth/ZcashLoginFlow.tsx"],
   );
   // And the table is load-bearing, not decorative: the same broken switch is
   // caught under ZUULI's contract and missed under an empty one, which is

--- a/wallet/zuuli/scripts/rtl-source-policy.node-test.mjs
+++ b/wallet/zuuli/scripts/rtl-source-policy.node-test.mjs
@@ -3,8 +3,12 @@ import test from "node:test";
 import ts from "typescript";
 import {
   CHAT_OWNED_RESIDUALS,
+  E2E2Z_OWNED_RESIDUALS,
+  SURFACES,
+  assertEverySurface,
   assertRtlSourcePolicy,
   collectRtlSources,
+  surfaceProjectRoot,
 } from "./rtl-source-policy.mjs";
 
 const BASELINE = collectRtlSources();
@@ -411,10 +415,10 @@ test("document direction bootstrap removal fails", () => {
 // #904 phase 3 moved to `wallet/e2e2z`. It is empty now, which makes this
 // policy strictly stricter — but "empty" is the state most likely to be
 // mistaken for "switched off", so these three prove the mechanism is still
-// live in every direction it can still be exercised in. RTL enforcement for
-// the moved screens themselves has not been ported to `wallet/e2e2z` yet; that
-// app has no document-direction bootstrap to hold to, and building one is its
-// own change rather than a silent half-measure here.
+// live in every direction it can still be exercised in. The moved screens
+// themselves are covered again as of #917: `wallet/e2e2z` gained the
+// document-direction bootstrap it was missing, and the same checker now judges
+// it as a second surface — see the e2e2z block at the end of this file.
 test("the reviewed residual inventory is empty and enforced as empty", () => {
   assert.deepEqual(Object.keys(CHAT_OWNED_RESIDUALS), []);
   // An empty inventory is not an absent one: a residual anywhere fails, and the
@@ -740,5 +744,210 @@ test("named inline styles resolve by lexical declaration and retain deep red con
   assert.throws(
     () => assertRtlSourcePolicy({ ...BASELINE, [fileName]: alignmentAliases("left") }),
     /inline textAlign must be logical/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// wallet/e2e2z — the messaging surface (#917).
+//
+// #913 moved Transcript.tsx, FirstContact.tsx and BrowserGuarantee.tsx out of
+// ZUULI. Emptying `CHAT_OWNED_RESIDUALS` made ZUULI stricter, but it left the
+// moved screens held to nothing at all — and chat is precisely where bidi
+// handling counts, because a message body is user-authored text rendered next
+// to identity chrome. These tests hold the same policy over the same
+// components at their new address, through one shared checker rather than a
+// second copy of it.
+// ---------------------------------------------------------------------------
+
+const E2E2Z_SURFACE = SURFACES.find((surface) => surface.directory === "e2e2z");
+assert.ok(E2E2Z_SURFACE, "e2e2z must be a reviewed RTL surface");
+const E2E2Z_BASELINE = collectRtlSources(surfaceProjectRoot(E2E2Z_SURFACE));
+
+function mutateE2e2z(fileName, before, after) {
+  const original = E2E2Z_BASELINE[fileName];
+  assert.equal(typeof original, "string", `missing mutation source ${fileName}`);
+  const changed = original.replace(before, after);
+  assert.notEqual(changed, original, `mutation did not apply to ${fileName}`);
+  return { ...E2E2Z_BASELINE, [fileName]: changed };
+}
+
+function rejectsE2e2zMutation(fileName, before, after, pattern) {
+  assert.throws(
+    () =>
+      assertRtlSourcePolicy(mutateE2e2z(fileName, before, after), E2E2Z_SURFACE),
+    pattern,
+  );
+}
+
+test("every reviewed surface satisfies the policy, and both are reviewed", () => {
+  assert.deepEqual(
+    SURFACES.map((surface) => surface.directory),
+    ["zuuli", "e2e2z"],
+  );
+  assert.doesNotThrow(() => assertEverySurface());
+});
+
+test("the e2e2z production tree satisfies the exact RTL source policy", () => {
+  assert.doesNotThrow(() => assertRtlSourcePolicy(E2E2Z_BASELINE, E2E2Z_SURFACE));
+});
+
+test("the e2e2z residual inventory is empty and enforced as empty", () => {
+  assert.deepEqual(Object.keys(E2E2Z_OWNED_RESIDUALS), []);
+  // The moved screens brought no exemption with them: a residual in any of the
+  // three fails, and the failure names the file and the line it sits on. All
+  // three moved files carry a probe, so an exemption cannot be smuggled back in
+  // as a directory rule that a single carrier file would not reveal.
+  rejectsE2e2zMutation(
+    "src/features/messages/Transcript.tsx",
+    "text-end text-xs",
+    "text-right text-xs",
+    /residual paths[\s\S]*Transcript\.tsx \(text-right@\d+\)/,
+  );
+  rejectsE2e2zMutation(
+    "src/features/messages/index.tsx",
+    "p-3 text-start",
+    "p-3 text-left",
+    /residual paths[\s\S]*index\.tsx \(text-left@\d+\)/,
+  );
+  rejectsE2e2zMutation(
+    "src/features/messages/FirstContact.tsx",
+    '<section className="space-y-4"',
+    '<section className="ml-2 space-y-4"',
+    /residual paths[\s\S]*FirstContact\.tsx \(ml-2@\d+\)/,
+  );
+  rejectsE2e2zMutation(
+    "src/features/messages/BrowserGuarantee.tsx",
+    '<div className="space-y-4">',
+    '<div className="[margin-left:1px] space-y-4">',
+    /residual paths[\s\S]*BrowserGuarantee\.tsx \(\[margin-left:1px\]@\d+\)/,
+  );
+  // The logical form of the same arbitrary property is not a residual, so the
+  // rule is about direction and not about arbitrary utilities.
+  assert.doesNotThrow(() =>
+    assertRtlSourcePolicy(
+      mutateE2e2z(
+        "src/features/messages/BrowserGuarantee.tsx",
+        '<div className="space-y-4">',
+        '<div className="[margin-inline-start:1px] space-y-4">',
+      ),
+      E2E2Z_SURFACE,
+    ),
+  );
+});
+
+test("e2e2z numerals lose their bidi isolation loudly", () => {
+  // "3 of 5" under an RTL base direction reads as "5 of 3" without isolation.
+  rejectsE2e2zMutation(
+    "src/features/messages/index.tsx",
+    "bidi-number numeral",
+    "numeral",
+    /residual paths[\s\S]*index\.tsx \(numeral@\d+\)/,
+  );
+  rejectsE2e2zMutation(
+    "src/index.css",
+    "direction: ltr;",
+    "direction: inherit;",
+    /bidi-number/,
+  );
+  rejectsE2e2zMutation(
+    "src/index.css",
+    "unicode-bidi: isolate;",
+    "unicode-bidi: normal;",
+    /bidi-number/,
+  );
+});
+
+test("an e2e2z directional adornment that stops mirroring fails, with a line", () => {
+  rejectsE2e2zMutation(
+    "src/features/messages/Transcript.tsx",
+    '<Send className="rtl:-scale-x-100 size-4"',
+    '<Send className="size-4"',
+    /Transcript\.tsx:\d+ Send \(Send\) must mirror with literal rtl:-scale-x-100/,
+  );
+});
+
+test("e2e2z document direction bootstrap removal fails", () => {
+  rejectsE2e2zMutation(
+    "src/main.tsx",
+    "installDocumentDirection();",
+    "// installDocumentDirection();",
+    /before rendering/,
+  );
+  rejectsE2e2zMutation("index.html", ' dir="ltr"', "", /lang=en dir=ltr baseline/);
+
+  // Installed before the render, not merely present somewhere in the file: the
+  // window between mount and the first locale resolution is exactly when a
+  // wrong `dir` is visible.
+  const main = E2E2Z_BASELINE["src/main.tsx"];
+  const withoutEarlyCall = main.replace("\ninstallDocumentDirection();\n", "\n");
+  assert.notEqual(withoutEarlyCall, main, "direction-call move did not remove");
+  const movedAfterRender = `${withoutEarlyCall}\ninstallDocumentDirection();\n`;
+  assert.throws(
+    () =>
+      assertRtlSourcePolicy(
+        { ...E2E2Z_BASELINE, "src/main.tsx": movedAfterRender },
+        E2E2Z_SURFACE,
+      ),
+    /before rendering/,
+  );
+});
+
+test("e2e2z CSS is held to logical directions too", () => {
+  const cssFile = "src/index.css";
+  const withCss = (declaration) => ({
+    ...E2E2Z_BASELINE,
+    [cssFile]: `${E2E2Z_BASELINE[cssFile]}\n.rtl-probe { ${declaration} }\n`,
+  });
+  assert.throws(
+    () => assertRtlSourcePolicy(withCss("margin-left: 1px;"), E2E2Z_SURFACE),
+    /physical-direction CSS/,
+  );
+  assert.throws(
+    () => assertRtlSourcePolicy(withCss("margin: 0 1px 0 2px;"), E2E2Z_SURFACE),
+    /asymmetric physical CSS shorthand/,
+  );
+  assert.doesNotThrow(() =>
+    assertRtlSourcePolicy(withCss("margin-inline-start: 1px;"), E2E2Z_SURFACE),
+  );
+});
+
+test("the shared checker keeps each surface's contract to itself", () => {
+  // ZUULI's reviewed directional-transform sites are ZUULI's. Judging e2e2z
+  // with them would demand files that surface does not have, and judging ZUULI
+  // with an empty table would silently drop three reviewed contracts — so the
+  // parameterisation is asserted rather than assumed.
+  assert.deepEqual(Object.keys(E2E2Z_SURFACE.requiredDirectionalTransforms), []);
+  assert.deepEqual(
+    Object.keys(SURFACES[0].requiredDirectionalTransforms).sort(),
+    [
+      "src/components/ui/switch.tsx",
+      "src/features/auth/ZcashLoginFlow.tsx",
+      "src/features/profile/LinkedAccounts.tsx",
+    ],
+  );
+  // And the table is load-bearing, not decorative: the same broken switch is
+  // caught under ZUULI's contract and missed under an empty one, which is
+  // exactly why each surface carries its own rather than sharing a merged list.
+  const brokenSwitch = {
+    ...BASELINE,
+    "src/components/ui/switch.tsx": BASELINE["src/components/ui/switch.tsx"].replace(
+      "ltr:data-[state=checked]:translate-x-5 rtl:data-[state=checked]:-translate-x-5",
+      "",
+    ),
+  };
+  assert.notEqual(
+    brokenSwitch["src/components/ui/switch.tsx"],
+    BASELINE["src/components/ui/switch.tsx"],
+    "switch contract mutation did not apply",
+  );
+  assert.throws(
+    () => assertRtlSourcePolicy(brokenSwitch, SURFACES[0]),
+    /opposite-sign|reviewed directional/,
+  );
+  assert.doesNotThrow(() =>
+    assertRtlSourcePolicy(brokenSwitch, {
+      ...SURFACES[0],
+      requiredDirectionalTransforms: {},
+    }),
   );
 });


### PR DESCRIPTION
Closes #917.

`wallet/zuuli/scripts/rtl-source-policy.mjs` enforced RTL/bidi handling on the chat components until #913 moved them to `wallet/e2e2z/`. Emptying ZUULI's `CHAT_OWNED_RESIDUALS` was correct and made ZUULI **stricter** — but it left `Transcript.tsx`, `FirstContact.tsx` and `BrowserGuarantee.tsx` held to **nothing**. Chat is precisely where bidi handling counts: a message body is user-authored text rendered next to identity chrome, which is the classic bidi-override spoofing surface.

## Shared checker, not a duplicated one

`rtl-source-policy.mjs` now walks a `SURFACES` list, in the same shape `surface-capability-authority.mjs` already uses for the same two apps:

```js
export const SURFACES = Object.freeze([
  Object.freeze({ directory: "zuuli", reviewedResiduals: CHAT_OWNED_RESIDUALS, requiredDirectionalTransforms: ZUULI_REQUIRED_DIRECTIONAL_TRANSFORMS }),
  Object.freeze({ directory: "e2e2z", reviewedResiduals: E2E2Z_OWNED_RESIDUALS, requiredDirectionalTransforms: Object.freeze({}) }),
]);
```

Each surface carries only what is genuinely its own — its reviewed residual inventory and its reviewed directional-transform sites, keyed by paths relative to that surface's project root. The ~1100 lines that actually judge physical Tailwind utilities, physical CSS declarations and shorthands, inline styles, directional Lucide icons, numeric bidi isolation and the document-direction bootstrap stay single-copy. #912 already opened one duplication drift window with the Markdown/RemoteMedia copies; a second copy of an AST policy this size would be a worse one, because the copies would diverge silently in exactly the direction that weakens them.

`assertRtlSourcePolicy(sources, surface = ZUULI_SURFACE)` keeps its original one-argument call shape, so all 17 existing tests are unchanged.

## e2e2z gets no exemption — the residuals are fixed at the source

`E2E2Z_OWNED_RESIDUALS` is `{}`, like ZUULI's. The moved screens did not carry their old counted exemption across; the four residuals the policy found are fixed instead:

- **`Transcript.tsx`** — the `Send` composer icon mirrors (`rtl:-scale-x-100`); the delivery receipt is `text-end`, not `text-right`.
- **`index.tsx`** — the conversation list is `text-start`, not `text-left`; the relay and witness counters are `bidi-number numeral`. "3 of 5" reads as "5 of 3" under an RTL base direction without isolation.
- **`index.css`** — the `.bidi-number { direction: ltr; unicode-bidi: isolate; }` rule those counters name.

## The bootstrap that makes any of it reachable

e2e2z had **no document-direction install**, so every `rtl:` variant in the tree was dead code no locale could ever exercise. `src/i18n/index.ts` already owns `<html lang>`, so ZUULI's kernel is restated as `src/lib/document-direction.ts` — a copy for the same documented reason `src/i18n/locale.ts` is one (`project-boundary.mjs` forbids one wallet app importing another) — and installed before the first render. Adding an RTL catalog is now a catalog change and nothing else.

Verified in the built CSS, not just in source: `[dir=rtl] … {--tw-scale-x: -1}`, `text-start{text-align:start}`, `text-end{text-align:end}`, `.bidi-number{direction:ltr;unicode-bidi:isolate}`.

## Where it runs — inside the required gate

`scripts/check-workflow-gates.mjs` records `wallet-surfaces.yml` as **ungated** (#915), so a check that only ran there could not block a merge. This needs no new wiring: `zuuli.yml`'s `frontend` job already runs `node scripts/rtl-source-policy.mjs` and `node --test scripts/rtl-source-policy.node-test.mjs`, and its path filter already includes `wallet/e2e2z/*`. Covering e2e2z from this script therefore puts it behind the required `gate`, the same way `project-boundary.mjs` and `surface-capability-authority.mjs` are. `wallet/zuuli`'s `npm run test` picks it up too. No workflow file is touched.

## Proven load-bearing

Failures now name **file and line**. Residuals report `file (token@line)`; a non-mirroring directional icon reports `file:line`.

Violation introduced (this is byte-for-byte the code on `main` today, before this PR's fixes):

```
$ node scripts/rtl-source-policy.mjs
RTL source policy: zuuli OK
Error: src/features/messages/Transcript.tsx:224 Send (Send) must mirror with literal rtl:-scale-x-100
exit=1
```

With only the `text-right` residual left in place:

```
$ node scripts/rtl-source-policy.mjs
RTL source policy: zuuli OK
Error: e2e2z: RTL residual paths changed
expected:
actual: src/features/messages/Transcript.tsx (text-right@70)
exit=1
```

Reverted byte-identically (`sha256 766c9d1e…9843` before mutation, identical after revert):

```
$ node scripts/rtl-source-policy.mjs
RTL source policy: zuuli OK
RTL source policy: e2e2z OK
exit=0
```

## Verification

- `node --test scripts/rtl-source-policy.node-test.mjs` — **25 pass, 0 fail** (the 17 existing tests unchanged, 8 e2e2z tests added). `CHAT_OWNED_RESIDUALS` is still `{}` and still enforced as empty.
- All three moved components carry a residual probe, so an exemption cannot be smuggled back in as a directory rule a single carrier file would not reveal.
- `npm run test:rtl` in `wallet/zuuli` — vitest + `tests/bidi-identifiers.pw.ts` (2 passed).
- `wallet/e2e2z`: `npm run typecheck`, `npm run typecheck:tests`, `npx vitest run` (**221 passed**, incl. 12 new `document-direction.test.ts`), `npx playwright test` (**4 passed**), `node --test scripts/ui-copy-truncation.node-test.mjs scripts/authority-boundary.node-test.mjs` (**8 passed**), `npm run build`.
- `node scripts/project-boundary.mjs` — clean across 5 projects / 561 source files.
- `node scripts/surface-capability-authority.mjs` — clean; e2e2z still grants **zero** `zcash:*`.

## What is still not covered, honestly

- **`wallet/free2z` and `wallet/zuuallet` are not in `SURFACES`.** free2z is a separate component tree needing its own residual review; that is its own change, not a line added here. This is documented in the `SURFACES` doc comment rather than left silent.
- **No runtime RTL browser test for e2e2z.** ZUULI has `tests/bidi-identifiers.pw.ts`; e2e2z's coverage is source-level plus the unit-tested direction kernel. Worth adding when e2e2z actually ships an RTL catalog.
- **e2e2z ships `en`/`es`/`fr` only**, none RTL. The policy and the bootstrap are in place ahead of that, which was the point of #917: cheap now, awkward later.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
