### PR TITLE
chore(e2e2z): record the Apple store identity so a TestFlight-only release clears prepare

### DIFF
--- a/wallet/e2e2z/README.md
+++ b/wallet/e2e2z/README.md
@@ -219,10 +219,11 @@ also needs the Apple secrets in the protected `e2e2z-app-stores` environment:
 `APPLE_DISTRIBUTION_CERTIFICATE_BASE64`, its password, and `ASC_KEY_BASE64` are
 not yet.
 
-The third value in that file — `google.appSigningCertificateSha256` — is the one
-`assetlinks.json` needs. Play App Signing generates it, so it is readable only
-from Play Console (Setup → App integrity → App signing) once the listing exists.
-It is tracked in #461 and this release path does not use it.
+One field in `store-identity.json` is recorded but never read by this release
+path: `google.appSigningCertificateSha256`, the fingerprint `assetlinks.json`
+needs. Play App Signing generates it, so it is readable only from Play Console
+(Setup → App integrity → App signing) once the listing exists. It is tracked in
+#461.
 
 ### Android permissions
 

--- a/wallet/e2e2z/README.md
+++ b/wallet/e2e2z/README.md
@@ -192,14 +192,32 @@ own environment rather than sharing ZUULI's.
 `scripts/mobile-release.sh android [--upload]` is the operator path for the same
 Android artifact from a workstation.
 
-### Both store records are missing, and that blocks everything
+### Apple is ready; Play is not, and that still blocks Android
 
-`cash.free2z.e2e2z` has no App Store Connect app record and no Play Console
-listing, and neither can be created from an API. Until a human creates them,
-every release attempt stops in the first job with the full list of what to do:
-`node scripts/store-identity.mjs --require=apple --require=android` prints it,
-and `store-identity.json` is where the resulting profile name, profile UUID and
-upload-certificate fingerprint get recorded.
+Neither store record could be created from an API, so both had to be made by
+hand and then recorded in `store-identity.json`. One of them has been:
+
+- **App Store Connect — created.** The app record exists for
+  `cash.free2z.e2e2z`, and so does its App Store distribution profile,
+  `e2e2z appstore ci` (UUID `ce910824-c3e3-44c0-b53e-435d15a4a091`), issued
+  against the Corpora `F9AV5HKF6N` distribution certificate. A `target: ios`
+  release therefore clears the `prepare` job's store preflight.
+- **Google Play Console — missing.** e2e2z is going TestFlight-first, so no
+  listing has been created and no upload key exists. `target: android` and
+  `target: mobile` still stop in the first job, printing what a human must go
+  and do.
+
+`node scripts/store-identity.mjs --require=apple --require=android` prints the
+remaining list; drop `--require=android` to see the iOS lane pass. The two lanes
+are checked independently on purpose — recording one store's facts must never
+quietly vouch for the other's, and `--self-test` pins that asymmetry so it
+cannot drift silently.
+
+Clearing `prepare` is not the same as being able to upload. A TestFlight run
+also needs the Apple secrets in the protected `e2e2z-app-stores` environment:
+`APPLE_PROVISIONING_PROFILE_BASE64` is installed, while
+`APPLE_DISTRIBUTION_CERTIFICATE_BASE64`, its password, and `ASC_KEY_BASE64` are
+not yet.
 
 The third value in that file — `google.appSigningCertificateSha256` — is the one
 `assetlinks.json` needs. Play App Signing generates it, so it is readable only

--- a/wallet/e2e2z/scripts/assert-no-apple-credentials.sh
+++ b/wallet/e2e2z/scripts/assert-no-apple-credentials.sh
@@ -2,9 +2,9 @@
 # A canary, not a control. See assert-no-android-credentials.sh for why.
 #
 # The profile-file check is written against whatever UUID
-# `store-identity.json` records, because e2e2z has no profile yet: hardcoding a
-# UUID that does not exist would be a check that can never fire. When the
-# profile is issued and its UUID recorded, this starts proving the same thing
+# `store-identity.json` records rather than a hardcoded one, so it followed the
+# profile into existence instead of being a check that could never fire. That
+# profile now exists (`e2e2z appstore ci`), so this proves the same thing
 # ZUULI's canary proves — that the credential-free runner is not carrying a
 # distribution profile someone left behind.
 set -euo pipefail

