### PR TITLE
test(free2z): port the Live, AI and Search Playwright coverage

### DIFF
--- a/wallet/free2z/tests/ai-context-switch.pw.ts
+++ b/wallet/free2z/tests/ai-context-switch.pw.ts
@@ -1,0 +1,121 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function openSignedInAi(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+  });
+  await page.goto("/ai");
+  await expect(
+    page.getByRole("button", { name: "Select AI model" }),
+  ).toContainText("GPT-4o");
+}
+
+async function sendMessage(page: Page, message: string) {
+  await page.getByRole("textbox", { name: "Message" }).fill(message);
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(page.getByText(message, { exact: true })).toBeVisible();
+  await expect(page.getByText(/Here's a reply in character/).last()).toBeVisible();
+}
+
+async function chooseModel(page: Page, name: string) {
+  await page.getByRole("button", { name: "Select AI model" }).click();
+  const option = page.getByRole("menuitem", { name: new RegExp(name) });
+  // Focus exercises the keyboard-select path even when a long menu places the
+  // requested mock model outside Playwright's compact default viewport.
+  await option.focus();
+  await option.press("Enter");
+}
+
+test("model and personality switches start honest, separate chat threads", async ({
+  page,
+}) => {
+  await openSignedInAi(page);
+  await sendMessage(page, "Context only the first model received");
+
+  await chooseModel(page, "Claude Haiku 4.5");
+  const dialog = page.getByRole("dialog", { name: "Start a new chat?" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText(
+    "The current transcript will be cleared because the new conversation cannot see it.",
+  );
+  await expect(dialog).toContainText("Claude Haiku 4.5");
+  await expect(
+    page.getByText("Context only the first model received", { exact: true }),
+  ).toBeVisible();
+
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(dialog).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Select AI model" }),
+  ).toContainText("GPT-4o");
+  await expect(
+    page.getByText("Context only the first model received", { exact: true }),
+  ).toBeVisible();
+
+  await chooseModel(page, "Claude Haiku 4.5");
+  await dialog.getByRole("button", { name: "Start new chat" }).click();
+  await expect(
+    page.getByRole("button", { name: "Select AI model" }),
+  ).toContainText("Claude Haiku 4.5");
+  await expect(
+    page.getByText("Context only the first model received", { exact: true }),
+  ).toHaveCount(0);
+
+  await sendMessage(page, "Context only Claude received");
+  await expect(page.getByText(/Claude Haiku 4\.5/).last()).toBeVisible();
+
+  await page.getByRole("button", { name: "Select AI personality" }).click();
+  await page.getByRole("menuitem", { name: /ZK Tutor/ }).click();
+  await expect(dialog).toContainText("Claude Haiku 4.5");
+  await expect(dialog).toContainText("ZK Tutor");
+  await dialog.getByRole("button", { name: "Start new chat" }).click();
+  await expect(
+    page.getByRole("button", { name: "Select AI personality" }),
+  ).toContainText("ZK Tutor");
+  await expect(
+    page.getByText("Context only Claude received", { exact: true }),
+  ).toHaveCount(0);
+
+  await sendMessage(page, "Context only the tutor received");
+  await expect(page.getByText(/primed as “ZK Tutor”/).last()).toBeVisible();
+});
+
+test("an empty chat switches immediately without a destructive confirmation", async ({
+  page,
+}) => {
+  await openSignedInAi(page);
+  await chooseModel(page, "Claude Sonnet 5");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Select AI model" }),
+  ).toContainText("Claude Sonnet 5");
+});
+
+test("an in-flight personality save cannot close into a mismatched chat", async ({
+  page,
+}) => {
+  await openSignedInAi(page);
+  await page.getByRole("button", { name: "Select AI personality" }).click();
+  await page.getByRole("menuitem", { name: "Manage personalities…" }).click();
+
+  const manager = page.getByRole("dialog", { name: "Personalities" });
+  await manager.getByRole("button", { name: "New personality" }).click();
+  await page.getByLabel("Name").fill("Late Persona");
+  await page
+    .getByLabel("System message")
+    .fill("Answer as the late but correctly bound persona.");
+  await page.getByRole("button", { name: "Save" }).click();
+  await page.getByRole("button", { name: "Close" }).click();
+
+  await expect(page.getByRole("dialog")).toBeVisible();
+  const savedManager = page.getByRole("dialog", { name: "Personalities" });
+  await expect(savedManager.getByText("Late Persona", { exact: true })).toBeVisible();
+  await savedManager.getByRole("button", { name: "Close" }).click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Select AI personality" }),
+  ).toContainText("Late Persona");
+
+  await sendMessage(page, "This message belongs to Late Persona");
+  await expect(page.getByText(/primed as “Late Persona”/).last()).toBeVisible();
+});

--- a/wallet/free2z/tests/ai-paid-intent.pw.ts
+++ b/wallet/free2z/tests/ai-paid-intent.pw.ts
@@ -1,0 +1,133 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * The `/ai` half of ZUULI's `paid-actions.pw.ts`.
+ *
+ * ZUULI's spec covers `/wallet/fund`, `/buy`, creator tips and `/ai` in one
+ * file. free2z mounts none of the wallet routes (#904), so the file cannot be
+ * ported whole; the four AI tests are lifted into their own spec instead. What
+ * they guard is a privacy property, not just a convenience one: a signed-out
+ * draft is a private message the reader has not sent yet, and it must survive
+ * an intentional login while being destroyed by every other exit.
+ */
+
+const PHONE = { width: 320, height: 568 };
+
+async function setSession(page: Page, signedIn: boolean) {
+  await page.addInitScript((authenticated) => {
+    const key = "zuuli.knox.token";
+    if (authenticated) localStorage.setItem(key, "mock-knox-token");
+    else localStorage.removeItem(key);
+    sessionStorage.removeItem("zuuli.auth.pending-paid-intent");
+  }, signedIn);
+}
+
+async function openAi(page: Page, signedIn = false) {
+  await page.setViewportSize(PHONE);
+  await setSession(page, signedIn);
+  await page.goto("/ai");
+  await page.locator("[data-app-frame]").waitFor();
+  if (signedIn) {
+    await expect(
+      page.getByRole("button", { name: "Account menu" }),
+    ).toBeVisible();
+  } else {
+    await expect(
+      page.getByRole("button", { name: "Log in", exact: true }),
+    ).toBeVisible();
+  }
+}
+
+async function expectNoAnonymousBalanceDiagnosis(page: Page) {
+  await expect(
+    page.getByText(/^(?:Your |Current )?Balance(?: after)?:/i),
+  ).toHaveCount(0);
+  await expect(page.getByText(/Not enough (?:2Z|2Zs)/i)).toHaveCount(0);
+  await expect(page.getByText(/You have .* need/i)).toHaveCount(0);
+  await expect(page.getByRole("link", { name: /Buy more 2Z/i })).toHaveCount(0);
+}
+
+async function expectLoginReturn(page: Page, returnTo: string) {
+  await expect(page).toHaveURL(/\/login$/);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const state = window.history.state as {
+          usr?: { returnTo?: unknown };
+        } | null;
+        return state?.usr?.returnTo ?? null;
+      }),
+    )
+    .toBe(returnTo);
+}
+
+async function storedIntent(page: Page) {
+  return page.evaluate(() => {
+    const raw = sessionStorage.getItem("zuuli.auth.pending-paid-intent");
+    return raw ? JSON.parse(raw) : null;
+  });
+}
+
+test("AI preserves its draft while authenticating before the paid conversation APIs", async ({
+  page,
+}) => {
+  await openAi(page);
+
+  const draft = "Explain shielded payments simply";
+  await page.getByRole("textbox", { name: "Message" }).fill(draft);
+  await expect(
+    page.getByText("Sign in to use AI.", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Buy 2Zs" })).toHaveCount(0);
+  await expectNoAnonymousBalanceDiagnosis(page);
+  await page.getByRole("button", { name: "Sign in to send message" }).click();
+
+  await expectLoginReturn(page, "/ai");
+  await expect.poll(() => storedIntent(page)).toMatchObject({
+    returnTo: "/ai",
+    intent: { kind: "ai", draft },
+  });
+});
+
+test("abandoning login destroys the guest's private AI draft", async ({
+  page,
+}) => {
+  await openAi(page);
+  await page.getByRole("textbox", { name: "Message" }).fill("private draft");
+  await page.getByRole("button", { name: "Sign in to send message" }).click();
+  await expectLoginReturn(page, "/ai");
+  await expect.poll(() => storedIntent(page)).not.toBeNull();
+
+  await page.getByRole("link", { name: "Continue as guest" }).click();
+  // ZUULI's guest exit lands on its Home feature. free2z has none, so the
+  // index route forwards to /articles.
+  await expect(page).toHaveURL(/\/articles$/);
+  await expect.poll(() => storedIntent(page)).toBeNull();
+});
+
+test("reloading login destroys the guest's private AI draft", async ({
+  page,
+}) => {
+  await openAi(page);
+  await page.getByRole("textbox", { name: "Message" }).fill("private draft");
+  await page.getByRole("button", { name: "Sign in to send message" }).click();
+  await expectLoginReturn(page, "/ai");
+  await expect.poll(() => storedIntent(page)).not.toBeNull();
+
+  await page.reload();
+  await expect(page).toHaveURL(/\/login$/);
+  await expect.poll(() => storedIntent(page)).toBeNull();
+});
+
+test("browser Back cannot restore a private AI draft while signed out", async ({
+  page,
+}) => {
+  await openAi(page);
+  await page.getByRole("textbox", { name: "Message" }).fill("private draft");
+  await page.getByRole("button", { name: "Sign in to send message" }).click();
+  await expectLoginReturn(page, "/ai");
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/ai$/);
+  await expect(page.getByRole("textbox", { name: "Message" })).toHaveValue("");
+});

--- a/wallet/free2z/tests/helpers/mock-capture.ts
+++ b/wallet/free2z/tests/helpers/mock-capture.ts
@@ -1,0 +1,95 @@
+import type { Page } from "@playwright/test";
+
+export async function installMockCapture(page: Page) {
+  await page.addInitScript(() => {
+    const captureState = {
+      requests: [] as MediaStreamConstraints[],
+      stoppedTracks: 0,
+    };
+    Object.defineProperty(window, "__free2zCapture", {
+      configurable: true,
+      value: captureState,
+    });
+
+    const deviceListeners = new Set<EventListenerOrEventListenerObject>();
+    function track(kind: "audio" | "video", deviceId: string) {
+      const ended = new Set<EventListenerOrEventListenerObject>();
+      return {
+        kind,
+        enabled: true,
+        label: kind === "audio" ? "Studio microphone" : "Front camera",
+        stop() {
+          captureState.stoppedTracks += 1;
+        },
+        getSettings() {
+          return { deviceId };
+        },
+        addEventListener(event: string, listener: EventListenerOrEventListenerObject) {
+          if (event === "ended") ended.add(listener);
+        },
+        removeEventListener(event: string, listener: EventListenerOrEventListenerObject) {
+          if (event === "ended") ended.delete(listener);
+        },
+      };
+    }
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        async enumerateDevices() {
+          return [
+            {
+              kind: "videoinput",
+              deviceId: "cam-1",
+              groupId: "video",
+              label: "Front camera",
+              toJSON() { return {}; },
+            },
+            {
+              kind: "audioinput",
+              deviceId: "mic-1",
+              groupId: "audio",
+              label: "Studio microphone",
+              toJSON() { return {}; },
+            },
+          ];
+        },
+        async getUserMedia(constraints: MediaStreamConstraints) {
+          captureState.requests.push(constraints);
+          const audio = track("audio", "mic-1");
+          const video = track("video", "cam-1");
+          return {
+            getTracks: () => [audio, video],
+            getAudioTracks: () => [audio],
+            getVideoTracks: () => [video],
+          };
+        },
+        addEventListener(event: string, listener: EventListenerOrEventListenerObject) {
+          if (event === "devicechange") deviceListeners.add(listener);
+        },
+        removeEventListener(event: string, listener: EventListenerOrEventListenerObject) {
+          if (event === "devicechange") deviceListeners.delete(listener);
+        },
+      },
+    });
+
+    Object.defineProperty(HTMLMediaElement.prototype, "srcObject", {
+      configurable: true,
+      get() { return (this as HTMLMediaElement & { __stream?: unknown }).__stream ?? null; },
+      set(value) { (this as HTMLMediaElement & { __stream?: unknown }).__stream = value; },
+    });
+    HTMLMediaElement.prototype.play = async () => {};
+    HTMLMediaElement.prototype.pause = () => {};
+  });
+}
+
+export async function captureState(page: Page) {
+  return page.evaluate(() => (
+    window as Window & {
+      __free2zCapture: {
+        requests: MediaStreamConstraints[];
+        stoppedTracks: number;
+      };
+    }
+  ).__free2zCapture);
+}

