### PR TITLE
fix(f2zmsg): bind the installed identity to the signed credential

### DIFF
--- a/wallet/plugins/tauri-plugin-f2zmsg/src/bin/peer.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/bin/peer.rs
@@ -462,9 +462,8 @@ async fn enroll(engine: &Engine<SqliteBackend>, options: &Options) -> Result<()>
 
     engine
         .install_identity(IdentityInstall {
-            handle: options.handle.clone(),
-            identity_pk: hex::encode(account.identity.public().as_bytes()),
             credential: credential_bytes,
+            expected_handle: options.handle.clone(),
             wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: now,
         })

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
@@ -208,16 +208,57 @@ enum BindReadiness {
 /// The seed itself never appears in this type, in any argument to this module,
 /// or in any IPC payload — that is the whole reason enrollment lives in the app
 /// crate (§2.2).
+///
+/// # Why there is no `handle` and no `identity_pk` here
+///
+/// Both are **already inside the credential, covered by its signature**
+/// (`f2z-kt-core`'s `DeviceCredentialTBS`). A second copy carried beside it
+/// would be *unsigned*, and under #929 an unsigned value is chosen by whoever
+/// answered rather than by whoever signed. Worse, the unsigned copy used to be
+/// the one [`Engine::install_identity`] stored. So the rule ADR 0016 draws is
+/// the inverse of widening this struct: the install step reads both **out of
+/// the credential** and stops accepting them as arguments. Under #904's
+/// three-app split the credential arrives from ZUULI over the intent bridge
+/// while the rest of the request is assembled in e2e2z, so the two sources
+/// genuinely can disagree — and the signed one has to win.
+///
+/// [`IdentityInstall::expected_handle`] is not a counter-example to that rule;
+/// it is its second half, and its doc comment says why.
 #[derive(Clone, Debug)]
 pub struct IdentityInstall {
-    pub handle: String,
-    /// `ISK.public`, the account identity key, hex.
-    pub identity_pk: String,
-    /// The `DeviceCredential`, canonically encoded.
+    /// The `DeviceCredential`, canonically encoded. The **only** source of the
+    /// handle and the identity key this device installs.
     pub credential: Vec<u8>,
+    /// The handle **this enrollment asked for**, so a credential attesting a
+    /// different one can be refused.
+    ///
+    /// This is required, not optional, and the difference between it and a
+    /// `handle` field beside the credential is the whole of #929.
+    ///
+    /// `validate_at` verifies a credential's signature under the credential's
+    /// **own embedded `identity_pk`**, which is self-*consistency* and not
+    /// authenticity: a hostile responder mints its own `ISK` and signs a
+    /// perfectly well-formed credential for any handle it likes, and every
+    /// structural check, the validity window, the signature and the `device_pk`
+    /// binding all pass. Nothing in the credential can catch that. Compared
+    /// against the handle *this session requested* — a value the caller already
+    /// held before it ever spoke to a responder, and which never travelled in
+    /// the response — it is refused.
+    ///
+    /// It is also the **only** authenticity check available here. On a first
+    /// enrollment there is no trusted `identity_pk` to verify against, so
+    /// "is this the handle I asked for" is the entire budget that
+    /// trust-on-first-response permits. What contains the rest is the KT
+    /// directory, not this function.
+    pub expected_handle: String,
     /// The seed-derived `BackupWrapKey` (`ARCHITECTURE.md` §4.2), under which
     /// the device secrets are sealed. §6.1's `locked` is the state this device
     /// is in whenever it does not have it.
+    ///
+    /// ADR 0016 (#935) decides this field is removed in favour of a per-device
+    /// `DeviceWrapKey` the plugin samples and seals under itself. That is a
+    /// larger change with its own restore analysis and is deliberately **not**
+    /// bundled with the credential-binding fix; #928 tracks it.
     pub wrap_key: [u8; 32],
     pub submitted_at: i64,
 }
@@ -546,19 +587,68 @@ impl<B: StorageBackend> Engine<B> {
     /// Seal the prepared device secrets, record the identity, and build the MLS
     /// engine.
     ///
+    /// # What this installs, and from where
+    ///
+    /// The handle and the identity key come **out of the signed credential**,
+    /// never from a field carried beside it — see [`IdentityInstall`] for why
+    /// the inverse would let an unsigned value beat a signed one. The one thing
+    /// the credential cannot vouch for is that it is the *right* credential: it
+    /// is signed under its own `identity_pk`, so it is self-consistent no matter
+    /// who minted it. That is what
+    /// [`expected_handle`](IdentityInstall::expected_handle) is compared against,
+    /// and refusing on a mismatch is the only authenticity check available on a
+    /// first enrollment.
+    ///
+    /// Both handle refusals happen **before** the pending device secrets are
+    /// consumed, so a credential rejected for its handle leaves the enrollment
+    /// retryable rather than discarding a key the caller cannot regenerate
+    /// without a second [`Engine::prepare_device`] — which would in turn
+    /// invalidate the credential it is retrying with.
+    ///
     /// # Errors
     ///
-    /// `handle-ineligible` if the handle is not §11.3's charset, `internal` if
-    /// [`Engine::prepare_device`] was not called first or the credential does
-    /// not bind the prepared device key.
+    /// `handle-ineligible` if the credential's handle is not §11.3's charset or
+    /// is not the one this enrollment asked for, `internal` if
+    /// [`Engine::prepare_device`] was not called first, the credential does not
+    /// parse, or it does not bind the prepared device key.
     pub async fn install_identity(&self, install: IdentityInstall) -> Result<EnrollmentStatus> {
         let mut inner = self.inner.lock().await;
-        if !handle::is_handle(&install.handle) {
+
+        let credential = f2z_msg_mls::credential::parse(&install.credential).map_err(|error| {
+            Error::internal(format!("the issued credential does not parse: {error}"))
+        })?;
+
+        // §11.3's charset, checked here so a credential the directory could
+        // never hold is `handle-ineligible` rather than an opaque `internal`
+        // out of the MLS engine's own validation.
+        let handle = std::str::from_utf8(credential.credential.handle.as_slice())
+            .ok()
+            .filter(|candidate| handle::is_handle(candidate))
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::HandleIneligible,
+                    format!(
+                        "the credential's handle {:?} is not a messaging handle",
+                        String::from_utf8_lossy(credential.credential.handle.as_slice())
+                    ),
+                )
+            })?
+            .to_owned();
+
+        // The signature proves the credential is internally consistent, not
+        // that it is *ours*. Whoever answered could have signed one for any
+        // handle under a key they minted. This is where that is caught.
+        if handle != install.expected_handle {
             return Err(Error::new(
                 ErrorCode::HandleIneligible,
-                format!("{:?} is not a messaging handle", install.handle),
+                format!(
+                    "the credential attests {handle:?}, but this enrollment asked for {:?}",
+                    install.expected_handle
+                ),
             ));
         }
+        let identity_pk = hex::encode(credential.credential.identity_pk.as_bytes());
+
         let signing = inner
             .pending_device
             .as_ref()
@@ -572,10 +662,6 @@ impl<B: StorageBackend> Engine<B> {
             .ok_or_else(|| Error::internal("validated pending device disappeared"))?;
         let device_pk = hex::encode(signer.public_key());
 
-        let credential = f2z_msg_mls::credential::parse(&install.credential).map_err(|error| {
-            Error::internal(format!("the issued credential does not parse: {error}"))
-        })?;
-
         let now = now_ms();
         let mls = MlsEngine::new(
             inner.backend.clone(),
@@ -587,8 +673,9 @@ impl<B: StorageBackend> Engine<B> {
 
         let identity = StoredIdentity {
             device_id: hex::encode(&device_pk.as_bytes()[..16]),
-            handle: install.handle.clone(),
-            identity_pk: install.identity_pk.clone(),
+            // Both out of the signed credential. Nothing beside it gets a vote.
+            handle,
+            identity_pk,
             device_pk,
             credential: hex::encode(&install.credential),
             created_at: now,

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/engine_lifecycle.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/engine_lifecycle.rs
@@ -49,9 +49,8 @@ async fn enroll(engine: &Engine<MemoryBackend>, handle: &str, seed: u8) -> [u8; 
     let wrap_key = *account.backup_wrap.as_bytes();
     engine
         .install_identity(IdentityInstall {
-            handle: handle.to_owned(),
-            identity_pk: hex::encode(account.identity.public().as_bytes()),
             credential: f2z_msg_mls::credential::encode(&credential).expect("encode"),
+            expected_handle: handle.to_owned(),
             wrap_key,
             submitted_at: NOW,
         })
@@ -104,6 +103,142 @@ async fn enrolling_leaves_the_submission_unmerged_and_says_why() {
     assert_eq!(
         engine.status().await.expect("status").state,
         EngineState::Enrolling
+    );
+}
+
+/// A credential is signed under **its own** `identity_pk`, so anyone who
+/// answers an enrollment request can mint a perfectly valid one for a handle
+/// the user never asked for. This is that credential, and the only thing that
+/// catches it is the handle *this session requested* (#936).
+#[tokio::test]
+async fn a_flawlessly_signed_credential_for_another_handle_is_refused() {
+    let engine = engine();
+    let device = engine.prepare_device().await.expect("device keys");
+
+    // A responder's own account key — never the enrolling user's — attesting a
+    // handle the user never typed, over the device key the user did prepare.
+    let attacker = AccountKeys::from_seed(&[0xaa; 64], 0).expect("§4.2 keys");
+    let forged = attacker
+        .identity
+        .issue_device_credential(&DeviceCredentialRequest {
+            handle: Handle::new(b"mallory".to_vec()).expect("handle"),
+            device_pk: PublicKey::new(device.device_pk),
+            device_kem_pk: KemPublicKey::new(device.device_kem_pk.clone()).expect("kem key"),
+            not_before_ms: 0,
+            not_after_ms: u64::MAX / 2,
+        })
+        .expect("credential");
+
+    // Every check that exists today passes: structure, charset, window,
+    // signature, and the identity->device binding to this very leaf. Asserting
+    // it here is the point — a test that fed in something malformed would prove
+    // nothing about the check under test.
+    f2z_msg_mls::credential::validate_for_leaf(
+        &forged,
+        &device.device_pk,
+        u64::try_from(NOW).expect("now"),
+    )
+    .expect("a self-consistent credential passes every existing check");
+
+    let refused = engine
+        .install_identity(IdentityInstall {
+            credential: f2z_msg_mls::credential::encode(&forged).expect("encode"),
+            expected_handle: "alice".to_owned(),
+            wrap_key: [9; 32],
+            submitted_at: NOW,
+        })
+        .await
+        .expect_err("a credential for another handle must not install");
+    assert_eq!(refused.code(), ErrorCode::HandleIneligible);
+    assert!(!engine.enrollment_status().await.expect("status").enrolled);
+
+    // And the refusal happened before the prepared secrets were consumed, so
+    // the enrollment is retryable with the right credential rather than needing
+    // a second `prepare_device` — which would discard the device key the
+    // credential above was issued over.
+    let account = AccountKeys::from_seed(&[1; 64], 0).expect("§4.2 keys");
+    let genuine = account
+        .identity
+        .issue_device_credential(&DeviceCredentialRequest {
+            handle: Handle::new(b"alice".to_vec()).expect("handle"),
+            device_pk: PublicKey::new(device.device_pk),
+            device_kem_pk: KemPublicKey::new(device.device_kem_pk).expect("kem key"),
+            not_before_ms: 0,
+            not_after_ms: u64::MAX / 2,
+        })
+        .expect("credential");
+    engine
+        .install_identity(IdentityInstall {
+            credential: f2z_msg_mls::credential::encode(&genuine).expect("encode"),
+            expected_handle: "alice".to_owned(),
+            wrap_key: *account.backup_wrap.as_bytes(),
+            submitted_at: NOW,
+        })
+        .await
+        .expect("install");
+    assert_eq!(
+        engine
+            .enrollment_status()
+            .await
+            .expect("status")
+            .handle
+            .as_deref(),
+        Some("alice")
+    );
+}
+
+/// The same comparison seen from the other side: the credential is genuine and
+/// the *request* is the thing that disagrees with it.
+#[tokio::test]
+async fn an_install_asking_for_a_handle_the_credential_does_not_attest_is_refused() {
+    let engine = engine();
+    let device = engine.prepare_device().await.expect("device keys");
+    let account = AccountKeys::from_seed(&[1; 64], 0).expect("§4.2 keys");
+    let credential = account
+        .identity
+        .issue_device_credential(&DeviceCredentialRequest {
+            handle: Handle::new(b"alice".to_vec()).expect("handle"),
+            device_pk: PublicKey::new(device.device_pk),
+            device_kem_pk: KemPublicKey::new(device.device_kem_pk).expect("kem key"),
+            not_before_ms: 0,
+            not_after_ms: u64::MAX / 2,
+        })
+        .expect("credential");
+
+    let refused = engine
+        .install_identity(IdentityInstall {
+            credential: f2z_msg_mls::credential::encode(&credential).expect("encode"),
+            expected_handle: "bob".to_owned(),
+            wrap_key: *account.backup_wrap.as_bytes(),
+            submitted_at: NOW,
+        })
+        .await
+        .expect_err("the request and the credential disagree");
+    assert_eq!(refused.code(), ErrorCode::HandleIneligible);
+    assert!(!engine.enrollment_status().await.expect("status").enrolled);
+}
+
+/// What is stored is the **signed** credential's handle and identity key. There
+/// is no longer a second, unsigned copy of either beside it that could win.
+#[tokio::test]
+async fn the_installed_identity_is_read_out_of_the_credential() {
+    let engine = engine();
+    enroll(&engine, "alice", 1).await;
+    let account = AccountKeys::from_seed(&[1; 64], 0).expect("§4.2 keys");
+
+    assert_eq!(
+        engine
+            .enrollment_status()
+            .await
+            .expect("status")
+            .handle
+            .as_deref(),
+        Some("alice")
+    );
+    let device_info = engine.device_info().await.expect("device info");
+    assert_eq!(
+        device_info.identity_fingerprint.replace(' ', ""),
+        hex::encode(account.identity.public().as_bytes())
     );
 }
 

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/enrollment_refuses_without_custody.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/enrollment_refuses_without_custody.rs
@@ -79,9 +79,12 @@ async fn enroll(engine: &Engine<MemoryBackend>, handle: &str) -> tauri_plugin_f2
         .expect("credential");
     engine
         .install_identity(IdentityInstall {
-            handle: handle.to_owned(),
-            identity_pk: hex::encode(account.identity.public().as_bytes()),
             credential: f2z_msg_mls::credential::encode(&credential).expect("encode"),
+            // The handle this enrollment asked for, which is what the engine
+            // compares the credential's own handle against (#936). It is the
+            // helper's argument rather than anything read back out of the
+            // credential, so the comparison stays a real one.
+            expected_handle: handle.to_owned(),
             wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: NOW,
         })
@@ -145,18 +148,46 @@ async fn a_refused_enrollment_mints_nothing() {
 
     // And it did not half-enroll: `install_identity` without a completed
     // `prepare_device` has no pending device to consume.
+    //
+    // The credential here is well-formed and attests the handle being asked
+    // for, deliberately. `install_identity` parses the credential and compares
+    // its handle *before* it looks for the pending device (#936), so a stub
+    // credential would fail on the parse and this assertion would pass without
+    // ever reaching the property it names.
     let account = AccountKeys::from_seed(&[7; 64], 0).expect("§4.2 keys");
+    let credential = account
+        .identity
+        .issue_device_credential(&DeviceCredentialRequest {
+            handle: Handle::new(b"someone".to_vec()).expect("handle"),
+            // No device was prepared, so there is no leaf key to bind. Any
+            // well-formed key does here: the refusal under test happens before
+            // the binding is checked.
+            device_pk: PublicKey::new([3; 32]),
+            device_kem_pk: KemPublicKey::new(vec![4; 32]).expect("kem key"),
+            not_before_ms: 0,
+            not_after_ms: u64::MAX / 2,
+        })
+        .expect("credential");
     let orphaned = engine
         .install_identity(IdentityInstall {
-            handle: "someone".to_owned(),
-            identity_pk: hex::encode(account.identity.public().as_bytes()),
-            credential: Vec::new(),
+            credential: f2z_msg_mls::credential::encode(&credential).expect("encode"),
+            expected_handle: "someone".to_owned(),
             wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: NOW,
         })
         .await
         .expect_err("no device was prepared, so none can be installed");
     assert_eq!(orphaned.code(), ErrorCode::Internal);
+    // §8 sends `internal` to the frontend with no detail, so the code alone
+    // cannot say *which* internal refusal this was — and every earlier check in
+    // `install_identity` also reports `internal`. Pinning the context is what
+    // keeps this assertion measuring the missing pending device rather than a
+    // credential that never got that far.
+    assert!(
+        orphaned.context().contains("without prepare_device"),
+        "refused before reaching the pending-device check: {}",
+        orphaned.context()
+    );
 }
 
 #[tokio::test]

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/last_resort_rotation.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/last_resort_rotation.rs
@@ -45,9 +45,8 @@ async fn enrolled_engine() -> Engine<MemoryBackend> {
     let wrap_key = *account.backup_wrap.as_bytes();
     engine
         .install_identity(IdentityInstall {
-            handle: "alice".to_owned(),
-            identity_pk: hex::encode(account.identity.public().as_bytes()),
             credential: f2z_msg_mls::credential::encode(&credential).expect("encode"),
+            expected_handle: "alice".to_owned(),
             wrap_key,
             submitted_at: NOW,
         })

--- a/wallet/plugins/tauri-plugin-f2zmsg/tests/two_record_rollback_over_a_relay.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/tests/two_record_rollback_over_a_relay.rs
@@ -334,9 +334,8 @@ async fn enroll<B: StorageBackend>(
         .expect("credential");
     engine
         .install_identity(IdentityInstall {
-            handle: handle.to_owned(),
-            identity_pk: hex::encode(account.identity.public().as_bytes()),
             credential: f2z_msg_mls::credential::encode(&credential).expect("encode credential"),
+            expected_handle: handle.to_owned(),
             wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: NOW,
         })

--- a/wallet/zuuli/src-tauri/src/messaging.rs
+++ b/wallet/zuuli/src-tauri/src/messaging.rs
@@ -189,9 +189,12 @@ pub async fn f2zmsg_enroll<R: Runtime>(
 
     engine
         .install_identity(IdentityInstall {
-            handle: args.handle,
-            identity_pk: hex::encode(account.identity.public().as_bytes()),
             credential,
+            // The handle the user asked for. ZUULI issues this credential
+            // itself, from the seed, so today the comparison cannot fail — it
+            // is the same check e2e2z will need when the credential arrives
+            // over the intent bridge instead (#936).
+            expected_handle: args.handle,
             wrap_key: *account.backup_wrap.as_bytes(),
             submitted_at: now,
         })


### PR DESCRIPTION
Closes #936.

Implements the **implementable half** of #936 — the plugin boundary. `docs/` is
untouched, so this does not collide with #935 (ADR 0016, merged as be9ee00e — docs only, so no rebase is needed), and
`IdentityInstall.wrap_key` is deliberately **not** removed here: that is ADR
0016's Decision 1, a larger change with its own restore analysis, and bundling
it would make both unreviewable. #928 tracks it.

## The defect

`install_identity` stored the `handle` and `identity_pk` the **request**
supplied, and compared neither against the signed `DeviceCredential` carried
beside them (`engine.rs:501-556`, old `:537-538`). `validate_for_leaf` covers the
label, charset, window, signature and the `device_pk` binding — not those two
fields. Harmless while one process performs both halves of enrollment; under
#904's three-app split the credential arrives from ZUULI over the intent bridge
while the request is assembled in e2e2z, and **an unsigned field supplied beside
a signed credential would win over the signed one**. That is #929's exact shape.

## Two changes, and the second is the one that actually defends

**1. `IdentityInstall` loses `handle` and `identity_pk`.** Both come out of the
parsed credential now, so there is no longer a second, unsigned copy of either
that *could* disagree. This is ADR 0016's Decision 2, verbatim, and adds no wire
field.

**2. `IdentityInstall` gains a required `expected_handle`,** compared against the
credential's handle.

Reading the fields out of the credential is **necessary but not sufficient**, and
this is the correction on #936 that matters. `validate_at`
(`rs/crates/f2z-msg-mls/src/credential.rs:157-162`) verifies the signature under
the credential's **own embedded `identity_pk`**. That is self-*consistency*, not
authenticity: a hostile responder mints its own ISK and signs a perfectly
well-formed credential for **any handle it likes**, over the device key the
caller just prepared, and every structural check, the validity window, the
signature and the identity→device binding all pass. Under "just read the fields
out of the credential", e2e2z would install exactly that and store the attacker's
handle and identity key as its own.

The handle **this session requested** is not a second attacker-supplied copy — it
is the caller's own intent, held before it ever spoke to a responder, and it
never travelled in the response. Comparing against it is the only authenticity
check trust-on-first-response permits.

### Why it lives in `IdentityInstall` rather than only in the ADR's install command

ADR 0016 §4 says the check may live "in the renderer before it invokes, or as an
explicit `expected_handle` argument to the install command", and §5 sketches
`e2e2z_install_device_credential(credential, expectedHandle)`. **That command does
not exist yet** (`wallet/e2e2z/src-tauri/src/device.rs` has only
`e2e2z_device_credential_keys`), so the closest boundary that exists today is
`Engine::install_identity`. Putting `expected_handle` there — as a required
field, not an `Option` — makes it **unskippable**: a caller cannot construct an
`IdentityInstall` without deciding what handle it asked for. When
`e2e2z_install_device_credential` lands it forwards its `expectedHandle` straight
into this field; nothing about that command's signature changes.

This is a documented, deliberate divergence from the ADR's literal "`IdentityInstall`
becomes `{ credential, submitted_at }`". Under this PR it is
`{ credential, expected_handle, wrap_key, submitted_at }`, and after ADR 0016's
Decision 1 lands it becomes `{ credential, expected_handle, submitted_at }`. The
ADR's §4 second half ("the caller **MUST** refuse a credential whose handle is not
the one it requested") is normative and stronger than its field list, and the two
are reconciled here rather than one silently dropped.

### A behavioural improvement that came for free

Both handle refusals now happen **before** `pending_device.take()`. Previously
every refusal after that point discarded the prepared device secrets — and since
`prepare_device` is not idempotent, retrying meant a new device key, which
invalidates the credential being retried with. A test asserts the retry works.

## Tests

Three new tests in `tests/engine_lifecycle.rs`:

- **`a_flawlessly_signed_credential_for_another_handle_is_refused`** — the case
  that matters. An attacker `AccountKeys` mints a credential for `"mallory"` over
  the *prepared* device key. The test first asserts
  `f2z_msg_mls::credential::validate_for_leaf(...)` **accepts** it, so it is
  provably refusing a credential that passes every check that exists today rather
  than a malformed input. Installing it with `expected_handle: "alice"` is
  refused with `handle-ineligible`, the engine stays unenrolled, and the same
  prepared device then enrolls successfully with the genuine credential.
- **`an_install_asking_for_a_handle_the_credential_does_not_attest_is_refused`** —
  the same comparison from the other side: genuine credential for `"alice"`,
  request naming `"bob"`.
- **`the_installed_identity_is_read_out_of_the_credential`** — the stored
  `identity_pk` is the credential's.

### Mutation proof

**Mutation A — delete the `handle != install.expected_handle` comparison:**

```
test an_install_asking_for_a_handle_the_credential_does_not_attest_is_refused ... FAILED
test a_flawlessly_signed_credential_for_another_handle_is_refused ... FAILED

---- a_flawlessly_signed_credential_for_another_handle_is_refused stdout ----
panicked at tests/engine_lifecycle.rs:149:10:
a credential for another handle must not install: EnrollmentStatus {
  enrolled: true, handle: Some("mallory"), ... }

test result: FAILED. 11 passed; 2 failed
```

Note the failure text: the attacker's handle installed as this device's identity.
That is the bug, reproduced.

**Mutation B — source `identity_pk` from anywhere but the credential:**

```
---- the_installed_identity_is_read_out_of_the_credential stdout ----
assertion `left == right` failed
  left: "0000000000000000000000000000000000000000000000000000000000000000"
 right: "9b9be4841594587d0dabba3963275c3cd13db1fe66723e96bc57139a2f709ea1"

test result: FAILED. 12 passed; 1 failed
```

**Restored:** `test result: ok. 13 passed; 0 failed`.

**One honest caveat about Mutation B.** The "unsigned field beats signed field"
half of the fix is now *structural* — the `handle` and `identity_pk` request
fields no longer exist, so no mutation can make the two sources disagree. Mutation
B is the closest available proof: it shows the assertion pinning the stored
identity key to the credential is real. It is a weaker mutation than A, and I am
not claiming otherwise.

## What remains caller-side

Nothing in this repo today, but the obligation is real and named:

> When `e2e2z_install_device_credential` is written, it **must** forward the
> handle passed to `requestDeviceCredential(handle)`
> (`wallet/e2e2z/src/lib/enrollment/issueDeviceCredential.ts:208`) as
> `IdentityInstall.expected_handle`. Passing anything derived from the credential
> itself — including re-parsing it — defeats the check completely.

The required field makes the *omission* impossible; it cannot make the
*deliberate defeat* impossible, and no Rust signature can. That obligation is
written into the `expected_handle` doc comment so it is in front of whoever
implements the command.

## Call sites updated

Five, as expected: 3 integration tests, `src/bin/peer.rs:462`, and
`wallet/zuuli/src-tauri/src/messaging.rs:191` — **the last one is outside the
stated scope of this change**, but `IdentityInstall` is a Rust API and ZUULI is a
compile-time consumer, so it could not be avoided. That edit is 7 lines and
purely mechanical (`handle:`/`identity_pk:` → `expected_handle: args.handle`);
nothing else in `messaging.rs` moves. No file under `wallet/zuuli/src/**`,
`wallet/free2z/**`, `wallet/e2e2z/**` or `.github/workflows/` is touched.

## Verification

| Check | Result |
| --- | --- |
| `cargo test --locked` (tauri-plugin-f2zmsg) | 13 + 80 + 2 + 2 + 1 + 1 passed, 0 failed |
| `cargo test --locked --features relay-harness` | all green, incl. both two-process relay tests |
| `cargo test --locked -p f2z-msg-mls` | 22 + 1 doctest passed (crate unchanged) |
| `cargo fmt --check` (plugin and `rs/`) | clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `node wallet/zuuli/scripts/messaging-contract.node-test.mjs` | 9/9 pass, **no digest re-derivation needed** |
| `cargo check --locked` (`wallet/zuuli/src-tauri`) | clean |

On the contract test: `install_identity` is not one of the bodies that script
digests (it pins `stop`, `shutdown`, `deliver`, `send_control`, and the bind
helpers), so no reviewed digest moved and none was re-derived.

`f2z-msg-mls` is **unchanged**. The expected-handle comparison is an *enrollment*
obligation, not the MLS-side credential obligation that module documents itself as
owning, and inventing a `validate_for_handle` there with exactly one caller would
put the rule in two places. Said here so the choice is on the record.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
