### PR TITLE
fix(free2z): install document direction, bring free2z under the RTL policy, drop PaidIntent "send"

### DIFF
--- a/wallet/free2z/src/lib/auth/paid-intent.test.ts
+++ b/wallet/free2z/src/lib/auth/paid-intent.test.ts
@@ -35,46 +35,32 @@ describe("paid login intent", () => {
     expect(consumePaidIntent("/ai", "ai", storage, 200)).toBeNull();
   });
 
-  it("round-trips canonical numeric Send amounts while accepting the legacy string shape", () => {
+  // #925: this surface holds no seed, grants no `zcash:*` capability and links
+  // no wallet plugin, so a ZEC Send is not something it can resume. The variant
+  // is gone from the type; these two assertions are what stops it coming back
+  // through storage, which types cannot see.
+  it("refuses to write a Send intent it can no longer perform", () => {
     const storage = new MemoryStorage();
-
     preservePaidIntent(
       "/fund",
-      { kind: "send", query: "alice", amount: 3_000 },
+      { kind: "send", query: "alice", amount: 3_000 } as never,
       storage,
       100,
     );
-    expect(consumePaidIntent("/fund", "send", storage, 200)).toEqual({
-      kind: "send",
-      query: "alice",
-      amount: 3_000,
-    });
+    expect(storage.value).toBeNull();
+  });
 
+  it("destroys a Send record left behind by an older build", () => {
+    const storage = new MemoryStorage();
     storage.value = JSON.stringify({
       returnTo: "/fund",
       createdAt: 100,
-      intent: { kind: "send", query: "alice", amount: "3,000" },
+      intent: { kind: "send", query: "alice", amount: 3_000 },
     });
-    expect(consumePaidIntent("/fund", "send", storage, 200)).toEqual({
-      kind: "send",
-      query: "alice",
-      amount: "3,000",
-    });
-  });
 
-  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 1_000_001])(
-    "rejects an invalid canonical Send amount (%s)",
-    (amount) => {
-      const storage = new MemoryStorage();
-      preservePaidIntent(
-        "/fund",
-        { kind: "send", query: "alice", amount } as never,
-        storage,
-        100,
-      );
-      expect(storage.value).toBeNull();
-    },
-  );
+    expect(consumePaidIntent("/fund", "send" as never, storage, 200)).toBeNull();
+    expect(storage.value).toBeNull();
+  });
 
   it.each([
     ["/ai", { kind: "ai", draft: "draft" }],
@@ -84,7 +70,6 @@ describe("paid login intent", () => {
     ],
     ["/creator/alice", { kind: "creator-tip", subject: "alice", amount: "50" }],
     ["/creator/alice", { kind: "creator-subscription", subject: "alice" }],
-    ["/fund", { kind: "send", query: "alice", amount: "500" }],
     ["/live/alice", { kind: "live-entry", subject: "alice", mode: "ppv" }],
   ] as const)("preserves the %s paid intent across login", (path, intent) => {
     const storage = new MemoryStorage();

--- a/wallet/free2z/src/lib/auth/paid-intent.ts
+++ b/wallet/free2z/src/lib/auth/paid-intent.ts
@@ -2,7 +2,6 @@ import {
   safeLoginDestination,
   type LoginDestination,
 } from "./login-destination";
-import { MAX_TUZIS } from "@/lib/format";
 
 const STORAGE_KEY = "zuuli.auth.pending-paid-intent";
 const MAX_AGE_MS = 30 * 60 * 1000;
@@ -12,12 +11,25 @@ const MAX_USERNAME = 150;
 
 type IntentStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
+/**
+ * Every paid action this surface can actually resume after a login.
+ *
+ * `{ kind: "send" }` used to sit here, carried over from ZUULI's ZEC Send when
+ * the content surface was extracted (#904). It is gone as of #925: free2z grants
+ * zero `zcash:*` capability, registers no `invoke_handler`, and links no wallet
+ * plugin, so it cannot spend and never will. A stale `send` record written by an
+ * older build now fails `validIntent` and is destroyed on read like any other
+ * malformed record, rather than being restored into a screen that does not exist.
+ *
+ * This is not the ZEC tip path (#790/#924): a tip is an `execute-payment`
+ * *intent sent to ZUULI over the bridge*, where ZUULI shows its own native
+ * confirmation and does the signing. That path needs no local `send` variant.
+ */
 export type PaidIntent =
   | { kind: "ai"; draft: string }
   | { kind: "article-tip"; subject: string; amount: string }
   | { kind: "creator-tip"; subject: string; amount: string }
   | { kind: "creator-subscription"; subject: string }
-  | { kind: "send"; query: string; amount: number | string }
   | { kind: "live-entry"; subject: string; mode: "ppv" | "subscriber" };
 
 interface StoredPaidIntent {
@@ -43,19 +55,6 @@ function usernameString(value: unknown): value is string {
   return typeof value === "string" && [...value].length <= MAX_USERNAME;
 }
 
-function sendAmount(value: unknown): value is number | string {
-  // Strings are the one-release migration shape and deliberately remain
-  // permissive: malformed legacy input must restore as invalid UI text rather
-  // than being coerced into a different amount. New valid drafts use numbers.
-  return (
-    shortString(value, 32) ||
-    (typeof value === "number" &&
-      Number.isSafeInteger(value) &&
-      value >= 1 &&
-      value <= MAX_TUZIS)
-  );
-}
-
 function validIntent(value: unknown): value is PaidIntent {
   if (typeof value !== "object" || value === null) return false;
   const record = value as Record<string, unknown>;
@@ -67,8 +66,6 @@ function validIntent(value: unknown): value is PaidIntent {
       return usernameString(record.subject) && shortString(record.amount, 32);
     case "creator-subscription":
       return usernameString(record.subject);
-    case "send":
-      return usernameString(record.query) && sendAmount(record.amount);
     case "live-entry":
       return (
         usernameString(record.subject) &&

--- a/wallet/free2z/src/lib/document-direction.test.ts
+++ b/wallet/free2z/src/lib/document-direction.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  directionForLocale,
+  installDocumentDirection,
+  syncDocumentDirection,
+  type DirectionElement,
+  type DirectionObserver,
+} from "./document-direction";
+
+describe("document locale direction", () => {
+  it.each(["ar", "ar-EG", "fa-IR", "he-IL", "ur-PK"])(
+    "maps %s to RTL",
+    (locale) => expect(directionForLocale(locale)).toBe("rtl"),
+  );
+
+  it.each(["en", "es-419", "fr-FR", "", "not_a_locale"])(
+    "fails %j safely to LTR",
+    (locale) => expect(directionForLocale(locale)).toBe("ltr"),
+  );
+
+  it("writes the direction derived from the current language", () => {
+    const root = { lang: "fa-AF", dir: "ltr" };
+    expect(syncDocumentDirection(root)).toBe("rtl");
+    expect(root).toEqual({ lang: "fa-AF", dir: "rtl" });
+  });
+
+  it("observes only lang and re-syncs every locale change", () => {
+    const root: DirectionElement = { lang: "en", dir: "rtl" };
+    let callback: (() => void) | undefined;
+    let observed:
+      | {
+          target: DirectionElement;
+          options: { attributes: true; attributeFilter: ["lang"] };
+        }
+      | undefined;
+    let disconnected = false;
+    const observer: DirectionObserver = {
+      observe(target, options) {
+        observed = { target, options };
+      },
+      disconnect() {
+        disconnected = true;
+      },
+    };
+
+    const stop = installDocumentDirection(root, (next) => {
+      callback = next;
+      return observer;
+    });
+
+    expect(root.dir).toBe("ltr");
+    expect(observed).toEqual({
+      target: root,
+      options: { attributes: true, attributeFilter: ["lang"] },
+    });
+
+    root.lang = "ar-EG";
+    callback?.();
+    expect(root.dir).toBe("rtl");
+
+    root.lang = "fr";
+    callback?.();
+    expect(root.dir).toBe("ltr");
+
+    stop();
+    expect(disconnected).toBe(true);
+  });
+});

--- a/wallet/free2z/src/lib/document-direction.ts
+++ b/wallet/free2z/src/lib/document-direction.ts
@@ -1,0 +1,87 @@
+// The document-direction kernel ZUULI and e2e2z use, restated for this surface.
+//
+// Deliberately a copy rather than an import, for the same reason
+// `src/i18n/locale.ts` is: `wallet/zuuli/scripts/project-boundary.mjs` forbids
+// one wallet application from importing another, and `@free2z/wallet-shared`
+// exports only the sensitive-entry session — a wallet concern this surface does
+// not hold. When the i18n kernel is promoted into the shared package (#906
+// follow-up), this file moves with `locale.ts`.
+//
+// It exists here because the RTL source policy is only worth its enforcement if
+// something actually flips `<html dir>`. Before #940 nothing in free2z ever
+// wrote `dir`: `index.html` pinned `dir="ltr"` and no module touched it, so the
+// twenty-four `rtl:` variants in this tree compiled into the bundle as CSS that
+// no locale could ever select — support that was present in source and dead at
+// runtime, exactly the defect #934 found in e2e2z. free2z renders articles,
+// creator profiles, search results and AI output, so it is the surface where a
+// bidi failure has the most untrusted text to act on.
+//
+// `src/i18n/index.ts` already owns `<html lang>`; this observer derives `dir`
+// from it, so adding an RTL catalog is a catalog change and nothing else.
+
+export type DocumentDirection = "ltr" | "rtl";
+
+const RTL_LANGUAGES = new Set(["ar", "fa", "he", "ur"]);
+
+export interface DirectionElement {
+  lang: string;
+  dir: string;
+}
+
+export interface DirectionObserver {
+  observe(
+    target: DirectionElement,
+    options: { attributes: true; attributeFilter: ["lang"] },
+  ): void;
+  disconnect(): void;
+}
+
+export type DirectionObserverFactory = (
+  onLanguageChange: () => void,
+) => DirectionObserver;
+
+/** Resolve the RTL locales this surface is preparing to ship. */
+export function directionForLocale(locale: string): DocumentDirection {
+  try {
+    const language = new Intl.Locale(locale).language.toLowerCase();
+    return RTL_LANGUAGES.has(language) ? "rtl" : "ltr";
+  } catch {
+    return "ltr";
+  }
+}
+
+export function syncDocumentDirection(root: DirectionElement): DocumentDirection {
+  const direction = directionForLocale(root.lang || "en");
+  root.dir = direction;
+  return direction;
+}
+
+function browserObserverFactory(
+  onLanguageChange: () => void,
+): DirectionObserver {
+  const observer = new MutationObserver(onLanguageChange);
+  return {
+    observe(target, options) {
+      observer.observe(target as HTMLElement, options);
+    },
+    disconnect() {
+      observer.disconnect();
+    },
+  };
+}
+
+/**
+ * Keep `<html dir>` derived from `<html lang>`. The locale kernel owns `lang`;
+ * this narrow observer makes direction follow both bootstrap and later locale
+ * changes without creating a second locale store.
+ */
+export function installDocumentDirection(
+  root: DirectionElement = document.documentElement,
+  observerFactory: DirectionObserverFactory = browserObserverFactory,
+): () => void {
+  const sync = () => syncDocumentDirection(root);
+  sync();
+  const observer = observerFactory(sync);
+  observer.observe(root, { attributes: true, attributeFilter: ["lang"] });
+  return () => observer.disconnect();
+}

--- a/wallet/free2z/src/main.tsx
+++ b/wallet/free2z/src/main.tsx
@@ -4,7 +4,13 @@ import { I18nextProvider } from "react-i18next";
 import App from "./App";
 import { mountApplication, RootFallback } from "./app-bootstrap";
 import { ErrorBoundary } from "./components/common/ErrorBoundary";
+import { installDocumentDirection } from "./lib/document-direction";
 import "./index.css";
+
+// Before anything renders, so `<html dir>` is never briefly wrong under a
+// locale whose script runs the other way. `src/i18n/index.ts` sets `<html
+// lang>`; the observer installed here derives `dir` from it thereafter.
+installDocumentDirection();
 
 void mountApplication({
   root: ReactDOM.createRoot(document.getElementById("root")!),

--- a/wallet/free2z/tests/document-direction.pw.ts
+++ b/wallet/free2z/tests/document-direction.pw.ts
@@ -1,0 +1,47 @@
+/**
+ * #940: proof that free2z's RTL support is live rather than compiled-and-dead.
+ *
+ * Before this change nothing in the app ever wrote `<html dir>`: `index.html`
+ * pinned `dir="ltr"` and no module touched it, so the twenty-four `rtl:`
+ * variants in this tree shipped as CSS that no locale could ever select —
+ * exactly the defect #934 found in e2e2z. `rtl-source-policy.mjs` now asserts
+ * that `installDocumentDirection()` runs before the root renders, but that is a
+ * source contract; this file asserts the runtime consequence in a real browser:
+ * a locale change reaches `<html dir>`, and the compiled `rtl:` rule then
+ * actually matches a rendered element.
+ */
+import { expect, test } from "@playwright/test";
+
+const MIRRORED = "matrix(-1, 0, 0, 1, 0, 0)";
+
+test("a locale change reaches <html dir> and the rtl: variants really apply", async ({
+  page,
+}) => {
+  await page.goto("/login");
+
+  const guest = page.getByRole("link", { name: "Continue as guest" });
+  await expect(guest).toBeVisible();
+  const arrow = guest.locator("svg").last();
+
+  // The bootstrap baseline: English resolves to LTR and the icon is unmirrored.
+  await expect(page.locator("html")).toHaveAttribute("dir", "ltr");
+  await expect(arrow).toHaveCSS("transform", "none");
+
+  // The i18n kernel owns `<html lang>` and writes it exactly this way; the
+  // observer installed in main.tsx is the only thing that derives `dir` from it.
+  await page.evaluate(() => {
+    document.documentElement.lang = "ar";
+  });
+
+  await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+  await expect(arrow).toHaveCSS("transform", MIRRORED);
+
+  // And back, so the observer is proven to track the locale rather than to have
+  // flipped once.
+  await page.evaluate(() => {
+    document.documentElement.lang = "en";
+  });
+
+  await expect(page.locator("html")).toHaveAttribute("dir", "ltr");
+  await expect(arrow).toHaveCSS("transform", "none");
+});

--- a/wallet/zuuli/scripts/rtl-source-policy.mjs
+++ b/wallet/zuuli/scripts/rtl-source-policy.mjs
@@ -105,6 +105,26 @@ const REACT_PHYSICAL_SHORTHANDS = new Map([
 // counted exception gets counted, not excluded.
 export const CHAT_OWNED_RESIDUALS = Object.freeze({});
 
+/// free2z's reviewed direction-sensitive translation sites. Keyed by path
+/// relative to `wallet/free2z`, the same shape ZUULI uses.
+///
+/// The switch thumb slides horizontally, so its `ltr:`/`rtl:` pair is the only
+/// thing that keeps the travel pointing at the checked end under an RTL locale;
+/// pinning it means deleting the pair fails loudly instead of sliding the thumb
+/// the wrong way. `src/components/ui/dialog.tsx` carries the other pair
+/// (`ltr:-translate-x-1/2 rtl:translate-x-1/2`) and is deliberately *not* pinned
+/// here: its `className` is followed by `{...props}`, and `effectiveJsxAttribute`
+/// treats a later spread as making the class set unknowable, so an anchor entry
+/// there could never match and would assert nothing. That pair is still held to
+/// `assertPairedDirectionalTranslations`, which reads the literal directly.
+const FREE2Z_REQUIRED_DIRECTIONAL_TRANSFORMS = Object.freeze({
+  "src/components/ui/switch.tsx": Object.freeze({
+    anchors: Object.freeze(["data-[state=unchecked]:translate-x-0", "h-5", "w-5"]),
+    ltr: "ltr:data-[state=checked]:translate-x-5",
+    rtl: "rtl:data-[state=checked]:-translate-x-5",
+  }),
+});
+
 /// e2e2z's reviewed residual inventory, and it is empty too.
 ///
 /// The messaging screens arrived here from ZUULI in #904 phase 3 carrying
@@ -116,13 +136,36 @@ export const CHAT_OWNED_RESIDUALS = Object.freeze({});
 /// the worst-placed one in the tree.
 export const E2E2Z_OWNED_RESIDUALS = Object.freeze({});
 
+/// free2z's reviewed residual inventory (#940), and it is empty as well.
+///
+/// This is a counted verdict, not a directory exemption: the whole tree was
+/// scanned by the checker below and produced no residual at all, so the exact
+/// inventory that describes it is the empty one. free2z's components came from
+/// the same #912/#920/#927 ports whose physical-direction residuals #917 fixed
+/// at the source, which is why nothing remained to count here.
+///
+/// The residuals were never the defect on this surface. The defect was that
+/// nothing installed `<html dir>` — `index.html` pins `dir="ltr"` and no module
+/// wrote it — so free2z's twenty-four `rtl:` variants compiled into the bundle
+/// as CSS no locale could select. That is the same silent deadness #934 found in
+/// e2e2z, and it is fixed by `src/lib/document-direction.ts` plus its
+/// installation in `src/main.tsx`, which `assertBootstrapContracts` now holds
+/// this surface to. free2z renders articles, creator profiles, search results
+/// and AI output, so it carries the most user-authored text in the system and is
+/// where an unhandled `U+202E` has the most chrome to reorder; an exemption here
+/// would be worth less than nowhere else.
+export const FREE2Z_OWNED_RESIDUALS = Object.freeze({});
+
 /**
  * The reviewed contract, per surface. `directory` is relative to `wallet/`.
  *
- * `wallet/free2z` is deliberately absent: it is a separate surface with its own
- * component tree, and bringing it under this policy is its own change with its
- * own residual review, not a line added here. `wallet/zuuallet` is likewise
- * absent — it is the reference wallet, not a shipped locale surface.
+ * `wallet/zuuallet` is deliberately absent, and this is the explicit decision
+ * #940 asked for rather than an omission: it is the whitelabel *reference*
+ * wallet, not a shipped locale surface. It has no `src/i18n` kernel, nothing
+ * that ever writes `<html lang>`, and no `.bidi-number` rule, so every clause of
+ * the bootstrap contract would be vacuous there — the policy would assert a
+ * localization story the app does not have. Covering it becomes worthwhile the
+ * day it grows a locale kernel, and that change should add the line here.
  */
 export const SURFACES = Object.freeze([
   Object.freeze({
@@ -134,6 +177,11 @@ export const SURFACES = Object.freeze([
     directory: "e2e2z",
     reviewedResiduals: E2E2Z_OWNED_RESIDUALS,
     requiredDirectionalTransforms: Object.freeze({}),
+  }),
+  Object.freeze({
+    directory: "free2z",
+    reviewedResiduals: FREE2Z_OWNED_RESIDUALS,
+    requiredDirectionalTransforms: FREE2Z_REQUIRED_DIRECTIONAL_TRANSFORMS,
   }),
 ]);
 

--- a/wallet/zuuli/scripts/rtl-source-policy.node-test.mjs
+++ b/wallet/zuuli/scripts/rtl-source-policy.node-test.mjs
@@ -4,6 +4,7 @@ import ts from "typescript";
 import {
   CHAT_OWNED_RESIDUALS,
   E2E2Z_OWNED_RESIDUALS,
+  FREE2Z_OWNED_RESIDUALS,
   SURFACES,
   assertEverySurface,
   assertRtlSourcePolicy,
@@ -779,10 +780,30 @@ function rejectsE2e2zMutation(fileName, before, after, pattern) {
   );
 }
 
-test("every reviewed surface satisfies the policy, and both are reviewed", () => {
+const FREE2Z_SURFACE = SURFACES.find((surface) => surface.directory === "free2z");
+assert.ok(FREE2Z_SURFACE, "free2z must be a reviewed RTL surface");
+const FREE2Z_BASELINE = collectRtlSources(surfaceProjectRoot(FREE2Z_SURFACE));
+
+function mutateFree2z(fileName, before, after) {
+  const original = FREE2Z_BASELINE[fileName];
+  assert.equal(typeof original, "string", `missing mutation source ${fileName}`);
+  const changed = original.replace(before, after);
+  assert.notEqual(changed, original, `mutation did not apply to ${fileName}`);
+  return { ...FREE2Z_BASELINE, [fileName]: changed };
+}
+
+function rejectsFree2zMutation(fileName, before, after, pattern) {
+  assert.throws(
+    () =>
+      assertRtlSourcePolicy(mutateFree2z(fileName, before, after), FREE2Z_SURFACE),
+    pattern,
+  );
+}
+
+test("every reviewed surface satisfies the policy, and all three are reviewed", () => {
   assert.deepEqual(
     SURFACES.map((surface) => surface.directory),
-    ["zuuli", "e2e2z"],
+    ["zuuli", "e2e2z", "free2z"],
   );
   assert.doesNotThrow(() => assertEverySurface());
 });
@@ -911,6 +932,160 @@ test("e2e2z CSS is held to logical directions too", () => {
   );
 });
 
+// ---------------------------------------------------------------------------
+// free2z (#940). The content surface: articles, creator profiles, search
+// results and AI output — the largest volume of user-authored text in the
+// system and the least under our control, which is exactly where an unhandled
+// `U+202E` has the most UI chrome to reorder.
+// ---------------------------------------------------------------------------
+
+test("the free2z production tree satisfies the exact RTL source policy", () => {
+  assert.doesNotThrow(() =>
+    assertRtlSourcePolicy(FREE2Z_BASELINE, FREE2Z_SURFACE),
+  );
+});
+
+test("the free2z residual inventory is empty and enforced as empty", () => {
+  assert.deepEqual(Object.keys(FREE2Z_OWNED_RESIDUALS), []);
+  // free2z inherited its components from the #912/#920/#927 ports, whose
+  // physical-direction residuals #917 fixed at the source, so there was nothing
+  // left to count. Empty is a verdict, not a skip: a residual in any feature
+  // tree fails, and the failure names the file and the line it sits on. The
+  // probes are spread across articles, AI, search and creator so an exemption
+  // cannot be smuggled back in as a directory rule that one carrier would hide.
+  rejectsFree2zMutation(
+    "src/features/articles/components/ArticleTagInput.tsx",
+    "py-2 text-start last:border-b-0",
+    "py-2 text-left last:border-b-0",
+    /residual paths[\s\S]*ArticleTagInput\.tsx \(text-left@\d+\)/,
+  );
+  rejectsFree2zMutation(
+    "src/features/ai/ModelPicker.tsx",
+    '<span className="text-end text-foreground">',
+    '<span className="text-right text-foreground">',
+    /residual paths[\s\S]*ModelPicker\.tsx \(text-right@\d+\)/,
+  );
+  rejectsFree2zMutation(
+    "src/features/search/index.tsx",
+    "py-1 text-start text-xs",
+    "py-1 text-left text-xs",
+    /residual paths[\s\S]*search\/index\.tsx \(text-left@\d+\)/,
+  );
+  rejectsFree2zMutation(
+    "src/features/creator/index.tsx",
+    '<div className="space-y-4">',
+    '<div className="ml-2 space-y-4">',
+    /residual paths[\s\S]*creator\/index\.tsx \(ml-2@\d+\)/,
+  );
+  // The article reader is the surface that renders the untrusted body itself,
+  // so it carries the arbitrary-property probe as well.
+  rejectsFree2zMutation(
+    "src/features/articles/pages/Reader.tsx",
+    '<div className="space-y-2">',
+    '<div className="[margin-left:1px] space-y-2">',
+    /residual paths[\s\S]*Reader\.tsx \(\[margin-left:1px\]@\d+\)/,
+  );
+  // The logical form of the same arbitrary property is not a residual, so the
+  // rule is about direction and not about arbitrary utilities.
+  assert.doesNotThrow(() =>
+    assertRtlSourcePolicy(
+      mutateFree2z(
+        "src/features/articles/pages/Reader.tsx",
+        '<div className="space-y-2">',
+        '<div className="[margin-inline-start:1px] space-y-2">',
+      ),
+      FREE2Z_SURFACE,
+    ),
+  );
+});
+
+test("free2z numerals lose their bidi isolation loudly", () => {
+  // A creator's "12 pages · 3,481 tuzis" reverses without isolation, and this
+  // surface renders counts beside user-authored names.
+  rejectsFree2zMutation(
+    "src/features/creator/index.tsx",
+    '<span className="bidi-number tabular-nums">',
+    '<span className="tabular-nums">',
+    /residual paths[\s\S]*creator\/index\.tsx \(tabular-nums@\d+\)/,
+  );
+  rejectsFree2zMutation(
+    "src/index.css",
+    "direction: ltr;",
+    "direction: inherit;",
+    /bidi-number/,
+  );
+  rejectsFree2zMutation(
+    "src/index.css",
+    "unicode-bidi: isolate;",
+    "unicode-bidi: normal;",
+    /bidi-number/,
+  );
+});
+
+test("a free2z directional adornment that stops mirroring fails, with a line", () => {
+  rejectsFree2zMutation(
+    "src/features/articles/pages/Reader.tsx",
+    '<ArrowLeft className="rtl:-scale-x-100 h-4 w-4"',
+    '<ArrowLeft className="h-4 w-4"',
+    /Reader\.tsx:\d+ ArrowLeft \(ArrowLeft\) must mirror with literal rtl:-scale-x-100/,
+  );
+});
+
+// The finding #940 predicted. free2z had NO document-direction install at all:
+// `index.html` pinned `dir="ltr"` and no module ever wrote `dir`, so the
+// twenty-four `rtl:` variants in this tree compiled into the bundle as CSS no
+// locale could select — support present in source and dead at runtime, the same
+// defect #934 found in e2e2z. These assertions are what keeps it installed.
+test("free2z document direction bootstrap removal fails", () => {
+  rejectsFree2zMutation(
+    "src/main.tsx",
+    "installDocumentDirection();",
+    "// installDocumentDirection();",
+    /before rendering/,
+  );
+  rejectsFree2zMutation(
+    "index.html",
+    ' dir="ltr"',
+    "",
+    /lang=en dir=ltr baseline/,
+  );
+
+  // Installed before the render, not merely present somewhere in the file: the
+  // window between mount and the first locale resolution is exactly when a
+  // wrong `dir` is visible.
+  const main = FREE2Z_BASELINE["src/main.tsx"];
+  const withoutEarlyCall = main.replace("\ninstallDocumentDirection();\n", "\n");
+  assert.notEqual(withoutEarlyCall, main, "direction-call move did not remove");
+  const movedAfterRender = `${withoutEarlyCall}\ninstallDocumentDirection();\n`;
+  assert.throws(
+    () =>
+      assertRtlSourcePolicy(
+        { ...FREE2Z_BASELINE, "src/main.tsx": movedAfterRender },
+        FREE2Z_SURFACE,
+      ),
+    /before rendering/,
+  );
+});
+
+test("free2z CSS is held to logical directions too", () => {
+  const cssFile = "src/index.css";
+  const withCss = (declaration) => ({
+    ...FREE2Z_BASELINE,
+    [cssFile]: `${FREE2Z_BASELINE[cssFile]}\n.rtl-probe { ${declaration} }\n`,
+  });
+  assert.throws(
+    () => assertRtlSourcePolicy(withCss("padding-right: 1px;"), FREE2Z_SURFACE),
+    /physical-direction CSS/,
+  );
+  assert.throws(
+    () => assertRtlSourcePolicy(withCss("padding: 0 1px 0 2px;"), FREE2Z_SURFACE),
+    /asymmetric physical CSS shorthand/,
+  );
+  assert.doesNotThrow(() =>
+    assertRtlSourcePolicy(withCss("padding-inline-end: 1px;"), FREE2Z_SURFACE),
+  );
+});
+
 // A reviewed inventory that names a file the tree no longer has is not a
 // stricter policy — it is a dead entry that reads like coverage. #943 deleted
 // `src/features/profile` from ZUULI, and the only thing that noticed was a
@@ -920,7 +1095,14 @@ test("every reviewed inventory path names a file that still exists", () => {
   const trees = new Map([
     [SURFACES[0], BASELINE],
     [E2E2Z_SURFACE, E2E2Z_BASELINE],
+    [FREE2Z_SURFACE, FREE2Z_BASELINE],
   ]);
+  // Every reviewed surface is checked, not a hand-listed subset — otherwise
+  // adding a surface silently opts its inventory out of this guard.
+  assert.deepEqual(
+    [...trees.keys()].map((surface) => surface.directory),
+    SURFACES.map((surface) => surface.directory),
+  );
   for (const [surface, sources] of trees) {
     for (const table of [
       surface.requiredDirectionalTransforms,
@@ -946,6 +1128,29 @@ test("the shared checker keeps each surface's contract to itself", () => {
   assert.deepEqual(
     Object.keys(SURFACES[0].requiredDirectionalTransforms).sort(),
     ["src/components/ui/switch.tsx", "src/features/auth/ZcashLoginFlow.tsx"],
+  );
+  // free2z has the switch but not the Zcash login flow, which stayed with the
+  // app that keeps the seed — so its table is its own, not ZUULI's.
+  assert.deepEqual(Object.keys(FREE2Z_SURFACE.requiredDirectionalTransforms), [
+    "src/components/ui/switch.tsx",
+  ]);
+  const brokenFree2zSwitch = {
+    ...FREE2Z_BASELINE,
+    "src/components/ui/switch.tsx": FREE2Z_BASELINE[
+      "src/components/ui/switch.tsx"
+    ].replace(
+      "ltr:data-[state=checked]:translate-x-5 rtl:data-[state=checked]:-translate-x-5",
+      "",
+    ),
+  };
+  assert.notEqual(
+    brokenFree2zSwitch["src/components/ui/switch.tsx"],
+    FREE2Z_BASELINE["src/components/ui/switch.tsx"],
+    "free2z switch contract mutation did not apply",
+  );
+  assert.throws(
+    () => assertRtlSourcePolicy(brokenFree2zSwitch, FREE2Z_SURFACE),
+    /opposite-sign|reviewed directional/,
   );
   // And the table is load-bearing, not decorative: the same broken switch is
   // caught under ZUULI's contract and missed under an empty one, which is


### PR DESCRIPTION
Closes #940
Closes #925

## The finding: free2z's RTL support was dead code

#940 predicted this and it was right. free2z had **no document-direction install
at all**. `index.html` pins `dir="ltr"`, and nothing in the tree ever wrote
`dir` — the only `documentElement` writer is `src/i18n/index.ts`, which sets
`lang` and nothing else. The twenty-four `rtl:` variants in this tree *did*
compile into the bundle:

```
rtl\:-scale-x-100:where([dir=rtl],[dir=rtl] *){--tw-scale-x: -1;transform:...}
```

…as CSS that no locale could ever select. Support present in source, doing
nothing at runtime — the same defect #934 found in e2e2z, on the surface that
renders articles, creator profiles, search results and AI output.

Recorded with the install commented out, before the fix:

```
✘  1 tests/document-direction.pw.ts:17:1 › a locale change reaches <html dir> and the rtl: variants really apply
   Error: expect(locator).toHaveAttribute(expected) failed
   Expected: "rtl"
   Received: "ltr"
       14 × locator resolved to <html lang="ar" dir="ltr" class="dark">…</html>
```

`lang="ar"`, `dir="ltr"`: the locale is Arabic and the direction never follows.

## What changed

**The kernel.** `wallet/free2z/src/lib/document-direction.ts` — a copy, not an
import, with the reason written at the top: `project-boundary.mjs` forbids one
wallet application from importing another, and `@free2z/wallet-shared` exports
only the sensitive-entry session. Same established pattern as #934. Installed in
`src/main.tsx` before the root renders; the policy's bootstrap contract now holds
free2z to that ordering.

**The policy.** `wallet/free2z` joins `SURFACES` with its own **reviewed residual
inventory**, and it is `Object.freeze({})` — **empty**. That is a counted verdict,
not a directory exemption: the whole tree was scanned and produced no residual at
all, because free2z's components came from the same #912/#920/#927 ports whose
physical-direction residuals #917 fixed at the source. All three surfaces now
carry an empty inventory; nothing anywhere is excused.

`src/components/ui/switch.tsx`'s `ltr:`/`rtl:` pair is pinned as a reviewed
directional-transform site. `src/components/ui/dialog.tsx` carries the other pair
and is deliberately **not** pinned: its `className` is followed by `{...props}`,
and `effectiveJsxAttribute` treats a later spread as making the class set
unknowable, so an anchor entry there could never match and would assert nothing.
That is written down at the entry rather than left as a silent gap — the pair is
still held to `assertPairedDirectionalTranslations`, which reads the literal.

**`wallet/zuuallet` is now an explicit decision, not an omission.** It is the
whitelabel *reference* wallet: no `src/i18n` kernel, nothing that ever writes
`<html lang>`, no `.bidi-number` rule. Every clause of the bootstrap contract
would be vacuous there, so the policy would assert a localization story the app
does not have. Covering it becomes worthwhile the day it grows a locale kernel.

**#934's inventory-path guard.** It listed two surfaces by hand. It now asserts
that the map it walks covers every entry in `SURFACES`, so adding a surface
cannot silently opt its inventory out of that guard.

**Tests: 26 → 32.** free2z residual probes spread across articles, AI, search and
creator (so an exemption cannot be smuggled back as a directory rule one carrier
would hide), the arbitrary-property probe on the article reader, numeral bidi
isolation, icon mirroring, the bootstrap contract including the
install-before-render ordering, and CSS logical directions.

**#925.** `{ kind: "send" }` is gone from free2z's `PaidIntent`, along with its
`sendAmount` validator and the now-unused `MAX_TUZIS` import and the `case "send"`
branch. free2z grants zero `zcash:*`, registers no `invoke_handler`, and links no
wallet plugin — it cannot spend and never will. Distinct from the #790/#924 ZEC
tip, which is an `execute-payment` intent sent to ZUULI over the bridge and needs
no local variant. ZUULI's `PaidIntent` is untouched.

Three tests covered the removed branch; two are replaced by assertions that the
narrowing holds where types cannot see — `preservePaidIntent` refuses to write a
`send` record, and `consumePaidIntent` destroys one left behind by an older build
rather than replaying it.

## Verification

**Load-bearing, on the real tree.** `<div className="space-y-2">` →
`<div className="ml-2 space-y-2">` in `src/features/articles/pages/Reader.tsx`:

```
RTL source policy: zuuli OK
RTL source policy: e2e2z OK
Error: free2z: RTL residual paths changed
expected:
actual: src/features/articles/pages/Reader.tsx (ml-2@264)
```

File and line. Reverted byte-identically — `ab82fc4be60457953e285500c9cb2adcfe5f5e405674737871a73925e1092d37` before and after, `git diff` empty — and green again:

```
RTL source policy: zuuli OK
RTL source policy: e2e2z OK
RTL source policy: free2z OK
```

**Live, not just compiled.** `tests/document-direction.pw.ts` drives a real
browser: `<html dir>` starts `ltr` with the icon unmirrored, `lang="ar"` flips it
to `rtl` and the icon's computed transform becomes `matrix(-1, 0, 0, 1, 0, 0)`,
and `lang="en"` puts both back — so the observer tracks the locale rather than
having flipped once.

| check | result |
| --- | --- |
| `free2z: npm run typecheck` | clean |
| `free2z: npm run typecheck:tests` | clean |
| `free2z: npx vitest run` | 924 passed, 5 skipped (64 files) |
| `free2z: npx playwright test` | **92 passed** (91 + the new direction spec) |
| `node --test scripts/rtl-source-policy.node-test.mjs` | **32 passed**, 0 failed |
| `node scripts/rtl-source-policy.mjs` | zuuli OK · e2e2z OK · free2z OK |
| `node scripts/project-boundary.mjs` | 5 projects, 483 files, 2116 refs verified |
| `node scripts/surface-capability-authority.mjs` | free2z grants no `zcash:*` or `f2zmsg:*` at all |

Two `article-drafts.pw.ts` cases flaked once under full parallel load and passed
on a clean re-run and on a second full-suite run (92/92); CI runs with
`retries: 1`. Unrelated to this change.

**Gate.** No workflow change needed, verified rather than assumed: `zuuli.yml`'s
`frontend` job runs `node --test scripts/rtl-source-policy.node-test.mjs` and
`node scripts/rtl-source-policy.mjs` (lines 264-265), `gate` lists `frontend` in
its `needs`, and the `changes` path filter already selects on `wallet/free2z/*`
and `wallet/zuuli/*`.

**Inventories unweakened.** All three are `Object.freeze({})`:

```
106:export const CHAT_OWNED_RESIDUALS = Object.freeze({});
137:export const E2E2Z_OWNED_RESIDUALS = Object.freeze({});
157:export const FREE2Z_OWNED_RESIDUALS = Object.freeze({});
```

The diff touches neither ZUULI's nor e2e2z's inventory or their reviewed
transform tables.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