--- a/wallet/free2z/tests/media-preflight.pw.ts
+++ b/wallet/free2z/tests/media-preflight.pw.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import { captureState, installMockCapture } from "./helpers/mock-capture";
+
+async function signInAndOpen(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+  });
+  await installMockCapture(page);
+  await page.goto("/live");
+  await page.getByRole("button", { name: "Go Live" }).click();
+}
+
+test("capture needs explicit intent and a distinct ready confirmation before start", async ({
+  page,
+}) => {
+  await signInAndOpen(page);
+  await page.getByLabel("Title").fill("A deliberate stream");
+
+  expect((await captureState(page)).requests).toHaveLength(0);
+  await expect(page.getByRole("button", { name: "Confirm and start" })).toBeDisabled();
+  await expect(page).toHaveURL(/\/live$/);
+
+  await page.getByRole("button", { name: "Set up camera and microphone" }).click();
+  await expect(page.getByRole("heading", { name: "Preview ready" })).toBeVisible();
+  expect((await captureState(page)).requests).toEqual([{ audio: true, video: true }]);
+  await expect(page.getByRole("status")).toContainText("Camera on. Microphone muted.");
+  await expect(page.getByRole("button", { name: "Turn on microphone" })).toHaveAttribute(
+    "aria-pressed",
+    "false",
+  );
+  await expect(page.getByRole("button", { name: "Turn off camera" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+
+  await page.getByRole("button", { name: "Confirm and start" }).click();
+  await expect(page).toHaveURL(/\/live\/demo-creator$/);
+  await expect.poll(async () => (await captureState(page)).stoppedTracks).toBe(2);
+});
+
+for (const closeMethod of ["Cancel", "Close", "Escape", "outside"] as const) {
+  test(`${closeMethod} closes the dialog, releases capture, and keeps live unstarted`, async ({
+    page,
+  }) => {
+    await signInAndOpen(page);
+    await page.getByRole("button", { name: "Set up camera and microphone" }).click();
+    await expect(page.getByRole("heading", { name: "Preview ready" })).toBeVisible();
+    if (closeMethod === "Escape") await page.keyboard.press("Escape");
+    else if (closeMethod === "outside") await page.mouse.click(2, 2);
+    else await page.getByRole("button", { name: closeMethod, exact: true }).click();
+
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(page).toHaveURL(/\/live$/);
+    await expect.poll(async () => (await captureState(page)).stoppedTracks).toBe(2);
+  });
+}
+
+test("preflight is keyboard operable, touch sized, motion-safe, and fits 320px", async ({
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.setViewportSize({ width: 320, height: 760 });
+  await signInAndOpen(page);
+  await page.getByRole("button", { name: "Set up camera and microphone" }).click();
+  await expect(page.getByRole("heading", { name: "Preview ready" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Turn on microphone" }).focus();
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("button", { name: "Mute microphone" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+
+  const geometry = await page.getByRole("dialog").evaluate((dialog) => {
+    const rect = dialog.getBoundingClientRect();
+    const targets = [...dialog.querySelectorAll<HTMLElement>("button, input, select")]
+      .filter((element) => {
+        const box = element.getBoundingClientRect();
+        return box.width > 0 && box.height > 0;
+      })
+      .map((element) => {
+        const box = element.getBoundingClientRect();
+        return { width: box.width, height: box.height };
+      });
+    const animated = getComputedStyle(dialog);
+    return {
+      left: rect.left,
+      right: rect.right,
+      viewport: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      targets,
+      animationDuration: animated.animationDuration,
+      transitionDuration: animated.transitionDuration,
+    };
+  });
+  expect(geometry.left).toBeGreaterThanOrEqual(0);
+  expect(geometry.right).toBeLessThanOrEqual(geometry.viewport);
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.viewport);
+  for (const target of geometry.targets) {
+    expect(target.width).toBeGreaterThanOrEqual(43.5);
+    expect(target.height).toBeGreaterThanOrEqual(43.5);
+  }
+  expect(Number.parseFloat(geometry.animationDuration)).toBeLessThanOrEqual(0.00001);
+  expect(Number.parseFloat(geometry.transitionDuration)).toBeLessThanOrEqual(0.00001);
+});

--- a/wallet/free2z/tests/participant-counts.pw.ts
+++ b/wallet/free2z/tests/participant-counts.pw.ts
@@ -1,0 +1,93 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installMockCapture } from "./helpers/mock-capture";
+
+const privateSecret = "123e4567-e89b-42d3-a456-426614174000";
+
+async function signIn(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+  });
+}
+
+/**
+ * ZUULI's version of this test also asserts the same two counts on its Home
+ * feature's live rail. free2z mounts no Home: its index route forwards to
+ * `/articles`, and `features/home` was never ported (#912/#920). The home half
+ * is dropped rather than aimed at `/articles`, where no live card renders and
+ * every assertion would have been about an element that does not exist. The
+ * redirect is asserted so the omission stays a stated fact rather than a
+ * silent one — if a Home surface with a live rail ever lands here, this fails
+ * and the dropped coverage has to be restored.
+ */
+test("known and unavailable counts stay truthful in discovery cards", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page).toHaveURL(/\/articles$/);
+  await expect(page.locator('a[href^="/live/"]')).toHaveCount(0);
+
+  await page.goto("/live");
+
+  const discoveryKnown = page.locator('a[href="/live/nine"]');
+  await expect(discoveryKnown).toHaveAccessibleName(/214 people watching/);
+  await expect(discoveryKnown.getByText("214", { exact: true })).toBeVisible();
+
+  const discoveryUnknown = page.locator('a[href="/live/mining_maya"]');
+  await expect(discoveryUnknown).toHaveAccessibleName(
+    /Participant count unavailable/,
+  );
+  await expect(
+    discoveryUnknown.getByText("Unavailable", { exact: true }),
+  ).toBeVisible();
+  // Carried over from the dropped home block: an unknown count must read as
+  // unavailable, never as a confident zero.
+  await expect(discoveryUnknown).not.toContainText("0 watching");
+});
+
+test("local host and guest tickets never synthesize themselves into the count", async ({
+  page,
+}) => {
+  await signIn(page);
+  await installMockCapture(page);
+  await page.goto("/live");
+  await page.getByRole("button", { name: "Go Live" }).click();
+  await page.getByRole("radio", { name: /Private/ }).click();
+  await page.getByLabel("Title").fill("Count-safe private room");
+  await page.getByRole("button", { name: "Set up camera and microphone" }).click();
+  await expect(page.getByRole("heading", { name: "Preview ready" })).toBeVisible();
+  await page.getByRole("button", { name: "Confirm and start" }).click();
+
+  await expect(
+    page.getByText("Participant count unavailable", { exact: true }).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByText("1 person watching", { exact: true }),
+  ).toHaveCount(0);
+
+  await page.goto(`/live/alice#private=${privateSecret}`);
+  await expect(page.getByText("participant", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Participant count unavailable", { exact: true }).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByText("1 person watching", { exact: true }),
+  ).toHaveCount(0);
+});
+
+test("joining a public room leaves its known count unchanged", async ({
+  page,
+}) => {
+  await page.goto("/live/nine");
+  await expect(page.getByText("214 people watching", { exact: true })).toHaveCount(
+    1,
+  );
+
+  await page.getByRole("button", { name: "Join free" }).click();
+  await expect(page.getByText("Connected", { exact: true })).toBeVisible();
+  await expect(page.getByText("214 people watching", { exact: true })).toHaveCount(
+    2,
+  );
+  await expect(page.getByText("215 people watching", { exact: true })).toHaveCount(
+    0,
+  );
+});

--- a/wallet/free2z/tests/private-live.pw.ts
+++ b/wallet/free2z/tests/private-live.pw.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installMockCapture } from "./helpers/mock-capture";
+
+const secret = "123e4567-e89b-42d3-a456-426614174000";
+
+async function signIn(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("zuuli.knox.token", "mock-knox-token");
+  });
+}
+
+test("private host creates, displays, refreshes, and ends the opaque invite room", async ({
+  page,
+}) => {
+  await signIn(page);
+  await installMockCapture(page);
+  await page.goto("/live");
+  await page.getByRole("button", { name: "Go Live" }).click();
+  await page.getByRole("radio", { name: /Private/ }).click();
+  await page.getByLabel("Title").fill("Invite-only call");
+  await page.getByRole("button", { name: "Set up camera and microphone" }).click();
+  await expect(page.getByRole("heading", { name: "Preview ready" })).toBeVisible();
+  await page.getByRole("button", { name: "Confirm and start" }).click();
+
+  await expect(page).toHaveURL(
+    new RegExp(`/live/demo-creator#private=${secret}$`),
+  );
+  const origin = new URL(page.url()).origin;
+  const invite = page.getByLabel("Private invite");
+  await expect(invite).toHaveValue(
+    `${origin}/live/demo-creator#private=${secret}`,
+  );
+  expect(new URL(await invite.inputValue()).pathname).not.toContain(secret);
+  await expect(
+    page.getByRole("button", { name: "Copy private invite" }),
+  ).toBeVisible();
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"], {
+    origin,
+  });
+  await page.getByRole("button", { name: "Copy private invite" }).click();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(`${origin}/live/demo-creator#private=${secret}`);
+  await expect(
+    page.getByText("You're hosting as @demo-creator."),
+  ).toBeVisible();
+
+  await page.reload();
+  await expect(
+    page.getByText("You're hosting as @demo-creator."),
+  ).toBeVisible();
+  await expect(invite).toHaveValue(
+    `${origin}/live/demo-creator#private=${secret}`,
+  );
+
+  await page.getByRole("button", { name: "End stream" }).click();
+  await expect(page).toHaveURL(/\/live$/);
+  expect(page.url()).not.toContain(secret);
+  await expect(page.getByLabel("Private invite")).toHaveCount(0);
+});
+
+test("cold guest invite joins without discovery and wrong secrets disclose nothing", async ({
+  page,
+}) => {
+  await page.goto(`/live/demo-creator#private=${secret}`);
+  await expect(page.getByText("Role")).toBeVisible();
+  await expect(page.getByText("participant", { exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Private call" }),
+  ).toBeVisible();
+  await expect(page.getByText(/active public stream listed/)).toHaveCount(0);
+
+  const wrong = "123e4567-e89b-42d3-a456-426614174001";
+  await page.goto(`/live/demo-creator#private=${wrong}`);
+  await expect(
+    page.getByText("Private room unavailable", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText(/No room details were disclosed/)).toBeVisible();
+  await expect(page.getByText("Private call")).toHaveCount(0);
+  await expect(page.getByText("Demo Creator")).toHaveCount(0);
+});
+
+test("an authenticated non-owner remains a guest and never becomes the room creator", async ({
+  page,
+}) => {
+  await signIn(page);
+  await page.goto(`/live/alice#private=${secret}`);
+
+  await expect(page.getByText("Role")).toBeVisible();
+  await expect(page.getByText("participant", { exact: true })).toBeVisible();
+  await expect(page.getByText("alice", { exact: true })).toBeVisible();
+  await expect(page.getByText(/^@alice · started /)).toBeVisible();
+  await expect(page.getByText("Demo Creator", { exact: true })).toHaveCount(0);
+  await expect(page.getByText(/You're hosting as/)).toHaveCount(0);
+});

--- a/wallet/free2z/tests/search-autocomplete.pw.ts
+++ b/wallet/free2z/tests/search-autocomplete.pw.ts
@@ -1,0 +1,277 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const SEARCH_NAME = "Search creators, pages, and topics";
+const SEARCH_NAME_ES = "Buscar creadores, páginas y temas";
+
+function globalSearch(page: Page) {
+  return page.getByRole("combobox", { name: SEARCH_NAME });
+}
+
+test("global Search offers mixed keyboard and screen-reader suggestions", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 640 });
+  await page.goto("/search");
+
+  const input = globalSearch(page);
+  await expect(input).toBeFocused();
+  await expect(input).toHaveAttribute("aria-expanded", "false");
+  await expect(
+    page.getByRole("listbox", { name: "Search suggestions" }),
+  ).toHaveCount(0);
+  await expect(page.locator("[data-suggestion-kind]")).toHaveCount(0);
+
+  await input.fill("z");
+  const listbox = page.getByRole("listbox", { name: "Search suggestions" });
+  await expect(listbox).toBeVisible();
+  await expect(input).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator('[data-suggestion-kind="topic"]')).not.toHaveCount(
+    0,
+  );
+  await expect(
+    page.locator('[data-suggestion-kind="creator"]'),
+  ).not.toHaveCount(0);
+  await expect(page.locator('[data-suggestion-kind="page"]')).not.toHaveCount(
+    0,
+  );
+
+  await input.press("ArrowDown");
+  const activeId = await input.getAttribute("aria-activedescendant");
+  expect(activeId).toBeTruthy();
+  await expect(page.locator(`[id="${activeId}"]`)).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+
+  await input.press("Escape");
+  await expect(input).toHaveValue("z");
+  await expect(input).toHaveAttribute("aria-expanded", "false");
+  await expect(listbox).toHaveCount(0);
+
+  await input.press("ArrowDown");
+  await expect(listbox).toBeVisible();
+  await input.press("Enter");
+  await expect(page.getByLabel("Selected topics")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /^Remove topic / }),
+  ).toBeVisible();
+  expect(new URL(page.url()).searchParams.getAll("topic")).toHaveLength(1);
+  await expect(input).toHaveValue("");
+
+  const viewport = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth,
+  }));
+  expect(viewport.scroll).toBeLessThanOrEqual(viewport.client);
+});
+
+test("global Search rejects an older response that resolves last and exposes a retryable error", async ({
+  page,
+}) => {
+  await page.goto("/search");
+  const input = globalSearch(page);
+
+  // Invert the two search generations deterministically: the first creator
+  // and page calls take 1.2s, while the second pair takes 10ms. This exercises
+  // the production request-generation guard instead of merely clearing an
+  // already-rendered list between sequential searches.
+  await page.evaluate(() => {
+    const nativeSetTimeout = window.setTimeout.bind(window);
+    let searchCalls = 0;
+    window.setTimeout = ((
+      handler: TimerHandler,
+      timeout?: number,
+      ...args: unknown[]
+    ) => {
+      if (timeout === 200 || timeout === 220) {
+        const delay = searchCalls < 2 ? 1_200 : 10;
+        searchCalls += 1;
+        return nativeSetTimeout(handler, delay, ...args);
+      }
+      return nativeSetTimeout(handler, timeout, ...args);
+    }) as typeof window.setTimeout;
+  });
+
+  await input.fill("z");
+  await page.waitForTimeout(350);
+  await input.fill("privacy");
+  const listbox = page.getByRole("listbox", { name: "Search suggestions" });
+  await expect(listbox.getByRole("option").first()).toBeVisible();
+  await expect(input).toHaveValue("privacy");
+  await expect(listbox).toContainText("#privacy");
+
+  // The delayed `z` response has resolved by now. It must not replace the
+  // newer privacy generation or resurrect its topic suggestions.
+  await page.waitForTimeout(1_000);
+  await expect(input).toHaveValue("privacy");
+  await expect(listbox).toContainText("#privacy");
+  await expect(listbox).not.toContainText("#zcash");
+
+  await page.evaluate(() => {
+    sessionStorage.setItem("zuuli.mock.search-creators", "unavailable");
+    sessionStorage.setItem("zuuli.mock.search-pages", "unavailable");
+  });
+  await input.fill("error-state");
+  await expect(
+    page.getByText("Search unavailable", { exact: true }).first(),
+  ).toBeVisible();
+  const retry = page.getByRole("button", { name: "Try again" }).first();
+  await expect(retry).toBeVisible();
+
+  await page.evaluate(() => {
+    sessionStorage.removeItem("zuuli.mock.search-creators");
+    sessionStorage.removeItem("zuuli.mock.search-pages");
+  });
+  await retry.click();
+  await expect(page.getByText("No matches", { exact: true })).toBeVisible();
+});
+
+test("Articles replaces the topic wall with a quiet removable autocomplete", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 360, height: 720 });
+  await page.goto("/articles");
+
+  await expect(page.locator('[aria-label="Filter by tag"]')).toHaveCount(0);
+  const input = page.getByRole("combobox", { name: "Filter by topic" });
+  await expect(input).toBeVisible();
+  await expect(input).toHaveAttribute("aria-expanded", "false");
+  await expect(
+    page.getByRole("listbox", { name: "Topic suggestions" }),
+  ).toHaveCount(0);
+
+  await input.fill("pri");
+  const listbox = page.getByRole("listbox", { name: "Topic suggestions" });
+  await expect(listbox.getByRole("option").first()).toBeVisible();
+  await input.press("ArrowDown");
+  await input.press("Enter");
+  await expect(page).toHaveURL(/\/articles\?tags=privacy$/);
+
+  const remove = page.getByRole("button", { name: "Remove topic privacy" });
+  await expect(remove).toBeVisible();
+  const box = await remove.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.height).toBeGreaterThanOrEqual(44);
+  await remove.click();
+  expect(new URL(page.url()).searchParams.has("tags")).toBe(false);
+
+  await input.fill("pri");
+  await expect(listbox).toBeVisible();
+  await input.press("Escape");
+  await expect(input).toHaveValue("pri");
+  await expect(input).toHaveAttribute("aria-expanded", "false");
+
+  await input.fill("zc");
+  await expect(listbox).toBeVisible();
+  await expect(listbox.getByRole("option")).toHaveCount(1);
+  await expect(listbox.getByRole("option")).toContainText("zcash");
+
+  const viewport = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth,
+  }));
+  expect(viewport.scroll).toBeLessThanOrEqual(viewport.client);
+});
+
+test("Articles exposes a retryable topic failure instead of misreporting an empty corpus", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    sessionStorage.setItem("zuuli.mock.article-topics", "unavailable-once");
+  });
+  await page.goto("/articles");
+
+  const input = page.getByRole("combobox", { name: "Filter by topic" });
+  await input.fill("pri");
+  await expect(
+    page.getByText("Topics unavailable", { exact: true }).first(),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Try again" }).first().click();
+  await expect(
+    page.getByRole("listbox", { name: "Topic suggestions" }),
+  ).toContainText("privacy");
+});
+
+for (const width of [320, 360] as const) {
+  for (const signedIn of [false, true]) {
+    test(`${signedIn ? "signed-in" : "signed-out"} Search tabs remain operable while autocomplete loads and is empty at ${width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 720 });
+      await page.addInitScript((authenticated) => {
+        const key = "zuuli.knox.token";
+        if (authenticated) localStorage.setItem(key, "mock-knox-token");
+        else localStorage.removeItem(key);
+      }, signedIn);
+      await page.goto("/search?q=no-results-for-this-query");
+
+      const pagesTab = page.getByRole("tab", { name: /Pages/ });
+      await pagesTab.click();
+      await expect(pagesTab).toHaveAttribute("aria-selected", "true");
+      await globalSearch(page).fill("still-no-results-for-this-query");
+      await expect(page.getByText("No matches", { exact: true })).toBeVisible();
+
+      const creatorsTab = page.getByRole("tab", { name: /Creators/ });
+      await creatorsTab.click();
+      await expect(creatorsTab).toHaveAttribute("aria-selected", "true");
+      await expect(page.getByText("No matches", { exact: true })).toHaveCount(
+        0,
+      );
+    });
+  }
+}
+
+test("Search clears a pointer transaction released outside the route", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 800, height: 720 });
+  await page.goto("/search?q=no-results-for-this-query");
+
+  const input = globalSearch(page);
+  const noMatches = page.getByText("No matches", { exact: true });
+  await expect(noMatches).toBeVisible();
+
+  const clearSearch = page.getByRole("button", { name: "Clear search" });
+  const clearBounds = await clearSearch.boundingBox();
+  const topBarBounds = await page.locator("[data-app-top-bar]").boundingBox();
+  expect(clearBounds).not.toBeNull();
+  expect(topBarBounds).not.toBeNull();
+  await page.mouse.move(
+    clearBounds!.x + clearBounds!.width / 2,
+    clearBounds!.y + clearBounds!.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    topBarBounds!.x + topBarBounds!.width / 2,
+    topBarBounds!.y + topBarBounds!.height / 2,
+  );
+  await page.mouse.up();
+  await expect(noMatches).toHaveCount(0);
+
+  // Force a new keyboard focus transition even on browsers that keep the
+  // pressed clear button from taking focus when released elsewhere.
+  await page.getByRole("button", { name: "Log in" }).focus();
+  await input.focus();
+  await expect(noMatches).toBeVisible();
+  await input.press("Tab");
+  await expect(clearSearch).toBeFocused();
+  await expect(noMatches).toBeVisible();
+  await page.keyboard.press("Tab");
+  await expect(noMatches).toHaveCount(0);
+});
+
+test.describe("locale-aware Search", () => {
+  test.use({ locale: "es-ES" });
+
+  test("keeps mixed suggestions bounded and selectable outside en-US", async ({
+    page,
+  }) => {
+    await page.goto("/search");
+    const input = page.getByRole("combobox", { name: SEARCH_NAME_ES });
+    await input.fill("privacy");
+    const options = page.getByRole("option");
+    await expect(options.first()).toBeVisible();
+    expect(await options.count()).toBeLessThanOrEqual(8);
+    await expect(input).toHaveAttribute("aria-autocomplete", "list");
+  });
+});

--- a/wallet/free2z/tests/search-pagination.pw.ts
+++ b/wallet/free2z/tests/search-pagination.pw.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page } from "@playwright/test";
+
+function viewport(page: Page) {
+  return page.locator("[data-scroll-area-viewport]");
+}
+
+async function dismissAutocomplete(page: Page) {
+  const input = page.getByRole("combobox", {
+    name: "Search creators, pages, and topics",
+  });
+  await input.press("Escape");
+  await expect(input).toHaveAttribute("aria-expanded", "false");
+}
+
+async function useSearchScenarios(page: Page, creators: string, pages: string) {
+  await page.addInitScript(
+    ({ creatorScenario, pageScenario }) => {
+      sessionStorage.setItem("zuuli.mock.search-creators", creatorScenario);
+      sessionStorage.setItem("zuuli.mock.search-pages", pageScenario);
+    },
+    { creatorScenario: creators, pageScenario: pages },
+  );
+}
+
+test("every result remains loaded with its tab and scroll position across back navigation", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 640 });
+  await useSearchScenarios(page, "small-pages", "small-pages");
+  await page.goto("/search?q=a");
+
+  const creatorResults = page.locator("[data-search-creator-result]");
+  await expect(creatorResults).toHaveCount(2);
+  await dismissAutocomplete(page);
+  await expect(page.getByRole("tab", { name: /Creators/ })).toContainText("4");
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(creatorResults).toHaveCount(4);
+  await expect(
+    page.getByText("4 of 4 creators", { exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("tab", { name: /Pages/ }).click();
+  await expect(page).toHaveURL(/\/search\?q=a&tab=pages$/);
+  const pageResults = page.locator("[data-search-page-result]");
+  await expect(pageResults).toHaveCount(2);
+  const pagesTab = page.getByRole("tab", { name: /Pages/ });
+  const pageTotal = Number(await pagesTab.locator("span").last().textContent());
+  expect(pageTotal).toBeGreaterThan(2);
+
+  let expected = 2;
+  while (expected < pageTotal) {
+    await page.getByRole("button", { name: "Load more pages" }).click();
+    expected = Math.min(expected + 2, pageTotal);
+    await expect(pageResults).toHaveCount(expected);
+  }
+  await expect(
+    page.getByText(`${pageTotal} of ${pageTotal} pages`, { exact: true }),
+  ).toBeVisible();
+
+  const scroller = viewport(page);
+  const savedOffset = await scroller.evaluate((element) => {
+    element.scrollTop = element.scrollHeight - element.clientHeight - 100;
+    return element.scrollTop;
+  });
+  expect(savedOffset).toBeGreaterThan(1_000);
+
+  await pageResults.last().getByRole("link").click();
+  await expect(page).toHaveURL(/\/articles\//);
+  await page.goBack();
+  await expect(page).toHaveURL(/\/search\?q=a&tab=pages$/);
+  await expect(pageResults).toHaveCount(pageTotal);
+  await expect
+    .poll(() => scroller.evaluate((element) => element.scrollTop))
+    .toBeCloseTo(savedOffset, 0);
+
+  await page.getByRole("tab", { name: /Creators/ }).click();
+  await expect(creatorResults).toHaveCount(4);
+  await expect(page.getByRole("combobox")).toHaveValue("a");
+});
+
+test("a fully duplicated page advances to later unique results", async ({
+  page,
+}) => {
+  await useSearchScenarios(page, "duplicate-page", "small-pages");
+  await page.goto("/search?q=a");
+
+  const creators = page.locator("[data-search-creator-result]");
+  await expect(creators).toHaveCount(2);
+  await dismissAutocomplete(page);
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(creators).toHaveCount(2);
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(page.locator("[data-search-creator-result]")).toHaveCount(4);
+  await expect(
+    page.getByText("4 of 4 creators", { exact: true }),
+  ).toBeVisible();
+});
+
+test("count drift and tied-row skips retain the valid terminal results", async ({
+  page,
+}) => {
+  await useSearchScenarios(page, "count-drift", "skip-row");
+  await page.goto("/search?q=a");
+
+  const creators = page.locator("[data-search-creator-result]");
+  await expect(creators).toHaveCount(2);
+  await dismissAutocomplete(page);
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(creators).toHaveCount(4);
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(
+    page.getByText("4 of 5 creators", { exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("tab", { name: /Pages/ }).click();
+  const pages = page.locator("[data-search-page-result]");
+  await expect(pages).toHaveCount(2);
+  const pageTotal = Number(
+    await page
+      .getByRole("tab", { name: /Pages/ })
+      .locator("span")
+      .last()
+      .textContent(),
+  );
+  let expected = 2;
+  while (expected < pageTotal - 1) {
+    await page.getByRole("button", { name: "Load more pages" }).click();
+    expected = Math.min(expected + 2, pageTotal - 1);
+    await expect(pages).toHaveCount(expected);
+  }
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await expect(
+    page.getByText(`${pageTotal - 1} of ${pageTotal} pages`, { exact: true }),
+  ).toBeVisible();
+});
+
+test("overlapping backend pages are deduplicated without losing order", async ({
+  page,
+}) => {
+  await useSearchScenarios(page, "overlap", "small-pages");
+  await page.goto("/search?q=a");
+
+  const creators = page.locator("[data-search-creator-result]");
+  await expect(creators).toHaveCount(2);
+  await dismissAutocomplete(page);
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(creators).toHaveCount(3);
+  await page.getByRole("button", { name: "Load more creators" }).click();
+  await expect(creators).toHaveCount(4);
+  const destinations = await creators.evaluateAll((links) =>
+    links.map((link) => link.getAttribute("href")),
+  );
+  expect(new Set(destinations).size).toBe(4);
+  await expect(
+    page.getByText("4 of 4 creators", { exact: true }),
+  ).toBeVisible();
+});

--- a/wallet/free2z/tests/search.pw.ts
+++ b/wallet/free2z/tests/search.pw.ts
@@ -1,0 +1,150 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const SEARCH_NAME = "Search creators, pages, and topics";
+/**
+ * free2z's index route forwards to `/articles` with `replace`, so the first
+ * history entry — the one `goBack()` lands on — is `/articles`, not `/`.
+ */
+const ENTRY_URL = /\/articles$/;
+const VIEWPORTS = [
+  { name: "phone", width: 320, height: 568 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+] as const;
+
+/**
+ * ZUULI enters Search two ways: a chrome-owned `<form role="search">` on wide
+ * viewports and a chrome-owned Search icon link below 640px. free2z's TopBar
+ * has neither — it deliberately carries no search affordance at any width (see
+ * `components/layout/TopBar.tsx`), so the shell navigation is the only entry
+ * and the route owns the only search input in the app. Entering through the
+ * nav link at every width is therefore the faithful adaptation, not a
+ * weakening: it is the real and only path a free2z reader has.
+ */
+async function enterSearch(page: Page) {
+  await page.goto("/articles");
+  await expect(page).toHaveURL(ENTRY_URL);
+  await page.getByRole("link", { name: SEARCH_NAME }).click();
+  await expect(page).toHaveURL(/\/search$/);
+}
+
+async function expectSingleRouteSearch(page: Page) {
+  const input = page.getByRole("combobox", { name: SEARCH_NAME });
+  const topBar = page.locator("[data-app-top-bar]");
+
+  await expect(input).toHaveCount(1);
+  await expect(input).toBeVisible();
+  // The top bar must actually be on the page for the two absence assertions
+  // below to mean anything — without this they would pass against a renamed
+  // attribute just as happily as against a chrome that carries no search.
+  await expect(topBar).toHaveCount(1);
+  await expect(
+    topBar.getByRole("searchbox", { name: SEARCH_NAME }),
+  ).toHaveCount(0);
+  await expect(topBar.getByLabel("Search", { exact: true })).toHaveCount(0);
+  await expect(input).toHaveAttribute("data-custom-search-clear", "true");
+  await expect(input).toHaveAttribute("type", "text");
+  await expect(input).toHaveAttribute("aria-autocomplete", "list");
+  await expect(input).toHaveAttribute("inputmode", "search");
+  return input;
+}
+
+for (const viewport of VIEWPORTS) {
+  test(
+    `${viewport.name} Search has one route-backed interaction`,
+    async ({ page }) => {
+      await page.setViewportSize(viewport);
+      await enterSearch(page);
+
+      const input = await expectSingleRouteSearch(page);
+      await expect(input).toBeFocused();
+
+      await input.fill("alpha route");
+      await expect(page).toHaveURL(/\/search\?q=alpha(?:\+|%20)route$/);
+
+      await input.fill("beta history");
+      await expect(page).toHaveURL(/\/search\?q=beta(?:\+|%20)history$/);
+
+      await page.goBack();
+      await expect(page).toHaveURL(ENTRY_URL);
+      await page.goForward();
+      await expect(page).toHaveURL(/\/search\?q=beta(?:\+|%20)history$/);
+      await expect(await expectSingleRouteSearch(page)).toHaveValue(
+        "beta history",
+      );
+
+      const clear = page.getByRole("button", { name: "Clear search" });
+      await expect(clear).toHaveCount(1);
+      const clearBox = await clear.boundingBox();
+      expect(clearBox).not.toBeNull();
+      expect(clearBox!.width).toBeGreaterThanOrEqual(44);
+      expect(clearBox!.height).toBeGreaterThanOrEqual(44);
+
+      const clearPresentation = await input.evaluate((element) => {
+        const inputRect = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+        return {
+          inputRight: inputRect.right,
+          editableRight:
+            inputRect.right -
+            Number.parseFloat(style.paddingRight) -
+            Number.parseFloat(style.borderRightWidth),
+          documentClientWidth: document.documentElement.clientWidth,
+          documentScrollWidth: document.documentElement.scrollWidth,
+        };
+      });
+      expect(clearBox!.x).toBeGreaterThanOrEqual(
+        clearPresentation.editableRight - 0.5,
+      );
+      expect(clearBox!.x + clearBox!.width).toBeLessThanOrEqual(
+        clearPresentation.inputRight + 0.5,
+      );
+      expect(clearPresentation.documentScrollWidth).toBeLessThanOrEqual(
+        clearPresentation.documentClientWidth,
+      );
+
+      await input.focus();
+      await page.keyboard.press("Tab");
+      await expect(clear).toBeFocused();
+      await page.keyboard.press("Enter");
+      await expect(page).toHaveURL(/\/search$/);
+      await expect(input).toHaveValue("");
+      await expect(input).toBeFocused();
+      await expect(clear).toHaveCount(0);
+      await expect(
+        page.getByText("Search all of free2z", { exact: true }),
+      ).toBeVisible();
+
+      await page.goBack();
+      await expect(page).toHaveURL(ENTRY_URL);
+      await page.goForward();
+      await expect(page).toHaveURL(/\/search$/);
+      await expect(await expectSingleRouteSearch(page)).toHaveValue("");
+
+      await page.goto("/search?tab=pages&q=direct%20query");
+      const directInput = await expectSingleRouteSearch(page);
+      await expect(directInput).toHaveValue("direct query");
+      await page.getByRole("button", { name: "Clear search" }).click();
+      await expect(page).toHaveURL(/\/search\?tab=pages$/);
+      await expect(directInput).toHaveValue("");
+
+      // Articles uses the same explicit-clear compound-input contract. A text
+      // input with search keyboard hints cannot acquire Chromium/WebKit's
+      // anonymous native cancel beside the accessible in-app action.
+      await page.goto("/articles");
+      const articleSearch = page.getByRole("searchbox", {
+        name: "Search articles",
+      });
+      await articleSearch.fill("shielded publishing");
+      await expect(articleSearch).toHaveAttribute("type", "text");
+      await expect(articleSearch).toHaveAttribute("inputmode", "search");
+      await expect(articleSearch).toHaveAttribute(
+        "data-custom-search-clear",
+        "true",
+      );
+      await expect(
+        page.getByRole("button", { name: "Clear search" }),
+      ).toHaveCount(1);
+    },
+  );
+}


### PR DESCRIPTION
Closes #923.

#920 moved `features/live`, `features/ai` and `features/search` into
`wallet/free2z` and left their specs in `wallet/zuuli/tests/`. This ports them.

**free2z's Playwright suite: 47 tests in 9 files → 83 tests in 18 files.**

## What ported, and how

| spec | status |
|---|---|
| `ai-context-switch.pw.ts` | verbatim |
| `media-preflight.pw.ts` | verbatim (+ `helpers/mock-capture.ts`) |
| `private-live.pw.ts` | verbatim |
| `search-autocomplete.pw.ts` | verbatim |
| `search-pagination.pw.ts` | verbatim |
| `search.pw.ts` | **adapted** — entry path |
| `participant-counts.pw.ts` | **adapted** — one half dropped |
| `ai-paid-intent.pw.ts` | **new** — the `/ai` half of ZUULI's `paid-actions.pw.ts` |

The three surfaces' sources are byte-identical between the two apps apart from
`/wallet/fund` → `/fund` and one copy string, which is why five of seven specs
needed no edit at all.

### `search.pw.ts` — adapted entry, unchanged contract

ZUULI enters Search two ways: a chrome-owned `<form role="search">` above
640px, and a chrome-owned Search icon link below it. **free2z's TopBar has
neither, at any width** — #920/#912 dropped the global search form deliberately
(see the comment in `components/layout/TopBar.tsx`). The shell navigation is the
only entry a free2z reader has, so that is what the test uses, at all three
viewports.

Everything the spec actually asserts about the route — autofocus, the
`replace`-based history contract across `goBack`/`goForward`, the 44px clear
button and its geometry inside the input, no horizontal overflow, the direct
`?tab=pages&q=` deep link, and the Articles compound-input contract — is
unchanged. The `goBack` target moves from `/` to `/articles` because free2z's
index route forwards there with `replace`.

One assertion was strengthened rather than ported as-is.
`expectSingleRouteSearch` asserts the top bar carries no searchbox and no
`Search` label. In free2z that is now true by construction, which means it
would also pass if `[data-app-top-bar]` were renamed and the locator matched
nothing. `await expect(topBar).toHaveCount(1)` was added ahead of it so the
absence assertions are anchored to a chrome that is actually on the page. It
remains a real guard: re-adding ZUULI's TopBar search form here fails this test.

### `participant-counts.pw.ts` — home half dropped

ZUULI's first test asserts the same two counts twice: once on its Home feature's
live rail, once on `/live` discovery. **free2z mounts no Home** — `features/home`
was never ported and `/` forwards to `/articles`. Aiming those assertions at
`/articles` would have been the exact failure mode #923 was opened about: no
live card renders there, so every locator would resolve to nothing and the
`not.toContainText` half would pass vacuously.

The home block is dropped and replaced with an assertion of the redirect and of
`a[href^="/live/"]` having count 0 on the landing route — the omission is a
stated fact, and if a Home surface with a live rail lands here the test fails
and the dropped coverage has to come back. The home-only
`not.toContainText("0 watching")` assertion is carried onto the discovery card
so nothing is lost.

### `ai-paid-intent.pw.ts` — new

#923 notes `/ai` is also exercised in `paid-actions.pw.ts:172-226`. That file
also covers `/wallet/fund`, `/buy` and creator tips, so it cannot move whole.
The four AI tests are lifted into their own spec. They guard a privacy
property, not a convenience one: an unsent draft is a private message, and it
must survive an intentional login while being destroyed by abandoning login,
reloading login, and browser Back. The guest exit lands on `/articles` here
rather than ZUULI's Home.

## Proof the tests are load-bearing

#923 exists because coverage was assumed. Four mutations, each applied to
`src/`, run, and reverted — **no source change is in this PR** (`git status`
after each revert was clean; the diff is `wallet/free2z/tests/**` only).

**1. `ai-context-switch` — drop `startNewChat()` from `confirmChatIdentity`**
(the transcript survives a model switch, i.e. the dishonest behaviour):

```
  ✘  1 tests/ai-context-switch.pw.ts:29:1 › model and personality switches start honest, separate chat threads (10.5s)

    Error: expect(locator).toHaveCount(expected) failed
    Locator:  getByText('Context only the first model received', { exact: true })
    Expected: 0
    Received: 1
```

**2. `participant-counts` — `participantCountCopy(null)` returns a fabricated
zero instead of "Participant count unavailable":**

```
  ✘  1 tests/participant-counts.pw.ts:47:1 › local host and guest tickets never synthesize themselves into the count (7.6s)
  ✘  2 tests/participant-counts.pw.ts:22:1 › known and unavailable counts stay truthful in discovery cards (8.3s)

    Error: expect(locator).toHaveAccessibleName(expected) failed
    Expected pattern: /Participant count unavailable/
    Received string:  "PPV: Deep dive … — live now, 0 watching"
```

**3. `search` — the query update pushes instead of replacing** (the adapted
history contract, so this proves the adaptation itself is load-bearing):

```
  ✘  1 tests/search.pw.ts:53:3 › phone Search has one route-backed interaction (6.7s)
  ✘  2 tests/search.pw.ts:53:3 › tablet Search has one route-backed interaction (6.7s)
  ✘  3 tests/search.pw.ts:53:3 › desktop Search has one route-backed interaction (5.9s)

    Error: expect(page).toHaveURL(expected) failed
    Expected pattern: /\/articles$/
    Received string:  "http://127.0.0.1:1435/search?q=alpha+route"
```

**4. `media-preflight` — `stopMediaStream` releases nothing** (camera left on
after the dialog closes):

```
  ✘ 5 of 6 media-preflight tests

    Error: expect(received).toBe(expected)
    Expected: 2
    Received: 0
      at await expect.poll(async () => (await captureState(page)).stoppedTracks).toBe(2);
```

## Collection is confirmed by name, not by glob

`playwright.config.ts` is unchanged. Every ported file appears in the run
output — `ai-context-switch.pw.ts`, `ai-paid-intent.pw.ts`,
`media-preflight.pw.ts`, `participant-counts.pw.ts`, `private-live.pw.ts`,
`search.pw.ts`, `search-autocomplete.pw.ts`, `search-pagination.pw.ts`.

## What this coverage does and does not prove

**It does not prove the native path works.** These run against the Vite dev
server with `VITE_MOCK=1`, where `isDev` short-circuits to browser `fetch`.
free2z's native layer is unwired (#918, in flight). What is now covered is the
rendering and interaction layer of Live, AI and Search — which is where the
behaviours these specs assert actually live.

**It cannot block a merge yet.** `surfaces / frontend (free2z)` is registered in
`scripts/check-workflow-gates.mjs` as ungated, so this suite runs but is not a
required check until #915 is resolved. Not addressed here.

**Still uncovered.** `features/ai/` still has no unit test — `index.tsx` alone
is 921 lines. free2z has no `viewport.pw.ts` or `touch-targets.pw.ts` at all
(ZUULI's are route sweeps over `/wallet/*`, `/kyc`, `/profile`, `/buy`; porting
them is a separate job), so `/ai`, `/live` and `/search` get no cross-route
overflow or touch-target audit here. `media-preflight.pw.ts` carries a 320px
geometry check for the preflight dialog only.

## Verification

- `npx playwright test` → **83 passed** (was 47), 18 files
- `npx vitest run` → 63 files, 911 passed, 5 skipped
- `npm run typecheck` and `npm run typecheck:tests` → clean
- `node wallet/zuuli/scripts/project-boundary.mjs` → exit 0, "boundaries
  verified across 5 discovered projects, 559 source files"

`wallet/zuuli/tests/` is untouched; ZUULI's suite was not run. The diff is
`wallet/free2z/tests/**` only — no application source, no config.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
