### PR TITLE
feat(free2z): wire the native layer — scoped HTTP, no OAuth commands, its own deep-link scheme

### DIFF
--- a/wallet/free2z/README.md
+++ b/wallet/free2z/README.md
@@ -3,8 +3,8 @@
 `cash.free2z.free2z`. One of the three apps ZUULI is being split into (#904),
 scaffolded by #906. **Phase 1 of the extraction has landed: Articles, the
 Markdown/media pipeline, Creator profiles and a login that keeps password and
-linked accounts now live here** — in a browser and under `vite dev`. Read the
-next section before you try to package it.
+linked accounts now live here**, and since #918 the native layer under them is
+wired: it runs packaged, not only in a browser and under `vite dev`.
 
 | App | Role | Privileged plugins |
 | --- | --- | --- |
@@ -12,67 +12,163 @@ next section before you try to package it.
 | **`cash.free2z.free2z`** | **content — articles, live, AI, creator, search** | **none** |
 | `cash.free2z.e2e2z` | messaging | `f2zmsg` |
 
-## Not yet wired natively
+## The native layer
 
-**This app runs in the browser and under `vite dev`. It is NOT functional as a
-packaged Tauri app.** The frontend was ported complete, including three code
-paths that branch on `isTauri() && !DEV` — and the Rust side those paths call
-into was never written here. Nothing in CI can see this: vitest, Playwright and
-`npm run build` all execute where `isTauri()` is `false` or `import.meta.env.DEV`
-is `true`, which is exactly the condition under which none of these branches is
-taken, and `cargo check` compiles a backend that is not asked whether the
-frontend expects commands from it.
+**This app is functional as a packaged Tauri build.** `bundle.active` is `true`
+again in `src-tauri/tauri.conf.json`, which #912 had set to `false` on purpose so
+nobody could emit an installer for a binary with a dead network layer. #918 is
+the work that earned the flag back. What follows is what it did, and — more
+importantly — where the evidence for each claim comes from, because #918 exists
+precisely because "green" was measured where the bug could not appear.
 
-So `bundle.active` is `false` in `src-tauri/tauri.conf.json`. That is
-deliberate: `tauri build` should not be able to emit an installer for a binary
-whose network layer is dead. Flipping it back is part of the fix, not a
-prerequisite for it. Tracking issue: **#918**.
+### 1. HTTP: a URL-scoped native client
 
-The three gaps, precisely:
+`src-tauri/Cargo.toml` links `tauri-plugin-http`, `src-tauri/src/lib.rs` calls
+`.plugin(tauri_plugin_http::init())`, and both capability files carry a **scoped**
+`http:default`. Every API request (`src/lib/api/http.ts`) and every first-party
+image download (`src/components/common/RemoteMedia.tsx`) takes that path in a
+packaged build; in a browser and under `vite dev` they still use `window.fetch`
+through the proxy, unchanged.
 
-1. **HTTP is unwired.** `package.json` depends on `@tauri-apps/plugin-http`, but
-   `src-tauri/` was never touched to match: `src-tauri/Cargo.toml` does not list
-   `tauri-plugin-http`, `src-tauri/src/lib.rs` does not call
-   `.plugin(tauri_plugin_http::init())`, and neither capability file grants an
-   `http:*` permission. Both `src/lib/api/http.ts:129-132` and
-   `src/components/common/RemoteMedia.tsx:50-51` switch to the native client
-   when `isTauri() && !DEV`, so in a packaged build **every** API request and
-   every first-party image download would invoke `plugin:http|fetch`, a command
-   that does not exist in this binary.
+The scope admits four origins and nothing else:
 
-   Note that this is not a one-line capability addition.
-   `wallet/zuuli/scripts/surface-capability-authority.mjs:56-61` holds
-   `REVIEWED_NAMESPACES = {core, deep-link, opener, f2zmsg}`, and `http` is not
-   in it — adding `http:default` fails the required `gate`. By design: what a
-   content surface's HTTP client may reach is a scope decision somebody has to
-   review, not a default anyone can grant in passing.
+| Origin | Why |
+| --- | --- |
+| `https://free2z.cash/*` | production API and `/uploadz` media |
+| `https://*.free2z.cash/*` | `stage.` / `new.` / `test.`, the deployments this client is pointed at |
+| `https://free2z.com/*` | the `.com` apex, which `connect-src` already admits |
+| `https://*.free2z.com/*` | its subdomains, same reason |
 
-2. **The OAuth commands are unwired.** `src/lib/oauth/transport.ts` invokes ten
-   `oauth_*` commands (`oauth_callback_transport`, `oauth_loopback_start` /
-   `_wait` / `_cancel`, `oauth_mobile_arm` / `_claim` / `_cancel` / `_pending` /
-   `_resume` / `_finish`) that exist only in
-   `wallet/zuuli/src-tauri/src/oauth.rs`. This app's `src-tauri/src/lib.rs` has
-   no `invoke_handler` at all. `nativeTransport()` rethrows rather than falling
-   back to the web flow, and `src/App.tsx:58` calls `recoverMobileOAuth()`
-   unconditionally on mount behind a `.catch` that fires
-   `toast.error("Couldn't finish sign-in")` (`src/App.tsx:82`) — so a packaged
-   build shows a sign-in error toast on **every launch**, before the user has
-   done anything.
+Narrower than the app's `connect-src`: the three RealtimeKit origins are **not**
+here, because the Live SDK talks from the webview with `window.fetch` and a
+WebSocket, not through this client. `surface-capability-authority.mjs` refuses
+any allowed origin the CSP does not already admit, so the native client can never
+reach further than the document.
 
-3. **The deep-link scheme belongs to the wallet.**
-   `src/lib/oauth/protocol.ts:3` uses `cash.free2z.zuuli://oauth/callback` and
-   `src/lib/checkout/native-return.ts:3` uses
-   `cash.free2z.zuuli://checkout/return` (with the matching guard at
-   `src/lib/checkout/native-return.ts:72`). Those are **ZUULI's** URIs. This
-   app's own manifest registers only `cash.free2z.free2z://bridge/return`
-   (`src-tauri/tauri.conf.json`, `plugins.deep-link`). On a device with both
-   apps installed, an OAuth authorization code or a Stripe checkout return
-   initiated by the content app would be delivered by the OS to the **wallet
-   authority** app — the cross-app URI collision this entire split exists to
-   prevent.
+Two things are worth being exact about, because the issue text was not:
 
-Fixing all three is a separate reviewed PR (#918). Do not patch one of them in
-isolation and re-enable the bundle.
+* `http:default` is **not** an unrestricted client. It is `allow-fetch` with an
+  **empty** allow list, and `Scope::is_allowed` requires *some* allow entry to
+  match — so a bare `http:default` denies every `http`/`https` URL. It is refused
+  anyway: what is reviewable is *which origins this client may reach*, and the
+  identifier alone says nothing about that.
+* The scope is matched with **URLPattern**, not globs, so the hostname is a
+  component match rather than a substring of the URL text.
+  `https://evil.example/free2z.cash/api/` does not match `https://*.free2z.cash/*`.
+  `tests/http_scope.rs` asserts that, along with userinfo confusion, suffix
+  confusion, plaintext `http:`, loopback and a cloud metadata endpoint.
+
+The client is also **stateless**: `tauri-plugin-http` is taken with
+`default-features = false`, which drops `cookies` from its default set. The
+default build installs a process-wide `reqwest` cookie jar shared by every
+request the binary makes; that would make the native client an ambient-authority
+one, and under #367 a hostile subframe could ride the jar against free2z.cash and
+read the answer with no CORS in the way. free2z authenticates with a Knox token
+in an `Authorization` header and needs no jar.
+
+### 2. OAuth: the native transport was deleted, not ported
+
+The ten `oauth_*` commands were **not** brought over, and this was the decision
+with the most in it.
+
+`oauth_loopback_wait`, `oauth_mobile_claim` and `oauth_mobile_resume` each
+**return an authorization code — and, on mobile, the PKCE verifier minted for
+it — to the renderer**. That pair is a sign-in credential: anything holding it
+can finish the exchange and take the account. Registering them here would put
+that credential behind an `invoke()` in the one process that renders third-party
+markup, remote media and a livestream SDK, and #367 is the defect that makes
+"which frame asked" undecidable — Wry injects the bridge into every frame and its
+Android IPC reports the top-level URL, so a remote subframe resolves as the
+trusted main window. A capability file cannot separate the two: it scopes by
+window label, and there is one label.
+
+So `src/lib/oauth/transport.ts` now has exactly one transport, the same-origin
+web popup, and **no `invoke()` at all**. In a packaged shell
+`oauthCallbackTransport()` returns `"unavailable"` — the document origin is
+`tauri://localhost`, which is not a registered redirect URI at any provider —
+and three things follow:
+
+* `auth.socialProviders()` answers all-unconfigured **without asking the
+  backend**, so the login screen shows its empty state instead of a button whose
+  only outcome is an error toast.
+* `captureOAuthCode()` refuses before opening a popup, for any caller that
+  reaches the API directly.
+* `recoverMobileOAuth()` resolves `null`. `App.tsx` still calls it on mount, and
+  that is now correct: "nothing to finish". Before, it invoked
+  `oauth_mobile_pending` into an empty handler, so a packaged build greeted every
+  launch with `Couldn't finish sign-in` before the user touched anything.
+
+Password sign-in and already-linked accounts are unaffected. Social sign-in in a
+packaged build comes back as a wallet-authority bridge grant (#905), not as an
+invoke handler here.
+
+### 3. The deep-link scheme is this app's own
+
+`src/lib/oauth/protocol.ts` and `src/lib/checkout/native-return.ts` named
+**ZUULI's** URIs, ported verbatim. On a device carrying both apps, an OAuth code
+or a Stripe checkout return initiated by the *content* app would have been
+delivered by the OS to the *wallet-authority* app. Both now use
+`cash.free2z.free2z://`, `parseCheckoutReturnUrl` **refuses** the wallet's
+scheme, and `src-tauri/tauri.conf.json` registers three routes:
+
+| Route | State |
+| --- | --- |
+| `cash.free2z.free2z://bridge/return` | scaffolded for the intent bridge (#911) |
+| `cash.free2z.free2z://oauth/callback` | declared; nothing consumes it (there is no native OAuth transport) |
+| `cash.free2z.free2z://checkout/return` | declared; nothing consumes it (`/fund` is a placeholder) |
+
+`checkoutReturnMode()` returns `"web"` unconditionally, and the reason is a
+backend one: `zuuli_mobile` is a **wire** value that makes free2z issue a return
+URI in the *wallet's* scheme. There is no `free2z_*` return mode server-side yet,
+so asking for a native return from here would post a payer's claim code to a
+different application. That, and the funding port itself, is #904's remaining
+work — not something this app can fix client-side.
+
+### What now catches this class of bug
+
+`wallet/zuuli/scripts/surface-capability-authority.mjs` runs inside the required
+`gate` (via ZUULI's `npm test`) and now also compares the two halves of the
+JS→native contract, off the files:
+
+* every `@tauri-apps/plugin-*` in `package.json` has its crate in
+  `src-tauri/Cargo.toml` **and** a `.plugin(...::init())` call in the builder;
+* every `invoke("literal")` in production `src/` names a command this binary
+  registers, or a `plugin:<x>|…` whose crate is linked;
+* a surface that registers **no** command — free2z — may not hold an
+  `invoke_handler` and may not so much as import `@tauri-apps/api/core`;
+* every `cash.free2z.*://host/path` literal in the tree uses **this** app's
+  scheme and names a route this app's manifest registers;
+* an `http` grant must be a scoped object whose every origin the app's own
+  `connect-src` already admits — a bare `http:default` fails.
+
+Each rule has a negative-control case in
+`surface-capability-authority.node-test.mjs`, and an empty source population is a
+blindness failure rather than a pass.
+
+### The evidence, and its limits
+
+`src-tauri/tests/http_scope.rs` builds a real Tauri app from this crate's real
+`tauri.conf.json` and real `capabilities/*.json` — `generate_context!()` embeds
+the resolved ACL — registers `tauri-plugin-http` exactly as `lib.rs` does, and
+drives `plugin:http|fetch` over the IPC path a webview uses. `fetch` builds the
+request and returns a resource id **without** any network I/O, so this runs
+offline and in CI. Both negative controls were watched to fail:
+
+* replace the scoped capability with a bare `http:default` →
+  `url not allowed on the configured scope: https://free2z.cash/api/articles/`
+* drop `.plugin(tauri_plugin_http::init())` → `plugin http not found`, which is
+  exactly what a packaged build did before #918.
+
+**What is still not proven end to end:** no automated test drives the packaged
+binary against the live `free2z.cash` over the network, and the multipart
+`FormData` path (`/kyc`, #927) has never run through `@tauri-apps/plugin-http` at
+all — every other surface sends JSON. Reading the plugin's `fetch`, a `FormData`
+body is serialized by the browser `Request` and its generated
+`content-type: multipart/form-data; boundary=…` is merged in because
+`src/lib/api/http.ts` deliberately sets no `Content-Type` for one, so it *should*
+work; that is a reading, not a measurement. Note also that the plugin drops
+`Content-Length` as a forbidden header and re-derives it, and that `Authorization`
+passes through untouched.
 
 ## What has moved, and what has not
 
@@ -155,8 +251,11 @@ components that no longer exist.
 Not its CSP. **Its dependency list.**
 
 `src-tauri/Cargo.toml` links neither `tauri-plugin-zcash` nor
-`tauri-plugin-f2zmsg`, and `src-tauri/capabilities/*.json` contain no `zcash:*`
-and no `f2zmsg:*` entry. That is deliberate and load-bearing: Wry injects
+`tauri-plugin-f2zmsg`, `src-tauri/capabilities/*.json` contain no `zcash:*` and
+no `f2zmsg:*` entry, and `src-tauri/src/lib.rs` registers **no `invoke_handler`
+at all** — #918 added `tauri-plugin-http` and still did not add one, because the
+`oauth_*` commands it would have carried hand a sign-in credential back to the
+renderer. That is deliberate and load-bearing: Wry injects
 Tauri's bridge scripts into *every* frame and its Android IPC reports the
 top-level URL rather than the requesting frame (#367), so a remote subframe in
 this process resolves as the trusted main window. The only durable answer is
@@ -167,7 +266,11 @@ Three things enforce it, all inside the required `gate`:
 * `wallet/zuuli/scripts/surface-capability-authority.mjs` — the contract test.
   It enumerates every capability file off the filesystem (so a new one cannot
   escape by being added), rejects any `zcash:*`/`f2zmsg:*` identifier including
-  one hidden in a scoped object entry, and rejects linking either plugin.
+  one hidden in a scoped object entry, and rejects linking either plugin. Since
+  #918 it also refuses an unscoped `http` grant, an `invoke_handler` or an
+  `@tauri-apps/api/core` import on this surface, a JS plugin package with no
+  crate behind it, and any `cash.free2z.*://` URI that is not this app's own —
+  see **What now catches this class of bug** above.
 * `wallet/zuuli/scripts/project-boundary.mjs` — no import may cross between
   wallet applications in either direction, and it now also builds this project's
   real production Rollup graph inside the constrained audit sandbox.
@@ -266,7 +369,11 @@ npm ci
 npm run typecheck && npm run typecheck:tests
 npm test          # vitest + the UI-copy policy test + Playwright
 npm run build
-cargo check --locked --all-targets --manifest-path src-tauri/Cargo.toml
+cargo build --locked --all-targets --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml   # incl. the real-ACL http scope test
+npm run tauri -- build --bundles app              # the bundle is active again (#918)
+node ../zuuli/scripts/surface-capability-authority.mjs
+node --test ../zuuli/scripts/surface-capability-authority.node-test.mjs
 ```
 
 `npm run dev` serves on 1425 (zuuallet owns 1421, ZUULI 1423) and proxies

--- a/wallet/free2z/src-tauri/Cargo.lock
+++ b/wallet/free2z/src-tauri/Cargo.lock
@@ -454,6 +454,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +533,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -537,7 +564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -550,7 +577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -559,6 +586,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -675,6 +711,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dbus"
@@ -921,6 +963,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1144,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-http",
  "tauri-plugin-opener",
 ]
 
@@ -1296,8 +1348,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1319,8 +1373,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1472,6 +1529,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1648,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1580,6 +1657,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1600,9 +1693,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2062,6 +2157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,6 +2436,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2747,6 +2849,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2766,6 +2924,32 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2844,6 +3028,47 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2874,6 +3099,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2915,10 +3154,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3111,6 +3391,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3181,7 +3473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3320,6 +3612,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,6 +3681,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3403,7 +3722,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -3482,7 +3801,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3600,6 +3919,52 @@ dependencies = [
  "url",
  "windows-registry",
  "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.20",
+ "toml 1.1.5+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-http"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7241a0c762649be8fba7dd4cc84684d0e409f26b335a978ef4dd5fe78da74ce6"
+dependencies = [
+ "data-url",
+ "http",
+ "regex",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.20",
+ "tokio",
+ "url",
+ "urlpattern",
 ]
 
 [[package]]
@@ -3861,7 +4226,29 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3873,6 +4260,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4178,6 +4566,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,6 +4759,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4418,6 +4822,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4659,6 +5072,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5042,6 +5464,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/wallet/free2z/src-tauri/Cargo.toml
+++ b/wallet/free2z/src-tauri/Cargo.toml
@@ -25,12 +25,55 @@ tauri-build = { version = "2", features = [] }
 # confusion could reach, whatever the capability files say. Adding one here is
 # the change that `wallet/zuuli/scripts/surface-capability-authority.mjs`
 # refuses on the capability side and that a reviewer must refuse on this side.
+#
+# `tauri-plugin-http` is the one plugin added since (#918), and it is a
+# different kind of thing from the two forbidden ones. `zcash`/`f2zmsg` export
+# authority the process holds locally — a seed, device keys — which a hostile
+# subframe would gain outright under #367. The HTTP plugin exports no local
+# authority at all: it is a network client whose entire reach is the URL scope
+# in `capabilities/*.json`. A subframe that reaches it can talk to free2z's own
+# API, which is a thing it can already do with `window.fetch` from a page it
+# controls. What it must never become is an unscoped client, which is why the
+# capability files carry an `allow` list and the checker refuses a bare
+# `http:default`.
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-deep-link = "2.4.9"
 tauri-plugin-opener = "2"
+# The native HTTP client the frontend reaches through `@tauri-apps/plugin-http`
+# (#918). It registers `plugin:http|fetch`, which is NOT an app command and
+# grants no local authority: what it may reach is decided entirely by the URL
+# scope in `capabilities/*.json`, and `http:default` on its own has an EMPTY
+# allow list, so it denies every http/https URL until origins are named. The
+# origins named there are free2z's own API and media hosts and nothing else —
+# see the comment in `capabilities/default.json`, which is the reviewed record.
+#
+# `default-features = false` drops exactly one thing from the plugin's default
+# set: `cookies`. The default build installs a process-wide `reqwest` cookie
+# jar shared by every request this binary makes, which would make the native
+# client an AMBIENT-AUTHORITY client — a request would carry whatever session
+# cookie the jar had accumulated, and under #367 a hostile subframe could ride
+# it against free2z.cash and read the answer with no CORS in the way. free2z
+# authenticates with a Knox token in an `Authorization` header (see
+# `src/lib/api/http.ts`) and needs no jar, so this surface's HTTP client is
+# stateless: it carries only the credentials the caller put on the request.
+# The rest of the default set is kept verbatim.
+tauri-plugin-http = { version = "2.5.9", default-features = false, features = [
+    "rustls-tls",
+    "http2",
+    "charset",
+    "macos-system-configuration",
+] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[dev-dependencies]
+# `tauri::test::mock_builder` + the REAL `generate_context!()` ACL. This is the
+# only way to measure the capability scope where the bug can appear: under
+# `isTauri() === false` (vitest, Playwright, `npm run build`) the native branch
+# is never taken, and `cargo check` never asks whether the frontend's commands
+# exist. See `tests/http_scope.rs`.
+tauri = { version = "2", features = ["test"] }
 
 # ---------------------------------------------------------------------------
 # Build profiles. This package is its own workspace root — the repository keeps

--- a/wallet/free2z/src-tauri/capabilities/default.json
+++ b/wallet/free2z/src-tauri/capabilities/default.json
@@ -1,7 +1,20 @@
 {
   "identifier": "default",
-  "description": "Desktop capability for the main free2z window. Grants NOTHING privileged: no zcash:* entry and no f2zmsg:* entry, ever. wallet/zuuli/scripts/surface-capability-authority.mjs is the contract test that fails if one appears.",
+  "description": "Desktop capability for the main free2z window. Grants NOTHING privileged: no zcash:* entry and no f2zmsg:* entry, ever. wallet/zuuli/scripts/surface-capability-authority.mjs is the contract test that fails if one appears. The one non-core plugin permission here, http:default, is URL-SCOPED to free2z's own API and media hosts — the same checker refuses it as a bare string, because an http grant with no allow list is a grant nobody reviewed.",
   "platforms": ["linux", "macOS", "windows"],
   "windows": ["main"],
-  "permissions": ["core:default", "deep-link:default", "opener:default"]
+  "permissions": [
+    "core:default",
+    "deep-link:default",
+    "opener:default",
+    {
+      "identifier": "http:default",
+      "allow": [
+        { "url": "https://free2z.cash/*" },
+        { "url": "https://*.free2z.cash/*" },
+        { "url": "https://free2z.com/*" },
+        { "url": "https://*.free2z.com/*" }
+      ]
+    }
+  ]
 }

--- a/wallet/free2z/src-tauri/capabilities/mobile.json
+++ b/wallet/free2z/src-tauri/capabilities/mobile.json
@@ -1,7 +1,20 @@
 {
   "identifier": "mobile",
-  "description": "Mobile capability for the main free2z webview. Grants NOTHING privileged: no zcash:* entry and no f2zmsg:* entry, ever. This is the surface that renders third-party content, so #367's frame-confusion defect must find no privileged command to reach.",
+  "description": "Mobile capability for the main free2z webview. Grants NOTHING privileged: no zcash:* entry and no f2zmsg:* entry, ever. This is the surface that renders third-party content, so #367's frame-confusion defect must find no privileged command to reach. http:default is URL-SCOPED to free2z's own API and media hosts and is the only reach it has; a bare, unscoped http:default is refused by wallet/zuuli/scripts/surface-capability-authority.mjs.",
   "platforms": ["iOS", "android"],
   "windows": ["main"],
-  "permissions": ["core:default", "deep-link:default", "opener:default"]
+  "permissions": [
+    "core:default",
+    "deep-link:default",
+    "opener:default",
+    {
+      "identifier": "http:default",
+      "allow": [
+        { "url": "https://free2z.cash/*" },
+        { "url": "https://*.free2z.cash/*" },
+        { "url": "https://free2z.com/*" },
+        { "url": "https://*.free2z.com/*" }
+      ]
+    }
+  ]
 }

--- a/wallet/free2z/src-tauri/src/lib.rs
+++ b/wallet/free2z/src-tauri/src/lib.rs
@@ -7,12 +7,24 @@
 //! operation is a scoped, revocable, native-confirmed grant issued by the
 //! wallet authority over the cross-surface bridge (#905), never a command in
 //! this invoke handler.
+//!
+//! There is still no `invoke_handler` here, and #918 deliberately did not add
+//! one. The ten `oauth_*` commands ZUULI carries were NOT ported: they hand an
+//! OAuth authorization code and its PKCE verifier back to the renderer, which
+//! is a sign-in credential, and #367 means the frame asking might not be ours.
+//! The frontend's native OAuth transport was deleted instead — see
+//! `../../src/lib/oauth/transport.ts`.
+//!
+//! What #918 did add is `tauri-plugin-http`. It registers `plugin:http|fetch`
+//! rather than an app command, holds no local authority, and reaches only the
+//! URL scope named in `../capabilities/*.json`.
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_http::init())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
@@ -31,5 +43,44 @@ mod tests {
                 "free2z must not link {forbidden}: it renders third-party content"
             );
         }
+    }
+
+    /// The native HTTP client must stay stateless. `cookies` is in the plugin's
+    /// DEFAULT feature set, so re-enabling it is a one-word edit — and it would
+    /// install a process-wide cookie jar that every request rides, turning a
+    /// scoped network client into an ambient-authority one (#918).
+    #[test]
+    fn the_native_http_client_carries_no_cookie_jar() {
+        let manifest = include_str!("../Cargo.toml");
+        let entry = manifest
+            .split("\ntauri-plugin-http = ")
+            .nth(1)
+            .and_then(|rest| rest.split("] }").next())
+            .expect("the tauri-plugin-http dependency entry");
+        assert!(
+            entry.contains("default-features = false"),
+            "tauri-plugin-http must opt out of its default features; `cookies` is one of them"
+        );
+        assert!(
+            !entry.contains("\"cookies\""),
+            "free2z's HTTP client must carry no cookie jar: it authenticates with a header"
+        );
+    }
+
+    /// The whole security property of this surface is that there is no command
+    /// to reach. `invoke_handler` is the only way one could appear, and it is
+    /// one line, so the source is asserted rather than the doc comment.
+    #[test]
+    fn no_invoke_handler_is_registered() {
+        let source = include_str!("lib.rs");
+        let builder = source
+            .split("pub fn run() {")
+            .nth(1)
+            .and_then(|rest| rest.split("\n}").next())
+            .expect("the run() body");
+        assert!(
+            !builder.contains("invoke_handler"),
+            "free2z must register no command: #367 means a remote subframe could call it"
+        );
     }
 }

--- a/wallet/free2z/src-tauri/tauri.conf.json
+++ b/wallet/free2z/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
     }
   },
   "bundle": {
-    "active": false,
+    "active": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",
@@ -44,6 +44,18 @@
         {
           "scheme": ["cash.free2z.free2z"],
           "host": "bridge",
+          "path": ["/return"],
+          "appLink": false
+        },
+        {
+          "scheme": ["cash.free2z.free2z"],
+          "host": "oauth",
+          "path": ["/callback"],
+          "appLink": false
+        },
+        {
+          "scheme": ["cash.free2z.free2z"],
+          "host": "checkout",
           "path": ["/return"],
           "appLink": false
         }

--- a/wallet/free2z/src-tauri/tests/http_scope.rs
+++ b/wallet/free2z/src-tauri/tests/http_scope.rs
@@ -1,0 +1,152 @@
+//! What the content surface's native HTTP client may actually reach.
+//!
+//! #918 exists because every earlier green measurement was taken where the bug
+//! could not appear. vitest, Playwright and `npm run build` all run with
+//! `isTauri() === false` or `import.meta.env.DEV === true` — exactly the branch
+//! that does NOT take the native path — and `cargo check` compiles a backend
+//! nobody asked whether the frontend's commands exist in it.
+//!
+//! So this test does not read the JSON and agree with it. It builds a real
+//! Tauri app from this crate's REAL `tauri.conf.json` and REAL
+//! `capabilities/*.json` — `generate_context!()` embeds the resolved ACL — puts
+//! `tauri-plugin-http` in it exactly as `lib.rs` does, and drives
+//! `plugin:http|fetch` over the IPC path a webview uses. The verdict comes from
+//! the plugin's own scope evaluation, not from this file's opinion of it.
+//!
+//! `fetch` builds the request and hands back a resource id WITHOUT performing
+//! any network I/O (the future is only polled by `fetch_send`), so an allowed
+//! origin is provable offline and in CI: reaching a resource id means the ACL
+//! admitted the command and the URL scope admitted the origin.
+
+use tauri::ipc::{CallbackFn, InvokeBody};
+use tauri::test::{mock_builder, MockRuntime, INVOKE_KEY};
+use tauri::webview::InvokeRequest;
+use tauri::{WebviewWindow, WebviewWindowBuilder};
+
+/// The real app: real config, real capabilities, and the same plugin set
+/// `free2z_lib::run` registers.
+fn main_window() -> WebviewWindow<MockRuntime> {
+    let app = mock_builder()
+        .plugin(tauri_plugin_http::init())
+        .build(tauri::generate_context!())
+        .expect("the free2z app builds from its own tauri.conf.json");
+    // "main" is the label both capability files scope themselves to.
+    WebviewWindowBuilder::new(&app, "main", Default::default())
+        .build()
+        .expect("the main webview")
+}
+
+/// The packaged webview's own origin, which is what the ACL calls "local".
+/// Tauri serves the app from a custom protocol everywhere except Windows and
+/// Android, where the same thing is spelled `http://tauri.localhost`.
+#[cfg(any(windows, target_os = "android"))]
+const WEBVIEW_ORIGIN: &str = "http://tauri.localhost";
+#[cfg(not(any(windows, target_os = "android")))]
+const WEBVIEW_ORIGIN: &str = "tauri://localhost";
+
+fn fetch(window: &WebviewWindow<MockRuntime>, url: &str) -> Result<(), String> {
+    let request = InvokeRequest {
+        cmd: "plugin:http|fetch".into(),
+        callback: CallbackFn(0),
+        error: CallbackFn(1),
+        // The webview's own origin. The capability is scoped to `local` URLs,
+        // and this is what "local" means — but that is NOT what keeps a remote
+        // frame out: #367 is precisely the defect where Wry reports the
+        // top-level (local) URL for a subframe's IPC. So the reach of this
+        // command has to be decided by URL scope, not by caller.
+        url: WEBVIEW_ORIGIN.parse().unwrap(),
+        body: InvokeBody::Json(serde_json::json!({
+            "clientConfig": {
+                "method": "GET",
+                "url": url,
+                "headers": [["accept", "application/json"]],
+                "data": null,
+            }
+        })),
+        headers: Default::default(),
+        invoke_key: INVOKE_KEY.to_string(),
+    };
+    tauri::test::get_ipc_response(window, request)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+/// Every origin the frontend actually talks to over the native client:
+/// `src/lib/api/http.ts` (the whole API surface) and
+/// `src/components/common/RemoteMedia.tsx` (first-party image downloads).
+#[test]
+fn the_free2z_api_and_media_hosts_are_reachable() {
+    let window = main_window();
+    for url in [
+        "https://free2z.cash/api/articles/",
+        "https://free2z.cash/api/token/login/",
+        "https://free2z.cash/uploadz/public/cover.webp",
+        "https://stage.free2z.cash/api/articles/",
+        "https://new.free2z.cash/api/auth/social/providers/",
+        "https://free2z.com/api/articles/",
+        "https://www.free2z.com/uploadz/public/cover.webp",
+    ] {
+        assert_eq!(
+            fetch(&window, url),
+            Ok(()),
+            "the packaged capability must admit {url}; without it every API \
+             request and every first-party image in a packaged build fails"
+        );
+    }
+}
+
+/// The scope is the boundary, so the refusals are asserted rather than merely
+/// omitted. A content surface's HTTP client that can reach anything is the
+/// thing #918 refused to ship, and each of these is a way it could.
+#[test]
+fn everything_else_is_refused() {
+    let window = main_window();
+    for (url, why) in [
+        ("https://example.com/", "an unrelated origin"),
+        (
+            "https://api.realtime.cloudflare.com/v2/internals/participant-details",
+            "the RealtimeKit SDK talks from the webview, not through this client",
+        ),
+        (
+            "http://free2z.cash/api/articles/",
+            "plaintext http, even to our own host",
+        ),
+        (
+            "http://127.0.0.1:8080/",
+            "loopback — no local service is reachable",
+        ),
+        ("http://localhost:1425/", "the dev server"),
+        (
+            "https://free2z.cash.evil.example/api/",
+            "a suffix-confusion host",
+        ),
+        (
+            "https://evil.example/free2z.cash/api/",
+            "our host inside someone's path",
+        ),
+        ("https://free2z.cash@evil.example/", "our host as userinfo"),
+        (
+            "https://metadata.google.internal/",
+            "a cloud metadata endpoint",
+        ),
+    ] {
+        let result = fetch(&window, url);
+        assert!(
+            result.is_err(),
+            "free2z's HTTP client must not reach {url} ({why}), got {result:?}"
+        );
+    }
+}
+
+/// The permission identifier alone decides nothing. `http:default` is
+/// `allow-fetch` with an EMPTY allow list, and an empty allow list denies every
+/// http/https URL — which is why the capability files carry an explicit scope
+/// and why `surface-capability-authority.mjs` refuses the bare string form.
+#[test]
+fn the_scope_is_actually_consulted() {
+    let window = main_window();
+    // Negative control for the test above: if the scope were being ignored and
+    // `fetch` were simply always succeeding, this would pass too.
+    assert!(fetch(&window, "https://example.com/").is_err());
+    assert_eq!(fetch(&window, "https://free2z.cash/api/articles/"), Ok(()));
+}

--- a/wallet/free2z/src/components/common/SocialButtons.tsx
+++ b/wallet/free2z/src/components/common/SocialButtons.tsx
@@ -1,6 +1,11 @@
-// Real social login (X / Google / GitHub) — desktop RFC 8252 loopback
-// transport on Tauri, a popup fallback on the web (see
-// `@/lib/oauth/transport.ts`), wired to `dj.apps.social` on the backend.
+// Real social login (X / Google / GitHub) over this surface's one transport,
+// the same-origin web popup (see `@/lib/oauth/transport.ts`), wired to
+// `dj.apps.social` on the backend. ZUULI's two NATIVE transports are absent
+// here on purpose: their commands hand an authorization code and its PKCE
+// verifier back to the renderer, and this is the process that renders remote
+// content (#367, #918). So in a packaged shell there is no transport, and no
+// button — `useSocialProviders()` answers all-unconfigured and the empty state
+// below is what a reader sees.
 //
 // A button renders ONLY for a provider `useSocialProviders()` reports as
 // configured for this exact callback transport. A valid all-unconfigured

--- a/wallet/free2z/src/lib/api/free2z.ts
+++ b/wallet/free2z/src/lib/api/free2z.ts
@@ -15,9 +15,7 @@ import {
   sumParticipantCounts,
 } from "../participant-count";
 import {
-  cancelMobileOAuth,
   captureOAuthCode,
-  finishMobileOAuth,
   oauthCallbackTransport,
   withOAuthSession,
   type OAuthCapture,
@@ -123,7 +121,16 @@ const delay = (ms = 260) => new Promise((r) => setTimeout(r, ms));
 const NATIVE_RETURN_TIMEOUT_MS = 15_000;
 
 const SOCIAL_PROVIDER_PATH = "/api/auth/social/providers/";
-const MOBILE_SOCIAL_PROVIDER_PATH = "/api/auth/social/mobile/providers/";
+// `/api/auth/social/mobile/providers/` is deliberately not consulted here.
+// It is the readiness contract for the private-use deep-link relay, and this
+// surface has no native OAuth transport to relay into (#918).
+
+/** No provider is available where there is no transport that can finish one. */
+const NO_SOCIAL_PROVIDER: SocialProvidersStatus = {
+  x: false,
+  google: false,
+  github: false,
+};
 
 function mockSocialProvidersWire(): unknown {
   const scenario =
@@ -967,10 +974,15 @@ export const auth = {
 
   /**
    * Which social providers (X / Google / GitHub) are available for this exact
-   * callback transport. Web and Tauri desktop consume credential truth from
-   * GET /api/auth/social/providers/. Tauri iOS/Android consume the stricter
-   * GET /api/auth/social/mobile/providers/ readiness contract (credentials,
-   * PKCE, exact relay policy and rollout activation).
+   * callback transport. On the web that is credential truth from
+   * GET /api/auth/social/providers/.
+   *
+   * In a packaged Tauri shell it is nothing: this surface has no native OAuth
+   * transport (#918), and the web popup cannot come back to `tauri://localhost`.
+   * Answering all-unconfigured is what keeps the login screen from advertising a
+   * method it cannot finish — `SocialButtons` then shows its empty state rather
+   * than a button whose only outcome is an error toast. That is a deliberate
+   * difference from ZUULI, which asks a native command which transport it has.
    *
    * The wire response is an object containing a `providers` array. Treat it as
    * unknown until every entry is validated, then normalize it to the stable
@@ -982,15 +994,10 @@ export const auth = {
       await delay(100);
       return parseSocialProvidersStatus(mockSocialProvidersWire());
     }
-    // If the native discriminator is unavailable, reject discovery. Falling
-    // back to the generic endpoint could advertise a desktop-ready provider
-    // whose mobile relay is deliberately disabled.
-    const transport = await oauthCallbackTransport();
-    const path =
-      transport === "mobile"
-        ? MOBILE_SOCIAL_PROVIDER_PATH
-        : SOCIAL_PROVIDER_PATH;
-    const response = await request<unknown>(path, {
+    if ((await oauthCallbackTransport()) !== "web") {
+      return { ...NO_SOCIAL_PROVIDER };
+    }
+    const response = await request<unknown>(SOCIAL_PROVIDER_PATH, {
       anonymous: true,
     });
     return parseSocialProvidersStatus(response);
@@ -1021,10 +1028,12 @@ export const auth = {
 
   /**
    * Social login / link with a provider (X / Google / GitHub). Runs the
-   * OAuth authorization-code round trip over the desktop loopback transport,
-   * the mobile free2z-HTTPS-to-app relay, or a web popup fallback
-   * (`../oauth/transport.ts`) — callers receive an uncommitted result and own
-   * the final current-attempt session publication.
+   * OAuth authorization-code round trip over this surface's ONLY transport, the
+   * same-origin web popup (`../oauth/transport.ts`) — callers receive an
+   * uncommitted result and own the final current-attempt session publication.
+   * In a packaged shell there is no transport and this refuses (#918); the
+   * button is not offered there, because `socialProviders()` answers
+   * all-unconfigured.
    *
    * Dual-mode, mirroring `zcashLogin`/`zcashAssociate`:
    *   - `associate: false` (default) — POSTs anonymously; the backend logs
@@ -1057,9 +1066,11 @@ export const auth = {
   },
 
   /**
-   * Exchange a callback already validated and one-shot claimed by the native
-   * transport. Public so App startup can finish a crash-recovered cold-start
-   * callback through exactly the same backend path as the live button flow.
+   * Exchange a callback the transport already validated against this attempt's
+   * state. Public so App startup can finish a recovered callback through
+   * exactly the same backend path as the live button flow — there is no such
+   * callback on this surface today (`recoverMobileOAuth` resolves null), and
+   * the call site stays for the day a bridge grant produces one (#905, #918).
    */
   async completeSocialOAuth(capture: OAuthCapture): Promise<SocialAuthResult> {
     return withOAuthSession<SocialAuthResult>(capture, async (lease) => {
@@ -1082,14 +1093,7 @@ export const auth = {
             signal: lease.signal,
           });
           lease.assertCurrent();
-          // The backend mutation already succeeded. Local scratch-file cleanup
-          // must not turn a completed link into a user-visible auth failure.
-          await finishMobileOAuth(state).catch(() => undefined);
-          lease.assertCurrent();
         } catch (e) {
-          if (e instanceof ApiError && e.status >= 400 && e.status < 500) {
-            await cancelMobileOAuth(state).catch(() => undefined);
-          }
           if (e instanceof ApiError && e.status === 409) {
             throw new Error(
               "That account is already linked — either to a different free2z account, or this account already has a linked identity for this provider. Unlink it there first, or use a different account.",
@@ -1114,14 +1118,7 @@ export const auth = {
         body,
         anonymous: true,
         signal: lease.signal,
-      }).catch(async (error) => {
-        if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
-          await cancelMobileOAuth(state).catch(() => undefined);
-        }
-        throw error;
       });
-      lease.assertCurrent();
-      await finishMobileOAuth(state).catch(() => undefined);
       lease.assertCurrent();
       const me = await auth.me(tok.token, lease.signal);
       lease.assertCurrent();

--- a/wallet/free2z/src/lib/api/social-providers.test.ts
+++ b/wallet/free2z/src/lib/api/social-providers.test.ts
@@ -119,25 +119,8 @@ describe("social-provider discovery contract", () => {
     });
   });
 
-  it.each(["web", "desktop"] as const)(
-    "uses anonymous generic discovery for %s",
-    async (transport) => {
-      vi.mocked(oauthCallbackTransport).mockResolvedValue(transport);
-      vi.mocked(request).mockResolvedValue(productionResponse);
-
-      await expect(auth.socialProviders()).resolves.toEqual({
-        x: true,
-        google: false,
-        github: false,
-      });
-      expect(request).toHaveBeenCalledWith("/api/auth/social/providers/", {
-        anonymous: true,
-      });
-    },
-  );
-
-  it("uses anonymous mobile-readiness discovery on iOS and Android", async () => {
-    vi.mocked(oauthCallbackTransport).mockResolvedValue("mobile");
+  it("uses anonymous generic discovery for the web popup transport", async () => {
+    vi.mocked(oauthCallbackTransport).mockResolvedValue("web");
     vi.mocked(request).mockResolvedValue(productionResponse);
 
     await expect(auth.socialProviders()).resolves.toEqual({
@@ -145,20 +128,27 @@ describe("social-provider discovery contract", () => {
       google: false,
       github: false,
     });
-    expect(request).toHaveBeenCalledWith(
-      "/api/auth/social/mobile/providers/",
-      { anonymous: true },
-    );
+    expect(request).toHaveBeenCalledWith("/api/auth/social/providers/", {
+      anonymous: true,
+    });
   });
 
-  it("fails closed when native transport cannot be resolved", async () => {
-    vi.mocked(oauthCallbackTransport).mockRejectedValue(
-      new Error("native transport unavailable"),
-    );
+  // The bug this replaces (#918): a packaged shell resolved its transport from
+  // a native command that does not exist here, so discovery REJECTED and the
+  // login screen showed "Couldn't check sign-in options" with a retry that
+  // could never succeed. There is no native transport on this surface at all,
+  // so the honest answer is that no provider is available — and it must not be
+  // reached by asking the backend, which would advertise a provider whose
+  // callback could never come back to `tauri://localhost`.
+  it("offers no provider, and asks the backend nothing, without a transport", async () => {
+    vi.mocked(oauthCallbackTransport).mockResolvedValue("unavailable");
+    vi.mocked(request).mockResolvedValue(productionResponse);
 
-    await expect(auth.socialProviders()).rejects.toThrow(
-      "native transport unavailable",
-    );
+    await expect(auth.socialProviders()).resolves.toEqual({
+      x: false,
+      google: false,
+      github: false,
+    });
     expect(request).not.toHaveBeenCalled();
   });
 

--- a/wallet/free2z/src/lib/checkout/native-return.test.ts
+++ b/wallet/free2z/src/lib/checkout/native-return.test.ts
@@ -6,8 +6,8 @@ const deepLink = vi.hoisted(() => ({
   unlisten: vi.fn(),
 }));
 
-vi.mock("@/lib/oauth/transport", () => ({
-  isMobileTauri: vi.fn().mockResolvedValue(true),
+vi.mock("@/lib/platform", () => ({
+  isTauri: () => true,
 }));
 
 vi.mock("@tauri-apps/plugin-deep-link", () => ({
@@ -44,19 +44,39 @@ describe("native Checkout deep-link parser", () => {
 
   it.each([
     `https://free2z.cash/checkout/return?code=${CODE}`,
-    `cash.free2z.zuuli://oauth/callback?code=${CODE}`,
-    `cash.free2z.zuuli://checkout/other?code=${CODE}`,
-    `cash.free2z.zuuli://checkout/return%2F?code=${CODE}`,
-    `cash.free2z.zuuli://user@checkout/return?code=${CODE}`,
-    `cash.free2z.zuuli://checkout/return?code=${CODE}#fragment`,
-    `cash.free2z.zuuli://checkout/return?code=${CODE}&next=https://evil.example`,
-    `cash.free2z.zuuli://checkout/return?code=${CODE}&code=${CODE}`,
-    `cash.free2z.zuuli://checkout/return?code=short`,
-    `cash.free2z.zuuli://checkout/return?code=${"a".repeat(2049)}`,
-    `cash.free2z.zuuli://checkout/return?code=signed%2Fclaim%3Ainvalid`,
-    `cash.free2z.zuuli://checkout/return?code=signed%20claim%3Ainvalid`,
+    `cash.free2z.free2z://oauth/callback?code=${CODE}`,
+    `cash.free2z.free2z://bridge/return?code=${CODE}`,
+    `cash.free2z.free2z://checkout/other?code=${CODE}`,
+    `cash.free2z.free2z://checkout/return%2F?code=${CODE}`,
+    `cash.free2z.free2z://user@checkout/return?code=${CODE}`,
+    `cash.free2z.free2z://checkout/return?code=${CODE}#fragment`,
+    `cash.free2z.free2z://checkout/return?code=${CODE}&next=https://evil.example`,
+    `cash.free2z.free2z://checkout/return?code=${CODE}&code=${CODE}`,
+    `cash.free2z.free2z://checkout/return?code=short`,
+    `cash.free2z.free2z://checkout/return?code=${"a".repeat(2049)}`,
+    `cash.free2z.free2z://checkout/return?code=signed%2Fclaim%3Ainvalid`,
+    `cash.free2z.free2z://checkout/return?code=signed%20claim%3Ainvalid`,
   ])("rejects a near-miss callback: %s", (value) => {
     expect(parseCheckoutReturnUrl(value)).toBeNull();
+  });
+
+  // #918. Before the scheme was corrected this parser ACCEPTED
+  // `cash.free2z.zuuli://checkout/return`, which is not this app's URI: on a
+  // device carrying both apps the OS delivers that one to the wallet authority,
+  // and a claim code initiated here would have been redeemed there. The URI is
+  // now this app's own, and the wallet's is refused like any other stranger's.
+  it("refuses the wallet app's checkout return, which is not this app's URI", () => {
+    expect(CHECKOUT_RETURN_URI.startsWith("cash.free2z.free2z://")).toBe(true);
+    expect(
+      parseCheckoutReturnUrl(
+        `cash.free2z.zuuli://checkout/return?code=${CODE}`,
+      ),
+    ).toBeNull();
+    expect(
+      parseCheckoutReturnUrl(
+        `cash.free2z.e2e2z://checkout/return?code=${CODE}`,
+      ),
+    ).toBeNull();
   });
 });
 
@@ -303,7 +323,7 @@ describe("cold and warm native delivery", () => {
     deepLink.callback?.([`${CHECKOUT_RETURN_URI}?code=${CODE}`]);
     deepLink.callback?.([
       `${CHECKOUT_RETURN_URI}?code=${"b".repeat(32)}:stamp:signature`,
-      `cash.free2z.zuuli://oauth/callback?code=${"c".repeat(43)}`,
+      `cash.free2z.free2z://oauth/callback?code=${"c".repeat(43)}`,
     ]);
     expect(deliver).toHaveBeenCalledTimes(2);
     expect(deliver).toHaveBeenLastCalledWith(

--- a/wallet/free2z/src/lib/checkout/native-return.ts
+++ b/wallet/free2z/src/lib/checkout/native-return.ts
@@ -1,13 +1,35 @@
-import { isMobileTauri } from "@/lib/oauth/transport";
+import { isTauri } from "@/lib/platform";
 
-export const CHECKOUT_RETURN_URI = "cash.free2z.zuuli://checkout/return";
+/**
+ * This app's own Stripe checkout return URI.
+ *
+ * It named the WALLET app's scheme (`cash.free2z.zuuli`, `checkout/return`)
+ * when this module was ported out of ZUULI (#912). On a device carrying both
+ * apps the OS would have delivered a payer's claim code — initiated here — to
+ * the wallet-authority app instead (#918). This route is registered by this
+ * app's own manifest, and `parseCheckoutReturnUrl` below now REFUSES the
+ * wallet's scheme rather than accepting it.
+ */
+export const CHECKOUT_RETURN_URI = "cash.free2z.free2z://checkout/return";
 // Django's timestamp signer emits URL-safe base64 segments separated by
 // colons, with an optional leading compression marker. Keep this bounded and
 // fail closed before the value reaches the authenticated claim endpoint.
 const CLAIM_CODE = /^[A-Za-z0-9_.:-]{16,2048}$/;
 const STATUS_TOKEN = /^[A-Za-z0-9_.:-]{16,1024}$/;
 
-export type CheckoutReturnMode = "web" | "zuuli_mobile";
+/**
+ * The return mode this app may ask free2z's checkout API for.
+ *
+ * `"web"` is the only member on purpose. `zuuli_mobile` — ZUULI's value — is a
+ * WIRE value, not a local capability flag: it makes the backend issue a return
+ * URI in the WALLET app's scheme (`cash.free2z.zuuli`), which the OS hands to
+ * that app. free2z has no return mode of its own on the backend yet, so asking
+ * for a native return here would post a payer's claim code to a different
+ * application. Sending `web` is the honest thing this surface can do until a
+ * `free2z_*` return mode exists server-side; that is a backend change, and the
+ * client half of it lands with `features/wallet/funding` (#918, #904).
+ */
+export type CheckoutReturnMode = "web";
 
 export type CheckoutReturnClaim =
   | { outcome: "cancel"; status: "cancelled" }
@@ -69,7 +91,7 @@ export function parseCheckoutReturnUrl(value: string): string | null {
     return null;
   }
   if (
-    url.protocol !== "cash.free2z.zuuli:" ||
+    url.protocol !== "cash.free2z.free2z:" ||
     url.hostname !== "checkout" ||
     url.pathname !== "/return" ||
     url.username ||
@@ -155,7 +177,7 @@ export function parseCheckoutPaymentStatus(
 }
 
 export async function checkoutReturnMode(): Promise<CheckoutReturnMode> {
-  return (await isMobileTauri()) ? "zuuli_mobile" : "web";
+  return "web";
 }
 
 // Stripe redirects the payer the instant the Session completes, so the
@@ -204,11 +226,19 @@ export async function recoverCheckoutReturn(
   return { status: "processing" };
 }
 
-/** Deliver both cold-start getCurrent() and warm-start onOpenUrl() returns. */
+/**
+ * Deliver both cold-start getCurrent() and warm-start onOpenUrl() returns.
+ *
+ * Gated on `isTauri()` rather than on the OAuth transport: this surface has no
+ * `oauth_callback_transport` command to ask (#918), and `tauri-plugin-deep-link`
+ * delivers on desktop as well as on mobile. Nothing calls this yet — `/fund` is
+ * a placeholder until `features/wallet/funding` moves — and `checkoutReturnMode`
+ * never asks the backend for a native return, so no code is expected here.
+ */
 export async function listenForCheckoutReturns(
   deliver: (code: string) => void | Promise<void>,
 ): Promise<() => void> {
-  if (!(await isMobileTauri())) return () => undefined;
+  if (!isTauri()) return () => undefined;
   const { getCurrent, onOpenUrl } =
     await import("@tauri-apps/plugin-deep-link");
   const seen = new Set<string>();

--- a/wallet/free2z/src/lib/oauth/protocol.ts
+++ b/wallet/free2z/src/lib/oauth/protocol.ts
@@ -1,6 +1,25 @@
 import type { SocialProvider } from "../api/types";
 
-export const MOBILE_REDIRECT_URI = "cash.free2z.zuuli://oauth/callback";
+/**
+ * This app's own private-use OAuth callback URI.
+ *
+ * It must name **this** application's identifier. It named the WALLET app's
+ * scheme (`cash.free2z.zuuli`, `oauth/callback`) when the login surface was
+ * ported out of ZUULI (#912), which on a device carrying both apps would have
+ * handed an authorization code initiated by the content app to the
+ * wallet-authority app — the cross-app custom-scheme collision the three-app
+ * split exists to prevent (#918). `cash.free2z.free2z` is this app's own, and
+ * the route below is registered by this app's own manifest
+ * (`src-tauri/tauri.conf.json`, `plugins.deep-link`), and
+ * `wallet/zuuli/scripts/surface-capability-authority.mjs` now fails any
+ * `cash.free2z.*://` literal in this tree whose scheme is not this app's.
+ *
+ * Nothing in production consumes it yet: this surface has no native OAuth
+ * transport (see `./transport.ts`), so the only live flow is the web popup.
+ * The constant is the declaration of what the URI is, and the validator below
+ * is what holds the backend's authorization URL to it.
+ */
+export const MOBILE_REDIRECT_URI = "cash.free2z.free2z://oauth/callback";
 const MOBILE_RELAY_HOSTS = new Set([
   "free2z.cash",
   "new.free2z.cash",

--- a/wallet/free2z/src/lib/oauth/transport-kind.test.ts
+++ b/wallet/free2z/src/lib/oauth/transport-kind.test.ts
@@ -2,15 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   isTauri: false,
-  invoke: vi.fn(),
 }));
 
 vi.mock("../platform", () => ({
   isTauri: () => mocks.isTauri,
-}));
-
-vi.mock("@tauri-apps/api/core", () => ({
-  invoke: mocks.invoke,
 }));
 
 async function resolveTransport() {
@@ -22,29 +17,28 @@ describe("OAuth callback transport discriminator", () => {
   beforeEach(() => {
     vi.resetModules();
     mocks.isTauri = false;
-    mocks.invoke.mockReset();
   });
 
-  it("uses web without asking the native shell", async () => {
+  it("uses the same-origin popup in a browser", async () => {
     await expect(resolveTransport()).resolves.toBe("web");
-    expect(mocks.invoke).not.toHaveBeenCalled();
   });
 
-  it.each(["desktop", "mobile"] as const)(
-    "returns the native command's exact %s result",
-    async (transport) => {
-      mocks.isTauri = true;
-      mocks.invoke.mockResolvedValue(transport);
-
-      await expect(resolveTransport()).resolves.toBe(transport);
-      expect(mocks.invoke).toHaveBeenCalledWith("oauth_callback_transport", undefined);
-    },
-  );
-
-  it("rejects rather than guessing when the native command fails", async () => {
+  // Before #918 this asked the native `oauth_callback_transport` command, which
+  // this binary does not register and never will: the commands behind it hand an
+  // authorization code and its PKCE verifier back to the renderer, and #367
+  // means the renderer asking might be a remote subframe. So a packaged shell
+  // has NO transport — not a desktop one, not a mobile one — and says so.
+  it("reports no transport at all inside a packaged Tauri shell", async () => {
     mocks.isTauri = true;
-    mocks.invoke.mockRejectedValue(new Error("native discriminator failed"));
+    await expect(resolveTransport()).resolves.toBe("unavailable");
+  });
 
-    await expect(resolveTransport()).rejects.toThrow("native discriminator failed");
+  it("never reaches the Tauri IPC bridge to decide", async () => {
+    const invoke = vi.fn();
+    vi.doMock("@tauri-apps/api/core", () => ({ invoke }));
+    mocks.isTauri = true;
+
+    await expect(resolveTransport()).resolves.toBe("unavailable");
+    expect(invoke).not.toHaveBeenCalled();
   });
 });

--- a/wallet/free2z/src/lib/oauth/transport.test.ts
+++ b/wallet/free2z/src/lib/oauth/transport.test.ts
@@ -101,53 +101,47 @@ describe("OAuth session lifecycle", () => {
     expect(popup.close).toHaveBeenCalledOnce();
   });
 
-  it("cancels persisted mobile recovery when its session changes", async () => {
+  // #918: App.tsx calls this unconditionally on mount, behind a `.catch` that
+  // fires `toast.error("Couldn't finish sign-in")`. Before this change it
+  // invoked `oauth_mobile_pending`, a command this binary does not register, so
+  // a packaged build greeted every launch with a sign-in failure the user had
+  // not asked for. It must resolve "nothing to finish" — and it must not reach
+  // the IPC bridge to find that out, because there is nothing there to ask.
+  it("has no native callback to recover, and never asks the shell", async () => {
     installBrowser();
     mocks.isTauri = true;
-    let listening!: () => void;
-    const didListen = new Promise<void>((resolve) => {
-      listening = resolve;
-    });
-    let installListener!: (stop: () => void) => void;
-    const listenerInstall = new Promise<() => void>((resolve) => {
-      installListener = resolve;
-    });
-    const stopListening = vi.fn();
-    mocks.onOpenUrl.mockImplementation(() => {
-      listening();
-      return listenerInstall;
-    });
-    mocks.getCurrent.mockResolvedValue(null);
-    mocks.invoke.mockImplementation(async (command: string) => {
-      if (command === "oauth_callback_transport") return "mobile";
-      if (command === "oauth_mobile_pending") {
-        return {
-          provider: "google",
-          associate: true,
-          phase: "armed",
-          state: STATE,
-        };
-      }
-      if (command === "oauth_mobile_resume") return { status: "ignored" };
-      if (command === "oauth_mobile_cancel") return undefined;
-      throw new Error(`unexpected command: ${command}`);
-    });
-    const [{ recoverMobileOAuth }, { setToken }] = await Promise.all([
+    mocks.invoke.mockRejectedValue(new Error("no such command"));
+    const { recoverMobileOAuth } = await import("./transport");
+
+    await expect(recoverMobileOAuth()).resolves.toBeNull();
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    expect(mocks.onOpenUrl).not.toHaveBeenCalled();
+    expect(mocks.getCurrent).not.toHaveBeenCalled();
+  });
+
+  // The login screen already hides the affordance (`socialProviders()` answers
+  // all-unconfigured without a transport). This is the second refusal, for any
+  // caller reaching the API directly: fail before a popup that cannot come back
+  // to `tauri://localhost` is opened at all.
+  it("refuses to start a flow inside a packaged shell, without opening a popup", async () => {
+    const open = vi.fn(() => null);
+    installBrowser(open);
+    mocks.isTauri = true;
+    const [{ captureOAuthCode }, { setToken }] = await Promise.all([
       import("./transport"),
       import("../api/http"),
     ]);
-    setToken("account-a");
+    setToken(null);
+    const buildStart = vi.fn(async (redirectUri: string) =>
+      startResponse(redirectUri),
+    );
 
-    const recovery = recoverMobileOAuth();
-    await didListen;
-    setToken("account-b");
-    installListener(stopListening);
-
-    await expect(recovery).resolves.toBeNull();
-    expect(stopListening).toHaveBeenCalledOnce();
-    expect(mocks.invoke).toHaveBeenCalledWith("oauth_mobile_cancel", {
-      args: { state: STATE },
-    });
+    await expect(
+      captureOAuthCode("google", false, buildStart),
+    ).rejects.toThrow(/not available in the free2z app/i);
+    expect(open).not.toHaveBeenCalled();
+    expect(buildStart).not.toHaveBeenCalled();
+    expect(mocks.invoke).not.toHaveBeenCalled();
   });
 
   it("rejects a token change while completion is awaiting backend work", async () => {

--- a/wallet/free2z/src/lib/oauth/transport.ts
+++ b/wallet/free2z/src/lib/oauth/transport.ts
@@ -1,9 +1,31 @@
-// OAuth authorization-code callback transports. Desktop keeps RFC 8252
-// loopback; iOS/Android use the canonical private-use callback registered by
-// tauri-plugin-deep-link; plain web uses a same-origin popup.
+// OAuth authorization-code callback transport for the content surface.
+//
+// There is exactly one: a same-origin web popup. ZUULI's two native transports
+// — the RFC 8252 loopback listener and the private-use deep-link relay — are
+// deliberately absent here, and so are the ten `oauth_*` commands they call.
+//
+// WHY THEY ARE ABSENT (#918). Porting them was the alternative, and it is not a
+// small privilege question dressed up as a big one. `oauth_loopback_wait`,
+// `oauth_mobile_claim` and `oauth_mobile_resume` each RETURN an authorization
+// code — and, on mobile, the PKCE verifier minted for it — to whatever called
+// them. That pair is a sign-in credential: anything holding it can complete the
+// exchange and take the account. Registering them here would put that credential
+// behind an `invoke()` in the one process of the three-app split that renders
+// third-party markup, remote media and a livestream SDK, and #367 is the defect
+// that makes "whatever called them" undecidable: Wry injects Tauri's bridge into
+// every frame and its Android IPC reports the top-level URL as the origin, so a
+// remote subframe resolves as the trusted main window. A capability file cannot
+// separate the two callers, because there is only one window label. The only
+// durable answer is that the command does not exist, so the code was deleted
+// rather than gated — `wallet/zuuli/scripts/surface-capability-authority.mjs`
+// now fails this tree if `@tauri-apps/api/core` is imported at all.
+//
+// The consequence is honest and closed: in a packaged build this app offers no
+// social sign-in, rather than offering a button that cannot finish. Password and
+// already-linked accounts are unaffected. Bringing it back is a bridge grant
+// issued by the wallet authority (#905), not an invoke handler here.
 
 import {
-  getToken,
   getTokenSnapshot,
   onTokenChange,
   type TokenSnapshot,
@@ -11,11 +33,8 @@ import {
 import type { SocialProvider } from "../api/types";
 import { isTauri } from "../platform";
 import {
-  MOBILE_REDIRECT_URI,
   assertSessionBinding,
   buildSessionBinding,
-  canResumeMobileOAuth,
-  generatePkcePair,
   validateAuthorizationStart,
   type OAuthStartResponse,
 } from "./protocol";
@@ -34,43 +53,15 @@ export interface OAuthCapture {
   transport: OAuthCallbackTransport;
 }
 
-interface LoopbackStart {
-  port: number;
-  redirectPath: string;
-}
-
-interface LoopbackResult {
-  code: string;
-  state: string;
-}
-
-interface MobilePendingSummary {
-  provider: SocialProvider;
-  associate: boolean;
-  phase: "armed" | "received";
-  state: string;
-}
-
-type NativeOAuthCapture = Omit<
-  OAuthCapture,
-  "sessionBinding" | "sessionGeneration" | "transport"
->;
-
-type MobileClaimResult =
-  | { status: "ignored" }
-  | { status: "captured"; capture: NativeOAuthCapture }
-  | { status: "rejected" | "cancelled"; message: string };
-
-async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
-  const { invoke: tauriInvoke } = await import("@tauri-apps/api/core");
-  return tauriInvoke<T>(cmd, args);
-}
-
 const POPUP_POLL_MS = 350;
 const OAUTH_TIMEOUT_MS = 10 * 60 * 1_000;
 const POPUP_FEATURES = "width=480,height=680,noopener=no,noreferrer=no";
 
 const SESSION_CHANGED = "Your account session changed while the provider was open. Start again.";
+
+/** Said when a caller reaches a transport this surface does not have. */
+export const SOCIAL_SIGN_IN_UNAVAILABLE =
+  "Social sign-in is not available in the free2z app yet. Sign in with your free2z username and password, or continue at free2z.cash in a browser.";
 
 function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
   if (signal.aborted) return Promise.reject(new Error(SESSION_CHANGED));
@@ -145,255 +136,20 @@ export function assertOAuthResultCurrent(sessionGeneration: number): void {
   if (getTokenSnapshot().generation !== sessionGeneration) throw sessionChanged();
 }
 
-let transportKind: Promise<"desktop" | "mobile"> | null = null;
-async function nativeTransport(): Promise<"desktop" | "mobile"> {
-  transportKind ??= invoke<"desktop" | "mobile">("oauth_callback_transport").catch(
-    (error) => {
-      transportKind = null;
-      throw error;
-    },
-  );
-  return transportKind;
-}
-
-export type OAuthCallbackTransport = "web" | "desktop" | "mobile";
+export type OAuthCallbackTransport = "web" | "unavailable";
 
 /**
- * Resolve the callback transport from the native command rather than from a
- * user agent or the presence of Tauri alone. Provider discovery uses the same
- * decision as the actual OAuth flow, so desktop never consumes mobile rollout
- * readiness and mobile never falls back to desktop credential truth.
+ * Resolve the callback transport for this surface.
+ *
+ * Deliberately NOT derived from a native command: this app registers none. A
+ * plain browser gets the same-origin popup. A packaged Tauri shell gets
+ * `"unavailable"` — its document origin is `tauri://localhost`, which is not a
+ * registered redirect URI at any provider and never will be, so there is no
+ * transport rather than a broken one. Provider discovery reads this so the
+ * login screen never advertises a method it cannot finish.
  */
 export async function oauthCallbackTransport(): Promise<OAuthCallbackTransport> {
-  return isTauri() ? nativeTransport() : "web";
-}
-
-/**
- * True only for a Tauri iOS/Android shell, never plain web or desktop.
- * Derived from `oauthCallbackTransport` so the checkout return bridge and the
- * OAuth flow can never disagree about what "mobile" means.
- */
-export async function isMobileTauri(): Promise<boolean> {
-  return (await oauthCallbackTransport()) === "mobile";
-}
-
-async function runDesktopLoopback(
-  provider: SocialProvider,
-  associate: boolean,
-  sessionBinding: string,
-  sessionGeneration: number,
-  signal: AbortSignal,
-  buildStart: (redirectUri: string) => Promise<OAuthStartResponse>,
-): Promise<OAuthCapture> {
-  let redirectPath: string | undefined;
-  try {
-    // The native start is local and fast. Await it directly so that, if abort
-    // races its resolution, we still retain the flow id needed to cancel it.
-    const loopback = await invoke<LoopbackStart>("oauth_loopback_start");
-    redirectPath = loopback.redirectPath;
-    if (signal.aborted) throw sessionChanged();
-    const redirectUri = `http://127.0.0.1:${loopback.port}/${loopback.redirectPath}`;
-    const start = await abortable(buildStart(redirectUri), signal);
-    const authorizeUrl = validateAuthorizationStart(provider, start, redirectUri, false);
-    const { openUrl } = await import("@tauri-apps/plugin-opener");
-    if (signal.aborted) throw sessionChanged();
-    await abortable(openUrl(authorizeUrl), signal);
-    if (signal.aborted) throw sessionChanged();
-    const result = await abortable(
-      invoke<LoopbackResult>("oauth_loopback_wait", {
-        expectedState: start.state,
-        redirectPath: loopback.redirectPath,
-      }),
-      signal,
-    );
-    if (signal.aborted) throw sessionChanged();
-    return {
-      provider,
-      associate,
-      code: result.code,
-      state: result.state,
-      redirectUri,
-      sessionBinding,
-      sessionGeneration,
-      transport: "desktop",
-    };
-  } catch (error) {
-    if (redirectPath) {
-      await invoke<void>("oauth_loopback_cancel", { redirectPath }).catch(() => undefined);
-    }
-    throw error;
-  }
-}
-
-function settleMobileResult(
-  result: MobileClaimResult,
-  resolve: (capture: NativeOAuthCapture) => void,
-  reject: (error: Error) => void,
-): boolean {
-  if (result.status === "captured") {
-    resolve(result.capture);
-    return true;
-  }
-  if (result.status === "rejected" || result.status === "cancelled") {
-    reject(new Error(result.message));
-    return true;
-  }
-  return false;
-}
-
-async function waitForMobileCallback(
-  associate: boolean,
-  expectedState: string,
-  signal?: AbortSignal,
-): Promise<NativeOAuthCapture> {
-  const { getCurrent, onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
-  let finished = false;
-  let unlisten: (() => void) | undefined;
-  let timer: number | undefined;
-
-  const promise = new Promise<NativeOAuthCapture>((resolve, reject) => {
-    const finishResolve = (capture: NativeOAuthCapture) => {
-      if (finished) return;
-      finished = true;
-      if (timer !== undefined) window.clearTimeout(timer);
-      unlisten?.();
-      signal?.removeEventListener("abort", abort);
-      resolve(capture);
-    };
-    const finishReject = (error: Error) => {
-      if (finished) return;
-      finished = true;
-      if (timer !== undefined) window.clearTimeout(timer);
-      unlisten?.();
-      signal?.removeEventListener("abort", abort);
-      reject(error);
-    };
-    const abort = () => finishReject(new Error("Sign-in was cancelled."));
-    if (signal?.aborted) {
-      abort();
-      return;
-    }
-    signal?.addEventListener("abort", abort, { once: true });
-    const processUrls = async (urls: string[]) => {
-      for (const callbackUrl of urls) {
-        if (finished) return;
-        try {
-          // Re-read the session at delivery time. Using only the binding from
-          // start would let a sign-out/account switch while Safari/Chrome is
-          // open associate the returning identity with the wrong account.
-          const currentBinding = await buildSessionBinding(associate, getToken());
-          if (finished) return;
-          const result = await invoke<MobileClaimResult>("oauth_mobile_claim", {
-            args: { callbackUrl, sessionBinding: currentBinding, expectedState },
-          });
-          if (settleMobileResult(result, finishResolve, finishReject)) return;
-        } catch (error) {
-          await invoke<void>("oauth_mobile_cancel", {
-            args: { state: expectedState },
-          }).catch(() => undefined);
-          finishReject(error instanceof Error ? error : new Error(String(error)));
-          return;
-        }
-      }
-    };
-
-    void onOpenUrl((urls) => void processUrls(urls))
-      .then((stop) => {
-        if (finished) {
-          stop();
-          return null;
-        }
-        unlisten = stop;
-        return getCurrent();
-      })
-      .then((urls) => {
-        if (urls) void processUrls(urls);
-      })
-      .catch((error) =>
-        finishReject(error instanceof Error ? error : new Error(String(error))),
-      );
-
-    timer = window.setTimeout(() => {
-      void invoke<void>("oauth_mobile_cancel", { args: { state: expectedState } }).finally(() =>
-        finishReject(new Error("Timed out waiting for the OAuth redirect.")),
-      );
-    }, OAUTH_TIMEOUT_MS);
-  });
-  return promise;
-}
-
-async function runMobileDeepLink(
-  provider: SocialProvider,
-  associate: boolean,
-  sessionBinding: string,
-  sessionGeneration: number,
-  outerSignal: AbortSignal,
-  buildStart: (
-    redirectUri: string,
-    codeChallenge?: string,
-  ) => Promise<OAuthStartResponse>,
-): Promise<OAuthCapture> {
-  const pkce = await abortable(generatePkcePair(), outerSignal);
-  const start = await abortable(
-    buildStart(MOBILE_REDIRECT_URI, pkce.challenge),
-    outerSignal,
-  );
-  const authorizeUrl = validateAuthorizationStart(
-    provider,
-    start,
-    MOBILE_REDIRECT_URI,
-    true,
-    pkce.challenge,
-  );
-  if (outerSignal.aborted) throw sessionChanged();
-  // Await the local arm command directly: if cancellation races the command,
-  // we must know that the persisted record exists before returning/rejecting.
-  await invoke<void>("oauth_mobile_arm", {
-    args: {
-      provider,
-      state: start.state,
-      associate,
-      sessionBinding,
-      codeVerifier: pkce.verifier,
-    },
-  });
-  if (outerSignal.aborted) {
-    await invoke<void>("oauth_mobile_cancel", {
-      args: { state: start.state },
-    }).catch(() => undefined);
-    throw sessionChanged();
-  }
-  recoveryController?.abort();
-  recoveryController = null;
-  const controller = new AbortController();
-  const abortFromSessionChange = () => controller.abort();
-  outerSignal.addEventListener("abort", abortFromSessionChange, { once: true });
-  if (outerSignal.aborted) controller.abort();
-  const callback = waitForMobileCallback(associate, start.state, controller.signal);
-  // Observe listener/setup failures immediately; the original promise is
-  // still awaited below so the caller receives the same rejection.
-  void callback.catch(() => undefined);
-  try {
-    const { openUrl } = await import("@tauri-apps/plugin-opener");
-    if (outerSignal.aborted) throw sessionChanged();
-    await abortable(openUrl(authorizeUrl), outerSignal);
-    if (outerSignal.aborted) throw sessionChanged();
-    return {
-      ...(await callback),
-      sessionBinding,
-      sessionGeneration,
-      transport: "mobile",
-    };
-  } catch (error) {
-    controller.abort();
-    await invoke<void>("oauth_mobile_cancel", {
-      args: { state: start.state },
-    }).catch(() => undefined);
-    await callback.catch(() => undefined);
-    throw error;
-  } finally {
-    outerSignal.removeEventListener("abort", abortFromSessionChange);
-  }
+  return isTauri() ? "unavailable" : "web";
 }
 
 function runWebPopup(
@@ -407,7 +163,7 @@ function runWebPopup(
 ): Promise<OAuthCapture> {
   const authorizeUrl = validateAuthorizationStart(provider, start, redirectUri, false);
   return new Promise((resolve, reject) => {
-    const popup = window.open(authorizeUrl, "zuuli-oauth", POPUP_FEATURES);
+    const popup = window.open(authorizeUrl, "free2z-oauth", POPUP_FEATURES);
     if (!popup) {
       reject(new Error("The sign-in popup was blocked. Allow popups and try again."));
       return;
@@ -499,30 +255,15 @@ export async function captureOAuthCode(
     lease.assertCurrent();
     const transport = await abortable(oauthCallbackTransport(), lease.signal);
     lease.assertCurrent();
-    if (transport !== "web") {
-      // `return await` is intentional: a bare returned promise executes this
-      // function's finally immediately and silently removes the session watch.
-      return await (transport === "mobile"
-        ? runMobileDeepLink(
-            provider,
-            associate,
-            sessionBinding,
-            lease.generation,
-            lease.signal,
-            buildStart,
-          )
-        : runDesktopLoopback(
-            provider,
-            associate,
-            sessionBinding,
-            lease.generation,
-            lease.signal,
-            buildStart,
-          ));
-    }
+    // Fail closed rather than opening a popup that cannot come back. The login
+    // screen already hides the affordance; this is the second, load-bearing
+    // refusal for any caller that reaches the API directly.
+    if (transport !== "web") throw new Error(SOCIAL_SIGN_IN_UNAVAILABLE);
     const redirectUri = window.location.origin;
     const start = await abortable(buildStart(redirectUri), lease.signal);
     lease.assertCurrent();
+    // `return await` is intentional: a bare returned promise executes this
+    // function's finally immediately and silently removes the session watch.
     return await runWebPopup(
       provider,
       associate,
@@ -537,96 +278,27 @@ export async function captureOAuthCode(
   }
 }
 
-let recovery: Promise<OAuthCapture | null> | null = null;
-let recoveryController: AbortController | null = null;
-
-/** Recover a received cold-start callback (or claim getCurrent()) once. */
+/**
+ * There is no native callback for this surface to recover.
+ *
+ * ZUULI's version invokes `oauth_mobile_pending` / `_resume` / `_cancel`, which
+ * do not exist in this binary — and must not, because `_resume` returns an
+ * authorization code and its PKCE verifier to the renderer (#367, #918). Before
+ * #918 this rejected on every launch of a packaged build, and `App.tsx` calls it
+ * unconditionally on mount behind a `.catch` that toasts "Couldn't finish
+ * sign-in", so the first thing a user saw was a sign-in failure they had not
+ * asked for.
+ *
+ * It resolves `null` — "nothing to finish" — rather than being deleted, so the
+ * one mount-time call site stays put for the day a native return arrives as a
+ * wallet-authority bridge grant (#905).
+ */
 export function recoverMobileOAuth(): Promise<OAuthCapture | null> {
-  recovery ??= (async () => {
-    if (!isTauri() || (await nativeTransport()) !== "mobile") return null;
-    const pending = await invoke<MobilePendingSummary | null>("oauth_mobile_pending");
-    if (!pending) return null;
-    const snapshot = getTokenSnapshot();
-    const token = snapshot.token;
-    if (!canResumeMobileOAuth(pending.associate, token)) {
-      // Session bootstrap may have signed in, signed out, or invalidated a
-      // token while the app was away. Consume the now-impossible flow instead
-      // of throwing on every cold start until its TTL expires.
-      await invoke<void>("oauth_mobile_cancel", {
-        args: { state: pending.state },
-      }).catch(() => undefined);
-      return null;
-    }
-    const sessionBinding = await buildSessionBinding(pending.associate, token);
-    if (!tokenSnapshotIsCurrent(snapshot)) {
-      await invoke<void>("oauth_mobile_cancel", {
-        args: { state: pending.state },
-      }).catch(() => undefined);
-      return null;
-    }
-    const result = await invoke<MobileClaimResult>("oauth_mobile_resume", {
-      args: { sessionBinding, expectedState: pending.state },
-    });
-    if (!tokenSnapshotIsCurrent(snapshot)) {
-      await invoke<void>("oauth_mobile_cancel", {
-        args: { state: pending.state },
-      }).catch(() => undefined);
-      return null;
-    }
-    if (result.status === "ignored" && pending.phase === "armed") {
-      // The app may have been reopened manually while the system browser is
-      // still active. Keep a warm-start listener alive; getCurrent() inside
-      // the waiter also closes the cold-start race.
-      const controller = new AbortController();
-      recoveryController = controller;
-      const stopWatching = onTokenChange(() => controller.abort());
-      if (!tokenSnapshotIsCurrent(snapshot)) controller.abort();
-      try {
-        const capture = await waitForMobileCallback(
-          pending.associate,
-          pending.state,
-          controller.signal,
-        );
-        return {
-          ...capture,
-          sessionBinding,
-          sessionGeneration: snapshot.generation,
-          transport: "mobile",
-        };
-      } catch (error) {
-        await invoke<void>("oauth_mobile_cancel", {
-          args: { state: pending.state },
-        }).catch(() => undefined);
-        if (controller.signal.aborted) return null;
-        throw error;
-      } finally {
-        stopWatching();
-        if (recoveryController === controller) recoveryController = null;
-      }
-    }
-    if (result.status === "captured") {
-      return {
-        ...result.capture,
-        sessionBinding,
-        sessionGeneration: snapshot.generation,
-        transport: "mobile",
-      };
-    }
-    if (result.status === "rejected" || result.status === "cancelled") {
-      throw new Error(result.message);
-    }
-    return null;
-  })();
-  return recovery;
+  return Promise.resolve(null);
 }
 
-export async function finishMobileOAuth(state: string): Promise<void> {
-  if (!isTauri() || (await nativeTransport()) !== "mobile") return;
-  await invoke<void>("oauth_mobile_finish", { args: { state } });
-}
-
-/** Hold the initiating session across native claim, backend exchange, profile
- * read, and the final post-await generation check. */
+/** Hold the initiating session across the backend exchange, profile read, and
+ * the final post-await generation check. */
 export async function withOAuthSession<T>(
   capture: OAuthCapture,
   complete: (lease: OAuthCompletionLease) => Promise<T>,
@@ -645,28 +317,6 @@ export async function withOAuthSession<T>(
     );
     lease.assertCurrent();
 
-    if (capture.transport === "mobile") {
-      const result = await abortable(
-        invoke<MobileClaimResult>("oauth_mobile_resume", {
-          args: { sessionBinding: capture.sessionBinding, expectedState: capture.state },
-        }),
-        lease.signal,
-      );
-      lease.assertCurrent();
-      if (
-        result.status !== "captured" ||
-        result.capture.state !== capture.state ||
-        result.capture.provider !== capture.provider ||
-        result.capture.associate !== capture.associate
-      ) {
-        throw new Error(
-          result.status === "rejected" || result.status === "cancelled"
-            ? result.message
-            : "The mobile sign-in session no longer matches this callback.",
-        );
-      }
-    }
-
     const completed = await complete({
       initiatingToken: verifiedToken,
       sessionGeneration: lease.generation,
@@ -676,19 +326,9 @@ export async function withOAuthSession<T>(
     lease.assertCurrent();
     return completed;
   } catch (error) {
-    if (capture.transport === "mobile") {
-      await invoke<void>("oauth_mobile_cancel", {
-        args: { state: capture.state },
-      }).catch(() => undefined);
-    }
     if (lease.signal.aborted) throw sessionChanged();
     throw error;
   } finally {
     lease.stop();
   }
-}
-
-export async function cancelMobileOAuth(state: string): Promise<void> {
-  if (!isTauri() || (await nativeTransport()) !== "mobile") return;
-  await invoke<void>("oauth_mobile_cancel", { args: { state } });
 }

--- a/wallet/zuuli/scripts/surface-capability-authority.mjs
+++ b/wallet/zuuli/scripts/surface-capability-authority.mjs
@@ -50,15 +50,14 @@ const WALLET_ROOT = path.resolve(
   "../..",
 );
 
-/// Namespaces a capability entry may name at all. Anything outside this set is
-/// a plugin nobody reviewed for these surfaces, so it fails rather than being
-/// judged only against the two forbidden prefixes.
-const REVIEWED_NAMESPACES = new Set([
-  "core",
-  "deep-link",
-  "opener",
-  "f2zmsg",
-]);
+/// Namespaces every delegated surface may name. Anything outside a surface's
+/// own set is a plugin nobody reviewed for it, so it fails rather than being
+/// judged only against the forbidden prefixes.
+///
+/// The set is PER SURFACE, not global: what a content app may reach and what a
+/// messaging app may reach are different questions with different answers, and
+/// a single shared set silently answers both at once the moment either changes.
+const BASE_NAMESPACES = ["core", "deep-link", "opener"];
 
 /// The reviewed contract, per delegated surface.
 export const SURFACES = [
@@ -69,12 +68,46 @@ export const SURFACES = [
     forbiddenCrates: ["tauri-plugin-zcash", "tauri-plugin-f2zmsg"],
     requiredCrates: [],
     namedMessagingPermissions: null,
+    // `http` IS reviewed for this surface, and this comment is the record of
+    // that review (#918).
+    //
+    // WHAT IT IS. `tauri-plugin-http` registers `plugin:http|fetch`: a native
+    // HTTP client that is not subject to browser CORS. The frontend needs it
+    // because the free2z backend whitelists a handful of web origins and
+    // `tauri://localhost` is not one of them, so in a packaged build EVERY API
+    // request and every first-party image download goes through it
+    // (`src/lib/api/http.ts`, `src/components/common/RemoteMedia.tsx`).
+    //
+    // WHY IT IS NOT THE SAME KIND OF THING AS `zcash`/`f2zmsg`. Those export
+    // authority the process holds locally — a seed, device keys — so a caller
+    // reaching them gains something it could not otherwise have. This one
+    // exports no local authority at all; its entire reach is the URL scope
+    // below. A hostile subframe that reaches it can talk to free2z's own API,
+    // which is a thing it can already do from a page it controls.
+    //
+    // WHAT THE REVIEW ACTUALLY DECIDED, and what `scopedNamespaces` enforces:
+    // an `http` grant on this surface must be a SCOPED object with a non-empty
+    // allow list, every entry `https://<host>/*`, and every host already
+    // admitted by this app's own `connect-src`. A bare `"http:default"` fails —
+    // which matters even though an empty allow list denies every URL, because
+    // "the identifier alone is inert" is a property of today's plugin, and the
+    // reviewable statement is which origins this client may reach.
+    reviewedNamespaces: [...BASE_NAMESPACES, "http"],
+    scopedNamespaces: ["http"],
     // The content surface's CSP is the one that must eventually relax to admit
     // embeds and the RealtimeKit SDK (#816/#818). It starts closed, and the
     // relaxation is a reviewed change — but it is NOT asserted here, because a
     // CSP is not what makes this surface safe. Having no privileged command to
     // reach is.
     requireFrameSrcNone: false,
+    // The load-bearing one. This process renders third-party markup, remote
+    // media and a livestream SDK, and #367 means a remote subframe resolves as
+    // the trusted main window — so the only durable answer is that there is no
+    // app command in it to reach. A capability file cannot express that: it
+    // scopes by window label, and there is one label. The crate must register
+    // no `invoke_handler`, and the frontend must not even import the function
+    // that would call one.
+    registersCommands: false,
   },
   {
     directory: "e2e2z",
@@ -83,13 +116,18 @@ export const SURFACES = [
     forbiddenCrates: ["tauri-plugin-zcash"],
     requiredCrates: ["tauri-plugin-f2zmsg"],
     namedMessagingPermissions: REVIEWED_MOBILE_F2ZMSG_PERMISSIONS,
+    reviewedNamespaces: [...BASE_NAMESPACES, "f2zmsg"],
+    scopedNamespaces: [],
     // The messaging surface renders no remote content and does hold privileged
     // commands, so it is held to the same rule ZUULI's privileged webview is.
     requireFrameSrcNone: true,
+    // It registers `e2e2z_device_credential_keys`, and its own crate test holds
+    // the handler to that one command.
+    registersCommands: true,
   },
 ];
 
-function capabilityIdentifiers(capability, file) {
+function capabilityPermissions(capability, file) {
   if (!Array.isArray(capability?.permissions)) {
     throw new Error(`${file}: capability permissions must be an array`);
   }
@@ -99,8 +137,58 @@ function capabilityIdentifiers(capability, file) {
     if (typeof identifier !== "string" || identifier.length === 0) {
       throw new Error(`${file}: every permission must have an identifier`);
     }
-    return identifier;
+    return { identifier, entry: permission };
   });
+}
+
+/// A scoped URL entry: exactly `https://<host>/*`, where `<host>` may lead with
+/// one `*.` label. Anything else — a scheme wildcard, a bare `*` host, a port,
+/// userinfo, a query, a fixed path — is refused rather than reasoned about,
+/// because the reviewable statement is "this client may reach these origins".
+const SCOPED_URL = /^https:\/\/(\*\.)?([a-z0-9-]+(?:\.[a-z0-9-]+)+)\/\*$/;
+
+/// Hold a scoped namespace to a non-empty allow list of origins the app's own
+/// `connect-src` already admits. The CSP is not what makes the surface safe,
+/// but it IS the reviewed statement of where this app talks, and a native
+/// client that can reach further than the document can is a second, unreviewed
+/// network boundary.
+function scopedEntryFailures(surface, file, identifier, entry, connectSources) {
+  const label = `wallet/${surface.directory}`;
+  const failures = [];
+  if (typeof entry === "string") {
+    failures.push(
+      `${file}: ${identifier} must be a scoped object with an allow list, not a bare string; ` +
+        `an unscoped ${namespaceOf(identifier)} grant on ${label} is a grant nobody reviewed`,
+    );
+    return failures;
+  }
+  const allow = entry?.allow;
+  if (!Array.isArray(allow) || allow.length === 0) {
+    failures.push(`${file}: ${identifier} must carry a non-empty allow list`);
+    return failures;
+  }
+  for (const item of allow) {
+    const url = typeof item === "string" ? item : item?.url;
+    if (typeof url !== "string") {
+      failures.push(`${file}: ${identifier} allow entries must each name a url`);
+      continue;
+    }
+    const match = SCOPED_URL.exec(url);
+    if (!match) {
+      failures.push(
+        `${file}: ${identifier} may only allow \`https://<host>/*\` — found ${url}`,
+      );
+      continue;
+    }
+    const origin = `https://${match[1] ?? ""}${match[2]}`;
+    if (connectSources && !connectSources.includes(origin)) {
+      failures.push(
+        `${file}: ${identifier} allows ${url}, which ${label}'s connect-src does not admit; ` +
+          "the native client must not reach further than the document",
+      );
+    }
+  }
+  return failures;
 }
 
 function namespaceOf(identifier) {
@@ -121,23 +209,30 @@ function cspDirective(csp, name) {
 /// `capabilities` is a `Map` of relative file path -> parsed capability object,
 /// and must be the COMPLETE set the app ships; the live reader enumerates the
 /// directory so that stays true.
-export function surfaceFailures(surface, { capabilities, manifest, tauriConfig }) {
+export function surfaceFailures(
+  surface,
+  { capabilities, manifest, tauriConfig, packageJson, entrypoint, sources },
+) {
   const failures = [];
   const label = `wallet/${surface.directory}`;
+  const csp = tauriConfig?.app?.security?.csp;
+  const connectSources =
+    typeof csp === "string" ? cspDirective(csp, "connect-src") : null;
 
   if (capabilities.size === 0) {
     failures.push(`${label}: no capability file was read; this check has gone blind`);
   }
 
   for (const [file, capability] of capabilities) {
-    let identifiers;
+    let permissions;
     try {
-      identifiers = capabilityIdentifiers(capability, file);
+      permissions = capabilityPermissions(capability, file);
     } catch (error) {
       failures.push(error.message);
       continue;
     }
-    for (const identifier of identifiers) {
+    const identifiers = permissions.map((permission) => permission.identifier);
+    for (const { identifier, entry } of permissions) {
       const namespace = namespaceOf(identifier);
       if (surface.forbiddenNamespaces.includes(namespace)) {
         failures.push(
@@ -145,9 +240,15 @@ export function surfaceFailures(surface, { capabilities, manifest, tauriConfig }
         );
         continue;
       }
-      if (!REVIEWED_NAMESPACES.has(namespace)) {
+      if (!surface.reviewedNamespaces.includes(namespace)) {
         failures.push(
-          `${file}: ${identifier} is outside the reviewed namespaces for ${label} (${[...REVIEWED_NAMESPACES].sort().join(", ")})`,
+          `${file}: ${identifier} is outside the reviewed namespaces for ${label} (${[...surface.reviewedNamespaces].sort().join(", ")})`,
+        );
+        continue;
+      }
+      if (surface.scopedNamespaces.includes(namespace)) {
+        failures.push(
+          ...scopedEntryFailures(surface, file, identifier, entry, connectSources),
         );
       }
     }
@@ -196,7 +297,6 @@ export function surfaceFailures(surface, { capabilities, manifest, tauriConfig }
       `${label}/src-tauri/tauri.conf.json: identifier must be ${surface.identifier}, got ${JSON.stringify(tauriConfig?.identifier)}`,
     );
   }
-  const csp = tauriConfig?.app?.security?.csp;
   if (typeof csp !== "string") {
     failures.push(`${label}/src-tauri/tauri.conf.json: packaged CSP must be a string`);
   } else if (surface.requireFrameSrcNone) {
@@ -205,6 +305,190 @@ export function surfaceFailures(surface, { capabilities, manifest, tauriConfig }
       failures.push(
         `${label}/src-tauri/tauri.conf.json: a privileged native WebView must declare frame-src 'none'`,
       );
+    }
+  }
+
+  failures.push(
+    ...nativeContractFailures(surface, {
+      manifest,
+      tauriConfig,
+      packageJson,
+      entrypoint,
+      sources,
+    }),
+  );
+
+  return failures;
+}
+
+// ---------------------------------------------------------------------------
+// The JS -> native contract.
+//
+// #918 is what happens when nobody checks it. #912 ported three frontend paths
+// that branch on `isTauri() && !DEV` and never wrote the Rust side they call
+// into, and no gate could see it: vitest, Playwright and `npm run build` all
+// run where `isTauri()` is false or DEV is true — exactly the branch NOT taken
+// — and `cargo check` compiles a backend nobody asked whether the frontend
+// expects commands from it. So the two halves are compared here, off the files.
+// ---------------------------------------------------------------------------
+
+/// `@tauri-apps/plugin-deep-link` -> `tauri_plugin_deep_link`.
+function crateModule(plugin) {
+  return `tauri_plugin_${plugin.replaceAll("-", "_")}`;
+}
+
+/// The `tauri::Builder` chain itself, so a doc comment or a crate test that
+/// mentions `invoke_handler` is not mistaken for one.
+function builderBody(entrypoint) {
+  return entrypoint.split("pub fn run() {")[1]?.split("\n}")[0] ?? "";
+}
+
+/// Command names the crate registers, read out of `generate_handler![...]`.
+/// An absent `invoke_handler` is an empty set, which is the point for free2z.
+function registeredCommands(entrypoint) {
+  const list = builderBody(entrypoint)
+    .split("invoke_handler(tauri::generate_handler![")
+    .slice(1)
+    .flatMap((rest) => rest.split("])")[0].split(","));
+  return new Set(
+    list
+      .map((name) => name.trim().split("::").pop())
+      .filter((name) => /^[a-z_][a-z0-9_]*$/.test(name)),
+  );
+}
+
+/// Every `invoke("literal")` in production sources. A command built from a
+/// variable is out of reach of a text check and is left to the surface's own
+/// contract tests; a literal is the shape that actually drifted (#918).
+const INVOKE_LITERAL = /\binvoke\s*(?:<[^<>]*>)?\s*\(\s*["'`]([^"'`\n]+)["'`]/g;
+
+/// Any private-use URI belonging to one of the three apps in the split.
+const APP_SCHEME_URI = /\b(cash\.free2z\.[a-z0-9]+):\/\/([a-z0-9.-]*)(\/[A-Za-z0-9/_%-]*)?/g;
+
+function deepLinkRoutes(tauriConfig) {
+  const routes = new Set();
+  const mobile = tauriConfig?.plugins?.["deep-link"]?.mobile;
+  if (!Array.isArray(mobile)) return routes;
+  for (const entry of mobile) {
+    const schemes = Array.isArray(entry?.scheme) ? entry.scheme : [entry?.scheme];
+    const paths = Array.isArray(entry?.path) ? entry.path : [entry?.path];
+    for (const scheme of schemes) {
+      for (const routePath of paths) {
+        if (typeof scheme !== "string" || typeof entry?.host !== "string") continue;
+        routes.add(`${scheme}://${entry.host}${routePath ?? ""}`);
+      }
+    }
+  }
+  return routes;
+}
+
+export function nativeContractFailures(
+  surface,
+  { manifest, tauriConfig, packageJson, entrypoint, sources },
+) {
+  const failures = [];
+  const label = `wallet/${surface.directory}`;
+  const dependencies = packageJson?.dependencies ?? {};
+
+  if (!sources || sources.size === 0) {
+    failures.push(
+      `${label}/src: no production source was read; the JS -> native contract check has gone blind`,
+    );
+  }
+  if (!entrypoint) {
+    failures.push(`${label}/src-tauri/src/lib.rs: was not read; this check has gone blind`);
+    return failures;
+  }
+
+  // 1. A JS plugin package with no crate is a command that does not exist.
+  //    `@tauri-apps/plugin-http` sat in free2z's package.json for two releases
+  //    with no `tauri-plugin-http` behind it, so every API request in a
+  //    packaged build invoked `plugin:http|fetch` into an empty handler.
+  for (const dependency of Object.keys(dependencies)) {
+    const plugin = dependency.startsWith("@tauri-apps/plugin-")
+      ? dependency.slice("@tauri-apps/plugin-".length)
+      : null;
+    if (!plugin) continue;
+    if (!manifest.includes(`\ntauri-plugin-${plugin} =`)) {
+      failures.push(
+        `${label}/src-tauri/Cargo.toml: package.json depends on ${dependency} but the crate ` +
+          `tauri-plugin-${plugin} is not linked; its commands do not exist in this binary`,
+      );
+      continue;
+    }
+    if (!builderBody(entrypoint).includes(`${crateModule(plugin)}::init()`)) {
+      failures.push(
+        `${label}/src-tauri/src/lib.rs: tauri-plugin-${plugin} is linked but never initialized; ` +
+          "a linked plugin registers nothing until .plugin(...) runs",
+      );
+    }
+  }
+
+  // 2. No production source may invoke a command this binary does not register.
+  const commands = registeredCommands(entrypoint);
+  for (const [file, source] of sources) {
+    for (const [, command] of source.matchAll(INVOKE_LITERAL)) {
+      if (command.startsWith("plugin:")) {
+        const plugin = command.slice("plugin:".length).split("|")[0];
+        if (!manifest.includes(`\ntauri-plugin-${plugin} =`)) {
+          failures.push(
+            `${file}: invokes ${command}, but ${label} does not link tauri-plugin-${plugin}`,
+          );
+        }
+        continue;
+      }
+      if (!commands.has(command)) {
+        failures.push(
+          `${file}: invokes "${command}", which ${label}'s invoke handler does not register`,
+        );
+      }
+    }
+  }
+
+  // 3. A surface that registers no command must not hold the function that
+  //    would call one. This is the stronger form of rule 2 and the one that
+  //    actually fires: it does not depend on a command name being spelled as a
+  //    literal, and it makes "there is nothing to reach" mechanical rather than
+  //    a claim in a comment.
+  if (!surface.registersCommands) {
+    if (builderBody(entrypoint).includes("invoke_handler")) {
+      failures.push(
+        `${label}/src-tauri/src/lib.rs: must register no invoke_handler; ` +
+          "#367 means a remote subframe in this process resolves as the trusted main window",
+      );
+    }
+    for (const [file, source] of sources) {
+      if (/["']@tauri-apps\/api\/core["']/.test(source)) {
+        failures.push(
+          `${file}: imports @tauri-apps/api/core, but ${label} registers no command to invoke`,
+        );
+      }
+    }
+  }
+
+  // 4. A private-use URI in this tree must be THIS app's, and must be a route
+  //    this app's manifest actually registers. Getting this wrong is the worst
+  //    of #918's three defects: the other two fail closed and loudly, while a
+  //    `cash.free2z.zuuli://` URI in the content app hands an OAuth code or a
+  //    Stripe claim code to the wallet-authority app on any device with both
+  //    installed.
+  const routes = deepLinkRoutes(tauriConfig);
+  for (const [file, source] of sources) {
+    for (const [, scheme, host, routePath] of source.matchAll(APP_SCHEME_URI)) {
+      if (scheme !== surface.identifier) {
+        failures.push(
+          `${file}: names ${scheme}://${host}${routePath ?? ""}, which belongs to another app; ` +
+            `${label} must use ${surface.identifier}://`,
+        );
+        continue;
+      }
+      const route = `${scheme}://${host}${routePath ?? ""}`;
+      if (!routes.has(route)) {
+        failures.push(
+          `${file}: ${route} is not registered in ${label}/src-tauri/tauri.conf.json ` +
+            "(plugins.deep-link), so the OS would never deliver it here",
+        );
+      }
     }
   }
 
@@ -225,11 +509,52 @@ export function readSurface(surface, walletRoot = WALLET_ROOT) {
       JSON.parse(readFileSync(path.join(capabilityDirectory, entry.name), "utf8")),
     );
   }
+  const project = path.join(walletRoot, surface.directory);
   return {
     capabilities,
     manifest: readFileSync(path.join(root, "Cargo.toml"), "utf8"),
     tauriConfig: JSON.parse(readFileSync(path.join(root, "tauri.conf.json"), "utf8")),
+    packageJson: JSON.parse(readFileSync(path.join(project, "package.json"), "utf8")),
+    entrypoint: readFileSync(path.join(root, "src", "lib.rs"), "utf8"),
+    sources: readProductionSources(surface, project),
   };
+}
+
+/// Production TypeScript, keyed by repository-relative path.
+///
+/// Tests are excluded on purpose: a test that asserts the wallet app's URI is
+/// refused has to spell that URI, and a test that proves the invoke-parity rule
+/// fires has to spell a command that does not exist.
+function readProductionSources(surface, project) {
+  const sources = new Map();
+  const root = path.join(project, "src");
+  const walk = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true }).sort(
+      (left, right) => left.name.localeCompare(right.name),
+    )) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (!/\.tsx?$/.test(entry.name) || /\.(test|spec)\.tsx?$/.test(entry.name)) {
+        continue;
+      }
+      const relative = path.relative(project, absolute).split(path.sep).join("/");
+      sources.set(
+        `wallet/${surface.directory}/${relative}`,
+        readFileSync(absolute, "utf8"),
+      );
+    }
+  };
+  walk(root);
+  if (sources.size === 0) {
+    throw new Error(
+      `wallet/${surface.directory}/src: no production source was read; this check has gone blind`,
+    );
+  }
+  return sources;
 }
 
 export function assertSurfaceCapabilityAuthority(walletRoot = WALLET_ROOT) {

--- a/wallet/zuuli/scripts/surface-capability-authority.node-test.mjs
+++ b/wallet/zuuli/scripts/surface-capability-authority.node-test.mjs
@@ -22,7 +22,17 @@ function inputs(surface) {
     ),
     manifest: read.manifest,
     tauriConfig: structuredClone(read.tauriConfig),
+    packageJson: structuredClone(read.packageJson),
+    entrypoint: read.entrypoint,
+    sources: new Map(read.sources),
   };
+}
+
+/// Add one fabricated production source to an otherwise shipped tree.
+function withSource(surface, name, source) {
+  const copy = inputs(surface);
+  copy.sources.set(`wallet/${surface.directory}/src/${name}`, source);
+  return copy;
 }
 
 function mutateEveryCapability(surface, mutate) {
@@ -205,6 +215,270 @@ test("an empty capability population is a blindness failure, not a pass", () => 
   assert.ok(
     surfaceFailures(CONTENT, content).some((failure) =>
       failure.includes("this check has gone blind"),
+    ),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// #918: the scoped `http` grant, and the negative control that keeps it honest.
+//
+// `http` is in free2z's reviewed namespaces now. What was reviewed is not the
+// namespace but the SCOPE, so the identifier alone must still fail.
+// ---------------------------------------------------------------------------
+
+test("an unscoped http:default still fails on the content surface", () => {
+  for (const [file, mutated] of mutateEveryCapability(CONTENT, (capability) => {
+    capability.permissions = capability.permissions.filter(
+      (permission) =>
+        typeof permission === "string" || permission.identifier !== "http:default",
+    );
+    capability.permissions.push("http:default");
+    return capability;
+  })) {
+    const failures = surfaceFailures(CONTENT, mutated);
+    assert.ok(
+      failures.some((failure) =>
+        failure.includes("must be a scoped object with an allow list"),
+      ),
+      `${file}: a bare http:default must fail, got ${failures.join("; ") || "(none)"}`,
+    );
+  }
+});
+
+test("a scoped http grant with an empty allow list fails", () => {
+  for (const [, mutated] of mutateEveryCapability(CONTENT, (capability) => {
+    capability.permissions = capability.permissions.map((permission) =>
+      typeof permission !== "string" && permission.identifier === "http:default"
+        ? { identifier: "http:default", allow: [] }
+        : permission,
+    );
+    return capability;
+  })) {
+    assert.ok(
+      surfaceFailures(CONTENT, mutated).some((failure) =>
+        failure.includes("must carry a non-empty allow list"),
+      ),
+    );
+  }
+});
+
+test("a wildcard or non-https http scope entry fails", () => {
+  for (const url of [
+    "*://*",
+    "https://*",
+    "https://*/*",
+    "http://free2z.cash/*",
+    "https://free2z.cash",
+    "https://free2z.cash:8443/*",
+    "https://user@free2z.cash/*",
+  ]) {
+    for (const [, mutated] of mutateEveryCapability(CONTENT, (capability) => {
+      capability.permissions = capability.permissions.map((permission) =>
+        typeof permission !== "string" && permission.identifier === "http:default"
+          ? { identifier: "http:default", allow: [{ url }] }
+          : permission,
+      );
+      return capability;
+    })) {
+      assert.ok(
+        surfaceFailures(CONTENT, mutated).some((failure) =>
+          failure.includes("may only allow"),
+        ),
+        `${url} must be refused as an http scope entry`,
+      );
+    }
+  }
+});
+
+test("an http scope entry the app's own connect-src does not admit fails", () => {
+  for (const [, mutated] of mutateEveryCapability(CONTENT, (capability) => {
+    capability.permissions = capability.permissions.map((permission) =>
+      typeof permission !== "string" && permission.identifier === "http:default"
+        ? {
+            identifier: "http:default",
+            allow: [{ url: "https://free2z.cash/*" }, { url: "https://evil.example/*" }],
+          }
+        : permission,
+    );
+    return capability;
+  })) {
+    assert.ok(
+      surfaceFailures(CONTENT, mutated).some((failure) =>
+        failure.includes("connect-src does not admit"),
+      ),
+    );
+  }
+});
+
+test("reviewing http for the content surface did not review it for the messaging one", () => {
+  for (const [, mutated] of mutateEveryCapability(MESSAGING, (capability) => {
+    capability.permissions.push({
+      identifier: "http:default",
+      allow: [{ url: "https://free2z.cash/*" }],
+    });
+    return capability;
+  })) {
+    assert.ok(
+      surfaceFailures(MESSAGING, mutated).some((failure) =>
+        failure.includes("outside the reviewed namespaces"),
+      ),
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #918: the JS -> native contract. Each of these reproduces one half of what
+// actually shipped in #912 and could not be seen by any gate.
+// ---------------------------------------------------------------------------
+
+test("a @tauri-apps/plugin-* dependency with no crate behind it fails", () => {
+  const content = inputs(CONTENT);
+  content.packageJson.dependencies["@tauri-apps/plugin-http"] = "^2.5.9";
+  content.manifest = content.manifest.replaceAll(
+    "\ntauri-plugin-http =",
+    "\n# tauri-plugin-http =",
+  );
+  assert.ok(
+    surfaceFailures(CONTENT, content).some((failure) =>
+      failure.includes("tauri-plugin-http is not linked"),
+    ),
+  );
+});
+
+test("a linked plugin that is never initialized fails", () => {
+  const content = inputs(CONTENT);
+  content.entrypoint = content.entrypoint.replace(
+    ".plugin(tauri_plugin_http::init())\n        ",
+    "",
+  );
+  assert.ok(
+    surfaceFailures(CONTENT, content).some((failure) =>
+      failure.includes("linked but never initialized"),
+    ),
+  );
+});
+
+test("invoking a command the binary does not register fails", () => {
+  const content = withSource(
+    CONTENT,
+    "fabricated.ts",
+    'const x = await invoke<string>("oauth_callback_transport");\n',
+  );
+  assert.ok(
+    surfaceFailures(CONTENT, content).some((failure) =>
+      failure.includes('invokes "oauth_callback_transport"'),
+    ),
+  );
+});
+
+test("invoking a plugin command whose crate is absent fails", () => {
+  const content = withSource(
+    CONTENT,
+    "fabricated.ts",
+    'await invoke("plugin:zcash|sign_challenge", {});\n',
+  );
+  assert.ok(
+    surfaceFailures(CONTENT, content).some((failure) =>
+      failure.includes("does not link tauri-plugin-zcash"),
+    ),
+  );
+});
+
+test("a command name that IS registered passes, so the rule is not blanket", () => {
+  const messaging = withSource(
+    MESSAGING,
+    "fabricated.ts",
+    'await invoke("e2e2z_device_credential_keys");\n',
+  );
+  assert.deepEqual(surfaceFailures(MESSAGING, messaging), []);
+});
+
+test("the content surface must not even import the invoke function", () => {
+  const content = withSource(
+    CONTENT,
+    "fabricated.ts",
+    'import { invoke } from "@tauri-apps/api/core";\nexport default invoke;\n',
+  );
+  assert.ok(
+    surfaceFailures(CONTENT, content).some((failure) =>
+      failure.includes("imports @tauri-apps/api/core"),
+    ),
+  );
+});
+
+test("an invoke_handler on the content surface fails", () => {
+  const content = inputs(CONTENT);
+  content.entrypoint = content.entrypoint.replace(
+    ".run(tauri::generate_context!())",
+    ".invoke_handler(tauri::generate_handler![something])\n        .run(tauri::generate_context!())",
+  );
+  assert.ok(
+    surfaceFailures(CONTENT, content).some((failure) =>
+      failure.includes("must register no invoke_handler"),
+    ),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// #918's most serious defect: a private-use URI belonging to another app.
+// The other two gaps fail closed and loudly; this one delivers a secret to the
+// wrong process on any device carrying both apps.
+// ---------------------------------------------------------------------------
+
+test("a URI in another app's scheme fails", () => {
+  for (const uri of [
+    "cash.free2z.zuuli://oauth/callback",
+    "cash.free2z.zuuli://checkout/return",
+    "cash.free2z.e2e2z://bridge/return",
+  ]) {
+    const content = withSource(
+      CONTENT,
+      "fabricated.ts",
+      `export const RETURN_URI = "${uri}";\n`,
+    );
+    assert.ok(
+      surfaceFailures(CONTENT, content).some((failure) =>
+        failure.includes("belongs to another app"),
+      ),
+      `${uri} must be refused in the content surface`,
+    );
+  }
+});
+
+test("this app's own scheme on an unregistered route fails", () => {
+  const content = withSource(
+    CONTENT,
+    "fabricated.ts",
+    'export const RETURN_URI = "cash.free2z.free2z://oauth/unregistered";\n',
+  );
+  assert.ok(
+    surfaceFailures(CONTENT, content).some((failure) =>
+      failure.includes("is not registered in"),
+    ),
+  );
+});
+
+test("removing a deep-link route breaks the constant that names it", () => {
+  const content = inputs(CONTENT);
+  content.tauriConfig.plugins["deep-link"].mobile =
+    content.tauriConfig.plugins["deep-link"].mobile.filter(
+      (entry) => entry.host !== "checkout",
+    );
+  assert.ok(
+    surfaceFailures(CONTENT, content).some(
+      (failure) =>
+        failure.includes("cash.free2z.free2z://checkout/return") &&
+        failure.includes("is not registered in"),
+    ),
+  );
+});
+
+test("an empty production source population is a blindness failure, not a pass", () => {
+  const content = inputs(CONTENT);
+  content.sources = new Map();
+  assert.ok(
+    surfaceFailures(CONTENT, content).some((failure) =>
+      failure.includes("the JS -> native contract check has gone blind"),
     ),
   );
 });


### PR DESCRIPTION
Closes #918.

`cash.free2z.free2z` is functional as a packaged Tauri build, and `bundle.active` is `true` again. The security property #904/#912 were reviewed for is **not** weakened: still **zero** `zcash:*`, **zero** `f2zmsg:*`, neither privileged plugin linked, and `src-tauri/src/lib.rs` still registers **no `invoke_handler` at all**.

---

## 1. HTTP — a URL-scoped native client

`tauri-plugin-http` is linked and initialized, and both capability files carry a **scoped** `http:default`:

```json
{ "identifier": "http:default",
  "allow": [ { "url": "https://free2z.cash/*" },
             { "url": "https://*.free2z.cash/*" },
             { "url": "https://free2z.com/*" },
             { "url": "https://*.free2z.com/*" } ] }
```

**Every admitted origin, justified.** `src/lib/api/http.ts` builds URLs from `API_BASE` and `RemoteMedia` from `MEDIA_BASE`; both default to `https://free2z.cash` and are overridable to a deployment via `VITE_F2Z_API` / `VITE_F2Z_MEDIA`.

| Origin | Why it is admitted |
| --- | --- |
| `https://free2z.cash/*` | The production API (`/api/…`) and the media host (`/uploadz/…`). Without it nothing in the app loads. |
| `https://*.free2z.cash/*` | `stage.`, `new.`, `test.` — the deployments a build can be pointed at, and the exact hosts `protocol.ts`'s relay allowlist already names. |
| `https://free2z.com/*` | The `.com` apex, already in this app's `connect-src`; a build pointed there must reach it. |
| `https://*.free2z.com/*` | Its subdomains, same reason. |

**This is narrower than the app's own `connect-src`.** The three RealtimeKit origins are deliberately absent: the Live SDK talks from the webview with `window.fetch` and a `WebSocket`, never through this client. The new checker enforces that direction — an allowed origin the CSP does not already admit is a failure — so the native client can never reach further than the document.

**Two corrections to the issue's framing, both load-bearing.**

* `http:default` is **not** "an unrestricted HTTP client". It is `allow-fetch` with an **empty** allow list, and `Scope::is_allowed` requires *some* allow entry to match, so a bare `http:default` denies every `http`/`https` URL. I watched that: swapping the scoped object for the bare string makes `tests/http_scope.rs` fail with `url not allowed on the configured scope: https://free2z.cash/api/articles/`. It is still refused by the gate, because the reviewable statement is *which origins this client may reach*, and the identifier alone says nothing about that.
* The scope is matched with **URLPattern**, not globs (`tauri-plugin-http/src/scope.rs`), so the hostname is a component match rather than a substring of the URL text. `https://evil.example/free2z.cash/api/` does **not** match `https://*.free2z.cash/*`. Asserted, along with userinfo confusion (`https://free2z.cash@evil.example/`), suffix confusion (`free2z.cash.evil.example`), plaintext `http:`, loopback, the dev-server port, and `metadata.google.internal`.

**Hardening the issue did not ask for.** `tauri-plugin-http` is taken with `default-features = false`, dropping `cookies` from its default set. The default build installs a process-wide `reqwest` cookie jar shared by every request the binary makes — that would make the native client an *ambient-authority* client, and under #367 a hostile subframe could ride it against free2z.cash and read the answer with no CORS in the way. free2z authenticates with a Knox token in an `Authorization` header and needs no jar. A crate test asserts the opt-out stays, because re-enabling it is a one-word edit.

### Why linking this plugin is not the thing the split forbids

`zcash`/`f2zmsg` export authority the process holds **locally** — a seed, device keys — so a caller reaching them gains something it could not otherwise have. `plugin:http|fetch` exports no local authority: its entire reach is the URL scope, and a subframe that reached it could talk to free2z's own API, which it can already do from a page it controls. What it must never become is an *unscoped* or *stateful* client. Both are now mechanically prevented.

`REVIEWED_NAMESPACES` was extended as the record of that review — and made **per surface**, so reviewing `http` for the content app did not silently review it for the messaging app. There is a test for exactly that.

## 2. OAuth — option (b), and not because it is smaller

I chose **(b) drop the native transport**, and the reason is not size.

`oauth_loopback_wait`, `oauth_mobile_claim` and `oauth_mobile_resume` each **return an authorization code — and, on mobile, the PKCE verifier minted for it — to the renderer**. That pair is a sign-in credential: anything holding it completes the exchange and takes the account. Porting them would put that credential behind an `invoke()` in the one process that renders third-party markup, remote media and a livestream SDK, and #367 is precisely the defect that makes "which frame asked" undecidable — Wry injects the bridge into every frame and its Android IPC reports the top-level URL, so a remote subframe resolves as the trusted main window. A capability file cannot separate them: it scopes by window label, and there is one label. So (a) is not "the app gains its first privileged surface"; it is "the content app hands out account-takeover credentials to anything that can get itself framed".

So the code is **deleted, not gated**. `src/lib/oauth/transport.ts` keeps the session-lease machinery and the web popup and contains **no `invoke()` and no `@tauri-apps/api/core` import at all** — which is now a gate rule, so it cannot creep back. Consequences:

* `oauthCallbackTransport()` → `"unavailable"` in a packaged shell (the document origin is `tauri://localhost`, not a registered redirect URI at any provider).
* `auth.socialProviders()` answers all-unconfigured **without asking the backend**, so `SocialButtons` renders its empty state rather than a button whose only outcome is an error toast. (Previously discovery *rejected*, giving "Couldn't check sign-in options" with a retry that could never succeed.)
* `captureOAuthCode()` refuses before opening a popup — the second, load-bearing refusal for a caller reaching the API directly.
* `recoverMobileOAuth()` resolves `null`. **`App.tsx` is untouched** (#927 is in flight there); the mount-time call is now correct — "nothing to finish" — and the `toast.error("Couldn't finish sign-in")` on every launch is unreachable.

Password sign-in and already-linked accounts are unaffected. Social sign-in in a packaged build comes back as a wallet-authority bridge grant (#905).

## 3. The deep-link scheme

`MOBILE_REDIRECT_URI` and `CHECKOUT_RETURN_URI` are now `cash.free2z.free2z://`, `parseCheckoutReturnUrl` **refuses** the wallet's (and e2e2z's) scheme rather than accepting it, `native-return.test.ts`'s near-miss cases moved onto the new scheme, and the manifest registers `oauth/callback` and `checkout/return` beside `bridge/return`.

`native-return.ts` also no longer imports from `lib/oauth/transport` — the deep-link listener is gated on `isTauri()`, not on an OAuth command that does not exist.

**One thing that is declared, not live, and says so.** `checkoutReturnMode()` returns `"web"` unconditionally. `zuuli_mobile` is a **wire** value: it makes the backend issue a return URI in the *wallet's* scheme. There is no `free2z_*` return mode server-side, so asking for a native return from here would post a payer's claim code to a different application. `/fund` is a placeholder and nothing calls this today; it moves with `features/wallet/funding`.

## 4. The check that would have caught this

`wallet/zuuli/scripts/surface-capability-authority.mjs` (inside the required `gate`, via ZUULI's byte-pinned `npm test`) now also compares the two halves of the JS→native contract, off the files:

1. every `@tauri-apps/plugin-*` in `package.json` has its crate in `Cargo.toml` **and** a `.plugin(…::init())` call in the builder;
2. every `invoke("literal")` in production `src/` names a registered command, or a `plugin:<x>|…` whose crate is linked;
3. a surface that registers **no** command may not hold an `invoke_handler` and may not import `@tauri-apps/api/core` — the stronger form of (2), and the one that actually fires;
4. every `cash.free2z.*://host/path` literal uses **this** app's scheme and names a route this app's manifest registers;
5. an `http` grant must be a scoped object, every entry `https://<host>/*`, every origin already in the app's `connect-src`.

Empty capability *or* empty source population is a blindness failure. 28 node-test cases, up from 12; every new rule has a negative control, including the one #918 names explicitly: **an unscoped `http:default` still fails.**

---

## Verification

Everything below was run on this branch.

| Check | Result |
| --- | --- |
| `npm run typecheck` / `typecheck:tests` | pass |
| `npx vitest run` | 911 passed, 5 skipped, 63 files |
| `npx playwright test` | **47 passed** (separate suite) |
| `node --test scripts/ui-copy-truncation.node-test.mjs` | 4 passed |
| `cargo build --locked --all-targets` | pass |
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo test` | 6 passed (3 crate + 3 integration) |
| `scripts/check-rust-deny.sh --root wallet/free2z --config wallet/deny.toml` | advisories / bans / licenses / sources ok |
| `node wallet/zuuli/scripts/project-boundary.mjs` | 5 projects, 559 files, 3 constrained Vite builds |
| `node --test …/project-boundary.node-test.mjs` | 92 passed |
| `node wallet/zuuli/scripts/surface-capability-authority.mjs` | pass |
| `node --test …/surface-capability-authority.node-test.mjs` | **28 passed** |
| `node --test …/mobile-webview-authority.node-test.mjs` | 12 passed |
| `check-workflow-gates.mjs` / `check-github-actions-pins.mjs` / `check-tauri-plugin-permissions.mjs` | pass |
| `npm run tauri -- build --bundles app` | **`free2z.app` built** (18m 13s, release) |

The script has **no `--self-test` flag** (that is `check-rust-deny.sh` / `verify-ci-cache-policy.mjs`); its self-test is the `node --test` file, which is what CI runs and what is listed above.

### Measuring where the bug can actually appear

This is the crux of #918, so two independent measurements, neither taken under `isTauri() === false` or `DEV === true`.

**(a) The ACL and the scope, from the real files.** `src-tauri/tests/http_scope.rs` builds a real Tauri app from this crate's real `tauri.conf.json` and real `capabilities/*.json` — `generate_context!()` embeds the *resolved ACL* — registers `tauri-plugin-http` exactly as `lib.rs` does, and drives `plugin:http|fetch` over the IPC path a webview uses, with the webview's own `tauri://localhost` origin. `fetch` builds the request and returns a resource id **without** network I/O, so it runs offline and in CI (`wallet-surfaces.yml` already runs `cargo test --locked` for both surfaces).

**Both negative controls were watched to fail, on the live tree:**

* scoped capability → bare `http:default`: `Err("url not allowed on the configured scope: https://free2z.cash/api/articles/")`
* remove `.plugin(tauri_plugin_http::init())`: `Err("plugin http not found")` — **exactly the error a packaged build produced before this PR**, reproduced.

Each was also caught by the gate script before the Rust test ran (`must be a scoped object with an allow list`; `linked but never initialized`). Files restored; the tree is green.

**(b) The packaged binary, on the network.** `free2z.app` was built and launched, and its process's own sockets recorded:

```
free2z  72898 skyl    9u  IPv4 … TCP 10.0.0.49:55912->34.102.196.190:443 (ESTABLISHED)
…19 established TLS connections to 34.102.196.190:443…

$ dig +short free2z.cash
34.102.196.190
```

Those sockets are owned by the **`free2z` process itself**, i.e. the Rust `reqwest` client behind `plugin:http|fetch`. WebView-originated traffic on macOS goes through a *separate* `com.apple.WebKit.Networking.xpc` process (observed at PID 73039), so this is not the webview's own fetching — it is the native client, in a packaged release build, reaching free2z.cash. Before this PR the same code path invoked a command that did not exist.

### What is still NOT verified — read this before merging

* **No screenshot of the rendered app.** `screencapture` returns an all-black frame in this environment (screen-recording permission), so I cannot show articles on screen. What is shown above is the network layer working, not the pixels. Someone with a desktop session should open `free2z.app` once and confirm articles render.
* **Multipart `FormData` is untested.** #927 (`/kyc`) had not merged when this was written, so there is no multipart call site to exercise. Every other surface sends JSON. From reading `@tauri-apps/plugin-http`'s `fetch`: a `FormData` body is serialized by the browser `Request`, and its generated `content-type: multipart/form-data; boundary=…` is merged in *because* `src/lib/api/http.ts` deliberately sets no `Content-Type` for one — so it should work, but **that is a reading, not a measurement**. Two related facts for whoever lands #927: the plugin drops `Content-Length` as a forbidden header (the Rust side re-derives it), and `Authorization` passes through untouched. **Please verify multipart on a device before shipping `/kyc`.**
* **The `oauth/callback` and `checkout/return` deep-link routes are registered but nothing consumes them.** The README says so in the same table.
* **Android and iOS were not built.** The mobile capability changed identically to the desktop one, and the Rust scope test is run on the host target only.

## Scope

`wallet/free2z/**` plus `wallet/zuuli/scripts/surface-capability-authority.mjs` and its node test — the one checker #918 names. **Not touched:** `wallet/free2z/src/features/{profile,kyc}`, `App.tsx`, `navigation.ts` (#927), and `wallet/zuuli/src/**` (phase-4 teardown). `SocialButtons.tsx` has a comment-only change.

## Hard constraints

* zero `zcash:*`, zero `f2zmsg:*` — asserted by the checker and by two crate tests
* neither privileged plugin linked
* no broad `http:default` — refused by the checker *and* inert in the plugin
* no `invoke_handler`, and no `@tauri-apps/api/core` import anywhere in `src/`

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
