### PR TITLE
test(f2zmsg): park on the fault injector instead of spinning at it

### DIFF
--- a/rs/crates/f2z-relay-testkit/src/faults.rs
+++ b/rs/crates/f2z-relay-testkit/src/faults.rs
@@ -37,6 +37,8 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use tokio::sync::watch;
+
 use f2z_codec::ErrorCode;
 use f2z_codec::commands::{Command, PushEvent};
 
@@ -247,9 +249,28 @@ pub struct PolicyFaults {
 /// Cheap to clone and shared with every connection, so a test can arm a fault
 /// in the middle of a conversation — which is the only way to reach half of
 /// them. Arming is not a restart.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct FaultInjector {
     inner: Arc<Mutex<Faults>>,
+    /// A mirror of `Faults::rules.len()`, published on every change so a test
+    /// can **await** the count reaching zero rather than spin on
+    /// [`FaultInjector::armed`].
+    ///
+    /// A spin is not merely wasteful here, it is self-defeating: the waiting
+    /// task occupies a runtime worker for the whole wait, and the task it is
+    /// waiting for needs that runtime to make progress. On a contended CI
+    /// runner that is the difference between a test that finishes and one that
+    /// burns its deadline. See [`FaultInjector::wait_until_disarmed`].
+    armed: Arc<watch::Sender<usize>>,
+}
+
+impl Default for FaultInjector {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Faults::default())),
+            armed: Arc::new(watch::Sender::new(0)),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -269,6 +290,7 @@ impl FaultInjector {
     pub fn arm(&self, fault: Fault) {
         if let Ok(mut faults) = self.inner.lock() {
             faults.rules.push(fault);
+            self.publish(&faults);
         }
     }
 
@@ -284,7 +306,40 @@ impl FaultInjector {
     pub fn disarm(&self) {
         if let Ok(mut faults) = self.inner.lock() {
             faults.rules.clear();
+            self.publish(&faults);
         }
+    }
+
+    /// Republish the armed count. Called under the lock, after every change to
+    /// `rules`, so `armed` and the rule list cannot disagree.
+    fn publish(&self, faults: &Faults) {
+        self.armed.send_replace(faults.rules.len());
+    }
+
+    /// Resolve once no rule is armed.
+    ///
+    /// The event-driven counterpart to [`FaultInjector::armed`], and the one a
+    /// test should use. Arming a one-shot fault and waiting for it to fire is
+    /// the standard way to say "let the relay apply this, then continue", and
+    /// the obvious spelling —
+    ///
+    /// ```ignore
+    /// while faults.armed() != 0 { tokio::task::yield_now().await; }
+    /// ```
+    ///
+    /// — is a hot loop that keeps a runtime worker busy for the entire wait.
+    /// The relay task it is waiting on needs that runtime, so under contention
+    /// the spin starves the very progress it is polling for. This parks
+    /// instead.
+    ///
+    /// Returns immediately when nothing is armed. A rule armed again after the
+    /// count reaches zero is not observed — the question this answers is "has
+    /// what I armed fired yet", asked by the test that armed it.
+    pub async fn wait_until_disarmed(&self) {
+        let mut armed = self.armed.subscribe();
+        // `wait_for` inspects the current value before awaiting, so an already
+        // empty injector never suspends.
+        let _ = armed.wait_for(|armed| *armed == 0).await;
     }
 
     /// Replace the policy faults.
@@ -357,6 +412,7 @@ impl FaultInjector {
             }
         }
         faults.rules.retain(|fault| !fault.retired());
+        self.publish(&faults);
         chosen
     }
 }

--- a/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
+++ b/wallet/plugins/tauri-plugin-f2zmsg/src/engine.rs
@@ -5603,6 +5603,23 @@ mod tests {
         }
     }
 
+    /// How long to wait for the fake relay to apply an armed one-shot fault.
+    ///
+    /// **This is a hang detector, not a performance budget, and it must not be
+    /// retuned to whatever the local machine happens to need.** The relay is
+    /// in-process and applies the fault in microseconds; the only thing this
+    /// value protects against is a genuine deadlock, where a test would
+    /// otherwise sit until the CI job's own timeout and report nothing useful.
+    ///
+    /// It was `5s`, which is why it kept failing (#952). That number was
+    /// calibrated on a developer machine, where this whole test binary
+    /// finishes in ~0.03s. A GitHub runner is not that machine: the same
+    /// binary was observed at **4.46s** on a passing run and **6.69s** on the
+    /// run that failed, so a 5-second deadline sat inside ordinary runner
+    /// variance rather than outside it. Anything under ~30s is measuring the
+    /// runner's load, not the code.
+    const FAULT_APPLIED_DEADLINE: std::time::Duration = std::time::Duration::from_secs(60);
+
     fn conversation(
         relay_url: &str,
         send_addr: f2z_codec::types::QueueAddress,
@@ -6149,13 +6166,9 @@ mod tests {
                 .ensure_bound(&stale)
                 .await
         });
