### PR TITLE
ci: scope the Rust matrix to Rust changes and gate the surfaces suites

### DIFF
--- a/.github/workflows/wallet-surfaces.yml
+++ b/.github/workflows/wallet-surfaces.yml
@@ -1,14 +1,14 @@
 name: wallet/surfaces
 
-# Builds the two delegated surfaces of the three-app split (#904/#906):
+# Compiles the two delegated surfaces of the three-app split (#904/#906):
 #
 #   wallet/free2z  — the content surface. Links NO privileged plugin.
 #   wallet/e2e2z   — the messaging surface. Links tauri-plugin-f2zmsg only.
 #
-# What this workflow is NOT is the thing that keeps those surfaces unprivileged.
-# That property is decided inside the required `gate` in zuuli.yml, three ways,
-# all of which run on every pull request that touches `wallet/free2z/**` or
-# `wallet/e2e2z/**` because the ZUULI change detector now selects both trees:
+# What this workflow is NOT is the thing that keeps those surfaces unprivileged,
+# and since #915 it is no longer the thing that runs their tests either. Both
+# now live inside the required `gate` in zuuli.yml, which carries no `paths:`
+# filter and so reports on every pull request:
 #
 #   * `wallet/zuuli/scripts/surface-capability-authority.mjs` (+ its node test)
 #     runs inside the protected `zuuli / frontend` job via `npm run test`. It is
@@ -18,18 +18,22 @@ name: wallet/surfaces
 #   * `wallet/zuuli/scripts/project-boundary.mjs`, same job, refuses a cross-
 #     application import in either direction.
 #   * `rust_fmt` / `rust_clippy` / `rust_deny` discover crates rather than
-#     listing them, so both new `src-tauri` crates are gated from this commit.
+#     listing them, so both new `src-tauri` crates are gated.
+#   * zuuli.yml's `surfaces` job — added by #915 — runs each surface's own
+#     typecheck, vitest, ui-copy and Playwright suites, including
+#     wallet/e2e2z/tests/enrollment-gap.pw.ts. Those suites MOVED there rather
+#     than being copied there: running ~900 vitest cases and two Playwright
+#     suites twice per pull request is the cost #949 is about.
 #
-# So what is left here is build coverage — typecheck, tests, bundle, and a
-# `cargo` build of each backend — on a `paths:` filter. That is exactly the
-# shape of `zuuallet.yml`, and like it this workflow publishes no gate and is
-# registered in `scripts/check-workflow-gates.mjs`'s UNGATED_WORKFLOWS.
+# So what is left here is the `cargo` build and test of each backend, on a
+# `paths:` filter. That is the shape of `zuuallet.yml`, and like it this
+# workflow publishes no gate and is registered in
+# `scripts/check-workflow-gates.mjs`'s UNGATED_WORKFLOWS.
 #
-# Since #904 phase 3 the e2e2z lane also carries the messaging surface's own
-# tests, which moved out of ZUULI with it. The contract test that holds that
-# client to `docs/e2ee/CLIENT-CONTRACT.md` — `messaging-contract.node-test.mjs`
-# — deliberately did NOT move: it stays in `wallet/zuuli/scripts` so it keeps
-# running inside the protected `gate`, and it now reads across both trees.
+# The contract test that holds the messaging client to
+# `docs/e2ee/CLIENT-CONTRACT.md` — `messaging-contract.node-test.mjs` — never
+# moved out of ZUULI at all: it stays in `wallet/zuuli/scripts` so it keeps
+# running inside the protected `gate`, and it reads across both trees.
 
 on:
   pull_request:
@@ -52,12 +56,7 @@ on:
       - 'rs/crates/f2z-relay-proto/**'
       - 'rs/crates/f2z-relay-testkit/**'
       - 'scripts/check-rust-toolchain.sh'
-      - 'wallet/zuuli/scripts/surface-capability-authority.mjs'
       - '.github/workflows/wallet-surfaces.yml'
-      # release-path.node-test.mjs, part of e2e2z's `npm test`, reads this
-      # workflow's inlined copy of aab-payload-digest.sh and its protected
-      # environment declarations. A change to it must re-run that test.
-      - '.github/workflows/e2e2z-release.yml'
   push:
     branches: [main]
     paths:
@@ -79,12 +78,7 @@ on:
       - 'rs/crates/f2z-relay-proto/**'
       - 'rs/crates/f2z-relay-testkit/**'
       - 'scripts/check-rust-toolchain.sh'
-      - 'wallet/zuuli/scripts/surface-capability-authority.mjs'
       - '.github/workflows/wallet-surfaces.yml'
-      # release-path.node-test.mjs, part of e2e2z's `npm test`, reads this
-      # workflow's inlined copy of aab-payload-digest.sh and its protected
-      # environment declarations. A change to it must re-run that test.
-      - '.github/workflows/e2e2z-release.yml'
   workflow_dispatch:
 
 permissions:
@@ -99,81 +93,6 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # Frontend: typecheck, owned unit tests, production bundle.
-  #
-  # free2z ships a real `vite.config.ts` as of the content extraction (#904
-  # phase 1) — its Markdown pipeline needs `worker.format: "es"` for the Mermaid
-  # worker and a `PACKAGE_VERSION` define for rehype-mathjax — so the constrained
-  # audit in project-boundary.mjs builds it for real. e2e2z is still a
-  # placeholder screen and still ships none, so its `vite build` runs on the
-  # defaults: `index.html` at the project root, `dist/` out, and esbuild reading
-  # `jsx: "react-jsx"` from its tsconfig. See the comment on
-  # `viteBuildsVerified` in wallet/zuuli/scripts/project-boundary.node-test.mjs.
-  #
-  # free2z's `npm test` also runs Playwright against the mock backend, which
-  # uses the runner image's Google Chrome (`channel: "chrome"` under CI), the
-  # same browser the ZUULI gate uses.
-  # ---------------------------------------------------------------------------
-  surfaces_frontend:
-    name: surfaces / frontend (${{ matrix.app }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        app: [free2z, e2e2z]
-    defaults:
-      run:
-        working-directory: wallet/${{ matrix.app }}
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '24'
-          cache: npm
-          cache-dependency-path: wallet/${{ matrix.app }}/package-lock.json
-
-      - name: Install locked dependencies
-        run: npm ci
-
-      # Dependency refreshes belong in focused PRs; bounded retries tolerate
-      # registry failures without weakening the high-severity floor.
-      - name: Audit dependencies (high and critical)
-        run: |
-          for attempt in 1 2 3; do
-            npm audit --audit-level=high && exit 0
-            [ "$attempt" -eq 3 ] && exit 1
-            sleep $((attempt * 5))
-          done
-
-      - name: Typecheck
-        run: |
-          npm run typecheck
-          npm run typecheck:tests
-
-      # Both surfaces' `npm test` ends in `playwright test`, and this step runs
-      # on each leg of the matrix because each leg needs the browser.
-      #
-      # For e2e2z (#904 phase 3) that Playwright run is the only one that
-      # exercises the ported messaging surface in a real browser — including the
-      # enrollment gap against a Tauri IPC host that registers the plugin and
-      # not the app-crate enrollment trio. For free2z (#904 phase 1) it is the
-      # article/creator surface driven against the mock backend. Both configs
-      # select `channel: "chrome"` under CI, so this uses the runner image's
-      # preinstalled stable Chrome rather than downloading a browser, exactly as
-      # zuuli.yml does — and fails here, with a readable message, if the image
-      # ever stops shipping it.
-      - name: Verify the browser-test browser
-        run: google-chrome --version
-
-      - name: Test owned frontend modules
-        run: npm test
-
-      - name: Build production frontend
-        run: npm run build
-
   # ---------------------------------------------------------------------------
   # Rust: compile each Tauri backend against the committed lockfile.
   #

--- a/.github/workflows/zuuli.yml
+++ b/.github/workflows/zuuli.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       zuuli: ${{ steps.filter.outputs.zuuli }}
       zuuallet_schema: ${{ steps.filter.outputs.zuuallet_schema }}
+      surfaces: ${{ steps.filter.outputs.surfaces }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -115,6 +116,7 @@ jobs:
             echo "::notice::No usable base commit; running the full ZUULI gate."
             echo "zuuli=true" >> "$GITHUB_OUTPUT"
             echo "zuuallet_schema=true" >> "$GITHUB_OUTPUT"
+            echo "surfaces=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -124,11 +126,13 @@ jobs:
             echo "::warning::Diff failed; running the full ZUULI gate."
             echo "zuuli=true" >> "$GITHUB_OUTPUT"
             echo "zuuallet_schema=true" >> "$GITHUB_OUTPUT"
+            echo "surfaces=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           zuuli=false
           zuuallet_schema=false
+          surfaces=false
           while IFS= read -r -d '' file; do
             # Prose under an application directory — STATUS.md, README.md,
             # CLAUDE.md, docs/**.md — describes the app; it is not compiled into
@@ -154,8 +158,45 @@ jobs:
                   "$file" == wallet/e2e2z/*.md ]]; then
               continue
             fi
+            # Frontend test sources for the two delegated surfaces. A Playwright
+            # spec or a vitest file here is executed by the `surfaces` job below
+            # and read by nothing else: no Rust job compiles it, no production
+            # bundle ships it, and `npm run build` type-checks against
+            # tsconfig.build.json, which excludes it. Without this guard the
+            # broad `wallet/free2z/*` and `wallet/e2e2z/*` patterns in the arm
+            # below select the whole native matrix, so #938 — 1,226 lines
+            # entirely under wallet/free2z/tests/, no source, no config — waited
+            # on `Rust / lints` (41m) and `Rust / native lints (macos)` (37m)
+            # that no line it changed can reach (#949).
+            #
+            # It is deliberately NOT a `wallet/<app>/tests/*` glob in general. A
+            # Rust integration test lives under `src-tauri/tests/` —
+            # wallet/free2z/src-tauri/tests/http_scope.rs arrived in #942 — and
+            # MUST run the Rust jobs. Every pattern here is anchored at the
+            # literal prefix `wallet/<app>/tests/` or `wallet/<app>/src/`, and
+            # neither is a prefix of `wallet/<app>/src-tauri/`, so nothing under
+            # src-tauri/ can reach this guard however far `*` spans.
+            #
+            # wallet/zuuli's own tests are deliberately absent: they run inside
+            # the protected `zuuli / frontend` job, so carving them out would
+            # skip the job that executes them.
+            #
+            # `surfaces` is set rather than nothing being set, because these
+            # files ARE the input to the surfaces suite; and like the markdown
+            # guard this runs only per-file, so it cannot affect the fail-open
+            # paths above, and a commit that touches a test *and* source still
+            # selects the full gate on the source file.
+            if [[ "$file" == wallet/free2z/tests/* ||
+                  "$file" == wallet/e2e2z/tests/* ||
+                  "$file" == wallet/free2z/src/*.test.ts ||
+                  "$file" == wallet/free2z/src/*.test.tsx ||
+                  "$file" == wallet/e2e2z/src/*.test.ts ||
+                  "$file" == wallet/e2e2z/src/*.test.tsx ]]; then
+              surfaces=true
+              continue
+            fi
             case "$file" in
-              Cargo.toml|Cargo.lock|.cargo/*|clippy.toml|.clippy.toml|wallet/Cargo.toml|wallet/Cargo.lock|wallet/.cargo/*|wallet/clippy.toml|wallet/.clippy.toml|wallet/*.rs|wallet/*/Cargo.toml|wallet/*/Cargo.lock|wallet/*/.cargo/*|wallet/*/clippy.toml|wallet/*/.clippy.toml|wallet/package.json|wallet/package-lock.json|wallet/shared/*|wallet/zuuli/*|wallet/zuuallet/*|wallet/free2z/*|wallet/e2e2z/*|wallet/plugins/*|rs/crates/f2z-codec/*|rs/crates/f2z-intent/*|rs/crates/f2z-kt-client/*|rs/crates/f2z-kt-core/*|rs/crates/f2z-msg-dag/*|rs/crates/f2z-msg-identity/*|rs/crates/f2z-msg-mls/*|rs/crates/f2z-msg-store/*|rs/crates/f2z-relay-proto/*|rs/crates/f2z-relay-testkit/*|rs/rust-toolchain.toml|wallet/zuuallet/package.json|wallet/zuuallet/package-lock.json|wallet/zuuallet/src/hooks/useWallet.ts|wallet/zuuallet/src/lib/mnemonic.ts|wallet/zuuallet/src/lib/sensitive-entry.ts|wallet/zuuallet/src/lib/sensitive-seed-session.ts|wallet/zuuallet/src/lib/sensitive-seed.ts|wallet/zuuallet/src/lib/tauri.ts|wallet/zuuallet/src/pages/CreateWallet.tsx|wallet/zuuallet/src/pages/RestoreWallet.tsx|wallet/zuuallet/src/pages/Settings.tsx|wallet/zuuallet/src/pages/Welcome.tsx|wallet/zuuallet/src/pages/sensitive-entry-routes.test.tsx|wallet/zuuallet/src/types/index.ts|wallet/rust-toolchain.toml|wallet/deny.toml|docs/e2ee/CLIENT-CONTRACT.md|docs/e2ee/WIRE.md|scripts/check-github-actions-pins.mjs|scripts/check-librustzcash-compat.mjs|scripts/check-rust-toolchain.sh|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-tauri-plugin-permissions.mjs|scripts/check-zuuli-linux-image.mjs|scripts/check-zuuli-store-capture-image.mjs|scripts/check-zuuli-android-gate.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/containers/zuuli-store-capture/*|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-store-capture-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-store-audit.yml|.github/workflows/zuuli-store-publish.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md|docs/ZUULI-STORE-CAPTURE-IMAGE.md)
+              Cargo.toml|Cargo.lock|.cargo/*|clippy.toml|.clippy.toml|wallet/Cargo.toml|wallet/Cargo.lock|wallet/.cargo/*|wallet/clippy.toml|wallet/.clippy.toml|wallet/*.rs|wallet/*/Cargo.toml|wallet/*/Cargo.lock|wallet/*/.cargo/*|wallet/*/clippy.toml|wallet/*/.clippy.toml|wallet/package.json|wallet/package-lock.json|wallet/shared/*|wallet/zuuli/*|wallet/zuuallet/*|wallet/free2z/*|wallet/e2e2z/*|wallet/plugins/*|rs/crates/f2z-codec/*|rs/crates/f2z-intent/*|rs/crates/f2z-kt-client/*|rs/crates/f2z-kt-core/*|rs/crates/f2z-msg-dag/*|rs/crates/f2z-msg-identity/*|rs/crates/f2z-msg-mls/*|rs/crates/f2z-msg-store/*|rs/crates/f2z-relay-proto/*|rs/crates/f2z-relay-testkit/*|rs/rust-toolchain.toml|wallet/zuuallet/package.json|wallet/zuuallet/package-lock.json|wallet/zuuallet/src/hooks/useWallet.ts|wallet/zuuallet/src/lib/mnemonic.ts|wallet/zuuallet/src/lib/sensitive-entry.ts|wallet/zuuallet/src/lib/sensitive-seed-session.ts|wallet/zuuallet/src/lib/sensitive-seed.ts|wallet/zuuallet/src/lib/tauri.ts|wallet/zuuallet/src/pages/CreateWallet.tsx|wallet/zuuallet/src/pages/RestoreWallet.tsx|wallet/zuuallet/src/pages/Settings.tsx|wallet/zuuallet/src/pages/Welcome.tsx|wallet/zuuallet/src/pages/sensitive-entry-routes.test.tsx|wallet/zuuallet/src/types/index.ts|wallet/rust-toolchain.toml|wallet/deny.toml|docs/e2ee/CLIENT-CONTRACT.md|docs/e2ee/WIRE.md|scripts/check-github-actions-pins.mjs|scripts/check-librustzcash-compat.mjs|scripts/check-rust-toolchain.sh|scripts/check-rust-fmt.sh|scripts/check-rust-deny.sh|scripts/check-rust-clippy.sh|scripts/check-tauri-plugin-permissions.mjs|scripts/check-zuuli-linux-image.mjs|scripts/check-zuuli-store-capture-image.mjs|scripts/check-zuuli-android-gate.mjs|z/zcash/librustzcash|.gitmodules|.github/containers/zuuli-linux/*|.github/containers/zuuli-store-capture/*|.github/workflows/e2e2z-release.yml|.github/workflows/zuuli.yml|.github/workflows/zuuli-linux-image.yml|.github/workflows/zuuli-store-capture-image.yml|.github/workflows/zuuli-packaging.yml|.github/workflows/zuuli-release.yml|.github/workflows/zuuli-store-audit.yml|.github/workflows/zuuli-store-publish.yml|.github/workflows/zuuli-testflight-bootstrap.yml|.github/workflows/zuuli-testflight-recovery.yml|.github/workflows/cache-cleanup.yml|.github/actions/zuuli-rust-cache/*|docs/ZUULI-LINUX-BUILD-IMAGE.md|docs/ZUULI-STORE-CAPTURE-IMAGE.md)
                 zuuli=true
                 ;;
             esac
@@ -166,13 +207,30 @@ jobs:
             esac
           done < "$changed_files"
 
+          # `surfaces` is a strict superset of `zuuli`: every input that selects
+          # the full gate — a shared package, a lockfile, the toolchain pin, a
+          # surface's own source — also changes what free2z and e2e2z build and
+          # test against. Deriving it here rather than restating the selector
+          # keeps one authoritative pattern list, and makes the only way for the
+          # surfaces suite to skip be that every changed file was excused above.
+          if [[ "$zuuli" == true ]]; then
+            surfaces=true
+          fi
+
           echo "zuuli=$zuuli" >> "$GITHUB_OUTPUT"
           echo "zuuallet_schema=$zuuallet_schema" >> "$GITHUB_OUTPUT"
+          echo "surfaces=$surfaces" >> "$GITHUB_OUTPUT"
 
   frontend:
     name: zuuli / frontend
     needs: changes
-    if: needs.changes.outputs.zuuli == 'true'
+    # `surfaces` as well as `zuuli`, because this job owns the cross-application
+    # boundary verdicts for free2z and e2e2z — project-boundary.mjs and, via
+    # `npm run test`, surface-capability-authority.mjs. A change that only edits
+    # a surface's tests skips the ~40-minute native matrix (#949) but must not
+    # skip the 6-minute job that decides whether that surface may import across
+    # the split or hold a capability it is not allowed.
+    if: needs.changes.outputs.zuuli == 'true' || needs.changes.outputs.surfaces == 'true'
     runs-on: ubuntu-latest
     # Retain bounded time for the mandatory viewport suite and production build,
     # including occasional hosted-runner provisioning delays.
@@ -273,6 +331,86 @@ jobs:
         run: |
           npm run test
           npm --prefix ../zuuallet run test:sensitive-entry
+
+      - name: Build production frontend
+        run: npm run build
+
+  # The two delegated surfaces of the three-app split (#904/#906) — wallet/free2z
+  # and wallet/e2e2z — run their OWN unit and browser suites here, inside the
+  # required gate, rather than in wallet-surfaces.yml where they could not fail a
+  # merge (#915).
+  #
+  # Branch protection requires exactly ["gate", "rs / gate"], and growing that
+  # list is a repository-settings change no pull request can make — a wrong name
+  # there blocks every merge forever. So this job publishes no required context
+  # of its own: it is added to `gate`'s `needs:`, and the gate's exhaustive
+  # verifier (check-github-actions-pins.mjs --verify-gate-results) refuses any
+  # result but the one this job's selector predicts. `gate` itself carries
+  # `if: always()` and zuuli.yml has no `paths:` filter, so the required context
+  # reports on every pull request whether this job ran or skipped; there is no
+  # required-but-skipped deadlock to fall into.
+  #
+  # What moved here is the whole frontend leg, not a copy of it: leaving it in
+  # wallet-surfaces.yml as well would run ~900 free2z vitest cases and both
+  # Playwright suites twice per pull request, which is the cost #949 is about.
+  # wallet-surfaces.yml keeps the Rust leg and stays registered as ungated.
+  surfaces:
+    name: zuuli / surfaces (${{ matrix.app }})
+    needs: changes
+    if: needs.changes.outputs.zuuli == 'true' || needs.changes.outputs.surfaces == 'true'
+    runs-on: ubuntu-latest
+    # free2z's leg is the long one: ~900 vitest cases plus a Playwright run
+    # against the mock backend. Bounded well clear of it, and still a quarter of
+    # the native matrix this job lets a test-only change skip.
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [free2z, e2e2z]
+    defaults:
+      run:
+        working-directory: wallet/${{ matrix.app }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: wallet/${{ matrix.app }}/package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      # Dependency refreshes belong in focused PRs; bounded retries tolerate
+      # registry failures without weakening the high-severity floor.
+      - name: Audit dependencies (high and critical)
+        run: |
+          for attempt in 1 2 3; do
+            npm audit --audit-level=high && exit 0
+            [ "$attempt" -eq 3 ] && exit 1
+            sleep $((attempt * 5))
+          done
+
+      - name: Typecheck
+        run: |
+          npm run typecheck
+          npm run typecheck:tests
+
+      # Both surfaces' `npm test` ends in `playwright test`, and both configs
+      # select `channel: "chrome"` under CI, so this uses the runner image's
+      # preinstalled stable Chrome rather than downloading a browser — exactly as
+      # the frontend job above does — and fails here, with a readable message, if
+      # the image ever stops shipping it.
+      - name: Verify the browser-test browser
+        run: google-chrome --version
+
+      # For e2e2z this is the only run that exercises the ported messaging
+      # surface in a real browser, including tests/enrollment-gap.pw.ts, which
+      # proves the messaging surface cannot appear enrolled without the wallet
+      # authority. Until #915 that test could go red without blocking a merge.
+      - name: Test owned frontend modules
+        run: npm test
 
       - name: Build production frontend
         run: npm run build
@@ -993,7 +1131,7 @@ jobs:
   # change detector and every applicable full-stack job succeeded; legitimate
   # non-ZUULI skips continue to report success instead of remaining pending.
   gate:
-    needs: [changes, frontend, rust_fmt, rust_deny, rust_clippy, rust_native_clippy, rust_native_tests, rust_plugin, rust_msg_plugin, rust_android_32, rust_app, zuuallet_schema, rust_crypto_targets]
+    needs: [changes, frontend, surfaces, rust_fmt, rust_deny, rust_clippy, rust_native_clippy, rust_native_tests, rust_plugin, rust_msg_plugin, rust_android_32, rust_app, zuuallet_schema, rust_crypto_targets]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,7 +144,10 @@ change detector selects `wallet/free2z/**` and `wallet/e2e2z/**`:
 Each app's Rust crate also asserts its own manifest in a unit test, so the
 property is stated where the violation would be written as well as centrally.
 
-Build coverage for the two delegated surfaces lives in
+Each surface's own suite — typecheck, vitest, ui-copy and Playwright, including
+`wallet/e2e2z/tests/enrollment-gap.pw.ts` — runs in `zuuli.yml`'s `surfaces` job,
+which the required gate awaits (#915). Their Tauri backends are compiled and
+tested by
 [`.github/workflows/wallet-surfaces.yml`](../.github/workflows/wallet-surfaces.yml),
 which publishes no gate — deliberately. What keeps those surfaces unprivileged
 is the required gate above, not their own build.

--- a/docs/development.md
+++ b/docs/development.md
@@ -106,7 +106,7 @@ of them.
 | --- | --- | --- |
 | `zuuli.yml` | **yes — the required `gate`** | ZUULI frontend + Playwright, Rust fmt/clippy/deny across every crate under `wallet/`, target-native clippy on macOS and Windows, and the repository policy scripts |
 | `rs.yml` | **yes — the required `rs / gate`** | the `rs/` Rust workspace, plus the tree-wide policy checks its `changes` job runs unconditionally: action pins, gate wiring, hash-domain labels, server images, the toolchain pin, and Markdown link resolution |
-| `wallet-surfaces.yml` | no | build coverage for free2z and e2e2z — typecheck, tests, bundle, `cargo build` per backend |
+| `wallet-surfaces.yml` | no | `cargo build --all-targets` and `cargo test` of the free2z and e2e2z backends. Their frontend suites moved into `zuuli.yml`'s gated `surfaces` job in #915 |
 | `zuuallet.yml` | no | Zuuallet frontend + backend, and the weekly `upstream-canary` against latest librustzcash `main` |
 
 Two consequences worth internalising:
@@ -115,9 +115,15 @@ Two consequences worth internalising:
   workflow.** Its change detector selects `wallet/free2z/**` and
   `wallet/e2e2z/**`, so the capability and boundary checks in
   [`docs/architecture.md` §4](./architecture.md#4-what-enforces-the-boundary)
-  run on every pull request that touches either tree. `wallet-surfaces.yml`
+  run on every pull request that touches either tree — and since #915 so do both
+  surfaces' own suites, in the gated `surfaces` job. `wallet-surfaces.yml`
   publishes no gate and is registered in `check-workflow-gates.mjs`'s
   `UNGATED_WORKFLOWS`.
+- **A change touching only a surface's frontend tests skips the native matrix.**
+  `wallet/{free2z,e2e2z}/tests/**` and their `src/**/*.test.ts?(x)` are carved
+  out of the `zuuli` selector and select `surfaces` instead (#949). Anything
+  under `src-tauri/` — including a Rust integration test — is not, and still
+  selects everything.
 - **`rust_fmt` / `rust_clippy` / `rust_deny` discover crates** by finding
   `Cargo.toml` under `wallet/` rather than listing them, so a new crate is gated
   from its first commit and cannot escape the MSRV check by never being

--- a/docs/status.md
+++ b/docs/status.md
@@ -33,7 +33,7 @@ Per-app detail stays in the per-app documents:
 | `execute-payment` is implemented end-to-end **on ZUULI's side of the seam** | `wallet/zuuli/src-tauri/src/intent.rs` — admit, propose, re-derive the review, confirm natively, bind, execute |
 | Content surfaces are ported to free2z: articles, creator, live, AI, search | `wallet/free2z/src/features/` |
 | The messaging surface is ported to e2e2z | `wallet/e2e2z/src/features/messages/` |
-| Both delegated surfaces have CI build coverage | `.github/workflows/wallet-surfaces.yml` |
+| Both delegated surfaces' own test suites can fail a merge | the `surfaces` job in `.github/workflows/zuuli.yml`, awaited by the required `gate` (#915) |
 
 Merged for the split, in order: [#909](https://github.com/free2z/zuu/pull/909)
 scaffolds · [#911](https://github.com/free2z/zuu/pull/911) intent protocol ·

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -1777,7 +1777,7 @@ function requiredFrontendWasmControlFailures(relativeFile, lines, frontend) {
     frontend.properties.get("if")?.value !== REQUIRED_SURFACE_SELECTOR_CONDITION
   ) {
     failures.push(
-      `${relativeFile}:${frontend.start + 1}: frontend must run exactly when the fail-closed ZUULI selector is true`,
+      `${relativeFile}:${frontend.start + 1}: frontend must run exactly when the fail-closed surface selector is true`,
     );
   }
   const steps = policyJobSteps(
@@ -5176,9 +5176,9 @@ function runCurrentWorkflowMutationTests(repoRoot) {
     {
       name: "real workflow rejects a dynamically dead frontend job",
       needle:
-        "frontend must run exactly when the fail-closed ZUULI selector is true",
+        "frontend must run exactly when the fail-closed surface selector is true",
       source: replaceFrontend(
-        "    if: needs.changes.outputs.zuuli == 'true'",
+        `    if: ${REQUIRED_SURFACE_SELECTOR_CONDITION}`,
         "    if: false",
       ),
     },

--- a/scripts/check-github-actions-pins.mjs
+++ b/scripts/check-github-actions-pins.mjs
@@ -67,12 +67,102 @@ const RUST_ROOT_CONTRACTS = [
           // under the same two prefixes still selects the full gate.
           "wallet/free2z/src/App.tsx",
           "wallet/e2e2z/src/App.tsx",
+          // #949 carved the two delegated surfaces' frontend tests out of this
+          // selector. wallet/zuuli's own tests are not carved out and must not
+          // be: they run inside `zuuli / frontend`, which this output gates.
+          "wallet/zuuli/tests/viewport.pw.ts",
+          // wallet/e2e2z/scripts/release-path.node-test.mjs reads this file and
+          // runs inside the gate as part of e2e2z's `npm test`.
+          ".github/workflows/e2e2z-release.yml",
         ],
       },
       {
         name: "zuuallet_schema",
         probeRoot: "wallet/zuuallet/src-tauri",
       },
+      // #915 put the two delegated surfaces' own suites inside the required
+      // gate, as zuuli.yml's `surfaces` job. Its selector is a strict superset
+      // of `zuuli`: everything that selects the full gate also changes what
+      // free2z and e2e2z build against, and the frontend-test paths #949 carved
+      // out of `zuuli` select it and nothing else.
+      {
+        name: "surfaces",
+        probeRoot: "wallet",
+        additionalProbePaths: [
+          "wallet/free2z/src/App.tsx",
+          "wallet/e2e2z/src/App.tsx",
+          ".github/workflows/e2e2z-release.yml",
+        ],
+      },
+    ],
+    // Paths whose whole point is that the outputs disagree: the #949 carve-out
+    // exists precisely so a frontend test selects the surfaces suite that runs
+    // it and not the ~40-minute native matrix that cannot see it. An entry here
+    // must name every output, so widening the carve-out to swallow a path that
+    // should still select ZUULI is red rather than merely different.
+    mixedProbePaths: [
+      // The carve-out itself, at both depths a `*` that spans `/` reaches, and
+      // for both surfaces.
+      [
+        "wallet/free2z/tests/search.pw.ts",
+        { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+      ],
+      [
+        "wallet/free2z/tests/helpers/mock-capture.ts",
+        { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+      ],
+      [
+        "wallet/e2e2z/tests/enrollment-gap.pw.ts",
+        { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+      ],
+      [
+        "wallet/free2z/src/lib/markdown.test.ts",
+        { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+      ],
+      [
+        "wallet/free2z/src/components/Article.test.tsx",
+        { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+      ],
+      [
+        "wallet/e2e2z/src/lib/enrollment.test.ts",
+        { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+      ],
+      [
+        "wallet/e2e2z/src/screens/Threads.test.tsx",
+        { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+      ],
+      // `zuuallet_schema` is "true" on the three `.rs` probes below because the
+      // schema arm selects `wallet/*.rs` at any depth. That is pre-existing and
+      // correct; it is stated here rather than asserted away.
+      //
+      // The trap. A Rust integration test lives under `src-tauri/tests/`
+      // (wallet/free2z/src-tauri/tests/http_scope.rs, #942) and MUST run the
+      // Rust jobs; a `wallet/<app>/*tests/*`-shaped carve-out would swallow it.
+      // `wallet/<app>/src/*.test.ts` is the same trap one directory over:
+      // `src-tauri` is not `src`, and a carve-out that treats it as one takes
+      // the whole native matrix off a Rust source change.
+      [
+        "wallet/free2z/src-tauri/tests/http_scope.rs",
+        { zuuli: "true", zuuallet_schema: "true", surfaces: "true" },
+      ],
+      [
+        "wallet/e2e2z/src-tauri/tests/authority.rs",
+        { zuuli: "true", zuuallet_schema: "true", surfaces: "true" },
+      ],
+      [
+        "wallet/free2z/src-tauri/src/http.test.ts",
+        { zuuli: "true", zuuallet_schema: "false", surfaces: "true" },
+      ],
+      // A test *and* a source file in one commit still selects the full gate:
+      // the guard is per-file, so the source file decides.
+      [
+        "wallet/free2z/tests/search.pw.ts\0wallet/free2z/src/App.tsx",
+        { zuuli: "true", zuuallet_schema: "false", surfaces: "true" },
+      ],
+      [
+        "wallet/free2z/tests/search.pw.ts\0wallet/free2z/src-tauri/src/lib.rs",
+        { zuuli: "true", zuuallet_schema: "true", surfaces: "true" },
+      ],
     ],
     excludedProbePaths: [
       "wallet/README.md",
@@ -401,11 +491,70 @@ const REQUIRED_FRONTEND_BUILD_TSCONFIG = Object.freeze({
   extends: "./tsconfig.json",
   exclude: Object.freeze(["src/**/*.test.ts", "src/**/*.test.tsx"]),
 });
+/// The condition both frontend jobs run under.
+///
+/// `surfaces` is a strict superset of `zuuli`, so the second disjunct is what
+/// decides; the first is retained so that a future edit which breaks the
+/// superset invariant cannot silently stop running the wallet's own frontend
+/// suite on a wallet source change. #949 carved frontend test paths out of
+/// `zuuli` to skip the ~40-minute native matrix, and these two jobs are exactly
+/// the ones such a change must still run: `frontend` owns the cross-application
+/// boundary verdicts, `surfaces` executes the tests that changed.
+const REQUIRED_SURFACE_SELECTOR_CONDITION =
+  "needs.changes.outputs.zuuli == 'true' || needs.changes.outputs.surfaces == 'true'";
+/// The complete execution program of the gated surfaces suite (#915).
+///
+/// Pinned line-for-line like the frontend job below, because this is the job
+/// that makes ~900 free2z vitest cases, both Playwright suites and
+/// wallet/e2e2z/tests/enrollment-gap.pw.ts able to fail a merge. A step deleted
+/// or made conditional here is a merge that stops being blocked by them, which
+/// looks exactly like the advisory situation #915 closed.
+const REQUIRED_SURFACES_JOB_LINES = [
+  "  surfaces:",
+  "    name: zuuli / surfaces (${{ matrix.app }})",
+  "    needs: changes",
+  `    if: ${REQUIRED_SURFACE_SELECTOR_CONDITION}`,
+  "    runs-on: ubuntu-latest",
+  "    timeout-minutes: 25",
+  "    strategy:",
+  "      fail-fast: false",
+  "      matrix:",
+  "        app: [free2z, e2e2z]",
+  "    defaults:",
+  "      run:",
+  "        working-directory: wallet/${{ matrix.app }}",
+  "    steps:",
+  `      - uses: ${FRONTEND_CHECKOUT_REFERENCE} # v7.0.1`,
+  "      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0",
+  "        with:",
+  "          node-version: '24'",
+  "          cache: npm",
+  "          cache-dependency-path: wallet/${{ matrix.app }}/package-lock.json",
+  "      - name: Install locked dependencies",
+  "        run: npm ci",
+  "      - name: Audit dependencies (high and critical)",
+  "        run: |",
+  "          for attempt in 1 2 3; do",
+  "            npm audit --audit-level=high && exit 0",
+  '            [ "$attempt" -eq 3 ] && exit 1',
+  "            sleep $((attempt * 5))",
+  "          done",
+  "      - name: Typecheck",
+  "        run: |",
+  "          npm run typecheck",
+  "          npm run typecheck:tests",
+  "      - name: Verify the browser-test browser",
+  "        run: google-chrome --version",
+  "      - name: Test owned frontend modules",
+  "        run: npm test",
+  "      - name: Build production frontend",
+  "        run: npm run build",
+];
 const REQUIRED_FRONTEND_JOB_LINES = [
   "  frontend:",
   "    name: zuuli / frontend",
   "    needs: changes",
-  "    if: needs.changes.outputs.zuuli == 'true'",
+  `    if: ${REQUIRED_SURFACE_SELECTOR_CONDITION}`,
   "    runs-on: ubuntu-latest",
   "    timeout-minutes: 35",
   "    defaults:",
@@ -499,6 +648,7 @@ const REQUIRED_JOB_ENVIRONMENTS = new Map([
 ]);
 const REQUIRED_JOB_DEFAULT_WORKING_DIRECTORIES = new Map([
   ["frontend", "wallet/zuuli"],
+  ["surfaces", "wallet/${{ matrix.app }}"],
 ]);
 const REQUIRED_STEP_ENVIRONMENTS = new Map([
   [
@@ -1571,6 +1721,44 @@ function requiredClassicFrontendAuditFailures(relativeFile, lines) {
   return failures;
 }
 
+/// The gated surfaces suite must exist, be selected by the surface condition,
+/// and match its reviewed program exactly.
+///
+/// A missing job is its own failure rather than a silent pass: #915's whole
+/// defect was a suite that ran somewhere no required check could see, and
+/// deleting this job would restore that state while every other rule here still
+/// reported green.
+function requiredSurfacesControlFailures(relativeFile, lines, surfaces) {
+  if (!surfaces) {
+    return [
+      `${relativeFile}: required workflow must contain the surfaces job that gates the delegated surfaces' own suites`,
+    ];
+  }
+  const failures = [];
+  const actual = lines
+    .slice(surfaces.start, surfaces.end)
+    .filter((line) => line.trim() && !line.trimStart().startsWith("#"))
+    .map((line) => line.trimEnd());
+  if (JSON.stringify(actual) !== JSON.stringify(REQUIRED_SURFACES_JOB_LINES)) {
+    failures.push(
+      `${relativeFile}:${surfaces.start + 1}: surfaces must match the complete exact current-source execution program`,
+    );
+  }
+  if (
+    surfaces.properties.get("if")?.value !== REQUIRED_SURFACE_SELECTOR_CONDITION
+  ) {
+    failures.push(
+      `${relativeFile}:${surfaces.start + 1}: surfaces must run exactly when the fail-closed surface selector is true`,
+    );
+  }
+  if (surfaces.properties.has("continue-on-error")) {
+    failures.push(
+      `${relativeFile}:${surfaces.start + 1}: surfaces cannot soft-fail`,
+    );
+  }
+  return failures;
+}
+
 function requiredFrontendWasmControlFailures(relativeFile, lines, frontend) {
   const failures = [];
   const actualFrontendJobLines = lines
@@ -1586,8 +1774,7 @@ function requiredFrontendWasmControlFailures(relativeFile, lines, frontend) {
     );
   }
   if (
-    frontend.properties.get("if")?.value !==
-    "needs.changes.outputs.zuuli == 'true'"
+    frontend.properties.get("if")?.value !== REQUIRED_SURFACE_SELECTOR_CONDITION
   ) {
     failures.push(
       `${relativeFile}:${frontend.start + 1}: frontend must run exactly when the fail-closed ZUULI selector is true`,
@@ -2068,8 +2255,14 @@ function rustRootSelectorProbeFixture(probePath) {
     "base",
   ]);
   const base = runSelectorProbeGit(repo, ["rev-parse", "HEAD"]);
-  writeFixture(repo, probePath, "selector probe\n");
-  runSelectorProbeGit(repo, ["add", "--", probePath]);
+  // A probe may name several paths, NUL-joined, so a commit that touches a
+  // carved-out file *and* a selecting file can be probed as one diff — the
+  // per-file guards must not let the first excuse the second.
+  const probePaths = probePath.split("\0");
+  for (const entry of probePaths) {
+    writeFixture(repo, entry, "selector probe\n");
+  }
+  runSelectorProbeGit(repo, ["add", "--", ...probePaths]);
   runSelectorProbeGit(repo, ["commit", "--quiet", "-m", "head"]);
   const head = runSelectorProbeGit(repo, ["rev-parse", "HEAD"]);
   const fixture = { base, head, repo };
@@ -2276,6 +2469,37 @@ function rustRootWorkflowFailures(relativeFile, lines, contract) {
                 : `${contract.root}/ owner selector output ${name}`;
             failures.push(
               `${relativeFile}:${selector.start + 1}: ${subject} must actively select ${JSON.stringify(probePath)} as its effective last value`,
+            );
+          }
+        }
+      }
+      // Paths whose expected verdict differs per output. `excludedProbePaths`
+      // asserts "false everywhere" and the per-output probe lists assert "true
+      // for this one"; neither can state the property #949 introduced, which is
+      // that one path selects one output and not another.
+      for (const [probePath, expectations] of contract.mixedProbePaths ?? []) {
+        const declared = Object.keys(expectations).sort().join(",");
+        const outputs = contract.selectorOutputs
+          .map(({ name }) => name)
+          .sort()
+          .join(",");
+        if (declared !== outputs) {
+          failures.push(
+            `${relativeFile}:${selector.start + 1}: ${contract.root}/ owner mixed probe ${JSON.stringify(probePath)} must state every selector output (${outputs}), got ${declared || "(none)"}`,
+          );
+          continue;
+        }
+        const fixture = rustRootSelectorProbeFixture(probePath);
+        const result = executeRustRootSelector(
+          body,
+          fixture,
+          contract,
+          fixture.head,
+        );
+        for (const [name, expected] of Object.entries(expectations)) {
+          if (result.status !== 0 || result.effective.get(name) !== expected) {
+            failures.push(
+              `${relativeFile}:${selector.start + 1}: ${contract.root}/ owner selector must leave ${name} ${expected} for ${JSON.stringify(probePath)}, got ${JSON.stringify(result.effective.get(name))}`,
             );
           }
         }
@@ -2936,6 +3160,11 @@ function gatePolicyFailures(repoRoot, relativeFile, lines) {
       ...requiredFrontendWasmControlFailures(relativeFile, lines, frontend),
     );
   }
+  if (enforceWasmBoundary) {
+    failures.push(
+      ...requiredSurfacesControlFailures(relativeFile, lines, jobs.get("surfaces")),
+    );
+  }
   failures.push(...requiredGateControlFailures(relativeFile, lines, gate));
 
   return failures;
@@ -2993,6 +3222,28 @@ function verifyGateResults(policyOutcome, serializedNeeds) {
       ? "success"
       : "skipped";
   const NATIVE_JOBS = new Set(["rust_native_clippy", "rust_native_tests"]);
+  // #949 carved the two delegated surfaces' frontend test paths out of the
+  // `zuuli` selector so a test-only change skips the ~40-minute native matrix.
+  // The two jobs that must still run on such a change share one selector, for
+  // the same reason the native pair does: `frontend` decides whether either
+  // surface may import across the application split or hold a capability it is
+  // not allowed, and `surfaces` executes the tests that changed. Deriving both
+  // from one value means the gate can never accept a skip from one it would
+  // reject from the other.
+  //
+  // This is also where the required-but-skipped deadlock is avoided rather than
+  // risked. `gate` is the branch-protected context; it carries `if: always()`
+  // and zuuli.yml has no `paths:` filter, so it reports on every pull request.
+  // When `surfaces` is false the surfaces job is skipped and "skipped" is
+  // exactly what this expects, so the gate resolves green. Nothing new was
+  // added to branch protection, so no pull request can wait on a context no job
+  // publishes.
+  const surfaceExpected =
+    zuuliExpected === "success" ||
+    selectorResult(changes.outputs.surfaces, "surfaces") === "success"
+      ? "success"
+      : "skipped";
+  const SURFACE_JOBS = new Set(["frontend", "surfaces"]);
 
   const verdicts = [];
   for (const [job, state] of entries) {
@@ -3010,7 +3261,9 @@ function verifyGateResults(policyOutcome, serializedNeeds) {
           ? schemaExpected
           : NATIVE_JOBS.has(job)
             ? nativeExpected
-            : zuuliExpected;
+            : SURFACE_JOBS.has(job)
+              ? surfaceExpected
+              : zuuliExpected;
     if (state.result !== expected) {
       throw new Error(
         `required job ${job} must be ${expected}, got ${state.result}`,
@@ -3745,6 +3998,109 @@ function runRustRootWorkflowMutationTests(repoRoot) {
           `must leave zuuli false for unrelated input "wallet/${app}/docs/${app === "zuuli" ? "e2ee/" : ""}notes.md"`,
         );
       }
+      // The #949 frontend-test guard is the second negative selector in this
+      // step, and the more dangerous one: markdown genuinely cannot affect a
+      // Rust build, whereas a `tests/` glob one character too wide takes the
+      // whole native matrix off a Rust integration test. Its failure directions
+      // are deleting it, widening it past `src`/`tests` into `src-tauri`,
+      // dropping an application, extending it to wallet/zuuli, and severing the
+      // surfaces output it exists to feed — all exercised against the live
+      // workflow.
+      assertWorkflowFailure(
+        contract,
+        source,
+        "wallet/ rejects deleting the frontend-test guard",
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            '            if [[ "$file" == wallet/free2z/tests/* ||\n' +
+              '                  "$file" == wallet/e2e2z/tests/* ||\n' +
+              '                  "$file" == wallet/free2z/src/*.test.ts ||\n' +
+              '                  "$file" == wallet/free2z/src/*.test.tsx ||\n' +
+              '                  "$file" == wallet/e2e2z/src/*.test.ts ||\n' +
+              '                  "$file" == wallet/e2e2z/src/*.test.tsx ]]; then\n' +
+              "              surfaces=true\n" +
+              "              continue\n" +
+              "            fi\n",
+            "",
+          ),
+        'must leave zuuli false for "wallet/free2z/tests/search.pw.ts"',
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        "wallet/ rejects a frontend-test guard widened into src-tauri/tests",
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            '"$file" == wallet/free2z/tests/*',
+            '"$file" == wallet/free2z/*tests/*',
+          ),
+        'must leave zuuli true for "wallet/free2z/src-tauri/tests/http_scope.rs"',
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        "wallet/ rejects a frontend-test guard widened into src-tauri/src",
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            '"$file" == wallet/free2z/src/*.test.ts ',
+            '"$file" == wallet/free2z/src* ',
+          ),
+        'must leave zuuli true for "wallet/free2z/src-tauri/src/http.test.ts"',
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        "wallet/ rejects dropping wallet/e2e2z from the frontend-test guard",
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            '                  "$file" == wallet/e2e2z/tests/* ||\n',
+            "",
+          ),
+        'must leave zuuli false for "wallet/e2e2z/tests/enrollment-gap.pw.ts"',
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        "wallet/ rejects extending the frontend-test guard to wallet/zuuli",
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            '            if [[ "$file" == wallet/free2z/tests/* ||\n',
+            '            if [[ "$file" == wallet/zuuli/tests/* ||\n' +
+              '                  "$file" == wallet/free2z/tests/* ||\n',
+          ),
+        'must actively select "wallet/zuuli/tests/viewport.pw.ts"',
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        "wallet/ rejects a frontend-test guard that selects nothing at all",
+        (value) =>
+          mutateJob(value, "changes", "              surfaces=true\n              continue\n", "              continue\n"),
+        'must leave surfaces true for "wallet/free2z/tests/search.pw.ts"',
+      );
+      assertWorkflowFailure(
+        contract,
+        source,
+        "wallet/ rejects severing surfaces from the full-gate selector",
+        (value) =>
+          mutateJob(
+            value,
+            "changes",
+            '          if [[ "$zuuli" == true ]]; then\n            surfaces=true\n          fi\n',
+            "",
+          ),
+        'owner selector output surfaces must actively select "wallet/ordinary.rs"',
+      );
       for (const [guard, target, replacement, needle] of
         selectorPatternMutations) {
         const action = replacement ? "broadened" : "removed";
@@ -6450,7 +6806,7 @@ function runSelfTest(repoRoot) {
       needs: {
         changes: {
           result: "success",
-          outputs: { zuuli: "true", zuuallet_schema: "false" },
+          outputs: { zuuli: "true", zuuallet_schema: "false", surfaces: "true" },
         },
         build: { result: "success", outputs: {} },
         rust_android_32: { result: "success", outputs: {} },
@@ -6463,7 +6819,7 @@ function runSelfTest(repoRoot) {
       needs: {
         changes: {
           result: "success",
-          outputs: { zuuli: "false", zuuallet_schema: "true" },
+          outputs: { zuuli: "false", zuuallet_schema: "true", surfaces: "false" },
         },
         build: { result: "skipped", outputs: {} },
         rust_native_clippy: { result: "success", outputs: {} },
@@ -6477,7 +6833,7 @@ function runSelfTest(repoRoot) {
       needs: {
         changes: {
           result: "success",
-          outputs: { zuuli: "false", zuuallet_schema: "true" },
+          outputs: { zuuli: "false", zuuallet_schema: "true", surfaces: "false" },
         },
         rust_native_clippy: { result: "skipped", outputs: {} },
         zuuallet_schema: { result: "success", outputs: {} },
@@ -6490,7 +6846,7 @@ function runSelfTest(repoRoot) {
       needs: {
         changes: {
           result: "success",
-          outputs: { zuuli: "false", zuuallet_schema: "true" },
+          outputs: { zuuli: "false", zuuallet_schema: "true", surfaces: "false" },
         },
         rust_native_tests: { result: "skipped", outputs: {} },
         zuuallet_schema: { result: "success", outputs: {} },
@@ -6502,7 +6858,7 @@ function runSelfTest(repoRoot) {
       needs: {
         changes: {
           result: "success",
-          outputs: { zuuli: "false", zuuallet_schema: "false" },
+          outputs: { zuuli: "false", zuuallet_schema: "false", surfaces: "false" },
         },
         rust_native_clippy: { result: "skipped", outputs: {} },
         rust_native_tests: { result: "skipped", outputs: {} },
@@ -6516,7 +6872,7 @@ function runSelfTest(repoRoot) {
       needs: {
         changes: {
           result: "success",
-          outputs: { zuuli: "true", zuuallet_schema: "false" },
+          outputs: { zuuli: "true", zuuallet_schema: "false", surfaces: "true" },
         },
         rust_native_tests: { result: "failure", outputs: {} },
       },
@@ -6534,7 +6890,7 @@ function runSelfTest(repoRoot) {
       needs: {
         changes: {
           result: "success",
-          outputs: { zuuli: "true", zuuallet_schema: "false" },
+          outputs: { zuuli: "true", zuuallet_schema: "false", surfaces: "true" },
         },
         build: { result: "failure", outputs: {} },
       },
@@ -6546,7 +6902,7 @@ function runSelfTest(repoRoot) {
       needs: {
         changes: {
           result: "success",
-          outputs: { zuuli: "true", zuuallet_schema: "false" },
+          outputs: { zuuli: "true", zuuallet_schema: "false", surfaces: "true" },
         },
         frontend: { result: "failure", outputs: {} },
       },
@@ -6558,7 +6914,7 @@ function runSelfTest(repoRoot) {
       needs: {
         changes: {
           result: "success",
-          outputs: { zuuli: "true", zuuallet_schema: "false" },
+          outputs: { zuuli: "true", zuuallet_schema: "false", surfaces: "true" },
         },
         zuuallet_schema: { result: "success", outputs: {} },
       },
@@ -6570,11 +6926,100 @@ function runSelfTest(repoRoot) {
       needs: {
         changes: {
           result: "success",
-          outputs: { zuuli: "", zuuallet_schema: "false" },
+          outputs: { zuuli: "", zuuallet_schema: "false", surfaces: "false" },
+        },
+      },
+    },
+    {
+      name: "a frontend-test-only change still gates the surfaces suite (#949/#915)",
+      policyOutcome: "success",
+      needs: {
+        changes: {
+          result: "success",
+          outputs: { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+        },
+        frontend: { result: "success", outputs: {} },
+        surfaces: { result: "success", outputs: {} },
+        rust_clippy: { result: "skipped", outputs: {} },
+        rust_native_clippy: { result: "skipped", outputs: {} },
+        zuuallet_schema: { result: "skipped", outputs: {} },
+      },
+    },
+    {
+      name: "a failing free2z suite fails the protected gate (#915)",
+      policyOutcome: "success",
+      needle: "required job surfaces must be success, got failure",
+      needs: {
+        changes: {
+          result: "success",
+          outputs: { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+        },
+        surfaces: { result: "failure", outputs: {} },
+      },
+    },
+    {
+      name: "the surfaces suite cannot skip a change that selected it",
+      policyOutcome: "success",
+      needle: "required job surfaces must be success, got skipped",
+      needs: {
+        changes: {
+          result: "success",
+          outputs: { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+        },
+        surfaces: { result: "skipped", outputs: {} },
+      },
+    },
+    {
+      name: "the frontend boundary job cannot skip a surfaces-only change",
+      policyOutcome: "success",
+      needle: "required job frontend must be success, got skipped",
+      needs: {
+        changes: {
+          result: "success",
+          outputs: { zuuli: "false", zuuallet_schema: "false", surfaces: "true" },
+        },
+        frontend: { result: "skipped", outputs: {} },
+      },
+    },
+    {
+      name: "a change touching neither app leaves the surfaces suite skipped, and the gate green",
+      policyOutcome: "success",
+      needs: {
+        changes: {
+          result: "success",
+          outputs: { zuuli: "false", zuuallet_schema: "false", surfaces: "false" },
+        },
+        frontend: { result: "skipped", outputs: {} },
+        surfaces: { result: "skipped", outputs: {} },
+        rust_clippy: { result: "skipped", outputs: {} },
+        zuuallet_schema: { result: "skipped", outputs: {} },
+      },
+    },
+    {
+      name: "the surfaces suite cannot run itself green off an unselected change",
+      policyOutcome: "success",
+      needle: "required job surfaces must be skipped, got success",
+      needs: {
+        changes: {
+          result: "success",
+          outputs: { zuuli: "false", zuuallet_schema: "false", surfaces: "false" },
+        },
+        surfaces: { result: "success", outputs: {} },
+      },
+    },
+    {
+      name: "an invalid surfaces selector fails closed",
+      policyOutcome: "success",
+      needle: "invalid or missing surfaces change-detector output",
+      needs: {
+        changes: {
+          result: "success",
+          outputs: { zuuli: "false", zuuallet_schema: "false", surfaces: "" },
         },
       },
     },
   ];
+
   for (const testCase of gateResultCases) {
     let error = null;
     try {

--- a/scripts/check-workflow-gates.mjs
+++ b/scripts/check-workflow-gates.mjs
@@ -232,20 +232,22 @@ const UNGATED_WORKFLOWS = new Map([
   ],
   [
     ".github/workflows/wallet-surfaces.yml",
-    "Advisory build of the two delegated surfaces of the three-app split (#904/#906) — wallet/free2z " +
+    "Cargo build and test of the two delegated surfaces' Tauri backends (#904/#906) — wallet/free2z " +
       "and wallet/e2e2z — behind an `on: pull_request: paths:` filter. Nothing that decides whether " +
-      "either surface is safe is decided here: the ZUULI change detector selects `wallet/free2z/*` and " +
-      "`wallet/e2e2z/*`, so the required `gate` in zuuli.yml already runs the capability contract " +
-      "(wallet/zuuli/scripts/surface-capability-authority.mjs) and the cross-application import check " +
-      "(project-boundary.mjs) inside the protected `zuuli / frontend` job, and rust_fmt/rust_clippy/" +
-      "rust_deny discover both new src-tauri crates rather than listing them. What remains here is " +
-      "surface build coverage plus, since #904 phase 3, each surface's OWN unit and browser suites — " +
-      "including wallet/e2e2z/tests/enrollment-gap.pw.ts, which proves the messaging surface cannot " +
-      "appear enrolled without the wallet authority. Those suites therefore cannot fail a merge " +
-      "today, and this entry does not pretend otherwise: #915 decides whether they move into the " +
-      "required gate. The security PROPERTY they illustrate is separately gated — no `zcash:*` for " +
-      "e2e2z and no cross-application import are both decided by the two checkers named above, " +
-      "inside `gate`.",
+      "either surface is safe is decided here, and since #915 neither are their test suites. The " +
+      "ZUULI change detector selects `wallet/free2z/*` and `wallet/e2e2z/*`, so the required `gate` " +
+      "in zuuli.yml runs the capability contract (wallet/zuuli/scripts/surface-capability-authority" +
+      ".mjs) and the cross-application import check (project-boundary.mjs) inside the protected " +
+      "`zuuli / frontend` job; rust_fmt/rust_clippy/rust_deny discover both src-tauri crates rather " +
+      "than listing them; and zuuli.yml's `surfaces` job now runs each surface's OWN typecheck, " +
+      "vitest, ui-copy and Playwright suites — including wallet/e2e2z/tests/enrollment-gap.pw.ts, " +
+      "which proves the messaging surface cannot appear enrolled without the wallet authority. Those " +
+      "suites MOVED into the gate rather than being copied into it, so this file no longer runs " +
+      "them and the entry claims no coverage it does not have. What is left is the `cargo build " +
+      "--all-targets` and `cargo test` of each backend, which restate work the gate's rust_fmt/" +
+      "rust_clippy/rust_deny legs already cover for compilation and lint; gating the remainder means " +
+      "first moving its paths filter into a change-detector job, since a required context from a " +
+      "path-filtered workflow that did not run never reports.",
   ],
   [
     ".github/workflows/f2z-images.yml",

--- a/scripts/check-zuuli-android-gate.mjs
+++ b/scripts/check-zuuli-android-gate.mjs
@@ -13,8 +13,26 @@ const toolchainEnvPath = "wallet/zuuli/scripts/android-toolchain-env.sh";
 const target = "armv7-linux-androideabi";
 const ndk = "27.0.12077973";
 const cacheKey = `zuuli-plugin-android-armv7-ndk${ndk}-api29`;
+// Re-derived for #949/#915. The reviewed semantic delta from
+// cad2731734c97401e94ae2b25a722141f09488a107ddde6f28618a5454786c02 is:
+//
+//   * a third output, `surfaces`, initialised false, set true in both fail-open
+//     arms — whose *conditions* are unchanged byte for byte — and derived after
+//     the loop as `zuuli || <frontend test path seen>`, i.e. a strict superset
+//     of `zuuli`;
+//   * a per-file guard, in the shape of the #919 markdown guard, that excuses
+//     six frontend test path patterns under wallet/free2z and wallet/e2e2z from
+//     the `zuuli` arm and selects `surfaces` instead. Every pattern is anchored
+//     at the literal prefix `wallet/<app>/tests/` or `wallet/<app>/src/`, and
+//     `src-tauri` is neither, so a Rust integration test still selects the full
+//     matrix (scripts/check-github-actions-pins.mjs probes both directions);
+//   * `.github/workflows/e2e2z-release.yml` added to the `zuuli` arm — purely
+//     additive — because wallet/e2e2z/scripts/release-path.node-test.mjs reads
+//     it and now runs inside the gate.
+//
+// Nothing else in the step changed, and no existing pattern was removed.
 const changeDetectorDigest =
-  "cad2731734c97401e94ae2b25a722141f09488a107ddde6f28618a5454786c02";
+  "464b7a522cdb2348ee9fdbfa46300ba536de8bb911c10ddaa5bb00da249fa410";
 const toolchainEnvDigest =
   "403f59c58bca0a37b98a3bb0ea0ae7f1c289b3531d6e1eec8496643866ee2013";
 const requiredMessagingSelector = "wallet/zuuli/*";
@@ -409,7 +427,7 @@ function runSelfTest(workflow, toolchainEnv) {
   for (const [name, digest] of [
     [
       "the reviewed change-detector digest is stale",
-      "c6310395af8224c88b3e58fddf182950d65c52cf12caf6b48bbf82815694f52b",
+      "cad2731734c97401e94ae2b25a722141f09488a107ddde6f28618a5454786c02",
     ],
     ["the reviewed change-detector digest is wrong", "0".repeat(64)],
   ]) {


### PR DESCRIPTION
Closes #949. Closes #915.

Both issues are about the same required check — `gate` in `zuuli.yml` — from
opposite directions: it selects too much work for changes that cannot affect it,
and too little work for changes that can.

---

## #949 — frontend-test-only changes no longer select the native matrix

`#919` carved `wallet/{zuuli,free2z,e2e2z}/**/*.md` out of the change detector.
Frontend test files got no such carve-out, so `#938` — 1,226 lines entirely
under `wallet/free2z/tests/`, no application source, no config — waited on the
full matrix. Measured on run `33969224048`, that is `Rust / lints` **41m** and
`Rust / native lints (macos)` **37m**, against a `zuuli / frontend` job of
**6m**.

A second per-file guard, in the shape of the markdown one, now excuses six
frontend test path patterns and selects the surfaces suite instead:

```bash
if [[ "$file" == wallet/free2z/tests/* ||
      "$file" == wallet/e2e2z/tests/* ||
      "$file" == wallet/free2z/src/*.test.ts ||
      "$file" == wallet/free2z/src/*.test.tsx ||
      "$file" == wallet/e2e2z/src/*.test.ts ||
      "$file" == wallet/e2e2z/src/*.test.tsx ]]; then
  surfaces=true
  continue
fi
```

**Why this is not a `tests/` glob.** `wallet/free2z/src-tauri/tests/http_scope.rs`
(#942) is a Rust integration test and must run the Rust jobs. Every pattern above
is anchored at the literal prefix `wallet/<app>/tests/` or `wallet/<app>/src/`.
`*` inside `[[ ]]` spans `/`, but the *prefix* still has to match, and
`wallet/<app>/src-tauri/` is not `wallet/<app>/src/` or `wallet/<app>/tests/`,
so nothing under `src-tauri/` can reach the guard however far the wildcard runs.

**`wallet/zuuli`'s own tests are deliberately absent.** They execute inside the
protected `zuuli / frontend` job, so carving them out would skip the job that
runs them — the exact defect #915 is about.

### Observed filter output

Not reasoning — output. I extracted the `run:` body of the
`Detect release-impacting ZUULI changes` step **verbatim** from
`.github/workflows/zuuli.yml` and executed that exact shell against real
throwaway Git repositories with the `BASE_SHA` / `GITHUB_SHA` / `GITHUB_OUTPUT`
environment GitHub supplies. **This is the real predicate, not the workflow: no
Actions run was involved.** (`scripts/check-github-actions-pins.mjs` does the
same thing, which is why it can be a negative control.)

```
# extracted 114 lines of the selector's run: body from .github/workflows/zuuli.yml

A  a Playwright spec alone (#949: must SKIP the Rust matrix)
    changed: wallet/free2z/tests/search.pw.ts
  -> exit 0  zuuli=false  zuuallet_schema=false  surfaces=true

B  a src-tauri integration test alone (#942: must run the FULL matrix)
    changed: wallet/free2z/src-tauri/tests/http_scope.rs
  -> exit 0  zuuli=true  zuuallet_schema=true  surfaces=true

C  a frontend test PLUS a source file (must run the FULL matrix)
    changed: wallet/free2z/tests/search.pw.ts
    changed: wallet/free2z/src/App.tsx
  -> exit 0  zuuli=true  zuuallet_schema=false  surfaces=true

D  a frontend test PLUS a src-tauri file (must run the FULL matrix)
    changed: wallet/free2z/tests/search.pw.ts
    changed: wallet/free2z/src-tauri/src/lib.rs
  -> exit 0  zuuli=true  zuuallet_schema=true  surfaces=true

E  a vitest file under a surface's src/ (must SKIP the Rust matrix)
    changed: wallet/free2z/src/lib/markdown.test.ts
  -> exit 0  zuuli=false  zuuallet_schema=false  surfaces=true

F  the e2e2z enrollment-gap spec (must SKIP the Rust matrix, RUN surfaces)
    changed: wallet/e2e2z/tests/enrollment-gap.pw.ts
  -> exit 0  zuuli=false  zuuallet_schema=false  surfaces=true

G  wallet/zuuli's OWN Playwright spec (deliberately NOT carved out)
    changed: wallet/zuuli/tests/viewport.pw.ts
  -> exit 0  zuuli=true  zuuallet_schema=false  surfaces=true

H  prose only (#919 markdown guard, unchanged)
    changed: wallet/free2z/README.md
  -> exit 0  zuuli=false  zuuallet_schema=false  surfaces=false

I  a file no selector names (everything skips)
    changed: docs/unrelated.md
  -> exit 0  zuuli=false  zuuallet_schema=false  surfaces=false

J  fail-open: an unusable base SHA must still run EVERYTHING
    changed: wallet/free2z/tests/search.pw.ts
    BASE_SHA: "not-a-commit-sha"
  -> exit 0  zuuli=true  zuuallet_schema=true  surfaces=true

K  fail-open: an unresolvable base commit must still run EVERYTHING
    changed: wallet/free2z/tests/search.pw.ts
    BASE_SHA: "ffffffffffffffffffffffffffffffffffffffff"
  -> exit 0  zuuli=true  zuuallet_schema=true  surfaces=true
```

`zuuallet_schema=true` on B and D is pre-existing and correct: the schema arm
selects `wallet/*.rs` at any depth.

### Fail-open

The two fail-open **conditions** are unchanged byte for byte:

```bash
if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
   ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
...
if ! git diff --name-only -z --no-renames "$BASE_SHA" "$GITHUB_SHA" > "$changed_files"; then
```

Each arm gains one line — `echo "surfaces=true"` — because "run everything" has
to include the new output. J and K above are the observed proof; the policy
script probes both directions independently for all three outputs.

### Negative control

Widening one clause so it swallows `src-tauri/tests/**` must go **red**, not
merely look wrong. Applying `wallet/free2z/tests/*` → `wallet/free2z/*tests/*`:

```
=== observed predicate under the widened glob ===
B  a src-tauri integration test alone (#942: must run the FULL matrix)
    changed: wallet/free2z/src-tauri/tests/http_scope.rs
  -> exit 0  zuuli=false  zuuallet_schema=false  surfaces=true

=== check-github-actions-pins.mjs (live) under the widened glob ===
GitHub Actions fail-closed policy failed:
- .github/workflows/zuuli.yml:104: wallet/ owner selector must leave zuuli true for "wallet/free2z/src-tauri/tests/http_scope.rs", got "false"
- .github/workflows/zuuli.yml:104: wallet/ owner selector must leave zuuallet_schema true for "wallet/free2z/src-tauri/tests/http_scope.rs", got "false"
2 failure(s); scanned 21 workflow/action file(s) and 241 external reference(s).
exit=1

=== check-zuuli-android-gate.mjs (live) under the widened glob ===
- change detector differs from the reviewed fail-open/fail-closed selector step
exit=1
```

Seven such mutations are now permanent self-test cases:

```
self-test: wallet/ rejects deleting the frontend-test guard: passed
self-test: wallet/ rejects a frontend-test guard widened into src-tauri/tests: passed
self-test: wallet/ rejects a frontend-test guard widened into src-tauri/src: passed
self-test: wallet/ rejects dropping wallet/e2e2z from the frontend-test guard: passed
self-test: wallet/ rejects extending the frontend-test guard to wallet/zuuli: passed
self-test: wallet/ rejects a frontend-test guard that selects nothing at all: passed
self-test: wallet/ rejects severing surfaces from the full-gate selector: passed
```

They rest on a new `mixedProbePaths` contract in
`scripts/check-github-actions-pins.mjs`. The existing machinery could say
"true everywhere" (`additionalProbePaths`) or "false everywhere"
(`excludedProbePaths`); neither can state the property this PR introduces, which
is that one path selects one output and *not* another. An entry must name every
selector output, so a future output cannot be quietly left unasserted.

### Re-derived digest

The detector step is digest-pinned. The new value is
`464b7a522cdb2348ee9fdbfa46300ba536de8bb911c10ddaa5bb00da249fa410`, derived with
`--print-change-detector-digest` **after** confirming the semantic delta from
`cad2731734c9…`, which is recorded next to the constant:

* a third output, `surfaces`, initialised false, set true in both fail-open arms
  (conditions unchanged), and derived after the loop as `zuuli || <frontend test
  path seen>` — a strict superset of `zuuli`;
* the per-file frontend-test guard above;
* `.github/workflows/e2e2z-release.yml` added to the `zuuli` arm — purely
  additive, nothing removed — because
  `wallet/e2e2z/scripts/release-path.node-test.mjs` reads it and now runs inside
  the gate.

**What the pin protects:** the digest is the one control that fails on *any*
edit to this step, including edits none of the semantic rules model — a reordered
`case`, a `continue` moved above a guard, an `esac` that ends a different block,
dead code wrapping the real selector. The semantic rules answer "does it still
select the right things"; the digest answers "did a human look". A subtractive
edit is exactly the shape that needs both, which is why re-deriving it is the
last step here and not the first. The self-test's stale-digest control is now
the immediately preceding reviewed value rather than an arbitrary constant, so
it fails for the reason it names.

---

## #915 — the delegated surfaces' suites can now fail a merge

Branch protection requires exactly `["gate", "rs / gate"]`. The security half was
already correct: `gate` needs `frontend`, which runs `project-boundary.mjs` and
`surface-capability-authority.mjs`. The suites were not: they ran in
`wallet-surfaces.yml` as `surfaces_frontend`, which publishes no required
context — roughly 900 vitest cases plus Playwright for free2z, ~209 plus
Playwright for e2e2z, including `enrollment-gap.pw.ts`.

**`gate` depends on the suite; branch protection is untouched.** Adding a
required context is a repo-settings change no PR can make, and a wrong name
blocks every merge forever. So the frontend leg **moved** out of
`wallet-surfaces.yml` into `zuuli.yml` as the `surfaces` job (a `free2z`/`e2e2z`
matrix), and that job joined `gate`'s `needs:` — the same way every other job in
that file is gated. It moved rather than being copied: running both suites twice
per pull request is the cost #949 is about. `wallet-surfaces.yml` keeps its
`cargo build --all-targets` / `cargo test` leg.

### The required-but-skipped deadlock, reasoned through

This is the part that can stop the repo merging, so, explicitly:

1. The required context is `gate`, and it is **unchanged**. No name was added to
   branch protection, so there is no name that can go unpublished.
2. `zuuli.yml` has **no `paths:` filter** on `pull_request`, so `changes` and
   `gate` run on every pull request. `gate` carries `if: always()`. It therefore
   always reports.
3. `surfaces` is skipped when its selector is false. A skipped `needs:` entry
   does not skip `gate` — `if: always()` — it arrives in `toJSON(needs)` with
   `result: "skipped"`.
4. `--verify-gate-results` compares every entry against the result its selector
   predicts. `surfaces` and `frontend` are predicted from
   `zuuli || surfaces`, exactly as `rust_native_clippy` / `rust_native_tests`
   are already predicted from `zuuli || zuuallet_schema`. A skip when the
   selector is false is *expected*, so the gate resolves green.
5. The matrix is `fail-fast: false`; `needs.surfaces.result` is the aggregate, so
   either leg failing makes it `failure` and the gate red.

Observed, running the real gate verdict step
(`node scripts/check-github-actions-pins.mjs --verify-gate-results`) with the
`needs` payloads GitHub would hand it:

```
1  frontend-test-only PR, everything as predicted (gate must be GREEN)
The full-stack gate passed: changes=success, frontend=success, surfaces=success, rust_fmt=skipped, ...
  -> gate exit=0

2  same PR, but a free2z test failed (gate must be RED)
Required-gate verdict failed: required job surfaces must be success, got failure
  -> gate exit=1

3  same PR, but the surfaces suite never ran (gate must be RED)
Required-gate verdict failed: required job surfaces must be success, got skipped
  -> gate exit=1

4  a PR touching NEITHER new app: every job skipped (gate must be GREEN - no deadlock)
The full-stack gate passed: changes=success, frontend=skipped, surfaces=skipped, rust_fmt=skipped, ...
  -> gate exit=0

5  a full-matrix PR with a failing e2e2z suite (gate must be RED)
Required-gate verdict failed: required job surfaces must be success, got failure
  -> gate exit=1
```

Case 4 is the deadlock control and case 2 is #915's acceptance criterion: a red
free2z suite is now an unmergeable pull request. Seven equivalents are permanent
self-test cases, including "the surfaces suite cannot run itself green off an
unselected change" and "an invalid surfaces selector fails closed".

The job itself is pinned line-for-line (`REQUIRED_SURFACES_JOB_LINES`), the way
`frontend` is, and a *missing* `surfaces` job is its own failure — deleting it
would restore exactly the state #915 describes while every other rule stayed
green.

### `frontend` runs on the surfaces selector too

`zuuli / frontend` owns the cross-application boundary verdicts for both
surfaces — `project-boundary.mjs`, and `surface-capability-authority.mjs` via
`npm run test`. A change that only edits a surface's tests skips the 41-minute
matrix but must not skip the 6-minute job deciding whether that surface may
import across the split. Its `if` is now the same
`zuuli || surfaces` condition, so #949 costs no boundary coverage.

Two `paths:` entries left `wallet-surfaces.yml` with the frontend leg, because
both existed only for it: `.github/workflows/e2e2z-release.yml` (read by
`wallet/e2e2z/scripts/release-path.node-test.mjs`, part of e2e2z's `npm test` —
which is why that file joins the ZUULI selector here, so the test keeps its
trigger) and `wallet/zuuli/scripts/surface-capability-authority.mjs` (nothing in
either surface's remaining `cargo` leg reads it, and it already selects the
whole gate through `wallet/zuuli/*`).

### The registration stays true

`wallet-surfaces.yml`'s `UNGATED_WORKFLOWS` entry was corrected once before for
claiming "surface-only build coverage" long after real tests moved there. It is
rewritten to say what the file now does — `cargo build`/`cargo test` only — to
say the suites **moved** into the gate rather than being newly covered from two
places, and to keep the standing reason gating the remainder is not a one-liner
(a required context from a path-filtered workflow that did not run never
reports). `check-workflow-gates.mjs --self-test` (39 cases) and its live verdict
both pass.

---

## Trade-off, stated

`surfaces` is a strict superset of `zuuli`, so a pull request that selects the
full gate for an unrelated reason (a `wallet/zuuli/src` change, say) now also
runs both surface legs, which `wallet-surfaces.yml`'s `paths:` filter would have
skipped. That costs runner minutes, not wall clock — those legs are ~10–15
minutes beside a 41-minute `Rust / lints` — and it buys one authoritative
pattern list instead of a second copy of the selector that can drift. The
alternative, a dedicated pattern list for `surfaces`, would duplicate
`wallet/zuuli/*` and break the "exactly one active arm" rule the policy script
already enforces.

## Verification

| Check | Result |
| --- | --- |
| `check-zuuli-android-gate.mjs --self-test` | 34 mutations passed |
| `check-zuuli-android-gate.mjs` (live) | passed |
| `check-workflow-gates.mjs --self-test` | 39 cases passed |
| `check-workflow-gates.mjs` (live) | passed — 2 gates, 18 registered ungated, 77 jobs, 20 workflows |
| `check-github-actions-pins.mjs --self-test` | 74 source-policy, 18 gate-verdict, 148 current-workflow, 3 project-discovery, 18 frontend-build, 4 classic-frontend-audit, 141 Rust-root cases passed (9m04s locally, vs 8m47s on `main` — +3%) |
| `check-github-actions-pins.mjs` (live) | passed — 241 external refs, 21 files |
| `check-public-repo-boundary.sh --self-test`, live | passed (exit 0) |
| `check-zuuli-linux-image.mjs`, `check-zuuli-store-capture-image.mjs`, `check-librustzcash-compat.mjs`, `check-pow-policy.mjs`, `check-tauri-plugin-permissions.mjs` | passed |
| Observed selector output | 11 cases above |
| Negative control: glob widened into `src-tauri/tests` | both policy checks red |
| Negative control: failing free2z suite | gate verdict red |

## Scope

`.github/workflows/**` and `scripts/**`. No file under `wallet/**` is touched.

One deliberate addition, in a second commit: `docs/status.md`,
`docs/architecture.md` and `docs/development.md` each stated that the two
delegated surfaces' tests run in `wallet-surfaces.yml`. That stops being true
here. The same doctrine that made `UNGATED_WORKFLOWS`' entry worth rewriting —
an excuse that outlives its situation reads as considered — applies to the three
documents that say the same thing, so they are corrected rather than left to
rot. `check-markdown-links.mjs` passes (920 links, 491 anchors, 113 documents).