--- a/wallet/e2e2z/scripts/normalize-generated-ios-project.mjs
+++ b/wallet/e2e2z/scripts/normalize-generated-ios-project.mjs
@@ -29,10 +29,11 @@
 //
 // This is the smaller sibling of wallet/zuuli/scripts/normalize-generated-ios-project.mjs.
 // ZUULI's also has a `--prepare-manual-signing` mode that writes its
-// provisioning profile into the project before building. e2e2z has no
-// provisioning profile yet (see scripts/store-identity.mjs), so there is nothing
-// to write and no mode that could be tested; the export configuration lives in
-// the ExportOptions.plist the release workflow composes instead.
+// provisioning profile into the project before building. e2e2z does not write
+// its profile (`e2e2z appstore ci`, see scripts/store-identity.mjs) into the
+// project at all; the export configuration lives in the ExportOptions.plist the
+// release workflow composes from the source-bound store identity instead, so
+// there is no mode here to test.
 //
 // Usage:
 //   node scripts/normalize-generated-ios-project.mjs

--- a/wallet/e2e2z/scripts/store-identity.mjs
+++ b/wallet/e2e2z/scripts/store-identity.mjs
@@ -8,17 +8,21 @@
 // the workflow and in `normalize-generated-ios-project.mjs`: the provisioning
 // profile `ZUULI App Store CI`, its UUID, and the Android upload certificate
 // fingerprint. It can, because those things exist. For `cash.free2z.e2e2z` they
-// do not:
+// did not, and each has to be created by a human before CI can bind to it:
 //
 //   * The App Store Connect **app record** must be created by a human in App
 //     Store Connect. There is no API that creates one. Until it exists, no
 //     provisioning profile can be issued for the bundle id, `altool
 //     --validate-app` has nothing to validate against, and TestFlight has no
-//     app to receive a build.
+//     app to receive a build. **This one now exists**, along with the App Store
+//     distribution profile named below, which is why the Apple lane clears its
+//     preflight.
 //   * The Play Console **listing** must likewise be created by a human. The
 //     Android Publisher API only edits apps that already exist; `POST
 //     /edits` against a package name Play has never seen returns a 404 that
-//     reads like a permissions problem and is not one.
+//     reads like a permissions problem and is not one. **This one does not
+//     exist**: e2e2z is going TestFlight-first, so the Android lane is still
+//     blocked here, deliberately.
 //   * Play App Signing then generates the **app signing certificate**, and its
 //     SHA-256 — the fingerprint `assetlinks.json` must carry — is readable only
 //     from Play Console (Setup -> App integrity -> App signing) once the
@@ -30,6 +34,11 @@
 // stated blocker is the goal. A pipeline that appears to work and does not is
 // the failure this file exists to prevent, and an opaque 404 from Google three
 // jobs deep is that failure wearing a hat.
+//
+// The two lanes are checked independently, so a `target: ios` release proceeds
+// on the Apple facts alone while `mobile` and `android` still stop at the Play
+// listing. That asymmetry is the point: recording one store's facts must not
+// quietly vouch for the other's.
 //
 // Nothing here is a secret. The profile name and UUID are not credentials, the
 // upload fingerprint is a public certificate digest, and binding them in source