-        tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while faults.armed() != 0 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("relay applied BIND_SEND and dropped its response");
+        tokio::time::timeout(FAULT_APPLIED_DEADLINE, faults.wait_until_disarmed())
+            .await
+            .expect("relay applied BIND_SEND and dropped its response");
         bind.abort();
         let _ = bind.await;
         drop(engine);
@@ -6327,13 +6340,9 @@ mod tests {
                 .ensure_bound(&stale)
                 .await
         });
-        tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while faults.armed() != 0 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("relay applied the first BIND_SEND and dropped its response");
+        tokio::time::timeout(FAULT_APPLIED_DEADLINE, faults.wait_until_disarmed())
+            .await
+            .expect("relay applied the first BIND_SEND and dropped its response");
         bind.abort();
         let _ = bind.await;
         drop(engine);


### PR DESCRIPTION
Closes #952.

Test-only. No shipping code path changes: `f2z-relay-testkit` is a test crate,
and the other edit is inside `#[cfg(test)] mod tests`.

## The failure

```
panicked at src/engine.rs:6423:10:
relay applied the first BIND_SEND and dropped its response: Elapsed(())
```

`Elapsed(())` is `tokio::time::timeout` expiring — not an assertion, not a wrong
error code. Both affected tests wrapped a hot spin in a 5-second deadline:

```rust
tokio::time::timeout(Duration::from_secs(5), async {
    while faults.armed() != 0 { tokio::task::yield_now().await; }
})
```

These are the **only two** `while faults.armed()` sites in the crate, which is
why the failure always presents as the same pair with everything else green.

## Two defects, and the number is the smaller one

### 1. The deadline was calibrated on the wrong machine

| Where | Same 90-test binary | Result |
|---|---|---|
| Developer machine | 0.03s | pass |
| Runner, #927's run | **4.46s** | pass |
| Runner, #944's run | **6.69s** | **fail** |

The budget was 5s. It sat *inside* ordinary runner variance rather than outside
it — 4.46s squeaked under, 6.69s did not.

The replacement is 60s, and the comment says what it is for:

> **This is a hang detector, not a performance budget, and it must not be
> retuned to whatever the local machine happens to need.**

with both observed numbers recorded. A bare `Duration::from_secs(5)` gets
retuned by whoever it next annoys; the next person will not have the runner
table unless it is written down next to the value.

### 2. The spin is self-defeating

`yield_now()` in a tight loop keeps a runtime worker busy for the **entire**
wait, and the relay task being waited on needs that runtime to make progress.
Raising the deadline alone would paper over that.

`FaultInjector` now publishes its armed count to a `tokio::sync::watch` channel
on every change and offers `wait_until_disarmed()`, which parks. The count is
republished under the same lock that mutates the rules, so the two cannot
disagree.

## Proven load-bearing by mutation

**Making `wait_until_disarmed` return immediately** — fails exactly those two
tests, on a real assertion further down rather than a timeout, so the wait is a
genuine synchronisation point and not a no-op:

```
test result: FAILED. 88 passed; 2 failed; 1 ignored; finished in 0.03s
panicked at src/engine.rs:6204:9
```

**Dropping the republish from the retirement path** — both tests hang until the
deadline, confirming the wakeup is driven by the fault retiring *and* that the
new deadline still catches a genuine hang:

```
test engine::tests::fresh_dropped_... has been running for over 60 seconds
relay applied the first BIND_SEND and dropped its response: Elapsed(())
test result: FAILED. 88 passed; 2 failed; 1 ignored; finished in 60.02s
```

Restored: `90 passed; 0 failed`.

## Under contention

All 12 cores saturated with busy loops, `--test-threads 90` to oversubscribe the
runtimes, ten consecutive runs — green every time.

## What I could not show

**I could not reproduce the original failure locally**, with or without the fix:
not under core saturation, not oversubscribed, and not with the runtime pinned
to `worker_threads = 1`. So the *demonstrated* cause is the deadline. The spin is
a real defect that makes the wait actively worse under exactly the conditions a
contended runner provides, and it is removed on that principle rather than on a
local repro. I would rather say that than imply I measured something I did not.

## The other red timing surface — different shape

`two_instances_over_a_relay.rs:349` (red on #927 at 182.54s) does **not** share
this pattern. Line 349 is `assert!(subject.ok, ...)` in `report()`: a peer
**subprocess** exhausted its own `PEER_TIMEOUT_SECONDS = 180` budget and exited
non-zero. The harness would only report `Elapsed` at 210s. Different mechanism,
different layer — so the crate has one instance of the spin-wait pattern, not
two. That test is worth its own look; it is not this.

## Verification

| Check | Result |
| --- | --- |
| `cargo test --locked` (plugin) | 90 + 13 + 4 + 2 + …, 0 failed |
| `--features relay-harness` | 9 binaries ok, 0 failed |
| `cargo test --locked` (whole `rs/` workspace) | 99 ok, 0 failed |
| `cargo fmt --check` (both trees) | clean |
| `cargo clippy --all-targets --all-features -D warnings` | clean |
| `node wallet/zuuli/scripts/messaging-contract.node-test.mjs` | 9/9 |

Branched directly from `f27adb9f`, not stacked on #944.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