@@ -203,8 +212,14 @@ function selfTest() {
   mutated.applicationId = "cash.free2z.zuuli";
   expect("foreign application id", validate(mutated), "applicationId must be cash.free2z.e2e2z");
 
+  // Each bad state below is spelled out in full rather than produced by
+  // flipping one field of the committed file. The committed file changes as
+  // store records get created -- Apple's now exist -- and a control that is
+  // only bad relative to today's contents silently stops testing anything.
   mutated = clone();
-  mutated.apple.provisioningProfileName = "e2e2z App Store CI";
+  mutated.apple.appStoreConnectRecord = "missing";
+  mutated.apple.provisioningProfileName = "e2e2z appstore ci";
+  mutated.apple.provisioningProfileUuid = "ce910824-c3e3-44c0-b53e-435d15a4a091";
   expect(
     "profile named without a record",
     validate(mutated),
@@ -213,8 +228,17 @@ function selfTest() {
 
   mutated = clone();
   mutated.apple.appStoreConnectRecord = "created";
-  mutated.apple.provisioningProfileName = "e2e2z App Store CI";
+  mutated.apple.provisioningProfileName = "e2e2z appstore ci";
+  mutated.apple.provisioningProfileUuid = null;
   expect("half a profile", validate(mutated), "must both be set or both be null");
+
+  // The profile UUID is transcribed by hand out of a `.mobileprovision`, and
+  // `security cms -D` prints it uppercase. An uppercase UUID would name a
+  // profile file that does not exist on the signing runner, so it is rejected
+  // here rather than at codesign time.
+  mutated = clone();
+  mutated.apple.provisioningProfileUuid = "CE910824-C3E3-44C0-B53E-435D15A4A091";
+  expect("uppercase profile UUID", validate(mutated), "must be a lowercase UUID or null");
 
   mutated = clone();
   mutated.google.uploadCertificateSha256 = "aa:bb";
@@ -228,8 +252,39 @@ function selfTest() {
   if (androidBlockers(mutated).length !== 0)
     throw new Error("store-identity self-test failed: a complete Play identity still blocked");
 
-  if (appleBlockers(base).length !== 1 || androidBlockers(base).length !== 1)
-    throw new Error("store-identity self-test failed: the committed identity must block both lanes");
+  // The Apple lane's two blockers no longer fire for the committed file, so
+  // they are exercised against a synthesized identity instead. Losing these
+  // would mean nothing proves the iOS preflight can still say no.
+  mutated = clone();
+  mutated.apple.appStoreConnectRecord = "missing";
+  mutated.apple.provisioningProfileName = null;
+  mutated.apple.provisioningProfileUuid = null;
+  expect("no App Store Connect record", appleBlockers(mutated), "no App Store Connect app record");
+
+  mutated = clone();
+  mutated.apple.appStoreConnectRecord = "created";
+  mutated.apple.provisioningProfileName = null;
+  mutated.apple.provisioningProfileUuid = null;
+  if (validate(mutated).length !== 0)
+    throw new Error("store-identity self-test failed: a record without a profile is a legal state");
+  expect(
+    "record without a profile",
+    appleBlockers(mutated),
+    "no recorded App Store distribution provisioning profile",
+  );
+
+  // What the committed file actually claims today: Apple ready, Play not. This
+  // asymmetry is load-bearing -- `target: ios` clears the preflight, `mobile`
+  // and `android` do not -- so changing either half must be a deliberate edit
+  // here, not a silent consequence of editing store-identity.json.
+  if (appleBlockers(base).length !== 0)
+    throw new Error(
+      `store-identity self-test failed: the committed identity must not block the Apple lane:\n${appleBlockers(base).join("\n")}`,
+    );
+  if (androidBlockers(base).length !== 1)
+    throw new Error("store-identity self-test failed: the committed identity must block the Android lane");
+  if (!androidBlockers(base)[0].includes("no Google Play Console listing"))
+    throw new Error("store-identity self-test failed: the Android blocker must name the missing Play listing");
 }
 
 function main() {

--- a/wallet/e2e2z/store-identity.json
+++ b/wallet/e2e2z/store-identity.json
@@ -5,9 +5,9 @@
   "apple": {
     "teamId": "F9AV5HKF6N",
     "distributionIdentity": "Apple Distribution: Corpora Inc (F9AV5HKF6N)",
-    "appStoreConnectRecord": "missing",
-    "provisioningProfileName": null,
-    "provisioningProfileUuid": null
+    "appStoreConnectRecord": "created",
+    "provisioningProfileName": "e2e2z appstore ci",
+    "provisioningProfileUuid": "ce910824-c3e3-44c0-b53e-435d15a4a091"
   },
   "google": {
     "playConsoleListing": "missing",


### PR DESCRIPTION
The App Store Connect app record for `cash.free2z.e2e2z` now exists, and so does
its App Store distribution provisioning profile. This records those facts in
`wallet/e2e2z/store-identity.json`, which shipped with every Apple field unknown
precisely so the release path would stop rather than fail later inside
`xcodebuild` with an error about something else.

```
apple.appStoreConnectRecord    "missing" -> "created"
apple.provisioningProfileName  null      -> "e2e2z appstore ci"
apple.provisioningProfileUuid  null      -> "ce910824-c3e3-44c0-b53e-435d15a4a091"
```

The values come from decoding the actual `.mobileprovision`: `application-identifier`
`F9AV5HKF6N.cash.free2z.e2e2z`, team `F9AV5HKF6N`, expiring 2027-08-08, with
`com.apple.developer.associated-domains` present. `apple.teamId` and
`apple.distributionIdentity` were already correct and are untouched.

## What this unlocks, and what it does not

- **A `target: ios` release can now clear `prepare`.** Its store preflight is
  `store-identity.mjs --require=apple`, which now exits 0.
- **`target: mobile` and `target: android` still cannot, by design.** The
  `google` block is deliberately unchanged — `playConsoleListing: "missing"`,
  both fingerprints `null`. The Play listing genuinely does not exist; e2e2z is
  going TestFlight-first. No Android value has been invented or inferred.
- **Clearing `prepare` is not the same as being able to upload to TestFlight.**
  That still needs the Apple secrets in the protected `e2e2z-app-stores`
  environment. `APPLE_PROVISIONING_PROFILE_BASE64` is installed;
  `APPLE_DISTRIBUTION_CERTIFICATE_BASE64`, its password, and `ASC_KEY_BASE64`
  are not yet.

That asymmetry is the point of the change, so here are all three targets run
against the committed file:

**`--require=apple` — passes (exit 0)**

```
$ node wallet/e2e2z/scripts/store-identity.mjs --require=apple ; echo "exit=$?"
{"$schema":"./store-identity.schema.json","schemaVersion":1,"applicationId":"cash.free2z.e2e2z","apple":{"teamId":"F9AV5HKF6N","distributionIdentity":"Apple Distribution: Corpora Inc (F9AV5HKF6N)","appStoreConnectRecord":"created","provisioningProfileName":"e2e2z appstore ci","provisioningProfileUuid":"ce910824-c3e3-44c0-b53e-435d15a4a091"},"google":{"playConsoleListing":"missing","uploadCertificateSha256":null,"appSigningCertificateSha256":null}}
exit=0
```

**`--require=android` — still fails, exit 78 (EX_CONFIG), naming the Play listing**

```
$ node wallet/e2e2z/scripts/store-identity.mjs --require=android ; echo "exit=$?"
cash.free2z.e2e2z has no Google Play Console listing.

The Android Publisher API can only edit an app Play already knows about, so
no CI step can create this. A human with access to the Play developer
account must:

  1. Play Console -> Create app, package name cash.free2z.e2e2z, and complete
     enough of the dashboard for an internal-testing release to be accepted.
  2. Grant the existing release service account access to the new app.
  3. Create an upload key, register it with Play App Signing, and record its
     SHA-256 as google.uploadCertificateSha256 in
     wallet/e2e2z/store-identity.json (uppercase, colon-delimited, exactly as
     `keytool -list -v` prints it), with the keystore itself stored as
     ANDROID_KEYSTORE_BASE64 in the e2e2z-app-stores environment.
  4. Set google.playConsoleListing to "created".

Separately, and only after the listing exists, Play generates the app signing
certificate. Its SHA-256 (Setup -> App integrity -> App signing) is the
fingerprint assetlinks.json needs; record it as
google.appSigningCertificateSha256. That value is tracked in #461 and is not
used by this release path.
exit=78
```

**`--require=apple --require=android` (the `mobile` target) — still fails, exit 78,
with exactly the Play blocker and nothing about Apple**

```
$ node wallet/e2e2z/scripts/store-identity.mjs --require=apple --require=android ; echo "exit=$?"
cash.free2z.e2e2z has no Google Play Console listing.
... (identical to the block above)
exit=78
```

## The self-test had to change, and that is the substantive part of this diff

Three of the self-test's Apple negative controls were written against a
committed file in which every Apple field was absent, so they were only "bad"
relative to that state and stopped testing anything the moment the fields were
filled in:

- `provisioningProfileName = "..."` alone no longer produces "profile named
  without a record", because the record now exists.
- setting `appStoreConnectRecord = "created"` plus a name no longer produces
  "half a profile", because the UUID is now present too.
- `appleBlockers(base).length !== 1` was asserting the committed identity blocks
  the Apple lane, which is exactly what this PR changes.

Each bad state is now spelled out in full rather than produced by flipping one
field of the committed file, so the controls keep testing the same thing no
matter which store records exist later. Both `appleBlockers` paths — no record,
and a record with no profile — are exercised against synthesized identities, so
the iOS preflight is still proven able to say no. A new control rejects an
uppercase profile UUID: the schema's pattern is lowercase-only, `security cms -D`
prints the UUID uppercase, and an uppercase value would name a
`.mobileprovision` file that does not exist on the signing runner.

The final assertion now pins what the committed file actually claims — Apple
unblocked, Play blocked with a message naming the listing — so changing either
half has to be a deliberate edit there, not a silent consequence of editing
`store-identity.json`.

Proven to fail first, not just to pass: reverting `store-identity.json` to its
previous all-missing Apple state makes `--self-test` fail with

```
Error: store-identity self-test failed: the committed identity must not block the Apple lane:
cash.free2z.e2e2z has no App Store Connect app record.
```

## Schema

Confirmed rather than assumed, with `ajv` (draft 2020-12) against
`store-identity.schema.json`:

- committed file: **VALID**
- `appStoreConnectRecord` enum is exactly `["missing", "created"]` — `"Created"`
  and `"exists"` are both rejected, so `created` is the right spelling.
- `provisioningProfileUuid` pattern is
  `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$` — lowercase
  hex only; the uppercase form and a non-UUID string are both rejected.
- `provisioningProfileName` is `["string","null"]` with `minLength: 1` — `""` is
  rejected. `"e2e2z appstore ci"` is accepted verbatim, lowercase and all; it is
  the profile's real name and must match ExportOptions.plist exactly.

Note the schema alone does not enforce the cross-field rules (a profile named
against a missing record, or half a profile) — those live only in `validate()`
in `store-identity.mjs`, and both are covered by the self-test.

## Nothing in `.github/workflows` needs to change

`grep -rn "provisioningProfileUuid\|appStoreConnectRecord"` turns up four
consumers, all of which read the file rather than hardcoding a value:

- `.github/workflows/e2e2z-release.yml` — `prepare` reads
  `.apple.provisioningProfileName` / `.apple.provisioningProfileUuid` out of
  `store-identity.mjs` output into job outputs, and the protected signing jobs
  consume them as `PROFILE_NAME` / `EXPECTED_PROFILE_NAME` /
  `EXPECTED_PROFILE_UUID` and cross-check against the environment. The new
  values flow through unchanged.
- `wallet/e2e2z/scripts/assert-no-apple-credentials.sh` — its canary already
  read the UUID from this file with `jq`, precisely so it would follow the
  profile into existence. It now actually fires; comment updated to say so.
- `wallet/e2e2z/scripts/release-identity.mjs` — calls `validate()` and asserts
  the application id; no expectation of `"missing"`.
- `wallet/e2e2z/scripts/mobile-release.sh` — Android-only, still gated on the
  Play blocker.

One stale comment is knowingly left alone: the `WHAT IS BLOCKED` header in
`.github/workflows/e2e2z-release.yml` still says "Neither store record exists
yet." That file is out of scope here (#957 is in flight against
`.github/workflows/**`), so it should be corrected there or in a follow-up. It
is a comment only — no behaviour depends on it.

`README.md` and the two script header comments that described "e2e2z has no
provisioning profile yet" are updated in this PR, since they are under
`wallet/e2e2z/**`.

## Verification

- `node scripts/store-identity.mjs --self-test` — passed
- `node scripts/release-path.node-test.mjs` — 5/5 passed
- `node --test` over all three e2e2z node suites — 13/13 passed
- `npm run typecheck` and `npm run typecheck:tests` — clean
- `npx vitest run` — 221 passed, 16 files
- `npx playwright test` — 4 passed
- `node wallet/zuuli/scripts/surface-capability-authority.mjs` — clean
- `node wallet/zuuli/scripts/project-boundary.mjs` — verified across 5 projects,
  483 source files

Scope is `wallet/e2e2z/**` only; no overlap with #955, #957, or the free2z
mobile-release work.

https://claude.ai/code/session_01MA76477TjX36dQoBtxHxHH
